### PR TITLE
fix(sandbox-proxy): reduce noisy proxy logs

### DIFF
--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -34,10 +34,23 @@ from onyx.external_apps.matching.engine import AllMatchedActions
 from onyx.sandbox_proxy import approval_cache
 from onyx.sandbox_proxy.credential_injection import CredentialInjectionDispatcher
 from onyx.sandbox_proxy.credential_injection import InjectionContext
+from onyx.sandbox_proxy.credential_injection import InjectionOutcome
 from onyx.sandbox_proxy.errors import http_403
 from onyx.sandbox_proxy.errors import SandboxProxyError
 from onyx.sandbox_proxy.identity import ResolvedSandbox
 from onyx.sandbox_proxy.identity import SessionContext
+from onyx.sandbox_proxy.logging_utils import credential_outcome_label
+from onyx.sandbox_proxy.logging_utils import egress_approval_matched_args
+from onyx.sandbox_proxy.logging_utils import EGRESS_APPROVAL_MATCHED_FIELDS
+from onyx.sandbox_proxy.logging_utils import egress_matched_args
+from onyx.sandbox_proxy.logging_utils import EGRESS_MATCHED_FIELDS
+from onyx.sandbox_proxy.logging_utils import egress_session_matched_args
+from onyx.sandbox_proxy.logging_utils import EGRESS_SESSION_MATCHED_FIELDS
+from onyx.sandbox_proxy.logging_utils import egress_target_args
+from onyx.sandbox_proxy.logging_utils import EGRESS_TARGET_FIELDS
+from onyx.sandbox_proxy.logging_utils import full_log_id
+from onyx.sandbox_proxy.logging_utils import sandbox_log_label
+from onyx.sandbox_proxy.logging_utils import short_log_id
 from onyx.sandbox_proxy.request_evaluator import RequestEvaluator
 from onyx.sandbox_proxy.snapshot_egress import SnapshotEgressPolicy
 from onyx.server.features.build.db import action_approval
@@ -170,12 +183,13 @@ class GateAddon:
         tag = _parse_proxy_auth_username(auth_header)
 
         logger.debug(
-            "gate.http_connect conn_id=%s host=%s port=%s proxy_auth=%r parsed_tag=%s",
-            conn_id,
+            "proxy.session_tag_capture conn=%s host=%s port=%s session=%s "
+            "proxy_auth_present=%s",
+            conn_id or "-",
             flow.request.host,
             flow.request.port,
-            auth_header,
-            tag,
+            short_log_id(tag),
+            str(auth_header is not None).lower(),
         )
         if conn_id is None:
             return
@@ -235,9 +249,9 @@ class GateAddon:
         flow.request.stream = True
         flow.metadata[_SNAPSHOT_STREAM_FLAG] = True
         logger.info(
-            "gate.snapshot_stream sandbox_id=%s tenant_id=%s host=%s method=%s",
-            sandbox.sandbox_id,
+            "proxy.snapshot_stream tenant=%s sandbox=%s host=%s method=%s",
             sandbox.tenant_id,
+            sandbox_log_label(sandbox),
             flow.request.host,
             flow.request.method,
         )
@@ -267,19 +281,43 @@ class GateAddon:
             # the original request, bypassing the gate after an APPROVED row
             # exists.
             try:
-                await asyncio.to_thread(
+                injection = await asyncio.to_thread(
                     self._dispatch_injection_or_block,
                     flow,
                     sandbox=ctx.without_session(),
                     matched_actions=matched_actions,
                 )
+                if injection is InjectionOutcome.BLOCKED:
+                    logger.warning(
+                        "proxy.egress_block "
+                        + EGRESS_SESSION_MATCHED_FIELDS
+                        + " reason=%s credential_outcome=%s",
+                        *egress_session_matched_args(
+                            flow, ctx, matched_actions, EndpointPolicy.ASK
+                        ),
+                        SandboxProxyError.CREDENTIAL_ERROR.value,
+                        credential_outcome_label(injection),
+                    )
+                else:
+                    logger.info(
+                        "proxy.egress_allow "
+                        + EGRESS_SESSION_MATCHED_FIELDS
+                        + " credential_outcome=%s",
+                        *egress_session_matched_args(
+                            flow, ctx, matched_actions, EndpointPolicy.ASK
+                        ),
+                        credential_outcome_label(injection),
+                    )
             except Exception:
                 logger.exception(
-                    "gate.approval_grant_dispatch_error session_id=%s tenant_id=%s "
-                    "action_type=%s",
-                    ctx.session_id,
+                    "proxy.approval_dispatch_error tenant=%s sandbox=%s "
+                    "session=%s app=%r action_type=%s session_id=%s",
                     ctx.tenant_id,
+                    sandbox_log_label(ctx),
+                    short_log_id(ctx.session_id),
+                    matched_actions.app_name,
                     matched_actions.governing_action.action_type,
+                    full_log_id(ctx.session_id),
                 )
                 flow.response = http_403(SandboxProxyError.INTERNAL_ERROR)
             return
@@ -302,20 +340,60 @@ class GateAddon:
                 # OAuth token (token POST + Redis lock) before rendering
                 # headers; Keep that off the proxy event loop so a slow token
                 # endpoint stalls only this request, not every in-flight flow.
-                await asyncio.to_thread(
+                injection = await asyncio.to_thread(
                     self._dispatch_injection_or_block,
                     flow,
                     sandbox=ctx.without_session(),
                     matched_actions=matched_actions,
                 )
+                if injection is InjectionOutcome.BLOCKED:
+                    logger.warning(
+                        "proxy.egress_block "
+                        + EGRESS_APPROVAL_MATCHED_FIELDS
+                        + " reason=%s credential_outcome=%s",
+                        *egress_approval_matched_args(
+                            flow, ctx, matched_actions, EndpointPolicy.ASK, approval_id
+                        ),
+                        SandboxProxyError.CREDENTIAL_ERROR.value,
+                        credential_outcome_label(injection),
+                    )
+                else:
+                    logger.info(
+                        "proxy.egress_allow "
+                        + EGRESS_APPROVAL_MATCHED_FIELDS
+                        + " credential_outcome=%s",
+                        *egress_approval_matched_args(
+                            flow, ctx, matched_actions, EndpointPolicy.ASK, approval_id
+                        ),
+                        credential_outcome_label(injection),
+                    )
+            else:
+                reason = (
+                    SandboxProxyError.USER_REJECTED.value
+                    if decision == ApprovalDecision.REJECTED
+                    else SandboxProxyError.NOT_AUTHORIZED.value
+                )
+                logger.info(
+                    "proxy.egress_block "
+                    + EGRESS_APPROVAL_MATCHED_FIELDS
+                    + " reason=%s",
+                    *egress_approval_matched_args(
+                        flow, ctx, matched_actions, EndpointPolicy.ASK, approval_id
+                    ),
+                    reason,
+                )
         except Exception:
             logger.exception(
-                "gate.unhandled_error session_id=%s tenant_id=%s "
-                "approval_id=%s action_type=%s",
-                ctx.session_id,
+                "proxy.approval_unhandled_error tenant=%s sandbox=%s session=%s "
+                "approval=%s app=%r action_type=%s session_id=%s approval_id=%s",
                 ctx.tenant_id,
-                approval_id,
+                sandbox_log_label(ctx),
+                short_log_id(ctx.session_id),
+                short_log_id(approval_id),
+                matched_actions.app_name,
                 matched_actions.governing_action.action_type,
+                full_log_id(ctx.session_id),
+                full_log_id(approval_id),
             )
             flow.response = http_403(SandboxProxyError.INTERNAL_ERROR)
             if approval_id is not None:
@@ -344,10 +422,12 @@ class GateAddon:
             # mitmproxy peername returned no usable IP -- should never happen
             # over real TCP. Log loudly so a stuck NAT or transport-mode mishap
             # doesn't read as "everything just 403's silently".
+            peer = flow.client_conn.peername
+            peer_label = "-" if peer is None else ":".join(str(part) for part in peer)
             logger.warning(
-                "gate.no_src_ip host=%s peername=%s",
+                "proxy.identity_missing_src_ip host=%s peer=%s",
                 flow.request.host,
-                flow.client_conn.peername,
+                peer_label,
             )
             flow.response = http_403(SandboxProxyError.UNIDENTIFIED_SANDBOX)
             return None
@@ -357,7 +437,7 @@ class GateAddon:
         except Exception:
             # A DB blip can't be allowed to grant ungated egress.
             logger.exception(
-                "gate.identity_error src_ip=%s host=%s",
+                "proxy.identity_error src_ip=%s host=%s",
                 src_ip,
                 flow.request.host,
             )
@@ -369,7 +449,7 @@ class GateAddon:
             # (2) Deployment-shape SNAT masks the sandbox's real bridge IP (e.g.
             # proxy outside the sandbox bridge).
             logger.warning(
-                "gate.unidentified_sandbox src_ip=%s host=%s",
+                "proxy.identity_unknown_sandbox src_ip=%s host=%s",
                 src_ip,
                 flow.request.host,
             )
@@ -380,6 +460,15 @@ class GateAddon:
         # future stream opt-in can't silently bypass the cap.
         raw = flow.request.raw_content
         if raw is None or len(raw) > PARSER_MAX_BODY_BYTES:
+            logger.info(
+                "proxy.egress_block "
+                + EGRESS_TARGET_FIELDS
+                + " reason=%s body_bytes=%s body_limit=%s",
+                *egress_target_args(flow, sandbox),
+                SandboxProxyError.BODY_TOO_LARGE.value,
+                "-" if raw is None else len(raw),
+                PARSER_MAX_BODY_BYTES,
+            )
             flow.response = http_403(SandboxProxyError.BODY_TOO_LARGE)
             return None
 
@@ -392,51 +481,82 @@ class GateAddon:
             # still get a chance to inject so the request doesn't forward with a
             # placeholder credential.
             logger.exception(
-                "gate.matcher_error host=%s error=%s",
+                "proxy.matcher_error tenant=%s sandbox=%s host=%s error=%r",
+                sandbox.tenant_id,
+                sandbox_log_label(sandbox),
                 flow.request.host,
                 str(e),
             )
             matched_actions = None
 
-        # Audit every evaluated request. session_id is the unvalidated claimed
-        # tag (the ASK path validates it below); off_catalog = nothing matched.
-        logger.info(
-            "gate.request tenant_id=%s sandbox_id=%s session_id=%s host=%s "
-            "action_type=%s policy=%s",
-            sandbox.tenant_id,
-            sandbox.sandbox_id,
-            self._extract_session_tag(flow),
-            flow.request.host,
-            matched_actions.governing_action.action_type
-            if matched_actions is not None
-            else "-",
-            matched_actions.governing_action.policy.value
-            if matched_actions is not None
-            else "off_catalog",
-        )
-
         # ALWAYS / DENY / off-catalog terminate here; ASK falls through to the
         # approval pipeline in `request()`.
         if matched_actions is None:
-            self._dispatch_injection_or_block(
+            injection = self._dispatch_injection_or_block(
                 flow, sandbox=sandbox, matched_actions=None
             )
+            if injection is InjectionOutcome.BLOCKED:
+                logger.warning(
+                    "proxy.egress_block "
+                    + EGRESS_TARGET_FIELDS
+                    + " reason=%s credential_outcome=%s",
+                    *egress_target_args(flow, sandbox),
+                    SandboxProxyError.CREDENTIAL_ERROR.value,
+                    credential_outcome_label(injection),
+                )
+            elif injection is not InjectionOutcome.PASS_THROUGH:
+                logger.info(
+                    "proxy.egress_allow "
+                    + EGRESS_TARGET_FIELDS
+                    + " policy=%s credential_outcome=%s",
+                    *egress_target_args(flow, sandbox),
+                    "off_catalog",
+                    credential_outcome_label(injection),
+                )
             return None
 
         if matched_actions.governing_action.policy is EndpointPolicy.DENY:
             flow.response = http_403(SandboxProxyError.POLICY_DENIED)
+            logger.info(
+                "proxy.egress_block " + EGRESS_MATCHED_FIELDS + " reason=%s",
+                *egress_matched_args(
+                    flow, sandbox, matched_actions, EndpointPolicy.DENY
+                ),
+                SandboxProxyError.POLICY_DENIED.value,
+            )
             return None
 
         if matched_actions.governing_action.policy is EndpointPolicy.ALWAYS:
             # Off-thread: see the ASK path in `request` — the resolver may
             # refresh an expiring OAuth token before injecting on this
             # auto-approved call.
-            await asyncio.to_thread(
+            injection = await asyncio.to_thread(
                 self._dispatch_injection_or_block,
                 flow,
                 sandbox=sandbox,
                 matched_actions=matched_actions,
             )
+            if injection is InjectionOutcome.BLOCKED:
+                logger.warning(
+                    "proxy.egress_block "
+                    + EGRESS_MATCHED_FIELDS
+                    + " reason=%s credential_outcome=%s",
+                    *egress_matched_args(
+                        flow, sandbox, matched_actions, EndpointPolicy.ALWAYS
+                    ),
+                    SandboxProxyError.CREDENTIAL_ERROR.value,
+                    credential_outcome_label(injection),
+                )
+            else:
+                logger.info(
+                    "proxy.egress_allow "
+                    + EGRESS_MATCHED_FIELDS
+                    + " credential_outcome=%s",
+                    *egress_matched_args(
+                        flow, sandbox, matched_actions, EndpointPolicy.ALWAYS
+                    ),
+                    credential_outcome_label(injection),
+                )
             return None
 
         # ASK: resolve the originating session before prompting. An
@@ -445,35 +565,38 @@ class GateAddon:
             session_id = self._resolve_gated_session(flow, sandbox)
         except Exception:
             logger.exception(
-                "gate.session_lookup_error sandbox_id=%s user_id=%s host=%s",
-                sandbox.sandbox_id,
-                sandbox.user_id,
+                "proxy.session_lookup_error tenant=%s sandbox=%s host=%s app=%r "
+                "action_type=%s",
+                sandbox.tenant_id,
+                sandbox_log_label(sandbox),
                 flow.request.host,
+                matched_actions.app_name,
+                matched_actions.governing_action.action_type,
             )
             flow.response = http_403(SandboxProxyError.NO_ACTIVE_SESSION)
             return None
         if session_id is None:
             logger.info(
-                "gate.unattributed_block sandbox_id=%s user_id=%s "
-                "tenant_id=%s action_type=%s host=%s",
-                sandbox.sandbox_id,
-                sandbox.user_id,
-                sandbox.tenant_id,
-                matched_actions.governing_action.action_type,
-                flow.request.host,
+                "proxy.egress_block " + EGRESS_MATCHED_FIELDS + " reason=%s",
+                *egress_matched_args(
+                    flow, sandbox, matched_actions, EndpointPolicy.ASK
+                ),
+                SandboxProxyError.NO_ACTIVE_SESSION.value,
             )
             flow.response = http_403(SandboxProxyError.NO_ACTIVE_SESSION)
             return None
 
         ctx = sandbox.with_session(session_id)
-        logger.info(
-            "gate.match session_id=%s tenant_id=%s sandbox_id=%s "
-            "action_type=%s host=%s",
-            ctx.session_id,
+        logger.debug(
+            "proxy.approval_match tenant=%s sandbox=%s session=%s host=%s "
+            "method=%s app=%r action_type=%s",
             ctx.tenant_id,
-            ctx.sandbox_id,
-            matched_actions.governing_action.action_type,
+            sandbox_log_label(ctx),
+            short_log_id(ctx.session_id),
             flow.request.host,
+            flow.request.method,
+            matched_actions.app_name,
+            matched_actions.governing_action.action_type,
         )
         return ctx, matched_actions
 
@@ -536,11 +659,12 @@ class GateAddon:
                 return _ApprovalGrant(decided_via=ApprovalDecidedVia.SESSION_GRANT)
         except CACHE_TRANSIENT_ERRORS as e:
             logger.warning(
-                "gate.session_grant_cache_check_failed session_id=%s "
-                "tenant_id=%s external_app_id=%s error=%s",
-                ctx.session_id,
+                "proxy.approval_grant_cache_error tenant=%s session=%s "
+                "external_app_id=%s operation=%s error=%r",
                 ctx.tenant_id,
+                short_log_id(ctx.session_id),
                 matched_actions.external_app_id,
+                "check",
                 str(e),
             )
 
@@ -571,11 +695,12 @@ class GateAddon:
                     )
             except CACHE_TRANSIENT_ERRORS as e:
                 logger.warning(
-                    "gate.session_grant_cache_hydrate_failed session_id=%s "
-                    "tenant_id=%s external_app_id=%s error=%s",
-                    ctx.session_id,
+                    "proxy.approval_grant_cache_error tenant=%s session=%s "
+                    "external_app_id=%s operation=%s error=%r",
                     ctx.tenant_id,
+                    short_log_id(ctx.session_id),
                     matched_actions.external_app_id,
+                    "hydrate",
                     str(e),
                 )
         return _ApprovalGrant(decided_via=ApprovalDecidedVia.SESSION_GRANT)
@@ -596,12 +721,17 @@ class GateAddon:
             )
         except Exception:
             logger.exception(
-                "gate.approval_grant_check_error session_id=%s tenant_id=%s "
-                "approval_id=%s action_type=%s",
-                ctx.session_id,
+                "proxy.approval_grant_check_error tenant=%s sandbox=%s "
+                "session=%s approval=%s app=%r action_type=%s session_id=%s "
+                "approval_id=%s",
                 ctx.tenant_id,
-                approval_id,
+                sandbox_log_label(ctx),
+                short_log_id(ctx.session_id),
+                short_log_id(approval_id),
+                matched_actions.app_name,
                 matched_actions.governing_action.action_type,
+                full_log_id(ctx.session_id),
+                full_log_id(approval_id),
             )
             return False
 
@@ -643,23 +773,30 @@ class GateAddon:
             db.commit()
 
         logger.info(
-            "gate.approval_grant_applied approval_id=%s session_id=%s tenant_id=%s "
-            "decided_via=%s external_app_id=%s action_type=%s",
-            applied_approval_id,
-            ctx.session_id,
+            "proxy.approval_decided tenant=%s sandbox=%s session=%s approval=%s "
+            "app=%r external_app_id=%s action_type=%s decision=%s source=%s "
+            "session_id=%s approval_id=%s",
             ctx.tenant_id,
-            grant.decided_via,
+            sandbox_log_label(ctx),
+            short_log_id(ctx.session_id),
+            short_log_id(applied_approval_id),
+            matched_actions.app_name,
             matched_actions.external_app_id,
             matched_actions.governing_action.action_type,
+            ApprovalDecision.APPROVED.value,
+            grant.decided_via.value,
+            full_log_id(ctx.session_id),
+            full_log_id(applied_approval_id),
         )
         try:
             if grant.notif_type is not None:
                 self._notify_approval_grant(ctx, grant)
         except Exception as e:
             logger.warning(
-                "gate.approval_grant_notify_failed approval_id=%s error=%s",
-                applied_approval_id,
+                "proxy.approval_notify_error approval=%s error=%r approval_id=%s",
+                short_log_id(applied_approval_id),
                 str(e),
+                full_log_id(applied_approval_id),
             )
         return True
 
@@ -693,30 +830,37 @@ class GateAddon:
             )
         except CACHE_TRANSIENT_ERRORS as e:
             logger.warning(
-                "gate.announce_failed approval_id=%s error=%s",
-                approval_id,
+                "proxy.approval_announce_error approval=%s error=%r approval_id=%s",
+                short_log_id(approval_id),
                 str(e),
+                full_log_id(approval_id),
             )
 
         logger.info(
-            "gate.row_committed approval_id=%s session_id=%s tenant_id=%s "
-            "sandbox_id=%s proxy_instance_id=%s action_type=%s action_count=%s",
-            approval_id,
-            ctx.session_id,
+            "proxy.approval_requested tenant=%s sandbox=%s session=%s approval=%s "
+            "app=%r external_app_id=%s action_type=%s action_count=%s "
+            "proxy_instance=%s session_id=%s approval_id=%s",
             ctx.tenant_id,
-            ctx.sandbox_id,
-            self._proxy_instance_id,
+            sandbox_log_label(ctx),
+            short_log_id(ctx.session_id),
+            short_log_id(approval_id),
+            matched_actions.app_name,
+            matched_actions.external_app_id,
             matched_actions.governing_action.action_type,
             len(matched_actions.actions),
+            self._proxy_instance_id,
+            full_log_id(ctx.session_id),
+            full_log_id(approval_id),
         )
 
         try:
             self._notify_approval_requested(approval_id, ctx, matched_actions)
         except Exception as e:
             logger.warning(
-                "approval.notify_failed approval_id=%s error=%s",
-                approval_id,
+                "proxy.approval_notify_error approval=%s error=%r approval_id=%s",
+                short_log_id(approval_id),
                 str(e),
+                full_log_id(approval_id),
             )
 
         return approval_id
@@ -738,30 +882,40 @@ class GateAddon:
             )
             if decision is not None:
                 logger.info(
-                    "gate.wake_received approval_id=%s session_id=%s "
-                    "tenant_id=%s decision=%s",
-                    approval_id,
-                    ctx.session_id,
+                    "proxy.approval_decided tenant=%s sandbox=%s session=%s "
+                    "approval=%s app=%r action_type=%s decision=%s wake=%s "
+                    "source=%s session_id=%s approval_id=%s",
                     ctx.tenant_id,
+                    sandbox_log_label(ctx),
+                    short_log_id(ctx.session_id),
+                    short_log_id(approval_id),
+                    matched_actions.app_name,
+                    matched_actions.governing_action.action_type,
                     decision.value,
+                    "received",
+                    "wake",
+                    full_log_id(ctx.session_id),
+                    full_log_id(approval_id),
                 )
                 return decision
-            logger.info(
-                "gate.wake_timeout approval_id=%s session_id=%s tenant_id=%s "
-                "action_type=%s",
-                approval_id,
-                ctx.session_id,
-                ctx.tenant_id,
-                matched_actions.governing_action.action_type,
-            )
             resolved = self._claim_expired_or_read_winner(approval_id, ctx.tenant_id)
-            if resolved == ApprovalDecision.EXPIRED:
-                logger.info(
-                    "gate.expired_on_timeout approval_id=%s session_id=%s tenant_id=%s",
-                    approval_id,
-                    ctx.session_id,
-                    ctx.tenant_id,
-                )
+            source = "timeout" if resolved == ApprovalDecision.EXPIRED else "db_winner"
+            logger.info(
+                "proxy.approval_decided tenant=%s sandbox=%s session=%s approval=%s "
+                "app=%r action_type=%s decision=%s wake=%s source=%s "
+                "session_id=%s approval_id=%s",
+                ctx.tenant_id,
+                sandbox_log_label(ctx),
+                short_log_id(ctx.session_id),
+                short_log_id(approval_id),
+                matched_actions.app_name,
+                matched_actions.governing_action.action_type,
+                resolved.value,
+                "missed",
+                source,
+                full_log_id(ctx.session_id),
+                full_log_id(approval_id),
+            )
             return resolved
         except asyncio.CancelledError:
             # Sandbox socket closed mid-wait. Terminalize the audit row, then
@@ -792,9 +946,10 @@ class GateAddon:
                 # FK cascade dropped the row (build_session deleted).
                 # Treat as expired so the upstream call is rejected.
                 logger.error(
-                    "gate.row_missing_on_claim approval_id=%s tenant_id=%s",
-                    approval_id,
+                    "proxy.approval_row_missing tenant=%s approval=%s approval_id=%s",
                     tenant_id,
+                    short_log_id(approval_id),
+                    full_log_id(approval_id),
                 )
                 return ApprovalDecision.EXPIRED
             return existing.decision
@@ -817,15 +972,18 @@ class GateAddon:
         *,
         sandbox: ResolvedSandbox,
         matched_actions: AllMatchedActions | None,
-    ) -> None:
+    ) -> InjectionOutcome:
         """Runs the credential dispatcher; Fails closed with a 403 on BLOCKED."""
-        self._credential_dispatcher.apply_or_block(
+        outcome = self._credential_dispatcher.apply(
             flow,
             InjectionContext(
                 sandbox=sandbox,
                 matched_actions=matched_actions,
             ),
         )
+        if outcome is InjectionOutcome.BLOCKED:
+            flow.response = http_403(SandboxProxyError.CREDENTIAL_ERROR)
+        return outcome
 
     def _terminalize_after_unhandled_error(
         self, approval_id: UUID, tenant_id: str
@@ -840,9 +998,12 @@ class GateAddon:
             decision = self._claim_expired_or_read_winner(approval_id, tenant_id)
         except Exception:
             logger.exception(
-                "gate.terminalize_db_failed approval_id=%s tenant_id=%s",
-                approval_id,
+                "proxy.approval_terminalize_error tenant=%s approval=%s "
+                "operation=%s approval_id=%s",
                 tenant_id,
+                short_log_id(approval_id),
+                "db",
+                full_log_id(approval_id),
             )
             return
         try:
@@ -851,9 +1012,12 @@ class GateAddon:
             )
         except Exception:
             logger.exception(
-                "gate.terminalize_wake_failed approval_id=%s tenant_id=%s",
-                approval_id,
+                "proxy.approval_terminalize_error tenant=%s approval=%s "
+                "operation=%s approval_id=%s",
                 tenant_id,
+                short_log_id(approval_id),
+                "wake",
+                full_log_id(approval_id),
             )
 
     # ------------------------------------------------------------------
@@ -882,24 +1046,28 @@ class GateAddon:
                         pass
                     if decision == ApprovalDecision.EXPIRED:
                         logger.info(
-                            "gate.drain_expired approval_id=%s tenant_id=%s",
-                            approval_id,
+                            "proxy.drain_expired tenant=%s approval=%s approval_id=%s",
                             tenant_id,
+                            short_log_id(approval_id),
+                            full_log_id(approval_id),
                         )
                     else:
                         logger.info(
-                            "gate.drain_forwarded approval_id=%s "
-                            "tenant_id=%s decision=%s",
-                            approval_id,
+                            "proxy.drain_forwarded tenant=%s approval=%s "
+                            "decision=%s approval_id=%s",
                             tenant_id,
+                            short_log_id(approval_id),
                             decision.value,
+                            full_log_id(approval_id),
                         )
                 except Exception as e:
                     logger.warning(
-                        "gate.drain_error approval_id=%s tenant_id=%s error=%s",
-                        approval_id,
+                        "proxy.drain_error tenant=%s approval=%s error=%r "
+                        "approval_id=%s",
                         tenant_id,
+                        short_log_id(approval_id),
                         str(e),
+                        full_log_id(approval_id),
                     )
 
         # Exclude self so we don't deadlock if drain ever ends up registered in
@@ -907,7 +1075,7 @@ class GateAddon:
         self_task = asyncio.current_task()
         pending = [t for t in self._inflight_tasks if t is not self_task]
         if pending:
-            logger.info("gate.drain_awaiting_tasks count=%d", len(pending))
+            logger.info("proxy.drain_wait requests=%s", len(pending))
             await asyncio.wait(pending)
 
     # --------------------------------------------------------------------------
@@ -991,9 +1159,9 @@ class GateAddon:
         tag = self._extract_session_tag(flow)
         if tag is None:
             logger.warning(
-                "gate.session_tag_missing sandbox_id=%s user_id=%s host=%s",
-                sandbox.sandbox_id,
-                sandbox.user_id,
+                "proxy.session_missing tenant=%s sandbox=%s host=%s",
+                sandbox.tenant_id,
+                sandbox_log_label(sandbox),
                 flow.request.host,
             )
             return None
@@ -1001,9 +1169,9 @@ class GateAddon:
             tagged_id = UUID(tag)
         except ValueError:
             logger.warning(
-                "gate.session_tag_malformed sandbox_id=%s user_id=%s host=%s",
-                sandbox.sandbox_id,
-                sandbox.user_id,
+                "proxy.session_malformed tenant=%s sandbox=%s host=%s",
+                sandbox.tenant_id,
+                sandbox_log_label(sandbox),
                 flow.request.host,
             )
             return None
@@ -1013,16 +1181,18 @@ class GateAddon:
         if exact is None:
             # Stale, foreign, or tampered tag. Fail closed — do not guess.
             logger.warning(
-                "gate.session_tag_unverified sandbox_id=%s user_id=%s host=%s",
-                sandbox.sandbox_id,
-                sandbox.user_id,
+                "proxy.session_unverified tenant=%s sandbox=%s session=%s host=%s",
+                sandbox.tenant_id,
+                sandbox_log_label(sandbox),
+                short_log_id(tagged_id),
                 flow.request.host,
             )
             return None
-        logger.info(
-            "gate.session_exact session_id=%s sandbox_id=%s host=%s",
-            exact,
-            sandbox.sandbox_id,
+        logger.debug(
+            "proxy.session_verified tenant=%s sandbox=%s session=%s host=%s",
+            sandbox.tenant_id,
+            sandbox_log_label(sandbox),
+            short_log_id(exact),
             flow.request.host,
         )
         return exact
@@ -1040,14 +1210,14 @@ class GateAddon:
         tag = cached or direct
 
         logger.debug(
-            "gate.session_tag_extract conn_id=%s host=%s cached=%s "
-            "direct=%s direct_proxy_auth=%r resolved=%s",
-            conn_id,
+            "proxy.session_tag_resolved conn=%s host=%s cached=%s direct=%s "
+            "proxy_auth_present=%s session=%s",
+            conn_id or "-",
             flow.request.host,
-            cached,
-            direct,
-            direct_auth_header,
-            tag,
+            short_log_id(cached),
+            short_log_id(direct),
+            str(direct_auth_header is not None).lower(),
+            short_log_id(tag),
         )
         return tag
 

--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -39,6 +39,8 @@ from onyx.sandbox_proxy.errors import http_403
 from onyx.sandbox_proxy.errors import SandboxProxyError
 from onyx.sandbox_proxy.identity import ResolvedSandbox
 from onyx.sandbox_proxy.identity import SessionContext
+from onyx.sandbox_proxy.logging_utils import approval_decided_args
+from onyx.sandbox_proxy.logging_utils import APPROVAL_DECIDED_FIELDS
 from onyx.sandbox_proxy.logging_utils import credential_outcome_label
 from onyx.sandbox_proxy.logging_utils import egress_approval_matched_args
 from onyx.sandbox_proxy.logging_utils import EGRESS_APPROVAL_MATCHED_FIELDS
@@ -183,7 +185,7 @@ class GateAddon:
         tag = _parse_proxy_auth_username(auth_header)
 
         logger.debug(
-            "proxy.session_tag_capture conn=%s host=%s port=%s session=%s "
+            "session_tag_capture conn=%s host=%s port=%s session=%s "
             "proxy_auth_present=%s",
             conn_id or "-",
             flow.request.host,
@@ -249,7 +251,7 @@ class GateAddon:
         flow.request.stream = True
         flow.metadata[_SNAPSHOT_STREAM_FLAG] = True
         logger.info(
-            "proxy.snapshot_stream tenant=%s sandbox=%s host=%s method=%s",
+            "snapshot_stream tenant=%s sandbox=%s host=%s method=%s",
             sandbox.tenant_id,
             sandbox_log_label(sandbox),
             flow.request.host,
@@ -276,42 +278,19 @@ class GateAddon:
         # Grant sources can approve without asking the user. Check
         # before we insert a pending row, then re-check after insert to close the
         # window where a session grant appears between those two steps.
-        if await self._approval_grant_applies(ctx, matched_actions):
+        applied_approval_id = await self._apply_approval_grant(ctx, matched_actions)
+        if applied_approval_id is not None:
             # Fail closed: an unguarded raise here would let mitmproxy forward
             # the original request, bypassing the gate after an APPROVED row
             # exists.
             try:
-                injection = await asyncio.to_thread(
-                    self._dispatch_injection_or_block,
-                    flow,
-                    sandbox=ctx.without_session(),
-                    matched_actions=matched_actions,
+                await self._dispatch_approved_request(
+                    flow, ctx, matched_actions, approval_id=applied_approval_id
                 )
-                if injection is InjectionOutcome.BLOCKED:
-                    logger.warning(
-                        "proxy.egress_block "
-                        + EGRESS_SESSION_MATCHED_FIELDS
-                        + " reason=%s credential_outcome=%s",
-                        *egress_session_matched_args(
-                            flow, ctx, matched_actions, EndpointPolicy.ASK
-                        ),
-                        SandboxProxyError.CREDENTIAL_ERROR.value,
-                        credential_outcome_label(injection),
-                    )
-                else:
-                    logger.info(
-                        "proxy.egress_allow "
-                        + EGRESS_SESSION_MATCHED_FIELDS
-                        + " credential_outcome=%s",
-                        *egress_session_matched_args(
-                            flow, ctx, matched_actions, EndpointPolicy.ASK
-                        ),
-                        credential_outcome_label(injection),
-                    )
             except Exception:
                 logger.exception(
-                    "proxy.approval_dispatch_error tenant=%s sandbox=%s "
-                    "session=%s app=%r action_type=%s session_id=%s",
+                    "approval_dispatch_error tenant=%s sandbox=%s "
+                    "session=%s app_name=%r action_type=%s session_id=%s",
                     ctx.tenant_id,
                     sandbox_log_label(ctx),
                     short_log_id(ctx.session_id),
@@ -327,8 +306,11 @@ class GateAddon:
         approval_id: UUID | None = None
         try:
             approval_id = self._persist_approval_row(ctx, matched_actions)
-            if await self._approval_grant_applies(
-                ctx, matched_actions, approval_id=approval_id
+            if (
+                await self._apply_approval_grant(
+                    ctx, matched_actions, approval_id=approval_id
+                )
+                is not None
             ):
                 self._parked.remove(ctx.tenant_id, approval_id)
                 decision = ApprovalDecision.APPROVED
@@ -336,37 +318,9 @@ class GateAddon:
                 decision = await self._await_decision(approval_id, ctx, matched_actions)
             self._write_response_for_decision(flow, decision)
             if decision == ApprovalDecision.APPROVED:
-                # Off-thread: the external-app resolver may refresh an expiring
-                # OAuth token (token POST + Redis lock) before rendering
-                # headers; Keep that off the proxy event loop so a slow token
-                # endpoint stalls only this request, not every in-flight flow.
-                injection = await asyncio.to_thread(
-                    self._dispatch_injection_or_block,
-                    flow,
-                    sandbox=ctx.without_session(),
-                    matched_actions=matched_actions,
+                await self._dispatch_approved_request(
+                    flow, ctx, matched_actions, approval_id=approval_id
                 )
-                if injection is InjectionOutcome.BLOCKED:
-                    logger.warning(
-                        "proxy.egress_block "
-                        + EGRESS_APPROVAL_MATCHED_FIELDS
-                        + " reason=%s credential_outcome=%s",
-                        *egress_approval_matched_args(
-                            flow, ctx, matched_actions, EndpointPolicy.ASK, approval_id
-                        ),
-                        SandboxProxyError.CREDENTIAL_ERROR.value,
-                        credential_outcome_label(injection),
-                    )
-                else:
-                    logger.info(
-                        "proxy.egress_allow "
-                        + EGRESS_APPROVAL_MATCHED_FIELDS
-                        + " credential_outcome=%s",
-                        *egress_approval_matched_args(
-                            flow, ctx, matched_actions, EndpointPolicy.ASK, approval_id
-                        ),
-                        credential_outcome_label(injection),
-                    )
             else:
                 reason = (
                     SandboxProxyError.USER_REJECTED.value
@@ -374,9 +328,7 @@ class GateAddon:
                     else SandboxProxyError.NOT_AUTHORIZED.value
                 )
                 logger.info(
-                    "proxy.egress_block "
-                    + EGRESS_APPROVAL_MATCHED_FIELDS
-                    + " reason=%s",
+                    "egress_block " + EGRESS_APPROVAL_MATCHED_FIELDS + " reason=%s",
                     *egress_approval_matched_args(
                         flow, ctx, matched_actions, EndpointPolicy.ASK, approval_id
                     ),
@@ -384,8 +336,8 @@ class GateAddon:
                 )
         except Exception:
             logger.exception(
-                "proxy.approval_unhandled_error tenant=%s sandbox=%s session=%s "
-                "approval=%s app=%r action_type=%s session_id=%s approval_id=%s",
+                "approval_unhandled_error tenant=%s sandbox=%s session=%s "
+                "approval=%s app_name=%r action_type=%s session_id=%s approval_id=%s",
                 ctx.tenant_id,
                 sandbox_log_label(ctx),
                 short_log_id(ctx.session_id),
@@ -398,6 +350,48 @@ class GateAddon:
             flow.response = http_403(SandboxProxyError.INTERNAL_ERROR)
             if approval_id is not None:
                 self._terminalize_after_unhandled_error(approval_id, ctx.tenant_id)
+
+    async def _dispatch_approved_request(
+        self,
+        flow: http.HTTPFlow,
+        ctx: SessionContext,
+        matched_actions: AllMatchedActions,
+        *,
+        approval_id: UUID | None = None,
+    ) -> None:
+        # Off-thread: resolvers may refresh an expiring OAuth token before
+        # rendering headers; keep that off the proxy event loop so a slow token
+        # endpoint stalls only this request, not every in-flight flow.
+        injection = await asyncio.to_thread(
+            self._dispatch_injection_or_block,
+            flow,
+            sandbox=ctx.without_session(),
+            matched_actions=matched_actions,
+        )
+        if approval_id is None:
+            fields = EGRESS_SESSION_MATCHED_FIELDS
+            args = egress_session_matched_args(
+                flow, ctx, matched_actions, EndpointPolicy.ASK
+            )
+        else:
+            fields = EGRESS_APPROVAL_MATCHED_FIELDS
+            args = egress_approval_matched_args(
+                flow, ctx, matched_actions, EndpointPolicy.ASK, approval_id
+            )
+
+        if injection is InjectionOutcome.BLOCKED:
+            logger.warning(
+                "egress_block " + fields + " reason=%s credential_outcome=%s",
+                *args,
+                SandboxProxyError.CREDENTIAL_ERROR.value,
+                credential_outcome_label(injection),
+            )
+        else:
+            logger.info(
+                "egress_allow " + fields + " credential_outcome=%s",
+                *args,
+                credential_outcome_label(injection),
+            )
 
     # --------------------------------------------------------------------------
     # request() helpers
@@ -425,7 +419,7 @@ class GateAddon:
             peer = flow.client_conn.peername
             peer_label = "-" if peer is None else ":".join(str(part) for part in peer)
             logger.warning(
-                "proxy.identity_missing_src_ip host=%s peer=%s",
+                "identity_missing_src_ip host=%s peer=%s",
                 flow.request.host,
                 peer_label,
             )
@@ -437,7 +431,7 @@ class GateAddon:
         except Exception:
             # A DB blip can't be allowed to grant ungated egress.
             logger.exception(
-                "proxy.identity_error src_ip=%s host=%s",
+                "identity_error src_ip=%s host=%s",
                 src_ip,
                 flow.request.host,
             )
@@ -449,7 +443,7 @@ class GateAddon:
             # (2) Deployment-shape SNAT masks the sandbox's real bridge IP (e.g.
             # proxy outside the sandbox bridge).
             logger.warning(
-                "proxy.identity_unknown_sandbox src_ip=%s host=%s",
+                "identity_unknown_sandbox src_ip=%s host=%s",
                 src_ip,
                 flow.request.host,
             )
@@ -461,7 +455,7 @@ class GateAddon:
         raw = flow.request.raw_content
         if raw is None or len(raw) > PARSER_MAX_BODY_BYTES:
             logger.info(
-                "proxy.egress_block "
+                "egress_block "
                 + EGRESS_TARGET_FIELDS
                 + " reason=%s body_bytes=%s body_limit=%s",
                 *egress_target_args(flow, sandbox),
@@ -481,7 +475,7 @@ class GateAddon:
             # still get a chance to inject so the request doesn't forward with a
             # placeholder credential.
             logger.exception(
-                "proxy.matcher_error tenant=%s sandbox=%s host=%s error=%r",
+                "matcher_error tenant=%s sandbox=%s host=%s error=%r",
                 sandbox.tenant_id,
                 sandbox_log_label(sandbox),
                 flow.request.host,
@@ -497,7 +491,7 @@ class GateAddon:
             )
             if injection is InjectionOutcome.BLOCKED:
                 logger.warning(
-                    "proxy.egress_block "
+                    "egress_block "
                     + EGRESS_TARGET_FIELDS
                     + " reason=%s credential_outcome=%s",
                     *egress_target_args(flow, sandbox),
@@ -506,7 +500,7 @@ class GateAddon:
                 )
             elif injection is not InjectionOutcome.PASS_THROUGH:
                 logger.info(
-                    "proxy.egress_allow "
+                    "egress_allow "
                     + EGRESS_TARGET_FIELDS
                     + " policy=%s credential_outcome=%s",
                     *egress_target_args(flow, sandbox),
@@ -518,7 +512,7 @@ class GateAddon:
         if matched_actions.governing_action.policy is EndpointPolicy.DENY:
             flow.response = http_403(SandboxProxyError.POLICY_DENIED)
             logger.info(
-                "proxy.egress_block " + EGRESS_MATCHED_FIELDS + " reason=%s",
+                "egress_block " + EGRESS_MATCHED_FIELDS + " reason=%s",
                 *egress_matched_args(
                     flow, sandbox, matched_actions, EndpointPolicy.DENY
                 ),
@@ -538,7 +532,7 @@ class GateAddon:
             )
             if injection is InjectionOutcome.BLOCKED:
                 logger.warning(
-                    "proxy.egress_block "
+                    "egress_block "
                     + EGRESS_MATCHED_FIELDS
                     + " reason=%s credential_outcome=%s",
                     *egress_matched_args(
@@ -549,9 +543,7 @@ class GateAddon:
                 )
             else:
                 logger.info(
-                    "proxy.egress_allow "
-                    + EGRESS_MATCHED_FIELDS
-                    + " credential_outcome=%s",
+                    "egress_allow " + EGRESS_MATCHED_FIELDS + " credential_outcome=%s",
                     *egress_matched_args(
                         flow, sandbox, matched_actions, EndpointPolicy.ALWAYS
                     ),
@@ -565,7 +557,7 @@ class GateAddon:
             session_id = self._resolve_gated_session(flow, sandbox)
         except Exception:
             logger.exception(
-                "proxy.session_lookup_error tenant=%s sandbox=%s host=%s app=%r "
+                "session_lookup_error tenant=%s sandbox=%s host=%s app_name=%r "
                 "action_type=%s",
                 sandbox.tenant_id,
                 sandbox_log_label(sandbox),
@@ -577,7 +569,7 @@ class GateAddon:
             return None
         if session_id is None:
             logger.info(
-                "proxy.egress_block " + EGRESS_MATCHED_FIELDS + " reason=%s",
+                "egress_block " + EGRESS_MATCHED_FIELDS + " reason=%s",
                 *egress_matched_args(
                     flow, sandbox, matched_actions, EndpointPolicy.ASK
                 ),
@@ -588,8 +580,8 @@ class GateAddon:
 
         ctx = sandbox.with_session(session_id)
         logger.debug(
-            "proxy.approval_match tenant=%s sandbox=%s session=%s host=%s "
-            "method=%s app=%r action_type=%s",
+            "approval_match tenant=%s sandbox=%s session=%s host=%s "
+            "method=%s app_name=%r action_type=%s",
             ctx.tenant_id,
             sandbox_log_label(ctx),
             short_log_id(ctx.session_id),
@@ -659,7 +651,7 @@ class GateAddon:
                 return _ApprovalGrant(decided_via=ApprovalDecidedVia.SESSION_GRANT)
         except CACHE_TRANSIENT_ERRORS as e:
             logger.warning(
-                "proxy.approval_grant_cache_error tenant=%s session=%s "
+                "approval_grant_cache_error tenant=%s session=%s "
                 "external_app_id=%s operation=%s error=%r",
                 ctx.tenant_id,
                 short_log_id(ctx.session_id),
@@ -695,7 +687,7 @@ class GateAddon:
                     )
             except CACHE_TRANSIENT_ERRORS as e:
                 logger.warning(
-                    "proxy.approval_grant_cache_error tenant=%s session=%s "
+                    "approval_grant_cache_error tenant=%s session=%s "
                     "external_app_id=%s operation=%s error=%r",
                     ctx.tenant_id,
                     short_log_id(ctx.session_id),
@@ -705,13 +697,13 @@ class GateAddon:
                 )
         return _ApprovalGrant(decided_via=ApprovalDecidedVia.SESSION_GRANT)
 
-    async def _approval_grant_applies(
+    async def _apply_approval_grant(
         self,
         ctx: SessionContext,
         matched_actions: AllMatchedActions,
         *,
         approval_id: UUID | None = None,
-    ) -> bool:
+    ) -> UUID | None:
         try:
             return await asyncio.to_thread(
                 self._try_apply_approval_grant,
@@ -721,8 +713,8 @@ class GateAddon:
             )
         except Exception:
             logger.exception(
-                "proxy.approval_grant_check_error tenant=%s sandbox=%s "
-                "session=%s approval=%s app=%r action_type=%s session_id=%s "
+                "approval_grant_check_error tenant=%s sandbox=%s "
+                "session=%s approval=%s app_name=%r action_type=%s session_id=%s "
                 "approval_id=%s",
                 ctx.tenant_id,
                 sandbox_log_label(ctx),
@@ -733,19 +725,19 @@ class GateAddon:
                 full_log_id(ctx.session_id),
                 full_log_id(approval_id),
             )
-            return False
+            return None
 
     def _try_apply_approval_grant(
         self,
         ctx: SessionContext,
         matched_actions: AllMatchedActions,
         approval_id: UUID | None,
-    ) -> bool:
+    ) -> UUID | None:
         """Apply an existing approval grant to a new or already-persisted row."""
         with get_session_with_tenant(tenant_id=ctx.tenant_id) as db:
             grant = self._resolve_approval_grant(db, ctx, matched_actions)
             if grant is None:
-                return False
+                return None
             if approval_id is None:
                 row = action_approval.insert_action_approval(
                     db,
@@ -768,37 +760,32 @@ class GateAddon:
                     decided_via=grant.decided_via,
                 )
                 if decided is None:
-                    return False
+                    return None
                 applied_approval_id = approval_id
             db.commit()
 
         logger.info(
-            "proxy.approval_decided tenant=%s sandbox=%s session=%s approval=%s "
-            "app=%r external_app_id=%s action_type=%s decision=%s source=%s "
-            "session_id=%s approval_id=%s",
-            ctx.tenant_id,
-            sandbox_log_label(ctx),
-            short_log_id(ctx.session_id),
-            short_log_id(applied_approval_id),
-            matched_actions.app_name,
-            matched_actions.external_app_id,
-            matched_actions.governing_action.action_type,
-            ApprovalDecision.APPROVED.value,
-            grant.decided_via.value,
-            full_log_id(ctx.session_id),
-            full_log_id(applied_approval_id),
+            "approval_decided " + APPROVAL_DECIDED_FIELDS,
+            *approval_decided_args(
+                ctx,
+                applied_approval_id,
+                matched_actions,
+                decision=ApprovalDecision.APPROVED.value,
+                wake="-",
+                source=grant.decided_via.value,
+            ),
         )
         try:
             if grant.notif_type is not None:
                 self._notify_approval_grant(ctx, grant)
         except Exception as e:
             logger.warning(
-                "proxy.approval_notify_error approval=%s error=%r approval_id=%s",
+                "approval_notify_error approval=%s error=%r approval_id=%s",
                 short_log_id(applied_approval_id),
                 str(e),
                 full_log_id(applied_approval_id),
             )
-        return True
+        return applied_approval_id
 
     def _persist_approval_row(
         self, ctx: SessionContext, matched_actions: AllMatchedActions
@@ -830,15 +817,15 @@ class GateAddon:
             )
         except CACHE_TRANSIENT_ERRORS as e:
             logger.warning(
-                "proxy.approval_announce_error approval=%s error=%r approval_id=%s",
+                "approval_announce_error approval=%s error=%r approval_id=%s",
                 short_log_id(approval_id),
                 str(e),
                 full_log_id(approval_id),
             )
 
         logger.info(
-            "proxy.approval_requested tenant=%s sandbox=%s session=%s approval=%s "
-            "app=%r external_app_id=%s action_type=%s action_count=%s "
+            "approval_requested tenant=%s sandbox=%s session=%s approval=%s "
+            "app_name=%r external_app_id=%s action_type=%s action_count=%s "
             "proxy_instance=%s session_id=%s approval_id=%s",
             ctx.tenant_id,
             sandbox_log_label(ctx),
@@ -857,7 +844,7 @@ class GateAddon:
             self._notify_approval_requested(approval_id, ctx, matched_actions)
         except Exception as e:
             logger.warning(
-                "proxy.approval_notify_error approval=%s error=%r approval_id=%s",
+                "approval_notify_error approval=%s error=%r approval_id=%s",
                 short_log_id(approval_id),
                 str(e),
                 full_log_id(approval_id),
@@ -882,39 +869,29 @@ class GateAddon:
             )
             if decision is not None:
                 logger.info(
-                    "proxy.approval_decided tenant=%s sandbox=%s session=%s "
-                    "approval=%s app=%r action_type=%s decision=%s wake=%s "
-                    "source=%s session_id=%s approval_id=%s",
-                    ctx.tenant_id,
-                    sandbox_log_label(ctx),
-                    short_log_id(ctx.session_id),
-                    short_log_id(approval_id),
-                    matched_actions.app_name,
-                    matched_actions.governing_action.action_type,
-                    decision.value,
-                    "received",
-                    "wake",
-                    full_log_id(ctx.session_id),
-                    full_log_id(approval_id),
+                    "approval_decided " + APPROVAL_DECIDED_FIELDS,
+                    *approval_decided_args(
+                        ctx,
+                        approval_id,
+                        matched_actions,
+                        decision=decision.value,
+                        wake="received",
+                        source="wake",
+                    ),
                 )
                 return decision
             resolved = self._claim_expired_or_read_winner(approval_id, ctx.tenant_id)
             source = "timeout" if resolved == ApprovalDecision.EXPIRED else "db_winner"
             logger.info(
-                "proxy.approval_decided tenant=%s sandbox=%s session=%s approval=%s "
-                "app=%r action_type=%s decision=%s wake=%s source=%s "
-                "session_id=%s approval_id=%s",
-                ctx.tenant_id,
-                sandbox_log_label(ctx),
-                short_log_id(ctx.session_id),
-                short_log_id(approval_id),
-                matched_actions.app_name,
-                matched_actions.governing_action.action_type,
-                resolved.value,
-                "missed",
-                source,
-                full_log_id(ctx.session_id),
-                full_log_id(approval_id),
+                "approval_decided " + APPROVAL_DECIDED_FIELDS,
+                *approval_decided_args(
+                    ctx,
+                    approval_id,
+                    matched_actions,
+                    decision=resolved.value,
+                    wake="missed",
+                    source=source,
+                ),
             )
             return resolved
         except asyncio.CancelledError:
@@ -946,7 +923,7 @@ class GateAddon:
                 # FK cascade dropped the row (build_session deleted).
                 # Treat as expired so the upstream call is rejected.
                 logger.error(
-                    "proxy.approval_row_missing tenant=%s approval=%s approval_id=%s",
+                    "approval_row_missing tenant=%s approval=%s approval_id=%s",
                     tenant_id,
                     short_log_id(approval_id),
                     full_log_id(approval_id),
@@ -998,7 +975,7 @@ class GateAddon:
             decision = self._claim_expired_or_read_winner(approval_id, tenant_id)
         except Exception:
             logger.exception(
-                "proxy.approval_terminalize_error tenant=%s approval=%s "
+                "approval_terminalize_error tenant=%s approval=%s "
                 "operation=%s approval_id=%s",
                 tenant_id,
                 short_log_id(approval_id),
@@ -1012,7 +989,7 @@ class GateAddon:
             )
         except Exception:
             logger.exception(
-                "proxy.approval_terminalize_error tenant=%s approval=%s "
+                "approval_terminalize_error tenant=%s approval=%s "
                 "operation=%s approval_id=%s",
                 tenant_id,
                 short_log_id(approval_id),
@@ -1046,14 +1023,14 @@ class GateAddon:
                         pass
                     if decision == ApprovalDecision.EXPIRED:
                         logger.info(
-                            "proxy.drain_expired tenant=%s approval=%s approval_id=%s",
+                            "drain_expired tenant=%s approval=%s approval_id=%s",
                             tenant_id,
                             short_log_id(approval_id),
                             full_log_id(approval_id),
                         )
                     else:
                         logger.info(
-                            "proxy.drain_forwarded tenant=%s approval=%s "
+                            "drain_forwarded tenant=%s approval=%s "
                             "decision=%s approval_id=%s",
                             tenant_id,
                             short_log_id(approval_id),
@@ -1062,8 +1039,7 @@ class GateAddon:
                         )
                 except Exception as e:
                     logger.warning(
-                        "proxy.drain_error tenant=%s approval=%s error=%r "
-                        "approval_id=%s",
+                        "drain_error tenant=%s approval=%s error=%r approval_id=%s",
                         tenant_id,
                         short_log_id(approval_id),
                         str(e),
@@ -1075,7 +1051,7 @@ class GateAddon:
         self_task = asyncio.current_task()
         pending = [t for t in self._inflight_tasks if t is not self_task]
         if pending:
-            logger.info("proxy.drain_wait requests=%s", len(pending))
+            logger.info("drain_wait requests=%s", len(pending))
             await asyncio.wait(pending)
 
     # --------------------------------------------------------------------------
@@ -1159,7 +1135,7 @@ class GateAddon:
         tag = self._extract_session_tag(flow)
         if tag is None:
             logger.warning(
-                "proxy.session_missing tenant=%s sandbox=%s host=%s",
+                "session_missing tenant=%s sandbox=%s host=%s",
                 sandbox.tenant_id,
                 sandbox_log_label(sandbox),
                 flow.request.host,
@@ -1169,7 +1145,7 @@ class GateAddon:
             tagged_id = UUID(tag)
         except ValueError:
             logger.warning(
-                "proxy.session_malformed tenant=%s sandbox=%s host=%s",
+                "session_malformed tenant=%s sandbox=%s host=%s",
                 sandbox.tenant_id,
                 sandbox_log_label(sandbox),
                 flow.request.host,
@@ -1181,7 +1157,7 @@ class GateAddon:
         if exact is None:
             # Stale, foreign, or tampered tag. Fail closed — do not guess.
             logger.warning(
-                "proxy.session_unverified tenant=%s sandbox=%s session=%s host=%s",
+                "session_unverified tenant=%s sandbox=%s session=%s host=%s",
                 sandbox.tenant_id,
                 sandbox_log_label(sandbox),
                 short_log_id(tagged_id),
@@ -1189,7 +1165,7 @@ class GateAddon:
             )
             return None
         logger.debug(
-            "proxy.session_verified tenant=%s sandbox=%s session=%s host=%s",
+            "session_verified tenant=%s sandbox=%s session=%s host=%s",
             sandbox.tenant_id,
             sandbox_log_label(sandbox),
             short_log_id(exact),
@@ -1210,7 +1186,7 @@ class GateAddon:
         tag = cached or direct
 
         logger.debug(
-            "proxy.session_tag_resolved conn=%s host=%s cached=%s direct=%s "
+            "session_tag_resolved conn=%s host=%s cached=%s direct=%s "
             "proxy_auth_present=%s session=%s",
             conn_id or "-",
             flow.request.host,

--- a/backend/onyx/sandbox_proxy/credential_injection.py
+++ b/backend/onyx/sandbox_proxy/credential_injection.py
@@ -5,8 +5,7 @@ and asks each in turn whether it owns the request. The first one that claims
 renders its auth headers; the dispatcher writes them onto `flow.request` so the
 real secret never has to live in the sandbox pod. Resolution outcomes are
 explicit (`PASS_THROUGH` / `CLAIMED` / `INJECTED` / `BLOCKED`) and the
-dispatcher never raises. `apply_or_block(flow, ctx)` is a convenience wrapper
-for callers that do not need to inspect the outcome directly.
+dispatcher never raises.
 """
 
 from __future__ import annotations
@@ -18,8 +17,6 @@ from typing import Protocol
 from mitmproxy import http
 
 from onyx.external_apps.matching.engine import AllMatchedActions
-from onyx.sandbox_proxy.errors import http_403
-from onyx.sandbox_proxy.errors import SandboxProxyError
 from onyx.sandbox_proxy.identity import ResolvedSandbox
 from onyx.utils.logger import setup_logger
 
@@ -84,7 +81,7 @@ class CredentialInjectionDispatcher:
             headers = resolver.resolve(flow.request, ctx)
         except CredentialUnavailableError as e:
             logger.warning(
-                "proxy.credential_unavailable resolver=%s host=%s error=%r",
+                "credential_unavailable resolver=%s host=%s error=%r",
                 resolver_name,
                 host,
                 str(e),
@@ -92,7 +89,7 @@ class CredentialInjectionDispatcher:
             return InjectionOutcome.BLOCKED
         except Exception:
             logger.exception(
-                "proxy.credential_resolver_error resolver=%s host=%s",
+                "credential_resolver_error resolver=%s host=%s",
                 resolver_name,
                 host,
             )
@@ -100,10 +97,12 @@ class CredentialInjectionDispatcher:
 
         if not headers:
             logger.debug(
-                "proxy.credential_claimed resolver=%s host=%s headers=%s",
+                "credential_claimed resolver=%s host=%s "
+                "header_count=%s header_names=%s",
                 resolver_name,
                 host,
                 0,
+                "-",
             )
             return InjectionOutcome.CLAIMED
 
@@ -111,21 +110,13 @@ class CredentialInjectionDispatcher:
             flow.request.headers[name] = value
         # Header NAMES only — never log the injected secret values.
         logger.debug(
-            "proxy.credential_injected resolver=%s host=%s headers=%s",
+            "credential_injected resolver=%s host=%s header_count=%s header_names=%s",
             resolver_name,
             host,
+            len(headers),
             ",".join(sorted(headers)),
         )
         return InjectionOutcome.INJECTED
-
-    def apply_or_block(self, flow: http.HTTPFlow, ctx: InjectionContext) -> None:
-        """Run `apply`; on `BLOCKED`, write a sandbox-visible 403 to `flow`.
-
-        Convenience wrapper for callers that do not need to inspect the
-        credential outcome directly.
-        """
-        if self.apply(flow, ctx) is InjectionOutcome.BLOCKED:
-            flow.response = http_403(SandboxProxyError.CREDENTIAL_ERROR)
 
     def _pick(
         self, request: http.Request, ctx: InjectionContext
@@ -137,7 +128,7 @@ class CredentialInjectionDispatcher:
             except Exception:
                 # One buggy resolver must not deny the others a chance.
                 logger.exception(
-                    "proxy.credential_claim_error resolver=%s host=%s",
+                    "credential_claim_error resolver=%s host=%s",
                     type(resolver).__name__,
                     request.host,
                 )

--- a/backend/onyx/sandbox_proxy/credential_injection.py
+++ b/backend/onyx/sandbox_proxy/credential_injection.py
@@ -4,10 +4,9 @@
 and asks each in turn whether it owns the request. The first one that claims
 renders its auth headers; the dispatcher writes them onto `flow.request` so the
 real secret never has to live in the sandbox pod. Resolution outcomes are
-explicit (`PASS_THROUGH` / `INJECTED` / `BLOCKED`) and the dispatcher never
-raises. The high-level `apply_or_block(flow, ctx)` does both the dispatch and
-the fail-closed 403 in one call; tests use `apply(flow, ctx)` when they want
-to inspect the outcome directly.
+explicit (`PASS_THROUGH` / `CLAIMED` / `INJECTED` / `BLOCKED`) and the
+dispatcher never raises. `apply_or_block(flow, ctx)` is a convenience wrapper
+for callers that do not need to inspect the outcome directly.
 """
 
 from __future__ import annotations
@@ -63,6 +62,7 @@ class CredentialResolver(Protocol):
 
 class InjectionOutcome(Enum):
     PASS_THROUGH = "pass_through"
+    CLAIMED = "claimed"
     INJECTED = "injected"
     BLOCKED = "blocked"
 
@@ -84,7 +84,7 @@ class CredentialInjectionDispatcher:
             headers = resolver.resolve(flow.request, ctx)
         except CredentialUnavailableError as e:
             logger.warning(
-                "credential_injection.unavailable resolver=%s host=%s error=%s",
+                "proxy.credential_unavailable resolver=%s host=%s error=%r",
                 resolver_name,
                 host,
                 str(e),
@@ -92,29 +92,37 @@ class CredentialInjectionDispatcher:
             return InjectionOutcome.BLOCKED
         except Exception:
             logger.exception(
-                "credential_injection.resolver_error resolver=%s host=%s",
+                "proxy.credential_resolver_error resolver=%s host=%s",
                 resolver_name,
                 host,
             )
             return InjectionOutcome.BLOCKED
 
+        if not headers:
+            logger.debug(
+                "proxy.credential_claimed resolver=%s host=%s headers=%s",
+                resolver_name,
+                host,
+                0,
+            )
+            return InjectionOutcome.CLAIMED
+
         for name, value in headers.items():
             flow.request.headers[name] = value
         # Header NAMES only — never log the injected secret values.
-        logger.info(
-            "credential_injection.applied resolver=%s host=%s headers=%s",
+        logger.debug(
+            "proxy.credential_injected resolver=%s host=%s headers=%s",
             resolver_name,
             host,
-            sorted(headers),
+            ",".join(sorted(headers)),
         )
         return InjectionOutcome.INJECTED
 
     def apply_or_block(self, flow: http.HTTPFlow, ctx: InjectionContext) -> None:
         """Run `apply`; on `BLOCKED`, write a sandbox-visible 403 to `flow`.
 
-        The single seam most call sites want — they don't need to inspect the
-        outcome, just to fail closed on it. Tests that need to assert on the
-        outcome directly call `apply` instead.
+        Convenience wrapper for callers that do not need to inspect the
+        credential outcome directly.
         """
         if self.apply(flow, ctx) is InjectionOutcome.BLOCKED:
             flow.response = http_403(SandboxProxyError.CREDENTIAL_ERROR)
@@ -129,7 +137,7 @@ class CredentialInjectionDispatcher:
             except Exception:
                 # One buggy resolver must not deny the others a chance.
                 logger.exception(
-                    "credential_injection.claims_error resolver=%s host=%s",
+                    "proxy.credential_claim_error resolver=%s host=%s",
                     type(resolver).__name__,
                     request.host,
                 )

--- a/backend/onyx/sandbox_proxy/logging_utils.py
+++ b/backend/onyx/sandbox_proxy/logging_utils.py
@@ -10,19 +10,23 @@ from onyx.sandbox_proxy.credential_injection import InjectionOutcome
 from onyx.sandbox_proxy.identity import ResolvedSandbox
 from onyx.sandbox_proxy.identity import SessionContext
 
-LOG_ID_PREFIX_LEN = 8
-
-EGRESS_TARGET_FIELDS = "tenant=%s sandbox=%s host=%s method=%s"
-EGRESS_MATCHED_FIELDS = (
-    EGRESS_TARGET_FIELDS + " app=%r external_app_id=%s action_type=%s policy=%s"
+_EGRESS_CONTEXT_FIELDS = "tenant=%s sandbox=%s"
+_EGRESS_SESSION_FIELDS = f"{_EGRESS_CONTEXT_FIELDS} session=%s"
+_EGRESS_APPROVAL_FIELDS = f"{_EGRESS_SESSION_FIELDS} approval=%s"
+_EGRESS_REQUEST_FIELDS = "host=%s method=%s"
+_EGRESS_ACTION_FIELDS = "app_name=%r external_app_id=%s action_type=%s policy=%s"
+APPROVAL_DECIDED_FIELDS = (
+    f"{_EGRESS_APPROVAL_FIELDS} app_name=%r external_app_id=%s action_type=%s "
+    "decision=%s wake=%s source=%s session_id=%s approval_id=%s"
 )
+
+EGRESS_TARGET_FIELDS = f"{_EGRESS_CONTEXT_FIELDS} {_EGRESS_REQUEST_FIELDS}"
+EGRESS_MATCHED_FIELDS = f"{EGRESS_TARGET_FIELDS} {_EGRESS_ACTION_FIELDS}"
 EGRESS_SESSION_MATCHED_FIELDS = (
-    "tenant=%s sandbox=%s session=%s host=%s method=%s app=%r "
-    "external_app_id=%s action_type=%s policy=%s"
+    f"{_EGRESS_SESSION_FIELDS} {_EGRESS_REQUEST_FIELDS} {_EGRESS_ACTION_FIELDS}"
 )
 EGRESS_APPROVAL_MATCHED_FIELDS = (
-    "tenant=%s sandbox=%s session=%s approval=%s host=%s method=%s app=%r "
-    "external_app_id=%s action_type=%s policy=%s"
+    f"{_EGRESS_APPROVAL_FIELDS} {_EGRESS_REQUEST_FIELDS} {_EGRESS_ACTION_FIELDS}"
 )
 
 
@@ -31,7 +35,7 @@ def short_log_id(value: UUID | str | None) -> str:
         return "-"
     text = str(value)
     try:
-        return str(UUID(text))[:LOG_ID_PREFIX_LEN]
+        return str(UUID(text))[:8]
     except ValueError:
         return text
 
@@ -62,14 +66,31 @@ def _policy_label(policy: EndpointPolicy | str) -> str:
     return policy.value if isinstance(policy, EndpointPolicy) else policy
 
 
+def _egress_context_args(sandbox: ResolvedSandbox | SessionContext) -> tuple[str, str]:
+    return sandbox.tenant_id, sandbox_log_label(sandbox)
+
+
+def _egress_request_args(flow: http.HTTPFlow) -> tuple[str, str]:
+    return flow.request.host, flow.request.method
+
+
+def _egress_action_args(
+    matched_actions: AllMatchedActions, policy: EndpointPolicy | str
+) -> tuple[object, ...]:
+    return (
+        matched_actions.app_name,
+        matched_actions.external_app_id,
+        matched_actions.governing_action.action_type,
+        _policy_label(policy),
+    )
+
+
 def egress_target_args(
     flow: http.HTTPFlow, sandbox: ResolvedSandbox | SessionContext
 ) -> tuple[object, ...]:
     return (
-        sandbox.tenant_id,
-        sandbox_log_label(sandbox),
-        flow.request.host,
-        flow.request.method,
+        *_egress_context_args(sandbox),
+        *_egress_request_args(flow),
     )
 
 
@@ -81,10 +102,7 @@ def egress_matched_args(
 ) -> tuple[object, ...]:
     return (
         *egress_target_args(flow, sandbox),
-        matched_actions.app_name,
-        matched_actions.external_app_id,
-        matched_actions.governing_action.action_type,
-        _policy_label(policy),
+        *_egress_action_args(matched_actions, policy),
     )
 
 
@@ -95,15 +113,10 @@ def egress_session_matched_args(
     policy: EndpointPolicy | str,
 ) -> tuple[object, ...]:
     return (
-        ctx.tenant_id,
-        sandbox_log_label(ctx),
+        *_egress_context_args(ctx),
         short_log_id(ctx.session_id),
-        flow.request.host,
-        flow.request.method,
-        matched_actions.app_name,
-        matched_actions.external_app_id,
-        matched_actions.governing_action.action_type,
-        _policy_label(policy),
+        *_egress_request_args(flow),
+        *_egress_action_args(matched_actions, policy),
     )
 
 
@@ -112,17 +125,36 @@ def egress_approval_matched_args(
     ctx: SessionContext,
     matched_actions: AllMatchedActions,
     policy: EndpointPolicy | str,
-    approval_id: UUID | None,
+    approval_id: UUID,
 ) -> tuple[object, ...]:
     return (
-        ctx.tenant_id,
-        sandbox_log_label(ctx),
+        *_egress_context_args(ctx),
         short_log_id(ctx.session_id),
         short_log_id(approval_id),
-        flow.request.host,
-        flow.request.method,
+        *_egress_request_args(flow),
+        *_egress_action_args(matched_actions, policy),
+    )
+
+
+def approval_decided_args(
+    ctx: SessionContext,
+    approval_id: UUID,
+    matched_actions: AllMatchedActions,
+    *,
+    decision: str,
+    wake: str,
+    source: str,
+) -> tuple[object, ...]:
+    return (
+        *_egress_context_args(ctx),
+        short_log_id(ctx.session_id),
+        short_log_id(approval_id),
         matched_actions.app_name,
         matched_actions.external_app_id,
         matched_actions.governing_action.action_type,
-        _policy_label(policy),
+        decision,
+        wake,
+        source,
+        full_log_id(ctx.session_id),
+        full_log_id(approval_id),
     )

--- a/backend/onyx/sandbox_proxy/logging_utils.py
+++ b/backend/onyx/sandbox_proxy/logging_utils.py
@@ -57,6 +57,8 @@ def sandbox_log_label(sandbox: ResolvedSandbox | SessionContext) -> str:
 def credential_outcome_label(outcome: InjectionOutcome) -> str:
     if outcome is InjectionOutcome.PASS_THROUGH:
         return "none"
+    if outcome is InjectionOutcome.CLAIMED:
+        return "claimed_no_headers"
     if outcome is InjectionOutcome.INJECTED:
         return "headers_injected"
     return outcome.value

--- a/backend/onyx/sandbox_proxy/logging_utils.py
+++ b/backend/onyx/sandbox_proxy/logging_utils.py
@@ -1,0 +1,128 @@
+"""Shared rendering helpers for sandbox proxy logs."""
+
+from uuid import UUID
+
+from mitmproxy import http
+
+from onyx.db.enums import EndpointPolicy
+from onyx.external_apps.matching.engine import AllMatchedActions
+from onyx.sandbox_proxy.credential_injection import InjectionOutcome
+from onyx.sandbox_proxy.identity import ResolvedSandbox
+from onyx.sandbox_proxy.identity import SessionContext
+
+LOG_ID_PREFIX_LEN = 8
+
+EGRESS_TARGET_FIELDS = "tenant=%s sandbox=%s host=%s method=%s"
+EGRESS_MATCHED_FIELDS = (
+    EGRESS_TARGET_FIELDS + " app=%r external_app_id=%s action_type=%s policy=%s"
+)
+EGRESS_SESSION_MATCHED_FIELDS = (
+    "tenant=%s sandbox=%s session=%s host=%s method=%s app=%r "
+    "external_app_id=%s action_type=%s policy=%s"
+)
+EGRESS_APPROVAL_MATCHED_FIELDS = (
+    "tenant=%s sandbox=%s session=%s approval=%s host=%s method=%s app=%r "
+    "external_app_id=%s action_type=%s policy=%s"
+)
+
+
+def short_log_id(value: UUID | str | None) -> str:
+    if value is None:
+        return "-"
+    text = str(value)
+    try:
+        return str(UUID(text))[:LOG_ID_PREFIX_LEN]
+    except ValueError:
+        return text
+
+
+def full_log_id(value: UUID | str | None) -> str:
+    if value is None:
+        return "-"
+    text = str(value)
+    try:
+        return str(UUID(text))
+    except ValueError:
+        return text
+
+
+def sandbox_log_label(sandbox: ResolvedSandbox | SessionContext) -> str:
+    return sandbox.sandbox_name or short_log_id(sandbox.sandbox_id)
+
+
+def credential_outcome_label(outcome: InjectionOutcome) -> str:
+    if outcome is InjectionOutcome.PASS_THROUGH:
+        return "none"
+    if outcome is InjectionOutcome.INJECTED:
+        return "headers_injected"
+    return outcome.value
+
+
+def _policy_label(policy: EndpointPolicy | str) -> str:
+    return policy.value if isinstance(policy, EndpointPolicy) else policy
+
+
+def egress_target_args(
+    flow: http.HTTPFlow, sandbox: ResolvedSandbox | SessionContext
+) -> tuple[object, ...]:
+    return (
+        sandbox.tenant_id,
+        sandbox_log_label(sandbox),
+        flow.request.host,
+        flow.request.method,
+    )
+
+
+def egress_matched_args(
+    flow: http.HTTPFlow,
+    sandbox: ResolvedSandbox | SessionContext,
+    matched_actions: AllMatchedActions,
+    policy: EndpointPolicy | str,
+) -> tuple[object, ...]:
+    return (
+        *egress_target_args(flow, sandbox),
+        matched_actions.app_name,
+        matched_actions.external_app_id,
+        matched_actions.governing_action.action_type,
+        _policy_label(policy),
+    )
+
+
+def egress_session_matched_args(
+    flow: http.HTTPFlow,
+    ctx: SessionContext,
+    matched_actions: AllMatchedActions,
+    policy: EndpointPolicy | str,
+) -> tuple[object, ...]:
+    return (
+        ctx.tenant_id,
+        sandbox_log_label(ctx),
+        short_log_id(ctx.session_id),
+        flow.request.host,
+        flow.request.method,
+        matched_actions.app_name,
+        matched_actions.external_app_id,
+        matched_actions.governing_action.action_type,
+        _policy_label(policy),
+    )
+
+
+def egress_approval_matched_args(
+    flow: http.HTTPFlow,
+    ctx: SessionContext,
+    matched_actions: AllMatchedActions,
+    policy: EndpointPolicy | str,
+    approval_id: UUID | None,
+) -> tuple[object, ...]:
+    return (
+        ctx.tenant_id,
+        sandbox_log_label(ctx),
+        short_log_id(ctx.session_id),
+        short_log_id(approval_id),
+        flow.request.host,
+        flow.request.method,
+        matched_actions.app_name,
+        matched_actions.external_app_id,
+        matched_actions.governing_action.action_type,
+        _policy_label(policy),
+    )

--- a/backend/onyx/sandbox_proxy/resolvers/external_app.py
+++ b/backend/onyx/sandbox_proxy/resolvers/external_app.py
@@ -61,10 +61,13 @@ class ExternalAppResolver(CredentialResolver):
         # the dispatcher's credential logs group by resolver.
         # Empty `headers` means "app disabled / deleted / placeholders unfillable" —
         # the request still forwards (upstream 401 surfaces to the user).
+        header_names = ",".join(sorted(headers)) or "-"
         logger.debug(
-            "external_app_resolver.resolved external_app_id=%s host=%s headers=%s",
+            "external_app_resolver.resolved external_app_id=%s host=%s "
+            "header_count=%s header_names=%s",
             matched_actions.external_app_id,
             request.host,
-            sorted(headers),
+            len(headers),
+            header_names,
         )
         return headers

--- a/backend/onyx/sandbox_proxy/resolvers/external_app.py
+++ b/backend/onyx/sandbox_proxy/resolvers/external_app.py
@@ -57,11 +57,11 @@ class ExternalAppResolver(CredentialResolver):
                 db, matched_actions.external_app_id, ctx.sandbox.user_id
             )
 
-        # Per-app audit line so `external_app_id` survives in logs even when
-        # the dispatcher's `credential_injection.applied` log groups by resolver.
+        # Per-app debug line so `external_app_id` survives in logs even when
+        # the dispatcher's credential logs group by resolver.
         # Empty `headers` means "app disabled / deleted / placeholders unfillable" —
         # the request still forwards (upstream 401 surfaces to the user).
-        logger.info(
+        logger.debug(
             "external_app_resolver.resolved external_app_id=%s host=%s headers=%s",
             matched_actions.external_app_id,
             request.host,

--- a/backend/onyx/sandbox_proxy/resolvers/llm_provider_key.py
+++ b/backend/onyx/sandbox_proxy/resolvers/llm_provider_key.py
@@ -18,6 +18,7 @@ from onyx.db.users import fetch_user_by_id
 from onyx.sandbox_proxy.credential_injection import CredentialResolver
 from onyx.sandbox_proxy.credential_injection import CredentialUnavailableError
 from onyx.sandbox_proxy.credential_injection import InjectionContext
+from onyx.sandbox_proxy.logging_utils import short_log_id
 from onyx.server.features.build.db.build_session import (
     fetch_all_supported_build_llm_providers,
 )
@@ -50,7 +51,9 @@ class LLMProviderKeyResolver(CredentialResolver):
         with get_session_with_tenant(tenant_id=ctx.sandbox.tenant_id) as db:
             user = fetch_user_by_id(db, user_id)
             if user is None:
-                raise CredentialUnavailableError(f"sandbox user {user_id} not found")
+                raise CredentialUnavailableError(
+                    f"sandbox user {short_log_id(user_id)} not found"
+                )
             providers = fetch_all_supported_build_llm_providers(db, user)
 
         # First accessible provider of the type, matching how provisioning picks
@@ -58,14 +61,14 @@ class LLMProviderKeyResolver(CredentialResolver):
         provider = next((p for p in providers if p.provider == provider_type), None)
         if provider is None:
             raise CredentialUnavailableError(
-                f"no accessible {provider_type} provider for user {user_id}"
+                f"no accessible {provider_type} provider for user {short_log_id(user_id)}"
             )
         if not provider.api_key:
             raise CredentialUnavailableError(
-                f"{provider_type} provider for user {user_id} has no api_key"
+                f"{provider_type} provider for user {short_log_id(user_id)} has no api_key"
             )
 
-        logger.info(
+        logger.debug(
             "llm_provider_key_resolver.resolved provider=%s host=%s",
             provider_type,
             request.host,

--- a/backend/onyx/sandbox_proxy/resolvers/onyx_pat.py
+++ b/backend/onyx/sandbox_proxy/resolvers/onyx_pat.py
@@ -19,6 +19,7 @@ from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.sandbox_proxy.credential_injection import CredentialResolver
 from onyx.sandbox_proxy.credential_injection import CredentialUnavailableError
 from onyx.sandbox_proxy.credential_injection import InjectionContext
+from onyx.sandbox_proxy.logging_utils import full_log_id
 from onyx.sandbox_proxy.logging_utils import short_log_id
 from onyx.server.features.build.configs import SANDBOX_API_SERVER_URL
 from onyx.server.features.build.db.sandbox import get_sandbox_by_id
@@ -56,17 +57,17 @@ class OnyxPatResolver(CredentialResolver):
             sandbox = get_sandbox_by_id(db, sandbox_id)
             if sandbox is None:
                 raise CredentialUnavailableError(
-                    f"sandbox {short_log_id(sandbox_id)} not found"
+                    f"sandbox {full_log_id(sandbox_id)} not found"
                 )
             if sandbox.encrypted_pat is None:
                 raise CredentialUnavailableError(
-                    f"sandbox {short_log_id(sandbox_id)} has no PAT"
+                    f"sandbox {full_log_id(sandbox_id)} has no PAT"
                 )
             try:
                 raw_token = sandbox.encrypted_pat.get_value(apply_mask=False)
             except Exception as e:
                 raise CredentialUnavailableError(
-                    f"failed to decrypt PAT for sandbox {short_log_id(sandbox_id)}"
+                    f"failed to decrypt PAT for sandbox {full_log_id(sandbox_id)}"
                 ) from e
 
         logger.debug(

--- a/backend/onyx/sandbox_proxy/resolvers/onyx_pat.py
+++ b/backend/onyx/sandbox_proxy/resolvers/onyx_pat.py
@@ -19,6 +19,7 @@ from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.sandbox_proxy.credential_injection import CredentialResolver
 from onyx.sandbox_proxy.credential_injection import CredentialUnavailableError
 from onyx.sandbox_proxy.credential_injection import InjectionContext
+from onyx.sandbox_proxy.logging_utils import short_log_id
 from onyx.server.features.build.configs import SANDBOX_API_SERVER_URL
 from onyx.server.features.build.db.sandbox import get_sandbox_by_id
 from onyx.utils.logger import setup_logger
@@ -54,18 +55,24 @@ class OnyxPatResolver(CredentialResolver):
         with get_session_with_tenant(tenant_id=ctx.sandbox.tenant_id) as db:
             sandbox = get_sandbox_by_id(db, sandbox_id)
             if sandbox is None:
-                raise CredentialUnavailableError(f"sandbox {sandbox_id} not found")
+                raise CredentialUnavailableError(
+                    f"sandbox {short_log_id(sandbox_id)} not found"
+                )
             if sandbox.encrypted_pat is None:
-                raise CredentialUnavailableError(f"sandbox {sandbox_id} has no PAT")
+                raise CredentialUnavailableError(
+                    f"sandbox {short_log_id(sandbox_id)} has no PAT"
+                )
             try:
                 raw_token = sandbox.encrypted_pat.get_value(apply_mask=False)
             except Exception as e:
                 raise CredentialUnavailableError(
-                    f"failed to decrypt PAT for sandbox {sandbox_id}"
+                    f"failed to decrypt PAT for sandbox {short_log_id(sandbox_id)}"
                 ) from e
 
-        logger.info(
-            "onyx_pat_resolver.resolved sandbox_id=%s host=%s", sandbox_id, request.host
+        logger.debug(
+            "onyx_pat_resolver.resolved sandbox=%s host=%s",
+            short_log_id(sandbox_id),
+            request.host,
         )
         bearer = f"{BEARER_PREFIX}{raw_token}"
         return {API_KEY_HEADER_NAME: bearer, API_KEY_HEADER_ALTERNATIVE_NAME: bearer}

--- a/backend/onyx/sandbox_proxy/server.py
+++ b/backend/onyx/sandbox_proxy/server.py
@@ -266,7 +266,7 @@ def main() -> int:
         # DumpMaster binds to the running event loop in its constructor.
         async def _async_main() -> None:
             options = _build_mitm_options()
-            master = DumpMaster(options=options, with_termlog=True, with_dumper=False)
+            master = DumpMaster(options=options, with_termlog=False, with_dumper=False)
             master.addons.add(gate)
             _install_signal_handlers(
                 asyncio.get_running_loop(),

--- a/backend/tests/unit/sandbox_proxy/test_credential_injection.py
+++ b/backend/tests/unit/sandbox_proxy/test_credential_injection.py
@@ -16,20 +16,22 @@ from onyx.sandbox_proxy.credential_injection import CredentialUnavailableError
 from onyx.sandbox_proxy.credential_injection import InjectionContext
 from onyx.sandbox_proxy.credential_injection import InjectionOutcome
 from onyx.sandbox_proxy.errors import SandboxProxyError
-from tests.unit.sandbox_proxy.conftest import make_flow as _flow
+from tests.unit.sandbox_proxy.conftest import make_flow
 from tests.unit.sandbox_proxy.conftest import make_matched_actions
-from tests.unit.sandbox_proxy.conftest import make_resolved_sandbox as _sandbox
+from tests.unit.sandbox_proxy.conftest import make_resolved_sandbox
 from tests.unit.sandbox_proxy.conftest import RecordingCredentialResolver
 
 
 def _ctx(*, matched_actions: AllMatchedActions | None = None) -> InjectionContext:
-    return InjectionContext(sandbox=_sandbox(), matched_actions=matched_actions)
+    return InjectionContext(
+        sandbox=make_resolved_sandbox(), matched_actions=matched_actions
+    )
 
 
 def test_no_resolver_claims_returns_pass_through() -> None:
     a = RecordingCredentialResolver(claims_result=False)
     b = RecordingCredentialResolver(claims_result=False)
-    flow = _flow()
+    flow = make_flow()
     flow.request.headers["X-Existing"] = "preserve"
 
     outcome = CredentialInjectionDispatcher([a, b]).apply(flow, _ctx())
@@ -48,7 +50,7 @@ def test_first_claim_wins() -> None:
     second = RecordingCredentialResolver(
         claims_result=True, headers={"Authorization": "from-second"}
     )
-    flow = _flow()
+    flow = make_flow()
 
     CredentialInjectionDispatcher([first, second]).apply(flow, _ctx())
 
@@ -63,7 +65,7 @@ def test_injected_headers_overwrite_existing() -> None:
     resolver = RecordingCredentialResolver(
         claims_result=True, headers={"Authorization": "Bearer real"}
     )
-    flow = _flow()
+    flow = make_flow()
     flow.request.headers["Authorization"] = "placeholder"
 
     CredentialInjectionDispatcher([resolver]).apply(flow, _ctx())
@@ -71,20 +73,20 @@ def test_injected_headers_overwrite_existing() -> None:
     assert flow.request.headers["Authorization"] == "Bearer real"
 
 
-def test_resolver_claiming_but_returning_no_headers_is_injected() -> None:
-    """Claim is the contract — empty header set is INJECTED, not PASS_THROUGH."""
+def test_resolver_claiming_but_returning_no_headers_is_claimed() -> None:
+    """A resolver can claim a request without writing any headers."""
     resolver = RecordingCredentialResolver(claims_result=True, headers={})
 
-    outcome = CredentialInjectionDispatcher([resolver]).apply(_flow(), _ctx())
+    outcome = CredentialInjectionDispatcher([resolver]).apply(make_flow(), _ctx())
 
-    assert outcome is InjectionOutcome.INJECTED
+    assert outcome is InjectionOutcome.CLAIMED
 
 
 def test_credential_unavailable_returns_blocked() -> None:
     resolver = RecordingCredentialResolver(
         claims_result=True, exc=CredentialUnavailableError("no PAT for sandbox")
     )
-    flow = _flow()
+    flow = make_flow()
 
     outcome = CredentialInjectionDispatcher([resolver]).apply(flow, _ctx())
 
@@ -98,7 +100,7 @@ def test_unexpected_exception_returns_blocked() -> None:
         claims_result=True, exc=RuntimeError("db down mid-resolve")
     )
 
-    outcome = CredentialInjectionDispatcher([resolver]).apply(_flow(), _ctx())
+    outcome = CredentialInjectionDispatcher([resolver]).apply(make_flow(), _ctx())
 
     assert outcome is InjectionOutcome.BLOCKED
 
@@ -108,7 +110,7 @@ def test_claims_exception_falls_through_to_next_resolver() -> None:
     bad = MagicMock(spec=CredentialResolver)
     bad.claims.side_effect = RuntimeError("claims is buggy")
     good = RecordingCredentialResolver(claims_result=True, headers={"X-Hdr": "val"})
-    flow = _flow()
+    flow = make_flow()
 
     outcome = CredentialInjectionDispatcher([bad, good]).apply(flow, _ctx())
 
@@ -123,7 +125,7 @@ def test_all_claims_raise_returns_pass_through() -> None:
     b = MagicMock(spec=CredentialResolver)
     b.claims.side_effect = RuntimeError("b")
 
-    outcome = CredentialInjectionDispatcher([a, b]).apply(_flow(), _ctx())
+    outcome = CredentialInjectionDispatcher([a, b]).apply(make_flow(), _ctx())
 
     assert outcome is InjectionOutcome.PASS_THROUGH
 
@@ -133,7 +135,7 @@ def test_apply_or_block_writes_403_on_blocked() -> None:
     resolver = RecordingCredentialResolver(
         claims_result=True, exc=CredentialUnavailableError("no creds")
     )
-    flow = _flow()
+    flow = make_flow()
 
     CredentialInjectionDispatcher([resolver]).apply_or_block(flow, _ctx())
 
@@ -146,28 +148,32 @@ def test_apply_or_block_writes_403_on_blocked() -> None:
     assert body["message"]
 
 
-def test_apply_or_block_leaves_response_unset_on_inject_or_pass_through() -> None:
-    """INJECTED and PASS_THROUGH both leave `flow.response` untouched so the
-    request forwards through mitmproxy."""
+def test_apply_or_block_leaves_response_unset_on_forwarding_outcomes() -> None:
+    """Forwarding outcomes leave `flow.response` untouched."""
     claiming = RecordingCredentialResolver(claims_result=True, headers={"X": "y"})
+    claiming_empty = RecordingCredentialResolver(claims_result=True, headers={})
     not_claiming = RecordingCredentialResolver(claims_result=False)
 
-    flow_a = _flow()
+    flow_a = make_flow()
     CredentialInjectionDispatcher([claiming]).apply_or_block(flow_a, _ctx())
     assert flow_a.response is None
 
-    flow_b = _flow()
-    CredentialInjectionDispatcher([not_claiming]).apply_or_block(flow_b, _ctx())
+    flow_b = make_flow()
+    CredentialInjectionDispatcher([claiming_empty]).apply_or_block(flow_b, _ctx())
     assert flow_b.response is None
+
+    flow_c = make_flow()
+    CredentialInjectionDispatcher([not_claiming]).apply_or_block(flow_c, _ctx())
+    assert flow_c.response is None
 
 
 def test_resolver_receives_request_and_full_context() -> None:
     """Sanity: `claims` and `resolve` both see the same request + ctx the
     dispatcher was handed, unchanged."""
-    sandbox = _sandbox(tenant_id="tenant-xyz")
+    sandbox = make_resolved_sandbox(tenant_id="tenant-xyz")
     matched_actions = make_matched_actions()
     resolver = RecordingCredentialResolver(claims_result=True)
-    flow = _flow(host="api.anthropic.com")
+    flow = make_flow(host="api.anthropic.com")
     ctx = InjectionContext(sandbox=sandbox, matched_actions=matched_actions)
 
     CredentialInjectionDispatcher([resolver]).apply(flow, ctx)

--- a/backend/tests/unit/sandbox_proxy/test_credential_injection.py
+++ b/backend/tests/unit/sandbox_proxy/test_credential_injection.py
@@ -6,7 +6,6 @@ The dispatcher is the single seam between the gate and any concrete
 
 from __future__ import annotations
 
-import json
 from unittest.mock import MagicMock
 
 from onyx.external_apps.matching.engine import AllMatchedActions
@@ -15,7 +14,6 @@ from onyx.sandbox_proxy.credential_injection import CredentialResolver
 from onyx.sandbox_proxy.credential_injection import CredentialUnavailableError
 from onyx.sandbox_proxy.credential_injection import InjectionContext
 from onyx.sandbox_proxy.credential_injection import InjectionOutcome
-from onyx.sandbox_proxy.errors import SandboxProxyError
 from tests.unit.sandbox_proxy.conftest import make_flow
 from tests.unit.sandbox_proxy.conftest import make_matched_actions
 from tests.unit.sandbox_proxy.conftest import make_resolved_sandbox
@@ -128,43 +126,6 @@ def test_all_claims_raise_returns_pass_through() -> None:
     outcome = CredentialInjectionDispatcher([a, b]).apply(make_flow(), _ctx())
 
     assert outcome is InjectionOutcome.PASS_THROUGH
-
-
-def test_apply_or_block_writes_403_on_blocked() -> None:
-    """The high-level seam: BLOCKED → sandbox-visible 403 with the documented body."""
-    resolver = RecordingCredentialResolver(
-        claims_result=True, exc=CredentialUnavailableError("no creds")
-    )
-    flow = make_flow()
-
-    CredentialInjectionDispatcher([resolver]).apply_or_block(flow, _ctx())
-
-    assert flow.response is not None
-    assert flow.response.status_code == 403
-    content = flow.response.content
-    assert content is not None
-    body = json.loads(content)
-    assert body["error"] == SandboxProxyError.CREDENTIAL_ERROR.value
-    assert body["message"]
-
-
-def test_apply_or_block_leaves_response_unset_on_forwarding_outcomes() -> None:
-    """Forwarding outcomes leave `flow.response` untouched."""
-    claiming = RecordingCredentialResolver(claims_result=True, headers={"X": "y"})
-    claiming_empty = RecordingCredentialResolver(claims_result=True, headers={})
-    not_claiming = RecordingCredentialResolver(claims_result=False)
-
-    flow_a = make_flow()
-    CredentialInjectionDispatcher([claiming]).apply_or_block(flow_a, _ctx())
-    assert flow_a.response is None
-
-    flow_b = make_flow()
-    CredentialInjectionDispatcher([claiming_empty]).apply_or_block(flow_b, _ctx())
-    assert flow_b.response is None
-
-    flow_c = make_flow()
-    CredentialInjectionDispatcher([not_claiming]).apply_or_block(flow_c, _ctx())
-    assert flow_c.response is None
 
 
 def test_resolver_receives_request_and_full_context() -> None:

--- a/backend/tests/unit/sandbox_proxy/test_external_app_resolver.py
+++ b/backend/tests/unit/sandbox_proxy/test_external_app_resolver.py
@@ -18,11 +18,11 @@ import pytest
 from onyx.external_apps.matching.engine import AllMatchedActions
 from onyx.sandbox_proxy.credential_injection import CredentialUnavailableError
 from onyx.sandbox_proxy.credential_injection import InjectionContext
-from onyx.sandbox_proxy.resolvers import external_app as external_app_mod
+from onyx.sandbox_proxy.resolvers import external_app
 from onyx.sandbox_proxy.resolvers.external_app import ExternalAppResolver
-from tests.unit.sandbox_proxy.conftest import make_flow as _flow
+from tests.unit.sandbox_proxy.conftest import make_flow
 from tests.unit.sandbox_proxy.conftest import make_matched_actions
-from tests.unit.sandbox_proxy.conftest import make_resolved_sandbox as _sandbox
+from tests.unit.sandbox_proxy.conftest import make_resolved_sandbox
 
 
 @pytest.fixture(autouse=True)
@@ -31,7 +31,7 @@ def _noop_token_refresh(monkeypatch: pytest.MonkeyPatch) -> None:
     claim rule and rendering contract; the refresh-seam test re-patches it.
     The refresh mechanics live in `tests/unit/external_apps/test_token_refresh.py`."""
     monkeypatch.setattr(
-        external_app_mod, "ensure_fresh_credentials", lambda *_a, **_k: None
+        external_app, "ensure_fresh_credentials", lambda *_a, **_k: None
     )
 
 
@@ -46,14 +46,15 @@ def _recorder_db_factory(ops: list[str]) -> Any:
 
 def _ctx(*, matched_actions: AllMatchedActions | None = None) -> InjectionContext:
     return InjectionContext(
-        sandbox=_sandbox(tenant_id="tenant-7"), matched_actions=matched_actions
+        sandbox=make_resolved_sandbox(tenant_id="tenant-7"),
+        matched_actions=matched_actions,
     )
 
 
 def test_claims_true_iff_match_present() -> None:
     """Host is irrelevant — the matcher has already attributed the request."""
     resolver = ExternalAppResolver()
-    req = _flow(host="api.slack.com").request
+    req = make_flow(host="api.slack.com").request
     assert resolver.claims(req, _ctx(matched_actions=make_matched_actions())) is True
     assert resolver.claims(req, _ctx(matched_actions=None)) is False
 
@@ -71,16 +72,16 @@ def test_resolve_forwards_external_app_id_user_id_and_tenant(
         captured["user_id"] = user_id
         return {"Authorization": "Bearer real"}
 
-    monkeypatch.setattr(external_app_mod, "resolve_injection_headers", _fake)
+    monkeypatch.setattr(external_app, "resolve_injection_headers", _fake)
     ops: list[str] = []
     monkeypatch.setattr(
-        external_app_mod, "get_session_with_tenant", _recorder_db_factory(ops)
+        external_app, "get_session_with_tenant", _recorder_db_factory(ops)
     )
 
     matched_actions = make_matched_actions(external_app_id=99)
     ctx = _ctx(matched_actions=matched_actions)
 
-    headers = ExternalAppResolver().resolve(_flow().request, ctx)
+    headers = ExternalAppResolver().resolve(make_flow().request, ctx)
 
     assert headers == {"Authorization": "Bearer real"}
     assert captured["external_app_id"] == 99
@@ -100,20 +101,20 @@ def test_resolve_refreshes_token_before_rendering(
     def _ensure(tenant_id: str, app_id: int, user_id: Any) -> None:
         calls.append((tenant_id, app_id, user_id))
 
-    monkeypatch.setattr(external_app_mod, "ensure_fresh_credentials", _ensure)
+    monkeypatch.setattr(external_app, "ensure_fresh_credentials", _ensure)
     monkeypatch.setattr(
-        external_app_mod,
+        external_app,
         "resolve_injection_headers",
         lambda *_a, **_k: {"Authorization": "Bearer real"},
     )
     monkeypatch.setattr(
-        external_app_mod, "get_session_with_tenant", _recorder_db_factory([])
+        external_app, "get_session_with_tenant", _recorder_db_factory([])
     )
 
     matched_actions = make_matched_actions(external_app_id=99)
     ctx = _ctx(matched_actions=matched_actions)
 
-    headers = ExternalAppResolver().resolve(_flow().request, ctx)
+    headers = ExternalAppResolver().resolve(make_flow().request, ctx)
 
     assert headers == {"Authorization": "Bearer real"}
     assert calls == [("tenant-7", 99, ctx.sandbox.user_id)]
@@ -124,4 +125,4 @@ def test_resolve_raises_when_match_is_none() -> None:
     a Protocol bug must surface as a 403, not a NoneType crash inside SQL code."""
     resolver = ExternalAppResolver()
     with pytest.raises(CredentialUnavailableError):
-        resolver.resolve(_flow().request, _ctx(matched_actions=None))
+        resolver.resolve(make_flow().request, _ctx(matched_actions=None))

--- a/backend/tests/unit/sandbox_proxy/test_gate.py
+++ b/backend/tests/unit/sandbox_proxy/test_gate.py
@@ -213,7 +213,22 @@ async def test_resolve_and_match_sandbox_resolution_fails_closed(
 
 
 # Spec value hardcoded so this test exercises the documented 1 MiB cap.
+_MAX_BODY = b"\x00" * 1_048_576
 _OVERSIZE_BODY = b"\x00" * 1_048_577
+
+
+@pytest.mark.asyncio
+async def test_resolve_and_match_body_at_cap_is_allowed() -> None:
+    resolver = StubResolver(sandbox=make_resolved_sandbox())
+    matcher = _StubMatcher(result=None)
+    addon = _build(resolver=resolver, matcher=matcher)
+    flow = make_flow(raw_content=_MAX_BODY)
+
+    result = await addon._resolve_and_match(flow)
+
+    assert result is None
+    assert flow.response is None
+    assert matcher.calls == 1
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/unit/sandbox_proxy/test_gate.py
+++ b/backend/tests/unit/sandbox_proxy/test_gate.py
@@ -303,9 +303,9 @@ async def test_resolve_and_match_off_catalog_pass_through_is_not_logged(
 
     assert result is None
     assert flow.response is None
-    messages = "\n".join(record.getMessage() for record in caplog.records)
-    assert "proxy.egress_" not in messages
-    assert "proxy.session_tag_resolved" not in messages
+    messages = [record.getMessage() for record in caplog.records]
+    assert not any(message.startswith("egress_") for message in messages)
+    assert not any(message.startswith("session_tag_resolved") for message in messages)
     assert resolver.resolve_session_by_id_calls == []
 
 

--- a/backend/tests/unit/sandbox_proxy/test_gate.py
+++ b/backend/tests/unit/sandbox_proxy/test_gate.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+import logging
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -32,23 +33,23 @@ from onyx.db.enums import ApprovalDecision
 from onyx.db.enums import EndpointPolicy
 from onyx.external_apps.matching.engine import AllMatchedActions
 from onyx.external_apps.matching.engine import MatchedAction
-from onyx.sandbox_proxy.addons import gate as gate_mod
+from onyx.sandbox_proxy.addons import gate
 from onyx.sandbox_proxy.addons.gate import GateAddon
 from onyx.sandbox_proxy.addons.gate import ParkedApprovals
-from onyx.sandbox_proxy.addons.gate import PARSER_MAX_BODY_BYTES
 from onyx.sandbox_proxy.credential_injection import CredentialInjectionDispatcher
 from onyx.sandbox_proxy.credential_injection import CredentialResolver
 from onyx.sandbox_proxy.credential_injection import CredentialUnavailableError
+from onyx.sandbox_proxy.credential_injection import InjectionOutcome
 from onyx.sandbox_proxy.errors import SandboxProxyError
 from onyx.sandbox_proxy.identity import ResolvedSandbox
 from onyx.sandbox_proxy.identity import SessionContext
 from onyx.sandbox_proxy.request_evaluator import RequestEvaluator
 from onyx.sandbox_proxy.snapshot_egress import SnapshotEgressPolicy
-from tests.unit.sandbox_proxy.conftest import make_flow as _flow
+from tests.unit.sandbox_proxy.conftest import make_flow
 from tests.unit.sandbox_proxy.conftest import make_matched_actions
-from tests.unit.sandbox_proxy.conftest import make_resolved_sandbox as _sandbox
+from tests.unit.sandbox_proxy.conftest import make_resolved_sandbox
 from tests.unit.sandbox_proxy.conftest import RecordingCredentialResolver
-from tests.unit.sandbox_proxy.conftest import StubResolver as _StubResolver
+from tests.unit.sandbox_proxy.conftest import StubResolver
 
 # ---------------------------------------------------------------------------
 # Stubs
@@ -100,12 +101,12 @@ def _ctx(
 
 @pytest.fixture(autouse=True)
 def _patch_gate_session(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The gate opens tenant sessions via `gate_mod.get_session_with_tenant`.
+    """The gate opens tenant sessions via `gate.get_session_with_tenant`.
     Default it to a dummy MagicMock-yielding session; tests asserting on
     session-open ordering re-patch it with `_recorder_db_factory(ops)`."""
-    monkeypatch.setattr(gate_mod, "get_session_with_tenant", _recorder_db_factory([]))
+    monkeypatch.setattr(gate, "get_session_with_tenant", _recorder_db_factory([]))
     monkeypatch.setattr(
-        gate_mod.action_approval,
+        gate.action_approval,
         "list_session_grant_action_approvals",
         lambda _db, *, session_id, external_app_id: [],  # noqa: ARG005
     )
@@ -113,7 +114,7 @@ def _patch_gate_session(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def _build(
     *,
-    resolver: _StubResolver,
+    resolver: StubResolver,
     matcher: _StubMatcher,
     cache_factory: Any = _noop_cache_factory,
     credential_resolvers: list[CredentialResolver] | None = None,
@@ -172,10 +173,10 @@ _MATCH_DENY = make_matched_actions(payload={"text": "hi"}, policy=EndpointPolicy
 
 @pytest.mark.asyncio
 async def test_resolve_and_match_no_source_ip_fails_closed() -> None:
-    resolver = _StubResolver()
+    resolver = StubResolver()
     matcher = _StubMatcher(result=_MATCH)
     addon = _build(resolver=resolver, matcher=matcher)
-    flow = _flow(peername=None)
+    flow = make_flow(peername=None)
 
     result = await addon._resolve_and_match(flow)
 
@@ -199,10 +200,10 @@ async def test_resolve_and_match_sandbox_resolution_fails_closed(
     resolver_kwargs: dict[str, Any],
 ) -> None:
     """Absent pod and DB blip during resolution both fail closed."""
-    resolver = _StubResolver(**resolver_kwargs)
+    resolver = StubResolver(**resolver_kwargs)
     matcher = _StubMatcher(result=_MATCH)
     addon = _build(resolver=resolver, matcher=matcher)
-    flow = _flow()
+    flow = make_flow()
 
     result = await addon._resolve_and_match(flow)
 
@@ -211,8 +212,7 @@ async def test_resolve_and_match_sandbox_resolution_fails_closed(
     assert matcher.calls == 0
 
 
-# Spec value hardcoded, not derived from the constant under test (which
-# is pinned separately by test_parser_max_body_bytes_constant_matches_spec).
+# Spec value hardcoded so this test exercises the documented 1 MiB cap.
 _OVERSIZE_BODY = b"\x00" * 1_048_577
 
 
@@ -226,10 +226,10 @@ async def test_resolve_and_match_body_too_large_fails_closed(
     raw_content: bytes | None,
 ) -> None:
     """Streamed (None) and oversize bodies both fail closed."""
-    resolver = _StubResolver(sandbox=_sandbox())
+    resolver = StubResolver(sandbox=make_resolved_sandbox())
     matcher = _StubMatcher(result=_MATCH)
     addon = _build(resolver=resolver, matcher=matcher)
-    flow = _flow(raw_content=raw_content)
+    flow = make_flow(raw_content=raw_content)
 
     result = await addon._resolve_and_match(flow)
 
@@ -238,19 +238,14 @@ async def test_resolve_and_match_body_too_large_fails_closed(
     assert matcher.calls == 0
 
 
-def test_parser_max_body_bytes_constant_matches_spec() -> None:
-    """Pin the parser body cap to the documented 1 MiB."""
-    assert PARSER_MAX_BODY_BYTES == 1_048_576
-
-
 @pytest.mark.asyncio
 async def test_resolve_and_match_no_tag_fails_closed() -> None:
     """Identified pod, no session tag: fail closed with no fallback, so
     the session lookup is never attempted."""
-    resolver = _StubResolver(sandbox=_sandbox())
+    resolver = StubResolver(sandbox=make_resolved_sandbox())
     matcher = _StubMatcher(result=_MATCH)
     addon = _build(resolver=resolver, matcher=matcher)
-    flow = _flow()  # no proxy_auth
+    flow = make_flow()  # no proxy_auth
 
     result = await addon._resolve_and_match(flow)
 
@@ -269,12 +264,12 @@ async def test_resolve_and_match_matcher_returns_none_fails_open() -> None:
     """Non-gated traffic: matcher returns None → forwarded; the off-catalog
     dispatcher invocation runs with `matched_actions=None` so host-only resolvers can
     still claim by host."""
-    sandbox = _sandbox()
-    resolver = _StubResolver(sandbox=sandbox)
+    sandbox = make_resolved_sandbox()
+    resolver = StubResolver(sandbox=sandbox)
     matcher = _StubMatcher(result=None)
     spy = RecordingCredentialResolver(claims_result=False)
     addon = _build(resolver=resolver, matcher=matcher, credential_resolvers=[spy])
-    flow = _flow()
+    flow = make_flow()
 
     result = await addon._resolve_and_match(flow)
 
@@ -289,15 +284,41 @@ async def test_resolve_and_match_matcher_returns_none_fails_open() -> None:
 
 
 @pytest.mark.asyncio
+async def test_resolve_and_match_off_catalog_pass_through_is_not_logged(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """High-volume package-manager traffic should forward without producing a
+    proxy event line or extracting the session tag."""
+    resolver = StubResolver(sandbox=make_resolved_sandbox())
+    matcher = _StubMatcher(result=None)
+    addon = _build(
+        resolver=resolver,
+        matcher=matcher,
+        credential_resolvers=[RecordingCredentialResolver(claims_result=False)],
+    )
+    flow = make_flow(host="registry.npmjs.org", proxy_auth=_basic_auth(_TAG_UUID))
+
+    with caplog.at_level(logging.DEBUG, logger="onyx.utils.logger"):
+        result = await addon._resolve_and_match(flow)
+
+    assert result is None
+    assert flow.response is None
+    messages = "\n".join(record.getMessage() for record in caplog.records)
+    assert "proxy.egress_" not in messages
+    assert "proxy.session_tag_resolved" not in messages
+    assert resolver.resolve_session_by_id_calls == []
+
+
+@pytest.mark.asyncio
 async def test_resolve_and_match_matcher_raises_falls_through_as_off_catalog() -> None:
     """Matcher exception falls through to off-catalog dispatch — otherwise
     the request would forward with placeholder credentials, surfacing as a
     fingerprintable upstream 401 once host-only resolvers exist."""
-    resolver = _StubResolver(sandbox=_sandbox())
+    resolver = StubResolver(sandbox=make_resolved_sandbox())
     matcher = _StubMatcher(exc=RuntimeError("matcher boom"))
     spy = RecordingCredentialResolver(claims_result=False)
     addon = _build(resolver=resolver, matcher=matcher, credential_resolvers=[spy])
-    flow = _flow()
+    flow = make_flow()
 
     result = await addon._resolve_and_match(flow)
 
@@ -319,7 +340,9 @@ async def test_resolve_and_match_always_forwards_without_session() -> None:
     """ALWAYS auto-approves: forward (with credentials injected), no approval
     row, and (since it's not gated) no session lookup — even when a tag is
     present."""
-    resolver = _StubResolver(sandbox=_sandbox(), session_by_id=UUID(_TAG_UUID))
+    resolver = StubResolver(
+        sandbox=make_resolved_sandbox(), session_by_id=UUID(_TAG_UUID)
+    )
     addon = _build(
         resolver=resolver,
         matcher=_StubMatcher(result=_MATCH_ALWAYS),
@@ -327,7 +350,7 @@ async def test_resolve_and_match_always_forwards_without_session() -> None:
         # flow forwarded with no response.
         credential_resolvers=[RecordingCredentialResolver(claims_result=False)],
     )
-    flow = _flow(proxy_auth=_basic_auth(_TAG_UUID))
+    flow = make_flow(proxy_auth=_basic_auth(_TAG_UUID))
 
     result = await addon._resolve_and_match(flow)
 
@@ -339,9 +362,11 @@ async def test_resolve_and_match_always_forwards_without_session() -> None:
 @pytest.mark.asyncio
 async def test_resolve_and_match_deny_blocks_with_403() -> None:
     """DENY blocks outright with a policy_denied 403, no session needed."""
-    resolver = _StubResolver(sandbox=_sandbox(), session_by_id=UUID(_TAG_UUID))
+    resolver = StubResolver(
+        sandbox=make_resolved_sandbox(), session_by_id=UUID(_TAG_UUID)
+    )
     addon = _build(resolver=resolver, matcher=_StubMatcher(result=_MATCH_DENY))
-    flow = _flow(proxy_auth=_basic_auth(_TAG_UUID))
+    flow = make_flow(proxy_auth=_basic_auth(_TAG_UUID))
 
     result = await addon._resolve_and_match(flow)
 
@@ -409,8 +434,9 @@ def _spy_pipeline(
         *,
         sandbox: ResolvedSandbox,
         matched_actions: AllMatchedActions | None,
-    ) -> None:
+    ) -> InjectionOutcome:
         spy.dispatched.append((matched_actions, sandbox.user_id, sandbox.tenant_id))
+        return InjectionOutcome.INJECTED
 
     monkeypatch.setattr(addon, "_persist_approval_row", _persist)
     monkeypatch.setattr(addon, "_await_decision", _await)
@@ -421,13 +447,13 @@ def _spy_pipeline(
 @pytest.mark.asyncio
 async def test_always_goes_straight_through(monkeypatch: pytest.MonkeyPatch) -> None:
     """ALWAYS: forwarded immediately with credentials, no approval prompt."""
-    sandbox = _sandbox()
+    sandbox = make_resolved_sandbox()
     addon = _build(
-        resolver=_StubResolver(sandbox=sandbox),
+        resolver=StubResolver(sandbox=sandbox),
         matcher=_StubMatcher(result=_MATCH_ALWAYS),
     )
     spy = _spy_pipeline(addon, monkeypatch)
-    flow = _flow()
+    flow = make_flow()
 
     await addon.request(flow)
 
@@ -440,11 +466,11 @@ async def test_always_goes_straight_through(monkeypatch: pytest.MonkeyPatch) -> 
 async def test_deny_blocks(monkeypatch: pytest.MonkeyPatch) -> None:
     """DENY: blocked with a 403, no approval prompt, NO dispatch."""
     addon = _build(
-        resolver=_StubResolver(sandbox=_sandbox()),
+        resolver=StubResolver(sandbox=make_resolved_sandbox()),
         matcher=_StubMatcher(result=_MATCH_DENY),
     )
     spy = _spy_pipeline(addon, monkeypatch)
-    flow = _flow()
+    flow = make_flow()
 
     await addon.request(flow)
 
@@ -459,11 +485,11 @@ async def test_ask_approved_forwards_after_approval(
 ) -> None:
     """ASK: runs the approval pipeline; on APPROVED forwards + dispatches."""
     user_id = uuid4()
-    sandbox = _sandbox(user_id=user_id)
-    resolver = _StubResolver(sandbox=sandbox, session_by_id=UUID(_TAG_UUID))
+    sandbox = make_resolved_sandbox(user_id=user_id)
+    resolver = StubResolver(sandbox=sandbox, session_by_id=UUID(_TAG_UUID))
     addon = _build(resolver=resolver, matcher=_StubMatcher(result=_MATCH))
     spy = _spy_pipeline(addon, monkeypatch, decision=ApprovalDecision.APPROVED)
-    flow = _flow(proxy_auth=_basic_auth(_TAG_UUID))
+    flow = make_flow(proxy_auth=_basic_auth(_TAG_UUID))
 
     await addon.request(flow)
 
@@ -487,10 +513,12 @@ async def test_ask_denied_blocks(
     expected_code: SandboxProxyError,
 ) -> None:
     """ASK: runs the approval pipeline; on REJECTED/EXPIRED blocks, no dispatch."""
-    resolver = _StubResolver(sandbox=_sandbox(), session_by_id=UUID(_TAG_UUID))
+    resolver = StubResolver(
+        sandbox=make_resolved_sandbox(), session_by_id=UUID(_TAG_UUID)
+    )
     addon = _build(resolver=resolver, matcher=_StubMatcher(result=_MATCH))
     spy = _spy_pipeline(addon, monkeypatch, decision=decision)
-    flow = _flow(proxy_auth=_basic_auth(_TAG_UUID))
+    flow = make_flow(proxy_auth=_basic_auth(_TAG_UUID))
 
     await addon.request(flow)
 
@@ -526,7 +554,7 @@ def _stub_grants(
             raise result
         return result
 
-    monkeypatch.setattr(gate_mod, "get_live_scheduled_run_grants", _lookup)
+    monkeypatch.setattr(gate, "get_live_scheduled_run_grants", _lookup)
     return calls
 
 
@@ -540,9 +568,7 @@ def _spy_pre_approve_insert(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, A
         row.approval_id = uuid4()
         return row
 
-    monkeypatch.setattr(
-        gate_mod.action_approval, "insert_action_approval", _fake_insert
-    )
+    monkeypatch.setattr(gate.action_approval, "insert_action_approval", _fake_insert)
     return inserted
 
 
@@ -591,17 +617,15 @@ async def test_pre_approved_scheduled_run_skips_park(
     """Granted app on a RUNNING scheduled run: forwarded immediately with a
     pre-decided APPROVED row — the park pipeline never runs."""
     user_id = uuid4()
-    sandbox = _sandbox(user_id=user_id)
-    resolver = _StubResolver(sandbox=sandbox, session_by_id=UUID(_TAG_UUID))
+    sandbox = make_resolved_sandbox(user_id=user_id)
+    resolver = StubResolver(sandbox=sandbox, session_by_id=UUID(_TAG_UUID))
     addon = _build(resolver=resolver, matcher=_StubMatcher(result=_MATCH))
     spy = _spy_pipeline(addon, monkeypatch)
     _stub_grants(monkeypatch, (_RUN_ID, [_GRANTED_APP_ID]))
     inserted = _spy_pre_approve_insert(monkeypatch)
     notified: list[dict[str, Any]] = []
-    monkeypatch.setattr(
-        gate_mod, "create_notification", lambda **kw: notified.append(kw)
-    )
-    flow = _flow(proxy_auth=_basic_auth(_TAG_UUID))
+    monkeypatch.setattr(gate, "create_notification", lambda **kw: notified.append(kw))
+    flow = make_flow(proxy_auth=_basic_auth(_TAG_UUID))
 
     await addon.request(flow)
 
@@ -626,9 +650,9 @@ async def test_session_grant_skips_park_without_notification(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     user_id = uuid4()
-    sandbox = _sandbox(user_id=user_id)
+    sandbox = make_resolved_sandbox(user_id=user_id)
     cache = _SessionGrantCache(granted=True)
-    resolver = _StubResolver(sandbox=sandbox, session_by_id=UUID(_TAG_UUID))
+    resolver = StubResolver(sandbox=sandbox, session_by_id=UUID(_TAG_UUID))
     addon = _build(
         resolver=resolver,
         matcher=_StubMatcher(result=_MATCH),
@@ -638,10 +662,8 @@ async def test_session_grant_skips_park_without_notification(
     _stub_grants(monkeypatch, None)
     inserted = _spy_pre_approve_insert(monkeypatch)
     notified: list[dict[str, Any]] = []
-    monkeypatch.setattr(
-        gate_mod, "create_notification", lambda **kw: notified.append(kw)
-    )
-    flow = _flow(proxy_auth=_basic_auth(_TAG_UUID))
+    monkeypatch.setattr(gate, "create_notification", lambda **kw: notified.append(kw))
+    flow = make_flow(proxy_auth=_basic_auth(_TAG_UUID))
 
     await addon.request(flow)
 
@@ -662,9 +684,9 @@ async def test_session_grant_db_fallback_hydrates_cache(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     user_id = uuid4()
-    sandbox = _sandbox(user_id=user_id)
+    sandbox = make_resolved_sandbox(user_id=user_id)
     cache = _SessionGrantCache(granted=False)
-    resolver = _StubResolver(sandbox=sandbox, session_by_id=UUID(_TAG_UUID))
+    resolver = StubResolver(sandbox=sandbox, session_by_id=UUID(_TAG_UUID))
     addon = _build(
         resolver=resolver,
         matcher=_StubMatcher(result=_MATCH),
@@ -679,11 +701,11 @@ async def test_session_grant_db_fallback_hydrates_cache(
     grant_source.actions = [action.model_dump(mode="json") for action in _MATCH.actions]
 
     monkeypatch.setattr(
-        gate_mod.action_approval,
+        gate.action_approval,
         "list_session_grant_action_approvals",
         lambda _db, *, session_id, external_app_id: [grant_source],  # noqa: ARG005
     )
-    flow = _flow(proxy_auth=_basic_auth(_TAG_UUID))
+    flow = make_flow(proxy_auth=_basic_auth(_TAG_UUID))
 
     await addon.request(flow)
 
@@ -703,7 +725,9 @@ async def test_partial_session_grant_still_parks_multi_action_request(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     cache = _SessionGrantCache(granted_action_types={"slack.messages.write"})
-    resolver = _StubResolver(sandbox=_sandbox(), session_by_id=UUID(_TAG_UUID))
+    resolver = StubResolver(
+        sandbox=make_resolved_sandbox(), session_by_id=UUID(_TAG_UUID)
+    )
     addon = _build(
         resolver=resolver,
         matcher=_StubMatcher(result=_MATCH_MULTI_ASK),
@@ -712,7 +736,7 @@ async def test_partial_session_grant_still_parks_multi_action_request(
     spy = _spy_pipeline(addon, monkeypatch, decision=ApprovalDecision.REJECTED)
     _stub_grants(monkeypatch, None)
     inserted = _spy_pre_approve_insert(monkeypatch)
-    flow = _flow(proxy_auth=_basic_auth(_TAG_UUID))
+    flow = make_flow(proxy_auth=_basic_auth(_TAG_UUID))
 
     await addon.request(flow)
 
@@ -729,9 +753,9 @@ async def test_session_grant_recheck_after_persist_skips_park(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     user_id = uuid4()
-    sandbox = _sandbox(user_id=user_id)
+    sandbox = make_resolved_sandbox(user_id=user_id)
     cache = _SessionGrantCache(granted=[False, True])
-    resolver = _StubResolver(sandbox=sandbox, session_by_id=UUID(_TAG_UUID))
+    resolver = StubResolver(sandbox=sandbox, session_by_id=UUID(_TAG_UUID))
     addon = _build(
         resolver=resolver,
         matcher=_StubMatcher(result=_MATCH),
@@ -752,10 +776,8 @@ async def test_session_grant_recheck_after_persist_skips_park(
         decisions.append(kwargs)
         return object()
 
-    monkeypatch.setattr(
-        gate_mod.action_approval, "try_record_decision", _record_decision
-    )
-    flow = _flow(proxy_auth=_basic_auth(_TAG_UUID))
+    monkeypatch.setattr(gate.action_approval, "try_record_decision", _record_decision)
+    flow = make_flow(proxy_auth=_basic_auth(_TAG_UUID))
 
     await addon.request(flow)
 
@@ -779,20 +801,20 @@ async def test_grant_lookup_cached_across_requests(
 ) -> None:
     """The per-session grant cache is consulted before Postgres: two gated
     requests on the same session hit the DB lookup only once."""
-    sandbox = _sandbox()
-    resolver = _StubResolver(sandbox=sandbox, session_by_id=UUID(_TAG_UUID))
+    sandbox = make_resolved_sandbox()
+    resolver = StubResolver(sandbox=sandbox, session_by_id=UUID(_TAG_UUID))
     addon = _build(resolver=resolver, matcher=_StubMatcher(result=_MATCH))
     _spy_pipeline(addon, monkeypatch)
     lookup_calls = _stub_grants(monkeypatch, (_RUN_ID, [_GRANTED_APP_ID]))
     _spy_pre_approve_insert(monkeypatch)
     monkeypatch.setattr(
-        gate_mod,
+        gate,
         "create_notification",
         lambda **kw: None,  # noqa: ARG005
     )
 
-    await addon.request(_flow(proxy_auth=_basic_auth(_TAG_UUID)))
-    await addon.request(_flow(proxy_auth=_basic_auth(_TAG_UUID)))
+    await addon.request(make_flow(proxy_auth=_basic_auth(_TAG_UUID)))
+    await addon.request(make_flow(proxy_auth=_basic_auth(_TAG_UUID)))
 
     assert lookup_calls == [UUID(_TAG_UUID)]  # second request served from cache
 
@@ -804,7 +826,9 @@ def test_grant_lookup_cache_keyed_on_session_only(
     session re-queried with a fresh db hits cache, a different session misses.
     Guards the key lambda against leaking one session's grants to another."""
     addon = _build(
-        resolver=_StubResolver(sandbox=_sandbox(), session_by_id=UUID(_TAG_UUID)),
+        resolver=StubResolver(
+            sandbox=make_resolved_sandbox(), session_by_id=UUID(_TAG_UUID)
+        ),
         matcher=_StubMatcher(result=_MATCH),
     )
     lookup_calls = _stub_grants(monkeypatch, (_RUN_ID, [_GRANTED_APP_ID]))
@@ -823,13 +847,15 @@ async def test_pre_approval_dispatch_failure_fails_closed(
 ) -> None:
     """Dispatch raising after the APPROVED row is committed blocks (403) — it
     must not let mitmproxy forward the original request."""
-    resolver = _StubResolver(sandbox=_sandbox(), session_by_id=UUID(_TAG_UUID))
+    resolver = StubResolver(
+        sandbox=make_resolved_sandbox(), session_by_id=UUID(_TAG_UUID)
+    )
     addon = _build(resolver=resolver, matcher=_StubMatcher(result=_MATCH))
     _spy_pipeline(addon, monkeypatch)
     _stub_grants(monkeypatch, (_RUN_ID, [_GRANTED_APP_ID]))
     _spy_pre_approve_insert(monkeypatch)
     monkeypatch.setattr(
-        gate_mod,
+        gate,
         "create_notification",
         lambda **kw: None,  # noqa: ARG005
     )
@@ -838,7 +864,7 @@ async def test_pre_approval_dispatch_failure_fails_closed(
         raise RuntimeError("credential refresh failed")
 
     monkeypatch.setattr(addon, "_dispatch_injection_or_block", _boom)
-    flow = _flow(proxy_auth=_basic_auth(_TAG_UUID))
+    flow = make_flow(proxy_auth=_basic_auth(_TAG_UUID))
 
     await addon.request(flow)
 
@@ -861,7 +887,9 @@ async def test_no_pre_approval_falls_through_to_park(
     grants: tuple[UUID, list[int]] | None | Exception,
 ) -> None:
     """Every non-granted shape (including a lookup crash) parks as usual."""
-    resolver = _StubResolver(sandbox=_sandbox(), session_by_id=UUID(_TAG_UUID))
+    resolver = StubResolver(
+        sandbox=make_resolved_sandbox(), session_by_id=UUID(_TAG_UUID)
+    )
     addon = _build(
         resolver=resolver,
         matcher=_StubMatcher(result=_MATCH),
@@ -870,7 +898,7 @@ async def test_no_pre_approval_falls_through_to_park(
     spy = _spy_pipeline(addon, monkeypatch, decision=ApprovalDecision.REJECTED)
     _stub_grants(monkeypatch, grants)
     inserted = _spy_pre_approve_insert(monkeypatch)
-    flow = _flow(proxy_auth=_basic_auth(_TAG_UUID))
+    flow = make_flow(proxy_auth=_basic_auth(_TAG_UUID))
 
     await addon.request(flow)
 
@@ -884,11 +912,13 @@ async def test_deny_wins_over_pre_approval_grant(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Admin DENY blocks before the grant lookup is ever consulted."""
-    resolver = _StubResolver(sandbox=_sandbox(), session_by_id=UUID(_TAG_UUID))
+    resolver = StubResolver(
+        sandbox=make_resolved_sandbox(), session_by_id=UUID(_TAG_UUID)
+    )
     addon = _build(resolver=resolver, matcher=_StubMatcher(result=_MATCH_DENY))
     spy = _spy_pipeline(addon, monkeypatch)
     lookup_calls = _stub_grants(monkeypatch, (_RUN_ID, [_GRANTED_APP_ID]))
-    flow = _flow(proxy_auth=_basic_auth(_TAG_UUID))
+    flow = make_flow(proxy_auth=_basic_auth(_TAG_UUID))
 
     await addon.request(flow)
 
@@ -907,11 +937,11 @@ async def test_deny_wins_over_pre_approval_grant(
 async def test_resolve_and_match_happy_path_promotes_session() -> None:
     user_id = uuid4()
     session_id = UUID(_TAG_UUID)
-    sandbox = _sandbox(user_id=user_id)
-    resolver = _StubResolver(sandbox=sandbox, session_by_id=session_id)
+    sandbox = make_resolved_sandbox(user_id=user_id)
+    resolver = StubResolver(sandbox=sandbox, session_by_id=session_id)
     matcher = _StubMatcher(result=_MATCH)
     addon = _build(resolver=resolver, matcher=matcher)
-    flow = _flow(proxy_auth=_basic_auth(_TAG_UUID))
+    flow = make_flow(proxy_auth=_basic_auth(_TAG_UUID))
 
     result = await addon._resolve_and_match(flow)
 
@@ -955,12 +985,12 @@ _TAG_UUID = "44444444-4444-4444-4444-444444444444"
     ],
 )
 def test_parse_proxy_auth_username(header: str | None, expected: str | None) -> None:
-    assert gate_mod._parse_proxy_auth_username(header) == expected
+    assert gate._parse_proxy_auth_username(header) == expected
 
 
 def test_http_connect_caches_tag_and_client_disconnected_evicts() -> None:
-    addon = _build(resolver=_StubResolver(), matcher=_StubMatcher())
-    flow = _flow(conn_id="conn-xyz", proxy_auth=_basic_auth(_TAG_UUID))
+    addon = _build(resolver=StubResolver(), matcher=_StubMatcher())
+    flow = make_flow(conn_id="conn-xyz", proxy_auth=_basic_auth(_TAG_UUID))
 
     addon.http_connect(flow)
     assert addon._conn_session_tags == {"conn-xyz": _TAG_UUID}
@@ -970,9 +1000,9 @@ def test_http_connect_caches_tag_and_client_disconnected_evicts() -> None:
 
 
 def test_http_connect_ignores_missing_or_garbled_header() -> None:
-    addon = _build(resolver=_StubResolver(), matcher=_StubMatcher())
-    addon.http_connect(_flow(conn_id="c1"))  # no Proxy-Authorization
-    addon.http_connect(_flow(conn_id="c2", proxy_auth="Bearer nope"))
+    addon = _build(resolver=StubResolver(), matcher=_StubMatcher())
+    addon.http_connect(make_flow(conn_id="c1"))  # no Proxy-Authorization
+    addon.http_connect(make_flow(conn_id="c2", proxy_auth="Bearer nope"))
     assert addon._conn_session_tags == {}
 
 
@@ -987,10 +1017,10 @@ async def test_resolve_and_match_exact_tag_on_http_request() -> None:
     tag routes to that exact session."""
     user_id = uuid4()
     tagged_id = UUID(_TAG_UUID)
-    sandbox = _sandbox(user_id=user_id)
-    resolver = _StubResolver(sandbox=sandbox, session_by_id=tagged_id)
+    sandbox = make_resolved_sandbox(user_id=user_id)
+    resolver = StubResolver(sandbox=sandbox, session_by_id=tagged_id)
     addon = _build(resolver=resolver, matcher=_StubMatcher(result=_MATCH))
-    flow = _flow(proxy_auth=_basic_auth(_TAG_UUID))
+    flow = make_flow(proxy_auth=_basic_auth(_TAG_UUID))
 
     result = await addon._resolve_and_match(flow)
 
@@ -1008,14 +1038,14 @@ async def test_resolve_and_match_exact_tag_on_https_connect() -> None:
     and is read back off the connection, not the MITM'd request."""
     user_id = uuid4()
     tagged_id = UUID(_TAG_UUID)
-    sandbox = _sandbox(user_id=user_id)
-    resolver = _StubResolver(sandbox=sandbox, session_by_id=tagged_id)
+    sandbox = make_resolved_sandbox(user_id=user_id)
+    resolver = StubResolver(sandbox=sandbox, session_by_id=tagged_id)
     addon = _build(resolver=resolver, matcher=_StubMatcher(result=_MATCH))
 
-    connect_flow = _flow(conn_id="conn-1", proxy_auth=_basic_auth(_TAG_UUID))
+    connect_flow = make_flow(conn_id="conn-1", proxy_auth=_basic_auth(_TAG_UUID))
     addon.http_connect(connect_flow)
     # Decrypted request has no Proxy-Authorization of its own.
-    request_flow = _flow(conn_id="conn-1")
+    request_flow = make_flow(conn_id="conn-1")
 
     result = await addon._resolve_and_match(request_flow)
 
@@ -1028,10 +1058,10 @@ async def test_resolve_and_match_exact_tag_on_https_connect() -> None:
 async def test_resolve_and_match_unverified_tag_fails_closed() -> None:
     """Tag doesn't resolve to one of this user's sessions (stale /
     foreign / tampered): fail closed, no fallback."""
-    sandbox = _sandbox()
-    resolver = _StubResolver(sandbox=sandbox, session_by_id=None)
+    sandbox = make_resolved_sandbox()
+    resolver = StubResolver(sandbox=sandbox, session_by_id=None)
     addon = _build(resolver=resolver, matcher=_StubMatcher(result=_MATCH))
-    flow = _flow(proxy_auth=_basic_auth(_TAG_UUID))
+    flow = make_flow(proxy_auth=_basic_auth(_TAG_UUID))
 
     result = await addon._resolve_and_match(flow)
 
@@ -1043,9 +1073,9 @@ async def test_resolve_and_match_unverified_tag_fails_closed() -> None:
 @pytest.mark.asyncio
 async def test_resolve_and_match_malformed_tag_fails_closed() -> None:
     """A non-UUID username fails closed without hitting the DB."""
-    resolver = _StubResolver(sandbox=_sandbox())
+    resolver = StubResolver(sandbox=make_resolved_sandbox())
     addon = _build(resolver=resolver, matcher=_StubMatcher(result=_MATCH))
-    flow = _flow(proxy_auth=_basic_auth("not-a-uuid"))
+    flow = make_flow(proxy_auth=_basic_auth("not-a-uuid"))
 
     result = await addon._resolve_and_match(flow)
 
@@ -1057,11 +1087,11 @@ async def test_resolve_and_match_malformed_tag_fails_closed() -> None:
 @pytest.mark.asyncio
 async def test_resolve_and_match_session_by_id_db_error_fails_closed() -> None:
     """A DB blip validating the tag fails closed, not silently forward."""
-    resolver = _StubResolver(
-        sandbox=_sandbox(), session_by_id_exc=RuntimeError("db down")
+    resolver = StubResolver(
+        sandbox=make_resolved_sandbox(), session_by_id_exc=RuntimeError("db down")
     )
     addon = _build(resolver=resolver, matcher=_StubMatcher(result=_MATCH))
-    flow = _flow(proxy_auth=_basic_auth(_TAG_UUID))
+    flow = make_flow(proxy_auth=_basic_auth(_TAG_UUID))
 
     result = await addon._resolve_and_match(flow)
 
@@ -1074,9 +1104,9 @@ async def test_resolve_and_match_session_by_id_db_error_fails_closed() -> None:
 async def test_request_strips_proxy_authorization_before_forward() -> None:
     """The in-band tag must never reach the origin: a forwarded request
     has Proxy-Authorization stripped."""
-    resolver = _StubResolver(sandbox=_sandbox())
+    resolver = StubResolver(sandbox=make_resolved_sandbox())
     addon = _build(resolver=resolver, matcher=_StubMatcher(result=None))
-    flow = _flow(proxy_auth=_basic_auth(_TAG_UUID))
+    flow = make_flow(proxy_auth=_basic_auth(_TAG_UUID))
     assert "Proxy-Authorization" in flow.request.headers
 
     await addon.request(flow)
@@ -1105,7 +1135,7 @@ def _snapshot_flow(
 ) -> http.HTTPFlow:
     # UploadPart shape; oversize body so a missed streaming opt-in fails
     # closed on the cap.
-    return _flow(
+    return make_flow(
         host=host,
         port=9000,
         method="PUT",
@@ -1122,8 +1152,8 @@ def _snapshot_flow(
 
 @pytest.mark.asyncio
 async def test_requestheaders_streams_tenant_snapshot_upload() -> None:
-    sandbox = _sandbox(tenant_id="tenant_acme")
-    resolver = _StubResolver(sandbox=sandbox)
+    sandbox = make_resolved_sandbox(tenant_id="tenant_acme")
+    resolver = StubResolver(sandbox=sandbox)
     addon = _build(resolver=resolver, matcher=_StubMatcher(result=_MATCH))
     addon._snapshot_policy = _snapshot_policy()
     flow = _snapshot_flow(tenant_segment="tenant_acme")
@@ -1131,21 +1161,21 @@ async def test_requestheaders_streams_tenant_snapshot_upload() -> None:
     await addon.requestheaders(flow)
 
     assert flow.request.stream is True
-    assert flow.metadata[gate_mod._SNAPSHOT_STREAM_FLAG] is True
+    assert flow.metadata[gate._SNAPSHOT_STREAM_FLAG] is True
 
 
 @pytest.mark.asyncio
 async def test_requestheaders_ignores_non_s3_host() -> None:
     """Cheap host pre-check must short-circuit before any DB resolve."""
-    resolver = _StubResolver(sandbox=_sandbox())
+    resolver = StubResolver(sandbox=make_resolved_sandbox())
     addon = _build(resolver=resolver, matcher=_StubMatcher(result=_MATCH))
     addon._snapshot_policy = _snapshot_policy()
-    flow = _flow(host="slack.com")
+    flow = make_flow(host="slack.com")
 
     await addon.requestheaders(flow)
 
     assert flow.request.stream is False
-    assert gate_mod._SNAPSHOT_STREAM_FLAG not in flow.metadata
+    assert gate._SNAPSHOT_STREAM_FLAG not in flow.metadata
     assert resolver.resolve_sandbox_calls == 0
 
 
@@ -1153,14 +1183,14 @@ async def test_requestheaders_ignores_non_s3_host() -> None:
 async def test_requestheaders_rejects_cross_tenant_prefix() -> None:
     """Pod is tenant_acme but the key targets tenant_evil's prefix: must
     not stream, so `request` then fail-closes on the cap."""
-    resolver = _StubResolver(sandbox=_sandbox(tenant_id="tenant_acme"))
+    resolver = StubResolver(sandbox=make_resolved_sandbox(tenant_id="tenant_acme"))
     addon = _build(resolver=resolver, matcher=_StubMatcher(result=None))
     addon._snapshot_policy = _snapshot_policy()
     flow = _snapshot_flow(tenant_segment="tenant_evil")
 
     await addon.requestheaders(flow)
     assert flow.request.stream is False
-    assert gate_mod._SNAPSHOT_STREAM_FLAG not in flow.metadata
+    assert gate._SNAPSHOT_STREAM_FLAG not in flow.metadata
 
     # Unmarked oversize flow now hits the fail-closed cap.
     result = await addon._resolve_and_match(flow)
@@ -1172,11 +1202,11 @@ async def test_requestheaders_rejects_cross_tenant_prefix() -> None:
 async def test_request_forwards_flagged_snapshot_flow() -> None:
     """A flagged flow forwards from `request` without touching the
     matcher, the cap, or the session lookup."""
-    resolver = _StubResolver(sandbox=_sandbox())
+    resolver = StubResolver(sandbox=make_resolved_sandbox())
     matcher = _StubMatcher(result=_MATCH)
     addon = _build(resolver=resolver, matcher=matcher)
     flow = _snapshot_flow(tenant_segment="tenant_acme")
-    flow.metadata[gate_mod._SNAPSHOT_STREAM_FLAG] = True
+    flow.metadata[gate._SNAPSHOT_STREAM_FLAG] = True
 
     await addon.request(flow)
 
@@ -1187,14 +1217,14 @@ async def test_request_forwards_flagged_snapshot_flow() -> None:
 
 @pytest.mark.asyncio
 async def test_requestheaders_noop_without_policy() -> None:
-    resolver = _StubResolver(sandbox=_sandbox())
+    resolver = StubResolver(sandbox=make_resolved_sandbox())
     addon = _build(resolver=resolver, matcher=_StubMatcher(result=_MATCH))
     flow = _snapshot_flow(tenant_segment="tenant_acme")
 
     await addon.requestheaders(flow)
 
     assert flow.request.stream is False
-    assert gate_mod._SNAPSHOT_STREAM_FLAG not in flow.metadata
+    assert gate._SNAPSHOT_STREAM_FLAG not in flow.metadata
     assert resolver.resolve_sandbox_calls == 0
 
 
@@ -1207,23 +1237,14 @@ def test_responseheaders_streams_response_body() -> None:
     """Responses are never gated, so they must stream through unbuffered —
     otherwise long SSE bodies (the agent's streamed LLM completions) are held
     until complete and can truncate."""
-    addon = _build(resolver=_StubResolver(), matcher=_StubMatcher())
-    flow = _flow()
+    addon = _build(resolver=StubResolver(), matcher=_StubMatcher())
+    flow = make_flow()
     flow.response = MagicMock()
     flow.response.stream = False
 
     addon.responseheaders(flow)
 
     assert flow.response.stream is True
-
-
-def test_responseheaders_no_response_is_noop() -> None:
-    """A flow without a response (shouldn't happen at this hook) must not raise."""
-    addon = _build(resolver=_StubResolver(), matcher=_StubMatcher())
-    flow = _flow()
-    flow.response = None
-
-    addon.responseheaders(flow)  # must not raise
 
 
 # ---------------------------------------------------------------------------
@@ -1238,18 +1259,19 @@ def test_dispatch_injection_writes_resolved_headers() -> None:
         claims_result=True, headers={"Authorization": "Bearer real-secret"}
     )
     addon = _build(
-        resolver=_StubResolver(),
+        resolver=StubResolver(),
         matcher=_StubMatcher(),
         credential_resolvers=[spy],
     )
-    flow = _flow()
+    flow = make_flow()
     flow.request.headers["Authorization"] = "sandbox-placeholder"
-    sandbox = _sandbox()
+    sandbox = make_resolved_sandbox()
 
-    addon._dispatch_injection_or_block(
+    outcome = addon._dispatch_injection_or_block(
         flow, sandbox=sandbox, matched_actions=_MATCH_ALWAYS
     )
 
+    assert outcome is InjectionOutcome.INJECTED
     assert flow.response is None  # forwarded
     assert flow.request.headers["Authorization"] == "Bearer real-secret"
     assert len(spy.resolve_calls) == 1
@@ -1261,17 +1283,18 @@ def test_dispatch_injection_writes_resolved_headers() -> None:
 def test_dispatch_injection_pass_through_forwards_untouched() -> None:
     """No resolver claims: forward, don't 403, don't modify headers."""
     addon = _build(
-        resolver=_StubResolver(),
+        resolver=StubResolver(),
         matcher=_StubMatcher(),
         credential_resolvers=[RecordingCredentialResolver(claims_result=False)],
     )
-    flow = _flow()
+    flow = make_flow()
     flow.request.headers["X-Pod-Side"] = "preserve"
 
-    addon._dispatch_injection_or_block(
-        flow, sandbox=_sandbox(), matched_actions=_MATCH_ALWAYS
+    outcome = addon._dispatch_injection_or_block(
+        flow, sandbox=make_resolved_sandbox(), matched_actions=_MATCH_ALWAYS
     )
 
+    assert outcome is InjectionOutcome.PASS_THROUGH
     assert flow.response is None
     assert flow.request.headers["X-Pod-Side"] == "preserve"
 
@@ -1280,7 +1303,7 @@ def test_dispatch_injection_credential_unavailable_blocks_with_403() -> None:
     """A claiming resolver that can't render fails closed at the gate boundary
     — the request never forwards with the sandbox's own headers."""
     addon = _build(
-        resolver=_StubResolver(),
+        resolver=StubResolver(),
         matcher=_StubMatcher(),
         credential_resolvers=[
             RecordingCredentialResolver(
@@ -1289,63 +1312,33 @@ def test_dispatch_injection_credential_unavailable_blocks_with_403() -> None:
             )
         ],
     )
-    flow = _flow()
+    flow = make_flow()
 
-    addon._dispatch_injection_or_block(
-        flow, sandbox=_sandbox(), matched_actions=_MATCH_ALWAYS
+    outcome = addon._dispatch_injection_or_block(
+        flow, sandbox=make_resolved_sandbox(), matched_actions=_MATCH_ALWAYS
     )
 
+    assert outcome is InjectionOutcome.BLOCKED
     _assert_403(flow, SandboxProxyError.CREDENTIAL_ERROR)
 
 
 def test_dispatch_injection_resolver_exception_blocks_with_403() -> None:
     """Any other resolver error is also fail-closed — never a silent forward."""
     addon = _build(
-        resolver=_StubResolver(),
+        resolver=StubResolver(),
         matcher=_StubMatcher(),
         credential_resolvers=[
             RecordingCredentialResolver(claims_result=True, exc=RuntimeError("db blip"))
         ],
     )
-    flow = _flow()
+    flow = make_flow()
 
-    addon._dispatch_injection_or_block(
-        flow, sandbox=_sandbox(), matched_actions=_MATCH_ALWAYS
+    outcome = addon._dispatch_injection_or_block(
+        flow, sandbox=make_resolved_sandbox(), matched_actions=_MATCH_ALWAYS
     )
 
+    assert outcome is InjectionOutcome.BLOCKED
     _assert_403(flow, SandboxProxyError.CREDENTIAL_ERROR)
-
-
-# ---------------------------------------------------------------------------
-# _write_response_for_decision
-# ---------------------------------------------------------------------------
-
-
-def test_write_response_approved_does_not_set_response() -> None:
-    addon = _build(resolver=_StubResolver(), matcher=_StubMatcher())
-    flow = _flow()
-
-    addon._write_response_for_decision(flow, ApprovalDecision.APPROVED)
-
-    assert flow.response is None
-
-
-def test_write_response_rejected_sets_user_rejected_403() -> None:
-    addon = _build(resolver=_StubResolver(), matcher=_StubMatcher())
-    flow = _flow()
-
-    addon._write_response_for_decision(flow, ApprovalDecision.REJECTED)
-
-    _assert_403(flow, SandboxProxyError.USER_REJECTED)
-
-
-def test_write_response_expired_sets_not_authorized_403() -> None:
-    addon = _build(resolver=_StubResolver(), matcher=_StubMatcher())
-    flow = _flow()
-
-    addon._write_response_for_decision(flow, ApprovalDecision.EXPIRED)
-
-    _assert_403(flow, SandboxProxyError.NOT_AUTHORIZED)
 
 
 # ---------------------------------------------------------------------------
@@ -1481,14 +1474,12 @@ def test_persist_approval_row_commits_announces_notifies(
         ops.append("insert")
         return MagicMock(approval_id=approval_id)
 
-    monkeypatch.setattr(
-        gate_mod.action_approval, "insert_action_approval", _fake_insert
-    )
+    monkeypatch.setattr(gate.action_approval, "insert_action_approval", _fake_insert)
 
     cache = _RecorderCache(ops)
-    monkeypatch.setattr(gate_mod, "get_session_with_tenant", _recorder_db_factory(ops))
+    monkeypatch.setattr(gate, "get_session_with_tenant", _recorder_db_factory(ops))
     addon = _build(
-        resolver=_StubResolver(),
+        resolver=StubResolver(),
         matcher=_StubMatcher(),
         cache_factory=lambda tenant_id: cache,  # noqa: ARG005
     )
@@ -1535,14 +1526,12 @@ def test_persist_approval_row_announce_failure_is_swallowed(
         ops.append("insert")
         return MagicMock(approval_id=approval_id)
 
-    monkeypatch.setattr(
-        gate_mod.action_approval, "insert_action_approval", _fake_insert
-    )
+    monkeypatch.setattr(gate.action_approval, "insert_action_approval", _fake_insert)
 
     cache = _RecorderCache(ops, rpush_raises=RedisError("connection refused"))
-    monkeypatch.setattr(gate_mod, "get_session_with_tenant", _recorder_db_factory(ops))
+    monkeypatch.setattr(gate, "get_session_with_tenant", _recorder_db_factory(ops))
     addon = _build(
-        resolver=_StubResolver(),
+        resolver=StubResolver(),
         matcher=_StubMatcher(),
         cache_factory=lambda tenant_id: cache,  # noqa: ARG005
     )
@@ -1587,11 +1576,11 @@ async def test_await_decision_wake_received_returns_decision(
     ) -> ApprovalDecision | None:
         return ApprovalDecision.APPROVED
 
-    monkeypatch.setattr(gate_mod.approval_cache, "wait_for_wake", _fake_wait_for_wake)
+    monkeypatch.setattr(gate.approval_cache, "wait_for_wake", _fake_wait_for_wake)
 
     cache = _RecorderCache([])
     addon = _build(
-        resolver=_StubResolver(),
+        resolver=StubResolver(),
         matcher=_StubMatcher(),
         cache_factory=lambda tenant_id: cache,  # noqa: ARG005
     )
@@ -1616,11 +1605,11 @@ async def test_await_decision_timeout_claims_expired(
     ) -> ApprovalDecision | None:
         return None
 
-    monkeypatch.setattr(gate_mod.approval_cache, "wait_for_wake", _fake_wait_for_wake)
+    monkeypatch.setattr(gate.approval_cache, "wait_for_wake", _fake_wait_for_wake)
 
     cache = _RecorderCache([])
     addon = _build(
-        resolver=_StubResolver(),
+        resolver=StubResolver(),
         matcher=_StubMatcher(),
         cache_factory=lambda tenant_id: cache,  # noqa: ARG005
     )
@@ -1655,11 +1644,11 @@ async def test_await_decision_cancelled_claims_expired_and_reraises(
     ) -> ApprovalDecision | None:
         raise asyncio.CancelledError()
 
-    monkeypatch.setattr(gate_mod.approval_cache, "wait_for_wake", _fake_wait_for_wake)
+    monkeypatch.setattr(gate.approval_cache, "wait_for_wake", _fake_wait_for_wake)
 
     cache = _RecorderCache([])
     addon = _build(
-        resolver=_StubResolver(),
+        resolver=StubResolver(),
         matcher=_StubMatcher(),
         cache_factory=lambda tenant_id: cache,  # noqa: ARG005
     )
@@ -1700,7 +1689,7 @@ async def test_drain_inflight_walks_parked_per_tenant(
     }
 
     addon = _build(
-        resolver=_StubResolver(),
+        resolver=StubResolver(),
         matcher=_StubMatcher(),
         cache_factory=lambda tenant_id: per_tenant_caches[tenant_id],
     )
@@ -1725,7 +1714,7 @@ async def test_drain_inflight_walks_parked_per_tenant(
     def _fake_send_wake(aid: UUID, decision: ApprovalDecision, cache: Any) -> None:
         send_wake_calls.append((aid, decision, cache))
 
-    monkeypatch.setattr(gate_mod.approval_cache, "send_wake", _fake_send_wake)
+    monkeypatch.setattr(gate.approval_cache, "send_wake", _fake_send_wake)
 
     await addon.drain_inflight()
 
@@ -1753,7 +1742,7 @@ async def test_drain_inflight_completes_when_inflight_set_empty() -> None:
         return _RecorderCache([])
 
     addon = _build(
-        resolver=_StubResolver(),
+        resolver=StubResolver(),
         matcher=_StubMatcher(),
         cache_factory=_tracking_cache_factory,
     )
@@ -1784,7 +1773,7 @@ def test_terminalize_happy_path_writes_wake(
     approval_id = uuid4()
     cache = _RecorderCache([])
     addon = _build(
-        resolver=_StubResolver(),
+        resolver=StubResolver(),
         matcher=_StubMatcher(),
         cache_factory=lambda tenant_id: cache,  # noqa: ARG005
     )
@@ -1800,7 +1789,7 @@ def test_terminalize_happy_path_writes_wake(
     def _fake_send_wake(aid: UUID, decision: ApprovalDecision, _cache: Any) -> None:
         wake_calls.append((aid, decision))
 
-    monkeypatch.setattr(gate_mod.approval_cache, "send_wake", _fake_send_wake)
+    monkeypatch.setattr(gate.approval_cache, "send_wake", _fake_send_wake)
 
     addon._terminalize_after_unhandled_error(approval_id, "tenant-1")
 
@@ -1815,7 +1804,7 @@ def test_terminalize_db_failure_skips_wake(
     approval_id = uuid4()
     cache = _RecorderCache([])
     addon = _build(
-        resolver=_StubResolver(),
+        resolver=StubResolver(),
         matcher=_StubMatcher(),
         cache_factory=lambda tenant_id: cache,  # noqa: ARG005
     )
@@ -1831,7 +1820,7 @@ def test_terminalize_db_failure_skips_wake(
         nonlocal wake_count
         wake_count += 1
 
-    monkeypatch.setattr(gate_mod.approval_cache, "send_wake", _fake_send_wake)
+    monkeypatch.setattr(gate.approval_cache, "send_wake", _fake_send_wake)
 
     # Should not raise.
     addon._terminalize_after_unhandled_error(approval_id, "tenant-1")
@@ -1847,7 +1836,7 @@ def test_terminalize_wake_failure_swallowed(
     approval_id = uuid4()
     cache = _RecorderCache([])
     addon = _build(
-        resolver=_StubResolver(),
+        resolver=StubResolver(),
         matcher=_StubMatcher(),
         cache_factory=lambda tenant_id: cache,  # noqa: ARG005
     )
@@ -1861,7 +1850,7 @@ def test_terminalize_wake_failure_swallowed(
     def _wake_raises(_aid: UUID, _decision: ApprovalDecision, _cache: Any) -> None:
         raise RedisError("wake failed")
 
-    monkeypatch.setattr(gate_mod.approval_cache, "send_wake", _wake_raises)
+    monkeypatch.setattr(gate.approval_cache, "send_wake", _wake_raises)
 
     # Should not raise.
     addon._terminalize_after_unhandled_error(approval_id, "tenant-1")

--- a/backend/tests/unit/sandbox_proxy/test_llm_provider_key_resolver.py
+++ b/backend/tests/unit/sandbox_proxy/test_llm_provider_key_resolver.py
@@ -18,11 +18,11 @@ import pytest
 
 from onyx.sandbox_proxy.credential_injection import CredentialUnavailableError
 from onyx.sandbox_proxy.credential_injection import InjectionContext
-from onyx.sandbox_proxy.resolvers import llm_provider_key as mod
+from onyx.sandbox_proxy.resolvers import llm_provider_key
 from onyx.sandbox_proxy.resolvers.llm_provider_key import LLMProviderKeyResolver
 from onyx.server.features.build.configs import BUILD_MODE_ALLOWED_PROVIDER_TYPES
-from tests.unit.sandbox_proxy.conftest import make_flow as _flow
-from tests.unit.sandbox_proxy.conftest import make_resolved_sandbox as _sandbox
+from tests.unit.sandbox_proxy.conftest import make_flow
+from tests.unit.sandbox_proxy.conftest import make_resolved_sandbox
 
 
 class _FakeProvider:
@@ -43,12 +43,12 @@ def _noop_db_factory() -> Any:
 def _patch_session(monkeypatch: pytest.MonkeyPatch) -> None:
     """The resolver opens its own tenant session via `get_session_with_tenant`;
     yield a dummy so the patched DB-access functions receive it."""
-    monkeypatch.setattr(mod, "get_session_with_tenant", _noop_db_factory())
+    monkeypatch.setattr(llm_provider_key, "get_session_with_tenant", _noop_db_factory())
 
 
 def _ctx() -> InjectionContext:
     return InjectionContext(
-        sandbox=_sandbox(tenant_id="tenant-7"), matched_actions=None
+        sandbox=make_resolved_sandbox(tenant_id="tenant-7"), matched_actions=None
     )
 
 
@@ -60,18 +60,20 @@ def resolver() -> LLMProviderKeyResolver:
 def _patch_providers(
     monkeypatch: pytest.MonkeyPatch, providers: list[_FakeProvider]
 ) -> None:
-    monkeypatch.setattr(mod, "fetch_user_by_id", lambda *_: object())
+    monkeypatch.setattr(llm_provider_key, "fetch_user_by_id", lambda *_: object())
     monkeypatch.setattr(
-        mod, "fetch_all_supported_build_llm_providers", lambda *_: providers
+        llm_provider_key,
+        "fetch_all_supported_build_llm_providers",
+        lambda *_: providers,
     )
 
 
 def test_claims_only_canonical_hosts(resolver: LLMProviderKeyResolver) -> None:
     for host in ("api.openai.com", "api.anthropic.com", "openrouter.ai"):
-        assert resolver.claims(_flow(host=host).request, _ctx()) is True
-        assert resolver.claims(_flow(host=host.upper()).request, _ctx()) is True
-    assert resolver.claims(_flow(host="api.slack.com").request, _ctx()) is False
-    assert resolver.claims(_flow(host="example.com").request, _ctx()) is False
+        assert resolver.claims(make_flow(host=host).request, _ctx()) is True
+        assert resolver.claims(make_flow(host=host.upper()).request, _ctx()) is True
+    assert resolver.claims(make_flow(host="api.slack.com").request, _ctx()) is False
+    assert resolver.claims(make_flow(host="example.com").request, _ctx()) is False
 
 
 def test_openai_and_openrouter_render_bearer(
@@ -81,10 +83,10 @@ def test_openai_and_openrouter_render_bearer(
         monkeypatch,
         [_FakeProvider("openai", "sk-oai"), _FakeProvider("openrouter", "sk-or")],
     )
-    assert resolver.resolve(_flow(host="api.openai.com").request, _ctx()) == {
+    assert resolver.resolve(make_flow(host="api.openai.com").request, _ctx()) == {
         "Authorization": "Bearer sk-oai"
     }
-    assert resolver.resolve(_flow(host="openrouter.ai").request, _ctx()) == {
+    assert resolver.resolve(make_flow(host="openrouter.ai").request, _ctx()) == {
         "Authorization": "Bearer sk-or"
     }
 
@@ -94,7 +96,7 @@ def test_anthropic_renders_x_api_key_only(
 ) -> None:
     _patch_providers(monkeypatch, [_FakeProvider("anthropic", "sk-ant")])
     # x-api-key only — anthropic-version and other SDK headers must survive.
-    assert resolver.resolve(_flow(host="api.anthropic.com").request, _ctx()) == {
+    assert resolver.resolve(make_flow(host="api.anthropic.com").request, _ctx()) == {
         "x-api-key": "sk-ant"
     }
 
@@ -110,7 +112,7 @@ def test_selects_first_provider_of_claimed_type(
             _FakeProvider("anthropic", "sk-ant"),
         ],
     )
-    assert resolver.resolve(_flow(host="api.openai.com").request, _ctx()) == {
+    assert resolver.resolve(make_flow(host="api.openai.com").request, _ctx()) == {
         "Authorization": "Bearer sk-first"
     }
 
@@ -118,9 +120,9 @@ def test_selects_first_provider_of_claimed_type(
 def test_resolve_raises_when_user_missing(
     resolver: LLMProviderKeyResolver, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setattr(mod, "fetch_user_by_id", lambda *_: None)
+    monkeypatch.setattr(llm_provider_key, "fetch_user_by_id", lambda *_: None)
     with pytest.raises(CredentialUnavailableError):
-        resolver.resolve(_flow(host="api.openai.com").request, _ctx())
+        resolver.resolve(make_flow(host="api.openai.com").request, _ctx())
 
 
 def test_resolve_raises_when_no_provider_of_type(
@@ -128,7 +130,7 @@ def test_resolve_raises_when_no_provider_of_type(
 ) -> None:
     _patch_providers(monkeypatch, [_FakeProvider("anthropic", "sk-ant")])
     with pytest.raises(CredentialUnavailableError):
-        resolver.resolve(_flow(host="api.openai.com").request, _ctx())
+        resolver.resolve(make_flow(host="api.openai.com").request, _ctx())
 
 
 def test_resolve_raises_when_provider_has_no_key(
@@ -136,7 +138,7 @@ def test_resolve_raises_when_provider_has_no_key(
 ) -> None:
     _patch_providers(monkeypatch, [_FakeProvider("openai", None)])
     with pytest.raises(CredentialUnavailableError):
-        resolver.resolve(_flow(host="api.openai.com").request, _ctx())
+        resolver.resolve(make_flow(host="api.openai.com").request, _ctx())
 
 
 # The wire contract per provider, written out independently of the resolver's
@@ -149,7 +151,7 @@ _EXPECTED_HOST_TABLE = {
 
 
 def test_host_table_matches_wire_spec() -> None:
-    assert mod._HOST_TO_PROVIDER == _EXPECTED_HOST_TABLE
+    assert llm_provider_key._HOST_TO_PROVIDER == _EXPECTED_HOST_TABLE
 
 
 def test_host_table_covers_every_build_mode_provider_type() -> None:

--- a/backend/tests/unit/sandbox_proxy/test_onyx_pat_resolver.py
+++ b/backend/tests/unit/sandbox_proxy/test_onyx_pat_resolver.py
@@ -19,10 +19,10 @@ from onyx.auth.constants import API_KEY_HEADER_ALTERNATIVE_NAME
 from onyx.auth.constants import API_KEY_HEADER_NAME
 from onyx.sandbox_proxy.credential_injection import CredentialUnavailableError
 from onyx.sandbox_proxy.credential_injection import InjectionContext
-from onyx.sandbox_proxy.resolvers import onyx_pat as onyx_pat_mod
+from onyx.sandbox_proxy.resolvers import onyx_pat
 from onyx.sandbox_proxy.resolvers.onyx_pat import OnyxPatResolver
-from tests.unit.sandbox_proxy.conftest import make_flow as _flow
-from tests.unit.sandbox_proxy.conftest import make_resolved_sandbox as _sandbox
+from tests.unit.sandbox_proxy.conftest import make_flow
+from tests.unit.sandbox_proxy.conftest import make_resolved_sandbox
 
 _API_URL = "https://api.onyx.example.com"
 _API_HOST = "api.onyx.example.com"
@@ -58,45 +58,53 @@ def _noop_db_factory() -> Any:
 def _patch_session(monkeypatch: pytest.MonkeyPatch) -> None:
     """The resolver opens its own tenant session via `get_session_with_tenant`;
     yield a dummy so the patched DB-access functions receive it."""
-    monkeypatch.setattr(onyx_pat_mod, "get_session_with_tenant", _noop_db_factory())
+    monkeypatch.setattr(onyx_pat, "get_session_with_tenant", _noop_db_factory())
 
 
 def _ctx() -> InjectionContext:
     return InjectionContext(
-        sandbox=_sandbox(tenant_id="tenant-7"), matched_actions=None
+        sandbox=make_resolved_sandbox(tenant_id="tenant-7"), matched_actions=None
     )
 
 
 @pytest.fixture
 def resolver(monkeypatch: pytest.MonkeyPatch) -> OnyxPatResolver:
     # __init__ captures the API host, so the patch must precede construction.
-    monkeypatch.setattr(onyx_pat_mod, "SANDBOX_API_SERVER_URL", _API_URL)
+    monkeypatch.setattr(onyx_pat, "SANDBOX_API_SERVER_URL", _API_URL)
     return OnyxPatResolver()
 
 
 def test_claims_requires_matching_host_and_port(resolver: OnyxPatResolver) -> None:
     # _API_URL is https with no explicit port, so the effective port is 443.
-    assert resolver.claims(_flow(host=_API_HOST, port=443).request, _ctx()) is True
+    assert resolver.claims(make_flow(host=_API_HOST, port=443).request, _ctx()) is True
     assert (
-        resolver.claims(_flow(host=_API_HOST.upper(), port=443).request, _ctx()) is True
+        resolver.claims(make_flow(host=_API_HOST.upper(), port=443).request, _ctx())
+        is True
     )
-    assert resolver.claims(_flow(host=_API_HOST, port=8080).request, _ctx()) is False
     assert (
-        resolver.claims(_flow(host="api.slack.com", port=443).request, _ctx()) is False
+        resolver.claims(make_flow(host=_API_HOST, port=8080).request, _ctx()) is False
+    )
+    assert (
+        resolver.claims(make_flow(host="api.slack.com", port=443).request, _ctx())
+        is False
     )
 
 
 def test_claims_matches_explicit_port(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(onyx_pat_mod, "SANDBOX_API_SERVER_URL", "http://internal:8080")
+    monkeypatch.setattr(onyx_pat, "SANDBOX_API_SERVER_URL", "http://internal:8080")
     resolver = OnyxPatResolver()
-    assert resolver.claims(_flow(host="internal", port=8080).request, _ctx()) is True
-    assert resolver.claims(_flow(host="internal", port=443).request, _ctx()) is False
+    assert (
+        resolver.claims(make_flow(host="internal", port=8080).request, _ctx()) is True
+    )
+    assert (
+        resolver.claims(make_flow(host="internal", port=443).request, _ctx()) is False
+    )
 
 
 def test_inert_when_api_url_unset(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(onyx_pat_mod, "SANDBOX_API_SERVER_URL", "")
+    monkeypatch.setattr(onyx_pat, "SANDBOX_API_SERVER_URL", "")
     assert (
-        OnyxPatResolver().claims(_flow(host=_API_HOST, port=443).request, _ctx())
+        OnyxPatResolver().claims(make_flow(host=_API_HOST, port=443).request, _ctx())
         is False
     )
 
@@ -105,11 +113,11 @@ def test_resolve_renders_pat_on_both_auth_headers(
     resolver: OnyxPatResolver, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(
-        onyx_pat_mod,
+        onyx_pat,
         "get_sandbox_by_id",
         lambda *_: _FakeSandbox(_FakeEncrypted(value="onyx_pat_t.secret")),
     )
-    headers = resolver.resolve(_flow(host=_API_HOST).request, _ctx())
+    headers = resolver.resolve(make_flow(host=_API_HOST).request, _ctx())
     assert headers == {
         API_KEY_HEADER_NAME: "Bearer onyx_pat_t.secret",
         API_KEY_HEADER_ALTERNATIVE_NAME: "Bearer onyx_pat_t.secret",
@@ -119,28 +127,26 @@ def test_resolve_renders_pat_on_both_auth_headers(
 def test_resolve_raises_when_sandbox_missing(
     resolver: OnyxPatResolver, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setattr(onyx_pat_mod, "get_sandbox_by_id", lambda *_: None)
+    monkeypatch.setattr(onyx_pat, "get_sandbox_by_id", lambda *_: None)
     with pytest.raises(CredentialUnavailableError):
-        resolver.resolve(_flow(host=_API_HOST).request, _ctx())
+        resolver.resolve(make_flow(host=_API_HOST).request, _ctx())
 
 
 def test_resolve_raises_when_pat_unset(
     resolver: OnyxPatResolver, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setattr(
-        onyx_pat_mod, "get_sandbox_by_id", lambda *_: _FakeSandbox(None)
-    )
+    monkeypatch.setattr(onyx_pat, "get_sandbox_by_id", lambda *_: _FakeSandbox(None))
     with pytest.raises(CredentialUnavailableError):
-        resolver.resolve(_flow(host=_API_HOST).request, _ctx())
+        resolver.resolve(make_flow(host=_API_HOST).request, _ctx())
 
 
 def test_resolve_raises_when_decrypt_fails(
     resolver: OnyxPatResolver, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(
-        onyx_pat_mod,
+        onyx_pat,
         "get_sandbox_by_id",
         lambda *_: _FakeSandbox(_FakeEncrypted(exc=ValueError("boom"))),
     )
     with pytest.raises(CredentialUnavailableError):
-        resolver.resolve(_flow(host=_API_HOST).request, _ctx())
+        resolver.resolve(make_flow(host=_API_HOST).request, _ctx())


### PR DESCRIPTION
## Description

Reduce sandbox proxy log noise and make the remaining events easier to scan.

- Disable mitmproxy terminal/dumper request logs.
- Stop logging off-catalog pass-through traffic that no credential resolver claims.
- Standardize proxy event messages as `event_name key=value ...`, with short IDs in readable fields and full IDs only for correlation keys.
- Normalize egress, approval, and credential logs without logging credential values.

## How Has This Been Tested?

No end-to-end local testing was run.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check