### PR TITLE
fix: fall back to global default model when personal default's provider is gone (#11866) to release v4.1

### DIFF
--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -1,4 +1,5 @@
 from sqlalchemy import delete
+from sqlalchemy import or_
 from sqlalchemy import select
 from sqlalchemy import update
 from sqlalchemy.dialects.postgresql import insert
@@ -680,6 +681,29 @@ def remove_llm_provider(
 
     for persona in get_personas_using_provider(db_session, provider_id):
         persona.default_model_configuration_id = None
+
+    # Clear personal default models referencing this provider. They are stored
+    # as "<provider display name>__<provider type>__<model name>" strings, so
+    # they'd otherwise dangle forever and silently resolve to an arbitrary
+    # provider in the UI instead of the global default. Display names are not
+    # unique at the DB level, so include the provider type in the match.
+    # Nameless providers have been serialized with either an empty display
+    # name or the provider id depending on the frontend writer, so match both.
+    display_names = [provider.name] if provider.name else ["", str(provider.id)]
+    db_session.execute(
+        update(User)
+        .where(
+            or_(
+                *(
+                    User.default_model.startswith(
+                        f"{display_name}__{provider.provider}__", autoescape=True
+                    )
+                    for display_name in display_names
+                )
+            )
+        )
+        .values(default_model=None)
+    )
 
     db_session.execute(
         delete(LLMProvider__UserGroup).where(

--- a/backend/tests/external_dependency_unit/llm/test_llm_provider_user_default_cleanup.py
+++ b/backend/tests/external_dependency_unit/llm/test_llm_provider_user_default_cleanup.py
@@ -1,0 +1,69 @@
+"""
+Tests that deleting an LLM provider clears personal default models
+(User.default_model) referencing it, so users fall back to the global
+default instead of a dangling provider reference.
+"""
+
+from uuid import uuid4
+
+from sqlalchemy import delete
+from sqlalchemy.orm import Session
+
+from onyx.db.llm import remove_llm_provider
+from onyx.db.llm import upsert_llm_provider
+from onyx.db.models import User
+from onyx.llm.constants import LlmProviderNames
+from onyx.server.manage.llm.models import LLMProviderUpsertRequest
+from onyx.server.manage.llm.models import LLMProviderView
+from onyx.server.manage.llm.models import ModelConfigurationUpsertRequest
+from tests.external_dependency_unit.conftest import create_test_user
+
+
+def _create_test_provider(db_session: Session, name: str) -> LLMProviderView:
+    return upsert_llm_provider(
+        LLMProviderUpsertRequest(
+            name=name,
+            provider=LlmProviderNames.OPENAI,
+            api_key="sk-test-key-00000000000000000000000000000000000",
+            api_key_changed=True,
+            model_configurations=[
+                ModelConfigurationUpsertRequest(name="gpt-4o-mini", is_visible=True)
+            ],
+        ),
+        db_session=db_session,
+    )
+
+
+def test_remove_llm_provider_clears_matching_user_defaults(
+    db_session: Session,
+) -> None:
+    provider_to_delete = _create_test_provider(
+        db_session, f"test-provider-{uuid4().hex[:8]}"
+    )
+    provider_to_keep = _create_test_provider(
+        db_session, f"test-provider-{uuid4().hex[:8]}"
+    )
+
+    affected_user = create_test_user(db_session, "default_model_cleared")
+    unaffected_user = create_test_user(db_session, "default_model_kept")
+
+    kept_default = f"{provider_to_keep.name}__openai__gpt-4o-mini"
+    affected_user.default_model = f"{provider_to_delete.name}__openai__gpt-4o-mini"
+    unaffected_user.default_model = kept_default
+    db_session.commit()
+
+    try:
+        remove_llm_provider(db_session, provider_to_delete.id)
+
+        db_session.refresh(affected_user)
+        db_session.refresh(unaffected_user)
+
+        assert affected_user.default_model is None
+        assert unaffected_user.default_model == kept_default
+    finally:
+        remove_llm_provider(db_session, provider_to_keep.id)
+        # Bulk delete to avoid loading the users' relationship graph
+        db_session.execute(
+            delete(User).where(User.id.in_([affected_user.id, unaffected_user.id]))
+        )
+        db_session.commit()

--- a/web/src/lib/hooks.llmResolver.test.ts
+++ b/web/src/lib/hooks.llmResolver.test.ts
@@ -144,6 +144,54 @@ describe("LLM resolver helpers", () => {
     });
   });
 
+  test("falls back to the global default when the saved model's provider is gone", () => {
+    const providers: LLMProviderDescriptor[] = [
+      makeProvider({
+        id: 10,
+        name: "First Provider",
+        provider: "openai",
+        model_configurations: [
+          {
+            name: "gpt-first",
+            is_visible: true,
+            max_input_tokens: null,
+            supports_image_input: false,
+            supports_reasoning: false,
+          },
+        ],
+      }),
+      makeProvider({
+        id: 20,
+        name: "Global Default Provider",
+        provider: "anthropic",
+        model_configurations: [
+          {
+            name: "claude-global-default",
+            is_visible: true,
+            max_input_tokens: null,
+            supports_image_input: false,
+            supports_reasoning: false,
+          },
+        ],
+      }),
+    ];
+
+    // Personal default points at a provider that no longer exists (e.g. it
+    // was deleted by an admin). The admin-configured global default should
+    // win over the first provider in the list.
+    const descriptor = getValidLlmDescriptorForProviders(
+      structureValue("Deleted Provider", "litellm", "some-old-model"),
+      providers,
+      { provider_id: 20, model_name: "claude-global-default" }
+    );
+
+    expect(descriptor).toEqual({
+      name: "Global Default Provider",
+      provider: "anthropic",
+      modelName: "claude-global-default",
+    });
+  });
+
   test("uses first provider with models when no explicit default exists", () => {
     const providers: LLMProviderDescriptor[] = [
       makeProvider({

--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -490,7 +490,8 @@ export function getDefaultLlmDescriptor(
 
 export function getValidLlmDescriptorForProviders(
   modelName: string | null | undefined,
-  llmProviders: LLMProviderDescriptor[] | undefined | null
+  llmProviders: LLMProviderDescriptor[] | undefined | null,
+  defaultText?: DefaultModel | null
 ): LlmDescriptor {
   // Return early if providers haven't loaded yet (undefined/null)
   // Empty arrays are valid (user has no provider access for this assistant)
@@ -556,9 +557,12 @@ export function getValidLlmDescriptorForProviders(
     }
   }
 
-  // Model not found in available providers - fall back to default model
+  // Model not found in available providers - fall back to the admin-configured
+  // global default before resorting to the first provider with visible models.
+  // Without this, a stale personal default (e.g. its provider was deleted)
+  // would silently land on an arbitrary provider instead of the global default.
   return (
-    getDefaultLlmDescriptor(llmProviders) ?? {
+    getDefaultLlmDescriptor(llmProviders, defaultText) ?? {
       name: "",
       provider: "",
       modelName: "",
@@ -641,7 +645,11 @@ export function useLlmManager(
   function getValidLlmDescriptor(
     modelName: string | null | undefined
   ): LlmDescriptor {
-    return getValidLlmDescriptorForProviders(modelName, llmProviders);
+    return getValidLlmDescriptorForProviders(
+      modelName,
+      llmProviders,
+      defaultText
+    );
   }
 
   // Compute the resolved LLM synchronously so it's never one render behind.
@@ -666,12 +674,14 @@ export function useLlmManager(
     } else if (currentChatSession?.current_alternate_model) {
       resolved = getValidLlmDescriptorForProviders(
         currentChatSession.current_alternate_model,
-        llmProviders
+        llmProviders,
+        defaultText
       );
     } else if (user?.preferences?.default_model) {
       resolved = getValidLlmDescriptorForProviders(
         user.preferences.default_model,
-        llmProviders
+        llmProviders,
+        defaultText
       );
     } else {
       resolved =


### PR DESCRIPTION
## Description

Cherry-pick of #11866 (squash commit `37bf6b7`) onto `release/v4.1`. Applied conflict-free.

When a user has a personal default model set and the LLM provider backing it is deleted, the chat UI silently resolved to the first provider with visible models instead of the admin-configured global default. This threads the global default through the frontend fallback and clears `User.default_model` rows referencing a provider when it is deleted.

## How Has This Been Tested?

On this branch: jest resolver suite passes (5/5) and the new external dependency unit test passes. Same tests as #11866.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes model selection fallback so chats use the admin global default when a user’s personal default points to a deleted provider. Also clears stale personal defaults on provider removal to prevent silent misrouting.

- **Bug Fixes**
  - Frontend: Thread the global default into the resolver and prefer it before “first available” fallback. Updated `getValidLlmDescriptorForProviders(modelName, providers, defaultText)` and calls in `useLlmManager`.
  - Backend: When deleting a provider, unset `User.default_model` that reference it (match by display name + provider type; handle empty/ID display names).
  - Tests: Added backend unit test for user default cleanup and a web test that verifies fallback to the global default.

<sup>Written for commit 85c60ebc0c90b6c787ef74460c91bc09e450e77b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

