### PR TITLE
test(agents): split flaky welcome-page-with-assistant screenshot

### DIFF
--- a/web/tests/e2e/agents/create_and_edit_agent.spec.ts
+++ b/web/tests/e2e/agents/create_and_edit_agent.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect, Page, Browser } from "@playwright/test";
 import { loginAs, loginAsWorkerUser } from "@tests/e2e/utils/auth";
 import { OnyxApiClient } from "@tests/e2e/utils/onyxApiClient";
-import { expectScreenshot } from "@tests/e2e/utils/visualRegression";
+import { expectElementScreenshot } from "@tests/e2e/utils/visualRegression";
 
 // --- Locator Helper Functions ---
 const getNameInput = (page: Page) => page.locator('input[name="name"]');
@@ -292,8 +292,27 @@ test.describe("Assistant Creation and Edit Verification", () => {
       expect(agentIdMatch).toBeTruthy();
       const agentId = agentIdMatch ? agentIdMatch[1] : null;
       expect(agentId).not.toBeNull();
-      await expectScreenshot(page, {
-        name: "welcome-page-with-assistant",
+      // Split the previous full-page screenshot into two scoped element
+      // screenshots. The full-page variant was flaky because the sidebar can
+      // pick up agents/projects/recents created by other tests; scoping to the
+      // Agents section and the main container isolates the relevant UI.
+      //
+      // Locate the Agents SidebarSection by its title rather than a dedicated
+      // test id: SidebarSection roots are the only elements carrying
+      // `data-hover-group="sidebar-section"`, and we filter to the one whose
+      // section title is exactly "Agents".
+      const agentsSidebarSection = page
+        .locator('[data-hover-group="sidebar-section"]')
+        .filter({ has: page.getByText("Agents", { exact: true }) });
+      await expect(agentsSidebarSection).toBeVisible();
+      await expectElementScreenshot(agentsSidebarSection, {
+        name: "welcome-page-with-assistant-agents-sidebar",
+      });
+
+      const mainContainer = page.locator("[data-main-container]");
+      await expect(mainContainer).toBeVisible();
+      await expectElementScreenshot(mainContainer, {
+        name: "welcome-page-with-assistant-main",
         hide: ["[data-testid='model-selector']"],
       });
 


### PR DESCRIPTION
## Description

The `welcome-page-with-assistant` full-page visual regression screenshot (in `create_and_edit_agent.spec.ts`) is flaky: the sidebar can conditionally include agents/projects/recents created by other tests in the suite, causing spurious diffs.

This PR makes it more resilient by **splitting the single full-page screenshot into two scoped element screenshots**, matching the pattern used by other tests (e.g. the admin `disconnect-provider` specs and `ChatPage`):

- `welcome-page-with-assistant-agents-sidebar` — just the **Agents `sidebar-section`**, isolating the region that reflects the newly-created assistant.
- `welcome-page-with-assistant-main` — the **`[data-main-container]`** main content area (keeps the existing `model-selector` hide).

**Test-only change — no production code is touched.** The Agents section is located by its existing `title="Agents"` rather than a dedicated test id: `SidebarSection` roots are the only elements carrying `data-hover-group="sidebar-section"`, so we select the one whose section title is exactly `"Agents"`.

> Note: this introduces two **new** screenshot baseline names, so the first `VISUAL_REGRESSION=true` run will generate/accept their baselines (the old `welcome-page-with-assistant` baseline is not committed in-repo).

## How Has This Been Tested?

- `oxfmt` + `oxlint` clean on the changed file.
- The new locators reuse existing selectors (`data-hover-group` section root filtered by the `"Agents"` title, and `[data-main-container]`), each guarded by a `toBeVisible()` assertion before the screenshot.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)