### PR TITLE
test(voice): pin well-known STT model for realtime live tests

### DIFF
--- a/backend/tests/external_dependency_unit/voice/test_openai_streaming.py
+++ b/backend/tests/external_dependency_unit/voice/test_openai_streaming.py
@@ -10,7 +10,6 @@ import struct
 
 import pytest
 
-from onyx.voice.providers.openai import OPENAI_REALTIME_STT_MODEL
 from onyx.voice.providers.openai import OpenAIStreamingTranscriber
 from onyx.voice.providers.openai import OpenAIVoiceProvider
 from tests.utils.secret_names import TestSecret
@@ -18,6 +17,14 @@ from tests.utils.secret_names import TestSecret
 # 24kHz mono PCM16 — matches the browser's voice WS format.
 _SAMPLE_RATE_HZ = 24000
 _BYTES_PER_SAMPLE = 2
+
+# These tests validate the GA Realtime `session.update` *shape* and the PCM16
+# round-trip, both of which are independent of the transcription model. Pin a
+# universally-available model rather than production's `gpt-realtime-whisper`,
+# which can sit behind org verification (a CI key without access gets
+# `model_not_found`). `whisper-1` is a valid realtime input-transcription model
+# and is available on every account, so the handshake is exercised everywhere.
+_WELL_KNOWN_STT_MODEL = "whisper-1"
 
 
 def _silence_pcm16(duration_s: float) -> bytes:
@@ -46,7 +53,7 @@ def test_streaming_connect_uses_ga_realtime_shape(
     async def run() -> None:
         transcriber = OpenAIStreamingTranscriber(
             api_key=test_secrets[TestSecret.OPENAI_API_KEY],
-            model=OPENAI_REALTIME_STT_MODEL,
+            model=_WELL_KNOWN_STT_MODEL,
         )
         try:
             await transcriber.connect()
@@ -71,7 +78,7 @@ def test_streaming_accepts_pcm16_audio_chunks(
     async def run() -> None:
         transcriber = OpenAIStreamingTranscriber(
             api_key=test_secrets[TestSecret.OPENAI_API_KEY],
-            model=OPENAI_REALTIME_STT_MODEL,
+            model=_WELL_KNOWN_STT_MODEL,
         )
         await transcriber.connect()
         try:


### PR DESCRIPTION
## What

The OpenAI realtime STT live tests in `test_openai_streaming.py` validate the GA Realtime **`session.update` handshake shape** and a **PCM16 round-trip**. They were pinned to production's `gpt-realtime-whisper` and hard-failed in CI with:

> The model `gpt-realtime-whisper-api-ev3` does not exist or you do not have access to it.

## Why

- Both things these tests check are **independent of the transcription model** — it's just one string field in the `session.update` JSON. The premium `gpt-realtime-whisper` can sit behind **org verification**, so a CI key without access gets `model_not_found` (the message echoes OpenAI's internal eval snapshot `gpt-realtime-whisper-api-ev3`).
- The original failure was **only** about the transcription model — the session model `gpt-realtime-1.5` in the URL was accepted, so the account does have realtime access; it just lacks the new premium STT model.

## Change

Pin `whisper-1` for these tests — a valid realtime input-transcription model that's available on every account. The handshake is now exercised on **any** realtime-enabled account (instead of skipping or failing on premium-model provisioning), and genuine `session.update` shape regressions still fail the assertion. Production keeps `gpt-realtime-whisper` (it wants the natively-streaming low-latency deltas); only the tests change.

## Testing

- `ruff check` + `ruff format --check`: clean
- `ty check`: clean
- `pytest --collect-only`: all 3 tests collect

> Note: I couldn't run these against the live API locally (no OpenAI key in this env), so CI is the real validation. `whisper-1` is a documented realtime input-transcription model available on all accounts, so it should connect everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)