### PR TITLE
fix(chat): SSE heartbeat + first-chunk stream retry to stop silent stream deaths

### DIFF
--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -1217,7 +1217,7 @@ def _run_models(
 
         # ── Main thread: merge and yield packets ────────────────────────────
         models_remaining = n_models
-        last_packet_yield = time.monotonic()
+        last_packet_yield: float = time.monotonic()
         while models_remaining > 0:
             try:
                 model_idx, item = merged_queue.get(timeout=_CANCEL_POLL_INTERVAL_S)

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -9,6 +9,7 @@ import os
 import queue
 import re
 import threading
+import time
 import traceback
 from collections.abc import Callable
 from collections.abc import Generator
@@ -57,6 +58,7 @@ from onyx.chat.stop_signal_checker import is_connected as check_stop_signal
 from onyx.chat.stop_signal_checker import reset_cancel_status
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
 from onyx.configs.app_configs import INTEGRATION_TESTS_MODE
+from onyx.configs.chat_configs import CHAT_HEARTBEAT_INTERVAL_S
 from onyx.configs.constants import DEFAULT_PERSONA_ID
 from onyx.configs.constants import DocumentSource
 from onyx.configs.constants import MessageType
@@ -111,6 +113,7 @@ from onyx.server.query_and_chat.models import SendMessageRequest
 from onyx.server.query_and_chat.placement import Placement
 from onyx.server.query_and_chat.streaming_models import AgentResponseDelta
 from onyx.server.query_and_chat.streaming_models import AgentResponseStart
+from onyx.server.query_and_chat.streaming_models import ChatHeartbeat
 from onyx.server.query_and_chat.streaming_models import CitationInfo
 from onyx.server.query_and_chat.streaming_models import OverallStop
 from onyx.server.query_and_chat.streaming_models import Packet
@@ -1214,6 +1217,7 @@ def _run_models(
 
         # ── Main thread: merge and yield packets ────────────────────────────
         models_remaining = n_models
+        last_packet_yield = time.monotonic()
         while models_remaining > 0:
             try:
                 model_idx, item = merged_queue.get(timeout=_CANCEL_POLL_INTERVAL_S)
@@ -1254,6 +1258,13 @@ def _run_models(
                     )
                     completion_persisted = True
                     return
+                now = time.monotonic()
+                if now - last_packet_yield >= CHAT_HEARTBEAT_INTERVAL_S:
+                    yield Packet(
+                        placement=Placement(turn_index=0),
+                        obj=ChatHeartbeat(),
+                    )
+                    last_packet_yield = now
                 continue
             else:
                 if item is _MODEL_DONE:
@@ -1285,9 +1296,11 @@ def _run_models(
                             "model_index": model_idx,
                         },
                     )
+                    last_packet_yield = time.monotonic()
                 elif isinstance(item, Packet):
                     # model_index already embedded by the model's Emitter in _run_model
                     yield item
+                    last_packet_yield = time.monotonic()
 
         # ── Completion: save each successful model's response ───────────────
         # All model loops have completed (run_llm_loop returned) — no more writes

--- a/backend/onyx/configs/chat_configs.py
+++ b/backend/onyx/configs/chat_configs.py
@@ -30,18 +30,16 @@ CONTEXT_CHUNKS_BELOW = int(os.environ.get("CONTEXT_CHUNKS_BELOW") or 1)
 LLM_SOCKET_READ_TIMEOUT = int(
     os.environ.get("LLM_SOCKET_READ_TIMEOUT") or "60"
 )  # 60 seconds
-# Interval between chat-level heartbeat packets emitted during long internal LLM
-# generations, to keep idle-proxy connections (nginx 300s, customer ALBs 60s) alive.
+# Max silent gap before the chat stream emits a keepalive packet; must stay below
+# the smallest proxy idle timeout in front (ALBs default to 60s).
 CHAT_HEARTBEAT_INTERVAL_S = int(os.environ.get("CHAT_HEARTBEAT_INTERVAL_S") or "15")
-# Max EXTRA attempts to re-issue a streaming completion when the provider raises a
-# timeout/connection error BEFORE any chunk has been yielded. Never retried once any
-# chunk is consumed downstream.
+# Extra attempts when a streaming completion errors before its first chunk.
+# Never retried after partial output.
 LLM_FIRST_CHUNK_MAX_RETRIES = max(
     0, int(os.environ.get("LLM_FIRST_CHUNK_MAX_RETRIES") or "2")
 )
-# Socket-read timeout (max gap between chunks) for deep-research report LLM calls.
-# 60s still permits arbitrarily long generations; combined with first-chunk retry a
-# zero-chunk stall costs <=60s per attempt instead of a fatal 300s.
+# Socket-read timeout for deep-research report calls — bounds inter-chunk gaps
+# (including a zero-chunk stall), not total generation time.
 DR_REPORT_LLM_TIMEOUT_S = int(os.environ.get("DR_REPORT_LLM_TIMEOUT_S") or "60")
 # Weighting factor between vector and keyword Search; 1 for completely vector
 # search, 0 for keyword. Enforces a valid range of [0, 1]. A supplied value from

--- a/backend/onyx/configs/chat_configs.py
+++ b/backend/onyx/configs/chat_configs.py
@@ -30,6 +30,17 @@ CONTEXT_CHUNKS_BELOW = int(os.environ.get("CONTEXT_CHUNKS_BELOW") or 1)
 LLM_SOCKET_READ_TIMEOUT = int(
     os.environ.get("LLM_SOCKET_READ_TIMEOUT") or "60"
 )  # 60 seconds
+# Interval between chat-level heartbeat packets emitted during long internal LLM
+# generations, to keep idle-proxy connections (nginx 300s, customer ALBs 60s) alive.
+CHAT_HEARTBEAT_INTERVAL_S = int(os.environ.get("CHAT_HEARTBEAT_INTERVAL_S") or "15")
+# Max EXTRA attempts to re-issue a streaming completion when the provider raises a
+# timeout/connection error BEFORE any chunk has been yielded. Never retried once any
+# chunk is consumed downstream.
+LLM_FIRST_CHUNK_MAX_RETRIES = int(os.environ.get("LLM_FIRST_CHUNK_MAX_RETRIES") or "2")
+# Socket-read timeout (max gap between chunks) for deep-research report LLM calls.
+# 60s still permits arbitrarily long generations; combined with first-chunk retry a
+# zero-chunk stall costs <=60s per attempt instead of a fatal 300s.
+DR_REPORT_LLM_TIMEOUT_S = int(os.environ.get("DR_REPORT_LLM_TIMEOUT_S") or "60")
 # Weighting factor between vector and keyword Search; 1 for completely vector
 # search, 0 for keyword. Enforces a valid range of [0, 1]. A supplied value from
 # the env outside of this range will be clipped to the respective end of the

--- a/backend/onyx/configs/chat_configs.py
+++ b/backend/onyx/configs/chat_configs.py
@@ -36,7 +36,9 @@ CHAT_HEARTBEAT_INTERVAL_S = int(os.environ.get("CHAT_HEARTBEAT_INTERVAL_S") or "
 # Max EXTRA attempts to re-issue a streaming completion when the provider raises a
 # timeout/connection error BEFORE any chunk has been yielded. Never retried once any
 # chunk is consumed downstream.
-LLM_FIRST_CHUNK_MAX_RETRIES = int(os.environ.get("LLM_FIRST_CHUNK_MAX_RETRIES") or "2")
+LLM_FIRST_CHUNK_MAX_RETRIES = max(
+    0, int(os.environ.get("LLM_FIRST_CHUNK_MAX_RETRIES") or "2")
+)
 # Socket-read timeout (max gap between chunks) for deep-research report LLM calls.
 # 60s still permits arbitrarily long generations; combined with first-chunk retry a
 # zero-chunk stall costs <=60s per attempt instead of a fatal 300s.

--- a/backend/onyx/deep_research/dr_loop.py
+++ b/backend/onyx/deep_research/dr_loop.py
@@ -18,6 +18,7 @@ from onyx.chat.models import ChatMessageSimple
 from onyx.chat.models import FileToolMetadata
 from onyx.chat.models import LlmStepResult
 from onyx.chat.models import ToolCallSimple
+from onyx.configs.chat_configs import DR_REPORT_LLM_TIMEOUT_S
 from onyx.configs.chat_configs import SKIP_DEEP_RESEARCH_CLARIFICATION
 from onyx.configs.constants import MessageType
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
@@ -163,7 +164,7 @@ def generate_final_report(
             max_tokens=MAX_FINAL_REPORT_TOKENS,
             is_deep_research=True,
             pre_answer_processing_time=pre_answer_processing_time,
-            timeout_override=300,  # 5 minute read timeout for long report generation
+            timeout_override=DR_REPORT_LLM_TIMEOUT_S,
         )
 
         # Save citation mapping to state_container so citations are persisted

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -917,8 +917,8 @@ class LitellmLLM(LLM):
             LiteLLMServiceUnavailableError,
             LiteLLMInternalServerError,
         )
-        max_attempts = 1 + LLM_FIRST_CHUNK_MAX_RETRIES
-        yielded_any = False
+        max_attempts: int = 1 + LLM_FIRST_CHUNK_MAX_RETRIES
+        yielded_any: bool = False
 
         # HTTPHandler Threading & Connection Pool Notes:
         # =============================================

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -11,6 +11,7 @@ from typing import Union
 
 from onyx.configs.app_configs import MOCK_LLM_RESPONSE
 from onyx.configs.app_configs import SEND_USER_METADATA_TO_LLM_PROVIDER
+from onyx.configs.chat_configs import LLM_FIRST_CHUNK_MAX_RETRIES
 from onyx.configs.chat_configs import LLM_SOCKET_READ_TIMEOUT
 from onyx.configs.model_configs import GEN_AI_TEMPERATURE
 from onyx.configs.model_configs import LITELLM_EXTRA_BODY
@@ -901,8 +902,23 @@ class LitellmLLM(LLM):
     ) -> Iterator[ModelResponseStream]:
         from litellm import CustomStreamWrapper as LiteLLMCustomStreamWrapper
         from litellm import HTTPHandler
+        from litellm.exceptions import APIConnectionError as LiteLLMAPIConnectionError
+        from litellm.exceptions import InternalServerError as LiteLLMInternalServerError
+        from litellm.exceptions import (
+            ServiceUnavailableError as LiteLLMServiceUnavailableError,
+        )
+        from litellm.exceptions import Timeout as LiteLLMTimeout
 
         from onyx.llm.model_response import from_litellm_model_response_stream
+
+        retryable_exceptions = (
+            LiteLLMTimeout,
+            LiteLLMAPIConnectionError,
+            LiteLLMServiceUnavailableError,
+            LiteLLMInternalServerError,
+        )
+        max_attempts = 1 + LLM_FIRST_CHUNK_MAX_RETRIES
+        yielded_any = False
 
         # HTTPHandler Threading & Connection Pool Notes:
         # =============================================
@@ -933,39 +949,52 @@ class LitellmLLM(LLM):
         #    - litellm's InMemoryCache (used for client caching) is NOT thread-safe
         #    - Shared pools can have connections corrupted by other threads
         #    - Per-request HTTPHandler eliminates cross-thread interference
-        client = None
-        if is_true_openai_model(self.config.model_provider, self.config.model_name):
-            client = HTTPHandler(timeout=timeout_override or self._timeout)
+        for attempt in range(max_attempts):
+            client = None
+            if is_true_openai_model(self.config.model_provider, self.config.model_name):
+                client = HTTPHandler(timeout=timeout_override or self._timeout)
 
-        try:
-            response = cast(
-                LiteLLMCustomStreamWrapper,
-                self._completion(
-                    prompt=prompt,
-                    tools=tools,
-                    tool_choice=tool_choice,
-                    stream=True,
-                    structured_response_format=structured_response_format,
-                    timeout_override=timeout_override,
-                    max_tokens=max_tokens,
-                    parallel_tool_calls=True,
-                    reasoning_effort=reasoning_effort,
-                    user_identity=user_identity,
-                    client=client,
-                ),
-            )
+            try:
+                response = cast(
+                    LiteLLMCustomStreamWrapper,
+                    self._completion(
+                        prompt=prompt,
+                        tools=tools,
+                        tool_choice=tool_choice,
+                        stream=True,
+                        structured_response_format=structured_response_format,
+                        timeout_override=timeout_override,
+                        max_tokens=max_tokens,
+                        parallel_tool_calls=True,
+                        reasoning_effort=reasoning_effort,
+                        user_identity=user_identity,
+                        client=client,
+                    ),
+                )
 
-            for chunk in response:
-                model_response = from_litellm_model_response_stream(chunk)
+                for chunk in response:
+                    model_response = from_litellm_model_response_stream(chunk)
 
-                # Track LLM cost when usage info is available (typically in the last chunk)
-                if model_response.usage:
-                    self._track_llm_cost(model_response.usage)
+                    # Track LLM cost when usage info is available (typically in the last chunk)
+                    if model_response.usage:
+                        self._track_llm_cost(model_response.usage)
 
-                yield model_response
-        finally:
-            if client is not None:
-                client.close()
+                    yielded_any = True
+                    yield model_response
+                return
+            except retryable_exceptions as e:
+                if yielded_any or attempt >= max_attempts - 1:
+                    raise
+                logger.warning(
+                    "Retrying pre-chunk stream for model %s after %s on attempt %d/%d",
+                    self.config.model_name,
+                    type(e).__name__,
+                    attempt + 1,
+                    max_attempts,
+                )
+            finally:
+                if client is not None:
+                    client.close()
 
 
 @contextmanager

--- a/backend/onyx/server/query_and_chat/streaming_models.py
+++ b/backend/onyx/server/query_and_chat/streaming_models.py
@@ -18,6 +18,7 @@ class StreamingType(Enum):
     STOP = "stop"
     TOP_LEVEL_BRANCHING = "top_level_branching"
     ERROR = "error"
+    CHAT_HEARTBEAT = "chat_heartbeat"
 
     MESSAGE_START = "message_start"
     MESSAGE_DELTA = "message_delta"
@@ -93,6 +94,12 @@ class PacketException(BaseObj):
 
     exception: Exception = Field(exclude=True)
     model_config = {"arbitrary_types_allowed": True}
+
+
+# Generic chat-level heartbeat: emitted during long internal LLM generations
+# to keep the SSE connection alive past idle-proxy timeouts. Carries no payload.
+class ChatHeartbeat(BaseObj):
+    type: Literal["chat_heartbeat"] = StreamingType.CHAT_HEARTBEAT.value
 
 
 ################################################
@@ -421,6 +428,7 @@ PacketObj = Union[
     SectionEnd,
     TopLevelBranching,
     PacketException,
+    ChatHeartbeat,
     # Agent Response Packets
     AgentResponseStart,
     AgentResponseDelta,

--- a/backend/onyx/server/query_and_chat/streaming_models.py
+++ b/backend/onyx/server/query_and_chat/streaming_models.py
@@ -96,8 +96,7 @@ class PacketException(BaseObj):
     model_config = {"arbitrary_types_allowed": True}
 
 
-# Generic chat-level heartbeat: emitted during long internal LLM generations
-# to keep the SSE connection alive past idle-proxy timeouts. Carries no payload.
+# Payload-less keepalive so idle proxies don't kill an otherwise-silent stream
 class ChatHeartbeat(BaseObj):
     type: Literal["chat_heartbeat"] = StreamingType.CHAT_HEARTBEAT.value
 

--- a/backend/onyx/tools/fake_tools/research_agent.py
+++ b/backend/onyx/tools/fake_tools/research_agent.py
@@ -18,6 +18,7 @@ from onyx.chat.llm_step import run_llm_step_pkt_generator
 from onyx.chat.models import ChatMessageSimple
 from onyx.chat.models import LlmStepResult
 from onyx.chat.models import ToolCallSimple
+from onyx.configs.chat_configs import DR_REPORT_LLM_TIMEOUT_S
 from onyx.configs.constants import MessageType
 from onyx.context.search.models import SearchDocsResponse
 from onyx.deep_research.dr_mock_tools import (
@@ -139,7 +140,7 @@ def generate_intermediate_report(
             max_tokens=MAX_INTERMEDIATE_REPORT_LENGTH_TOKENS,
             use_existing_tab_index=True,
             is_deep_research=True,
-            timeout_override=300,  # 5 minute read timeout for long report generation
+            timeout_override=DR_REPORT_LLM_TIMEOUT_S,
         )
 
         while True:

--- a/backend/tests/unit/onyx/chat/test_multi_model_streaming.py
+++ b/backend/tests/unit/onyx/chat/test_multi_model_streaming.py
@@ -21,6 +21,7 @@ from onyx.db.chat import set_preferred_response
 from onyx.llm.override_models import LLMOverride
 from onyx.server.query_and_chat.models import SendMessageRequest
 from onyx.server.query_and_chat.placement import Placement
+from onyx.server.query_and_chat.streaming_models import ChatHeartbeat
 from onyx.server.query_and_chat.streaming_models import OverallStop
 from onyx.server.query_and_chat.streaming_models import Packet
 from onyx.server.query_and_chat.streaming_models import ReasoningStart
@@ -317,6 +318,38 @@ class TestRunModels:
         stop_obj = stops[0].obj
         assert isinstance(stop_obj, OverallStop)
         assert stop_obj.stop_reason == "complete"
+
+    def test_idle_gap_emits_chat_heartbeat(self) -> None:
+        """Idle gaps in the drain loop emit ChatHeartbeat packets."""
+
+        def sleep_then_return(**_kwargs: Any) -> None:
+            time.sleep(0.2)
+
+        with (
+            patch(
+                "onyx.chat.process_message.CHAT_HEARTBEAT_INTERVAL_S",
+                0.05,
+            ),
+            patch(
+                "onyx.chat.process_message.run_llm_loop",
+                side_effect=sleep_then_return,
+            ),
+            patch("onyx.chat.process_message.run_deep_research_llm_loop"),
+            patch("onyx.chat.process_message.construct_tools", return_value={}),
+            patch("onyx.chat.process_message.llm_loop_completion_handle"),
+            patch(
+                "onyx.chat.process_message.get_llm_token_counter",
+                return_value=lambda _: 0,
+            ),
+        ):
+            packets = _run_models_collect(_make_setup(n_models=1))
+
+        heartbeats = [
+            p
+            for p in packets
+            if isinstance(p, Packet) and isinstance(p.obj, ChatHeartbeat)
+        ]
+        assert heartbeats
 
     def test_n1_emitted_packet_has_model_index_zero(self) -> None:
         """Single-model path: model_index is 0 (Emitter defaults model_idx=0)."""

--- a/backend/tests/unit/onyx/llm/test_multi_llm_stream_retry.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm_stream_retry.py
@@ -1,0 +1,93 @@
+from collections.abc import Iterator
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from litellm.exceptions import Timeout as LiteLLMTimeout
+
+from onyx.llm.interfaces import LanguageModelInput
+from onyx.llm.model_response import Delta
+from onyx.llm.model_response import ModelResponseStream
+from onyx.llm.model_response import StreamingChoice
+from onyx.llm.models import UserMessage
+from onyx.llm.multi_llm import LitellmLLM
+
+
+def _make_fake_llm() -> MagicMock:
+    llm = MagicMock()
+    llm.config.model_name = "gpt-test"
+    llm.config.model_provider = "openai"
+    llm._timeout = 30
+    llm._track_llm_cost = MagicMock()
+    return llm
+
+
+def _make_prompt() -> LanguageModelInput:
+    return [UserMessage(content="hello")]
+
+
+def _make_stream_response(content: str) -> ModelResponseStream:
+    return ModelResponseStream(
+        id="chunk-1",
+        created="1",
+        choice=StreamingChoice(delta=Delta(content=content)),
+    )
+
+
+def test_stream_retries_timeout_before_first_chunk() -> None:
+    fake_llm = _make_fake_llm()
+    translated_chunk = _make_stream_response("hello")
+    attempt_count = 0
+
+    def completion_side_effect(**_kwargs: object) -> list[object]:
+        nonlocal attempt_count
+        attempt_count += 1
+        if attempt_count == 1:
+            raise LiteLLMTimeout("timed out", "gpt-test", "openai")
+        return [object()]
+
+    fake_llm._completion = MagicMock(side_effect=completion_side_effect)
+
+    with (
+        patch("onyx.llm.multi_llm.LLM_FIRST_CHUNK_MAX_RETRIES", 1),
+        patch("onyx.llm.multi_llm.is_true_openai_model", return_value=False),
+        patch(
+            "onyx.llm.model_response.from_litellm_model_response_stream",
+            return_value=translated_chunk,
+        ),
+        patch("onyx.llm.multi_llm.logger") as mock_logger,
+    ):
+        # Bind the unbound method to a fake self to isolate retry behavior.
+        results = list(LitellmLLM.stream(fake_llm, prompt=_make_prompt()))
+
+    assert len(results) == 1
+    assert results[0].choice.delta.content == "hello"
+    assert fake_llm._completion.call_count == 2
+    mock_logger.warning.assert_called_once()
+
+
+def test_stream_does_not_retry_after_first_chunk() -> None:
+    fake_llm = _make_fake_llm()
+    translated_chunk = _make_stream_response("partial")
+
+    def stream_then_timeout() -> Iterator[object]:
+        yield object()
+        raise LiteLLMTimeout("timed out", "gpt-test", "openai")
+
+    fake_llm._completion = MagicMock(return_value=stream_then_timeout())
+
+    with (
+        patch("onyx.llm.multi_llm.LLM_FIRST_CHUNK_MAX_RETRIES", 2),
+        patch("onyx.llm.multi_llm.is_true_openai_model", return_value=False),
+        patch(
+            "onyx.llm.model_response.from_litellm_model_response_stream",
+            return_value=translated_chunk,
+        ),
+        patch("onyx.llm.multi_llm.logger") as mock_logger,
+    ):
+        # Bind the unbound method to a fake self to isolate retry behavior.
+        with pytest.raises(LiteLLMTimeout):
+            list(LitellmLLM.stream(fake_llm, prompt=_make_prompt()))
+
+    assert fake_llm._completion.call_count == 1
+    mock_logger.warning.assert_not_called()


### PR DESCRIPTION
## Description

**Bug:** Deep research / chat streams die with a generic error. The SSE stream is legally byte-silent for minutes during internal report generations; idle proxies kill the connection (cloud nginx 300s, customer ALBs 60s) and the run dies with it. Separately, report LLM calls can stall at zero chunks for 300s with no retry — and `timeout_override=300` exactly equals the cloud nginx timeout, so the app always loses the race.

**Fix:**
- Emit a `chat_heartbeat` packet from the `_run_models` drain loop when no real packet has flowed for `CHAT_HEARTBEAT_INTERVAL_S` (default 15s)
- Retry streaming completions on provider timeout/connection errors that occur **before the first chunk** (`LLM_FIRST_CHUNK_MAX_RETRIES`, default 2); never retry after partial output
- DR report `timeout_override` 300s → `DR_REPORT_LLM_TIMEOUT_S` (default 60s) — read timeout only bounds inter-chunk gaps, so long generations are unaffected

Root cause + fix tracker (fixes #3 and #4): [Deep Research Instability — Fix Tracker](https://dev-wiki.onyx.app/app/wiki/Engineering%20Projects/Onyx%20Projects/Deep%20Research/dr_instability_fixes.md)

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check