### PR TITLE
feat(craft): movable craft-edge (tracks main) + ad-hoc craft-dev tag

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -35,7 +35,8 @@ jobs:
       is-beta-standalone: ${{ steps.check.outputs.is-beta-standalone }}
       is-stable: ${{ steps.check.outputs.is-stable }}
       is-latest: ${{ steps.check.outputs.is-latest }}
-      is-experimental-cc4a: ${{ steps.check.outputs.is-experimental-cc4a }}
+      is-craft-edge: ${{ steps.check.outputs.is-craft-edge }}
+      is-craft-dev: ${{ steps.check.outputs.is-craft-dev }}
       is-test-run: ${{ steps.check.outputs.is-test-run }}
       sanitized-tag: ${{ steps.check.outputs.sanitized-tag }}
       short-sha: ${{ steps.check.outputs.short-sha }}
@@ -73,7 +74,8 @@ jobs:
           IS_BETA_STANDALONE=false
           IS_LATEST=false
           IS_PROD_TAG=false
-          IS_EXPERIMENTAL_CC4A=false
+          IS_CRAFT_EDGE=false
+          IS_CRAFT_DEV=false
           IS_TEST_RUN=false
           BUILD_DESKTOP=false
           BUILD_WEB=false
@@ -98,15 +100,23 @@ jobs:
           if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-beta(\.[0-9]+)?$ ]]; then
             IS_BETA=true
           fi
-          if [[ "$TAG" == experimental-cc4a.* ]]; then
-            IS_EXPERIMENTAL_CC4A=true
+          # craft-edge: shared rolling channel (full stack, auto-moved to main).
+          # craft-dev: ad-hoc branch test.
+          if [[ "$TAG" == "craft-edge" ]]; then
+            IS_CRAFT_EDGE=true
+          fi
+          if [[ "$TAG" == "craft-dev" ]]; then
+            IS_CRAFT_DEV=true
           fi
 
           # Determine what to build based on tag type
-          if [[ "$IS_EXPERIMENTAL_CC4A" == "true" ]]; then
-            # experimental-cc4a tags: craft backend + web + model-server, no regular backend
+          if [[ "$IS_CRAFT_EDGE" == "true" ]] || [[ "$IS_CRAFT_DEV" == "true" ]]; then
             BUILD_BACKEND=false
             BUILD_WEB=true
+            # craft-dev: backend + web + sandbox only; model-server isn't craft-specific.
+            if [[ "$IS_CRAFT_DEV" == "true" ]]; then
+              BUILD_MODEL_SERVER=false
+            fi
           elif [[ "$IS_CLOUD" == "true" ]]; then
             BUILD_WEB_CLOUD=true
           else
@@ -134,9 +144,8 @@ jobs:
             fi
           fi
 
-          # Build craft backend for stable releases (tagged craft-latest) and
-          # experimental cc4a tags (tagged craft-edge for dev clusters).
-          if [[ "$IS_LATEST" == "true" ]] || [[ "$IS_EXPERIMENTAL_CC4A" == "true" ]]; then
+          # Build craft backend for stable releases, craft-edge, and craft-dev.
+          if [[ "$IS_LATEST" == "true" ]] || [[ "$IS_CRAFT_EDGE" == "true" ]] || [[ "$IS_CRAFT_DEV" == "true" ]]; then
             BUILD_BACKEND_CRAFT=true
           fi
 
@@ -162,7 +171,8 @@ jobs:
             echo "is-beta-standalone=$IS_BETA_STANDALONE"
             echo "is-stable=$IS_STABLE"
             echo "is-latest=$IS_LATEST"
-            echo "is-experimental-cc4a=$IS_EXPERIMENTAL_CC4A"
+            echo "is-craft-edge=$IS_CRAFT_EDGE"
+            echo "is-craft-dev=$IS_CRAFT_DEV"
             echo "is-test-run=$IS_TEST_RUN"
             echo "sanitized-tag=$SANITIZED_TAG"
             echo "short-sha=$SHORT_SHA"
@@ -171,7 +181,7 @@ jobs:
   check-version-tag:
     runs-on: ubuntu-slim
     timeout-minutes: 10
-    if: ${{ !startsWith(github.ref_name, 'nightly-latest') && !startsWith(github.ref_name, 'experimental-') && github.ref_name != 'edge' && github.event_name != 'workflow_dispatch' }}
+    if: ${{ !startsWith(github.ref_name, 'nightly-latest') && github.ref_name != 'craft-edge' && github.ref_name != 'craft-dev' && github.ref_name != 'edge' && github.event_name != 'workflow_dispatch' }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
@@ -627,7 +637,8 @@ jobs:
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run == 'true' && format('web-{0}', needs.determine-builds.outputs.sanitized-tag) || github.ref_name }}
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-latest == 'true' && 'latest' || '' }}
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-latest == 'true' && 'craft-latest' || '' }}
-            type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-experimental-cc4a == 'true' && 'craft-edge' || '' }}
+            type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-craft-edge == 'true' && 'craft-edge' || '' }}
+            type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-craft-dev == 'true' && 'craft-dev' || '' }}
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && env.EDGE_TAG == 'true' && 'edge' || '' }}
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-beta == 'true' && 'beta' || '' }}
             type=semver,pattern={{version}},enable=${{ needs.determine-builds.outputs.is-stable == 'true' }}
@@ -1265,8 +1276,7 @@ jobs:
           flavor: |
             latest=false
           tags: |
-            type=raw,value=${{ needs.determine-builds.outputs.is-experimental-cc4a == 'true' && 'craft-edge' || 'craft-latest' }}
-            type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-experimental-cc4a == 'true' && github.ref_name || '' }}
+            type=raw,value=${{ needs.determine-builds.outputs.is-craft-dev == 'true' && 'craft-dev' || (needs.determine-builds.outputs.is-craft-edge == 'true' && 'craft-edge' || 'craft-latest') }}
 
       - name: Create and push manifest
         env:
@@ -1485,7 +1495,7 @@ jobs:
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run == 'true' && format('model-server-{0}', needs.determine-builds.outputs.sanitized-tag) || github.ref_name }}
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-latest == 'true' && 'latest' || '' }}
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-latest == 'true' && 'craft-latest' || '' }}
-            type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-experimental-cc4a == 'true' && 'craft-edge' || '' }}
+            type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-craft-edge == 'true' && 'craft-edge' || '' }}
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && env.EDGE_TAG == 'true' && 'edge' || '' }}
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-beta-standalone == 'true' && 'beta' || '' }}
             type=semver,pattern={{version}},enable=${{ needs.determine-builds.outputs.is-stable == 'true' }}

--- a/.github/workflows/sandbox-deployment.yml
+++ b/.github/workflows/sandbox-deployment.yml
@@ -3,7 +3,9 @@ name: Build and Push Sandbox Image on Tag
 on:
   push:
     tags:
-      - "experimental-cc4a.*"
+      # craft-edge: shared, versioned + latest. craft-dev: ad-hoc, tagged craft-dev only.
+      - "craft-edge"
+      - "craft-dev"
 
 # Restrictive defaults; jobs declare what they need.
 permissions: {}
@@ -26,38 +28,40 @@ jobs:
 
       - name: Check for sandbox-relevant file changes
         id: check
+        env:
+          # movable tag: github.event.before = commit it previously pointed at
+          BEFORE_SHA: ${{ github.event.before }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          # Get the previous tag to diff against
-          CURRENT_TAG="${GITHUB_REF_NAME}"
-          PREVIOUS_TAG=$(git tag --sort=-creatordate | grep '^experimental-cc4a\.' | grep -v "^${CURRENT_TAG}$" | head -n 1)
-
-          if [ -z "$PREVIOUS_TAG" ]; then
-            echo "No previous experimental-cc4a tag found, building unconditionally"
+          # craft-dev: always build (prior position is unrelated)
+          if [ "$REF_NAME" = "craft-dev" ]; then
+            echo "craft-dev tag: building sandbox unconditionally"
             echo "sandbox-changed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          echo "Comparing ${PREVIOUS_TAG}..${CURRENT_TAG}"
+          ZERO_SHA="0000000000000000000000000000000000000000"
+          if [ -z "$BEFORE_SHA" ] || [ "$BEFORE_SHA" = "$ZERO_SHA" ] || ! git cat-file -e "${BEFORE_SHA}^{commit}" 2>/dev/null; then
+            echo "No usable previous craft-edge commit; building unconditionally"
+            echo "sandbox-changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
-          # Check if any sandbox-relevant files changed
-          SANDBOX_PATHS=(
-            "backend/onyx/server/features/build/sandbox/"
-          )
-
-          CHANGED=false
-          for path in "${SANDBOX_PATHS[@]}"; do
-            if git diff --name-only "${PREVIOUS_TAG}..${CURRENT_TAG}" -- "$path" | grep -q .; then
-              echo "Changes detected in: $path"
-              CHANGED=true
-              break
-            fi
-          done
-
-          echo "sandbox-changed=$CHANGED" >> "$GITHUB_OUTPUT"
+          echo "Comparing ${BEFORE_SHA}..${GITHUB_SHA}"
+          # diff only the image build context (rest of sandbox/ ships in the backend)
+          if git diff --name-only "${BEFORE_SHA}..${GITHUB_SHA}" -- \
+              "backend/onyx/server/features/build/sandbox/image/" | grep -q .; then
+            echo "Sandbox image changes detected"
+            echo "sandbox-changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No sandbox-relevant changes"
+            echo "sandbox-changed=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Determine new sandbox version
         id: version
-        if: steps.check.outputs.sandbox-changed == 'true'
+        # only craft-edge is versioned; craft-dev never bumps the version
+        if: steps.check.outputs.sandbox-changed == 'true' && github.ref_name == 'craft-edge'
         run: |
           # Query Docker Hub for the latest versioned tag
           LATEST_TAG=$(curl -s "https://hub.docker.com/v2/repositories/onyxdotapp/sandbox/tags?page_size=100" \
@@ -274,8 +278,9 @@ jobs:
           flavor: |
             latest=false
           tags: |
-            type=raw,value=v${{ needs.check-sandbox-changes.outputs.new-version }}
-            type=raw,value=latest
+            type=raw,value=${{ github.ref_name == 'craft-edge' && format('v{0}', needs.check-sandbox-changes.outputs.new-version) || '' }}
+            type=raw,value=${{ github.ref_name == 'craft-edge' && 'latest' || '' }}
+            type=raw,value=${{ github.ref_name == 'craft-dev' && 'craft-dev' || '' }}
 
       - name: Create and push manifest
         env:

--- a/.github/workflows/tag-nightly.yml
+++ b/.github/workflows/tag-nightly.yml
@@ -56,6 +56,13 @@ jobs:
           TAG_NAME="nightly-latest-$(date +'%Y%m%d')"
           git push origin $TAG_NAME
 
+      # Move craft-edge to current main so the craft dev cluster tracks main.
+      # Force-push (movable tag); DEPLOY_KEY lets it trigger the build workflows.
+      - name: Move craft-edge tag to latest main
+        run: |
+          git tag -f craft-edge
+          git push -f origin craft-edge
+
       - name: Send Slack notification
         if: failure()
         uses: ./.github/actions/slack-notify


### PR DESCRIPTION
## Description

Reworks the Craft image-build triggers so the shared dev channel and an ad-hoc testing tag no longer collide. **Pure CI / tagging machinery — safe to merge now** (no dependency on a `craft-latest` release). The `install.sh` default flip to `craft-latest` + the user-facing docs are in the follow-up #11874 (gated on v4.1.0).

### What changed

- **`deployment.yml` + `sandbox-deployment.yml`** — replace the incrementing `experimental-cc4a.*` trigger with a movable **`craft-edge`** tag, and add a movable **`craft-dev`** tag for testing an arbitrary (possibly unmerged) branch.
- **`tag-nightly.yml`** — force-move `craft-edge` to the latest `main` each night so the shared Craft dev cluster (pinned to `craft-edge`) tracks `main`.
- **Sandbox change-detection** — diffs `github.event.before` (correct for a movable tag), scoped to the sandbox **image build context** (`sandbox/image/`), so a new sandbox `vX.Y.Z` is cut only when the image actually changes.

### Tag model

| Git tag | Builds | Image tag | Moved by |
|---|---|---|---|
| `craft-edge` | full stack: backend-craft + web + model-server + sandbox | `craft-edge` (sandbox: `vX.Y.Z`+`latest` on change) | nightly → `main` |
| `craft-dev` | craft-specific only: backend-craft + web + sandbox | `craft-dev` | you, manually |

Only the **backend** (built with `ENABLE_CRAFT`) is genuinely craft-specific; web ships the craft UI. model-server isn't craft-specific, so `craft-dev` skips it — the craft-dev cluster pins backend/web/sandbox per-component to `craft-dev` and leaves model-server on a regular tag. `craft-edge` still builds the full stack so `global.version=craft-edge` pins everything for the shared cluster.

```bash
# Test a branch on the craft-dev cluster:
git tag -f craft-dev <commit> && git push -f origin craft-dev
# → onyx-backend:craft-dev, onyx-web-server:craft-dev, sandbox:craft-dev
# then: helm upgrade (backend/web tag=craft-dev, SANDBOX_CONTAINER_IMAGE=onyxdotapp/sandbox:craft-dev)
```

## How Has This Been Tested?

- `pre-commit` (zizmor, actionlint, YAML check) passes on all changed workflows.
- Verified no remaining `experimental-cc4a` references and that all renamed job/output references are internally consistent.
- CI-only change; no application code paths touched.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check
