### PR TITLE
feat(craft): default self-hosting to craft-latest + document channels (gated on v4.1.0)

### DIFF
--- a/deployment/docker_compose/install.sh
+++ b/deployment/docker_compose/install.sh
@@ -996,8 +996,8 @@ if [ -f "$ENV_FILE" ]; then
             # --include-craft requires the craft-tagged backend image (Node.js
             # + opencode CLI are only built into that image), so the tag is
             # forced rather than prompted for.
-            VERSION="craft-edge"
-            print_info "Update selected. Using craft-edge (required by --include-craft)."
+            VERSION="craft-latest"
+            print_info "Update selected. Using craft-latest (required by --include-craft)."
         else
             print_info "Update selected. Which tag would you like to deploy?"
             echo ""
@@ -1052,8 +1052,8 @@ else
     # Ask for version (skipped when --include-craft forces the craft-tagged
     # backend image, which is the only image that ships Node.js + opencode CLI).
     if [ "$INCLUDE_CRAFT" = true ]; then
-        VERSION="craft-edge"
-        print_info "Using craft-edge (required by --include-craft)."
+        VERSION="craft-latest"
+        print_info "Using craft-latest (required by --include-craft)."
     else
         print_info "Which tag would you like to deploy?"
         echo ""

--- a/docs/craft/docker/docker-compose-overview.md
+++ b/docs/craft/docker/docker-compose-overview.md
@@ -72,7 +72,7 @@ These must end up in `~/onyx_data/deployment/.env` after install:
 | `SANDBOX_BACKEND=docker` | yes | Same as above — install script gates on fresh-install. |
 | `SANDBOX_API_SERVER_URL=http://host.docker.internal:3001` | yes | Provision raises `ValueError("SANDBOX_API_SERVER_URL must be set")` without it. Must be a URL the sandbox container can reach **from the `onyx_craft_sandbox` bridge** — compose-internal hostnames (`api_server`, `nginx`) won't resolve there. Match the port to `HOST_PORT`. |
 | `HOST_PORT=3001` | only if 3000 conflicts | Default is 3000; nginx binds this on the host. Free up 3000 or change here. |
-| `IMAGE_TAG=craft-edge` | yes | `craft-latest` lags `main` by weeks and predates the Docker sandbox backend (see [image staleness](#image-staleness--published-tags-lag-main) below). Use `craft-edge`. |
+| `IMAGE_TAG=craft-latest` | yes | Two Craft channels exist: **`craft-latest`** is the latest stable Craft release — recommended for self-hosting. **`craft-edge`** is the rolling dev build from `main` — newest Craft features, but may be unstable. See [image channels](#image-staleness--published-tags-lag-main) below. |
 | `ONYX_BACKEND_IMAGE` | only when running unreleased PRs | Lets you override just the backend image without forcing model-server / web-server to the same tag. |
 | `SANDBOX_CONTAINER_IMAGE` | only when running unreleased PRs | Same idea for the sandbox image itself. Default is a pinned tag like `onyxdotapp/sandbox:v0.1.44`. |
 | `AGENT_TRANSPORT=serve` | for serve transport | `docker-compose.craft.yml` defaults this to `serve` (post-#11402); override to `acp` for the rollback path. Reaches the sandbox container via env passthrough. |
@@ -132,7 +132,7 @@ ENABLE_CRAFT=true
 SANDBOX_BACKEND=docker
 SANDBOX_API_SERVER_URL=http://host.docker.internal:3001
 HOST_PORT=3001
-IMAGE_TAG=craft-edge
+IMAGE_TAG=craft-latest
 ENV
 ```
 
@@ -217,13 +217,25 @@ is a backend-only override.
 ### Sandbox image
 
 The sandbox container has its own image (`onyxdotapp/sandbox:vX.Y.Z`)
-pinned in compose. The published version lags `main` substantially —
-e.g. `v0.1.44` ships an old `entrypoint.sh` that does `sleep infinity` and
-has no `AGENT_TRANSPORT=serve` gate, so the serve transport will time
-out waiting for opencode-serve on :4096 even though your api_server side
-is correct.
+pinned in compose. It is **decoupled from the backend channel** — the
+default `SANDBOX_CONTAINER_IMAGE` is a fixed `vX.Y.Z` regardless of whether
+the backend is `craft-latest` / `craft-edge` / `craft-dev`. The published
+version lags `main` substantially — e.g. `v0.1.44` ships an old
+`entrypoint.sh` that does `sleep infinity` and has no `AGENT_TRANSPORT=serve`
+gate, so the serve transport will time out waiting for opencode-serve on
+:4096 even though your api_server side is correct.
 
-Build the sandbox image:
+To pick up sandbox changes you either build the image locally (below) or
+push the `craft-dev` git tag — CI builds and publishes
+`onyxdotapp/sandbox:craft-dev` (alongside the rest of the craft stack at
+`:craft-dev`). Either way you must point `SANDBOX_CONTAINER_IMAGE` at it;
+it is never selected automatically. For the CI route:
+
+```
+SANDBOX_CONTAINER_IMAGE=onyxdotapp/sandbox:craft-dev
+```
+
+Build the sandbox image locally instead:
 
 ```bash
 docker build --network=host \
@@ -375,16 +387,30 @@ environment:
 
 ### Image staleness: published tags lag main
 
-Symptom A: api_server crashes on boot with
-`ValueError: 'docker' is not a valid SandboxBackend`. Cause: the
-`craft-latest` tag is built off a release (e.g. `v4.0.0`) that predates
-the Docker sandbox backend (PR #11222, May 20). The `SandboxBackend`
-enum in that image only has `LOCAL` and `KUBERNETES`.
+The Craft image channels:
 
-Fix: switch to `craft-edge` (rolling tag built from `main`):
+- **`craft-latest`** — the latest stable Craft release. Recommended for
+  self-hosting.
+- **`craft-edge`** — rolling dev build that tracks `main` (auto-moved
+  nightly). Has the newest merged Craft code, but may be unstable.
+- **`craft-dev`** — ad-hoc build for testing an arbitrary (possibly
+  unmerged) branch. Built only when someone force-pushes the `craft-dev`
+  git tag. Builds the craft-specific images — `onyx-backend`, `onyx-web-server`,
+  and the sandbox — all tagged `craft-dev` only (model-server isn't craft-specific
+  and is skipped). Pin those per-component on the craft-dev cluster
+  (`SANDBOX_CONTAINER_IMAGE=onyxdotapp/sandbox:craft-dev`) and `helm upgrade`;
+  it never touches the shared `craft-edge` / `latest` channels.
+
+Symptom A: api_server crashes on boot with
+`ValueError: 'docker' is not a valid SandboxBackend`. Cause: a **stale
+cached** `craft-latest` image from before the Docker sandbox backend
+shipped (PR #11222, May 20) — the `SandboxBackend` enum in that old image
+only has `LOCAL` and `KUBERNETES`. Current `craft-latest` includes it.
+
+Fix: pull the current image, or switch to `craft-edge` for the newest code:
 
 ```
-IMAGE_TAG=craft-edge
+docker compose -f docker-compose.yml -f docker-compose.craft.yml pull
 ```
 
 Symptom B: `craft-edge` works for the Docker backend but is missing PR

--- a/docs/craft/kubernetes/craft-eks-runbook.md
+++ b/docs/craft/kubernetes/craft-eks-runbook.md
@@ -224,9 +224,11 @@ Point at the terraform endpoints; disable in-cluster deps:
 - Craft: `ENABLE_CRAFT=true`, `SANDBOX_API_SERVER_URL=http://onyx-api-service.onyx.svc.cluster.local:8080`, `SANDBOX_S3_BUCKET`, `auth.sandboxPushSecret.enabled=true`. (`SANDBOX_SERVICE_ACCOUNT_NAME`/`SANDBOX_CONTAINER_IMAGE` default correctly.)
 
 ### Images
-`global.version: craft-edge` (backend/web/model-server — the moving Craft build; stable v4.0.x has no
-Craft). `code-interpreter`: `latest` (no craft-edge tag). Sandbox image default tracks the current
-`onyxdotapp/sandbox:vX.Y.Z`.
+`global.version: craft-edge` (backend/web/model-server — the rolling Craft dev build that tracks `main`,
+auto-moved nightly; newest Craft, may be unstable. `craft-latest` is the latest stable Craft release —
+use it for a stable deploy. `craft-dev` is an ad-hoc tag for testing an unmerged branch without
+disturbing `craft-edge`). `code-interpreter`: `latest` (no craft-edge tag). Sandbox image default
+tracks the current `onyxdotapp/sandbox:vX.Y.Z`.
 
 ---
 


### PR DESCRIPTION
## Description

> [!WARNING]
> **Do not merge until v4.1.0 is released.** v4.1.0 is the first stable release to include the Docker sandbox backend. Until then `craft-latest` points at v4.0.x, which lacks it — defaulting self-hosters to `craft-latest` before v4.1.0 would break Craft.

Makes `craft-latest` the recommended stable Craft channel for self-hosting, and documents the Craft image channels. **Depends on the machinery PR (#11873)** for the `craft-edge` / `craft-dev` tags the docs reference.

### Craft image channels (documented here)

| Tag | Meaning |
|---|---|
| **`craft-latest`** | Latest **stable** Craft release. Recommended for self-hosting. |
| **`craft-edge`** | Rolling dev build that tracks `main`. Newest merged Craft, may be unstable. |
| **`craft-dev`** | Ad-hoc build for testing an arbitrary (possibly unmerged) branch. |

### Changes
- **`deployment/docker_compose/install.sh`** — `--include-craft` defaults to `craft-latest` (matches `install.ps1`).
- **`docs/craft/docker/docker-compose-overview.md`**, **`docs/craft/kubernetes/craft-eks-runbook.md`** — document the three channels, recommend `craft-latest` for self-hosting, and document selecting the `craft-dev` sandbox via `SANDBOX_CONTAINER_IMAGE`.

## How Has This Been Tested?

- `pre-commit` (shellcheck, ripsecrets) passes on `install.sh`.
- Docs-only otherwise; no code paths touched.
- Verified `craft-latest` currently resolves to v4.0.7 (no Docker backend) — hence the v4.1.0 merge gate.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defaults self-hosted installs to the stable `craft-latest` channel and updates docs to explain Craft image channels and how to use `craft-dev` for sandbox testing. Merge only after v4.1.0, the first stable release with the Docker sandbox backend.

- **New Features**
  - `deployment/docker_compose/install.sh`: `--include-craft` now forces `craft-latest` (matches `install.ps1`).
  - Docs: define `craft-latest` (stable), `craft-edge` (rolling), and `craft-dev` (ad-hoc). Recommend `craft-latest` for self-hosting. Clarify the sandbox image is decoupled from backend channels and show how to target `onyxdotapp/sandbox:craft-dev` via `SANDBOX_CONTAINER_IMAGE` (or build locally). Add EKS notes and update staleness guidance.

- **Migration**
  - Do not merge until v4.1.0 ships; earlier `craft-latest` (v4.0.x) lacks the Docker sandbox backend.
  - For newest code, set `IMAGE_TAG=craft-edge`.
  - To test sandbox changes, set `SANDBOX_CONTAINER_IMAGE=onyxdotapp/sandbox:craft-dev` or build locally.

<sup>Written for commit a3fd0c458023a73b875534b2686c95c7e1b96a6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11874?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

