### PR TITLE
fix(logging): suppress noisy dependency logs

### DIFF
--- a/backend/onyx/background/celery/apps/app_base.py
+++ b/backend/onyx/background/celery/apps/app_base.py
@@ -49,6 +49,7 @@ from onyx.redis.redis_pool import get_redis_client
 from onyx.redis.redis_usergroup import RedisUserGroup
 from onyx.tracing.setup import setup_tracing
 from onyx.utils.logger import ColoredFormatter
+from onyx.utils.logger import configure_noisy_dependency_loggers
 from onyx.utils.logger import get_json_formatter
 from onyx.utils.logger import get_log_level_from_str
 from onyx.utils.logger import LoggerContextVars
@@ -527,6 +528,7 @@ def on_setup_logging(
         root_logger.addHandler(root_file_handler)
 
     root_logger.setLevel(effective_loglevel)
+    configure_noisy_dependency_loggers()
 
     # Emit the diagnostic after the root logger is configured so it goes through
     # the fresh handler at the level we just chose. (Before this point Python's

--- a/backend/onyx/background/celery/apps/app_base.py
+++ b/backend/onyx/background/celery/apps/app_base.py
@@ -528,7 +528,7 @@ def on_setup_logging(
         root_logger.addHandler(root_file_handler)
 
     root_logger.setLevel(effective_loglevel)
-    configure_noisy_dependency_loggers()
+    configure_noisy_dependency_loggers(max(logging.WARNING, effective_loglevel))
 
     # Emit the diagnostic after the root logger is configured so it goes through
     # the fresh handler at the level we just chose. (Before this point Python's

--- a/backend/onyx/utils/logger.py
+++ b/backend/onyx/utils/logger.py
@@ -292,13 +292,13 @@ def setup_logger(
     extra: MutableMapping[str, Any] | None = None,
     propagate: bool = True,
 ) -> OnyxLoggingAdapter:
-    configure_noisy_dependency_loggers()
-
     logger = logging.getLogger(name)
 
     # If the logger already has handlers, assume it was already configured and return it.
     if logger.handlers:
         return OnyxLoggingAdapter(logger, extra=extra)
+
+    configure_noisy_dependency_loggers(max(logging.WARNING, log_level))
 
     logger.setLevel(log_level)
 

--- a/backend/onyx/utils/logger.py
+++ b/backend/onyx/utils/logger.py
@@ -20,6 +20,15 @@ from shared_configs.contextvars import ONYX_REQUEST_ID_CONTEXTVAR
 
 logging.addLevelName(logging.INFO + 5, "NOTICE")
 
+NOISY_THIRD_PARTY_LOGGER_PREFIXES = (
+    "googleapiclient",
+    "httpcore",
+    "httpx",
+    "kubernetes",
+    "slack_sdk",
+    "urllib3",
+)
+
 pruning_ctx: contextvars.ContextVar[dict[str, Any]] = contextvars.ContextVar(
     "pruning_ctx", default=dict()
 )
@@ -48,6 +57,28 @@ def get_log_level_from_str(log_level_str: str = LOG_LEVEL) -> int:
     }
 
     return log_level_dict.get(log_level_str.upper(), logging.INFO)
+
+
+def configure_noisy_dependency_loggers(log_level: int = logging.WARNING) -> None:
+    """Keep verbose dependency internals out of container stdout.
+
+    In debug environments, SDK-level request/response logging can rotate
+    Kubernetes container logs before Onyx application logs are useful.
+    """
+    for logger_prefix in NOISY_THIRD_PARTY_LOGGER_PREFIXES:
+        logging.getLogger(logger_prefix).setLevel(log_level)
+
+    for logger_name, candidate_logger in list(
+        logging.Logger.manager.loggerDict.items()
+    ):
+        if not isinstance(candidate_logger, logging.Logger):
+            continue
+
+        if any(
+            logger_name.startswith(f"{logger_prefix}.")
+            for logger_prefix in NOISY_THIRD_PARTY_LOGGER_PREFIXES
+        ):
+            candidate_logger.setLevel(log_level)
 
 
 class OnyxRequestIDFilter(logging.Filter):
@@ -261,6 +292,8 @@ def setup_logger(
     extra: MutableMapping[str, Any] | None = None,
     propagate: bool = True,
 ) -> OnyxLoggingAdapter:
+    configure_noisy_dependency_loggers()
+
     logger = logging.getLogger(name)
 
     # If the logger already has handlers, assume it was already configured and return it.

--- a/backend/tests/unit/onyx/background/celery/test_app_base_logging.py
+++ b/backend/tests/unit/onyx/background/celery/test_app_base_logging.py
@@ -14,6 +14,43 @@ from collections.abc import Generator
 import pytest
 
 from onyx.background.celery.apps import app_base
+from onyx.utils.logger import NOISY_THIRD_PARTY_LOGGER_PREFIXES
+
+NOISY_DEPENDENCY_CHILD_LOGGER_NAMES = (
+    "googleapiclient.discovery",
+    "googleapiclient.discovery_cache",
+    "googleapiclient.http",
+    "httpcore.connection",
+    "httpcore.http11",
+    "httpx",
+    "kubernetes.client.rest",
+    "slack_sdk.web.base_client",
+    "urllib3.connectionpool",
+)
+
+
+def _matches_noisy_dependency_prefix(logger_name: str) -> bool:
+    return logger_name in NOISY_THIRD_PARTY_LOGGER_PREFIXES or any(
+        logger_name.startswith(f"{logger_prefix}.")
+        for logger_prefix in NOISY_THIRD_PARTY_LOGGER_PREFIXES
+    )
+
+
+def _noisy_dependency_loggers() -> dict[str, logging.Logger]:
+    loggers = {
+        logger_prefix: logging.getLogger(logger_prefix)
+        for logger_prefix in NOISY_THIRD_PARTY_LOGGER_PREFIXES
+    }
+
+    for logger_name, candidate_logger in list(
+        logging.Logger.manager.loggerDict.items()
+    ):
+        if not isinstance(candidate_logger, logging.Logger):
+            continue
+        if _matches_noisy_dependency_prefix(logger_name):
+            loggers[logger_name] = candidate_logger
+
+    return loggers
 
 
 @pytest.fixture
@@ -31,6 +68,10 @@ def _snapshot_loggers() -> Generator[None, None, None]:
     task_handlers_before = list(task.handlers)
     task_level_before = task.level
     task_propagate_before = task.propagate
+    noisy_logger_levels_before = {
+        logger_name: logger.level
+        for logger_name, logger in _noisy_dependency_loggers().items()
+    }
 
     yield
 
@@ -39,6 +80,9 @@ def _snapshot_loggers() -> Generator[None, None, None]:
     task.handlers = task_handlers_before
     task.setLevel(task_level_before)
     task.propagate = task_propagate_before
+
+    for logger_name, logger in _noisy_dependency_loggers().items():
+        logger.setLevel(noisy_logger_levels_before.get(logger_name, logging.NOTSET))
 
 
 def _clean_argv(monkeypatch: pytest.MonkeyPatch, *extra: str) -> None:
@@ -168,6 +212,34 @@ def test_env_loglevel_case_insensitive(
 
     assert logging.getLogger().level == logging.WARNING
     assert app_base.task_logger.level == logging.WARNING
+
+
+def test_noisy_dependency_loggers_suppress_debug_and_info_with_debug_root(
+    _snapshot_loggers: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+    _clean_argv(monkeypatch)
+
+    dependency_loggers = [
+        logging.getLogger(logger_name)
+        for logger_name in NOISY_DEPENDENCY_CHILD_LOGGER_NAMES
+    ]
+    for dependency_logger in dependency_loggers:
+        dependency_logger.setLevel(logging.DEBUG)
+
+    app_base.on_setup_logging(
+        loglevel=logging.WARNING,
+        logfile=None,
+        format="",
+        colorize=False,
+    )
+
+    assert logging.getLogger().level == logging.DEBUG
+    assert app_base.task_logger.level == logging.DEBUG
+    for dependency_logger in dependency_loggers:
+        assert not dependency_logger.isEnabledFor(logging.DEBUG)
+        assert not dependency_logger.isEnabledFor(logging.INFO)
+        assert dependency_logger.isEnabledFor(logging.WARNING)
 
 
 # Direct tests of the resolver helper so we can assert on the human-readable

--- a/backend/tests/unit/onyx/background/celery/test_app_base_logging.py
+++ b/backend/tests/unit/onyx/background/celery/test_app_base_logging.py
@@ -14,52 +14,6 @@ from collections.abc import Generator
 import pytest
 
 from onyx.background.celery.apps import app_base
-from onyx.utils.logger import NOISY_THIRD_PARTY_LOGGER_PREFIXES
-
-NOISY_DEPENDENCY_CHILD_LOGGER_NAMES = (
-    "googleapiclient.discovery",
-    "googleapiclient.discovery_cache",
-    "googleapiclient.http",
-    "httpcore.connection",
-    "httpcore.http11",
-    "httpx",
-    "kubernetes.client.rest",
-    "slack_sdk.web.base_client",
-    "urllib3.connectionpool",
-)
-
-
-class CapturingHandler(logging.Handler):
-    def __init__(self) -> None:
-        super().__init__()
-        self.records: list[logging.LogRecord] = []
-
-    def emit(self, record: logging.LogRecord) -> None:
-        self.records.append(record)
-
-
-def _matches_noisy_dependency_prefix(logger_name: str) -> bool:
-    return logger_name in NOISY_THIRD_PARTY_LOGGER_PREFIXES or any(
-        logger_name.startswith(f"{logger_prefix}.")
-        for logger_prefix in NOISY_THIRD_PARTY_LOGGER_PREFIXES
-    )
-
-
-def _noisy_dependency_loggers() -> dict[str, logging.Logger]:
-    loggers = {
-        logger_prefix: logging.getLogger(logger_prefix)
-        for logger_prefix in NOISY_THIRD_PARTY_LOGGER_PREFIXES
-    }
-
-    for logger_name, candidate_logger in list(
-        logging.Logger.manager.loggerDict.items()
-    ):
-        if not isinstance(candidate_logger, logging.Logger):
-            continue
-        if _matches_noisy_dependency_prefix(logger_name):
-            loggers[logger_name] = candidate_logger
-
-    return loggers
 
 
 @pytest.fixture
@@ -77,10 +31,6 @@ def _snapshot_loggers() -> Generator[None, None, None]:
     task_handlers_before = list(task.handlers)
     task_level_before = task.level
     task_propagate_before = task.propagate
-    noisy_logger_levels_before = {
-        logger_name: logger.level
-        for logger_name, logger in _noisy_dependency_loggers().items()
-    }
 
     yield
 
@@ -90,9 +40,6 @@ def _snapshot_loggers() -> Generator[None, None, None]:
     task.setLevel(task_level_before)
     task.propagate = task_propagate_before
 
-    for logger_name, logger in _noisy_dependency_loggers().items():
-        logger.setLevel(noisy_logger_levels_before.get(logger_name, logging.NOTSET))
-
 
 def _clean_argv(monkeypatch: pytest.MonkeyPatch, *extra: str) -> None:
     """Replaces sys.argv with a celery-like invocation (plus any extra args).
@@ -101,13 +48,6 @@ def _clean_argv(monkeypatch: pytest.MonkeyPatch, *extra: str) -> None:
     from pytest's command line as a false short-flag match.
     """
     monkeypatch.setattr(sys, "argv", ["celery", "-A", "app", "worker", *extra])
-
-
-def _dependency_loggers() -> list[logging.Logger]:
-    return [
-        logging.getLogger(logger_name)
-        for logger_name in NOISY_DEPENDENCY_CHILD_LOGGER_NAMES
-    ]
 
 
 def test_env_unset_cli_not_passed_falls_back_to_celery_default(
@@ -228,85 +168,6 @@ def test_env_loglevel_case_insensitive(
 
     assert logging.getLogger().level == logging.WARNING
     assert app_base.task_logger.level == logging.WARNING
-
-
-def test_noisy_dependency_loggers_suppress_debug_and_info_with_debug_root(
-    _snapshot_loggers: None, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
-    _clean_argv(monkeypatch)
-
-    dependency_loggers = _dependency_loggers()
-    for dependency_logger in dependency_loggers:
-        dependency_logger.setLevel(logging.DEBUG)
-
-    app_base.on_setup_logging(
-        loglevel=logging.WARNING,
-        logfile=None,
-        format="",
-        colorize=False,
-    )
-
-    assert logging.getLogger().level == logging.DEBUG
-    assert app_base.task_logger.level == logging.DEBUG
-    capture_handler = CapturingHandler()
-    logging.getLogger().addHandler(capture_handler)
-
-    for dependency_logger in dependency_loggers:
-        dependency_logger.debug("debug should be hidden")
-        dependency_logger.info("info should be hidden")
-        dependency_logger.warning("warning should be visible")
-
-    dependency_records = [
-        record
-        for record in capture_handler.records
-        if record.name in NOISY_DEPENDENCY_CHILD_LOGGER_NAMES
-    ]
-    assert {record.getMessage() for record in dependency_records} == {
-        "warning should be visible"
-    }
-    assert {record.name for record in dependency_records} == set(
-        NOISY_DEPENDENCY_CHILD_LOGGER_NAMES
-    )
-
-
-def test_noisy_dependency_loggers_do_not_loosen_error_root(
-    _snapshot_loggers: None, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setenv("LOG_LEVEL", "ERROR")
-    _clean_argv(monkeypatch)
-
-    dependency_loggers = _dependency_loggers()
-    for dependency_logger in dependency_loggers:
-        dependency_logger.setLevel(logging.DEBUG)
-
-    app_base.on_setup_logging(
-        loglevel=logging.WARNING,
-        logfile=None,
-        format="",
-        colorize=False,
-    )
-
-    assert logging.getLogger().level == logging.ERROR
-    assert app_base.task_logger.level == logging.ERROR
-    capture_handler = CapturingHandler()
-    logging.getLogger().addHandler(capture_handler)
-
-    for dependency_logger in dependency_loggers:
-        dependency_logger.warning("warning should be hidden")
-        dependency_logger.error("error should be visible")
-
-    dependency_records = [
-        record
-        for record in capture_handler.records
-        if record.name in NOISY_DEPENDENCY_CHILD_LOGGER_NAMES
-    ]
-    assert {record.getMessage() for record in dependency_records} == {
-        "error should be visible"
-    }
-    assert {record.name for record in dependency_records} == set(
-        NOISY_DEPENDENCY_CHILD_LOGGER_NAMES
-    )
 
 
 # Direct tests of the resolver helper so we can assert on the human-readable

--- a/backend/tests/unit/onyx/background/celery/test_app_base_logging.py
+++ b/backend/tests/unit/onyx/background/celery/test_app_base_logging.py
@@ -29,6 +29,15 @@ NOISY_DEPENDENCY_CHILD_LOGGER_NAMES = (
 )
 
 
+class CapturingHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__()
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+
 def _matches_noisy_dependency_prefix(logger_name: str) -> bool:
     return logger_name in NOISY_THIRD_PARTY_LOGGER_PREFIXES or any(
         logger_name.startswith(f"{logger_prefix}.")
@@ -92,6 +101,13 @@ def _clean_argv(monkeypatch: pytest.MonkeyPatch, *extra: str) -> None:
     from pytest's command line as a false short-flag match.
     """
     monkeypatch.setattr(sys, "argv", ["celery", "-A", "app", "worker", *extra])
+
+
+def _dependency_loggers() -> list[logging.Logger]:
+    return [
+        logging.getLogger(logger_name)
+        for logger_name in NOISY_DEPENDENCY_CHILD_LOGGER_NAMES
+    ]
 
 
 def test_env_unset_cli_not_passed_falls_back_to_celery_default(
@@ -220,10 +236,7 @@ def test_noisy_dependency_loggers_suppress_debug_and_info_with_debug_root(
     monkeypatch.setenv("LOG_LEVEL", "DEBUG")
     _clean_argv(monkeypatch)
 
-    dependency_loggers = [
-        logging.getLogger(logger_name)
-        for logger_name in NOISY_DEPENDENCY_CHILD_LOGGER_NAMES
-    ]
+    dependency_loggers = _dependency_loggers()
     for dependency_logger in dependency_loggers:
         dependency_logger.setLevel(logging.DEBUG)
 
@@ -236,10 +249,64 @@ def test_noisy_dependency_loggers_suppress_debug_and_info_with_debug_root(
 
     assert logging.getLogger().level == logging.DEBUG
     assert app_base.task_logger.level == logging.DEBUG
+    capture_handler = CapturingHandler()
+    logging.getLogger().addHandler(capture_handler)
+
     for dependency_logger in dependency_loggers:
-        assert not dependency_logger.isEnabledFor(logging.DEBUG)
-        assert not dependency_logger.isEnabledFor(logging.INFO)
-        assert dependency_logger.isEnabledFor(logging.WARNING)
+        dependency_logger.debug("debug should be hidden")
+        dependency_logger.info("info should be hidden")
+        dependency_logger.warning("warning should be visible")
+
+    dependency_records = [
+        record
+        for record in capture_handler.records
+        if record.name in NOISY_DEPENDENCY_CHILD_LOGGER_NAMES
+    ]
+    assert {record.getMessage() for record in dependency_records} == {
+        "warning should be visible"
+    }
+    assert {record.name for record in dependency_records} == set(
+        NOISY_DEPENDENCY_CHILD_LOGGER_NAMES
+    )
+
+
+def test_noisy_dependency_loggers_do_not_loosen_error_root(
+    _snapshot_loggers: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("LOG_LEVEL", "ERROR")
+    _clean_argv(monkeypatch)
+
+    dependency_loggers = _dependency_loggers()
+    for dependency_logger in dependency_loggers:
+        dependency_logger.setLevel(logging.DEBUG)
+
+    app_base.on_setup_logging(
+        loglevel=logging.WARNING,
+        logfile=None,
+        format="",
+        colorize=False,
+    )
+
+    assert logging.getLogger().level == logging.ERROR
+    assert app_base.task_logger.level == logging.ERROR
+    capture_handler = CapturingHandler()
+    logging.getLogger().addHandler(capture_handler)
+
+    for dependency_logger in dependency_loggers:
+        dependency_logger.warning("warning should be hidden")
+        dependency_logger.error("error should be visible")
+
+    dependency_records = [
+        record
+        for record in capture_handler.records
+        if record.name in NOISY_DEPENDENCY_CHILD_LOGGER_NAMES
+    ]
+    assert {record.getMessage() for record in dependency_records} == {
+        "error should be visible"
+    }
+    assert {record.name for record in dependency_records} == set(
+        NOISY_DEPENDENCY_CHILD_LOGGER_NAMES
+    )
 
 
 # Direct tests of the resolver helper so we can assert on the human-readable


### PR DESCRIPTION
## Description

Fixes ENG-4169 by clamping known noisy third-party Python logger families to `WARNING` during Onyx logger setup and Celery logger setup. This keeps Onyx/Celery application logging at the configured level, including `DEBUG`, while preventing dependency SDK internals from flooding container stdout.

I confirmed the current st-dev cluster is in the failure mode this targets:

- context: `onyx-st-dev`, namespace `onyx`
- `env-configmap` has `LOG_LEVEL: DEBUG`
- `onyx-celery-worker-heavy` has no explicit `--loglevel`, so it inherits `LOG_LEVEL=DEBUG`
- current heavy worker logs retained only about 63 seconds despite the pod being up for about 87 minutes
- current docprocessing logs retained only about 29 seconds despite the pod being up for about 87 minutes
- across a sampled Celery worker tail, 2,135 lines matched the dependency logger families targeted by this PR

Logs hidden below `WARNING`:

- `googleapiclient.discovery`: debug URL/request logs such as Google Drive `URL being requested: GET ...`
- `googleapiclient.discovery_cache`: repeated info logs such as `file_cache is only supported with oauth2client<4.0.0`
- `googleapiclient.http`: low-severity HTTP client internals; warnings/errors remain visible
- `urllib3.connectionpool`: connectionpool request/connection chatter
- `httpcore.*`: connection and HTTP/1.1 wire-level trace logs
- `httpx`: per-request client logs
- `kubernetes.*`: Kubernetes client internals, including `kubernetes.client.rest` response/request debug output
- `slack_sdk.*`: Slack SDK request/response debug output

Warnings and errors from these libraries are still emitted. For example, `googleapiclient.http` 403 warnings remain visible.

## How Has This Been Tested?

Not run. This is process logging configuration; no local end-to-end user workflow was exercised.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppress noisy third‑party DEBUG/INFO logs by clamping common SDK loggers to at least WARNING during app and Celery logger setup. Keeps Onyx/Celery DEBUG logs while preventing SDK chatter from rotating container logs, addressing ENG-4169.

- **Bug Fixes**
  - Clamp `googleapiclient`, `httpcore`, `httpx`, `kubernetes`, `slack_sdk`, and `urllib3` logger families to max(WARNING, effective app level).
  - Apply suppression in `setup_logger()` and Celery `on_setup_logging()` via `configure_noisy_dependency_loggers()`; stricter app levels (e.g., ERROR) are preserved.

<sup>Written for commit b70910ce76b2ce1d541e6c30ac1335fa7ecdcde2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

