### PR TITLE
fix(craft): persist opencode chat history across sandbox pod re-provisions (ENG-4167)

### DIFF
--- a/.vscode/.env.k8s.template
+++ b/.vscode/.env.k8s.template
@@ -80,6 +80,16 @@ S3_FILE_STORE_BUCKET_NAME=onyx-file-store-bucket
 S3_AWS_ACCESS_KEY_ID=minioadmin
 S3_AWS_SECRET_ACCESS_KEY=minioadmin
 
+# Craft sandbox snapshots: the K8s sandbox manager forwards these AWS_*
+# vars from the api_server's env into each sandbox pod. Prod uses
+# IRSA instead. FQDN is required — sandbox pods live in the onyx-sandboxes
+# namespace, where the short `onyx-minio` name doesn't resolve.
+AWS_ENDPOINT_URL=http://onyx-minio.onyx.svc.cluster.local:9000
+AWS_ACCESS_KEY_ID=minioadmin
+AWS_SECRET_ACCESS_KEY=minioadmin
+AWS_REGION=us-east-1
+SANDBOX_S3_BUCKET=onyx-sandbox-files
+
 # Inference / indexing
 MODEL_SERVER_HOST=onyx-inference-model-service
 INDEXING_MODEL_SERVER_HOST=onyx-indexing-model-service

--- a/backend/onyx/server/features/build/api/sessions_api.py
+++ b/backend/onyx/server/features/build/api/sessions_api.py
@@ -382,6 +382,17 @@ def restore_session(
                     "Sandbox %s marked as RUNNING but pod is unhealthy/missing. Entering recovery mode.",
                     sandbox.id,
                 )
+                # Best-effort history snapshot: the sidecar may be up even
+                # if opencode isn't.
+                try:
+                    sandbox_manager.create_opencode_data_snapshot(
+                        sandbox.id, tenant_id, timeout_seconds=30.0
+                    )
+                except Exception:
+                    logger.warning(
+                        "opencode-data snapshot failed during recovery of sandbox %s",
+                        sandbox.id,
+                    )
                 sandbox_manager.terminate(sandbox.id)
                 update_sandbox_status__no_commit(
                     db_session, sandbox.id, SandboxStatus.TERMINATED

--- a/backend/onyx/server/features/build/db/build_session.py
+++ b/backend/onyx/server/features/build/db/build_session.py
@@ -379,6 +379,21 @@ def create_message(
     return message
 
 
+def session_has_assistant_messages(session_id: UUID, db_session: Session) -> bool:
+    """True if the agent has responded at least once in this session —
+    i.e. there is opencode chat history worth protecting."""
+    return bool(
+        db_session.query(
+            db_session.query(BuildMessage.id)
+            .filter(
+                BuildMessage.session_id == session_id,
+                BuildMessage.type == MessageType.ASSISTANT,
+            )
+            .exists()
+        ).scalar()
+    )
+
+
 def count_user_messages(session_id: UUID, db_session: Session) -> int:
     """Count persisted user messages in a build session."""
     return (

--- a/backend/onyx/server/features/build/sandbox/base.py
+++ b/backend/onyx/server/features/build/sandbox/base.py
@@ -109,6 +109,11 @@ class SandboxManager(_ServeMixin, ABC):
     Use get_sandbox_manager() to get the appropriate implementation.
     """
 
+    # True when chat history survives re-provisions. Gates the
+    # OpencodeSessionLostError path: without persistence, stale opencode
+    # session ids are normal and the transport mints silently.
+    supports_opencode_history_persistence: bool = False
+
     @abstractmethod
     def provision(
         self,
@@ -126,6 +131,10 @@ class SandboxManager(_ServeMixin, ABC):
         configured. K8s pre-loads each into opencode-serve's startup config
         so per-prompt model overrides can cross providers without restarting
         the pod. Defaults to ``[llm_config]`` (single-provider, back-compat).
+
+        On K8s, provisioning also restores the sandbox's chat-history
+        snapshot before opencode-serve starts, so persisted opencode
+        session ids resolve after a re-provision.
 
         Creates the sandbox container/directory with:
         - sessions/ directory for per-session workspaces
@@ -242,6 +251,25 @@ class SandboxManager(_ServeMixin, ABC):
         ...
 
     @abstractmethod
+    def create_opencode_data_snapshot(
+        self,
+        sandbox_id: UUID,
+        tenant_id: str,
+        timeout_seconds: float = 300.0,
+    ) -> bool:
+        """Snapshot the sandbox-global opencode store (chat history) so the
+        next ``provision`` can restore it. One blob per sandbox,
+        overwritten each sleep.
+
+        Returns False when nothing was uploaded (empty store, or the
+        backend doesn't persist history).
+
+        Raises:
+            RuntimeError: If snapshot creation fails
+        """
+        ...
+
+    @abstractmethod
     def restore_snapshot(
         self,
         sandbox_id: UUID,
@@ -330,6 +358,7 @@ class SandboxManager(_ServeMixin, ABC):
         opencode_session_id: str | None = None,
         agent_provider: str | None = None,
         agent_model: str | None = None,
+        expect_existing_opencode_session: bool = False,
         on_opencode_session_resolved: Callable[[str], None] | None = None,
         should_interrupt: Callable[[], bool] | None = None,
     ) -> Generator[SandboxEvent, None, None]:
@@ -340,6 +369,10 @@ class SandboxManager(_ServeMixin, ABC):
           ``BuildSession.opencode_session_id`` or ``None`` to mint.
         - ``agent_provider`` / ``agent_model``: per-prompt model override;
           either ``None`` falls back to the loaded default.
+        - ``expect_existing_opencode_session``: the session has prior
+          history, so a stale persisted id raises
+          ``OpencodeSessionLostError`` instead of minting a replacement
+          (history loss must not masquerade as a fresh chat).
         - ``on_opencode_session_resolved``: invoked with the resolved id
           when it differs from the caller's. Caller persists it so later
           turns don't orphan a fresh session each time.
@@ -351,6 +384,7 @@ class SandboxManager(_ServeMixin, ABC):
             opencode_session_id,
             agent_provider,
             agent_model,
+            expect_existing_opencode_session=expect_existing_opencode_session,
             on_opencode_session_resolved=on_opencode_session_resolved,
             should_interrupt=should_interrupt,
         )

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -1134,8 +1134,7 @@ echo "Session cleanup complete"
             (
                 f"cd {session_path} && tar -czf - "
                 f"$([ -d outputs ] && echo outputs) "
-                f"$([ -d attachments ] && echo attachments) "
-                f"$([ -d .opencode-data ] && echo .opencode-data)"
+                f"$([ -d attachments ] && echo attachments)"
             ),
         ]
 
@@ -1162,6 +1161,15 @@ echo "Session cleanup complete"
             size_bytes,
         )
         return SnapshotResult(storage_path=storage_path, size_bytes=size_bytes)
+
+    def create_opencode_data_snapshot(
+        self,
+        sandbox_id: UUID,  # noqa: ARG002
+        tenant_id: str,  # noqa: ARG002
+        timeout_seconds: float = 300.0,  # noqa: ARG002
+    ) -> bool:
+        # Docker doesn't persist chat history across terminate (K8s-only).
+        return False
 
     def restore_snapshot(
         self,

--- a/backend/onyx/server/features/build/sandbox/image/entrypoint.sh
+++ b/backend/onyx/server/features/build/sandbox/image/entrypoint.sh
@@ -4,11 +4,15 @@
 # OPENCODE_SERVER_PASSWORD is the only env input. Port and XDG_DATA_HOME
 # are internal contracts (configs.py + sandbox_daemon snapshot path);
 # overriding from env would silently break snapshot capture / restore.
+#
+# XDG_DATA_HOME (opencode's chat-history store) lives on the shared
+# /workspace/sessions volume. The opencode-restore init container puts the
+# saved db back before this container ever starts.
 
 set -euo pipefail
 
 OPENCODE_PORT=4096
-export XDG_DATA_HOME=/workspace/.opencode-data
+export XDG_DATA_HOME=/workspace/sessions/.opencode-data
 mkdir -p "$XDG_DATA_HOME"
 
 child_pid=

--- a/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/models.py
+++ b/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/models.py
@@ -59,3 +59,19 @@ class SnapshotRestoreRequest(BaseModel):
 
 
 # Restore has no response body — failures raise, success is the 204.
+
+
+class OpencodeDataRequest(BaseModel):
+    """Snapshot the opencode chat-history store. The S3 key is
+    deterministic and derived daemon-side, so no path travels on the wire.
+    (Restore happens in the opencode_restore init container, not via the
+    daemon.)
+    """
+
+    sandbox_id: UUID
+    tenant_id: TenantId
+    s3_bucket: str
+
+
+class OpencodeDataCreateResponse(BaseModel):
+    status: SnapshotCreateStatus

--- a/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/opencode_restore.py
+++ b/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/opencode_restore.py
@@ -1,0 +1,97 @@
+"""Init-container entrypoint: restore opencode's chat-history db from S3.
+
+Runs to completion before any regular container starts (kubelet-ordered),
+so opencode-serve can never open the store mid-restore. Exit codes:
+0 = restored or nothing to restore (fresh sandbox); nonzero = failure,
+which fails pod startup so provisioning retries instead of silently
+starting with empty history.
+"""
+
+import os
+import subprocess
+import sys
+import time
+from uuid import UUID
+
+from sandbox_daemon.snapshot import opencode_data_storage_path
+from sandbox_daemon.snapshot import OPENCODE_DB_PATH
+
+SQLITE_MAGIC = b"SQLite format 3\x00"
+
+# This is the pod's first proxied egress: the egress proxy identifies pods
+# by source IP from a K8s informer that may not have seen this pod yet, so
+# early requests can 403 with "unidentified_sandbox". Retry until the
+# proxy knows us.
+_RETRY_BUDGET_SECONDS = 90
+_RETRY_DELAY_SECONDS = 3
+_ATTEMPT_TIMEOUT_SECONDS = 60
+
+
+def _is_missing_object(stderr: str) -> bool:
+    # s5cmd's "key does not exist" messages: `cat` on a plain key stats it
+    # first ("given object ... not found"); list/wildcard paths say "no
+    # object found".
+    lowered = stderr.lower()
+    if "no object found" in lowered:
+        return True
+    return "given object" in lowered and "not found" in lowered
+
+
+def _download(s3_uri: str, dest: str) -> tuple[int, str]:
+    with open(dest, "wb") as f:
+        # Single-stream, small parts: the default 5x50MiB buffers could
+        # blow the init container's memory limit.
+        try:
+            proc = subprocess.run(
+                ["s5cmd", "cat", "--concurrency", "1", "--part-size", "16", s3_uri],
+                stdout=f,
+                stderr=subprocess.PIPE,
+                text=False,
+                timeout=_ATTEMPT_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired:
+            return 1, f"timed out after {_ATTEMPT_TIMEOUT_SECONDS}s"
+    return proc.returncode, proc.stderr.decode(errors="replace").strip()
+
+
+def main() -> int:
+    sandbox_id = UUID(os.environ["ONYX_SANDBOX_ID"])
+    tenant_id = os.environ["ONYX_TENANT_ID"]
+    s3_bucket = os.environ["SANDBOX_S3_BUCKET"]
+    s3_uri = f"s3://{s3_bucket}/{opencode_data_storage_path(tenant_id, sandbox_id)}"
+
+    OPENCODE_DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = OPENCODE_DB_PATH.with_suffix(".db.restore")
+
+    deadline = time.monotonic() + _RETRY_BUDGET_SECONDS
+    while True:
+        returncode, stderr = _download(s3_uri, str(tmp_path))
+        if returncode == 0:
+            break
+        tmp_path.unlink(missing_ok=True)
+        if _is_missing_object(stderr):
+            print(f"[opencode-restore] no snapshot at {s3_uri}; starting fresh")
+            return 0
+        if time.monotonic() >= deadline:
+            print(f"[opencode-restore] download failed: {stderr}", file=sys.stderr)
+            return 1
+        print(f"[opencode-restore] download failed, retrying: {stderr}")
+        time.sleep(_RETRY_DELAY_SECONDS)
+
+    with open(tmp_path, "rb") as f:
+        magic = f.read(len(SQLITE_MAGIC))
+    if magic != SQLITE_MAGIC:
+        tmp_path.unlink(missing_ok=True)
+        print(
+            f"[opencode-restore] {s3_uri} is not a sqlite db; refusing",
+            file=sys.stderr,
+        )
+        return 1
+
+    tmp_path.rename(OPENCODE_DB_PATH)
+    print(f"[opencode-restore] restored {OPENCODE_DB_PATH} from {s3_uri}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/server.py
+++ b/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/server.py
@@ -16,9 +16,12 @@ from fastapi import Query
 from fastapi import Request
 from sandbox_daemon.extract import MAX_BUNDLE_BYTES
 from sandbox_daemon.extract import safe_extract_then_atomic_swap
+from sandbox_daemon.models import OpencodeDataCreateResponse
+from sandbox_daemon.models import OpencodeDataRequest
 from sandbox_daemon.models import SnapshotCreateRequest
 from sandbox_daemon.models import SnapshotCreateResponse
 from sandbox_daemon.models import SnapshotRestoreRequest
+from sandbox_daemon.snapshot import create_opencode_data_snapshot
 from sandbox_daemon.snapshot import create_snapshot
 from sandbox_daemon.snapshot import restore_snapshot
 from sandbox_daemon.snapshot import SnapshotError
@@ -195,6 +198,44 @@ async def snapshot_restore(
         raise HTTPException(status_code=500, detail=f"Snapshot restore failed: {e}")
     except OSError as e:
         raise HTTPException(status_code=500, detail=f"Snapshot restore OS error: {e}")
+
+
+@app.post("/opencode-data/create")
+async def opencode_data_create(
+    request: Request,
+    x_push_signature: str = Header(..., alias="X-Push-Signature"),
+    x_push_timestamp: str = Header(..., alias="X-Push-Timestamp"),
+) -> OpencodeDataCreateResponse:
+    body = await request.body()
+    _verify_signature(
+        "/opencode-data/create",
+        hashlib.sha256(body).hexdigest(),
+        x_push_signature,
+        x_push_timestamp,
+    )
+
+    try:
+        payload = OpencodeDataRequest.model_validate_json(body)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=f"Invalid request body: {e}")
+
+    try:
+        status = await asyncio.to_thread(
+            create_opencode_data_snapshot,
+            sandbox_id=payload.sandbox_id,
+            tenant_id=payload.tenant_id,
+            s3_bucket=payload.s3_bucket,
+        )
+    except SnapshotError as e:
+        raise HTTPException(
+            status_code=500, detail=f"opencode-data snapshot create failed: {e}"
+        )
+    except OSError as e:
+        raise HTTPException(
+            status_code=500, detail=f"opencode-data snapshot create OS error: {e}"
+        )
+
+    return OpencodeDataCreateResponse(status=status)
 
 
 if __name__ == "__main__":

--- a/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/snapshot.py
+++ b/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/snapshot.py
@@ -5,8 +5,12 @@ upload/download tar.gz archives to/from S3. Tarring/extraction happens
 via shell pipelines so we don't buffer large snapshots in memory.
 """
 
+import os
 import shlex
+import signal
+import sqlite3
 import subprocess
+import tempfile
 from pathlib import Path
 from uuid import UUID
 
@@ -17,6 +21,13 @@ SESSIONS_ROOT = Path("/workspace/sessions")
 # daemon can't import from the main package at runtime, hence the copy.
 BUN_CACHE_DIR = SESSIONS_ROOT / ".bun-cache"
 BUN_IMAGE_CACHE_DIR = Path("/home/sandbox/.bun/install/cache")
+# opencode's sqlite store (chat history), under XDG_DATA_HOME. Restored by
+# the opencode_restore init container before opencode-serve ever starts.
+OPENCODE_DATA_DIR = SESSIONS_ROOT / ".opencode-data"
+OPENCODE_DB_PATH = OPENCODE_DATA_DIR / "opencode" / "opencode.db"
+
+# Keep the upload bounded well under the manager's 300s sidecar deadline.
+OPENCODE_DATA_UPLOAD_TIMEOUT_SECONDS = 240
 
 
 class SnapshotError(RuntimeError):
@@ -25,7 +36,7 @@ class SnapshotError(RuntimeError):
     """
 
 
-def _run(script: str) -> None:
+def _run(script: str, timeout: float | None = None) -> None:
     """Run a shell script with stderr merged into stdout for the error.
 
     We deliberately merge stderr into stdout (rather than capturing them
@@ -33,18 +44,26 @@ def _run(script: str) -> None:
     surfaces *something* in the SnapshotError — `set -o pipefail` can
     otherwise tear the stream down before stderr buffers flush, leaving
     a useless "no output" diagnostic.
+
+    Timeout kills the whole process GROUP — killing only the bash wrapper
+    would orphan tar/s5cmd, which could keep writing past the deadline.
     """
+    proc = subprocess.Popen(
+        ["/bin/bash", "-c", script],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        start_new_session=True,
+    )
     try:
-        subprocess.run(
-            ["/bin/bash", "-c", script],
-            check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-        )
-    except subprocess.CalledProcessError as e:
-        detail = (e.stdout or "").strip() or "no output"
-        raise SnapshotError(f"exit {e.returncode}: {detail}") from e
+        stdout, _ = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired as e:
+        os.killpg(proc.pid, signal.SIGKILL)
+        proc.communicate()
+        raise SnapshotError(f"timed out after {timeout}s") from e
+    if proc.returncode != 0:
+        detail = (stdout or "").strip() or "no output"
+        raise SnapshotError(f"exit {proc.returncode}: {detail}")
 
 
 def create_snapshot(
@@ -53,7 +72,8 @@ def create_snapshot(
     s3_bucket: str,
     snapshot_id: UUID,
 ) -> tuple[SnapshotCreateStatus, str]:
-    """Create a snapshot of a session's outputs/attachments/.opencode-data.
+    """Create a snapshot of a session's outputs/attachments. Chat history
+    is sandbox-global — see :func:`create_opencode_data_snapshot`.
 
     Returns:
         (status, storage_path). storage_path is empty when status is "empty".
@@ -67,7 +87,7 @@ def create_snapshot(
     # /etc or the sidecar's IRSA token mount. GNU tar's default already
     # archives symlinks as symlinks (so the target isn't exfiltrated), but
     # we fail-loud here so the operator notices the tamper.
-    for sub in ("outputs", "attachments", ".opencode-data"):
+    for sub in ("outputs", "attachments"):
         candidate = session_path / sub
         if candidate.is_symlink():
             raise SnapshotError(f"{sub} is a symlink; refusing to snapshot")
@@ -93,15 +113,15 @@ dirs="outputs"
 if [ -d attachments ] && [ "$(ls -A attachments 2>/dev/null)" ]; then
     dirs="$dirs attachments"
 fi
-if [ -d .opencode-data ] && [ "$(ls -A .opencode-data 2>/dev/null)" ]; then
-    dirs="$dirs .opencode-data"
-fi
 
 set +e
 tar --exclude='outputs/web/node_modules' --exclude='outputs/web/.next' \\
     -czf - $dirs | s5cmd --log info pipe {safe_s3_uri}
-tar_ec=${{PIPESTATUS[0]-0}}
-s5_ec=${{PIPESTATUS[1]-0}}
+# Copy PIPESTATUS in one shot — any command (even an assignment) resets it,
+# so reading the indices on separate lines silently yields 0 for s5cmd.
+ecs=("${{PIPESTATUS[@]}}")
+tar_ec=${{ecs[0]-0}}
+s5_ec=${{ecs[1]-0}}
 set -e
 
 if [ "$tar_ec" -ne 0 ] || [ "$s5_ec" -ne 0 ]; then
@@ -154,3 +174,51 @@ fi
 """
 
     _run(script)
+
+
+def opencode_data_storage_path(tenant_id: str, sandbox_id: UUID) -> str:
+    """Deterministic S3 key for a sandbox's opencode chat-history snapshot.
+    One blob per sandbox, overwritten on every idle-sleep."""
+    return f"{tenant_id}/snapshots/opencode-data/{sandbox_id}/latest.db"
+
+
+def create_opencode_data_snapshot(
+    sandbox_id: UUID,
+    tenant_id: str,
+    s3_bucket: str,
+) -> SnapshotCreateStatus:
+    """Snapshot opencode's sqlite store (chat history) to S3.
+
+    Sandbox-level because one opencode-serve process serves every session
+    in the pod, with one global db. ``VACUUM INTO`` produces a
+    transactionally consistent single-file copy even while opencode has
+    the db open, so nothing else (wal/shm, repo cache, logs) needs to be
+    captured.
+    """
+    # The agent has rw access to the store's parent dirs — refuse any
+    # symlink trickery that redirects the snapshot source.
+    if OPENCODE_DB_PATH.resolve() != OPENCODE_DB_PATH:
+        raise SnapshotError("opencode.db path contains a symlink; refusing")
+    if not OPENCODE_DB_PATH.is_file():
+        return "empty"
+
+    s3_uri = f"s3://{s3_bucket}/{opencode_data_storage_path(tenant_id, sandbox_id)}"
+
+    with tempfile.TemporaryDirectory() as tmp:
+        copy_path = Path(tmp) / "opencode.db"
+        # mode=ro so a vanished db raises instead of sqlite minting an
+        # empty one and overwriting the good blob.
+        conn = sqlite3.connect(f"file:{OPENCODE_DB_PATH}?mode=ro", uri=True)
+        try:
+            conn.execute("PRAGMA busy_timeout = 5000")
+            conn.execute("VACUUM INTO ?", (str(copy_path),))
+        except sqlite3.Error as e:
+            raise SnapshotError(f"VACUUM INTO failed: {e}") from e
+        finally:
+            conn.close()
+
+        _run(
+            f"s5cmd --log info cp {shlex.quote(str(copy_path))} {shlex.quote(s3_uri)}",
+            timeout=OPENCODE_DATA_UPLOAD_TIMEOUT_SECONDS,
+        )
+    return "created"

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -86,6 +86,12 @@ from onyx.server.features.build.sandbox.base import BUN_CACHE_DIR
 from onyx.server.features.build.sandbox.base import BUN_IMAGE_CACHE_DIR
 from onyx.server.features.build.sandbox.base import SandboxManager
 from onyx.server.features.build.sandbox.image.sandbox_daemon.models import (
+    OpencodeDataCreateResponse,
+)
+from onyx.server.features.build.sandbox.image.sandbox_daemon.models import (
+    OpencodeDataRequest,
+)
+from onyx.server.features.build.sandbox.image.sandbox_daemon.models import (
     SnapshotCreateRequest,
 )
 from onyx.server.features.build.sandbox.image.sandbox_daemon.models import (
@@ -199,6 +205,35 @@ def _proxy_main_container_env_vars() -> list[client.V1EnvVar]:
         client.V1EnvVar(name="CURL_CA_BUNDLE", value=_PROXY_CA_BUNDLE_FILE),
         client.V1EnvVar(name="GIT_SSL_CAINFO", value=_PROXY_CA_BUNDLE_FILE),
     ]
+
+
+def _s3_access_env_vars() -> list[client.V1EnvVar]:
+    """S3 credentials fallback for containers that run s5cmd. In prod IRSA
+    injects credentials; in local-dev / CI we forward AWS_* from the
+    api_server env (MinIO reachable in-cluster).
+
+    s5cmd v2.3.0 reads S3_ENDPOINT_URL — it does NOT honor
+    AWS_ENDPOINT_URL — so mirror it. We do NOT forward the api_server's own
+    S3_ENDPOINT_URL: in CI that points at a host-network MinIO that's
+    unreachable from inside the pod; the cluster-DNS-reachable endpoint is
+    always in AWS_ENDPOINT_URL.
+    """
+    env_vars: list[client.V1EnvVar] = []
+    for var in (
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+        "AWS_REGION",
+        "AWS_DEFAULT_REGION",
+        "AWS_ENDPOINT_URL",
+    ):
+        value = os.environ.get(var)
+        if value:
+            env_vars.append(client.V1EnvVar(name=var, value=value))
+    aws_endpoint = os.environ.get("AWS_ENDPOINT_URL")
+    if aws_endpoint:
+        env_vars.append(client.V1EnvVar(name="S3_ENDPOINT_URL", value=aws_endpoint))
+    return env_vars
 
 
 def _proxy_init_container() -> client.V1Container:
@@ -380,6 +415,8 @@ class KubernetesSandboxManager(SandboxManager):
 
     This is a singleton class - use get_sandbox_manager() to get the instance.
     """
+
+    supports_opencode_history_persistence = True
 
     _instance: "KubernetesSandboxManager | None" = None
     _lock = threading.Lock()
@@ -677,33 +714,8 @@ class KubernetesSandboxManager(SandboxManager):
         sidecar_env = [
             client.V1EnvVar(name=_PUSH_PUBLIC_KEY_ENV, value=push_public_key_b64),
             *_proxy_main_container_env_vars(),
+            *_s3_access_env_vars(),
         ]
-        for var in (
-            "AWS_ACCESS_KEY_ID",
-            "AWS_SECRET_ACCESS_KEY",
-            "AWS_SESSION_TOKEN",
-            "AWS_REGION",
-            "AWS_DEFAULT_REGION",
-            "AWS_ENDPOINT_URL",
-        ):
-            value = os.environ.get(var)
-            if value:
-                sidecar_env.append(client.V1EnvVar(name=var, value=value))
-
-        # s5cmd v2.3.0 reads S3_ENDPOINT_URL — it does NOT honor
-        # AWS_ENDPOINT_URL. Mirror AWS_ENDPOINT_URL into S3_ENDPOINT_URL
-        # so the snapshot daemon's `s5cmd pipe`/`cat` and the file-sync
-        # sidecar's `s5cmd sync` both hit MinIO in dev/CI.
-        #
-        # We do NOT forward the api_server's own S3_ENDPOINT_URL: in CI
-        # that points at a host-network MinIO (localhost:9004 from
-        # docker-compose) which is unreachable from inside the pod. The
-        # cluster-DNS-reachable endpoint is always in AWS_ENDPOINT_URL.
-        aws_endpoint = os.environ.get("AWS_ENDPOINT_URL")
-        if aws_endpoint:
-            sidecar_env.append(
-                client.V1EnvVar(name="S3_ENDPOINT_URL", value=aws_endpoint)
-            )
         sidecar_container = client.V1Container(
             name="sidecar",
             image=self._image,
@@ -781,9 +793,53 @@ class KubernetesSandboxManager(SandboxManager):
             client.V1HostAlias(ip=self._resolve_proxy_ip(), hostnames=[_PROXY_ALIAS])
         ]
 
+        # Restores opencode's chat-history db from S3 before any regular
+        # container starts (kubelet-ordered, after the firewall init so
+        # s5cmd routes through the proxy). A failure fails pod startup —
+        # provisioning retries instead of starting with empty history.
+        restore_init_container = client.V1Container(
+            name="opencode-restore",
+            image=self._image,
+            image_pull_policy="IfNotPresent",
+            working_dir="/workspace",
+            command=[
+                "/workspace/.venv/bin/python",
+                "-m",
+                "sandbox_daemon.opencode_restore",
+            ],
+            env=[
+                client.V1EnvVar(name="ONYX_SANDBOX_ID", value=sandbox_id),
+                client.V1EnvVar(name="ONYX_TENANT_ID", value=tenant_id),
+                client.V1EnvVar(name="SANDBOX_S3_BUCKET", value=self._s3_bucket),
+                client.V1EnvVar(name="PYTHONUNBUFFERED", value="1"),
+                *_proxy_main_container_env_vars(),
+                *_s3_access_env_vars(),
+            ],
+            volume_mounts=[
+                client.V1VolumeMount(
+                    name="workspace", mount_path="/workspace/sessions"
+                ),
+                client.V1VolumeMount(
+                    name=_PROXY_CA_BUNDLE_VOLUME,
+                    mount_path=_PROXY_CA_BUNDLE_DIR,
+                    read_only=True,
+                ),
+            ],
+            resources=client.V1ResourceRequirements(
+                requests={"cpu": "100m", "memory": "128Mi"},
+                limits={"cpu": "500m", "memory": "512Mi"},
+            ),
+            security_context=client.V1SecurityContext(
+                allow_privilege_escalation=False,
+                read_only_root_filesystem=False,
+                privileged=False,
+                capabilities=client.V1Capabilities(drop=["ALL"]),
+            ),
+        )
+
         pod_spec = client.V1PodSpec(
             service_account_name=self._service_account,
-            init_containers=[_proxy_init_container()],
+            init_containers=[_proxy_init_container(), restore_init_container],
             containers=[sandbox_container, sidecar_container],
             host_aliases=host_aliases,
             share_process_namespace=False,
@@ -1794,7 +1850,9 @@ echo "Session cleanup complete"
         Captures:
         - sessions/$session_id/outputs/
         - sessions/$session_id/attachments/
-        - sessions/$session_id/.opencode-data/
+
+        opencode chat history is sandbox-global and captured separately via
+        :meth:`create_opencode_data_snapshot`.
 
         Returns None if there are no outputs to snapshot.
         """
@@ -1833,6 +1891,59 @@ echo "Session cleanup complete"
             storage_path=parsed.storage_path,
             size_bytes=parsed.size_bytes,
         )
+
+    def _opencode_data_request_body(self, sandbox_id: UUID, tenant_id: str) -> bytes:
+        return (
+            OpencodeDataRequest(
+                sandbox_id=sandbox_id,
+                tenant_id=tenant_id,
+                s3_bucket=self._s3_bucket,
+            )
+            .model_dump_json()
+            .encode()
+        )
+
+    def create_opencode_data_snapshot(
+        self,
+        sandbox_id: UUID,
+        tenant_id: str,
+        timeout_seconds: float = 300.0,
+    ) -> bool:
+        """Snapshot the sandbox-global opencode store (chat history) via
+        the sidecar's /opencode-data/create endpoint, overwriting the
+        previous snapshot.
+
+        Returns False when the store is empty (nothing uploaded).
+        """
+        body = self._opencode_data_request_body(sandbox_id, tenant_id)
+        try:
+            resp = self._post_to_sidecar(
+                sandbox_id, "/opencode-data/create", body, timeout=timeout_seconds
+            )
+        except httpx.TransportError as e:
+            raise RuntimeError(f"opencode-data snapshot request failed: {e}") from e
+
+        if resp.status_code == 404:
+            # Pre-rollout pod whose sidecar lacks the endpoint; don't block
+            # its sleep (its store was never persisted anyway).
+            logger.warning(
+                "Sidecar for sandbox %s has no /opencode-data/create "
+                "(old image); skipping history snapshot",
+                sandbox_id,
+            )
+            return False
+        if resp.status_code != 200:
+            raise RuntimeError(
+                f"opencode-data snapshot failed: {resp.status_code} {resp.text}"
+            )
+
+        parsed = OpencodeDataCreateResponse.model_validate_json(resp.content)
+        if parsed.status == "empty":
+            logger.info("No opencode data to snapshot for sandbox %s", sandbox_id)
+            return False
+
+        logger.info("Created opencode-data snapshot for sandbox %s", sandbox_id)
+        return True
 
     def session_workspace_exists(
         self,

--- a/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
+++ b/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
@@ -842,6 +842,13 @@ def _emit_terminator(
 # ---------------------------------------------------------------------------
 
 
+class OpencodeSessionLostError(RuntimeError):
+    """A session with prior history has a persisted opencode id that no
+    longer resolves — its chat history was lost. Raised instead of minting
+    a fresh session so the loss can't masquerade as a new chat.
+    """
+
+
 class OpencodeServeClient:
     """Thin Python client over a single in-pod ``opencode serve`` instance.
 
@@ -1024,8 +1031,13 @@ class OpencodeServeClient:
         *,
         directory: str,
         title: str | None = None,
+        expect_existing: bool = False,
     ) -> str:
         """Return a valid opencode session id. Idempotent across replicas.
+
+        ``expect_existing``: the caller knows this session has prior
+        history, so a stale persisted id raises
+        :class:`OpencodeSessionLostError` instead of minting a replacement.
 
         ``directory`` anchors the opencode Instance for this session.
         Opencode-serve scopes its session store per-directory via the
@@ -1059,6 +1071,14 @@ class OpencodeServeClient:
                 )
                 return opencode_session_id
             if r.status_code == 404:
+                if expect_existing:
+                    # User-facing: surfaces verbatim as the turn's error.
+                    raise OpencodeSessionLostError(
+                        "This session's chat history could not be restored in "
+                        "the sandbox, so the agent cannot continue the "
+                        "conversation. (opencode session "
+                        f"{opencode_session_id} missing from the store)"
+                    )
                 logger.warning(
                     "[SESSION-LIFECYCLE] ensure_session: GET /session/%s -> 404 "
                     "(persisted id stale; will create new)",

--- a/backend/onyx/server/features/build/sandbox/serve_transport.py
+++ b/backend/onyx/server/features/build/sandbox/serve_transport.py
@@ -245,6 +245,24 @@ class _ServeMixin:
                 title=f"build-session-{str(session_id)[:8]}",
             )
 
+    def delete_opencode_session(
+        self,
+        sandbox_id: UUID,
+        session_id: UUID,
+        opencode_session_id: str,
+    ) -> None:
+        """Drop a deleted build session's chat history from the opencode
+        store. Best-effort and eventually consistent: it only reaches the
+        live store, so the S3 blob keeps the history until the next sleep.
+        """
+        session_path = self._session_directory(session_id)
+        with self._build_serve_client(
+            sandbox_id,
+            session_path,
+            with_event_bus=False,
+        ) as client:
+            client.delete_session(opencode_session_id, directory=session_path)
+
     def list_subagents(
         self,
         sandbox_id: UUID,
@@ -463,6 +481,7 @@ class _ServeMixin:
         agent_provider: str | None,
         agent_model: str | None,
         *,
+        expect_existing_opencode_session: bool = False,
         on_opencode_session_resolved: Callable[[str], None] | None = None,
         should_interrupt: Callable[[], bool] | None = None,
     ) -> Generator[SandboxEvent, None, None]:
@@ -483,6 +502,7 @@ class _ServeMixin:
                 opencode_session_id,
                 directory=session_path,
                 title=f"build-session-{str(session_id)[:8]}",
+                expect_existing=expect_existing_opencode_session,
             )
             if resolved_session_id != opencode_session_id:
                 # Caller must persist the new id or we orphan one opencode

--- a/backend/onyx/server/features/build/sandbox/tasks/tasks.py
+++ b/backend/onyx/server/features/build/sandbox/tasks/tasks.py
@@ -90,6 +90,26 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
                 task_logger.info(f"Putting sandbox {sandbox_id_str} to sleep")
 
                 try:
+                    # A failed history snapshot aborts the sleep: terminating
+                    # would roll history back to the previous snapshot. But
+                    # only when the pod is actually reachable — otherwise a
+                    # dead pod would pin the sandbox in RUNNING forever.
+                    try:
+                        sandbox_manager.create_opencode_data_snapshot(
+                            sandbox_id, tenant_id
+                        )
+                    except Exception as e:
+                        if sandbox_manager.health_check(sandbox_id, timeout=5.0):
+                            task_logger.error(
+                                f"opencode-data snapshot failed for sandbox "
+                                f"{sandbox_id_str}; leaving it RUNNING: {e}"
+                            )
+                            continue
+                        task_logger.warning(
+                            f"Sandbox {sandbox_id_str} pod unreachable; sleeping "
+                            f"without a fresh history snapshot: {e}"
+                        )
+
                     # List session directories in the sandbox via the
                     # backend-agnostic manager API. K8s lists pod paths via
                     # exec; Docker lists container paths via exec; Local

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -48,6 +48,7 @@ from onyx.server.features.build.db.build_session import get_build_session
 from onyx.server.features.build.db.build_session import get_empty_session_for_user
 from onyx.server.features.build.db.build_session import get_session_messages
 from onyx.server.features.build.db.build_session import get_user_build_sessions
+from onyx.server.features.build.db.build_session import session_has_assistant_messages
 from onyx.server.features.build.db.build_session import update_session_activity
 from onyx.server.features.build.db.sandbox import get_sandbox_by_user_id
 from onyx.server.features.build.db.sandbox import get_snapshots_for_session
@@ -222,6 +223,20 @@ class SessionManager:
         session's frontend-ready state aligned with the agent runtime being
         ready to accept the first user message.
         """
+        # Never touch a non-empty session's id: ensure_opencode_session
+        # mints a replacement when the persisted one doesn't resolve, which
+        # would silently discard the session's history.
+        if session.opencode_session_id is not None and session_has_assistant_messages(
+            session.id, self._db_session
+        ):
+            logger.warning(
+                "Refusing to prewarm opencode session for non-empty build "
+                "session %s (persisted id %s must not be replaced)",
+                session.id,
+                session.opencode_session_id,
+            )
+            return
+
         opencode_session_id = self._sandbox_manager.ensure_opencode_session(
             sandbox_id=sandbox_id,
             session_id=session.id,
@@ -650,6 +665,18 @@ class SessionManager:
         # Get user's sandbox to clean up session workspace
         sandbox = get_sandbox_by_user_id(self._db_session, user_id)
         if sandbox and sandbox.status.is_active():
+            if session.opencode_session_id:
+                try:
+                    self._sandbox_manager.delete_opencode_session(
+                        sandbox.id, session_id, session.opencode_session_id
+                    )
+                except Exception:
+                    logger.warning(
+                        "Failed to delete opencode session for %s",
+                        session_id,
+                        exc_info=True,
+                    )
+
             # Clean up session workspace (but don't terminate sandbox)
             try:
                 self._sandbox_manager.cleanup_session_workspace(
@@ -1506,6 +1533,15 @@ class SessionManager:
             return True
 
         try:
+            # Snapshot chat history so sessions still resume after the
+            # wipe; skip when the pod is unreachable.
+            if sandbox.status == SandboxStatus.RUNNING and (
+                self._sandbox_manager.health_check(sandbox.id, timeout=5.0)
+            ):
+                self._sandbox_manager.create_opencode_data_snapshot(
+                    sandbox.id, get_current_tenant_id()
+                )
+
             # Terminate the sandbox (this cleans up all resources)
             self._sandbox_manager.terminate(sandbox.id)
             logger.info("Terminated sandbox %s for user %s", sandbox.id, user_id)

--- a/backend/onyx/server/features/build/session/sandbox_lifecycle.py
+++ b/backend/onyx/server/features/build/session/sandbox_lifecycle.py
@@ -187,6 +187,17 @@ def ensure_sandbox_ready(
             "Sandbox %s marked RUNNING but pod is unhealthy/missing; recovering.",
             sandbox.id,
         )
+        # Best-effort history snapshot: the sidecar may be up even if
+        # opencode isn't.
+        try:
+            sandbox_manager.create_opencode_data_snapshot(
+                sandbox.id, get_current_tenant_id(), timeout_seconds=30.0
+            )
+        except Exception:
+            logger.warning(
+                "opencode-data snapshot failed during recovery of sandbox %s",
+                sandbox.id,
+            )
         sandbox_manager.terminate(sandbox.id)
         update_sandbox_status__no_commit(
             db_session, sandbox.id, SandboxStatus.TERMINATED

--- a/backend/onyx/server/features/build/session/streaming.py
+++ b/backend/onyx/server/features/build/session/streaming.py
@@ -38,6 +38,7 @@ from onyx.server.features.build.api.packets import ErrorPacket
 from onyx.server.features.build.api.packets import SubagentStartedPacket
 from onyx.server.features.build.db.build_session import create_message
 from onyx.server.features.build.db.build_session import get_build_session
+from onyx.server.features.build.db.build_session import session_has_assistant_messages
 from onyx.server.features.build.db.build_session import update_session_activity
 from onyx.server.features.build.db.build_session import upsert_agent_plan
 from onyx.server.features.build.db.sandbox import get_sandbox_by_user_id
@@ -52,6 +53,9 @@ from onyx.server.features.build.sandbox.event_schema import PromptResponse
 from onyx.server.features.build.sandbox.event_schema import ToolCallProgress
 from onyx.server.features.build.sandbox.event_schema import ToolCallStart
 from onyx.server.features.build.sandbox.opencode.serve_client import _merge_field_meta
+from onyx.server.features.build.sandbox.opencode.serve_client import (
+    OpencodeSessionLostError,
+)
 from onyx.server.features.build.sandbox.sse import SSEKeepalive
 from onyx.utils.logger import setup_logger
 
@@ -415,11 +419,12 @@ def yield_sandbox_events(
 ) -> Generator[Any, None, None]:
     """Drive the agent to completion, yielding raw sandbox events.
 
-    Thin pass-through to ``sandbox_manager.send_message`` — no DB reads,
-    no SSE formatting. Callers resolve the turn inputs first
-    (interactive path off the session row it holds; headless via
-    :func:`load_turn_session`), then compose the events with
-    `persist_sandbox_event` and, in the SSE case, an SSE serializer.
+    Thin pass-through to ``sandbox_manager.send_message`` — no SSE
+    formatting, and no DB reads beyond the history-presence check below.
+    Callers resolve the turn inputs first (interactive path off the
+    session row it holds; headless via :func:`load_turn_session`), then
+    compose the events with `persist_sandbox_event` and, in the SSE case,
+    an SSE serializer.
 
     The events include `SSEKeepalive` markers from the sandbox client;
     callers should pass them through (interactive) or drop them
@@ -433,16 +438,33 @@ def yield_sandbox_events(
         # opencode session (dropping conversation history).
         _persist_opencode_session_id(db_session, session_id, new_id)
 
-    yield from sandbox_manager.send_message(
-        sandbox_id,
-        session_id,
-        user_message_content,
-        opencode_session_id=opencode_session_id,
-        agent_provider=agent_provider,
-        agent_model=agent_model,
-        on_opencode_session_resolved=_persist_resolved_id,
-        should_interrupt=should_interrupt,
+    # On a history-persisting backend, a stale id for a session the agent
+    # has responded in means history was lost — fail the turn loudly.
+    # Without persistence (Docker), stale ids are normal: mint silently.
+    expect_existing = (
+        sandbox_manager.supports_opencode_history_persistence
+        and opencode_session_id is not None
+        and session_has_assistant_messages(session_id, db_session)
     )
+
+    try:
+        yield from sandbox_manager.send_message(
+            sandbox_id,
+            session_id,
+            user_message_content,
+            opencode_session_id=opencode_session_id,
+            agent_provider=agent_provider,
+            agent_model=agent_model,
+            expect_existing_opencode_session=expect_existing,
+            on_opencode_session_resolved=_persist_resolved_id,
+            should_interrupt=should_interrupt,
+        )
+    except OpencodeSessionLostError:
+        # Loud once, then recover: this turn fails visibly, and clearing
+        # the dangling id lets the next turn mint a fresh opencode session
+        # instead of erroring forever.
+        _clear_opencode_session_id(db_session, session_id)
+        raise
 
 
 def _ensure_opencode_session_id(
@@ -478,6 +500,22 @@ def _ensure_opencode_session_id(
         build_session.id,
     )
     return new_id
+
+
+def _clear_opencode_session_id(db_session: DBSession, session_id: UUID) -> None:
+    build_session = (
+        db_session.query(BuildSession).filter(BuildSession.id == session_id).first()
+    )
+    if build_session is None:
+        return
+    logger.warning(
+        "[SESSION-LIFECYCLE] clearing lost opencode_session_id %s for "
+        "build_session=%s; next turn starts a fresh opencode session",
+        build_session.opencode_session_id,
+        session_id,
+    )
+    build_session.opencode_session_id = None
+    db_session.commit()
 
 
 def _persist_opencode_session_id(

--- a/backend/tests/common/craft/stubs.py
+++ b/backend/tests/common/craft/stubs.py
@@ -131,6 +131,8 @@ class StubSandboxManager(SandboxManager):
         self.health_check_returns: bool | None = None
         self.session_workspace_exists_returns: bool | None = None
         self.create_snapshot_returns: SnapshotResult | None | object = _UNSET
+        self.create_opencode_data_snapshot_returns: bool = False
+        self.supports_opencode_history_persistence: bool = True
         self.list_directory_returns: list[FilesystemEntry] | None = None
         self.read_file_returns: bytes | None = None
         self.upload_file_returns: str | None = None
@@ -153,6 +155,7 @@ class StubSandboxManager(SandboxManager):
 
         # Fault injection.
         self.write_files_to_sandbox_raises_for: dict[UUID, Exception] | None = None
+        self.create_opencode_data_snapshot_raises: Exception | None = None
 
         # ``send_message_events`` is stored via the property below so it is
         # materialised at assignment time (see __setattr__-like setter).
@@ -165,6 +168,8 @@ class StubSandboxManager(SandboxManager):
         self.setup_session_workspace_count: int = 0
         self.cleanup_session_workspace_count: int = 0
         self.create_snapshot_count: int = 0
+        self.create_opencode_data_snapshot_count: int = 0
+        self.delete_opencode_session_count: int = 0
         self.restore_snapshot_count: int = 0
         self.session_workspace_exists_count: int = 0
         self.list_session_workspaces_count: int = 0
@@ -190,6 +195,8 @@ class StubSandboxManager(SandboxManager):
         self.last_setup_session_workspace_payload: dict[str, Any] | None = None
         self.last_cleanup_session_workspace_payload: dict[str, Any] | None = None
         self.last_create_snapshot_payload: dict[str, Any] | None = None
+        self.last_create_opencode_data_snapshot_payload: dict[str, Any] | None = None
+        self.last_delete_opencode_session_payload: dict[str, Any] | None = None
         self.last_restore_snapshot_payload: dict[str, Any] | None = None
         self.last_session_workspace_exists_payload: dict[str, Any] | None = None
         self.last_health_check_payload: dict[str, Any] | None = None
@@ -314,6 +321,36 @@ class StubSandboxManager(SandboxManager):
             raise _not_configured("create_snapshot")
         return cast("SnapshotResult | None", self.create_snapshot_returns)
 
+    def create_opencode_data_snapshot(
+        self,
+        sandbox_id: UUID,
+        tenant_id: str,
+        timeout_seconds: float = 300.0,  # noqa: ARG002
+    ) -> bool:
+        self.create_opencode_data_snapshot_count += 1
+        self.last_create_opencode_data_snapshot_payload = {
+            "sandbox_id": sandbox_id,
+            "tenant_id": tenant_id,
+        }
+        if self.create_opencode_data_snapshot_raises is not None:
+            raise self.create_opencode_data_snapshot_raises
+        return self.create_opencode_data_snapshot_returns
+
+    def delete_opencode_session(
+        self,
+        sandbox_id: UUID,
+        session_id: UUID,
+        opencode_session_id: str,
+    ) -> None:
+        # Override the _ServeMixin implementation — there is no pod to
+        # reach under the stub.
+        self.delete_opencode_session_count += 1
+        self.last_delete_opencode_session_payload = {
+            "sandbox_id": sandbox_id,
+            "session_id": session_id,
+            "opencode_session_id": opencode_session_id,
+        }
+
     def restore_snapshot(
         self,
         sandbox_id: UUID,
@@ -393,6 +430,7 @@ class StubSandboxManager(SandboxManager):
         opencode_session_id: str | None = None,
         agent_provider: str | None = None,
         agent_model: str | None = None,
+        expect_existing_opencode_session: bool = False,
         on_opencode_session_resolved: Callable[[str], None] | None = None,
         should_interrupt: Callable[[], bool] | None = None,
     ) -> Generator[SandboxEvent, None, None]:
@@ -404,6 +442,7 @@ class StubSandboxManager(SandboxManager):
             "opencode_session_id": opencode_session_id,
             "agent_provider": agent_provider,
             "agent_model": agent_model,
+            "expect_existing_opencode_session": expect_existing_opencode_session,
             "on_opencode_session_resolved": on_opencode_session_resolved,
             "should_interrupt": should_interrupt,
         }

--- a/backend/tests/external_dependency_unit/craft/conftest.py
+++ b/backend/tests/external_dependency_unit/craft/conftest.py
@@ -875,12 +875,15 @@ def _cleanup_pool_workspace(
         "-mindepth 1 -delete 2>/dev/null; true",
         container="sidecar",
     )
-    # sessions/ is the per-session emptyDir tree.
+    # sessions/ is the per-session emptyDir tree. Preserve .opencode-data
+    # (the live opencode store): opencode-serve holds the sqlite db open.
     pod_exec(
         k8s_client,
         pod_name,
         SANDBOX_NAMESPACE,
-        "find /workspace/sessions -mindepth 1 -delete 2>/dev/null; true",
+        "find /workspace/sessions -mindepth 1 "
+        "-not -path '/workspace/sessions/.opencode-data*' -delete "
+        "2>/dev/null; true",
         container="sandbox",
     )
 

--- a/backend/tests/external_dependency_unit/craft/test_idle_cleanup.py
+++ b/backend/tests/external_dependency_unit/craft/test_idle_cleanup.py
@@ -156,6 +156,87 @@ def test_idle_sandbox_snapshotted_then_terminated_then_sleep_status(
     assert stubbed_cleanup.terminate_count == 1
     assert stubbed_cleanup.last_terminate_sandbox_id == sandbox.id
 
+    # Chat history must be snapshotted before the pod is destroyed.
+    assert stubbed_cleanup.create_opencode_data_snapshot_count == 1
+
+
+def test_opencode_data_snapshot_failure_aborts_sleep(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+    stubbed_cleanup: StubSandboxManager,
+    short_idle_threshold: int,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A failed opencode-data (chat history) snapshot aborts the sleep —
+    but only while the pod is reachable.
+
+    Terminating anyway would silently roll history back to the previous
+    snapshot on the next wake — the sandbox must stay RUNNING so the next
+    cleanup cycle retries. The history snapshot runs first, so the abort
+    also skips the per-session snapshots (no duplicate rows per retry).
+    """
+    user = make_user(db_session)
+    sandbox = make_sandbox(db_session, user)
+    session_row = BuildSession(
+        user_id=user.id,
+        name="abort-sleep-session",
+        status=BuildSessionStatus.ACTIVE,
+    )
+    db_session.add(session_row)
+    db_session.commit()
+    db_session.refresh(session_row)
+
+    _backdate_heartbeat(db_session, sandbox, seconds_ago=short_idle_threshold * 4)
+
+    stubbed_cleanup.list_session_workspaces_returns = [session_row.id]
+    stubbed_cleanup.create_opencode_data_snapshot_raises = RuntimeError(
+        "S3 unreachable"
+    )
+    stubbed_cleanup.health_check_returns = True
+    stubbed_cleanup.terminate_silent = True
+
+    with caplog.at_level(logging.ERROR):
+        cleanup_idle_sandboxes_task.run(tenant_id=TEST_TENANT_ID)
+
+    db_session.expire_all()
+    refreshed = db_session.get(Sandbox, sandbox.id)
+    assert refreshed is not None
+    assert refreshed.status == SandboxStatus.RUNNING
+    assert stubbed_cleanup.terminate_count == 0
+    assert stubbed_cleanup.create_snapshot_count == 0
+    assert any(
+        "opencode-data snapshot failed" in r.getMessage() for r in caplog.records
+    )
+
+
+def test_opencode_data_snapshot_failure_on_dead_pod_still_sleeps(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+    stubbed_cleanup: StubSandboxManager,
+    short_idle_threshold: int,
+) -> None:
+    """An unreachable pod must not pin the sandbox in RUNNING forever:
+    the sleep proceeds without a fresh history snapshot (the previous
+    blob is intact)."""
+    user = make_user(db_session)
+    sandbox = make_sandbox(db_session, user)
+    _backdate_heartbeat(db_session, sandbox, seconds_ago=short_idle_threshold * 4)
+
+    stubbed_cleanup.list_session_workspaces_returns = []
+    stubbed_cleanup.create_opencode_data_snapshot_raises = RuntimeError(
+        "sidecar unreachable"
+    )
+    stubbed_cleanup.health_check_returns = False
+    stubbed_cleanup.terminate_silent = True
+
+    cleanup_idle_sandboxes_task.run(tenant_id=TEST_TENANT_ID)
+
+    db_session.expire_all()
+    refreshed = db_session.get(Sandbox, sandbox.id)
+    assert refreshed is not None
+    assert refreshed.status == SandboxStatus.SLEEPING
+    assert stubbed_cleanup.terminate_count == 1
+
 
 def test_active_sandbox_within_threshold_not_touched(
     db_session: Session,

--- a/backend/tests/external_dependency_unit/craft/test_kubernetes_sandbox_file_ops.py
+++ b/backend/tests/external_dependency_unit/craft/test_kubernetes_sandbox_file_ops.py
@@ -263,7 +263,7 @@ class TestCreateSnapshot:
             pod_name,
             SANDBOX_NAMESPACE,
             f"rm -rf {session_root}/outputs {session_root}/attachments "
-            f"{session_root}/.opencode-data 2>/dev/null; true",
+            f"2>/dev/null; true",
         )
 
         result = k8s_manager.create_snapshot(

--- a/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
@@ -262,6 +262,7 @@ class TestDeleteSession:
             user_id=test_user.id,
             name="cascading",
             status=BuildSessionStatus.ACTIVE,
+            opencode_session_id="ses_cascading",
         )
         db_session.add(session_row)
         db_session.commit()
@@ -313,6 +314,13 @@ class TestDeleteSession:
             db_session.query(Artifact).filter(Artifact.id == artifact_id).one_or_none()
             is None
         )
+
+        # Chat history is pruned from the sandbox-global opencode store.
+        assert stub_sandbox_manager.delete_opencode_session_count == 1
+        payload = stub_sandbox_manager.last_delete_opencode_session_payload
+        assert payload is not None
+        assert payload["session_id"] == session_id
+        assert payload["opencode_session_id"] == "ses_cascading"
 
     def test_delete_session_removes_s3_snapshots(
         self,

--- a/backend/tests/external_dependency_unit/craft/test_snapshot_restore.py
+++ b/backend/tests/external_dependency_unit/craft/test_snapshot_restore.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import io
 import os
+import sqlite3
 import tarfile
 from pathlib import Path
 from typing import Any
@@ -71,7 +72,6 @@ def _populate_session_workspace(
         "outputs/web/page.tsx": "// hello from outputs\n",
         "outputs/data/manifest.json": '{"v": 1}\n',
         "attachments/notes.txt": "user uploaded notes\n",
-        ".opencode-data/session.json": '{"id": "deadbeef"}\n',
     }
 
     script_lines = ["set -e", f"cd {session_path}"]
@@ -166,7 +166,7 @@ def _list_archive_members(tar_path: Path) -> list[str]:
 # ---------------------------------------------------------------------------
 
 
-def test_snapshot_includes_outputs_and_attachments_and_opencode_data(
+def test_snapshot_includes_outputs_and_attachments(
     k8s_manager: KubernetesSandboxManager,
     k8s_client: client.CoreV1Api,
     pool_session: tuple[UUID, UUID, str],
@@ -191,14 +191,136 @@ def test_snapshot_includes_outputs_and_attachments_and_opencode_data(
     assert any(m == "attachments" or m.startswith("attachments/") for m in members), (
         f"Expected attachments/ tree. Members: {members}"
     )
-    assert any(
-        m == ".opencode-data" or m.startswith(".opencode-data/") for m in members
-    ), f"Expected .opencode-data/ tree. Members: {members}"
+    # opencode chat history is sandbox-global and captured by the separate
+    # opencode-data snapshot — never per-session.
+    assert not any(".opencode-data" in m for m in members), (
+        f"Per-session snapshot must not contain .opencode-data. Members: {members}"
+    )
 
     # The specific seed files should round-trip.
     assert any(m.endswith("outputs/web/page.tsx") for m in members)
     assert any(m.endswith("attachments/notes.txt") for m in members)
-    assert any(m.endswith(".opencode-data/session.json") for m in members)
+
+
+_OC_DB = "/workspace/sessions/.opencode-data/opencode/opencode.db"
+
+
+def _seed_opencode_db(k8s: client.CoreV1Api, pod_name: str, value: str) -> None:
+    """Create a real sqlite db in the pod (VACUUM INTO requires one)."""
+    py = (
+        "import sqlite3, os; "
+        f"os.makedirs(os.path.dirname('{_OC_DB}'), exist_ok=True); "
+        f"c = sqlite3.connect('{_OC_DB}'); "
+        "c.execute('CREATE TABLE IF NOT EXISTS t (v TEXT)'); "
+        "c.execute('DELETE FROM t'); "
+        f"c.execute('INSERT INTO t VALUES (?)', ('{value}',)); "
+        "c.commit(); c.close()"
+    )
+    pod_exec(k8s, pod_name, SANDBOX_NAMESPACE, ["python3", "-c", py])
+
+
+def _run_restore_init(k8s: client.CoreV1Api, pod_name: str, sandbox_id: UUID) -> str:
+    """Run the opencode_restore init-container module in the sidecar
+    (same image/env as the real init container) and report its exit code."""
+    cmd = (
+        f"cd /workspace && ONYX_SANDBOX_ID={sandbox_id} "
+        f"ONYX_TENANT_ID={TEST_TENANT_ID} SANDBOX_S3_BUCKET={SANDBOX_S3_BUCKET} "
+        "/workspace/.venv/bin/python -m sandbox_daemon.opencode_restore 2>&1; "
+        "echo EXIT=$?"
+    )
+    return pod_exec(k8s, pod_name, SANDBOX_NAMESPACE, cmd, container="sidecar")
+
+
+def test_opencode_data_snapshot_round_trip(
+    k8s_manager: KubernetesSandboxManager,
+    k8s_client: client.CoreV1Api,
+    pool_session: tuple[UUID, UUID, str],
+    tmp_path: Path,
+) -> None:
+    """VACUUM INTO snapshot of the opencode sqlite db → S3, then the
+    init-container restore module brings it back intact."""
+    sandbox_id, _session_id, pod_name = pool_session
+
+    storage_path = f"{TEST_TENANT_ID}/snapshots/opencode-data/{sandbox_id}/latest.db"
+
+    _seed_opencode_db(k8s_client, pod_name, "history-marker")
+    created = k8s_manager.create_opencode_data_snapshot(sandbox_id, TEST_TENANT_ID)
+    assert created, "db was seeded; snapshot must not be empty"
+
+    # The blob is a plain consistent sqlite db — verify by opening it.
+    local_db = tmp_path / "latest.db"
+    _download_snapshot(storage_path, local_db)
+    conn = sqlite3.connect(local_db)
+    try:
+        rows = conn.execute("SELECT v FROM t").fetchall()
+    finally:
+        conn.close()
+    assert rows == [("history-marker",)]
+
+    # Fresh pod: store gone; the restore module brings the db back.
+    pod_exec(k8s_client, pod_name, SANDBOX_NAMESPACE, f"rm -rf {_OC_DB}")
+    out = _run_restore_init(k8s_client, pod_name, sandbox_id)
+    assert "EXIT=0" in out, out
+    restored = pod_exec(
+        k8s_client,
+        pod_name,
+        SANDBOX_NAMESPACE,
+        [
+            "python3",
+            "-c",
+            f"import sqlite3; print(sqlite3.connect('{_OC_DB}').execute('SELECT v FROM t').fetchall())",
+        ],
+    )
+    assert "history-marker" in restored
+
+    _delete_snapshot(storage_path)
+
+
+def test_opencode_data_restore_edge_cases(
+    k8s_manager: KubernetesSandboxManager,
+    k8s_client: client.CoreV1Api,
+    pool_session: tuple[UUID, UUID, str],
+) -> None:
+    """Missing blob = fresh sandbox (exit 0, no file). Corrupt blob =
+    fail closed (nonzero exit fails pod startup; no partial file left).
+    Empty store = nothing snapshotted."""
+    sandbox_id, _session_id, pod_name = pool_session
+
+    storage_path = f"{TEST_TENANT_ID}/snapshots/opencode-data/{sandbox_id}/latest.db"
+
+    # Missing blob → exit 0 and no db written.
+    _delete_snapshot(storage_path)
+    pod_exec(k8s_client, pod_name, SANDBOX_NAMESPACE, f"rm -rf {_OC_DB}")
+    out = _run_restore_init(k8s_client, pod_name, sandbox_id)
+    assert "EXIT=0" in out, out
+    state = pod_exec(
+        k8s_client,
+        pod_name,
+        SANDBOX_NAMESPACE,
+        f"[ -f {_OC_DB} ] && echo DB_PRESENT || echo DB_MISSING",
+    )
+    assert "DB_MISSING" in state
+
+    # Corrupt blob → nonzero exit (pod startup would fail → retriable),
+    # and no partial file left behind.
+    _put_snapshot_bytes(storage_path, b"definitely not a sqlite db")
+    out = _run_restore_init(k8s_client, pod_name, sandbox_id)
+    assert "EXIT=1" in out, out
+    state = pod_exec(
+        k8s_client,
+        pod_name,
+        SANDBOX_NAMESPACE,
+        f"ls /workspace/sessions/.opencode-data/opencode/ 2>/dev/null; "
+        f"[ -f {_OC_DB} ] && echo DB_PRESENT || echo DB_MISSING",
+    )
+    assert "DB_MISSING" in state
+    assert ".restore" not in state, "partial download must be cleaned up"
+    _delete_snapshot(storage_path)
+
+    # Empty store → nothing to snapshot.
+    assert (
+        k8s_manager.create_opencode_data_snapshot(sandbox_id, TEST_TENANT_ID) is False
+    )
 
 
 def test_snapshot_excludes_managed_skills_agents_md_opencode_json(
@@ -259,7 +381,7 @@ def test_restore_from_snapshot_recreates_workspace(
         pod_name,
         SANDBOX_NAMESPACE,
         f"cd /workspace/sessions/{session_id} && "
-        f"find outputs attachments .opencode-data -type f | sort | "
+        f"find outputs attachments -type f | sort | "
         f"xargs sha256sum",
     )
 
@@ -295,7 +417,7 @@ def test_restore_from_snapshot_recreates_workspace(
         pod_name,
         SANDBOX_NAMESPACE,
         f"cd /workspace/sessions/{session_id} && "
-        f"find outputs attachments .opencode-data -type f | sort | "
+        f"find outputs attachments -type f | sort | "
         f"xargs sha256sum",
     )
     assert pre_hashes.strip() == post_hashes.strip(), (

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_ensure_session.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_ensure_session.py
@@ -26,9 +26,13 @@ import json
 from typing import Any
 
 import httpx
+import pytest
 
 from onyx.server.features.build.sandbox.opencode.serve_client import ClientTimeouts
 from onyx.server.features.build.sandbox.opencode.serve_client import OpencodeServeClient
+from onyx.server.features.build.sandbox.opencode.serve_client import (
+    OpencodeSessionLostError,
+)
 
 _STALE_ID = "ses_stale_old_id_001"
 _FRESH_ID = "ses_fresh_new_id_002"
@@ -217,6 +221,46 @@ def test_ensure_session_passes_directory_as_query_string() -> None:
     # and the Session.create schema would silently drop it.
     body = json.loads(post_req.content)
     assert "directory" not in body
+
+
+def test_ensure_session_expect_existing_raises_on_stale_id() -> None:
+    """For a session with prior history (``expect_existing=True``), a stale
+    persisted id means the opencode store was lost — ensure_session MUST
+    raise instead of minting a replacement, so history loss can't
+    masquerade as a fresh chat. No POST must be issued."""
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.method == "GET" and req.url.path == f"/session/{_STALE_ID}":
+            return httpx.Response(404, json={"error": "not found"})
+        raise AssertionError(f"unexpected request {req.method} {req.url.path}")
+
+    transport = _RecordingTransport(handler)
+    client = _make_client(transport)
+
+    with pytest.raises(OpencodeSessionLostError):
+        client.ensure_session(_STALE_ID, directory=_CWD, expect_existing=True)
+
+    # Exactly one request: the lookup. We did NOT fall through to POST.
+    assert len(transport.requests) == 1
+    assert transport.requests[0].method == "GET"
+
+
+def test_ensure_session_expect_existing_reuses_valid_id() -> None:
+    """``expect_existing=True`` with a still-valid id behaves exactly like
+    the happy path: one GET, no POST, same id returned."""
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.method == "GET" and req.url.path == f"/session/{_STALE_ID}":
+            return httpx.Response(200, json={"id": _STALE_ID})
+        raise AssertionError(f"unexpected request {req.method} {req.url.path}")
+
+    transport = _RecordingTransport(handler)
+    client = _make_client(transport)
+
+    resolved = client.ensure_session(_STALE_ID, directory=_CWD, expect_existing=True)
+
+    assert resolved == _STALE_ID
+    assert len(transport.requests) == 1
 
 
 def test_ensure_session_callback_does_not_fire_on_valid_id() -> None:

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_pod_spec.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_pod_spec.py
@@ -236,11 +236,22 @@ def test_proxy_env_is_set_on_sandbox_and_sidecar(pod: client.V1Pod) -> None:
         )
 
 
-def test_proxy_init_container_present(pod: client.V1Pod) -> None:
+def test_init_container_ordering(pod: client.V1Pod) -> None:
     """The iptables-lockdown initContainer must run before any user code —
-    it's what blocks direct egress that the HTTPS_PROXY env doesn't catch."""
+    it's what blocks direct egress that the HTTPS_PROXY env doesn't catch.
+    The chat-history restore runs after it (so s5cmd routes through the
+    proxy) and before all regular containers, so opencode-serve can never
+    open the store mid-restore."""
     init_names = [c.name for c in (pod.spec.init_containers or [])]
-    assert init_names == ["sandbox-init"]
+    assert init_names == ["sandbox-init", "opencode-restore"]
+
+
+def test_opencode_restore_init_container_wiring(pod: client.V1Pod) -> None:
+    restore = next(c for c in pod.spec.init_containers if c.name == "opencode-restore")
+    env = {e.name for e in restore.env or []}
+    assert {"ONYX_SANDBOX_ID", "ONYX_TENANT_ID", "SANDBOX_S3_BUCKET"} <= env
+    mounts = {m.name: m.mount_path for m in restore.volume_mounts or []}
+    assert mounts.get("workspace") == "/workspace/sessions"
 
 
 def test_host_aliases_pin_proxy(pod: client.V1Pod) -> None:

--- a/backend/tests/unit/onyx/server/features/build/session/test_prewarm_opencode_session.py
+++ b/backend/tests/unit/onyx/server/features/build/session/test_prewarm_opencode_session.py
@@ -61,7 +61,13 @@ def test_prewarm_opencode_session_persists_resolved_id(
     initial_id: str | None,
     resolved_id: str,
     flush_count: int,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # Empty session (no assistant messages) — prewarm may mint/replace.
+    monkeypatch.setattr(
+        "onyx.server.features.build.session.manager.session_has_assistant_messages",
+        lambda *_args: False,
+    )
     sandbox_id = uuid4()
     session = _build_session(initial_id)
     sandbox_manager = _FakeSandboxManager(resolved_id)
@@ -72,6 +78,28 @@ def test_prewarm_opencode_session_persists_resolved_id(
     assert session.opencode_session_id == resolved_id
     assert db_session.flush_count == flush_count
     assert sandbox_manager.calls == [(sandbox_id, session.id, initial_id)]
+
+
+def test_prewarm_opencode_session_refuses_non_empty_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A session with assistant history must keep its persisted opencode id:
+    prewarm must not call ensure_opencode_session at all (a 404 there would
+    mint a replacement and silently discard the chat history)."""
+    monkeypatch.setattr(
+        "onyx.server.features.build.session.manager.session_has_assistant_messages",
+        lambda *_args: True,
+    )
+    sandbox_id = uuid4()
+    session = _build_session("persisted-opencode")
+    sandbox_manager = _FakeSandboxManager("fresh-opencode")
+    db_session = _FakeDbSession()
+
+    _manager(sandbox_manager, db_session)._prewarm_opencode_session(sandbox_id, session)
+
+    assert session.opencode_session_id == "persisted-opencode"
+    assert db_session.flush_count == 0
+    assert sandbox_manager.calls == []
 
 
 def test_prewarm_opencode_session_raises_when_runtime_returns_no_id() -> None:

--- a/backend/tests/unit/onyx/server/features/build/session/test_yield_sandbox_events_expect_existing.py
+++ b/backend/tests/unit/onyx/server/features/build/session/test_yield_sandbox_events_expect_existing.py
@@ -1,0 +1,135 @@
+"""Locks the ``expect_existing_opencode_session`` wiring in
+``streaming.yield_sandbox_events``.
+
+The flag is what makes history loss loud (OpencodeSessionLostError) instead
+of silently minting a fresh opencode session — it must be set exactly when
+(a) the backend persists the opencode store across re-provisions, (b) a
+session id was persisted, and (c) the agent has already responded.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from typing import cast
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session as DBSession
+
+from onyx.server.features.build.session import streaming
+from tests.common.craft.stubs import StubSandboxManager
+
+
+def _drive(
+    stub: StubSandboxManager,
+    *,
+    opencode_session_id: str | None,
+) -> dict[str, Any]:
+    stub.send_message_events = []
+    list(
+        streaming.yield_sandbox_events(
+            # The db session only reaches the monkeypatched history helper.
+            cast(DBSession, object()),
+            stub,
+            uuid4(),
+            uuid4(),
+            "hello",
+            opencode_session_id=opencode_session_id,
+            agent_provider=None,
+            agent_model=None,
+        )
+    )
+    assert stub.last_send_message_payload is not None
+    return stub.last_send_message_payload
+
+
+@pytest.mark.parametrize(
+    ("has_assistant_messages", "opencode_session_id", "expected"),
+    [
+        pytest.param(True, "ses_persisted", True, id="history-present"),
+        pytest.param(False, "ses_persisted", False, id="no-assistant-messages"),
+        pytest.param(True, None, False, id="no-persisted-id"),
+    ],
+)
+def test_expect_existing_set_from_history_and_persisted_id(
+    has_assistant_messages: bool,
+    opencode_session_id: str | None,
+    expected: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        streaming,
+        "session_has_assistant_messages",
+        lambda *_args: has_assistant_messages,
+    )
+    stub = StubSandboxManager()
+
+    payload = _drive(stub, opencode_session_id=opencode_session_id)
+
+    assert payload["expect_existing_opencode_session"] is expected
+
+
+def test_session_lost_error_clears_persisted_id_and_reraises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """History loss is loud once, then recoverable: the turn fails with
+    OpencodeSessionLostError, and the dangling id is cleared so the next
+    turn mints a fresh opencode session instead of erroring forever."""
+    from onyx.server.features.build.sandbox.opencode.serve_client import (
+        OpencodeSessionLostError,
+    )
+
+    monkeypatch.setattr(
+        streaming, "session_has_assistant_messages", lambda *_args: True
+    )
+    cleared: list[Any] = []
+    monkeypatch.setattr(
+        streaming,
+        "_clear_opencode_session_id",
+        lambda _db, sid: cleared.append(sid),
+    )
+    stub = StubSandboxManager()
+
+    def _raise(*_args: Any, **_kwargs: Any) -> Any:
+        raise OpencodeSessionLostError("history lost")
+        yield  # makes this a generator function
+
+    monkeypatch.setattr(stub, "send_message", _raise)
+
+    session_id = uuid4()
+    with pytest.raises(OpencodeSessionLostError):
+        list(
+            streaming.yield_sandbox_events(
+                cast(DBSession, object()),
+                stub,
+                uuid4(),
+                session_id,
+                "hello",
+                opencode_session_id="ses_persisted",
+                agent_provider=None,
+                agent_model=None,
+            )
+        )
+    assert cleared == [session_id]
+
+
+def test_expect_existing_false_without_history_persistence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Backends that don't restore the opencode store (Docker) must keep the
+    silent mint-a-fresh-session behavior — a stale id after sleep is
+    expected there, and a hard error would permanently brick the session."""
+    helper_calls: list[object] = []
+    monkeypatch.setattr(
+        streaming,
+        "session_has_assistant_messages",
+        lambda *args: helper_calls.append(args) or True,
+    )
+    stub = StubSandboxManager()
+    stub.supports_opencode_history_persistence = False
+
+    payload = _drive(stub, opencode_session_id="ses_persisted")
+
+    assert payload["expect_existing_opencode_session"] is False
+    # Capability short-circuits before the DB is consulted.
+    assert helper_calls == []

--- a/deployment/helm/charts/onyx/values-localdev.yaml
+++ b/deployment/helm/charts/onyx/values-localdev.yaml
@@ -81,6 +81,14 @@ configMap:
   # Host gateway (Docker Desktop), not internal cluster DNS; Linux-kind devs sub their own.
   SANDBOX_API_SERVER_URL: "http://host.docker.internal:3000"
   ENABLE_PAID_ENTERPRISE_EDITION_FEATURES: "true"
+  # Craft snapshot storage: the in-cluster MinIO (FQDN — sandbox pods live
+  # in the onyx-sandboxes namespace). The sandbox-proxy inherits these via
+  # envFrom, and its snapshot-egress allowlist must agree with what the
+  # sidecar / restore init container actually target. Telepresence devs
+  # must mirror these as AWS_* in their local api-server env
+  # (.vscode/.env.k8s) — the manager forwards them into sandbox pods.
+  SANDBOX_S3_BUCKET: "onyx-sandbox-files"
+  AWS_ENDPOINT_URL: "http://onyx-minio.onyx.svc.cluster.local:9000"
 
 sandboxProxy:
   replicaCount: 1

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1064,6 +1064,10 @@ minio:
   existingSecret: onyx-objectstorage
   buckets:
     - name: onyx-file-store-bucket
+    # Craft sandbox snapshots (workspace + opencode chat history). Must
+    # match SANDBOX_S3_BUCKET. Only relevant when ENABLE_CRAFT=true; in
+    # prod MinIO is disabled and the bucket lives in real S3.
+    - name: onyx-sandbox-files
   persistence:
     enabled: true
     size: 30Gi


### PR DESCRIPTION
Fixes [ENG-4167](https://linear.app/onyx-app/issue/ENG-4167/opencode-chat-history-is-never-captured-in-snapshots-session-resume).

## Problem

opencode-serve's store (`XDG_DATA_HOME`: a sqlite db holding all chat history, tool outputs, and agent state) lived at `/workspace/.opencode-data` — the main container's overlay fs. The shared emptyDir is mounted at `/workspace/sessions`, so the snapshot sidecar could never see it, and the per-session snapshot's `.opencode-data` entry pointed at a path that never existed. Every pod re-provision lost all chat history; the persisted `build_session.opencode_session_id` 404'd and the transport silently minted a fresh session ("no history available").

## Fix

**Save** — at idle-sleep (and best-effort before every terminate path), the sidecar takes a transactionally consistent copy of opencode's sqlite db via `VACUUM INTO` (safe while opencode has the db open; no wal/shm handling, no tar) and uploads the single file to a deterministic key: `{tenant}/snapshots/opencode-data/{sandbox_id}/latest.db`. No DB pointer. A failed save **aborts the sleep** (pod stays RUNNING, retried next cycle) — terminating would roll history back to the previous snapshot.

**Restore** — a new `opencode-restore` **initContainer** (same image; runs after the firewall init so s5cmd routes through the proxy) downloads the blob into the shared volume before any regular container starts. Missing blob = fresh sandbox, exit 0. Any failure (including a non-sqlite blob, checked by magic bytes) fails pod startup, so provisioning fails loudly and the retry restores again — it is impossible by construction for opencode to start mid-restore or to come up silently with empty history. Verified live in st-dev that the IRSA webhook injects credentials into initContainers (the existing `sandbox-init` gets them; the agent container stays excluded via `skip-containers`).

**Loud loss** — when the backend persists history (`SandboxManager.supports_opencode_history_persistence`: K8s true, Docker false) and the session has assistant messages, a stale opencode id raises `OpencodeSessionLostError` (user-readable message) instead of silently starting a fresh chat. Prewarm refuses to replace the id of a non-empty session. Docker (terminate deletes its volume; backend being reworked separately) keeps its existing silent-mint behavior.

**GC** — session delete prunes that session's history from the live opencode store (eventually consistent; converges at next sleep).

**Fixed in passing** — `PIPESTATUS` was read on separate lines in the per-session snapshot pipeline, which resets it: the s5cmd upload exit code was always seen as 0. Now copied atomically.

## Notes / accepted residuals

- Kubelet evictions still bypass the at-sleep snapshot (ENG-4166); a periodic `VACUUM INTO` upload loop in the sidecar is the natural follow-up there (~70 additive lines).
- The `latest.db` blob has no retention/GC on user deletion — snapshot retention doesn't exist yet for per-session blobs either.
- The `repos/` clone cache and logs are intentionally not persisted (caches; opencode re-creates them).

## Tests

- Unit: `ensure_session` expect-existing contract, prewarm guard, `expect_existing` wiring incl. capability short-circuit, pod-spec initContainer ordering + wiring (454 passing locally).
- External-dep: idle-cleanup asserts history-snapshot-first ordering and that a failed snapshot aborts the sleep; session delete asserts opencode-store pruning.
- K8s CI lane: VACUUM INTO round-trip (real sqlite db seeded in-pod, blob opened and queried locally, init-container module restores it), plus edge cases: missing blob (exit 0, no file), corrupt blob (exit 1, no partial file), empty store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)