### PR TITLE
fix(chat): runs survive client disconnect — workers own persistence

### DIFF
--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -14,6 +14,7 @@ from collections.abc import Callable
 from collections.abc import Generator
 from concurrent.futures import ThreadPoolExecutor
 from contextvars import Token
+from enum import Enum
 from typing import Final
 from uuid import UUID
 
@@ -1018,6 +1019,15 @@ def build_chat_turn(
 # Sentinel placed on the merged queue when a model thread finishes.
 _MODEL_DONE = object()
 
+
+# Which exit path persisted a model's outcome — for log attribution.
+class _PersistContext(Enum):
+    WORKER = "worker"
+    STOP_BUTTON = "stop-button"
+    NORMAL = "normal"
+    POST_STEPS = "post-steps"
+
+
 # How often the drain loop polls for user-initiated cancellation (stop button).
 _CANCEL_POLL_INTERVAL_S: Final[float] = 0.05
 
@@ -1081,7 +1091,10 @@ def _run_models(
     drain_done = threading.Event()
 
     def _persist_model_outcome(
-        model_idx: int, context: str, *, stop_button: bool = False
+        model_idx: int,
+        context: _PersistContext,
+        *,
+        stop_button: bool = False,
     ) -> None:
         """Persist one model's outcome exactly once, from any thread.
 
@@ -1120,7 +1133,7 @@ def _run_models(
         except Exception:
             logger.exception(
                 "%s completion failed for model %d (%s)",
-                context,
+                context.value,
                 model_idx,
                 setup.model_display_names[model_idx],
             )
@@ -1132,7 +1145,7 @@ def _run_models(
             post_steps_done.set()
 
         for i in range(n_models):
-            _persist_model_outcome(i, "post-steps")
+            _persist_model_outcome(i, _PersistContext.POST_STEPS)
 
         # _stream_chat_turn's own reset can be abandoned on disconnect; reset here
         # so the session never sticks at "processing". Normal exits (drain alive)
@@ -1248,7 +1261,7 @@ def _run_models(
             merged_queue.put((model_idx, e))
 
         finally:
-            _persist_model_outcome(model_idx, "worker")
+            _persist_model_outcome(model_idx, _PersistContext.WORKER)
 
             is_last = False
             with persist_lock:
@@ -1265,7 +1278,7 @@ def _run_models(
 
             merged_queue.put((model_idx, _MODEL_DONE))
 
-    def _save_errored_message(model_idx: int, context: str) -> None:
+    def _save_errored_message(model_idx: int, context: _PersistContext) -> None:
         """Save an error message to a reserved ChatMessage that failed during execution."""
         try:
             with get_session_with_current_tenant() as save_db_session:
@@ -1283,7 +1296,7 @@ def _run_models(
         except Exception:
             logger.exception(
                 "%s error save failed for model %d (%s)",
-                context,
+                context.value,
                 model_idx,
                 setup.model_display_names[model_idx],
             )
@@ -1311,7 +1324,9 @@ def _run_models(
                     for i in range(n_models):
                         # Snapshot every model now: finished loops save complete,
                         # in-flight ones save partial + stopped-by-user.
-                        _persist_model_outcome(i, "stop-button", stop_button=True)
+                        _persist_model_outcome(
+                            i, _PersistContext.STOP_BUTTON, stop_button=True
+                        )
                     yield Packet(
                         placement=Placement(turn_index=0),
                         obj=OverallStop(type="stop", stop_reason="user_cancelled"),
@@ -1355,7 +1370,7 @@ def _run_models(
                     yield item
 
         for i in range(n_models):
-            _persist_model_outcome(i, "normal")
+            _persist_model_outcome(i, _PersistContext.NORMAL)
         _run_post_steps()
         completion_persisted = True
 

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -1081,14 +1081,22 @@ def _run_models(
     drain_done = threading.Event()
 
     def _persist_model_outcome(
-        model_idx: int, context: str, completed_normally: bool | None = None
+        model_idx: int, context: str, *, stop_button: bool = False
     ) -> None:
+        """Persist one model's outcome exactly once, from any thread.
+
+        The LLM loops never observe the stop signal, so a worker that returns
+        non-errored always holds a complete answer. Partial content exists only
+        when the stop-button path snapshots a still-running model mid-loop —
+        that call forces a claim (``stop_button=True``) so the in-flight state
+        is saved with the stopped-by-user annotation and the worker's later
+        call becomes a no-op."""
         with persist_lock:
             if persisted[model_idx]:
                 return
             succeeded = model_succeeded[model_idx]
             errored = model_errored[model_idx]
-            if not succeeded and not errored:
+            if not succeeded and not errored and not stop_button:
                 return
             persisted[model_idx] = True
 
@@ -1096,11 +1104,7 @@ def _run_models(
             _save_errored_message(model_idx, context)
             return
 
-        # completed_normally decides the "stopped by the user" annotation. The
-        # stop-button path overrides it to True for models whose loops finished
-        # before the stop was noticed; otherwise fall back to the stop signal.
-        if completed_normally is None:
-            completed_normally = setup.check_is_connected()
+        completed_normally = succeeded if stop_button else True
 
         def _is_connected(value: bool = completed_normally) -> bool:
             return value
@@ -1305,11 +1309,9 @@ def _run_models(
                 if not setup.check_is_connected():
                     # Persist finished models now; workers persist themselves on exit.
                     for i in range(n_models):
-                        # Loops that finished before the stop was noticed are
-                        # complete answers — don't annotate them as stopped.
-                        _persist_model_outcome(
-                            i, "stop-button", completed_normally=True
-                        )
+                        # Snapshot every model now: finished loops save complete,
+                        # in-flight ones save partial + stopped-by-user.
+                        _persist_model_outcome(i, "stop-button", stop_button=True)
                     yield Packet(
                         placement=Placement(turn_index=0),
                         obj=OverallStop(type="stop", stop_reason="user_cancelled"),

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -1119,9 +1119,8 @@ def _run_models(
         for i in range(n_models):
             _persist_model_outcome(i, "post-steps")
 
-        # Normally reset in _stream_chat_turn's finally, but that generator can be
-        # abandoned on HTTP disconnect — without this the session shows "processing"
-        # forever after a disconnected run completes.
+        # _stream_chat_turn's own reset can be abandoned on disconnect; reset here
+        # so the session never sticks at "processing".
         try:
             set_processing_status(
                 chat_session_id=setup.chat_session.id,
@@ -1351,8 +1350,7 @@ def _run_models(
             with persist_lock:
                 all_finished: bool = finished_count[0] == n_models
                 running_count: int = n_models - finished_count[0]
-            # Workers that finished before drain_done was set saw is_last=False and
-            # skipped post-steps — no later worker will run them, so do it here.
+            # No worker runs post-steps if they all finished before drain_done was set.
             if all_finished:
                 _run_post_steps()
             else:

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -1080,7 +1080,9 @@ def _run_models(
     # Signals emitters to skip future puts so workers exit promptly.
     drain_done = threading.Event()
 
-    def _persist_model_outcome(model_idx: int, context: str) -> None:
+    def _persist_model_outcome(
+        model_idx: int, context: str, completed_normally: bool | None = None
+    ) -> None:
         with persist_lock:
             if persisted[model_idx]:
                 return
@@ -1094,10 +1096,19 @@ def _run_models(
             _save_errored_message(model_idx, context)
             return
 
+        # completed_normally decides the "stopped by the user" annotation. The
+        # stop-button path overrides it to True for models whose loops finished
+        # before the stop was noticed; otherwise fall back to the stop signal.
+        if completed_normally is None:
+            completed_normally = setup.check_is_connected()
+
+        def _is_connected(value: bool = completed_normally) -> bool:
+            return value
+
         try:
             llm_loop_completion_handle(
                 state_container=state_containers[model_idx],
-                is_connected=setup.check_is_connected,
+                is_connected=_is_connected,
                 assistant_message=setup.reserved_messages[model_idx],
                 llm=setup.llms[model_idx],
                 reserved_tokens=setup.reserved_token_count,
@@ -1120,7 +1131,10 @@ def _run_models(
             _persist_model_outcome(i, "post-steps")
 
         # _stream_chat_turn's own reset can be abandoned on disconnect; reset here
-        # so the session never sticks at "processing".
+        # so the session never sticks at "processing". Normal exits (drain alive)
+        # leave it to _stream_chat_turn.
+        if not drain_done.is_set():
+            return
         try:
             set_processing_status(
                 chat_session_id=setup.chat_session.id,
@@ -1291,7 +1305,11 @@ def _run_models(
                 if not setup.check_is_connected():
                     # Persist finished models now; workers persist themselves on exit.
                     for i in range(n_models):
-                        _persist_model_outcome(i, "stop-button")
+                        # Loops that finished before the stop was noticed are
+                        # complete answers — don't annotate them as stopped.
+                        _persist_model_outcome(
+                            i, "stop-button", completed_normally=True
+                        )
                     yield Packet(
                         placement=Placement(turn_index=0),
                         obj=OverallStop(type="stop", stop_reason="user_cancelled"),

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -1071,10 +1071,65 @@ def _run_models(
     # Set to True when a model raises an exception (distinct from "still running").
     # Used in the stop-button path to avoid calling completion for errored models.
     model_errored: list[bool] = [False] * n_models
+    persist_lock = threading.Lock()
+    persisted: list[bool] = [False] * n_models
+    finished_count: list[int] = [0]
+    post_steps_done = threading.Event()
 
     # Set when the drain loop exits early (HTTP disconnect / GeneratorExit).
     # Signals emitters to skip future puts so workers exit promptly.
     drain_done = threading.Event()
+
+    def _persist_model_outcome(model_idx: int, context: str) -> None:
+        with persist_lock:
+            if persisted[model_idx]:
+                return
+            succeeded = model_succeeded[model_idx]
+            errored = model_errored[model_idx]
+            if not succeeded and not errored:
+                return
+            persisted[model_idx] = True
+
+        if errored:
+            _save_errored_message(model_idx, context)
+            return
+
+        try:
+            llm_loop_completion_handle(
+                state_container=state_containers[model_idx],
+                is_connected=setup.check_is_connected,
+                assistant_message=setup.reserved_messages[model_idx],
+                llm=setup.llms[model_idx],
+                reserved_tokens=setup.reserved_token_count,
+            )
+        except Exception:
+            logger.exception(
+                "%s completion failed for model %d (%s)",
+                context,
+                model_idx,
+                setup.model_display_names[model_idx],
+            )
+
+    def _run_post_steps() -> None:
+        with persist_lock:
+            if post_steps_done.is_set():
+                return
+            post_steps_done.set()
+
+        for i in range(n_models):
+            _persist_model_outcome(i, "post-steps")
+
+        # Normally reset in _stream_chat_turn's finally, but that generator can be
+        # abandoned on HTTP disconnect — without this the session shows "processing"
+        # forever after a disconnected run completes.
+        try:
+            set_processing_status(
+                chat_session_id=setup.chat_session.id,
+                cache=setup.cache,
+                value=False,
+            )
+        except Exception:
+            logger.exception("post-steps processing status reset failed")
 
     def _run_model(model_idx: int) -> None:
         """Run one LLM loop inside a worker thread, writing packets to ``merged_queue``."""
@@ -1176,6 +1231,21 @@ def _run_models(
             merged_queue.put((model_idx, e))
 
         finally:
+            _persist_model_outcome(model_idx, "worker")
+
+            is_last = False
+            with persist_lock:
+                finished_count[0] += 1
+                is_last = finished_count[0] == n_models and drain_done.is_set()
+
+            if is_last:
+                _run_post_steps()
+                while True:
+                    try:
+                        merged_queue.get_nowait()
+                    except queue.Empty:
+                        break
+
             merged_queue.put((model_idx, _MODEL_DONE))
 
     def _save_errored_message(model_idx: int, context: str) -> None:
@@ -1220,38 +1290,14 @@ def _run_models(
             except queue.Empty:
                 # Check for user-initiated cancellation every 50 ms.
                 if not setup.check_is_connected():
-                    # Save state for every model before exiting.
-                    # - Succeeded models: full answer (is_connected=True).
-                    # - Still-in-flight models: partial answer + "stopped by user".
-                    # - Errored models: delete the orphaned reserved message; do NOT
-                    #   save "stopped by user" for a model that actually threw an exception.
+                    # Persist finished models now; workers persist themselves on exit.
                     for i in range(n_models):
-                        if model_errored[i]:
-                            _save_errored_message(i, "stop-button")
-                            continue
-                        try:
-                            succeeded = model_succeeded[i]
-
-                            def _stop_button_is_connected(s: bool = succeeded) -> bool:
-                                return s
-
-                            llm_loop_completion_handle(
-                                state_container=state_containers[i],
-                                is_connected=_stop_button_is_connected,
-                                assistant_message=setup.reserved_messages[i],
-                                llm=setup.llms[i],
-                                reserved_tokens=setup.reserved_token_count,
-                            )
-                        except Exception:
-                            logger.exception(
-                                "stop-button completion failed for model %d (%s)",
-                                i,
-                                setup.model_display_names[i],
-                            )
+                        _persist_model_outcome(i, "stop-button")
                     yield Packet(
                         placement=Placement(turn_index=0),
                         obj=OverallStop(type="stop", stop_reason="user_cancelled"),
                     )
+                    drain_done.set()
                     completion_persisted = True
                     return
                 continue
@@ -1289,29 +1335,9 @@ def _run_models(
                     # model_index already embedded by the model's Emitter in _run_model
                     yield item
 
-        # ── Completion: save each successful model's response ───────────────
-        # All model loops have completed (run_llm_loop returned) — no more writes
-        # to state_containers. Each model's completion runs inside its own
-        # short-lived DB session so no connection is held across the loop.
         for i in range(n_models):
-            if not model_succeeded[i]:
-                # Model errored — delete its orphaned reserved message.
-                _save_errored_message(i, "normal")
-                continue
-            try:
-                llm_loop_completion_handle(
-                    state_container=state_containers[i],
-                    is_connected=setup.check_is_connected,
-                    assistant_message=setup.reserved_messages[i],
-                    llm=setup.llms[i],
-                    reserved_tokens=setup.reserved_token_count,
-                )
-            except Exception:
-                logger.exception(
-                    "normal completion failed for model %d (%s)",
-                    i,
-                    setup.model_display_names[i],
-                )
+            _persist_model_outcome(i, "normal")
+        _run_post_steps()
         completion_persisted = True
 
     finally:
@@ -1320,40 +1346,20 @@ def _run_models(
             # Threads are done (normal path) or can finish in the background (stop-button).
             executor.shutdown(wait=False)
         else:
-            # Early exit (GeneratorExit from raw HTTP disconnect, or unhandled
-            # exception in the drain loop).
-            # 1. Signal emitters to stop — future emit() calls return immediately,
-            #    so workers exit their LLM loops promptly.
             drain_done.set()
-            # 2. Wait for all workers to finish. Once drain_done is set the Emitter
-            #    short-circuits, so workers should exit quickly.
-            executor.shutdown(wait=True)
-            # 3. All workers are done — complete from the main thread only.
-            for i in range(n_models):
-                if model_succeeded[i]:
-                    try:
-                        llm_loop_completion_handle(
-                            state_container=state_containers[i],
-                            # Model already finished — persist full response.
-                            is_connected=lambda: True,
-                            assistant_message=setup.reserved_messages[i],
-                            llm=setup.llms[i],
-                            reserved_tokens=setup.reserved_token_count,
-                        )
-                    except Exception:
-                        logger.exception(
-                            "disconnect completion failed for model %d (%s)",
-                            i,
-                            setup.model_display_names[i],
-                        )
-                elif model_errored[i]:
-                    _save_errored_message(i, "disconnect")
-            # 4. Drain buffered packets from memory — no consumer is running.
-            while not merged_queue.empty():
-                try:
-                    merged_queue.get_nowait()
-                except queue.Empty:
-                    break
+            executor.shutdown(wait=False)
+            with persist_lock:
+                all_finished: bool = finished_count[0] == n_models
+                running_count: int = n_models - finished_count[0]
+            # Workers that finished before drain_done was set saw is_last=False and
+            # skipped post-steps — no later worker will run them, so do it here.
+            if all_finished:
+                _run_post_steps()
+            else:
+                logger.info(
+                    "client disconnected; %d model(s) still running will persist on completion",
+                    running_count,
+                )
 
 
 def _stream_chat_turn(

--- a/backend/tests/unit/onyx/chat/test_multi_model_streaming.py
+++ b/backend/tests/unit/onyx/chat/test_multi_model_streaming.py
@@ -5,6 +5,7 @@ The validation logic in handle_multi_model_stream fires before any external
 calls, so we can trigger it with lightweight mocks.
 """
 
+import threading
 import time
 from collections.abc import Generator
 from typing import Any
@@ -18,6 +19,7 @@ import pytest
 from onyx.chat.models import StreamingError
 from onyx.configs.constants import MessageType
 from onyx.db.chat import set_preferred_response
+from onyx.db.models import ChatMessage
 from onyx.llm.override_models import LLMOverride
 from onyx.server.query_and_chat.models import SendMessageRequest
 from onyx.server.query_and_chat.placement import Placement
@@ -441,22 +443,29 @@ class TestRunModels:
         """If check_is_connected returns False, drain loop emits user_cancelled."""
 
         def slow_llm(**_kwargs: Any) -> None:
-            time.sleep(0.3)  # Outlasts the 50 ms queue-poll interval
+            time.sleep(0.2)  # Outlasts the 50 ms queue-poll interval
 
         setup = _make_setup(n_models=1)
         setup.check_is_connected = MagicMock(return_value=False)
+        completion_called = threading.Event()
 
         with (
             patch("onyx.chat.process_message.run_llm_loop", side_effect=slow_llm),
             patch("onyx.chat.process_message.run_deep_research_llm_loop"),
             patch("onyx.chat.process_message.construct_tools", return_value={}),
-            patch("onyx.chat.process_message.llm_loop_completion_handle"),
+            patch(
+                "onyx.chat.process_message.llm_loop_completion_handle",
+                side_effect=lambda *_, **__: completion_called.set(),
+            ),
             patch(
                 "onyx.chat.process_message.get_llm_token_counter",
                 return_value=lambda _: 0,
             ),
         ):
             packets = _run_models_collect(setup)
+            # The cancelled worker self-persists after the generator returns, so
+            # wait inside the patch context — otherwise it calls the real handler.
+            assert completion_called.wait(timeout=5)
 
         stops = [
             p
@@ -469,42 +478,56 @@ class TestRunModels:
         )
 
     def test_stop_button_calls_completion_for_all_models(self) -> None:
-        """llm_loop_completion_handle must be called for all models when the stop button fires.
-
-        Regression test for the disconnect-cleanup bug: the old
-        run_chat_loop_with_state_containers always called completion_callback in
-        its finally block (even on disconnect) so the DB message was updated from
-        the TERMINATED placeholder to a partial answer.  The new _run_models must
-        replicate this — otherwise the integration test
-        test_send_message_disconnect_and_cleanup fails because the message stays
-        as "Response was terminated prior to completion, try regenerating."
-        """
+        """Stop-button exit yields immediately and persists each model once."""
 
         def slow_llm(**_kwargs: Any) -> None:
-            time.sleep(0.3)
+            time.sleep(0.2)
 
         setup = _make_setup(n_models=2)
         setup.check_is_connected = MagicMock(return_value=False)
+        model_0_persisted = threading.Event()
+        model_1_persisted = threading.Event()
+
+        def mark_persisted(*_: Any, **kwargs: Any) -> None:
+            if kwargs["llm"] is setup.llms[0]:
+                model_0_persisted.set()
+            else:
+                model_1_persisted.set()
 
         with (
             patch("onyx.chat.process_message.run_llm_loop", side_effect=slow_llm),
             patch("onyx.chat.process_message.run_deep_research_llm_loop"),
             patch("onyx.chat.process_message.construct_tools", return_value={}),
             patch(
-                "onyx.chat.process_message.llm_loop_completion_handle"
+                "onyx.chat.process_message.llm_loop_completion_handle",
+                side_effect=mark_persisted,
             ) as mock_handle,
             patch(
                 "onyx.chat.process_message.get_llm_token_counter",
                 return_value=lambda _: 0,
             ),
         ):
-            _run_models_collect(setup)
+            packets = _run_models_collect(setup)
+            assert model_0_persisted.wait(timeout=5)
+            assert model_1_persisted.wait(timeout=5)
+            assert mock_handle.call_count == 2
 
-        # Must be called once per model, not zero times
-        assert mock_handle.call_count == 2
+        stops = [
+            p
+            for p in packets
+            if isinstance(p, Packet) and isinstance(p.obj, OverallStop)
+        ]
+        assert any(
+            isinstance(stop.obj, OverallStop)
+            and stop.obj.stop_reason == "user_cancelled"
+            for stop in stops
+        )
+        persisted_llms = [call.kwargs["llm"] for call in mock_handle.call_args_list]
+        assert persisted_llms.count(setup.llms[0]) == 1
+        assert persisted_llms.count(setup.llms[1]) == 1
 
     def test_completion_handle_called_for_each_successful_model(self) -> None:
-        """llm_loop_completion_handle must be called once per model that succeeded."""
+        """Normal completion persists each successful model once."""
         setup = _make_setup(n_models=2)
 
         with (
@@ -522,6 +545,9 @@ class TestRunModels:
             _run_models_collect(setup)
 
         assert mock_handle.call_count == 2
+        persisted_llms = [call.kwargs["llm"] for call in mock_handle.call_args_list]
+        assert persisted_llms.count(setup.llms[0]) == 1
+        assert persisted_llms.count(setup.llms[1]) == 1
 
     def test_completion_handle_not_called_for_failed_model(self) -> None:
         """llm_loop_completion_handle must be skipped for a model that raised."""
@@ -546,37 +572,18 @@ class TestRunModels:
         mock_handle.assert_not_called()
 
     def test_http_disconnect_completion_via_generator_exit(self) -> None:
-        """GeneratorExit from HTTP disconnect triggers main-thread completion.
-
-        When the HTTP client closes the connection, Starlette throws GeneratorExit
-        into the stream generator. The finally block sets drain_done (signalling
-        emitters to stop blocking), waits for workers via executor.shutdown(wait=True),
-        then calls llm_loop_completion_handle for each successful model from the main
-        thread.
-
-        This is the primary regression for test_send_message_disconnect_and_cleanup:
-        the integration test disconnects mid-stream and expects the DB message to be
-        updated from the TERMINATED placeholder to the real response.
-        """
-        import threading
+        """Worker-thread completion survives HTTP disconnect."""
 
         completion_called = threading.Event()
 
         def emit_then_block_until_drain(**kwargs: Any) -> None:
-            """Emit one packet (to give the drain loop a yield point), then block
-            until drain_done is set — simulating a mid-stream LLM call that exits
-            promptly once the emitter signals shutdown.
-            """
             emitter = kwargs["emitter"]
             emitter.emit(
                 Packet(placement=Placement(turn_index=0), obj=ReasoningStart())
             )
-            # Block until drain_done is set by gen.close(). The Emitter's _drain_done
-            # is the same Event that _run_models sets, so this unblocks promptly.
             emitter._drain_done.wait(timeout=5)
 
         setup = _make_setup(n_models=1)
-        # is_connected() always True — HTTP disconnect does NOT set the Redis stop fence.
         setup.check_is_connected = MagicMock(return_value=True)
 
         with (
@@ -600,28 +607,71 @@ class TestRunModels:
             gen = cast(Generator, _run_models(setup, MagicMock()))
             first = next(gen)
             assert isinstance(first, Packet)
-            # Simulate Starlette closing the stream on HTTP client disconnect.
-            # gen.close() → GeneratorExit → finally → drain_done.set() →
-            # executor.shutdown(wait=True) → main thread completes models.
             gen.close()
 
-            assert completion_called.is_set(), (
-                "main thread must call completion for the successful model"
+            assert completion_called.wait(timeout=5), (
+                "worker thread must call completion for the successful model"
             )
             assert mock_handle.call_count == 1
 
+    def test_http_disconnect_error_saves_message_once(self) -> None:
+        """Disconnecting during an erroring run saves the errored message once."""
+
+        def emit_then_raise_after_drain(**kwargs: Any) -> None:
+            emitter = kwargs["emitter"]
+            emitter.emit(
+                Packet(placement=Placement(turn_index=0), obj=ReasoningStart())
+            )
+            emitter._drain_done.wait(timeout=5)
+            raise RuntimeError("disconnect failure")
+
+        setup = _make_setup(n_models=1)
+        setup.check_is_connected = MagicMock(return_value=True)
+        commit_called = threading.Event()
+        db_session = MagicMock()
+        db_session.get.return_value = MagicMock()
+        db_session.commit.side_effect = lambda: commit_called.set()
+        session_ctx = MagicMock()
+        session_ctx.__enter__.return_value = db_session
+        session_ctx.__exit__.return_value = None
+
+        with (
+            patch(
+                "onyx.chat.process_message.run_llm_loop",
+                side_effect=emit_then_raise_after_drain,
+            ),
+            patch("onyx.chat.process_message.run_deep_research_llm_loop"),
+            patch("onyx.chat.process_message.construct_tools", return_value={}),
+            patch(
+                "onyx.chat.process_message.llm_loop_completion_handle"
+            ) as mock_handle,
+            patch(
+                "onyx.chat.process_message.get_session_with_current_tenant",
+                return_value=session_ctx,
+            ) as mock_get_session,
+            patch(
+                "onyx.chat.process_message.get_llm_token_counter",
+                return_value=lambda _: 0,
+            ),
+        ):
+            from onyx.chat.process_message import _run_models
+
+            gen = cast(Generator, _run_models(setup, MagicMock()))
+            first = next(gen)
+            assert isinstance(first, Packet)
+            gen.close()
+
+            assert commit_called.wait(timeout=5)
+            mock_handle.assert_not_called()
+            assert mock_get_session.call_count == 1
+            assert db_session.commit.call_count == 1
+            db_session.get.assert_called_once_with(
+                ChatMessage,
+                setup.reserved_messages[0].id,
+            )
+
     def test_b1_race_disconnect_handler_completes_already_finished_model(self) -> None:
-        """B1 regression: model finishes BEFORE GeneratorExit fires.
-
-        The worker exits _run_model before drain_done is set. When gen.close()
-        fires afterward, the finally block sets drain_done, waits for workers
-        (already done), then the main thread calls llm_loop_completion_handle.
-
-        Contrast with test_http_disconnect_completion_via_generator_exit, which
-        tests the opposite ordering (worker finishes AFTER disconnect).
-        """
-        import threading
-        import time
+        """A finished worker is not persisted again after a later disconnect."""
 
         completion_called = threading.Event()
 
@@ -656,46 +706,86 @@ class TestRunModels:
             gen = cast(Generator, _run_models(setup, MagicMock()))
             first = next(gen)
             assert isinstance(first, Packet)
-
-            # Give the worker thread time to finish completely (emit + return +
-            # finally + self-completion check).  It does almost no work, so 100 ms
-            # is far more than enough while still keeping the test fast.
-            time.sleep(0.1)
-
-            # Now close — worker is already done, so else-branch handles completion.
+            assert completion_called.wait(timeout=5)
             gen.close()
 
             assert completion_called.wait(timeout=5), (
-                "disconnect handler must call completion for a model that already finished"
+                "completed model should stay persisted"
             )
             assert mock_handle.call_count == 1, "completion must be called exactly once"
 
-    def test_stop_button_does_not_call_completion_for_errored_model(self) -> None:
-        """B2 regression: stop-button must NOT call completion for an errored model.
+    def test_http_disconnect_persists_each_model_once(self) -> None:
+        """Disconnecting mid-run persists each model once, even with staggered exits."""
 
-        When model 0 raises an exception, its reserved ChatMessage must not be
-        saved with 'stopped by user' — that message is wrong for a model that
-        errored.  llm_loop_completion_handle must only be called for non-errored
-        models when the stop button fires.
-        """
+        def emit_and_maybe_block(**kwargs: Any) -> None:
+            emitter = kwargs["emitter"]
+            llm = kwargs["llm"]
+            emitter.emit(
+                Packet(placement=Placement(turn_index=0), obj=ReasoningStart())
+            )
+            if llm is setup.llms[1]:
+                emitter._drain_done.wait(timeout=5)
+
+        setup = _make_setup(n_models=2)
+        setup.check_is_connected = MagicMock(return_value=True)
+        model_0_persisted = threading.Event()
+        model_1_persisted = threading.Event()
+
+        def mark_persisted(*_: Any, **kwargs: Any) -> None:
+            if kwargs["llm"] is setup.llms[0]:
+                model_0_persisted.set()
+            else:
+                model_1_persisted.set()
+
+        with (
+            patch(
+                "onyx.chat.process_message.run_llm_loop",
+                side_effect=emit_and_maybe_block,
+            ),
+            patch("onyx.chat.process_message.run_deep_research_llm_loop"),
+            patch("onyx.chat.process_message.construct_tools", return_value={}),
+            patch(
+                "onyx.chat.process_message.llm_loop_completion_handle",
+                side_effect=mark_persisted,
+            ) as mock_handle,
+            patch(
+                "onyx.chat.process_message.get_llm_token_counter",
+                return_value=lambda _: 0,
+            ),
+        ):
+            from onyx.chat.process_message import _run_models
+
+            gen = cast(Generator, _run_models(setup, MagicMock()))
+            first = next(gen)
+            assert isinstance(first, Packet)
+            assert model_0_persisted.wait(timeout=5)
+            gen.close()
+            assert model_1_persisted.wait(timeout=5)
+
+        assert mock_handle.call_count == 2
+        persisted_llms = [call.kwargs["llm"] for call in mock_handle.call_args_list]
+        assert persisted_llms.count(setup.llms[0]) == 1
+        assert persisted_llms.count(setup.llms[1]) == 1
+
+    def test_stop_button_does_not_call_completion_for_errored_model(self) -> None:
+        """Stop-button completion skips errored models."""
 
         def fail_model_0(**kwargs: Any) -> None:
             if kwargs["llm"] is setup.llms[0]:
                 raise RuntimeError("model 0 errored")
-            # Model 1: run forever (stop button fires before it finishes)
-            time.sleep(10)
+            time.sleep(0.2)
 
         setup = _make_setup(n_models=2)
-        # Return False immediately so the stop-button path fires while model 1
-        # is still sleeping (model 0 has already errored by then).
         setup.check_is_connected = lambda: False
+        model_1_persisted = threading.Event()
 
         with (
             patch("onyx.chat.process_message.run_llm_loop", side_effect=fail_model_0),
             patch("onyx.chat.process_message.run_deep_research_llm_loop"),
             patch("onyx.chat.process_message.construct_tools", return_value={}),
             patch(
-                "onyx.chat.process_message.llm_loop_completion_handle"
+                "onyx.chat.process_message.llm_loop_completion_handle",
+                side_effect=lambda *_, **__: model_1_persisted.set(),
             ) as mock_handle,
             patch(
                 "onyx.chat.process_message.get_llm_token_counter",
@@ -703,9 +793,9 @@ class TestRunModels:
             ),
         ):
             _run_models_collect(setup)
+            assert model_1_persisted.wait(timeout=5)
+            assert mock_handle.call_count == 1
 
-        # Completion must NOT be called for model 0 (it errored).
-        # It MAY be called for model 1 (still in-flight when stop fired).
         for call in mock_handle.call_args_list:
             assert call.kwargs.get("llm") is not setup.llms[0], (
                 "llm_loop_completion_handle must not be called for the errored model"


### PR DESCRIPTION
## Description

**Bug:** When the client disconnects mid-run (closed tab, proxy timeout), the run dies with the connection: the reserved assistant message keeps its placeholder text forever, and the session can stay stuck in "processing". There is disconnect-cleanup code in `_run_models` that is supposed to save finished work, but it runs inside the dying request's generator teardown, and the ASGI stack can abandon that teardown entirely — in a production incident it never executed (no logs, placeholder untouched). Background: [Deep Research instability tracker](https://dev-wiki.onyx.app/app/wiki/Engineering%20Projects/Onyx%20Projects/Deep%20Research/dr_instability_fixes.md), follow-up A′.

**Fix:** saving results no longer depends on the dying request. The worker threads are unaffected by a disconnect and keep running, so they now do the saving themselves:

- each worker saves its own model's outcome when its loop exits (lock-guarded, exactly once)
- after a disconnect, the last worker to finish runs the wrap-up: a final save sweep, resetting the session's "processing" flag, and draining the packet queue
- the disconnect cleanup no longer blocks or saves anything
- the stop button still responds immediately: already-finished answers are saved as complete, in-flight ones as a partial snapshot marked "stopped by the user"

Applies to regular chat, multi-model chat, and deep research — all three run through `_run_models`.


### In plain terms

A run has three parts: your browser holding a connection, a coordinator on the server feeding output down it, and worker threads doing the actual LLM work. The coordinator was also the one who saved the finished answer.

**Before:** saving depended on the coordinator, which dies with the connection. Its "last gasp" cleanup was supposed to save finished work, but the ASGI stack can skip that teardown entirely — so workers could finish a perfectly good answer and nobody would ever write it down. The chat kept the placeholder forever and could stay stuck on "processing".

**After:** each worker saves its own answer the moment it finishes — workers aren't tied to the connection, so they keep going through a disconnect. A lock makes every save exactly-once, and the last worker to finish does the housekeeping (clear "processing", drop undelivered output). Close your laptop mid-deep-research, come back, and the finished report is in the chat.

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
