### PR TITLE
perf(llm): memoize litellm reasoning-support probe per process

### DIFF
--- a/backend/onyx/llm/utils.py
+++ b/backend/onyx/llm/utils.py
@@ -843,13 +843,12 @@ def litellm_thinks_model_supports_image_input(
 
 _REASONING_PROBE_FAILURE_TTL_SECONDS = 300
 
-# value: (result, expires_at) — expires_at None means permanent (a real probe
-# result, which is static model metadata); a float means a failure placeholder
-# that re-probes once the TTL passes.
+# (result, expires_at): None expiry = permanent probe result (static metadata);
+# float = failure placeholder that re-probes once the TTL passes
 _LITELLM_SUPPORTS_REASONING_CACHE: dict[str, tuple[bool, float | None]] = {}
 
-# per-model locks so concurrent cold misses probe once instead of stampeding;
-# a single shared lock would serialize unrelated models behind one slow host
+# per-model locks so concurrent cold misses probe once; a single shared lock
+# would serialize unrelated models behind one slow host
 _REASONING_PROBE_LOCKS: dict[str, threading.Lock] = {}
 _REASONING_PROBE_LOCKS_GUARD = threading.Lock()
 
@@ -865,14 +864,11 @@ def _cached_reasoning_result(full_model_name: str) -> bool | None:
 
 
 def _litellm_supports_reasoning(full_model_name: str) -> bool:
-    """litellm.supports_reasoning can fetch model info over the network for some
-    providers (e.g. Ollama hosts), and every request used to pay that cost —
-    convoying on litellm's shared httpx pool under load. Memoize per process.
-    Failures are cached as False with a short TTL: an unreachable host costs one
-    attempt per TTL window instead of one per request, but a recovered host is
-    re-probed rather than pinned to False until restart (a wrong False silently
-    degrades reasoning models in chat and deep research).
-    """
+    """Single-flight, process-lifetime cache around litellm.supports_reasoning,
+    which can fetch model info over the network (e.g. Ollama hosts). Successful
+    probes cache permanently; failures cache as False with a short TTL so an
+    unreachable host isn't probed per-request but recovers without a restart
+    (a stuck False silently downgrades reasoning models)."""
     cached = _cached_reasoning_result(full_model_name)
     if cached is not None:
         return cached

--- a/backend/onyx/llm/utils.py
+++ b/backend/onyx/llm/utils.py
@@ -1,5 +1,6 @@
 import copy
 import re
+import threading
 import time
 from collections.abc import Callable
 from collections.abc import Iterable
@@ -847,6 +848,21 @@ _REASONING_PROBE_FAILURE_TTL_SECONDS = 300
 # that re-probes once the TTL passes.
 _LITELLM_SUPPORTS_REASONING_CACHE: dict[str, tuple[bool, float | None]] = {}
 
+# per-model locks so concurrent cold misses probe once instead of stampeding;
+# a single shared lock would serialize unrelated models behind one slow host
+_REASONING_PROBE_LOCKS: dict[str, threading.Lock] = {}
+_REASONING_PROBE_LOCKS_GUARD = threading.Lock()
+
+
+def _cached_reasoning_result(full_model_name: str) -> bool | None:
+    entry = _LITELLM_SUPPORTS_REASONING_CACHE.get(full_model_name)
+    if entry is None:
+        return None
+    result, expires_at = entry
+    if expires_at is None or time.monotonic() < expires_at:
+        return result
+    return None
+
 
 def _litellm_supports_reasoning(full_model_name: str) -> bool:
     """litellm.supports_reasoning can fetch model info over the network for some
@@ -857,23 +873,31 @@ def _litellm_supports_reasoning(full_model_name: str) -> bool:
     re-probed rather than pinned to False until restart (a wrong False silently
     degrades reasoning models in chat and deep research).
     """
-    entry = _LITELLM_SUPPORTS_REASONING_CACHE.get(full_model_name)
-    if entry is not None:
-        result, expires_at = entry
-        if expires_at is None or time.monotonic() < expires_at:
-            return result
+    cached = _cached_reasoning_result(full_model_name)
+    if cached is not None:
+        return cached
 
-    import litellm
+    with _REASONING_PROBE_LOCKS_GUARD:
+        key_lock = _REASONING_PROBE_LOCKS.setdefault(full_model_name, threading.Lock())
 
-    expires_at = None
-    try:
-        result = bool(litellm.supports_reasoning(model=full_model_name))
-    except Exception:
-        logger.exception("Failed to check if %s supports reasoning", full_model_name)
-        result = False
-        expires_at = time.monotonic() + _REASONING_PROBE_FAILURE_TTL_SECONDS
-    _LITELLM_SUPPORTS_REASONING_CACHE[full_model_name] = (result, expires_at)
-    return result
+    with key_lock:
+        cached = _cached_reasoning_result(full_model_name)
+        if cached is not None:
+            return cached
+
+        import litellm
+
+        expires_at = None
+        try:
+            result = bool(litellm.supports_reasoning(model=full_model_name))
+        except Exception:
+            logger.exception(
+                "Failed to check if %s supports reasoning", full_model_name
+            )
+            result = False
+            expires_at = time.monotonic() + _REASONING_PROBE_FAILURE_TTL_SECONDS
+        _LITELLM_SUPPORTS_REASONING_CACHE[full_model_name] = (result, expires_at)
+        return result
 
 
 def model_is_reasoning_model(model_name: str, model_provider: str) -> bool:

--- a/backend/onyx/llm/utils.py
+++ b/backend/onyx/llm/utils.py
@@ -32,6 +32,7 @@ from onyx.prompts.contextual_retrieval import CONTEXTUAL_RAG_TOKEN_ESTIMATE
 from onyx.prompts.contextual_retrieval import DOCUMENT_SUMMARY_TOKEN_ESTIMATE
 from onyx.utils.logger import setup_logger
 from shared_configs.configs import DOC_EMBEDDING_CONTEXT_SIZE
+from shared_configs.contextvars import get_current_tenant_id
 
 if TYPE_CHECKING:
     from onyx.server.manage.llm.models import LLMProviderView
@@ -843,18 +844,24 @@ def litellm_thinks_model_supports_image_input(
 
 _REASONING_PROBE_FAILURE_TTL_SECONDS = 300
 
+# keyed per (tenant, model): tenants can define the same custom model name for
+# different models, so probe results must never cross tenant boundaries.
 # (result, expires_at): None expiry = permanent probe result (static metadata);
 # float = failure placeholder that re-probes once the TTL passes
 _LITELLM_SUPPORTS_REASONING_CACHE: dict[str, tuple[bool, float | None]] = {}
 
-# per-model locks so concurrent cold misses probe once; a single shared lock
-# would serialize unrelated models behind one slow host
+# per-(tenant, model) locks so concurrent cold misses probe once; a single
+# shared lock would serialize unrelated models behind one slow host
 _REASONING_PROBE_LOCKS: dict[str, threading.Lock] = {}
 _REASONING_PROBE_LOCKS_GUARD = threading.Lock()
 
 
-def _cached_reasoning_result(full_model_name: str) -> bool | None:
-    entry = _LITELLM_SUPPORTS_REASONING_CACHE.get(full_model_name)
+def _reasoning_cache_key(full_model_name: str) -> str:
+    return f"{get_current_tenant_id()}:{full_model_name}"
+
+
+def _cached_reasoning_result(cache_key: str) -> bool | None:
+    entry = _LITELLM_SUPPORTS_REASONING_CACHE.get(cache_key)
     if entry is None:
         return None
     result, expires_at = entry
@@ -864,20 +871,22 @@ def _cached_reasoning_result(full_model_name: str) -> bool | None:
 
 
 def _litellm_supports_reasoning(full_model_name: str) -> bool:
-    """Single-flight, process-lifetime cache around litellm.supports_reasoning,
-    which can fetch model info over the network (e.g. Ollama hosts). Successful
-    probes cache permanently; failures cache as False with a short TTL so an
-    unreachable host isn't probed per-request but recovers without a restart
-    (a stuck False silently downgrades reasoning models)."""
-    cached = _cached_reasoning_result(full_model_name)
+    """Single-flight, process-lifetime, tenant-scoped cache around
+    litellm.supports_reasoning, which can fetch model info over the network
+    (e.g. Ollama hosts). Successful probes cache permanently; failures cache as
+    False with a short TTL so an unreachable host isn't probed per-request but
+    recovers without a restart (a stuck False silently downgrades reasoning
+    models)."""
+    cache_key = _reasoning_cache_key(full_model_name)
+    cached = _cached_reasoning_result(cache_key)
     if cached is not None:
         return cached
 
     with _REASONING_PROBE_LOCKS_GUARD:
-        key_lock = _REASONING_PROBE_LOCKS.setdefault(full_model_name, threading.Lock())
+        key_lock = _REASONING_PROBE_LOCKS.setdefault(cache_key, threading.Lock())
 
     with key_lock:
-        cached = _cached_reasoning_result(full_model_name)
+        cached = _cached_reasoning_result(cache_key)
         if cached is not None:
             return cached
 
@@ -892,7 +901,7 @@ def _litellm_supports_reasoning(full_model_name: str) -> bool:
             )
             result = False
             expires_at = time.monotonic() + _REASONING_PROBE_FAILURE_TTL_SECONDS
-        _LITELLM_SUPPORTS_REASONING_CACHE[full_model_name] = (result, expires_at)
+        _LITELLM_SUPPORTS_REASONING_CACHE[cache_key] = (result, expires_at)
         return result
 
 

--- a/backend/onyx/llm/utils.py
+++ b/backend/onyx/llm/utils.py
@@ -1,5 +1,6 @@
 import copy
 import re
+import time
 from collections.abc import Callable
 from collections.abc import Iterable
 from functools import lru_cache
@@ -839,9 +840,43 @@ def litellm_thinks_model_supports_image_input(
         return False
 
 
-def model_is_reasoning_model(model_name: str, model_provider: str) -> bool:
+_REASONING_PROBE_FAILURE_TTL_SECONDS = 300
+
+# value: (result, expires_at) — expires_at None means permanent (a real probe
+# result, which is static model metadata); a float means a failure placeholder
+# that re-probes once the TTL passes.
+_LITELLM_SUPPORTS_REASONING_CACHE: dict[str, tuple[bool, float | None]] = {}
+
+
+def _litellm_supports_reasoning(full_model_name: str) -> bool:
+    """litellm.supports_reasoning can fetch model info over the network for some
+    providers (e.g. Ollama hosts), and every request used to pay that cost —
+    convoying on litellm's shared httpx pool under load. Memoize per process.
+    Failures are cached as False with a short TTL: an unreachable host costs one
+    attempt per TTL window instead of one per request, but a recovered host is
+    re-probed rather than pinned to False until restart (a wrong False silently
+    degrades reasoning models in chat and deep research).
+    """
+    entry = _LITELLM_SUPPORTS_REASONING_CACHE.get(full_model_name)
+    if entry is not None:
+        result, expires_at = entry
+        if expires_at is None or time.monotonic() < expires_at:
+            return result
+
     import litellm
 
+    expires_at = None
+    try:
+        result = bool(litellm.supports_reasoning(model=full_model_name))
+    except Exception:
+        logger.exception("Failed to check if %s supports reasoning", full_model_name)
+        result = False
+        expires_at = time.monotonic() + _REASONING_PROBE_FAILURE_TTL_SECONDS
+    _LITELLM_SUPPORTS_REASONING_CACHE[full_model_name] = (result, expires_at)
+    return result
+
+
+def model_is_reasoning_model(model_name: str, model_provider: str) -> bool:
     model_map = get_model_map()
     try:
         model_obj = find_model_obj(
@@ -859,22 +894,13 @@ def model_is_reasoning_model(model_name: str, model_provider: str) -> bool:
                 model_provider,
             )
 
-        # Fallback: try using litellm.supports_reasoning() for newer models
-        try:
-            # logger.debug("Falling back to `litellm.supports_reasoning`")
-            full_model_name = (
-                f"{model_provider}/{model_name}"
-                if model_provider not in model_name
-                else model_name
-            )
-            return litellm.supports_reasoning(model=full_model_name)
-        except Exception:
-            logger.exception(
-                "Failed to check if %s/%s supports reasoning",
-                model_provider,
-                model_name,
-            )
-            return False
+        # Fallback for newer models missing from the local model map
+        full_model_name = (
+            f"{model_provider}/{model_name}"
+            if model_provider not in model_name
+            else model_name
+        )
+        return _litellm_supports_reasoning(full_model_name)
 
     except Exception:
         logger.exception(

--- a/backend/tests/unit/onyx/llm/test_model_is_reasoning.py
+++ b/backend/tests/unit/onyx/llm/test_model_is_reasoning.py
@@ -1,3 +1,7 @@
+import litellm
+import pytest
+
+from onyx.llm import utils
 from onyx.llm.utils import model_is_reasoning_model
 
 
@@ -31,3 +35,53 @@ def test_model_is_reasoning_model() -> None:
         assert model_is_reasoning_model(model_name, provider) is False, (
             f"Expected {provider}/{model_name} to NOT be identified as a reasoning model"
         )
+
+
+def test_litellm_fallback_is_memoized(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Models missing from the local map fall back to litellm.supports_reasoning,
+    which can hit the network — it must run at most once per model per process."""
+    calls = []
+
+    def fake_supports_reasoning(model: str) -> bool:
+        calls.append(model)
+        return True
+
+    monkeypatch.setattr(litellm, "supports_reasoning", fake_supports_reasoning)
+    monkeypatch.setattr(utils, "_LITELLM_SUPPORTS_REASONING_CACHE", {})
+
+    assert model_is_reasoning_model("not-in-map-model", "fakeprov") is True
+    assert model_is_reasoning_model("not-in-map-model", "fakeprov") is True
+    assert calls == ["fakeprov/not-in-map-model"]
+
+
+def test_litellm_fallback_failure_cached_with_ttl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unreachable host costs one attempt per TTL window (not one per
+    request), but a recovered host is re-probed after the TTL instead of being
+    pinned to False until process restart."""
+    calls = []
+    should_raise = True
+
+    def flaky_supports_reasoning(model: str) -> bool:
+        calls.append(model)
+        if should_raise:
+            raise ConnectionError("host unreachable")
+        return True
+
+    fake_now = 1000.0
+    monkeypatch.setattr(litellm, "supports_reasoning", flaky_supports_reasoning)
+    monkeypatch.setattr(utils, "_LITELLM_SUPPORTS_REASONING_CACHE", {})
+    monkeypatch.setattr(utils.time, "monotonic", lambda: fake_now)
+
+    # failure cached: second call within TTL does not re-probe
+    assert model_is_reasoning_model("unreachable-model", "fakeprov") is False
+    assert model_is_reasoning_model("unreachable-model", "fakeprov") is False
+    assert len(calls) == 1
+
+    # past the TTL, a recovered host is re-probed and the result is permanent
+    fake_now += utils._REASONING_PROBE_FAILURE_TTL_SECONDS + 1
+    should_raise = False
+    assert model_is_reasoning_model("unreachable-model", "fakeprov") is True
+    assert model_is_reasoning_model("unreachable-model", "fakeprov") is True
+    assert len(calls) == 2

--- a/backend/tests/unit/onyx/llm/test_model_is_reasoning.py
+++ b/backend/tests/unit/onyx/llm/test_model_is_reasoning.py
@@ -121,3 +121,33 @@ def test_concurrent_cold_misses_probe_once(monkeypatch: pytest.MonkeyPatch) -> N
 
     assert results == [True, True, True, True]
     assert calls == ["fakeprov/cold-model"]
+
+
+def test_probe_results_are_tenant_scoped(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two tenants can define the same custom model name for different models —
+    a probe result for one tenant must never be served to another."""
+    calls = []
+    answers = {"tenant_a": True, "tenant_b": False}
+    current_tenant = "tenant_a"
+
+    def per_tenant_supports_reasoning(model: str) -> bool:
+        calls.append((current_tenant, model))
+        return answers[current_tenant]
+
+    monkeypatch.setattr(litellm, "supports_reasoning", per_tenant_supports_reasoning)
+    monkeypatch.setattr(utils, "_LITELLM_SUPPORTS_REASONING_CACHE", {})
+    monkeypatch.setattr(utils, "_REASONING_PROBE_LOCKS", {})
+    monkeypatch.setattr(utils, "get_current_tenant_id", lambda: current_tenant)
+
+    assert model_is_reasoning_model("shared-name-model", "fakeprov") is True
+
+    current_tenant = "tenant_b"
+    assert model_is_reasoning_model("shared-name-model", "fakeprov") is False
+
+    current_tenant = "tenant_a"
+    assert model_is_reasoning_model("shared-name-model", "fakeprov") is True
+
+    assert calls == [
+        ("tenant_a", "fakeprov/shared-name-model"),
+        ("tenant_b", "fakeprov/shared-name-model"),
+    ]

--- a/backend/tests/unit/onyx/llm/test_model_is_reasoning.py
+++ b/backend/tests/unit/onyx/llm/test_model_is_reasoning.py
@@ -85,3 +85,39 @@ def test_litellm_fallback_failure_cached_with_ttl(
     assert model_is_reasoning_model("unreachable-model", "fakeprov") is True
     assert model_is_reasoning_model("unreachable-model", "fakeprov") is True
     assert len(calls) == 2
+
+
+def test_concurrent_cold_misses_probe_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Concurrent cold misses for the same model must produce a single probe
+    (per-key lock), not a stampede."""
+    import threading
+
+    calls = []
+    release_probe = threading.Event()
+
+    def slow_supports_reasoning(model: str) -> bool:
+        calls.append(model)
+        release_probe.wait(timeout=5)
+        return True
+
+    monkeypatch.setattr(litellm, "supports_reasoning", slow_supports_reasoning)
+    monkeypatch.setattr(utils, "_LITELLM_SUPPORTS_REASONING_CACHE", {})
+    monkeypatch.setattr(utils, "_REASONING_PROBE_LOCKS", {})
+
+    results: list[bool] = []
+    threads = [
+        threading.Thread(
+            target=lambda: results.append(
+                model_is_reasoning_model("cold-model", "fakeprov")
+            )
+        )
+        for _ in range(4)
+    ]
+    for t in threads:
+        t.start()
+    release_probe.set()
+    for t in threads:
+        t.join(timeout=5)
+
+    assert results == [True, True, True, True]
+    assert calls == ["fakeprov/cold-model"]


### PR DESCRIPTION
## Description

**Problem:** to label models as "reasoning" in the model picker (and pick reasoning settings in chat/deep research), the backend asks `litellm.supports_reasoning` per model. For models missing from litellm's local table (e.g. self-hosted Ollama), litellm answers by **calling the model's host over the network — on every request**. All these calls share litellm's sync httpx connection pool, so one slow/unreachable host queues everyone: py-spy during the 2026-06-09 incident showed 80/92 in-flight threads blocked on that pool lock, stalling chat bootstrap and completions.

**Fix:** ask once per process, remember the answer.
- Successful probes cache permanently (model metadata is static).
- Failures cache as `False` for 300s — an unreachable host costs one attempt per window, but recovers without a restart (a stuck `False` silently downgrades reasoning models).
- Per-model single-flight lock: concurrent cold misses produce one probe, not a stampede.

All callers heal via the shared helper. Complements #11856 (cached the listing response); this fixes the underlying per-call cost everywhere else.

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check