### PR TITLE
fix(craft): gate scheduled-run-context fetch to scheduled sessions

### DIFF
--- a/backend/onyx/server/features/build/api/models.py
+++ b/backend/onyx/server/features/build/api/models.py
@@ -11,6 +11,7 @@ from onyx.db.enums import BuildSessionStatus
 from onyx.db.enums import EndpointPolicy
 from onyx.db.enums import ExternalAppType
 from onyx.db.enums import SandboxStatus
+from onyx.db.enums import SessionOrigin
 from onyx.db.enums import SharingScope
 from onyx.server.features.build.sandbox.models import FilesystemEntry as FileSystemEntry
 
@@ -109,6 +110,7 @@ class SessionResponse(BaseModel):
     sandbox: SandboxResponse | None
     artifacts: list[ArtifactResponse]
     sharing_scope: SharingScope
+    origin: SessionOrigin
     agent_provider: str | None
     agent_model: str | None
 
@@ -134,6 +136,7 @@ class SessionResponse(BaseModel):
             sandbox=(SandboxResponse.from_model(sandbox) if sandbox else None),
             artifacts=[ArtifactResponse.from_model(a) for a in session.artifacts],
             sharing_scope=session.sharing_scope,
+            origin=session.origin,
             agent_provider=session.agent_provider,
             agent_model=session.agent_model,
         )

--- a/web/src/app/craft/components/ChatPanel.tsx
+++ b/web/src/app/craft/components/ChatPanel.tsx
@@ -77,8 +77,11 @@ export default function BuildChatPanel({
   const session = useSession();
   const sessionId = useSessionId();
   const scheduledSessionId = sessionId ?? existingSessionId ?? null;
+  // Gate on origin so interactive sessions don't 404 on scheduled-run-context.
+  const scheduledRunSessionId =
+    session?.origin === "SCHEDULED" ? scheduledSessionId : null;
   const { data: scheduledRunContext, mutate: mutateScheduledRunContext } =
-    useScheduledRunContext(scheduledSessionId);
+    useScheduledRunContext(scheduledRunSessionId);
   const scheduledRunInFlight =
     isScheduledRunContextInFlight(scheduledRunContext);
   const shouldStreamScheduledRun = scheduledRunContext?.status === "RUNNING";

--- a/web/src/app/craft/hooks/useBuildSessionStore.ts
+++ b/web/src/app/craft/hooks/useBuildSessionStore.ts
@@ -10,6 +10,7 @@ import {
   BuildMessage,
   Session,
   SessionHistoryItem,
+  SessionOrigin,
   SessionStatus,
   ToolCall,
   ToolCallStatus,
@@ -611,6 +612,7 @@ export interface BuildSessionData {
   /** Model this session runs on (from the row); seeds the composer picker. */
   agentProvider: string | null;
   agentModel: string | null;
+  origin: SessionOrigin;
   abortController: AbortController;
   lastAccessed: Date;
   isLoaded: boolean;
@@ -870,6 +872,7 @@ const createInitialSessionData = (
   sandbox: null,
   agentProvider: null,
   agentModel: null,
+  origin: "INTERACTIVE",
   abortController: new AbortController(),
   lastAccessed: new Date(),
   isLoaded: false,
@@ -1767,6 +1770,7 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
         sandbox,
         agentProvider: sessionData.agent_provider,
         agentModel: sessionData.agent_model,
+        origin: sessionData.origin,
         activeTurnId: resolvedActiveTurnId,
         activeTurnIndex: resolvedActiveTurnIndex,
         activeTurnLocalOwner: isStreaming

--- a/web/src/app/craft/types/streamingTypes.ts
+++ b/web/src/app/craft/types/streamingTypes.ts
@@ -4,6 +4,8 @@
 
 export type SharingScope = "private" | "public_org";
 
+export type SessionOrigin = "INTERACTIVE" | "SCHEDULED";
+
 // =============================================================================
 // Session Error Constants
 // =============================================================================
@@ -173,6 +175,7 @@ export interface ApiSessionResponse {
   sandbox: ApiSandboxResponse | null;
   artifacts: ApiArtifactResponse[];
   sharing_scope: SharingScope;
+  origin: SessionOrigin;
   agent_provider: string | null;
   agent_model: string | null;
 }


### PR DESCRIPTION
## Description

On the Craft session page, `scheduled-run-context` was fetched on every load and returned **404** for normal interactive sessions (the endpoint only returns data for sessions created by a scheduled task). This eliminates that noisy request.

- Expose session `origin` through the API response (`SessionResponse`) → frontend session store.
- Only call `useScheduledRunContext` when `origin === "SCHEDULED"`, so interactive sessions no longer fire a per-load 404.

## How Has This Been Tested?

- `bunx tsc --noEmit` — clean
- `bunx jest useBuildStreaming` — 25/25 pass
- Pre-commit (`ty`, `ruff`, `ruff format`, TypeScript type check) — pass

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
