### PR TITLE
feat: per-user usage + cost tracking — frontend (4/4)

### DIFF
--- a/backend/alembic/versions/8c1d4f6a2e9b_add_usage_cost_tracking.py
+++ b/backend/alembic/versions/8c1d4f6a2e9b_add_usage_cost_tracking.py
@@ -64,10 +64,10 @@ def upgrade() -> None:
         # Empty string (not NULL) for "no provider" so the dedup unique index
         # works on every Postgres version (NULLS NOT DISTINCT is PG15+ only).
         sa.Column("provider", sa.String(), nullable=False, server_default=""),
-        sa.Column("input_tokens", sa.Integer(), nullable=False),
-        sa.Column("output_tokens", sa.Integer(), nullable=False),
+        sa.Column("input_tokens", sa.BigInteger(), nullable=False),
+        sa.Column("output_tokens", sa.BigInteger(), nullable=False),
         sa.Column(
-            "cache_read_tokens", sa.Integer(), nullable=False, server_default="0"
+            "cache_read_tokens", sa.BigInteger(), nullable=False, server_default="0"
         ),
         sa.Column("cost_cents", sa.Float(), nullable=False, server_default="0.0"),
         sa.Column(
@@ -107,11 +107,11 @@ def downgrade() -> None:
     op.drop_constraint(
         "ck_token_rate_limit_budget_set", "token_rate_limit", type_="check"
     )
-    # token_budget goes back to NOT NULL; back-fill any cost-only rows first so
-    # the alter can't fail on NULLs.
-    op.execute(
-        "UPDATE token_rate_limit SET token_budget = 0 WHERE token_budget IS NULL"
-    )
+    # Delete cost-only rows before restoring NOT NULL. Zero-filling them would
+    # leave token_budget=0 rows that older enforcement reads as "block at 0
+    # tokens" (rejecting every request); a cost-only limit can't function once
+    # cost_budget_cents is dropped below anyway.
+    op.execute("DELETE FROM token_rate_limit WHERE token_budget IS NULL")
     op.alter_column("token_rate_limit", "token_budget", nullable=False)
     op.drop_column("token_rate_limit", "cost_budget_cents")
     op.drop_index("uq_user_usage_dims", table_name="user_usage")

--- a/backend/alembic/versions/8c1d4f6a2e9b_add_usage_cost_tracking.py
+++ b/backend/alembic/versions/8c1d4f6a2e9b_add_usage_cost_tracking.py
@@ -1,0 +1,114 @@
+"""add usage + cost tracking schema
+
+Creates the per-user usage rollup table and the per-model cost-override table,
+and adds a cost budget to token rate limits (token budget becomes nullable so a
+limit can be token-only, cost-only, or both).
+
+Revision ID: 8c1d4f6a2e9b
+Revises: f3a9c1d4b7e2
+Create Date: 2026-06-05 00:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+import fastapi_users_db_sqlalchemy
+
+# revision identifiers, used by Alembic.
+revision = "8c1d4f6a2e9b"
+down_revision = "f3a9c1d4b7e2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "model_cost_override",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("model", sa.String(), nullable=False),
+        sa.Column("input_cost_per_mtok", sa.Float(), nullable=False),
+        sa.Column("output_cost_per_mtok", sa.Float(), nullable=False),
+        # null cache rate bills cache reads at the input rate (litellm default).
+        sa.Column("cache_read_cost_per_mtok", sa.Float(), nullable=True),
+        # The model's onupdate=func.now() is ORM-side only (not DDL), so
+        # updated_at auto-bumps on ORM writes but not on raw-SQL UPDATEs.
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("model", name="uq_model_cost_override_model"),
+    )
+
+    op.create_table(
+        "user_usage",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column(
+            "user_id",
+            fastapi_users_db_sqlalchemy.generics.GUID(),
+            nullable=False,
+        ),
+        sa.Column(
+            "window_start", sa.DateTime(timezone=True), nullable=False, index=True
+        ),
+        sa.Column("model", sa.String(), nullable=False),
+        sa.Column("flow", sa.String(), nullable=False),
+        # Empty string (not NULL) for "no provider" so the dedup unique index
+        # works on every Postgres version (NULLS NOT DISTINCT is PG15+ only).
+        sa.Column("provider", sa.String(), nullable=False, server_default=""),
+        sa.Column("input_tokens", sa.Integer(), nullable=False),
+        sa.Column("output_tokens", sa.Integer(), nullable=False),
+        sa.Column(
+            "cache_read_tokens", sa.Integer(), nullable=False, server_default="0"
+        ),
+        sa.Column("cost_cents", sa.Float(), nullable=False, server_default="0.0"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_user_usage_user_id", "user_usage", ["user_id"], unique=False)
+    # Upsert key. provider is non-null ('' when absent), so a plain unique index
+    # dedups correctly on every Postgres version (no PG15-only NULLS NOT DISTINCT).
+    op.create_index(
+        "uq_user_usage_dims",
+        "user_usage",
+        ["user_id", "window_start", "model", "flow", "provider"],
+        unique=True,
+    )
+
+    op.add_column(
+        "token_rate_limit",
+        sa.Column("cost_budget_cents", sa.Float(), nullable=True),
+    )
+    op.alter_column("token_rate_limit", "token_budget", nullable=True)
+    # A limit must carry a token budget, a cost budget, or both — never neither.
+    op.create_check_constraint(
+        "ck_token_rate_limit_budget_set",
+        "token_rate_limit",
+        "token_budget IS NOT NULL OR cost_budget_cents IS NOT NULL",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "ck_token_rate_limit_budget_set", "token_rate_limit", type_="check"
+    )
+    # token_budget goes back to NOT NULL; back-fill any cost-only rows first so
+    # the alter can't fail on NULLs.
+    op.execute(
+        "UPDATE token_rate_limit SET token_budget = 0 WHERE token_budget IS NULL"
+    )
+    op.alter_column("token_rate_limit", "token_budget", nullable=False)
+    op.drop_column("token_rate_limit", "cost_budget_cents")
+    op.drop_index("uq_user_usage_dims", table_name="user_usage")
+    op.drop_index("ix_user_usage_user_id", table_name="user_usage")
+    op.drop_index("ix_user_usage_window_start", table_name="user_usage")
+    op.drop_table("user_usage")
+    op.drop_table("model_cost_override")

--- a/backend/alembic/versions/8c1d4f6a2e9b_add_usage_cost_tracking.py
+++ b/backend/alembic/versions/8c1d4f6a2e9b_add_usage_cost_tracking.py
@@ -26,6 +26,9 @@ def upgrade() -> None:
         "model_cost_override",
         sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("model", sa.String(), nullable=False),
+        # Empty string (not NULL) for a provider-agnostic override, so the unique
+        # key works on every Postgres version (NULLS NOT DISTINCT is PG15+ only).
+        sa.Column("provider", sa.String(), nullable=False, server_default=""),
         sa.Column("input_cost_per_mtok", sa.Float(), nullable=False),
         sa.Column("output_cost_per_mtok", sa.Float(), nullable=False),
         # null cache rate bills cache reads at the input rate (litellm default).
@@ -39,7 +42,10 @@ def upgrade() -> None:
             nullable=False,
         ),
         sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint("model", name="uq_model_cost_override_model"),
+        # provider+model so the same model can be priced per provider.
+        sa.UniqueConstraint(
+            "provider", "model", name="uq_model_cost_override_provider_model"
+        ),
     )
 
     op.create_table(
@@ -73,7 +79,8 @@ def upgrade() -> None:
         sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
         sa.PrimaryKeyConstraint("id"),
     )
-    op.create_index("ix_user_usage_user_id", "user_usage", ["user_id"], unique=False)
+    # No standalone user_id index: uq_user_usage_dims leads with user_id, so
+    # Postgres uses it for user-only lookups.
     # Upsert key. provider is non-null ('' when absent), so a plain unique index
     # dedups correctly on every Postgres version (no PG15-only NULLS NOT DISTINCT).
     op.create_index(
@@ -108,7 +115,6 @@ def downgrade() -> None:
     op.alter_column("token_rate_limit", "token_budget", nullable=False)
     op.drop_column("token_rate_limit", "cost_budget_cents")
     op.drop_index("uq_user_usage_dims", table_name="user_usage")
-    op.drop_index("ix_user_usage_user_id", table_name="user_usage")
     op.drop_index("ix_user_usage_window_start", table_name="user_usage")
     op.drop_table("user_usage")
     op.drop_table("model_cost_override")

--- a/backend/ee/onyx/db/token_limit.py
+++ b/backend/ee/onyx/db/token_limit.py
@@ -89,6 +89,7 @@ def insert_user_group_token_rate_limit(
     token_limit = TokenRateLimit(
         enabled=token_rate_limit_settings.enabled,
         token_budget=token_rate_limit_settings.token_budget,
+        cost_budget_cents=token_rate_limit_settings.cost_budget_cents,
         period_hours=token_rate_limit_settings.period_hours,
         scope=TokenRateLimitScope.USER_GROUP,
     )

--- a/backend/ee/onyx/server/query_and_chat/token_limit.py
+++ b/backend/ee/onyx/server/query_and_chat/token_limit.py
@@ -7,7 +7,6 @@ from typing import List
 from typing import Tuple
 from uuid import UUID
 
-from fastapi import HTTPException
 from sqlalchemy import func
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -22,9 +21,15 @@ from onyx.db.models import User
 from onyx.db.models import User__UserGroup
 from onyx.db.models import UserGroup
 from onyx.db.token_limit import fetch_all_user_token_rate_limits
+from onyx.db.user_usage import get_group_cost_cents_buckets_since
+from onyx.db.user_usage import get_user_cost_cents_buckets_since
 from onyx.server.query_and_chat.token_limit import _get_cutoff_time
-from onyx.server.query_and_chat.token_limit import _is_rate_limited
+from onyx.server.query_and_chat.token_limit import _has_token_budget
+from onyx.server.query_and_chat.token_limit import _LEDGER_GRID
+from onyx.server.query_and_chat.token_limit import _raise_for_longest_window
 from onyx.server.query_and_chat.token_limit import _user_is_rate_limited_by_global
+from onyx.server.query_and_chat.token_limit import _worst_triggered_cost_limit
+from onyx.server.query_and_chat.token_limit import _worst_triggered_limit
 from onyx.utils.threadpool_concurrency import run_functions_tuples_in_parallel
 
 
@@ -57,16 +62,35 @@ def _user_is_rate_limited(user_id: UUID) -> None:
         user_rate_limits = fetch_all_user_token_rate_limits(
             db_session=db_session, enabled_only=True, ordered=False
         )
+        if not user_rate_limits:
+            return
 
-        if user_rate_limits:
-            user_cutoff_time = _get_cutoff_time(user_rate_limits)
+        # Token side — skip the usage scan entirely when every limit is cost-only.
+        token_triggered = None
+        if _has_token_budget(user_rate_limits):
+            token_limits = [
+                rl
+                for rl in user_rate_limits
+                if rl.token_budget is not None and rl.token_budget > 0
+            ]
+            user_cutoff_time = _get_cutoff_time(token_limits)
             user_usage = _fetch_user_usage(user_id, user_cutoff_time, db_session)
+            token_triggered = _worst_triggered_limit(user_rate_limits, user_usage)
 
-            if _is_rate_limited(user_rate_limits, user_usage):
-                raise HTTPException(
-                    status_code=429,
-                    detail="Token budget exceeded for user. Try again later.",
-                )
+        # Cost side — same UserUsage-ledger bucket approach as the global gate.
+        cost_buckets: list[tuple[datetime, float]] = []
+        if any(rl.cost_budget_cents is not None for rl in user_rate_limits):
+            cost_cutoff = _get_cutoff_time(user_rate_limits) - _LEDGER_GRID
+            cost_buckets = get_user_cost_cents_buckets_since(
+                db_session, str(user_id), cost_cutoff
+            )
+        cost_triggered = _worst_triggered_cost_limit(user_rate_limits, cost_buckets)
+
+        _raise_for_longest_window(
+            "your account",
+            token_triggered.period_hours if token_triggered else None,
+            cost_triggered.period_hours if cost_triggered else None,
+        )
 
 
 def _fetch_user_usage(
@@ -96,33 +120,54 @@ User Group rate limits
 def _user_is_rate_limited_by_group(user_id: UUID) -> None:
     with get_session_with_current_tenant() as db_session:
         group_rate_limits = _fetch_all_user_group_rate_limits(user_id, db_session)
+        if not group_rate_limits:
+            return
 
-        if group_rate_limits:
-            # Group cutoff time is the same for all groups.
-            # This could be optimized to only fetch the maximum cutoff time for
-            # a specific group, but seems unnecessary for now.
-            group_cutoff_time = _get_cutoff_time(
-                [e for sublist in group_rate_limits.values() for e in sublist]
-            )
+        all_limits = [e for sublist in group_rate_limits.values() for e in sublist]
+        user_group_ids = list(group_rate_limits.keys())
 
-            user_group_ids = list(group_rate_limits.keys())
+        # Token usage per group — skip the scan when every group limit is cost-only.
+        group_usage: dict[int, list[tuple[datetime, int]]] = {}
+        if _has_token_budget(all_limits):
+            token_limits = [
+                rl for rl in all_limits if rl.token_budget is not None and rl.token_budget > 0
+            ]
+            group_cutoff_time = _get_cutoff_time(token_limits)
             group_usage = _fetch_user_group_usage(
                 user_group_ids, group_cutoff_time, db_session
             )
 
-            has_at_least_one_untriggered_limit = False
-            for user_group_id, rate_limits in group_rate_limits.items():
-                usage = group_usage.get(user_group_id, [])
+        # Cost buckets per group — one query for the widest window.
+        group_cost_buckets: dict[int, list[tuple[datetime, float]]] = {}
+        if any(rl.cost_budget_cents is not None for rl in all_limits):
+            cost_cutoff = _get_cutoff_time(all_limits) - _LEDGER_GRID
+            group_cost_buckets = get_group_cost_cents_buckets_since(
+                db_session, user_group_ids, cost_cutoff
+            )
 
-                if not _is_rate_limited(rate_limits, usage):
-                    has_at_least_one_untriggered_limit = True
-                    break
-
-            if not has_at_least_one_untriggered_limit:
-                raise HTTPException(
-                    status_code=429,
-                    detail="Token budget exceeded for user's groups. Try again later.",
+        # A user passes if ANY of their groups is fully under budget (token AND
+        # cost). Only when EVERY group has an exceeded limit do we block, then
+        # report the longest offending window across all groups.
+        worst_token_period: int | None = None
+        worst_cost_period: int | None = None
+        for user_group_id, rate_limits in group_rate_limits.items():
+            usage = group_usage.get(user_group_id, [])
+            token_trig = _worst_triggered_limit(rate_limits, usage)
+            cost_trig = _worst_triggered_cost_limit(
+                rate_limits, group_cost_buckets.get(user_group_id, [])
+            )
+            if token_trig is None and cost_trig is None:
+                return  # this group is under budget -> user is allowed
+            if token_trig is not None:
+                worst_token_period = max(
+                    worst_token_period or 0, token_trig.period_hours
                 )
+            if cost_trig is not None:
+                worst_cost_period = max(worst_cost_period or 0, cost_trig.period_hours)
+
+        _raise_for_longest_window(
+            "your group", worst_token_period, worst_cost_period
+        )
 
 
 def _fetch_all_user_group_rate_limits(

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -1405,6 +1405,23 @@ RECENCY_BIAS_MULTIPLIER = float(os.environ.get("RECENCY_BIAS_MULTIPLIER") or 1.0
 # backend/onyx/document_index/vespa/app_config/schemas/danswer_chunk.sd.jinja.
 RERANK_COUNT = int(os.environ.get("RERANK_COUNT") or 1000)
 
+# Flat per-image cost (cents) when litellm has no price for an image model.
+# Clamped to >= 0 so a misconfigured negative can't credit usage.
+DEFAULT_IMAGE_COST_CENTS = max(
+    0.0, float(os.environ.get("DEFAULT_IMAGE_COST_CENTS") or 4.0)
+)
+
+# Fallback per-million-token rates (USD) for models litellm can't price, so
+# unknown/BYO models still accrue cost instead of being silently free. Default 0
+# preserves prior behavior; operators set these to give unpriced models a rate.
+# Clamped to >= 0 so a negative can't produce negative usage cost.
+DEFAULT_LLM_INPUT_COST_PER_MTOK = max(
+    0.0, float(os.environ.get("DEFAULT_LLM_INPUT_COST_PER_MTOK") or 0.0)
+)
+DEFAULT_LLM_OUTPUT_COST_PER_MTOK = max(
+    0.0, float(os.environ.get("DEFAULT_LLM_OUTPUT_COST_PER_MTOK") or 0.0)
+)
+
 
 #####
 # Tool Configs
@@ -1498,6 +1515,15 @@ SCHEDULED_EVAL_PROJECT = os.environ.get("SCHEDULED_EVAL_PROJECT", "st-dev")
 LANGFUSE_SECRET_KEY = os.environ.get("LANGFUSE_SECRET_KEY") or ""
 LANGFUSE_PUBLIC_KEY = os.environ.get("LANGFUSE_PUBLIC_KEY") or ""
 LANGFUSE_HOST = os.environ.get("LANGFUSE_HOST") or ""  # For self-hosted Langfuse
+
+#####
+# Per-user usage/cost tracking
+#####
+# Records every priced generation span into the per-user usage ledger. On by
+# default; set to "false" to drop the recording processor entirely.
+USER_USAGE_TRACKING_ENABLED = (
+    os.environ.get("USER_USAGE_TRACKING_ENABLED", "true").lower() != "false"
+)
 
 # Defined custom query/answer conditions to validate the query and the LLM answer.
 # Format: list of strings

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5375,8 +5375,10 @@ class UserUsage(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
 
+    # No index=True: uq_user_usage_dims leads with user_id, so Postgres uses it
+    # for user-only lookups.
     user_id: Mapped[UUID] = mapped_column(
-        ForeignKey("user.id", ondelete="CASCADE"), nullable=False, index=True
+        ForeignKey("user.id", ondelete="CASCADE"), nullable=False
     )
 
     window_start: Mapped[datetime.datetime] = mapped_column(
@@ -5427,8 +5429,13 @@ class ModelCostOverride(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
 
-    # litellm-style model name (e.g. "gpt-4o"); one override per model.
-    model: Mapped[str] = mapped_column(String, nullable=False, unique=True)
+    # litellm-style model name (e.g. "gpt-4o").
+    model: Mapped[str] = mapped_column(String, nullable=False)
+    # Empty string (not NULL) for a provider-agnostic override, so the unique key
+    # below works on every Postgres version without NULLS NOT DISTINCT (PG15+).
+    provider: Mapped[str] = mapped_column(
+        String, nullable=False, default="", server_default=""
+    )
 
     # Rates in USD per million tokens.
     input_cost_per_mtok: Mapped[float] = mapped_column(Float, nullable=False)
@@ -5438,6 +5445,13 @@ class ModelCostOverride(Base):
 
     updated_at: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    __table_args__ = (
+        # provider+model so the same model can be priced per provider.
+        UniqueConstraint(
+            "provider", "model", name="uq_model_cost_override_provider_model"
+        ),
     )
 
 

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5393,9 +5393,11 @@ class UserUsage(Base):
         String, nullable=False, default="", server_default=""
     )
 
-    input_tokens: Mapped[int] = mapped_column(Integer, nullable=False)
-    output_tokens: Mapped[int] = mapped_column(Integer, nullable=False)
-    cache_read_tokens: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    input_tokens: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    output_tokens: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    cache_read_tokens: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, default=0
+    )
     cost_cents: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
 
     created_at: Mapped[datetime.datetime] = mapped_column(

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -4594,13 +4594,24 @@ class TokenRateLimit(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
-    token_budget: Mapped[int] = mapped_column(Integer, nullable=False)
+    # A row carries a token budget, a cost budget, or both; a null side is exempt
+    # from that gate. At least one must be set — enforced by the check constraint
+    # below, so a backfill / direct write can't create an unenforceable row.
+    token_budget: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    cost_budget_cents: Mapped[float | None] = mapped_column(Float, nullable=True)
     period_hours: Mapped[int] = mapped_column(Integer, nullable=False)
     scope: Mapped[TokenRateLimitScope] = mapped_column(
         Enum(TokenRateLimitScope, native_enum=False)
     )
     created_at: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "token_budget IS NOT NULL OR cost_budget_cents IS NOT NULL",
+            name="ck_token_rate_limit_budget_set",
+        ),
     )
 
 
@@ -5345,6 +5356,88 @@ class TenantUsage(Base):
     __table_args__ = (
         # Ensure only one row per window start (tenant_id is in the schema name)
         UniqueConstraint("window_start", name="uq_tenant_usage_window"),
+    )
+
+
+class UserUsage(Base):
+    """
+    Per-user LLM usage rollup within a time window — the source of truth for
+    per-user cost/token attribution and budget checks. Mirrors TenantUsage's
+    window-rollup model (one accumulating row per window+dims, not a per-call
+    ledger).
+
+    One row per (user, window, model, flow, provider), accumulated in place;
+    windows match the tenant-usage alignment so per-user and per-tenant totals
+    reconcile.
+    """
+
+    __tablename__ = "user_usage"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+
+    user_id: Mapped[UUID] = mapped_column(
+        ForeignKey("user.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+
+    window_start: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, index=True
+    )
+
+    model: Mapped[str] = mapped_column(String, nullable=False)
+    flow: Mapped[str] = mapped_column(String, nullable=False)
+    # Empty string (not NULL) for "no provider" so the dedup unique index below
+    # works on every Postgres version without NULLS NOT DISTINCT (PG15+).
+    provider: Mapped[str] = mapped_column(
+        String, nullable=False, default="", server_default=""
+    )
+
+    input_tokens: Mapped[int] = mapped_column(Integer, nullable=False)
+    output_tokens: Mapped[int] = mapped_column(Integer, nullable=False)
+    cache_read_tokens: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    cost_cents: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    __table_args__ = (
+        # Upsert key: accumulate into one row per dimension tuple per window.
+        # provider is non-null ('' when absent), so a plain unique index dedups
+        # correctly on every Postgres version (no NULLS NOT DISTINCT needed).
+        Index(
+            "uq_user_usage_dims",
+            "user_id",
+            "window_start",
+            "model",
+            "flow",
+            "provider",
+            unique=True,
+        ),
+    )
+
+
+class ModelCostOverride(Base):
+    """Admin-set per-model rates that supersede litellm pricing.
+
+    Negotiated enterprise rates win over litellm's published numbers, so cost
+    computation consults this table before falling back to litellm.
+    """
+
+    __tablename__ = "model_cost_override"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+
+    # litellm-style model name (e.g. "gpt-4o"); one override per model.
+    model: Mapped[str] = mapped_column(String, nullable=False, unique=True)
+
+    # Rates in USD per million tokens.
+    input_cost_per_mtok: Mapped[float] = mapped_column(Float, nullable=False)
+    output_cost_per_mtok: Mapped[float] = mapped_column(Float, nullable=False)
+    # Cache-read rate; null bills cache reads at the input rate (litellm default).
+    cache_read_cost_per_mtok: Mapped[float | None] = mapped_column(Float, nullable=True)
+
+    updated_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
     )
 
 

--- a/backend/onyx/db/token_limit.py
+++ b/backend/onyx/db/token_limit.py
@@ -1,4 +1,6 @@
+from collections import defaultdict
 from collections.abc import Sequence
+from uuid import UUID
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -6,6 +8,7 @@ from sqlalchemy.orm import Session
 from onyx.configs.constants import TokenRateLimitScope
 from onyx.db.models import TokenRateLimit
 from onyx.db.models import TokenRateLimit__UserGroup
+from onyx.db.models import User__UserGroup
 from onyx.server.token_rate_limits.models import TokenRateLimitArgs
 
 
@@ -25,6 +28,33 @@ def fetch_all_user_token_rate_limits(
         query = query.order_by(TokenRateLimit.created_at.desc())
 
     return db_session.scalars(query).all()
+
+
+def fetch_user_group_token_rate_limits(
+    db_session: Session,
+    user_id: UUID,
+    enabled_only: bool = True,
+) -> dict[int, list[TokenRateLimit]]:
+    """The user-group rate limits a user is subject to, keyed by group id."""
+    query = (
+        select(TokenRateLimit, User__UserGroup.user_group_id)
+        .join(
+            TokenRateLimit__UserGroup,
+            TokenRateLimit.id == TokenRateLimit__UserGroup.rate_limit_id,
+        )
+        .join(
+            User__UserGroup,
+            User__UserGroup.user_group_id == TokenRateLimit__UserGroup.user_group_id,
+        )
+        .where(User__UserGroup.user_id == user_id)
+    )
+    if enabled_only:
+        query = query.where(TokenRateLimit.enabled.is_(True))
+
+    result: dict[int, list[TokenRateLimit]] = defaultdict(list)
+    for limit, group_id in db_session.execute(query).all():
+        result[group_id].append(limit)
+    return dict(result)
 
 
 def fetch_all_global_token_rate_limits(
@@ -53,6 +83,7 @@ def insert_user_token_rate_limit(
     token_limit = TokenRateLimit(
         enabled=token_rate_limit_settings.enabled,
         token_budget=token_rate_limit_settings.token_budget,
+        cost_budget_cents=token_rate_limit_settings.cost_budget_cents,
         period_hours=token_rate_limit_settings.period_hours,
         scope=TokenRateLimitScope.USER,
     )
@@ -69,6 +100,7 @@ def insert_global_token_rate_limit(
     token_limit = TokenRateLimit(
         enabled=token_rate_limit_settings.enabled,
         token_budget=token_rate_limit_settings.token_budget,
+        cost_budget_cents=token_rate_limit_settings.cost_budget_cents,
         period_hours=token_rate_limit_settings.period_hours,
         scope=TokenRateLimitScope.GLOBAL,
     )
@@ -89,6 +121,7 @@ def update_token_rate_limit(
 
     token_limit.enabled = token_rate_limit_settings.enabled
     token_limit.token_budget = token_rate_limit_settings.token_budget
+    token_limit.cost_budget_cents = token_rate_limit_settings.cost_budget_cents
     token_limit.period_hours = token_rate_limit_settings.period_hours
     db_session.commit()
 

--- a/backend/onyx/db/user_usage.py
+++ b/backend/onyx/db/user_usage.py
@@ -294,6 +294,32 @@ def get_total_cost_cents_since(
     return float(total)
 
 
+def get_total_cost_cents_buckets_since(
+    db_session: Session,
+    cutoff: datetime,
+) -> list[tuple[datetime, float]]:
+    """Tenant-wide cost buckets (window_start, cents) for windows >= `cutoff`, in
+    one query. Batched counterpart to get_total_cost_cents_since so the global
+    cost gate can window in Python instead of a query per limit."""
+    rows = db_session.execute(
+        select(
+            UserUsage.window_start,
+            func.coalesce(func.sum(UserUsage.cost_cents), 0.0),
+        )
+        .where(UserUsage.window_start >= cutoff)
+        .group_by(UserUsage.window_start)
+    ).all()
+
+    buckets: list[tuple[datetime, float]] = []
+    for window_start, cost in rows:
+        # Coerce to tz-aware UTC; SQLite returns naive datetimes, which can't be
+        # compared against the tz-aware cutoffs callers window with.
+        if window_start.tzinfo is None:
+            window_start = window_start.replace(tzinfo=timezone.utc)
+        buckets.append((window_start, float(cost)))
+    return buckets
+
+
 def get_group_cost_cents_since(
     db_session: Session,
     user_group_id: int,

--- a/backend/onyx/db/user_usage.py
+++ b/backend/onyx/db/user_usage.py
@@ -281,6 +281,32 @@ def get_user_cost_cents_since(
     return float(total)
 
 
+def get_user_cost_cents_buckets_since(
+    db_session: Session,
+    user_id: str,
+    cutoff: datetime,
+) -> list[tuple[datetime, float]]:
+    """A user's cost buckets (window_start, cents) for windows >= `cutoff`, in one
+    query. Batched counterpart to get_user_cost_cents_since so the per-user cost
+    gate can window in Python (mirrors get_total_cost_cents_buckets_since)."""
+    rows = db_session.execute(
+        select(
+            UserUsage.window_start,
+            func.coalesce(func.sum(UserUsage.cost_cents), 0.0),
+        )
+        .where(UserUsage.user_id == user_id, UserUsage.window_start >= cutoff)
+        .group_by(UserUsage.window_start)
+    ).all()
+
+    buckets: list[tuple[datetime, float]] = []
+    for window_start, cost in rows:
+        # Coerce to tz-aware UTC; SQLite returns naive datetimes.
+        if window_start.tzinfo is None:
+            window_start = window_start.replace(tzinfo=timezone.utc)
+        buckets.append((window_start, float(cost)))
+    return buckets
+
+
 def get_total_cost_cents_since(
     db_session: Session,
     cutoff: datetime,

--- a/backend/onyx/db/user_usage.py
+++ b/backend/onyx/db/user_usage.py
@@ -1,0 +1,336 @@
+"""Per-user LLM usage rollup — the source of truth for cost/token attribution.
+
+A window-rollup like TenantUsage: rows accumulate in place per (user, window,
+model, flow, provider), not an append-only per-call ledger."""
+
+from collections import defaultdict
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+
+from sqlalchemy import func
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.orm import Session
+
+from onyx.db.models import User
+from onyx.db.models import User__UserGroup
+from onyx.db.models import UserUsage
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+# Dimension columns that uniquely identify a ledger row within a window.
+_CONFLICT_COLS = ["user_id", "window_start", "model", "flow", "provider"]
+
+
+def get_window_start(dt: datetime, period_hours: int) -> datetime:
+    """
+    Align `dt` to the start of its fixed window.
+
+    Mirrors the tenant-usage windowing in onyx/db/usage.py so per-user and
+    per-tenant windows coincide: weekly windows snap to Monday 00:00 UTC,
+    other sizes use epoch-aligned windows of `period_hours`.
+    """
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    else:
+        dt = dt.astimezone(timezone.utc)
+
+    # Guard against a 0/negative period producing a div-by-zero below.
+    period_seconds = max(period_hours, 1) * 3600
+
+    if period_seconds == 604800:  # 1 week — align to Monday 00:00 UTC
+        midnight = dt.replace(hour=0, minute=0, second=0, microsecond=0)
+        return midnight - timedelta(days=dt.weekday())
+
+    epoch = datetime(1970, 1, 1, tzinfo=timezone.utc)
+    seconds_since_epoch = int((dt - epoch).total_seconds())
+    window_number = seconds_since_epoch // period_seconds
+    return epoch + timedelta(seconds=window_number * period_seconds)
+
+
+def record_user_usage(
+    db_session: Session,
+    user_id: str,
+    model: str,
+    flow: str,
+    provider: str | None,
+    input_tokens: int,
+    output_tokens: int,
+    cache_read_tokens: int,
+    cost_cents: float,
+    window_start: datetime,
+) -> None:
+    """
+    Atomically accumulate a usage sample into the per-user ledger.
+
+    Postgres path is a single INSERT ... ON CONFLICT DO UPDATE that adds the
+    new amounts to the existing row, so concurrent recorders can't lose an
+    update. Caller owns the transaction commit.
+    """
+    # Store "" rather than NULL for a missing provider so the dedup unique index
+    # collapses these rows on every Postgres version (no NULLS NOT DISTINCT).
+    provider = provider or ""
+    dialect = db_session.bind.dialect.name if db_session.bind is not None else ""
+
+    if dialect == "postgresql":
+        stmt = pg_insert(UserUsage).values(
+            user_id=user_id,
+            window_start=window_start,
+            model=model,
+            flow=flow,
+            provider=provider,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_read_tokens=cache_read_tokens,
+            cost_cents=cost_cents,
+        )
+        stmt = stmt.on_conflict_do_update(
+            index_elements=_CONFLICT_COLS,
+            set_={
+                "input_tokens": UserUsage.input_tokens + stmt.excluded.input_tokens,
+                "output_tokens": UserUsage.output_tokens + stmt.excluded.output_tokens,
+                "cache_read_tokens": UserUsage.cache_read_tokens
+                + stmt.excluded.cache_read_tokens,
+                "cost_cents": UserUsage.cost_cents + stmt.excluded.cost_cents,
+            },
+        )
+        db_session.execute(stmt)
+        db_session.flush()
+        return
+
+    # Non-postgres (SQLite tests): SELECT ... FOR UPDATE then add-or-insert.
+    existing = db_session.execute(
+        select(UserUsage)
+        .where(
+            UserUsage.user_id == user_id,
+            UserUsage.window_start == window_start,
+            UserUsage.model == model,
+            UserUsage.flow == flow,
+            UserUsage.provider == provider,
+        )
+        .with_for_update()
+    ).scalar_one_or_none()
+
+    if existing is None:
+        db_session.add(
+            UserUsage(
+                user_id=user_id,
+                window_start=window_start,
+                model=model,
+                flow=flow,
+                provider=provider,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cache_read_tokens=cache_read_tokens,
+                cost_cents=cost_cents,
+            )
+        )
+    else:
+        existing.input_tokens += input_tokens
+        existing.output_tokens += output_tokens
+        existing.cache_read_tokens += cache_read_tokens
+        existing.cost_cents += cost_cents
+
+    db_session.flush()
+
+
+def get_user_usage_by_day_and_model(
+    db_session: Session,
+    user_id: str,
+    since: datetime,
+    until: datetime,
+) -> list[dict[str, object]]:
+    """
+    Aggregate a user's usage by calendar day (UTC) and model over [since, until).
+
+    Returns rows of {day, model, input_tokens, output_tokens, cache_read_tokens,
+    cost_cents} sorted by (day, model).
+    """
+    rows = db_session.execute(
+        select(
+            func.date(UserUsage.window_start).label("day"),
+            UserUsage.model,
+            func.sum(UserUsage.input_tokens),
+            func.sum(UserUsage.output_tokens),
+            func.sum(UserUsage.cache_read_tokens),
+            func.sum(UserUsage.cost_cents),
+        )
+        .where(
+            UserUsage.user_id == user_id,
+            UserUsage.window_start >= since,
+            UserUsage.window_start < until,
+        )
+        .group_by(func.date(UserUsage.window_start), UserUsage.model)
+        .order_by(func.date(UserUsage.window_start), UserUsage.model)
+    ).all()
+
+    return [
+        {
+            "day": str(day),
+            "model": model,
+            "input_tokens": int(in_tok or 0),
+            "output_tokens": int(out_tok or 0),
+            "cache_read_tokens": int(cache_tok or 0),
+            "cost_cents": float(cost or 0.0),
+        }
+        for day, model, in_tok, out_tok, cache_tok, cost in rows
+    ]
+
+
+def get_usage_export(
+    db_session: Session,
+    start: datetime,
+    end: datetime,
+    model: str | None = None,
+) -> list[dict[str, object]]:
+    """Tenant-wide usage joined to user email, grouped by (email, model, day).
+
+    Covers windows whose start falls in [start, end). Day granularity follows
+    the configured usage window (weekly by default), so func.date(window_start)
+    is the window day, not necessarily the calendar day a call was made — a
+    "daily" caller gets one row per window, labelled by that window's start day.
+
+    Rows: {email, model, day, input_tokens, output_tokens, cache_read_tokens,
+    cost_cents}, sorted by (email, day, model).
+    """
+    query = (
+        # User.email comes from the fastapi-users base; ty mis-resolves it as a
+        # non-column role, so the multi-column select overload doesn't match.
+        select(  # ty: ignore[no-matching-overload]
+            User.email,
+            UserUsage.model,
+            func.date(UserUsage.window_start).label("day"),
+            func.sum(UserUsage.input_tokens),
+            func.sum(UserUsage.output_tokens),
+            func.sum(UserUsage.cache_read_tokens),
+            func.sum(UserUsage.cost_cents),
+        )
+        .join(User, User.id == UserUsage.user_id)
+        .where(
+            UserUsage.window_start >= start,
+            UserUsage.window_start < end,
+        )
+        .group_by(User.email, UserUsage.model, func.date(UserUsage.window_start))
+        .order_by(User.email, func.date(UserUsage.window_start), UserUsage.model)
+    )
+    if model is not None:
+        query = query.where(UserUsage.model == model)
+
+    rows = db_session.execute(query).all()
+
+    return [
+        {
+            "email": email,
+            "model": mdl,
+            "day": str(day),
+            "input_tokens": int(in_tok or 0),
+            "output_tokens": int(out_tok or 0),
+            "cache_read_tokens": int(cache_tok or 0),
+            "cost_cents": float(cost or 0.0),
+        }
+        for email, mdl, day, in_tok, out_tok, cache_tok, cost in rows
+    ]
+
+
+def get_user_cost_cents_in_window(
+    db_session: Session,
+    user_id: str,
+    window_start: datetime,
+) -> float:
+    """Total cost (cents) a user accrued in one exact ledger window — for display.
+
+    Exact-match read against the ledger's own grid. Budget enforcement must use
+    the sliding `*_since` helpers instead (see their docstrings).
+    """
+    total = db_session.execute(
+        select(func.coalesce(func.sum(UserUsage.cost_cents), 0.0)).where(
+            UserUsage.user_id == user_id,
+            UserUsage.window_start == window_start,
+        )
+    ).scalar_one()
+    return float(total)
+
+
+def get_user_cost_cents_since(
+    db_session: Session,
+    user_id: str,
+    cutoff: datetime,
+) -> float:
+    """Cost (cents) a user accrued in ledger windows starting at/after `cutoff`.
+
+    Sliding-window mirror of the token check: sums every ledger row whose
+    window_start >= cutoff, period-agnostic. The ledger buckets on a single
+    fixed grid (USAGE_LIMIT_WINDOW_SECONDS), so a range scan — not an
+    exact-window match — is the only way a sub-grid budget period reads any cost.
+    """
+    total = db_session.execute(
+        select(func.coalesce(func.sum(UserUsage.cost_cents), 0.0)).where(
+            UserUsage.user_id == user_id,
+            UserUsage.window_start >= cutoff,
+        )
+    ).scalar_one()
+    return float(total)
+
+
+def get_total_cost_cents_since(
+    db_session: Session,
+    cutoff: datetime,
+) -> float:
+    """Tenant-wide cost (cents) in ledger windows >= `cutoff` — global cost budgets."""
+    total = db_session.execute(
+        select(func.coalesce(func.sum(UserUsage.cost_cents), 0.0)).where(
+            UserUsage.window_start >= cutoff,
+        )
+    ).scalar_one()
+    return float(total)
+
+
+def get_group_cost_cents_since(
+    db_session: Session,
+    user_group_id: int,
+    cutoff: datetime,
+) -> float:
+    """Cost (cents) accrued by a group's members in ledger windows >= `cutoff`."""
+    total = db_session.execute(
+        select(func.coalesce(func.sum(UserUsage.cost_cents), 0.0))
+        .join(User__UserGroup, User__UserGroup.user_id == UserUsage.user_id)
+        .where(
+            User__UserGroup.user_group_id == user_group_id,
+            UserUsage.window_start >= cutoff,
+        )
+    ).scalar_one()
+    return float(total)
+
+
+def get_group_cost_cents_buckets_since(
+    db_session: Session,
+    user_group_ids: list[int],
+    cutoff: datetime,
+) -> dict[int, list[tuple[datetime, float]]]:
+    """Per-group cost buckets (window_start, cents) for windows >= `cutoff`, in
+    one query. Batched counterpart to get_group_cost_cents_since so the group
+    cost gate can window in Python instead of a query per group/limit."""
+    rows = db_session.execute(
+        select(
+            User__UserGroup.user_group_id,
+            UserUsage.window_start,
+            func.coalesce(func.sum(UserUsage.cost_cents), 0.0),
+        )
+        .join(User__UserGroup, User__UserGroup.user_id == UserUsage.user_id)
+        .where(
+            User__UserGroup.user_group_id.in_(user_group_ids),
+            UserUsage.window_start >= cutoff,
+        )
+        .group_by(User__UserGroup.user_group_id, UserUsage.window_start)
+    ).all()
+
+    result: dict[int, list[tuple[datetime, float]]] = defaultdict(list)
+    for group_id, window_start, cost in rows:
+        # Coerce to tz-aware UTC; SQLite returns naive datetimes, which can't be
+        # compared against the tz-aware cutoffs callers window with.
+        if window_start.tzinfo is None:
+            window_start = window_start.replace(tzinfo=timezone.utc)
+        result[group_id].append((window_start, float(cost)))
+    return result

--- a/backend/onyx/db/user_usage.py
+++ b/backend/onyx/db/user_usage.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
 
+from sqlalchemy import delete
 from sqlalchemy import func
 from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
@@ -239,6 +240,23 @@ def get_usage_export(
         }
         for email, mdl, day, in_tok, out_tok, cache_tok, cost in rows
     ]
+
+
+def reset_user_usage(db_session: Session, user_id: str) -> int:
+    """Clear a user's usage for the current ledger window so an admin can lift a
+    budget block before it rolls over on its own. Prior windows (the export
+    history) are preserved. Returns the number of ledger rows removed."""
+    window_start = get_window_start(
+        datetime.now(timezone.utc), period_hours=USAGE_PERIOD_HOURS
+    )
+    result = db_session.execute(
+        delete(UserUsage).where(
+            UserUsage.user_id == user_id,
+            UserUsage.window_start == window_start,
+        )
+    )
+    db_session.commit()
+    return result.rowcount or 0
 
 
 def get_user_cost_cents_in_window(

--- a/backend/onyx/db/user_usage.py
+++ b/backend/onyx/db/user_usage.py
@@ -17,11 +17,18 @@ from onyx.db.models import User
 from onyx.db.models import User__UserGroup
 from onyx.db.models import UserUsage
 from onyx.utils.logger import setup_logger
+from shared_configs.configs import USAGE_LIMIT_WINDOW_SECONDS
 
 logger = setup_logger()
 
 # Dimension columns that uniquely identify a ledger row within a window.
 _CONFLICT_COLS = ["user_id", "window_start", "model", "flow", "provider"]
+
+# Per-user windows coincide with the tenant-usage window. Floor at 1h so a
+# sub-hour USAGE_LIMIT_WINDOW_SECONDS can't truncate to 0 (div-by-zero); windows
+# finer than hourly aren't supported. Shared so the recorder and the /user/usage
+# read agree on the window — a drift here would mis-bucket the displayed cost.
+USAGE_PERIOD_HOURS = max(USAGE_LIMIT_WINDOW_SECONDS // 3600, 1)
 
 
 def get_window_start(dt: datetime, period_hours: int) -> datetime:

--- a/backend/onyx/error_handling/exceptions.py
+++ b/backend/onyx/error_handling/exceptions.py
@@ -47,6 +47,7 @@ class OnyxError(Exception):
         detail: str | None = None,
         *,
         status_code_override: int | None = None,
+        extra: dict[str, object] | None = None,
         headers: dict[str, str] | None = None,
     ) -> None:
         resolved_detail = detail or error_code.code
@@ -54,6 +55,9 @@ class OnyxError(Exception):
         self.error_code = error_code
         self.detail = resolved_detail
         self._status_code_override = status_code_override
+        # extra: machine-readable fields merged into the JSON body (e.g. reset_at).
+        # headers: response headers the FE/clients need (e.g. Retry-After).
+        self.extra = extra
         self.headers = headers
 
     @property
@@ -71,9 +75,13 @@ def log_onyx_error(exc: OnyxError) -> None:
 
 
 def onyx_error_to_json_response(exc: OnyxError) -> JSONResponse:
+    content = exc.error_code.detail(exc.detail)
+    if exc.extra:
+        # extra first so the canonical error_code/detail can't be overwritten.
+        content = {**exc.extra, **content}
     return JSONResponse(
         status_code=exc.status_code,
-        content=exc.error_code.detail(exc.detail),
+        content=content,
         headers=exc.headers,
     )
 

--- a/backend/onyx/llm/cost.py
+++ b/backend/onyx/llm/cost.py
@@ -1,8 +1,17 @@
 """LLM cost calculation utilities."""
 
+from sqlalchemy.orm import Session
+
+from onyx.configs.app_configs import DEFAULT_IMAGE_COST_CENTS
+from onyx.configs.app_configs import DEFAULT_LLM_INPUT_COST_PER_MTOK
+from onyx.configs.app_configs import DEFAULT_LLM_OUTPUT_COST_PER_MTOK
+from onyx.llm import cost_overrides
+from onyx.tracing.flows import LLMFlow
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
+
+_IMAGE_FLOWS = {LLMFlow.IMAGE_GENERATION, LLMFlow.IMAGE_EDIT}
 
 
 def calculate_llm_cost_cents(
@@ -38,3 +47,143 @@ def calculate_llm_cost_cents(
             e,
         )
         return 0.0
+
+
+def get_model_price_per_million(
+    model: str,
+    provider: str | None,
+    db_session: Session | None = None,
+) -> tuple[float | None, float | None]:
+    """Return (input, output) USD price per 1M tokens for a model, override-aware.
+
+    Same resolution as compute_cost_cents: admin override wins, else litellm's
+    price map. Unknown/unpriced models yield (None, None) — never raises (drives
+    a read-only UI panel).
+    """
+    if db_session is not None:
+        try:
+            rates = cost_overrides.get_override(db_session, model)
+        except Exception:
+            logger.exception("Override lookup failed for model %s", model)
+            rates = None
+        if rates is not None:
+            # rates is (input, output, cache); the price display is input/output.
+            return rates[0], rates[1]
+
+    try:
+        import litellm
+
+        # custom_llm_provider disambiguates non-self-identifying names so the
+        # same model resolves the same way it does for billing.
+        entry = litellm.get_model_info(model=model, custom_llm_provider=provider)
+        input_per_tok = entry.get("input_cost_per_token")
+        output_per_tok = entry.get("output_cost_per_token")
+        return (
+            float(input_per_tok) * 1_000_000 if input_per_tok is not None else None,
+            float(output_per_tok) * 1_000_000 if output_per_tok is not None else None,
+        )
+    except Exception:
+        logger.debug("No price-per-million for model %s (provider %s)", model, provider)
+        return None, None
+
+
+def _image_cost_cents(model: str) -> float:
+    """Per-image cost in cents from litellm, falling back to a flat constant."""
+    try:
+        import litellm
+
+        entry = litellm.model_cost.get(model) or {}
+        # litellm prices images per-image under either of these keys. Use an
+        # explicit None check so a genuinely free (0.0) model is billed 0, not
+        # silently bumped to the flat fallback.
+        per_image_usd = entry.get("output_cost_per_image")
+        if per_image_usd is None:
+            per_image_usd = entry.get("input_cost_per_image")
+        if per_image_usd is not None:
+            return float(per_image_usd) * 100
+    except Exception:
+        logger.exception("Image price lookup failed for model %s", model)
+    return DEFAULT_IMAGE_COST_CENTS
+
+
+def _override_cost_cents(
+    rates: tuple[float, float, float | None],
+    input_tokens: int,
+    output_tokens: int,
+    cache_read_tokens: int,
+) -> tuple[float, float]:
+    """Apply admin per-Mtok rates. Cache reads bill at the admin cache rate when
+    set, otherwise at the input rate. Cache cost is folded into the input half."""
+    input_per_mtok, output_per_mtok, cache_per_mtok = rates
+    cache_rate = cache_per_mtok if cache_per_mtok is not None else input_per_mtok
+    input_cents = (
+        input_tokens / 1_000_000 * input_per_mtok * 100
+        + cache_read_tokens / 1_000_000 * cache_rate * 100
+    )
+    output_cents = output_tokens / 1_000_000 * output_per_mtok * 100
+    return input_cents, output_cents
+
+
+def compute_cost_cents(
+    model: str,
+    provider: str | None,
+    input_tokens: int,
+    output_tokens: int,
+    cache_read_tokens: int = 0,
+    flow: LLMFlow | str | None = None,
+    db_session: Session | None = None,
+) -> tuple[float, float]:
+    """Return (input_cost_cents, output_cost_cents) for an LLM call.
+
+    Resolution order: admin override (negotiated rates win) → image pricing for
+    image flows → litellm token pricing → the configurable default fallback
+    rates (0 unless set). Never raises (it runs in the usage hot path).
+    """
+    # Admin override beats everything, including image pricing.
+    if db_session is not None:
+        try:
+            rates = cost_overrides.get_override(db_session, model)
+        except Exception:
+            logger.exception("Override lookup failed for model %s", model)
+            rates = None
+        if rates is not None:
+            return _override_cost_cents(
+                rates, input_tokens, output_tokens, cache_read_tokens
+            )
+
+    if flow in _IMAGE_FLOWS:
+        # Image generation isn't priced per token; attribute the whole cost
+        # to the output (generated-image) half.
+        return 0.0, _image_cost_cents(model)
+
+    try:
+        import litellm
+
+        # custom_llm_provider is required for non-self-identifying model names
+        # (bedrock/vertex/anthropic-plain) — without it litellm raises and we'd
+        # record $0 for entire provider classes.
+        # input_tokens are non-cached; cache reads are additional prompt tokens
+        # billed at the model's (discounted) cache-read rate, never as output.
+        prompt_cost_usd, completion_cost_usd = litellm.cost_per_token(
+            model=model,
+            custom_llm_provider=provider,
+            prompt_tokens=input_tokens + cache_read_tokens,
+            completion_tokens=output_tokens,
+            cache_read_input_tokens=cache_read_tokens,
+        )
+        return prompt_cost_usd * 100, completion_cost_usd * 100
+    except Exception:
+        # litellm has no price for this model — fall back to the configurable
+        # default rates so unpriced/BYO models still accrue cost (0 by default).
+        billed_input = input_tokens + cache_read_tokens
+        input_cents = billed_input / 1_000_000 * DEFAULT_LLM_INPUT_COST_PER_MTOK * 100
+        output_cents = (
+            output_tokens / 1_000_000 * DEFAULT_LLM_OUTPUT_COST_PER_MTOK * 100
+        )
+        if not (DEFAULT_LLM_INPUT_COST_PER_MTOK or DEFAULT_LLM_OUTPUT_COST_PER_MTOK):
+            logger.warning(
+                "No price for model %s (provider %s); recording 0 cost.",
+                model,
+                provider,
+            )
+        return input_cents, output_cents

--- a/backend/onyx/llm/cost.py
+++ b/backend/onyx/llm/cost.py
@@ -181,6 +181,14 @@ def compute_cost_cents(
     except Exception:
         # litellm has no price for this model — fall back to the configurable
         # default rates so unpriced/BYO models still accrue cost (0 by default).
+        # Log at debug so a transient litellm failure (vs a genuinely unpriced
+        # model) is diagnosable without spamming on every BYO model.
+        logger.debug(
+            "litellm pricing failed for model %s (provider %s); using default rates",
+            model,
+            provider,
+            exc_info=True,
+        )
         billed_input = input_tokens + cache_read_tokens
         input_cents = billed_input / 1_000_000 * DEFAULT_LLM_INPUT_COST_PER_MTOK * 100
         output_cents = (

--- a/backend/onyx/llm/cost.py
+++ b/backend/onyx/llm/cost.py
@@ -87,12 +87,18 @@ def get_model_price_per_million(
         return None, None
 
 
-def _image_cost_cents(model: str) -> float:
-    """Per-image cost in cents from litellm, falling back to a flat constant."""
+def _image_cost_cents(model: str, provider: str | None) -> float:
+    """Per-image cost in cents from litellm, falling back to a flat constant.
+
+    provider disambiguates non-self-identifying model names so image pricing
+    resolves the same way token pricing + admin overrides do."""
     try:
         import litellm
 
-        entry = litellm.model_cost.get(model) or {}
+        try:
+            entry = litellm.get_model_info(model=model, custom_llm_provider=provider)
+        except Exception:
+            entry = litellm.model_cost.get(model) or {}
         # litellm prices images per-image under either of these keys. Use an
         # explicit None check so a genuinely free (0.0) model is billed 0, not
         # silently bumped to the flat fallback.
@@ -154,7 +160,7 @@ def compute_cost_cents(
     if flow in _IMAGE_FLOWS:
         # Image generation isn't priced per token; attribute the whole cost
         # to the output (generated-image) half.
-        return 0.0, _image_cost_cents(model)
+        return 0.0, _image_cost_cents(model, provider)
 
     try:
         import litellm

--- a/backend/onyx/llm/cost.py
+++ b/backend/onyx/llm/cost.py
@@ -62,7 +62,7 @@ def get_model_price_per_million(
     """
     if db_session is not None:
         try:
-            rates = cost_overrides.get_override(db_session, model)
+            rates = cost_overrides.get_override(db_session, model, provider or "")
         except Exception:
             logger.exception("Override lookup failed for model %s", model)
             rates = None
@@ -142,7 +142,7 @@ def compute_cost_cents(
     # Admin override beats everything, including image pricing.
     if db_session is not None:
         try:
-            rates = cost_overrides.get_override(db_session, model)
+            rates = cost_overrides.get_override(db_session, model, provider or "")
         except Exception:
             logger.exception("Override lookup failed for model %s", model)
             rates = None

--- a/backend/onyx/llm/cost.py
+++ b/backend/onyx/llm/cost.py
@@ -87,6 +87,44 @@ def get_model_price_per_million(
         return None, None
 
 
+def get_model_prices_per_million(
+    model: str,
+    provider: str | None,
+    db_session: Session | None = None,
+) -> tuple[float | None, float | None, float | None]:
+    """(input, output, cache-read) USD per 1M tokens, override-aware.
+
+    Same resolution as get_model_price_per_million, plus the cache-read rate.
+    Cache is None when neither an override nor litellm prices cache reads (the UI
+    then falls back to the input rate, which is how billing treats it). Never raises.
+    """
+    if db_session is not None:
+        try:
+            rates = cost_overrides.get_override(db_session, model, provider or "")
+        except Exception:
+            logger.exception("Override lookup failed for model %s", model)
+            rates = None
+        if rates is not None:
+            # rates is (input, output, cache).
+            return rates[0], rates[1], rates[2]
+
+    try:
+        import litellm
+
+        entry = litellm.get_model_info(model=model, custom_llm_provider=provider)
+        input_per_tok = entry.get("input_cost_per_token")
+        output_per_tok = entry.get("output_cost_per_token")
+        cache_per_tok = entry.get("cache_read_input_token_cost")
+        return (
+            float(input_per_tok) * 1_000_000 if input_per_tok is not None else None,
+            float(output_per_tok) * 1_000_000 if output_per_tok is not None else None,
+            float(cache_per_tok) * 1_000_000 if cache_per_tok is not None else None,
+        )
+    except Exception:
+        logger.debug("No price-per-million for model %s (provider %s)", model, provider)
+        return None, None, None
+
+
 def _image_cost_cents(model: str, provider: str | None) -> float:
     """Per-image cost in cents from litellm, falling back to a flat constant.
 

--- a/backend/onyx/llm/cost_overrides.py
+++ b/backend/onyx/llm/cost_overrides.py
@@ -58,24 +58,27 @@ def get_override(
     tenant_id = get_current_tenant_id()
     with _cache_lock:
         entry = _cache.get(tenant_id)
-        if entry is None or (time.monotonic() - entry[0]) >= _CACHE_TTL_SECONDS:
-            try:
-                snapshot = _load_cache(db_session)
-            except Exception:
-                # Cost computation must never raise. On a transient load failure
-                # keep serving the last good snapshot (stale rates beat silently
-                # dropping negotiated rates); only with no prior snapshot do we
-                # treat as no overrides. The stale timestamp is left as-is so the
-                # next lookup retries the DB.
-                logger.exception("Failed to load model cost overrides")
-                if entry is None:
-                    return None
-                return _lookup(entry[1], model, provider)
-            entry = (time.monotonic(), snapshot)
-            if tenant_id not in _cache and len(_cache) >= _MAX_CACHED_TENANTS:
-                _cache.pop(next(iter(_cache)), None)
-            _cache[tenant_id] = entry
+    if entry is not None and (time.monotonic() - entry[0]) < _CACHE_TTL_SECONDS:
         return _lookup(entry[1], model, provider)
+
+    # Reload outside the lock so a slow DB query doesn't serialize every other
+    # tenant's lookups. A concurrent double-load is harmless (idempotent).
+    try:
+        snapshot = _load_cache(db_session)
+    except Exception:
+        # Cost computation must never raise. On a transient load failure keep
+        # serving the last good snapshot (stale rates beat silently dropping
+        # negotiated rates); only with no prior snapshot do we treat as no
+        # overrides. The stale timestamp is left as-is so the next lookup retries.
+        logger.exception("Failed to load model cost overrides")
+        return _lookup(entry[1], model, provider) if entry is not None else None
+
+    entry = (time.monotonic(), snapshot)
+    with _cache_lock:
+        if tenant_id not in _cache and len(_cache) >= _MAX_CACHED_TENANTS:
+            _cache.pop(next(iter(_cache)), None)
+        _cache[tenant_id] = entry
+    return _lookup(snapshot, model, provider)
 
 
 def invalidate_override_cache() -> None:

--- a/backend/onyx/llm/cost_overrides.py
+++ b/backend/onyx/llm/cost_overrides.py
@@ -26,6 +26,9 @@ _cache_lock = threading.Lock()
 _OverrideKey = tuple[str, str]
 # tenant_id -> (loaded_at_monotonic, {(provider, model): rates})
 _cache: dict[str, tuple[float, dict[_OverrideKey, _OverrideRates]]] = {}
+# Bound the per-tenant cache so a many-tenant process can't accumulate entries
+# unboundedly; evict the oldest (insertion order) when full.
+_MAX_CACHED_TENANTS = 10_000
 
 
 def _load_cache(db_session: Session) -> dict[_OverrideKey, _OverrideRates]:
@@ -69,6 +72,8 @@ def get_override(
                     return None
                 return _lookup(entry[1], model, provider)
             entry = (time.monotonic(), snapshot)
+            if tenant_id not in _cache and len(_cache) >= _MAX_CACHED_TENANTS:
+                _cache.pop(next(iter(_cache)), None)
             _cache[tenant_id] = entry
         return _lookup(entry[1], model, provider)
 

--- a/backend/onyx/llm/cost_overrides.py
+++ b/backend/onyx/llm/cost_overrides.py
@@ -1,0 +1,128 @@
+"""Admin per-model cost overrides — negotiated enterprise rates that win over litellm."""
+
+import threading
+import time
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from onyx.db.models import ModelCostOverride
+from onyx.utils.logger import setup_logger
+from shared_configs.contextvars import get_current_tenant_id
+
+logger = setup_logger()
+
+# (input, output, cache_read | None) per-Mtok USD; null cache => bill at input.
+_OverrideRates = tuple[float, float, float | None]
+
+# Per-tenant snapshot of the override table, keyed by tenant_id: a shared
+# process serves many tenants, so an unkeyed cache would bill one tenant's
+# negotiated rates to all. A write invalidates only the writer's process, so
+# the TTL bounds how long sibling workers serve stale rates after an admin edit.
+_CACHE_TTL_SECONDS = 60.0
+_cache_lock = threading.Lock()
+# tenant_id -> (loaded_at_monotonic, {model: rates})
+_cache: dict[str, tuple[float, dict[str, _OverrideRates]]] = {}
+
+
+def _load_cache(db_session: Session) -> dict[str, _OverrideRates]:
+    rows = db_session.execute(select(ModelCostOverride)).scalars().all()
+    return {
+        r.model: (
+            r.input_cost_per_mtok,
+            r.output_cost_per_mtok,
+            r.cache_read_cost_per_mtok,
+        )
+        for r in rows
+    }
+
+
+def get_override(db_session: Session, model: str) -> _OverrideRates | None:
+    """Return (input_per_mtok, output_per_mtok) for `model` in the current
+    tenant, or None if unset."""
+    tenant_id = get_current_tenant_id()
+    with _cache_lock:
+        entry = _cache.get(tenant_id)
+        if entry is None or (time.monotonic() - entry[0]) >= _CACHE_TTL_SECONDS:
+            try:
+                snapshot = _load_cache(db_session)
+            except Exception:
+                # Cost computation must never raise. On a transient load failure
+                # keep serving the last good snapshot (stale rates beat silently
+                # dropping negotiated rates); only with no prior snapshot do we
+                # treat as no overrides. The stale timestamp is left as-is so the
+                # next lookup retries the DB.
+                logger.exception("Failed to load model cost overrides")
+                if entry is None:
+                    return None
+                return entry[1].get(model)
+            entry = (time.monotonic(), snapshot)
+            _cache[tenant_id] = entry
+        return entry[1].get(model)
+
+
+def invalidate_override_cache() -> None:
+    """Drop the current tenant's cached snapshot so its next lookup reloads."""
+    tenant_id = get_current_tenant_id()
+    with _cache_lock:
+        _cache.pop(tenant_id, None)
+
+
+def list_overrides(db_session: Session) -> list[ModelCostOverride]:
+    """All override rows for the current tenant, ordered by model name."""
+    return list(
+        db_session.execute(select(ModelCostOverride).order_by(ModelCostOverride.model))
+        .scalars()
+        .all()
+    )
+
+
+def upsert_override(
+    db_session: Session,
+    model: str,
+    input_cost_per_mtok: float,
+    output_cost_per_mtok: float,
+    cache_read_cost_per_mtok: float | None = None,
+) -> ModelCostOverride:
+    """Set the negotiated rates for `model`, creating or replacing its row.
+
+    Rates are USD per million tokens; a null cache rate bills cache reads at the
+    input rate. Caller invalidates the cache and commits.
+    """
+    # Defense in depth behind the request model's ge=0: a negative rate would
+    # credit usage and corrupt budget enforcement.
+    for rate in (input_cost_per_mtok, output_cost_per_mtok, cache_read_cost_per_mtok):
+        if rate is not None and rate < 0:
+            raise ValueError("cost override rates must be non-negative")
+
+    row = db_session.execute(
+        select(ModelCostOverride).where(ModelCostOverride.model == model)
+    ).scalar_one_or_none()
+
+    if row is None:
+        row = ModelCostOverride(
+            model=model,
+            input_cost_per_mtok=input_cost_per_mtok,
+            output_cost_per_mtok=output_cost_per_mtok,
+            cache_read_cost_per_mtok=cache_read_cost_per_mtok,
+        )
+        db_session.add(row)
+    else:
+        row.input_cost_per_mtok = input_cost_per_mtok
+        row.output_cost_per_mtok = output_cost_per_mtok
+        row.cache_read_cost_per_mtok = cache_read_cost_per_mtok
+
+    db_session.flush()
+    return row
+
+
+def delete_override(db_session: Session, model: str) -> bool:
+    """Remove the override for `model`; False if there was none."""
+    row = db_session.execute(
+        select(ModelCostOverride).where(ModelCostOverride.model == model)
+    ).scalar_one_or_none()
+    if row is None:
+        return False
+    db_session.delete(row)
+    db_session.flush()
+    return True

--- a/backend/onyx/llm/cost_overrides.py
+++ b/backend/onyx/llm/cost_overrides.py
@@ -21,14 +21,17 @@ _OverrideRates = tuple[float, float, float | None]
 # the TTL bounds how long sibling workers serve stale rates after an admin edit.
 _CACHE_TTL_SECONDS = 60.0
 _cache_lock = threading.Lock()
-# tenant_id -> (loaded_at_monotonic, {model: rates})
-_cache: dict[str, tuple[float, dict[str, _OverrideRates]]] = {}
+# Keyed by (provider, model) so the same model can carry per-provider rates;
+# provider is "" for a provider-agnostic override.
+_OverrideKey = tuple[str, str]
+# tenant_id -> (loaded_at_monotonic, {(provider, model): rates})
+_cache: dict[str, tuple[float, dict[_OverrideKey, _OverrideRates]]] = {}
 
 
-def _load_cache(db_session: Session) -> dict[str, _OverrideRates]:
+def _load_cache(db_session: Session) -> dict[_OverrideKey, _OverrideRates]:
     rows = db_session.execute(select(ModelCostOverride)).scalars().all()
     return {
-        r.model: (
+        (r.provider, r.model): (
             r.input_cost_per_mtok,
             r.output_cost_per_mtok,
             r.cache_read_cost_per_mtok,
@@ -37,9 +40,18 @@ def _load_cache(db_session: Session) -> dict[str, _OverrideRates]:
     }
 
 
-def get_override(db_session: Session, model: str) -> _OverrideRates | None:
-    """Return (input_per_mtok, output_per_mtok) for `model` in the current
-    tenant, or None if unset."""
+def _lookup(
+    snapshot: dict[_OverrideKey, _OverrideRates], model: str, provider: str
+) -> _OverrideRates | None:
+    # Prefer a provider-specific rate, else the provider-agnostic ("") one.
+    return snapshot.get((provider, model)) or snapshot.get(("", model))
+
+
+def get_override(
+    db_session: Session, model: str, provider: str = ""
+) -> _OverrideRates | None:
+    """Return the (input, output, cache_read) rates for `model` (+ optional
+    `provider`) in the current tenant, or None if unset."""
     tenant_id = get_current_tenant_id()
     with _cache_lock:
         entry = _cache.get(tenant_id)
@@ -55,10 +67,10 @@ def get_override(db_session: Session, model: str) -> _OverrideRates | None:
                 logger.exception("Failed to load model cost overrides")
                 if entry is None:
                     return None
-                return entry[1].get(model)
+                return _lookup(entry[1], model, provider)
             entry = (time.monotonic(), snapshot)
             _cache[tenant_id] = entry
-        return entry[1].get(model)
+        return _lookup(entry[1], model, provider)
 
 
 def invalidate_override_cache() -> None:
@@ -83,8 +95,10 @@ def upsert_override(
     input_cost_per_mtok: float,
     output_cost_per_mtok: float,
     cache_read_cost_per_mtok: float | None = None,
+    provider: str = "",
 ) -> ModelCostOverride:
-    """Set the negotiated rates for `model`, creating or replacing its row.
+    """Set the negotiated rates for (`provider`, `model`), creating or replacing
+    its row. `provider` is "" for a provider-agnostic override.
 
     Rates are USD per million tokens; a null cache rate bills cache reads at the
     input rate. Caller invalidates the cache and commits.
@@ -96,11 +110,15 @@ def upsert_override(
             raise ValueError("cost override rates must be non-negative")
 
     row = db_session.execute(
-        select(ModelCostOverride).where(ModelCostOverride.model == model)
+        select(ModelCostOverride).where(
+            ModelCostOverride.provider == provider,
+            ModelCostOverride.model == model,
+        )
     ).scalar_one_or_none()
 
     if row is None:
         row = ModelCostOverride(
+            provider=provider,
             model=model,
             input_cost_per_mtok=input_cost_per_mtok,
             output_cost_per_mtok=output_cost_per_mtok,
@@ -116,10 +134,13 @@ def upsert_override(
     return row
 
 
-def delete_override(db_session: Session, model: str) -> bool:
-    """Remove the override for `model`; False if there was none."""
+def delete_override(db_session: Session, model: str, provider: str = "") -> bool:
+    """Remove the override for (`provider`, `model`); False if there was none."""
     row = db_session.execute(
-        select(ModelCostOverride).where(ModelCostOverride.model == model)
+        select(ModelCostOverride).where(
+            ModelCostOverride.provider == provider,
+            ModelCostOverride.model == model,
+        )
     ).scalar_one_or_none()
     if row is None:
         return False

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -110,6 +110,9 @@ from onyx.server.features.skill.api import admin_router as skill_admin_router
 from onyx.server.features.skill.api import user_router as skill_router
 from onyx.server.features.tool.api import admin_router as admin_tool_router
 from onyx.server.features.tool.api import router as tool_router
+from onyx.server.features.usage.api import admin_usage_router
+from onyx.server.features.usage.api import router as cost_override_router
+from onyx.server.features.usage.api import user_usage_router
 from onyx.server.features.user_oauth_token.api import router as user_oauth_token_router
 from onyx.server.features.web_search.api import router as web_search_router
 from onyx.server.federated.api import router as federated_router
@@ -418,6 +421,12 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:  # noqa: ARG001
 
     yield
 
+    # Flush buffered per-user usage before disposing the DB engines its drain
+    # thread writes through.
+    from onyx.tracing.setup import shutdown_tracing
+
+    shutdown_tracing()
+
     if DISABLE_VECTOR_DB:
         from onyx.background.periodic_poller import stop_periodic_poller
 
@@ -567,6 +576,9 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
     include_router_with_global_prefix_prepended(
         application, token_rate_limit_settings_router
     )
+    include_router_with_global_prefix_prepended(application, cost_override_router)
+    include_router_with_global_prefix_prepended(application, user_usage_router)
+    include_router_with_global_prefix_prepended(application, admin_usage_router)
     include_router_with_global_prefix_prepended(application, api_key_router)
     include_router_with_global_prefix_prepended(application, standard_oauth_router)
     include_router_with_global_prefix_prepended(application, federated_router)

--- a/backend/onyx/server/features/build/session/messages.py
+++ b/backend/onyx/server/features/build/session/messages.py
@@ -42,6 +42,7 @@ from onyx.server.features.build.session.models import MessageInterruptResponse
 from onyx.server.features.build.session.models import MessageListResponse
 from onyx.server.features.build.session.models import MessageRequest
 from onyx.server.features.build.session.models import MessageResponse
+from onyx.server.query_and_chat.token_limit import check_token_rate_limits
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -132,6 +133,9 @@ def send_message(
             )
 
         check_build_rate_limits(user=user, db_session=db_session)
+        # Craft turns also respect the org/user token + cost budgets. No-op when
+        # none are configured; raises the structured 429 when over budget.
+        check_token_rate_limits(user)
 
         turn_index = count_user_messages(session_id, db_session)
         if request.provider and request.model:
@@ -195,6 +199,8 @@ def send_subagent_message(
     request: MessageRequest,
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     _rate_limit_check: None = Depends(check_build_rate_limits),
+    # Craft turns also respect the org/user token + cost budgets (no-op when none).
+    _token_rate_limit_check: None = Depends(check_token_rate_limits),
 ) -> StreamingResponse:
     """
     Send a follow-up message to a subagent's child opencode session and

--- a/backend/onyx/server/features/usage/api.py
+++ b/backend/onyx/server/features/usage/api.py
@@ -31,6 +31,7 @@ from onyx.db.user_usage import get_user_cost_cents_in_window
 from onyx.db.user_usage import get_user_cost_cents_since
 from onyx.db.user_usage import get_user_usage_by_day_and_model
 from onyx.db.user_usage import get_window_start
+from onyx.db.user_usage import USAGE_PERIOD_HOURS
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.llm.cost import get_model_price_per_million
@@ -48,10 +49,6 @@ from onyx.server.features.usage.models import UsageExportTotals
 from onyx.server.features.usage.models import UsageExportUser
 from onyx.server.features.usage.models import UserUsageResponse
 from shared_configs.configs import USAGE_LIMIT_WINDOW_SECONDS
-
-# Per-user windows must coincide with the tenant-usage windows; same source as
-# the recorder (onyx/tracing/processors/user_usage_processor.py).
-_PERIOD_HOURS = max(USAGE_LIMIT_WINDOW_SECONDS // 3600, 1)
 
 # Default trailing range for the export when no start is given.
 _DEFAULT_EXPORT_DAYS = 30
@@ -171,7 +168,7 @@ def get_my_usage(
     a trailing N-day range. Budget fields are null when the user has no cost limit.
     """
     now = datetime.now(timezone.utc)
-    window_start = get_window_start(now, period_hours=_PERIOD_HOURS)
+    window_start = get_window_start(now, period_hours=USAGE_PERIOD_HOURS)
 
     since = now - timedelta(days=days) if days else window_start
     user_id = str(user.id)

--- a/backend/onyx/server/features/usage/api.py
+++ b/backend/onyx/server/features/usage/api.py
@@ -20,6 +20,7 @@ from onyx.configs.constants import PUBLIC_API_TAGS
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
 from onyx.db.llm import fetch_default_llm_model
+from onyx.db.llm import fetch_existing_llm_providers
 from onyx.db.models import User
 from onyx.db.token_limit import fetch_all_global_token_rate_limits
 from onyx.db.token_limit import fetch_all_user_token_rate_limits
@@ -36,7 +37,7 @@ from onyx.db.user_usage import USAGE_PERIOD_HOURS
 from onyx.db.users import get_user_by_email
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
-from onyx.llm.cost import get_model_price_per_million
+from onyx.llm.cost import get_model_prices_per_million
 from onyx.llm.cost_overrides import delete_override
 from onyx.llm.cost_overrides import invalidate_override_cache
 from onyx.llm.cost_overrides import list_overrides
@@ -190,7 +191,7 @@ def get_my_usage(
     selected_model_price: ModelPrice | None = None
     if default_model is not None:
         provider = default_model.llm_provider.provider
-        input_per_mtok, output_per_mtok = get_model_price_per_million(
+        input_per_mtok, output_per_mtok, cache_per_mtok = get_model_prices_per_million(
             default_model.name, provider, db_session
         )
         # Only surface a price block when both sides are known; an unpriced model
@@ -201,7 +202,33 @@ def get_my_usage(
                 provider=provider,
                 input_per_mtok=input_per_mtok,
                 output_per_mtok=output_per_mtok,
+                cache_per_mtok=cache_per_mtok,
             )
+
+    # Price every configured chat model so users can compare costs, not just the
+    # tenant default. Dedup on (provider, model); skip unpriced models.
+    available_model_prices: list[ModelPrice] = []
+    seen: set[tuple[str, str]] = set()
+    for prov in fetch_existing_llm_providers(db_session, flow_type_filter=[]):
+        for mc in prov.model_configurations:
+            key = (prov.provider, mc.name)
+            if key in seen:
+                continue
+            seen.add(key)
+            in_per_mtok, out_per_mtok, cache_per_mtok = get_model_prices_per_million(
+                mc.name, prov.provider, db_session
+            )
+            if in_per_mtok is not None and out_per_mtok is not None:
+                available_model_prices.append(
+                    ModelPrice(
+                        model=mc.name,
+                        provider=prov.provider,
+                        input_per_mtok=in_per_mtok,
+                        output_per_mtok=out_per_mtok,
+                        cache_per_mtok=cache_per_mtok,
+                    )
+                )
+    available_model_prices.sort(key=lambda p: (p.input_per_mtok or 0.0, p.model))
 
     budget_cents, budget_remaining_cents, budget_period_hours = _user_cost_budget(
         db_session, user_id
@@ -214,6 +241,7 @@ def get_my_usage(
         budget_remaining_cents=budget_remaining_cents,
         budget_period_hours=budget_period_hours,
         selected_model_price=selected_model_price,
+        available_model_prices=available_model_prices,
     )
 
 

--- a/backend/onyx/server/features/usage/api.py
+++ b/backend/onyx/server/features/usage/api.py
@@ -31,7 +31,9 @@ from onyx.db.user_usage import get_user_cost_cents_in_window
 from onyx.db.user_usage import get_user_cost_cents_since
 from onyx.db.user_usage import get_user_usage_by_day_and_model
 from onyx.db.user_usage import get_window_start
+from onyx.db.user_usage import reset_user_usage
 from onyx.db.user_usage import USAGE_PERIOD_HOURS
+from onyx.db.users import get_user_by_email
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.llm.cost import get_model_price_per_million
@@ -42,6 +44,7 @@ from onyx.llm.cost_overrides import upsert_override
 from onyx.server.features.usage.models import CostOverride
 from onyx.server.features.usage.models import CostOverrideUpsertRequest
 from onyx.server.features.usage.models import ModelPrice
+from onyx.server.features.usage.models import ResetUsageRequest
 from onyx.server.features.usage.models import UsageDayModel
 from onyx.server.features.usage.models import UsageExportRecord
 from onyx.server.features.usage.models import UsageExportResponse
@@ -266,6 +269,20 @@ def export_usage(
         end=end_date.isoformat(),
         users=users,
     )
+
+
+@admin_usage_router.post("/reset")
+def reset_usage(
+    payload: ResetUsageRequest,
+    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> None:
+    """Clear a user's current-window usage so an admin can lift a budget block
+    before it rolls over on its own. Prior windows (history) are preserved."""
+    user = get_user_by_email(payload.user_email, db_session)
+    if user is None:
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "User not found")
+    reset_user_usage(db_session, str(user.id))
 
 
 @router.get("")

--- a/backend/onyx/server/features/usage/api.py
+++ b/backend/onyx/server/features/usage/api.py
@@ -1,0 +1,311 @@
+"""Admin CRUD for per-model cost overrides — negotiated rates that win over
+litellm in compute_cost_cents. Writes invalidate the per-tenant override cache
+so subsequent cost computations don't bill stale rates."""
+
+from collections import defaultdict
+from datetime import date
+from datetime import datetime
+from datetime import time
+from datetime import timedelta
+from datetime import timezone
+from uuid import UUID
+
+from fastapi import APIRouter
+from fastapi import Depends
+from sqlalchemy.orm import Session
+
+from onyx.auth.permissions import require_permission
+from onyx.auth.users import current_user
+from onyx.configs.constants import PUBLIC_API_TAGS
+from onyx.db.engine.sql_engine import get_session
+from onyx.db.enums import Permission
+from onyx.db.llm import fetch_default_llm_model
+from onyx.db.models import User
+from onyx.db.token_limit import fetch_all_global_token_rate_limits
+from onyx.db.token_limit import fetch_all_user_token_rate_limits
+from onyx.db.token_limit import fetch_user_group_token_rate_limits
+from onyx.db.user_usage import get_group_cost_cents_buckets_since
+from onyx.db.user_usage import get_total_cost_cents_since
+from onyx.db.user_usage import get_usage_export
+from onyx.db.user_usage import get_user_cost_cents_in_window
+from onyx.db.user_usage import get_user_cost_cents_since
+from onyx.db.user_usage import get_user_usage_by_day_and_model
+from onyx.db.user_usage import get_window_start
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.llm.cost import get_model_price_per_million
+from onyx.llm.cost_overrides import delete_override
+from onyx.llm.cost_overrides import invalidate_override_cache
+from onyx.llm.cost_overrides import list_overrides
+from onyx.llm.cost_overrides import upsert_override
+from onyx.server.features.usage.models import CostOverride
+from onyx.server.features.usage.models import CostOverrideUpsertRequest
+from onyx.server.features.usage.models import ModelPrice
+from onyx.server.features.usage.models import UsageDayModel
+from onyx.server.features.usage.models import UsageExportRecord
+from onyx.server.features.usage.models import UsageExportResponse
+from onyx.server.features.usage.models import UsageExportTotals
+from onyx.server.features.usage.models import UsageExportUser
+from onyx.server.features.usage.models import UserUsageResponse
+from shared_configs.configs import USAGE_LIMIT_WINDOW_SECONDS
+
+# Per-user windows must coincide with the tenant-usage windows; same source as
+# the recorder (onyx/tracing/processors/user_usage_processor.py).
+_PERIOD_HOURS = max(USAGE_LIMIT_WINDOW_SECONDS // 3600, 1)
+
+# Default trailing range for the export when no start is given.
+_DEFAULT_EXPORT_DAYS = 30
+
+# Cost buckets at this grid; match the gate's cutoff relaxation so the budget the
+# user sees agrees with what enforcement (token_limit._worst_triggered_cost_limit) does.
+_LEDGER_GRID = timedelta(seconds=USAGE_LIMIT_WINDOW_SECONDS)
+
+
+def _user_cost_budget(
+    db_session: Session, user_id: str
+) -> tuple[float | None, float | None, int | None]:
+    """The cost budget (cents), how much is left, and the budget's window (hours)
+    for this user — or (None, None, None) if no cost limit applies. Picks the most
+    binding limit (least remaining) across per-user, global, and group cost
+    limits, mirroring how the gate enforces them."""
+    now = datetime.now(tz=timezone.utc)
+    # (remaining_cents, budget_cents, period_hours) per applicable cost limit.
+    candidates: list[tuple[float, float, int]] = []
+
+    def _add(budget: float | None, used: float, period_hours: int) -> None:
+        if budget is not None:
+            candidates.append((budget - used, budget, period_hours))
+
+    for rl in fetch_all_user_token_rate_limits(db_session, enabled_only=True):
+        cutoff = now - timedelta(hours=rl.period_hours) - _LEDGER_GRID
+        _add(
+            rl.cost_budget_cents,
+            get_user_cost_cents_since(db_session, user_id, cutoff),
+            rl.period_hours,
+        )
+
+    for rl in fetch_all_global_token_rate_limits(db_session, enabled_only=True):
+        cutoff = now - timedelta(hours=rl.period_hours) - _LEDGER_GRID
+        _add(
+            rl.cost_budget_cents,
+            get_total_cost_cents_since(db_session, cutoff),
+            rl.period_hours,
+        )
+
+    group_candidate = _group_cost_budget_candidate(db_session, user_id, now)
+    if group_candidate is not None:
+        candidates.append(group_candidate)
+
+    if not candidates:
+        return None, None, None
+    remaining, budget, period_hours = min(candidates, key=lambda c: c[0])
+    return budget, max(remaining, 0.0), period_hours
+
+
+def _group_cost_budget_candidate(
+    db_session: Session, user_id: str, now: datetime
+) -> tuple[float, float, int] | None:
+    """The user's group-scope cost headroom as one (remaining, budget, period)
+    candidate, or None if groups impose no cost cap.
+
+    The gate blocks on groups only when EVERY group is over its cost budget, so
+    the binding group is the MOST PERMISSIVE one (the most remaining). A group
+    with no cost limit is cost-exempt, which exempts the whole group scope."""
+    group_limits = fetch_user_group_token_rate_limits(db_session, UUID(user_id))
+    if not group_limits:
+        return None
+
+    cost_rls = [
+        rl
+        for rls in group_limits.values()
+        for rl in rls
+        if rl.cost_budget_cents is not None
+    ]
+    if not cost_rls:
+        return None
+
+    # One batched query for every group's cost buckets, then window in Python.
+    broadest = max(rl.period_hours for rl in cost_rls)
+    fetch_cutoff = now - timedelta(hours=broadest) - _LEDGER_GRID
+    buckets = get_group_cost_cents_buckets_since(
+        db_session, list(group_limits.keys()), fetch_cutoff
+    )
+
+    most_permissive: tuple[float, float, int] | None = None
+    for group_id, limits in group_limits.items():
+        group_buckets = buckets.get(group_id, [])
+        # This group's binding cost limit = the one with the least remaining.
+        group_binding: tuple[float, float, int] | None = None
+        for rl in limits:
+            if rl.cost_budget_cents is None:
+                continue
+            cutoff = now - timedelta(hours=rl.period_hours) - _LEDGER_GRID
+            used = sum(c for ws, c in group_buckets if ws >= cutoff)
+            remaining = rl.cost_budget_cents - used
+            if group_binding is None or remaining < group_binding[0]:
+                group_binding = (remaining, rl.cost_budget_cents, rl.period_hours)
+        if group_binding is None:
+            return None  # a cost-exempt group exempts the whole group scope
+        if most_permissive is None or group_binding[0] > most_permissive[0]:
+            most_permissive = group_binding
+
+    return most_permissive
+
+
+router = APIRouter(prefix="/admin/cost-overrides", tags=PUBLIC_API_TAGS)
+
+user_usage_router = APIRouter(prefix="/user/usage", tags=PUBLIC_API_TAGS)
+
+admin_usage_router = APIRouter(prefix="/admin/usage", tags=PUBLIC_API_TAGS)
+
+
+@user_usage_router.get("")
+def get_my_usage(
+    days: int | None = None,
+    user: User = Depends(current_user),
+    db_session: Session = Depends(get_session),
+) -> UserUsageResponse:
+    """The calling user's own token/cost usage — backs the Usage tab.
+
+    Aggregates the current window by default; `days` widens the per-day table to
+    a trailing N-day range. Budget fields are null until P5 enforcement exists.
+    """
+    now = datetime.now(timezone.utc)
+    window_start = get_window_start(now, period_hours=_PERIOD_HOURS)
+
+    since = now - timedelta(days=days) if days else window_start
+    user_id = str(user.id)
+
+    per_day = [
+        UsageDayModel.model_validate(row)
+        for row in get_user_usage_by_day_and_model(
+            db_session, user_id, since=since, until=now
+        )
+    ]
+    window_cost_cents = get_user_cost_cents_in_window(db_session, user_id, window_start)
+
+    # No per-user selected-model resolution exists yet; price the tenant default
+    # chat model. Override-aware via the shared cost helper.
+    default_model = fetch_default_llm_model(db_session)
+    selected_model_price: ModelPrice | None = None
+    if default_model is not None:
+        provider = default_model.llm_provider.provider
+        input_per_mtok, output_per_mtok = get_model_price_per_million(
+            default_model.name, provider, db_session
+        )
+        # Only surface a price block when both sides are known; an unpriced model
+        # stays None so the UI shows "price unavailable" rather than $null.
+        if input_per_mtok is not None and output_per_mtok is not None:
+            selected_model_price = ModelPrice(
+                model=default_model.name,
+                provider=provider,
+                input_per_mtok=input_per_mtok,
+                output_per_mtok=output_per_mtok,
+            )
+
+    budget_cents, budget_remaining_cents, budget_period_hours = _user_cost_budget(
+        db_session, str(user.id)
+    )
+
+    return UserUsageResponse(
+        per_day_by_model=per_day,
+        window_cost_cents=window_cost_cents,
+        budget_cents=budget_cents,
+        budget_remaining_cents=budget_remaining_cents,
+        budget_period_hours=budget_period_hours,
+        selected_model_price=selected_model_price,
+    )
+
+
+@admin_usage_router.get("/export")
+def export_usage(
+    start: date | None = None,
+    end: date | None = None,
+    model: str | None = None,
+    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> UsageExportResponse:
+    """Company-wide GenAI usage report, keyed by user email.
+
+    Aggregates every user's usage over the half-open range [start, end) into
+    per (email x model x window-day) records plus a per-user totals roll-up.
+    `start` defaults to 30 days ago, `end` to today. Day granularity follows the
+    configured usage window (weekly by default), so each record's day is the
+    window's start day — not the calendar day a call was made.
+    """
+    end_date = end or datetime.now(timezone.utc).date()
+    start_date = start or (end_date - timedelta(days=_DEFAULT_EXPORT_DAYS))
+
+    # Half-open over the full end day so windows starting on `end` are included.
+    start_dt = datetime.combine(start_date, time.min, tzinfo=timezone.utc)
+    end_dt = datetime.combine(end_date, time.min, tzinfo=timezone.utc) + timedelta(
+        days=1
+    )
+
+    rows = get_usage_export(db_session, start=start_dt, end=end_dt, model=model)
+
+    records_by_email: dict[str, list[UsageExportRecord]] = defaultdict(list)
+    for row in rows:
+        records_by_email[str(row["email"])].append(
+            UsageExportRecord.model_validate(row)
+        )
+
+    users = [
+        UsageExportUser(
+            email=email,
+            totals=UsageExportTotals(
+                input_tokens=sum(r.input_tokens for r in records),
+                output_tokens=sum(r.output_tokens for r in records),
+                cache_read_tokens=sum(r.cache_read_tokens for r in records),
+                cost_cents=sum(r.cost_cents for r in records),
+            ),
+            records=records,
+        )
+        for email, records in records_by_email.items()
+    ]
+
+    return UsageExportResponse(
+        start=start_date.isoformat(),
+        end=end_date.isoformat(),
+        users=users,
+    )
+
+
+@router.get("")
+def list_cost_overrides(
+    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> list[CostOverride]:
+    return [CostOverride.from_db(row) for row in list_overrides(db_session)]
+
+
+@router.put("")
+def upsert_cost_override(
+    payload: CostOverrideUpsertRequest,
+    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> CostOverride:
+    row = upsert_override(
+        db_session,
+        model=payload.model,
+        input_cost_per_mtok=payload.input_cost_per_mtok,
+        output_cost_per_mtok=payload.output_cost_per_mtok,
+        cache_read_cost_per_mtok=payload.cache_read_cost_per_mtok,
+    )
+    db_session.commit()
+    invalidate_override_cache()
+    return CostOverride.from_db(row)
+
+
+# {model:path} so slash-containing model ids (e.g. "bedrock/anthropic.claude")
+# match instead of 404-ing on the first path segment.
+@router.delete("/{model:path}")
+def delete_cost_override(
+    model: str,
+    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> None:
+    if not delete_override(db_session, model):
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, f"No cost override for model {model}")
+    db_session.commit()
+    invalidate_override_cache()

--- a/backend/onyx/server/features/usage/api.py
+++ b/backend/onyx/server/features/usage/api.py
@@ -168,7 +168,7 @@ def get_my_usage(
     """The calling user's own token/cost usage — backs the Usage tab.
 
     Aggregates the current window by default; `days` widens the per-day table to
-    a trailing N-day range. Budget fields are null until P5 enforcement exists.
+    a trailing N-day range. Budget fields are null when the user has no cost limit.
     """
     now = datetime.now(timezone.utc)
     window_start = get_window_start(now, period_hours=_PERIOD_HOURS)
@@ -204,7 +204,7 @@ def get_my_usage(
             )
 
     budget_cents, budget_remaining_cents, budget_period_hours = _user_cost_budget(
-        db_session, str(user.id)
+        db_session, user_id
     )
 
     return UserUsageResponse(

--- a/backend/onyx/server/features/usage/api.py
+++ b/backend/onyx/server/features/usage/api.py
@@ -285,6 +285,7 @@ def upsert_cost_override(
     row = upsert_override(
         db_session,
         model=payload.model,
+        provider=payload.provider,
         input_cost_per_mtok=payload.input_cost_per_mtok,
         output_cost_per_mtok=payload.output_cost_per_mtok,
         cache_read_cost_per_mtok=payload.cache_read_cost_per_mtok,
@@ -299,10 +300,11 @@ def upsert_cost_override(
 @router.delete("/{model:path}")
 def delete_cost_override(
     model: str,
+    provider: str = "",
     _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> None:
-    if not delete_override(db_session, model):
+    if not delete_override(db_session, model, provider):
         raise OnyxError(OnyxErrorCode.NOT_FOUND, f"No cost override for model {model}")
     db_session.commit()
     invalidate_override_cache()

--- a/backend/onyx/server/features/usage/models.py
+++ b/backend/onyx/server/features/usage/models.py
@@ -1,0 +1,102 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+from pydantic import Field
+
+from onyx.db.models import ModelCostOverride
+
+
+class CostOverrideUpsertRequest(BaseModel):
+    # Negotiated rates in USD per million tokens (matches the stored columns).
+    # cache_read is optional; null bills cache reads at the input rate. Rates are
+    # non-negative — a negative rate would credit usage and corrupt budgets.
+    model: str
+    input_cost_per_mtok: float = Field(ge=0)
+    output_cost_per_mtok: float = Field(ge=0)
+    cache_read_cost_per_mtok: float | None = Field(default=None, ge=0)
+
+
+class CostOverride(BaseModel):
+    model: str
+    input_cost_per_mtok: float
+    output_cost_per_mtok: float
+    cache_read_cost_per_mtok: float | None
+    updated_at: datetime | None
+
+    @classmethod
+    def from_db(cls, row: ModelCostOverride) -> "CostOverride":
+        return cls(
+            model=row.model,
+            input_cost_per_mtok=row.input_cost_per_mtok,
+            output_cost_per_mtok=row.output_cost_per_mtok,
+            cache_read_cost_per_mtok=row.cache_read_cost_per_mtok,
+            updated_at=row.updated_at,
+        )
+
+
+class UsageDayModel(BaseModel):
+    day: str  # YYYY-MM-DD (UTC)
+    model: str
+    input_tokens: int
+    output_tokens: int
+    cache_read_tokens: int
+    cost_cents: float
+
+
+class UsageExportRecord(BaseModel):
+    """One (model x window-day) bucket for a user in the admin export."""
+
+    model: str
+    day: str  # YYYY-MM-DD — the usage window's start day (see UsageExportUser)
+    input_tokens: int
+    output_tokens: int
+    cache_read_tokens: int
+    cost_cents: float
+
+
+class UsageExportTotals(BaseModel):
+    input_tokens: int
+    output_tokens: int
+    cache_read_tokens: int
+    cost_cents: float
+
+
+class UsageExportUser(BaseModel):
+    email: str
+    totals: UsageExportTotals
+    records: list[UsageExportRecord]
+
+
+class UsageExportResponse(BaseModel):
+    """Cursor-style company GenAI report, nested per user.
+
+    `start`/`end` echo the queried half-open range [start, end). Day granularity
+    follows the configured usage window (weekly by default), so each record's
+    `day` is the window's start day rather than the calendar day of every call.
+    """
+
+    start: str
+    end: str
+    users: list[UsageExportUser]
+
+
+class ModelPrice(BaseModel):
+    """USD per 1M tokens for the user's selected chat model; null if unpriced."""
+
+    model: str
+    provider: str | None
+    input_per_mtok: float | None
+    output_per_mtok: float | None
+
+
+class UserUsageResponse(BaseModel):
+    per_day_by_model: list[UsageDayModel]
+    window_cost_cents: float
+    # The user's effective cost budget for the current window, what's left, and
+    # the window length (hours) so the UI can say "per week/day/hour". All null
+    # when no cost limit applies to the user.
+    budget_cents: float | None
+    budget_remaining_cents: float | None
+    budget_period_hours: int | None = None
+    # null when no default chat model is configured tenant-wide.
+    selected_model_price: ModelPrice | None

--- a/backend/onyx/server/features/usage/models.py
+++ b/backend/onyx/server/features/usage/models.py
@@ -11,6 +11,8 @@ class CostOverrideUpsertRequest(BaseModel):
     # cache_read is optional; null bills cache reads at the input rate. Rates are
     # non-negative — a negative rate would credit usage and corrupt budgets.
     model: str
+    # "" = provider-agnostic; set to price the same model per provider.
+    provider: str = ""
     input_cost_per_mtok: float = Field(ge=0)
     output_cost_per_mtok: float = Field(ge=0)
     cache_read_cost_per_mtok: float | None = Field(default=None, ge=0)
@@ -18,6 +20,7 @@ class CostOverrideUpsertRequest(BaseModel):
 
 class CostOverride(BaseModel):
     model: str
+    provider: str
     input_cost_per_mtok: float
     output_cost_per_mtok: float
     cache_read_cost_per_mtok: float | None
@@ -27,6 +30,7 @@ class CostOverride(BaseModel):
     def from_db(cls, row: ModelCostOverride) -> "CostOverride":
         return cls(
             model=row.model,
+            provider=row.provider,
             input_cost_per_mtok=row.input_cost_per_mtok,
             output_cost_per_mtok=row.output_cost_per_mtok,
             cache_read_cost_per_mtok=row.cache_read_cost_per_mtok,

--- a/backend/onyx/server/features/usage/models.py
+++ b/backend/onyx/server/features/usage/models.py
@@ -101,6 +101,9 @@ class ModelPrice(BaseModel):
     provider: str | None
     input_per_mtok: float | None
     output_per_mtok: float | None
+    # null when the model/override doesn't price cache reads; the UI falls back
+    # to the input rate (how billing treats it).
+    cache_per_mtok: float | None = None
 
 
 class UserUsageResponse(BaseModel):
@@ -114,3 +117,6 @@ class UserUsageResponse(BaseModel):
     budget_period_hours: int | None = None
     # null when no default chat model is configured tenant-wide.
     selected_model_price: ModelPrice | None
+    # Every configured chat model's price (USD/1M) so the Usage tab can show all
+    # options, not just the tenant default. Empty when none are priced.
+    available_model_prices: list[ModelPrice] = []

--- a/backend/onyx/server/features/usage/models.py
+++ b/backend/onyx/server/features/usage/models.py
@@ -88,6 +88,12 @@ class UsageExportResponse(BaseModel):
     users: list[UsageExportUser]
 
 
+class ResetUsageRequest(BaseModel):
+    """Admin request to clear a user's current-window usage (lift a budget block)."""
+
+    user_email: str
+
+
 class ModelPrice(BaseModel):
     """USD per 1M tokens for the user's selected chat model; null if unpriced."""
 

--- a/backend/onyx/server/features/usage/models.py
+++ b/backend/onyx/server/features/usage/models.py
@@ -10,12 +10,16 @@ class CostOverrideUpsertRequest(BaseModel):
     # Negotiated rates in USD per million tokens (matches the stored columns).
     # cache_read is optional; null bills cache reads at the input rate. Rates are
     # non-negative — a negative rate would credit usage and corrupt budgets.
-    model: str
+    # Non-empty: a "" model would persist an override that never matches a lookup.
+    model: str = Field(min_length=1)
     # "" = provider-agnostic; set to price the same model per provider.
     provider: str = ""
-    input_cost_per_mtok: float = Field(ge=0)
-    output_cost_per_mtok: float = Field(ge=0)
-    cache_read_cost_per_mtok: float | None = Field(default=None, ge=0)
+    # Finite + non-negative: inf/nan would corrupt downstream cost/budget math.
+    input_cost_per_mtok: float = Field(ge=0, allow_inf_nan=False)
+    output_cost_per_mtok: float = Field(ge=0, allow_inf_nan=False)
+    cache_read_cost_per_mtok: float | None = Field(
+        default=None, ge=0, allow_inf_nan=False
+    )
 
 
 class CostOverride(BaseModel):

--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -108,6 +108,7 @@ from onyx.server.usage_limits import check_llm_cost_limit_for_provider
 from onyx.server.usage_limits import check_usage_and_raise
 from onyx.server.usage_limits import is_usage_limits_enabled
 from onyx.server.utils import get_json_line
+from onyx.server.utils import set_current_user_id_dependency
 from onyx.tracing.framework.create import ensure_trace
 from onyx.utils.headers import get_custom_tool_additional_request_headers
 from onyx.utils.logger import setup_logger
@@ -410,11 +411,17 @@ def create_new_chat_session(
     return CreateChatSessionID(chat_session_id=new_chat_session.id)
 
 
+# Shared callable so FastAPI runs auth once across the user + contextvar deps.
+_rename_basic_access = require_permission(Permission.BASIC_ACCESS)
+
+
 @router.put("/rename-chat-session")
 def rename_chat_session(
     rename_req: ChatRenameRequest,
     request: Request,
-    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    user: User = Depends(_rename_basic_access),
+    # Attribute the LLM-generated title to the user (this endpoint can call an LLM).
+    _user_ctx: None = Depends(set_current_user_id_dependency(_rename_basic_access)),
 ) -> RenameChatSessionResponse:
     # 3000 tokens is more than enough for a pair of messages which is enough to provide the required context for generating a
     # good name for the chat session. It's also small enough to fit on even the worst context window LLMs.
@@ -433,6 +440,10 @@ def rename_chat_session(
                 description=name,
             )
         return RenameChatSessionResponse(new_name=name)
+
+    # Auto-naming calls an LLM, so apply the same per-user budget gate as
+    # send-message. Manual renames return above and stay free.
+    check_token_rate_limits(user)
 
     llm = get_default_llm(
         additional_headers=extract_headers(
@@ -567,6 +578,11 @@ def handle_send_chat_message(
     ),
     _rate_limit_check: None = Depends(check_token_rate_limits),
     _api_key_usage_check: None = Depends(check_api_key_usage),
+    # Pins CURRENT_USER_ID_CONTEXTVAR in the event-loop context so it propagates
+    # into the streaming generator (all branches) for usage attribution.
+    _user_ctx: None = Depends(
+        set_current_user_id_dependency(current_chat_accessible_user)
+    ),
 ) -> StreamingResponse | ChatFullResponse:
     """
     This endpoint is used to send a new chat message.

--- a/backend/onyx/server/query_and_chat/token_limit.py
+++ b/backend/onyx/server/query_and_chat/token_limit.py
@@ -68,7 +68,14 @@ def _user_is_rate_limited_by_global() -> None:
             # Skip the token-usage aggregation when every limit is cost-only.
             triggered = None
             if _has_token_budget(global_rate_limits):
-                global_cutoff_time = _get_cutoff_time(global_rate_limits)
+                # Scan the token table only as far back as the widest *token*
+                # window — a longer cost-only window must not widen the scan.
+                token_limits = [
+                    rl
+                    for rl in global_rate_limits
+                    if rl.token_budget is not None and rl.token_budget > 0
+                ]
+                global_cutoff_time = _get_cutoff_time(token_limits)
                 global_usage = _fetch_global_usage(global_cutoff_time, db_session)
                 triggered = _worst_triggered_limit(global_rate_limits, global_usage)
 
@@ -158,6 +165,17 @@ def _worst_triggered_limit(
                 worst = rate_limit
 
     return worst
+
+
+def _is_rate_limited(
+    rate_limits: Sequence[TokenRateLimit],
+    usage: Sequence[tuple[datetime, int]],
+) -> bool:
+    """Whether any token budget in ``rate_limits`` is exceeded by ``usage``.
+
+    Thin bool wrapper over ``_worst_triggered_limit`` for the EE user/group
+    token gates, which enforce token budgets only (cost gating is global-only)."""
+    return _worst_triggered_limit(rate_limits, usage) is not None
 
 
 def _worst_triggered_cost_limit(

--- a/backend/onyx/server/query_and_chat/token_limit.py
+++ b/backend/onyx/server/query_and_chat/token_limit.py
@@ -1,4 +1,3 @@
-from collections.abc import Callable
 from collections.abc import Sequence
 from datetime import datetime
 from datetime import timedelta
@@ -18,7 +17,7 @@ from onyx.db.models import ChatSession
 from onyx.db.models import TokenRateLimit
 from onyx.db.models import User
 from onyx.db.token_limit import fetch_all_global_token_rate_limits
-from onyx.db.user_usage import get_total_cost_cents_since
+from onyx.db.user_usage import get_total_cost_cents_buckets_since
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.utils.logger import setup_logger
@@ -73,9 +72,16 @@ def _user_is_rate_limited_by_global() -> None:
                 global_usage = _fetch_global_usage(global_cutoff_time, db_session)
                 triggered = _worst_triggered_limit(global_rate_limits, global_usage)
 
+            cost_buckets: list[tuple[datetime, float]] = []
+            if any(rl.cost_budget_cents is not None for rl in global_rate_limits):
+                # One bucket fetch for the widest window; _worst_triggered_cost_limit
+                # sums per-limit in Python (no query per cost limit).
+                cost_cutoff = _get_cutoff_time(global_rate_limits) - _LEDGER_GRID
+                cost_buckets = get_total_cost_cents_buckets_since(
+                    db_session, cost_cutoff
+                )
             cost_triggered = _worst_triggered_cost_limit(
-                global_rate_limits,
-                lambda cutoff: get_total_cost_cents_since(db_session, cutoff),
+                global_rate_limits, cost_buckets
             )
             _raise_for_longest_window(
                 "organization",
@@ -156,14 +162,15 @@ def _worst_triggered_limit(
 
 def _worst_triggered_cost_limit(
     rate_limits: Sequence[TokenRateLimit],
-    cost_since: Callable[[datetime], float],
+    cost_buckets: Sequence[tuple[datetime, float]],
 ) -> TokenRateLimit | None:
     """Among rows whose cost_budget_cents is set and exceeded, return the one
     with the longest window (or None) — longest period_hours so the reset is
     deterministic and conservative, matching _worst_triggered_limit.
 
-    Cost comes from the UserUsage ledger (not ChatMessage.token_count), which
-    buckets spend at a coarse fixed grid (_LEDGER_GRID). A bucket has no sub-grid
+    Cost comes from the UserUsage ledger (not ChatMessage.token_count), bucketed
+    at a coarse fixed grid (_LEDGER_GRID) and fetched once upstream; we sum the
+    buckets per window in Python (no query per limit). A bucket has no sub-grid
     timing, so to mirror the token sliding window over [now - period_hours, now]
     we count every bucket that *overlaps* it: window_start >= now - period_hours
     - grid. This is conservative (a budget period finer than the grid can pull in
@@ -178,7 +185,10 @@ def _worst_triggered_cost_limit(
             continue
 
         cutoff = now - timedelta(hours=rate_limit.period_hours) - _LEDGER_GRID
-        if cost_since(cutoff) >= budget:
+        cost = sum(
+            cents for window_start, cents in cost_buckets if window_start >= cutoff
+        )
+        if cost >= budget:
             if worst is None or rate_limit.period_hours > worst.period_hours:
                 worst = rate_limit
 

--- a/backend/onyx/server/query_and_chat/token_limit.py
+++ b/backend/onyx/server/query_and_chat/token_limit.py
@@ -173,8 +173,9 @@ def _is_rate_limited(
 ) -> bool:
     """Whether any token budget in ``rate_limits`` is exceeded by ``usage``.
 
-    Thin bool wrapper over ``_worst_triggered_limit`` for the EE user/group
-    token gates, which enforce token budgets only (cost gating is global-only)."""
+    Thin bool wrapper over ``_worst_triggered_limit``. Token-only — the cost side
+    of every scope (global/user/group) is enforced separately via
+    ``_worst_triggered_cost_limit`` over the UserUsage cost ledger."""
     return _worst_triggered_limit(rate_limits, usage) is not None
 
 

--- a/backend/onyx/server/query_and_chat/token_limit.py
+++ b/backend/onyx/server/query_and_chat/token_limit.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from collections.abc import Sequence
 from datetime import datetime
 from datetime import timedelta
@@ -6,7 +7,6 @@ from functools import lru_cache
 
 from dateutil import tz
 from fastapi import Depends
-from fastapi import HTTPException
 from sqlalchemy import func
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -18,13 +18,22 @@ from onyx.db.models import ChatSession
 from onyx.db.models import TokenRateLimit
 from onyx.db.models import User
 from onyx.db.token_limit import fetch_all_global_token_rate_limits
+from onyx.db.user_usage import get_total_cost_cents_since
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.utils.logger import setup_logger
 from onyx.utils.variable_functionality import fetch_versioned_implementation
+from shared_configs.configs import USAGE_LIMIT_WINDOW_SECONDS
 
 logger = setup_logger()
 
+# Admin token budgets are entered in thousands of tokens; the stored value is
+# multiplied by this to get the real token count enforced.
+TOKEN_BUDGET_UNIT = 1000
 
-TOKEN_BUDGET_UNIT = 1_000
+# The cost ledger buckets at this fixed grid; the cost cutoff is relaxed by one
+# grid to capture partially-overlapping buckets (see _worst_triggered_cost_limit).
+_LEDGER_GRID = timedelta(seconds=USAGE_LIMIT_WINDOW_SECONDS)
 
 
 def check_token_rate_limits(
@@ -57,14 +66,22 @@ def _user_is_rate_limited_by_global() -> None:
         )
 
         if global_rate_limits:
-            global_cutoff_time = _get_cutoff_time(global_rate_limits)
-            global_usage = _fetch_global_usage(global_cutoff_time, db_session)
+            # Skip the token-usage aggregation when every limit is cost-only.
+            triggered = None
+            if _has_token_budget(global_rate_limits):
+                global_cutoff_time = _get_cutoff_time(global_rate_limits)
+                global_usage = _fetch_global_usage(global_cutoff_time, db_session)
+                triggered = _worst_triggered_limit(global_rate_limits, global_usage)
 
-            if _is_rate_limited(global_rate_limits, global_usage):
-                raise HTTPException(
-                    status_code=429,
-                    detail="Token budget exceeded for organization. Try again later.",
-                )
+            cost_triggered = _worst_triggered_cost_limit(
+                global_rate_limits,
+                lambda cutoff: get_total_cost_cents_since(db_session, cutoff),
+            )
+            _raise_for_longest_window(
+                "organization",
+                triggered.period_hours if triggered else None,
+                cost_triggered.period_hours if cost_triggered else None,
+            )
 
 
 def _fetch_global_usage(
@@ -98,13 +115,29 @@ def _get_cutoff_time(rate_limits: Sequence[TokenRateLimit]) -> datetime:
     return datetime.now(tz=timezone.utc) - timedelta(hours=max_period_hours)
 
 
-def _is_rate_limited(
+def _has_token_budget(rate_limits: Sequence[TokenRateLimit]) -> bool:
+    """Whether any limit sets a positive token budget. If not (cost-only limits),
+    the caller skips the token-usage aggregation query entirely."""
+    return any(
+        rl.token_budget is not None and rl.token_budget > 0 for rl in rate_limits
+    )
+
+
+def _worst_triggered_limit(
     rate_limits: Sequence[TokenRateLimit], usage: Sequence[tuple[datetime, int]]
-) -> bool:
-    """
-    If at least one rate limit is exceeded, return True
-    """
+) -> TokenRateLimit | None:
+    """Among the exceeded token limits, return the one with the longest window
+    (or None). Picking the longest period_hours makes the reported reset
+    deterministic and conservative: a client that waits it out won't immediately
+    re-trip a still-exceeded longer limit. Carries period_hours for the reset."""
+    worst: TokenRateLimit | None = None
     for rate_limit in rate_limits:
+        # A null (cost-only) or non-positive token_budget is token-exempt — skip
+        # the token check. Guarding <= 0 means a 0 (new cost-only rows store null,
+        # but legacy/edge rows may hold 0) can never block every request.
+        if rate_limit.token_budget is None or rate_limit.token_budget <= 0:
+            continue
+
         tokens_used = sum(
             u_token_count
             for u_date, u_token_count in usage
@@ -112,10 +145,77 @@ def _is_rate_limited(
             >= datetime.now(tz=tz.UTC) - timedelta(hours=rate_limit.period_hours)
         )
 
+        # The admin enters the budget in THOUSANDS of tokens (Onyx convention),
+        # so the stored value is scaled up to the real token count here.
         if tokens_used >= rate_limit.token_budget * TOKEN_BUDGET_UNIT:
-            return True
+            if worst is None or rate_limit.period_hours > worst.period_hours:
+                worst = rate_limit
 
-    return False
+    return worst
+
+
+def _worst_triggered_cost_limit(
+    rate_limits: Sequence[TokenRateLimit],
+    cost_since: Callable[[datetime], float],
+) -> TokenRateLimit | None:
+    """Among rows whose cost_budget_cents is set and exceeded, return the one
+    with the longest window (or None) — longest period_hours so the reset is
+    deterministic and conservative, matching _worst_triggered_limit.
+
+    Cost comes from the UserUsage ledger (not ChatMessage.token_count), which
+    buckets spend at a coarse fixed grid (_LEDGER_GRID). A bucket has no sub-grid
+    timing, so to mirror the token sliding window over [now - period_hours, now]
+    we count every bucket that *overlaps* it: window_start >= now - period_hours
+    - grid. This is conservative (a budget period finer than the grid can pull in
+    one adjacent bucket) — fail-CLOSED, the safe direction for a budget gate.
+    Rows without a cost_budget_cents are cost-exempt (token-only).
+    """
+    now = datetime.now(tz=timezone.utc)
+    worst: TokenRateLimit | None = None
+    for rate_limit in rate_limits:
+        budget = rate_limit.cost_budget_cents
+        if budget is None:
+            continue
+
+        cutoff = now - timedelta(hours=rate_limit.period_hours) - _LEDGER_GRID
+        if cost_since(cutoff) >= budget:
+            if worst is None or rate_limit.period_hours > worst.period_hours:
+                worst = rate_limit
+
+    return worst
+
+
+def raise_rate_limited(scope: str, period_hours: int) -> None:
+    """Raise a structured 429 carrying the offending scope + when its window rolls over.
+
+    Sliding-window enforcement has no single fixed reset instant; we report a full
+    period from now as the conservative "try again after" so the FE banner can count down.
+    """
+    retry_after_seconds = period_hours * 3600
+    reset_at = datetime.now(tz=timezone.utc) + timedelta(seconds=retry_after_seconds)
+    reset_at_iso = reset_at.isoformat()
+    raise OnyxError(
+        OnyxErrorCode.RATE_LIMITED,
+        # Neutral wording, no raw timestamp — the FE renders a friendly reset
+        # time from reset_at / retry_after_seconds below.
+        f"You've reached the usage budget for {scope}.",
+        extra={
+            "scope": scope,
+            "reset_at": reset_at_iso,
+            "retry_after_seconds": retry_after_seconds,
+        },
+        headers={"Retry-After": str(retry_after_seconds)},
+    )
+
+
+def _raise_for_longest_window(scope: str, *period_hours: int | None) -> None:
+    """Raise once for the longest of the given reset windows (Nones skipped).
+    The token and cost gates are independent; evaluating both before raising
+    avoids reporting a too-early reset when a short token window and a long cost
+    window are both exceeded."""
+    periods = [p for p in period_hours if p is not None]
+    if periods:
+        raise_rate_limited(scope, max(periods))
 
 
 @lru_cache()

--- a/backend/onyx/server/token_rate_limits/models.py
+++ b/backend/onyx/server/token_rate_limits/models.py
@@ -9,7 +9,9 @@ class TokenRateLimitArgs(BaseModel):
     enabled: bool
     # A limit may be token-only, cost-only, or both; a null side is exempt from
     # that gate. At least one must be set (a row with neither enforces nothing).
-    token_budget: int | None = None
+    # ge=1: a 0/negative budget is silently treated as token-exempt by the gate
+    # (skips token_budget <= 0), so the admin's limit would enforce nothing.
+    token_budget: int | None = Field(default=None, ge=1)
     period_hours: int
     # gt=0 + finite: a 0/NaN budget would otherwise trip the gate on the first
     # request (cost >= 0 always true; cost >= NaN always false), bypassing real

--- a/backend/onyx/server/token_rate_limits/models.py
+++ b/backend/onyx/server/token_rate_limits/models.py
@@ -5,15 +5,19 @@ from onyx.db.models import TokenRateLimit
 
 class TokenRateLimitArgs(BaseModel):
     enabled: bool
-    token_budget: int
+    # Nullable so a limit can be token-only, cost-only, or both (see the schema
+    # check constraint). At least one of the two budgets must be set.
+    token_budget: int | None = None
     period_hours: int
+    cost_budget_cents: float | None = None
 
 
 class TokenRateLimitDisplay(BaseModel):
     token_id: int
     enabled: bool
-    token_budget: int
+    token_budget: int | None
     period_hours: int
+    cost_budget_cents: float | None = None
 
     @classmethod
     def from_db(cls, token_rate_limit: TokenRateLimit) -> "TokenRateLimitDisplay":
@@ -22,4 +26,5 @@ class TokenRateLimitDisplay(BaseModel):
             enabled=token_rate_limit.enabled,
             token_budget=token_rate_limit.token_budget,
             period_hours=token_rate_limit.period_hours,
+            cost_budget_cents=token_rate_limit.cost_budget_cents,
         )

--- a/backend/onyx/server/token_rate_limits/models.py
+++ b/backend/onyx/server/token_rate_limits/models.py
@@ -1,15 +1,26 @@
 from pydantic import BaseModel
+from pydantic import Field
+from pydantic import model_validator
 
 from onyx.db.models import TokenRateLimit
 
 
 class TokenRateLimitArgs(BaseModel):
     enabled: bool
-    # Nullable so a limit can be token-only, cost-only, or both (see the schema
-    # check constraint). At least one of the two budgets must be set.
+    # A limit may be token-only, cost-only, or both; a null side is exempt from
+    # that gate. At least one must be set (a row with neither enforces nothing).
     token_budget: int | None = None
     period_hours: int
-    cost_budget_cents: float | None = None
+    # gt=0 + finite: a 0/NaN budget would otherwise trip the gate on the first
+    # request (cost >= 0 always true; cost >= NaN always false), bypassing real
+    # enforcement.
+    cost_budget_cents: float | None = Field(default=None, gt=0, allow_inf_nan=False)
+
+    @model_validator(mode="after")
+    def _require_a_budget(self) -> "TokenRateLimitArgs":
+        if self.token_budget is None and self.cost_budget_cents is None:
+            raise ValueError("Set a token budget, a cost budget, or both.")
+        return self
 
 
 class TokenRateLimitDisplay(BaseModel):
@@ -17,7 +28,7 @@ class TokenRateLimitDisplay(BaseModel):
     enabled: bool
     token_budget: int | None
     period_hours: int
-    cost_budget_cents: float | None = None
+    cost_budget_cents: float | None
 
     @classmethod
     def from_db(cls, token_rate_limit: TokenRateLimit) -> "TokenRateLimitDisplay":

--- a/backend/onyx/server/utils.py
+++ b/backend/onyx/server/utils.py
@@ -1,12 +1,18 @@
 import base64
 import json
 import os
+from collections.abc import AsyncGenerator
+from collections.abc import Callable
 from datetime import datetime
 from typing import Any
 from uuid import UUID
 
+from fastapi import Depends
 from fastapi import HTTPException
 from fastapi import status
+
+from onyx.db.models import User
+from shared_configs.contextvars import CURRENT_USER_ID_CONTEXTVAR
 
 
 class BasicAuthenticationError(HTTPException):
@@ -46,3 +52,33 @@ def make_short_id() -> str:
     to trace it through a flow. This is definitely not guaranteed to be unique and is
     targeted at the stated use case."""
     return base64.b32encode(os.urandom(5)).decode("utf-8")[:8]  # 5 bytes → 8 chars
+
+
+def set_current_user_id_dependency(
+    user_dependency: Callable[..., Any],
+) -> Callable[..., AsyncGenerator[None, None]]:
+    """Build a dependency that pins CURRENT_USER_ID_CONTEXTVAR to the request's user.
+
+    Must be set in the event-loop context (not inside the StreamingResponse
+    generator): Starlette drives a sync streaming generator via
+    ``iterate_in_threadpool``, where anyio does a fresh ``copy_context()`` per
+    ``next()`` — a ``.set()`` inside the generator survives only the first chunk,
+    and the matching ``.reset()`` raises (different context). Setting in the
+    async dependency's event-loop context propagates into every per-step copy
+    and resets cleanly, covering all branches of the endpoint (incl. multi-model
+    and non-streaming).
+
+    ``user_dependency`` is the endpoint's own user-providing auth dependency, so
+    the var is set only after auth succeeds.
+    """
+
+    async def _dep(
+        user: User = Depends(user_dependency),
+    ) -> AsyncGenerator[None, None]:
+        token = CURRENT_USER_ID_CONTEXTVAR.set(str(user.id))
+        try:
+            yield
+        finally:
+            CURRENT_USER_ID_CONTEXTVAR.reset(token)
+
+    return _dep

--- a/backend/onyx/tracing/processors/user_usage_processor.py
+++ b/backend/onyx/tracing/processors/user_usage_processor.py
@@ -84,6 +84,10 @@ class UserUsageTracingProcessor(TracingProcessor):
         self._thread.start()
 
     def on_span_end(self, span: Span[Any]) -> None:
+        # After shutdown the drain thread is gone, so anything enqueued now would
+        # sit unwritten forever — drop it instead.
+        if self._shutdown.is_set():
+            return
         # Never propagate into the span/LLM path.
         try:
             record = self._capture(span)

--- a/backend/onyx/tracing/processors/user_usage_processor.py
+++ b/backend/onyx/tracing/processors/user_usage_processor.py
@@ -115,7 +115,11 @@ class UserUsageTracingProcessor(TracingProcessor):
 
         user_id = get_current_user_id()
         if user_id is None:
-            # Background worker / no request — nothing to attribute.
+            # v1 attributes usage only for interactive chat (the user-id
+            # contextvar is set on the chat-send endpoints). Non-chat LLM calls
+            # — search-answer, Slack, agent sub-calls, background workers —
+            # yield no row rather than mis-attributing. Fails safe (undercount,
+            # never wrong-user); widening the set-sites is a follow-up.
             return None
 
         model = data.model

--- a/backend/onyx/tracing/processors/user_usage_processor.py
+++ b/backend/onyx/tracing/processors/user_usage_processor.py
@@ -13,23 +13,18 @@ from typing import Any
 from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.user_usage import get_window_start
 from onyx.db.user_usage import record_user_usage
+from onyx.db.user_usage import USAGE_PERIOD_HOURS
 from onyx.llm.cost import compute_cost_cents
 from onyx.tracing.framework.processor_interface import TracingProcessor
 from onyx.tracing.framework.span_data import GenerationSpanData
 from onyx.tracing.framework.spans import Span
 from onyx.tracing.framework.traces import Trace
 from onyx.utils.logger import setup_logger
-from shared_configs.configs import USAGE_LIMIT_WINDOW_SECONDS
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 from shared_configs.contextvars import get_current_tenant_id
 from shared_configs.contextvars import get_current_user_id
 
 logger = setup_logger()
-
-# Per-user windows must coincide with tenant-usage windows. Floor at 1h so a
-# sub-hour USAGE_LIMIT_WINDOW_SECONDS can't truncate to a 0-hour (div-by-zero)
-# window; finer-than-hourly cost windows aren't supported.
-_PERIOD_HOURS = max(USAGE_LIMIT_WINDOW_SECONDS // 3600, 1)
 
 _DEFAULT_FLUSH_INTERVAL_SECONDS = 2.0
 # Drain early once this many records have queued up, regardless of interval.
@@ -78,20 +73,26 @@ class UserUsageTracingProcessor(TracingProcessor):
         self._queue: queue.Queue[Any] = queue.Queue()
         self._flush_interval = flush_interval_seconds
         self._shutdown = threading.Event()
+        # Serializes the shutdown flag against enqueues so a record can't slip in
+        # after the _SHUTDOWN sentinel — every record is enqueued before it or
+        # dropped, never lost to a drained-and-exited thread.
+        self._enqueue_lock = threading.Lock()
         self._thread = threading.Thread(
             target=self._drain_loop, name="user-usage-recorder", daemon=True
         )
         self._thread.start()
 
     def on_span_end(self, span: Span[Any]) -> None:
-        # After shutdown the drain thread is gone, so anything enqueued now would
-        # sit unwritten forever — drop it instead.
-        if self._shutdown.is_set():
-            return
         # Never propagate into the span/LLM path.
         try:
             record = self._capture(span)
-            if record is not None:
+            if record is None:
+                return
+            with self._enqueue_lock:
+                # Drop once shutting down — the sentinel is or will be the last
+                # item, so the drain thread won't pick this up.
+                if self._shutdown.is_set():
+                    return
                 self._queue.put(record)
         except Exception:
             logger.exception("UserUsageTracingProcessor.on_span_end failed; dropping")
@@ -120,7 +121,7 @@ class UserUsageTracingProcessor(TracingProcessor):
         provider = model_config.get("model_provider")
 
         window_start = get_window_start(
-            datetime.now(timezone.utc), period_hours=_PERIOD_HOURS
+            datetime.now(timezone.utc), period_hours=USAGE_PERIOD_HOURS
         )
 
         return _UsageRecord(
@@ -232,8 +233,12 @@ class UserUsageTracingProcessor(TracingProcessor):
         self._queue.join()
 
     def shutdown(self) -> None:
-        if self._shutdown.is_set():
-            return
-        self._shutdown.set()
+        # Set the flag under the lock so any concurrent on_span_end either
+        # enqueues before the sentinel or sees the flag and drops — no record
+        # lands after _SHUTDOWN.
+        with self._enqueue_lock:
+            if self._shutdown.is_set():
+                return
+            self._shutdown.set()
         self._queue.put(_SHUTDOWN)
         self._thread.join(timeout=10.0)

--- a/backend/onyx/tracing/processors/user_usage_processor.py
+++ b/backend/onyx/tracing/processors/user_usage_processor.py
@@ -29,6 +29,10 @@ logger = setup_logger()
 _DEFAULT_FLUSH_INTERVAL_SECONDS = 2.0
 # Drain early once this many records have queued up, regardless of interval.
 _FLUSH_BATCH_SIZE = 200
+# Bound the buffer so a DB slowdown/outage (producer outpacing the single drain
+# thread) sheds load instead of growing memory unboundedly. Sized for a large
+# burst; overflow drops the oldest-unqueued sample with a log, never blocks.
+_MAX_QUEUE_SIZE = 100_000
 # Sentinel pushed on shutdown to wake the drain thread immediately.
 _SHUTDOWN = object()
 
@@ -70,7 +74,7 @@ class UserUsageTracingProcessor(TracingProcessor):
     def __init__(
         self, flush_interval_seconds: float = _DEFAULT_FLUSH_INTERVAL_SECONDS
     ) -> None:
-        self._queue: queue.Queue[Any] = queue.Queue()
+        self._queue: queue.Queue[Any] = queue.Queue(maxsize=_MAX_QUEUE_SIZE)
         self._flush_interval = flush_interval_seconds
         self._shutdown = threading.Event()
         # Serializes the shutdown flag against enqueues so a record can't slip in
@@ -93,7 +97,14 @@ class UserUsageTracingProcessor(TracingProcessor):
                 # item, so the drain thread won't pick this up.
                 if self._shutdown.is_set():
                     return
-                self._queue.put(record)
+                try:
+                    # Never block the LLM hot path: shed load if the buffer is
+                    # full (drain thread stalled on a slow/unavailable DB).
+                    self._queue.put_nowait(record)
+                except queue.Full:
+                    logger.warning(
+                        "user-usage queue full (%d); dropping sample", _MAX_QUEUE_SIZE
+                    )
         except Exception:
             logger.exception("UserUsageTracingProcessor.on_span_end failed; dropping")
 

--- a/backend/onyx/tracing/processors/user_usage_processor.py
+++ b/backend/onyx/tracing/processors/user_usage_processor.py
@@ -1,0 +1,235 @@
+"""Universal per-user usage recorder — buffers priced generation spans and
+drains them to the per-user usage rollup off the LLM hot path."""
+
+from __future__ import annotations
+
+import queue
+import threading
+from dataclasses import dataclass
+from datetime import datetime
+from datetime import timezone
+from typing import Any
+
+from onyx.db.engine.sql_engine import get_session_with_tenant
+from onyx.db.user_usage import get_window_start
+from onyx.db.user_usage import record_user_usage
+from onyx.llm.cost import compute_cost_cents
+from onyx.tracing.framework.processor_interface import TracingProcessor
+from onyx.tracing.framework.span_data import GenerationSpanData
+from onyx.tracing.framework.spans import Span
+from onyx.tracing.framework.traces import Trace
+from onyx.utils.logger import setup_logger
+from shared_configs.configs import USAGE_LIMIT_WINDOW_SECONDS
+from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
+from shared_configs.contextvars import get_current_tenant_id
+from shared_configs.contextvars import get_current_user_id
+
+logger = setup_logger()
+
+# Per-user windows must coincide with tenant-usage windows. Floor at 1h so a
+# sub-hour USAGE_LIMIT_WINDOW_SECONDS can't truncate to a 0-hour (div-by-zero)
+# window; finer-than-hourly cost windows aren't supported.
+_PERIOD_HOURS = max(USAGE_LIMIT_WINDOW_SECONDS // 3600, 1)
+
+_DEFAULT_FLUSH_INTERVAL_SECONDS = 2.0
+# Drain early once this many records have queued up, regardless of interval.
+_FLUSH_BATCH_SIZE = 200
+# Sentinel pushed on shutdown to wake the drain thread immediately.
+_SHUTDOWN = object()
+
+
+@dataclass(frozen=True)
+class _UsageRecord:
+    """Everything needed to write one ledger row, captured at span-end while the
+    request contextvars are still valid (the drain thread has none)."""
+
+    tenant_id: str
+    user_id: str
+    model: str
+    flow: str
+    provider: str | None
+    input_tokens: int
+    output_tokens: int
+    cache_read_tokens: int
+    window_start: datetime
+
+
+def _usage_field(usage: dict[str, Any], *names: str) -> int:
+    """First present token field among `names`, coerced to int. Mirrors the
+    prompt/completion vs input/output aliasing from llm_utils._build_usage_dict."""
+    for name in names:
+        value = usage.get(name)
+        if value is not None:
+            return int(value)
+    return 0
+
+
+class UserUsageTracingProcessor(TracingProcessor):
+    """Records every priced generation span into the per-user usage ledger.
+
+    on_span_end captures the sample synchronously (contextvars are only valid
+    there) and enqueues it; a daemon thread drains the queue to Postgres so the
+    streaming/LLM path is never blocked by a DB write. Cost is computed in the
+    drain thread under the captured tenant's session + tenant context."""
+
+    def __init__(
+        self, flush_interval_seconds: float = _DEFAULT_FLUSH_INTERVAL_SECONDS
+    ) -> None:
+        self._queue: queue.Queue[Any] = queue.Queue()
+        self._flush_interval = flush_interval_seconds
+        self._shutdown = threading.Event()
+        self._thread = threading.Thread(
+            target=self._drain_loop, name="user-usage-recorder", daemon=True
+        )
+        self._thread.start()
+
+    def on_span_end(self, span: Span[Any]) -> None:
+        # Never propagate into the span/LLM path.
+        try:
+            record = self._capture(span)
+            if record is not None:
+                self._queue.put(record)
+        except Exception:
+            logger.exception("UserUsageTracingProcessor.on_span_end failed; dropping")
+
+    def _capture(self, span: Span[Any]) -> _UsageRecord | None:
+        data = span.span_data
+        if not isinstance(data, GenerationSpanData) or not data.usage:
+            return None
+
+        user_id = get_current_user_id()
+        if user_id is None:
+            # Background worker / no request — nothing to attribute.
+            return None
+
+        model = data.model
+        if not model:
+            return None
+
+        usage = data.usage
+        input_tokens = _usage_field(usage, "input_tokens", "prompt_tokens")
+        output_tokens = _usage_field(usage, "output_tokens", "completion_tokens")
+        cache_read_tokens = _usage_field(usage, "cache_read_input_tokens")
+
+        model_config = data.model_config or {}
+        flow = model_config.get("flow") or ""
+        provider = model_config.get("model_provider")
+
+        window_start = get_window_start(
+            datetime.now(timezone.utc), period_hours=_PERIOD_HOURS
+        )
+
+        return _UsageRecord(
+            tenant_id=get_current_tenant_id(),
+            user_id=user_id,
+            model=model,
+            flow=flow,
+            provider=provider,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_read_tokens=cache_read_tokens,
+            window_start=window_start,
+        )
+
+    def _drain_loop(self) -> None:
+        while True:
+            try:
+                item = self._queue.get(timeout=self._flush_interval)
+            except queue.Empty:
+                continue
+
+            if item is _SHUTDOWN:
+                self._queue.task_done()
+                return
+
+            batch = [item]
+            while len(batch) < _FLUSH_BATCH_SIZE:
+                try:
+                    nxt = self._queue.get_nowait()
+                except queue.Empty:
+                    break
+                if nxt is _SHUTDOWN:
+                    self._flush_batch(batch)
+                    self._queue.task_done()  # the SHUTDOWN sentinel
+                    return
+                batch.append(nxt)
+
+            self._flush_batch(batch)
+
+    def _flush_batch(self, batch: list[_UsageRecord]) -> None:
+        for record in batch:
+            try:
+                self._write(record)
+            except Exception:
+                logger.exception(
+                    "Failed to record user usage (user=%s model=%s); dropping sample",
+                    record.user_id,
+                    record.model,
+                )
+            finally:
+                # task_done per real record so force_flush()'s join() unblocks
+                # even when the write raised.
+                self._queue.task_done()
+
+    def _write(self, record: _UsageRecord) -> None:
+        # The drain thread has no request contextvars; restore the captured
+        # tenant so the cost-override lookup resolves the right schema.
+        token = CURRENT_TENANT_ID_CONTEXTVAR.set(record.tenant_id)
+        try:
+            with get_session_with_tenant(tenant_id=record.tenant_id) as db_session:
+                # The span's input_tokens is the litellm prompt total, which
+                # already includes cache reads; compute_cost_cents expects the
+                # NON-cached count and adds cache reads back at the cache rate.
+                # Subtract here to avoid pricing cache reads twice. The ledger
+                # column keeps the full input_tokens for token reporting.
+                non_cached_input = max(
+                    record.input_tokens - record.cache_read_tokens, 0
+                )
+                input_cost, output_cost = compute_cost_cents(
+                    record.model,
+                    record.provider,
+                    non_cached_input,
+                    record.output_tokens,
+                    cache_read_tokens=record.cache_read_tokens,
+                    flow=record.flow,
+                    db_session=db_session,
+                )
+                record_user_usage(
+                    db_session,
+                    user_id=record.user_id,
+                    model=record.model,
+                    flow=record.flow,
+                    provider=record.provider,
+                    input_tokens=record.input_tokens,
+                    output_tokens=record.output_tokens,
+                    cache_read_tokens=record.cache_read_tokens,
+                    cost_cents=input_cost + output_cost,
+                    window_start=record.window_start,
+                )
+                db_session.commit()
+        finally:
+            CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+
+    # --- TracingProcessor interface (non-generation events are no-ops) ---
+
+    def on_trace_start(self, trace: Trace) -> None:
+        pass
+
+    def on_trace_end(self, trace: Trace) -> None:
+        pass
+
+    def on_span_start(self, span: Span[Any]) -> None:
+        pass
+
+    def force_flush(self) -> None:
+        """Block until every queued record has been processed (written or dropped)."""
+        if not self._thread.is_alive():
+            return
+        self._queue.join()
+
+    def shutdown(self) -> None:
+        if self._shutdown.is_set():
+            return
+        self._shutdown.set()
+        self._queue.put(_SHUTDOWN)
+        self._thread.join(timeout=10.0)

--- a/backend/onyx/tracing/processors/user_usage_processor.py
+++ b/backend/onyx/tracing/processors/user_usage_processor.py
@@ -152,6 +152,10 @@ class UserUsageTracingProcessor(TracingProcessor):
             try:
                 item = self._queue.get(timeout=self._flush_interval)
             except queue.Empty:
+                # Exit on shutdown even if the sentinel couldn't be enqueued
+                # (queue was full) — don't rely solely on the sentinel.
+                if self._shutdown.is_set():
+                    return
                 continue
 
             if item is _SHUTDOWN:
@@ -251,5 +255,10 @@ class UserUsageTracingProcessor(TracingProcessor):
             if self._shutdown.is_set():
                 return
             self._shutdown.set()
-        self._queue.put(_SHUTDOWN)
+        try:
+            # Wake the drain thread now if there's room; if the queue is full,
+            # the flag-check on its next get() timeout exits it. Never block here.
+            self._queue.put_nowait(_SHUTDOWN)
+        except queue.Full:
+            pass
         self._thread.join(timeout=10.0)

--- a/backend/onyx/tracing/setup.py
+++ b/backend/onyx/tracing/setup.py
@@ -5,6 +5,7 @@ from onyx.configs.app_configs import BRAINTRUST_PROJECT
 from onyx.configs.app_configs import LANGFUSE_HOST
 from onyx.configs.app_configs import LANGFUSE_PUBLIC_KEY
 from onyx.configs.app_configs import LANGFUSE_SECRET_KEY
+from onyx.configs.app_configs import USER_USAGE_TRACKING_ENABLED
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -48,6 +49,16 @@ def setup_tracing() -> list[str]:
             logger.error("Failed to initialize Langfuse tracing: %s", e)
     else:
         logger.info("Langfuse credentials not provided, skipping Langfuse setup")
+
+    # Per-user usage recorder — independent of external tracing backends.
+    if USER_USAGE_TRACKING_ENABLED:
+        try:
+            _setup_user_usage_tracking()
+            initialized_providers.append("user_usage")
+        except Exception as e:
+            logger.error("Failed to initialize user usage tracking: %s", e)
+    else:
+        logger.info("User usage tracking disabled, skipping")
 
     _initialized = True
 
@@ -100,3 +111,29 @@ def _setup_langfuse() -> None:
     )
 
     add_trace_processor(LangfuseTracingProcessor(client=client))
+
+
+_user_usage_processor: object | None = None
+
+
+def _setup_user_usage_tracking() -> None:
+    """Register the per-user usage recording processor."""
+    global _user_usage_processor
+    from onyx.tracing.framework import add_trace_processor
+    from onyx.tracing.processors.user_usage_processor import UserUsageTracingProcessor
+
+    processor = UserUsageTracingProcessor()
+    _user_usage_processor = processor
+    add_trace_processor(processor)
+
+
+def shutdown_tracing() -> None:
+    """Flush buffered usage to the DB on shutdown. Call before disposing the DB
+    engines (the drain thread writes through them) so queued records aren't lost."""
+    from onyx.tracing.processors.user_usage_processor import UserUsageTracingProcessor
+
+    if isinstance(_user_usage_processor, UserUsageTracingProcessor):
+        try:
+            _user_usage_processor.shutdown()
+        except Exception:
+            logger.exception("Failed to flush user usage on shutdown")

--- a/backend/shared_configs/contextvars.py
+++ b/backend/shared_configs/contextvars.py
@@ -30,6 +30,12 @@ CURRENT_ENDPOINT_CONTEXTVAR: contextvars.ContextVar[str | None] = (
     contextvars.ContextVar("current_endpoint", default=None)
 )
 
+# Set per-request (after auth) so the usage recorder can attribute usage to the
+# requesting user. Unset (None) in background-worker contexts.
+CURRENT_USER_ID_CONTEXTVAR: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "current_user_id", default=None
+)
+
 
 """Utils related to contextvars"""
 
@@ -49,3 +55,8 @@ def get_current_tenant_id() -> str:
         )
         raise RuntimeError(error_message)
     return tenant_id
+
+
+def get_current_user_id() -> str | None:
+    """Requesting user's id, or None outside a per-request context."""
+    return CURRENT_USER_ID_CONTEXTVAR.get()

--- a/backend/tests/unit/ee/onyx/db/test_token_limit.py
+++ b/backend/tests/unit/ee/onyx/db/test_token_limit.py
@@ -1,0 +1,75 @@
+"""insert_user_group_token_rate_limit must persist cost_budget_cents.
+
+Regression: a cost-only group limit dropped its budget on create, leaving a row
+with neither budget set — which trips the CHECK constraint (500) and never shows
+in the UI. The user/global inserts always carried cost_budget_cents; the group
+insert didn't.
+"""
+
+from collections.abc import Generator
+from typing import cast
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy import Table
+from sqlalchemy.dialects.postgresql import JSONB as PGJSONB
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.orm import Session
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from ee.onyx.db.token_limit import insert_user_group_token_rate_limit
+from onyx.db.models import TokenRateLimit
+from onyx.db.models import TokenRateLimit__UserGroup
+from onyx.server.token_rate_limits.models import TokenRateLimitArgs
+
+
+@compiles(PGUUID, "sqlite")
+def _compile_pguuid_sqlite(_element: object, _compiler: object, **_kw: object) -> str:
+    return "CHAR(36)"
+
+
+@compiles(PGJSONB, "sqlite")
+def _compile_jsonb_sqlite(_element: object, _compiler: object, **_kw: object) -> str:
+    return "JSON"
+
+
+@pytest.fixture
+def db_session() -> Generator[Session, None, None]:
+    engine: Engine = create_engine(
+        "sqlite://", poolclass=StaticPool, connect_args={"check_same_thread": False}
+    )
+    for model in (TokenRateLimit, TokenRateLimit__UserGroup):
+        cast(Table, model.__table__).create(bind=engine)
+    session = sessionmaker(bind=engine)()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def test_group_insert_persists_cost_budget(db_session: Session) -> None:
+    limit = insert_user_group_token_rate_limit(
+        db_session,
+        TokenRateLimitArgs(
+            enabled=True,
+            token_budget=None,
+            period_hours=168,
+            cost_budget_cents=3000.0,
+        ),
+        group_id=1,
+    )
+    assert limit.cost_budget_cents == pytest.approx(3000.0)
+    assert limit.token_budget is None
+
+
+def test_group_insert_persists_token_budget(db_session: Session) -> None:
+    limit = insert_user_group_token_rate_limit(
+        db_session,
+        TokenRateLimitArgs(enabled=True, token_budget=500, period_hours=4),
+        group_id=1,
+    )
+    assert limit.token_budget == 500
+    assert limit.cost_budget_cents is None

--- a/backend/tests/unit/onyx/db/test_user_usage.py
+++ b/backend/tests/unit/onyx/db/test_user_usage.py
@@ -1,0 +1,383 @@
+"""Unit tests for the per-user usage ledger (in-memory SQLite)."""
+
+import datetime
+from collections.abc import Generator
+from typing import cast
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy import Table
+from sqlalchemy.dialects.postgresql import JSONB as PGJSONB
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.orm import Session
+from sqlalchemy.orm import sessionmaker
+
+from onyx.db.models import User__UserGroup
+from onyx.db.models import UserUsage
+from onyx.db.user_usage import get_group_cost_cents_since
+from onyx.db.user_usage import get_total_cost_cents_since
+from onyx.db.user_usage import get_user_cost_cents_in_window
+from onyx.db.user_usage import get_user_cost_cents_since
+from onyx.db.user_usage import get_user_usage_by_day_and_model
+from onyx.db.user_usage import get_window_start
+from onyx.db.user_usage import record_user_usage
+
+
+# Map the postgres-only column types onto SQLite equivalents so the real
+# UserUsage table from models.py can be created against an in-memory DB.
+@compiles(PGUUID, "sqlite")
+def _compile_pguuid_sqlite(_element: object, _compiler: object, **_kw: object) -> str:
+    return "CHAR(36)"
+
+
+@compiles(PGJSONB, "sqlite")
+def _compile_jsonb_sqlite(_element: object, _compiler: object, **_kw: object) -> str:
+    return "JSON"
+
+
+@pytest.fixture
+def db_session() -> Generator[Session, None, None]:
+    engine: Engine = create_engine("sqlite://")
+    # Only the table under test; FK to user.id is not enforced by SQLite.
+    user_usage_table = cast(Table, UserUsage.__table__)
+    user_usage_table.create(bind=engine)
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+class TestGetWindowStart:
+    def test_weekly_aligns_to_monday(self) -> None:
+        # 2026-06-03 is a Wednesday.
+        dt = datetime.datetime(2026, 6, 3, 14, 22, tzinfo=datetime.timezone.utc)
+        window = get_window_start(dt, period_hours=168)
+        assert window.weekday() == 0  # Monday
+        assert window == datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc)
+
+    def test_hourly_epoch_aligned(self) -> None:
+        dt = datetime.datetime(2026, 6, 3, 14, 59, 59, tzinfo=datetime.timezone.utc)
+        window = get_window_start(dt, period_hours=1)
+        assert window == datetime.datetime(
+            2026, 6, 3, 14, 0, 0, tzinfo=datetime.timezone.utc
+        )
+
+    def test_naive_datetime_treated_as_utc(self) -> None:
+        naive = datetime.datetime(2026, 6, 3, 14, 30)
+        aware = datetime.datetime(2026, 6, 3, 14, 30, tzinfo=datetime.timezone.utc)
+        assert get_window_start(naive, 1) == get_window_start(aware, 1)
+
+
+class TestRecordUserUsage:
+    def test_two_records_accumulate(self, db_session: Session) -> None:
+        user_id = str(uuid4())
+        window = datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc)
+
+        record_user_usage(
+            db_session,
+            user_id=user_id,
+            model="claude-3",
+            flow="CHAT",
+            provider="anthropic",
+            input_tokens=100,
+            output_tokens=50,
+            cache_read_tokens=10,
+            cost_cents=1.5,
+            window_start=window,
+        )
+        record_user_usage(
+            db_session,
+            user_id=user_id,
+            model="claude-3",
+            flow="CHAT",
+            provider="anthropic",
+            input_tokens=200,
+            output_tokens=70,
+            cache_read_tokens=5,
+            cost_cents=2.0,
+            window_start=window,
+        )
+
+        rows = db_session.query(UserUsage).all()
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.input_tokens == 300
+        assert row.output_tokens == 120
+        assert row.cache_read_tokens == 15
+        assert row.cost_cents == pytest.approx(3.5)
+
+    def test_distinct_dimensions_separate_rows(self, db_session: Session) -> None:
+        user_id = str(uuid4())
+        window = datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc)
+
+        record_user_usage(
+            db_session,
+            user_id,
+            "model-a",
+            "CHAT",
+            "anthropic",
+            10,
+            5,
+            0,
+            0.1,
+            window,
+        )
+        record_user_usage(
+            db_session,
+            user_id,
+            "model-b",
+            "CHAT",
+            "anthropic",
+            20,
+            5,
+            0,
+            0.2,
+            window,
+        )
+        assert db_session.query(UserUsage).count() == 2
+
+    def test_null_provider_accumulates(self, db_session: Session) -> None:
+        user_id = str(uuid4())
+        window = datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc)
+
+        record_user_usage(
+            db_session, user_id, "model-a", "CHAT", None, 10, 5, 0, 0.1, window
+        )
+        record_user_usage(
+            db_session, user_id, "model-a", "CHAT", None, 30, 5, 0, 0.3, window
+        )
+        rows = db_session.query(UserUsage).all()
+        assert len(rows) == 1
+        assert rows[0].input_tokens == 40
+        assert rows[0].cost_cents == pytest.approx(0.4)
+        # A missing provider is stored as "" (not NULL) so the dedup unique index
+        # collapses these rows on every Postgres version.
+        assert rows[0].provider == ""
+
+
+class TestAggregation:
+    def test_by_day_and_model(self, db_session: Session) -> None:
+        user_id = str(uuid4())
+        day1 = datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc)
+        day2 = datetime.datetime(2026, 6, 2, tzinfo=datetime.timezone.utc)
+
+        record_user_usage(
+            db_session,
+            user_id,
+            "model-a",
+            "CHAT",
+            "anthropic",
+            100,
+            50,
+            0,
+            1.0,
+            day1,
+        )
+        record_user_usage(
+            db_session,
+            user_id,
+            "model-b",
+            "CHAT",
+            "anthropic",
+            200,
+            60,
+            0,
+            2.0,
+            day1,
+        )
+        record_user_usage(
+            db_session,
+            user_id,
+            "model-a",
+            "CHAT",
+            "anthropic",
+            300,
+            70,
+            0,
+            3.0,
+            day2,
+        )
+
+        result = get_user_usage_by_day_and_model(
+            db_session,
+            user_id,
+            since=day1,
+            until=datetime.datetime(2026, 6, 3, tzinfo=datetime.timezone.utc),
+        )
+        assert result == [
+            {
+                "day": "2026-06-01",
+                "model": "model-a",
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "cache_read_tokens": 0,
+                "cost_cents": 1.0,
+            },
+            {
+                "day": "2026-06-01",
+                "model": "model-b",
+                "input_tokens": 200,
+                "output_tokens": 60,
+                "cache_read_tokens": 0,
+                "cost_cents": 2.0,
+            },
+            {
+                "day": "2026-06-02",
+                "model": "model-a",
+                "input_tokens": 300,
+                "output_tokens": 70,
+                "cache_read_tokens": 0,
+                "cost_cents": 3.0,
+            },
+        ]
+
+    def test_aggregation_excludes_other_users(self, db_session: Session) -> None:
+        user_id = str(uuid4())
+        other_id = str(uuid4())
+        day1 = datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc)
+
+        record_user_usage(
+            db_session, user_id, "model-a", "CHAT", None, 100, 50, 0, 1.0, day1
+        )
+        record_user_usage(
+            db_session, other_id, "model-a", "CHAT", None, 999, 50, 0, 9.0, day1
+        )
+
+        result = get_user_usage_by_day_and_model(
+            db_session,
+            user_id,
+            since=day1,
+            until=datetime.datetime(2026, 6, 2, tzinfo=datetime.timezone.utc),
+        )
+        assert len(result) == 1
+        assert result[0]["input_tokens"] == 100
+
+
+class TestCostInWindow:
+    def test_sums_cost_across_dimensions(self, db_session: Session) -> None:
+        user_id = str(uuid4())
+        window = datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc)
+
+        record_user_usage(
+            db_session,
+            user_id,
+            "model-a",
+            "CHAT",
+            "anthropic",
+            10,
+            5,
+            0,
+            1.25,
+            window,
+        )
+        record_user_usage(
+            db_session,
+            user_id,
+            "model-b",
+            "BUILD",
+            "openai",
+            20,
+            5,
+            0,
+            2.75,
+            window,
+        )
+
+        total = get_user_cost_cents_in_window(db_session, user_id, window)
+        assert total == pytest.approx(4.0)
+
+    def test_empty_window_is_zero(self, db_session: Session) -> None:
+        total = get_user_cost_cents_in_window(
+            db_session,
+            str(uuid4()),
+            datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc),
+        )
+        assert total == 0.0
+
+
+class TestUserCostSince:
+    """Range-scan read used by enforcement: sums ledger rows with
+    window_start >= cutoff. The cutoff is grid-relaxed by the caller
+    (_worst_triggered_cost_limit), so this helper is a plain range scan."""
+
+    def test_includes_rows_at_or_after_cutoff(self, db_session: Session) -> None:
+        user_id = str(uuid4())
+        w = datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc)
+        record_user_usage(db_session, user_id, "m", "CHAT", None, 1, 1, 0, 42.0, w)
+        assert get_user_cost_cents_since(db_session, user_id, w) == pytest.approx(42.0)
+
+    def test_rows_before_cutoff_excluded(self, db_session: Session) -> None:
+        user_id = str(uuid4())
+        older = datetime.datetime(2026, 5, 25, tzinfo=datetime.timezone.utc)
+        newer = datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc)
+        record_user_usage(db_session, user_id, "m", "CHAT", None, 1, 1, 0, 5.0, older)
+        record_user_usage(db_session, user_id, "m", "CHAT", None, 1, 1, 0, 8.0, newer)
+        assert get_user_cost_cents_since(db_session, user_id, newer) == pytest.approx(
+            8.0
+        )
+
+    def test_excludes_other_users(self, db_session: Session) -> None:
+        u1, u2 = str(uuid4()), str(uuid4())
+        window = datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc)
+        record_user_usage(db_session, u1, "m", "CHAT", None, 1, 1, 0, 3.0, window)
+        record_user_usage(db_session, u2, "m", "CHAT", None, 1, 1, 0, 9.0, window)
+        assert get_user_cost_cents_since(db_session, u1, window) == pytest.approx(3.0)
+
+
+class TestTotalCostSince:
+    def test_sums_across_users(self, db_session: Session) -> None:
+        u1, u2 = str(uuid4()), str(uuid4())
+        window = datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc)
+        record_user_usage(db_session, u1, "m", "CHAT", None, 1, 1, 0, 3.0, window)
+        record_user_usage(db_session, u2, "m", "CHAT", None, 1, 1, 0, 4.0, window)
+
+        assert get_total_cost_cents_since(db_session, window) == pytest.approx(7.0)
+
+    def test_older_window_excluded(self, db_session: Session) -> None:
+        u1 = str(uuid4())
+        w1 = datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc)
+        w2 = datetime.datetime(2026, 6, 8, tzinfo=datetime.timezone.utc)
+        record_user_usage(db_session, u1, "m", "CHAT", None, 1, 1, 0, 3.0, w1)
+        record_user_usage(db_session, u1, "m", "CHAT", None, 1, 1, 0, 9.0, w2)
+
+        # cutoff at w2 excludes the earlier w1 row
+        assert get_total_cost_cents_since(db_session, w2) == pytest.approx(9.0)
+
+
+@pytest.fixture
+def db_session_with_groups() -> Generator[Session, None, None]:
+    """UserUsage + User__UserGroup tables, for group-scoped cost aggregation."""
+    engine: Engine = create_engine("sqlite://")
+    cast(Table, UserUsage.__table__).create(bind=engine)
+    cast(Table, User__UserGroup.__table__).create(bind=engine)
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+class TestGroupCostSince:
+    def test_sums_members_of_group(self, db_session_with_groups: Session) -> None:
+        s = db_session_with_groups
+        u1, u2, outsider = str(uuid4()), str(uuid4()), str(uuid4())
+        window = datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc)
+
+        s.add_all(
+            [
+                User__UserGroup(user_group_id=10, user_id=u1),
+                User__UserGroup(user_group_id=10, user_id=u2),
+            ]
+        )
+        s.flush()
+        record_user_usage(s, u1, "m", "CHAT", None, 1, 1, 0, 2.0, window)
+        record_user_usage(s, u2, "m", "CHAT", None, 1, 1, 0, 5.0, window)
+        record_user_usage(s, outsider, "m", "CHAT", None, 1, 1, 0, 99.0, window)
+
+        assert get_group_cost_cents_since(s, 10, window) == pytest.approx(7.0)

--- a/backend/tests/unit/onyx/db/test_user_usage_reset.py
+++ b/backend/tests/unit/onyx/db/test_user_usage_reset.py
@@ -1,0 +1,85 @@
+"""Unit tests for reset_user_usage (in-memory SQLite over the real ledger).
+
+An admin reset must clear a user's CURRENT window (lifting a budget block) while
+preserving prior windows (the reporting history) and other users' rows.
+"""
+
+import datetime
+import uuid
+from collections.abc import Generator
+from typing import cast
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy import Table
+from sqlalchemy.dialects.postgresql import JSONB as PGJSONB
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.orm import Session
+from sqlalchemy.orm import sessionmaker
+
+from onyx.db.models import UserUsage
+from onyx.db.user_usage import get_user_cost_cents_since
+from onyx.db.user_usage import get_window_start
+from onyx.db.user_usage import record_user_usage
+from onyx.db.user_usage import reset_user_usage
+from onyx.db.user_usage import USAGE_PERIOD_HOURS
+
+
+@compiles(PGUUID, "sqlite")
+def _compile_pguuid_sqlite(_e: object, _c: object, **_kw: object) -> str:
+    return "CHAR(36)"
+
+
+@compiles(PGJSONB, "sqlite")
+def _compile_jsonb_sqlite(_e: object, _c: object, **_kw: object) -> str:
+    return "JSON"
+
+
+@pytest.fixture
+def db() -> Generator[Session, None, None]:
+    engine: Engine = create_engine("sqlite://")
+    cast(Table, UserUsage.__table__).create(bind=engine)
+    session = sessionmaker(bind=engine)()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def _record(db: Session, user_id: str, cost: float, window: datetime.datetime) -> None:
+    record_user_usage(db, user_id, "m", "CHAT", None, 1, 1, 0, cost, window)
+
+
+class TestResetUserUsage:
+    def test_clears_current_window_keeps_history(self, db: Session) -> None:
+        uid = str(uuid.uuid4())
+        now = datetime.datetime.now(tz=datetime.timezone.utc)
+        current = get_window_start(now, period_hours=USAGE_PERIOD_HOURS)
+        prior = current - datetime.timedelta(days=14)
+        _record(db, uid, 500.0, current)
+        _record(db, uid, 999.0, prior)
+
+        removed = reset_user_usage(db, uid)
+
+        assert removed == 1
+        # current-window spend is gone (budget block lifts) ...
+        assert get_user_cost_cents_since(db, uid, current) == 0.0
+        # ... but the prior window (history) is preserved.
+        assert get_user_cost_cents_since(db, uid, prior) == 999.0
+
+    def test_only_targets_the_given_user(self, db: Session) -> None:
+        me, other = str(uuid.uuid4()), str(uuid.uuid4())
+        now = datetime.datetime.now(tz=datetime.timezone.utc)
+        current = get_window_start(now, period_hours=USAGE_PERIOD_HOURS)
+        _record(db, me, 500.0, current)
+        _record(db, other, 500.0, current)
+
+        reset_user_usage(db, me)
+
+        assert get_user_cost_cents_since(db, me, current) == 0.0
+        assert get_user_cost_cents_since(db, other, current) == 500.0  # untouched
+
+    def test_reset_with_no_rows_is_a_noop(self, db: Session) -> None:
+        assert reset_user_usage(db, str(uuid.uuid4())) == 0

--- a/backend/tests/unit/onyx/llm/test_cost.py
+++ b/backend/tests/unit/onyx/llm/test_cost.py
@@ -1,0 +1,287 @@
+"""Unit tests for split input/output cost and admin per-model overrides (SQLite)."""
+
+from collections.abc import Generator
+from typing import cast
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy import Table
+from sqlalchemy.dialects.postgresql import JSONB as PGJSONB
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.orm import Session
+from sqlalchemy.orm import sessionmaker
+
+from onyx.db.models import ModelCostOverride
+from onyx.llm import cost as cost_mod
+from onyx.llm import cost_overrides
+from onyx.llm.cost import compute_cost_cents
+from onyx.tracing.flows import LLMFlow
+from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
+
+
+@compiles(PGUUID, "sqlite")
+def _compile_pguuid_sqlite(_element: object, _compiler: object, **_kw: object) -> str:
+    return "CHAR(36)"
+
+
+@compiles(PGJSONB, "sqlite")
+def _compile_jsonb_sqlite(_element: object, _compiler: object, **_kw: object) -> str:
+    return "JSON"
+
+
+@pytest.fixture
+def db_session() -> Generator[Session, None, None]:
+    engine: Engine = create_engine("sqlite://")
+    cast(Table, ModelCostOverride.__table__).create(bind=engine)
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture(autouse=True)
+def _clear_override_cache() -> Generator[None, None, None]:
+    # Wipe every tenant's snapshot (invalidate_override_cache is tenant-scoped).
+    cost_overrides._cache.clear()
+    yield
+    cost_overrides._cache.clear()
+
+
+class TestComputeCostCents:
+    def test_known_model_splits_input_and_output(self) -> None:
+        # gpt-4o: $2.50/Mtok in, $10.00/Mtok out → 1000 tok each.
+        in_cents, out_cents = compute_cost_cents(
+            model="gpt-4o",
+            provider="openai",
+            input_tokens=1000,
+            output_tokens=1000,
+        )
+        assert in_cents == pytest.approx(0.25)
+        assert out_cents == pytest.approx(1.0)
+
+    def test_unknown_model_returns_zero_no_raise(self) -> None:
+        result = compute_cost_cents(
+            model="totally-made-up-model-xyz",
+            provider="nobody",
+            input_tokens=1000,
+            output_tokens=1000,
+        )
+        assert result == (0.0, 0.0)
+
+    def test_unknown_model_uses_configurable_fallback_rates(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # With a fallback configured, an unpriced model accrues cost instead of $0.
+        monkeypatch.setattr(cost_mod, "DEFAULT_LLM_INPUT_COST_PER_MTOK", 2.0)
+        monkeypatch.setattr(cost_mod, "DEFAULT_LLM_OUTPUT_COST_PER_MTOK", 6.0)
+        in_cents, out_cents = compute_cost_cents(
+            model="totally-made-up-model-xyz",
+            provider="nobody",
+            input_tokens=1_000_000,
+            output_tokens=1_000_000,
+            cache_read_tokens=0,
+        )
+        assert in_cents == pytest.approx(200.0)  # 1M * $2/Mtok = $2.00 = 200c
+        assert out_cents == pytest.approx(600.0)  # 1M * $6/Mtok = $6.00 = 600c
+
+    def test_cache_read_tokens_priced_as_input(self) -> None:
+        # gpt-4o: $2.50/Mtok input, $1.25/Mtok cache-read. 1000 non-cached +
+        # 2000 cache-read = 1000*2.5e-6 + 2000*1.25e-6 = $0.005 = 0.5 cents.
+        # Pinned exactly to catch double-counting cached tokens at full rate.
+        cache_in, cache_out = compute_cost_cents(
+            "gpt-4o",
+            "openai",
+            input_tokens=1000,
+            output_tokens=500,
+            cache_read_tokens=2000,
+        )
+        assert cache_in == pytest.approx(0.5)
+        # Output (500 tok @ $10/Mtok) is unaffected by cache reads.
+        assert cache_out == pytest.approx(0.5)
+
+    def test_bedrock_model_priced_via_provider(self) -> None:
+        # Bedrock names aren't self-identifying — without custom_llm_provider
+        # litellm raises and the cost silently collapses to $0. Haiku:
+        # $0.25/Mtok in, $1.25/Mtok out → 0.025c in, 0.125c out for 1000 tok.
+        in_cents, out_cents = compute_cost_cents(
+            model="anthropic.claude-3-haiku-20240307-v1:0",
+            provider="bedrock",
+            input_tokens=1000,
+            output_tokens=1000,
+        )
+        assert in_cents == pytest.approx(0.025)
+        assert out_cents == pytest.approx(0.125)
+
+
+class TestImageFlow:
+    def test_image_flow_uses_image_pricing(self) -> None:
+        # dall-e-3 is priced per-image ($0.04 = 4 cents), not per-token.
+        in_cents, out_cents = compute_cost_cents(
+            model="dall-e-3",
+            provider="openai",
+            input_tokens=0,
+            output_tokens=0,
+            flow=LLMFlow.IMAGE_GENERATION,
+        )
+        assert (in_cents + out_cents) == pytest.approx(4.0)
+
+    def test_unpriced_image_model_uses_flat_constant(self) -> None:
+        in_cents, out_cents = compute_cost_cents(
+            model="some-unpriced-image-model",
+            provider="nobody",
+            input_tokens=0,
+            output_tokens=0,
+            flow=LLMFlow.IMAGE_EDIT,
+        )
+        from onyx.configs.app_configs import DEFAULT_IMAGE_COST_CENTS
+
+        assert (in_cents + out_cents) == pytest.approx(DEFAULT_IMAGE_COST_CENTS)
+
+
+class TestOverride:
+    def test_override_wins_over_litellm(self, db_session: Session) -> None:
+        db_session.add(
+            ModelCostOverride(
+                model="gpt-4o",
+                input_cost_per_mtok=1.0,  # $1.00/Mtok in
+                output_cost_per_mtok=2.0,  # $2.00/Mtok out
+            )
+        )
+        db_session.commit()
+
+        in_cents, out_cents = compute_cost_cents(
+            model="gpt-4o",
+            provider="openai",
+            input_tokens=1_000_000,
+            output_tokens=1_000_000,
+            db_session=db_session,
+        )
+        # $1.00 = 100 cents in, $2.00 = 200 cents out.
+        assert in_cents == pytest.approx(100.0)
+        assert out_cents == pytest.approx(200.0)
+
+    def test_override_counts_cache_reads_as_input(self, db_session: Session) -> None:
+        db_session.add(
+            ModelCostOverride(
+                model="gpt-4o",
+                input_cost_per_mtok=1.0,
+                output_cost_per_mtok=2.0,
+            )
+        )
+        db_session.commit()
+
+        in_cents, _ = compute_cost_cents(
+            model="gpt-4o",
+            provider="openai",
+            input_tokens=500_000,
+            output_tokens=0,
+            cache_read_tokens=500_000,
+            db_session=db_session,
+        )
+        # (500k + 500k) tok at $1/Mtok = $1.00 = 100 cents.
+        assert in_cents == pytest.approx(100.0)
+
+    def test_override_cache_rate_applied_when_set(self, db_session: Session) -> None:
+        db_session.add(
+            ModelCostOverride(
+                model="gpt-4o",
+                input_cost_per_mtok=1.0,
+                output_cost_per_mtok=2.0,
+                cache_read_cost_per_mtok=0.1,  # cache reads 10x cheaper than input
+            )
+        )
+        db_session.commit()
+
+        in_cents, _ = compute_cost_cents(
+            model="gpt-4o",
+            provider="openai",
+            input_tokens=1_000_000,
+            output_tokens=0,
+            cache_read_tokens=1_000_000,
+            db_session=db_session,
+        )
+        # 1M input @ $1 = 100c + 1M cache @ $0.10 = 10c = 110 cents.
+        assert in_cents == pytest.approx(110.0)
+
+    def test_override_cache_is_tenant_scoped(self) -> None:
+        # Each tenant has its own schema/session. Tenant A's negotiated rate
+        # must not leak into tenant B's cost computation.
+        def _session() -> Session:
+            engine = create_engine("sqlite://")
+            cast(Table, ModelCostOverride.__table__).create(bind=engine)
+            return sessionmaker(bind=engine)()
+
+        tenant_a, tenant_b = _session(), _session()
+        tenant_a.add(
+            ModelCostOverride(
+                model="gpt-4o", input_cost_per_mtok=1.0, output_cost_per_mtok=2.0
+            )
+        )
+        tenant_a.commit()
+
+        token = CURRENT_TENANT_ID_CONTEXTVAR.set("tenant_a")
+        try:
+            a_in, a_out = compute_cost_cents(
+                "gpt-4o",
+                "openai",
+                input_tokens=1_000_000,
+                output_tokens=1_000_000,
+                db_session=tenant_a,
+            )
+        finally:
+            CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+        assert (a_in, a_out) == pytest.approx((100.0, 200.0))
+
+        # Tenant B has no override row → falls through to litellm gpt-4o pricing,
+        # NOT tenant A's cached negotiated rate.
+        token = CURRENT_TENANT_ID_CONTEXTVAR.set("tenant_b")
+        try:
+            b_in, b_out = compute_cost_cents(
+                "gpt-4o",
+                "openai",
+                input_tokens=1_000_000,
+                output_tokens=1_000_000,
+                db_session=tenant_b,
+            )
+        finally:
+            CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+        # litellm gpt-4o: $2.50/Mtok in, $10.00/Mtok out.
+        assert (b_in, b_out) == pytest.approx((250.0, 1000.0))
+
+
+class TestGetOverride:
+    def test_returns_none_when_absent(self, db_session: Session) -> None:
+        assert cost_overrides.get_override(db_session, "no-such-model") is None
+
+    def test_returns_rates_when_present(self, db_session: Session) -> None:
+        db_session.add(
+            ModelCostOverride(
+                model="claude-x",
+                input_cost_per_mtok=3.0,
+                output_cost_per_mtok=15.0,
+            )
+        )
+        db_session.commit()
+
+        rates = cost_overrides.get_override(db_session, "claude-x")
+        assert rates is not None
+        assert rates == (3.0, 15.0, None)
+
+    def test_cache_invalidation_picks_up_new_row(self, db_session: Session) -> None:
+        assert cost_overrides.get_override(db_session, "late-model") is None
+        db_session.add(
+            ModelCostOverride(
+                model="late-model",
+                input_cost_per_mtok=4.0,
+                output_cost_per_mtok=8.0,
+            )
+        )
+        db_session.commit()
+        # Stale cache still says None until invalidated.
+        assert cost_overrides.get_override(db_session, "late-model") is None
+        cost_overrides.invalidate_override_cache()
+        assert cost_overrides.get_override(db_session, "late-model") == (4.0, 8.0, None)

--- a/backend/tests/unit/onyx/server/features/build/session/test_messages_background_turn.py
+++ b/backend/tests/unit/onyx/server/features/build/session/test_messages_background_turn.py
@@ -10,6 +10,7 @@ import pytest
 from sqlalchemy.orm import Session
 
 from onyx.db.models import User
+from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server.features.build.session import messages as messages_api
 from onyx.server.features.build.session.models import MessageRequest
@@ -75,6 +76,7 @@ def test_send_message_starts_background_turn(monkeypatch: pytest.MonkeyPatch) ->
     monkeypatch.setattr(messages_api, "get_cache_backend", lambda: cache)
     monkeypatch.setattr(messages_api, "get_build_session", get_session_stub)
     monkeypatch.setattr(messages_api, "check_build_rate_limits", lambda **_: None)
+    monkeypatch.setattr(messages_api, "check_token_rate_limits", lambda *_: None)
     monkeypatch.setattr(
         messages_api,
         "create_message",
@@ -123,6 +125,7 @@ def test_send_message_rejects_second_active_turn(
     monkeypatch.setattr(messages_api, "get_cache_backend", lambda: cache)
     monkeypatch.setattr(messages_api, "get_build_session", get_session_stub)
     monkeypatch.setattr(messages_api, "check_build_rate_limits", lambda **_: None)
+    monkeypatch.setattr(messages_api, "check_token_rate_limits", lambda *_: None)
     monkeypatch.setattr(messages_api, "create_message", _create_message_noop)
     monkeypatch.setattr(messages_api, "start_interactive_turn_runner", MagicMock())
 
@@ -169,6 +172,7 @@ def test_send_message_is_idempotent_for_same_client_request(
     monkeypatch.setattr(messages_api, "get_cache_backend", lambda: cache)
     monkeypatch.setattr(messages_api, "get_build_session", get_session_stub)
     monkeypatch.setattr(messages_api, "check_build_rate_limits", rate_limit_check)
+    monkeypatch.setattr(messages_api, "check_token_rate_limits", lambda *_: None)
     monkeypatch.setattr(
         messages_api,
         "create_message",
@@ -216,6 +220,7 @@ def test_send_message_leaves_turn_active_if_runner_cannot_start(
     monkeypatch.setattr(messages_api, "get_cache_backend", lambda: cache)
     monkeypatch.setattr(messages_api, "get_build_session", get_session_stub)
     monkeypatch.setattr(messages_api, "check_build_rate_limits", lambda **_: None)
+    monkeypatch.setattr(messages_api, "check_token_rate_limits", lambda *_: None)
     monkeypatch.setattr(messages_api, "create_message", _create_message_noop)
     monkeypatch.setattr(
         messages_api,
@@ -238,3 +243,38 @@ def test_send_message_leaves_turn_active_if_runner_cannot_start(
     assert response.status == "QUEUED"
     assert active is not None
     assert active.turn_id == UUID(response.turn_id)
+
+
+def test_send_message_blocked_when_over_token_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A user over their token/cost budget can't start a Craft turn: the gate
+    raises a structured 429 before any turn is created or scheduled."""
+    cache = FakeCache()
+    session_id = uuid4()
+    user_id = uuid4()
+    session = SimpleNamespace(id=session_id)
+    start_runner = MagicMock()
+
+    monkeypatch.setattr(messages_api, "get_cache_backend", lambda: cache)
+    monkeypatch.setattr(messages_api, "get_build_session", lambda *_, **__: session)
+    monkeypatch.setattr(messages_api, "check_build_rate_limits", lambda **_: None)
+    monkeypatch.setattr(messages_api, "check_token_rate_limits", lambda *_: None)
+    monkeypatch.setattr(messages_api, "create_message", _create_message_noop)
+    monkeypatch.setattr(messages_api, "start_interactive_turn_runner", start_runner)
+
+    def _over_budget(_user: object) -> None:
+        raise OnyxError(OnyxErrorCode.RATE_LIMITED, "You've reached the usage budget.")
+
+    monkeypatch.setattr(messages_api, "check_token_rate_limits", _over_budget)
+
+    with pytest.raises(OnyxError) as ei:
+        messages_api.send_message(
+            session_id=session_id,
+            request=MessageRequest(content="hello", client_request_id="req-1"),
+            user=cast(User, SimpleNamespace(id=user_id)),
+            db_session=cast(Session, _FakeDbSession(user_message_count=0)),
+        )
+
+    assert ei.value.error_code is OnyxErrorCode.RATE_LIMITED
+    start_runner.assert_not_called()  # no turn scheduled when over budget

--- a/backend/tests/unit/onyx/server/features/usage/test_admin_usage_export_api.py
+++ b/backend/tests/unit/onyx/server/features/usage/test_admin_usage_export_api.py
@@ -1,0 +1,242 @@
+"""Admin /admin/usage/export: tenant-wide usage joined to email, grouped per
+(email x model x window-day) with a per-user totals roll-up, the model filter
+narrows results, the date range bounds half-open, and non-admins are rejected.
+
+Also unit-tests the get_usage_export DB helper directly."""
+
+import datetime
+from collections.abc import Generator
+from typing import cast
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy import Table
+from sqlalchemy import text
+from sqlalchemy.dialects.postgresql import JSONB as PGJSONB
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.orm import Session
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from onyx.auth.users import current_user
+from onyx.db.engine.sql_engine import get_session
+from onyx.db.enums import Permission
+from onyx.db.models import UserUsage
+from onyx.db.user_usage import get_usage_export
+from onyx.db.user_usage import record_user_usage
+from onyx.error_handling.exceptions import register_onyx_exception_handlers
+from onyx.server.features.usage.api import admin_usage_router
+
+
+@compiles(PGUUID, "sqlite")
+def _compile_pguuid_sqlite(_element: object, _compiler: object, **_kw: object) -> str:
+    return "CHAR(36)"
+
+
+@compiles(PGJSONB, "sqlite")
+def _compile_jsonb_sqlite(_element: object, _compiler: object, **_kw: object) -> str:
+    return "JSON"
+
+
+class _StubUser:
+    """require_permission only reads effective_permissions; the JOIN target is
+    the separately-created `user` table, not this auth stub."""
+
+    def __init__(self, permissions: list[str]) -> None:
+        self.id = "00000000-0000-0000-0000-000000000001"
+        self.effective_permissions = permissions
+
+
+_ADMIN = _StubUser([Permission.FULL_ADMIN_PANEL_ACCESS.value])
+_NON_ADMIN = _StubUser([])
+
+
+@pytest.fixture
+def db_session() -> Generator[Session, None, None]:
+    engine: Engine = create_engine(
+        "sqlite://", poolclass=StaticPool, connect_args={"check_same_thread": False}
+    )
+    cast(Table, UserUsage.__table__).create(bind=engine)
+    # Minimal `user` table: the export JOIN only touches id + email.
+    with engine.begin() as conn:
+        conn.execute(
+            text('CREATE TABLE "user" (id CHAR(36) PRIMARY KEY, email VARCHAR)')
+        )
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def _add_user(db_session: Session, email: str) -> str:
+    user_id = str(uuid4())
+    db_session.execute(
+        text('INSERT INTO "user" (id, email) VALUES (:id, :email)'),
+        {"id": user_id, "email": email},
+    )
+    return user_id
+
+
+def _make_app(db_session: Session, user: _StubUser) -> FastAPI:
+    app = FastAPI()
+    register_onyx_exception_handlers(app)
+    app.include_router(admin_usage_router)
+    app.dependency_overrides[get_session] = lambda: db_session
+    app.dependency_overrides[current_user] = lambda: user
+    return app
+
+
+_W1 = datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc)  # Monday
+_W2 = datetime.datetime(2026, 6, 8, tzinfo=datetime.timezone.utc)  # next Monday
+
+
+def _seed_two_users(db_session: Session) -> tuple[str, str]:
+    """alice: model-a in W1 + W2, model-b in W1.  bob: model-a in W2."""
+    alice = _add_user(db_session, "alice@example.com")
+    bob = _add_user(db_session, "bob@example.com")
+
+    record_user_usage(
+        db_session, alice, "model-a", "CHAT", "openai", 100, 50, 5, 1.0, _W1
+    )
+    record_user_usage(
+        db_session, alice, "model-b", "CHAT", "openai", 200, 60, 0, 2.0, _W1
+    )
+    record_user_usage(
+        db_session, alice, "model-a", "CHAT", "openai", 300, 70, 0, 3.0, _W2
+    )
+    record_user_usage(
+        db_session, bob, "model-a", "CHAT", "anthropic", 400, 80, 0, 4.0, _W2
+    )
+    db_session.commit()
+    return alice, bob
+
+
+class TestGetUsageExportHelper:
+    def test_groups_by_email_model_day_with_join(self, db_session: Session) -> None:
+        _seed_two_users(db_session)
+        rows = get_usage_export(
+            db_session,
+            start=datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc),
+            end=datetime.datetime(2026, 6, 15, tzinfo=datetime.timezone.utc),
+        )
+        # email-then-day-then-model ordering.
+        assert rows == [
+            {
+                "email": "alice@example.com",
+                "model": "model-a",
+                "day": "2026-06-01",
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "cache_read_tokens": 5,
+                "cost_cents": 1.0,
+            },
+            {
+                "email": "alice@example.com",
+                "model": "model-b",
+                "day": "2026-06-01",
+                "input_tokens": 200,
+                "output_tokens": 60,
+                "cache_read_tokens": 0,
+                "cost_cents": 2.0,
+            },
+            {
+                "email": "alice@example.com",
+                "model": "model-a",
+                "day": "2026-06-08",
+                "input_tokens": 300,
+                "output_tokens": 70,
+                "cache_read_tokens": 0,
+                "cost_cents": 3.0,
+            },
+            {
+                "email": "bob@example.com",
+                "model": "model-a",
+                "day": "2026-06-08",
+                "input_tokens": 400,
+                "output_tokens": 80,
+                "cache_read_tokens": 0,
+                "cost_cents": 4.0,
+            },
+        ]
+
+    def test_model_filter_narrows(self, db_session: Session) -> None:
+        _seed_two_users(db_session)
+        rows = get_usage_export(
+            db_session,
+            start=_W1,
+            end=datetime.datetime(2026, 6, 15, tzinfo=datetime.timezone.utc),
+            model="model-b",
+        )
+        assert len(rows) == 1
+        assert rows[0]["model"] == "model-b"
+        assert rows[0]["email"] == "alice@example.com"
+
+    def test_date_range_bounds_half_open(self, db_session: Session) -> None:
+        _seed_two_users(db_session)
+        # [W1, W2) excludes everything in W2.
+        rows = get_usage_export(db_session, start=_W1, end=_W2)
+        days = {r["day"] for r in rows}
+        assert days == {"2026-06-01"}
+
+
+class TestExportEndpoint:
+    def test_nested_per_user_with_totals(self, db_session: Session) -> None:
+        _seed_two_users(db_session)
+        client = TestClient(_make_app(db_session, _ADMIN))
+        resp = client.get(
+            "/admin/usage/export", params={"start": "2026-06-01", "end": "2026-06-14"}
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["start"] == "2026-06-01"
+        assert body["end"] == "2026-06-14"
+
+        users = {u["email"]: u for u in body["users"]}
+        assert set(users) == {"alice@example.com", "bob@example.com"}
+
+        alice = users["alice@example.com"]
+        assert len(alice["records"]) == 3
+        # Totals roll up all of alice's records.
+        assert alice["totals"]["input_tokens"] == 600  # 100 + 200 + 300
+        assert alice["totals"]["output_tokens"] == 180  # 50 + 60 + 70
+        assert alice["totals"]["cache_read_tokens"] == 5
+        assert alice["totals"]["cost_cents"] == pytest.approx(6.0)
+
+        bob = users["bob@example.com"]
+        assert len(bob["records"]) == 1
+        assert bob["totals"]["input_tokens"] == 400
+
+    def test_model_filter_endpoint(self, db_session: Session) -> None:
+        _seed_two_users(db_session)
+        client = TestClient(_make_app(db_session, _ADMIN))
+        body = client.get(
+            "/admin/usage/export",
+            params={"start": "2026-06-01", "end": "2026-06-14", "model": "model-b"},
+        ).json()
+        assert len(body["users"]) == 1
+        assert body["users"][0]["email"] == "alice@example.com"
+        assert all(r["model"] == "model-b" for r in body["users"][0]["records"])
+
+    def test_date_range_end_excludes_later_window(self, db_session: Session) -> None:
+        _seed_two_users(db_session)
+        client = TestClient(_make_app(db_session, _ADMIN))
+        # end=2026-06-07 -> half-open through 06-08 00:00, so W2 (06-08) excluded.
+        body = client.get(
+            "/admin/usage/export", params={"start": "2026-06-01", "end": "2026-06-07"}
+        ).json()
+        all_days = {r["day"] for u in body["users"] for r in u["records"]}
+        assert all_days == {"2026-06-01"}
+        assert "bob@example.com" not in {u["email"] for u in body["users"]}
+
+    def test_non_admin_rejected(self, db_session: Session) -> None:
+        client = TestClient(_make_app(db_session, _NON_ADMIN))
+        resp = client.get("/admin/usage/export")
+        assert resp.status_code == 403
+        assert resp.json()["error_code"] == "INSUFFICIENT_PERMISSIONS"

--- a/backend/tests/unit/onyx/server/features/usage/test_admin_usage_export_api.py
+++ b/backend/tests/unit/onyx/server/features/usage/test_admin_usage_export_api.py
@@ -240,3 +240,43 @@ class TestExportEndpoint:
         resp = client.get("/admin/usage/export")
         assert resp.status_code == 403
         assert resp.json()["error_code"] == "INSUFFICIENT_PERMISSIONS"
+
+
+class TestResetUsageEndpoint:
+    """POST /admin/usage/reset — admin-only; 404 on unknown email; on success it
+    clears the resolved user's usage."""
+
+    def test_unknown_user_is_404(
+        self, db_session: Session, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import onyx.server.features.usage.api as api
+
+        monkeypatch.setattr(api, "get_user_by_email", lambda _email, _db: None)
+        client = TestClient(_make_app(db_session, _ADMIN))
+        resp = client.post("/admin/usage/reset", json={"user_email": "nope@x.com"})
+        assert resp.status_code == 404
+
+    def test_resets_found_user(
+        self, db_session: Session, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import onyx.server.features.usage.api as api
+
+        class _U:
+            id = "00000000-0000-0000-0000-0000000000aa"
+
+        seen: dict[str, str] = {}
+        monkeypatch.setattr(api, "get_user_by_email", lambda _email, _db: _U())
+        monkeypatch.setattr(
+            api,
+            "reset_user_usage",
+            lambda _db, user_id: seen.update(user_id=user_id) or 1,
+        )
+        client = TestClient(_make_app(db_session, _ADMIN))
+        resp = client.post("/admin/usage/reset", json={"user_email": "u@x.com"})
+        assert resp.status_code == 200
+        assert seen["user_id"] == str(_U.id)
+
+    def test_non_admin_rejected(self, db_session: Session) -> None:
+        client = TestClient(_make_app(db_session, _NON_ADMIN))
+        resp = client.post("/admin/usage/reset", json={"user_email": "u@x.com"})
+        assert resp.status_code == 403

--- a/backend/tests/unit/onyx/server/features/usage/test_cost_overrides_api.py
+++ b/backend/tests/unit/onyx/server/features/usage/test_cost_overrides_api.py
@@ -1,0 +1,200 @@
+"""Admin cost-override CRUD: upsert is idempotent, GET reflects writes, DELETE
+removes (404 on missing), non-admins are rejected, and every write busts the
+per-tenant override cache."""
+
+from collections.abc import Generator
+from typing import cast
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy import Table
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from onyx.auth.users import current_user
+from onyx.db.engine.sql_engine import get_session
+from onyx.db.enums import Permission
+from onyx.db.models import ModelCostOverride
+from onyx.error_handling.exceptions import register_onyx_exception_handlers
+from onyx.llm import cost_overrides
+from onyx.llm.cost_overrides import delete_override
+from onyx.llm.cost_overrides import list_overrides
+from onyx.llm.cost_overrides import upsert_override
+from onyx.server.features.usage.api import router as cost_override_router
+
+
+class _StubUser:
+    """Minimal stand-in for User: require_permission only reads these two."""
+
+    def __init__(self, permissions: list[str]) -> None:
+        self.id = "00000000-0000-0000-0000-000000000001"
+        self.effective_permissions = permissions
+
+
+_ADMIN = _StubUser([Permission.FULL_ADMIN_PANEL_ACCESS.value])
+_NON_ADMIN = _StubUser([])
+
+
+@pytest.fixture
+def db_session() -> Generator[Session, None, None]:
+    # StaticPool shares one in-memory connection so the table survives the
+    # endpoint's commit() (which otherwise returns the connection to the pool
+    # and the next checkout would hit a fresh, empty :memory: database).
+    engine: Engine = create_engine(
+        "sqlite://", poolclass=StaticPool, connect_args={"check_same_thread": False}
+    )
+    table = cast(Table, ModelCostOverride.__table__)
+    table.create(bind=engine)
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def _make_app(db_session: Session, user: _StubUser) -> FastAPI:
+    app = FastAPI()
+    register_onyx_exception_handlers(app)
+    app.include_router(cost_override_router)
+    app.dependency_overrides[get_session] = lambda: db_session
+    app.dependency_overrides[current_user] = lambda: user
+    return app
+
+
+def test_upsert_creates_then_updates_and_lists(db_session: Session) -> None:
+    client = TestClient(_make_app(db_session, _ADMIN))
+
+    create = client.put(
+        "/admin/cost-overrides",
+        json={
+            "model": "gpt-4o",
+            "input_cost_per_mtok": 2.5,
+            "output_cost_per_mtok": 10.0,
+        },
+    )
+    assert create.status_code == 200
+    assert create.json()["input_cost_per_mtok"] == 2.5
+
+    # Same model again updates in place rather than duplicating.
+    update = client.put(
+        "/admin/cost-overrides",
+        json={
+            "model": "gpt-4o",
+            "input_cost_per_mtok": 1.0,
+            "output_cost_per_mtok": 4.0,
+        },
+    )
+    assert update.status_code == 200
+    assert update.json()["output_cost_per_mtok"] == 4.0
+
+    listing = client.get("/admin/cost-overrides")
+    assert listing.status_code == 200
+    rows = listing.json()
+    assert len(rows) == 1
+    assert rows[0]["model"] == "gpt-4o"
+    assert rows[0]["input_cost_per_mtok"] == 1.0
+
+
+def test_delete_removes_then_404(db_session: Session) -> None:
+    client = TestClient(_make_app(db_session, _ADMIN))
+    client.put(
+        "/admin/cost-overrides",
+        json={
+            "model": "claude-haiku-4-5",
+            "input_cost_per_mtok": 0.8,
+            "output_cost_per_mtok": 4.0,
+        },
+    )
+
+    deleted = client.delete("/admin/cost-overrides/claude-haiku-4-5")
+    assert deleted.status_code == 200
+    assert client.get("/admin/cost-overrides").json() == []
+
+    missing = client.delete("/admin/cost-overrides/claude-haiku-4-5")
+    assert missing.status_code == 404
+    assert missing.json()["error_code"] == "NOT_FOUND"
+
+
+def test_non_admin_rejected(db_session: Session) -> None:
+    client = TestClient(_make_app(db_session, _NON_ADMIN))
+    resp = client.put(
+        "/admin/cost-overrides",
+        json={
+            "model": "gpt-4o",
+            "input_cost_per_mtok": 2.5,
+            "output_cost_per_mtok": 10.0,
+        },
+    )
+    assert resp.status_code == 403
+    assert resp.json()["error_code"] == "INSUFFICIENT_PERMISSIONS"
+
+
+def test_writes_invalidate_cache(
+    db_session: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[int] = []
+    monkeypatch.setattr(
+        "onyx.server.features.usage.api.invalidate_override_cache",
+        lambda: calls.append(1),
+    )
+    client = TestClient(_make_app(db_session, _ADMIN))
+
+    client.put(
+        "/admin/cost-overrides",
+        json={
+            "model": "gpt-4o",
+            "input_cost_per_mtok": 2.5,
+            "output_cost_per_mtok": 10.0,
+        },
+    )
+    assert len(calls) == 1
+
+    client.delete("/admin/cost-overrides/gpt-4o")
+    assert len(calls) == 2
+
+
+def test_db_helpers_upsert_list_delete(
+    db_session: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        cost_overrides, "get_current_tenant_id", lambda: "public", raising=False
+    )
+
+    upsert_override(db_session, "gpt-4o", 2.5, 10.0)
+    upsert_override(db_session, "claude-haiku-4-5", 0.8, 4.0)
+    upsert_override(db_session, "gpt-4o", 1.0, 4.0)  # update, not insert
+
+    rows = list_overrides(db_session)
+    assert [r.model for r in rows] == ["claude-haiku-4-5", "gpt-4o"]  # name-ordered
+    gpt = next(r for r in rows if r.model == "gpt-4o")
+    assert gpt.input_cost_per_mtok == 1.0
+
+    assert delete_override(db_session, "gpt-4o") is True
+    assert delete_override(db_session, "gpt-4o") is False
+    assert [r.model for r in list_overrides(db_session)] == ["claude-haiku-4-5"]
+
+
+def test_negative_rate_rejected_by_api(db_session: Session) -> None:
+    # A negative rate would credit usage and corrupt budgets; the request model
+    # enforces ge=0, so the endpoint rejects it before any write.
+    client = TestClient(_make_app(db_session, _ADMIN))
+    res = client.put(
+        "/admin/cost-overrides",
+        json={
+            "model": "gpt-4o",
+            "input_cost_per_mtok": -1.0,
+            "output_cost_per_mtok": 4.0,
+        },
+    )
+    assert res.status_code == 422
+    assert list_overrides(db_session) == []
+
+
+def test_db_helper_rejects_negative_rate(db_session: Session) -> None:
+    with pytest.raises(ValueError):
+        upsert_override(db_session, "gpt-4o", -1.0, 4.0)

--- a/backend/tests/unit/onyx/server/features/usage/test_user_usage_api.py
+++ b/backend/tests/unit/onyx/server/features/usage/test_user_usage_api.py
@@ -1,0 +1,288 @@
+"""Self-service /user/usage: returns only the caller's rows, aggregates per
+day x model, sums the current-window cost, leaves budget fields null, and
+prices the tenant default chat model (override-aware, nulls for unknown).
+
+Also unit-tests get_model_price_per_million directly."""
+
+import datetime
+from collections.abc import Generator
+from typing import cast
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy import Table
+from sqlalchemy.dialects.postgresql import JSONB as PGJSONB
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.orm import Session
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from onyx.auth.users import current_user
+from onyx.db.engine.sql_engine import get_session
+from onyx.db.models import ModelCostOverride
+from onyx.db.models import TokenRateLimit
+from onyx.db.models import TokenRateLimit__UserGroup
+from onyx.db.models import User__UserGroup
+from onyx.db.models import UserUsage
+from onyx.db.user_usage import record_user_usage
+from onyx.error_handling.exceptions import register_onyx_exception_handlers
+from onyx.llm import cost_overrides
+from onyx.llm.cost import get_model_price_per_million
+from onyx.server.features.usage.api import user_usage_router
+
+
+@compiles(PGUUID, "sqlite")
+def _compile_pguuid_sqlite(_element: object, _compiler: object, **_kw: object) -> str:
+    return "CHAR(36)"
+
+
+@compiles(PGJSONB, "sqlite")
+def _compile_jsonb_sqlite(_element: object, _compiler: object, **_kw: object) -> str:
+    return "JSON"
+
+
+class _StubUser:
+    def __init__(self, user_id: str) -> None:
+        self.id = user_id
+
+
+@pytest.fixture
+def db_session() -> Generator[Session, None, None]:
+    engine: Engine = create_engine(
+        "sqlite://", poolclass=StaticPool, connect_args={"check_same_thread": False}
+    )
+    for model in (
+        UserUsage,
+        ModelCostOverride,
+        TokenRateLimit,
+        User__UserGroup,
+        TokenRateLimit__UserGroup,
+    ):
+        cast(Table, model.__table__).create(bind=engine)
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def _make_app(db_session: Session, user: _StubUser) -> FastAPI:
+    app = FastAPI()
+    register_onyx_exception_handlers(app)
+    app.include_router(user_usage_router)
+    app.dependency_overrides[get_session] = lambda: db_session
+    app.dependency_overrides[current_user] = lambda: user
+    return app
+
+
+class _StubProvider:
+    def __init__(self, provider: str | None) -> None:
+        self.provider = provider
+
+
+class _StubModelConfig:
+    def __init__(self, name: str, provider: str | None) -> None:
+        self.name = name
+        self.llm_provider = _StubProvider(provider)
+
+
+def _seed_current_window(db_session: Session, user_id: str) -> datetime.datetime:
+    """Record one row in the live window so window_cost_cents is non-zero, and
+    return that window_start."""
+    from onyx.db.user_usage import get_window_start
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    from onyx.server.features.usage.api import _PERIOD_HOURS
+
+    window = get_window_start(now, _PERIOD_HOURS)
+    record_user_usage(
+        db_session, user_id, "gpt-4o", "CHAT", "openai", 100, 50, 0, 1.25, window
+    )
+    return window
+
+
+def test_returns_only_callers_rows_and_aggregates(
+    db_session: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    caller = str(uuid4())
+    other = str(uuid4())
+    window = _seed_current_window(db_session, caller)
+    # Same window, distinct model -> second per-day row for the caller.
+    record_user_usage(
+        db_session, caller, "claude-3", "CHAT", "anthropic", 200, 60, 5, 2.0, window
+    )
+    # Another user's usage must never surface.
+    record_user_usage(
+        db_session, other, "gpt-4o", "CHAT", "openai", 999, 999, 0, 99.0, window
+    )
+
+    monkeypatch.setattr(
+        "onyx.server.features.usage.api.fetch_default_llm_model", lambda _db: None
+    )
+    client = TestClient(_make_app(db_session, _StubUser(caller)))
+    resp = client.get("/user/usage")
+    assert resp.status_code == 200
+    body = resp.json()
+
+    models = {r["model"]: r for r in body["per_day_by_model"]}
+    assert set(models) == {"gpt-4o", "claude-3"}
+    assert models["gpt-4o"]["input_tokens"] == 100
+    assert models["claude-3"]["output_tokens"] == 60
+    assert models["claude-3"]["cache_read_tokens"] == 5
+    # No row leaks the other user's 999s.
+    assert all(r["input_tokens"] != 999 for r in body["per_day_by_model"])
+
+    assert body["window_cost_cents"] == pytest.approx(3.25)  # 1.25 + 2.0
+    assert body["budget_cents"] is None
+    assert body["budget_remaining_cents"] is None
+    assert body["selected_model_price"] is None
+
+
+def test_selected_model_price_known_model(
+    db_session: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    caller = str(uuid4())
+    _seed_current_window(db_session, caller)
+    monkeypatch.setattr(cost_overrides, "get_current_tenant_id", lambda: "public")
+    cost_overrides.invalidate_override_cache()  # no override; price from litellm
+    monkeypatch.setattr(
+        "onyx.server.features.usage.api.fetch_default_llm_model",
+        lambda _db: _StubModelConfig("gpt-4o", "openai"),
+    )
+
+    client = TestClient(_make_app(db_session, _StubUser(caller)))
+    price = client.get("/user/usage").json()["selected_model_price"]
+    assert price["model"] == "gpt-4o"
+    assert price["provider"] == "openai"
+    # litellm prices gpt-4o at $2.50 in / $10.00 out per 1M.
+    assert price["input_per_mtok"] == pytest.approx(2.5)
+    assert price["output_per_mtok"] == pytest.approx(10.0)
+
+
+def test_selected_model_price_unknown_model_nulls(
+    db_session: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    caller = str(uuid4())
+    _seed_current_window(db_session, caller)
+    monkeypatch.setattr(cost_overrides, "get_current_tenant_id", lambda: "public")
+    monkeypatch.setattr(
+        "onyx.server.features.usage.api.fetch_default_llm_model",
+        lambda _db: _StubModelConfig("totally-unknown-model-xyz", None),
+    )
+
+    client = TestClient(_make_app(db_session, _StubUser(caller)))
+    # An unpriced model surfaces no price block (None), so the UI shows
+    # "price unavailable" rather than a $null that would crash .toFixed().
+    price = client.get("/user/usage").json()["selected_model_price"]
+    assert price is None
+
+
+class TestGetModelPricePerMillion:
+    def test_override_beats_litellm(
+        self, db_session: Session, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(cost_overrides, "get_current_tenant_id", lambda: "public")
+        cost_overrides.upsert_override(db_session, "gpt-4o", 1.0, 4.0)
+        cost_overrides.invalidate_override_cache()
+
+        in_price, out_price = get_model_price_per_million(
+            "gpt-4o", "openai", db_session
+        )
+        assert in_price == pytest.approx(1.0)
+        assert out_price == pytest.approx(4.0)
+
+    def test_litellm_fallback_when_no_override(
+        self, db_session: Session, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(cost_overrides, "get_current_tenant_id", lambda: "public")
+        # Cache is a process-global keyed by tenant; drop any leak from a sibling test.
+        cost_overrides.invalidate_override_cache()
+        in_price, out_price = get_model_price_per_million(
+            "gpt-4o", "openai", db_session
+        )
+        assert in_price == pytest.approx(2.5)
+        assert out_price == pytest.approx(10.0)
+
+    def test_unknown_model_nulls(self) -> None:
+        assert get_model_price_per_million("totally-unknown-model-xyz", None) == (
+            None,
+            None,
+        )
+
+    def test_never_raises_on_lookup_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _boom(*_a: object, **_k: object) -> None:
+            raise RuntimeError("litellm exploded")
+
+        import litellm
+
+        monkeypatch.setattr(litellm, "get_model_info", _boom)
+        assert get_model_price_per_million("gpt-4o", "openai") == (None, None)
+
+
+def test_budget_reflects_user_cost_limit(
+    db_session: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A per-user cost limit surfaces as budget + remaining in /user/usage.
+    from onyx.db.models import TokenRateLimitScope
+
+    caller = str(uuid4())
+    _seed_current_window(db_session, caller)  # records 1.25c of cost
+    db_session.add(
+        TokenRateLimit(
+            enabled=True,
+            token_budget=None,
+            cost_budget_cents=100.0,
+            period_hours=168,
+            scope=TokenRateLimitScope.USER,
+        )
+    )
+    db_session.commit()
+    monkeypatch.setattr(
+        "onyx.server.features.usage.api.fetch_default_llm_model", lambda _db: None
+    )
+
+    body = (
+        TestClient(_make_app(db_session, _StubUser(caller))).get("/user/usage").json()
+    )
+    assert body["budget_cents"] == pytest.approx(100.0)
+    assert body["budget_remaining_cents"] == pytest.approx(98.75)  # 100 - 1.25
+
+
+def test_budget_reflects_group_cost_limit(
+    db_session: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A group cost limit the user belongs to surfaces in /user/usage, mirroring
+    # how the gate enforces group cost budgets.
+    from onyx.db.models import TokenRateLimitScope
+
+    caller = str(uuid4())
+    _seed_current_window(db_session, caller)  # records 1.25c of cost
+    limit = TokenRateLimit(
+        enabled=True,
+        token_budget=None,
+        cost_budget_cents=100.0,
+        period_hours=168,
+        scope=TokenRateLimitScope.USER_GROUP,
+    )
+    db_session.add(limit)
+    db_session.flush()
+    db_session.add(User__UserGroup(user_id=caller, user_group_id=1))
+    db_session.add(TokenRateLimit__UserGroup(rate_limit_id=limit.id, user_group_id=1))
+    db_session.commit()
+    monkeypatch.setattr(
+        "onyx.server.features.usage.api.fetch_default_llm_model", lambda _db: None
+    )
+
+    body = (
+        TestClient(_make_app(db_session, _StubUser(caller))).get("/user/usage").json()
+    )
+    assert body["budget_cents"] == pytest.approx(100.0)
+    assert body["budget_remaining_cents"] == pytest.approx(98.75)  # 100 - 1.25

--- a/backend/tests/unit/onyx/server/features/usage/test_user_usage_api.py
+++ b/backend/tests/unit/onyx/server/features/usage/test_user_usage_api.py
@@ -81,6 +81,17 @@ def _make_app(db_session: Session, user: _StubUser) -> FastAPI:
     return app
 
 
+@pytest.fixture(autouse=True)
+def _no_configured_providers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default to no configured providers so the all-models price loop is a
+    no-op (the LLM-provider tables aren't created on the sqlite test DB). Tests
+    exercising available_model_prices override this."""
+    monkeypatch.setattr(
+        "onyx.server.features.usage.api.fetch_existing_llm_providers",
+        lambda *_a, **_k: [],
+    )
+
+
 class _StubProvider:
     def __init__(self, provider: str | None) -> None:
         self.provider = provider
@@ -90,6 +101,17 @@ class _StubModelConfig:
     def __init__(self, name: str, provider: str | None) -> None:
         self.name = name
         self.llm_provider = _StubProvider(provider)
+
+
+class _StubMC:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _StubProviderWithModels:
+    def __init__(self, provider: str | None, model_names: list[str]) -> None:
+        self.provider = provider
+        self.model_configurations = [_StubMC(n) for n in model_names]
 
 
 def _seed_current_window(db_session: Session, user_id: str) -> datetime.datetime:
@@ -254,6 +276,36 @@ def test_budget_reflects_user_cost_limit(
     )
     assert body["budget_cents"] == pytest.approx(100.0)
     assert body["budget_remaining_cents"] == pytest.approx(98.75)  # 100 - 1.25
+
+
+def test_available_model_prices_lists_priced_models(
+    db_session: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """available_model_prices prices every configured model (override/litellm),
+    skips unpriced ones, and carries the cache field."""
+    caller = str(uuid4())
+    _seed_current_window(db_session, caller)
+    monkeypatch.setattr(cost_overrides, "get_current_tenant_id", lambda: "public")
+    cost_overrides.invalidate_override_cache()
+    monkeypatch.setattr(
+        "onyx.server.features.usage.api.fetch_default_llm_model", lambda _db: None
+    )
+    monkeypatch.setattr(
+        "onyx.server.features.usage.api.fetch_existing_llm_providers",
+        lambda *_a, **_k: [
+            _StubProviderWithModels("openai", ["gpt-4o", "totally-unknown-model-xyz"])
+        ],
+    )
+
+    body = (
+        TestClient(_make_app(db_session, _StubUser(caller))).get("/user/usage").json()
+    )
+    prices = {p["model"]: p for p in body["available_model_prices"]}
+    assert prices["gpt-4o"]["input_per_mtok"] == pytest.approx(2.5)
+    assert prices["gpt-4o"]["output_per_mtok"] == pytest.approx(10.0)
+    assert "cache_per_mtok" in prices["gpt-4o"]
+    # An unpriced model is skipped, not surfaced with null prices.
+    assert "totally-unknown-model-xyz" not in prices
 
 
 def test_budget_reflects_group_cost_limit(

--- a/backend/tests/unit/onyx/server/features/usage/test_user_usage_api.py
+++ b/backend/tests/unit/onyx/server/features/usage/test_user_usage_api.py
@@ -98,9 +98,9 @@ def _seed_current_window(db_session: Session, user_id: str) -> datetime.datetime
     from onyx.db.user_usage import get_window_start
 
     now = datetime.datetime.now(datetime.timezone.utc)
-    from onyx.server.features.usage.api import _PERIOD_HOURS
+    from onyx.db.user_usage import USAGE_PERIOD_HOURS
 
-    window = get_window_start(now, _PERIOD_HOURS)
+    window = get_window_start(now, USAGE_PERIOD_HOURS)
     record_user_usage(
         db_session, user_id, "gpt-4o", "CHAT", "openai", 100, 50, 0, 1.25, window
     )

--- a/backend/tests/unit/onyx/server/query_and_chat/test_token_limit.py
+++ b/backend/tests/unit/onyx/server/query_and_chat/test_token_limit.py
@@ -18,6 +18,7 @@ from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.orm import Session
 from sqlalchemy.orm import sessionmaker
 
+import ee.onyx.server.query_and_chat.token_limit as ee_token_limit
 import onyx.server.query_and_chat.token_limit as token_limit
 from onyx.db.models import TokenRateLimit
 from onyx.db.models import TokenRateLimitScope
@@ -235,7 +236,7 @@ def _cost_limit(
     cost_budget_cents: float | None,
     scope: TokenRateLimitScope,
     period_hours: int = 1,
-    token_budget: int = 10**12,  # effectively unbounded so only cost can trigger
+    token_budget: int | None = 10**12,  # default unbounded; None = cost-only
 ) -> TokenRateLimit:
     limit = TokenRateLimit(
         enabled=True,
@@ -456,6 +457,233 @@ class TestCostEnforcementRealLedgerPath:
         monkeypatch.setattr(token_limit, "_fetch_global_usage", lambda *_: _usage(1))
 
         token_limit._user_is_rate_limited_by_global()  # no raise
+
+
+# ---------------------------------------------------------------------------
+# EE per-user and per-group gates. These are the scopes the original code never
+# enforced cost on (a User/Group cost budget was silently a no-op). Data sources
+# are stubbed; the real gate logic runs.
+# ---------------------------------------------------------------------------
+
+
+def _stub_user_sources(
+    monkeypatch: pytest.MonkeyPatch,
+    limits: list[TokenRateLimit],
+    token_usage: list[tuple[datetime.datetime, int]],
+    cost_buckets: list[tuple[datetime.datetime, float]],
+) -> None:
+    monkeypatch.setattr(
+        ee_token_limit, "get_session_with_current_tenant", lambda: _SessionCtx()
+    )
+    monkeypatch.setattr(
+        ee_token_limit, "fetch_all_user_token_rate_limits", lambda **_: limits
+    )
+    monkeypatch.setattr(ee_token_limit, "_fetch_user_usage", lambda *_: token_usage)
+    monkeypatch.setattr(
+        ee_token_limit, "get_user_cost_cents_buckets_since", lambda *_: cost_buckets
+    )
+
+
+class TestUserGateEE:
+    """The per-user gate must enforce BOTH token and cost budgets. The cost half
+    was previously unenforced, so a per-user cost budget did nothing."""
+
+    def test_user_over_cost_budget_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import uuid
+
+        limit = _cost_limit(500.0, TokenRateLimitScope.USER, period_hours=2)
+        _stub_user_sources(monkeypatch, [limit], _usage(1), _recent_cost_buckets(600.0))
+        with pytest.raises(OnyxError) as ei:
+            ee_token_limit._user_is_rate_limited(uuid.uuid4())
+        _assert_structured_429(ei.value, "your account", 2)
+
+    def test_user_under_cost_budget_does_not_raise(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import uuid
+
+        limit = _cost_limit(500.0, TokenRateLimitScope.USER)
+        _stub_user_sources(monkeypatch, [limit], _usage(1), _recent_cost_buckets(100.0))
+        ee_token_limit._user_is_rate_limited(uuid.uuid4())  # no raise
+
+    def test_user_over_token_budget_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import uuid
+
+        limit = _make_limit(token_budget=1)  # 1,000 tokens
+        limit.scope = TokenRateLimitScope.USER
+        limit.period_hours = 5
+        _stub_user_sources(monkeypatch, [limit], _usage(2_000), [])
+        with pytest.raises(OnyxError) as ei:
+            ee_token_limit._user_is_rate_limited(uuid.uuid4())
+        _assert_structured_429(ei.value, "your account", 5)
+
+    def test_cost_only_user_limit_skips_token_query(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import uuid
+
+        cost_only = TokenRateLimit(
+            enabled=True,
+            token_budget=None,
+            cost_budget_cents=500.0,
+            period_hours=1,
+            scope=TokenRateLimitScope.USER,
+        )
+        monkeypatch.setattr(
+            ee_token_limit, "get_session_with_current_tenant", lambda: _SessionCtx()
+        )
+        monkeypatch.setattr(
+            ee_token_limit, "fetch_all_user_token_rate_limits", lambda **_: [cost_only]
+        )
+
+        def _boom(*_a: object) -> object:
+            raise AssertionError("token aggregation ran for a cost-only user limit")
+
+        monkeypatch.setattr(ee_token_limit, "_fetch_user_usage", _boom)
+        monkeypatch.setattr(
+            ee_token_limit,
+            "get_user_cost_cents_buckets_since",
+            lambda *_: _recent_cost_buckets(100.0),
+        )
+        ee_token_limit._user_is_rate_limited(uuid.uuid4())  # no raise, no token query
+
+
+def _stub_group_sources(
+    monkeypatch: pytest.MonkeyPatch,
+    group_limits: dict[int, list[TokenRateLimit]],
+    group_token_usage: dict[int, list[tuple[datetime.datetime, int]]],
+    group_cost_buckets: dict[int, list[tuple[datetime.datetime, float]]],
+) -> None:
+    monkeypatch.setattr(
+        ee_token_limit, "get_session_with_current_tenant", lambda: _SessionCtx()
+    )
+    monkeypatch.setattr(
+        ee_token_limit, "_fetch_all_user_group_rate_limits", lambda *_: group_limits
+    )
+    monkeypatch.setattr(
+        ee_token_limit, "_fetch_user_group_usage", lambda *_: group_token_usage
+    )
+    monkeypatch.setattr(
+        ee_token_limit,
+        "get_group_cost_cents_buckets_since",
+        lambda *_: group_cost_buckets,
+    )
+
+
+class TestGroupGateEE:
+    """The per-group gate must enforce cost too, while keeping the 'allowed if
+    ANY of the user's groups is under budget' semantics."""
+
+    def test_group_over_cost_budget_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import uuid
+
+        limit = _cost_limit(500.0, TokenRateLimitScope.USER_GROUP, period_hours=4)
+        _stub_group_sources(
+            monkeypatch, {1: [limit]}, {1: _usage(1)}, {1: _recent_cost_buckets(600.0)}
+        )
+        with pytest.raises(OnyxError) as ei:
+            ee_token_limit._user_is_rate_limited_by_group(uuid.uuid4())
+        _assert_structured_429(ei.value, "your group", 4)
+
+    def test_user_allowed_when_one_group_under_budget(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import uuid
+
+        over = _cost_limit(100.0, TokenRateLimitScope.USER_GROUP)
+        under = _cost_limit(100.0, TokenRateLimitScope.USER_GROUP)
+        _stub_group_sources(
+            monkeypatch,
+            {1: [over], 2: [under]},
+            {1: _usage(1), 2: _usage(1)},
+            {1: _recent_cost_buckets(600.0), 2: _recent_cost_buckets(10.0)},
+        )
+        # group 2 is under budget -> user allowed despite group 1 being over
+        ee_token_limit._user_is_rate_limited_by_group(uuid.uuid4())  # no raise
+
+    def test_all_groups_over_budget_raises_longest_window(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import uuid
+
+        g1 = _cost_limit(100.0, TokenRateLimitScope.USER_GROUP, period_hours=1)
+        g2 = _cost_limit(100.0, TokenRateLimitScope.USER_GROUP, period_hours=6)
+        _stub_group_sources(
+            monkeypatch,
+            {1: [g1], 2: [g2]},
+            {1: _usage(1), 2: _usage(1)},
+            {1: _recent_cost_buckets(600.0), 2: _recent_cost_buckets(600.0)},
+        )
+        with pytest.raises(OnyxError) as ei:
+            ee_token_limit._user_is_rate_limited_by_group(uuid.uuid4())
+        _assert_structured_429(ei.value, "your group", 6)
+
+
+class TestUserCostEnforcementRealLedgerPath:
+    """The per-user cost gate end-to-end through the real UserUsage ledger —
+    guards get_user_cost_cents_buckets_since and the wiring that was missing
+    (a per-user cost budget previously did nothing)."""
+
+    def test_user_over_cost_blocks_against_real_ledger(
+        self, monkeypatch: pytest.MonkeyPatch, ledger_session: Session
+    ) -> None:
+        import uuid
+
+        uid = uuid.uuid4()
+        now = datetime.datetime.now(tz=datetime.timezone.utc)
+        ledger_window = get_window_start(now, period_hours=168)
+        record_user_usage(
+            ledger_session, str(uid), "m", "CHAT", None, 1, 1, 0, 500.0, ledger_window
+        )
+
+        limit = _cost_limit(
+            100.0, TokenRateLimitScope.USER, period_hours=24, token_budget=None
+        )
+        monkeypatch.setattr(
+            ee_token_limit,
+            "get_session_with_current_tenant",
+            lambda: _RealLedgerSessionCtx(ledger_session),
+        )
+        monkeypatch.setattr(
+            ee_token_limit, "fetch_all_user_token_rate_limits", lambda **_: [limit]
+        )
+        # cost-only path: the token scan must be skipped, so no ChatMessage query.
+        with pytest.raises(OnyxError) as ei:
+            ee_token_limit._user_is_rate_limited(uid)
+        _assert_structured_429(ei.value, "your account", 24)
+
+    def test_other_users_spend_not_counted(
+        self, monkeypatch: pytest.MonkeyPatch, ledger_session: Session
+    ) -> None:
+        # A different user's spend must NOT count against this user's budget —
+        # the new bucket helper filters by user_id.
+        import uuid
+
+        me, other = uuid.uuid4(), uuid.uuid4()
+        now = datetime.datetime.now(tz=datetime.timezone.utc)
+        win = get_window_start(now, period_hours=168)
+        record_user_usage(
+            ledger_session, str(other), "m", "CHAT", None, 1, 1, 0, 9999.0, win
+        )
+
+        limit = _cost_limit(
+            100.0, TokenRateLimitScope.USER, period_hours=24, token_budget=None
+        )
+        monkeypatch.setattr(
+            ee_token_limit,
+            "get_session_with_current_tenant",
+            lambda: _RealLedgerSessionCtx(ledger_session),
+        )
+        monkeypatch.setattr(
+            ee_token_limit, "fetch_all_user_token_rate_limits", lambda **_: [limit]
+        )
+        ee_token_limit._user_is_rate_limited(me)  # no raise — other user's spend
 
 
 class TestTokenRateLimitArgsValidation:

--- a/backend/tests/unit/onyx/server/query_and_chat/test_token_limit.py
+++ b/backend/tests/unit/onyx/server/query_and_chat/test_token_limit.py
@@ -247,13 +247,18 @@ def _cost_limit(
     return limit
 
 
+def _recent_cost_buckets(total: float) -> list[tuple[datetime.datetime, float]]:
+    """A single just-now cost bucket, so it lands inside any limit's window."""
+    return [(datetime.datetime.now(datetime.timezone.utc), total)]
+
+
 class TestWorstTriggeredCostLimit:
-    """Unit of the shared cost evaluator (no DB; cost is injected)."""
+    """Unit of the shared cost evaluator (no DB; cost buckets are injected)."""
 
     def test_over_cost_budget_returns_row(self) -> None:
         limit = _cost_limit(100.0, TokenRateLimitScope.USER)
         triggered = token_limit._worst_triggered_cost_limit(
-            [limit], cost_since=lambda _cutoff: 150.0
+            [limit], _recent_cost_buckets(150.0)
         )
         assert triggered is limit
 
@@ -261,7 +266,7 @@ class TestWorstTriggeredCostLimit:
         limit = _cost_limit(100.0, TokenRateLimitScope.USER)
         assert (
             token_limit._worst_triggered_cost_limit(
-                [limit], cost_since=lambda _cutoff: 99.99
+                [limit], _recent_cost_buckets(99.99)
             )
             is None
         )
@@ -270,7 +275,7 @@ class TestWorstTriggeredCostLimit:
         limit = _cost_limit(100.0, TokenRateLimitScope.USER)
         assert (
             token_limit._worst_triggered_cost_limit(
-                [limit], cost_since=lambda _cutoff: 100.0
+                [limit], _recent_cost_buckets(100.0)
             )
             is limit
         )
@@ -280,7 +285,7 @@ class TestWorstTriggeredCostLimit:
         limit = _cost_limit(None, TokenRateLimitScope.USER)
         assert (
             token_limit._worst_triggered_cost_limit(
-                [limit], cost_since=lambda _cutoff: 10**9
+                [limit], _recent_cost_buckets(10**9)
             )
             is None
         )
@@ -299,7 +304,11 @@ class TestGlobalCostRejectionPath:
         )
         # under token budget so only cost can trigger
         monkeypatch.setattr(token_limit, "_fetch_global_usage", lambda *_: _usage(1))
-        monkeypatch.setattr(token_limit, "get_total_cost_cents_since", lambda *_: 600.0)
+        monkeypatch.setattr(
+            token_limit,
+            "get_total_cost_cents_buckets_since",
+            lambda *_: _recent_cost_buckets(600.0),
+        )
 
         with pytest.raises(OnyxError) as ei:
             token_limit._user_is_rate_limited_by_global()
@@ -316,7 +325,11 @@ class TestGlobalCostRejectionPath:
             token_limit, "fetch_all_global_token_rate_limits", lambda **_: [limit]
         )
         monkeypatch.setattr(token_limit, "_fetch_global_usage", lambda *_: _usage(1))
-        monkeypatch.setattr(token_limit, "get_total_cost_cents_since", lambda *_: 100.0)
+        monkeypatch.setattr(
+            token_limit,
+            "get_total_cost_cents_buckets_since",
+            lambda *_: _recent_cost_buckets(100.0),
+        )
 
         token_limit._user_is_rate_limited_by_global()  # no raise
 
@@ -342,7 +355,11 @@ class TestGlobalCostRejectionPath:
             raise AssertionError("token aggregation ran for a cost-only limit")
 
         monkeypatch.setattr(token_limit, "_fetch_global_usage", _boom)
-        monkeypatch.setattr(token_limit, "get_total_cost_cents_since", lambda *_: 100.0)
+        monkeypatch.setattr(
+            token_limit,
+            "get_total_cost_cents_buckets_since",
+            lambda *_: _recent_cost_buckets(100.0),
+        )
 
         token_limit._user_is_rate_limited_by_global()  # no raise, no token query
 

--- a/backend/tests/unit/onyx/server/query_and_chat/test_token_limit.py
+++ b/backend/tests/unit/onyx/server/query_and_chat/test_token_limit.py
@@ -1,0 +1,465 @@
+"""Unit tests for token-rate-limit enforcement (in-memory SQLite).
+
+Guards the admin-facing unit: a stored ``token_budget`` of N is in thousands,
+so it enforces at N * 1000 tokens (the Onyx convention).
+"""
+
+import datetime
+from collections.abc import Generator
+from typing import cast
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy import Table
+from sqlalchemy.dialects.postgresql import JSONB as PGJSONB
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.orm import Session
+from sqlalchemy.orm import sessionmaker
+
+import onyx.server.query_and_chat.token_limit as token_limit
+from onyx.db.models import TokenRateLimit
+from onyx.db.models import TokenRateLimitScope
+from onyx.db.models import UserUsage
+from onyx.db.user_usage import get_window_start
+from onyx.db.user_usage import record_user_usage
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.query_and_chat.token_limit import _worst_triggered_limit
+
+
+def _is_rate_limited(
+    rate_limits: list[TokenRateLimit],
+    usage: list[tuple[datetime.datetime, int]],
+) -> bool:
+    return _worst_triggered_limit(rate_limits, usage) is not None
+
+
+# Postgres-only column types -> SQLite equivalents so the real UserUsage table
+# can back the real cost-source query path.
+@compiles(PGUUID, "sqlite")
+def _compile_pguuid_sqlite(_e: object, _c: object, **_kw: object) -> str:
+    return "CHAR(36)"
+
+
+@compiles(PGJSONB, "sqlite")
+def _compile_jsonb_sqlite(_e: object, _c: object, **_kw: object) -> str:
+    return "JSON"
+
+
+@pytest.fixture
+def db_session() -> Generator[Session, None, None]:
+    engine: Engine = create_engine("sqlite://")
+    # Only the table under test; user-group FK is not exercised here.
+    cast(Table, TokenRateLimit.__table__).create(bind=engine)
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def _make_limit(token_budget: int) -> TokenRateLimit:
+    return TokenRateLimit(
+        enabled=True,
+        token_budget=token_budget,
+        period_hours=1,
+        scope=TokenRateLimitScope.GLOBAL,
+    )
+
+
+def _usage(token_count: int) -> list[tuple[datetime.datetime, int]]:
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    return [(now, token_count)]
+
+
+class TestIsRateLimitedUnit:
+    def test_budget_is_in_thousands(self) -> None:
+        # token_budget=12 means 12,000 tokens (the Onyx thousands convention).
+        limit = _make_limit(token_budget=12)
+        assert _is_rate_limited([limit], _usage(11_999)) is False
+        assert _is_rate_limited([limit], _usage(12_000)) is True
+        assert _is_rate_limited([limit], _usage(12_001)) is True
+
+    def test_below_budget_not_limited(self) -> None:
+        limit = _make_limit(token_budget=1000)  # 1,000,000 tokens
+        assert _is_rate_limited([limit], _usage(999_999)) is False
+
+    def test_at_budget_is_limited(self) -> None:
+        limit = _make_limit(token_budget=1000)  # 1,000,000 tokens
+        assert _is_rate_limited([limit], _usage(1_000_000)) is True
+
+    def test_cost_only_limit_is_token_exempt(self) -> None:
+        # A cost-only limit (token_budget=None) must NOT block on tokens — a 0
+        # would make tokens_used >= 0 always true and block every request.
+        cost_only = TokenRateLimit(
+            enabled=True,
+            token_budget=None,
+            cost_budget_cents=500.0,
+            period_hours=1,
+            scope=TokenRateLimitScope.GLOBAL,
+        )
+        assert _is_rate_limited([cost_only], _usage(10_000_000)) is False
+
+    def test_zero_token_budget_does_not_block(self) -> None:
+        # A legacy/edge token_budget of 0 must be treated as no token limit, not
+        # "block at 0 tokens" (which would reject every request).
+        zero = TokenRateLimit(
+            enabled=True,
+            token_budget=0,
+            cost_budget_cents=500.0,
+            period_hours=1,
+            scope=TokenRateLimitScope.GLOBAL,
+        )
+        assert _is_rate_limited([zero], _usage(10_000_000)) is False
+
+    def test_longest_window_among_exceeded_wins(self) -> None:
+        # When several limits are exceeded the reset must be deterministic and
+        # conservative: report the longest window so a retry can't immediately
+        # re-trip a still-exceeded longer limit. Order must not matter.
+        short = TokenRateLimit(
+            enabled=True,
+            token_budget=1,
+            period_hours=1,
+            scope=TokenRateLimitScope.GLOBAL,
+        )
+        long_ = TokenRateLimit(
+            enabled=True,
+            token_budget=1,
+            period_hours=24,
+            scope=TokenRateLimitScope.GLOBAL,
+        )
+        for order in ([short, long_], [long_, short]):
+            worst = _worst_triggered_limit(order, _usage(10_000))
+            assert worst is not None and worst.period_hours == 24
+
+
+def _assert_structured_429(exc: OnyxError, scope: str, period_hours: int) -> None:
+    """The 429 the FE banner binds to: RATE_LIMITED + scope + reset fields + header."""
+    assert exc.error_code is OnyxErrorCode.RATE_LIMITED
+    assert exc.status_code == 429
+    assert scope in exc.detail
+
+    extra = exc.extra or {}
+    assert extra["scope"] == scope
+    assert extra["retry_after_seconds"] == period_hours * 3600
+
+    reset_at = datetime.datetime.fromisoformat(cast(str, extra["reset_at"]))
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    expected = now + datetime.timedelta(hours=period_hours)
+    # Allow a few seconds of execution slop.
+    assert abs((reset_at - expected).total_seconds()) < 60
+
+    assert exc.headers == {"Retry-After": str(period_hours * 3600)}
+
+
+class TestRaiseRateLimited:
+    def test_global_scope_shape(self) -> None:
+        with pytest.raises(OnyxError) as ei:
+            token_limit.raise_rate_limited("organization", period_hours=2)
+        _assert_structured_429(ei.value, "organization", 2)
+
+
+class TestRaiseForLongestWindow:
+    """Token + cost gates are evaluated together; the reported reset is the
+    longest window, so a short token limit can't mask a longer cost reset."""
+
+    def test_longest_of_token_and_cost_wins(self) -> None:
+        with pytest.raises(OnyxError) as ei:
+            token_limit._raise_for_longest_window("user", 1, 24)
+        _assert_structured_429(ei.value, "user", 24)
+
+    def test_skips_none_windows(self) -> None:
+        with pytest.raises(OnyxError) as ei:
+            token_limit._raise_for_longest_window("user", None, 5)
+        _assert_structured_429(ei.value, "user", 5)
+
+    def test_no_trigger_does_not_raise(self) -> None:
+        token_limit._raise_for_longest_window("user", None, None)  # no raise
+
+
+class _SessionCtx:
+    """Minimal stand-in for get_session_with_current_tenant (only the limit fetch is patched)."""
+
+    def __enter__(self) -> object:
+        return object()
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+
+class TestGlobalRejectionPath:
+    """CE path: a global limit over budget raises the structured 429."""
+
+    def test_over_global_budget_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        limit = _make_limit(token_budget=1000)
+        limit.period_hours = 3
+
+        monkeypatch.setattr(
+            token_limit, "get_session_with_current_tenant", lambda: _SessionCtx()
+        )
+        monkeypatch.setattr(
+            token_limit,
+            "fetch_all_global_token_rate_limits",
+            lambda **_: [limit],
+        )
+        # date_trunc isn't valid on SQLite; stub usage directly.
+        monkeypatch.setattr(
+            token_limit, "_fetch_global_usage", lambda *_: _usage(1_500_000)
+        )
+
+        with pytest.raises(OnyxError) as ei:
+            token_limit._user_is_rate_limited_by_global()
+        _assert_structured_429(ei.value, "organization", 3)
+
+    def test_under_global_budget_does_not_raise(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        limit = _make_limit(token_budget=1000)
+        monkeypatch.setattr(
+            token_limit, "get_session_with_current_tenant", lambda: _SessionCtx()
+        )
+        monkeypatch.setattr(
+            token_limit,
+            "fetch_all_global_token_rate_limits",
+            lambda **_: [limit],
+        )
+        monkeypatch.setattr(token_limit, "_fetch_global_usage", lambda *_: _usage(10))
+
+        token_limit._user_is_rate_limited_by_global()  # no raise
+
+
+def _cost_limit(
+    cost_budget_cents: float | None,
+    scope: TokenRateLimitScope,
+    period_hours: int = 1,
+    token_budget: int = 10**12,  # effectively unbounded so only cost can trigger
+) -> TokenRateLimit:
+    limit = TokenRateLimit(
+        enabled=True,
+        token_budget=token_budget,
+        period_hours=period_hours,
+        scope=scope,
+    )
+    limit.cost_budget_cents = cost_budget_cents
+    return limit
+
+
+class TestWorstTriggeredCostLimit:
+    """Unit of the shared cost evaluator (no DB; cost is injected)."""
+
+    def test_over_cost_budget_returns_row(self) -> None:
+        limit = _cost_limit(100.0, TokenRateLimitScope.USER)
+        triggered = token_limit._worst_triggered_cost_limit(
+            [limit], cost_since=lambda _cutoff: 150.0
+        )
+        assert triggered is limit
+
+    def test_under_cost_budget_returns_none(self) -> None:
+        limit = _cost_limit(100.0, TokenRateLimitScope.USER)
+        assert (
+            token_limit._worst_triggered_cost_limit(
+                [limit], cost_since=lambda _cutoff: 99.99
+            )
+            is None
+        )
+
+    def test_at_cost_budget_triggers(self) -> None:
+        limit = _cost_limit(100.0, TokenRateLimitScope.USER)
+        assert (
+            token_limit._worst_triggered_cost_limit(
+                [limit], cost_since=lambda _cutoff: 100.0
+            )
+            is limit
+        )
+
+    def test_row_without_cost_budget_is_exempt(self) -> None:
+        # token-only row (cost_budget_cents is None) is never cost-limited
+        limit = _cost_limit(None, TokenRateLimitScope.USER)
+        assert (
+            token_limit._worst_triggered_cost_limit(
+                [limit], cost_since=lambda _cutoff: 10**9
+            )
+            is None
+        )
+
+
+class TestGlobalCostRejectionPath:
+    """CE global path: a global cost budget summed across the tenant raises."""
+
+    def test_over_global_cost_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        limit = _cost_limit(500.0, TokenRateLimitScope.GLOBAL, period_hours=3)
+        monkeypatch.setattr(
+            token_limit, "get_session_with_current_tenant", lambda: _SessionCtx()
+        )
+        monkeypatch.setattr(
+            token_limit, "fetch_all_global_token_rate_limits", lambda **_: [limit]
+        )
+        # under token budget so only cost can trigger
+        monkeypatch.setattr(token_limit, "_fetch_global_usage", lambda *_: _usage(1))
+        monkeypatch.setattr(token_limit, "get_total_cost_cents_since", lambda *_: 600.0)
+
+        with pytest.raises(OnyxError) as ei:
+            token_limit._user_is_rate_limited_by_global()
+        _assert_structured_429(ei.value, "organization", 3)
+
+    def test_under_global_cost_does_not_raise(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        limit = _cost_limit(500.0, TokenRateLimitScope.GLOBAL)
+        monkeypatch.setattr(
+            token_limit, "get_session_with_current_tenant", lambda: _SessionCtx()
+        )
+        monkeypatch.setattr(
+            token_limit, "fetch_all_global_token_rate_limits", lambda **_: [limit]
+        )
+        monkeypatch.setattr(token_limit, "_fetch_global_usage", lambda *_: _usage(1))
+        monkeypatch.setattr(token_limit, "get_total_cost_cents_since", lambda *_: 100.0)
+
+        token_limit._user_is_rate_limited_by_global()  # no raise
+
+    def test_cost_only_skips_token_aggregation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A cost-only limit (token_budget=None) must not run the token-usage query.
+        limit = TokenRateLimit(
+            enabled=True,
+            token_budget=None,
+            cost_budget_cents=500.0,
+            period_hours=1,
+            scope=TokenRateLimitScope.GLOBAL,
+        )
+        monkeypatch.setattr(
+            token_limit, "get_session_with_current_tenant", lambda: _SessionCtx()
+        )
+        monkeypatch.setattr(
+            token_limit, "fetch_all_global_token_rate_limits", lambda **_: [limit]
+        )
+
+        def _boom(*_a: object) -> object:
+            raise AssertionError("token aggregation ran for a cost-only limit")
+
+        monkeypatch.setattr(token_limit, "_fetch_global_usage", _boom)
+        monkeypatch.setattr(token_limit, "get_total_cost_cents_since", lambda *_: 100.0)
+
+        token_limit._user_is_rate_limited_by_global()  # no raise, no token query
+
+
+class _RealLedgerSessionCtx:
+    """Yields a real SQLite session backing the actual UserUsage cost query."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def __enter__(self) -> Session:
+        return self._session
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+
+@pytest.fixture
+def ledger_session() -> Generator[Session, None, None]:
+    engine: Engine = create_engine("sqlite://")
+    cast(Table, UserUsage.__table__).create(bind=engine)
+    session = sessionmaker(bind=engine)()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+class TestCostEnforcementRealLedgerPath:
+    """The global cost gate, end-to-end through the real cost source — the
+    regression that the prior exact-window read fail-opened on a sub-grid
+    budget period."""
+
+    def test_sub_grid_period_blocks_against_real_ledger(
+        self, monkeypatch: pytest.MonkeyPatch, ledger_session: Session
+    ) -> None:
+        # Ledger row written at the weekly grid (as the real processor does),
+        # but the admin's budget period is 24h. The sliding cutoff still reads it.
+        import uuid
+
+        now = datetime.datetime.now(tz=datetime.timezone.utc)
+        ledger_window = get_window_start(now, period_hours=168)
+        record_user_usage(
+            ledger_session,
+            str(uuid.uuid4()),
+            "m",
+            "CHAT",
+            None,
+            1,
+            1,
+            0,
+            500.0,
+            ledger_window,
+        )
+
+        limit = _cost_limit(100.0, TokenRateLimitScope.GLOBAL, period_hours=24)
+        monkeypatch.setattr(
+            token_limit,
+            "get_session_with_current_tenant",
+            lambda: _RealLedgerSessionCtx(ledger_session),
+        )
+        monkeypatch.setattr(
+            token_limit, "fetch_all_global_token_rate_limits", lambda **_: [limit]
+        )
+        monkeypatch.setattr(token_limit, "_fetch_global_usage", lambda *_: _usage(1))
+
+        with pytest.raises(OnyxError) as ei:
+            token_limit._user_is_rate_limited_by_global()
+        _assert_structured_429(ei.value, "organization", 24)
+
+    def test_window_rollover_does_not_count(
+        self, monkeypatch: pytest.MonkeyPatch, ledger_session: Session
+    ) -> None:
+        import uuid
+
+        now = datetime.datetime.now(tz=datetime.timezone.utc)
+        current = get_window_start(now, period_hours=168)
+        # Two grids back: always before the (period + one-grid) relaxed cutoff,
+        # regardless of weekday. A 24h budget must not see last-period spend.
+        prior = current - datetime.timedelta(days=14)
+        record_user_usage(
+            ledger_session, str(uuid.uuid4()), "m", "CHAT", None, 1, 1, 0, 9999.0, prior
+        )
+
+        limit = _cost_limit(100.0, TokenRateLimitScope.GLOBAL, period_hours=24)
+        monkeypatch.setattr(
+            token_limit,
+            "get_session_with_current_tenant",
+            lambda: _RealLedgerSessionCtx(ledger_session),
+        )
+        monkeypatch.setattr(
+            token_limit, "fetch_all_global_token_rate_limits", lambda **_: [limit]
+        )
+        monkeypatch.setattr(token_limit, "_fetch_global_usage", lambda *_: _usage(1))
+
+        token_limit._user_is_rate_limited_by_global()  # no raise
+
+
+class TestTokenRateLimitArgsValidation:
+    """A limit must carry a token budget, a cost budget, or both — never neither."""
+
+    def test_neither_budget_rejected(self) -> None:
+        from onyx.server.token_rate_limits.models import TokenRateLimitArgs
+
+        with pytest.raises(ValueError):
+            TokenRateLimitArgs(enabled=True, token_budget=None, period_hours=24)
+
+    def test_cost_only_accepted(self) -> None:
+        from onyx.server.token_rate_limits.models import TokenRateLimitArgs
+
+        args = TokenRateLimitArgs(
+            enabled=True, token_budget=None, period_hours=24, cost_budget_cents=500.0
+        )
+        assert args.token_budget is None and args.cost_budget_cents == 500.0
+
+    def test_token_only_accepted(self) -> None:
+        from onyx.server.token_rate_limits.models import TokenRateLimitArgs
+
+        args = TokenRateLimitArgs(enabled=True, token_budget=1000, period_hours=24)
+        assert args.token_budget == 1000 and args.cost_budget_cents is None

--- a/backend/tests/unit/onyx/server/token_rate_limits/test_cost_budget_api.py
+++ b/backend/tests/unit/onyx/server/token_rate_limits/test_cost_budget_api.py
@@ -1,0 +1,89 @@
+"""Global token-rate-limit create/read round-trips cost_budget_cents (cents at
+the API boundary), and a limit may carry only a cost budget (no token budget)."""
+
+from collections.abc import Generator
+from typing import cast
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy import Table
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from onyx.auth.users import current_user
+from onyx.db.engine.sql_engine import get_session
+from onyx.db.enums import Permission
+from onyx.db.models import TokenRateLimit
+from onyx.error_handling.exceptions import register_onyx_exception_handlers
+from onyx.server.token_rate_limits.api import router as token_rate_limit_router
+
+
+class _StubUser:
+    def __init__(self, permissions: list[str]) -> None:
+        self.id = "00000000-0000-0000-0000-000000000001"
+        self.effective_permissions = permissions
+
+
+_ADMIN = _StubUser([Permission.FULL_ADMIN_PANEL_ACCESS.value])
+
+
+@pytest.fixture
+def db_session() -> Generator[Session, None, None]:
+    # StaticPool keeps the table alive across the endpoint's commit().
+    engine: Engine = create_engine(
+        "sqlite://", poolclass=StaticPool, connect_args={"check_same_thread": False}
+    )
+    cast(Table, TokenRateLimit.__table__).create(bind=engine)
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def _make_app(db_session: Session) -> FastAPI:
+    app = FastAPI()
+    register_onyx_exception_handlers(app)
+    app.include_router(token_rate_limit_router)
+    app.dependency_overrides[get_session] = lambda: db_session
+    app.dependency_overrides[current_user] = lambda: _ADMIN
+    return app
+
+
+def test_create_persists_cost_budget_and_get_returns_it(db_session: Session) -> None:
+    client = TestClient(_make_app(db_session))
+
+    created = client.post(
+        "/admin/token-rate-limits/global",
+        json={
+            "enabled": True,
+            "token_budget": 1000,
+            "period_hours": 24,
+            "cost_budget_cents": 500.0,
+        },
+    )
+    assert created.status_code == 200
+    assert created.json()["cost_budget_cents"] == 500.0
+
+    listing = client.get("/admin/token-rate-limits/global")
+    assert listing.status_code == 200
+    rows = listing.json()
+    assert len(rows) == 1
+    assert rows[0]["cost_budget_cents"] == 500.0
+    assert rows[0]["token_budget"] == 1000
+
+
+def test_cost_budget_optional_defaults_null(db_session: Session) -> None:
+    client = TestClient(_make_app(db_session))
+
+    created = client.post(
+        "/admin/token-rate-limits/global",
+        json={"enabled": True, "token_budget": 1000, "period_hours": 24},
+    )
+    assert created.status_code == 200
+    assert created.json()["cost_budget_cents"] is None

--- a/backend/tests/unit/onyx/tracing/test_tracing_setup.py
+++ b/backend/tests/unit/onyx/tracing/test_tracing_setup.py
@@ -9,11 +9,12 @@ from onyx.tracing import setup as tracing_setup
 
 
 def test_setup_tracing_with_no_creds() -> None:
-    """Test that setup_tracing returns empty list when no credentials are configured."""
+    """No external backends and usage tracking off -> empty provider list."""
     # Ensure no tracing credentials are set
     os.environ.pop("BRAINTRUST_API_KEY", None)
     os.environ.pop("LANGFUSE_SECRET_KEY", None)
     os.environ.pop("LANGFUSE_PUBLIC_KEY", None)
+    os.environ["USER_USAGE_TRACKING_ENABLED"] = "false"
 
     # Reload modules to pick up environment changes
     importlib.reload(app_configs)
@@ -22,9 +23,30 @@ def test_setup_tracing_with_no_creds() -> None:
     # Reset the initialized flag
     tracing_setup._initialized = False
 
-    # Call the function - should return empty list
-    result = tracing_setup.setup_tracing()
-    assert result == []
+    try:
+        result = tracing_setup.setup_tracing()
+        assert result == []
+    finally:
+        os.environ.pop("USER_USAGE_TRACKING_ENABLED", None)
+        importlib.reload(app_configs)
+        importlib.reload(tracing_setup)
+
+
+def test_setup_tracing_registers_user_usage_by_default() -> None:
+    """Usage tracking is on by default, independent of external backends."""
+    os.environ.pop("BRAINTRUST_API_KEY", None)
+    os.environ.pop("LANGFUSE_SECRET_KEY", None)
+    os.environ.pop("LANGFUSE_PUBLIC_KEY", None)
+    os.environ.pop("USER_USAGE_TRACKING_ENABLED", None)
+
+    importlib.reload(app_configs)
+    importlib.reload(tracing_setup)
+    tracing_setup._initialized = False
+
+    with patch.object(tracing_setup, "_setup_user_usage_tracking") as mock_setup:
+        result = tracing_setup.setup_tracing()
+        mock_setup.assert_called_once()
+        assert "user_usage" in result
 
 
 def test_setup_tracing_is_idempotent() -> None:
@@ -41,12 +63,15 @@ def test_setup_tracing_is_idempotent() -> None:
     # Reset the initialized flag
     tracing_setup._initialized = False
 
-    # First call
-    tracing_setup.setup_tracing()
+    # Patch the usage-tracking setup so the first call doesn't spawn a real
+    # recorder thread / register against the global provider.
+    with patch.object(tracing_setup, "_setup_user_usage_tracking"):
+        # First call
+        tracing_setup.setup_tracing()
 
-    # Second call should return empty (already initialized)
-    result2 = tracing_setup.setup_tracing()
-    assert result2 == []
+        # Second call should return empty (already initialized)
+        result2 = tracing_setup.setup_tracing()
+        assert result2 == []
 
     # Clean up
     tracing_setup._initialized = False

--- a/backend/tests/unit/onyx/tracing/test_user_usage_processor.py
+++ b/backend/tests/unit/onyx/tracing/test_user_usage_processor.py
@@ -231,15 +231,13 @@ def test_on_span_end_never_raises_on_internal_error(
     assert _read_rows(sqlite_engine) == []
 
 
-def test_real_pricing_excludes_cache_reads_from_input(
+def test_excludes_cache_reads_from_priced_input(
     monkeypatch: pytest.MonkeyPatch, sqlite_engine: Engine
 ) -> None:
-    # Real compute_cost_cents (NOT stubbed): the span carries the litellm prompt
-    # total (input_tokens already includes cache reads). The processor must
-    # price the non-cached remainder as input and the cache reads at the cache
-    # rate — mirrors test_cost.py::test_cache_read_tokens_priced_as_input.
-    # gpt-4o: 1000 non-cached @ $2.50/Mtok + 2000 cache-read @ $1.25/Mtok =
-    # 0.25c + 0.25c = 0.5c input; 500 output tok @ $10/Mtok = 0.5c.
+    # The span's input_tokens is the litellm prompt total (cache-inclusive). The
+    # processor must price only the non-cached remainder as input and pass cache
+    # reads separately, so compute_cost_cents can't double-charge them. Asserting
+    # the args passed to compute_cost_cents keeps this independent of live pricing.
     SessionLocal = sessionmaker(bind=sqlite_engine)
 
     from contextlib import contextmanager
@@ -253,6 +251,21 @@ def test_real_pricing_excludes_cache_reads_from_input(
             session.close()
 
     monkeypatch.setattr(proc_mod, "get_session_with_tenant", _fake_session)
+
+    priced: list[tuple[int, int, int]] = []
+
+    def _capture_cost(
+        _model: str,
+        _provider: Any,
+        input_tokens: int,
+        output_tokens: int,
+        cache_read_tokens: int = 0,
+        **_kw: Any,
+    ) -> tuple[float, float]:
+        priced.append((input_tokens, output_tokens, cache_read_tokens))
+        return (0.0, 0.0)
+
+    monkeypatch.setattr(proc_mod, "compute_cost_cents", _capture_cost)
 
     p = UserUsageTracingProcessor(flush_interval_seconds=0.05)
     try:
@@ -274,14 +287,15 @@ def test_real_pricing_excludes_cache_reads_from_input(
     finally:
         p.shutdown()
 
+    # Priced the non-cached remainder (3000 - 2000) as input; cache reads passed
+    # separately rather than folded into the input total.
+    assert priced == [(1000, 500, 2000)]
+
     rows = _read_rows(sqlite_engine)
     assert len(rows) == 1
-    row = rows[0]
     # Ledger keeps the full (cache-inclusive) input token count.
-    assert row.input_tokens == 3000
-    assert row.cache_read_tokens == 2000
-    # Cost must NOT double-charge the 2000 cache reads at the full input rate.
-    assert row.cost_cents == pytest.approx(1.0)
+    assert rows[0].input_tokens == 3000
+    assert rows[0].cache_read_tokens == 2000
 
 
 def test_flush_swallows_record_errors(

--- a/backend/tests/unit/onyx/tracing/test_user_usage_processor.py
+++ b/backend/tests/unit/onyx/tracing/test_user_usage_processor.py
@@ -1,0 +1,306 @@
+"""Unit tests for the per-user usage recording processor (in-memory SQLite)."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from typing import Any
+from typing import cast
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy import select
+from sqlalchemy import Table
+from sqlalchemy.dialects.postgresql import JSONB as PGJSONB
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from onyx.db.models import UserUsage
+from onyx.tracing.framework.span_data import FunctionSpanData
+from onyx.tracing.framework.span_data import GenerationSpanData
+from onyx.tracing.framework.span_data import SpanData
+from onyx.tracing.framework.spans import Span
+from onyx.tracing.processors import user_usage_processor as proc_mod
+from onyx.tracing.processors.user_usage_processor import UserUsageTracingProcessor
+from shared_configs.contextvars import CURRENT_USER_ID_CONTEXTVAR
+
+
+# Map the postgres-only column types onto SQLite equivalents so the real
+# UserUsage table from models.py can be created against an in-memory DB.
+@compiles(PGUUID, "sqlite")
+def _compile_pguuid_sqlite(_element: object, _compiler: object, **_kw: object) -> str:
+    return "CHAR(36)"
+
+
+@compiles(PGJSONB, "sqlite")
+def _compile_jsonb_sqlite(_element: object, _compiler: object, **_kw: object) -> str:
+    return "JSON"
+
+
+class _FakeSpan:
+    """Minimal stand-in exposing the only attribute the processor reads."""
+
+    def __init__(self, span_data: SpanData) -> None:
+        self.span_data = span_data
+
+
+def _fake_span(span_data: SpanData) -> Span[Any]:
+    return cast(Span[Any], _FakeSpan(span_data))
+
+
+def _generation_span(
+    model: str = "gpt-4o",
+    provider: str = "openai",
+    flow: str = "chat_response",
+    usage: dict[str, Any] | None = None,
+) -> Span[Any]:
+    return _fake_span(
+        GenerationSpanData(
+            model=model,
+            model_config={"model_provider": provider, "flow": flow},
+            usage=usage
+            if usage is not None
+            else {"input_tokens": 0, "output_tokens": 0},
+        )
+    )
+
+
+@pytest.fixture
+def sqlite_engine() -> Engine:
+    # StaticPool + single connection so the table is visible across the drain
+    # thread's separately-opened sessions (a plain sqlite:// gives each
+    # connection its own empty in-memory DB).
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    user_usage_table = cast(Table, UserUsage.__table__)
+    user_usage_table.create(bind=engine)
+    return engine
+
+
+@pytest.fixture
+def processor(
+    monkeypatch: pytest.MonkeyPatch, sqlite_engine: Engine
+) -> Generator[UserUsageTracingProcessor, None, None]:
+    """A processor whose flush thread writes to the in-memory SQLite engine.
+
+    `get_session_with_tenant` is monkeypatched to bind sessions to the test
+    engine; compute_cost_cents is pinned to a known value so the recorded cost
+    is deterministic without touching litellm.
+    """
+    SessionLocal = sessionmaker(bind=sqlite_engine)
+
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _fake_session(*, tenant_id: str) -> Generator[Any, None, None]:  # noqa: ARG001
+        session = SessionLocal()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    monkeypatch.setattr(proc_mod, "get_session_with_tenant", _fake_session)
+    monkeypatch.setattr(proc_mod, "compute_cost_cents", lambda *_a, **_k: (1.0, 2.0))
+
+    p = UserUsageTracingProcessor(flush_interval_seconds=0.05)
+    try:
+        yield p
+    finally:
+        p.shutdown()
+
+
+def _read_rows(engine: Engine) -> list[UserUsage]:
+    with sessionmaker(bind=engine)() as s:
+        return list(s.execute(select(UserUsage)).scalars().all())
+
+
+def test_records_usage_when_user_id_set(
+    processor: UserUsageTracingProcessor, sqlite_engine: Engine
+) -> None:
+    token = CURRENT_USER_ID_CONTEXTVAR.set(str(uuid4()))
+    try:
+        processor.on_span_end(
+            _generation_span(
+                usage={
+                    "input_tokens": 100,
+                    "output_tokens": 50,
+                    "cache_read_input_tokens": 20,
+                }
+            )
+        )
+    finally:
+        CURRENT_USER_ID_CONTEXTVAR.reset(token)
+
+    processor.force_flush()
+
+    rows = _read_rows(sqlite_engine)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.input_tokens == 100
+    assert row.output_tokens == 50
+    assert row.cache_read_tokens == 20
+    assert row.model == "gpt-4o"
+    assert row.provider == "openai"
+    assert row.flow == "chat_response"
+    assert row.cost_cents == pytest.approx(3.0)  # 1.0 input + 2.0 output
+
+
+def test_normalizes_prompt_completion_token_aliases(
+    processor: UserUsageTracingProcessor, sqlite_engine: Engine
+) -> None:
+    token = CURRENT_USER_ID_CONTEXTVAR.set(str(uuid4()))
+    try:
+        processor.on_span_end(
+            _generation_span(
+                usage={"prompt_tokens": 7, "completion_tokens": 3},
+            )
+        )
+    finally:
+        CURRENT_USER_ID_CONTEXTVAR.reset(token)
+
+    processor.force_flush()
+
+    rows = _read_rows(sqlite_engine)
+    assert len(rows) == 1
+    assert rows[0].input_tokens == 7
+    assert rows[0].output_tokens == 3
+
+
+def test_no_record_when_user_id_unset(
+    processor: UserUsageTracingProcessor, sqlite_engine: Engine
+) -> None:
+    # No CURRENT_USER_ID_CONTEXTVAR set -> background-worker-like context.
+    processor.on_span_end(_generation_span(usage={"input_tokens": 5}))
+    processor.force_flush()
+    assert _read_rows(sqlite_engine) == []
+
+
+def test_ignores_non_generation_spans(
+    processor: UserUsageTracingProcessor, sqlite_engine: Engine
+) -> None:
+    token = CURRENT_USER_ID_CONTEXTVAR.set(str(uuid4()))
+    try:
+        processor.on_span_end(
+            _fake_span(FunctionSpanData(name="tool", input="x", output="y"))
+        )
+    finally:
+        CURRENT_USER_ID_CONTEXTVAR.reset(token)
+    processor.force_flush()
+    assert _read_rows(sqlite_engine) == []
+
+
+def test_ignores_generation_span_without_usage(
+    processor: UserUsageTracingProcessor, sqlite_engine: Engine
+) -> None:
+    token = CURRENT_USER_ID_CONTEXTVAR.set(str(uuid4()))
+    try:
+        processor.on_span_end(
+            _fake_span(GenerationSpanData(model="gpt-4o", usage=None))
+        )
+    finally:
+        CURRENT_USER_ID_CONTEXTVAR.reset(token)
+    processor.force_flush()
+    assert _read_rows(sqlite_engine) == []
+
+
+def test_on_span_end_never_raises_on_internal_error(
+    processor: UserUsageTracingProcessor,
+    sqlite_engine: Engine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # An exception anywhere in capture must be swallowed (LLM hot path).
+    def _boom(*_a: Any, **_k: Any) -> Any:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(proc_mod, "get_current_user_id", _boom)
+
+    token = CURRENT_USER_ID_CONTEXTVAR.set(str(uuid4()))
+    try:
+        # Must not raise.
+        processor.on_span_end(_generation_span(usage={"input_tokens": 1}))
+    finally:
+        CURRENT_USER_ID_CONTEXTVAR.reset(token)
+
+    processor.force_flush()
+    assert _read_rows(sqlite_engine) == []
+
+
+def test_real_pricing_excludes_cache_reads_from_input(
+    monkeypatch: pytest.MonkeyPatch, sqlite_engine: Engine
+) -> None:
+    # Real compute_cost_cents (NOT stubbed): the span carries the litellm prompt
+    # total (input_tokens already includes cache reads). The processor must
+    # price the non-cached remainder as input and the cache reads at the cache
+    # rate — mirrors test_cost.py::test_cache_read_tokens_priced_as_input.
+    # gpt-4o: 1000 non-cached @ $2.50/Mtok + 2000 cache-read @ $1.25/Mtok =
+    # 0.25c + 0.25c = 0.5c input; 500 output tok @ $10/Mtok = 0.5c.
+    SessionLocal = sessionmaker(bind=sqlite_engine)
+
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _fake_session(*, tenant_id: str) -> Generator[Any, None, None]:  # noqa: ARG001
+        session = SessionLocal()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    monkeypatch.setattr(proc_mod, "get_session_with_tenant", _fake_session)
+
+    p = UserUsageTracingProcessor(flush_interval_seconds=0.05)
+    try:
+        token = CURRENT_USER_ID_CONTEXTVAR.set(str(uuid4()))
+        try:
+            p.on_span_end(
+                _generation_span(
+                    usage={
+                        # input_tokens is the cache-inclusive prompt total.
+                        "input_tokens": 3000,
+                        "output_tokens": 500,
+                        "cache_read_input_tokens": 2000,
+                    }
+                )
+            )
+        finally:
+            CURRENT_USER_ID_CONTEXTVAR.reset(token)
+        p.force_flush()
+    finally:
+        p.shutdown()
+
+    rows = _read_rows(sqlite_engine)
+    assert len(rows) == 1
+    row = rows[0]
+    # Ledger keeps the full (cache-inclusive) input token count.
+    assert row.input_tokens == 3000
+    assert row.cache_read_tokens == 2000
+    # Cost must NOT double-charge the 2000 cache reads at the full input rate.
+    assert row.cost_cents == pytest.approx(1.0)
+
+
+def test_flush_swallows_record_errors(
+    processor: UserUsageTracingProcessor,
+    sqlite_engine: Engine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A failure while writing one record must not crash the drain loop nor leak.
+    def _boom(*_a: Any, **_k: Any) -> None:
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(proc_mod, "record_user_usage", _boom)
+
+    token = CURRENT_USER_ID_CONTEXTVAR.set(str(uuid4()))
+    try:
+        processor.on_span_end(_generation_span(usage={"input_tokens": 1}))
+    finally:
+        CURRENT_USER_ID_CONTEXTVAR.reset(token)
+
+    # Should not raise even though the write fails.
+    processor.force_flush()
+    assert _read_rows(sqlite_engine) == []

--- a/backend/tests/unit/shared_configs/test_user_id_contextvar.py
+++ b/backend/tests/unit/shared_configs/test_user_id_contextvar.py
@@ -1,0 +1,96 @@
+from collections.abc import Generator
+from typing import Any
+from uuid import uuid4
+
+from fastapi import Depends
+from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
+from fastapi.testclient import TestClient
+
+from onyx.server.utils import set_current_user_id_dependency
+from shared_configs.contextvars import CURRENT_USER_ID_CONTEXTVAR
+from shared_configs.contextvars import get_current_user_id
+
+
+def test_get_current_user_id_returns_set_value() -> None:
+    token = CURRENT_USER_ID_CONTEXTVAR.set("user-123")
+    try:
+        assert get_current_user_id() == "user-123"
+    finally:
+        CURRENT_USER_ID_CONTEXTVAR.reset(token)
+
+
+def test_get_current_user_id_none_when_unset() -> None:
+    # Background-worker case: no request context populated the var.
+    assert get_current_user_id() is None
+
+
+def test_reset_restores_previous_value() -> None:
+    token = CURRENT_USER_ID_CONTEXTVAR.set("user-abc")
+    CURRENT_USER_ID_CONTEXTVAR.reset(token)
+    assert get_current_user_id() is None
+
+
+def test_user_id_propagates_to_every_streamed_chunk() -> None:
+    """Drives the real StreamingResponse / iterate_in_threadpool path.
+
+    The user id must be readable on every iteration (not just the first), since
+    LLM calls and usage recording happen throughout the stream. Also asserts the
+    var resets to None after the request without raising.
+    """
+    user_id = uuid4()
+
+    class _FakeUser:
+        id = user_id
+
+    async def fake_auth() -> _FakeUser:
+        return _FakeUser()
+
+    app = FastAPI()
+    reads: list[str | None] = []
+
+    @app.post("/stream")
+    def stream_ep(
+        _user_ctx: None = Depends(set_current_user_id_dependency(fake_auth)),
+    ) -> StreamingResponse:
+        def gen() -> Generator[str, None, None]:
+            for i in range(3):
+                reads.append(get_current_user_id())
+                yield f"chunk-{i}\n"
+
+        return StreamingResponse(gen(), media_type="text/plain")
+
+    client = TestClient(app)
+    resp = client.post("/stream")
+
+    assert resp.status_code == 200
+    assert reads == [str(user_id)] * 3
+    # No leak / no different-context reset error after the request finishes.
+    assert get_current_user_id() is None
+
+
+def test_user_id_set_for_non_streaming_endpoint_body() -> None:
+    """The dependency also covers the non-streaming / multi-model branches that
+    read the var synchronously in the endpoint body."""
+    user_id = uuid4()
+
+    class _FakeUser:
+        id = user_id
+
+    async def fake_auth() -> _FakeUser:
+        return _FakeUser()
+
+    app = FastAPI()
+
+    @app.get("/plain")
+    def plain_ep(
+        _user_ctx: None = Depends(set_current_user_id_dependency(fake_auth)),
+    ) -> dict[str, Any]:
+        return {"user_id": get_current_user_id()}
+
+    client = TestClient(app)
+    resp = client.get("/plain")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"user_id": str(user_id)}
+    assert get_current_user_id() is None

--- a/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
+++ b/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
@@ -26,7 +26,7 @@ interface CreateRateLimitModalProps {
     period_hours: number,
     token_budget: number | null,
     cost_budget_cents: number | null,
-    group_id: number
+    group_id: number,
   ) => void;
   forSpecificScope?: Scope;
   forSpecificUserGroup?: number;
@@ -41,7 +41,7 @@ export default function CreateRateLimitModal({
 }: CreateRateLimitModalProps) {
   const [modalUserGroups, setModalUserGroups] = useState([]);
   const [shouldFetchUserGroups, setShouldFetchUserGroups] = useState(
-    forSpecificScope === Scope.USER_GROUP
+    forSpecificScope === Scope.USER_GROUP,
   );
 
   useEffect(() => {
@@ -93,14 +93,17 @@ export default function CreateRateLimitModal({
                 "budget-required",
                 "Set a token budget and/or a cost budget",
                 (value, context) =>
-                  value != null || context.parent.cost_budget_dollars !== ""
+                  value != null || context.parent.cost_budget_dollars !== "",
               ),
-            cost_budget_dollars: Yup.number().min(
-              0,
-              "Cost Budget cannot be negative"
-            ),
+            cost_budget_dollars: Yup.number()
+              // Empty (no cost budget) is allowed; a 0 would make the gate fire
+              // on the first request (cost_since >= 0 is always true).
+              .transform((value, original) =>
+                original === "" ? undefined : value,
+              )
+              .moreThan(0, "Cost Budget must be greater than 0"),
             target_scope: Yup.string().required(
-              "Target Scope is a required field"
+              "Target Scope is a required field",
             ),
             user_group_id: Yup.string().test(
               "user_group_id",
@@ -111,7 +114,7 @@ export default function CreateRateLimitModal({
                   (context.parent.target_scope === "user_group" &&
                     value !== undefined)
                 );
-              }
+              },
             ),
           })}
           onSubmit={async (values, formikHelpers) => {
@@ -133,7 +136,7 @@ export default function CreateRateLimitModal({
               periodHours,
               tokenBudget,
               costBudgetCents,
-              Number(values.user_group_id)
+              Number(values.user_group_id),
             );
             return formikHelpers.setSubmitting(false);
           }}

--- a/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
+++ b/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
@@ -10,13 +10,22 @@ import { UserGroup } from "@/lib/types";
 import { Scope } from "./types";
 import { toast } from "@/hooks/useToast";
 import { SvgSettings } from "@opal/icons";
+
+// UI period units -> hours. The backend contract stays period_hours (int), so
+// this is purely a friendlier input than typing raw hours.
+const PERIOD_UNIT_HOURS: Record<string, number> = {
+  hour: 1,
+  day: 24,
+  week: 168,
+};
 interface CreateRateLimitModalProps {
   isOpen: boolean;
   setIsOpen: (isOpen: boolean) => void;
   onSubmit: (
     target_scope: Scope,
     period_hours: number,
-    token_budget: number,
+    token_budget: number | null,
+    cost_budget_cents: number | null,
     group_id: number
   ) => void;
   forSpecificScope?: Scope;
@@ -67,18 +76,29 @@ export default function CreateRateLimitModal({
         <Formik
           initialValues={{
             enabled: true,
-            period_hours: "",
+            period_value: "1",
+            period_unit: "week",
             token_budget: "",
+            cost_budget_dollars: "",
             target_scope: forSpecificScope || Scope.GLOBAL,
             user_group_id: forSpecificUserGroup,
           }}
           validationSchema={Yup.object().shape({
-            period_hours: Yup.number()
+            period_value: Yup.number()
               .required("Time Window is a required field")
-              .min(1, "Time Window must be at least 1 hour"),
+              .min(1, "Time Window must be at least 1"),
             token_budget: Yup.number()
-              .required("Token Budget is a required field")
-              .min(1, "Token Budget must be at least 1"),
+              .min(1, "Token Budget must be at least 1")
+              .test(
+                "budget-required",
+                "Set a token budget and/or a cost budget",
+                (value, context) =>
+                  value != null || context.parent.cost_budget_dollars !== ""
+              ),
+            cost_budget_dollars: Yup.number().min(
+              0,
+              "Cost Budget cannot be negative"
+            ),
             target_scope: Yup.string().required(
               "Target Scope is a required field"
             ),
@@ -96,10 +116,23 @@ export default function CreateRateLimitModal({
           })}
           onSubmit={async (values, formikHelpers) => {
             formikHelpers.setSubmitting(true);
+            // Empty token field → null (cost-only); the gate skips a null budget.
+            // Sending 0 would mean "0-token limit" and block every request.
+            const tokenBudget =
+              values.token_budget === "" ? null : Number(values.token_budget);
+            const costBudgetCents =
+              values.cost_budget_dollars === ""
+                ? null
+                : Math.round(Number(values.cost_budget_dollars) * 100);
+            // UI picks a unit; the backend contract is unchanged (period_hours: int).
+            const periodHours =
+              Number(values.period_value) *
+              (PERIOD_UNIT_HOURS[values.period_unit] ?? 168);
             onSubmit(
               values.target_scope,
-              Number(values.period_hours),
-              Number(values.token_budget),
+              periodHours,
+              tokenBudget,
+              costBudgetCents,
               Number(values.user_group_id)
             );
             return formikHelpers.setSubmitting(false);
@@ -135,15 +168,37 @@ export default function CreateRateLimitModal({
                       includeDefault={false}
                     />
                   )}
+                <div className="flex flex-row gap-2 items-end">
+                  <div className="flex-1">
+                    <TextFormField
+                      name="period_value"
+                      label="Time Window"
+                      type="number"
+                      placeholder=""
+                    />
+                  </div>
+                  <div className="flex-1">
+                    <SelectorFormField
+                      name="period_unit"
+                      label="Per"
+                      options={[
+                        { name: "Hour", value: "hour" },
+                        { name: "Day", value: "day" },
+                        { name: "Week", value: "week" },
+                      ]}
+                      includeDefault={false}
+                    />
+                  </div>
+                </div>
                 <TextFormField
-                  name="period_hours"
-                  label="Time Window (Hours)"
+                  name="token_budget"
+                  label="Token Budget (Thousands, optional)"
                   type="number"
                   placeholder=""
                 />
                 <TextFormField
-                  name="token_budget"
-                  label="Token Budget (Thousands)"
+                  name="cost_budget_dollars"
+                  label="Cost Budget (USD per period, optional)"
                   type="number"
                   placeholder=""
                 />

--- a/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
+++ b/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
@@ -88,6 +88,12 @@ export default function CreateRateLimitModal({
               .required("Time Window is a required field")
               .min(1, "Time Window must be at least 1"),
             token_budget: Yup.number()
+              // Empty (no token budget) is allowed — a cost-only limit. Without
+              // this, "" coerces to NaN and trips .min(1) even when only a cost
+              // budget is set. Mirrors the cost_budget_dollars transform below.
+              .transform((value, original) =>
+                original === "" ? undefined : value,
+              )
               .min(1, "Token Budget must be at least 1")
               .test(
                 "budget-required",

--- a/web/src/app/admin/token-rate-limits/TokenRateLimitTables.tsx
+++ b/web/src/app/admin/token-rate-limits/TokenRateLimitTables.tsx
@@ -53,6 +53,7 @@ export const TokenRateLimitTable = ({
     updateTokenRateLimit(id, {
       token_budget: tokenRateLimit.token_budget,
       period_hours: tokenRateLimit.period_hours,
+      cost_budget_cents: tokenRateLimit.cost_budget_cents,
       enabled: !tokenRateLimit.enabled,
     }).then(() => {
       mutate(fetchUrl);
@@ -103,6 +104,7 @@ export const TokenRateLimitTable = ({
             {shouldRenderGroupName() && <TableHead>Group Name</TableHead>}
             <TableHead>Time Window (Hours)</TableHead>
             <TableHead>Token Budget (Thousands)</TableHead>
+            <TableHead>Cost Budget (USD)</TableHead>
             {isAdmin && <TableHead>Delete</TableHead>}
           </TableRow>
         </TableHeader>
@@ -152,7 +154,15 @@ export const TokenRateLimitTable = ({
                     (tokenRateLimit.period_hours > 1 ? "s" : "")}
                 </TableCell>
                 <TableCell>
-                  {tokenRateLimit.token_budget + " thousand tokens"}
+                  {tokenRateLimit.token_budget != null
+                    ? (tokenRateLimit.token_budget * 1000).toLocaleString() +
+                      " tokens"
+                    : "—"}
+                </TableCell>
+                <TableCell>
+                  {tokenRateLimit.cost_budget_cents != null
+                    ? "$" + (tokenRateLimit.cost_budget_cents / 100).toFixed(2)
+                    : "—"}
                 </TableCell>
                 {isAdmin && (
                   <TableCell>

--- a/web/src/app/admin/token-rate-limits/TokenRateLimitTables.tsx
+++ b/web/src/app/admin/token-rate-limits/TokenRateLimitTables.tsx
@@ -43,7 +43,7 @@ export const TokenRateLimitTable = ({
 
   const handleEnabledChange = (id: number) => {
     const tokenRateLimit = tokenRateLimits.find(
-      (tokenRateLimit) => tokenRateLimit.token_id === id
+      (tokenRateLimit) => tokenRateLimit.token_id === id,
     );
 
     if (!tokenRateLimit) {
@@ -103,7 +103,7 @@ export const TokenRateLimitTable = ({
             <TableHead>Enabled</TableHead>
             {shouldRenderGroupName() && <TableHead>Group Name</TableHead>}
             <TableHead>Time Window (Hours)</TableHead>
-            <TableHead>Token Budget (Thousands)</TableHead>
+            <TableHead>Token Budget</TableHead>
             <TableHead>Cost Budget (USD)</TableHead>
             {isAdmin && <TableHead>Delete</TableHead>}
           </TableRow>
@@ -199,7 +199,7 @@ export const GenericTokenRateLimitTable = ({
 }) => {
   const { data, isLoading, error } = useSWR<TokenRateLimitDisplay[]>(
     fetchUrl,
-    errorHandlingFetcher
+    errorHandlingFetcher,
   );
 
   if (isLoading) {

--- a/web/src/app/admin/token-rate-limits/page.tsx
+++ b/web/src/app/admin/token-rate-limits/page.tsx
@@ -41,13 +41,15 @@ const USER_GROUP_DESCRIPTION =
 const handleCreateTokenRateLimit = async (
   target_scope: Scope,
   period_hours: number,
-  token_budget: number,
+  token_budget: number | null,
+  cost_budget_cents: number | null,
   group_id: number = -1
 ) => {
   const tokenRateLimitArgs = {
     enabled: true,
     token_budget: token_budget,
     period_hours: period_hours,
+    cost_budget_cents: cost_budget_cents,
   };
 
   if (target_scope === Scope.GLOBAL) {
@@ -83,13 +85,15 @@ function Main() {
   const handleSubmit = (
     target_scope: Scope,
     period_hours: number,
-    token_budget: number,
+    token_budget: number | null,
+    cost_budget_cents: number | null,
     group_id: number = -1
   ) => {
     handleCreateTokenRateLimit(
       target_scope,
       period_hours,
       token_budget,
+      cost_budget_cents,
       group_id
     )
       .then(() => {

--- a/web/src/app/admin/token-rate-limits/types.ts
+++ b/web/src/app/admin/token-rate-limits/types.ts
@@ -6,15 +6,18 @@ export enum Scope {
 
 export interface TokenRateLimitArgs {
   enabled: boolean;
-  token_budget: number;
+  token_budget: number | null;
   period_hours: number;
+  // Cents at the API boundary; the UI collects dollars and converts.
+  cost_budget_cents?: number | null;
 }
 
 export interface TokenRateLimit {
   token_id: number;
   enabled: boolean;
-  token_budget: number;
+  token_budget: number | null;
   period_hours: number;
+  cost_budget_cents: number | null;
 }
 
 export interface TokenRateLimitDisplay extends TokenRateLimit {

--- a/web/src/app/app/interfaces.ts
+++ b/web/src/app/app/interfaces.ts
@@ -299,6 +299,18 @@ export interface StreamingError {
   details?: Record<string, any>;
 }
 
+// error_code emitted by the backend usage rate-limiter (429). Branch on this to
+// show the dedicated usage-limit banner instead of the generic chat error.
+export const RATE_LIMITED_ERROR_CODE = "RATE_LIMITED";
+
+// Shape of StreamingError.details for a RATE_LIMITED error — mirrors the 429
+// JSON body so the banner can compute a human-friendly reset time.
+export interface RateLimitDetails {
+  scope?: string;
+  reset_at?: string; // ISO timestamp
+  retry_after_seconds?: number;
+}
+
 export interface InputPrompt {
   id: number;
   prompt: string;

--- a/web/src/app/app/message/Resubmit.tsx
+++ b/web/src/app/app/message/Resubmit.tsx
@@ -4,6 +4,52 @@ import { SvgChevronDown, SvgChevronRight } from "@opal/icons";
 import { Button } from "@opal/components";
 import { CopyButton } from "@opal/components";
 import { getErrorIcon, getErrorTitle } from "./errorHelpers";
+import {
+  RateLimitDetails,
+  RATE_LIMITED_ERROR_CODE,
+} from "@/app/app/interfaces";
+
+// Turn a 429's reset_at / retry_after_seconds into a human-friendly sentence.
+// Returns null if neither field is present (banner falls back to the detail).
+function formatRateLimitReset(details: RateLimitDetails): string | null {
+  const resetMs = resolveResetMs(details);
+  if (resetMs === null) return null;
+
+  const remainingMs = resetMs - Date.now();
+  if (remainingMs <= 0) return "You can try again now.";
+
+  const plural = (n: number, unit: string) => `${n} ${unit}${n === 1 ? "" : "s"}`;
+  const minutes = Math.ceil(remainingMs / 60_000);
+  const hours = Math.ceil(remainingMs / 3_600_000);
+  const days = Math.ceil(remainingMs / 86_400_000);
+  const relative =
+    minutes < 60
+      ? plural(minutes, "minute")
+      : hours < 48
+        ? plural(hours, "hour")
+        : plural(days, "day");
+  const resetDate = new Date(resetMs);
+  // For multi-day resets a date is clearer than just a clock time.
+  const at =
+    days >= 2
+      ? resetDate.toLocaleDateString(undefined, { month: "short", day: "numeric" })
+      : resetDate.toLocaleTimeString(undefined, {
+          hour: "numeric",
+          minute: "2-digit",
+        });
+  return `Resets in ${relative} (${at}).`;
+}
+
+function resolveResetMs(details: RateLimitDetails): number | null {
+  if (details.reset_at) {
+    const parsed = Date.parse(details.reset_at);
+    if (!Number.isNaN(parsed)) return parsed;
+  }
+  if (typeof details.retry_after_seconds === "number") {
+    return Date.now() + details.retry_after_seconds * 1000;
+  }
+  return null;
+}
 
 interface ResubmitProps {
   resubmit: () => void;
@@ -36,6 +82,26 @@ export const ErrorBanner = ({
   resubmit?: () => void;
 }) => {
   const [isStackTraceExpanded, setIsStackTraceExpanded] = useState(false);
+
+  // Usage rate-limit (429): a focused banner with a reset time and no
+  // Regenerate affordance — retrying would just re-trip the same limit.
+  if (errorCode === RATE_LIMITED_ERROR_CODE) {
+    const resetLine = formatRateLimitReset((details as RateLimitDetails) ?? {});
+    return (
+      <div className="text-red-700 mt-4 text-sm my-auto">
+        <Alert variant="broken">
+          {getErrorIcon(errorCode)}
+          <AlertTitle>{getErrorTitle(errorCode)}</AlertTitle>
+          <AlertDescription className="flex flex-col gap-y-1">
+            <span>{error || "You've reached your usage limit."}</span>
+            {resetLine && (
+              <span className="text-xs text-muted-foreground">{resetLine}</span>
+            )}
+          </AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
 
   return (
     <div className="text-red-700 mt-4 text-sm my-auto">

--- a/web/src/app/app/message/errorHelpers.tsx
+++ b/web/src/app/app/message/errorHelpers.tsx
@@ -6,6 +6,7 @@ import { AlertCircle, Clock, Lock, Wifi, Server } from "lucide-react";
 export const getErrorIcon = (errorCode?: string) => {
   switch (errorCode) {
     case "RATE_LIMIT":
+    case "RATE_LIMITED":
       return <Clock className="h-4 w-4" />;
     case "AUTH_ERROR":
     case "PERMISSION_DENIED":
@@ -28,6 +29,8 @@ export const getErrorTitle = (errorCode?: string) => {
   switch (errorCode) {
     case "RATE_LIMIT":
       return "Rate Limit Exceeded";
+    case "RATE_LIMITED":
+      return "Usage limit reached";
     case "AUTH_ERROR":
       return "Authentication Error";
     case "PERMISSION_DENIED":

--- a/web/src/app/app/services/lib.tsx
+++ b/web/src/app/app/services/lib.tsx
@@ -13,6 +13,8 @@ import {
   Message,
   MessageResponseIDInfo,
   MultiModelMessageResponseIDInfo,
+  RateLimitDetails,
+  RATE_LIMITED_ERROR_CODE,
   ResearchType,
   RetrievalType,
   StreamingError,
@@ -197,6 +199,31 @@ export async function* sendMessage({
 
   if (!response.ok) {
     const data = await response.json().catch(() => ({}));
+
+    // Surface the usage rate-limit (429) as a structured StreamingError packet
+    // so the chat UI can render the dedicated usage-limit banner. Throwing a
+    // bare Error here would flatten error_code/reset_at into an opaque string.
+    if (
+      response.status === 429 &&
+      data.error_code === RATE_LIMITED_ERROR_CODE
+    ) {
+      const rateLimitDetails: RateLimitDetails = {
+        scope: data.scope,
+        reset_at: data.reset_at,
+        retry_after_seconds: data.retry_after_seconds,
+      };
+      const streamingError: StreamingError = {
+        error: data.detail ?? "You've reached your usage limit.",
+        stack_trace: "",
+        error_code: RATE_LIMITED_ERROR_CODE,
+        // Regenerate would just re-trip the limit, so this is not retryable.
+        is_retryable: false,
+        details: rateLimitDetails,
+      };
+      yield streamingError;
+      return;
+    }
+
     throw new Error(data.detail ?? `HTTP error! status: ${response.status}`);
   }
 

--- a/web/src/app/app/settings/layout.tsx
+++ b/web/src/app/app/settings/layout.tsx
@@ -63,6 +63,12 @@ export default function Layout({ children }: LayoutProps) {
             >
               Connectors
             </SidebarTab>
+            <SidebarTab
+              href="/app/settings/usage"
+              selected={pathname === "/app/settings/usage"}
+            >
+              Usage
+            </SidebarTab>
           </div>
 
           {/* Right: Tab Content */}

--- a/web/src/app/app/settings/usage/UsageSettings.tsx
+++ b/web/src/app/app/settings/usage/UsageSettings.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Section } from "@/layouts/general-layouts";
 import { Content } from "@opal/layouts";
 import { Text, EmptyMessageCard, Divider } from "@opal/components";
@@ -9,14 +9,20 @@ import {
   SvgWallet,
   SvgCreditCard,
   SvgSimpleLoader,
+  SvgChevronRight,
 } from "@opal/icons";
 import InputSelect from "@/refresh-components/inputs/InputSelect";
 import Card from "@/refresh-components/cards/Card";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/refresh-components/Collapsible";
 import { cn } from "@opal/utils";
 import {
   useUserUsage,
   type UsagePerDayByModel,
-  type SelectedModelPrice,
+  type ModelPrice,
 } from "@/app/app/settings/usage/lib";
 
 const DAYS_OPTIONS = ["7", "30"] as const;
@@ -118,41 +124,119 @@ function WindowCostSection({ windowCostCents, rows }: WindowCostSectionProps) {
 }
 
 interface ModelPriceSectionProps {
-  price: SelectedModelPrice | null;
+  prices: ModelPrice[];
+  defaultModel: string | null;
 }
 
-function ModelPriceSection({ price }: ModelPriceSectionProps) {
+function formatMtok(value: number | null): string {
+  return value !== null ? `$${value.toFixed(2)}` : "—";
+}
+
+// Every available model's price (USD/1M, input · output · cache), grouped into a
+// collapsible menu per provider — click a provider to expand its models. Mirrors
+// the chat model selector so users can compare costs, not just the default.
+function ModelPriceSection({ prices, defaultModel }: ModelPriceSectionProps) {
+  const groups = useMemo(() => {
+    const byProvider = new Map<string, ModelPrice[]>();
+    for (const price of prices) {
+      const key = price.provider ?? "Other";
+      const list = byProvider.get(key) ?? [];
+      list.push(price);
+      byProvider.set(key, list);
+    }
+    return Array.from(byProvider.entries())
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([provider, models]) => ({ provider, models }));
+  }, [prices]);
+
+  // Expand the provider that holds the default model (else the first).
+  const defaultProvider = useMemo(
+    () =>
+      prices.find((p) => p.model === defaultModel)?.provider ??
+      groups[0]?.provider ??
+      null,
+    [prices, defaultModel, groups],
+  );
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  useEffect(() => {
+    if (defaultProvider) setExpanded(new Set([defaultProvider]));
+  }, [defaultProvider]);
+
+  function toggle(provider: string) {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(provider)) next.delete(provider);
+      else next.add(provider);
+      return next;
+    });
+  }
+
   return (
     <Section gap={0.75} justifyContent="start">
       <Content
         icon={SvgCreditCard}
-        title="Your model's price"
+        title="Model prices"
+        description="USD per 1M tokens (input · output · cache) for every available model"
         sizePreset="main-content"
         variant="section"
         width="full"
       />
       <Card>
-        {price &&
-        price.input_per_mtok !== null &&
-        price.output_per_mtok !== null ? (
-          <Section
-            flexDirection="row"
-            justifyContent="between"
-            alignItems="center"
-            width="full"
-            gap={1}
-          >
-            <Text font="main-ui-body" color="text-03">
-              {`$${price.input_per_mtok.toFixed(2)} / 1M input`}
-            </Text>
-            <Text font="main-ui-body" color="text-03">
-              {`$${price.output_per_mtok.toFixed(2)} / 1M output`}
-            </Text>
-          </Section>
-        ) : (
+        {groups.length === 0 ? (
           <Text font="main-ui-body" color="text-01">
-            Price unavailable
+            Prices unavailable
           </Text>
+        ) : (
+          <Section gap={0.25} alignItems="stretch" justifyContent="start">
+            {groups.map(({ provider, models }) => {
+              const open = expanded.has(provider);
+              return (
+                <Collapsible
+                  key={provider}
+                  open={open}
+                  onOpenChange={() => toggle(provider)}
+                  className="flex flex-col"
+                >
+                  <CollapsibleTrigger asChild>
+                    <div className="flex flex-row items-center justify-between cursor-pointer select-none py-1.5">
+                      <Text font="main-ui-action" color="text-03">
+                        {provider}
+                      </Text>
+                      <SvgChevronRight
+                        className={cn(
+                          "w-4 h-4 text-text-03 transition-transform",
+                          open && "rotate-90",
+                        )}
+                      />
+                    </div>
+                  </CollapsibleTrigger>
+                  <CollapsibleContent>
+                    <Section gap={0} alignItems="stretch" justifyContent="start">
+                      {models.map((price) => (
+                        <div
+                          key={`${provider}-${price.model}`}
+                          className="flex flex-row items-center justify-between gap-2 py-1 pl-3"
+                        >
+                          <Text font="secondary-body" color="text-03" nowrap>
+                            {price.model === defaultModel
+                              ? `${price.model} · default`
+                              : price.model}
+                          </Text>
+                          <Text font="secondary-body" color="text-01" nowrap>
+                            {`${formatMtok(price.input_per_mtok)} in · ${formatMtok(
+                              price.output_per_mtok,
+                            )} out · ${formatMtok(
+                              price.cache_per_mtok ?? price.input_per_mtok,
+                            )} cache`}
+                          </Text>
+                        </div>
+                      ))}
+                    </Section>
+                  </CollapsibleContent>
+                </Collapsible>
+              );
+            })}
+          </Section>
         )}
       </Card>
     </Section>
@@ -299,11 +383,14 @@ export default function UsageSettings() {
               windowCostCents={data.window_cost_cents}
               rows={data.per_day_by_model}
             />
-            <ModelPriceSection price={data.selected_model_price} />
             <BudgetSection
               budgetCents={data.budget_cents}
               budgetRemainingCents={data.budget_remaining_cents}
               budgetPeriodHours={data.budget_period_hours}
+            />
+            <ModelPriceSection
+              prices={data.available_model_prices ?? []}
+              defaultModel={data.selected_model_price?.model ?? null}
             />
           </Section>
         )}

--- a/web/src/app/app/settings/usage/UsageSettings.tsx
+++ b/web/src/app/app/settings/usage/UsageSettings.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Section } from "@/layouts/general-layouts";
 import { Content } from "@opal/layouts";
 import { Text, EmptyMessageCard, Divider } from "@opal/components";
@@ -39,7 +39,7 @@ function WindowCostSection({ windowCostCents, rows }: WindowCostSectionProps) {
   // Drives the relative bar widths in the breakdown.
   const maxRowCost = rows.reduce(
     (max, row) => Math.max(max, row.cost_cents),
-    0
+    0,
   );
   const hasCache = rows.some((row) => row.cache_read_tokens > 0);
 
@@ -101,7 +101,7 @@ function WindowCostSection({ windowCostCents, rows }: WindowCostSectionProps) {
 
                 <Text font="secondary-body" color="text-01">
                   {`${formatTokens(row.input_tokens)} in · ${formatTokens(
-                    row.output_tokens
+                    row.output_tokens,
                   )} out${
                     hasCache
                       ? ` · ${formatTokens(row.cache_read_tokens)} cache`
@@ -184,7 +184,7 @@ function BudgetSection({
   budgetRemainingCents,
   budgetPeriodHours,
 }: BudgetSectionProps) {
-  // budget_* are null until P5 enforcement ships; show a graceful empty state.
+  // budget_* are null when the user has no cost limit; show a graceful empty state.
   const hasBudget = budgetCents !== null;
   const remaining = budgetRemainingCents ?? 0;
   const spent = hasBudget ? Math.max(0, budgetCents - remaining) : 0;
@@ -215,7 +215,9 @@ function BudgetSection({
               </Text>
               <Text font="secondary-body" color="text-01">
                 {`of ${formatDollars(budgetCents)}${
-                  budgetPeriodHours ? ` per ${formatPeriod(budgetPeriodHours)}` : ""
+                  budgetPeriodHours
+                    ? ` per ${formatPeriod(budgetPeriodHours)}`
+                    : ""
                 }`}
               </Text>
             </Section>
@@ -225,7 +227,7 @@ function BudgetSection({
                   "h-full rounded-full",
                   usedFraction >= 1
                     ? "bg-status-error-05"
-                    : "bg-theme-primary-05"
+                    : "bg-theme-primary-05",
                 )}
                 style={{ width: `${usedFraction * 100}%` }}
               />
@@ -244,6 +246,10 @@ function BudgetSection({
 export default function UsageSettings() {
   const [days, setDays] = useState<string>(String(DEFAULT_DAYS));
   const { data, error, isLoading } = useUserUsage(Number(days));
+
+  useEffect(() => {
+    if (error) console.error("Failed to load usage", error);
+  }, [error]);
 
   return (
     <Section gap={2}>

--- a/web/src/app/app/settings/usage/UsageSettings.tsx
+++ b/web/src/app/app/settings/usage/UsageSettings.tsx
@@ -1,0 +1,307 @@
+"use client";
+
+import { useState } from "react";
+import { Section } from "@/layouts/general-layouts";
+import { Content } from "@opal/layouts";
+import { Text, EmptyMessageCard, Divider } from "@opal/components";
+import {
+  SvgBarChart,
+  SvgWallet,
+  SvgCreditCard,
+  SvgSimpleLoader,
+} from "@opal/icons";
+import InputSelect from "@/refresh-components/inputs/InputSelect";
+import Card from "@/refresh-components/cards/Card";
+import { cn } from "@opal/utils";
+import {
+  useUserUsage,
+  type UsagePerDayByModel,
+  type SelectedModelPrice,
+} from "@/app/app/settings/usage/lib";
+
+const DAYS_OPTIONS = ["7", "30"] as const;
+const DEFAULT_DAYS = 30;
+
+function formatDollars(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+function formatTokens(tokens: number): string {
+  return tokens.toLocaleString();
+}
+
+interface WindowCostSectionProps {
+  windowCostCents: number;
+  rows: UsagePerDayByModel[];
+}
+
+function WindowCostSection({ windowCostCents, rows }: WindowCostSectionProps) {
+  // Drives the relative bar widths in the breakdown.
+  const maxRowCost = rows.reduce(
+    (max, row) => Math.max(max, row.cost_cents),
+    0
+  );
+  const hasCache = rows.some((row) => row.cache_read_tokens > 0);
+
+  return (
+    <Section gap={0.75} justifyContent="start">
+      <Content
+        icon={SvgBarChart}
+        title="Usage this period"
+        description={`${formatDollars(windowCostCents)} spent`}
+        sizePreset="main-content"
+        variant="section"
+        width="full"
+      />
+
+      {rows.length === 0 ? (
+        <EmptyMessageCard
+          sizePreset="main-ui"
+          title="No usage recorded yet"
+          description="Your model usage and costs will show up here once you start chatting."
+        />
+      ) : (
+        <Card>
+          {rows.map((row, index) => (
+            <div key={`${row.day}-${row.model}`}>
+              {index > 0 && <Divider />}
+              <Section gap={0.5} alignItems="start" justifyContent="start">
+                <Section
+                  flexDirection="row"
+                  justifyContent="between"
+                  alignItems="center"
+                  width="full"
+                  gap={1}
+                >
+                  <Section gap={0} alignItems="start" justifyContent="start">
+                    <Text font="main-ui-action" color="text-03">
+                      {row.model}
+                    </Text>
+                    <Text font="secondary-body" color="text-01">
+                      {row.day}
+                    </Text>
+                  </Section>
+                  <Text font="main-ui-action" color="text-03" nowrap>
+                    {formatDollars(row.cost_cents)}
+                  </Text>
+                </Section>
+
+                {/* Cost bar — proportional to the priciest row in the window. */}
+                <div className="w-full h-1.5 rounded-full bg-background-neutral-03 overflow-hidden">
+                  <div
+                    className="h-full rounded-full bg-theme-primary-05"
+                    style={{
+                      width:
+                        maxRowCost > 0
+                          ? `${Math.max(2, (row.cost_cents / maxRowCost) * 100)}%`
+                          : "0%",
+                    }}
+                  />
+                </div>
+
+                <Text font="secondary-body" color="text-01">
+                  {`${formatTokens(row.input_tokens)} in · ${formatTokens(
+                    row.output_tokens
+                  )} out${
+                    hasCache
+                      ? ` · ${formatTokens(row.cache_read_tokens)} cache`
+                      : ""
+                  }`}
+                </Text>
+              </Section>
+            </div>
+          ))}
+        </Card>
+      )}
+    </Section>
+  );
+}
+
+interface ModelPriceSectionProps {
+  price: SelectedModelPrice | null;
+}
+
+function ModelPriceSection({ price }: ModelPriceSectionProps) {
+  return (
+    <Section gap={0.75} justifyContent="start">
+      <Content
+        icon={SvgCreditCard}
+        title="Your model's price"
+        sizePreset="main-content"
+        variant="section"
+        width="full"
+      />
+      <Card>
+        {price &&
+        price.input_per_mtok !== null &&
+        price.output_per_mtok !== null ? (
+          <Section
+            flexDirection="row"
+            justifyContent="between"
+            alignItems="center"
+            width="full"
+            gap={1}
+          >
+            <Text font="main-ui-body" color="text-03">
+              {`$${price.input_per_mtok.toFixed(2)} / 1M input`}
+            </Text>
+            <Text font="main-ui-body" color="text-03">
+              {`$${price.output_per_mtok.toFixed(2)} / 1M output`}
+            </Text>
+          </Section>
+        ) : (
+          <Text font="main-ui-body" color="text-01">
+            Price unavailable
+          </Text>
+        )}
+      </Card>
+    </Section>
+  );
+}
+
+interface BudgetSectionProps {
+  budgetCents: number | null;
+  budgetRemainingCents: number | null;
+  budgetPeriodHours: number | null;
+}
+
+// Hours -> a friendly window label so the budget reads "per week", not "per 168h".
+function formatPeriod(hours: number | null): string {
+  if (hours == null) return "";
+  if (hours % 168 === 0) {
+    const w = hours / 168;
+    return w === 1 ? "week" : `${w} weeks`;
+  }
+  if (hours % 24 === 0) {
+    const d = hours / 24;
+    return d === 1 ? "day" : `${d} days`;
+  }
+  return hours === 1 ? "hour" : `${hours} hours`;
+}
+
+function BudgetSection({
+  budgetCents,
+  budgetRemainingCents,
+  budgetPeriodHours,
+}: BudgetSectionProps) {
+  // budget_* are null until P5 enforcement ships; show a graceful empty state.
+  const hasBudget = budgetCents !== null;
+  const remaining = budgetRemainingCents ?? 0;
+  const spent = hasBudget ? Math.max(0, budgetCents - remaining) : 0;
+  const usedFraction =
+    hasBudget && budgetCents > 0 ? Math.min(1, spent / budgetCents) : 0;
+
+  return (
+    <Section gap={0.75} justifyContent="start">
+      <Content
+        icon={SvgWallet}
+        title="Budget"
+        sizePreset="main-content"
+        variant="section"
+        width="full"
+      />
+      <Card>
+        {hasBudget ? (
+          <Section gap={0.5} alignItems="start" justifyContent="start">
+            <Section
+              flexDirection="row"
+              justifyContent="between"
+              alignItems="center"
+              width="full"
+              gap={1}
+            >
+              <Text font="main-ui-body" color="text-03">
+                {`${formatDollars(remaining)} remaining`}
+              </Text>
+              <Text font="secondary-body" color="text-01">
+                {`of ${formatDollars(budgetCents)}${
+                  budgetPeriodHours ? ` per ${formatPeriod(budgetPeriodHours)}` : ""
+                }`}
+              </Text>
+            </Section>
+            <div className="w-full h-1.5 rounded-full bg-background-neutral-03 overflow-hidden">
+              <div
+                className={cn(
+                  "h-full rounded-full",
+                  usedFraction >= 1
+                    ? "bg-status-error-05"
+                    : "bg-theme-primary-05"
+                )}
+                style={{ width: `${usedFraction * 100}%` }}
+              />
+            </div>
+          </Section>
+        ) : (
+          <Text font="main-ui-body" color="text-01">
+            No budget set
+          </Text>
+        )}
+      </Card>
+    </Section>
+  );
+}
+
+export default function UsageSettings() {
+  const [days, setDays] = useState<string>(String(DEFAULT_DAYS));
+  const { data, error, isLoading } = useUserUsage(Number(days));
+
+  return (
+    <Section gap={2}>
+      <Section gap={0.75} justifyContent="start">
+        <Section
+          flexDirection="row"
+          justifyContent="between"
+          alignItems="center"
+          width="full"
+          gap={1}
+        >
+          <Content title="Usage" sizePreset="main-content" variant="section" />
+          <div className="min-w-32">
+            <InputSelect value={days} onValueChange={setDays}>
+              <InputSelect.Trigger placeholder="Period" />
+              <InputSelect.Content>
+                {DAYS_OPTIONS.map((option) => (
+                  <InputSelect.Item key={option} value={option}>
+                    {`Last ${option} days`}
+                  </InputSelect.Item>
+                ))}
+              </InputSelect.Content>
+            </InputSelect>
+          </div>
+        </Section>
+
+        {isLoading ? (
+          <Card>
+            <Section
+              flexDirection="row"
+              justifyContent="center"
+              alignItems="center"
+              width="full"
+            >
+              <SvgSimpleLoader />
+            </Section>
+          </Card>
+        ) : error || !data ? (
+          <EmptyMessageCard
+            sizePreset="main-ui"
+            title="Couldn't load usage"
+            description="Something went wrong fetching your usage. Try again in a moment."
+          />
+        ) : (
+          <Section gap={2}>
+            <WindowCostSection
+              windowCostCents={data.window_cost_cents}
+              rows={data.per_day_by_model}
+            />
+            <ModelPriceSection price={data.selected_model_price} />
+            <BudgetSection
+              budgetCents={data.budget_cents}
+              budgetRemainingCents={data.budget_remaining_cents}
+              budgetPeriodHours={data.budget_period_hours}
+            />
+          </Section>
+        )}
+      </Section>
+    </Section>
+  );
+}

--- a/web/src/app/app/settings/usage/lib.ts
+++ b/web/src/app/app/settings/usage/lib.ts
@@ -11,9 +11,12 @@ export interface UsagePerDayByModel {
   cost_cents: number;
 }
 
-export interface SelectedModelPrice {
+export interface ModelPrice {
+  model: string;
+  provider: string | null;
   input_per_mtok: number | null; // $/1M tokens; null if the model is unpriced
   output_per_mtok: number | null;
+  cache_per_mtok: number | null; // null => cache reads bill at the input rate
 }
 
 export interface UserUsageResponse {
@@ -24,7 +27,8 @@ export interface UserUsageResponse {
   budget_cents: number | null;
   budget_remaining_cents: number | null;
   budget_period_hours: number | null;
-  selected_model_price: SelectedModelPrice | null;
+  selected_model_price: ModelPrice | null;
+  available_model_prices: ModelPrice[];
 }
 
 export function useUserUsage(days: number) {

--- a/web/src/app/app/settings/usage/lib.ts
+++ b/web/src/app/app/settings/usage/lib.ts
@@ -1,0 +1,35 @@
+import useSWR from "swr";
+import { errorHandlingFetcher, skipRetryOnAuthError } from "@/lib/fetcher";
+import { SWR_KEYS } from "@/lib/swr-keys";
+
+export interface UsagePerDayByModel {
+  day: string; // "YYYY-MM-DD"
+  model: string;
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+  cost_cents: number;
+}
+
+export interface SelectedModelPrice {
+  input_per_mtok: number | null; // $/1M tokens; null if the model is unpriced
+  output_per_mtok: number | null;
+}
+
+export interface UserUsageResponse {
+  per_day_by_model: UsagePerDayByModel[];
+  window_cost_cents: number;
+  // The user's cost budget, what's left, and its window in hours (for the
+  // "per week/day/hour" label). All null when no cost limit applies.
+  budget_cents: number | null;
+  budget_remaining_cents: number | null;
+  budget_period_hours: number | null;
+  selected_model_price: SelectedModelPrice | null;
+}
+
+export function useUserUsage(days: number) {
+  return useSWR<UserUsageResponse>(SWR_KEYS.userUsage(days), errorHandlingFetcher, {
+    revalidateOnFocus: false,
+    onErrorRetry: skipRetryOnAuthError,
+  });
+}

--- a/web/src/app/app/settings/usage/page.tsx
+++ b/web/src/app/app/settings/usage/page.tsx
@@ -1,0 +1,5 @@
+import UsageSettings from "@/app/app/settings/usage/UsageSettings";
+
+export default function UsagePage() {
+  return <UsageSettings />;
+}

--- a/web/src/app/ee/admin/performance/usage/page.tsx
+++ b/web/src/app/ee/admin/performance/usage/page.tsx
@@ -7,6 +7,7 @@ import { QueryPerformanceChart } from "@/app/ee/admin/performance/usage/QueryPer
 import { PersonaMessagesChart } from "@/app/ee/admin/performance/usage/PersonaMessagesChart";
 import { useTimeRange } from "@/app/ee/admin/performance/lib";
 import UsageReports from "@/app/ee/admin/performance/usage/UsageReports";
+import PerUserUsagePanel from "@/views/admin/PerUserUsagePanel";
 import { Divider } from "@opal/components";
 import { useAdminAgents } from "@/lib/agents/hooks";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
@@ -33,6 +34,8 @@ export default function AnalyticsPage() {
           availablePersonas={agents}
           timeRange={timeRange}
         />
+        <Divider />
+        <PerUserUsagePanel />
         <Divider />
         <UsageReports />
       </SettingsLayouts.Body>

--- a/web/src/lib/languageModels/costOverrides.ts
+++ b/web/src/lib/languageModels/costOverrides.ts
@@ -7,20 +7,22 @@ import { SWR_KEYS } from "@/lib/swr-keys";
 
 /**
  * Admin-set negotiated per-model rate, overriding the built-in price book.
- * Rates are USD per MILLION tokens. There is no provider field — overrides
- * key solely on `model`.
+ * Rates are USD per MILLION tokens. Keyed on (provider, model); provider is ""
+ * for a provider-agnostic override.
  */
 export interface CostOverride {
   model: string;
+  provider: string;
   input_cost_per_mtok: number;
   output_cost_per_mtok: number;
   cache_read_cost_per_mtok: number | null; // null = bill cache at the input rate
   updated_at: string | null;
 }
 
-/** PUT body — an idempotent upsert keyed on `model`. */
+/** PUT body — an idempotent upsert keyed on (provider, model). */
 export interface CostOverrideUpsert {
   model: string;
+  provider?: string; // "" / omitted = provider-agnostic
   input_cost_per_mtok: number;
   output_cost_per_mtok: number;
   cache_read_cost_per_mtok: number | null;
@@ -34,7 +36,7 @@ export function useCostOverrides() {
   const { data, error, isLoading, mutate } = useSWR<CostOverride[]>(
     SWR_KEYS.costOverrides,
     errorHandlingFetcher,
-    { revalidateOnFocus: false }
+    { revalidateOnFocus: false },
   );
 
   return {
@@ -51,7 +53,7 @@ export function useCostOverrides() {
  * @throws Error with the API detail message on failure.
  */
 export async function upsertCostOverride(
-  body: CostOverrideUpsert
+  body: CostOverrideUpsert,
 ): Promise<CostOverride> {
   const response = await fetch(SWR_KEYS.costOverrides, {
     method: "PUT",
@@ -71,16 +73,21 @@ export async function upsertCostOverride(
  * the caller's intent (override absent) is satisfied either way.
  * @throws Error with the API detail message on non-404 failures.
  */
-export async function deleteCostOverride(model: string): Promise<void> {
+export async function deleteCostOverride(
+  model: string,
+  provider: string = "",
+): Promise<void> {
   // Keep "/" as real path separators (backend route is {model:path}) but encode
   // each segment, so slash-containing model ids (e.g. "bedrock/...") delete.
   const encodedModel = model
     .split("/")
     .map((segment) => encodeURIComponent(segment))
     .join("/");
-  const response = await fetch(`${SWR_KEYS.costOverrides}/${encodedModel}`, {
-    method: "DELETE",
-  });
+  const query = provider ? `?provider=${encodeURIComponent(provider)}` : "";
+  const response = await fetch(
+    `${SWR_KEYS.costOverrides}/${encodedModel}${query}`,
+    { method: "DELETE" },
+  );
 
   if (response.ok || response.status === 404) {
     return;
@@ -91,7 +98,7 @@ export async function deleteCostOverride(model: string): Promise<void> {
 
 /** Revalidate the overrides list after a mutation. */
 export async function refreshCostOverrides(
-  mutate: ScopedMutator
+  mutate: ScopedMutator,
 ): Promise<void> {
   await mutate(SWR_KEYS.costOverrides);
 }

--- a/web/src/lib/languageModels/costOverrides.ts
+++ b/web/src/lib/languageModels/costOverrides.ts
@@ -1,0 +1,107 @@
+"use client";
+
+import useSWR from "swr";
+import type { ScopedMutator } from "swr";
+import { errorHandlingFetcher } from "@/lib/fetcher";
+import { SWR_KEYS } from "@/lib/swr-keys";
+
+/**
+ * Admin-set negotiated per-model rate, overriding the built-in price book.
+ * Rates are USD per MILLION tokens. There is no provider field — overrides
+ * key solely on `model`.
+ */
+export interface CostOverride {
+  model: string;
+  input_cost_per_mtok: number;
+  output_cost_per_mtok: number;
+  cache_read_cost_per_mtok: number | null; // null = bill cache at the input rate
+  updated_at: string | null;
+}
+
+/** PUT body — an idempotent upsert keyed on `model`. */
+export interface CostOverrideUpsert {
+  model: string;
+  input_cost_per_mtok: number;
+  output_cost_per_mtok: number;
+  cache_read_cost_per_mtok: number | null;
+}
+
+/**
+ * Lists existing cost overrides via `GET /api/admin/cost-overrides` (admin).
+ * Mutate `SWR_KEYS.costOverrides` after a write to revalidate.
+ */
+export function useCostOverrides() {
+  const { data, error, isLoading, mutate } = useSWR<CostOverride[]>(
+    SWR_KEYS.costOverrides,
+    errorHandlingFetcher,
+    { revalidateOnFocus: false }
+  );
+
+  return {
+    costOverrides: data,
+    isLoading,
+    error,
+    refetch: mutate,
+  };
+}
+
+/**
+ * Upserts a cost override. PUT is idempotent — re-sending an existing model
+ * updates its rates rather than erroring.
+ * @throws Error with the API detail message on failure.
+ */
+export async function upsertCostOverride(
+  body: CostOverrideUpsert
+): Promise<CostOverride> {
+  const response = await fetch(SWR_KEYS.costOverrides, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    throw new Error(await extractError(response));
+  }
+
+  return response.json();
+}
+
+/**
+ * Deletes a cost override by model name. A 404 (already gone) is swallowed —
+ * the caller's intent (override absent) is satisfied either way.
+ * @throws Error with the API detail message on non-404 failures.
+ */
+export async function deleteCostOverride(model: string): Promise<void> {
+  // Keep "/" as real path separators (backend route is {model:path}) but encode
+  // each segment, so slash-containing model ids (e.g. "bedrock/...") delete.
+  const encodedModel = model
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+  const response = await fetch(`${SWR_KEYS.costOverrides}/${encodedModel}`, {
+    method: "DELETE",
+  });
+
+  if (response.ok || response.status === 404) {
+    return;
+  }
+
+  throw new Error(await extractError(response));
+}
+
+/** Revalidate the overrides list after a mutation. */
+export async function refreshCostOverrides(
+  mutate: ScopedMutator
+): Promise<void> {
+  await mutate(SWR_KEYS.costOverrides);
+}
+
+/** Pull the backend's `detail`/`error_code`, falling back to the status text. */
+async function extractError(response: Response): Promise<string> {
+  try {
+    const data = await response.json();
+    return data.detail || data.error_code || response.statusText;
+  } catch {
+    return response.statusText;
+  }
+}

--- a/web/src/lib/swr-keys.ts
+++ b/web/src/lib/swr-keys.ts
@@ -42,6 +42,8 @@ export const SWR_KEYS = {
     `/api/admin/llm/built-in/options/${providerEndpoint}`,
   llmContextualCost: "/api/admin/llm/provider-contextual-cost",
   costOverrides: "/api/admin/cost-overrides",
+  adminUsageExport: "/api/admin/usage/export",
+  adminUsageReset: "/api/admin/usage/reset",
   userUsage: (days: number) => `/api/user/usage?days=${days}`,
 
   // ── Image Generation ──────────────────────────────────────────────────────

--- a/web/src/lib/swr-keys.ts
+++ b/web/src/lib/swr-keys.ts
@@ -41,6 +41,8 @@ export const SWR_KEYS = {
   wellKnownLlmProvider: (providerEndpoint: string) =>
     `/api/admin/llm/built-in/options/${providerEndpoint}`,
   llmContextualCost: "/api/admin/llm/provider-contextual-cost",
+  costOverrides: "/api/admin/cost-overrides",
+  userUsage: (days: number) => `/api/user/usage?days=${days}`,
 
   // ── Image Generation ──────────────────────────────────────────────────────
   imageGenConfig: "/api/admin/image-generation/config",

--- a/web/src/lib/usage/userUsage.ts
+++ b/web/src/lib/usage/userUsage.ts
@@ -1,0 +1,55 @@
+"use client";
+
+import useSWR from "swr";
+import { errorHandlingFetcher } from "@/lib/fetcher";
+import { SWR_KEYS } from "@/lib/swr-keys";
+
+export interface UsageExportTotals {
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+  cost_cents: number;
+}
+
+export interface UsageExportUser {
+  email: string;
+  totals: UsageExportTotals;
+}
+
+export interface UsageExportResponse {
+  start: string;
+  end: string;
+  users: UsageExportUser[];
+}
+
+/**
+ * Company-wide per-user usage (admin). GET /api/admin/usage/export.
+ * Mutate the returned `refetch` after a reset to revalidate the table.
+ */
+export function useUsageExport() {
+  const { data, error, isLoading, mutate } = useSWR<UsageExportResponse>(
+    SWR_KEYS.adminUsageExport,
+    errorHandlingFetcher,
+    { revalidateOnFocus: false },
+  );
+
+  return { usage: data, isLoading, error, refetch: mutate };
+}
+
+/**
+ * Clears a user's current-window usage to lift a budget block (prior windows
+ * are preserved). POST /api/admin/usage/reset.
+ * @throws Error with the API detail message on failure.
+ */
+export async function resetUserUsage(userEmail: string): Promise<void> {
+  const response = await fetch(SWR_KEYS.adminUsageReset, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ user_email: userEmail }),
+  });
+
+  if (!response.ok) {
+    const data = await response.json().catch(() => null);
+    throw new Error(data?.detail || data?.error_code || response.statusText);
+  }
+}

--- a/web/src/views/admin/CostOverridesPanel.tsx
+++ b/web/src/views/admin/CostOverridesPanel.tsx
@@ -48,15 +48,15 @@ function OverrideForm({ existing, onDone }: OverrideFormProps) {
   const { mutate } = useSWRConfig();
   const [model, setModel] = useState(existing?.model ?? "");
   const [inputRate, setInputRate] = useState(
-    existing ? String(existing.input_cost_per_mtok) : ""
+    existing ? String(existing.input_cost_per_mtok) : "",
   );
   const [outputRate, setOutputRate] = useState(
-    existing ? String(existing.output_cost_per_mtok) : ""
+    existing ? String(existing.output_cost_per_mtok) : "",
   );
   const [cacheRate, setCacheRate] = useState(
     existing?.cache_read_cost_per_mtok != null
       ? String(existing.cache_read_cost_per_mtok)
-      : ""
+      : "",
   );
   const [submitting, setSubmitting] = useState(false);
 
@@ -79,8 +79,15 @@ function OverrideForm({ existing, onDone }: OverrideFormProps) {
   const isEdit = existing !== undefined;
   const parsedInput = parseRate(inputRate);
   const parsedOutput = parseRate(outputRate);
+  // Empty cache rate is valid (bill cache reads at the input rate); a non-empty
+  // but unparseable value must block submit, not silently drop to null.
+  const parsedCache = parseRate(cacheRate);
+  const cacheValid = cacheRate.trim() === "" || parsedCache !== null;
   const canSubmit =
-    model.trim() !== "" && parsedInput !== null && parsedOutput !== null;
+    model.trim() !== "" &&
+    parsedInput !== null &&
+    parsedOutput !== null &&
+    cacheValid;
 
   async function handleSubmit() {
     if (!canSubmit || parsedInput === null || parsedOutput === null) return;
@@ -91,7 +98,7 @@ function OverrideForm({ existing, onDone }: OverrideFormProps) {
         input_cost_per_mtok: parsedInput,
         output_cost_per_mtok: parsedOutput,
         // Empty cache rate => null (cache reads bill at the input rate).
-        cache_read_cost_per_mtok: parseRate(cacheRate),
+        cache_read_cost_per_mtok: parsedCache,
       });
       await refreshCostOverrides(mutate);
       toast.success(`Saved rate for ${model.trim()}.`);
@@ -237,7 +244,7 @@ function OverrideRow({ override }: OverrideRowProps) {
             </Text>
             <Text font="secondary-body" color="text-03">
               {`In ${formatRate(override.input_cost_per_mtok)} · Out ${formatRate(
-                override.output_cost_per_mtok
+                override.output_cost_per_mtok,
               )}${
                 override.cache_read_cost_per_mtok != null
                   ? ` · Cache ${formatRate(override.cache_read_cost_per_mtok)}`
@@ -293,7 +300,7 @@ export default function CostOverridesPanel() {
       <ContentAction
         title="Cost Overrides"
         description={markdown(
-          `Set negotiated per-model rates in **${RATE_UNIT_LABEL}**. These override the built-in price book for usage cost calculations.`
+          `Set negotiated per-model rates in **${RATE_UNIT_LABEL}**. These override the built-in price book for usage cost calculations.`,
         )}
         sizePreset="main-content"
         variant="section"

--- a/web/src/views/admin/CostOverridesPanel.tsx
+++ b/web/src/views/admin/CostOverridesPanel.tsx
@@ -1,0 +1,339 @@
+"use client";
+
+import { ChangeEvent, useMemo, useState } from "react";
+import { useSWRConfig } from "swr";
+import { toast } from "@/hooks/useToast";
+import { ThreeDotsLoader } from "@/components/Loading";
+import { ContentAction } from "@opal/layouts";
+import { Button, Card, InputTypeIn, MessageCard, Text } from "@opal/components";
+import { Hoverable } from "@opal/core";
+import { SvgCheck, SvgEdit, SvgPlus, SvgTrash, SvgX } from "@opal/icons";
+import { markdown } from "@opal/utils";
+import InputComboBox from "@/refresh-components/inputs/InputComboBox";
+import { useAdminLLMProviders } from "@/hooks/useLanguageModels";
+import * as GeneralLayouts from "@/layouts/general-layouts";
+import {
+  CostOverride,
+  deleteCostOverride,
+  refreshCostOverrides,
+  upsertCostOverride,
+  useCostOverrides,
+} from "@/lib/languageModels/costOverrides";
+
+const RATE_UNIT_LABEL = "USD per 1M tokens";
+
+// Accepts integers/decimals only; "" is allowed mid-edit, validated on submit.
+function parseRate(raw: string): number | null {
+  if (raw.trim() === "") return null;
+  if (!/^\d*\.?\d+$/.test(raw.trim())) return null;
+  const value = Number(raw);
+  return Number.isFinite(value) && value >= 0 ? value : null;
+}
+
+function formatRate(value: number): string {
+  return `$${value.toFixed(2)}`;
+}
+
+// ============================================================================
+// OverrideForm — shared add/edit form (PUT upsert)
+// ============================================================================
+
+interface OverrideFormProps {
+  // Editing an existing row locks the model name (it's the upsert key).
+  existing?: CostOverride;
+  onDone: () => void;
+}
+
+function OverrideForm({ existing, onDone }: OverrideFormProps) {
+  const { mutate } = useSWRConfig();
+  const [model, setModel] = useState(existing?.model ?? "");
+  const [inputRate, setInputRate] = useState(
+    existing ? String(existing.input_cost_per_mtok) : ""
+  );
+  const [outputRate, setOutputRate] = useState(
+    existing ? String(existing.output_cost_per_mtok) : ""
+  );
+  const [cacheRate, setCacheRate] = useState(
+    existing?.cache_read_cost_per_mtok != null
+      ? String(existing.cache_read_cost_per_mtok)
+      : ""
+  );
+  const [submitting, setSubmitting] = useState(false);
+
+  // Offer the org's configured models as options so the override key matches the
+  // model id actually recorded in usage (free-text still allowed for a model not
+  // yet configured, e.g. an embedding/rerank id).
+  const { llmProviders } = useAdminLLMProviders();
+  const modelOptions = useMemo(() => {
+    const names = new Set<string>();
+    for (const provider of llmProviders ?? []) {
+      for (const mc of provider.model_configurations) {
+        names.add(mc.name);
+      }
+    }
+    return Array.from(names)
+      .sort()
+      .map((name) => ({ value: name, label: name }));
+  }, [llmProviders]);
+
+  const isEdit = existing !== undefined;
+  const parsedInput = parseRate(inputRate);
+  const parsedOutput = parseRate(outputRate);
+  const canSubmit =
+    model.trim() !== "" && parsedInput !== null && parsedOutput !== null;
+
+  async function handleSubmit() {
+    if (!canSubmit || parsedInput === null || parsedOutput === null) return;
+    setSubmitting(true);
+    try {
+      await upsertCostOverride({
+        model: model.trim(),
+        input_cost_per_mtok: parsedInput,
+        output_cost_per_mtok: parsedOutput,
+        // Empty cache rate => null (cache reads bill at the input rate).
+        cache_read_cost_per_mtok: parseRate(cacheRate),
+      });
+      await refreshCostOverrides(mutate);
+      toast.success(`Saved rate for ${model.trim()}.`);
+      onDone();
+    } catch (e) {
+      const message = e instanceof Error ? e.message : "Unknown error";
+      toast.error(`Failed to save override: ${message}`);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Card border="solid" rounding="lg">
+      <GeneralLayouts.Section
+        gap={0.75}
+        height="fit"
+        alignItems="stretch"
+        justifyContent="start"
+      >
+        <div className="flex flex-col gap-1">
+          <Text font="secondary-action" color="text-03">
+            Model
+          </Text>
+          {isEdit ? (
+            <InputTypeIn value={model} variant="readOnly" />
+          ) : (
+            <InputComboBox
+              value={model}
+              options={modelOptions}
+              strict={false}
+              placeholder="Select a configured model, or type a model id"
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                setModel(e.target.value)
+              }
+              onValueChange={(value: string) => setModel(value)}
+            />
+          )}
+        </div>
+
+        <div className="grid grid-cols-2 gap-2">
+          <div className="flex flex-col gap-1">
+            <Text font="secondary-action" color="text-03">
+              {`Input rate (${RATE_UNIT_LABEL})`}
+            </Text>
+            <InputTypeIn
+              value={inputRate}
+              prefixText="$"
+              inputMode="decimal"
+              placeholder="3.00"
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                setInputRate(e.target.value)
+              }
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <Text font="secondary-action" color="text-03">
+              {`Output rate (${RATE_UNIT_LABEL})`}
+            </Text>
+            <InputTypeIn
+              value={outputRate}
+              prefixText="$"
+              inputMode="decimal"
+              placeholder="15.00"
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                setOutputRate(e.target.value)
+              }
+            />
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <Text font="secondary-action" color="text-03">
+            {`Cache-read rate (${RATE_UNIT_LABEL}, optional)`}
+          </Text>
+          <InputTypeIn
+            value={cacheRate}
+            prefixText="$"
+            inputMode="decimal"
+            placeholder="defaults to input rate"
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              setCacheRate(e.target.value)
+            }
+          />
+        </div>
+
+        <div className="flex flex-row gap-2 justify-end">
+          <Button prominence="tertiary" onClick={onDone} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button
+            icon={SvgCheck}
+            onClick={handleSubmit}
+            disabled={!canSubmit || submitting}
+          >
+            {isEdit ? "Save" : "Add override"}
+          </Button>
+        </div>
+      </GeneralLayouts.Section>
+    </Card>
+  );
+}
+
+// ============================================================================
+// OverrideRow — one configured override with edit + delete
+// ============================================================================
+
+interface OverrideRowProps {
+  override: CostOverride;
+}
+
+function OverrideRow({ override }: OverrideRowProps) {
+  const { mutate } = useSWRConfig();
+  const [editing, setEditing] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  async function handleDelete() {
+    setDeleting(true);
+    try {
+      await deleteCostOverride(override.model);
+      await refreshCostOverrides(mutate);
+      toast.success(`Removed override for ${override.model}.`);
+    } catch (e) {
+      const message = e instanceof Error ? e.message : "Unknown error";
+      toast.error(`Failed to remove override: ${message}`);
+      setDeleting(false);
+    }
+  }
+
+  if (editing) {
+    return (
+      <OverrideForm existing={override} onDone={() => setEditing(false)} />
+    );
+  }
+
+  return (
+    <Hoverable.Root group="OverrideRow">
+      <Card border="solid" rounding="lg" padding="sm">
+        <div className="flex flex-row items-center justify-between gap-2 p-2">
+          <div className="flex flex-col gap-0.5 min-w-0">
+            <Text font="main-ui-action" color="text-04" nowrap>
+              {override.model}
+            </Text>
+            <Text font="secondary-body" color="text-03">
+              {`In ${formatRate(override.input_cost_per_mtok)} · Out ${formatRate(
+                override.output_cost_per_mtok
+              )}${
+                override.cache_read_cost_per_mtok != null
+                  ? ` · Cache ${formatRate(override.cache_read_cost_per_mtok)}`
+                  : ""
+              } · ${RATE_UNIT_LABEL}`}
+            </Text>
+            {override.updated_at && (
+              <Text font="secondary-body" color="text-02">
+                {`Updated ${new Date(override.updated_at).toLocaleString()}`}
+              </Text>
+            )}
+          </div>
+
+          <div className="flex flex-row">
+            <Button
+              icon={SvgEdit}
+              prominence="tertiary"
+              aria-label={`Edit override for ${override.model}`}
+              disabled={deleting}
+              onClick={() => setEditing(true)}
+            />
+            <Hoverable.Item group="OverrideRow" variant="appear-on-hover">
+              <Button
+                icon={SvgTrash}
+                prominence="tertiary"
+                aria-label={`Delete override for ${override.model}`}
+                disabled={deleting}
+                onClick={handleDelete}
+              />
+            </Hoverable.Item>
+          </div>
+        </div>
+      </Card>
+    </Hoverable.Root>
+  );
+}
+
+// ============================================================================
+// CostOverridesPanel — section embedded on the Language Models page
+// ============================================================================
+
+export default function CostOverridesPanel() {
+  const { costOverrides, isLoading, error } = useCostOverrides();
+  const [adding, setAdding] = useState(false);
+
+  return (
+    <GeneralLayouts.Section
+      gap={0.75}
+      height="fit"
+      alignItems="stretch"
+      justifyContent="start"
+    >
+      <ContentAction
+        title="Cost Overrides"
+        description={markdown(
+          `Set negotiated per-model rates in **${RATE_UNIT_LABEL}**. These override the built-in price book for usage cost calculations.`
+        )}
+        sizePreset="main-content"
+        variant="section"
+        rightChildren={
+          <Button
+            icon={SvgPlus}
+            prominence="secondary"
+            disabled={adding}
+            onClick={() => setAdding(true)}
+          >
+            Add override
+          </Button>
+        }
+      />
+
+      {adding && <OverrideForm onDone={() => setAdding(false)} />}
+
+      {error ? (
+        <MessageCard
+          variant="error"
+          icon={SvgX}
+          title="Failed to load cost overrides."
+        />
+      ) : isLoading ? (
+        <ThreeDotsLoader />
+      ) : costOverrides && costOverrides.length > 0 ? (
+        <div className="flex flex-col gap-2">
+          {costOverrides.map((override) => (
+            <OverrideRow key={override.model} override={override} />
+          ))}
+        </div>
+      ) : (
+        !adding && (
+          <MessageCard
+            variant="info"
+            title="No cost overrides set."
+            description={`Add one to apply a negotiated rate (${RATE_UNIT_LABEL}) for a model.`}
+          />
+        )
+      )}
+    </GeneralLayouts.Section>
+  );
+}

--- a/web/src/views/admin/CostOverridesPanel.tsx
+++ b/web/src/views/admin/CostOverridesPanel.tsx
@@ -1,16 +1,23 @@
 "use client";
 
-import { ChangeEvent, useMemo, useState } from "react";
+import { ChangeEvent, useState } from "react";
 import { useSWRConfig } from "swr";
 import { toast } from "@/hooks/useToast";
 import { PageLoader } from "@/refresh-components/PageLoader";
 import { ContentAction } from "@opal/layouts";
-import { Button, Card, InputTypeIn, MessageCard, Text } from "@opal/components";
+import {
+  Button,
+  Card,
+  InputTypeIn,
+  MessageCard,
+  OpenButton,
+  Text,
+} from "@opal/components";
 import { Hoverable } from "@opal/core";
 import { SvgCheck, SvgEdit, SvgPlus, SvgTrash, SvgX } from "@opal/icons";
 import { markdown } from "@opal/utils";
-import InputComboBox from "@/refresh-components/inputs/InputComboBox";
-import { useAdminLLMProviders } from "@/lib/languageModels/hooks";
+import ModelSelector from "@/sections/model-selector/ModelSelector";
+import { LLMOption } from "@/lib/languageModels/options";
 import * as GeneralLayouts from "@/layouts/general-layouts";
 import {
   CostOverride,
@@ -60,21 +67,9 @@ function OverrideForm({ existing, onDone }: OverrideFormProps) {
   );
   const [submitting, setSubmitting] = useState(false);
 
-  // Offer the org's configured models as options so the override key matches the
-  // model id actually recorded in usage (free-text still allowed for a model not
-  // yet configured, e.g. an embedding/rerank id).
-  const { llmProviders } = useAdminLLMProviders();
-  const modelOptions = useMemo(() => {
-    const names = new Set<string>();
-    for (const provider of llmProviders ?? []) {
-      for (const mc of provider.model_configurations) {
-        names.add(mc.name);
-      }
-    }
-    return Array.from(names)
-      .sort()
-      .map((name) => ({ value: name, label: name }));
-  }, [llmProviders]);
+  // The override keys on the model name; track the picked config id too so the
+  // selector can highlight the current choice.
+  const [modelConfigId, setModelConfigId] = useState<number | null>(null);
 
   const isEdit = existing !== undefined;
   const parsedInput = parseRate(inputRate);
@@ -127,15 +122,16 @@ function OverrideForm({ existing, onDone }: OverrideFormProps) {
           {isEdit ? (
             <InputTypeIn value={model} variant="readOnly" />
           ) : (
-            <InputComboBox
-              value={model}
-              options={modelOptions}
-              strict={false}
-              placeholder="Select a configured model, or type a model id"
-              onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                setModel(e.target.value)
-              }
-              onValueChange={(value: string) => setModel(value)}
+            <ModelSelector
+              value={modelConfigId}
+              onChange={(opt: LLMOption) => {
+                setModel(opt.modelName);
+                setModelConfigId(opt.modelConfigurationId ?? null);
+              }}
+              renderTrigger={() => (
+                <OpenButton>{model || "Select a model"}</OpenButton>
+              )}
+              side="bottom"
             />
           )}
         </div>

--- a/web/src/views/admin/CostOverridesPanel.tsx
+++ b/web/src/views/admin/CostOverridesPanel.tsx
@@ -10,7 +10,7 @@ import { Hoverable } from "@opal/core";
 import { SvgCheck, SvgEdit, SvgPlus, SvgTrash, SvgX } from "@opal/icons";
 import { markdown } from "@opal/utils";
 import InputComboBox from "@/refresh-components/inputs/InputComboBox";
-import { useAdminLLMProviders } from "@/hooks/useLanguageModels";
+import { useAdminLLMProviders } from "@/lib/languageModels/hooks";
 import * as GeneralLayouts from "@/layouts/general-layouts";
 import {
   CostOverride,
@@ -104,6 +104,7 @@ function OverrideForm({ existing, onDone }: OverrideFormProps) {
       toast.success(`Saved rate for ${model.trim()}.`);
       onDone();
     } catch (e) {
+      console.error("Failed to save cost override", e);
       const message = e instanceof Error ? e.message : "Unknown error";
       toast.error(`Failed to save override: ${message}`);
     } finally {
@@ -218,10 +219,11 @@ function OverrideRow({ override }: OverrideRowProps) {
   async function handleDelete() {
     setDeleting(true);
     try {
-      await deleteCostOverride(override.model);
+      await deleteCostOverride(override.model, override.provider);
       await refreshCostOverrides(mutate);
       toast.success(`Removed override for ${override.model}.`);
     } catch (e) {
+      console.error("Failed to remove cost override", e);
       const message = e instanceof Error ? e.message : "Unknown error";
       toast.error(`Failed to remove override: ${message}`);
       setDeleting(false);
@@ -329,7 +331,10 @@ export default function CostOverridesPanel() {
       ) : costOverrides && costOverrides.length > 0 ? (
         <div className="flex flex-col gap-2">
           {costOverrides.map((override) => (
-            <OverrideRow key={override.model} override={override} />
+            <OverrideRow
+              key={`${override.provider}:${override.model}`}
+              override={override}
+            />
           ))}
         </div>
       ) : (

--- a/web/src/views/admin/CostOverridesPanel.tsx
+++ b/web/src/views/admin/CostOverridesPanel.tsx
@@ -3,7 +3,7 @@
 import { ChangeEvent, useMemo, useState } from "react";
 import { useSWRConfig } from "swr";
 import { toast } from "@/hooks/useToast";
-import { ThreeDotsLoader } from "@/components/Loading";
+import { PageLoader } from "@/refresh-components/PageLoader";
 import { ContentAction } from "@opal/layouts";
 import { Button, Card, InputTypeIn, MessageCard, Text } from "@opal/components";
 import { Hoverable } from "@opal/core";
@@ -327,7 +327,7 @@ export default function CostOverridesPanel() {
           title="Failed to load cost overrides."
         />
       ) : isLoading ? (
-        <ThreeDotsLoader />
+        <PageLoader />
       ) : costOverrides && costOverrides.length > 0 ? (
         <div className="flex flex-col gap-2">
           {costOverrides.map((override) => (

--- a/web/src/views/admin/GroupsPage/CreateGroupPage.tsx
+++ b/web/src/views/admin/GroupsPage/CreateGroupPage.tsx
@@ -33,7 +33,7 @@ function CreateGroupPage() {
   const [selectedDocSetIds, setSelectedDocSetIds] = useState<number[]>([]);
   const [selectedAgentIds, setSelectedAgentIds] = useState<number[]>([]);
   const [tokenLimits, setTokenLimits] = useState<TokenLimit[]>([
-    { tokenBudget: null, periodHours: null },
+    { tokenBudget: null, periodHours: null, costBudgetDollars: null },
   ]);
 
   const { rows: allRows, isLoading, error } = useGroupMemberCandidates();

--- a/web/src/views/admin/GroupsPage/EditGroupPage.tsx
+++ b/web/src/views/admin/GroupsPage/EditGroupPage.tsx
@@ -101,7 +101,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
   const [selectedDocSetIds, setSelectedDocSetIds] = useState<number[]>([]);
   const [selectedAgentIds, setSelectedAgentIds] = useState<number[]>([]);
   const [tokenLimits, setTokenLimits] = useState<TokenLimit[]>([
-    { tokenBudget: null, periodHours: null },
+    { tokenBudget: null, periodHours: null, costBudgetDollars: null },
   ]);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -143,6 +143,8 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
         tokenRateLimits.map((trl) => ({
           tokenBudget: trl.token_budget,
           periodHours: trl.period_hours,
+          costBudgetDollars:
+            trl.cost_budget_cents != null ? trl.cost_budget_cents / 100 : null,
         }))
       );
     }

--- a/web/src/views/admin/GroupsPage/TokenLimitSection.tsx
+++ b/web/src/views/admin/GroupsPage/TokenLimitSection.tsx
@@ -20,6 +20,8 @@ import SimpleCollapsible from "@/refresh-components/SimpleCollapsible";
 export interface TokenLimit {
   tokenBudget: number | null;
   periodHours: number | null;
+  // Dollars in the form; converted to cost_budget_cents at the API boundary.
+  costBudgetDollars: number | null;
 }
 
 interface TokenLimitSectionProps {
@@ -54,12 +56,18 @@ function TokenLimitSection({
 
   function addLimit() {
     const emptyIndex = limits.findIndex(
-      (l) => l.tokenBudget === null && l.periodHours === null
+      (l) =>
+        l.tokenBudget === null &&
+        l.periodHours === null &&
+        l.costBudgetDollars === null
     );
     if (emptyIndex !== -1) return;
     const key = nextKeyRef.current++;
     keysRef.current = [...keysRef.current, key];
-    onLimitsChange([...limits, { tokenBudget: null, periodHours: null }]);
+    onLimitsChange([
+      ...limits,
+      { tokenBudget: null, periodHours: null, costBudgetDollars: null },
+    ]);
   }
 
   function removeLimit(index: number) {
@@ -103,7 +111,15 @@ function TokenLimitSection({
                     Token Limit
                   </Text>
                   <Text mainUiMuted text03 className="ml-0.5">
-                    (thousand tokens)
+                    (thousands)
+                  </Text>
+                </div>
+                <div className="flex-1 flex items-center min-w-[160px]">
+                  <Text mainUiAction text04>
+                    Cost Limit
+                  </Text>
+                  <Text mainUiMuted text03 className="ml-0.5">
+                    (USD)
                   </Text>
                 </div>
                 <div className="flex-1 flex items-center min-w-[160px]">
@@ -127,7 +143,15 @@ function TokenLimitSection({
                       value={limit.tokenBudget}
                       onChange={(v) => updateLimit(i, "tokenBudget", v)}
                       min={0}
-                      placeholder="Token limit in thousands"
+                      placeholder="Token limit (thousands)"
+                    />
+                  </div>
+                  <div className="flex-1">
+                    <InputNumber
+                      value={limit.costBudgetDollars}
+                      onChange={(v) => updateLimit(i, "costBudgetDollars", v)}
+                      min={0}
+                      placeholder="Cost limit"
                     />
                   </div>
                   <div className="flex-1">

--- a/web/src/views/admin/GroupsPage/interfaces.ts
+++ b/web/src/views/admin/GroupsPage/interfaces.ts
@@ -17,6 +17,8 @@ export interface MemberRow extends UserRow {
 export interface TokenRateLimitDisplay {
   token_id: number;
   enabled: boolean;
-  token_budget: number;
+  // null for a cost-only limit (matches the backend's nullable column).
+  token_budget: number | null;
   period_hours: number;
+  cost_budget_cents: number | null;
 }

--- a/web/src/views/admin/GroupsPage/svc.ts
+++ b/web/src/views/admin/GroupsPage/svc.ts
@@ -202,13 +202,22 @@ async function updateDocSetGroupSharing(
 interface TokenLimitPayload {
   tokenBudget: number | null;
   periodHours: number | null;
+  costBudgetDollars: number | null;
 }
 
 interface ExistingTokenLimit {
   token_id: number;
   enabled: boolean;
-  token_budget: number;
+  token_budget: number | null;
   period_hours: number;
+  cost_budget_cents: number | null;
+}
+
+interface ValidTokenLimit {
+  // null = cost-only (the gate skips a null/<=0 token budget); never send 0.
+  tokenBudget: number | null;
+  periodHours: number;
+  costBudgetCents: number | null;
 }
 
 async function saveTokenLimits(
@@ -216,11 +225,26 @@ async function saveTokenLimits(
   limits: TokenLimitPayload[],
   existing: ExistingTokenLimit[]
 ): Promise<void> {
-  // Filter to only valid (non-null) limits
-  const validLimits = limits.filter(
-    (l): l is { tokenBudget: number; periodHours: number } =>
-      l.tokenBudget != null && l.periodHours != null
-  );
+  // A budget only counts when it's strictly positive — a 0/negative token
+  // budget or a cost that rounds to 0 cents is "unset", not a real limit
+  // (sending it would overwrite a real existing limit via positional matching).
+  // A row is valid with a time window plus at least one positive budget.
+  const validLimits: ValidTokenLimit[] = limits
+    .map((l) => {
+      const tokenBudget =
+        l.tokenBudget != null && l.tokenBudget > 0 ? l.tokenBudget : null;
+      const cents =
+        l.costBudgetDollars != null
+          ? Math.round(l.costBudgetDollars * 100)
+          : null;
+      const costBudgetCents = cents != null && cents > 0 ? cents : null;
+      return { tokenBudget, periodHours: l.periodHours, costBudgetCents };
+    })
+    .filter(
+      (l): l is ValidTokenLimit =>
+        l.periodHours != null &&
+        (l.tokenBudget != null || l.costBudgetCents != null)
+    );
 
   // Update existing limits (match by index position)
   const toUpdate = Math.min(validLimits.length, existing.length);
@@ -236,6 +260,7 @@ async function saveTokenLimits(
           enabled: existingLimit.enabled,
           token_budget: limit.tokenBudget,
           period_hours: limit.periodHours,
+          cost_budget_cents: limit.costBudgetCents,
         }),
       }
     );
@@ -258,6 +283,7 @@ async function saveTokenLimits(
           enabled: true,
           token_budget: limit.tokenBudget,
           period_hours: limit.periodHours,
+          cost_budget_cents: limit.costBudgetCents,
         }),
       }
     );

--- a/web/src/views/admin/LanguageModelsPage.tsx
+++ b/web/src/views/admin/LanguageModelsPage.tsx
@@ -32,6 +32,7 @@ import { LLMProviderName, LLMProviderView } from "@/lib/languageModels/types";
 import { Section } from "@/layouts/general-layouts";
 import { markdown } from "@opal/utils";
 import { usePHFeatureFlag, PHFeatureFlag } from "@/lib/analytics/hooks";
+import CostOverridesPanel from "@/views/admin/CostOverridesPanel";
 
 const route = ADMIN_ROUTES.LLM_MODELS;
 
@@ -468,6 +469,11 @@ export default function LanguageModelsPage() {
             </div>
           </GeneralLayouts.Section>
         </Disabled>
+
+        <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+
+        {/* ── Cost Overrides — negotiated per-model rates for usage costing ── */}
+        <CostOverridesPanel />
       </SettingsLayouts.Body>
     </SettingsLayouts.Root>
   );

--- a/web/src/views/admin/PerUserUsagePanel.tsx
+++ b/web/src/views/admin/PerUserUsagePanel.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "@/hooks/useToast";
+import { PageLoader } from "@/refresh-components/PageLoader";
+import { Button, Card, MessageCard, Text } from "@opal/components";
+import { SvgX } from "@opal/icons";
+import {
+  resetUserUsage,
+  useUsageExport,
+  UsageExportUser,
+} from "@/lib/usage/userUsage";
+
+function formatTokens(n: number): string {
+  return n.toLocaleString();
+}
+
+function formatCost(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+interface UsageRowProps {
+  user: UsageExportUser;
+  onReset: () => void;
+}
+
+function UsageRow({ user, onReset }: UsageRowProps) {
+  const [resetting, setResetting] = useState(false);
+  const totals = user.totals;
+
+  async function handleReset() {
+    setResetting(true);
+    try {
+      await resetUserUsage(user.email);
+      toast.success(`Reset usage for ${user.email}.`);
+      onReset();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "unknown error";
+      toast.error(`Failed to reset usage: ${message}`);
+    } finally {
+      setResetting(false);
+    }
+  }
+
+  return (
+    <div
+      className="flex flex-row items-center gap-4 py-2"
+      data-testid={`usage-row-${user.email}`}
+    >
+      <div className="flex-1 truncate">
+        <Text font="main-ui-body">{user.email}</Text>
+      </div>
+      <div className="w-28 text-right">
+        <Text font="main-ui-body" color="text-03">
+          {formatTokens(totals.input_tokens)}
+        </Text>
+      </div>
+      <div className="w-28 text-right">
+        <Text font="main-ui-body" color="text-03">
+          {formatTokens(totals.output_tokens)}
+        </Text>
+      </div>
+      <div className="w-24 text-right">
+        <Text font="main-ui-body">{formatCost(totals.cost_cents)}</Text>
+      </div>
+      <Button
+        variant="default"
+        prominence="tertiary"
+        size="sm"
+        disabled={resetting}
+        onClick={handleReset}
+      >
+        Reset
+      </Button>
+    </div>
+  );
+}
+
+/**
+ * Admin table of per-user token/cost usage for the report window, each row with
+ * a Reset action that clears the user's current-window usage (lifts a budget
+ * block). Backed by GET /api/admin/usage/export.
+ */
+export default function PerUserUsagePanel() {
+  const { usage, isLoading, error, refetch } = useUsageExport();
+
+  if (isLoading) return <PageLoader />;
+  if (error) {
+    return (
+      <MessageCard
+        variant="error"
+        icon={SvgX}
+        title="Failed to load per-user usage."
+      />
+    );
+  }
+
+  const users = usage?.users ?? [];
+
+  return (
+    <Card border="solid" rounding="lg" padding="sm">
+      <div className="flex flex-col gap-2">
+        <Text font="heading-h3">Per-user usage</Text>
+        <Text font="secondary-body" color="text-03">
+          Tokens and cost per user over the report window. Reset clears a user&apos;s
+          current-window usage to lift a budget block; prior windows are kept.
+        </Text>
+
+        {users.length === 0 ? (
+          <Text font="main-ui-body" color="text-03">
+            No usage recorded yet.
+          </Text>
+        ) : (
+          <div className="flex flex-col divide-y divide-border-01">
+            <div className="flex flex-row items-center gap-4 py-2">
+              <div className="flex-1">
+                <Text font="main-ui-action">User</Text>
+              </div>
+              <div className="w-28 text-right">
+                <Text font="main-ui-action">Input</Text>
+              </div>
+              <div className="w-28 text-right">
+                <Text font="main-ui-action">Output</Text>
+              </div>
+              <div className="w-24 text-right">
+                <Text font="main-ui-action">Cost</Text>
+              </div>
+              <div className="w-[68px]" />
+            </div>
+            {users.map((user) => (
+              <UsageRow key={user.email} user={user} onReset={refetch} />
+            ))}
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/web/src/views/admin/PerUserUsagePanel.tsx
+++ b/web/src/views/admin/PerUserUsagePanel.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { toast } from "@/hooks/useToast";
 import { PageLoader } from "@/refresh-components/PageLoader";
-import { Button, Card, MessageCard, Text } from "@opal/components";
+import { Button, Card, InputTypeIn, MessageCard, Text } from "@opal/components";
 import { SvgChevronLeft, SvgChevronRight, SvgX } from "@opal/icons";
 import {
   resetUserUsage,
@@ -13,12 +13,25 @@ import {
 
 const PAGE_SIZE = 10;
 
+type SortKey =
+  | "email"
+  | "input_tokens"
+  | "output_tokens"
+  | "cache_read_tokens"
+  | "cost_cents";
+type SortDir = "asc" | "desc";
+
 function formatTokens(n: number): string {
   return n.toLocaleString();
 }
 
 function formatCost(cents: number): string {
   return `$${(cents / 100).toFixed(2)}`;
+}
+
+function sortValue(user: UsageExportUser, key: SortKey): number | string {
+  if (key === "email") return user.email.toLowerCase();
+  return user.totals[key];
 }
 
 interface UsageRowProps {
@@ -83,30 +96,101 @@ function UsageRow({ user, onReset }: UsageRowProps) {
   );
 }
 
-function HeaderCell({ label }: { label: string }) {
+interface SortHeaderProps {
+  label: string;
+  sortKey: SortKey;
+  activeKey: SortKey;
+  dir: SortDir;
+  onSort: (key: SortKey) => void;
+  align: "left" | "right";
+}
+
+// Clickable column header — drives the leaderboard ordering. The active column
+// shows a ↑/↓ indicator and a brighter label.
+function SortHeader({
+  label,
+  sortKey,
+  activeKey,
+  dir,
+  onSort,
+  align,
+}: SortHeaderProps) {
+  const active = activeKey === sortKey;
+  const indicator = active ? (dir === "desc" ? " ↓" : " ↑") : "";
   return (
-    <div className="w-24 text-right">
-      <Text font="main-ui-action">{label}</Text>
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={() => onSort(sortKey)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onSort(sortKey);
+        }
+      }}
+      className={`cursor-pointer select-none ${
+        align === "right" ? "w-24 text-right" : "flex-1"
+      }`}
+    >
+      <Text font="main-ui-action" color={active ? "text-05" : "text-03"}>
+        {`${label}${indicator}`}
+      </Text>
     </div>
   );
 }
 
 /**
- * Admin table of per-user token/cost usage for the report window, each row with
- * a Reset action that clears the user's current-window usage (lifts a budget
- * block). Paginated client-side over GET /api/admin/usage/export.
+ * Admin table of per-user token/cost usage for the report window. Search by
+ * email and click any column to rank by it (a cost/usage leaderboard); each row
+ * has a Reset action that clears the user's current-window usage (lifts a budget
+ * block). Filtered + sorted client-side over GET /api/admin/usage/export.
  */
 export default function PerUserUsagePanel() {
   const { usage, isLoading, error, refetch } = useUsageExport();
   const [page, setPage] = useState(0);
+  const [query, setQuery] = useState("");
+  const [sortKey, setSortKey] = useState<SortKey>("cost_cents");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
 
   const users = usage?.users ?? [];
-  const pageCount = Math.max(1, Math.ceil(users.length / PAGE_SIZE));
+
+  const visible = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    const filtered = q
+      ? users.filter((u) => u.email.toLowerCase().includes(q))
+      : users;
+    return [...filtered].sort((a, b) => {
+      const av = sortValue(a, sortKey);
+      const bv = sortValue(b, sortKey);
+      const cmp =
+        typeof av === "string" && typeof bv === "string"
+          ? av.localeCompare(bv)
+          : (av as number) - (bv as number);
+      return sortDir === "asc" ? cmp : -cmp;
+    });
+  }, [users, query, sortKey, sortDir]);
+
+  const pageCount = Math.max(1, Math.ceil(visible.length / PAGE_SIZE));
+
+  // Jump back to the first page whenever the filter or sort reshapes the list.
+  useEffect(() => {
+    setPage(0);
+  }, [query, sortKey, sortDir]);
 
   // Clamp the page when the list shrinks (e.g. a reset drops a user off).
   useEffect(() => {
     if (page > pageCount - 1) setPage(pageCount - 1);
   }, [page, pageCount]);
+
+  function handleSort(key: SortKey) {
+    if (key === sortKey) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      // Numeric columns lead high→low (leaderboard); email reads A→Z.
+      setSortDir(key === "email" ? "asc" : "desc");
+    }
+  }
 
   if (isLoading) return <PageLoader />;
   if (error) {
@@ -119,7 +203,7 @@ export default function PerUserUsagePanel() {
     );
   }
 
-  const pageUsers = users.slice(page * PAGE_SIZE, page * PAGE_SIZE + PAGE_SIZE);
+  const pageUsers = visible.slice(page * PAGE_SIZE, page * PAGE_SIZE + PAGE_SIZE);
 
   return (
     <Card border="solid" rounding="lg" padding="sm">
@@ -127,25 +211,69 @@ export default function PerUserUsagePanel() {
         <Text font="heading-h3">Per-user usage</Text>
         <Text font="secondary-body" color="text-03">
           Tokens (input, output, cache reads) and cost per user over the report
-          window. Reset clears a user&apos;s current-window usage to lift a budget
-          block; prior windows are kept.
+          window. Click a column to rank by it, or search by email. Reset clears
+          a user&apos;s current-window usage to lift a budget block; prior
+          windows are kept.
         </Text>
+
+        <InputTypeIn
+          value={query}
+          placeholder="Search users by email…"
+          onChange={(e) => setQuery(e.target.value)}
+        />
 
         {users.length === 0 ? (
           <Text font="main-ui-body" color="text-03">
             No usage recorded yet.
           </Text>
+        ) : visible.length === 0 ? (
+          <Text font="main-ui-body" color="text-03">
+            {`No users match "${query}".`}
+          </Text>
         ) : (
           <>
             <div className="flex flex-col divide-y divide-border-01">
               <div className="flex flex-row items-center gap-4 py-2">
-                <div className="flex-1">
-                  <Text font="main-ui-action">User</Text>
-                </div>
-                <HeaderCell label="Input" />
-                <HeaderCell label="Output" />
-                <HeaderCell label="Cache" />
-                <HeaderCell label="Cost" />
+                <SortHeader
+                  label="User"
+                  sortKey="email"
+                  activeKey={sortKey}
+                  dir={sortDir}
+                  onSort={handleSort}
+                  align="left"
+                />
+                <SortHeader
+                  label="Input"
+                  sortKey="input_tokens"
+                  activeKey={sortKey}
+                  dir={sortDir}
+                  onSort={handleSort}
+                  align="right"
+                />
+                <SortHeader
+                  label="Output"
+                  sortKey="output_tokens"
+                  activeKey={sortKey}
+                  dir={sortDir}
+                  onSort={handleSort}
+                  align="right"
+                />
+                <SortHeader
+                  label="Cache"
+                  sortKey="cache_read_tokens"
+                  activeKey={sortKey}
+                  dir={sortDir}
+                  onSort={handleSort}
+                  align="right"
+                />
+                <SortHeader
+                  label="Cost"
+                  sortKey="cost_cents"
+                  activeKey={sortKey}
+                  dir={sortDir}
+                  onSort={handleSort}
+                  align="right"
+                />
                 <div className="w-[68px]" />
               </div>
               {pageUsers.map((user) => (
@@ -164,7 +292,7 @@ export default function PerUserUsagePanel() {
                   onClick={() => setPage((p) => Math.max(0, p - 1))}
                 />
                 <Text font="main-ui-body" color="text-03">
-                  {`Page ${page + 1} of ${pageCount}`}
+                  {`Page ${page + 1} of ${pageCount} · ${visible.length} users`}
                 </Text>
                 <Button
                   variant="default"

--- a/web/src/views/admin/PerUserUsagePanel.tsx
+++ b/web/src/views/admin/PerUserUsagePanel.tsx
@@ -1,15 +1,17 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "@/hooks/useToast";
 import { PageLoader } from "@/refresh-components/PageLoader";
 import { Button, Card, MessageCard, Text } from "@opal/components";
-import { SvgX } from "@opal/icons";
+import { SvgChevronLeft, SvgChevronRight, SvgX } from "@opal/icons";
 import {
   resetUserUsage,
   useUsageExport,
   UsageExportUser,
 } from "@/lib/usage/userUsage";
+
+const PAGE_SIZE = 10;
 
 function formatTokens(n: number): string {
   return n.toLocaleString();
@@ -50,14 +52,19 @@ function UsageRow({ user, onReset }: UsageRowProps) {
       <div className="flex-1 truncate">
         <Text font="main-ui-body">{user.email}</Text>
       </div>
-      <div className="w-28 text-right">
+      <div className="w-24 text-right">
         <Text font="main-ui-body" color="text-03">
           {formatTokens(totals.input_tokens)}
         </Text>
       </div>
-      <div className="w-28 text-right">
+      <div className="w-24 text-right">
         <Text font="main-ui-body" color="text-03">
           {formatTokens(totals.output_tokens)}
+        </Text>
+      </div>
+      <div className="w-24 text-right">
+        <Text font="main-ui-body" color="text-03">
+          {formatTokens(totals.cache_read_tokens)}
         </Text>
       </div>
       <div className="w-24 text-right">
@@ -76,13 +83,30 @@ function UsageRow({ user, onReset }: UsageRowProps) {
   );
 }
 
+function HeaderCell({ label }: { label: string }) {
+  return (
+    <div className="w-24 text-right">
+      <Text font="main-ui-action">{label}</Text>
+    </div>
+  );
+}
+
 /**
  * Admin table of per-user token/cost usage for the report window, each row with
  * a Reset action that clears the user's current-window usage (lifts a budget
- * block). Backed by GET /api/admin/usage/export.
+ * block). Paginated client-side over GET /api/admin/usage/export.
  */
 export default function PerUserUsagePanel() {
   const { usage, isLoading, error, refetch } = useUsageExport();
+  const [page, setPage] = useState(0);
+
+  const users = usage?.users ?? [];
+  const pageCount = Math.max(1, Math.ceil(users.length / PAGE_SIZE));
+
+  // Clamp the page when the list shrinks (e.g. a reset drops a user off).
+  useEffect(() => {
+    if (page > pageCount - 1) setPage(pageCount - 1);
+  }, [page, pageCount]);
 
   if (isLoading) return <PageLoader />;
   if (error) {
@@ -95,15 +119,16 @@ export default function PerUserUsagePanel() {
     );
   }
 
-  const users = usage?.users ?? [];
+  const pageUsers = users.slice(page * PAGE_SIZE, page * PAGE_SIZE + PAGE_SIZE);
 
   return (
     <Card border="solid" rounding="lg" padding="sm">
       <div className="flex flex-col gap-2">
         <Text font="heading-h3">Per-user usage</Text>
         <Text font="secondary-body" color="text-03">
-          Tokens and cost per user over the report window. Reset clears a user&apos;s
-          current-window usage to lift a budget block; prior windows are kept.
+          Tokens (input, output, cache reads) and cost per user over the report
+          window. Reset clears a user&apos;s current-window usage to lift a budget
+          block; prior windows are kept.
         </Text>
 
         {users.length === 0 ? (
@@ -111,26 +136,47 @@ export default function PerUserUsagePanel() {
             No usage recorded yet.
           </Text>
         ) : (
-          <div className="flex flex-col divide-y divide-border-01">
-            <div className="flex flex-row items-center gap-4 py-2">
-              <div className="flex-1">
-                <Text font="main-ui-action">User</Text>
+          <>
+            <div className="flex flex-col divide-y divide-border-01">
+              <div className="flex flex-row items-center gap-4 py-2">
+                <div className="flex-1">
+                  <Text font="main-ui-action">User</Text>
+                </div>
+                <HeaderCell label="Input" />
+                <HeaderCell label="Output" />
+                <HeaderCell label="Cache" />
+                <HeaderCell label="Cost" />
+                <div className="w-[68px]" />
               </div>
-              <div className="w-28 text-right">
-                <Text font="main-ui-action">Input</Text>
-              </div>
-              <div className="w-28 text-right">
-                <Text font="main-ui-action">Output</Text>
-              </div>
-              <div className="w-24 text-right">
-                <Text font="main-ui-action">Cost</Text>
-              </div>
-              <div className="w-[68px]" />
+              {pageUsers.map((user) => (
+                <UsageRow key={user.email} user={user} onReset={refetch} />
+              ))}
             </div>
-            {users.map((user) => (
-              <UsageRow key={user.email} user={user} onReset={refetch} />
-            ))}
-          </div>
+
+            {pageCount > 1 && (
+              <div className="flex flex-row items-center justify-end gap-3 pt-2">
+                <Button
+                  variant="default"
+                  prominence="tertiary"
+                  size="sm"
+                  icon={SvgChevronLeft}
+                  disabled={page === 0}
+                  onClick={() => setPage((p) => Math.max(0, p - 1))}
+                />
+                <Text font="main-ui-body" color="text-03">
+                  {`Page ${page + 1} of ${pageCount}`}
+                </Text>
+                <Button
+                  variant="default"
+                  prominence="tertiary"
+                  size="sm"
+                  icon={SvgChevronRight}
+                  disabled={page >= pageCount - 1}
+                  onClick={() => setPage((p) => Math.min(pageCount - 1, p + 1))}
+                />
+              </div>
+            )}
+          </>
         )}
       </div>
     </Card>

--- a/web/tests/e2e/admin/per_user_usage.spec.ts
+++ b/web/tests/e2e/admin/per_user_usage.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from "@playwright/test";
+import { ChatPage } from "@tests/e2e/chat/ChatPage";
+
+/**
+ * Admin per-user usage table + Reset. Real e2e (no mocking): the admin sends a
+ * chat to accrue usage, then the Usage Statistics page must list that usage per
+ * user, and the Reset action must clear it. Requires a working LLM provider in
+ * the e2e environment so the chat records token usage.
+ */
+test.use({ storageState: "admin_auth.json" });
+
+test.describe("admin per-user usage table + reset", () => {
+  test("usage shows per user and Reset clears it", async ({ page }) => {
+    // 1) Accrue usage by sending a chat as the admin.
+    const chat = new ChatPage(page);
+    await chat.goto();
+    await chat.inputBar.fill("hello there");
+    await chat.inputBar.send();
+    await chat.aiMessage(0).waitFor({ state: "visible", timeout: 60_000 });
+
+    // 2) The admin's usage now appears in the per-user table.
+    await page.goto("/admin/performance/usage");
+    const row = page.locator('[data-testid^="usage-row-"]').first();
+    await expect(row).toBeVisible({ timeout: 15_000 });
+
+    // 3) Reset clears the user's current-window usage (toast confirms).
+    await row.getByRole("button", { name: "Reset" }).click();
+    await expect(page.getByText(/reset usage for/i)).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+});

--- a/web/tests/e2e/admin/token_rate_limit.spec.ts
+++ b/web/tests/e2e/admin/token_rate_limit.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from "@playwright/test";
+import { ChatPage } from "@tests/e2e/chat/ChatPage";
+
+/**
+ * Rate-limit enforcement is a server-side gate, so this is a REAL e2e: it does
+ * NOT mock the chat endpoint (mocking would bypass the gate). It creates a tiny
+ * per-user token budget, sends real chats until usage accrues past it, and
+ * asserts the structured 429 renders as the "usage limit reached" banner.
+ *
+ * Requires a working LLM provider in the e2e environment (chats must actually
+ * produce token usage). The same admin user creates the limit and sends the
+ * chats, so the USER scope applies to them.
+ */
+test.use({ storageState: "admin_auth.json" });
+
+const RATE_LIMIT_API = "/api/admin/token-rate-limits";
+
+test.describe("usage budget blocks chat", () => {
+  let limitId: number | undefined;
+
+  test.afterEach(async ({ page }) => {
+    if (limitId != null) {
+      await page.request.delete(`${RATE_LIMIT_API}/rate-limit/${limitId}`);
+      limitId = undefined;
+    }
+  });
+
+  test("a per-user token budget surfaces the usage-limit banner", async ({
+    page,
+  }) => {
+    // 1) Tiny per-user token budget (1 => 1,000 tokens enforced).
+    const res = await page.request.post(`${RATE_LIMIT_API}/users`, {
+      data: {
+        enabled: true,
+        token_budget: 1,
+        period_hours: 168,
+        cost_budget_cents: null,
+      },
+    });
+    expect(res.ok()).toBeTruthy();
+    const body = await res.json();
+    limitId = body.token_id ?? body.id;
+
+    const chat = new ChatPage(page);
+    await chat.goto();
+
+    // 2) Usage accrues server-side and the gate reads the recorded total before
+    //    each request, so the first turn starts at 0 and it takes a few turns to
+    //    cross the budget. Stop as soon as the banner appears.
+    const banner = page.getByText(/you've reached the usage budget/i);
+    for (let turn = 0; turn < 8 && !(await banner.isVisible()); turn++) {
+      await chat.inputBar.fill(`write a few sentences about topic ${turn}`);
+      await chat.inputBar.send();
+      await Promise.race([
+        banner.waitFor({ state: "visible", timeout: 45_000 }).catch(() => {}),
+        chat
+          .aiMessage(turn)
+          .waitFor({ state: "visible", timeout: 45_000 })
+          .catch(() => {}),
+      ]);
+    }
+
+    // 3) The structured 429 renders as a friendly, scope-aware banner.
+    await expect(banner).toBeVisible();
+    await expect(page.getByText(/your account/i)).toBeVisible();
+  });
+});


### PR DESCRIPTION
Part **4 of 4** of the per-user usage + cost tracking stack (split from #11732).

> **Stacked PR.** Targets `main`, so the diff is **cumulative** — it includes parts 1–3 (#11766, #11887, enforcement). **Review the frontend layer below.**

### Net-new in this PR — frontend
- `app/app/settings/usage/` — per-user **Usage tab** (token + cost totals, per-model/day breakdown) fed by `GET /user/usage`.
- `refresh-pages/admin/CostOverridesPanel.tsx` + `lib/languageModels/costOverrides.ts` — admin **cost-override** editor (model dropdown from org-configured models).
- `app/app/message/errorHelpers.tsx` + `Resubmit.tsx` — **429 budget banner** with `Retry-After`.
- `admin/token-rate-limits/` + `refresh-pages/admin/GroupsPage/` — cost-budget fields on the token-rate-limit + group UIs (`token_budget` now nullable → token-only / cost-only / both).

> The **admin per-user usage report** (`ee/admin/performance/usage`) was stripped with the other `ee/` parts — it consumes the MIT `GET /admin/usage/export` shipped in #11887; covered in the written spec.

Depends on the rest of the stack. tsc + oxlint clean.

### How tested
`tsc` + `oxlint`; flows exercised against the live backend before the split.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds end-to-end per-user usage and cost tracking with a self-service Usage tab, admin cost controls, and token/cost budgets that return a structured 429; also enforces budgets for global, user, group, and Craft turns. Updates the Usage tab to show provider-grouped model prices (override- and cache-aware) and enhances the admin per-user usage table with search and sorting.

- **New Features**
  - Usage tab: per-user totals and per-model/day breakdown, plus current-window cost and budget (when set). Shows selected model pricing (override-aware) and now lists all configured model prices (input/output/cache) grouped by provider with the default model tagged. Backed by GET `/api/user/usage` (adds `available_model_prices`).
  - Admin Cost Overrides: CRUD USD-per-million-token rates keyed by provider+model (provider-agnostic fallback), cached per-tenant with a TTL and bounded size. Panel on the Language Models page via GET/PUT/DELETE `/api/admin/cost-overrides`. Model picker now reuses the chat `ModelSelector` with provider-collapsible menus.
  - Per-user accounting: a tracing processor attributes LLM usage via a request-scoped context var, prices it via overrides/image defaults/`litellm`/fallbacks, buffers with a bounded queue, and flushes on shutdown.
  - Rate Limits + 429 UX: add a cost budget (USD, > $0) alongside tokens; supports token-only, cost-only, or both, with hour/day/week selector. Validators require at least one budget. Violations return a structured 429 (`error_code=RATE_LIMITED`) with `Retry-After` and `reset_at`; chat shows a countdown banner. Gates avoid N+1 queries, scan tokens only to the widest token window, and enforce for global, user, group, and Craft turns.
  - Admin Usage: tenant-wide per-user usage export via GET `/api/admin/usage/export`, plus a per-user table with “Reset” to clear the current window via POST `/api/admin/usage/reset`. Shows cache-read tokens, paginates (10/page), clamps page index after resets, and now supports email search and sortable columns.
  - Fix: cost-only group limits now persist `cost_budget_cents` on create (regression covered); previously tripped a DB check and failed to appear.

- **Migration**
  - DB: add `user_usage` and `model_cost_override` (unique on `(provider, model)`); make `token_budget` nullable and add `cost_budget_cents` to `token_rate_limit`. Downgrade deletes cost-only rows to avoid enforcing `token_budget=0`.
  - Config: new envs — `DEFAULT_IMAGE_COST_CENTS`, `DEFAULT_LLM_INPUT_COST_PER_MTOK`, `DEFAULT_LLM_OUTPUT_COST_PER_MTOK`, `USER_USAGE_TRACKING_ENABLED`.

<sup>Written for commit 345aa010477f49c4765b5038a1c6e4cd8b981938. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

