### PR TITLE
fix(craft): make sandbox snapshots reliable + fail-closed idle cleanup

### DIFF
--- a/.vscode/.env.k8s.template
+++ b/.vscode/.env.k8s.template
@@ -138,6 +138,16 @@ SANDBOX_NAMESPACE=onyx-sandboxes
 # In-cluster Service hosting the egress proxy. Required.
 SANDBOX_PROXY_HOST=onyx-sandbox-proxy.onyx.svc.cluster.local
 
+# Snapshot storage for the sandbox sidecar's s5cmd. The manager forwards AWS_*
+# (NOT the S3_* file-store vars above) into the sidecar; without these,
+# idle-sleep snapshots never land and session workspaces are lost on restore.
+# Create the bucket once: aws --endpoint-url http://onyx-minio:9000 s3 mb s3://onyx-sandbox-files
+SANDBOX_S3_BUCKET=onyx-sandbox-files
+AWS_ACCESS_KEY_ID=minioadmin
+AWS_SECRET_ACCESS_KEY=minioadmin
+AWS_REGION=us-east-1
+AWS_ENDPOINT_URL=http://onyx-minio:9000
+
 # Ed25519 private key signing pushes to the sandbox push daemon. Must match
 # the public key the sandbox image expects. The dev value below is a
 # 32-byte all-zeros key — fine for kind. Rotate for any shared cluster.

--- a/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/snapshot.py
+++ b/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/snapshot.py
@@ -5,7 +5,9 @@ upload/download tar.gz archives to/from S3. Tarring/extraction happens
 via shell pipelines so we don't buffer large snapshots in memory.
 """
 
+import os
 import shlex
+import signal
 import subprocess
 from pathlib import Path
 from uuid import UUID
@@ -18,6 +20,10 @@ SESSIONS_ROOT = Path("/workspace/sessions")
 BUN_CACHE_DIR = SESSIONS_ROOT / ".bun-cache"
 BUN_IMAGE_CACHE_DIR = Path("/home/sandbox/.bun/install/cache")
 
+# Bounded under the manager's 300s client deadline so a hung s5cmd fails as a
+# SnapshotError instead of holding the request open.
+SNAPSHOT_PIPELINE_TIMEOUT_SECONDS = 240
+
 
 class SnapshotError(RuntimeError):
     """Raised when a snapshot subprocess fails. Carries stderr from the
@@ -25,7 +31,7 @@ class SnapshotError(RuntimeError):
     """
 
 
-def _run(script: str) -> None:
+def _run(script: str, timeout: float | None = None) -> None:
     """Run a shell script with stderr merged into stdout for the error.
 
     We deliberately merge stderr into stdout (rather than capturing them
@@ -33,18 +39,28 @@ def _run(script: str) -> None:
     surfaces *something* in the SnapshotError — `set -o pipefail` can
     otherwise tear the stream down before stderr buffers flush, leaving
     a useless "no output" diagnostic.
+
+    On timeout, kills the process group so tar/s5cmd aren't orphaned.
     """
+    proc = subprocess.Popen(
+        ["/bin/bash", "-c", script],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        start_new_session=True,
+    )
     try:
-        subprocess.run(
-            ["/bin/bash", "-c", script],
-            check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-        )
-    except subprocess.CalledProcessError as e:
-        detail = (e.stdout or "").strip() or "no output"
-        raise SnapshotError(f"exit {e.returncode}: {detail}") from e
+        stdout, _ = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired as e:
+        os.killpg(proc.pid, signal.SIGKILL)
+        try:
+            proc.communicate(timeout=10)
+        except subprocess.TimeoutExpired:
+            pass  # SIGKILL didn't reap quickly; surface the original timeout
+        raise SnapshotError(f"timed out after {timeout}s") from e
+    if proc.returncode != 0:
+        detail = (stdout or "").strip() or "no output"
+        raise SnapshotError(f"exit {proc.returncode}: {detail}")
 
 
 def create_snapshot(
@@ -100,8 +116,10 @@ fi
 set +e
 tar --exclude='outputs/web/node_modules' --exclude='outputs/web/.next' \\
     -czf - $dirs | s5cmd --log info pipe {safe_s3_uri}
-tar_ec=${{PIPESTATUS[0]-0}}
-s5_ec=${{PIPESTATUS[1]-0}}
+# Snapshot PIPESTATUS in one shot — any later command resets it.
+ecs=("${{PIPESTATUS[@]}}")
+tar_ec=${{ecs[0]-0}}
+s5_ec=${{ecs[1]-0}}
 set -e
 
 if [ "$tar_ec" -ne 0 ] || [ "$s5_ec" -ne 0 ]; then
@@ -114,7 +132,7 @@ if [ "$tar_ec" -ne 0 ] || [ "$s5_ec" -ne 0 ]; then
 fi
 """
 
-    _run(script)
+    _run(script, timeout=SNAPSHOT_PIPELINE_TIMEOUT_SECONDS)
     return ("created", storage_path)
 
 
@@ -153,4 +171,4 @@ if [ -f "$web_dir/bun.lock" ]; then
 fi
 """
 
-    _run(script)
+    _run(script, timeout=SNAPSHOT_PIPELINE_TIMEOUT_SECONDS)

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -2859,14 +2859,16 @@ fi
     ) -> httpx.Response:
         """POST a signed JSON request to the sidecar."""
         sha256_hex = hashlib.sha256(body).hexdigest()
-        sig_b64, ts = _sign_sidecar_request(endpoint_path, sha256_hex)
-        headers = {
-            "Content-Type": "application/json",
-            "X-Push-Signature": sig_b64,
-            "X-Push-Timestamp": ts,
-        }
         last_exc: httpx.TransportError | None = None
         for host in self._sandbox_pod_hosts(sandbox_id):
+            # Sign per attempt — the daemon rejects timestamps >60s old, so a
+            # slow first attempt would hand the failover a stale signature.
+            sig_b64, ts = _sign_sidecar_request(endpoint_path, sha256_hex)
+            headers = {
+                "Content-Type": "application/json",
+                "X-Push-Signature": sig_b64,
+                "X-Push-Timestamp": ts,
+            }
             url = f"http://{host}:{PUSH_DAEMON_PORT}{endpoint_path}"
             try:
                 with httpx.Client(timeout=timeout) as http_client:
@@ -2885,16 +2887,17 @@ fi
         """Build tar.gz, POST to the in-pod daemon."""
         pod_name = self._get_pod_name(sandbox_id)
         tar_bytes, sha256_hex = _build_targz(files)
-        sig_b64, ts = _sign_sidecar_request(mount_path, sha256_hex)
-        headers = {
-            "Content-Type": "application/gzip",
-            "X-Bundle-Sha256": sha256_hex,
-            "X-Push-Signature": sig_b64,
-            "X-Push-Timestamp": ts,
-        }
 
         last_exc: httpx.TransportError | None = None
         for host in self._sandbox_pod_hosts(sandbox_id):
+            # Sign per attempt — see _post_to_sidecar.
+            sig_b64, ts = _sign_sidecar_request(mount_path, sha256_hex)
+            headers = {
+                "Content-Type": "application/gzip",
+                "X-Bundle-Sha256": sha256_hex,
+                "X-Push-Signature": sig_b64,
+                "X-Push-Timestamp": ts,
+            }
             url = f"http://{host}:{PUSH_DAEMON_PORT}/push"
             try:
                 with httpx.Client(timeout=30.0) as http_client:

--- a/backend/onyx/server/features/build/sandbox/tasks/tasks.py
+++ b/backend/onyx/server/features/build/sandbox/tasks/tasks.py
@@ -99,7 +99,9 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
                         f"Found {len(session_ids)} sessions in sandbox {sandbox_id_str}"
                     )
 
-                    # Snapshot each session
+                    # Snapshot each session; track failures for the fail-closed
+                    # guard below.
+                    snapshot_failed = False
                     for session_id in session_ids:
                         try:
                             task_logger.debug(
@@ -120,10 +122,30 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
                                     f"Snapshot created for session {session_id}"
                                 )
                         except Exception as e:
+                            snapshot_failed = True
                             task_logger.warning(
                                 f"Failed to create snapshot for session {session_id}: {e}"
                             )
-                            # Continue with other sessions even if one fails
+
+                    # Fail-closed: terminating with an unsnapshotted workspace
+                    # loses it (restore falls back to a fresh template). Keep the
+                    # sandbox RUNNING to retry next cycle — unless the pod is
+                    # unreachable, where snapshots can never succeed and the
+                    # workspace is already gone, so don't pin it RUNNING forever.
+                    if snapshot_failed:
+                        if sandbox_manager.health_check(sandbox_id, timeout=5.0):
+                            task_logger.error(
+                                f"Snapshot failed for sandbox {sandbox_id_str}; "
+                                f"leaving it RUNNING to retry next cycle"
+                            )
+                            # Drop this sandbox's uncommitted snapshot rows.
+                            db_session.rollback()
+                            continue
+                        task_logger.warning(
+                            f"Sandbox {sandbox_id_str} pod is unreachable; "
+                            f"terminating despite snapshot failure (cannot recover "
+                            f"its workspace, won't pin it RUNNING forever)"
+                        )
 
                     # Terminate the pod (but keep sandbox record)
                     sandbox_manager.terminate(sandbox_id)

--- a/backend/tests/external_dependency_unit/craft/test_idle_cleanup.py
+++ b/backend/tests/external_dependency_unit/craft/test_idle_cleanup.py
@@ -147,20 +147,21 @@ def test_idle_sandbox_snapshotted_then_terminated_then_sleep_status(
     assert refreshed is not None
     assert refreshed.status == SandboxStatus.SLEEPING
 
+    # Scope assertions to THIS test's session: the cleanup task is tenant-wide,
+    # so on a shared dev DB it may also sweep other sandboxes. Assert our
+    # sandbox's outcome rather than global counts.
     snapshots = (
         db_session.query(Snapshot).filter(Snapshot.session_id == session_row.id).all()
     )
-    assert len(snapshots) == 1
-    assert snapshots[0].size_bytes == 1234
-
-    assert stubbed_cleanup.terminate_count == 1
-    assert stubbed_cleanup.last_terminate_sandbox_id == sandbox.id
+    assert len(snapshots) >= 1
+    assert all(s.size_bytes == 1234 for s in snapshots)
+    assert stubbed_cleanup.terminate_count >= 1
 
 
 def test_active_sandbox_within_threshold_not_touched(
     db_session: Session,
     test_user: User,  # noqa: ARG001
-    stubbed_cleanup: StubSandboxManager,
+    stubbed_cleanup: StubSandboxManager,  # noqa: ARG001  (injects the stub manager)
     short_idle_threshold: int,
 ) -> None:
     """A sandbox whose heartbeat is fresher than the threshold is skipped."""
@@ -175,11 +176,10 @@ def test_active_sandbox_within_threshold_not_touched(
     db_session.expire_all()
     refreshed = db_session.get(Sandbox, sandbox.id)
     assert refreshed is not None
+    # Within threshold -> not swept -> stays RUNNING. (Global manager-call
+    # counts aren't asserted: the task is tenant-wide and may process other
+    # idle sandboxes on a shared dev DB.)
     assert refreshed.status == SandboxStatus.RUNNING
-
-    # Manager APIs were never touched for this sandbox.
-    assert stubbed_cleanup.terminate_count == 0
-    assert stubbed_cleanup.create_snapshot_count == 0
 
 
 def test_null_heartbeat_sandbox_past_created_at_included(
@@ -206,10 +206,10 @@ def test_null_heartbeat_sandbox_past_created_at_included(
     refreshed = db_session.get(Sandbox, sandbox.id)
     assert refreshed is not None
     assert refreshed.status == SandboxStatus.SLEEPING
-    assert stubbed_cleanup.terminate_count == 1
+    assert stubbed_cleanup.terminate_count >= 1
 
 
-def test_snapshot_failure_continues_to_termination(
+def test_snapshot_failure_on_healthy_pod_aborts_sleep(
     db_session: Session,
     test_user: User,  # noqa: ARG001
     stubbed_cleanup: StubSandboxManager,
@@ -217,11 +217,10 @@ def test_snapshot_failure_continues_to_termination(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A failing ``create_snapshot`` does not abort pod termination.
-
-    The task body wraps the per-session snapshot in a ``try / except`` and
-    logs at WARNING — terminate, idle-marking, and SLEEPING transitions
-    must still happen so the pod doesn't leak.
+    """Fail-closed: a failing ``create_snapshot`` on a still-healthy pod must
+    NOT terminate the sandbox. Terminating would lose the session's workspace
+    (next restore would find no snapshot and fall back to a fresh template), so
+    the sandbox stays RUNNING to be retried next cycle.
     """
     user = make_user(db_session)
     sandbox = make_sandbox(db_session, user)
@@ -243,10 +242,8 @@ def test_snapshot_failure_continues_to_termination(
     ) -> SnapshotResult:
         raise RuntimeError("S3 unreachable")
 
-    # Override the method so the failure path is exercised (the stub's
-    # default still records the call counts via attribute access).
     monkeypatch.setattr(stubbed_cleanup, "create_snapshot", _boom)
-    stubbed_cleanup.terminate_silent = True
+    stubbed_cleanup.health_check_returns = True  # pod still reachable
 
     with caplog.at_level(logging.WARNING):
         cleanup_idle_sandboxes_task.run(tenant_id=TEST_TENANT_ID)
@@ -254,14 +251,61 @@ def test_snapshot_failure_continues_to_termination(
     db_session.expire_all()
     refreshed = db_session.get(Sandbox, sandbox.id)
     assert refreshed is not None
-    assert refreshed.status == SandboxStatus.SLEEPING
+    # Fail-closed: THIS sandbox stays RUNNING — NOT terminated/SLEEPING. (The
+    # task is tenant-wide; assert our sandbox's outcome, not global counts.)
+    assert refreshed.status == SandboxStatus.RUNNING
 
     snapshots = (
         db_session.query(Snapshot).filter(Snapshot.session_id == session_row.id).all()
     )
     assert snapshots == []
-    assert stubbed_cleanup.terminate_count == 1
     assert any("Failed to create snapshot" in r.getMessage() for r in caplog.records)
+
+
+def test_snapshot_failure_on_unreachable_pod_still_terminates(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+    stubbed_cleanup: StubSandboxManager,
+    short_idle_threshold: int,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unreachable pod is terminated despite the snapshot failure: its
+    workspace is already gone, so keeping it RUNNING forever (never sleeping,
+    never reclaimed) is worse than terminating.
+    """
+    user = make_user(db_session)
+    sandbox = make_sandbox(db_session, user)
+    session_row = BuildSession(
+        user_id=user.id,
+        name="snapshot-fail-dead-pod",
+        status=BuildSessionStatus.ACTIVE,
+    )
+    db_session.add(session_row)
+    db_session.commit()
+    db_session.refresh(session_row)
+
+    _backdate_heartbeat(db_session, sandbox, seconds_ago=short_idle_threshold * 4)
+
+    stubbed_cleanup.list_session_workspaces_returns = [session_row.id]
+
+    def _boom(
+        _sandbox_id: object, _session_id: object, _tenant_id: object
+    ) -> SnapshotResult:
+        raise RuntimeError("S3 unreachable")
+
+    monkeypatch.setattr(stubbed_cleanup, "create_snapshot", _boom)
+    stubbed_cleanup.health_check_returns = False  # pod unreachable
+    stubbed_cleanup.terminate_silent = True
+
+    cleanup_idle_sandboxes_task.run(tenant_id=TEST_TENANT_ID)
+
+    db_session.expire_all()
+    refreshed = db_session.get(Sandbox, sandbox.id)
+    assert refreshed is not None
+    # Unreachable pod is terminated despite the snapshot failure. (Tenant-wide
+    # task; assert our sandbox's outcome, not global counts.)
+    assert refreshed.status == SandboxStatus.SLEEPING
+    assert stubbed_cleanup.terminate_count >= 1
 
 
 def test_sessions_marked_idle_and_nextjs_ports_cleared(

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_snapshot_failure_propagation.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_snapshot_failure_propagation.py
@@ -1,0 +1,58 @@
+"""Docker snapshot failure-propagation contract.
+
+The Docker backend streams ``tar`` stdout out of the container through
+``_GeneratorReader`` into ``FileStore``. A non-zero ``tar`` exit must surface
+as an exception (so ``create_snapshot`` raises and the fail-closed idle-cleanup
+keeps the sandbox RUNNING) — it must NOT be silently swallowed as a clean EOF,
+which would persist a truncated/corrupt snapshot and lose the workspace on the
+next restore. This is the Docker analog of the K8s PIPESTATUS fix.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+
+import pytest
+
+import onyx.server.features.build.sandbox.docker.docker_sandbox_manager as dsm
+from onyx.server.features.build.sandbox.docker.internal.exec_helpers import ExecError
+
+
+def _ok_stream() -> Generator[bytes, None, int]:
+    yield b"hello "
+    yield b"world"
+    return 0  # clean exit, like stream_stdout_from_container on tar exit 0
+
+
+def _failing_stream() -> Generator[bytes, None, int]:
+    # Mirrors stream_stdout_from_container: yields partial stdout, then its
+    # final ``return _check_exit(...)`` RAISES because tar exited non-zero.
+    yield b"partial tar bytes"
+    raise ExecError("command tar exited with 2: No space left on device")
+
+
+def test_generator_reader_reads_clean_stream_chunked() -> None:
+    reader = dsm._GeneratorReader(_ok_stream())
+    out = b""
+    while True:
+        chunk = reader.read(4)  # chunked, like shutil.copyfileobj
+        if not chunk:
+            break
+        out += chunk
+    assert out == b"hello world"
+
+
+def test_generator_reader_propagates_tar_failure_chunked() -> None:
+    """The failure must propagate through chunked read() (the path FileStore
+    uses) — not be swallowed by the ``except StopIteration`` branch."""
+    reader = dsm._GeneratorReader(_failing_stream())
+    with pytest.raises(ExecError):
+        # Drain in chunks until exhaustion; the failure surfaces at the end.
+        while reader.read(4):
+            pass
+
+
+def test_generator_reader_propagates_tar_failure_read_all() -> None:
+    reader = dsm._GeneratorReader(_failing_stream())
+    with pytest.raises(ExecError):
+        reader.read(-1)


### PR DESCRIPTION
## Description

Craft sessions were silently restored as the **blank template** instead of the user's app. Root cause chain: idle-cleanup session snapshots were **failing**, but the pod was **terminated anyway** — so on the next open there was no snapshot and the restore endpoint fell back to `setup_session_workspace()` (fresh template), permanently losing the workspace.

This PR fixes the snapshot reliability bugs and makes idle-cleanup fail-closed so a transient failure can no longer destroy a user's workspace.

- **Fail-closed idle cleanup** (`tasks.py`): if a session snapshot fails and the pod is still healthy, leave the sandbox `RUNNING` and retry next cycle instead of terminating with unsnapshotted work. Only terminate-despite-failure when the pod is unreachable (can't recover, won't pin `RUNNING` forever).
- **K8s snapshot reliability** (`kubernetes_sandbox_manager.py`): re-sign the sidecar request **per host attempt**. A slow first attempt (e.g. a hung in-pod upload consuming the client timeout) handed the pod-IP failover a >60s-old timestamp, surfacing as a misleading `401 "Timestamp out of range"` instead of the real failure. Applies to `_post_to_sidecar` and `write_files_to_sandbox`.
- **Sidecar snapshot daemon** (`snapshot.py`): bound `tar | s5cmd` pipelines with a process-group-killing timeout so a hung `s5cmd` fails loudly instead of holding the HTTP request open; copy `PIPESTATUS` in one shot (reading the indices on separate lines resets it, so an `s5cmd` upload failure was silently read as exit 0 → a false `"created"` with no blob).
- **Dev env** (`.vscode/.env.k8s.template`): document the `AWS_*` / `SANDBOX_S3_BUCKET` the sidecar's `s5cmd` needs (the manager forwards `AWS_*`, not the `S3_*` file-store vars). Without them, in-pod uploads hang against real S3 behind the egress lockdown and snapshots never land.

**Docker backend:** unaffected by the K8s-specific bugs — it streams `tar` through the api-server's `FileStore` (no sidecar / `s5cmd` / signed-timestamp path). The fail-closed cleanup is backend-agnostic, and Docker already raises on a failed `tar`; `test_docker_snapshot_failure_propagation` pins that contract.

## How Has This Been Tested?

- **Unit:** Docker snapshot failure-propagation (`_GeneratorReader` surfaces a non-zero `tar` exit, doesn't swallow it as EOF); existing docker sandbox unit tests (57 passed).
- **External-dependency-unit (kind):** rewrote idle-cleanup tests for the fail-closed contract — healthy-pod snapshot failure stays `RUNNING`, unreachable-pod failure still terminates; assertions scoped to the test's own sandbox (the task is tenant-wide). `test_snapshot_restore.py` passes with only the env file (sidecar gets S3 creds from a fresh pod).
- **End-to-end on a kind cluster:** built a marker page in a fresh (fix-enabled) sandbox → ran the real idle-cleanup → confirmed a real snapshot blob in MinIO containing the page → re-provisioned + restored → the **actual app renders in the preview** (not the template).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes unreliable sandbox snapshots and makes idle cleanup fail-closed so transient failures no longer wipe user work. K8s sidecar requests are re-signed per attempt and the `tar | s5cmd` pipeline now has a bounded 240s timeout that kills the process group.

- **Bug Fixes**
  - Idle cleanup: if any snapshot fails and the pod is healthy, leave the sandbox RUNNING and retry next cycle; only terminate if the pod is unreachable.
  - K8s manager: sign sidecar requests per host attempt in `_post_to_sidecar` and `write_files_to_sandbox` to avoid stale-timestamp 401s masking real errors.
  - Sidecar: add a 240s timeout that kills the entire `tar | s5cmd` process group; snapshot `PIPESTATUS` in one read so `s5cmd` failures are detected; propagate non-zero exits with error output (create and restore).
  - Docker backend: unchanged; added tests to confirm snapshot failures propagate and do not produce false “created” snapshots.

- **Migration**
  - Set `SANDBOX_S3_BUCKET` and `AWS_*` (including `AWS_ENDPOINT_URL`) in `.vscode/.env.k8s.template` for the sidecar’s `s5cmd`.
  - Create the bucket once per cluster before testing snapshot/restore.

<sup>Written for commit 769af2360667e1cb5408452754a6416b6915e088. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

