### PR TITLE
ci(craft): deploy ad-hoc sandbox images via sandbox/dev git tags

### DIFF
--- a/.github/workflows/sandbox-deployment.yml
+++ b/.github/workflows/sandbox-deployment.yml
@@ -4,15 +4,15 @@ name: Build and Push Sandbox Image
 # the nightly tag when its build context changed, or manually on demand.
 #
 # To push an ad-hoc dev build:
-#   git tag -f sandbox/dev && git push -f origin sandbox/dev
+#   git tag -f sandbox-dev && git push -f origin sandbox-dev
 # builds unconditionally and pushes onyxdotapp/sandbox:dev. Dev builds never
 # cut a vX.Y.Z version or move :latest — those only happen on the nightly
-# path. Only sandbox/dev is supported, to keep Docker Hub free of one-off tags.
+# path. Only sandbox-dev is supported, to keep Docker Hub free of one-off tags.
 on:
   push:
     tags:
       - "nightly-latest-*"
-      - "sandbox/dev"
+      - "sandbox-dev"
   workflow_dispatch:
 
 # Restrictive defaults; jobs declare what they need.
@@ -47,8 +47,8 @@ jobs:
             exit 0
           fi
 
-          # The sandbox/dev tag always builds and pushes the :dev image tag.
-          if [ "$GITHUB_REF_NAME" = "sandbox/dev" ]; then
+          # The sandbox-dev tag always builds and pushes the :dev image tag.
+          if [ "$GITHUB_REF_NAME" = "sandbox-dev" ]; then
             echo "Dev tag: building and pushing :dev"
             echo "custom-tag=dev" >> "$GITHUB_OUTPUT"
             echo "sandbox-changed=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/sandbox-deployment.yml
+++ b/.github/workflows/sandbox-deployment.yml
@@ -26,8 +26,9 @@ jobs:
       contents: read
     outputs:
       sandbox-changed: ${{ steps.check.outputs.sandbox-changed }}
-      new-version: ${{ steps.version.outputs.new-version }}
-      custom-tag: ${{ steps.check.outputs.custom-tag }}
+      # metadata-action tags input: set by the check step for dev builds,
+      # otherwise by the version step.
+      image-tags: ${{ steps.check.outputs.image-tags || steps.version.outputs.image-tags }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
@@ -50,7 +51,7 @@ jobs:
           # The sandbox-dev tag always builds and pushes the :dev image tag.
           if [ "$GITHUB_REF_NAME" = "sandbox-dev" ]; then
             echo "Dev tag: building and pushing :dev"
-            echo "custom-tag=dev" >> "$GITHUB_OUTPUT"
+            echo "image-tags=type=raw,value=dev" >> "$GITHUB_OUTPUT"
             echo "sandbox-changed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -76,7 +77,7 @@ jobs:
 
       - name: Determine new sandbox version
         id: version
-        if: steps.check.outputs.sandbox-changed == 'true' && steps.check.outputs.custom-tag == ''
+        if: steps.check.outputs.sandbox-changed == 'true' && steps.check.outputs.image-tags == ''
         run: |
           # Query Docker Hub for the latest versioned tag
           LATEST_TAG=$(curl -s "https://hub.docker.com/v2/repositories/onyxdotapp/sandbox/tags?page_size=100" \
@@ -101,7 +102,12 @@ jobs:
           fi
 
           echo "New version: $NEW_VERSION"
-          echo "new-version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          {
+            echo "image-tags<<EOF"
+            echo "type=raw,value=v${NEW_VERSION}"
+            echo "type=raw,value=latest"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
   build-sandbox-amd64:
     needs: check-sandbox-changes
@@ -292,9 +298,7 @@ jobs:
           images: ${{ env.REGISTRY_IMAGE }}
           flavor: |
             latest=false
-          tags: |
-            ${{ needs.check-sandbox-changes.outputs.custom-tag != '' && format('type=raw,value={0}', needs.check-sandbox-changes.outputs.custom-tag) || format('type=raw,value=v{0}', needs.check-sandbox-changes.outputs.new-version) }}
-            ${{ needs.check-sandbox-changes.outputs.custom-tag == '' && 'type=raw,value=latest' || '' }}
+          tags: ${{ needs.check-sandbox-changes.outputs.image-tags }}
 
       - name: Create and push manifest
         env:

--- a/.github/workflows/sandbox-deployment.yml
+++ b/.github/workflows/sandbox-deployment.yml
@@ -2,10 +2,17 @@ name: Build and Push Sandbox Image
 
 # The sandbox image is the only Craft-specific image. Build a new version on
 # the nightly tag when its build context changed, or manually on demand.
+#
+# To push an ad-hoc build, tag the commit with sandbox/<docker-tag>, e.g.
+#   git tag -f sandbox/dev && git push -f origin sandbox/dev
+# builds unconditionally and pushes onyxdotapp/sandbox:dev. Ad-hoc builds
+# never cut a vX.Y.Z version or move :latest — those only happen on the
+# nightly path.
 on:
   push:
     tags:
       - "nightly-latest-*"
+      - "sandbox/*"
   workflow_dispatch:
 
 # Restrictive defaults; jobs declare what they need.
@@ -20,6 +27,7 @@ jobs:
     outputs:
       sandbox-changed: ${{ steps.check.outputs.sandbox-changed }}
       new-version: ${{ steps.version.outputs.new-version }}
+      custom-tag: ${{ steps.check.outputs.custom-tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
@@ -38,6 +46,21 @@ jobs:
             echo "sandbox-changed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+
+          # sandbox/<docker-tag> tags always build and push that exact image tag.
+          case "$GITHUB_REF_NAME" in
+            sandbox/*)
+              CUSTOM_TAG="${GITHUB_REF_NAME#sandbox/}"
+              if ! printf '%s' "$CUSTOM_TAG" | grep -qE '^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$'; then
+                echo "Invalid docker tag derived from git tag: '$CUSTOM_TAG'"
+                exit 1
+              fi
+              echo "Custom sandbox tag: building and pushing :${CUSTOM_TAG}"
+              echo "custom-tag=$CUSTOM_TAG" >> "$GITHUB_OUTPUT"
+              echo "sandbox-changed=true" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+          esac
 
           # Diff the sandbox image build context against the previous nightly tag.
           CURRENT_TAG="${GITHUB_REF_NAME}"
@@ -60,7 +83,7 @@ jobs:
 
       - name: Determine new sandbox version
         id: version
-        if: steps.check.outputs.sandbox-changed == 'true'
+        if: steps.check.outputs.sandbox-changed == 'true' && steps.check.outputs.custom-tag == ''
         run: |
           # Query Docker Hub for the latest versioned tag
           LATEST_TAG=$(curl -s "https://hub.docker.com/v2/repositories/onyxdotapp/sandbox/tags?page_size=100" \
@@ -277,8 +300,8 @@ jobs:
           flavor: |
             latest=false
           tags: |
-            type=raw,value=v${{ needs.check-sandbox-changes.outputs.new-version }}
-            type=raw,value=latest
+            ${{ needs.check-sandbox-changes.outputs.custom-tag != '' && format('type=raw,value={0}', needs.check-sandbox-changes.outputs.custom-tag) || format('type=raw,value=v{0}', needs.check-sandbox-changes.outputs.new-version) }}
+            ${{ needs.check-sandbox-changes.outputs.custom-tag == '' && 'type=raw,value=latest' || '' }}
 
       - name: Create and push manifest
         env:

--- a/.github/workflows/sandbox-deployment.yml
+++ b/.github/workflows/sandbox-deployment.yml
@@ -3,16 +3,16 @@ name: Build and Push Sandbox Image
 # The sandbox image is the only Craft-specific image. Build a new version on
 # the nightly tag when its build context changed, or manually on demand.
 #
-# To push an ad-hoc build, tag the commit with sandbox/<docker-tag>, e.g.
+# To push an ad-hoc dev build:
 #   git tag -f sandbox/dev && git push -f origin sandbox/dev
-# builds unconditionally and pushes onyxdotapp/sandbox:dev. Ad-hoc builds
-# never cut a vX.Y.Z version or move :latest — those only happen on the
-# nightly path.
+# builds unconditionally and pushes onyxdotapp/sandbox:dev. Dev builds never
+# cut a vX.Y.Z version or move :latest — those only happen on the nightly
+# path. Only sandbox/dev is supported, to keep Docker Hub free of one-off tags.
 on:
   push:
     tags:
       - "nightly-latest-*"
-      - "sandbox/*"
+      - "sandbox/dev"
   workflow_dispatch:
 
 # Restrictive defaults; jobs declare what they need.
@@ -47,20 +47,13 @@ jobs:
             exit 0
           fi
 
-          # sandbox/<docker-tag> tags always build and push that exact image tag.
-          case "$GITHUB_REF_NAME" in
-            sandbox/*)
-              CUSTOM_TAG="${GITHUB_REF_NAME#sandbox/}"
-              if ! printf '%s' "$CUSTOM_TAG" | grep -qE '^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$'; then
-                echo "Invalid docker tag derived from git tag: '$CUSTOM_TAG'"
-                exit 1
-              fi
-              echo "Custom sandbox tag: building and pushing :${CUSTOM_TAG}"
-              echo "custom-tag=$CUSTOM_TAG" >> "$GITHUB_OUTPUT"
-              echo "sandbox-changed=true" >> "$GITHUB_OUTPUT"
-              exit 0
-              ;;
-          esac
+          # The sandbox/dev tag always builds and pushes the :dev image tag.
+          if [ "$GITHUB_REF_NAME" = "sandbox/dev" ]; then
+            echo "Dev tag: building and pushing :dev"
+            echo "custom-tag=dev" >> "$GITHUB_OUTPUT"
+            echo "sandbox-changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           # Diff the sandbox image build context against the previous nightly tag.
           CURRENT_TAG="${GITHUB_REF_NAME}"

--- a/.vscode/.env.k8s.template
+++ b/.vscode/.env.k8s.template
@@ -128,6 +128,9 @@ K8S_CONTEXT=kind-onyx-dev
 #     backend/onyx/server/features/build/sandbox/image
 #   kind load docker-image onyxdotapp/sandbox:dev --name onyx-dev
 SANDBOX_CONTAINER_IMAGE=onyxdotapp/sandbox:dev
+# Keep the default SANDBOX_IMAGE_PULL_POLICY=IfNotPresent here: the image is
+# kind-loaded, not on Docker Hub, so Always would fail the pull. Remote envs
+# pinning the mutable :dev tag should set Always instead.
 
 # How sandboxes reach the api_server: out through the egress proxy to the host
 # gateway, not internal cluster DNS. Linux-kind devs sub their own host gateway.

--- a/backend/onyx/server/features/build/configs.py
+++ b/backend/onyx/server/features/build/configs.py
@@ -54,11 +54,9 @@ SANDBOX_CONTAINER_IMAGE = os.environ.get(
     "SANDBOX_CONTAINER_IMAGE", "onyxdotapp/sandbox:v0.1.52"
 )
 
-# The :dev tag is mutable (re-pushed via the sandbox-dev git tag), so nodes
-# must re-pull it; immutable version tags can use the node cache.
-SANDBOX_IMAGE_PULL_POLICY = (
-    "Always" if SANDBOX_CONTAINER_IMAGE.endswith(":dev") else "IfNotPresent"
-)
+# Set to "Always" in environments that pin a mutable tag (e.g. :dev) so nodes
+# re-pull on every pod start; immutable version pins can use the node cache.
+SANDBOX_IMAGE_PULL_POLICY = os.environ.get("SANDBOX_IMAGE_PULL_POLICY", "IfNotPresent")
 
 # Path structure: s3://{bucket}/{tenant_id}/snapshots/{session_id}/{snapshot_id}.tar.gz
 #                 s3://{bucket}/{tenant_id}/knowledge/{user_id}/

--- a/backend/onyx/server/features/build/configs.py
+++ b/backend/onyx/server/features/build/configs.py
@@ -54,6 +54,12 @@ SANDBOX_CONTAINER_IMAGE = os.environ.get(
     "SANDBOX_CONTAINER_IMAGE", "onyxdotapp/sandbox:v0.1.52"
 )
 
+# The :dev tag is mutable (re-pushed via the sandbox-dev git tag), so nodes
+# must re-pull it; immutable version tags can use the node cache.
+SANDBOX_IMAGE_PULL_POLICY = (
+    "Always" if SANDBOX_CONTAINER_IMAGE.endswith(":dev") else "IfNotPresent"
+)
+
 # Path structure: s3://{bucket}/{tenant_id}/snapshots/{session_id}/{snapshot_id}.tar.gz
 #                 s3://{bucket}/{tenant_id}/knowledge/{user_id}/
 #                 s3://{bucket}/{tenant_id}/uploads/{session_id}/

--- a/backend/onyx/server/features/build/sandbox/image/README.md
+++ b/backend/onyx/server/features/build/sandbox/image/README.md
@@ -24,15 +24,16 @@ and are pushed into sandboxes at session setup, never baked into the image.
 
 ### Via CI (preferred)
 
-Push a `sandbox/<docker-tag>` git tag to have `.github/workflows/sandbox-deployment.yml`
-build multi-arch and push `onyxdotapp/sandbox:<docker-tag>`:
+Push the `sandbox/dev` git tag to have `.github/workflows/sandbox-deployment.yml`
+build multi-arch and push `onyxdotapp/sandbox:dev`:
 
 ```bash
 git tag -f sandbox/dev && git push -f origin sandbox/dev
 ```
 
-Ad-hoc builds never cut a `vX.Y.Z` version or move `:latest`. The nightly tag
+Dev builds never cut a `vX.Y.Z` version or move `:latest`. The nightly tag
 still cuts an auto-versioned `vX.Y.Z` + `latest` when the image context changed.
+Only `sandbox/dev` is supported, to keep Docker Hub free of one-off tags.
 
 ### Building locally
 

--- a/backend/onyx/server/features/build/sandbox/image/README.md
+++ b/backend/onyx/server/features/build/sandbox/image/README.md
@@ -35,9 +35,9 @@ Dev builds never cut a `vX.Y.Z` version or move `:latest`. The nightly tag
 still cuts an auto-versioned `vX.Y.Z` + `latest` when the image context changed.
 Only `sandbox-dev` is supported, to keep Docker Hub free of one-off tags.
 
-When `SANDBOX_CONTAINER_IMAGE` is pinned to `:dev`, sandbox pods pull with
-`imagePullPolicy: Always` (instead of `IfNotPresent`) so re-pushed dev builds
-are picked up by new pods. See `docs/craft/image-architecture.md`.
+Environments that pin `SANDBOX_CONTAINER_IMAGE` to `:dev` must also set
+`SANDBOX_IMAGE_PULL_POLICY=Always` (default `IfNotPresent`) so re-pushed dev
+builds are picked up by new pods. See `docs/craft/image-architecture.md`.
 
 ### Building locally
 

--- a/backend/onyx/server/features/build/sandbox/image/README.md
+++ b/backend/onyx/server/features/build/sandbox/image/README.md
@@ -22,6 +22,20 @@ and are pushed into sandboxes at session setup, never baked into the image.
 
 ## Building the Image
 
+### Via CI (preferred)
+
+Push a `sandbox/<docker-tag>` git tag to have `.github/workflows/sandbox-deployment.yml`
+build multi-arch and push `onyxdotapp/sandbox:<docker-tag>`:
+
+```bash
+git tag -f sandbox/dev && git push -f origin sandbox/dev
+```
+
+Ad-hoc builds never cut a `vX.Y.Z` version or move `:latest`. The nightly tag
+still cuts an auto-versioned `vX.Y.Z` + `latest` when the image context changed.
+
+### Building locally
+
 The sandbox image must be built for **amd64** architecture since our Kubernetes cluster runs on x86_64 nodes.
 
 ### Build for amd64 only (fastest)

--- a/backend/onyx/server/features/build/sandbox/image/README.md
+++ b/backend/onyx/server/features/build/sandbox/image/README.md
@@ -24,16 +24,20 @@ and are pushed into sandboxes at session setup, never baked into the image.
 
 ### Via CI (preferred)
 
-Push the `sandbox/dev` git tag to have `.github/workflows/sandbox-deployment.yml`
+Push the `sandbox-dev` git tag to have `.github/workflows/sandbox-deployment.yml`
 build multi-arch and push `onyxdotapp/sandbox:dev`:
 
 ```bash
-git tag -f sandbox/dev && git push -f origin sandbox/dev
+git tag -f sandbox-dev && git push -f origin sandbox-dev
 ```
 
 Dev builds never cut a `vX.Y.Z` version or move `:latest`. The nightly tag
 still cuts an auto-versioned `vX.Y.Z` + `latest` when the image context changed.
-Only `sandbox/dev` is supported, to keep Docker Hub free of one-off tags.
+Only `sandbox-dev` is supported, to keep Docker Hub free of one-off tags.
+
+When `SANDBOX_CONTAINER_IMAGE` is pinned to `:dev`, sandbox pods pull with
+`imagePullPolicy: Always` (instead of `IfNotPresent`) so re-pushed dev builds
+are picked up by new pods. See `docs/craft/image-architecture.md`.
 
 ### Building locally
 

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -68,6 +68,7 @@ from onyx.server.features.build.configs import OPENCODE_SERVE_PORT
 from onyx.server.features.build.configs import OPENCODE_SERVER_PASSWORD
 from onyx.server.features.build.configs import SANDBOX_API_SERVER_URL
 from onyx.server.features.build.configs import SANDBOX_CONTAINER_IMAGE
+from onyx.server.features.build.configs import SANDBOX_IMAGE_PULL_POLICY
 from onyx.server.features.build.configs import SANDBOX_NAMESPACE
 from onyx.server.features.build.configs import SANDBOX_NEXTJS_PORT_END
 from onyx.server.features.build.configs import SANDBOX_NEXTJS_PORT_START
@@ -205,7 +206,7 @@ def _proxy_init_container() -> client.V1Container:
     return client.V1Container(
         name="sandbox-init",
         image=SANDBOX_CONTAINER_IMAGE,
-        image_pull_policy="IfNotPresent",
+        image_pull_policy=SANDBOX_IMAGE_PULL_POLICY,
         command=["/workspace/firewall-init.sh"],
         env=[
             client.V1EnvVar(name="SANDBOX_PROXY_HOST", value=SANDBOX_PROXY_HOST),
@@ -602,7 +603,7 @@ class KubernetesSandboxManager(SandboxManager):
         sandbox_container = client.V1Container(
             name=_SANDBOX_CONTAINER_NAME,
             image=self._image,
-            image_pull_policy="IfNotPresent",
+            image_pull_policy=SANDBOX_IMAGE_PULL_POLICY,
             command=["/workspace/entrypoint.sh"],
             ports=sandbox_ports,
             env=[
@@ -707,7 +708,7 @@ class KubernetesSandboxManager(SandboxManager):
         sidecar_container = client.V1Container(
             name="sidecar",
             image=self._image,
-            image_pull_policy="IfNotPresent",
+            image_pull_policy=SANDBOX_IMAGE_PULL_POLICY,
             command=["/workspace/sidecar-entrypoint.sh"],
             ports=[
                 client.V1ContainerPort(

--- a/docs/craft/image-architecture.md
+++ b/docs/craft/image-architecture.md
@@ -32,6 +32,16 @@ previous nightly. It publishes `onyxdotapp/sandbox:vX.Y.Z` (auto-incremented
 patch) + `:latest`. Run it manually any time via the workflow's
 `workflow_dispatch` to cut a build on demand.
 
+For an ad-hoc build, push a `sandbox/<docker-tag>` git tag:
+
+```bash
+git tag -f sandbox/dev && git push -f origin sandbox/dev
+```
+
+This builds unconditionally and pushes `onyxdotapp/sandbox:dev`. Ad-hoc builds
+never cut a `vX.Y.Z` version or move `:latest` — those only happen on the
+nightly path.
+
 The backend does **not** track `:latest` — it pins a specific version via
 `SANDBOX_CONTAINER_IMAGE` (default in `configs.py`). Bump that pin to adopt a
 new sandbox version.

--- a/docs/craft/image-architecture.md
+++ b/docs/craft/image-architecture.md
@@ -43,11 +43,12 @@ never cut a `vX.Y.Z` version or move `:latest` — those only happen on the
 nightly path. Only `sandbox-dev` is supported, to keep Docker Hub free of
 one-off tags.
 
-Sandbox pods normally use `imagePullPolicy: IfNotPresent`, which would keep
-serving a node-cached `:dev` after a re-push. `SANDBOX_IMAGE_PULL_POLICY`
-(`configs.py`) flips to `Always` when `SANDBOX_CONTAINER_IMAGE` is pinned to
-the mutable `:dev` tag, so new pods always pull the latest dev build. Already
-running sandbox pods are unaffected — delete them to pick up the new image.
+Sandbox pods default to `imagePullPolicy: IfNotPresent`, which would keep
+serving a node-cached `:dev` after a re-push. Environments that pin the
+mutable `:dev` tag must also set `SANDBOX_IMAGE_PULL_POLICY=Always` (next to
+`SANDBOX_CONTAINER_IMAGE` in the env config) so new pods always pull the
+latest dev build. Already running sandbox pods are unaffected — delete them
+to pick up the new image.
 
 The backend does **not** track `:latest` — it pins a specific version via
 `SANDBOX_CONTAINER_IMAGE` (default in `configs.py`). Bump that pin to adopt a

--- a/docs/craft/image-architecture.md
+++ b/docs/craft/image-architecture.md
@@ -32,16 +32,22 @@ previous nightly. It publishes `onyxdotapp/sandbox:vX.Y.Z` (auto-incremented
 patch) + `:latest`. Run it manually any time via the workflow's
 `workflow_dispatch` to cut a build on demand.
 
-For an ad-hoc dev build, push the `sandbox/dev` git tag:
+For an ad-hoc dev build, push the `sandbox-dev` git tag:
 
 ```bash
-git tag -f sandbox/dev && git push -f origin sandbox/dev
+git tag -f sandbox-dev && git push -f origin sandbox-dev
 ```
 
 This builds unconditionally and pushes `onyxdotapp/sandbox:dev`. Dev builds
 never cut a `vX.Y.Z` version or move `:latest` — those only happen on the
-nightly path. Only `sandbox/dev` is supported, to keep Docker Hub free of
+nightly path. Only `sandbox-dev` is supported, to keep Docker Hub free of
 one-off tags.
+
+Sandbox pods normally use `imagePullPolicy: IfNotPresent`, which would keep
+serving a node-cached `:dev` after a re-push. `SANDBOX_IMAGE_PULL_POLICY`
+(`configs.py`) flips to `Always` when `SANDBOX_CONTAINER_IMAGE` is pinned to
+the mutable `:dev` tag, so new pods always pull the latest dev build. Already
+running sandbox pods are unaffected — delete them to pick up the new image.
 
 The backend does **not** track `:latest` — it pins a specific version via
 `SANDBOX_CONTAINER_IMAGE` (default in `configs.py`). Bump that pin to adopt a

--- a/docs/craft/image-architecture.md
+++ b/docs/craft/image-architecture.md
@@ -32,15 +32,16 @@ previous nightly. It publishes `onyxdotapp/sandbox:vX.Y.Z` (auto-incremented
 patch) + `:latest`. Run it manually any time via the workflow's
 `workflow_dispatch` to cut a build on demand.
 
-For an ad-hoc build, push a `sandbox/<docker-tag>` git tag:
+For an ad-hoc dev build, push the `sandbox/dev` git tag:
 
 ```bash
 git tag -f sandbox/dev && git push -f origin sandbox/dev
 ```
 
-This builds unconditionally and pushes `onyxdotapp/sandbox:dev`. Ad-hoc builds
+This builds unconditionally and pushes `onyxdotapp/sandbox:dev`. Dev builds
 never cut a `vX.Y.Z` version or move `:latest` — those only happen on the
-nightly path.
+nightly path. Only `sandbox/dev` is supported, to keep Docker Hub free of
+one-off tags.
 
 The backend does **not** track `:latest` — it pins a specific version via
 `SANDBOX_CONTAINER_IMAGE` (default in `configs.py`). Bump that pin to adopt a


### PR DESCRIPTION
## Description

Makes deploying a new dev sandbox image a one-liner: push the `sandbox-dev` git tag and CI builds + publishes `onyxdotapp/sandbox:dev`.

```bash
git tag -f sandbox-dev && git push -f origin sandbox-dev
```

Only `sandbox-dev` is supported (not arbitrary tags). Re-pushing the mutable `:dev` tag just repoints it — old digests become untagged — so Docker Hub stays at exactly one dev image.

### All sandbox image deployment paths

`.github/workflows/sandbox-deployment.yml` now has three triggers:

| Path | Trigger | Builds when | Pushes |
|------|---------|-------------|--------|
| **Dev tag** (new) | `sandbox-dev` git tag | Always | `onyxdotapp/sandbox:dev` only — never bumps `vX.Y.Z`, never moves `:latest` |
| **Nightly** (unchanged) | `nightly-latest-*` tag | Only if the image build context (`backend/onyx/server/features/build/sandbox/image/`) changed since the previous nightly | Auto-incremented `vX.Y.Z` **+** `:latest` (so `:latest` keeps tracking the newest released version) |
| **Manual dispatch** (unchanged) | `workflow_dispatch` | Always | Auto-incremented `vX.Y.Z` + `:latest` |

Local `docker build && docker push` remains documented in the image README as a fallback.

### Image pull policy

Sandbox pods used a hardcoded `imagePullPolicy: IfNotPresent`, which would keep serving a node-cached `:dev` after a re-push. New `SANDBOX_IMAGE_PULL_POLICY` env var (default `IfNotPresent`) is applied to all three sandbox pod containers (init, sandbox, sidecar). Environments that pin the mutable `:dev` tag set `SANDBOX_IMAGE_PULL_POLICY=Always` next to `SANDBOX_CONTAINER_IMAGE` — the code never inspects tag names. The local kind template keeps the default since its `:dev` image is kind-loaded, not on Docker Hub.

Notes:
- For the dev cluster: set `SANDBOX_IMAGE_PULL_POLICY=Always` in the internal-repo env ConfigMap alongside `SANDBOX_CONTAINER_IMAGE=onyxdotapp/sandbox:dev`. New builds are picked up by new pods; delete existing sandbox pods to refresh them.
- The backend still pins a specific version via `SANDBOX_CONTAINER_IMAGE` (default in `configs.py`); adopting a new release still means bumping that pin.
- Docs updated: `docs/craft/image-architecture.md` (tag flow + pull policy) and the sandbox image README.

## How Has This Been Tested?

- `pre-commit run` on the changed files: zizmor, actionlint, YAML, ruff, and ty all pass.
- `pytest backend/tests/unit/onyx/server/features/build/sandbox/test_pod_spec.py` — 15 passed.
- Not run end-to-end (requires pushing a tag to this repo); the build/merge jobs themselves are unchanged apart from tag selection.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)
