### PR TITLE
fix(ods): run bun install when node_modules is empty

### DIFF
--- a/tools/ods/cmd/web.go
+++ b/tools/ods/cmd/web.go
@@ -49,8 +49,8 @@ func runWebScript(args []string) {
 	}
 
 	nodeModules := filepath.Join(webDir, "node_modules")
-	if _, err := os.Stat(nodeModules); os.IsNotExist(err) {
-		log.Info("node_modules not found, running bun install --frozen-lockfile...")
+	if needsInstall, reason := nodeModulesNeedsInstall(nodeModules); needsInstall {
+		log.Infof("%s, running bun install --frozen-lockfile...", reason)
 		installCmd := exec.Command("bun", "install", "--frozen-lockfile")
 		installCmd.Dir = webDir
 		installCmd.Stdout = os.Stdout
@@ -92,6 +92,25 @@ func runWebScript(args []string) {
 		}
 		log.Fatalf("Failed to run bun: %v", err)
 	}
+}
+
+// nodeModulesNeedsInstall reports whether bun install should be run, along with
+// a human-readable reason. Install is needed when node_modules is missing or
+// exists but is empty.
+func nodeModulesNeedsInstall(nodeModules string) (bool, string) {
+	entries, err := os.ReadDir(nodeModules)
+	if errors.Is(err, os.ErrNotExist) {
+		return true, "node_modules not found"
+	}
+	if err != nil {
+		// Couldn't read the directory for some other reason; let bun install
+		// attempt to sort it out rather than silently skipping.
+		return true, fmt.Sprintf("could not read node_modules (%v)", err)
+	}
+	if len(entries) == 0 {
+		return true, "node_modules is empty"
+	}
+	return false, ""
 }
 
 func webScriptNames() []string {


### PR DESCRIPTION
## Summary

`ods web <script>` checks whether `node_modules` exists before running a bun script and runs `bun install --frozen-lockfile` if it's missing. However, it only handled the *missing* case — an empty `node_modules` directory (e.g. left behind by an interrupted install) would pass the existence check and the subsequent script would fail with missing dependencies.

This switches the check from `os.Stat` to `os.ReadDir` so we install when `node_modules` is **missing or empty**.

## Changes

- Add `nodeModulesNeedsInstall` helper returning whether to install plus a human-readable reason:
  - missing → "node_modules not found"
  - empty → "node_modules is empty"
  - unreadable for another reason → install anyway, surfacing the error rather than silently skipping
  - non-empty → skip
- Log message now reflects the actual reason.

## Testing

- `go build ./...` and `go vet ./cmd/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `ods web` to run `bun install --frozen-lockfile` when `node_modules` is missing, empty, or unreadable. This prevents failing web scripts and logs why the install is needed.

- **Bug Fixes**
  - Added `nodeModulesNeedsInstall` using `os.ReadDir` to detect missing/empty/unreadable `node_modules` and return a human-readable reason; skips when non-empty.
  - Log now prints the specific reason before running install.

<sup>Written for commit 45de808437b61d1633c91d9c4203a887c8d43080. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

