### PR TITLE
fix(fe): stop useAuthType clobbering the shared auth-type SWR cache

### DIFF
--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -39,6 +39,7 @@ import { useUser } from "@/providers/UserProvider";
 import { SEARCH_TOOL_ID } from "@/app/app/components/tools/constants";
 import { updateTemperatureOverrideForChatSession } from "@/app/app/services/lib";
 import { useLLMProviders } from "@/hooks/useLanguageModels";
+import { useAuthTypeMetadata } from "@/hooks/useAuthTypeMetadata";
 import { SWR_KEYS } from "@/lib/swr-keys";
 
 export const usePublicCredentials = () => {
@@ -843,20 +844,20 @@ export function useLlmManager(
 }
 
 export function useAuthType(): AuthType | null {
-  const { data, error } = useSWR<{ auth_type: AuthType }>(
-    SWR_KEYS.authType,
-    errorHandlingFetcher
-  );
+  // Delegate to useAuthTypeMetadata so the shared SWR key always holds the
+  // camelCase-mapped shape — a raw fetcher here would poison the cache for
+  // every other consumer of the key.
+  const { authTypeMetadata, isLoading, error } = useAuthTypeMetadata();
 
   if (NEXT_PUBLIC_CLOUD_ENABLED) {
     return AuthType.CLOUD;
   }
 
-  if (error || !data) {
+  if (error || isLoading) {
     return null;
   }
 
-  return data.auth_type;
+  return authTypeMetadata.authType;
 }
 
 /*


### PR DESCRIPTION
## Description

**Bug:** Cloud "Change Password" modal rejects every password with *"Password must be at least undefined characters"* (customer report).

**Cause:** `useAuthType` fetched `/api/auth/type` with `errorHandlingFetcher` (raw snake_case JSON) under the same SWR key that `useAuthTypeMetadata` populates with the camelCase-mapped shape. SWR caches by key only, so when `useAuthType` revalidated — the settings page mounts both hooks — the cache entry lost its mapped fields and `authTypeMetadata.passwordMinLength` became `undefined`, making the Yup `.min(undefined)` check fail for every input.

**Fix:** `useAuthType` now delegates to `useAuthTypeMetadata` so a single fetcher owns the key. `useAuthTypeMetadata` is now the key's only consumer.

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check