### PR TITLE
fix(terraform): expose EKS security group outputs

### DIFF
--- a/deployment/terraform/modules/aws/eks/outputs.tf
+++ b/deployment/terraform/modules/aws/eks/outputs.tf
@@ -26,6 +26,8 @@ output "cluster_security_group_id" {
   value       = module.eks.cluster_security_group_id
 }
 
+# Re-exported from the upstream eks module so the craft_sandbox module can
+# trust-scope its IRSA role to the cluster's OIDC provider.
 output "oidc_provider_arn" {
   description = "EKS OIDC provider ARN (for IRSA roles)"
   value       = module.eks.oidc_provider_arn

--- a/deployment/terraform/modules/aws/eks/outputs.tf
+++ b/deployment/terraform/modules/aws/eks/outputs.tf
@@ -16,8 +16,16 @@ output "workload_irsa_role_arn" {
   value       = length(module.irsa-workload-access) > 0 ? module.irsa-workload-access[0].iam_role_arn : null
 }
 
-# Re-exported from the upstream eks module so the craft_sandbox module can
-# trust-scope its IRSA role to the cluster's OIDC provider.
+output "node_security_group_id" {
+  description = "Node security group ID from the EKS module"
+  value       = module.eks.node_security_group_id
+}
+
+output "cluster_security_group_id" {
+  description = "Cluster security group ID from the EKS module"
+  value       = module.eks.cluster_security_group_id
+}
+
 output "oidc_provider_arn" {
   description = "EKS OIDC provider ARN (for IRSA roles)"
   value       = module.eks.oidc_provider_arn


### PR DESCRIPTION
## Description

The top-level AWS Onyx Terraform module passes `module.eks.node_security_group_id` and `module.eks.cluster_security_group_id` into the OpenSearch module so the OpenSearch domain can reuse the EKS security groups.

Those attributes are produced by the upstream `terraform-aws-modules/eks/aws` module, but our local `deployment/terraform/modules/aws/eks` wrapper did not re-export them. That makes the parent module reference outputs that do not exist on the wrapper module.

This PR re-exports the node and cluster security group IDs from the wrapper module so the existing OpenSearch wiring resolves correctly.

## How This Was Found

The issue shows up when validating the AWS Terraform module. On `origin/main`, from `deployment/terraform/modules/aws/onyx`:

```text
$ terraform init -backend=false
Terraform has been successfully initialized!

$ terraform validate
Error: Unsupported attribute

  on main.tf line 131, in module "opensearch":
 131:   security_group_ids = [module.eks.node_security_group_id, module.eks.cluster_security_group_id]
    ├────────────────
    │ module.eks is object with 6 attributes

This object does not have an attribute named "node_security_group_id".

Error: Unsupported attribute

  on main.tf line 131, in module "opensearch":
 131:   security_group_ids = [module.eks.node_security_group_id, module.eks.cluster_security_group_id]
    ├────────────────
    │ module.eks is object with 6 attributes

This object does not have an attribute named "cluster_security_group_id".
```

With these wrapper outputs added, `terraform validate` succeeds for `deployment/terraform/modules/aws/onyx`.

## How Has This Been Tested?

Not run; no local end-to-end infrastructure environment was exercised.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
