### PR TITLE
fix(bookstack): index documents updated on the current day

### DIFF
--- a/backend/onyx/connectors/bookstack/connector.py
+++ b/backend/onyx/connectors/bookstack/connector.py
@@ -56,15 +56,20 @@ class BookstackConnector(LoadConnector, PollConnector):
             "sort": "+id",
         }
 
+        # BookStack interprets a date-only "updated_at" filter (YYYY-MM-DD) as
+        # "<= YYYY-MM-DD 00:00:00", which silently excludes documents updated
+        # later on the boundary day. Since every poll uses end=now, this drops
+        # anything edited "today" until the next calendar day. Full ISO-8601
+        # datetime granularity makes the gte/lte bounds inclusive as intended.
         if start:
             params["filter[updated_at:gte]"] = datetime.fromtimestamp(
                 start, tz=timezone.utc
-            ).strftime("%Y-%m-%d")
+            ).strftime("%Y-%m-%dT%H:%M:%S")
 
         if end:
             params["filter[updated_at:lte]"] = datetime.fromtimestamp(
                 end, tz=timezone.utc
-            ).strftime("%Y-%m-%d")
+            ).strftime("%Y-%m-%dT%H:%M:%S")
 
         batch = bookstack_client.get(endpoint, params=params).get("data", [])
         doc_batch: list[Document | HierarchyNode] = [


### PR DESCRIPTION
## Fix: BookStack connector drops documents updated on the current day

### Problem
`BookstackConnector._get_doc_batch` formats its `updated_at` poll filters with
**date-only** granularity (`%Y-%m-%d`). BookStack treats a date-only
`filter[updated_at:lte]=YYYY-MM-DD` as `<= YYYY-MM-DD 00:00:00`, so any document
updated later that same day is excluded.

Every poll run uses `end = now`, so the window's upper bound is effectively
midnight this morning. As a result a page created/edited **today** is never
indexed until the next calendar day — and because `BookstackConnector` is a
`PollConnector`, this affects "re-index from scratch" runs too (ConnectorRunner
always passes a `(start, end)` range).

The bug self-heals overnight, which makes it hard to diagnose.

### Fix
Use full ISO-8601 datetime granularity (`%Y-%m-%dT%H:%M:%S`) for both the
`gte` and `lte` boundaries so the filter is inclusive of intra-day times.

### Verification
Against a live BookStack instance + Onyx v4.0.7:
- Before: a page edited "today" → connector fetches 0 docs (incremental and full).
- After: an incremental run fetches exactly that page and indexes it
  (`docs=1 chunks=2`), no manual timestamp manipulation needed.

Direct API confirmation:
```
filter[updated_at:lte]=2026-06-10            -> total: 0   (page updated 2026-06-10 20:37)
filter[updated_at:lte]=2026-06-10T23:59:59   -> total: 1
```

### Notes
- One-line behavior change per boundary; no API/contract change.
- Could optionally add a connector unit test asserting the formatted filter
  values include a time component — happy to add if maintainers want it.

Fixes #11913


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where the BookStack connector skipped documents updated today. We now send ISO-8601 datetimes in `updated_at` filters so same-day edits are indexed. Fixes #11913.

- **Bug Fixes**
  - Format `filter[updated_at:gte]` and `filter[updated_at:lte]` as `%Y-%m-%dT%H:%M:%S`.
  - Ensures polling with `end=now` includes intra-day updates.
  - No breaking changes.

<sup>Written for commit d707bd0f1d1e95187d626a460dbbf241b60da467. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

