### PR TITLE
chore(opal): remove `className` from `Checkbox` and `RootLayout` interfaces

### DIFF
--- a/web/bun.lock
+++ b/web/bun.lock
@@ -130,7 +130,7 @@
     },
     "lib/opal": {
       "name": "@onyx-ai/opal",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "dependencies": {
         "clsx": "^2.0.0",
         "copy-to-clipboard": "^3.3.3",

--- a/web/lib/opal/package.json
+++ b/web/lib/opal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onyx-ai/opal",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Opal — Onyx's Typescript component library and design system.",
   "license": "MIT",
   "repository": {

--- a/web/lib/opal/src/components/checkbox/components.tsx
+++ b/web/lib/opal/src/components/checkbox/components.tsx
@@ -4,6 +4,7 @@ import "@opal/components/checkbox/styles.css";
 import React, { useEffect, useRef, useState } from "react";
 import { cn } from "@opal/utils";
 import { SvgCheck, SvgMinus } from "@opal/icons";
+import type { WithoutStyles } from "@opal/types";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -11,9 +12,8 @@ import { SvgCheck, SvgMinus } from "@opal/icons";
 
 type CheckboxState = "unchecked" | "checked" | "indeterminate";
 
-interface CheckboxProps extends Omit<
-  React.ComponentPropsWithoutRef<"input">,
-  "type" | "size"
+interface CheckboxProps extends WithoutStyles<
+  Omit<React.ComponentPropsWithoutRef<"input">, "type" | "size">
 > {
   checked?: boolean;
   defaultChecked?: boolean;
@@ -42,7 +42,6 @@ function CheckboxInner(
     onCheckedChange,
     indeterminate = false,
     disabled,
-    className,
     onChange,
     id,
     name,
@@ -129,7 +128,7 @@ function CheckboxInner(
         tabIndex={disabled ? -1 : 0}
         data-state={state}
         data-disabled={disabled || undefined}
-        className={cn("opal-checkbox-surface", className)}
+        className="opal-checkbox-surface"
         onClick={(e) => {
           if (!disabled && inputRef.current) {
             inputRef.current.click();

--- a/web/lib/opal/src/layouts/index.ts
+++ b/web/lib/opal/src/layouts/index.ts
@@ -55,7 +55,11 @@ export type { SettingsHeaderProps } from "@opal/layouts/settings/components";
 
 /* RootLayout */
 export * as RootLayout from "@opal/layouts/root/components";
-export { useSidebarFolded } from "@opal/layouts/root/components";
+export {
+  useSidebarFolded,
+  RootLayoutRightPanelSlotContext,
+} from "@opal/layouts/root/components";
+export type { RightPanelSlotSetter } from "@opal/layouts/root/components";
 
 /* SidebarLayouts */
 export * as SidebarLayouts from "@opal/layouts/sidebar/components";

--- a/web/lib/opal/src/layouts/root/components.tsx
+++ b/web/lib/opal/src/layouts/root/components.tsx
@@ -5,7 +5,9 @@ import {
   createContext,
   useContext,
   useLayoutEffect,
+  type Dispatch,
   type ReactNode,
+  type SetStateAction,
 } from "react";
 import useScreenSize from "@opal/hooks/useScreenSize";
 import type { WithoutStyles } from "@opal/types";
@@ -169,7 +171,7 @@ function RootLayoutLeftPanel(props: RootLayoutPanelProps) {
 // layout, e.g. AppChrome) instead of rendering in place. This lets it sit as
 // a flex sibling to the Header/Content/Footer column and push the whole column
 // in, regardless of where in the tree RightPanel is actually rendered.
-export type RightPanelSlotSetter = (panel: ReactNode) => void;
+export type RightPanelSlotSetter = Dispatch<SetStateAction<ReactNode>>;
 export const RootLayoutRightPanelSlotContext =
   createContext<RightPanelSlotSetter | null>(null);
 
@@ -178,8 +180,9 @@ function RootLayoutRightPanel({ children }: RootLayoutPanelProps) {
 
   useLayoutEffect(() => {
     if (!setSlot) return;
-    setSlot(<RootLayoutPanel>{children}</RootLayoutPanel>);
-    return () => setSlot(null);
+    const content = <RootLayoutPanel>{children}</RootLayoutPanel>;
+    setSlot(content);
+    return () => setSlot((prev) => (prev === content ? null : prev));
   }, [setSlot, children]);
 
   if (setSlot) return null;

--- a/web/lib/opal/src/layouts/root/components.tsx
+++ b/web/lib/opal/src/layouts/root/components.tsx
@@ -152,12 +152,16 @@ interface RootLayoutPanelProps {
   children: ReactNode;
 }
 
-function RootLayoutLeftPanel({ children }: RootLayoutPanelProps) {
+function RootLayoutPanel({ children }: RootLayoutPanelProps) {
   return <div className="opal-root-layout__panel">{children}</div>;
 }
 
-function RootLayoutRightPanel({ children }: RootLayoutPanelProps) {
-  return <div className="opal-root-layout__panel">{children}</div>;
+function RootLayoutLeftPanel(props: RootLayoutPanelProps) {
+  return <RootLayoutPanel {...props} />;
+}
+
+function RootLayoutRightPanel(props: RootLayoutPanelProps) {
+  return <RootLayoutPanel {...props} />;
 }
 
 // ---------------------------------------------------------------------------

--- a/web/lib/opal/src/layouts/root/components.tsx
+++ b/web/lib/opal/src/layouts/root/components.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import "@opal/layouts/root/styles.css";
-import { createContext, useContext, type ReactNode } from "react";
+import {
+  createContext,
+  useContext,
+  useLayoutEffect,
+  type ReactNode,
+} from "react";
 import useScreenSize from "@opal/hooks/useScreenSize";
 import type { WithoutStyles } from "@opal/types";
 
@@ -160,8 +165,25 @@ function RootLayoutLeftPanel(props: RootLayoutPanelProps) {
   return <RootLayoutPanel {...props} />;
 }
 
-function RootLayoutRightPanel(props: RootLayoutPanelProps) {
-  return <RootLayoutPanel {...props} />;
+// When provided, RightPanel hoists itself into this slot (set by the host
+// layout, e.g. AppChrome) instead of rendering in place. This lets it sit as
+// a flex sibling to the Header/Content/Footer column and push the whole column
+// in, regardless of where in the tree RightPanel is actually rendered.
+export type RightPanelSlotSetter = (panel: ReactNode) => void;
+export const RootLayoutRightPanelSlotContext =
+  createContext<RightPanelSlotSetter | null>(null);
+
+function RootLayoutRightPanel({ children }: RootLayoutPanelProps) {
+  const setSlot = useContext(RootLayoutRightPanelSlotContext);
+
+  useLayoutEffect(() => {
+    if (!setSlot) return;
+    setSlot(<RootLayoutPanel>{children}</RootLayoutPanel>);
+    return () => setSlot(null);
+  }, [setSlot, children]);
+
+  if (setSlot) return null;
+  return <RootLayoutPanel>{children}</RootLayoutPanel>;
 }
 
 // ---------------------------------------------------------------------------

--- a/web/lib/opal/src/layouts/root/components.tsx
+++ b/web/lib/opal/src/layouts/root/components.tsx
@@ -2,8 +2,8 @@
 
 import "@opal/layouts/root/styles.css";
 import { createContext, useContext, type ReactNode } from "react";
-import { cn } from "@opal/utils";
 import useScreenSize from "@opal/hooks/useScreenSize";
+import type { WithoutStyles } from "@opal/types";
 
 // ---------------------------------------------------------------------------
 // Folded context — readable by sidebar body content via useSidebarFolded()
@@ -115,11 +115,11 @@ function RootLayoutSidebar({
 // App — fills remaining flex space; use as direct child of Root
 // ---------------------------------------------------------------------------
 
-type RootLayoutAppProps = React.HTMLAttributes<HTMLDivElement>;
+type RootLayoutAppProps = WithoutStyles<React.HTMLAttributes<HTMLDivElement>>;
 
-function RootLayoutApp({ children, className, ...props }: RootLayoutAppProps) {
+function RootLayoutApp({ children, ...props }: RootLayoutAppProps) {
   return (
-    <div className={cn("opal-root-layout__app", className)} {...props}>
+    <div className="opal-root-layout__app" {...props}>
       {children}
     </div>
   );
@@ -129,15 +129,16 @@ function RootLayoutApp({ children, className, ...props }: RootLayoutAppProps) {
 // MainContent — scrollable content slot inside App
 // ---------------------------------------------------------------------------
 
-type RootLayoutMainContentProps = React.HTMLAttributes<HTMLDivElement>;
+type RootLayoutMainContentProps = WithoutStyles<
+  React.HTMLAttributes<HTMLDivElement>
+>;
 
 function RootLayoutMainContent({
   children,
-  className,
   ...props
 }: RootLayoutMainContentProps) {
   return (
-    <div className={cn("opal-root-layout__main", className)} {...props}>
+    <div className="opal-root-layout__main" {...props}>
       {children}
     </div>
   );
@@ -149,19 +150,14 @@ function RootLayoutMainContent({
 
 interface RootLayoutPanelProps {
   children: ReactNode;
-  className?: string;
 }
 
-function RootLayoutLeftPanel({ children, className }: RootLayoutPanelProps) {
-  return (
-    <div className={cn("opal-root-layout__panel", className)}>{children}</div>
-  );
+function RootLayoutLeftPanel({ children }: RootLayoutPanelProps) {
+  return <div className="opal-root-layout__panel">{children}</div>;
 }
 
-function RootLayoutRightPanel({ children, className }: RootLayoutPanelProps) {
-  return (
-    <div className={cn("opal-root-layout__panel", className)}>{children}</div>
-  );
+function RootLayoutRightPanel({ children }: RootLayoutPanelProps) {
+  return <div className="opal-root-layout__panel">{children}</div>;
 }
 
 // ---------------------------------------------------------------------------

--- a/web/lib/opal/src/layouts/root/styles.css
+++ b/web/lib/opal/src/layouts/root/styles.css
@@ -51,7 +51,7 @@
   @apply flex-1 overflow-auto;
 }
 
-/* Panel — permanent column (width is caller-supplied via className) */
+/* Panel — permanent column (width determined by child content) */
 .opal-root-layout__panel {
   @apply shrink-0 overflow-auto h-full;
 }

--- a/web/src/app/admin/connectors/[connector]/pages/FieldRendering.tsx
+++ b/web/src/app/admin/connectors/[connector]/pages/FieldRendering.tsx
@@ -218,7 +218,6 @@ export const RenderField: FC<RenderFieldProps> = ({
             label={label}
             sublabel={description}
             disabled={disabled}
-            size="lg"
             onChange={(checked) => setFieldValue(field.name, checked)}
           />
         </GeneralLayouts.Section>

--- a/web/src/components/Field.tsx
+++ b/web/src/components/Field.tsx
@@ -741,23 +741,26 @@ export const BooleanFormField = memo(function BooleanFormField({
               side={disabledTooltipSide}
             >
               <Section flexDirection="row" width="fit" height="fit" gap={0}>
-                <Checkbox
-                  aria-label={`${label
-                    .toLowerCase()
-                    .replace(" ", "-")}-checkbox`}
-                  id={checkboxId}
+                <div
                   className={cn(
                     disabled && "opacity-50",
                     removeIndent ? "mr-2" : "mx-3"
                   )}
-                  checked={Boolean(field.value)}
-                  onCheckedChange={(checked) => {
-                    if (!disabled) {
-                      form.setFieldValue(name, checked === true);
-                      if (onChange) onChange(checked === true);
-                    }
-                  }}
-                />
+                >
+                  <Checkbox
+                    aria-label={`${label
+                      .toLowerCase()
+                      .replace(" ", "-")}-checkbox`}
+                    id={checkboxId}
+                    checked={Boolean(field.value)}
+                    onCheckedChange={(checked) => {
+                      if (!disabled) {
+                        form.setFieldValue(name, checked === true);
+                        if (onChange) onChange(checked === true);
+                      }
+                    }}
+                  />
+                </div>
                 {!noLabel && (
                   <div
                     className={disabled ? "" : "cursor-pointer"}

--- a/web/src/hooks/formHooks.ts
+++ b/web/src/hooks/formHooks.ts
@@ -3,25 +3,6 @@
 import { useCallback } from "react";
 import { useField } from "formik";
 
-/**
- * Custom hook for handling form input changes in Formik forms.
- *
- * @example
- * ```tsx
- * function MyField({ name }: { name: string }) {
- *   const [field] = useField(name);
- *   const onChange = useOnChangeEvent(name);
- *
- *   return (
- *     <input
- *       name={name}
- *       value={field.value}
- *       onChange={onChange}
- *     />
- *   );
- * }
- * ```
- */
 export function useOnChangeEvent<T = any>(
   name: string,
   f?: (event: T) => void
@@ -36,22 +17,6 @@ export function useOnChangeEvent<T = any>(
   );
 }
 
-/**
- * Custom hook for handling form value changes in Formik forms.
- * Use this for components that pass values directly (not events).
- *
- * @example
- * ```tsx
- * function MySelect({ name, onValueChange }: Props) {
- *   const [field] = useField(name);
- *   const onChange = useOnChangeValue(name, onValueChange);
- *
- *   return (
- *     <Select value={field.value} onValueChange={onChange} />
- *   );
- * }
- * ```
- */
 export function useOnChangeValue<T = any>(
   name: string,
   f?: (value: T) => void
@@ -59,41 +24,21 @@ export function useOnChangeValue<T = any>(
   const [, , helpers] = useField<T>(name);
   return useCallback(
     (value: T) => {
-      helpers.setTouched(true);
       helpers.setValue(value);
+      helpers.setTouched(true);
       f?.(value);
     },
     [helpers, f]
   );
 }
 
-/**
- * Custom hook for handling form input blur events in Formik forms.
- *
- * @example
- * ```tsx
- * function MyField({ name, onBlur }: Props) {
- *   const [field] = useField(name);
- *   const handleBlur = useOnBlurEvent(name, onBlur);
- *
- *   return (
- *     <input
- *       name={name}
- *       value={field.value}
- *       onBlur={handleBlur}
- *     />
- *   );
- * }
- * ```
- */
 export function useOnBlurEvent<T = any>(name: string, f?: (event: T) => void) {
-  const [field, , helpers] = useField<T>(name);
+  const [field] = useField<T>(name);
   return useCallback(
     (event: T) => {
       f?.(event);
       field.onBlur(event);
-      helpers.setTouched(true);
     },
-    [field, helpers, f]
+    [field, f]
   );
 }

--- a/web/src/hooks/formHooks.ts
+++ b/web/src/hooks/formHooks.ts
@@ -59,6 +59,7 @@ export function useOnChangeValue<T = any>(
   const [, , helpers] = useField<T>(name);
   return useCallback(
     (value: T) => {
+      helpers.setTouched(true);
       helpers.setValue(value);
       f?.(value);
     },

--- a/web/src/hooks/formHooks.ts
+++ b/web/src/hooks/formHooks.ts
@@ -1,18 +1,16 @@
 "use client";
 
+import { useCallback } from "react";
 import { useField } from "formik";
 
 /**
  * Custom hook for handling form input changes in Formik forms.
  *
- * This hook automatically sets the field as "touched" when its value changes,
- * enabling immediate validation feedback after the first user interaction.
- *
  * @example
  * ```tsx
  * function MyField({ name }: { name: string }) {
  *   const [field] = useField(name);
- *   const onChange = useFormInputCallback(name);
+ *   const onChange = useOnChangeEvent(name);
  *
  *   return (
  *     <input
@@ -23,37 +21,23 @@ import { useField } from "formik";
  *   );
  * }
  * ```
- *
- * @example
- * ```tsx
- * // With callback
- * function MySelect({ name, onValueChange }: Props) {
- *   const [field] = useField(name);
- *   const onChange = useFormInputCallback(name, onValueChange);
- *
- *   return (
- *     <Select value={field.value} onValueChange={onChange} />
- *   );
- * }
- * ```
  */
 export function useOnChangeEvent<T = any>(
   name: string,
   f?: (event: T) => void
 ) {
-  const [field, , helpers] = useField<T>(name);
-  return (event: T) => {
-    helpers.setTouched(true);
-    f?.(event);
-    field.onChange(event);
-  };
+  const [field] = useField<T>(name);
+  return useCallback(
+    (event: T) => {
+      field.onChange(event);
+      f?.(event);
+    },
+    [field, f]
+  );
 }
 
 /**
  * Custom hook for handling form value changes in Formik forms.
- *
- * This hook automatically sets the field as "touched" when its value changes,
- * enabling immediate validation feedback after the first user interaction.
  * Use this for components that pass values directly (not events).
  *
  * @example
@@ -67,36 +51,23 @@ export function useOnChangeEvent<T = any>(
  *   );
  * }
  * ```
- *
- * @example
- * ```tsx
- * function MyDatePicker({ name }: Props) {
- *   const [field] = useField(name);
- *   const onChange = useOnChangeValue(name);
- *
- *   return (
- *     <DatePicker selectedDate={field.value} setSelectedDate={onChange} />
- *   );
- * }
- * ```
  */
 export function useOnChangeValue<T = any>(
   name: string,
   f?: (value: T) => void
 ) {
   const [, , helpers] = useField<T>(name);
-  return (value: T) => {
-    helpers.setTouched(true);
-    f?.(value);
-    helpers.setValue(value);
-  };
+  return useCallback(
+    (value: T) => {
+      helpers.setValue(value);
+      f?.(value);
+    },
+    [helpers, f]
+  );
 }
 
 /**
  * Custom hook for handling form input blur events in Formik forms.
- *
- * This hook chains the consumer's onBlur callback with Formik's blur handler,
- * ensuring both effects run when the field loses focus.
  *
  * @example
  * ```tsx
@@ -115,9 +86,13 @@ export function useOnChangeValue<T = any>(
  * ```
  */
 export function useOnBlurEvent<T = any>(name: string, f?: (event: T) => void) {
-  const [field] = useField<T>(name);
-  return (event: T) => {
-    f?.(event);
-    field.onBlur(event);
-  };
+  const [field, , helpers] = useField<T>(name);
+  return useCallback(
+    (event: T) => {
+      f?.(event);
+      field.onBlur(event);
+      helpers.setTouched(true);
+    },
+    [field, helpers, f]
+  );
 }

--- a/web/src/refresh-components/form/LabeledCheckboxField.tsx
+++ b/web/src/refresh-components/form/LabeledCheckboxField.tsx
@@ -11,7 +11,6 @@ interface CheckboxFieldProps {
   label: string;
   labelClassName?: string;
   sublabel?: string;
-  size?: "sm" | "md" | "lg";
   tooltip?: string;
   onChange?: (checked: boolean) => void;
   disabled?: boolean;
@@ -22,19 +21,12 @@ export const CheckboxField: React.FC<CheckboxFieldProps> = ({
   label,
   onChange,
   sublabel,
-  size = "md",
   tooltip,
   labelClassName,
   disabled,
   ...props
 }) => {
   const [field, , helpers] = useField<boolean>({ name, type: "checkbox" });
-
-  const sizeClasses = {
-    sm: "h-2 w-2",
-    md: "h-3 w-3",
-    lg: "h-4 w-4",
-  };
 
   const handleClick = (e: React.MouseEvent<HTMLLabelElement>) => {
     e.preventDefault();
@@ -55,7 +47,6 @@ export const CheckboxField: React.FC<CheckboxFieldProps> = ({
           helpers.setValue(Boolean(checked));
           onChange?.(Boolean(checked));
         }}
-        className={cn(sizeClasses[size])}
         disabled={disabled}
         {...props}
       />

--- a/web/src/refresh-pages/AppPage.tsx
+++ b/web/src/refresh-pages/AppPage.tsx
@@ -680,7 +680,10 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
   const setAppRightPanel = useSetAppRightPanel();
   useLayoutEffect(() => {
     setAppRightPanel(
-      retrievalEnabled && !settings.isMobile ? (
+      isReady &&
+        !(noAgents && !isLoadingAgents) &&
+        retrievalEnabled &&
+        !settings.isMobile ? (
         <RootLayout.RightPanel>
           <div
             className={cn(
@@ -700,6 +703,9 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
     );
     return () => setAppRightPanel(null);
   }, [
+    isReady,
+    noAgents,
+    isLoadingAgents,
     retrievalEnabled,
     settings.isMobile,
     documentSidebarVisible,

--- a/web/src/refresh-pages/AppPage.tsx
+++ b/web/src/refresh-pages/AppPage.tsx
@@ -671,13 +671,13 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
 
   const desktopDocumentSidebar =
     retrievalEnabled && !settings.isMobile ? (
-      <RootLayout.RightPanel
-        className={cn(
-          "overflow-hidden transition-all duration-300 ease-in-out",
-          documentSidebarVisible ? "w-100" : "w-0"
-        )}
-      >
-        <div className="h-full w-100">
+      <RootLayout.RightPanel>
+        <div
+          className={cn(
+            "overflow-hidden transition-all duration-300 ease-in-out h-full",
+            documentSidebarVisible ? "w-100" : "w-0"
+          )}
+        >
           <DocumentsSidebar
             setPresentingDocument={setPresentingDocument}
             modal={false}

--- a/web/src/refresh-pages/AppPage.tsx
+++ b/web/src/refresh-pages/AppPage.tsx
@@ -2,14 +2,7 @@
 
 import { redirect, useRouter, useSearchParams } from "next/navigation";
 import { personaIncludesRetrieval } from "@/app/app/services/lib";
-import {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast, useToastFromQuery } from "@/hooks/useToast";
 import { SEARCH_PARAM_NAMES } from "@/app/app/services/searchParams";
 import { Section } from "@/layouts/general-layouts";
@@ -67,7 +60,6 @@ import { useProjectsContext } from "@/providers/ProjectsContext";
 import { getProjectTokenCount } from "@/app/app/projects/projectsService";
 import ProjectChatSessionList from "@/app/app/components/projects/ProjectChatSessionList";
 import { cn } from "@opal/utils";
-import { useSetAppRightPanel } from "@/sections/app-chrome/AppChrome";
 import Suggestions from "@/sections/Suggestions";
 import OnboardingFlow from "@/sections/onboarding/OnboardingFlow";
 import { OnboardingStep } from "@/interfaces/onboarding";
@@ -677,44 +669,6 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
     setTimeout(() => updateCurrentDocumentSidebarVisible(false), 300);
   }, [updateCurrentDocumentSidebarVisible]);
 
-  const setAppRightPanel = useSetAppRightPanel();
-  useLayoutEffect(() => {
-    setAppRightPanel(
-      isReady &&
-        !(noAgents && !isLoadingAgents) &&
-        retrievalEnabled &&
-        !settings.isMobile ? (
-        <RootLayout.RightPanel>
-          <div
-            className={cn(
-              "overflow-hidden transition-all duration-300 ease-in-out h-full",
-              documentSidebarVisible ? "w-100" : "w-0"
-            )}
-          >
-            <DocumentsSidebar
-              setPresentingDocument={setPresentingDocument}
-              modal={false}
-              closeSidebar={handleDesktopDocumentSidebarClose}
-              selectedDocuments={selectedDocuments}
-            />
-          </div>
-        </RootLayout.RightPanel>
-      ) : null
-    );
-    return () => setAppRightPanel(null);
-  }, [
-    isReady,
-    noAgents,
-    isLoadingAgents,
-    retrievalEnabled,
-    settings.isMobile,
-    documentSidebarVisible,
-    setPresentingDocument,
-    handleDesktopDocumentSidebarClose,
-    selectedDocuments,
-    setAppRightPanel,
-  ]);
-
   // When no chat session exists but a project is selected, fetch the
   // total tokens for the project's files so upload UX can compare
   // against available context similar to session-based flows.
@@ -806,6 +760,26 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
       )}
 
       <FederatedOAuthModal />
+
+      {!(noAgents && !isLoadingAgents) &&
+        retrievalEnabled &&
+        !settings.isMobile && (
+          <RootLayout.RightPanel>
+            <div
+              className={cn(
+                "overflow-hidden transition-all duration-300 ease-in-out h-full",
+                documentSidebarVisible ? "w-100" : "w-0"
+              )}
+            >
+              <DocumentsSidebar
+                setPresentingDocument={setPresentingDocument}
+                modal={false}
+                closeSidebar={handleDesktopDocumentSidebarClose}
+                selectedDocuments={selectedDocuments}
+              />
+            </div>
+          </RootLayout.RightPanel>
+        )}
 
       <div className="w-full h-full overflow-hidden">
         <Dropzone

--- a/web/src/refresh-pages/AppPage.tsx
+++ b/web/src/refresh-pages/AppPage.tsx
@@ -2,7 +2,14 @@
 
 import { redirect, useRouter, useSearchParams } from "next/navigation";
 import { personaIncludesRetrieval } from "@/app/app/services/lib";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { toast, useToastFromQuery } from "@/hooks/useToast";
 import { SEARCH_PARAM_NAMES } from "@/app/app/services/searchParams";
 import { Section } from "@/layouts/general-layouts";
@@ -60,6 +67,7 @@ import { useProjectsContext } from "@/providers/ProjectsContext";
 import { getProjectTokenCount } from "@/app/app/projects/projectsService";
 import ProjectChatSessionList from "@/app/app/components/projects/ProjectChatSessionList";
 import { cn } from "@opal/utils";
+import { useSetAppRightPanel } from "@/sections/app-chrome/AppChrome";
 import Suggestions from "@/sections/Suggestions";
 import OnboardingFlow from "@/sections/onboarding/OnboardingFlow";
 import { OnboardingStep } from "@/interfaces/onboarding";
@@ -669,24 +677,37 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
     setTimeout(() => updateCurrentDocumentSidebarVisible(false), 300);
   }, [updateCurrentDocumentSidebarVisible]);
 
-  const desktopDocumentSidebar =
-    retrievalEnabled && !settings.isMobile ? (
-      <RootLayout.RightPanel>
-        <div
-          className={cn(
-            "overflow-hidden transition-all duration-300 ease-in-out h-full",
-            documentSidebarVisible ? "w-100" : "w-0"
-          )}
-        >
-          <DocumentsSidebar
-            setPresentingDocument={setPresentingDocument}
-            modal={false}
-            closeSidebar={handleDesktopDocumentSidebarClose}
-            selectedDocuments={selectedDocuments}
-          />
-        </div>
-      </RootLayout.RightPanel>
-    ) : null;
+  const setAppRightPanel = useSetAppRightPanel();
+  useLayoutEffect(() => {
+    setAppRightPanel(
+      retrievalEnabled && !settings.isMobile ? (
+        <RootLayout.RightPanel>
+          <div
+            className={cn(
+              "overflow-hidden transition-all duration-300 ease-in-out h-full",
+              documentSidebarVisible ? "w-100" : "w-0"
+            )}
+          >
+            <DocumentsSidebar
+              setPresentingDocument={setPresentingDocument}
+              modal={false}
+              closeSidebar={handleDesktopDocumentSidebarClose}
+              selectedDocuments={selectedDocuments}
+            />
+          </div>
+        </RootLayout.RightPanel>
+      ) : null
+    );
+    return () => setAppRightPanel(null);
+  }, [
+    retrievalEnabled,
+    settings.isMobile,
+    documentSidebarVisible,
+    setPresentingDocument,
+    handleDesktopDocumentSidebarClose,
+    selectedDocuments,
+    setAppRightPanel,
+  ]);
 
   // When no chat session exists but a project is selected, fetch the
   // total tokens for the project's files so upload UX can compare
@@ -780,186 +801,184 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
 
       <FederatedOAuthModal />
 
-      <div className="flex flex-row w-full h-full overflow-hidden">
-        <div className="flex-1 h-full overflow-hidden">
-          <Dropzone
-            onDrop={(acceptedFiles) =>
-              handleMessageSpecificFileUpload(acceptedFiles)
-            }
-            noClick
-          >
-            {({ getRootProps }) => (
+      <div className="w-full h-full overflow-hidden">
+        <Dropzone
+          onDrop={(acceptedFiles) =>
+            handleMessageSpecificFileUpload(acceptedFiles)
+          }
+          noClick
+        >
+          {({ getRootProps }) => (
+            <div
+              className="h-full w-full flex flex-col items-center outline-hidden relative"
+              {...getRootProps({ tabIndex: -1 })}
+            >
+              {/* Main content grid — 3 rows, animated */}
               <div
-                className="h-full w-full flex flex-col items-center outline-hidden relative"
-                {...getRootProps({ tabIndex: -1 })}
+                className="flex-1 w-full grid min-h-0 transition-[grid-template-rows] duration-150 ease-in-out"
+                style={gridStyle}
               >
-                {/* Main content grid — 3 rows, animated */}
-                <div
-                  className="flex-1 w-full grid min-h-0 transition-[grid-template-rows] duration-150 ease-in-out"
-                  style={gridStyle}
-                >
-                  {/* ── Top row: ChatUI / WelcomeMessage / ProjectUI ── */}
-                  <div className="row-start-1 min-h-0 overflow-hidden flex flex-col items-center px-4">
-                    {/* ChatUI */}
-                    <Fade
-                      show={
-                        appFocus.isChat() &&
-                        !!currentChatSessionId &&
-                        !!liveAgent &&
-                        !sessionFetchError
-                      }
-                      className="h-full w-full flex flex-col items-center"
+                {/* ── Top row: ChatUI / WelcomeMessage / ProjectUI ── */}
+                <div className="row-start-1 min-h-0 overflow-hidden flex flex-col items-center px-4">
+                  {/* ChatUI */}
+                  <Fade
+                    show={
+                      appFocus.isChat() &&
+                      !!currentChatSessionId &&
+                      !!liveAgent &&
+                      !sessionFetchError
+                    }
+                    className="h-full w-full flex flex-col items-center"
+                  >
+                    <ChatScrollContainer
+                      ref={scrollContainerRef}
+                      sessionId={currentChatSessionId!}
+                      anchorSelector={anchorSelector}
+                      autoScroll={autoScrollEnabled}
+                      isStreaming={isStreaming}
+                      onScrollButtonVisibilityChange={setShowScrollButton}
                     >
-                      <ChatScrollContainer
-                        ref={scrollContainerRef}
-                        sessionId={currentChatSessionId!}
-                        anchorSelector={anchorSelector}
-                        autoScroll={autoScrollEnabled}
-                        isStreaming={isStreaming}
-                        onScrollButtonVisibilityChange={setShowScrollButton}
+                      <ChatUI
+                        liveAgent={liveAgent!}
+                        llmManager={llmManager}
+                        deepResearchEnabled={
+                          deepResearchEnabledForCurrentWorkflow
+                        }
+                        currentMessageFiles={currentMessageFiles}
+                        setPresentingDocument={setPresentingDocument}
+                        onSubmit={onSubmit}
+                        onMessageSelection={onMessageSelection}
+                        stopGenerating={stopGenerating}
+                        onResubmit={handleResubmitLastMessage}
+                        anchorNodeId={anchorNodeId}
+                        selectedModels={multiModel.selectedModels}
+                      />
+                    </ChatScrollContainer>
+                  </Fade>
+
+                  {/* Session fetch error (404 / 403) */}
+                  <Fade
+                    show={appFocus.isChat() && sessionFetchError !== null}
+                    className="h-full w-full flex flex-col items-center justify-center"
+                  >
+                    {sessionFetchError && (
+                      <Section
+                        flexDirection="column"
+                        alignItems="center"
+                        gap={1}
                       >
-                        <ChatUI
-                          liveAgent={liveAgent!}
-                          llmManager={llmManager}
-                          deepResearchEnabled={
-                            deepResearchEnabledForCurrentWorkflow
+                        <IllustrationContent
+                          illustration={
+                            sessionFetchError.type === "access_denied"
+                              ? SvgNoAccess
+                              : SvgNotFound
                           }
-                          currentMessageFiles={currentMessageFiles}
-                          setPresentingDocument={setPresentingDocument}
-                          onSubmit={onSubmit}
-                          onMessageSelection={onMessageSelection}
-                          stopGenerating={stopGenerating}
-                          onResubmit={handleResubmitLastMessage}
-                          anchorNodeId={anchorNodeId}
-                          selectedModels={multiModel.selectedModels}
+                          title={
+                            sessionFetchError.type === "not_found"
+                              ? "Chat not found"
+                              : sessionFetchError.type === "access_denied"
+                                ? "Access denied"
+                                : "Something went wrong"
+                          }
+                          description={
+                            sessionFetchError.type === "not_found"
+                              ? "This chat session doesn't exist or has been deleted."
+                              : sessionFetchError.type === "access_denied"
+                                ? "You don't have permission to view this chat session."
+                                : sessionFetchError.detail
+                          }
                         />
-                      </ChatScrollContainer>
-                    </Fade>
+                        <Button href="/app" prominence="secondary">
+                          Start a new chat
+                        </Button>
+                      </Section>
+                    )}
+                  </Fade>
 
-                    {/* Session fetch error (404 / 403) */}
-                    <Fade
-                      show={appFocus.isChat() && sessionFetchError !== null}
-                      className="h-full w-full flex flex-col items-center justify-center"
+                  {/* ProjectUI */}
+                  {appFocus.isProject() && (
+                    <div className="w-full max-h-[50vh] overflow-y-auto overscroll-y-none">
+                      <ProjectContextPanel
+                        projectTokenCount={projectContextTokenCount}
+                        availableContextTokens={availableContextTokens}
+                        setPresentingDocument={setPresentingDocument}
+                      />
+                    </div>
+                  )}
+
+                  {/* WelcomeMessageUI */}
+                  <Fade
+                    show={
+                      (appFocus.isNewSession() || appFocus.isAgent()) &&
+                      (state.phase === "idle" || state.phase === "classifying")
+                    }
+                    className="w-full flex-1 flex flex-col items-center justify-end"
+                  >
+                    <Section
+                      flexDirection="row"
+                      justifyContent="between"
+                      alignItems="end"
+                      className="max-w-(--app-page-main-content-width)"
                     >
-                      {sessionFetchError && (
-                        <Section
-                          flexDirection="column"
-                          alignItems="center"
-                          gap={1}
-                        >
-                          <IllustrationContent
-                            illustration={
-                              sessionFetchError.type === "access_denied"
-                                ? SvgNoAccess
-                                : SvgNotFound
-                            }
-                            title={
-                              sessionFetchError.type === "not_found"
-                                ? "Chat not found"
-                                : sessionFetchError.type === "access_denied"
-                                  ? "Access denied"
-                                  : "Something went wrong"
-                            }
-                            description={
-                              sessionFetchError.type === "not_found"
-                                ? "This chat session doesn't exist or has been deleted."
-                                : sessionFetchError.type === "access_denied"
-                                  ? "You don't have permission to view this chat session."
-                                  : sessionFetchError.detail
-                            }
+                      <WelcomeMessage
+                        agent={liveAgent}
+                        isDefaultAgent={isDefaultAgent}
+                      />
+                      {!isSearch &&
+                        !(
+                          state.phase === "idle" && state.appMode === "search"
+                        ) &&
+                        liveAgent &&
+                        !llmManager.isLoadingProviders && (
+                          <ModelSelector
+                            llmManager={llmManager}
+                            selectedModels={multiModel.selectedModels}
+                            onAdd={multiModel.addModel}
+                            onRemove={multiModel.removeModel}
+                            onReplace={multiModel.replaceModel}
                           />
-                          <Button href="/app" prominence="secondary">
-                            Start a new chat
-                          </Button>
-                        </Section>
-                      )}
-                    </Fade>
+                        )}
+                    </Section>
+                    <Spacer rem={1.5} />
+                  </Fade>
+                </div>
 
-                    {/* ProjectUI */}
-                    {appFocus.isProject() && (
-                      <div className="w-full max-h-[50vh] overflow-y-auto overscroll-y-none">
-                        <ProjectContextPanel
-                          projectTokenCount={projectContextTokenCount}
-                          availableContextTokens={availableContextTokens}
-                          setPresentingDocument={setPresentingDocument}
+                {/* ── Middle-center: AppInputBar ── */}
+                <div
+                  className={cn(
+                    "row-start-2 flex flex-col items-center px-4",
+                    sessionFetchError && "hidden"
+                  )}
+                >
+                  <div className="relative w-full max-w-(--app-page-main-content-width) flex flex-col">
+                    {/* Scroll to bottom button - positioned absolutely above AppInputBar */}
+                    {appFocus.isChat() && showScrollButton && (
+                      <div className="absolute -top-14 self-center">
+                        <Button
+                          icon={SvgChevronDown}
+                          onClick={handleScrollToBottom}
+                          aria-label="Scroll to bottom"
+                          prominence="secondary"
                         />
                       </div>
                     )}
 
-                    {/* WelcomeMessageUI */}
-                    <Fade
-                      show={
-                        (appFocus.isNewSession() || appFocus.isAgent()) &&
-                        (state.phase === "idle" ||
-                          state.phase === "classifying")
-                      }
-                      className="w-full flex-1 flex flex-col items-center justify-end"
-                    >
-                      <Section
-                        flexDirection="row"
-                        justifyContent="between"
-                        alignItems="end"
-                        className="max-w-(--app-page-main-content-width)"
-                      >
-                        <WelcomeMessage
-                          agent={liveAgent}
-                          isDefaultAgent={isDefaultAgent}
+                    {/* OnboardingUI */}
+                    {(appFocus.isNewSession() || appFocus.isAgent()) &&
+                      (state.phase === "idle" ||
+                        state.phase === "classifying") &&
+                      (showOnboarding || !user?.personalization?.name) &&
+                      !onboardingDismissed && (
+                        <OnboardingFlow
+                          showOnboarding={showOnboarding}
+                          handleHideOnboarding={hideOnboarding}
+                          handleFinishOnboarding={finishOnboarding}
+                          state={onboardingState}
+                          actions={onboardingActions}
                         />
-                        {!isSearch &&
-                          !(
-                            state.phase === "idle" && state.appMode === "search"
-                          ) &&
-                          liveAgent &&
-                          !llmManager.isLoadingProviders && (
-                            <ModelSelector
-                              llmManager={llmManager}
-                              selectedModels={multiModel.selectedModels}
-                              onAdd={multiModel.addModel}
-                              onRemove={multiModel.removeModel}
-                              onReplace={multiModel.replaceModel}
-                            />
-                          )}
-                      </Section>
-                      <Spacer rem={1.5} />
-                    </Fade>
-                  </div>
-
-                  {/* ── Middle-center: AppInputBar ── */}
-                  <div
-                    className={cn(
-                      "row-start-2 flex flex-col items-center px-4",
-                      sessionFetchError && "hidden"
-                    )}
-                  >
-                    <div className="relative w-full max-w-(--app-page-main-content-width) flex flex-col">
-                      {/* Scroll to bottom button - positioned absolutely above AppInputBar */}
-                      {appFocus.isChat() && showScrollButton && (
-                        <div className="absolute -top-14 self-center">
-                          <Button
-                            icon={SvgChevronDown}
-                            onClick={handleScrollToBottom}
-                            aria-label="Scroll to bottom"
-                            prominence="secondary"
-                          />
-                        </div>
                       )}
 
-                      {/* OnboardingUI */}
-                      {(appFocus.isNewSession() || appFocus.isAgent()) &&
-                        (state.phase === "idle" ||
-                          state.phase === "classifying") &&
-                        (showOnboarding || !user?.personalization?.name) &&
-                        !onboardingDismissed && (
-                          <OnboardingFlow
-                            showOnboarding={showOnboarding}
-                            handleHideOnboarding={hideOnboarding}
-                            handleFinishOnboarding={finishOnboarding}
-                            state={onboardingState}
-                            actions={onboardingActions}
-                          />
-                        )}
-
-                      {/*
+                    {/*
                       # Note (@raunakab)
 
                       `shadow-01` on AppInputBar extends ~14px below the element
@@ -977,120 +996,116 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                       (Footer) that explains why the Footer removes its top
                       padding during chat to compensate for this extra space.
                     */}
-                      <div>
-                        <div
-                          className={cn(
-                            "transition-all duration-150 ease-in-out overflow-hidden",
-                            isSearch ? "h-[14px]" : "h-0"
-                          )}
-                        />
-                        {appFocus.isChat() &&
-                          liveAgent &&
-                          !llmManager.isLoadingProviders && (
-                            <div className="pb-1">
-                              <ModelSelector
-                                llmManager={llmManager}
-                                selectedModels={multiModel.selectedModels}
-                                onAdd={multiModel.addModel}
-                                onRemove={multiModel.removeModel}
-                                onReplace={multiModel.replaceModel}
-                              />
-                            </div>
-                          )}
-                        <AppInputBar
-                          ref={chatInputBarRef}
-                          deepResearchEnabled={
-                            deepResearchEnabledForCurrentWorkflow
-                          }
-                          toggleDeepResearch={toggleDeepResearch}
-                          isMultiModelActive={multiModel.isMultiModelActive}
-                          filterManager={filterManager}
-                          llmManager={llmManager}
-                          initialMessage={
-                            searchParams?.get(SEARCH_PARAM_NAMES.USER_PROMPT) ||
-                            ""
-                          }
-                          stopGenerating={stopGenerating}
-                          onSubmit={handleAppInputBarSubmit}
-                          chatState={currentChatState}
-                          currentSessionFileTokenCount={
-                            currentChatSessionId
-                              ? currentSessionFileTokenCount
-                              : projectContextTokenCount
-                          }
-                          availableContextTokens={availableContextTokens}
-                          selectedAgent={selectedAgent || liveAgent}
-                          handleFileUpload={handleMessageSpecificFileUpload}
-                          setPresentingDocument={setPresentingDocument}
-                          // Intentionally enabled during name-only onboarding (showOnboarding=false)
-                          // since LLM providers are already configured and the user can chat.
-                          disabled={
-                            (!llmManager.isLoadingProviders &&
-                              llmManager.hasAnyProvider === false) ||
-                            (showOnboarding &&
-                              !isLoadingOnboarding &&
-                              onboardingState.currentStep !==
-                                OnboardingStep.Complete)
-                          }
-                          awaitingPreferredSelection={
-                            awaitingPreferredSelection
-                          }
-                        />
-                        <div
-                          className={cn(
-                            "transition-all duration-150 ease-in-out overflow-hidden",
-                            appFocus.isChat() ? "h-[14px]" : "h-0"
-                          )}
-                        />
-                      </div>
+                    <div>
+                      <div
+                        className={cn(
+                          "transition-all duration-150 ease-in-out overflow-hidden",
+                          isSearch ? "h-[14px]" : "h-0"
+                        )}
+                      />
+                      {appFocus.isChat() &&
+                        liveAgent &&
+                        !llmManager.isLoadingProviders && (
+                          <div className="pb-1">
+                            <ModelSelector
+                              llmManager={llmManager}
+                              selectedModels={multiModel.selectedModels}
+                              onAdd={multiModel.addModel}
+                              onRemove={multiModel.removeModel}
+                              onReplace={multiModel.replaceModel}
+                            />
+                          </div>
+                        )}
+                      <AppInputBar
+                        ref={chatInputBarRef}
+                        deepResearchEnabled={
+                          deepResearchEnabledForCurrentWorkflow
+                        }
+                        toggleDeepResearch={toggleDeepResearch}
+                        isMultiModelActive={multiModel.isMultiModelActive}
+                        filterManager={filterManager}
+                        llmManager={llmManager}
+                        initialMessage={
+                          searchParams?.get(SEARCH_PARAM_NAMES.USER_PROMPT) ||
+                          ""
+                        }
+                        stopGenerating={stopGenerating}
+                        onSubmit={handleAppInputBarSubmit}
+                        chatState={currentChatState}
+                        currentSessionFileTokenCount={
+                          currentChatSessionId
+                            ? currentSessionFileTokenCount
+                            : projectContextTokenCount
+                        }
+                        availableContextTokens={availableContextTokens}
+                        selectedAgent={selectedAgent || liveAgent}
+                        handleFileUpload={handleMessageSpecificFileUpload}
+                        setPresentingDocument={setPresentingDocument}
+                        // Intentionally enabled during name-only onboarding (showOnboarding=false)
+                        // since LLM providers are already configured and the user can chat.
+                        disabled={
+                          (!llmManager.isLoadingProviders &&
+                            llmManager.hasAnyProvider === false) ||
+                          (showOnboarding &&
+                            !isLoadingOnboarding &&
+                            onboardingState.currentStep !==
+                              OnboardingStep.Complete)
+                        }
+                        awaitingPreferredSelection={awaitingPreferredSelection}
+                      />
+                      <div
+                        className={cn(
+                          "transition-all duration-150 ease-in-out overflow-hidden",
+                          appFocus.isChat() ? "h-[14px]" : "h-0"
+                        )}
+                      />
                     </div>
                   </div>
+                </div>
 
-                  {/* ── Bottom: SearchResults + SourceFilter / Suggestions / ProjectChatList ── */}
-                  <div className="row-start-3 min-h-0 overflow-hidden flex flex-col items-center w-full px-4">
-                    {/* Agent description below input */}
-                    {(appFocus.isNewSession() || appFocus.isAgent()) &&
-                      !isDefaultAgent && (
-                        <>
-                          <Spacer rem={1} />
-                          <AgentDescription agent={liveAgent} />
-                          <Spacer rem={1.5} />
-                        </>
-                      )}
-                    {/* ProjectChatSessionList */}
-                    {appFocus.isProject() && (
-                      <div className="w-full max-w-(--app-page-main-content-width) h-full overflow-y-auto overscroll-y-none mx-auto">
-                        <ProjectChatSessionList />
-                      </div>
+                {/* ── Bottom: SearchResults + SourceFilter / Suggestions / ProjectChatList ── */}
+                <div className="row-start-3 min-h-0 overflow-hidden flex flex-col items-center w-full px-4">
+                  {/* Agent description below input */}
+                  {(appFocus.isNewSession() || appFocus.isAgent()) &&
+                    !isDefaultAgent && (
+                      <>
+                        <Spacer rem={1} />
+                        <AgentDescription agent={liveAgent} />
+                        <Spacer rem={1.5} />
+                      </>
                     )}
+                  {/* ProjectChatSessionList */}
+                  {appFocus.isProject() && (
+                    <div className="w-full max-w-(--app-page-main-content-width) h-full overflow-y-auto overscroll-y-none mx-auto">
+                      <ProjectChatSessionList />
+                    </div>
+                  )}
 
-                    {/* SuggestionsUI */}
-                    <Fade
-                      show={
-                        (appFocus.isNewSession() || appFocus.isAgent()) &&
-                        hasAgentStarterMessages
-                      }
-                      className="h-full flex-1 w-full max-w-(--app-page-main-content-width)"
-                    >
-                      <Spacer rem={0.5} />
-                      <Suggestions onSubmit={onSubmit} />
-                    </Fade>
+                  {/* SuggestionsUI */}
+                  <Fade
+                    show={
+                      (appFocus.isNewSession() || appFocus.isAgent()) &&
+                      hasAgentStarterMessages
+                    }
+                    className="h-full flex-1 w-full max-w-(--app-page-main-content-width)"
+                  >
+                    <Spacer rem={0.5} />
+                    <Suggestions onSubmit={onSubmit} />
+                  </Fade>
 
-                    {/* SearchUI */}
-                    <Fade
-                      show={isSearch}
-                      className="h-full flex-1 w-full max-w-(--app-page-main-content-width) px-1 flex flex-col"
-                    >
-                      <Spacer rem={0.75} />
-                      <SearchUI onDocumentClick={handleSearchDocumentClick} />
-                    </Fade>
-                  </div>
+                  {/* SearchUI */}
+                  <Fade
+                    show={isSearch}
+                    className="h-full flex-1 w-full max-w-(--app-page-main-content-width) px-1 flex flex-col"
+                  >
+                    <Spacer rem={0.75} />
+                    <SearchUI onDocumentClick={handleSearchDocumentClick} />
+                  </Fade>
                 </div>
               </div>
-            )}
-          </Dropzone>
-        </div>
-        {desktopDocumentSidebar}
+            </div>
+          )}
+        </Dropzone>
       </div>
     </>
   );

--- a/web/src/sections/app-chrome/AppChrome.tsx
+++ b/web/src/sections/app-chrome/AppChrome.tsx
@@ -58,15 +58,27 @@ import { Tier } from "@/interfaces/settings";
 import { APP_SLOGAN } from "@/lib/constants";
 
 // ---------------------------------------------------------------------------
-// Right-panel slot — pages hoist their panel content here so it sits as a
-// flex sibling to the Header/MainContent/Footer column and pushes them in.
+// Left / right panel slots — pages hoist their panel content here so it sits
+// as a flex sibling to the Header/MainContent/Footer column and pushes it in.
 // ---------------------------------------------------------------------------
 
-type RightPanelSetter = (panel: ReactNode) => void;
-const AppChromeRightPanelContext = createContext<RightPanelSetter>(() => {});
+type PanelSetter = (panel: ReactNode) => void;
 
-export function useSetAppRightPanel(): RightPanelSetter {
-  return useContext(AppChromeRightPanelContext);
+const AppChromeLeftPanelContext = createContext<PanelSetter | null>(null);
+const AppChromeRightPanelContext = createContext<PanelSetter | null>(null);
+
+export function useSetAppLeftPanel(): PanelSetter {
+  const setter = useContext(AppChromeLeftPanelContext);
+  if (!setter)
+    throw new Error("useSetAppLeftPanel must be used within AppChrome");
+  return setter;
+}
+
+export function useSetAppRightPanel(): PanelSetter {
+  const setter = useContext(AppChromeRightPanelContext);
+  if (!setter)
+    throw new Error("useSetAppRightPanel must be used within AppChrome");
+  return setter;
 }
 
 // ---------------------------------------------------------------------------
@@ -512,8 +524,10 @@ interface AppChromeProps {
 }
 
 export default function AppChrome({ children }: AppChromeProps) {
+  const [leftPanel, setLeftPanel] = useState<ReactNode>(null);
   const [rightPanel, setRightPanel] = useState<ReactNode>(null);
-  const setPanel = useCallback((panel: ReactNode) => setRightPanel(panel), []);
+  const setLeft = useCallback((panel: ReactNode) => setLeftPanel(panel), []);
+  const setRight = useCallback((panel: ReactNode) => setRightPanel(panel), []);
 
   const appFocus = useAppFocus();
   const { hasBackground, appBackgroundUrl } = useAppBackground();
@@ -561,73 +575,76 @@ export default function AppChrome({ children }: AppChromeProps) {
   }, []);
 
   return (
-    <AppChromeRightPanelContext.Provider value={setPanel}>
-      <RootLayout.App
-        data-main-container
-        onMouseDown={handleMouseDown}
-        onMouseUp={handleMouseUp}
-      >
-        <div className="flex flex-row flex-1 min-h-0">
-          <div
-            className={cn(
-              "@container relative isolate flex-1 flex flex-col min-h-0",
-              showBackground && "bg-cover bg-center bg-fixed"
-            )}
-            style={
-              showBackground
-                ? { backgroundImage: `url(${appBackgroundUrl})` }
-                : undefined
-            }
-          >
-            {/* Effect 1 — Vignette overlay for custom backgrounds (disabled in light mode).
+    <AppChromeLeftPanelContext.Provider value={setLeft}>
+      <AppChromeRightPanelContext.Provider value={setRight}>
+        <RootLayout.App
+          data-main-container
+          onMouseDown={handleMouseDown}
+          onMouseUp={handleMouseUp}
+        >
+          <div className="flex flex-row flex-1 min-h-0">
+            {leftPanel}
+            <div
+              className={cn(
+                "@container relative isolate flex-1 flex flex-col min-h-0",
+                showBackground && "bg-cover bg-center bg-fixed"
+              )}
+              style={
+                showBackground
+                  ? { backgroundImage: `url(${appBackgroundUrl})` }
+                  : undefined
+              }
+            >
+              {/* Effect 1 — Vignette overlay for custom backgrounds (disabled in light mode).
               z-[-1] keeps overlays below the normal-flow header/content/footer. */}
-            {showBackground && !isLightMode && (
-              <div
-                className="absolute z-[-1] inset-0 pointer-events-none"
-                style={{
-                  background: `
+              {showBackground && !isLightMode && (
+                <div
+                  className="absolute z-[-1] inset-0 pointer-events-none"
+                  style={{
+                    background: `
                   linear-gradient(to bottom, rgba(0, 0, 0, 0.4) 0%, transparent 4rem),
                   linear-gradient(to top, rgba(0, 0, 0, 0.4) 0%, transparent 4rem)
                 `,
-                }}
-              />
-            )}
-            {/* Effect 2 — Semi-transparent overlay for readability when background is set */}
-            {showBackground && appFocus.isChat() && (
-              <>
-                <div className="absolute z-[-1] inset-0 backdrop-blur-[1px] pointer-events-none" />
-                {isSafari ? (
-                  <div
-                    className="absolute z-[-1] inset-0 bg-cover bg-center bg-fixed pointer-events-none"
-                    style={{
-                      backgroundImage: `url(${appBackgroundUrl})`,
-                      filter: "blur(16px)",
-                      maskImage: horizontalBlurMask,
-                      WebkitMaskImage: horizontalBlurMask,
-                    }}
-                  />
-                ) : (
-                  <div
-                    className="absolute z-[-1] inset-0 backdrop-blur-md transition-all duration-600 pointer-events-none"
-                    style={{
-                      maskImage: horizontalBlurMask,
-                      WebkitMaskImage: horizontalBlurMask,
-                    }}
-                  />
-                )}
-              </>
-            )}
-            <RootLayout.Header>
-              <Header />
-            </RootLayout.Header>
-            <RootLayout.MainContent>{children}</RootLayout.MainContent>
-            <RootLayout.Footer>
-              <Footer />
-            </RootLayout.Footer>
+                  }}
+                />
+              )}
+              {/* Effect 2 — Semi-transparent overlay for readability when background is set */}
+              {showBackground && appFocus.isChat() && (
+                <>
+                  <div className="absolute z-[-1] inset-0 backdrop-blur-[1px] pointer-events-none" />
+                  {isSafari ? (
+                    <div
+                      className="absolute z-[-1] inset-0 bg-cover bg-center bg-fixed pointer-events-none"
+                      style={{
+                        backgroundImage: `url(${appBackgroundUrl})`,
+                        filter: "blur(16px)",
+                        maskImage: horizontalBlurMask,
+                        WebkitMaskImage: horizontalBlurMask,
+                      }}
+                    />
+                  ) : (
+                    <div
+                      className="absolute z-[-1] inset-0 backdrop-blur-md transition-all duration-600 pointer-events-none"
+                      style={{
+                        maskImage: horizontalBlurMask,
+                        WebkitMaskImage: horizontalBlurMask,
+                      }}
+                    />
+                  )}
+                </>
+              )}
+              <RootLayout.Header>
+                <Header />
+              </RootLayout.Header>
+              <RootLayout.MainContent>{children}</RootLayout.MainContent>
+              <RootLayout.Footer>
+                <Footer />
+              </RootLayout.Footer>
+            </div>
+            {rightPanel}
           </div>
-          {rightPanel}
-        </div>
-      </RootLayout.App>
-    </AppChromeRightPanelContext.Provider>
+        </RootLayout.App>
+      </AppChromeRightPanelContext.Provider>
+    </AppChromeLeftPanelContext.Provider>
   );
 }

--- a/web/src/sections/app-chrome/AppChrome.tsx
+++ b/web/src/sections/app-chrome/AppChrome.tsx
@@ -544,7 +544,7 @@ export default function AppChrome({ children }: AppChromeProps) {
     >
       <div
         className={cn(
-          "@container relative isolate flex-1 flex flex-col",
+          "@container relative isolate flex-1 flex flex-col min-h-0",
           showBackground && "bg-cover bg-center bg-fixed"
         )}
         style={

--- a/web/src/sections/app-chrome/AppChrome.tsx
+++ b/web/src/sections/app-chrome/AppChrome.tsx
@@ -499,10 +499,6 @@ interface AppChromeProps {
 
 export default function AppChrome({ children }: AppChromeProps) {
   const [rightPanel, setRightPanel] = useState<ReactNode>(null);
-  const setRight = useCallback<(panel: ReactNode) => void>(
-    (panel) => setRightPanel(panel),
-    []
-  );
 
   const appFocus = useAppFocus();
   const { hasBackground, appBackgroundUrl } = useAppBackground();
@@ -550,7 +546,7 @@ export default function AppChrome({ children }: AppChromeProps) {
   }, []);
 
   return (
-    <RootLayoutRightPanelSlotContext.Provider value={setRight}>
+    <RootLayoutRightPanelSlotContext.Provider value={setRightPanel}>
       <RootLayout.App
         data-main-container
         onMouseDown={handleMouseDown}

--- a/web/src/sections/app-chrome/AppChrome.tsx
+++ b/web/src/sections/app-chrome/AppChrome.tsx
@@ -58,21 +58,13 @@ import { Tier } from "@/interfaces/settings";
 import { APP_SLOGAN } from "@/lib/constants";
 
 // ---------------------------------------------------------------------------
-// Left / right panel slots — pages hoist their panel content here so it sits
-// as a flex sibling to the Header/MainContent/Footer column and pushes it in.
+// Right-panel slot — pages hoist their panel content here so it sits as a
+// flex sibling to the Header/MainContent/Footer column and pushes them in.
 // ---------------------------------------------------------------------------
 
 type PanelSetter = (panel: ReactNode) => void;
 
-const AppChromeLeftPanelContext = createContext<PanelSetter | null>(null);
 const AppChromeRightPanelContext = createContext<PanelSetter | null>(null);
-
-export function useSetAppLeftPanel(): PanelSetter {
-  const setter = useContext(AppChromeLeftPanelContext);
-  if (!setter)
-    throw new Error("useSetAppLeftPanel must be used within AppChrome");
-  return setter;
-}
 
 export function useSetAppRightPanel(): PanelSetter {
   const setter = useContext(AppChromeRightPanelContext);
@@ -524,9 +516,7 @@ interface AppChromeProps {
 }
 
 export default function AppChrome({ children }: AppChromeProps) {
-  const [leftPanel, setLeftPanel] = useState<ReactNode>(null);
   const [rightPanel, setRightPanel] = useState<ReactNode>(null);
-  const setLeft = useCallback((panel: ReactNode) => setLeftPanel(panel), []);
   const setRight = useCallback((panel: ReactNode) => setRightPanel(panel), []);
 
   const appFocus = useAppFocus();
@@ -575,76 +565,73 @@ export default function AppChrome({ children }: AppChromeProps) {
   }, []);
 
   return (
-    <AppChromeLeftPanelContext.Provider value={setLeft}>
-      <AppChromeRightPanelContext.Provider value={setRight}>
-        <RootLayout.App
-          data-main-container
-          onMouseDown={handleMouseDown}
-          onMouseUp={handleMouseUp}
-        >
-          <div className="flex flex-row flex-1 min-h-0">
-            {leftPanel}
-            <div
-              className={cn(
-                "@container relative isolate flex-1 flex flex-col min-h-0",
-                showBackground && "bg-cover bg-center bg-fixed"
-              )}
-              style={
-                showBackground
-                  ? { backgroundImage: `url(${appBackgroundUrl})` }
-                  : undefined
-              }
-            >
-              {/* Effect 1 — Vignette overlay for custom backgrounds (disabled in light mode).
+    <AppChromeRightPanelContext.Provider value={setRight}>
+      <RootLayout.App
+        data-main-container
+        onMouseDown={handleMouseDown}
+        onMouseUp={handleMouseUp}
+      >
+        <div className="flex flex-row flex-1 min-h-0">
+          <div
+            className={cn(
+              "@container relative isolate flex-1 flex flex-col min-h-0",
+              showBackground && "bg-cover bg-center bg-fixed"
+            )}
+            style={
+              showBackground
+                ? { backgroundImage: `url(${appBackgroundUrl})` }
+                : undefined
+            }
+          >
+            {/* Effect 1 — Vignette overlay for custom backgrounds (disabled in light mode).
               z-[-1] keeps overlays below the normal-flow header/content/footer. */}
-              {showBackground && !isLightMode && (
-                <div
-                  className="absolute z-[-1] inset-0 pointer-events-none"
-                  style={{
-                    background: `
+            {showBackground && !isLightMode && (
+              <div
+                className="absolute z-[-1] inset-0 pointer-events-none"
+                style={{
+                  background: `
                   linear-gradient(to bottom, rgba(0, 0, 0, 0.4) 0%, transparent 4rem),
                   linear-gradient(to top, rgba(0, 0, 0, 0.4) 0%, transparent 4rem)
                 `,
-                  }}
-                />
-              )}
-              {/* Effect 2 — Semi-transparent overlay for readability when background is set */}
-              {showBackground && appFocus.isChat() && (
-                <>
-                  <div className="absolute z-[-1] inset-0 backdrop-blur-[1px] pointer-events-none" />
-                  {isSafari ? (
-                    <div
-                      className="absolute z-[-1] inset-0 bg-cover bg-center bg-fixed pointer-events-none"
-                      style={{
-                        backgroundImage: `url(${appBackgroundUrl})`,
-                        filter: "blur(16px)",
-                        maskImage: horizontalBlurMask,
-                        WebkitMaskImage: horizontalBlurMask,
-                      }}
-                    />
-                  ) : (
-                    <div
-                      className="absolute z-[-1] inset-0 backdrop-blur-md transition-all duration-600 pointer-events-none"
-                      style={{
-                        maskImage: horizontalBlurMask,
-                        WebkitMaskImage: horizontalBlurMask,
-                      }}
-                    />
-                  )}
-                </>
-              )}
-              <RootLayout.Header>
-                <Header />
-              </RootLayout.Header>
-              <RootLayout.MainContent>{children}</RootLayout.MainContent>
-              <RootLayout.Footer>
-                <Footer />
-              </RootLayout.Footer>
-            </div>
-            {rightPanel}
+                }}
+              />
+            )}
+            {/* Effect 2 — Semi-transparent overlay for readability when background is set */}
+            {showBackground && appFocus.isChat() && (
+              <>
+                <div className="absolute z-[-1] inset-0 backdrop-blur-[1px] pointer-events-none" />
+                {isSafari ? (
+                  <div
+                    className="absolute z-[-1] inset-0 bg-cover bg-center bg-fixed pointer-events-none"
+                    style={{
+                      backgroundImage: `url(${appBackgroundUrl})`,
+                      filter: "blur(16px)",
+                      maskImage: horizontalBlurMask,
+                      WebkitMaskImage: horizontalBlurMask,
+                    }}
+                  />
+                ) : (
+                  <div
+                    className="absolute z-[-1] inset-0 backdrop-blur-md transition-all duration-600 pointer-events-none"
+                    style={{
+                      maskImage: horizontalBlurMask,
+                      WebkitMaskImage: horizontalBlurMask,
+                    }}
+                  />
+                )}
+              </>
+            )}
+            <RootLayout.Header>
+              <Header />
+            </RootLayout.Header>
+            <RootLayout.MainContent>{children}</RootLayout.MainContent>
+            <RootLayout.Footer>
+              <Footer />
+            </RootLayout.Footer>
           </div>
-        </RootLayout.App>
-      </AppChromeRightPanelContext.Provider>
-    </AppChromeLeftPanelContext.Provider>
+          {rightPanel}
+        </div>
+      </RootLayout.App>
+    </AppChromeRightPanelContext.Provider>
   );
 }

--- a/web/src/sections/app-chrome/AppChrome.tsx
+++ b/web/src/sections/app-chrome/AppChrome.tsx
@@ -1,6 +1,15 @@
 "use client";
 
-import { useCallback, useMemo, useRef, useState, useEffect } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+  useEffect,
+  type ReactNode,
+} from "react";
 import { RootLayout } from "@opal/layouts";
 import { cn } from "@opal/utils";
 import { ensureHrefProtocol, INTERACTIVE_SELECTOR, noProp } from "@/lib/utils";
@@ -47,6 +56,18 @@ import { useQueryController } from "@/providers/QueryControllerProvider";
 import { useTierAtLeast } from "@/hooks/useTierAtLeast";
 import { Tier } from "@/interfaces/settings";
 import { APP_SLOGAN } from "@/lib/constants";
+
+// ---------------------------------------------------------------------------
+// Right-panel slot — pages hoist their panel content here so it sits as a
+// flex sibling to the Header/MainContent/Footer column and pushes them in.
+// ---------------------------------------------------------------------------
+
+type RightPanelSetter = (panel: ReactNode) => void;
+const AppChromeRightPanelContext = createContext<RightPanelSetter>(() => {});
+
+export function useSetAppRightPanel(): RightPanelSetter {
+  return useContext(AppChromeRightPanelContext);
+}
 
 // ---------------------------------------------------------------------------
 // Header
@@ -491,6 +512,9 @@ interface AppChromeProps {
 }
 
 export default function AppChrome({ children }: AppChromeProps) {
+  const [rightPanel, setRightPanel] = useState<ReactNode>(null);
+  const setPanel = useCallback((panel: ReactNode) => setRightPanel(panel), []);
+
   const appFocus = useAppFocus();
   const { hasBackground, appBackgroundUrl } = useAppBackground();
   const { resolvedTheme } = useTheme();
@@ -537,68 +561,73 @@ export default function AppChrome({ children }: AppChromeProps) {
   }, []);
 
   return (
-    <RootLayout.App
-      data-main-container
-      onMouseDown={handleMouseDown}
-      onMouseUp={handleMouseUp}
-    >
-      <div
-        className={cn(
-          "@container relative isolate flex-1 flex flex-col min-h-0",
-          showBackground && "bg-cover bg-center bg-fixed"
-        )}
-        style={
-          showBackground
-            ? { backgroundImage: `url(${appBackgroundUrl})` }
-            : undefined
-        }
+    <AppChromeRightPanelContext.Provider value={setPanel}>
+      <RootLayout.App
+        data-main-container
+        onMouseDown={handleMouseDown}
+        onMouseUp={handleMouseUp}
       >
-        {/* Effect 1 — Vignette overlay for custom backgrounds (disabled in light mode).
-          z-[-1] keeps overlays below the normal-flow header/content/footer. */}
-        {showBackground && !isLightMode && (
+        <div className="flex flex-row flex-1 min-h-0">
           <div
-            className="absolute z-[-1] inset-0 pointer-events-none"
-            style={{
-              background: `
-              linear-gradient(to bottom, rgba(0, 0, 0, 0.4) 0%, transparent 4rem),
-              linear-gradient(to top, rgba(0, 0, 0, 0.4) 0%, transparent 4rem)
-            `,
-            }}
-          />
-        )}
-        {/* Effect 2 — Semi-transparent overlay for readability when background is set */}
-        {showBackground && appFocus.isChat() && (
-          <>
-            <div className="absolute z-[-1] inset-0 backdrop-blur-[1px] pointer-events-none" />
-            {isSafari ? (
+            className={cn(
+              "@container relative isolate flex-1 flex flex-col min-h-0",
+              showBackground && "bg-cover bg-center bg-fixed"
+            )}
+            style={
+              showBackground
+                ? { backgroundImage: `url(${appBackgroundUrl})` }
+                : undefined
+            }
+          >
+            {/* Effect 1 — Vignette overlay for custom backgrounds (disabled in light mode).
+              z-[-1] keeps overlays below the normal-flow header/content/footer. */}
+            {showBackground && !isLightMode && (
               <div
-                className="absolute z-[-1] inset-0 bg-cover bg-center bg-fixed pointer-events-none"
+                className="absolute z-[-1] inset-0 pointer-events-none"
                 style={{
-                  backgroundImage: `url(${appBackgroundUrl})`,
-                  filter: "blur(16px)",
-                  maskImage: horizontalBlurMask,
-                  WebkitMaskImage: horizontalBlurMask,
-                }}
-              />
-            ) : (
-              <div
-                className="absolute z-[-1] inset-0 backdrop-blur-md transition-all duration-600 pointer-events-none"
-                style={{
-                  maskImage: horizontalBlurMask,
-                  WebkitMaskImage: horizontalBlurMask,
+                  background: `
+                  linear-gradient(to bottom, rgba(0, 0, 0, 0.4) 0%, transparent 4rem),
+                  linear-gradient(to top, rgba(0, 0, 0, 0.4) 0%, transparent 4rem)
+                `,
                 }}
               />
             )}
-          </>
-        )}
-        <RootLayout.Header>
-          <Header />
-        </RootLayout.Header>
-        <RootLayout.MainContent>{children}</RootLayout.MainContent>
-        <RootLayout.Footer>
-          <Footer />
-        </RootLayout.Footer>
-      </div>
-    </RootLayout.App>
+            {/* Effect 2 — Semi-transparent overlay for readability when background is set */}
+            {showBackground && appFocus.isChat() && (
+              <>
+                <div className="absolute z-[-1] inset-0 backdrop-blur-[1px] pointer-events-none" />
+                {isSafari ? (
+                  <div
+                    className="absolute z-[-1] inset-0 bg-cover bg-center bg-fixed pointer-events-none"
+                    style={{
+                      backgroundImage: `url(${appBackgroundUrl})`,
+                      filter: "blur(16px)",
+                      maskImage: horizontalBlurMask,
+                      WebkitMaskImage: horizontalBlurMask,
+                    }}
+                  />
+                ) : (
+                  <div
+                    className="absolute z-[-1] inset-0 backdrop-blur-md transition-all duration-600 pointer-events-none"
+                    style={{
+                      maskImage: horizontalBlurMask,
+                      WebkitMaskImage: horizontalBlurMask,
+                    }}
+                  />
+                )}
+              </>
+            )}
+            <RootLayout.Header>
+              <Header />
+            </RootLayout.Header>
+            <RootLayout.MainContent>{children}</RootLayout.MainContent>
+            <RootLayout.Footer>
+              <Footer />
+            </RootLayout.Footer>
+          </div>
+          {rightPanel}
+        </div>
+      </RootLayout.App>
+    </AppChromeRightPanelContext.Provider>
   );
 }

--- a/web/src/sections/app-chrome/AppChrome.tsx
+++ b/web/src/sections/app-chrome/AppChrome.tsx
@@ -1,16 +1,14 @@
 "use client";
 
 import {
-  createContext,
   useCallback,
-  useContext,
   useMemo,
   useRef,
   useState,
   useEffect,
   type ReactNode,
 } from "react";
-import { RootLayout } from "@opal/layouts";
+import { RootLayout, RootLayoutRightPanelSlotContext } from "@opal/layouts";
 import { cn } from "@opal/utils";
 import { ensureHrefProtocol, INTERACTIVE_SELECTOR, noProp } from "@/lib/utils";
 import { useAppBackground } from "@/providers/AppBackgroundProvider";
@@ -56,22 +54,6 @@ import { useQueryController } from "@/providers/QueryControllerProvider";
 import { useTierAtLeast } from "@/hooks/useTierAtLeast";
 import { Tier } from "@/interfaces/settings";
 import { APP_SLOGAN } from "@/lib/constants";
-
-// ---------------------------------------------------------------------------
-// Right-panel slot — pages hoist their panel content here so it sits as a
-// flex sibling to the Header/MainContent/Footer column and pushes them in.
-// ---------------------------------------------------------------------------
-
-type PanelSetter = (panel: ReactNode) => void;
-
-const AppChromeRightPanelContext = createContext<PanelSetter | null>(null);
-
-export function useSetAppRightPanel(): PanelSetter {
-  const setter = useContext(AppChromeRightPanelContext);
-  if (!setter)
-    throw new Error("useSetAppRightPanel must be used within AppChrome");
-  return setter;
-}
 
 // ---------------------------------------------------------------------------
 // Header
@@ -517,7 +499,10 @@ interface AppChromeProps {
 
 export default function AppChrome({ children }: AppChromeProps) {
   const [rightPanel, setRightPanel] = useState<ReactNode>(null);
-  const setRight = useCallback((panel: ReactNode) => setRightPanel(panel), []);
+  const setRight = useCallback<(panel: ReactNode) => void>(
+    (panel) => setRightPanel(panel),
+    []
+  );
 
   const appFocus = useAppFocus();
   const { hasBackground, appBackgroundUrl } = useAppBackground();
@@ -565,7 +550,7 @@ export default function AppChrome({ children }: AppChromeProps) {
   }, []);
 
   return (
-    <AppChromeRightPanelContext.Provider value={setRight}>
+    <RootLayoutRightPanelSlotContext.Provider value={setRight}>
       <RootLayout.App
         data-main-container
         onMouseDown={handleMouseDown}
@@ -632,6 +617,6 @@ export default function AppChrome({ children }: AppChromeProps) {
           {rightPanel}
         </div>
       </RootLayout.App>
-    </AppChromeRightPanelContext.Provider>
+    </RootLayoutRightPanelSlotContext.Provider>
   );
 }

--- a/web/src/sections/app-chrome/AppChrome.tsx
+++ b/web/src/sections/app-chrome/AppChrome.tsx
@@ -539,63 +539,66 @@ export default function AppChrome({ children }: AppChromeProps) {
   return (
     <RootLayout.App
       data-main-container
-      className={cn(
-        "@container relative isolate",
-        showBackground && "bg-cover bg-center bg-fixed"
-      )}
-      style={
-        showBackground
-          ? { backgroundImage: `url(${appBackgroundUrl})` }
-          : undefined
-      }
       onMouseDown={handleMouseDown}
       onMouseUp={handleMouseUp}
     >
-      {/* Effect 1 — Vignette overlay for custom backgrounds (disabled in light mode).
+      <div
+        className={cn(
+          "@container relative isolate flex-1 flex flex-col",
+          showBackground && "bg-cover bg-center bg-fixed"
+        )}
+        style={
+          showBackground
+            ? { backgroundImage: `url(${appBackgroundUrl})` }
+            : undefined
+        }
+      >
+        {/* Effect 1 — Vignette overlay for custom backgrounds (disabled in light mode).
           z-[-1] keeps overlays below the normal-flow header/content/footer. */}
-      {showBackground && !isLightMode && (
-        <div
-          className="absolute z-[-1] inset-0 pointer-events-none"
-          style={{
-            background: `
+        {showBackground && !isLightMode && (
+          <div
+            className="absolute z-[-1] inset-0 pointer-events-none"
+            style={{
+              background: `
               linear-gradient(to bottom, rgba(0, 0, 0, 0.4) 0%, transparent 4rem),
               linear-gradient(to top, rgba(0, 0, 0, 0.4) 0%, transparent 4rem)
             `,
-          }}
-        />
-      )}
-      {/* Effect 2 — Semi-transparent overlay for readability when background is set */}
-      {showBackground && appFocus.isChat() && (
-        <>
-          <div className="absolute z-[-1] inset-0 backdrop-blur-[1px] pointer-events-none" />
-          {isSafari ? (
-            <div
-              className="absolute z-[-1] inset-0 bg-cover bg-center bg-fixed pointer-events-none"
-              style={{
-                backgroundImage: `url(${appBackgroundUrl})`,
-                filter: "blur(16px)",
-                maskImage: horizontalBlurMask,
-                WebkitMaskImage: horizontalBlurMask,
-              }}
-            />
-          ) : (
-            <div
-              className="absolute z-[-1] inset-0 backdrop-blur-md transition-all duration-600 pointer-events-none"
-              style={{
-                maskImage: horizontalBlurMask,
-                WebkitMaskImage: horizontalBlurMask,
-              }}
-            />
-          )}
-        </>
-      )}
-      <RootLayout.Header>
-        <Header />
-      </RootLayout.Header>
-      <RootLayout.MainContent>{children}</RootLayout.MainContent>
-      <RootLayout.Footer>
-        <Footer />
-      </RootLayout.Footer>
+            }}
+          />
+        )}
+        {/* Effect 2 — Semi-transparent overlay for readability when background is set */}
+        {showBackground && appFocus.isChat() && (
+          <>
+            <div className="absolute z-[-1] inset-0 backdrop-blur-[1px] pointer-events-none" />
+            {isSafari ? (
+              <div
+                className="absolute z-[-1] inset-0 bg-cover bg-center bg-fixed pointer-events-none"
+                style={{
+                  backgroundImage: `url(${appBackgroundUrl})`,
+                  filter: "blur(16px)",
+                  maskImage: horizontalBlurMask,
+                  WebkitMaskImage: horizontalBlurMask,
+                }}
+              />
+            ) : (
+              <div
+                className="absolute z-[-1] inset-0 backdrop-blur-md transition-all duration-600 pointer-events-none"
+                style={{
+                  maskImage: horizontalBlurMask,
+                  WebkitMaskImage: horizontalBlurMask,
+                }}
+              />
+            )}
+          </>
+        )}
+        <RootLayout.Header>
+          <Header />
+        </RootLayout.Header>
+        <RootLayout.MainContent>{children}</RootLayout.MainContent>
+        <RootLayout.Footer>
+          <Footer />
+        </RootLayout.Footer>
+      </div>
     </RootLayout.App>
   );
 }


### PR DESCRIPTION
## Description

Enforces design-system styling by removing `className`/`style` from Opal components, and fixes the right-panel layout so it correctly pushes Header/Content/Footer in.

**`WithoutStyles<>` enforcement:**
- `Checkbox` — `CheckboxProps` now extends `WithoutStyles<Omit<ComponentPropsWithoutRef<"input">, "type" | "size">>`
- `RootLayout.App` / `RootLayout.MainContent` — props wrapped in `WithoutStyles<>`
- `RootLayout.LeftPanel` / `RootLayout.RightPanel` — `className?: string` removed; both delegate to a shared `RootLayoutPanel` to prevent drift
- Stale CSS comment updated: panel width is determined by child content

**Right-panel layout fix:**
- `RootLayout.RightPanel` now detects `RootLayoutRightPanelSlotContext` and, when present, registers its content into the slot via `useLayoutEffect` and renders `null` in place. When no context is present (pure Opal usage), it renders normally as a flex sibling in `RootLayout.Root`.
- `AppChrome` provides the context and renders the slot as a flex sibling to the Header/Content/Footer column (with `min-h-0` to preserve scroll). Consumers just render `<RootLayout.RightPanel>` anywhere in the tree — no manual hoisting needed.

**Call-site updates:**
- `Field.tsx` — wraps `<Checkbox>` in a `<div>` for spacing/disabled-opacity classes
- `LabeledCheckboxField.tsx` — removes the defunct `size` prop (no callers used it)
- `FieldRendering.tsx` — removes `size="lg"` from `<CheckboxField>`
- `AppPage.tsx` — renders `<RootLayout.RightPanel>` directly; removes the old flex wrapper and all manual hoisting code
- `AppChrome.tsx` — moves `@container relative isolate` + background styles into a `flex-1 flex flex-col min-h-0` wrapper div

**`formHooks.ts`:** synced with `agent-wiki/frontend` — `useOnChangeValue` sets value then touched; `useOnBlurEvent` no longer redundantly sets touched.

## How Has This Been Tested?

- `bun run types:check` passes
- All Playwright test suites pass (lite, admin 1/2, admin 2/2, exclusive)

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check