### PR TITLE
feat(craft): codify sandbox pod spec into a Helm PodTemplate

### DIFF
--- a/.github/workflows/pr-craft-k8s-tests.yml
+++ b/.github/workflows/pr-craft-k8s-tests.yml
@@ -53,17 +53,7 @@ env:
   SANDBOX_NAMESPACE: "onyx-sandboxes"
   SANDBOX_SERVICE_ACCOUNT_NAME: "sandbox"
   SANDBOX_CONTAINER_IMAGE: "localhost:5001/onyx-sandbox:ci"
-  # CI runs on a 4 vCPU runner, and tests like test_skill_push provision
-  # up to 4 sandbox pods concurrently (pool + 3 cohort). With prod-default
-  # requests of 1 CPU/pod, the 4th pod stays Pending and trips the 60s
-  # readiness ceiling. Override to tiny requests so kind's scheduler can
-  # fit all four — kind isn't enforcing fairness here, just placement.
-  SANDBOX_POD_CPU_REQUEST: "100m"
-  SANDBOX_POD_MEMORY_REQUEST: "256Mi"
-  SANDBOX_POD_CPU_LIMIT: "2000m"
-  SANDBOX_POD_MEMORY_LIMIT: "4Gi"
-  # Placeholder — only injected as ONYX_SERVER_URL into the pod; the
-  # tests never call back to it, so the URL doesn't need to resolve.
+  # Sandbox pod resource requests live in values-ci.yaml (configMap.SANDBOX_POD_*).
   SANDBOX_API_SERVER_URL: "http://api-server.onyx-ci.invalid"
 
   # Proxy lives in release namespace `onyx`. SANDBOX_PROXY_HOST is set
@@ -233,6 +223,7 @@ jobs:
             --set "celery_shared.image.tag=ci" \
             --show-only templates/sandbox-namespace.yaml \
             --show-only templates/sandbox-rbac.yaml \
+            --show-only templates/sandbox-podtemplate.yaml \
             --show-only templates/sandbox-proxy/deployment.yaml \
             --show-only templates/sandbox-proxy/service.yaml \
             --show-only templates/sandbox-proxy/rbac.yaml \

--- a/backend/onyx/server/features/build/configs.py
+++ b/backend/onyx/server/features/build/configs.py
@@ -79,15 +79,6 @@ ENABLE_OPENCODE_DEBUGGING = (
 # deployment).
 SANDBOX_API_SERVER_URL = os.environ.get("SANDBOX_API_SERVER_URL", "")
 
-# Defaults match production sizing. CI overrides these in kind clusters where
-# the runner only has 4 vCPU and we provision 4+ sandbox pods concurrently; the
-# k8s scheduler honors requests, so production defaults would block all but one
-# pod from being scheduled at the same time.
-SANDBOX_POD_CPU_REQUEST = os.environ.get("SANDBOX_POD_CPU_REQUEST", "1000m")
-SANDBOX_POD_MEMORY_REQUEST = os.environ.get("SANDBOX_POD_MEMORY_REQUEST", "2Gi")
-SANDBOX_POD_CPU_LIMIT = os.environ.get("SANDBOX_POD_CPU_LIMIT", "2000m")
-SANDBOX_POD_MEMORY_LIMIT = os.environ.get("SANDBOX_POD_MEMORY_LIMIT", "10Gi")
-
 # ==============================================================================
 # Sandbox egress proxy
 # ==============================================================================

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -564,9 +564,9 @@ class KubernetesSandboxManager(SandboxManager):
             if e.status == 404:
                 raise RuntimeError(
                     f"Sandbox PodTemplate '{_PODTEMPLATE_NAME}' not found in "
-                    f"namespace '{self._namespace}'. Apply the onyx Helm chart "
-                    f"with ENABLE_CRAFT=true so templates/sandbox-podtemplate.yaml "
-                    f"is rendered."
+                    f"namespace '{self._namespace}'. It must be applied to the "
+                    f"cluster (by the deploy tooling when Craft is enabled) "
+                    f"before sandboxes can be provisioned."
                 ) from e
             raise
 
@@ -637,17 +637,17 @@ class KubernetesSandboxManager(SandboxManager):
     def _require_container(spec: client.V1PodSpec, name: str) -> client.V1Container:
         """Find a container in the PodTemplate by name, or raise a clear error.
 
-        A bare ``next()`` would surface a chart/version skew (template missing
-        the expected container) as an opaque ``StopIteration``; this names the
-        container and the fix, matching the 404 PodTemplate error above.
+        A bare ``next()`` would surface a PodTemplate/version skew (template
+        missing the expected container) as an opaque ``StopIteration``; this
+        names the container and the fix, matching the 404 PodTemplate error.
         """
         for container in spec.containers or []:
             if container.name == name:
                 return container
         raise RuntimeError(
             f"PodTemplate '{_PODTEMPLATE_NAME}' has no '{name}' container. "
-            f"The chart and api-server versions are likely out of sync — "
-            f"apply the matching onyx Helm chart."
+            f"The PodTemplate and api-server versions are likely out of sync — "
+            f"apply the matching sandbox PodTemplate."
         )
 
     def _create_sandbox_service(

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -36,6 +36,7 @@ Use get_sandbox_manager() from base.py to get the appropriate implementation.
 
 import base64
 import binascii
+import copy
 import hashlib
 import io
 import ipaddress
@@ -71,15 +72,9 @@ from onyx.server.features.build.configs import OPENCODE_SERVE_PORT
 from onyx.server.features.build.configs import OPENCODE_SERVER_PASSWORD
 from onyx.server.features.build.configs import SANDBOX_API_SERVER_URL
 from onyx.server.features.build.configs import SANDBOX_CONTAINER_IMAGE
-from onyx.server.features.build.configs import SANDBOX_IMAGE_PULL_POLICY
 from onyx.server.features.build.configs import SANDBOX_NAMESPACE
 from onyx.server.features.build.configs import SANDBOX_NEXTJS_PORT_END
 from onyx.server.features.build.configs import SANDBOX_NEXTJS_PORT_START
-from onyx.server.features.build.configs import SANDBOX_POD_CPU_LIMIT
-from onyx.server.features.build.configs import SANDBOX_POD_CPU_REQUEST
-from onyx.server.features.build.configs import SANDBOX_POD_MEMORY_LIMIT
-from onyx.server.features.build.configs import SANDBOX_POD_MEMORY_REQUEST
-from onyx.server.features.build.configs import SANDBOX_PROXY_CA_CONFIGMAP
 from onyx.server.features.build.configs import SANDBOX_PROXY_HOST
 from onyx.server.features.build.configs import SANDBOX_PROXY_INJECTED_PLACEHOLDER
 from onyx.server.features.build.configs import SANDBOX_PROXY_NAMESPACE
@@ -140,15 +135,17 @@ RESOURCE_DELETION_POLL_INTERVAL_SECONDS = 0.5
 _PUSH_PRIVATE_KEY_ENV = "ONYX_SANDBOX_PUSH_PRIVATE_KEY"
 _PUSH_PUBLIC_KEY_ENV = "ONYX_SANDBOX_PUSH_PUBLIC_KEY"
 
+# Proxy CA bundle path; still referenced by _proxy_main_container_env_vars().
 _PROXY_CA_BUNDLE_DIR = "/etc/ssl/sandbox"
 _PROXY_CA_BUNDLE_FILE = f"{_PROXY_CA_BUNDLE_DIR}/ca-bundle.crt"
-_PROXY_CA_SOURCE_DIR = "/sandbox-ca"
-_PROXY_CA_BUNDLE_VOLUME = "sandbox-ca-bundle"
-_PROXY_CA_SOURCE_VOLUME = "sandbox-ca-source"
 # Pinned to the proxy IP via pod hostAliases — the iptables lockdown blocks DNS,
 # so the sandbox can't resolve it on its own.
 _PROXY_ALIAS = "sandbox-proxy"
 _SANDBOX_CONTAINER_NAME = "sandbox"
+_SIDECAR_CONTAINER_NAME = "sidecar"
+
+# Helm-rendered PodTemplate carrying the static sandbox pod shape.
+_PODTEMPLATE_NAME = "sandbox-pod"
 
 # Per-session egress tagging plugin, baked into the sandbox image (see
 # docker/Dockerfile). Path must match the COPY destination there.
@@ -197,53 +194,6 @@ def _proxy_main_container_env_vars() -> list[client.V1EnvVar]:
         client.V1EnvVar(name="CURL_CA_BUNDLE", value=_PROXY_CA_BUNDLE_FILE),
         client.V1EnvVar(name="GIT_SSL_CAINFO", value=_PROXY_CA_BUNDLE_FILE),
     ]
-
-
-def _proxy_init_container() -> client.V1Container:
-    return client.V1Container(
-        name="sandbox-init",
-        image=SANDBOX_CONTAINER_IMAGE,
-        image_pull_policy=SANDBOX_IMAGE_PULL_POLICY,
-        command=["/workspace/firewall-init.sh"],
-        env=[
-            client.V1EnvVar(name="SANDBOX_PROXY_HOST", value=SANDBOX_PROXY_HOST),
-            client.V1EnvVar(name="SANDBOX_PROXY_PORT", value=str(SANDBOX_PROXY_PORT)),
-            client.V1EnvVar(name="SANDBOX_PROXY_BOOTSTRAP_MODE", value="initcontainer"),
-            client.V1EnvVar(
-                name="SANDBOX_PROXY_CA_BUNDLE_SRC",
-                value=f"{_PROXY_CA_SOURCE_DIR}/ca.crt",
-            ),
-            client.V1EnvVar(
-                name="SANDBOX_PROXY_CA_BUNDLE_DST",
-                value=_PROXY_CA_BUNDLE_FILE,
-            ),
-        ],
-        volume_mounts=[
-            client.V1VolumeMount(
-                name=_PROXY_CA_SOURCE_VOLUME,
-                mount_path=_PROXY_CA_SOURCE_DIR,
-                read_only=True,
-            ),
-            client.V1VolumeMount(
-                name=_PROXY_CA_BUNDLE_VOLUME,
-                mount_path=_PROXY_CA_BUNDLE_DIR,
-            ),
-        ],
-        resources=client.V1ResourceRequirements(
-            requests={"cpu": "50m", "memory": "32Mi"},
-            limits={"cpu": "500m", "memory": "128Mi"},
-        ),
-        security_context=client.V1SecurityContext(
-            # Overrides pod-level runAsNonRoot so this container can
-            # run iptables.
-            run_as_non_root=False,
-            run_as_user=0,
-            allow_privilege_escalation=False,
-            read_only_root_filesystem=False,
-            privileged=False,
-            capabilities=client.V1Capabilities(drop=["ALL"], add=["NET_ADMIN"]),
-        ),
-    )
 
 
 _push_private_key: Ed25519PrivateKey | None = None
@@ -602,215 +552,26 @@ class KubernetesSandboxManager(SandboxManager):
         sandbox_id: str,
         tenant_id: str,
     ) -> client.V1Pod:
-        """Create Pod specification for sandbox (user-level).
-
-        Creates pod with:
-        - sessions/ directory for per-session workspaces
-
-        NOTE: Session-specific setup is done via setup_session_workspace().
-        """
+        """Build the sandbox Pod from the Helm PodTemplate, overlaying the
+        dynamic fields the template can't carry."""
         pod_name = self._get_pod_name(sandbox_id)
 
-        # Sandbox container — runs the agent. It never receives durable-storage
-        # credentials; snapshots stream through the sidecar to api-server-owned
-        # FileStore persistence.
-        sandbox_ports = [
-            client.V1ContainerPort(name="opencode", container_port=OPENCODE_SERVE_PORT),
-        ]
-        for port in range(SANDBOX_NEXTJS_PORT_START, SANDBOX_NEXTJS_PORT_END):
-            sandbox_ports.append(
-                client.V1ContainerPort(name=f"nextjs-{port}", container_port=port)
+        try:
+            pod_template = self._core_api.read_namespaced_pod_template(
+                name=_PODTEMPLATE_NAME, namespace=self._namespace
             )
+        except ApiException as e:
+            if e.status == 404:
+                raise RuntimeError(
+                    f"Sandbox PodTemplate '{_PODTEMPLATE_NAME}' not found in "
+                    f"namespace '{self._namespace}'. Apply the onyx Helm chart "
+                    f"with ENABLE_CRAFT=true so templates/sandbox-podtemplate.yaml "
+                    f"is rendered."
+                ) from e
+            raise
 
-        sandbox_container = client.V1Container(
-            name=_SANDBOX_CONTAINER_NAME,
-            image=self._image,
-            image_pull_policy=SANDBOX_IMAGE_PULL_POLICY,
-            command=["/workspace/entrypoint.sh"],
-            ports=sandbox_ports,
-            env=[
-                client.V1EnvVar(
-                    name="ONYX_PAT", value=SANDBOX_PROXY_INJECTED_PLACEHOLDER
-                ),
-                client.V1EnvVar(name="ONYX_SERVER_URL", value=SANDBOX_API_SERVER_URL),
-                client.V1EnvVar(
-                    name="GH_TOKEN", value=SANDBOX_PROXY_INJECTED_PLACEHOLDER
-                ),
-                client.V1EnvVar(name="GH_NO_UPDATE_NOTIFIER", value="1"),
-                client.V1EnvVar(
-                    name=OPENCODE_SERVER_PASSWORD,
-                    value_from=client.V1EnvVarSource(
-                        secret_key_ref=client.V1SecretKeySelector(
-                            name=self._get_opencode_secret_name(sandbox_id),
-                            key=self._OPENCODE_PASSWORD_SECRET_KEY,
-                        )
-                    ),
-                ),
-                client.V1EnvVar(
-                    name="OPENCODE_CONFIG_CONTENT",
-                    value_from=client.V1EnvVarSource(
-                        secret_key_ref=client.V1SecretKeySelector(
-                            name=self._get_opencode_secret_name(sandbox_id),
-                            key=self._OPENCODE_CONFIG_SECRET_KEY,
-                        )
-                    ),
-                ),
-                *_proxy_main_container_env_vars(),
-            ],
-            volume_mounts=[
-                client.V1VolumeMount(
-                    name="workspace", mount_path="/workspace/sessions"
-                ),
-                client.V1VolumeMount(
-                    name="managed", mount_path="/workspace/managed", read_only=True
-                ),
-                client.V1VolumeMount(
-                    name=_PROXY_CA_BUNDLE_VOLUME,
-                    mount_path=_PROXY_CA_BUNDLE_DIR,
-                    read_only=True,
-                ),
-            ],
-            resources=client.V1ResourceRequirements(
-                requests={
-                    "cpu": SANDBOX_POD_CPU_REQUEST,
-                    "memory": SANDBOX_POD_MEMORY_REQUEST,
-                },
-                limits={
-                    "cpu": SANDBOX_POD_CPU_LIMIT,
-                    "memory": SANDBOX_POD_MEMORY_LIMIT,
-                },
-            ),
-            security_context=client.V1SecurityContext(
-                allow_privilege_escalation=False,
-                read_only_root_filesystem=False,
-                privileged=False,
-                capabilities=client.V1Capabilities(drop=["ALL"]),
-            ),
-        )
-
-        # Sidecar container — runs the push daemon + snapshot filesystem API
-        # on port 8731. It does not persist snapshots; the api-server streams
-        # tarballs to/from the main Onyx FileStore.
-        _, push_public_key_b64 = _get_push_key_pair()
-        sidecar_env = [
-            client.V1EnvVar(name=_PUSH_PUBLIC_KEY_ENV, value=push_public_key_b64),
-            *_proxy_main_container_env_vars(),
-        ]
-        sidecar_container = client.V1Container(
-            name="sidecar",
-            image=self._image,
-            image_pull_policy=SANDBOX_IMAGE_PULL_POLICY,
-            command=["/workspace/sidecar-entrypoint.sh"],
-            ports=[
-                client.V1ContainerPort(
-                    name="push-daemon", container_port=PUSH_DAEMON_PORT
-                ),
-            ],
-            env=sidecar_env,
-            volume_mounts=[
-                client.V1VolumeMount(
-                    name="workspace", mount_path="/workspace/sessions"
-                ),
-                client.V1VolumeMount(name="managed", mount_path="/workspace/managed"),
-                client.V1VolumeMount(
-                    name=_PROXY_CA_BUNDLE_VOLUME,
-                    mount_path=_PROXY_CA_BUNDLE_DIR,
-                    read_only=True,
-                ),
-            ],
-            resources=client.V1ResourceRequirements(
-                requests={"cpu": "100m", "memory": "256Mi"},
-                limits={"cpu": "500m", "memory": "512Mi"},
-            ),
-            security_context=client.V1SecurityContext(
-                allow_privilege_escalation=False,
-                read_only_root_filesystem=False,
-                privileged=False,
-                capabilities=client.V1Capabilities(drop=["ALL"]),
-            ),
-            liveness_probe=client.V1Probe(
-                http_get=client.V1HTTPGetAction(path="/health", port=PUSH_DAEMON_PORT),
-                initial_delay_seconds=5,
-                period_seconds=30,
-            ),
-            readiness_probe=client.V1Probe(
-                http_get=client.V1HTTPGetAction(path="/health", port=PUSH_DAEMON_PORT),
-                initial_delay_seconds=1,
-                period_seconds=2,
-                failure_threshold=10,
-            ),
-        )
-
-        volumes = [
-            client.V1Volume(
-                name="workspace",
-                empty_dir=client.V1EmptyDirVolumeSource(size_limit="50Gi"),
-            ),
-            client.V1Volume(
-                name="managed",
-                empty_dir=client.V1EmptyDirVolumeSource(size_limit="5Gi"),
-            ),
-        ]
-
-        volumes.extend(
-            [
-                client.V1Volume(
-                    name=_PROXY_CA_SOURCE_VOLUME,
-                    config_map=client.V1ConfigMapVolumeSource(
-                        name=SANDBOX_PROXY_CA_CONFIGMAP,
-                        optional=False,
-                    ),
-                ),
-                client.V1Volume(
-                    name=_PROXY_CA_BUNDLE_VOLUME,
-                    empty_dir=client.V1EmptyDirVolumeSource(),
-                ),
-            ]
-        )
-        # kubelet injects hostAliases into every container's /etc/hosts;
-        # initContainer mutations don't propagate, so we set it here.
-        host_aliases = [
-            client.V1HostAlias(ip=self._resolve_proxy_ip(), hostnames=[_PROXY_ALIAS])
-        ]
-
-        pod_spec = client.V1PodSpec(
-            service_account_name=self._service_account,
-            automount_service_account_token=False,
-            init_containers=[_proxy_init_container()],
-            containers=[sandbox_container, sidecar_container],
-            host_aliases=host_aliases,
-            share_process_namespace=False,
-            volumes=volumes,
-            restart_policy="Never",
-            termination_grace_period_seconds=10,  # Fast pod termination
-            # CRITICAL: Disable service environment variable injection
-            # Without this, Kubernetes injects env vars for ALL services in the namespace,
-            # which can exceed ARG_MAX (2.6MB) when there are many sandbox pods.
-            # With 40+ sandboxes × 100 ports × 4 env vars each = ~16k env vars (~2.2MB)
-            # This causes "exec /bin/sh: argument list too long" errors.
-            enable_service_links=False,
-            # Node selection for sandbox nodes
-            node_selector={"onyx.app/workload": "sandbox"},
-            tolerations=[
-                client.V1Toleration(
-                    key="workload",
-                    operator="Equal",
-                    value="sandbox",
-                    effect="NoSchedule",
-                ),
-            ],
-            # Security context for pod
-            security_context=client.V1PodSecurityContext(
-                run_as_non_root=True,
-                run_as_user=1000,
-                fs_group=1000,
-                seccomp_profile=client.V1SeccompProfile(type="RuntimeDefault"),
-            ),
-            # Disable host access
-            host_network=False,
-            host_pid=False,
-            host_ipc=False,
-        )
+        spec: client.V1PodSpec = copy.deepcopy(pod_template.template.spec)
+        self._overlay_dynamic_fields(spec, sandbox_id)
 
         return client.V1Pod(
             api_version="v1",
@@ -819,14 +580,74 @@ class KubernetesSandboxManager(SandboxManager):
                 name=pod_name,
                 namespace=self._namespace,
                 labels={
+                    **(pod_template.template.metadata.labels or {}),
                     LABEL_K8S_COMPONENT: LABEL_K8S_COMPONENT_SANDBOX,
                     LABEL_K8S_MANAGED_BY: LABEL_K8S_MANAGED_BY_ONYX,
                     LABEL_SANDBOX_ID: sandbox_id,
                     LABEL_TENANT_ID: tenant_id,
-                    "admission.datadoghq.com/enabled": "false",
                 },
             ),
-            spec=pod_spec,
+            spec=spec,
+        )
+
+    def _overlay_dynamic_fields(self, spec: client.V1PodSpec, sandbox_id: str) -> None:
+        """Inject the per-pod values the deploy-time PodTemplate can't carry.
+
+        These are the *only* parts of the pod spec set from Python:
+        - hostAliases pinning the proxy ClusterIP (resolved at runtime; the
+          firewall blocks DNS so the pod can't resolve it itself)
+        - the opencode-auth secretKeyRef env (the Secret name is per-pod)
+        - the push public key on the sidecar (derived from the api-server's
+          private key, so it's never in the chart; sidecar only)
+        """
+        spec.host_aliases = [
+            client.V1HostAlias(ip=self._resolve_proxy_ip(), hostnames=[_PROXY_ALIAS])
+        ]
+
+        secret_name = self._get_opencode_secret_name(sandbox_id)
+        sandbox_container = self._require_container(spec, _SANDBOX_CONTAINER_NAME)
+        sandbox_container.env = list(sandbox_container.env or []) + [
+            client.V1EnvVar(
+                name=OPENCODE_SERVER_PASSWORD,
+                value_from=client.V1EnvVarSource(
+                    secret_key_ref=client.V1SecretKeySelector(
+                        name=secret_name,
+                        key=self._OPENCODE_PASSWORD_SECRET_KEY,
+                    )
+                ),
+            ),
+            client.V1EnvVar(
+                name="OPENCODE_CONFIG_CONTENT",
+                value_from=client.V1EnvVarSource(
+                    secret_key_ref=client.V1SecretKeySelector(
+                        name=secret_name,
+                        key=self._OPENCODE_CONFIG_SECRET_KEY,
+                    )
+                ),
+            ),
+        ]
+
+        _, push_public_key_b64 = _get_push_key_pair()
+        sidecar_container = self._require_container(spec, _SIDECAR_CONTAINER_NAME)
+        sidecar_container.env = list(sidecar_container.env or []) + [
+            client.V1EnvVar(name=_PUSH_PUBLIC_KEY_ENV, value=push_public_key_b64),
+        ]
+
+    @staticmethod
+    def _require_container(spec: client.V1PodSpec, name: str) -> client.V1Container:
+        """Find a container in the PodTemplate by name, or raise a clear error.
+
+        A bare ``next()`` would surface a chart/version skew (template missing
+        the expected container) as an opaque ``StopIteration``; this names the
+        container and the fix, matching the 404 PodTemplate error above.
+        """
+        for container in spec.containers or []:
+            if container.name == name:
+                return container
+        raise RuntimeError(
+            f"PodTemplate '{_PODTEMPLATE_NAME}' has no '{name}' container. "
+            f"The chart and api-server versions are likely out of sync — "
+            f"apply the matching onyx Helm chart."
         )
 
     def _create_sandbox_service(

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_pod_spec.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_pod_spec.py
@@ -10,14 +10,24 @@ them carry the security model:
   - The sidecar must expose the push/snapshot port with health probes.
   - Neither container should receive durable-storage credentials for snapshots.
 
-Pure logic — bypasses `_initialize` so no cluster is needed.
+The static pod shape now lives in the Helm-rendered ``sandbox-pod`` PodTemplate
+(templates/sandbox-podtemplate.yaml); `_create_sandbox_pod` reads it and overlays
+the per-pod fields. This suite renders that chart template, feeds it through the
+overlay (via a mocked ``read_namespaced_pod_template``), and asserts the
+invariants on the result — so it verifies the Helm template + Python overlay
+end to end. Skips if the ``helm`` binary or chart deps are unavailable.
 """
 
 from __future__ import annotations
 
 import base64
+import json
+import shutil
+import subprocess
+from pathlib import Path
 
 import pytest
+import yaml
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from cryptography.hazmat.primitives.serialization import Encoding
 from cryptography.hazmat.primitives.serialization import NoEncryption
@@ -32,6 +42,10 @@ from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager im
 from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager import (
     PUSH_DAEMON_PORT,
 )
+
+# backend/tests/unit/onyx/server/features/build/sandbox/ -> repo root
+_REPO_ROOT = Path(__file__).resolve().parents[8]
+_CHART_DIR = _REPO_ROOT / "deployment" / "helm" / "charts" / "onyx"
 
 
 def _gen_key_b64() -> str:
@@ -59,15 +73,62 @@ def _push_key_env(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
+def _render_pod_template() -> client.V1PodTemplate:
+    """Render the sandbox-pod PodTemplate from the chart and deserialize it
+    into the same model the K8s API would return."""
+    helm = shutil.which("helm")
+    if helm is None:
+        pytest.skip("helm binary not available")
+    result = subprocess.run(
+        [
+            helm,
+            "template",
+            "onyx",
+            str(_CHART_DIR),
+            "-n",
+            "onyx",
+            "-f",
+            str(_CHART_DIR / "values-ci.yaml"),
+            "--show-only",
+            "templates/sandbox-podtemplate.yaml",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        pytest.skip(f"helm template failed (chart deps?): {result.stderr.strip()}")
+    rendered = yaml.safe_load(result.stdout)
+
+    class _Resp:
+        def __init__(self, obj: dict) -> None:
+            self.data = json.dumps(obj)
+
+    return client.ApiClient().deserialize(_Resp(rendered), "V1PodTemplate")
+
+
 def _build_pod() -> client.V1Pod:
+    pod_template = _render_pod_template()
     mgr: KubernetesSandboxManager = object.__new__(KubernetesSandboxManager)
     mgr._namespace = "onyx-sandboxes"  # type: ignore[attr-defined]
-    mgr._image = "onyxdotapp/sandbox:test"  # type: ignore[attr-defined]
-    mgr._service_account = "sandbox"  # type: ignore[attr-defined]
+    mgr._core_api = _FakeCoreApi(pod_template)  # type: ignore[attr-defined]
     return mgr._create_sandbox_pod(  # type: ignore[attr-defined]
         sandbox_id="abc12345-abcd-abcd-abcd-abcdef123456",
         tenant_id="t-1",
     )
+
+
+class _FakeCoreApi:
+    """Returns the rendered PodTemplate from read_namespaced_pod_template."""
+
+    def __init__(self, pod_template: client.V1PodTemplate) -> None:
+        self._pod_template = pod_template
+
+    def read_namespaced_pod_template(
+        self,
+        name: str,  # noqa: ARG002
+        namespace: str,  # noqa: ARG002
+    ) -> client.V1PodTemplate:
+        return self._pod_template
 
 
 @pytest.fixture
@@ -272,6 +333,14 @@ def test_ca_bundle_mounted_read_only_on_both_containers(pod: client.V1Pod) -> No
         mount = _mount(_container(pod, name), "sandbox-ca-bundle")
         assert mount.read_only is True
         assert mount.mount_path == "/etc/ssl/sandbox"
+
+
+def test_missing_container_raises_clear_error_on_version_skew() -> None:
+    """A chart/api-server version skew (template missing an expected container)
+    must surface as an actionable RuntimeError, not an opaque StopIteration."""
+    spec = client.V1PodSpec(containers=[client.V1Container(name="sandbox")])
+    with pytest.raises(RuntimeError, match="sidecar"):
+        KubernetesSandboxManager._require_container(spec, "sidecar")
 
 
 def test_service_exposes_push_daemon_port() -> None:

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.5.22
+version: 0.5.23
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/templates/_helpers.tpl
+++ b/deployment/helm/charts/onyx/templates/_helpers.tpl
@@ -202,6 +202,23 @@ Return the configured autoscaling engine; defaults to HPA when unset.
 {{- if eq (toString (index .Values.configMap "ENABLE_CRAFT" | default "")) "true" -}}true{{- end -}}
 {{- end }}
 
+{{/* Sandbox egress-proxy env. Mirrors _proxy_main_container_env_vars(). */}}
+{{- define "onyx.sandboxProxyEnv" -}}
+{{- $proxyUrl := printf "http://sandbox-proxy:%v" .proxyPort }}
+- { name: HTTPS_PROXY, value: "{{ $proxyUrl }}" }
+- { name: HTTP_PROXY, value: "{{ $proxyUrl }}" }
+- { name: https_proxy, value: "{{ $proxyUrl }}" }
+- { name: http_proxy, value: "{{ $proxyUrl }}" }
+- { name: NO_PROXY, value: "127.0.0.1,localhost" }
+- { name: no_proxy, value: "127.0.0.1,localhost" }
+- { name: NODE_EXTRA_CA_CERTS, value: "{{ .caBundleFile }}" }
+- { name: REQUESTS_CA_BUNDLE, value: "{{ .caBundleFile }}" }
+- { name: SSL_CERT_FILE, value: "{{ .caBundleFile }}" }
+- { name: AWS_CA_BUNDLE, value: "{{ .caBundleFile }}" }
+- { name: CURL_CA_BUNDLE, value: "{{ .caBundleFile }}" }
+- { name: GIT_SSL_CAINFO, value: "{{ .caBundleFile }}" }
+{{- end }}
+
 {{/*
 "true" when custom CA certificates are configured, empty otherwise.
 */}}

--- a/deployment/helm/charts/onyx/templates/sandbox-podtemplate.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-podtemplate.yaml
@@ -126,8 +126,9 @@ template:
           - { name: managed, mountPath: /workspace/managed }
           - { name: sandbox-ca-bundle, mountPath: /etc/ssl/sandbox, readOnly: true }
         resources:
+          # Snapshot tar/stream runs through this sidecar, so give it headroom.
           requests: { cpu: "100m", memory: "256Mi" }
-          limits: { cpu: "500m", memory: "512Mi" }
+          limits: { cpu: "1", memory: "1Gi" }
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: false

--- a/deployment/helm/charts/onyx/templates/sandbox-podtemplate.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-podtemplate.yaml
@@ -1,0 +1,157 @@
+{{- if eq (include "onyx.craftEnabled" .) "true" }}
+{{/*
+Static shape of the per-user sandbox Pod. _create_sandbox_pod reads this and
+overlays the dynamic fields (name, sandbox/tenant labels, per-pod
+opencode-auth + push-key env, proxy hostAliases IP).
+*/}}
+{{- $cm := .Values.configMap }}
+{{- $sandboxNs := $cm.SANDBOX_NAMESPACE | default "onyx-sandboxes" }}
+{{- $saName := (index $cm "SANDBOX_SERVICE_ACCOUNT_NAME") | default "sandbox" }}
+{{- $image := (index $cm "SANDBOX_CONTAINER_IMAGE") | default "onyxdotapp/sandbox:v0.1.52" }}
+{{- $pullPolicy := (index $cm "SANDBOX_IMAGE_PULL_POLICY") | default "IfNotPresent" }}
+{{- $cpuReq := (index $cm "SANDBOX_POD_CPU_REQUEST") | default "1000m" }}
+{{- $memReq := (index $cm "SANDBOX_POD_MEMORY_REQUEST") | default "2Gi" }}
+{{- $cpuLim := (index $cm "SANDBOX_POD_CPU_LIMIT") | default "2000m" }}
+{{- $memLim := (index $cm "SANDBOX_POD_MEMORY_LIMIT") | default "10Gi" }}
+{{- $nextjsStart := (index $cm "SANDBOX_NEXTJS_PORT_START") | default "3010" | int }}
+{{- $nextjsEnd := (index $cm "SANDBOX_NEXTJS_PORT_END") | default "3100" | int }}
+{{- $opencodePort := (index $cm "OPENCODE_SERVE_PORT") | default "4096" | int }}
+{{/* Keep in sync with PUSH_DAEMON_PORT in kubernetes_sandbox_manager.py. */}}
+{{- $pushDaemonPort := (index $cm "PUSH_DAEMON_PORT") | default "8731" | int }}
+{{- $proxyPort := (index $cm "SANDBOX_PROXY_PORT") | default "8080" }}
+{{- $proxyHost := (index $cm "SANDBOX_PROXY_HOST") | default (printf "%s-sandbox-proxy.%s.svc.cluster.local" (include "onyx.fullname" .) .Release.Namespace) }}
+{{- $caConfigMap := (index $cm "SANDBOX_PROXY_CA_CONFIGMAP") | default "sandbox-proxy-ca-bundle" }}
+{{- $serverUrl := (index $cm "SANDBOX_API_SERVER_URL") }}
+{{- $sandboxPod := .Values.sandboxPod | default dict }}
+{{- $caBundleFile := "/etc/ssl/sandbox/ca-bundle.crt" }}
+apiVersion: v1
+kind: PodTemplate
+metadata:
+  name: sandbox-pod
+  namespace: {{ $sandboxNs }}
+  labels:
+    {{- include "onyx.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sandbox
+template:
+  metadata:
+    labels:
+      app.kubernetes.io/component: sandbox
+      app.kubernetes.io/managed-by: onyx
+      admission.datadoghq.com/enabled: "false"
+  spec:
+    serviceAccountName: {{ $saName }}
+    automountServiceAccountToken: false
+    restartPolicy: Never
+    terminationGracePeriodSeconds: 10
+    enableServiceLinks: false
+    shareProcessNamespace: false
+    hostNetwork: false
+    hostPID: false
+    hostIPC: false
+    nodeSelector:
+      {{- (index $sandboxPod "nodeSelector" | default (dict "onyx.app/workload" "sandbox")) | toYaml | nindent 6 }}
+    tolerations:
+      {{- (index $sandboxPod "tolerations" | default (list (dict "key" "workload" "operator" "Equal" "value" "sandbox" "effect" "NoSchedule"))) | toYaml | nindent 6 }}
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+      fsGroup: 1000
+      seccompProfile:
+        type: RuntimeDefault
+    initContainers:
+      - name: sandbox-init
+        image: {{ $image }}
+        imagePullPolicy: {{ $pullPolicy }}
+        command: ["/workspace/firewall-init.sh"]
+        env:
+          - { name: SANDBOX_PROXY_HOST, value: "{{ $proxyHost }}" }
+          - { name: SANDBOX_PROXY_PORT, value: "{{ $proxyPort }}" }
+          - { name: SANDBOX_PROXY_BOOTSTRAP_MODE, value: "initcontainer" }
+          - { name: SANDBOX_PROXY_CA_BUNDLE_SRC, value: "/sandbox-ca/ca.crt" }
+          - { name: SANDBOX_PROXY_CA_BUNDLE_DST, value: "{{ $caBundleFile }}" }
+        volumeMounts:
+          - { name: sandbox-ca-source, mountPath: /sandbox-ca, readOnly: true }
+          - { name: sandbox-ca-bundle, mountPath: /etc/ssl/sandbox }
+        resources:
+          requests: { cpu: "50m", memory: "32Mi" }
+          limits: { cpu: "500m", memory: "128Mi" }
+        securityContext:
+          runAsNonRoot: false
+          runAsUser: 0
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
+          privileged: false
+          capabilities:
+            drop: ["ALL"]
+            add: ["NET_ADMIN"]
+    containers:
+      - name: sandbox
+        image: {{ $image }}
+        imagePullPolicy: {{ $pullPolicy }}
+        command: ["/workspace/entrypoint.sh"]
+        ports:
+          - { name: opencode, containerPort: {{ $opencodePort }} }
+          {{- range $p := untilStep $nextjsStart $nextjsEnd 1 }}
+          - { name: "nextjs-{{ $p }}", containerPort: {{ $p }} }
+          {{- end }}
+        env:
+          - { name: ONYX_PAT, value: "replaced_by_egress_proxy" }
+          - { name: ONYX_SERVER_URL, value: "{{ $serverUrl }}" }
+          - { name: GH_TOKEN, value: "replaced_by_egress_proxy" }
+          - { name: GH_NO_UPDATE_NOTIFIER, value: "1" }
+          {{- include "onyx.sandboxProxyEnv" (dict "proxyPort" $proxyPort "caBundleFile" $caBundleFile) | nindent 10 }}
+        volumeMounts:
+          - { name: workspace, mountPath: /workspace/sessions }
+          - { name: managed, mountPath: /workspace/managed, readOnly: true }
+          - { name: sandbox-ca-bundle, mountPath: /etc/ssl/sandbox, readOnly: true }
+        resources:
+          requests: { cpu: "{{ $cpuReq }}", memory: "{{ $memReq }}" }
+          limits: { cpu: "{{ $cpuLim }}", memory: "{{ $memLim }}" }
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
+          privileged: false
+          capabilities:
+            drop: ["ALL"]
+      - name: sidecar
+        image: {{ $image }}
+        imagePullPolicy: {{ $pullPolicy }}
+        command: ["/workspace/sidecar-entrypoint.sh"]
+        ports:
+          - { name: push-daemon, containerPort: {{ $pushDaemonPort }} }
+        env:
+          {{- include "onyx.sandboxProxyEnv" (dict "proxyPort" $proxyPort "caBundleFile" $caBundleFile) | nindent 10 }}
+        volumeMounts:
+          - { name: workspace, mountPath: /workspace/sessions }
+          - { name: managed, mountPath: /workspace/managed }
+          - { name: sandbox-ca-bundle, mountPath: /etc/ssl/sandbox, readOnly: true }
+        resources:
+          requests: { cpu: "100m", memory: "256Mi" }
+          limits: { cpu: "500m", memory: "512Mi" }
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
+          privileged: false
+          capabilities:
+            drop: ["ALL"]
+        livenessProbe:
+          httpGet: { path: /health, port: {{ $pushDaemonPort }} }
+          initialDelaySeconds: 5
+          periodSeconds: 30
+        readinessProbe:
+          httpGet: { path: /health, port: {{ $pushDaemonPort }} }
+          initialDelaySeconds: 1
+          periodSeconds: 2
+          failureThreshold: 10
+    volumes:
+      - name: workspace
+        emptyDir: { sizeLimit: 50Gi }
+      - name: managed
+        emptyDir: { sizeLimit: 5Gi }
+      - name: sandbox-ca-source
+        configMap:
+          name: {{ $caConfigMap }}
+          optional: false
+      - name: sandbox-ca-bundle
+        emptyDir: {}
+{{- end }}

--- a/deployment/helm/charts/onyx/templates/sandbox-rbac.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-rbac.yaml
@@ -34,6 +34,10 @@ rules:
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "list", "watch", "create", "delete"]
+  # _create_sandbox_pod reads the sandbox-pod PodTemplate to build the pod.
+  - apiGroups: [""]
+    resources: ["podtemplates"]
+    verbs: ["get"]
   - apiGroups: [""]
     resources: ["services"]
     verbs: ["get", "create", "delete"]

--- a/deployment/helm/charts/onyx/values-ci.yaml
+++ b/deployment/helm/charts/onyx/values-ci.yaml
@@ -10,6 +10,13 @@ configMap:
   # Placeholder; the K8s sandbox tests don't call back to it. Required to
   # satisfy the chart's fail() guard for ENABLE_CRAFT=true.
   SANDBOX_API_SERVER_URL: "http://api.invalid"
+  # Sandbox image the kind cluster pulls (built+pushed by the CI workflow).
+  SANDBOX_CONTAINER_IMAGE: "localhost:5001/onyx-sandbox:ci"
+  # Tiny requests so the 4 vCPU runner can fit 4 concurrent sandbox pods.
+  SANDBOX_POD_CPU_REQUEST: "100m"
+  SANDBOX_POD_MEMORY_REQUEST: "256Mi"
+  SANDBOX_POD_CPU_LIMIT: "2000m"
+  SANDBOX_POD_MEMORY_LIMIT: "4Gi"
 
 # Placeholder secret values so auth-secrets.yaml renders without erroring.
 # Postgres/Redis run in docker-compose alongside the kind

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1523,6 +1523,17 @@ craft:
   # Extra SAs (release ns) to also grant sandbox RBAC, e.g. a separate worker SA.
   extraBoundServiceAccounts: []
 
+# -- Sandbox Pod scheduling (rendered into the sandbox-pod PodTemplate).
+# Image/resources/ports come from the configMap.SANDBOX_* keys.
+sandboxPod:
+  nodeSelector:
+    onyx.app/workload: sandbox
+  tolerations:
+    - key: workload
+      operator: Equal
+      value: sandbox
+      effect: NoSchedule
+
 # -- Sandbox egress proxy.
 sandboxProxy:
   replicaCount: 2

--- a/docs/craft/sandbox/sandbox-exec-sidecar.md
+++ b/docs/craft/sandbox/sandbox-exec-sidecar.md
@@ -1,0 +1,136 @@
+# Move sandbox filesystem ops off `kubectl exec` onto the signed sidecar
+
+## Issues to Address
+
+`KubernetesSandboxManager` drives in-pod work through 14 `k8s_stream`
+(`connect_get_namespaced_pod_exec`) call sites. Most are filesystem operations
+implemented as interpolated shell scripts and parsed via stdout sentinels. This
+has three recurring problems:
+
+- **Shell-injection surface:** f-string scripts with hand-rolled quoting, e.g.
+  `agent_instructions.replace("'", "'\\''")` in `setup_session_workspace` and
+  `_regenerate_session_config`, and `content.replace("'", ...)` in
+  `write_sandbox_file`.
+- **Stdout-sentinel parsing:** behavior is derived from substring matches like
+  `"WORKSPACE_FOUND"`, `"ERROR_NOT_FOUND"`, `"DELETED"`, `"WRITE_OK"`,
+  `"EXISTS"`. This is the exact bug class that caused the
+  `"EXISTS" in "NOT_EXISTS"` substring failure in snapshot restore.
+- **Transport complexity:** exec runs over SPDY/WebSocket, which forced the
+  dual-`ApiClient` workaround (`_rest_api_client` vs `_stream_api_client`,
+  lines ~422-436) to avoid the streaming monkeypatch leaking into REST calls.
+
+The codebase already has the better channel: a signed HTTP sidecar daemon
+(`sandbox_daemon/server.py`, port 8731, Ed25519-verified) that shares the
+`workspace` and `managed` volumes read-write and already serves `/push`,
+`/snapshot/create`, `/snapshot/restore`. Snapshots and file pushes were already
+migrated off exec onto it. This plan finishes that migration for the remaining
+filesystem ops, hardens the small residual that must stay as exec, and adopts
+the **complementary split**: sidecar owns all filesystem/compute; exec is
+retained only for in-sandbox-container process control.
+
+## Important Notes
+
+- **Residual exec is exactly the Next.js dev-server lifecycle — 3 call sites:**
+  start (in `setup_session_workspace` line ~1668 and `restore_snapshot` line
+  ~2003) and kill (in `cleanup_session_workspace` line ~1737). The dev server
+  must run as a long-lived process *in the sandbox container* (it serves traffic
+  on that container's exposed port); the sidecar can't host or signal it because
+  `share_process_namespace=False`. Everything else moves to the sidecar.
+- **`bun install` can move to the sidecar.** The sidecar runs the same image, so
+  it has `bun`, and `node_modules` lands on the shared `workspace` volume. Only
+  the dev-server *process* is container-bound — not the install. This shrinks
+  residual exec to just start/stop.
+- **Audit of all 14 sites:**
+  - Filesystem → new sidecar endpoints: `session_workspace_exists` (3),
+    `list_session_workspaces` (4), `_regenerate_session_config` (6),
+    `list_directory` (7), `read_file` (8), `_ensure_agents_md_attachments_section`
+    (10), `delete_file` (12), `write_sandbox_file` (13), `get_upload_stats` (14),
+    and the filesystem halves of `setup_session_workspace` (1) and
+    `cleanup_session_workspace` (2).
+  - `upload_file` (11) is the only stdin-streaming exec; it tar-extracts into
+    `attachments/` — i.e. exactly what `/push` already does. Reuse/extend the
+    existing `/push` endpoint rather than adding a new one.
+  - `generate_pptx_preview` (9) runs `python preview.py` (soffice/pdftoppm).
+    Tools are in the shared image so it *can* run in the sidecar, but it is
+    CPU-heavy and the sidecar is capped at 500m CPU. Decision point: give it its
+    own sidecar endpoint with bumped sidecar limits, or leave it as a hardened
+    exec in the sandbox container. Recommend sidecar endpoint + raise the sidecar
+    CPU limit, to keep the "no filesystem exec" invariant clean.
+  - Residual (process control): the dev-server start/stop in sites 1, 2, 5.
+- **Honest tradeoffs of the complementary split** (chosen over sidecar-only):
+  because exec remains for the dev server, two benefits are NOT realized —
+  `pods/exec` stays in the sandbox-manager RBAC Role
+  (`deployment/helm/charts/onyx/templates/sandbox-rbac.yaml`; K8s can't scope
+  exec by command), and the dual-`ApiClient` workaround stays (it's required as
+  long as any `k8s_stream` exists). Both shrink to serving only 3 call sites. A
+  later sandbox-container control endpoint could remove them entirely if desired.
+- **Wire-schema location:** request/response models go in
+  `sandbox_daemon/models.py` (the daemon imports `sandbox_daemon.models`; the
+  api-server imports the full
+  `onyx.server.features.build.sandbox.image.sandbox_daemon.models` path). This is
+  the existing shared-contract pattern — both ends stay in sync.
+- **Reuse the existing client plumbing** on the api-server side:
+  `_signed_sidecar_headers` + `_sandbox_pod_hosts` (Service FQDN, then pod-IP
+  fallback for out-of-cluster CI), exactly as `create_snapshot` /
+  `write_files_to_sandbox` do today.
+- **Sidecar requires no new privilege** — it already mounts both volumes RW.
+- **Image build:** the residual exec uses a baked script (below), so the sandbox
+  image (`image/Dockerfile`) changes — coordinate the `SANDBOX_CONTAINER_IMAGE`
+  bump, and note the daemon endpoints also ship in that image.
+
+## Implementation Strategy
+
+1. **Add typed models** to `sandbox_daemon/models.py` for each new operation
+   (session setup, cleanup, list-sessions, exists, list-directory, read-file,
+   delete-file, write-file, upload-stats, ensure-attachments, regenerate-config,
+   pptx-preview). Structured request bodies + JSON responses replace every
+   stdout sentinel.
+
+2. **Add signed endpoints** to `sandbox_daemon/server.py`, each guarded by the
+   existing `_verify_signature` pattern. Implement the filesystem logic in the
+   daemon (it can `import` and reuse helpers rather than shell out). Extend
+   `/push` (or add a sibling) to cover `upload_file`'s tar-extract-with-collision
+   semantics. Decide pptx-preview placement per the note above.
+
+3. **Add a baked dev-server script** to the image, e.g.
+   `/workspace/session-dev-server.sh start|stop <session_path> <port>`,
+   containing today's `_build_nextjs_start_script` logic plus the PID-kill from
+   cleanup. Exec it with **positional args only** — no interpolation. This
+   removes the last f-string exec and the `agent_instructions` quoting (AGENTS.md
+   is now written via the sidecar).
+
+4. **Rewrite the api-server methods** to call the sidecar over `httpx`
+   (reusing `_signed_sidecar_headers` / `_sandbox_pod_hosts`) and to return
+   typed results. Split `setup_session_workspace` into: sidecar `/session/setup`
+   (mkdir/cp/symlink/AGENTS.md/bun-cache/bun-install) → hardened exec
+   `session-dev-server.sh start`. Split `cleanup_session_workspace` into:
+   hardened exec `session-dev-server.sh stop` → sidecar `/session/cleanup`
+   (`rm -rf`). `restore_snapshot` keeps the hardened dev-server-start exec and
+   moves `_regenerate_session_config` to the sidecar.
+
+5. **Delete** `_parse_ls_output` stdout parsing, the sentinel checks, and the
+   per-method inline scripts as their callers move to typed responses. Keep
+   `_stream_api_client` and the 3 residual exec call sites.
+
+6. **Leave RBAC unchanged** (`pods/exec` still needed for the dev-server). Add a
+   code comment at the residual exec sites noting they are the only remaining
+   exec users and why.
+
+## Tests
+
+- **Integration test (kind, primary):** for a provisioned sandbox, exercise the
+  migrated round-trips end-to-end through the sidecar — `setup_session_workspace`
+  then `session_workspace_exists`/`list_session_workspaces`, `write_sandbox_file`
+  + `read_file`, `upload_file` + `get_upload_stats` + `delete_file`,
+  `list_directory`, and `restore_snapshot`. Assert the dev server still comes up
+  (residual exec path) and the webapp URL responds.
+- **Daemon unit tests (sidecar):** for each new endpoint, test signature
+  rejection (bad/expired signature → 401) and the success/not-found/error paths
+  return structured status codes — explicitly covering the cases that used to be
+  stdout sentinels (e.g. missing file → 404, not a substring match).
+- **Regression guard:** a test asserting `session_workspace_exists` returns the
+  correct boolean for both an existing and a non-existing session — the
+  `"EXISTS" in "NOT_EXISTS"` bug class — now via a typed response.
+
+Prefer the kind integration test as the backbone; add daemon unit tests only for
+the signature/error-path logic that integration can't cleanly force.

--- a/docs/craft/sandbox/sandbox-podtemplate.md
+++ b/docs/craft/sandbox/sandbox-podtemplate.md
@@ -1,0 +1,121 @@
+# Codify the sandbox Pod spec into Helm (PodTemplate)
+
+## Issues to Address
+
+The per-sandbox Pod spec is constructed field-by-field in Python
+(`KubernetesSandboxManager._create_sandbox_pod`, ~230 lines). Everything in it
+except a handful of per-pod values is static infrastructure config — container
+images, ports, volumes, security contexts, init/sidecar containers, node
+selector, tolerations, resource sizing, proxy CA wiring. This duplicates what
+Helm already owns for the rest of the sandbox stack (namespace, RBAC, network
+policy, egress proxy — all in `deployment/helm/charts/onyx/templates/`) and
+means any change to the pod's shape requires a backend image rebuild + deploy
+rather than a `helm upgrade`.
+
+Goal: move the static shape of the sandbox Pod into a Helm-rendered
+`core/v1` **PodTemplate**, leaving Python to read it and overlay only the
+genuinely dynamic per-pod fields.
+
+## Important Notes
+
+- **Why PodTemplate, not a plain resource:** the Pod is created per-user at
+  request time, so it can't be a static Helm Pod. `core/v1 PodTemplate` is the
+  typed, first-class K8s object designed exactly for "declare the shape at
+  deploy time, instantiate at runtime." Prefer it over a ConfigMap-carried YAML
+  (untyped, unvalidated).
+- **Only four fields are dynamic** and must stay in Python:
+  1. `metadata.name` (`sandbox-{uuid[:8]}`)
+  2. `metadata.labels` — `LABEL_SANDBOX_ID`, `LABEL_TENANT_ID` merged onto the
+     template's base labels
+  3. the two `secretKeyRef.name` env entries on the sandbox container, pointing
+     at the per-pod `{pod}-opencode-auth` Secret
+  4. `spec.hostAliases[0].ip` — the proxy ClusterIP resolved at runtime by
+     `_resolve_proxy_ip()` (DNS to the proxy is blocked by the firewall, so this
+     can't be static)
+- **Everything else is static** and moves into the template: both containers
+  (`sandbox` + `sidecar`), the `sandbox-init` init container (NET_ADMIN +
+  `firewall-init.sh`), `workspace`/`managed` emptyDirs, CA source/bundle
+  volumes, pod + container security contexts, `nodeSelector`,
+  `tolerations`, `enableServiceLinks: false`, probes, and the proxy env
+  constants from `_proxy_main_container_env_vars()` /
+  `_proxy_init_container()`.
+- **The Service stays in Python.** K8s has no `ServiceTemplate` object, and
+  `_create_sandbox_service` is ~30 lines (names + the Next.js port range). Do
+  NOT try to template it. Instead single-source the port range
+  (`SANDBOX_NEXTJS_PORT_START`/`END`) so the template's container/service ports
+  and the Python service can't drift.
+- **Resource sizing is already half-codified** via `SANDBOX_POD_CPU_REQUEST`
+  etc. (`configs.py`), injected from the Helm ConfigMap. These move into the
+  PodTemplate values and the env vars in `configs.py` are retired (or kept only
+  as the template's value source — pick one source of truth, prefer the
+  template).
+- **Image ownership:** `SANDBOX_CONTAINER_IMAGE` default lives in `configs.py`
+  today and is referenced for all three containers. Once the template owns the
+  image, the chart is the single source; the api-server no longer needs the
+  value except possibly for logging.
+- **Version skew is the main risk.** A PodTemplate rendered by an older chart
+  against a newer api-server (or vice versa). The overlay code must be
+  defensive — append the secret-env entries and hostAliases in Python rather
+  than assuming list indices in the template. Keep the template free of any
+  per-pod knowledge (no placeholder secret names to find-and-replace).
+- **New runtime dependency / failure mode:** the api-server now requires the
+  PodTemplate to exist in `SANDBOX_NAMESPACE` at provision time. Add a clear
+  error (and ideally a one-time startup check when `ENABLE_CRAFT` +
+  `SANDBOX_BACKEND=kubernetes`) so a missing/misnamed template fails loudly
+  rather than deep inside `provision()`.
+- Gate the new template on `ENABLE_CRAFT` via the existing
+  `onyx.craftEnabled` helper in `_helpers.tpl`, matching the other sandbox
+  templates.
+
+## Implementation Strategy
+
+1. **Add `templates/sandbox-podtemplate.yaml`** rendering a `v1/PodTemplate`
+   named e.g. `sandbox-pod` into `SANDBOX_NAMESPACE`. Its `.template.spec` is
+   the full static pod spec; `.template.metadata.labels` carries the static
+   labels (`LABEL_K8S_COMPONENT`, `LABEL_K8S_MANAGED_BY`). Drive all tunables
+   from a new `sandboxPod:` block in `values.yaml`.
+
+2. **Add the `sandboxPod:` values block** exposing: `image`, `imagePullPolicy`,
+   the Next.js port range, the three resource sets (sandbox / sidecar / init),
+   `nodeSelector`, `tolerations`, and CA mount config. Wire CI/localdev
+   overlays (`values-ci.yaml`, `values-localdev.yaml`) — CI overrides the
+   resource requests for the 4-vCPU kind runner exactly as the env vars do
+   today.
+
+3. **Rewrite `_create_sandbox_pod`** to:
+   `read_namespaced_pod_template(name, SANDBOX_NAMESPACE)` →
+   `copy.deepcopy(tpl.template.spec)` → overlay the four dynamic fields →
+   return `V1Pod(metadata=..., spec=...)`. Delete the static construction.
+   Keep `_proxy_init_container`/`_proxy_main_container_env_vars` only if still
+   referenced; otherwise remove.
+
+4. **Single-source the port range** between the template and
+   `_create_sandbox_service` (config constant feeding both). Leave the Service
+   construction in Python.
+
+5. **Add a startup/preflight check** that the PodTemplate exists when
+   `ENABLE_CRAFT` and the K8s backend are active, raising a clear error
+   naming the expected template + namespace.
+
+6. **Retire** the now-template-owned env vars from `configs.py`
+   (`SANDBOX_POD_CPU_*`, `SANDBOX_POD_MEMORY_*`, and the image default if fully
+   migrated), updating any other readers.
+
+## Tests
+
+- **Integration test (kind, primary):** provision a sandbox against the kind
+  cluster (see the existing kind integration-test env in CLAUDE.md / memory) and
+  assert the resulting Pod has the expected containers, volumes, security
+  context, node selector, the correct `secretKeyRef` names, and a resolved
+  `hostAliases` IP. This is the real coverage — it exercises template-read +
+  overlay end to end.
+- **Helm:** `helm template` + lint with `ENABLE_CRAFT=true` across
+  default/CI/localdev values to confirm the PodTemplate renders and the
+  resource/port values flow through. Confirm it does NOT render when
+  `ENABLE_CRAFT` is false.
+- **External-dependency unit test (optional):** mock `read_namespaced_pod_template`
+  to return a known template and assert the overlay sets exactly the four
+  dynamic fields and nothing else — guards the version-skew contract.
+
+Do not overtest — the kind integration test plus helm template lint is the core
+of the coverage.


### PR DESCRIPTION
## Description

Codifies the per-user sandbox Pod spec into the Helm chart, moving it out of `kubernetes_sandbox_manager.py`.

- **New `templates/sandbox-podtemplate.yaml`** renders a `core/v1` PodTemplate (`sandbox-pod`) into `SANDBOX_NAMESPACE`, gated on `ENABLE_CRAFT`. It carries the full static pod shape: both containers, the `sandbox-init` init container, volumes, security contexts, probes, proxy env, and node selection.
- **`_create_sandbox_pod` shrinks ~280→~95 lines**: it reads the PodTemplate via `read_namespaced_pod_template` and overlays only the dynamic per-pod fields — name, sandbox/tenant labels, the per-pod opencode-auth `secretKeyRef` env, the sidecar push public key, and the resolved proxy `hostAliases` IP. Missing template raises a clear, actionable error.
- **Backward compatible**: the template reads the same `configMap.SANDBOX_*` keys the env-var path used, so existing CI / craft-dev / prod overlays work unchanged. No `cloud-deployment-yamls` changes required.
- Pod resource sizing moves to `values-ci.yaml` (`configMap.SANDBOX_POD_*`); the now-dead `SANDBOX_POD_*` constants are retired from `configs.py`. The K8s CI lane renders + applies the new template.
- The existing pod-spec invariant suite now renders the actual chart template and feeds it through the overlay, so it verifies the Helm→Python path end to end.

## How Has This Been Tested?

- `pytest backend/tests/unit/.../test_pod_spec.py` — 16/16 invariants pass against the rendered PodTemplate + overlay; full sandbox unit dir: 344 passed (10 pre-existing event-bus DB-harness failures, unrelated — confirmed identical with changes stashed).
- `helm lint` + `helm template --show-only` clean under default, `values-ci.yaml`, and craft-dev prod values (correct SA, image, pull policy).
- `ruff` + `ty` clean on all touched Python.
- Live `kind-onyx-dev`: applied the rendered PodTemplate, ran the real manager code to read + overlay it, and the resulting Pod passed server-side validation (`kubectl apply --dry-run=server`).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the sandbox Pod spec into a Helm-managed PodTemplate so pod-shape changes ship via `helm upgrade`; the manager now reads the template and overlays only per-pod fields.

- **Refactors**
  - Added `templates/sandbox-podtemplate.yaml` with the full static pod shape; single-sourced proxy env and push-daemon port via `templates/_helpers.tpl`, exposed scheduling knobs under `values.sandboxPod`, and raised sidecar limits to 1 CPU / 1Gi.
  - Manager deep-copies the template and overlays only per-pod fields via `_overlay_dynamic_fields`; clear, deploy-tool-agnostic errors for missing PodTemplate or expected containers (`_require_container`). Tests render the chart PodTemplate and verify the Python overlay end to end; chart bumped to `0.5.23`.
  - Granted `podtemplates:get` to the sandbox-manager Role; moved sandbox resource sizing to chart values (`values*.yaml`) and retired `SANDBOX_POD_*` from `configs.py`. CI now templates the new PodTemplate.

- **Migration**
  - Run `helm upgrade` with `ENABLE_CRAFT=true` to render `sandbox-pod` in `SANDBOX_NAMESPACE`. Set image/resources via chart values and drop env-based overrides. Apply the PodTemplate and RBAC with your deploy tooling before provisioning sandboxes.

<sup>Written for commit 3e5b0f8cb57919e90e955a3dd54b376628326191. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

