### PR TITLE
feat(craft): enforce snapshot retention and skip unchanged snapshots

### DIFF
--- a/backend/alembic/versions/eefb92217285_add_snapshot_tree_digest.py
+++ b/backend/alembic/versions/eefb92217285_add_snapshot_tree_digest.py
@@ -1,0 +1,28 @@
+"""add snapshot tree_digest
+
+Revision ID: eefb92217285
+Revises: 1cb59a95b250
+Create Date: 2026-06-11 09:21:40.264488
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "eefb92217285"
+down_revision = "1cb59a95b250"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "snapshot",
+        sa.Column("tree_digest", sa.String(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("snapshot", "tree_digest")

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5453,6 +5453,8 @@ class Snapshot(Base):
     )
     storage_path: Mapped[str] = mapped_column(String, nullable=False)
     size_bytes: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
+    # Digest of the snapshot tree; lets the next snapshot skip an unchanged workspace.
+    tree_digest: Mapped[str | None] = mapped_column(String, nullable=True)
     created_at: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/backend/onyx/server/features/build/configs.py
+++ b/backend/onyx/server/features/build/configs.py
@@ -32,6 +32,12 @@ SANDBOX_MAX_CONCURRENT_PER_ORG = int(
     os.environ.get("SANDBOX_MAX_CONCURRENT_PER_ORG", "10")
 )
 
+# Snapshot retention: snapshots older than this are pruned, except the newest
+# SNAPSHOT_KEEP_LAST_N per session (the most recent is always kept so a
+# session's workspace is never orphaned).
+SNAPSHOT_RETENTION_DAYS = int(os.environ.get("SNAPSHOT_RETENTION_DAYS", "30"))
+SNAPSHOT_KEEP_LAST_N = int(os.environ.get("SNAPSHOT_KEEP_LAST_N", "3"))
+
 SANDBOX_NEXTJS_PORT_START = int(os.environ.get("SANDBOX_NEXTJS_PORT_START", "3010"))
 SANDBOX_NEXTJS_PORT_END = int(os.environ.get("SANDBOX_NEXTJS_PORT_END", "3100"))
 

--- a/backend/onyx/server/features/build/db/sandbox.py
+++ b/backend/onyx/server/features/build/db/sandbox.py
@@ -205,6 +205,7 @@ def create_snapshot__no_commit(
     session_id: UUID,
     storage_path: str,
     size_bytes: int,
+    tree_digest: str | None = None,
 ) -> Snapshot:
     """Create a snapshot record for a session.
 
@@ -216,6 +217,7 @@ def create_snapshot__no_commit(
         session_id=session_id,
         storage_path=storage_path,
         size_bytes=size_bytes,
+        tree_digest=tree_digest,
     )
     db_session.add(snapshot)
     db_session.flush()
@@ -245,35 +247,34 @@ def get_snapshots_for_session(db_session: Session, session_id: UUID) -> list[Sna
     return list(db_session.execute(stmt).scalars().all())
 
 
-def delete_old_snapshots(
+def get_prunable_snapshots(
     db_session: Session,
-    tenant_id: str,  # noqa: ARG001
     retention_days: int,
-) -> int:
-    """Delete snapshots older than retention period, return count deleted.
+    keep_last_n: int,
+) -> list[Snapshot]:
+    """Return snapshots eligible for deletion under the retention policy.
 
-    Note: tenant_id parameter is kept for API compatibility but is not used
-    since Snapshot model no longer has tenant_id. This function deletes
-    all snapshots older than the retention period.
+    Keeps each session's ``keep_last_n`` most recent snapshots (the newest is
+    the always-kept workspace anchor) and prunes older surplus beyond
+    ``retention_days``. The caller deletes the file-store blobs and DB rows.
     """
     cutoff_time = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
         days=retention_days
     )
-
-    stmt = select(Snapshot).where(
-        Snapshot.created_at < cutoff_time,
+    rank = func.row_number().over(
+        partition_by=Snapshot.session_id,
+        order_by=Snapshot.created_at.desc(),
     )
-    old_snapshots = db_session.execute(stmt).scalars().all()
-
-    count = 0
-    for snapshot in old_snapshots:
-        db_session.delete(snapshot)
-        count += 1
-
-    if count > 0:
-        db_session.commit()
-
-    return count
+    ranked = select(Snapshot.id, Snapshot.created_at, rank.label("rank")).subquery()
+    prunable_ids = select(ranked.c.id).where(
+        ranked.c.rank > 1,
+        or_(ranked.c.rank > keep_last_n, ranked.c.created_at < cutoff_time),
+    )
+    return list(
+        db_session.execute(select(Snapshot).where(Snapshot.id.in_(prunable_ids)))
+        .scalars()
+        .all()
+    )
 
 
 def delete_snapshot(db_session: Session, snapshot_id: UUID) -> bool:

--- a/backend/onyx/server/features/build/sandbox/base.py
+++ b/backend/onyx/server/features/build/sandbox/base.py
@@ -214,8 +214,15 @@ class SandboxManager(_ServeMixin, ABC):
         sandbox_id: UUID,
         session_id: UUID,
         tenant_id: str,
+        previous_digest: str | None = None,
     ) -> SnapshotResult | None:
         """Create a snapshot of a session's outputs and attachments directories.
+
+        ``previous_digest`` is the tree digest of the session's most recent
+        snapshot, if any. Backends that support it compute the current
+        workspace digest and, when it matches, skip re-archiving and return a
+        SnapshotResult with ``unchanged=True`` so the caller reuses the prior
+        snapshot.
 
         Captures session-specific user data:
         - sessions/$session_id/outputs/ (generated artifacts, web apps)

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -1095,6 +1095,7 @@ echo "Session cleanup complete"
         sandbox_id: UUID,
         session_id: UUID,
         tenant_id: str,
+        previous_digest: str | None = None,
     ) -> SnapshotResult | None:
         container = self._get_container(sandbox_id)
         if container is None:
@@ -1117,6 +1118,10 @@ echo "Session cleanup complete"
             return None
         if "OK" not in probe.stdout_text:
             return None
+
+        tree_digest = self._session_tree_digest(container, session_path)
+        if tree_digest is not None and tree_digest == previous_digest:
+            return SnapshotResult(storage_path="", size_bytes=0, unchanged=True)
 
         # Stream tar bytes out of the container through FileStore.
         tar_cmd = [
@@ -1152,7 +1157,37 @@ echo "Session cleanup complete"
             session_id,
             size_bytes,
         )
-        return SnapshotResult(storage_path=storage_path, size_bytes=size_bytes)
+        return SnapshotResult(
+            storage_path=storage_path, size_bytes=size_bytes, tree_digest=tree_digest
+        )
+
+    def _session_tree_digest(
+        self, container: Container, session_path: str
+    ) -> str | None:
+        """Digest of the session's snapshotted tree (file path/size/mtime).
+
+        Mirrors the archived set (outputs/attachments/.opencode-data, minus
+        regenerable node_modules/.next), so an unchanged workspace yields the
+        same digest across sleep/wake -- tar -x preserves mtimes on restore.
+
+        Best-effort: this only feeds the skip-unchanged optimization, so any
+        failure returns None and the caller snapshots normally.
+        """
+        cmd = (
+            f"cd {session_path} && {{ "
+            "for d in outputs attachments .opencode-data; do "
+            '[ -d "$d" ] && find "$d" \\( -name node_modules -o -name .next \\) '
+            "-prune -o -type f -exec stat -c '%n %s %Y' {} + ; "
+            "done; } | LC_ALL=C sort | sha256sum | awk '{print $1}'"
+        )
+        try:
+            digest = run_in_container(
+                container, ["/bin/sh", "-c", cmd]
+            ).stdout_text.strip()
+        except ExecError as e:
+            logger.warning("snapshot digest failed for %s: %s", session_path, e)
+            return None
+        return digest or None
 
     def restore_snapshot(
         self,

--- a/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/server.py
+++ b/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/server.py
@@ -22,7 +22,7 @@ from fastapi.responses import StreamingResponse
 from sandbox_daemon.extract import MAX_BUNDLE_BYTES
 from sandbox_daemon.extract import safe_extract_then_atomic_swap
 from sandbox_daemon.models import SnapshotCreateRequest
-from sandbox_daemon.snapshot import has_snapshot_content
+from sandbox_daemon.snapshot import compute_snapshot_digest
 from sandbox_daemon.snapshot import iter_snapshot_archive
 from sandbox_daemon.snapshot import MAX_SNAPSHOT_ARCHIVE_BYTES
 from sandbox_daemon.snapshot import restore_snapshot
@@ -138,6 +138,7 @@ async def snapshot_create(
     request: Request,
     x_push_signature: str = Header(..., alias="X-Push-Signature"),
     x_push_timestamp: str = Header(..., alias="X-Push-Timestamp"),
+    if_none_match: str | None = Header(None, alias="If-None-Match"),
 ) -> Response:
     body = await request.body()
     _verify_signature(
@@ -153,18 +154,23 @@ async def snapshot_create(
         raise HTTPException(status_code=400, detail=f"Invalid request body: {e}")
 
     try:
-        has_content = await asyncio.to_thread(has_snapshot_content, payload.session_id)
+        digest = await asyncio.to_thread(compute_snapshot_digest, payload.session_id)
     except SnapshotError as e:
         raise HTTPException(status_code=500, detail=f"Snapshot create failed: {e}")
     except OSError as e:
         raise HTTPException(status_code=500, detail=f"Snapshot create OS error: {e}")
 
-    if not has_content:
+    if digest is None:
         return Response(status_code=204)
+
+    # ETag conditional request: matching digest => workspace unchanged, skip archiving.
+    if if_none_match is not None and if_none_match == digest:
+        return Response(status_code=304)
 
     return StreamingResponse(
         iter_snapshot_archive(payload.session_id),
         media_type="application/gzip",
+        headers={"ETag": digest},
     )
 
 

--- a/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/snapshot.py
+++ b/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/snapshot.py
@@ -4,6 +4,7 @@ The sidecar owns pod-local filesystem access. The api-server owns durable
 storage by streaming these tarballs into/out of the main Onyx FileStore.
 """
 
+import hashlib
 import logging
 import os
 import shutil
@@ -330,10 +331,57 @@ def _extract_snapshot_archive(archive_path: Path, session_path: Path) -> None:
                     with src, final_path.open("wb") as out_file:
                         shutil.copyfileobj(src, out_file)
                     os.chmod(final_path, (member.mode or 0o644) & 0o777)
+                    # Preserve mtime so compute_snapshot_digest stays stable
+                    # across sleep/wake and unchanged workspaces skip re-snapshot.
+                    os.utime(final_path, (member.mtime, member.mtime))
 
             _replace_snapshot_roots(session_path, staging_path, roots)
     except (tarfile.TarError, OSError) as e:
         raise SnapshotError(f"invalid snapshot archive: {e}") from e
+
+
+def compute_snapshot_digest(session_id: UUID) -> str | None:
+    """Return a stable digest of the snapshot tree, or None if nothing to snapshot.
+
+    The digest covers each archived regular file's session-relative path, size,
+    and integer mtime. tar stores mtimes at 1-second granularity and restore
+    re-applies them, so an unchanged workspace produces the same digest across
+    sleep/wake cycles -- letting the caller skip re-snapshotting identical state.
+    Generated dirs, symlinks, hardlinks and special files are excluded to match
+    what ``iter_snapshot_archive`` actually writes.
+    """
+    session_path = _safe_session_path(session_id, create=False)
+    dirs = _snapshot_dirs(session_path)
+    if not dirs:
+        return None
+
+    entries: list[tuple[str, int, int]] = []
+    for dirname in dirs:
+        root_path = session_path / dirname
+        for dirpath, dirnames, filenames in os.walk(root_path, followlinks=False):
+            current = Path(dirpath)
+            dirnames[:] = [
+                d
+                for d in dirnames
+                if not _is_excluded_snapshot_dir(
+                    (current / d).relative_to(session_path)
+                )
+            ]
+            for filename in filenames:
+                entry = current / filename
+                relative = entry.relative_to(session_path)
+                try:
+                    st = entry.lstat()
+                except OSError:
+                    continue
+                if _snapshot_entry_skip_reason(relative, st.st_mode, st.st_nlink):
+                    continue
+                entries.append((relative.as_posix(), st.st_size, int(st.st_mtime)))
+
+    hasher = hashlib.sha256()
+    for rel, size, mtime in sorted(entries):
+        hasher.update(f"{rel}\0{size}\0{mtime}\0".encode("utf-8"))
+    return hasher.hexdigest()
 
 
 def has_snapshot_content(session_id: UUID) -> bool:

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -1595,6 +1595,7 @@ echo "Session cleanup complete"
         sandbox_id: UUID,
         session_id: UUID,
         tenant_id: str,
+        previous_digest: str | None = None,
     ) -> SnapshotResult | None:
         """Create a FileStore-backed snapshot via the sidecar filesystem API.
 
@@ -1603,7 +1604,8 @@ echo "Session cleanup complete"
         - sessions/$session_id/attachments/
         - sessions/$session_id/.opencode-data/
 
-        Returns None if there are no outputs to snapshot.
+        Returns None if there are no outputs to snapshot, or a SnapshotResult
+        with ``unchanged=True`` when the workspace matches ``previous_digest``.
         """
         body = SnapshotCreateRequest(session_id=session_id).model_dump_json().encode()
         sha256_hex = hashlib.sha256(body).hexdigest()
@@ -1616,16 +1618,19 @@ echo "Session cleanup complete"
                 sha256_hex=sha256_hex,
                 content_type="application/json",
             )
+            if previous_digest is not None:
+                headers["If-None-Match"] = previous_digest
             url = f"http://{host}:{PUSH_DAEMON_PORT}/snapshot/create"
             try:
                 with httpx.Client(timeout=timeout) as http_client:
                     with http_client.stream(
                         "POST", url, content=body, headers=headers
                     ) as resp:
-                        if resp.status_code == 204:
-                            logger.info(
-                                "No outputs to snapshot for session %s", session_id
+                        if resp.status_code == 304:
+                            return SnapshotResult(
+                                storage_path="", size_bytes=0, unchanged=True
                             )
+                        if resp.status_code == 204:
                             return None
                         if resp.status_code != 200:
                             detail = resp.read().decode(errors="replace")
@@ -1633,6 +1638,7 @@ echo "Session cleanup complete"
                                 f"Snapshot create failed: {resp.status_code} {detail}"
                             )
 
+                        tree_digest = resp.headers.get("ETag")
                         adapter = _IteratorReader(
                             resp.iter_bytes(chunk_size=_SNAPSHOT_CHUNK_SIZE)
                         )
@@ -1643,16 +1649,10 @@ echo "Session cleanup complete"
                                 tenant_id=tenant_id,
                             )
                         )
-
-                        logger.info(
-                            "Created snapshot for sandbox %s session %s (size=%s bytes).",
-                            sandbox_id,
-                            session_id,
-                            size_bytes,
-                        )
                         return SnapshotResult(
                             storage_path=storage_path,
                             size_bytes=size_bytes,
+                            tree_digest=tree_digest,
                         )
             except httpx.TransportError as e:
                 last_exc = e

--- a/backend/onyx/server/features/build/sandbox/models.py
+++ b/backend/onyx/server/features/build/sandbox/models.py
@@ -44,6 +44,9 @@ class SnapshotResult(BaseModel):
 
     storage_path: str
     size_bytes: int
+    tree_digest: str | None = None
+    # True when unchanged since the prior digest; no new snapshot was created.
+    unchanged: bool = False
 
 
 class SnapshotInfo(BaseModel):

--- a/backend/onyx/server/features/build/sandbox/tasks/tasks.py
+++ b/backend/onyx/server/features/build/sandbox/tasks/tasks.py
@@ -11,17 +11,19 @@ from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.redis.redis_pool import get_redis_client
 from onyx.redis.redis_tenant_work_gating import maybe_mark_tenant_active
 from onyx.server.features.build.configs import SANDBOX_IDLE_TIMEOUT_SECONDS
+from onyx.server.features.build.configs import SNAPSHOT_KEEP_LAST_N
+from onyx.server.features.build.configs import SNAPSHOT_RETENTION_DAYS
 from onyx.server.features.build.db.build_session import clear_nextjs_ports_for_user
 from onyx.server.features.build.db.build_session import (
     mark_user_sessions_idle__no_commit,
 )
 from onyx.server.features.build.sandbox.base import get_sandbox_manager
 
-# Snapshot retention period in days
-SNAPSHOT_RETENTION_DAYS = 30
-
 # 100 minutes - snapshotting can take time
 TIMEOUT_SECONDS = 6000
+
+# Snapshot pruning is I/O-light; cap its runtime well under the beat cadence.
+SNAPSHOT_CLEANUP_TIMEOUT_SECONDS = 600
 
 
 @shared_task(
@@ -61,6 +63,9 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
         from onyx.db.enums import SandboxStatus
         from onyx.server.features.build.db.sandbox import create_snapshot__no_commit
         from onyx.server.features.build.db.sandbox import get_idle_sandboxes
+        from onyx.server.features.build.db.sandbox import (
+            get_latest_snapshot_for_session,
+        )
         from onyx.server.features.build.db.sandbox import (
             update_sandbox_status__no_commit,
         )
@@ -107,16 +112,27 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
                             task_logger.debug(
                                 f"Creating snapshot for session {session_id}"
                             )
-                            snapshot_result = sandbox_manager.create_snapshot(
-                                sandbox_id, session_id, tenant_id
+                            latest = get_latest_snapshot_for_session(
+                                db_session, session_id
                             )
-                            if snapshot_result:
-                                # Create DB record for the snapshot
+                            snapshot_result = sandbox_manager.create_snapshot(
+                                sandbox_id,
+                                session_id,
+                                tenant_id,
+                                previous_digest=latest.tree_digest if latest else None,
+                            )
+                            if snapshot_result and snapshot_result.unchanged:
+                                task_logger.debug(
+                                    f"Workspace unchanged for session {session_id}; "
+                                    f"reusing prior snapshot"
+                                )
+                            elif snapshot_result:
                                 create_snapshot__no_commit(
                                     db_session,
                                     session_id,
                                     snapshot_result.storage_path,
                                     snapshot_result.size_bytes,
+                                    tree_digest=snapshot_result.tree_digest,
                                 )
                                 task_logger.debug(
                                     f"Snapshot created for session {session_id}"
@@ -186,3 +202,76 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
             lock.release()
 
     task_logger.info("cleanup_idle_sandboxes_task completed")
+
+
+@shared_task(
+    name=OnyxCeleryTask.CLEANUP_OLD_SNAPSHOTS,
+    soft_time_limit=SNAPSHOT_CLEANUP_TIMEOUT_SECONDS,
+    bind=True,
+    ignore_result=True,
+)
+def cleanup_old_snapshots_task(self: Task, *, tenant_id: str) -> None:  # noqa: ARG001
+    """Prune expired/excess session snapshots from the file store and DB.
+
+    Enforces SNAPSHOT_RETENTION_DAYS + SNAPSHOT_KEEP_LAST_N (see
+    onyx.server.features.build.db.sandbox.get_prunable_snapshots). The most
+    recent snapshot per session is always retained so a workspace is never
+    orphaned. Blobs are deleted before their DB rows: if a blob delete fails,
+    the row is left in place and retried next cycle, so we never leak storage.
+    """
+    redis_client = get_redis_client(tenant_id=tenant_id)
+    lock: RedisLock = redis_client.lock(
+        OnyxRedisLocks.CLEANUP_OLD_SNAPSHOTS_BEAT_LOCK,
+        timeout=SNAPSHOT_CLEANUP_TIMEOUT_SECONDS,
+    )
+
+    if not lock.acquire(blocking=False):
+        task_logger.info("cleanup_old_snapshots_task - lock not acquired, skipping")
+        return
+
+    try:
+        from onyx.file_store.file_store import get_default_file_store
+        from onyx.server.features.build.db.sandbox import get_prunable_snapshots
+        from onyx.server.features.build.sandbox.manager.snapshot_manager import (
+            SnapshotManager,
+        )
+
+        snapshot_manager = SnapshotManager(get_default_file_store())
+
+        with get_session_with_current_tenant() as db_session:
+            prunable = get_prunable_snapshots(
+                db_session,
+                retention_days=SNAPSHOT_RETENTION_DAYS,
+                keep_last_n=SNAPSHOT_KEEP_LAST_N,
+            )
+
+            if not prunable:
+                task_logger.debug("No snapshots to prune")
+                return
+
+            maybe_mark_tenant_active(tenant_id, caller="snapshot_cleanup")
+            task_logger.info(f"Pruning {len(prunable)} expired/excess snapshots")
+
+            deleted = 0
+            for snapshot in prunable:
+                try:
+                    snapshot_manager.delete_snapshot(snapshot.storage_path)
+                except Exception as e:
+                    task_logger.warning(
+                        f"Skipping snapshot {snapshot.id}; blob delete failed "
+                        f"(will retry next cycle): {e}"
+                    )
+                    continue
+                db_session.delete(snapshot)
+                deleted += 1
+
+            db_session.commit()
+            task_logger.info(f"Pruned {deleted} snapshots")
+
+    except Exception:
+        task_logger.exception("Error in cleanup_old_snapshots_task")
+        raise
+
+    finally:
+        if lock.owned():
+            lock.release()

--- a/backend/tests/common/craft/stubs.py
+++ b/backend/tests/common/craft/stubs.py
@@ -301,12 +301,14 @@ class StubSandboxManager(SandboxManager):
         sandbox_id: UUID,
         session_id: UUID,
         tenant_id: str,
+        previous_digest: str | None = None,
     ) -> SnapshotResult | None:
         self.create_snapshot_count += 1
         self.last_create_snapshot_payload = {
             "sandbox_id": sandbox_id,
             "session_id": session_id,
             "tenant_id": tenant_id,
+            "previous_digest": previous_digest,
         }
         if self.create_snapshot_returns is _UNSET:
             raise _not_configured("create_snapshot")

--- a/backend/tests/external_dependency_unit/craft/test_snapshot_retention.py
+++ b/backend/tests/external_dependency_unit/craft/test_snapshot_retention.py
@@ -1,0 +1,66 @@
+"""Retention selection (keep-last-N + age expiry) against a real DB."""
+
+import datetime
+from uuid import UUID
+from uuid import uuid4
+
+from sqlalchemy.orm import Session
+
+from onyx.db.models import BuildSession
+from onyx.db.models import Snapshot
+from onyx.server.features.build.db.sandbox import get_prunable_snapshots
+
+
+def _make_session_with_snapshots(db_session: Session, ages_days: list[int]) -> UUID:
+    session = BuildSession(id=uuid4(), name="RETENTION-TEST")
+    db_session.add(session)
+    db_session.flush()
+    now = datetime.datetime.now(datetime.timezone.utc)
+    for age in ages_days:
+        snap = Snapshot(
+            session_id=session.id,
+            storage_path=f"snap/{uuid4()}.tar.gz",
+            size_bytes=1,
+        )
+        snap.created_at = now - datetime.timedelta(days=age)
+        db_session.add(snap)
+    db_session.flush()
+    return session.id
+
+
+def _pruned_ages(
+    db_session: Session, session_id: UUID, retention_days: int, keep_last_n: int
+) -> list[int]:
+    now = datetime.datetime.now(datetime.timezone.utc)
+    prunable = get_prunable_snapshots(db_session, retention_days, keep_last_n)
+    return sorted(
+        (now - s.created_at).days for s in prunable if s.session_id == session_id
+    )
+
+
+def test_keeps_latest_even_when_ancient(db_session: Session) -> None:
+    session_id = _make_session_with_snapshots(db_session, [400])
+    assert _pruned_ages(db_session, session_id, retention_days=30, keep_last_n=3) == []
+
+
+def test_hard_caps_at_keep_last_n(db_session: Session) -> None:
+    session_id = _make_session_with_snapshots(db_session, [0, 1, 2, 3])
+    # keep newest 2; ages 2 and 3 prune despite being recent.
+    assert _pruned_ages(db_session, session_id, retention_days=30, keep_last_n=2) == [
+        2,
+        3,
+    ]
+
+
+def test_expires_old_within_cap_but_keeps_anchor(db_session: Session) -> None:
+    session_id = _make_session_with_snapshots(db_session, [40, 35, 31])
+    # all older than retention, but the newest (31d) is the kept anchor.
+    assert _pruned_ages(db_session, session_id, retention_days=30, keep_last_n=10) == [
+        35,
+        40,
+    ]
+
+
+def test_recent_within_cap_are_kept(db_session: Session) -> None:
+    session_id = _make_session_with_snapshots(db_session, [0, 5, 10])
+    assert _pruned_ages(db_session, session_id, retention_days=30, keep_last_n=10) == []

--- a/backend/tests/unit/onyx/server/features/build/sandbox/sandbox_daemon/test_sandbox_daemon.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/sandbox_daemon/test_sandbox_daemon.py
@@ -416,6 +416,7 @@ def _post_snapshot(
     timestamp: str,
     content_type: str = "application/json",
     bundle_sha256: str | None = None,
+    extra_headers: dict[str, str] | None = None,
 ) -> httpx.Response:
     headers = {
         "Content-Type": content_type,
@@ -424,6 +425,8 @@ def _post_snapshot(
     }
     if bundle_sha256 is not None:
         headers["X-Bundle-Sha256"] = bundle_sha256
+    if extra_headers:
+        headers.update(extra_headers)
     return client.post(
         endpoint_path,
         content=body,
@@ -436,6 +439,7 @@ def _signed_snapshot_post(
     endpoint_path: str,
     body: bytes,
     priv: Ed25519PrivateKey,
+    extra_headers: dict[str, str] | None = None,
 ) -> httpx.Response:
     ts = str(int(time.time()))
     sig = _sign_snapshot(priv, endpoint_path=endpoint_path, body=body, timestamp=ts)
@@ -445,6 +449,7 @@ def _signed_snapshot_post(
         body,
         signature=sig,
         timestamp=ts,
+        extra_headers=extra_headers,
     )
 
 
@@ -483,11 +488,13 @@ def test_snapshot_create_empty_session_returns_204(
     _, server_mod, priv, _ = configured_sandbox_daemon
     captured: dict[str, UUID] = {}
 
-    def fake_has_snapshot_content(session_id: UUID) -> bool:
+    def fake_compute_snapshot_digest(session_id: UUID) -> str | None:
         captured["session_id"] = session_id
-        return False
+        return None
 
-    monkeypatch.setattr(server_mod, "has_snapshot_content", fake_has_snapshot_content)
+    monkeypatch.setattr(
+        server_mod, "compute_snapshot_digest", fake_compute_snapshot_digest
+    )
 
     body = b'{"session_id":"00000000-0000-0000-0000-000000000001"}'
     resp = _signed_snapshot_post(client, "/snapshot/create", body, priv)
@@ -507,16 +514,18 @@ def test_snapshot_create_streams_archive_when_content_exists(
     _, server_mod, priv, _ = configured_sandbox_daemon
     captured: dict[str, UUID] = {}
 
-    def fake_has_snapshot_content(session_id: UUID) -> bool:
+    def fake_compute_snapshot_digest(session_id: UUID) -> str | None:
         captured["session_id"] = session_id
-        return True
+        return "deadbeef"
 
     def fake_iter_snapshot_archive(session_id: UUID) -> Generator[bytes, None, None]:
         captured["iter_session_id"] = session_id
         yield b"tar"
         yield b"bytes"
 
-    monkeypatch.setattr(server_mod, "has_snapshot_content", fake_has_snapshot_content)
+    monkeypatch.setattr(
+        server_mod, "compute_snapshot_digest", fake_compute_snapshot_digest
+    )
     monkeypatch.setattr(server_mod, "iter_snapshot_archive", fake_iter_snapshot_archive)
 
     body = b'{"session_id":"00000000-0000-0000-0000-000000000003"}'
@@ -524,9 +533,38 @@ def test_snapshot_create_streams_archive_when_content_exists(
 
     assert resp.status_code == 200, resp.text
     assert resp.headers["content-type"].startswith("application/gzip")
+    assert resp.headers["ETag"] == "deadbeef"
     assert resp.content == b"tarbytes"
     session_id = UUID("00000000-0000-0000-0000-000000000003")
     assert captured == {"session_id": session_id, "iter_session_id": session_id}
+
+
+def test_snapshot_create_unchanged_returns_304(
+    configured_sandbox_daemon: tuple[ModuleType, ModuleType, Ed25519PrivateKey, Path],
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, server_mod, priv, _ = configured_sandbox_daemon
+
+    def fake_compute_snapshot_digest(_session_id: UUID) -> str | None:
+        return "samedigest"
+
+    def fail_iter(_session_id: UUID) -> Generator[bytes, None, None]:
+        raise AssertionError("must not archive an unchanged workspace")
+        yield b""
+
+    monkeypatch.setattr(
+        server_mod, "compute_snapshot_digest", fake_compute_snapshot_digest
+    )
+    monkeypatch.setattr(server_mod, "iter_snapshot_archive", fail_iter)
+
+    body = b'{"session_id":"00000000-0000-0000-0000-000000000003"}'
+    resp = _signed_snapshot_post(
+        client, "/snapshot/create", body, priv, {"If-None-Match": "samedigest"}
+    )
+
+    assert resp.status_code == 304, resp.text
+    assert resp.content == b""
 
 
 def test_snapshot_create_rejects_stale_storage_fields(
@@ -537,12 +575,14 @@ def test_snapshot_create_rejects_stale_storage_fields(
     _, server_mod, priv, _ = configured_sandbox_daemon
     called = False
 
-    def fake_has_snapshot_content(_session_id: UUID) -> bool:
+    def fake_compute_snapshot_digest(_session_id: UUID) -> str | None:
         nonlocal called
         called = True
-        return True
+        return "digest"
 
-    monkeypatch.setattr(server_mod, "has_snapshot_content", fake_has_snapshot_content)
+    monkeypatch.setattr(
+        server_mod, "compute_snapshot_digest", fake_compute_snapshot_digest
+    )
 
     body = (
         b'{"session_id":"00000000-0000-0000-0000-000000000003",'
@@ -909,7 +949,7 @@ def test_snapshot_body_tampering_after_signing_is_rejected(
     redirect a snapshot to a different tenant by swapping tenant_id.
     """
     _, server_mod, priv, _ = configured_sandbox_daemon
-    monkeypatch.setattr(server_mod, "has_snapshot_content", lambda _session_id: False)
+    monkeypatch.setattr(server_mod, "compute_snapshot_digest", lambda _session_id: None)
 
     signed_body = b'{"session_id":"00000000-0000-0000-0000-000000000003"}'
     ts = str(int(time.time()))
@@ -954,3 +994,70 @@ def test_push_signature_cannot_be_replayed_against_snapshot_endpoint(
         client, "/snapshot/create", body, signature=push_style_sig, timestamp=ts
     )
     assert resp.status_code == 401
+
+
+def test_compute_snapshot_digest_stable_and_detects_change(
+    sandbox_daemon_modules: tuple[ModuleType, ModuleType],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Digest is stable for an unchanged tree and changes when content changes."""
+    _, _ = sandbox_daemon_modules
+    snapshot_mod = sys.modules["sandbox_daemon.snapshot"]
+    sessions_root = tmp_path / "sessions"
+    session_id = UUID("00000000-0000-0000-0000-000000000042")
+    outputs = sessions_root / str(session_id) / "outputs"
+    outputs.mkdir(parents=True)
+    (outputs / "page.tsx").write_text("hello\n")
+    monkeypatch.setattr(snapshot_mod, "SESSIONS_ROOT", sessions_root)
+
+    digest_a = snapshot_mod.compute_snapshot_digest(session_id)
+    digest_b = snapshot_mod.compute_snapshot_digest(session_id)
+    assert digest_a is not None
+    assert digest_a == digest_b
+
+    # Editing a file changes the digest (size differs).
+    (outputs / "page.tsx").write_text("hello world\n")
+    assert snapshot_mod.compute_snapshot_digest(session_id) != digest_a
+
+    # Empty session has no digest.
+    empty_id = UUID("00000000-0000-0000-0000-000000000099")
+    assert snapshot_mod.compute_snapshot_digest(empty_id) is None
+
+
+def test_snapshot_digest_survives_restore(
+    sandbox_daemon_modules: tuple[ModuleType, ModuleType],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A workspace restored from its own snapshot yields the same digest.
+
+    Restore preserves mtimes, so an idle->sleep->wake cycle without edits is
+    detected as unchanged and skips a redundant snapshot.
+    """
+    _, _ = sandbox_daemon_modules
+    snapshot_mod = sys.modules["sandbox_daemon.snapshot"]
+    sessions_root = tmp_path / "sessions"
+    monkeypatch.setattr(snapshot_mod, "SESSIONS_ROOT", sessions_root)
+
+    # Archive entries carry a fixed mtime (see _build_targz_bytes); restore
+    # re-applies it, so two restores of the same archive must produce the same
+    # digest -- i.e. an unchanged workspace is recognized across wake cycles.
+    archive = tmp_path / "snap.tar.gz"
+    archive.write_bytes(
+        _build_targz_bytes(
+            {
+                "outputs/web/page.tsx": b"// hello\n",
+                "attachments/note.txt": b"note\n",
+            }
+        )
+    )
+
+    dst1 = UUID("00000000-0000-0000-0000-0000000000a1")
+    dst2 = UUID("00000000-0000-0000-0000-0000000000a2")
+    snapshot_mod.restore_snapshot(dst1, archive)
+    snapshot_mod.restore_snapshot(dst2, archive)
+
+    digest1 = snapshot_mod.compute_snapshot_digest(dst1)
+    assert digest1 is not None
+    assert digest1 == snapshot_mod.compute_snapshot_digest(dst2)

--- a/docs/craft/infra/snapshot-retention.md
+++ b/docs/craft/infra/snapshot-retention.md
@@ -1,0 +1,78 @@
+# Snapshot Retention & Skip-Unchanged
+
+## What a snapshot is
+
+When a Craft sandbox goes idle, the cleanup task snapshots each session's
+workspace (`outputs/`, `attachments/`, `.opencode-data/`) into a `tar.gz` and
+persists it through the Onyx FileStore, then terminates the pod. On wake, the
+latest snapshot is restored. Snapshots are internal sleep/wake plumbing — they
+are not a user-facing version history, and the user's most recent state is
+never lost to retention (see below).
+
+## Retention policy
+
+Pruning runs in the `cleanup_old_snapshots` Celery beat task (daily, `SANDBOX`
+queue). For each session, snapshots are ordered newest-first and:
+
+- **Position 0 (the latest) is always kept** — the workspace anchor. A session
+  is never left without a restorable snapshot, regardless of age.
+- **Snapshots beyond `SNAPSHOT_KEEP_LAST_N` are pruned** (hard cap), even if
+  recent. This bounds per-session storage.
+- **Within the cap, snapshots older than `SNAPSHOT_RETENTION_DAYS` are pruned.**
+
+Net effect: a user keeps their latest project state forever; only older history
+and excess snapshots are cleaned up. Because the latest is always retained,
+retention has **no user-visible data-loss impact** — there is nothing to warn
+users about. The only thing reclaimed is redundant snapshot history in S3.
+
+Selection lives in `get_prunable_snapshots` /
+`_select_prunable_snapshots` (`onyx/server/features/build/db/sandbox.py`).
+
+### Configuration
+
+Both knobs are env-overridable (`onyx/server/features/build/configs.py`):
+
+| Env var                  | Default | Meaning                                  |
+| ------------------------ | ------- | ---------------------------------------- |
+| `SNAPSHOT_RETENTION_DAYS`| `30`    | Age beyond which surplus snapshots prune |
+| `SNAPSHOT_KEEP_LAST_N`   | `3`     | Newest-N per session always kept         |
+
+To run a 90-day window, set `SNAPSHOT_RETENTION_DAYS=90` for the environment.
+
+### Deletion is blob-then-row, fail-safe
+
+`cleanup_old_snapshots_task` deletes the S3 blob first, then the `snapshot` DB
+row. If the blob delete fails, the row is **left in place and retried next
+cycle** — so we never delete a row while leaking its blob, and never orphan a
+session. A row therefore only survives a prune cycle if its blob could not be
+removed.
+
+## Skip-unchanged
+
+To avoid writing an identical full `tar.gz` every idle cycle (e.g. a user who
+sleeps/wakes daily without editing), the sidecar computes a cheap digest of the
+snapshot tree — `sha256` over sorted `(relpath, size, int(mtime))` — in
+`compute_snapshot_digest` (`sandbox_daemon/snapshot.py`).
+
+The digest acts as an HTTP ETag. Flow:
+
+1. The api-server sends the prior snapshot's digest (stored on the
+   `snapshot.tree_digest` column) as the `If-None-Match` request header.
+2. If it matches the current digest, the sidecar returns `304 Not Modified`
+   and skips archiving. The cleanup task treats this as success and reuses the
+   existing snapshot (no new blob, no new row).
+3. Otherwise it streams the archive with the digest in the `ETag` header, which
+   the api-server persists on the new snapshot's `tree_digest`.
+
+Restore re-applies file mtimes (`os.utime`), and `tar` stores mtimes at
+1-second granularity, so an untouched workspace yields the same digest across
+sleep/wake — which is what makes the skip reliable.
+
+The Docker backend (self-hosted) has no sidecar, so its `create_snapshot`
+computes an equivalent digest with an in-container `find … stat`/`sha256sum`
+command and skips identically (`tar -x` preserves mtimes on restore). The two
+backends never share a session, so their digest schemes need not match.
+
+Note: the K8s digest/skip logic lives in the sandbox **image**, so changes to
+it take effect only after the sandbox image is rebuilt and redeployed. The
+Docker path runs from the api-server, so it ships with a normal deploy.


### PR DESCRIPTION
## Description

### Problem

Snapshot storage grew without bound and idle cleanup did redundant work:

- `SNAPSHOT_RETENTION_DAYS` existed in config, but **nothing ever deleted a snapshot**. The `cleanup_old_snapshots` task was wired into the Celery beat schedule yet was never actually defined, so it silently no-op'd and S3 grew forever.
- The old `delete_old_snapshots` helper only deleted DB rows, never the file-store blobs — so even a working task would have leaked storage.
- Every idle reap wrote a fresh full `tar.gz` per session, even when the workspace was untouched since the last snapshot. A user who sleeps/wakes daily without editing accumulated identical full snapshots (we saw a real dev session with 8 identical snapshots created in the same second).

### Retention enforcement

- Adds the missing **`cleanup_old_snapshots_task`** (Celery beat, daily, `SANDBOX` queue) — the task the beat schedule already expected.
- Deletes the **S3 blob first, then the DB row**. If a blob delete fails, the row is left in place and retried next cycle, so we never delete a row while leaking its blob and never orphan a session.
- Selection (`get_prunable_snapshots`) runs in SQL via a `ROW_NUMBER() OVER (PARTITION BY session_id ORDER BY created_at DESC)` window function — it returns only prunable rows instead of loading the whole table. Per session it keeps the newest snapshot always (the workspace anchor) plus the `SNAPSHOT_KEEP_LAST_N` most recent, and prunes older surplus past `SNAPSHOT_RETENTION_DAYS`.
- Both windows are env-overridable. **Defaults: 30 days retention, keep last 3.**
- Because the latest snapshot is always retained, retention has **no user-visible data-loss impact** — it only reclaims redundant history.

### Skip-unchanged

Avoids re-archiving an unchanged workspace on idle reap, using a tree digest as an HTTP **ETag**:

- The sidecar computes `compute_snapshot_digest` — `sha256` over sorted `(relpath, size, int(mtime))`.
- The api-server sends the prior snapshot's digest (persisted on the new **`snapshot.tree_digest`** column) as the `If-None-Match` request header. A match returns **`304 Not Modified`** and skips archiving; otherwise the archive streams back with the digest in the `ETag` header.
- Restore re-applies file mtimes (`os.utime`); `tar` stores mtimes at 1-second granularity, so an untouched workspace yields the same digest across sleep/wake — what makes the skip reliable.
- The **Docker backend** (no sidecar) honors the same `create_snapshot(previous_digest=...)` contract via an in-container `find … stat`/`sha256sum` digest (`tar -x` preserves mtimes on restore). It is **best-effort**: any failure returns `None` and the snapshot is taken normally, so the optimization can never break the core path. The two backends never share a session, so their digest schemes need not match.

### Schema / docs

- Adds the nullable `snapshot.tree_digest` column (migration `eefb92217285`).
- `docs/craft/infra/snapshot-retention.md` documents the lifecycle, retention policy, knobs, and skip-unchanged mechanism (both backends).

### Rollout notes

- Restart Celery workers to register the new task.
- Rebuild/redeploy the sandbox **image** for the K8s skip-unchanged path (the digest logic lives in the sidecar). The Docker path runs from the api-server and ships with a normal deploy.

## How Has This Been Tested?

- **Unit:** sidecar `sandbox_daemon/test_sandbox_daemon.py` covers digest stability/change-detection, restore round-trip, and the `304`/`ETag` endpoint behavior; docker snapshot tests pass. `ty` + `ruff` clean.
- **External-dependency:** `craft/test_snapshot_retention.py` exercises the real window-function SQL (keep-last-N, age expiry, anchor protection) against Postgres — runs in CI against a migrated DB.
- **Live on `kind-onyx-dev`** (earlier revision) via `scripts/run-all-k8s.sh`: confirmed the task registers in the `heavy`/`light` workers and, dispatched through the broker, pruned blobs+rows against the real DB + S3, kept the latest/recent, and correctly skipped a missing-blob case (row retained). Seeded test data cleaned up afterward.
- Not validated live: the migration apply and the ext-dep retention test require the shared cluster Postgres (applying the migration there is intentionally gated); both run in CI.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check
