### PR TITLE
fix(craft): set ephemeral-storage requests/limits on sandbox pods

### DIFF
--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_pod_spec.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_pod_spec.py
@@ -424,6 +424,20 @@ def test_snapshot_storage_credentials_are_not_in_pod_env(pod: client.V1Pod) -> N
         )
 
 
+def test_all_containers_set_ephemeral_storage_requests(pod: client.V1Pod) -> None:
+    """A pod with no ephemeral-storage request is invisible to the scheduler's
+    disk accounting and first in line for kubelet eviction under node disk
+    pressure — the exact failure that loses un-snapshotted workspaces."""
+    for container in (_container(pod, "sandbox"), _sidecar(pod)):
+        resources = container.resources
+        assert "ephemeral-storage" in (resources.requests or {}), (
+            f"{container.name} container missing ephemeral-storage request"
+        )
+        assert "ephemeral-storage" in (resources.limits or {}), (
+            f"{container.name} container missing ephemeral-storage limit"
+        )
+
+
 def test_init_containers_preserve_proxy_then_sidecar_order(pod: client.V1Pod) -> None:
     """The iptables-lockdown initContainer must run before any user code —
     it's what blocks direct egress that the HTTPS_PROXY env doesn't catch."""

--- a/deployment/helm/charts/onyx/templates/sandbox-podtemplate.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-podtemplate.yaml
@@ -13,6 +13,10 @@ opencode-auth + push-key env, proxy hostAliases IP).
 {{- $memReq := (index $cm "SANDBOX_POD_MEMORY_REQUEST") | default "2Gi" }}
 {{- $cpuLim := (index $cm "SANDBOX_POD_CPU_LIMIT") | default "2000m" }}
 {{- $memLim := (index $cm "SANDBOX_POD_MEMORY_LIMIT") | default "10Gi" }}
+{{/* Without a request, the scheduler ignores sandbox disk usage and the
+kubelet evicts sandbox pods first under node disk pressure. */}}
+{{- $ephReq := (index $cm "SANDBOX_POD_EPHEMERAL_STORAGE_REQUEST") | default "5Gi" }}
+{{- $ephLim := (index $cm "SANDBOX_POD_EPHEMERAL_STORAGE_LIMIT") | default "20Gi" }}
 {{- $nextjsStart := (index $cm "SANDBOX_NEXTJS_PORT_START") | default "3010" | int }}
 {{- $nextjsEnd := (index $cm "SANDBOX_NEXTJS_PORT_END") | default "3100" | int }}
 {{- $opencodePort := (index $cm "OPENCODE_SERVE_PORT") | default "4096" | int }}
@@ -100,8 +104,9 @@ template:
           - { name: sandbox-ca-bundle, mountPath: /etc/ssl/sandbox, readOnly: true }
         resources:
           # Snapshot tar/stream runs through this sidecar, so give it headroom.
-          requests: { cpu: "100m", memory: "256Mi" }
-          limits: { cpu: "1", memory: "1Gi" }
+          # Restore buffers the downloaded archive (<=100MB cap) in /tmp.
+          requests: { cpu: "100m", memory: "256Mi", ephemeral-storage: "512Mi" }
+          limits: { cpu: "1", memory: "1Gi", ephemeral-storage: "2Gi" }
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: false
@@ -144,8 +149,10 @@ template:
           - { name: managed, mountPath: /workspace/managed, readOnly: true }
           - { name: sandbox-ca-bundle, mountPath: /etc/ssl/sandbox, readOnly: true }
         resources:
-          requests: { cpu: "{{ $cpuReq }}", memory: "{{ $memReq }}" }
-          limits: { cpu: "{{ $cpuLim }}", memory: "{{ $memLim }}" }
+          requests:
+            { cpu: "{{ $cpuReq }}", memory: "{{ $memReq }}", ephemeral-storage: "{{ $ephReq }}" }
+          limits:
+            { cpu: "{{ $cpuLim }}", memory: "{{ $memLim }}", ephemeral-storage: "{{ $ephLim }}" }
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: false

--- a/deployment/helm/charts/onyx/values-ci.yaml
+++ b/deployment/helm/charts/onyx/values-ci.yaml
@@ -17,6 +17,9 @@ configMap:
   SANDBOX_POD_MEMORY_REQUEST: "256Mi"
   SANDBOX_POD_CPU_LIMIT: "2000m"
   SANDBOX_POD_MEMORY_LIMIT: "4Gi"
+  # kind runner disks are small; production default is 5Gi/20Gi.
+  SANDBOX_POD_EPHEMERAL_STORAGE_REQUEST: "512Mi"
+  SANDBOX_POD_EPHEMERAL_STORAGE_LIMIT: "4Gi"
 
 # test_sigterm_drain_unblocks_parked_request deletes "the" proxy pod via an
 # arbitrary `items[0]` from the label selector and expects that pod to be the


### PR DESCRIPTION
## Description

Sandbox pods set no ephemeral-storage requests/limits, so the scheduler doesn't account for their disk usage and the kubelet evicts them **first** under node disk pressure. This is the direct trigger of the st-dev incident on 2026-06-09: `sandbox-bbb562d8` was evicted with `The node was low on resource: ephemeral-storage ... Container sandbox was using 924832Ki, request is 0`, and the user's session workspace was permanently lost (no snapshot existed for it).

This sets ephemeral-storage requests/limits in the Helm sandbox PodTemplate (#11919), matching how cpu/memory are configured:

- sandbox container: configMap-tunable via `SANDBOX_POD_EPHEMERAL_STORAGE_REQUEST` / `_LIMIT`, defaults **5Gi / 20Gi**
- sidecar init container: fixed **512Mi / 2Gi** (snapshot restore buffers the downloaded archive — ≤100MB cap — in `/tmp` before extracting)
- kind CI values use **512Mi / 4Gi** (runner disks are small and CI provisions several pods concurrently)

With requests set, the scheduler packs nodes against actual sandbox disk usage and sandbox pods stop being the preferred eviction victims; the limit stops one runaway sandbox from driving the whole node into disk pressure and getting its neighbors evicted.

Note: this is the prevention half of the incident fix. Bounding data loss when a pod still dies ungracefully (node loss, OOM, spot reclaim) is split out into a separate background-snapshots PR.

## How Has This Been Tested?

- `test_pod_spec.py` gains `test_all_containers_set_ephemeral_storage_requests`, asserting both containers carry ephemeral-storage requests/limits — the suite renders the real chart via `helm template` and builds the pod through `_create_sandbox_pod`, so the assertion covers the actual deployed shape (19 passed).
- Verified earlier on the kind cluster that pods provisioned from this spec carry `ephemeral-storage: req=5Gi lim=20Gi` (sandbox) and `512Mi/2Gi` (sidecar).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
