### PR TITLE
Codify sandbox proxy IRSA wiring

### DIFF
--- a/deployment/helm/charts/onyx/templates/sandbox-proxy/rbac.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-proxy/rbac.yaml
@@ -1,5 +1,11 @@
 {{- if eq (include "onyx.craftEnabled" .) "true" }}
 {{- $sandboxNs := .Values.configMap.SANDBOX_NAMESPACE | default "onyx-sandboxes" }}
+{{- $sandboxProxyServiceAccount := .Values.sandboxProxy.serviceAccount | default dict }}
+{{- $sandboxProxyServiceAccountAutomount := true }}
+{{- if hasKey $sandboxProxyServiceAccount "automount" }}
+{{- $sandboxProxyServiceAccountAutomount = $sandboxProxyServiceAccount.automount }}
+{{- end }}
+{{- $proxyServiceAccountAnnotations := $sandboxProxyServiceAccount.annotations | default dict }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -7,6 +13,11 @@ metadata:
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     app.kubernetes.io/component: sandbox-proxy
+  {{- with $proxyServiceAccountAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ $sandboxProxyServiceAccountAutomount }}
 ---
 # CA Secret access, scoped to the single named Secret.
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1537,6 +1537,11 @@ sandboxProxy:
   caSecretName: "sandbox-proxy-ca"
   caConfigMapName: "sandbox-proxy-ca-bundle"
   podAnnotations: {}
+  serviceAccount:
+    # Set IRSA annotations here when the sandbox proxy uses IAM-backed services,
+    # such as RDS IAM auth.
+    annotations: {}
+    automount: true
   # Matches the `onyx` user (uid 1001) baked into the backend image.
   runAsUser: 1001
   fsGroup: 1001

--- a/deployment/terraform/modules/aws/eks/main.tf
+++ b/deployment/terraform/modules/aws/eks/main.tf
@@ -4,6 +4,14 @@ locals {
     bucket_objects = "arn:aws:s3:::${name}/*"
   }]
 
+  workload_irsa_service_account_subjects = [
+    for service_account_name in distinct(concat(
+      [var.irsa_service_account_name],
+      var.irsa_additional_service_account_names,
+    )) :
+    "system:serviceaccount:${var.irsa_service_account_namespace}:${service_account_name}"
+  ]
+
   # Optional dedicated node group for sandbox pods (nodeSelector/toleration below).
   # IMDSv2 hop-limit 1 blocks sandboxed containers from the node metadata service.
   craft_sandbox_node_groups = var.enable_craft_sandbox_node_group ? {
@@ -193,7 +201,7 @@ module "irsa-workload-access" {
   role_name                     = "AmazonEKSTFWorkloadAccessRole-${module.eks.cluster_name}"
   provider_url                  = module.eks.oidc_provider
   role_policy_arns              = [aws_iam_policy.s3_access_policy[0].arn]
-  oidc_fully_qualified_subjects = ["system:serviceaccount:${var.irsa_service_account_namespace}:${var.irsa_service_account_name}"]
+  oidc_fully_qualified_subjects = local.workload_irsa_service_account_subjects
 
   depends_on = [module.eks]
 }

--- a/deployment/terraform/modules/aws/eks/outputs.tf
+++ b/deployment/terraform/modules/aws/eks/outputs.tf
@@ -16,6 +16,11 @@ output "workload_irsa_role_arn" {
   value       = length(module.irsa-workload-access) > 0 ? module.irsa-workload-access[0].iam_role_arn : null
 }
 
+output "workload_irsa_service_account_subjects" {
+  description = "Kubernetes service account subjects trusted by the workload IRSA role"
+  value       = length(module.irsa-workload-access) > 0 ? local.workload_irsa_service_account_subjects : []
+}
+
 output "node_security_group_id" {
   description = "Node security group ID from the EKS module"
   value       = module.eks.node_security_group_id

--- a/deployment/terraform/modules/aws/eks/variables.tf
+++ b/deployment/terraform/modules/aws/eks/variables.tf
@@ -180,6 +180,12 @@ variable "irsa_service_account_name" {
   default     = "onyx-workload-access"
 }
 
+variable "irsa_additional_service_account_names" {
+  type        = list(string)
+  description = "Additional service accounts in irsa_service_account_namespace that may assume the workload IRSA role. Use this for chart-created workloads, such as <release>-sandbox-proxy, that also need RDS IAM auth."
+  default     = []
+}
+
 variable "enable_rds_iam_for_service_account" {
   type        = bool
   description = "Whether to create a dedicated RDS IRSA role and service account (grants rds-db:connect)"

--- a/docs/craft/kubernetes/craft-eks-runbook.md
+++ b/docs/craft/kubernetes/craft-eks-runbook.md
@@ -32,7 +32,7 @@ Craft provisions a sandbox + snapshot/restore, with no manual kubectl/RBAC/node 
 | `cluster_name` | `aws eks update-kubeconfig` (then helm targets the cluster) |
 | `postgres_endpoint` / redis / `opensearch_endpoint` | `configMap.POSTGRES_HOST` / `REDIS_HOST` / `OPENSEARCH_HOST` |
 | file-store bucket name | `configMap.S3_FILE_STORE_BUCKET_NAME` |
-| workload role ARN | `serviceAccount.annotations` (recommended) |
+| workload role ARN | `serviceAccount.annotations` and, when the proxy uses IAM-authenticated RDS, `sandboxProxy.serviceAccount.annotations` |
 
 Craft snapshots now use the normal Onyx FileStore from the API server/Celery
 path. Do not configure `SANDBOX_S3_BUCKET`, `craft.sandboxFileSyncRoleArn`, or
@@ -100,6 +100,7 @@ opencode auth/config.
 | `craft.extraBoundServiceAccounts` | Only for additional managers | Extra release-namespace ServiceAccounts that should manage sandboxes. |
 | `configMap.SANDBOX_SERVICE_ACCOUNT_NAME` | Optional | Defaults to `sandbox`; the chart renders the matching ServiceAccount in `onyx-sandboxes`. |
 | `sandboxProxy.*` | Existing Craft proxy config | Controls sandbox proxy replicas, ports, resources, CA names, scheduling, and security context. |
+| `sandboxProxy.serviceAccount.annotations` | Required for RDS IAM auth when the main workload SA is not Helm-created | Adds IRSA annotations to the chart-created sandbox-proxy ServiceAccount. |
 
 ## 2. How the sandbox node group works
 
@@ -197,7 +198,16 @@ so the app workload identity must have access to the main file-store bucket.
 ### Required managed-service wiring (chart `configMap`)
 Point at the terraform endpoints; disable in-cluster deps:
 - `postgresql.enabled/redis.enabled/opensearch.enabled/minio.enabled: false`; `serviceAccount.name: onyx-workload-access` (IRSA), `auth.objectstorage.enabled: false`.
-- RDS: `POSTGRES_HOST`, `PGSSLMODE=require`. ElastiCache: `REDIS_HOST`, `REDIS_SSL=true`, `REDIS_SSL_CERT_REQS=none`, `auth.redis.enabled=false` (no auth token).
+- RDS: `POSTGRES_HOST`, `PGSSLMODE=require`. If `USE_IAM_AUTH=true`, the sandbox-proxy ServiceAccount must also be trusted by the workload IRSA role and annotated with that same role ARN. For release `onyx`, set Terraform `irsa_additional_service_account_names = ["onyx-sandbox-proxy"]`. In Helm values, set the proxy annotation:
+
+```yaml
+sandboxProxy:
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: <workload_irsa_role_arn>
+```
+
+- ElastiCache: `REDIS_HOST`, `REDIS_SSL=true`, `REDIS_SSL_CERT_REQS=none`, `auth.redis.enabled=false` (no auth token).
 - OpenSearch (v4.0 search backend): `ONYX_DISABLE_VESPA=true`, `ENABLE_OPENSEARCH_INDEXING/RETRIEVAL_FOR_ONYX=true`, `USING_AWS_MANAGED_OPENSEARCH=true`, `OPENSEARCH_REST_API_PORT=443`, `OPENSEARCH_USE_SSL=true`, `OPENSEARCH_ADMIN_USERNAME=admin`.
 - S3: `S3_FILE_STORE_BUCKET_NAME`, `S3_ENDPOINT_URL=""`, `AWS_REGION_NAME`.
 - Craft: `ENABLE_CRAFT=true`, `SANDBOX_API_SERVER_URL=http://onyx-api-service.onyx.svc.cluster.local:8080`, `auth.sandboxPushSecret.enabled=true`. (`SANDBOX_SERVICE_ACCOUNT_NAME`/`SANDBOX_CONTAINER_IMAGE` default correctly.)
@@ -357,6 +367,12 @@ kubectl get nodes -l onyx.app/workload=sandbox
 
 # The sandbox SA exists, has no IRSA annotation, and does not automount tokens.
 kubectl -n onyx-sandboxes get sa sandbox -o yaml
+
+# The sandbox proxy is a DB client; with RDS IAM auth it must have the workload
+# role annotation and that role must trust this SA subject.
+kubectl -n onyx get sa onyx-sandbox-proxy -o yaml
+aws iam get-role --role-name AmazonEKSTFWorkloadAccessRole-<cluster-name> \
+  --query 'Role.AssumeRolePolicyDocument.Statement[].Condition.StringEquals'
 ```
 
 ## 5. Lead infra TODO coverage
@@ -414,8 +430,10 @@ The lead infra TODO list in `docs/craft/infra/todos.md` is accounted for as:
   `aws s3 rm` the buckets first, then destroy.
 - `sandbox-proxy` is a DB/Redis client, not just a forward proxy: its `gate.py` resolves tenant / sandbox /
   egress-policy from **RDS** (and uses **Redis**) on every request, so it needs the same managed-service
-  wiring + network reachability as the app pods. Verified: proxy node SG → RDS:5432 path open and an
-  authenticated query succeeds; the gate logs `tenant_id=…/sandbox_id=…` resolved per request.
+  wiring + network reachability as the app pods. With RDS IAM auth this includes both the IRSA annotation on
+  `ServiceAccount/onyx-sandbox-proxy` and the matching role trust policy subject. Verified: proxy node SG →
+  RDS:5432 path open and an authenticated query succeeds; the gate logs `tenant_id=…/sandbox_id=…` resolved
+  per request.
 - Teardown order/gotchas: `helm uninstall` before `terraform destroy` (else the `onyx` namespace hangs on
   finalizers). The VPC CNI can leave orphaned `available` `aws-K8S-*` ENIs that pin the node SG/subnets →
   `destroy` hangs ~15 min then fails on `DependencyViolation`; delete those ENIs, then re-run destroy.


### PR DESCRIPTION
## Summary
- add explicit Helm values for sandbox-proxy ServiceAccount annotations and token automount
- allow the Terraform EKS workload IRSA role to trust additional ServiceAccounts, including the chart-created sandbox proxy
- document the RDS IAM auth wiring and validation checks for Craft on EKS

## Testing
- helm template sandbox-proxy RBAC with explicit IRSA annotation
- helm template sandbox-proxy RBAC with automount disabled
- helm lint deployment/helm/charts/onyx with Craft enabled
- git diff --check
- terraform fmt -check deployment/terraform/modules/aws/eks

Note: terraform validate is blocked by the existing eks-blueprints-addons / Helm provider mismatch in downloaded modules (unsupported postrender/set blocks), unrelated to this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Codifies sandbox-proxy IRSA wiring so the chart-created proxy can use RDS IAM auth. Adds Helm values to annotate the proxy ServiceAccount and control token automount, and lets the workload IRSA role trust multiple ServiceAccounts via Terraform.

- **New Features**
  - Helm: add `sandboxProxy.serviceAccount.annotations` and `sandboxProxy.serviceAccount.automount`; ServiceAccount now renders `annotations` and `automountServiceAccountToken`.
  - Terraform (EKS module): new `irsa_additional_service_account_names`; IRSA `oidc_fully_qualified_subjects` built from all trusted SAs; new output `workload_irsa_service_account_subjects`.
  - Docs: EKS runbook details proxy IRSA requirements for RDS IAM with sample values and validation steps.

- **Migration**
  - For RDS IAM auth, add the proxy SA (e.g., `onyx-sandbox-proxy`) to `irsa_additional_service_account_names` and set the same role ARN under `sandboxProxy.serviceAccount.annotations`.
  - Keep `sandboxProxy.serviceAccount.automount: true` unless you have a specific need to disable it.

<sup>Written for commit 33cf532263b2364ee49cead35058a45f0b3286c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11924?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

