### PR TITLE
fix(craft): codify sandbox proxy IRSA wiring

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.5.22
+version: 0.5.23
 appVersion: latest
 annotations:
   category: Productivity
@@ -16,6 +16,9 @@ annotations:
     - name: background
       image: docker.io/onyxdotapp/onyx-backend:latest
   artifacthub.io/changes: |
+    - kind: changed
+      description: Add sandbox-proxy ServiceAccount annotation support for
+        IAM-backed managed services.
     - kind: changed
       description: Store Craft sandbox snapshots in the Onyx filestore instead
         of requiring sandbox pods to write directly to S3.

--- a/deployment/helm/charts/onyx/templates/sandbox-proxy/deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-proxy/deployment.yaml
@@ -22,6 +22,7 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/service-account: {{ toJson (.Values.sandboxProxy.serviceAccount | default dict) | sha256sum }}
         {{- with .Values.sandboxProxy.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/deployment/helm/charts/onyx/templates/sandbox-proxy/rbac.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-proxy/rbac.yaml
@@ -1,5 +1,11 @@
 {{- if eq (include "onyx.craftEnabled" .) "true" }}
 {{- $sandboxNs := .Values.configMap.SANDBOX_NAMESPACE | default "onyx-sandboxes" }}
+{{- $sandboxProxyServiceAccount := .Values.sandboxProxy.serviceAccount | default dict }}
+{{- $sandboxProxyServiceAccountAutomount := true }}
+{{- if hasKey $sandboxProxyServiceAccount "automount" }}
+{{- $sandboxProxyServiceAccountAutomount = $sandboxProxyServiceAccount.automount }}
+{{- end }}
+{{- $proxyServiceAccountAnnotations := $sandboxProxyServiceAccount.annotations | default dict }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -7,6 +13,11 @@ metadata:
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     app.kubernetes.io/component: sandbox-proxy
+  {{- with $proxyServiceAccountAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ $sandboxProxyServiceAccountAutomount }}
 ---
 # CA Secret access, scoped to the single named Secret.
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1537,6 +1537,11 @@ sandboxProxy:
   caSecretName: "sandbox-proxy-ca"
   caConfigMapName: "sandbox-proxy-ca-bundle"
   podAnnotations: {}
+  serviceAccount:
+    # Set IRSA annotations here when the sandbox proxy uses IAM-backed services,
+    # such as RDS IAM auth.
+    annotations: {}
+    automount: true
   # Matches the `onyx` user (uid 1001) baked into the backend image.
   runAsUser: 1001
   fsGroup: 1001

--- a/deployment/terraform/modules/aws/eks/main.tf
+++ b/deployment/terraform/modules/aws/eks/main.tf
@@ -4,6 +4,19 @@ locals {
     bucket_objects = "arn:aws:s3:::${name}/*"
   }]
 
+  workload_irsa_enabled = (
+    length(var.s3_bucket_names) > 0 ||
+    (var.enable_rds_iam_for_service_account && var.rds_db_connect_arn != null)
+  )
+
+  workload_irsa_service_account_subjects = [
+    for service_account_name in distinct(concat(
+      [var.irsa_service_account_name],
+      var.irsa_additional_service_account_names,
+    )) :
+    "system:serviceaccount:${var.irsa_service_account_namespace}:${service_account_name}"
+  ]
+
   # Optional dedicated node group for sandbox pods (nodeSelector/toleration below).
   # IMDSv2 hop-limit 1 blocks sandboxed containers from the node metadata service.
   craft_sandbox_node_groups = var.enable_craft_sandbox_node_group ? {
@@ -185,22 +198,22 @@ resource "aws_iam_policy" "s3_access_policy" {
 
 # Create IAM role for workload access using IRSA (S3 + RDS)
 module "irsa-workload-access" {
-  count   = length(var.s3_bucket_names) == 0 ? 0 : 1
+  count   = local.workload_irsa_enabled ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
   version = "4.7.0"
 
   create_role                   = true
   role_name                     = "AmazonEKSTFWorkloadAccessRole-${module.eks.cluster_name}"
   provider_url                  = module.eks.oidc_provider
-  role_policy_arns              = [aws_iam_policy.s3_access_policy[0].arn]
-  oidc_fully_qualified_subjects = ["system:serviceaccount:${var.irsa_service_account_namespace}:${var.irsa_service_account_name}"]
+  role_policy_arns              = aws_iam_policy.s3_access_policy[*].arn
+  oidc_fully_qualified_subjects = local.workload_irsa_service_account_subjects
 
   depends_on = [module.eks]
 }
 
-# Create Kubernetes service account for S3 access (optional)
+# Create Kubernetes service account for workload IRSA access (optional)
 resource "kubernetes_service_account" "s3_access" {
-  count = length(var.s3_bucket_names) == 0 ? 0 : 1
+  count = local.workload_irsa_enabled ? 1 : 0
   metadata {
     name      = var.irsa_service_account_name
     namespace = var.irsa_service_account_namespace

--- a/deployment/terraform/modules/aws/eks/outputs.tf
+++ b/deployment/terraform/modules/aws/eks/outputs.tf
@@ -13,7 +13,12 @@ output "cluster_certificate_authority_data" {
 
 output "workload_irsa_role_arn" {
   description = "ARN of the IAM role for workloads (S3 + optional RDS)"
-  value       = length(module.irsa-workload-access) > 0 ? module.irsa-workload-access[0].iam_role_arn : null
+  value       = local.workload_irsa_enabled ? module.irsa-workload-access[0].iam_role_arn : null
+}
+
+output "workload_irsa_service_account_subjects" {
+  description = "Kubernetes service account subjects trusted by the workload IRSA role"
+  value       = local.workload_irsa_enabled ? local.workload_irsa_service_account_subjects : []
 }
 
 output "node_security_group_id" {

--- a/deployment/terraform/modules/aws/eks/variables.tf
+++ b/deployment/terraform/modules/aws/eks/variables.tf
@@ -180,6 +180,12 @@ variable "irsa_service_account_name" {
   default     = "onyx-workload-access"
 }
 
+variable "irsa_additional_service_account_names" {
+  type        = list(string)
+  description = "Additional service accounts in irsa_service_account_namespace that may assume the workload IRSA role. Use this for chart-created workloads, such as <release>-sandbox-proxy, that also need RDS IAM auth. The role is created when s3_bucket_names is non-empty or RDS IAM auth is enabled."
+  default     = []
+}
+
 variable "enable_rds_iam_for_service_account" {
   type        = bool
   description = "Whether to create a dedicated RDS IRSA role and service account (grants rds-db:connect)"

--- a/deployment/terraform/modules/aws/onyx/main.tf
+++ b/deployment/terraform/modules/aws/onyx/main.tf
@@ -74,6 +74,8 @@ module "eks" {
   tags            = local.merged_tags
   s3_bucket_names = [local.bucket_name]
 
+  irsa_additional_service_account_names = var.irsa_additional_service_account_names
+
   enable_craft_sandbox_node_group   = var.enable_craft_sandbox_node_group
   craft_sandbox_node_instance_types = var.craft_sandbox_node_instance_types
   craft_sandbox_node_min_size       = var.craft_sandbox_node_min_size

--- a/deployment/terraform/modules/aws/onyx/outputs.tf
+++ b/deployment/terraform/modules/aws/onyx/outputs.tf
@@ -15,6 +15,16 @@ output "oidc_provider" {
   value = module.eks.oidc_provider
 }
 
+output "workload_irsa_role_arn" {
+  description = "ARN of the IAM role for workloads (S3 + optional RDS)"
+  value       = module.eks.workload_irsa_role_arn
+}
+
+output "workload_irsa_service_account_subjects" {
+  description = "Kubernetes service account subjects trusted by the workload IRSA role"
+  value       = module.eks.workload_irsa_service_account_subjects
+}
+
 output "postgres_endpoint" {
   description = "RDS endpoint hostname"
   value       = module.postgres.endpoint

--- a/deployment/terraform/modules/aws/onyx/variables.tf
+++ b/deployment/terraform/modules/aws/onyx/variables.tf
@@ -147,6 +147,12 @@ variable "enable_iam_auth" {
   default     = false
 }
 
+variable "irsa_additional_service_account_names" {
+  type        = list(string)
+  description = "Additional service accounts in the Onyx namespace that may assume the workload IRSA role. Use the rendered ServiceAccount name for chart-created workloads, such as onyx-sandbox-proxy, that also need RDS IAM auth."
+  default     = []
+}
+
 variable "rds_db_connect_arn" {
   type        = string
   description = "Full rds-db:connect ARN to pass to the EKS module. Required when enable_rds_iam_auth is true."

--- a/docs/craft/kubernetes/craft-eks-runbook.md
+++ b/docs/craft/kubernetes/craft-eks-runbook.md
@@ -32,7 +32,7 @@ Craft provisions a sandbox + snapshot/restore, with no manual kubectl/RBAC/node 
 | `cluster_name` | `aws eks update-kubeconfig` (then helm targets the cluster) |
 | `postgres_endpoint` / redis / `opensearch_endpoint` | `configMap.POSTGRES_HOST` / `REDIS_HOST` / `OPENSEARCH_HOST` |
 | file-store bucket name | `configMap.S3_FILE_STORE_BUCKET_NAME` |
-| workload role ARN | `serviceAccount.annotations` (recommended) |
+| workload role ARN | `serviceAccount.annotations` and, when the proxy uses IAM-authenticated RDS, `sandboxProxy.serviceAccount.annotations` |
 
 Craft snapshots now use the normal Onyx FileStore from the API server/Celery
 path. Do not configure `SANDBOX_S3_BUCKET`, `craft.sandboxFileSyncRoleArn`, or
@@ -100,6 +100,7 @@ opencode auth/config.
 | `craft.extraBoundServiceAccounts` | Only for additional managers | Extra release-namespace ServiceAccounts that should manage sandboxes. |
 | `configMap.SANDBOX_SERVICE_ACCOUNT_NAME` | Optional | Defaults to `sandbox`; the chart renders the matching ServiceAccount in `onyx-sandboxes`. |
 | `sandboxProxy.*` | Existing Craft proxy config | Controls sandbox proxy replicas, ports, resources, CA names, scheduling, and security context. |
+| `sandboxProxy.serviceAccount.annotations` | Required for RDS IAM auth when the main workload SA is not Helm-created | Adds IRSA annotations to the chart-created sandbox-proxy ServiceAccount. |
 
 ## 2. How the sandbox node group works
 
@@ -197,7 +198,16 @@ so the app workload identity must have access to the main file-store bucket.
 ### Required managed-service wiring (chart `configMap`)
 Point at the terraform endpoints; disable in-cluster deps:
 - `postgresql.enabled/redis.enabled/opensearch.enabled/minio.enabled: false`; `serviceAccount.name: onyx-workload-access` (IRSA), `auth.objectstorage.enabled: false`.
-- RDS: `POSTGRES_HOST`, `PGSSLMODE=require`. ElastiCache: `REDIS_HOST`, `REDIS_SSL=true`, `REDIS_SSL_CERT_REQS=none`, `auth.redis.enabled=false` (no auth token).
+- RDS: `POSTGRES_HOST`, `PGSSLMODE=require`. If `USE_IAM_AUTH=true`, the sandbox-proxy ServiceAccount must also be trusted by the workload IRSA role and annotated with that same role ARN. Set Terraform `irsa_additional_service_account_names` to the rendered sandbox-proxy ServiceAccount name (`onyx-sandbox-proxy` for release `onyx`; verify with `helm template` for other release names). In Helm values, set the proxy annotation:
+
+```yaml
+sandboxProxy:
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: <workload_irsa_role_arn>
+```
+
+- ElastiCache: `REDIS_HOST`, `REDIS_SSL=true`, `REDIS_SSL_CERT_REQS=none`, `auth.redis.enabled=false` (no auth token).
 - OpenSearch (v4.0 search backend): `ONYX_DISABLE_VESPA=true`, `ENABLE_OPENSEARCH_INDEXING/RETRIEVAL_FOR_ONYX=true`, `USING_AWS_MANAGED_OPENSEARCH=true`, `OPENSEARCH_REST_API_PORT=443`, `OPENSEARCH_USE_SSL=true`, `OPENSEARCH_ADMIN_USERNAME=admin`.
 - S3: `S3_FILE_STORE_BUCKET_NAME`, `S3_ENDPOINT_URL=""`, `AWS_REGION_NAME`.
 - Craft: `ENABLE_CRAFT=true`, `SANDBOX_API_SERVER_URL=http://onyx-api-service.onyx.svc.cluster.local:8080`, `auth.sandboxPushSecret.enabled=true`. (`SANDBOX_SERVICE_ACCOUNT_NAME`/`SANDBOX_CONTAINER_IMAGE` default correctly.)
@@ -357,6 +367,12 @@ kubectl get nodes -l onyx.app/workload=sandbox
 
 # The sandbox SA exists, has no IRSA annotation, and does not automount tokens.
 kubectl -n onyx-sandboxes get sa sandbox -o yaml
+
+# The sandbox proxy is a DB client; with RDS IAM auth it must have the workload
+# role annotation and that role must trust this SA subject.
+kubectl -n onyx get sa onyx-sandbox-proxy -o yaml
+aws iam get-role --role-name AmazonEKSTFWorkloadAccessRole-<cluster-name> \
+  --query 'Role.AssumeRolePolicyDocument.Statement[].Condition.StringEquals'
 ```
 
 ## 5. Lead infra TODO coverage
@@ -414,8 +430,10 @@ The lead infra TODO list in `docs/craft/infra/todos.md` is accounted for as:
   `aws s3 rm` the buckets first, then destroy.
 - `sandbox-proxy` is a DB/Redis client, not just a forward proxy: its `gate.py` resolves tenant / sandbox /
   egress-policy from **RDS** (and uses **Redis**) on every request, so it needs the same managed-service
-  wiring + network reachability as the app pods. Verified: proxy node SG → RDS:5432 path open and an
-  authenticated query succeeds; the gate logs `tenant_id=…/sandbox_id=…` resolved per request.
+  wiring + network reachability as the app pods. With RDS IAM auth this includes both the IRSA annotation on
+  `ServiceAccount/onyx-sandbox-proxy` and the matching role trust policy subject. Verified: proxy node SG →
+  RDS:5432 path open and an authenticated query succeeds; the gate logs `tenant_id=…/sandbox_id=…` resolved
+  per request.
 - Teardown order/gotchas: `helm uninstall` before `terraform destroy` (else the `onyx` namespace hangs on
   finalizers). The VPC CNI can leave orphaned `available` `aws-K8S-*` ENIs that pin the node SG/subnets →
   `destroy` hangs ~15 min then fails on `DependencyViolation`; delete those ENIs, then re-run destroy.


### PR DESCRIPTION
## Description

Codifies the sandbox-proxy IRSA wiring needed for RDS IAM auth. This adds explicit Helm ServiceAccount annotation support, rolls sandbox-proxy pods when that ServiceAccount config changes, and threads additional trusted ServiceAccount subjects through both Terraform EKS modules.

## How Has This Been Tested?

- `helm template` for `templates/sandbox-proxy/rbac.yaml` with explicit IRSA annotation
- `helm template` for `templates/sandbox-proxy/deployment.yaml` confirming the ServiceAccount checksum rollout annotation
- `helm lint deployment/helm/charts/onyx` with Craft enabled
- `terraform fmt -check deployment/terraform/modules/aws/eks deployment/terraform/modules/aws/onyx`
- `git diff --check`

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Codifies IRSA for the sandbox proxy by adding Helm ServiceAccount annotations/automount and rollout triggers, and extending Terraform to trust proxy ServiceAccounts and create the workload IRSA role when S3 or RDS IAM is enabled. Enables the proxy to use RDS IAM auth with clearer docs and new surfaced outputs.

- **New Features**
  - Helm: `sandboxProxy.serviceAccount.annotations` and `automount`; renders annotations/`automountServiceAccountToken`; adds `checksum/service-account` to roll pods on SA changes.
  - Terraform (`deployment/terraform/modules/aws/eks`): `irsa_additional_service_account_names` to build trusted OIDC subjects; IRSA role/SA now created when `s3_bucket_names` is set or RDS IAM is enabled; new output `workload_irsa_service_account_subjects`.
  - Terraform (`deployment/terraform/modules/aws/onyx`): threads `irsa_additional_service_account_names`; exposes `workload_irsa_role_arn` and `workload_irsa_service_account_subjects`.
  - Docs: EKS runbook updated with RDS IAM auth wiring for the proxy, a Helm values snippet, and trust-policy validation steps.

- **Migration**
  - Using RDS IAM auth? Set `irsa_additional_service_account_names = ["<release>-sandbox-proxy"]` in Terraform.
  - In Helm, annotate the proxy SA: `sandboxProxy.serviceAccount.annotations.eks.amazonaws.com/role-arn: <workload_irsa_role_arn>`; optionally set `sandboxProxy.serviceAccount.automount`. The IRSA role is created when S3 is used or RDS IAM is enabled, and the deployment auto-rolls on SA changes.

<sup>Written for commit 6a8a43ece4ce1304ca232aaf4b9ccc8100e8b5a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

