### PR TITLE
feat(craft): migrate sandbox sidecar to restartable init container

### DIFF
--- a/.github/workflows/pr-craft-k8s-tests.yml
+++ b/.github/workflows/pr-craft-k8s-tests.yml
@@ -168,6 +168,7 @@ jobs:
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # ratchet:helm/kind-action@v1.14.0
         with:
           cluster_name: onyx-craft-ci
+          node_image: kindest/node:v1.33.1
           config: ${{ runner.temp }}/kind-config.yaml
 
       # Connect the registry to kind's docker network and tell containerd
@@ -219,6 +220,7 @@ jobs:
           helm template onyx deployment/helm/charts/onyx \
             -n "${HELM_RELEASE_NAMESPACE}" \
             -f deployment/helm/charts/onyx/values-ci.yaml \
+            --kube-version 1.33.0 \
             --set "celery_shared.image.repository=localhost:5001/onyx-backend" \
             --set "celery_shared.image.tag=ci" \
             --show-only templates/sandbox-namespace.yaml \

--- a/backend/onyx/server/features/build/sandbox/README.md
+++ b/backend/onyx/server/features/build/sandbox/README.md
@@ -21,10 +21,12 @@ The sandbox system provides isolated execution environments where OpenCode agent
 
 1. **Kubernetes Mode** (`SANDBOX_BACKEND=kubernetes`) — default
    - Sandboxes run as Kubernetes pods, one per user
+   - Each pod has one app container (`sandbox`) plus one native restartable init sidecar (`sidecar`) for push/snapshot control-plane work
    - api_server talks to the Kubernetes API for pod lifecycle and `kubectl exec`
    - Automatic snapshots stream through the in-pod sidecar to the api_server-owned `FileStore`
    - Auto-cleanup of idle sandboxes
    - Production-ready with resource isolation, security context, and NetworkPolicies
+   - Requires Kubernetes `>= 1.33` for native restartable init sidecar containers
    - Used by Onyx's Helm chart / cloud deployment
    - For local-cluster development, see [docs/dev/local-kubernetes.md](/docs/dev/local-kubernetes.md).
 
@@ -97,7 +99,7 @@ docker build -t onyxdotapp/sandbox:latest .
 **How it works:**
 
 - **Sandbox image**: Bakes in the web template (`/workspace/templates/outputs`) and a pre-built Python venv (`/workspace/.venv`) from `initial-requirements.txt`
-- **Sidecar daemon** (Kubernetes only): Packages and restores session snapshots on the pod-local filesystem
+- **Native init sidecar daemon** (Kubernetes only): Starts before the sandbox app container, stays running for the pod lifetime, and packages/restores session snapshots on the pod-local filesystem
 - **Sandbox startup**: Runs `bun install --frozen-lockfile` (hardlinks from the image's pre-warmed Bun cache) + `bun run dev`
 
 ## OpenCode Configuration
@@ -152,6 +154,11 @@ OPENCODE_DISABLED_TOOLS=question           # Comma-separated list, default: ques
 ```
 
 ### Kubernetes Settings
+
+Kubernetes Craft sandboxes require Kubernetes `>= 1.33` because sandbox pods
+use native restartable init sidecar containers (`initContainers[*].restartPolicy:
+Always`). Helm installs with `ENABLE_CRAFT=true` and `SANDBOX_BACKEND=kubernetes`
+fail during render/install on older clusters.
 
 ```bash
 # Kubernetes namespace
@@ -254,7 +261,7 @@ uv run pytest backend/tests/external_dependency_unit/craft/test_kubernetes_sandb
 ### Sandbox Isolation
 
 - **Kubernetes pods** run with restricted security context (non-root, no privilege escalation)
-- **Sandbox and sidecar containers** do not receive FileStore, S3, or MinIO credentials
+- **Sandbox app containers and sidecar init containers** do not receive FileStore, S3, or MinIO credentials
 - **Network policies** can restrict sandbox egress traffic
 - **Resource limits** prevent resource exhaustion
 - **Docker containers** run with `--security-opt no-new-privileges`, `--cap-drop ALL`, `user=1000:1000`, no Docker socket, and a fixed env allowlist (`ONYX_PAT` + `ONYX_SERVER_URL`)

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -846,7 +846,8 @@ class KubernetesSandboxManager(SandboxManager):
         Returns:
             Error message if an init container failed, None otherwise
         """
-        if not pod.status.init_container_statuses:
+        init_statuses = pod.status.init_container_statuses or []
+        if not init_statuses:
             return None
 
         restartable_init_container_names = {
@@ -855,33 +856,30 @@ class KubernetesSandboxManager(SandboxManager):
             if init_container.name and init_container.restart_policy == "Always"
         }
 
-        for init_status in pod.status.init_container_statuses:
-            if init_status.state:
-                # Check for terminated state with non-zero exit code
-                if init_status.state.terminated:
-                    if (
-                        init_status.state.terminated.exit_code != 0
-                        and init_status.name not in restartable_init_container_names
-                    ):
-                        container_name = init_status.name
-                        logs = self._get_init_container_logs(
-                            pod.metadata.name, container_name
-                        )
-                        return (
-                            f"Init container '{container_name}' failed with exit code "
-                            f"{init_status.state.terminated.exit_code}. "
-                            f"Logs:\n{logs}"
-                        )
-                # Check for waiting state with error reason
-                elif init_status.state.waiting:
-                    if init_status.state.waiting.reason in [
-                        "Error",
-                        "CrashLoopBackOff",
-                    ]:
-                        container_name = init_status.name
-                        reason = init_status.state.waiting.reason
-                        message = init_status.state.waiting.message or ""
-                        return f"Init container '{container_name}' is in '{reason}' state. Message: {message}"
+        for init_status in init_statuses:
+            state = init_status.state
+            if state is None:
+                continue
+
+            waiting = state.waiting
+            if waiting and waiting.reason in ["Error", "CrashLoopBackOff"]:
+                message = waiting.message or ""
+                return (
+                    f"Init container '{init_status.name}' is in "
+                    f"'{waiting.reason}' state. Message: {message}"
+                )
+
+            terminated = state.terminated
+            if terminated is None or terminated.exit_code == 0:
+                continue
+            if init_status.name in restartable_init_container_names:
+                continue
+
+            logs = self._get_init_container_logs(pod.metadata.name, init_status.name)
+            return (
+                f"Init container '{init_status.name}' failed with exit code "
+                f"{terminated.exit_code}. Logs:\n{logs}"
+            )
 
         return None
 

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -641,7 +641,7 @@ class KubernetesSandboxManager(SandboxManager):
         missing the expected container) as an opaque ``StopIteration``; this
         names the container and the fix, matching the 404 PodTemplate error.
         """
-        for container in spec.containers or []:
+        for container in list(spec.containers or []) + list(spec.init_containers or []):
             if container.name == name:
                 return container
         raise RuntimeError(
@@ -849,11 +849,20 @@ class KubernetesSandboxManager(SandboxManager):
         if not pod.status.init_container_statuses:
             return None
 
+        restartable_init_container_names = {
+            init_container.name
+            for init_container in pod.spec.init_containers or []
+            if init_container.name and init_container.restart_policy == "Always"
+        }
+
         for init_status in pod.status.init_container_statuses:
             if init_status.state:
                 # Check for terminated state with non-zero exit code
                 if init_status.state.terminated:
-                    if init_status.state.terminated.exit_code != 0:
+                    if (
+                        init_status.state.terminated.exit_code != 0
+                        and init_status.name not in restartable_init_container_names
+                    ):
                         container_name = init_status.name
                         logs = self._get_init_container_logs(
                             pod.metadata.name, container_name

--- a/backend/tests/external_dependency_unit/craft/conftest.py
+++ b/backend/tests/external_dependency_unit/craft/conftest.py
@@ -859,10 +859,10 @@ def _cleanup_pool_workspace(
 ) -> None:
     """Wipe mutable trees on the pool pod before the next test runs.
 
-    ``managed/`` is read-only in the sandbox container but writable from the
-    sidecar (see ``kubernetes_sandbox_manager._build_pod_spec``), so we exec
-    via the sidecar for the skills + user_library subtrees. ``sessions/`` is
-    on a shared emptyDir, writable from either container.
+    ``managed/`` is read-only in the sandbox app container but writable from
+    the native init sidecar, so we exec via the sidecar for the skills +
+    user_library subtrees. ``sessions/`` is on a shared emptyDir, writable from
+    either container.
     """
     # managed/{skills,user_library} live under the RO mount — clean via sidecar.
     # ``find -mindepth 1 -delete`` removes only the directory's contents

--- a/backend/tests/external_dependency_unit/craft/test_kubernetes_sandbox.py
+++ b/backend/tests/external_dependency_unit/craft/test_kubernetes_sandbox.py
@@ -367,28 +367,36 @@ def test_health_check_returns_false_for_missing_pod(
 
 
 # ---------------------------------------------------------------------------
-# Sidecar contract: the two-container model is what enforces credential
-# isolation. These tests verify the live-cluster shape that the unit-level
-# pod-spec tests can't observe (IRSA injection happens at admission time).
+# Sidecar contract: the sandbox app container plus native init sidecar model
+# is what enforces credential isolation. These tests verify the live-cluster
+# shape that the unit-level pod-spec tests can't observe (IRSA injection
+# happens at admission time).
 # ---------------------------------------------------------------------------
 
 
-def test_pod_runs_sandbox_and_sidecar_containers(
+def test_pod_runs_sandbox_container_and_native_init_sidecar(
     k8s_client: client.CoreV1Api,
     pool_session: tuple[UUID, UUID, str],
 ) -> None:
-    """After provision, the pod has both `sandbox` and `sidecar` containers
-    and the sidecar reports ready (its `/health` probe is what gates this).
+    """After provision, the pod has one `sandbox` app container and a running
+    `sidecar` init container. The sidecar's `/health` readiness probe gates
+    pod readiness.
     """
     _, _, pod_name = pool_session
     pod = k8s_client.read_namespaced_pod(name=pod_name, namespace=SANDBOX_NAMESPACE)
 
-    statuses = {c.name: c for c in pod.status.container_statuses or []}
-    assert set(statuses) == {"sandbox", "sidecar"}, (
-        f"pod should have exactly 2 containers, got {set(statuses)}"
+    container_statuses = {c.name: c for c in pod.status.container_statuses or []}
+    init_statuses = {c.name: c for c in pod.status.init_container_statuses or []}
+    assert set(container_statuses) == {"sandbox"}, (
+        f"pod should have exactly 1 app container, got {set(container_statuses)}"
     )
-    assert statuses["sidecar"].ready, "sidecar should be ready via /health probe"
-    assert statuses["sandbox"].ready, "sandbox container should be ready"
+    assert {"sandbox-init", "sidecar"}.issubset(init_statuses), (
+        f"pod missing expected init containers, got {set(init_statuses)}"
+    )
+    assert init_statuses["sidecar"].ready, (
+        "sidecar init container should be ready via /health probe"
+    )
+    assert container_statuses["sandbox"].ready, "sandbox container should be ready"
 
 
 def test_irsa_credentials_stripped_from_sandbox_container(

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_k8s_push_error_mapping.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_k8s_push_error_mapping.py
@@ -27,6 +27,7 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from cryptography.hazmat.primitives.serialization import Encoding
 from cryptography.hazmat.primitives.serialization import NoEncryption
 from cryptography.hazmat.primitives.serialization import PrivateFormat
+from kubernetes import client
 from kubernetes.client.rest import ApiException
 
 from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager import (
@@ -293,6 +294,8 @@ def test_health_check_returns_false_when_sandbox_container_terminated() -> None:
                 running=None, terminated=SimpleNamespace(reason="OOMKilled")
             ),
         ),
+    ]
+    pod.status.init_container_statuses = [
         SimpleNamespace(
             name="sidecar",
             ready=True,
@@ -304,6 +307,99 @@ def test_health_check_returns_false_when_sandbox_container_terminated() -> None:
     with patch(_HTTPX_CLIENT_PATH, factory):
         assert mgr.health_check(_sandbox_id(), timeout=1.0) is False
     factory.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Pod readiness: restartable init sidecar failure semantics
+# ---------------------------------------------------------------------------
+
+
+def _pod_with_init_status(
+    *,
+    init_container: client.V1Container,
+    init_status: client.V1ContainerStatus,
+) -> client.V1Pod:
+    return client.V1Pod(
+        metadata=client.V1ObjectMeta(name="sandbox-test-pod"),
+        spec=client.V1PodSpec(
+            containers=[client.V1Container(name="sandbox")],
+            init_containers=[init_container],
+        ),
+        status=client.V1PodStatus(init_container_statuses=[init_status]),
+    )
+
+
+def test_init_container_nonzero_termination_is_fatal() -> None:
+    mgr = _make_manager()
+    pod = _pod_with_init_status(
+        init_container=client.V1Container(name="sandbox-init"),
+        init_status=client.V1ContainerStatus(
+            name="sandbox-init",
+            image="sandbox",
+            image_id="sandbox",
+            ready=False,
+            restart_count=0,
+            state=client.V1ContainerState(
+                terminated=client.V1ContainerStateTerminated(exit_code=1)
+            ),
+        ),
+    )
+
+    with patch.object(mgr, "_get_init_container_logs", return_value="iptables failed"):
+        error = mgr._check_init_container_status(pod)
+
+    assert error is not None
+    assert "sandbox-init" in error
+    assert "exit code 1" in error
+    assert "iptables failed" in error
+
+
+def test_restartable_init_container_transient_termination_is_not_fatal() -> None:
+    mgr = _make_manager()
+    pod = _pod_with_init_status(
+        init_container=client.V1Container(name="sidecar", restart_policy="Always"),
+        init_status=client.V1ContainerStatus(
+            name="sidecar",
+            image="sandbox",
+            image_id="sandbox",
+            ready=False,
+            restart_count=1,
+            state=client.V1ContainerState(
+                terminated=client.V1ContainerStateTerminated(exit_code=1)
+            ),
+        ),
+    )
+
+    with patch.object(mgr, "_get_init_container_logs") as get_logs:
+        assert mgr._check_init_container_status(pod) is None
+
+    get_logs.assert_not_called()
+
+
+def test_restartable_init_container_crashloop_waiting_is_fatal() -> None:
+    mgr = _make_manager()
+    pod = _pod_with_init_status(
+        init_container=client.V1Container(name="sidecar", restart_policy="Always"),
+        init_status=client.V1ContainerStatus(
+            name="sidecar",
+            image="sandbox",
+            image_id="sandbox",
+            ready=False,
+            restart_count=3,
+            state=client.V1ContainerState(
+                waiting=client.V1ContainerStateWaiting(
+                    reason="CrashLoopBackOff",
+                    message="back-off restarting failed container",
+                )
+            ),
+        ),
+    )
+
+    error = mgr._check_init_container_status(pod)
+
+    assert error is not None
+    assert "sidecar" in error
+    assert "CrashLoopBackOff" in error
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_pod_spec.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_pod_spec.py
@@ -1,8 +1,9 @@
-"""Pod spec invariants for the two-container sandbox.
+"""Pod spec invariants for the Kubernetes sandbox pod.
 
-The pod has two containers — `sandbox` (agent) and `sidecar` (control plane) —
-sharing a single image with different entrypoints. The asymmetries between
-them carry the security model:
+The pod has one app container — `sandbox` (agent) — plus a native Kubernetes
+sidecar implemented as a restartable init container named `sidecar`. They
+share a single image with different entrypoints. The asymmetries between them
+carry the security model:
 
   - `sandbox` must not see the push public key or run the push daemon.
   - `sandbox` must not be able to mutate `/workspace/managed/`.
@@ -141,6 +142,14 @@ def _container(pod: client.V1Pod, name: str) -> client.V1Container:
     return next(c for c in pod.spec.containers if c.name == name)
 
 
+def _init_container(pod: client.V1Pod, name: str) -> client.V1Container:
+    return next(c for c in pod.spec.init_containers or [] if c.name == name)
+
+
+def _sidecar(pod: client.V1Pod) -> client.V1Container:
+    return _init_container(pod, "sidecar")
+
+
 def _mount(container: client.V1Container, name: str) -> client.V1VolumeMount:
     return next(m for m in container.volume_mounts if m.name == name)
 
@@ -150,17 +159,22 @@ def _mount(container: client.V1Container, name: str) -> client.V1VolumeMount:
 # ---------------------------------------------------------------------------
 
 
-def test_pod_has_sandbox_and_sidecar_with_distinct_entrypoints(
+def test_pod_has_sandbox_app_container_and_native_init_sidecar(
     pod: client.V1Pod,
 ) -> None:
     """Same image, different commands — the asymmetry that turns one image
     into two roles."""
-    by_name = {c.name: c for c in pod.spec.containers}
-    assert set(by_name) == {"sandbox", "sidecar"}
-    assert by_name["sandbox"].image == by_name["sidecar"].image
-    assert by_name["sandbox"].command != by_name["sidecar"].command
-    assert by_name["sandbox"].command == ["/workspace/entrypoint.sh"]
-    assert by_name["sidecar"].command == ["/workspace/sidecar-entrypoint.sh"]
+    app_by_name = {c.name: c for c in pod.spec.containers}
+    init_by_name = {c.name: c for c in pod.spec.init_containers or []}
+
+    assert set(app_by_name) == {"sandbox"}
+    assert list(init_by_name) == ["sandbox-init", "sidecar"]
+    assert app_by_name["sandbox"].image == init_by_name["sidecar"].image
+    assert app_by_name["sandbox"].command != init_by_name["sidecar"].command
+    assert app_by_name["sandbox"].command == ["/workspace/entrypoint.sh"]
+    assert init_by_name["sidecar"].command == ["/workspace/sidecar-entrypoint.sh"]
+    assert init_by_name["sidecar"].restart_policy == "Always"
+    assert pod.spec.restart_policy == "Never"
 
 
 # ---------------------------------------------------------------------------
@@ -170,7 +184,7 @@ def test_pod_has_sandbox_and_sidecar_with_distinct_entrypoints(
 
 def test_push_daemon_port_is_declared_on_sidecar_only(pod: client.V1Pod) -> None:
     sandbox_ports = {p.container_port for p in _container(pod, "sandbox").ports}
-    sidecar_ports = {p.container_port for p in _container(pod, "sidecar").ports}
+    sidecar_ports = {p.container_port for p in _sidecar(pod).ports}
     assert PUSH_DAEMON_PORT in sidecar_ports
     assert PUSH_DAEMON_PORT not in sandbox_ports
 
@@ -183,13 +197,13 @@ def test_push_public_key_is_in_sidecar_env_only(pod: client.V1Pod) -> None:
     but unnecessary surface.
     """
     sandbox_env = {e.name for e in _container(pod, "sandbox").env}
-    sidecar_env = {e.name for e in _container(pod, "sidecar").env}
+    sidecar_env = {e.name for e in _sidecar(pod).env}
     assert "ONYX_SANDBOX_PUSH_PUBLIC_KEY" in sidecar_env
     assert "ONYX_SANDBOX_PUSH_PUBLIC_KEY" not in sandbox_env
 
 
 def test_sidecar_health_probes_target_the_daemon_port(pod: client.V1Pod) -> None:
-    sidecar = _container(pod, "sidecar")
+    sidecar = _sidecar(pod)
     for probe in (sidecar.liveness_probe, sidecar.readiness_probe):
         assert probe is not None
         assert probe.http_get.path == "/health"
@@ -207,7 +221,7 @@ def test_managed_volume_is_writable_only_from_sidecar(pod: client.V1Pod) -> None
     after extraction — so it mounts the same volume read-only.
     """
     sandbox_mount = _mount(_container(pod, "sandbox"), "managed")
-    sidecar_mount = _mount(_container(pod, "sidecar"), "managed")
+    sidecar_mount = _mount(_sidecar(pod), "managed")
     assert sandbox_mount.read_only is True
     # K8s treats None and False equivalently for volume mounts.
     assert not sidecar_mount.read_only
@@ -225,8 +239,8 @@ def test_workspace_volume_is_shared_for_session_io(pod: client.V1Pod) -> None:
         "sandbox-ca-source",
         "sandbox-ca-bundle",
     }
-    for name in ("sandbox", "sidecar"):
-        mount = _mount(_container(pod, name), "workspace")
+    for container in (_container(pod, "sandbox"), _sidecar(pod)):
+        mount = _mount(container, "workspace")
         assert mount.mount_path == "/workspace/sessions"
         assert not mount.read_only
 
@@ -284,8 +298,12 @@ _PROXY_ENV_NAMES = {
 def test_proxy_env_is_set_on_sandbox_and_sidecar(pod: client.V1Pod) -> None:
     """Both containers' outbound traffic must be routed through the proxy —
     sandbox for the agent and sidecar for control-plane callbacks."""
-    for name in ("sandbox", "sidecar"):
-        env = {e.name for e in _container(pod, name).env}
+    containers = {
+        "sandbox": _container(pod, "sandbox"),
+        "sidecar": _sidecar(pod),
+    }
+    for name, container in containers.items():
+        env = {e.name for e in container.env}
         assert _PROXY_ENV_NAMES.issubset(env), (
             f"{name} container missing proxy env: {_PROXY_ENV_NAMES - env}"
         )
@@ -303,18 +321,36 @@ def test_snapshot_storage_credentials_are_not_in_pod_env(pod: client.V1Pod) -> N
         "S3_AWS_ACCESS_KEY_ID",
         "S3_AWS_SECRET_ACCESS_KEY",
     }
-    for name in ("sandbox", "sidecar"):
-        env = {e.name for e in _container(pod, name).env}
+    containers = {
+        "sandbox": _container(pod, "sandbox"),
+        "sidecar": _sidecar(pod),
+    }
+    for name, container in containers.items():
+        env = {e.name for e in container.env}
         assert env.isdisjoint(forbidden), (
             f"{name} leaked storage env: {env & forbidden}"
         )
 
 
-def test_proxy_init_container_present(pod: client.V1Pod) -> None:
+def test_init_containers_preserve_proxy_then_sidecar_order(pod: client.V1Pod) -> None:
     """The iptables-lockdown initContainer must run before any user code —
     it's what blocks direct egress that the HTTPS_PROXY env doesn't catch."""
     init_names = [c.name for c in (pod.spec.init_containers or [])]
-    assert init_names == ["sandbox-init"]
+    assert init_names == ["sandbox-init", "sidecar"]
+    assert _init_container(pod, "sandbox-init").restart_policy is None
+    assert _sidecar(pod).restart_policy == "Always"
+
+
+def test_sidecar_restart_policy_serializes_for_kubernetes_api(
+    pod: client.V1Pod,
+) -> None:
+    serialized = client.ApiClient().sanitize_for_serialization(pod)
+    init_containers = serialized["spec"]["initContainers"]
+    sidecar = next(c for c in init_containers if c["name"] == "sidecar")
+    sandbox_init = next(c for c in init_containers if c["name"] == "sandbox-init")
+
+    assert sidecar["restartPolicy"] == "Always"
+    assert "restartPolicy" not in sandbox_init
 
 
 def test_host_aliases_pin_proxy(pod: client.V1Pod) -> None:
@@ -329,8 +365,8 @@ def test_ca_bundle_mounted_read_only_on_both_containers(pod: client.V1Pod) -> No
     """The proxy terminates TLS with its own CA, so every container that
     makes HTTPS calls must mount the CA bundle. Read-only — the bundle is
     populated by the initContainer and must not be writable by the agent."""
-    for name in ("sandbox", "sidecar"):
-        mount = _mount(_container(pod, name), "sandbox-ca-bundle")
+    for container in (_container(pod, "sandbox"), _sidecar(pod)):
+        mount = _mount(container, "sandbox-ca-bundle")
         assert mount.read_only is True
         assert mount.mount_path == "/etc/ssl/sandbox"
 

--- a/deployment/helm/README.md
+++ b/deployment/helm/README.md
@@ -46,6 +46,19 @@ If you don't want the bundled Redis (recommended for production environments usi
 managed Redis like AWS ElastiCache), see [Using an external Redis](#using-an-external-redis)
 below and set `redis.enabled: false` to skip the operator entirely.
 
+## Onyx Craft with Kubernetes sandboxes
+
+When `configMap.ENABLE_CRAFT="true"` and `configMap.SANDBOX_BACKEND="kubernetes"`
+(the Helm default), the target cluster must run Kubernetes `>= 1.33`. Craft
+sandbox pods use native restartable init sidecar containers: `sandbox-init`
+runs and completes first, `sidecar` starts next as an `initContainers` entry
+with `restartPolicy: Always`, and the main `sandbox` app container starts
+after the sidecar is ready.
+
+The chart fails during render/install on older clusters so the incompatibility
+is caught before sandbox provisioning. This guard does not apply to non-Craft
+installs or Docker sandbox deployments.
+
 ## Using an external Redis
 
 To point Onyx at an externally-managed Redis (e.g. AWS ElastiCache) and skip
@@ -197,6 +210,11 @@ Other docker-compose-style values you should set deliberately:
 ## Output template to file and inspect
 * cd charts/onyx
 * helm template test-output . --set auth.opensearch.values.opensearch_admin_password='StrongPassword123!' > test-output.yaml
+* Craft Kubernetes sandbox version guard check:
+  * expect failure:
+    `helm template test-output . -f values-ci.yaml --kube-version 1.32.0 --show-only templates/craft-kubernetes-version-check.yaml`
+  * expect success:
+    `helm template test-output . -f values-ci.yaml --kube-version 1.33.0 --show-only templates/craft-kubernetes-version-check.yaml`
 
 ## Test the entire cluster manually
 * cd charts/onyx

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.5.23
+version: 0.5.24
 appVersion: latest
 annotations:
   category: Productivity
@@ -17,11 +17,8 @@ annotations:
       image: docker.io/onyxdotapp/onyx-backend:latest
   artifacthub.io/changes: |
     - kind: changed
-      description: Add sandbox-proxy ServiceAccount annotation support for
-        IAM-backed managed services.
-    - kind: changed
-      description: Store Craft sandbox snapshots in the Onyx filestore instead
-        of requiring sandbox pods to write directly to S3.
+      description: Run the Craft Kubernetes sandbox sidecar as a restartable
+        init container and require Kubernetes 1.33 or newer for that backend.
 dependencies:
   - name: cloudnative-pg
     version: 0.26.0

--- a/deployment/helm/charts/onyx/templates/_helpers.tpl
+++ b/deployment/helm/charts/onyx/templates/_helpers.tpl
@@ -220,6 +220,14 @@ Return the configured autoscaling engine; defaults to HPA when unset.
 {{- end }}
 
 {{/*
+"true" when Craft is enabled and configured to provision Kubernetes sandbox pods.
+*/}}
+{{- define "onyx.craftKubernetesSandboxEnabled" -}}
+{{- $sandboxBackend := toString ((index .Values.configMap "SANDBOX_BACKEND") | default "kubernetes") -}}
+{{- if and (eq (include "onyx.craftEnabled" .) "true") (eq $sandboxBackend "kubernetes") -}}true{{- end -}}
+{{- end }}
+
+{{/*
 "true" when custom CA certificates are configured, empty otherwise.
 */}}
 {{- define "onyx.customCACerts.enabled" -}}

--- a/deployment/helm/charts/onyx/templates/craft-kubernetes-version-check.yaml
+++ b/deployment/helm/charts/onyx/templates/craft-kubernetes-version-check.yaml
@@ -1,0 +1,8 @@
+{{- if eq (include "onyx.craftKubernetesSandboxEnabled" .) "true" }}
+{{- if not (semverCompare ">=1.33.0-0" .Capabilities.KubeVersion.Version) }}
+{{- fail (printf "Onyx Craft with configMap.SANDBOX_BACKEND=kubernetes requires Kubernetes >= 1.33 because sandbox pods use native restartable init sidecar containers; target cluster reports %s. Use a newer Kubernetes cluster or set configMap.SANDBOX_BACKEND=docker for Docker sandbox deployments." .Capabilities.KubeVersion.Version) }}
+{{- end }}
+# Craft Kubernetes sandbox version check passed for {{ .Capabilities.KubeVersion.Version }}.
+{{- else }}
+# Craft Kubernetes sandbox version check skipped.
+{{- end }}

--- a/deployment/helm/charts/onyx/templates/sandbox-podtemplate.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-podtemplate.yaml
@@ -84,6 +84,38 @@ template:
           capabilities:
             drop: ["ALL"]
             add: ["NET_ADMIN"]
+      - name: sidecar
+        image: {{ $image }}
+        imagePullPolicy: {{ $pullPolicy }}
+        command: ["/workspace/sidecar-entrypoint.sh"]
+        restartPolicy: Always
+        ports:
+          - { name: push-daemon, containerPort: {{ $pushDaemonPort }} }
+        env:
+          {{- include "onyx.sandboxProxyEnv" (dict "proxyPort" $proxyPort "caBundleFile" $caBundleFile) | nindent 10 }}
+        volumeMounts:
+          - { name: workspace, mountPath: /workspace/sessions }
+          - { name: managed, mountPath: /workspace/managed }
+          - { name: sandbox-ca-bundle, mountPath: /etc/ssl/sandbox, readOnly: true }
+        resources:
+          # Snapshot tar/stream runs through this sidecar, so give it headroom.
+          requests: { cpu: "100m", memory: "256Mi" }
+          limits: { cpu: "1", memory: "1Gi" }
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
+          privileged: false
+          capabilities:
+            drop: ["ALL"]
+        livenessProbe:
+          httpGet: { path: /health, port: {{ $pushDaemonPort }} }
+          initialDelaySeconds: 5
+          periodSeconds: 30
+        readinessProbe:
+          httpGet: { path: /health, port: {{ $pushDaemonPort }} }
+          initialDelaySeconds: 1
+          periodSeconds: 2
+          failureThreshold: 10
     containers:
       - name: sandbox
         image: {{ $image }}
@@ -113,37 +145,6 @@ template:
           privileged: false
           capabilities:
             drop: ["ALL"]
-      - name: sidecar
-        image: {{ $image }}
-        imagePullPolicy: {{ $pullPolicy }}
-        command: ["/workspace/sidecar-entrypoint.sh"]
-        ports:
-          - { name: push-daemon, containerPort: {{ $pushDaemonPort }} }
-        env:
-          {{- include "onyx.sandboxProxyEnv" (dict "proxyPort" $proxyPort "caBundleFile" $caBundleFile) | nindent 10 }}
-        volumeMounts:
-          - { name: workspace, mountPath: /workspace/sessions }
-          - { name: managed, mountPath: /workspace/managed }
-          - { name: sandbox-ca-bundle, mountPath: /etc/ssl/sandbox, readOnly: true }
-        resources:
-          # Snapshot tar/stream runs through this sidecar, so give it headroom.
-          requests: { cpu: "100m", memory: "256Mi" }
-          limits: { cpu: "1", memory: "1Gi" }
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: false
-          privileged: false
-          capabilities:
-            drop: ["ALL"]
-        livenessProbe:
-          httpGet: { path: /health, port: {{ $pushDaemonPort }} }
-          initialDelaySeconds: 5
-          periodSeconds: 30
-        readinessProbe:
-          httpGet: { path: /health, port: {{ $pushDaemonPort }} }
-          initialDelaySeconds: 1
-          periodSeconds: 2
-          failureThreshold: 10
     volumes:
       - name: workspace
         emptyDir: { sizeLimit: 50Gi }

--- a/deployment/helm/dev/k8s-up.sh
+++ b/deployment/helm/dev/k8s-up.sh
@@ -23,6 +23,7 @@ NAMESPACE="onyx"
 OPENSEARCH_PASSWORD=""
 SKIP_CLUSTER_CREATE=0
 SKIP_HELM=0
+KIND_NODE_IMAGE="${KIND_NODE_IMAGE:-kindest/node:v1.33.1}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CHART_DIR="$(cd "$SCRIPT_DIR/../charts/onyx" && pwd)"
@@ -65,8 +66,8 @@ if [[ "$SKIP_CLUSTER_CREATE" -eq 0 ]]; then
   if kind get clusters 2>/dev/null | grep -qx "$CLUSTER_NAME"; then
     echo "kind cluster '$CLUSTER_NAME' already exists; skipping create"
   else
-    echo "creating kind cluster '$CLUSTER_NAME' ..."
-    kind create cluster --name "$CLUSTER_NAME"
+    echo "creating kind cluster '$CLUSTER_NAME' with node image '$KIND_NODE_IMAGE' ..."
+    kind create cluster --name "$CLUSTER_NAME" --image "$KIND_NODE_IMAGE"
   fi
 fi
 

--- a/docs/craft/infra/sidecar-reimplementation.md
+++ b/docs/craft/infra/sidecar-reimplementation.md
@@ -1,10 +1,12 @@
 # Sidecar Reimplementation for Craft Sandboxes
 
-The sandbox pod uses two containers from the same image:
+The sandbox pod uses one app container plus one native restartable init
+sidecar from the same image:
 
 - `sandbox`: untrusted agent/code execution.
 - `sidecar`: signed control-plane filesystem API for bundle pushes and
-  snapshot tar/untar operations.
+  snapshot tar/untar operations. It is rendered in `initContainers` with
+  `restartPolicy: Always`.
 
 The sidecar is not a durable-storage client. It does not receive S3 bucket
 names, AWS credentials, or workload identity. Snapshot bytes are streamed
@@ -18,20 +20,26 @@ Pod: sandbox-{id}
 ServiceAccount: sandbox
 shareProcessNamespace: false
 
-containers:
-  sandbox
-    - opencode agent
-    - Next.js dev server
-    - read-only /workspace/managed
-    - read/write /workspace/sessions
-    - no snapshot storage credentials
+initContainers:
+  sandbox-init
+    - firewall/proxy bootstrap
+    - must complete before user code
 
   sidecar
+    - restartPolicy: Always
     - daemon on :8731
     - POST /push for bundle materialization
     - POST /snapshot/create for gzip snapshot stream
     - POST /snapshot/restore/{session_id} for gzip restore stream
     - read/write /workspace/managed
+    - read/write /workspace/sessions
+    - no snapshot storage credentials
+
+containers:
+  sandbox
+    - opencode agent
+    - Next.js dev server
+    - read-only /workspace/managed
     - read/write /workspace/sessions
     - no snapshot storage credentials
 ```
@@ -66,6 +74,8 @@ Restore:
 - Helm renders `ServiceAccount/sandbox` without storage annotations.
 - Helm renders sandbox manager RBAC for the Onyx workload ServiceAccount and
   any `craft.extraBoundServiceAccounts`.
+- Kubernetes `>= 1.33` is required for native restartable init sidecar
+  containers.
 - Terraform does not create Craft-specific snapshot buckets or roles.
 - The main FileStore configuration is the only durable storage configuration
   needed for snapshots.
@@ -74,6 +84,7 @@ Restore:
 
 - Sidecar unit tests for signed create/restore, checksum validation, and replay
   resistance.
-- Pod spec tests proving storage env vars are absent from both containers.
+- Pod spec tests proving storage env vars are absent from the sandbox app
+  container and sidecar init container.
 - K8s external dependency tests proving snapshot create/restore round trips via
   FileStore.

--- a/docs/dev/local-kubernetes.md
+++ b/docs/dev/local-kubernetes.md
@@ -22,6 +22,11 @@ Builds on the CONTRIBUTING.md prereqs (Python 3.13, uv, Node.js 22, the venv,
 `.vscode/.env`). Docker Desktop must be running with at least 8 CPU / 16 GB
 allocated.
 
+Craft sandbox pods use Kubernetes native restartable init sidecar containers,
+so the cluster must run Kubernetes `>= 1.33`. The local `k8s-up.sh` script pins
+kind to `kindest/node:v1.33.1` by default; set `KIND_NODE_IMAGE` before running
+the script if you need a different compatible kind node image.
+
 ```bash
 brew install kind helm kubectl
 
@@ -111,7 +116,9 @@ can also invoke them individually for tighter rebuild loops.
 [`deployment/helm/dev/k8s-up.sh`](/deployment/helm/dev/k8s-up.sh). The
 script is idempotent and refuses to run unless your kubectl context is
 `kind-onyx-dev`. It also installs the telepresence traffic-manager once
-per cluster.
+per cluster. New clusters use the `kindest/node:v1.33.1` node image so Craft's
+native init sidecar pod shape is supported. Existing clusters are not recreated;
+set `KIND_NODE_IMAGE` to override the default for a newly created cluster.
 
 Watch pods (vespa and CNPG-postgres take a minute or two on first boot):
 


### PR DESCRIPTION
## Description

- Move the Craft Kubernetes sandbox sidecar into `initContainers` with `restartPolicy: Always` so it uses native restartable init sidecar semantics.
- Add a Helm guard requiring Kubernetes >= 1.33 when Craft uses the Kubernetes sandbox backend.
- Update CI/local kind config, tests, and docs for the new pod shape.

## How Has This Been Tested?

- Applied the rebased Helm chart to local kind (`kind-onyx-dev`) with `helm upgrade --install`; release `onyx` is deployed at revision 24.
- Confirmed the live `sandbox-pod` PodTemplate renders one app container (`sandbox`) and restartable init containers `sandbox-init` and `sidecar: Always`.
- Ran a local E2E smoke through `http://localhost:3000/api` using `wenxi@onyx.app` to mint a PAT, authenticate with `Authorization: Bearer`, create a headless Craft build session, verify `/build/sessions/{id}` and `/build/sessions/{id}/files?path=outputs`, and inspect the resulting kind pod.
- Confirmed the live sandbox pod had `containers=['sandbox']`, `initContainers=[('sandbox-init', None), ('sidecar', 'Always')]`, and both `sandbox` and `sidecar` were running/ready.
- Deleted the smoke-test build session and revoked the temporary PAT.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the Craft Kubernetes sandbox sidecar to a native restartable init sidecar to simplify lifecycle while preserving the security model. Adds a Helm guard for Kubernetes >= 1.33 and updates the pod template, manager logic, tests, CI/kind, and docs.

- **Migration**
  - Sidecar moves to `initContainers` with `restartPolicy: Always`; run order is `sandbox-init` → `sidecar` → `sandbox`, with readiness gated on the sidecar’s `/health`.
  - Manager searches app and init containers; treats non-zero terminations of restartable init containers as non-fatal, but `CrashLoopBackOff` as fatal. Adds tests for failure semantics and Kubernetes API serialization of sidecar `restartPolicy`.

- **Dependencies**
  - Helm adds a version check that fails render/install on clusters < 1.33 when Craft uses the Kubernetes backend; new helper `onyx.craftKubernetesSandboxEnabled`.
  - CI/dev pin `kindest/node:v1.33.1` and render with `--kube-version 1.33.0`; `KIND_NODE_IMAGE` allows overrides. Docs updated; chart bumped to `0.5.24`.

<sup>Written for commit 055d770b6ac4913b06387cef3db15ad5fe7fdc21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

