### PR TITLE
fix(chat): flush trailing lookahead buffer at end of stream

### DIFF
--- a/backend/onyx/chat/citation_processor.py
+++ b/backend/onyx/chat/citation_processor.py
@@ -275,11 +275,15 @@ class DynamicCitationProcessor:
             str: Text chunks to display. Citation format depends on citation_mode.
             CitationInfo: Citation metadata (only when citation_mode=HYPERLINK)
         """
-        # None -> end of stream, flush remaining segment
-        if token is None:
-            if self.curr_segment:
-                yield self.curr_segment
-            return
+        # None -> end of stream, flush remaining segment and lookahead buffers
+if token is None:
+    # Combine any held characters from partial stop-token matches with the current segment
+    remaining = self.hold + self.curr_segment
+    if remaining:
+        yield remaining
+    self.hold = ""
+    self.curr_segment = ""
+    return
 
         # Handle stop stream token
         if self.stop_stream:


### PR DESCRIPTION
Fixes mid-token truncation on stream termination by properly clearing and yielding the lookahead buffer (self.hold) inside the DynamicCitationProcessor. When the stream ends, any characters held in self.hold were previously dropped; this change ensures they are flushed alongside the current segment.

## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mid-token truncation at stream end by flushing the lookahead buffer in `DynamicCitationProcessor`. Ensures trailing characters in `self.hold` are emitted with the final segment.

- **Bug Fixes**
  - On `token is None`, combine `self.hold` + `self.curr_segment`, yield once, then reset both buffers.

<sup>Written for commit 91a8ae789f15d11ace5e6b709a8de563ca918ca2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11934?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

