### PR TITLE
feat(load-tests): tool-call + deep-research support in mock LLM, scenarios, Dockerfile 1/n

### DIFF
--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -49,6 +49,20 @@ required/forced, the deep-research phase sequence (clarification →
 plan → orchestrator → research agents → reports), and `max_tokens` caps.
 Contract tests: `uv run pytest tests/ -q`.
 
+### Provider profiles
+
+Knob combinations imitate real provider latency profiles — register each as
+a model configuration and select per scenario to test how Onyx behaves when
+the provider is fast, slow, or degraded (slow providers hold streams and
+their resources open longer, which is exactly what stresses the api-server):
+
+| Profile | Model name |
+|---|---|
+| Fast chat model (gpt-class) | `mock-ttft300-itl15-len150` |
+| Slow reasoning model (long silent TTFT) | `mock-ttft8000-itl40-len600` |
+| Degraded/overloaded provider | `mock-ttft20000-itl200-len300` |
+| Long-answer generation | `mock-ttft500-itl20-len2000` |
+
 ## Running
 
 ```bash

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -74,8 +74,8 @@ ONYX_API_KEY=<key> uv run locust --headless -u 5 -r 1 -t 5m -H https://st-dev.on
 Scenario selection (all run by default; pick classes explicitly):
 
 ```bash
-... uv run locust --headless -u 10 -r 2 -t 10m BasicChatUser ChatWithSearchUser
-... uv run locust --headless -u 5 -r 1 -t 20m DeepResearchUser
+... uv run locust --headless -u 10 -r 2 -t 10m -H https://st-dev.onyx.app BasicChatUser ChatWithSearchUser
+... uv run locust --headless -u 5 -r 1 -t 20m -H https://st-dev.onyx.app DeepResearchUser
 ```
 
 - **BasicChatUser** (`chat:*` metrics) — single-turn chat, plain answer.

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -32,7 +32,9 @@ provider type **`openai_compatible`** — NOT `openai`, which litellm routes
 through the OpenAI Responses API bridge that the mock doesn't implement —
 with `api_base` pointing at the server (e.g. `http://localhost:8001`), any
 api_key, and model configurations for the model names you'll use (e.g.
-`mock-model`, `mock-tools1`, `mock-agents2`).
+`mock-model`, `mock-tools1`, `mock-agents2`). Set **max input tokens ≥
+50,000** on each model configuration — deep research refuses models below
+that, and unregistered models default far lower.
 
 Behavior knobs ride in the model name (litellm passes it through verbatim):
 

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -1,14 +1,13 @@
 # Onyx Chat Load Tests (Locust)
 
-Load tests for the critical chat path: streaming chat turns with tool calls
-and (later phases) deep research, measured by per-milestone latency.
+Load tests for the critical chat path: streaming chat turns, search-tool
+turns, and deep research, measured by per-milestone latency.
 
 **Guiding principle:** these tests measure Onyx's application code and
 infrastructure under load — never LLM answer quality. The LLM is a
-controllable dependency: a real cheap model is used only for the initial
-harness shakeout; real load runs use a zero-cost deterministic mock LLM
-provider (Phase 1) so call volume is unlimited and every regression is
-attributable to Onyx code/infra.
+controllable dependency: the bundled mock LLM server provides unlimited,
+zero-cost, deterministic call volume so every regression is attributable to
+Onyx code.
 
 This is a **standalone uv project** — intentionally not a member of the root
 uv workspace, so Locust's gevent pins never constrain the backend lockfile.
@@ -22,17 +21,54 @@ cd loadtest
 uv sync
 ```
 
+### Mock LLM server
+
+```bash
+uv run uvicorn mock_llm.app:app --port 8001
+```
+
+Register it in Onyx (Admin Panel → LLM, or `PUT /api/admin/llm/provider`) as
+provider type **`openai_compatible`** — NOT `openai`, which litellm routes
+through the OpenAI Responses API bridge that the mock doesn't implement —
+with `api_base` pointing at the server (e.g. `http://localhost:8001`), any
+api_key, and model configurations for the model names you'll use (e.g.
+`mock-model`, `mock-tools1`, `mock-agents2`).
+
+Behavior knobs ride in the model name (litellm passes it through verbatim):
+
+| Knob | Example | Meaning |
+|---|---|---|
+| `ttft<ms>` | `mock-ttft500` | time to first token |
+| `itl<ms>` | `mock-itl20` | inter-token delay |
+| `len<n>` | `mock-len400` | answer length in tokens |
+| `tools<0/1>` | `mock-tools1` | call the search tool on the first AUTO cycle |
+| `agents<n>` | `mock-agents2` | parallel research agents per DR orchestrator cycle |
+
+The mock understands Onyx's LLM-loop contract: `tool_choice` none/auto/
+required/forced, the deep-research phase sequence (clarification →
+plan → orchestrator → research agents → reports), and `max_tokens` caps.
+Contract tests: `uv run pytest tests/ -q`.
+
 ## Running
 
 ```bash
 ONYX_API_KEY=<key> uv run locust --headless -u 5 -r 1 -t 5m -H https://st-dev.onyx.app
 ```
 
-Or with the web UI (live charts at http://localhost:8089):
+Scenario selection (all run by default; pick classes explicitly):
 
 ```bash
-ONYX_API_KEY=<key> uv run locust -H https://st-dev.onyx.app
+... uv run locust --headless -u 10 -r 2 -t 10m BasicChatUser ChatWithSearchUser
+... uv run locust --headless -u 5 -r 1 -t 20m DeepResearchUser
 ```
+
+- **BasicChatUser** (`chat:*` metrics) — single-turn chat, plain answer.
+- **ChatWithSearchUser** (`search:*`) — mock emits an `internal_search` tool
+  call, so query expansion, the embedding model server, and Vespa/OpenSearch
+  genuinely execute. Requires indexed documents in the target deployment.
+- **DeepResearchUser** (`dr:*`) — full deep-research turn (plan, parallel
+  research agents, intermediate + final reports). Heaviest scenario; one
+  turn = ~8+ LLM calls + real search executions on one held stream.
 
 The API key is created by an admin via `POST /api/admin/api-key`
 (`{"name": "loadtest", "role": "basic"}`) or Admin Panel → API Keys.
@@ -42,30 +78,43 @@ The API key is created by an admin via `POST /api/admin/api-key`
 | Variable | Default | Purpose |
 |---|---|---|
 | `ONYX_API_KEY` | required | Bearer token for all requests |
-| `ONYX_LLM_PROVIDER` + `ONYX_LLM_MODEL` | unset | Per-request `llm_override` (e.g. provider name + `gpt-5-mini`); unset = persona default |
+| `ONYX_LLM_PROVIDER` | unset | Provider name for `llm_override` (needed when the mock isn't the deployment default) |
+| `ONYX_LLM_MODEL` | unset | Model for BasicChatUser (unset = persona default) |
+| `ONYX_SEARCH_MODEL` | `mock-tools1` | Model for ChatWithSearchUser |
+| `ONYX_DR_MODEL` | `mock-agents2` | Model for DeepResearchUser |
 | `ONYX_WAIT_SECONDS` | 15 | Think time between turns per user |
-| `ONYX_STREAM_READ_TIMEOUT` | 180 | Max seconds between stream chunks before failing the turn |
-| `ONYX_DEEP_RESEARCH` | unset | `true` = send `deep_research: true` on every turn |
+| `ONYX_DR_WAIT_SECONDS` | 30 | Think time for DR users |
+| `ONYX_STREAM_READ_TIMEOUT` | 180 | Max seconds between stream chunks |
+| `ONYX_DR_STREAM_READ_TIMEOUT` | 300 | Same, for DR turns |
+| `MOCK_TTFT_MS` / `MOCK_ITL_MS` / `MOCK_LEN_TOKENS` | 300 / 15 / 150 | Mock server defaults (model-name knobs override) |
 
 ## Metrics
 
-Each chat turn fires named pseudo-requests the moment the milestone packet
-arrives on the stream; Locust aggregates percentiles per name:
+Each turn fires named pseudo-requests (`<scenario>:<milestone>`) the moment
+the milestone packet arrives; Locust aggregates percentiles per name:
 
-- `chat:first_packet` — first stream line (server accepted + began work)
-- `chat:first_search_doc` — first search-tool document batch
-- `chat:first_answer_token` — first answer content (TTFT)
-- `chat:total_turn` — full turn wall time; success/failure is recorded here
-- `chat:send (headers)` — the raw HTTP request; its time is headers-only
-  (stream=True), so read milestones above for real latency
+- `*:first_packet` — first stream line (server accepted + began work)
+- `*:first_search_doc` — first search-tool document batch (retrieval latency)
+- `*:first_answer_token` — first answer content (TTFT)
+- `*:first_dr_plan` / `*:first_research_agent` — deep-research phase starts
+- `*:total_turn` — full turn wall time; success/failure recorded here
+- `*:send (headers)` — raw HTTP request (headers-only timing)
 
-A turn fails if: non-200 response, an error packet appears, the stream stalls
-past the read timeout, or the stream ends without answer content.
+A turn fails on: non-200, an error packet, a stream stalling past the read
+timeout, or a stream ending without answer content / without the `stop`
+packet (truncation).
+
+## Docker
+
+```bash
+cd loadtest && docker build -f mock_llm/Dockerfile -t onyx-mock-llm .
+docker run -p 8001:8000 onyx-mock-llm
+```
 
 ## Roadmap
 
-- Phase 0 (this): basic chat vs st-dev, real cheap LLM via `llm_override`
-- Phase 1: `mock_llm/` — OpenAI-compatible deterministic mock server
+- ✅ Phase 0: harness + milestones + mock LLM core
+- ✅ Phase 1: tool-call & deep-research scripting, scenarios, Dockerfile
 - Phase 2: in-cluster Locust master/workers + mock provider on st-dev (`k8s/`)
-- Phase 3: weighted scenario suite (chat+search, multi-turn, deep research)
+- Phase 3: weighted scenario mixes, multi-turn sessions, open-workload arrivals
 - Phase 4: Prometheus export + Grafana correlation dashboard

--- a/loadtest/locustfile.py
+++ b/loadtest/locustfile.py
@@ -5,9 +5,15 @@ Usage (from this directory, after `uv sync`):
     ONYX_API_KEY=... uv run locust --headless -u 5 -r 1 -t 5m \
         -H https://st-dev.onyx.app
 
+Select scenarios with Locust's class picker, e.g.:
+
+    ... uv run locust --headless -u 10 -r 2 -t 10m BasicChatUser ChatWithSearchUser
+
 See README.md for configuration env vars and scenario details.
 """
 
 from onyx_client.chat_user import BasicChatUser
+from scenarios import ChatWithSearchUser
+from scenarios import DeepResearchUser
 
-__all__ = ["BasicChatUser"]
+__all__ = ["BasicChatUser", "ChatWithSearchUser", "DeepResearchUser"]

--- a/loadtest/mock_llm/Dockerfile
+++ b/loadtest/mock_llm/Dockerfile
@@ -5,7 +5,8 @@ FROM ${BASE_IMAGE_REGISTRY}/library/python:3.13-slim@sha256:b04b5d7233d2ad9c379e
 
 WORKDIR /app
 
-RUN pip install --no-cache-dir fastapi uvicorn
+# Keep pins in sync with ../pyproject.toml + uv.lock (reproducible builds).
+RUN pip install --no-cache-dir fastapi==0.136.3 uvicorn==0.49.0
 
 COPY ./mock_llm /app/mock_llm
 

--- a/loadtest/mock_llm/Dockerfile
+++ b/loadtest/mock_llm/Dockerfile
@@ -1,0 +1,14 @@
+# Mock OpenAI-compatible LLM server for Onyx load testing.
+# Build from the loadtest/ directory:  docker build -f mock_llm/Dockerfile -t onyx-mock-llm .
+ARG BASE_IMAGE_REGISTRY=docker.io
+FROM ${BASE_IMAGE_REGISTRY}/library/python:3.13-slim@sha256:b04b5d7233d2ad9c379e22ea8927cd1378cd15c60d4ef876c065b25ea8fb3bf3
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir fastapi uvicorn
+
+COPY ./mock_llm/app.py /app/app.py
+
+EXPOSE 8000
+
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/loadtest/mock_llm/Dockerfile
+++ b/loadtest/mock_llm/Dockerfile
@@ -7,8 +7,8 @@ WORKDIR /app
 
 RUN pip install --no-cache-dir fastapi uvicorn
 
-COPY ./mock_llm/app.py /app/app.py
+COPY ./mock_llm /app/mock_llm
 
 EXPOSE 8000
 
-CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "mock_llm.app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/loadtest/mock_llm/app.py
+++ b/loadtest/mock_llm/app.py
@@ -32,7 +32,7 @@ deep_research/dr_loop.py):
 - tool_choice forced to one function → call exactly that tool.
 - tool_choice REQUIRED               → must emit a tool call. Priority:
   `research_agent` if not yet called in this history (DR orchestrator),
-  else a search-ish tool if not yet called (DR research-agent loop),
+  else a retrieval tool if not yet called (DR research-agent loop),
   else `generate_report`, else the first offered tool.
 - tool_choice AUTO                   → `generate_plan` if offered (DR
   clarification phase — always taken so a load-test DR turn never ends in a
@@ -55,6 +55,7 @@ import re
 import time
 import uuid
 from collections.abc import AsyncGenerator
+from typing import Any
 
 from fastapi import FastAPI
 from fastapi import HTTPException
@@ -91,7 +92,7 @@ _FILLER_WORDS = (
 ).split()
 
 # Tool names from Onyx's chat / deep-research loops (see module docstring).
-_SEARCHISH_TOOLS = ("internal_search", "web_search", "open_url")
+_RETRIEVAL_TOOLS = ("internal_search", "web_search", "open_url")
 _RESEARCH_AGENT = "research_agent"
 _GENERATE_REPORT = "generate_report"
 _GENERATE_PLAN = "generate_plan"
@@ -129,16 +130,25 @@ def _assistant_called(messages: list[ChatMessage], names: tuple[str, ...]) -> bo
     return False
 
 
+def _content_text(content: str | list[Any] | None) -> str | None:
+    """Extract text from message content, which is either a plain string or
+    a list of multimodal content parts."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        for part in content:
+            if isinstance(part, dict) and part.get("type") == "text":
+                return str(part.get("text", ""))
+    return None
+
+
 def _last_user_text(messages: list[ChatMessage]) -> str:
     for message in reversed(messages):
         if message.role != "user":
             continue
-        if isinstance(message.content, str):
-            return message.content
-        if isinstance(message.content, list):  # multimodal content parts
-            for part in message.content:
-                if isinstance(part, dict) and part.get("type") == "text":
-                    return str(part.get("text", ""))
+        text = _content_text(message.content)
+        if text is not None:
+            return text
     return "load test query"
 
 
@@ -246,9 +256,9 @@ def _pick_tool(request: ChatCompletionRequest, knobs: Knobs) -> list[ToolCall]:
             if _GENERATE_REPORT in by_name:
                 return [make(by_name[_GENERATE_REPORT])]
         # DR research-agent loop: search once, then ask for the report.
-        searchish = next((n for n in _SEARCHISH_TOOLS if n in by_name), None)
-        if searchish and not _assistant_called(messages, _SEARCHISH_TOOLS):
-            return [make(by_name[searchish])]
+        retrieval_tool = next((n for n in _RETRIEVAL_TOOLS if n in by_name), None)
+        if retrieval_tool and not _assistant_called(messages, _RETRIEVAL_TOOLS):
+            return [make(by_name[retrieval_tool])]
         if _GENERATE_REPORT in by_name:
             return [make(by_name[_GENERATE_REPORT])]
         return [make(tools[0])]
@@ -258,8 +268,8 @@ def _pick_tool(request: ChatCompletionRequest, knobs: Knobs) -> list[ToolCall]:
     if _GENERATE_PLAN in by_name:
         return [make(by_name[_GENERATE_PLAN])]
     if knobs.tools_on_auto and not has_tool_result:
-        searchish = next((n for n in _SEARCHISH_TOOLS if n in by_name), None)
-        target = by_name.get(searchish) if searchish else tools[0]
+        retrieval_tool = next((n for n in _RETRIEVAL_TOOLS if n in by_name), None)
+        target = by_name.get(retrieval_tool) if retrieval_tool else tools[0]
         if target is not None:
             return [make(target)]
     return []

--- a/loadtest/mock_llm/app.py
+++ b/loadtest/mock_llm/app.py
@@ -13,11 +13,31 @@ Timing knobs are encoded in the model name (litellm passes it through):
     mock-model                      — env-var defaults
     mock-ttft500-itl20-len400       — 500ms to first token, 20ms between
                                       tokens, 400 tokens of filler answer
+    mock-tools1-ttft300             — emit a tool call on the first AUTO-
+                                      tool-choice cycle (drives the search
+                                      tool path in a normal chat turn)
+    mock-agents2                    — spawn 2 parallel research agents per
+                                      deep-research orchestrator cycle
 
-Tool-call behavior (exercises the real tool-execution path): when the request
-offers tools and MOCK_FORCE_TOOL_CALL=true, the first call of a turn (no
-tool-role message yet) responds with a tool call for the first offered tool;
-the follow-up call (tool result present) streams the final answer.
+Branching follows the contract of Onyx's LLM loops (chat llm_loop.py and
+deep_research/dr_loop.py):
+
+- tool_choice NONE / no tools        → stream plain filler text ("stop").
+  Covers: final answers, DR plan / intermediate / final reports, and
+  secondary invoke() flows (query rephrase, doc selection, ...).
+- tool_choice forced to one function → call exactly that tool.
+- tool_choice REQUIRED               → must emit a tool call. Priority:
+  `research_agent` if not yet called in this history (DR orchestrator),
+  else a search-ish tool if not yet called (DR research-agent loop),
+  else `generate_report`, else the first offered tool.
+- tool_choice AUTO                   → `generate_plan` if offered (DR
+  clarification phase — always taken so a load-test DR turn never ends in a
+  clarification question); else, with the `-tools1` knob and no tool result
+  yet, the preferred search tool (normal chat-with-search); else plain text.
+
+Tool-call arguments are synthesized from each tool's JSON schema (required
+string props get a snippet of the last user message; arrays of strings get a
+single-element list), so schema changes in Onyx degrade gracefully.
 
 Run locally:  uvicorn mock_llm.app:app --port 8001
 """
@@ -43,26 +63,167 @@ app = FastAPI()
 DEFAULT_TTFT_MS = int(os.environ.get("MOCK_TTFT_MS", "300"))
 DEFAULT_ITL_MS = int(os.environ.get("MOCK_ITL_MS", "15"))
 DEFAULT_LEN_TOKENS = int(os.environ.get("MOCK_LEN_TOKENS", "150"))
-FORCE_TOOL_CALL = os.environ.get("MOCK_FORCE_TOOL_CALL", "").lower() == "true"
 
-_KNOB_RE = re.compile(r"-(ttft|itl|len)(\d+)")
+_KNOB_RE = re.compile(r"-(ttft|itl|len|tools|agents)(\d+)")
 
 _FILLER_WORDS = (
     "This is deterministic mock answer content used only for load testing "
     "the Onyx application and infrastructure under controlled conditions. "
 ).split()
 
+# Tool names from Onyx's chat / deep-research loops (see module docstring).
+_SEARCHISH_TOOLS = ("internal_search", "web_search", "open_url")
+_RESEARCH_AGENT = "research_agent"
+_GENERATE_REPORT = "generate_report"
+_GENERATE_PLAN = "generate_plan"
 
-def _parse_knobs(model: str) -> tuple[float, float, int]:
-    ttft_ms, itl_ms, n_tokens = DEFAULT_TTFT_MS, DEFAULT_ITL_MS, DEFAULT_LEN_TOKENS
-    for name, value in _KNOB_RE.findall(model):
-        if name == "ttft":
-            ttft_ms = int(value)
-        elif name == "itl":
-            itl_ms = int(value)
-        elif name == "len":
-            n_tokens = int(value)
-    return ttft_ms / 1000.0, itl_ms / 1000.0, n_tokens
+
+class Knobs:
+    def __init__(self, model: str) -> None:
+        self.ttft_s = DEFAULT_TTFT_MS / 1000.0
+        self.itl_s = DEFAULT_ITL_MS / 1000.0
+        self.n_tokens = DEFAULT_LEN_TOKENS
+        self.tools_on_auto = False
+        self.n_agents = 1
+        for name, value in _KNOB_RE.findall(model):
+            if name == "ttft":
+                self.ttft_s = int(value) / 1000.0
+            elif name == "itl":
+                self.itl_s = int(value) / 1000.0
+            elif name == "len":
+                self.n_tokens = int(value)
+            elif name == "tools":
+                self.tools_on_auto = bool(int(value))
+            elif name == "agents":
+                self.n_agents = max(1, int(value))
+
+
+def _tool_names(tools: list[dict[str, Any]] | None) -> list[str]:
+    if not tools:
+        return []
+    return [t.get("function", {}).get("name", "") for t in tools]
+
+
+def _assistant_called(messages: list[dict[str, Any]], names: tuple[str, ...]) -> bool:
+    """True if any assistant message in the history already called one of
+    `names` — the stateless signal for which phase of a loop we're in."""
+    for m in messages:
+        if m.get("role") != "assistant":
+            continue
+        for tc in m.get("tool_calls") or []:
+            if tc.get("function", {}).get("name") in names:
+                return True
+    return False
+
+
+def _last_user_snippet(messages: list[dict[str, Any]]) -> str:
+    for m in reversed(messages):
+        if m.get("role") != "user":
+            continue
+        content = m.get("content")
+        if isinstance(content, str):
+            return content[:200]
+        if isinstance(content, list):  # multimodal content parts
+            for part in content:
+                if isinstance(part, dict) and part.get("type") == "text":
+                    return str(part.get("text", ""))[:200]
+    return "load test query"
+
+
+def _synthesize_arguments(tool: dict[str, Any], snippet: str) -> str:
+    """Fill a tool's required params from its JSON schema: strings get the
+    user-message snippet, string-arrays get a one-element list."""
+    params = tool.get("function", {}).get("parameters", {}) or {}
+    properties = params.get("properties", {}) or {}
+    required = params.get("required", list(properties.keys())) or []
+    args: dict[str, Any] = {}
+    for prop in required:
+        schema = properties.get(prop, {})
+        prop_type = schema.get("type")
+        if prop_type == "array":
+            args[prop] = [snippet]
+        elif prop_type in (None, "string"):
+            args[prop] = snippet
+        elif prop_type in ("integer", "number"):
+            args[prop] = 1
+        elif prop_type == "boolean":
+            args[prop] = True
+        else:
+            args[prop] = snippet
+    return json.dumps(args)
+
+
+def _pick_tool(
+    tools: list[dict[str, Any]],
+    tool_choice: Any,
+    messages: list[dict[str, Any]],
+    knobs: Knobs,
+) -> tuple[list[dict[str, Any]], bool]:
+    """Decide which tool call(s) to emit, if any.
+
+    Returns (tool_calls, emit) where each tool_call is the full OpenAI
+    non-streaming shape; emit=False means stream plain text instead.
+    """
+    names = _tool_names(tools)
+    by_name = {n: t for n, t in zip(names, tools)}
+    snippet = _last_user_snippet(messages)
+    has_tool_result = any(m.get("role") == "tool" for m in messages)
+
+    def make(tool: dict[str, Any], task: str | None = None) -> dict[str, Any]:
+        arguments = _synthesize_arguments(tool, task or snippet)
+        return {
+            "id": f"call_mock_{uuid.uuid4().hex[:10]}",
+            "type": "function",
+            "function": {
+                "name": tool.get("function", {}).get("name", ""),
+                "arguments": arguments,
+            },
+        }
+
+    # Forced specific function: {"type": "function", "function": {"name": ...}}
+    if isinstance(tool_choice, dict):
+        forced = tool_choice.get("function", {}).get("name")
+        if forced and forced in by_name:
+            return [make(by_name[forced])], True
+
+    choice = tool_choice if isinstance(tool_choice, str) else None
+    if choice is None:
+        choice = "auto" if tools else "none"
+
+    if choice == "none" or not tools:
+        return [], False
+
+    if choice == "required":
+        # DR orchestrator: spawn agents once, then ask for the report.
+        if _RESEARCH_AGENT in by_name:
+            if not _assistant_called(messages, (_RESEARCH_AGENT,)):
+                return [
+                    make(
+                        by_name[_RESEARCH_AGENT],
+                        task=f"research aspect {i + 1}: {snippet}",
+                    )
+                    for i in range(knobs.n_agents)
+                ], True
+            if _GENERATE_REPORT in by_name:
+                return [make(by_name[_GENERATE_REPORT])], True
+        # DR research-agent loop: search once, then ask for the report.
+        searchish = next((n for n in _SEARCHISH_TOOLS if n in by_name), None)
+        if searchish and not _assistant_called(messages, _SEARCHISH_TOOLS):
+            return [make(by_name[searchish])], True
+        if _GENERATE_REPORT in by_name:
+            return [make(by_name[_GENERATE_REPORT])], True
+        return [make(tools[0])], True
+
+    # choice == "auto"
+    # DR clarification: always proceed to the plan, never ask to clarify.
+    if _GENERATE_PLAN in by_name:
+        return [make(by_name[_GENERATE_PLAN])], True
+    if knobs.tools_on_auto and not has_tool_result:
+        searchish = next((n for n in _SEARCHISH_TOOLS if n in by_name), None)
+        target = by_name.get(searchish) if searchish else tools[0]
+        if target is not None:
+            return [make(target)], True
+    return [], False
 
 
 def _chunk(
@@ -95,25 +256,32 @@ async def chat_completions(request: Request) -> Response:
     stream: bool = body.get("stream", False)
     messages: list[dict[str, Any]] = body.get("messages", [])
     tools: list[dict[str, Any]] | None = body.get("tools")
-    ttft_s, itl_s, n_tokens = _parse_knobs(model)
+    tool_choice: Any = body.get("tool_choice")
+    max_tokens: int | None = body.get("max_tokens") or body.get("max_completion_tokens")
+    knobs = Knobs(model)
     completion_id = f"chatcmpl-mock-{uuid.uuid4().hex[:12]}"
 
-    has_tool_result = any(m.get("role") == "tool" for m in messages)
-    do_tool_call = bool(FORCE_TOOL_CALL and tools and not has_tool_result)
+    tool_calls, emit_tools = _pick_tool(tools or [], tool_choice, messages, knobs)
 
+    n_tokens = knobs.n_tokens
+    if max_tokens is not None:
+        n_tokens = min(n_tokens, max(1, int(max_tokens)))
     answer = " ".join(_FILLER_WORDS[i % len(_FILLER_WORDS)] for i in range(n_tokens))
 
     if not stream:
-        await asyncio.sleep(ttft_s + itl_s * n_tokens)
-        message: dict[str, Any] = {"role": "assistant", "content": answer}
-        finish = "stop"
-        if do_tool_call:
-            message = {
+        await asyncio.sleep(
+            knobs.ttft_s + (0 if emit_tools else knobs.itl_s * n_tokens)
+        )
+        if emit_tools:
+            message: dict[str, Any] = {
                 "role": "assistant",
                 "content": None,
-                "tool_calls": [_tool_call(tools, messages)],
+                "tool_calls": tool_calls,
             }
             finish = "tool_calls"
+        else:
+            message = {"role": "assistant", "content": answer}
+            finish = "stop"
         return JSONResponse(
             {
                 "id": completion_id,
@@ -123,16 +291,17 @@ async def chat_completions(request: Request) -> Response:
                 "choices": [{"index": 0, "message": message, "finish_reason": finish}],
                 "usage": {
                     "prompt_tokens": 100,
-                    "completion_tokens": n_tokens,
-                    "total_tokens": 100 + n_tokens,
+                    "completion_tokens": n_tokens if not emit_tools else 20,
+                    "total_tokens": 100 + (n_tokens if not emit_tools else 20),
                 },
             }
         )
 
     async def generate() -> Any:
-        await asyncio.sleep(ttft_s)
-        if do_tool_call:
-            tool_call = _tool_call(tools, messages)
+        await asyncio.sleep(knobs.ttft_s)
+        if emit_tools:
+            # Header chunk: ids + names with empty arguments, then one
+            # argument-delta chunk per call (OpenAI parallel format).
             yield _chunk(
                 model,
                 completion_id,
@@ -141,33 +310,33 @@ async def chat_completions(request: Request) -> Response:
                     "content": None,
                     "tool_calls": [
                         {
-                            "index": 0,
-                            "id": tool_call["id"],
+                            "index": i,
+                            "id": tc["id"],
                             "type": "function",
                             "function": {
-                                "name": tool_call["function"]["name"],
+                                "name": tc["function"]["name"],
                                 "arguments": "",
                             },
                         }
+                        for i, tc in enumerate(tool_calls)
                     ],
                 },
                 None,
             )
-            yield _chunk(
-                model,
-                completion_id,
-                {
-                    "tool_calls": [
-                        {
-                            "index": 0,
-                            "function": {
-                                "arguments": tool_call["function"]["arguments"]
-                            },
-                        }
-                    ]
-                },
-                None,
-            )
+            for i, tc in enumerate(tool_calls):
+                yield _chunk(
+                    model,
+                    completion_id,
+                    {
+                        "tool_calls": [
+                            {
+                                "index": i,
+                                "function": {"arguments": tc["function"]["arguments"]},
+                            }
+                        ]
+                    },
+                    None,
+                )
             yield _chunk(model, completion_id, {}, "tool_calls")
         else:
             yield _chunk(
@@ -176,31 +345,9 @@ async def chat_completions(request: Request) -> Response:
             for i in range(n_tokens):
                 word = _FILLER_WORDS[i % len(_FILLER_WORDS)]
                 yield _chunk(model, completion_id, {"content": word + " "}, None)
-                if itl_s > 0:
-                    await asyncio.sleep(itl_s)
+                if knobs.itl_s > 0:
+                    await asyncio.sleep(knobs.itl_s)
             yield _chunk(model, completion_id, {}, "stop")
         yield "data: [DONE]\n\n"
 
     return StreamingResponse(generate(), media_type="text/event-stream")
-
-
-def _tool_call(
-    tools: list[dict[str, Any]] | None, messages: list[dict[str, Any]]
-) -> dict[str, Any]:
-    tool_name = "run_search"
-    if tools:
-        tool_name = tools[0].get("function", {}).get("name", tool_name)
-    last_user = next(
-        (m.get("content") for m in reversed(messages) if m.get("role") == "user"),
-        "load test query",
-    )
-    if not isinstance(last_user, str):
-        last_user = "load test query"
-    return {
-        "id": f"call_mock_{uuid.uuid4().hex[:10]}",
-        "type": "function",
-        "function": {
-            "name": tool_name,
-            "arguments": json.dumps({"query": last_user[:200]}),
-        },
-    }

--- a/loadtest/mock_llm/app.py
+++ b/loadtest/mock_llm/app.py
@@ -57,6 +57,7 @@ import uuid
 from collections.abc import AsyncGenerator
 
 from fastapi import FastAPI
+from fastapi import HTTPException
 from fastapi import Response
 from fastapi.responses import JSONResponse
 from fastapi.responses import StreamingResponse
@@ -211,8 +212,18 @@ def _pick_tool(request: ChatCompletionRequest, knobs: Knobs) -> list[ToolCall]:
     # Forced specific function: {"type": "function", "function": {"name": ...}}
     if isinstance(request.tool_choice, dict):
         forced = request.tool_choice.get("function", {}).get("name")
-        if forced and forced in by_name:
-            return [make(by_name[forced])]
+        if not forced or forced not in by_name:
+            # Mirror OpenAI: 400 on a forced function that isn't offered.
+            # Failing loudly matters here — silent fallback would mask the
+            # exact contract violations this mock exists to surface.
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Invalid 'tool_choice': function {forced!r} is not in "
+                    f"'tools': {sorted(by_name)}"
+                ),
+            )
+        return [make(by_name[forced])]
 
     choice = request.tool_choice if isinstance(request.tool_choice, str) else None
     if choice is None:

--- a/loadtest/mock_llm/app.py
+++ b/loadtest/mock_llm/app.py
@@ -128,17 +128,44 @@ def _assistant_called(messages: list[ChatMessage], names: tuple[str, ...]) -> bo
     return False
 
 
-def _last_user_snippet(messages: list[ChatMessage]) -> str:
+def _last_user_text(messages: list[ChatMessage]) -> str:
     for message in reversed(messages):
         if message.role != "user":
             continue
         if isinstance(message.content, str):
-            return message.content[:200]
+            return message.content
         if isinstance(message.content, list):  # multimodal content parts
             for part in message.content:
                 if isinstance(part, dict) and part.get("type") == "text":
-                    return str(part.get("text", ""))[:200]
+                    return str(part.get("text", ""))
     return "load test query"
+
+
+def _last_user_snippet(messages: list[ChatMessage]) -> str:
+    return _last_user_text(messages)[:200]
+
+
+# Stable phrases from Onyx's secondary-flow prompts whose LLM output feeds
+# back into the pipeline (backend/onyx/prompts/search_prompts.py — both the
+# semantic and keyword query-rephrase system prompts share this prefix). For
+# these calls the mock must echo the real question's terms, not filler, or
+# retrieval searches for nonsense and returns nothing.
+_ECHO_PROMPT_MARKERS = ("reformulates the last user message",)
+
+
+def _is_echo_flow(messages: list[ChatMessage]) -> bool:
+    for message in messages:
+        if message.role != "system" or not isinstance(message.content, str):
+            continue
+        if any(marker in message.content for marker in _ECHO_PROMPT_MARKERS):
+            return True
+    return False
+
+
+def _echo_answer(messages: list[ChatMessage]) -> str:
+    """Prompt templates put the actual question at the end of the user
+    message, so echo the tail."""
+    return _last_user_text(messages)[-300:]
 
 
 def _synthesize_arguments(tool: ToolDefinition, snippet: str) -> str:
@@ -282,7 +309,15 @@ async def chat_completions(request: ChatCompletionRequest) -> Response:
     n_tokens = knobs.n_tokens
     if request.effective_max_tokens is not None:
         n_tokens = min(n_tokens, max(1, request.effective_max_tokens))
-    answer = " ".join(_FILLER_WORDS[i % len(_FILLER_WORDS)] for i in range(n_tokens))
+    if _is_echo_flow(request.messages):
+        # NOTE: invoke() also streams at the litellm layer, so echo-flow
+        # detection must come from the prompt, not the stream flag.
+        answer = _echo_answer(request.messages)
+        n_tokens = len(answer.split())
+    else:
+        answer = " ".join(
+            _FILLER_WORDS[i % len(_FILLER_WORDS)] for i in range(n_tokens)
+        )
 
     if not request.stream:
         await asyncio.sleep(
@@ -364,8 +399,7 @@ async def chat_completions(request: ChatCompletionRequest) -> Response:
                     None,
                 )
             )
-            for i in range(n_tokens):
-                word = _FILLER_WORDS[i % len(_FILLER_WORDS)]
+            for word in answer.split():
                 yield _sse(
                     _make_chunk(
                         request.model,

--- a/loadtest/mock_llm/app.py
+++ b/loadtest/mock_llm/app.py
@@ -19,6 +19,10 @@ Timing knobs are encoded in the model name (litellm passes it through):
     mock-agents2                    — spawn 2 parallel research agents per
                                       deep-research orchestrator cycle
 
+Knob combinations can imitate provider latency profiles (see README:
+"Provider profiles") — e.g. a slow reasoning model is just
+`mock-ttft8000-itl40-len600`.
+
 Branching follows the contract of Onyx's LLM loops (chat llm_loop.py and
 deep_research/dr_loop.py):
 
@@ -50,13 +54,27 @@ import os
 import re
 import time
 import uuid
-from typing import Any
+from collections.abc import AsyncGenerator
 
 from fastapi import FastAPI
-from fastapi import Request
 from fastapi import Response
 from fastapi.responses import JSONResponse
 from fastapi.responses import StreamingResponse
+
+from mock_llm.models import AssistantMessage
+from mock_llm.models import ChatCompletionChunk
+from mock_llm.models import ChatCompletionRequest
+from mock_llm.models import ChatCompletionResponse
+from mock_llm.models import ChatMessage
+from mock_llm.models import Choice
+from mock_llm.models import ChunkChoice
+from mock_llm.models import ChunkDelta
+from mock_llm.models import StreamToolCall
+from mock_llm.models import StreamToolCallFunction
+from mock_llm.models import ToolCall
+from mock_llm.models import ToolCallFunction
+from mock_llm.models import ToolDefinition
+from mock_llm.models import Usage
 
 app = FastAPI()
 
@@ -80,11 +98,11 @@ _GENERATE_PLAN = "generate_plan"
 
 class Knobs:
     def __init__(self, model: str) -> None:
-        self.ttft_s = DEFAULT_TTFT_MS / 1000.0
-        self.itl_s = DEFAULT_ITL_MS / 1000.0
-        self.n_tokens = DEFAULT_LEN_TOKENS
-        self.tools_on_auto = False
-        self.n_agents = 1
+        self.ttft_s: float = DEFAULT_TTFT_MS / 1000.0
+        self.itl_s: float = DEFAULT_ITL_MS / 1000.0
+        self.n_tokens: int = DEFAULT_LEN_TOKENS
+        self.tools_on_auto: bool = False
+        self.n_agents: int = 1
         for name, value in _KNOB_RE.findall(model):
             if name == "ttft":
                 self.ttft_s = int(value) / 1000.0
@@ -98,45 +116,38 @@ class Knobs:
                 self.n_agents = max(1, int(value))
 
 
-def _tool_names(tools: list[dict[str, Any]] | None) -> list[str]:
-    if not tools:
-        return []
-    return [t.get("function", {}).get("name", "") for t in tools]
-
-
-def _assistant_called(messages: list[dict[str, Any]], names: tuple[str, ...]) -> bool:
+def _assistant_called(messages: list[ChatMessage], names: tuple[str, ...]) -> bool:
     """True if any assistant message in the history already called one of
     `names` — the stateless signal for which phase of a loop we're in."""
-    for m in messages:
-        if m.get("role") != "assistant":
+    for message in messages:
+        if message.role != "assistant":
             continue
-        for tc in m.get("tool_calls") or []:
-            if tc.get("function", {}).get("name") in names:
+        for tool_call in message.tool_calls or []:
+            if tool_call.function.name in names:
                 return True
     return False
 
 
-def _last_user_snippet(messages: list[dict[str, Any]]) -> str:
-    for m in reversed(messages):
-        if m.get("role") != "user":
+def _last_user_snippet(messages: list[ChatMessage]) -> str:
+    for message in reversed(messages):
+        if message.role != "user":
             continue
-        content = m.get("content")
-        if isinstance(content, str):
-            return content[:200]
-        if isinstance(content, list):  # multimodal content parts
-            for part in content:
+        if isinstance(message.content, str):
+            return message.content[:200]
+        if isinstance(message.content, list):  # multimodal content parts
+            for part in message.content:
                 if isinstance(part, dict) and part.get("type") == "text":
                     return str(part.get("text", ""))[:200]
     return "load test query"
 
 
-def _synthesize_arguments(tool: dict[str, Any], snippet: str) -> str:
+def _synthesize_arguments(tool: ToolDefinition, snippet: str) -> str:
     """Fill a tool's required params from its JSON schema: strings get the
     user-message snippet, string-arrays get a one-element list."""
-    params = tool.get("function", {}).get("parameters", {}) or {}
+    params = tool.function.parameters or {}
     properties = params.get("properties", {}) or {}
     required = params.get("required", list(properties.keys())) or []
-    args: dict[str, Any] = {}
+    args: dict[str, object] = {}
     for prop in required:
         schema = properties.get(prop, {})
         prop_type = schema.get("type")
@@ -153,45 +164,35 @@ def _synthesize_arguments(tool: dict[str, Any], snippet: str) -> str:
     return json.dumps(args)
 
 
-def _pick_tool(
-    tools: list[dict[str, Any]],
-    tool_choice: Any,
-    messages: list[dict[str, Any]],
-    knobs: Knobs,
-) -> tuple[list[dict[str, Any]], bool]:
-    """Decide which tool call(s) to emit, if any.
-
-    Returns (tool_calls, emit) where each tool_call is the full OpenAI
-    non-streaming shape; emit=False means stream plain text instead.
-    """
-    names = _tool_names(tools)
-    by_name = {n: t for n, t in zip(names, tools)}
+def _pick_tool(request: ChatCompletionRequest, knobs: Knobs) -> list[ToolCall]:
+    """Decide which tool call(s) to emit; empty list means stream text."""
+    tools = request.tools or []
+    by_name = {t.function.name: t for t in tools}
+    messages = request.messages
     snippet = _last_user_snippet(messages)
-    has_tool_result = any(m.get("role") == "tool" for m in messages)
+    has_tool_result = any(m.role == "tool" for m in messages)
 
-    def make(tool: dict[str, Any], task: str | None = None) -> dict[str, Any]:
-        arguments = _synthesize_arguments(tool, task or snippet)
-        return {
-            "id": f"call_mock_{uuid.uuid4().hex[:10]}",
-            "type": "function",
-            "function": {
-                "name": tool.get("function", {}).get("name", ""),
-                "arguments": arguments,
-            },
-        }
+    def make(tool: ToolDefinition, task: str | None = None) -> ToolCall:
+        return ToolCall(
+            id=f"call_mock_{uuid.uuid4().hex[:10]}",
+            function=ToolCallFunction(
+                name=tool.function.name,
+                arguments=_synthesize_arguments(tool, task or snippet),
+            ),
+        )
 
     # Forced specific function: {"type": "function", "function": {"name": ...}}
-    if isinstance(tool_choice, dict):
-        forced = tool_choice.get("function", {}).get("name")
+    if isinstance(request.tool_choice, dict):
+        forced = request.tool_choice.get("function", {}).get("name")
         if forced and forced in by_name:
-            return [make(by_name[forced])], True
+            return [make(by_name[forced])]
 
-    choice = tool_choice if isinstance(tool_choice, str) else None
+    choice = request.tool_choice if isinstance(request.tool_choice, str) else None
     if choice is None:
         choice = "auto" if tools else "none"
 
     if choice == "none" or not tools:
-        return [], False
+        return []
 
     if choice == "required":
         # DR orchestrator: spawn agents once, then ask for the report.
@@ -203,40 +204,61 @@ def _pick_tool(
                         task=f"research aspect {i + 1}: {snippet}",
                     )
                     for i in range(knobs.n_agents)
-                ], True
+                ]
             if _GENERATE_REPORT in by_name:
-                return [make(by_name[_GENERATE_REPORT])], True
+                return [make(by_name[_GENERATE_REPORT])]
         # DR research-agent loop: search once, then ask for the report.
         searchish = next((n for n in _SEARCHISH_TOOLS if n in by_name), None)
         if searchish and not _assistant_called(messages, _SEARCHISH_TOOLS):
-            return [make(by_name[searchish])], True
+            return [make(by_name[searchish])]
         if _GENERATE_REPORT in by_name:
-            return [make(by_name[_GENERATE_REPORT])], True
-        return [make(tools[0])], True
+            return [make(by_name[_GENERATE_REPORT])]
+        return [make(tools[0])]
 
     # choice == "auto"
     # DR clarification: always proceed to the plan, never ask to clarify.
     if _GENERATE_PLAN in by_name:
-        return [make(by_name[_GENERATE_PLAN])], True
+        return [make(by_name[_GENERATE_PLAN])]
     if knobs.tools_on_auto and not has_tool_result:
         searchish = next((n for n in _SEARCHISH_TOOLS if n in by_name), None)
         target = by_name.get(searchish) if searchish else tools[0]
         if target is not None:
-            return [make(target)], True
-    return [], False
+            return [make(target)]
+    return []
 
 
-def _chunk(
-    model: str, completion_id: str, delta: dict[str, Any], finish: str | None
-) -> str:
-    payload = {
-        "id": completion_id,
-        "object": "chat.completion.chunk",
-        "created": int(time.time()),
-        "model": model,
-        "choices": [{"index": 0, "delta": delta, "finish_reason": finish}],
-    }
-    return f"data: {json.dumps(payload)}\n\n"
+def _sse(chunk: ChatCompletionChunk) -> str:
+    # Match OpenAI's wire format: unset fields are omitted inside delta (and
+    # its tool_calls entries), but finish_reason is always present (null).
+    data = chunk.model_dump()
+    for choice in data["choices"]:
+        delta = {k: v for k, v in choice["delta"].items() if v is not None}
+        if "tool_calls" in delta:
+            delta["tool_calls"] = [
+                {
+                    k: (
+                        {fk: fv for fk, fv in v.items() if fv is not None}
+                        if k == "function"
+                        else v
+                    )
+                    for k, v in tc.items()
+                    if v is not None
+                }
+                for tc in delta["tool_calls"]
+            ]
+        choice["delta"] = delta
+    return f"data: {json.dumps(data)}\n\n"
+
+
+def _make_chunk(
+    model: str, completion_id: str, delta: ChunkDelta, finish: str | None
+) -> ChatCompletionChunk:
+    return ChatCompletionChunk(
+        id=completion_id,
+        created=int(time.time()),
+        model=model,
+        choices=[ChunkChoice(delta=delta, finish_reason=finish)],
+    )
 
 
 @app.get("/v1/models")
@@ -250,104 +272,111 @@ def list_models() -> JSONResponse:
 
 
 @app.post("/v1/chat/completions")
-async def chat_completions(request: Request) -> Response:
-    body = await request.json()
-    model: str = body.get("model", "mock-model")
-    stream: bool = body.get("stream", False)
-    messages: list[dict[str, Any]] = body.get("messages", [])
-    tools: list[dict[str, Any]] | None = body.get("tools")
-    tool_choice: Any = body.get("tool_choice")
-    max_tokens: int | None = body.get("max_tokens") or body.get("max_completion_tokens")
-    knobs = Knobs(model)
+async def chat_completions(request: ChatCompletionRequest) -> Response:
+    knobs = Knobs(request.model)
     completion_id = f"chatcmpl-mock-{uuid.uuid4().hex[:12]}"
 
-    tool_calls, emit_tools = _pick_tool(tools or [], tool_choice, messages, knobs)
+    tool_calls = _pick_tool(request, knobs)
+    emit_tools = bool(tool_calls)
 
     n_tokens = knobs.n_tokens
-    if max_tokens is not None:
-        n_tokens = min(n_tokens, max(1, int(max_tokens)))
+    if request.effective_max_tokens is not None:
+        n_tokens = min(n_tokens, max(1, request.effective_max_tokens))
     answer = " ".join(_FILLER_WORDS[i % len(_FILLER_WORDS)] for i in range(n_tokens))
 
-    if not stream:
+    if not request.stream:
         await asyncio.sleep(
             knobs.ttft_s + (0 if emit_tools else knobs.itl_s * n_tokens)
         )
         if emit_tools:
-            message: dict[str, Any] = {
-                "role": "assistant",
-                "content": None,
-                "tool_calls": tool_calls,
-            }
+            message = AssistantMessage(content=None, tool_calls=tool_calls)
             finish = "tool_calls"
         else:
-            message = {"role": "assistant", "content": answer}
+            message = AssistantMessage(content=answer)
             finish = "stop"
-        return JSONResponse(
-            {
-                "id": completion_id,
-                "object": "chat.completion",
-                "created": int(time.time()),
-                "model": model,
-                "choices": [{"index": 0, "message": message, "finish_reason": finish}],
-                "usage": {
-                    "prompt_tokens": 100,
-                    "completion_tokens": n_tokens if not emit_tools else 20,
-                    "total_tokens": 100 + (n_tokens if not emit_tools else 20),
-                },
-            }
+        completion_tokens = 20 if emit_tools else n_tokens
+        response = ChatCompletionResponse(
+            id=completion_id,
+            created=int(time.time()),
+            model=request.model,
+            choices=[Choice(message=message, finish_reason=finish)],
+            usage=Usage(
+                prompt_tokens=100,
+                completion_tokens=completion_tokens,
+                total_tokens=100 + completion_tokens,
+            ),
         )
+        return JSONResponse(response.model_dump())
 
-    async def generate() -> Any:
+    async def generate() -> AsyncGenerator[str, None]:
         await asyncio.sleep(knobs.ttft_s)
         if emit_tools:
             # Header chunk: ids + names with empty arguments, then one
             # argument-delta chunk per call (OpenAI parallel format).
-            yield _chunk(
-                model,
-                completion_id,
-                {
-                    "role": "assistant",
-                    "content": None,
-                    "tool_calls": [
-                        {
-                            "index": i,
-                            "id": tc["id"],
-                            "type": "function",
-                            "function": {
-                                "name": tc["function"]["name"],
-                                "arguments": "",
-                            },
-                        }
-                        for i, tc in enumerate(tool_calls)
-                    ],
-                },
-                None,
-            )
-            for i, tc in enumerate(tool_calls):
-                yield _chunk(
-                    model,
+            yield _sse(
+                _make_chunk(
+                    request.model,
                     completion_id,
-                    {
-                        "tool_calls": [
-                            {
-                                "index": i,
-                                "function": {"arguments": tc["function"]["arguments"]},
-                            }
-                        ]
-                    },
+                    ChunkDelta(
+                        role="assistant",
+                        tool_calls=[
+                            StreamToolCall(
+                                index=i,
+                                id=tc.id,
+                                type="function",
+                                function=StreamToolCallFunction(
+                                    name=tc.function.name, arguments=""
+                                ),
+                            )
+                            for i, tc in enumerate(tool_calls)
+                        ],
+                    ),
                     None,
                 )
-            yield _chunk(model, completion_id, {}, "tool_calls")
+            )
+            for i, tc in enumerate(tool_calls):
+                yield _sse(
+                    _make_chunk(
+                        request.model,
+                        completion_id,
+                        ChunkDelta(
+                            tool_calls=[
+                                StreamToolCall(
+                                    index=i,
+                                    function=StreamToolCallFunction(
+                                        arguments=tc.function.arguments
+                                    ),
+                                )
+                            ]
+                        ),
+                        None,
+                    )
+                )
+            yield _sse(
+                _make_chunk(request.model, completion_id, ChunkDelta(), "tool_calls")
+            )
         else:
-            yield _chunk(
-                model, completion_id, {"role": "assistant", "content": ""}, None
+            yield _sse(
+                _make_chunk(
+                    request.model,
+                    completion_id,
+                    ChunkDelta(role="assistant", content=""),
+                    None,
+                )
             )
             for i in range(n_tokens):
                 word = _FILLER_WORDS[i % len(_FILLER_WORDS)]
-                yield _chunk(model, completion_id, {"content": word + " "}, None)
+                yield _sse(
+                    _make_chunk(
+                        request.model,
+                        completion_id,
+                        ChunkDelta(content=word + " "),
+                        None,
+                    )
+                )
                 if knobs.itl_s > 0:
                     await asyncio.sleep(knobs.itl_s)
-            yield _chunk(model, completion_id, {}, "stop")
+            yield _sse(_make_chunk(request.model, completion_id, ChunkDelta(), "stop"))
         yield "data: [DONE]\n\n"
 
     return StreamingResponse(generate(), media_type="text/event-stream")

--- a/loadtest/mock_llm/models.py
+++ b/loadtest/mock_llm/models.py
@@ -1,0 +1,144 @@
+"""Pydantic models for the mock LLM server's OpenAI-compatible wire format.
+
+Request models use extra="allow" and optional fields throughout: litellm
+sends provider-specific extras (stream_options, user, etc.) and the mock must
+never 422 a request the real OpenAI API would accept.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from typing import Literal
+
+from pydantic import BaseModel
+from pydantic import ConfigDict
+
+################################################
+# Request
+################################################
+
+
+class ToolCallFunction(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    name: str
+    arguments: str = "{}"
+
+
+class ToolCall(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    id: str
+    type: Literal["function"] = "function"
+    function: ToolCallFunction
+
+
+class ChatMessage(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    role: str
+    # str for normal messages, list of content parts for multimodal
+    content: str | list[Any] | None = None
+    tool_calls: list[ToolCall] | None = None
+    tool_call_id: str | None = None
+
+
+class ToolFunctionDefinition(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    name: str
+    description: str | None = None
+    parameters: dict[str, Any] = {}
+
+
+class ToolDefinition(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    type: str = "function"
+    function: ToolFunctionDefinition
+
+
+class ChatCompletionRequest(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    model: str = "mock-model"
+    stream: bool = False
+    messages: list[ChatMessage] = []
+    tools: list[ToolDefinition] | None = None
+    # "auto" | "none" | "required" | {"type": "function", "function": {...}}
+    tool_choice: str | dict[str, Any] | None = None
+    max_tokens: int | None = None
+    max_completion_tokens: int | None = None
+
+    @property
+    def effective_max_tokens(self) -> int | None:
+        return self.max_tokens or self.max_completion_tokens
+
+
+################################################
+# Non-streaming response
+################################################
+
+
+class Usage(BaseModel):
+    prompt_tokens: int
+    completion_tokens: int
+    total_tokens: int
+
+
+class AssistantMessage(BaseModel):
+    role: Literal["assistant"] = "assistant"
+    content: str | None = None
+    tool_calls: list[ToolCall] | None = None
+
+
+class Choice(BaseModel):
+    index: int = 0
+    message: AssistantMessage
+    finish_reason: str
+
+
+class ChatCompletionResponse(BaseModel):
+    id: str
+    object: Literal["chat.completion"] = "chat.completion"
+    created: int
+    model: str
+    choices: list[Choice]
+    usage: Usage
+
+
+################################################
+# Streaming chunks
+################################################
+
+
+class StreamToolCallFunction(BaseModel):
+    name: str | None = None
+    arguments: str | None = None
+
+
+class StreamToolCall(BaseModel):
+    index: int
+    id: str | None = None
+    type: Literal["function"] | None = None
+    function: StreamToolCallFunction
+
+
+class ChunkDelta(BaseModel):
+    role: str | None = None
+    content: str | None = None
+    tool_calls: list[StreamToolCall] | None = None
+
+
+class ChunkChoice(BaseModel):
+    index: int = 0
+    delta: ChunkDelta
+    finish_reason: str | None = None
+
+
+class ChatCompletionChunk(BaseModel):
+    id: str
+    object: Literal["chat.completion.chunk"] = "chat.completion.chunk"
+    created: int
+    model: str
+    choices: list[ChunkChoice]

--- a/loadtest/onyx_client/chat_user.py
+++ b/loadtest/onyx_client/chat_user.py
@@ -4,12 +4,16 @@ Each turn POSTs /api/chat/send-chat-message with stream=True and consumes the
 NDJSON response line by line, firing a named pseudo-request the moment each
 milestone packet arrives:
 
-    chat:first_packet       — time to first stream line (server accepted + began work)
-    chat:first_search_doc   — time to first search-tool document batch
-    chat:first_answer_token — time to first answer content (TTFT)
-    chat:total_turn         — full turn wall time (success/failure recorded here)
+    <prefix>:first_packet         — time to first stream line
+    <prefix>:first_search_doc     — time to first search-tool document batch
+    <prefix>:first_answer_token   — time to first answer content (TTFT)
+    <prefix>:first_dr_plan        — deep research plan started
+    <prefix>:first_research_agent — first DR research agent spawned
+    <prefix>:total_turn           — full turn wall time (success/failure here)
 
-Configuration is via environment variables; see README.md.
+Scenario subclasses (see scenarios/) set `scenario_prefix`, `mock_model`,
+`deep_research`, and timeouts. Configuration is via environment variables;
+see README.md.
 """
 
 from __future__ import annotations
@@ -43,11 +47,17 @@ def _env_float(name: str, default: float) -> float:
 class OnyxChatUser(HttpUser):
     abstract = True
 
+    scenario_prefix: str = "chat"
+    # Model name sent as llm_override (mock knobs ride in the name). None =
+    # persona default. Requires ONYX_LLM_PROVIDER when the target provider
+    # is not the deployment default.
+    mock_model: str | None = None
+    deep_research: bool = False
+
     wait_time = constant(_env_float("ONYX_WAIT_SECONDS", 15.0))
     # Read timeout is between chunks, not total; chat_heartbeat keepalives in
     # the stream mean a healthy turn never goes silent this long.
     stream_read_timeout: float = _env_float("ONYX_STREAM_READ_TIMEOUT", 180.0)
-    deep_research: bool = os.environ.get("ONYX_DEEP_RESEARCH", "").lower() == "true"
 
     def on_start(self) -> None:
         api_key = os.environ.get("ONYX_API_KEY")
@@ -55,11 +65,13 @@ class OnyxChatUser(HttpUser):
             raise RuntimeError("ONYX_API_KEY env var is required")
         self.client.headers["Authorization"] = f"Bearer {api_key}"
 
-        self.llm_override: dict[str, Any] | None = None
         provider = os.environ.get("ONYX_LLM_PROVIDER")
-        model = os.environ.get("ONYX_LLM_MODEL")
-        if provider and model:
-            self.llm_override = {"model_provider": provider, "model_version": model}
+        model = self.mock_model or os.environ.get("ONYX_LLM_MODEL")
+        self.llm_override: dict[str, Any] | None = None
+        if model:
+            self.llm_override = {"model_version": model}
+            if provider:
+                self.llm_override["model_provider"] = provider
 
         self.messages: list[str] = DEFAULT_MESSAGES
         self.turn_index: int = 0
@@ -73,7 +85,7 @@ class OnyxChatUser(HttpUser):
     ) -> None:
         self.environment.events.request.fire(
             request_type="CHAT",
-            name=name,
+            name=f"{self.scenario_prefix}:{name}",
             response_time=(time.perf_counter() - start) * 1000,
             response_length=response_length,
             exception=exception,
@@ -109,14 +121,14 @@ class OnyxChatUser(HttpUser):
                 "/api/chat/send-chat-message",
                 json=payload,
                 stream=True,
-                name="chat:send (headers)",
+                name=f"{self.scenario_prefix}:send (headers)",
                 timeout=(30, self.stream_read_timeout),
                 catch_response=True,
             ) as response:
                 if response.status_code != 200:
                     response.failure(f"HTTP {response.status_code}")
                     self._fire(
-                        "chat:total_turn",
+                        "total_turn",
                         start,
                         exception=Exception(
                             f"HTTP {response.status_code}: {response.text[:200]}"
@@ -126,18 +138,18 @@ class OnyxChatUser(HttpUser):
 
                 for line in response.iter_lines(decode_unicode=True):
                     for milestone in analyzer.feed(line):
-                        self._fire(f"chat:{milestone}", start)
+                        self._fire(milestone, start)
                 response.success()
         except Exception as exc:
-            self._fire("chat:total_turn", start, exception=exc)
+            self._fire("total_turn", start, exception=exc)
             return
 
         summary = analyzer.summary
         if analyzer.completed_ok():
-            self._fire("chat:total_turn", start, response_length=summary.answer_chars)
+            self._fire("total_turn", start, response_length=summary.answer_chars)
         else:
             self._fire(
-                "chat:total_turn",
+                "total_turn",
                 start,
                 exception=Exception(analyzer.failure_reason()),
             )

--- a/loadtest/pyproject.toml
+++ b/loadtest/pyproject.toml
@@ -10,6 +10,12 @@ dependencies = [
     "uvicorn>=0.30",
 ]
 
+[dependency-groups]
+dev = [
+    "pytest>=8",
+    "httpx>=0.27",  # starlette TestClient transport for mock_llm tests
+]
+
 # Intentionally NOT a member of the root uv workspace: locust pins
 # gevent/geventhttpclient/flask, which must not constrain the backend's
 # shared lockfile. Run `uv sync` from inside this directory.

--- a/loadtest/scenarios/__init__.py
+++ b/loadtest/scenarios/__init__.py
@@ -1,0 +1,4 @@
+from scenarios.chat_with_search import ChatWithSearchUser
+from scenarios.deep_research import DeepResearchUser
+
+__all__ = ["ChatWithSearchUser", "DeepResearchUser"]

--- a/loadtest/scenarios/chat_with_search.py
+++ b/loadtest/scenarios/chat_with_search.py
@@ -1,0 +1,24 @@
+"""Chat turn that exercises the search tool path.
+
+The `-tools1` model knob makes the mock LLM answer the first AUTO-tool-choice
+cycle with an `internal_search` tool call, so Onyx genuinely executes the
+search tool: query expansion, embedding model server, Vespa/OpenSearch
+retrieval, document streaming. The follow-up LLM call (tool result in
+history) streams the final answer.
+
+The `<prefix>:first_search_doc` milestone measures time to the first
+document batch — i.e. real retrieval-stack latency under load.
+"""
+
+from __future__ import annotations
+
+import os
+
+from onyx_client.chat_user import OnyxChatUser
+
+
+class ChatWithSearchUser(OnyxChatUser):
+    abstract = False
+
+    scenario_prefix: str = "search"
+    mock_model: str | None = os.environ.get("ONYX_SEARCH_MODEL", "mock-tools1")

--- a/loadtest/scenarios/deep_research.py
+++ b/loadtest/scenarios/deep_research.py
@@ -1,0 +1,32 @@
+"""Deep research turn.
+
+No special model knobs are needed: the DR orchestrator and research agents
+call the LLM with tool_choice=REQUIRED, and the mock's branching handles the
+whole sequence statelessly — clarification (`generate_plan`), plan text,
+research_agent spawn (parallelism via the `-agents<N>` knob), per-agent
+search → intermediate report, then the final report.
+
+This is the heaviest scenario: one turn holds the streaming connection (and
+api-server resources) across ~8+ LLM calls plus real search-tool executions.
+"""
+
+from __future__ import annotations
+
+import os
+
+from locust import constant
+from onyx_client.chat_user import _env_float
+from onyx_client.chat_user import OnyxChatUser
+
+
+class DeepResearchUser(OnyxChatUser):
+    abstract = False
+
+    scenario_prefix: str = "dr"
+    deep_research: bool = True
+    mock_model: str | None = os.environ.get("ONYX_DR_MODEL", "mock-agents2")
+
+    # DR turns run minutes, not seconds: think longer between turns and
+    # tolerate longer inter-chunk silence (heartbeats should still arrive).
+    wait_time = constant(_env_float("ONYX_DR_WAIT_SECONDS", 30.0))
+    stream_read_timeout: float = _env_float("ONYX_DR_STREAM_READ_TIMEOUT", 300.0)

--- a/loadtest/tests/test_mock_llm.py
+++ b/loadtest/tests/test_mock_llm.py
@@ -278,6 +278,23 @@ def test_dr_research_agent_searches_then_reports() -> None:
     assert second["message"]["tool_calls"][0]["function"]["name"] == "generate_report"
 
 
+def test_forced_unknown_tool_returns_400() -> None:
+    # Mirror OpenAI: forcing a function that isn't offered is a 400, not a
+    # silent fallback — fallback would mask real contract violations.
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "mock-ttft0-itl0",
+            "stream": False,
+            "messages": [{"role": "user", "content": "q"}],
+            "tools": [INTERNAL_SEARCH_TOOL],
+            "tool_choice": {"type": "function", "function": {"name": "nonexistent"}},
+        },
+    )
+    assert response.status_code == 400
+    assert "nonexistent" in response.text
+
+
 def test_forced_specific_tool_is_honored() -> None:
     choice = complete(
         tools=[INTERNAL_SEARCH_TOOL, GENERATE_REPORT_TOOL],

--- a/loadtest/tests/test_mock_llm.py
+++ b/loadtest/tests/test_mock_llm.py
@@ -1,0 +1,258 @@
+"""Contract tests for the mock LLM server.
+
+Each test replays the exact request shapes Onyx's LLM loops send (per
+backend/onyx/chat/llm_loop.py, llm_step.py and deep_research/dr_loop.py) and
+asserts the mock responds the way those loops need to make progress.
+
+Run:  uv run pytest tests/ -q
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from fastapi.testclient import TestClient
+from mock_llm.app import app
+
+client = TestClient(app)
+
+INTERNAL_SEARCH_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "internal_search",
+        "description": "Search connected applications for information.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "queries": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "List of search queries to execute.",
+                }
+            },
+            "required": ["queries"],
+        },
+    },
+}
+
+RESEARCH_AGENT_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "research_agent",
+        "parameters": {
+            "type": "object",
+            "properties": {"task": {"type": "string"}},
+            "required": ["task"],
+        },
+    },
+}
+
+GENERATE_REPORT_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "generate_report",
+        "parameters": {"type": "object", "properties": {}},
+    },
+}
+
+GENERATE_PLAN_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "generate_plan",
+        "parameters": {"type": "object", "properties": {}},
+    },
+}
+
+THINK_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "think_tool",
+        "parameters": {
+            "type": "object",
+            "properties": {"reasoning": {"type": "string"}},
+            "required": ["reasoning"],
+        },
+    },
+}
+
+
+def complete(
+    model: str = "mock-ttft0-itl0-len20",
+    messages: list[dict[str, Any]] | None = None,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "model": model,
+        "stream": False,
+        "messages": messages or [{"role": "user", "content": "load test question"}],
+    }
+    body.update(kwargs)
+    response = client.post("/v1/chat/completions", json=body)
+    assert response.status_code == 200
+    return response.json()["choices"][0]
+
+
+def stream_chunks(
+    model: str = "mock-ttft0-itl0-len20",
+    messages: list[dict[str, Any]] | None = None,
+    **kwargs: Any,
+) -> list[dict[str, Any]]:
+    body: dict[str, Any] = {
+        "model": model,
+        "stream": True,
+        "messages": messages or [{"role": "user", "content": "load test question"}],
+    }
+    body.update(kwargs)
+    chunks = []
+    with client.stream("POST", "/v1/chat/completions", json=body) as response:
+        assert response.status_code == 200
+        for line in response.iter_lines():
+            if line.startswith("data: ") and line != "data: [DONE]":
+                chunks.append(json.loads(line[len("data: ") :]))
+    return chunks
+
+
+def assistant_tool_calls_message(name: str, arguments: str = "{}") -> dict[str, Any]:
+    return {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {
+                "id": "call_prev_1",
+                "type": "function",
+                "function": {"name": name, "arguments": arguments},
+            }
+        ],
+    }
+
+
+def test_plain_chat_no_tools_streams_text_with_stop() -> None:
+    chunks = stream_chunks()
+    finish = [
+        c["choices"][0]["finish_reason"]
+        for c in chunks
+        if c["choices"][0]["finish_reason"]
+    ]
+    assert finish == ["stop"]
+    text = "".join(c["choices"][0]["delta"].get("content") or "" for c in chunks)
+    assert len(text.split()) == 20
+
+
+def test_tool_choice_none_forces_text_even_with_tools() -> None:
+    # Final chat cycle: tools offered but tool_choice="none" must yield text.
+    choice = complete(tools=[INTERNAL_SEARCH_TOOL], tool_choice="none")
+    assert choice["finish_reason"] == "stop"
+    assert choice["message"]["content"]
+
+
+def test_chat_auto_with_tools_knob_emits_internal_search_with_queries_array() -> None:
+    chunks = stream_chunks(
+        model="mock-tools1-ttft0-itl0",
+        tools=[INTERNAL_SEARCH_TOOL],
+        tool_choice="auto",
+    )
+    assert chunks[-1]["choices"][0]["finish_reason"] == "tool_calls"
+    header = chunks[0]["choices"][0]["delta"]["tool_calls"][0]
+    assert header["function"]["name"] == "internal_search"
+    arguments = "".join(
+        tc["function"].get("arguments", "")
+        for c in chunks
+        for tc in (c["choices"][0]["delta"].get("tool_calls") or [])
+    )
+    parsed = json.loads(arguments)
+    assert isinstance(parsed["queries"], list) and parsed["queries"]
+
+
+def test_chat_auto_after_tool_result_streams_final_answer() -> None:
+    messages = [
+        {"role": "user", "content": "find the docs"},
+        assistant_tool_calls_message("internal_search", '{"queries": ["docs"]}'),
+        {"role": "tool", "content": "doc snippets...", "tool_call_id": "call_prev_1"},
+    ]
+    choice = complete(
+        model="mock-tools1-ttft0-itl0-len20",
+        messages=messages,
+        tools=[INTERNAL_SEARCH_TOOL],
+        tool_choice="auto",
+    )
+    assert choice["finish_reason"] == "stop"
+    assert choice["message"]["content"]
+
+
+def test_chat_auto_without_knob_answers_directly() -> None:
+    choice = complete(tools=[INTERNAL_SEARCH_TOOL], tool_choice="auto")
+    assert choice["finish_reason"] == "stop"
+
+
+def test_dr_clarification_always_calls_generate_plan() -> None:
+    choice = complete(tools=[GENERATE_PLAN_TOOL], tool_choice="auto")
+    assert choice["finish_reason"] == "tool_calls"
+    assert choice["message"]["tool_calls"][0]["function"]["name"] == "generate_plan"
+
+
+def test_dr_plan_call_is_plain_text() -> None:
+    choice = complete(tools=[], tool_choice="none")
+    assert choice["finish_reason"] == "stop"
+    assert choice["message"]["content"]
+
+
+def test_dr_orchestrator_first_cycle_spawns_research_agents() -> None:
+    choice = complete(
+        model="mock-agents2-ttft0-itl0",
+        tools=[RESEARCH_AGENT_TOOL, GENERATE_REPORT_TOOL, THINK_TOOL],
+        tool_choice="required",
+    )
+    assert choice["finish_reason"] == "tool_calls"
+    calls = choice["message"]["tool_calls"]
+    assert len(calls) == 2
+    assert all(c["function"]["name"] == "research_agent" for c in calls)
+    for c in calls:
+        assert json.loads(c["function"]["arguments"])["task"]
+
+
+def test_dr_orchestrator_second_cycle_generates_report() -> None:
+    messages = [
+        {"role": "user", "content": "research this"},
+        assistant_tool_calls_message("research_agent", '{"task": "aspect 1"}'),
+        {
+            "role": "tool",
+            "content": "intermediate report",
+            "tool_call_id": "call_prev_1",
+        },
+    ]
+    choice = complete(
+        messages=messages,
+        tools=[RESEARCH_AGENT_TOOL, GENERATE_REPORT_TOOL, THINK_TOOL],
+        tool_choice="required",
+    )
+    assert choice["finish_reason"] == "tool_calls"
+    assert choice["message"]["tool_calls"][0]["function"]["name"] == "generate_report"
+
+
+def test_dr_research_agent_searches_then_reports() -> None:
+    agent_tools = [INTERNAL_SEARCH_TOOL, GENERATE_REPORT_TOOL, THINK_TOOL]
+    first = complete(tools=agent_tools, tool_choice="required")
+    assert first["message"]["tool_calls"][0]["function"]["name"] == "internal_search"
+
+    messages = [
+        {"role": "user", "content": "research task"},
+        assistant_tool_calls_message("internal_search", '{"queries": ["q"]}'),
+        {"role": "tool", "content": "results", "tool_call_id": "call_prev_1"},
+    ]
+    second = complete(messages=messages, tools=agent_tools, tool_choice="required")
+    assert second["message"]["tool_calls"][0]["function"]["name"] == "generate_report"
+
+
+def test_forced_specific_tool_is_honored() -> None:
+    choice = complete(
+        tools=[INTERNAL_SEARCH_TOOL, GENERATE_REPORT_TOOL],
+        tool_choice={"type": "function", "function": {"name": "generate_report"}},
+    )
+    assert choice["finish_reason"] == "tool_calls"
+    assert choice["message"]["tool_calls"][0]["function"]["name"] == "generate_report"
+
+
+def test_max_tokens_caps_answer_length() -> None:
+    choice = complete(model="mock-ttft0-itl0-len500", max_tokens=10)
+    assert len(choice["message"]["content"].split()) == 10

--- a/loadtest/tests/test_mock_llm.py
+++ b/loadtest/tests/test_mock_llm.py
@@ -146,6 +146,40 @@ def test_tool_choice_none_forces_text_even_with_tools() -> None:
     assert choice["message"]["content"]
 
 
+def test_query_rephrase_flow_echoes_user_text() -> None:
+    # Query rephrase/expansion output feeds back into retrieval as the search
+    # query — detected by the prompt marker (Onyx's invoke() still streams at
+    # the wire level, so the stream flag can't discriminate). The mock must
+    # echo the question's terms, not return filler.
+    question = "what is the onboarding process for new connectors?"
+    messages = [
+        {
+            "role": "system",
+            "content": "You are an assistant that reformulates the last user "
+            "message into a standalone, self-contained query.",
+        },
+        {
+            "role": "user",
+            "content": f"Chat history above. Final user query:\n{question}",
+        },
+    ]
+    chunks = stream_chunks(messages=messages)
+    text = "".join(c["choices"][0]["delta"].get("content") or "" for c in chunks)
+    assert question.split()[-3] in text  # echo contains the question's terms
+    assert "deterministic mock answer" not in text
+
+    choice = complete(messages=messages)  # non-streaming variant too
+    assert "onboarding" in choice["message"]["content"]
+
+
+def test_normal_answer_is_filler_not_echo() -> None:
+    chunks = stream_chunks(
+        messages=[{"role": "user", "content": "what is the onboarding process?"}]
+    )
+    text = "".join(c["choices"][0]["delta"].get("content") or "" for c in chunks)
+    assert "deterministic mock answer" in text
+
+
 def test_chat_auto_with_tools_knob_emits_internal_search_with_queries_array() -> None:
     chunks = stream_chunks(
         model="mock-tools1-ttft0-itl0",
@@ -254,5 +288,6 @@ def test_forced_specific_tool_is_honored() -> None:
 
 
 def test_max_tokens_caps_answer_length() -> None:
-    choice = complete(model="mock-ttft0-itl0-len500", max_tokens=10)
-    assert len(choice["message"]["content"].split()) == 10
+    chunks = stream_chunks(model="mock-ttft0-itl0-len500", max_tokens=10)
+    text = "".join(c["choices"][0]["delta"].get("content") or "" for c in chunks)
+    assert len(text.split()) == 10

--- a/loadtest/uv.lock
+++ b/loadtest/uv.lock
@@ -557,6 +557,34 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.18"
 source = { registry = "https://pypi.org/simple" }
@@ -759,11 +787,23 @@ dependencies = [
     { name = "uvicorn" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "httpx" },
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115" },
     { name = "locust", specifier = ">=2.32" },
     { name = "uvicorn", specifier = ">=0.30" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "pytest", specifier = ">=8" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Stacked on #11917 (Phase 0). Completes the mock LLM and adds the tool-call and deep-research load-test scenarios.

**Mock LLM rewritten around Onyx's actual LLM-loop contract** (mapped from `chat/llm_loop.py`, `chat/llm_step.py`, `deep_research/dr_loop.py`):

- `tool_choice` drives branching — `none` (final cycles, DR plan/reports, secondary `invoke()` flows) streams text; `required` (every DR orchestrator/agent cycle) always emits a tool call; forced-function honored; `auto` emits a search tool call only with the `-tools1` model knob.
- Deep research works end to end, statelessly: the clarification phase's `generate_plan` tool is always called (so a load-test DR turn never dies on a clarifying question), `research_agent` spawns are derived from history (parallelism via the `-agents<N>` knob), each agent loop searches once then calls `generate_report`, and plan/intermediate/final reports stream as text.
- `internal_search` gets the correct `{"queries": [...]}` array schema; tool arguments are synthesized generically from each tool's JSON schema so Onyx-side schema changes degrade gracefully; `max_tokens` caps are respected.
- **Typed pydantic models** (`mock_llm/models.py`, per review on #11917): request validation via FastAPI with `extra="allow"` (litellm extras can never 422), typed response/chunk models, chunk serialization matching OpenAI's wire format exactly (unset delta fields omitted, `finish_reason: null` always present).

**New scenarios** (`scenarios/`): `ChatWithSearchUser` (`search:*` metrics — the mock's tool call makes Onyx genuinely execute query expansion, the embedding model server, and Vespa/OpenSearch retrieval) and `DeepResearchUser` (`dr:*` metrics, longer timeouts — the heaviest scenario: ~8+ LLM calls plus real search executions on one held stream). Per-scenario metric prefixes throughout.

**Also**: `mock_llm/Dockerfile` (mirrors the `mock_connector_server` pattern, ready for the Phase 2 in-cluster deploy), README provider-latency profiles (fast gpt-class / slow reasoning / degraded provider — per review discussion, slow providers hold streams open longer, which is exactly what stresses the api-server).

## How Has This Been Tested?

- **12 contract tests** (`cd loadtest && uv run pytest tests/ -q`, no infrastructure needed): each replays the exact request shapes Onyx's loops send and asserts the response lets the loop make progress — plain chat, `tool_choice` none/auto/required/forced, the queries-array schema on `internal_search`, DR orchestrator first/second cycles (agent spawn → report), DR research-agent loop (search → report), parallel-agent spawning via `-agents2`, `max_tokens` capping, and OpenAI chunk wire format (`finish_reason` present on every chunk, tool-call header + argument-delta sequence).
- The Phase 0 harness end-to-end run (24 turns / 0 failures through api_server → litellm → mock) was done in #11917; the plain-chat path here is the same code plus validation models.
- **Pending before merge**: integrated validation of the search and DR scenarios against a running stack (search turn showing `search_tool_start` → `search_tool_documents_delta` → answer on the stream; one DR turn completing all phases; mixed 3-scenario Locust run with 0 failures). Blocked on a dev environment right now; will post results on this PR when run.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an OpenAI‑compatible mock LLM that mirrors Onyx’s chat and deep‑research contracts, plus search/DR load‑test scenarios with per‑scenario metrics and a Dockerized server with pinned deps. Implements contract‑accurate tool‑call branching, echo handling for query‑rephrase flows, and OpenAI‑shape streaming.

- **New Features**
  - Mock LLM: `tool_choice` none/auto/required/forced; DR phases (`generate_plan` → `research_agent` via `-agents<N>` → `generate_report`); schema‑driven tool args; `max_tokens` caps; handles multimodal message content; OpenAI streaming (sparse delta, parallel tool‑calls, `finish_reason` always present); 400 on invalid forced tool.
  - Search and rephrase: `-tools1` triggers `internal_search`; arguments use `{"queries":[...]}`; query‑rephrase flows detected by prompt markers echo the user question so retrieval uses real terms.
  - Scenarios: `ChatWithSearchUser` (`search:*`) and `DeepResearchUser` (`dr:*`, longer timeouts); per‑scenario metric prefixes; new DR milestones (`first_dr_plan`, `first_research_agent`); provider latency knobs in model name (`ttft`, `itl`, `len`).
  - Infra/tests: typed `pydantic` request/response models (`extra="allow"`); exact OpenAI chunk serialization; 12 contract tests; `mock_llm/Dockerfile` pinned to `fastapi==0.136.3` and `uvicorn==0.49.0`; README adds provider profiles and setup steps.

- **Migration**
  - Run the mock server and register it as provider type `openai_compatible` with `api_base`; add model configs (e.g. `mock-tools1`, `mock-agents2`, latency profiles) with max input tokens ≥ 50,000.
  - In Locust, pick scenarios; set `ONYX_LLM_PROVIDER` (if the mock isn’t default), `ONYX_LLM_MODEL` (BasicChat), `ONYX_SEARCH_MODEL` (`mock-tools1`), `ONYX_DR_MODEL` (`mock-agents2`); tune `ONYX_STREAM_READ_TIMEOUT`, `ONYX_DR_WAIT_SECONDS`, `ONYX_DR_STREAM_READ_TIMEOUT`.
  - Use `MOCK_TTFT_MS` / `MOCK_ITL_MS` / `MOCK_LEN_TOKENS` for server defaults; override via model‑name knobs.

<sup>Written for commit f72c40a3b8fec0ca34db6214a7cd6e211551b646. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11938?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

