### PR TITLE
feat(craft): sneaky easter egg

### DIFF
--- a/web/src/app/craft/components/BuildWelcome.tsx
+++ b/web/src/app/craft/components/BuildWelcome.tsx
@@ -2,6 +2,7 @@
 
 import { useRef, useState } from "react";
 import { BuildFile } from "@/app/craft/contexts/UploadFilesContext";
+import { useVideoBackgroundToggleClick } from "@/app/craft/components/video-background/useVideoBackgroundToggleClick";
 import { Text } from "@opal/components";
 import Logo from "@/refresh-components/Logo";
 import CraftInputBar, {
@@ -37,6 +38,7 @@ export default function BuildWelcome({
   const [selectedModel, setSelectedModel] = useState<BuildLlmSelection | null>(
     null
   );
+  const handleWordmarkClick = useVideoBackgroundToggleClick();
 
   const handlePromptClick = (promptText: string) => {
     inputBarRef.current?.setMessage(promptText);
@@ -45,14 +47,13 @@ export default function BuildWelcome({
   return (
     <div className="h-full flex flex-col items-center justify-center px-4">
       <div className="w-full max-w-(--app-page-main-content-width) flex flex-col">
-        {/* Branding on the left, model picker on the right — mirrors AppPage. */}
         <div className="flex flex-row items-center justify-between gap-4 pb-6">
-          {/* Typed Onyx wordmark + "Craft" (heading-h2, 24/36 — matches the
-              main app's chat welcome). The wordmark's letters sit in the
-              upper-middle of its box (baseline ~79% down), so we baseline-align
-              and nudge the wordmark down (~0.21 × size) to share Craft's
-              baseline. */}
-          <div className="flex flex-row items-baseline gap-2">
+          {/* The wordmark's baseline sits ~79% down its box, so nudge it
+              down (~0.21 × size) to share Craft's baseline. */}
+          <div
+            className="flex flex-row items-baseline gap-2 select-none"
+            onClick={handleWordmarkClick}
+          >
             <Logo onyxBranded size={28} className="translate-y-[6px]" />
             <Text font="heading-h2" color="text-05">
               Craft

--- a/web/src/app/craft/components/video-background/VideoBackground.tsx
+++ b/web/src/app/craft/components/video-background/VideoBackground.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useBuildContext } from "@/app/craft/contexts/BuildContext";
+import { VIDEO_BACKGROUND_SRC } from "@/app/craft/components/video-background/constants";
+
+export default function VideoBackground() {
+  const { videoBackgroundEnabled } = useBuildContext();
+
+  if (!videoBackgroundEnabled) return null;
+
+  return (
+    <video
+      autoPlay
+      loop
+      muted
+      playsInline
+      className="absolute inset-0 w-full h-full object-cover z-0 pointer-events-none opacity-30 blur-sm"
+    >
+      <source src={VIDEO_BACKGROUND_SRC} type="video/mp4" />
+    </video>
+  );
+}

--- a/web/src/app/craft/components/video-background/constants.ts
+++ b/web/src/app/craft/components/video-background/constants.ts
@@ -1,0 +1,4 @@
+export const VIDEO_BACKGROUND_SRC = "https://cdn.onyx.app/build/background.mp4";
+export const VIDEO_BACKGROUND_STORAGE_KEY = "craft-video-background";
+export const VIDEO_BACKGROUND_CLICK_COUNT = 7;
+export const VIDEO_BACKGROUND_CLICK_RESET_MS = 1500;

--- a/web/src/app/craft/components/video-background/useVideoBackgroundToggleClick.ts
+++ b/web/src/app/craft/components/video-background/useVideoBackgroundToggleClick.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import { useCallback, useRef } from "react";
+import { useBuildContext } from "@/app/craft/contexts/BuildContext";
+import {
+  VIDEO_BACKGROUND_CLICK_COUNT,
+  VIDEO_BACKGROUND_CLICK_RESET_MS,
+} from "@/app/craft/components/video-background/constants";
+
+export function useVideoBackgroundToggleClick() {
+  const { toggleVideoBackground } = useBuildContext();
+  const clickCountRef = useRef(0);
+  const lastClickRef = useRef(0);
+
+  return useCallback(() => {
+    const now = Date.now();
+    if (now - lastClickRef.current > VIDEO_BACKGROUND_CLICK_RESET_MS) {
+      clickCountRef.current = 0;
+    }
+    lastClickRef.current = now;
+    clickCountRef.current += 1;
+    if (clickCountRef.current >= VIDEO_BACKGROUND_CLICK_COUNT) {
+      clickCountRef.current = 0;
+      toggleVideoBackground();
+    }
+  }, [toggleVideoBackground]);
+}

--- a/web/src/app/craft/contexts/BuildContext.tsx
+++ b/web/src/app/craft/contexts/BuildContext.tsx
@@ -2,11 +2,14 @@
 
 import {
   createContext,
+  useCallback,
   useContext,
+  useEffect,
   useState,
   useMemo,
   type ReactNode,
 } from "react";
+import { VIDEO_BACKGROUND_STORAGE_KEY } from "@/app/craft/components/video-background/constants";
 
 /**
  * Build UI Context
@@ -18,6 +21,8 @@ interface BuildContextValue {
   // UI state - left sidebar
   leftSidebarFolded: boolean;
   setLeftSidebarFolded: React.Dispatch<React.SetStateAction<boolean>>;
+  videoBackgroundEnabled: boolean;
+  toggleVideoBackground: () => void;
 }
 
 const BuildContext = createContext<BuildContextValue | null>(null);
@@ -28,13 +33,30 @@ export interface BuildProviderProps {
 
 export function BuildProvider({ children }: BuildProviderProps) {
   const [leftSidebarFolded, setLeftSidebarFolded] = useState(false);
+  const [videoBackgroundEnabled, setVideoBackgroundEnabled] = useState(false);
+
+  useEffect(() => {
+    setVideoBackgroundEnabled(
+      localStorage.getItem(VIDEO_BACKGROUND_STORAGE_KEY) === "true"
+    );
+  }, []);
+
+  const toggleVideoBackground = useCallback(() => {
+    setVideoBackgroundEnabled((prev) => {
+      const next = !prev;
+      localStorage.setItem(VIDEO_BACKGROUND_STORAGE_KEY, String(next));
+      return next;
+    });
+  }, []);
 
   const value = useMemo<BuildContextValue>(
     () => ({
       leftSidebarFolded,
       setLeftSidebarFolded,
+      videoBackgroundEnabled,
+      toggleVideoBackground,
     }),
-    [leftSidebarFolded]
+    [leftSidebarFolded, videoBackgroundEnabled, toggleVideoBackground]
   );
 
   return (

--- a/web/src/app/craft/v1/page.tsx
+++ b/web/src/app/craft/v1/page.tsx
@@ -9,6 +9,7 @@ import {
 import { getSessionIdFromSearchParams } from "@/app/craft/services/searchParams";
 import BuildChatPanel from "@/app/craft/components/ChatPanel";
 import BuildOutputPanel from "@/app/craft/components/OutputPanel";
+import VideoBackground from "@/app/craft/components/video-background/VideoBackground";
 
 /**
  * Build V1 Page - Entry point for builds
@@ -30,11 +31,15 @@ export default function BuildV1Page() {
     // overflow-clip, not overflow-hidden: a hidden box is still programmatically
     // scrollable, which would shove the chat column off-screen.
     <div className="relative flex-1 h-full overflow-clip">
-      {/* Chat panel - always full width for background */}
-      <BuildChatPanel existingSessionId={sessionId} />
+      <VideoBackground />
 
-      {/* Output panel - slides in from the right edge, full viewport height */}
-      <BuildOutputPanel onClose={toggleOutputPanel} isOpen={outputPanelOpen} />
+      <div className="relative z-10 w-full h-full">
+        <BuildChatPanel existingSessionId={sessionId} />
+        <BuildOutputPanel
+          onClose={toggleOutputPanel}
+          isOpen={outputPanelOpen}
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Description

sneaky easter egg

## How Has This Been Tested?

secret testing

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Brings back the Craft launch video background as a hidden easter egg that users can toggle on the welcome screen. The setting persists across visits.

- **New Features**
  - Preference saved in `localStorage` under `craft-video-background`.
  - New `VideoBackground` component and `useVideoBackgroundToggleClick` hook; config in a single `constants.ts`.
  - State and toggle exposed via `BuildContext`.
  - Video sits behind content (`z-0`) with a `z-10` wrapper; output panel layering remains unchanged.

<sup>Written for commit 73ac49160bfd9e7da6c1afb1b49c02079fc762d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

