### PR TITLE
feat(sandbox-proxy): authenticated GitHub git clone/fetch over HTTPS

### DIFF
--- a/backend/onyx/external_apps/github_token.py
+++ b/backend/onyx/external_apps/github_token.py
@@ -1,0 +1,30 @@
+"""Resolve a user's GitHub OAuth token from the built-in GitHub external app.
+
+Shared by the sandbox proxy (to authenticate git over HTTPS) and any
+api-server caller that needs the user's GitHub credential. Reads the same
+``ExternalAppUserCredential`` the GitHub external app stores — there is no
+separate token store.
+"""
+
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from onyx.db.enums import ExternalAppType
+from onyx.db.external_app import get_built_in_external_app
+from onyx.db.external_app import get_external_app_user_credential
+
+
+def get_user_github_access_token(db_session: Session, user_id: UUID) -> str | None:
+    """The user's GitHub external-app OAuth token, or None if not connected."""
+    app = get_built_in_external_app(db_session, ExternalAppType.GITHUB)
+    if app is None:
+        return None
+    credential = get_external_app_user_credential(
+        db_session, external_app_id=app.id, user_id=user_id
+    )
+    if credential is None:
+        return None
+    values = credential.user_credentials.get_value(apply_mask=False)
+    token = values.get("access_token")
+    return token if isinstance(token, str) and token else None

--- a/backend/onyx/sandbox_proxy/git_smart_http.py
+++ b/backend/onyx/sandbox_proxy/git_smart_http.py
@@ -1,0 +1,62 @@
+"""Git Smart HTTP request recognition for the sandbox proxy.
+
+Lets the proxy recognize git-over-HTTPS traffic to github.com so a resolver
+can inject the user's GitHub credential. A clone/fetch is two requests:
+
+    GET  https://github.com/<owner>/<repo>.git/info/refs?service=git-upload-pack
+    POST https://github.com/<owner>/<repo>.git/git-upload-pack
+
+`git-upload-pack` is the read service (clone/fetch); `git-receive-pack` is the
+write counterpart used by `git push`. GitHub canonicalizes the path with a
+`.git` suffix. This module only *recognizes* requests and extracts owner/repo
++ read-vs-write — it carries no policy.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from mitmproxy import http
+
+GIT_HOST = "github.com"
+
+_GIT_PATH_PATTERN = re.compile(
+    r"^/(?P<owner>[A-Za-z0-9][A-Za-z0-9-]{0,38})/(?P<name>[A-Za-z0-9._-]{1,100}?)"
+    r"(?:\.git)?"
+    r"(?P<endpoint>/info/refs|/git-upload-pack|/git-receive-pack)$"
+)
+
+
+@dataclass(frozen=True)
+class GitRequestInfo:
+    owner: str
+    name: str
+    is_push: bool  # receive-pack (push) vs upload-pack (fetch/clone)
+
+
+def parse_git_request(request: http.Request) -> GitRequestInfo | None:
+    """Recognize a git smart-HTTP request to github.com, or return None."""
+    if request.host.lower() != GIT_HOST:
+        return None
+
+    match = _GIT_PATH_PATTERN.match(request.path.split("?", 1)[0])
+    if match is None:
+        return None
+    endpoint = match.group("endpoint")
+
+    if endpoint == "/info/refs":
+        if request.method != "GET":
+            return None
+        service = request.query.get("service", "")
+        if service not in ("git-upload-pack", "git-receive-pack"):
+            return None
+        is_push = service == "git-receive-pack"
+    else:
+        if request.method != "POST":
+            return None
+        is_push = endpoint == "/git-receive-pack"
+
+    return GitRequestInfo(
+        owner=match.group("owner"), name=match.group("name"), is_push=is_push
+    )

--- a/backend/onyx/sandbox_proxy/resolvers/git_remote.py
+++ b/backend/onyx/sandbox_proxy/resolvers/git_remote.py
@@ -1,0 +1,88 @@
+"""GitHub git-over-HTTPS credential resolver (read: clone/fetch).
+
+Claims git smart-HTTP *read* requests to github.com and injects the user's
+GitHub external-app OAuth token as Basic auth (`x-access-token:<token>`, the
+form GitHub requires now that account-password auth is disabled). The token is
+injected by the proxy — outside the sandbox — so untrusted agent code never
+sees it. Unauthenticated requests (no connected GitHub app) forward as-is, so
+public clones keep working and private ones fail with GitHub's own 401/404.
+
+This resolver is repo-agnostic: it injects the user's own credential for any
+github.com repo that credential can reach, mirroring the read access the
+existing api.github.com injection already grants. Push (`git-receive-pack`) is
+deliberately NOT handled here — it requires ref-namespace enforcement and is
+added by a separate layer.
+"""
+
+from __future__ import annotations
+
+import base64
+
+from mitmproxy import http
+
+from onyx.db.engine.sql_engine import get_session_with_tenant
+from onyx.db.enums import ExternalAppType
+from onyx.db.external_app import get_built_in_external_app
+from onyx.external_apps.github_token import get_user_github_access_token
+from onyx.external_apps.token_refresh import ensure_fresh_credentials
+from onyx.sandbox_proxy.credential_injection import CredentialResolver
+from onyx.sandbox_proxy.credential_injection import CredentialUnavailableError
+from onyx.sandbox_proxy.credential_injection import InjectionContext
+from onyx.sandbox_proxy.git_smart_http import parse_git_request
+from onyx.sandbox_proxy.logging_utils import short_log_id
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+class GitRemoteResolver(CredentialResolver):
+    """`CredentialResolver` for git smart-HTTP reads (clone/fetch) to github.com."""
+
+    def claims(
+        self,
+        request: http.Request,
+        ctx: InjectionContext,  # noqa: ARG002
+    ) -> bool:
+        info = parse_git_request(request)
+        return info is not None and not info.is_push
+
+    def resolve(self, request: http.Request, ctx: InjectionContext) -> dict[str, str]:
+        info = parse_git_request(request)
+        if info is None or info.is_push:
+            raise CredentialUnavailableError(
+                "GitRemoteResolver invoked on a non-read git request"
+            )
+
+        github_app = None
+        with get_session_with_tenant(tenant_id=ctx.sandbox.tenant_id) as db:
+            github_app = get_built_in_external_app(db, ExternalAppType.GITHUB)
+
+        if github_app is not None:
+            # Refresh an expiring OAuth token before injecting (no-op for
+            # non-expiring tokens; single-flighted via Redis internally).
+            ensure_fresh_credentials(
+                ctx.sandbox.tenant_id, github_app.id, ctx.sandbox.user_id
+            )
+
+        with get_session_with_tenant(tenant_id=ctx.sandbox.tenant_id) as db:
+            token = get_user_github_access_token(db, ctx.sandbox.user_id)
+
+        if token is None:
+            # No connected GitHub app: forward unauthenticated. Public clones
+            # work; private repos surface GitHub's own auth error.
+            logger.debug(
+                "git_remote_resolver.pass_through sandbox=%s repo=%s/%s",
+                short_log_id(ctx.sandbox.sandbox_id),
+                info.owner,
+                info.name,
+            )
+            return {}
+
+        logger.info(
+            "git_remote_resolver.injected sandbox=%s repo=%s/%s",
+            short_log_id(ctx.sandbox.sandbox_id),
+            info.owner,
+            info.name,
+        )
+        basic = base64.b64encode(f"x-access-token:{token}".encode()).decode()
+        return {"Authorization": f"Basic {basic}"}

--- a/backend/onyx/sandbox_proxy/server.py
+++ b/backend/onyx/sandbox_proxy/server.py
@@ -27,6 +27,7 @@ from onyx.sandbox_proxy.identity import IdentityResolver
 from onyx.sandbox_proxy.identity import SandboxIPLookup
 from onyx.sandbox_proxy.request_evaluator import ExternalAppRequestEvaluator
 from onyx.sandbox_proxy.resolvers.external_app import ExternalAppResolver
+from onyx.sandbox_proxy.resolvers.git_remote import GitRemoteResolver
 from onyx.sandbox_proxy.resolvers.llm_provider_key import LLMProviderKeyResolver
 from onyx.sandbox_proxy.resolvers.onyx_pat import OnyxPatResolver
 from onyx.server.features.build.configs import SANDBOX_NAMESPACE
@@ -178,7 +179,12 @@ def build_resolvers() -> list[CredentialResolver]:
     canonical hosts). Order is a safety net against accidental overlap, not a
     designed-in priority.
     """
-    return [OnyxPatResolver(), LLMProviderKeyResolver(), ExternalAppResolver()]
+    return [
+        OnyxPatResolver(),
+        LLMProviderKeyResolver(),
+        GitRemoteResolver(),
+        ExternalAppResolver(),
+    ]
 
 
 def _install_signal_handlers(

--- a/backend/tests/unit/sandbox_proxy/test_git_smart_http.py
+++ b/backend/tests/unit/sandbox_proxy/test_git_smart_http.py
@@ -1,0 +1,120 @@
+"""Unit tests for git smart-HTTP recognition and the read-only
+GitRemoteResolver (clone/fetch token injection)."""
+
+import base64
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+from mitmproxy import http
+
+from onyx.sandbox_proxy.credential_injection import CredentialUnavailableError
+from onyx.sandbox_proxy.credential_injection import InjectionContext
+from onyx.sandbox_proxy.git_smart_http import parse_git_request
+from onyx.sandbox_proxy.resolvers.git_remote import GitRemoteResolver
+from tests.unit.sandbox_proxy.conftest import make_resolved_sandbox
+
+
+def _request(
+    method: str = "GET",
+    host: str = "github.com",
+    path: str = "/acme/webapp.git/info/refs?service=git-upload-pack",
+    content: bytes = b"",
+) -> http.Request:
+    return http.Request.make(method, f"https://{host}{path}", content=content)
+
+
+class TestParseGitRequest:
+    @pytest.mark.parametrize(
+        "method,path,is_push",
+        [
+            ("GET", "/acme/webapp.git/info/refs?service=git-upload-pack", False),
+            ("GET", "/acme/webapp.git/info/refs?service=git-receive-pack", True),
+            ("GET", "/acme/webapp/info/refs?service=git-upload-pack", False),
+            ("POST", "/acme/webapp.git/git-upload-pack", False),
+            ("POST", "/acme/webapp.git/git-receive-pack", True),
+            ("POST", "/acme/web.app/git-receive-pack", True),
+        ],
+    )
+    def test_recognized_shapes(self, method: str, path: str, is_push: bool) -> None:
+        info = parse_git_request(_request(method=method, path=path))
+        assert info is not None
+        assert info.owner == "acme"
+        assert info.is_push is is_push
+
+    @pytest.mark.parametrize(
+        "method,host,path",
+        [
+            ("GET", "api.github.com", "/acme/webapp.git/info/refs?service=git-upload-pack"),
+            ("GET", "github.com", "/acme/webapp"),
+            ("GET", "github.com", "/acme/webapp/releases"),
+            ("GET", "github.com", "/acme/webapp.git/info/refs"),
+            ("GET", "github.com", "/acme/webapp.git/info/refs?service=other"),
+            ("POST", "github.com", "/acme/webapp.git/info/refs?service=git-upload-pack"),
+            ("GET", "github.com", "/acme/webapp.git/git-receive-pack"),
+            ("POST", "github.com", "/acme/../evil/git-receive-pack"),
+        ],
+    )
+    def test_unrecognized_shapes(self, method: str, host: str, path: str) -> None:
+        assert parse_git_request(_request(method=method, host=host, path=path)) is None
+
+    def test_strips_git_suffix(self) -> None:
+        info = parse_git_request(
+            _request(path="/acme/webapp.git/git-upload-pack", method="POST")
+        )
+        assert info is not None
+        assert info.name == "webapp"
+
+
+class TestReadOnlyResolver:
+    def _ctx(self) -> InjectionContext:
+        return InjectionContext(
+            sandbox=make_resolved_sandbox(user_id=uuid4()), matched_actions=None
+        )
+
+    def test_claims_reads_not_pushes(self) -> None:
+        resolver = GitRemoteResolver()
+        read = _request(path="/acme/webapp.git/info/refs?service=git-upload-pack")
+        push = _request(
+            method="POST", path="/acme/webapp.git/git-receive-pack", content=b"x"
+        )
+        assert resolver.claims(read, self._ctx())
+        assert not resolver.claims(push, self._ctx())
+
+    def test_read_injects_basic_x_access_token(self) -> None:
+        request = _request(path="/acme/webapp.git/info/refs?service=git-upload-pack")
+        with patch(
+            "onyx.sandbox_proxy.resolvers.git_remote.get_session_with_tenant"
+        ) as session_cm, patch(
+            "onyx.sandbox_proxy.resolvers.git_remote.get_built_in_external_app",
+            return_value=None,
+        ), patch(
+            "onyx.sandbox_proxy.resolvers.git_remote.get_user_github_access_token",
+            return_value="gho_token123",
+        ):
+            session_cm.return_value.__enter__.return_value = object()
+            headers = GitRemoteResolver().resolve(request, self._ctx())
+        assert headers["Authorization"].startswith("Basic ")
+        decoded = base64.b64decode(headers["Authorization"].split(" ", 1)[1]).decode()
+        assert decoded == "x-access-token:gho_token123"
+
+    def test_no_token_passes_through(self) -> None:
+        request = _request(path="/acme/webapp.git/info/refs?service=git-upload-pack")
+        with patch(
+            "onyx.sandbox_proxy.resolvers.git_remote.get_session_with_tenant"
+        ) as session_cm, patch(
+            "onyx.sandbox_proxy.resolvers.git_remote.get_built_in_external_app",
+            return_value=None,
+        ), patch(
+            "onyx.sandbox_proxy.resolvers.git_remote.get_user_github_access_token",
+            return_value=None,
+        ):
+            session_cm.return_value.__enter__.return_value = object()
+            assert GitRemoteResolver().resolve(request, self._ctx()) == {}
+
+    def test_resolve_on_push_raises(self) -> None:
+        push = _request(
+            method="POST", path="/acme/webapp.git/git-receive-pack", content=b"x"
+        )
+        with pytest.raises(CredentialUnavailableError):
+            GitRemoteResolver().resolve(push, self._ctx())


### PR DESCRIPTION
## Description

First in a stacked series adding **connect a git repo to Onyx Craft**. This PR is the standalone, **read-only** capability — it has no dependency on the Craft repo feature (no DB model, no `ConnectedRepo`), so it can be reviewed and merged on its own.

The sandbox egress proxy now recognizes GitHub git Smart-HTTP traffic to `github.com` and injects the user's GitHub external-app OAuth token as Basic `x-access-token` auth for **clone/fetch**. The token is injected by the proxy — outside the untrusted sandbox — so agent-generated code never sees it. Requests with no connected GitHub app forward unauthenticated (public clones keep working; private repos surface GitHub's own 401/404).

- `git_smart_http.parse_git_request` recognizes the info/refs + upload-pack/receive-pack shapes and extracts owner/repo + read-vs-write.
- `GitRemoteResolver` injects the token for reads; it's repo-agnostic (mirrors the read access the existing `api.github.com` injection already grants).
- Token lookup lives in the neutral `onyx/external_apps/github_token.py` so the proxy doesn't import from the build feature.
- No gate change needed — upload-pack request bodies are small (push, which needs the body-cap carve-out + ref enforcement, comes in the next PR).

## How Has This Been Tested?

`tests/unit/sandbox_proxy/test_git_smart_http.py` — request recognition across clone/fetch/push shapes and rejections (wrong host, non-git paths, wrong methods, traversal), read-path Basic `x-access-token` injection, and pass-through when no GitHub app is connected. This injection path is what backs the worktree clone validated end-to-end on a kind cluster (a private repo cloned through the proxy).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable authenticated GitHub git clone/fetch over HTTPS in the sandbox egress proxy by recognizing Smart-HTTP requests to `github.com` and injecting the user’s GitHub OAuth token outside the sandbox. Read-only; public clones still work; push is not handled here.

- **New Features**
  - Recognizes Git Smart-HTTP requests to `github.com` and extracts owner/repo and read vs write via `parse_git_request`.
  - Adds `GitRemoteResolver` to inject Basic `x-access-token:<token>` for clone/fetch; repo-agnostic and passes through when no GitHub app is connected.
  - Introduces `get_user_github_access_token` for token lookup and refreshes tokens via `ensure_fresh_credentials` before injection.
  - Registers `GitRemoteResolver` in `server.build_resolvers` ahead of the external app resolver.
  - Adds unit tests for request recognition, read-only injection, and unauthenticated pass-through.

<sup>Written for commit 646c5d687f0a05fa256c093e5821ca02bc941f43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

