### PR TITLE
feat(sandbox-proxy): git push over HTTPS confined to refs/heads/craft/*

### DIFF
--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -37,6 +37,8 @@ from onyx.sandbox_proxy.credential_injection import InjectionContext
 from onyx.sandbox_proxy.credential_injection import InjectionOutcome
 from onyx.sandbox_proxy.errors import http_403
 from onyx.sandbox_proxy.errors import SandboxProxyError
+from onyx.sandbox_proxy.git_smart_http import GIT_SMART_HTTP_MAX_BODY_BYTES
+from onyx.sandbox_proxy.git_smart_http import parse_git_request
 from onyx.sandbox_proxy.identity import ResolvedSandbox
 from onyx.sandbox_proxy.identity import SessionContext
 from onyx.sandbox_proxy.logging_utils import approval_decided_args
@@ -398,8 +400,16 @@ class GateAddon:
 
         # raw_content is None for streamed bodies; treat None as oversize so a
         # future stream opt-in can't silently bypass the cap.
+        #
+        # Git smart-HTTP gets its own (higher) cap: push packfiles routinely
+        # exceed the parser cap, are never action-matched (see below), and the
+        # GitRemoteResolver enforces the craft/* ref namespace on them.
         raw = flow.request.raw_content
-        if raw is None or len(raw) > PARSER_MAX_BODY_BYTES:
+        is_git_request = parse_git_request(flow.request) is not None
+        body_limit = (
+            GIT_SMART_HTTP_MAX_BODY_BYTES if is_git_request else PARSER_MAX_BODY_BYTES
+        )
+        if raw is None or len(raw) > body_limit:
             logger.info(
                 "egress_block "
                 + EGRESS_TARGET_FIELDS
@@ -407,9 +417,40 @@ class GateAddon:
                 *egress_target_args(flow, sandbox),
                 SandboxProxyError.BODY_TOO_LARGE.value,
                 "-" if raw is None else len(raw),
-                PARSER_MAX_BODY_BYTES,
+                body_limit,
             )
             flow.response = http_403(SandboxProxyError.BODY_TOO_LARGE)
+            return None
+
+        if is_git_request:
+            # Git protocol bodies are packfiles, not API payloads — skip the
+            # matcher (no catalog covers github.com git endpoints) so it never
+            # parses megabytes of pack data. Off-catalog dispatch below routes
+            # to the GitRemoteResolver.
+            injection = await asyncio.to_thread(
+                self._dispatch_injection_or_block,
+                flow,
+                sandbox=sandbox,
+                matched_actions=None,
+            )
+            if injection is InjectionOutcome.BLOCKED:
+                logger.warning(
+                    "egress_block "
+                    + EGRESS_TARGET_FIELDS
+                    + " reason=%s credential_outcome=%s",
+                    *egress_target_args(flow, sandbox),
+                    SandboxProxyError.CREDENTIAL_ERROR.value,
+                    credential_outcome_label(injection),
+                )
+            else:
+                logger.info(
+                    "egress_allow "
+                    + EGRESS_TARGET_FIELDS
+                    + " policy=%s credential_outcome=%s",
+                    *egress_target_args(flow, sandbox),
+                    "git_smart_http",
+                    credential_outcome_label(injection),
+                )
             return None
 
         try:

--- a/backend/onyx/sandbox_proxy/git_smart_http.py
+++ b/backend/onyx/sandbox_proxy/git_smart_http.py
@@ -14,6 +14,7 @@ write counterpart used by `git push`. GitHub canonicalizes the path with a
 
 from __future__ import annotations
 
+import os
 import re
 from dataclasses import dataclass
 
@@ -21,11 +22,31 @@ from mitmproxy import http
 
 GIT_HOST = "github.com"
 
+# Push packfiles legitimately exceed the gate's generic 1 MiB body cap (a pack
+# carries full blobs), so recognized git requests are exempted up to this size
+# and skip action-matching (git endpoints are in no action catalog).
+GIT_SMART_HTTP_MAX_BODY_BYTES = int(
+    os.environ.get("GIT_SMART_HTTP_MAX_BODY_BYTES", str(128 * 1024 * 1024))
+)
+
+# Branch namespace Craft sessions are allowed to push to. Mirrors
+# onyx.server.features.build.sandbox.util.git_scripts.CRAFT_BRANCH_PATTERN.
+ALLOWED_PUSH_REF_PATTERN = re.compile(
+    r"^refs/heads/craft/[A-Za-z0-9][A-Za-z0-9._/-]{0,120}$"
+)
+
 _GIT_PATH_PATTERN = re.compile(
     r"^/(?P<owner>[A-Za-z0-9][A-Za-z0-9-]{0,38})/(?P<name>[A-Za-z0-9._-]{1,100}?)"
     r"(?:\.git)?"
     r"(?P<endpoint>/info/refs|/git-upload-pack|/git-receive-pack)$"
 )
+
+_FLUSH_PKT = b"0000"
+_ZERO_SHA = "0" * 40
+
+
+class GitProtocolError(ValueError):
+    """The request claims to be git smart-HTTP but the body doesn't parse."""
 
 
 @dataclass(frozen=True)
@@ -60,3 +81,73 @@ def parse_git_request(request: http.Request) -> GitRequestInfo | None:
     return GitRequestInfo(
         owner=match.group("owner"), name=match.group("name"), is_push=is_push
     )
+
+
+@dataclass(frozen=True)
+class RefUpdate:
+    old_sha: str
+    new_sha: str
+    ref_name: str
+
+    @property
+    def is_delete(self) -> bool:
+        return self.new_sha == _ZERO_SHA
+
+
+def parse_receive_pack_commands(body: bytes) -> list[RefUpdate]:
+    """Parse the pkt-line command section of a git-receive-pack request body.
+
+    Each pkt-line: 4 hex length chars (including themselves), then
+    ``<old-sha> <new-sha> <ref-name>``; the first line also carries a
+    NUL-separated capability list. A flush-pkt (``0000``) ends the section;
+    the packfile follows. Raises GitProtocolError on anything malformed — the
+    caller fails closed (no credential, request blocked).
+    """
+    updates: list[RefUpdate] = []
+    offset = 0
+    while True:
+        if offset + 4 > len(body):
+            raise GitProtocolError("truncated pkt-line stream")
+        length_hex = body[offset : offset + 4]
+        if length_hex == _FLUSH_PKT:
+            break
+        try:
+            length = int(length_hex, 16)
+        except ValueError as e:
+            raise GitProtocolError(f"bad pkt-line length {length_hex!r}") from e
+        if length < 4 or offset + length > len(body):
+            raise GitProtocolError("pkt-line length out of bounds")
+
+        line = body[offset + 4 : offset + length]
+        offset += length
+
+        line = line.split(b"\0", 1)[0].rstrip(b"\n")
+        try:
+            decoded = line.decode("utf-8")
+        except UnicodeDecodeError as e:
+            raise GitProtocolError("non-utf8 ref command") from e
+
+        parts = decoded.split(" ", 2)
+        if len(parts) != 3 or len(parts[0]) != 40 or len(parts[1]) != 40:
+            raise GitProtocolError(f"malformed ref command: {decoded!r}")
+        updates.append(RefUpdate(old_sha=parts[0], new_sha=parts[1], ref_name=parts[2]))
+
+        if len(updates) > 100:
+            raise GitProtocolError("too many ref updates in one push")
+
+    if not updates:
+        raise GitProtocolError("push contains no ref updates")
+    return updates
+
+
+def disallowed_push_refs(body: bytes) -> list[str]:
+    """Ref names in a receive-pack body outside the craft/ namespace.
+
+    Empty list ⇒ the push only touches ``refs/heads/craft/*``. Raises
+    GitProtocolError when the body doesn't parse.
+    """
+    return [
+        update.ref_name
+        for update in parse_receive_pack_commands(body)
+        if not ALLOWED_PUSH_REF_PATTERN.match(update.ref_name)
+    ]

--- a/backend/onyx/sandbox_proxy/resolvers/git_remote.py
+++ b/backend/onyx/sandbox_proxy/resolvers/git_remote.py
@@ -9,9 +9,10 @@ public clones keep working and private ones fail with GitHub's own 401/404.
 
 This resolver is repo-agnostic: it injects the user's own credential for any
 github.com repo that credential can reach, mirroring the read access the
-existing api.github.com injection already grants. Push (`git-receive-pack`) is
-deliberately NOT handled here — it requires ref-namespace enforcement and is
-added by a separate layer.
+existing api.github.com injection already grants. Pushes (`git-receive-pack`)
+are additionally namespace-enforced — every ref update must target
+`refs/heads/craft/*`, checked before any credential is attached — so untrusted
+sandbox code can never push outside the craft/ namespace.
 """
 
 from __future__ import annotations
@@ -28,6 +29,8 @@ from onyx.external_apps.token_refresh import ensure_fresh_credentials
 from onyx.sandbox_proxy.credential_injection import CredentialResolver
 from onyx.sandbox_proxy.credential_injection import CredentialUnavailableError
 from onyx.sandbox_proxy.credential_injection import InjectionContext
+from onyx.sandbox_proxy.git_smart_http import disallowed_push_refs
+from onyx.sandbox_proxy.git_smart_http import GitProtocolError
 from onyx.sandbox_proxy.git_smart_http import parse_git_request
 from onyx.sandbox_proxy.logging_utils import short_log_id
 from onyx.utils.logger import setup_logger
@@ -36,22 +39,44 @@ logger = setup_logger()
 
 
 class GitRemoteResolver(CredentialResolver):
-    """`CredentialResolver` for git smart-HTTP reads (clone/fetch) to github.com."""
+    """`CredentialResolver` for git smart-HTTP (clone/fetch/push) to github.com."""
 
     def claims(
         self,
         request: http.Request,
         ctx: InjectionContext,  # noqa: ARG002
     ) -> bool:
-        info = parse_git_request(request)
-        return info is not None and not info.is_push
+        return parse_git_request(request) is not None
 
     def resolve(self, request: http.Request, ctx: InjectionContext) -> dict[str, str]:
         info = parse_git_request(request)
-        if info is None or info.is_push:
+        if info is None:
             raise CredentialUnavailableError(
-                "GitRemoteResolver invoked on a non-read git request"
+                "GitRemoteResolver invoked on a non-git request"
             )
+
+        # Enforce the push namespace BEFORE any credential decision so a
+        # malformed or out-of-namespace push is blocked unconditionally.
+        if info.is_push and request.method == "POST":
+            # Refuse a compressed push body: `git push` sends the packfile
+            # uncompressed, so a Content-Encoding here would force a
+            # decompression of attacker-controlled size when we read
+            # `request.content` (a gzip-bomb DoS against the shared proxy).
+            content_encoding = request.headers.get("content-encoding", "").strip()
+            if content_encoding and content_encoding.lower() != "identity":
+                raise CredentialUnavailableError(
+                    f"compressed git push rejected (content-encoding={content_encoding})"
+                )
+            try:
+                rejected = disallowed_push_refs(request.content or b"")
+            except GitProtocolError as e:
+                raise CredentialUnavailableError(
+                    f"unparseable git push rejected: {e}"
+                ) from e
+            if rejected:
+                raise CredentialUnavailableError(
+                    f"push to non-craft refs rejected: {', '.join(rejected[:5])}"
+                )
 
         github_app = None
         with get_session_with_tenant(tenant_id=ctx.sandbox.tenant_id) as db:
@@ -79,10 +104,11 @@ class GitRemoteResolver(CredentialResolver):
             return {}
 
         logger.info(
-            "git_remote_resolver.injected sandbox=%s repo=%s/%s",
+            "git_remote_resolver.injected sandbox=%s repo=%s/%s push=%s",
             short_log_id(ctx.sandbox.sandbox_id),
             info.owner,
             info.name,
+            info.is_push,
         )
         basic = base64.b64encode(f"x-access-token:{token}".encode()).decode()
         return {"Authorization": f"Basic {basic}"}

--- a/backend/tests/unit/sandbox_proxy/test_git_smart_http.py
+++ b/backend/tests/unit/sandbox_proxy/test_git_smart_http.py
@@ -66,20 +66,20 @@ class TestParseGitRequest:
         assert info.name == "webapp"
 
 
-class TestReadOnlyResolver:
+class TestReadResolver:
     def _ctx(self) -> InjectionContext:
         return InjectionContext(
             sandbox=make_resolved_sandbox(user_id=uuid4()), matched_actions=None
         )
 
-    def test_claims_reads_not_pushes(self) -> None:
+    def test_claims_reads_and_pushes(self) -> None:
         resolver = GitRemoteResolver()
         read = _request(path="/acme/webapp.git/info/refs?service=git-upload-pack")
         push = _request(
             method="POST", path="/acme/webapp.git/git-receive-pack", content=b"x"
         )
         assert resolver.claims(read, self._ctx())
-        assert not resolver.claims(push, self._ctx())
+        assert resolver.claims(push, self._ctx())
 
     def test_read_injects_basic_x_access_token(self) -> None:
         request = _request(path="/acme/webapp.git/info/refs?service=git-upload-pack")
@@ -112,9 +112,124 @@ class TestReadOnlyResolver:
             session_cm.return_value.__enter__.return_value = object()
             assert GitRemoteResolver().resolve(request, self._ctx()) == {}
 
-    def test_resolve_on_push_raises(self) -> None:
-        push = _request(
-            method="POST", path="/acme/webapp.git/git-receive-pack", content=b"x"
+
+_OLD = "a" * 40
+_NEW = "b" * 40
+_ZERO = "0" * 40
+
+
+def _pkt(line: bytes) -> bytes:
+    return f"{len(line) + 4:04x}".encode() + line
+
+
+def _push_body(*refs: str, zero_new: bool = False) -> bytes:
+    body = b""
+    for index, ref in enumerate(refs):
+        new_sha = _ZERO if zero_new else _NEW
+        line = f"{_OLD} {new_sha} {ref}".encode()
+        if index == 0:
+            line += b"\0report-status side-band-64k"
+        body += _pkt(line + b"\n")
+    return body + b"0000" + b"PACK\x00\x00fake"
+
+
+class TestParseReceivePackCommands:
+    def test_single_command_with_capabilities(self) -> None:
+        from onyx.sandbox_proxy.git_smart_http import parse_receive_pack_commands
+
+        updates = parse_receive_pack_commands(_push_body("refs/heads/craft/x-aa"))
+        assert len(updates) == 1
+        assert updates[0].ref_name == "refs/heads/craft/x-aa"
+        assert not updates[0].is_delete
+
+    def test_delete_detected(self) -> None:
+        from onyx.sandbox_proxy.git_smart_http import parse_receive_pack_commands
+
+        updates = parse_receive_pack_commands(
+            _push_body("refs/heads/craft/x-aa", zero_new=True)
         )
-        with pytest.raises(CredentialUnavailableError):
-            GitRemoteResolver().resolve(push, self._ctx())
+        assert updates[0].is_delete
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            b"",
+            b"00",
+            b"zzzz" + b"0000",
+            b"0000",
+            _pkt(b"garbage line\n") + b"0000",
+        ],
+    )
+    def test_malformed_bodies_raise(self, body: bytes) -> None:
+        from onyx.sandbox_proxy.git_smart_http import GitProtocolError
+        from onyx.sandbox_proxy.git_smart_http import parse_receive_pack_commands
+
+        with pytest.raises(GitProtocolError):
+            parse_receive_pack_commands(body)
+
+    def test_disallowed_refs(self) -> None:
+        from onyx.sandbox_proxy.git_smart_http import disallowed_push_refs
+
+        assert disallowed_push_refs(_push_body("refs/heads/craft/ok-aa")) == []
+        assert disallowed_push_refs(
+            _push_body("refs/heads/craft/ok-aa", "refs/heads/main")
+        ) == ["refs/heads/main"]
+        assert disallowed_push_refs(_push_body("refs/tags/v1")) == ["refs/tags/v1"]
+        assert disallowed_push_refs(_push_body("refs/craft/x")) == ["refs/craft/x"]
+
+
+class TestPushEnforcement:
+    def _ctx(self) -> InjectionContext:
+        return InjectionContext(
+            sandbox=make_resolved_sandbox(user_id=uuid4()), matched_actions=None
+        )
+
+    def test_push_outside_craft_blocked_before_credentials(self) -> None:
+        request = _request(
+            method="POST",
+            path="/acme/webapp.git/git-receive-pack",
+            content=_push_body("refs/heads/main"),
+        )
+        resolver = GitRemoteResolver()
+        assert resolver.claims(request, self._ctx())
+        with pytest.raises(CredentialUnavailableError, match="non-craft"):
+            resolver.resolve(request, self._ctx())
+
+    def test_unparseable_push_blocked(self) -> None:
+        request = _request(
+            method="POST",
+            path="/acme/webapp.git/git-receive-pack",
+            content=b"not pkt lines at all",
+        )
+        with pytest.raises(CredentialUnavailableError, match="unparseable"):
+            GitRemoteResolver().resolve(request, self._ctx())
+
+    def test_compressed_push_rejected(self) -> None:
+        request = _request(
+            method="POST",
+            path="/acme/webapp.git/git-receive-pack",
+            content=_push_body("refs/heads/craft/ok-aa"),
+        )
+        request.headers["content-encoding"] = "gzip"
+        with pytest.raises(CredentialUnavailableError, match="compressed"):
+            GitRemoteResolver().resolve(request, self._ctx())
+
+    def test_craft_push_injects_basic_auth(self) -> None:
+        request = _request(
+            method="POST",
+            path="/acme/webapp.git/git-receive-pack",
+            content=_push_body("refs/heads/craft/ok-aa"),
+        )
+        with patch(
+            "onyx.sandbox_proxy.resolvers.git_remote.get_session_with_tenant"
+        ) as session_cm, patch(
+            "onyx.sandbox_proxy.resolvers.git_remote.get_built_in_external_app",
+            return_value=None,
+        ), patch(
+            "onyx.sandbox_proxy.resolvers.git_remote.get_user_github_access_token",
+            return_value="gho_token123",
+        ):
+            session_cm.return_value.__enter__.return_value = object()
+            headers = GitRemoteResolver().resolve(request, self._ctx())
+        decoded = base64.b64decode(headers["Authorization"].split(" ", 1)[1]).decode()
+        assert decoded == "x-access-token:gho_token123"


### PR DESCRIPTION
## Description

Second in the stack (on top of #11940). Extends the `GitRemoteResolver` to handle **`git push`** (`git-receive-pack`), confined to the `refs/heads/craft/*` namespace.

- Parses the pkt-line command section of the push and **rejects any push touching a ref outside `refs/heads/craft/*` before injecting credentials** — so untrusted sandbox code can only push to craft branches, and can't touch `main`, releases, tags, or anyone else's branch. (The session branch is named by the platform, not the agent, so this is zero-friction.)
- Rejects compressed push bodies (a gzip-bomb DoS guard — `git push` sends the packfile uncompressed, so a `Content-Encoding` here would force decompression of attacker-controlled size).
- Exempts recognized git requests from the gate's 1 MiB request-body cap and skips action-matching for them (packfiles are large and `github.com` git endpoints are in no action catalog).

Enforcement happens at the pkt-line level and the firewall forces all egress through the proxy, so there's no way around it from inside the sandbox.

## How Has This Been Tested?

`tests/unit/sandbox_proxy/test_git_smart_http.py` — pkt-line parser (capability list, multiple refs, deletes, and malformed bodies that must fail closed), `craft/*` enforcement (a push to `refs/heads/main` / tags / non-craft refs is blocked before any credential is attached), compressed-body rejection, and the gate body-cap carve-out for git requests. 94 proxy unit tests pass.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds push handling to the `GitRemoteResolver` and confines `git-receive-pack` to `refs/heads/craft/*` using pkt-line validation before any credential injection. Also blocks compressed push bodies and raises the body cap for recognized git smart-HTTP while skipping action matching.

- **New Features**
  - Parses receive-pack pkt-lines and rejects any ref outside `refs/heads/craft/*` (including deletes) before credentials are attached; malformed pushes fail closed.
  - Rejects `Content-Encoding` on push requests to prevent gzip-bomb decompression.
  - Gate exempts recognized git requests from the 1 MiB cap, using `GIT_SMART_HTTP_MAX_BODY_BYTES` (default 128 MiB), and bypasses action matching to route directly to the resolver.
  - Unit tests cover pkt-line parsing, namespace enforcement, compressed-body rejection, and gate carve-out.

<sup>Written for commit 23afdadb77ab295a661f5e8b4aceab8d00610a2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

