### PR TITLE
fix(web): only render custom chat background on chat surfaces

### DIFF
--- a/web/lib/opal/src/layouts/settings/components.tsx
+++ b/web/lib/opal/src/layouts/settings/components.tsx
@@ -112,8 +112,8 @@ function SettingsHeader({
     <div
       ref={headerRef}
       className={cn(
-        "w-full bg-background-tint-01",
-        isSticky && "sticky top-0 z-settings-header",
+        "w-full",
+        isSticky && "sticky top-0 z-settings-header bg-background-tint-01",
         showBackButton && "md:pt-4"
       )}
     >

--- a/web/src/sections/app-chrome/AppChrome.tsx
+++ b/web/src/sections/app-chrome/AppChrome.tsx
@@ -505,7 +505,8 @@ export default function AppChrome({ children }: AppChromeProps) {
   const { resolvedTheme } = useTheme();
   const { isSafari } = useBrowserInfo();
   const isLightMode = resolvedTheme === "light";
-  const showBackground = hasBackground && !appFocus.isProject();
+  const showBackground =
+    hasBackground && (appFocus.isChat() || appFocus.isNewSession());
 
   const horizontalBlurMask = `linear-gradient(
     to right,


### PR DESCRIPTION
## Problem

The user's custom chat background was bleeding onto the **user-settings pages** (and other non-chat surfaces). It was gated on:

```js
const showBackground = hasBackground && !appFocus.isProject();
```

Since settings pages aren't `isProject()`, they were eligible for the background. This is a deny-list, so every new non-project surface inherits the background by default.

## Fix

Flip it to an opt-in allow-list — only render the custom background on the chat surfaces where it's intended:

```js
const showBackground =
  hasBackground && (appFocus.isChat() || appFocus.isNewSession());
```

This covers active conversations and the new-chat landing page, and excludes settings, projects, the agents list, and shared chat.

## Settings header fill

While here, scoped the settings header's `bg-background-tint-01` to the **sticky** case only:

```diff
-  "w-full bg-background-tint-01",
-  isSticky && "sticky top-0 z-settings-header",
+  "w-full",
+  isSticky && "sticky top-0 z-settings-header bg-background-tint-01",
```

The header is only sticky when it's given `rightChildren` (`isSticky = !!rightChildren`), and no page does that today — so on every current header the fill was a purely cosmetic tint. But the sticky capability is real: when a header *is* sticky, the opaque fill keeps body content from bleeding through as it scrolls underneath. Gating on `isSticky` drops the useless tint while preserving the fill exactly where it's functionally needed.

## Notes

- The chat readability blur (Effect 2) is separately gated on `appFocus.isChat()`, so it's unchanged.
- This was surfaced while looking at #11918 (`f3d52abb3b`), but that commit was a `className`/structural refactor and left the `showBackground` condition unchanged — the background was already eligible to render on settings; this PR fixes the underlying condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)