### PR TITLE
chore(hotfix): cherry-pick 5 commits to release v4.1

### DIFF
--- a/backend/alembic/versions/1cb59a95b250_add_security_settings_table.py
+++ b/backend/alembic/versions/1cb59a95b250_add_security_settings_table.py
@@ -1,0 +1,67 @@
+"""add security_settings table
+
+Replaces the per-tenant ``onyx_security_settings`` JSONB blob in
+``key_value_store`` with a dedicated, typed ``security_settings`` table.
+
+The table holds a single row per tenant schema (enforced by a boolean
+primary key pinned to ``true`` via CHECK). Every column is an *override*:
+``NULL`` means "fall back to the env-derived default", mirroring the
+``SecuritySettingsOverrides`` storage shape (absent field == env default).
+
+Revision ID: 1cb59a95b250
+Revises: 99ecd56cb2ce
+Create Date: 2026-06-09 17:36:09.181328
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = "1cb59a95b250"
+down_revision = "99ecd56cb2ce"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "security_settings",
+        # Singleton row: pinned to true so a second INSERT collides on the PK.
+        sa.Column(
+            "id",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.true(),
+        ),
+        sa.Column("user_directory_admin_only", sa.Boolean(), nullable=True),
+        sa.Column("track_external_idp_expiry", sa.Boolean(), nullable=True),
+        sa.Column("mask_credential_prefix", sa.Boolean(), nullable=True),
+        sa.Column(
+            "valid_email_domains",
+            postgresql.ARRAY(sa.String()),
+            nullable=True,
+        ),
+        sa.Column("password_min_length", sa.Integer(), nullable=True),
+        sa.Column("password_max_length", sa.Integer(), nullable=True),
+        sa.Column("password_require_uppercase", sa.Boolean(), nullable=True),
+        sa.Column("password_require_lowercase", sa.Boolean(), nullable=True),
+        sa.Column("password_require_digit", sa.Boolean(), nullable=True),
+        sa.Column("password_require_special_char", sa.Boolean(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.CheckConstraint("id = true", name="ck_security_settings_singleton"),
+        # Only constrains rows where both bounds are explicitly overridden; a
+        # NULL bound falls back to its env default, invisible to this CHECK.
+        sa.CheckConstraint(
+            "password_min_length IS NULL "
+            "OR password_max_length IS NULL "
+            "OR password_min_length <= password_max_length",
+            name="ck_security_settings_pw_length_range",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("security_settings")

--- a/backend/alembic/versions/1cb59a95b250_add_security_settings_table.py
+++ b/backend/alembic/versions/1cb59a95b250_add_security_settings_table.py
@@ -1,13 +1,5 @@
 """add security_settings table
 
-Replaces the per-tenant ``onyx_security_settings`` JSONB blob in
-``key_value_store`` with a dedicated, typed ``security_settings`` table.
-
-The table holds a single row per tenant schema (enforced by a boolean
-primary key pinned to ``true`` via CHECK). Every column is an *override*:
-``NULL`` means "fall back to the env-derived default", mirroring the
-``SecuritySettingsOverrides`` storage shape (absent field == env default).
-
 Revision ID: 1cb59a95b250
 Revises: 99ecd56cb2ce
 Create Date: 2026-06-09 17:36:09.181328
@@ -29,7 +21,6 @@ depends_on = None
 def upgrade() -> None:
     op.create_table(
         "security_settings",
-        # Singleton row: pinned to true so a second INSERT collides on the PK.
         sa.Column(
             "id",
             sa.Boolean(),
@@ -52,8 +43,6 @@ def upgrade() -> None:
         sa.Column("password_require_special_char", sa.Boolean(), nullable=True),
         sa.PrimaryKeyConstraint("id"),
         sa.CheckConstraint("id = true", name="ck_security_settings_singleton"),
-        # Only constrains rows where both bounds are explicitly overridden; a
-        # NULL bound falls back to its env default, invisible to this CHECK.
         sa.CheckConstraint(
             "password_min_length IS NULL "
             "OR password_max_length IS NULL "

--- a/backend/ee/onyx/server/user_group/api.py
+++ b/backend/ee/onyx/server/user_group/api.py
@@ -38,6 +38,7 @@ from onyx.db.models import UserRole
 from onyx.db.persona import get_persona_by_id
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
+from onyx.server.security.store import get_security_settings
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -66,7 +67,11 @@ def list_user_groups(
             eager_load_for_snapshot=True,
             include_default=include_default,
         )
-    return [UserGroup.from_model(user_group) for user_group in user_groups]
+    mask_credential_prefix = get_security_settings().mask_credential_prefix
+    return [
+        UserGroup.from_model(user_group, mask_credential_prefix=mask_credential_prefix)
+        for user_group in user_groups
+    ]
 
 
 @router.get("/user-groups/minimal")
@@ -149,7 +154,10 @@ def create_user_group(
             f"User group with name '{user_group.name}' already exists. Please "
             + "choose a different name.",
         )
-    return UserGroup.from_model(db_user_group)
+    return UserGroup.from_model(
+        db_user_group,
+        mask_credential_prefix=get_security_settings().mask_credential_prefix,
+    )
 
 
 @router.patch("/admin/user-group/rename")
@@ -167,7 +175,8 @@ def rename_user_group_endpoint(
                 db_session=db_session,
                 user_group_id=rename_request.id,
                 new_name=rename_request.name,
-            )
+            ),
+            mask_credential_prefix=get_security_settings().mask_credential_prefix,
         )
     except IntegrityError:
         raise OnyxError(
@@ -195,7 +204,8 @@ def patch_user_group(
                 user=user,
                 user_group_id=user_group_id,
                 user_group_update=user_group_update,
-            )
+            ),
+            mask_credential_prefix=get_security_settings().mask_credential_prefix,
         )
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
@@ -215,7 +225,8 @@ def add_users(
                 user=user,
                 user_group_id=user_group_id,
                 user_ids=add_users_request.user_ids,
-            )
+            ),
+            mask_credential_prefix=get_security_settings().mask_credential_prefix,
         )
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))

--- a/backend/ee/onyx/server/user_group/models.py
+++ b/backend/ee/onyx/server/user_group/models.py
@@ -26,7 +26,12 @@ class UserGroup(BaseModel):
     is_default: bool
 
     @classmethod
-    def from_model(cls, user_group_model: UserGroupModel) -> "UserGroup":
+    def from_model(
+        cls,
+        user_group_model: UserGroupModel,
+        *,
+        mask_credential_prefix: bool,
+    ) -> "UserGroup":
         return cls(
             id=user_group_model.id,
             name=user_group_model.name,
@@ -59,7 +64,8 @@ class UserGroup(BaseModel):
                         credential_ids=[cc_pair_relationship.cc_pair.credential_id],
                     ),
                     credential=CredentialSnapshot.from_credential_db_model(
-                        cc_pair_relationship.cc_pair.credential
+                        cc_pair_relationship.cc_pair.credential,
+                        mask_credential_prefix=mask_credential_prefix,
                     ),
                     access_type=cc_pair_relationship.cc_pair.access_type,
                 )
@@ -67,7 +73,10 @@ class UserGroup(BaseModel):
                 if cc_pair_relationship.is_current
             ],
             document_sets=[
-                DocumentSet.from_model(ds) for ds in user_group_model.document_sets
+                DocumentSet.from_model(
+                    ds, mask_credential_prefix=mask_credential_prefix
+                )
+                for ds in user_group_model.document_sets
             ],
             personas=[
                 PersonaSnapshot.from_model(persona)

--- a/backend/onyx/auth/oauth_refresher.py
+++ b/backend/onyx/auth/oauth_refresher.py
@@ -17,9 +17,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from onyx.configs.app_configs import OAUTH_CLIENT_ID
 from onyx.configs.app_configs import OAUTH_CLIENT_SECRET
 from onyx.configs.app_configs import OPENID_CONFIG_URL
-from onyx.configs.app_configs import TRACK_EXTERNAL_IDP_EXPIRY
 from onyx.db.models import OAuthAccount
 from onyx.db.models import User
+from onyx.server.security.store import get_security_settings
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -252,8 +252,7 @@ async def refresh_oauth_token(
             if new_expires_at:
                 updated_data["expires_at"] = new_expires_at
 
-                # Update oidc_expiry in user model if we're tracking it
-                if TRACK_EXTERNAL_IDP_EXPIRY:
+                if get_security_settings().track_external_idp_expiry:
                     oidc_expiry = datetime.fromtimestamp(
                         new_expires_at, tz=timezone.utc
                     )

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -7,6 +7,7 @@ import secrets
 import string
 import uuid
 from collections.abc import AsyncGenerator
+from collections.abc import Sequence
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
@@ -90,18 +91,10 @@ from onyx.configs.app_configs import AUTH_COOKIE_EXPIRE_TIME_SECONDS
 from onyx.configs.app_configs import AUTH_TYPE
 from onyx.configs.app_configs import EMAIL_CONFIGURED
 from onyx.configs.app_configs import JWT_PUBLIC_KEY_URL
-from onyx.configs.app_configs import PASSWORD_MAX_LENGTH
-from onyx.configs.app_configs import PASSWORD_MIN_LENGTH
-from onyx.configs.app_configs import PASSWORD_REQUIRE_DIGIT
-from onyx.configs.app_configs import PASSWORD_REQUIRE_LOWERCASE
-from onyx.configs.app_configs import PASSWORD_REQUIRE_SPECIAL_CHAR
-from onyx.configs.app_configs import PASSWORD_REQUIRE_UPPERCASE
 from onyx.configs.app_configs import REDIS_AUTH_KEY_PREFIX
 from onyx.configs.app_configs import REQUIRE_EMAIL_VERIFICATION
 from onyx.configs.app_configs import SESSION_EXPIRE_TIME_SECONDS
-from onyx.configs.app_configs import TRACK_EXTERNAL_IDP_EXPIRY
 from onyx.configs.app_configs import USER_AUTH_SECRET
-from onyx.configs.app_configs import VALID_EMAIL_DOMAINS
 from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.configs.constants import ANONYMOUS_USER_COOKIE_NAME
 from onyx.configs.constants import ANONYMOUS_USER_EMAIL
@@ -140,6 +133,7 @@ from onyx.error_handling.exceptions import onyx_error_to_json_response
 from onyx.error_handling.exceptions import OnyxError
 from onyx.redis.redis_pool import get_async_redis_connection
 from onyx.redis.redis_pool import retrieve_ws_token_data
+from onyx.server.security.store import get_security_settings
 from onyx.server.settings.store import load_settings
 from onyx.server.utils import BasicAuthenticationError
 from onyx.utils.logger import setup_logger
@@ -295,7 +289,12 @@ def verify_email_in_whitelist(email: str, tenant_id: str) -> None:
             verify_email_is_invited(email)
 
 
-def verify_email_domain(email: str, *, is_registration: bool = False) -> None:
+def verify_email_domain(
+    email: str,
+    *,
+    valid_email_domains: Sequence[str],
+    is_registration: bool = False,
+) -> None:
     if email.count("@") != 1:
         raise OnyxError(OnyxErrorCode.INVALID_INPUT, "Email is not valid")
 
@@ -333,8 +332,8 @@ def verify_email_domain(email: str, *, is_registration: bool = False) -> None:
         )
 
     # Check domain whitelist if configured
-    if VALID_EMAIL_DOMAINS:
-        if domain not in VALID_EMAIL_DOMAINS:
+    if valid_email_domains:
+        if domain not in valid_email_domains:
             raise OnyxError(OnyxErrorCode.INVALID_INPUT, "Email domain is not valid")
 
 
@@ -511,8 +510,13 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
     ) -> User:
         # Check for disposable emails FIRST so obvious throwaway domains are
         # rejected before hitting Google's siteverify API. Cheap local check.
+        security_settings = get_security_settings()
         try:
-            verify_email_domain(user_create.email, is_registration=True)
+            verify_email_domain(
+                user_create.email,
+                valid_email_domains=security_settings.valid_email_domains,
+                is_registration=True,
+            )
         except OnyxError as e:
             # Log blocked disposable email attempts
             if "Disposable email" in e.detail:
@@ -771,28 +775,34 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
     async def validate_password(  # ty: ignore[invalid-method-override]
         self, password: str, _: schemas.UC | models.UP
     ) -> None:
-        # Validate password according to configurable security policy (defined via environment variables)
-        if len(password) < PASSWORD_MIN_LENGTH:
+        settings = get_security_settings()
+        if len(password) < settings.password_min_length:
             raise exceptions.InvalidPasswordException(
-                reason=f"Password must be at least {PASSWORD_MIN_LENGTH} characters long."
+                reason=f"Password must be at least {settings.password_min_length} characters long."
             )
-        if len(password) > PASSWORD_MAX_LENGTH:
+        if len(password) > settings.password_max_length:
             raise exceptions.InvalidPasswordException(
-                reason=f"Password must not exceed {PASSWORD_MAX_LENGTH} characters."
+                reason=f"Password must not exceed {settings.password_max_length} characters."
             )
-        if PASSWORD_REQUIRE_UPPERCASE and not any(char.isupper() for char in password):
+        if settings.password_require_uppercase and not any(
+            char.isupper() for char in password
+        ):
             raise exceptions.InvalidPasswordException(
                 reason="Password must contain at least one uppercase letter."
             )
-        if PASSWORD_REQUIRE_LOWERCASE and not any(char.islower() for char in password):
+        if settings.password_require_lowercase and not any(
+            char.islower() for char in password
+        ):
             raise exceptions.InvalidPasswordException(
                 reason="Password must contain at least one lowercase letter."
             )
-        if PASSWORD_REQUIRE_DIGIT and not any(char.isdigit() for char in password):
+        if settings.password_require_digit and not any(
+            char.isdigit() for char in password
+        ):
             raise exceptions.InvalidPasswordException(
                 reason="Password must contain at least one number."
             )
-        if PASSWORD_REQUIRE_SPECIAL_CHAR and not any(
+        if settings.password_require_special_char and not any(
             char in PASSWORD_SPECIAL_CHARS for char in password
         ):
             raise exceptions.InvalidPasswordException(
@@ -837,7 +847,11 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             token = CURRENT_TENANT_ID_CONTEXTVAR.set(tenant_id)
 
             verify_email_in_whitelist(account_email, tenant_id)
-            verify_email_domain(account_email)
+            oauth_security_settings = get_security_settings()
+            verify_email_domain(
+                account_email,
+                valid_email_domains=oauth_security_settings.valid_email_domains,
+            )
 
             # NOTE(rkuo): If this UserManager is instantiated per connection
             # should we even be doing this here?
@@ -883,7 +897,10 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                     # OAuth-created accounts are not subject to the dotted-Gmail
                     # signup block: the provider vouches for one canonical email
                     # per account, so dot-alias abuse isn't possible here.
-                    verify_email_domain(account_email)
+                    verify_email_domain(
+                        account_email,
+                        valid_email_domains=oauth_security_settings.valid_email_domains,
+                    )
 
                     # Lock + check on the same session that does the insert.
                     await self.user_db.session.run_sync(
@@ -921,7 +938,10 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
 
             # NOTE: Most IdPs have very short expiry times, and we don't want to force the user to
             # re-authenticate that frequently, so by default this is disabled
-            if expires_at and TRACK_EXTERNAL_IDP_EXPIRY:
+            track_external_idp_expiry = (
+                oauth_security_settings.track_external_idp_expiry
+            )
+            if expires_at and track_external_idp_expiry:
                 oidc_expiry = datetime.fromtimestamp(expires_at, tz=timezone.utc)
                 await self.user_db.update(
                     user, update_dict={"oidc_expiry": oidc_expiry}
@@ -972,9 +992,10 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                 user = await self.user_db.get(user.id)
                 assert user is not None
 
-            # this is needed if an organization goes from `TRACK_EXTERNAL_IDP_EXPIRY=true` to `false`
-            # otherwise, the oidc expiry will always be old, and the user will never be able to login
-            if user.oidc_expiry is not None and not TRACK_EXTERNAL_IDP_EXPIRY:
+            # this is needed if an organization toggles track_external_idp_expiry from
+            # true to false; otherwise the oidc expiry will always be old and the user
+            # will never be able to login.
+            if user.oidc_expiry is not None and not track_external_idp_expiry:
                 await self.user_db.update(user, {"oidc_expiry": None})
                 user.oidc_expiry = None  # ty: ignore[invalid-assignment]
             remove_user_from_invited_users(user.email)
@@ -1160,7 +1181,10 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         token: str,
         request: Optional[Request] = None,  # noqa: ARG002
     ) -> None:
-        verify_email_domain(user.email)
+        verify_email_domain(
+            user.email,
+            valid_email_domains=get_security_settings().valid_email_domains,
+        )
 
         logger.notice(
             "Verification requested for user %s. Verification token: %s", user.id, token
@@ -1659,7 +1683,7 @@ def _extract_email_from_jwt(payload: dict[str, Any]) -> str | None:
 async def _sync_jwt_oidc_expiry(
     user_manager: UserManager, user: User, payload: dict[str, Any]
 ) -> None:
-    if TRACK_EXTERNAL_IDP_EXPIRY:
+    if get_security_settings().track_external_idp_expiry:
         expires_at = payload.get("exp")
         if expires_at is None:
             return
@@ -1696,7 +1720,10 @@ async def _get_or_create_user_from_jwt(
 
     # Enforce the same allowlist/domain policies as other auth flows
     verify_email_is_invited(email)
-    verify_email_domain(email)
+    verify_email_domain(
+        email,
+        valid_email_domains=get_security_settings().valid_email_domains,
+    )
 
     user_db: SQLAlchemyUserAdminDB[User, uuid.UUID] = SQLAlchemyUserAdminDB(
         async_db_session, User, OAuthAccount

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -286,6 +286,12 @@ METRICS_AUTH_TOKEN = os.environ.get("METRICS_AUTH_TOKEN") or ""
 # deliberate choice, since auth is otherwise required by default.
 DISABLE_METRICS_AUTH = os.environ.get("DISABLE_METRICS_AUTH", "").lower() == "true"
 
+# Explicit opt-in: serve the interactive API docs and schema (/openapi.json,
+# /docs, /redoc) publicly with no authentication. Default off so the API surface
+# is not exposed on a fresh deployment. When disabled the routes are not
+# registered at all (404). Note: these renderers never bypass per-route auth.
+ENABLE_PUBLIC_DOCS = os.environ.get("ENABLE_PUBLIC_DOCS", "").lower() == "true"
+
 # Duration (in seconds) for which the FastAPI Users JWT token remains valid in the user's browser.
 # By default, this is set to match the Redis expiry time for consistency.
 AUTH_COOKIE_EXPIRE_TIME_SECONDS = int(

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -471,6 +471,8 @@ class OnyxRedisLocks:
     OPENSEARCH_MIGRATION_BEAT_LOCK = "da_lock:opensearch_migration_beat"
     OPENSEARCH_VERIFY_INDEX_LOCK_PREFIX = "da_lock:opensearch_verify_index"
 
+    SECURITY_SETTINGS = "da_lock:security_settings"
+
     MONITOR_BACKGROUND_PROCESSES_LOCK = "da_lock:monitor_background_processes"
     CHECK_AVAILABLE_TENANTS_LOCK = "da_lock:check_available_tenants"
     CLOUD_PRE_PROVISION_TENANT_LOCK = "da_lock:pre_provision_tenant"

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -4096,14 +4096,10 @@ class KVStore(Base):
 
 
 class SecuritySettings(Base):
-    """Per-tenant runtime overrides for the env-derived security settings.
+    """Per-tenant runtime overrides for env-derived security settings.
 
-    Singleton: one row per tenant schema, enforced by a boolean primary key
-    pinned to ``true`` via a CHECK constraint. Every column is an *override* —
-    ``None`` means "fall back to the env-derived default" — so this is the
-    typed, relational counterpart of the ``SecuritySettingsOverrides`` wire
-    shape (absent field == env default). Replaces the prior
-    ``onyx_security_settings`` JSONB blob in ``key_value_store``.
+    Singleton row (boolean PK pinned to ``true`` via CHECK). Every column is
+    an override — ``None`` == "fall back to env default".
     """
 
     __tablename__ = "security_settings"
@@ -4145,9 +4141,8 @@ class SecuritySettings(Base):
 
     __table_args__ = (
         CheckConstraint("id = true", name="ck_security_settings_singleton"),
-        # Only constrains rows where both bounds are explicitly overridden; a
-        # bound left NULL falls back to its env default, which this CHECK can't
-        # see. App-layer validation still guards the mixed (override + env) case.
+        # Only catches min > max when both are explicitly overridden; the
+        # mixed-with-env case is enforced at the application layer.
         CheckConstraint(
             "password_min_length IS NULL "
             "OR password_max_length IS NULL "

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -30,6 +30,7 @@ from sqlalchemy import Sequence
 from sqlalchemy import String
 from sqlalchemy import Text
 from sqlalchemy import text
+from sqlalchemy import true
 from sqlalchemy import UniqueConstraint
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql import JSONB as PGJSONB
@@ -4091,6 +4092,68 @@ class KVStore(Base):
     value: Mapped[JSON_ro] = mapped_column(postgresql.JSONB(), nullable=True)
     encrypted_value: Mapped[SensitiveValue[dict[str, Any]] | None] = mapped_column(
         EncryptedJson(), nullable=True
+    )
+
+
+class SecuritySettings(Base):
+    """Per-tenant runtime overrides for the env-derived security settings.
+
+    Singleton: one row per tenant schema, enforced by a boolean primary key
+    pinned to ``true`` via a CHECK constraint. Every column is an *override* —
+    ``None`` means "fall back to the env-derived default" — so this is the
+    typed, relational counterpart of the ``SecuritySettingsOverrides`` wire
+    shape (absent field == env default). Replaces the prior
+    ``onyx_security_settings`` JSONB blob in ``key_value_store``.
+    """
+
+    __tablename__ = "security_settings"
+
+    id: Mapped[bool] = mapped_column(
+        Boolean, primary_key=True, default=True, server_default=true()
+    )
+
+    user_directory_admin_only: Mapped[bool | None] = mapped_column(
+        Boolean, nullable=True, default=None
+    )
+    track_external_idp_expiry: Mapped[bool | None] = mapped_column(
+        Boolean, nullable=True, default=None
+    )
+    mask_credential_prefix: Mapped[bool | None] = mapped_column(
+        Boolean, nullable=True, default=None
+    )
+    valid_email_domains: Mapped[list[str] | None] = mapped_column(
+        postgresql.ARRAY(String), nullable=True, default=None
+    )
+    password_min_length: Mapped[int | None] = mapped_column(
+        Integer, nullable=True, default=None
+    )
+    password_max_length: Mapped[int | None] = mapped_column(
+        Integer, nullable=True, default=None
+    )
+    password_require_uppercase: Mapped[bool | None] = mapped_column(
+        Boolean, nullable=True, default=None
+    )
+    password_require_lowercase: Mapped[bool | None] = mapped_column(
+        Boolean, nullable=True, default=None
+    )
+    password_require_digit: Mapped[bool | None] = mapped_column(
+        Boolean, nullable=True, default=None
+    )
+    password_require_special_char: Mapped[bool | None] = mapped_column(
+        Boolean, nullable=True, default=None
+    )
+
+    __table_args__ = (
+        CheckConstraint("id = true", name="ck_security_settings_singleton"),
+        # Only constrains rows where both bounds are explicitly overridden; a
+        # bound left NULL falls back to its env default, which this CHECK can't
+        # see. App-layer validation still guards the mixed (override + env) case.
+        CheckConstraint(
+            "password_min_length IS NULL "
+            "OR password_max_length IS NULL "
+            "OR password_min_length <= password_max_length",
+            name="ck_security_settings_pw_length_range",
+        ),
     )
 
 

--- a/backend/onyx/db/security_settings.py
+++ b/backend/onyx/db/security_settings.py
@@ -1,0 +1,37 @@
+"""Persistence for the singleton ``security_settings`` row.
+
+One row per tenant schema (boolean PK pinned to ``true``). Every column is
+an *override*: ``NULL`` == "fall back to env default".
+"""
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.orm import Session
+
+from onyx.db.models import SecuritySettings as SecuritySettingsRow
+from onyx.server.security.models import SecuritySettingsOverrides
+
+
+def load_overrides(db_session: Session) -> SecuritySettingsOverrides:
+    """Returns an empty overrides object (all-None) when no row exists."""
+    row = db_session.execute(select(SecuritySettingsRow)).scalar_one_or_none()
+    if row is None:
+        return SecuritySettingsOverrides()
+    return SecuritySettingsOverrides.model_validate(row, from_attributes=True)
+
+
+def upsert_overrides(db_session: Session, overrides: SecuritySettingsOverrides) -> None:
+    """Upsert the singleton row.
+
+    We pass every column explicitly (not ``exclude_none``) so DO UPDATE
+    actually clears fields the admin removed — leaving them out would keep
+    the previously-set value.
+    """
+    payload = {
+        name: getattr(overrides, name)
+        for name in SecuritySettingsOverrides.model_fields
+    }
+    stmt = insert(SecuritySettingsRow).values(id=True, **payload)
+    stmt = stmt.on_conflict_do_update(index_elements=["id"], set_=payload)
+    db_session.execute(stmt)
+    db_session.commit()

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -39,6 +39,7 @@ from onyx.configs.app_configs import APP_PORT
 from onyx.configs.app_configs import AUTH_TYPE
 from onyx.configs.app_configs import CACHE_BACKEND
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
+from onyx.configs.app_configs import ENABLE_PUBLIC_DOCS
 from onyx.configs.app_configs import GOOGLE_LOGIN_BASE_SCOPES
 from onyx.configs.app_configs import GOOGLE_OAUTH_SCOPE_OVERRIDE
 from onyx.configs.app_configs import LOG_ENDPOINT_LATENCY
@@ -457,6 +458,12 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
         servers=[
             {"url": f"{WEB_DOMAIN.rstrip('/')}/api", "description": "Onyx API Server"}
         ],
+        # The interactive docs and schema are opt-in (see ENABLE_PUBLIC_DOCS).
+        # When disabled, these routes are not registered at all (404), so the
+        # API surface is not exposed publicly on a default deployment.
+        openapi_url="/openapi.json" if ENABLE_PUBLIC_DOCS else None,
+        docs_url="/docs" if ENABLE_PUBLIC_DOCS else None,
+        redoc_url="/redoc" if ENABLE_PUBLIC_DOCS else None,
         lifespan=lifespan_override or lifespan,
     )
     if SENTRY_DSN:

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -148,6 +148,7 @@ from onyx.server.query_and_chat.chat_backend import router as chat_router
 from onyx.server.query_and_chat.query_backend import admin_router as admin_query_router
 from onyx.server.query_and_chat.query_backend import basic_router as query_router
 from onyx.server.saml import router as saml_router
+from onyx.server.security.api import admin_router as security_admin_router
 from onyx.server.settings.api import admin_router as settings_admin_router
 from onyx.server.settings.api import basic_router as settings_router
 from onyx.server.token_rate_limits.api import router as token_rate_limit_settings_router
@@ -529,6 +530,7 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
     include_router_with_global_prefix_prepended(application, onyx_api_router)
     include_router_with_global_prefix_prepended(application, settings_router)
     include_router_with_global_prefix_prepended(application, settings_admin_router)
+    include_router_with_global_prefix_prepended(application, security_admin_router)
     include_router_with_global_prefix_prepended(application, llm_admin_router)
     include_router_with_global_prefix_prepended(application, kg_admin_router)
     include_router_with_global_prefix_prepended(application, llm_router)

--- a/backend/onyx/server/auth_check.py
+++ b/backend/onyx/server/auth_check.py
@@ -14,7 +14,11 @@ from onyx.configs.app_configs import APP_API_PREFIX
 from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
 
 PUBLIC_ENDPOINT_SPECS = [
-    # built-in documentation functions
+    # Built-in API docs / schema. These routes only exist when ENABLE_PUBLIC_DOCS
+    # is set (see get_application); they are gated off by default so the API
+    # surface is not exposed publicly. When the flag is off the routes are not
+    # registered, so these specs simply go unmatched. When on, they are served
+    # publicly with no session (the renderers never bypass per-route auth).
     ("/openapi.json", {"GET", "HEAD"}),
     ("/docs", {"GET", "HEAD"}),
     ("/docs/oauth2-redirect", {"GET", "HEAD"}),

--- a/backend/onyx/server/documents/cc_pair.py
+++ b/backend/onyx/server/documents/cc_pair.py
@@ -80,6 +80,7 @@ from onyx.server.documents.models import IndexAttemptStageMetricSnapshot
 from onyx.server.documents.models import IndexAttemptStageMetricsResponse
 from onyx.server.documents.models import PaginatedReturn
 from onyx.server.models import StatusResponse
+from onyx.server.security.store import get_security_settings
 from onyx.utils.logger import setup_logger
 from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
 from shared_configs.contextvars import get_current_tenant_id
@@ -363,6 +364,7 @@ def get_cc_pair_full_info(
 
     return CCPairFullInfo.from_models(
         cc_pair_model=cc_pair,
+        mask_credential_prefix=get_security_settings().mask_credential_prefix,
         number_of_index_attempts=count_index_attempts_for_cc_pair(
             db_session=db_session,
             cc_pair_id=cc_pair_id,

--- a/backend/onyx/server/documents/connector.py
+++ b/backend/onyx/server/documents/connector.py
@@ -133,6 +133,7 @@ from onyx.server.documents.models import RunConnectorRequest
 from onyx.server.documents.models import SourceSummary
 from onyx.server.federated.models import FederatedConnectorStatus
 from onyx.server.models import StatusResponse
+from onyx.server.security.store import get_security_settings
 from onyx.server.utils_vector_db import require_vector_db
 from onyx.utils.logger import setup_logger
 from onyx.utils.telemetry import mt_cloud_telemetry
@@ -1065,6 +1066,7 @@ def get_connector_status(
             cc_pair.credential_id
         )
 
+    mask_credential_prefix = get_security_settings().mask_credential_prefix
     return [
         ConnectorStatus(
             cc_pair_id=cc_pair.id,
@@ -1075,7 +1077,10 @@ def get_connector_status(
                     cc_pair.connector_id, []
                 ),
             ),
-            credential=CredentialSnapshot.from_credential_db_model(cc_pair.credential),
+            credential=CredentialSnapshot.from_credential_db_model(
+                cc_pair.credential,
+                mask_credential_prefix=mask_credential_prefix,
+            ),
             access_type=cc_pair.access_type,
             groups=group_cc_pair_relationships_dict.get(cc_pair.id, []),
         )

--- a/backend/onyx/server/documents/credential.py
+++ b/backend/onyx/server/documents/credential.py
@@ -37,6 +37,7 @@ from onyx.server.documents.private_key_types import FILE_TYPE_TO_FILE_PROCESSOR
 from onyx.server.documents.private_key_types import PrivateKeyFileTypes
 from onyx.server.documents.private_key_types import ProcessPrivateKeyFileProtocol
 from onyx.server.models import StatusResponse
+from onyx.server.security.store import get_security_settings
 from onyx.utils.logger import setup_logger
 from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
 
@@ -64,8 +65,11 @@ def list_credentials_admin(
         user=user,
         get_editable=False,
     )
+    mask_credential_prefix = get_security_settings().mask_credential_prefix
     return [
-        CredentialSnapshot.from_credential_db_model(credential)
+        CredentialSnapshot.from_credential_db_model(
+            credential, mask_credential_prefix=mask_credential_prefix
+        )
         for credential in credentials
     ]
 
@@ -86,8 +90,11 @@ def get_cc_source_full_info(
         get_editable=get_editable,
     )
 
+    mask_credential_prefix = get_security_settings().mask_credential_prefix
     return [
-        CredentialSnapshot.from_credential_db_model(credential)
+        CredentialSnapshot.from_credential_db_model(
+            credential, mask_credential_prefix=mask_credential_prefix
+        )
         for credential in credentials
     ]
 
@@ -155,7 +162,10 @@ def create_credential_from_model(
     credential = create_credential(credential_info, user, db_session)
     return ObjectCreationIdResponse(
         id=credential.id,
-        credential=CredentialSnapshot.from_credential_db_model(credential),
+        credential=CredentialSnapshot.from_credential_db_model(
+            credential,
+            mask_credential_prefix=get_security_settings().mask_credential_prefix,
+        ),
     )
 
 
@@ -219,7 +229,10 @@ def create_credential_with_private_key(
     credential = create_credential(credential_info, user, db_session)
     return ObjectCreationIdResponse(
         id=credential.id,
-        credential=CredentialSnapshot.from_credential_db_model(credential),
+        credential=CredentialSnapshot.from_credential_db_model(
+            credential,
+            mask_credential_prefix=get_security_settings().mask_credential_prefix,
+        ),
     )
 
 
@@ -232,8 +245,11 @@ def list_credentials(
     db_session: Session = Depends(get_session),
 ) -> list[CredentialSnapshot]:
     credentials = fetch_credentials_for_user(db_session=db_session, user=user)
+    mask_credential_prefix = get_security_settings().mask_credential_prefix
     return [
-        CredentialSnapshot.from_credential_db_model(credential)
+        CredentialSnapshot.from_credential_db_model(
+            credential, mask_credential_prefix=mask_credential_prefix
+        )
         for credential in credentials
     ]
 
@@ -256,7 +272,10 @@ def get_credential_by_id(
             detail=f"Credential {credential_id} does not exist or does not belong to user",
         )
 
-    return CredentialSnapshot.from_credential_db_model(credential)
+    return CredentialSnapshot.from_credential_db_model(
+        credential,
+        mask_credential_prefix=get_security_settings().mask_credential_prefix,
+    )
 
 
 @router.put("/admin/credential/{credential_id}")
@@ -280,7 +299,10 @@ def update_credential_data(
             detail=f"Credential {credential_id} does not exist or does not belong to user",
         )
 
-    return CredentialSnapshot.from_credential_db_model(credential)
+    return CredentialSnapshot.from_credential_db_model(
+        credential,
+        mask_credential_prefix=get_security_settings().mask_credential_prefix,
+    )
 
 
 @router.put("/admin/credential/private-key/{credential_id}")
@@ -327,7 +349,10 @@ def update_credential_private_key(
             detail=f"Credential {credential_id} does not exist or does not belong to user",
         )
 
-    return CredentialSnapshot.from_credential_db_model(credential)
+    return CredentialSnapshot.from_credential_db_model(
+        credential,
+        mask_credential_prefix=get_security_settings().mask_credential_prefix,
+    )
 
 
 @router.patch("/credential/{credential_id}")
@@ -346,9 +371,9 @@ def update_credential_from_model(
             detail=f"Credential {credential_id} does not exist or does not belong to user",
         )
 
-    # Get credential_json value - use masking for API responses
+    mask_credential_prefix = get_security_settings().mask_credential_prefix
     credential_json_value = (
-        updated_credential.credential_json.get_value(apply_mask=True)
+        updated_credential.credential_json.get_value(apply_mask=mask_credential_prefix)
         if updated_credential.credential_json
         else {}
     )

--- a/backend/onyx/server/documents/models.py
+++ b/backend/onyx/server/documents/models.py
@@ -12,7 +12,6 @@ from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
 
-from onyx.configs.app_configs import MASK_CREDENTIAL_PREFIX
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.models import InputType
 from onyx.db.enums import AccessType
@@ -148,17 +147,18 @@ class CredentialSnapshot(CredentialBase):
     time_updated: datetime
 
     @classmethod
-    def from_credential_db_model(cls, credential: Credential) -> "CredentialSnapshot":
+    def from_credential_db_model(
+        cls,
+        credential: Credential,
+        *,
+        mask_credential_prefix: bool,
+    ) -> "CredentialSnapshot":
         # Get the credential_json value with appropriate masking
         if credential.credential_json is None:
             credential_json_value: dict[str, Any] = {}
-        elif MASK_CREDENTIAL_PREFIX:
-            credential_json_value = credential.credential_json.get_value(
-                apply_mask=True
-            )
         else:
             credential_json_value = credential.credential_json.get_value(
-                apply_mask=False
+                apply_mask=mask_credential_prefix
             )
 
         return CredentialSnapshot(
@@ -456,6 +456,8 @@ class CCPairFullInfo(BaseModel):
         num_docs_indexed: int,  # not ideal, but this must be computed separately
         is_editable_for_current_user: bool,
         indexing: bool,
+        *,
+        mask_credential_prefix: bool,
         last_successful_index_time: datetime | None = None,
         last_permission_sync_attempt_status: PermissionSyncStatus | None = None,
         permission_syncing: bool = False,
@@ -497,7 +499,8 @@ class CCPairFullInfo(BaseModel):
                 credential_ids=[cc_pair_model.credential_id],
             ),
             credential=CredentialSnapshot.from_credential_db_model(
-                cc_pair_model.credential
+                cc_pair_model.credential,
+                mask_credential_prefix=mask_credential_prefix,
             ),
             number_of_index_attempts=number_of_index_attempts,
             last_index_attempt_status=last_indexing_status,

--- a/backend/onyx/server/features/document_set/models.py
+++ b/backend/onyx/server/features/document_set/models.py
@@ -102,7 +102,12 @@ class DocumentSet(BaseModel):
     )
 
     @classmethod
-    def from_model(cls, document_set_model: DocumentSetDBModel) -> "DocumentSet":
+    def from_model(
+        cls,
+        document_set_model: DocumentSetDBModel,
+        *,
+        mask_credential_prefix: bool,
+    ) -> "DocumentSet":
         return cls(
             id=document_set_model.id,
             name=document_set_model.name,
@@ -116,7 +121,8 @@ class DocumentSet(BaseModel):
                         credential_ids=[cc_pair.credential_id],
                     ),
                     credential=CredentialSnapshot.from_credential_db_model(
-                        cc_pair.credential
+                        cc_pair.credential,
+                        mask_credential_prefix=mask_credential_prefix,
                     ),
                     access_type=cc_pair.access_type,
                 )

--- a/backend/onyx/server/manage/get_state.py
+++ b/backend/onyx/server/manage/get_state.py
@@ -11,7 +11,6 @@ from onyx.auth.users import anonymous_user_enabled
 from onyx.auth.users import user_needs_to_be_verified
 from onyx.configs.app_configs import AUTH_TYPE
 from onyx.configs.app_configs import OAUTH_ENABLED
-from onyx.configs.app_configs import PASSWORD_MIN_LENGTH
 from onyx.configs.constants import AuthType
 from onyx.configs.constants import DEV_VERSION_PATTERN
 from onyx.configs.constants import PUBLIC_API_TAGS
@@ -22,6 +21,7 @@ from onyx.server.manage.models import AuthTypeResponse
 from onyx.server.manage.models import ContainerVersions
 from onyx.server.manage.models import VersionResponse
 from onyx.server.models import StatusResponse
+from onyx.server.security.store import get_security_settings
 
 router = APIRouter()
 
@@ -53,7 +53,7 @@ async def get_auth_type(response: Response) -> AuthTypeResponse:
         auth_type=AUTH_TYPE,
         requires_verification=user_needs_to_be_verified(),
         anonymous_user_enabled=anonymous_user_enabled(),
-        password_min_length=PASSWORD_MIN_LENGTH,
+        password_min_length=get_security_settings().password_min_length,
         has_users=has_users,
         oauth_enabled=OAUTH_ENABLED,
     )

--- a/backend/onyx/server/manage/models.py
+++ b/backend/onyx/server/manage/models.py
@@ -11,7 +11,6 @@ from pydantic import field_validator
 from pydantic import model_validator
 
 from onyx.auth.schemas import UserRole
-from onyx.configs.app_configs import TRACK_EXTERNAL_IDP_EXPIRY
 from onyx.configs.constants import AuthType
 from onyx.context.search.models import SavedSearchSettings
 from onyx.db.enums import DefaultAppMode
@@ -142,6 +141,8 @@ class UserInfo(BaseModel):
     def from_model(
         cls,
         user: User,
+        *,
+        track_external_idp_expiry: bool,
         current_token_created_at: datetime | None = None,
         expiry_length: int | None = None,
         is_cloud_superuser: bool = False,
@@ -180,11 +181,11 @@ class UserInfo(BaseModel):
                 )
             ),
             team_name=team_name,
-            # set to None if TRACK_EXTERNAL_IDP_EXPIRY is False so that we avoid cases
+            # set to None if track_external_idp_expiry is False so that we avoid cases
             # where they previously had this set + used OIDC, and now they switched to
             # basic auth are now constantly getting redirected back to the login page
             # since their "oidc_expiry is old"
-            oidc_expiry=user.oidc_expiry if TRACK_EXTERNAL_IDP_EXPIRY else None,
+            oidc_expiry=user.oidc_expiry if track_external_idp_expiry else None,
             current_token_created_at=current_token_created_at,
             current_token_expiry_length=expiry_length,
             is_cloud_superuser=is_cloud_superuser,

--- a/backend/onyx/server/manage/users.py
+++ b/backend/onyx/server/manage/users.py
@@ -45,8 +45,6 @@ from onyx.configs.app_configs import NUM_FREE_TRIAL_USER_INVITES
 from onyx.configs.app_configs import REDIS_AUTH_KEY_PREFIX
 from onyx.configs.app_configs import SESSION_EXPIRE_TIME_SECONDS
 from onyx.configs.app_configs import USER_AUTH_SECRET
-from onyx.configs.app_configs import USER_DIRECTORY_ADMIN_ONLY
-from onyx.configs.app_configs import VALID_EMAIL_DOMAINS
 from onyx.configs.constants import FASTAPI_USERS_AUTH_COOKIE_NAME
 from onyx.configs.constants import PUBLIC_API_TAGS
 from onyx.db.api_key import is_api_key_email_address
@@ -118,6 +116,7 @@ from onyx.server.models import FullUserSnapshot
 from onyx.server.models import InvitedUserSnapshot
 from onyx.server.models import MinimalUserSnapshot
 from onyx.server.models import UserGroupInfo
+from onyx.server.security.store import get_security_settings
 from onyx.server.usage_limits import is_tenant_on_trial_fn
 from onyx.server.utils import BasicAuthenticationError
 from onyx.utils.csv_utils import sanitize_csv_cell
@@ -740,7 +739,7 @@ def activate_user_api(
 def get_valid_domains(
     _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
 ) -> list[str]:
-    return VALID_EMAIL_DOMAINS
+    return list(get_security_settings().valid_email_domains)
 
 
 """Endpoints for all"""
@@ -753,7 +752,7 @@ def list_all_users_basic_info(
     db_session: Session = Depends(get_session),
 ) -> list[MinimalUserSnapshot]:
     if (
-        USER_DIRECTORY_ADMIN_ONLY
+        get_security_settings().user_directory_admin_only
         and Permission.READ_USERS not in get_effective_permissions(user)
     ):
         raise OnyxError(
@@ -934,6 +933,7 @@ def verify_user_logged_in(
 
     user_info = UserInfo.from_model(
         user,
+        track_external_idp_expiry=get_security_settings().track_external_idp_expiry,
         current_token_created_at=token_created_at,
         expiry_length=SESSION_EXPIRE_TIME_SECONDS,
         is_cloud_superuser=user.email in super_users_list,
@@ -1120,7 +1120,10 @@ def update_user_assistant_visibility_api(
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> None:
-    user_preferences = UserInfo.from_model(user).preferences
+    user_preferences = UserInfo.from_model(
+        user,
+        track_external_idp_expiry=get_security_settings().track_external_idp_expiry,
+    ).preferences
     updated_preferences = update_assistant_visibility(
         user_preferences, assistant_id, show
     )

--- a/backend/onyx/server/security/api.py
+++ b/backend/onyx/server/security/api.py
@@ -1,0 +1,79 @@
+import json
+from typing import Any
+
+from fastapi import APIRouter
+from fastapi import Depends
+from fastapi import Request
+from fastapi.concurrency import run_in_threadpool
+from pydantic import ValidationError
+
+from onyx.auth.permissions import require_permission
+from onyx.db.enums import Permission
+from onyx.db.models import User
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.security.models import OPERATOR_LOCKED_FIELDS
+from onyx.server.security.models import SecuritySettings
+from onyx.server.security.models import SecuritySettingsOverrides
+from onyx.server.security.store import apply_patch
+from onyx.server.security.store import get_security_settings
+from onyx.utils.logger import setup_logger
+from shared_configs.configs import MULTI_TENANT
+
+logger = setup_logger()
+
+admin_router = APIRouter(prefix="/admin/security")
+
+
+def _parse_put_body(raw: bytes) -> tuple[SecuritySettingsOverrides, set[str]]:
+    """Parse the PUT body. Returns (parsed model, present_keys).
+
+    ``present_keys`` is the set of keys the caller actually included — needed
+    downstream to distinguish absent (keep existing) from explicit-null (clear
+    → env fallback), which Pydantic collapses to ``None`` on the model.
+    """
+    try:
+        payload_dict = json.loads(raw) if raw else {}
+    except json.JSONDecodeError as e:
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, f"Malformed JSON: {e}")
+
+    if not isinstance(payload_dict, dict):
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, "Body must be a JSON object")
+
+    try:
+        overrides = SecuritySettingsOverrides.model_validate(payload_dict)
+    except ValidationError as e:
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, str(e))
+
+    payload_dict_typed: dict[str, Any] = payload_dict
+    return overrides, set(payload_dict_typed.keys())
+
+
+@admin_router.get("")
+def get_security_settings_endpoint(
+    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+) -> SecuritySettings:
+    return get_security_settings()
+
+
+@admin_router.put("")
+async def put_security_settings_endpoint(
+    request: Request,
+    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+) -> SecuritySettings:
+    raw = await request.body()
+    overrides, present_keys = _parse_put_body(raw)
+
+    # Primary boundary for operator-locked fields. The storage layer also
+    # strips them; this gives admins a clear 403 instead of a silent no-op.
+    if MULTI_TENANT:
+        locked_in_payload = present_keys & OPERATOR_LOCKED_FIELDS
+        if locked_in_payload:
+            raise OnyxError(
+                OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+                "These fields are operator-controlled in multi-tenant deployments: "
+                + ", ".join(sorted(locked_in_payload)),
+            )
+
+    # Sync DB + Redis IO — offload so the event loop isn't blocked.
+    return await run_in_threadpool(apply_patch, overrides, present_keys)

--- a/backend/onyx/server/security/models.py
+++ b/backend/onyx/server/security/models.py
@@ -1,0 +1,131 @@
+from pydantic import BaseModel
+from pydantic import ConfigDict
+from pydantic import Field
+from pydantic import field_validator
+from pydantic import model_validator
+from typing_extensions import Self
+
+PASSWORD_LENGTH_CAP = 256
+# 4 = one char per required character class; lower would lock out signups
+# once all four require_* flags are on.
+PASSWORD_MAX_LENGTH_FLOOR = 4
+
+
+_OPERATOR_LOCKED_MARKER = "operator_locked"
+
+
+def _operator_locked() -> dict[str, bool]:
+    """Field marker: operator (env) only — tenant admins can't override."""
+    return {_OPERATOR_LOCKED_MARKER: True}
+
+
+def _tenant_editable() -> dict[str, bool]:
+    """Field marker: tenant admins may override at runtime."""
+    return {_OPERATOR_LOCKED_MARKER: False}
+
+
+class SecuritySettingsOverrides(BaseModel):
+    """Wire/storage shape. Absent / None on any field means "use env default"."""
+
+    # hide_input_in_errors strips offending input_value from ValidationError
+    # messages — they surface back through the PUT envelope and would otherwise
+    # leak any sensitive value an admin sends (any future secret-shaped field).
+    model_config = ConfigDict(extra="forbid", hide_input_in_errors=True)
+
+    user_directory_admin_only: bool | None = Field(
+        default=None, json_schema_extra=_tenant_editable()
+    )
+    track_external_idp_expiry: bool | None = Field(
+        default=None, json_schema_extra=_tenant_editable()
+    )
+    mask_credential_prefix: bool | None = Field(
+        default=None, json_schema_extra=_operator_locked()
+    )
+    valid_email_domains: list[str] | None = Field(
+        default=None, json_schema_extra=_operator_locked()
+    )
+    password_min_length: int | None = Field(
+        default=None, json_schema_extra=_operator_locked()
+    )
+    password_max_length: int | None = Field(
+        default=None, json_schema_extra=_operator_locked()
+    )
+    password_require_uppercase: bool | None = Field(
+        default=None, json_schema_extra=_operator_locked()
+    )
+    password_require_lowercase: bool | None = Field(
+        default=None, json_schema_extra=_operator_locked()
+    )
+    password_require_digit: bool | None = Field(
+        default=None, json_schema_extra=_operator_locked()
+    )
+    password_require_special_char: bool | None = Field(
+        default=None, json_schema_extra=_operator_locked()
+    )
+
+    @field_validator("valid_email_domains")
+    @classmethod
+    def _normalize_domains(cls, v: list[str] | None) -> list[str] | None:
+        if v is None:
+            return None
+        # Mirror env-parse for VALID_EMAIL_DOMAINS exactly. NO dedup — env
+        # parser doesn't dedupe and behavior must match byte-for-byte.
+        return [d.strip().lower() for d in v if d.strip()]
+
+
+def _derive_operator_locked_fields() -> frozenset[str]:
+    """Names of fields whose ``operator_locked`` marker is True.
+
+    Raises at module import if any field is missing the marker — forces an
+    explicit yes/no at declaration rather than a silent tenant-editable default.
+    """
+    locked: set[str] = set()
+    missing: list[str] = []
+    for name, info in SecuritySettingsOverrides.model_fields.items():
+        extras = info.json_schema_extra
+        if not isinstance(extras, dict) or _OPERATOR_LOCKED_MARKER not in extras:
+            missing.append(name)
+            continue
+        if extras[_OPERATOR_LOCKED_MARKER]:
+            locked.add(name)
+    if missing:
+        raise RuntimeError(
+            "SecuritySettingsOverrides fields missing operator_locked marker: "
+            f"{sorted(missing)}. Use Field(..., json_schema_extra=_operator_locked()) "
+            f"or _tenant_editable() to declare each field's status."
+        )
+    return frozenset(locked)
+
+
+OPERATOR_LOCKED_FIELDS: frozenset[str] = _derive_operator_locked_fields()
+
+
+class SecuritySettings(BaseModel):
+    """Effective, env-merged, immutable security settings."""
+
+    model_config = ConfigDict(frozen=True)
+
+    user_directory_admin_only: bool
+    track_external_idp_expiry: bool
+    mask_credential_prefix: bool
+    valid_email_domains: tuple[str, ...]
+    password_min_length: int
+    password_max_length: int
+    password_require_uppercase: bool
+    password_require_lowercase: bool
+    password_require_digit: bool
+    password_require_special_char: bool
+
+    @model_validator(mode="after")
+    def _check_password_length_invariants(self) -> Self:
+        if self.password_min_length < 0:
+            raise ValueError("password_min_length must be >= 0")
+        if self.password_max_length < PASSWORD_MAX_LENGTH_FLOOR:
+            raise ValueError(
+                f"password_max_length must be >= {PASSWORD_MAX_LENGTH_FLOOR}"
+            )
+        if self.password_max_length > PASSWORD_LENGTH_CAP:
+            raise ValueError(f"password_max_length must be <= {PASSWORD_LENGTH_CAP}")
+        if self.password_min_length > self.password_max_length:
+            raise ValueError("password_min_length must be <= password_max_length")
+        return self

--- a/backend/onyx/server/security/store.py
+++ b/backend/onyx/server/security/store.py
@@ -1,0 +1,206 @@
+import threading
+import time
+from collections.abc import Callable
+from typing import Any
+
+from cachetools import TTLCache
+from pydantic import ValidationError
+
+from onyx.cache.factory import get_cache_backend
+from onyx.configs import app_configs as _cfg
+from onyx.configs.constants import OnyxRedisLocks
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.security_settings import load_overrides as _db_load_overrides
+from onyx.db.security_settings import upsert_overrides as _db_upsert_overrides
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.security.models import OPERATOR_LOCKED_FIELDS
+from onyx.server.security.models import SecuritySettings
+from onyx.server.security.models import SecuritySettingsOverrides
+from onyx.utils.logger import setup_logger
+from shared_configs.configs import MULTI_TENANT
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
+from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
+
+logger = setup_logger()
+
+
+# Bounds cross-process staleness after an admin save — no pub/sub today, so
+# other api_server processes converge via TTL expiry.
+_CACHE_TTL_SECONDS = 10.0
+
+
+_CACHE_LOCK = threading.RLock()
+_CACHE: TTLCache[str, SecuritySettings] = TTLCache(
+    maxsize=10_000, ttl=_CACHE_TTL_SECONDS, timer=time.monotonic
+)
+
+
+# Lock lifetime; held during a single read+merge+write.
+_WRITE_LOCK_LEASE_SECONDS = 30.0
+# How long a competing writer waits before giving up with CONFLICT.
+_WRITE_LOCK_WAIT_SECONDS = 10.0
+
+
+def _install_cache_for_test(
+    *, ttl: float, timer: Callable[[], float], maxsize: int = 10_000
+) -> None:
+    """Test seam for fake-clock TTL testing; production never calls this."""
+    global _CACHE
+    with _CACHE_LOCK:
+        _CACHE = TTLCache(maxsize=maxsize, ttl=ttl, timer=timer)
+
+
+def _build_env_defaults() -> SecuritySettings:
+    """Builds from env constants at call time so tests can monkeypatch them."""
+    return SecuritySettings(
+        user_directory_admin_only=_cfg.USER_DIRECTORY_ADMIN_ONLY,
+        track_external_idp_expiry=_cfg.TRACK_EXTERNAL_IDP_EXPIRY,
+        mask_credential_prefix=_cfg.MASK_CREDENTIAL_PREFIX,
+        valid_email_domains=tuple(_cfg.VALID_EMAIL_DOMAINS),
+        password_min_length=_cfg.PASSWORD_MIN_LENGTH,
+        password_max_length=_cfg.PASSWORD_MAX_LENGTH,
+        password_require_uppercase=_cfg.PASSWORD_REQUIRE_UPPERCASE,
+        password_require_lowercase=_cfg.PASSWORD_REQUIRE_LOWERCASE,
+        password_require_digit=_cfg.PASSWORD_REQUIRE_DIGIT,
+        password_require_special_char=_cfg.PASSWORD_REQUIRE_SPECIAL_CHAR,
+    )
+
+
+def merge_with_env(overrides: SecuritySettingsOverrides) -> SecuritySettings:
+    """Apply per-field env fallbacks. Explicit ``is None`` so 0/False overrides
+    aren't dropped by a truthy fallback. In multi-tenant, operator-locked
+    overrides are ignored (env wins) — belt-and-braces alongside the API
+    rejection.
+    """
+    env = _build_env_defaults()
+    locked = OPERATOR_LOCKED_FIELDS if MULTI_TENANT else frozenset()
+
+    merged: dict[str, Any] = {}
+    for name in SecuritySettings.model_fields:
+        override_value = getattr(overrides, name, None)
+        if name in locked or override_value is None:
+            merged[name] = getattr(env, name)
+        else:
+            merged[name] = override_value
+    # SecuritySettings types valid_email_domains as tuple; overrides as list.
+    if isinstance(merged["valid_email_domains"], list):
+        merged["valid_email_domains"] = tuple(merged["valid_email_domains"])
+    return SecuritySettings(**merged)
+
+
+def _load_raw_overrides_unlocked() -> SecuritySettingsOverrides:
+    """Uncached DB read. Read-consistency comes from the write path's lock;
+    cache-miss readers may see a stale value bounded by the TTL.
+    """
+    with get_session_with_current_tenant() as db_session:
+        return _db_load_overrides(db_session)
+
+
+def _store_overrides_unlocked(overrides: SecuritySettingsOverrides) -> None:
+    """DB upsert + local cache invalidate. ``apply_patch`` is the only caller,
+    and only while holding the Redis write lock.
+
+    In multi-tenant, operator-locked fields are forced to ``None`` before
+    write — defense-in-depth if a future internal caller bypasses the API check.
+    """
+    if MULTI_TENANT:
+        overrides = overrides.model_copy(
+            update={field: None for field in OPERATOR_LOCKED_FIELDS}
+        )
+    with get_session_with_current_tenant() as db_session:
+        _db_upsert_overrides(db_session, overrides)
+    invalidate_security_cache(_current_tenant_id_or_default())
+
+
+def _apply_present_keys(
+    existing: SecuritySettingsOverrides,
+    patch: SecuritySettingsOverrides,
+    present_keys: set[str],
+) -> SecuritySettingsOverrides:
+    """PATCH-semantic merge. Caller must pass ``present_keys`` so we can tell
+    absent (keep existing) from explicit-null (clear → env fallback) — Pydantic
+    collapses both to ``None`` on the parsed model.
+    """
+    merged: dict[str, Any] = existing.model_dump()
+    for name in present_keys:
+        merged[name] = getattr(patch, name, None)
+    return SecuritySettingsOverrides.model_validate(merged)
+
+
+def apply_patch(
+    patch: SecuritySettingsOverrides, present_keys: set[str]
+) -> SecuritySettings:
+    """Public write entry point. Acquires the Redis lock for the full
+    read-modify-write so concurrent writers can't clobber each other.
+
+    Raises ``OnyxError(CONFLICT)`` if a competing writer holds the lock past
+    the wait window, and ``OnyxError(INVALID_INPUT)`` if the merged effective
+    state would violate a model invariant.
+    """
+    cache = get_cache_backend()
+    lock = cache.lock(
+        OnyxRedisLocks.SECURITY_SETTINGS, timeout=_WRITE_LOCK_LEASE_SECONDS
+    )
+    if not lock.acquire(blocking=True, blocking_timeout=_WRITE_LOCK_WAIT_SECONDS):
+        raise OnyxError(
+            OnyxErrorCode.CONFLICT,
+            "Another security settings save is in progress, please retry.",
+        )
+    try:
+        existing = _load_raw_overrides_unlocked()
+        merged = _apply_present_keys(existing, patch, present_keys)
+        try:
+            # SecuritySettings invariants run via model_validator on construction.
+            effective = merge_with_env(merged)
+        except ValidationError as e:
+            raise OnyxError(OnyxErrorCode.INVALID_INPUT, str(e))
+        _store_overrides_unlocked(merged)
+        return effective
+    finally:
+        # Lease may have expired during the write; unconditional release would
+        # raise LockNotOwnedError and mask a successful save as a 500.
+        if lock.owned():
+            lock.release()
+
+
+def _current_tenant_id_or_default() -> str:
+    """Tenant id from the contextvar, or ``POSTGRES_DEFAULT_SCHEMA`` if unset.
+
+    Inspects the contextvar directly; ``get_current_tenant_id()`` raises a
+    stack-traced ``RuntimeError`` in multi-tenant when unset, which is too
+    expensive for hot pre-tenant paths like ``/auth/type``.
+    """
+    tid = CURRENT_TENANT_ID_CONTEXTVAR.get()
+    return tid if tid is not None else POSTGRES_DEFAULT_SCHEMA
+
+
+def invalidate_security_cache(tenant_id: str) -> None:
+    with _CACHE_LOCK:
+        _CACHE.pop(tenant_id, None)
+
+
+def get_security_settings() -> SecuritySettings:
+    """Effective, env-merged, immutable settings for the current tenant.
+
+    Pre-tenant safe: returns env defaults (uncached) when the contextvar is
+    unset in multi-tenant. DB errors fall back to env defaults so a Postgres
+    outage never bricks the auth path. Returned ``SecuritySettings`` is frozen.
+    """
+    tenant_id = CURRENT_TENANT_ID_CONTEXTVAR.get()
+    if tenant_id is None:
+        # Single-tenant defaults the contextvar at module import; this branch
+        # fires only in multi-tenant before tenant resolution.
+        return _build_env_defaults()
+
+    with _CACHE_LOCK:
+        cached = _CACHE.get(tenant_id)
+        if cached is not None:
+            return cached
+        try:
+            effective = merge_with_env(_load_raw_overrides_unlocked())
+        except Exception as e:
+            logger.error("Failed to load security settings, using env defaults: %s", e)
+            return _build_env_defaults()
+        _CACHE[tenant_id] = effective
+        return effective

--- a/backend/tests/external_dependency_unit/server/security/test_security_settings_put.py
+++ b/backend/tests/external_dependency_unit/server/security/test_security_settings_put.py
@@ -1,0 +1,309 @@
+"""PUT /admin/security tests.
+
+Invokes the handler directly with a Request shim — exercises merge and
+lock-serialization semantics against the real DB + Redis lock without HTTP
+framing.
+"""
+
+import asyncio
+import json
+import threading
+from collections.abc import Generator
+from typing import Any
+from typing import cast
+
+import pytest
+from fastapi import Request
+from sqlalchemy import delete
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.models import SecuritySettings as SecuritySettingsRow
+from onyx.db.models import User
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.security import api as security_api
+from onyx.server.security import store as security_store
+from onyx.server.security.api import put_security_settings_endpoint
+from onyx.server.security.models import SecuritySettingsOverrides
+from onyx.server.security.store import _build_env_defaults
+from onyx.server.security.store import _install_cache_for_test
+from onyx.server.security.store import invalidate_security_cache
+from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
+from tests.external_dependency_unit.constants import TEST_TENANT_ID
+
+
+class _FakeRequest:
+    """Stand-in for fastapi.Request — the handler only awaits ``.body()``."""
+
+    def __init__(self, body_bytes: bytes) -> None:
+        self._body = body_bytes
+
+    async def body(self) -> bytes:
+        return self._body
+
+
+# The `_: User` Depends param is unread; direct invocation bypasses Depends.
+_PLACEHOLDER_USER: User = cast(User, None)
+
+
+def _put(body: dict[str, Any] | bytes) -> Any:
+    raw = body if isinstance(body, bytes) else json.dumps(body).encode("utf-8")
+    request = cast(Request, _FakeRequest(raw))
+    return asyncio.run(put_security_settings_endpoint(request, _=_PLACEHOLDER_USER))
+
+
+def _load_row_as_dict() -> dict[str, Any] | None:
+    """Singleton row as a dict of only explicitly-set overrides, or None."""
+    with get_session_with_current_tenant() as session:
+        row = session.execute(select(SecuritySettingsRow)).scalar_one_or_none()
+    if row is None:
+        return None
+    overrides = SecuritySettingsOverrides.model_validate(row, from_attributes=True)
+    return overrides.model_dump(exclude_none=True)
+
+
+def _delete_security_settings_row() -> None:
+    with get_session_with_current_tenant() as session:
+        session.execute(delete(SecuritySettingsRow))
+        session.commit()
+
+
+@pytest.fixture(autouse=True)
+def _clean_db_and_cache(
+    db_session: Session,  # noqa: ARG001 — requested for side-effect (SQL engine init)
+    tenant_context: None,  # noqa: ARG001 — requested for side-effect (tenant contextvar)
+) -> Generator[None, None, None]:
+    _delete_security_settings_row()
+    invalidate_security_cache(TEST_TENANT_ID)
+    import time as _time
+
+    _install_cache_for_test(ttl=10.0, timer=_time.monotonic)
+    yield
+    _delete_security_settings_row()
+    invalidate_security_cache(TEST_TENANT_ID)
+
+
+# -----------------------------------------------------------------------------
+# Single-tenant PUT semantics
+# -----------------------------------------------------------------------------
+
+
+def test_put_writes_only_explicit_fields() -> None:
+    """Absent fields must not appear as non-null columns in the row."""
+    _put({"user_directory_admin_only": True})
+
+    assert _load_row_as_dict() == {"user_directory_admin_only": True}
+
+
+def test_put_explicit_null_clears_previously_set_field() -> None:
+    """Explicit null clears the column to NULL (loader falls back to env)."""
+    _put({"user_directory_admin_only": True})
+    assert _load_row_as_dict() == {"user_directory_admin_only": True}
+
+    _put({"user_directory_admin_only": None})
+    # Row exists but every column is NULL → empty dict after exclude_none.
+    assert _load_row_as_dict() == {}
+
+
+def test_put_cross_field_validation_against_effective_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A payload that's individually valid but violates the merged invariant
+    (min > max) must be rejected with INVALID_INPUT."""
+    from onyx.configs import app_configs
+
+    # Force env max=8 so payload min=10 violates after merge.
+    monkeypatch.setattr(app_configs, "PASSWORD_MAX_LENGTH", 8, raising=False)
+
+    with pytest.raises(OnyxError) as exc_info:
+        _put({"password_min_length": 10})
+    assert exc_info.value.error_code is OnyxErrorCode.INVALID_INPUT
+
+    assert _load_row_as_dict() is None
+
+
+def test_put_accepts_password_min_length_zero() -> None:
+    """``password_min_length=0`` is valid; the merge must not coerce it
+    away via a truthy fallback."""
+    result = _put({"password_min_length": 0})
+    assert result.password_min_length == 0
+
+    assert _load_row_as_dict() == {"password_min_length": 0}
+
+
+def test_put_extra_field_rejected_as_invalid_input() -> None:
+    with pytest.raises(OnyxError) as exc_info:
+        _put({"this_field_does_not_exist": True})
+    assert exc_info.value.error_code is OnyxErrorCode.INVALID_INPUT
+
+
+def test_put_malformed_json_rejected_as_invalid_input() -> None:
+    with pytest.raises(OnyxError) as exc_info:
+        _put(b"{not valid json")
+    assert exc_info.value.error_code is OnyxErrorCode.INVALID_INPUT
+
+
+def test_put_non_object_body_rejected_as_invalid_input() -> None:
+    with pytest.raises(OnyxError) as exc_info:
+        _put(b"[1, 2, 3]")
+    assert exc_info.value.error_code is OnyxErrorCode.INVALID_INPUT
+
+
+def test_put_single_tenant_allows_operator_locked_fields() -> None:
+    """In single-tenant deployments, no fields are operator-locked."""
+    result = _put({"password_min_length": 12, "mask_credential_prefix": False})
+    assert result.password_min_length == 12
+    assert result.mask_credential_prefix is False
+
+
+def test_put_rejects_max_length_below_floor() -> None:
+    """``password_max_length`` is floored at PASSWORD_MAX_LENGTH_FLOOR."""
+    with pytest.raises(OnyxError) as exc_info:
+        _put({"password_max_length": 3})
+    assert exc_info.value.error_code is OnyxErrorCode.INVALID_INPUT
+    assert _load_row_as_dict() is None
+
+
+# -----------------------------------------------------------------------------
+# Multi-tenant operator-locked rejection
+# -----------------------------------------------------------------------------
+
+
+def test_put_multi_tenant_rejects_operator_locked_field(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An operator-locked key in payload returns INSUFFICIENT_PERMISSIONS."""
+    monkeypatch.setattr(security_api, "MULTI_TENANT", True)
+    monkeypatch.setattr(security_store, "MULTI_TENANT", True)
+
+    with pytest.raises(OnyxError) as exc_info:
+        _put({"password_min_length": 12})
+    assert exc_info.value.error_code is OnyxErrorCode.INSUFFICIENT_PERMISSIONS
+
+    assert _load_row_as_dict() is None
+
+
+def test_put_multi_tenant_accepts_tenant_editable_field(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Payload with only tenant-editable keys succeeds in multi-tenant mode."""
+    monkeypatch.setattr(security_api, "MULTI_TENANT", True)
+    monkeypatch.setattr(security_store, "MULTI_TENANT", True)
+
+    result = _put({"user_directory_admin_only": True})
+    assert result.user_directory_admin_only is True
+
+    assert _load_row_as_dict() == {"user_directory_admin_only": True}
+
+
+# -----------------------------------------------------------------------------
+# Concurrency: lock serializes writers, both disjoint writes land
+# -----------------------------------------------------------------------------
+
+
+def _put_in_thread(body: dict[str, Any], errors: list[BaseException]) -> None:
+    # Threads don't inherit contextvars; re-establish before the PUT.
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set(TEST_TENANT_ID)
+    try:
+        _put(body)
+    except BaseException as e:  # noqa: BLE001
+        errors.append(e)
+    finally:
+        CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+
+
+def test_concurrent_puts_disjoint_fields_both_land() -> None:
+    """Two concurrent writers updating different keys must both persist."""
+    errors: list[BaseException] = []
+    t1 = threading.Thread(
+        target=_put_in_thread,
+        args=({"user_directory_admin_only": True}, errors),
+    )
+    t2 = threading.Thread(
+        target=_put_in_thread,
+        args=({"track_external_idp_expiry": True}, errors),
+    )
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    assert errors == []
+    assert _load_row_as_dict() == {
+        "user_directory_admin_only": True,
+        "track_external_idp_expiry": True,
+    }
+
+
+def test_concurrent_puts_under_invariant_pressure_never_corrupt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two writers racing on fields whose combination could break the
+    min<=max invariant: the lock serializes them and the post-merge
+    validator rejects the loser. Persisted state is never invalid.
+    """
+    from onyx.configs import app_configs
+
+    # Pin env so natural defaults don't accidentally satisfy a bad ordering.
+    monkeypatch.setattr(app_configs, "PASSWORD_MIN_LENGTH", 8, raising=False)
+    monkeypatch.setattr(app_configs, "PASSWORD_MAX_LENGTH", 64, raising=False)
+
+    errors: list[BaseException] = []
+    t_min = threading.Thread(
+        target=_put_in_thread,
+        args=({"password_min_length": 20}, errors),
+    )
+    t_max = threading.Thread(
+        target=_put_in_thread,
+        args=({"password_max_length": 10}, errors),
+    )
+    t_min.start()
+    t_max.start()
+    t_min.join()
+    t_max.join()
+
+    # Exactly one writer wins; the other sees the merged state and is rejected.
+    rejections = [
+        e
+        for e in errors
+        if isinstance(e, OnyxError) and e.error_code is OnyxErrorCode.INVALID_INPUT
+    ]
+    assert len(rejections) == 1
+    assert len(errors) == 1
+
+    stored = _load_row_as_dict() or {}
+    env = _build_env_defaults()
+    effective_min = stored.get("password_min_length", env.password_min_length)
+    effective_max = stored.get("password_max_length", env.password_max_length)
+    assert effective_min <= effective_max
+
+
+# -----------------------------------------------------------------------------
+# Storage-layer belt-and-braces (defense-in-depth)
+# -----------------------------------------------------------------------------
+
+
+def test_apply_patch_strips_operator_locked_in_multi_tenant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Belt-and-braces: the write itself strips operator-locked fields in
+    multi-tenant, even if a future caller bypasses the API-layer rejection.
+    """
+    monkeypatch.setattr(security_store, "MULTI_TENANT", True)
+
+    security_store.apply_patch(
+        SecuritySettingsOverrides(
+            user_directory_admin_only=True,
+            password_min_length=12,
+            mask_credential_prefix=False,
+        ),
+        present_keys={
+            "user_directory_admin_only",
+            "password_min_length",
+            "mask_credential_prefix",
+        },
+    )
+
+    assert _load_row_as_dict() == {"user_directory_admin_only": True}

--- a/backend/tests/external_dependency_unit/server/security/test_security_settings_store.py
+++ b/backend/tests/external_dependency_unit/server/security/test_security_settings_store.py
@@ -1,0 +1,189 @@
+"""Loader tests against the real Postgres-backed singleton row."""
+
+import threading
+from collections.abc import Generator
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+from sqlalchemy import delete
+from sqlalchemy.orm import Session
+
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.models import SecuritySettings as SecuritySettingsRow
+from onyx.server.security import store as security_store
+from onyx.server.security.models import SecuritySettingsOverrides
+from onyx.server.security.store import _build_env_defaults
+from onyx.server.security.store import _install_cache_for_test
+from onyx.server.security.store import apply_patch
+from onyx.server.security.store import get_security_settings
+from onyx.server.security.store import invalidate_security_cache
+from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
+from tests.external_dependency_unit.constants import TEST_TENANT_ID
+
+
+def _delete_security_settings_row() -> None:
+    with get_session_with_current_tenant() as session:
+        session.execute(delete(SecuritySettingsRow))
+        session.commit()
+
+
+@pytest.fixture(autouse=True)
+def _clean_db_and_cache(
+    db_session: Session,  # noqa: ARG001 — requested for side-effect (SQL engine init)
+    tenant_context: None,  # noqa: ARG001 — requested for side-effect (tenant contextvar)
+) -> Generator[None, None, None]:
+    _delete_security_settings_row()
+    invalidate_security_cache(TEST_TENANT_ID)
+    # Reset to a real-clock cache so fake-clock tests don't leak state across.
+    import time as _time
+
+    _install_cache_for_test(ttl=10.0, timer=_time.monotonic)
+    yield
+    _delete_security_settings_row()
+    invalidate_security_cache(TEST_TENANT_ID)
+
+
+def test_empty_db_returns_env_defaults() -> None:
+    """When no row exists, every field must match the env-derived default."""
+    effective = get_security_settings()
+    env = _build_env_defaults()
+    assert effective == env
+
+
+def test_partial_overrides_only_overrides_specified_fields() -> None:
+    """Setting one field via the store must not perturb the others."""
+    apply_patch(
+        SecuritySettingsOverrides(user_directory_admin_only=True),
+        present_keys={"user_directory_admin_only"},
+    )
+    effective = get_security_settings()
+    env = _build_env_defaults()
+
+    assert effective.user_directory_admin_only is True
+    # All other fields fall back to env.
+    assert effective.track_external_idp_expiry == env.track_external_idp_expiry
+    assert effective.mask_credential_prefix == env.mask_credential_prefix
+    assert effective.valid_email_domains == env.valid_email_domains
+    assert effective.password_min_length == env.password_min_length
+    assert effective.password_max_length == env.password_max_length
+    assert effective.password_require_uppercase == env.password_require_uppercase
+
+
+def test_cache_hits_avoid_db_reads() -> None:
+    """Repeated loader calls within the TTL must hit the DB once."""
+    get_security_settings()  # warm cache
+
+    with patch.object(
+        security_store,
+        "_load_raw_overrides_unlocked",
+        wraps=security_store._load_raw_overrides_unlocked,
+    ) as spy:
+        for _ in range(100):
+            get_security_settings()
+        assert spy.call_count == 0
+
+
+def test_apply_patch_invalidates_cache() -> None:
+    """After a write, the next load must re-read the DB."""
+    get_security_settings()  # warm cache
+
+    with patch.object(
+        security_store,
+        "_load_raw_overrides_unlocked",
+        wraps=security_store._load_raw_overrides_unlocked,
+    ) as spy:
+        apply_patch(
+            SecuritySettingsOverrides(user_directory_admin_only=True),
+            present_keys={"user_directory_admin_only"},
+        )
+        # apply_patch reads existing before merging; the post-invalidate
+        # read is the only additional call we care about counting.
+        spy_after_write = spy.call_count
+        get_security_settings()
+        assert spy.call_count == spy_after_write + 1
+
+
+def test_cache_ttl_expiry_triggers_reload() -> None:
+    """Advancing past the TTL must force a DB re-read."""
+    fake_now = [0.0]
+
+    def fake_timer() -> float:
+        return fake_now[0]
+
+    _install_cache_for_test(ttl=5.0, timer=fake_timer)
+
+    get_security_settings()  # warm
+    with patch.object(
+        security_store,
+        "_load_raw_overrides_unlocked",
+        wraps=security_store._load_raw_overrides_unlocked,
+    ) as spy:
+        fake_now[0] = 4.0  # within TTL
+        get_security_settings()
+        assert spy.call_count == 0
+        fake_now[0] = 6.0  # past TTL
+        get_security_settings()
+        assert spy.call_count == 1
+
+
+def test_thread_safe_concurrent_reads() -> None:
+    """Many threads hammering the loader must not race or raise."""
+    apply_patch(
+        SecuritySettingsOverrides(user_directory_admin_only=True),
+        present_keys={"user_directory_admin_only"},
+    )
+    results: list[Any] = []
+    errors: list[BaseException] = []
+
+    def worker() -> None:
+        try:
+            for _ in range(50):
+                results.append(get_security_settings().user_directory_admin_only)
+        except BaseException as e:  # noqa: BLE001
+            errors.append(e)
+
+    threads = [threading.Thread(target=worker) for _ in range(20)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert errors == []
+    assert all(v is True for v in results)
+
+
+def test_effective_settings_are_frozen() -> None:
+    """Cached SecuritySettings instances must be immutable from caller code."""
+    settings = get_security_settings()
+    with pytest.raises(ValidationError):
+        settings.user_directory_admin_only = True  # type: ignore[misc]
+
+
+def test_pre_tenant_returns_env_defaults_without_raising(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Multi-tenant + contextvar unset must short-circuit to env defaults
+    without touching the DB."""
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set(None)
+    try:
+        monkeypatch.setattr(security_store, "MULTI_TENANT", True)
+
+        with patch.object(security_store, "_load_raw_overrides_unlocked") as spy:
+            effective = get_security_settings()
+            spy.assert_not_called()
+        assert effective == _build_env_defaults()
+    finally:
+        CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+
+
+def test_db_error_falls_back_to_env_defaults() -> None:
+    """An unexpected DB exception must not brick auth — fall back to env."""
+    with patch.object(
+        security_store,
+        "_load_raw_overrides_unlocked",
+        side_effect=RuntimeError("simulated DB outage"),
+    ):
+        invalidate_security_cache(TEST_TENANT_ID)
+        effective = get_security_settings()
+        assert effective == _build_env_defaults()

--- a/backend/tests/integration/tests/security/test_runtime_security_settings.py
+++ b/backend/tests/integration/tests/security/test_runtime_security_settings.py
@@ -1,0 +1,148 @@
+"""Integration test for runtime-configurable security settings.
+
+The integration api_server runs as a single uvicorn worker, so the PUT
+handler's local-cache invalidation takes effect on the very next request
+without any TTL wait.
+"""
+
+from collections.abc import Generator
+
+import pytest
+
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.http_client import client
+from tests.integration.common_utils.test_models import DATestUser
+
+SECURITY_URL = f"{API_SERVER_URL}/admin/security"
+USERS_URL = f"{API_SERVER_URL}/users"
+
+
+def _put_security(payload: dict, user: DATestUser) -> dict:
+    response = client.put(
+        SECURITY_URL,
+        json=payload,
+        headers=user.headers,
+        cookies=user.cookies,
+        timeout=30,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+# Sending every override key as null clears the row to pure env defaults,
+# so teardown doesn't need to know which fields a test touched.
+_ALL_OVERRIDE_KEYS_NULL: dict[str, None] = {
+    "user_directory_admin_only": None,
+    "track_external_idp_expiry": None,
+    "mask_credential_prefix": None,
+    "valid_email_domains": None,
+    "password_min_length": None,
+    "password_max_length": None,
+    "password_require_uppercase": None,
+    "password_require_lowercase": None,
+    "password_require_digit": None,
+    "password_require_special_char": None,
+}
+
+
+@pytest.fixture
+def reset_security_settings(
+    admin_user: DATestUser,
+) -> Generator[None, None, None]:
+    """Restore env defaults after the test — overrides are tenant-persistent."""
+    yield
+    try:
+        _put_security(dict(_ALL_OVERRIDE_KEYS_NULL), admin_user)
+    except Exception:
+        # Best-effort cleanup; don't mask the underlying test failure.
+        pass
+
+
+def test_user_directory_admin_only_toggle_flips_basic_access(
+    admin_user: DATestUser,
+    basic_user: DATestUser,
+    reset_security_settings: None,  # noqa: ARG001
+) -> None:
+    """Toggling ``user_directory_admin_only`` must immediately flip a basic
+    user's /users access."""
+    # Baseline: with the flag off, a basic user can list users.
+    _put_security({"user_directory_admin_only": False}, admin_user)
+
+    resp_before = client.get(
+        USERS_URL,
+        headers=basic_user.headers,
+        cookies=basic_user.cookies,
+        timeout=30,
+    )
+    assert resp_before.status_code == 200, (
+        f"Expected basic user to list /users when flag is off, "
+        f"got {resp_before.status_code}: {resp_before.text}"
+    )
+
+    # Flip the flag on. Basic user should now be rejected.
+    _put_security({"user_directory_admin_only": True}, admin_user)
+
+    resp_blocked = client.get(
+        USERS_URL,
+        headers=basic_user.headers,
+        cookies=basic_user.cookies,
+        timeout=30,
+    )
+    assert resp_blocked.status_code == 403, (
+        f"Expected basic user to be denied /users when flag is on, "
+        f"got {resp_blocked.status_code}: {resp_blocked.text}"
+    )
+
+    # Admin should still see the directory.
+    resp_admin = client.get(
+        USERS_URL,
+        headers=admin_user.headers,
+        cookies=admin_user.cookies,
+        timeout=30,
+    )
+    assert resp_admin.status_code == 200
+
+    # Flip back off. Basic user regains access immediately.
+    _put_security({"user_directory_admin_only": False}, admin_user)
+
+    resp_after = client.get(
+        USERS_URL,
+        headers=basic_user.headers,
+        cookies=basic_user.cookies,
+        timeout=30,
+    )
+    assert resp_after.status_code == 200, (
+        f"Expected basic user to regain /users access after flag is off, "
+        f"got {resp_after.status_code}: {resp_after.text}"
+    )
+
+
+def test_get_security_settings_round_trip_persists(
+    admin_user: DATestUser,
+    reset_security_settings: None,  # noqa: ARG001
+) -> None:
+    """PUT then GET reflects the persisted override; other fields unchanged."""
+    baseline = client.get(
+        SECURITY_URL,
+        headers=admin_user.headers,
+        cookies=admin_user.cookies,
+        timeout=30,
+    ).json()
+
+    desired = not baseline["track_external_idp_expiry"]
+    _put_security({"track_external_idp_expiry": desired}, admin_user)
+
+    after = client.get(
+        SECURITY_URL,
+        headers=admin_user.headers,
+        cookies=admin_user.cookies,
+        timeout=30,
+    ).json()
+
+    assert after["track_external_idp_expiry"] is desired
+    for key in baseline:
+        if key == "track_external_idp_expiry":
+            continue
+        assert after[key] == baseline[key], (
+            f"Field {key!r} unexpectedly changed: {baseline[key]!r} -> {after[key]!r}"
+        )

--- a/backend/tests/unit/onyx/auth/test_jwt_provisioning.py
+++ b/backend/tests/unit/onyx/auth/test_jwt_provisioning.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from datetime import datetime
 from datetime import timezone
 from typing import Any
@@ -7,6 +8,25 @@ from unittest.mock import MagicMock
 import pytest
 
 from onyx.auth import users as users_module
+from onyx.server.security.models import SecuritySettings
+
+
+@pytest.fixture
+def stub_security_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Callable[..., SecuritySettings]:
+    """Patch ``users_module.get_security_settings`` to return a SecuritySettings
+    built from env defaults with the supplied field overrides applied."""
+    from onyx.server.security.store import _build_env_defaults
+
+    def _apply(**overrides: Any) -> SecuritySettings:
+        merged = _build_env_defaults().model_dump()
+        merged.update(overrides)
+        stubbed = SecuritySettings(**merged)
+        monkeypatch.setattr(users_module, "get_security_settings", lambda: stubbed)
+        return stubbed
+
+    return _apply
 
 
 def test_extract_email_requires_valid_format() -> None:
@@ -21,9 +41,10 @@ def test_extract_email_requires_valid_format() -> None:
 @pytest.mark.asyncio
 async def test_get_or_create_user_updates_expiry(
     monkeypatch: pytest.MonkeyPatch,
+    stub_security_settings: Callable[..., SecuritySettings],
 ) -> None:
     """Existing web-login users should be returned and their expiry synced."""
-    monkeypatch.setattr(users_module, "TRACK_EXTERNAL_IDP_EXPIRY", True)
+    stub_security_settings(track_external_idp_expiry=True)
     invited_checked: dict[str, str] = {}
 
     def mark_invited(value: str) -> None:
@@ -31,7 +52,7 @@ async def test_get_or_create_user_updates_expiry(
 
     domain_checked: dict[str, str] = {}
 
-    def mark_domain(value: str) -> None:
+    def mark_domain(value: str, **_kw: Any) -> None:
         domain_checked["email"] = value
 
     monkeypatch.setattr(users_module, "verify_email_is_invited", mark_invited)
@@ -82,9 +103,10 @@ async def test_get_or_create_user_updates_expiry(
 @pytest.mark.asyncio
 async def test_get_or_create_user_skips_inactive(
     monkeypatch: pytest.MonkeyPatch,
+    stub_security_settings: Callable[..., SecuritySettings],
 ) -> None:
     """Inactive users should not be re-authenticated via JWT."""
-    monkeypatch.setattr(users_module, "TRACK_EXTERNAL_IDP_EXPIRY", True)
+    stub_security_settings(track_external_idp_expiry=True)
     monkeypatch.setattr(users_module, "verify_email_is_invited", lambda _: None)
     monkeypatch.setattr(users_module, "verify_email_domain", lambda *_a, **_kw: None)
 
@@ -122,9 +144,10 @@ async def test_get_or_create_user_skips_inactive(
 @pytest.mark.asyncio
 async def test_get_or_create_user_handles_race_conditions(
     monkeypatch: pytest.MonkeyPatch,
+    stub_security_settings: Callable[..., SecuritySettings],
 ) -> None:
     """If provisioning races, newly inactive users should still be blocked."""
-    monkeypatch.setattr(users_module, "TRACK_EXTERNAL_IDP_EXPIRY", True)
+    stub_security_settings(track_external_idp_expiry=True)
     monkeypatch.setattr(users_module, "verify_email_is_invited", lambda _: None)
     monkeypatch.setattr(users_module, "verify_email_domain", lambda *_a, **_kw: None)
 
@@ -170,6 +193,7 @@ async def test_get_or_create_user_handles_race_conditions(
 @pytest.mark.asyncio
 async def test_get_or_create_user_provisions_new_user(
     monkeypatch: pytest.MonkeyPatch,
+    stub_security_settings: Callable[..., SecuritySettings],
 ) -> None:
     """A brand new JWT user should be provisioned automatically."""
     email = "new-user@example.com"
@@ -179,7 +203,7 @@ async def test_get_or_create_user_provisions_new_user(
     created_user.oidc_expiry = None
     created_user.role.is_web_login.return_value = True
 
-    monkeypatch.setattr(users_module, "TRACK_EXTERNAL_IDP_EXPIRY", False)
+    stub_security_settings(track_external_idp_expiry=False)
     monkeypatch.setattr(users_module, "generate_password", lambda: "TempPass123!")
     monkeypatch.setattr(users_module, "verify_email_is_invited", lambda _: None)
     monkeypatch.setattr(users_module, "verify_email_domain", lambda *_a, **_kw: None)

--- a/backend/tests/unit/onyx/auth/test_user_registration.py
+++ b/backend/tests/unit/onyx/auth/test_user_registration.py
@@ -140,7 +140,9 @@ class TestDisposableEmailValidation:
 
         # Verify domain validation was called
         mock_verify_domain.assert_called_once_with(
-            mock_user_create.email, is_registration=True
+            mock_user_create.email,
+            valid_email_domains=(),
+            is_registration=True,
         )
 
 
@@ -540,7 +542,9 @@ class TestCaseInsensitiveEmailMatching:
 
         # Verify flow
         mock_verify_domain.assert_called_once_with(
-            user_create.email, is_registration=True
+            user_create.email,
+            valid_email_domains=(),
+            is_registration=True,
         )
 
     @patch("onyx.auth.users.is_disposable_email")
@@ -592,7 +596,9 @@ class TestCaseInsensitiveEmailMatching:
 
         # Verify flow
         mock_verify_domain.assert_called_once_with(
-            mock_user_create.email, is_registration=True
+            mock_user_create.email,
+            valid_email_domains=(),
+            is_registration=True,
         )
         mock_verify_invited.assert_called_once()  # Existing tenant = invite needed
 

--- a/backend/tests/unit/onyx/auth/test_verify_email_domain.py
+++ b/backend/tests/unit/onyx/auth/test_verify_email_domain.py
@@ -6,34 +6,21 @@ from onyx.configs.constants import AuthType
 from onyx.error_handling.exceptions import OnyxError
 
 
-def test_verify_email_domain_allows_case_insensitive_match(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_verify_email_domain_allows_case_insensitive_match() -> None:
     # Configure whitelist to lowercase while email has uppercase domain
-    monkeypatch.setattr(users, "VALID_EMAIL_DOMAINS", ["example.com"], raising=False)
-
-    # Should not raise
-    verify_email_domain("User@EXAMPLE.COM")
+    verify_email_domain("User@EXAMPLE.COM", valid_email_domains=["example.com"])
 
 
-def test_verify_email_domain_rejects_non_whitelisted_domain(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(users, "VALID_EMAIL_DOMAINS", ["example.com"], raising=False)
-
+def test_verify_email_domain_rejects_non_whitelisted_domain() -> None:
     with pytest.raises(OnyxError) as exc:
-        verify_email_domain("user@another.com")
+        verify_email_domain("user@another.com", valid_email_domains=["example.com"])
     assert exc.value.status_code == 400
     assert "Email domain is not valid" in exc.value.detail
 
 
-def test_verify_email_domain_invalid_email_format(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(users, "VALID_EMAIL_DOMAINS", ["example.com"], raising=False)
-
+def test_verify_email_domain_invalid_email_format() -> None:
     with pytest.raises(OnyxError) as exc:
-        verify_email_domain("userexample.com")  # missing '@'
+        verify_email_domain("userexample.com", valid_email_domains=["example.com"])
     assert exc.value.status_code == 400
     assert "Email is not valid" in exc.value.detail
 
@@ -41,11 +28,10 @@ def test_verify_email_domain_invalid_email_format(
 def test_verify_email_domain_rejects_plus_addressing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(users, "VALID_EMAIL_DOMAINS", [], raising=False)
     monkeypatch.setattr(users, "AUTH_TYPE", AuthType.CLOUD, raising=False)
 
     with pytest.raises(OnyxError) as exc:
-        verify_email_domain("user+tag@gmail.com")
+        verify_email_domain("user+tag@gmail.com", valid_email_domains=[])
     assert exc.value.status_code == 400
     assert "'+'" in exc.value.detail
 
@@ -53,21 +39,23 @@ def test_verify_email_domain_rejects_plus_addressing(
 def test_verify_email_domain_allows_plus_for_onyx_app(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(users, "VALID_EMAIL_DOMAINS", [], raising=False)
     monkeypatch.setattr(users, "AUTH_TYPE", AuthType.CLOUD, raising=False)
 
     # Should not raise for onyx.app domain
-    verify_email_domain("user+tag@onyx.app")
+    verify_email_domain("user+tag@onyx.app", valid_email_domains=[])
 
 
 def test_verify_email_domain_rejects_dotted_gmail_on_registration(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(users, "VALID_EMAIL_DOMAINS", [], raising=False)
     monkeypatch.setattr(users, "AUTH_TYPE", AuthType.CLOUD, raising=False)
 
     with pytest.raises(OnyxError) as exc:
-        verify_email_domain("first.last@gmail.com", is_registration=True)
+        verify_email_domain(
+            "first.last@gmail.com",
+            valid_email_domains=[],
+            is_registration=True,
+        )
     assert exc.value.status_code == 400
     assert "'.'" in exc.value.detail
 
@@ -75,38 +63,44 @@ def test_verify_email_domain_rejects_dotted_gmail_on_registration(
 def test_verify_email_domain_dotted_gmail_allowed_when_not_registration(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(users, "VALID_EMAIL_DOMAINS", [], raising=False)
     monkeypatch.setattr(users, "AUTH_TYPE", AuthType.CLOUD, raising=False)
 
     # Existing user signing in — should not be blocked
-    verify_email_domain("first.last@gmail.com", is_registration=False)
+    verify_email_domain(
+        "first.last@gmail.com", valid_email_domains=[], is_registration=False
+    )
 
 
 def test_verify_email_domain_allows_dotted_non_gmail_on_registration(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(users, "VALID_EMAIL_DOMAINS", [], raising=False)
     monkeypatch.setattr(users, "AUTH_TYPE", AuthType.CLOUD, raising=False)
 
-    verify_email_domain("first.last@example.com", is_registration=True)
+    verify_email_domain(
+        "first.last@example.com",
+        valid_email_domains=[],
+        is_registration=True,
+    )
 
 
 def test_verify_email_domain_dotted_gmail_allowed_when_not_cloud(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(users, "VALID_EMAIL_DOMAINS", [], raising=False)
     monkeypatch.setattr(users, "AUTH_TYPE", AuthType.BASIC, raising=False)
 
-    verify_email_domain("first.last@gmail.com", is_registration=True)
+    verify_email_domain(
+        "first.last@gmail.com",
+        valid_email_domains=[],
+        is_registration=True,
+    )
 
 
 def test_verify_email_domain_rejects_googlemail(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(users, "VALID_EMAIL_DOMAINS", [], raising=False)
     monkeypatch.setattr(users, "AUTH_TYPE", AuthType.CLOUD, raising=False)
 
     with pytest.raises(OnyxError) as exc:
-        verify_email_domain("user@googlemail.com")
+        verify_email_domain("user@googlemail.com", valid_email_domains=[])
     assert exc.value.status_code == 400
     assert "gmail.com" in exc.value.detail

--- a/backend/tests/unit/onyx/server/manage/test_users_directory_visibility.py
+++ b/backend/tests/unit/onyx/server/manage/test_users_directory_visibility.py
@@ -9,6 +9,24 @@ from onyx.db.enums import Permission
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server.manage.users import list_all_users_basic_info
+from onyx.server.security.models import SecuritySettings
+from onyx.server.security.store import _build_env_defaults
+
+
+def _settings(*, user_directory_admin_only: bool) -> SecuritySettings:
+    base = _build_env_defaults()
+    return SecuritySettings(
+        user_directory_admin_only=user_directory_admin_only,
+        track_external_idp_expiry=base.track_external_idp_expiry,
+        mask_credential_prefix=base.mask_credential_prefix,
+        valid_email_domains=base.valid_email_domains,
+        password_min_length=base.password_min_length,
+        password_max_length=base.password_max_length,
+        password_require_uppercase=base.password_require_uppercase,
+        password_require_lowercase=base.password_require_lowercase,
+        password_require_digit=base.password_require_digit,
+        password_require_special_char=base.password_require_special_char,
+    )
 
 
 def _fake_user(
@@ -21,8 +39,13 @@ def _fake_user(
     return user
 
 
-@patch("onyx.server.manage.users.USER_DIRECTORY_ADMIN_ONLY", True)
-def test_list_all_users_basic_info_blocks_non_admin_when_directory_restricted() -> None:
+@patch(
+    "onyx.server.manage.users.get_security_settings",
+    return_value=_settings(user_directory_admin_only=True),
+)
+def test_list_all_users_basic_info_blocks_non_admin_when_directory_restricted(
+    _mock_settings: MagicMock,
+) -> None:
     """With the flag on, a caller lacking READ_USERS cannot enumerate the directory."""
     user = MagicMock()
     user.effective_permissions = [Permission.BASIC_ACCESS.value]
@@ -37,10 +60,14 @@ def test_list_all_users_basic_info_blocks_non_admin_when_directory_restricted() 
     assert exc_info.value.error_code is OnyxErrorCode.INSUFFICIENT_PERMISSIONS
 
 
-@patch("onyx.server.manage.users.USER_DIRECTORY_ADMIN_ONLY", True)
+@patch(
+    "onyx.server.manage.users.get_security_settings",
+    return_value=_settings(user_directory_admin_only=True),
+)
 @patch("onyx.server.manage.users.get_all_users")
 def test_list_all_users_basic_info_allows_admin_when_directory_restricted(
     mock_get_all_users: MagicMock,
+    _mock_settings: MagicMock,
 ) -> None:
     """With the flag on, an admin (FULL_ADMIN_PANEL_ACCESS) still gets the directory."""
     admin = MagicMock()
@@ -56,10 +83,14 @@ def test_list_all_users_basic_info_allows_admin_when_directory_restricted(
     assert [u.email for u in result] == ["a@example.com"]
 
 
-@patch("onyx.server.manage.users.USER_DIRECTORY_ADMIN_ONLY", False)
+@patch(
+    "onyx.server.manage.users.get_security_settings",
+    return_value=_settings(user_directory_admin_only=False),
+)
 @patch("onyx.server.manage.users.get_all_users")
 def test_list_all_users_basic_info_allows_non_admin_when_flag_off(
     mock_get_all_users: MagicMock,
+    _mock_settings: MagicMock,
 ) -> None:
     """With the flag off (default), non-admin callers continue to get the directory."""
     basic = MagicMock()

--- a/backend/tests/unit/onyx/server/security/test_models.py
+++ b/backend/tests/unit/onyx/server/security/test_models.py
@@ -1,0 +1,131 @@
+"""Model-level tests (validators, field metadata) — no external deps."""
+
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from onyx.server.security.models import _derive_operator_locked_fields
+from onyx.server.security.models import _operator_locked
+from onyx.server.security.models import _tenant_editable
+from onyx.server.security.models import OPERATOR_LOCKED_FIELDS
+from onyx.server.security.models import PASSWORD_LENGTH_CAP
+from onyx.server.security.models import PASSWORD_MAX_LENGTH_FLOOR
+from onyx.server.security.models import SecuritySettings
+from onyx.server.security.models import SecuritySettingsOverrides
+
+_VALID_EFFECTIVE_KWARGS: dict[str, Any] = {
+    "user_directory_admin_only": False,
+    "track_external_idp_expiry": False,
+    "mask_credential_prefix": True,
+    "valid_email_domains": (),
+    "password_min_length": 8,
+    "password_max_length": 64,
+    "password_require_uppercase": True,
+    "password_require_lowercase": True,
+    "password_require_digit": True,
+    "password_require_special_char": False,
+}
+
+
+def test_every_overrides_field_declares_operator_locked_marker() -> None:
+    """Pins the contract enforced at module import — every field must carry
+    the marker, with a bool value."""
+    for name, info in SecuritySettingsOverrides.model_fields.items():
+        extras = info.json_schema_extra
+        assert isinstance(extras, dict), f"{name}: json_schema_extra must be a dict"
+        assert "operator_locked" in extras, (
+            f"{name}: missing operator_locked marker — use "
+            f"Field(..., json_schema_extra=_operator_locked()) or _tenant_editable()"
+        )
+        assert isinstance(extras["operator_locked"], bool), (
+            f"{name}: operator_locked must be a bool"
+        )
+
+
+def test_operator_locked_fields_matches_marker_declarations() -> None:
+    expected = {
+        name
+        for name, info in SecuritySettingsOverrides.model_fields.items()
+        if isinstance(info.json_schema_extra, dict)
+        and info.json_schema_extra.get("operator_locked") is True
+    }
+    assert OPERATOR_LOCKED_FIELDS == frozenset(expected)
+
+
+def test_derivation_works_on_a_fresh_call() -> None:
+    assert _derive_operator_locked_fields() == OPERATOR_LOCKED_FIELDS
+
+
+def test_helper_marker_factories_produce_independent_dicts() -> None:
+    """Each factory call returns a fresh dict so Pydantic field metadata is
+    never shared by reference."""
+    a = _operator_locked()
+    b = _operator_locked()
+    assert a is not b
+    a.clear()
+    assert b["operator_locked"] is True
+    assert _tenant_editable()["operator_locked"] is False
+
+
+def _effective_with(**overrides: Any) -> dict[str, Any]:
+    return {**_VALID_EFFECTIVE_KWARGS, **overrides}
+
+
+def test_security_settings_accepts_valid_default_state() -> None:
+    SecuritySettings.model_validate(_VALID_EFFECTIVE_KWARGS)
+
+
+def test_security_settings_rejects_negative_min_length() -> None:
+    with pytest.raises(ValidationError):
+        SecuritySettings.model_validate(_effective_with(password_min_length=-1))
+
+
+def test_security_settings_rejects_max_length_below_floor() -> None:
+    with pytest.raises(ValidationError):
+        SecuritySettings.model_validate(
+            _effective_with(
+                password_min_length=0,
+                password_max_length=PASSWORD_MAX_LENGTH_FLOOR - 1,
+            )
+        )
+
+
+def test_security_settings_rejects_max_length_above_cap() -> None:
+    with pytest.raises(ValidationError):
+        SecuritySettings.model_validate(
+            _effective_with(password_max_length=PASSWORD_LENGTH_CAP + 1)
+        )
+
+
+def test_security_settings_rejects_min_greater_than_max() -> None:
+    with pytest.raises(ValidationError):
+        SecuritySettings.model_validate(
+            _effective_with(password_min_length=20, password_max_length=10)
+        )
+
+
+def test_overrides_extra_field_rejected() -> None:
+    with pytest.raises(ValidationError):
+        SecuritySettingsOverrides.model_validate({"not_a_real_field": True})
+
+
+def test_overrides_valid_email_domains_normalized() -> None:
+    """Strip, lowercase, drop empties; preserve order; no dedup."""
+    parsed = SecuritySettingsOverrides.model_validate(
+        {"valid_email_domains": [" ACME.com", "", "  ", "Foo.IO", "acme.com"]}
+    )
+    assert parsed.valid_email_domains == ["acme.com", "foo.io", "acme.com"]
+
+
+def test_overrides_hide_input_in_errors() -> None:
+    """ValidationError must not echo the offending input — that's how an
+    admin's secret-shaped value would leak out of the PUT response envelope.
+    """
+    sentinel = "DO-NOT-LEAK-12345"
+    try:
+        SecuritySettingsOverrides.model_validate({"password_min_length": sentinel})
+    except ValidationError as e:
+        assert sentinel not in str(e)
+    else:  # pragma: no cover
+        raise AssertionError("expected ValidationError")

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -66,6 +66,10 @@ USER_AUTH_SECRET=""
 # METRICS_AUTH_TOKEN=
 ### Set to "true" to expose /metrics with NO authentication (explicit opt-out).
 # DISABLE_METRICS_AUTH=
+### Set to "true" to expose the interactive API docs and schema (/openapi.json,
+### /docs, /redoc) publicly with NO authentication. Off by default so the API
+### surface is not exposed; when off these routes are not registered (404).
+# ENABLE_PUBLIC_DOCS=
 ### Optional
 # API_KEY_HASH_ROUNDS=
 ### You can add a comma separated list of domains like onyx.app, only those domains will be allowed to signup/log in

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.5.18
+version: 0.5.19
 appVersion: latest
 annotations:
   category: Productivity
@@ -17,11 +17,10 @@ annotations:
       image: docker.io/onyxdotapp/onyx-backend:latest
   artifacthub.io/changes: |
     - kind: added
-      description: '`auth.metricsAuth` bearer token guarding the API server''s
-        /metrics endpoint. /metrics returns 401 by default until you enable
-        auth.metricsAuth (injects `METRICS_AUTH_TOKEN`, and the api ServiceMonitor
-        scrapes with `Authorization: Bearer <token>`) or explicitly opt out via
-        configMap.DISABLE_METRICS_AUTH=true.'
+      description: '`configMap.ENABLE_PUBLIC_DOCS` flag (default off) gating the
+        interactive API docs and schema. When unset, /openapi.json, /docs, and
+        /redoc are not registered (404); set to "true" to expose them publicly
+        with no authentication.'
 dependencies:
   - name: cloudnative-pg
     version: 0.26.0

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1410,6 +1410,10 @@ configMap:
   # (enable auth.metricsAuth) OR you explicitly opt out here. Set to "true" to
   # expose /metrics with NO authentication.
   DISABLE_METRICS_AUTH: ""
+  # The interactive API docs and schema (/openapi.json, /docs, /redoc) are off by
+  # default and the routes are not registered (404). Set to "true" to expose them
+  # publicly with NO authentication.
+  ENABLE_PUBLIC_DOCS: ""
   # For sending verification emails, true or false
   REQUIRE_EMAIL_VERIFICATION: ""
   # If unspecified then defaults to 'smtp.gmail.com'

--- a/web/src/app/admin/security/page.tsx
+++ b/web/src/app/admin/security/page.tsx
@@ -1,15 +1,5 @@
-"use client";
-
-import { SettingsLayouts } from "@opal/layouts";
-import { ADMIN_ROUTES } from "@/lib/admin-routes";
-
-const route = ADMIN_ROUTES.SECURITY_HARDENING;
+import SecurityHardeningPage from "@/refresh-pages/admin/SecurityHardeningPage";
 
 export default function Page() {
-  return (
-    <SettingsLayouts.Root>
-      <SettingsLayouts.Header icon={route.icon} title={route.title} divider />
-      <SettingsLayouts.Body />
-    </SettingsLayouts.Root>
-  );
+  return <SecurityHardeningPage />;
 }

--- a/web/src/lib/admin-routes.ts
+++ b/web/src/lib/admin-routes.ts
@@ -236,8 +236,8 @@ export const ADMIN_ROUTES = {
   SECURITY_HARDENING: {
     path: "/admin/security",
     icon: SvgShield,
-    title: "Security and Hardening",
-    sidebarLabel: "Security and Hardening",
+    title: "Security & Hardening",
+    sidebarLabel: "Security & Hardening",
   },
   // Prefix-only entries used for layout matching — not rendered as sidebar
   // items or page headers.

--- a/web/src/lib/swr-keys.ts
+++ b/web/src/lib/swr-keys.ts
@@ -19,6 +19,7 @@ export const SWR_KEYS = {
   enterpriseSettings: "/api/enterprise-settings",
   customAnalyticsScript: "/api/enterprise-settings/custom-analytics-script",
   authType: "/api/auth/type",
+  adminSecuritySettings: "/api/admin/security",
 
   // ── Agents / Personas ─────────────────────────────────────────────────────
   personas: "/api/persona",

--- a/web/src/refresh-pages/admin/SecurityHardeningPage.tsx
+++ b/web/src/refresh-pages/admin/SecurityHardeningPage.tsx
@@ -1,0 +1,434 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import useSWR, { mutate } from "swr";
+import { errorHandlingFetcher } from "@/lib/fetcher";
+import { SWR_KEYS } from "@/lib/swr-keys";
+import { ADMIN_ROUTES } from "@/lib/admin-routes";
+import { NEXT_PUBLIC_CLOUD_ENABLED } from "@/lib/constants";
+import { toast } from "@/hooks/useToast";
+import InputNumber from "@/refresh-components/inputs/InputNumber";
+import InputChipField, {
+  type ChipItem,
+} from "@/refresh-components/inputs/InputChipField";
+import InputSelect from "@/refresh-components/inputs/InputSelect";
+import {
+  Content,
+  InputHorizontal,
+  InputVertical,
+  Section,
+  SettingsLayouts,
+} from "@opal/layouts";
+import { Card, Switch } from "@opal/components";
+import { markdown } from "@opal/utils";
+import type { RichStr } from "@opal/types";
+
+const route = ADMIN_ROUTES.SECURITY_HARDENING;
+
+// Read shape: the effective, env-merged settings returned by GET /admin/security.
+// Every field is concrete — the backend never returns null here (see
+// `SecuritySettings` in backend/onyx/server/security/models.py).
+interface SecuritySettings {
+  user_directory_admin_only: boolean;
+  track_external_idp_expiry: boolean;
+  mask_credential_prefix: boolean;
+  valid_email_domains: string[];
+  password_min_length: number;
+  password_max_length: number;
+  password_require_uppercase: boolean;
+  password_require_lowercase: boolean;
+  password_require_digit: boolean;
+  password_require_special_char: boolean;
+}
+
+// Write shape: a partial patch. The backend treats only the keys present in the
+// PUT body as explicit overrides; absent keys keep their stored value, while an
+// explicit `null` clears an override back to the env default (see
+// `SecuritySettingsOverrides` + `present_keys` in the backend).
+type SecuritySettingsUpdate = {
+  [K in keyof SecuritySettings]?: SecuritySettings[K] | null;
+};
+
+interface ToggleRowProps {
+  title: string;
+  description?: string | RichStr;
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}
+
+function ToggleRow({
+  title,
+  description,
+  checked,
+  onCheckedChange,
+}: ToggleRowProps) {
+  return (
+    <InputHorizontal title={title} description={description} withLabel>
+      <Switch checked={checked} onCheckedChange={onCheckedChange} />
+    </InputHorizontal>
+  );
+}
+
+export default function SecurityHardeningPage() {
+  const isMultiTenant = NEXT_PUBLIC_CLOUD_ENABLED;
+
+  const { data: settings, isLoading: settingsLoading } =
+    useSWR<SecuritySettings>(
+      SWR_KEYS.adminSecuritySettings,
+      errorHandlingFetcher
+    );
+
+  // Local state mirrors the loaded settings; we save on every change.
+  const [draft, setDraft] = useState<SecuritySettings | null>(null);
+  const [domainInput, setDomainInput] = useState("");
+  // The "Restrict Email Domains" toggle has no backing field — restriction is
+  // active iff the allowlist is non-empty. This lets an admin turn the toggle on
+  // and reveal the (still empty) input before typing the first domain. It stays
+  // independent of `draft` so unrelated saves don't collapse the open input.
+  const [forceShowDomains, setForceShowDomains] = useState(false);
+
+  useEffect(() => {
+    if (settings) setDraft(settings);
+  }, [settings]);
+
+  const saveSettings = useCallback(async (updates: SecuritySettingsUpdate) => {
+    // Optimistically reflect concrete changes for snappy toggles. A `null`
+    // clears an override; its resolved env default only arrives with the PUT
+    // response, so we leave the current value in place rather than guess.
+    setDraft((prev) => {
+      if (!prev) return prev;
+      const concrete = Object.fromEntries(
+        Object.entries(updates).filter(([, value]) => value != null)
+      ) as Partial<SecuritySettings>;
+      return { ...prev, ...concrete };
+    });
+    try {
+      const response = await fetch(SWR_KEYS.adminSecuritySettings, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        // Send ONLY the changed fields. The backend persists each present key
+        // as an explicit override and lets absent keys fall back to env
+        // defaults. Sending the full settings would freeze every env default
+        // as an override and 403 on operator-locked fields in multi-tenant.
+        body: JSON.stringify(updates),
+      });
+      if (!response.ok) {
+        const errorMsg = (await response.json()).detail;
+        throw new Error(errorMsg);
+      }
+      // PUT returns the new effective settings — adopt them as the source of
+      // truth so the UI matches what was actually persisted/merged.
+      const effective: SecuritySettings = await response.json();
+      setDraft(effective);
+      await mutate(SWR_KEYS.adminSecuritySettings, effective, {
+        revalidate: false,
+      });
+      toast.success("Security settings updated");
+    } catch (error) {
+      // Re-sync from the server (the source of truth) rather than a possibly
+      // stale local snapshot — a late failure must not clobber other edits
+      // that may have succeeded while this request was in flight.
+      try {
+        const fresh = await mutate<SecuritySettings>(
+          SWR_KEYS.adminSecuritySettings
+        );
+        if (fresh) setDraft(fresh);
+      } catch {
+        // If revalidation also fails (e.g. network down), the optimistic
+        // update stays until the next successful SWR refresh (e.g. focus).
+      }
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Failed to update security settings";
+      toast.error(message);
+    }
+  }, []);
+
+  if (settingsLoading || !draft) {
+    return (
+      <SettingsLayouts.Root>
+        <SettingsLayouts.Header icon={route.icon} title={route.title} divider />
+        <SettingsLayouts.Body />
+      </SettingsLayouts.Root>
+    );
+  }
+
+  const validDomains: ChipItem[] = draft.valid_email_domains.map((domain) => ({
+    id: domain,
+    label: domain,
+  }));
+
+  // Show the domain allowlist when it's populated, or when the admin has
+  // explicitly turned the restriction on but not yet added a domain.
+  const showDomains = forceShowDomains || draft.valid_email_domains.length > 0;
+
+  function addDomain(value: string) {
+    const trimmed = value.trim().toLowerCase();
+    if (!trimmed) return;
+    const current = draft?.valid_email_domains ?? [];
+    if (current.includes(trimmed)) {
+      setDomainInput("");
+      return;
+    }
+    void saveSettings({ valid_email_domains: [...current, trimmed] });
+    setDomainInput("");
+  }
+
+  function removeDomain(id: string) {
+    const current = draft?.valid_email_domains ?? [];
+    void saveSettings({
+      valid_email_domains: current.filter((domain) => domain !== id),
+    });
+  }
+
+  return (
+    <SettingsLayouts.Root>
+      <SettingsLayouts.Header
+        icon={route.icon}
+        title={route.title}
+        description="Runtime-configurable security settings. Unset values fall back to your deployment's environment configuration."
+        divider
+      />
+
+      <SettingsLayouts.Body>
+        {/* Authentication */}
+        <div className="flex w-full flex-col gap-3">
+          <Content
+            title="Authentication"
+            sizePreset="main-content"
+            variant="section"
+          />
+
+          <Card border="solid" rounding="lg">
+            <Section>
+              <ToggleRow
+                title="Sync Session Expiry with Identity Provider"
+                description="Log users out when the upstream OAuth/OIDC provider session expires."
+                checked={draft.track_external_idp_expiry}
+                onCheckedChange={(checked) =>
+                  void saveSettings({ track_external_idp_expiry: checked })
+                }
+              />
+
+              {!isMultiTenant && (
+                <>
+                  <ToggleRow
+                    title="Restrict Email Domains"
+                    description="Limit new user registrations to specific email domains."
+                    checked={showDomains}
+                    onCheckedChange={(checked) => {
+                      if (checked) {
+                        setForceShowDomains(true);
+                      } else {
+                        // Clearing the allowlist disables the restriction.
+                        setForceShowDomains(false);
+                        void saveSettings({ valid_email_domains: [] });
+                      }
+                    }}
+                  />
+
+                  {showDomains && (
+                    <InputVertical
+                      title="Allowed Email Domains"
+                      subDescription="New users can only register new accounts with emails in this domain list."
+                      withLabel
+                    >
+                      <InputChipField
+                        chips={validDomains}
+                        onRemoveChip={removeDomain}
+                        onAdd={addDomain}
+                        value={domainInput}
+                        onChange={setDomainInput}
+                        placeholder="Add a domain (e.g. onyx.app)"
+                      />
+                    </InputVertical>
+                  )}
+                </>
+              )}
+            </Section>
+          </Card>
+
+          {/* Password policy (single-tenant only) */}
+          {!isMultiTenant && (
+            <Card border="solid" rounding="lg">
+              <Section>
+                <Content
+                  title="Password Policy"
+                  description="Requirements for all new passwords. Applies to basic auth only."
+                  sizePreset="main-ui"
+                  variant="section"
+                />
+
+                <div className="flex w-full items-start gap-4">
+                  <div className="flex-1">
+                    <InputVertical
+                      title="Minimum Password Length"
+                      suffix="(characters)"
+                      withLabel
+                    >
+                      <InputNumber
+                        value={draft.password_min_length}
+                        onChange={(value) =>
+                          void saveSettings({ password_min_length: value })
+                        }
+                        min={1}
+                        max={1024}
+                        placeholder="Default"
+                      />
+                    </InputVertical>
+                  </div>
+                  <div className="flex-1">
+                    <InputVertical
+                      title="Maximum Password Length"
+                      suffix="(characters)"
+                      withLabel
+                    >
+                      <InputNumber
+                        value={draft.password_max_length}
+                        onChange={(value) =>
+                          void saveSettings({ password_max_length: value })
+                        }
+                        min={1}
+                        max={1024}
+                        placeholder="Default"
+                      />
+                    </InputVertical>
+                  </div>
+                </div>
+
+                <ToggleRow
+                  title="Require Uppercase Letter"
+                  checked={draft.password_require_uppercase}
+                  onCheckedChange={(checked) =>
+                    void saveSettings({ password_require_uppercase: checked })
+                  }
+                />
+
+                <ToggleRow
+                  title="Require Lowercase Letter"
+                  checked={draft.password_require_lowercase}
+                  onCheckedChange={(checked) =>
+                    void saveSettings({ password_require_lowercase: checked })
+                  }
+                />
+
+                <ToggleRow
+                  title="Require Number"
+                  checked={draft.password_require_digit}
+                  onCheckedChange={(checked) =>
+                    void saveSettings({ password_require_digit: checked })
+                  }
+                />
+
+                <ToggleRow
+                  title="Require Special Characters"
+                  description={markdown(
+                    "Accepted characters: `!@#$%^&*()_+-=[]{}|;:,.<>?`"
+                  )}
+                  checked={draft.password_require_special_char}
+                  onCheckedChange={(checked) =>
+                    void saveSettings({
+                      password_require_special_char: checked,
+                    })
+                  }
+                />
+              </Section>
+            </Card>
+          )}
+        </div>
+
+        {/* Admin Controls */}
+        <div className="flex w-full flex-col gap-3">
+          <Content
+            title="Admin Controls"
+            sizePreset="main-content"
+            variant="section"
+          />
+
+          <Card border="solid" rounding="lg">
+            <Section>
+              <InputHorizontal
+                title="Full User Directory Visibility"
+                description="Exact name and email lookups work regardless of this setting."
+                withLabel
+              >
+                <div className="w-60">
+                  <InputSelect
+                    value={
+                      draft.user_directory_admin_only
+                        ? "admins_only"
+                        : "all_users"
+                    }
+                    onValueChange={(value) =>
+                      void saveSettings({
+                        user_directory_admin_only: value === "admins_only",
+                      })
+                    }
+                  >
+                    <InputSelect.Trigger />
+                    <InputSelect.Content>
+                      <InputSelect.Item
+                        value="all_users"
+                        wrapDescription
+                        description="Anyone signed in can see the full user list when sharing resources."
+                      >
+                        Visible to All Users
+                      </InputSelect.Item>
+                      <InputSelect.Item
+                        value="admins_only"
+                        wrapDescription
+                        description="Only admins can see the full user list."
+                      >
+                        Visible to Admins Only
+                      </InputSelect.Item>
+                    </InputSelect.Content>
+                  </InputSelect>
+                </div>
+              </InputHorizontal>
+
+              {!isMultiTenant && (
+                <InputHorizontal
+                  title="Mask Stored Credentials"
+                  description="Display format for saved API keys and credentials for admins."
+                  withLabel
+                >
+                  <div className="w-60">
+                    <InputSelect
+                      value={
+                        draft.mask_credential_prefix ? "masked" : "visible"
+                      }
+                      onValueChange={(value) =>
+                        void saveSettings({
+                          mask_credential_prefix: value === "masked",
+                        })
+                      }
+                    >
+                      <InputSelect.Trigger />
+                      <InputSelect.Content>
+                        <InputSelect.Item
+                          value="masked"
+                          wrapDescription
+                          description="Show only the first and last few characters (e.g. abcd...wxyz)."
+                        >
+                          Partially Masked
+                        </InputSelect.Item>
+                        <InputSelect.Item
+                          value="visible"
+                          wrapDescription
+                          description="Show the full credential value to admins."
+                        >
+                          Fully Visible
+                        </InputSelect.Item>
+                      </InputSelect.Content>
+                    </InputSelect>
+                  </div>
+                </InputHorizontal>
+              )}
+            </Section>
+          </Card>
+        </div>
+      </SettingsLayouts.Body>
+    </SettingsLayouts.Root>
+  );
+}

--- a/web/src/sections/sidebar/AdminSidebar.tsx
+++ b/web/src/sections/sidebar/AdminSidebar.tsx
@@ -131,6 +131,7 @@ function buildItems(
 
   // 6. Organization (admin only)
   if (!isCurator) {
+    add(SECTIONS.ORGANIZATION, ADMIN_ROUTES.SECURITY_HARDENING);
     if (hasSubscription) {
       add(SECTIONS.ORGANIZATION, ADMIN_ROUTES.BILLING);
     }

--- a/web/tests/e2e/admin/security-hardening.spec.ts
+++ b/web/tests/e2e/admin/security-hardening.spec.ts
@@ -1,0 +1,31 @@
+import { test } from "@playwright/test";
+import { loginAs } from "@tests/e2e/utils/auth";
+import { AdminSecurityPage } from "@tests/e2e/pages/AdminSecurityPage";
+
+test.describe("Security Hardening Page @exclusive", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.context().clearCookies();
+    await loginAs(page, "admin");
+  });
+
+  test("admin can toggle a setting, reload, and see it persisted", async ({
+    page,
+  }) => {
+    const securityPage = new AdminSecurityPage(page);
+    await securityPage.goto();
+
+    const toggle = AdminSecurityPage.SESSION_EXPIRY_TOGGLE;
+    const initial = await securityPage.isToggleOn(toggle);
+
+    // Flip it and confirm the save.
+    await securityPage.clickToggleAndSave(toggle);
+
+    // Reload and confirm the flipped value persisted.
+    await securityPage.reload();
+    await securityPage.expectToggle(toggle, !initial);
+
+    // Restore the original value so the test leaves no residue.
+    await securityPage.clickToggleAndSave(toggle);
+    await securityPage.expectToggle(toggle, initial);
+  });
+});

--- a/web/tests/e2e/pages/AdminSecurityPage.ts
+++ b/web/tests/e2e/pages/AdminSecurityPage.ts
@@ -1,0 +1,78 @@
+/**
+ * Page Object Model for the Security & Hardening admin page (/admin/security).
+ *
+ * Encapsulates the toggle rows (each rendered as an Opal <Switch> inside an
+ * InputHorizontal <label>) and the save-confirmation toast so specs stay
+ * declarative and locator churn is confined to this file.
+ */
+
+import { type Page, type Locator, expect } from "@playwright/test";
+
+export class AdminSecurityPage {
+  readonly page: Page;
+  readonly savedToast: Locator;
+
+  // A stable, always-present, tenant-editable toggle — used as the subject for
+  // round-trip persistence checks (visible in both single- and multi-tenant).
+  static readonly SESSION_EXPIRY_TOGGLE =
+    "Sync Session Expiry with Identity Provider";
+
+  constructor(page: Page) {
+    this.page = page;
+    this.savedToast = page.getByText("Security settings updated");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Navigation
+  // ---------------------------------------------------------------------------
+
+  /** Navigate to the page and wait for it to finish loading. */
+  async goto(): Promise<void> {
+    await this.page.goto("/admin/security");
+    await this.waitForLoaded();
+  }
+
+  /** Reload the page and wait for it to finish loading. */
+  async reload(): Promise<void> {
+    await this.page.reload();
+    await this.waitForLoaded();
+  }
+
+  private async waitForLoaded(): Promise<void> {
+    await this.page.waitForLoadState("networkidle");
+    await expect(
+      this.page.getByText(AdminSecurityPage.SESSION_EXPIRY_TOGGLE)
+    ).toBeVisible({ timeout: 10000 });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Toggle rows
+  // ---------------------------------------------------------------------------
+
+  /** The <Switch> control for the toggle row with the given title. */
+  toggle(title: string): Locator {
+    return this.page
+      .getByText(title)
+      .locator("xpath=ancestor::label[1]")
+      .getByRole("switch");
+  }
+
+  /** Whether the named toggle is currently on (aria-checked === "true"). */
+  async isToggleOn(title: string): Promise<boolean> {
+    return (await this.toggle(title).getAttribute("aria-checked")) === "true";
+  }
+
+  /** Flip the named toggle and wait for the save-confirmation toast. */
+  async clickToggleAndSave(title: string): Promise<void> {
+    await this.toggle(title).click();
+    await expect(this.savedToast).toBeVisible({ timeout: 5000 });
+  }
+
+  /** Assert the named toggle is in the expected on/off state. */
+  async expectToggle(title: string, on: boolean): Promise<void> {
+    await expect(this.toggle(title)).toHaveAttribute(
+      "aria-checked",
+      on ? "true" : "false"
+    );
+  }
+}


### PR DESCRIPTION
Cherry-pick of 5 commits to release/v4.1 branch:

- 590f97276831639564d6df24e143cacb7de553c9 (Original: #11837)
- 6fc74295d5a846a431d4b088a6b3008bc045675f (Original: #11853)
- 38231ff35de5d1e76fb7bebfe69e572dfedbb7cb (Original: #11453)
- fc769e6f257881c065adcf4921f987b0eb1b97eb (Original: #11863)
- 4c65e331ff10cc83196976f02886554035039c81 (Original: #11758)


- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds runtime‑configurable security settings per tenant with an admin API and UI, and gates API docs behind `ENABLE_PUBLIC_DOCS` (default off). Admins can update password policy, email domain allowlist, credential masking, user directory visibility, and SSO expiry tracking without redeploys.

- **New Features**
  - DB‑backed `security_settings` singleton with cached loader and lock‑protected updates; admin endpoints `GET/PUT /admin/security`.
  - New “Security & Hardening” page under Organization to view and edit settings.
  - Server now reads these at runtime: credential prefix masking, user directory visibility, external IdP expiry tracking, valid email domains, and password policy (min/max length and character requirements).
  - API docs/schema are disabled by default; set `ENABLE_PUBLIC_DOCS=true` to expose `/openapi.json`, `/docs`, and `/redoc` publicly. Routes are unregistered when off.

- **Migration**
  - Run DB migrations to add the `security_settings` table.
  - Optional: set `ENABLE_PUBLIC_DOCS` in Helm/Docker if you want public API docs; defaults to off.
  - No breaking changes: env defaults continue to apply until overridden in Admin → Security & Hardening.

<sup>Written for commit 612680fe7a696c13ecf3e4dda2de83d8eb540296. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

