### PR TITLE
chore: Restore ruff G004 (no f-strings in logging) and fix 15 violations that crept in

### DIFF
--- a/backend/onyx/file_store/file_store.py
+++ b/backend/onyx/file_store/file_store.py
@@ -300,7 +300,7 @@ class S3BackedFileStore(FileStore):
             elif error_code == "403":
                 # Bucket exists but we don't have permission to access it
                 logger.warning(
-                    f"S3 bucket '{bucket_name}' exists but access is forbidden"
+                    "S3 bucket '%s' exists but access is forbidden", bucket_name
                 )
                 raise RuntimeError(
                     f"Access denied to S3 bucket '{bucket_name}'. Check credentials and permissions."

--- a/backend/onyx/file_store/gcs_file_store.py
+++ b/backend/onyx/file_store/gcs_file_store.py
@@ -98,10 +98,10 @@ class GCSBackedFileStore(FileStore):
                     self._gcs_client = storage.Client(**client_kwargs)
 
             except ImportError as e:
-                logger.error(f"Failed to import google-cloud-storage: {e}")
+                logger.error("Failed to import google-cloud-storage: %s", e)
                 raise
             except Exception as e:
-                logger.error(f"Failed to initialize GCS client: {e}")
+                logger.error("Failed to initialize GCS client: %s", e)
                 raise RuntimeError(f"Failed to initialize GCS client: {e}") from e
 
         return self._gcs_client
@@ -119,7 +119,7 @@ class GCSBackedFileStore(FileStore):
             max_key_length=1024,
         )
         if len(key) == 1024:
-            logger.info(f"File name was too long and was truncated: {file_name}")
+            logger.info("File name was too long and was truncated: %s", file_name)
         return key
 
     def initialize(self) -> None:
@@ -130,14 +130,14 @@ class GCSBackedFileStore(FileStore):
         client = self._get_gcs_client()
         try:
             client.get_bucket(self._bucket_name)
-            logger.info(f"GCS bucket '{self._bucket_name}' already exists")
+            logger.info("GCS bucket '%s' already exists", self._bucket_name)
         except NotFound:
-            logger.info(f"Creating GCS bucket '{self._bucket_name}'")
+            logger.info("Creating GCS bucket '%s'", self._bucket_name)
             client.create_bucket(self._bucket_name)
-            logger.info(f"Successfully created GCS bucket '{self._bucket_name}'")
+            logger.info("Successfully created GCS bucket '%s'", self._bucket_name)
         except Forbidden:
             logger.warning(
-                f"GCS bucket '{self._bucket_name}' exists but access is forbidden"
+                "GCS bucket '%s' exists but access is forbidden", self._bucket_name
             )
             raise RuntimeError(
                 f"Access denied to GCS bucket '{self._bucket_name}'. Check permissions."
@@ -206,8 +206,11 @@ class GCSBackedFileStore(FileStore):
                 blob.delete()
             except Exception:
                 logger.warning(
-                    f"Failed to clean up orphaned GCS blob {self._bucket_name}/{object_key} "
-                    f"after DB persistence failure for file {file_id}",
+                    "Failed to clean up orphaned GCS blob %s/%s "
+                    "after DB persistence failure for file %s",
+                    self._bucket_name,
+                    object_key,
+                    file_id,
                     exc_info=True,
                 )
             raise
@@ -264,7 +267,7 @@ class GCSBackedFileStore(FileStore):
             blob.reload()
             return blob.size
         except Exception as e:
-            logger.warning(f"Error getting file size for {file_id}: {e}")
+            logger.warning("Error getting file size for %s: %s", file_id, e)
             return None
 
     def delete_file(
@@ -286,8 +289,10 @@ class GCSBackedFileStore(FileStore):
                     return
                 if not file_record.bucket_name:
                     logger.error(
-                        f"File record {file_id} with key {file_record.object_key} "  # noqa: S608 - log message, not SQL
-                        "has no bucket name, cannot delete from filestore"
+                        "File record %s with key %s "  # noqa: S608 - log message, not SQL
+                        "has no bucket name, cannot delete from filestore",
+                        file_id,
+                        file_record.object_key,
                     )
                     delete_filerecord_by_file_id(file_id=file_id, db_session=db_session)
                     db_session.commit()
@@ -302,9 +307,10 @@ class GCSBackedFileStore(FileStore):
                     blob.delete()
                 except NotFound:
                     logger.warning(
-                        f"delete_file: File {file_id} not found in GCS "
-                        f"(key: {file_record.object_key}), "
-                        "cleaning up database record."
+                        "delete_file: File %s not found in GCS "
+                        "(key: %s), cleaning up database record.",
+                        file_id,
+                        file_record.object_key,
                     )
 
                 delete_filerecord_by_file_id(file_id=file_id, db_session=db_session)
@@ -357,15 +363,20 @@ class GCSBackedFileStore(FileStore):
                     source_blob.delete()
                 except Exception:
                     logger.warning(
-                        f"Failed to delete old GCS blob after changing file ID from "
-                        f"{old_file_id} to {new_file_id}; blob may be orphaned",
+                        "Failed to delete old GCS blob after changing file ID from "
+                        "%s to %s; blob may be orphaned",
+                        old_file_id,
+                        new_file_id,
                         exc_info=True,
                     )
 
             except Exception as e:
                 db_session.rollback()
                 logger.exception(
-                    f"Failed to change file ID from {old_file_id} to {new_file_id}: {e}"
+                    "Failed to change file ID from %s to %s: %s",
+                    old_file_id,
+                    new_file_id,
+                    e,
                 )
                 raise
 

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -375,7 +375,7 @@ def get_docs_to_update(
         if not timestamp_advanced:
             db_doc = id_to_db_doc_map.get(doc.id)
             if db_doc and db_doc.content_hash == content_hash:
-                logger.debug(f"Skipping document {doc.id!r} — content hash unchanged")
+                logger.debug("Skipping document %r — content hash unchanged", doc.id)
                 continue
 
         doc_id_to_content_hash[doc.id] = content_hash

--- a/loadtest/pyproject.toml
+++ b/loadtest/pyproject.toml
@@ -13,3 +13,6 @@ dependencies = [
 # Intentionally NOT a member of the root uv workspace: locust pins
 # gevent/geventhttpclient/flask, which must not constrain the backend's
 # shared lockfile. Run `uv sync` from inside this directory.
+#
+# No [tool.ruff] section on purpose: ruff then falls back to the root
+# pyproject, keeping this project under the repo-wide lint rules.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -267,7 +267,8 @@ ignore = [
     # cleaned up:
     "S113", # request-without-timeout (~463 existing violations).
 ]
-select = ["ARG", "E", "F", "I", "S", "W"]
+# G004: f-strings in logging break Sentry's message-pattern grouping.
+select = ["ARG", "E", "F", "G004", "I", "S", "W"]
 
 [tool.ruff.lint.isort]
 force-single-line = true


### PR DESCRIPTION
## Description

Follow-up from review discussion on #11917 (and split out of #11938 to keep backend changes out of the load-test PR).

`G004` (logging-f-string-interpolation) was enforced repo-wide by #10767 — Sentry groups errors by message pattern, and f-string interpolation creates a unique pattern per value, exploding issue counts. A later lint-config rewrite (`07eaa81298`) replaced the whole ruff `select` list and silently dropped the rule, so it has not been enforced for ~6 weeks.

This restores `G004` to the root `select` (with a comment explaining why it must stay), converts the 15 f-string logging calls that accumulated while it was off (13 in `gcs_file_store.py`, plus one each in `file_store.py` and `indexing_pipeline.py`) to lazy `%`-formatting, and adds a note in `loadtest/pyproject.toml` that it must never grow a `[tool.ruff]` section without replicating the root rules (ruff resolves config from the nearest ancestor that defines one).

## How Has This Been Tested?

- `ruff check --select G004 backend loadtest tools` → zero violations with the rule restored.
- Full `ruff check` on the three edited files → clean; pre-commit (ruff, ruff-format, ty) passes.
- Conversions are logging-only — f-strings in exception messages are intentionally untouched (the rule's purpose is log-pattern grouping, not banning f-strings generally).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores `ruff` rule `G004` (no f-strings in logging) and converts 15 logging calls to lazy `%` formatting to keep Sentry error grouping stable.

- **Refactors**
  - Added `G004` to root `pyproject.toml` `select` with a comment on why it must stay.
  - Replaced f-string logging with lazy `%` formatting in `gcs_file_store.py` (13), `file_store.py`, and `indexing_pipeline.py`.
  - Added a note in `loadtest/pyproject.toml` to inherit root `ruff` rules and avoid a local `[tool.ruff]` section.

<sup>Written for commit 5b37e1f55d34f94c2572677ecd4e0e6fc145e70e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

