### PR TITLE
fix(craft): Fix github external app can't git pull private repos

### DIFF
--- a/backend/alembic/versions/0115952654a9_github_git_smart_http_url_pattern.py
+++ b/backend/alembic/versions/0115952654a9_github_git_smart_http_url_pattern.py
@@ -1,0 +1,52 @@
+"""github git smart-http url pattern
+
+``upstream_url_patterns`` is snapshotted onto the ``external_app`` row at
+creation (tenant provisioning / admin create), so existing GitHub apps only
+claim ``api.github.com``. Append the github.com git smart-HTTP pattern (added
+to the provider spec in the same change) so the proxy injects credentials for
+``git clone``/``fetch``/``push`` on already-installed apps too.
+
+Revision ID: 0115952654a9
+Revises: 1cb59a95b250
+Create Date: 2026-06-11 10:51:38.157515
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0115952654a9"
+down_revision = "1cb59a95b250"
+branch_labels = None
+depends_on = None
+
+# Keep in sync with _GIT_SMART_HTTP_URL_PATTERN in
+# onyx/external_apps/providers/github.py (migrations don't import app code).
+_GIT_SMART_HTTP_URL_PATTERN = (
+    r"https://github\.com/[^/]+/[^/]+/"
+    r"(info/refs|git-upload-pack|git-receive-pack)(\?.*)?"
+)
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            "UPDATE external_app "
+            "SET upstream_url_patterns = "
+            "array_append(upstream_url_patterns, :pattern) "
+            "WHERE app_type = 'GITHUB' "
+            "AND NOT (:pattern = ANY(upstream_url_patterns))"
+        ).bindparams(pattern=_GIT_SMART_HTTP_URL_PATTERN)
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text(
+            "UPDATE external_app "
+            "SET upstream_url_patterns = "
+            "array_remove(upstream_url_patterns, :pattern) "
+            "WHERE app_type = 'GITHUB'"
+        ).bindparams(pattern=_GIT_SMART_HTTP_URL_PATTERN)
+    )

--- a/backend/onyx/external_apps/credentials.py
+++ b/backend/onyx/external_apps/credentials.py
@@ -9,6 +9,9 @@ from onyx.db.external_app import get_external_app_user_credential
 from onyx.db.models import ExternalApp
 from onyx.external_apps.providers.registry import get_endpoint_catalog
 from onyx.external_apps.providers.registry import get_provider_for_app
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
 
 
 def build_auth_headers(
@@ -51,8 +54,9 @@ def resolve_injection_headers(
     the user's stored credentials (the user's win on key conflicts), extends
     them with the provider's ``derive_credentials``, then renders the
     ``auth_template`` via :func:`build_auth_headers`. ``action_types`` is the
-    request's matched catalog actions (strictest-first); the first with an
-    ``EndpointSpec.auth_template`` overrides the app's stored template.
+    request's matched catalog actions; a matched ``EndpointSpec.auth_template``
+    overrides the app's stored template (co-matched overrides must agree —
+    conflicts are logged and the first wins).
     """
     app = get_external_app_by_id(db_session, external_app_id)
     if app is None or not app.skill.enabled:
@@ -78,11 +82,17 @@ def resolve_injection_headers(
             for endpoint in get_endpoint_catalog(app.app_type)
             if endpoint.auth_template is not None
         }
-        # First override in the list wins — assumes co-matched actions never
-        # carry conflicting templates (true while overrides are host-disjoint).
-        override = next((overrides[a] for a in action_types if a in overrides), None)
-        if override is not None:
-            auth_template = override
+        matched = [overrides[a] for a in action_types if a in overrides]
+        if matched:
+            auth_template = matched[0]
+            # Selection must not hinge on action ordering: co-matched overrides
+            # are expected to agree, so a conflict is a catalog bug — log it.
+            if any(override != auth_template for override in matched[1:]):
+                logger.warning(
+                    "conflicting_auth_template_overrides app_type=%s action_types=%s",
+                    app.app_type.value,
+                    ",".join(action_types),
+                )
 
     return build_auth_headers(auth_template, credentials)
 
@@ -96,8 +106,7 @@ def app_is_available(db_session: Session, app: ExternalApp, user_id: UUID) -> bo
     injects nothing) is available; an app whose template can't be filled is not.
     A disabled skill (the proxy's kill switch) is never available. Injection
     re-resolves later with an OAuth refresh, so this verdict-time render is the
-    cheap presence check, not the final one. Probes the stored template only —
-    assumes per-action ``auth_template`` overrides are fillable iff it is.
+    cheap presence check, not the final one.
     """
     if not app.skill.enabled:
         return False

--- a/backend/onyx/external_apps/credentials.py
+++ b/backend/onyx/external_apps/credentials.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from typing import Any
 from uuid import UUID
 
@@ -6,6 +7,8 @@ from sqlalchemy.orm import Session
 from onyx.db.external_app import get_external_app_by_id
 from onyx.db.external_app import get_external_app_user_credential
 from onyx.db.models import ExternalApp
+from onyx.external_apps.providers.registry import get_endpoint_catalog
+from onyx.external_apps.providers.registry import get_provider_for_app
 
 
 def build_auth_headers(
@@ -37,6 +40,7 @@ def resolve_injection_headers(
     db_session: Session,
     external_app_id: int,
     user_id: UUID,
+    action_types: Sequence[str] | None = None,
 ) -> dict[str, str]:
     """Auth headers the egress proxy should inject for a *verified* request to
     ``external_app_id`` on behalf of ``user_id``.
@@ -44,8 +48,11 @@ def resolve_injection_headers(
     Returns ``{}`` when the app is gone or disabled (the linked skill's
     ``enabled`` flag is the proxy's kill switch), or when no header's
     placeholders can be filled. Merges the app's organization credentials with
-    the user's stored credentials (the user's win on key conflicts), then
-    renders the ``auth_template`` via :func:`build_auth_headers`.
+    the user's stored credentials (the user's win on key conflicts), extends
+    them with the provider's ``derive_credentials``, then renders the
+    ``auth_template`` via :func:`build_auth_headers`. ``action_types`` is the
+    request's matched catalog actions (strictest-first); the first with an
+    ``EndpointSpec.auth_template`` overrides the app's stored template.
     """
     app = get_external_app_by_id(db_session, external_app_id)
     if app is None or not app.skill.enabled:
@@ -60,7 +67,24 @@ def resolve_injection_headers(
     if user_cred is not None:
         credentials.update(user_cred.user_credentials.get_value(apply_mask=False))
 
-    return build_auth_headers(app.auth_template, credentials)
+    provider = get_provider_for_app(app)
+    if provider is not None:
+        credentials = provider.derive_credentials(credentials)
+
+    auth_template = app.auth_template
+    if action_types:
+        overrides = {
+            endpoint.id.value: endpoint.auth_template
+            for endpoint in get_endpoint_catalog(app.app_type)
+            if endpoint.auth_template is not None
+        }
+        # First override in the list wins — assumes co-matched actions never
+        # carry conflicting templates (true while overrides are host-disjoint).
+        override = next((overrides[a] for a in action_types if a in overrides), None)
+        if override is not None:
+            auth_template = override
+
+    return build_auth_headers(auth_template, credentials)
 
 
 def app_is_available(db_session: Session, app: ExternalApp, user_id: UUID) -> bool:
@@ -72,7 +96,8 @@ def app_is_available(db_session: Session, app: ExternalApp, user_id: UUID) -> bo
     injects nothing) is available; an app whose template can't be filled is not.
     A disabled skill (the proxy's kill switch) is never available. Injection
     re-resolves later with an OAuth refresh, so this verdict-time render is the
-    cheap presence check, not the final one.
+    cheap presence check, not the final one. Probes the stored template only —
+    assumes per-action ``auth_template`` overrides are fillable iff it is.
     """
     if not app.skill.enabled:
         return False

--- a/backend/onyx/external_apps/providers/actions.py
+++ b/backend/onyx/external_apps/providers/actions.py
@@ -121,3 +121,7 @@ class EndpointSpec(BaseModel):
     # The policy a freshly-created built-in app starts this action at, unless the
     # admin overrides it.
     default_policy: EndpointPolicy = EndpointPolicy.ASK
+    # Replaces the app's stored ``auth_template`` for this action, for endpoints
+    # whose auth scheme differs from the rest of the provider. Placeholders may
+    # reference ``derive_credentials`` values.
+    auth_template: dict[str, str] | None = None

--- a/backend/onyx/external_apps/providers/base.py
+++ b/backend/onyx/external_apps/providers/base.py
@@ -152,6 +152,12 @@ class ExternalAppProvider(ABC):
         ``action_type``. Empty by default; override to register decoders."""
         return {}
 
+    def derive_credentials(self, credentials: dict[str, Any]) -> dict[str, Any]:
+        """Add computed values auth templates can reference (e.g. a base64'd
+        Basic pair). Must copy, not mutate, and derived keys must not collide
+        with stored credential fields. Default: unchanged."""
+        return credentials
+
 
 class OnyxManagedExtApp(ExternalAppProvider, abstract=True):
     """Interface for a built-in provider whose OAuth client credentials Onyx

--- a/backend/onyx/external_apps/providers/github.py
+++ b/backend/onyx/external_apps/providers/github.py
@@ -1,3 +1,4 @@
+import base64
 from typing import Any
 
 import requests
@@ -20,6 +21,16 @@ from onyx.external_apps.providers.base import OnyxManagedExtApp
 from onyx.external_apps.providers.base import OrgCredentialField
 from onyx.external_apps.providers.base import token_response_error
 
+# git's smart-HTTP endpoints on github.com (not api.github.com): ref discovery
+# plus the fetch/push POSTs.
+_GIT_SMART_HTTP_URL_PATTERN = (
+    r"https://github\.com/[^/]+/[^/]+/"
+    r"(info/refs|git-upload-pack|git-receive-pack)(\?.*)?"
+)
+
+# git endpoints reject Bearer; `{access_token_basic}` comes from derive_credentials.
+_GIT_BASIC_AUTH_TEMPLATE = {"Authorization": "Basic {access_token_basic}"}
+
 
 class GitHubAction(ExternalAppAction):
     """Strongly-typed catalog ids for the GitHub provider."""
@@ -34,11 +45,13 @@ class GitHubAction(ExternalAppAction):
     CONTENTS_READ = "github.contents.read"
     GIT_DATA_READ = "github.git_data.read"
     RELEASES_READ = "github.releases.read"
+    GIT_READ = "github.git.read"
     ISSUES_CREATE = "github.issues.create"
     COMMENTS_CREATE = "github.comments.create"
     CONTENTS_WRITE = "github.contents.write"
     REFS_WRITE = "github.refs.write"
     PULLS_CREATE = "github.pulls.create"
+    GIT_PUSH = "github.git.push"
 
 
 # GitHub's REST API is a path-addressed JSON API rooted at
@@ -168,6 +181,23 @@ _ENDPOINTS: list[EndpointSpec] = [
         ),
         default_policy=EndpointPolicy.ALWAYS,
     ),
+    # These paths are on github.com (see _GIT_SMART_HTTP_URL_PATTERN), not
+    # api.github.com. Matching is host-blind, so same-shaped api.github.com
+    # paths also resolve here; no real API route collides (GitHub 404s them).
+    EndpointSpec(
+        id=GitHubAction.GIT_READ,
+        normalised_name="Clone or fetch a repository",
+        description=(
+            "Clone or fetch a repository's contents with git over HTTPS "
+            "(ref discovery and upload-pack)."
+        ),
+        matches=(
+            RestRoute(method="GET", path="/{owner}/{repo}/info/refs"),
+            RestRoute(method="POST", path="/{owner}/{repo}/git-upload-pack"),
+        ),
+        default_policy=EndpointPolicy.ALWAYS,
+        auth_template=_GIT_BASIC_AUTH_TEMPLATE,
+    ),
     EndpointSpec(
         id=GitHubAction.ISSUES_CREATE,
         normalised_name="Create an issue",
@@ -216,6 +246,15 @@ _ENDPOINTS: list[EndpointSpec] = [
             GraphQLOp(operation_type="mutation", field="createPullRequest"),
         ),
     ),
+    EndpointSpec(
+        id=GitHubAction.GIT_PUSH,
+        normalised_name="Push to a repository",
+        description=(
+            "Push commits and refs to a repository with git over HTTPS (receive-pack)."
+        ),
+        matches=(RestRoute(method="POST", path="/{owner}/{repo}/git-receive-pack"),),
+        auth_template=_GIT_BASIC_AUTH_TEMPLATE,
+    ),
 ]
 
 
@@ -231,10 +270,14 @@ class GitHubProvider(OAuthExternalAppProvider, OnyxManagedExtApp):
         ),
         descriptor=AdminDescriptorSpec(
             description=(
-                "Read repositories, issues, and pull requests, open new issues, "
-                "and add comments in GitHub on the user's behalf."
+                "Clone and read repositories, issues, and pull requests, open "
+                "new issues, add comments, and push changes in GitHub on the "
+                "user's behalf."
             ),
-            upstream_url_patterns=["https://api\\.github\\.com/.*"],
+            upstream_url_patterns=[
+                "https://api\\.github\\.com/.*",
+                _GIT_SMART_HTTP_URL_PATTERN,
+            ],
             auth_template={"Authorization": "Bearer {access_token}"},
             required_org_credential_fields=[
                 OrgCredentialField(
@@ -275,6 +318,14 @@ class GitHubProvider(OAuthExternalAppProvider, OnyxManagedExtApp):
     # GitHub signals a dead refresh token with `bad_refresh_token` rather than
     # RFC-6749's `invalid_grant`; treat it as terminal so the user reconnects.
     terminal_refresh_errors = frozenset({"invalid_grant", "bad_refresh_token"})
+
+    def derive_credentials(self, credentials: dict[str, Any]) -> dict[str, Any]:
+        # Basic pair for _GIT_BASIC_AUTH_TEMPLATE: base64(x-access-token:<token>).
+        access_token = credentials.get("access_token")
+        if isinstance(access_token, str) and access_token:
+            basic = base64.b64encode(f"x-access-token:{access_token}".encode()).decode()
+            credentials = {**credentials, "access_token_basic": basic}
+        return credentials
 
     def classify_token_response(
         self, response: requests.Response, body: dict[str, Any]

--- a/backend/onyx/sandbox_proxy/resolvers/external_app.py
+++ b/backend/onyx/sandbox_proxy/resolvers/external_app.py
@@ -1,7 +1,8 @@
 """External-app credential resolver.
 
 Claims a request iff the matcher has attributed it to a connected `ExternalApp`
-(`ctx.matched_actions is not None`) and renders the app's `auth_template` from the org +
+(`ctx.matched_actions is not None`) and renders the matched action's auth
+template (catalog override, else the app's stored `auth_template`) from the org +
 per-user credentials via `resolve_injection_headers`. Per-header fail-open
 behaviour for missing placeholders lives in `build_auth_headers`.
 """
@@ -54,7 +55,10 @@ class ExternalAppResolver(CredentialResolver):
 
         with get_session_with_tenant(tenant_id=ctx.sandbox.tenant_id) as db:
             headers = resolve_injection_headers(
-                db, matched_actions.external_app_id, ctx.sandbox.user_id
+                db,
+                matched_actions.external_app_id,
+                ctx.sandbox.user_id,
+                action_types=[a.action_type for a in matched_actions.actions],
             )
 
         # Per-app debug line so `external_app_id` survives in logs even when

--- a/backend/onyx/skills/builtin/github/SKILL.md.template
+++ b/backend/onyx/skills/builtin/github/SKILL.md.template
@@ -1,6 +1,6 @@
 ---
 name: github
-description: Read repositories, issues, and pull requests, open new issues, and add comments in GitHub on the user's behalf via the GitHub CLI (gh).
+description: Clone and read repositories, issues, and pull requests, open new issues, add comments, and push changes in GitHub on the user's behalf via git and the GitHub CLI (gh).
 ---
 
 # GitHub
@@ -25,6 +25,15 @@ gh api user
 ```
 gh repo view OWNER/REPO
 gh repo list [OWNER] [--limit N]
+```
+
+### Clone or fetch a repository
+
+Clone with the plain HTTPS URL — no token in the URL, auth is injected on the
+wire. `git fetch`/`pull` work the same way.
+
+```
+git clone https://github.com/OWNER/REPO
 ```
 
 ### Issues
@@ -86,9 +95,11 @@ the command failed — surface the error rather than retrying blindly.
 
 ## Notes
 
-- **HTTPS only.** SSH and `github.com` git remotes are unreachable from here, so
-  `git clone`/`push` against GitHub and `gh repo clone` over SSH will fail. Stay
-  on the API commands above (and `gh api`).
+- **HTTPS only.** SSH remotes (`git@github.com`) are unreachable from here —
+  always use `https://github.com/...` URLs for git. `git clone`/`fetch`/`pull`
+  run as the connected user; `git push` may pause for the user's approval, and
+  the proxy rejects pushes over ~1 MiB of pack data — report that limit to the
+  user instead of retrying.
 - **Scopes are fixed** by the admin (repo, read:org, read:user). An operation
   needing a scope you don't have returns `403 / Resource not accessible` — tell
   the user rather than retrying.

--- a/backend/tests/unit/external_apps/test_action_policy_defaults.py
+++ b/backend/tests/unit/external_apps/test_action_policy_defaults.py
@@ -7,6 +7,8 @@ to ``ASK``). The write path persists only deviations from that default
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from onyx.db.enums import EndpointPolicy
@@ -25,7 +27,9 @@ class _TestAction(ExternalAppAction):
 def _spec(
     action: _TestAction, default_policy: EndpointPolicy | None = None
 ) -> EndpointSpec:
-    kwargs = {} if default_policy is None else {"default_policy": default_policy}
+    kwargs: dict[str, Any] = (
+        {} if default_policy is None else {"default_policy": default_policy}
+    )
     return EndpointSpec(
         id=action,
         normalised_name=action.value,

--- a/backend/tests/unit/external_apps/test_github_catalog.py
+++ b/backend/tests/unit/external_apps/test_github_catalog.py
@@ -70,6 +70,10 @@ def _graphql(query: str) -> bytes:
         ("GET", "/repos/onyx/onyx/commits/abc123", {GitHubAction.GIT_DATA_READ}),
         ("GET", "/repos/onyx/onyx/releases", {GitHubAction.RELEASES_READ}),
         ("GET", "/repos/onyx/onyx/releases/latest", {GitHubAction.RELEASES_READ}),
+        # git smart-HTTP endpoints (on github.com; matching is host-blind).
+        ("GET", "/onyx/onyx/info/refs", {GitHubAction.GIT_READ}),
+        ("POST", "/onyx/onyx.git/git-upload-pack", {GitHubAction.GIT_READ}),
+        ("POST", "/onyx/onyx/git-receive-pack", {GitHubAction.GIT_PUSH}),
         # Writes.
         (
             "PUT",
@@ -166,12 +170,14 @@ def test_rest_request_does_not_trigger_graphql_match() -> None:
         (GitHubAction.CONTENTS_READ, EndpointPolicy.ALWAYS),
         (GitHubAction.GIT_DATA_READ, EndpointPolicy.ALWAYS),
         (GitHubAction.RELEASES_READ, EndpointPolicy.ALWAYS),
+        (GitHubAction.GIT_READ, EndpointPolicy.ALWAYS),
         # Writes require approval out of the box.
         (GitHubAction.ISSUES_CREATE, EndpointPolicy.ASK),
         (GitHubAction.COMMENTS_CREATE, EndpointPolicy.ASK),
         (GitHubAction.CONTENTS_WRITE, EndpointPolicy.ASK),
         (GitHubAction.REFS_WRITE, EndpointPolicy.ASK),
         (GitHubAction.PULLS_CREATE, EndpointPolicy.ASK),
+        (GitHubAction.GIT_PUSH, EndpointPolicy.ASK),
     ],
 )
 def test_default_policies(

--- a/backend/tests/unit/external_apps/test_github_provider.py
+++ b/backend/tests/unit/external_apps/test_github_provider.py
@@ -1,0 +1,115 @@
+"""GitHub provider git-over-HTTPS support: URL claiming and the Basic auth
+scheme git endpoints require. Catalog route/policy coverage lives in
+``test_github_catalog.py``."""
+
+from __future__ import annotations
+
+import base64
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from onyx.db.enums import ExternalAppType
+from onyx.db.models import ExternalApp
+from onyx.external_apps import credentials as credentials_mod
+from onyx.external_apps.credentials import build_auth_headers
+from onyx.external_apps.credentials import resolve_injection_headers
+from onyx.external_apps.providers.github import GitHubAction
+from onyx.external_apps.providers.github import GitHubProvider
+from onyx.external_apps.providers.registry import PROVIDERS
+from onyx.sandbox_proxy.request_evaluator import resolve_app_for_url
+
+_CLONE_URLS = [
+    "https://github.com/onyx-dot-app/onyx/info/refs?service=git-upload-pack",
+    "https://github.com/onyx-dot-app/onyx.git/info/refs?service=git-receive-pack",
+    "https://github.com/onyx-dot-app/onyx/git-upload-pack",
+    "https://github.com/onyx-dot-app/onyx.git/git-receive-pack",
+]
+
+_UNCLAIMED_GITHUB_URLS = [
+    "https://github.com/login/oauth/authorize?client_id=x",
+    "https://github.com/onyx-dot-app/onyx",  # repo HTML page
+    "https://github.com/onyx-dot-app/onyx/releases/download/v1/asset.tgz",
+]
+
+_EXPECTED_BASIC = base64.b64encode(b"x-access-token:gho_token123").decode()
+
+
+def _provider() -> GitHubProvider:
+    provider = PROVIDERS[ExternalAppType.GITHUB]
+    assert isinstance(provider, GitHubProvider)
+    return provider
+
+
+def _spec_app() -> ExternalApp:
+    return ExternalApp(
+        app_type=ExternalAppType.GITHUB,
+        upstream_url_patterns=list(_provider().spec.descriptor.upstream_url_patterns),
+    )
+
+
+def test_patterns_claim_git_smart_http_only() -> None:
+    app = _spec_app()
+    for url in _CLONE_URLS:
+        assert resolve_app_for_url(url, [app]) is app, url
+    for url in _UNCLAIMED_GITHUB_URLS:
+        assert resolve_app_for_url(url, [app]) is None, url
+    # The API host stays claimed.
+    assert resolve_app_for_url("https://api.github.com/user", [app]) is app
+
+
+def test_git_actions_render_basic_auth() -> None:
+    """The git actions' catalog ``auth_template`` + ``derive_credentials``
+    together produce the Basic header github.com's git endpoints require."""
+    provider = _provider()
+    by_action = {e.id: e for e in provider.spec.endpoint_catalog}
+
+    template = by_action[GitHubAction.GIT_READ].auth_template
+    assert template is not None
+    assert by_action[GitHubAction.GIT_PUSH].auth_template == template
+
+    creds = provider.derive_credentials({"access_token": "gho_token123"})
+    assert build_auth_headers(template, creds) == {
+        "Authorization": f"Basic {_EXPECTED_BASIC}"
+    }
+
+
+def test_derive_credentials_without_token_is_a_noop() -> None:
+    assert _provider().derive_credentials({}) == {}
+
+
+def test_resolve_injection_headers_selects_template_by_action(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Git actions render their catalog override (Basic); everything else —
+    including no matched actions — renders the app's stored Bearer template."""
+    app = MagicMock()
+    app.skill.enabled = True
+    app.app_type = ExternalAppType.GITHUB
+    app.auth_template = {"Authorization": "Bearer {access_token}"}
+    app.organization_credentials.get_value.return_value = {
+        "access_token": "gho_token123"
+    }
+    monkeypatch.setattr(credentials_mod, "get_external_app_by_id", lambda *_a: app)
+    monkeypatch.setattr(
+        credentials_mod,
+        "get_external_app_user_credential",
+        lambda *_a, **_k: None,
+    )
+
+    def _resolve(action_types: list[str] | None) -> dict[str, str]:
+        return resolve_injection_headers(
+            MagicMock(), 1, uuid4(), action_types=action_types
+        )
+
+    assert _resolve([GitHubAction.GIT_READ.value]) == {
+        "Authorization": f"Basic {_EXPECTED_BASIC}"
+    }
+    assert _resolve([GitHubAction.GIT_PUSH.value]) == {
+        "Authorization": f"Basic {_EXPECTED_BASIC}"
+    }
+    assert _resolve([GitHubAction.REPOS_READ.value]) == {
+        "Authorization": "Bearer gho_token123"
+    }
+    assert _resolve(None) == {"Authorization": "Bearer gho_token123"}

--- a/backend/tests/unit/sandbox_proxy/test_external_app_resolver.py
+++ b/backend/tests/unit/sandbox_proxy/test_external_app_resolver.py
@@ -63,13 +63,19 @@ def test_resolve_forwards_external_app_id_user_id_and_tenant(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The resolver opens a tenant-scoped session and forwards
-    `(external_app_id, user_id)` to the renderer."""
+    `(external_app_id, user_id, action_types)` to the renderer."""
     captured: dict[str, Any] = {}
 
-    def _fake(db: Any, external_app_id: int, user_id: Any) -> dict[str, str]:
+    def _fake(
+        db: Any,
+        external_app_id: int,
+        user_id: Any,
+        action_types: list[str] | None = None,
+    ) -> dict[str, str]:
         captured["db"] = db
         captured["external_app_id"] = external_app_id
         captured["user_id"] = user_id
+        captured["action_types"] = action_types
         return {"Authorization": "Bearer real"}
 
     monkeypatch.setattr(external_app, "resolve_injection_headers", _fake)
@@ -86,6 +92,7 @@ def test_resolve_forwards_external_app_id_user_id_and_tenant(
     assert headers == {"Authorization": "Bearer real"}
     assert captured["external_app_id"] == 99
     assert captured["user_id"] == ctx.sandbox.user_id
+    assert captured["action_types"] == [a.action_type for a in matched_actions.actions]
     assert ops == ["session:tenant-7"]
 
 


### PR DESCRIPTION
## Description
When craft runs `git pull ....` on a private repo, this currently goes to a 'smart github endpoint'. We currently do not handle these endpoints. This means that git pull is currently not supported for private repos. This PR adds support to the smart github endpoint, allowing this to work

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds git-over-HTTPS support for GitHub so clone/fetch/pull and push work with private repos by switching git endpoints to Basic auth while keeping API calls on Bearer. Introduces per-action auth template overrides and provider-derived credentials to pick the right scheme automatically.

- **Bug Fixes**
  - Added catalog actions `github.git.read` (info/refs, upload-pack) and `github.git.push` (receive-pack) and claimed `github.com` smart-HTTP URLs; private `git pull` now works. Existing apps are updated via an Alembic migration.
  - Implemented Basic auth for git endpoints using `x-access-token:<token>`; API routes continue to use Bearer.
  - Resolver now forwards matched action types so per-action `auth_template` overrides are applied correctly.
  - Updated upstream URL patterns and GitHub skill docs; added unit tests for URL claiming, Basic header rendering, and resolver wiring.

- **New Features**
  - `EndpointSpec.auth_template` for per-action auth overrides.
  - `ExternalAppProvider.derive_credentials` to compute values like `access_token_basic` for templates.

<sup>Written for commit d405d8574c971c7b83ab5df15b849cbc9873cbda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11946?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

