### PR TITLE
fix(craft): Fix docker compose integration test log matching

### DIFF
--- a/backend/tests/integration/tests/craft/docker_e2e/test_approval_gate_docker.py
+++ b/backend/tests/integration/tests/craft/docker_e2e/test_approval_gate_docker.py
@@ -426,7 +426,7 @@ def test_iptables_rejects_bypass_attempts(
 def test_unlabeled_container_gets_unidentified_sandbox_403() -> None:
     """
     A non-sandbox container on the bridge that hits the proxy must get a 403 + a
-    ``gate.unidentified_sandbox`` warning in the proxy logs. Proves
+    ``identity_unknown_sandbox`` warning in the proxy logs. Proves
     DockerEventsLookup rejects unknown source IPs and the observability hook we
     added in branch 6 still fires.
     """
@@ -463,8 +463,8 @@ def test_unlabeled_container_gets_unidentified_sandbox_403() -> None:
         timeout=10,
         check=False,
     )
-    assert "gate.unidentified_sandbox" in proxy_logs.stderr + proxy_logs.stdout, (
-        f"Proxy did not log gate.unidentified_sandbox warning. Recent "
+    assert "identity_unknown_sandbox" in proxy_logs.stderr + proxy_logs.stdout, (
+        f"Proxy did not log identity_unknown_sandbox warning. Recent "
         f"logs:\n{proxy_logs.stdout[-2000:]}"
     )
 


### PR DESCRIPTION
## Description

#11867 changed some logging, the test needs to be adjusted.

## How Has This Been Tested?

It is the test.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Docker Compose integration test by updating the expected proxy log warning from gate.unidentified_sandbox to identity_unknown_sandbox, aligning with the logging change in #11867 and preventing a false failure when an unlabeled container gets a 403.

<sup>Written for commit 55dc11c6a53b47dc4dc29a74eadfab8d45fb7a6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11947?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

