### PR TITLE
fix(CORS): Never pair wildcard CORS origins with allow_credentials (ENG-4126)

### DIFF
--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -168,6 +168,7 @@ from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
 from onyx.utils.variable_functionality import fetch_versioned_implementation
 from onyx.utils.variable_functionality import global_version
 from onyx.utils.variable_functionality import set_is_ee_based_on_env_variable
+from shared_configs.configs import CORS_ALLOW_CREDENTIALS
 from shared_configs.configs import CORS_ALLOWED_ORIGIN
 from shared_configs.configs import MULTI_TENANT
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
@@ -691,10 +692,17 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
 
     application.add_exception_handler(ValueError, value_error_handler)
 
+    if not CORS_ALLOW_CREDENTIALS:
+        logger.warning(
+            "CORS_ALLOWED_ORIGIN is unset or contains '*'; cross-origin "
+            "requests will be served without credentials. Set "
+            "CORS_ALLOWED_ORIGIN to your frontend origin(s) to allow "
+            "credentialed cross-origin requests."
+        )
     application.add_middleware(
         CORSMiddleware,
         allow_origins=CORS_ALLOWED_ORIGIN,  # Configurable via environment variable
-        allow_credentials=True,
+        allow_credentials=CORS_ALLOW_CREDENTIALS,
         allow_methods=["*"],
         allow_headers=["*"],
     )

--- a/backend/onyx/mcp_server/api.py
+++ b/backend/onyx/mcp_server/api.py
@@ -20,6 +20,7 @@ from onyx.mcp_server.auth import OnyxTokenVerifier
 from onyx.mcp_server.utils import shutdown_http_client
 from onyx.utils.logger import setup_logger
 from onyx.utils.variable_functionality import set_is_ee_based_on_env_variable
+from shared_configs.configs import cors_allow_credentials
 
 logger = setup_logger()
 
@@ -101,7 +102,7 @@ def create_mcp_fastapi_app() -> FastAPI:
         app.add_middleware(
             CORSMiddleware,
             allow_origins=MCP_SERVER_CORS_ORIGINS,
-            allow_credentials=True,
+            allow_credentials=cors_allow_credentials(MCP_SERVER_CORS_ORIGINS),
             allow_methods=["*"],
             allow_headers=["*"],
         )

--- a/backend/shared_configs/configs.py
+++ b/backend/shared_configs/configs.py
@@ -139,28 +139,35 @@ def validate_cors_origin(origin: str) -> None:
 
 
 # Examples of valid values for the environment variable:
-# - "" (allow all origins)
+# - "" (allow all origins, credentials disabled)
 # - "http://example.com" (single origin)
 # - "http://example.com,https://example.org" (multiple origins)
-# - "*" (allow all origins)
+# - "*" (allow all origins, credentials disabled)
 CORS_ALLOWED_ORIGIN_ENV = os.environ.get("CORS_ALLOWED_ORIGIN", "")
 
-# Explicitly declare the type of CORS_ALLOWED_ORIGIN
-CORS_ALLOWED_ORIGIN: List[str]
 
-if CORS_ALLOWED_ORIGIN_ENV:
-    # Split the environment variable into a list of origins
-    CORS_ALLOWED_ORIGIN = [
-        origin.strip()
-        for origin in CORS_ALLOWED_ORIGIN_ENV.split(",")
-        if origin.strip()
-    ]
-    # Validate each origin in the list
-    for origin in CORS_ALLOWED_ORIGIN:
-        validate_cors_origin(origin)
-else:
-    # If the environment variable is empty, allow all origins
-    CORS_ALLOWED_ORIGIN = ["*"]
+def parse_cors_allowed_origins(env_value: str) -> List[str]:
+    origins = [origin.strip() for origin in env_value.split(",") if origin.strip()]
+    if not origins:
+        # If the environment variable is empty, allow all origins
+        return ["*"]
+    for origin in origins:
+        if origin != "*":
+            validate_cors_origin(origin)
+    return origins
+
+
+def cors_allow_credentials(allowed_origins: List[str]) -> bool:
+    # A wildcard origin must never be paired with allow_credentials=True:
+    # browsers reject "Access-Control-Allow-Origin: *" on credentialed
+    # responses, and Starlette compensates by echoing arbitrary request
+    # Origins on preflights, which would let any site make credentialed
+    # (cookie-authenticated) cross-origin requests.
+    return "*" not in allowed_origins
+
+
+CORS_ALLOWED_ORIGIN: List[str] = parse_cors_allowed_origins(CORS_ALLOWED_ORIGIN_ENV)
+CORS_ALLOW_CREDENTIALS: bool = cors_allow_credentials(CORS_ALLOWED_ORIGIN)
 
 
 # Multi-tenancy configuration

--- a/backend/tests/unit/shared_configs/test_cors_config.py
+++ b/backend/tests/unit/shared_configs/test_cors_config.py
@@ -1,0 +1,41 @@
+import pytest
+
+from shared_configs.configs import cors_allow_credentials
+from shared_configs.configs import parse_cors_allowed_origins
+
+
+def test_empty_env_allows_all_origins_without_credentials() -> None:
+    origins = parse_cors_allowed_origins("")
+    assert origins == ["*"]
+    assert cors_allow_credentials(origins) is False
+
+
+def test_explicit_wildcard_disables_credentials() -> None:
+    origins = parse_cors_allowed_origins("*")
+    assert origins == ["*"]
+    assert cors_allow_credentials(origins) is False
+
+
+def test_single_origin_keeps_credentials() -> None:
+    origins = parse_cors_allowed_origins("http://localhost:3000")
+    assert origins == ["http://localhost:3000"]
+    assert cors_allow_credentials(origins) is True
+
+
+def test_multiple_origins_parsed_and_stripped() -> None:
+    origins = parse_cors_allowed_origins(
+        " https://onyx.example.com , http://localhost:3000 ,"
+    )
+    assert origins == ["https://onyx.example.com", "http://localhost:3000"]
+    assert cors_allow_credentials(origins) is True
+
+
+def test_wildcard_mixed_with_explicit_origins_disables_credentials() -> None:
+    origins = parse_cors_allowed_origins("https://onyx.example.com,*")
+    assert origins == ["https://onyx.example.com", "*"]
+    assert cors_allow_credentials(origins) is False
+
+
+def test_invalid_origin_rejected() -> None:
+    with pytest.raises(ValueError):
+        parse_cors_allowed_origins("not-a-url")

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -239,6 +239,9 @@ LOG_ONYX_MODEL_INTERACTIONS=False
 # OPENID_CONFIG_URL=
 # OIDC_PKCE_ENABLED=
 # TRACK_EXTERNAL_IDP_EXPIRY=
+# Comma-separated list of origins allowed to make cross-origin (CORS) requests,
+# e.g. "https://onyx.example.com". When unset, all origins are allowed but
+# credentialed (cookie-authenticated) cross-origin requests are disabled.
 # CORS_ALLOWED_ORIGIN=
 # INTEGRATION_TESTS_MODE=
 # JWT_PUBLIC_KEY_URL=


### PR DESCRIPTION
## Description

Linear: ENG-4126

Fixes a pentest finding (medium): when `CORS_ALLOWED_ORIGIN` is unset, the global `CORSMiddleware` in `main.py` ran with `allow_origins=["*"]` **and** `allow_credentials=True`.

This is worse than just config hygiene on our Starlette version (0.49.3): when credentials are enabled with a wildcard, Starlette sets `preflight_explicit_allow_origin` and **echoes the arbitrary request `Origin` back on preflight responses** together with `Access-Control-Allow-Credentials: true` — so any website could make credentialed (cookie-authenticated, preflighted) cross-origin requests on behalf of a logged-in user.

Changes:

- `shared_configs/configs.py`: CORS origin parsing moved into `parse_cors_allowed_origins()`, and a new `CORS_ALLOW_CREDENTIALS` flag is computed via `cors_allow_credentials()` — credentials are disabled whenever the origin list contains `"*"` (default-unset or explicit). Explicitly configured origins keep credentials enabled.
- `onyx/main.py`: middleware uses `allow_credentials=CORS_ALLOW_CREDENTIALS` and logs a startup warning pointing operators at `CORS_ALLOWED_ORIGIN` when running with the wildcard.
- `onyx/mcp_server/api.py`: same guard applied to `MCP_SERVER_CORS_ORIGINS`.
- `deployment/docker_compose/env.template`: documents the variable and the new unset behavior.
- Also fixes a latent bug: `CORS_ALLOWED_ORIGIN="*"` is a documented value but previously crashed `validate_cors_origin` on startup.

Backward compatibility: standard deployments are unaffected (the web server proxies `/api`, so requests are same-origin and CORS never applies; non-credentialed wildcard access still works). Deployments serving the frontend from a different origin than the API **with cookie auth** were relying on the vulnerable echo behavior and must now set `CORS_ALLOWED_ORIGIN` to their frontend origin(s) — which is the pentest-recommended configuration.

## How Has This Been Tested?

- New unit tests: `backend/tests/unit/shared_configs/test_cors_config.py` (parsing, wildcard/explicit/mixed credential gating, invalid-origin rejection).
- Manual `TestClient` verification of the middleware with both configs:
  - unset → preflight from `https://evil.example` returns `ACAO: *` with **no** `Access-Control-Allow-Credentials` (previously echoed the evil origin with credentials);
  - `CORS_ALLOWED_ORIGIN=http://localhost:3000` → evil origin rejected (400, no ACAO), configured origin echoed with credentials.
- `pre-commit` (ruff, ty, etc.) passes on changed files.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop pairing wildcard CORS origins with credentials to close ENG-4126. This removes a pentest-reported path where an unset `CORS_ALLOWED_ORIGIN` let any site make cookie‑authenticated cross‑origin requests.

- **Bug Fixes**
  - Added a `cors_allow_credentials` guard: credentials are disabled when allowed origins include `*`; explicit origins keep credentials.
  - Applied the guard to API and MCP server CORS config; added a startup warning when credentials are off.
  - Fixed support for `CORS_ALLOWED_ORIGIN="*"` and documented the new default; added unit tests for parsing and validation.

- **Migration**
  - If your frontend is on a different origin and uses cookies, set `CORS_ALLOWED_ORIGIN` to your frontend origin(s) to allow credentialed CORS.

<sup>Written for commit b9ac6663dffc15f6a1ae86e5f7be4478eaf4f5ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

