### PR TITLE
feat(load-tests): in-cluster harness image + k8s manifests for mock LLM and Locust 2/n

### DIFF
--- a/loadtest/Dockerfile
+++ b/loadtest/Dockerfile
@@ -1,0 +1,12 @@
+# Locust harness image for running the chat load tests in-cluster.
+# Build from the loadtest/ directory:  docker build -t onyx-loadtest .
+# Master/worker mode and run flags are supplied by the deployment (see k8s/).
+ARG BASE_IMAGE_REGISTRY=docker.io
+# Keep the tag in sync with the locust pin in uv.lock.
+FROM ${BASE_IMAGE_REGISTRY}/locustio/locust:2.44.1
+
+COPY locustfile.py /loadtest/locustfile.py
+COPY onyx_client /loadtest/onyx_client
+COPY scenarios /loadtest/scenarios
+
+ENTRYPOINT ["locust", "-f", "/loadtest/locustfile.py"]

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -68,14 +68,14 @@ their resources open longer, which is exactly what stresses the api-server):
 ## Running
 
 ```bash
-ONYX_API_KEY=<key> uv run locust --headless -u 5 -r 1 -t 5m -H https://st-dev.onyx.app
+ONYX_API_KEY=<key> uv run locust --headless -u 5 -r 1 -t 5m -H https://<your-onyx-url>
 ```
 
 Scenario selection (all run by default; pick classes explicitly):
 
 ```bash
-... uv run locust --headless -u 10 -r 2 -t 10m -H https://st-dev.onyx.app BasicChatUser ChatWithSearchUser
-... uv run locust --headless -u 5 -r 1 -t 20m -H https://st-dev.onyx.app DeepResearchUser
+... uv run locust --headless -u 10 -r 2 -t 10m -H https://<your-onyx-url> BasicChatUser ChatWithSearchUser
+... uv run locust --headless -u 5 -r 1 -t 20m -H https://<your-onyx-url> DeepResearchUser
 ```
 
 - **BasicChatUser** (`chat:*` metrics) — single-turn chat, plain answer.
@@ -125,12 +125,31 @@ packet (truncation).
 ```bash
 cd loadtest && docker build -f mock_llm/Dockerfile -t onyx-mock-llm .
 docker run -p 8001:8000 onyx-mock-llm
+
+# Locust harness image (locustfile + scenarios baked in, for k8s/)
+docker build -t onyx-loadtest .
 ```
+
+## In-cluster (`k8s/`)
+
+Run the whole rig inside the target cluster so latency measurements aren't
+polluted by WAN jitter and the LLM stays free:
+
+1. `kubectl apply -n <onyx-namespace> -f k8s/mock-llm.yaml`, then register
+   `http://onyx-mock-llm:8000` as an `openai_compatible` provider (see Mock
+   LLM server above; keep it `is_public=false` and persona-scoped so real
+   users never see it).
+2. `kubectl create secret generic onyx-loadtest --from-literal=ONYX_API_KEY=...`
+3. `kubectl apply -n <onyx-namespace> -f k8s/locust.yaml`, then
+   `kubectl port-forward svc/onyx-loadtest-master 8089:8089` and drive runs
+   from the web UI. Scale `onyx-loadtest-worker` replicas for bigger runs,
+   and pin workers to a dedicated nodegroup if available (see comments in
+   the manifest).
 
 ## Roadmap
 
 - ✅ Phase 0: harness + milestones + mock LLM core
 - ✅ Phase 1: tool-call & deep-research scripting, scenarios, Dockerfile
-- Phase 2: in-cluster Locust master/workers + mock provider on st-dev (`k8s/`)
+- Phase 2: in-cluster Locust master/workers + mock provider (`k8s/`)
 - Phase 3: weighted scenario mixes, multi-turn sessions, open-workload arrivals
 - Phase 4: Prometheus export + Grafana correlation dashboard

--- a/loadtest/k8s/locust.yaml
+++ b/loadtest/k8s/locust.yaml
@@ -38,7 +38,7 @@ spec:
         - name: locust-master
           # Pinned tag: in distributed mode every pod must run the same build
           # or results are silently corrupted.
-          image: onyxdotapp/onyx-loadtest:v0.1.0
+          image: <your-registry>/onyx-loadtest:v0.1.0
           imagePullPolicy: IfNotPresent
           args: ["--master"]
           ports:
@@ -102,7 +102,7 @@ spec:
       # tolerations: [{ key: loadtest, operator: Exists, effect: NoSchedule }]
       containers:
         - name: locust-worker
-          image: onyxdotapp/onyx-loadtest:v0.1.0
+          image: <your-registry>/onyx-loadtest:v0.1.0
           imagePullPolicy: IfNotPresent
           args: ["--worker", "--master-host", "onyx-loadtest-master"]
           env:

--- a/loadtest/k8s/locust.yaml
+++ b/loadtest/k8s/locust.yaml
@@ -1,0 +1,122 @@
+# Locust master + workers for the Onyx chat load tests, using the harness
+# image built from ../Dockerfile (locustfile + scenarios baked in).
+#
+# Prereqs in the target namespace:
+#   kubectl create secret generic onyx-loadtest --from-literal=ONYX_API_KEY=<key>
+#
+# Apply:   kubectl apply -n <onyx-namespace> -f locust.yaml
+# Drive:   kubectl port-forward svc/onyx-loadtest-master 8089:8089
+#          then start runs from the web UI (host, user count, scenarios), or
+#          edit the master args to run headless (-u/-r/-t/--host).
+#
+# The default host targets the in-cluster web server service, matching the
+# browser path (/api/* proxied to the api server). Point LOCUST_HOST at the
+# external URL instead to exercise the ingress/load-balancer path — both are
+# worth measuring (LB idle timeouts are a classic killer of long streams).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: onyx-loadtest-master
+  labels:
+    app: onyx-loadtest
+    role: master
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: onyx-loadtest
+      role: master
+  template:
+    metadata:
+      labels:
+        app: onyx-loadtest
+        role: master
+    spec:
+      containers:
+        - name: locust-master
+          image: onyxdotapp/onyx-loadtest:latest
+          imagePullPolicy: Always
+          args: ["--master"]
+          ports:
+            - containerPort: 8089 # web UI
+            - containerPort: 5557 # worker communication
+          env:
+            - name: LOCUST_HOST
+              value: "http://onyx-webserver:3000"
+            - name: ONYX_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: onyx-loadtest
+                  key: ONYX_API_KEY
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: onyx-loadtest-master
+  labels:
+    app: onyx-loadtest
+spec:
+  type: ClusterIP
+  selector:
+    app: onyx-loadtest
+    role: master
+  ports:
+    - name: web
+      port: 8089
+      targetPort: 8089
+    - name: comm
+      port: 5557
+      targetPort: 5557
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: onyx-loadtest-worker
+  labels:
+    app: onyx-loadtest
+    role: worker
+spec:
+  # One worker handles hundreds of concurrent streams; scale for bigger runs.
+  replicas: 2
+  selector:
+    matchLabels:
+      app: onyx-loadtest
+      role: worker
+  template:
+    metadata:
+      labels:
+        app: onyx-loadtest
+        role: worker
+    spec:
+      # If the cluster has a dedicated load-generator nodegroup, pin workers
+      # to it so the generator never competes with the system under test:
+      # nodeSelector: { workload: loadtest }
+      # tolerations: [{ key: loadtest, operator: Exists, effect: NoSchedule }]
+      containers:
+        - name: locust-worker
+          image: onyxdotapp/onyx-loadtest:latest
+          imagePullPolicy: Always
+          args: ["--worker", "--master-host", "onyx-loadtest-master"]
+          env:
+            - name: ONYX_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: onyx-loadtest
+                  key: ONYX_API_KEY
+            # Optional scenario tuning (see ../README.md):
+            # ONYX_LLM_PROVIDER, ONYX_SEARCH_MODEL, ONYX_DR_MODEL,
+            # ONYX_WAIT_SECONDS, ONYX_STREAM_READ_TIMEOUT, ...
+          resources:
+            requests:
+              cpu: 500m
+              memory: 512Mi
+            limits:
+              cpu: "2"
+              memory: 1Gi

--- a/loadtest/k8s/locust.yaml
+++ b/loadtest/k8s/locust.yaml
@@ -34,20 +34,19 @@ spec:
     spec:
       containers:
         - name: locust-master
-          image: onyxdotapp/onyx-loadtest:latest
-          imagePullPolicy: Always
+          # Pinned tag: in distributed mode every pod must run the same build
+          # or results are silently corrupted.
+          image: onyxdotapp/onyx-loadtest:v0.1.0
+          imagePullPolicy: IfNotPresent
           args: ["--master"]
           ports:
             - containerPort: 8089 # web UI
             - containerPort: 5557 # worker communication
+          # No ONYX_API_KEY here: the master only coordinates — user
+          # greenlets (and API calls) run on the workers.
           env:
             - name: LOCUST_HOST
               value: "http://onyx-webserver:3000"
-            - name: ONYX_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: onyx-loadtest
-                  key: ONYX_API_KEY
           resources:
             requests:
               cpu: 250m
@@ -101,8 +100,8 @@ spec:
       # tolerations: [{ key: loadtest, operator: Exists, effect: NoSchedule }]
       containers:
         - name: locust-worker
-          image: onyxdotapp/onyx-loadtest:latest
-          imagePullPolicy: Always
+          image: onyxdotapp/onyx-loadtest:v0.1.0
+          imagePullPolicy: IfNotPresent
           args: ["--worker", "--master-host", "onyx-loadtest-master"]
           env:
             - name: ONYX_API_KEY

--- a/loadtest/k8s/locust.yaml
+++ b/loadtest/k8s/locust.yaml
@@ -9,10 +9,12 @@
 #          then start runs from the web UI (host, user count, scenarios), or
 #          edit the master args to run headless (-u/-r/-t/--host).
 #
-# The default host targets the in-cluster web server service, matching the
-# browser path (/api/* proxied to the api server). Point LOCUST_HOST at the
-# external URL instead to exercise the ingress/load-balancer path — both are
-# worth measuring (LB idle timeouts are a classic killer of long streams).
+# LOCUST_HOST must be a URL that serves the browser-equivalent path, i.e.
+# routes /api/* to the api server — in practice the deployment's user-facing
+# URL (ingress/load balancer). The web server service only proxies /api/* in
+# dev-mode builds, and the in-cluster nginx routes by Host header, so neither
+# bare service name works against production images. Going through the
+# ingress also exercises LB idle timeouts — a classic killer of long streams.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -46,7 +48,7 @@ spec:
           # greenlets (and API calls) run on the workers.
           env:
             - name: LOCUST_HOST
-              value: "http://onyx-webserver:3000"
+              value: "https://<your-onyx-url>"
           resources:
             requests:
               cpu: 250m

--- a/loadtest/k8s/mock-llm.yaml
+++ b/loadtest/k8s/mock-llm.yaml
@@ -24,7 +24,7 @@ spec:
         - name: mock-llm
           # Pin the tag: master/workers and mid-run restarts must never pick
           # up a different build (bump deliberately when publishing).
-          image: onyxdotapp/onyx-mock-llm:v0.1.0
+          image: <your-registry>/onyx-mock-llm:v0.1.0
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8000

--- a/loadtest/k8s/mock-llm.yaml
+++ b/loadtest/k8s/mock-llm.yaml
@@ -22,8 +22,10 @@ spec:
     spec:
       containers:
         - name: mock-llm
-          image: onyxdotapp/onyx-mock-llm:latest
-          imagePullPolicy: Always
+          # Pin the tag: master/workers and mid-run restarts must never pick
+          # up a different build (bump deliberately when publishing).
+          image: onyxdotapp/onyx-mock-llm:v0.1.0
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8000
           # Default timing knobs; per-request knobs ride in the model name.

--- a/loadtest/k8s/mock-llm.yaml
+++ b/loadtest/k8s/mock-llm.yaml
@@ -1,0 +1,63 @@
+# Mock LLM server for load testing — deploy alongside an Onyx installation
+# and register as an `openai_compatible` LLM provider with
+# api_base=http://onyx-mock-llm:8000 (see ../README.md for provider setup,
+# including the max-input-tokens >= 50k requirement).
+#
+# Apply into the Onyx namespace:  kubectl apply -n <onyx-namespace> -f mock-llm.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: onyx-mock-llm
+  labels:
+    app: onyx-mock-llm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: onyx-mock-llm
+  template:
+    metadata:
+      labels:
+        app: onyx-mock-llm
+    spec:
+      containers:
+        - name: mock-llm
+          image: onyxdotapp/onyx-mock-llm:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8000
+          # Default timing knobs; per-request knobs ride in the model name.
+          env:
+            - name: MOCK_TTFT_MS
+              value: "300"
+            - name: MOCK_ITL_MS
+              value: "15"
+            - name: MOCK_LEN_TOKENS
+              value: "150"
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 512Mi
+          readinessProbe:
+            httpGet:
+              path: /v1/models
+              port: 8000
+            initialDelaySeconds: 2
+            periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: onyx-mock-llm
+  labels:
+    app: onyx-mock-llm
+spec:
+  type: ClusterIP
+  selector:
+    app: onyx-mock-llm
+  ports:
+    - port: 8000
+      targetPort: 8000

--- a/loadtest/locustfile.py
+++ b/loadtest/locustfile.py
@@ -3,7 +3,7 @@
 Usage (from this directory, after `uv sync`):
 
     ONYX_API_KEY=... uv run locust --headless -u 5 -r 1 -t 5m \
-        -H https://st-dev.onyx.app
+        -H https://<your-onyx-url>
 
 Select scenarios with Locust's class picker, e.g.:
 


### PR DESCRIPTION
## Description

Follow-up to #11938 — makes the load-test rig deployable inside any Onyx Kubernetes installation:

- **`loadtest/Dockerfile`** — bakes the multi-module harness (locustfile, `onyx_client/`, `scenarios/`) into a `locustio/locust` image (tag pinned to match `uv.lock`). Master/worker mode and run flags come from the deployment.
- **`k8s/mock-llm.yaml`** — Deployment + ClusterIP Service for the mock LLM server, with readiness probe and default timing knobs; registered in Onyx as an `openai_compatible` provider pointing at the in-cluster service.
- **`k8s/locust.yaml`** — plain Locust master/worker manifests (API key from a Secret, web UI via port-forward, worker replicas scalable, commented nodeSelector/toleration hooks for a dedicated load-generator nodegroup). With the harness baked into an image, the deliveryhero Helm chart's main feature (ConfigMap-mounted locustfiles, which can't represent nested packages anyway) buys nothing — raw manifests keep it dependency-free.
- README: in-cluster runbook; usage examples now use a generic deployment URL placeholder.

Cluster-specific values (image publication, target environment wiring) intentionally live outside this repo — these manifests are written for any self-hosted deployment.

## How Has This Been Tested?

- All 15 mock-LLM contract tests pass unchanged (`uv run pytest tests/ -q`) — no harness code changes beyond a docstring.
- `docker build` of both images succeeds locally (harness image from `loadtest/`, mock from `mock_llm/`).
- The manifests mirror the exact topology validated end-to-end in #11938's integrated run (mock provider + 3-scenario Locust, 355 events / 0 failures); an in-cluster baseline run will be reported on this PR once the rig is deployed to a dev environment.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an in-cluster load-testing rig for Onyx: a Dockerized Locust harness and Kubernetes manifests for a mock LLM and Locust master/worker. Enables reproducible, dependency-free load tests in any Onyx cluster.

- **New Features**
  - Added `loadtest/Dockerfile` to build the harness image on `locustio/locust:2.44.1`; entrypoint runs `locust`.
  - Added `loadtest/k8s/mock-llm.yaml`: Deployment + ClusterIP Service for the mock LLM with readiness probe and timing envs; register at `http://onyx-mock-llm:8000` as an `openai_compatible` provider.
  - Added `loadtest/k8s/locust.yaml`: Locust master/worker Deployments + Service; image refs use `<your-registry>/...:v0.1.0` placeholders with `IfNotPresent` (no public image; build from `loadtest/` and push to your registry); master has no API key; workers read `ONYX_API_KEY` from a Secret; `LOCUST_HOST` must be the user-facing ingress URL; scalable workers; optional nodeSelector/tolerations.
  - Updated README and `loadtest/locustfile.py`: use `<your-onyx-url>`, add an in-cluster runbook, and document building/pushing images to a private registry.

<sup>Written for commit d2b601cad95c55b6c3bea2ae16e4b132f6fc4d54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

