### PR TITLE
chore(dev): ignore sandbox image files in hot reload

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -194,6 +194,8 @@
         "--reload",
         "--reload-exclude",
         "${workspaceFolder}/backend/onyx/skills/builtin",
+        "--reload-exclude",
+        "${workspaceFolder}/backend/onyx/server/features/build/sandbox/image",
         "--port",
         "8080"
       ],
@@ -222,6 +224,8 @@
         "--reload",
         "--reload-exclude",
         "${workspaceFolder}/backend/onyx/skills/builtin",
+        "--reload-exclude",
+        "${workspaceFolder}/backend/onyx/server/features/build/sandbox/image",
         "--port",
         "8080"
       ],

--- a/backend/scripts/dev_celery_reload.py
+++ b/backend/scripts/dev_celery_reload.py
@@ -30,8 +30,10 @@ from watchfiles import run_process
 # not imported by the worker, so editing them shouldn't trigger a restart.
 # Mirrors BUILTIN_SKILLS_PATH (onyx/skills/built_in.py); kept inline to avoid
 # importing onyx.db into the reloader supervisor just for a path.
-_SKILLS_BUNDLE_DIR = str(
-    Path(__file__).resolve().parents[1] / "onyx" / "skills" / "builtin"
+_BACKEND_DIR = Path(__file__).resolve().parents[1]
+_SKILLS_BUNDLE_DIR = str(_BACKEND_DIR / "onyx" / "skills" / "builtin")
+_SANDBOX_IMAGE_DIR = str(
+    _BACKEND_DIR / "onyx" / "server" / "features" / "build" / "sandbox" / "image"
 )
 
 
@@ -49,5 +51,7 @@ if __name__ == "__main__":
         *watch_paths,
         target=_run,
         args=(celery_argv,),
-        watch_filter=DefaultFilter(ignore_paths=[_SKILLS_BUNDLE_DIR]),
+        watch_filter=DefaultFilter(
+            ignore_paths=[_SKILLS_BUNDLE_DIR, _SANDBOX_IMAGE_DIR]
+        ),
     )


### PR DESCRIPTION
## Description

- Excludes the sandbox image tree from VS Code API hot reload watchers.
- Excludes the same tree from the Celery dev reload watcher to avoid restarts while editing sandbox image files.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude the sandbox image directory from dev hot reload to prevent unnecessary server and worker restarts when editing image files. This reduces noisy reloads and speeds up local development.

- **Bug Fixes**
  - Added `--reload-exclude` for `backend/onyx/server/features/build/sandbox/image` in `.vscode/launch.json` API launch configs.
  - Updated `backend/scripts/dev_celery_reload.py` to ignore the same path in the reload filter.

<sup>Written for commit 34739193eb59c505c0a6dd122930cec11ce3cc63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

