### PR TITLE
fix(craft): use OnyxError in reset sandbox API

### DIFF
--- a/backend/onyx/server/features/build/api/api.py
+++ b/backend/onyx/server/features/build/api/api.py
@@ -36,6 +36,8 @@ from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
 from onyx.db.enums import SharingScope
 from onyx.db.models import User
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.server.features.build.api.debug_api import router as debug_router
 from onyx.server.features.build.api.external_apps_api import (
     router as external_apps_router,
@@ -500,19 +502,13 @@ def reset_sandbox(
     try:
         success = session_manager.terminate_user_sandbox(user.id)
         if not success:
-            raise HTTPException(
-                status_code=404,
-                detail="No sandbox found for user",
-            )
+            raise OnyxError(OnyxErrorCode.NOT_FOUND, "No sandbox found for user")
         db_session.commit()
-    except HTTPException:
+    except OnyxError:
         raise
     except Exception as e:
         db_session.rollback()
         logger.error("Failed to reset sandbox for user %s: %s", user.id, e)
-        raise HTTPException(
-            status_code=500,
-            detail=f"Failed to reset sandbox: {e}",
-        )
+        raise OnyxError(OnyxErrorCode.INTERNAL_ERROR, f"Failed to reset sandbox: {e}")
 
     return Response(status_code=204)


### PR DESCRIPTION
## Description

- Replaces direct HTTPException usage in the reset sandbox API with OnyxError.
- Preserves the not-found and internal-error behavior through the global error handler.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the `reset_sandbox` API to use `OnyxError`/`OnyxErrorCode` instead of `HTTPException`, standardizing error handling while keeping the same 404/500 behavior via the global handler.

- **Refactors**
  - Replace `HTTPException` with `OnyxError` for not-found and internal errors.
  - Preserve 204 success response and commit/rollback flow.
  - Route errors through the global handler for consistent formatting and logging.

<sup>Written for commit fb24a6e7064871315cd42257ba927249b5cddf08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

