### PR TITLE
chore(llm): recommend Claude Fable 5 as default Anthropic model

### DIFF
--- a/backend/onyx/llm/well_known_providers/recommended-models.json
+++ b/backend/onyx/llm/well_known_providers/recommended-models.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.4",
-  "updated_at": "2026-06-04T00:00:00Z",
+  "version": "1.5",
+  "updated_at": "2026-06-11T00:00:00Z",
   "providers": {
     "openai": {
       "default_model": "gpt-5.5",
@@ -11,27 +11,19 @@
       ]
     },
     "anthropic": {
-      "default_model": "claude-opus-4-8",
+      "default_model": "claude-fable-5",
       "additional_visible_models": [
+        {
+          "name": "claude-fable-5",
+          "display_name": "Claude Fable 5"
+        },
         {
           "name": "claude-opus-4-8",
           "display_name": "Claude Opus 4.8"
         },
         {
-          "name": "claude-opus-4-7",
-          "display_name": "Claude Opus 4.7"
-        },
-        {
-          "name": "claude-opus-4-6",
-          "display_name": "Claude Opus 4.6"
-        },
-        {
           "name": "claude-sonnet-4-6",
           "display_name": "Claude Sonnet 4.6"
-        },
-        {
-          "name": "claude-haiku-4-5",
-          "display_name": "Claude Haiku 4.5"
         }
       ]
     },


### PR DESCRIPTION
## Description

Updates the bundled `recommended-models.json` (v1.4 → v1.5) to make **Claude Fable 5** the recommended default Anthropic model.

- `default_model` for the `anthropic` provider is now `claude-fable-5`
- Visible models reordered: Claude Fable 5 → Claude Opus 4.8 → Claude Sonnet 4.6
- Removed Claude Opus 4.7, Claude Opus 4.6, and Claude Haiku 4.5 from the recommended visible list (they remain available as non-visible options via litellm's model list)

## How Has This Been Tested?

- Verified the bundled JSON loads through `_load_bundled_recommendations()` with the expected default and visible-model ordering
- `pytest backend/tests/unit/onyx/llm/test_llm_provider_options.py` — 4 passed

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `claude-fable-5` as the default `anthropic` model and update the visible recommendations list. Bumps the bundled `recommended-models.json` to v1.5, reorders Anthropic models to Fable 5 → Opus 4.8 → Sonnet 4.6, and hides Opus 4.7, Opus 4.6, and Haiku 4.5 (still available via `litellm`).

<sup>Written for commit d8def30c5d4be15a88c1ad9d2841a0df4b388a6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

