### PR TITLE
fix(helm): validate Craft sandbox proxy config

### DIFF
--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -333,21 +333,20 @@ _NO_PROXY_LIST = "127.0.0.1,localhost"
 def _proxy_env_vars(
     *,
     sandbox_proxy_host: str,
-    sandbox_proxy_port: int,
 ) -> dict[str, str]:
     """Proxy-enabled env additions for the sandbox container.
 
     Mirrors ``kubernetes_sandbox_manager._proxy_main_container_env_vars`` but
     layered on the docker env dict instead of a list of V1EnvVars. Includes the
-    firewall-init.sh contract vars (``SANDBOX_PROXY_*``,
-    ``CA_BUNDLE_SRC``/``DST``) since the script runs as the container's
-    entrypoint wrapper and reads them from its own environment.
+    firewall-init.sh contract vars since the script runs as the container's
+    entrypoint wrapper and reads them from its own environment. Proxy ports come
+    from build config and are injected as internal env, not caller arguments.
     """
-    proxy_url = f"http://{sandbox_proxy_host}:{sandbox_proxy_port}"
+    proxy_url = f"http://{sandbox_proxy_host}:{SANDBOX_PROXY_PORT}"
     return {
         # firewall-init.sh contract.
         "SANDBOX_PROXY_HOST": sandbox_proxy_host,
-        "SANDBOX_PROXY_PORT": str(sandbox_proxy_port),
+        "SANDBOX_PROXY_PORT": str(SANDBOX_PROXY_PORT),
         "SANDBOX_PROXY_BOOTSTRAP_MODE": "entrypoint",
         "SANDBOX_PROXY_CA_BUNDLE_SRC": f"{_PROXY_CA_SOURCE_DIR}/ca.crt",
         "SANDBOX_PROXY_CA_BUNDLE_DST": _PROXY_CA_BUNDLE_FILE,
@@ -423,7 +422,6 @@ def build_container_create_kwargs(
     opencode_config_json: str,
     compose_project: str | None = None,
     sandbox_proxy_host: str | None = None,
-    sandbox_proxy_port: int | None = None,
     proxy_ca_volume_name: str | None = None,
 ) -> ContainerCreateKwargs:
     """Builds the kwargs dict for ``DockerClient.containers.create``.
@@ -449,8 +447,9 @@ def build_container_create_kwargs(
     ``--include-craft``):
 
     - Env layered with ``HTTPS_PROXY`` / SDK CA vars + the ``firewall-init.sh``
-      contract vars (``SANDBOX_PROXY_BOOTSTRAP_MODE= entrypoint``,
-      ``CA_BUNDLE_SRC``/``DST``). The legacy 4-key core is preserved; proxy keys
+      contract vars (``SANDBOX_PROXY_HOST``, ``SANDBOX_PROXY_PORT``,
+      ``SANDBOX_PROXY_BOOTSTRAP_MODE=entrypoint``, ``CA_BUNDLE_SRC``/``DST``).
+      The legacy 4-key core is preserved; proxy keys
       are layered on top.
     - ``ONYX_PAT`` and the opencode ``api_key`` are replaced with
       ``SANDBOX_PROXY_INJECTED_PLACEHOLDER``; the proxy reads the real values
@@ -515,16 +514,15 @@ def build_container_create_kwargs(
     }
 
     if sandbox_proxy_host:
-        # All-or-nothing: port + ca volume must be supplied when host is.
-        if sandbox_proxy_port is None or not proxy_ca_volume_name:
+        # All-or-nothing: ca volume must be supplied when host is.
+        if not proxy_ca_volume_name:
             raise ValueError(
-                "sandbox_proxy_host is set but sandbox_proxy_port or proxy_ca_volume_name is "
-                "missing; Proxy posture requires all three."
+                "sandbox_proxy_host is set but proxy_ca_volume_name is missing; "
+                "Proxy posture requires both."
             )
         env.update(
             _proxy_env_vars(
                 sandbox_proxy_host=sandbox_proxy_host,
-                sandbox_proxy_port=sandbox_proxy_port,
             )
         )
         volumes[proxy_ca_volume_name] = {
@@ -857,7 +855,6 @@ class DockerSandboxManager(SandboxManager):
             opencode_config_json=opencode_config_json,
             compose_project=self._compose_project,
             sandbox_proxy_host=proxy_host,
-            sandbox_proxy_port=SANDBOX_PROXY_PORT if proxy_host else None,
             proxy_ca_volume_name=(SANDBOX_PROXY_CA_VOLUME_NAME if proxy_host else None),
         )
         try:

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_manager_config.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_manager_config.py
@@ -153,7 +153,6 @@ def proxy_kwargs() -> ContainerCreateKwargs:
         opencode_password=_OPENCODE_PASSWORD,
         opencode_config_json=_OPENCODE_CONFIG_JSON,
         sandbox_proxy_host="sandbox-proxy",
-        sandbox_proxy_port=8080,
         proxy_ca_volume_name="sandbox_proxy_ca",
     )
 
@@ -463,7 +462,7 @@ def test_proxy_kwargs_env_contains_proxy_and_ca_keys(
 ) -> None:
     """
     Env must wire HTTPS_PROXY + the SDK CA envs + firewall-init.sh's own
-    contract vars (bootstrap mode + CA paths).
+    contract vars.
     """
     env = proxy_kwargs["environment"]
     # The legacy 4-key core is preserved; ONYX_PAT is the proxy placeholder in
@@ -578,22 +577,9 @@ def test_no_proxy_kwargs_keep_legacy_command(kwargs: ContainerCreateKwargs) -> N
     assert kwargs["command"] == ["/workspace/entrypoint.sh"]
 
 
-@pytest.mark.parametrize(
-    "port, ca_volume",
-    [
-        (None, "sandbox_proxy_ca"),
-        (8080, None),
-    ],
-)
-def test_proxy_kwargs_requires_port_and_ca_volume(
-    port: int | None, ca_volume: str | None
-) -> None:
-    """
-    All-or-nothing: setting the proxy host without BOTH port and CA volume is a
-    misconfiguration and must raise loudly. Cover each missing piece separately
-    so a short-circuiting guard can't pass.
-    """
-    with pytest.raises(ValueError, match="Proxy posture requires all three"):
+def test_proxy_kwargs_requires_ca_volume() -> None:
+    """Proxy posture needs the CA volume when the proxy host is set."""
+    with pytest.raises(ValueError, match="Proxy posture requires both"):
         build_container_create_kwargs(
             sandbox_id=SANDBOX_ID,
             user_id=USER_ID,
@@ -608,6 +594,5 @@ def test_proxy_kwargs_requires_port_and_ca_volume(
             opencode_password=_OPENCODE_PASSWORD,
             opencode_config_json=_OPENCODE_CONFIG_JSON,
             sandbox_proxy_host="sandbox-proxy",
-            sandbox_proxy_port=port,
-            proxy_ca_volume_name=ca_volume,
+            proxy_ca_volume_name=None,
         )

--- a/deployment/helm/README.md
+++ b/deployment/helm/README.md
@@ -48,16 +48,19 @@ below and set `redis.enabled: false` to skip the operator entirely.
 
 ## Onyx Craft with Kubernetes sandboxes
 
-When `configMap.ENABLE_CRAFT="true"` and `configMap.SANDBOX_BACKEND="kubernetes"`
-(the Helm default), the target cluster must run Kubernetes `>= 1.33`. Craft
-sandbox pods use native restartable init sidecar containers: `sandbox-init`
-runs and completes first, `sidecar` starts next as an `initContainers` entry
-with `restartPolicy: Always`, and the main `sandbox` app container starts
-after the sidecar is ready.
+When `configMap.ENABLE_CRAFT="true"`, the target cluster must run Kubernetes
+`>= 1.33`. Craft Helm deployments provision Kubernetes sandbox pods; Docker
+is not a Helm deployment backend for Craft and `configMap.SANDBOX_BACKEND` is
+not a bypass for this requirement.
+
+Craft sandbox pods use native restartable init sidecar containers:
+`sandbox-init` runs and completes first, `sidecar` starts next as an
+`initContainers` entry with `restartPolicy: Always`, and the main `sandbox` app
+container starts after the sidecar is ready.
 
 The chart fails during render/install on older clusters so the incompatibility
 is caught before sandbox provisioning. This guard does not apply to non-Craft
-installs or Docker sandbox deployments.
+installs.
 
 ## Using an external Redis
 

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.5.24
+version: 0.5.25
 appVersion: latest
 annotations:
   category: Productivity
@@ -17,8 +17,8 @@ annotations:
       image: docker.io/onyxdotapp/onyx-backend:latest
   artifacthub.io/changes: |
     - kind: changed
-      description: Run the Craft Kubernetes sandbox sidecar as a restartable
-        init container and require Kubernetes 1.33 or newer for that backend.
+      description: Validate Craft Helm configuration and derive sandbox proxy
+        host and internal proxy port env settings from the chart.
 dependencies:
   - name: cloudnative-pg
     version: 0.26.0

--- a/deployment/helm/charts/onyx/templates/_helpers.tpl
+++ b/deployment/helm/charts/onyx/templates/_helpers.tpl
@@ -202,6 +202,14 @@ Return the configured autoscaling engine; defaults to HPA when unset.
 {{- if eq (toString (index .Values.configMap "ENABLE_CRAFT" | default "")) "true" -}}true{{- end -}}
 {{- end }}
 
+{{- define "onyx.sandboxProxyHost" -}}
+{{- (index .Values.configMap "SANDBOX_PROXY_HOST") | default (printf "%s-sandbox-proxy.%s.svc.cluster.local" (include "onyx.fullname" .) .Release.Namespace) -}}
+{{- end }}
+
+{{- define "onyx.sandboxProxyPort" -}}
+8080
+{{- end }}
+
 {{/* Sandbox egress-proxy env. Mirrors _proxy_main_container_env_vars(). */}}
 {{- define "onyx.sandboxProxyEnv" -}}
 {{- $proxyUrl := printf "http://sandbox-proxy:%v" .proxyPort }}
@@ -217,14 +225,6 @@ Return the configured autoscaling engine; defaults to HPA when unset.
 - { name: AWS_CA_BUNDLE, value: "{{ .caBundleFile }}" }
 - { name: CURL_CA_BUNDLE, value: "{{ .caBundleFile }}" }
 - { name: GIT_SSL_CAINFO, value: "{{ .caBundleFile }}" }
-{{- end }}
-
-{{/*
-"true" when Craft is enabled and configured to provision Kubernetes sandbox pods.
-*/}}
-{{- define "onyx.craftKubernetesSandboxEnabled" -}}
-{{- $sandboxBackend := toString ((index .Values.configMap "SANDBOX_BACKEND") | default "kubernetes") -}}
-{{- if and (eq (include "onyx.craftEnabled" .) "true") (eq $sandboxBackend "kubernetes") -}}true{{- end -}}
 {{- end }}
 
 {{/*

--- a/deployment/helm/charts/onyx/templates/configmap.yaml
+++ b/deployment/helm/charts/onyx/templates/configmap.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
 data:
+  {{- $craftEnabled := eq (include "onyx.craftEnabled" .) "true" }}
   INTERNAL_URL: "http://{{ include "onyx.fullname" . }}-api-service:{{ .Values.api.service.servicePort | default 8080 }}"
   {{- if .Values.postgresql.enabled }}
   POSTGRES_HOST: {{ .Release.Name }}-pg-rw
@@ -28,7 +29,8 @@ data:
   DISABLE_VECTOR_DB: "true"
   {{- end }}
 {{- range $key, $value := .Values.configMap }}
-{{- if not (empty $value) }}
+{{- $skipCraftProxyKey := and $craftEnabled (or (eq $key "SANDBOX_PROXY_HOST") (eq $key "SANDBOX_PROXY_PORT")) }}
+{{- if and (not (empty $value)) (not $skipCraftProxyKey) }}
   {{ $key }}: "{{ $value }}"
 {{- end }}
 {{- end }}
@@ -38,13 +40,7 @@ data:
   {{- if .Values.codeInterpreter.enabled }}
   CODE_INTERPRETER_BASE_URL: "http://{{ .Release.Name }}-code-interpreter:{{ .Values.codeInterpreter.service.port }}"
   {{- end }}
-  {{- if eq (include "onyx.craftEnabled" .) "true" }}
-  SANDBOX_PROXY_HOST: "{{ include "onyx.fullname" . }}-sandbox-proxy.{{ .Release.Namespace }}.svc.cluster.local"
-  SANDBOX_PROXY_PORT: "{{ (((.Values.sandboxProxy | default dict).service | default dict).proxyPort | default 8080) }}"
-  {{- end }}
-  {{- if and (toString (index .Values.configMap "ENABLE_CRAFT" | default "") | eq "true") (not (index .Values.configMap "SANDBOX_API_SERVER_URL")) }}
-  {{- fail "configMap.SANDBOX_API_SERVER_URL must be set when configMap.ENABLE_CRAFT is enabled" }}
-  {{- end }}
-  {{- if and (toString (index .Values.configMap "ENABLE_CRAFT" | default "") | eq "true") (not .Values.auth.sandboxPushSecret.enabled) }}
-  {{- fail "auth.sandboxPushSecret.enabled must be true when configMap.ENABLE_CRAFT is enabled" }}
+  {{- if $craftEnabled }}
+  SANDBOX_PROXY_HOST: "{{ include "onyx.sandboxProxyHost" . }}"
+  SANDBOX_PROXY_PORT: "{{ include "onyx.sandboxProxyPort" . }}"
   {{- end }}

--- a/deployment/helm/charts/onyx/templates/craft-kubernetes-version-check.yaml
+++ b/deployment/helm/charts/onyx/templates/craft-kubernetes-version-check.yaml
@@ -1,6 +1,6 @@
-{{- if eq (include "onyx.craftKubernetesSandboxEnabled" .) "true" }}
+{{- if eq (include "onyx.craftEnabled" .) "true" }}
 {{- if not (semverCompare ">=1.33.0-0" .Capabilities.KubeVersion.Version) }}
-{{- fail (printf "Onyx Craft with configMap.SANDBOX_BACKEND=kubernetes requires Kubernetes >= 1.33 because sandbox pods use native restartable init sidecar containers; target cluster reports %s. Use a newer Kubernetes cluster or set configMap.SANDBOX_BACKEND=docker for Docker sandbox deployments." .Capabilities.KubeVersion.Version) }}
+{{- fail (printf "Onyx Craft Kubernetes deployments support Kubernetes >= 1.33 because sandbox pods use stable native restartable init sidecar containers; target cluster reports %s. Use a newer Kubernetes cluster." .Capabilities.KubeVersion.Version) }}
 {{- end }}
 # Craft Kubernetes sandbox version check passed for {{ .Capabilities.KubeVersion.Version }}.
 {{- else }}

--- a/deployment/helm/charts/onyx/templates/craft-validation.yaml
+++ b/deployment/helm/charts/onyx/templates/craft-validation.yaml
@@ -1,0 +1,16 @@
+{{- $craftEnabled := eq (include "onyx.craftEnabled" .) "true" }}
+{{- if $craftEnabled }}
+{{- $sandboxBackend := lower (toString (index .Values.configMap "SANDBOX_BACKEND" | default "")) }}
+{{- if and $sandboxBackend (ne $sandboxBackend "kubernetes") }}
+{{- fail "configMap.SANDBOX_BACKEND must be \"kubernetes\" when configMap.ENABLE_CRAFT is enabled in the Helm chart" }}
+{{- end }}
+{{- if not (index .Values.configMap "SANDBOX_API_SERVER_URL") }}
+{{- fail "configMap.SANDBOX_API_SERVER_URL must be set when configMap.ENABLE_CRAFT is enabled" }}
+{{- end }}
+{{- if not .Values.auth.sandboxPushSecret.enabled }}
+{{- fail "auth.sandboxPushSecret.enabled must be true when configMap.ENABLE_CRAFT is enabled" }}
+{{- end }}
+# Craft chart validation passed.
+{{- else }}
+# Craft chart validation skipped.
+{{- end }}

--- a/deployment/helm/charts/onyx/templates/craft-validation.yaml
+++ b/deployment/helm/charts/onyx/templates/craft-validation.yaml
@@ -1,5 +1,6 @@
 {{- $craftEnabled := eq (include "onyx.craftEnabled" .) "true" }}
 {{- if $craftEnabled }}
+{{- /* Empty SANDBOX_BACKEND is intentional: absent/null/"" uses the backend's Kubernetes default. */}}
 {{- $sandboxBackend := lower (toString (index .Values.configMap "SANDBOX_BACKEND" | default "")) }}
 {{- if and $sandboxBackend (ne $sandboxBackend "kubernetes") }}
 {{- fail "configMap.SANDBOX_BACKEND must be \"kubernetes\" when configMap.ENABLE_CRAFT is enabled in the Helm chart" }}
@@ -7,7 +8,9 @@
 {{- if not (index .Values.configMap "SANDBOX_API_SERVER_URL") }}
 {{- fail "configMap.SANDBOX_API_SERVER_URL must be set when configMap.ENABLE_CRAFT is enabled" }}
 {{- end }}
-{{- if not .Values.auth.sandboxPushSecret.enabled }}
+{{- $auth := .Values.auth | default dict }}
+{{- $sandboxPushSecret := (index $auth "sandboxPushSecret") | default dict }}
+{{- if ne (toString (dig "enabled" false $sandboxPushSecret)) "true" }}
 {{- fail "auth.sandboxPushSecret.enabled must be true when configMap.ENABLE_CRAFT is enabled" }}
 {{- end }}
 # Craft chart validation passed.

--- a/deployment/helm/charts/onyx/templates/sandbox-podtemplate.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-podtemplate.yaml
@@ -17,9 +17,9 @@ opencode-auth + push-key env, proxy hostAliases IP).
 {{- $nextjsEnd := (index $cm "SANDBOX_NEXTJS_PORT_END") | default "3100" | int }}
 {{- $opencodePort := (index $cm "OPENCODE_SERVE_PORT") | default "4096" | int }}
 {{/* Keep in sync with PUSH_DAEMON_PORT in kubernetes_sandbox_manager.py. */}}
-{{- $pushDaemonPort := (index $cm "PUSH_DAEMON_PORT") | default "8731" | int }}
-{{- $proxyPort := (index $cm "SANDBOX_PROXY_PORT") | default "8080" }}
-{{- $proxyHost := (index $cm "SANDBOX_PROXY_HOST") | default (printf "%s-sandbox-proxy.%s.svc.cluster.local" (include "onyx.fullname" .) .Release.Namespace) }}
+{{- $pushDaemonPort := 8731 }}
+{{- $proxyPort := include "onyx.sandboxProxyPort" . }}
+{{- $proxyHost := include "onyx.sandboxProxyHost" . }}
 {{- $caConfigMap := (index $cm "SANDBOX_PROXY_CA_CONFIGMAP") | default "sandbox-proxy-ca-bundle" }}
 {{- $serverUrl := (index $cm "SANDBOX_API_SERVER_URL") }}
 {{- $sandboxPod := .Values.sandboxPod | default dict }}

--- a/deployment/helm/charts/onyx/templates/sandbox-proxy/deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-proxy/deployment.yaml
@@ -1,4 +1,6 @@
 {{- if eq (include "onyx.craftEnabled" .) "true" }}
+{{- $proxyPort := include "onyx.sandboxProxyPort" . }}
+{{- $healthzPort := "8081" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -65,10 +67,10 @@ spec:
           command: ["python", "-m", "onyx.sandbox_proxy.server"]
           ports:
             - name: proxy
-              containerPort: {{ .Values.sandboxProxy.containerPorts.proxy }}
+              containerPort: {{ $proxyPort }}
               protocol: TCP
             - name: healthz
-              containerPort: {{ .Values.sandboxProxy.containerPorts.healthz }}
+              containerPort: {{ $healthzPort }}
               protocol: TCP
           env:
             - name: SANDBOX_PROXY_NAMESPACE
@@ -76,9 +78,9 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: SANDBOX_PROXY_LISTEN_PORT
-              value: {{ .Values.sandboxProxy.containerPorts.proxy | quote }}
+              value: {{ $proxyPort | quote }}
             - name: SANDBOX_PROXY_HEALTHZ_PORT
-              value: {{ .Values.sandboxProxy.containerPorts.healthz | quote }}
+              value: {{ $healthzPort | quote }}
             {{- include "onyx.envSecrets" . | nindent 12}}
           envFrom:
             - configMapRef:

--- a/deployment/helm/charts/onyx/templates/sandbox-proxy/networkpolicy.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-proxy/networkpolicy.yaml
@@ -24,5 +24,5 @@ spec:
               kubernetes.io/metadata.name: {{ $sandboxNs }}
       ports:
         - protocol: TCP
-          port: {{ (((.Values.sandboxProxy | default dict).containerPorts | default dict).proxy | default 8080) }}
+          port: {{ include "onyx.sandboxProxyPort" . }}
 {{- end }}

--- a/deployment/helm/charts/onyx/templates/sandbox-proxy/service.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-proxy/service.yaml
@@ -13,7 +13,7 @@ spec:
     app.kubernetes.io/component: sandbox-proxy
   ports:
     - name: proxy
-      port: {{ .Values.sandboxProxy.service.proxyPort }}
+      port: {{ include "onyx.sandboxProxyPort" . }}
       targetPort: proxy
       protocol: TCP
 {{- end }}

--- a/deployment/helm/charts/onyx/templates/sandbox-rbac.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-rbac.yaml
@@ -40,7 +40,7 @@ rules:
     verbs: ["get"]
   - apiGroups: [""]
     resources: ["services"]
-    verbs: ["get", "create", "delete", "patch"]
+    verbs: ["get", "create", "delete"]
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "create", "update", "delete"]

--- a/deployment/helm/charts/onyx/templates/sandbox-rbac.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-rbac.yaml
@@ -40,7 +40,7 @@ rules:
     verbs: ["get"]
   - apiGroups: [""]
     resources: ["services"]
-    verbs: ["get", "create", "delete"]
+    verbs: ["get", "create", "delete", "patch"]
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "create", "update", "delete"]

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1410,10 +1410,12 @@ configMap:
   # block. The compose stack uses underscored service names (e.g. `api_server`,
   # `cache`, `inference_model_server`) which are invalid in K8s DNS labels and
   # break inter-pod traffic in ways that look like a hung service.
-  # In particular, leave these UNSET and let the chart compute correct
-  # K8s-service hostnames:
+  # In particular, avoid copying these compose-only hostnames:
   #   REDIS_HOST, INTERNAL_URL, API_SERVER_HOST,
   #   MODEL_SERVER_HOST, INDEXING_MODEL_SERVER_HOST
+  # Leave SANDBOX_PROXY_PORT unset; the chart owns the internal proxy port.
+  # SANDBOX_PROXY_HOST defaults to the chart-managed Service DNS name and may be
+  # overridden only if sandboxes must reach a different proxy host.
   # See deployment/helm/README.md for the external-Redis / ElastiCache path.
 
   # Auth type: "basic" (default), "google_oauth", "oidc", or "saml"
@@ -1537,11 +1539,6 @@ sandboxPod:
 # -- Sandbox egress proxy.
 sandboxProxy:
   replicaCount: 2
-  containerPorts:
-    proxy: 8080
-    healthz: 8081
-  service:
-    proxyPort: 8080
   terminationGracePeriodSeconds: 200
   progressDeadlineSeconds: 300
   confdirSizeLimit: 100Mi


### PR DESCRIPTION
## Description

- Adds Craft Helm validation for Kubernetes-only sandbox deployments and required sandbox API/push-secret settings.
- Derives sandbox proxy host and internal proxy port env settings from the chart while ignoring legacy user proxy overrides.
- Keeps Docker sandbox proxy env construction aligned with the internal proxy port contract.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds strict Craft Helm validation, enforces Kubernetes-only support with a 1.33+ version check, and makes the sandbox proxy port chart-owned at 8080 across the stack. Docker now reads the same internal port and no longer accepts a port argument.

- **New Features**
  - Helm validation for Craft: requires `configMap.SANDBOX_BACKEND="kubernetes"` (or unset), `configMap.SANDBOX_API_SERVER_URL`, and `auth.sandboxPushSecret.enabled=true`; fails fast otherwise.
  - Chart-owned proxy config: sets `SANDBOX_PROXY_PORT=8080` and computes `SANDBOX_PROXY_HOST` via helpers; applied across ConfigMap, PodTemplate, Deployment, Service, and NetworkPolicy. Version check runs whenever Craft is enabled and requires Kubernetes >= 1.33. README clarifies Helm deploys Kubernetes sandboxes only.
  - Docker sandbox manager: removes the proxy port argument, reads the port from the internal constant, injects `SANDBOX_PROXY_HOST`/`SANDBOX_PROXY_PORT`, and now only requires the CA volume when a proxy host is set. Tests updated.

- **Migration**
  - Set `configMap.SANDBOX_API_SERVER_URL` and enable `auth.sandboxPushSecret`.
  - Ensure the cluster runs Kubernetes >= 1.33 and `configMap.SANDBOX_BACKEND` is "kubernetes" (or unset).
  - Remove overrides for `configMap.SANDBOX_PROXY_PORT` and any `sandboxProxy.containerPorts`/`sandboxProxy.service.proxyPort`; the proxy now listens on 8080. Only override `SANDBOX_PROXY_HOST` if sandboxes must reach a non-default host.

<sup>Written for commit 676dc32a596e5b1a8489560cb9f1e25f9f5b0f7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11956?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

