### PR TITLE
fix(mcp): persist OAuth discovery metadata for token refresh

### DIFF
--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -336,6 +336,27 @@ def _build_oauth_admin_config_data_for_update(
     return config_data
 
 
+def _preserve_oauth_metadata(
+    config_data: MCPConnectionData,
+    existing_config_data: MCPConnectionData | None,
+) -> MCPConnectionData:
+    """Carry forward persisted MCP OAuth discovery metadata when rewriting a
+    connection config.
+
+    `update_connection_config()` replaces the whole JSON blob, so callers that
+    rebuild OAuth config from scratch must explicitly preserve metadata fields
+    that are still valid across reconnects (PRM/OAuth metadata is tied to the
+    protected resource + auth server, not the current token set).
+    """
+    if not existing_config_data:
+        return config_data
+
+    metadata = existing_config_data.get(MCPOAuthKeys.METADATA.value)
+    if metadata:
+        config_data[MCPOAuthKeys.METADATA.value] = metadata
+    return config_data
+
+
 router = APIRouter(prefix="/mcp")
 admin_router = APIRouter(prefix="/admin/mcp")
 STATE_TTL_SECONDS = 60 * 5  # 5 minutes
@@ -839,6 +860,10 @@ async def _connect_oauth(
             admin_config.id
         )  # might not have to do this
     elif is_admin:  # only update admin config if we're an admin
+        existing_admin_config_data = extract_connection_data(
+            mcp_server.admin_connection_config, apply_mask=False
+        )
+        config_data = _preserve_oauth_metadata(config_data, existing_admin_config_data)
         update_connection_config(mcp_server.admin_connection_config_id, db, config_data)
 
     connection_config = get_user_connection_config(mcp_server.id, user.email, db)
@@ -851,6 +876,10 @@ async def _connect_oauth(
             db_session=db,
         )
     else:
+        existing_user_config_data = extract_connection_data(
+            connection_config, apply_mask=False
+        )
+        config_data = _preserve_oauth_metadata(config_data, existing_user_config_data)
         update_connection_config(connection_config.id, db, config_data)
 
     db.commit()

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -9,6 +9,7 @@ from secrets import token_urlsafe
 from typing import Literal
 from urllib.parse import urlparse
 
+import httpx
 import requests
 from fastapi import APIRouter
 from fastapi import Depends
@@ -18,7 +19,9 @@ from mcp.client.auth import OAuthClientProvider
 from mcp.client.auth import TokenStorage
 from mcp.shared.auth import OAuthClientInformationFull
 from mcp.shared.auth import OAuthClientMetadata
+from mcp.shared.auth import OAuthMetadata
 from mcp.shared.auth import OAuthToken
+from mcp.shared.auth import ProtectedResourceMetadata
 from mcp.types import InitializeResult
 from mcp.types import Tool as MCPLibTool
 from pydantic import AnyUrl
@@ -340,6 +343,9 @@ OAUTH_WAIT_SECONDS = 30  # Give the user 30 seconds to complete the OAuth flow
 UNUSED_RETURN_PATH = "unused_path"
 
 HEADER_SUBSTITUTIONS: Literal["header_substitutions"] = "header_substitutions"
+MCP_OAUTH_PROTECTED_RESOURCE_METADATA_KEY = "protected_resource_metadata"
+MCP_OAUTH_AUTH_SERVER_METADATA_KEY = "oauth_metadata"
+MCP_OAUTH_AUTH_SERVER_URL_KEY = "auth_server_url"
 
 
 def key_auth_url(user_id: str) -> str:
@@ -460,6 +466,98 @@ class OnyxTokenStorage(TokenStorage):
                     self.alt_config_id, db_session, alt_config_data
                 )
 
+    async def get_metadata(self) -> dict[str, object] | None:
+        with get_session_with_current_tenant() as db_session:
+            config = self._ensure_connection_config(db_session)
+            config_data = extract_connection_data(config)
+            metadata_raw = config_data.get(MCPOAuthKeys.METADATA.value)
+            if metadata_raw:
+                return metadata_raw
+            if self.alt_config_id:
+                alt_config = get_connection_config_by_id(self.alt_config_id, db_session)
+                if alt_config:
+                    alt_config_data = extract_connection_data(alt_config)
+                    alt_metadata = alt_config_data.get(MCPOAuthKeys.METADATA.value)
+                    if alt_metadata:
+                        config_data[MCPOAuthKeys.METADATA.value] = alt_metadata
+                        update_connection_config(config.id, db_session, config_data)
+                        return alt_metadata
+            return None
+
+    async def set_metadata(self, metadata: dict[str, object]) -> None:
+        with get_session_with_current_tenant() as db_session:
+            config = self._ensure_connection_config(db_session)
+            config_data = extract_connection_data(config)
+            config_data[MCPOAuthKeys.METADATA.value] = metadata
+            update_connection_config(config.id, db_session, config_data)
+
+            if self.alt_config_id:
+                alt_config = get_connection_config_by_id(self.alt_config_id, db_session)
+                alt_config_data = extract_connection_data(alt_config)
+                alt_config_data[MCPOAuthKeys.METADATA.value] = metadata
+                update_connection_config(self.alt_config_id, db_session, alt_config_data)
+
+
+class OnyxOAuthClientProvider(OAuthClientProvider):
+    """OAuth provider that persists MCP discovery metadata across instances."""
+
+    async def _initialize(self) -> None:
+        await super()._initialize()
+
+        storage = self.context.storage
+        if not isinstance(storage, OnyxTokenStorage):
+            return
+
+        metadata = await storage.get_metadata()
+        if not metadata:
+            return
+
+        protected_resource_metadata = metadata.get(
+            MCP_OAUTH_PROTECTED_RESOURCE_METADATA_KEY
+        )
+        if protected_resource_metadata:
+            self.context.protected_resource_metadata = (
+                ProtectedResourceMetadata.model_validate(protected_resource_metadata)
+            )
+
+        oauth_metadata = metadata.get(MCP_OAUTH_AUTH_SERVER_METADATA_KEY)
+        if oauth_metadata:
+            self.context.oauth_metadata = OAuthMetadata.model_validate(oauth_metadata)
+
+        auth_server_url = metadata.get(MCP_OAUTH_AUTH_SERVER_URL_KEY)
+        if isinstance(auth_server_url, str):
+            self.context.auth_server_url = auth_server_url
+
+    async def _persist_metadata(self) -> None:
+        storage = self.context.storage
+        if not isinstance(storage, OnyxTokenStorage):
+            return
+
+        metadata: dict[str, object] = {}
+        if self.context.protected_resource_metadata:
+            metadata[MCP_OAUTH_PROTECTED_RESOURCE_METADATA_KEY] = (
+                self.context.protected_resource_metadata.model_dump(mode="json")
+            )
+        if self.context.oauth_metadata:
+            metadata[MCP_OAUTH_AUTH_SERVER_METADATA_KEY] = (
+                self.context.oauth_metadata.model_dump(mode="json")
+            )
+        if self.context.auth_server_url:
+            metadata[MCP_OAUTH_AUTH_SERVER_URL_KEY] = self.context.auth_server_url
+
+        if metadata:
+            await storage.set_metadata(metadata)
+
+    async def _handle_token_response(self, response: httpx.Response) -> None:
+        await super()._handle_token_response(response)
+        await self._persist_metadata()
+
+    async def _handle_refresh_response(self, response: httpx.Response) -> bool:
+        did_refresh = await super()._handle_refresh_response(response)
+        if did_refresh:
+            await self._persist_metadata()
+        return did_refresh
+
 
 def make_oauth_provider(
     mcp_server: DbMCPServer,
@@ -525,7 +623,7 @@ def make_oauth_provider(
         r.delete(key_auth_url(user_id), key_state(user_id))
         return code, state_obj.state
 
-    return OAuthClientProvider(
+    return OnyxOAuthClientProvider(
         server_url=mcp_server.server_url,
         client_metadata=OAuthClientMetadata(
             client_name=f"Onyx - {mcp_server.name}",

--- a/backend/onyx/server/features/mcp/models.py
+++ b/backend/onyx/server/features/mcp/models.py
@@ -79,7 +79,7 @@ class MCPConnectionData(TypedDict):
     # with SQLAlchemy
     client_info: NotRequired[dict[str, Any]]  # OAuthClientInformationFull
     tokens: NotRequired[dict[str, Any]]  # OAuthToken
-    metadata: NotRequired[dict[str, Any]]  # OAuthClientMetadata
+    metadata: NotRequired[dict[str, Any]]  # Discovered MCP OAuth metadata
 
     # the actual models are defined in mcp.shared.auth
     # from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata, OAuthToken

--- a/backend/tests/unit/onyx/server/features/mcp/test_oauth_credentials_resolver.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_oauth_credentials_resolver.py
@@ -15,6 +15,7 @@ from pydantic import AnyUrl
 
 from onyx.server.features.mcp.api import _build_oauth_admin_config_data
 from onyx.server.features.mcp.api import _build_oauth_admin_config_data_for_update
+from onyx.server.features.mcp.api import _preserve_oauth_metadata
 from onyx.server.features.mcp.api import _resolve_oauth_credentials
 from onyx.server.features.mcp.models import MCPOAuthKeys
 from onyx.utils.encryption import mask_string
@@ -410,3 +411,40 @@ class TestBuildOAuthAdminConfigDataForUpdate:
         )
         # scope is reset to REQUESTED_SCOPE (currently None)
         assert client_info_dict.get("scope") is None
+
+
+class TestPreserveOAuthMetadata:
+    def test_existing_metadata_is_carried_forward_on_rewrite(self) -> None:
+        config_data = _build_oauth_admin_config_data(
+            client_id="client-id",
+            client_secret="client-secret",
+        )
+        existing_config_data = {
+            "headers": {"Authorization": "Bearer old-token"},
+            MCPOAuthKeys.METADATA.value: {
+                "oauth_metadata": {
+                    "token_endpoint": "https://github.com/login/oauth/access_token"
+                }
+            },
+        }
+
+        preserved = _preserve_oauth_metadata(config_data, existing_config_data)
+
+        assert preserved[MCPOAuthKeys.METADATA.value] == {
+            "oauth_metadata": {
+                "token_endpoint": "https://github.com/login/oauth/access_token"
+            }
+        }
+
+    def test_missing_metadata_leaves_rewritten_config_unchanged(self) -> None:
+        config_data = _build_oauth_admin_config_data(
+            client_id="client-id",
+            client_secret="client-secret",
+        )
+
+        preserved = _preserve_oauth_metadata(
+            config_data,
+            {"headers": {"Authorization": "Bearer old-token"}},
+        )
+
+        assert MCPOAuthKeys.METADATA.value not in preserved

--- a/backend/tests/unit/onyx/server/features/mcp/test_oauth_metadata_persistence.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_oauth_metadata_persistence.py
@@ -1,0 +1,151 @@
+from typing import Any
+from typing import cast
+
+import httpx
+import pytest
+from mcp.shared.auth import OAuthClientInformationFull
+from mcp.shared.auth import OAuthClientMetadata
+from mcp.shared.auth import OAuthMetadata
+from mcp.shared.auth import OAuthToken
+from mcp.shared.auth import ProtectedResourceMetadata
+from pydantic import AnyHttpUrl
+from pydantic import AnyUrl
+
+from onyx.server.features.mcp.api import MCP_OAUTH_AUTH_SERVER_METADATA_KEY
+from onyx.server.features.mcp.api import MCP_OAUTH_AUTH_SERVER_URL_KEY
+from onyx.server.features.mcp.api import MCP_OAUTH_PROTECTED_RESOURCE_METADATA_KEY
+from onyx.server.features.mcp.api import OnyxOAuthClientProvider
+from onyx.server.features.mcp.api import OnyxTokenStorage
+
+
+class InMemoryOnyxTokenStorage(OnyxTokenStorage):
+    def __init__(self) -> None:
+        self.tokens: OAuthToken | None = None
+        self.client_info: OAuthClientInformationFull | None = None
+        self.metadata: dict[str, object] | None = None
+
+    async def get_tokens(self) -> OAuthToken | None:
+        return self.tokens
+
+    async def set_tokens(self, tokens: OAuthToken) -> None:
+        self.tokens = tokens
+
+    async def get_client_info(self) -> OAuthClientInformationFull | None:
+        return self.client_info
+
+    async def set_client_info(self, info: OAuthClientInformationFull) -> None:
+        self.client_info = info
+
+    async def get_metadata(self) -> dict[str, object] | None:
+        return self.metadata
+
+    async def set_metadata(self, metadata: dict[str, object]) -> None:
+        self.metadata = metadata
+
+
+def _make_client_info() -> OAuthClientInformationFull:
+    return OAuthClientInformationFull(
+        client_id="client-id",
+        client_secret="client-secret",
+        redirect_uris=[AnyUrl("https://onyx.example.com/mcp/oauth/callback")],
+        grant_types=["authorization_code", "refresh_token"],
+        response_types=["code"],
+        token_endpoint_auth_method="client_secret_post",
+    )
+
+
+def _make_provider(storage: InMemoryOnyxTokenStorage) -> OnyxOAuthClientProvider:
+    return OnyxOAuthClientProvider(
+        server_url="https://api.githubcopilot.com/mcp",
+        client_metadata=OAuthClientMetadata(
+            client_name="Onyx - delegated auth test",
+            redirect_uris=[AnyUrl("https://onyx.example.com/mcp/oauth/callback")],
+            grant_types=["authorization_code", "refresh_token"],
+            response_types=["code"],
+        ),
+        storage=storage,
+    )
+
+
+def _make_protected_resource_metadata() -> ProtectedResourceMetadata:
+    return ProtectedResourceMetadata(
+        resource=AnyHttpUrl("https://api.githubcopilot.com/mcp"),
+        authorization_servers=[AnyHttpUrl("https://github.com/login/oauth")],
+    )
+
+
+def _make_oauth_metadata() -> OAuthMetadata:
+    return OAuthMetadata(
+        issuer=AnyHttpUrl("https://github.com/login/oauth"),
+        authorization_endpoint=AnyHttpUrl(
+            "https://github.com/login/oauth/authorize"
+        ),
+        token_endpoint=AnyHttpUrl("https://github.com/login/oauth/access_token"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_token_response_persists_discovered_oauth_metadata() -> None:
+    storage = InMemoryOnyxTokenStorage()
+    provider = _make_provider(storage)
+    provider.context.protected_resource_metadata = _make_protected_resource_metadata()
+    provider.context.oauth_metadata = _make_oauth_metadata()
+    provider.context.auth_server_url = "https://github.com/login/oauth"
+
+    await provider._handle_token_response(
+        httpx.Response(
+            200,
+            json={
+                "access_token": "access-token",
+                "refresh_token": "refresh-token",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+            },
+        )
+    )
+
+    assert storage.metadata is not None
+    oauth_metadata = cast(
+        dict[str, Any], storage.metadata[MCP_OAUTH_AUTH_SERVER_METADATA_KEY]
+    )
+    assert (
+        oauth_metadata["token_endpoint"]
+        == "https://github.com/login/oauth/access_token"
+    )
+    assert MCP_OAUTH_PROTECTED_RESOURCE_METADATA_KEY in storage.metadata
+    assert (
+        storage.metadata[MCP_OAUTH_AUTH_SERVER_URL_KEY]
+        == "https://github.com/login/oauth"
+    )
+
+
+@pytest.mark.asyncio
+async def test_refresh_uses_persisted_oauth_metadata_token_endpoint() -> None:
+    storage = InMemoryOnyxTokenStorage()
+    storage.client_info = _make_client_info()
+    storage.tokens = OAuthToken(
+        access_token="expired-access-token",
+        refresh_token="refresh-token",
+        token_type="Bearer",
+        expires_in=1,
+    )
+    storage.metadata = {
+        MCP_OAUTH_PROTECTED_RESOURCE_METADATA_KEY: _make_protected_resource_metadata().model_dump(
+            mode="json"
+        ),
+        MCP_OAUTH_AUTH_SERVER_METADATA_KEY: _make_oauth_metadata().model_dump(
+            mode="json"
+        ),
+        MCP_OAUTH_AUTH_SERVER_URL_KEY: "https://github.com/login/oauth",
+    }
+    provider = _make_provider(storage)
+
+    await provider._initialize()
+    request = await provider._refresh_token()
+
+    assert (
+        str(request.url)
+        == "https://github.com/login/oauth/access_token"
+    )
+    assert request.content is not None
+    assert b"refresh_token=refresh-token" in request.content


### PR DESCRIPTION
## Description

This PR fixes unnecessary re-authentication for auto-discovered MCP OAuth servers whose OAuth token endpoint differs from their MCP server URL.

Onyx creates a fresh MCP OAuth provider for later MCP operations, including tool calls and tool discovery/listing. Previously, each fresh provider could reload the persisted OAuth tokens and client info from the MCP connection config, but not the discovered OAuth metadata that contains the provider's real token endpoint.

For example, a user may configure an MCP server at:

`https://api.githubcopilot.com/mcp`

During the MCP OAuth handshake, that server can advertise a separate OAuth token endpoint, such as:

`https://github.com/login/oauth/access_token`

Before this PR, a later tool call could have a valid refresh token but no longer know that discovered token endpoint. If the access token had expired, the MCP SDK could fall back to guessing a token endpoint from the MCP server URL, such as `https://api.githubcopilot.com/token`. That guessed endpoint is wrong for providers whose OAuth server is separate from the MCP resource server, so refresh could fail and users would be asked to reconnect even though their refresh token was still valid.


This change adds an `OnyxOAuthClientProvider` wrapper around the MCP SDK provider that persists discovered OAuth metadata after token exchange/refresh and reloads it whenever a new provider instance is initialized. It also preserves that metadata when `/oauth/connect` rewrites admin or per-user MCP connection configs, so reconnects and credential edits do not erase the discovered token endpoint.


## How Has This Been Tested?

- Docker compose

- Ran focused unit tests for OAuth metadata persistence, refresh endpoint reuse, and reconnect/config rewrite preservation

- Testing in our dev environment is pending

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [X] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist MCP OAuth discovery metadata and reload it for new provider instances so token refresh uses the correct token endpoint. This prevents unnecessary re-auth when the OAuth server differs from the MCP server (e.g., GitHub).

- **Bug Fixes**
  - Added OnyxOAuthClientProvider that saves and restores discovered OAuth metadata (`ProtectedResourceMetadata`, `OAuthMetadata`, auth server URL) via `OnyxTokenStorage`, persisting it after token exchange/refresh.
  - Preserved stored metadata when `/oauth/connect` rewrites admin or user connection configs using `_preserve_oauth_metadata`.
  - Refresh now targets the discovered `token_endpoint` instead of guessing from the MCP server URL.

<sup>Written for commit b3b5a99d1d2cfee8f483864bc5294ad52fd6c809. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

