### PR TITLE
feat(load-tests): scenario mix, multi-turn, disconnects, collapse-point ramp 3/n

### DIFF
--- a/loadtest/Dockerfile
+++ b/loadtest/Dockerfile
@@ -6,6 +6,7 @@ ARG BASE_IMAGE_REGISTRY=docker.io
 FROM ${BASE_IMAGE_REGISTRY}/locustio/locust:2.44.1
 
 COPY locustfile.py /loadtest/locustfile.py
+COPY shapes.py /loadtest/shapes.py
 COPY onyx_client /loadtest/onyx_client
 COPY scenarios /loadtest/scenarios
 

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -43,7 +43,7 @@ Behavior knobs ride in the model name (litellm passes it through verbatim):
 | `ttft<ms>` | `mock-ttft500` | time to first token |
 | `itl<ms>` | `mock-itl20` | inter-token delay |
 | `len<n>` | `mock-len400` | answer length in tokens |
-| `tools<0/1>` | `mock-tools1` | call the search tool on the first AUTO cycle |
+| `tools<n>` | `mock-tools1` | call up to `n` retrieval tools (in parallel for `n>1`) on the first AUTO cycle |
 | `agents<n>` | `mock-agents2` | parallel research agents per DR orchestrator cycle |
 
 The mock understands Onyx's LLM-loop contract: `tool_choice` none/auto/
@@ -71,20 +71,58 @@ their resources open longer, which is exactly what stresses the api-server):
 ONYX_API_KEY=<key> uv run locust --headless -u 5 -r 1 -t 5m -H https://<your-onyx-url>
 ```
 
-Scenario selection (all run by default; pick classes explicitly):
+### Scenario mix
+
+With no user classes named, the **default weighted steady-state mix** runs,
+approximating production traffic shape:
+
+| Scenario | Metrics | Weight | What it exercises |
+|---|---|---|---|
+| **BasicChatUser** | `chat:*` | 70 | single-turn chat, plain answer |
+| **ChatWithSearchUser** | `search:*` | 20 | one `internal_search` tool call → query expansion, embedding model server, Vespa/OpenSearch retrieval (needs indexed docs) |
+| **MultiToolUser** | `multitool:*` | 8 | up to 3 retrieval tools in parallel in one turn (`mock-tools3`) |
+| **DeepResearchUser** | `dr:*` | 2 | full DR turn — plan, parallel agents, reports; ~8+ LLM calls on one held stream |
 
 ```bash
+# default weighted mix:
+... uv run locust --headless -u 50 -r 5 -t 15m -H https://<your-onyx-url>
+# or pin to specific classes:
 ... uv run locust --headless -u 10 -r 2 -t 10m -H https://<your-onyx-url> BasicChatUser ChatWithSearchUser
-... uv run locust --headless -u 5 -r 1 -t 20m -H https://<your-onyx-url> DeepResearchUser
 ```
 
-- **BasicChatUser** (`chat:*` metrics) — single-turn chat, plain answer.
-- **ChatWithSearchUser** (`search:*`) — mock emits an `internal_search` tool
-  call, so query expansion, the embedding model server, and Vespa/OpenSearch
-  genuinely execute. Requires indexed documents in the target deployment.
-- **DeepResearchUser** (`dr:*`) — full deep-research turn (plan, parallel
-  research agents, intermediate + final reports). Heaviest scenario; one
-  turn = ~8+ LLM calls + real search executions on one held stream.
+### Targeted reproducers
+
+Run on their own (not part of the default mix) to stress a specific failure
+mode. Each maps to a real production incident class:
+
+- **LongConversationUser** (`longconv:*`) — keeps one chat session alive for
+  `ONYX_SESSION_TURNS` turns (default 20), chaining `parent_message_id` so the
+  history grows every turn. Drives full-history load + token counting +
+  summarization/compression each turn (history-driven slowdowns).
+- **DisconnectUser** (`disconnect:*`) — drops the connection mid-stream the
+  moment `ONYX_DISCONNECT_AFTER` (default `first_answer_token`) arrives, then
+  abandons the session. Stresses server-side disconnect cleanup of held
+  transactions/connections/buffers (slow leaks). The turn is recorded as
+  `disconnect:disconnected`, separate from success/failure.
+
+```bash
+... uv run locust --headless -u 50 -r 5 -t 15m -H https://<your-onyx-url> LongConversationUser
+... uv run locust --headless -u 50 -r 5 -t 15m -H https://<your-onyx-url> DisconnectUser
+```
+
+### Collapse-point ramp (`ONYX_SHAPE=stepramp`)
+
+Walk the user count up through plateaus to find the knee where the system
+stops keeping up, instead of guessing a fixed count. Pair with the
+slow-provider profile (`ONYX_LLM_MODEL=mock-ttft8000-itl40-len600`) to hold
+streams open and surface connection/memory exhaustion sooner. The shape
+overrides `-u/-r` and is only active when `ONYX_SHAPE=stepramp` is set.
+
+```bash
+ONYX_SHAPE=stepramp ONYX_RAMP_STAGES=25,50,100,200 ONYX_RAMP_DWELL=300 \
+ONYX_LLM_MODEL=mock-ttft8000-itl40-len600 \
+ONYX_API_KEY=<key> uv run locust --headless -t 25m -H https://<your-onyx-url>
+```
 
 The API key is created by an admin via `POST /api/admin/api-key`
 (`{"name": "loadtest", "role": "basic"}`) or Admin Panel → API Keys.
@@ -97,7 +135,13 @@ The API key is created by an admin via `POST /api/admin/api-key`
 | `ONYX_LLM_PROVIDER` | unset | Provider name for `llm_override` (needed when the mock isn't the deployment default) |
 | `ONYX_LLM_MODEL` | unset | Model for BasicChatUser (unset = persona default) |
 | `ONYX_SEARCH_MODEL` | `mock-tools1` | Model for ChatWithSearchUser |
+| `ONYX_MULTITOOL_MODEL` | `mock-tools3` | Model for MultiToolUser |
 | `ONYX_DR_MODEL` | `mock-agents2` | Model for DeepResearchUser |
+| `ONYX_LONGCONV_MODEL` | unset | Model for LongConversationUser (unset = persona default) |
+| `ONYX_SESSION_TURNS` | 1 | Turns to keep one session alive (LongConversationUser defaults to 20) |
+| `ONYX_DISCONNECT_AFTER` | `first_answer_token` | Milestone after which DisconnectUser drops the stream |
+| `ONYX_SHAPE` | unset | `stepramp` activates the staged ramp shape |
+| `ONYX_RAMP_STAGES` / `ONYX_RAMP_DWELL` / `ONYX_RAMP_SPAWN` | `25,50,100,200` / 300 / 5 | Ramp user plateaus, dwell seconds, spawn rate |
 | `ONYX_WAIT_SECONDS` | 15 | Think time between turns per user |
 | `ONYX_DR_WAIT_SECONDS` | 30 | Think time for DR users |
 | `ONYX_STREAM_READ_TIMEOUT` | 180 | Max seconds between stream chunks |
@@ -115,6 +159,9 @@ the milestone packet arrives; Locust aggregates percentiles per name:
 - `*:first_dr_plan` / `*:first_research_agent` — deep-research phase starts
 - `*:total_turn` — full turn wall time; success/failure recorded here
 - `*:send (headers)` — raw HTTP request (headers-only timing)
+- `*:create-session` — multi-turn session creation (LongConversationUser)
+- `disconnect:disconnected` — turns ended by a deliberate mid-stream
+  disconnect (DisconnectUser); kept separate from success/failure
 
 A turn fails on: non-200, an error packet, a stream stalling past the read
 timeout, or a stream ending without answer content / without the `stop`
@@ -150,6 +197,7 @@ polluted by WAN jitter and the LLM stays free:
 
 - ✅ Phase 0: harness + milestones + mock LLM core
 - ✅ Phase 1: tool-call & deep-research scripting, scenarios, Dockerfile
-- Phase 2: in-cluster Locust master/workers + mock provider (`k8s/`)
-- Phase 3: weighted scenario mixes, multi-turn sessions, open-workload arrivals
+- ✅ Phase 2: in-cluster Locust master/workers + mock provider (`k8s/`)
+- ✅ Phase 3: weighted scenario mix, multi-tool turns, multi-turn long-history
+  sessions, mid-stream disconnects, staged collapse-point ramp
 - Phase 4: Prometheus export + Grafana correlation dashboard

--- a/loadtest/locustfile.py
+++ b/loadtest/locustfile.py
@@ -1,20 +1,9 @@
 """Locust entrypoint for Onyx chat load tests.
 
-Usage (from this directory, after `uv sync`):
-
-    ONYX_API_KEY=... uv run locust --headless -u 5 -r 1 -t 5m \
-        -H https://<your-onyx-url>
-
-Select scenarios by naming user classes; with none named, the default
-weighted steady-state mix runs (BasicChatUser 70 / ChatWithSearchUser 20 /
-MultiToolUser 8 / DeepResearchUser 2). Targeted reproducers are run on their
-own, e.g.:
-
-    ... uv run locust --headless -u 50 -r 5 -t 15m LongConversationUser
-    ... uv run locust --headless -u 50 -r 5 -t 15m DisconnectUser
-
-Set ONYX_SHAPE=stepramp to drive a staged ramp instead of a fixed user count
-(see shapes.py). See README.md for all configuration env vars.
+With no user classes named, the default weighted mix runs (BasicChat 70 /
+ChatWithSearch 20 / MultiTool 8 / DeepResearch 2); name a class to run a
+targeted reproducer (LongConversationUser, DisconnectUser). ONYX_SHAPE=stepramp
+drives a staged ramp. See README.md for usage and env vars.
 """
 
 import os
@@ -35,9 +24,8 @@ __all__ = [
     "DisconnectUser",
 ]
 
-# Only expose the ramp shape when explicitly requested: Locust auto-activates
-# any LoadTestShape it discovers, which would otherwise override the manual
-# -u/-r controls on every run.
+# Expose the ramp only on request: Locust auto-activates any shape it finds,
+# which would override -u/-r on every run.
 if os.environ.get("ONYX_SHAPE") == "stepramp":
     from shapes import StepRampShape  # noqa: F401  (Locust discovers it via globals)
 

--- a/loadtest/locustfile.py
+++ b/loadtest/locustfile.py
@@ -5,15 +5,40 @@ Usage (from this directory, after `uv sync`):
     ONYX_API_KEY=... uv run locust --headless -u 5 -r 1 -t 5m \
         -H https://<your-onyx-url>
 
-Select scenarios with Locust's class picker, e.g.:
+Select scenarios by naming user classes; with none named, the default
+weighted steady-state mix runs (BasicChatUser 70 / ChatWithSearchUser 20 /
+MultiToolUser 8 / DeepResearchUser 2). Targeted reproducers are run on their
+own, e.g.:
 
-    ... uv run locust --headless -u 10 -r 2 -t 10m BasicChatUser ChatWithSearchUser
+    ... uv run locust --headless -u 50 -r 5 -t 15m LongConversationUser
+    ... uv run locust --headless -u 50 -r 5 -t 15m DisconnectUser
 
-See README.md for configuration env vars and scenario details.
+Set ONYX_SHAPE=stepramp to drive a staged ramp instead of a fixed user count
+(see shapes.py). See README.md for all configuration env vars.
 """
+
+import os
 
 from onyx_client.chat_user import BasicChatUser
 from scenarios import ChatWithSearchUser
 from scenarios import DeepResearchUser
+from scenarios import DisconnectUser
+from scenarios import LongConversationUser
+from scenarios import MultiToolUser
 
-__all__ = ["BasicChatUser", "ChatWithSearchUser", "DeepResearchUser"]
+__all__ = [
+    "BasicChatUser",
+    "ChatWithSearchUser",
+    "MultiToolUser",
+    "DeepResearchUser",
+    "LongConversationUser",
+    "DisconnectUser",
+]
+
+# Only expose the ramp shape when explicitly requested: Locust auto-activates
+# any LoadTestShape it discovers, which would otherwise override the manual
+# -u/-r controls on every run.
+if os.environ.get("ONYX_SHAPE") == "stepramp":
+    from shapes import StepRampShape  # noqa: F401  (Locust discovers it via globals)
+
+    __all__.append("StepRampShape")

--- a/loadtest/mock_llm/app.py
+++ b/loadtest/mock_llm/app.py
@@ -107,10 +107,8 @@ class Knobs:
         self.ttft_s: float = DEFAULT_TTFT_MS / 1000.0
         self.itl_s: float = DEFAULT_ITL_MS / 1000.0
         self.n_tokens: int = DEFAULT_LEN_TOKENS
-        # Number of retrieval tools to call in parallel on an AUTO cycle:
-        # 0 = none (plain chat), 1 = single search (mock-tools1), 2+ = parallel
-        # multi-tool (mock-tools2 / mock-tools3). Capped by how many retrieval
-        # tools the persona actually offers, so it degrades gracefully.
+        # Retrieval tools to call in parallel on an AUTO cycle (0=none,
+        # 1=mock-tools1, 2+=multi-tool); capped by tools the persona offers.
         self.n_auto_tools: int = 0
         self.n_agents: int = 1
         for name, value in _KNOB_RE.findall(model):
@@ -276,9 +274,7 @@ def _pick_tool(request: ChatCompletionRequest, knobs: Knobs) -> list[ToolCall]:
     if _GENERATE_PLAN in by_name:
         return [make(by_name[_GENERATE_PLAN])]
     if knobs.n_auto_tools > 0 and not has_tool_result:
-        # Emit up to n_auto_tools of the offered retrieval tools in parallel
-        # (mock-tools2/3 → multi-tool turn). Falls back to the first offered
-        # tool when the persona exposes no retrieval tools.
+        # Up to n_auto_tools retrieval tools in parallel; else the first tool.
         retrieval = [by_name[n] for n in _RETRIEVAL_TOOLS if n in by_name]
         chosen = retrieval[: knobs.n_auto_tools]
         if not chosen and tools:

--- a/loadtest/mock_llm/app.py
+++ b/loadtest/mock_llm/app.py
@@ -16,6 +16,9 @@ Timing knobs are encoded in the model name (litellm passes it through):
     mock-tools1-ttft300             — emit a tool call on the first AUTO-
                                       tool-choice cycle (drives the search
                                       tool path in a normal chat turn)
+    mock-tools3                     — call up to 3 retrieval tools in parallel
+                                      on the AUTO cycle (multi-tool turn);
+                                      capped by how many the persona offers
     mock-agents2                    — spawn 2 parallel research agents per
                                       deep-research orchestrator cycle
 
@@ -36,8 +39,9 @@ deep_research/dr_loop.py):
   else `generate_report`, else the first offered tool.
 - tool_choice AUTO                   → `generate_plan` if offered (DR
   clarification phase — always taken so a load-test DR turn never ends in a
-  clarification question); else, with the `-tools1` knob and no tool result
-  yet, the preferred search tool (normal chat-with-search); else plain text.
+  clarification question); else, with the `-tools<N>` knob and no tool result
+  yet, up to N offered retrieval tools in parallel (normal chat-with-search,
+  or a multi-tool turn for N>1); else plain text.
 
 Tool-call arguments are synthesized from each tool's JSON schema (required
 string props get a snippet of the last user message; arrays of strings get a
@@ -103,7 +107,11 @@ class Knobs:
         self.ttft_s: float = DEFAULT_TTFT_MS / 1000.0
         self.itl_s: float = DEFAULT_ITL_MS / 1000.0
         self.n_tokens: int = DEFAULT_LEN_TOKENS
-        self.tools_on_auto: bool = False
+        # Number of retrieval tools to call in parallel on an AUTO cycle:
+        # 0 = none (plain chat), 1 = single search (mock-tools1), 2+ = parallel
+        # multi-tool (mock-tools2 / mock-tools3). Capped by how many retrieval
+        # tools the persona actually offers, so it degrades gracefully.
+        self.n_auto_tools: int = 0
         self.n_agents: int = 1
         for name, value in _KNOB_RE.findall(model):
             if name == "ttft":
@@ -113,7 +121,7 @@ class Knobs:
             elif name == "len":
                 self.n_tokens = int(value)
             elif name == "tools":
-                self.tools_on_auto = bool(int(value))
+                self.n_auto_tools = int(value)
             elif name == "agents":
                 self.n_agents = max(1, int(value))
 
@@ -267,11 +275,16 @@ def _pick_tool(request: ChatCompletionRequest, knobs: Knobs) -> list[ToolCall]:
     # DR clarification: always proceed to the plan, never ask to clarify.
     if _GENERATE_PLAN in by_name:
         return [make(by_name[_GENERATE_PLAN])]
-    if knobs.tools_on_auto and not has_tool_result:
-        retrieval_tool = next((n for n in _RETRIEVAL_TOOLS if n in by_name), None)
-        target = by_name.get(retrieval_tool) if retrieval_tool else tools[0]
-        if target is not None:
-            return [make(target)]
+    if knobs.n_auto_tools > 0 and not has_tool_result:
+        # Emit up to n_auto_tools of the offered retrieval tools in parallel
+        # (mock-tools2/3 → multi-tool turn). Falls back to the first offered
+        # tool when the persona exposes no retrieval tools.
+        retrieval = [by_name[n] for n in _RETRIEVAL_TOOLS if n in by_name]
+        chosen = retrieval[: knobs.n_auto_tools]
+        if not chosen and tools:
+            chosen = [tools[0]]
+        if chosen:
+            return [make(t) for t in chosen]
     return []
 
 

--- a/loadtest/onyx_client/chat_user.py
+++ b/loadtest/onyx_client/chat_user.py
@@ -44,6 +44,11 @@ def _env_float(name: str, default: float) -> float:
     return float(raw) if raw else default
 
 
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    return int(raw) if raw else default
+
+
 class OnyxChatUser(HttpUser):
     abstract = True
 
@@ -53,6 +58,20 @@ class OnyxChatUser(HttpUser):
     # is not the deployment default.
     mock_model: str | None = None
     deep_research: bool = False
+
+    # >1 keeps a single chat session alive for this many turns, chaining each
+    # turn's parent_message_id off the previous assistant reply so the history
+    # grows turn over turn (reproduces the full-history recompute path). 1 (the
+    # default) sends a fresh auto-created session every turn — unchanged from
+    # the single-turn scenarios.
+    max_session_turns: int = _env_int("ONYX_SESSION_TURNS", 1)
+
+    # When set to a milestone name (e.g. "first_answer_token"), the client
+    # stops reading and drops the connection the instant that milestone
+    # arrives — a user closing the tab mid-stream. Exercises server-side
+    # disconnect handling (tx/connection cleanup while the turn is in flight).
+    # The turn is recorded as <prefix>:disconnected, not success/failure.
+    disconnect_after_milestone: str | None = None
 
     wait_time = constant(_env_float("ONYX_WAIT_SECONDS", 15.0))
     # Read timeout is between chunks, not total; chat_heartbeat keepalives in
@@ -76,6 +95,35 @@ class OnyxChatUser(HttpUser):
         self.messages: list[str] = DEFAULT_MESSAGES
         self.turn_index: int = 0
 
+        # Multi-turn session state (only used when max_session_turns > 1).
+        self._session_id: str | None = None
+        self._parent_message_id: int | None = None
+        self._session_turn: int = 0
+
+    def _create_session(self) -> str | None:
+        """Open a fresh chat session for a multi-turn conversation.
+
+        Returns the new session id, or None if creation failed (a failure
+        sample is recorded in that case).
+        """
+        start = time.perf_counter()
+        with self.client.post(
+            "/api/chat/create-chat-session",
+            json={"persona_id": 0, "description": f"loadtest-{uuid.uuid4().hex[:8]}"},
+            name=f"{self.scenario_prefix}:create-session",
+            catch_response=True,
+        ) as response:
+            if response.status_code != 200:
+                response.failure(f"HTTP {response.status_code}")
+                self._fire(
+                    "create_session",
+                    start,
+                    exception=Exception(f"HTTP {response.status_code}"),
+                )
+                return None
+            response.success()
+            return response.json().get("chat_session_id")
+
     def _fire(
         self,
         name: str,
@@ -92,26 +140,49 @@ class OnyxChatUser(HttpUser):
             context={},
         )
 
+    def _next_payload(self, message: str) -> dict[str, Any] | None:
+        """Build the send-chat-message payload, managing session reuse.
+
+        Returns None if a multi-turn session needed to be (re)created but
+        creation failed — the caller should skip the turn.
+        """
+        payload: dict[str, Any] = {"message": message, "stream": True}
+
+        if self.max_session_turns > 1:
+            if self._session_id is None or self._session_turn >= self.max_session_turns:
+                self._session_id = self._create_session()
+                self._parent_message_id = None
+                self._session_turn = 0
+                if self._session_id is None:
+                    return None
+            payload["chat_session_id"] = self._session_id
+            if self._parent_message_id is not None:
+                payload["parent_message_id"] = self._parent_message_id
+        else:
+            # Omitting chat_session_id auto-creates a session with the
+            # default persona (SendMessageRequest validator).
+            payload["chat_session_info"] = {
+                "description": f"loadtest-{uuid.uuid4().hex[:8]}",
+            }
+
+        if self.llm_override:
+            payload["llm_override"] = self.llm_override
+        if self.deep_research:
+            payload["deep_research"] = True
+        return payload
+
     @task
     def chat_turn(self) -> None:
         message = self.messages[self.turn_index % len(self.messages)]
         self.turn_index += 1
 
-        payload: dict[str, Any] = {
-            "message": message,
-            "stream": True,
-            # Omitting chat_session_id auto-creates a session with the
-            # default persona (SendMessageRequest validator).
-            "chat_session_info": {
-                "description": f"loadtest-{uuid.uuid4().hex[:8]}",
-            },
-        }
-        if self.llm_override:
-            payload["llm_override"] = self.llm_override
-        if self.deep_research:
-            payload["deep_research"] = True
+        payload = self._next_payload(message)
+        if payload is None:
+            return
 
         analyzer = ChatStreamAnalyzer()
+        disconnect_target = self.disconnect_after_milestone
+        disconnected = False
         start = time.perf_counter()
         try:
             # name= groups the auto-recorded HTTP metric; with stream=True its
@@ -139,10 +210,34 @@ class OnyxChatUser(HttpUser):
                 for line in response.iter_lines(decode_unicode=True):
                     for milestone in analyzer.feed(line):
                         self._fire(milestone, start)
+                        if disconnect_target and milestone == disconnect_target:
+                            disconnected = True
+                            break
+                    if disconnected:
+                        break
+                # On disconnect we deliberately leave the stream unconsumed;
+                # exiting the `with` closes the socket, so the server sees a
+                # client disconnect. The HTTP sample itself is fine — the early
+                # close is the intended behavior, not an error.
                 response.success()
         except Exception as exc:
             self._fire("total_turn", start, exception=exc)
             return
+
+        if disconnected:
+            self._fire(
+                "disconnected", start, response_length=analyzer.summary.answer_chars
+            )
+            # A mid-stream disconnect abandons this conversation; the next turn
+            # starts a fresh session.
+            self._session_id = None
+            return
+
+        if self.max_session_turns > 1:
+            self._session_turn += 1
+            rid = analyzer.summary.reserved_assistant_message_id
+            if rid is not None:
+                self._parent_message_id = rid
 
         summary = analyzer.summary
         if analyzer.completed_ok():
@@ -156,6 +251,10 @@ class OnyxChatUser(HttpUser):
 
 
 class BasicChatUser(OnyxChatUser):
-    """Single-turn basic chat, new session each turn."""
+    """Single-turn basic chat, new session each turn.
+
+    The bulk of the default weighted mix (see README "Scenario mix").
+    """
 
     abstract = False
+    weight = 70

--- a/loadtest/onyx_client/chat_user.py
+++ b/loadtest/onyx_client/chat_user.py
@@ -59,18 +59,12 @@ class OnyxChatUser(HttpUser):
     mock_model: str | None = None
     deep_research: bool = False
 
-    # >1 keeps a single chat session alive for this many turns, chaining each
-    # turn's parent_message_id off the previous assistant reply so the history
-    # grows turn over turn (reproduces the full-history recompute path). 1 (the
-    # default) sends a fresh auto-created session every turn — unchanged from
-    # the single-turn scenarios.
+    # >1 keeps one session alive for N turns, chaining parent_message_id so
+    # history grows; 1 (default) = a fresh session per turn.
     max_session_turns: int = _env_int("ONYX_SESSION_TURNS", 1)
 
-    # When set to a milestone name (e.g. "first_answer_token"), the client
-    # stops reading and drops the connection the instant that milestone
-    # arrives — a user closing the tab mid-stream. Exercises server-side
-    # disconnect handling (tx/connection cleanup while the turn is in flight).
-    # The turn is recorded as <prefix>:disconnected, not success/failure.
+    # If set to a milestone name, drop the stream the instant it arrives
+    # (client disconnect). Recorded as <prefix>:disconnected, not a failure.
     disconnect_after_milestone: str | None = None
 
     wait_time = constant(_env_float("ONYX_WAIT_SECONDS", 15.0))
@@ -101,11 +95,7 @@ class OnyxChatUser(HttpUser):
         self._session_turn: int = 0
 
     def _create_session(self) -> str | None:
-        """Open a fresh chat session for a multi-turn conversation.
-
-        Returns the new session id, or None if creation failed (a failure
-        sample is recorded in that case).
-        """
+        """Open a session for a multi-turn conversation; None on failure."""
         start = time.perf_counter()
         with self.client.post(
             "/api/chat/create-chat-session",
@@ -141,11 +131,8 @@ class OnyxChatUser(HttpUser):
         )
 
     def _next_payload(self, message: str) -> dict[str, Any] | None:
-        """Build the send-chat-message payload, managing session reuse.
-
-        Returns None if a multi-turn session needed to be (re)created but
-        creation failed — the caller should skip the turn.
-        """
+        """Build the send payload, managing session reuse. None = skip turn
+        (a multi-turn session was needed but couldn't be created)."""
         payload: dict[str, Any] = {"message": message, "stream": True}
 
         if self.max_session_turns > 1:
@@ -215,10 +202,8 @@ class OnyxChatUser(HttpUser):
                             break
                     if disconnected:
                         break
-                # On disconnect we deliberately leave the stream unconsumed;
-                # exiting the `with` closes the socket, so the server sees a
-                # client disconnect. The HTTP sample itself is fine — the early
-                # close is the intended behavior, not an error.
+                # On disconnect, exiting the `with` unconsumed closes the
+                # socket so the server sees the client drop; the sample is ok.
                 response.success()
         except Exception as exc:
             self._fire("total_turn", start, exception=exc)

--- a/loadtest/onyx_client/chat_user.py
+++ b/loadtest/onyx_client/chat_user.py
@@ -27,6 +27,8 @@ from locust import constant
 from locust import HttpUser
 from locust import task
 
+from onyx_client.env import env_float
+from onyx_client.env import env_int
 from onyx_client.stream_parser import ChatStreamAnalyzer
 
 DEFAULT_MESSAGES = [
@@ -37,16 +39,6 @@ DEFAULT_MESSAGES = [
     "What integrations and connectors are supported?",
     "Summarize how background indexing works.",
 ]
-
-
-def _env_float(name: str, default: float) -> float:
-    raw = os.environ.get(name)
-    return float(raw) if raw else default
-
-
-def _env_int(name: str, default: int) -> int:
-    raw = os.environ.get(name)
-    return int(raw) if raw else default
 
 
 class OnyxChatUser(HttpUser):
@@ -61,16 +53,16 @@ class OnyxChatUser(HttpUser):
 
     # >1 keeps one session alive for N turns, chaining parent_message_id so
     # history grows; 1 (default) = a fresh session per turn.
-    max_session_turns: int = _env_int("ONYX_SESSION_TURNS", 1)
+    max_session_turns: int = env_int("ONYX_SESSION_TURNS", 1)
 
     # If set to a milestone name, drop the stream the instant it arrives
     # (client disconnect). Recorded as <prefix>:disconnected, not a failure.
     disconnect_after_milestone: str | None = None
 
-    wait_time = constant(_env_float("ONYX_WAIT_SECONDS", 15.0))
+    wait_time = constant(env_float("ONYX_WAIT_SECONDS", 15.0))
     # Read timeout is between chunks, not total; chat_heartbeat keepalives in
     # the stream mean a healthy turn never goes silent this long.
-    stream_read_timeout: float = _env_float("ONYX_STREAM_READ_TIMEOUT", 180.0)
+    stream_read_timeout: float = env_float("ONYX_STREAM_READ_TIMEOUT", 180.0)
 
     def on_start(self) -> None:
         api_key = os.environ.get("ONYX_API_KEY")
@@ -96,7 +88,6 @@ class OnyxChatUser(HttpUser):
 
     def _create_session(self) -> str | None:
         """Open a session for a multi-turn conversation; None on failure."""
-        start = time.perf_counter()
         with self.client.post(
             "/api/chat/create-chat-session",
             json={"persona_id": 0, "description": f"loadtest-{uuid.uuid4().hex[:8]}"},
@@ -105,11 +96,6 @@ class OnyxChatUser(HttpUser):
         ) as response:
             if response.status_code != 200:
                 response.failure(f"HTTP {response.status_code}")
-                self._fire(
-                    "create_session",
-                    start,
-                    exception=Exception(f"HTTP {response.status_code}"),
-                )
                 return None
             response.success()
             return response.json().get("chat_session_id")

--- a/loadtest/onyx_client/env.py
+++ b/loadtest/onyx_client/env.py
@@ -1,0 +1,15 @@
+"""Small env-var parsing helpers shared across users and scenarios."""
+
+from __future__ import annotations
+
+import os
+
+
+def env_float(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    return float(raw) if raw else default
+
+
+def env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    return int(raw) if raw else default

--- a/loadtest/onyx_client/stream_parser.py
+++ b/loadtest/onyx_client/stream_parser.py
@@ -45,6 +45,10 @@ class StreamSummary:
     saw_stop: bool = False
     error: str | None = None
     milestones_hit: set[str] = field(default_factory=set)
+    # Assistant message id reserved by the backend for this turn (top-level
+    # stream field, not inside `obj`). Multi-turn scenarios chain the next
+    # turn's parent_message_id from it.
+    reserved_assistant_message_id: int | None = None
 
 
 class ChatStreamAnalyzer:
@@ -73,6 +77,12 @@ class ChatStreamAnalyzer:
 
         if not isinstance(data, dict):
             return hit
+
+        # Reserved id rides at the top level of an early packet, alongside
+        # (not inside) obj — capture it before the obj dispatch below.
+        reserved_id = data.get("reserved_assistant_message_id")
+        if isinstance(reserved_id, int):
+            self.summary.reserved_assistant_message_id = reserved_id
 
         if data.get("error"):
             self.summary.error = str(data["error"])

--- a/loadtest/scenarios/__init__.py
+++ b/loadtest/scenarios/__init__.py
@@ -1,4 +1,13 @@
 from scenarios.chat_with_search import ChatWithSearchUser
 from scenarios.deep_research import DeepResearchUser
+from scenarios.disconnect import DisconnectUser
+from scenarios.long_conversation import LongConversationUser
+from scenarios.multi_tool import MultiToolUser
 
-__all__ = ["ChatWithSearchUser", "DeepResearchUser"]
+__all__ = [
+    "ChatWithSearchUser",
+    "DeepResearchUser",
+    "DisconnectUser",
+    "LongConversationUser",
+    "MultiToolUser",
+]

--- a/loadtest/scenarios/chat_with_search.py
+++ b/loadtest/scenarios/chat_with_search.py
@@ -19,6 +19,7 @@ from onyx_client.chat_user import OnyxChatUser
 
 class ChatWithSearchUser(OnyxChatUser):
     abstract = False
+    weight = 20
 
     scenario_prefix: str = "search"
     mock_model: str | None = os.environ.get("ONYX_SEARCH_MODEL", "mock-tools1")

--- a/loadtest/scenarios/deep_research.py
+++ b/loadtest/scenarios/deep_research.py
@@ -21,6 +21,7 @@ from onyx_client.chat_user import OnyxChatUser
 
 class DeepResearchUser(OnyxChatUser):
     abstract = False
+    weight = 2
 
     scenario_prefix: str = "dr"
     deep_research: bool = True

--- a/loadtest/scenarios/deep_research.py
+++ b/loadtest/scenarios/deep_research.py
@@ -15,8 +15,8 @@ from __future__ import annotations
 import os
 
 from locust import constant
-from onyx_client.chat_user import _env_float
 from onyx_client.chat_user import OnyxChatUser
+from onyx_client.env import env_float
 
 
 class DeepResearchUser(OnyxChatUser):
@@ -29,5 +29,5 @@ class DeepResearchUser(OnyxChatUser):
 
     # DR turns run minutes, not seconds: think longer between turns and
     # tolerate longer inter-chunk silence (heartbeats should still arrive).
-    wait_time = constant(_env_float("ONYX_DR_WAIT_SECONDS", 30.0))
-    stream_read_timeout: float = _env_float("ONYX_DR_STREAM_READ_TIMEOUT", 300.0)
+    wait_time = constant(env_float("ONYX_DR_WAIT_SECONDS", 30.0))
+    stream_read_timeout: float = env_float("ONYX_DR_STREAM_READ_TIMEOUT", 300.0)

--- a/loadtest/scenarios/disconnect.py
+++ b/loadtest/scenarios/disconnect.py
@@ -1,24 +1,7 @@
-"""Chat turns where the client disconnects mid-stream.
-
-Each turn starts a normal streaming chat, then drops the connection the moment
-the configured milestone arrives (default: the first answer token) — a user
-closing the tab while the answer is still streaming. The server is left
-holding a turn that no one is reading, which exercises disconnect detection
-and the cleanup of whatever that turn was holding (DB transactions/connections,
-per-stream buffers). Resource that isn't released on client disconnect is a
-classic slow leak under load.
-
-Turns are recorded as `<prefix>:disconnected` (plus whatever milestones were
-reached first), kept separate from success/failure so the disconnect rate is
-explicit rather than masquerading as errors.
-
-Tuning (env):
-    ONYX_DISCONNECT_AFTER   milestone to disconnect after — one of
-                            first_packet, first_search_doc, first_answer_token
-                            (default), first_dr_plan, first_research_agent.
-
-Selected explicitly (not part of the default steady-state mix), e.g.:
-    locust -f locustfile.py DisconnectUser
+"""Client drops the stream mid-turn (default: after the first answer token)
+to exercise server-side disconnect cleanup (held transactions/connections/
+buffers). Recorded as `<prefix>:disconnected`, not a failure. Run on its own
+(not in the default mix). See README.
 """
 
 from __future__ import annotations

--- a/loadtest/scenarios/disconnect.py
+++ b/loadtest/scenarios/disconnect.py
@@ -1,0 +1,37 @@
+"""Chat turns where the client disconnects mid-stream.
+
+Each turn starts a normal streaming chat, then drops the connection the moment
+the configured milestone arrives (default: the first answer token) — a user
+closing the tab while the answer is still streaming. The server is left
+holding a turn that no one is reading, which exercises disconnect detection
+and the cleanup of whatever that turn was holding (DB transactions/connections,
+per-stream buffers). Resource that isn't released on client disconnect is a
+classic slow leak under load.
+
+Turns are recorded as `<prefix>:disconnected` (plus whatever milestones were
+reached first), kept separate from success/failure so the disconnect rate is
+explicit rather than masquerading as errors.
+
+Tuning (env):
+    ONYX_DISCONNECT_AFTER   milestone to disconnect after — one of
+                            first_packet, first_search_doc, first_answer_token
+                            (default), first_dr_plan, first_research_agent.
+
+Selected explicitly (not part of the default steady-state mix), e.g.:
+    locust -f locustfile.py DisconnectUser
+"""
+
+from __future__ import annotations
+
+import os
+
+from onyx_client.chat_user import OnyxChatUser
+
+
+class DisconnectUser(OnyxChatUser):
+    abstract = False
+
+    scenario_prefix: str = "disconnect"
+    disconnect_after_milestone: str | None = os.environ.get(
+        "ONYX_DISCONNECT_AFTER", "first_answer_token"
+    )

--- a/loadtest/scenarios/long_conversation.py
+++ b/loadtest/scenarios/long_conversation.py
@@ -1,0 +1,37 @@
+"""Multi-turn conversation that grows a long chat history.
+
+Each user keeps one chat session alive for ONYX_SESSION_TURNS turns, chaining
+parent_message_id off the previous assistant reply so the message history
+grows every turn. This exercises the path real long-running chats hit:
+loading the full thread, history token-counting, and (past the model's input
+window) summarization/compression on every turn — the ingredient missing from
+the single-turn scenarios, and the one behind history-driven slowdowns and
+compression blowups.
+
+Tuning (env):
+    ONYX_SESSION_TURNS   turns per session before starting a fresh one (>1;
+                         this scenario forces a sane minimum if unset).
+    ONYX_LONGCONV_MODEL  mock model knob (default plain chat, no tools).
+
+Selected explicitly (not part of the default steady-state mix), e.g.:
+    locust -f locustfile.py LongConversationUser
+"""
+
+from __future__ import annotations
+
+import os
+
+from onyx_client.chat_user import _env_int
+from onyx_client.chat_user import OnyxChatUser
+
+
+class LongConversationUser(OnyxChatUser):
+    abstract = False
+
+    scenario_prefix: str = "longconv"
+    mock_model: str | None = os.environ.get("ONYX_LONGCONV_MODEL")
+
+    # Keep a session alive for many turns so history actually grows long.
+    # Defaults to 20 here (vs the base default of 1) but still honors an
+    # explicit ONYX_SESSION_TURNS override.
+    max_session_turns: int = max(2, _env_int("ONYX_SESSION_TURNS", 20))

--- a/loadtest/scenarios/long_conversation.py
+++ b/loadtest/scenarios/long_conversation.py
@@ -7,8 +7,8 @@ from __future__ import annotations
 
 import os
 
-from onyx_client.chat_user import _env_int
 from onyx_client.chat_user import OnyxChatUser
+from onyx_client.env import env_int
 
 
 class LongConversationUser(OnyxChatUser):
@@ -16,5 +16,6 @@ class LongConversationUser(OnyxChatUser):
 
     scenario_prefix: str = "longconv"
     mock_model: str | None = os.environ.get("ONYX_LONGCONV_MODEL")
-    # Default 20 turns/session (base default is 1); honors ONYX_SESSION_TURNS.
-    max_session_turns: int = max(2, _env_int("ONYX_SESSION_TURNS", 20))
+    # Default 20 turns/session (base default is 1); ONYX_SESSION_TURNS overrides,
+    # clamped to a minimum of 2 (a single turn defeats this scenario).
+    max_session_turns: int = max(2, env_int("ONYX_SESSION_TURNS", 20))

--- a/loadtest/scenarios/long_conversation.py
+++ b/loadtest/scenarios/long_conversation.py
@@ -1,20 +1,6 @@
-"""Multi-turn conversation that grows a long chat history.
-
-Each user keeps one chat session alive for ONYX_SESSION_TURNS turns, chaining
-parent_message_id off the previous assistant reply so the message history
-grows every turn. This exercises the path real long-running chats hit:
-loading the full thread, history token-counting, and (past the model's input
-window) summarization/compression on every turn — the ingredient missing from
-the single-turn scenarios, and the one behind history-driven slowdowns and
-compression blowups.
-
-Tuning (env):
-    ONYX_SESSION_TURNS   turns per session before starting a fresh one (>1;
-                         this scenario forces a sane minimum if unset).
-    ONYX_LONGCONV_MODEL  mock model knob (default plain chat, no tools).
-
-Selected explicitly (not part of the default steady-state mix), e.g.:
-    locust -f locustfile.py LongConversationUser
+"""Long multi-turn chat: grows one session's history to stress the
+full-history load / token-counting / compression path that single-turn runs
+never reach. Run on its own (not in the default mix). See README.
 """
 
 from __future__ import annotations
@@ -30,8 +16,5 @@ class LongConversationUser(OnyxChatUser):
 
     scenario_prefix: str = "longconv"
     mock_model: str | None = os.environ.get("ONYX_LONGCONV_MODEL")
-
-    # Keep a session alive for many turns so history actually grows long.
-    # Defaults to 20 here (vs the base default of 1) but still honors an
-    # explicit ONYX_SESSION_TURNS override.
+    # Default 20 turns/session (base default is 1); honors ONYX_SESSION_TURNS.
     max_session_turns: int = max(2, _env_int("ONYX_SESSION_TURNS", 20))

--- a/loadtest/scenarios/multi_tool.py
+++ b/loadtest/scenarios/multi_tool.py
@@ -1,0 +1,26 @@
+"""Chat turn that drives multiple retrieval tools in parallel.
+
+The `-tools3` knob makes the mock LLM answer the first AUTO-tool-choice cycle
+with parallel calls to every retrieval tool the persona offers (internal
+search, web search, open url), so Onyx executes them concurrently inside one
+chat turn — fan-out over the embedding model server, Vespa/OpenSearch, and the
+web fetch path, then a single follow-up answer call.
+
+A small but real slice of production traffic; weighted accordingly in the
+default mix. Degrades gracefully to a single search when the persona exposes
+only one retrieval tool.
+"""
+
+from __future__ import annotations
+
+import os
+
+from onyx_client.chat_user import OnyxChatUser
+
+
+class MultiToolUser(OnyxChatUser):
+    abstract = False
+    weight = 8
+
+    scenario_prefix: str = "multitool"
+    mock_model: str | None = os.environ.get("ONYX_MULTITOOL_MODEL", "mock-tools3")

--- a/loadtest/scenarios/multi_tool.py
+++ b/loadtest/scenarios/multi_tool.py
@@ -1,14 +1,6 @@
-"""Chat turn that drives multiple retrieval tools in parallel.
-
-The `-tools3` knob makes the mock LLM answer the first AUTO-tool-choice cycle
-with parallel calls to every retrieval tool the persona offers (internal
-search, web search, open url), so Onyx executes them concurrently inside one
-chat turn — fan-out over the embedding model server, Vespa/OpenSearch, and the
-web fetch path, then a single follow-up answer call.
-
-A small but real slice of production traffic; weighted accordingly in the
-default mix. Degrades gracefully to a single search when the persona exposes
-only one retrieval tool.
+"""Chat turn that calls several retrieval tools in parallel (the `-tools3`
+knob), exercising concurrent tool execution within one turn. Degrades to a
+single search if the persona offers fewer tools. Part of the default mix.
 """
 
 from __future__ import annotations

--- a/loadtest/shapes.py
+++ b/loadtest/shapes.py
@@ -1,19 +1,10 @@
-"""Load-test shapes for collapse-point hunting.
+"""Staged ramp for collapse-point hunting.
 
-A Locust LoadTestShape drives the user count over time, overriding the manual
--u/-r controls. Onyx only activates one when ONYX_SHAPE is set (the locustfile
-binds the class conditionally) — by default runs use a fixed user count.
-
-StepRampShape walks the user count up through a series of plateaus, holding
-each long enough for latency/throughput to settle, so the knee where the
-system stops keeping up is visible in the timeline rather than guessed at.
-Pair it with the slow-provider mock profile (mock-ttft8000-itl40-len600) to
-hold streams open and surface connection/memory exhaustion sooner.
-
-Tuning (env):
-    ONYX_RAMP_STAGES   comma-separated user counts (default "25,50,100,200")
-    ONYX_RAMP_DWELL    seconds to hold each stage (default 300)
-    ONYX_RAMP_SPAWN    users spawned per second at each step (default 5)
+StepRampShape holds the user count at successive plateaus so the knee where
+the system stops keeping up is visible in the timeline. Opt-in only: the
+locustfile binds it when ONYX_SHAPE=stepramp, since Locust auto-activates any
+shape it finds and overrides -u/-r. Tune via ONYX_RAMP_STAGES / _DWELL /
+_SPAWN (see README).
 """
 
 from __future__ import annotations
@@ -34,11 +25,10 @@ class StepRampShape(LoadTestShape):
 
     def __init__(self) -> None:
         super().__init__()
-        users = _stage_users()
-        # Precompute (cumulative_end_time, users) plateaus.
+        # (cumulative_end_time, users) plateaus.
         self._stages: list[tuple[float, int]] = []
         end = 0.0
-        for count in users:
+        for count in _stage_users():
             end += self.dwell_s
             self._stages.append((end, count))
 
@@ -47,5 +37,4 @@ class StepRampShape(LoadTestShape):
         for end, count in self._stages:
             if run_time < end:
                 return count, self.spawn_rate
-        # Past the last plateau: stop, which ends the run.
-        return None
+        return None  # past the last plateau → stop

--- a/loadtest/shapes.py
+++ b/loadtest/shapes.py
@@ -1,0 +1,51 @@
+"""Load-test shapes for collapse-point hunting.
+
+A Locust LoadTestShape drives the user count over time, overriding the manual
+-u/-r controls. Onyx only activates one when ONYX_SHAPE is set (the locustfile
+binds the class conditionally) — by default runs use a fixed user count.
+
+StepRampShape walks the user count up through a series of plateaus, holding
+each long enough for latency/throughput to settle, so the knee where the
+system stops keeping up is visible in the timeline rather than guessed at.
+Pair it with the slow-provider mock profile (mock-ttft8000-itl40-len600) to
+hold streams open and surface connection/memory exhaustion sooner.
+
+Tuning (env):
+    ONYX_RAMP_STAGES   comma-separated user counts (default "25,50,100,200")
+    ONYX_RAMP_DWELL    seconds to hold each stage (default 300)
+    ONYX_RAMP_SPAWN    users spawned per second at each step (default 5)
+"""
+
+from __future__ import annotations
+
+import os
+
+from locust import LoadTestShape
+
+
+def _stage_users() -> list[int]:
+    raw = os.environ.get("ONYX_RAMP_STAGES", "25,50,100,200")
+    return [int(part) for part in raw.split(",") if part.strip()]
+
+
+class StepRampShape(LoadTestShape):
+    dwell_s: int = int(os.environ.get("ONYX_RAMP_DWELL", "300"))
+    spawn_rate: float = float(os.environ.get("ONYX_RAMP_SPAWN", "5"))
+
+    def __init__(self) -> None:
+        super().__init__()
+        users = _stage_users()
+        # Precompute (cumulative_end_time, users) plateaus.
+        self._stages: list[tuple[float, int]] = []
+        end = 0.0
+        for count in users:
+            end += self.dwell_s
+            self._stages.append((end, count))
+
+    def tick(self) -> tuple[int, float] | None:
+        run_time = self.get_run_time()
+        for end, count in self._stages:
+            if run_time < end:
+                return count, self.spawn_rate
+        # Past the last plateau: stop, which ends the run.
+        return None

--- a/loadtest/tests/test_mock_llm.py
+++ b/loadtest/tests/test_mock_llm.py
@@ -64,6 +64,30 @@ GENERATE_PLAN_TOOL = {
     },
 }
 
+WEB_SEARCH_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "web_search",
+        "parameters": {
+            "type": "object",
+            "properties": {"queries": {"type": "array", "items": {"type": "string"}}},
+            "required": ["queries"],
+        },
+    },
+}
+
+OPEN_URL_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "open_url",
+        "parameters": {
+            "type": "object",
+            "properties": {"urls": {"type": "array", "items": {"type": "string"}}},
+            "required": ["urls"],
+        },
+    },
+}
+
 THINK_TOOL = {
     "type": "function",
     "function": {
@@ -196,6 +220,43 @@ def test_chat_auto_with_tools_knob_emits_internal_search_with_queries_array() ->
     )
     parsed = json.loads(arguments)
     assert isinstance(parsed["queries"], list) and parsed["queries"]
+
+
+def test_multi_tool_knob_emits_parallel_retrieval_calls() -> None:
+    # mock-tools3 + three retrieval tools offered → all three called in
+    # parallel in one assistant message (multi-tool chat turn).
+    choice = complete(
+        model="mock-tools3-ttft0-itl0",
+        tools=[INTERNAL_SEARCH_TOOL, WEB_SEARCH_TOOL, OPEN_URL_TOOL],
+        tool_choice="auto",
+    )
+    assert choice["finish_reason"] == "tool_calls"
+    names = [c["function"]["name"] for c in choice["message"]["tool_calls"]]
+    assert names == ["internal_search", "web_search", "open_url"]
+
+
+def test_multi_tool_knob_caps_at_offered_retrieval_tools() -> None:
+    # mock-tools3 but only one retrieval tool offered → degrades to a single
+    # call rather than inventing tools.
+    choice = complete(
+        model="mock-tools3-ttft0-itl0",
+        tools=[INTERNAL_SEARCH_TOOL],
+        tool_choice="auto",
+    )
+    calls = choice["message"]["tool_calls"]
+    assert len(calls) == 1
+    assert calls[0]["function"]["name"] == "internal_search"
+
+
+def test_tools_knob_count_is_honored() -> None:
+    # mock-tools2 picks exactly two of three offered retrieval tools.
+    choice = complete(
+        model="mock-tools2-ttft0-itl0",
+        tools=[INTERNAL_SEARCH_TOOL, WEB_SEARCH_TOOL, OPEN_URL_TOOL],
+        tool_choice="auto",
+    )
+    names = [c["function"]["name"] for c in choice["message"]["tool_calls"]]
+    assert names == ["internal_search", "web_search"]
 
 
 def test_chat_auto_after_tool_result_streams_final_answer() -> None:

--- a/loadtest/tests/test_stream_parser.py
+++ b/loadtest/tests/test_stream_parser.py
@@ -1,9 +1,4 @@
-"""Tests for the NDJSON stream parser's milestone + message-id extraction.
-
-These assert the parser reads the same packet shapes Onyx streams (see
-backend/onyx/server/query_and_chat/streaming_models.py and the integration
-chat manager) so milestone timing and multi-turn chaining stay correct.
-"""
+"""Tests for the NDJSON parser's milestone + message-id extraction."""
 
 from __future__ import annotations
 

--- a/loadtest/tests/test_stream_parser.py
+++ b/loadtest/tests/test_stream_parser.py
@@ -1,0 +1,68 @@
+"""Tests for the NDJSON stream parser's milestone + message-id extraction.
+
+These assert the parser reads the same packet shapes Onyx streams (see
+backend/onyx/server/query_and_chat/streaming_models.py and the integration
+chat manager) so milestone timing and multi-turn chaining stay correct.
+"""
+
+from __future__ import annotations
+
+import json
+
+from onyx_client.stream_parser import ChatStreamAnalyzer
+from onyx_client.stream_parser import FIRST_ANSWER_TOKEN
+from onyx_client.stream_parser import FIRST_PACKET
+
+
+def _feed_all(analyzer: ChatStreamAnalyzer, lines: list[str]) -> list[str]:
+    hit: list[str] = []
+    for line in lines:
+        hit.extend(analyzer.feed(line))
+    return hit
+
+
+def test_captures_reserved_assistant_message_id() -> None:
+    analyzer = ChatStreamAnalyzer()
+    _feed_all(
+        analyzer,
+        [
+            json.dumps({"reserved_assistant_message_id": 4321}),
+            json.dumps({"obj": {"type": "message_start", "content": "hi"}}),
+            json.dumps({"obj": {"type": "message_delta", "content": " there"}}),
+            json.dumps({"obj": {"type": "stop"}}),
+        ],
+    )
+    assert analyzer.summary.reserved_assistant_message_id == 4321
+    assert analyzer.completed_ok()
+
+
+def test_message_id_absent_is_none() -> None:
+    analyzer = ChatStreamAnalyzer()
+    _feed_all(
+        analyzer,
+        [
+            json.dumps({"obj": {"type": "message_start", "content": "hi"}}),
+            json.dumps({"obj": {"type": "stop"}}),
+        ],
+    )
+    assert analyzer.summary.reserved_assistant_message_id is None
+
+
+def test_milestones_fire_once_in_order() -> None:
+    analyzer = ChatStreamAnalyzer()
+    first = analyzer.feed(json.dumps({"reserved_assistant_message_id": 1}))
+    assert first == [FIRST_PACKET]
+    # First content packet fires FIRST_ANSWER_TOKEN; a later one does not refire.
+    assert FIRST_ANSWER_TOKEN in analyzer.feed(
+        json.dumps({"obj": {"type": "message_start", "content": "x"}})
+    )
+    assert FIRST_ANSWER_TOKEN not in analyzer.feed(
+        json.dumps({"obj": {"type": "message_delta", "content": "y"}})
+    )
+
+
+def test_error_packet_marks_failure() -> None:
+    analyzer = ChatStreamAnalyzer()
+    _feed_all(analyzer, [json.dumps({"error": "boom"})])
+    assert not analyzer.completed_ok()
+    assert "boom" in analyzer.failure_reason()


### PR DESCRIPTION
## Description

Phase 3 of the chat load-testing effort (builds on #11917, #11938, #11951). The single-turn scenarios so far are verification-scale; this PR adds the traffic shapes needed to actually stress the system, each mapped to a known production failure mode. **No backend changes — all under `loadtest/`.**

- **Weighted steady-state mix** runs by default (BasicChat 70 / ChatWithSearch 20 / MultiTool 8 / DeepResearch 2), approximating production traffic shape. Targeted reproducers are selected by class name instead.
- **MultiToolUser** + generalized mock `-tools<N>` knob — calls up to N retrieval tools in parallel in one chat turn (degrades gracefully if the persona offers fewer). `-tools1` behavior is unchanged.
- **LongConversationUser** — keeps one chat session alive for N turns (default 20), chaining `parent_message_id` so the message history grows each turn. Drives the full-history load + token-counting + summarization/compression path that single-turn runs never reach. The stream parser now captures `reserved_assistant_message_id` for the chaining.
- **DisconnectUser** — drops the connection mid-stream (default: right after the first answer token) and abandons the session, exercising server-side disconnect cleanup of held transactions/connections/buffers. Recorded as a separate `disconnect:disconnected` metric, not as a failure.
- **StepRampShape** (`ONYX_SHAPE=stepramp`) — walks the user count up through plateaus to find the collapse point instead of guessing a fixed count. Opt-in: only activates when the env var is set, so it never overrides `-u/-r` on normal runs.

The single-turn fast path (auto-created session per turn) is byte-for-byte unchanged, so existing baselines stay comparable.

## How Has This Been Tested?

- `uv run pytest tests/ -q` → 22 passed (15 prior + 4 new stream-parser tests for message-id capture and milestone ordering + 3 new mock contract tests for the multi-tool knob).
- `uvx ruff check . && uvx ruff format --check .` clean.
- Imported the locustfile and verified scenario discovery, weights (70/20/8/2), `LongConversationUser.max_session_turns`, and that `StepRampShape` is exposed only when `ONYX_SHAPE=stepramp`.

End-to-end smoke runs of the new scenarios against a real deployment will follow before any large-scale ramp.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds production-like traffic to the chat load tests: a default weighted scenario mix, multi-turn sessions, mid-stream disconnects, and an opt-in step ramp to find collapse points. Also adds a multi-tool knob, shared env helpers, fixes duplicate create-session failure recording, and bakes the ramp shape into the Docker image; backend remains unchanged and the single-turn fast path stays the same.

- **New Features**
  - Default weighted mix when no classes are named: BasicChat 70 / ChatWithSearch 20 / MultiTool 8 / DeepResearch 2.
  - `MultiToolUser` + `-tools<N>` knob: calls up to N retrieval tools in parallel in one turn (degrades if fewer are offered).
  - `LongConversationUser`: keeps a session alive for N turns (default 20), chaining `parent_message_id`; stream parser captures `reserved_assistant_message_id` for chaining.
  - `DisconnectUser`: drops the stream after a chosen milestone (default first answer token); records `disconnect:disconnected` instead of a failure.
  - `StepRampShape` (opt-in via `ONYX_SHAPE=stepramp`): staged user ramp for collapse-point hunting; never overrides `-u/-r` unless set.

- **Refactors**
  - Shared env-var helpers (`env.py`) for `int`/`float` parsing; adopted across users.
  - Clamp `LongConversationUser.max_session_turns` to at least 2; README clarifies the behavior.
  - Avoid double-recording create-session failures; record once via the `create-session` sample.
  - Dockerfile now copies `shapes.py` so `StepRampShape` is available in the harness image.

<sup>Written for commit 3df6b2b74cb6cbd7734fbb0e00f4f9e591b18db3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

