### PR TITLE
fix(web): stop background tabs from polling the API forever

### DIFF
--- a/web/src/hooks/usePaginatedFetch.ts
+++ b/web/src/hooks/usePaginatedFetch.ts
@@ -5,6 +5,7 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import type { Route } from "next";
 
 import { errorHandlingFetcher } from "@/lib/fetcher";
+import { useVisibilityGatedInterval } from "@/hooks/useVisibilityGatedInterval";
 
 // Any type that has an id property
 type PaginatedType = {
@@ -214,17 +215,11 @@ function usePaginatedFetch<T extends PaginatedType>({
     }
   }, [currentPage, cachedBatches, pagesPerBatch]);
 
-  // Implements periodic refresh
-  useEffect(() => {
-    if (!refreshIntervalInMs) return;
-
-    const interval = setInterval(() => {
-      const { batchNum } = batchAndPageIndices;
-      fetchBatchData(batchNum);
-    }, refreshIntervalInMs);
-
-    return () => clearInterval(interval);
-  }, [currentPage, pagesPerBatch, refreshIntervalInMs, fetchBatchData]);
+  // Periodic refresh; visibility-gated so backgrounded admin tabs stop polling
+  useVisibilityGatedInterval(() => {
+    const { batchNum } = batchAndPageIndices;
+    fetchBatchData(batchNum);
+  }, refreshIntervalInMs || null);
 
   // Manually refreshes the current batch
   const refresh = useCallback(async () => {

--- a/web/src/hooks/useTokenRefresh.test.tsx
+++ b/web/src/hooks/useTokenRefresh.test.tsx
@@ -1,4 +1,5 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
+import { setDocumentVisibility } from "@tests/setup/test-utils";
 import { useTokenRefresh } from "@/hooks/useTokenRefresh";
 import { AuthTypeMetadata } from "@/hooks/useAuthTypeMetadata";
 import { AuthType } from "@/lib/constants";
@@ -108,5 +109,35 @@ describe("useTokenRefresh", () => {
     // The time-gate should suppress every follow-up attempt; the original
     // bug fired ~one extra call per re-render.
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("hidden tabs do not refresh; returning to visibility catches up", async () => {
+    jest.useFakeTimers();
+    try {
+      setDocumentVisibility(false);
+      renderHook(() =>
+        useTokenRefresh(
+          fakeUser,
+          baseAuthMetadata(AuthType.BASIC),
+          false,
+          jest.fn()
+        )
+      );
+
+      // No refresh on hidden mount, and none from interval ticks while hidden.
+      await act(async () => {
+        jest.advanceTimersByTime(31 * 60 * 1000);
+      });
+      expect(fetchMock).not.toHaveBeenCalled();
+
+      await act(async () => {
+        setDocumentVisibility(true);
+        document.dispatchEvent(new Event("visibilitychange"));
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.useRealTimers();
+      setDocumentVisibility(true);
+    }
   });
 });

--- a/web/src/hooks/useTokenRefresh.ts
+++ b/web/src/hooks/useTokenRefresh.ts
@@ -64,9 +64,16 @@ export function useTokenRefresh(
       }
     };
 
-    refreshTokenPeriodically();
+    // Hidden tabs skip refreshes entirely; the visibilitychange handler below
+    // catches the session up as soon as the user returns.
+    if (!document.hidden) {
+      refreshTokenPeriodically();
+    }
 
-    const intervalId = setInterval(refreshTokenPeriodically, REFRESH_INTERVAL);
+    const intervalId = setInterval(() => {
+      if (document.hidden) return;
+      refreshTokenPeriodically();
+    }, REFRESH_INTERVAL);
 
     const handleVisibilityChange = () => {
       if (

--- a/web/src/hooks/useVisibilityGatedInterval.test.tsx
+++ b/web/src/hooks/useVisibilityGatedInterval.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * Regression coverage for visibility-gated polling: hidden tabs must not
+ * tick, and returning to visibility runs a single catch-up tick when a full
+ * interval has elapsed.
+ */
+import { act, renderHook } from "@testing-library/react";
+import { setDocumentVisibility } from "@tests/setup/test-utils";
+import { useVisibilityGatedInterval } from "@/hooks/useVisibilityGatedInterval";
+
+describe("useVisibilityGatedInterval", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    setDocumentVisibility(true);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    setDocumentVisibility(true);
+  });
+
+  test("ticks on the interval while visible", () => {
+    const callback = jest.fn();
+    renderHook(() => useVisibilityGatedInterval(callback, 1000));
+
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+    expect(callback).toHaveBeenCalledTimes(3);
+  });
+
+  test("skips ticks while hidden", () => {
+    const callback = jest.fn();
+    renderHook(() => useVisibilityGatedInterval(callback, 1000));
+
+    setDocumentVisibility(false);
+    act(() => {
+      jest.advanceTimersByTime(10000);
+    });
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  test("runs one catch-up tick when an overdue tab becomes visible", () => {
+    const callback = jest.fn();
+    renderHook(() => useVisibilityGatedInterval(callback, 1000));
+
+    setDocumentVisibility(false);
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+    expect(callback).not.toHaveBeenCalled();
+
+    act(() => {
+      setDocumentVisibility(true);
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not catch up when no full interval has elapsed", () => {
+    const callback = jest.fn();
+    renderHook(() => useVisibilityGatedInterval(callback, 60000));
+
+    setDocumentVisibility(false);
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    act(() => {
+      setDocumentVisibility(true);
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  test("does nothing when interval is null", () => {
+    const callback = jest.fn();
+    renderHook(() => useVisibilityGatedInterval(callback, null));
+
+    act(() => {
+      jest.advanceTimersByTime(60000);
+    });
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  test("stops ticking after unmount", () => {
+    const callback = jest.fn();
+    const { unmount } = renderHook(() =>
+      useVisibilityGatedInterval(callback, 1000)
+    );
+    unmount();
+
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+    expect(callback).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/hooks/useVisibilityGatedInterval.ts
+++ b/web/src/hooks/useVisibilityGatedInterval.ts
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+/**
+ * setInterval that goes quiet while the tab is hidden: ticks are skipped when
+ * `document.hidden`, and returning to visibility runs one catch-up tick if a
+ * full interval has elapsed. Keeps abandoned background tabs from polling the
+ * API forever. Pass `null` to disable.
+ */
+export function useVisibilityGatedInterval(
+  callback: () => void,
+  intervalMs: number | null
+) {
+  const callbackRef = useRef(callback);
+  callbackRef.current = callback;
+
+  useEffect(() => {
+    if (!intervalMs) return;
+
+    let lastRun = Date.now();
+    const run = () => {
+      lastRun = Date.now();
+      callbackRef.current();
+    };
+
+    const intervalId = setInterval(() => {
+      if (document.hidden) return;
+      run();
+    }, intervalMs);
+
+    const handleVisibilityChange = () => {
+      if (
+        document.visibilityState === "visible" &&
+        Date.now() - lastRun >= intervalMs
+      ) {
+        run();
+      }
+    };
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      clearInterval(intervalId);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [intervalMs]);
+}

--- a/web/src/lib/fetcher.skipRetry.test.tsx
+++ b/web/src/lib/fetcher.skipRetry.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * Regression coverage for skipRetryOnAuthError: auth errors never retry;
+ * non-auth retries fire after backoff while visible; hidden tabs defer the
+ * retry until visibility returns instead of dropping the chain.
+ */
+import { FetchError, skipRetryOnAuthError } from "@/lib/fetcher";
+import { setDocumentVisibility } from "@tests/setup/test-utils";
+
+type RetryParams = Parameters<typeof skipRetryOnAuthError>;
+const emptyConfig = {} as RetryParams[2];
+
+// ts-jest compiles to ES5, where `class extends Error` breaks instanceof on
+// construction; build via the prototype so the guard's instanceof check holds.
+function makeAuthError(status: number): FetchError {
+  const err = Object.create(FetchError.prototype) as FetchError;
+  err.status = status;
+  return err;
+}
+
+function makeRevalidate() {
+  return jest.fn().mockResolvedValue(true) as unknown as RetryParams[3] &
+    jest.Mock;
+}
+
+describe("skipRetryOnAuthError", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    setDocumentVisibility(true);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    setDocumentVisibility(true);
+  });
+
+  test("never retries auth errors", () => {
+    const revalidate = makeRevalidate();
+    skipRetryOnAuthError(makeAuthError(401), "key", emptyConfig, revalidate, {
+      retryCount: 0,
+      dedupe: false,
+    });
+
+    jest.advanceTimersByTime(60000);
+    expect(revalidate).not.toHaveBeenCalled();
+  });
+
+  test("retries non-auth errors after backoff while visible", () => {
+    const revalidate = makeRevalidate();
+    skipRetryOnAuthError(new Error("boom"), "key", emptyConfig, revalidate, {
+      retryCount: 0,
+      dedupe: false,
+    });
+
+    jest.advanceTimersByTime(2000);
+    expect(revalidate).toHaveBeenCalledWith({ retryCount: 0 });
+  });
+
+  test("defers the retry while hidden and fires on return to visibility", () => {
+    const revalidate = makeRevalidate();
+    skipRetryOnAuthError(new Error("boom"), "key", emptyConfig, revalidate, {
+      retryCount: 0,
+      dedupe: false,
+    });
+
+    setDocumentVisibility(false);
+    jest.advanceTimersByTime(2000);
+    expect(revalidate).not.toHaveBeenCalled();
+
+    setDocumentVisibility(true);
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(revalidate).toHaveBeenCalledWith({ retryCount: 0 });
+  });
+});

--- a/web/src/lib/fetcher.ts
+++ b/web/src/lib/fetcher.ts
@@ -41,10 +41,19 @@ export const skipRetryOnAuthError: NonNullable<
     return;
   const delay = Math.min(2000 * 2 ** retryCount, 30000);
   setTimeout(() => {
-    // Hidden tabs drop the retry chain instead of retrying forever in the
-    // background; revalidateOnFocus refetches when the user returns.
-    if (typeof document !== "undefined" && document.hidden) return;
-    revalidate({ retryCount });
+    if (typeof document === "undefined" || !document.hidden) {
+      revalidate({ retryCount });
+      return;
+    }
+    // Hidden at retry time: defer until the tab is visible again, so hidden
+    // tabs stay quiet without permanently dropping the retry chain (which
+    // would strand consumers that disable revalidateOnFocus).
+    const retryOnVisible = () => {
+      if (document.hidden) return;
+      document.removeEventListener("visibilitychange", retryOnVisible);
+      revalidate({ retryCount });
+    };
+    document.addEventListener("visibilitychange", retryOnVisible);
   }, delay);
 };
 

--- a/web/src/lib/fetcher.ts
+++ b/web/src/lib/fetcher.ts
@@ -40,7 +40,12 @@ export const skipRetryOnAuthError: NonNullable<
   )
     return;
   const delay = Math.min(2000 * 2 ** retryCount, 30000);
-  setTimeout(() => revalidate({ retryCount }), delay);
+  setTimeout(() => {
+    // Hidden tabs drop the retry chain instead of retrying forever in the
+    // background; revalidateOnFocus refetches when the user returns.
+    if (typeof document !== "undefined" && document.hidden) return;
+    revalidate({ retryCount });
+  }, delay);
 };
 
 export const errorHandlingFetcher = async <T>(url: string): Promise<T> => {

--- a/web/src/sections/AppHealthBanner.tsx
+++ b/web/src/sections/AppHealthBanner.tsx
@@ -215,10 +215,12 @@ export default function AppHealthBanner() {
         clearInterval(refreshIntervalRef.current);
       }
 
-      refreshIntervalRef.current = setInterval(
-        attemptTokenRefresh,
-        refreshInterval * 1000
-      );
+      refreshIntervalRef.current = setInterval(() => {
+        // Hidden tabs skip the refresh; UserProvider's useTokenRefresh
+        // catches the session up on return to visibility.
+        if (document.hidden) return;
+        attemptTokenRefresh();
+      }, refreshInterval * 1000);
 
       // If we're going to expire before the next refresh, kick off a refresh now
       if (secondsUntilExpiration < refreshInterval) {

--- a/web/tests/setup/test-utils.tsx
+++ b/web/tests/setup/test-utils.tsx
@@ -83,6 +83,22 @@ export { userEvent };
 export { customRender as render };
 
 /**
+ * Override jsdom's document visibility (always "visible" by default) so tests
+ * can exercise hidden-tab behavior. Dispatch a "visibilitychange" event after
+ * calling to notify listeners. Reset to visible in afterEach.
+ */
+export function setDocumentVisibility(visible: boolean) {
+  Object.defineProperty(document, "hidden", {
+    configurable: true,
+    get: () => !visible,
+  });
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => (visible ? "visible" : "hidden"),
+  });
+}
+
+/**
  * Setup userEvent with optimized configuration for testing.
  * All user interactions are automatically wrapped in act() to prevent warnings.
  * Use this helper instead of userEvent.setup() directly.


### PR DESCRIPTION
## Description

**Bug:** api-server request rate sawtooths between deploys — collapses to ~4 req/s right after each deploy, then climbs continuously to 600–800 req/s until the next one.

**Evidence that the climb is unattended/background tabs** (Prometheus `http_requests_total`, prod):
- The climb runs straight through nights with no diurnal dip (153 → 655 req/s across two consecutive nights, 06-07 → 06-08). Monotonic overnight growth = unattended clients, not users.
- The post-deploy floor is ~4 req/s during business hours — nearly all steady-state traffic is machine-generated.
- The growing handlers map exactly onto the client loops that ignore tab visibility: `/auth/refresh` +59 req/s (`useTokenRefresh`, raw 10-min `setInterval`), cc-pair `index-attempts` / `errors` +27 req/s each (`usePaginatedFetch`, raw 5s `setInterval`), `/me` +29 req/s **including 403s** — expired sessions whose loops kept firing with nobody there to re-login. SWR's own `refreshInterval` already pauses hidden tabs; the climbers are precisely the loops that don't.
- Deploys reset it because long-lived sessions break on the new build, then accumulation restarts.

**Fix:** gate background network loops on tab visibility:
- new `useVisibilityGatedInterval` hook — skips ticks while `document.hidden`, one catch-up tick on return; `usePaginatedFetch` now uses it
- `useTokenRefresh` / `AppHealthBanner` skip hidden ticks; visibilitychange handler + SWR `revalidateOnFocus` catch sessions/data up on return
- `skipRetryOnAuthError` defers scheduled retries while hidden and fires them on return

Visible tabs behave exactly as before. Known limit: clients that are *visible* but unattended (wall monitors, headless automation) are intentionally untouched here; #11963 removes the heaviest per-page polling for that class.

**Verification after deploy:** the post-deploy baseline should hold flat (organic diurnal only) instead of climbing day-over-day — directly visible on the api-server request-rate board.

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check