### PR TITLE
fix(web): poll search settings only while a re-embedding migration is active

### DIFF
--- a/web/src/hooks/useSearchSettings.test.ts
+++ b/web/src/hooks/useSearchSettings.test.ts
@@ -1,0 +1,28 @@
+import { secondaryRefreshInterval } from "@/hooks/useSearchSettings";
+import type { EmbeddingModelResponse } from "@/lib/indexing/interfaces";
+
+const embeddingModelResponse: EmbeddingModelResponse = {
+  model_name: "text-embedding-3-small",
+  model_dim: 1536,
+  normalize: true,
+  query_prefix: null,
+  passage_prefix: null,
+  provider_type: null,
+  api_key: null,
+  api_url: null,
+  index_name: null,
+};
+
+describe("secondaryRefreshInterval", () => {
+  test("returns 5000 when a migration is in flight", () => {
+    expect(secondaryRefreshInterval(embeddingModelResponse)).toBe(5000);
+  });
+
+  test("returns 60000 when there is no secondary model", () => {
+    expect(secondaryRefreshInterval(null)).toBe(60000);
+  });
+
+  test("returns 60000 before SWR has loaded data", () => {
+    expect(secondaryRefreshInterval(undefined)).toBe(60000);
+  });
+});

--- a/web/src/hooks/useSearchSettings.ts
+++ b/web/src/hooks/useSearchSettings.ts
@@ -11,48 +11,55 @@ import {
 } from "@/lib/indexing/interfaces";
 
 /**
- * Fetches the currently-active search settings, including the embedding model
- * configuration and advanced retrieval options.
- *
- * Polls every 5 seconds so the UI stays in sync with backend-side changes
- * (e.g. embedding migration completion).
+ * Fetches the active search settings.
+ * Polls only when a caller provides `pollIntervalMs`.
  */
-export function useCurrentSearchSettings() {
+export function useCurrentSearchSettings({
+  pollIntervalMs = 0,
+}: { pollIntervalMs?: number } = {}) {
   return useSWR<SavedSearchSettings | null>(
     SWR_KEYS.currentSearchSettings,
     errorHandlingFetcher,
-    { refreshInterval: 5000 }
+    { refreshInterval: pollIntervalMs }
   );
 }
 
 /**
- * Fetches the FUTURE embedding model, populated only while a
- * switchover is in progress. Returns null when no re-index is running.
- *
- * Polls every 5 seconds so the in-progress banner appears/disappears
- * promptly when the backend transitions states.
+ * SWR refresh cadence for the secondary settings: 5s while a migration is in
+ * flight, 60s otherwise to catch migrations started elsewhere.
+ */
+export function secondaryRefreshInterval(
+  latestData: EmbeddingModelResponse | null | undefined
+): number {
+  return latestData ? 5000 : 60000;
+}
+
+/**
+ * Returns the secondary (in-progress) embedding model, or null when no
+ * re-index is running. Self-throttles via {@link secondaryRefreshInterval}.
  */
 export function useSecondarySearchSettings() {
   return useSWR<EmbeddingModelResponse | null>(
     SWR_KEYS.secondarySearchSettings,
     errorHandlingFetcher,
-    { refreshInterval: 5000 }
+    { refreshInterval: secondaryRefreshInterval }
   );
 }
 
 /**
- * Fetches the currently-active embedding model. Narrower-typed view of
- * {@link useCurrentSearchSettings} focused on model metadata (name,
- * provider, etc.).
+ * Fetches the active embedding model from the current search settings key.
+ * Polls only when a caller provides `pollIntervalMs`.
  *
  * Returns the backend-persisted shape, which does NOT carry a `description`.
  * Descriptions are frontend-only — look them up via `getCurrentModelCopy`.
  */
-export function useCurrentEmbeddingModel() {
+export function useCurrentEmbeddingModel({
+  pollIntervalMs = 0,
+}: { pollIntervalMs?: number } = {}) {
   return useSWR<EmbeddingModelResponse | null>(
     SWR_KEYS.currentSearchSettings,
     errorHandlingFetcher,
-    { refreshInterval: 5000 }
+    { refreshInterval: pollIntervalMs }
   );
 }
 

--- a/web/src/refresh-pages/admin/IndexSettingsPage/index.tsx
+++ b/web/src/refresh-pages/admin/IndexSettingsPage/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Formik } from "formik";
 import { markdown } from "@opal/utils";
 import { useRouter } from "next/navigation";
@@ -764,8 +764,21 @@ export default function IndexSettingsPage() {
   const imageProcessingEnabled =
     settings.settings.image_extraction_and_analysis_enabled ?? false;
 
+  const { data: secondarySearchSettings } = useSecondarySearchSettings();
+  const isReindexing = !!secondarySearchSettings;
+
+  // When a migration finishes, the fast poll on the current settings stops in
+  // the same render — revalidate once so the new model shows as current.
+  const wasReindexingRef = useRef(false);
+  useEffect(() => {
+    if (wasReindexingRef.current && !isReindexing) {
+      mutate(SWR_KEYS.currentSearchSettings);
+    }
+    wasReindexingRef.current = isReindexing;
+  }, [isReindexing]);
+
   const { data: currentEmbeddingModel, isLoading: isLoadingCurrentModel } =
-    useCurrentEmbeddingModel();
+    useCurrentEmbeddingModel({ pollIntervalMs: isReindexing ? 5000 : 0 });
 
   /**
    * Camel-cased view of the active embedding model for modal preload.
@@ -798,15 +811,13 @@ export default function IndexSettingsPage() {
     : false;
 
   const { data: searchSettings, isLoading: isLoadingSearchSettings } =
-    useCurrentSearchSettings();
+    useCurrentSearchSettings({ pollIntervalMs: isReindexing ? 5000 : 0 });
   const { data: configuredProvidersList } = useConfiguredEmbeddingProviders();
   const configuredProviders = useMemo(
     () =>
       new Map((configuredProvidersList ?? []).map((p) => [p.provider_type, p])),
     [configuredProvidersList]
   );
-  const { data: secondarySearchSettings } = useSecondarySearchSettings();
-  const isReindexing = !!secondarySearchSettings;
   const cancelReindexModal = useCreateModal();
   const customModelModal = useCreateModal();
 

--- a/web/src/refresh-pages/admin/IndexSettingsPage/index.tsx
+++ b/web/src/refresh-pages/admin/IndexSettingsPage/index.tsx
@@ -777,8 +777,10 @@ export default function IndexSettingsPage() {
     wasReindexingRef.current = isReindexing;
   }, [isReindexing]);
 
+  // Shares the current-settings SWR key, which useCurrentSearchSettings
+  // below already polls while reindexing — one timer drives both hooks.
   const { data: currentEmbeddingModel, isLoading: isLoadingCurrentModel } =
-    useCurrentEmbeddingModel({ pollIntervalMs: isReindexing ? 5000 : 0 });
+    useCurrentEmbeddingModel();
 
   /**
    * Camel-cased view of the active embedding model for modal preload.


### PR DESCRIPTION
## Description

**Bug:** the admin Index Settings page polls `/api/search-settings/get-current-search-settings` and `get-secondary-search-settings` every 5s per viewer, unconditionally — even when no migration is running. In prod this amplified into single-tenant storms of 30–45 req/s per endpoint (at peak ~22% of all api-server requests), from clients sitting on the page.

**Fix:**
- `useSecondarySearchSettings` self-throttles: 5s while a migration is in flight (non-null response), 60s idle heartbeat to catch migrations started elsewhere
- `useCurrentSearchSettings` / `useCurrentEmbeddingModel` no longer poll by default; the page passes a 5s interval only while reindexing
- when a migration finishes, the page revalidates the current settings once so the new model shows immediately
- explicit user actions still refresh instantly via the existing `mutate` calls

Idle viewer: 24 req/min → 1 req/min. Active migration UX unchanged.

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check