### PR TITLE
feat(load-tests): Prometheus exporter + Grafana correlation dashboard 4/n

### DIFF
--- a/loadtest/Dockerfile
+++ b/loadtest/Dockerfile
@@ -5,9 +5,17 @@ ARG BASE_IMAGE_REGISTRY=docker.io
 # Keep the tag in sync with the locust pin in uv.lock.
 FROM ${BASE_IMAGE_REGISTRY}/locustio/locust:2.44.1
 
+# Not in the base locust image; pin to the version in uv.lock.
+RUN pip install --no-cache-dir prometheus-client==0.25.0
+
 COPY locustfile.py /loadtest/locustfile.py
 COPY shapes.py /loadtest/shapes.py
+COPY prometheus_exporter.py /loadtest/prometheus_exporter.py
+COPY prometheus_collector.py /loadtest/prometheus_collector.py
 COPY onyx_client /loadtest/onyx_client
 COPY scenarios /loadtest/scenarios
+
+# 8089 web UI, 5557 worker comms, 9646 Prometheus /metrics (master only).
+EXPOSE 9646
 
 ENTRYPOINT ["locust", "-f", "/loadtest/locustfile.py"]

--- a/loadtest/Dockerfile
+++ b/loadtest/Dockerfile
@@ -5,7 +5,8 @@ ARG BASE_IMAGE_REGISTRY=docker.io
 # Keep the tag in sync with the locust pin in uv.lock.
 FROM ${BASE_IMAGE_REGISTRY}/locustio/locust:2.44.1
 
-# Not in the base locust image; pin to the version in uv.lock.
+# prometheus-client isn't in the base locust image. Pinned to match the
+# resolved version in uv.lock — bump both together when the lockfile updates.
 RUN pip install --no-cache-dir prometheus-client==0.25.0
 
 COPY locustfile.py /loadtest/locustfile.py

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -167,6 +167,24 @@ A turn fails on: non-200, an error packet, a stream stalling past the read
 timeout, or a stream ending without answer content / without the `stop`
 packet (truncation).
 
+### Prometheus + Grafana correlation
+
+The master exposes milestone metrics for Prometheus on a dedicated port
+(default `9646`, `LOCUST_PROMETHEUS_PORT` to override) at `/metrics`:
+
+- `locust_users`
+- `locust_requests_total{name,method}` / `locust_failures_total{name,method}`
+- `locust_response_time_p50_milliseconds` / `..._p95_milliseconds{name,method}`
+- `locust_current_rps{name,method}`
+
+Scrape it (the `k8s/` master pod carries `prometheus.io/scrape` annotations,
+or point a ServiceMonitor at the `metrics` service port) and import
+`dashboards/chat-loadtest-correlation.json` to overlay milestone latency and
+failure rate against server-side CPU/memory on one timeline — set the
+dashboard's `$namespace` / `$workload` variables to the deployment under
+load. That overlay is how you read the collapse point: the user count where
+p95 / failure rate bend up, and which resource saturates first.
+
 ## Docker
 
 ```bash
@@ -200,4 +218,5 @@ polluted by WAN jitter and the LLM stays free:
 - ✅ Phase 2: in-cluster Locust master/workers + mock provider (`k8s/`)
 - ✅ Phase 3: weighted scenario mix, multi-tool turns, multi-turn long-history
   sessions, mid-stream disconnects, staged collapse-point ramp
-- Phase 4: Prometheus export + Grafana correlation dashboard
+- ✅ Phase 4: Prometheus exporter (`/metrics`) + Grafana correlation dashboard
+  (`dashboards/`)

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -177,8 +177,11 @@ The master exposes milestone metrics for Prometheus on a dedicated port
 - `locust_response_time_p50_milliseconds` / `..._p95_milliseconds{name,method}`
 - `locust_current_rps{name,method}`
 
-Scrape it (the `k8s/` master pod carries `prometheus.io/scrape` annotations,
-or point a ServiceMonitor at the `metrics` service port) and import
+Scrape it: annotation-based Prometheus uses the master pod's
+`prometheus.io/scrape` annotations; **Prometheus Operator
+(kube-prometheus-stack) ignores annotations and needs a ServiceMonitor**
+targeting the `metrics` service port (commented example in `k8s/locust.yaml`).
+Then import
 `dashboards/chat-loadtest-correlation.json` to overlay milestone latency and
 failure rate against server-side CPU/memory on one timeline — set the
 dashboard's `$namespace` / `$workload` variables to the deployment under

--- a/loadtest/dashboards/chat-loadtest-correlation.json
+++ b/loadtest/dashboards/chat-loadtest-correlation.json
@@ -116,7 +116,7 @@
       "type": "timeseries",
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 14 },
-      "fieldConfig": { "defaults": { "unit": "decmbytes", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "fieldConfig": { "defaults": { "unit": "mbytes", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
       "targets": [
         {
           "refId": "A",

--- a/loadtest/dashboards/chat-loadtest-correlation.json
+++ b/loadtest/dashboards/chat-loadtest-correlation.json
@@ -134,7 +134,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "locust_current_rps",
+          "expr": "locust_current_rps{name=~\"$milestone\"}",
           "legendFormat": "{{name}}"
         }
       ]

--- a/loadtest/dashboards/chat-loadtest-correlation.json
+++ b/loadtest/dashboards/chat-loadtest-correlation.json
@@ -1,0 +1,143 @@
+{
+  "__inputs": [],
+  "annotations": { "list": [] },
+  "description": "Overlays Locust chat-path milestone latency / failure rate (from the loadtest Prometheus exporter) with server-side resource usage, so load and saturation can be read on one timeline. Templated: pick a Prometheus datasource and set $namespace / $workload to the Onyx deployment under test.",
+  "editable": true,
+  "graphTooltip": 1,
+  "schemaVersion": 39,
+  "tags": ["onyx", "loadtest", "locust"],
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "label": "Prometheus",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {},
+        "hide": 0
+      },
+      {
+        "name": "namespace",
+        "label": "Namespace",
+        "type": "textbox",
+        "query": "onyx",
+        "current": { "text": "onyx", "value": "onyx" },
+        "hide": 0
+      },
+      {
+        "name": "workload",
+        "label": "Server workload (pod prefix)",
+        "type": "textbox",
+        "query": "onyx-api-server",
+        "current": { "text": "onyx-api-server", "value": "onyx-api-server" },
+        "hide": 0
+      },
+      {
+        "name": "milestone",
+        "label": "Milestone filter (regex)",
+        "type": "textbox",
+        "query": ".*:total_turn",
+        "current": { "text": ".*:total_turn", "value": ".*:total_turn" },
+        "hide": 0
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "panels": [
+    {
+      "title": "Locust users",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 6, "w": 12, "x": 0, "y": 0 },
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "targets": [
+        { "refId": "A", "expr": "locust_users", "legendFormat": "users" }
+      ]
+    },
+    {
+      "title": "Failure rate (%)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "percent", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "100 * sum(rate(locust_failures_total[1m])) / clamp_min(sum(rate(locust_requests_total[1m])), 1)",
+          "legendFormat": "failure %"
+        }
+      ]
+    },
+    {
+      "title": "Milestone latency p50 (ms)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "fieldConfig": { "defaults": { "unit": "ms", "custom": { "drawStyle": "line", "fillOpacity": 5 } } },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "locust_response_time_p50_milliseconds{name=~\"$milestone\"}",
+          "legendFormat": "{{name}}"
+        }
+      ]
+    },
+    {
+      "title": "Milestone latency p95 (ms)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "fieldConfig": { "defaults": { "unit": "ms", "custom": { "drawStyle": "line", "fillOpacity": 5 } } },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "locust_response_time_p95_milliseconds{name=~\"$milestone\"}",
+          "legendFormat": "{{name}}"
+        }
+      ]
+    },
+    {
+      "title": "Server CPU (cores) — $workload",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 14 },
+      "fieldConfig": { "defaults": { "unit": "none", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod=~\"$workload.*\", container!=\"\"}[1m])) by (pod)",
+          "legendFormat": "{{pod}}"
+        }
+      ]
+    },
+    {
+      "title": "Server memory (working set, MiB) — $workload",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 14 },
+      "fieldConfig": { "defaults": { "unit": "decmbytes", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(container_memory_working_set_bytes{namespace=\"$namespace\", pod=~\"$workload.*\", container!=\"\"}) by (pod) / 1024 / 1024",
+          "legendFormat": "{{pod}}"
+        }
+      ]
+    },
+    {
+      "title": "Throughput (req/s) by milestone",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 22 },
+      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 5 } } },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "locust_current_rps",
+          "legendFormat": "{{name}}"
+        }
+      ]
+    }
+  ]
+}

--- a/loadtest/k8s/locust.yaml
+++ b/loadtest/k8s/locust.yaml
@@ -131,3 +131,29 @@ spec:
             limits:
               cpu: "2"
               memory: 1Gi
+# Metrics discovery:
+#   - Annotation-based Prometheus scrapes the master pod via the
+#     prometheus.io/* annotations above (no extra object needed).
+#   - Prometheus Operator (kube-prometheus-stack) ignores those annotations —
+#     it needs a ServiceMonitor. Uncomment below and set the `release` label to
+#     whatever your Prometheus's serviceMonitorSelector matches. Requires the
+#     monitoring.coreos.com CRDs, so it's left commented to keep this manifest
+#     applyable on clusters without the operator.
+#
+# ---
+# apiVersion: monitoring.coreos.com/v1
+# kind: ServiceMonitor
+# metadata:
+#   name: onyx-loadtest
+#   labels:
+#     release: <your-prometheus-release>
+# spec:
+#   namespaceSelector:
+#     matchNames: [<onyx-namespace>]
+#   selector:
+#     matchLabels:
+#       app: onyx-loadtest
+#   endpoints:
+#     - port: metrics
+#       path: /metrics
+#       interval: 15s

--- a/loadtest/k8s/locust.yaml
+++ b/loadtest/k8s/locust.yaml
@@ -33,6 +33,12 @@ spec:
       labels:
         app: onyx-loadtest
         role: master
+      # Scrape Locust milestone metrics (Phase 4 correlation). Drop these if
+      # your Prometheus uses ServiceMonitor/PodMonitor CRDs instead.
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9646"
+        prometheus.io/path: "/metrics"
     spec:
       containers:
         - name: locust-master
@@ -44,6 +50,7 @@ spec:
           ports:
             - containerPort: 8089 # web UI
             - containerPort: 5557 # worker communication
+            - containerPort: 9646 # Prometheus /metrics
           # No ONYX_API_KEY here: the master only coordinates — user
           # greenlets (and API calls) run on the workers.
           env:
@@ -75,6 +82,9 @@ spec:
     - name: comm
       port: 5557
       targetPort: 5557
+    - name: metrics
+      port: 9646
+      targetPort: 9646
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/loadtest/locustfile.py
+++ b/loadtest/locustfile.py
@@ -8,6 +8,7 @@ drives a staged ramp. See README.md for usage and env vars.
 
 import os
 
+import prometheus_exporter  # noqa: F401  (registers the /metrics exporter)
 from onyx_client.chat_user import BasicChatUser
 from scenarios import ChatWithSearchUser
 from scenarios import DeepResearchUser

--- a/loadtest/onyx_client/chat_user.py
+++ b/loadtest/onyx_client/chat_user.py
@@ -97,8 +97,14 @@ class OnyxChatUser(HttpUser):
             if response.status_code != 200:
                 response.failure(f"HTTP {response.status_code}")
                 return None
+            session_id = response.json().get("chat_session_id")
+            if not session_id:
+                # A 200 with no id would otherwise be counted a success while
+                # silently dropping the turn — fail it explicitly instead.
+                response.failure("create-chat-session: missing chat_session_id")
+                return None
             response.success()
-            return response.json().get("chat_session_id")
+            return session_id
 
     def _fire(
         self,
@@ -178,6 +184,9 @@ class OnyxChatUser(HttpUser):
                             f"HTTP {response.status_code}: {response.text[:200]}"
                         ),
                     )
+                    # Abandon a multi-turn session that just errored so the
+                    # next turn starts fresh rather than reusing a bad session.
+                    self._session_id = None
                     return
 
                 for line in response.iter_lines(decode_unicode=True):
@@ -193,6 +202,7 @@ class OnyxChatUser(HttpUser):
                 response.success()
         except Exception as exc:
             self._fire("total_turn", start, exception=exc)
+            self._session_id = None  # don't reuse a session after a failure
             return
 
         if disconnected:

--- a/loadtest/prometheus_collector.py
+++ b/loadtest/prometheus_collector.py
@@ -1,0 +1,69 @@
+"""Prometheus collector for Locust stats — pure prometheus_client, no locust
+import (so it stays gevent-free and unit-testable alongside the fastapi tests).
+
+The locust integration (init listener + http server) lives in
+prometheus_exporter.py, which is imported by locustfile.py for its side effect.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+from prometheus_client.core import CounterMetricFamily
+from prometheus_client.core import GaugeMetricFamily
+
+_LABELS = ["name", "method"]
+
+
+def _percentile(entry: Any, pct: float) -> float:
+    # Prefer the sliding-window value (better for time-series correlation);
+    # fall back to all-time when the response-times cache isn't populated.
+    val = entry.get_current_response_time_percentile(pct)
+    if val is None:
+        val = entry.get_response_time_percentile(pct) or 0
+    return float(val)
+
+
+class LocustCollector:
+    """Pulls current aggregated stats from the runner at scrape time."""
+
+    def __init__(self, environment: Any) -> None:
+        self.environment = environment
+
+    def collect(self) -> Iterator[Any]:
+        runner = self.environment.runner
+        if runner is None:
+            return
+
+        users = GaugeMetricFamily("locust_users", "Current number of users")
+        users.add_metric([], runner.user_count)
+        yield users
+
+        reqs = CounterMetricFamily(
+            "locust_requests_total", "Total requests", labels=_LABELS
+        )
+        fails = CounterMetricFamily(
+            "locust_failures_total", "Total failed requests", labels=_LABELS
+        )
+        p50 = GaugeMetricFamily(
+            "locust_response_time_p50_milliseconds", "p50 response time", labels=_LABELS
+        )
+        p95 = GaugeMetricFamily(
+            "locust_response_time_p95_milliseconds", "p95 response time", labels=_LABELS
+        )
+        rps = GaugeMetricFamily(
+            "locust_current_rps", "Current requests per second", labels=_LABELS
+        )
+        for entry in runner.stats.entries.values():
+            labels = [entry.name, entry.method or ""]
+            reqs.add_metric(labels, entry.num_requests)
+            fails.add_metric(labels, entry.num_failures)
+            p50.add_metric(labels, _percentile(entry, 0.5))
+            p95.add_metric(labels, _percentile(entry, 0.95))
+            rps.add_metric(labels, entry.current_rps or 0)
+        yield reqs
+        yield fails
+        yield p50
+        yield p95
+        yield rps

--- a/loadtest/prometheus_exporter.py
+++ b/loadtest/prometheus_exporter.py
@@ -1,0 +1,37 @@
+"""Locust integration for the Prometheus collector.
+
+Imported for its side effect (the init listener) by locustfile.py. On the
+master/standalone runner it registers the collector and serves /metrics on a
+dedicated port (default 9646; set LOCUST_PROMETHEUS_PORT to override) so chat
+milestone latency / failure rate can be overlaid against server-side metrics
+in Grafana (see dashboards/). No-ops on workers, which lack aggregated stats.
+
+The collector itself lives in prometheus_collector.py (locust-free, so it
+stays gevent-free and unit-testable).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from locust import events
+from locust.runners import WorkerRunner
+from prometheus_client import start_http_server
+from prometheus_client.core import REGISTRY
+from prometheus_collector import LocustCollector
+
+METRICS_PORT = int(os.environ.get("LOCUST_PROMETHEUS_PORT", "9646"))
+
+_started = False
+
+
+@events.init.add_listener
+def _start_prometheus(environment: Any, **_kwargs: Any) -> None:
+    global _started
+    # Workers don't hold aggregated stats; only export from master/standalone.
+    if isinstance(environment.runner, WorkerRunner) or _started:
+        return
+    REGISTRY.register(LocustCollector(environment))
+    start_http_server(METRICS_PORT)
+    _started = True

--- a/loadtest/pyproject.toml
+++ b/loadtest/pyproject.toml
@@ -8,6 +8,8 @@ dependencies = [
     # mock_llm server (also deployed standalone in later phases)
     "fastapi>=0.115",
     "uvicorn>=0.30",
+    # Prometheus exporter for Locust milestone metrics (Phase 4 correlation)
+    "prometheus-client>=0.21",
 ]
 
 [dependency-groups]

--- a/loadtest/shapes.py
+++ b/loadtest/shapes.py
@@ -13,15 +13,24 @@ import os
 
 from locust import LoadTestShape
 
+_DEFAULT_STAGES = "25,50,100,200"
+
 
 def _stage_users() -> list[int]:
-    raw = os.environ.get("ONYX_RAMP_STAGES", "25,50,100,200")
-    return [int(part) for part in raw.split(",") if part.strip()]
+    raw = os.environ.get("ONYX_RAMP_STAGES", _DEFAULT_STAGES)
+    users = [int(part) for part in raw.split(",") if part.strip()]
+    # Empty/garbage (e.g. ONYX_RAMP_STAGES="") would make tick() stop instantly
+    # with no users ever spawned — fall back to the default instead.
+    if not users:
+        users = [int(p) for p in _DEFAULT_STAGES.split(",")]
+    return users
 
 
 class StepRampShape(LoadTestShape):
-    dwell_s: int = int(os.environ.get("ONYX_RAMP_DWELL", "300"))
-    spawn_rate: float = float(os.environ.get("ONYX_RAMP_SPAWN", "5"))
+    # Clamp to sane minimums: a non-positive dwell makes end times non-increasing
+    # (test stops immediately) and a non-positive spawn rate stalls spawning.
+    dwell_s: int = max(1, int(os.environ.get("ONYX_RAMP_DWELL", "300")))
+    spawn_rate: float = max(0.1, float(os.environ.get("ONYX_RAMP_SPAWN", "5")))
 
     def __init__(self) -> None:
         super().__init__()

--- a/loadtest/tests/test_exporter.py
+++ b/loadtest/tests/test_exporter.py
@@ -1,0 +1,81 @@
+"""Tests for the Locust Prometheus collector.
+
+Uses lightweight fakes for the runner/stats so it imports neither locust nor
+gevent — keeping it safe to run in the same pytest session as the fastapi
+mock_llm tests.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from prometheus_collector import LocustCollector
+
+
+class _Entry:
+    def __init__(
+        self, name: str, method: str, num_requests: int, num_failures: int, p95: float
+    ) -> None:
+        self.name = name
+        self.method = method
+        self.num_requests = num_requests
+        self.num_failures = num_failures
+        self.current_rps = 0.0
+        self._p95 = p95
+
+    def get_current_response_time_percentile(self, _pct: float) -> float | None:
+        return None  # cache empty → collector falls back to all-time
+
+    def get_response_time_percentile(self, pct: float) -> float:
+        return self._p95 if pct >= 0.95 else self._p95 / 2
+
+
+class _Stats:
+    def __init__(self, entries: dict[tuple[str, str], _Entry]) -> None:
+        self.entries = entries
+
+
+class _Runner:
+    def __init__(self, stats: _Stats, user_count: int) -> None:
+        self.stats = stats
+        self.user_count = user_count
+
+
+class _Env:
+    def __init__(self, runner: Any) -> None:
+        self.runner = runner
+
+
+def _collect(collector: LocustCollector) -> dict[str, Any]:
+    return {mf.name: mf for mf in collector.collect()}
+
+
+def test_collector_emits_locust_metrics() -> None:
+    entries = {
+        ("chat:total_turn", "CHAT"): _Entry("chat:total_turn", "CHAT", 2, 1, 1200),
+        ("search:first_search_doc", "CHAT"): _Entry(
+            "search:first_search_doc", "CHAT", 1, 0, 300
+        ),
+    }
+    families = _collect(LocustCollector(_Env(_Runner(_Stats(entries), user_count=42))))
+
+    # prometheus_client strips the _total suffix from the family name.
+    assert families["locust_users"].samples[0].value == 42
+
+    reqs = {s.labels["name"]: s.value for s in families["locust_requests"].samples}
+    assert reqs["chat:total_turn"] == 2
+    assert reqs["search:first_search_doc"] == 1
+
+    fails = {s.labels["name"]: s.value for s in families["locust_failures"].samples}
+    assert fails["chat:total_turn"] == 1
+
+    p95 = {
+        s.labels["name"]: s.value
+        for s in families["locust_response_time_p95_milliseconds"].samples
+    }
+    assert p95["chat:total_turn"] > 0
+
+
+def test_collector_no_runner_is_empty() -> None:
+    families = _collect(LocustCollector(_Env(None)))
+    assert families == {}

--- a/loadtest/uv.lock
+++ b/loadtest/uv.lock
@@ -784,6 +784,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "fastapi" },
     { name = "locust" },
+    { name = "prometheus-client" },
     { name = "uvicorn" },
 ]
 
@@ -797,6 +798,7 @@ dev = [
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115" },
     { name = "locust", specifier = ">=2.32" },
+    { name = "prometheus-client", specifier = ">=0.21" },
     { name = "uvicorn", specifier = ">=0.30" },
 ]
 
@@ -822,6 +824,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Phase 4 of the chat load-testing effort — make offered load and server-side saturation readable on a single timeline, so a collapse point can be *correlated* to a resource rather than guessed. **Stacks on #11961 (Phase 3); loadtest-only, no backend changes.** (The diff will show the Phase 3 commits until #11961 merges.)

- **`prometheus_collector.py`** — `LocustCollector` (pure `prometheus_client`, deliberately no `locust` import so it stays gevent-free and unit-testable in the same pytest session as the fastapi mock tests). Emits, by `{name, method}`: `locust_users`, `locust_requests_total`, `locust_failures_total`, `locust_response_time_p50/p95_milliseconds`, `locust_current_rps`.
- **`prometheus_exporter.py`** — Locust `init` listener that registers the collector and serves `/metrics` on a dedicated port (default `9646`, `LOCUST_PROMETHEUS_PORT` to override). Master/standalone only — no-ops on workers (they lack aggregated stats). Imported for side effect by `locustfile.py`.
- **`dashboards/chat-loadtest-correlation.json`** — templated Grafana dashboard overlaying milestone latency / failure-rate / rps with server CPU + memory. Deployment-agnostic: pick a Prometheus datasource and set `$namespace` / `$workload`.
- **Dockerfile** — `pip install prometheus-client==0.25.0` (pinned to `uv.lock`), bake the exporter, `EXPOSE 9646`.
- **`k8s/locust.yaml`** — master pod exposes `9646` + `prometheus.io/scrape` annotations + a `metrics` service port.

## How Has This Been Tested?

- `uv run pytest tests/ -q` → **24 passed** (22 prior + 2 new collector tests). The collector is split from the locust import specifically so the suite doesn't hang on gevent teardown.
- Functional: ran Locust locally against a backend, scraped `:9646/metrics`, confirmed `locust_*` series populate with correct values (counts, p50/p95, rps, users).
- `uvx ruff check . && uvx ruff format --check .` clean.

## Notes

- `/metrics` lives on a dedicated port, independent of `--web-base-path`, so scraping doesn't collide with the UI route.
- DB connection-pool depth isn't a Prometheus metric Onyx exports today; the dashboard uses Locust failure-rate as the client-side proxy and server CPU/mem as the saturation signal. Surfacing pool metrics is a possible follow-up.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Prometheus exporter for Locust milestone metrics and a Grafana dashboard to correlate offered load with server CPU/memory on a single timeline; the throughput panel now respects the `$milestone` filter. Loadtest-only; no backend changes.

- New Features
  - `prometheus_collector.py`: exports `locust_users`, `locust_requests_total`/`locust_failures_total`, `locust_response_time_p50/p95_milliseconds`, `locust_current_rps` by `{name,method}`.
  - `prometheus_exporter.py`: serves `/metrics` on a dedicated port (default `9646`, override `LOCUST_PROMETHEUS_PORT`); master/standalone only.
  - Grafana `dashboards/chat-loadtest-correlation.json`: overlays milestone p50/p95, failure %, and throughput with server CPU/mem; select Prometheus datasource and set `$namespace` / `$workload`. Throughput panel now applies the `$milestone` filter for consistency.
  - K8s master: exposes `9646` with `prometheus.io/scrape` annotations and a `metrics` service port. Prometheus Operator needs a ServiceMonitor — commented example in `k8s/locust.yaml`.
  - Dockerfile: includes `prometheus-client==0.25.0`, bakes exporter, `EXPOSE 9646`; `pyproject.toml` adds `prometheus-client`.
  - Hardening: reset multi-turn session on non-200/exception; fail create-session when id missing; ramp shape clamps dwell/spawn and defaults stages on empty input; dashboard memory unit fixed.

- Migration
  - Scrape `http://<locust-master>:9646/metrics` (or add a ServiceMonitor targeting the `metrics` port).
  - Import the dashboard and set `$namespace` / `$workload`; use the overlay to find the knee where p95/failure rate rise and which resource saturates first.

<sup>Written for commit dd79bd55510a9ea53e1f4066769bda5f13169042. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



