### PR TITLE
feat(craft): copy user and agent messages in the craft chat

### DIFF
--- a/web/src/app/craft/components/BuildAgentMessage.tsx
+++ b/web/src/app/craft/components/BuildAgentMessage.tsx
@@ -37,10 +37,7 @@ export default function BuildAgentMessage({
         <div className="flex-1 flex flex-col gap-2 min-w-0">
           {children}
           {hasCopyableText && (
-            <Hoverable.Item
-              group="craftAgentMessage"
-              variant="appear-on-hover"
-            >
+            <Hoverable.Item group="craftAgentMessage" variant="appear-on-hover">
               <div className="flex pl-1">
                 <CopyButton
                   getCopyText={() => convertMarkdownTablesToTsv(copyText)}

--- a/web/src/app/craft/components/BuildAgentMessage.tsx
+++ b/web/src/app/craft/components/BuildAgentMessage.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { CopyButton } from "@opal/components";
+import { Hoverable } from "@opal/core";
+import Logo from "@/refresh-components/Logo";
+import { convertMarkdownTablesToTsv } from "@/app/app/message/copyingUtils";
+
+interface BuildAgentMessageProps {
+  /** Raw markdown text of the agent's response, used for the copy action. */
+  copyText: string;
+  /** Rendered message body (text chunks, tool cards, thinking, etc.). */
+  children: React.ReactNode;
+  /** Optional trailing content (e.g. approval cards) appended under the turn. */
+  trailing?: React.ReactNode;
+}
+
+/**
+ * BuildAgentMessage - Renders a single saved agent turn in the craft chat.
+ *
+ * Mirrors the main chat's agent message: the body is shown alongside the Onyx
+ * logo, and a hover-revealed copy action (reusing the shared Opal `CopyButton`)
+ * lets the user copy the agent's textual output.
+ */
+export default function BuildAgentMessage({
+  copyText,
+  children,
+  trailing,
+}: BuildAgentMessageProps) {
+  const hasCopyableText = copyText.trim().length > 0;
+
+  return (
+    <Hoverable.Root group="craftAgentMessage" width="full">
+      <div className="flex items-start gap-3 py-4">
+        <div className="shrink-0 h-9 flex items-center">
+          <Logo onyxBranded folded size={24} />
+        </div>
+        <div className="flex-1 flex flex-col gap-2 min-w-0">
+          {children}
+          {hasCopyableText && (
+            <Hoverable.Item
+              group="craftAgentMessage"
+              variant="appear-on-hover"
+            >
+              <div className="flex pl-1">
+                <CopyButton
+                  getCopyText={() => convertMarkdownTablesToTsv(copyText)}
+                  prominence="tertiary"
+                  data-testid="CraftAgentMessage/copy-button"
+                />
+              </div>
+            </Hoverable.Item>
+          )}
+          {trailing}
+        </div>
+      </div>
+    </Hoverable.Root>
+  );
+}

--- a/web/src/app/craft/components/BuildMessageList.test.tsx
+++ b/web/src/app/craft/components/BuildMessageList.test.tsx
@@ -18,6 +18,13 @@ jest.mock("@/app/app/message/BlinkingBar", () => ({
   BlinkingBar: () => <span data-testid="blinking-bar" />,
 }));
 
+// copyingUtils pulls in the ESM-only unified/rehype stack, which Jest cannot
+// parse. The copy text transform is exercised elsewhere; here we only need a
+// passthrough so the component tree renders.
+jest.mock("@/app/app/message/copyingUtils", () => ({
+  convertMarkdownTablesToTsv: (content: string) => content,
+}));
+
 jest.mock("motion/react", () => ({
   AnimatePresence: ({ children }: { children: React.ReactNode }) => (
     <>{children}</>

--- a/web/src/app/craft/components/BuildMessageList.test.tsx
+++ b/web/src/app/craft/components/BuildMessageList.test.tsx
@@ -84,6 +84,31 @@ const savedAssistantMessage: BuildMessage = {
   },
 };
 
+const userMessage: BuildMessage = {
+  id: "user-1",
+  type: "user",
+  content: "Build me a dashboard",
+  timestamp: new Date("2026-01-01T00:00:00Z"),
+};
+
+describe("BuildMessageList copy actions", () => {
+  it("renders a copy button for user messages", () => {
+    renderList({ messages: [userMessage] });
+
+    expect(
+      screen.getByTestId("CraftUserMessage/copy-button")
+    ).toBeInTheDocument();
+  });
+
+  it("renders a copy button for saved agent messages", () => {
+    renderList({ messages: [savedAssistantMessage] });
+
+    expect(
+      screen.getByTestId("CraftAgentMessage/copy-button")
+    ).toBeInTheDocument();
+  });
+});
+
 describe("BuildMessageList thinking visibility", () => {
   it("shows restored thought packets as collapsed thinking rows", () => {
     renderList({ messages: [savedAssistantMessage] });

--- a/web/src/app/craft/components/BuildMessageList.tsx
+++ b/web/src/app/craft/components/BuildMessageList.tsx
@@ -12,6 +12,7 @@ import CraftToolCard from "@/app/craft/components/tool-cards/CraftToolCard";
 import CraftToolGroup from "@/app/craft/components/tool-cards/CraftToolGroup";
 import TodoListCard from "@/app/craft/components/TodoListCard";
 import UserMessage from "@/app/craft/components/UserMessage";
+import BuildAgentMessage from "@/app/craft/components/BuildAgentMessage";
 import { BuildMessage } from "@/app/craft/types/streamingTypes";
 import {
   StreamItem,
@@ -27,6 +28,28 @@ import {
 type RenderBlock =
   | { kind: "tools"; tools: ToolCallState[] }
   | { kind: "item"; item: Exclude<StreamItem, { type: "tool_call" }> };
+
+/**
+ * Extract the agent's textual output for an assistant message so it can be
+ * copied. Prefers the concatenated text from saved stream items (the prose the
+ * agent streamed out), falling back to the message's plain content.
+ */
+function getAgentCopyText(message: BuildMessage): string {
+  const savedStreamItems = message.message_metadata?.streamItems as
+    | StreamItem[]
+    | undefined;
+  if (savedStreamItems && savedStreamItems.length > 0) {
+    const text = savedStreamItems
+      .filter((it): it is Extract<StreamItem, { type: "text" }> =>
+        it.type === "text"
+      )
+      .map((it) => it.content)
+      .join("\n\n")
+      .trim();
+    if (text) return text;
+  }
+  return message.content;
+}
 
 interface BuildMessageListProps {
   messages: BuildMessage[];
@@ -248,29 +271,27 @@ export default function BuildMessageList({
         : null;
 
     return (
-      <div key={message.id} className="flex items-start gap-3 py-4">
-        <div className="shrink-0 h-9 flex items-center">
-          <Logo onyxBranded folded size={24} />
-        </div>
-        <div className="flex-1 flex flex-col gap-2 min-w-0">
-          {visibleSavedRender ? (
-            <>
-              {visibleSavedRender.pinnedTodo && (
-                <div>
-                  <TodoListCard
-                    todoList={visibleSavedRender.pinnedTodo}
-                    defaultOpen={visibleSavedRender.pinnedTodo.isOpen}
-                  />
-                </div>
-              )}
-              {visibleSavedRender.nodes}
-            </>
-          ) : (
-            <TextChunk content={message.content} />
-          )}
-          {trailing}
-        </div>
-      </div>
+      <BuildAgentMessage
+        key={message.id}
+        copyText={getAgentCopyText(message)}
+        trailing={trailing}
+      >
+        {visibleSavedRender ? (
+          <>
+            {visibleSavedRender.pinnedTodo && (
+              <div>
+                <TodoListCard
+                  todoList={visibleSavedRender.pinnedTodo}
+                  defaultOpen={visibleSavedRender.pinnedTodo.isOpen}
+                />
+              </div>
+            )}
+            {visibleSavedRender.nodes}
+          </>
+        ) : (
+          <TextChunk content={message.content} />
+        )}
+      </BuildAgentMessage>
     );
   };
 

--- a/web/src/app/craft/components/BuildMessageList.tsx
+++ b/web/src/app/craft/components/BuildMessageList.tsx
@@ -35,13 +35,14 @@ type RenderBlock =
  * agent streamed out), falling back to the message's plain content.
  */
 function getAgentCopyText(message: BuildMessage): string {
-  const savedStreamItems = message.message_metadata?.streamItems as
-    | StreamItem[]
-    | undefined;
+  const rawItems = message.message_metadata?.streamItems;
+  const savedStreamItems: StreamItem[] | undefined = Array.isArray(rawItems)
+    ? (rawItems as StreamItem[])
+    : undefined;
   if (savedStreamItems && savedStreamItems.length > 0) {
     const text = savedStreamItems
-      .filter((it): it is Extract<StreamItem, { type: "text" }> =>
-        it.type === "text"
+      .filter(
+        (it): it is Extract<StreamItem, { type: "text" }> => it.type === "text"
       )
       .map((it) => it.content)
       .join("\n\n")

--- a/web/src/app/craft/components/UserMessage.tsx
+++ b/web/src/app/craft/components/UserMessage.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { Text, Button } from "@opal/components";
+import { Text, Button, CopyButton } from "@opal/components";
 import { SvgChevronDown } from "@opal/icons";
+import { Hoverable } from "@opal/core";
 
 const COLLAPSED_MAX_PX = 240; // ~10 lines
 
@@ -51,10 +52,19 @@ function ClampedContent({ content }: { content: string }) {
 
 export default function UserMessage({ content }: UserMessageProps) {
   return (
-    <div className="flex justify-end py-4">
-      <div className="max-w-[80%] whitespace-break-spaces rounded-t-16 rounded-bl-16 bg-background-tint-02 py-3 px-4">
-        <ClampedContent content={content} />
+    <Hoverable.Root group="craftUserMessage" width="full">
+      <div className="flex items-start justify-end gap-1 py-4">
+        <Hoverable.Item group="craftUserMessage" variant="appear-on-hover">
+          <CopyButton
+            getCopyText={() => content}
+            prominence="tertiary"
+            data-testid="CraftUserMessage/copy-button"
+          />
+        </Hoverable.Item>
+        <div className="max-w-[80%] whitespace-break-spaces rounded-t-16 rounded-bl-16 bg-background-tint-02 py-3 px-4">
+          <ClampedContent content={content} />
+        </div>
       </div>
-    </div>
+    </Hoverable.Root>
   );
 }


### PR DESCRIPTION
## Summary

Adds the ability to copy chat messages in **Onyx Craft**, matching how copying works in the main chat window. Both the user's own messages and the agent's textual output can now be copied, reusing the exact same shared component used by the main chat.

## What changed

- **Reuses the shared Opal `CopyButton`** (`@opal/components`) and the `Hoverable` reveal pattern (`@opal/core`) — the same components the main chat uses in `HumanMessage.tsx` and `MessageToolbar.tsx`. No new copy logic was introduced.
- **`UserMessage.tsx`** — a hover-revealed copy button now sits beside the user's message bubble (mirrors the main chat's human message copy affordance).
- **`BuildAgentMessage.tsx`** (new) — wraps a saved agent turn (logo + body) and adds a hover-revealed copy button that copies the agent's markdown output, running it through the shared `convertMarkdownTablesToTsv` helper for spreadsheet-friendly tables (same util the main chat uses).
- **`BuildMessageList.tsx`** — renders agent turns through `BuildAgentMessage` and derives the copyable text from the saved stream items (falling back to `message.content`).

## Testing

- Added unit tests in `BuildMessageList.test.tsx` asserting the copy buttons render for both user and saved agent messages.
- `oxlint` passes on all changed files.

## Notes

The copy button appears on hover to keep the craft chat visually clean, consistent with the main chat's `HumanMessage` hover affordance.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable copying in Craft chat for both user messages and agent responses, matching the main chat behavior. Uses the shared `CopyButton` and hover reveal to copy plain text and agent markdown (tables converted to TSV).

- **New Features**
  - Reuse `@opal/components` `CopyButton` and `@opal/core` `Hoverable`; no new copy logic.
  - `UserMessage`: adds a hover-revealed copy button beside the user bubble.
  - `BuildAgentMessage` + `BuildMessageList`: render agent turns with a hover copy button; copy text comes from saved stream items (fallback to `message.content`) and runs through `convertMarkdownTablesToTsv`.

- **Bug Fixes**
  - Safely read `message_metadata.streamItems` using `Array.isArray` to prevent crashes on bad metadata.
  - Mock `copyingUtils` in tests to avoid Jest ESM parsing issues.

<sup>Written for commit 13747c6253b5dc9875c4ff2bf198ddf1cda3abdc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

