### PR TITLE
fix(load-tests): add title + uid to correlation dashboard

### DIFF
--- a/loadtest/dashboards/chat-loadtest-correlation.json
+++ b/loadtest/dashboards/chat-loadtest-correlation.json
@@ -1,5 +1,7 @@
 {
   "__inputs": [],
+  "title": "Onyx Chat Load Test — Correlation",
+  "uid": "onyx-chat-loadtest-correlation",
   "annotations": { "list": [] },
   "description": "Overlays Locust chat-path milestone latency / failure rate (from the loadtest Prometheus exporter) with server-side resource usage, so load and saturation can be read on one timeline. Templated: pick a Prometheus datasource and set $namespace / $workload to the Onyx deployment under test.",
   "editable": true,


### PR DESCRIPTION
## Description

The Phase 4 correlation dashboard JSON (`loadtest/dashboards/chat-loadtest-correlation.json`) was missing a top-level `title` (and `uid`). Grafana won't load a dashboard without a title — when provisioned via the kube-prometheus-stack sidecar, the file is written but the dashboard never appears in the UI.

Adds `"title": "Onyx Chat Load Test — Correlation"` and a stable `"uid": "onyx-chat-loadtest-correlation"`.

## How Has This Been Tested?

Loaded the corrected JSON into the st-dev Grafana via its dashboard ConfigMap (sidecar) and confirmed the dashboard renders and its panels query the `locust_*` + container metrics. `json.load` validates.

Follows #11967 (Phase 4).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add missing title and uid to the Phase 4 correlation dashboard JSON so Grafana loads it. Fixes provisioning via the `kube-prometheus-stack` sidecar and makes the dashboard visible in the UI.

<sup>Written for commit f8d954307c656d6c02b1c5374683fcc73efc34bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

