### PR TITLE
fix(web-connector): apply URL validation across all fetch paths

### DIFF
--- a/backend/onyx/connectors/web/connector.py
+++ b/backend/onyx/connectors/web/connector.py
@@ -144,6 +144,10 @@ def protected_url_check(url: str) -> None:
 
 
 def check_internet_connection(url: str) -> None:
+    # SSRF guard on the fetch primitive itself, so no call site can reach an
+    # internal target. No-op unless SSRF protection is at its strictest level.
+    protected_url_check(url)
+
     try:
         # Use a more realistic browser-like request
         session = requests.Session()
@@ -240,6 +244,11 @@ def get_internal_links(
 
 
 def extract_urls_from_sitemap(sitemap_url: str) -> list[str]:
+    # SSRF guard. This fetch runs in __init__, before validation, so the check
+    # must live here. Placed before the try so it surfaces as the SSRF error
+    # rather than a wrapped sitemap-parse failure.
+    protected_url_check(sitemap_url)
+
     # Note: brotli compression is handled automatically by the requests library
     # as long as the brotli package is installed in the venv.
     try:
@@ -725,16 +734,11 @@ class WebConnector(LoadConnector, SlimConnector):
                 "No URL configured. Please provide at least one valid URL."
             )
 
-        if (
-            self.web_connector_type == WEB_CONNECTOR_VALID_SETTINGS.SITEMAP.value
-            or self.web_connector_type == WEB_CONNECTOR_VALID_SETTINGS.RECURSIVE.value
-        ):
-            return None
-
         # We'll just test the first URL for connectivity and correctness
         test_url = self.to_visit_list[0]
 
-        # Check that the URL is allowed and well-formed
+        # SSRF check runs for every connector type so an internal target is
+        # rejected at creation rather than at index time.
         try:
             protected_url_check(test_url)
         except ValueError as e:
@@ -744,6 +748,14 @@ class WebConnector(LoadConnector, SlimConnector):
         except ConnectionError as e:
             # Typically DNS or other network issues
             raise ConnectorValidationError(str(e))
+
+        # Recursive/sitemap defer page fetches to index time; skip the connectivity
+        # probe for them (the SSRF check above still ran).
+        if (
+            self.web_connector_type == WEB_CONNECTOR_VALID_SETTINGS.SITEMAP.value
+            or self.web_connector_type == WEB_CONNECTOR_VALID_SETTINGS.RECURSIVE.value
+        ):
+            return None
 
         # Make a quick request to see if we get a valid response
         try:

--- a/backend/onyx/connectors/web/connector.py
+++ b/backend/onyx/connectors/web/connector.py
@@ -757,7 +757,8 @@ class WebConnector(LoadConnector, SlimConnector):
         ):
             return None
 
-        # Make a quick request to see if we get a valid response
+        # Make a quick request to see if we get a valid response. This re-runs the
+        # SSRF check internally (intentional, cheap defense-in-depth).
         try:
             check_internet_connection(test_url)
         except Exception as e:

--- a/backend/tests/unit/onyx/connectors/web/test_ssrf_protection.py
+++ b/backend/tests/unit/onyx/connectors/web/test_ssrf_protection.py
@@ -33,9 +33,7 @@ def _enforce_ssrf(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         web_connector,
         "get_security_settings",
-        lambda: SimpleNamespace(
-            ssrf_protection_level=SSRFProtectionLevel.VALIDATE_ALL
-        ),
+        lambda: SimpleNamespace(ssrf_protection_level=SSRFProtectionLevel.VALIDATE_ALL),
     )
 
 

--- a/backend/tests/unit/onyx/connectors/web/test_ssrf_protection.py
+++ b/backend/tests/unit/onyx/connectors/web/test_ssrf_protection.py
@@ -61,7 +61,9 @@ def test_extract_urls_from_sitemap_blocks_internal_before_fetch() -> None:
         WEB_CONNECTOR_VALID_SETTINGS.RECURSIVE.value,
     ],
 )
-def test_validate_rejects_internal_target_for_all_types(connector_type: str) -> None:
+def test_validate_rejects_internal_target_for_single_and_recursive(
+    connector_type: str,
+) -> None:
     """Validation must reject an internal base_url for both single and recursive."""
     connector = WebConnector(base_url=PRIVATE_URL, web_connector_type=connector_type)
     with pytest.raises(ConnectorValidationError, match="Protected URL check failed"):

--- a/backend/tests/unit/onyx/connectors/web/test_ssrf_protection.py
+++ b/backend/tests/unit/onyx/connectors/web/test_ssrf_protection.py
@@ -1,0 +1,82 @@
+"""The web connector must not fetch internal/loopback targets (SSRF) anywhere in
+its lifecycle — sitemap construction, validation, or indexing — at the default
+VALIDATE_ALL level. Covers the recursive and sitemap paths (ON-001 / ON-002).
+
+Targets use literal IPs so socket.getaddrinfo resolves locally (hermetic).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from onyx.connectors.exceptions import ConnectorValidationError
+from onyx.connectors.web import connector as web_connector
+from onyx.connectors.web.connector import check_internet_connection
+from onyx.connectors.web.connector import extract_urls_from_sitemap
+from onyx.connectors.web.connector import WEB_CONNECTOR_VALID_SETTINGS
+from onyx.connectors.web.connector import WebConnector
+from onyx.server.security.models import SSRFProtectionLevel
+
+LOOPBACK_URL = "http://127.0.0.1:9999/ssrf-poc"
+PRIVATE_URL = "http://10.0.0.5/internal"
+# Cloud metadata endpoint (link-local).
+METADATA_URL = "http://169.254.169.254/latest/meta-data/"
+
+
+@pytest.fixture(autouse=True)
+def _enforce_ssrf(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force the most restrictive SSRF level so ``protected_url_check`` enforces,
+    independent of DB/env resolution."""
+    monkeypatch.setattr(
+        web_connector,
+        "get_security_settings",
+        lambda: SimpleNamespace(
+            ssrf_protection_level=SSRFProtectionLevel.VALIDATE_ALL
+        ),
+    )
+
+
+def test_check_internet_connection_blocks_internal_before_fetch() -> None:
+    """The connectivity primitive must reject an internal target before any GET."""
+    with patch.object(web_connector.requests, "Session") as mock_session:
+        with pytest.raises(ValueError, match="Non-global IP"):
+            check_internet_connection(LOOPBACK_URL)
+        mock_session.assert_not_called()
+
+
+def test_extract_urls_from_sitemap_blocks_internal_before_fetch() -> None:
+    """The sitemap fetch (runs in ``__init__``) must reject an internal target
+    before any GET."""
+    with patch.object(web_connector.requests, "get") as mock_get:
+        with pytest.raises(ValueError, match="Non-global IP"):
+            extract_urls_from_sitemap(PRIVATE_URL)
+        mock_get.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "connector_type",
+    [
+        WEB_CONNECTOR_VALID_SETTINGS.SINGLE.value,
+        WEB_CONNECTOR_VALID_SETTINGS.RECURSIVE.value,
+    ],
+)
+def test_validate_rejects_internal_target_for_all_types(connector_type: str) -> None:
+    """Validation must reject an internal base_url for both single and recursive."""
+    connector = WebConnector(base_url=PRIVATE_URL, web_connector_type=connector_type)
+    with pytest.raises(ConnectorValidationError, match="Protected URL check failed"):
+        connector.validate_connector_settings()
+
+
+def test_sitemap_connector_construction_blocks_internal() -> None:
+    """A sitemap connector fetches at construction; an internal sitemap URL must
+    fail before any outbound request — the connector can't even be instantiated."""
+    with patch.object(web_connector.requests, "get") as mock_get:
+        with pytest.raises(ValueError, match="Non-global IP"):
+            WebConnector(
+                base_url=METADATA_URL,
+                web_connector_type=WEB_CONNECTOR_VALID_SETTINGS.SITEMAP.value,
+            )
+        mock_get.assert_not_called()


### PR DESCRIPTION
## Summary

`protected_url_check` was applied inconsistently across the web connector — it ran on the single/upload validation path and the recursive crawl loop, but not on the sitemap fetch (which happens in `__init__`), the index-time base-url connectivity probe, or recursive/sitemap validation. This applies the same check across all fetch entry points so validation behaves consistently regardless of connector type.

## Changes
- `check_internet_connection` runs the check on the fetch primitive itself
- `extract_urls_from_sitemap` checks before the sitemap fetch in `__init__`
- `validate_connector_settings` runs the check for recursive/sitemap too, rejecting disallowed targets at creation time

These are no-ops unless SSRF protection is at its strictest level, so there is no behavior change for deployments at other levels.

## Testing
- New hermetic unit test (`test_ssrf_protection.py`) covering each fetch path
- Full web-connector unit suite + `ty check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply SSRF URL validation across all web-connector fetch paths to block internal, private, and metadata IPs consistently. Aligns behavior for single, recursive, and sitemap connectors; only affects deployments with SSRF at `VALIDATE_ALL`.

- **Bug Fixes**
  - Run the check in `check_internet_connection`, before sitemap fetch in `__init__`, and during settings validation for recursive/sitemap.
  - Reject disallowed targets at creation/instantiation; recursive/sitemap skip the connectivity probe, and the probe re-checks SSRF for single/upload as defense-in-depth.
  - Updated hermetic tests to cover connectivity, sitemap, and validation paths; renamed the validate test to reflect single + recursive and verified no network calls occur when blocked.

<sup>Written for commit 33e8f2a57b60ba8a1409faace0c3da0acc311bc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11973?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

