### PR TITLE
feat(load-tests): file-attachment scenario for connection-hold testing 5/n

### DIFF
--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -160,6 +160,7 @@ The API key is created by an admin via `POST /api/admin/api-key`
 | `ONYX_MSG_CHARS` | 0 | Per-message size in chars (CompressionUser defaults to 8000; 0 = short questions) |
 | `ONYX_DISCONNECT_AFTER` | `first_answer_token` | Milestone after which DisconnectUser drops the stream |
 | `ONYX_FILE_KB` | 512 | Uploaded file size (KB) for FileAttachmentUser |
+| `ONYX_HOST_HEADER` | unset | `Host` header to send (set when `LOCUST_HOST` targets an internal Service to bypass an external ALB/WAF for high-rps runs) |
 | `ONYX_SHAPE` | unset | `stepramp` activates the staged ramp shape |
 | `ONYX_RAMP_STAGES` / `ONYX_RAMP_DWELL` / `ONYX_RAMP_SPAWN` | `25,50,100,200` / 300 / 5 | Ramp user plateaus, dwell seconds, spawn rate |
 | `ONYX_WAIT_SECONDS` | 15 | Think time between turns per user |

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -116,6 +116,12 @@ mode. Each maps to a real production incident class:
 ONYX_LONGCONV_MODEL=mock-smallctx \
 ... uv run locust --headless -u 25 -r 5 -t 20m -H https://<your-onyx-url> CompressionUser
 ```
+- **FileAttachmentUser** (`fileattach:*`) — uploads one file (`ONYX_FILE_KB`,
+  default 512) up front, then attaches it to every message. Exercises the
+  chat-setup path that loads attached files from object storage while the DB
+  connection is held — the connection-hold contributor that plain-text
+  scenarios never touch. Set `ONYX_SESSION_TURNS > 1` to accumulate files
+  across a growing history (a file-heavy long chat).
 
 ```bash
 ... uv run locust --headless -u 50 -r 5 -t 15m -H https://<your-onyx-url> LongConversationUser
@@ -153,6 +159,7 @@ The API key is created by an admin via `POST /api/admin/api-key`
 | `ONYX_SESSION_TURNS` | 1 | Turns to keep one session alive (LongConversationUser 20, CompressionUser 60) |
 | `ONYX_MSG_CHARS` | 0 | Per-message size in chars (CompressionUser defaults to 8000; 0 = short questions) |
 | `ONYX_DISCONNECT_AFTER` | `first_answer_token` | Milestone after which DisconnectUser drops the stream |
+| `ONYX_FILE_KB` | 512 | Uploaded file size (KB) for FileAttachmentUser |
 | `ONYX_SHAPE` | unset | `stepramp` activates the staged ramp shape |
 | `ONYX_RAMP_STAGES` / `ONYX_RAMP_DWELL` / `ONYX_RAMP_SPAWN` | `25,50,100,200` / 300 / 5 | Ramp user plateaus, dwell seconds, spawn rate |
 | `ONYX_WAIT_SECONDS` | 15 | Think time between turns per user |

--- a/loadtest/locustfile.py
+++ b/loadtest/locustfile.py
@@ -14,6 +14,7 @@ from scenarios import ChatWithSearchUser
 from scenarios import CompressionUser
 from scenarios import DeepResearchUser
 from scenarios import DisconnectUser
+from scenarios import FileAttachmentUser
 from scenarios import LongConversationUser
 from scenarios import MultiToolUser
 
@@ -25,6 +26,7 @@ __all__ = [
     "LongConversationUser",
     "DisconnectUser",
     "CompressionUser",
+    "FileAttachmentUser",
 ]
 
 # Expose the ramp only on request: Locust auto-activates any shape it finds,

--- a/loadtest/onyx_client/chat_user.py
+++ b/loadtest/onyx_client/chat_user.py
@@ -108,6 +108,15 @@ class OnyxChatUser(HttpUser):
         self._parent_message_id: int | None = None
         self._session_turn: int = 0
 
+        # File attachments to include on every turn (populated by scenarios
+        # that exercise the file path; empty for plain chat).
+        self.file_descriptors: list[dict[str, Any]] = []
+        self.setup_files()
+
+    def setup_files(self) -> None:
+        """Hook for scenarios to upload files and populate file_descriptors.
+        No-op by default."""
+
     def _create_session(self) -> str | None:
         """Open a session for a multi-turn conversation; None on failure."""
         with self.client.post(
@@ -170,6 +179,8 @@ class OnyxChatUser(HttpUser):
             payload["llm_override"] = self.llm_override
         if self.deep_research:
             payload["deep_research"] = True
+        if self.file_descriptors:
+            payload["file_descriptors"] = self.file_descriptors
         return payload
 
     @task

--- a/loadtest/onyx_client/chat_user.py
+++ b/loadtest/onyx_client/chat_user.py
@@ -87,6 +87,13 @@ class OnyxChatUser(HttpUser):
             raise RuntimeError("ONYX_API_KEY env var is required")
         self.client.headers["Authorization"] = f"Bearer {api_key}"
 
+        # When LOCUST_HOST points at an internal Service (to bypass an external
+        # ALB/WAF rate limit for high-rps runs), set ONYX_HOST_HEADER to the
+        # real domain so the in-cluster nginx routes by Host as usual.
+        host_header = os.environ.get("ONYX_HOST_HEADER")
+        if host_header:
+            self.client.headers["Host"] = host_header
+
         provider = os.environ.get("ONYX_LLM_PROVIDER")
         model = self.mock_model or os.environ.get("ONYX_LLM_MODEL")
         self.llm_override: dict[str, Any] | None = None

--- a/loadtest/scenarios/__init__.py
+++ b/loadtest/scenarios/__init__.py
@@ -2,6 +2,7 @@ from scenarios.chat_with_search import ChatWithSearchUser
 from scenarios.compression import CompressionUser
 from scenarios.deep_research import DeepResearchUser
 from scenarios.disconnect import DisconnectUser
+from scenarios.file_attachment import FileAttachmentUser
 from scenarios.long_conversation import LongConversationUser
 from scenarios.multi_tool import MultiToolUser
 
@@ -10,6 +11,7 @@ __all__ = [
     "ChatWithSearchUser",
     "DeepResearchUser",
     "DisconnectUser",
+    "FileAttachmentUser",
     "LongConversationUser",
     "MultiToolUser",
 ]

--- a/loadtest/scenarios/file_attachment.py
+++ b/loadtest/scenarios/file_attachment.py
@@ -1,0 +1,63 @@
+"""Chat turns that carry a file attachment.
+
+Each user uploads one file up front, then attaches it to every message. This
+exercises the chat-setup path that loads attached files from object storage
+(MinIO/S3) inside `build_chat_turn` *while the DB connection is held* — the
+suspected connection-pool-hold contributor that plain-text scenarios never
+touch (they attach no files). Set ONYX_SESSION_TURNS > 1 to also accumulate
+files across a growing history (a file-heavy long chat).
+
+Tuning (env):
+    ONYX_FILE_KB   uploaded file size in KB (default 512) — bigger = longer
+                   object-storage read held across the connection.
+
+Selected explicitly (not in the default mix):
+    locust -f locustfile.py FileAttachmentUser
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from onyx_client.chat_user import OnyxChatUser
+from onyx_client.env import env_int
+
+
+class FileAttachmentUser(OnyxChatUser):
+    abstract = False
+
+    scenario_prefix: str = "fileattach"
+
+    def setup_files(self) -> None:
+        kb = env_int("ONYX_FILE_KB", 512)
+        # ~1KB repeating unit, truncated to the requested size.
+        unit = b"Onyx load-test attachment payload. Lorem ipsum dolor sit. " * 18
+        blob = (unit * max(1, kb))[: kb * 1024]
+        filename = f"loadtest-{uuid.uuid4().hex[:8]}.txt"
+
+        with self.client.post(
+            "/api/user/projects/file/upload",
+            files={"files": (filename, blob, "text/plain")},
+            name=f"{self.scenario_prefix}:upload",
+            catch_response=True,
+        ) as response:
+            if response.status_code != 200:
+                response.failure(f"HTTP {response.status_code}: {response.text[:200]}")
+                return
+            user_files = response.json().get("user_files", [])
+            if not user_files:
+                response.failure("upload: no user_files in response")
+                return
+            response.success()
+            self.file_descriptors = [
+                {
+                    "id": uf["file_id"],
+                    "type": uf["chat_file_type"],
+                    "name": uf["name"],
+                    "user_file_id": str(uf["id"]),
+                }
+                for uf in user_files
+            ]
+
+    # chat_turn (the @task) is inherited from OnyxChatUser; it now includes
+    # self.file_descriptors in the payload, so every turn attaches the file.


### PR DESCRIPTION
- [x] Override Linear Check

## Description

Adds **FileAttachmentUser** to test the one path the existing scenarios never exercise: attached-file loading during chat setup. Each user uploads one file (`ONYX_FILE_KB`, default 512) and attaches it to every message, so `build_chat_turn` loads it from object storage (MinIO/S3) **while the DB connection is held**.

This is the targeted reproducer for the connection-pool-hold hypothesis in ENG-4210: plain-text load tests collapse via CPU starvation (fixed by api CPU + HPA), but the *code-level* concern — holding a PG connection across object-storage I/O in `build_chat_turn` — only triggers with file attachments, which no prior scenario sends. This lets us confirm (or rule out) whether that pattern causes a connection-hold collapse under load before investing in a code change.

- Base `OnyxChatUser` gains a `setup_files()` hook (no-op default) and threads `self.file_descriptors` into the send payload.
- `FileAttachmentUser` uploads via `/api/user/projects/file/upload` and attaches the returned descriptor every turn. Honors `ONYX_SESSION_TURNS > 1` to accumulate files across a growing history.

## How Has This Been Tested?

Locally against a running backend + mock LLM: upload succeeded and 10 file-attached turns completed with **0 failures** (`uv run pytest tests/ -q` → 24 pass, ruff clean). The first turn took ~6.3s vs ~150ms after — the file plaintext-extraction/load cost is visible, confirming the attached-file path is actually exercised.

Stacks logically after the Phase 3/4 harness; loadtest-only, no backend changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a file-attachment load-test scenario to stress object-storage loading during chat setup while a DB connection is held, targeting ENG-4210. Also adds `ONYX_HOST_HEADER` for internal routing on high-RPS runs. Loadtest-only, no backend changes.

- **New Features**
  - Added `FileAttachmentUser` (`fileattach:*`): uploads one file (`ONYX_FILE_KB`, default 512 KB) and attaches it on every turn; honors `ONYX_SESSION_TURNS` to grow history.
  - Extended base `OnyxChatUser` with `setup_files()` and `file_descriptors` in the send payload; added optional `ONYX_HOST_HEADER` to set `Host` when targeting an internal Service.
  - Exposed the scenario in `locustfile.py` and `scenarios/__init__.py`; updated README with `ONYX_FILE_KB` and `ONYX_HOST_HEADER`.

<sup>Written for commit 225a86ee8188962bf2aa2b99848209c665426471. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

