### PR TITLE
feat(reindex): OpenSearch PIT scan + create-only writes (4/11)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -318,7 +318,7 @@
         "--loglevel=INFO",
         "--hostname=light@%n",
         "-Q",
-        "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration"
+        "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration,port"
       ],
       "presentation": {
         "group": "2",
@@ -606,7 +606,7 @@
         "--loglevel=INFO",
         "--hostname=light@%n",
         "-Q",
-        "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration"
+        "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration,port"
       ],
       "presentation": {
         "group": "2",

--- a/backend/alembic/versions/d49e41659191_add_port_attempt_and_sync_flags.py
+++ b/backend/alembic/versions/d49e41659191_add_port_attempt_and_sync_flags.py
@@ -40,6 +40,12 @@ def upgrade() -> None:
         sa.Column("last_processed_doc_id", sa.String(), nullable=True),
         sa.Column("docs_ported", sa.Integer(), server_default="0", nullable=False),
         sa.Column("last_progress_time", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "cancel_requested",
+            sa.Boolean(),
+            server_default=sa.false(),
+            nullable=False,
+        ),
         sa.Column("error_msg", sa.Text(), nullable=True),
         sa.Column("celery_task_id", sa.String(), nullable=True),
         sa.Column(

--- a/backend/onyx/background/celery/apps/app_base.py
+++ b/backend/onyx/background/celery/apps/app_base.py
@@ -237,6 +237,30 @@ def on_task_postrun(
         return
 
 
+def on_task_revoked(
+    request: Any | None = None,
+    **kwds: Any,  # noqa: ARG001
+) -> None:
+    """Drain the doc-sync taskset when a task is revoked/expired.
+
+    Expired tasks are discarded before running, so task_postrun (which normally
+    srem's the taskset) never fires. Without this, the stranded id keeps the
+    taskset non-empty and wedges the sync fence until its 7-day TTL.
+    """
+    task_id = getattr(request, "id", None)
+    if not task_id:
+        return
+
+    if not task_id.startswith(DOCUMENT_SYNC_PREFIX):
+        return
+
+    request_kwargs = getattr(request, "kwargs", None) or {}
+    tenant_id = cast(str, request_kwargs.get("tenant_id", POSTGRES_DEFAULT_SCHEMA))
+
+    r = get_redis_client(tenant_id=tenant_id)
+    r.srem(DOCUMENT_SYNC_TASKSET_KEY, task_id)
+
+
 def on_celeryd_init(
     sender: str,  # noqa: ARG001
     conf: Any = None,  # noqa: ARG001

--- a/backend/onyx/background/celery/apps/light.py
+++ b/backend/onyx/background/celery/apps/light.py
@@ -70,6 +70,7 @@ def on_task_retry(sender: Any | None = None, **kwargs: Any) -> None:  # noqa: AR
 def on_task_revoked(sender: Any | None = None, **kwargs: Any) -> None:
     task_name = getattr(sender, "name", None) or str(sender)
     on_celery_task_revoked(kwargs.get("task_id"), task_name)
+    app_base.on_task_revoked(**kwargs)
 
 
 @signals.task_rejected.connect
@@ -158,6 +159,7 @@ celery_app.autodiscover_tasks(
             "onyx.background.celery.tasks.connector_deletion",
             "onyx.background.celery.tasks.doc_permission_syncing",
             "onyx.background.celery.tasks.docprocessing",
+            "onyx.background.celery.tasks.port",
             "onyx.background.celery.tasks.opensearch_migration",
             # Sandbox cleanup tasks (isolated in build feature)
             "onyx.server.features.build.sandbox.tasks",

--- a/backend/onyx/background/celery/apps/primary.py
+++ b/backend/onyx/background/celery/apps/primary.py
@@ -350,6 +350,7 @@ celery_app.autodiscover_tasks(
         [
             "onyx.background.celery.tasks.connector_deletion",
             "onyx.background.celery.tasks.docprocessing",
+            "onyx.background.celery.tasks.port",
             "onyx.background.celery.tasks.evals",
             "onyx.background.celery.tasks.hierarchyfetching",
             "onyx.background.celery.tasks.pruning",

--- a/backend/onyx/background/celery/tasks/beat_schedule.py
+++ b/backend/onyx/background/celery/tasks/beat_schedule.py
@@ -73,6 +73,18 @@ beat_task_templates: list[dict] = [
         },
     },
     {
+        "name": "check-for-port",
+        "task": OnyxCeleryTask.CHECK_FOR_PORT,
+        "schedule": timedelta(seconds=30),
+        "options": {
+            "priority": OnyxCeleryPriority.MEDIUM,
+            "expires": BEAT_EXPIRES_DEFAULT,
+            # Intentionally gated (skip_gated defaults True): don't run the port's
+            # expensive re-embed for non-paying tenants; it pauses and self-heals on un-gate.
+            "work_gated": True,
+        },
+    },
+    {
         "name": "check-for-checkpoint-cleanup",
         "task": OnyxCeleryTask.CHECK_FOR_CHECKPOINT_CLEANUP,
         "schedule": timedelta(hours=1),
@@ -294,6 +306,7 @@ if (
 # Beat task names that require a vector DB. Filtered out when DISABLE_VECTOR_DB.
 _VECTOR_DB_BEAT_TASK_NAMES: set[str] = {
     "check-for-indexing",
+    "check-for-port",
     "check-for-connector-deletion",
     "check-for-vespa-sync",
     "check-for-pruning",

--- a/backend/onyx/background/celery/tasks/connector_deletion/tasks.py
+++ b/backend/onyx/background/celery/tasks/connector_deletion/tasks.py
@@ -49,6 +49,8 @@ from onyx.db.permission_sync_attempt import (
 from onyx.db.permission_sync_attempt import (
     delete_external_group_permission_sync_attempts__no_commit,
 )
+from onyx.db.port_attempt import get_active_port_attempt
+from onyx.db.port_attempt import request_port_cancel
 from onyx.db.search_settings import get_all_search_settings
 from onyx.db.sync_record import cleanup_sync_records
 from onyx.db.sync_record import insert_sync_record
@@ -320,6 +322,23 @@ def try_generate_document_cc_pair_cleanup_tasks(
                 inc_deletion_blocked(tenant_id, "indexing")
                 raise TaskDependencyError(
                     "Connector deletion - Delayed (indexing in progress): "
+                    f"cc_pair={cc_pair_id} "
+                    f"search_settings={search_settings.id}"
+                )
+
+            # A running port could re-add docs we're deleting (create-only write).
+            # request_port_cancel asks it to stop but leaves it active, so
+            # get_active_port_attempt keeps returning it until the port acks terminal
+            # after its last write — making cleanup the last writer. A dead port is
+            # failed by the stall watchdog.
+            active_port = get_active_port_attempt(
+                db_session, cc_pair_id, search_settings.id
+            )
+            if active_port is not None:
+                request_port_cancel(db_session, active_port.id)
+                inc_deletion_blocked(tenant_id, "port")
+                raise TaskDependencyError(
+                    "Connector deletion - Delayed (waiting for in-progress port to stop): "
                     f"cc_pair={cc_pair_id} "
                     f"search_settings={search_settings.id}"
                 )

--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -1798,6 +1798,9 @@ def _docprocessing_task(
             )
             search_settings_id: int = index_attempt.search_settings.id
             from_beginning: bool = index_attempt.from_beginning
+            # FUTURE build: skip the PRESENT-only content_hash dedup so the two
+            # indices don't suppress each other's writes.
+            index_to_secondary: bool = index_attempt.search_settings.status.is_future()
 
         # Session is now closed; no connection held during embedding.
 
@@ -1833,6 +1836,7 @@ def _docprocessing_task(
             embedder=embedding_model,
             document_indices=document_indices,
             ignore_time_skip=True,  # Documents are already filtered during extraction
+            index_to_secondary=index_to_secondary,
             tenant_id=tenant_id,
             document_batch=documents,
             request_id=index_attempt_metadata.request_id,

--- a/backend/onyx/background/celery/tasks/docprocessing/utils.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/utils.py
@@ -221,8 +221,14 @@ def should_index(
             # )
             return False
 
-    # When switching over models, always index at least once
-    if search_settings_instance.status == IndexModelStatus.FUTURE:
+    # Legacy FUTURE reindex indexes once, then stops so the swap can fire. A
+    # port-flow FUTURE polls continuously like PRESENT (its synthetic seed primes
+    # the cursor), so skip this block and fall through.
+    # TODO(subash): drop this branch once all FUTUREs use the port flow.
+    if (
+        search_settings_instance.status == IndexModelStatus.FUTURE
+        and not search_settings_instance.use_port_flow
+    ):
         if last_index_attempt:
             # No new index if the last index attempt succeeded
             # Once is enough. The model will never be able to swap otherwise.

--- a/backend/onyx/background/celery/tasks/monitoring/tasks.py
+++ b/backend/onyx/background/celery/tasks/monitoring/tasks.py
@@ -150,6 +150,7 @@ def _collect_queue_metrics(redis_celery: Redis) -> list[Metric]:
     queue_mappings = {
         "celery_queue_length": OnyxCeleryQueues.PRIMARY,
         "docprocessing_queue_length": OnyxCeleryQueues.DOCPROCESSING,
+        "port_queue_length": OnyxCeleryQueues.PORT,
         "docfetching_queue_length": OnyxCeleryQueues.CONNECTOR_DOC_FETCHING,
         "sync_queue_length": OnyxCeleryQueues.VESPA_METADATA_SYNC,
         "deletion_queue_length": OnyxCeleryQueues.CONNECTOR_DELETION,
@@ -910,6 +911,7 @@ def monitor_celery_queues_helper(
         OnyxCeleryQueues.CONNECTOR_DOC_FETCHING, r_celery
     )
     n_docprocessing = celery_get_queue_length(OnyxCeleryQueues.DOCPROCESSING, r_celery)
+    n_port = celery_get_queue_length(OnyxCeleryQueues.PORT, r_celery)
 
     n_user_file_processing = celery_get_queue_length(
         OnyxCeleryQueues.USER_FILE_PROCESSING, r_celery
@@ -966,6 +968,7 @@ def monitor_celery_queues_helper(
         f"docfetching_prefetched={len(n_docfetching_prefetched)} "
         f"docprocessing={n_docprocessing} "
         f"docprocessing_prefetched={len(n_docprocessing_prefetched)} "
+        f"port={n_port} "
         f"user_file_processing={n_user_file_processing} "
         f"user_file_project_sync={n_user_file_project_sync} "
         f"user_file_delete={n_user_file_delete} "

--- a/backend/onyx/background/celery/tasks/port/tasks.py
+++ b/backend/onyx/background/celery/tasks/port/tasks.py
@@ -1,0 +1,567 @@
+"""Reindexing port machinery: the producer task plus the beat scheduler.
+
+`run_port_attempt` (producer) drains one PortAttempt, copying a cc_pair's
+documents PRESENT -> FUTURE (re-embedded under the new model) and committing a
+per-batch cursor so a crash or stall resumes rather than restarts.
+
+`check_for_port` (beat scheduler) runs once per tick: it fails stalled attempts,
+then creates + enqueues a fresh PortAttempt for every in-scope cc_pair of a
+use_port_flow FUTURE with pending work (a FAILED attempt resumes its cursor;
+SUCCESS/CANCELED are left alone).
+"""
+
+import logging
+import time
+from collections.abc import Callable
+from collections.abc import MutableMapping
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from typing import Any
+
+from celery import Celery
+from celery import shared_task
+from celery import Task
+from redis.lock import Lock as RedisLock
+from sqlalchemy.orm import Session
+
+from onyx.background.celery.apps.app_base import task_logger
+from onyx.background.celery.tasks.beat_schedule import BEAT_EXPIRES_DEFAULT
+from onyx.configs.app_configs import INDEX_BATCH_SIZE
+from onyx.configs.constants import CELERY_GENERIC_BEAT_LOCK_TIMEOUT
+from onyx.configs.constants import OnyxCeleryPriority
+from onyx.configs.constants import OnyxCeleryQueues
+from onyx.configs.constants import OnyxCeleryTask
+from onyx.configs.constants import OnyxRedisLocks
+from onyx.db.connector_credential_pair import (
+    fetch_indexable_standard_connector_credential_pair_ids,
+)
+from onyx.db.connector_credential_pair import get_connector_credential_pair_from_id
+from onyx.db.document import filter_existing_cc_pair_document_ids
+from onyx.db.document import get_document_ids_for_cc_pair_batch
+from onyx.db.document import get_max_document_id_for_cc_pair
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.enums import ConnectorCredentialPairStatus
+from onyx.db.enums import PortAttemptStatus
+from onyx.db.enums import SwitchoverType
+from onyx.db.models import PortAttempt
+from onyx.db.models import SearchSettings
+from onyx.db.port_attempt import commit_port_cursor
+from onyx.db.port_attempt import count_consecutive_failed_port_attempts_no_progress
+from onyx.db.port_attempt import create_port_attempt
+from onyx.db.port_attempt import get_active_port_attempt
+from onyx.db.port_attempt import get_latest_port_attempt
+from onyx.db.port_attempt import get_port_attempt
+from onyx.db.port_attempt import get_stale_in_progress_port_attempts
+from onyx.db.port_attempt import mark_port_canceled
+from onyx.db.port_attempt import mark_port_failed
+from onyx.db.port_attempt import mark_port_in_progress
+from onyx.db.port_attempt import mark_port_succeeded
+from onyx.db.port_attempt import port_backfill_has_pending_work
+from onyx.db.port_attempt import touch_port_progress
+from onyx.db.search_settings import get_current_search_settings
+from onyx.db.search_settings import get_search_settings_by_id
+from onyx.db.search_settings import get_secondary_search_settings
+from onyx.document_index.opensearch.port_copy import PortCopier
+from onyx.redis.redis_pool import get_redis_client
+
+_PORT_SOFT_TIME_LIMIT = 60 * 30  # 30 minutes
+_PORT_TIME_LIMIT = _PORT_SOFT_TIME_LIMIT + 60
+
+_PORT_BATCH_MAX_RETRIES = 5
+_PORT_BATCH_RETRY_SLEEP_S = 2
+
+# Above the slowest single page — the longest gap between per-page heartbeats
+# (touch_port_progress fires before each write) — so check_for_port fails only
+# genuinely dead/yielded workers, never a slow-but-alive batch. A live worker that
+# hits the 30min soft limit self-yields and is rescheduled from its committed
+# cursor; that's a separate path, not what this value guards against.
+_PORT_STALL_THRESHOLD_SECONDS = 10 * 60  # 10 minutes
+
+# Backoff before recreating a FAILED port stuck at the same cursor (durable error:
+# bad/over-quota embed key, deleted model) so it doesn't recreate + re-embed every
+# tick. First failure retries promptly (likely transient); repeated same-cursor
+# failures back off exponentially, capped — a doomed port slows to hourly instead of
+# burning embedding spend ~2880x/day.
+_PORT_RETRY_BACKOFF_BASE_S = 30.0
+_PORT_RETRY_BACKOFF_MAX_S = 60.0 * 60  # 1 hour
+
+
+class _PortLogAdapter(logging.LoggerAdapter):
+    """Prefix every port log line with its attempt + cc_pair so concurrent ports
+    are distinguishable in the shared worker log (mirrors the indexing
+    [Index Attempt][CC Pair] prefix). cc_pair_id is filled in once the attempt is
+    read, so the few lines logged before that omit it."""
+
+    def process(
+        self, msg: str, kwargs: MutableMapping[str, Any]
+    ) -> tuple[str, MutableMapping[str, Any]]:
+        extra = self.extra or {}
+        cc_pair_id = extra.get("cc_pair_id")
+        cc_prefix = f"[CC Pair: {cc_pair_id}] " if cc_pair_id is not None else ""
+        return (
+            f"[Port Attempt: {extra.get('port_attempt_id')}] {cc_prefix}{msg}",
+            kwargs,
+        )
+
+
+def _copy_batch_with_retry(
+    copier: PortCopier,
+    doc_ids: list[str],
+    log: logging.LoggerAdapter,
+    surviving_doc_ids: Callable[[], set[str]] | None = None,
+    should_abort: Callable[[], bool] | None = None,
+) -> tuple[int, bool]:
+    """Copy one batch, retrying up to _PORT_BATCH_MAX_RETRIES on any failure.
+    Returns (chunks written, aborted); aborted=True means should_abort stopped
+    the copy mid-batch, so the caller must not advance its cursor past it.
+
+    Re-raises the last error on exhaustion so the caller fails the attempt with
+    the cursor still at the prior good batch. Retrying is safe because the write
+    is idempotent (deterministic _id + create-only: re-creating an existing chunk
+    is a benign 409, and the port never overwrites a forward/live write).
+
+    The delay is fixed, not exponential: the embedder and OpenSearch layers
+    already back off internally on rate-limits/transients, so a second curve here
+    would just stack on theirs. This only guards a whole-pipeline hiccup that
+    outlived them.
+    """
+    last_error: Exception | None = None
+    for attempt_num in range(1, _PORT_BATCH_MAX_RETRIES + 1):
+        try:
+            return copier.copy_doc_batch(
+                doc_ids,
+                surviving_doc_ids=surviving_doc_ids,
+                should_abort=should_abort,
+            )
+        except Exception as e:
+            last_error = e
+            log.warning(
+                "Port batch attempt %d/%d failed: %s",
+                attempt_num,
+                _PORT_BATCH_MAX_RETRIES,
+                e,
+            )
+            if attempt_num < _PORT_BATCH_MAX_RETRIES:
+                time.sleep(_PORT_BATCH_RETRY_SLEEP_S)
+    assert last_error is not None
+    raise last_error
+
+
+def run_port_attempt(port_attempt_id: int, celery_task_id: str | None = None) -> None:
+    """Body of the port task, lifted out of @shared_task so tests call it
+    directly. Resumes from the attempt's cursor and commits a new cursor after
+    each batch, so a fresh attempt continues `WHERE document_id > cursor` rather
+    than re-porting from the start.
+    """
+    log = _PortLogAdapter(
+        task_logger,
+        {
+            "port_attempt_id": port_attempt_id,
+            "celery_task_id": celery_task_id,
+            "cc_pair_id": None,
+        },
+    )
+
+    # PortCopier must be built while the search settings are session-attached, so
+    # do all setup here; the scan/embed/write loop below then holds no connection.
+    with get_session_with_current_tenant() as db_session:
+        attempt = get_port_attempt(db_session, port_attempt_id)
+        if attempt is None:
+            log.warning("PortAttempt not found, dropping task")
+            return
+        if attempt.status.is_terminal():
+            log.info(
+                "PortAttempt already terminal (%s), dropping task",
+                attempt.status.value,
+            )
+            return
+        if attempt.cancel_requested:
+            # nothing written yet; ack immediately
+            mark_port_canceled(db_session, port_attempt_id)
+            log.info("Port cancel requested at startup; acknowledged and stopping")
+            return
+
+        cc_pair_id = attempt.cc_pair_id
+        # Replace extra (a read-only Mapping) so every later line carries the cc_pair.
+        log.extra = {**(log.extra or {}), "cc_pair_id": cc_pair_id}
+        cursor = attempt.last_processed_doc_id
+        up_to_doc_id = attempt.up_to_doc_id  # snapshot upper bound (None = unbounded)
+        docs_ported = attempt.docs_ported or 0
+
+        future_search_settings = get_search_settings_by_id(
+            db_session, attempt.search_settings_id
+        )
+        if future_search_settings is None:
+            mark_port_failed(
+                db_session, port_attempt_id, error_msg="FUTURE search settings missing"
+            )
+            return
+        # Source to copy from: the recorded backfill source when the target was
+        # promoted mid-port (INSTANT) — "current" is now the target itself — else
+        # the live PRESENT for a normal reindex.
+        if future_search_settings.port_backfill_source_id is not None:
+            present_search_settings = get_search_settings_by_id(
+                db_session, future_search_settings.port_backfill_source_id
+            )
+            if present_search_settings is None:
+                mark_port_failed(
+                    db_session,
+                    port_attempt_id,
+                    error_msg="port backfill source settings missing",
+                )
+                return
+        else:
+            present_search_settings = get_current_search_settings(db_session)
+
+        if not mark_port_in_progress(
+            db_session, port_attempt_id, celery_task_id=celery_task_id
+        ):
+            # A supersede/cancel landed during startup; don't un-cancel and run on.
+            log.info("PortAttempt went terminal during startup, dropping task")
+            return
+
+        try:
+            copier = PortCopier(present_search_settings, future_search_settings)
+        except Exception as e:
+            log.exception("Failed to build port copier; marking FAILED")
+            mark_port_failed(db_session, port_attempt_id, error_msg=str(e))
+            return
+
+    start_monotonic = time.monotonic()
+    chunks_ported = 0
+
+    # Per page: stop on terminal or cancel_requested, else heartbeat so the watchdog
+    # doesn't fail a live port. Aborting stops writes; the ack (-> CANCELED) happens
+    # at the batch-loop top, after this page, keeping cleanup the last writer.
+    def _should_abort() -> bool:
+        with get_session_with_current_tenant() as db_session:
+            attempt = get_port_attempt(db_session, port_attempt_id)
+            if (
+                attempt is None
+                or attempt.status.is_terminal()
+                or attempt.cancel_requested
+            ):
+                return True
+            touch_port_progress(db_session, port_attempt_id)
+            return False
+
+    while True:
+        if time.monotonic() - start_monotonic > _PORT_SOFT_TIME_LIMIT:
+            # Thread-pool tasks ignore celery's soft_time_limit, so enforce it
+            # here; check_for_port reschedules from the committed cursor.
+            log.info("Port soft time limit reached, yielding")
+            return
+
+        # Fresh session per batch: frees the connection across the scan/embed/write,
+        # and re-reads the row so a CANCEL or stall-FAIL committed elsewhere is seen.
+        with get_session_with_current_tenant() as db_session:
+            attempt = get_port_attempt(db_session, port_attempt_id)
+            if attempt is None or attempt.status.is_terminal():
+                log.info("PortAttempt gone/terminal, stopping")
+                return
+            if attempt.cancel_requested:
+                # ack between batches, after our last write: this unblocks the waiting
+                # deletion, so its cleanup writes strictly after us
+                mark_port_canceled(db_session, port_attempt_id)
+                log.info("Port cancel requested; acknowledged and stopping")
+                return
+            cc_pair = get_connector_credential_pair_from_id(db_session, cc_pair_id)
+            if (
+                cc_pair is None
+                or cc_pair.status == ConnectorCredentialPairStatus.DELETING
+            ):
+                # A deletion is waiting on us; ack now (between batches, after our last
+                # write) so it proceeds next tick instead of waiting out the watchdog.
+                mark_port_canceled(db_session, port_attempt_id)
+                log.info("cc_pair gone/deleting, stopping port")
+                return
+            doc_ids = get_document_ids_for_cc_pair_batch(
+                db_session,
+                cc_pair_id,
+                after_doc_id=cursor,
+                limit=INDEX_BATCH_SIZE,
+                up_to_doc_id=up_to_doc_id,
+            )
+
+        if not doc_ids:
+            break
+
+        # Re-checked in the copier before each write: drop docs deleted mid-batch
+        # so create-only doesn't resurrect them. Default-arg binds this batch's ids.
+        def _surviving_doc_ids(_ids: list[str] = doc_ids) -> set[str]:
+            with get_session_with_current_tenant() as db_session:
+                return filter_existing_cc_pair_document_ids(
+                    db_session, cc_pair_id, _ids
+                )
+
+        try:
+            batch_chunks, aborted = _copy_batch_with_retry(
+                copier,
+                doc_ids,
+                log,
+                surviving_doc_ids=_surviving_doc_ids,
+                should_abort=_should_abort,
+            )
+        except Exception as e:
+            log.exception("Port batch failed after retries; marking FAILED")
+            with get_session_with_current_tenant() as db_session:
+                mark_port_failed(db_session, port_attempt_id, error_msg=str(e))
+            return
+
+        chunks_ported += batch_chunks
+        if aborted:
+            # Tail was never written; advancing the cursor would skip it forever
+            # on a FAILED resume. Loop back so the top does the terminal/cancel ack.
+            continue
+
+        cursor = doc_ids[-1]
+        docs_ported += len(doc_ids)
+        with get_session_with_current_tenant() as db_session:
+            commit_port_cursor(
+                db_session,
+                port_attempt_id,
+                last_processed_doc_id=cursor,
+                docs_ported=docs_ported,
+            )
+
+    with get_session_with_current_tenant() as db_session:
+        mark_port_succeeded(db_session, port_attempt_id)
+    log.info("Port complete: %d docs, %d chunks", docs_ported, chunks_ported)
+
+
+@shared_task(
+    name=OnyxCeleryTask.RUN_PORT_ATTEMPT,
+    soft_time_limit=_PORT_SOFT_TIME_LIMIT,
+    time_limit=_PORT_TIME_LIMIT,
+    bind=True,
+)
+def run_port_attempt_task(
+    self: Task,
+    *,
+    port_attempt_id: int,
+    tenant_id: str,  # noqa: ARG001  # consumed by TenantAwareTask wrapper
+) -> None:
+    run_port_attempt(
+        port_attempt_id=port_attempt_id,
+        celery_task_id=self.request.id,
+    )
+
+
+def _fail_stalled_port_attempts(
+    db_session: Session, search_settings_id: int, lock_beat: RedisLock
+) -> None:
+    """Fail IN_PROGRESS attempts whose last_progress_time is past the stall
+    threshold (a dead or self-yielded worker) so a fresh attempt can resume."""
+    stale_before = datetime.now(timezone.utc) - timedelta(
+        seconds=_PORT_STALL_THRESHOLD_SECONDS
+    )
+    for stale in get_stale_in_progress_port_attempts(
+        db_session, search_settings_id, stale_before
+    ):
+        lock_beat.reacquire()
+        fresh = get_port_attempt(db_session, stale.id)
+        if fresh is None or fresh.status.is_terminal():
+            continue
+        task_logger.warning(
+            "check_for_port: failing stalled PortAttempt %s (cc_pair %s)",
+            stale.id,
+            stale.cc_pair_id,
+        )
+        mark_port_failed(
+            db_session, stale.id, error_msg="stalled: no progress within threshold"
+        )
+
+
+def _port_retry_delay_seconds(consecutive_failures: int) -> float:
+    """Exponential backoff (capped) for the consecutive same-cursor failure streak.
+    The first failure retries immediately (likely transient); each repeat at the same
+    cursor doubles the wait, up to the cap."""
+    if consecutive_failures <= 1:
+        return 0.0
+    return min(
+        _PORT_RETRY_BACKOFF_BASE_S * 2 ** (consecutive_failures - 2),
+        _PORT_RETRY_BACKOFF_MAX_S,
+    )
+
+
+def _failed_port_ready_for_retry(
+    db_session: Session,
+    cc_pair_id: int,
+    search_settings_id: int,
+    latest: PortAttempt,
+) -> bool:
+    """Whether the backoff since the latest FAILED attempt has elapsed, so a port
+    stuck failing at the same cursor isn't recreated (and re-embedded) every tick."""
+    if latest.time_completed is None:
+        return True
+    failures = count_consecutive_failed_port_attempts_no_progress(
+        db_session, cc_pair_id, search_settings_id
+    )
+    delay = _port_retry_delay_seconds(failures)
+    return datetime.now(timezone.utc) >= latest.time_completed + timedelta(
+        seconds=delay
+    )
+
+
+def _enqueue_run_port_attempt(
+    celery_app: Celery, port_attempt_id: int, tenant_id: str
+) -> None:
+    """Enqueue run_port_attempt for one attempt. The TTL means a task not consumed
+    within BEAT_EXPIRES_DEFAULT is dropped; check_for_port re-issues it next tick."""
+    celery_app.send_task(
+        OnyxCeleryTask.RUN_PORT_ATTEMPT,
+        kwargs={"port_attempt_id": port_attempt_id, "tenant_id": tenant_id},
+        queue=OnyxCeleryQueues.PORT,
+        priority=OnyxCeleryPriority.MEDIUM,
+        expires=BEAT_EXPIRES_DEFAULT,
+    )
+
+
+def _resolve_port_target_settings(db_session: Session) -> SearchSettings | None:
+    """The settings the port should populate. A normal reindex ports the FUTURE
+    (secondary). An INSTANT swap already promoted the FUTURE to PRESENT, so the port
+    keeps backfilling that now-live index until every cc_pair is ported."""
+    future = get_secondary_search_settings(db_session)
+    if future is not None and future.use_port_flow:
+        return future
+    present = get_current_search_settings(db_session)
+    if (
+        present.use_port_flow
+        and present.port_backfill_source_id is not None
+        and port_backfill_has_pending_work(db_session, present.id)
+    ):
+        return present
+    return None
+
+
+def run_check_for_port(tenant_id: str, celery_app: Celery) -> int | None:
+    """Lifted out of check_for_port so tests can pass a mock celery app.
+
+    Returns the number of attempts enqueued, or None if the lock was contended or
+    there is no port-flow FUTURE.
+    """
+    redis_client = get_redis_client()
+    lock_beat: RedisLock = redis_client.lock(
+        OnyxRedisLocks.CHECK_PORT_BEAT_LOCK,
+        timeout=CELERY_GENERIC_BEAT_LOCK_TIMEOUT,
+    )
+    if not lock_beat.acquire(blocking=False):
+        return None
+
+    tasks_created = 0
+    try:
+        with get_session_with_current_tenant() as db_session:
+            port_settings = _resolve_port_target_settings(db_session)
+            if port_settings is None:
+                return None
+            search_settings_id = port_settings.id
+
+            include_paused = port_settings.switchover_type != SwitchoverType.ACTIVE_ONLY
+            cc_pair_ids = fetch_indexable_standard_connector_credential_pair_ids(
+                db_session, active_cc_pairs_only=not include_paused
+            )
+
+            _fail_stalled_port_attempts(db_session, search_settings_id, lock_beat)
+
+            # A NOT_STARTED not (re-)enqueued within the task TTL had its
+            # run_port_attempt dropped (worker down/absent); re-issue it, else it
+            # strands forever since it still counts as "active".
+            not_started_expired_before = datetime.now(timezone.utc) - timedelta(
+                seconds=BEAT_EXPIRES_DEFAULT
+            )
+
+            for cc_pair_id in cc_pair_ids:
+                lock_beat.reacquire()
+                active = get_active_port_attempt(
+                    db_session, cc_pair_id, search_settings_id
+                )
+                if active is not None:
+                    # IN_PROGRESS is the stall watchdog's job; a recent NOT_STARTED is
+                    # still in flight. Only re-issue a NOT_STARTED whose task has
+                    # definitely expired -- idempotent (the run task's terminal-check
+                    # + the active-unique index make a re-send safe, and the original
+                    # task is already gone, so there's no double-run).
+                    if (
+                        active.status == PortAttemptStatus.NOT_STARTED
+                        and active.time_updated < not_started_expired_before
+                    ):
+                        # Stamp before re-sending (the gate reads time_updated) so a
+                        # down worker gets one re-send per TTL window, not one per beat.
+                        active.time_updated = datetime.now(timezone.utc)
+                        db_session.commit()
+                        try:
+                            _enqueue_run_port_attempt(celery_app, active.id, tenant_id)
+                            tasks_created += 1
+                        except Exception:
+                            task_logger.exception(
+                                "check_for_port: re-enqueue failed for stale "
+                                "NOT_STARTED PortAttempt %s",
+                                active.id,
+                            )
+                    continue
+                latest = get_latest_port_attempt(
+                    db_session, cc_pair_id, search_settings_id
+                )
+                # SUCCESS -> backlog already ported; CANCELED -> operator stopped it.
+                # Only a FAILED (or no) attempt warrants a fresh run.
+                if latest is not None and latest.status != PortAttemptStatus.FAILED:
+                    continue
+                # Back off a port stuck failing at the same cursor (durable error) so
+                # it doesn't recreate + re-embed every tick. A progressing port (cursor
+                # advanced) has a streak of 1, so it isn't throttled.
+                if latest is not None and not _failed_port_ready_for_retry(
+                    db_session, cc_pair_id, search_settings_id, latest
+                ):
+                    continue
+                # Snapshot the upper bound on a fresh run; carry it across resumes so
+                # the whole backfill targets the same doc set (the backlog at start).
+                if latest is not None:
+                    resume_cursor = latest.last_processed_doc_id
+                    up_to_doc_id = latest.up_to_doc_id
+                else:
+                    resume_cursor = None
+                    up_to_doc_id = get_max_document_id_for_cc_pair(
+                        db_session, cc_pair_id
+                    )
+                try:
+                    attempt = create_port_attempt(
+                        db_session,
+                        cc_pair_id,
+                        search_settings_id,
+                        resume_from_doc_id=resume_cursor,
+                        up_to_doc_id=up_to_doc_id,
+                    )
+                except Exception:
+                    # One cc_pair's failure (unique-index race, transient DB error)
+                    # must not abort the tick; the next tick retries it.
+                    task_logger.exception(
+                        "check_for_port: create failed for cc_pair %s", cc_pair_id
+                    )
+                    continue
+                try:
+                    _enqueue_run_port_attempt(celery_app, attempt.id, tenant_id)
+                except Exception:
+                    # Row is committed; on enqueue failure mark it FAILED so the
+                    # next tick recreates it (else an orphaned NOT_STARTED sticks).
+                    task_logger.exception(
+                        "check_for_port: enqueue failed; failing PortAttempt %s",
+                        attempt.id,
+                    )
+                    mark_port_failed(db_session, attempt.id, error_msg="enqueue failed")
+                    continue
+                tasks_created += 1
+    finally:
+        if lock_beat.owned():
+            lock_beat.release()
+
+    return tasks_created
+
+
+@shared_task(
+    name=OnyxCeleryTask.CHECK_FOR_PORT,
+    soft_time_limit=300,
+    bind=True,
+)
+def check_for_port(self: Task, *, tenant_id: str) -> int | None:
+    return run_check_for_port(tenant_id, self.app)

--- a/backend/onyx/background/celery/tasks/vespa/document_sync.py
+++ b/backend/onyx/background/celery/tasks/vespa/document_sync.py
@@ -7,13 +7,18 @@ from redis.lock import Lock as RedisLock
 from sqlalchemy.orm import Session
 
 from onyx.configs.app_configs import DB_YIELD_PER_DEFAULT
+from onyx.configs.constants import CELERY_DOCUMENT_SYNC_TASK_EXPIRES
 from onyx.configs.constants import CELERY_VESPA_SYNC_BEAT_LOCK_TIMEOUT
 from onyx.configs.constants import OnyxCeleryPriority
 from onyx.configs.constants import OnyxCeleryQueues
 from onyx.configs.constants import OnyxCeleryTask
 from onyx.configs.constants import OnyxRedisConstants
-from onyx.db.document import construct_document_id_select_by_needs_sync
-from onyx.db.document import count_documents_by_needs_sync
+from onyx.db.document import (
+    construct_document_id_select_by_needs_sync_or_secondary_pending,
+)
+from onyx.db.document import count_documents_by_needs_sync_or_secondary_pending
+from onyx.db.document import count_secondary_only_sync_pending_documents
+from onyx.db.port_attempt import any_future_port_in_progress
 from onyx.redis.redis_tenant_work_gating import maybe_mark_tenant_active
 from onyx.redis.tenant_redis_client import TenantRedisClient
 from onyx.utils.logger import setup_logger
@@ -94,10 +99,17 @@ def generate_document_sync_tasks(
     num_tasks_sent = 0
     num_docs = 0
 
-    # Get all documents that need syncing
-    stmt = construct_document_id_select_by_needs_sync()
+    stmt = construct_document_id_select_by_needs_sync_or_secondary_pending()
+    port_running = any_future_port_in_progress(db_session)
+    # The backlog>0 guard keeps "no active port" from also matching normal steady
+    # state, which would wrongly demote every needs_sync to LOW.
+    draining_for_flip = (
+        not port_running and count_secondary_only_sync_pending_documents(db_session) > 0
+    )
 
-    for doc_id in db_session.scalars(stmt).yield_per(DB_YIELD_PER_DEFAULT):
+    for doc_id, is_secondary_pending in db_session.execute(stmt).yield_per(
+        DB_YIELD_PER_DEFAULT
+    ):
         doc_id = cast(str, doc_id)
         current_time = time.monotonic()
 
@@ -115,13 +127,26 @@ def generate_document_sync_tasks(
         r.sadd(DOCUMENT_SYNC_TASKSET_KEY, custom_task_id)
         r.expire(DOCUMENT_SYNC_TASKSET_KEY, TASKSET_TTL)
 
+        # Deferred FUTURE sync: LOW mid-port (may not be in FUTURE yet; don't
+        # starve needs_sync), HIGH post-port since that drain gates the flip —
+        # which is also why needs_sync yields to LOW during it.
+        if is_secondary_pending:
+            priority = (
+                OnyxCeleryPriority.LOW if port_running else OnyxCeleryPriority.HIGH
+            )
+        elif draining_for_flip:
+            priority = OnyxCeleryPriority.LOW
+        else:
+            priority = OnyxCeleryPriority.MEDIUM
+
         # Create the Celery task
         celery_app.send_task(
             OnyxCeleryTask.DOCUMENT_INDEX_METADATA_SYNC_TASK,
             kwargs=dict(document_id=doc_id, tenant_id=tenant_id),
             queue=OnyxCeleryQueues.VESPA_METADATA_SYNC,
             task_id=custom_task_id,
-            priority=OnyxCeleryPriority.MEDIUM,
+            priority=priority,
+            expires=CELERY_DOCUMENT_SYNC_TASK_EXPIRES,
             ignore_result=True,
         )
 
@@ -146,7 +171,7 @@ def try_generate_stale_document_sync_tasks(
         return None
 
     # add tasks to celery and build up the task set to monitor in redis
-    stale_doc_count = count_documents_by_needs_sync(db_session)
+    stale_doc_count = count_documents_by_needs_sync_or_secondary_pending(db_session)
     if stale_doc_count == 0:
         logger.info("No stale documents found. Skipping sync tasks generation.")
         return None

--- a/backend/onyx/background/celery/tasks/vespa/tasks.py
+++ b/backend/onyx/background/celery/tasks/vespa/tasks.py
@@ -32,8 +32,10 @@ from onyx.configs.constants import CELERY_VESPA_SYNC_BEAT_LOCK_TIMEOUT
 from onyx.configs.constants import OnyxCeleryTask
 from onyx.configs.constants import OnyxRedisConstants
 from onyx.configs.constants import OnyxRedisLocks
+from onyx.db.document import document_has_indexable_cc_pair
 from onyx.db.document import get_document
 from onyx.db.document import mark_document_as_synced
+from onyx.db.document import mark_document_synced_secondary_pending
 from onyx.db.document_set import delete_document_set
 from onyx.db.document_set import fetch_document_sets
 from onyx.db.document_set import fetch_document_sets_for_document
@@ -50,6 +52,7 @@ from onyx.db.sync_record import insert_sync_record
 from onyx.db.sync_record import update_sync_record_status
 from onyx.document_index.factory import get_all_document_indices
 from onyx.document_index.interfaces_new import MetadataUpdateRequest
+from onyx.document_index.interfaces_new import SecondaryIndexDocumentMissingError
 from onyx.httpx.httpx_pool import HttpxPool
 from onyx.redis.redis_document_set import RedisDocumentSet
 from onyx.redis.redis_pool import get_redis_client
@@ -512,16 +515,32 @@ def document_index_metadata_sync_task(
                     hidden=doc.hidden,
                 )
 
+                # PRESENT synced but doc not in FUTURE yet (reindex port): defer
+                # rather than fail. PRESENT write already committed in the pair.
+                secondary_only_missing = False
                 for retry_document_index in retry_document_indices:
-                    # TODO(andrei): Previously there was a comment here saying
-                    # it was ok if a doc did not exist in the document index. I
-                    # don't agree with that claim, so keep an eye on this task
-                    # to see if this raises.
-                    retry_document_index.update([update_request])
+                    try:
+                        # TODO(andrei): Previously there was a comment here saying
+                        # it was ok if a doc did not exist in the document index. I
+                        # don't agree with that claim, so keep an eye on this task
+                        # to see if this raises.
+                        retry_document_index.update([update_request])
+                    except SecondaryIndexDocumentMissingError:
+                        task_logger.debug(
+                            f"doc={document_id} not in secondary index; deferring FUTURE sync."
+                        )
+                        secondary_only_missing = True
 
                 # update db last. Worst case = we crash right before this and
-                # the sync might repeat again later
-                mark_document_as_synced(document_id, db_session)
+                # the sync might repeat again later.
+                # Defer only if the doc can still reach FUTURE; an INVALID/DELETING-only
+                # doc's flag would never clear -> swap deadlock, so mark it synced.
+                if secondary_only_missing and document_has_indexable_cc_pair(
+                    db_session, document_id
+                ):
+                    mark_document_synced_secondary_pending(document_id, db_session)
+                else:
+                    mark_document_as_synced(document_id, db_session)
 
                 elapsed = time.monotonic() - start
                 task_logger.info(f"doc={document_id} action=sync elapsed={elapsed:.2f}")

--- a/backend/onyx/background/indexing/run_docfetching.py
+++ b/backend/onyx/background/indexing/run_docfetching.py
@@ -474,7 +474,8 @@ def connector_document_extraction(
             and (from_beginning or not has_successful_attempt)
         )
 
-        # Set up time windows for polling
+        # Set up time windows for polling. A port-flow FUTURE's resume cursor comes from its
+        # synthetic seed (get_last_successful_... keeps ignore_synthetic_seed=False by default).
         last_successful_index_poll_range_end = (
             earliest_index_time
             if from_beginning

--- a/backend/onyx/background/indexing/run_targeted_reindex.py
+++ b/backend/onyx/background/indexing/run_targeted_reindex.py
@@ -148,6 +148,8 @@ def _flush_batch(
         embedder=embedder,
         document_indices=document_indices,
         ignore_time_skip=True,
+        # FUTURE/secondary build: skip the PRESENT-only content_hash dedup.
+        index_to_secondary=search_settings.status.is_future(),
         db_session=db_session,
         tenant_id=tenant_id,
         document_batch=documents,

--- a/backend/onyx/context/search/models.py
+++ b/backend/onyx/context/search/models.py
@@ -36,6 +36,8 @@ class SearchSettingsCreationRequest(IndexingSetting):
 class SavedSearchSettings(IndexingSetting):
     # Previously this contained also Inference time settings. Keeping this wrapper class around
     # as there may again be inference time settings that may get added.
+    use_port_flow: bool | None = None
+
     @classmethod
     def from_db_model(cls, search_settings: SearchSettings) -> "SavedSearchSettings":
         return cls(
@@ -51,6 +53,7 @@ class SavedSearchSettings(IndexingSetting):
             embedding_precision=search_settings.embedding_precision,
             reduced_dimension=search_settings.reduced_dimension,
             switchover_type=search_settings.switchover_type,
+            use_port_flow=search_settings.use_port_flow,
             enable_contextual_rag=search_settings.enable_contextual_rag,
             contextual_rag_model_configuration_id=search_settings.contextual_rag_model_configuration_id,
         )

--- a/backend/onyx/db/connector_credential_pair.py
+++ b/backend/onyx/db/connector_credential_pair.py
@@ -720,6 +720,7 @@ def resync_cc_pair(
     cc_pair: ConnectorCredentialPair,
     search_settings_id: int,
     db_session: Session,
+    commit: bool = True,
 ) -> None:
     """
     Updates state stored in the connector_credential_pair table based on the
@@ -769,4 +770,5 @@ def resync_cc_pair(
         last_success.time_started if last_success else None
     )
 
-    db_session.commit()
+    if commit:
+        db_session.commit()

--- a/backend/onyx/db/index_attempt.py
+++ b/backend/onyx/db/index_attempt.py
@@ -874,6 +874,7 @@ def delete_index_attempts(
 def expire_index_attempts(
     search_settings_id: int,
     db_session: Session,
+    commit: bool = True,
 ) -> None:
     not_started_query = (
         update(IndexAttempt)
@@ -897,7 +898,8 @@ def expire_index_attempts(
     )
     db_session.execute(update_query)
 
-    db_session.commit()
+    if commit:
+        db_session.commit()
 
 
 def cancel_indexing_attempts_for_ccpair(

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -2497,6 +2497,12 @@ class PortAttempt(Base):
         DateTime(timezone=True), nullable=True
     )
 
+    # Non-terminal cancel request: the port stays active (waiter keeps blocking)
+    # until the task acks by going CANCELED itself, after its last write.
+    cancel_requested: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=text("false")
+    )
+
     # only filled if status = FAILED (failure reason, including any traceback)
     error_msg: Mapped[str | None] = mapped_column(Text, nullable=True, default=None)
 

--- a/backend/onyx/db/port_attempt.py
+++ b/backend/onyx/db/port_attempt.py
@@ -253,13 +253,15 @@ def get_stale_in_progress_port_attempts(
 def mark_port_in_progress(
     db_session: Session, port_attempt_id: int, celery_task_id: str | None = None
 ) -> bool:
-    """Flip the attempt to IN_PROGRESS, returning True. Returns False without
-    changing anything if it's already terminal — a supersede/cancel that landed
-    during the task's startup must not be flipped back to IN_PROGRESS. The row lock
-    serializes this against the cancel, so first-terminal-write-wins holds."""
+    """Flip NOT_STARTED -> IN_PROGRESS, returning True. Returns False (no change) for
+    any other status under the row lock: a terminal row (a supersede/cancel that
+    landed during startup), or an already-IN_PROGRESS row (a re-dispatched duplicate —
+    a second concurrent writer would let one worker's cancel-ack unblock deletion
+    while the other writes). A resume is always a fresh attempt id, so requiring
+    NOT_STARTED rejects nothing valid."""
     try:
         attempt = _get_locked(db_session, port_attempt_id)
-        if attempt.status.is_terminal():
+        if attempt.status != PortAttemptStatus.NOT_STARTED:
             db_session.rollback()
             return False
         attempt.status = PortAttemptStatus.IN_PROGRESS
@@ -319,6 +321,31 @@ def mark_port_canceled(db_session: Session, port_attempt_id: int) -> None:
     _mark_terminal(db_session, port_attempt_id, PortAttemptStatus.CANCELED)
 
 
+def request_port_cancel(db_session: Session, port_attempt_id: int) -> None:
+    """Ask a port to stop so a waiter (connector deletion) can be the last writer.
+    Under the row lock (serializes vs mark_port_in_progress):
+      - NOT_STARTED: cancel outright. Must terminalize, not just flag: a NOT_STARTED
+        attempt is invisible to the stall watchdog and isn't re-enqueued once the
+        cc_pair is DELETING, so a flag alone would wedge the waiter forever.
+      - IN_PROGRESS: flag only; the task acks (-> CANCELED) after its last write.
+      - terminal: no-op.
+    Idempotent."""
+    try:
+        attempt = _get_locked(db_session, port_attempt_id)
+        if attempt.status.is_terminal():
+            db_session.rollback()
+            return
+        if attempt.status == PortAttemptStatus.NOT_STARTED:
+            attempt.status = PortAttemptStatus.CANCELED
+            attempt.time_completed = func.now()
+        else:  # IN_PROGRESS
+            attempt.cancel_requested = True
+        db_session.commit()
+    except Exception:
+        db_session.rollback()
+        raise
+
+
 def _mark_terminal(
     db_session: Session,
     port_attempt_id: int,
@@ -353,15 +380,17 @@ def cancel_active_port_attempts(
     search_settings_id: int,
     reason: str = "Canceled: superseded by a newer reindex",
 ) -> int:
-    """Cancel all active (NOT_STARTED / IN_PROGRESS) port attempts for a FUTURE
-    (superseded by a newer reindex, or promoted by a swap). A running port re-reads
-    its row each batch/page and stops on CANCELED; only active rows are touched, so
-    first-terminal-write-wins holds. Returns the number canceled."""
-    result = db_session.execute(
+    """Stop all active port attempts for a FUTURE (superseded/promoted by a swap),
+    via the same two-phase cancel as request_port_cancel so a concurrently-waiting
+    deletion stays the last writer: NOT_STARTED -> CANCELED, IN_PROGRESS -> flag (the
+    task acks after its last write, rather than being terminalized mid-write here).
+    Two scoped UPDATEs: an attempt flipping NOT_STARTED -> IN_PROGRESS between them is
+    still caught by the second. Returns the number affected."""
+    not_started = db_session.execute(
         update(PortAttempt)
         .where(
             PortAttempt.search_settings_id == search_settings_id,
-            PortAttempt.status.in_(_ACTIVE_STATUSES),
+            PortAttempt.status == PortAttemptStatus.NOT_STARTED,
         )
         .values(
             status=PortAttemptStatus.CANCELED,
@@ -369,5 +398,15 @@ def cancel_active_port_attempts(
             error_msg=reason,
         )
     )
+    in_progress = db_session.execute(
+        update(PortAttempt)
+        .where(
+            PortAttempt.search_settings_id == search_settings_id,
+            PortAttempt.status == PortAttemptStatus.IN_PROGRESS,
+        )
+        .values(cancel_requested=True)
+    )
     db_session.commit()
-    return result.rowcount  # ty: ignore[unresolved-attribute]
+    ns_count = not_started.rowcount  # ty: ignore[unresolved-attribute]
+    ip_count = in_progress.rowcount  # ty: ignore[unresolved-attribute]
+    return (ns_count or 0) + (ip_count or 0)

--- a/backend/onyx/db/search_settings.py
+++ b/backend/onyx/db/search_settings.py
@@ -37,6 +37,11 @@ def create_search_settings(
     search_settings: SavedSearchSettings,
     db_session: Session,
     status: IndexModelStatus = IndexModelStatus.FUTURE,
+    # Server-set, not a request field; the reindex endpoint opts into True.
+    use_port_flow: bool = False,
+    # False flushes instead of committing, so the caller can commit this row
+    # atomically with its port seeds (a seedless FUTURE makes workers re-scan).
+    commit: bool = True,
 ) -> SearchSettings:
     embedding_model = SearchSettings(
         model_name=search_settings.model_name,
@@ -53,11 +58,14 @@ def create_search_settings(
         enable_contextual_rag=search_settings.enable_contextual_rag,
         contextual_rag_model_configuration_id=search_settings.contextual_rag_model_configuration_id,
         switchover_type=search_settings.switchover_type,
-        use_port_flow=search_settings.use_port_flow,
+        use_port_flow=use_port_flow,
     )
 
     db_session.add(embedding_model)
-    db_session.commit()
+    if commit:
+        db_session.commit()
+    else:
+        db_session.flush()  # populate id without committing
 
     return embedding_model
 

--- a/backend/onyx/db/swap_index.py
+++ b/backend/onyx/db/swap_index.py
@@ -5,8 +5,12 @@ from sqlalchemy.orm import Session
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
 from onyx.configs.app_configs import VESPA_NUM_ATTEMPTS_ON_STARTUP
 from onyx.configs.constants import KV_REINDEX_KEY
+from onyx.db.connector_credential_pair import (
+    fetch_indexable_standard_connector_credential_pair_ids,
+)
 from onyx.db.connector_credential_pair import get_connector_credential_pairs
 from onyx.db.connector_credential_pair import resync_cc_pair
+from onyx.db.document import count_secondary_only_sync_pending_documents_for_cc_pairs
 from onyx.db.document import delete_all_documents_for_connector_credential_pair
 from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.enums import IndexModelStatus
@@ -20,6 +24,9 @@ from onyx.db.llm import update_default_contextual_model
 from onyx.db.llm import update_no_default_contextual_rag_provider
 from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import SearchSettings
+from onyx.db.port_attempt import cancel_active_port_attempts
+from onyx.db.port_attempt import get_active_port_attempt
+from onyx.db.port_attempt import get_latest_port_attempt
 from onyx.db.search_settings import get_current_search_settings
 from onyx.db.search_settings import get_secondary_search_settings
 from onyx.db.search_settings import update_search_settings_status
@@ -70,6 +77,16 @@ def _perform_index_swap(
                     credential_id=cc_pair.credential_id,
                 )
 
+    # Record the index being promoted-from so the INSTANT post-swap port keeps
+    # reading it once it becomes PAST. Only INSTANT backfills after the swap; setting
+    # this for a non-INSTANT swap wrongly keeps the old index un-deletable, since a
+    # lingering FAILED port row keeps is_active_port_backfill_source True forever.
+    if (
+        new_search_settings.use_port_flow
+        and new_search_settings.switchover_type == SwitchoverType.INSTANT
+    ):
+        new_search_settings.port_backfill_source_id = current_search_settings.id
+
     # swap over search settings
     update_search_settings_status(
         search_settings=current_search_settings,
@@ -81,6 +98,19 @@ def _perform_index_swap(
         new_status=IndexModelStatus.PRESENT,
         db_session=db_session,
     )
+
+    # FUTURE is now live: cancel stragglers that dropped out of the required set
+    # (paused/INVALID) so they stop writing into the live index. Skip for INSTANT —
+    # there the swap is deliberately mid-port and the ports keep backfilling.
+    if (
+        new_search_settings.use_port_flow
+        and new_search_settings.switchover_type != SwitchoverType.INSTANT
+    ):
+        cancel_active_port_attempts(
+            db_session,
+            new_search_settings.id,
+            reason="Canceled: FUTURE promoted by index swap",
+        )
 
     # Update the default contextual model to match the newly promoted settings
     try:
@@ -141,6 +171,54 @@ def _perform_index_swap(
     return current_search_settings
 
 
+def _required_cc_pairs_for_switchover(
+    db_session: Session,
+    all_cc_pairs: list[ConnectorCredentialPair],
+    switchover_type: SwitchoverType,
+) -> list[ConnectorCredentialPair]:
+    """The cc_pairs whose port must finish before a port-flow swap.
+
+    Scoped through the SAME helper check_for_port uses, so the gated set stays a
+    subset of what the watchdog ports — gating on a cc_pair it never ports (e.g.
+    INVALID, excluded by indexable_statuses()) would deadlock the swap. ACTIVE_ONLY
+    restricts to active statuses; other modes also include PAUSED. The Ingestion
+    pair is kept in: check_for_port ports it too, so its port must gate the swap.
+    """
+    portable_ids = set(
+        fetch_indexable_standard_connector_credential_pair_ids(
+            db_session,
+            active_cc_pairs_only=(switchover_type == SwitchoverType.ACTIVE_ONLY),
+        )
+    )
+    return [cc_pair for cc_pair in all_cc_pairs if cc_pair.id in portable_ids]
+
+
+def _port_swap_ready(
+    db_session: Session,
+    new_search_settings: SearchSettings,
+    required_cc_pairs: list[ConnectorCredentialPair],
+) -> bool:
+    """Port-flow swap gate: True once every required cc_pair's port is SUCCESS (none
+    active) and its deferred metadata-sync backlog has drained. The port copy is the
+    whole bar — no post-port connector index attempt. The drain is scoped to
+    required_cc_pairs: a global count would deadlock on un-portable INVALID/DELETING
+    docs that never reach FUTURE."""
+    ss_id = new_search_settings.id
+    for cc_pair in required_cc_pairs:
+        if get_active_port_attempt(db_session, cc_pair.id, ss_id) is not None:
+            return False
+        latest_port = get_latest_port_attempt(db_session, cc_pair.id, ss_id)
+        if latest_port is None or not latest_port.status.is_successful():
+            return False
+
+    return (
+        count_secondary_only_sync_pending_documents_for_cc_pairs(
+            db_session, [cc_pair.id for cc_pair in required_cc_pairs]
+        )
+        == 0
+    )
+
+
 def check_and_perform_index_swap(db_session: Session) -> SearchSettings | None:
     """Get count of cc-pairs and count of successful index_attempts for the
     new model grouped by connector + credential, if it's the same, then assume
@@ -162,6 +240,31 @@ def check_and_perform_index_swap(db_session: Session) -> SearchSettings | None:
 
     # Handle switchover based on switchover_type
     switchover_type = new_search_settings.switchover_type
+
+    # Port-flow FUTURE: swap on the port-aware criterion, not the legacy
+    # successful-index count (a broken connector must not block the swap).
+    if new_search_settings.use_port_flow:
+        if switchover_type == SwitchoverType.INSTANT:
+            # Swap now and let the port keep backfilling old data into the now-live
+            # index in the background — no wait, and no wipe (the port populates it,
+            # so cleanup_documents would destroy live data).
+            return _perform_index_swap(
+                db_session=db_session,
+                new_search_settings=new_search_settings,
+                all_cc_pairs=all_cc_pairs,
+            )
+        required_cc_pairs = _required_cc_pairs_for_switchover(
+            db_session, all_cc_pairs, switchover_type
+        )
+        if not required_cc_pairs or _port_swap_ready(
+            db_session, new_search_settings, required_cc_pairs
+        ):
+            return _perform_index_swap(
+                db_session=db_session,
+                new_search_settings=new_search_settings,
+                all_cc_pairs=all_cc_pairs,
+            )
+        return None
 
     # INSTANT: Swap immediately without waiting
     if switchover_type == SwitchoverType.INSTANT:

--- a/backend/onyx/document_index/chunk_content_enrichment.py
+++ b/backend/onyx/document_index/chunk_content_enrichment.py
@@ -3,10 +3,9 @@ from onyx.configs.constants import RETURN_SEPARATOR
 from onyx.context.search.models import InferenceChunk
 from onyx.context.search.models import InferenceChunkUncleaned
 from onyx.indexing.models import DocAwareChunk
-from onyx.indexing.models import DocMetadataAwareIndexChunk
 
 
-def generate_enriched_content_for_chunk_text(chunk: DocMetadataAwareIndexChunk) -> str:
+def generate_enriched_content_for_chunk_text(chunk: DocAwareChunk) -> str:
     return f"{chunk.title_prefix}{chunk.doc_summary}{chunk.content}{chunk.chunk_context}{chunk.metadata_suffix_keyword}"
 
 

--- a/backend/onyx/document_index/factory.py
+++ b/backend/onyx/document_index/factory.py
@@ -24,29 +24,35 @@ def _build_tenant_state() -> TenantState:
     return TenantState(tenant_id=get_current_tenant_id(), multitenant=MULTI_TENANT)
 
 
-def _build_opensearch_pair(
+def build_opensearch_document_index(
     search_settings: SearchSettings,
-    secondary_search_settings: SearchSettings | None,
-) -> OpenSearchIndexPair:
-    tenant_state = _build_tenant_state()
+) -> OpenSearchDocumentIndex:
+    """A single OpenSearch index handle for one search settings.
+
+    The reindex port needs the lone index (to scan a PIT / call index_raw_chunks),
+    not the primary+secondary pair `get_default_document_index` returns. Shared
+    with `_build_opensearch_pair` so the construction lives in one place.
+    """
     indexing_setting = IndexingSetting.from_db_model(search_settings)
-    primary = OpenSearchDocumentIndex(
-        tenant_state=tenant_state,
+    return OpenSearchDocumentIndex(
+        tenant_state=_build_tenant_state(),
         index_name=search_settings.index_name,
         embedding_dim=indexing_setting.final_embedding_dim,
         embedding_precision=indexing_setting.embedding_precision,
     )
+
+
+def _build_opensearch_pair(
+    search_settings: SearchSettings,
+    secondary_search_settings: SearchSettings | None,
+) -> OpenSearchIndexPair:
+    primary = build_opensearch_document_index(search_settings)
     if secondary_search_settings is None:
         return OpenSearchIndexPair(primary=primary, secondary=None)
     secondary_indexing_setting = IndexingSetting.from_db_model(
         secondary_search_settings
     )
-    secondary = OpenSearchDocumentIndex(
-        tenant_state=tenant_state,
-        index_name=secondary_search_settings.index_name,
-        embedding_dim=secondary_indexing_setting.final_embedding_dim,
-        embedding_precision=secondary_indexing_setting.embedding_precision,
-    )
+    secondary = build_opensearch_document_index(secondary_search_settings)
     return OpenSearchIndexPair(
         primary=primary,
         secondary=secondary,

--- a/backend/onyx/document_index/interfaces_new.py
+++ b/backend/onyx/document_index/interfaces_new.py
@@ -152,6 +152,18 @@ class MetadataUpdateRequest(BaseModel):
     persona_ids: set[int] | None = None
 
 
+class SecondaryIndexDocumentMissingError(Exception):
+    """A metadata update applied to the primary index but the doc isn't in the
+    secondary (FUTURE) index yet (e.g. mid reindex port). Carries the doc ids so
+    the caller can defer the secondary sync instead of failing."""
+
+    def __init__(self, document_ids: list[str]) -> None:
+        self.document_ids = document_ids
+        super().__init__(
+            f"{len(document_ids)} document(s) missing from the secondary index."
+        )
+
+
 class IndexRetrievalFilters(BaseModel):
     """
     Filters for retrieving chunks from the index.

--- a/backend/onyx/document_index/opensearch/client.py
+++ b/backend/onyx/document_index/opensearch/client.py
@@ -1,12 +1,15 @@
 import json
 import logging
 import time
+from collections.abc import Iterator
 from contextlib import AbstractContextManager
 from contextlib import nullcontext
+from http import HTTPStatus
 from typing import Any
 from typing import Generic
 from typing import TypeVar
 
+from opensearchpy import NotFoundError
 from opensearchpy import OpenSearch
 from opensearchpy import TransportError
 from opensearchpy.helpers import bulk
@@ -18,11 +21,18 @@ from onyx.configs.app_configs import OPENSEARCH_ADMIN_USERNAME
 from onyx.configs.app_configs import OPENSEARCH_HOST
 from onyx.configs.app_configs import OPENSEARCH_REST_API_PORT
 from onyx.configs.app_configs import OPENSEARCH_USE_SSL
+from onyx.configs.app_configs import PIT_KEEP_ALIVE
 from onyx.document_index.interfaces_new import TenantState
+from onyx.document_index.opensearch.constants import DEFAULT_MAX_CHUNK_SIZE
 from onyx.document_index.opensearch.constants import OpenSearchSearchType
+from onyx.document_index.opensearch.schema import CHUNK_INDEX_FIELD_NAME
+from onyx.document_index.opensearch.schema import CONTENT_VECTOR_FIELD_NAME
+from onyx.document_index.opensearch.schema import DOCUMENT_ID_FIELD_NAME
 from onyx.document_index.opensearch.schema import DocumentChunk
 from onyx.document_index.opensearch.schema import DocumentChunkWithoutVectors
 from onyx.document_index.opensearch.schema import get_opensearch_doc_chunk_id
+from onyx.document_index.opensearch.schema import MAX_CHUNK_SIZE_FIELD_NAME
+from onyx.document_index.opensearch.schema import TITLE_VECTOR_FIELD_NAME
 from onyx.document_index.opensearch.search import DEFAULT_OPENSEARCH_MAX_RESULT_WINDOW
 from onyx.server.metrics.opensearch_search import observe_opensearch_search
 from onyx.server.metrics.opensearch_search import record_opensearch_search_error
@@ -106,6 +116,35 @@ class OpenSearchIndexError(Exception):
     was caught by OpenSearchIndexClient. This exception is not exhaustive of all
     exceptions index calls can raise.
     """
+
+
+class OpenSearchDocumentMissingError(Exception):
+    """Target chunks don't exist on an _update (404) and the caller opted to
+    surface this rather than fail (reindex port: doc not in FUTURE yet)."""
+
+    def __init__(
+        self,
+        missing_chunk_ids: list[str],
+        missing_document_ids: list[str] | None = None,
+    ) -> None:
+        self.missing_chunk_ids = missing_chunk_ids
+        # Only the layer that built the chunk ids knows the doc mapping; the
+        # client raises with chunks only and the index layer fills doc ids in.
+        self.missing_document_ids = missing_document_ids or []
+        super().__init__(
+            f"{len(missing_chunk_ids)} document chunk(s) missing during update."
+        )
+
+
+# Server-side error.type strings (not exposed as enums by opensearch-py; cf.
+# _RETRYABLE_UPDATE_ERROR_TYPES above). Status codes use http.HTTPStatus.
+_DOCUMENT_MISSING_ERROR_TYPE = "document_missing_exception"
+_VERSION_CONFLICT_ERROR_TYPE = "version_conflict_engine_exception"
+# Raised by a search whose PIT has expired/been deleted; we re-open and retry.
+_SEARCH_CONTEXT_MISSING_ERROR_TYPE = "search_context_missing"
+# Chunks per PIT-scan page. A port doc-batch is small (INDEX_BATCH_SIZE docs), so
+# one page covers a batch; paging still protects against a pathological doc.
+_PIT_SCAN_PAGE_SIZE = 1000
 
 
 class OpenSearchServerSideTimeout(Exception):
@@ -822,6 +861,7 @@ class OpenSearchIndexClient(OpenSearchClient):
             "documents": len,
             "tenant_state": str,
             "update_if_exists": str,
+            "use_create_only": str,
         },
     )
     def bulk_index_documents(
@@ -829,6 +869,7 @@ class OpenSearchIndexClient(OpenSearchClient):
         documents: list[DocumentChunk],
         tenant_state: TenantState,
         update_if_exists: bool = False,
+        use_create_only: bool = False,
     ) -> None:
         """Bulk indexes documents.
 
@@ -846,6 +887,11 @@ class OpenSearchIndexClient(OpenSearchClient):
             update_if_exists: Whether to update the document if it already
                 exists. If False, will raise an exception if the document
                 already exists. Defaults to False.
+            use_create_only: When True, write each chunk with _op_type=create
+                (don't overwrite if it already exists) and treat the resulting
+                409 as benign. The reindex port uses this so a stale backlog
+                write can never clobber a chunk a live/forward writer already
+                owns in FUTURE. Default False leaves the write path unchanged.
 
         Raises:
             Exception: There was an error during the bulk index. This
@@ -860,10 +906,12 @@ class OpenSearchIndexClient(OpenSearchClient):
         if not documents:
             return
         logger.debug(
-            "Bulk indexing %s documents for tenant %s. update_if_exists=%s.",
+            "Bulk indexing %s documents for tenant %s. update_if_exists=%s "
+            "use_create_only=%s.",
             len(documents),
             tenant_state.tenant_id,
             update_if_exists,
+            use_create_only,
         )
         data = []
         for document in documents:
@@ -874,29 +922,83 @@ class OpenSearchIndexClient(OpenSearchClient):
                 max_chunk_size=document.max_chunk_size,
             )
             body: dict[str, Any] = document.model_dump(exclude_none=True)
+            # create-only never overwrites: an existing chunk (a live/forward
+            # writer already owns it) comes back as a benign 409.
+            if use_create_only:
+                op_type = "create"
+            else:
+                op_type = "index" if update_if_exists else "create"
             data_for_document: dict[str, Any] = {
                 "_index": self._index_name,
                 "_id": document_chunk_id,
-                "_op_type": "index" if update_if_exists else "create",
+                "_op_type": op_type,
                 "_source": body,
             }
             data.append(data_for_document)
-        # max_retries is the number of times to retry a request if we get a 429.
-        # Explicitly raise on error and exception; we will not attempt retries.
-        successes, _ = bulk(
-            self._client,
-            data,
-            max_retries=3,
-            raise_on_error=True,
-            raise_on_exception=True,
-        )
-        if successes != len(documents):
-            raise OpenSearchIndexError(
-                "OpenSearch reported no errors during bulk index but the number of successful "
-                f"operations ({successes}) does not match the number of documents "
-                f"({len(documents)})."
+
+        if use_create_only:
+            # a chunk that already exists is owned by a live/forward writer, so
+            # the port yields with a benign 409 instead of failing the batch
+            successes, errors = bulk(
+                self._client,
+                data,
+                max_retries=3,
+                raise_on_error=False,
+                raise_on_exception=True,
             )
-        logger.debug("Successfully bulk indexed %s documents.", len(documents))
+            benign_conflicts = self._benign_create_conflict_count(errors)
+        else:
+            # any error fails the batch (the caller may refresh-retry
+            # on the BulkIndexError that bulk raises)
+            successes, _ = bulk(
+                self._client,
+                data,
+                max_retries=3,
+                raise_on_error=True,
+                raise_on_exception=True,
+            )
+            benign_conflicts = 0
+
+        if successes + benign_conflicts != len(documents):
+            raise OpenSearchIndexError(
+                f"Bulk index for index {self._index_name}: successful operations ({successes}) "
+                f"plus benign version conflicts ({benign_conflicts}) does not match the number "
+                f"of documents ({len(documents)})."
+            )
+        logger.debug(
+            "Successfully bulk indexed %s documents (%s benign version conflicts).",
+            len(documents),
+            benign_conflicts,
+        )
+
+    def _benign_create_conflict_count(self, errors: list[dict[str, Any]]) -> int:
+        """Count benign 409s from create-only writes (the chunk already exists,
+        so a live/forward writer owns it and the port yields); raise
+        OpenSearchIndexError on any other error.
+
+        opensearch-py exposes no typed model for bulk per-item errors (bulk() ->
+        Any, BulkIndexError.errors -> List[Any]); they are raw {op_type: {...}}
+        dicts, so we read the fields directly. A create-conflict is keyed under
+        "create" (the op_type) and reports status 409 / version_conflict.
+        """
+        benign = 0
+        fatal: list[dict[str, Any]] = []
+        for error in errors:
+            item = error.get("create") or {}
+            err_type = (item.get("error") or {}).get("type", "")
+            if (
+                item.get("status") == HTTPStatus.CONFLICT
+                and err_type == _VERSION_CONFLICT_ERROR_TYPE
+            ):
+                benign += 1
+            else:
+                fatal.append(error)
+        if fatal:
+            raise OpenSearchIndexError(
+                f"Failed to bulk index documents for index {self._index_name}. "
+                f"{len(fatal)} fatal error(s) occurred: {fatal}"
+            )
+        return benign
 
     @log_function_time(print_only=True, debug_only=True, include_args=True)
     def delete_document(self, document_chunk_id: str) -> bool:
@@ -1066,7 +1168,10 @@ class OpenSearchIndexClient(OpenSearchClient):
         },
     )
     def bulk_update_documents(
-        self, document_chunk_ids: list[str], properties_to_update: dict[str, Any]
+        self,
+        document_chunk_ids: list[str],
+        properties_to_update: dict[str, Any],
+        swallow_document_missing: bool = False,
     ) -> None:
         """Bulk updates OpenSearch document chunks' properties.
 
@@ -1078,6 +1183,9 @@ class OpenSearchIndexClient(OpenSearchClient):
                 update.
             properties_to_update: The properties of the document to update. Each
                 property should exist in the schema.
+            swallow_document_missing: When True and the only fatal errors are 404
+                document_missing, raise OpenSearchDocumentMissingError instead of
+                OpenSearchUpdateError (FUTURE write during a reindex port).
 
         Raises:
             Exception: There was an error during the bulk update.
@@ -1088,6 +1196,8 @@ class OpenSearchIndexClient(OpenSearchClient):
                 by OpenSearch does not match the number of document chunks to
                 update, or there was at least one other kind of fatal error for
                 a particular document chunk.
+            OpenSearchDocumentMissingError: ``swallow_document_missing`` was set
+                and the only fatal errors were 404 document_missing.
         """
         if not document_chunk_ids:
             return
@@ -1120,6 +1230,7 @@ class OpenSearchIndexClient(OpenSearchClient):
             raise_on_exception=True,
         )
 
+        missing_chunk_ids: list[str] = []
         if errors:
             retryable_ids = []
             fatal_errors = []
@@ -1135,7 +1246,14 @@ class OpenSearchIndexClient(OpenSearchClient):
                 err_obj = info.get("error", {})
                 err_type = err_obj.get("type", "") if isinstance(err_obj, dict) else ""
 
-                if status >= 500 and err_type in _RETRYABLE_UPDATE_ERROR_TYPES:
+                if (
+                    swallow_document_missing
+                    and status == HTTPStatus.NOT_FOUND
+                    and err_type == _DOCUMENT_MISSING_ERROR_TYPE
+                ):
+                    # doc not in this index yet; surface instead of failing
+                    missing_chunk_ids.append(info.get("_id", ""))
+                elif status >= 500 and err_type in _RETRYABLE_UPDATE_ERROR_TYPES:
                     # We have seen a bug in OpenSearch version 3.4.0 when using
                     # the knn plugin and when derived_source is enabled (the
                     # default), when OpenSearch is under load sometimes updates
@@ -1195,12 +1313,15 @@ class OpenSearchIndexClient(OpenSearchClient):
                 )
             successes += new_successes
 
-        if successes != len(document_chunk_ids):
+        # missing chunks are accounted for separately, not counted as successes
+        if successes + len(missing_chunk_ids) != len(document_chunk_ids):
             raise OpenSearchUpdateError(
                 f"OpenSearch reported no errors during bulk update but the number of successful "
-                f"operations ({successes}) does not match the number of document chunks "
-                f"({len(document_chunk_ids)})."
+                f"operations ({successes}) plus missing ({len(missing_chunk_ids)}) does not match "
+                f"the number of document chunks ({len(document_chunk_ids)})."
             )
+        if missing_chunk_ids:
+            raise OpenSearchDocumentMissingError(missing_chunk_ids)
         logger.debug(
             "Successfully bulk updated %s document chunks.", len(document_chunk_ids)
         )
@@ -1443,6 +1564,214 @@ class OpenSearchIndexClient(OpenSearchClient):
             len(document_chunk_ids),
         )
         return document_chunk_ids
+
+    def open_pit(self, keep_alive: str = PIT_KEEP_ALIVE) -> str:
+        """Opens a point-in-time (PIT) over this index for a consistent scan.
+
+        The PIT pins the index across searches so concurrent writes don't shift
+        the result set. The caller threads the returned id into
+        fetch_chunks_for_doc_ids and releases it with close_pit when done.
+
+        Args:
+            keep_alive: How long the PIT lives between uses; each search extends
+                the lease.
+
+        Raises:
+            RuntimeError: OpenSearch returned no pit_id.
+
+        Returns:
+            The point-in-time id.
+        """
+        response = self._client.create_pit(
+            index=self._index_name, params={"keep_alive": keep_alive}
+        )
+        pit_id = response.get("pit_id")
+        if not pit_id:
+            raise RuntimeError(
+                f"create_pit returned no pit_id for index {self._index_name}."
+            )
+        return pit_id
+
+    def close_pit(self, pit_id: str) -> None:
+        """Releases a PIT. Best-effort — a leaked PIT self-expires after keep_alive.
+
+        Args:
+            pit_id: The point-in-time id to delete.
+        """
+        try:
+            self._client.delete_pit(body={"pit_id": [pit_id]})
+        except NotFoundError:
+            pass
+
+    def fetch_chunks_for_doc_ids(
+        self,
+        pit_id: str,
+        doc_ids: list[str],
+        search_after: list[object] | None = None,
+        page_size: int = _PIT_SCAN_PAGE_SIZE,
+        keep_alive: str = PIT_KEEP_ALIVE,
+    ) -> tuple[list[DocumentChunkWithoutVectors], list[object] | None, str]:
+        """Fetches one page of regular chunks for a batch of documents from a PIT.
+
+        Filters to regular chunks (max_chunk_size == DEFAULT_MAX_CHUNK_SIZE) so
+        large/mini chunks are never ported, sorts by (document_id, chunk_index),
+        and pages with search_after. Vectors are excluded — the port re-embeds.
+        If the PIT expired the scan re-opens it and retries once.
+
+        Args:
+            pit_id: The point-in-time id from open_pit.
+            doc_ids: The document ids whose chunks to fetch.
+            search_after: The sort cursor from the previous page; None for the
+                first page.
+            page_size: Max chunks per page.
+            keep_alive: PIT lease extension applied on each search.
+
+        Raises:
+            OpenSearchServerSideTimeout: The search timed out server-side; the
+                caller should retry the batch.
+            Exception: There was an error searching the index.
+
+        Returns:
+            A tuple of (chunks, next_search_after, pit_id_in_use). next_search_after
+            is None once the batch is exhausted; pit_id_in_use reflects the new PIT
+            when the scan re-opened, so the caller threads it forward.
+        """
+        if not doc_ids:
+            return [], None, pit_id
+
+        # Background scans intentionally skip the user-search metrics/pipeline that
+        # search() applies; we still detect a server-side timeout below so a
+        # truncated page is never mistaken for the end of the scan.
+        try:
+            result = self._client.search(
+                body=self._pit_scan_body(
+                    pit_id, doc_ids, search_after, page_size, keep_alive
+                )
+            )
+        except NotFoundError as e:
+            if not self._is_pit_expired(e):
+                raise
+            logger.debug(
+                "PIT %s expired mid-scan for index %s; reopening.",
+                pit_id,
+                self._index_name,
+            )
+            pit_id = self.open_pit(keep_alive)
+            result = self._client.search(
+                body=self._pit_scan_body(
+                    pit_id, doc_ids, search_after, page_size, keep_alive
+                )
+            )
+
+        if result.get("timed_out"):
+            # A timed-out page returns partial hits; treating it as a short page
+            # would silently end the scan early, so fail and let the caller retry.
+            raise OpenSearchServerSideTimeout(
+                f"PIT scan of index {self._index_name} timed out server-side."
+            )
+
+        hits: list[dict[str, Any]] = result.get("hits", {}).get("hits", [])
+        chunks: list[DocumentChunkWithoutVectors] = []
+        last_sort: list[object] | None = None
+        for hit in hits:
+            source = hit.get("_source")
+            if not source:
+                raise RuntimeError(
+                    f'Document chunk with ID "{hit.get("_id", "")}" has no data.'
+                )
+            chunks.append(DocumentChunkWithoutVectors.model_validate(source))
+            last_sort = hit.get("sort")
+
+        # A short page means the batch is exhausted; a full page means resume from
+        # the last hit's sort values on the next call.
+        next_search_after = last_sort if len(hits) == page_size else None
+        return chunks, next_search_after, pit_id
+
+    def iter_chunks_for_doc_ids(
+        self,
+        doc_ids: list[str],
+        page_size: int = _PIT_SCAN_PAGE_SIZE,
+        keep_alive: str = PIT_KEEP_ALIVE,
+    ) -> Iterator[list[DocumentChunkWithoutVectors]]:
+        """Scans regular chunks for a batch of documents, one page at a time.
+
+        Owns the whole PIT lifecycle: opens it, pages with search_after, re-opens
+        transparently on expiry, and always closes it (even if the consumer
+        raises). The preferred entry point so callers can't leak a PIT.
+
+        Args:
+            doc_ids: The document ids whose chunks to scan.
+            page_size: Max chunks per page.
+            keep_alive: PIT lease extension applied on each search.
+
+        Yields:
+            One page (list) of chunks at a time.
+        """
+        if not doc_ids:
+            return
+        pit_id = self.open_pit(keep_alive)
+        try:
+            search_after: list[object] | None = None
+            while True:
+                chunks, search_after, pit_id = self.fetch_chunks_for_doc_ids(
+                    pit_id,
+                    doc_ids,
+                    search_after=search_after,
+                    page_size=page_size,
+                    keep_alive=keep_alive,
+                )
+                if chunks:
+                    yield chunks
+                if search_after is None:
+                    return
+        finally:
+            self.close_pit(pit_id)
+
+    def _pit_scan_body(
+        self,
+        pit_id: str,
+        doc_ids: list[str],
+        search_after: list[object] | None,
+        page_size: int,
+        keep_alive: str,
+    ) -> dict[str, Any]:
+        """Builds the PIT search body for one page.
+
+        No index= is sent — the PIT pins the index; keep_alive in the pit block
+        extends the lease on every page.
+        """
+        body: dict[str, Any] = {
+            "pit": {"id": pit_id, "keep_alive": keep_alive},
+            "size": page_size,
+            "_source": {
+                "excludes": [CONTENT_VECTOR_FIELD_NAME, TITLE_VECTOR_FIELD_NAME]
+            },
+            "query": {
+                "bool": {
+                    "filter": [
+                        {"terms": {DOCUMENT_ID_FIELD_NAME: doc_ids}},
+                        {"term": {MAX_CHUNK_SIZE_FIELD_NAME: DEFAULT_MAX_CHUNK_SIZE}},
+                    ]
+                }
+            },
+            "sort": [
+                {DOCUMENT_ID_FIELD_NAME: "asc"},
+                {CHUNK_INDEX_FIELD_NAME: "asc"},
+            ],
+        }
+        if search_after is not None:
+            body["search_after"] = search_after
+        return body
+
+    @staticmethod
+    def _is_pit_expired(error: NotFoundError) -> bool:
+        """True if the 404 is an expired/deleted PIT (search_context_missing).
+
+        The type can be nested under root_cause, so match the stringified body.
+        """
+        return _SEARCH_CONTEXT_MISSING_ERROR_TYPE in str(
+            getattr(error, "info", "")
+        ) or _SEARCH_CONTEXT_MISSING_ERROR_TYPE in str(error)
 
     @log_function_time(print_only=True, debug_only=True)
     def refresh_index(self) -> None:

--- a/backend/onyx/document_index/opensearch/client.py
+++ b/backend/onyx/document_index/opensearch/client.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import time
+from collections import Counter
 from collections.abc import Iterator
 from contextlib import AbstractContextManager
 from contextlib import nullcontext
@@ -151,6 +152,28 @@ class OpenSearchServerSideTimeout(Exception):
     """
     A server-side timeout occurred when searching an OpenSearch index.
     """
+
+
+def _summarize_bulk_errors(errors: list[dict[str, Any]]) -> str:
+    """Reduce raw bulk per-item errors to (op, status, type) counts.
+
+    error.reason / caused_by echo a preview of the offending document's field
+    values; dumping them into an exception message would leak indexed content
+    into logs, so only op/status/type are surfaced.
+    """
+    counts: Counter[tuple[str, Any, str]] = Counter()
+    for error in errors:
+        op, item = next(iter(error.items()), ("", {}))
+        item = item if isinstance(item, dict) else {}
+        err_obj = item.get("error")
+        err_type = err_obj.get("type", "") if isinstance(err_obj, dict) else ""
+        counts[(op, item.get("status", 0), err_type)] += 1
+    return ", ".join(
+        f"{count}x op={op or 'unknown'} status={status} type={err_type or 'unknown'}"
+        for (op, status, err_type), count in sorted(
+            counts.items(), key=lambda kv: str(kv)
+        )
+    )
 
 
 def get_new_body_without_vectors(body: dict[str, Any]) -> dict[str, Any]:
@@ -996,7 +1019,7 @@ class OpenSearchIndexClient(OpenSearchClient):
         if fatal:
             raise OpenSearchIndexError(
                 f"Failed to bulk index documents for index {self._index_name}. "
-                f"{len(fatal)} fatal error(s) occurred: {fatal}"
+                f"{len(fatal)} fatal error(s) occurred: {_summarize_bulk_errors(fatal)}"
             )
         return benign
 
@@ -1287,8 +1310,9 @@ class OpenSearchIndexClient(OpenSearchClient):
 
             if fatal_errors:
                 raise OpenSearchUpdateError(
-                    f"Failed to bulk update document chunks for index {self._index_name}. At least "
-                    f"one fatal error occurred: {fatal_errors[0]}"
+                    f"Failed to bulk update document chunks for index {self._index_name}. "
+                    f"{len(fatal_errors)} fatal error(s) occurred: "
+                    f"{_summarize_bulk_errors(fatal_errors)}"
                 )
 
             data = []

--- a/backend/onyx/document_index/opensearch/client.py
+++ b/backend/onyx/document_index/opensearch/client.py
@@ -1252,7 +1252,14 @@ class OpenSearchIndexClient(OpenSearchClient):
                     and err_type == _DOCUMENT_MISSING_ERROR_TYPE
                 ):
                     # doc not in this index yet; surface instead of failing
-                    missing_chunk_ids.append(info.get("_id", ""))
+                    missing_chunk_id = info.get("_id", "")
+                    if not missing_chunk_id:
+                        raise OpenSearchUpdateError(
+                            "OpenSearch returned a document_missing error when trying to bulk "
+                            f"update document chunks for index {self._index_name}. Error: {error}. "
+                            "The error did not contain an ID however.",
+                        )
+                    missing_chunk_ids.append(missing_chunk_id)
                 elif status >= 500 and err_type in _RETRYABLE_UPDATE_ERROR_TYPES:
                     # We have seen a bug in OpenSearch version 3.4.0 when using
                     # the knn plugin and when derived_source is enabled (the

--- a/backend/onyx/document_index/opensearch/client.py
+++ b/backend/onyx/document_index/opensearch/client.py
@@ -1600,7 +1600,7 @@ class OpenSearchIndexClient(OpenSearchClient):
         """Opens a point-in-time (PIT) over this index for a consistent scan.
 
         The PIT pins the index across searches so concurrent writes don't shift
-        the result set. The caller threads the returned id into
+        the result set. The caller passes the returned id into
         fetch_chunks_for_doc_ids and releases it with close_pit when done.
 
         Args:
@@ -1644,10 +1644,10 @@ class OpenSearchIndexClient(OpenSearchClient):
     ) -> tuple[list[DocumentChunkWithoutVectors], list[object] | None, str]:
         """Fetches one page of regular chunks for a batch of documents from a PIT.
 
-        Filters to regular chunks (max_chunk_size == DEFAULT_MAX_CHUNK_SIZE) so
-        large/mini chunks are never ported, sorts by (document_id, chunk_index),
-        and pages with search_after. Vectors are excluded — the port re-embeds.
-        If the PIT expired the scan re-opens it and retries once.
+        Filters to regular chunks (max_chunk_size == DEFAULT_MAX_CHUNK_SIZE),
+        sorts by (document_id, chunk_index), and pages with search_after.
+        Vectors are excluded — the port re-embeds. If the PIT expired the scan
+        re-opens it and retries once.
 
         Args:
             pit_id: The point-in-time id from open_pit.
@@ -1665,7 +1665,7 @@ class OpenSearchIndexClient(OpenSearchClient):
         Returns:
             A tuple of (chunks, next_search_after, pit_id_in_use). next_search_after
             is None once the batch is exhausted; pit_id_in_use reflects the new PIT
-            when the scan re-opened, so the caller threads it forward.
+            when the scan re-opened, so the caller passes it forward.
         """
         if not doc_ids:
             return [], None, pit_id
@@ -1781,6 +1781,8 @@ class OpenSearchIndexClient(OpenSearchClient):
                 "bool": {
                     "filter": [
                         {"terms": {DOCUMENT_ID_FIELD_NAME: doc_ids}},
+                        # OpenSearch holds no large/mini chunks today, so this
+                        # matches everything; kept as a guard if that changes
                         {"term": {MAX_CHUNK_SIZE_FIELD_NAME: DEFAULT_MAX_CHUNK_SIZE}},
                     ]
                 }

--- a/backend/onyx/document_index/opensearch/opensearch_document_index.py
+++ b/backend/onyx/document_index/opensearch/opensearch_document_index.py
@@ -28,8 +28,10 @@ from onyx.document_index.interfaces_new import DocumentInsertionRecord
 from onyx.document_index.interfaces_new import DocumentSectionRequest
 from onyx.document_index.interfaces_new import IndexingMetadata
 from onyx.document_index.interfaces_new import MetadataUpdateRequest
+from onyx.document_index.interfaces_new import SecondaryIndexDocumentMissingError
 from onyx.document_index.interfaces_new import TenantState
 from onyx.document_index.opensearch.client import OpenSearchClient
+from onyx.document_index.opensearch.client import OpenSearchDocumentMissingError
 from onyx.document_index.opensearch.client import OpenSearchIndexClient
 from onyx.document_index.opensearch.client import SearchHit
 from onyx.document_index.opensearch.cluster_settings import OPENSEARCH_CLUSTER_SETTINGS
@@ -542,6 +544,7 @@ class OpenSearchDocumentIndex(DocumentIndex):
     def update(
         self,
         update_requests: list[MetadataUpdateRequest],
+        swallow_document_missing: bool = False,
     ) -> None:
         """Updates some set of chunks.
 
@@ -570,6 +573,10 @@ class OpenSearchDocumentIndex(DocumentIndex):
             len(update_requests),
             self._index_name,
         )
+        # When swallowing, keep going past a missing-doc request so later
+        # requests still update; attribute only the docs that were truly missing.
+        missing_chunk_ids: list[str] = []
+        missing_document_ids: set[str] = set()
         for update_request in update_requests:
             properties_to_update: dict[str, Any] = dict()
             # TODO(andrei): Nit but consider if we can use DocumentChunk here so
@@ -612,6 +619,7 @@ class OpenSearchDocumentIndex(DocumentIndex):
                 continue
 
             doc_chunk_ids_to_update: list[str] = []
+            chunk_id_to_doc_id: dict[str, str] = {}
             for doc_id in update_request.document_ids:
                 doc_chunk_count = update_request.doc_id_to_chunk_cnt.get(doc_id, -1)
                 if doc_chunk_count < 0:
@@ -643,10 +651,27 @@ class OpenSearchDocumentIndex(DocumentIndex):
                         chunk_index=chunk_index,
                     )
                     doc_chunk_ids_to_update.append(document_chunk_id)
+                    chunk_id_to_doc_id[document_chunk_id] = doc_id
 
-            self._client.bulk_update_documents(
-                document_chunk_ids=doc_chunk_ids_to_update,
-                properties_to_update=properties_to_update,
+            try:
+                self._client.bulk_update_documents(
+                    document_chunk_ids=doc_chunk_ids_to_update,
+                    properties_to_update=properties_to_update,
+                    swallow_document_missing=swallow_document_missing,
+                )
+            except OpenSearchDocumentMissingError as e:
+                # Only raised when swallowing; record the missing docs and keep
+                # processing the remaining requests.
+                missing_chunk_ids.extend(e.missing_chunk_ids)
+                missing_document_ids.update(
+                    chunk_id_to_doc_id[cid]
+                    for cid in e.missing_chunk_ids
+                    if cid in chunk_id_to_doc_id
+                )
+
+        if missing_chunk_ids:
+            raise OpenSearchDocumentMissingError(
+                missing_chunk_ids, sorted(missing_document_ids)
             )
 
     def id_based_retrieval(
@@ -880,22 +905,32 @@ class OpenSearchDocumentIndex(DocumentIndex):
 
         return inference_chunks
 
-    def index_raw_chunks(self, chunks: list[DocumentChunk]) -> None:
+    def index_raw_chunks(
+        self, chunks: list[DocumentChunk], use_create_only: bool = False
+    ) -> None:
         """Indexes raw document chunks into OpenSearch.
 
-        Used in the Vespa migration task. Can be deleted after migrations are
-        complete.
+        Used by the Vespa migration task and the reindex port. The reindex port
+        passes use_create_only=True so its stale backlog snapshot can never
+        overwrite a chunk a live/forward writer already owns in FUTURE (an
+        existing chunk is a benign 409). The port is pure gap-fill backfill of
+        PRESENT, which is always >= the port in recency, so it never needs to
+        overwrite an existing chunk.
         """
         logger.debug(
             "[OpenSearchDocumentIndex] Indexing %s raw chunks for index %s.",
             len(chunks),
             self._index_name,
         )
-        # Do not raise if the document already exists, just update. This is
-        # because the document may already have been indexed during the
-        # OpenSearch transition period.
+        # Migration path (use_create_only=False): update_if_exists overwrites,
+        # since the doc may already have been indexed during the OpenSearch
+        # transition period. Port path (use_create_only=True): create-only, so
+        # it never overwrites.
         self._client.bulk_index_documents(
-            documents=chunks, tenant_state=self._tenant_state, update_if_exists=True
+            documents=chunks,
+            tenant_state=self._tenant_state,
+            update_if_exists=True,
+            use_create_only=use_create_only,
         )
 
 
@@ -974,7 +1009,12 @@ class OpenSearchIndexPair(DocumentIndex):
     def update(self, update_requests: list[MetadataUpdateRequest]) -> None:
         self._primary.update(update_requests)
         if self._secondary is not None:
-            self._secondary.update(update_requests)
+            # FUTURE may not have the doc yet (port); re-raise as a typed signal
+            # carrying only the docs that were actually missing.
+            try:
+                self._secondary.update(update_requests, swallow_document_missing=True)
+            except OpenSearchDocumentMissingError as e:
+                raise SecondaryIndexDocumentMissingError(e.missing_document_ids)
 
     def id_based_retrieval(
         self,

--- a/backend/onyx/document_index/opensearch/opensearch_document_index.py
+++ b/backend/onyx/document_index/opensearch/opensearch_document_index.py
@@ -126,7 +126,7 @@ def set_cluster_state(client: OpenSearchClient) -> None:
     )
 
 
-def _convert_retrieved_opensearch_chunk_to_inference_chunk_uncleaned(
+def convert_retrieved_opensearch_chunk_to_inference_chunk_uncleaned(
     chunk: DocumentChunkWithoutVectors,
     score: float | None,
     highlights: dict[str, list[str]],
@@ -716,7 +716,7 @@ class OpenSearchDocumentIndex(DocumentIndex):
                 search_type=OpenSearchSearchType.DOC_ID_RETRIEVAL,
             )
             inference_chunks_uncleaned: list[InferenceChunkUncleaned] = [
-                _convert_retrieved_opensearch_chunk_to_inference_chunk_uncleaned(
+                convert_retrieved_opensearch_chunk_to_inference_chunk_uncleaned(
                     search_hit.document_chunk, None, {}
                 )
                 for search_hit in search_hits
@@ -772,7 +772,7 @@ class OpenSearchDocumentIndex(DocumentIndex):
         # Good place for a breakpoint to inspect the search hits if you have
         # "explain" enabled.
         inference_chunks_uncleaned: list[InferenceChunkUncleaned] = [
-            _convert_retrieved_opensearch_chunk_to_inference_chunk_uncleaned(
+            convert_retrieved_opensearch_chunk_to_inference_chunk_uncleaned(
                 search_hit.document_chunk, search_hit.score, search_hit.match_highlights
             )
             for search_hit in search_hits
@@ -817,7 +817,7 @@ class OpenSearchDocumentIndex(DocumentIndex):
         )
 
         inference_chunks_uncleaned: list[InferenceChunkUncleaned] = [
-            _convert_retrieved_opensearch_chunk_to_inference_chunk_uncleaned(
+            convert_retrieved_opensearch_chunk_to_inference_chunk_uncleaned(
                 search_hit.document_chunk, search_hit.score, search_hit.match_highlights
             )
             for search_hit in search_hits
@@ -861,7 +861,7 @@ class OpenSearchDocumentIndex(DocumentIndex):
         )
 
         inference_chunks_uncleaned: list[InferenceChunkUncleaned] = [
-            _convert_retrieved_opensearch_chunk_to_inference_chunk_uncleaned(
+            convert_retrieved_opensearch_chunk_to_inference_chunk_uncleaned(
                 search_hit.document_chunk, search_hit.score, search_hit.match_highlights
             )
             for search_hit in search_hits
@@ -894,7 +894,7 @@ class OpenSearchDocumentIndex(DocumentIndex):
             search_type=OpenSearchSearchType.RANDOM,
         )
         inference_chunks_uncleaned: list[InferenceChunkUncleaned] = [
-            _convert_retrieved_opensearch_chunk_to_inference_chunk_uncleaned(
+            convert_retrieved_opensearch_chunk_to_inference_chunk_uncleaned(
                 search_hit.document_chunk, search_hit.score, search_hit.match_highlights
             )
             for search_hit in search_hits

--- a/backend/onyx/document_index/opensearch/port_copy.py
+++ b/backend/onyx/document_index/opensearch/port_copy.py
@@ -1,0 +1,187 @@
+"""PRESENT -> FUTURE chunk copy for the reindex port.
+
+Reads a document's existing chunks from the PRESENT OpenSearch index via the PIT
+scan, re-embeds them under the FUTURE model, and writes them to the FUTURE index
+create-only (it never overwrites a chunk a live/forward writer already owns, so a
+stale backlog write can't clobber a fresher one). The port Celery task drives this per
+batch and owns lifecycle (cursor, stall); keeping the OpenSearch specifics here
+keeps them off the generic docprocessing worker.
+
+The AUGMENTATION strategy (contextual-RAG toggle/model change) re-enriches each
+document, which needs all of a document's chunks together to reconstruct the doc
+text — and a document's chunks can span PIT pages — so that path buffers the
+batch into a single page, while MODEL_ONLY streams page by page.
+"""
+
+from collections.abc import Callable
+from collections.abc import Iterable
+
+from onyx.db.models import SearchSettings
+from onyx.document_index.factory import build_opensearch_document_index
+from onyx.document_index.opensearch.client import OpenSearchIndexClient
+from onyx.document_index.opensearch.opensearch_document_index import (
+    OpenSearchDocumentIndex,
+)
+from onyx.document_index.opensearch.schema import DocumentChunkWithoutVectors
+from onyx.indexing.chunker import DEFAULT_CONTEXTUAL_RAG_RESERVED_TOKENS
+from onyx.indexing.embedder import DefaultIndexingEmbedder
+from onyx.indexing.embedder import IndexingEmbedder
+from onyx.indexing.port_reembed import AugmentationReembedContext
+from onyx.indexing.port_reembed import re_embed_chunks
+from onyx.indexing.port_reembed import ReembedStrategy
+from onyx.indexing.port_reembed import select_reembed_strategy
+from onyx.llm.factory import get_contextual_rag_llm_for_search_settings
+from onyx.natural_language_processing.utils import BaseTokenizer
+from onyx.natural_language_processing.utils import get_tokenizer
+from shared_configs.configs import DOC_EMBEDDING_CONTEXT_SIZE
+
+# Chunks per create-only write. AUGMENTATION buffers a whole batch into one page, so
+# an unbounded write could run minutes with no heartbeat and get a live port falsely
+# stall-failed. Matches the MODEL_ONLY per-page size the watchdog already tolerates.
+_PORT_WRITE_PAGE_SIZE = 1000
+
+
+def _build_augmentation_ctx(
+    future_search_settings: SearchSettings,
+) -> AugmentationReembedContext:
+    """Prepare the AUGMENTATION inputs while a DB session is available. For
+    FUTURE-RAG-off only the flag matters; for FUTURE-RAG-on we also resolve the
+    contextual LLM/tokenizer and the same token budgets the chunker uses."""
+    if not future_search_settings.enable_contextual_rag:
+        return AugmentationReembedContext(future_enable_contextual_rag=False)
+
+    llm = get_contextual_rag_llm_for_search_settings(future_search_settings)
+    if llm is None:
+        raise ValueError(
+            "contextual-RAG is enabled on the FUTURE search settings but no "
+            "contextual RAG model is configured (and no tenant default exists)"
+        )
+    tokenizer = get_tokenizer(
+        model_name=llm.config.model_name,
+        provider_type=llm.config.model_provider,
+    )
+    return AugmentationReembedContext(
+        future_enable_contextual_rag=True,
+        llm=llm,
+        tokenizer=tokenizer,
+        # The same *2 fudge factor over the chunk size that the indexing
+        # pipeline applies to absorb embedder-vs-LLM tokenizer drift.
+        chunk_token_limit=DOC_EMBEDDING_CONTEXT_SIZE * 2,
+        contextual_rag_reserved_tokens=DEFAULT_CONTEXTUAL_RAG_RESERVED_TOKENS,
+    )
+
+
+def copy_present_chunks_to_future(
+    present_client: OpenSearchIndexClient,
+    future_index: OpenSearchDocumentIndex,
+    doc_ids: list[str],
+    strategy: ReembedStrategy,
+    embedder: IndexingEmbedder,
+    present_tokenizer: BaseTokenizer,
+    augmentation_ctx: AugmentationReembedContext | None = None,
+    surviving_doc_ids: Callable[[], set[str]] | None = None,
+    should_abort: Callable[[], bool] | None = None,
+) -> tuple[int, bool]:
+    """Port one batch PRESENT -> FUTURE; returns (chunks written, aborted).
+    aborted=True means should_abort stopped the copy mid-batch, so the caller
+    must not advance its cursor past this partially-ported batch.
+
+    Both callbacks run per page right before the write (after the slow re-embed):
+    surviving_doc_ids drops chunks of docs deleted mid-batch (no resurrection);
+    should_abort stops writing once the attempt is cancelled."""
+    pages: Iterable[list[DocumentChunkWithoutVectors]]
+    if strategy is ReembedStrategy.AUGMENTATION:
+        # Buffer the batch into one page: re-enrichment needs each document's
+        # chunks complete (they can span PIT pages), and one page also means one
+        # embed round-trip + one bulk write for the whole batch.
+        pages = [
+            [
+                chunk
+                for page in present_client.iter_chunks_for_doc_ids(doc_ids)
+                for chunk in page
+            ]
+        ]
+    else:
+        pages = present_client.iter_chunks_for_doc_ids(doc_ids)
+
+    chunks_written = 0
+    for page_chunks in pages:
+        reembedded = re_embed_chunks(
+            page_chunks,
+            strategy,
+            embedder,
+            augmentation_ctx=augmentation_ctx,
+            present_tokenizer=present_tokenizer,
+        )
+        if not reembedded:
+            continue
+        # Stop writing the instant the attempt is cancelled (e.g. by a deletion).
+        if should_abort is not None and should_abort():
+            return chunks_written, True
+        # Drop chunks of docs deleted mid-batch — create-only would otherwise
+        # re-add them to FUTURE (resurrection).
+        if surviving_doc_ids is not None:
+            surviving = surviving_doc_ids()
+            reembedded = [c for c in reembedded if c.document_id in surviving]
+            if not reembedded:
+                continue
+        # Sub-page the write, heartbeating (via should_abort) before each, so one
+        # write can't outlast the watchdog and get this live port falsely failed.
+        for i in range(0, len(reembedded), _PORT_WRITE_PAGE_SIZE):
+            if should_abort is not None and should_abort():
+                return chunks_written, True
+            sub = reembedded[i : i + _PORT_WRITE_PAGE_SIZE]
+            future_index.index_raw_chunks(sub, use_create_only=True)
+            chunks_written += len(sub)
+    return chunks_written, False
+
+
+class PortCopier:
+    """Resolves the OpenSearch handles, reembed strategy, and embedder once so
+    copy_doc_batch runs with no DB session held. Build it while the search
+    settings are session-attached: the FUTURE provider credentials lazy-load,
+    and the AUGMENTATION contextual LLM/model-config resolution needs a session.
+    """
+
+    def __init__(
+        self,
+        present_search_settings: SearchSettings,
+        future_search_settings: SearchSettings,
+    ) -> None:
+        self._strategy = select_reembed_strategy(
+            present_search_settings, future_search_settings
+        )
+        self._present_client = OpenSearchIndexClient(
+            index_name=present_search_settings.index_name
+        )
+        self._future_index = build_opensearch_document_index(future_search_settings)
+        self._embedder = DefaultIndexingEmbedder.from_db_search_settings(
+            future_search_settings
+        )
+        # The PRESENT model's tokenizer (what indexing used) — MODEL_ONLY needs it to
+        # reproduce the metadata-tail skip; the FUTURE embedder's would flip it.
+        self._present_tokenizer = get_tokenizer(
+            model_name=present_search_settings.model_name,
+            provider_type=present_search_settings.provider_type,
+        )
+        self._augmentation_ctx: AugmentationReembedContext | None = None
+        if self._strategy is ReembedStrategy.AUGMENTATION:
+            self._augmentation_ctx = _build_augmentation_ctx(future_search_settings)
+
+    def copy_doc_batch(
+        self,
+        doc_ids: list[str],
+        surviving_doc_ids: Callable[[], set[str]] | None = None,
+        should_abort: Callable[[], bool] | None = None,
+    ) -> tuple[int, bool]:
+        return copy_present_chunks_to_future(
+            present_client=self._present_client,
+            future_index=self._future_index,
+            doc_ids=doc_ids,
+            strategy=self._strategy,
+            embedder=self._embedder,
+            present_tokenizer=self._present_tokenizer,
+            augmentation_ctx=self._augmentation_ctx,
+            surviving_doc_ids=surviving_doc_ids,
+            should_abort=should_abort,
+        )

--- a/backend/onyx/indexing/adapters/document_indexing_adapter.py
+++ b/backend/onyx/indexing/adapters/document_indexing_adapter.py
@@ -53,7 +53,10 @@ class DocumentIndexingBatchAdapter(IndexingBatchAdapter):
         self.index_attempt_metadata = index_attempt_metadata
 
     def prepare(
-        self, documents: list[Document], ignore_time_skip: bool
+        self,
+        documents: list[Document],
+        ignore_time_skip: bool,
+        index_to_secondary: bool,
     ) -> DocumentBatchPrepareContext | None:
         """Upsert docs, map CC pairs, return context or mark as indexed if no-op.
 
@@ -66,6 +69,7 @@ class DocumentIndexingBatchAdapter(IndexingBatchAdapter):
                 index_attempt_metadata=self.index_attempt_metadata,
                 db_session=db_session,
                 ignore_time_skip=ignore_time_skip,
+                index_to_secondary=index_to_secondary,
             )
 
             if not context:

--- a/backend/onyx/indexing/adapters/user_file_indexing_adapter.py
+++ b/backend/onyx/indexing/adapters/user_file_indexing_adapter.py
@@ -74,6 +74,7 @@ class UserFileIndexingAdapter:
         self,
         documents: list[Document],
         ignore_time_skip: bool,  # noqa: ARG002
+        index_to_secondary: bool,  # noqa: ARG002
     ) -> DocumentBatchPrepareContext:
         return DocumentBatchPrepareContext(
             updatable_docs=documents,

--- a/backend/onyx/indexing/chunker.py
+++ b/backend/onyx/indexing/chunker.py
@@ -30,11 +30,16 @@ CHUNK_OVERLAP = 0
 # overwhelm the actual contents of the chunk
 MAX_METADATA_PERCENTAGE = 0.25
 CHUNK_MIN_CONTENT = 256
+# Tokens reserved per chunk for the contextual-RAG doc summary + chunk context.
+# Single source of truth — the reindex port reuses it to mirror indexing budgets.
+DEFAULT_CONTEXTUAL_RAG_RESERVED_TOKENS = MAX_CONTEXT_TOKENS * (
+    int(USE_CHUNK_SUMMARY) + int(USE_DOCUMENT_SUMMARY)
+)
 
 logger = setup_logger()
 
 
-def _get_metadata_suffix_for_document_index(
+def get_metadata_suffix_for_document_index(
     metadata: dict[str, str | list[str]], include_separator: bool = False
 ) -> tuple[str, str]:
     """
@@ -144,8 +149,8 @@ class Chunker:
             assert USE_CHUNK_SUMMARY or USE_DOCUMENT_SUMMARY, (
                 "Contextual RAG requires at least one of chunk summary and document summary enabled"
             )
-        self.default_contextual_rag_reserved_tokens = MAX_CONTEXT_TOKENS * (
-            int(USE_CHUNK_SUMMARY) + int(USE_DOCUMENT_SUMMARY)
+        self.default_contextual_rag_reserved_tokens = (
+            DEFAULT_CONTEXTUAL_RAG_RESERVED_TOKENS
         )
         self.tokenizer = tokenizer
         self.callback = callback
@@ -209,7 +214,7 @@ class Chunker:
             (
                 metadata_suffix_semantic,
                 metadata_suffix_keyword,
-            ) = _get_metadata_suffix_for_document_index(
+            ) = get_metadata_suffix_for_document_index(
                 document.metadata, include_separator=True
             )
             metadata_tokens = len(self.tokenizer.encode(metadata_suffix_semantic))

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -74,9 +74,10 @@ from onyx.indexing.models import DocMetadataAwareIndexChunk
 from onyx.indexing.models import IndexingBatchAdapter
 from onyx.indexing.models import UpdatableChunkData
 from onyx.indexing.vector_db_insertion import write_chunks_to_vector_db_with_backoff
+from onyx.llm.factory import get_contextual_rag_llm_for_search_settings
 from onyx.llm.factory import get_default_llm_with_vision
-from onyx.llm.factory import get_llm_for_contextual_rag
 from onyx.llm.interfaces import LLM
+from onyx.llm.models import ReasoningEffort
 from onyx.llm.models import UserMessage
 from onyx.llm.multi_llm import LLMRateLimitError
 from onyx.llm.utils import llm_response_to_string
@@ -101,6 +102,11 @@ logger = setup_logger()
 
 MAX_CONTEXTUAL_RAG_WORKERS = 128  # Assume 8mb of memory per worker
 MAX_IMAGE_WORKERS = 16
+
+# Contextual-RAG doc/chunk summaries are a short, non-reasoning task. On a reasoning
+# model the hidden reasoning tokens consume the small MAX_CONTEXT_TOKENS budget and the
+# visible summary returns empty, so disable reasoning for these calls.
+CONTEXTUAL_RAG_REASONING_EFFORT = ReasoningEffort.OFF
 
 
 class _DocsToUpdateResult(NamedTuple):
@@ -321,6 +327,7 @@ def get_docs_to_update(
     documents: list[Document],
     db_docs: list[DBDocument],
     ignore_timestamp_gate: bool = False,
+    ignore_content_hash_gate: bool = False,
 ) -> _DocsToUpdateResult:
     """Return the subset of documents that need to be re-indexed, plus their pre-computed hashes.
 
@@ -340,6 +347,9 @@ def get_docs_to_update(
       a timestamp advance is authoritative evidence of a change and must not be
       overridden (e.g. GDrive in-place image replacement: same image_file_id, but image
       bytes changed; hash would incorrectly say "skip").
+
+      Also skipped when ignore_content_hash_gate=True: a FUTURE/secondary build
+      must not consult the shared (PRESENT-only) hash, else writes cross-suppress.
 
     The returned doc_id_to_content_hash map contains hashes for all documents that
     will be indexed. These are persisted to the DB after successful vector DB writes
@@ -372,7 +382,7 @@ def get_docs_to_update(
         # A timestamp advance is authoritative evidence of a change — skip the hash
         # check so we never suppress a legitimate re-index (see docstring).
         content_hash = doc.content_hash()
-        if not timestamp_advanced:
+        if not timestamp_advanced and not ignore_content_hash_gate:
             db_doc = id_to_db_doc_map.get(doc.id)
             if db_doc and db_doc.content_hash == content_hash:
                 logger.debug(f"Skipping document {doc.id!r} — content hash unchanged")
@@ -394,6 +404,7 @@ def index_doc_batch_with_handler(
     tenant_id: str,
     adapter: IndexingBatchAdapter,
     ignore_time_skip: bool = False,
+    index_to_secondary: bool = False,
     from_beginning: bool = False,
     enable_contextual_rag: bool = False,
     llm: LLM | None = None,
@@ -408,6 +419,7 @@ def index_doc_batch_with_handler(
             tenant_id=tenant_id,
             adapter=adapter,
             ignore_time_skip=ignore_time_skip,
+            index_to_secondary=index_to_secondary,
             from_beginning=from_beginning,
             enable_contextual_rag=enable_contextual_rag,
             llm=llm,
@@ -494,6 +506,7 @@ def index_doc_batch_prepare(
     index_attempt_metadata: IndexAttemptMetadata,
     db_session: Session,
     ignore_time_skip: bool = False,
+    index_to_secondary: bool = False,
 ) -> DocumentBatchPrepareContext | None:
     """Sets up the documents in the relational DB (source of truth) for permissions, metadata, etc.
     This preceeds indexing it into the actual document index."""
@@ -516,6 +529,7 @@ def index_doc_batch_prepare(
         documents=documents,
         db_docs=db_docs,
         ignore_timestamp_gate=ignore_time_skip,
+        ignore_content_hash_gate=index_to_secondary,
     )
     if len(updatable_docs) != len(documents):
         updatable_doc_ids = [doc.id for doc in updatable_docs]
@@ -860,7 +874,11 @@ def add_document_summaries(
         flow=LLMFlow.CONTEXTUAL_RAG_DOC_SUMMARY,
         input_messages=[prompt_msg],
     ) as span_generation:
-        response = llm.invoke(prompt_msg, max_tokens=MAX_CONTEXT_TOKENS)
+        response = llm.invoke(
+            prompt_msg,
+            max_tokens=MAX_CONTEXT_TOKENS,
+            reasoning_effort=CONTEXTUAL_RAG_REASONING_EFFORT,
+        )
         record_llm_response(span_generation, response)
     doc_summary = llm_response_to_string(response)
 
@@ -909,7 +927,11 @@ def add_chunk_summaries(
             flow=LLMFlow.CONTEXTUAL_RAG_DOC_SUMMARY,
             input_messages=[fallback_prompt],
         ) as span_generation:
-            response = llm.invoke(fallback_prompt, max_tokens=MAX_CONTEXT_TOKENS)
+            response = llm.invoke(
+                fallback_prompt,
+                max_tokens=MAX_CONTEXT_TOKENS,
+                reasoning_effort=CONTEXTUAL_RAG_REASONING_EFFORT,
+            )
             record_llm_response(span_generation, response)
         doc_info = llm_response_to_string(response)
 
@@ -934,7 +956,11 @@ def add_chunk_summaries(
                 flow=LLMFlow.CONTEXTUAL_RAG_CHUNK_CONTEXT,
                 input_messages=[processed_prompt],
             ) as span_generation:
-                response = llm.invoke(processed_prompt, max_tokens=MAX_CONTEXT_TOKENS)
+                response = llm.invoke(
+                    processed_prompt,
+                    max_tokens=MAX_CONTEXT_TOKENS,
+                    reasoning_effort=CONTEXTUAL_RAG_REASONING_EFFORT,
+                )
                 record_llm_response(span_generation, response)
             chunk.chunk_context = llm_response_to_string(response)
 
@@ -1230,6 +1256,7 @@ def index_doc_batch(
     enable_contextual_rag: bool = False,
     llm: LLM | None = None,
     ignore_time_skip: bool = False,
+    index_to_secondary: bool = False,
     from_beginning: bool = False,
     filter_fnc: Callable[
         [list[Document]], tuple[list[Document], list[ConnectorFailure]]
@@ -1267,7 +1294,9 @@ def index_doc_batch(
     filtered_documents, filter_failures = filter_fnc(document_batch)
     filtered_documents = _apply_document_ingestion_hook(filtered_documents)
     with time_stage_if_set(IndexAttemptStage.DOC_DB_PREPARE, attempt_id):
-        context = adapter.prepare(filtered_documents, ignore_time_skip)
+        context = adapter.prepare(
+            filtered_documents, ignore_time_skip, index_to_secondary
+        )
     if not context:
         result = IndexingPipelineResult.empty(len(filtered_documents))
         result.failures.extend(filter_failures)
@@ -1438,7 +1467,9 @@ def index_doc_batch(
             # vector DB. Doing this here (after the write) prevents a failed
             # index from storing a hash that would permanently skip the document
             # on the next sync. Hashes were pre-computed in get_docs_to_update.
-            if primary_doc_idx_insertion_records is not None:
+            # Skipped for FUTURE writes: stamping the PRESENT-only hash would make
+            # the PRESENT poll skip the doc (cross-index suppression).
+            if primary_doc_idx_insertion_records is not None and not index_to_secondary:
                 successfully_indexed_ids = {
                     r.document_id for r in primary_doc_idx_insertion_records
                 }
@@ -1484,9 +1515,14 @@ def run_indexing_pipeline(
     adapter: IndexingBatchAdapter,
     chunker: Chunker | None = None,
     ignore_time_skip: bool = False,
+    index_to_secondary: bool = False,
     from_beginning: bool = False,
 ) -> IndexingPipelineResult:
-    """Builds a pipeline which takes in a list (batch) of docs and indexes them."""
+    """Builds a pipeline which takes in a list (batch) of docs and indexes them.
+
+    index_to_secondary disables the content-hash gate + stamp for FUTURE writes so
+    they don't cross-suppress the PRESENT index's shared hash.
+    """
     if db_session is not None:
         all_search_settings = get_active_search_settings(db_session)
     else:
@@ -1507,16 +1543,7 @@ def run_indexing_pipeline(
     )
     llm = None
     if enable_contextual_rag:
-        mc_id = search_settings.contextual_rag_model_configuration_id
-        if mc_id is None:
-            # Fall back to the global default contextual RAG model (LLMModelFlow).
-            from onyx.db.llm import fetch_default_contextual_rag_model
-
-            with get_session_with_current_tenant() as fallback_session:
-                mc = fetch_default_contextual_rag_model(fallback_session)
-            mc_id = mc.id if mc else None
-        if mc_id is not None:
-            llm = get_llm_for_contextual_rag(mc_id)
+        llm = get_contextual_rag_llm_for_search_settings(search_settings)
 
     chunker = chunker or Chunker(
         tokenizer=embedder.embedding_model.tokenizer,
@@ -1537,5 +1564,6 @@ def run_indexing_pipeline(
         enable_contextual_rag=enable_contextual_rag,
         llm=llm,
         ignore_time_skip=ignore_time_skip,
+        index_to_secondary=index_to_secondary,
         from_beginning=from_beginning,
     )

--- a/backend/onyx/indexing/models.py
+++ b/backend/onyx/indexing/models.py
@@ -197,8 +197,6 @@ class IndexingSetting(EmbeddingModelDetail):
     reduced_dimension: int | None = None
 
     switchover_type: SwitchoverType = SwitchoverType.REINDEX
-    # Reindex "port" flow gate; see SearchSettings.use_port_flow.
-    use_port_flow: bool = False
     enable_contextual_rag: bool
     contextual_rag_model_configuration_id: int | None = None
     # Deprecated: accepted for backward compat but silently ignored on write.
@@ -230,7 +228,6 @@ class IndexingSetting(EmbeddingModelDetail):
             embedding_precision=search_settings.embedding_precision,
             reduced_dimension=search_settings.reduced_dimension,
             switchover_type=search_settings.switchover_type,
-            use_port_flow=search_settings.use_port_flow,
             enable_contextual_rag=search_settings.enable_contextual_rag,
             contextual_rag_model_configuration_id=search_settings.contextual_rag_model_configuration_id,
         )

--- a/backend/onyx/indexing/port_reembed.py
+++ b/backend/onyx/indexing/port_reembed.py
@@ -1,0 +1,432 @@
+"""Re-embed stored PRESENT chunks under FUTURE search settings without
+re-fetching the source document (solution-design.md §5.1.1).
+
+Two strategies, chosen by comparing PRESENT vs FUTURE settings:
+
+- MODEL_ONLY (model / prefix / normalize / dimension changed, enrichment did
+  not): the embedding input is unchanged from indexing, so we re-embed the same
+  enriched text — the title prefix, doc summary and chunk context are kept,
+  because the stored vector encoded all of them and the new model must encode
+  the same text. The only catch is that the stored `content` ends with the
+  *keyword* metadata tail while indexing embedded the *semantic* tail, so we
+  swap just that tail back.
+- AUGMENTATION (contextual-RAG toggle or model changed): the enriched text
+  itself changes, so we strip the stored augmentation back to the bare chunk
+  text, re-glue under FUTURE settings, then re-embed. Two sub-cases keyed on the
+  FUTURE `enable_contextual_rag`:
+    * FUTURE RAG off — strip the doc summary / chunk context / title / metadata
+      and re-embed the bare chunk (no LLM).
+    * FUTURE RAG on — additionally regenerate the doc summary + chunk context
+      under the FUTURE contextual LLM. The full document text the LLM needs is
+      *reconstructed by concatenating the document's own (bare) chunks* in chunk
+      order; the port never re-fetches the source. This duplicates chunk-overlap
+      regions and loses the original section boundaries, so the reconstructed
+      text is not byte-identical to the source — an accepted imprecision (the LLM
+      truncates to a token budget anyway, and re-fetching the source is the
+      fragility this feature exists to remove).
+
+Only regular chunks are handled (the port reads `max_chunk_size ==
+DEFAULT_MAX_CHUNK_SIZE`); writes are idempotent (create-only: re-creating an
+existing chunk is a benign 409) so we re-embed unconditionally rather than
+diffing content hashes.
+"""
+
+from __future__ import annotations
+
+import enum
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from onyx.configs.constants import DocumentSource
+from onyx.configs.constants import RETURN_SEPARATOR
+from onyx.connectors.models import convert_metadata_list_of_strings_to_dict
+from onyx.connectors.models import Document
+from onyx.connectors.models import TextSection
+from onyx.db.models import SearchSettings
+from onyx.document_index.chunk_content_enrichment import cleanup_content_for_chunks
+from onyx.document_index.chunk_content_enrichment import (
+    generate_enriched_content_for_chunk_text,
+)
+from onyx.document_index.opensearch.schema import DocumentChunk
+from onyx.document_index.opensearch.schema import DocumentChunkWithoutVectors
+from onyx.indexing.chunker import get_metadata_suffix_for_document_index
+from onyx.indexing.chunker import MAX_METADATA_PERCENTAGE
+from onyx.indexing.embedder import IndexingEmbedder
+from onyx.indexing.models import DocAwareChunk
+from onyx.indexing.models import IndexChunk
+
+if TYPE_CHECKING:
+    from onyx.llm.interfaces import LLM
+    from onyx.natural_language_processing.utils import BaseTokenizer
+
+
+class ReembedStrategy(enum.Enum):
+    # Only the embedder changed; re-embed the same enriched text (tail swapped).
+    MODEL_ONLY = "model_only"
+    # The contextual-RAG enrichment changed; rebuild the text, then re-embed.
+    AUGMENTATION = "augmentation"
+
+
+@dataclass
+class AugmentationReembedContext:
+    """Everything the AUGMENTATION path needs beyond the embedder. Built once by
+    the port copier (which holds a DB session); `re_embed_chunks` itself stays
+    DB-free. For the FUTURE-RAG-off (strip) case only `future_enable_contextual_rag`
+    is needed; the LLM/tokenizer/budgets are required only when regenerating."""
+
+    future_enable_contextual_rag: bool
+    llm: "LLM | None" = None
+    tokenizer: "BaseTokenizer | None" = None
+    chunk_token_limit: int = 0
+    contextual_rag_reserved_tokens: int = 0
+
+
+def select_reembed_strategy(
+    present_ss: SearchSettings, future_ss: SearchSettings
+) -> ReembedStrategy:
+    """AUGMENTATION when the contextual-RAG *enrichment* differs (the embedded
+    text changes), otherwise MODEL_ONLY. A change in
+    `contextual_rag_model_configuration_id` only matters when contextual RAG is
+    on in present or future — if it is off in both, no enrichment exists in
+    either index, so a stale model-id difference must not force AUGMENTATION.
+    Model/prefix/normalize/dimension and multipass changes only alter the vectors
+    (or large/mini chunks the port doesn't read), so they fall through to
+    MODEL_ONLY."""
+    rag_relevant = present_ss.enable_contextual_rag or future_ss.enable_contextual_rag
+    augmentation_changed = (
+        present_ss.enable_contextual_rag != future_ss.enable_contextual_rag
+        or (
+            rag_relevant
+            and present_ss.contextual_rag_model_configuration_id
+            != future_ss.contextual_rag_model_configuration_id
+        )
+    )
+    return (
+        ReembedStrategy.AUGMENTATION
+        if augmentation_changed
+        else ReembedStrategy.MODEL_ONLY
+    )
+
+
+def rebuild_semantic_tail(chunk: DocumentChunkWithoutVectors) -> str:
+    """Rebuild the *semantic* metadata suffix that was embedded, from the stored
+    `metadata_list`. Empty when the chunk has no metadata."""
+    if not chunk.metadata_list:
+        return ""
+    metadata = convert_metadata_list_of_strings_to_dict(chunk.metadata_list)
+    semantic_suffix, _ = get_metadata_suffix_for_document_index(
+        metadata, include_separator=True
+    )
+    return semantic_suffix
+
+
+def _semantic_tail_was_embedded(
+    semantic_tail: str, max_chunk_size: int, present_tokenizer: BaseTokenizer
+) -> bool:
+    """Whether indexing embedded the semantic tail. The chunker drops it from the
+    embedding when it exceeds MAX_METADATA_PERCENTAGE of the chunk budget, yet still
+    stores the keyword tail on `content` — so recovery must reproduce the skip or it
+    re-embeds metadata the vector never saw. Both inputs must be PRESENT-side to
+    match the index-time decision: `max_chunk_size` is the stored PRESENT budget and
+    `present_tokenizer` is the PRESENT model's — the FUTURE model's can count the
+    tail differently and flip the threshold."""
+    if not semantic_tail:
+        return False
+    metadata_tokens = len(present_tokenizer.encode(semantic_tail))
+    return metadata_tokens < max_chunk_size * MAX_METADATA_PERCENTAGE
+
+
+def recover_embedding_input(
+    chunk: DocumentChunkWithoutVectors, present_tokenizer: BaseTokenizer
+) -> str:
+    """Rebuild the text that was actually embedded when this chunk was indexed.
+
+    Stored `content` ends in the metadata's keyword form ("Jane Doe"); the embedding
+    used the labeled form ("Metadata: author - Jane Doe"). So swap the keyword tail
+    (`metadata_suffix`) for the labeled form rebuilt from `metadata_list` — but only
+    when indexing embedded it: the chunker skips an oversized labeled tail while
+    still storing the keyword one, so re-appending it would drift the vector (see
+    `_semantic_tail_was_embedded`). No stored metadata -> return `content` as-is.
+
+    `present_tokenizer` must be the PRESENT model's (what indexing used); the FUTURE
+    embedder's would defeat the skip check on a model change.
+
+    Residual: a second chunker branch (title + metadata nearly filling the budget)
+    also drops the labeled tail but isn't reconstructible here without the PRESENT
+    search settings, so that rare case is left uncorrected.
+    """
+    keyword_metadata = chunk.metadata_suffix or ""
+    if not keyword_metadata:
+        return chunk.content
+    without_metadata = chunk.content.removesuffix(keyword_metadata)
+    # If nothing was removed, content didn't end with the stored metadata, so
+    # return it unchanged rather than appending a second metadata block.
+    if without_metadata == chunk.content:
+        return chunk.content
+    semantic_tail = rebuild_semantic_tail(chunk)
+    if not _semantic_tail_was_embedded(
+        semantic_tail, chunk.max_chunk_size, present_tokenizer
+    ):
+        return without_metadata
+    return without_metadata + semantic_tail
+
+
+def _title_prefix(chunk: DocumentChunkWithoutVectors) -> str:
+    """The title prefix the chunker prepends to content (`extract_blurb(title) +
+    RETURN_SEPARATOR`). Approximated with the full stored title; for very long
+    titles the chunker truncates to BLURB_SIZE tokens, so the rebuilt prefix can
+    be marginally longer — accepted imprecision (the title is also encoded
+    separately as `title_vector`)."""
+    return f"{chunk.title}{RETURN_SEPARATOR}" if chunk.title else ""
+
+
+def _stored_chunk_to_doc_aware(
+    chunk: DocumentChunkWithoutVectors, embed_input: str
+) -> DocAwareChunk:
+    """Minimal DocAwareChunk that drives DefaultIndexingEmbedder unchanged.
+
+    The whole embedding input goes in `content` with every enrichment field
+    empty, so generate_enriched_content_for_chunk_embedding reproduces exactly
+    `embed_input`. The source_document only needs `id` + title for the embedder
+    (`.id`, `.get_title_for_document_index()`)."""
+    source_document = Document(
+        id=chunk.document_id,
+        source=DocumentSource(chunk.source_type),
+        semantic_identifier=chunk.semantic_identifier,
+        # A stored title of None means the source title was empty, which at index
+        # time produced NO title embedding. Pass "" (not None) so
+        # get_title_for_document_index returns None and reproduces that; passing
+        # None would wrongly fall back to semantic_identifier and add a title vector.
+        title=chunk.title if chunk.title is not None else "",
+        sections=[],
+        metadata={},
+    )
+    return DocAwareChunk(
+        chunk_id=chunk.chunk_index,
+        blurb=chunk.blurb,
+        content=embed_input,
+        source_links=None,
+        image_file_id=None,
+        section_continuation=False,
+        source_document=source_document,
+        title_prefix="",
+        metadata_suffix_semantic="",
+        metadata_suffix_keyword="",
+        contextual_rag_reserved_tokens=0,
+        doc_summary="",
+        chunk_context="",
+        mini_chunk_texts=None,
+        large_chunk_id=None,
+        large_chunk_reference_ids=[],
+    )
+
+
+def _match_embeddings_by_identity(
+    stored_chunks: list[DocumentChunkWithoutVectors],
+    embedded: list[IndexChunk],
+) -> list[IndexChunk]:
+    """Reorder `embedded` to line up with `stored_chunks` by identity
+    (document_id, chunk_index), NOT list position — embed_chunks may return chunks
+    in a different order, and pairing by position would bind a chunk's id to another
+    chunk's vector (a reorder the count check can't catch). Identity is unique per
+    call: only regular chunks are ported."""
+    if len(embedded) != len(stored_chunks):
+        raise RuntimeError(
+            f"Embedder returned {len(embedded)} chunks for {len(stored_chunks)} inputs."
+        )
+    by_identity = {(ic.source_document.id, ic.chunk_id): ic for ic in embedded}
+    if len(by_identity) != len(embedded):
+        raise RuntimeError(
+            "Duplicate (document_id, chunk_index) identities among re-embedded "
+            "chunks; cannot pair vectors to stored chunks unambiguously."
+        )
+    matched: list[IndexChunk] = []
+    for stored in stored_chunks:
+        ic = by_identity.get((stored.document_id, stored.chunk_index))
+        if ic is None:
+            raise RuntimeError(
+                f"Embedder returned no chunk for "
+                f"{stored.document_id}#{stored.chunk_index}"
+            )
+        matched.append(ic)
+    return matched
+
+
+def re_embed_chunks(
+    stored_chunks: list[DocumentChunkWithoutVectors],
+    strategy: ReembedStrategy,
+    embedder: IndexingEmbedder,
+    augmentation_ctx: AugmentationReembedContext | None = None,
+    present_tokenizer: BaseTokenizer | None = None,
+) -> list[DocumentChunk]:
+    """Re-embed stored chunks under a prebuilt strategy + embedder (no DB access).
+
+    Returns DocumentChunks ready to write to the FUTURE index. For MODEL_ONLY only
+    `content_vector`/`title_vector` change; every other field is copied through.
+    For AUGMENTATION the stored `content`, `doc_summary` and `chunk_context` are
+    also rebuilt under FUTURE settings (`augmentation_ctx` is required, and for
+    FUTURE-RAG-on must carry the contextual LLM). Chunks may span documents, but
+    each document's chunks must ALL be in the same call — the doc-text
+    reconstruction needs the document complete.
+
+    `present_tokenizer` (required for MODEL_ONLY) is the PRESENT embedding model's
+    tokenizer — the one indexing used — needed to reproduce the metadata-tail skip
+    exactly. The FUTURE embedder's tokenizer must NOT be substituted: on a model
+    change it can count the tail differently and flip the threshold, re-embedding
+    text the PRESENT index never did.
+    """
+    if not stored_chunks:
+        return []
+    if strategy is ReembedStrategy.AUGMENTATION:
+        if augmentation_ctx is None:
+            raise ValueError(
+                "AUGMENTATION re-embed requires an AugmentationReembedContext"
+            )
+        return _augmentation_reembed(stored_chunks, embedder, augmentation_ctx)
+
+    if present_tokenizer is None:
+        raise ValueError("MODEL_ONLY re-embed requires the PRESENT tokenizer")
+    embed_inputs = [
+        recover_embedding_input(chunk, present_tokenizer) for chunk in stored_chunks
+    ]
+    doc_aware_chunks = [
+        _stored_chunk_to_doc_aware(chunk, embed_input)
+        for chunk, embed_input in zip(stored_chunks, embed_inputs)
+    ]
+    embedded = embedder.embed_chunks(doc_aware_chunks)
+    # Pair each stored chunk with its OWN vector by identity, not list position.
+    matched = _match_embeddings_by_identity(stored_chunks, embedded)
+    # Whole stored chunk + the two new vectors; everything else copied through.
+    return [
+        DocumentChunk(
+            **dict(stored),
+            content_vector=index_chunk.embeddings.full_embedding,
+            title_vector=index_chunk.title_embedding,
+        )
+        for stored, index_chunk in zip(stored_chunks, matched)
+    ]
+
+
+def _bare_contents(stored_chunks: list[DocumentChunkWithoutVectors]) -> list[str]:
+    """Strip every stored chunk back to its original (un-augmented) text via the
+    canonical inverse of the indexing-time enrichment."""
+    # Lazy import: opensearch_document_index is a heavy module and only needed on
+    # the AUGMENTATION path; keeps port_reembed's import surface light + cycle-free.
+    from onyx.document_index.opensearch.opensearch_document_index import (
+        convert_retrieved_opensearch_chunk_to_inference_chunk_uncleaned,
+    )
+
+    uncleaned = [
+        convert_retrieved_opensearch_chunk_to_inference_chunk_uncleaned(chunk, None, {})
+        for chunk in stored_chunks
+    ]
+    cleaned = cleanup_content_for_chunks(uncleaned)
+    return [chunk.content for chunk in cleaned]
+
+
+def _reconstruct_source_document(
+    stored_chunks: list[DocumentChunkWithoutVectors], bare_contents: list[str]
+) -> Document:
+    """Rebuild a minimal Document whose get_text_content() returns the document
+    text reconstructed from its bare chunks (chunk-index order). Used by the
+    contextual LLM to regenerate summaries — see the module docstring on the
+    accepted imprecision of concatenating overlapping chunks."""
+    ordered = sorted(
+        zip(stored_chunks, bare_contents), key=lambda pair: pair[0].chunk_index
+    )
+    doc_text = " ".join(bare for _, bare in ordered if bare)
+    first = stored_chunks[0]
+    return Document(
+        id=first.document_id,
+        source=DocumentSource(first.source_type),
+        semantic_identifier=first.semantic_identifier,
+        title=first.title if first.title is not None else "",
+        sections=[TextSection(text=doc_text)],
+        metadata={},
+    )
+
+
+def _augmentation_reembed(
+    stored_chunks: list[DocumentChunkWithoutVectors],
+    embedder: IndexingEmbedder,
+    ctx: AugmentationReembedContext,
+) -> list[DocumentChunk]:
+    bare_contents = _bare_contents(stored_chunks)
+    future_rag_on = ctx.future_enable_contextual_rag
+    reserved = ctx.contextual_rag_reserved_tokens if future_rag_on else 0
+
+    # One reconstructed Document per document_id — the input may span documents,
+    # and each chunk's enrichment must see only its own document's text.
+    pairs_by_doc: dict[str, list[tuple[DocumentChunkWithoutVectors, str]]] = (
+        defaultdict(list)
+    )
+    for chunk, bare in zip(stored_chunks, bare_contents):
+        pairs_by_doc[chunk.document_id].append((chunk, bare))
+    source_documents = {
+        doc_id: _reconstruct_source_document(
+            [chunk for chunk, _ in pairs], [bare for _, bare in pairs]
+        )
+        for doc_id, pairs in pairs_by_doc.items()
+    }
+
+    # Rebuild each chunk from its bare content under FUTURE enrichment settings.
+    # title_prefix + metadata are unchanged by a RAG toggle, so they are restored;
+    # doc_summary/chunk_context start empty and are filled below when RAG is on.
+    doc_aware_chunks = [
+        DocAwareChunk(
+            chunk_id=chunk.chunk_index,
+            blurb=chunk.blurb,
+            content=bare,
+            source_links=None,
+            image_file_id=None,
+            section_continuation=False,
+            source_document=source_documents[chunk.document_id],
+            title_prefix=_title_prefix(chunk),
+            metadata_suffix_semantic=rebuild_semantic_tail(chunk),
+            metadata_suffix_keyword=chunk.metadata_suffix or "",
+            contextual_rag_reserved_tokens=reserved,
+            doc_summary="",
+            chunk_context="",
+            mini_chunk_texts=None,
+            large_chunk_id=None,
+            large_chunk_reference_ids=[],
+        )
+        for chunk, bare in zip(stored_chunks, bare_contents)
+    ]
+
+    if future_rag_on:
+        if ctx.llm is None or ctx.tokenizer is None:
+            raise ValueError(
+                "contextual-RAG-on re-embed requires an LLM + tokenizer in the context"
+            )
+        # Lazy import to avoid an import cycle with the indexing pipeline.
+        from onyx.indexing.indexing_pipeline import add_contextual_summaries
+
+        # Groups by source_document.id internally, so the mixed-doc input is fine.
+        add_contextual_summaries(
+            chunks=doc_aware_chunks,
+            llm=ctx.llm,
+            tokenizer=ctx.tokenizer,
+            chunk_token_limit=ctx.chunk_token_limit,
+        )
+
+    embedded = embedder.embed_chunks(doc_aware_chunks)
+    # Pair each stored chunk with its OWN vector by identity, not list position.
+    matched = _match_embeddings_by_identity(stored_chunks, embedded)
+
+    results: list[DocumentChunk] = []
+    for stored, doc_aware, index_chunk in zip(stored_chunks, doc_aware_chunks, matched):
+        fields = dict(stored)
+        # The stored (BM25) content, rebuilt under FUTURE enrichment.
+        fields["content"] = generate_enriched_content_for_chunk_text(doc_aware)
+        fields["doc_summary"] = doc_aware.doc_summary
+        fields["chunk_context"] = doc_aware.chunk_context
+        results.append(
+            DocumentChunk(
+                **fields,
+                content_vector=index_chunk.embeddings.full_embedding,
+                title_vector=index_chunk.title_embedding,
+            )
+        )
+    return results

--- a/backend/onyx/llm/factory.py
+++ b/backend/onyx/llm/factory.py
@@ -8,6 +8,7 @@ from onyx.configs.model_configs import GEN_AI_TEMPERATURE
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import LLMModelFlowType
 from onyx.db.llm import can_user_access_llm_provider
+from onyx.db.llm import fetch_default_contextual_rag_model
 from onyx.db.llm import fetch_default_llm_model
 from onyx.db.llm import fetch_default_vision_model
 from onyx.db.llm import fetch_existing_llm_provider
@@ -16,6 +17,7 @@ from onyx.db.llm import fetch_model_configuration_by_id
 from onyx.db.llm import fetch_user_group_ids
 from onyx.db.models import LLMProvider as LLMProviderModel
 from onyx.db.models import Persona
+from onyx.db.models import SearchSettings
 from onyx.db.models import User
 from onyx.llm.constants import LlmProviderNames
 from onyx.llm.interfaces import LLM
@@ -345,6 +347,19 @@ def get_llm_for_contextual_rag(model_configuration_id: int) -> LLM:
             model_name=mc.name,
             llm_provider=LLMProviderView.from_model(mc.llm_provider),
         )
+
+
+def get_contextual_rag_llm_for_search_settings(
+    search_settings: SearchSettings,
+) -> LLM | None:
+    """Resolve the contextual-RAG LLM for the given search settings: the explicit
+    model configuration if set, else the tenant default; None when neither exists."""
+    mc_id = search_settings.contextual_rag_model_configuration_id
+    if mc_id is None:
+        with get_session_with_current_tenant() as db_session:
+            mc = fetch_default_contextual_rag_model(db_session)
+        mc_id = mc.id if mc else None
+    return get_llm_for_contextual_rag(mc_id) if mc_id is not None else None
 
 
 def get_default_llm(

--- a/backend/onyx/server/manage/search_settings.py
+++ b/backend/onyx/server/manage/search_settings.py
@@ -9,14 +9,20 @@ from onyx.configs.app_configs import DISABLE_INDEX_UPDATE_ON_SWAP
 from onyx.context.search.models import SavedSearchSettings
 from onyx.context.search.models import SearchSettingsCreationRequest
 from onyx.db.connector_credential_pair import get_connector_credential_pairs
+from onyx.db.connector_credential_pair import get_last_successful_attempt_poll_range_end
 from onyx.db.connector_credential_pair import resync_cc_pair
 from onyx.db.engine.sql_engine import get_session
+from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.enums import Permission
+from onyx.db.enums import SwitchoverType
+from onyx.db.index_attempt import create_synthetic_seed_attempt
 from onyx.db.index_attempt import expire_index_attempts
+from onyx.db.llm import fetch_default_contextual_rag_model
 from onyx.db.llm import update_default_contextual_model
 from onyx.db.llm import update_no_default_contextual_rag_provider
 from onyx.db.models import IndexModelStatus
 from onyx.db.models import User
+from onyx.db.port_attempt import cancel_active_port_attempts
 from onyx.db.search_settings import create_search_settings
 from onyx.db.search_settings import delete_search_settings
 from onyx.db.search_settings import get_current_search_settings
@@ -79,6 +85,7 @@ def set_new_search_settings(
     validate_contextual_rag_model(
         model_configuration_id=search_settings_new.contextual_rag_model_configuration_id,
         db_session=db_session,
+        enable_contextual_rag=search_settings_new.enable_contextual_rag,
     )
 
     search_settings = get_current_search_settings(db_session)
@@ -114,8 +121,23 @@ def set_new_search_settings(
             db_session=db_session,
         )
 
+        # Cancel in-flight reindex ports for the superseded FUTURE. After the PAST
+        # flip so check_for_port (which only targets the current secondary) won't
+        # enqueue a replacement; the running port task stops at its next batch
+        # boundary once it sees CANCELED.
+        cancel_active_port_attempts(
+            db_session, search_settings_id=secondary_search_settings.id
+        )
+
+    # Every new FUTURE reindexes via the port flow (re-embed PRESENT -> FUTURE in
+    # place, no connector re-fetch). commit=False here and below so the FUTURE and
+    # its seeds commit together: a FUTURE visible before its seeds makes workers
+    # re-scan from scratch instead of resuming from PRESENT's poll cursor.
     new_search_settings = create_search_settings(
-        search_settings=new_search_settings_request, db_session=db_session
+        search_settings=new_search_settings_request,
+        db_session=db_session,
+        use_port_flow=True,
+        commit=False,
     )
 
     # Ensure the document indices have the new index immediately.
@@ -131,15 +153,42 @@ def set_new_search_settings(
     # Pause index attempts for the currently in-use index to preserve resources.
     if DISABLE_INDEX_UPDATE_ON_SWAP:
         expire_index_attempts(
-            search_settings_id=search_settings.id, db_session=db_session
+            search_settings_id=search_settings.id,
+            db_session=db_session,
+            commit=False,
         )
         for cc_pair in get_connector_credential_pairs(db_session):
             resync_cc_pair(
                 cc_pair=cc_pair,
                 search_settings_id=new_search_settings.id,
                 db_session=db_session,
+                commit=False,
             )
 
+    # Seed the poll cursor: a synthetic SUCCESS IndexAttempt per in-scope cc_pair
+    # carrying PRESENT's cursor, so the promoted settings resume instead of re-scanning
+    # full history. INSTANT needs it too — it promotes immediately, so no seed means a
+    # full re-fetch. Scope mirrors the swap: ACTIVE_ONLY = active cc_pairs, else all non-deleting.
+    if new_search_settings.use_port_flow:
+        active_only = new_search_settings.switchover_type == SwitchoverType.ACTIVE_ONLY
+        for cc_pair in get_connector_credential_pairs(db_session):
+            if active_only and not cc_pair.status.is_active():
+                continue
+            if cc_pair.status == ConnectorCredentialPairStatus.DELETING:
+                continue
+            indexing_start = cc_pair.connector.indexing_start
+            earliest_index = indexing_start.timestamp() if indexing_start else 0.0
+            poll_range_end = get_last_successful_attempt_poll_range_end(
+                cc_pair.id, earliest_index, search_settings, db_session
+            )
+            create_synthetic_seed_attempt(
+                connector_credential_pair_id=cc_pair.id,
+                search_settings_id=new_search_settings.id,
+                poll_range_end=poll_range_end,
+                db_session=db_session,
+            )
+
+    # Atomic: FUTURE row and its seeds become visible together.
     db_session.commit()
     return IdReturn(id=new_search_settings.id)
 
@@ -160,6 +209,12 @@ def cancel_new_embedding(
             search_settings=secondary_search_settings,
             new_status=IndexModelStatus.PAST,
             db_session=db_session,
+        )
+
+        # Stop any in-flight reindex port for the canceled FUTURE; the running
+        # task stops at its next batch boundary once it sees CANCELED.
+        cancel_active_port_attempts(
+            db_session, search_settings_id=secondary_search_settings.id
         )
 
         # remove the old index from the vector db
@@ -243,6 +298,7 @@ def update_saved_search_settings(
     validate_contextual_rag_model(
         model_configuration_id=search_settings.contextual_rag_model_configuration_id,
         db_session=db_session,
+        enable_contextual_rag=search_settings.enable_contextual_rag,
     )
 
     update_current_search_settings(
@@ -283,8 +339,18 @@ def delete_unstructured_api_key_endpoint(
 def validate_contextual_rag_model(
     model_configuration_id: int | None,
     db_session: Session,
+    enable_contextual_rag: bool = False,
 ) -> None:
     if model_configuration_id is None:
+        if (
+            enable_contextual_rag
+            and fetch_default_contextual_rag_model(db_session) is None
+        ):
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                "Contextual Retrieval is enabled but no Contextual Retrieval "
+                "model is configured, and no tenant default exists.",
+            )
         return
     from onyx.db.models import ModelConfiguration
 

--- a/backend/onyx/server/onyx_api/ingestion.py
+++ b/backend/onyx/server/onyx_api/ingestion.py
@@ -162,6 +162,9 @@ def upsert_ingestion_doc(
             embedder=new_index_embedding_model,
             document_indices=sec_document_indices,
             ignore_time_skip=True,
+            # FUTURE write: skip content_hash dedup, else the primary run's hash
+            # suppresses this into a no-op.
+            index_to_secondary=True,
             db_session=db_session,
             tenant_id=tenant_id,
             document_batch=[document],

--- a/backend/scripts/dev_run_background_jobs.py
+++ b/backend/scripts/dev_run_background_jobs.py
@@ -41,7 +41,7 @@ def run_jobs() -> None:
         "--loglevel=INFO",
         "--hostname=light@%n",
         "-Q",
-        "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration",
+        "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration,port",
     ]
 
     cmd_worker_docprocessing = [

--- a/backend/shared_configs/configs.py
+++ b/backend/shared_configs/configs.py
@@ -129,6 +129,8 @@ PRESERVED_SEARCH_FIELDS = [
     "normalize",
     "passage_prefix",
     "query_prefix",
+    # Immutable per settings id; server-controlled, never set via update.
+    "use_port_flow",
 ]
 
 

--- a/backend/supervisord.conf
+++ b/backend/supervisord.conf
@@ -44,7 +44,7 @@ stopasgroup=true
 [program:celery_worker_light]
 command=celery -A onyx.background.celery.versioned_apps.light worker
     --hostname=light@%%n
-    -Q vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration
+    -Q vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration,port
 stdout_logfile=/var/log/celery_worker_light.log
 stdout_logfile_maxbytes=16MB
 redirect_stderr=true

--- a/backend/tests/external_dependency_unit/celery/test_document_sync_revoke_cleanup.py
+++ b/backend/tests/external_dependency_unit/celery/test_document_sync_revoke_cleanup.py
@@ -1,0 +1,79 @@
+"""Doc-sync taskset cleanup on task revoke/expire (uses real Redis).
+
+Regression: an expired doc-sync task fires `task_revoked`, not `task_postrun`, so its
+id must be removed from the taskset by `app_base.on_task_revoked`. Otherwise the taskset
+never empties, `monitor_document_sync_taskset` never resets the fence, and new doc-sync
+generation is blocked until the 7-day fence TTL.
+"""
+
+from collections.abc import Generator
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from onyx.background.celery.apps.app_base import on_task_revoked
+from onyx.background.celery.tasks.vespa.document_sync import DOCUMENT_SYNC_PREFIX
+from onyx.background.celery.tasks.vespa.document_sync import DOCUMENT_SYNC_TASKSET_KEY
+from onyx.background.celery.tasks.vespa.document_sync import get_document_sync_remaining
+from onyx.background.celery.tasks.vespa.document_sync import is_document_sync_fenced
+from onyx.background.celery.tasks.vespa.document_sync import reset_document_sync
+from onyx.background.celery.tasks.vespa.document_sync import set_document_sync_fence
+from onyx.background.celery.tasks.vespa.tasks import monitor_document_sync_taskset
+from onyx.redis.redis_pool import get_redis_client
+from onyx.redis.tenant_redis_client import TenantRedisClient
+from tests.external_dependency_unit.constants import TEST_TENANT_ID
+
+
+def _revoke_request(task_id: str, tenant_id: str = TEST_TENANT_ID) -> SimpleNamespace:
+    """Mimic the celery Context the task_revoked signal delivers (has id + kwargs)."""
+    return SimpleNamespace(id=task_id, kwargs={"tenant_id": tenant_id})
+
+
+@pytest.fixture
+def redis_client(
+    tenant_context: None,  # noqa: ARG001
+) -> Generator[TenantRedisClient, None, None]:
+    r = get_redis_client(tenant_id=TEST_TENANT_ID)
+    reset_document_sync(r)
+    try:
+        yield r
+    finally:
+        reset_document_sync(r)
+
+
+def test_revoked_doc_sync_task_drains_taskset(redis_client: TenantRedisClient) -> None:
+    task_id = f"{DOCUMENT_SYNC_PREFIX}_{uuid4()}"
+    redis_client.sadd(DOCUMENT_SYNC_TASKSET_KEY, task_id)
+    assert get_document_sync_remaining(redis_client) == 1
+
+    on_task_revoked(request=_revoke_request(task_id))
+
+    assert get_document_sync_remaining(redis_client) == 0
+
+
+def test_revoked_non_doc_sync_task_ignored(redis_client: TenantRedisClient) -> None:
+    doc_sync_id = f"{DOCUMENT_SYNC_PREFIX}_{uuid4()}"
+    redis_client.sadd(DOCUMENT_SYNC_TASKSET_KEY, doc_sync_id)
+
+    on_task_revoked(request=_revoke_request(f"connectordeletion_{uuid4()}"))
+
+    # an unrelated revoke must not touch the doc-sync taskset
+    assert get_document_sync_remaining(redis_client) == 1
+
+
+def test_revoke_unwedges_fence_end_to_end(redis_client: TenantRedisClient) -> None:
+    """The stranded id is what holds the fence up; draining it lets the monitor reset."""
+    task_id = f"{DOCUMENT_SYNC_PREFIX}_{uuid4()}"
+    redis_client.sadd(DOCUMENT_SYNC_TASKSET_KEY, task_id)
+    set_document_sync_fence(redis_client, 1)
+    assert is_document_sync_fenced(redis_client)
+
+    # stranded id present -> monitor cannot reset the fence
+    monitor_document_sync_taskset(redis_client)
+    assert is_document_sync_fenced(redis_client)
+
+    # revoke drains the id -> monitor now resets, unblocking new generation
+    on_task_revoked(request=_revoke_request(task_id))
+    monitor_document_sync_taskset(redis_client)
+    assert not is_document_sync_fenced(redis_client)

--- a/backend/tests/external_dependency_unit/db/test_port_flow_e2e.py
+++ b/backend/tests/external_dependency_unit/db/test_port_flow_e2e.py
@@ -1,0 +1,378 @@
+"""End-to-end composition test for the reindex port flow (MODEL_ONLY strategy).
+
+Proves the layers COMPOSE with NO PortCopier mocking: check_for_port kickoff ->
+run_port_attempt (real PIT scan of PRESENT + real re-embed under the FUTURE model
+via the local model server + create-only write to FUTURE) -> the port-aware
+swap promotion. Asserts the FUTURE chunks carry the seeded content with a freshly
+re-embedded 768-dim vector (different from the seeded placeholder), and that the
+swap flips our FUTURE row to PRESENT and the present-like row to PAST.
+
+Uses real Postgres + Redis + OpenSearch + the indexing model server.
+Restores the dev DB's real current
+SearchSettings row in teardown (this dev DB has a leftover PRESENT row + a stale
+FUTURE row, so we never rely on the live current/secondary settings being ours).
+"""
+
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from unittest.mock import MagicMock
+from unittest.mock import patch
+from uuid import uuid4
+
+from sqlalchemy.orm import Session
+
+from onyx.access.models import DocumentAccess
+from onyx.background.celery.tasks.port import tasks as port_task
+from onyx.background.celery.tasks.port.tasks import run_check_for_port
+from onyx.background.celery.tasks.port.tasks import run_port_attempt
+from onyx.configs.constants import DocumentSource
+from onyx.configs.model_configs import ASYM_PASSAGE_PREFIX
+from onyx.configs.model_configs import ASYM_QUERY_PREFIX
+from onyx.context.search.models import SavedSearchSettings
+from onyx.db import swap_index
+from onyx.db.enums import EmbeddingPrecision
+from onyx.db.enums import IndexingStatus
+from onyx.db.enums import IndexModelStatus
+from onyx.db.enums import PortAttemptStatus
+from onyx.db.enums import SwitchoverType
+from onyx.db.models import ConnectorCredentialPair
+from onyx.db.models import IndexAttempt
+from onyx.db.models import PortAttempt
+from onyx.db.models import SearchSettings
+from onyx.db.port_attempt import get_port_attempt
+from onyx.db.search_settings import create_search_settings
+from onyx.db.search_settings import get_current_search_settings
+from onyx.document_index.interfaces_new import TenantState
+from onyx.document_index.opensearch.client import OpenSearchIndexClient
+from onyx.document_index.opensearch.constants import DEFAULT_MAX_CHUNK_SIZE
+from onyx.document_index.opensearch.opensearch_document_index import (
+    generate_opensearch_filtered_access_control_list,
+)
+from onyx.document_index.opensearch.schema import DocumentChunk
+from onyx.document_index.opensearch.schema import DocumentSchema
+from onyx.document_index.opensearch.schema import get_opensearch_doc_chunk_id
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
+from shared_configs.contextvars import get_current_tenant_id
+from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair
+from tests.external_dependency_unit.indexing_helpers import make_cc_pair
+from tests.external_dependency_unit.indexing_helpers import seed_cc_pair_documents
+
+_VECTOR_DIM = 768
+_CHUNKS_PER_DOC = 2
+_NUM_DOCS = 4
+# A constant placeholder vector seeded into PRESENT; the port re-embeds, so the
+# FUTURE vector must differ from this to prove a real embed happened.
+_PLACEHOLDER_VECTOR = [0.123] * _VECTOR_DIM
+# Real sentences so the local embedder produces meaningful, non-degenerate vectors.
+_CHUNK_SENTENCES = [
+    "The migration ports stored chunks from the present index to the future one.",
+    "Each chunk is re-embedded under the new model before it is written.",
+    "External versioning ensures the newest source write wins on a conflict.",
+    "The swap promotes the future settings once every required port succeeds.",
+    "Documents reach the future index only through the reindex port flow.",
+    "A point-in-time scan reads the present chunks without their vectors.",
+    "The embedder runs against the local model server during the port.",
+    "Cursor commits make a crashed or stalled port resume rather than restart.",
+]
+
+
+def _make_chunk(
+    document_id: str,
+    chunk_index: int,
+    content: str,
+    tenant_state: TenantState,
+    last_updated: datetime,
+) -> DocumentChunk:
+    """Minimal PRESENT chunk seeded for the port to scan + re-embed. content is a
+    real sentence; content_vector is the placeholder the port must overwrite."""
+    access = DocumentAccess.build(
+        user_emails=[],
+        user_groups=[],
+        external_user_emails=[],
+        external_user_group_ids=[],
+        is_public=True,
+    )
+    return DocumentChunk(
+        document_id=document_id,
+        chunk_index=chunk_index,
+        title=None,
+        title_vector=None,
+        content=content,
+        content_vector=list(_PLACEHOLDER_VECTOR),
+        source_type=DocumentSource.FILE.value,
+        metadata_list=None,
+        last_updated=last_updated,
+        public=access.is_public,
+        access_control_list=generate_opensearch_filtered_access_control_list(access),
+        hidden=False,
+        global_boost=0,
+        semantic_identifier=f"semantic-{document_id}",
+        image_file_id=None,
+        source_links=None,
+        blurb="blurb",
+        doc_summary="",
+        chunk_context="",
+        document_sets=None,
+        user_projects=None,
+        primary_owners=None,
+        secondary_owners=None,
+        tenant_id=tenant_state,
+    )
+
+
+def _make_saved_settings(
+    *,
+    index_name: str,
+    use_port_flow: bool,
+    switchover_type: SwitchoverType,
+) -> SavedSearchSettings:
+    """nomic MODEL_ONLY settings (contextual RAG off, provider None -> local
+    model server)."""
+    return SavedSearchSettings(
+        model_name="nomic-ai/nomic-embed-text-v1",
+        model_dim=_VECTOR_DIM,
+        normalize=True,
+        query_prefix=ASYM_QUERY_PREFIX,
+        passage_prefix=ASYM_PASSAGE_PREFIX,
+        provider_type=None,
+        index_name=index_name,
+        multipass_indexing=False,
+        embedding_precision=EmbeddingPrecision.FLOAT,
+        reduced_dimension=None,
+        enable_contextual_rag=False,
+        contextual_rag_llm_name=None,
+        contextual_rag_llm_provider=None,
+        switchover_type=switchover_type,
+        use_port_flow=use_port_flow,
+    )
+
+
+def _create_os_index(index_name: str) -> OpenSearchIndexClient:
+    client = OpenSearchIndexClient(index_name=index_name)
+    mappings = DocumentSchema.get_document_schema(
+        vector_dimension=_VECTOR_DIM, multitenant=False
+    )
+    settings = DocumentSchema.get_index_settings_based_on_environment()
+    client.create_index(mappings=mappings, settings=settings)
+    return client
+
+
+def test_port_flow_end_to_end(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    tenant_state = TenantState(tenant_id=POSTGRES_DEFAULT_SCHEMA, multitenant=False)
+    present_index_name = f"test_e2e_present_{uuid4().hex[:8]}"
+    future_index_name = f"test_e2e_future_{uuid4().hex[:8]}"
+
+    # The dev DB's real current row — restore this in teardown.
+    original_present_id = get_current_search_settings(db_session).id
+
+    pair: ConnectorCredentialPair | None = None
+    present_like_id: int | None = None
+    future_id: int | None = None
+    present_client: OpenSearchIndexClient | None = None
+    future_client: OpenSearchIndexClient | None = None
+    promoted = False
+
+    try:
+        # --- SETUP: cc_pair + docs ---
+        pair = make_cc_pair(db_session)
+        doc_ids = seed_cc_pair_documents(
+            db_session, pair, _NUM_DOCS, prefix="e2edoc-", unique=True
+        )
+
+        # --- SETUP: SearchSettings (present-like PAST + FUTURE) ---
+        present_like = create_search_settings(
+            _make_saved_settings(
+                index_name=present_index_name,
+                use_port_flow=False,
+                switchover_type=SwitchoverType.REINDEX,
+            ),
+            db_session,
+            status=IndexModelStatus.PAST,
+        )
+        present_like_id = present_like.id
+        future = create_search_settings(
+            _make_saved_settings(
+                index_name=future_index_name,
+                use_port_flow=True,
+                switchover_type=SwitchoverType.REINDEX,
+            ),
+            db_session,
+            status=IndexModelStatus.FUTURE,
+        )
+        future_id = future.id
+
+        # --- SETUP: OpenSearch indices + seed PRESENT chunks ---
+        present_client = _create_os_index(present_index_name)
+        future_client = _create_os_index(future_index_name)
+
+        seeded_ts = datetime.now(timezone.utc).replace(microsecond=0)
+        seeded_content: dict[tuple[str, int], str] = {}
+        chunks: list[DocumentChunk] = []
+        for d_i, doc_id in enumerate(doc_ids):
+            for c_i in range(_CHUNKS_PER_DOC):
+                content = _CHUNK_SENTENCES[
+                    (d_i * _CHUNKS_PER_DOC + c_i) % len(_CHUNK_SENTENCES)
+                ]
+                seeded_content[(doc_id, c_i)] = content
+                chunks.append(
+                    _make_chunk(doc_id, c_i, content, tenant_state, seeded_ts)
+                )
+        present_client.bulk_index_documents(documents=chunks, tenant_state=tenant_state)
+        present_client.refresh_index()
+
+        # --- KICKOFF: check_for_port scoped to our FUTURE + cc_pair ---
+        celery_app = MagicMock()
+        with (
+            patch.object(
+                port_task,
+                "get_secondary_search_settings",
+                lambda db, *_, **__: db.get(SearchSettings, future_id),
+            ),
+            patch.object(
+                port_task,
+                "fetch_indexable_standard_connector_credential_pair_ids",
+                lambda *_, **__: [pair.id],
+            ),
+        ):
+            result = run_check_for_port(get_current_tenant_id(), celery_app)
+        assert result == 1
+        attempt_id = celery_app.send_task.call_args.kwargs["kwargs"]["port_attempt_id"]
+
+        # --- PORT: real PortCopier (re-embed via model server) ---
+        # get_current_search_settings is patched to our present-like row only
+        # (the dev DB's live current row has no real model / index).
+        with patch.object(
+            port_task,
+            "get_current_search_settings",
+            lambda db: db.get(SearchSettings, present_like_id),
+        ):
+            run_port_attempt(attempt_id)
+
+        # --- ASSERT PORT ---
+        db_session.expire_all()
+        attempt = get_port_attempt(db_session, attempt_id)
+        assert attempt is not None
+        assert attempt.status == PortAttemptStatus.SUCCESS
+        assert attempt.last_processed_doc_id == max(doc_ids)
+        assert attempt.docs_ported == _NUM_DOCS
+
+        future_client.refresh_index()
+        for doc_id in doc_ids:
+            for c_i in range(_CHUNKS_PER_DOC):
+                chunk_id = get_opensearch_doc_chunk_id(
+                    tenant_state=tenant_state,
+                    document_id=doc_id,
+                    chunk_index=c_i,
+                    max_chunk_size=DEFAULT_MAX_CHUNK_SIZE,
+                )
+                fetched = future_client.get_document(document_chunk_id=chunk_id)
+                assert fetched.content == seeded_content[(doc_id, c_i)]
+                assert len(fetched.content_vector) == _VECTOR_DIM
+                # The port re-embedded: the vector is NOT the seeded placeholder.
+                assert fetched.content_vector != _PLACEHOLDER_VECTOR
+
+        # --- SWAP ---
+        port_row = get_port_attempt(db_session, attempt_id)
+        assert port_row is not None and port_row.time_completed is not None
+        # A real (non-seed) FUTURE index attempt landing after the port.
+        index_started = port_row.time_completed + timedelta(seconds=1)
+        db_session.add(
+            IndexAttempt(
+                connector_credential_pair_id=pair.id,
+                search_settings_id=future_id,
+                from_beginning=False,
+                status=IndexingStatus.SUCCESS,
+                is_synthetic_seed=False,
+                time_started=index_started,
+                time_updated=index_started,
+            )
+        )
+        db_session.commit()
+
+        # check_and_perform_index_swap fetches the FUTURE row via
+        # get_secondary_search_settings (a stale FUTURE row exists in this dev
+        # DB), and get_all_document_indices would touch real Vespa/OpenSearch
+        # provisioning -> patch both in the swap_index namespace. The deferred
+        # metadata-sync backlog is 0 in this dev DB; if it weren't, the swap
+        # criterion would block, so we don't need to patch the count.
+        # _required_cc_pairs_for_switchover gates the swap on EVERY indexable
+        # cc_pair in the dev DB (via fetch_indexable...), none of which have a
+        # port for our FUTURE -> scope the required set to our cc_pair only.
+        with (
+            patch.object(
+                swap_index,
+                "get_secondary_search_settings",
+                lambda db: db.get(SearchSettings, future_id),
+            ),
+            patch.object(
+                swap_index,
+                "fetch_indexable_standard_connector_credential_pair_ids",
+                lambda *_, **__: [pair.id],
+            ),
+            patch.object(swap_index, "get_all_document_indices", return_value=[]),
+        ):
+            old_settings = swap_index.check_and_perform_index_swap(db_session)
+
+        assert old_settings is not None
+        promoted = True
+
+        # --- ASSERT SWAP ---
+        db_session.expire_all()
+        future_row = db_session.get(SearchSettings, future_id)
+        present_like_row = db_session.get(SearchSettings, present_like_id)
+        assert future_row is not None and present_like_row is not None
+        assert future_row.status == IndexModelStatus.PRESENT
+        assert present_like_row.status == IndexModelStatus.PAST
+    finally:
+        db_session.rollback()
+        # Restore the dev DB's swap state FIRST: original current -> PRESENT, our
+        # promoted row off PRESENT (so get_current_search_settings is correct
+        # again). _perform_index_swap also set original_present_id -> PAST.
+        if promoted and original_present_id is not None:
+            db_session.query(SearchSettings).filter(
+                SearchSettings.id == original_present_id
+            ).update(
+                {SearchSettings.status: IndexModelStatus.PRESENT},
+                synchronize_session="fetch",
+            )
+            if future_id is not None:
+                db_session.query(SearchSettings).filter(
+                    SearchSettings.id == future_id
+                ).update(
+                    {SearchSettings.status: IndexModelStatus.PAST},
+                    synchronize_session="fetch",
+                )
+            db_session.commit()
+
+        # PortAttempt + IndexAttempt before SearchSettings before cc_pair.
+        if pair is not None:
+            db_session.query(PortAttempt).filter(
+                PortAttempt.cc_pair_id == pair.id
+            ).delete(synchronize_session="fetch")
+            db_session.query(IndexAttempt).filter(
+                IndexAttempt.connector_credential_pair_id == pair.id
+            ).delete(synchronize_session="fetch")
+            db_session.commit()
+
+        for ss_id in (future_id, present_like_id):
+            if ss_id is not None:
+                db_session.query(SearchSettings).filter(
+                    SearchSettings.id == ss_id
+                ).delete(synchronize_session="fetch")
+        db_session.commit()
+
+        if pair is not None:
+            cleanup_cc_pair(db_session, pair)
+
+        for client in (present_client, future_client):
+            if client is not None:
+                try:
+                    client.delete_index()
+                except Exception:
+                    pass
+                finally:
+                    client.close()

--- a/backend/tests/external_dependency_unit/db/test_port_metadata_defer_e2e.py
+++ b/backend/tests/external_dependency_unit/db/test_port_metadata_defer_e2e.py
@@ -1,0 +1,566 @@
+"""End-to-end deferred-metadata-sync (permission) test for the reindex port.
+
+The existing sync-priority tests mock the document index and assert the producer's
+LOW/MEDIUM/HIGH *decision*. This test instead drives the real OpenSearch
+`OpenSearchIndexPair.update()` defer path against live indices, proving the
+correctness invariant the swap gate relies on:
+
+  D1 (inflight): a metadata/permission update on a doc PRESENT has but FUTURE does
+      not yet lands in PRESENT and is *deferred* for FUTURE -- surfaced as the typed
+      SecondaryIndexDocumentMissingError carrying exactly the missing doc id.
+  flag lifecycle: mark_document_synced_secondary_pending sets the gate flag;
+      mark_document_as_synced clears it once FUTURE catches up.
+  D4 (no stale-permission leak): after the port copies the doc into FUTURE carrying
+      the OLD access, the deferred-sync drain re-applies and FUTURE ends with the
+      NEW access -- not the stale one the port wrote.
+
+Uses real Postgres + OpenSearch. Mirrors test_port_flow_e2e's index lifecycle.
+"""
+
+from collections.abc import Generator
+from datetime import datetime
+from datetime import timezone
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.access.models import DocumentAccess
+from onyx.configs.constants import DocumentSource
+from onyx.db.document import count_secondary_only_sync_pending_documents
+from onyx.db.document import document_has_indexable_cc_pair
+from onyx.db.document import mark_document_as_synced
+from onyx.db.document import mark_document_synced_secondary_pending
+from onyx.db.enums import ConnectorCredentialPairStatus
+from onyx.db.enums import EmbeddingPrecision
+from onyx.db.models import ConnectorCredentialPair
+from onyx.db.models import Document as DbDocument
+from onyx.db.models import DocumentByConnectorCredentialPair
+from onyx.db.models import SearchSettings
+from onyx.db.port_attempt import any_future_port_in_progress
+from onyx.db.port_attempt import create_port_attempt
+from onyx.db.port_attempt import mark_port_in_progress
+from onyx.document_index.interfaces_new import MetadataUpdateRequest
+from onyx.document_index.interfaces_new import SecondaryIndexDocumentMissingError
+from onyx.document_index.interfaces_new import TenantState
+from onyx.document_index.opensearch.client import OpenSearchIndexClient
+from onyx.document_index.opensearch.opensearch_document_index import (
+    generate_opensearch_filtered_access_control_list,
+)
+from onyx.document_index.opensearch.opensearch_document_index import (
+    OpenSearchDocumentIndex,
+)
+from onyx.document_index.opensearch.opensearch_document_index import OpenSearchIndexPair
+from onyx.document_index.opensearch.schema import DocumentChunk
+from onyx.document_index.opensearch.schema import DocumentSchema
+from onyx.document_index.opensearch.schema import get_opensearch_doc_chunk_id
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
+from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair
+from tests.external_dependency_unit.indexing_helpers import make_cc_pair
+from tests.external_dependency_unit.indexing_helpers import make_future_search_settings
+
+_VECTOR_DIM = 8  # tiny: this test never re-embeds, it only updates metadata
+_CHUNKS_PER_DOC = 2
+_PLACEHOLDER_VECTOR = [0.1] * _VECTOR_DIM
+
+# Two distinct *non-public* access states so PRESENT vs FUTURE acls are
+# unambiguously comparable (a public state would collapse to an empty acl).
+_ACCESS_OLD = DocumentAccess.build(
+    user_emails=["bob@example.com"],
+    user_groups=[],
+    external_user_emails=[],
+    external_user_group_ids=[],
+    is_public=False,
+)
+_ACCESS_NEW = DocumentAccess.build(
+    user_emails=["alice@example.com"],
+    user_groups=[],
+    external_user_emails=[],
+    external_user_group_ids=[],
+    is_public=False,
+)
+_ACL_OLD = set(generate_opensearch_filtered_access_control_list(_ACCESS_OLD))
+_ACL_NEW = set(generate_opensearch_filtered_access_control_list(_ACCESS_NEW))
+
+_TENANT_STATE = TenantState(tenant_id=POSTGRES_DEFAULT_SCHEMA, multitenant=False)
+
+
+def _make_chunk(
+    document_id: str,
+    chunk_index: int,
+    access: DocumentAccess,
+    last_updated: datetime | None = None,
+    content: str | None = None,
+) -> DocumentChunk:
+    # The port re-copies the SAME stored PRESENT chunk on a batch retry, so its
+    # doc_updated_at (the external version) is identical across retries — callers
+    # exercising the retry race must pin last_updated rather than take now().
+    if last_updated is None:
+        last_updated = datetime.now(timezone.utc).replace(microsecond=0)
+    # Distinct content lets a test prove a write overwrote (vs merely merged acls).
+    if content is None:
+        content = f"chunk {chunk_index} of {document_id}"
+    return DocumentChunk(
+        document_id=document_id,
+        chunk_index=chunk_index,
+        title=None,
+        title_vector=None,
+        content=content,
+        content_vector=list(_PLACEHOLDER_VECTOR),
+        source_type=DocumentSource.FILE.value,
+        metadata_list=None,
+        last_updated=last_updated,
+        public=access.is_public,
+        access_control_list=generate_opensearch_filtered_access_control_list(access),
+        hidden=False,
+        global_boost=0,
+        semantic_identifier=f"semantic-{document_id}",
+        image_file_id=None,
+        source_links=None,
+        blurb="blurb",
+        doc_summary="",
+        chunk_context="",
+        document_sets=None,
+        user_projects=None,
+        primary_owners=None,
+        secondary_owners=None,
+        tenant_id=_TENANT_STATE,
+    )
+
+
+def _create_os_index(index_name: str) -> OpenSearchIndexClient:
+    client = OpenSearchIndexClient(index_name=index_name)
+    client.create_index(
+        mappings=DocumentSchema.get_document_schema(
+            vector_dimension=_VECTOR_DIM, multitenant=False
+        ),
+        settings=DocumentSchema.get_index_settings_based_on_environment(),
+    )
+    return client
+
+
+def _index(index_name: str) -> OpenSearchDocumentIndex:
+    return OpenSearchDocumentIndex(
+        tenant_state=_TENANT_STATE,
+        index_name=index_name,
+        embedding_dim=_VECTOR_DIM,
+        embedding_precision=EmbeddingPrecision.FLOAT,
+    )
+
+
+def _read_acl(client: OpenSearchIndexClient, doc_id: str, chunk_index: int) -> set[str]:
+    chunk_id = get_opensearch_doc_chunk_id(
+        tenant_state=_TENANT_STATE, document_id=doc_id, chunk_index=chunk_index
+    )
+    return set(client.get_document(document_chunk_id=chunk_id).access_control_list)
+
+
+def _read_content(client: OpenSearchIndexClient, doc_id: str, chunk_index: int) -> str:
+    chunk_id = get_opensearch_doc_chunk_id(
+        tenant_state=_TENANT_STATE, document_id=doc_id, chunk_index=chunk_index
+    )
+    return client.get_document(document_chunk_id=chunk_id).content
+
+
+@pytest.fixture
+def env(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> Generator[
+    tuple[
+        ConnectorCredentialPair,
+        str,
+        OpenSearchIndexClient,
+        OpenSearchIndexClient,
+        str,
+        str,
+    ],
+    None,
+    None,
+]:
+    pair = make_cc_pair(db_session)
+    doc_id = f"deferdoc-{uuid4().hex[:8]}"
+    db_session.add(DbDocument(id=doc_id, semantic_id=doc_id))
+    db_session.commit()
+
+    present_name = f"test_defer_present_{uuid4().hex[:8]}"
+    future_name = f"test_defer_future_{uuid4().hex[:8]}"
+    present_client = _create_os_index(present_name)
+    future_client = _create_os_index(future_name)
+    try:
+        yield pair, doc_id, present_client, future_client, present_name, future_name
+    finally:
+        db_session.rollback()
+        db_session.query(DbDocument).filter(DbDocument.id == doc_id).delete(
+            synchronize_session="fetch"
+        )
+        db_session.commit()
+        cleanup_cc_pair(db_session, pair)
+        for client in (present_client, future_client):
+            try:
+                client.delete_index()
+            except Exception:
+                pass
+            finally:
+                client.close()
+
+
+@pytest.fixture
+def future_port(
+    db_session: Session,
+    env: tuple[
+        ConnectorCredentialPair,
+        str,
+        OpenSearchIndexClient,
+        OpenSearchIndexClient,
+        str,
+        str,
+    ],
+) -> Generator[int, None, None]:
+    """An IN_PROGRESS PortAttempt against an isolated FUTURE SearchSettings, so the
+    interleavings below run while any_future_port_in_progress() is genuinely True --
+    i.e. a real, live port. Deleting the FUTURE settings on teardown cascades the
+    attempt (FK ondelete=CASCADE) before env tears down the cc_pair."""
+    pair = env[0]
+    future = make_future_search_settings(db_session, use_port_flow=True)
+    future_id = future.id
+    attempt = create_port_attempt(db_session, pair.id, future_id)
+    mark_port_in_progress(db_session, attempt.id)
+    try:
+        yield future_id
+    finally:
+        db_session.rollback()
+        db_session.query(SearchSettings).filter(SearchSettings.id == future_id).delete(
+            synchronize_session="fetch"
+        )
+        db_session.commit()
+
+
+def test_deferred_metadata_sync_no_stale_permission_leak(
+    db_session: Session,
+    env: tuple[
+        ConnectorCredentialPair,
+        str,
+        OpenSearchIndexClient,
+        OpenSearchIndexClient,
+        str,
+        str,
+    ],
+) -> None:
+    pair, doc_id, present_client, future_client, present_name, future_name = env
+
+    # --- PRESENT has the doc (old access); FUTURE does not yet (mid-port). ---
+    present_client.bulk_index_documents(
+        documents=[
+            _make_chunk(doc_id, c_i, _ACCESS_OLD) for c_i in range(_CHUNKS_PER_DOC)
+        ],
+        tenant_state=_TENANT_STATE,
+    )
+    present_client.refresh_index()
+
+    pair_index = OpenSearchIndexPair(
+        primary=_index(present_name),
+        secondary=_index(future_name),
+        secondary_embedding_dim=_VECTOR_DIM,
+        secondary_embedding_precision=EmbeddingPrecision.FLOAT,
+    )
+    req = MetadataUpdateRequest(
+        document_ids=[doc_id],
+        doc_id_to_chunk_cnt={doc_id: _CHUNKS_PER_DOC},
+        access=_ACCESS_NEW,
+    )
+
+    baseline_deferred = count_secondary_only_sync_pending_documents(db_session)
+
+    # --- D1: permission change. PRESENT applies; FUTURE is missing -> typed signal. ---
+    with pytest.raises(SecondaryIndexDocumentMissingError) as exc:
+        pair_index.update([req])
+    assert exc.value.document_ids == [doc_id]
+
+    # mimic the sync task's defer branch (this doc has a portable cc_pair)
+    mark_document_synced_secondary_pending(doc_id, db_session)
+
+    present_client.refresh_index()
+    assert _read_acl(present_client, doc_id, 0) == _ACL_NEW  # PRESENT got new access
+    db_session.expire_all()
+    doc = db_session.get(DbDocument, doc_id)
+    assert doc is not None and doc.secondary_only_sync_pending is True
+    assert (
+        count_secondary_only_sync_pending_documents(db_session) == baseline_deferred + 1
+    )
+
+    # --- the port copies the doc into FUTURE carrying the OLD (pre-change) access. ---
+    future_client.bulk_index_documents(
+        documents=[
+            _make_chunk(doc_id, c_i, _ACCESS_OLD) for c_i in range(_CHUNKS_PER_DOC)
+        ],
+        tenant_state=_TENANT_STATE,
+        use_create_only=True,
+    )
+    future_client.refresh_index()
+    assert _read_acl(future_client, doc_id, 0) == _ACL_OLD  # FUTURE is stale right now
+
+    # --- D4: the deferred-sync drain re-applies; both indices now carry new access. ---
+    pair_index.update([req])  # FUTURE present now -> no raise
+    mark_document_as_synced(doc_id, db_session)
+
+    future_client.refresh_index()
+    assert _read_acl(future_client, doc_id, 0) == _ACL_NEW  # no stale-permission leak
+    assert _read_acl(future_client, doc_id, 1) == _ACL_NEW
+    db_session.expire_all()
+    doc = db_session.get(DbDocument, doc_id)
+    assert doc is not None and doc.secondary_only_sync_pending is False
+    assert count_secondary_only_sync_pending_documents(db_session) == baseline_deferred
+
+
+def test_port_batch_retry_does_not_revert_a_newer_metadata_update(
+    env: tuple[
+        ConnectorCredentialPair,
+        str,
+        OpenSearchIndexClient,
+        OpenSearchIndexClient,
+        str,
+        str,
+    ],
+) -> None:
+    """The residual race: a port BATCH RETRY re-writes a chunk the port already
+    copied, AFTER a live metadata sync applied a newer access to FUTURE. Because
+    the port writes create-only, the retry hits an already-existing chunk and is
+    rejected as a benign 409 — so the newer metadata update is NOT reverted.
+
+    This exercises a *partial* metadata update followed by a port create-only
+    re-index — the interleaving the reindex port can hit when a metadata sync
+    lands between two retry attempts of the same batch.
+    """
+    _, doc_id, _present_client, future_client, _present_name, future_name = env
+    future_index = _index(future_name)
+    pinned_ts = datetime(
+        2026, 6, 1, tzinfo=timezone.utc
+    )  # chunk last_updated (create-only ignores it)
+
+    # 1. Port copies the chunk into FUTURE with OLD access (create-only).
+    future_client.bulk_index_documents(
+        documents=[_make_chunk(doc_id, 0, _ACCESS_OLD, last_updated=pinned_ts)],
+        tenant_state=_TENANT_STATE,
+        use_create_only=True,
+    )
+    future_client.refresh_index()
+    assert _read_acl(future_client, doc_id, 0) == _ACL_OLD
+
+    # 2. A live metadata sync applies NEW access (partial update, not versioned).
+    future_index.update(
+        [
+            MetadataUpdateRequest(
+                document_ids=[doc_id],
+                doc_id_to_chunk_cnt={doc_id: 1},
+                access=_ACCESS_NEW,
+            )
+        ]
+    )
+    future_client.refresh_index()
+    assert _read_acl(future_client, doc_id, 0) == _ACL_NEW
+
+    # 3. Port BATCH RETRY re-writes the SAME chunk (OLD access); the chunk already exists.
+    future_client.bulk_index_documents(
+        documents=[_make_chunk(doc_id, 0, _ACCESS_OLD, last_updated=pinned_ts)],
+        tenant_state=_TENANT_STATE,
+        use_create_only=True,
+    )
+    future_client.refresh_index()
+
+    # 4. The newer metadata update must survive — the stale retry is a benign 409.
+    assert _read_acl(future_client, doc_id, 0) == _ACL_NEW
+
+
+def test_metadata_sync_does_not_defer_non_indexable_only_doc(
+    db_session: Session,
+    env: tuple[
+        ConnectorCredentialPair,
+        str,
+        OpenSearchIndexClient,
+        OpenSearchIndexClient,
+        str,
+        str,
+    ],
+) -> None:
+    """Writer-side deadlock fix: an INVALID-only doc is genuinely missing from FUTURE
+    (real update() raises) but must NOT be deferred — its flag would never clear and
+    deadlock the swap. The task marks it synced; the gate count stays unchanged."""
+    pair, doc_id, present_client, future_client, present_name, future_name = env
+    pair.status = ConnectorCredentialPairStatus.INVALID
+    db_session.add(
+        DocumentByConnectorCredentialPair(
+            id=doc_id,
+            connector_id=pair.connector_id,
+            credential_id=pair.credential_id,
+            has_been_indexed=True,
+        )
+    )
+    db_session.commit()
+    try:
+        present_client.bulk_index_documents(
+            documents=[
+                _make_chunk(doc_id, c_i, _ACCESS_OLD) for c_i in range(_CHUNKS_PER_DOC)
+            ],
+            tenant_state=_TENANT_STATE,
+        )
+        present_client.refresh_index()
+
+        pair_index = OpenSearchIndexPair(
+            primary=_index(present_name),
+            secondary=_index(future_name),
+            secondary_embedding_dim=_VECTOR_DIM,
+            secondary_embedding_precision=EmbeddingPrecision.FLOAT,
+        )
+        req = MetadataUpdateRequest(
+            document_ids=[doc_id],
+            doc_id_to_chunk_cnt={doc_id: _CHUNKS_PER_DOC},
+            access=_ACCESS_NEW,
+        )
+        baseline = count_secondary_only_sync_pending_documents(db_session)
+
+        # FUTURE genuinely lacks the doc -> the real update still raises (D1).
+        with pytest.raises(SecondaryIndexDocumentMissingError):
+            pair_index.update([req])
+
+        # the sync task's branch: no portable owner -> mark synced, do NOT defer
+        if document_has_indexable_cc_pair(db_session, doc_id):
+            mark_document_synced_secondary_pending(doc_id, db_session)
+        else:
+            mark_document_as_synced(doc_id, db_session)
+
+        db_session.expire_all()
+        doc = db_session.get(DbDocument, doc_id)
+        assert doc is not None and doc.secondary_only_sync_pending is False
+        assert count_secondary_only_sync_pending_documents(db_session) == baseline
+    finally:
+        db_session.query(DocumentByConnectorCredentialPair).filter(
+            DocumentByConnectorCredentialPair.id == doc_id
+        ).delete(synchronize_session="fetch")
+        db_session.commit()
+
+
+def test_forward_write_wins_over_concurrent_port_copy(
+    db_session: Session,
+    env: tuple[
+        ConnectorCredentialPair,
+        str,
+        OpenSearchIndexClient,
+        OpenSearchIndexClient,
+        str,
+        str,
+    ],
+    future_port: int,  # noqa: ARG001 -- a live IN_PROGRESS port for the duration
+) -> None:
+    """Indexing a doc while a port is in flight. The port copies a STALE snapshot of
+    the doc into FUTURE first (create-only); then the connector forward-indexes the
+    SAME doc with FRESH content via a normal write (update_if_exists, internal
+    versioning). The forward write must OVERWRITE the ported chunk -- a stale backlog
+    copy can never shadow live content. The mirror ordering (forward-first, then a
+    stale port create yielding via a benign 409) lives in
+    test_opensearch_client.test_port_create_only_yields_to_forward_write.
+    """
+    _, doc_id, _present_client, future_client, _present_name, _future_name = env
+    assert any_future_port_in_progress(db_session) is True
+
+    # 1. Port copies the doc into FUTURE first: stale content + old access, create-only.
+    future_client.bulk_index_documents(
+        documents=[
+            _make_chunk(doc_id, c_i, _ACCESS_OLD, content=f"stale {c_i} of {doc_id}")
+            for c_i in range(_CHUNKS_PER_DOC)
+        ],
+        tenant_state=_TENANT_STATE,
+        use_create_only=True,
+    )
+    future_client.refresh_index()
+    assert _read_content(future_client, doc_id, 0) == f"stale 0 of {doc_id}"
+    assert _read_acl(future_client, doc_id, 0) == _ACL_OLD
+
+    # 2. Connector forward-indexes the SAME doc into FUTURE: fresh content + new
+    #    access, a normal overwrite (NOT create-only).
+    future_client.bulk_index_documents(
+        documents=[
+            _make_chunk(doc_id, c_i, _ACCESS_NEW, content=f"fresh {c_i} of {doc_id}")
+            for c_i in range(_CHUNKS_PER_DOC)
+        ],
+        tenant_state=_TENANT_STATE,
+        update_if_exists=True,
+    )
+    future_client.refresh_index()
+
+    # 3. The forward write won: FUTURE holds the fresh content + new access, not the
+    #    stale ported snapshot.
+    for c_i in range(_CHUNKS_PER_DOC):
+        assert _read_content(future_client, doc_id, c_i) == f"fresh {c_i} of {doc_id}"
+        assert _read_acl(future_client, doc_id, c_i) == _ACL_NEW
+
+
+def test_acl_update_during_port_applies_to_both_indices(
+    db_session: Session,
+    env: tuple[
+        ConnectorCredentialPair,
+        str,
+        OpenSearchIndexClient,
+        OpenSearchIndexClient,
+        str,
+        str,
+    ],
+    future_port: int,  # noqa: ARG001 -- a live IN_PROGRESS port for the duration
+) -> None:
+    """Updating a doc's permissions while a port is in flight, for a doc the port has
+    ALREADY copied into FUTURE. The pair update lands on BOTH PRESENT and FUTURE in
+    one shot -- no SecondaryIndexDocumentMissingError, so the doc is NOT (falsely)
+    deferred and the swap-gate backlog count is unchanged. The mirror case (doc still
+    MISSING from FUTURE, which defers correctly) is
+    test_deferred_metadata_sync_no_stale_permission_leak.
+    """
+    _, doc_id, present_client, future_client, present_name, future_name = env
+    assert any_future_port_in_progress(db_session) is True
+
+    # PRESENT (forward-indexed) and FUTURE (port-copied) both already hold the doc
+    # with the old access -- the port reached this doc before the permission change.
+    present_client.bulk_index_documents(
+        documents=[
+            _make_chunk(doc_id, c_i, _ACCESS_OLD) for c_i in range(_CHUNKS_PER_DOC)
+        ],
+        tenant_state=_TENANT_STATE,
+    )
+    future_client.bulk_index_documents(
+        documents=[
+            _make_chunk(doc_id, c_i, _ACCESS_OLD) for c_i in range(_CHUNKS_PER_DOC)
+        ],
+        tenant_state=_TENANT_STATE,
+        use_create_only=True,
+    )
+    present_client.refresh_index()
+    future_client.refresh_index()
+
+    pair_index = OpenSearchIndexPair(
+        primary=_index(present_name),
+        secondary=_index(future_name),
+        secondary_embedding_dim=_VECTOR_DIM,
+        secondary_embedding_precision=EmbeddingPrecision.FLOAT,
+    )
+    req = MetadataUpdateRequest(
+        document_ids=[doc_id],
+        doc_id_to_chunk_cnt={doc_id: _CHUNKS_PER_DOC},
+        access=_ACCESS_NEW,
+    )
+    baseline_deferred = count_secondary_only_sync_pending_documents(db_session)
+
+    # The permission change while the port runs: the doc exists in BOTH indices, so
+    # the pair update succeeds outright -- no defer signal is raised.
+    pair_index.update([req])
+    mark_document_as_synced(doc_id, db_session)  # the sync task's success branch
+
+    present_client.refresh_index()
+    future_client.refresh_index()
+    assert _read_acl(present_client, doc_id, 0) == _ACL_NEW
+    assert _read_acl(future_client, doc_id, 0) == _ACL_NEW
+    assert _read_acl(future_client, doc_id, 1) == _ACL_NEW
+
+    # The doc was never deferred -> the swap-gate backlog is unchanged.
+    db_session.expire_all()
+    doc = db_session.get(DbDocument, doc_id)
+    assert doc is not None and doc.secondary_only_sync_pending is False
+    assert count_secondary_only_sync_pending_documents(db_session) == baseline_deferred

--- a/backend/tests/external_dependency_unit/db/test_port_swap_criterion.py
+++ b/backend/tests/external_dependency_unit/db/test_port_swap_criterion.py
@@ -1,0 +1,391 @@
+"""External dependency unit tests for the port-aware swap criterion (T7/D8).
+
+The port-flow branch of `check_and_perform_index_swap` swaps on four conditions
+rather than the legacy successful-index count: every required cc_pair's port is
+SUCCESS, a real (non-seed) FUTURE index attempt landed after the port, nothing is
+in progress, and the deferred metadata-sync backlog has drained. The push-based
+Ingestion pair is gated on its port only (it never runs a connector index attempt).
+Mode C (INSTANT) swaps immediately; the legacy (flag-off) path is untouched.
+
+`_port_swap_ready` is tested directly with an explicit required list (isolated
+from other cc_pairs); the `check_and_perform_index_swap` cases patch
+`_perform_index_swap` so no destructive real swap runs.
+
+The two-phase-cancel tests at the bottom cover the port_attempt DB contract that
+keeps connector deletion the last writer: `request_port_cancel` leaves an IN_PROGRESS
+port active until the task acks CANCELED after its last write, cancels a NOT_STARTED
+port outright, `mark_port_in_progress` starts only NOT_STARTED (no double writer), and
+`cancel_active_port_attempts` (the swap path) uses the same two-phase rule.
+"""
+
+from collections.abc import Generator
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.configs.constants import DocumentSource
+from onyx.db import swap_index
+from onyx.db.document import mark_document_synced_secondary_pending
+from onyx.db.enums import ConnectorCredentialPairStatus
+from onyx.db.enums import PortAttemptStatus
+from onyx.db.enums import SwitchoverType
+from onyx.db.models import ConnectorCredentialPair
+from onyx.db.models import Document as DbDocument
+from onyx.db.models import PortAttempt
+from onyx.db.models import SearchSettings
+from onyx.db.port_attempt import cancel_active_port_attempts
+from onyx.db.port_attempt import create_port_attempt
+from onyx.db.port_attempt import get_active_port_attempt
+from onyx.db.port_attempt import mark_port_canceled
+from onyx.db.port_attempt import mark_port_in_progress
+from onyx.db.port_attempt import mark_port_succeeded
+from onyx.db.port_attempt import request_port_cancel
+from onyx.db.swap_index import _port_swap_ready
+from onyx.db.swap_index import _required_cc_pairs_for_switchover
+from onyx.db.swap_index import check_and_perform_index_swap
+from onyx.kg.models import KGStage
+from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair
+from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair_and_future
+from tests.external_dependency_unit.indexing_helpers import make_cc_pair
+from tests.external_dependency_unit.indexing_helpers import make_future_search_settings
+
+_PENDING_DOC_PREFIX = "swapdoc-"
+
+
+@pytest.fixture
+def cc_pair_and_future(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> Generator[tuple[ConnectorCredentialPair, int], None, None]:
+    pair = make_cc_pair(db_session)
+    future_id = make_future_search_settings(db_session).id
+    try:
+        yield pair, future_id
+    finally:
+        cleanup_cc_pair_and_future(
+            db_session, pair, future_id, doc_prefix=_PENDING_DOC_PREFIX
+        )
+
+
+def _make_success_port(db_session: Session, cc_pair_id: int, ss_id: int) -> datetime:
+    """A SUCCESS port attempt; returns its (non-None) completion time so callers can
+    order index attempts relative to it."""
+    attempt = create_port_attempt(db_session, cc_pair_id, ss_id)
+    mark_port_in_progress(db_session, attempt.id)
+    mark_port_succeeded(db_session, attempt.id)
+    db_session.expire_all()
+    row = db_session.get(PortAttempt, attempt.id)
+    assert row is not None and row.time_completed is not None
+    return row.time_completed
+
+
+def test_port_swap_ready_when_port_succeeded(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """A successful port (no active attempt) with a drained sync backlog is ready —
+    no post-port connector index attempt is required."""
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    _make_success_port(db_session, cc_pair.id, future_id)
+    assert _port_swap_ready(db_session, future_ss, [cc_pair]) is True
+
+
+def test_port_swap_blocks_when_no_port(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    assert _port_swap_ready(db_session, future_ss, [cc_pair]) is False
+
+
+def test_port_swap_blocks_on_active_port(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    attempt = create_port_attempt(db_session, cc_pair.id, future_id)
+    mark_port_in_progress(db_session, attempt.id)  # active, not terminal
+    assert _port_swap_ready(db_session, future_ss, [cc_pair]) is False
+
+
+def test_port_swap_blocks_on_pending_sync_backlog(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    _make_success_port(db_session, cc_pair.id, future_id)
+    # a deferred-sync doc remains -> the backlog gate fails (tenant-global count)
+    doc_id = f"{_PENDING_DOC_PREFIX}pending"
+    db_session.add(
+        DbDocument(id=doc_id, semantic_id=doc_id, kg_stage=KGStage.NOT_STARTED)
+    )
+    db_session.commit()
+    mark_document_synced_secondary_pending(doc_id, db_session)
+    assert _port_swap_ready(db_session, future_ss, [cc_pair]) is False
+
+
+def test_port_swap_blocks_on_unfinished_ingestion_port(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """check_for_port ports the push-based Ingestion pair too, and the port is its
+    only path into FUTURE — so an unfinished Ingestion port must hold the swap, even
+    though it never yields a FUTURE index attempt."""
+    _standard, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    ingestion = make_cc_pair(db_session, source=DocumentSource.INGESTION_API)
+    try:
+        attempt = create_port_attempt(db_session, ingestion.id, future_id)
+        mark_port_in_progress(db_session, attempt.id)  # active -> not done
+        assert _port_swap_ready(db_session, future_ss, [ingestion]) is False
+    finally:
+        db_session.query(PortAttempt).filter(
+            PortAttempt.cc_pair_id == ingestion.id
+        ).delete(synchronize_session="fetch")
+        db_session.commit()
+        cleanup_cc_pair(db_session, ingestion)
+
+
+def test_port_swap_ready_ingestion_skips_index_attempt(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """Once its port succeeds, the Ingestion pair is ready with NO FUTURE index
+    attempt — the post-port index condition standard connectors face is skipped."""
+    _standard, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    ingestion = make_cc_pair(db_session, source=DocumentSource.INGESTION_API)
+    try:
+        _make_success_port(db_session, ingestion.id, future_id)
+        assert _port_swap_ready(db_session, future_ss, [ingestion]) is True
+    finally:
+        db_session.query(PortAttempt).filter(
+            PortAttempt.cc_pair_id == ingestion.id
+        ).delete(synchronize_session="fetch")
+        db_session.commit()
+        cleanup_cc_pair(db_session, ingestion)
+
+
+def test_required_cc_pairs_for_switchover_scopes_by_mode(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    active = make_cc_pair(db_session)
+    paused = make_cc_pair(db_session)
+    deleting = make_cc_pair(db_session)
+    paused.status = ConnectorCredentialPairStatus.PAUSED
+    deleting.status = ConnectorCredentialPairStatus.DELETING
+    db_session.commit()
+    all_ccp = [active, paused, deleting]
+    try:
+        # REINDEX uses indexable_statuses (incl PAUSED, excl DELETING)
+        reindex = _required_cc_pairs_for_switchover(
+            db_session, all_ccp, SwitchoverType.REINDEX
+        )
+        assert {c.id for c in reindex} == {active.id, paused.id}
+
+        # ACTIVE_ONLY uses active_statuses (excl PAUSED + DELETING)
+        active_only = _required_cc_pairs_for_switchover(
+            db_session, all_ccp, SwitchoverType.ACTIVE_ONLY
+        )
+        assert {c.id for c in active_only} == {active.id}
+    finally:
+        for cc_pair in (active, paused, deleting):
+            cleanup_cc_pair(db_session, cc_pair)
+
+
+def test_swap_holds_when_port_not_ready(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    future_ss.use_port_flow = True
+    future_ss.switchover_type = SwitchoverType.REINDEX  # not INSTANT -> gated
+    db_session.commit()
+
+    with patch.object(swap_index, "_perform_index_swap") as mock_swap:
+        result = check_and_perform_index_swap(db_session)
+
+    assert result is None
+    mock_swap.assert_not_called()
+
+
+def test_mode_c_swaps_immediately(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    _, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    future_ss.use_port_flow = True
+    future_ss.switchover_type = SwitchoverType.INSTANT
+    db_session.commit()
+
+    sentinel = object()
+    with patch.object(
+        swap_index, "_perform_index_swap", return_value=sentinel
+    ) as mock_swap:
+        result = check_and_perform_index_swap(db_session)
+
+    assert result is sentinel
+    mock_swap.assert_called_once()
+    # port-flow INSTANT swaps live WITHOUT the wipe: the port backfills the new
+    # index, so cleanup_documents would destroy live data — the swap omits it.
+    assert mock_swap.call_args.kwargs.get("cleanup_documents") is not True
+
+
+def test_legacy_path_does_not_consult_port_helpers(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    _, future_id = cc_pair_and_future  # use_port_flow stays False (default)
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    future_ss.switchover_type = SwitchoverType.REINDEX  # non-INSTANT legacy path
+    db_session.commit()
+
+    with (
+        patch.object(
+            swap_index,
+            "_port_swap_ready",
+            side_effect=AssertionError("legacy must not use the port path"),
+        ) as mock_ready,
+        patch.object(swap_index, "_perform_index_swap") as mock_swap,
+    ):
+        result = check_and_perform_index_swap(db_session)
+
+    mock_ready.assert_not_called()
+    # legacy REINDEX holds (cc_pairs without successful FUTURE indexings) -> no swap
+    assert result is None
+    mock_swap.assert_not_called()
+
+
+# --- two-phase cancel: the port_attempt contract that keeps deletion the last writer
+
+
+def _port_row(db_session: Session, attempt_id: int) -> PortAttempt:
+    db_session.expire_all()
+    row = db_session.get(PortAttempt, attempt_id)
+    assert row is not None
+    return row
+
+
+def test_request_cancel_not_started_terminalizes(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """NOT_STARTED: cancel outright so a waiting deletion can proceed — a mere flag
+    would wedge it (NOT_STARTED is invisible to the stall watchdog)."""
+    cc_pair, future_id = cc_pair_and_future
+    attempt = create_port_attempt(db_session, cc_pair.id, future_id)
+
+    request_port_cancel(db_session, attempt.id)
+
+    assert _port_row(db_session, attempt.id).status == PortAttemptStatus.CANCELED
+    assert get_active_port_attempt(db_session, cc_pair.id, future_id) is None
+
+
+def test_request_cancel_in_progress_flags_but_stays_active(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """IN_PROGRESS: flag only, row stays active — a waiter must keep blocking until
+    the task itself acks after its last write."""
+    cc_pair, future_id = cc_pair_and_future
+    attempt = create_port_attempt(db_session, cc_pair.id, future_id)
+    mark_port_in_progress(db_session, attempt.id)
+
+    request_port_cancel(db_session, attempt.id)
+
+    row = _port_row(db_session, attempt.id)
+    assert row.status == PortAttemptStatus.IN_PROGRESS
+    assert row.cancel_requested is True
+    still_active = get_active_port_attempt(db_session, cc_pair.id, future_id)
+    assert still_active is not None and still_active.id == attempt.id
+
+
+def test_in_progress_ack_unblocks_waiter(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """The task's ack (mark_port_canceled) is what flips the row terminal and lets
+    the waiter proceed — get_active_port_attempt returns None only after it."""
+    cc_pair, future_id = cc_pair_and_future
+    attempt = create_port_attempt(db_session, cc_pair.id, future_id)
+    mark_port_in_progress(db_session, attempt.id)
+    request_port_cancel(db_session, attempt.id)
+    assert get_active_port_attempt(db_session, cc_pair.id, future_id) is not None
+
+    mark_port_canceled(db_session, attempt.id)
+
+    assert _port_row(db_session, attempt.id).status == PortAttemptStatus.CANCELED
+    assert get_active_port_attempt(db_session, cc_pair.id, future_id) is None
+
+
+def test_request_cancel_terminal_is_noop(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    cc_pair, future_id = cc_pair_and_future
+    attempt = create_port_attempt(db_session, cc_pair.id, future_id)
+    mark_port_in_progress(db_session, attempt.id)
+    mark_port_succeeded(db_session, attempt.id)
+
+    request_port_cancel(db_session, attempt.id)
+
+    row = _port_row(db_session, attempt.id)
+    assert row.status == PortAttemptStatus.SUCCESS
+    assert row.cancel_requested is False
+
+
+def test_mark_in_progress_rejects_duplicate_and_terminal(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """Only a NOT_STARTED row may start. A re-dispatched duplicate (already
+    IN_PROGRESS) and a terminal row are both rejected, so one attempt never runs two
+    concurrent writers."""
+    cc_pair, future_id = cc_pair_and_future
+    attempt = create_port_attempt(db_session, cc_pair.id, future_id)
+
+    assert mark_port_in_progress(db_session, attempt.id) is True
+    assert mark_port_in_progress(db_session, attempt.id) is False  # duplicate
+
+    mark_port_canceled(db_session, attempt.id)
+    assert mark_port_in_progress(db_session, attempt.id) is False  # terminal
+
+
+def test_cancel_active_port_attempts_is_two_phase(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    """The swap-path bulk cancel uses the same two-phase rule: NOT_STARTED ->
+    CANCELED, IN_PROGRESS -> flagged-but-active (so a concurrent deletion waiting on
+    that port isn't unblocked mid-write)."""
+    future_id = make_future_search_settings(db_session).id
+    # active-unique is per (cc_pair, ss), so use two cc_pairs on one FUTURE
+    not_started_pair = make_cc_pair(db_session)
+    in_progress_pair = make_cc_pair(db_session)
+    try:
+        ns = create_port_attempt(db_session, not_started_pair.id, future_id)
+        ip = create_port_attempt(db_session, in_progress_pair.id, future_id)
+        mark_port_in_progress(db_session, ip.id)
+
+        affected = cancel_active_port_attempts(db_session, future_id)
+
+        assert affected == 2
+        assert _port_row(db_session, ns.id).status == PortAttemptStatus.CANCELED
+        ip_row = _port_row(db_session, ip.id)
+        assert ip_row.status == PortAttemptStatus.IN_PROGRESS
+        assert ip_row.cancel_requested is True
+        assert (
+            get_active_port_attempt(db_session, in_progress_pair.id, future_id)
+            is not None
+        )
+    finally:
+        for pair in (not_started_pair, in_progress_pair):
+            cleanup_cc_pair(db_session, pair)
+        db_session.query(PortAttempt).filter(
+            PortAttempt.search_settings_id == future_id
+        ).delete(synchronize_session="fetch")
+        db_session.commit()

--- a/backend/tests/external_dependency_unit/db/test_reindex_port.py
+++ b/backend/tests/external_dependency_unit/db/test_reindex_port.py
@@ -1,0 +1,1222 @@
+"""External dependency unit tests for the reindexing-port DB layer.
+
+Scoped to behavior/invariants worth guarding (the column existence + defaults are
+covered by applying the migration, which this repo does not test programmatically):
+- the partial-unique "one active attempt per (cc_pair, FUTURE)" index — and that
+  its predicate matches the stored (uppercase) enum name, not the value
+- the PortAttempt lifecycle helpers (create -> in_progress -> cursor -> terminal)
+  and first-terminal-write-wins
+- mark_document_synced_secondary_pending sets the flag (and clears needs-sync),
+  and a later mark_document_as_synced clears it again
+- the synthetic seed: writer row shape, seed-blind filtering for counts/latest/swap (a
+  seed must not count toward the swap or appear as the latest run) while it DOES prime the
+  resume poll cursor, and the gated should_index FUTURE branch (legacy once-only vs
+  port-flow continuous)
+- run_port_attempt: ports docs in batches, advances/commits the cursor, retries a
+  failed batch then marks FAILED (cursor left at the prior good batch)
+"""
+
+from collections.abc import Generator
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from typing import cast
+from unittest.mock import MagicMock
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from onyx.background.celery.tasks.beat_schedule import BEAT_EXPIRES_DEFAULT
+from onyx.background.celery.tasks.docprocessing.utils import should_index
+from onyx.background.celery.tasks.port import tasks as port_task
+from onyx.background.celery.tasks.port.tasks import run_check_for_port
+from onyx.background.celery.tasks.port.tasks import run_port_attempt
+from onyx.configs.app_configs import INDEX_BATCH_SIZE
+from onyx.configs.constants import OnyxCeleryQueues
+from onyx.configs.constants import OnyxCeleryTask
+from onyx.context.search.models import SavedSearchSettings
+from onyx.db.connector_credential_pair import get_last_successful_attempt_poll_range_end
+from onyx.db.document import document_has_indexable_cc_pair
+from onyx.db.document import get_document_ids_for_cc_pair_batch
+from onyx.db.document import mark_document_as_modified
+from onyx.db.document import mark_document_as_synced
+from onyx.db.document import mark_document_synced_secondary_pending
+from onyx.db.enums import ConnectorCredentialPairStatus
+from onyx.db.enums import EmbeddingPrecision
+from onyx.db.enums import IndexingStatus
+from onyx.db.enums import IndexModelStatus
+from onyx.db.enums import PortAttemptStatus
+from onyx.db.index_attempt import (
+    count_unique_active_cc_pairs_with_successful_index_attempts,
+)
+from onyx.db.index_attempt import count_unique_cc_pairs_with_successful_index_attempts
+from onyx.db.index_attempt import create_synthetic_seed_attempt
+from onyx.db.index_attempt import get_latest_successful_index_attempt_for_cc_pair_id
+from onyx.db.index_attempt import mock_successful_index_attempt
+from onyx.db.models import ConnectorCredentialPair
+from onyx.db.models import Document as DbDocument
+from onyx.db.models import DocumentByConnectorCredentialPair
+from onyx.db.models import IndexAttempt
+from onyx.db.models import PortAttempt
+from onyx.db.models import SearchSettings
+from onyx.db.port_attempt import cancel_active_port_attempts
+from onyx.db.port_attempt import commit_port_cursor
+from onyx.db.port_attempt import count_consecutive_failed_port_attempts_no_progress
+from onyx.db.port_attempt import create_port_attempt
+from onyx.db.port_attempt import get_active_port_attempt
+from onyx.db.port_attempt import get_latest_port_attempt
+from onyx.db.port_attempt import mark_port_canceled
+from onyx.db.port_attempt import mark_port_failed
+from onyx.db.port_attempt import mark_port_in_progress
+from onyx.db.port_attempt import mark_port_succeeded
+from onyx.db.search_settings import create_search_settings
+from onyx.db.search_settings import get_current_search_settings
+from onyx.db.swap_index import _port_swap_ready
+from onyx.document_index.opensearch import port_copy
+from onyx.document_index.opensearch.port_copy import copy_present_chunks_to_future
+from onyx.indexing.port_reembed import ReembedStrategy
+from onyx.kg.models import KGStage
+from shared_configs.contextvars import get_current_tenant_id
+from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair
+from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair_and_future
+from tests.external_dependency_unit.indexing_helpers import make_cc_pair
+from tests.external_dependency_unit.indexing_helpers import make_future_search_settings
+from tests.external_dependency_unit.indexing_helpers import (
+    seed_cc_pair_documents as _seed_cc_pair_documents,
+)
+
+
+def _run_check_for_port(
+    cc_pair: ConnectorCredentialPair,
+    future_id: int,
+    celery_app: MagicMock | None = None,
+) -> tuple[int | None, MagicMock]:
+    """Run check_for_port scoped to this test's FUTURE + cc_pair (the real
+    get_secondary/fetch helpers are global). Returns (result, celery_app)."""
+    celery_app = celery_app or MagicMock()
+    with (
+        patch.object(
+            port_task,
+            "get_secondary_search_settings",
+            lambda db, *_, **__: db.get(SearchSettings, future_id),
+        ),
+        patch.object(
+            port_task,
+            "fetch_indexable_standard_connector_credential_pair_ids",
+            lambda *_, **__: [cc_pair.id],
+        ),
+    ):
+        result = run_check_for_port(get_current_tenant_id(), celery_app)
+    return result, celery_app
+
+
+@pytest.fixture
+def cc_pair(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> Generator[ConnectorCredentialPair, None, None]:
+    pair = make_cc_pair(db_session)
+    try:
+        yield pair
+    finally:
+        db_session.rollback()
+        db_session.query(PortAttempt).filter(PortAttempt.cc_pair_id == pair.id).delete(
+            synchronize_session="fetch"
+        )
+        db_session.commit()
+        cleanup_cc_pair(db_session, pair)
+
+
+def test_port_attempt_active_unique_constraint(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    """At most one active (NOT_STARTED/IN_PROGRESS) attempt per (cc_pair, FUTURE);
+    terminal rows may coexist. Also guards the index predicate against the stored
+    enum casing (uppercase name) — a lowercase predicate would silently no-op."""
+    ss = get_current_search_settings(db_session)
+
+    db_session.add(
+        PortAttempt(
+            cc_pair_id=cc_pair.id,
+            search_settings_id=ss.id,
+            status=PortAttemptStatus.IN_PROGRESS,
+        )
+    )
+    db_session.commit()
+
+    db_session.add(
+        PortAttempt(
+            cc_pair_id=cc_pair.id,
+            search_settings_id=ss.id,
+            status=PortAttemptStatus.NOT_STARTED,
+        )
+    )
+    with pytest.raises(IntegrityError):
+        db_session.commit()
+    db_session.rollback()
+
+    # a terminal attempt for the same pair is allowed (outside the predicate)
+    db_session.add(
+        PortAttempt(
+            cc_pair_id=cc_pair.id,
+            search_settings_id=ss.id,
+            status=PortAttemptStatus.SUCCESS,
+        )
+    )
+    db_session.commit()
+
+    active = (
+        db_session.query(PortAttempt)
+        .filter(
+            PortAttempt.cc_pair_id == cc_pair.id,
+            PortAttempt.status.in_(
+                [PortAttemptStatus.NOT_STARTED, PortAttemptStatus.IN_PROGRESS]
+            ),
+        )
+        .count()
+    )
+    assert active == 1
+
+
+def test_mark_secondary_pending_then_synced_clears_it(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    doc_id = "test-secondary-pending-doc"
+    db_session.add(
+        DbDocument(id=doc_id, semantic_id=doc_id, kg_stage=KGStage.NOT_STARTED)
+    )
+    db_session.commit()
+    try:
+        mark_document_as_modified(doc_id, db_session)  # needs-sync
+
+        # PRESENT synced but FUTURE missing -> defer
+        mark_document_synced_secondary_pending(doc_id, db_session)
+        db_session.expire_all()
+        row = db_session.query(DbDocument).filter(DbDocument.id == doc_id).one()
+        assert row.last_synced is not None and row.last_modified is not None
+        assert row.last_synced >= row.last_modified  # needs-sync cleared
+        assert row.secondary_only_sync_pending is True
+
+        # a later full sync reaches FUTURE -> flag flips back to False
+        mark_document_as_synced(doc_id, db_session)
+        db_session.expire_all()
+        row = db_session.query(DbDocument).filter(DbDocument.id == doc_id).one()
+        assert row.secondary_only_sync_pending is False
+    finally:
+        db_session.query(DbDocument).filter(DbDocument.id == doc_id).delete(
+            synchronize_session="fetch"
+        )
+        db_session.commit()
+
+
+def test_mark_secondary_pending_raises_on_missing_document(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    with pytest.raises(ValueError):
+        mark_document_synced_secondary_pending("does-not-exist", db_session)
+
+
+def test_port_attempt_lifecycle_helpers(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    """create -> in_progress -> cursor commit -> success; get_active tracks the
+    active attempt and stops returning it once the attempt is terminal."""
+    ss = get_current_search_settings(db_session)
+
+    attempt = create_port_attempt(db_session, cc_pair.id, ss.id, celery_task_id="t-1")
+    attempt_id = attempt.id
+    assert attempt.status == PortAttemptStatus.NOT_STARTED
+    assert get_active_port_attempt(db_session, cc_pair.id, ss.id) is not None
+
+    mark_port_in_progress(db_session, attempt_id, celery_task_id="t-1")
+    commit_port_cursor(
+        db_session, attempt_id, last_processed_doc_id="doc-50", docs_ported=50
+    )
+    db_session.expire_all()
+    row = db_session.get(PortAttempt, attempt_id)
+    assert row is not None
+    assert row.status == PortAttemptStatus.IN_PROGRESS
+    assert row.last_processed_doc_id == "doc-50"
+    assert row.docs_ported == 50
+    assert row.time_started is not None and row.last_progress_time is not None
+
+    # a second cursor commit advances the (absolute) cumulative counter
+    commit_port_cursor(
+        db_session, attempt_id, last_processed_doc_id="doc-80", docs_ported=80
+    )
+    db_session.expire_all()
+    row = db_session.get(PortAttempt, attempt_id)
+    assert row is not None
+    assert row.last_processed_doc_id == "doc-80" and row.docs_ported == 80
+
+    mark_port_succeeded(db_session, attempt_id)
+    db_session.expire_all()
+    row = db_session.get(PortAttempt, attempt_id)
+    assert row is not None
+    assert row.status == PortAttemptStatus.SUCCESS
+    assert row.time_completed is not None
+    # terminal attempts are no longer "active"
+    assert get_active_port_attempt(db_session, cc_pair.id, ss.id) is None
+
+
+def test_port_attempt_terminal_is_first_write_wins(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    """A terminal attempt ignores later transitions, so a late task SUCCESS can't
+    clobber a watchdog FAILED (the row lock makes this deterministic)."""
+    ss = get_current_search_settings(db_session)
+    attempt = create_port_attempt(db_session, cc_pair.id, ss.id)
+    mark_port_in_progress(db_session, attempt.id)
+
+    mark_port_failed(db_session, attempt.id, error_msg="stalled")
+    mark_port_succeeded(db_session, attempt.id)  # no-op: already terminal
+
+    db_session.expire_all()
+    row = db_session.get(PortAttempt, attempt.id)
+    assert row is not None
+    assert row.status == PortAttemptStatus.FAILED
+    assert row.error_msg == "stalled"
+
+
+@pytest.fixture
+def cc_pair_and_future(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> Generator[tuple[ConnectorCredentialPair, int], None, None]:
+    """A cc_pair plus an isolated FUTURE SearchSettings (unique index_name) so the
+    global count/cursor helpers see only this test's attempts."""
+    pair = make_cc_pair(db_session)
+    future_id = make_future_search_settings(db_session).id
+    try:
+        yield pair, future_id
+    finally:
+        cleanup_cc_pair_and_future(db_session, pair, future_id)
+
+
+def test_use_port_flow_default_and_round_trip(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    """use_port_flow persists as False via the server default when the saved model
+    omits it, and an explicit True round-trips through a fresh read + the
+    SavedSearchSettings mapper the port flow uses. PAST status avoids the
+    PRESENT-uniqueness + concurrent-FUTURE collisions a round-trip test would hit.
+    """
+
+    def _saved() -> SavedSearchSettings:
+        # Minimal explicit settings (not a clone of the polluted live row) so the
+        # omitted use_port_flow falls through to the server default.
+        return SavedSearchSettings(
+            model_name="test-port-flow-model",
+            model_dim=128,
+            normalize=True,
+            query_prefix="",
+            passage_prefix="",
+            provider_type=None,
+            multipass_indexing=False,
+            embedding_precision=EmbeddingPrecision.FLOAT,
+            index_name=f"test_port_flow_{uuid4().hex[:8]}",
+            enable_contextual_rag=False,
+        )
+
+    default_id = create_search_settings(
+        _saved(), db_session, status=IndexModelStatus.PAST
+    ).id
+    true_id = create_search_settings(
+        _saved().model_copy(update={"use_port_flow": True}),
+        db_session,
+        status=IndexModelStatus.PAST,
+    ).id
+    try:
+        db_session.expire_all()
+        default_fresh = db_session.get(SearchSettings, default_id)
+        assert default_fresh is not None and default_fresh.use_port_flow is False
+        true_fresh = db_session.get(SearchSettings, true_id)
+        assert true_fresh is not None and true_fresh.use_port_flow is True
+        # Rehydrate through the pydantic mapper the port flow reads through.
+        assert SavedSearchSettings.from_db_model(true_fresh).use_port_flow is True
+    finally:
+        for row_id in (default_id, true_id):
+            row = db_session.get(SearchSettings, row_id)
+            if row is not None:
+                db_session.delete(row)
+        db_session.commit()
+
+
+def test_create_synthetic_seed_attempt(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    cc_pair, future_id = cc_pair_and_future
+    epoch = 1_700_000_000.0
+
+    seed_id = create_synthetic_seed_attempt(
+        cc_pair.id, future_id, poll_range_end=epoch, db_session=db_session
+    )
+    db_session.expire_all()
+    seed = db_session.get(IndexAttempt, seed_id)
+    assert seed is not None
+    assert seed.status == IndexingStatus.SUCCESS
+    assert seed.is_synthetic_seed is True
+    # time_started == time_created so the swap criterion's "real attempt after the
+    # port" comparison is well-defined for the run that supersedes the seed
+    assert seed.time_started is not None and seed.time_created is not None
+    assert seed.time_started == seed.time_created
+    assert seed.poll_range_end is not None
+    assert seed.poll_range_end.timestamp() == epoch
+
+
+def test_seed_excluded_from_latest_and_counts(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    cc_pair, future_id = cc_pair_and_future
+
+    # only a synthetic seed exists
+    create_synthetic_seed_attempt(
+        cc_pair.id, future_id, poll_range_end=1000.0, db_session=db_session
+    )
+    db_session.expire_all()
+    assert (
+        count_unique_cc_pairs_with_successful_index_attempts(future_id, db_session) == 0
+    )
+    assert (
+        count_unique_active_cc_pairs_with_successful_index_attempts(
+            future_id, db_session
+        )
+        == 0
+    )
+    assert (
+        get_latest_successful_index_attempt_for_cc_pair_id(
+            db_session, cc_pair.id, secondary_index=True
+        )
+        is None
+    )
+
+    # a real SUCCESS attempt IS counted and returned
+    real_id = mock_successful_index_attempt(
+        cc_pair.id, future_id, docs_indexed=5, db_session=db_session
+    )
+    db_session.expire_all()
+    assert (
+        count_unique_cc_pairs_with_successful_index_attempts(future_id, db_session) == 1
+    )
+    latest = get_latest_successful_index_attempt_for_cc_pair_id(
+        db_session, cc_pair.id, secondary_index=True
+    )
+    assert latest is not None and latest.id == real_id
+
+
+def test_seed_primes_poll_cursor(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """The seed IS the resume cursor: with only a seed present, the FUTURE's first
+    connector attempt starts from PRESENT's cursor (carried by the seed), not the
+    earliest_index fallback. A later real SUCCESS attempt then supersedes the seed."""
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+
+    seed_cursor = 1000.0
+    create_synthetic_seed_attempt(
+        cc_pair.id, future_id, poll_range_end=seed_cursor, db_session=db_session
+    )
+    db_session.expire_all()
+    # resume from the seed cursor, not the earliest_index arg (42.0)
+    assert (
+        get_last_successful_attempt_poll_range_end(
+            cc_pair.id, 42.0, future_ss, db_session
+        )
+        == seed_cursor
+    )
+
+    # a real SUCCESS attempt with a later cursor supersedes the seed
+    later_cursor = seed_cursor + 5000.0
+    real_id = mock_successful_index_attempt(
+        cc_pair.id, future_id, docs_indexed=5, db_session=db_session
+    )
+    real = db_session.get(IndexAttempt, real_id)
+    assert real is not None
+    real.poll_range_end = datetime.fromtimestamp(later_cursor, tz=timezone.utc)
+    db_session.commit()
+    db_session.expire_all()
+    assert (
+        get_last_successful_attempt_poll_range_end(
+            cc_pair.id, 42.0, future_ss, db_session
+        )
+        == later_cursor
+    )
+
+
+def test_should_index_future_gated_on_port_flow(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    cc_pair, future_id = cc_pair_and_future
+    # make the connector pollable on the continuous path
+    cc_pair.connector.refresh_freq = 60
+    # a real SUCCESS attempt, old enough to be re-pollable
+    old = datetime.now(timezone.utc) - timedelta(hours=1)
+    db_session.add(
+        IndexAttempt(
+            connector_credential_pair_id=cc_pair.id,
+            search_settings_id=future_id,
+            from_beginning=True,
+            status=IndexingStatus.SUCCESS,
+            time_started=old,
+            time_updated=old,
+        )
+    )
+    db_session.commit()
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+
+    # legacy (flag off): one success is enough -> don't index again
+    future_ss.use_port_flow = False
+    db_session.commit()
+    assert (
+        should_index(
+            cc_pair, future_ss, secondary_index_building=True, db_session=db_session
+        )
+        is False
+    )
+
+    # port flow (flag on): polls continuously -> index again
+    future_ss.use_port_flow = True
+    db_session.commit()
+    assert (
+        should_index(
+            cc_pair, future_ss, secondary_index_building=True, db_session=db_session
+        )
+        is True
+    )
+
+
+def test_get_document_ids_for_cc_pair_batch(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    """Cursor pagination over a cc_pair's doc ids: ascending, exclusive of the
+    cursor, capped at limit, empty once exhausted -> the port's resume scan."""
+    doc_ids = _seed_cc_pair_documents(db_session, cc_pair, 5)
+
+    first = get_document_ids_for_cc_pair_batch(
+        db_session, cc_pair.id, after_doc_id=None, limit=2
+    )
+    assert first == doc_ids[:2]
+
+    # resume past the last id of the prior page
+    second = get_document_ids_for_cc_pair_batch(
+        db_session, cc_pair.id, after_doc_id=first[-1], limit=2
+    )
+    assert second == doc_ids[2:4]
+
+    third = get_document_ids_for_cc_pair_batch(
+        db_session, cc_pair.id, after_doc_id=second[-1], limit=2
+    )
+    assert third == doc_ids[4:]
+
+    # cursor at/after the last id -> exhausted
+    assert (
+        get_document_ids_for_cc_pair_batch(
+            db_session, cc_pair.id, after_doc_id=doc_ids[-1], limit=2
+        )
+        == []
+    )
+
+
+def test_copy_present_chunks_to_future_orchestration() -> None:
+    """Per batch: each PIT-scan page is re-embedded and written to FUTURE
+    create-only; returns (chunks written, aborted). Mocks the OpenSearch
+    read/write + re-embed (covered by their own tests)."""
+    present_client = MagicMock()
+    future_index = MagicMock()
+    strategy = cast(ReembedStrategy, MagicMock())
+    embedder = MagicMock()
+    # two pages out of the PIT scan
+    present_client.iter_chunks_for_doc_ids.return_value = iter([["c1", "c2"], ["c3"]])
+
+    with patch.object(
+        port_copy,
+        "re_embed_chunks",
+        side_effect=lambda chunks, _strategy, _embedder, **_kwargs: [
+            f"re:{c}" for c in chunks
+        ],
+    ) as mock_reembed:
+        written, aborted = copy_present_chunks_to_future(
+            present_client,
+            future_index,
+            ["d1", "d2"],
+            strategy,
+            embedder,
+            present_tokenizer=MagicMock(),
+        )
+
+    assert written == 3
+    assert aborted is False
+    present_client.iter_chunks_for_doc_ids.assert_called_once_with(["d1", "d2"])
+    # re-embed once per page, with that page's chunks + prebuilt strategy/embedder
+    assert mock_reembed.call_count == 2
+    assert mock_reembed.call_args_list[0].args == (["c1", "c2"], strategy, embedder)
+    # FUTURE write once per page, always create-only (the port never overwrites)
+    assert future_index.index_raw_chunks.call_count == 2
+    first_write = future_index.index_raw_chunks.call_args_list[0]
+    assert first_write.args[0] == ["re:c1", "re:c2"]
+    assert first_write.kwargs == {"use_create_only": True}
+
+
+def test_run_port_attempt_happy_path(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """Ports every doc in INDEX_BATCH_SIZE batches: copier called once per batch,
+    cursor advanced to the last id, docs_ported == total, status SUCCESS."""
+    cc_pair, future_id = cc_pair_and_future
+    doc_ids = _seed_cc_pair_documents(db_session, cc_pair, INDEX_BATCH_SIZE + 4)
+    attempt_id = create_port_attempt(db_session, cc_pair.id, future_id).id
+
+    mock_copier = MagicMock()
+    mock_copier.copy_doc_batch.side_effect = lambda ids, **_: (len(ids), False)
+    with patch.object(port_task, "PortCopier", return_value=mock_copier):
+        run_port_attempt(attempt_id)
+
+    # two batches: a full INDEX_BATCH_SIZE then the remaining 4
+    assert mock_copier.copy_doc_batch.call_count == 2
+    assert (
+        mock_copier.copy_doc_batch.call_args_list[0].args[0]
+        == doc_ids[:INDEX_BATCH_SIZE]
+    )
+    assert (
+        mock_copier.copy_doc_batch.call_args_list[1].args[0]
+        == doc_ids[INDEX_BATCH_SIZE:]
+    )
+
+    db_session.expire_all()
+    row = db_session.get(PortAttempt, attempt_id)
+    assert row is not None
+    assert row.status == PortAttemptStatus.SUCCESS
+    assert row.last_processed_doc_id == doc_ids[-1]
+    assert row.docs_ported == len(doc_ids)
+    assert row.time_completed is not None
+
+
+def test_run_port_attempt_batch_retry_then_failed(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """A batch that keeps failing is retried _PORT_BATCH_MAX_RETRIES times, then
+    the attempt is FAILED with the cursor un-advanced (a fresh attempt resumes
+    from the prior good batch -- here, the start)."""
+    cc_pair, future_id = cc_pair_and_future
+    _seed_cc_pair_documents(db_session, cc_pair, 3)
+    attempt_id = create_port_attempt(db_session, cc_pair.id, future_id).id
+
+    mock_copier = MagicMock()
+    mock_copier.copy_doc_batch.side_effect = RuntimeError("opensearch down")
+    with (
+        patch.object(port_task, "PortCopier", return_value=mock_copier),
+        patch.object(port_task.time, "sleep"),  # don't sleep between retries
+    ):
+        run_port_attempt(attempt_id)
+
+    assert mock_copier.copy_doc_batch.call_count == port_task._PORT_BATCH_MAX_RETRIES
+    db_session.expire_all()
+    row = db_session.get(PortAttempt, attempt_id)
+    assert row is not None
+    assert row.status == PortAttemptStatus.FAILED
+    assert row.error_msg == "opensearch down"
+    assert row.last_processed_doc_id is None  # cursor never advanced
+    assert row.docs_ported == 0
+    assert row.time_completed is not None
+
+
+def test_run_port_attempt_resumes_from_cursor(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """A resumed attempt scans only ids past its stored cursor and accumulates
+    docs_ported on top of the prior count."""
+    cc_pair, future_id = cc_pair_and_future
+    doc_ids = _seed_cc_pair_documents(db_session, cc_pair, 5)
+    attempt_id = create_port_attempt(db_session, cc_pair.id, future_id).id
+    # simulate a prior partial run: cursor at the 2nd doc, 2 docs ported
+    mark_port_in_progress(db_session, attempt_id)
+    commit_port_cursor(
+        db_session, attempt_id, last_processed_doc_id=doc_ids[1], docs_ported=2
+    )
+
+    mock_copier = MagicMock()
+    mock_copier.copy_doc_batch.side_effect = lambda ids, **_: (len(ids), False)
+    with patch.object(port_task, "PortCopier", return_value=mock_copier):
+        run_port_attempt(attempt_id)
+
+    # only the docs after the cursor are copied
+    assert mock_copier.copy_doc_batch.call_count == 1
+    assert mock_copier.copy_doc_batch.call_args_list[0].args[0] == doc_ids[2:]
+    db_session.expire_all()
+    row = db_session.get(PortAttempt, attempt_id)
+    assert row is not None
+    assert row.status == PortAttemptStatus.SUCCESS
+    assert row.last_processed_doc_id == doc_ids[-1]
+    assert row.docs_ported == 5  # 2 prior + 3 newly ported
+
+
+def test_run_port_attempt_stops_when_canceled(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """An external CANCEL (operator) marks the attempt terminal; the task stops at
+    the next batch boundary with its partial cursor preserved."""
+    cc_pair, future_id = cc_pair_and_future
+    doc_ids = _seed_cc_pair_documents(db_session, cc_pair, INDEX_BATCH_SIZE + 4)
+    attempt_id = create_port_attempt(db_session, cc_pair.id, future_id).id
+
+    def copy_then_cancel(ids: list[str], **_: object) -> tuple[int, bool]:
+        mark_port_canceled(db_session, attempt_id)  # operator cancels after batch 1
+        return len(ids), False
+
+    mock_copier = MagicMock()
+    mock_copier.copy_doc_batch.side_effect = copy_then_cancel
+    with patch.object(port_task, "PortCopier", return_value=mock_copier):
+        run_port_attempt(attempt_id)
+
+    # first batch ran; the CANCELED status stops it at the next boundary
+    assert mock_copier.copy_doc_batch.call_count == 1
+    db_session.expire_all()
+    row = db_session.get(PortAttempt, attempt_id)
+    assert row is not None
+    assert row.status == PortAttemptStatus.CANCELED
+    assert row.last_processed_doc_id == doc_ids[INDEX_BATCH_SIZE - 1]
+    assert row.docs_ported == INDEX_BATCH_SIZE
+
+
+def test_cancel_active_port_attempts_on_supersede(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """Superseding a FUTURE cancels its active (NOT_STARTED/IN_PROGRESS) port
+    attempts — the running task then stops at its next batch — while terminal
+    attempts are left untouched."""
+    cc_pair, future_id = cc_pair_and_future
+
+    active = create_port_attempt(db_session, cc_pair.id, future_id)
+    mark_port_in_progress(db_session, active.id)
+    # a terminal attempt for the same pair/future must be left alone
+    db_session.add(
+        PortAttempt(
+            cc_pair_id=cc_pair.id,
+            search_settings_id=future_id,
+            status=PortAttemptStatus.SUCCESS,
+        )
+    )
+    db_session.commit()
+
+    canceled = cancel_active_port_attempts(db_session, search_settings_id=future_id)
+    assert canceled == 1
+
+    db_session.expire_all()
+    active_row = db_session.get(PortAttempt, active.id)
+    assert active_row is not None
+    assert active_row.status == PortAttemptStatus.CANCELED
+    assert active_row.time_completed is not None
+    # the terminal SUCCESS is preserved (first-terminal-write-wins)
+    successes = (
+        db_session.query(PortAttempt)
+        .filter(
+            PortAttempt.search_settings_id == future_id,
+            PortAttempt.status == PortAttemptStatus.SUCCESS,
+        )
+        .count()
+    )
+    assert successes == 1
+
+
+def test_run_port_attempt_exits_when_cc_pair_deleting(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """A cc_pair flipped to DELETING stops the port at the boundary before any
+    copy (the CASCADE will remove the attempt row)."""
+    cc_pair, future_id = cc_pair_and_future
+    _seed_cc_pair_documents(db_session, cc_pair, 3)
+    attempt_id = create_port_attempt(db_session, cc_pair.id, future_id).id
+    cc_pair.status = ConnectorCredentialPairStatus.DELETING
+    db_session.commit()
+
+    mock_copier = MagicMock()
+    with patch.object(port_task, "PortCopier", return_value=mock_copier):
+        run_port_attempt(attempt_id)
+
+    assert mock_copier.copy_doc_batch.call_count == 0
+    db_session.expire_all()
+    row = db_session.get(PortAttempt, attempt_id)
+    assert row is not None
+    assert row.status == PortAttemptStatus.IN_PROGRESS  # left for the CASCADE to remove
+
+
+def test_run_port_attempt_soft_time_limit_yields(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """Hitting the self-enforced soft time limit yields (no copy, no terminal
+    mark) so the watchdog can reschedule from the cursor."""
+    cc_pair, future_id = cc_pair_and_future
+    _seed_cc_pair_documents(db_session, cc_pair, 3)
+    attempt_id = create_port_attempt(db_session, cc_pair.id, future_id).id
+
+    mock_copier = MagicMock()
+    with (
+        patch.object(port_task, "PortCopier", return_value=mock_copier),
+        patch.object(port_task, "_PORT_SOFT_TIME_LIMIT", -1),  # already "expired"
+    ):
+        run_port_attempt(attempt_id)
+
+    assert mock_copier.copy_doc_batch.call_count == 0
+    db_session.expire_all()
+    row = db_session.get(PortAttempt, attempt_id)
+    assert row is not None
+    assert row.status == PortAttemptStatus.IN_PROGRESS  # not terminal; watchdog resumes
+
+
+def test_check_for_port_creates_and_enqueues(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """A use_port_flow FUTURE with an in-scope cc_pair and no active attempt ->
+    one NOT_STARTED PortAttempt created + run_port_attempt enqueued."""
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    future_ss.use_port_flow = True
+    db_session.commit()
+
+    result, celery_app = _run_check_for_port(cc_pair, future_id)
+
+    assert result == 1
+    db_session.expire_all()
+    attempts = (
+        db_session.query(PortAttempt)
+        .filter(
+            PortAttempt.cc_pair_id == cc_pair.id,
+            PortAttempt.search_settings_id == future_id,
+        )
+        .all()
+    )
+    assert len(attempts) == 1
+    assert attempts[0].status == PortAttemptStatus.NOT_STARTED
+    celery_app.send_task.assert_called_once()
+    call = celery_app.send_task.call_args
+    assert call.args[0] == OnyxCeleryTask.RUN_PORT_ATTEMPT
+    assert call.kwargs["kwargs"] == {
+        "port_attempt_id": attempts[0].id,
+        "tenant_id": get_current_tenant_id(),
+    }
+    assert call.kwargs["queue"] == OnyxCeleryQueues.PORT
+    assert call.kwargs["expires"] == BEAT_EXPIRES_DEFAULT
+
+
+def test_check_for_port_gated_off_when_not_port_flow(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """A legacy FUTURE (use_port_flow=False) is a no-op -> nothing created/enqueued."""
+    cc_pair, future_id = cc_pair_and_future  # use_port_flow stays False (default)
+
+    result, celery_app = _run_check_for_port(cc_pair, future_id)
+
+    assert result is None
+    celery_app.send_task.assert_not_called()
+    assert (
+        db_session.query(PortAttempt)
+        .filter(PortAttempt.cc_pair_id == cc_pair.id)
+        .count()
+        == 0
+    )
+
+
+def test_check_for_port_resumes_failed_cursor(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """A prior FAILED attempt is rescheduled with its cursor carried forward."""
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    future_ss.use_port_flow = True
+    db_session.commit()
+
+    failed = create_port_attempt(db_session, cc_pair.id, future_id)
+    mark_port_in_progress(db_session, failed.id)
+    commit_port_cursor(
+        db_session, failed.id, last_processed_doc_id="portdoc-042", docs_ported=42
+    )
+    mark_port_failed(db_session, failed.id, error_msg="boom")
+
+    result, _ = _run_check_for_port(cc_pair, future_id)
+
+    assert result == 1
+    db_session.expire_all()
+    fresh = (
+        db_session.query(PortAttempt)
+        .filter(
+            PortAttempt.cc_pair_id == cc_pair.id,
+            PortAttempt.status == PortAttemptStatus.NOT_STARTED,
+        )
+        .all()
+    )
+    assert len(fresh) == 1
+    assert fresh[0].last_processed_doc_id == "portdoc-042"  # resumed cursor
+
+
+def test_check_for_port_fails_stale_in_progress(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """A stalled IN_PROGRESS attempt is FAILED, then a fresh attempt is created
+    and enqueued to resume."""
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    future_ss.use_port_flow = True
+    db_session.commit()
+
+    stale = create_port_attempt(db_session, cc_pair.id, future_id)
+    mark_port_in_progress(db_session, stale.id)
+    # force last_progress_time well past the stall threshold
+    old = datetime.now(timezone.utc) - timedelta(hours=1)
+    db_session.query(PortAttempt).filter(PortAttempt.id == stale.id).update(
+        {PortAttempt.last_progress_time: old}
+    )
+    db_session.commit()
+
+    result, celery_app = _run_check_for_port(cc_pair, future_id)
+
+    db_session.expire_all()
+    stale_row = db_session.get(PortAttempt, stale.id)
+    assert stale_row is not None
+    assert stale_row.status == PortAttemptStatus.FAILED  # watchdog failed the stall
+    fresh = (
+        db_session.query(PortAttempt)
+        .filter(
+            PortAttempt.cc_pair_id == cc_pair.id,
+            PortAttempt.status == PortAttemptStatus.NOT_STARTED,
+        )
+        .all()
+    )
+    assert len(fresh) == 1
+    assert result == 1
+    celery_app.send_task.assert_called_once()
+
+
+def test_check_for_port_leaves_active_in_progress(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """A healthy (recent) IN_PROGRESS attempt is left untouched and not duplicated."""
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    future_ss.use_port_flow = True
+    db_session.commit()
+
+    active = create_port_attempt(db_session, cc_pair.id, future_id)
+    mark_port_in_progress(db_session, active.id)  # recent last_progress_time
+
+    result, celery_app = _run_check_for_port(cc_pair, future_id)
+
+    assert result == 0
+    celery_app.send_task.assert_not_called()
+    db_session.expire_all()
+    row = db_session.get(PortAttempt, active.id)
+    assert row is not None
+    assert row.status == PortAttemptStatus.IN_PROGRESS  # untouched
+    assert (
+        db_session.query(PortAttempt)
+        .filter(PortAttempt.cc_pair_id == cc_pair.id)
+        .count()
+        == 1
+    )
+
+
+def test_check_for_port_reissues_stale_not_started(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """A NOT_STARTED attempt whose enqueued task was lost/expired (not re-enqueued
+    within the TTL window) is re-enqueued in place — not stranded, not duplicated —
+    and the enqueue clock advances so it re-sends once per window, not every beat."""
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    future_ss.use_port_flow = True
+    db_session.commit()
+
+    stale = create_port_attempt(db_session, cc_pair.id, future_id)
+    # backdate time_updated past the TTL so the gate sees the task as expired
+    # (explicit set wins over the column's onupdate)
+    old = datetime.now(timezone.utc) - timedelta(seconds=BEAT_EXPIRES_DEFAULT + 60)
+    stale.time_updated = old
+    db_session.commit()
+
+    result, celery_app = _run_check_for_port(cc_pair, future_id)
+
+    assert result == 1
+    celery_app.send_task.assert_called_once()
+    assert (
+        celery_app.send_task.call_args.kwargs["kwargs"]["port_attempt_id"] == stale.id
+    )
+    # re-issued in place: still the same single attempt, still NOT_STARTED
+    db_session.expire_all()
+    rows = (
+        db_session.query(PortAttempt).filter(PortAttempt.cc_pair_id == cc_pair.id).all()
+    )
+    assert len(rows) == 1 and rows[0].id == stale.id
+    assert rows[0].status == PortAttemptStatus.NOT_STARTED
+    # the clock advanced past the backdate, so an immediate next tick is throttled
+    assert rows[0].time_updated > old
+    result2, celery_app2 = _run_check_for_port(cc_pair, future_id)
+    assert result2 == 0
+    celery_app2.send_task.assert_not_called()
+
+
+def test_check_for_port_leaves_fresh_not_started(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """A recently-created NOT_STARTED attempt (task still in flight, within the TTL)
+    is left alone — not re-enqueued or duplicated."""
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    future_ss.use_port_flow = True
+    db_session.commit()
+
+    fresh = create_port_attempt(db_session, cc_pair.id, future_id)  # time_updated = now
+
+    result, celery_app = _run_check_for_port(cc_pair, future_id)
+
+    assert result == 0
+    celery_app.send_task.assert_not_called()
+    db_session.expire_all()
+    assert (
+        db_session.query(PortAttempt)
+        .filter(PortAttempt.cc_pair_id == cc_pair.id)
+        .count()
+        == 1
+    )
+    row = db_session.get(PortAttempt, fresh.id)
+    assert row is not None and row.status == PortAttemptStatus.NOT_STARTED
+
+
+def test_check_for_port_fails_attempt_when_enqueue_raises(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """If send_task fails after the row is committed, the attempt is FAILED (not
+    left orphaned NOT_STARTED) so the next tick recreates + re-enqueues it."""
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    future_ss.use_port_flow = True
+    db_session.commit()
+
+    celery_app = MagicMock()
+    celery_app.send_task.side_effect = RuntimeError("broker down")
+    _run_check_for_port(cc_pair, future_id, celery_app=celery_app)
+
+    db_session.expire_all()
+    attempts = (
+        db_session.query(PortAttempt).filter(PortAttempt.cc_pair_id == cc_pair.id).all()
+    )
+    assert len(attempts) == 1
+    assert attempts[0].status == PortAttemptStatus.FAILED  # not orphaned NOT_STARTED
+    assert attempts[0].error_msg == "enqueue failed"
+
+
+def test_check_for_port_survives_create_failure(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """A create_port_attempt failure for one cc_pair is swallowed so the tick
+    completes (the next tick retries) rather than aborting every other cc_pair."""
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    future_ss.use_port_flow = True
+    db_session.commit()
+
+    celery_app = MagicMock()
+    with (
+        patch.object(
+            port_task,
+            "get_secondary_search_settings",
+            lambda db, *_, **__: db.get(SearchSettings, future_id),
+        ),
+        patch.object(
+            port_task,
+            "fetch_indexable_standard_connector_credential_pair_ids",
+            lambda *_, **__: [cc_pair.id],
+        ),
+        patch.object(
+            port_task, "create_port_attempt", side_effect=RuntimeError("db blip")
+        ),
+    ):
+        result = run_check_for_port(get_current_tenant_id(), celery_app)
+
+    assert result == 0  # tick completed; the failed create was skipped
+    celery_app.send_task.assert_not_called()
+    db_session.expire_all()
+    assert (
+        db_session.query(PortAttempt)
+        .filter(PortAttempt.cc_pair_id == cc_pair.id)
+        .count()
+        == 0
+    )
+
+
+def test_port_retry_delay_backoff() -> None:
+    """First same-cursor failure retries immediately; repeats back off, then cap."""
+    delay = port_task._port_retry_delay_seconds
+    base = port_task._PORT_RETRY_BACKOFF_BASE_S
+    assert delay(0) == 0.0
+    assert delay(1) == 0.0  # first failure: retry now (likely transient)
+    assert delay(2) == base  # second same-cursor failure: start backing off
+    assert delay(3) == base * 2
+    assert delay(4) == base * 4
+    assert delay(1000) == port_task._PORT_RETRY_BACKOFF_MAX_S  # capped
+
+
+def _fail_port_at(
+    db_session: Session, cc_pair_id: int, future_id: int, cursor: str | None
+) -> int:
+    """Create a terminal FAILED attempt resuming from `cursor`; returns its id."""
+    a = create_port_attempt(
+        db_session, cc_pair_id, future_id, resume_from_doc_id=cursor
+    )
+    mark_port_in_progress(db_session, a.id)
+    mark_port_failed(db_session, a.id, error_msg="durable")
+    return a.id
+
+
+def test_consecutive_failed_no_progress_streak(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """Streak counts trailing FAILED attempts at the same cursor; a cursor advance
+    (progress) resets it to 1, and a non-FAILED latest attempt resets it to 0."""
+    cc_pair, future_id = cc_pair_and_future
+    streak = count_consecutive_failed_port_attempts_no_progress
+
+    assert streak(db_session, cc_pair.id, future_id) == 0
+    _fail_port_at(db_session, cc_pair.id, future_id, "doc-5")
+    _fail_port_at(db_session, cc_pair.id, future_id, "doc-5")
+    assert streak(db_session, cc_pair.id, future_id) == 2
+    # an advanced cursor means progress was made -> streak resets to 1
+    _fail_port_at(db_session, cc_pair.id, future_id, "doc-9")
+    assert streak(db_session, cc_pair.id, future_id) == 1
+    # a SUCCESS latest attempt breaks the streak entirely
+    ok = create_port_attempt(
+        db_session, cc_pair.id, future_id, resume_from_doc_id="doc-9"
+    )
+    mark_port_in_progress(db_session, ok.id)
+    mark_port_succeeded(db_session, ok.id)
+    assert streak(db_session, cc_pair.id, future_id) == 0
+
+
+def test_check_for_port_backs_off_repeated_failures(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """A port stuck failing at the same cursor is not recreated within its backoff
+    window, but is once the backoff has elapsed."""
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    future_ss.use_port_flow = True
+    db_session.commit()
+
+    # two same-cursor failures -> streak 2 -> backoff = BASE seconds
+    _fail_port_at(db_session, cc_pair.id, future_id, "doc-1")
+    _fail_port_at(db_session, cc_pair.id, future_id, "doc-1")
+
+    # latest failure just happened -> still within backoff -> not recreated
+    result, celery_app = _run_check_for_port(cc_pair, future_id)
+    assert result == 0
+    celery_app.send_task.assert_not_called()
+
+    # backdate the latest failure past the backoff -> recreated
+    latest = get_latest_port_attempt(db_session, cc_pair.id, future_id)
+    assert latest is not None
+    latest.time_completed = datetime.now(timezone.utc) - timedelta(
+        seconds=port_task._PORT_RETRY_BACKOFF_BASE_S + 30
+    )
+    db_session.commit()
+    result, celery_app = _run_check_for_port(cc_pair, future_id)
+    assert result == 1
+    celery_app.send_task.assert_called_once()
+
+
+def _cleanup_pairs(db_session: Session, *pairs: ConnectorCredentialPair) -> None:
+    """Inline-cc_pair teardown (mirrors the cc_pair fixture): drop PortAttempts, then
+    cleanup_cc_pair each (shared-doc safe)."""
+    db_session.rollback()
+    for pair in pairs:
+        db_session.query(PortAttempt).filter(PortAttempt.cc_pair_id == pair.id).delete(
+            synchronize_session="fetch"
+        )
+    db_session.commit()
+    for pair in pairs:
+        cleanup_cc_pair(db_session, pair)
+
+
+def test_port_swap_ready_scoped_to_required_cc_pairs(
+    db_session: Session,
+    cc_pair_and_future: tuple[ConnectorCredentialPair, int],
+) -> None:
+    """Swap gate ignores an INVALID-only deferred doc (no deadlock) but STILL waits
+    on a required cc_pair's deferred doc (regression guard)."""
+    required_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+
+    # required pair's port is done (SUCCESS, none active)
+    attempt = create_port_attempt(db_session, required_pair.id, future_id)
+    mark_port_in_progress(db_session, attempt.id)
+    mark_port_succeeded(db_session, attempt.id)
+
+    invalid_pair = make_cc_pair(db_session)
+    try:
+        [invalid_doc] = _seed_cc_pair_documents(
+            db_session, invalid_pair, 1, unique=True
+        )
+        mark_document_synced_secondary_pending(invalid_doc, db_session)
+        invalid_pair.status = ConnectorCredentialPairStatus.INVALID
+        db_session.commit()
+
+        # not blocked by the INVALID-only deferred doc
+        assert _port_swap_ready(db_session, future_ss, [required_pair]) is True
+
+        # a deferred doc on the REQUIRED pair DOES still block the swap
+        [req_doc] = _seed_cc_pair_documents(db_session, required_pair, 1, unique=True)
+        mark_document_synced_secondary_pending(req_doc, db_session)
+        db_session.commit()
+        assert _port_swap_ready(db_session, future_ss, [required_pair]) is False
+    finally:
+        _cleanup_pairs(db_session, invalid_pair)
+
+
+def test_document_has_indexable_cc_pair(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    """Writer-side gate the sync task consults before deferring a FUTURE write:
+    True iff some owning cc_pair is indexable."""
+    pair_active = make_cc_pair(db_session)
+    pair_invalid = make_cc_pair(db_session)
+    try:
+        [doc_active] = _seed_cc_pair_documents(db_session, pair_active, 1, unique=True)
+        [doc_invalid] = _seed_cc_pair_documents(
+            db_session, pair_invalid, 1, unique=True
+        )
+        # doc_shared is owned by both the ACTIVE and the INVALID pair
+        [doc_shared] = _seed_cc_pair_documents(db_session, pair_active, 1, unique=True)
+        db_session.add(
+            DocumentByConnectorCredentialPair(
+                id=doc_shared,
+                connector_id=pair_invalid.connector_id,
+                credential_id=pair_invalid.credential_id,
+                has_been_indexed=True,
+            )
+        )
+        pair_invalid.status = ConnectorCredentialPairStatus.INVALID
+        db_session.commit()
+
+        assert document_has_indexable_cc_pair(db_session, doc_active) is True
+        assert document_has_indexable_cc_pair(db_session, doc_invalid) is False
+        assert document_has_indexable_cc_pair(db_session, doc_shared) is True
+        assert document_has_indexable_cc_pair(db_session, "no-such-doc") is False
+    finally:
+        _cleanup_pairs(db_session, pair_active, pair_invalid)

--- a/backend/tests/external_dependency_unit/db/test_sync_priority.py
+++ b/backend/tests/external_dependency_unit/db/test_sync_priority.py
@@ -1,0 +1,174 @@
+"""External dependency unit tests for the reindex-port sync-enqueue priority (T8/D9).
+
+Covers: the UNION select surfacing needs_sync + deferred docs (each self-tagged);
+the gate count including deferred-only docs; the any-FUTURE-port-in-progress
+pre-query; and the producer's per-doc priority (deferred doc LOW while a port runs,
+HIGH once it stops; needs_sync MEDIUM normally but LOW while a completed port's
+backlog drains) plus the expires= on every enqueue. The Celery send_task is mocked
+— we assert the producer's decision, not real dispatch.
+"""
+
+from collections.abc import Generator
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.background.celery.tasks.vespa.document_sync import (
+    generate_document_sync_tasks,
+)
+from onyx.configs.constants import OnyxCeleryPriority
+from onyx.db.document import (
+    construct_document_id_select_by_needs_sync_or_secondary_pending,
+)
+from onyx.db.document import count_documents_by_needs_sync
+from onyx.db.document import count_documents_by_needs_sync_or_secondary_pending
+from onyx.db.document import mark_document_as_modified
+from onyx.db.document import mark_document_synced_secondary_pending
+from onyx.db.models import ConnectorCredentialPair
+from onyx.db.models import Document as DbDocument
+from onyx.db.port_attempt import any_future_port_in_progress
+from onyx.db.port_attempt import create_port_attempt
+from onyx.db.port_attempt import mark_port_in_progress
+from onyx.db.port_attempt import mark_port_succeeded
+from onyx.kg.models import KGStage
+from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair_and_future
+from tests.external_dependency_unit.indexing_helpers import make_cc_pair
+from tests.external_dependency_unit.indexing_helpers import make_future_search_settings
+
+_DOC_PREFIX = "syncdoc-"
+
+
+@pytest.fixture
+def cc_pair_and_future(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> Generator[tuple[ConnectorCredentialPair, int], None, None]:
+    pair = make_cc_pair(db_session)
+    future_id = make_future_search_settings(db_session).id
+    try:
+        yield pair, future_id
+    finally:
+        cleanup_cc_pair_and_future(db_session, pair, future_id, doc_prefix=_DOC_PREFIX)
+
+
+def _make_doc(db_session: Session, doc_id: str) -> None:
+    db_session.add(
+        DbDocument(id=doc_id, semantic_id=doc_id, kg_stage=KGStage.NOT_STARTED)
+    )
+    db_session.commit()
+    mark_document_as_modified(doc_id, db_session)  # needs_sync
+
+
+def _run_generate(db_session: Session) -> dict[str, dict[str, int]]:
+    """Run the producer with mocked Celery/Redis; return {doc_id: {priority, expires}}
+    for this test's docs only (the select is tenant-global)."""
+    celery_app = MagicMock()
+    generate_document_sync_tasks(
+        MagicMock(),  # redis client
+        10**9,  # max_tasks (process everything)
+        celery_app,
+        db_session,
+        MagicMock(),  # lock
+        "test-tenant",
+    )
+    captured: dict[str, dict[str, int]] = {}
+    for call in celery_app.send_task.call_args_list:
+        doc_id = call.kwargs["kwargs"]["document_id"]
+        if doc_id.startswith(_DOC_PREFIX):
+            captured[doc_id] = {
+                "priority": call.kwargs["priority"],
+                "expires": call.kwargs["expires"],
+            }
+    return captured
+
+
+@pytest.mark.usefixtures("cc_pair_and_future")
+def test_select_needs_sync_or_secondary_pending_surfaces_both(
+    db_session: Session,
+) -> None:
+    _make_doc(db_session, f"{_DOC_PREFIX}A")  # needs_sync
+    _make_doc(db_session, f"{_DOC_PREFIX}B")
+    mark_document_synced_secondary_pending(f"{_DOC_PREFIX}B", db_session)  # deferred
+
+    stmt = construct_document_id_select_by_needs_sync_or_secondary_pending()
+    rows = {
+        (doc_id, flag)
+        for doc_id, flag in db_session.execute(stmt)
+        if doc_id.startswith(_DOC_PREFIX)
+    }
+    assert (f"{_DOC_PREFIX}A", False) in rows  # needs_sync leg, self-tagged False
+    assert (f"{_DOC_PREFIX}B", True) in rows  # deferred leg, self-tagged True
+
+
+@pytest.mark.usefixtures("cc_pair_and_future")
+def test_needs_sync_and_deferred_doc_tags_false(db_session: Session) -> None:
+    """A doc that is BOTH needs_sync and deferred surfaces once via the needs_sync
+    leg (tag False) -> real work wins, never under-prioritized to LOW."""
+    doc_id = f"{_DOC_PREFIX}C"
+    _make_doc(db_session, doc_id)  # needs_sync
+    mark_document_synced_secondary_pending(
+        doc_id, db_session
+    )  # deferred (needs_sync cleared)
+    mark_document_as_modified(doc_id, db_session)  # re-dirty -> needs_sync AND deferred
+
+    stmt = construct_document_id_select_by_needs_sync_or_secondary_pending()
+    rows = {(d, f) for d, f in db_session.execute(stmt) if d.startswith(_DOC_PREFIX)}
+    assert (doc_id, False) in rows
+    assert (doc_id, True) not in rows
+
+
+@pytest.mark.usefixtures("cc_pair_and_future")
+def test_count_or_includes_deferred_only(
+    db_session: Session,
+) -> None:
+    before_or = count_documents_by_needs_sync_or_secondary_pending(db_session)
+    before_needs_sync = count_documents_by_needs_sync(db_session)
+
+    _make_doc(db_session, f"{_DOC_PREFIX}B")
+    mark_document_synced_secondary_pending(f"{_DOC_PREFIX}B", db_session)  # deferred
+
+    # the OR-count sees the deferred doc; the plain needs_sync count does not
+    assert (
+        count_documents_by_needs_sync_or_secondary_pending(db_session) == before_or + 1
+    )
+    assert count_documents_by_needs_sync(db_session) == before_needs_sync
+
+
+def test_any_future_port_in_progress(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    cc_pair, future_id = cc_pair_and_future
+    assert any_future_port_in_progress(db_session) is False
+
+    attempt = create_port_attempt(db_session, cc_pair.id, future_id)
+    mark_port_in_progress(db_session, attempt.id)
+    assert any_future_port_in_progress(db_session) is True
+
+    mark_port_succeeded(db_session, attempt.id)
+    assert any_future_port_in_progress(db_session) is False
+
+
+def test_sync_priority_across_three_states(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    cc_pair, future_id = cc_pair_and_future
+    _make_doc(db_session, f"{_DOC_PREFIX}A")  # needs_sync
+    _make_doc(db_session, f"{_DOC_PREFIX}B")
+    mark_document_synced_secondary_pending(f"{_DOC_PREFIX}B", db_session)  # deferred
+
+    # port running: needs_sync stays MEDIUM, deferred drops to LOW
+    attempt = create_port_attempt(db_session, cc_pair.id, future_id)
+    mark_port_in_progress(db_session, attempt.id)
+    captured = _run_generate(db_session)
+    assert captured[f"{_DOC_PREFIX}A"]["priority"] == OnyxCeleryPriority.MEDIUM
+    assert captured[f"{_DOC_PREFIX}B"]["priority"] == OnyxCeleryPriority.LOW
+    assert captured[f"{_DOC_PREFIX}A"]["expires"] > 0
+    assert captured[f"{_DOC_PREFIX}B"]["expires"] > 0
+
+    # port stopped with a deferred backlog still pending: that drain is the swap
+    # gate, so the deferred doc goes HIGH and needs_sync yields to LOW
+    mark_port_succeeded(db_session, attempt.id)
+    captured = _run_generate(db_session)
+    assert captured[f"{_DOC_PREFIX}B"]["priority"] == OnyxCeleryPriority.HIGH
+    assert captured[f"{_DOC_PREFIX}A"]["priority"] == OnyxCeleryPriority.LOW

--- a/backend/tests/external_dependency_unit/indexing/test_port_reembed.py
+++ b/backend/tests/external_dependency_unit/indexing/test_port_reembed.py
@@ -1,0 +1,611 @@
+"""Tests for the reindex-port re-embedding (port_reembed).
+
+These cover the pure re-embed logic: strategy selection, rebuilding the semantic
+metadata tail, the embed-input recovery (the crux — stored content carries the
+keyword tail, but the embedded text used the semantic tail), and the minimal
+DocAwareChunk reconstruction that feeds that input to the embedder.
+
+The embedder is a pure function of its input text, so proving the input differs
+from the raw stored content (here) is equivalent to proving the resulting vector
+differs; the real-embedder path is exercised once the port task is wired.
+"""
+
+from typing import cast
+from unittest.mock import MagicMock
+
+import pytest
+
+from onyx.configs.constants import DocumentSource
+from onyx.configs.constants import RETURN_SEPARATOR
+from onyx.configs.model_configs import ASYM_PASSAGE_PREFIX
+from onyx.configs.model_configs import ASYM_QUERY_PREFIX
+from onyx.configs.model_configs import DEFAULT_DOCUMENT_ENCODER_MODEL
+from onyx.configs.model_configs import DOC_EMBEDDING_DIM
+from onyx.configs.model_configs import NORMALIZE_EMBEDDINGS
+from onyx.connectors.models import convert_metadata_dict_to_list_of_strings
+from onyx.connectors.models import convert_metadata_list_of_strings_to_dict
+from onyx.db.models import SearchSettings
+from onyx.document_index.chunk_content_enrichment import (
+    generate_enriched_content_for_chunk_embedding,
+)
+from onyx.document_index.interfaces_new import TenantState
+from onyx.document_index.opensearch.constants import DEFAULT_MAX_CHUNK_SIZE
+from onyx.document_index.opensearch.schema import DocumentChunkWithoutVectors
+from onyx.indexing.chunker import get_metadata_suffix_for_document_index
+from onyx.indexing.embedder import DefaultIndexingEmbedder
+from onyx.indexing.embedder import IndexingEmbedder
+from onyx.indexing.models import ChunkEmbedding
+from onyx.indexing.models import DocAwareChunk
+from onyx.indexing.models import IndexChunk
+from onyx.indexing.port_reembed import _bare_contents
+from onyx.indexing.port_reembed import _reconstruct_source_document
+from onyx.indexing.port_reembed import _stored_chunk_to_doc_aware
+from onyx.indexing.port_reembed import AugmentationReembedContext
+from onyx.indexing.port_reembed import re_embed_chunks
+from onyx.indexing.port_reembed import rebuild_semantic_tail
+from onyx.indexing.port_reembed import recover_embedding_input
+from onyx.indexing.port_reembed import ReembedStrategy
+from onyx.indexing.port_reembed import select_reembed_strategy
+from onyx.natural_language_processing.utils import BaseTokenizer
+from onyx.utils.pydantic_util import shallow_model_dump
+from shared_configs.configs import DOC_EMBEDDING_CONTEXT_SIZE
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
+
+
+def _stored_chunk(
+    content: str,
+    *,
+    document_id: str = "doc-1",
+    metadata_suffix: str | None = None,
+    metadata_list: list[str] | None = None,
+    title: str | None = "Doc Title",
+    chunk_index: int = 0,
+    doc_summary: str = "",
+    chunk_context: str = "",
+    max_chunk_size: int = 512,
+) -> DocumentChunkWithoutVectors:
+    return DocumentChunkWithoutVectors(
+        document_id=document_id,
+        chunk_index=chunk_index,
+        content=content,
+        max_chunk_size=max_chunk_size,
+        source_type=DocumentSource.FILE.value,
+        metadata_list=metadata_list,
+        metadata_suffix=metadata_suffix,
+        title=title,
+        public=True,
+        access_control_list=[],
+        global_boost=0,
+        semantic_identifier="Doc semantic id",
+        blurb="blurb",
+        doc_summary=doc_summary,
+        chunk_context=chunk_context,
+        tenant_id=TenantState(tenant_id=POSTGRES_DEFAULT_SCHEMA, multitenant=False),
+    )
+
+
+class _CharTokenizer:
+    """One-token-per-char BaseTokenizer stand-in: exercises the metadata-budget skip
+    without loading a real model (char count >= token count, a conservative proxy)."""
+
+    def encode(self, text: str) -> list[int]:
+        return [ord(ch) for ch in text]
+
+
+_TOKENIZER = cast(BaseTokenizer, _CharTokenizer())
+
+
+def _vec(text: str) -> list[float]:
+    """A deterministic, content-dependent fake embedding: different input text
+    yields a different vector, so a test can prove the embedding input changed."""
+    return [float(len(text)), float(sum(ord(ch) for ch in text) % 1000)]
+
+
+class _ContentVecEmbedder:
+    """Fake embedder whose vectors depend on the actual embedding input, so tests
+    can assert that stripping/re-enriching changed what got embedded."""
+
+    def embed_chunks(self, chunks: list[DocAwareChunk]) -> list[IndexChunk]:
+        out = []
+        for chunk in chunks:
+            text = generate_enriched_content_for_chunk_embedding(chunk)
+            title = chunk.source_document.get_title_for_document_index()
+            out.append(
+                IndexChunk.model_construct(
+                    **shallow_model_dump(chunk),
+                    embeddings=ChunkEmbedding(
+                        full_embedding=_vec(text), mini_chunk_embeddings=[]
+                    ),
+                    title_embedding=_vec(title) if title else None,
+                )
+            )
+        return out
+
+
+def _ss(
+    enable_contextual_rag: bool = False,
+    contextual_rag_model_configuration_id: int | None = None,
+) -> SearchSettings:
+    return SearchSettings(
+        enable_contextual_rag=enable_contextual_rag,
+        contextual_rag_model_configuration_id=contextual_rag_model_configuration_id,
+    )
+
+
+def test_select_reembed_strategy() -> None:
+    base = _ss()
+    assert select_reembed_strategy(base, _ss()) is ReembedStrategy.MODEL_ONLY
+    assert (
+        select_reembed_strategy(base, _ss(enable_contextual_rag=True))
+        is ReembedStrategy.AUGMENTATION
+    )
+    # RAG on in both, model changed -> AUGMENTATION (re-enrich under new LLM)
+    assert (
+        select_reembed_strategy(
+            _ss(enable_contextual_rag=True, contextual_rag_model_configuration_id=1),
+            _ss(enable_contextual_rag=True, contextual_rag_model_configuration_id=2),
+        )
+        is ReembedStrategy.AUGMENTATION
+    )
+    # RAG on in both, same model -> only the embedder could differ -> MODEL_ONLY
+    assert (
+        select_reembed_strategy(
+            _ss(enable_contextual_rag=True, contextual_rag_model_configuration_id=1),
+            _ss(enable_contextual_rag=True, contextual_rag_model_configuration_id=1),
+        )
+        is ReembedStrategy.MODEL_ONLY
+    )
+    # RAG OFF in both: a stale model-id difference is irrelevant (no enrichment in
+    # either index) -> MODEL_ONLY, not a spurious AUGMENTATION.
+    assert (
+        select_reembed_strategy(
+            _ss(enable_contextual_rag=False, contextual_rag_model_configuration_id=1),
+            _ss(enable_contextual_rag=False, contextual_rag_model_configuration_id=2),
+        )
+        is ReembedStrategy.MODEL_ONLY
+    )
+
+
+def test_rebuild_semantic_tail() -> None:
+    metadata_list = convert_metadata_dict_to_list_of_strings(
+        {"author": "Jane Doe", "team": "finance"}
+    )
+    expected, _ = get_metadata_suffix_for_document_index(
+        convert_metadata_list_of_strings_to_dict(metadata_list), include_separator=True
+    )
+    assert rebuild_semantic_tail(
+        _stored_chunk("body", metadata_list=metadata_list)
+    ) == (expected)
+    assert rebuild_semantic_tail(_stored_chunk("body", metadata_list=None)) == ""
+
+
+def test_recover_embedding_input_swaps_semantic_tail() -> None:
+    metadata_list = convert_metadata_dict_to_list_of_strings(
+        {"author": "Jane Doe", "team": "finance"}
+    )
+    semantic, keyword = get_metadata_suffix_for_document_index(
+        convert_metadata_list_of_strings_to_dict(metadata_list), include_separator=True
+    )
+    assert semantic != keyword  # precondition: the two tails genuinely differ
+
+    # stored content carries the KEYWORD tail
+    chunk = _stored_chunk(
+        "the body text" + keyword,
+        metadata_suffix=keyword,
+        metadata_list=metadata_list,
+    )
+    embed_input = recover_embedding_input(chunk, _TOKENIZER)
+    assert embed_input == "the body text" + semantic
+    # the crux: the embedding input is NOT the stored (keyword-tailed) content
+    assert embed_input != chunk.content
+
+    # no suffix (chunker dropped it) -> content passes through unchanged
+    plain = _stored_chunk("just body", metadata_suffix=None, metadata_list=None)
+    assert recover_embedding_input(plain, _TOKENIZER) == "just body"
+
+    # no keyword tail was glued in (empty metadata_suffix) -> don't add a tail,
+    # even if metadata_list is present
+    no_tail = _stored_chunk(
+        "just body", metadata_suffix=None, metadata_list=metadata_list
+    )
+    assert recover_embedding_input(no_tail, _TOKENIZER) == "just body"
+
+    # content doesn't actually end with the stored suffix -> embed as-is, never
+    # double-append a tail
+    mismatched = _stored_chunk(
+        "body without the tail",
+        metadata_suffix="\n\r\nMetadata: x",
+        metadata_list=metadata_list,
+    )
+    assert recover_embedding_input(mismatched, _TOKENIZER) == "body without the tail"
+
+
+def test_skip_threshold_budget_matches_index_time() -> None:
+    # recover_embedding_input reconstructs the index-time metadata-tail skip using
+    # the stored max_chunk_size as the budget. That equals the chunker's index-time
+    # chunk_token_limit only because ported (regular) chunks have
+    # max_chunk_size == DEFAULT_MAX_CHUNK_SIZE == DOC_EMBEDDING_CONTEXT_SIZE. These
+    # constants live in separate modules; if they drift the skip threshold silently
+    # diverges, so pin the equality here.
+    assert DEFAULT_MAX_CHUNK_SIZE == DOC_EMBEDDING_CONTEXT_SIZE
+
+
+def test_recover_embedding_input_skips_oversized_metadata_tail() -> None:
+    """Oversized metadata: indexing embedded the chunk without the semantic tail but
+    still stored the keyword tail. Recovery must reproduce that skip — strip the
+    keyword tail and stop, not re-append the semantic tail the vector never saw."""
+    metadata_list = convert_metadata_dict_to_list_of_strings(
+        {"author": "Jane Doe", "team": "finance"}
+    )
+    semantic, keyword = get_metadata_suffix_for_document_index(
+        convert_metadata_list_of_strings_to_dict(metadata_list), include_separator=True
+    )
+    # Tiny budget so the tail exceeds MAX_METADATA_PERCENTAGE — the index-time
+    # condition that drops it from the embedding.
+    chunk = _stored_chunk(
+        "the body text" + keyword,
+        metadata_suffix=keyword,
+        metadata_list=metadata_list,
+        max_chunk_size=8,
+    )
+    assert recover_embedding_input(chunk, _TOKENIZER) == "the body text"
+
+
+def test_to_doc_aware_chunk_feeds_embed_input() -> None:
+    """The reconstructed DocAwareChunk makes the embedder embed exactly the
+    recovered embedding input (not the stored content), and carries the title
+    for the title vector with a semantic_identifier fallback."""
+    chunk = _stored_chunk("body", title="My Title")
+    embed_input = recover_embedding_input(chunk, _TOKENIZER)
+    doc_aware = _stored_chunk_to_doc_aware(chunk, embed_input)
+
+    assert generate_enriched_content_for_chunk_embedding(doc_aware) == embed_input
+    assert doc_aware.source_document.id == chunk.document_id
+    assert doc_aware.source_document.get_title_for_document_index() == "My Title"
+    assert doc_aware.chunk_id == chunk.chunk_index
+
+    # stored title None == the source title was empty == no title embedding;
+    # it must NOT fall back to semantic_identifier.
+    no_title = _stored_chunk("body", title=None)
+    da = _stored_chunk_to_doc_aware(no_title, "body")
+    assert da.source_document.get_title_for_document_index() is None
+
+
+def test_augmentation_requires_context() -> None:
+    with pytest.raises(ValueError):
+        re_embed_chunks(
+            [_stored_chunk("body")], ReembedStrategy.AUGMENTATION, MagicMock()
+        )
+
+
+def test_model_only_requires_present_tokenizer() -> None:
+    # The skip check must run against the PRESENT tokenizer; refusing None guards
+    # against silently falling back to the FUTURE embedder's tokenizer.
+    with pytest.raises(ValueError):
+        re_embed_chunks(
+            [_stored_chunk("body")], ReembedStrategy.MODEL_ONLY, MagicMock()
+        )
+
+
+def _augmented_stored_chunk() -> tuple[DocumentChunkWithoutVectors, str]:
+    """A stored chunk whose content carries title prefix + doc summary +
+    chunk context + keyword metadata tail. Returns (chunk, bare_text)."""
+    metadata_list = convert_metadata_dict_to_list_of_strings({"author": "Jane"})
+    _semantic, keyword = get_metadata_suffix_for_document_index(
+        convert_metadata_list_of_strings_to_dict(metadata_list), include_separator=True
+    )
+    title = "My Title"
+    doc_summary = "DOCSUM. "
+    chunk_context = " CTX."
+    bare = "the body text"
+    content = f"{title}{RETURN_SEPARATOR}{doc_summary}{bare}{chunk_context}{keyword}"
+    chunk = _stored_chunk(
+        content,
+        metadata_suffix=keyword,
+        metadata_list=metadata_list,
+        title=title,
+        doc_summary=doc_summary,
+        chunk_context=chunk_context,
+    )
+    return chunk, bare
+
+
+def test_strip_stored_chunk_to_bare_content() -> None:
+    """cleanup strips title prefix, metadata tail, doc summary and chunk context,
+    leaving only the original chunk body."""
+    chunk, bare = _augmented_stored_chunk()
+    assert _bare_contents([chunk]) == [bare]
+
+
+def test_reconstruct_document_text_from_chunks() -> None:
+    """Doc text is reconstructed by joining the bare chunks in chunk-index order."""
+    c0 = _stored_chunk("first part", chunk_index=0, title="T")
+    c1 = _stored_chunk("second part", chunk_index=1, title="T")
+    # pass out of order to prove the helper sorts by chunk_index
+    doc = _reconstruct_source_document([c1, c0], ["second part", "first part"])
+    assert doc.id == "doc-1"
+    assert doc.get_text_content() == "first part second part"
+    assert doc.get_title_for_document_index() == "T"
+
+
+def test_augmentation_strip_off_reembeds_bare() -> None:
+    """RAG on -> off: the FUTURE chunk drops doc_summary/chunk_context from both
+    the stored content and the embedding input, and clears those fields. The
+    embedding input (hence the vector) differs from the MODEL_ONLY input, which
+    keeps the augmentation glued in."""
+    chunk, bare = _augmented_stored_chunk()
+    keyword = chunk.metadata_suffix or ""
+    semantic = rebuild_semantic_tail(chunk)
+
+    ctx = AugmentationReembedContext(future_enable_contextual_rag=False)
+    [result] = re_embed_chunks(
+        [chunk],
+        ReembedStrategy.AUGMENTATION,
+        cast(IndexingEmbedder, _ContentVecEmbedder()),
+        augmentation_ctx=ctx,
+    )
+
+    # stored (BM25) content rebuilt without the contextual-RAG augmentation
+    assert result.content == f"My Title{RETURN_SEPARATOR}{bare}{keyword}"
+    assert result.doc_summary == ""
+    assert result.chunk_context == ""
+
+    # the embedded text was title_prefix + bare + semantic tail (no summary/context)
+    strip_embed_input = f"My Title{RETURN_SEPARATOR}{bare}{semantic}"
+    assert result.content_vector == _vec(strip_embed_input)
+    # ... and that genuinely differs from the MODEL_ONLY embed input, which
+    # keeps the doc summary + chunk context.
+    model_only_embed_input = recover_embedding_input(chunk, _TOKENIZER)
+    assert result.content_vector != _vec(model_only_embed_input)
+    # non-augmentation fields are preserved
+    assert result.metadata_suffix == keyword
+    assert result.title == chunk.title
+
+
+def test_augmentation_enrich_on_generates_and_reembeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RAG off -> on: the bare chunk is re-enriched under the FUTURE LLM (stubbed
+    here), and the new doc_summary/chunk_context land in the stored content, the
+    stored fields, and the embedding input. The vector differs from the strip
+    path because the embedded text now carries the regenerated summaries."""
+
+    # Stub the contextual-RAG enrichment (the LLM call is the indexing pipeline's
+    # own tested surface; here we prove the port's strip -> enrich -> re-glue ->
+    # embed wiring). The lazy import inside _augmentation_reembed resolves this.
+    def _fake_enrich(
+        chunks: list[DocAwareChunk], **_kwargs: object
+    ) -> list[DocAwareChunk]:
+        for c in chunks:
+            c.doc_summary = "SUMMARY. "
+            c.chunk_context = " CONTEXT."
+        return chunks
+
+    monkeypatch.setattr(
+        "onyx.indexing.indexing_pipeline.add_contextual_summaries", _fake_enrich
+    )
+
+    bare = "the body text"
+    metadata_list = convert_metadata_dict_to_list_of_strings({"author": "Jane"})
+    _semantic, keyword = get_metadata_suffix_for_document_index(
+        convert_metadata_list_of_strings_to_dict(metadata_list), include_separator=True
+    )
+    # PRESENT had RAG off: no doc_summary/chunk_context glued in.
+    chunk = _stored_chunk(
+        f"My Title{RETURN_SEPARATOR}{bare}{keyword}",
+        metadata_suffix=keyword,
+        metadata_list=metadata_list,
+        title="My Title",
+    )
+    semantic = rebuild_semantic_tail(chunk)
+
+    ctx = AugmentationReembedContext(
+        future_enable_contextual_rag=True,
+        llm=MagicMock(),
+        tokenizer=MagicMock(),
+        chunk_token_limit=128,
+        contextual_rag_reserved_tokens=512,
+    )
+    [result] = re_embed_chunks(
+        [chunk],
+        ReembedStrategy.AUGMENTATION,
+        cast(IndexingEmbedder, _ContentVecEmbedder()),
+        augmentation_ctx=ctx,
+    )
+
+    # the regenerated summaries are stored both as fields and glued into content
+    assert result.doc_summary == "SUMMARY. "
+    assert result.chunk_context == " CONTEXT."
+    assert (
+        result.content == f"My Title{RETURN_SEPARATOR}SUMMARY. {bare} CONTEXT.{keyword}"
+    )
+
+    # the embedded text carries the new summaries; vector differs from strip-only
+    enrich_embed_input = f"My Title{RETURN_SEPARATOR}SUMMARY. {bare} CONTEXT.{semantic}"
+    assert result.content_vector == _vec(enrich_embed_input)
+    strip_embed_input = f"My Title{RETURN_SEPARATOR}{bare}{semantic}"
+    assert result.content_vector != _vec(strip_embed_input)
+
+
+def test_augmentation_mixed_docs_enrich_per_document(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One AUGMENTATION call may span documents (the port batches them): each
+    chunk must be enriched against its OWN document's reconstructed text, and
+    output order must match input order."""
+
+    def _fake_enrich(
+        chunks: list[DocAwareChunk], **_kwargs: object
+    ) -> list[DocAwareChunk]:
+        for c in chunks:
+            doc = c.source_document
+            c.doc_summary = f"[{doc.id}:{doc.get_text_content()}] "
+        return chunks
+
+    monkeypatch.setattr(
+        "onyx.indexing.indexing_pipeline.add_contextual_summaries", _fake_enrich
+    )
+
+    a0 = _stored_chunk("a-first", document_id="doc-a", chunk_index=0, title=None)
+    a1 = _stored_chunk("a-second", document_id="doc-a", chunk_index=1, title=None)
+    b0 = _stored_chunk("b-only", document_id="doc-b", chunk_index=0, title=None)
+
+    ctx = AugmentationReembedContext(
+        future_enable_contextual_rag=True,
+        llm=MagicMock(),
+        tokenizer=MagicMock(),
+        chunk_token_limit=128,
+        contextual_rag_reserved_tokens=512,
+    )
+    # interleaved on purpose: the per-doc grouping must not rely on input order
+    results = re_embed_chunks(
+        [a0, b0, a1],
+        ReembedStrategy.AUGMENTATION,
+        cast(IndexingEmbedder, _ContentVecEmbedder()),
+        augmentation_ctx=ctx,
+    )
+
+    assert [(r.document_id, r.chunk_index) for r in results] == [
+        ("doc-a", 0),
+        ("doc-b", 0),
+        ("doc-a", 1),
+    ]
+    # each chunk saw its own document's reconstructed text, not the whole batch's
+    assert results[0].doc_summary == "[doc-a:a-first a-second] "
+    assert results[1].doc_summary == "[doc-b:b-only] "
+    assert results[2].doc_summary == "[doc-a:a-first a-second] "
+
+
+def test_reembed_pairs_embeddings_by_identity_not_position() -> None:
+    """The embedder may return chunks in a different order than it was given (e.g.
+    grouped by document for batching); each stored chunk must still get ITS OWN
+    vector — paired by (document_id, chunk_index), not list position. A positional
+    zip would silently bind a chunk's id to another chunk's vector."""
+
+    class _ReversingEmbedder:
+        """Content-dependent vectors (like _ContentVecEmbedder) but returns the list
+        REVERSED, simulating an embedder that reorders its output."""
+
+        def embed_chunks(self, chunks: list[DocAwareChunk]) -> list[IndexChunk]:
+            out = [
+                IndexChunk.model_construct(
+                    **shallow_model_dump(chunk),
+                    embeddings=ChunkEmbedding(
+                        full_embedding=_vec(
+                            generate_enriched_content_for_chunk_embedding(chunk)
+                        ),
+                        mini_chunk_embeddings=[],
+                    ),
+                    title_embedding=None,
+                )
+                for chunk in chunks
+            ]
+            return list(reversed(out))
+
+    # plain chunks (no title/metadata) so the embed input == content
+    c0 = _stored_chunk("alpha first", document_id="doc-a", chunk_index=0, title=None)
+    c1 = _stored_chunk("beta only", document_id="doc-b", chunk_index=0, title=None)
+    c2 = _stored_chunk("alpha second", document_id="doc-a", chunk_index=1, title=None)
+
+    results = re_embed_chunks(
+        [c0, c1, c2],
+        ReembedStrategy.MODEL_ONLY,
+        cast(IndexingEmbedder, _ReversingEmbedder()),
+        present_tokenizer=_TOKENIZER,
+    )
+
+    # output follows stored order...
+    assert [(r.document_id, r.chunk_index) for r in results] == [
+        ("doc-a", 0),
+        ("doc-b", 0),
+        ("doc-a", 1),
+    ]
+    # ...and each chunk carries ITS OWN content's vector despite the reversed output
+    # (a positional zip would give c0 the vector of c2, etc.).
+    for result, stored in zip(results, [c0, c1, c2]):
+        assert result.content_vector == _vec(stored.content)
+
+
+def test_re_embed_preserves_all_fields_swaps_only_vectors() -> None:
+    """re_embed_chunks returns the whole stored chunk as a DocumentChunk with only
+    content_vector/title_vector recomputed — every other field is copied through
+    (so the FUTURE write is a faithful copy with new embeddings). Empty in -> out."""
+    metadata_list = convert_metadata_dict_to_list_of_strings({"author": "Jane"})
+    stored = _stored_chunk(
+        "body text", title="My Title", metadata_list=metadata_list, chunk_index=3
+    )
+    fake_cv, fake_tv = [0.5, 0.5], [0.9, 0.9]
+
+    class _FakeEmbedder:
+        def embed_chunks(self, chunks: list[DocAwareChunk]) -> list[IndexChunk]:
+            return [
+                IndexChunk.model_construct(
+                    **shallow_model_dump(chunk),
+                    embeddings=ChunkEmbedding(
+                        full_embedding=fake_cv, mini_chunk_embeddings=[]
+                    ),
+                    title_embedding=fake_tv,
+                )
+                for chunk in chunks
+            ]
+
+    embedder = cast(IndexingEmbedder, _FakeEmbedder())
+    assert re_embed_chunks([], ReembedStrategy.MODEL_ONLY, embedder) == []
+
+    [result] = re_embed_chunks(
+        [stored], ReembedStrategy.MODEL_ONLY, embedder, present_tokenizer=_TOKENIZER
+    )
+
+    # only the two vectors are new
+    assert result.content_vector == fake_cv
+    assert result.title_vector == fake_tv
+    # every other field is the stored chunk's, unchanged
+    for field in DocumentChunkWithoutVectors.model_fields:
+        assert getattr(result, field) == getattr(stored, field), field
+
+
+def test_model_only_reembed_vector_differs_from_naive_stored_content() -> None:
+    """With a REAL embedder, the MODEL_ONLY path embeds the recovered input
+    (semantic metadata tail) which yields a DIFFERENT vector than naively
+    embedding the raw stored content (keyword tail). Proves the tail swap matters
+    end-to-end, not just under the fake embedder."""
+    embedder = DefaultIndexingEmbedder(
+        model_name=DEFAULT_DOCUMENT_ENCODER_MODEL,
+        normalize=NORMALIZE_EMBEDDINGS,
+        query_prefix=ASYM_QUERY_PREFIX,
+        passage_prefix=ASYM_PASSAGE_PREFIX,
+        provider_type=None,
+    )
+
+    metadata_list = convert_metadata_dict_to_list_of_strings(
+        {"author": "Jane Doe", "team": "finance"}
+    )
+    semantic, keyword = get_metadata_suffix_for_document_index(
+        convert_metadata_list_of_strings_to_dict(metadata_list), include_separator=True
+    )
+    assert semantic != keyword  # precondition: the two tails genuinely differ
+
+    # stored content carries the KEYWORD tail (as indexing wrote it)
+    chunk = _stored_chunk(
+        "the body text" + keyword,
+        metadata_suffix=keyword,
+        metadata_list=metadata_list,
+    )
+
+    # MODEL_ONLY re-embed: input is the recovered (semantic-tail) text.
+    [result] = re_embed_chunks(
+        [chunk],
+        ReembedStrategy.MODEL_ONLY,
+        cast(IndexingEmbedder, embedder),
+        present_tokenizer=_TOKENIZER,
+    )
+
+    # Naive: embed the RAW stored content (keyword tail) with the SAME embedder.
+    naive_doc_aware = _stored_chunk_to_doc_aware(chunk, chunk.content)
+    [naive_index_chunk] = embedder.embed_chunks([naive_doc_aware])
+    naive_vector = naive_index_chunk.embeddings.full_embedding
+
+    # the crux: the recovered-input vector differs from the naive raw-content vector
+    # (field preservation is covered by the fast fake-embedder test above).
+    assert result.content_vector != naive_vector
+    assert len(result.content_vector) == DOC_EMBEDDING_DIM

--- a/backend/tests/external_dependency_unit/indexing_helpers.py
+++ b/backend/tests/external_dependency_unit/indexing_helpers.py
@@ -19,8 +19,10 @@ from onyx.configs.constants import FileOrigin
 from onyx.connectors.models import Document
 from onyx.connectors.models import InputType
 from onyx.connectors.models import TextSection
+from onyx.context.search.models import SavedSearchSettings
 from onyx.db.enums import AccessType
 from onyx.db.enums import ConnectorCredentialPairStatus
+from onyx.db.enums import IndexModelStatus
 from onyx.db.file_record import get_filerecord_by_file_id_optional
 from onyx.db.models import Connector
 from onyx.db.models import ConnectorCredentialPair
@@ -28,7 +30,12 @@ from onyx.db.models import Credential
 from onyx.db.models import Document as DBDocument
 from onyx.db.models import DocumentByConnectorCredentialPair
 from onyx.db.models import FileRecord
+from onyx.db.models import IndexAttempt
+from onyx.db.models import SearchSettings
+from onyx.db.search_settings import create_search_settings
+from onyx.db.search_settings import get_current_search_settings
 from onyx.file_store.file_store import get_default_file_store
+from onyx.kg.models import KGStage
 
 
 def make_doc(
@@ -76,14 +83,18 @@ def get_filerecord(db_session: Session, file_id: str) -> FileRecord | None:
     return get_filerecord_by_file_id_optional(file_id=file_id, db_session=db_session)
 
 
-def make_cc_pair(db_session: Session) -> ConnectorCredentialPair:
+def make_cc_pair(
+    db_session: Session,
+    source: DocumentSource = DocumentSource.MOCK_CONNECTOR,
+) -> ConnectorCredentialPair:
     """Create a Connector + Credential + ConnectorCredentialPair for a test.
 
-    All names are UUID-suffixed so parallel test runs don't collide.
+    All names are UUID-suffixed so parallel test runs don't collide. Pass `source`
+    to build a non-standard pair (e.g. INGESTION_API for push-based-pair tests).
     """
     connector = Connector(
         name=f"test-connector-{uuid4().hex[:8]}",
-        source=DocumentSource.MOCK_CONNECTOR,
+        source=source,
         input_type=InputType.LOAD_STATE,
         connector_specific_config={},
         refresh_freq=None,
@@ -94,7 +105,7 @@ def make_cc_pair(db_session: Session) -> ConnectorCredentialPair:
     db_session.flush()
 
     credential = Credential(
-        source=DocumentSource.MOCK_CONNECTOR,
+        source=source,
         credential_json={},
     )
     db_session.add(credential)
@@ -188,3 +199,89 @@ def cleanup_cc_pair(db_session: Session, pair: ConnectorCredentialPair) -> None:
         synchronize_session="fetch"
     )
     db_session.commit()
+
+
+def make_future_search_settings(
+    db_session: Session,
+    *,
+    status: IndexModelStatus = IndexModelStatus.FUTURE,
+    use_port_flow: bool = False,
+) -> SearchSettings:
+    """An isolated secondary SearchSettings cloned from the live PRESENT row with a
+    unique index_name, so the tenant-global port/count/cursor helpers see only this
+    test's rows. `use_port_flow` is set explicitly (default False) so the fixture
+    never inherits the live PRESENT row's flag; pass `status=PAST` for round-trip
+    tests that must not collide with concurrent FUTUREs.
+    """
+    present = get_current_search_settings(db_session)
+    saved = SavedSearchSettings.from_db_model(present).model_copy(
+        update={"index_name": f"test_future_{uuid4().hex[:8]}"}
+    )
+    return create_search_settings(
+        saved, db_session, status=status, use_port_flow=use_port_flow
+    )
+
+
+def seed_cc_pair_documents(
+    db_session: Session,
+    cc_pair: ConnectorCredentialPair,
+    count: int,
+    *,
+    prefix: str = "portdoc-",
+    unique: bool = False,
+) -> list[str]:
+    """Create `count` documents linked to the cc_pair; returns their ids, sorted.
+    `unique=True` adds a random suffix so a test seeding a real index across runs
+    never collides."""
+    if unique:
+        doc_ids = sorted(
+            f"{prefix}{i:03d}-{uuid4().hex[:6]}" for i in range(1, count + 1)
+        )
+    else:
+        doc_ids = [f"{prefix}{i:03d}" for i in range(1, count + 1)]
+    for doc_id in doc_ids:
+        db_session.add(
+            DBDocument(id=doc_id, semantic_id=doc_id, kg_stage=KGStage.NOT_STARTED)
+        )
+    db_session.flush()
+    for doc_id in doc_ids:
+        db_session.add(
+            DocumentByConnectorCredentialPair(
+                id=doc_id,
+                connector_id=cc_pair.connector_id,
+                credential_id=cc_pair.credential_id,
+                has_been_indexed=True,
+            )
+        )
+    db_session.commit()
+    return doc_ids
+
+
+def cleanup_cc_pair_and_future(
+    db_session: Session,
+    pair: ConnectorCredentialPair,
+    future_id: int,
+    *,
+    doc_prefix: str | None = None,
+) -> None:
+    """Teardown for the cc_pair + isolated FUTURE settings fixtures.
+
+    Deleting the FUTURE SearchSettings cascades its PortAttempts (FK
+    ondelete=CASCADE), so they need no explicit delete. `doc_prefix` clears any
+    unlinked test docs that cleanup_cc_pair (which only removes cc_pair-linked
+    docs) won't reach. Rolls back first so a failed test's aborted transaction
+    doesn't block the cleanup queries.
+    """
+    db_session.rollback()
+    if doc_prefix is not None:
+        db_session.query(DBDocument).filter(
+            DBDocument.id.like(f"{doc_prefix}%")
+        ).delete(synchronize_session="fetch")
+    db_session.query(IndexAttempt).filter(
+        IndexAttempt.connector_credential_pair_id == pair.id
+    ).delete(synchronize_session="fetch")
+    db_session.query(SearchSettings).filter(SearchSettings.id == future_id).delete(
+        synchronize_session="fetch"
+    )
+    db_session.commit()
+    cleanup_cc_pair(db_session, pair)

--- a/backend/tests/external_dependency_unit/opensearch/test_opensearch_client.py
+++ b/backend/tests/external_dependency_unit/opensearch/test_opensearch_client.py
@@ -832,8 +832,6 @@ class TestOpenSearchClient:
             use_create_only=True,
         )
 
-        # FIX: the stale port write did not clobber. Fresh content and the
-        # revoked ACL both survive -- the victim stays revoked.
         after = test_client.get_document(chunk_id)
         assert after.content == "live-fresh"
         assert after.access_control_list == []

--- a/backend/tests/external_dependency_unit/opensearch/test_opensearch_client.py
+++ b/backend/tests/external_dependency_unit/opensearch/test_opensearch_client.py
@@ -24,6 +24,7 @@ from onyx.access.utils import prefix_user_email
 from onyx.configs.constants import DocumentSource
 from onyx.context.search.models import IndexFilters
 from onyx.document_index.interfaces_new import TenantState
+from onyx.document_index.opensearch.client import OpenSearchDocumentMissingError
 from onyx.document_index.opensearch.client import OpenSearchIndexClient
 from onyx.document_index.opensearch.client import OpenSearchIndexError
 from onyx.document_index.opensearch.client import OpenSearchServerSideTimeout
@@ -36,6 +37,7 @@ from onyx.document_index.opensearch.constants import OpenSearchSearchType
 from onyx.document_index.opensearch.opensearch_document_index import (
     generate_opensearch_filtered_access_control_list,
 )
+from onyx.document_index.opensearch.schema import ACCESS_CONTROL_LIST_FIELD_NAME
 from onyx.document_index.opensearch.schema import CONTENT_FIELD_NAME
 from onyx.document_index.opensearch.schema import DocumentChunk
 from onyx.document_index.opensearch.schema import DocumentChunkWithoutVectors
@@ -746,6 +748,181 @@ class TestOpenSearchClient:
         # Under test and postcondition.
         with pytest.raises(OpenSearchIndexError, match="does not match"):
             test_client.bulk_index_documents(documents=docs, tenant_state=tenant_state)
+
+    def test_port_create_only_yields_to_forward_write(
+        self, test_client: OpenSearchIndexClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The reindex port writes create-only, so a stale backlog write can
+        NEVER overwrite a chunk the forward/live path already owns in FUTURE.
+
+        The forward path indexes fresh content (internal versioning) and the
+        ACL/metadata sync revokes access (internal partial update). A stale port
+        snapshot that still grants access then tries to write the same chunk --
+        create-only makes that a benign 409, so the fresh content and the revoked
+        ACL both survive. (Previously the port used external versioning, whose
+        epoch-ms version beat the internal one and re-applied the revoked ACL --
+        the security bug this closes.)
+        """
+        _patch_global_tenant_state(monkeypatch, False)
+        tenant_state = TenantState(tenant_id=POSTGRES_DEFAULT_SCHEMA, multitenant=False)
+        mappings = DocumentSchema.get_document_schema(
+            vector_dimension=128, multitenant=tenant_state.multitenant
+        )
+        settings = DocumentSchema.get_index_settings_based_on_environment()
+        test_client.create_index(mappings=mappings, settings=settings)
+
+        doc_id = "acl-clobber-doc"
+        victim = "victim@example.com"
+        chunk_id = get_opensearch_doc_chunk_id(
+            tenant_state=tenant_state,
+            document_id=doc_id,
+            chunk_index=0,
+            max_chunk_size=DEFAULT_MAX_CHUNK_SIZE,
+        )
+        granted = DocumentAccess.build(
+            user_emails=[victim],
+            user_groups=[],
+            external_user_emails=[],
+            external_user_group_ids=[],
+            is_public=False,
+        )
+
+        # The stale PRESENT snapshot the port will later replay: stale content,
+        # access still GRANTED to the victim.
+        stale_snapshot = _create_test_document_chunk(
+            document_id=doc_id,
+            content="stale-snapshot",
+            tenant_state=tenant_state,
+            document_access=granted,
+            last_updated=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        )
+
+        # 1) Forward/live indexing writes fresh content (internal versioning).
+        live = _create_test_document_chunk(
+            document_id=doc_id,
+            content="live-fresh",
+            tenant_state=tenant_state,
+            document_access=granted,
+            last_updated=datetime.now(timezone.utc).replace(microsecond=0),
+        )
+        test_client.bulk_index_documents(
+            documents=[live],
+            tenant_state=tenant_state,
+            update_if_exists=True,
+        )
+
+        # 2) Live ACL sync REVOKES the victim (internal partial update).
+        test_client.bulk_update_documents(
+            document_chunk_ids=[chunk_id],
+            properties_to_update={ACCESS_CONTROL_LIST_FIELD_NAME: []},
+        )
+        revoked = test_client.get_document(chunk_id)
+        assert revoked.content == "live-fresh"
+        assert revoked.access_control_list == []  # access really gone
+        version_before_port = test_client._client.get(
+            index=test_client._index_name, id=chunk_id
+        )["_version"]
+
+        # 3) The stale port write lands AFTER, now CREATE-ONLY: the chunk already
+        # exists (the forward path owns it), so this is a benign 409 -- no raise,
+        # no overwrite. The port yields.
+        test_client.bulk_index_documents(
+            documents=[stale_snapshot],
+            tenant_state=tenant_state,
+            use_create_only=True,
+        )
+
+        # FIX: the stale port write did not clobber. Fresh content and the
+        # revoked ACL both survive -- the victim stays revoked.
+        after = test_client.get_document(chunk_id)
+        assert after.content == "live-fresh"
+        assert after.access_control_list == []
+        assert prefix_user_email(victim) not in after.access_control_list
+
+        # The port create was a no-op: stored _version is unchanged.
+        version_after_port = test_client._client.get(
+            index=test_client._index_name, id=chunk_id
+        )["_version"]
+        assert version_after_port == version_before_port
+
+    def test_bulk_index_create_only_creates_absent_chunk(
+        self, test_client: OpenSearchIndexClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """create-only writes a chunk that is absent (the common port case: the
+        forward path has not touched this doc), and re-writing it is a benign
+        no-op (idempotent re-port), not an error."""
+        _patch_global_tenant_state(monkeypatch, False)
+        tenant_state = TenantState(tenant_id=POSTGRES_DEFAULT_SCHEMA, multitenant=False)
+        mappings = DocumentSchema.get_document_schema(
+            vector_dimension=128, multitenant=tenant_state.multitenant
+        )
+        settings = DocumentSchema.get_index_settings_based_on_environment()
+        test_client.create_index(mappings=mappings, settings=settings)
+
+        doc_id = "create-only-doc"
+        chunk_id = get_opensearch_doc_chunk_id(
+            tenant_state=tenant_state,
+            document_id=doc_id,
+            chunk_index=0,
+            max_chunk_size=DEFAULT_MAX_CHUNK_SIZE,
+        )
+
+        def port_write(content: str) -> None:
+            chunk = _create_test_document_chunk(
+                document_id=doc_id,
+                chunk_index=0,
+                content=content,
+                tenant_state=tenant_state,
+            )
+            test_client.bulk_index_documents(
+                documents=[chunk],
+                tenant_state=tenant_state,
+                use_create_only=True,
+            )
+
+        # Absent -> created.
+        port_write("ported")
+        assert test_client.get_document(chunk_id).content == "ported"
+
+        # Re-port the same chunk -> benign 409, no raise, no change (idempotent).
+        port_write("ported-again")
+        assert test_client.get_document(chunk_id).content == "ported"
+
+    def test_bulk_update_swallow_document_missing(
+        self, test_client: OpenSearchIndexClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A 404 document_missing on update is fatal by default, but surfaced as
+        OpenSearchDocumentMissingError when the caller opts in (reindex port)."""
+        _patch_global_tenant_state(monkeypatch, False)
+        tenant_state = TenantState(tenant_id=POSTGRES_DEFAULT_SCHEMA, multitenant=False)
+        mappings = DocumentSchema.get_document_schema(
+            vector_dimension=128, multitenant=tenant_state.multitenant
+        )
+        settings = DocumentSchema.get_index_settings_based_on_environment()
+        test_client.create_index(mappings=mappings, settings=settings)
+
+        missing_id = get_opensearch_doc_chunk_id(
+            tenant_state=tenant_state,
+            document_id="does-not-exist",
+            chunk_index=0,
+            max_chunk_size=DEFAULT_MAX_CHUNK_SIZE,
+        )
+
+        # Default: a missing doc is fatal.
+        with pytest.raises(OpenSearchUpdateError):
+            test_client.bulk_update_documents(
+                document_chunk_ids=[missing_id],
+                properties_to_update={"hidden": True},
+            )
+
+        # Opted-in: surfaced as OpenSearchDocumentMissingError instead.
+        with pytest.raises(OpenSearchDocumentMissingError) as exc:
+            test_client.bulk_update_documents(
+                document_chunk_ids=[missing_id],
+                properties_to_update={"hidden": True},
+                swallow_document_missing=True,
+            )
+        assert missing_id in exc.value.missing_chunk_ids
 
     def test_get_document(
         self, test_client: OpenSearchIndexClient, monkeypatch: pytest.MonkeyPatch
@@ -2447,3 +2624,177 @@ class TestSearchFailureMetrics:
         assert recorded_search_type == OpenSearchSearchType.KEYWORD
         assert isinstance(recorded_exc, OpenSearchServerSideTimeout)
         assert observe_mock.call_count == 0
+
+    @staticmethod
+    def _index_pit_scan_chunks(
+        client: OpenSearchIndexClient,
+        tenant_state: TenantState,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> tuple[list[str], set[tuple[str, int]]]:
+        """Index 3 docs x 5 regular chunks plus one large chunk (which the scan
+        must exclude). Returns (doc_ids, expected regular (doc_id, chunk_index))."""
+        _patch_global_tenant_state(monkeypatch, False)
+        mappings = DocumentSchema.get_document_schema(
+            vector_dimension=128, multitenant=False
+        )
+        settings = DocumentSchema.get_index_settings_based_on_environment()
+        client.create_index(mappings=mappings, settings=settings)
+
+        doc_ids = ["doc-a", "doc-b", "doc-c"]
+        regular = [
+            _create_test_document_chunk(
+                document_id=doc_id,
+                chunk_index=ci,
+                content=f"{doc_id}-{ci}",
+                tenant_state=tenant_state,
+            )
+            for doc_id in doc_ids
+            for ci in range(5)
+        ]
+        expected = {(doc_id, ci) for doc_id in doc_ids for ci in range(5)}
+        # A large chunk (max_chunk_size != 512) shares doc-a/chunk 0 but gets a
+        # distinct _id; the max_chunk_size filter must keep it out of the scan.
+        large = _create_test_document_chunk(
+            document_id="doc-a",
+            chunk_index=0,
+            content="large",
+            tenant_state=tenant_state,
+        ).model_copy(update={"max_chunk_size": 1024})
+        client.bulk_index_documents(
+            documents=regular + [large], tenant_state=tenant_state
+        )
+        client.refresh_index()
+        return doc_ids, expected
+
+    def test_pit_scan_full_coverage_and_order(
+        self, test_client: OpenSearchIndexClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Paging the PIT scan covers every regular chunk exactly once, in
+        (document_id, chunk_index) order, excluding the large chunk."""
+        tenant_state = TenantState(tenant_id=POSTGRES_DEFAULT_SCHEMA, multitenant=False)
+        doc_ids, expected = self._index_pit_scan_chunks(
+            test_client, tenant_state, monkeypatch
+        )
+
+        pit_id = test_client.open_pit()
+        seen: list[tuple[str, int]] = []
+        search_after: list[object] | None = None
+        while True:
+            chunks, search_after, pit_id = test_client.fetch_chunks_for_doc_ids(
+                pit_id, doc_ids, search_after=search_after, page_size=4
+            )
+            seen.extend((c.document_id, c.chunk_index) for c in chunks)
+            if search_after is None:
+                break
+        test_client.close_pit(pit_id)
+
+        assert sorted(seen) == sorted(expected)  # every regular chunk, large excluded
+        assert len(seen) == len(expected)  # exactly once, no dupes
+        assert seen == sorted(seen)  # globally non-decreasing order
+
+    def test_pit_scan_reopens_on_expiry(
+        self, test_client: OpenSearchIndexClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A PIT deleted mid-scan is transparently re-opened; the scan resumes
+        from the same cursor and still yields full coverage."""
+        tenant_state = TenantState(tenant_id=POSTGRES_DEFAULT_SCHEMA, multitenant=False)
+        doc_ids, expected = self._index_pit_scan_chunks(
+            test_client, tenant_state, monkeypatch
+        )
+
+        stale_pit = test_client.open_pit()
+        chunks, search_after, stale_pit = test_client.fetch_chunks_for_doc_ids(
+            stale_pit, doc_ids, page_size=4
+        )
+        seen: list[tuple[str, int]] = [(c.document_id, c.chunk_index) for c in chunks]
+        assert search_after is not None
+
+        # Force expiry: delete the PIT out from under the scan.
+        test_client.close_pit(stale_pit)
+
+        pit_id = stale_pit
+        while True:
+            chunks, search_after, pit_id = test_client.fetch_chunks_for_doc_ids(
+                pit_id, doc_ids, search_after=search_after, page_size=4
+            )
+            seen.extend((c.document_id, c.chunk_index) for c in chunks)
+            if search_after is None:
+                break
+        test_client.close_pit(pit_id)
+
+        assert pit_id != stale_pit  # transparently re-opened
+        assert sorted(seen) == sorted(expected)  # full coverage across the re-open
+
+    def test_pit_scan_iterator_owns_lifecycle(
+        self, test_client: OpenSearchIndexClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """iter_chunks_for_doc_ids yields full coverage and closes its PIT once."""
+        tenant_state = TenantState(tenant_id=POSTGRES_DEFAULT_SCHEMA, multitenant=False)
+        doc_ids, expected = self._index_pit_scan_chunks(
+            test_client, tenant_state, monkeypatch
+        )
+
+        closed: list[str] = []
+        original_close = test_client.close_pit
+
+        def _spy_close(pit_id: str) -> None:
+            closed.append(pit_id)
+            original_close(pit_id)
+
+        monkeypatch.setattr(test_client, "close_pit", _spy_close)
+
+        seen = [
+            (c.document_id, c.chunk_index)
+            for page in test_client.iter_chunks_for_doc_ids(doc_ids, page_size=4)
+            for c in page
+        ]
+
+        assert sorted(seen) == sorted(expected)
+        assert seen == sorted(seen)
+        assert len(closed) == 1  # PIT closed exactly once by the iterator
+
+    def test_pit_scan_retries_reopen_once_then_raises(
+        self, test_client: OpenSearchIndexClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A persistently-expiring PIT is retried once (re-open) then the error
+        propagates — no infinite loop."""
+        _patch_global_tenant_state(monkeypatch, False)
+        mappings = DocumentSchema.get_document_schema(
+            vector_dimension=128, multitenant=False
+        )
+        settings = DocumentSchema.get_index_settings_based_on_environment()
+        test_client.create_index(mappings=mappings, settings=settings)
+        pit_id = test_client.open_pit()
+
+        expired = NotFoundError(
+            404,
+            "search_phase_execution_exception",
+            {"error": {"root_cause": [{"type": "search_context_missing_exception"}]}},
+        )
+        mock_search = MagicMock(side_effect=expired)
+        monkeypatch.setattr(test_client._client, "search", mock_search)
+
+        with pytest.raises(NotFoundError):
+            test_client.fetch_chunks_for_doc_ids(pit_id, ["doc-a"], page_size=4)
+        assert mock_search.call_count == 2  # original attempt + one reopened retry
+
+    def test_pit_scan_raises_on_server_timeout(
+        self, test_client: OpenSearchIndexClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A server-side timeout must raise, not be read as a short (final) page."""
+        _patch_global_tenant_state(monkeypatch, False)
+        mappings = DocumentSchema.get_document_schema(
+            vector_dimension=128, multitenant=False
+        )
+        settings = DocumentSchema.get_index_settings_based_on_environment()
+        test_client.create_index(mappings=mappings, settings=settings)
+        pit_id = test_client.open_pit()
+
+        monkeypatch.setattr(
+            test_client._client,
+            "search",
+            MagicMock(return_value={"timed_out": True, "hits": {"hits": []}}),
+        )
+
+        with pytest.raises(OpenSearchServerSideTimeout):
+            test_client.fetch_chunks_for_doc_ids(pit_id, ["doc-a"], page_size=4)

--- a/backend/tests/unit/onyx/background/celery/tasks/port/test_run_port_attempt_cursor.py
+++ b/backend/tests/unit/onyx/background/celery/tasks/port/test_run_port_attempt_cursor.py
@@ -1,0 +1,98 @@
+"""Unit coverage for the reindex-port producer's cursor-advance invariant.
+
+`run_port_attempt` must only advance `last_processed_doc_id` past a batch that
+was FULLY ported. When a batch aborts mid-copy (the copier returns aborted=True,
+e.g. the stall watchdog marked the attempt FAILED while it was re-embedding), the
+cursor must stay put — otherwise a FAILED-attempt resume scans `WHERE id > cursor`
+and permanently skips the un-ported tail (silent corpus drop after the swap).
+"""
+
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from onyx.background.celery.tasks.port import tasks as port_tasks
+from onyx.db.enums import PortAttemptStatus
+
+
+@contextmanager
+def _fake_session() -> Any:
+    yield MagicMock()
+
+
+def _make_attempt() -> MagicMock:
+    attempt = MagicMock()
+    attempt.status = PortAttemptStatus.IN_PROGRESS
+    attempt.cancel_requested = False
+    attempt.last_processed_doc_id = None
+    attempt.up_to_doc_id = None
+    attempt.docs_ported = 0
+    attempt.cc_pair_id = 123
+    attempt.search_settings_id = 2
+    return attempt
+
+
+def _patched(copy_result: tuple[int, bool], attempt: MagicMock) -> Any:
+    """Patch every collaborator run_port_attempt touches so only the batch
+    loop's cursor logic is under test. The copier is mocked to return
+    `copy_result` directly (so _should_abort is never really invoked)."""
+    copier = MagicMock()
+    copier.copy_doc_batch.return_value = copy_result
+
+    cc_pair = MagicMock()
+    cc_pair.status = port_tasks.ConnectorCredentialPairStatus.ACTIVE
+
+    patches = {
+        "get_session_with_current_tenant": MagicMock(side_effect=_fake_session),
+        "get_port_attempt": MagicMock(return_value=attempt),
+        "get_search_settings_by_id": MagicMock(
+            return_value=MagicMock(port_backfill_source_id=None)
+        ),
+        "get_current_search_settings": MagicMock(return_value=MagicMock()),
+        "mark_port_in_progress": MagicMock(return_value=True),
+        "PortCopier": MagicMock(return_value=copier),
+        "get_connector_credential_pair_from_id": MagicMock(return_value=cc_pair),
+        "get_document_ids_for_cc_pair_batch": MagicMock(
+            side_effect=[["d1", "d2", "d3"], []]  # one batch, then exhausted
+        ),
+        "commit_port_cursor": MagicMock(),
+        "mark_port_succeeded": MagicMock(),
+        "mark_port_failed": MagicMock(),
+        "mark_port_canceled": MagicMock(),
+    }
+    return patches
+
+
+def test_cursor_not_advanced_when_batch_aborts() -> None:
+    # Watchdog FAILs the attempt mid-copy: copier reports aborted=True and the row
+    # flips terminal, so the next iteration stops.
+    attempt = _make_attempt()
+    patches = _patched((1, True), attempt)
+
+    def _abort_flips_status(*_: Any, **__: Any) -> tuple[int, bool]:
+        attempt.status = PortAttemptStatus.FAILED
+        return (1, True)
+
+    patches["PortCopier"].return_value.copy_doc_batch.side_effect = _abort_flips_status
+
+    with patch.multiple(port_tasks, **patches):
+        port_tasks.run_port_attempt(port_attempt_id=1)
+
+    patches["commit_port_cursor"].assert_not_called()
+    patches["mark_port_succeeded"].assert_not_called()
+
+
+def test_cursor_advanced_when_batch_completes() -> None:
+    # Positive control: a fully-ported batch advances the cursor to its last id.
+    attempt = _make_attempt()
+    patches = _patched((5, False), attempt)
+
+    with patch.multiple(port_tasks, **patches):
+        port_tasks.run_port_attempt(port_attempt_id=1)
+
+    patches["commit_port_cursor"].assert_called_once()
+    _, kwargs = patches["commit_port_cursor"].call_args
+    assert kwargs["last_processed_doc_id"] == "d3"
+    assert kwargs["docs_ported"] == 3
+    patches["mark_port_succeeded"].assert_called_once()

--- a/backend/tests/unit/onyx/background/celery/tasks/test_port_wiring.py
+++ b/backend/tests/unit/onyx/background/celery/tasks/test_port_wiring.py
@@ -1,0 +1,76 @@
+"""Guards the Celery wiring of the reindex-port flow.
+
+The port logic itself is covered by the external_dependency_unit `db/test_*port*`
+suites (which run against real Postgres/OpenSearch). Those mock the celery app, so
+nothing there proves a beat-enqueued port task actually reaches a worker. These
+unit tests guard exactly that transport seam — the part a dropped autodiscover line
+or `-Q` entry would silently break with every other test still green:
+
+  beat schedules check_for_port  ->  light worker consumes the `port` queue
+  ->  light worker has run_port_attempt registered to execute it.
+"""
+
+import re
+from pathlib import Path
+
+from onyx.background.celery.tasks.beat_schedule import beat_task_templates
+from onyx.configs.app_configs import DISABLE_VECTOR_DB
+from onyx.configs.constants import OnyxCeleryQueues
+from onyx.configs.constants import OnyxCeleryTask
+
+
+def _find_supervisord_conf() -> Path:
+    for parent in Path(__file__).resolve().parents:
+        candidate = parent / "supervisord.conf"
+        if candidate.is_file():
+            return candidate
+    raise AssertionError("supervisord.conf not found above this test")
+
+
+def _worker_queues(program: str) -> set[str]:
+    """The `-Q` queue set a supervisord worker program consumes.
+
+    Reads the queues from anywhere in the `[program:*]` block, so it survives the
+    `command=celery ... -Q a,b,c` being on one line or wrapped across several.
+    """
+    conf = _find_supervisord_conf().read_text()
+    block = re.search(
+        rf"^\[program:{re.escape(program)}\]\n(.*?)(?=^\[|\Z)",
+        conf,
+        re.DOTALL | re.MULTILINE,
+    )
+    if block is None:
+        raise AssertionError(f"no [program:{program}] block found")
+    queues = re.search(r"-Q\s+(\S+)", block.group(1))
+    if queues is None:
+        raise AssertionError(f"no -Q queues found in [program:{program}]")
+    return set(queues.group(1).split(","))
+
+
+def test_check_for_port_scheduled_in_beat() -> None:
+    # check_for_port is the only producer of PortAttempts; if it falls out of the
+    # beat schedule the whole flow stops with zero other test failures.
+    scheduled = {t["task"] for t in beat_task_templates}
+    if DISABLE_VECTOR_DB:
+        # Vector-DB-gated: must be filtered out of minimal-mode deployments.
+        assert OnyxCeleryTask.CHECK_FOR_PORT not in scheduled
+    else:
+        assert OnyxCeleryTask.CHECK_FOR_PORT in scheduled
+
+
+def test_light_worker_consumes_port_queue() -> None:
+    # run_port_attempt is enqueued to the PORT queue; the light worker is its only
+    # consumer. Dropping `port` from this `-Q` list strands every port task.
+    assert OnyxCeleryQueues.PORT in _worker_queues("celery_worker_light")
+
+
+def test_light_worker_registers_port_tasks() -> None:
+    # Consuming the queue is moot if autodiscovery doesn't register the task body:
+    # the worker would reject it as unknown. Importing + loading the light app
+    # mirrors worker bootstrap, so both port tasks must resolve by name.
+    from onyx.background.celery.apps.light import celery_app
+
+    celery_app.loader.import_default_modules()
+    registered = set(celery_app.tasks.keys())
+    assert OnyxCeleryTask.RUN_PORT_ATTEMPT in registered
+    assert OnyxCeleryTask.CHECK_FOR_PORT in registered

--- a/backend/tests/unit/onyx/document_index/opensearch/test_index_pair_secondary_missing.py
+++ b/backend/tests/unit/onyx/document_index/opensearch/test_index_pair_secondary_missing.py
@@ -1,0 +1,108 @@
+"""Unit tests for the FUTURE-404 (secondary missing) conversion path.
+
+Two pure-Python seams:
+- `OpenSearchDocumentIndex.update` keeps processing requests past a missing-doc
+  one and reports only the docs that were actually missing (chunk -> doc mapping).
+- `OpenSearchIndexPair.update` lets PRESENT (primary) write, then converts a
+  secondary `OpenSearchDocumentMissingError` into a typed
+  `SecondaryIndexDocumentMissingError` carrying those doc ids.
+The underlying 404/409 behavior is covered for real against a live cluster in
+tests/external_dependency_unit/opensearch/test_opensearch_client.py.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from onyx.document_index.interfaces_new import MetadataUpdateRequest
+from onyx.document_index.interfaces_new import SecondaryIndexDocumentMissingError
+from onyx.document_index.interfaces_new import TenantState
+from onyx.document_index.opensearch.client import OpenSearchDocumentMissingError
+from onyx.document_index.opensearch.client import OpenSearchUpdateError
+from onyx.document_index.opensearch.opensearch_document_index import (
+    OpenSearchDocumentIndex,
+)
+from onyx.document_index.opensearch.opensearch_document_index import OpenSearchIndexPair
+from onyx.document_index.opensearch.schema import get_opensearch_doc_chunk_id
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
+
+
+def _make_pair(secondary: object) -> tuple[OpenSearchIndexPair, MagicMock]:
+    """Returns the pair plus the primary mock (asserting through the typed
+    `_primary` attribute would confuse the type checker)."""
+    pair = OpenSearchIndexPair.__new__(OpenSearchIndexPair)
+    primary = MagicMock()
+    pair._primary = primary
+    pair._secondary = secondary
+    return pair, primary
+
+
+def _update_request(doc_id: str = "doc-1") -> MetadataUpdateRequest:
+    return MetadataUpdateRequest(
+        document_ids=[doc_id], doc_id_to_chunk_cnt={doc_id: 1}, boost=1
+    )
+
+
+def _make_index() -> tuple[OpenSearchDocumentIndex, TenantState, MagicMock]:
+    """Returns the index, its tenant state, and the client mock (asserting
+    through the typed `_client` attribute would confuse the type checker)."""
+    ts = TenantState(tenant_id=POSTGRES_DEFAULT_SCHEMA, multitenant=False)
+    idx = OpenSearchDocumentIndex.__new__(OpenSearchDocumentIndex)
+    client = MagicMock()
+    idx._client = client
+    idx._tenant_state = ts
+    idx._index_name = "test-index"
+    return idx, ts, client
+
+
+def test_update_continues_past_missing_and_attributes_precisely() -> None:
+    """A missing doc in one request must not drop the others, and only the
+    truly-missing doc is reported (not every doc in the batch)."""
+    idx, ts, client = _make_index()
+    missing_chunk = get_opensearch_doc_chunk_id(
+        tenant_state=ts, document_id="doc-missing", chunk_index=0
+    )
+    client.bulk_update_documents.side_effect = [
+        OpenSearchDocumentMissingError([missing_chunk]),
+        None,
+    ]
+
+    with pytest.raises(OpenSearchDocumentMissingError) as exc:
+        idx.update(
+            [_update_request("doc-missing"), _update_request("doc-present")],
+            swallow_document_missing=True,
+        )
+
+    assert exc.value.missing_document_ids == ["doc-missing"]
+    assert exc.value.missing_chunk_ids == [missing_chunk]
+    # the present doc's request was still attempted after the missing one
+    assert client.bulk_update_documents.call_count == 2
+
+
+def test_pair_converts_secondary_missing_to_typed_signal() -> None:
+    secondary = MagicMock()
+    secondary.update.side_effect = OpenSearchDocumentMissingError(
+        ["chunk-1"], ["doc-1"]
+    )
+    pair, primary = _make_pair(secondary)
+
+    with pytest.raises(SecondaryIndexDocumentMissingError) as exc:
+        pair.update([_update_request()])
+
+    assert exc.value.document_ids == ["doc-1"]
+    primary.update.assert_called_once()  # PRESENT written before FUTURE
+    assert secondary.update.call_args.kwargs.get("swallow_document_missing") is True
+
+
+def test_pair_propagates_other_secondary_errors() -> None:
+    secondary = MagicMock()
+    secondary.update.side_effect = OpenSearchUpdateError("boom")
+    pair, _primary = _make_pair(secondary)
+    with pytest.raises(OpenSearchUpdateError):
+        pair.update([_update_request()])
+
+
+def test_pair_no_secondary_just_primary() -> None:
+    pair, primary = _make_pair(None)
+    pair.update([_update_request()])
+    primary.update.assert_called_once()

--- a/backend/tests/unit/onyx/document_index/opensearch/test_port_copy.py
+++ b/backend/tests/unit/onyx/document_index/opensearch/test_port_copy.py
@@ -1,0 +1,126 @@
+"""Unit coverage for the reindex-port copier's mid-batch deletion guard.
+
+`copy_present_chunks_to_future` re-checks document existence right before the
+create-only write (after the slow re-embed) so a doc deleted while the batch was
+being read/embedded is not resurrected into the FUTURE index.
+"""
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from onyx.document_index.opensearch.port_copy import copy_present_chunks_to_future
+from onyx.indexing.port_reembed import ReembedStrategy
+
+
+def _chunk(doc_id: str) -> MagicMock:
+    chunk = MagicMock()
+    chunk.document_id = doc_id
+    return chunk
+
+
+def _passthrough_reembed(page: list, *_: object, **__: object) -> list:
+    # re-embed stub: return the page unchanged (preserves document_ids).
+    return list(page)
+
+
+@patch("onyx.document_index.opensearch.port_copy.re_embed_chunks")
+def test_copier_drops_docs_deleted_mid_batch(mock_reembed: MagicMock) -> None:
+    present_client = MagicMock()
+    present_client.iter_chunks_for_doc_ids.return_value = [
+        [_chunk("doc_a"), _chunk("doc_b")]
+    ]
+    mock_reembed.side_effect = _passthrough_reembed
+    future_index = MagicMock()
+
+    written, aborted = copy_present_chunks_to_future(
+        present_client=present_client,
+        future_index=future_index,
+        doc_ids=["doc_a", "doc_b"],
+        strategy=ReembedStrategy.MODEL_ONLY,
+        embedder=MagicMock(),
+        present_tokenizer=MagicMock(),
+        surviving_doc_ids=lambda: {"doc_a"},  # doc_b deleted mid-batch
+    )
+
+    assert written == 1
+    assert aborted is False
+    (written_chunks,), _ = future_index.index_raw_chunks.call_args
+    assert [c.document_id for c in written_chunks] == ["doc_a"]
+
+
+@patch("onyx.document_index.opensearch.port_copy.re_embed_chunks")
+def test_copier_skips_write_when_whole_batch_deleted(mock_reembed: MagicMock) -> None:
+    present_client = MagicMock()
+    present_client.iter_chunks_for_doc_ids.return_value = [[_chunk("doc_a")]]
+    mock_reembed.side_effect = _passthrough_reembed
+    future_index = MagicMock()
+
+    written, aborted = copy_present_chunks_to_future(
+        present_client=present_client,
+        future_index=future_index,
+        doc_ids=["doc_a"],
+        strategy=ReembedStrategy.MODEL_ONLY,
+        embedder=MagicMock(),
+        present_tokenizer=MagicMock(),
+        surviving_doc_ids=lambda: set(),  # everything deleted
+    )
+
+    assert written == 0
+    assert aborted is False
+    future_index.index_raw_chunks.assert_not_called()
+
+
+@patch("onyx.document_index.opensearch.port_copy.re_embed_chunks")
+def test_copier_aborts_write_when_cancelled_mid_batch(mock_reembed: MagicMock) -> None:
+    # Two pages; the attempt is cancelled after the first page is written.
+    present_client = MagicMock()
+    present_client.iter_chunks_for_doc_ids.return_value = [
+        [_chunk("doc_a")],
+        [_chunk("doc_b")],
+    ]
+    mock_reembed.side_effect = _passthrough_reembed
+    future_index = MagicMock()
+
+    # should_abort is polled twice per page (pre-filter + before the sub-page
+    # write): allow both of page 1's polls, then cancel at page 2's first poll.
+    aborts = iter([False, False, True])
+
+    written, aborted = copy_present_chunks_to_future(
+        present_client=present_client,
+        future_index=future_index,
+        doc_ids=["doc_a", "doc_b"],
+        strategy=ReembedStrategy.MODEL_ONLY,
+        embedder=MagicMock(),
+        present_tokenizer=MagicMock(),
+        should_abort=lambda: next(aborts),
+    )
+
+    # only the first page was written; the second is skipped by the abort.
+    assert written == 1
+    assert aborted is True
+    future_index.index_raw_chunks.assert_called_once()
+    (written_chunks,), _ = future_index.index_raw_chunks.call_args
+    assert [c.document_id for c in written_chunks] == ["doc_a"]
+
+
+@patch("onyx.document_index.opensearch.port_copy.re_embed_chunks")
+def test_copier_writes_all_without_filter(mock_reembed: MagicMock) -> None:
+    present_client = MagicMock()
+    present_client.iter_chunks_for_doc_ids.return_value = [
+        [_chunk("doc_a"), _chunk("doc_b")]
+    ]
+    mock_reembed.side_effect = _passthrough_reembed
+    future_index = MagicMock()
+
+    written, aborted = copy_present_chunks_to_future(
+        present_client=present_client,
+        future_index=future_index,
+        doc_ids=["doc_a", "doc_b"],
+        strategy=ReembedStrategy.MODEL_ONLY,
+        embedder=MagicMock(),
+        present_tokenizer=MagicMock(),
+    )
+
+    assert written == 2
+    assert aborted is False
+    future_index.index_raw_chunks.assert_called_once()

--- a/backend/tests/unit/onyx/indexing/test_indexing_pipeline.py
+++ b/backend/tests/unit/onyx/indexing/test_indexing_pipeline.py
@@ -1013,3 +1013,31 @@ def test_get_docs_to_update_mixed_batch() -> None:
     assert docs[0].id == "changed"
     assert "changed" in hashes
     assert "unchanged" not in hashes
+
+
+def test_get_docs_to_update_secondary_build_ignores_content_hash_gate() -> None:
+    """FUTURE/secondary build (ignore_content_hash_gate=True) must NOT hash-skip.
+
+    content_hash is a single column shared by both indices but tracks only the
+    PRESENT/live index. A matching hash means PRESENT already has the doc — it
+    says nothing about the FUTURE index being built. Honoring the gate here is
+    the #11159 regression: the secondary write gets suppressed and FUTURE never
+    receives the doc (swap deadlock / stale promotion). The gate must be bypassed.
+    """
+    doc = _doc_with_text("Title", "unchanged content")
+    doc.id = "doc1"
+    doc.doc_updated_at = None
+    stored_hash = doc.content_hash()  # PRESENT already indexed this exact content
+    db_doc = _make_db_doc("doc1", content_hash=stored_hash)
+
+    # Default (PRESENT write): hash matches → skipped, as before.
+    present_docs, _ = get_docs_to_update([doc], db_docs=[db_doc])
+    assert present_docs == []
+
+    # Secondary/FUTURE write: gate bypassed → doc still indexed into FUTURE.
+    future_docs, future_hashes = get_docs_to_update(
+        [doc], db_docs=[db_doc], ignore_content_hash_gate=True
+    )
+    assert len(future_docs) == 1
+    assert future_docs[0].id == "doc1"
+    assert "doc1" in future_hashes

--- a/deployment/helm/charts/onyx/templates/celery-worker-light.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-light.yaml
@@ -70,7 +70,7 @@ spec:
               {{- end }}
               "--hostname=light@%n",
               "-Q",
-              "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration",
+              "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration,port",
             ]
           ports:
             - name: metrics

--- a/web/src/lib/indexing/interfaces.ts
+++ b/web/src/lib/indexing/interfaces.ts
@@ -157,6 +157,8 @@ export interface SavedSearchSettings
   passage_prefix: string | null;
   provider_type: EmbeddingProviderName | null;
   switchover_type?: SwitchoverType;
+  // Read-only; server-set, always true for new settings.
+  use_port_flow: boolean;
 }
 
 export interface LLMContextualCost {

--- a/web/src/refresh-pages/admin/IndexSettingsPage/index.tsx
+++ b/web/src/refresh-pages/admin/IndexSettingsPage/index.tsx
@@ -925,6 +925,17 @@ export default function IndexSettingsPage() {
             enableReinitialize
             initialValues={initialFormValues}
             onSubmit={async (values) => {
+              // Contextual Retrieval re-embeds each chunk through an LLM; with
+              // the toggle on but no model chosen the port fails, so block here.
+              if (
+                values.enable_contextual_rag &&
+                values.contextual_rag_model_configuration_id === null
+              ) {
+                toast.error(
+                  "Select a Contextual Retrieval LLM before re-indexing."
+                );
+                return;
+              }
               // Custom self-hosted models live outside the static registry,
               // so the form carries their spec (`modelDim`, `normalize`, etc.)
               // in `custom_model` for submission. The provider, however, is
@@ -968,6 +979,10 @@ export default function IndexSettingsPage() {
                 !!values.model_name;
               const stagedModelName = isModelStaged ? values.model_name : null;
               const statusVariant = dirty ? "warning" : undefined;
+              // Block apply when Contextual Retrieval is on but no LLM is set.
+              const contextualRagModelMissing =
+                values.enable_contextual_rag &&
+                values.contextual_rag_model_configuration_id === null;
 
               return (
                 <>
@@ -1026,11 +1041,19 @@ export default function IndexSettingsPage() {
                   ) : (
                     !NEXT_PUBLIC_CLOUD_ENABLED && (
                       <MessageCard
-                        variant={statusVariant}
+                        variant={
+                          contextualRagModelMissing ? "error" : statusVariant
+                        }
                         headerPadding="sm"
-                        title="Changes require a full re-index."
+                        title={
+                          contextualRagModelMissing
+                            ? "Select a Contextual Retrieval LLM"
+                            : "Changes require a full re-index."
+                        }
                         description={markdown(
-                          "Modifying embedding or retrieval settings requires a full re-index of all documents to take effect, which may take **hours or days** depending on corpus size. [Learn More](https://docs.onyx.app/security/architecture/data_flows)"
+                          contextualRagModelMissing
+                            ? "Contextual Retrieval is enabled but no model is selected. Pick a Contextual Retrieval LLM below before re-indexing — without one, the re-index cannot run."
+                            : "Modifying embedding or retrieval settings requires a full re-index of all documents to take effect, which may take **hours or days** depending on corpus size. [Learn More](https://docs.onyx.app/security/architecture/data_flows)"
                         )}
                         bottomChildren={
                           dirty ? (
@@ -1081,7 +1104,10 @@ export default function IndexSettingsPage() {
                                 >
                                   Revert
                                 </Button>
-                                <Button onClick={() => void submitForm()}>
+                                <Button
+                                  onClick={() => void submitForm()}
+                                  disabled={contextualRagModelMissing}
+                                >
                                   Apply & Re-index
                                 </Button>
                               </div>


### PR DESCRIPTION
> **Stacked PR — review in order. Base of the stack: `main`.**
>
> #11977 — `01-schema`
> #11978 — `02-lifecycle`
> #11979 — `03-defer`
> #11980 — `04-opensearch`  :point_left: **this PR**
> #11981 — `05-reembed`
> #11982 — `06-copy`
> #11983 — `07-swap`
> #11984 — `08-sync`
> #11985 — `09-machinery`
> #11986 — `10-enablement`
> #11987 — `11-tests`


## Description

- Add point-in-time (PIT) scanning to the OpenSearch client (open / iterate / refresh-on-expiry) for consistent reads of live chunks during a port.
- Surface FUTURE-index 404s as `SecondaryIndexDocumentMissingError` and continue past missing docs in bulk updates instead of failing the whole batch.
- Support create-only writes so porting never overwrites live chunks.

## How Has This Been Tested?

**Automated**
- `test_opensearch_client.py` (PIT scan, external-versioning newest-wins, missing-doc surfacing) and `test_index_pair_secondary_missing.py` (FUTURE-404 conversion) against a real OpenSearch.
- `ty` and `ruff` pass.

**Manual** (verified end-to-end on a local stack; this is a stacked feature, so manual scenarios exercise the full flow once the stack is assembled):
- Verified a PIT scan pages through all live chunks consistently while concurrent writes occur, and that a missing FUTURE doc is reported rather than fatal.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
