### PR TITLE
feat(reindex): enable the port flow (queue, seeding, deploy) (10/11)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -318,7 +318,7 @@
         "--loglevel=INFO",
         "--hostname=light@%n",
         "-Q",
-        "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration"
+        "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration,port"
       ],
       "presentation": {
         "group": "2",
@@ -606,7 +606,7 @@
         "--loglevel=INFO",
         "--hostname=light@%n",
         "-Q",
-        "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration"
+        "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration,port"
       ],
       "presentation": {
         "group": "2",

--- a/backend/onyx/background/celery/apps/light.py
+++ b/backend/onyx/background/celery/apps/light.py
@@ -158,6 +158,7 @@ celery_app.autodiscover_tasks(
             "onyx.background.celery.tasks.connector_deletion",
             "onyx.background.celery.tasks.doc_permission_syncing",
             "onyx.background.celery.tasks.docprocessing",
+            "onyx.background.celery.tasks.port",
             "onyx.background.celery.tasks.opensearch_migration",
             # Sandbox cleanup tasks (isolated in build feature)
             "onyx.server.features.build.sandbox.tasks",

--- a/backend/onyx/background/celery/apps/primary.py
+++ b/backend/onyx/background/celery/apps/primary.py
@@ -350,6 +350,7 @@ celery_app.autodiscover_tasks(
         [
             "onyx.background.celery.tasks.connector_deletion",
             "onyx.background.celery.tasks.docprocessing",
+            "onyx.background.celery.tasks.port",
             "onyx.background.celery.tasks.evals",
             "onyx.background.celery.tasks.hierarchyfetching",
             "onyx.background.celery.tasks.pruning",

--- a/backend/onyx/background/indexing/run_docfetching.py
+++ b/backend/onyx/background/indexing/run_docfetching.py
@@ -474,7 +474,8 @@ def connector_document_extraction(
             and (from_beginning or not has_successful_attempt)
         )
 
-        # Set up time windows for polling
+        # Set up time windows for polling. A port-flow FUTURE's resume cursor comes from its
+        # synthetic seed (get_last_successful_... keeps ignore_synthetic_seed=False by default).
         last_successful_index_poll_range_end = (
             earliest_index_time
             if from_beginning

--- a/backend/onyx/background/indexing/run_targeted_reindex.py
+++ b/backend/onyx/background/indexing/run_targeted_reindex.py
@@ -148,6 +148,8 @@ def _flush_batch(
         embedder=embedder,
         document_indices=document_indices,
         ignore_time_skip=True,
+        # FUTURE/secondary build: skip the PRESENT-only content_hash dedup.
+        index_to_secondary=not search_settings.status.is_current(),
         db_session=db_session,
         tenant_id=tenant_id,
         document_batch=documents,

--- a/backend/onyx/context/search/models.py
+++ b/backend/onyx/context/search/models.py
@@ -36,6 +36,8 @@ class SearchSettingsCreationRequest(IndexingSetting):
 class SavedSearchSettings(IndexingSetting):
     # Previously this contained also Inference time settings. Keeping this wrapper class around
     # as there may again be inference time settings that may get added.
+    use_port_flow: bool | None = None
+
     @classmethod
     def from_db_model(cls, search_settings: SearchSettings) -> "SavedSearchSettings":
         return cls(

--- a/backend/onyx/db/connector_credential_pair.py
+++ b/backend/onyx/db/connector_credential_pair.py
@@ -720,6 +720,7 @@ def resync_cc_pair(
     cc_pair: ConnectorCredentialPair,
     search_settings_id: int,
     db_session: Session,
+    commit: bool = True,
 ) -> None:
     """
     Updates state stored in the connector_credential_pair table based on the
@@ -769,4 +770,5 @@ def resync_cc_pair(
         last_success.time_started if last_success else None
     )
 
-    db_session.commit()
+    if commit:
+        db_session.commit()

--- a/backend/onyx/db/index_attempt.py
+++ b/backend/onyx/db/index_attempt.py
@@ -874,6 +874,7 @@ def delete_index_attempts(
 def expire_index_attempts(
     search_settings_id: int,
     db_session: Session,
+    commit: bool = True,
 ) -> None:
     not_started_query = (
         update(IndexAttempt)
@@ -897,7 +898,8 @@ def expire_index_attempts(
     )
     db_session.execute(update_query)
 
-    db_session.commit()
+    if commit:
+        db_session.commit()
 
 
 def cancel_indexing_attempts_for_ccpair(

--- a/backend/onyx/db/search_settings.py
+++ b/backend/onyx/db/search_settings.py
@@ -37,10 +37,11 @@ def create_search_settings(
     search_settings: SavedSearchSettings,
     db_session: Session,
     status: IndexModelStatus = IndexModelStatus.FUTURE,
-    # Defaults to the DB column default (False). The reindex endpoint opts into
-    # True so every new FUTURE ports PRESENT -> FUTURE in place; it is set here
-    # (not a request field) so a client can't toggle it.
+    # Server-set, not a request field; the reindex endpoint opts into True.
     use_port_flow: bool = False,
+    # False flushes instead of committing, so the caller can commit this row
+    # atomically with its port seeds (a seedless FUTURE makes workers re-scan).
+    commit: bool = True,
 ) -> SearchSettings:
     embedding_model = SearchSettings(
         model_name=search_settings.model_name,
@@ -61,7 +62,10 @@ def create_search_settings(
     )
 
     db_session.add(embedding_model)
-    db_session.commit()
+    if commit:
+        db_session.commit()
+    else:
+        db_session.flush()  # populate id without committing
 
     return embedding_model
 

--- a/backend/onyx/db/search_settings.py
+++ b/backend/onyx/db/search_settings.py
@@ -37,6 +37,10 @@ def create_search_settings(
     search_settings: SavedSearchSettings,
     db_session: Session,
     status: IndexModelStatus = IndexModelStatus.FUTURE,
+    # Defaults to the DB column default (False). The reindex endpoint opts into
+    # True so every new FUTURE ports PRESENT -> FUTURE in place; it is set here
+    # (not a request field) so a client can't toggle it.
+    use_port_flow: bool = False,
 ) -> SearchSettings:
     embedding_model = SearchSettings(
         model_name=search_settings.model_name,
@@ -53,7 +57,7 @@ def create_search_settings(
         enable_contextual_rag=search_settings.enable_contextual_rag,
         contextual_rag_model_configuration_id=search_settings.contextual_rag_model_configuration_id,
         switchover_type=search_settings.switchover_type,
-        use_port_flow=search_settings.use_port_flow,
+        use_port_flow=use_port_flow,
     )
 
     db_session.add(embedding_model)

--- a/backend/onyx/indexing/models.py
+++ b/backend/onyx/indexing/models.py
@@ -197,8 +197,6 @@ class IndexingSetting(EmbeddingModelDetail):
     reduced_dimension: int | None = None
 
     switchover_type: SwitchoverType = SwitchoverType.REINDEX
-    # Reindex "port" flow gate; see SearchSettings.use_port_flow.
-    use_port_flow: bool = False
     enable_contextual_rag: bool
     contextual_rag_model_configuration_id: int | None = None
     # Deprecated: accepted for backward compat but silently ignored on write.
@@ -230,7 +228,6 @@ class IndexingSetting(EmbeddingModelDetail):
             embedding_precision=search_settings.embedding_precision,
             reduced_dimension=search_settings.reduced_dimension,
             switchover_type=search_settings.switchover_type,
-            use_port_flow=search_settings.use_port_flow,
             enable_contextual_rag=search_settings.enable_contextual_rag,
             contextual_rag_model_configuration_id=search_settings.contextual_rag_model_configuration_id,
         )

--- a/backend/onyx/server/manage/search_settings.py
+++ b/backend/onyx/server/manage/search_settings.py
@@ -106,12 +106,6 @@ def set_new_search_settings(
             **search_settings_new.model_dump()
         )
 
-    # Every new (FUTURE) search settings drives its reindex through the port flow:
-    # re-embed PRESENT -> FUTURE in place rather than re-fetching from connectors.
-    new_search_settings_request = new_search_settings_request.model_copy(
-        update={"use_port_flow": True}
-    )
-
     secondary_search_settings = get_secondary_search_settings(db_session)
 
     if secondary_search_settings:
@@ -135,8 +129,12 @@ def set_new_search_settings(
             db_session, search_settings_id=secondary_search_settings.id
         )
 
+    # Every new FUTURE reindexes via the port flow: re-embed PRESENT -> FUTURE in
+    # place rather than re-fetching from connectors.
     new_search_settings = create_search_settings(
-        search_settings=new_search_settings_request, db_session=db_session
+        search_settings=new_search_settings_request,
+        db_session=db_session,
+        use_port_flow=True,
     )
 
     # Ensure the document indices have the new index immediately.

--- a/backend/onyx/server/manage/search_settings.py
+++ b/backend/onyx/server/manage/search_settings.py
@@ -9,14 +9,20 @@ from onyx.configs.app_configs import DISABLE_INDEX_UPDATE_ON_SWAP
 from onyx.context.search.models import SavedSearchSettings
 from onyx.context.search.models import SearchSettingsCreationRequest
 from onyx.db.connector_credential_pair import get_connector_credential_pairs
+from onyx.db.connector_credential_pair import get_last_successful_attempt_poll_range_end
 from onyx.db.connector_credential_pair import resync_cc_pair
 from onyx.db.engine.sql_engine import get_session
+from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.enums import Permission
+from onyx.db.enums import SwitchoverType
+from onyx.db.index_attempt import create_synthetic_seed_attempt
 from onyx.db.index_attempt import expire_index_attempts
+from onyx.db.llm import fetch_default_contextual_rag_model
 from onyx.db.llm import update_default_contextual_model
 from onyx.db.llm import update_no_default_contextual_rag_provider
 from onyx.db.models import IndexModelStatus
 from onyx.db.models import User
+from onyx.db.port_attempt import cancel_active_port_attempts
 from onyx.db.search_settings import create_search_settings
 from onyx.db.search_settings import delete_search_settings
 from onyx.db.search_settings import get_current_search_settings
@@ -79,6 +85,7 @@ def set_new_search_settings(
     validate_contextual_rag_model(
         model_configuration_id=search_settings_new.contextual_rag_model_configuration_id,
         db_session=db_session,
+        enable_contextual_rag=search_settings_new.enable_contextual_rag,
     )
 
     search_settings = get_current_search_settings(db_session)
@@ -99,6 +106,12 @@ def set_new_search_settings(
             **search_settings_new.model_dump()
         )
 
+    # Every new (FUTURE) search settings drives its reindex through the port flow:
+    # re-embed PRESENT -> FUTURE in place rather than re-fetching from connectors.
+    new_search_settings_request = new_search_settings_request.model_copy(
+        update={"use_port_flow": True}
+    )
+
     secondary_search_settings = get_secondary_search_settings(db_session)
 
     if secondary_search_settings:
@@ -112,6 +125,14 @@ def set_new_search_settings(
             search_settings=secondary_search_settings,
             new_status=IndexModelStatus.PAST,
             db_session=db_session,
+        )
+
+        # Cancel in-flight reindex ports for the superseded FUTURE. After the PAST
+        # flip so check_for_port (which only targets the current secondary) won't
+        # enqueue a replacement; the running port task stops at its next batch
+        # boundary once it sees CANCELED.
+        cancel_active_port_attempts(
+            db_session, search_settings_id=secondary_search_settings.id
         )
 
     new_search_settings = create_search_settings(
@@ -140,6 +161,33 @@ def set_new_search_settings(
                 db_session=db_session,
             )
 
+    # Seed the port flow: one SUCCESS synthetic IndexAttempt per in-scope cc_pair
+    # carrying PRESENT's poll cursor, so the FUTURE connector-incremental resumes
+    # from there rather than re-scanning. INSTANT swaps immediately (nothing to
+    # poll), so it is not seeded. Scope mirrors the swap criterion: ACTIVE_ONLY
+    # seeds active cc_pairs only; otherwise all non-deleting.
+    if (
+        new_search_settings.use_port_flow
+        and new_search_settings.switchover_type != SwitchoverType.INSTANT
+    ):
+        active_only = new_search_settings.switchover_type == SwitchoverType.ACTIVE_ONLY
+        for cc_pair in get_connector_credential_pairs(db_session):
+            if active_only and not cc_pair.status.is_active():
+                continue
+            if cc_pair.status == ConnectorCredentialPairStatus.DELETING:
+                continue
+            indexing_start = cc_pair.connector.indexing_start
+            earliest_index = indexing_start.timestamp() if indexing_start else 0.0
+            poll_range_end = get_last_successful_attempt_poll_range_end(
+                cc_pair.id, earliest_index, search_settings, db_session
+            )
+            create_synthetic_seed_attempt(
+                connector_credential_pair_id=cc_pair.id,
+                search_settings_id=new_search_settings.id,
+                poll_range_end=poll_range_end,
+                db_session=db_session,
+            )
+
     db_session.commit()
     return IdReturn(id=new_search_settings.id)
 
@@ -160,6 +208,12 @@ def cancel_new_embedding(
             search_settings=secondary_search_settings,
             new_status=IndexModelStatus.PAST,
             db_session=db_session,
+        )
+
+        # Stop any in-flight reindex port for the canceled FUTURE; the running
+        # task stops at its next batch boundary once it sees CANCELED.
+        cancel_active_port_attempts(
+            db_session, search_settings_id=secondary_search_settings.id
         )
 
         # remove the old index from the vector db
@@ -243,6 +297,7 @@ def update_saved_search_settings(
     validate_contextual_rag_model(
         model_configuration_id=search_settings.contextual_rag_model_configuration_id,
         db_session=db_session,
+        enable_contextual_rag=search_settings.enable_contextual_rag,
     )
 
     update_current_search_settings(
@@ -283,8 +338,18 @@ def delete_unstructured_api_key_endpoint(
 def validate_contextual_rag_model(
     model_configuration_id: int | None,
     db_session: Session,
+    enable_contextual_rag: bool = False,
 ) -> None:
     if model_configuration_id is None:
+        if (
+            enable_contextual_rag
+            and fetch_default_contextual_rag_model(db_session) is None
+        ):
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                "Contextual Retrieval is enabled but no Contextual Retrieval "
+                "model is configured, and no tenant default exists.",
+            )
         return
     from onyx.db.models import ModelConfiguration
 

--- a/backend/onyx/server/manage/search_settings.py
+++ b/backend/onyx/server/manage/search_settings.py
@@ -129,12 +129,15 @@ def set_new_search_settings(
             db_session, search_settings_id=secondary_search_settings.id
         )
 
-    # Every new FUTURE reindexes via the port flow: re-embed PRESENT -> FUTURE in
-    # place rather than re-fetching from connectors.
+    # Every new FUTURE reindexes via the port flow (re-embed PRESENT -> FUTURE in
+    # place, no connector re-fetch). commit=False here and below so the FUTURE and
+    # its seeds commit together: a FUTURE visible before its seeds makes workers
+    # re-scan from scratch instead of resuming from PRESENT's poll cursor.
     new_search_settings = create_search_settings(
         search_settings=new_search_settings_request,
         db_session=db_session,
         use_port_flow=True,
+        commit=False,
     )
 
     # Ensure the document indices have the new index immediately.
@@ -150,13 +153,16 @@ def set_new_search_settings(
     # Pause index attempts for the currently in-use index to preserve resources.
     if DISABLE_INDEX_UPDATE_ON_SWAP:
         expire_index_attempts(
-            search_settings_id=search_settings.id, db_session=db_session
+            search_settings_id=search_settings.id,
+            db_session=db_session,
+            commit=False,
         )
         for cc_pair in get_connector_credential_pairs(db_session):
             resync_cc_pair(
                 cc_pair=cc_pair,
                 search_settings_id=new_search_settings.id,
                 db_session=db_session,
+                commit=False,
             )
 
     # Seed the port flow: one SUCCESS synthetic IndexAttempt per in-scope cc_pair
@@ -186,6 +192,7 @@ def set_new_search_settings(
                 db_session=db_session,
             )
 
+    # Atomic: FUTURE row and its seeds become visible together.
     db_session.commit()
     return IdReturn(id=new_search_settings.id)
 

--- a/backend/scripts/dev_run_background_jobs.py
+++ b/backend/scripts/dev_run_background_jobs.py
@@ -41,7 +41,7 @@ def run_jobs() -> None:
         "--loglevel=INFO",
         "--hostname=light@%n",
         "-Q",
-        "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration",
+        "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration,port",
     ]
 
     cmd_worker_docprocessing = [

--- a/backend/shared_configs/configs.py
+++ b/backend/shared_configs/configs.py
@@ -129,6 +129,8 @@ PRESERVED_SEARCH_FIELDS = [
     "normalize",
     "passage_prefix",
     "query_prefix",
+    # Server-controlled reindex-flow flag; immutable for a given settings id.
+    "use_port_flow",
 ]
 
 

--- a/backend/shared_configs/configs.py
+++ b/backend/shared_configs/configs.py
@@ -129,7 +129,7 @@ PRESERVED_SEARCH_FIELDS = [
     "normalize",
     "passage_prefix",
     "query_prefix",
-    # Server-controlled reindex-flow flag; immutable for a given settings id.
+    # Immutable per settings id; server-controlled, never set via update.
     "use_port_flow",
 ]
 

--- a/backend/supervisord.conf
+++ b/backend/supervisord.conf
@@ -44,7 +44,7 @@ stopasgroup=true
 [program:celery_worker_light]
 command=celery -A onyx.background.celery.versioned_apps.light worker
     --hostname=light@%%n
-    -Q vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration
+    -Q vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration,port
 stdout_logfile=/var/log/celery_worker_light.log
 stdout_logfile_maxbytes=16MB
 redirect_stderr=true

--- a/backend/tests/external_dependency_unit/db/test_port_flow_e2e.py
+++ b/backend/tests/external_dependency_unit/db/test_port_flow_e2e.py
@@ -1,0 +1,378 @@
+"""End-to-end composition test for the reindex port flow (MODEL_ONLY strategy).
+
+Proves the layers COMPOSE with NO PortCopier mocking: check_for_port kickoff ->
+run_port_attempt (real PIT scan of PRESENT + real re-embed under the FUTURE model
+via the local model server + create-only write to FUTURE) -> the port-aware
+swap promotion. Asserts the FUTURE chunks carry the seeded content with a freshly
+re-embedded 768-dim vector (different from the seeded placeholder), and that the
+swap flips our FUTURE row to PRESENT and the present-like row to PAST.
+
+Uses real Postgres + Redis + OpenSearch + the indexing model server.
+Restores the dev DB's real current
+SearchSettings row in teardown (this dev DB has a leftover PRESENT row + a stale
+FUTURE row, so we never rely on the live current/secondary settings being ours).
+"""
+
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from unittest.mock import MagicMock
+from unittest.mock import patch
+from uuid import uuid4
+
+from sqlalchemy.orm import Session
+
+from onyx.access.models import DocumentAccess
+from onyx.background.celery.tasks.port import tasks as port_task
+from onyx.background.celery.tasks.port.tasks import run_check_for_port
+from onyx.background.celery.tasks.port.tasks import run_port_attempt
+from onyx.configs.constants import DocumentSource
+from onyx.configs.model_configs import ASYM_PASSAGE_PREFIX
+from onyx.configs.model_configs import ASYM_QUERY_PREFIX
+from onyx.context.search.models import SavedSearchSettings
+from onyx.db import swap_index
+from onyx.db.enums import EmbeddingPrecision
+from onyx.db.enums import IndexingStatus
+from onyx.db.enums import IndexModelStatus
+from onyx.db.enums import PortAttemptStatus
+from onyx.db.enums import SwitchoverType
+from onyx.db.models import ConnectorCredentialPair
+from onyx.db.models import IndexAttempt
+from onyx.db.models import PortAttempt
+from onyx.db.models import SearchSettings
+from onyx.db.port_attempt import get_port_attempt
+from onyx.db.search_settings import create_search_settings
+from onyx.db.search_settings import get_current_search_settings
+from onyx.document_index.interfaces_new import TenantState
+from onyx.document_index.opensearch.client import OpenSearchIndexClient
+from onyx.document_index.opensearch.constants import DEFAULT_MAX_CHUNK_SIZE
+from onyx.document_index.opensearch.opensearch_document_index import (
+    generate_opensearch_filtered_access_control_list,
+)
+from onyx.document_index.opensearch.schema import DocumentChunk
+from onyx.document_index.opensearch.schema import DocumentSchema
+from onyx.document_index.opensearch.schema import get_opensearch_doc_chunk_id
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
+from shared_configs.contextvars import get_current_tenant_id
+from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair
+from tests.external_dependency_unit.indexing_helpers import make_cc_pair
+from tests.external_dependency_unit.indexing_helpers import seed_cc_pair_documents
+
+_VECTOR_DIM = 768
+_CHUNKS_PER_DOC = 2
+_NUM_DOCS = 4
+# A constant placeholder vector seeded into PRESENT; the port re-embeds, so the
+# FUTURE vector must differ from this to prove a real embed happened.
+_PLACEHOLDER_VECTOR = [0.123] * _VECTOR_DIM
+# Real sentences so the local embedder produces meaningful, non-degenerate vectors.
+_CHUNK_SENTENCES = [
+    "The migration ports stored chunks from the present index to the future one.",
+    "Each chunk is re-embedded under the new model before it is written.",
+    "External versioning ensures the newest source write wins on a conflict.",
+    "The swap promotes the future settings once every required port succeeds.",
+    "Documents reach the future index only through the reindex port flow.",
+    "A point-in-time scan reads the present chunks without their vectors.",
+    "The embedder runs against the local model server during the port.",
+    "Cursor commits make a crashed or stalled port resume rather than restart.",
+]
+
+
+def _make_chunk(
+    document_id: str,
+    chunk_index: int,
+    content: str,
+    tenant_state: TenantState,
+    last_updated: datetime,
+) -> DocumentChunk:
+    """Minimal PRESENT chunk seeded for the port to scan + re-embed. content is a
+    real sentence; content_vector is the placeholder the port must overwrite."""
+    access = DocumentAccess.build(
+        user_emails=[],
+        user_groups=[],
+        external_user_emails=[],
+        external_user_group_ids=[],
+        is_public=True,
+    )
+    return DocumentChunk(
+        document_id=document_id,
+        chunk_index=chunk_index,
+        title=None,
+        title_vector=None,
+        content=content,
+        content_vector=list(_PLACEHOLDER_VECTOR),
+        source_type=DocumentSource.FILE.value,
+        metadata_list=None,
+        last_updated=last_updated,
+        public=access.is_public,
+        access_control_list=generate_opensearch_filtered_access_control_list(access),
+        hidden=False,
+        global_boost=0,
+        semantic_identifier=f"semantic-{document_id}",
+        image_file_id=None,
+        source_links=None,
+        blurb="blurb",
+        doc_summary="",
+        chunk_context="",
+        document_sets=None,
+        user_projects=None,
+        primary_owners=None,
+        secondary_owners=None,
+        tenant_id=tenant_state,
+    )
+
+
+def _make_saved_settings(
+    *,
+    index_name: str,
+    use_port_flow: bool,
+    switchover_type: SwitchoverType,
+) -> SavedSearchSettings:
+    """nomic MODEL_ONLY settings (contextual RAG off, provider None -> local
+    model server)."""
+    return SavedSearchSettings(
+        model_name="nomic-ai/nomic-embed-text-v1",
+        model_dim=_VECTOR_DIM,
+        normalize=True,
+        query_prefix=ASYM_QUERY_PREFIX,
+        passage_prefix=ASYM_PASSAGE_PREFIX,
+        provider_type=None,
+        index_name=index_name,
+        multipass_indexing=False,
+        embedding_precision=EmbeddingPrecision.FLOAT,
+        reduced_dimension=None,
+        enable_contextual_rag=False,
+        contextual_rag_llm_name=None,
+        contextual_rag_llm_provider=None,
+        switchover_type=switchover_type,
+        use_port_flow=use_port_flow,
+    )
+
+
+def _create_os_index(index_name: str) -> OpenSearchIndexClient:
+    client = OpenSearchIndexClient(index_name=index_name)
+    mappings = DocumentSchema.get_document_schema(
+        vector_dimension=_VECTOR_DIM, multitenant=False
+    )
+    settings = DocumentSchema.get_index_settings_based_on_environment()
+    client.create_index(mappings=mappings, settings=settings)
+    return client
+
+
+def test_port_flow_end_to_end(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    tenant_state = TenantState(tenant_id=POSTGRES_DEFAULT_SCHEMA, multitenant=False)
+    present_index_name = f"test_e2e_present_{uuid4().hex[:8]}"
+    future_index_name = f"test_e2e_future_{uuid4().hex[:8]}"
+
+    # The dev DB's real current row — restore this in teardown.
+    original_present_id = get_current_search_settings(db_session).id
+
+    pair: ConnectorCredentialPair | None = None
+    present_like_id: int | None = None
+    future_id: int | None = None
+    present_client: OpenSearchIndexClient | None = None
+    future_client: OpenSearchIndexClient | None = None
+    promoted = False
+
+    try:
+        # --- SETUP: cc_pair + docs ---
+        pair = make_cc_pair(db_session)
+        doc_ids = seed_cc_pair_documents(
+            db_session, pair, _NUM_DOCS, prefix="e2edoc-", unique=True
+        )
+
+        # --- SETUP: SearchSettings (present-like PAST + FUTURE) ---
+        present_like = create_search_settings(
+            _make_saved_settings(
+                index_name=present_index_name,
+                use_port_flow=False,
+                switchover_type=SwitchoverType.REINDEX,
+            ),
+            db_session,
+            status=IndexModelStatus.PAST,
+        )
+        present_like_id = present_like.id
+        future = create_search_settings(
+            _make_saved_settings(
+                index_name=future_index_name,
+                use_port_flow=True,
+                switchover_type=SwitchoverType.REINDEX,
+            ),
+            db_session,
+            status=IndexModelStatus.FUTURE,
+        )
+        future_id = future.id
+
+        # --- SETUP: OpenSearch indices + seed PRESENT chunks ---
+        present_client = _create_os_index(present_index_name)
+        future_client = _create_os_index(future_index_name)
+
+        seeded_ts = datetime.now(timezone.utc).replace(microsecond=0)
+        seeded_content: dict[tuple[str, int], str] = {}
+        chunks: list[DocumentChunk] = []
+        for d_i, doc_id in enumerate(doc_ids):
+            for c_i in range(_CHUNKS_PER_DOC):
+                content = _CHUNK_SENTENCES[
+                    (d_i * _CHUNKS_PER_DOC + c_i) % len(_CHUNK_SENTENCES)
+                ]
+                seeded_content[(doc_id, c_i)] = content
+                chunks.append(
+                    _make_chunk(doc_id, c_i, content, tenant_state, seeded_ts)
+                )
+        present_client.bulk_index_documents(documents=chunks, tenant_state=tenant_state)
+        present_client.refresh_index()
+
+        # --- KICKOFF: check_for_port scoped to our FUTURE + cc_pair ---
+        celery_app = MagicMock()
+        with (
+            patch.object(
+                port_task,
+                "get_secondary_search_settings",
+                lambda db, *_, **__: db.get(SearchSettings, future_id),
+            ),
+            patch.object(
+                port_task,
+                "fetch_indexable_standard_connector_credential_pair_ids",
+                lambda *_, **__: [pair.id],
+            ),
+        ):
+            result = run_check_for_port(get_current_tenant_id(), celery_app)
+        assert result == 1
+        attempt_id = celery_app.send_task.call_args.kwargs["kwargs"]["port_attempt_id"]
+
+        # --- PORT: real PortCopier (re-embed via model server) ---
+        # get_current_search_settings is patched to our present-like row only
+        # (the dev DB's live current row has no real model / index).
+        with patch.object(
+            port_task,
+            "get_current_search_settings",
+            lambda db: db.get(SearchSettings, present_like_id),
+        ):
+            run_port_attempt(attempt_id)
+
+        # --- ASSERT PORT ---
+        db_session.expire_all()
+        attempt = get_port_attempt(db_session, attempt_id)
+        assert attempt is not None
+        assert attempt.status == PortAttemptStatus.SUCCESS
+        assert attempt.last_processed_doc_id == max(doc_ids)
+        assert attempt.docs_ported == _NUM_DOCS
+
+        future_client.refresh_index()
+        for doc_id in doc_ids:
+            for c_i in range(_CHUNKS_PER_DOC):
+                chunk_id = get_opensearch_doc_chunk_id(
+                    tenant_state=tenant_state,
+                    document_id=doc_id,
+                    chunk_index=c_i,
+                    max_chunk_size=DEFAULT_MAX_CHUNK_SIZE,
+                )
+                fetched = future_client.get_document(document_chunk_id=chunk_id)
+                assert fetched.content == seeded_content[(doc_id, c_i)]
+                assert len(fetched.content_vector) == _VECTOR_DIM
+                # The port re-embedded: the vector is NOT the seeded placeholder.
+                assert fetched.content_vector != _PLACEHOLDER_VECTOR
+
+        # --- SWAP ---
+        port_row = get_port_attempt(db_session, attempt_id)
+        assert port_row is not None and port_row.time_completed is not None
+        # A real (non-seed) FUTURE index attempt landing after the port.
+        index_started = port_row.time_completed + timedelta(seconds=1)
+        db_session.add(
+            IndexAttempt(
+                connector_credential_pair_id=pair.id,
+                search_settings_id=future_id,
+                from_beginning=False,
+                status=IndexingStatus.SUCCESS,
+                is_synthetic_seed=False,
+                time_started=index_started,
+                time_updated=index_started,
+            )
+        )
+        db_session.commit()
+
+        # check_and_perform_index_swap fetches the FUTURE row via
+        # get_secondary_search_settings (a stale FUTURE row exists in this dev
+        # DB), and get_all_document_indices would touch real Vespa/OpenSearch
+        # provisioning -> patch both in the swap_index namespace. The deferred
+        # metadata-sync backlog is 0 in this dev DB; if it weren't, the swap
+        # criterion would block, so we don't need to patch the count.
+        # _required_cc_pairs_for_switchover gates the swap on EVERY indexable
+        # cc_pair in the dev DB (via fetch_indexable...), none of which have a
+        # port for our FUTURE -> scope the required set to our cc_pair only.
+        with (
+            patch.object(
+                swap_index,
+                "get_secondary_search_settings",
+                lambda db: db.get(SearchSettings, future_id),
+            ),
+            patch.object(
+                swap_index,
+                "fetch_indexable_standard_connector_credential_pair_ids",
+                lambda *_, **__: [pair.id],
+            ),
+            patch.object(swap_index, "get_all_document_indices", return_value=[]),
+        ):
+            old_settings = swap_index.check_and_perform_index_swap(db_session)
+
+        assert old_settings is not None
+        promoted = True
+
+        # --- ASSERT SWAP ---
+        db_session.expire_all()
+        future_row = db_session.get(SearchSettings, future_id)
+        present_like_row = db_session.get(SearchSettings, present_like_id)
+        assert future_row is not None and present_like_row is not None
+        assert future_row.status == IndexModelStatus.PRESENT
+        assert present_like_row.status == IndexModelStatus.PAST
+    finally:
+        db_session.rollback()
+        # Restore the dev DB's swap state FIRST: original current -> PRESENT, our
+        # promoted row off PRESENT (so get_current_search_settings is correct
+        # again). _perform_index_swap also set original_present_id -> PAST.
+        if promoted and original_present_id is not None:
+            db_session.query(SearchSettings).filter(
+                SearchSettings.id == original_present_id
+            ).update(
+                {SearchSettings.status: IndexModelStatus.PRESENT},
+                synchronize_session="fetch",
+            )
+            if future_id is not None:
+                db_session.query(SearchSettings).filter(
+                    SearchSettings.id == future_id
+                ).update(
+                    {SearchSettings.status: IndexModelStatus.PAST},
+                    synchronize_session="fetch",
+                )
+            db_session.commit()
+
+        # PortAttempt + IndexAttempt before SearchSettings before cc_pair.
+        if pair is not None:
+            db_session.query(PortAttempt).filter(
+                PortAttempt.cc_pair_id == pair.id
+            ).delete(synchronize_session="fetch")
+            db_session.query(IndexAttempt).filter(
+                IndexAttempt.connector_credential_pair_id == pair.id
+            ).delete(synchronize_session="fetch")
+            db_session.commit()
+
+        for ss_id in (future_id, present_like_id):
+            if ss_id is not None:
+                db_session.query(SearchSettings).filter(
+                    SearchSettings.id == ss_id
+                ).delete(synchronize_session="fetch")
+        db_session.commit()
+
+        if pair is not None:
+            cleanup_cc_pair(db_session, pair)
+
+        for client in (present_client, future_client):
+            if client is not None:
+                try:
+                    client.delete_index()
+                except Exception:
+                    pass
+                finally:
+                    client.close()

--- a/backend/tests/external_dependency_unit/db/test_port_metadata_defer_e2e.py
+++ b/backend/tests/external_dependency_unit/db/test_port_metadata_defer_e2e.py
@@ -36,6 +36,10 @@ from onyx.db.enums import EmbeddingPrecision
 from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import Document as DbDocument
 from onyx.db.models import DocumentByConnectorCredentialPair
+from onyx.db.models import SearchSettings
+from onyx.db.port_attempt import any_future_port_in_progress
+from onyx.db.port_attempt import create_port_attempt
+from onyx.db.port_attempt import mark_port_in_progress
 from onyx.document_index.interfaces_new import MetadataUpdateRequest
 from onyx.document_index.interfaces_new import SecondaryIndexDocumentMissingError
 from onyx.document_index.interfaces_new import TenantState
@@ -53,6 +57,7 @@ from onyx.document_index.opensearch.schema import get_opensearch_doc_chunk_id
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
 from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair
 from tests.external_dependency_unit.indexing_helpers import make_cc_pair
+from tests.external_dependency_unit.indexing_helpers import make_future_search_settings
 
 _VECTOR_DIM = 8  # tiny: this test never re-embeds, it only updates metadata
 _CHUNKS_PER_DOC = 2
@@ -85,18 +90,22 @@ def _make_chunk(
     chunk_index: int,
     access: DocumentAccess,
     last_updated: datetime | None = None,
+    content: str | None = None,
 ) -> DocumentChunk:
     # The port re-copies the SAME stored PRESENT chunk on a batch retry, so its
     # doc_updated_at (the external version) is identical across retries — callers
     # exercising the retry race must pin last_updated rather than take now().
     if last_updated is None:
         last_updated = datetime.now(timezone.utc).replace(microsecond=0)
+    # Distinct content lets a test prove a write overwrote (vs merely merged acls).
+    if content is None:
+        content = f"chunk {chunk_index} of {document_id}"
     return DocumentChunk(
         document_id=document_id,
         chunk_index=chunk_index,
         title=None,
         title_vector=None,
-        content=f"chunk {chunk_index} of {document_id}",
+        content=content,
         content_vector=list(_PLACEHOLDER_VECTOR),
         source_type=DocumentSource.FILE.value,
         metadata_list=None,
@@ -146,6 +155,13 @@ def _read_acl(client: OpenSearchIndexClient, doc_id: str, chunk_index: int) -> s
     return set(client.get_document(document_chunk_id=chunk_id).access_control_list)
 
 
+def _read_content(client: OpenSearchIndexClient, doc_id: str, chunk_index: int) -> str:
+    chunk_id = get_opensearch_doc_chunk_id(
+        tenant_state=_TENANT_STATE, document_id=doc_id, chunk_index=chunk_index
+    )
+    return client.get_document(document_chunk_id=chunk_id).content
+
+
 @pytest.fixture
 def env(
     db_session: Session,
@@ -187,6 +203,37 @@ def env(
                 pass
             finally:
                 client.close()
+
+
+@pytest.fixture
+def future_port(
+    db_session: Session,
+    env: tuple[
+        ConnectorCredentialPair,
+        str,
+        OpenSearchIndexClient,
+        OpenSearchIndexClient,
+        str,
+        str,
+    ],
+) -> Generator[int, None, None]:
+    """An IN_PROGRESS PortAttempt against an isolated FUTURE SearchSettings, so the
+    interleavings below run while any_future_port_in_progress() is genuinely True --
+    i.e. a real, live port. Deleting the FUTURE settings on teardown cascades the
+    attempt (FK ondelete=CASCADE) before env tears down the cc_pair."""
+    pair = env[0]
+    future = make_future_search_settings(db_session, use_port_flow=True)
+    future_id = future.id
+    attempt = create_port_attempt(db_session, pair.id, future_id)
+    mark_port_in_progress(db_session, attempt.id)
+    try:
+        yield future_id
+    finally:
+        db_session.rollback()
+        db_session.query(SearchSettings).filter(SearchSettings.id == future_id).delete(
+            synchronize_session="fetch"
+        )
+        db_session.commit()
 
 
 def test_deferred_metadata_sync_no_stale_permission_leak(
@@ -391,3 +438,129 @@ def test_metadata_sync_does_not_defer_non_indexable_only_doc(
             DocumentByConnectorCredentialPair.id == doc_id
         ).delete(synchronize_session="fetch")
         db_session.commit()
+
+
+def test_forward_write_wins_over_concurrent_port_copy(
+    db_session: Session,
+    env: tuple[
+        ConnectorCredentialPair,
+        str,
+        OpenSearchIndexClient,
+        OpenSearchIndexClient,
+        str,
+        str,
+    ],
+    future_port: int,  # noqa: ARG001 -- a live IN_PROGRESS port for the duration
+) -> None:
+    """Indexing a doc while a port is in flight. The port copies a STALE snapshot of
+    the doc into FUTURE first (create-only); then the connector forward-indexes the
+    SAME doc with FRESH content via a normal write (update_if_exists, internal
+    versioning). The forward write must OVERWRITE the ported chunk -- a stale backlog
+    copy can never shadow live content. The mirror ordering (forward-first, then a
+    stale port create yielding via a benign 409) lives in
+    test_opensearch_client.test_port_create_only_yields_to_forward_write.
+    """
+    _, doc_id, _present_client, future_client, _present_name, _future_name = env
+    assert any_future_port_in_progress(db_session) is True
+
+    # 1. Port copies the doc into FUTURE first: stale content + old access, create-only.
+    future_client.bulk_index_documents(
+        documents=[
+            _make_chunk(doc_id, c_i, _ACCESS_OLD, content=f"stale {c_i} of {doc_id}")
+            for c_i in range(_CHUNKS_PER_DOC)
+        ],
+        tenant_state=_TENANT_STATE,
+        use_create_only=True,
+    )
+    future_client.refresh_index()
+    assert _read_content(future_client, doc_id, 0) == f"stale 0 of {doc_id}"
+    assert _read_acl(future_client, doc_id, 0) == _ACL_OLD
+
+    # 2. Connector forward-indexes the SAME doc into FUTURE: fresh content + new
+    #    access, a normal overwrite (NOT create-only).
+    future_client.bulk_index_documents(
+        documents=[
+            _make_chunk(doc_id, c_i, _ACCESS_NEW, content=f"fresh {c_i} of {doc_id}")
+            for c_i in range(_CHUNKS_PER_DOC)
+        ],
+        tenant_state=_TENANT_STATE,
+        update_if_exists=True,
+    )
+    future_client.refresh_index()
+
+    # 3. The forward write won: FUTURE holds the fresh content + new access, not the
+    #    stale ported snapshot.
+    for c_i in range(_CHUNKS_PER_DOC):
+        assert _read_content(future_client, doc_id, c_i) == f"fresh {c_i} of {doc_id}"
+        assert _read_acl(future_client, doc_id, c_i) == _ACL_NEW
+
+
+def test_acl_update_during_port_applies_to_both_indices(
+    db_session: Session,
+    env: tuple[
+        ConnectorCredentialPair,
+        str,
+        OpenSearchIndexClient,
+        OpenSearchIndexClient,
+        str,
+        str,
+    ],
+    future_port: int,  # noqa: ARG001 -- a live IN_PROGRESS port for the duration
+) -> None:
+    """Updating a doc's permissions while a port is in flight, for a doc the port has
+    ALREADY copied into FUTURE. The pair update lands on BOTH PRESENT and FUTURE in
+    one shot -- no SecondaryIndexDocumentMissingError, so the doc is NOT (falsely)
+    deferred and the swap-gate backlog count is unchanged. The mirror case (doc still
+    MISSING from FUTURE, which defers correctly) is
+    test_deferred_metadata_sync_no_stale_permission_leak.
+    """
+    _, doc_id, present_client, future_client, present_name, future_name = env
+    assert any_future_port_in_progress(db_session) is True
+
+    # PRESENT (forward-indexed) and FUTURE (port-copied) both already hold the doc
+    # with the old access -- the port reached this doc before the permission change.
+    present_client.bulk_index_documents(
+        documents=[
+            _make_chunk(doc_id, c_i, _ACCESS_OLD) for c_i in range(_CHUNKS_PER_DOC)
+        ],
+        tenant_state=_TENANT_STATE,
+    )
+    future_client.bulk_index_documents(
+        documents=[
+            _make_chunk(doc_id, c_i, _ACCESS_OLD) for c_i in range(_CHUNKS_PER_DOC)
+        ],
+        tenant_state=_TENANT_STATE,
+        use_create_only=True,
+    )
+    present_client.refresh_index()
+    future_client.refresh_index()
+
+    pair_index = OpenSearchIndexPair(
+        primary=_index(present_name),
+        secondary=_index(future_name),
+        secondary_embedding_dim=_VECTOR_DIM,
+        secondary_embedding_precision=EmbeddingPrecision.FLOAT,
+    )
+    req = MetadataUpdateRequest(
+        document_ids=[doc_id],
+        doc_id_to_chunk_cnt={doc_id: _CHUNKS_PER_DOC},
+        access=_ACCESS_NEW,
+    )
+    baseline_deferred = count_secondary_only_sync_pending_documents(db_session)
+
+    # The permission change while the port runs: the doc exists in BOTH indices, so
+    # the pair update succeeds outright -- no defer signal is raised.
+    pair_index.update([req])
+    mark_document_as_synced(doc_id, db_session)  # the sync task's success branch
+
+    present_client.refresh_index()
+    future_client.refresh_index()
+    assert _read_acl(present_client, doc_id, 0) == _ACL_NEW
+    assert _read_acl(future_client, doc_id, 0) == _ACL_NEW
+    assert _read_acl(future_client, doc_id, 1) == _ACL_NEW
+
+    # The doc was never deferred -> the swap-gate backlog is unchanged.
+    db_session.expire_all()
+    doc = db_session.get(DbDocument, doc_id)
+    assert doc is not None and doc.secondary_only_sync_pending is False
+    assert count_secondary_only_sync_pending_documents(db_session) == baseline_deferred

--- a/backend/tests/external_dependency_unit/db/test_reindex_port.py
+++ b/backend/tests/external_dependency_unit/db/test_reindex_port.py
@@ -1,0 +1,1211 @@
+"""External dependency unit tests for the reindexing-port DB layer.
+
+Scoped to behavior/invariants worth guarding (the column existence + defaults are
+covered by applying the migration, which this repo does not test programmatically):
+- the partial-unique "one active attempt per (cc_pair, FUTURE)" index — and that
+  its predicate matches the stored (uppercase) enum name, not the value
+- the PortAttempt lifecycle helpers (create -> in_progress -> cursor -> terminal)
+  and first-terminal-write-wins
+- mark_document_synced_secondary_pending sets the flag (and clears needs-sync),
+  and a later mark_document_as_synced clears it again
+- the synthetic seed: writer row shape, seed-blind filtering for counts/latest/swap (a
+  seed must not count toward the swap or appear as the latest run) while it DOES prime the
+  resume poll cursor, and the gated should_index FUTURE branch (legacy once-only vs
+  port-flow continuous)
+- run_port_attempt: ports docs in batches, advances/commits the cursor, retries a
+  failed batch then marks FAILED (cursor left at the prior good batch)
+"""
+
+from collections.abc import Generator
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from typing import cast
+from unittest.mock import MagicMock
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from onyx.background.celery.tasks.beat_schedule import BEAT_EXPIRES_DEFAULT
+from onyx.background.celery.tasks.docprocessing.utils import should_index
+from onyx.background.celery.tasks.port import tasks as port_task
+from onyx.background.celery.tasks.port.tasks import run_check_for_port
+from onyx.background.celery.tasks.port.tasks import run_port_attempt
+from onyx.configs.app_configs import INDEX_BATCH_SIZE
+from onyx.configs.constants import OnyxCeleryQueues
+from onyx.configs.constants import OnyxCeleryTask
+from onyx.context.search.models import SavedSearchSettings
+from onyx.db.connector_credential_pair import get_last_successful_attempt_poll_range_end
+from onyx.db.document import document_has_indexable_cc_pair
+from onyx.db.document import get_document_ids_for_cc_pair_batch
+from onyx.db.document import mark_document_as_modified
+from onyx.db.document import mark_document_as_synced
+from onyx.db.document import mark_document_synced_secondary_pending
+from onyx.db.enums import ConnectorCredentialPairStatus
+from onyx.db.enums import EmbeddingPrecision
+from onyx.db.enums import IndexingStatus
+from onyx.db.enums import IndexModelStatus
+from onyx.db.enums import PortAttemptStatus
+from onyx.db.index_attempt import (
+    count_unique_active_cc_pairs_with_successful_index_attempts,
+)
+from onyx.db.index_attempt import count_unique_cc_pairs_with_successful_index_attempts
+from onyx.db.index_attempt import create_synthetic_seed_attempt
+from onyx.db.index_attempt import get_latest_successful_index_attempt_for_cc_pair_id
+from onyx.db.index_attempt import mock_successful_index_attempt
+from onyx.db.models import ConnectorCredentialPair
+from onyx.db.models import Document as DbDocument
+from onyx.db.models import DocumentByConnectorCredentialPair
+from onyx.db.models import IndexAttempt
+from onyx.db.models import PortAttempt
+from onyx.db.models import SearchSettings
+from onyx.db.port_attempt import cancel_active_port_attempts
+from onyx.db.port_attempt import commit_port_cursor
+from onyx.db.port_attempt import count_consecutive_failed_port_attempts_no_progress
+from onyx.db.port_attempt import create_port_attempt
+from onyx.db.port_attempt import get_active_port_attempt
+from onyx.db.port_attempt import get_latest_port_attempt
+from onyx.db.port_attempt import mark_port_canceled
+from onyx.db.port_attempt import mark_port_failed
+from onyx.db.port_attempt import mark_port_in_progress
+from onyx.db.port_attempt import mark_port_succeeded
+from onyx.db.search_settings import create_search_settings
+from onyx.db.search_settings import get_current_search_settings
+from onyx.db.swap_index import _port_swap_ready
+from onyx.document_index.opensearch import port_copy
+from onyx.document_index.opensearch.port_copy import copy_present_chunks_to_future
+from onyx.indexing.port_reembed import ReembedStrategy
+from onyx.kg.models import KGStage
+from shared_configs.contextvars import get_current_tenant_id
+from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair
+from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair_and_future
+from tests.external_dependency_unit.indexing_helpers import make_cc_pair
+from tests.external_dependency_unit.indexing_helpers import make_future_search_settings
+from tests.external_dependency_unit.indexing_helpers import (
+    seed_cc_pair_documents as _seed_cc_pair_documents,
+)
+
+
+def _run_check_for_port(
+    cc_pair: ConnectorCredentialPair,
+    future_id: int,
+    celery_app: MagicMock | None = None,
+) -> tuple[int | None, MagicMock]:
+    """Run check_for_port scoped to this test's FUTURE + cc_pair (the real
+    get_secondary/fetch helpers are global). Returns (result, celery_app)."""
+    celery_app = celery_app or MagicMock()
+    with (
+        patch.object(
+            port_task,
+            "get_secondary_search_settings",
+            lambda db, *_, **__: db.get(SearchSettings, future_id),
+        ),
+        patch.object(
+            port_task,
+            "fetch_indexable_standard_connector_credential_pair_ids",
+            lambda *_, **__: [cc_pair.id],
+        ),
+    ):
+        result = run_check_for_port(get_current_tenant_id(), celery_app)
+    return result, celery_app
+
+
+@pytest.fixture
+def cc_pair(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> Generator[ConnectorCredentialPair, None, None]:
+    pair = make_cc_pair(db_session)
+    try:
+        yield pair
+    finally:
+        db_session.rollback()
+        db_session.query(PortAttempt).filter(PortAttempt.cc_pair_id == pair.id).delete(
+            synchronize_session="fetch"
+        )
+        db_session.commit()
+        cleanup_cc_pair(db_session, pair)
+
+
+def test_port_attempt_active_unique_constraint(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    """At most one active (NOT_STARTED/IN_PROGRESS) attempt per (cc_pair, FUTURE);
+    terminal rows may coexist. Also guards the index predicate against the stored
+    enum casing (uppercase name) — a lowercase predicate would silently no-op."""
+    ss = get_current_search_settings(db_session)
+
+    db_session.add(
+        PortAttempt(
+            cc_pair_id=cc_pair.id,
+            search_settings_id=ss.id,
+            status=PortAttemptStatus.IN_PROGRESS,
+        )
+    )
+    db_session.commit()
+
+    db_session.add(
+        PortAttempt(
+            cc_pair_id=cc_pair.id,
+            search_settings_id=ss.id,
+            status=PortAttemptStatus.NOT_STARTED,
+        )
+    )
+    with pytest.raises(IntegrityError):
+        db_session.commit()
+    db_session.rollback()
+
+    # a terminal attempt for the same pair is allowed (outside the predicate)
+    db_session.add(
+        PortAttempt(
+            cc_pair_id=cc_pair.id,
+            search_settings_id=ss.id,
+            status=PortAttemptStatus.SUCCESS,
+        )
+    )
+    db_session.commit()
+
+    active = (
+        db_session.query(PortAttempt)
+        .filter(
+            PortAttempt.cc_pair_id == cc_pair.id,
+            PortAttempt.status.in_(
+                [PortAttemptStatus.NOT_STARTED, PortAttemptStatus.IN_PROGRESS]
+            ),
+        )
+        .count()
+    )
+    assert active == 1
+
+
+def test_mark_secondary_pending_then_synced_clears_it(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    doc_id = "test-secondary-pending-doc"
+    db_session.add(
+        DbDocument(id=doc_id, semantic_id=doc_id, kg_stage=KGStage.NOT_STARTED)
+    )
+    db_session.commit()
+    try:
+        mark_document_as_modified(doc_id, db_session)  # needs-sync
+
+        # PRESENT synced but FUTURE missing -> defer
+        mark_document_synced_secondary_pending(doc_id, db_session)
+        db_session.expire_all()
+        row = db_session.query(DbDocument).filter(DbDocument.id == doc_id).one()
+        assert row.last_synced is not None and row.last_modified is not None
+        assert row.last_synced >= row.last_modified  # needs-sync cleared
+        assert row.secondary_only_sync_pending is True
+
+        # a later full sync reaches FUTURE -> flag flips back to False
+        mark_document_as_synced(doc_id, db_session)
+        db_session.expire_all()
+        row = db_session.query(DbDocument).filter(DbDocument.id == doc_id).one()
+        assert row.secondary_only_sync_pending is False
+    finally:
+        db_session.query(DbDocument).filter(DbDocument.id == doc_id).delete(
+            synchronize_session="fetch"
+        )
+        db_session.commit()
+
+
+def test_mark_secondary_pending_raises_on_missing_document(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    with pytest.raises(ValueError):
+        mark_document_synced_secondary_pending("does-not-exist", db_session)
+
+
+def test_port_attempt_lifecycle_helpers(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    """create -> in_progress -> cursor commit -> success; get_active tracks the
+    active attempt and stops returning it once the attempt is terminal."""
+    ss = get_current_search_settings(db_session)
+
+    attempt = create_port_attempt(db_session, cc_pair.id, ss.id, celery_task_id="t-1")
+    attempt_id = attempt.id
+    assert attempt.status == PortAttemptStatus.NOT_STARTED
+    assert get_active_port_attempt(db_session, cc_pair.id, ss.id) is not None
+
+    mark_port_in_progress(db_session, attempt_id, celery_task_id="t-1")
+    commit_port_cursor(
+        db_session, attempt_id, last_processed_doc_id="doc-50", docs_ported=50
+    )
+    db_session.expire_all()
+    row = db_session.get(PortAttempt, attempt_id)
+    assert row is not None
+    assert row.status == PortAttemptStatus.IN_PROGRESS
+    assert row.last_processed_doc_id == "doc-50"
+    assert row.docs_ported == 50
+    assert row.time_started is not None and row.last_progress_time is not None
+
+    # a second cursor commit advances the (absolute) cumulative counter
+    commit_port_cursor(
+        db_session, attempt_id, last_processed_doc_id="doc-80", docs_ported=80
+    )
+    db_session.expire_all()
+    row = db_session.get(PortAttempt, attempt_id)
+    assert row is not None
+    assert row.last_processed_doc_id == "doc-80" and row.docs_ported == 80
+
+    mark_port_succeeded(db_session, attempt_id)
+    db_session.expire_all()
+    row = db_session.get(PortAttempt, attempt_id)
+    assert row is not None
+    assert row.status == PortAttemptStatus.SUCCESS
+    assert row.time_completed is not None
+    # terminal attempts are no longer "active"
+    assert get_active_port_attempt(db_session, cc_pair.id, ss.id) is None
+
+
+def test_port_attempt_terminal_is_first_write_wins(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    """A terminal attempt ignores later transitions, so a late task SUCCESS can't
+    clobber a watchdog FAILED (the row lock makes this deterministic)."""
+    ss = get_current_search_settings(db_session)
+    attempt = create_port_attempt(db_session, cc_pair.id, ss.id)
+    mark_port_in_progress(db_session, attempt.id)
+
+    mark_port_failed(db_session, attempt.id, error_msg="stalled")
+    mark_port_succeeded(db_session, attempt.id)  # no-op: already terminal
+
+    db_session.expire_all()
+    row = db_session.get(PortAttempt, attempt.id)
+    assert row is not None
+    assert row.status == PortAttemptStatus.FAILED
+    assert row.error_msg == "stalled"
+
+
+@pytest.fixture
+def cc_pair_and_future(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> Generator[tuple[ConnectorCredentialPair, int], None, None]:
+    """A cc_pair plus an isolated FUTURE SearchSettings (unique index_name) so the
+    global count/cursor helpers see only this test's attempts."""
+    pair = make_cc_pair(db_session)
+    future_id = make_future_search_settings(db_session).id
+    try:
+        yield pair, future_id
+    finally:
+        cleanup_cc_pair_and_future(db_session, pair, future_id)
+
+
+def test_use_port_flow_default_and_round_trip(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    """use_port_flow persists as False via the server default when the saved model
+    omits it, and an explicit True round-trips through a fresh read + the
+    SavedSearchSettings mapper the port flow uses. PAST status avoids the
+    PRESENT-uniqueness + concurrent-FUTURE collisions a round-trip test would hit.
+    """
+
+    def _saved() -> SavedSearchSettings:
+        # Minimal explicit settings (not a clone of the polluted live row) so the
+        # omitted use_port_flow falls through to the server default.
+        return SavedSearchSettings(
+            model_name="test-port-flow-model",
+            model_dim=128,
+            normalize=True,
+            query_prefix="",
+            passage_prefix="",
+            provider_type=None,
+            multipass_indexing=False,
+            embedding_precision=EmbeddingPrecision.FLOAT,
+            index_name=f"test_port_flow_{uuid4().hex[:8]}",
+            enable_contextual_rag=False,
+        )
+
+    default_id = create_search_settings(
+        _saved(), db_session, status=IndexModelStatus.PAST
+    ).id
+    true_id = create_search_settings(
+        _saved().model_copy(update={"use_port_flow": True}),
+        db_session,
+        status=IndexModelStatus.PAST,
+    ).id
+    try:
+        db_session.expire_all()
+        default_fresh = db_session.get(SearchSettings, default_id)
+        assert default_fresh is not None and default_fresh.use_port_flow is False
+        true_fresh = db_session.get(SearchSettings, true_id)
+        assert true_fresh is not None and true_fresh.use_port_flow is True
+        # Rehydrate through the pydantic mapper the port flow reads through.
+        assert SavedSearchSettings.from_db_model(true_fresh).use_port_flow is True
+    finally:
+        for row_id in (default_id, true_id):
+            row = db_session.get(SearchSettings, row_id)
+            if row is not None:
+                db_session.delete(row)
+        db_session.commit()
+
+
+def test_create_synthetic_seed_attempt(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    cc_pair, future_id = cc_pair_and_future
+    epoch = 1_700_000_000.0
+
+    seed_id = create_synthetic_seed_attempt(
+        cc_pair.id, future_id, poll_range_end=epoch, db_session=db_session
+    )
+    db_session.expire_all()
+    seed = db_session.get(IndexAttempt, seed_id)
+    assert seed is not None
+    assert seed.status == IndexingStatus.SUCCESS
+    assert seed.is_synthetic_seed is True
+    # time_started == time_created so the swap criterion's "real attempt after the
+    # port" comparison is well-defined for the run that supersedes the seed
+    assert seed.time_started is not None and seed.time_created is not None
+    assert seed.time_started == seed.time_created
+    assert seed.poll_range_end is not None
+    assert seed.poll_range_end.timestamp() == epoch
+
+
+def test_seed_excluded_from_latest_and_counts(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    cc_pair, future_id = cc_pair_and_future
+
+    # only a synthetic seed exists
+    create_synthetic_seed_attempt(
+        cc_pair.id, future_id, poll_range_end=1000.0, db_session=db_session
+    )
+    db_session.expire_all()
+    assert (
+        count_unique_cc_pairs_with_successful_index_attempts(future_id, db_session) == 0
+    )
+    assert (
+        count_unique_active_cc_pairs_with_successful_index_attempts(
+            future_id, db_session
+        )
+        == 0
+    )
+    assert (
+        get_latest_successful_index_attempt_for_cc_pair_id(
+            db_session, cc_pair.id, secondary_index=True
+        )
+        is None
+    )
+
+    # a real SUCCESS attempt IS counted and returned
+    real_id = mock_successful_index_attempt(
+        cc_pair.id, future_id, docs_indexed=5, db_session=db_session
+    )
+    db_session.expire_all()
+    assert (
+        count_unique_cc_pairs_with_successful_index_attempts(future_id, db_session) == 1
+    )
+    latest = get_latest_successful_index_attempt_for_cc_pair_id(
+        db_session, cc_pair.id, secondary_index=True
+    )
+    assert latest is not None and latest.id == real_id
+
+
+def test_seed_primes_poll_cursor(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """The seed IS the resume cursor: with only a seed present, the FUTURE's first
+    connector attempt starts from PRESENT's cursor (carried by the seed), not the
+    earliest_index fallback. A later real SUCCESS attempt then supersedes the seed."""
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+
+    seed_cursor = 1000.0
+    create_synthetic_seed_attempt(
+        cc_pair.id, future_id, poll_range_end=seed_cursor, db_session=db_session
+    )
+    db_session.expire_all()
+    # resume from the seed cursor, not the earliest_index arg (42.0)
+    assert (
+        get_last_successful_attempt_poll_range_end(
+            cc_pair.id, 42.0, future_ss, db_session
+        )
+        == seed_cursor
+    )
+
+    # a real SUCCESS attempt with a later cursor supersedes the seed
+    later_cursor = seed_cursor + 5000.0
+    real_id = mock_successful_index_attempt(
+        cc_pair.id, future_id, docs_indexed=5, db_session=db_session
+    )
+    real = db_session.get(IndexAttempt, real_id)
+    assert real is not None
+    real.poll_range_end = datetime.fromtimestamp(later_cursor, tz=timezone.utc)
+    db_session.commit()
+    db_session.expire_all()
+    assert (
+        get_last_successful_attempt_poll_range_end(
+            cc_pair.id, 42.0, future_ss, db_session
+        )
+        == later_cursor
+    )
+
+
+def test_should_index_future_gated_on_port_flow(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    cc_pair, future_id = cc_pair_and_future
+    # make the connector pollable on the continuous path
+    cc_pair.connector.refresh_freq = 60
+    # a real SUCCESS attempt, old enough to be re-pollable
+    old = datetime.now(timezone.utc) - timedelta(hours=1)
+    db_session.add(
+        IndexAttempt(
+            connector_credential_pair_id=cc_pair.id,
+            search_settings_id=future_id,
+            from_beginning=True,
+            status=IndexingStatus.SUCCESS,
+            time_started=old,
+            time_updated=old,
+        )
+    )
+    db_session.commit()
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+
+    # legacy (flag off): one success is enough -> don't index again
+    future_ss.use_port_flow = False
+    db_session.commit()
+    assert (
+        should_index(
+            cc_pair, future_ss, secondary_index_building=True, db_session=db_session
+        )
+        is False
+    )
+
+    # port flow (flag on): polls continuously -> index again
+    future_ss.use_port_flow = True
+    db_session.commit()
+    assert (
+        should_index(
+            cc_pair, future_ss, secondary_index_building=True, db_session=db_session
+        )
+        is True
+    )
+
+
+def test_get_document_ids_for_cc_pair_batch(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    """Cursor pagination over a cc_pair's doc ids: ascending, exclusive of the
+    cursor, capped at limit, empty once exhausted -> the port's resume scan."""
+    doc_ids = _seed_cc_pair_documents(db_session, cc_pair, 5)
+
+    first = get_document_ids_for_cc_pair_batch(
+        db_session, cc_pair.id, after_doc_id=None, limit=2
+    )
+    assert first == doc_ids[:2]
+
+    # resume past the last id of the prior page
+    second = get_document_ids_for_cc_pair_batch(
+        db_session, cc_pair.id, after_doc_id=first[-1], limit=2
+    )
+    assert second == doc_ids[2:4]
+
+    third = get_document_ids_for_cc_pair_batch(
+        db_session, cc_pair.id, after_doc_id=second[-1], limit=2
+    )
+    assert third == doc_ids[4:]
+
+    # cursor at/after the last id -> exhausted
+    assert (
+        get_document_ids_for_cc_pair_batch(
+            db_session, cc_pair.id, after_doc_id=doc_ids[-1], limit=2
+        )
+        == []
+    )
+
+
+def test_copy_present_chunks_to_future_orchestration() -> None:
+    """Per batch: each PIT-scan page is re-embedded and written to FUTURE
+    create-only; the return is the total chunks written. Mocks the
+    OpenSearch read/write + re-embed (covered by their own tests)."""
+    present_client = MagicMock()
+    future_index = MagicMock()
+    strategy = cast(ReembedStrategy, MagicMock())
+    embedder = MagicMock()
+    # two pages out of the PIT scan
+    present_client.iter_chunks_for_doc_ids.return_value = iter([["c1", "c2"], ["c3"]])
+
+    with patch.object(
+        port_copy,
+        "re_embed_chunks",
+        side_effect=lambda chunks, _strategy, _embedder, **_kwargs: [
+            f"re:{c}" for c in chunks
+        ],
+    ) as mock_reembed:
+        written = copy_present_chunks_to_future(
+            present_client, future_index, ["d1", "d2"], strategy, embedder
+        )
+
+    assert written == 3
+    present_client.iter_chunks_for_doc_ids.assert_called_once_with(["d1", "d2"])
+    # re-embed once per page, with that page's chunks + prebuilt strategy/embedder
+    assert mock_reembed.call_count == 2
+    assert mock_reembed.call_args_list[0].args == (["c1", "c2"], strategy, embedder)
+    # FUTURE write once per page, always create-only (the port never overwrites)
+    assert future_index.index_raw_chunks.call_count == 2
+    first_write = future_index.index_raw_chunks.call_args_list[0]
+    assert first_write.args[0] == ["re:c1", "re:c2"]
+    assert first_write.kwargs == {"use_create_only": True}
+
+
+def test_run_port_attempt_happy_path(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """Ports every doc in INDEX_BATCH_SIZE batches: copier called once per batch,
+    cursor advanced to the last id, docs_ported == total, status SUCCESS."""
+    cc_pair, future_id = cc_pair_and_future
+    doc_ids = _seed_cc_pair_documents(db_session, cc_pair, INDEX_BATCH_SIZE + 4)
+    attempt_id = create_port_attempt(db_session, cc_pair.id, future_id).id
+
+    mock_copier = MagicMock()
+    mock_copier.copy_doc_batch.side_effect = lambda ids, **_: len(ids)
+    with patch.object(port_task, "PortCopier", return_value=mock_copier):
+        run_port_attempt(attempt_id)
+
+    # two batches: a full INDEX_BATCH_SIZE then the remaining 4
+    assert mock_copier.copy_doc_batch.call_count == 2
+    assert (
+        mock_copier.copy_doc_batch.call_args_list[0].args[0]
+        == doc_ids[:INDEX_BATCH_SIZE]
+    )
+    assert (
+        mock_copier.copy_doc_batch.call_args_list[1].args[0]
+        == doc_ids[INDEX_BATCH_SIZE:]
+    )
+
+    db_session.expire_all()
+    row = db_session.get(PortAttempt, attempt_id)
+    assert row is not None
+    assert row.status == PortAttemptStatus.SUCCESS
+    assert row.last_processed_doc_id == doc_ids[-1]
+    assert row.docs_ported == len(doc_ids)
+    assert row.time_completed is not None
+
+
+def test_run_port_attempt_batch_retry_then_failed(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """A batch that keeps failing is retried _PORT_BATCH_MAX_RETRIES times, then
+    the attempt is FAILED with the cursor un-advanced (a fresh attempt resumes
+    from the prior good batch -- here, the start)."""
+    cc_pair, future_id = cc_pair_and_future
+    _seed_cc_pair_documents(db_session, cc_pair, 3)
+    attempt_id = create_port_attempt(db_session, cc_pair.id, future_id).id
+
+    mock_copier = MagicMock()
+    mock_copier.copy_doc_batch.side_effect = RuntimeError("opensearch down")
+    with (
+        patch.object(port_task, "PortCopier", return_value=mock_copier),
+        patch.object(port_task.time, "sleep"),  # don't sleep between retries
+    ):
+        run_port_attempt(attempt_id)
+
+    assert mock_copier.copy_doc_batch.call_count == port_task._PORT_BATCH_MAX_RETRIES
+    db_session.expire_all()
+    row = db_session.get(PortAttempt, attempt_id)
+    assert row is not None
+    assert row.status == PortAttemptStatus.FAILED
+    assert row.error_msg == "opensearch down"
+    assert row.last_processed_doc_id is None  # cursor never advanced
+    assert row.docs_ported == 0
+    assert row.time_completed is not None
+
+
+def test_run_port_attempt_resumes_from_cursor(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """A resumed attempt scans only ids past its stored cursor and accumulates
+    docs_ported on top of the prior count."""
+    cc_pair, future_id = cc_pair_and_future
+    doc_ids = _seed_cc_pair_documents(db_session, cc_pair, 5)
+    attempt_id = create_port_attempt(db_session, cc_pair.id, future_id).id
+    # simulate a prior partial run: cursor at the 2nd doc, 2 docs ported
+    mark_port_in_progress(db_session, attempt_id)
+    commit_port_cursor(
+        db_session, attempt_id, last_processed_doc_id=doc_ids[1], docs_ported=2
+    )
+
+    mock_copier = MagicMock()
+    mock_copier.copy_doc_batch.side_effect = lambda ids, **_: len(ids)
+    with patch.object(port_task, "PortCopier", return_value=mock_copier):
+        run_port_attempt(attempt_id)
+
+    # only the docs after the cursor are copied
+    assert mock_copier.copy_doc_batch.call_count == 1
+    assert mock_copier.copy_doc_batch.call_args_list[0].args[0] == doc_ids[2:]
+    db_session.expire_all()
+    row = db_session.get(PortAttempt, attempt_id)
+    assert row is not None
+    assert row.status == PortAttemptStatus.SUCCESS
+    assert row.last_processed_doc_id == doc_ids[-1]
+    assert row.docs_ported == 5  # 2 prior + 3 newly ported
+
+
+def test_run_port_attempt_stops_when_canceled(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """An external CANCEL (operator) marks the attempt terminal; the task stops at
+    the next batch boundary with its partial cursor preserved."""
+    cc_pair, future_id = cc_pair_and_future
+    doc_ids = _seed_cc_pair_documents(db_session, cc_pair, INDEX_BATCH_SIZE + 4)
+    attempt_id = create_port_attempt(db_session, cc_pair.id, future_id).id
+
+    def copy_then_cancel(ids: list[str], **_: object) -> int:
+        mark_port_canceled(db_session, attempt_id)  # operator cancels after batch 1
+        return len(ids)
+
+    mock_copier = MagicMock()
+    mock_copier.copy_doc_batch.side_effect = copy_then_cancel
+    with patch.object(port_task, "PortCopier", return_value=mock_copier):
+        run_port_attempt(attempt_id)
+
+    # first batch ran; the CANCELED status stops it at the next boundary
+    assert mock_copier.copy_doc_batch.call_count == 1
+    db_session.expire_all()
+    row = db_session.get(PortAttempt, attempt_id)
+    assert row is not None
+    assert row.status == PortAttemptStatus.CANCELED
+    assert row.last_processed_doc_id == doc_ids[INDEX_BATCH_SIZE - 1]
+    assert row.docs_ported == INDEX_BATCH_SIZE
+
+
+def test_cancel_active_port_attempts_on_supersede(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """Superseding a FUTURE cancels its active (NOT_STARTED/IN_PROGRESS) port
+    attempts — the running task then stops at its next batch — while terminal
+    attempts are left untouched."""
+    cc_pair, future_id = cc_pair_and_future
+
+    active = create_port_attempt(db_session, cc_pair.id, future_id)
+    mark_port_in_progress(db_session, active.id)
+    # a terminal attempt for the same pair/future must be left alone
+    db_session.add(
+        PortAttempt(
+            cc_pair_id=cc_pair.id,
+            search_settings_id=future_id,
+            status=PortAttemptStatus.SUCCESS,
+        )
+    )
+    db_session.commit()
+
+    canceled = cancel_active_port_attempts(db_session, search_settings_id=future_id)
+    assert canceled == 1
+
+    db_session.expire_all()
+    active_row = db_session.get(PortAttempt, active.id)
+    assert active_row is not None
+    assert active_row.status == PortAttemptStatus.CANCELED
+    assert active_row.time_completed is not None
+    # the terminal SUCCESS is preserved (first-terminal-write-wins)
+    successes = (
+        db_session.query(PortAttempt)
+        .filter(
+            PortAttempt.search_settings_id == future_id,
+            PortAttempt.status == PortAttemptStatus.SUCCESS,
+        )
+        .count()
+    )
+    assert successes == 1
+
+
+def test_run_port_attempt_exits_when_cc_pair_deleting(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """A cc_pair flipped to DELETING stops the port at the boundary before any
+    copy (the CASCADE will remove the attempt row)."""
+    cc_pair, future_id = cc_pair_and_future
+    _seed_cc_pair_documents(db_session, cc_pair, 3)
+    attempt_id = create_port_attempt(db_session, cc_pair.id, future_id).id
+    cc_pair.status = ConnectorCredentialPairStatus.DELETING
+    db_session.commit()
+
+    mock_copier = MagicMock()
+    with patch.object(port_task, "PortCopier", return_value=mock_copier):
+        run_port_attempt(attempt_id)
+
+    assert mock_copier.copy_doc_batch.call_count == 0
+    db_session.expire_all()
+    row = db_session.get(PortAttempt, attempt_id)
+    assert row is not None
+    assert row.status == PortAttemptStatus.IN_PROGRESS  # left for the CASCADE to remove
+
+
+def test_run_port_attempt_soft_time_limit_yields(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """Hitting the self-enforced soft time limit yields (no copy, no terminal
+    mark) so the watchdog can reschedule from the cursor."""
+    cc_pair, future_id = cc_pair_and_future
+    _seed_cc_pair_documents(db_session, cc_pair, 3)
+    attempt_id = create_port_attempt(db_session, cc_pair.id, future_id).id
+
+    mock_copier = MagicMock()
+    with (
+        patch.object(port_task, "PortCopier", return_value=mock_copier),
+        patch.object(port_task, "_PORT_SOFT_TIME_LIMIT", -1),  # already "expired"
+    ):
+        run_port_attempt(attempt_id)
+
+    assert mock_copier.copy_doc_batch.call_count == 0
+    db_session.expire_all()
+    row = db_session.get(PortAttempt, attempt_id)
+    assert row is not None
+    assert row.status == PortAttemptStatus.IN_PROGRESS  # not terminal; watchdog resumes
+
+
+def test_check_for_port_creates_and_enqueues(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """A use_port_flow FUTURE with an in-scope cc_pair and no active attempt ->
+    one NOT_STARTED PortAttempt created + run_port_attempt enqueued."""
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    future_ss.use_port_flow = True
+    db_session.commit()
+
+    result, celery_app = _run_check_for_port(cc_pair, future_id)
+
+    assert result == 1
+    db_session.expire_all()
+    attempts = (
+        db_session.query(PortAttempt)
+        .filter(
+            PortAttempt.cc_pair_id == cc_pair.id,
+            PortAttempt.search_settings_id == future_id,
+        )
+        .all()
+    )
+    assert len(attempts) == 1
+    assert attempts[0].status == PortAttemptStatus.NOT_STARTED
+    celery_app.send_task.assert_called_once()
+    call = celery_app.send_task.call_args
+    assert call.args[0] == OnyxCeleryTask.RUN_PORT_ATTEMPT
+    assert call.kwargs["kwargs"] == {
+        "port_attempt_id": attempts[0].id,
+        "tenant_id": get_current_tenant_id(),
+    }
+    assert call.kwargs["queue"] == OnyxCeleryQueues.PORT
+    assert call.kwargs["expires"] == BEAT_EXPIRES_DEFAULT
+
+
+def test_check_for_port_gated_off_when_not_port_flow(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """A legacy FUTURE (use_port_flow=False) is a no-op -> nothing created/enqueued."""
+    cc_pair, future_id = cc_pair_and_future  # use_port_flow stays False (default)
+
+    result, celery_app = _run_check_for_port(cc_pair, future_id)
+
+    assert result is None
+    celery_app.send_task.assert_not_called()
+    assert (
+        db_session.query(PortAttempt)
+        .filter(PortAttempt.cc_pair_id == cc_pair.id)
+        .count()
+        == 0
+    )
+
+
+def test_check_for_port_resumes_failed_cursor(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """A prior FAILED attempt is rescheduled with its cursor carried forward."""
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    future_ss.use_port_flow = True
+    db_session.commit()
+
+    failed = create_port_attempt(db_session, cc_pair.id, future_id)
+    mark_port_in_progress(db_session, failed.id)
+    commit_port_cursor(
+        db_session, failed.id, last_processed_doc_id="portdoc-042", docs_ported=42
+    )
+    mark_port_failed(db_session, failed.id, error_msg="boom")
+
+    result, _ = _run_check_for_port(cc_pair, future_id)
+
+    assert result == 1
+    db_session.expire_all()
+    fresh = (
+        db_session.query(PortAttempt)
+        .filter(
+            PortAttempt.cc_pair_id == cc_pair.id,
+            PortAttempt.status == PortAttemptStatus.NOT_STARTED,
+        )
+        .all()
+    )
+    assert len(fresh) == 1
+    assert fresh[0].last_processed_doc_id == "portdoc-042"  # resumed cursor
+
+
+def test_check_for_port_fails_stale_in_progress(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """A stalled IN_PROGRESS attempt is FAILED, then a fresh attempt is created
+    and enqueued to resume."""
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    future_ss.use_port_flow = True
+    db_session.commit()
+
+    stale = create_port_attempt(db_session, cc_pair.id, future_id)
+    mark_port_in_progress(db_session, stale.id)
+    # force last_progress_time well past the stall threshold
+    old = datetime.now(timezone.utc) - timedelta(hours=1)
+    db_session.query(PortAttempt).filter(PortAttempt.id == stale.id).update(
+        {PortAttempt.last_progress_time: old}
+    )
+    db_session.commit()
+
+    result, celery_app = _run_check_for_port(cc_pair, future_id)
+
+    db_session.expire_all()
+    stale_row = db_session.get(PortAttempt, stale.id)
+    assert stale_row is not None
+    assert stale_row.status == PortAttemptStatus.FAILED  # watchdog failed the stall
+    fresh = (
+        db_session.query(PortAttempt)
+        .filter(
+            PortAttempt.cc_pair_id == cc_pair.id,
+            PortAttempt.status == PortAttemptStatus.NOT_STARTED,
+        )
+        .all()
+    )
+    assert len(fresh) == 1
+    assert result == 1
+    celery_app.send_task.assert_called_once()
+
+
+def test_check_for_port_leaves_active_in_progress(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """A healthy (recent) IN_PROGRESS attempt is left untouched and not duplicated."""
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    future_ss.use_port_flow = True
+    db_session.commit()
+
+    active = create_port_attempt(db_session, cc_pair.id, future_id)
+    mark_port_in_progress(db_session, active.id)  # recent last_progress_time
+
+    result, celery_app = _run_check_for_port(cc_pair, future_id)
+
+    assert result == 0
+    celery_app.send_task.assert_not_called()
+    db_session.expire_all()
+    row = db_session.get(PortAttempt, active.id)
+    assert row is not None
+    assert row.status == PortAttemptStatus.IN_PROGRESS  # untouched
+    assert (
+        db_session.query(PortAttempt)
+        .filter(PortAttempt.cc_pair_id == cc_pair.id)
+        .count()
+        == 1
+    )
+
+
+def test_check_for_port_reissues_stale_not_started(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """A NOT_STARTED attempt whose enqueued task was lost/expired (created before the
+    TTL window) is re-enqueued in place — not stranded, not duplicated."""
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    future_ss.use_port_flow = True
+    db_session.commit()
+
+    stale = create_port_attempt(db_session, cc_pair.id, future_id)
+    # backdate time_created past the task TTL so its enqueued task is "expired"
+    old = datetime.now(timezone.utc) - timedelta(seconds=BEAT_EXPIRES_DEFAULT + 60)
+    db_session.query(PortAttempt).filter(PortAttempt.id == stale.id).update(
+        {PortAttempt.time_created: old}
+    )
+    db_session.commit()
+
+    result, celery_app = _run_check_for_port(cc_pair, future_id)
+
+    assert result == 1
+    celery_app.send_task.assert_called_once()
+    assert (
+        celery_app.send_task.call_args.kwargs["kwargs"]["port_attempt_id"] == stale.id
+    )
+    # re-issued in place: still the same single attempt, still NOT_STARTED
+    db_session.expire_all()
+    rows = (
+        db_session.query(PortAttempt).filter(PortAttempt.cc_pair_id == cc_pair.id).all()
+    )
+    assert len(rows) == 1 and rows[0].id == stale.id
+    assert rows[0].status == PortAttemptStatus.NOT_STARTED
+
+
+def test_check_for_port_leaves_fresh_not_started(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """A recently-created NOT_STARTED attempt (task still in flight, within the TTL)
+    is left alone — not re-enqueued or duplicated."""
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    future_ss.use_port_flow = True
+    db_session.commit()
+
+    fresh = create_port_attempt(db_session, cc_pair.id, future_id)  # time_created = now
+
+    result, celery_app = _run_check_for_port(cc_pair, future_id)
+
+    assert result == 0
+    celery_app.send_task.assert_not_called()
+    db_session.expire_all()
+    assert (
+        db_session.query(PortAttempt)
+        .filter(PortAttempt.cc_pair_id == cc_pair.id)
+        .count()
+        == 1
+    )
+    row = db_session.get(PortAttempt, fresh.id)
+    assert row is not None and row.status == PortAttemptStatus.NOT_STARTED
+
+
+def test_check_for_port_fails_attempt_when_enqueue_raises(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """If send_task fails after the row is committed, the attempt is FAILED (not
+    left orphaned NOT_STARTED) so the next tick recreates + re-enqueues it."""
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    future_ss.use_port_flow = True
+    db_session.commit()
+
+    celery_app = MagicMock()
+    celery_app.send_task.side_effect = RuntimeError("broker down")
+    _run_check_for_port(cc_pair, future_id, celery_app=celery_app)
+
+    db_session.expire_all()
+    attempts = (
+        db_session.query(PortAttempt).filter(PortAttempt.cc_pair_id == cc_pair.id).all()
+    )
+    assert len(attempts) == 1
+    assert attempts[0].status == PortAttemptStatus.FAILED  # not orphaned NOT_STARTED
+    assert attempts[0].error_msg == "enqueue failed"
+
+
+def test_check_for_port_survives_create_failure(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """A create_port_attempt failure for one cc_pair is swallowed so the tick
+    completes (the next tick retries) rather than aborting every other cc_pair."""
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    future_ss.use_port_flow = True
+    db_session.commit()
+
+    celery_app = MagicMock()
+    with (
+        patch.object(
+            port_task,
+            "get_secondary_search_settings",
+            lambda db, *_, **__: db.get(SearchSettings, future_id),
+        ),
+        patch.object(
+            port_task,
+            "fetch_indexable_standard_connector_credential_pair_ids",
+            lambda *_, **__: [cc_pair.id],
+        ),
+        patch.object(
+            port_task, "create_port_attempt", side_effect=RuntimeError("db blip")
+        ),
+    ):
+        result = run_check_for_port(get_current_tenant_id(), celery_app)
+
+    assert result == 0  # tick completed; the failed create was skipped
+    celery_app.send_task.assert_not_called()
+    db_session.expire_all()
+    assert (
+        db_session.query(PortAttempt)
+        .filter(PortAttempt.cc_pair_id == cc_pair.id)
+        .count()
+        == 0
+    )
+
+
+def test_port_retry_delay_backoff() -> None:
+    """First same-cursor failure retries immediately; repeats back off, then cap."""
+    delay = port_task._port_retry_delay_seconds
+    base = port_task._PORT_RETRY_BACKOFF_BASE_S
+    assert delay(0) == 0.0
+    assert delay(1) == 0.0  # first failure: retry now (likely transient)
+    assert delay(2) == base  # second same-cursor failure: start backing off
+    assert delay(3) == base * 2
+    assert delay(4) == base * 4
+    assert delay(1000) == port_task._PORT_RETRY_BACKOFF_MAX_S  # capped
+
+
+def _fail_port_at(
+    db_session: Session, cc_pair_id: int, future_id: int, cursor: str | None
+) -> int:
+    """Create a terminal FAILED attempt resuming from `cursor`; returns its id."""
+    a = create_port_attempt(
+        db_session, cc_pair_id, future_id, resume_from_doc_id=cursor
+    )
+    mark_port_in_progress(db_session, a.id)
+    mark_port_failed(db_session, a.id, error_msg="durable")
+    return a.id
+
+
+def test_consecutive_failed_no_progress_streak(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """Streak counts trailing FAILED attempts at the same cursor; a cursor advance
+    (progress) resets it to 1, and a non-FAILED latest attempt resets it to 0."""
+    cc_pair, future_id = cc_pair_and_future
+    streak = count_consecutive_failed_port_attempts_no_progress
+
+    assert streak(db_session, cc_pair.id, future_id) == 0
+    _fail_port_at(db_session, cc_pair.id, future_id, "doc-5")
+    _fail_port_at(db_session, cc_pair.id, future_id, "doc-5")
+    assert streak(db_session, cc_pair.id, future_id) == 2
+    # an advanced cursor means progress was made -> streak resets to 1
+    _fail_port_at(db_session, cc_pair.id, future_id, "doc-9")
+    assert streak(db_session, cc_pair.id, future_id) == 1
+    # a SUCCESS latest attempt breaks the streak entirely
+    ok = create_port_attempt(
+        db_session, cc_pair.id, future_id, resume_from_doc_id="doc-9"
+    )
+    mark_port_in_progress(db_session, ok.id)
+    mark_port_succeeded(db_session, ok.id)
+    assert streak(db_session, cc_pair.id, future_id) == 0
+
+
+def test_check_for_port_backs_off_repeated_failures(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """A port stuck failing at the same cursor is not recreated within its backoff
+    window, but is once the backoff has elapsed."""
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    future_ss.use_port_flow = True
+    db_session.commit()
+
+    # two same-cursor failures -> streak 2 -> backoff = BASE seconds
+    _fail_port_at(db_session, cc_pair.id, future_id, "doc-1")
+    _fail_port_at(db_session, cc_pair.id, future_id, "doc-1")
+
+    # latest failure just happened -> still within backoff -> not recreated
+    result, celery_app = _run_check_for_port(cc_pair, future_id)
+    assert result == 0
+    celery_app.send_task.assert_not_called()
+
+    # backdate the latest failure past the backoff -> recreated
+    latest = get_latest_port_attempt(db_session, cc_pair.id, future_id)
+    assert latest is not None
+    latest.time_completed = datetime.now(timezone.utc) - timedelta(
+        seconds=port_task._PORT_RETRY_BACKOFF_BASE_S + 30
+    )
+    db_session.commit()
+    result, celery_app = _run_check_for_port(cc_pair, future_id)
+    assert result == 1
+    celery_app.send_task.assert_called_once()
+
+
+def _cleanup_pairs(db_session: Session, *pairs: ConnectorCredentialPair) -> None:
+    """Inline-cc_pair teardown (mirrors the cc_pair fixture): drop PortAttempts, then
+    cleanup_cc_pair each (shared-doc safe)."""
+    db_session.rollback()
+    for pair in pairs:
+        db_session.query(PortAttempt).filter(PortAttempt.cc_pair_id == pair.id).delete(
+            synchronize_session="fetch"
+        )
+    db_session.commit()
+    for pair in pairs:
+        cleanup_cc_pair(db_session, pair)
+
+
+def test_port_swap_ready_scoped_to_required_cc_pairs(
+    db_session: Session,
+    cc_pair_and_future: tuple[ConnectorCredentialPair, int],
+) -> None:
+    """Swap gate ignores an INVALID-only deferred doc (no deadlock) but STILL waits
+    on a required cc_pair's deferred doc (regression guard)."""
+    required_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+
+    # required pair's port is done (SUCCESS, none active)
+    attempt = create_port_attempt(db_session, required_pair.id, future_id)
+    mark_port_in_progress(db_session, attempt.id)
+    mark_port_succeeded(db_session, attempt.id)
+
+    invalid_pair = make_cc_pair(db_session)
+    try:
+        [invalid_doc] = _seed_cc_pair_documents(
+            db_session, invalid_pair, 1, unique=True
+        )
+        mark_document_synced_secondary_pending(invalid_doc, db_session)
+        invalid_pair.status = ConnectorCredentialPairStatus.INVALID
+        db_session.commit()
+
+        # not blocked by the INVALID-only deferred doc
+        assert _port_swap_ready(db_session, future_ss, [required_pair]) is True
+
+        # a deferred doc on the REQUIRED pair DOES still block the swap
+        [req_doc] = _seed_cc_pair_documents(db_session, required_pair, 1, unique=True)
+        mark_document_synced_secondary_pending(req_doc, db_session)
+        db_session.commit()
+        assert _port_swap_ready(db_session, future_ss, [required_pair]) is False
+    finally:
+        _cleanup_pairs(db_session, invalid_pair)
+
+
+def test_document_has_indexable_cc_pair(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    """Writer-side gate the sync task consults before deferring a FUTURE write:
+    True iff some owning cc_pair is indexable."""
+    pair_active = make_cc_pair(db_session)
+    pair_invalid = make_cc_pair(db_session)
+    try:
+        [doc_active] = _seed_cc_pair_documents(db_session, pair_active, 1, unique=True)
+        [doc_invalid] = _seed_cc_pair_documents(
+            db_session, pair_invalid, 1, unique=True
+        )
+        # doc_shared is owned by both the ACTIVE and the INVALID pair
+        [doc_shared] = _seed_cc_pair_documents(db_session, pair_active, 1, unique=True)
+        db_session.add(
+            DocumentByConnectorCredentialPair(
+                id=doc_shared,
+                connector_id=pair_invalid.connector_id,
+                credential_id=pair_invalid.credential_id,
+                has_been_indexed=True,
+            )
+        )
+        pair_invalid.status = ConnectorCredentialPairStatus.INVALID
+        db_session.commit()
+
+        assert document_has_indexable_cc_pair(db_session, doc_active) is True
+        assert document_has_indexable_cc_pair(db_session, doc_invalid) is False
+        assert document_has_indexable_cc_pair(db_session, doc_shared) is True
+        assert document_has_indexable_cc_pair(db_session, "no-such-doc") is False
+    finally:
+        _cleanup_pairs(db_session, pair_active, pair_invalid)

--- a/backend/tests/external_dependency_unit/indexing_helpers.py
+++ b/backend/tests/external_dependency_unit/indexing_helpers.py
@@ -215,12 +215,11 @@ def make_future_search_settings(
     """
     present = get_current_search_settings(db_session)
     saved = SavedSearchSettings.from_db_model(present).model_copy(
-        update={
-            "index_name": f"test_future_{uuid4().hex[:8]}",
-            "use_port_flow": use_port_flow,
-        }
+        update={"index_name": f"test_future_{uuid4().hex[:8]}"}
     )
-    return create_search_settings(saved, db_session, status=status)
+    return create_search_settings(
+        saved, db_session, status=status, use_port_flow=use_port_flow
+    )
 
 
 def seed_cc_pair_documents(

--- a/backend/tests/unit/onyx/background/celery/tasks/test_port_wiring.py
+++ b/backend/tests/unit/onyx/background/celery/tasks/test_port_wiring.py
@@ -1,0 +1,76 @@
+"""Guards the Celery wiring of the reindex-port flow.
+
+The port logic itself is covered by the external_dependency_unit `db/test_*port*`
+suites (which run against real Postgres/OpenSearch). Those mock the celery app, so
+nothing there proves a beat-enqueued port task actually reaches a worker. These
+unit tests guard exactly that transport seam — the part a dropped autodiscover line
+or `-Q` entry would silently break with every other test still green:
+
+  beat schedules check_for_port  ->  light worker consumes the `port` queue
+  ->  light worker has run_port_attempt registered to execute it.
+"""
+
+import re
+from pathlib import Path
+
+from onyx.background.celery.tasks.beat_schedule import beat_task_templates
+from onyx.configs.app_configs import DISABLE_VECTOR_DB
+from onyx.configs.constants import OnyxCeleryQueues
+from onyx.configs.constants import OnyxCeleryTask
+
+
+def _find_supervisord_conf() -> Path:
+    for parent in Path(__file__).resolve().parents:
+        candidate = parent / "supervisord.conf"
+        if candidate.is_file():
+            return candidate
+    raise AssertionError("supervisord.conf not found above this test")
+
+
+def _worker_queues(program: str) -> set[str]:
+    """The `-Q` queue set a supervisord worker program consumes.
+
+    Reads the queues from anywhere in the `[program:*]` block, so it survives the
+    `command=celery ... -Q a,b,c` being on one line or wrapped across several.
+    """
+    conf = _find_supervisord_conf().read_text()
+    block = re.search(
+        rf"^\[program:{re.escape(program)}\]\n(.*?)(?=^\[|\Z)",
+        conf,
+        re.DOTALL | re.MULTILINE,
+    )
+    if block is None:
+        raise AssertionError(f"no [program:{program}] block found")
+    queues = re.search(r"-Q\s+(\S+)", block.group(1))
+    if queues is None:
+        raise AssertionError(f"no -Q queues found in [program:{program}]")
+    return set(queues.group(1).split(","))
+
+
+def test_check_for_port_scheduled_in_beat() -> None:
+    # check_for_port is the only producer of PortAttempts; if it falls out of the
+    # beat schedule the whole flow stops with zero other test failures.
+    scheduled = {t["task"] for t in beat_task_templates}
+    if DISABLE_VECTOR_DB:
+        # Vector-DB-gated: must be filtered out of minimal-mode deployments.
+        assert OnyxCeleryTask.CHECK_FOR_PORT not in scheduled
+    else:
+        assert OnyxCeleryTask.CHECK_FOR_PORT in scheduled
+
+
+def test_light_worker_consumes_port_queue() -> None:
+    # run_port_attempt is enqueued to the PORT queue; the light worker is its only
+    # consumer. Dropping `port` from this `-Q` list strands every port task.
+    assert OnyxCeleryQueues.PORT in _worker_queues("celery_worker_light")
+
+
+def test_light_worker_registers_port_tasks() -> None:
+    # Consuming the queue is moot if autodiscovery doesn't register the task body:
+    # the worker would reject it as unknown. Importing + loading the light app
+    # mirrors worker bootstrap, so both port tasks must resolve by name.
+    from onyx.background.celery.apps.light import celery_app
+
+    celery_app.loader.import_default_modules()
+    registered = set(celery_app.tasks.keys())
+    assert OnyxCeleryTask.RUN_PORT_ATTEMPT in registered
+    assert OnyxCeleryTask.CHECK_FOR_PORT in registered

--- a/deployment/helm/charts/onyx/templates/celery-worker-light.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-light.yaml
@@ -70,7 +70,7 @@ spec:
               {{- end }}
               "--hostname=light@%n",
               "-Q",
-              "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration",
+              "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration,port",
             ]
           ports:
             - name: metrics

--- a/web/src/lib/indexing/interfaces.ts
+++ b/web/src/lib/indexing/interfaces.ts
@@ -157,6 +157,8 @@ export interface SavedSearchSettings
   passage_prefix: string | null;
   provider_type: EmbeddingProviderName | null;
   switchover_type?: SwitchoverType;
+  // Read-only: server-controlled reindex-flow flag, always true for new settings.
+  use_port_flow: boolean;
 }
 
 export interface LLMContextualCost {

--- a/web/src/lib/indexing/interfaces.ts
+++ b/web/src/lib/indexing/interfaces.ts
@@ -157,7 +157,7 @@ export interface SavedSearchSettings
   passage_prefix: string | null;
   provider_type: EmbeddingProviderName | null;
   switchover_type?: SwitchoverType;
-  // Read-only: server-controlled reindex-flow flag, always true for new settings.
+  // Read-only; server-set, always true for new settings.
   use_port_flow: boolean;
 }
 

--- a/web/src/refresh-pages/admin/IndexSettingsPage/index.tsx
+++ b/web/src/refresh-pages/admin/IndexSettingsPage/index.tsx
@@ -925,6 +925,17 @@ export default function IndexSettingsPage() {
             enableReinitialize
             initialValues={initialFormValues}
             onSubmit={async (values) => {
+              // Contextual Retrieval re-embeds each chunk through an LLM; with
+              // the toggle on but no model chosen the port fails, so block here.
+              if (
+                values.enable_contextual_rag &&
+                values.contextual_rag_model_configuration_id === null
+              ) {
+                toast.error(
+                  "Select a Contextual Retrieval LLM before re-indexing."
+                );
+                return;
+              }
               // Custom self-hosted models live outside the static registry,
               // so the form carries their spec (`modelDim`, `normalize`, etc.)
               // in `custom_model` for submission. The provider, however, is
@@ -968,6 +979,10 @@ export default function IndexSettingsPage() {
                 !!values.model_name;
               const stagedModelName = isModelStaged ? values.model_name : null;
               const statusVariant = dirty ? "warning" : undefined;
+              // Block apply when Contextual Retrieval is on but no LLM is set.
+              const contextualRagModelMissing =
+                values.enable_contextual_rag &&
+                values.contextual_rag_model_configuration_id === null;
 
               return (
                 <>
@@ -1026,11 +1041,19 @@ export default function IndexSettingsPage() {
                   ) : (
                     !NEXT_PUBLIC_CLOUD_ENABLED && (
                       <MessageCard
-                        variant={statusVariant}
+                        variant={
+                          contextualRagModelMissing ? "error" : statusVariant
+                        }
                         headerPadding="sm"
-                        title="Changes require a full re-index."
+                        title={
+                          contextualRagModelMissing
+                            ? "Select a Contextual Retrieval LLM"
+                            : "Changes require a full re-index."
+                        }
                         description={markdown(
-                          "Modifying embedding or retrieval settings requires a full re-index of all documents to take effect, which may take **hours or days** depending on corpus size. [Learn More](https://docs.onyx.app/security/architecture/data_flows)"
+                          contextualRagModelMissing
+                            ? "Contextual Retrieval is enabled but no model is selected. Pick a Contextual Retrieval LLM below before re-indexing — without one, the re-index cannot run."
+                            : "Modifying embedding or retrieval settings requires a full re-index of all documents to take effect, which may take **hours or days** depending on corpus size. [Learn More](https://docs.onyx.app/security/architecture/data_flows)"
                         )}
                         bottomChildren={
                           dirty ? (
@@ -1081,7 +1104,10 @@ export default function IndexSettingsPage() {
                                 >
                                   Revert
                                 </Button>
-                                <Button onClick={() => void submitForm()}>
+                                <Button
+                                  onClick={() => void submitForm()}
+                                  disabled={contextualRagModelMissing}
+                                >
                                   Apply & Re-index
                                 </Button>
                               </div>


### PR DESCRIPTION
> **Stacked PR — review in order. Base of the stack: `main`.**
>
> #11977 — `01-schema`
> #11978 — `02-lifecycle`
> #11979 — `03-defer`
> #11980 — `04-opensearch`
> #11981 — `05-reembed`
> #11982 — `06-copy`
> #11983 — `07-swap`
> #11984 — `08-sync`
> #11985 — `09-machinery`
> #11986 — `10-enablement`  :point_left: **this PR**
> #11987 — `11-tests`


## Description

- Turn the flow on: seed a synthetic port attempt from the search-settings endpoint, register the `port` queue/workers (supervisord, helm, dev scripts, celery apps), and surface contextual-RAG validation in the admin re-embed UI.

## How Has This Been Tested?

**Automated**
- Wiring covered by `test_port_wiring.py` (PR 11); web type-check for the admin page.
- `ty` and `ruff` pass.

**Manual** (verified end-to-end on a local stack; this is a stacked feature, so manual scenarios exercise the full flow once the stack is assembled):
- Started a re-embedding migration from the admin UI with `use_port_flow` enabled and confirmed the port queue/worker pick it up and run end-to-end.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables the port reindex flow end-to-end. Adds a server‑controlled `use_port_flow`, atomic FUTURE create-and-seed, `port` queue/workers, stricter Contextual Retrieval checks, and comprehensive tests (E2E, lifecycle, and Celery wiring).

- **New Features**
  - Seed synthetic index attempts for FUTURE on save to resume from PRESENT’s poll cursor; skip `INSTANT`; respect `ACTIVE_ONLY`; ignore `DELETING` pairs; commit FUTURE and seeds together; `use_port_flow` is server-set (not user-editable) and enabled for new FUTURE settings.
  - Register `onyx.background.celery.tasks.port` and add `port` to light worker queues in VS Code, dev script, supervisord, and Helm; unit tests guard beat schedule, queue consumption, and task registration.
  - Cancel active port attempts when a FUTURE is superseded or reindex is canceled.
  - Contextual Retrieval enforcement: require a model when enabled (server validation and Admin UI error/disabled “Apply & Re-index”).
  - Indexing path: route batches to secondary when FUTURE (`index_to_secondary`), and resume via the synthetic seed cursor.

- **Migration**
  - No manual steps. Deployment starts the `port` worker via supervisord and Helm; local dev/VS Code configs updated.

<sup>Written for commit 6e183d68c83a659686ce60faa95d715d0d95ff91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

