### PR TITLE
fix(web-connector): apply URL validation across all fetch paths (#11973) to release v4.1

### DIFF
--- a/backend/onyx/connectors/web/connector.py
+++ b/backend/onyx/connectors/web/connector.py
@@ -144,6 +144,10 @@ def protected_url_check(url: str) -> None:
 
 
 def check_internet_connection(url: str) -> None:
+    # SSRF guard on the fetch primitive itself, so no call site can reach an
+    # internal target. No-op unless SSRF protection is at its strictest level.
+    protected_url_check(url)
+
     try:
         # Use a more realistic browser-like request
         session = requests.Session()
@@ -240,6 +244,11 @@ def get_internal_links(
 
 
 def extract_urls_from_sitemap(sitemap_url: str) -> list[str]:
+    # SSRF guard. This fetch runs in __init__, before validation, so the check
+    # must live here. Placed before the try so it surfaces as the SSRF error
+    # rather than a wrapped sitemap-parse failure.
+    protected_url_check(sitemap_url)
+
     # Note: brotli compression is handled automatically by the requests library
     # as long as the brotli package is installed in the venv.
     try:
@@ -725,16 +734,11 @@ class WebConnector(LoadConnector, SlimConnector):
                 "No URL configured. Please provide at least one valid URL."
             )
 
-        if (
-            self.web_connector_type == WEB_CONNECTOR_VALID_SETTINGS.SITEMAP.value
-            or self.web_connector_type == WEB_CONNECTOR_VALID_SETTINGS.RECURSIVE.value
-        ):
-            return None
-
         # We'll just test the first URL for connectivity and correctness
         test_url = self.to_visit_list[0]
 
-        # Check that the URL is allowed and well-formed
+        # SSRF check runs for every connector type so an internal target is
+        # rejected at creation rather than at index time.
         try:
             protected_url_check(test_url)
         except ValueError as e:
@@ -745,7 +749,16 @@ class WebConnector(LoadConnector, SlimConnector):
             # Typically DNS or other network issues
             raise ConnectorValidationError(str(e))
 
-        # Make a quick request to see if we get a valid response
+        # Recursive/sitemap defer page fetches to index time; skip the connectivity
+        # probe for them (the SSRF check above still ran).
+        if (
+            self.web_connector_type == WEB_CONNECTOR_VALID_SETTINGS.SITEMAP.value
+            or self.web_connector_type == WEB_CONNECTOR_VALID_SETTINGS.RECURSIVE.value
+        ):
+            return None
+
+        # Make a quick request to see if we get a valid response. This re-runs the
+        # SSRF check internally (intentional, cheap defense-in-depth).
         try:
             check_internet_connection(test_url)
         except Exception as e:

--- a/backend/tests/unit/onyx/connectors/web/test_ssrf_protection.py
+++ b/backend/tests/unit/onyx/connectors/web/test_ssrf_protection.py
@@ -1,0 +1,82 @@
+"""The web connector must not fetch internal/loopback targets (SSRF) anywhere in
+its lifecycle — sitemap construction, validation, or indexing — at the default
+VALIDATE_ALL level. Covers the recursive and sitemap paths (ON-001 / ON-002).
+
+Targets use literal IPs so socket.getaddrinfo resolves locally (hermetic).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from onyx.connectors.exceptions import ConnectorValidationError
+from onyx.connectors.web import connector as web_connector
+from onyx.connectors.web.connector import check_internet_connection
+from onyx.connectors.web.connector import extract_urls_from_sitemap
+from onyx.connectors.web.connector import WEB_CONNECTOR_VALID_SETTINGS
+from onyx.connectors.web.connector import WebConnector
+from onyx.server.security.models import SSRFProtectionLevel
+
+LOOPBACK_URL = "http://127.0.0.1:9999/ssrf-poc"
+PRIVATE_URL = "http://10.0.0.5/internal"
+# Cloud metadata endpoint (link-local).
+METADATA_URL = "http://169.254.169.254/latest/meta-data/"
+
+
+@pytest.fixture(autouse=True)
+def _enforce_ssrf(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force the most restrictive SSRF level so ``protected_url_check`` enforces,
+    independent of DB/env resolution."""
+    monkeypatch.setattr(
+        web_connector,
+        "get_security_settings",
+        lambda: SimpleNamespace(ssrf_protection_level=SSRFProtectionLevel.VALIDATE_ALL),
+    )
+
+
+def test_check_internet_connection_blocks_internal_before_fetch() -> None:
+    """The connectivity primitive must reject an internal target before any GET."""
+    with patch.object(web_connector.requests, "Session") as mock_session:
+        with pytest.raises(ValueError, match="Non-global IP"):
+            check_internet_connection(LOOPBACK_URL)
+        mock_session.assert_not_called()
+
+
+def test_extract_urls_from_sitemap_blocks_internal_before_fetch() -> None:
+    """The sitemap fetch (runs in ``__init__``) must reject an internal target
+    before any GET."""
+    with patch.object(web_connector.requests, "get") as mock_get:
+        with pytest.raises(ValueError, match="Non-global IP"):
+            extract_urls_from_sitemap(PRIVATE_URL)
+        mock_get.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "connector_type",
+    [
+        WEB_CONNECTOR_VALID_SETTINGS.SINGLE.value,
+        WEB_CONNECTOR_VALID_SETTINGS.RECURSIVE.value,
+    ],
+)
+def test_validate_rejects_internal_target_for_single_and_recursive(
+    connector_type: str,
+) -> None:
+    """Validation must reject an internal base_url for both single and recursive."""
+    connector = WebConnector(base_url=PRIVATE_URL, web_connector_type=connector_type)
+    with pytest.raises(ConnectorValidationError, match="Protected URL check failed"):
+        connector.validate_connector_settings()
+
+
+def test_sitemap_connector_construction_blocks_internal() -> None:
+    """A sitemap connector fetches at construction; an internal sitemap URL must
+    fail before any outbound request — the connector can't even be instantiated."""
+    with patch.object(web_connector.requests, "get") as mock_get:
+        with pytest.raises(ValueError, match="Non-global IP"):
+            WebConnector(
+                base_url=METADATA_URL,
+                web_connector_type=WEB_CONNECTOR_VALID_SETTINGS.SITEMAP.value,
+            )
+        mock_get.assert_not_called()


### PR DESCRIPTION
Cherry-pick of commit 3612cacdf7ec69a7130e139d5f91955b54cc91f2 to release/v4.1 branch.

Original PR: #11973

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces SSRF protection across all web-connector fetch paths and during validation to block requests to loopback, private, and metadata IPs. This closes a gap where sitemap/recursive modes could bypass checks at creation time.

- **Bug Fixes**
  - Run `protected_url_check` inside `check_internet_connection` and `extract_urls_from_sitemap` before any network call.
  - Always run SSRF validation in `validate_connector_settings` for all connector types; skip only the connectivity probe for sitemap/recursive.
  - Add unit tests ensuring no HTTP call occurs and that targets like 127.0.0.1, 10.0.0.0/8, and 169.254.169.254 are rejected early.

<sup>Written for commit dca0e5732e8733894358a7a0ed5271ec1a076a45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

