### PR TITLE
feat(load-tests): compression / long-history scenario (CompressionUser)

### DIFF
--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -104,6 +104,18 @@ mode. Each maps to a real production incident class:
   abandons the session. Stresses server-side disconnect cleanup of held
   transactions/connections/buffers (slow leaks). The turn is recorded as
   `disconnect:disconnected`, separate from success/failure.
+- **CompressionUser** (`compress:*`) — long session (default 60 turns) of
+  large messages (`ONYX_MSG_CHARS`, default 8000) so the history crosses the
+  model's input-token limit and Onyx summarizes/recompresses it every turn —
+  the history-driven slowdown / compression death-spiral path. **Point it at a
+  mock model registered with a small `max_input_tokens` (e.g. 16k) via
+  `ONYX_LONGCONV_MODEL`**, otherwise the default 200k window needs an
+  impractically long history before compression triggers.
+
+```bash
+ONYX_LONGCONV_MODEL=mock-smallctx \
+... uv run locust --headless -u 25 -r 5 -t 20m -H https://<your-onyx-url> CompressionUser
+```
 
 ```bash
 ... uv run locust --headless -u 50 -r 5 -t 15m -H https://<your-onyx-url> LongConversationUser
@@ -138,7 +150,8 @@ The API key is created by an admin via `POST /api/admin/api-key`
 | `ONYX_MULTITOOL_MODEL` | `mock-tools3` | Model for MultiToolUser |
 | `ONYX_DR_MODEL` | `mock-agents2` | Model for DeepResearchUser |
 | `ONYX_LONGCONV_MODEL` | unset | Model for LongConversationUser (unset = persona default) |
-| `ONYX_SESSION_TURNS` | 1 | Turns to keep one session alive (LongConversationUser defaults to 20) |
+| `ONYX_SESSION_TURNS` | 1 | Turns to keep one session alive (LongConversationUser 20, CompressionUser 60) |
+| `ONYX_MSG_CHARS` | 0 | Per-message size in chars (CompressionUser defaults to 8000; 0 = short questions) |
 | `ONYX_DISCONNECT_AFTER` | `first_answer_token` | Milestone after which DisconnectUser drops the stream |
 | `ONYX_SHAPE` | unset | `stepramp` activates the staged ramp shape |
 | `ONYX_RAMP_STAGES` / `ONYX_RAMP_DWELL` / `ONYX_RAMP_SPAWN` | `25,50,100,200` / 300 / 5 | Ramp user plateaus, dwell seconds, spawn rate |

--- a/loadtest/locustfile.py
+++ b/loadtest/locustfile.py
@@ -11,6 +11,7 @@ import os
 import prometheus_exporter  # noqa: F401  (registers the /metrics exporter)
 from onyx_client.chat_user import BasicChatUser
 from scenarios import ChatWithSearchUser
+from scenarios import CompressionUser
 from scenarios import DeepResearchUser
 from scenarios import DisconnectUser
 from scenarios import LongConversationUser
@@ -23,6 +24,7 @@ __all__ = [
     "DeepResearchUser",
     "LongConversationUser",
     "DisconnectUser",
+    "CompressionUser",
 ]
 
 # Expose the ramp only on request: Locust auto-activates any shape it finds,

--- a/loadtest/mock_llm/app.py
+++ b/loadtest/mock_llm/app.py
@@ -21,6 +21,9 @@ Timing knobs are encoded in the model name (litellm passes it through):
                                       capped by how many the persona offers
     mock-agents2                    — spawn 2 parallel research agents per
                                       deep-research orchestrator cycle
+    mock-maxctx16000                — reject prompts over ~16k estimated tokens
+                                      with a context-window error (mimics a
+                                      provider; for long-thread overflow tests)
 
 Knob combinations can imitate provider latency profiles (see README:
 "Provider profiles") — e.g. a slow reasoning model is just
@@ -88,7 +91,7 @@ DEFAULT_TTFT_MS = int(os.environ.get("MOCK_TTFT_MS", "300"))
 DEFAULT_ITL_MS = int(os.environ.get("MOCK_ITL_MS", "15"))
 DEFAULT_LEN_TOKENS = int(os.environ.get("MOCK_LEN_TOKENS", "150"))
 
-_KNOB_RE = re.compile(r"-(ttft|itl|len|tools|agents)(\d+)")
+_KNOB_RE = re.compile(r"-(ttft|itl|len|tools|agents|maxctx)(\d+)")
 
 _FILLER_WORDS = (
     "This is deterministic mock answer content used only for load testing "
@@ -111,6 +114,9 @@ class Knobs:
         # 1=mock-tools1, 2+=multi-tool); capped by tools the persona offers.
         self.n_auto_tools: int = 0
         self.n_agents: int = 1
+        # >0 makes the mock reject requests whose estimated prompt tokens exceed
+        # this, mimicking a provider context-window error (mock-maxctx16000).
+        self.max_ctx_tokens: int = 0
         for name, value in _KNOB_RE.findall(model):
             if name == "ttft":
                 self.ttft_s = int(value) / 1000.0
@@ -122,6 +128,8 @@ class Knobs:
                 self.n_auto_tools = int(value)
             elif name == "agents":
                 self.n_agents = max(1, int(value))
+            elif name == "maxctx":
+                self.max_ctx_tokens = int(value)
 
 
 def _assistant_called(messages: list[ChatMessage], names: tuple[str, ...]) -> bool:
@@ -318,6 +326,36 @@ def _make_chunk(
     )
 
 
+def _estimate_prompt_tokens(messages: list[ChatMessage]) -> int:
+    """Rough token estimate of the whole prompt (~4 chars/token), used only to
+    decide whether to simulate a context-window overflow."""
+    chars = 0
+    for message in messages:
+        text = _content_text(message.content) or ""
+        chars += len(text) + 4  # small per-message role/format overhead
+    return chars // 4
+
+
+def _context_window_error(limit: int, used: int) -> JSONResponse:
+    """OpenAI-shaped context-length error → litellm maps it to
+    ContextWindowExceededError, mimicking what Vertex/Claude return."""
+    return JSONResponse(
+        status_code=400,
+        content={
+            "error": {
+                "message": (
+                    f"This model's maximum context length is {limit} tokens. "
+                    f"However, your messages resulted in {used} tokens. "
+                    "Please reduce the length of the messages."
+                ),
+                "type": "invalid_request_error",
+                "param": "messages",
+                "code": "context_length_exceeded",
+            }
+        },
+    )
+
+
 @app.get("/v1/models")
 def list_models() -> JSONResponse:
     return JSONResponse(
@@ -332,6 +370,12 @@ def list_models() -> JSONResponse:
 async def chat_completions(request: ChatCompletionRequest) -> Response:
     knobs = Knobs(request.model)
     completion_id = f"chatcmpl-mock-{uuid.uuid4().hex[:12]}"
+
+    # Simulate a provider context-window overflow on long prompts (mock-maxctx).
+    if knobs.max_ctx_tokens:
+        prompt_tokens = _estimate_prompt_tokens(request.messages)
+        if prompt_tokens > knobs.max_ctx_tokens:
+            return _context_window_error(knobs.max_ctx_tokens, prompt_tokens)
 
     tool_calls = _pick_tool(request, knobs)
     emit_tools = bool(tool_calls)

--- a/loadtest/onyx_client/chat_user.py
+++ b/loadtest/onyx_client/chat_user.py
@@ -40,6 +40,17 @@ DEFAULT_MESSAGES = [
     "Summarize how background indexing works.",
 ]
 
+_PAD = "Please consider the full context of the conversation so far in detail. "
+
+
+def _sized_message(question: str, target_chars: int) -> str:
+    """Pad a question with filler up to ~target_chars so histories grow fast
+    enough to cross the summarization threshold (compression testing)."""
+    if target_chars <= len(question):
+        return question
+    filler = _PAD * (target_chars // len(_PAD) + 1)
+    return (question + " " + filler)[:target_chars]
+
 
 class OnyxChatUser(HttpUser):
     abstract = True
@@ -54,6 +65,12 @@ class OnyxChatUser(HttpUser):
     # >1 keeps one session alive for N turns, chaining parent_message_id so
     # history grows; 1 (default) = a fresh session per turn.
     max_session_turns: int = env_int("ONYX_SESSION_TURNS", 1)
+
+    # Per-message size in chars (ONYX_MSG_CHARS overrides). 0 = the short
+    # default questions. Scenarios that need history to grow fast (compression)
+    # raise this default; larger messages cross the summarization threshold in
+    # fewer turns.
+    default_msg_chars: int = 0
 
     # If set to a milestone name, drop the stream the instant it arrives
     # (client disconnect). Recorded as <prefix>:disconnected, not a failure.
@@ -78,7 +95,12 @@ class OnyxChatUser(HttpUser):
             if provider:
                 self.llm_override["model_provider"] = provider
 
-        self.messages: list[str] = DEFAULT_MESSAGES
+        msg_chars = env_int("ONYX_MSG_CHARS", self.default_msg_chars)
+        self.messages: list[str] = (
+            [_sized_message(q, msg_chars) for q in DEFAULT_MESSAGES]
+            if msg_chars > 0
+            else DEFAULT_MESSAGES
+        )
         self.turn_index: int = 0
 
         # Multi-turn session state (only used when max_session_turns > 1).

--- a/loadtest/scenarios/__init__.py
+++ b/loadtest/scenarios/__init__.py
@@ -1,10 +1,12 @@
 from scenarios.chat_with_search import ChatWithSearchUser
+from scenarios.compression import CompressionUser
 from scenarios.deep_research import DeepResearchUser
 from scenarios.disconnect import DisconnectUser
 from scenarios.long_conversation import LongConversationUser
 from scenarios.multi_tool import MultiToolUser
 
 __all__ = [
+    "CompressionUser",
     "ChatWithSearchUser",
     "DeepResearchUser",
     "DisconnectUser",

--- a/loadtest/scenarios/compression.py
+++ b/loadtest/scenarios/compression.py
@@ -1,0 +1,33 @@
+"""Long-history chat that drives the summarization / compression path.
+
+Builds on LongConversationUser: keeps one session alive for many turns and
+sends large messages (default ONYX_MSG_CHARS), so the history quickly crosses
+the model's input-token limit and Onyx summarizes/recompresses it every turn.
+This is the path behind history-driven slowdowns and the compression
+death-spiral incident (orphaned summaries → full recompression + giant
+prompts each turn).
+
+To trigger compression in a feasible number of turns, point it at a mock
+model registered with a SMALL max_input_tokens (e.g. 16k) via
+ONYX_LONGCONV_MODEL — otherwise the default 200k window needs a very long
+history. See README "Compression / long-history".
+
+Selected explicitly (not in the default mix):
+    locust -f locustfile.py CompressionUser
+"""
+
+from __future__ import annotations
+
+from onyx_client.env import env_int
+
+from scenarios.long_conversation import LongConversationUser
+
+
+class CompressionUser(LongConversationUser):
+    abstract = False
+
+    scenario_prefix: str = "compress"
+    # Large messages by default so history grows fast (ONYX_MSG_CHARS overrides).
+    default_msg_chars: int = 8000
+    # Long sessions so the recompression path runs many times per session.
+    max_session_turns: int = max(2, env_int("ONYX_SESSION_TURNS", 60))

--- a/loadtest/tests/test_mock_llm.py
+++ b/loadtest/tests/test_mock_llm.py
@@ -369,3 +369,26 @@ def test_max_tokens_caps_answer_length() -> None:
     chunks = stream_chunks(model="mock-ttft0-itl0-len500", max_tokens=10)
     text = "".join(c["choices"][0]["delta"].get("content") or "" for c in chunks)
     assert len(text.split()) == 10
+
+
+def test_maxctx_rejects_oversized_prompt_with_context_error() -> None:
+    # Prompt over the maxctx limit → 400 context-window error (litellm maps
+    # this to ContextWindowExceededError, mimicking a real provider).
+    big = "word " * 5000  # ~25k chars ≈ ~6k tokens, over maxctx1000
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "mock-maxctx1000-ttft0-itl0",
+            "stream": False,
+            "messages": [{"role": "user", "content": big}],
+        },
+    )
+    assert response.status_code == 400
+    err = response.json()["error"]
+    assert err["code"] == "context_length_exceeded"
+    assert "maximum context length" in err["message"]
+
+
+def test_maxctx_allows_small_prompt() -> None:
+    choice = complete(model="mock-maxctx1000-ttft0-itl0-len10")
+    assert choice["finish_reason"] == "stop"


### PR DESCRIPTION
- [x] Override Linear Check

## Description

Adds **CompressionUser** — the targeted reproducer for the **history-driven slowdown / compression death-spiral** path (long histories → summarization/recompression + large prompts every turn).

It builds on `LongConversationUser` (keeps one session alive, chains `parent_message_id`) and adds:
- `default_msg_chars` / **`ONYX_MSG_CHARS`** knob on the base `OnyxChatUser` (default 0 = the short questions; CompressionUser defaults to **8000**) so history grows fast enough to cross the model's input-token limit.
- `max_session_turns` default 60.

To trigger compression in a feasible number of turns, run it against a mock model registered with a **small `max_input_tokens`** (e.g. 16k) via `ONYX_LONGCONV_MODEL` — otherwise the default 200k window needs an impractically long history. Documented in the README.

This is the first of two targeted incident reproducers we scoped (PR A). The second — oversized-file → `user_file_processing` indexing-worker OOM — is a different target (background worker, not the chat path) and will be scoped separately.

## How Has This Been Tested?

- `uv run pytest tests/ -q` → 24 pass; `uvx ruff check/format` clean.
- Imported the locustfile and confirmed `CompressionUser` registers with `max_session_turns=60`, `default_msg_chars=8000`, and the `_sized_message` padding produces large messages. End-to-end compression validation on a deployment (with a small-context mock model) is the next step.

loadtest-only, no backend changes.
