### PR TITLE
fix(llm): route Claude Fable 5 / Mythos 5 through adaptive thinking

### DIFF
--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -83,6 +83,8 @@ _VERTEX_ANTHROPIC_MODELS_REJECTING_OUTPUT_CONFIG = (
 _ANTHROPIC_ADAPTIVE_THINKING_MODELS = (
     "claude-opus-4-7",
     "claude-opus-4-8",
+    "claude-fable-5",
+    "claude-mythos-5",
 )
 
 # Anthropic models that reject any non-default sampling parameter (temperature,
@@ -100,6 +102,10 @@ _ANTHROPIC_NO_SAMPLING_PARAMS_MODELS = (
     "claude-opus-4.8",
     "claude-4-8-opus",
     "claude-4.8-opus",
+    "claude-fable-5",
+    "claude-5-fable",
+    "claude-mythos-5",
+    "claude-5-mythos",
 )
 
 

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -84,7 +84,9 @@ _ANTHROPIC_ADAPTIVE_THINKING_MODELS = (
     "claude-opus-4-7",
     "claude-opus-4-8",
     "claude-fable-5",
+    "claude-5-fable",
     "claude-mythos-5",
+    "claude-5-mythos",
 )
 
 # Anthropic models that reject any non-default sampling parameter (temperature,

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -437,6 +437,11 @@ ANTHROPIC_MODELS_OMITTING_SAMPLING_PARAMS = [
     "claude-opus-4.8",
     "claude-4-8-opus",
     "claude-4.8-opus",
+    "claude-fable-5",
+    "claude-fable-5@20260101",
+    "claude-5-fable",
+    "claude-mythos-5",
+    "claude-5-mythos",
 ]
 
 
@@ -463,8 +468,17 @@ def test_omits_temperature_for_no_sampling_params_models(model_name: str) -> Non
         assert "temperature" not in kwargs
 
 
-@pytest.mark.parametrize("model_name", ["claude-opus-4-7", "claude-opus-4-8"])
-def test_claude_adaptive_thinking_uses_output_config(model_name: str) -> None:
+@pytest.mark.parametrize(
+    "model_name",
+    ["claude-opus-4-7", "claude-opus-4-8", "claude-fable-5", "claude-mythos-5"],
+)
+@pytest.mark.parametrize(
+    "reasoning_effort, expected_effort",
+    [(ReasoningEffort.AUTO, "medium"), (ReasoningEffort.HIGH, "high")],
+)
+def test_claude_adaptive_thinking_uses_output_config(
+    model_name: str, reasoning_effort: ReasoningEffort, expected_effort: str
+) -> None:
     # Non-Vertex providers must use the adaptive thinking API for these models
     # (thinking.type=adaptive + output_config.effort) rather than the legacy
     # thinking.type.enabled + budget_tokens path, which they reject with a 400.
@@ -486,11 +500,11 @@ def test_claude_adaptive_thinking_uses_output_config(model_name: str) -> None:
         mock_completion.return_value = []
 
         messages: LanguageModelInput = [UserMessage(content="Hi")]
-        list(llm.stream(messages, reasoning_effort=ReasoningEffort.HIGH))
+        list(llm.stream(messages, reasoning_effort=reasoning_effort))
 
         kwargs = mock_completion.call_args.kwargs
         assert kwargs["thinking"] == {"type": "adaptive"}
-        assert "output_config" in kwargs
+        assert kwargs["output_config"] == {"effort": expected_effort}
         assert "budget_tokens" not in kwargs["thinking"]
 
 

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -470,7 +470,14 @@ def test_omits_temperature_for_no_sampling_params_models(model_name: str) -> Non
 
 @pytest.mark.parametrize(
     "model_name",
-    ["claude-opus-4-7", "claude-opus-4-8", "claude-fable-5", "claude-mythos-5"],
+    [
+        "claude-opus-4-7",
+        "claude-opus-4-8",
+        "claude-fable-5",
+        "claude-5-fable",
+        "claude-mythos-5",
+        "claude-5-mythos",
+    ],
 )
 @pytest.mark.parametrize(
     "reasoning_effort, expected_effort",


### PR DESCRIPTION
- [x] [Optional] Please cherry-pick this PR to the latest release version.

## Description

Fixes #11991

Claude Fable 5 (`claude-fable-5`) and Mythos 5 (`claude-mythos-5`) only support Anthropic's adaptive thinking API — they reject the legacy `thinking: {type: "enabled", budget_tokens: N}` payload with:

```
litellm.BadRequestError: AnthropicException - "thinking.type.enabled" is not supported for this model.
Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.
```

Because LiteLLM advertises `supports_reasoning: true` for these models, Onyx treated them as reasoning models and sent the legacy thinking block, so every chat request with reasoning enabled (anything other than Off) failed with a 400.

## Changes

- Add `claude-fable-5` / `claude-mythos-5` to `_ANTHROPIC_ADAPTIVE_THINKING_MODELS` so they take the existing adaptive path (`thinking: {type: "adaptive"}` + `output_config: {effort: ...}`).
- Add them (plus reversed-order proxy naming variants) to `_ANTHROPIC_NO_SAMPLING_PARAMS_MODELS`, since these models also reject non-default `temperature` / `top_p` / `top_k` — preventing a secondary 400 when reasoning is Off but a non-1 temperature is configured.

## Tests

<img width="1416" height="1820" alt="20260612_09h54m06s_grim" src="https://github.com/user-attachments/assets/f8f18bb2-5573-4a03-9a8f-e90701b984ec" />

Extended the existing parametrized unit tests in `backend/tests/unit/onyx/llm/test_multi_llm.py`:

- `test_claude_adaptive_thinking_uses_output_config` now covers `claude-fable-5` / `claude-mythos-5` and asserts the exact `output_config.effort` mapping for both `AUTO` (→ `medium`) and `HIGH` (→ `high`), with no `budget_tokens`.
- `test_omits_temperature_for_no_sampling_params_models` now covers the new model names and naming variants.

All 66 tests in the file pass; pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes Anthropic `claude-fable-5` and `claude-mythos-5` (including `claude-5-fable` and `claude-5-mythos`) through adaptive thinking to stop 400s and make reasoning work. Also omits non-default sampling params for these models to prevent failures.

- **Bug Fixes**
  - Use `thinking: {type: "adaptive"}` with `output_config.effort` for `claude-fable-5`/`claude-mythos-5` and aliases.
  - Skip `temperature`/`top_p`/`top_k` for these models.
  - Tests cover alias variants (incl. `claude-fable-5@20260101`), assert exact `output_config.effort` for AUTO/HIGH, and ensure no `budget_tokens`.

<sup>Written for commit f9c8884f9562ff4bf9d4d80d5e6499dc3eb45f39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

