### PR TITLE
feat(craft): sneaky craft easter egg

### DIFF
--- a/web/src/app/craft/components/ChatPanel.tsx
+++ b/web/src/app/craft/components/ChatPanel.tsx
@@ -88,7 +88,8 @@ export default function BuildChatPanel({
   const hasSession = useHasSession();
   const isRunning = useIsRunning();
   const displayIsRunning = isRunning || scheduledRunInFlight;
-  const { setLeftSidebarFolded, leftSidebarFolded } = useBuildContext();
+  const { setLeftSidebarFolded, leftSidebarFolded, videoBackgroundEnabled } =
+    useBuildContext();
   const { isMobile } = useScreenSize();
   const toggleOutputPanel = useToggleOutputPanel();
 
@@ -653,7 +654,9 @@ export default function BuildChatPanel({
                 />
               </div>
               {/* Soft fade border at bottom */}
-              <div className="absolute bottom-0 left-0 right-0 h-10 bg-linear-to-b from-background-neutral-01 to-transparent pointer-events-none translate-y-full z-10" />
+              {!videoBackgroundEnabled && (
+                <div className="absolute bottom-0 left-0 right-0 h-10 bg-linear-to-b from-background-neutral-01 to-transparent pointer-events-none translate-y-full z-10" />
+              )}
             </div>
 
             {/* Main content area — cross-fades when switching between the main
@@ -702,7 +705,9 @@ export default function BuildChatPanel({
             {(hasSession || existingSessionId) && (
               <div className="px-4 pb-8 pt-4 relative">
                 {/* Soft fade border at top */}
-                <div className="absolute top-0 left-0 right-0 h-12 bg-linear-to-t from-background-neutral-01 to-transparent pointer-events-none -translate-y-full" />
+                {!videoBackgroundEnabled && (
+                  <div className="absolute top-0 left-0 right-0 h-12 bg-linear-to-t from-background-neutral-01 to-transparent pointer-events-none -translate-y-full" />
+                )}
                 <div className="max-w-[720px] mx-auto">
                   {/* Scroll to bottom button - shown when user has scrolled away */}
                   {showScrollButton && (

--- a/web/src/app/craft/components/video-background/VideoBackground.tsx
+++ b/web/src/app/craft/components/video-background/VideoBackground.tsx
@@ -9,14 +9,22 @@ export default function VideoBackground() {
   if (!videoBackgroundEnabled) return null;
 
   return (
-    <video
-      autoPlay
-      loop
-      muted
-      playsInline
-      className="absolute inset-0 w-full h-full object-cover z-0 pointer-events-none opacity-30 blur-sm"
+    <div
+      aria-hidden
+      className="absolute inset-0 z-0 overflow-hidden pointer-events-none"
     >
-      <source src={VIDEO_BACKGROUND_SRC} type="video/mp4" />
-    </video>
+      {/* scale-105 crops the transparent fringe the blur creates at the edges */}
+      <video
+        autoPlay
+        loop
+        muted
+        playsInline
+        className="w-full h-full object-cover scale-105 blur-xs"
+      >
+        <source src={VIDEO_BACKGROUND_SRC} type="video/mp4" />
+      </video>
+      {/* tint overlay keeps foreground readable without washing the video out */}
+      <div className="absolute inset-0 bg-background-tint-00/60" />
+    </div>
   );
 }

--- a/web/src/app/craft/components/video-background/VideoBackground.tsx
+++ b/web/src/app/craft/components/video-background/VideoBackground.tsx
@@ -10,7 +10,7 @@ export default function VideoBackground() {
 
   return (
     <div
-      aria-hidden
+      aria-hidden="true"
       className="absolute inset-0 z-0 overflow-hidden pointer-events-none"
     >
       {/* scale-105 crops the transparent fringe the blur creates at the edges */}


### PR DESCRIPTION
## Description

Polishes the sneaky easter egg from #11939 so it earns its keep:

- Tailwind v4 renamed the blur scale, so `blur-sm` was applying double the intended blur — dialed back to `blur-xs`
- Swapped the washed-out `opacity-30` for a full-opacity render under a `background-tint-00/60` overlay (richer colors, still readable, dark-mode aware)
- `scale-105` crops the transparent fringe the blur creates at the edges
- The chat header/input soft-fade strips read as hard bands when the easter egg is active, so they're skipped in that mode

## How Has This Been Tested?

- Toggled the easter egg locally and verified the look in light and dark mode, on the welcome screen and with an open session
- `tsc --noEmit`, oxlint, and oxfmt pass via pre-commit

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the sneaky video background easter egg for better visual quality, readability, and accessibility.

- **Bug Fixes**
  - Tailwind v4 blur: `blur-sm` -> `blur-xs`; plus `scale-105` to crop blur-edge artifacts.
  - Full-opacity video with `bg-background-tint-00/60` overlay for richer color and readable foreground.
  - Skip chat header/input soft fades when `videoBackgroundEnabled` is true to avoid banding.
  - Mark background wrapper `aria-hidden="true"` to keep it out of the accessibility tree.

<sup>Written for commit 0ba79f4a141d8b34eecd6f4910e87f52c821f7d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

