### PR TITLE
fix(llm): route Claude Fable 5 / Mythos 5 through adaptive thinking (#11992) to release v4.1

### DIFF
--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -83,6 +83,10 @@ _VERTEX_ANTHROPIC_MODELS_REJECTING_OUTPUT_CONFIG = (
 _ANTHROPIC_ADAPTIVE_THINKING_MODELS = (
     "claude-opus-4-7",
     "claude-opus-4-8",
+    "claude-fable-5",
+    "claude-5-fable",
+    "claude-mythos-5",
+    "claude-5-mythos",
 )
 
 # Anthropic models that reject any non-default sampling parameter (temperature,
@@ -100,6 +104,10 @@ _ANTHROPIC_NO_SAMPLING_PARAMS_MODELS = (
     "claude-opus-4.8",
     "claude-4-8-opus",
     "claude-4.8-opus",
+    "claude-fable-5",
+    "claude-5-fable",
+    "claude-mythos-5",
+    "claude-5-mythos",
 )
 
 

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -437,6 +437,11 @@ ANTHROPIC_MODELS_OMITTING_SAMPLING_PARAMS = [
     "claude-opus-4.8",
     "claude-4-8-opus",
     "claude-4.8-opus",
+    "claude-fable-5",
+    "claude-fable-5@20260101",
+    "claude-5-fable",
+    "claude-mythos-5",
+    "claude-5-mythos",
 ]
 
 
@@ -463,8 +468,24 @@ def test_omits_temperature_for_no_sampling_params_models(model_name: str) -> Non
         assert "temperature" not in kwargs
 
 
-@pytest.mark.parametrize("model_name", ["claude-opus-4-7", "claude-opus-4-8"])
-def test_claude_adaptive_thinking_uses_output_config(model_name: str) -> None:
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "claude-opus-4-7",
+        "claude-opus-4-8",
+        "claude-fable-5",
+        "claude-5-fable",
+        "claude-mythos-5",
+        "claude-5-mythos",
+    ],
+)
+@pytest.mark.parametrize(
+    "reasoning_effort, expected_effort",
+    [(ReasoningEffort.AUTO, "medium"), (ReasoningEffort.HIGH, "high")],
+)
+def test_claude_adaptive_thinking_uses_output_config(
+    model_name: str, reasoning_effort: ReasoningEffort, expected_effort: str
+) -> None:
     # Non-Vertex providers must use the adaptive thinking API for these models
     # (thinking.type=adaptive + output_config.effort) rather than the legacy
     # thinking.type.enabled + budget_tokens path, which they reject with a 400.
@@ -486,11 +507,11 @@ def test_claude_adaptive_thinking_uses_output_config(model_name: str) -> None:
         mock_completion.return_value = []
 
         messages: LanguageModelInput = [UserMessage(content="Hi")]
-        list(llm.stream(messages, reasoning_effort=ReasoningEffort.HIGH))
+        list(llm.stream(messages, reasoning_effort=reasoning_effort))
 
         kwargs = mock_completion.call_args.kwargs
         assert kwargs["thinking"] == {"type": "adaptive"}
-        assert "output_config" in kwargs
+        assert kwargs["output_config"] == {"effort": expected_effort}
         assert "budget_tokens" not in kwargs["thinking"]
 
 


### PR DESCRIPTION
Cherry-pick of commit e66277486affb4627f1c38e1cd31a1841960b892 to release/v4.1 branch.

Original PR: #11992

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes Anthropic Claude Fable 5 and Mythos 5 models through adaptive thinking with `output_config.effort`, fixing 400 errors and aligning with the Anthropic API. Also treats these models as no-sampling-params.

- **Bug Fixes**
  - Added `claude-fable-5`, `claude-5-fable`, `claude-mythos-5`, `claude-5-mythos` to the adaptive thinking list.
  - Maps `reasoning_effort` to `output_config.effort` (AUTO → medium, HIGH → high) and removes `budget_tokens`; omits `temperature` for these models.
  - Expanded unit tests to cover new models and effort mapping.

<sup>Written for commit 7ccf3c89aeecf2d114e17b3fe4709c049565f2b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

