### PR TITLE
fix(deps): replace retry with tenacity to drop CVE-2022-42969 (py)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -35,7 +35,6 @@ RUN apt-get update && \
     apt-get clean
 
 # Install Python dependencies
-# Remove py which is pulled in by retry, py is not needed and is a CVE
 COPY ./requirements/default.txt /tmp/requirements.txt
 COPY ./requirements/ee.txt /tmp/ee-requirements.txt
 # requirements/*.txt are a complete, pre-resolved lock export, so --no-deps installs them as-is
@@ -45,7 +44,6 @@ COPY ./requirements/ee.txt /tmp/ee-requirements.txt
 RUN uv pip install --system --no-cache-dir --no-deps --require-hashes \
         -r /tmp/requirements.txt \
         -r /tmp/ee-requirements.txt && \
-    pip uninstall -y py && \
     # https://github.com/tornadoweb/tornado/issues/3107
     rm -f /usr/local/lib/python3.13/site-packages/tornado/test/test.key && \
     rm -rf ~/.cache/uv /tmp/*.txt

--- a/backend/ee/onyx/external_permissions/google_drive/permission_retrieval.py
+++ b/backend/ee/onyx/external_permissions/google_drive/permission_retrieval.py
@@ -1,14 +1,13 @@
-from retry import retry
-
 from ee.onyx.external_permissions.google_drive.models import GoogleDrivePermission
 from onyx.connectors.google_utils.google_utils import execute_paginated_retrieval
 from onyx.connectors.google_utils.resources import GoogleDriveService
 from onyx.utils.logger import setup_logger
+from onyx.utils.retry_wrapper import retry_builder
 
 logger = setup_logger()
 
 
-@retry(tries=3, delay=2, backoff=2)
+@retry_builder(tries=3, delay=2, backoff=2)
 def get_permissions_by_ids(
     drive_service: GoogleDriveService,
     doc_id: str,

--- a/backend/onyx/background/celery/tasks/user_file_processing/tasks.py
+++ b/backend/onyx/background/celery/tasks/user_file_processing/tasks.py
@@ -9,7 +9,6 @@ from celery import Celery
 from celery import shared_task
 from celery import Task
 from redis.lock import Lock as RedisLock
-from retry import retry
 from sqlalchemy import select
 
 from onyx.access.access import build_access_for_user_files
@@ -58,6 +57,7 @@ from onyx.indexing.embedder import DefaultIndexingEmbedder
 from onyx.indexing.indexing_pipeline import run_indexing_pipeline
 from onyx.redis.redis_pool import get_redis_client
 from onyx.redis.tenant_redis_client import TenantRedisClient
+from onyx.utils.retry_wrapper import retry_builder
 from onyx.utils.variable_functionality import global_version
 
 
@@ -148,7 +148,7 @@ def enqueue_user_file_project_sync_task(
     return True
 
 
-@retry(tries=3, delay=1, backoff=2, jitter=(0.0, 1.0))
+@retry_builder(tries=3, delay=1, backoff=2, jitter=(0.0, 1.0))
 def _visit_chunks(
     *,
     http_client: httpx.Client,

--- a/backend/onyx/connectors/airtable/airtable_connector.py
+++ b/backend/onyx/connectors/airtable/airtable_connector.py
@@ -11,7 +11,6 @@ import requests
 from pyairtable import Api as AirtableApi
 from pyairtable.api.types import RecordDict
 from pyairtable.models.schema import TableSchema
-from retry import retry
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
 from onyx.configs.app_configs import REQUEST_TIMEOUT_SECONDS
@@ -26,6 +25,7 @@ from onyx.connectors.models import TextSection
 from onyx.file_processing.extract_file_text import extract_file_text
 from onyx.file_processing.extract_file_text import get_file_ext
 from onyx.utils.logger import setup_logger
+from onyx.utils.retry_wrapper import retry_builder
 
 logger = setup_logger()
 
@@ -251,7 +251,7 @@ class AirtableConnector(LoadConnector):
                 if not url:
                     continue
 
-                @retry(
+                @retry_builder(
                     tries=5,
                     delay=1,
                     backoff=2,

--- a/backend/onyx/connectors/canvas/connector.py
+++ b/backend/onyx/connectors/canvas/connector.py
@@ -6,7 +6,6 @@ from typing import cast
 from typing import NoReturn
 
 from pydantic import BaseModel
-from retry import retry
 from typing_extensions import override
 
 from onyx.access.models import ExternalAccess
@@ -35,6 +34,7 @@ from onyx.error_handling.exceptions import OnyxError
 from onyx.file_processing.html_utils import parse_html_page_basic
 from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
 from onyx.utils.logger import setup_logger
+from onyx.utils.retry_wrapper import retry_builder
 
 logger = setup_logger()
 
@@ -268,7 +268,7 @@ class CanvasConnector(
             )
         return self._course_permissions_cache[course_id]
 
-    @retry(tries=3, delay=1, backoff=2)
+    @retry_builder(tries=3, delay=1, backoff=2)
     def _list_courses(self) -> list[CanvasCourse]:
         """Fetch all courses accessible to the authenticated user."""
         logger.debug("Fetching Canvas courses")
@@ -280,7 +280,7 @@ class CanvasConnector(
             courses.extend(CanvasCourse.from_api(c) for c in page)
         return courses
 
-    @retry(tries=3, delay=1, backoff=2)
+    @retry_builder(tries=3, delay=1, backoff=2)
     def _list_pages(self, course_id: int) -> list[CanvasPage]:
         """Fetch all pages for a given course."""
         logger.debug("Fetching pages for course %s", course_id)
@@ -293,7 +293,7 @@ class CanvasConnector(
             pages.extend(CanvasPage.from_api(p, course_id=course_id) for p in page)
         return pages
 
-    @retry(tries=3, delay=1, backoff=2)
+    @retry_builder(tries=3, delay=1, backoff=2)
     def _list_assignments(self, course_id: int) -> list[CanvasAssignment]:
         """Fetch all assignments for a given course."""
         logger.debug("Fetching assignments for course %s", course_id)
@@ -308,7 +308,7 @@ class CanvasConnector(
             )
         return assignments
 
-    @retry(tries=3, delay=1, backoff=2)
+    @retry_builder(tries=3, delay=1, backoff=2)
     def _list_announcements(self, course_id: int) -> list[CanvasAnnouncement]:
         """Fetch all announcements for a given course."""
         logger.debug("Fetching announcements for course %s", course_id)

--- a/backend/onyx/connectors/coda/connector.py
+++ b/backend/onyx/connectors/coda/connector.py
@@ -9,7 +9,6 @@ from typing import List
 from typing import Optional
 
 from pydantic import BaseModel
-from retry import retry
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
 from onyx.configs.constants import DocumentSource
@@ -27,6 +26,7 @@ from onyx.connectors.models import ImageSection
 from onyx.connectors.models import TextSection
 from onyx.utils.batching import batch_generator
 from onyx.utils.logger import setup_logger
+from onyx.utils.retry_wrapper import retry_builder
 
 _CODA_CALL_TIMEOUT = 30
 _CODA_BASE_URL = "https://coda.io/apis/v1"
@@ -142,7 +142,7 @@ class CodaConnector(LoadConnector, PollConnector):
             raise ConnectorMissingCredentialError("Coda")
         return self._coda_client
 
-    @retry(tries=3, delay=1, backoff=2)
+    @retry_builder(tries=3, delay=1, backoff=2)
     def _get_doc(self, doc_id: str) -> CodaDoc:
         """Fetch a specific Coda document by its ID."""
         logger.debug("Fetching Coda doc with ID: %s", doc_id)
@@ -166,7 +166,7 @@ class CodaConnector(LoadConnector, PollConnector):
             folder_name=response["folder"]["name"] if response.get("folder") else None,
         )
 
-    @retry(tries=3, delay=1, backoff=2)
+    @retry_builder(tries=3, delay=1, backoff=2)
     def _get_page(self, doc_id: str, page_id: str) -> CodaPage:
         """Fetch a specific page from a Coda document."""
         logger.debug("Fetching Coda page with ID: %s", page_id)
@@ -190,7 +190,7 @@ class CodaConnector(LoadConnector, PollConnector):
             updated_at=response["updatedAt"],
         )
 
-    @retry(tries=3, delay=1, backoff=2)
+    @retry_builder(tries=3, delay=1, backoff=2)
     def _get_table(self, doc_id: str, table_id: str) -> CodaTable:
         """Fetch a specific table from a Coda document."""
         logger.debug("Fetching Coda table with ID: %s", table_id)
@@ -213,7 +213,7 @@ class CodaConnector(LoadConnector, PollConnector):
             doc_id=doc_id,
         )
 
-    @retry(tries=3, delay=1, backoff=2)
+    @retry_builder(tries=3, delay=1, backoff=2)
     def _get_row(self, doc_id: str, table_id: str, row_id: str) -> CodaRow:
         """Fetch a specific row from a Coda table."""
         logger.debug("Fetching Coda row with ID: %s", row_id)
@@ -245,7 +245,7 @@ class CodaConnector(LoadConnector, PollConnector):
             doc_id=doc_id,
         )
 
-    @retry(tries=3, delay=1, backoff=2)
+    @retry_builder(tries=3, delay=1, backoff=2)
     def _list_all_docs(
         self, endpoint: str = "docs", params: Optional[Dict[str, str]] = None
     ) -> List[CodaDoc]:
@@ -294,7 +294,7 @@ class CodaConnector(LoadConnector, PollConnector):
         logger.debug("Found %s docs", len(all_docs))
         return all_docs
 
-    @retry(tries=3, delay=1, backoff=2)
+    @retry_builder(tries=3, delay=1, backoff=2)
     def _list_pages_in_doc(self, doc_id: str) -> List[CodaPage]:
         """List all pages in a Coda document."""
         logger.debug("Listing pages in Coda doc with ID: %s", doc_id)
@@ -343,7 +343,7 @@ class CodaConnector(LoadConnector, PollConnector):
         logger.debug("Found %s pages in doc %s", len(pages), doc_id)
         return pages
 
-    @retry(tries=3, delay=1, backoff=2)
+    @retry_builder(tries=3, delay=1, backoff=2)
     def _fetch_page_content(self, doc_id: str, page_id: str) -> str:
         """Fetch the content of a Coda page."""
         logger.debug("Fetching content for page %s in doc %s", page_id, doc_id)
@@ -381,7 +381,7 @@ class CodaConnector(LoadConnector, PollConnector):
 
         return "\n\n".join(content_parts)
 
-    @retry(tries=3, delay=1, backoff=2)
+    @retry_builder(tries=3, delay=1, backoff=2)
     def _list_tables(self, doc_id: str) -> List[CodaTable]:
         """List all tables in a Coda document."""
         logger.debug("Listing tables in Coda doc with ID: %s", doc_id)
@@ -425,7 +425,7 @@ class CodaConnector(LoadConnector, PollConnector):
         logger.debug("Found %s tables in doc %s", len(tables), doc_id)
         return tables
 
-    @retry(tries=3, delay=1, backoff=2)
+    @retry_builder(tries=3, delay=1, backoff=2)
     def _list_rows_and_values(self, doc_id: str, table_id: str) -> List[CodaRow]:
         """List all rows and their values in a table."""
         logger.debug("Listing rows in Coda table: %s in Coda doc: %s", table_id, doc_id)

--- a/backend/onyx/connectors/freshdesk/connector.py
+++ b/backend/onyx/connectors/freshdesk/connector.py
@@ -5,7 +5,6 @@ from datetime import timezone
 from typing import List
 
 import requests
-from retry import retry
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
 from onyx.configs.constants import DocumentSource
@@ -20,6 +19,7 @@ from onyx.connectors.models import HierarchyNode
 from onyx.connectors.models import TextSection
 from onyx.file_processing.html_utils import parse_html_page_basic
 from onyx.utils.logger import setup_logger
+from onyx.utils.retry_wrapper import retry_builder
 
 logger = setup_logger()
 
@@ -80,7 +80,7 @@ _STATUS_NUMBER_TYPE_MAP: dict[int, str] = {
 
 
 # TODO: unify this with other generic rate limited requests with retries (e.g. Axero, Notion?)
-@retry(tries=3, delay=1, backoff=2)
+@retry_builder(tries=3, delay=1, backoff=2)
 def _rate_limited_freshdesk_get(
     url: str, auth: tuple, params: dict
 ) -> requests.Response:

--- a/backend/onyx/connectors/notion/connector.py
+++ b/backend/onyx/connectors/notion/connector.py
@@ -10,7 +10,6 @@ from urllib.parse import urlparse
 
 import requests
 from pydantic import BaseModel
-from retry import retry
 from typing_extensions import override
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
@@ -34,6 +33,7 @@ from onyx.connectors.models import TextSection
 from onyx.db.enums import HierarchyNodeType
 from onyx.utils.batching import batch_generator
 from onyx.utils.logger import setup_logger
+from onyx.utils.retry_wrapper import retry_builder
 
 logger = setup_logger()
 
@@ -181,7 +181,7 @@ class NotionConnector(LoadConnector, PollConnector):
 
         return NormalizationResult(normalized_url=None, use_default=False)
 
-    @retry(tries=3, delay=1, backoff=2)
+    @retry_builder(tries=3, delay=1, backoff=2)
     def _fetch_child_blocks(
         self, block_id: str, cursor: str | None = None
     ) -> dict[str, Any] | None:
@@ -220,7 +220,7 @@ class NotionConnector(LoadConnector, PollConnector):
             return None
         return res.json()
 
-    @retry(tries=3, delay=1, backoff=2)
+    @retry_builder(tries=3, delay=1, backoff=2)
     def _fetch_page(self, page_id: str) -> NotionPage:
         """Fetch a page from its ID via the Notion API, retry with database if page fetch fails."""
         logger.debug("Fetching page for ID '%s'", page_id)
@@ -243,7 +243,7 @@ class NotionConnector(LoadConnector, PollConnector):
             return self._fetch_database_as_page(page_id)
         return NotionPage(**res.json())
 
-    @retry(tries=3, delay=1, backoff=2)
+    @retry_builder(tries=3, delay=1, backoff=2)
     def _fetch_database_as_page(self, database_id: str) -> NotionPage:
         """Attempt to fetch a database as a page.
 
@@ -272,7 +272,7 @@ class NotionConnector(LoadConnector, PollConnector):
 
         return NotionPage(**db_data, database_name=database_name)
 
-    @retry(tries=3, delay=1, backoff=2)
+    @retry_builder(tries=3, delay=1, backoff=2)
     def _fetch_data_sources_for_database(
         self, database_id: str
     ) -> list[NotionDataSource]:
@@ -306,7 +306,7 @@ class NotionConnector(LoadConnector, PollConnector):
             if ds.get("id")
         ]
 
-    @retry(tries=3, delay=1, backoff=2)
+    @retry_builder(tries=3, delay=1, backoff=2)
     def _fetch_data_source(
         self, data_source_id: str, cursor: str | None = None
     ) -> dict[str, Any]:
@@ -336,7 +336,7 @@ class NotionConnector(LoadConnector, PollConnector):
             raise e
         return res.json()
 
-    @retry(tries=3, delay=1, backoff=2)
+    @retry_builder(tries=3, delay=1, backoff=2)
     def _fetch_workspace_info(self) -> tuple[str, str]:
         """Fetch workspace ID and name from the bot user endpoint."""
         res = rl_requests.get(
@@ -893,7 +893,7 @@ class NotionConnector(LoadConnector, PollConnector):
                 ]
                 yield from self._read_pages(child_page_batch)
 
-    @retry(tries=3, delay=1, backoff=2)
+    @retry_builder(tries=3, delay=1, backoff=2)
     def _search_notion(self, query_dict: dict[str, Any]) -> NotionSearchResponse:
         """Search for pages from a Notion database. Includes some small number of
         retries to handle misc, flakey failures."""

--- a/backend/onyx/connectors/productboard/connector.py
+++ b/backend/onyx/connectors/productboard/connector.py
@@ -6,7 +6,6 @@ from typing import cast
 import requests
 from bs4 import BeautifulSoup
 from dateutil import parser
-from retry import retry
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
 from onyx.configs.app_configs import REQUEST_TIMEOUT_SECONDS
@@ -20,6 +19,7 @@ from onyx.connectors.models import Document
 from onyx.connectors.models import HierarchyNode
 from onyx.connectors.models import TextSection
 from onyx.utils.logger import setup_logger
+from onyx.utils.retry_wrapper import retry_builder
 
 logger = setup_logger()
 
@@ -67,7 +67,7 @@ class ProductboardConnector(PollConnector):
     ) -> Generator[dict[str, Any], None, None]:
         headers = self._build_headers()
 
-        @retry(tries=3, delay=1, backoff=2)
+        @retry_builder(tries=3, delay=1, backoff=2)
         def fetch(link: str) -> dict[str, Any]:
             response = requests.get(
                 link, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS

--- a/backend/onyx/document_index/vespa/chunk_retrieval.py
+++ b/backend/onyx/document_index/vespa/chunk_retrieval.py
@@ -9,7 +9,6 @@ from typing import Any
 from typing import cast
 
 import httpx
-from retry import retry
 
 from onyx.background.celery.tasks.opensearch_migration.constants import (
     FINISHED_VISITING_SLICE_CONTINUATION_TOKEN,
@@ -61,6 +60,7 @@ from onyx.document_index.vespa_constants import TENANT_ID
 from onyx.document_index.vespa_constants import TITLE
 from onyx.document_index.vespa_constants import YQL_BASE
 from onyx.utils.logger import setup_logger
+from onyx.utils.retry_wrapper import retry_builder
 from onyx.utils.threadpool_concurrency import run_functions_tuples_in_parallel
 from shared_configs.configs import MULTI_TENANT
 
@@ -502,7 +502,7 @@ def parallel_visit_api_retrieval(
     return inference_chunks
 
 
-@retry(tries=3, delay=1, backoff=2)
+@retry_builder(tries=3, delay=1, backoff=2)
 def query_vespa(
     query_params: Mapping[str, str | int | float],
 ) -> list[InferenceChunkUncleaned]:

--- a/backend/onyx/document_index/vespa/deletion.py
+++ b/backend/onyx/document_index/vespa/deletion.py
@@ -2,11 +2,11 @@ import concurrent.futures
 from uuid import UUID
 
 import httpx
-from retry import retry
 
 from onyx.document_index.vespa_constants import DOCUMENT_ID_ENDPOINT
 from onyx.document_index.vespa_constants import NUM_THREADS
 from onyx.utils.logger import setup_logger
+from onyx.utils.retry_wrapper import retry_builder
 
 logger = setup_logger()
 
@@ -14,7 +14,7 @@ logger = setup_logger()
 CONTENT_SUMMARY = "content_summary"
 
 
-@retry(tries=10, delay=1, backoff=2)
+@retry_builder(tries=10, delay=1, backoff=2)
 def _retryable_http_delete(http_client: httpx.Client, url: str) -> None:
     res = http_client.delete(url)
     res.raise_for_status()

--- a/backend/onyx/document_index/vespa/indexing_utils.py
+++ b/backend/onyx/document_index/vespa/indexing_utils.py
@@ -11,7 +11,6 @@ from datetime import timezone
 from http import HTTPStatus
 
 import httpx
-from retry import retry
 
 from onyx.connectors.cross_connector_utils.miscellaneous_utils import (
     get_experts_stores_representations,
@@ -60,6 +59,7 @@ from onyx.document_index.vespa_constants import TITLE_EMBEDDING
 from onyx.document_index.vespa_constants import USER_PROJECT
 from onyx.indexing.models import DocMetadataAwareIndexChunk
 from onyx.utils.logger import setup_logger
+from onyx.utils.retry_wrapper import retry_builder
 from onyx.utils.text_processing import remove_invalid_unicode_chars
 
 logger = setup_logger()
@@ -70,7 +70,7 @@ INDEXING_BASE_DELAY = 1.0
 INDEXING_MAX_DELAY = 60.0
 
 
-@retry(tries=3, delay=1, backoff=2)
+@retry_builder(tries=3, delay=1, backoff=2)
 def _does_doc_chunk_exist(
     doc_chunk_id: uuid.UUID, index_name: str, http_client: httpx.Client
 ) -> bool:

--- a/backend/onyx/document_index/vespa/vespa_document_index.py
+++ b/backend/onyx/document_index/vespa/vespa_document_index.py
@@ -20,7 +20,6 @@ import httpx
 import jinja2
 import requests
 from pydantic import BaseModel
-from retry import retry
 
 from onyx.configs.app_configs import MAX_CHUNKS_PER_DOC_BATCH
 from onyx.configs.app_configs import RECENCY_BIAS_MULTIPLIER
@@ -81,6 +80,7 @@ from onyx.kg.utils.formatting_utils import split_relationship_id
 from onyx.tools.tool_implementations.search.constants import KEYWORD_QUERY_HYBRID_ALPHA
 from onyx.utils.batching import batch_generator
 from onyx.utils.logger import setup_logger
+from onyx.utils.retry_wrapper import retry_builder
 from shared_configs.configs import MULTI_TENANT
 from shared_configs.model_server_models import Embedding
 
@@ -439,7 +439,7 @@ def _enrich_basic_chunk_info(
     return enriched_doc_info
 
 
-@retry(
+@retry_builder(
     tries=3,
     delay=1,
     backoff=2,
@@ -1131,7 +1131,7 @@ class VespaDocumentIndex(DocumentIndex):
         """Runs a batch of KG chunk updates in parallel via the
         ThreadPoolExecutor."""
 
-        @retry(tries=3, delay=1, backoff=2, jitter=(0.0, 1.0))
+        @retry_builder(tries=3, delay=1, backoff=2, jitter=(0.0, 1.0))
         def _kg_update_chunk(
             update: KGVespaChunkUpdateRequest, http_client: httpx.Client
         ) -> httpx.Response:

--- a/backend/onyx/onyxbot/slack/handlers/handle_regular_answer.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_regular_answer.py
@@ -4,7 +4,6 @@ from typing import Any
 from typing import Optional
 from typing import TypeVar
 
-from retry import retry
 from slack_sdk import WebClient
 
 from onyx.auth.users import get_anonymous_user
@@ -37,6 +36,7 @@ from onyx.server.query_and_chat.models import ChatSessionCreationRequest
 from onyx.server.query_and_chat.models import MessageOrigin
 from onyx.server.query_and_chat.models import SendMessageRequest
 from onyx.utils.logger import OnyxLoggingAdapter
+from onyx.utils.retry_wrapper import retry_builder
 
 srl = SlackRateLimiter()
 
@@ -234,7 +234,7 @@ def handle_regular_answer(
             "No message timestamp to respond to in `handle_message`. This should never happen."
         )
 
-    @retry(
+    @retry_builder(
         tries=num_retries,
         delay=0.25,
         backoff=2,

--- a/backend/onyx/onyxbot/slack/utils.py
+++ b/backend/onyx/onyxbot/slack/utils.py
@@ -1,4 +1,3 @@
-import logging
 import random
 import re
 import string
@@ -10,7 +9,6 @@ from contextlib import contextmanager
 from typing import Any
 from typing import cast
 
-from retry import retry
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 from slack_sdk.models.blocks import Block
@@ -34,6 +32,7 @@ from onyx.onyxbot.slack.constants import FeedbackVisibility
 from onyx.onyxbot.slack.models import ChannelType
 from onyx.onyxbot.slack.models import ThreadMessage
 from onyx.utils.logger import setup_logger
+from onyx.utils.retry_wrapper import retry_builder
 from onyx.utils.telemetry import optional_telemetry
 from onyx.utils.telemetry import RecordType
 from onyx.utils.text_processing import replace_whitespaces_w_space
@@ -232,11 +231,10 @@ def _build_error_block(error_message: str) -> Block:
     return SectionBlock(text=display_text)
 
 
-@retry(
+@retry_builder(
     tries=ONYX_BOT_NUM_RETRIES,
     delay=0.25,
     backoff=2,
-    logger=cast(logging.Logger, logger),
 )
 def respond_in_thread_or_channel(
     client: WebClient,

--- a/backend/onyx/utils/gpu_utils.py
+++ b/backend/onyx/utils/gpu_utils.py
@@ -2,9 +2,9 @@ import os
 from functools import lru_cache
 
 import requests
-from retry import retry
 
 from onyx.utils.logger import setup_logger
+from onyx.utils.retry_wrapper import retry_builder
 from shared_configs.configs import INDEXING_MODEL_SERVER_HOST
 from shared_configs.configs import INDEXING_MODEL_SERVER_PORT
 from shared_configs.configs import MODEL_SERVER_HOST
@@ -35,7 +35,8 @@ def _get_gpu_status_from_model_server(indexing: bool) -> bool:
         raise  # Re-raise exception to trigger a retry
 
 
-@retry(tries=5, delay=5)
+# backoff=1 preserves the constant 5s delay this had under the `retry` package
+@retry_builder(tries=5, delay=5, backoff=1)
 def gpu_status_request(indexing: bool) -> bool:
     return _get_gpu_status_from_model_server(indexing)
 

--- a/backend/onyx/utils/gpu_utils.py
+++ b/backend/onyx/utils/gpu_utils.py
@@ -35,8 +35,9 @@ def _get_gpu_status_from_model_server(indexing: bool) -> bool:
         raise  # Re-raise exception to trigger a retry
 
 
-# backoff=1 preserves the constant 5s delay this had under the `retry` package
-@retry_builder(tries=5, delay=5, backoff=1)
+# backoff=1 + jitter=0 preserve the constant 5s delay this had under the
+# legacy `retry` package
+@retry_builder(tries=5, delay=5, backoff=1, jitter=0)
 def gpu_status_request(indexing: bool) -> bool:
     return _get_gpu_status_from_model_server(indexing)
 

--- a/backend/onyx/utils/retry_wrapper.py
+++ b/backend/onyx/utils/retry_wrapper.py
@@ -54,6 +54,11 @@ def retry_builder(
     stop: stop_base = stop_after_attempt(tries) if tries >= 0 else stop_never
 
     def retry_with_default(func: F) -> F:
+        # `wraps` is intentionally applied *below* the tenacity decorator: it
+        # renames the inner function before tenacity captures it, so the
+        # `before_sleep_log` warnings name the real call site instead of
+        # `wrapped_func`. Final metadata is correct either way (tenacity
+        # applies `functools.wraps` to whatever it wraps).
         @tenacity_retry(
             retry=retry_if_exception_type(exceptions),
             wait=wait,

--- a/backend/onyx/utils/retry_wrapper.py
+++ b/backend/onyx/utils/retry_wrapper.py
@@ -1,3 +1,5 @@
+import functools
+import logging
 from collections.abc import Callable
 from logging import Logger
 from typing import Any
@@ -5,7 +7,15 @@ from typing import cast
 from typing import TypeVar
 
 import requests
-from retry import retry
+from tenacity import before_sleep_log
+from tenacity import retry as tenacity_retry
+from tenacity import retry_if_exception_type
+from tenacity import stop_after_attempt
+from tenacity import stop_never
+from tenacity import wait_exponential
+from tenacity import wait_random
+from tenacity.stop import stop_base
+from tenacity.wait import wait_base
 
 from onyx.configs.app_configs import REQUEST_TIMEOUT_SECONDS
 from onyx.utils.logger import setup_logger
@@ -28,16 +38,30 @@ def retry_builder(
     may fail due to rate limiting, flakes, or other reasons. Applies exponential
     backoff with jitter to retry the call."""
 
+    # mirror the semantics of the legacy `retry` package: the n-th wait is
+    # `delay * backoff**n` capped at `max_delay`, plus a random jitter
+    wait: wait_base = wait_exponential(
+        multiplier=delay,
+        exp_base=backoff,
+        max=max_delay if max_delay is not None else float("inf"),
+    )
+    if isinstance(jitter, tuple):
+        wait = wait + wait_random(jitter[0], jitter[1])
+    elif jitter:
+        wait = wait + wait_random(0, jitter)
+
+    # `tries=-1` in the legacy `retry` package meant "retry forever"
+    stop: stop_base = stop_after_attempt(tries) if tries >= 0 else stop_never
+
     def retry_with_default(func: F) -> F:
-        @retry(
-            tries=tries,
-            delay=delay,
-            max_delay=max_delay,
-            backoff=backoff,
-            jitter=jitter,
-            logger=cast(Logger, logger),
-            exceptions=exceptions,
+        @tenacity_retry(
+            retry=retry_if_exception_type(exceptions),
+            wait=wait,
+            stop=stop,
+            before_sleep=before_sleep_log(cast(Logger, logger), logging.WARNING),
+            reraise=True,
         )
+        @functools.wraps(func)
         def wrapped_func(*args: list, **kwargs: dict[str, Any]) -> Any:
             return func(*args, **kwargs)
 
@@ -59,7 +83,9 @@ def request_with_retries(
     delay: float = 1,
     backoff: float = 2,
 ) -> requests.Response:
-    @retry(tries=tries, delay=delay, backoff=backoff, logger=cast(Logger, logger))
+    # jitter=0 + max_delay=None preserves the exact wait curve this function
+    # had on the legacy `retry` package: delay * backoff**n, uncapped
+    @retry_builder(tries=tries, delay=delay, max_delay=None, backoff=backoff, jitter=0)
     def _make_request() -> requests.Response:
         response = requests.request(
             method=method,

--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -670,10 +670,6 @@ dateparser==1.2.2 \
     --hash=sha256:5a5d7211a09013499867547023a2a0c91d5a27d15dd4dbcea676ea9fe66f2482 \
     --hash=sha256:986316f17cb8cdc23ea8ce563027c5ef12fc725b6fb1d137c14ca08777c5ecf7
     # via htmldate
-decorator==5.2.1 \
-    --hash=sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360 \
-    --hash=sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a
-    # via retry
 defusedxml==0.7.1 \
     --hash=sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69 \
     --hash=sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61
@@ -2156,10 +2152,6 @@ pwdlib==0.3.0 \
     --hash=sha256:6ca30f9642a1467d4f5d0a4d18619de1c77f17dfccb42dd200b144127d3c83fc \
     --hash=sha256:f86c15c138858c09f3bba0a10984d4f9178158c55deaa72eac0210849b1a140d
     # via fastapi-users
-py==1.11.0 \
-    --hash=sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719 \
-    --hash=sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378
-    # via retry
 py-key-value-aio==0.4.4 \
     --hash=sha256:18e17564ecae61b987f909fc2cd41ee2012c84b4b1dcb8c055cf8b4bc1bf3f5d \
     --hash=sha256:e3012e6243ed7cc09bb05457bd4d03b1ba5c2b1ca8700096b3927db79ffbbe55
@@ -2647,10 +2639,6 @@ requests-toolbelt==1.0.0 \
     #   python-gitlab
     #   unstructured-client
     #   zeep
-retry==0.9.2 \
-    --hash=sha256:ccddf89761fa2c726ab29391837d4327f819ea14d244c232a1d24c67a2f98606 \
-    --hash=sha256:f8bfa8b99b69c4506d6f5bd3b0aabf77f98cdb17f3c9fc3f5ca820033336fba4
-    # via onyx
 rich==14.2.0 \
     --hash=sha256:73ff50c7c0c1c77c8243079283f4edb376f0f6442433aecb8ce7e6d0b92d1fe4 \
     --hash=sha256:76bc51fe2e57d2b1be1f96c524b890b816e334ab4c1e45888799bfaab0021edd
@@ -2864,6 +2852,7 @@ tenacity==9.1.2 \
     # via
     #   google-genai
     #   langchain-core
+    #   onyx
     #   voyageai
 text-unidecode==1.3 \
     --hash=sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8 \

--- a/backend/requirements/dev.txt
+++ b/backend/requirements/dev.txt
@@ -405,9 +405,7 @@ debugpy==1.8.17 \
 decorator==5.2.1 \
     --hash=sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360 \
     --hash=sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a
-    # via
-    #   ipython
-    #   retry
+    # via ipython
 distlib==0.4.0 \
     --hash=sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16 \
     --hash=sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d
@@ -1445,10 +1443,6 @@ pure-eval==0.2.3 \
     --hash=sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0 \
     --hash=sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42
     # via stack-data
-py==1.11.0 \
-    --hash=sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719 \
-    --hash=sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378
-    # via retry
 pyasn1==0.6.3 \
     --hash=sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf \
     --hash=sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde
@@ -1726,10 +1720,6 @@ requests==2.33.0 \
     #   pytest-base-url
     #   tiktoken
     #   voyageai
-retry==0.9.2 \
-    --hash=sha256:ccddf89761fa2c726ab29391837d4327f819ea14d244c232a1d24c67a2f98606 \
-    --hash=sha256:f8bfa8b99b69c4506d6f5bd3b0aabf77f98cdb17f3c9fc3f5ca820033336fba4
-    # via onyx
 rpds-py==0.29.0 \
     --hash=sha256:00e56b12d2199ca96068057e1ae7f9998ab6e99cda82431afafd32f3ec98cca9 \
     --hash=sha256:05a2bd42768ea988294ca328206efbcc66e220d2d9b7836ee5712c07ad6340ea \
@@ -1876,6 +1866,7 @@ tenacity==9.1.2 \
     --hash=sha256:f77bf36710d8b73a50b2dd155c97b870017ad21afe6ab300326b0371b3b05138
     # via
     #   google-genai
+    #   onyx
     #   voyageai
 text-unidecode==1.3 \
     --hash=sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8 \
@@ -2038,9 +2029,6 @@ types-requests==2.32.0.20250328 \
     # via
     #   cohere
     #   types-docker
-types-retry==0.9.9.3 \
-    --hash=sha256:1b7a0a04adf12f21237e76833574a9a8f755f88889c226ad99d6e3bfa5b6e3c8 \
-    --hash=sha256:238fdb08794862d951187250e443257bb09e927404c88edf7ce88618f4357c2a
 types-s3transfer==0.14.0 \
     --hash=sha256:108134854069a38b048e9b710b9b35904d22a9d0f37e4e1889c2e6b58e5b3253 \
     --hash=sha256:17f800a87c7eafab0434e9d87452c809c290ae906c2024c24261c564479e9c95

--- a/backend/requirements/ee.txt
+++ b/backend/requirements/ee.txt
@@ -307,10 +307,6 @@ cryptography==46.0.7 \
     --hash=sha256:fdd1736fed309b4300346f88f74cd120c27c56852c3838cab416e7a166f67298 \
     --hash=sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce
     # via google-auth
-decorator==5.2.1 \
-    --hash=sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360 \
-    --hash=sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a
-    # via retry
 distro==1.9.0 \
     --hash=sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed \
     --hash=sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2
@@ -991,10 +987,6 @@ protobuf==6.33.5 \
     #   grpc-google-iam-v1
     #   grpcio-status
     #   proto-plus
-py==1.11.0 \
-    --hash=sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719 \
-    --hash=sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378
-    # via retry
 pyasn1==0.6.3 \
     --hash=sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf \
     --hash=sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde
@@ -1166,10 +1158,6 @@ requests==2.33.0 \
     #   posthog
     #   tiktoken
     #   voyageai
-retry==0.9.2 \
-    --hash=sha256:ccddf89761fa2c726ab29391837d4327f819ea14d244c232a1d24c67a2f98606 \
-    --hash=sha256:f8bfa8b99b69c4506d6f5bd3b0aabf77f98cdb17f3c9fc3f5ca820033336fba4
-    # via onyx
 rpds-py==0.29.0 \
     --hash=sha256:00e56b12d2199ca96068057e1ae7f9998ab6e99cda82431afafd32f3ec98cca9 \
     --hash=sha256:05a2bd42768ea988294ca328206efbcc66e220d2d9b7836ee5712c07ad6340ea \
@@ -1268,6 +1256,7 @@ tenacity==9.1.2 \
     --hash=sha256:f77bf36710d8b73a50b2dd155c97b870017ad21afe6ab300326b0371b3b05138
     # via
     #   google-genai
+    #   onyx
     #   voyageai
 tiktoken==0.13.0 \
     --hash=sha256:115c4f26ffa11caac8b54eea35c2ad38c612c20a48d35dd15d70a02ac6f51f58 \

--- a/backend/requirements/model_server.txt
+++ b/backend/requirements/model_server.txt
@@ -334,10 +334,6 @@ cryptography==46.0.7 \
     --hash=sha256:fdd1736fed309b4300346f88f74cd120c27c56852c3838cab416e7a166f67298 \
     --hash=sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce
     # via google-auth
-decorator==5.2.1 \
-    --hash=sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360 \
-    --hash=sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a
-    # via retry
 distro==1.9.0 \
     --hash=sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed \
     --hash=sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2
@@ -1131,10 +1127,6 @@ psutil==7.1.3 \
     --hash=sha256:f39c2c19fe824b47484b96f9692932248a54c43799a84282cfe58d05a6449efd \
     --hash=sha256:fac9cd332c67f4422504297889da5ab7e05fd11e3c4392140f7370f4208ded1f
     # via accelerate
-py==1.11.0 \
-    --hash=sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719 \
-    --hash=sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378
-    # via retry
 pyasn1==0.6.3 \
     --hash=sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf \
     --hash=sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde
@@ -1311,10 +1303,6 @@ requests==2.33.0 \
     #   tiktoken
     #   transformers
     #   voyageai
-retry==0.9.2 \
-    --hash=sha256:ccddf89761fa2c726ab29391837d4327f819ea14d244c232a1d24c67a2f98606 \
-    --hash=sha256:f8bfa8b99b69c4506d6f5bd3b0aabf77f98cdb17f3c9fc3f5ca820033336fba4
-    # via onyx
 rpds-py==0.29.0 \
     --hash=sha256:00e56b12d2199ca96068057e1ae7f9998ab6e99cda82431afafd32f3ec98cca9 \
     --hash=sha256:05a2bd42768ea988294ca328206efbcc66e220d2d9b7836ee5712c07ad6340ea \
@@ -1505,6 +1493,7 @@ tenacity==9.1.2 \
     --hash=sha256:f77bf36710d8b73a50b2dd155c97b870017ad21afe6ab300326b0371b3b05138
     # via
     #   google-genai
+    #   onyx
     #   voyageai
 threadpoolctl==3.6.0 \
     --hash=sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb \

--- a/backend/tests/regression/answer_quality/api_utils.py
+++ b/backend/tests/regression/answer_quality/api_utils.py
@@ -17,8 +17,9 @@ def _api_url_builder(env_name: str, api_path: str) -> str:
         return "http://localhost:8080" + api_path
 
 
-# backoff=1 preserves the constant 10s delay this had under the `retry` package
-@retry_builder(tries=10, delay=10, backoff=1)
+# backoff=1 + jitter=0 preserve the constant 10s delay this had under the
+# legacy `retry` package
+@retry_builder(tries=10, delay=10, backoff=1, jitter=0)
 def check_indexing_status(env_name: str) -> tuple[int, bool]:
     url = _api_url_builder(env_name, "/manage/admin/connector/indexing-status/")
     try:

--- a/backend/tests/regression/answer_quality/api_utils.py
+++ b/backend/tests/regression/answer_quality/api_utils.py
@@ -1,10 +1,10 @@
 import requests
-from retry import retry
 
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.models import InputType
 from onyx.db.enums import IndexingStatus
 from onyx.server.documents.models import ConnectorBase
+from onyx.utils.retry_wrapper import retry_builder
 from tests.regression.answer_quality.cli_utils import get_api_server_host_port
 
 GENERAL_HEADERS = {"Content-Type": "application/json"}
@@ -17,7 +17,8 @@ def _api_url_builder(env_name: str, api_path: str) -> str:
         return "http://localhost:8080" + api_path
 
 
-@retry(tries=10, delay=10)
+# backoff=1 preserves the constant 10s delay this had under the `retry` package
+@retry_builder(tries=10, delay=10, backoff=1)
 def check_indexing_status(env_name: str) -> tuple[int, bool]:
     url = _api_url_builder(env_name, "/manage/admin/connector/indexing-status/")
     try:
@@ -147,7 +148,7 @@ def create_credential(env_name: str) -> int:
         raise RuntimeError(response.__dict__)
 
 
-@retry(tries=10, delay=2, backoff=2)
+@retry_builder(tries=10, delay=2, backoff=2)
 def upload_file(env_name: str, zip_file_path: str) -> list[str]:
     files = [
         ("files", open(zip_file_path, "rb")),

--- a/backend/tests/regression/answer_quality/cli_utils.py
+++ b/backend/tests/regression/answer_quality/cli_utils.py
@@ -9,7 +9,8 @@ from threading import Thread
 from typing import IO
 
 import yaml
-from retry import retry
+
+from onyx.utils.retry_wrapper import retry_builder
 
 
 def _run_command(command: str, stream_output: bool = False) -> tuple[str, str]:
@@ -236,7 +237,7 @@ def cleanup_docker(env_name: str) -> None:
         )
 
 
-@retry(tries=5, delay=5, backoff=2)
+@retry_builder(tries=5, delay=5, backoff=2)
 def get_api_server_host_port(env_name: str) -> str:
     """
     This pulls all containers with the provided env_name

--- a/backend/tests/regression/search_quality/run_search_eval.py
+++ b/backend/tests/regression/search_quality/run_search_eval.py
@@ -19,7 +19,8 @@ from dotenv import load_dotenv
 from matplotlib.patches import Patch
 from pydantic import ValidationError
 from requests.exceptions import RequestException
-from retry import retry
+
+from onyx.utils.retry_wrapper import retry_builder
 
 # add onyx/backend to path (since this isn't done automatically when running as a script)
 current_dir = Path(__file__).parent
@@ -415,7 +416,7 @@ class SearchAnswerAnalyzer:
 
         return dataset
 
-    @retry(tries=3, delay=1, backoff=2)
+    @retry_builder(tries=3, delay=1, backoff=2)
     def _perform_search(self, query: str) -> OneshotQAResult:
         """Perform a document search query against the Onyx API and time it."""
         # create the search request

--- a/backend/tests/unit/onyx/connectors/zendesk/test_zendesk_checkpointing.py
+++ b/backend/tests/unit/onyx/connectors/zendesk/test_zendesk_checkpointing.py
@@ -3,7 +3,6 @@ from collections.abc import Callable
 from collections.abc import Generator
 from typing import Any
 from typing import cast
-from unittest.mock import call
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -298,7 +297,12 @@ def test_load_from_checkpoint_with_rate_limit(
             outputs = load_everything_from_checkpoint_connector(
                 zendesk_connector, 0, end_time
             )
-            mock_sleep.assert_has_calls([call(60), call(0.1)])
+            assert mock_sleep.call_count == 2
+            sleep_durations = [c.args[0] for c in mock_sleep.call_args_list]
+            # Explicit Retry-After sleep from the 429 handler
+            assert sleep_durations[0] == 60
+            # retry_builder (tenacity) wait: delay=0.1 plus random jitter in [0, 1)
+            assert 0.1 <= sleep_durations[1] < 1.1
 
         # Check that we got the document after rate limit was handled
         assert len(outputs) == 2

--- a/backend/tests/unit/onyx/utils/test_retry_wrapper.py
+++ b/backend/tests/unit/onyx/utils/test_retry_wrapper.py
@@ -1,0 +1,54 @@
+"""Unit tests for retry_builder (tenacity-backed retry decorator)."""
+
+import pytest
+
+from onyx.utils.retry_wrapper import retry_builder
+
+
+def test_retry_builder_succeeds_after_transient_failures() -> None:
+    """A function failing twice then succeeding returns the success value
+    and is called exactly 3 times."""
+    call_count = 0
+
+    @retry_builder(tries=3, delay=0.01, backoff=1, jitter=0)
+    def flaky() -> str:
+        nonlocal call_count
+        call_count += 1
+        if call_count < 3:
+            raise RuntimeError("transient failure")
+        return "success"
+
+    assert flaky() == "success"
+    assert call_count == 3
+
+
+def test_retry_builder_reraises_original_exception() -> None:
+    """A function that always raises re-raises the original exception type
+    (not tenacity's RetryError) after exhausting all tries."""
+    call_count = 0
+
+    @retry_builder(tries=2, delay=0.01, backoff=1, jitter=0)
+    def always_fails() -> None:
+        nonlocal call_count
+        call_count += 1
+        raise ValueError("permanent failure")
+
+    with pytest.raises(ValueError, match="permanent failure"):
+        always_fails()
+    assert call_count == 2
+
+
+def test_retry_builder_does_not_retry_unlisted_exceptions() -> None:
+    """A function raising an exception type outside `exceptions=` raises
+    immediately, with no retries."""
+    call_count = 0
+
+    @retry_builder(tries=3, delay=0.01, backoff=1, jitter=0, exceptions=KeyError)
+    def raises_unlisted() -> None:
+        nonlocal call_count
+        call_count += 1
+        raise ValueError("not retryable")
+
+    with pytest.raises(ValueError, match="not retryable"):
+        raises_unlisted()
+    assert call_count == 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,8 @@ dependencies = [
     "python-json-logger==4.1.0",
     "prometheus_client>=0.21.1",
     "prometheus_fastapi_instrumentator==8.0.0",
-    "retry==0.9.2",                             # This pulls in py which is in CVE-2022-42969, must remove py from image
     "sentry-sdk==2.14.0",
+    "tenacity==9.1.2",
     "uvicorn==0.35.0",
     "voyageai==0.2.3",
     "brotli>=1.2.0",
@@ -165,7 +165,6 @@ dev = [
     "types-pytz==2023.3.1.1",
     "types-regex==2023.3.23.1",
     "types-requests==2.32.0.20250328",
-    "types-retry==0.9.9.3",
     "types-setuptools==68.0.0.3",
     { include-group = "zizmor" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -4046,8 +4046,8 @@ dependencies = [
     { name = "prometheus-fastapi-instrumentator" },
     { name = "pydantic" },
     { name = "python-json-logger" },
-    { name = "retry" },
     { name = "sentry-sdk" },
+    { name = "tenacity" },
     { name = "uvicorn" },
     { name = "voyageai" },
 ]
@@ -4176,7 +4176,6 @@ dev = [
     { name = "types-pyyaml" },
     { name = "types-regex" },
     { name = "types-requests" },
-    { name = "types-retry" },
     { name = "types-setuptools" },
     { name = "zizmor" },
 ]
@@ -4210,8 +4209,8 @@ requires-dist = [
     { name = "prometheus-fastapi-instrumentator", specifier = "==8.0.0" },
     { name = "pydantic", specifier = "==2.11.7" },
     { name = "python-json-logger", specifier = "==4.1.0" },
-    { name = "retry", specifier = "==0.9.2" },
     { name = "sentry-sdk", specifier = "==2.14.0" },
+    { name = "tenacity", specifier = "==9.1.2" },
     { name = "uvicorn", specifier = "==0.35.0" },
     { name = "voyageai", specifier = "==0.2.3" },
 ]
@@ -4340,7 +4339,6 @@ dev = [
     { name = "types-pyyaml", specifier = "==6.0.12.11" },
     { name = "types-regex", specifier = "==2023.3.23.1" },
     { name = "types-requests", specifier = "==2.32.0.20250328" },
-    { name = "types-retry", specifier = "==0.9.9.3" },
     { name = "types-setuptools", specifier = "==68.0.0.3" },
     { name = "zizmor", specifier = "==1.25.2" },
 ]
@@ -5083,15 +5081,6 @@ argon2 = [
 ]
 bcrypt = [
     { name = "bcrypt" },
-]
-
-[[package]]
-name = "py"
-version = "1.11.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/98/ff/fec109ceb715d2a6b4c4a85a61af3b40c723a961e8828319fbcb15b868dc/py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719", size = 207796, upload-time = "2021-11-04T17:17:01.377Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/f0/10642828a8dfb741e5f3fbaac830550a518a775c7fff6f04a007259b0548/py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378", size = 98708, upload-time = "2021-11-04T17:17:00.152Z" },
 ]
 
 [[package]]
@@ -5997,19 +5986,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481, upload-time = "2023-05-01T04:11:28.427Z" },
-]
-
-[[package]]
-name = "retry"
-version = "0.9.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "decorator" },
-    { name = "py" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/72/75d0b85443fbc8d9f38d08d2b1b67cc184ce35280e4a3813cda2f445f3a4/retry-0.9.2.tar.gz", hash = "sha256:f8bfa8b99b69c4506d6f5bd3b0aabf77f98cdb17f3c9fc3f5ca820033336fba4", size = 6448, upload-time = "2016-05-11T13:58:51.541Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/0d/53aea75710af4528a25ed6837d71d117602b01946b307a3912cb3cfcbcba/retry-0.9.2-py2.py3-none-any.whl", hash = "sha256:ccddf89761fa2c726ab29391837d4327f819ea14d244c232a1d24c67a2f98606", size = 7986, upload-time = "2016-05-11T13:58:39.925Z" },
 ]
 
 [[package]]
@@ -7038,15 +7014,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/00/7d/eb174f74e3f5634eaacb38031bbe467dfe2e545bc255e5c90096ec46bc46/types_requests-2.32.0.20250328.tar.gz", hash = "sha256:c9e67228ea103bd811c96984fac36ed2ae8da87a36a633964a21f199d60baf32", size = 22995, upload-time = "2025-03-28T02:55:13.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/15/3700282a9d4ea3b37044264d3e4d1b1f0095a4ebf860a99914fd544e3be3/types_requests-2.32.0.20250328-py3-none-any.whl", hash = "sha256:72ff80f84b15eb3aa7a8e2625fffb6a93f2ad5a0c20215fc1dcfa61117bcb2a2", size = 20663, upload-time = "2025-03-28T02:55:11.946Z" },
-]
-
-[[package]]
-name = "types-retry"
-version = "0.9.9.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/87/59/9ed70532dccd7e3ca4a4e3679d8ccd3f12c3a7ed6845976c9316974fd526/types-retry-0.9.9.3.tar.gz", hash = "sha256:1b7a0a04adf12f21237e76833574a9a8f755f88889c226ad99d6e3bfa5b6e3c8", size = 2749, upload-time = "2023-03-28T12:33:07.804Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/a5/692b66fc5b5b919c2a74f74c23724674525d3bb311b4f6d9e213760d9027/types_retry-0.9.9.3-py3-none-any.whl", hash = "sha256:238fdb08794862d951187250e443257bb09e927404c88edf7ce88618f4357c2a", size = 2434, upload-time = "2023-03-28T12:33:06.703Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The unmaintained `retry` package (last release 2016) pulls in `py==1.11.0`, which carries [CVE-2022-42969](https://nvd.nist.gov/vuln/detail/CVE-2022-42969) (ReDoS) and ships in every Onyx image, tripping customer security scanners. `pyproject.toml` has carried an acknowledged-but-unresolved comment about this indefinitely.

This PR rebuilds the shared retry machinery on `tenacity` (already in the dependency tree as a transitive dep, now promoted to a direct pin) and removes `retry`, `types-retry`, and the transitive `py` from the lock entirely.

- **`onyx/utils/retry_wrapper.py`**: `retry_builder` and `request_with_retries` keep byte-identical signatures, internally built on tenacity with `reraise=True` (callers still see the original exception) and per-retry warning logs via `before_sleep_log`. Wait curve maps 1:1 (`wait_exponential(multiplier=delay, exp_base=backoff, max=max_delay)` = `delay * backoff**n` capped, plus `wait_random` jitter).
- **18 call sites** migrated from bare `@retry(...)` decorators to `@retry_builder(...)`, preserving each site's explicit parameters.
- **`backend/Dockerfile`**: dropped the now-obsolete `pip uninstall -y py` workaround and its CVE comment.
- **`backend/requirements/*.txt`**: regenerated lock exports (no `retry`/`py`/`types-retry`).

### Retry-policy preservation notes (for reviewers)

- `request_with_retries` (model-server calls) keeps its **exact** old wait curve: `jitter=0, max_delay=None` passed explicitly.
- `gpu_utils.py` and `tests/regression/.../api_utils.py` had sites relying on the legacy implicit `backoff=1` (constant delay) — now passed explicitly so they stay constant instead of inheriting `retry_builder`'s exponential default.
- `onyxbot/slack/utils.py` dropped its `logger=` kwarg; `retry_builder` logs each retry through its own module logger.
- Known minor semantic shifts (accepted): jitter is now uniform-random per wait rather than the legacy cumulative add, and call sites migrated to `retry_builder` defaults inherit its 60s wait cap (only observable on `vespa/deletion.py`'s `tries=10` site, where worst-case total wait drops ~511s → ~243s).
- One zendesk unit test asserted the legacy exact first-wait timing (`call(0.1)`); updated to assert the jittered range `[0.1, 1.1)`.

## Test plan

- [x] New unit tests `backend/tests/unit/onyx/utils/test_retry_wrapper.py`: success after transient failures (exact call count), original exception re-raised (not `RetryError`), no retry on unlisted exception types.
- [x] `pytest backend/tests/unit` — 4918 passed; the single failure (`test_confluence_checkpointing.py::test_retrieve_all_slim_docs_perm_sync`) is a pre-existing order-dependent flake, reproduced identically on a clean tree with the old dependencies.
- [x] `uv run ty check` and `uv run ruff check backend` clean.
- [x] `uv.lock` / requirements exports verified free of `retry`, `py`, `types-retry`; `tenacity==9.1.2` present.
- [x] AST-scanned all 38 migrated decorated functions: none are generators or async (tenacity handles those differently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced `retry` with `tenacity` to remove the transitive `py` package and drop CVE-2022-42969 from all images, while keeping retry behavior consistent. Also set `backoff=1` and `jitter=0` where constant delays were expected.

- **Refactors**
  - Rebuilt `retry_builder` and `request_with_retries` on `tenacity` with the same signatures and `reraise=True`, preserving wait curves (constant-delay sites use `backoff=1, jitter=0`; model-server keeps `jitter=0`, uncapped; defaults keep uniform jitter and a 60s cap).
  - Added per-retry warnings via `before_sleep_log` and documented the intentional `functools.wraps` placement so logs show real call sites; mapped legacy `tries=-1` to retry-forever; migrated all `@retry(...)` uses to `@retry_builder(...)` and simplified Slack utils by dropping the `logger=` kwarg.
  - Added focused unit tests for the wrapper and updated a Zendesk test to assert a jittered range.

- **Dependencies**
  - Removed `retry`, `types-retry`, and transitive `py` from all locks; deleted the Dockerfile `py` uninstall workaround.
  - Added a direct pin to `tenacity==9.1.2`; regenerated `requirements/*.txt` and `uv.lock`.

<sup>Written for commit a7cac0e25f166d1ea3643a5df958bdf6328216a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12000?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

