### PR TITLE
chore: update go toolchain to 1.26.4

### DIFF
--- a/.github/workflows/pr-golang-tests.yml
+++ b/.github/workflows/pr-golang-tests.yml
@@ -17,7 +17,7 @@ permissions:
   contents: read # needed to checkout the repo on private repos (no-op on public)
 
 env:
-  GO_VERSION: "1.26"
+  GO_VERSION: "1.26.4"
 
 jobs:
   detect-modules:

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -358,7 +358,7 @@ jobs:
         if: contains(matrix.test-dir.path, 'tests/cli')
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # zizmor: ignore[cache-poisoning]
         with:
-          go-version: "1.26"
+          go-version: "1.26.4"
           cache-dependency-path: "cli/go.sum"
 
       - name: Compile CLI binary

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -137,7 +137,7 @@ repos:
     rev: 5d1e709b7be35cb2025444e19de266b056b7b7ee # frozen: v2.10.1
     hooks:
       - id: golangci-lint
-        language_version: "1.26.1"
+        language_version: "1.26.4"
         entry: bash -c "find . -name go.mod -not -path './.venv/*' -print0 | xargs -0 -I{} bash -c 'cd \"$(dirname {})\" && golangci-lint run ./...'"
 
   - repo: https://github.com/sirwart/ripsecrets

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -2,7 +2,7 @@
 # pull-through cache (<account>.dkr.ecr.us-east-2.amazonaws.com/docker-hub) to avoid Docker
 # Hub rate limits.
 ARG BASE_IMAGE_REGISTRY=docker.io
-FROM ${BASE_IMAGE_REGISTRY}/library/golang:1.26-alpine@sha256:2389ebfa5b7f43eeafbd6be0c3700cc46690ef842ad962f6c5bd6be49ed82039 AS builder
+FROM ${BASE_IMAGE_REGISTRY}/library/golang:1.26.4-alpine@sha256:7a3e50096189ad57c9f9f865e7e4aa8585ed1585248513dc5cda498e2f41812c AS builder
 
 WORKDIR /app
 COPY ./ .

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,6 +1,6 @@
 module github.com/onyx-dot-app/onyx/cli
 
-go 1.26.1
+go 1.26.4
 
 require (
 	github.com/charmbracelet/bubbles v1.0.0

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling==1.29.0", "go-bin~=1.26.1", "manygo==0.2.0"]
+requires = ["hatchling==1.29.0", "go-bin~=1.26.4", "manygo==0.2.0"]
 build-backend = "hatchling.build"
 
 [project]

--- a/tools/ods/go.mod
+++ b/tools/ods/go.mod
@@ -1,6 +1,6 @@
 module github.com/onyx-dot-app/onyx/tools/ods
 
-go 1.26.1
+go 1.26.4
 
 require (
 	github.com/gdamore/tcell/v2 v2.13.8

--- a/tools/ods/pyproject.toml
+++ b/tools/ods/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling==1.29.0", "go-bin~=1.26.1", "manygo==0.2.0"]
+requires = ["hatchling==1.29.0", "go-bin~=1.26.4", "manygo==0.2.0"]
 build-backend = "hatchling.build"
 
 [project]


### PR DESCRIPTION
## Description

Bumps the repo Go toolchain pins to Go 1.26.4 across local development, CI, and Python package release builds.

This specifically addresses Trivy Go `stdlib` findings from binaries built with Go 1.26.3:

- `CVE-2026-42504` (`high`)
- `CVE-2026-27145` (`medium`)
- `CVE-2026-42507` (`medium`)

Trivy reports these as fixed by Go `1.25.11` or `1.26.4`; this PR keeps the repo on the 1.26 line and moves to the patched `1.26.4` release.

This updates both Go modules (`cli` and `tools/ods`), the `go-bin` build dependencies used for packaged releases, the `golangci-lint` pre-commit runtime, and the GitHub Actions `setup-go` versions.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the Go toolchain to 1.26.4 across the repo to align local dev, CI, Docker, and release builds. Ensures consistent builds and pulls in the latest 1.26 patch fixes.

- **Dependencies**
  - Set `go` to 1.26.4 in `cli/go.mod` and `tools/ods/go.mod`.
  - Bumped `go-bin` to `~1.26.4` in `cli/pyproject.toml` and `tools/ods/pyproject.toml`.
  - CI: use Go 1.26.4 in `pr-golang-tests` and `pr-integration-tests` via `actions/setup-go`.
  - Pre-commit: `golangci-lint` `language_version` set to 1.26.4.
  - CLI Docker builder now uses `golang:1.26.4-alpine`.

<sup>Written for commit 611e3fa69d2f79bab10ce6e11d8e4f885b4e2586. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12001?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

