### PR TITLE
feat(craft): prune session snapshots on write (keep only the latest)

### DIFF
--- a/backend/onyx/background/celery/tasks/beat_schedule.py
+++ b/backend/onyx/background/celery/tasks/beat_schedule.py
@@ -196,16 +196,6 @@ beat_task_templates: list[dict] = [
             "work_gated": True,
         },
     },
-    {
-        "name": "cleanup-old-snapshots",
-        "task": OnyxCeleryTask.CLEANUP_OLD_SNAPSHOTS,
-        "schedule": timedelta(hours=24),
-        "options": {
-            "priority": OnyxCeleryPriority.LOW,
-            "expires": BEAT_EXPIRES_DEFAULT,
-            "queue": OnyxCeleryQueues.SANDBOX,
-        },
-    },
 ]
 
 # Mirror set_is_ee_based_on_env_variable(): EE features are active when either

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -512,7 +512,6 @@ class OnyxRedisLocks:
 
     # Sandbox cleanup
     CLEANUP_IDLE_SANDBOXES_BEAT_LOCK = "da_lock:cleanup_idle_sandboxes_beat"
-    CLEANUP_OLD_SNAPSHOTS_BEAT_LOCK = "da_lock:cleanup_old_snapshots_beat"
 
 
 class OnyxRedisSignals:
@@ -641,7 +640,6 @@ class OnyxCeleryTask:
 
     # Sandbox cleanup
     CLEANUP_IDLE_SANDBOXES = "cleanup_idle_sandboxes"
-    CLEANUP_OLD_SNAPSHOTS = "cleanup_old_snapshots"
 
     # Scheduled tasks (Craft)
     SCHEDULED_TASKS_DISPATCH_DUE = "scheduled_tasks_dispatch_due"

--- a/backend/onyx/server/features/build/db/sandbox.py
+++ b/backend/onyx/server/features/build/db/sandbox.py
@@ -245,37 +245,6 @@ def get_snapshots_for_session(db_session: Session, session_id: UUID) -> list[Sna
     return list(db_session.execute(stmt).scalars().all())
 
 
-def delete_old_snapshots(
-    db_session: Session,
-    tenant_id: str,  # noqa: ARG001
-    retention_days: int,
-) -> int:
-    """Delete snapshots older than retention period, return count deleted.
-
-    Note: tenant_id parameter is kept for API compatibility but is not used
-    since Snapshot model no longer has tenant_id. This function deletes
-    all snapshots older than the retention period.
-    """
-    cutoff_time = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
-        days=retention_days
-    )
-
-    stmt = select(Snapshot).where(
-        Snapshot.created_at < cutoff_time,
-    )
-    old_snapshots = db_session.execute(stmt).scalars().all()
-
-    count = 0
-    for snapshot in old_snapshots:
-        db_session.delete(snapshot)
-        count += 1
-
-    if count > 0:
-        db_session.commit()
-
-    return count
-
-
 def delete_snapshot(db_session: Session, snapshot_id: UUID) -> bool:
     """Delete a specific snapshot by ID. Returns True if deleted, False if not found."""
     stmt = select(Snapshot).where(Snapshot.id == snapshot_id)

--- a/backend/onyx/server/features/build/sandbox/manager/snapshot_manager.py
+++ b/backend/onyx/server/features/build/sandbox/manager/snapshot_manager.py
@@ -241,19 +241,23 @@ class SnapshotManager:
                 pass
 
     def delete_snapshot(self, storage_path: str) -> None:
-        """Delete snapshot from file store.
+        """Delete a snapshot's blob from the file store.
+
+        Idempotent: a missing blob is treated as already-deleted (not an error),
+        so a caller retrying after a partial failure can still drop its DB row
+        without the blob and row leaking out of sync.
 
         Args:
             storage_path: The file store path of the snapshot to delete
 
         Raises:
-            RuntimeError: If deletion fails (other than file not found)
+            RuntimeError: If deletion fails for a reason other than the blob
+                already being gone.
         """
         try:
-            self._file_store.delete_file(storage_path)
+            self._file_store.delete_file(storage_path, error_on_missing=False)
             logger.info("Deleted snapshot: %s", storage_path)
         except Exception as e:
-            # Log but don't fail if snapshot doesn't exist
             logger.warning("Failed to delete snapshot %s: %s", storage_path, e)
             raise RuntimeError(f"Failed to delete snapshot: {e}") from e
 

--- a/backend/onyx/server/features/build/sandbox/tasks/tasks.py
+++ b/backend/onyx/server/features/build/sandbox/tasks/tasks.py
@@ -1,7 +1,5 @@
 """Celery tasks for sandbox operations (cleanup, etc.)."""
 
-from typing import TYPE_CHECKING
-
 from celery import shared_task
 from celery import Task
 from redis.lock import Lock as RedisLock
@@ -11,6 +9,7 @@ from onyx.background.celery.apps.app_base import task_logger
 from onyx.configs.constants import OnyxCeleryTask
 from onyx.configs.constants import OnyxRedisLocks
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.models import Snapshot
 from onyx.redis.redis_pool import get_redis_client
 from onyx.redis.redis_tenant_work_gating import maybe_mark_tenant_active
 from onyx.server.features.build.configs import SANDBOX_IDLE_TIMEOUT_SECONDS
@@ -19,12 +18,7 @@ from onyx.server.features.build.db.build_session import (
     mark_user_sessions_idle__no_commit,
 )
 from onyx.server.features.build.sandbox.base import get_sandbox_manager
-
-if TYPE_CHECKING:
-    from onyx.db.models import Snapshot
-    from onyx.server.features.build.sandbox.manager.snapshot_manager import (
-        SnapshotManager,
-    )
+from onyx.server.features.build.sandbox.manager.snapshot_manager import SnapshotManager
 
 # 100 minutes - snapshotting can take time
 TIMEOUT_SECONDS = 6000
@@ -32,8 +26,8 @@ TIMEOUT_SECONDS = 6000
 
 def _prune_prior_session_snapshots(
     db_session: Session,
-    snapshot_manager: "SnapshotManager",
-    prior_snapshots: list["Snapshot"],
+    snapshot_manager: SnapshotManager,
+    prior_snapshots: list[Snapshot],
 ) -> None:
     """Delete a session's now-superseded snapshots (blob then row).
 
@@ -94,9 +88,6 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
         from onyx.server.features.build.db.sandbox import get_snapshots_for_session
         from onyx.server.features.build.db.sandbox import (
             update_sandbox_status__no_commit,
-        )
-        from onyx.server.features.build.sandbox.manager.snapshot_manager import (
-            SnapshotManager,
         )
 
         sandbox_manager = get_sandbox_manager()

--- a/backend/onyx/server/features/build/sandbox/tasks/tasks.py
+++ b/backend/onyx/server/features/build/sandbox/tasks/tasks.py
@@ -1,8 +1,11 @@
 """Celery tasks for sandbox operations (cleanup, etc.)."""
 
+from typing import TYPE_CHECKING
+
 from celery import shared_task
 from celery import Task
 from redis.lock import Lock as RedisLock
+from sqlalchemy.orm import Session
 
 from onyx.background.celery.apps.app_base import task_logger
 from onyx.configs.constants import OnyxCeleryTask
@@ -17,11 +20,37 @@ from onyx.server.features.build.db.build_session import (
 )
 from onyx.server.features.build.sandbox.base import get_sandbox_manager
 
-# Snapshot retention period in days
-SNAPSHOT_RETENTION_DAYS = 30
+if TYPE_CHECKING:
+    from onyx.db.models import Snapshot
+    from onyx.server.features.build.sandbox.manager.snapshot_manager import (
+        SnapshotManager,
+    )
 
 # 100 minutes - snapshotting can take time
 TIMEOUT_SECONDS = 6000
+
+
+def _prune_prior_session_snapshots(
+    db_session: Session,
+    snapshot_manager: "SnapshotManager",
+    prior_snapshots: list["Snapshot"],
+) -> None:
+    """Delete a session's now-superseded snapshots (blob then row).
+
+    We keep only the latest snapshot per session; once a fresh one is written,
+    the prior ones are pruned. Blob deletes are idempotent and best-effort: a
+    failed delete leaves that row in place to be retried on the session's next
+    reap, so a blob and its row never leak out of sync.
+    """
+    for old in prior_snapshots:
+        try:
+            snapshot_manager.delete_snapshot(old.storage_path)
+        except Exception as e:
+            task_logger.warning(
+                f"Skipping prune of snapshot {old.id}; blob delete failed: {e}"
+            )
+            continue
+        db_session.delete(old)
 
 
 @shared_task(
@@ -59,13 +88,19 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
     try:
         # Import here to avoid circular imports
         from onyx.db.enums import SandboxStatus
+        from onyx.file_store.file_store import get_default_file_store
         from onyx.server.features.build.db.sandbox import create_snapshot__no_commit
         from onyx.server.features.build.db.sandbox import get_idle_sandboxes
+        from onyx.server.features.build.db.sandbox import get_snapshots_for_session
         from onyx.server.features.build.db.sandbox import (
             update_sandbox_status__no_commit,
         )
+        from onyx.server.features.build.sandbox.manager.snapshot_manager import (
+            SnapshotManager,
+        )
 
         sandbox_manager = get_sandbox_manager()
+        snapshot_manager = SnapshotManager(get_default_file_store())
 
         with get_session_with_current_tenant() as db_session:
             idle_sandboxes = get_idle_sandboxes(
@@ -124,16 +159,23 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
                             task_logger.debug(
                                 f"Creating snapshot for session {session_id}"
                             )
+                            # Capture priors before the new snapshot so we can
+                            # prune them once the fresh one lands (keep-latest).
+                            prior_snapshots = get_snapshots_for_session(
+                                db_session, session_id
+                            )
                             snapshot_result = sandbox_manager.create_snapshot(
                                 sandbox_id, session_id, tenant_id
                             )
                             if snapshot_result:
-                                # Create DB record for the snapshot
                                 create_snapshot__no_commit(
                                     db_session,
                                     session_id,
                                     snapshot_result.storage_path,
                                     snapshot_result.size_bytes,
+                                )
+                                _prune_prior_session_snapshots(
+                                    db_session, snapshot_manager, prior_snapshots
                                 )
                                 task_logger.debug(
                                     f"Snapshot created for session {session_id}"

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_prune_prior_snapshots.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_prune_prior_snapshots.py
@@ -1,0 +1,53 @@
+"""Unit tests for prune-on-write: deleting a session's superseded snapshots."""
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from onyx.db.models import Snapshot
+from onyx.server.features.build.sandbox.tasks.tasks import (
+    _prune_prior_session_snapshots,
+)
+
+
+def _snap() -> Snapshot:
+    sid = uuid4()
+    return Snapshot(
+        id=sid, session_id=uuid4(), storage_path=f"snap/{sid}.tar.gz", size_bytes=1
+    )
+
+
+def test_prunes_blob_then_row_for_each_prior() -> None:
+    db_session = MagicMock()
+    snapshot_manager = MagicMock()
+    priors = [_snap(), _snap(), _snap()]
+
+    _prune_prior_session_snapshots(db_session, snapshot_manager, priors)
+
+    assert snapshot_manager.delete_snapshot.call_count == 3
+    snapshot_manager.delete_snapshot.assert_any_call(priors[0].storage_path)
+    deleted_rows = [c.args[0] for c in db_session.delete.call_args_list]
+    assert deleted_rows == priors
+
+
+def test_empty_priors_is_a_noop() -> None:
+    db_session = MagicMock()
+    snapshot_manager = MagicMock()
+
+    _prune_prior_session_snapshots(db_session, snapshot_manager, [])
+
+    snapshot_manager.delete_snapshot.assert_not_called()
+    db_session.delete.assert_not_called()
+
+
+def test_blob_delete_failure_keeps_that_row_but_continues() -> None:
+    db_session = MagicMock()
+    snapshot_manager = MagicMock()
+    priors = [_snap(), _snap(), _snap()]
+    # Second blob delete fails; its row must be kept, the rest still pruned.
+    snapshot_manager.delete_snapshot.side_effect = [None, RuntimeError("s3 down"), None]
+
+    _prune_prior_session_snapshots(db_session, snapshot_manager, priors)
+
+    deleted_rows = [c.args[0] for c in db_session.delete.call_args_list]
+    assert deleted_rows == [priors[0], priors[2]]
+    assert priors[1] not in deleted_rows

--- a/docs/craft/infra/snapshot-retention.md
+++ b/docs/craft/infra/snapshot-retention.md
@@ -1,0 +1,41 @@
+# Snapshot Retention
+
+## What a snapshot is
+
+When a Craft sandbox goes idle, the cleanup task snapshots each session's
+workspace (`outputs/`, `attachments/`, `.opencode-data/`) into a `tar.gz` and
+persists it through the Onyx FileStore, then terminates the pod. On wake, the
+latest snapshot is restored. Snapshots are internal sleep/wake plumbing — they
+are not a user-facing version history.
+
+## Retention policy: keep exactly one per session (prune-on-write)
+
+We keep exactly **one snapshot per session — the most recent**. Every snapshot
+is superseded by the next one taken for that session, so there is no value in
+retaining older ones.
+
+Rather than letting snapshots accumulate and sweeping them with a periodic job,
+we **prune on write**: in `cleanup_idle_sandboxes_task`, immediately after a
+session's new snapshot is written, `_prune_prior_session_snapshots` deletes that
+session's prior snapshots (the ones captured *before* the new one was created).
+The new snapshot is fully durable before any old one is removed, so a session is
+never left without a restorable snapshot, and storage never accumulates.
+
+This also self-heals: each session's reap prunes *all* of its prior snapshots,
+so any backlog (e.g. rows left by a past partial failure) is cleared on that
+session's next reap.
+
+### Deletion is blob-then-row, idempotent, best-effort
+
+For each superseded snapshot we delete the file-store blob first, then the
+`snapshot` DB row. `SnapshotManager.delete_snapshot` is **idempotent** — a
+missing blob counts as already-deleted (`delete_file(error_on_missing=False)`),
+so a row whose blob was already removed in a prior partial run still gets its
+row dropped. A genuine delete failure (e.g. S3 unreachable) leaves that row in
+place to be retried on the session's next reap, so a blob and its row never leak
+out of sync.
+
+### Rollout
+
+No periodic task, no beat entry, no config knobs, no DB migration. Restart
+Celery workers to pick up the new reap behavior.


### PR DESCRIPTION
## Description

Snapshot storage grew unbounded, for two reasons:

- Snapshot creation minted a **fresh path + new DB row every idle reap** (it never replaced the prior one), so each session accumulated a snapshot per sleep cycle.
- The `cleanup_old_snapshots` task that the Celery beat schedule referenced was **never actually defined**, so it silently no-op'd. The `delete_old_snapshots` helper also only deleted DB rows, never the file-store blobs — so even a working task would have leaked storage.

This PR makes the policy **exactly one snapshot per session** and enforces it at the source via **prune-on-write** (rather than a periodic sweeper):

- After a session's new snapshot is persisted in `cleanup_idle_sandboxes_task`, `_prune_prior_session_snapshots` deletes that session's prior snapshots (blob then row). The new snapshot is fully durable *before* any old one is removed, so a session is never left without a restorable snapshot, and storage never accumulates.
- Each reap prunes **all** of a session's priors, so any backlog (e.g. rows left by a past partial failure, or the pre-existing accumulation) self-heals on that session's next reap.
- `SnapshotManager.delete_snapshot` is now **idempotent** (`delete_file(error_on_missing=False)`): a row whose blob is already gone still gets dropped; a genuine delete failure (e.g. S3 unreachable) leaves the row in place to retry next reap, so a blob and its row never leak out of sync.
- **Removes** the never-defined `cleanup_old_snapshots` task, its beat-schedule entry, and the now-unused `CLEANUP_OLD_SNAPSHOTS` / `CLEANUP_OLD_SNAPSHOTS_BEAT_LOCK` constants.

No DB migration, no config knobs (keep-latest is a hard rule), no periodic task. Restart Celery workers to pick up the new reap behavior.

Docs: `docs/craft/infra/snapshot-retention.md`.

## How Has This Been Tested?

- **Unit test** (`test_prune_prior_snapshots.py`): verifies blob-then-row deletion per prior snapshot, that an empty prior list is a no-op, and that a failed blob delete keeps that row while still pruning the rest.
- Verified `ty` + `ruff` clean; the idle task imports, `cleanup_old_snapshots_task` is gone, `beat_schedule` imports cleanly.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
