### PR TITLE
fix(security): harden default MinIO/S3 object-storage credentials

### DIFF
--- a/.github/workflows/pr-helm-chart-testing.yml
+++ b/.github/workflows/pr-helm-chart-testing.yml
@@ -130,8 +130,7 @@ jobs:
           echo "=== Validating chart dependencies ==="
           cd deployment/helm/charts/onyx
           helm dependency update
-          # objectstorage ships no defaults (fail closed in values.yaml), so lint
-          # must supply placeholder credentials the same way userauth does.
+          # objectstorage ships no defaults (fail closed), so lint must set placeholders.
           helm lint . \
             --set auth.userauth.values.user_auth_secret=placeholder \
             --set auth.objectstorage.values.s3_aws_access_key_id=placeholder \

--- a/.github/workflows/pr-helm-chart-testing.yml
+++ b/.github/workflows/pr-helm-chart-testing.yml
@@ -130,7 +130,14 @@ jobs:
           echo "=== Validating chart dependencies ==="
           cd deployment/helm/charts/onyx
           helm dependency update
-          helm lint . --set auth.userauth.values.user_auth_secret=placeholder
+          # objectstorage ships no defaults (fail closed in values.yaml), so lint
+          # must supply placeholder credentials the same way userauth does.
+          helm lint . \
+            --set auth.userauth.values.user_auth_secret=placeholder \
+            --set auth.objectstorage.values.s3_aws_access_key_id=placeholder \
+            --set auth.objectstorage.values.s3_aws_secret_access_key=placeholder \
+            --set auth.objectstorage.values.rootUser=placeholder \
+            --set auth.objectstorage.values.rootPassword=placeholder
 
       - name: Run chart-testing (install) with enhanced monitoring
         timeout-minutes: 25

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -1454,6 +1454,35 @@ S3_VERIFY_SSL = os.environ.get("S3_VERIFY_SSL", "").lower() == "true"
 S3_AWS_ACCESS_KEY_ID = os.environ.get("S3_AWS_ACCESS_KEY_ID")
 S3_AWS_SECRET_ACCESS_KEY = os.environ.get("S3_AWS_SECRET_ACCESS_KEY")
 
+# Well-known MinIO default credential. A deployment left on this value lets anyone
+# who can reach the object-storage endpoint list, download, or modify stored files.
+DEFAULT_OBJECT_STORAGE_CREDENTIAL = "minioadmin"
+
+
+def _uses_default_object_storage_credentials(
+    s3_endpoint_url: str | None,
+    access_key: str | None,
+    secret_key: str | None,
+) -> bool:
+    # Only relevant for self-hosted S3-compatible storage (MinIO), which is
+    # signalled by an explicit endpoint URL. Real AWS S3 has no endpoint URL and
+    # never uses the minioadmin default, so it can't trip this check.
+    if not s3_endpoint_url:
+        return False
+    return DEFAULT_OBJECT_STORAGE_CREDENTIAL in (access_key, secret_key)
+
+
+if _uses_default_object_storage_credentials(
+    S3_ENDPOINT_URL, S3_AWS_ACCESS_KEY_ID, S3_AWS_SECRET_ACCESS_KEY
+):
+    logger.warning(
+        "Object storage is using the well-known default 'minioadmin' credentials. "
+        "Anyone who can reach the MinIO/S3 endpoint can read or modify stored files "
+        "(uploaded documents, file-store objects). Set S3_AWS_ACCESS_KEY_ID / "
+        "S3_AWS_SECRET_ACCESS_KEY (and MINIO_ROOT_USER / MINIO_ROOT_PASSWORD) to "
+        "strong, unique values before deploying to production."
+    )
+
 # Should we force S3 local checksumming
 S3_GENERATE_LOCAL_CHECKSUM = (
     os.environ.get("S3_GENERATE_LOCAL_CHECKSUM", "").lower() == "true"

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -1454,8 +1454,7 @@ S3_VERIFY_SSL = os.environ.get("S3_VERIFY_SSL", "").lower() == "true"
 S3_AWS_ACCESS_KEY_ID = os.environ.get("S3_AWS_ACCESS_KEY_ID")
 S3_AWS_SECRET_ACCESS_KEY = os.environ.get("S3_AWS_SECRET_ACCESS_KEY")
 
-# Well-known MinIO default credential. A deployment left on this value lets anyone
-# who can reach the object-storage endpoint list, download, or modify stored files.
+# Well-known MinIO default; deployments left on it expose all stored files.
 DEFAULT_OBJECT_STORAGE_CREDENTIAL = "minioadmin"
 
 
@@ -1464,9 +1463,7 @@ def _uses_default_object_storage_credentials(
     access_key: str | None,
     secret_key: str | None,
 ) -> bool:
-    # Only relevant for self-hosted S3-compatible storage (MinIO), which is
-    # signalled by an explicit endpoint URL. Real AWS S3 has no endpoint URL and
-    # never uses the minioadmin default, so it can't trip this check.
+    # Only for self-hosted MinIO (has an endpoint URL); real AWS S3 has none.
     if not s3_endpoint_url:
         return False
     return DEFAULT_OBJECT_STORAGE_CREDENTIAL in (access_key, secret_key)

--- a/backend/scripts/restart_containers.sh
+++ b/backend/scripts/restart_containers.sh
@@ -94,6 +94,8 @@ else
 fi
 
 # Start the MinIO container with optional volume
+# TODO(security): publish on 127.0.0.1:9004 / 127.0.0.1:9005 so MinIO binds
+# loopback instead of 0.0.0.0 and isn't reachable from the LAN on a dev machine.
 echo "Starting MinIO container..."
 if [[ -n "$MINIO_VOLUME" ]]; then
     docker run --detach --name onyx_minio --publish 9004:9000 --publish 9005:9001 -e MINIO_ROOT_USER=minioadmin -e MINIO_ROOT_PASSWORD=minioadmin -v "$MINIO_VOLUME":/data minio/minio server /data --console-address ":9001"

--- a/backend/scripts/restart_containers.sh
+++ b/backend/scripts/restart_containers.sh
@@ -94,8 +94,7 @@ else
 fi
 
 # Start the MinIO container with optional volume
-# TODO(security): publish on 127.0.0.1:9004 / 127.0.0.1:9005 so MinIO binds
-# loopback instead of 0.0.0.0 and isn't reachable from the LAN on a dev machine.
+# TODO(security): publish on 127.0.0.1:9004/9005 to bind loopback, not 0.0.0.0.
 echo "Starting MinIO container..."
 if [[ -n "$MINIO_VOLUME" ]]; then
     docker run --detach --name onyx_minio --publish 9004:9000 --publish 9005:9001 -e MINIO_ROOT_USER=minioadmin -e MINIO_ROOT_PASSWORD=minioadmin -v "$MINIO_VOLUME":/data minio/minio server /data --console-address ":9001"

--- a/backend/tests/unit/onyx/configs/test_object_storage_credentials.py
+++ b/backend/tests/unit/onyx/configs/test_object_storage_credentials.py
@@ -1,0 +1,49 @@
+from onyx.configs.app_configs import _uses_default_object_storage_credentials
+
+
+def test_default_credentials_detected_against_minio() -> None:
+    # MinIO endpoint set + the well-known default => flagged.
+    assert (
+        _uses_default_object_storage_credentials(
+            "http://minio:9000", "minioadmin", "minioadmin"
+        )
+        is True
+    )
+
+
+def test_default_credentials_detected_when_either_value_is_default() -> None:
+    # A default in either the access key or the secret is enough to flag.
+    assert (
+        _uses_default_object_storage_credentials(
+            "http://minio:9000", "minioadmin", "a-strong-secret"
+        )
+        is True
+    )
+    assert (
+        _uses_default_object_storage_credentials(
+            "http://minio:9000", "a-strong-key", "minioadmin"
+        )
+        is True
+    )
+
+
+def test_strong_credentials_not_flagged() -> None:
+    assert (
+        _uses_default_object_storage_credentials(
+            "http://minio:9000", "a-strong-key", "a-strong-secret"
+        )
+        is False
+    )
+
+
+def test_no_endpoint_never_flagged() -> None:
+    # Real AWS S3 has no endpoint URL; the check must never fire without one,
+    # even if the (unrelated) credential values happened to match the default.
+    assert (
+        _uses_default_object_storage_credentials(None, "minioadmin", "minioadmin")
+        is False
+    )
+    assert (
+        _uses_default_object_storage_credentials("", "minioadmin", "minioadmin")
+        is False
+    )

--- a/deployment/docker_compose/docker-compose.dev.yml
+++ b/deployment/docker_compose/docker-compose.dev.yml
@@ -46,9 +46,7 @@ services:
 
   minio:
     # Use different ports to avoid conflicts with model servers.
-    # TODO(security): prefix with 127.0.0.1: so MinIO binds loopback instead of
-    # 0.0.0.0 and isn't reachable from the LAN on a dev machine (prod publishes
-    # no MinIO ports). Deferred to keep remote-host dev workflows working.
+    # TODO(security): prefix 127.0.0.1: to bind loopback, not 0.0.0.0 (LAN-exposed).
     ports:
       - "${MINIO_API_HOST_PORT:-9004}:9000"
       - "${MINIO_CONSOLE_HOST_PORT:-9005}:9001"

--- a/deployment/docker_compose/docker-compose.dev.yml
+++ b/deployment/docker_compose/docker-compose.dev.yml
@@ -46,6 +46,9 @@ services:
 
   minio:
     # Use different ports to avoid conflicts with model servers.
+    # TODO(security): prefix with 127.0.0.1: so MinIO binds loopback instead of
+    # 0.0.0.0 and isn't reachable from the LAN on a dev machine (prod publishes
+    # no MinIO ports). Deferred to keep remote-host dev workflows working.
     ports:
       - "${MINIO_API_HOST_PORT:-9004}:9000"
       - "${MINIO_CONSOLE_HOST_PORT:-9005}:9001"

--- a/deployment/docker_compose/docker-compose.multitenant-dev.yml
+++ b/deployment/docker_compose/docker-compose.multitenant-dev.yml
@@ -493,8 +493,7 @@ services:
   minio:
     image: ${BASE_IMAGE_REGISTRY:-docker.io}/minio/minio:RELEASE.2025-07-23T15-54-02Z-cpuv1
     restart: unless-stopped
-    # TODO(security): prefix with 127.0.0.1: so MinIO binds loopback instead of
-    # 0.0.0.0 and isn't reachable from the LAN (prod publishes no MinIO ports).
+    # TODO(security): prefix 127.0.0.1: to bind loopback, not 0.0.0.0 (LAN-exposed).
     ports:
       - "9004:9000"
       - "9005:9001"

--- a/deployment/docker_compose/docker-compose.multitenant-dev.yml
+++ b/deployment/docker_compose/docker-compose.multitenant-dev.yml
@@ -493,6 +493,8 @@ services:
   minio:
     image: ${BASE_IMAGE_REGISTRY:-docker.io}/minio/minio:RELEASE.2025-07-23T15-54-02Z-cpuv1
     restart: unless-stopped
+    # TODO(security): prefix with 127.0.0.1: so MinIO binds loopback instead of
+    # 0.0.0.0 and isn't reachable from the LAN (prod publishes no MinIO ports).
     ports:
       - "9004:9000"
       - "9005:9001"

--- a/deployment/docker_compose/docker-compose.prod-cloud.yml
+++ b/deployment/docker_compose/docker-compose.prod-cloud.yml
@@ -26,8 +26,8 @@ services:
       - MODEL_SERVER_HOST=${MODEL_SERVER_HOST:-inference_model_server}
       # MinIO configuration
       - S3_ENDPOINT_URL=${S3_ENDPOINT_URL:-http://minio:9000}
-      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:-minioadmin}
-      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:-minioadmin}
+      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:?must be set to a strong unique value in .env (not the default minioadmin)}
+      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:?must be set to a strong unique value in .env (not the default minioadmin)}
     env_file:
       - path: .env
         required: false
@@ -62,8 +62,8 @@ services:
       - INDEXING_MODEL_SERVER_HOST=${INDEXING_MODEL_SERVER_HOST:-indexing_model_server}
       # MinIO configuration
       - S3_ENDPOINT_URL=${S3_ENDPOINT_URL:-http://minio:9000}
-      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:-minioadmin}
-      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:-minioadmin}
+      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:?must be set to a strong unique value in .env (not the default minioadmin)}
+      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:?must be set to a strong unique value in .env (not the default minioadmin)}
       - DISCORD_BOT_TOKEN=${DISCORD_BOT_TOKEN:-}
       - DISCORD_BOT_INVOKE_CHAR=${DISCORD_BOT_INVOKE_CHAR:-!}
       # API Server connection for Discord bot message processing
@@ -304,8 +304,8 @@ services:
     image: minio/minio:RELEASE.2025-07-23T15-54-02Z-cpuv1
     restart: unless-stopped
     environment:
-      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
-      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:?must be set to a strong unique value in .env (not the default minioadmin)}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?must be set to a strong unique value in .env (not the default minioadmin)}
       MINIO_DEFAULT_BUCKETS: ${S3_FILE_STORE_BUCKET_NAME:-onyx-file-store-bucket}
     volumes:
       - minio_data:/data

--- a/deployment/docker_compose/docker-compose.prod-cloud.yml
+++ b/deployment/docker_compose/docker-compose.prod-cloud.yml
@@ -26,8 +26,8 @@ services:
       - MODEL_SERVER_HOST=${MODEL_SERVER_HOST:-inference_model_server}
       # MinIO configuration
       - S3_ENDPOINT_URL=${S3_ENDPOINT_URL:-http://minio:9000}
-      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:?must be set to a strong unique value in .env (not the default minioadmin)}
-      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:?must be set to a strong unique value in .env (not the default minioadmin)}
+      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:?set a strong value in .env, not minioadmin}
+      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:?set a strong value in .env, not minioadmin}
     env_file:
       - path: .env
         required: false
@@ -62,8 +62,8 @@ services:
       - INDEXING_MODEL_SERVER_HOST=${INDEXING_MODEL_SERVER_HOST:-indexing_model_server}
       # MinIO configuration
       - S3_ENDPOINT_URL=${S3_ENDPOINT_URL:-http://minio:9000}
-      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:?must be set to a strong unique value in .env (not the default minioadmin)}
-      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:?must be set to a strong unique value in .env (not the default minioadmin)}
+      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:?set a strong value in .env, not minioadmin}
+      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:?set a strong value in .env, not minioadmin}
       - DISCORD_BOT_TOKEN=${DISCORD_BOT_TOKEN:-}
       - DISCORD_BOT_INVOKE_CHAR=${DISCORD_BOT_INVOKE_CHAR:-!}
       # API Server connection for Discord bot message processing
@@ -304,8 +304,8 @@ services:
     image: minio/minio:RELEASE.2025-07-23T15-54-02Z-cpuv1
     restart: unless-stopped
     environment:
-      MINIO_ROOT_USER: ${MINIO_ROOT_USER:?must be set to a strong unique value in .env (not the default minioadmin)}
-      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?must be set to a strong unique value in .env (not the default minioadmin)}
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:?set a strong value in .env, not minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?set a strong value in .env, not minioadmin}
       MINIO_DEFAULT_BUCKETS: ${S3_FILE_STORE_BUCKET_NAME:-onyx-file-store-bucket}
     volumes:
       - minio_data:/data

--- a/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
+++ b/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
@@ -31,8 +31,8 @@ services:
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY-}
       # MinIO configuration
       - S3_ENDPOINT_URL=${S3_ENDPOINT_URL:-http://minio:9000}
-      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:?must be set to a strong unique value in .env (not the default minioadmin)}
-      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:?must be set to a strong unique value in .env (not the default minioadmin)}
+      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:?set a strong value in .env, not minioadmin}
+      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:?set a strong value in .env, not minioadmin}
     env_file:
       - path: .env
         required: false
@@ -79,8 +79,8 @@ services:
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY-}
       # MinIO configuration
       - S3_ENDPOINT_URL=${S3_ENDPOINT_URL:-http://minio:9000}
-      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:?must be set to a strong unique value in .env (not the default minioadmin)}
-      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:?must be set to a strong unique value in .env (not the default minioadmin)}
+      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:?set a strong value in .env, not minioadmin}
+      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:?set a strong value in .env, not minioadmin}
     env_file:
       - path: .env
         required: false
@@ -311,8 +311,8 @@ services:
     image: minio/minio:RELEASE.2025-07-23T15-54-02Z-cpuv1
     restart: unless-stopped
     environment:
-      MINIO_ROOT_USER: ${MINIO_ROOT_USER:?must be set to a strong unique value in .env (not the default minioadmin)}
-      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?must be set to a strong unique value in .env (not the default minioadmin)}
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:?set a strong value in .env, not minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?set a strong value in .env, not minioadmin}
       MINIO_DEFAULT_BUCKETS: ${S3_FILE_STORE_BUCKET_NAME:-onyx-file-store-bucket}
     volumes:
       - minio_data:/data

--- a/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
+++ b/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
@@ -31,8 +31,8 @@ services:
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY-}
       # MinIO configuration
       - S3_ENDPOINT_URL=${S3_ENDPOINT_URL:-http://minio:9000}
-      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:-minioadmin}
-      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:-minioadmin}
+      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:?must be set to a strong unique value in .env (not the default minioadmin)}
+      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:?must be set to a strong unique value in .env (not the default minioadmin)}
     env_file:
       - path: .env
         required: false
@@ -79,8 +79,8 @@ services:
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY-}
       # MinIO configuration
       - S3_ENDPOINT_URL=${S3_ENDPOINT_URL:-http://minio:9000}
-      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:-minioadmin}
-      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:-minioadmin}
+      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:?must be set to a strong unique value in .env (not the default minioadmin)}
+      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:?must be set to a strong unique value in .env (not the default minioadmin)}
     env_file:
       - path: .env
         required: false
@@ -311,8 +311,8 @@ services:
     image: minio/minio:RELEASE.2025-07-23T15-54-02Z-cpuv1
     restart: unless-stopped
     environment:
-      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
-      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:?must be set to a strong unique value in .env (not the default minioadmin)}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?must be set to a strong unique value in .env (not the default minioadmin)}
       MINIO_DEFAULT_BUCKETS: ${S3_FILE_STORE_BUCKET_NAME:-onyx-file-store-bucket}
     volumes:
       - minio_data:/data

--- a/deployment/docker_compose/docker-compose.prod.yml
+++ b/deployment/docker_compose/docker-compose.prod.yml
@@ -32,8 +32,8 @@ services:
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY-}
       # MinIO configuration
       - S3_ENDPOINT_URL=${S3_ENDPOINT_URL:-http://minio:9000}
-      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:?must be set to a strong unique value in .env (not the default minioadmin)}
-      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:?must be set to a strong unique value in .env (not the default minioadmin)}
+      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:?set a strong value in .env, not minioadmin}
+      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:?set a strong value in .env, not minioadmin}
     env_file:
       - path: .env
         required: false
@@ -84,8 +84,8 @@ services:
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY-}
       # MinIO configuration
       - S3_ENDPOINT_URL=${S3_ENDPOINT_URL:-http://minio:9000}
-      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:?must be set to a strong unique value in .env (not the default minioadmin)}
-      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:?must be set to a strong unique value in .env (not the default minioadmin)}
+      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:?set a strong value in .env, not minioadmin}
+      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:?set a strong value in .env, not minioadmin}
       - DISCORD_BOT_TOKEN=${DISCORD_BOT_TOKEN:-}
       - DISCORD_BOT_INVOKE_CHAR=${DISCORD_BOT_INVOKE_CHAR:-!}
       # API Server connection for Discord bot message processing
@@ -359,8 +359,8 @@ services:
     image: minio/minio:RELEASE.2025-07-23T15-54-02Z-cpuv1
     restart: unless-stopped
     environment:
-      MINIO_ROOT_USER: ${MINIO_ROOT_USER:?must be set to a strong unique value in .env (not the default minioadmin)}
-      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?must be set to a strong unique value in .env (not the default minioadmin)}
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:?set a strong value in .env, not minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?set a strong value in .env, not minioadmin}
       MINIO_DEFAULT_BUCKETS: ${S3_FILE_STORE_BUCKET_NAME:-onyx-file-store-bucket}
     volumes:
       - minio_data:/data

--- a/deployment/docker_compose/docker-compose.prod.yml
+++ b/deployment/docker_compose/docker-compose.prod.yml
@@ -32,8 +32,8 @@ services:
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY-}
       # MinIO configuration
       - S3_ENDPOINT_URL=${S3_ENDPOINT_URL:-http://minio:9000}
-      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:-minioadmin}
-      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:-minioadmin}
+      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:?must be set to a strong unique value in .env (not the default minioadmin)}
+      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:?must be set to a strong unique value in .env (not the default minioadmin)}
     env_file:
       - path: .env
         required: false
@@ -84,8 +84,8 @@ services:
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY-}
       # MinIO configuration
       - S3_ENDPOINT_URL=${S3_ENDPOINT_URL:-http://minio:9000}
-      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:-minioadmin}
-      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:-minioadmin}
+      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:?must be set to a strong unique value in .env (not the default minioadmin)}
+      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:?must be set to a strong unique value in .env (not the default minioadmin)}
       - DISCORD_BOT_TOKEN=${DISCORD_BOT_TOKEN:-}
       - DISCORD_BOT_INVOKE_CHAR=${DISCORD_BOT_INVOKE_CHAR:-!}
       # API Server connection for Discord bot message processing
@@ -359,8 +359,8 @@ services:
     image: minio/minio:RELEASE.2025-07-23T15-54-02Z-cpuv1
     restart: unless-stopped
     environment:
-      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
-      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:?must be set to a strong unique value in .env (not the default minioadmin)}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?must be set to a strong unique value in .env (not the default minioadmin)}
       MINIO_DEFAULT_BUCKETS: ${S3_FILE_STORE_BUCKET_NAME:-onyx-file-store-bucket}
     volumes:
       - minio_data:/data

--- a/deployment/docker_compose/docker-compose.search-testing.yml
+++ b/deployment/docker_compose/docker-compose.search-testing.yml
@@ -226,8 +226,7 @@ services:
   minio:
     image: minio/minio:RELEASE.2025-07-23T15-54-02Z-cpuv1
     restart: unless-stopped
-    # TODO(security): prefix with 127.0.0.1: so MinIO binds loopback instead of
-    # 0.0.0.0 and isn't reachable from the LAN (prod publishes no MinIO ports).
+    # TODO(security): prefix 127.0.0.1: to bind loopback, not 0.0.0.0 (LAN-exposed).
     ports:
       - "9004:9000"
       - "9005:9001"

--- a/deployment/docker_compose/docker-compose.search-testing.yml
+++ b/deployment/docker_compose/docker-compose.search-testing.yml
@@ -226,6 +226,8 @@ services:
   minio:
     image: minio/minio:RELEASE.2025-07-23T15-54-02Z-cpuv1
     restart: unless-stopped
+    # TODO(security): prefix with 127.0.0.1: so MinIO binds loopback instead of
+    # 0.0.0.0 and isn't reachable from the LAN (prod publishes no MinIO ports).
     ports:
       - "9004:9000"
       - "9005:9001"

--- a/deployment/docker_compose/docker-compose.yml
+++ b/deployment/docker_compose/docker-compose.yml
@@ -12,9 +12,7 @@
 # 1. SECURITY HARDENING:
 #    - Remove all port exposures except nginx (80/443)
 #    - Comment out ports for: api_server, relational_db, cache, minio
-#    - Rotate object-storage credentials away from the minioadmin default: set
-#      MINIO_ROOT_USER/MINIO_ROOT_PASSWORD and the matching
-#      S3_AWS_ACCESS_KEY_ID/S3_AWS_SECRET_ACCESS_KEY to strong, unique values
+#    - Set strong MinIO/S3 credentials (MINIO_ROOT_* + S3_AWS_*), not minioadmin
 #
 # 2. SSL/TLS SETUP:
 #    - Uncomment the certbot service (see below)

--- a/deployment/docker_compose/docker-compose.yml
+++ b/deployment/docker_compose/docker-compose.yml
@@ -12,6 +12,9 @@
 # 1. SECURITY HARDENING:
 #    - Remove all port exposures except nginx (80/443)
 #    - Comment out ports for: api_server, relational_db, cache, minio
+#    - Rotate object-storage credentials away from the minioadmin default: set
+#      MINIO_ROOT_USER/MINIO_ROOT_PASSWORD and the matching
+#      S3_AWS_ACCESS_KEY_ID/S3_AWS_SECRET_ACCESS_KEY to strong, unique values
 #
 # 2. SSL/TLS SETUP:
 #    - Uncomment the certbot service (see below)

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -125,6 +125,13 @@ COMPOSE_PROFILES=s3-filestore
 FILE_STORE_BACKEND=s3
 
 ## MinIO/S3 Configuration (only needed when FILE_STORE_BACKEND=s3)
+## SECURITY: the minioadmin values below are insecure local-dev placeholders.
+## install.sh auto-generates strong, unique credentials on a fresh install. If
+## you create .env by hand, you MUST change all four credential values before any
+## production or network-exposed deployment — anyone who can reach MinIO with the
+## default minioadmin:minioadmin can list, download, or modify stored files.
+## Keep the S3_AWS_* pair identical to the MINIO_ROOT_* pair: the app
+## authenticates to MinIO using its root credentials.
 S3_ENDPOINT_URL=http://minio:9000
 S3_AWS_ACCESS_KEY_ID=minioadmin
 S3_AWS_SECRET_ACCESS_KEY=minioadmin

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -125,13 +125,9 @@ COMPOSE_PROFILES=s3-filestore
 FILE_STORE_BACKEND=s3
 
 ## MinIO/S3 Configuration (only needed when FILE_STORE_BACKEND=s3)
-## SECURITY: the minioadmin values below are insecure local-dev placeholders.
-## install.sh auto-generates strong, unique credentials on a fresh install. If
-## you create .env by hand, you MUST change all four credential values before any
-## production or network-exposed deployment — anyone who can reach MinIO with the
-## default minioadmin:minioadmin can list, download, or modify stored files.
-## Keep the S3_AWS_* pair identical to the MINIO_ROOT_* pair: the app
-## authenticates to MinIO using its root credentials.
+## SECURITY: minioadmin is a local-dev default. install.sh randomizes it; if you
+## edit .env by hand, change all four values before production. Keep the S3_AWS_*
+## pair identical to MINIO_ROOT_* (the app uses MinIO's root creds).
 S3_ENDPOINT_URL=http://minio:9000
 S3_AWS_ACCESS_KEY_ID=minioadmin
 S3_AWS_SECRET_ACCESS_KEY=minioadmin

--- a/deployment/docker_compose/install.sh
+++ b/deployment/docker_compose/install.sh
@@ -1126,13 +1126,8 @@ else
     USER_AUTH_SECRET=$(openssl rand -hex 32)
     sed -i.bak "s/^USER_AUTH_SECRET=.*/USER_AUTH_SECRET=\"$USER_AUTH_SECRET\"/" "$ENV_FILE" 2>/dev/null || true
 
-    # Generate strong, unique object-storage (MinIO/S3) credentials so the
-    # deployment never runs on the well-known minioadmin:minioadmin default.
-    # The app authenticates to MinIO using its root credentials, so the same
-    # access-key/secret pair must be written to both the MinIO server vars
-    # (MINIO_ROOT_USER / MINIO_ROOT_PASSWORD) and the app vars
-    # (S3_AWS_ACCESS_KEY_ID / S3_AWS_SECRET_ACCESS_KEY). openssl hex output is
-    # safe to use directly in sed replacements (no special characters).
+    # Random MinIO/S3 credentials instead of the minioadmin default. The app uses
+    # MinIO's root creds, so the same pair goes to both the server and app vars.
     MINIO_ACCESS_KEY=$(openssl rand -hex 16)
     MINIO_SECRET_KEY=$(openssl rand -hex 32)
     sed -i.bak "s/^MINIO_ROOT_USER=.*/MINIO_ROOT_USER=$MINIO_ACCESS_KEY/" "$ENV_FILE" 2>/dev/null || true

--- a/deployment/docker_compose/install.sh
+++ b/deployment/docker_compose/install.sh
@@ -1105,11 +1105,14 @@ else
     sed -i.bak "s/^IMAGE_TAG=.*/IMAGE_TAG=$VERSION/" "$ENV_FILE"
     print_success "IMAGE_TAG set to $VERSION"
 
-    # In lite mode, clear COMPOSE_PROFILES so profiled services (MinIO, etc.)
-    # stay disabled — the template ships with s3-filestore enabled by default.
+    # In lite mode, MinIO never starts (COMPOSE_PROFILES cleared) and the
+    # onyx-lite overlay forces FILE_STORE_BACKEND=postgres at runtime; set it in
+    # .env too so the file isn't misleadingly left on s3 (the MinIO/S3 creds
+    # generated below are then unused, but stay ready if s3-filestore is enabled).
     if [[ "$LITE_MODE" = true ]]; then
         sed -i.bak 's/^COMPOSE_PROFILES=.*/COMPOSE_PROFILES=/' "$ENV_FILE" 2>/dev/null || true
-        print_success "Cleared COMPOSE_PROFILES for lite mode"
+        sed -i.bak 's/^FILE_STORE_BACKEND=.*/FILE_STORE_BACKEND=postgres/' "$ENV_FILE" 2>/dev/null || true
+        print_success "Cleared COMPOSE_PROFILES and set FILE_STORE_BACKEND=postgres for lite mode"
     fi
 
     # Configure basic authentication (default)

--- a/deployment/docker_compose/install.sh
+++ b/deployment/docker_compose/install.sh
@@ -1126,6 +1126,20 @@ else
     USER_AUTH_SECRET=$(openssl rand -hex 32)
     sed -i.bak "s/^USER_AUTH_SECRET=.*/USER_AUTH_SECRET=\"$USER_AUTH_SECRET\"/" "$ENV_FILE" 2>/dev/null || true
 
+    # Generate strong, unique object-storage (MinIO/S3) credentials so the
+    # deployment never runs on the well-known minioadmin:minioadmin default.
+    # The app authenticates to MinIO using its root credentials, so the same
+    # access-key/secret pair must be written to both the MinIO server vars
+    # (MINIO_ROOT_USER / MINIO_ROOT_PASSWORD) and the app vars
+    # (S3_AWS_ACCESS_KEY_ID / S3_AWS_SECRET_ACCESS_KEY). openssl hex output is
+    # safe to use directly in sed replacements (no special characters).
+    MINIO_ACCESS_KEY=$(openssl rand -hex 16)
+    MINIO_SECRET_KEY=$(openssl rand -hex 32)
+    sed -i.bak "s/^MINIO_ROOT_USER=.*/MINIO_ROOT_USER=$MINIO_ACCESS_KEY/" "$ENV_FILE" 2>/dev/null || true
+    sed -i.bak "s/^MINIO_ROOT_PASSWORD=.*/MINIO_ROOT_PASSWORD=$MINIO_SECRET_KEY/" "$ENV_FILE" 2>/dev/null || true
+    sed -i.bak "s/^S3_AWS_ACCESS_KEY_ID=.*/S3_AWS_ACCESS_KEY_ID=$MINIO_ACCESS_KEY/" "$ENV_FILE" 2>/dev/null || true
+    sed -i.bak "s/^S3_AWS_SECRET_ACCESS_KEY=.*/S3_AWS_SECRET_ACCESS_KEY=$MINIO_SECRET_KEY/" "$ENV_FILE" 2>/dev/null || true
+
     # Configure Craft based on --include-craft.
     # By default, env.template has Craft commented out (disabled).
     if [ "$INCLUDE_CRAFT" = true ]; then

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.5.26
+version: 0.5.27
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.5.27
+version: 0.6.0
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/ci/ct-values.yaml
+++ b/deployment/helm/charts/onyx/ci/ct-values.yaml
@@ -7,3 +7,10 @@ auth:
   userauth:
     values:
       user_auth_secret: "placeholder-for-ci-testing"
+  # values.yaml ships no objectstorage defaults (fail closed), so ct must supply them.
+  objectstorage:
+    values:
+      s3_aws_access_key_id: "placeholder"
+      s3_aws_secret_access_key: "placeholder"
+      rootUser: "placeholder"
+      rootPassword: "placeholder"

--- a/deployment/helm/charts/onyx/values-ci.yaml
+++ b/deployment/helm/charts/onyx/values-ci.yaml
@@ -39,10 +39,8 @@ auth:
     values:
       redis_password: "password"
   objectstorage:
-    # CI-only credentials. values.yaml ships no objectstorage defaults (fail
-    # closed), so all four keys must be provided explicitly here for ct/craft
-    # renders. Never ship minioadmin to a real cluster — use existingSecret /
-    # externalSecret there (see values.yaml).
+    # CI-only creds. values.yaml ships no defaults (fail closed), so all four keys
+    # must be set here. Never use minioadmin on a real cluster.
     values:
       s3_aws_access_key_id: "minioadmin"
       s3_aws_secret_access_key: "minioadmin"

--- a/deployment/helm/charts/onyx/values-ci.yaml
+++ b/deployment/helm/charts/onyx/values-ci.yaml
@@ -39,6 +39,8 @@ auth:
     values:
       redis_password: "password"
   objectstorage:
+    # CI-only insecure defaults. Production must override via existingSecret /
+    # externalSecret (see values.yaml) — never ship minioadmin to a real cluster.
     values:
       s3_aws_access_key_id: "minioadmin"
       s3_aws_secret_access_key: "minioadmin"

--- a/deployment/helm/charts/onyx/values-ci.yaml
+++ b/deployment/helm/charts/onyx/values-ci.yaml
@@ -39,11 +39,15 @@ auth:
     values:
       redis_password: "password"
   objectstorage:
-    # CI-only insecure defaults. Production must override via existingSecret /
-    # externalSecret (see values.yaml) — never ship minioadmin to a real cluster.
+    # CI-only credentials. values.yaml ships no objectstorage defaults (fail
+    # closed), so all four keys must be provided explicitly here for ct/craft
+    # renders. Never ship minioadmin to a real cluster — use existingSecret /
+    # externalSecret there (see values.yaml).
     values:
       s3_aws_access_key_id: "minioadmin"
       s3_aws_secret_access_key: "minioadmin"
+      rootUser: "minioadmin"
+      rootPassword: "minioadmin"
   opensearch:
     values:
       opensearch_admin_password: "ci-test-not-used"

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1270,18 +1270,19 @@ auth:
       S3_AWS_ACCESS_KEY_ID: s3_aws_access_key_id
       S3_AWS_SECRET_ACCESS_KEY: s3_aws_secret_access_key
     # -- Secrets values IF existingSecret is empty. Key here must match the value in secretKeys to be used. Values will be base64 encoded in the k8s cluster.
-    # SECURITY: the minioadmin values below are insecure defaults for local/dev
-    # clusters only. For production, override these or (preferred) set
-    # `existingSecret` / the `externalSecret` block above to source credentials
-    # from a real secret store — anyone who can reach MinIO with the default
-    # minioadmin:minioadmin can list, download, or modify stored files. Keep the
-    # s3_aws_* pair identical to rootUser/rootPassword (the app authenticates to
-    # MinIO using its root credentials).
+    # SECURITY: no defaults are shipped — leaving these empty makes helm
+    # install/upgrade fail closed (see templates/auth-secrets.yaml) so a real
+    # cluster can never run on the well-known minioadmin:minioadmin. Provide
+    # values here, or (preferred) set `existingSecret` / the `externalSecret`
+    # block above to source credentials from a real secret store. Generate with:
+    # `openssl rand -hex 16` (key) and `openssl rand -hex 32` (secret). Keep the
+    # s3_aws_* pair identical to rootUser/rootPassword — the app authenticates to
+    # MinIO using its root credentials.
     values:
-      s3_aws_access_key_id: "minioadmin"
-      s3_aws_secret_access_key: "minioadmin"
-      rootUser: "minioadmin"
-      rootPassword: "minioadmin"
+      s3_aws_access_key_id: ""
+      s3_aws_secret_access_key: ""
+      rootUser: ""
+      rootPassword: ""
   oauth:
     # -- Enable or disable this secret entirely. Will remove from env var configurations and remove any created secrets.
     enabled: false

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1270,14 +1270,9 @@ auth:
       S3_AWS_ACCESS_KEY_ID: s3_aws_access_key_id
       S3_AWS_SECRET_ACCESS_KEY: s3_aws_secret_access_key
     # -- Secrets values IF existingSecret is empty. Key here must match the value in secretKeys to be used. Values will be base64 encoded in the k8s cluster.
-    # SECURITY: no defaults are shipped — leaving these empty makes helm
-    # install/upgrade fail closed (see templates/auth-secrets.yaml) so a real
-    # cluster can never run on the well-known minioadmin:minioadmin. Provide
-    # values here, or (preferred) set `existingSecret` / the `externalSecret`
-    # block above to source credentials from a real secret store. Generate with:
-    # `openssl rand -hex 16` (key) and `openssl rand -hex 32` (secret). Keep the
-    # s3_aws_* pair identical to rootUser/rootPassword — the app authenticates to
-    # MinIO using its root credentials.
+    # SECURITY: no defaults shipped — empty values fail closed (see
+    # auth-secrets.yaml) so prod can't run on minioadmin. Set these, or better,
+    # use existingSecret/externalSecret above. Keep s3_aws_* == rootUser/rootPassword.
     values:
       s3_aws_access_key_id: ""
       s3_aws_secret_access_key: ""

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1270,6 +1270,13 @@ auth:
       S3_AWS_ACCESS_KEY_ID: s3_aws_access_key_id
       S3_AWS_SECRET_ACCESS_KEY: s3_aws_secret_access_key
     # -- Secrets values IF existingSecret is empty. Key here must match the value in secretKeys to be used. Values will be base64 encoded in the k8s cluster.
+    # SECURITY: the minioadmin values below are insecure defaults for local/dev
+    # clusters only. For production, override these or (preferred) set
+    # `existingSecret` / the `externalSecret` block above to source credentials
+    # from a real secret store — anyone who can reach MinIO with the default
+    # minioadmin:minioadmin can list, download, or modify stored files. Keep the
+    # s3_aws_* pair identical to rootUser/rootPassword (the app authenticates to
+    # MinIO using its root credentials).
     values:
       s3_aws_access_key_id: "minioadmin"
       s3_aws_secret_access_key: "minioadmin"


### PR DESCRIPTION
## Description

Onyx shipped the well-known `minioadmin:minioadmin` default for MinIO/S3 object storage throughout the deployment layer. Any deployment that didn't explicitly override it ran on universally-known credentials with no warning, so anyone able to reach MinIO could list, download, or modify stored files (uploaded documents, file-store objects).

The exploitability comes from **predictability**, so this change randomizes credentials per-deployment on the standard install path, fails closed in production (compose **and** Helm), and warns at runtime to cover every other path. It implements the three recommended remediations:

**① Generate strong random MinIO credentials at install time**
- `install.sh` auto-generates a matched access-key/secret pair on a fresh install (mirroring the existing `USER_AUTH_SECRET` generation) and writes it to both `MINIO_ROOT_USER`/`MINIO_ROOT_PASSWORD` and the matching `S3_AWS_ACCESS_KEY_ID`/`S3_AWS_SECRET_ACCESS_KEY` (the app authenticates to MinIO with its root credentials, so the pairs stay identical).

**② Don't publish MinIO ports on `0.0.0.0` in production**
- Already satisfied: none of the `docker-compose.prod*.yml` files publish MinIO ports. Only the dev/test files do (`dev.yml`, `multitenant-dev.yml`, `search-testing.yml`, `restart_containers.sh`), which bind `0.0.0.0`. Those carry `TODO(security)` comments to bind `127.0.0.1` later — deferred to avoid changing remote-host dev workflows.

**③ Remove default passwords from Helm `values.yaml`**
- `values.yaml` now ships **empty** objectstorage credentials, so `helm install`/`upgrade` fails closed via the existing `auth-secrets.yaml` required-value check unless the operator provides values or an `existingSecret`/`externalSecret`. CI keeps working by supplying explicit values in `values-ci.yaml` (craft-k8s render) and `ci/ct-values.yaml` (chart-testing), plus placeholder `--set` flags in the `helm lint` step.

**Defense-in-depth (all paths):** `app_configs.py` logs a warning when an S3 endpoint is configured and either credential is still `minioadmin` — catching compose-up-direct, Helm, and manual deployments. Real AWS S3 (no endpoint URL) never trips the check. `env.template` and the `docker-compose.yml` production checklist also document the risk.

Dev/CI/test compose surfaces intentionally keep `minioadmin` (local-only, never network-exposed).

## Behavior changes (by scenario)

- **Local dev (base/dev/CI compose, `restart_containers.sh`):** unchanged — MinIO still comes up with `minioadmin:minioadmin`; only a new startup log warning when an S3 endpoint + default creds are detected.
- **Fresh `install.sh` install:** credentials are now random/matched — read them from the generated `.env`. Existing `.env` on upgrade is untouched.
- **Production compose (`docker-compose.prod*.yml`):** now **fails closed** — `up` errors immediately if the four credential vars aren't set. The only potentially-breaking change, and only if you relied on the implicit default.
- **Helm:** now **fails closed** too — a default `helm install` errors with a required-value message unless you set the objectstorage creds or an `existingSecret`/`externalSecret`. CI is unaffected (explicit values supplied).
- **Touching this code:** new testable helper `_uses_default_object_storage_credentials(endpoint, access_key, secret_key)` in `app_configs.py` with a unit test. The warning only fires when an endpoint URL is present (real-AWS path is exempt).

## How Has This Been Tested?

- New unit test `backend/tests/unit/onyx/configs/test_object_storage_credentials.py` (4 cases) — passes.
- Verified the backend warning fires for `minioadmin` + MinIO endpoint and stays **silent** for real AWS creds (no endpoint).
- Simulated the `install.sh` sed flow: access-key == root-user, secret == root-password, non-`minioadmin`, meets MinIO length minimums.
- Traced the Helm `auth-secrets.yaml` fail-closed logic; updated `values-ci.yaml`, `ci/ct-values.yaml`, and the `helm lint --set` so CI renders pass. (Live `helm` not available in the dev container — CI is the authoritative render check.)
- `pre-commit` on all changed files: `ty`, `ruff`/`ruff format`, `Check YAML`, `Lint GitHub Actions`, `shellcheck`, `zizmor`, `ripsecrets` all pass.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)