### PR TITLE
fix(scim): skip SCIM token probe below Enterprise tier

### DIFF
--- a/web/src/hooks/useScimToken.ts
+++ b/web/src/hooks/useScimToken.ts
@@ -1,12 +1,18 @@
 import useSWR from "swr";
 
 import { errorHandlingFetcher } from "@/lib/fetcher";
+import { useTierAtLeast } from "@/hooks/useTierAtLeast";
+import { Tier } from "@/interfaces/settings";
 import type { ScimTokenResponse } from "@/app/admin/scim/interfaces";
 import { SWR_KEYS } from "@/lib/swr-keys";
 
 export function useScimToken() {
+  // The endpoint is Enterprise-gated server-side; probing below that tier
+  // is a guaranteed 402, so skip the fetch entirely.
+  const enterpriseTier = useTierAtLeast(Tier.ENTERPRISE);
+
   const { data, error, isLoading, mutate } = useSWR<ScimTokenResponse | null>(
-    SWR_KEYS.scimToken,
+    enterpriseTier ? SWR_KEYS.scimToken : null,
     errorHandlingFetcher,
     { shouldRetryOnError: false }
   );


### PR DESCRIPTION
## Description

**Bug:** Opening Admin → Users as a Business-tier tenant always logs a 402 `FEATURE_NOT_AVAILABLE` ("This feature requires the Enterprise plan") in the browser network tab — confusing noise that reads like a real failure (recently reported by a customer debugging a separate invite issue).

**Why:** The page probes `/api/admin/enterprise-settings/scim/token` on mount to decide whether to show the SCIM card, but that endpoint is Enterprise-gated by the tier middleware, so the probe is a guaranteed 402 below Enterprise.

**Fix:** Gate the fetch inside `useScimToken` on `useTierAtLeast(Tier.ENTERPRISE)` (SWR conditional key), so no consumer can probe below Enterprise. Below that tier the hook returns no data and the SCIM card stays hidden, same as today — minus the misleading 402.

Design note: the Enterprise requirement is also encoded in the backend path-tier map; the FE already mirrors it for this route (admin sidebar gating), and there is no client-side mechanism to derive endpoint tiers from that map.

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check