### PR TITLE
fix(users): bound invite request with a timeout so the modal can't hang

### DIFF
--- a/web/src/refresh-pages/admin/UsersPage/InviteUsersModal.tsx
+++ b/web/src/refresh-pages/admin/UsersPage/InviteUsersModal.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useCallback } from "react";
 import { Button } from "@opal/components";
-import { SvgUsers, SvgAlertTriangle } from "@opal/icons";
+import { SvgUsers, SvgAlertTriangle, SvgLoader } from "@opal/icons";
 import Modal, { BasicModalFooter } from "@/refresh-components/Modal";
 import InputChipField from "@/refresh-components/inputs/InputChipField";
 import type { ChipItem } from "@/refresh-components/inputs/InputChipField";
@@ -186,6 +186,11 @@ export default function InviteUsersModal({
             submit={
               <Button
                 disabled={isSubmitting || chips.every((c) => c.error)}
+                icon={
+                  isSubmitting
+                    ? () => <SvgLoader size={16} className="animate-spin" />
+                    : undefined
+                }
                 onClick={handleInvite}
               >
                 Invite

--- a/web/src/refresh-pages/admin/UsersPage/svc.ts
+++ b/web/src/refresh-pages/admin/UsersPage/svc.ts
@@ -116,12 +116,27 @@ export async function approveRequest(email: string): Promise<void> {
   }
 }
 
+const INVITE_REQUEST_TIMEOUT_MS = 30_000;
+
 export async function inviteUsers(emails: string[]): Promise<void> {
-  const res = await fetch("/api/manage/admin/users", {
-    method: "PUT",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ emails }),
-  });
+  let res: Response;
+  try {
+    res = await fetch("/api/manage/admin/users", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ emails }),
+      // Seat enforcement can stall server-side (control-plane + Stripe round
+      // trips under a tenant lock); bound the wait so the failure surfaces.
+      signal: AbortSignal.timeout(INVITE_REQUEST_TIMEOUT_MS),
+    });
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "TimeoutError") {
+      throw new Error(
+        "The invite request timed out. The invites may still be processing — check the user list before retrying."
+      );
+    }
+    throw err;
+  }
   if (!res.ok) {
     throw new Error(await parseErrorDetail(res, "Failed to invite users"));
   }


### PR DESCRIPTION
## Description

**Bug:** Clicking Invite in the admin Users modal can freeze the dialog indefinitely — every control (Invite, Cancel, X, backdrop) is disabled while submitting, and no error ever appears. Reported by a customer right after a seat purchase.

**Why:** Seat-limit enforcement on `PUT /manage/admin/users` can stall server-side (control-plane + Stripe round-trips under a per-tenant lock). The frontend fetch has no deadline, so a stalled request leaves `isSubmitting` stuck forever and the existing error toast never fires.

**Fix:** Abort the invite fetch after 30s (`AbortSignal.timeout`) and map the timeout to a clear message through the existing toast path. The modal unfreezes and tells the user the invites may still be processing.

The server-side lock-over-network-calls issue is the root cause and worth its own fix; this bounds the user-facing damage.

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check