### PR TITLE
chore(deps): enable dependabot for sandbox image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,3 +44,27 @@ updates:
       - "jmelahman"
     labels:
       - "dependabot:javascript"
+  - package-ecosystem: "bun"
+    directory: "/backend/onyx/server/features/build/sandbox/image/templates/outputs/web"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 3
+    assignees:
+      - "wenxi-onyx"
+    labels:
+      - "dependabot:javascript"
+      - "dependabot:sandbox"
+  - package-ecosystem: "docker"
+    directory: "/backend/onyx/server/features/build/sandbox/image"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 3
+    assignees:
+      - "wenxi-onyx"
+    labels:
+      - "dependabot:docker"
+      - "dependabot:sandbox"


### PR DESCRIPTION
## Description

Adds Dependabot coverage for the sandbox image surfaces that are currently updated manually:

- Bun dependencies in the sandbox web output template
- Docker base image updates for the sandbox image Dockerfile

Both new update entries assign PRs to `wenxi-onyx` and apply sandbox-specific labels.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Dependabot for the sandbox image to auto-update `bun` deps in the web output template and `docker` base image in the sandbox image. This reduces manual updates and keeps the sandbox current.

- **Dependencies**
  - Adds two entries in `.github/dependabot.yml` for `/backend/onyx/server/features/build/sandbox/image/templates/outputs/web` (`bun`) and `/backend/onyx/server/features/build/sandbox/image` (`docker`)
  - Runs weekly with a 7-day cooldown; max 3 open PRs
  - Assigns to `wenxi-onyx` with labels `dependabot:javascript`, `dependabot:sandbox`, and `dependabot:docker`

<sup>Written for commit 36af66faaacd21e6074b29c7842ee38a6f2765e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

