### PR TITLE
ci(cli): scan release wheels with govulncheck

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -29,6 +29,14 @@ jobs:
             done
           done
         working-directory: cli
+      - name: Upload built wheels
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: onyx-cli-wheels
+          path: cli/dist/*.whl
+          if-no-files-found: error
+          retention-days: 7
+
       - run: uv publish
         working-directory: cli
 
@@ -206,3 +214,88 @@ jobs:
               -t "${REGISTRY_IMAGE}:${SANITIZED_TAG}" \
               "${IMAGES[@]}"
           fi
+
+  govulncheck:
+    needs:
+      - pypi
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read # needed to download the wheel artifact from the release job
+      security-events: write # needed for SARIF uploads
+    timeout-minutes: 10
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # ratchet:actions/download-artifact@v4
+        with:
+          name: onyx-cli-wheels
+          path: cli/dist
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # zizmor: ignore[cache-poisoning]
+        with:
+          go-version: "1.26.4"
+          cache: false
+
+      - name: Install govulncheck
+        run: |
+          GOBIN="${RUNNER_TEMP}/bin" go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
+          echo "${RUNNER_TEMP}/bin" >> "$GITHUB_PATH"
+
+      - name: Run govulncheck on released wheel binaries
+        run: |
+          set -euo pipefail
+          scan_exit=0
+          mkdir -p wheel-binaries govulncheck-results/raw
+
+          for wheel in cli/dist/*.whl; do
+            wheel_name="$(basename "$wheel" .whl)"
+            extract_dir="wheel-binaries/${wheel_name}"
+            sarif_file="govulncheck-results/raw/${wheel_name}.sarif"
+
+            unzip -q "$wheel" -d "$extract_dir"
+            binary="$(
+              find "$extract_dir" \
+                \( -path '*.data/scripts/onyx-cli' -o -path '*.data/scripts/onyx-cli.exe' \) \
+                -type f \
+                -print -quit
+            )"
+            if [ -z "$binary" ]; then
+              echo "No onyx-cli binary found in $wheel" >&2
+              exit 1
+            fi
+
+            if ! govulncheck -mode=binary -format=sarif "$binary" > "$sarif_file"; then
+              scan_exit=1
+            fi
+          done
+
+          python3 <<'PY'
+          import json
+          from pathlib import Path
+
+          raw_results_dir = Path("govulncheck-results/raw")
+          merged = {
+              "version": "2.1.0",
+              "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+              "runs": [],
+          }
+
+          for sarif_path in sorted(raw_results_dir.glob("*.sarif")):
+              data = json.loads(sarif_path.read_text())
+              for run in data.get("runs", []):
+                  run["automationDetails"] = {
+                      "id": f"onyx-cli-govulncheck/{sarif_path.stem}",
+                  }
+                  merged["runs"].append(run)
+
+          if not merged["runs"]:
+              raise SystemExit("No govulncheck SARIF runs were generated")
+
+          Path("govulncheck-results.sarif").write_text(json.dumps(merged))
+          PY
+
+          exit "$scan_exit"
+
+      - name: Upload govulncheck scan results to GitHub Security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@ba454b8ab46733eb6145342877cd148270bb77ab
+        with:
+          sarif_file: govulncheck-results.sarif


### PR DESCRIPTION
## Description

Adds a post-publish vulnerability scan to the CLI release workflow for the PyPI wheel artifacts that users install.

The PyPI release job now uploads the built wheels as a short-lived workflow artifact before publishing. After `uv publish` succeeds, a new `govulncheck` job downloads those wheels, extracts the bundled `onyx-cli` Go binaries, scans each binary with pinned `govulncheck@v1.3.0` in binary mode, merges the per-wheel SARIF into one upload with distinct automation IDs, and uploads the SARIF results to the GitHub Security tab.

The scan step preserves SARIF output even when vulnerabilities are found, so the release workflow can fail while still publishing findings for review.

This replaces the earlier Docker-image Trivy scan approach because the primary CLI distribution path is PyPI, not `docker.io/onyxdotapp/onyx-cli`.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
