### PR TITLE
feat(agent-sharing): schema for per-share permissions and ownership - 1/7

### DIFF
--- a/backend/alembic/versions/8f2c4a1d9e3b_agent_sharing_permissions_and_ownership.py
+++ b/backend/alembic/versions/8f2c4a1d9e3b_agent_sharing_permissions_and_ownership.py
@@ -18,6 +18,12 @@ down_revision = "01c63968ff8f"
 branch_labels = None
 depends_on = None
 
+# Lightweight table reference for the backfill DML — avoids importing ORM models.
+persona__user_group_table = sa.table(
+    "persona__user_group",
+    sa.column("permission", sa.String),
+)
+
 
 def upgrade() -> None:
     op.add_column(
@@ -30,7 +36,7 @@ def upgrade() -> None:
     )
     # Group shares previously granted group members edit access via
     # _add_user_filters; keep that for existing rows. New rows default VIEWER.
-    op.execute("UPDATE persona__user_group SET permission = 'EDITOR'")
+    op.execute(persona__user_group_table.update().values(permission="EDITOR"))
     op.add_column(
         "persona",
         sa.Column("owner_group_id", sa.Integer(), nullable=True),

--- a/backend/alembic/versions/8f2c4a1d9e3b_agent_sharing_permissions_and_ownership.py
+++ b/backend/alembic/versions/8f2c4a1d9e3b_agent_sharing_permissions_and_ownership.py
@@ -1,7 +1,7 @@
 """agent sharing permissions and ownership
 
 Revision ID: 8f2c4a1d9e3b
-Revises: 1cb59a95b250
+Revises: 01c63968ff8f
 Create Date: 2026-06-11
 
 Adds per-share permission levels (EDITOR/VIEWER) to persona shares, group
@@ -14,7 +14,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "8f2c4a1d9e3b"
-down_revision = "1cb59a95b250"
+down_revision = "01c63968ff8f"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/8f2c4a1d9e3b_agent_sharing_permissions_and_ownership.py
+++ b/backend/alembic/versions/8f2c4a1d9e3b_agent_sharing_permissions_and_ownership.py
@@ -1,0 +1,83 @@
+"""agent sharing permissions and ownership
+
+Revision ID: 8f2c4a1d9e3b
+Revises: 1cb59a95b250
+Create Date: 2026-06-11
+
+Adds per-share permission levels (EDITOR/VIEWER) to persona shares, group
+ownership + org-wide permission level to persona, and switches the owner FK
+to SET NULL so deleting a user orphans shared personas instead of cascading.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "8f2c4a1d9e3b"
+down_revision = "1cb59a95b250"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "persona__user",
+        sa.Column("permission", sa.String(), nullable=False, server_default="VIEWER"),
+    )
+    op.add_column(
+        "persona__user_group",
+        sa.Column("permission", sa.String(), nullable=False, server_default="VIEWER"),
+    )
+    # Group shares previously granted group members edit access via
+    # _add_user_filters; keep that for existing rows. New rows default VIEWER.
+    op.execute("UPDATE persona__user_group SET permission = 'EDITOR'")
+    op.add_column(
+        "persona",
+        sa.Column("owner_group_id", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "persona",
+        sa.Column(
+            "public_permission", sa.String(), nullable=False, server_default="VIEWER"
+        ),
+    )
+    op.create_foreign_key(
+        "persona_owner_group_id_fkey",
+        "persona",
+        "user_group",
+        ["owner_group_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.drop_constraint("persona__user_fk", "persona", type_="foreignkey")
+    op.create_foreign_key(
+        "persona__user_fk",
+        "persona",
+        "user",
+        ["user_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_check_constraint(
+        "ck_persona_single_owner",
+        "persona",
+        "user_id IS NULL OR owner_group_id IS NULL",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_persona_single_owner", "persona", type_="check")
+    op.drop_constraint("persona__user_fk", "persona", type_="foreignkey")
+    # Faithful restore: the original FK (b156fa702355) has no ondelete
+    op.create_foreign_key(
+        "persona__user_fk",
+        "persona",
+        "user",
+        ["user_id"],
+        ["id"],
+    )
+    op.drop_constraint("persona_owner_group_id_fkey", "persona", type_="foreignkey")
+    op.drop_column("persona", "public_permission")
+    op.drop_column("persona", "owner_group_id")
+    op.drop_column("persona__user_group", "permission")
+    op.drop_column("persona__user", "permission")

--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -573,8 +573,9 @@ class PersonaAccessLevel(str, PyEnum):
 
 
 class PersonaSharingStatus(str, PyEnum):
-    """Derived share state: group-owned or row-shared counts as SHARED even
-    with an empty share list; PUBLIC wins over both."""
+    """Derived share state computed from a persona's columns by the sharing
+    helpers (no DB column of its own): group-owned or row-shared counts as
+    SHARED even with an empty share list; PUBLIC wins over both."""
 
     PRIVATE = "PRIVATE"
     SHARED = "SHARED"

--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -552,3 +552,30 @@ Permission.IMPLIED = frozenset(
         Permission.READ_ADMIN,
     }
 )
+
+
+class PersonaSharePermission(str, PyEnum):
+    """Level granted by a persona share row (user or group), or to the whole
+    org via `Persona.public_permission`."""
+
+    EDITOR = "EDITOR"
+    VIEWER = "VIEWER"
+
+
+class PersonaAccessLevel(str, PyEnum):
+    """Computed access the requesting user holds on a persona.
+
+    OWNER outranks share rows; admins are reported as EDITOR unless owner."""
+
+    OWNER = "OWNER"
+    EDITOR = "EDITOR"
+    VIEWER = "VIEWER"
+
+
+class PersonaSharingStatus(str, PyEnum):
+    """Derived share state: group-owned or row-shared counts as SHARED even
+    with an empty share list; PUBLIC wins over both."""
+
+    PRIVATE = "PRIVATE"
+    SHARED = "SHARED"
+    PUBLIC = "PUBLIC"

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -3730,15 +3730,18 @@ class Persona(Base):
         "User",
         secondary=Persona__User.__table__,
         viewonly=True,
+        overlaps="user_shares",
     )
     # Share rows with permission levels (association objects)
     user_shares: Mapped[list[Persona__User]] = relationship(
         "Persona__User",
         viewonly=True,
+        overlaps="users",
     )
     group_shares: Mapped[list["Persona__UserGroup"]] = relationship(
         "Persona__UserGroup",
         viewonly=True,
+        overlaps="groups",
     )
     # EE only
     is_public: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
@@ -3753,6 +3756,7 @@ class Persona(Base):
         "UserGroup",
         secondary="persona__user_group",
         viewonly=True,
+        overlaps="group_shares",
     )
     allowed_by_llm_providers: Mapped[list["LLMProvider"]] = relationship(
         "LLMProvider",

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -88,6 +88,7 @@ from onyx.db.enums import OpenSearchTenantMigrationStatus
 from onyx.db.enums import PatType
 from onyx.db.enums import Permission
 from onyx.db.enums import PermissionSyncStatus
+from onyx.db.enums import PersonaSharePermission
 from onyx.db.enums import ProcessingMode
 from onyx.db.enums import SandboxStatus
 from onyx.db.enums import ScheduledTaskRunStatus
@@ -618,6 +619,14 @@ class Persona__User(Base):
     user_id: Mapped[UUID | None] = mapped_column(
         ForeignKey("user.id", ondelete="CASCADE"), primary_key=True, nullable=True
     )
+    permission: Mapped[PersonaSharePermission] = mapped_column(
+        Enum(PersonaSharePermission, native_enum=False),
+        nullable=False,
+        default=PersonaSharePermission.VIEWER,
+        server_default=PersonaSharePermission.VIEWER.value,
+    )
+
+    user: Mapped["User | None"] = relationship("User")
 
 
 class DocumentSet__User(Base):
@@ -3633,8 +3642,17 @@ class Persona(Base):
     __tablename__ = "persona"
 
     id: Mapped[int] = mapped_column(primary_key=True)
+    # Owner user. SET NULL (not CASCADE) so deleting a user orphans shared
+    # personas instead of destroying them; the delete flow soft-deletes the
+    # private ones first.
     user_id: Mapped[UUID | None] = mapped_column(
-        ForeignKey("user.id", ondelete="CASCADE"), nullable=True
+        ForeignKey("user.id", ondelete="SET NULL"), nullable=True
+    )
+    # Owner group (EE). Mutually exclusive with user_id — a persona is owned
+    # by exactly one user XOR one group; both NULL on a non-builtin persona
+    # means ownership rests with the admins (orphaned).
+    owner_group_id: Mapped[int | None] = mapped_column(
+        ForeignKey("user_group.id", ondelete="SET NULL"), nullable=True
     )
     name: Mapped[str] = mapped_column(String)
     description: Mapped[str] = mapped_column(String)
@@ -3700,15 +3718,37 @@ class Persona(Base):
         back_populates="personas",
     )
     # Owner
-    user: Mapped[User | None] = relationship("User", back_populates="personas")
+    user: Mapped[User | None] = relationship(
+        "User", back_populates="personas", foreign_keys=[user_id]
+    )
+    # Owner group (EE) — distinct from `groups` (share rows)
+    owner_group: Mapped["UserGroup | None"] = relationship(
+        "UserGroup", foreign_keys=[owner_group_id]
+    )
     # Other users with access
     users: Mapped[list[User]] = relationship(
         "User",
         secondary=Persona__User.__table__,
         viewonly=True,
     )
+    # Share rows with permission levels (association objects)
+    user_shares: Mapped[list[Persona__User]] = relationship(
+        "Persona__User",
+        viewonly=True,
+    )
+    group_shares: Mapped[list["Persona__UserGroup"]] = relationship(
+        "Persona__UserGroup",
+        viewonly=True,
+    )
     # EE only
     is_public: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    # Level granted to the whole org when is_public is True
+    public_permission: Mapped[PersonaSharePermission] = mapped_column(
+        Enum(PersonaSharePermission, native_enum=False),
+        nullable=False,
+        default=PersonaSharePermission.VIEWER,
+        server_default=PersonaSharePermission.VIEWER.value,
+    )
     groups: Mapped[list["UserGroup"]] = relationship(
         "UserGroup",
         secondary="persona__user_group",
@@ -3751,6 +3791,10 @@ class Persona(Base):
             "name",
             unique=True,
             postgresql_where=(builtin_persona == True),  # noqa: E712
+        ),
+        CheckConstraint(
+            "user_id IS NULL OR owner_group_id IS NULL",
+            name="ck_persona_single_owner",
         ),
     )
 
@@ -4396,6 +4440,14 @@ class Persona__UserGroup(Base):
     user_group_id: Mapped[int] = mapped_column(
         ForeignKey("user_group.id"), primary_key=True
     )
+    permission: Mapped[PersonaSharePermission] = mapped_column(
+        Enum(PersonaSharePermission, native_enum=False),
+        nullable=False,
+        default=PersonaSharePermission.VIEWER,
+        server_default=PersonaSharePermission.VIEWER.value,
+    )
+
+    user_group: Mapped["UserGroup"] = relationship("UserGroup")
 
 
 class Skill__UserGroup(Base):


### PR DESCRIPTION
## Description

PR 1/7 of the Agent Sharing stack — database schema only.

- Enums: `PersonaSharePermission`, `PersonaAccessLevel`, `PersonaSharingStatus`
- Per-share permission columns on `persona__user` and `persona__user_group`
- Single-owner model: `persona.user_id` XOR `owner_group_id` (CHECK `ck_persona_single_owner`)
- Owner FK switched to `ON DELETE SET NULL` so a deleted owner orphans rather than cascades

Backward compatible — existing share/ownership code runs unchanged against the new columns. Behavior lands in PRs 2–4.

Stack: 1/7 → schema · 2 sharing · 3 ownership · 4 knowledge-guard · 5 share-UI foundation · 6 dialog · 7 edit/admin/gallery.

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check