### PR TITLE
feat(agent-sharing): per-share permission model - 2/7

### DIFF
--- a/backend/ee/onyx/db/persona.py
+++ b/backend/ee/onyx/db/persona.py
@@ -2,13 +2,67 @@ from uuid import UUID
 
 from sqlalchemy.orm import Session
 
-from onyx.configs.constants import NotificationType
+from onyx.db.enums import PersonaSharePermission
 from onyx.db.models import Persona
-from onyx.db.models import Persona__User
 from onyx.db.models import Persona__UserGroup
-from onyx.db.notification import create_notification
+from onyx.db.persona import apply_persona_user_share_diff
 from onyx.db.persona import mark_persona_user_files_for_sync
-from onyx.server.features.persona.models import PersonaSharedNotificationData
+from onyx.db.persona import resolve_desired_user_shares
+
+
+def _resolve_desired_group_shares(
+    persona_id: int,
+    group_ids: list[int] | None,
+    group_shares: dict[int, PersonaSharePermission] | None,
+    db_session: Session,
+) -> dict[int, PersonaSharePermission] | None:
+    """Legacy group ids keep an existing row's level (new rows default to
+    VIEWER) so pre-permission callers can't downgrade editor groups."""
+    if group_shares is not None:
+        return dict(group_shares)
+    if group_ids is None:
+        return None
+    existing = {
+        row.user_group_id: row.permission
+        for row in db_session.query(Persona__UserGroup)
+        .filter(Persona__UserGroup.persona_id == persona_id)
+        .all()
+    }
+    return {
+        group_id: existing.get(group_id, PersonaSharePermission.VIEWER)
+        for group_id in set(group_ids)
+    }
+
+
+def _apply_persona_group_share_diff(
+    persona_id: int,
+    desired_shares: dict[int, PersonaSharePermission],
+    db_session: Session,
+) -> None:
+    """Reconcile persona__user_group rows to ``desired_shares`` — delete
+    missing, update changed levels in place, insert new rows."""
+    existing_rows = (
+        db_session.query(Persona__UserGroup)
+        .filter(Persona__UserGroup.persona_id == persona_id)
+        .all()
+    )
+    existing_by_group = {row.user_group_id: row for row in existing_rows}
+
+    for group_id, row in existing_by_group.items():
+        if group_id not in desired_shares:
+            db_session.delete(row)
+        elif row.permission != desired_shares[group_id]:
+            row.permission = desired_shares[group_id]
+
+    for group_id, permission in desired_shares.items():
+        if group_id not in existing_by_group:
+            db_session.add(
+                Persona__UserGroup(
+                    persona_id=persona_id,
+                    user_group_id=group_id,
+                    permission=permission,
+                )
+            )
 
 
 def update_persona_access(
@@ -18,56 +72,41 @@ def update_persona_access(
     is_public: bool | None = None,
     user_ids: list[UUID] | None = None,
     group_ids: list[int] | None = None,
+    user_shares: dict[UUID, PersonaSharePermission] | None = None,
+    group_shares: dict[int, PersonaSharePermission] | None = None,
+    public_permission: PersonaSharePermission | None = None,
 ) -> None:
-    """Updates the access settings for a persona including public status, user shares,
-    and group shares.
-
-    NOTE: This function batches all updates. If we don't dedupe the inputs,
-    the commit will exception.
+    """EE version of the MIT function: identical semantics plus group-share
+    support.
 
     NOTE: Callers are responsible for committing."""
-
     needs_sync = False
-    if is_public is not None:
+    if is_public is not None or public_permission is not None:
         needs_sync = True
         persona = db_session.query(Persona).filter(Persona.id == persona_id).first()
         if persona:
-            persona.is_public = is_public
+            if is_public is not None:
+                persona.is_public = is_public
+            if public_permission is not None:
+                persona.public_permission = public_permission
 
-    # NOTE: For user-ids and group-ids, `None` means "leave unchanged", `[]` means "clear all shares",
-    # and a non-empty list means "replace with these shares".
-
-    if user_ids is not None:
+    # NOTE: For share inputs, `None` means "leave unchanged", empty means
+    # "clear all shares", and non-empty means "replace with these shares".
+    desired_user_shares = resolve_desired_user_shares(
+        persona_id, user_ids, user_shares, db_session
+    )
+    if desired_user_shares is not None:
         needs_sync = True
-        db_session.query(Persona__User).filter(
-            Persona__User.persona_id == persona_id
-        ).delete(synchronize_session="fetch")
+        apply_persona_user_share_diff(
+            persona_id, desired_user_shares, creator_user_id, db_session
+        )
 
-        user_ids_set = set(user_ids)
-        for user_id in user_ids_set:
-            db_session.add(Persona__User(persona_id=persona_id, user_id=user_id))
-            if user_id != creator_user_id:
-                create_notification(
-                    user_id=user_id,
-                    notif_type=NotificationType.PERSONA_SHARED,
-                    title="A new agent was shared with you!",
-                    db_session=db_session,
-                    additional_data=PersonaSharedNotificationData(
-                        persona_id=persona_id,
-                    ).model_dump(),
-                )
-
-    if group_ids is not None:
+    desired_group_shares = _resolve_desired_group_shares(
+        persona_id, group_ids, group_shares, db_session
+    )
+    if desired_group_shares is not None:
         needs_sync = True
-        db_session.query(Persona__UserGroup).filter(
-            Persona__UserGroup.persona_id == persona_id
-        ).delete(synchronize_session="fetch")
-
-        group_ids_set = set(group_ids)
-        for group_id in group_ids_set:
-            db_session.add(
-                Persona__UserGroup(persona_id=persona_id, user_group_id=group_id)
-            )
+        _apply_persona_group_share_diff(persona_id, desired_group_shares, db_session)
 
     # When sharing changes, user file ACLs need to be updated in the vector DB
     if needs_sync:

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -22,6 +22,7 @@ from onyx.configs.constants import DEFAULT_PERSONA_ID
 from onyx.configs.constants import NotificationType
 from onyx.db.constants import SLACK_BOT_PERSONA_PREFIX
 from onyx.db.document_access import get_accessible_documents_by_ids
+from onyx.db.enums import PersonaSharePermission
 from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import Document
 from onyx.db.models import DocumentSet
@@ -38,6 +39,8 @@ from onyx.db.models import User__UserGroup
 from onyx.db.models import UserFile
 from onyx.db.models import UserGroup
 from onyx.db.notification import create_notification
+from onyx.db.persona_sharing import get_persona_access_level
+from onyx.db.persona_sharing import get_user_group_ids_for_user
 from onyx.server.features.persona.models import FullPersonaSnapshot
 from onyx.server.features.persona.models import MinimalPersonaSnapshot
 from onyx.server.features.persona.models import PersonaSharedNotificationData
@@ -81,8 +84,9 @@ def _add_user_filters(
     Persona__UG = aliased(Persona__UserGroup)
     User__UG = aliased(User__UserGroup)
     """
-    Here we select cc_pairs by relation:
-    User -> User__UserGroup -> Persona__UserGroup -> Persona
+    Join chain: Persona -> Persona__UserGroup (group share rows) ->
+    User__UserGroup (membership in the share group), plus direct
+    Persona__User share rows.
     """
     stmt = (
         stmt.outerjoin(Persona__UG)
@@ -95,17 +99,6 @@ def _add_user_filters(
             Persona__User.persona_id == Persona.id,
         )
     )
-    """
-    Filter Personas by:
-    - if the user is in the user_group that owns the Persona
-    - if the user is not a global_curator, they must also have a curator relationship
-    to the user_group
-    - if editing is being done, we also filter out Personas that are owned by groups
-    that the user isn't a curator for
-    - if we are not editing, we show all Personas in the groups the user is a curator
-    for (as well as public Personas)
-    - if we are not editing, we return all Personas directly connected to the user
-    """
 
     # Anonymous users only see public, listed Personas
     if user.is_anonymous:
@@ -122,33 +115,58 @@ def _add_user_filters(
         where_clause = (Persona.user_id == user.id) | (Persona.user_id.is_(None))
         return stmt.where(where_clause)
 
-    where_clause = User__UserGroup.user_id == user.id
-    if user.role == UserRole.CURATOR and get_editable:
-        where_clause &= User__UserGroup.is_curator == True  # noqa: E712
+    user_group_ids = select(User__UG.user_group_id).where(User__UG.user_id == user.id)
+
+    # Owner: the owning user, or any member of the owning group
+    owner_clause = (Persona.user_id == user.id) | (
+        Persona.owner_group_id.in_(user_group_ids)
+    )
+
     if get_editable:
-        user_groups = select(User__UG.user_group_id).where(User__UG.user_id == user.id)
-        if user.role == UserRole.CURATOR:
-            user_groups = user_groups.where(User__UG.is_curator == True)  # noqa: E712
-        where_clause &= ~exists().where(Persona__UG.persona_id == Persona.id).where(
-            ~Persona__UG.user_group_id.in_(user_groups)
-        ).correlate(Persona)
+        where_clause = owner_clause
+        # EDITOR-level direct share
+        where_clause |= (Persona__User.user_id == user.id) & (
+            Persona__User.permission == PersonaSharePermission.EDITOR
+        )
+        # EDITOR-level group share (any member of the share group)
+        where_clause |= (User__UserGroup.user_id == user.id) & (
+            Persona__UG.permission == PersonaSharePermission.EDITOR
+        )
+        # Org-wide edit
+        where_clause |= (Persona.is_public == True) & (  # noqa: E712
+            Persona.public_permission == PersonaSharePermission.EDITOR
+        )
+        # Curators keep their group-attachment edit rights: member (curator,
+        # for the CURATOR role) of share groups, with no share group outside
+        # their (curated) groups.
+        if user.role in [UserRole.CURATOR, UserRole.GLOBAL_CURATOR]:
+            curator_clause = User__UserGroup.user_id == user.id
+            curated_group_ids = user_group_ids
+            if user.role == UserRole.CURATOR:
+                curator_clause &= User__UserGroup.is_curator == True  # noqa: E712
+                curated_group_ids = curated_group_ids.where(
+                    User__UG.is_curator == True  # noqa: E712
+                )
+            curator_clause &= ~exists().where(
+                Persona__UG.persona_id == Persona.id
+            ).where(~Persona__UG.user_group_id.in_(curated_group_ids)).correlate(
+                Persona
+            )
+            where_clause |= curator_clause
     else:
         listed = Persona.is_listed == True  # noqa: E712
 
-        # Group membership — only listed agents
-        where_clause &= listed
+        # Group share membership — only listed agents
+        where_clause = (User__UserGroup.user_id == user.id) & listed
 
         # Public agents — must be listed
-        public_condition = (Persona.is_public == True) & listed  # noqa: E712
+        where_clause |= (Persona.is_public == True) & listed  # noqa: E712
 
         # Directly shared — only listed agents
-        shared_condition = (Persona__User.user_id == user.id) & listed
+        where_clause |= (Persona__User.user_id == user.id) & listed
 
-        where_clause |= public_condition
-        where_clause |= shared_condition
-
-    # Owner always sees their own agents (regardless of is_listed)
-    where_clause |= Persona.user_id == user.id
+        # Owners always see their own agents (regardless of is_listed)
+        where_clause |= owner_clause
 
     return stmt.where(where_clause)
 
@@ -209,6 +227,72 @@ def _get_persona_by_name(
     return result
 
 
+def apply_persona_user_share_diff(
+    persona_id: int,
+    desired_shares: dict[UUID, PersonaSharePermission],
+    creator_user_id: UUID | None,
+    db_session: Session,
+) -> None:
+    """Reconcile persona__user rows to ``desired_shares``: delete missing,
+    update changed levels in place, insert + notify genuinely new users.
+    Level-only changes never re-notify."""
+    existing_rows = (
+        db_session.query(Persona__User)
+        .filter(Persona__User.persona_id == persona_id)
+        .all()
+    )
+    existing_by_user = {row.user_id: row for row in existing_rows if row.user_id}
+
+    for user_id, row in existing_by_user.items():
+        if user_id not in desired_shares:
+            db_session.delete(row)
+        elif row.permission != desired_shares[user_id]:
+            row.permission = desired_shares[user_id]
+
+    for user_id, permission in desired_shares.items():
+        if user_id in existing_by_user:
+            continue
+        db_session.add(
+            Persona__User(persona_id=persona_id, user_id=user_id, permission=permission)
+        )
+        if user_id != creator_user_id:
+            create_notification(
+                user_id=user_id,
+                notif_type=NotificationType.PERSONA_SHARED,
+                title="A new agent was shared with you!",
+                db_session=db_session,
+                additional_data=PersonaSharedNotificationData(
+                    persona_id=persona_id,
+                ).model_dump(),
+            )
+
+
+def resolve_desired_user_shares(
+    persona_id: int,
+    user_ids: list[UUID] | None,
+    user_shares: dict[UUID, PersonaSharePermission] | None,
+    db_session: Session,
+) -> dict[UUID, PersonaSharePermission] | None:
+    """Merge the legacy id-list and leveled-share inputs into one desired map.
+    Legacy ids keep an existing row's level (new rows default to VIEWER) so
+    pre-permission callers can't downgrade editors."""
+    if user_shares is not None:
+        return dict(user_shares)
+    if user_ids is None:
+        return None
+    existing = {
+        row.user_id: row.permission
+        for row in db_session.query(Persona__User)
+        .filter(Persona__User.persona_id == persona_id)
+        .all()
+        if row.user_id
+    }
+    return {
+        user_id: existing.get(user_id, PersonaSharePermission.VIEWER)
+        for user_id in set(user_ids)
+    }
+
+
 def update_persona_access(
     persona_id: int,
     creator_user_id: UUID | None,
@@ -216,48 +300,44 @@ def update_persona_access(
     is_public: bool | None = None,
     user_ids: list[UUID] | None = None,
     group_ids: list[int] | None = None,
+    user_shares: dict[UUID, PersonaSharePermission] | None = None,
+    group_shares: dict[int, PersonaSharePermission] | None = None,
+    public_permission: PersonaSharePermission | None = None,
 ) -> None:
     """Updates the access settings for a persona including public status and user shares.
 
     NOTE: Callers are responsible for committing."""
 
     needs_sync = False
-    if is_public is not None:
+    if is_public is not None or public_permission is not None:
         needs_sync = True
         persona = db_session.query(Persona).filter(Persona.id == persona_id).first()
         if persona:
-            persona.is_public = is_public
+            if is_public is not None:
+                persona.is_public = is_public
+            if public_permission is not None:
+                persona.public_permission = public_permission
 
-    # NOTE: For user-ids and group-ids, `None` means "leave unchanged", `[]` means "clear all shares",
-    # and a non-empty list means "replace with these shares".
-    if user_ids is not None:
+    # NOTE: For share inputs, `None` means "leave unchanged", empty means
+    # "clear all shares", and non-empty means "replace with these shares".
+    desired_user_shares = resolve_desired_user_shares(
+        persona_id, user_ids, user_shares, db_session
+    )
+    if desired_user_shares is not None:
         needs_sync = True
-        db_session.query(Persona__User).filter(
-            Persona__User.persona_id == persona_id
-        ).delete(synchronize_session="fetch")
-
-        for user_uuid in user_ids:
-            db_session.add(Persona__User(persona_id=persona_id, user_id=user_uuid))
-            if user_uuid != creator_user_id:
-                create_notification(
-                    user_id=user_uuid,
-                    notif_type=NotificationType.PERSONA_SHARED,
-                    title="A new agent was shared with you!",
-                    db_session=db_session,
-                    additional_data=PersonaSharedNotificationData(
-                        persona_id=persona_id,
-                    ).model_dump(),
-                )
+        apply_persona_user_share_diff(
+            persona_id, desired_user_shares, creator_user_id, db_session
+        )
 
     # MIT doesn't support group-based sharing, so we allow clearing (no-op since
     # there shouldn't be any) but raise an error if trying to add actual groups.
-    if group_ids is not None:
+    if group_ids is not None or group_shares is not None:
         needs_sync = True
         db_session.query(Persona__UserGroup).filter(
             Persona__UserGroup.persona_id == persona_id
         ).delete(synchronize_session="fetch")
 
-        if group_ids:
+        if group_ids or group_shares:
             raise NotImplementedError("Onyx MIT does not support group-based sharing")
 
     # When sharing changes, user file ACLs need to be updated in the vector DB
@@ -350,16 +430,36 @@ def update_persona_shared(
     group_ids: list[int] | None = None,
     is_public: bool | None = None,
     label_ids: list[int] | None = None,
+    user_shares: dict[UUID, PersonaSharePermission] | None = None,
+    group_shares: dict[int, PersonaSharePermission] | None = None,
+    public_permission: PersonaSharePermission | None = None,
 ) -> None:
     """Simplified version of `create_update_persona` which only touches the
     accessibility rather than any of the logic (e.g. prompt, connected data sources,
-    etc.)."""
+    etc.). Allowed for the owner, EDITOR-level users, and admins — enforced by
+    the editable fetch.
+
+    The owner never appears in the share rows: incoming owner ids are dropped
+    silently so a dialog that went stale across an ownership transfer can
+    still save."""
     persona = fetch_persona_by_id_for_user(
         db_session=db_session, persona_id=persona_id, user=user, get_editable=True
     )
 
-    if user and user.role != UserRole.ADMIN and persona.user_id != user.id:
-        raise PermissionError("You don't have permission to modify this persona")
+    owner_user_id = persona.user_id
+    owner_group_id = persona.owner_group_id
+    if user_ids is not None and owner_user_id is not None:
+        user_ids = [uid for uid in user_ids if uid != owner_user_id]
+    if user_shares is not None and owner_user_id is not None:
+        user_shares = {
+            uid: perm for uid, perm in user_shares.items() if uid != owner_user_id
+        }
+    if group_ids is not None and owner_group_id is not None:
+        group_ids = [gid for gid in group_ids if gid != owner_group_id]
+    if group_shares is not None and owner_group_id is not None:
+        group_shares = {
+            gid: perm for gid, perm in group_shares.items() if gid != owner_group_id
+        }
 
     versioned_update_persona_access = fetch_versioned_implementation(
         "onyx.db.persona", "update_persona_access"
@@ -371,6 +471,9 @@ def update_persona_shared(
         is_public=is_public,
         user_ids=user_ids,
         group_ids=group_ids,
+        user_shares=user_shares,
+        group_shares=group_shares,
+        public_permission=public_permission,
     )
 
     if label_ids is not None:
@@ -394,10 +497,19 @@ def update_persona_public_status(
     persona = fetch_persona_by_id_for_user(
         db_session=db_session, persona_id=persona_id, user=user, get_editable=True
     )
-    if user.role != UserRole.ADMIN and persona.user_id != user.id:
+    is_owner_group_member = (
+        persona.owner_group_id is not None
+        and persona.owner_group_id in get_user_group_ids_for_user(db_session, user.id)
+    )
+    if (
+        user.role != UserRole.ADMIN
+        and persona.user_id != user.id
+        and not is_owner_group_member
+    ):
         raise ValueError("You don't have permission to modify this persona")
 
     persona.is_public = is_public
+    mark_persona_user_files_for_sync(persona_id, db_session)
     db_session.commit()
 
 
@@ -458,9 +570,19 @@ def get_minimal_persona_snapshots_for_user(
             Document.parent_hierarchy_node
         ),
         selectinload(Persona.user),
+        selectinload(Persona.owner_group),
+        selectinload(Persona.user_shares),
+        selectinload(Persona.group_shares),
     )
     results = db_session.scalars(stmt).all()
-    return [MinimalPersonaSnapshot.from_model(persona) for persona in results]
+    user_group_ids = get_user_group_ids_for_user(db_session, user.id)
+    return [
+        MinimalPersonaSnapshot.from_model(
+            persona,
+            user_permission=get_persona_access_level(persona, user, user_group_ids),
+        )
+        for persona in results
+    ]
 
 
 def get_persona_snapshots_for_user(
@@ -497,6 +619,9 @@ def get_persona_snapshots_for_user(
         selectinload(Persona.user_files),
         selectinload(Persona.users),
         selectinload(Persona.groups),
+        selectinload(Persona.owner_group),
+        selectinload(Persona.user_shares).selectinload(Persona__User.user),
+        selectinload(Persona.group_shares).selectinload(Persona__UserGroup.user_group),
     )
 
     results = db_session.scalars(stmt).all()
@@ -600,10 +725,20 @@ def get_minimal_persona_snapshots_paginated(
             ),
         ),
         selectinload(Persona.user),
+        selectinload(Persona.owner_group),
+        selectinload(Persona.user_shares),
+        selectinload(Persona.group_shares),
     )
 
     results = db_session.scalars(stmt).all()
-    return [MinimalPersonaSnapshot.from_model(persona) for persona in results]
+    user_group_ids = get_user_group_ids_for_user(db_session, user.id)
+    return [
+        MinimalPersonaSnapshot.from_model(
+            persona,
+            user_permission=get_persona_access_level(persona, user, user_group_ids),
+        )
+        for persona in results
+    ]
 
 
 def get_persona_snapshots_paginated(
@@ -671,6 +806,9 @@ def get_persona_snapshots_paginated(
         selectinload(Persona.user_files),
         selectinload(Persona.users),
         selectinload(Persona.groups),
+        selectinload(Persona.owner_group),
+        selectinload(Persona.user_shares).selectinload(Persona__User.user),
+        selectinload(Persona.group_shares).selectinload(Persona__UserGroup.user_group),
     )
 
     results = db_session.scalars(stmt).all()
@@ -914,7 +1052,7 @@ def upsert_persona(
     system_prompt: str | None,
     task_prompt: str | None,
     datetime_aware: bool | None,
-    is_public: bool,
+    is_public: bool | None,
     db_session: Session,
     default_model_configuration_id: int | None = None,
     document_set_ids: list[int] | None = None,
@@ -924,7 +1062,7 @@ def upsert_persona(
     uploaded_image_id: str | None = None,
     icon_name: str | None = None,
     display_priority: int | None = None,
-    is_listed: bool = True,
+    is_listed: bool | None = None,
     remove_image: bool | None = None,
     search_start_date: datetime | None = None,
     builtin_persona: bool = False,
@@ -1046,18 +1184,27 @@ def upsert_persona(
         existing_persona.default_model_configuration_id = default_model_configuration_id
         existing_persona.starter_messages = starter_messages
         existing_persona.deleted = False  # Un-delete if previously deleted
-        existing_persona.is_public = is_public
+        if is_public is not None:
+            existing_persona.is_public = is_public
         if remove_image or uploaded_image_id:
             existing_persona.uploaded_image_id = uploaded_image_id
         existing_persona.icon_name = icon_name
-        existing_persona.is_listed = is_listed
         existing_persona.search_start_date = search_start_date
         if label_ids is not None:
             existing_persona.labels.clear()
             existing_persona.labels = labels or []
-        existing_persona.is_featured = (
-            is_featured if is_featured is not None else existing_persona.is_featured
-        )
+        # Featured/listed changes are curator/admin-only (ENG-4179): shared
+        # editors saving the form must never flip them, so non-privileged
+        # updates silently preserve the stored values.
+        user_can_set_admin_flags = user is None or user.role in [
+            UserRole.ADMIN,
+            UserRole.CURATOR,
+            UserRole.GLOBAL_CURATOR,
+        ]
+        if is_listed is not None and user_can_set_admin_flags:
+            existing_persona.is_listed = is_listed
+        if is_featured is not None and user_can_set_admin_flags:
+            existing_persona.is_featured = is_featured
         # Update embedded prompt fields if provided
         if system_prompt is not None:
             existing_persona.system_prompt = system_prompt
@@ -1106,7 +1253,7 @@ def upsert_persona(
         new_persona = Persona(
             id=persona_id,
             user_id=user.id if user else None,
-            is_public=is_public,
+            is_public=(is_public if is_public is not None else True),
             name=name,
             description=description,
             builtin_persona=builtin_persona,
@@ -1121,7 +1268,7 @@ def upsert_persona(
             uploaded_image_id=uploaded_image_id,
             icon_name=icon_name,
             display_priority=display_priority,
-            is_listed=is_listed,
+            is_listed=(is_listed if is_listed is not None else True),
             search_start_date=search_start_date,
             is_featured=(is_featured if is_featured is not None else False),
             user_files=user_files or [],
@@ -1237,8 +1384,16 @@ def get_persona_by_id(
 
     # or check if user owns persona
     or_conditions = Persona.user_id == user.id
-    # allow access if persona user id is None
-    or_conditions |= Persona.user_id == None  # noqa: E711
+    # Builtin/system personas are ownerless and stay reachable for everyone
+    # (chat flows fetch them with this function's safe-default edit flag).
+    # Other ownerless personas are vacant — admin-managed, no blanket access.
+    or_conditions |= (Persona.user_id == None) & (  # noqa: E711
+        Persona.builtin_persona == True  # noqa: E712
+    )
+    # Members of the owning group hold owner rights
+    owner_group_ids = get_user_group_ids_for_user(db_session, user.id)
+    if owner_group_ids:
+        or_conditions |= Persona.owner_group_id.in_(owner_group_ids)
     if not is_for_edit:
         # if the user is in a group related to the persona
         or_conditions |= User__UserGroup.user_id == user.id

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -446,6 +446,22 @@ def update_persona_shared(
         db_session=db_session, persona_id=persona_id, user=user, get_editable=True
     )
 
+    # Org-wide visibility is an owner/admin decision. EDITOR-level sharees may
+    # edit user/group shares but must not flip is_public / public_permission
+    # (the same guard update_persona_public_status enforces).
+    is_owner_or_admin = (
+        user.role == UserRole.ADMIN
+        or persona.user_id == user.id
+        or (
+            persona.owner_group_id is not None
+            and persona.owner_group_id
+            in get_user_group_ids_for_user(db_session, user.id)
+        )
+    )
+    if not is_owner_or_admin:
+        is_public = None
+        public_permission = None
+
     owner_user_id = persona.user_id
     owner_group_id = persona.owner_group_id
     if user_ids is not None and owner_user_id is not None:

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -449,7 +449,7 @@ def update_persona_shared(
     # Org-wide visibility is an owner/admin decision. EDITOR-level sharees may
     # edit user/group shares but must not flip is_public / public_permission
     # (the same guard update_persona_public_status enforces).
-    is_owner_or_admin = (
+    is_owner_or_admin: bool = (
         user.role == UserRole.ADMIN
         or persona.user_id == user.id
         or (
@@ -462,8 +462,8 @@ def update_persona_shared(
         is_public = None
         public_permission = None
 
-    owner_user_id = persona.user_id
-    owner_group_id = persona.owner_group_id
+    owner_user_id: UUID | None = persona.user_id
+    owner_group_id: int | None = persona.owner_group_id
     if user_ids is not None and owner_user_id is not None:
         user_ids = [uid for uid in user_ids if uid != owner_user_id]
     if user_shares is not None and owner_user_id is not None:
@@ -1378,6 +1378,7 @@ def get_persona_by_id(
     db_session: Session,
     include_deleted: bool = False,
     is_for_edit: bool = True,  # NOTE: assume true for safety
+    user_group_ids: set[int] | None = None,
 ) -> Persona:
     persona_stmt = (
         select(Persona)
@@ -1406,8 +1407,13 @@ def get_persona_by_id(
     or_conditions |= (Persona.user_id == None) & (  # noqa: E711
         Persona.builtin_persona == True  # noqa: E712
     )
-    # Members of the owning group hold owner rights
-    owner_group_ids = get_user_group_ids_for_user(db_session, user.id)
+    # Members of the owning group hold owner rights. Reuse a caller-supplied
+    # set (the share-snapshot path already fetched it) to avoid a second query.
+    owner_group_ids = (
+        user_group_ids
+        if user_group_ids is not None
+        else get_user_group_ids_for_user(db_session, user.id)
+    )
     if owner_group_ids:
         or_conditions |= Persona.owner_group_id.in_(owner_group_ids)
     if not is_for_edit:

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -419,6 +419,18 @@ def create_update_persona(
         logger.exception("Failed to create persona")
         raise HTTPException(status_code=400, detail=str(e))
 
+    # Eager-load the share relations the snapshot reads so from_model doesn't
+    # lazy-load each one separately after the commit expires the instance.
+    persona = db_session.scalars(
+        select(Persona)
+        .where(Persona.id == persona.id)
+        .options(
+            selectinload(Persona.user_shares),
+            selectinload(Persona.group_shares),
+            selectinload(Persona.owner_group),
+        )
+    ).one()
+
     return FullPersonaSnapshot.from_model(persona)
 
 

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -425,8 +425,10 @@ def create_update_persona(
         select(Persona)
         .where(Persona.id == persona.id)
         .options(
-            selectinload(Persona.user_shares),
-            selectinload(Persona.group_shares),
+            selectinload(Persona.user_shares).selectinload(Persona__User.user),
+            selectinload(Persona.group_shares).selectinload(
+                Persona__UserGroup.user_group
+            ),
             selectinload(Persona.owner_group),
         )
     ).one()

--- a/backend/onyx/db/persona_sharing.py
+++ b/backend/onyx/db/persona_sharing.py
@@ -1,0 +1,83 @@
+"""Pure helpers over loaded Persona share relations. Kept import-light so both
+the persona db layer and the API snapshot models can use them without cycles."""
+
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from onyx.auth.schemas import UserRole
+from onyx.db.enums import PersonaAccessLevel
+from onyx.db.enums import PersonaSharePermission
+from onyx.db.enums import PersonaSharingStatus
+from onyx.db.models import Persona
+from onyx.db.models import User
+from onyx.db.models import User__UserGroup
+
+
+def get_user_group_ids_for_user(db_session: Session, user_id: UUID) -> set[int]:
+    return set(
+        db_session.scalars(
+            select(User__UserGroup.user_group_id).where(
+                User__UserGroup.user_id == user_id
+            )
+        ).all()
+    )
+
+
+def persona_ownership_is_vacant(persona: Persona) -> bool:
+    """True when no live owner holds the persona: both owner refs are NULL on
+    a non-builtin persona, or the owning user is deactivated. Vacant personas
+    are managed (and transferable) by admins. Requires `persona.user` loaded."""
+    if persona.builtin_persona:
+        return False
+    if persona.user_id is not None:
+        return persona.user is not None and not persona.user.is_active
+    return persona.owner_group_id is None
+
+
+def get_persona_access_level(
+    persona: Persona,
+    user: User,
+    user_group_ids: set[int],
+) -> PersonaAccessLevel | None:
+    """Computed access for ``user`` over loaded share relations. OWNER outranks
+    everything; admins report EDITOR on personas they don't own. Curators'
+    group-attachment edit rights are not reflected here — this level drives
+    the sharing UI, not the editable fetch."""
+    if persona.user_id == user.id or (
+        persona.owner_group_id is not None and persona.owner_group_id in user_group_ids
+    ):
+        return PersonaAccessLevel.OWNER
+    if user.role == UserRole.ADMIN:
+        return PersonaAccessLevel.EDITOR
+
+    has_viewer_access = False
+    for user_share in persona.user_shares:
+        if user_share.user_id == user.id:
+            if user_share.permission == PersonaSharePermission.EDITOR:
+                return PersonaAccessLevel.EDITOR
+            has_viewer_access = True
+    for group_share in persona.group_shares:
+        if group_share.user_group_id in user_group_ids:
+            if group_share.permission == PersonaSharePermission.EDITOR:
+                return PersonaAccessLevel.EDITOR
+            has_viewer_access = True
+    if persona.is_public:
+        if persona.public_permission == PersonaSharePermission.EDITOR:
+            return PersonaAccessLevel.EDITOR
+        has_viewer_access = True
+    return PersonaAccessLevel.VIEWER if has_viewer_access else None
+
+
+def derive_persona_sharing_status(persona: Persona) -> PersonaSharingStatus:
+    """PUBLIC > SHARED > PRIVATE; group ownership alone counts as SHARED."""
+    if persona.is_public:
+        return PersonaSharingStatus.PUBLIC
+    if (
+        persona.user_shares
+        or persona.group_shares
+        or persona.owner_group_id is not None
+    ):
+        return PersonaSharingStatus.SHARED
+    return PersonaSharingStatus.PRIVATE

--- a/backend/onyx/db/persona_sharing.py
+++ b/backend/onyx/db/persona_sharing.py
@@ -27,12 +27,13 @@ def get_user_group_ids_for_user(db_session: Session, user_id: UUID) -> set[int]:
 
 def persona_ownership_is_vacant(persona: Persona) -> bool:
     """True when no live owner holds the persona: both owner refs are NULL on
-    a non-builtin persona, or the owning user is deactivated. Vacant personas
-    are managed (and transferable) by admins. Requires `persona.user` loaded."""
+    a non-builtin persona, or the owning user is deactivated or gone. Vacant
+    personas are managed (and transferable) by admins. Requires `persona.user`
+    loaded."""
     if persona.builtin_persona:
         return False
     if persona.user_id is not None:
-        return persona.user is not None and not persona.user.is_active
+        return persona.user is None or not persona.user.is_active
     return persona.owner_group_id is None
 
 

--- a/backend/onyx/server/features/persona/api.py
+++ b/backend/onyx/server/features/persona/api.py
@@ -572,11 +572,15 @@ def get_persona(
     user: User = Depends(current_limited_user),
     db_session: Session = Depends(get_session),
 ) -> FullPersonaSnapshot:
+    user_group_ids: set[int] = (
+        get_user_group_ids_for_user(db_session, user.id) if user is not None else set()
+    )
     persona = get_persona_by_id(
         persona_id=persona_id,
         user=user,
         db_session=db_session,
         is_for_edit=False,
+        user_group_ids=user_group_ids,
     )
 
     # Validate and clear the model override if the referenced model is no longer
@@ -592,7 +596,7 @@ def get_persona(
     snapshot = FullPersonaSnapshot.from_model(persona)
     if user is not None:
         snapshot.user_permission = get_persona_access_level(
-            persona, user, get_user_group_ids_for_user(db_session, user.id)
+            persona, user, user_group_ids
         )
     return snapshot
 

--- a/backend/onyx/server/features/persona/api.py
+++ b/backend/onyx/server/features/persona/api.py
@@ -9,6 +9,7 @@ from fastapi import Response
 from fastapi import UploadFile
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
+from pydantic import model_validator
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -427,6 +428,16 @@ class PersonaShareRequest(BaseModel):
     is_public: bool | None = None
     public_permission: PersonaSharePermission | None = None
     label_ids: list[int] | None = None
+
+    @model_validator(mode="after")
+    def _reject_legacy_and_leveled(self) -> "PersonaShareRequest":
+        # A stale client sending both forms would silently lose the legacy list
+        # (the leveled map wins downstream); reject the ambiguity at the boundary.
+        if self.user_ids is not None and self.user_shares is not None:
+            raise ValueError("Provide either user_ids or user_shares, not both")
+        if self.group_ids is not None and self.group_shares is not None:
+            raise ValueError("Provide either group_ids or group_shares, not both")
+        return self
 
 
 # We notify each user when a user is shared with them

--- a/backend/onyx/server/features/persona/api.py
+++ b/backend/onyx/server/features/persona/api.py
@@ -477,6 +477,9 @@ def share_persona(
     except PermissionError as e:
         logger.exception("Failed to share persona")
         raise HTTPException(status_code=403, detail=str(e))
+    except NotImplementedError as e:
+        logger.exception("Failed to share persona")
+        raise HTTPException(status_code=400, detail=str(e))
     except ValueError as e:
         logger.exception("Failed to share persona")
         raise HTTPException(status_code=400, detail=str(e))

--- a/backend/onyx/server/features/persona/api.py
+++ b/backend/onyx/server/features/persona/api.py
@@ -22,6 +22,7 @@ from onyx.configs.constants import MilestoneRecordType
 from onyx.configs.constants import PUBLIC_API_TAGS
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
+from onyx.db.enums import PersonaSharePermission
 from onyx.db.file_record import get_filerecord_by_file_id_optional
 from onyx.db.models import User
 from onyx.db.persona import create_assistant_label
@@ -42,6 +43,8 @@ from onyx.db.persona import update_persona_public_status
 from onyx.db.persona import update_persona_shared
 from onyx.db.persona import update_persona_visibility
 from onyx.db.persona import update_personas_display_priority
+from onyx.db.persona_sharing import get_persona_access_level
+from onyx.db.persona_sharing import get_user_group_ids_for_user
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.file_store.file_store import get_default_file_store
@@ -404,10 +407,25 @@ def delete_label(
     delete_persona_label(label_id=label_id, db_session=db_session)
 
 
+class PersonaUserShareRequest(BaseModel):
+    user_id: UUID
+    permission: PersonaSharePermission
+
+
+class PersonaGroupShareRequest(BaseModel):
+    group_id: int
+    permission: PersonaSharePermission
+
+
 class PersonaShareRequest(BaseModel):
+    # Legacy id-lists: shares keep an existing row's level, new rows get VIEWER
     user_ids: list[UUID] | None = None
     group_ids: list[int] | None = None
+    # Leveled shares: full replacement including permission levels
+    user_shares: list[PersonaUserShareRequest] | None = None
+    group_shares: list[PersonaGroupShareRequest] | None = None
     is_public: bool | None = None
+    public_permission: PersonaSharePermission | None = None
     label_ids: list[int] | None = None
 
 
@@ -419,6 +437,19 @@ def share_persona(
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> None:
+    user_shares = (
+        {share.user_id: share.permission for share in persona_share_request.user_shares}
+        if persona_share_request.user_shares is not None
+        else None
+    )
+    group_shares = (
+        {
+            share.group_id: share.permission
+            for share in persona_share_request.group_shares
+        }
+        if persona_share_request.group_shares is not None
+        else None
+    )
     try:
         update_persona_shared(
             persona_id=persona_id,
@@ -426,7 +457,10 @@ def share_persona(
             db_session=db_session,
             user_ids=persona_share_request.user_ids,
             group_ids=persona_share_request.group_ids,
+            user_shares=user_shares,
+            group_shares=group_shares,
             is_public=persona_share_request.is_public,
+            public_permission=persona_share_request.public_permission,
             label_ids=persona_share_request.label_ids,
         )
     except PermissionError as e:
@@ -541,7 +575,12 @@ def get_persona(
             persona.default_model_configuration_id = None
             db_session.commit()
 
-    return FullPersonaSnapshot.from_model(persona)
+    snapshot = FullPersonaSnapshot.from_model(persona)
+    if user is not None:
+        snapshot.user_permission = get_persona_access_level(
+            persona, user, get_user_group_ids_for_user(db_session, user.id)
+        )
+    return snapshot
 
 
 @basic_router.get("/{persona_id}/avatar")

--- a/backend/onyx/server/features/persona/models.py
+++ b/backend/onyx/server/features/persona/models.py
@@ -59,6 +59,7 @@ def _group_shares_from_model(persona: Persona) -> list[PersonaGroupShare]:
             permission=share.permission,
         )
         for share in persona.group_shares
+        if share.user_group is not None
     ]
 
 

--- a/backend/onyx/server/features/persona/models.py
+++ b/backend/onyx/server/features/persona/models.py
@@ -6,11 +6,15 @@ from pydantic import Field
 
 from onyx.configs.constants import DocumentSource
 from onyx.db.enums import HierarchyNodeType
+from onyx.db.enums import PersonaAccessLevel
+from onyx.db.enums import PersonaSharePermission
+from onyx.db.enums import PersonaSharingStatus
 from onyx.db.models import Document
 from onyx.db.models import HierarchyNode
 from onyx.db.models import Persona
 from onyx.db.models import PersonaLabel
 from onyx.db.models import StarterMessage
+from onyx.db.persona_sharing import derive_persona_sharing_status
 from onyx.server.features.document_set.models import DocumentSetSummary
 from onyx.server.features.tool.models import ToolSnapshot
 from onyx.server.features.tool.tool_visibility import should_expose_tool_to_fe
@@ -18,6 +22,52 @@ from onyx.server.models import MinimalUserSnapshot
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
+
+
+class PersonaUserShare(BaseModel):
+    user: MinimalUserSnapshot
+    permission: PersonaSharePermission
+
+
+class PersonaGroupShare(BaseModel):
+    group_id: int
+    group_name: str
+    permission: PersonaSharePermission
+
+
+class PersonaOwnerGroupSnapshot(BaseModel):
+    id: int
+    name: str
+
+
+def _user_shares_from_model(persona: Persona) -> list[PersonaUserShare]:
+    return [
+        PersonaUserShare(
+            user=MinimalUserSnapshot(id=share.user.id, email=share.user.email),
+            permission=share.permission,
+        )
+        for share in persona.user_shares
+        if share.user is not None
+    ]
+
+
+def _group_shares_from_model(persona: Persona) -> list[PersonaGroupShare]:
+    return [
+        PersonaGroupShare(
+            group_id=share.user_group_id,
+            group_name=share.user_group.name,
+            permission=share.permission,
+        )
+        for share in persona.group_shares
+    ]
+
+
+def _owner_group_from_model(persona: Persona) -> PersonaOwnerGroupSnapshot | None:
+    if persona.owner_group is None:
+        return None
+    return PersonaOwnerGroupSnapshot(
+        id=persona.owner_group.id, name=persona.owner_group.name
+    )
 
 
 class HierarchyNodeSnapshot(BaseModel):
@@ -106,12 +156,14 @@ class PersonaUpsertRequest(BaseModel):
     name: str
     description: str
     document_set_ids: list[int]
-    is_public: bool
+    # None leaves the stored value/shares unchanged — sharing is managed by
+    # the share endpoint, so form saves must not clobber it with stale state
+    is_public: bool | None = None
     default_model_configuration_id: int | None = None
     starter_messages: list[StarterMessage] | None = None
     # For Private Personas, who should be able to access these
-    users: list[UUID] = Field(default_factory=list)
-    groups: list[int] = Field(default_factory=list)
+    users: list[UUID] | None = None
+    groups: list[int] | None = None
     # e.g. ID of SearchTool or ImageGenerationTool or <USER_DEFINED_TOOL>
     tool_ids: list[int]
     remove_image: bool | None = None
@@ -121,7 +173,8 @@ class PersonaUpsertRequest(BaseModel):
     )
     search_start_date: datetime | None = None
     label_ids: list[int] | None = None
-    is_featured: bool = False
+    # None preserves the stored value; non-admins can never change it
+    is_featured: bool | None = None
     display_priority: int | None = None
     # Accept string UUIDs from frontend
     user_file_ids: list[str] | None = None
@@ -172,9 +225,16 @@ class MinimalPersonaSnapshot(BaseModel):
 
     # Used to display ownership
     owner: MinimalUserSnapshot | None
+    owner_group: PersonaOwnerGroupSnapshot | None
+    # Computed for the requesting user when the list endpoint provides it
+    user_permission: PersonaAccessLevel | None = None
 
     @classmethod
-    def from_model(cls, persona: Persona) -> "MinimalPersonaSnapshot":
+    def from_model(
+        cls,
+        persona: Persona,
+        user_permission: PersonaAccessLevel | None = None,
+    ) -> "MinimalPersonaSnapshot":
         # Collect unique sources from document sets, hierarchy nodes, and attached documents
         sources: set[DocumentSource] = set()
 
@@ -231,6 +291,8 @@ class MinimalPersonaSnapshot(BaseModel):
                 if persona.user
                 else None
             ),
+            owner_group=_owner_group_from_model(persona),
+            user_permission=user_permission,
         )
 
 
@@ -251,8 +313,13 @@ class PersonaSnapshot(BaseModel):
     tools: list[ToolSnapshot]
     labels: list["PersonaLabelSnapshot"]
     owner: MinimalUserSnapshot | None
+    owner_group: PersonaOwnerGroupSnapshot | None
     users: list[MinimalUserSnapshot]
     groups: list[int]
+    user_shares: list[PersonaUserShare]
+    group_shares: list[PersonaGroupShare]
+    public_permission: PersonaSharePermission
+    sharing_status: PersonaSharingStatus
     document_sets: list[DocumentSetSummary]
     default_model_configuration_id: int | None = None
     # Hierarchy nodes attached for scoped search
@@ -300,11 +367,16 @@ class PersonaSnapshot(BaseModel):
                 if persona.user
                 else None
             ),
+            owner_group=_owner_group_from_model(persona),
             users=[
                 MinimalUserSnapshot(id=user.id, email=user.email)
                 for user in persona.users
             ],
             groups=[user_group.id for user_group in persona.groups],
+            user_shares=_user_shares_from_model(persona),
+            group_shares=_group_shares_from_model(persona),
+            public_permission=persona.public_permission,
+            sharing_status=derive_persona_sharing_status(persona),
             document_sets=[
                 DocumentSetSummary.from_model(document_set_model)
                 for document_set_model in persona.document_sets
@@ -321,6 +393,10 @@ class PersonaSnapshot(BaseModel):
 # This is used for flows which need to know all settings
 class FullPersonaSnapshot(PersonaSnapshot):
     search_start_date: datetime | None = None
+    # Per-requesting-user context, set by the single-persona endpoint
+    user_permission: PersonaAccessLevel | None = None
+    admin_count: int = 0
+    ownership_vacant: bool = False
 
     @classmethod
     def from_model(
@@ -351,6 +427,10 @@ class FullPersonaSnapshot(PersonaSnapshot):
                 for user in persona.users
             ],
             groups=[user_group.id for user_group in persona.groups],
+            user_shares=_user_shares_from_model(persona),
+            group_shares=_group_shares_from_model(persona),
+            public_permission=persona.public_permission,
+            sharing_status=derive_persona_sharing_status(persona),
             tools=[
                 ToolSnapshot.from_model(tool)
                 for tool in persona.tools
@@ -370,6 +450,7 @@ class FullPersonaSnapshot(PersonaSnapshot):
                 if persona.user
                 else None
             ),
+            owner_group=_owner_group_from_model(persona),
             document_sets=[
                 DocumentSetSummary.from_model(document_set_model)
                 for document_set_model in persona.document_sets

--- a/backend/tests/external_dependency_unit/db/agent_sharing_helpers.py
+++ b/backend/tests/external_dependency_unit/db/agent_sharing_helpers.py
@@ -1,0 +1,89 @@
+"""Shared builders for the agent-sharing permission/transfer/lifecycle tests."""
+
+from uuid import uuid4
+
+from sqlalchemy.orm import Session
+
+from onyx.db.enums import PersonaSharePermission
+from onyx.db.models import Persona
+from onyx.db.models import Persona__User
+from onyx.db.models import Persona__UserGroup
+from onyx.db.models import User
+from onyx.db.models import User__UserGroup
+from onyx.db.models import UserGroup
+
+
+def create_test_persona(
+    db_session: Session,
+    owner: User | None,
+    is_public: bool = False,
+    is_listed: bool = True,
+    builtin_persona: bool = False,
+    owner_group_id: int | None = None,
+    public_permission: PersonaSharePermission = PersonaSharePermission.VIEWER,
+) -> Persona:
+    persona = Persona(
+        name=f"agent-sharing-test-{uuid4().hex[:8]}",
+        description="agent sharing test persona",
+        user_id=owner.id if owner else None,
+        owner_group_id=owner_group_id,
+        is_public=is_public,
+        public_permission=public_permission,
+        system_prompt="",
+        task_prompt="",
+        datetime_aware=True,
+        builtin_persona=builtin_persona,
+        is_listed=is_listed,
+    )
+    db_session.add(persona)
+    db_session.commit()
+    db_session.refresh(persona)
+    return persona
+
+
+def share_persona_with_user(
+    db_session: Session,
+    persona: Persona,
+    user: User,
+    permission: PersonaSharePermission,
+) -> None:
+    db_session.add(
+        Persona__User(persona_id=persona.id, user_id=user.id, permission=permission)
+    )
+    db_session.commit()
+
+
+def create_test_user_group(
+    db_session: Session,
+    members: list[User],
+    curators: list[User] | None = None,
+) -> UserGroup:
+    group = UserGroup(name=f"agent-sharing-group-{uuid4().hex[:8]}")
+    db_session.add(group)
+    db_session.flush()
+    curator_ids = {user.id for user in (curators or [])}
+    for member in members:
+        db_session.add(
+            User__UserGroup(
+                user_group_id=group.id,
+                user_id=member.id,
+                is_curator=member.id in curator_ids,
+            )
+        )
+    db_session.commit()
+    db_session.refresh(group)
+    return group
+
+
+def share_persona_with_group(
+    db_session: Session,
+    persona: Persona,
+    group: UserGroup,
+    permission: PersonaSharePermission,
+) -> None:
+    db_session.add(
+        Persona__UserGroup(
+            persona_id=persona.id, user_group_id=group.id, permission=permission
+        )
+    )
+    db_session.commit()

--- a/backend/tests/external_dependency_unit/db/test_agent_sharing_permissions.py
+++ b/backend/tests/external_dependency_unit/db/test_agent_sharing_permissions.py
@@ -1,0 +1,222 @@
+"""Regression coverage for the persona share-permission predicate: EDITOR
+shares grant edit access, VIEWER shares grant use only, public_permission can
+extend edit org-wide, and the computed access level / sharing status helpers
+agree with the SQL filter."""
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from onyx.auth.schemas import UserRole
+from onyx.db.enums import PersonaAccessLevel
+from onyx.db.enums import PersonaSharePermission
+from onyx.db.enums import PersonaSharingStatus
+from onyx.db.models import Persona__User
+from onyx.db.models import User
+from onyx.db.persona import fetch_persona_by_id_for_user
+from onyx.db.persona import update_persona_access
+from onyx.db.persona_sharing import derive_persona_sharing_status
+from onyx.db.persona_sharing import get_persona_access_level
+from tests.external_dependency_unit.conftest import create_test_user
+from tests.external_dependency_unit.db.agent_sharing_helpers import create_test_persona
+from tests.external_dependency_unit.db.agent_sharing_helpers import (
+    share_persona_with_user,
+)
+
+
+def _can_fetch(
+    db_session: Session, persona_id: int, user: User, editable: bool
+) -> bool:
+    try:
+        fetch_persona_by_id_for_user(
+            db_session=db_session,
+            persona_id=persona_id,
+            user=user,
+            get_editable=editable,
+        )
+        return True
+    except HTTPException:
+        return False
+
+
+def test_owner_has_edit_access(db_session: Session) -> None:
+    owner = create_test_user(db_session, "owner")
+    persona = create_test_persona(db_session, owner)
+    assert _can_fetch(db_session, persona.id, owner, editable=True)
+    assert _can_fetch(db_session, persona.id, owner, editable=False)
+
+
+def test_viewer_share_grants_use_not_edit(db_session: Session) -> None:
+    owner = create_test_user(db_session, "owner")
+    viewer = create_test_user(db_session, "viewer")
+    persona = create_test_persona(db_session, owner)
+    share_persona_with_user(db_session, persona, viewer, PersonaSharePermission.VIEWER)
+
+    assert _can_fetch(db_session, persona.id, viewer, editable=False)
+    assert not _can_fetch(db_session, persona.id, viewer, editable=True)
+
+
+def test_editor_share_grants_edit(db_session: Session) -> None:
+    owner = create_test_user(db_session, "owner")
+    editor = create_test_user(db_session, "editor")
+    persona = create_test_persona(db_session, owner)
+    share_persona_with_user(db_session, persona, editor, PersonaSharePermission.EDITOR)
+
+    assert _can_fetch(db_session, persona.id, editor, editable=True)
+    assert _can_fetch(db_session, persona.id, editor, editable=False)
+
+
+def test_unrelated_user_has_no_access_to_private_persona(db_session: Session) -> None:
+    owner = create_test_user(db_session, "owner")
+    stranger = create_test_user(db_session, "stranger")
+    persona = create_test_persona(db_session, owner)
+
+    assert not _can_fetch(db_session, persona.id, stranger, editable=False)
+    assert not _can_fetch(db_session, persona.id, stranger, editable=True)
+
+
+def test_admin_always_has_edit_access(db_session: Session) -> None:
+    owner = create_test_user(db_session, "owner")
+    admin = create_test_user(db_session, "admin", role=UserRole.ADMIN)
+    persona = create_test_persona(db_session, owner)
+    assert _can_fetch(db_session, persona.id, admin, editable=True)
+
+
+def test_public_persona_use_only_by_default(db_session: Session) -> None:
+    owner = create_test_user(db_session, "owner")
+    other = create_test_user(db_session, "other")
+    persona = create_test_persona(db_session, owner, is_public=True)
+
+    assert _can_fetch(db_session, persona.id, other, editable=False)
+    assert not _can_fetch(db_session, persona.id, other, editable=True)
+
+
+def test_public_editor_permission_grants_org_wide_edit(db_session: Session) -> None:
+    owner = create_test_user(db_session, "owner")
+    other = create_test_user(db_session, "other")
+    persona = create_test_persona(
+        db_session,
+        owner,
+        is_public=True,
+        public_permission=PersonaSharePermission.EDITOR,
+    )
+    assert _can_fetch(db_session, persona.id, other, editable=True)
+
+
+def test_unlisted_shared_persona_hidden_from_use_but_owner_sees(
+    db_session: Session,
+) -> None:
+    owner = create_test_user(db_session, "owner")
+    viewer = create_test_user(db_session, "viewer")
+    persona = create_test_persona(db_session, owner, is_listed=False)
+    share_persona_with_user(db_session, persona, viewer, PersonaSharePermission.VIEWER)
+
+    assert not _can_fetch(db_session, persona.id, viewer, editable=False)
+    assert _can_fetch(db_session, persona.id, owner, editable=False)
+
+
+def test_legacy_user_ids_path_defaults_to_viewer(db_session: Session) -> None:
+    """Pre-permission callers (plain user_ids) must keep today's use-only
+    semantics: new rows land as VIEWER and grant no edit access."""
+    owner = create_test_user(db_session, "owner")
+    shared = create_test_user(db_session, "shared")
+    persona = create_test_persona(db_session, owner)
+
+    update_persona_access(
+        persona_id=persona.id,
+        creator_user_id=owner.id,
+        db_session=db_session,
+        user_ids=[shared.id],
+    )
+    db_session.commit()
+
+    row = (
+        db_session.query(Persona__User)
+        .filter(
+            Persona__User.persona_id == persona.id,
+            Persona__User.user_id == shared.id,
+        )
+        .one()
+    )
+    assert row.permission == PersonaSharePermission.VIEWER
+    assert not _can_fetch(db_session, persona.id, shared, editable=True)
+
+
+def test_legacy_user_ids_path_preserves_existing_editor_level(
+    db_session: Session,
+) -> None:
+    owner = create_test_user(db_session, "owner")
+    editor = create_test_user(db_session, "editor")
+    persona = create_test_persona(db_session, owner)
+    share_persona_with_user(db_session, persona, editor, PersonaSharePermission.EDITOR)
+
+    update_persona_access(
+        persona_id=persona.id,
+        creator_user_id=owner.id,
+        db_session=db_session,
+        user_ids=[editor.id],
+    )
+    db_session.commit()
+
+    row = (
+        db_session.query(Persona__User)
+        .filter(
+            Persona__User.persona_id == persona.id,
+            Persona__User.user_id == editor.id,
+        )
+        .one()
+    )
+    assert row.permission == PersonaSharePermission.EDITOR
+
+
+@pytest.mark.parametrize(
+    "permission,expected_level",
+    [
+        (PersonaSharePermission.EDITOR, PersonaAccessLevel.EDITOR),
+        (PersonaSharePermission.VIEWER, PersonaAccessLevel.VIEWER),
+    ],
+)
+def test_access_level_for_user_shares(
+    db_session: Session,
+    permission: PersonaSharePermission,
+    expected_level: PersonaAccessLevel,
+) -> None:
+    owner = create_test_user(db_session, "owner")
+    shared = create_test_user(db_session, "shared")
+    persona = create_test_persona(db_session, owner)
+    share_persona_with_user(db_session, persona, shared, permission)
+    db_session.refresh(persona)
+
+    assert get_persona_access_level(persona, shared, set()) == expected_level
+    assert get_persona_access_level(persona, owner, set()) == PersonaAccessLevel.OWNER
+
+
+def test_access_level_admin_and_stranger(db_session: Session) -> None:
+    owner = create_test_user(db_session, "owner")
+    admin = create_test_user(db_session, "admin", role=UserRole.ADMIN)
+    stranger = create_test_user(db_session, "stranger")
+    persona = create_test_persona(db_session, owner)
+    db_session.refresh(persona)
+
+    assert get_persona_access_level(persona, admin, set()) == PersonaAccessLevel.EDITOR
+    assert get_persona_access_level(persona, stranger, set()) is None
+
+
+def test_sharing_status_derivation(db_session: Session) -> None:
+    owner = create_test_user(db_session, "owner")
+    viewer = create_test_user(db_session, "viewer")
+
+    private_persona = create_test_persona(db_session, owner)
+    assert (
+        derive_persona_sharing_status(private_persona) == PersonaSharingStatus.PRIVATE
+    )
+
+    shared_persona = create_test_persona(db_session, owner)
+    share_persona_with_user(
+        db_session, shared_persona, viewer, PersonaSharePermission.VIEWER
+    )
+    db_session.refresh(shared_persona)
+    assert derive_persona_sharing_status(shared_persona) == PersonaSharingStatus.SHARED
+
+    public_persona = create_test_persona(db_session, owner, is_public=True)
+    assert derive_persona_sharing_status(public_persona) == PersonaSharingStatus.PUBLIC

--- a/backend/tests/unit/onyx/server/features/persona/test_knowledge_sources.py
+++ b/backend/tests/unit/onyx/server/features/persona/test_knowledge_sources.py
@@ -46,6 +46,10 @@ def _make_persona(**overrides: object) -> MagicMock:
     p.builtin_persona = False
     p.labels = []
     p.user = None
+    p.owner_group = None
+    p.owner_group_id = None
+    p.user_shares = []
+    p.group_shares = []
 
     for k, v in overrides.items():
         setattr(p, k, v)


### PR DESCRIPTION
## Description

PR 2/7 of the Agent Sharing stack — the sharing core (ENG-4175, backend).

- Per-user / per-group EDITOR vs VIEWER resolution in `_add_user_filters`
- Diff-based share application (`apply_persona_user_share_diff`, `resolve_desired_user_shares`, `update_persona_shared`)
- Org-wide `public_permission`; EE group shares
- `persona_sharing` helpers (access level, sharing status); share API + snapshot fields

Read + write of who can see/edit an agent. Stacked on the schema PR; ownership/transfer and the knowledge guard follow in 3/7 and 4/7.

Tests: per-share permission + status derivation (external_dependency_unit).

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check