### PR TITLE
fix(e2e): scope settings page screenshots to the settings container

### DIFF
--- a/web/tests/e2e/settings/settings_pages.spec.ts
+++ b/web/tests/e2e/settings/settings_pages.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { THEMES, setThemeBeforeNavigation } from "@tests/e2e/utils/theme";
-import { expectScreenshot } from "@tests/e2e/utils/visualRegression";
+import { expectElementScreenshot } from "@tests/e2e/utils/visualRegression";
 
 test.use({ storageState: "admin_auth.json" });
 
@@ -48,9 +48,15 @@ for (const theme of THEMES) {
           await page.waitForLoadState("networkidle");
         }
 
-        await expectScreenshot(page, {
-          name: `settings-${theme}-${slug}`,
-        });
+        // Scope the screenshot to the settings container (rendered by
+        // `SettingsLayouts.Root`) so dynamic app chrome (sidebar, greeting
+        // text, etc.) doesn't cause spurious diffs.
+        await expectElementScreenshot(
+          page.locator("#page-wrapper-scroll-container"),
+          {
+            name: `settings-${theme}-${slug}`,
+          }
+        );
       }
     });
   });


### PR DESCRIPTION
## Description

Deflakes the `settings-*.png` visual regression screenshots (e.g. `settings-dark-general.png`) from `web/tests/e2e/settings/settings_pages.spec.ts`.

The spec previously screenshotted the full page, so dynamic app chrome (sidebar greeting text, recent chats, etc.) caused spurious diffs. It now uses `expectElementScreenshot` scoped to `#page-wrapper-scroll-container` — the stable ID rendered by `SettingsLayouts.Root` — which captures the settings header, tab nav, and tab content while excluding the app chrome.

Note: there is a separate residual flake source not addressed here — `UserProvider` syncs the DB-stored `theme_preference` over the localStorage theme set by `setThemeBeforeNavigation` once `/me` loads, so a saved preference for the shared admin user can flip the theme mid-test. Can follow up separately if desired.

## How Has This Been Tested?

- Ran `bunx playwright test tests/e2e/settings/settings_pages.spec.ts --project=admin` locally against a running dev stack: 2/2 passed (light + dark).
- Visually inspected the captured PNGs — they contain only the settings container, no sidebar/chrome.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes settings page visual regression screenshots to the settings container to remove dynamic app chrome and deflake `settings-*.png` (e.g., `settings-dark-general.png`). Uses `expectElementScreenshot` on `#page-wrapper-scroll-container` rendered by `SettingsLayouts.Root` to capture only the header, tabs, and content.

<sup>Written for commit ead1f56e55e82f23e1258c71ae4eef126e5664ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

