### PR TITLE
fix(security): harden default MinIO/S3 object-storage credentials (#12003) to release v4.1

### DIFF
--- a/.github/workflows/pr-helm-chart-testing.yml
+++ b/.github/workflows/pr-helm-chart-testing.yml
@@ -130,7 +130,13 @@ jobs:
           echo "=== Validating chart dependencies ==="
           cd deployment/helm/charts/onyx
           helm dependency update
-          helm lint . --set auth.userauth.values.user_auth_secret=placeholder
+          # objectstorage ships no defaults (fail closed), so lint must set placeholders.
+          helm lint . \
+            --set auth.userauth.values.user_auth_secret=placeholder \
+            --set auth.objectstorage.values.s3_aws_access_key_id=placeholder \
+            --set auth.objectstorage.values.s3_aws_secret_access_key=placeholder \
+            --set auth.objectstorage.values.rootUser=placeholder \
+            --set auth.objectstorage.values.rootPassword=placeholder
 
       - name: Run chart-testing (install) with enhanced monitoring
         timeout-minutes: 25

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -1428,6 +1428,32 @@ S3_VERIFY_SSL = os.environ.get("S3_VERIFY_SSL", "").lower() == "true"
 S3_AWS_ACCESS_KEY_ID = os.environ.get("S3_AWS_ACCESS_KEY_ID")
 S3_AWS_SECRET_ACCESS_KEY = os.environ.get("S3_AWS_SECRET_ACCESS_KEY")
 
+# Well-known MinIO default; deployments left on it expose all stored files.
+DEFAULT_OBJECT_STORAGE_CREDENTIAL = "minioadmin"
+
+
+def _uses_default_object_storage_credentials(
+    s3_endpoint_url: str | None,
+    access_key: str | None,
+    secret_key: str | None,
+) -> bool:
+    # Only for self-hosted MinIO (has an endpoint URL); real AWS S3 has none.
+    if not s3_endpoint_url:
+        return False
+    return DEFAULT_OBJECT_STORAGE_CREDENTIAL in (access_key, secret_key)
+
+
+if _uses_default_object_storage_credentials(
+    S3_ENDPOINT_URL, S3_AWS_ACCESS_KEY_ID, S3_AWS_SECRET_ACCESS_KEY
+):
+    logger.warning(
+        "Object storage is using the well-known default 'minioadmin' credentials. "
+        "Anyone who can reach the MinIO/S3 endpoint can read or modify stored files "
+        "(uploaded documents, file-store objects). Set S3_AWS_ACCESS_KEY_ID / "
+        "S3_AWS_SECRET_ACCESS_KEY (and MINIO_ROOT_USER / MINIO_ROOT_PASSWORD) to "
+        "strong, unique values before deploying to production."
+    )
+
 # Should we force S3 local checksumming
 S3_GENERATE_LOCAL_CHECKSUM = (
     os.environ.get("S3_GENERATE_LOCAL_CHECKSUM", "").lower() == "true"

--- a/backend/scripts/restart_containers.sh
+++ b/backend/scripts/restart_containers.sh
@@ -94,6 +94,7 @@ else
 fi
 
 # Start the MinIO container with optional volume
+# TODO(security): publish on 127.0.0.1:9004/9005 to bind loopback, not 0.0.0.0.
 echo "Starting MinIO container..."
 if [[ -n "$MINIO_VOLUME" ]]; then
     docker run --detach --name onyx_minio --publish 9004:9000 --publish 9005:9001 -e MINIO_ROOT_USER=minioadmin -e MINIO_ROOT_PASSWORD=minioadmin -v "$MINIO_VOLUME":/data minio/minio server /data --console-address ":9001"

--- a/backend/tests/unit/onyx/configs/test_object_storage_credentials.py
+++ b/backend/tests/unit/onyx/configs/test_object_storage_credentials.py
@@ -1,0 +1,49 @@
+from onyx.configs.app_configs import _uses_default_object_storage_credentials
+
+
+def test_default_credentials_detected_against_minio() -> None:
+    # MinIO endpoint set + the well-known default => flagged.
+    assert (
+        _uses_default_object_storage_credentials(
+            "http://minio:9000", "minioadmin", "minioadmin"
+        )
+        is True
+    )
+
+
+def test_default_credentials_detected_when_either_value_is_default() -> None:
+    # A default in either the access key or the secret is enough to flag.
+    assert (
+        _uses_default_object_storage_credentials(
+            "http://minio:9000", "minioadmin", "a-strong-secret"
+        )
+        is True
+    )
+    assert (
+        _uses_default_object_storage_credentials(
+            "http://minio:9000", "a-strong-key", "minioadmin"
+        )
+        is True
+    )
+
+
+def test_strong_credentials_not_flagged() -> None:
+    assert (
+        _uses_default_object_storage_credentials(
+            "http://minio:9000", "a-strong-key", "a-strong-secret"
+        )
+        is False
+    )
+
+
+def test_no_endpoint_never_flagged() -> None:
+    # Real AWS S3 has no endpoint URL; the check must never fire without one,
+    # even if the (unrelated) credential values happened to match the default.
+    assert (
+        _uses_default_object_storage_credentials(None, "minioadmin", "minioadmin")
+        is False
+    )
+    assert (
+        _uses_default_object_storage_credentials("", "minioadmin", "minioadmin")
+        is False
+    )

--- a/deployment/docker_compose/docker-compose.dev.yml
+++ b/deployment/docker_compose/docker-compose.dev.yml
@@ -46,6 +46,7 @@ services:
 
   minio:
     # Use different ports to avoid conflicts with model servers.
+    # TODO(security): prefix 127.0.0.1: to bind loopback, not 0.0.0.0 (LAN-exposed).
     ports:
       - "${MINIO_API_HOST_PORT:-9004}:9000"
       - "${MINIO_CONSOLE_HOST_PORT:-9005}:9001"

--- a/deployment/docker_compose/docker-compose.multitenant-dev.yml
+++ b/deployment/docker_compose/docker-compose.multitenant-dev.yml
@@ -493,6 +493,7 @@ services:
   minio:
     image: ${BASE_IMAGE_REGISTRY:-docker.io}/minio/minio:RELEASE.2025-07-23T15-54-02Z-cpuv1
     restart: unless-stopped
+    # TODO(security): prefix 127.0.0.1: to bind loopback, not 0.0.0.0 (LAN-exposed).
     ports:
       - "9004:9000"
       - "9005:9001"

--- a/deployment/docker_compose/docker-compose.prod-cloud.yml
+++ b/deployment/docker_compose/docker-compose.prod-cloud.yml
@@ -26,8 +26,8 @@ services:
       - MODEL_SERVER_HOST=${MODEL_SERVER_HOST:-inference_model_server}
       # MinIO configuration
       - S3_ENDPOINT_URL=${S3_ENDPOINT_URL:-http://minio:9000}
-      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:-minioadmin}
-      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:-minioadmin}
+      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:?set a strong value in .env, not minioadmin}
+      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:?set a strong value in .env, not minioadmin}
     env_file:
       - path: .env
         required: false
@@ -62,8 +62,8 @@ services:
       - INDEXING_MODEL_SERVER_HOST=${INDEXING_MODEL_SERVER_HOST:-indexing_model_server}
       # MinIO configuration
       - S3_ENDPOINT_URL=${S3_ENDPOINT_URL:-http://minio:9000}
-      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:-minioadmin}
-      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:-minioadmin}
+      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:?set a strong value in .env, not minioadmin}
+      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:?set a strong value in .env, not minioadmin}
       - DISCORD_BOT_TOKEN=${DISCORD_BOT_TOKEN:-}
       - DISCORD_BOT_INVOKE_CHAR=${DISCORD_BOT_INVOKE_CHAR:-!}
       # API Server connection for Discord bot message processing
@@ -304,8 +304,8 @@ services:
     image: minio/minio:RELEASE.2025-07-23T15-54-02Z-cpuv1
     restart: unless-stopped
     environment:
-      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
-      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:?set a strong value in .env, not minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?set a strong value in .env, not minioadmin}
       MINIO_DEFAULT_BUCKETS: ${S3_FILE_STORE_BUCKET_NAME:-onyx-file-store-bucket}
     volumes:
       - minio_data:/data

--- a/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
+++ b/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
@@ -31,8 +31,8 @@ services:
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY-}
       # MinIO configuration
       - S3_ENDPOINT_URL=${S3_ENDPOINT_URL:-http://minio:9000}
-      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:-minioadmin}
-      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:-minioadmin}
+      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:?set a strong value in .env, not minioadmin}
+      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:?set a strong value in .env, not minioadmin}
     env_file:
       - path: .env
         required: false
@@ -79,8 +79,8 @@ services:
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY-}
       # MinIO configuration
       - S3_ENDPOINT_URL=${S3_ENDPOINT_URL:-http://minio:9000}
-      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:-minioadmin}
-      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:-minioadmin}
+      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:?set a strong value in .env, not minioadmin}
+      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:?set a strong value in .env, not minioadmin}
     env_file:
       - path: .env
         required: false
@@ -311,8 +311,8 @@ services:
     image: minio/minio:RELEASE.2025-07-23T15-54-02Z-cpuv1
     restart: unless-stopped
     environment:
-      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
-      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:?set a strong value in .env, not minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?set a strong value in .env, not minioadmin}
       MINIO_DEFAULT_BUCKETS: ${S3_FILE_STORE_BUCKET_NAME:-onyx-file-store-bucket}
     volumes:
       - minio_data:/data

--- a/deployment/docker_compose/docker-compose.prod.yml
+++ b/deployment/docker_compose/docker-compose.prod.yml
@@ -32,8 +32,8 @@ services:
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY-}
       # MinIO configuration
       - S3_ENDPOINT_URL=${S3_ENDPOINT_URL:-http://minio:9000}
-      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:-minioadmin}
-      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:-minioadmin}
+      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:?set a strong value in .env, not minioadmin}
+      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:?set a strong value in .env, not minioadmin}
     env_file:
       - path: .env
         required: false
@@ -84,8 +84,8 @@ services:
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY-}
       # MinIO configuration
       - S3_ENDPOINT_URL=${S3_ENDPOINT_URL:-http://minio:9000}
-      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:-minioadmin}
-      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:-minioadmin}
+      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:?set a strong value in .env, not minioadmin}
+      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:?set a strong value in .env, not minioadmin}
       - DISCORD_BOT_TOKEN=${DISCORD_BOT_TOKEN:-}
       - DISCORD_BOT_INVOKE_CHAR=${DISCORD_BOT_INVOKE_CHAR:-!}
       # API Server connection for Discord bot message processing
@@ -359,8 +359,8 @@ services:
     image: minio/minio:RELEASE.2025-07-23T15-54-02Z-cpuv1
     restart: unless-stopped
     environment:
-      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
-      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:?set a strong value in .env, not minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?set a strong value in .env, not minioadmin}
       MINIO_DEFAULT_BUCKETS: ${S3_FILE_STORE_BUCKET_NAME:-onyx-file-store-bucket}
     volumes:
       - minio_data:/data

--- a/deployment/docker_compose/docker-compose.search-testing.yml
+++ b/deployment/docker_compose/docker-compose.search-testing.yml
@@ -226,6 +226,7 @@ services:
   minio:
     image: minio/minio:RELEASE.2025-07-23T15-54-02Z-cpuv1
     restart: unless-stopped
+    # TODO(security): prefix 127.0.0.1: to bind loopback, not 0.0.0.0 (LAN-exposed).
     ports:
       - "9004:9000"
       - "9005:9001"

--- a/deployment/docker_compose/docker-compose.yml
+++ b/deployment/docker_compose/docker-compose.yml
@@ -12,6 +12,7 @@
 # 1. SECURITY HARDENING:
 #    - Remove all port exposures except nginx (80/443)
 #    - Comment out ports for: api_server, relational_db, cache, minio
+#    - Set strong MinIO/S3 credentials (MINIO_ROOT_* + S3_AWS_*), not minioadmin
 #
 # 2. SSL/TLS SETUP:
 #    - Uncomment the certbot service (see below)

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -121,6 +121,9 @@ COMPOSE_PROFILES=s3-filestore
 FILE_STORE_BACKEND=s3
 
 ## MinIO/S3 Configuration (only needed when FILE_STORE_BACKEND=s3)
+## SECURITY: minioadmin is a local-dev default. install.sh randomizes it; if you
+## edit .env by hand, change all four values before production. Keep the S3_AWS_*
+## pair identical to MINIO_ROOT_* (the app uses MinIO's root creds).
 S3_ENDPOINT_URL=http://minio:9000
 S3_AWS_ACCESS_KEY_ID=minioadmin
 S3_AWS_SECRET_ACCESS_KEY=minioadmin

--- a/deployment/docker_compose/install.sh
+++ b/deployment/docker_compose/install.sh
@@ -1110,11 +1110,14 @@ else
     sed -i.bak "s/^IMAGE_TAG=.*/IMAGE_TAG=$VERSION/" "$ENV_FILE"
     print_success "IMAGE_TAG set to $VERSION"
 
-    # In lite mode, clear COMPOSE_PROFILES so profiled services (MinIO, etc.)
-    # stay disabled — the template ships with s3-filestore enabled by default.
+    # In lite mode, MinIO never starts (COMPOSE_PROFILES cleared) and the
+    # onyx-lite overlay forces FILE_STORE_BACKEND=postgres at runtime; set it in
+    # .env too so the file isn't misleadingly left on s3 (the MinIO/S3 creds
+    # generated below are then unused, but stay ready if s3-filestore is enabled).
     if [[ "$LITE_MODE" = true ]]; then
         sed -i.bak 's/^COMPOSE_PROFILES=.*/COMPOSE_PROFILES=/' "$ENV_FILE" 2>/dev/null || true
-        print_success "Cleared COMPOSE_PROFILES for lite mode"
+        sed -i.bak 's/^FILE_STORE_BACKEND=.*/FILE_STORE_BACKEND=postgres/' "$ENV_FILE" 2>/dev/null || true
+        print_success "Cleared COMPOSE_PROFILES and set FILE_STORE_BACKEND=postgres for lite mode"
     fi
 
     # Configure basic authentication (default)
@@ -1130,6 +1133,15 @@ else
     # Generate a secure USER_AUTH_SECRET
     USER_AUTH_SECRET=$(openssl rand -hex 32)
     sed -i.bak "s/^USER_AUTH_SECRET=.*/USER_AUTH_SECRET=\"$USER_AUTH_SECRET\"/" "$ENV_FILE" 2>/dev/null || true
+
+    # Random MinIO/S3 credentials instead of the minioadmin default. The app uses
+    # MinIO's root creds, so the same pair goes to both the server and app vars.
+    MINIO_ACCESS_KEY=$(openssl rand -hex 16)
+    MINIO_SECRET_KEY=$(openssl rand -hex 32)
+    sed -i.bak "s/^MINIO_ROOT_USER=.*/MINIO_ROOT_USER=$MINIO_ACCESS_KEY/" "$ENV_FILE" 2>/dev/null || true
+    sed -i.bak "s/^MINIO_ROOT_PASSWORD=.*/MINIO_ROOT_PASSWORD=$MINIO_SECRET_KEY/" "$ENV_FILE" 2>/dev/null || true
+    sed -i.bak "s/^S3_AWS_ACCESS_KEY_ID=.*/S3_AWS_ACCESS_KEY_ID=$MINIO_ACCESS_KEY/" "$ENV_FILE" 2>/dev/null || true
+    sed -i.bak "s/^S3_AWS_SECRET_ACCESS_KEY=.*/S3_AWS_SECRET_ACCESS_KEY=$MINIO_SECRET_KEY/" "$ENV_FILE" 2>/dev/null || true
 
     # Configure Craft based on --include-craft.
     # By default, env.template has Craft commented out (disabled).


### PR DESCRIPTION
Cherry-pick of commit 26868070e6fa254b9a98cc3be8479a69f938c5fa to release/v4.1 branch.

Original PR: #12003

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened MinIO/S3 object storage by removing the `minioadmin` defaults, enforcing strong env vars in Docker Compose, and adding runtime detection to prevent data exposure. The installer now generates random MinIO/S3 credentials; AWS S3 (no endpoint URL) is unaffected.

- **Bug Fixes**
  - Docker Compose: removed `minioadmin` defaults; require strong `MINIO_ROOT_*` and `S3_AWS_*` via `${VAR:?...}`.
  - `install.sh`: generates random MinIO root creds and mirrors them to the app’s `S3_AWS_*`.
  - App: logs a warning if a MinIO endpoint is set and either credential is `minioadmin`.
  - Tests/CI: added unit tests; Helm lint passes placeholder object-storage secrets.

- **Migration**
  - In `.env`, set `MINIO_ROOT_USER`, `MINIO_ROOT_PASSWORD`, `S3_AWS_ACCESS_KEY_ID`, `S3_AWS_SECRET_ACCESS_KEY` to strong, matching values (the app uses MinIO root creds).
  - Or run `deployment/docker_compose/install.sh` to auto-generate them, then restart.
  - Lite mode now writes `FILE_STORE_BACKEND=postgres`; switch back to `s3` only if enabling MinIO/S3.

<sup>Written for commit 75ec00fd5214b047cf3defe63e3fd78cca7dad2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

