### PR TITLE
chore(search): stop inferring filters in the search pipeline

### DIFF
--- a/backend/onyx/context/search/pipeline.py
+++ b/backend/onyx/context/search/pipeline.py
@@ -21,14 +21,9 @@ from onyx.document_index.interfaces_new import DocumentIndex
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.federated_connectors.federated_retrieval import FederatedRetrievalInfo
-from onyx.llm.interfaces import LLM
 from onyx.natural_language_processing.english_stopwords import strip_stopwords
 from onyx.natural_language_processing.search_nlp_models import EmbeddingModel
-from onyx.secondary_llm_flows.source_filter import extract_source_filter
-from onyx.secondary_llm_flows.time_filter import extract_time_filter
 from onyx.utils.logger import setup_logger
-from onyx.utils.threadpool_concurrency import FunctionCall
-from onyx.utils.threadpool_concurrency import run_functions_in_parallel
 from onyx.utils.timing import log_function_time
 from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
 from shared_configs.configs import MULTI_TENANT
@@ -46,9 +41,6 @@ def _build_index_filters(
     persona_document_sets: list[str] | None,
     persona_time_cutoff: datetime | None,
     db_session: Session | None = None,
-    auto_detect_filters: bool = False,
-    query: str | None = None,
-    llm: LLM | None = None,
     bypass_acl: bool = False,
     # Assistant knowledge filters
     attached_document_ids: list[str] | None = None,
@@ -56,9 +48,6 @@ def _build_index_filters(
     # Pre-fetched ACL filters (skips DB query when provided)
     acl_filters: list[str] | None = None,
 ) -> IndexFilters:
-    if auto_detect_filters and (llm is None or query is None):
-        raise RuntimeError("LLM and query are required for auto detect filters")
-
     base_filters = user_provided_filters or BaseFilters()
 
     # When the caller supplies document set names, enforce that the user has view
@@ -94,34 +83,6 @@ def _build_index_filters(
 
     time_filter = base_filters.time_cutoff or persona_time_cutoff
     source_filter = base_filters.source_type
-
-    detected_time_filter = None
-    detected_source_filter = None
-    if auto_detect_filters:
-        time_filter_fnc = FunctionCall(extract_time_filter, (query, llm), {})
-        if not source_filter:
-            source_filter_fnc = FunctionCall(
-                extract_source_filter, (query, llm, db_session), {}
-            )
-        else:
-            source_filter_fnc = None
-
-        functions_to_run = [fn for fn in [time_filter_fnc, source_filter_fnc] if fn]
-        parallel_results = run_functions_in_parallel(functions_to_run)
-        # Detected favor recent is not used for now
-        detected_time_filter, _detected_favor_recent = parallel_results[
-            time_filter_fnc.result_id
-        ]
-        if source_filter_fnc:
-            detected_source_filter = parallel_results[source_filter_fnc.result_id]
-
-    # If the detected time filter is more recent, use that one
-    if time_filter and detected_time_filter and detected_time_filter > time_filter:
-        time_filter = detected_time_filter
-
-    # If the user has explicitly set a source filter, use that one
-    if not source_filter and detected_source_filter:
-        source_filter = detected_source_filter
 
     if bypass_acl:
         user_acl_filters = None
@@ -278,8 +239,6 @@ def search_pipeline(
     # Pre-extracted persona search configuration (None when no persona)
     persona_search_info: PersonaSearchInfo | None,
     db_session: Session | None = None,
-    auto_detect_filters: bool = False,
-    llm: LLM | None = None,
     # Vespa metadata filters for overflowing user files.  NOT the raw IDs
     # of the current project/persona — only set when user files couldn't fit
     # in the LLM context and need to be searched via vector DB.
@@ -313,9 +272,6 @@ def search_pipeline(
         persona_document_sets=persona_document_sets,
         persona_time_cutoff=persona_time_cutoff,
         db_session=db_session,
-        auto_detect_filters=auto_detect_filters,
-        query=chunk_search_request.query,
-        llm=llm,
         bypass_acl=chunk_search_request.bypass_acl,
         attached_document_ids=attached_document_ids,
         hierarchy_node_ids=hierarchy_node_ids,

--- a/backend/onyx/onyxbot/slack/handlers/handle_regular_answer.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_regular_answer.py
@@ -260,8 +260,6 @@ def handle_regular_answer(
         return answer
 
     try:
-        # By leaving time_cutoff and favor_recent as None, and setting enable_auto_detect_filters
-        # it allows the slack flow to extract out filters from the user query
         filters = BaseFilters(
             source_type=None,
             document_set=document_set_names,


### PR DESCRIPTION
## What

Stops `_build_index_filters` / `search_pipeline` from doing any source/time **filter inference**, ahead of relocating that logic to `SearchTool.run()` (which has the full conversation history).

## Why this is dead code

The pipeline's auto-detect path was never functional or reachable:

- `extract_source_filter` / `extract_time_filter` are `NotImplementedError` stubs.
- **Nothing sets `auto_detect_filters=True`.** The only reference was a stale comment in the Slack handler; the flag was never wired through `SendMessageRequest`, so the extractors were never invoked. (Confirmed: no caller passes `auto_detect_filters=` or `llm=` to `search_pipeline`.)

## Changes

- Remove the auto-detect block and the `auto_detect_filters` / `query` / `llm` params from `_build_index_filters`.
- Remove the now-dead `auto_detect_filters` / `llm` params from `search_pipeline` (no caller passed them; they were only forwarded to `_build_index_filters`).
- Fix the stale Slack comment.

## Intentionally kept

- `secondary_llm_flows/source_filter.py` and `secondary_llm_flows/time_filter.py` stubs **stay** — they'll be implemented and invoked from the new location (the search tool) in follow-up PRs.
- `prompts/filter_extration.py` stays (reused by the relocated implementation).

Follow-up: source filtering becomes a third parallel LLM call in `SearchTool.run()`, piping the inferred `source_type` into the search pipeline. Time filtering is a later, separate change.

- [x] [Optional] Override Linear Check
