### PR TITLE
feat(craft): background-snapshot RUNNING sandboxes in the idle sweep

### DIFF
--- a/backend/onyx/background/celery/tasks/beat_schedule.py
+++ b/backend/onyx/background/celery/tasks/beat_schedule.py
@@ -181,10 +181,10 @@ beat_task_templates: list[dict] = [
     {
         "name": "cleanup-idle-sandboxes",
         "task": OnyxCeleryTask.CLEANUP_IDLE_SANDBOXES,
-        # Ticks are cheap (the age gate skips fresh-snapshotted sessions);
-        # the cloud beat multiplier (x8) makes this ~40 min effective = the
-        # data-loss bound.
-        "schedule": timedelta(minutes=5),
+        # Ticks are cheap (DB-only when nothing is stale); snapshot pacing is
+        # gated inside the task at idle_timeout/4, so cloud's x8 multiplier
+        # (~8 min effective) still lands under the ~15 min data-loss bound.
+        "schedule": timedelta(minutes=1),
         "options": {
             "priority": OnyxCeleryPriority.LOW,
             "expires": BEAT_EXPIRES_DEFAULT,

--- a/backend/onyx/background/celery/tasks/beat_schedule.py
+++ b/backend/onyx/background/celery/tasks/beat_schedule.py
@@ -177,18 +177,14 @@ beat_task_templates: list[dict] = [
             "queue": OnyxCeleryQueues.PRIMARY,
         },
     },
-    # Sandbox cleanup tasks
+    # Sandbox sweep: background-snapshot changed sessions, sleep idle sandboxes.
     {
         "name": "cleanup-idle-sandboxes",
         "task": OnyxCeleryTask.CLEANUP_IDLE_SANDBOXES,
-        # SANDBOX_IDLE_TIMEOUT_SECONDS defaults to 1 hour, so there is no
-        # functional reason to scan more often than every ~15 minutes. In the
-        # cloud this is multiplied by CLOUD_BEAT_MULTIPLIER_DEFAULT (=8) so
-        # the effective cadence becomes ~2 hours, which still meets the
-        # idle-detection SLA. The previous 1-minute base schedule produced
-        # an 8-minute per-tenant fan-out and was the dominant source of
-        # background DB load on the cloud cluster.
-        "schedule": timedelta(minutes=15),
+        # Ticks are cheap (the age gate skips fresh-snapshotted sessions);
+        # the cloud beat multiplier (x8) makes this ~40 min effective = the
+        # data-loss bound.
+        "schedule": timedelta(minutes=5),
         "options": {
             "priority": OnyxCeleryPriority.LOW,
             "expires": BEAT_EXPIRES_DEFAULT,

--- a/backend/onyx/server/features/build/configs.py
+++ b/backend/onyx/server/features/build/configs.py
@@ -32,6 +32,12 @@ SANDBOX_MAX_CONCURRENT_PER_ORG = int(
     os.environ.get("SANDBOX_MAX_CONCURRENT_PER_ORG", "10")
 )
 
+# Data-loss bound for ungraceful pod death: the sweep skips sessions whose
+# latest snapshot is newer than this.
+SANDBOX_PERIODIC_SNAPSHOT_INTERVAL_SECONDS = int(
+    os.environ.get("SANDBOX_PERIODIC_SNAPSHOT_INTERVAL_SECONDS", "1800")
+)
+
 SANDBOX_NEXTJS_PORT_START = int(os.environ.get("SANDBOX_NEXTJS_PORT_START", "3010"))
 SANDBOX_NEXTJS_PORT_END = int(os.environ.get("SANDBOX_NEXTJS_PORT_END", "3100"))
 

--- a/backend/onyx/server/features/build/configs.py
+++ b/backend/onyx/server/features/build/configs.py
@@ -32,12 +32,6 @@ SANDBOX_MAX_CONCURRENT_PER_ORG = int(
     os.environ.get("SANDBOX_MAX_CONCURRENT_PER_ORG", "10")
 )
 
-# Data-loss bound for ungraceful pod death: the sweep skips sessions whose
-# latest snapshot is newer than this.
-SANDBOX_PERIODIC_SNAPSHOT_INTERVAL_SECONDS = int(
-    os.environ.get("SANDBOX_PERIODIC_SNAPSHOT_INTERVAL_SECONDS", "1800")
-)
-
 SANDBOX_NEXTJS_PORT_START = int(os.environ.get("SANDBOX_NEXTJS_PORT_START", "3010"))
 SANDBOX_NEXTJS_PORT_END = int(os.environ.get("SANDBOX_NEXTJS_PORT_END", "3100"))
 

--- a/backend/onyx/server/features/build/db/sandbox.py
+++ b/backend/onyx/server/features/build/db/sandbox.py
@@ -3,9 +3,7 @@
 import datetime
 from uuid import UUID
 
-from sqlalchemy import and_
 from sqlalchemy import func
-from sqlalchemy import or_
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
@@ -94,26 +92,6 @@ def get_sandbox_by_user_id(db_session: Session, user_id: UUID) -> Sandbox | None
     return db_session.execute(stmt).scalar_one_or_none()
 
 
-def get_sandbox_by_session_id(db_session: Session, session_id: UUID) -> Sandbox | None:
-    """Get sandbox by session ID (compatibility function).
-
-    This function provides backwards compatibility during the transition to
-    user-owned sandboxes. It looks up the session's user_id, then finds the
-    user's sandbox.
-
-    NOTE: This will be removed in a future phase when all callers are updated
-    to use get_sandbox_by_user_id() directly.
-    """
-    from onyx.db.models import BuildSession
-
-    stmt = select(BuildSession.user_id).where(BuildSession.id == session_id)
-    result = db_session.execute(stmt).scalar_one_or_none()
-    if result is None:
-        return None
-
-    return get_sandbox_by_user_id(db_session, result)
-
-
 def get_sandbox_by_id(db_session: Session, sandbox_id: UUID) -> Sandbox | None:
     """Get sandbox by its ID."""
     stmt = select(Sandbox).where(Sandbox.id == sandbox_id)
@@ -159,29 +137,9 @@ def update_sandbox_heartbeat(db_session: Session, sandbox_id: UUID) -> Sandbox:
     return sandbox
 
 
-def get_idle_sandboxes(
-    db_session: Session, idle_threshold_seconds: int
-) -> list[Sandbox]:
-    """Get sandboxes that have been idle longer than threshold.
-
-    Also includes sandboxes with NULL heartbeat, but only if they were created
-    before the threshold (to avoid sweeping up brand-new sandboxes that may have
-    NULL heartbeat due to edge cases like older rows or manual inserts).
-    """
-    threshold_time = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
-        seconds=idle_threshold_seconds
-    )
-
-    stmt = select(Sandbox).where(
-        Sandbox.status == SandboxStatus.RUNNING,
-        or_(
-            Sandbox.last_heartbeat < threshold_time,
-            and_(
-                Sandbox.last_heartbeat.is_(None),
-                Sandbox.created_at < threshold_time,
-            ),
-        ),
-    )
+def get_running_sandboxes(db_session: Session) -> list[Sandbox]:
+    """Get all RUNNING sandboxes (the sweep task's working set)."""
+    stmt = select(Sandbox).where(Sandbox.status == SandboxStatus.RUNNING)
     return list(db_session.execute(stmt).scalars().all())
 
 

--- a/backend/onyx/server/features/build/db/sandbox.py
+++ b/backend/onyx/server/features/build/db/sandbox.py
@@ -4,13 +4,16 @@ import datetime
 from uuid import UUID
 
 from sqlalchemy import func
+from sqlalchemy import or_
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from onyx.auth.pat import hash_pat
+from onyx.db.enums import BuildSessionStatus
 from onyx.db.enums import PatType
 from onyx.db.enums import Permission
 from onyx.db.enums import SandboxStatus
+from onyx.db.models import BuildSession
 from onyx.db.models import PersonalAccessToken
 from onyx.db.models import Sandbox
 from onyx.db.models import Snapshot
@@ -141,6 +144,34 @@ def get_running_sandboxes(db_session: Session) -> list[Sandbox]:
     """Get all RUNNING sandboxes (the sweep task's working set)."""
     stmt = select(Sandbox).where(Sandbox.status == SandboxStatus.RUNNING)
     return list(db_session.execute(stmt).scalars().all())
+
+
+def user_has_stale_active_session(
+    db_session: Session,
+    user_id: UUID,
+    snapshot_cutoff: datetime.datetime,
+) -> bool:
+    """True when any of the user's ACTIVE sessions lacks a snapshot fresher
+    than ``snapshot_cutoff`` — lets the sweep skip the pod round-trip when
+    every session is already covered."""
+    latest_snapshot_at = (
+        select(func.max(Snapshot.created_at))
+        .where(Snapshot.session_id == BuildSession.id)
+        .scalar_subquery()
+    )
+    stmt = (
+        select(BuildSession.id)
+        .where(
+            BuildSession.user_id == user_id,
+            BuildSession.status == BuildSessionStatus.ACTIVE,
+            or_(
+                latest_snapshot_at.is_(None),
+                latest_snapshot_at < snapshot_cutoff,
+            ),
+        )
+        .limit(1)
+    )
+    return db_session.execute(stmt).first() is not None
 
 
 def get_running_sandbox_count_by_tenant(

--- a/backend/onyx/server/features/build/sandbox/tasks/tasks.py
+++ b/backend/onyx/server/features/build/sandbox/tasks/tasks.py
@@ -30,6 +30,7 @@ from onyx.server.features.build.db.sandbox import get_latest_snapshot_for_sessio
 from onyx.server.features.build.db.sandbox import get_running_sandboxes
 from onyx.server.features.build.db.sandbox import get_snapshots_for_session
 from onyx.server.features.build.db.sandbox import update_sandbox_status__no_commit
+from onyx.server.features.build.db.sandbox import user_has_stale_active_session
 from onyx.server.features.build.sandbox.factory import get_sandbox_manager
 from onyx.server.features.build.sandbox.snapshot_manager import SnapshotManager
 
@@ -121,6 +122,15 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
                 idle = _is_idle(sandbox, now)
 
                 try:
+                    # DB-only prefilter: listing workspaces is a pod exec, so
+                    # skip it when every ACTIVE session already has a fresh
+                    # snapshot (idle sandboxes always proceed — they're about
+                    # to be reaped).
+                    if not idle and not user_has_stale_active_session(
+                        db_session, sandbox.user_id, snapshot_cutoff
+                    ):
+                        continue
+
                     if idle and sandbox_manager.supports_opencode_history_persistence:
                         try:
                             sandbox_manager.create_opencode_history_snapshot(
@@ -188,6 +198,8 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
                             )
                             db_session.rollback()
 
+                    # snapshot_failed only gates reap (below); background
+                    # snapshot failures are log-only.
                     if not idle:
                         # Chat history lives outside session workspaces;
                         # keep it equally fresh.

--- a/backend/onyx/server/features/build/sandbox/tasks/tasks.py
+++ b/backend/onyx/server/features/build/sandbox/tasks/tasks.py
@@ -1,5 +1,7 @@
 """Celery tasks for sandbox operations (cleanup, etc.)."""
 
+import datetime
+
 from celery import shared_task
 from celery import Task
 from redis.lock import Lock as RedisLock
@@ -9,14 +11,25 @@ from onyx.background.celery.apps.app_base import task_logger
 from onyx.configs.constants import OnyxCeleryTask
 from onyx.configs.constants import OnyxRedisLocks
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.enums import SandboxStatus
+from onyx.db.models import Sandbox
 from onyx.db.models import Snapshot
+from onyx.file_store.file_store import get_default_file_store
 from onyx.redis.redis_pool import get_redis_client
 from onyx.redis.redis_tenant_work_gating import maybe_mark_tenant_active
 from onyx.server.features.build.configs import SANDBOX_IDLE_TIMEOUT_SECONDS
+from onyx.server.features.build.configs import (
+    SANDBOX_PERIODIC_SNAPSHOT_INTERVAL_SECONDS,
+)
 from onyx.server.features.build.db.build_session import clear_nextjs_ports_for_user
 from onyx.server.features.build.db.build_session import (
     mark_user_sessions_idle__no_commit,
 )
+from onyx.server.features.build.db.sandbox import create_snapshot__no_commit
+from onyx.server.features.build.db.sandbox import get_latest_snapshot_for_session
+from onyx.server.features.build.db.sandbox import get_running_sandboxes
+from onyx.server.features.build.db.sandbox import get_snapshots_for_session
+from onyx.server.features.build.db.sandbox import update_sandbox_status__no_commit
 from onyx.server.features.build.sandbox.factory import get_sandbox_manager
 from onyx.server.features.build.sandbox.snapshot_manager import SnapshotManager
 
@@ -47,6 +60,13 @@ def _prune_prior_session_snapshots(
         db_session.delete(old)
 
 
+def _is_idle(sandbox: Sandbox, now: datetime.datetime) -> bool:
+    """Idle = no heartbeat for the timeout (NULL heartbeat falls back to
+    created_at so legacy/edge-case rows don't sit RUNNING forever)."""
+    reference = sandbox.last_heartbeat or sandbox.created_at
+    return reference < now - datetime.timedelta(seconds=SANDBOX_IDLE_TIMEOUT_SECONDS)
+
+
 @shared_task(
     name=OnyxCeleryTask.CLEANUP_IDLE_SANDBOXES,
     soft_time_limit=TIMEOUT_SECONDS,
@@ -54,17 +74,15 @@ def _prune_prior_session_snapshots(
     ignore_result=True,
 )
 def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa: ARG001
-    """Put idle sandboxes to sleep after snapshotting all sessions.
+    """Sweep RUNNING sandboxes: background-snapshot sessions, sleep idle ones.
 
-    This task:
-    1. Finds sandboxes that have been idle longer than SANDBOX_IDLE_TIMEOUT_SECONDS
-    2. Lists all session directories in the pod's /workspace/sessions/
-    3. Creates a FileStore-backed snapshot of each session's outputs
-    4. Terminates the pod (but keeps the sandbox record)
-    5. Marks the sandbox as SLEEPING (can be restored later)
-
-    Args:
-        tenant_id: The tenant ID for multi-tenant isolation
+    Background snapshots bound data loss from ungraceful pod death (kubelet
+    eviction, node loss, spot reclaim) to
+    ~SANDBOX_PERIODIC_SNAPSHOT_INTERVAL_SECONDS: sessions whose latest
+    snapshot is fresher than the interval are skipped without touching the
+    pod (except at reap — the pod is about to die, so always snapshot).
+    Reap stays fail-closed: snapshot failure on a reachable pod keeps the
+    sandbox RUNNING for retry next sweep.
     """
     task_logger.info(f"cleanup_idle_sandboxes_task starting for tenant {tenant_id}")
 
@@ -80,43 +98,30 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
         return
 
     try:
-        # Import here to avoid circular imports
-        from onyx.db.enums import SandboxStatus
-        from onyx.file_store.file_store import get_default_file_store
-        from onyx.server.features.build.db.sandbox import create_snapshot__no_commit
-        from onyx.server.features.build.db.sandbox import get_idle_sandboxes
-        from onyx.server.features.build.db.sandbox import get_snapshots_for_session
-        from onyx.server.features.build.db.sandbox import (
-            update_sandbox_status__no_commit,
-        )
-
         sandbox_manager = get_sandbox_manager()
         snapshot_manager = SnapshotManager(get_default_file_store())
 
         with get_session_with_current_tenant() as db_session:
-            idle_sandboxes = get_idle_sandboxes(
-                db_session, SANDBOX_IDLE_TIMEOUT_SECONDS
-            )
-
-            if not idle_sandboxes:
-                task_logger.debug("No idle sandboxes found")
+            running_sandboxes = get_running_sandboxes(db_session)
+            if not running_sandboxes:
+                task_logger.debug("No running sandboxes found")
                 return
 
             # Tenant-work-gating hook: refresh this tenant's active-set
-            # membership whenever sandbox cleanup has work to do.
+            # membership whenever the sweep has work to do.
             maybe_mark_tenant_active(tenant_id, caller="sandbox_cleanup")
 
-            task_logger.info(
-                f"Found {len(idle_sandboxes)} idle sandboxes to put to sleep"
+            now = datetime.datetime.now(datetime.timezone.utc)
+            snapshot_cutoff = now - datetime.timedelta(
+                seconds=SANDBOX_PERIODIC_SNAPSHOT_INTERVAL_SECONDS
             )
 
-            for sandbox in idle_sandboxes:
+            for sandbox in running_sandboxes:
                 sandbox_id = sandbox.id
-                sandbox_id_str = str(sandbox_id)
-                task_logger.info(f"Putting sandbox {sandbox_id_str} to sleep")
+                idle = _is_idle(sandbox, now)
 
                 try:
-                    if sandbox_manager.supports_opencode_history_persistence:
+                    if idle and sandbox_manager.supports_opencode_history_persistence:
                         try:
                             sandbox_manager.create_opencode_history_snapshot(
                                 sandbox_id, tenant_id
@@ -125,11 +130,11 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
                             if sandbox_manager.health_check(sandbox_id, timeout=5.0):
                                 task_logger.error(
                                     f"opencode history snapshot failed for sandbox "
-                                    f"{sandbox_id_str}; leaving it RUNNING: {e}"
+                                    f"{sandbox_id}; leaving it RUNNING: {e}"
                                 )
                                 continue
                             task_logger.warning(
-                                f"Sandbox {sandbox_id_str} pod unreachable; sleeping "
+                                f"Sandbox {sandbox_id} pod unreachable; sleeping "
                                 f"without a fresh opencode history snapshot: {e}"
                             )
 
@@ -138,18 +143,21 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
                     # exec; Docker lists container paths via exec; Local
                     # walks the on-disk sessions/ directory.
                     session_ids = sandbox_manager.list_session_workspaces(sandbox_id)
-                    task_logger.info(
-                        f"Found {len(session_ids)} sessions in sandbox {sandbox_id_str}"
-                    )
 
-                    # Snapshot each session; track failures for the fail-closed
-                    # guard below.
                     snapshot_failed = False
+                    snapshots_created = 0
                     for session_id in session_ids:
                         try:
-                            task_logger.debug(
-                                f"Creating snapshot for session {session_id}"
+                            latest = get_latest_snapshot_for_session(
+                                db_session, session_id
                             )
+                            if (
+                                not idle
+                                and latest
+                                and latest.created_at > snapshot_cutoff
+                            ):
+                                continue
+
                             # Capture priors before the new snapshot so we can
                             # prune them once the fresh one lands (keep-latest).
                             prior_snapshots = get_snapshots_for_session(
@@ -168,7 +176,9 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
                                 _prune_prior_session_snapshots(
                                     db_session, snapshot_manager, prior_snapshots
                                 )
-                                task_logger.debug(
+                                db_session.commit()
+                                snapshots_created += 1
+                                task_logger.info(
                                     f"Snapshot created for session {session_id}"
                                 )
                         except Exception as e:
@@ -176,6 +186,27 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
                             task_logger.warning(
                                 f"Failed to create snapshot for session {session_id}: {e}"
                             )
+                            db_session.rollback()
+
+                    if not idle:
+                        # Chat history lives outside session workspaces;
+                        # keep it equally fresh.
+                        if (
+                            snapshots_created
+                            and sandbox_manager.supports_opencode_history_persistence
+                        ):
+                            try:
+                                sandbox_manager.create_opencode_history_snapshot(
+                                    sandbox_id, tenant_id
+                                )
+                            except Exception as e:
+                                task_logger.warning(
+                                    f"Background opencode history snapshot failed "
+                                    f"for sandbox {sandbox_id}: {e}"
+                                )
+                        continue
+
+                    task_logger.info(f"Putting sandbox {sandbox_id} to sleep")
 
                     # Fail-closed: terminating with an unsnapshotted workspace
                     # loses it (restore falls back to a fresh template). Keep the
@@ -185,14 +216,12 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
                     if snapshot_failed:
                         if sandbox_manager.health_check(sandbox_id, timeout=5.0):
                             task_logger.error(
-                                f"Snapshot failed for sandbox {sandbox_id_str}; "
+                                f"Snapshot failed for sandbox {sandbox_id}; "
                                 f"leaving it RUNNING to retry next cycle"
                             )
-                            # Drop this sandbox's uncommitted snapshot rows.
-                            db_session.rollback()
                             continue
                         task_logger.warning(
-                            f"Sandbox {sandbox_id_str} pod is unreachable; "
+                            f"Sandbox {sandbox_id} pod is unreachable; "
                             f"terminating despite snapshot failure (cannot recover "
                             f"its workspace, won't pin it RUNNING forever)"
                         )
@@ -218,11 +247,11 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
                         db_session, sandbox_id, SandboxStatus.SLEEPING
                     )
                     db_session.commit()
-                    task_logger.info(f"Sandbox {sandbox_id_str} is now sleeping")
+                    task_logger.info(f"Sandbox {sandbox_id} is now sleeping")
 
                 except Exception as e:
                     task_logger.error(
-                        f"Failed to put sandbox {sandbox_id_str} to sleep: {e}",
+                        f"Failed to sweep sandbox {sandbox_id}: {e}",
                         exc_info=True,
                     )
                     db_session.rollback()

--- a/backend/onyx/server/features/build/sandbox/tasks/tasks.py
+++ b/backend/onyx/server/features/build/sandbox/tasks/tasks.py
@@ -18,9 +18,6 @@ from onyx.file_store.file_store import get_default_file_store
 from onyx.redis.redis_pool import get_redis_client
 from onyx.redis.redis_tenant_work_gating import maybe_mark_tenant_active
 from onyx.server.features.build.configs import SANDBOX_IDLE_TIMEOUT_SECONDS
-from onyx.server.features.build.configs import (
-    SANDBOX_PERIODIC_SNAPSHOT_INTERVAL_SECONDS,
-)
 from onyx.server.features.build.db.build_session import clear_nextjs_ports_for_user
 from onyx.server.features.build.db.build_session import (
     mark_user_sessions_idle__no_commit,
@@ -36,6 +33,11 @@ from onyx.server.features.build.sandbox.snapshot_manager import SnapshotManager
 
 # 100 minutes - snapshotting can take time
 TIMEOUT_SECONDS = 6000
+
+# Background snapshots ride the idle timeout: a session is re-snapshotted when
+# its latest snapshot is older than idle_timeout/4 (15 min at the default 1h),
+# so the data-loss bound scales with the pace of sandboxes going to sleep.
+SNAPSHOT_INTERVAL_DIVISOR = 4
 
 
 def _prune_prior_session_snapshots(
@@ -78,10 +80,10 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
     """Sweep RUNNING sandboxes: background-snapshot sessions, sleep idle ones.
 
     Background snapshots bound data loss from ungraceful pod death (kubelet
-    eviction, node loss, spot reclaim) to
-    ~SANDBOX_PERIODIC_SNAPSHOT_INTERVAL_SECONDS: sessions whose latest
-    snapshot is fresher than the interval are skipped without touching the
-    pod (except at reap — the pod is about to die, so always snapshot).
+    eviction, node loss, spot reclaim) to ~idle_timeout/SNAPSHOT_INTERVAL_DIVISOR:
+    sessions whose latest snapshot is fresher than that interval are skipped
+    without touching the pod (except at reap — the pod is about to die, so
+    always snapshot).
     Reap stays fail-closed: snapshot failure on a reachable pod keeps the
     sandbox RUNNING for retry next sweep.
     """
@@ -114,7 +116,7 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
 
             now = datetime.datetime.now(datetime.timezone.utc)
             snapshot_cutoff = now - datetime.timedelta(
-                seconds=SANDBOX_PERIODIC_SNAPSHOT_INTERVAL_SECONDS
+                seconds=SANDBOX_IDLE_TIMEOUT_SECONDS // SNAPSHOT_INTERVAL_DIVISOR
             )
 
             for sandbox in running_sandboxes:

--- a/backend/onyx/server/features/build/sandbox/tasks/tasks.py
+++ b/backend/onyx/server/features/build/sandbox/tasks/tasks.py
@@ -61,7 +61,7 @@ def _prune_prior_session_snapshots(
         db_session.delete(old)
 
 
-def _is_idle(sandbox: Sandbox, now: datetime.datetime) -> bool:
+def is_sandbox_idle(sandbox: Sandbox, now: datetime.datetime) -> bool:
     """Idle = no heartbeat for the timeout (NULL heartbeat falls back to
     created_at so legacy/edge-case rows don't sit RUNNING forever)."""
     reference = sandbox.last_heartbeat or sandbox.created_at
@@ -119,7 +119,7 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
 
             for sandbox in running_sandboxes:
                 sandbox_id = sandbox.id
-                idle = _is_idle(sandbox, now)
+                idle = is_sandbox_idle(sandbox, now)
 
                 try:
                     # DB-only prefilter: listing workspaces is a pod exec, so

--- a/backend/tests/external_dependency_unit/craft/test_background_snapshots.py
+++ b/backend/tests/external_dependency_unit/craft/test_background_snapshots.py
@@ -210,7 +210,10 @@ def test_stale_session_defeats_prefilter(
     fresh = _make_session(db_session, user)
     stale = _make_session(db_session, user)
     _add_snapshot(db_session, fresh.id, age_seconds=10)
-    interval = tasks_module.SANDBOX_PERIODIC_SNAPSHOT_INTERVAL_SECONDS
+    interval = (
+        tasks_module.SANDBOX_IDLE_TIMEOUT_SECONDS
+        // tasks_module.SNAPSHOT_INTERVAL_DIVISOR
+    )
     _add_snapshot(db_session, stale.id, age_seconds=interval * 2)
 
     stubbed_sweep.list_session_workspaces_returns = [fresh.id, stale.id]
@@ -240,7 +243,10 @@ def test_stale_snapshot_resnapshotted_and_priors_pruned(
     sandbox = make_sandbox(db_session, user)
     session_row = _make_session(db_session, user)
 
-    interval = tasks_module.SANDBOX_PERIODIC_SNAPSHOT_INTERVAL_SECONDS
+    interval = (
+        tasks_module.SANDBOX_IDLE_TIMEOUT_SECONDS
+        // tasks_module.SNAPSHOT_INTERVAL_DIVISOR
+    )
     prior = _add_snapshot(db_session, session_row.id, age_seconds=interval * 2)
     prior_path = prior.storage_path
 

--- a/backend/tests/external_dependency_unit/craft/test_background_snapshots.py
+++ b/backend/tests/external_dependency_unit/craft/test_background_snapshots.py
@@ -186,17 +186,46 @@ def test_fresh_snapshot_skipped_by_age_gate(
     stubbed_sweep: StubSandboxManager,
 ) -> None:
     """Sessions whose latest snapshot is newer than the interval are skipped
-    without any pod traffic."""
+    without any pod traffic — the DB prefilter even skips the workspace
+    listing exec."""
     user = make_user(db_session)
     make_sandbox(db_session, user)
     session_row = _make_session(db_session, user)
     _add_snapshot(db_session, session_row.id, age_seconds=10)
 
-    stubbed_sweep.list_session_workspaces_returns = [session_row.id]
+    cleanup_idle_sandboxes_task.run(tenant_id=TEST_TENANT_ID)
+
+    assert stubbed_sweep.list_session_workspaces_count == 0
+    assert stubbed_sweep.create_snapshot_count == 0
+
+
+def test_stale_session_defeats_prefilter(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+    stubbed_sweep: StubSandboxManager,
+) -> None:
+    """One stale session among fresh ones is enough to reach the pod."""
+    user = make_user(db_session)
+    make_sandbox(db_session, user)
+    fresh = _make_session(db_session, user)
+    stale = _make_session(db_session, user)
+    _add_snapshot(db_session, fresh.id, age_seconds=10)
+    interval = tasks_module.SANDBOX_PERIODIC_SNAPSHOT_INTERVAL_SECONDS
+    _add_snapshot(db_session, stale.id, age_seconds=interval * 2)
+
+    stubbed_sweep.list_session_workspaces_returns = [fresh.id, stale.id]
+    stubbed_sweep.create_snapshot_returns = SnapshotResult(
+        storage_path=f"s3://snapshots/{uuid4()}.tar.gz",
+        size_bytes=55,
+    )
 
     cleanup_idle_sandboxes_task.run(tenant_id=TEST_TENANT_ID)
 
-    assert stubbed_sweep.create_snapshot_count == 0
+    assert stubbed_sweep.list_session_workspaces_count == 1
+    # The per-session age gate still protects the fresh session.
+    assert stubbed_sweep.create_snapshot_count == 1
+    assert stubbed_sweep.last_create_snapshot_payload is not None
+    assert stubbed_sweep.last_create_snapshot_payload["session_id"] == stale.id
 
 
 def test_stale_snapshot_resnapshotted_and_priors_pruned(

--- a/backend/tests/external_dependency_unit/craft/test_background_snapshots.py
+++ b/backend/tests/external_dependency_unit/craft/test_background_snapshots.py
@@ -1,0 +1,292 @@
+"""Background snapshot behavior of the sandbox sweep (Celery task).
+
+Exercises the snapshot half of ``cleanup_idle_sandboxes_task`` — non-idle
+RUNNING sandboxes get their changed sessions snapshotted in place — end-to-end
+against real Postgres + Redis. Sandbox operations (``list_session_workspaces``,
+``create_snapshot``) are routed through the ``StubSandboxManager`` from
+``conftest.py``.
+
+For sandboxes that are NOT idle, the sweep must never terminate pods or
+change sandbox/session status — it only bounds data loss from ungraceful pod
+death (kubelet eviction, node loss). The reap half is covered by
+``test_idle_cleanup.py``.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+from collections.abc import Generator
+from uuid import UUID
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import update
+from sqlalchemy.orm import Session
+
+from onyx.configs.constants import OnyxRedisLocks
+from onyx.db.enums import BuildSessionStatus
+from onyx.db.enums import SandboxStatus
+from onyx.db.models import BuildSession
+from onyx.db.models import Sandbox
+from onyx.db.models import Snapshot
+from onyx.db.models import User
+from onyx.redis.redis_pool import get_redis_client
+from onyx.server.features.build.sandbox.models import SnapshotResult
+from onyx.server.features.build.sandbox.tasks import tasks as tasks_module
+from onyx.server.features.build.sandbox.tasks.tasks import cleanup_idle_sandboxes_task
+from tests.external_dependency_unit.constants import TEST_TENANT_ID
+from tests.external_dependency_unit.craft._test_helpers import make_sandbox
+from tests.external_dependency_unit.craft._test_helpers import make_user
+from tests.external_dependency_unit.craft.stubs import StubSandboxManager
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+class _FakeSnapshotManager:
+    """Records blob deletes instead of hitting the real file store."""
+
+    def __init__(self) -> None:
+        self.deleted_paths: list[str] = []
+
+    def delete_snapshot(self, storage_path: str) -> None:
+        self.deleted_paths.append(storage_path)
+
+
+@pytest.fixture
+def fake_snapshot_manager(monkeypatch: pytest.MonkeyPatch) -> _FakeSnapshotManager:
+    fake = _FakeSnapshotManager()
+    monkeypatch.setattr(tasks_module, "SnapshotManager", lambda _file_store: fake)
+    monkeypatch.setattr(tasks_module, "get_default_file_store", lambda: None)
+    return fake
+
+
+@pytest.fixture
+def stubbed_sweep(
+    stub_sandbox_manager: StubSandboxManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> StubSandboxManager:
+    """Wire the stub so the sweep runs entirely against it."""
+    monkeypatch.setattr(
+        tasks_module, "get_sandbox_manager", lambda: stub_sandbox_manager
+    )
+    return stub_sandbox_manager
+
+
+@pytest.fixture(autouse=True)
+def _quiesce_leaked_sandboxes(db_session: Session) -> None:
+    """Terminate RUNNING sandboxes leaked by earlier tests.
+
+    The sweep covers ALL RUNNING sandboxes globally, so rows committed by
+    other tests in this directory would otherwise leak into our assertions.
+    """
+    db_session.execute(
+        update(Sandbox)
+        .where(Sandbox.status == SandboxStatus.RUNNING)
+        .values(status=SandboxStatus.TERMINATED)
+    )
+    db_session.commit()
+
+
+@pytest.fixture(autouse=True)
+def _isolated_redis_lock() -> Generator[None, None, None]:
+    """Make sure the sweep beat lock is free before + after."""
+    redis_client = get_redis_client(tenant_id=TEST_TENANT_ID)
+    redis_client.delete(OnyxRedisLocks.CLEANUP_IDLE_SANDBOXES_BEAT_LOCK)
+    try:
+        yield
+    finally:
+        redis_client.delete(OnyxRedisLocks.CLEANUP_IDLE_SANDBOXES_BEAT_LOCK)
+
+
+def _make_session(db_session: Session, user: User) -> BuildSession:
+    session_row = BuildSession(
+        user_id=user.id,
+        name="background-snapshot-session",
+        status=BuildSessionStatus.ACTIVE,
+    )
+    db_session.add(session_row)
+    db_session.commit()
+    db_session.refresh(session_row)
+    return session_row
+
+
+def _add_snapshot(
+    db_session: Session,
+    session_id: UUID,
+    *,
+    age_seconds: int,
+) -> Snapshot:
+    """Insert a snapshot row backdated by ``age_seconds``."""
+    snapshot = Snapshot(
+        session_id=session_id,
+        storage_path=f"sandbox-snapshots/test/{uuid4()}.tar.gz",
+        size_bytes=100,
+    )
+    db_session.add(snapshot)
+    db_session.commit()
+    db_session.execute(
+        update(Snapshot)
+        .where(Snapshot.id == snapshot.id)
+        .values(
+            created_at=datetime.datetime.now(datetime.timezone.utc)
+            - datetime.timedelta(seconds=age_seconds)
+        )
+    )
+    db_session.commit()
+    db_session.refresh(snapshot)
+    return snapshot
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_running_sandbox_snapshotted_without_termination(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+    stubbed_sweep: StubSandboxManager,
+) -> None:
+    """Happy path: snapshot is recorded; pod and statuses are untouched."""
+    user = make_user(db_session)
+    sandbox = make_sandbox(db_session, user)
+    session_row = _make_session(db_session, user)
+    db_session.commit()
+
+    stubbed_sweep.list_session_workspaces_returns = [session_row.id]
+    stubbed_sweep.create_snapshot_returns = SnapshotResult(
+        storage_path=f"s3://snapshots/{sandbox.id}/{uuid4()}.tar.gz",
+        size_bytes=4321,
+    )
+
+    cleanup_idle_sandboxes_task.run(tenant_id=TEST_TENANT_ID)
+
+    db_session.expire_all()
+    snapshots = (
+        db_session.query(Snapshot).filter(Snapshot.session_id == session_row.id).all()
+    )
+    assert len(snapshots) == 1
+    assert snapshots[0].size_bytes == 4321
+
+    refreshed = db_session.get(Sandbox, sandbox.id)
+    assert refreshed is not None
+    assert refreshed.status == SandboxStatus.RUNNING
+    refreshed_session = db_session.get(BuildSession, session_row.id)
+    assert refreshed_session is not None
+    assert refreshed_session.status == BuildSessionStatus.ACTIVE
+    assert stubbed_sweep.terminate_count == 0
+
+
+def test_fresh_snapshot_skipped_by_age_gate(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+    stubbed_sweep: StubSandboxManager,
+) -> None:
+    """Sessions whose latest snapshot is newer than the interval are skipped
+    without any pod traffic."""
+    user = make_user(db_session)
+    make_sandbox(db_session, user)
+    session_row = _make_session(db_session, user)
+    _add_snapshot(db_session, session_row.id, age_seconds=10)
+
+    stubbed_sweep.list_session_workspaces_returns = [session_row.id]
+
+    cleanup_idle_sandboxes_task.run(tenant_id=TEST_TENANT_ID)
+
+    assert stubbed_sweep.create_snapshot_count == 0
+
+
+def test_stale_snapshot_resnapshotted_and_priors_pruned(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+    stubbed_sweep: StubSandboxManager,
+    fake_snapshot_manager: _FakeSnapshotManager,
+) -> None:
+    """A stale session is re-snapshotted; prune-on-write keeps only the
+    latest (prior blob deleted first, then its row)."""
+    user = make_user(db_session)
+    sandbox = make_sandbox(db_session, user)
+    session_row = _make_session(db_session, user)
+
+    interval = tasks_module.SANDBOX_PERIODIC_SNAPSHOT_INTERVAL_SECONDS
+    prior = _add_snapshot(db_session, session_row.id, age_seconds=interval * 2)
+    prior_path = prior.storage_path
+
+    stubbed_sweep.list_session_workspaces_returns = [session_row.id]
+    stubbed_sweep.create_snapshot_returns = SnapshotResult(
+        storage_path=f"s3://snapshots/{sandbox.id}/{uuid4()}.tar.gz",
+        size_bytes=999,
+    )
+
+    cleanup_idle_sandboxes_task.run(tenant_id=TEST_TENANT_ID)
+
+    assert stubbed_sweep.create_snapshot_count == 1
+    db_session.expire_all()
+    snapshots = (
+        db_session.query(Snapshot).filter(Snapshot.session_id == session_row.id).all()
+    )
+    assert len(snapshots) == 1
+    assert snapshots[0].size_bytes == 999
+    assert fake_snapshot_manager.deleted_paths == [prior_path]
+
+
+def test_snapshot_failure_continues_other_sessions(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+    stubbed_sweep: StubSandboxManager,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A failing ``create_snapshot`` is logged and the sweep continues."""
+    user = make_user(db_session)
+    make_sandbox(db_session, user)
+    session_a = _make_session(db_session, user)
+    session_b = _make_session(db_session, user)
+
+    stubbed_sweep.list_session_workspaces_returns = [session_a.id, session_b.id]
+
+    real_result = SnapshotResult(
+        storage_path=f"s3://snapshots/{uuid4()}.tar.gz", size_bytes=55
+    )
+
+    def _snapshot(
+        _sandbox_id: object, session_id: object, _tenant_id: object
+    ) -> SnapshotResult:
+        if session_id == session_a.id:
+            raise RuntimeError("FileStore unreachable")
+        return real_result
+
+    monkeypatch.setattr(stubbed_sweep, "create_snapshot", _snapshot)
+
+    with caplog.at_level(logging.WARNING):
+        cleanup_idle_sandboxes_task.run(tenant_id=TEST_TENANT_ID)
+
+    db_session.expire_all()
+    snapshots_a = (
+        db_session.query(Snapshot).filter(Snapshot.session_id == session_a.id).all()
+    )
+    snapshots_b = (
+        db_session.query(Snapshot).filter(Snapshot.session_id == session_b.id).all()
+    )
+    assert snapshots_a == []
+    assert len(snapshots_b) == 1
+    assert any("Failed to create snapshot" in r.getMessage() for r in caplog.records)
+
+
+def test_no_running_sandboxes_is_a_noop(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+    stubbed_sweep: StubSandboxManager,
+) -> None:
+    """SLEEPING sandboxes are never swept."""
+    user = make_user(db_session)
+    make_sandbox(db_session, user, status=SandboxStatus.SLEEPING)
+    db_session.commit()
+
+    cleanup_idle_sandboxes_task.run(tenant_id=TEST_TENANT_ID)
+
+    assert stubbed_sweep.list_session_workspaces_count == 0
+    assert stubbed_sweep.create_snapshot_count == 0

--- a/backend/tests/external_dependency_unit/craft/test_idle_cleanup.py
+++ b/backend/tests/external_dependency_unit/craft/test_idle_cleanup.py
@@ -15,6 +15,7 @@ import logging
 from collections.abc import Generator
 
 import pytest
+from sqlalchemy import update
 from sqlalchemy.orm import Session
 
 from onyx.configs.constants import OnyxRedisLocks
@@ -68,6 +69,21 @@ def short_idle_threshold(monkeypatch: pytest.MonkeyPatch) -> int:
     threshold = 60
     monkeypatch.setattr(tasks_module, "SANDBOX_IDLE_TIMEOUT_SECONDS", threshold)
     return threshold
+
+
+@pytest.fixture(autouse=True)
+def _quiesce_leaked_sandboxes(db_session: Session) -> None:
+    """Terminate RUNNING sandboxes leaked by earlier tests.
+
+    The sweep covers ALL RUNNING sandboxes globally, so rows committed by
+    other tests in this directory would otherwise leak into our assertions.
+    """
+    db_session.execute(
+        update(Sandbox)
+        .where(Sandbox.status == SandboxStatus.RUNNING)
+        .values(status=SandboxStatus.TERMINATED)
+    )
+    db_session.commit()
 
 
 @pytest.fixture(autouse=True)
@@ -178,6 +194,10 @@ def test_active_sandbox_within_threshold_not_touched(
     # Heartbeat half the threshold ago -> not idle.
     _backdate_heartbeat(db_session, sandbox, seconds_ago=short_idle_threshold // 2)
 
+    # Non-idle sandboxes still get the background-snapshot sweep; an empty
+    # workspace listing makes it a no-op so we can assert "not touched".
+    stubbed_cleanup.list_session_workspaces_returns = []
+
     cleanup_idle_sandboxes_task.run(tenant_id=TEST_TENANT_ID)
 
     db_session.expire_all()
@@ -198,7 +218,7 @@ def test_null_heartbeat_sandbox_past_created_at_included(
     """NULL heartbeat + ``created_at`` past threshold -> swept.
 
     Regression net for SHA ``eba89fa635`` — the OR-branch in
-    ``get_idle_sandboxes`` that handles legacy rows / edge cases.
+    the idle check that handles legacy rows / edge cases.
     """
     user = make_user(db_session)
     sandbox = make_sandbox(db_session, user)

--- a/backend/tests/external_dependency_unit/craft/test_sandbox_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_sandbox_lifecycle.py
@@ -2,7 +2,7 @@
 
 DB-bound tests that pin the sandbox state machine: PROVISIONING → RUNNING,
 provision failures rolling back the row, idempotent provisioning, the
-health-check failure -> re-provision recovery path, the ``get_idle_sandboxes``
+health-check failure -> re-provision recovery path, the idle-selection
 query shape, and the Redis lock that serializes concurrent provision
 attempts for the same user.
 
@@ -30,9 +30,10 @@ from onyx.redis.redis_pool import get_redis_client
 from onyx.server.features.build.api.sessions_api import restore_session
 from onyx.server.features.build.db.sandbox import create_sandbox__no_commit
 from onyx.server.features.build.db.sandbox import create_snapshot__no_commit
-from onyx.server.features.build.db.sandbox import get_idle_sandboxes
+from onyx.server.features.build.db.sandbox import get_running_sandboxes
 from onyx.server.features.build.sandbox.models import FilesystemEntry
 from onyx.server.features.build.sandbox.models import SandboxInfo
+from onyx.server.features.build.sandbox.tasks.tasks import _is_idle
 from onyx.server.features.build.session.manager import SessionManager
 from onyx.server.features.build.session.sandbox_lifecycle import provision_sandbox
 from tests.external_dependency_unit.constants import TEST_TENANT_ID
@@ -421,9 +422,8 @@ class TestIdleCleanupSelection:
         ) - datetime.timedelta(hours=2)
         db_session.commit()
 
-        idle = get_idle_sandboxes(db_session, idle_threshold_seconds=3600)
-
-        idle_ids = {s.id for s in idle}
+        now = datetime.datetime.now(datetime.timezone.utc)
+        idle_ids = {s.id for s in get_running_sandboxes(db_session) if _is_idle(s, now)}
         assert row.id in idle_ids
 
     def test_idle_cleanup_excludes_sandbox_within_threshold(
@@ -439,9 +439,9 @@ class TestIdleCleanupSelection:
         ) - datetime.timedelta(minutes=30)
         db_session.commit()
 
-        idle = get_idle_sandboxes(db_session, idle_threshold_seconds=3600)
-
-        assert row.id not in {s.id for s in idle}
+        now = datetime.datetime.now(datetime.timezone.utc)
+        idle_ids = {s.id for s in get_running_sandboxes(db_session) if _is_idle(s, now)}
+        assert row.id not in idle_ids
 
 
 # NOTE: ``test_idle_cleanup_marks_sandbox_sleeping_and_sessions_idle`` was

--- a/backend/tests/external_dependency_unit/craft/test_sandbox_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_sandbox_lifecycle.py
@@ -33,7 +33,7 @@ from onyx.server.features.build.db.sandbox import create_snapshot__no_commit
 from onyx.server.features.build.db.sandbox import get_running_sandboxes
 from onyx.server.features.build.sandbox.models import FilesystemEntry
 from onyx.server.features.build.sandbox.models import SandboxInfo
-from onyx.server.features.build.sandbox.tasks.tasks import _is_idle
+from onyx.server.features.build.sandbox.tasks.tasks import is_sandbox_idle
 from onyx.server.features.build.session.manager import SessionManager
 from onyx.server.features.build.session.sandbox_lifecycle import provision_sandbox
 from tests.external_dependency_unit.constants import TEST_TENANT_ID
@@ -423,7 +423,9 @@ class TestIdleCleanupSelection:
         db_session.commit()
 
         now = datetime.datetime.now(datetime.timezone.utc)
-        idle_ids = {s.id for s in get_running_sandboxes(db_session) if _is_idle(s, now)}
+        idle_ids = {
+            s.id for s in get_running_sandboxes(db_session) if is_sandbox_idle(s, now)
+        }
         assert row.id in idle_ids
 
     def test_idle_cleanup_excludes_sandbox_within_threshold(
@@ -440,7 +442,9 @@ class TestIdleCleanupSelection:
         db_session.commit()
 
         now = datetime.datetime.now(datetime.timezone.utc)
-        idle_ids = {s.id for s in get_running_sandboxes(db_session) if _is_idle(s, now)}
+        idle_ids = {
+            s.id for s in get_running_sandboxes(db_session) if is_sandbox_idle(s, now)
+        }
         assert row.id not in idle_ids
 
 


### PR DESCRIPTION
> Draft — split out of #11921 per discussion; the prevention half (ephemeral-storage requests) ships first, this bounds data loss when prevention fails. Holding until we decide we need it.

## Description

Graceful idle-sleep is the only snapshot path, so any ungraceful pod death (kubelet eviction, node loss, OOM, spot reclaim) loses **everything since the last sleep** — for an actively used sandbox that's hours of work, and for a never-slept sandbox it's everything. This was the data-loss half of the st-dev incident on 2026-06-09 (session `59d474d4` had no snapshot row at wake; the workspace came back as a fresh template).

`cleanup_idle_sandboxes_task` becomes a unified sweep over RUNNING sandboxes: background-snapshot sessions in place, then put idle ones to sleep — bounding ungraceful-death loss to ~`SANDBOX_PERIODIC_SNAPSHOT_INTERVAL_SECONDS` (default 30 min; ~40 min effective in cloud after the beat multiplier).

- Beat cadence moves 15 → 5 min; an age gate (skip sessions whose latest snapshot is fresher than the interval — not applied at reap) keeps ticks cheap.
- Composes with #12002's prune-on-write: every background snapshot prunes the session's priors, so storage stays at exactly one snapshot per session. Redundant re-uploads of unchanged sessions are bounded by the idle timeout (a session gets at most ~2 background snapshots before its sandbox is reaped).
- #11922's opencode chat-history snapshot keeps its fail-closed role at reap; background ticks refresh it whenever they captured at least one session snapshot, so chat history shares the same data-loss bound.
- Reap semantics are unchanged: fail-closed snapshot guard, port clearing, session idling, SLEEPING transition. `get_idle_sandboxes` is replaced by an inline idle check over the RUNNING set the sweep already fetches; dead `get_sandbox_by_session_id` removed.

Worker restart required (no new task — same `cleanup_idle_sandboxes` name and lock, so rolling deploys are safe).

## How Has This Been Tested?

- External-dependency-unit tests (real Postgres + Redis): new `test_background_snapshots.py` (happy path without termination, age gate, stale re-snapshot + prune-on-write keep-latest, per-session failure isolation, sleeping sandboxes untouched), `test_idle_cleanup.py` (reap half incl. fail-closed, adapted to the unified sweep), `test_sandbox_lifecycle.py` idle-selection tests rewritten against the inline idle check — 50 passed alongside #12002's prune unit test.
- Live end-to-end on the kind cluster (`./scripts/run-all-k8s.sh`, real pods/MinIO/celery), run on an earlier equivalent of this sweep: background snapshot of a real 833MB workspace → ~519KB archive; idle reap → terminate → SLEEPING → wake restores the edit; **eviction simulation**: work captured by a background snapshot survived `kubectl delete --grace-period=0 --force` and was restored on wake; celery beat fired the sweep at the 5-minute mark through the sandbox queue.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Background snapshots now run during the idle sweep for RUNNING sandboxes to cap ungraceful-death data loss to ~idle_timeout/4 (~15m by default). The sweep snapshots changed sessions in place and only sleeps sandboxes that are idle, with a DB prefilter and per-session age gate to avoid pod execs.

- **New Features**
  - Sweep RUNNING sandboxes: snapshot changed sessions, then sleep idle ones.
  - Interval derived from `SANDBOX_IDLE_TIMEOUT_SECONDS/4`; 1‑min beat (cloud x8 ≈ ~8m). Reap always snapshots before sleep; loss bound ~15m default.
  - Keep-one-per-session (prune on write); opencode chat history refreshed when snapshots are taken.

- **Refactors**
  - Inline idle check over RUNNING set; removed `get_idle_sandboxes` and `get_sandbox_by_session_id`; exported `is_sandbox_idle` for tests.
  - DB-only prefilter skips workspace listing when all ACTIVE sessions have fresh snapshots; added background-snapshot tests; updated unified sweep tests.
  - Reap semantics unchanged (fail-closed guard, port clearing, SLEEPING). Same task name/lock for safe rolling deploys.

<sup>Written for commit 2d0af3416e1b3a4447b9c467870de8832ddbf660. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

