### PR TITLE
feat(agent-sharing): ownership and transfer - 3/7

### DIFF
--- a/backend/ee/onyx/db/persona.py
+++ b/backend/ee/onyx/db/persona.py
@@ -5,6 +5,8 @@ from sqlalchemy.orm import Session
 from onyx.db.enums import PersonaSharePermission
 from onyx.db.models import Persona
 from onyx.db.models import Persona__UserGroup
+from onyx.db.models import User
+from onyx.db.persona import _transfer_persona_ownership
 from onyx.db.persona import apply_persona_user_share_diff
 from onyx.db.persona import mark_persona_user_files_for_sync
 from onyx.db.persona import resolve_desired_user_shares
@@ -111,3 +113,20 @@ def update_persona_access(
     # When sharing changes, user file ACLs need to be updated in the vector DB
     if needs_sync:
         mark_persona_user_files_for_sync(persona_id, db_session)
+
+
+def transfer_persona_ownership(
+    persona_id: int,
+    user: User,
+    db_session: Session,
+    new_owner_user_id: UUID | None = None,
+    new_owner_group_id: int | None = None,
+) -> None:
+    """EE version: additionally allows transferring ownership to a group."""
+    _transfer_persona_ownership(
+        persona_id=persona_id,
+        user=user,
+        db_session=db_session,
+        new_owner_user_id=new_owner_user_id,
+        new_owner_group_id=new_owner_group_id,
+    )

--- a/backend/ee/onyx/db/user_group.py
+++ b/backend/ee/onyx/db/user_group.py
@@ -32,6 +32,7 @@ from onyx.db.models import FederatedConnector__DocumentSet
 from onyx.db.models import LLMProvider__UserGroup
 from onyx.db.models import PermissionGrant
 from onyx.db.models import Persona
+from onyx.db.models import Persona__User
 from onyx.db.models import Persona__UserGroup
 from onyx.db.models import TokenRateLimit__UserGroup
 from onyx.db.models import User
@@ -90,6 +91,26 @@ def _cleanup_persona__user_group_relationships__no_commit(
     db_session.query(Persona__UserGroup).filter(
         Persona__UserGroup.user_group_id == user_group_id
     ).delete(synchronize_session=False)
+
+
+def _handle_owned_personas_for_group_deletion__no_commit(
+    db_session: Session, user_group_id: int
+) -> None:
+    """Personas owned by the group: otherwise-private ones die with it;
+    shared/public ones are orphaned (ownerless ⇒ managed by admins).
+
+    NOTE: does not commit the transaction."""
+    owned_personas = (
+        db_session.query(Persona).filter(Persona.owner_group_id == user_group_id).all()
+    )
+    for persona in owned_personas:
+        if (
+            not persona.is_public
+            and not persona.user_shares
+            and not persona.group_shares
+        ):
+            persona.deleted = True
+        persona.owner_group_id = None
 
 
 def _cleanup_token_rate_limit__user_group_relationships__no_commit(
@@ -252,6 +273,11 @@ def _add_user_group_snapshot_eager_loads(
             selectinload(Persona.user_files),
             selectinload(Persona.users),
             selectinload(Persona.groups),
+            selectinload(Persona.owner_group),
+            selectinload(Persona.user_shares).selectinload(Persona__User.user),
+            selectinload(Persona.group_shares).selectinload(
+                Persona__UserGroup.user_group
+            ),
         ),
     )
 
@@ -900,6 +926,9 @@ def prepare_user_group_for_deletion(db_session: Session, user_group_id: int) -> 
         db_session=db_session, user_group_id=user_group_id
     )
     _cleanup_persona__user_group_relationships__no_commit(
+        db_session=db_session, user_group_id=user_group_id
+    )
+    _handle_owned_personas_for_group_deletion__no_commit(
         db_session=db_session, user_group_id=user_group_id
     )
     _cleanup_user_group__cc_pair_relationships__no_commit(

--- a/backend/ee/onyx/db/user_group.py
+++ b/backend/ee/onyx/db/user_group.py
@@ -101,7 +101,13 @@ def _handle_owned_personas_for_group_deletion__no_commit(
 
     NOTE: does not commit the transaction."""
     owned_personas = (
-        db_session.query(Persona).filter(Persona.owner_group_id == user_group_id).all()
+        db_session.query(Persona)
+        .options(
+            selectinload(Persona.user_shares),
+            selectinload(Persona.group_shares),
+        )
+        .filter(Persona.owner_group_id == user_group_id)
+        .all()
     )
     for persona in owned_personas:
         if (

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -621,6 +621,10 @@ def _transfer_persona_ownership(
         )
         if group is None:
             raise ValueError("New owner group not found")
+        # A group whose deletion is already in flight would re-orphan the agent
+        # as soon as its sync worker runs.
+        if group.is_up_for_deletion:
+            raise ValueError("New owner group is being deleted")
         if group.id == prev_owner_group_id:
             raise ValueError("This group already owns the agent")
         persona.owner_group_id = group.id

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -22,6 +22,7 @@ from onyx.configs.constants import DEFAULT_PERSONA_ID
 from onyx.configs.constants import NotificationType
 from onyx.db.constants import SLACK_BOT_PERSONA_PREFIX
 from onyx.db.document_access import get_accessible_documents_by_ids
+from onyx.db.enums import AccountType
 from onyx.db.enums import PersonaSharePermission
 from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import Document
@@ -41,6 +42,7 @@ from onyx.db.models import UserGroup
 from onyx.db.notification import create_notification
 from onyx.db.persona_sharing import get_persona_access_level
 from onyx.db.persona_sharing import get_user_group_ids_for_user
+from onyx.db.persona_sharing import persona_ownership_is_vacant
 from onyx.server.features.persona.models import FullPersonaSnapshot
 from onyx.server.features.persona.models import MinimalPersonaSnapshot
 from onyx.server.features.persona.models import PersonaSharedNotificationData
@@ -539,6 +541,183 @@ def update_persona_public_status(
         raise ValueError("You don't have permission to modify this persona")
 
     persona.is_public = is_public
+    mark_persona_user_files_for_sync(persona_id, db_session)
+    db_session.commit()
+
+
+def user_can_transfer_persona(
+    persona: Persona, user: User, db_session: Session
+) -> bool:
+    """Only the owner may transfer; admins may transfer vacant personas."""
+    if persona.user_id is not None:
+        if persona.user_id == user.id:
+            return True
+    elif persona.owner_group_id is not None:
+        if persona.owner_group_id in get_user_group_ids_for_user(db_session, user.id):
+            return True
+    return user.role == UserRole.ADMIN and persona_ownership_is_vacant(persona)
+
+
+def _validate_transfer_target_user(target: User) -> None:
+    if not target.is_active:
+        raise ValueError("Ownership can only be transferred to an active user")
+    if target.role in [UserRole.SLACK_USER, UserRole.EXT_PERM_USER, UserRole.LIMITED]:
+        raise ValueError("Ownership cannot be transferred to this account type")
+    if target.account_type is not None and target.account_type != AccountType.STANDARD:
+        raise ValueError("Ownership cannot be transferred to bots or service accounts")
+
+
+def _transfer_persona_ownership(
+    persona_id: int,
+    user: User,
+    db_session: Session,
+    new_owner_user_id: UUID | None,
+    new_owner_group_id: int | None,
+) -> None:
+    """Shared MIT/EE transfer core. Demotes the previous owner to an EDITOR
+    share row (upsert) and removes the new owner's share row, all in one
+    transaction."""
+    if (new_owner_user_id is None) == (new_owner_group_id is None):
+        raise ValueError("Exactly one of a user or a group must be the new owner")
+
+    persona = (
+        db_session.query(Persona)
+        .filter(Persona.id == persona_id, Persona.deleted.is_(False))
+        .one_or_none()
+    )
+    if persona is None:
+        raise ValueError("Agent not found")
+    if persona.builtin_persona or persona.name.startswith(SLACK_BOT_PERSONA_PREFIX):
+        raise ValueError("Built-in agents cannot change ownership")
+    if not user_can_transfer_persona(persona, user, db_session):
+        raise PermissionError("Only the owner can transfer ownership of this agent")
+
+    prev_owner_user_id = persona.user_id
+    prev_owner_group_id = persona.owner_group_id
+
+    if new_owner_user_id is not None:
+        target = (
+            db_session.query(User)
+            .filter(User.id == new_owner_user_id)  # ty: ignore[invalid-argument-type]
+            .one_or_none()
+        )
+        if target is None:
+            raise ValueError("New owner not found")
+        _validate_transfer_target_user(target)
+        if target.id == prev_owner_user_id:
+            raise ValueError("This user already owns the agent")
+        persona.user_id = target.id
+        persona.owner_group_id = None
+        # The new owner leaves the share list
+        db_session.query(Persona__User).filter(
+            Persona__User.persona_id == persona_id,
+            Persona__User.user_id == target.id,
+        ).delete(synchronize_session="fetch")
+    else:
+        group = (
+            db_session.query(UserGroup)
+            .filter(UserGroup.id == new_owner_group_id)
+            .one_or_none()
+        )
+        if group is None:
+            raise ValueError("New owner group not found")
+        if group.id == prev_owner_group_id:
+            raise ValueError("This group already owns the agent")
+        persona.owner_group_id = group.id
+        persona.user_id = None
+        db_session.query(Persona__UserGroup).filter(
+            Persona__UserGroup.persona_id == persona_id,
+            Persona__UserGroup.user_group_id == group.id,
+        ).delete(synchronize_session="fetch")
+
+    if prev_owner_user_id is not None and prev_owner_user_id != persona.user_id:
+        existing_share = (
+            db_session.query(Persona__User)
+            .filter(
+                Persona__User.persona_id == persona_id,
+                Persona__User.user_id == prev_owner_user_id,
+            )
+            .one_or_none()
+        )
+        if existing_share:
+            existing_share.permission = PersonaSharePermission.EDITOR
+        else:
+            db_session.add(
+                Persona__User(
+                    persona_id=persona_id,
+                    user_id=prev_owner_user_id,
+                    permission=PersonaSharePermission.EDITOR,
+                )
+            )
+    if (
+        prev_owner_group_id is not None
+        and prev_owner_group_id != persona.owner_group_id
+    ):
+        existing_group_share = (
+            db_session.query(Persona__UserGroup)
+            .filter(
+                Persona__UserGroup.persona_id == persona_id,
+                Persona__UserGroup.user_group_id == prev_owner_group_id,
+            )
+            .one_or_none()
+        )
+        if existing_group_share:
+            existing_group_share.permission = PersonaSharePermission.EDITOR
+        else:
+            db_session.add(
+                Persona__UserGroup(
+                    persona_id=persona_id,
+                    user_group_id=prev_owner_group_id,
+                    permission=PersonaSharePermission.EDITOR,
+                )
+            )
+
+    mark_persona_user_files_for_sync(persona_id, db_session)
+    db_session.commit()
+
+
+def transfer_persona_ownership(
+    persona_id: int,
+    user: User,
+    db_session: Session,
+    new_owner_user_id: UUID | None = None,
+    new_owner_group_id: int | None = None,
+) -> None:
+    """Move ownership to a single user. Group targets are EE-only (versioned
+    override in ee.onyx.db.persona)."""
+    if new_owner_group_id is not None:
+        raise NotImplementedError("Onyx MIT does not support group ownership")
+    _transfer_persona_ownership(
+        persona_id=persona_id,
+        user=user,
+        db_session=db_session,
+        new_owner_user_id=new_owner_user_id,
+        new_owner_group_id=None,
+    )
+
+
+def remove_user_from_persona_shares(
+    persona_id: int,
+    user: User,
+    db_session: Session,
+) -> None:
+    """Self-service removal from a persona's share list. Owners can't leave
+    their own agent; not gated on edit access so viewers can leave too."""
+    persona = db_session.query(Persona).filter(Persona.id == persona_id).one_or_none()
+    if persona is None or persona.deleted:
+        raise ValueError("Agent not found")
+    if persona.user_id == user.id:
+        raise ValueError("The owner cannot remove themselves from their own agent")
+    deleted_count = (
+        db_session.query(Persona__User)
+        .filter(
+            Persona__User.persona_id == persona_id,
+            Persona__User.user_id == user.id,
+        )
+        .delete(synchronize_session="fetch")
+    )
+    if not deleted_count:
+        raise ValueError("You are not in this agent's share list")
     mark_persona_user_files_for_sync(persona_id, db_session)
     db_session.commit()
 

--- a/backend/onyx/db/users.py
+++ b/backend/onyx/db/users.py
@@ -7,8 +7,10 @@ from fastapi import HTTPException
 from fastapi_users.password import PasswordHelper
 from sqlalchemy import case
 from sqlalchemy import func
+from sqlalchemy import Select
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import selectinload
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import expression
 from sqlalchemy.sql.elements import ColumnElement
@@ -509,8 +511,11 @@ def assign_user_to_default_groups__no_commit(
 
 def get_active_admin_count(db_session: Session) -> int:
     """Count for the share dialog's Admins row — same filter set as
-    get_active_admin_users (no API-key dummies or system placeholders)."""
-    return len(get_active_admin_users(db_session))
+    get_active_admin_users (no API-key dummies or system placeholders).
+    Runs on the hot GET /persona/{id} path, so count in SQL rather than
+    materializing every admin row."""
+    stmt = select(func.count()).select_from(_active_admin_user_stmt().subquery())
+    return db_session.execute(stmt).scalar_one()
 
 
 def delete_user_from_db(
@@ -538,7 +543,13 @@ def delete_user_from_db(
     # Personas: private ones die with their owner; shared/public ones are
     # orphaned (ownerless ⇒ managed by admins until transferred away)
     owned_personas = (
-        db_session.query(Persona).filter(Persona.user_id == user_to_delete.id).all()
+        db_session.query(Persona)
+        .options(
+            selectinload(Persona.user_shares),
+            selectinload(Persona.group_shares),
+        )
+        .filter(Persona.user_id == user_to_delete.id)
+        .all()
     )
     for persona in owned_personas:
         if (
@@ -596,7 +607,7 @@ def batch_get_user_groups(
     return result
 
 
-def get_active_admin_users(db_session: Session) -> list[User]:
+def _active_admin_user_stmt() -> Select[tuple[User]]:
     """Active human admins, excluding API-key dummy users and system placeholders.
 
     Mirrors `_add_live_user_count_where_clause(only_admin_users=True)` in
@@ -606,11 +617,14 @@ def get_active_admin_users(db_session: Session) -> list[User]:
     email_col: KeyedColumnElement[Any] = User.__table__.c.email
     is_active_col: KeyedColumnElement[Any] = User.__table__.c.is_active
 
-    stmt = select(User).where(
+    return select(User).where(
         is_active_col.is_(True),
         User.role == UserRole.ADMIN,
         expression.not_(email_col.endswith(DANSWER_API_KEY_DUMMY_EMAIL_DOMAIN)),
         email_col != ANONYMOUS_USER_EMAIL,
         email_col != NO_AUTH_PLACEHOLDER_USER_EMAIL,
     )
-    return list(db_session.execute(stmt).unique().scalars().all())
+
+
+def get_active_admin_users(db_session: Session) -> list[User]:
+    return list(db_session.execute(_active_admin_user_stmt()).unique().scalars().all())

--- a/backend/onyx/db/users.py
+++ b/backend/onyx/db/users.py
@@ -507,6 +507,12 @@ def assign_user_to_default_groups__no_commit(
     )
 
 
+def get_active_admin_count(db_session: Session) -> int:
+    """Count for the share dialog's Admins row — same filter set as
+    get_active_admin_users (no API-key dummies or system placeholders)."""
+    return len(get_active_admin_users(db_session))
+
+
 def delete_user_from_db(
     user_to_delete: User,
     db_session: Session,
@@ -524,14 +530,24 @@ def delete_user_from_db(
     db_session.query(SamlAccount).filter(
         SamlAccount.user_id == user_to_delete.id
     ).delete()
-    # Null out ownership on document sets and personas so they're
-    # preserved for other users instead of being cascade-deleted
+    # Null out ownership on document sets so they're preserved for other
+    # users instead of being cascade-deleted
     db_session.query(DocumentSet).filter(
         DocumentSet.user_id == user_to_delete.id
     ).update({DocumentSet.user_id: None})
-    db_session.query(Persona).filter(Persona.user_id == user_to_delete.id).update(
-        {Persona.user_id: None}
+    # Personas: private ones die with their owner; shared/public ones are
+    # orphaned (ownerless ⇒ managed by admins until transferred away)
+    owned_personas = (
+        db_session.query(Persona).filter(Persona.user_id == user_to_delete.id).all()
     )
+    for persona in owned_personas:
+        if (
+            not persona.is_public
+            and not persona.user_shares
+            and not persona.group_shares
+        ):
+            persona.deleted = True
+        persona.user_id = None
 
     db_session.query(DocumentSet__User).filter(
         DocumentSet__User.user_id == user_to_delete.id

--- a/backend/onyx/server/features/persona/api.py
+++ b/backend/onyx/server/features/persona/api.py
@@ -38,6 +38,7 @@ from onyx.db.persona import get_persona_snapshots_for_user
 from onyx.db.persona import get_persona_snapshots_paginated
 from onyx.db.persona import mark_persona_as_deleted
 from onyx.db.persona import mark_persona_as_not_deleted
+from onyx.db.persona import remove_user_from_persona_shares
 from onyx.db.persona import update_persona_featured
 from onyx.db.persona import update_persona_label
 from onyx.db.persona import update_persona_public_status
@@ -46,6 +47,8 @@ from onyx.db.persona import update_persona_visibility
 from onyx.db.persona import update_personas_display_priority
 from onyx.db.persona_sharing import get_persona_access_level
 from onyx.db.persona_sharing import get_user_group_ids_for_user
+from onyx.db.persona_sharing import persona_ownership_is_vacant
+from onyx.db.users import get_active_admin_count
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.file_store.file_store import get_default_file_store
@@ -64,6 +67,7 @@ from onyx.server.models import DisplayPriorityRequest
 from onyx.server.settings.store import load_settings
 from onyx.utils.logger import setup_logger
 from onyx.utils.telemetry import mt_cloud_telemetry
+from onyx.utils.variable_functionality import fetch_versioned_implementation
 from shared_configs.contextvars import get_current_tenant_id
 
 logger = setup_logger()
@@ -485,6 +489,54 @@ def share_persona(
         raise HTTPException(status_code=400, detail=str(e))
 
 
+class TransferPersonaOwnershipRequest(BaseModel):
+    new_owner_user_id: UUID | None = None
+    new_owner_group_id: int | None = None
+
+
+@basic_router.post("/{persona_id}/transfer-ownership")
+def transfer_persona_ownership_endpoint(
+    persona_id: int,
+    transfer_request: TransferPersonaOwnershipRequest,
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> None:
+    versioned_transfer = fetch_versioned_implementation(
+        "onyx.db.persona", "transfer_persona_ownership"
+    )
+    try:
+        versioned_transfer(
+            persona_id=persona_id,
+            user=user,
+            db_session=db_session,
+            new_owner_user_id=transfer_request.new_owner_user_id,
+            new_owner_group_id=transfer_request.new_owner_group_id,
+        )
+    except PermissionError as e:
+        logger.exception("Failed to transfer persona ownership")
+        raise HTTPException(status_code=403, detail=str(e))
+    except (ValueError, NotImplementedError) as e:
+        logger.exception("Failed to transfer persona ownership")
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@basic_router.delete("/{persona_id}/share/me")
+def leave_persona_shares(
+    persona_id: int,
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> None:
+    try:
+        remove_user_from_persona_shares(
+            persona_id=persona_id,
+            user=user,
+            db_session=db_session,
+        )
+    except ValueError as e:
+        logger.exception("Failed to remove user from persona shares")
+        raise HTTPException(status_code=400, detail=str(e))
+
+
 @basic_router.delete("/{persona_id}", tags=PUBLIC_API_TAGS)
 def delete_persona(
     persona_id: int,
@@ -598,6 +650,8 @@ def get_persona(
         snapshot.user_permission = get_persona_access_level(
             persona, user, user_group_ids
         )
+    snapshot.admin_count = get_active_admin_count(db_session)
+    snapshot.ownership_vacant = persona_ownership_is_vacant(persona)
     return snapshot
 
 

--- a/backend/tests/external_dependency_unit/db/test_agent_sharing_groups.py
+++ b/backend/tests/external_dependency_unit/db/test_agent_sharing_groups.py
@@ -1,0 +1,156 @@
+"""EE regression coverage for group-based agent sharing: owner groups grant
+every member full owner rights, leveled group shares gate edit access, group
+ownership transfers, and group deletion orphans or deletes owned personas."""
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from ee.onyx.db.persona import transfer_persona_ownership as ee_transfer
+from ee.onyx.db.persona import update_persona_access as ee_update_persona_access
+from ee.onyx.db.user_group import _handle_owned_personas_for_group_deletion__no_commit
+from onyx.db.enums import PersonaAccessLevel
+from onyx.db.enums import PersonaSharePermission
+from onyx.db.enums import PersonaSharingStatus
+from onyx.db.models import Persona
+from onyx.db.models import Persona__UserGroup
+from onyx.db.models import User
+from onyx.db.persona import fetch_persona_by_id_for_user
+from onyx.db.persona_sharing import derive_persona_sharing_status
+from onyx.db.persona_sharing import get_persona_access_level
+from tests.external_dependency_unit.conftest import create_test_user
+from tests.external_dependency_unit.db.agent_sharing_helpers import create_test_persona
+from tests.external_dependency_unit.db.agent_sharing_helpers import (
+    create_test_user_group,
+)
+from tests.external_dependency_unit.db.agent_sharing_helpers import (
+    share_persona_with_group,
+)
+
+pytestmark = pytest.mark.usefixtures("enable_ee")
+
+
+def _can_edit(db_session: Session, persona_id: int, user: User) -> bool:
+    try:
+        fetch_persona_by_id_for_user(
+            db_session=db_session, persona_id=persona_id, user=user, get_editable=True
+        )
+        return True
+    except HTTPException:
+        return False
+
+
+def test_owner_group_members_get_owner_access(db_session: Session) -> None:
+    member = create_test_user(db_session, "member")
+    outsider = create_test_user(db_session, "outsider")
+    group = create_test_user_group(db_session, members=[member])
+    persona = create_test_persona(db_session, owner=None, owner_group_id=group.id)
+    db_session.refresh(persona)
+
+    assert _can_edit(db_session, persona.id, member)
+    assert not _can_edit(db_session, persona.id, outsider)
+    assert (
+        get_persona_access_level(persona, member, {group.id})
+        == PersonaAccessLevel.OWNER
+    )
+    # Group-owned but unshared still reads as SHARED, not PRIVATE (ENG-4175)
+    assert derive_persona_sharing_status(persona) == PersonaSharingStatus.SHARED
+
+
+def test_group_share_levels_gate_edit(db_session: Session) -> None:
+    owner = create_test_user(db_session, "owner")
+    member = create_test_user(db_session, "member")
+    group = create_test_user_group(db_session, members=[member])
+
+    viewer_persona = create_test_persona(db_session, owner)
+    share_persona_with_group(
+        db_session, viewer_persona, group, PersonaSharePermission.VIEWER
+    )
+    editor_persona = create_test_persona(db_session, owner)
+    share_persona_with_group(
+        db_session, editor_persona, group, PersonaSharePermission.EDITOR
+    )
+
+    assert not _can_edit(db_session, viewer_persona.id, member)
+    assert _can_edit(db_session, editor_persona.id, member)
+
+
+def test_ee_transfer_to_group(db_session: Session) -> None:
+    owner = create_test_user(db_session, "owner")
+    member = create_test_user(db_session, "member")
+    group = create_test_user_group(db_session, members=[member])
+    persona = create_test_persona(db_session, owner)
+    share_persona_with_group(db_session, persona, group, PersonaSharePermission.VIEWER)
+
+    ee_transfer(
+        persona_id=persona.id,
+        user=owner,
+        db_session=db_session,
+        new_owner_group_id=group.id,
+    )
+    db_session.refresh(persona)
+
+    assert persona.owner_group_id == group.id
+    assert persona.user_id is None
+    # The owning group's share row is removed; the previous owner keeps EDITOR
+    group_rows = (
+        db_session.query(Persona__UserGroup)
+        .filter(Persona__UserGroup.persona_id == persona.id)
+        .all()
+    )
+    assert all(row.user_group_id != group.id for row in group_rows)
+    assert any(
+        share.user_id == owner.id and share.permission == PersonaSharePermission.EDITOR
+        for share in persona.user_shares
+    )
+
+
+def test_ee_group_share_diff_updates_levels_in_place(db_session: Session) -> None:
+    owner = create_test_user(db_session, "owner")
+    member = create_test_user(db_session, "member")
+    group = create_test_user_group(db_session, members=[member])
+    persona = create_test_persona(db_session, owner)
+    share_persona_with_group(db_session, persona, group, PersonaSharePermission.VIEWER)
+
+    ee_update_persona_access(
+        persona_id=persona.id,
+        creator_user_id=owner.id,
+        db_session=db_session,
+        group_shares={group.id: PersonaSharePermission.EDITOR},
+    )
+    db_session.commit()
+
+    row = (
+        db_session.query(Persona__UserGroup)
+        .filter(
+            Persona__UserGroup.persona_id == persona.id,
+            Persona__UserGroup.user_group_id == group.id,
+        )
+        .one()
+    )
+    assert row.permission == PersonaSharePermission.EDITOR
+
+
+def test_group_deletion_orphans_shared_and_deletes_private(
+    db_session: Session,
+) -> None:
+    member = create_test_user(db_session, "member")
+    group = create_test_user_group(db_session, members=[member])
+
+    private_persona = create_test_persona(
+        db_session, owner=None, owner_group_id=group.id
+    )
+    public_persona = create_test_persona(
+        db_session, owner=None, owner_group_id=group.id, is_public=True
+    )
+
+    _handle_owned_personas_for_group_deletion__no_commit(
+        db_session=db_session, user_group_id=group.id
+    )
+    db_session.commit()
+
+    private_after = db_session.get(Persona, private_persona.id)
+    public_after = db_session.get(Persona, public_persona.id)
+    assert private_after is not None and private_after.deleted
+    assert public_after is not None and not public_after.deleted
+    assert public_after.owner_group_id is None

--- a/backend/tests/external_dependency_unit/db/test_agent_sharing_lifecycle.py
+++ b/backend/tests/external_dependency_unit/db/test_agent_sharing_lifecycle.py
@@ -170,3 +170,36 @@ def test_share_update_allowed_for_editor_and_preserves_flags(
     assert persona.is_featured
     assert not persona.is_listed
     assert any(share.user_id == new_viewer.id for share in persona.user_shares)
+
+
+def test_editor_cannot_flip_public_visibility(db_session: Session) -> None:
+    """EDITOR-level sharees may edit shares but not make a private agent
+    public; only the owner/admin can flip org-wide visibility."""
+    owner = create_test_user(db_session, "owner")
+    editor = create_test_user(db_session, "editor")
+    persona = create_test_persona(db_session, owner)
+    share_persona_with_user(db_session, persona, editor, PersonaSharePermission.EDITOR)
+    assert not persona.is_public
+
+    # Editor's attempt to go public is ignored.
+    update_persona_shared(
+        persona_id=persona.id,
+        user=editor,
+        db_session=db_session,
+        user_ids=None,
+        is_public=True,
+        public_permission=PersonaSharePermission.EDITOR,
+    )
+    db_session.refresh(persona)
+    assert not persona.is_public
+
+    # Owner can still flip it.
+    update_persona_shared(
+        persona_id=persona.id,
+        user=owner,
+        db_session=db_session,
+        user_ids=None,
+        is_public=True,
+    )
+    db_session.refresh(persona)
+    assert persona.is_public

--- a/backend/tests/external_dependency_unit/db/test_agent_sharing_lifecycle.py
+++ b/backend/tests/external_dependency_unit/db/test_agent_sharing_lifecycle.py
@@ -1,0 +1,172 @@
+"""Regression coverage for the persona ownership lifecycle: user deletion
+soft-deletes private personas and orphans shared/public ones, deactivation
+mutates nothing (vacancy is computed), and self-removal from the share list
+works for everyone except the owner."""
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.db.enums import PersonaSharePermission
+from onyx.db.models import Persona
+from onyx.db.persona import remove_user_from_persona_shares
+from onyx.db.persona import update_persona_shared
+from onyx.db.persona_sharing import persona_ownership_is_vacant
+from onyx.db.users import delete_user_from_db
+from tests.external_dependency_unit.conftest import create_test_user
+from tests.external_dependency_unit.db.agent_sharing_helpers import create_test_persona
+from tests.external_dependency_unit.db.agent_sharing_helpers import (
+    share_persona_with_user,
+)
+
+
+def test_user_deletion_soft_deletes_private_and_orphans_shared(
+    db_session: Session,
+) -> None:
+    owner = create_test_user(db_session, "owner")
+    viewer = create_test_user(db_session, "viewer")
+    private_persona = create_test_persona(db_session, owner)
+    shared_persona = create_test_persona(db_session, owner)
+    public_persona = create_test_persona(db_session, owner, is_public=True)
+    share_persona_with_user(
+        db_session, shared_persona, viewer, PersonaSharePermission.VIEWER
+    )
+
+    delete_user_from_db(owner, db_session)
+
+    private_after = db_session.get(Persona, private_persona.id)
+    shared_after = db_session.get(Persona, shared_persona.id)
+    public_after = db_session.get(Persona, public_persona.id)
+    assert private_after is not None and private_after.deleted
+    assert shared_after is not None and not shared_after.deleted
+    assert shared_after.user_id is None
+    assert public_after is not None and not public_after.deleted
+    assert public_after.user_id is None
+    # Orphaned personas are admin-manageable
+    assert persona_ownership_is_vacant(shared_after)
+
+
+def test_deactivation_mutates_nothing(db_session: Session) -> None:
+    owner = create_test_user(db_session, "owner")
+    viewer = create_test_user(db_session, "viewer")
+    persona = create_test_persona(db_session, owner)
+    share_persona_with_user(db_session, persona, viewer, PersonaSharePermission.VIEWER)
+
+    owner.is_active = False
+    db_session.commit()
+    db_session.refresh(persona)
+
+    # Owner reference preserved (reversible on reactivation), but the persona
+    # now reads as vacant so admins can transfer it away
+    assert persona.user_id == owner.id
+    assert not persona.deleted
+    assert persona_ownership_is_vacant(persona)
+
+    owner.is_active = True
+    db_session.commit()
+    db_session.refresh(persona)
+    assert not persona_ownership_is_vacant(persona)
+
+
+def test_self_removal_for_shared_user(db_session: Session) -> None:
+    owner = create_test_user(db_session, "owner")
+    viewer = create_test_user(db_session, "viewer")
+    persona = create_test_persona(db_session, owner)
+    share_persona_with_user(db_session, persona, viewer, PersonaSharePermission.VIEWER)
+
+    remove_user_from_persona_shares(
+        persona_id=persona.id, user=viewer, db_session=db_session
+    )
+    db_session.refresh(persona)
+    assert all(share.user_id != viewer.id for share in persona.user_shares)
+
+
+def test_owner_cannot_self_remove(db_session: Session) -> None:
+    owner = create_test_user(db_session, "owner")
+    persona = create_test_persona(db_session, owner)
+
+    with pytest.raises(ValueError):
+        remove_user_from_persona_shares(
+            persona_id=persona.id, user=owner, db_session=db_session
+        )
+
+
+def test_self_removal_without_share_row_errors(db_session: Session) -> None:
+    owner = create_test_user(db_session, "owner")
+    stranger = create_test_user(db_session, "stranger")
+    persona = create_test_persona(db_session, owner)
+
+    with pytest.raises(ValueError):
+        remove_user_from_persona_shares(
+            persona_id=persona.id, user=stranger, db_session=db_session
+        )
+
+
+def test_share_update_filters_owner_silently(db_session: Session) -> None:
+    """A stale dialog may include the (new) owner in its share list; the save
+    must succeed with the owner dropped rather than erroring."""
+    owner = create_test_user(db_session, "owner")
+    editor = create_test_user(db_session, "editor")
+    persona = create_test_persona(db_session, owner)
+    share_persona_with_user(db_session, persona, editor, PersonaSharePermission.EDITOR)
+
+    update_persona_shared(
+        persona_id=persona.id,
+        user=editor,
+        db_session=db_session,
+        user_ids=None,
+        user_shares={
+            owner.id: PersonaSharePermission.EDITOR,
+            editor.id: PersonaSharePermission.EDITOR,
+        },
+    )
+    db_session.refresh(persona)
+    assert all(share.user_id != owner.id for share in persona.user_shares)
+    assert any(share.user_id == editor.id for share in persona.user_shares)
+
+
+def test_share_update_denied_for_viewer(db_session: Session) -> None:
+    from fastapi import HTTPException
+
+    owner = create_test_user(db_session, "owner")
+    viewer = create_test_user(db_session, "viewer")
+    other = create_test_user(db_session, "other")
+    persona = create_test_persona(db_session, owner)
+    share_persona_with_user(db_session, persona, viewer, PersonaSharePermission.VIEWER)
+
+    with pytest.raises(HTTPException):
+        update_persona_shared(
+            persona_id=persona.id,
+            user=viewer,
+            db_session=db_session,
+            user_ids=None,
+            user_shares={other.id: PersonaSharePermission.VIEWER},
+        )
+
+
+def test_share_update_allowed_for_editor_and_preserves_flags(
+    db_session: Session,
+) -> None:
+    """Editors can manage sharing; doing so must not touch is_featured or
+    is_listed (ENG-4179)."""
+    owner = create_test_user(db_session, "owner")
+    editor = create_test_user(db_session, "editor")
+    new_viewer = create_test_user(db_session, "newviewer")
+    persona = create_test_persona(db_session, owner, is_listed=False)
+    persona.is_featured = True
+    db_session.commit()
+    share_persona_with_user(db_session, persona, editor, PersonaSharePermission.EDITOR)
+
+    update_persona_shared(
+        persona_id=persona.id,
+        user=editor,
+        db_session=db_session,
+        user_ids=None,
+        user_shares={
+            editor.id: PersonaSharePermission.EDITOR,
+            new_viewer.id: PersonaSharePermission.VIEWER,
+        },
+    )
+    db_session.refresh(persona)
+    assert persona.is_featured
+    assert not persona.is_listed
+    assert any(share.user_id == new_viewer.id for share in persona.user_shares)

--- a/backend/tests/external_dependency_unit/db/test_agent_sharing_transfer.py
+++ b/backend/tests/external_dependency_unit/db/test_agent_sharing_transfer.py
@@ -1,0 +1,265 @@
+"""Regression coverage for persona ownership transfer: owner-only authority,
+target validation (no bots/service accounts/slack/inactive users, no groups in
+MIT), previous-owner demotion to an EDITOR share row, and admin transfer of
+vacant (orphaned) personas."""
+
+from uuid import UUID
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.auth.schemas import UserRole
+from onyx.db.enums import AccountType
+from onyx.db.enums import PersonaSharePermission
+from onyx.db.models import Persona__User
+from onyx.db.persona import transfer_persona_ownership
+from onyx.db.persona_sharing import persona_ownership_is_vacant
+from tests.external_dependency_unit.conftest import create_test_user
+from tests.external_dependency_unit.db.agent_sharing_helpers import create_test_persona
+from tests.external_dependency_unit.db.agent_sharing_helpers import (
+    share_persona_with_user,
+)
+
+
+def _share_row(
+    db_session: Session, persona_id: int, user_id: UUID
+) -> Persona__User | None:
+    return (
+        db_session.query(Persona__User)
+        .filter(
+            Persona__User.persona_id == persona_id,
+            Persona__User.user_id == user_id,
+        )
+        .one_or_none()
+    )
+
+
+def test_owner_transfers_to_user(db_session: Session) -> None:
+    owner = create_test_user(db_session, "owner")
+    new_owner = create_test_user(db_session, "newowner")
+    persona = create_test_persona(db_session, owner)
+    share_persona_with_user(
+        db_session, persona, new_owner, PersonaSharePermission.VIEWER
+    )
+
+    transfer_persona_ownership(
+        persona_id=persona.id,
+        user=owner,
+        db_session=db_session,
+        new_owner_user_id=new_owner.id,
+    )
+    db_session.refresh(persona)
+
+    assert persona.user_id == new_owner.id
+    assert persona.owner_group_id is None
+    # New owner is no longer a sharee
+    assert _share_row(db_session, persona.id, new_owner.id) is None
+    # Previous owner was demoted to an EDITOR share row
+    prev_row = _share_row(db_session, persona.id, owner.id)
+    assert prev_row is not None
+    assert prev_row.permission == PersonaSharePermission.EDITOR
+
+
+def test_transfer_upserts_existing_prev_owner_row(db_session: Session) -> None:
+    """If the previous owner somehow already has a share row, transfer must
+    upgrade it in place instead of violating the primary key."""
+    owner = create_test_user(db_session, "owner")
+    new_owner = create_test_user(db_session, "newowner")
+    persona = create_test_persona(db_session, owner)
+    share_persona_with_user(db_session, persona, owner, PersonaSharePermission.VIEWER)
+
+    transfer_persona_ownership(
+        persona_id=persona.id,
+        user=owner,
+        db_session=db_session,
+        new_owner_user_id=new_owner.id,
+    )
+
+    prev_row = _share_row(db_session, persona.id, owner.id)
+    assert prev_row is not None
+    assert prev_row.permission == PersonaSharePermission.EDITOR
+
+
+def test_editor_cannot_transfer(db_session: Session) -> None:
+    owner = create_test_user(db_session, "owner")
+    editor = create_test_user(db_session, "editor")
+    target = create_test_user(db_session, "target")
+    persona = create_test_persona(db_session, owner)
+    share_persona_with_user(db_session, persona, editor, PersonaSharePermission.EDITOR)
+
+    with pytest.raises(PermissionError):
+        transfer_persona_ownership(
+            persona_id=persona.id,
+            user=editor,
+            db_session=db_session,
+            new_owner_user_id=target.id,
+        )
+
+
+def test_viewer_cannot_transfer(db_session: Session) -> None:
+    owner = create_test_user(db_session, "owner")
+    viewer = create_test_user(db_session, "viewer")
+    target = create_test_user(db_session, "target")
+    persona = create_test_persona(db_session, owner)
+    share_persona_with_user(db_session, persona, viewer, PersonaSharePermission.VIEWER)
+
+    with pytest.raises(PermissionError):
+        transfer_persona_ownership(
+            persona_id=persona.id,
+            user=viewer,
+            db_session=db_session,
+            new_owner_user_id=target.id,
+        )
+
+
+def test_admin_cannot_transfer_owned_persona(db_session: Session) -> None:
+    """ENG-4177: only owners transfer. Admin authority applies to vacant
+    personas only."""
+    owner = create_test_user(db_session, "owner")
+    admin = create_test_user(db_session, "admin", role=UserRole.ADMIN)
+    target = create_test_user(db_session, "target")
+    persona = create_test_persona(db_session, owner)
+
+    with pytest.raises(PermissionError):
+        transfer_persona_ownership(
+            persona_id=persona.id,
+            user=admin,
+            db_session=db_session,
+            new_owner_user_id=target.id,
+        )
+
+
+def test_admin_transfers_vacant_persona(db_session: Session) -> None:
+    admin = create_test_user(db_session, "admin", role=UserRole.ADMIN)
+    target = create_test_user(db_session, "target")
+    persona = create_test_persona(db_session, owner=None)
+    db_session.refresh(persona)
+    assert persona_ownership_is_vacant(persona)
+
+    transfer_persona_ownership(
+        persona_id=persona.id,
+        user=admin,
+        db_session=db_session,
+        new_owner_user_id=target.id,
+    )
+    db_session.refresh(persona)
+    assert persona.user_id == target.id
+
+
+def test_basic_user_cannot_transfer_vacant_persona(db_session: Session) -> None:
+    basic = create_test_user(db_session, "basic")
+    target = create_test_user(db_session, "target")
+    persona = create_test_persona(db_session, owner=None)
+
+    with pytest.raises(PermissionError):
+        transfer_persona_ownership(
+            persona_id=persona.id,
+            user=basic,
+            db_session=db_session,
+            new_owner_user_id=target.id,
+        )
+
+
+def test_deactivated_owner_makes_persona_admin_transferable(
+    db_session: Session,
+) -> None:
+    owner = create_test_user(db_session, "owner")
+    admin = create_test_user(db_session, "admin", role=UserRole.ADMIN)
+    target = create_test_user(db_session, "target")
+    persona = create_test_persona(db_session, owner)
+
+    owner.is_active = False
+    db_session.commit()
+    db_session.refresh(persona)
+    assert persona_ownership_is_vacant(persona)
+
+    transfer_persona_ownership(
+        persona_id=persona.id,
+        user=admin,
+        db_session=db_session,
+        new_owner_user_id=target.id,
+    )
+    db_session.refresh(persona)
+    assert persona.user_id == target.id
+
+
+@pytest.mark.parametrize(
+    "role,account_type",
+    [
+        (UserRole.SLACK_USER, AccountType.STANDARD),
+        (UserRole.EXT_PERM_USER, AccountType.STANDARD),
+        (UserRole.BASIC, AccountType.BOT),
+        (UserRole.BASIC, AccountType.SERVICE_ACCOUNT),
+    ],
+)
+def test_transfer_rejects_invalid_target_account(
+    db_session: Session, role: UserRole, account_type: AccountType
+) -> None:
+    owner = create_test_user(db_session, "owner")
+    target = create_test_user(
+        db_session, "target", role=role, account_type=account_type
+    )
+    persona = create_test_persona(db_session, owner)
+
+    with pytest.raises(ValueError):
+        transfer_persona_ownership(
+            persona_id=persona.id,
+            user=owner,
+            db_session=db_session,
+            new_owner_user_id=target.id,
+        )
+
+
+def test_transfer_rejects_inactive_target(db_session: Session) -> None:
+    owner = create_test_user(db_session, "owner")
+    target = create_test_user(db_session, "target")
+    target.is_active = False
+    db_session.commit()
+    persona = create_test_persona(db_session, owner)
+
+    with pytest.raises(ValueError):
+        transfer_persona_ownership(
+            persona_id=persona.id,
+            user=owner,
+            db_session=db_session,
+            new_owner_user_id=target.id,
+        )
+
+
+def test_transfer_to_group_rejected_in_mit(db_session: Session) -> None:
+    owner = create_test_user(db_session, "owner")
+    persona = create_test_persona(db_session, owner)
+
+    with pytest.raises(NotImplementedError):
+        transfer_persona_ownership(
+            persona_id=persona.id,
+            user=owner,
+            db_session=db_session,
+            new_owner_group_id=123,
+        )
+
+
+def test_transfer_requires_exactly_one_target(db_session: Session) -> None:
+    owner = create_test_user(db_session, "owner")
+    persona = create_test_persona(db_session, owner)
+
+    with pytest.raises(ValueError):
+        transfer_persona_ownership(
+            persona_id=persona.id,
+            user=owner,
+            db_session=db_session,
+        )
+
+
+def test_transfer_rejects_builtin_persona(db_session: Session) -> None:
+    owner = create_test_user(db_session, "owner")
+    target = create_test_user(db_session, "target")
+    persona = create_test_persona(db_session, owner, builtin_persona=True)
+
+    with pytest.raises(ValueError):
+        transfer_persona_ownership(
+            persona_id=persona.id,
+            user=owner,
+            db_session=db_session,
+            new_owner_user_id=target.id,
+        )

--- a/backend/tests/unit/onyx/db/test_delete_user.py
+++ b/backend/tests/unit/onyx/db/test_delete_user.py
@@ -41,6 +41,14 @@ def test_delete_user_nulls_out_document_set_ownership(
     user = _mock_user()
     db_session = MagicMock()
 
+    # A private/unshared persona dies with its owner; a shared one is orphaned.
+    private_persona = MagicMock(
+        is_public=False, user_shares=[], group_shares=[], deleted=False
+    )
+    shared_persona = MagicMock(
+        is_public=False, user_shares=[MagicMock()], group_shares=[], deleted=False
+    )
+
     query_chains: dict[type, MagicMock] = {}
 
     def query_side_effect(model: type) -> MagicMock:
@@ -49,6 +57,12 @@ def test_delete_user_nulls_out_document_set_ownership(
         return query_chains[model]
 
     db_session.query.side_effect = query_side_effect
+    # Owned personas are fetched via options(...).filter(...).all() then
+    # orphaned/deleted in Python.
+    persona_chain = _make_query_chain()
+    persona_chain.options.return_value = persona_chain
+    persona_chain.all.return_value = [private_persona, shared_persona]
+    query_chains[Persona] = persona_chain
 
     delete_user_from_db(user, db_session)
 
@@ -59,12 +73,12 @@ def test_delete_user_nulls_out_document_set_ownership(
         {DocumentSet.user_id: None}
     )
 
-    # Verify Persona.user_id is nulled out (update, not delete)
-    persona_chain = query_chains[Persona]
-    persona_chain.filter.assert_called()
-    persona_chain.filter.return_value.update.assert_called_once_with(
-        {Persona.user_id: None}
-    )
+    # Owned personas are orphaned (user_id -> None); the private, unshared one
+    # is additionally soft-deleted while the shared one survives ownerless.
+    assert private_persona.user_id is None
+    assert private_persona.deleted is True
+    assert shared_persona.user_id is None
+    assert shared_persona.deleted is False
 
 
 @patch("onyx.db.users.remove_user_from_invited_users")


### PR DESCRIPTION
## Description

PR 3/7 of the Agent Sharing stack — ownership (ENG-4177, backend).

- Single-owner with transfer: exactly one user XOR group; no service/slack users; owners irremovable; only owners (or admins of a vacant agent) transfer
- Orphaned agents auto-transfer to admins when a user or owning group is deleted (`users.py`, `ee/user_group.py`)
- Transfer + self-removal API endpoints; EE group-transfer path

Stacked on the sharing PR. Knowledge guard follows in 4/7.

Tests: transfer, lifecycle/orphan, group shares (external_dependency_unit).

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check