### PR TITLE
feat(agent-sharing): editor knowledge-attach guard - 4/7

### DIFF
--- a/backend/ee/onyx/db/hierarchy.py
+++ b/backend/ee/onyx/db/hierarchy.py
@@ -67,3 +67,17 @@ def _get_accessible_hierarchy_nodes_for_source(
     stmt = stmt.where(_build_hierarchy_access_filter(user_email, external_group_ids))
     stmt = stmt.order_by(HierarchyNode.display_name)
     return list(db_session.execute(stmt).scalars().all())
+
+
+def _filter_accessible_hierarchy_node_ids(
+    db_session: Session,
+    node_ids: list[int],
+    user_email: str,
+    external_group_ids: list[str],
+) -> set[int]:
+    """EE version: keep only the node ids the user can access."""
+    if not node_ids:
+        return set()
+    stmt = select(HierarchyNode.id).where(HierarchyNode.id.in_(node_ids))
+    stmt = stmt.where(_build_hierarchy_access_filter(user_email, external_group_ids))
+    return set(db_session.execute(stmt).scalars().all())

--- a/backend/ee/onyx/db/hierarchy.py
+++ b/backend/ee/onyx/db/hierarchy.py
@@ -76,8 +76,6 @@ def _filter_accessible_hierarchy_node_ids(
     external_group_ids: list[str],
 ) -> set[int]:
     """EE version: keep only the node ids the user can access."""
-    if not node_ids:
-        return set()
     stmt = select(HierarchyNode.id).where(HierarchyNode.id.in_(node_ids))
     stmt = stmt.where(_build_hierarchy_access_filter(user_email, external_group_ids))
     return set(db_session.execute(stmt).scalars().all())

--- a/backend/onyx/db/document_set.py
+++ b/backend/onyx/db/document_set.py
@@ -179,6 +179,21 @@ def filter_document_set_names_by_user_access(
     return set(db_session.scalars(stmt).all())
 
 
+def filter_document_set_ids_by_user_access(
+    db_session: Session,
+    document_set_ids: list[int],
+    user: User,
+) -> set[int]:
+    """Return the subset of ``document_set_ids`` the user has view access to."""
+    if not document_set_ids:
+        return set()
+    stmt = select(DocumentSetDBModel.id).where(
+        DocumentSetDBModel.id.in_(document_set_ids)
+    )
+    stmt = _add_user_filters(stmt, user, get_editable=False)
+    return set(db_session.scalars(stmt).all())
+
+
 def get_document_sets_by_ids(
     db_session: Session, document_set_ids: list[int]
 ) -> Sequence[DocumentSetDBModel]:

--- a/backend/onyx/db/hierarchy.py
+++ b/backend/onyx/db/hierarchy.py
@@ -532,6 +532,33 @@ def get_accessible_hierarchy_nodes_for_source(
     return versioned_fn(db_session, source, user_email, external_group_ids)
 
 
+def _filter_accessible_hierarchy_node_ids(
+    db_session: Session,  # noqa: ARG001
+    node_ids: list[int],
+    user_email: str,  # noqa: ARG001
+    external_group_ids: list[str],  # noqa: ARG001
+) -> set[int]:
+    """MIT version: hierarchy nodes carry no permission filtering — all
+    requested ids pass. The EE version applies the access filter."""
+    return set(node_ids)
+
+
+def filter_accessible_hierarchy_node_ids(
+    db_session: Session,
+    node_ids: list[int],
+    user_email: str,
+    external_group_ids: list[str],
+) -> set[int]:
+    """Return the subset of ``node_ids`` the user can access (EE filters,
+    MIT passes everything through)."""
+    if not node_ids:
+        return set()
+    versioned_fn = fetch_versioned_implementation(
+        "onyx.db.hierarchy", "_filter_accessible_hierarchy_node_ids"
+    )
+    return versioned_fn(db_session, node_ids, user_email, external_group_ids)
+
+
 def get_document_parent_hierarchy_node_ids(
     db_session: Session,
     document_ids: list[str],

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -1334,7 +1334,7 @@ def upsert_persona(
             .filter(DocumentSet.id.in_(document_set_ids))
             .all()
         )
-        if not document_sets and document_set_ids:
+        if len(document_sets) != len(set(document_set_ids)):
             raise ValueError("document_sets not found")
 
     # Editors may only ATTACH knowledge they can access themselves; anything
@@ -1394,7 +1394,7 @@ def upsert_persona(
             .filter(HierarchyNode.id.in_(hierarchy_node_ids))
             .all()
         )
-        if not hierarchy_nodes and hierarchy_node_ids:
+        if len(hierarchy_nodes) != len(set(hierarchy_node_ids)):
             raise ValueError("hierarchy_nodes not found")
 
     if hierarchy_node_ids is not None and knowledge_guard_applies and user is not None:

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -22,8 +22,10 @@ from onyx.configs.constants import DEFAULT_PERSONA_ID
 from onyx.configs.constants import NotificationType
 from onyx.db.constants import SLACK_BOT_PERSONA_PREFIX
 from onyx.db.document_access import get_accessible_documents_by_ids
+from onyx.db.document_set import filter_document_set_ids_by_user_access
 from onyx.db.enums import AccountType
 from onyx.db.enums import PersonaSharePermission
+from onyx.db.hierarchy import filter_accessible_hierarchy_node_ids
 from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import Document
 from onyx.db.models import DocumentSet
@@ -1335,6 +1337,24 @@ def upsert_persona(
         if not document_sets and document_set_ids:
             raise ValueError("document_sets not found")
 
+    # Editors may only ATTACH knowledge they can access themselves; anything
+    # already attached survives an update, but once removed it can't be
+    # re-added by someone without access (ENG-4180).
+    knowledge_guard_applies = user is not None and user.role != UserRole.ADMIN
+    if document_set_ids is not None and knowledge_guard_applies and user is not None:
+        existing_set_ids = (
+            {ds.id for ds in existing_persona.document_sets}
+            if existing_persona
+            else set()
+        )
+        added_set_ids = set(document_set_ids) - existing_set_ids
+        if added_set_ids:
+            accessible_set_ids = filter_document_set_ids_by_user_access(
+                db_session, list(added_set_ids), user
+            )
+            if added_set_ids - accessible_set_ids:
+                raise ValueError("Cannot attach document sets you don't have access to")
+
     # Fetch and attach user_files by IDs
     user_files = None
     if user_file_ids is not None:
@@ -1343,6 +1363,14 @@ def upsert_persona(
         )
         if not user_files and user_file_ids:
             raise ValueError("user_files not found")
+
+    if user_file_ids is not None and knowledge_guard_applies and user is not None:
+        existing_file_ids = (
+            {uf.id for uf in existing_persona.user_files} if existing_persona else set()
+        )
+        for user_file in user_files or []:
+            if user_file.id not in existing_file_ids and user_file.user_id != user.id:
+                raise ValueError("Cannot attach files you don't own")
 
     labels = None
     if label_ids is not None:
@@ -1362,6 +1390,25 @@ def upsert_persona(
         )
         if not hierarchy_nodes and hierarchy_node_ids:
             raise ValueError("hierarchy_nodes not found")
+
+    if hierarchy_node_ids and knowledge_guard_applies and user is not None:
+        existing_node_ids = (
+            {node.id for node in existing_persona.hierarchy_nodes}
+            if existing_persona
+            else set()
+        )
+        added_node_ids = set(hierarchy_node_ids) - existing_node_ids
+        if added_node_ids:
+            accessible_node_ids = filter_accessible_hierarchy_node_ids(
+                db_session,
+                list(added_node_ids),
+                user.email,
+                get_user_external_group_ids(db_session, user),
+            )
+            if added_node_ids - accessible_node_ids:
+                raise ValueError(
+                    "Cannot attach hierarchy nodes you don't have access to"
+                )
 
     # Fetch and attach documents by IDs, filtering for access permissions
     attached_documents = None

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -1361,7 +1361,7 @@ def upsert_persona(
         user_files = (
             db_session.query(UserFile).filter(UserFile.id.in_(user_file_ids)).all()
         )
-        if not user_files and user_file_ids:
+        if len(user_files) != len(set(user_file_ids)):
             raise ValueError("user_files not found")
 
         # Editors may only attach files they own (admins bypass)

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -1388,7 +1388,7 @@ def upsert_persona(
 
     # Fetch and attach hierarchy_nodes by IDs
     hierarchy_nodes = None
-    if hierarchy_node_ids:
+    if hierarchy_node_ids is not None:
         hierarchy_nodes = (
             db_session.query(HierarchyNode)
             .filter(HierarchyNode.id.in_(hierarchy_node_ids))
@@ -1397,7 +1397,7 @@ def upsert_persona(
         if not hierarchy_nodes and hierarchy_node_ids:
             raise ValueError("hierarchy_nodes not found")
 
-    if hierarchy_node_ids and knowledge_guard_applies and user is not None:
+    if hierarchy_node_ids is not None and knowledge_guard_applies and user is not None:
         existing_node_ids = (
             {node.id for node in existing_persona.hierarchy_nodes}
             if existing_persona

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -1340,7 +1340,7 @@ def upsert_persona(
     # Editors may only ATTACH knowledge they can access themselves; anything
     # already attached survives an update, but once removed it can't be
     # re-added by someone without access (ENG-4180).
-    knowledge_guard_applies = user is not None and user.role != UserRole.ADMIN
+    knowledge_guard_applies: bool = user is not None and user.role != UserRole.ADMIN
     if document_set_ids is not None and knowledge_guard_applies and user is not None:
         existing_set_ids = (
             {ds.id for ds in existing_persona.document_sets}
@@ -1364,13 +1364,19 @@ def upsert_persona(
         if not user_files and user_file_ids:
             raise ValueError("user_files not found")
 
-    if user_file_ids is not None and knowledge_guard_applies and user is not None:
-        existing_file_ids = (
-            {uf.id for uf in existing_persona.user_files} if existing_persona else set()
-        )
-        for user_file in user_files or []:
-            if user_file.id not in existing_file_ids and user_file.user_id != user.id:
-                raise ValueError("Cannot attach files you don't own")
+        # Editors may only attach files they own (admins bypass)
+        if knowledge_guard_applies and user is not None:
+            existing_file_ids = (
+                {uf.id for uf in existing_persona.user_files}
+                if existing_persona
+                else set()
+            )
+            for user_file in user_files:
+                if (
+                    user_file.id not in existing_file_ids
+                    and user_file.user_id != user.id
+                ):
+                    raise ValueError("Cannot attach files you don't own")
 
     labels = None
     if label_ids is not None:

--- a/backend/tests/external_dependency_unit/db/test_agent_sharing_knowledge_guard.py
+++ b/backend/tests/external_dependency_unit/db/test_agent_sharing_knowledge_guard.py
@@ -1,0 +1,130 @@
+"""Regression coverage for the editor knowledge-attach guard (ENG-4180): a
+non-owner editor may only ATTACH document sets they can access; pre-existing
+attachments survive updates, and a removed inaccessible set cannot be re-added
+by that editor."""
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.auth.schemas import UserRole
+from onyx.db.enums import PersonaSharePermission
+from onyx.db.models import DocumentSet
+from onyx.db.models import Persona
+from onyx.db.models import User
+from onyx.db.persona import upsert_persona
+from tests.external_dependency_unit.conftest import create_test_user
+from tests.external_dependency_unit.db.agent_sharing_helpers import create_test_persona
+from tests.external_dependency_unit.db.agent_sharing_helpers import (
+    share_persona_with_user,
+)
+
+
+def _create_persona_with_editor(
+    db_session: Session, owner: User, editor: User
+) -> Persona:
+    persona = create_test_persona(db_session, owner)
+    share_persona_with_user(db_session, persona, editor, PersonaSharePermission.EDITOR)
+    return persona
+
+
+def _create_document_set(
+    db_session: Session, owner: User, is_public: bool
+) -> DocumentSet:
+    document_set = DocumentSet(
+        name=f"agent-sharing-ds-{uuid4().hex[:8]}",
+        description="knowledge guard test set",
+        user_id=owner.id,
+        is_public=is_public,
+        is_up_to_date=True,
+    )
+    db_session.add(document_set)
+    db_session.commit()
+    db_session.refresh(document_set)
+    return document_set
+
+
+def _update_persona_document_sets(
+    db_session: Session, persona: Persona, user: User, document_set_ids: list[int]
+) -> Persona:
+    return upsert_persona(
+        persona_id=persona.id,
+        user=user,
+        name=persona.name,
+        description=persona.description,
+        starter_messages=None,
+        system_prompt=None,
+        task_prompt=None,
+        datetime_aware=None,
+        is_public=persona.is_public,
+        db_session=db_session,
+        document_set_ids=document_set_ids,
+    )
+
+
+def test_editor_cannot_attach_inaccessible_document_set(db_session: Session) -> None:
+    owner = create_test_user(db_session, "owner")
+    editor = create_test_user(db_session, "editor")
+    private_set = _create_document_set(db_session, owner, is_public=False)
+    persona = _create_persona_with_editor(db_session, owner, editor)
+
+    with pytest.raises(ValueError, match="document sets"):
+        _update_persona_document_sets(db_session, persona, editor, [private_set.id])
+
+
+def test_editor_can_attach_accessible_document_set(db_session: Session) -> None:
+    owner = create_test_user(db_session, "owner")
+    editor = create_test_user(db_session, "editor")
+    public_set = _create_document_set(db_session, owner, is_public=True)
+    persona = _create_persona_with_editor(db_session, owner, editor)
+
+    updated = _update_persona_document_sets(
+        db_session, persona, editor, [public_set.id]
+    )
+    db_session.commit()
+    assert {ds.id for ds in updated.document_sets} == {public_set.id}
+
+
+def test_editor_keeps_existing_inaccessible_set(db_session: Session) -> None:
+    owner = create_test_user(db_session, "owner")
+    editor = create_test_user(db_session, "editor")
+    private_set = _create_document_set(db_session, owner, is_public=False)
+    public_set = _create_document_set(db_session, owner, is_public=True)
+    persona = _create_persona_with_editor(db_session, owner, editor)
+    persona.document_sets = [private_set]
+    db_session.commit()
+
+    updated = _update_persona_document_sets(
+        db_session, persona, editor, [private_set.id, public_set.id]
+    )
+    db_session.commit()
+    assert {ds.id for ds in updated.document_sets} == {private_set.id, public_set.id}
+
+
+def test_editor_cannot_readd_removed_inaccessible_set(db_session: Session) -> None:
+    owner = create_test_user(db_session, "owner")
+    editor = create_test_user(db_session, "editor")
+    private_set = _create_document_set(db_session, owner, is_public=False)
+    persona = _create_persona_with_editor(db_session, owner, editor)
+    persona.document_sets = [private_set]
+    db_session.commit()
+
+    _update_persona_document_sets(db_session, persona, editor, [])
+    db_session.commit()
+
+    with pytest.raises(ValueError, match="document sets"):
+        _update_persona_document_sets(db_session, persona, editor, [private_set.id])
+
+
+def test_admin_bypasses_knowledge_guard(db_session: Session) -> None:
+    owner = create_test_user(db_session, "owner")
+    admin = create_test_user(db_session, "admin", role=UserRole.ADMIN)
+    private_set = _create_document_set(db_session, owner, is_public=False)
+    persona = create_test_persona(db_session, owner)
+
+    updated = _update_persona_document_sets(
+        db_session, persona, admin, [private_set.id]
+    )
+    db_session.commit()
+    assert {ds.id for ds in updated.document_sets} == {private_set.id}


### PR DESCRIPTION
## Description

PR 4/7 of the Agent Sharing stack — knowledge guard (ENG-4180, backend).

- Editors may only attach knowledge they can access: new document sets, user files, and hierarchy nodes are access-filtered in `upsert_persona`
- Already-attached knowledge survives an update; once removed, an inaccessible source can't be re-added (admins bypass)
- Adds the access filters in `document_set.py` / `hierarchy.py` (+EE)

Final backend PR; completes the backend feature. Stacked on the ownership PR.

Tests: knowledge-attach guard cases (external_dependency_unit).

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check