### PR TITLE
feat(agent-sharing): share UI foundation - 5/7

### DIFF
--- a/web/lib/opal/src/components/buttons/open-button/components.tsx
+++ b/web/lib/opal/src/components/buttons/open-button/components.tsx
@@ -9,7 +9,13 @@ import type {
   IconFunctionComponent,
   RichStr,
 } from "@opal/types";
-import { Text, Tooltip, type TooltipSide } from "@opal/components";
+import {
+  Text,
+  Tooltip,
+  type TextColor,
+  type TextFont,
+  type TooltipSide,
+} from "@opal/components";
 import type { InteractiveContainerRoundingVariant } from "@opal/core";
 import { cn } from "@opal/utils";
 import { iconWrapper } from "@opal/components/buttons/icon-wrapper";
@@ -63,6 +69,12 @@ type OpenButtonProps = Omit<InteractiveStatefulProps, "variant"> & {
      */
     justifyContent?: "between";
 
+    /** Override the label font (defaults to the size-derived body font). */
+    labelFont?: TextFont;
+
+    /** Override the label color (defaults to the variant's interactive color). */
+    labelColor?: TextColor;
+
     /** Tooltip text shown on hover. */
     tooltip?: string;
 
@@ -87,6 +99,8 @@ function OpenButton({
   foldable,
   width,
   justifyContent,
+  labelFont,
+  labelColor,
   tooltip,
   tooltipSide = "top",
   rounding: roundingOverride,
@@ -106,8 +120,8 @@ function OpenButton({
 
   const labelEl = children ? (
     <Text
-      font={isLarge ? "main-ui-body" : "secondary-body"}
-      color="inherit"
+      font={labelFont ?? (isLarge ? "main-ui-body" : "secondary-body")}
+      color={labelColor ?? "inherit"}
       nowrap
     >
       {children}

--- a/web/src/app/app/shared/[chatId]/page.tsx
+++ b/web/src/app/app/shared/[chatId]/page.tsx
@@ -17,6 +17,8 @@ export function constructMiniFiedPersona(name: string, id: number): Agent {
     document_sets: [],
     tools: [],
     owner: null,
+    owner_group: null,
+    user_permission: null,
     starter_messages: null,
     builtin_persona: false,
     is_featured: false,

--- a/web/src/lib/agents/svc.ts
+++ b/web/src/lib/agents/svc.ts
@@ -1,4 +1,8 @@
-import { AgentUpsertParameters, AgentUpsertRequest } from "@/lib/agents/types";
+import {
+  AgentUpsertParameters,
+  AgentUpsertRequest,
+  PersonaSharePermission,
+} from "@/lib/agents/types";
 
 /**
  * Maps client-facing AgentUpsertParameters to the wire shape expected by the
@@ -37,10 +41,10 @@ function buildAgentUpsertRequest(
 }
 
 /** Extracts `detail` from a non-OK JSON response body, falling back to `fallback`. */
-async function parseErrorDetail(res: Response, fallback: string) {
+export async function parseErrorDetail(res: Response, fallback: string) {
   try {
     const body = await res.json();
-    return (body?.detail as string) ?? fallback;
+    return typeof body?.detail === "string" ? body.detail : fallback;
   } catch {
     return fallback;
   }
@@ -150,6 +154,102 @@ export async function updateAgentSharedStatus(
   }
 }
 
+export interface AgentShareUpdatePayload {
+  user_shares?: {
+    user_id: string;
+    permission: PersonaSharePermission;
+  }[];
+  group_shares?: {
+    group_id: number;
+    permission: PersonaSharePermission;
+  }[];
+  is_public?: boolean;
+  public_permission?: PersonaSharePermission;
+  label_ids?: number[];
+}
+
+export async function updateAgentShares(
+  agentId: number,
+  payload: AgentShareUpdatePayload,
+  isPaidEnterpriseFeaturesEnabled: boolean
+): Promise<string | null> {
+  if (
+    !isPaidEnterpriseFeaturesEnabled &&
+    payload.group_shares &&
+    payload.group_shares.length > 0
+  ) {
+    console.error(
+      "updateAgentShares: group_shares provided but enterprise features are disabled. " +
+        "Group sharing is an EE-only feature. Discarding group_shares."
+    );
+  }
+
+  try {
+    const res = await fetch(`/api/persona/${agentId}/share`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        ...payload,
+        group_shares: isPaidEnterpriseFeaturesEnabled
+          ? payload.group_shares
+          : undefined,
+      }),
+      credentials: "include",
+    });
+
+    if (res.ok) {
+      return null;
+    }
+
+    return await parseErrorDetail(res, "Failed to update agent shares");
+  } catch {
+    return "Network error. Please check your connection and try again.";
+  }
+}
+
+export async function transferAgentOwnership(
+  agentId: number,
+  payload:
+    | { new_owner_user_id: string; new_owner_group_id?: never }
+    | { new_owner_group_id: number; new_owner_user_id?: never }
+): Promise<string | null> {
+  try {
+    const res = await fetch(`/api/persona/${agentId}/transfer-ownership`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+      credentials: "include",
+    });
+
+    if (res.ok) {
+      return null;
+    }
+
+    return await parseErrorDetail(res, "Failed to transfer ownership");
+  } catch {
+    return "Network error. Please check your connection and try again.";
+  }
+}
+
+export async function removeSelfFromAgentShares(
+  agentId: number
+): Promise<string | null> {
+  try {
+    const res = await fetch(`/api/persona/${agentId}/share/me`, {
+      method: "DELETE",
+      credentials: "include",
+    });
+
+    if (res.ok) {
+      return null;
+    }
+
+    return await parseErrorDetail(res, "Failed to remove access");
+  } catch {
+    return "Network error. Please check your connection and try again.";
+  }
+}
+
 // ── Featured / listed / display priority ─────────────────────────────────────
 
 /**
@@ -241,7 +341,6 @@ export async function pinAgents(pinnedAgentIds: number[]): Promise<void> {
   const res = await fetch(`/api/user/pinned-assistants`, {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
-    // TODO(ENG-3766): rename to agent
     body: JSON.stringify({ ordered_assistant_ids: pinnedAgentIds }),
   });
   if (!res.ok) {

--- a/web/src/lib/agents/svc.ts
+++ b/web/src/lib/agents/svc.ts
@@ -127,12 +127,8 @@ export async function updateAgentSharedStatus(
   isPaidEnterpriseFeaturesEnabled: boolean,
   labelIds?: number[]
 ): Promise<string | null> {
-  if (!isPaidEnterpriseFeaturesEnabled && groupIds.length > 0) {
-    console.error(
-      "updateAgentSharedStatus: groupIds provided but enterprise features are disabled. " +
-        "Group sharing is an EE-only feature. Discarding groupIds."
-    );
-  }
+  const groupSharesDiscarded =
+    !isPaidEnterpriseFeaturesEnabled && groupIds.length > 0;
 
   try {
     const res = await fetch(`/api/persona/${agentId}/share`, {
@@ -145,7 +141,11 @@ export async function updateAgentSharedStatus(
         label_ids: labelIds,
       }),
     });
-    if (res.ok) return null;
+    if (res.ok) {
+      return groupSharesDiscarded
+        ? "Group sharing is an enterprise-only feature; groups were not added."
+        : null;
+    }
     return (
       ((await res.json()) as { detail?: string }).detail ?? "Unknown error"
     );
@@ -173,16 +173,10 @@ export async function updateAgentShares(
   payload: AgentShareUpdatePayload,
   isPaidEnterpriseFeaturesEnabled: boolean
 ): Promise<string | null> {
-  if (
+  const groupSharesDiscarded =
     !isPaidEnterpriseFeaturesEnabled &&
-    payload.group_shares &&
-    payload.group_shares.length > 0
-  ) {
-    console.error(
-      "updateAgentShares: group_shares provided but enterprise features are disabled. " +
-        "Group sharing is an EE-only feature. Discarding group_shares."
-    );
-  }
+    !!payload.group_shares &&
+    payload.group_shares.length > 0;
 
   try {
     const res = await fetch(`/api/persona/${agentId}/share`, {
@@ -198,7 +192,9 @@ export async function updateAgentShares(
     });
 
     if (res.ok) {
-      return null;
+      return groupSharesDiscarded
+        ? "Group sharing is an enterprise-only feature; group shares were not applied."
+        : null;
     }
 
     return await parseErrorDetail(res, "Failed to update agent shares");

--- a/web/src/lib/agents/types.ts
+++ b/web/src/lib/agents/types.ts
@@ -33,6 +33,28 @@ export interface AgentLabel {
   name: string;
 }
 
+export type PersonaSharePermission = "EDITOR" | "VIEWER";
+
+export type PersonaAccessLevel = "OWNER" | "EDITOR" | "VIEWER";
+
+export type PersonaSharingStatus = "PRIVATE" | "SHARED" | "PUBLIC";
+
+export interface PersonaUserShare {
+  user: MinimalUserSnapshot;
+  permission: PersonaSharePermission;
+}
+
+export interface PersonaGroupShare {
+  group_id: number;
+  group_name: string;
+  permission: PersonaSharePermission;
+}
+
+export interface PersonaOwnerGroup {
+  id: number;
+  name: string;
+}
+
 export interface MinimalAgent {
   id: number;
   name: string;
@@ -53,6 +75,9 @@ export interface MinimalAgent {
   builtin_persona: boolean;
   labels?: AgentLabel[];
   owner: MinimalUserSnapshot | null;
+  owner_group: PersonaOwnerGroup | null;
+  // Requesting user's computed access, set by the list/detail endpoints
+  user_permission: PersonaAccessLevel | null;
 }
 
 export interface Agent extends MinimalAgent {
@@ -69,6 +94,12 @@ export interface Agent extends MinimalAgent {
 
 export interface FullAgent extends Agent {
   search_start_date: string | null;
+  user_shares: PersonaUserShare[];
+  group_shares: PersonaGroupShare[];
+  public_permission: PersonaSharePermission;
+  sharing_status: PersonaSharingStatus;
+  admin_count: number;
+  ownership_vacant: boolean;
 }
 
 // ── Upsert / API parameter types ──────────────────────────────────────────────
@@ -81,11 +112,13 @@ export interface AgentUpsertParameters {
   task_prompt: string;
   datetime_aware: boolean;
   document_set_ids: number[];
-  is_public: boolean;
+  // Sharing fields: omit on update — the share dialog owns sharing for
+  // saved agents and the backend treats absent as "leave unchanged"
+  is_public?: boolean;
   default_model_configuration_id?: number | null;
   starter_messages: AgentStarterMessage[] | null;
   users?: string[];
-  groups: number[];
+  groups?: number[];
   tool_ids: number[];
   remove_image?: boolean;
   search_start_date: Date | null;
@@ -105,11 +138,11 @@ export interface AgentUpsertRequest {
   task_prompt: string;
   datetime_aware: boolean;
   document_set_ids: number[];
-  is_public: boolean;
+  is_public?: boolean;
   default_model_configuration_id: number | null;
   starter_messages: AgentStarterMessage[] | null;
   users?: string[];
-  groups: number[];
+  groups?: number[];
   tool_ids: number[];
   remove_image?: boolean;
   uploaded_image_id: string | null;

--- a/web/src/lib/agents/utils.ts
+++ b/web/src/lib/agents/utils.ts
@@ -30,9 +30,13 @@ export function checkUserCanEditAgent(
 ): boolean {
   if (!user || agent.builtin_persona) return false;
   if (checkUserIsNoAuthUser(user.id)) return true;
-  return (
-    agent.user_permission === "OWNER" || agent.user_permission === "EDITOR"
-  );
+  if (agent.user_permission != null) {
+    return (
+      agent.user_permission === "OWNER" || agent.user_permission === "EDITOR"
+    );
+  }
+  // Fallback for payloads predating user_permission: only ownership is knowable
+  return agent.owner?.id === user.id;
 }
 
 // TODO(ENG-3766): rename to agent

--- a/web/src/lib/agents/utils.ts
+++ b/web/src/lib/agents/utils.ts
@@ -3,20 +3,35 @@ import { checkUserIsNoAuthUser } from "@/lib/user";
 import { MinimalAgent, Agent } from "@/lib/agents/types";
 
 /**
- * Returns true if the user owns the agent and may edit or delete it.
- * No-auth users are treated as owning all non-builtin agents.
- * Built-in agents are never owned by anyone.
+ * Returns true if the user owns the agent (directly or via an owner group —
+ * the server-computed `user_permission` covers both). No-auth users are
+ * treated as owning all non-builtin agents; built-ins are never owned.
  */
 export function checkUserOwnsAgent(
   user: User | null,
   agent: MinimalAgent | Agent
 ): boolean {
-  if (!user) return false;
-  const userId = user.id;
+  if (!user || agent.builtin_persona) return false;
+  if (checkUserIsNoAuthUser(user.id)) return true;
+  if (agent.user_permission != null) {
+    return agent.user_permission === "OWNER";
+  }
+  // Fallback for payloads predating user_permission
+  return agent.owner?.id === user.id;
+}
+
+/**
+ * Returns true if the user may edit the agent — owner, EDITOR-level sharee,
+ * or admin (admins report EDITOR server-side).
+ */
+export function checkUserCanEditAgent(
+  user: User | null,
+  agent: MinimalAgent | Agent
+): boolean {
+  if (!user || agent.builtin_persona) return false;
+  if (checkUserIsNoAuthUser(user.id)) return true;
   return (
-    !!userId &&
-    (checkUserIsNoAuthUser(userId) || agent.owner?.id === userId) &&
-    !agent.builtin_persona
+    agent.user_permission === "OWNER" || agent.user_permission === "EDITOR"
   );
 }
 

--- a/web/src/refresh-components/inputs/InputTypeIn.ts
+++ b/web/src/refresh-components/inputs/InputTypeIn.ts
@@ -1,0 +1,5 @@
+import { InputTypeIn, type InputTypeInProps } from "@opal/components";
+
+export type { InputTypeInProps };
+
+export default InputTypeIn;

--- a/web/src/sections/modals/AddPeoplePicker.tsx
+++ b/web/src/sections/modals/AddPeoplePicker.tsx
@@ -67,7 +67,7 @@ export function AddPeoplePicker({
     }
 
     const userSuggestions = users
-      .filter((user) => user.email.toLowerCase().startsWith(trimmedQuery))
+      .filter((user) => user.email.toLowerCase().includes(trimmedQuery))
       .filter((user) => !stagedUserIds.has(user.id))
       .map((user) => ({
         id: user.id,

--- a/web/src/sections/modals/AddPeoplePicker.tsx
+++ b/web/src/sections/modals/AddPeoplePicker.tsx
@@ -98,7 +98,7 @@ export function AddPeoplePicker({
   ]);
 
   const hasStagedItems = stagedUsers.length > 0 || stagedGroups.length > 0;
-  const permissionOptions = useMemo(() => PERMISSION_OPTIONS, []);
+  const permissionOptions = PERMISSION_OPTIONS;
 
   function handleSelectSuggestion(suggestion: Suggestion) {
     if (suggestion.shared) {

--- a/web/src/sections/modals/AddPeoplePicker.tsx
+++ b/web/src/sections/modals/AddPeoplePicker.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { ChangeEvent, useMemo, useState } from "react";
+import { Button, LineItemButton, Tag, Text } from "@opal/components";
+import { SvgUser, SvgUsers, SvgX } from "@opal/icons";
+import { cn } from "@opal/utils";
+import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
+import { PersonaSharePermission } from "@/lib/agents/types";
+import { MinimalUserSnapshot } from "@/lib/types";
+import { MinimalUserGroupSnapshot } from "@/hooks/useShareableGroups";
+import { SharePermissionMenu } from "@/sections/modals/SharePermissionMenu";
+import { PERMISSION_OPTIONS } from "@/sections/modals/shareAccessConstants";
+
+interface Suggestion {
+  id: string;
+  label: string;
+  shared: boolean;
+  type: "group" | "user";
+}
+
+export interface AddPeoplePickerProps {
+  disabled?: boolean;
+  existingGroupIds: Set<number>;
+  existingUserIds: Set<string>;
+  groups: MinimalUserGroupSnapshot[];
+  onAddGroup: (group: MinimalUserGroupSnapshot) => void;
+  onAddUser: (user: MinimalUserSnapshot) => void;
+  onRemoveGroup: (groupId: number) => void;
+  onRemoveUser: (userId: string) => void;
+  onStagedPermissionChange: (permission: PersonaSharePermission) => void;
+  stagedGroups: MinimalUserGroupSnapshot[];
+  stagedPermission: PersonaSharePermission;
+  stagedUsers: MinimalUserSnapshot[];
+  users: MinimalUserSnapshot[];
+}
+
+export function AddPeoplePicker({
+  disabled = false,
+  existingGroupIds,
+  existingUserIds,
+  groups,
+  onAddGroup,
+  onAddUser,
+  onRemoveGroup,
+  onRemoveUser,
+  onStagedPermissionChange,
+  stagedGroups,
+  stagedPermission,
+  stagedUsers,
+  users,
+}: AddPeoplePickerProps) {
+  const [query, setQuery] = useState("");
+
+  const stagedUserIds = useMemo(
+    () => new Set(stagedUsers.map((user) => user.id)),
+    [stagedUsers]
+  );
+  const stagedGroupIds = useMemo(
+    () => new Set(stagedGroups.map((group) => group.id)),
+    [stagedGroups]
+  );
+
+  const suggestions = useMemo((): Suggestion[] => {
+    const trimmedQuery = query.trim().toLowerCase();
+    if (!trimmedQuery) {
+      return [];
+    }
+
+    const userSuggestions = users
+      .filter((user) => user.email.toLowerCase().startsWith(trimmedQuery))
+      .filter((user) => !stagedUserIds.has(user.id))
+      .map((user) => ({
+        id: user.id,
+        label: user.email,
+        shared: existingUserIds.has(user.id),
+        type: "user" as const,
+      }));
+
+    const groupSuggestions = groups
+      .filter((group) => group.name.toLowerCase().includes(trimmedQuery))
+      .filter((group) => !stagedGroupIds.has(group.id))
+      .map((group) => ({
+        id: String(group.id),
+        label: group.name,
+        shared: existingGroupIds.has(group.id),
+        type: "group" as const,
+      }));
+
+    return [...userSuggestions, ...groupSuggestions].slice(0, 8);
+  }, [
+    existingGroupIds,
+    existingUserIds,
+    groups,
+    query,
+    stagedGroupIds,
+    stagedUserIds,
+    users,
+  ]);
+
+  const hasStagedItems = stagedUsers.length > 0 || stagedGroups.length > 0;
+  const permissionOptions = useMemo(() => PERMISSION_OPTIONS, []);
+
+  function handleSelectSuggestion(suggestion: Suggestion) {
+    if (suggestion.shared) {
+      return;
+    }
+
+    if (suggestion.type === "user") {
+      const user = users.find(
+        (shareableUser) => shareableUser.id === suggestion.id
+      );
+      if (user) {
+        onAddUser(user);
+      }
+    } else {
+      const group = groups.find(
+        (shareableGroup) => shareableGroup.id === Number(suggestion.id)
+      );
+      if (group) {
+        onAddGroup(group);
+      }
+    }
+
+    setQuery("");
+  }
+
+  return (
+    <div className="flex w-full flex-col gap-2">
+      {hasStagedItems ? (
+        <div className="flex flex-wrap gap-2">
+          {stagedUsers.map((user) => (
+            <div
+              className="flex items-center gap-1 rounded-08 bg-background-tint-02 px-2 py-1"
+              key={user.id}
+            >
+              <SvgUser className="h-4 w-4 stroke-text-03" />
+              <Text color="text-04" font="main-ui-body">
+                {user.email}
+              </Text>
+              <Button
+                icon={SvgX}
+                onClick={() => onRemoveUser(user.id)}
+                prominence="tertiary"
+                size="2xs"
+              />
+            </div>
+          ))}
+
+          {stagedGroups.map((group) => (
+            <div
+              className="flex items-center gap-1 rounded-08 bg-background-tint-02 px-2 py-1"
+              key={group.id}
+            >
+              <SvgUsers className="h-4 w-4 stroke-text-03" />
+              <Text color="text-04" font="main-ui-body">
+                {group.name}
+              </Text>
+              <Button
+                icon={SvgX}
+                onClick={() => onRemoveGroup(group.id)}
+                prominence="tertiary"
+                size="2xs"
+              />
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      <div className="flex items-start gap-2">
+        <div className="relative min-w-0 flex-1">
+          <InputTypeIn
+            clearButton
+            onChange={(event: ChangeEvent<HTMLInputElement>) =>
+              setQuery(event.target.value)
+            }
+            placeholder="Add users, groups, and accounts"
+            value={query}
+            variant={disabled ? "disabled" : "primary"}
+          />
+
+          {suggestions.length > 0 ? (
+            <div className="absolute left-0 right-0 top-[calc(100%+0.25rem)] z-20 rounded-12 border border-border-01 bg-background-tint-00 p-1 shadow-md">
+              <div className="flex flex-col gap-1">
+                {suggestions.map((suggestion) => (
+                  <div
+                    className={cn(suggestion.shared ? "opacity-60" : undefined)}
+                    key={`${suggestion.type}-${suggestion.id}`}
+                  >
+                    <LineItemButton
+                      description={
+                        suggestion.type === "group" ? "Group" : undefined
+                      }
+                      icon={suggestion.type === "group" ? SvgUsers : SvgUser}
+                      onClick={() => handleSelectSuggestion(suggestion)}
+                      rightChildren={
+                        suggestion.shared ? (
+                          <Tag color="gray" title="Shared" />
+                        ) : null
+                      }
+                      rounding="md"
+                      selectVariant="select-heavy"
+                      sizePreset="main-ui"
+                      state={suggestion.shared ? "filled" : "empty"}
+                      title={suggestion.label}
+                      variant="section"
+                      width="full"
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : null}
+        </div>
+
+        {hasStagedItems ? (
+          <div className="w-40 shrink-0">
+            <SharePermissionMenu
+              ariaLabel="Select staged permission"
+              onChange={onStagedPermissionChange}
+              options={permissionOptions}
+              value={stagedPermission}
+              width="full"
+            />
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/web/src/sections/modals/ShareAccessRow.tsx
+++ b/web/src/sections/modals/ShareAccessRow.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { Text } from "@opal/components";
+import { ContentAction } from "@opal/layouts";
+import type { IconFunctionComponent, RichStr } from "@opal/types";
+
+interface ShareAvatarProps {
+  initial?: string;
+  icon?: IconFunctionComponent;
+}
+
+// No opal avatar primitive exists yet — the mock's dark initial/glyph circle
+// is the one hand-built piece in this file
+function ShareAvatar({ initial, icon: Icon }: ShareAvatarProps) {
+  return (
+    <div className="flex h-7 w-7 items-center justify-center rounded-full bg-background-neutral-inverted-00">
+      {Icon ? (
+        <Icon size={12} className="stroke-text-inverted-05" aria-hidden />
+      ) : (
+        <Text font="secondary-action" color="text-inverted-05">
+          {initial}
+        </Text>
+      )}
+    </div>
+  );
+}
+
+interface PermissionColumnsProps {
+  rightChildren?: React.ReactNode;
+  trailing?: React.ReactNode;
+}
+
+// Fixed 160px left-aligned permission column (mock: Column/Medium) so every
+// row's permission label starts at the same x, plus the far-right slot
+function PermissionColumns({
+  rightChildren,
+  trailing,
+}: PermissionColumnsProps) {
+  return (
+    <div className="flex shrink-0 items-center">
+      <div className="flex w-40 items-center justify-start">
+        {rightChildren}
+      </div>
+      {trailing}
+    </div>
+  );
+}
+
+export interface ShareAccessRowProps {
+  icon: IconFunctionComponent;
+  /** Initial rendered in a dark avatar circle; omitted → the bare icon */
+  avatarInitial?: string;
+  /** Icon rendered inside a dark avatar circle (groups, service accounts) */
+  avatarIcon?: IconFunctionComponent;
+  title?: string | RichStr;
+  /** Replaces the title text (e.g. the scope dropdown trigger) */
+  titleSlot?: React.ReactNode;
+  description?: string | RichStr;
+  rightChildren?: React.ReactNode;
+  /** Far-right slot past the permission column (e.g. the owner swap icon) */
+  trailing?: React.ReactNode;
+}
+
+export function ShareAccessRow({
+  icon,
+  avatarInitial,
+  avatarIcon,
+  title,
+  titleSlot,
+  description,
+  rightChildren,
+  trailing,
+}: ShareAccessRowProps) {
+  const LeadingIcon: IconFunctionComponent =
+    avatarInitial || avatarIcon
+      ? function ShareRowAvatarIcon() {
+          return <ShareAvatar initial={avatarInitial} icon={avatarIcon} />;
+        }
+      : icon;
+
+  // ContentAction can't host a component title — the scope row (dropdown in
+  // the title position) keeps a layout-only flex of opal children
+  if (titleSlot) {
+    return (
+      <div className="flex min-h-11 w-full items-center justify-between gap-2 rounded-12 bg-background-tint-01 px-1 py-1">
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center">
+            <LeadingIcon size={16} className="stroke-text-03" aria-hidden />
+          </div>
+          {titleSlot}
+        </div>
+        <PermissionColumns rightChildren={rightChildren} trailing={trailing} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-11 w-full rounded-12 bg-background-tint-01 px-1">
+      <ContentAction
+        description={description}
+        icon={LeadingIcon}
+        padding="sm"
+        rightChildren={
+          <PermissionColumns
+            rightChildren={rightChildren}
+            trailing={trailing}
+          />
+        }
+        sizePreset="main-ui"
+        title={title ?? ""}
+        variant="section"
+      />
+    </div>
+  );
+}

--- a/web/src/sections/modals/ShareAccessRow.tsx
+++ b/web/src/sections/modals/ShareAccessRow.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useMemo } from "react";
+
 import { Text } from "@opal/components";
 import { ContentAction } from "@opal/layouts";
 import type { IconFunctionComponent, RichStr } from "@opal/types";
@@ -71,12 +73,17 @@ export function ShareAccessRow({
   rightChildren,
   trailing,
 }: ShareAccessRowProps) {
-  const LeadingIcon: IconFunctionComponent =
-    avatarInitial || avatarIcon
-      ? function ShareRowAvatarIcon() {
-          return <ShareAvatar initial={avatarInitial} icon={avatarIcon} />;
-        }
-      : icon;
+  // Stable identity: a fresh function each render makes ContentAction remount
+  // the icon subtree instead of updating it.
+  const LeadingIcon: IconFunctionComponent = useMemo(
+    () =>
+      avatarInitial || avatarIcon
+        ? function ShareRowAvatarIcon() {
+            return <ShareAvatar initial={avatarInitial} icon={avatarIcon} />;
+          }
+        : icon,
+    [avatarInitial, avatarIcon, icon]
+  );
 
   // ContentAction can't host a component title — the scope row (dropdown in
   // the title position) keeps a layout-only flex of opal children

--- a/web/src/sections/modals/SharePermissionMenu.tsx
+++ b/web/src/sections/modals/SharePermissionMenu.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { Button, LineItemButton, OpenButton, Popover } from "@opal/components";
+import { SvgMinusCircle } from "@opal/icons";
+import type { IconFunctionComponent } from "@opal/types";
+
+export interface SharePermissionMenuOption<T extends string> {
+  value: T;
+  label: string;
+  icon: IconFunctionComponent;
+}
+
+export interface SharePermissionMenuProps<T extends string> {
+  value: T;
+  options: SharePermissionMenuOption<T>[];
+  onChange?: (value: T) => void;
+  onRemove?: () => void;
+  removeLabel?: string;
+  disabled?: boolean;
+  width?: "fit" | "full";
+  /** The status row's qualifier already shows the scope icon — the mock's
+      scope pill is text + chevron only */
+  showTriggerIcon?: boolean;
+  /** Fixed menu width — full-width items inside a fit-content popover
+      collapse to min-content and truncate */
+  menuWidth?: "sm" | "md" | "lg" | "xl" | "2xl";
+  ariaLabel?: string;
+}
+
+export function SharePermissionMenu<T extends string>({
+  value,
+  options,
+  onChange,
+  onRemove,
+  removeLabel = "Remove Access",
+  disabled = false,
+  width = "fit",
+  showTriggerIcon = true,
+  menuWidth = "md",
+  ariaLabel,
+}: SharePermissionMenuProps<T>) {
+  const selectedOption =
+    options.find((option) => option.value === value) ?? options[0];
+
+  if (!selectedOption) {
+    return null;
+  }
+
+  if (disabled || (!onChange && !onRemove)) {
+    return (
+      <OpenButton
+        aria-label={ariaLabel}
+        disabled
+        foldable={false}
+        icon={showTriggerIcon ? selectedOption.icon : undefined}
+        labelColor="text-04"
+        labelFont="main-ui-action"
+        size="sm"
+        variant="select-light"
+        width={width}
+      >
+        {selectedOption.label}
+      </OpenButton>
+    );
+  }
+
+  return (
+    <Popover>
+      <Popover.Trigger asChild>
+        <OpenButton
+          aria-label={ariaLabel}
+          foldable={false}
+          icon={showTriggerIcon ? selectedOption.icon : undefined}
+          labelColor="text-04"
+          labelFont="main-ui-action"
+          size="sm"
+          variant="select-light"
+          width={width}
+        >
+          {selectedOption.label}
+        </OpenButton>
+      </Popover.Trigger>
+
+      <Popover.Content align="end" side="bottom" width={menuWidth}>
+        <Popover.Menu>
+          {options.map((option) => (
+            <Popover.Close asChild key={option.value}>
+              <LineItemButton
+                icon={option.icon}
+                onClick={() => onChange?.(option.value)}
+                rounding="md"
+                selectVariant="select-heavy"
+                sizePreset="main-ui"
+                state={option.value === value ? "selected" : "empty"}
+                title={option.label}
+                variant="section"
+                width="full"
+              />
+            </Popover.Close>
+          ))}
+
+          {onRemove && (
+            <Popover.Close asChild>
+              <Button
+                icon={SvgMinusCircle}
+                onClick={onRemove}
+                prominence="tertiary"
+                variant="danger"
+                width="full"
+              >
+                {removeLabel}
+              </Button>
+            </Popover.Close>
+          )}
+        </Popover.Menu>
+      </Popover.Content>
+    </Popover>
+  );
+}

--- a/web/src/sections/modals/TransferOwnershipView.tsx
+++ b/web/src/sections/modals/TransferOwnershipView.tsx
@@ -39,7 +39,11 @@ export function TransferOwnershipView({
   const [inputValue, setInputValue] = useState("");
 
   useEffect(() => {
-    setInputValue(selectedTarget?.label ?? "");
+    // Only sync the field when a real selection arrives. A null target comes
+    // from the user typing to change the selection, where their input must stand.
+    if (selectedTarget) {
+      setInputValue(selectedTarget.label);
+    }
   }, [selectedTarget]);
 
   const options = useMemo(() => {

--- a/web/src/sections/modals/TransferOwnershipView.tsx
+++ b/web/src/sections/modals/TransferOwnershipView.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import InputComboBox from "@/refresh-components/inputs/InputComboBox";
+import { MinimalUserGroupSnapshot } from "@/hooks/useShareableGroups";
+import { FullAgent } from "@/lib/agents/types";
+import { MinimalUserSnapshot } from "@/lib/types";
+import { Tag, Text } from "@opal/components";
+import { SvgUser, SvgUsers } from "@opal/icons";
+
+export type TransferOwnershipTarget =
+  | {
+      label: string;
+      type: "group";
+      value: `group-${number}`;
+    }
+  | {
+      label: string;
+      type: "user";
+      value: `user-${string}`;
+    }
+  | null;
+
+export interface TransferOwnershipViewProps {
+  agent: FullAgent | null;
+  groups: MinimalUserGroupSnapshot[];
+  onSelectedTargetChange: (target: TransferOwnershipTarget) => void;
+  selectedTarget: TransferOwnershipTarget;
+  users: MinimalUserSnapshot[];
+}
+
+export function TransferOwnershipView({
+  agent,
+  groups,
+  onSelectedTargetChange,
+  selectedTarget,
+  users,
+}: TransferOwnershipViewProps) {
+  const [inputValue, setInputValue] = useState("");
+
+  useEffect(() => {
+    setInputValue(selectedTarget?.label ?? "");
+  }, [selectedTarget]);
+
+  const options = useMemo(() => {
+    const ownerUserId = agent?.owner?.id;
+    const ownerGroupId = agent?.owner_group?.id;
+
+    const userOptions = users.map((user) => ({
+      value: `user-${user.id}`,
+      label: user.email,
+      description: ownerUserId === user.id ? "Current Owner" : undefined,
+      disabled: ownerUserId === user.id,
+    }));
+
+    const groupOptions = groups.map((group) => ({
+      value: `group-${group.id}`,
+      label: group.name,
+      description: ownerGroupId === group.id ? "Current Owner" : undefined,
+      disabled: ownerGroupId === group.id,
+    }));
+
+    return [...userOptions, ...groupOptions];
+  }, [agent?.owner?.id, agent?.owner_group?.id, groups, users]);
+
+  function handleValueChange(value: string) {
+    const selectedOption = options.find((option) => option.value === value);
+    if (!selectedOption) {
+      onSelectedTargetChange(null);
+      return;
+    }
+
+    if (value.startsWith("user-")) {
+      onSelectedTargetChange({
+        label: selectedOption.label,
+        type: "user",
+        value: value as `user-${string}`,
+      });
+      return;
+    }
+
+    onSelectedTargetChange({
+      label: selectedOption.label,
+      type: "group",
+      value: value as `group-${number}`,
+    });
+  }
+
+  return (
+    <div className="flex w-full flex-col gap-3">
+      <div className="flex flex-col gap-1">
+        <Text color="text-03" font="secondary-body">
+          Transfer Ownership To
+        </Text>
+
+        <InputComboBox
+          onChange={(event) => {
+            setInputValue(event.target.value);
+            onSelectedTargetChange(null);
+          }}
+          onValueChange={handleValueChange}
+          options={options}
+          placeholder="Add a user or group"
+          strict
+          value={inputValue}
+        />
+      </div>
+
+      {selectedTarget ? (
+        <div className="flex items-center justify-between rounded-12 border border-border-01 bg-background-tint-00 px-3 py-2">
+          <div className="flex items-center gap-2">
+            {selectedTarget.type === "group" ? (
+              <SvgUsers className="h-4 w-4 stroke-text-03" />
+            ) : (
+              <SvgUser className="h-4 w-4 stroke-text-03" />
+            )}
+
+            <Text color="text-04" font="main-ui-body">
+              {selectedTarget.label}
+            </Text>
+          </div>
+
+          {selectedTarget.type === "group" ? (
+            <Tag color="gray" title="Group" />
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/web/src/sections/modals/shareAccessConstants.ts
+++ b/web/src/sections/modals/shareAccessConstants.ts
@@ -1,0 +1,32 @@
+import { PersonaSharePermission } from "@/lib/agents/types";
+import { SvgBubbleText, SvgEdit, SvgLock, SvgOrganization } from "@opal/icons";
+import { SharePermissionMenuOption } from "@/sections/modals/SharePermissionMenu";
+
+export type ShareScope = "PRIVATE" | "PUBLIC";
+
+export const PERMISSION_OPTIONS: SharePermissionMenuOption<PersonaSharePermission>[] =
+  [
+    {
+      icon: SvgBubbleText,
+      label: "View & Chat",
+      value: "VIEWER",
+    },
+    {
+      icon: SvgEdit,
+      label: "Edit",
+      value: "EDITOR",
+    },
+  ];
+
+export const SCOPE_OPTIONS: SharePermissionMenuOption<ShareScope>[] = [
+  {
+    icon: SvgLock,
+    label: "Only those invited",
+    value: "PRIVATE",
+  },
+  {
+    icon: SvgOrganization,
+    label: "Anyone in your organization",
+    value: "PUBLIC",
+  },
+];


### PR DESCRIPTION
## Description

PR 5/7 of the Agent Sharing stack — frontend foundation (ENG-4175, UI). First frontend PR; no Python.

The pieces the redesigned dialog is built from:
- Client share/ownership type fields; svc calls (`updateAgentShares`, `transferAgentOwnership`, `removeSelfFromAgentShares`, `parseErrorDetail`); ownership/edit helpers
- Additive Opal `OpenButton` label props
- Reusable dialog components: `ShareAccessRow`, `SharePermissionMenu`, `AddPeoplePicker`, `TransferOwnershipView`

All additive/leaf — existing call sites unaffected; the new components are unused until the dialog composes them in 6/7. Stacked on the backend PRs.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check