### PR TITLE
feat(agent-sharing): edit-page section, admin gating, owned-only gallery - 7/7

### DIFF
--- a/web/lib/opal/src/components/cards/message-card/components.tsx
+++ b/web/lib/opal/src/components/cards/message-card/components.tsx
@@ -35,6 +35,9 @@ interface MessageCardBaseProps {
   /** Optional description below the title. */
   description?: string | RichStr;
 
+  /** Let the title wrap to multiple lines instead of truncating to one. */
+  titleWrap?: boolean;
+
   /** Padding preset. @default "sm" */
   padding?: Extract<PaddingVariants, "sm" | "xs">;
 
@@ -124,6 +127,7 @@ function MessageCard({
   icon: iconOverride,
   title,
   description,
+  titleWrap,
   padding = "sm",
   headerPadding = "fit",
   bottomChildren,
@@ -160,6 +164,7 @@ function MessageCard({
           )}
           title={title}
           description={description}
+          titleWrap={titleWrap}
           sizePreset="main-ui"
           variant="section"
           padding="md"

--- a/web/lib/opal/src/layouts/content/ContentMd.tsx
+++ b/web/lib/opal/src/layouts/content/ContentMd.tsx
@@ -70,6 +70,9 @@ interface ContentMdProps {
   /** Tag rendered beside the title. */
   tag?: TagProps;
 
+  /** Let the title wrap to multiple lines instead of truncating to one. */
+  titleWrap?: boolean;
+
   /** Size preset. Default: `"main-ui"`. */
   sizePreset?: ContentMdSizePreset;
 
@@ -138,6 +141,7 @@ function ContentMd({
   suffix,
   auxIcon,
   tag,
+  titleWrap,
   sizePreset = "main-ui",
   ref,
 }: ContentMdProps) {
@@ -214,7 +218,7 @@ function ContentMd({
             <Text
               font={config.titleFont}
               color="inherit"
-              maxLines={1}
+              maxLines={titleWrap ? undefined : 1}
               title={toPlainString(title)}
               onClick={editable ? startEditing : undefined}
             >

--- a/web/lib/opal/src/layouts/content/components.tsx
+++ b/web/lib/opal/src/layouts/content/components.tsx
@@ -113,6 +113,8 @@ type MdContentProps = ContentBaseProps & {
   auxIcon?: "info-gray" | "info-blue" | "warning" | "error";
   /** Tag rendered beside the title. */
   tag?: TagProps;
+  /** Let the title wrap to multiple lines instead of truncating to one. */
+  titleWrap?: boolean;
 };
 
 /** ContentSm does not support descriptions or inline editing. */

--- a/web/src/providers/ToastProvider.tsx
+++ b/web/src/providers/ToastProvider.tsx
@@ -123,6 +123,7 @@ function ToastContainer() {
             <MessageCard
               variant={LEVEL_TO_VARIANT[t.level ?? "info"]}
               title={truncatedTitle}
+              titleWrap
               description={buildDescription(t)}
               padding="xs"
               onClose={t.dismissible ? () => handleClose(t.id) : undefined}

--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -6,7 +6,7 @@ import { SettingsLayouts } from "@opal/layouts";
 import * as GeneralLayouts from "@/layouts/general-layouts";
 import { Button, Card, Divider, MessageCard } from "@opal/components";
 import { Hoverable, Disabled } from "@opal/core";
-import { FullAgent } from "@/lib/agents/types";
+import { FullAgent, PersonaSharingStatus } from "@/lib/agents/types";
 import { buildAgentAvatarUrl } from "@/lib/agents/utils";
 import { Formik, Form, FieldArray } from "formik";
 import * as Yup from "yup";
@@ -16,6 +16,7 @@ import InputTypeInElementField from "@/refresh-components/form/InputTypeInElemen
 import InputDatePickerField from "@/refresh-components/form/InputDatePickerField";
 import {
   Card as CardLayout,
+  Content,
   ContentAction,
   InputHorizontal,
   InputVertical,
@@ -53,11 +54,15 @@ import LineItem from "@/refresh-components/buttons/LineItem";
 import {
   SvgActions,
   SvgExpand,
+  SvgEye,
+  SvgEyeOff,
   SvgFold,
   SvgImage,
   SvgLock,
   SvgOnyxOctagon,
+  SvgOrganization,
   SvgSliders,
+  SvgTag,
   SvgUsers,
   SvgTrash,
   SvgSimpleLoader,
@@ -67,8 +72,9 @@ import CustomAgentAvatar, {
 } from "@/refresh-components/avatars/CustomAgentAvatar";
 import InputAvatar from "@/refresh-components/inputs/InputAvatar";
 import SquareButton from "@/refresh-components/buttons/SquareButton";
-import { useAgents } from "@/lib/agents/hooks";
+import { useAgents, useLabels } from "@/lib/agents/hooks";
 import { createAgent, updateAgent } from "@/lib/agents/svc";
+import InputChipField from "@/refresh-components/inputs/InputChipField";
 import { AgentUpsertParameters } from "@/lib/agents/types";
 import { useMcpServersForAgentEditor } from "@/lib/agents/hooks";
 import useOpenApiTools from "@/hooks/useOpenApiTools";
@@ -82,17 +88,20 @@ import { useAppRouter } from "@/hooks/appNavigation";
 import { isDateInFuture } from "@/lib/dateUtils";
 import {
   deleteAgent,
-  updateAgentFeaturedStatus,
-  updateAgentSharedStatus,
+  parseErrorDetail,
+  toggleAgentListed,
+  updateAgentShares,
 } from "@/lib/agents/svc";
+import { useTierAtLeast } from "@/hooks/useTierAtLeast";
+import { Tier } from "@/lib/settings/types";
 import ConfirmationModalLayout from "@/refresh-components/layouts/ConfirmationModalLayout";
-import ShareAgentModal from "@/sections/modals/ShareAgentModal";
+import ShareAgentModal, {
+  ShareDraftState,
+} from "@/sections/modals/ShareAgentModal";
 import AgentKnowledgePane from "@/sections/knowledge/AgentKnowledgePane";
 import { ValidSources } from "@/lib/types";
 import { useSettings } from "@/lib/settings/hooks";
 import { useUser } from "@/providers/UserProvider";
-import { useTierAtLeast } from "@/hooks/useTierAtLeast";
-import { Tier } from "@/lib/settings/types";
 
 interface AgentIconEditorProps {
   existingAgent?: FullAgent | null;
@@ -487,10 +496,58 @@ export default function AgentEditorPage({
   const { refresh: refreshAgents } = useAgents();
   const shareAgentModal = useCreateModal();
   const deleteAgentModal = useCreateModal();
-  const { isAdmin, isCurator } = useUser();
-  const canUpdateFeaturedStatus = isAdmin || isCurator;
+  const { isAdmin } = useUser();
+  // Feature/unlist are admin-only surfaces — never shown to non-admin
+  // owners or editors (ENG-4179)
+  const canUpdateFeaturedStatus = isAdmin;
   const { vectorDbEnabled } = useSettings();
   const businessTier = useTierAtLeast(Tier.BUSINESS);
+
+  // Labels are edited in the Share Agent section and saved with the form
+  const { labels: allLabels, createLabel } = useLabels();
+  const [labelInputValue, setLabelInputValue] = useState("");
+  const addAgentLabel = useCallback(
+    async (
+      name: string,
+      labelIds: number[],
+      setFieldValue: (field: string, value: number[]) => void
+    ) => {
+      const trimmed = name.trim();
+      if (!trimmed) return;
+      const existing = allLabels?.find(
+        (label) => label.name.toLowerCase() === trimmed.toLowerCase()
+      );
+      if (existing) {
+        if (!labelIds.includes(existing.id)) {
+          setFieldValue("label_ids", [...labelIds, existing.id]);
+        }
+      } else {
+        const newLabel = await createLabel(trimmed);
+        if (newLabel) {
+          setFieldValue("label_ids", [...labelIds, newLabel.id]);
+        }
+      }
+      setLabelInputValue("");
+    },
+    [allLabels, createLabel]
+  );
+
+  const [isTogglingListed, setIsTogglingListed] = useState(false);
+  const handleToggleListed = useCallback(async () => {
+    if (!existingAgent) return;
+    setIsTogglingListed(true);
+    try {
+      await toggleAgentListed(existingAgent.id, existingAgent.is_listed);
+      refreshAgent?.();
+      await refreshAgents();
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to toggle visibility"
+      );
+    } finally {
+      setIsTogglingListed(false);
+    }
+  }, [existingAgent, refreshAgent, refreshAgents]);
 
   // Hooks for Knowledge section
   const { allRecentFiles, beginUpload } = useProjectsContext();
@@ -672,6 +729,9 @@ export default function AgentEditorPage({
     shared_user_ids: existingAgent?.users?.map((user) => user.id) ?? [],
     shared_group_ids: existingAgent?.groups ?? [],
     is_public: existingAgent?.is_public ?? false,
+    // Full leveled share draft captured by the dialog before the agent
+    // exists; applied via the share endpoint right after create
+    shared_draft: null as ShareDraftState | null,
     label_ids: existingAgent?.labels?.map((l) => l.id) ?? [],
     is_featured: existingAgent?.is_featured ?? false,
   };
@@ -812,12 +872,19 @@ export default function AgentEditorPage({
         document_set_ids: values.enable_knowledge
           ? values.document_set_ids
           : [],
-        is_public: values.is_public,
+        // Sharing on saved agents is managed by the share dialog — omitting
+        // the fields here keeps form saves from clobbering it. Creates carry
+        // the draft share state captured before the agent existed.
+        ...(existingAgent
+          ? {}
+          : {
+              is_public: values.is_public,
+              users: values.shared_user_ids,
+              groups: values.shared_group_ids,
+            }),
         default_model_configuration_id:
           (values as any).default_model_configuration_id ?? null,
         starter_messages: finalAgentStarterMessages,
-        users: values.shared_user_ids,
-        groups: values.shared_group_ids,
         tool_ids: toolIds,
         // uploaded_image: null, // Already uploaded separately
         remove_image: values.remove_image ?? false,
@@ -837,7 +904,7 @@ export default function AgentEditorPage({
         system_prompt: values.instructions,
         replace_base_system_prompt: values.replace_base_system_prompt,
         task_prompt: values.reminders || "",
-        datetime_aware: false,
+        datetime_aware: existingAgent ? existingAgent.datetime_aware : false,
       };
 
       // Call API
@@ -850,17 +917,41 @@ export default function AgentEditorPage({
 
       // Handle response
       if (!personaResponse || !personaResponse.ok) {
-        const error = personaResponse
-          ? await personaResponse.text()
-          : "No response received";
-        toast.error(
-          `Failed to ${existingAgent ? "update" : "create"} agent - ${error}`
-        );
+        const prefix = `Failed to ${existingAgent ? "update" : "create"} agent`;
+        const detail = personaResponse
+          ? await parseErrorDetail(personaResponse, "unknown error")
+          : "no response received";
+        toast.error(`${prefix} - ${detail}`);
         return;
       }
 
       // Success
       const agent = await personaResponse.json();
+
+      // Apply the leveled share draft captured in the dialog before the
+      // agent existed (the create payload only carries viewer-level ids)
+      if (!existingAgent && values.shared_draft) {
+        const draft = values.shared_draft;
+        const shareError = await updateAgentShares(
+          agent.id,
+          {
+            user_shares: draft.userShares.map((share) => ({
+              user_id: share.user.id,
+              permission: share.permission,
+            })),
+            group_shares: draft.groupShares.map((share) => ({
+              group_id: share.group_id,
+              permission: share.permission,
+            })),
+            is_public: draft.isPublic,
+            public_permission: draft.publicPermission,
+          },
+          businessTier
+        );
+        if (shareError) {
+          toast.error(`Agent created, but sharing failed: ${shareError}`);
+        }
+      }
       toast.success(
         `Agent "${agent.name}" ${
           existingAgent ? "updated" : "created"
@@ -1018,10 +1109,22 @@ export default function AgentEditorPage({
               (fileId: string) =>
                 fileStatusMap.get(fileId) === UserFileStatus.PROCESSING
             );
-            const isShared =
-              values.is_public ||
-              values.shared_user_ids.length > 0 ||
-              values.shared_group_ids.length > 0;
+            // Saved agents report their status (group ownership counts as
+            // shared); unsaved ones derive it from the draft form state.
+            const sharingStatus: PersonaSharingStatus = existingAgent
+              ? existingAgent.sharing_status
+              : values.is_public
+                ? "PUBLIC"
+                : values.shared_user_ids.length > 0 ||
+                    values.shared_group_ids.length > 0
+                  ? "SHARED"
+                  : "PRIVATE";
+            const shareStatusIcon =
+              sharingStatus === "PRIVATE"
+                ? SvgLock
+                : sharingStatus === "SHARED"
+                  ? SvgUsers
+                  : SvgOrganization;
 
             return (
               <>
@@ -1078,116 +1181,22 @@ export default function AgentEditorPage({
                 <shareAgentModal.Provider>
                   <ShareAgentModal
                     agentId={existingAgent?.id}
-                    userIds={values.shared_user_ids}
-                    groupIds={values.shared_group_ids}
-                    isPublic={values.is_public}
-                    isFeatured={values.is_featured}
-                    labelIds={values.label_ids}
-                    onShare={async (
-                      userIds,
-                      groupIds,
-                      isPublic,
-                      isFeatured,
-                      labelIds
-                    ) => {
-                      if (!existingAgent) {
-                        // New agents are not persisted until the main Create action.
-                        setFieldValue("shared_user_ids", userIds);
-                        setFieldValue("shared_group_ids", groupIds);
-                        setFieldValue("is_public", isPublic);
-                        setFieldValue("is_featured", isFeatured);
-                        setFieldValue("label_ids", labelIds);
-                        shareAgentModal.toggle(false);
-                        return;
-                      }
-
-                      const applySharingFields = () => {
-                        setFieldValue("shared_user_ids", userIds);
-                        setFieldValue("shared_group_ids", groupIds);
-                        setFieldValue("is_public", isPublic);
-                        setFieldValue("label_ids", labelIds);
-                      };
-
-                      const refreshSharedUi = async () => {
-                        try {
-                          await refreshAgents();
-                          refreshAgent?.();
-                        } catch (error) {
-                          console.error(
-                            "Refresh failed after successful share:",
-                            error
-                          );
-                          toast.error(
-                            "Agent sharing was saved, but failed to refresh. Please reload."
-                          );
-                        }
-                      };
-
-                      let shareError: string | null;
-                      try {
-                        shareError = await updateAgentSharedStatus(
-                          existingAgent.id,
-                          userIds,
-                          groupIds,
-                          isPublic,
-                          businessTier,
-                          labelIds
-                        );
-                      } catch (error) {
-                        console.error(
-                          "Share agent mutation failed unexpectedly:",
-                          error
-                        );
-                        toast.error("Failed to share agent. Please try again.");
-                        return;
-                      }
-
-                      if (shareError) {
-                        toast.error(`Failed to share agent: ${shareError}`);
-                        return;
-                      }
-
-                      if (canUpdateFeaturedStatus) {
-                        let featuredError: string | null;
-                        try {
-                          featuredError = await updateAgentFeaturedStatus(
-                            existingAgent.id,
-                            isFeatured
-                          );
-                        } catch (error) {
-                          console.error(
-                            "Featured mutation failed unexpectedly:",
-                            error
-                          );
-                          // Share succeeded; sync form and UI before returning.
-                          applySharingFields();
-                          await refreshSharedUi();
-                          toast.error(
-                            "Failed to update featured status. Please try again."
-                          );
-                          return;
-                        }
-
-                        if (featuredError) {
-                          // Share succeeded, featured failed: keep modal open for retry.
-                          applySharingFields();
-                          await refreshSharedUi();
-                          toast.error(
-                            `Failed to update featured status: ${featuredError}`
-                          );
-                          return;
-                        }
-
-                        applySharingFields();
-                        setFieldValue("is_featured", isFeatured);
-                        shareAgentModal.toggle(false);
-                        await refreshSharedUi();
-                        return;
-                      }
-
-                      applySharingFields();
+                    draftShares={values.shared_draft}
+                    onDraftSave={(draft) => {
+                      // Saved agents persist sharing inside the dialog; the
+                      // draft only exists for agents not yet created and is
+                      // applied via the share endpoint right after create.
+                      setFieldValue("shared_draft", draft);
+                      setFieldValue(
+                        "shared_user_ids",
+                        draft.userShares.map((share) => share.user.id)
+                      );
+                      setFieldValue(
+                        "shared_group_ids",
+                        draft.groupShares.map((share) => share.group_id)
+                      );
+                      setFieldValue("is_public", draft.isPublic);
                       shareAgentModal.toggle(false);
-                      await refreshSharedUi();
                     }}
                   />
                 </shareAgentModal.Provider>
@@ -1378,6 +1387,101 @@ export default function AgentEditorPage({
                         paddingPerpendicular="fit"
                       />
 
+                      <GeneralLayouts.Section
+                        gap={0.5}
+                        alignItems="stretch"
+                        height="auto"
+                      >
+                        <Content
+                          title="Share Agent"
+                          sizePreset="main-content"
+                          variant="section"
+                        />
+                        <Card border="solid" rounding="lg">
+                          <GeneralLayouts.Section>
+                            <InputHorizontal
+                              title="Share This Agent"
+                              description="with other users, groups, or everyone in your organization."
+                              center
+                            >
+                              <Button
+                                prominence="secondary"
+                                icon={shareStatusIcon}
+                                onClick={() => shareAgentModal.toggle(true)}
+                              >
+                                Share
+                              </Button>
+                            </InputHorizontal>
+                            {canUpdateFeaturedStatus && (
+                              <>
+                                <InputHorizontal
+                                  withLabel="is_featured"
+                                  title="Feature This Agent"
+                                  description="Show this agent at the top of the explore agents list and automatically pin it to the sidebar for new users with access."
+                                >
+                                  <SwitchField name="is_featured" />
+                                </InputHorizontal>
+                                {values.is_featured &&
+                                  sharingStatus === "PRIVATE" && (
+                                    <MessageCard title="This agent is private to you and will only be featured for yourself." />
+                                  )}
+                                {values.is_featured &&
+                                  existingAgent &&
+                                  !existingAgent.is_listed && (
+                                    <MessageCard
+                                      variant="warning"
+                                      title="This agent is unlisted and won't be shown in the featured list."
+                                    />
+                                  )}
+                              </>
+                            )}
+                            <GeneralLayouts.Section
+                              gap={0.25}
+                              alignItems="stretch"
+                            >
+                              <InputChipField
+                                chips={(allLabels ?? [])
+                                  .filter((label) =>
+                                    values.label_ids.includes(label.id)
+                                  )
+                                  .map((label) => ({
+                                    id: String(label.id),
+                                    label: label.name,
+                                  }))}
+                                onRemoveChip={(id) =>
+                                  setFieldValue(
+                                    "label_ids",
+                                    values.label_ids.filter(
+                                      (labelId) => labelId !== Number(id)
+                                    )
+                                  )
+                                }
+                                onAdd={(name) =>
+                                  addAgentLabel(
+                                    name,
+                                    values.label_ids,
+                                    setFieldValue
+                                  )
+                                }
+                                value={labelInputValue}
+                                onChange={setLabelInputValue}
+                                placeholder="Add labels..."
+                                icon={SvgTag}
+                              />
+                              <Text text03 secondaryBody>
+                                Add labels and categories to help people better
+                                discover this agent.
+                              </Text>
+                            </GeneralLayouts.Section>
+                          </GeneralLayouts.Section>
+                        </Card>
+                      </GeneralLayouts.Section>
+
+                      <Divider
+                        paddingParallel="fit"
+                        paddingPerpendicular="fit"
+                      />
+
                       <SimpleCollapsible>
                         <SimpleCollapsible.Header
                           title="Actions"
@@ -1526,38 +1630,6 @@ export default function AgentEditorPage({
                             <Card border="solid" rounding="lg">
                               <GeneralLayouts.Section>
                                 <InputHorizontal
-                                  title="Share This Agent"
-                                  description="with other users, groups, or everyone in your organization."
-                                  center
-                                >
-                                  <Button
-                                    prominence="secondary"
-                                    icon={isShared ? SvgUsers : SvgLock}
-                                    onClick={() => shareAgentModal.toggle(true)}
-                                  >
-                                    Share
-                                  </Button>
-                                </InputHorizontal>
-                                {canUpdateFeaturedStatus && (
-                                  <>
-                                    <InputHorizontal
-                                      withLabel="is_featured"
-                                      title="Feature This Agent"
-                                      description="Show this agent at the top of the explore agents list and automatically pin it to the sidebar for new users with access."
-                                    >
-                                      <SwitchField name="is_featured" />
-                                    </InputHorizontal>
-                                    {values.is_featured && !isShared && (
-                                      <MessageCard title="This agent is private to you and will only be featured for yourself." />
-                                    )}
-                                  </>
-                                )}
-                              </GeneralLayouts.Section>
-                            </Card>
-
-                            <Card border="solid" rounding="lg">
-                              <GeneralLayouts.Section>
-                                <InputHorizontal
                                   withLabel="llm_model"
                                   title="Default Model"
                                   description="This model will be used by Onyx by default in your chats."
@@ -1630,19 +1702,51 @@ export default function AgentEditorPage({
                           />
 
                           <Card border="solid" rounding="lg">
-                            <InputHorizontal
-                              title="Delete This Agent"
-                              description="Anyone using this agent will no longer be able to access it."
-                              center
-                            >
-                              <Button
-                                variant="danger"
-                                prominence="secondary"
-                                onClick={() => deleteAgentModal.toggle(true)}
+                            <GeneralLayouts.Section>
+                              {canUpdateFeaturedStatus && (
+                                <InputHorizontal
+                                  title={
+                                    existingAgent.is_listed
+                                      ? "Unlist This Agent"
+                                      : "Relist This Agent"
+                                  }
+                                  description={
+                                    existingAgent.is_listed
+                                      ? "Unlisted agents don't appear in the explore agents list but remain accessible."
+                                      : "Relisted agents appear in the explore agents list again."
+                                  }
+                                  center
+                                >
+                                  <Button
+                                    prominence="tertiary"
+                                    icon={
+                                      existingAgent.is_listed
+                                        ? SvgEyeOff
+                                        : SvgEye
+                                    }
+                                    disabled={isTogglingListed}
+                                    onClick={handleToggleListed}
+                                  >
+                                    {existingAgent.is_listed
+                                      ? "Unlist Agent"
+                                      : "Relist Agent"}
+                                  </Button>
+                                </InputHorizontal>
+                              )}
+                              <InputHorizontal
+                                title="Delete This Agent"
+                                description="Anyone using this agent will no longer be able to access it."
+                                center
                               >
-                                Delete Agent
-                              </Button>
-                            </InputHorizontal>
+                                <Button
+                                  variant="danger"
+                                  prominence="secondary"
+                                  onClick={() => deleteAgentModal.toggle(true)}
+                                >
+                                  Delete Agent
+                                </Button>
+                              </InputHorizontal>
+                            </GeneralLayouts.Section>
                           </Card>
                         </>
                       )}

--- a/web/src/refresh-pages/admin/AgentsPage/AgentRowActions.tsx
+++ b/web/src/refresh-pages/admin/AgentsPage/AgentRowActions.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import { Button } from "@opal/components";
 // TODO(@raunakab): migrate to Opal LineItemButton once it supports danger variant
 import LineItem from "@/refresh-components/buttons/LineItem";
@@ -30,14 +30,8 @@ import type { Agent } from "@/lib/agents/types";
 import type { Route } from "next";
 import ShareAgentModal from "@/sections/modals/ShareAgentModal";
 import { useCreateModal } from "@/refresh-components/contexts/ModalContext";
-import { useAgent } from "@/lib/agents/hooks";
-import {
-  updateAgentSharedStatus,
-  updateAgentFeaturedStatus,
-} from "@/lib/agents/svc";
 import { useTierAtLeast } from "@/hooks/useTierAtLeast";
 import { Tier } from "@/lib/settings/types";
-import { useUser } from "@/providers/UserProvider";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -57,10 +51,7 @@ export default function AgentRowActions({
   onMutate,
 }: AgentRowActionsProps) {
   const router = useRouter();
-  const { isAdmin, isCurator } = useUser();
   const businessTier = useTierAtLeast(Tier.BUSINESS);
-  const canUpdateFeaturedStatus = isAdmin || isCurator;
-  const { agent: fullAgent, refresh: refreshAgent } = useAgent(agent.id);
   const shareModal = useCreateModal();
 
   const [popoverOpen, setPopoverOpen] = useState(false);
@@ -83,59 +74,11 @@ export default function AgentRowActions({
     }
   }
 
-  const handleShare = useCallback(
-    async (
-      userIds: string[],
-      groupIds: number[],
-      isPublic: boolean,
-      isFeatured: boolean,
-      labelIds: number[]
-    ) => {
-      const shareError = await updateAgentSharedStatus(
-        agent.id,
-        userIds,
-        groupIds,
-        isPublic,
-        businessTier,
-        labelIds
-      );
-
-      if (shareError) {
-        toast.error(`Failed to share agent: ${shareError}`);
-        return;
-      }
-
-      if (canUpdateFeaturedStatus) {
-        const featuredError = await updateAgentFeaturedStatus(
-          agent.id,
-          isFeatured
-        );
-        if (featuredError) {
-          toast.error(`Failed to update featured status: ${featuredError}`);
-          refreshAgent();
-          return;
-        }
-      }
-
-      refreshAgent();
-      onMutate();
-      shareModal.toggle(false);
-    },
-    [agent.id, businessTier, canUpdateFeaturedStatus, refreshAgent, onMutate]
-  );
-
   return (
     <>
       <shareModal.Provider>
-        <ShareAgentModal
-          agentId={agent.id}
-          userIds={fullAgent?.users?.map((u) => u.id) ?? []}
-          groupIds={fullAgent?.groups ?? []}
-          isPublic={fullAgent?.is_public ?? false}
-          isFeatured={fullAgent?.is_featured ?? false}
-          labelIds={fullAgent?.labels?.map((l) => l.id) ?? []}
-          onShare={handleShare}
-        />
+        {/* Saved agents persist sharing inside the dialog itself */}
+        <ShareAgentModal agentId={agent.id} />
       </shareModal.Provider>
 
       <div className="flex items-center gap-0.5">

--- a/web/src/refresh-pages/admin/AgentsPage/AgentsTable.tsx
+++ b/web/src/refresh-pages/admin/AgentsPage/AgentsTable.tsx
@@ -35,7 +35,10 @@ function renderCreatedByColumn(_value: MinimalUserSnapshot | null, row: Agent) {
 
 function getAccessTitle(row: Agent): string {
   if (row.is_public) return "Public";
-  if (row.groups.length > 0 || row.users.length > 0) return "Shared";
+  // Group ownership counts as shared even with an empty share list
+  if (row.groups.length > 0 || row.users.length > 0 || row.owner_group) {
+    return "Shared";
+  }
   return "Private";
 }
 

--- a/web/src/sections/agents/AgentCard.tsx
+++ b/web/src/sections/agents/AgentCard.tsx
@@ -11,13 +11,9 @@ import { noProp } from "@/lib/utils";
 import { cn } from "@opal/utils";
 import { useRouter } from "next/navigation";
 import type { Route } from "next";
-import { checkUserOwnsAgent } from "@/lib/agents/utils";
+import { checkUserCanEditAgent, checkUserOwnsAgent } from "@/lib/agents/utils";
 import { useTierAtLeast } from "@/hooks/useTierAtLeast";
 import { Tier } from "@/lib/settings/types";
-import {
-  updateAgentSharedStatus,
-  updateAgentFeaturedStatus,
-} from "@/lib/agents/svc";
 import { useUser } from "@/providers/UserProvider";
 import {
   SvgActions,
@@ -32,7 +28,6 @@ import {
 import { useCreateModal } from "@/refresh-components/contexts/ModalContext";
 import ShareAgentModal from "@/sections/modals/ShareAgentModal";
 import AgentViewerModal from "@/sections/modals/AgentViewerModal";
-import { toast } from "@/hooks/useToast";
 import { CardItemLayout } from "@/layouts/general-layouts";
 import { Content } from "@opal/layouts";
 import { Interactive } from "@opal/core";
@@ -50,13 +45,13 @@ export default function AgentCard({ agent }: AgentCardProps) {
     () => pinnedAgents.some((pinnedAgent) => pinnedAgent.id === agent.id),
     [agent.id, pinnedAgents]
   );
-  const { user, isAdmin, isCurator } = useUser();
+  const { user } = useUser();
   const businessTier = useTierAtLeast(Tier.BUSINESS);
-  const canUpdateFeaturedStatus = isAdmin || isCurator;
   const isOwnedByUser = checkUserOwnsAgent(user, agent);
+  const canEditAgent = checkUserCanEditAgent(user, agent);
   const shareAgentModal = useCreateModal();
   const agentViewerModal = useCreateModal();
-  const { agent: fullAgent, refresh: refreshAgent } = useAgent(agent.id);
+  const { agent: fullAgent } = useAgent(agent.id);
 
   // Start chat and auto-pin unpinned agents to the sidebar
   const handleStartChat = useCallback(() => {
@@ -66,58 +61,11 @@ export default function AgentCard({ agent }: AgentCardProps) {
     route({ agentId: agent.id });
   }, [pinned, togglePinnedAgent, agent, route]);
 
-  const handleShare = useCallback(
-    async (
-      userIds: string[],
-      groupIds: number[],
-      isPublic: boolean,
-      isFeatured: boolean,
-      labelIds: number[]
-    ) => {
-      const shareError = await updateAgentSharedStatus(
-        agent.id,
-        userIds,
-        groupIds,
-        isPublic,
-        businessTier,
-        labelIds
-      );
-
-      if (shareError) {
-        toast.error(`Failed to share agent: ${shareError}`);
-        return;
-      }
-
-      if (canUpdateFeaturedStatus) {
-        const featuredError = await updateAgentFeaturedStatus(
-          agent.id,
-          isFeatured
-        );
-        if (featuredError) {
-          toast.error(`Failed to update featured status: ${featuredError}`);
-          refreshAgent();
-          return;
-        }
-      }
-
-      refreshAgent();
-      shareAgentModal.toggle(false);
-    },
-    [agent.id, canUpdateFeaturedStatus, businessTier, refreshAgent]
-  );
-
   return (
     <>
       <shareAgentModal.Provider>
-        <ShareAgentModal
-          agentId={agent.id}
-          userIds={fullAgent?.users?.map((u) => u.id) ?? []}
-          groupIds={fullAgent?.groups ?? []}
-          isPublic={fullAgent?.is_public ?? false}
-          isFeatured={fullAgent?.is_featured ?? false}
-          labelIds={fullAgent?.labels?.map((l) => l.id) ?? []}
-          onShare={handleShare}
-        />
+        {/* Saved agents persist sharing inside the dialog itself */}
+        <ShareAgentModal agentId={agent.id} />
       </shareAgentModal.Provider>
 
       <agentViewerModal.Provider>
@@ -153,7 +101,7 @@ export default function AgentCard({ agent }: AgentCardProps) {
                       className="hidden group-hover/AgentCard:flex"
                     />
                   )}
-                  {isOwnedByUser && (
+                  {canEditAgent && (
                     // TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved
                     <IconButton
                       icon={SvgEdit}
@@ -165,7 +113,7 @@ export default function AgentCard({ agent }: AgentCardProps) {
                       className="hidden group-hover/AgentCard:flex"
                     />
                   )}
-                  {isOwnedByUser && (
+                  {canEditAgent && (
                     // TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved
                     <IconButton
                       icon={SvgShare}

--- a/web/src/sections/modals/SharePermissionMenu.tsx
+++ b/web/src/sections/modals/SharePermissionMenu.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Button, LineItemButton, OpenButton, Popover } from "@opal/components";
+import { LineItemButton, OpenButton, Popover } from "@opal/components";
 import { SvgMinusCircle } from "@opal/icons";
 import type { IconFunctionComponent } from "@opal/types";
 
@@ -101,15 +101,17 @@ export function SharePermissionMenu<T extends string>({
 
           {onRemove && (
             <Popover.Close asChild>
-              <Button
+              <LineItemButton
+                color="danger"
                 icon={SvgMinusCircle}
                 onClick={onRemove}
-                prominence="tertiary"
-                variant="danger"
+                rounding="md"
+                selectVariant="select-heavy"
+                sizePreset="main-ui"
+                title={removeLabel}
+                variant="section"
                 width="full"
-              >
-                {removeLabel}
-              </Button>
+              />
             </Popover.Close>
           )}
         </Popover.Menu>


### PR DESCRIPTION
## Description

PR 7/7 of the Agent Sharing stack — wires the new sharing into the rest of the UI (ENG-4176 / 4178 / 4179).

- Share Agent section moved out of Advanced on the edit page (adopts the dialog's draft contract)
- Feature / unlist gated admin-only
- "Your Agents" = owned-only, incl. group-owned; admin table access column counts group ownership
- Edit-page failure toast shows the parsed backend message, wrapped

Final PR in the stack. Stacked on the dialog PR.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check