### PR TITLE
refactor(craft): extract sandbox manager factory from base.py

### DIFF
--- a/backend/onyx/server/features/build/api/api.py
+++ b/backend/onyx/server/features/build/api/api.py
@@ -54,7 +54,7 @@ from onyx.server.features.build.api.user_library import router as user_library_r
 from onyx.server.features.build.approvals.api import router as approvals_router
 from onyx.server.features.build.db.build_session import get_webapp_access_async
 from onyx.server.features.build.db.build_session import get_webapp_target_async
-from onyx.server.features.build.sandbox.base import get_sandbox_manager
+from onyx.server.features.build.sandbox.factory import get_sandbox_manager
 from onyx.server.features.build.scheduled_tasks.api import (
     router as scheduled_tasks_router,
 )

--- a/backend/onyx/server/features/build/api/debug_api.py
+++ b/backend/onyx/server/features/build/api/debug_api.py
@@ -24,7 +24,7 @@ from onyx.db.enums import SandboxStatus
 from onyx.db.models import User
 from onyx.server.features.build.configs import ENABLE_OPENCODE_DEBUGGING
 from onyx.server.features.build.db.sandbox import get_sandbox_by_user_id
-from onyx.server.features.build.sandbox.base import get_sandbox_manager
+from onyx.server.features.build.sandbox.factory import get_sandbox_manager
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()

--- a/backend/onyx/server/features/build/api/sessions_api.py
+++ b/backend/onyx/server/features/build/api/sessions_api.py
@@ -53,7 +53,7 @@ from onyx.server.features.build.db.sandbox import get_latest_snapshot_for_sessio
 from onyx.server.features.build.db.sandbox import get_sandbox_by_user_id
 from onyx.server.features.build.db.sandbox import update_sandbox_heartbeat
 from onyx.server.features.build.db.sandbox import update_sandbox_status__no_commit
-from onyx.server.features.build.sandbox.base import get_sandbox_manager
+from onyx.server.features.build.sandbox.factory import get_sandbox_manager
 from onyx.server.features.build.session.errors import UploadLimitExceededError
 from onyx.server.features.build.session.manager import SessionManager
 from onyx.server.features.build.session.sandbox_lifecycle import (

--- a/backend/onyx/server/features/build/sandbox/base.py
+++ b/backend/onyx/server/features/build/sandbox/base.py
@@ -1,7 +1,7 @@
-"""Abstract base class and factory for sandbox operations.
+"""Abstract base class for sandbox operations.
 
 SandboxManager is the abstract interface for sandbox lifecycle management.
-Use get_sandbox_manager() to get the appropriate implementation based on SANDBOX_BACKEND.
+Use sandbox.factory.get_sandbox_manager() to get the implementation for SANDBOX_BACKEND.
 
 IMPORTANT: SandboxManager implementations must NOT interface with the database directly.
 All database operations should be handled by the caller (SessionManager, Celery tasks, etc.).
@@ -14,7 +14,6 @@ Architecture Note (User-Shared Sandbox Model):
 - terminate() destroys the entire sandbox (all sessions)
 """
 
-import threading
 import time
 from abc import ABC
 from abc import abstractmethod
@@ -23,8 +22,6 @@ from collections.abc import Generator
 from concurrent.futures import ThreadPoolExecutor
 from uuid import UUID
 
-from onyx.server.features.build.configs import SANDBOX_BACKEND
-from onyx.server.features.build.configs import SandboxBackend
 from onyx.server.features.build.sandbox.event_schema import AgentMessageChunk
 from onyx.server.features.build.sandbox.event_schema import AgentPlanUpdate
 from onyx.server.features.build.sandbox.event_schema import AgentThoughtChunk
@@ -710,41 +707,3 @@ class SandboxManager(_ServeMixin, ABC):
             session_id: The session ID
             nextjs_port: The port the Next.js server should be listening on
         """
-
-
-# Singleton instance cache for the factory
-_sandbox_manager_instance: SandboxManager | None = None
-_sandbox_manager_lock = threading.Lock()
-
-
-def get_sandbox_manager() -> SandboxManager:
-    """Get the appropriate SandboxManager implementation based on SANDBOX_BACKEND.
-
-    Returns:
-        SandboxManager instance:
-        - KubernetesSandboxManager for kubernetes backend (production + dev kind)
-        - DockerSandboxManager for self-hosted docker-compose
-    """
-    global _sandbox_manager_instance
-
-    if _sandbox_manager_instance is None:
-        with _sandbox_manager_lock:
-            if _sandbox_manager_instance is None:
-                if SANDBOX_BACKEND == SandboxBackend.KUBERNETES:
-                    from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager import (
-                        KubernetesSandboxManager,
-                    )
-
-                    _sandbox_manager_instance = KubernetesSandboxManager()
-                    logger.info("Using KubernetesSandboxManager for sandbox operations")
-                elif SANDBOX_BACKEND == SandboxBackend.DOCKER:
-                    from onyx.server.features.build.sandbox.docker.docker_sandbox_manager import (
-                        DockerSandboxManager,
-                    )
-
-                    _sandbox_manager_instance = DockerSandboxManager()
-                    logger.info("Using DockerSandboxManager for sandbox operations")
-                else:
-                    raise ValueError(f"Unknown sandbox backend: {SANDBOX_BACKEND}")
-
-    return _sandbox_manager_instance

--- a/backend/onyx/server/features/build/sandbox/factory.py
+++ b/backend/onyx/server/features/build/sandbox/factory.py
@@ -1,0 +1,53 @@
+"""Factory for selecting the SandboxManager implementation.
+
+Lives outside base.py so the abstract interface never references its concrete
+subclasses (which all import base).
+"""
+
+import threading
+
+from onyx.server.features.build.configs import SANDBOX_BACKEND
+from onyx.server.features.build.configs import SandboxBackend
+from onyx.server.features.build.sandbox.base import SandboxManager
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+# Singleton instance cache for the factory
+_sandbox_manager_instance: SandboxManager | None = None
+_sandbox_manager_lock = threading.Lock()
+
+
+def get_sandbox_manager() -> SandboxManager:
+    """Get the appropriate SandboxManager implementation based on SANDBOX_BACKEND.
+
+    Returns:
+        SandboxManager instance:
+        - KubernetesSandboxManager for kubernetes backend (production + dev kind)
+        - DockerSandboxManager for self-hosted docker-compose
+    """
+    global _sandbox_manager_instance
+
+    if _sandbox_manager_instance is None:
+        with _sandbox_manager_lock:
+            if _sandbox_manager_instance is None:
+                if SANDBOX_BACKEND == SandboxBackend.KUBERNETES:
+                    # Deferred: avoid loading the kubernetes client stack on
+                    # docker deployments (and vice versa).
+                    from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager import (
+                        KubernetesSandboxManager,
+                    )
+
+                    _sandbox_manager_instance = KubernetesSandboxManager()
+                    logger.info("Using KubernetesSandboxManager for sandbox operations")
+                elif SANDBOX_BACKEND == SandboxBackend.DOCKER:
+                    from onyx.server.features.build.sandbox.docker.docker_sandbox_manager import (
+                        DockerSandboxManager,
+                    )
+
+                    _sandbox_manager_instance = DockerSandboxManager()
+                    logger.info("Using DockerSandboxManager for sandbox operations")
+                else:
+                    raise ValueError(f"Unknown sandbox backend: {SANDBOX_BACKEND}")
+
+    return _sandbox_manager_instance

--- a/backend/onyx/server/features/build/sandbox/tasks/tasks.py
+++ b/backend/onyx/server/features/build/sandbox/tasks/tasks.py
@@ -17,7 +17,7 @@ from onyx.server.features.build.db.build_session import clear_nextjs_ports_for_u
 from onyx.server.features.build.db.build_session import (
     mark_user_sessions_idle__no_commit,
 )
-from onyx.server.features.build.sandbox.base import get_sandbox_manager
+from onyx.server.features.build.sandbox.factory import get_sandbox_manager
 from onyx.server.features.build.sandbox.manager.snapshot_manager import SnapshotManager
 
 # 100 minutes - snapshotting can take time

--- a/backend/onyx/server/features/build/sandbox/user_library.py
+++ b/backend/onyx/server/features/build/sandbox/user_library.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 from onyx.file_store.file_store import get_default_file_store
 from onyx.server.features.build.db.sandbox import get_sandbox_user_map
 from onyx.server.features.build.db.user_library import list_user_files
-from onyx.server.features.build.sandbox.base import get_sandbox_manager
+from onyx.server.features.build.sandbox.factory import get_sandbox_manager
 from onyx.server.features.build.sandbox.models import FileSet
 from onyx.server.features.build.sandbox.models import PushResult
 from onyx.utils.logger import setup_logger

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -54,7 +54,7 @@ from onyx.server.features.build.db.sandbox import get_sandbox_by_user_id
 from onyx.server.features.build.db.sandbox import get_snapshots_for_session
 from onyx.server.features.build.db.sandbox import update_sandbox_heartbeat
 from onyx.server.features.build.db.sandbox import update_sandbox_status__no_commit
-from onyx.server.features.build.sandbox.base import get_sandbox_manager
+from onyx.server.features.build.sandbox.factory import get_sandbox_manager
 from onyx.server.features.build.sandbox.manager.snapshot_manager import SnapshotManager
 from onyx.server.features.build.sandbox.models import FileSet
 from onyx.server.features.build.sandbox.models import LLMProviderConfig

--- a/backend/onyx/skills/push.py
+++ b/backend/onyx/skills/push.py
@@ -16,7 +16,7 @@ from onyx.db.skill import list_skills_for_sandbox_injection
 from onyx.file_store.file_store import FileStore
 from onyx.file_store.file_store import get_default_file_store
 from onyx.server.features.build.db.sandbox import get_sandbox_user_map
-from onyx.server.features.build.sandbox.base import get_sandbox_manager
+from onyx.server.features.build.sandbox.factory import get_sandbox_manager
 from onyx.server.features.build.sandbox.models import FileSet
 from onyx.server.features.build.sandbox.models import PushResult
 from onyx.server.features.build.sandbox.util.agent_instructions import (

--- a/backend/tests/external_dependency_unit/craft/conftest.py
+++ b/backend/tests/external_dependency_unit/craft/conftest.py
@@ -1265,7 +1265,7 @@ def session_manager_with_stub(
 
     Patches both ``session.manager.get_sandbox_manager`` (which
     ``SessionManager.__init__`` captures into ``self._sandbox_manager`` at
-    construction time) AND ``sandbox.base._sandbox_manager_instance`` so any
+    construction time) AND ``sandbox.factory._sandbox_manager_instance`` so any
     deferred lookup also lands on the stub. The LLM lookup runs for real
     against the provider from ``_seed_default_llm_provider``.
     """
@@ -1274,7 +1274,7 @@ def session_manager_with_stub(
         lambda: stub_sandbox_manager,
     )
     monkeypatch.setattr(
-        "onyx.server.features.build.sandbox.base._sandbox_manager_instance",
+        "onyx.server.features.build.sandbox.factory._sandbox_manager_instance",
         stub_sandbox_manager,
     )
     sm = SessionManager(db_session)

--- a/backend/tests/external_dependency_unit/craft/test_ensure_sandbox_running.py
+++ b/backend/tests/external_dependency_unit/craft/test_ensure_sandbox_running.py
@@ -28,8 +28,8 @@ from onyx.server.features.build.configs import SANDBOX_BACKEND
 from onyx.server.features.build.configs import SandboxBackend
 from onyx.server.features.build.db.sandbox import create_sandbox__no_commit
 from onyx.server.features.build.db.sandbox import update_sandbox_status__no_commit
-from onyx.server.features.build.sandbox.base import get_sandbox_manager
 from onyx.server.features.build.sandbox.base import SandboxManager
+from onyx.server.features.build.sandbox.factory import get_sandbox_manager
 from onyx.server.features.build.sandbox.models import LLMProviderConfig
 from onyx.server.features.build.session.errors import SandboxProvisioningError
 from onyx.server.features.build.session.manager import SessionManager

--- a/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
@@ -1116,7 +1116,7 @@ class TestSandboxReset:
             lambda: failing_stub,
         )
         monkeypatch.setattr(
-            "onyx.server.features.build.sandbox.base._sandbox_manager_instance",
+            "onyx.server.features.build.sandbox.factory._sandbox_manager_instance",
             failing_stub,
         )
         sm_fail = SessionManager(db_session)

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_sandbox_backend_selection.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_sandbox_backend_selection.py
@@ -12,24 +12,24 @@ import pytest
 
 from onyx.server.features.build import configs
 from onyx.server.features.build.configs import SandboxBackend
-from onyx.server.features.build.sandbox import base as base_module
+from onyx.server.features.build.sandbox import factory as factory_module
 
 
 @pytest.fixture(autouse=True)
 def _reset_singleton(monkeypatch: pytest.MonkeyPatch) -> None:
     """Reset the cached singleton before each test so backend switches are honored."""
-    monkeypatch.setattr(base_module, "_sandbox_manager_instance", None)
+    monkeypatch.setattr(factory_module, "_sandbox_manager_instance", None)
 
 
 def test_unknown_backend_raises(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(base_module, "SANDBOX_BACKEND", "totally-bogus")
+    monkeypatch.setattr(factory_module, "SANDBOX_BACKEND", "totally-bogus")
     with pytest.raises(ValueError, match="Unknown sandbox backend"):
-        base_module.get_sandbox_manager()
+        factory_module.get_sandbox_manager()
 
 
 def test_docker_backend_returns_docker_manager(monkeypatch: pytest.MonkeyPatch) -> None:
     """Backend=docker must dispatch to ``DockerSandboxManager``, not raise NotImplementedError."""
-    monkeypatch.setattr(base_module, "SANDBOX_BACKEND", SandboxBackend.DOCKER)
+    monkeypatch.setattr(factory_module, "SANDBOX_BACKEND", SandboxBackend.DOCKER)
 
     # Don't try to talk to /var/run/docker.sock in a unit test — stub _initialize.
     from onyx.server.features.build.sandbox.docker import docker_sandbox_manager
@@ -49,7 +49,7 @@ def test_docker_backend_returns_docker_manager(monkeypatch: pytest.MonkeyPatch) 
     monkeypatch.setattr(
         docker_sandbox_manager.DockerSandboxManager, "_initialize", _fake_init
     )
-    mgr = base_module.get_sandbox_manager()
+    mgr = factory_module.get_sandbox_manager()
     assert mgr.__class__.__name__ == "DockerSandboxManager"
 
 


### PR DESCRIPTION
## Description

Part 1/5 of the craft backend reorganization (no behavior changes).

`sandbox/base.py` held `get_sandbox_manager()`, which lazy-imported the concrete docker/k8s managers while both managers import `base` for the ABC — a latent import cycle papered over with inline imports. This moves the factory and its singleton to `sandbox/factory.py`, so `base.py` is purely the abstract interface and never references its subclasses. The deferred imports of the concrete managers stay in the factory deliberately: they avoid loading the kubernetes client stack on docker deployments and vice versa, and are no longer cyclic.

## How Has This Been Tested?

- Craft unit suites (`tests/unit/build`, `tests/unit/onyx/server/features/build`, `tests/unit/sandbox_proxy`) — failure set identical to `main` (pre-existing environmental failures only)
- Smoke-imported every `build` module plus all external consumers
- AST-based cycle check: zero cycles
- The full 5-PR stack tree is byte-identical to the single verified refactor commit

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check