### PR TITLE
chore(craft): kind image refresh tooling for local dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: craft-up craft-down craft-sandbox-image
+.PHONY: craft-up craft-down craft-sandbox-image craft-backend-image craft-refresh-images craft-check-images
 
 craft-up:
 	deployment/helm/dev/craft-up.sh
@@ -9,3 +9,16 @@ craft-down:
 craft-sandbox-image:
 	docker build -t onyxdotapp/sandbox:dev backend/onyx/server/features/build/sandbox/image
 	kind load docker-image onyxdotapp/sandbox:dev --name onyx-dev
+
+# Rebuild the image the in-cluster sandbox-proxy/api-server run, then restart them.
+craft-backend-image:
+	docker build -t onyxdotapp/onyx-backend:dev backend/
+	kind load docker-image onyxdotapp/onyx-backend:dev --name onyx-dev
+	kubectl rollout restart deploy/onyx-sandbox-proxy deploy/onyx-api-server -n onyx
+
+# Refresh everything: backend + sandbox images, PodTemplate, proxy/api restart.
+craft-refresh-images:
+	deployment/helm/dev/refresh-images.sh
+
+craft-check-images:
+	deployment/helm/dev/refresh-images.sh --check

--- a/Makefile
+++ b/Makefile
@@ -21,4 +21,4 @@ craft-refresh-images:
 	deployment/helm/dev/refresh-images.sh
 
 craft-check-images:
-	deployment/helm/dev/refresh-images.sh --check
+	deployment/helm/dev/refresh-images.sh --check || true

--- a/deployment/helm/dev/refresh-images.sh
+++ b/deployment/helm/dev/refresh-images.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Rebuild the backend + sandbox images from this worktree, load them into the
+# kind cluster, and restart the pods that run them (sandbox-proxy especially —
+# it is NOT telepresence-local and silently runs stale code otherwise).
+#
+#   refresh-images.sh           rebuild, load, restart
+#   refresh-images.sh --check   report staleness only
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+CLUSTER_NAME="${CLUSTER_NAME:-onyx-dev}"
+BACKEND_IMAGE="onyxdotapp/onyx-backend:dev"
+SANDBOX_IMAGE="${SANDBOX_IMAGE:-onyxdotapp/sandbox:dev}"
+SANDBOX_IMAGE_DIR="$REPO_ROOT/backend/onyx/server/features/build/sandbox/image"
+
+check_staleness() {
+  local stale=0
+  local backend_created last_commit
+  backend_created=$(docker image inspect "$BACKEND_IMAGE" --format '{{.Created}}' 2>/dev/null || echo "missing")
+  last_commit=$(git -C "$REPO_ROOT" log -1 --format=%cI -- backend/)
+  echo "backend image built:        $backend_created"
+  echo "last backend/ commit:       $last_commit"
+  if [[ "$backend_created" == "missing" || "$backend_created" < "$last_commit" ]]; then
+    echo "WARNING: $BACKEND_IMAGE is older than the latest backend/ commit — the"
+    echo "         sandbox-proxy is running stale code. Run: $0"
+    stale=1
+  fi
+  local podtemplate_image
+  podtemplate_image=$(kubectl get podtemplate sandbox-pod -n onyx-sandboxes \
+    -o jsonpath='{.template.spec.containers[0].image}' 2>/dev/null || echo "unknown")
+  echo "sandbox PodTemplate image:  $podtemplate_image"
+  return "$stale"
+}
+
+if [[ "${1:-}" == "--check" ]]; then
+  check_staleness
+  exit $?
+fi
+
+echo "==> building $BACKEND_IMAGE"
+docker build -t "$BACKEND_IMAGE" "$REPO_ROOT/backend"
+kind load docker-image "$BACKEND_IMAGE" --name "$CLUSTER_NAME"
+
+echo "==> building $SANDBOX_IMAGE"
+docker build -t "$SANDBOX_IMAGE" "$SANDBOX_IMAGE_DIR"
+kind load docker-image "$SANDBOX_IMAGE" --name "$CLUSTER_NAME"
+
+echo "==> pointing sandbox PodTemplate at $SANDBOX_IMAGE"
+kubectl patch podtemplate sandbox-pod -n onyx-sandboxes --type=json \
+  -p "[{\"op\":\"replace\",\"path\":\"/template/spec/containers/0/image\",\"value\":\"$SANDBOX_IMAGE\"}]"
+
+echo "==> restarting sandbox-proxy + api-server onto the new backend image"
+kubectl rollout restart deploy/onyx-sandbox-proxy deploy/onyx-api-server -n onyx
+kubectl rollout status deploy/onyx-sandbox-proxy -n onyx --timeout=180s
+
+echo "==> done. Existing sandbox pods keep their old image until recycled."

--- a/deployment/helm/dev/refresh-images.sh
+++ b/deployment/helm/dev/refresh-images.sh
@@ -12,18 +12,27 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 
 CLUSTER_NAME="${CLUSTER_NAME:-onyx-dev}"
-BACKEND_IMAGE="onyxdotapp/onyx-backend:dev"
+BACKEND_IMAGE="${BACKEND_IMAGE:-onyxdotapp/onyx-backend:dev}"
 SANDBOX_IMAGE="${SANDBOX_IMAGE:-onyxdotapp/sandbox:dev}"
 SANDBOX_IMAGE_DIR="$REPO_ROOT/backend/onyx/server/features/build/sandbox/image"
 
+# docker's .Created is always UTC; strip Z + fractional seconds, then parse
+# with GNU date (-d) or BSD date (-j -f).
+utc_to_epoch() {
+  local ts="${1%Z}"
+  ts="${ts%%.*}"
+  date -u -d "$ts" +%s 2>/dev/null || date -u -j -f '%Y-%m-%dT%H:%M:%S' "$ts" +%s
+}
+
 check_staleness() {
   local stale=0
-  local backend_created last_commit
+  local backend_created last_commit commit_epoch
   backend_created=$(docker image inspect "$BACKEND_IMAGE" --format '{{.Created}}' 2>/dev/null || echo "missing")
   last_commit=$(git -C "$REPO_ROOT" log -1 --format=%cI -- backend/)
+  commit_epoch=$(git -C "$REPO_ROOT" log -1 --format=%ct -- backend/)
   echo "backend image built:        $backend_created"
   echo "last backend/ commit:       $last_commit"
-  if [[ "$backend_created" == "missing" || "$backend_created" < "$last_commit" ]]; then
+  if [[ "$backend_created" == "missing" || "$(utc_to_epoch "$backend_created")" -lt "$commit_epoch" ]]; then
     echo "WARNING: $BACKEND_IMAGE is older than the latest backend/ commit — the"
     echo "         sandbox-proxy is running stale code. Run: $0"
     stale=1


### PR DESCRIPTION
## Description

The in-cluster `onyx-sandbox-proxy` runs a locally built `onyx-backend:dev` image that never auto-updates — only the api server is telepresence-local. After a rebase, the proxy silently runs stale code (most recently: a proxy image predating the GitHub external app made every `api.github.com` request classify as `off_catalog`, so no credential injection → upstream 401).

This adds dev tooling to keep kind cluster images in sync with the worktree:

- `deployment/helm/dev/refresh-images.sh` — rebuilds `onyx-backend:dev` + `sandbox:dev`, loads both into kind, repoints the `sandbox-pod` PodTemplate, and restarts `onyx-sandbox-proxy` / `onyx-api-server`. `--check` reports image-vs-commit staleness without changing anything.
- Make targets: `craft-refresh-images`, `craft-check-images`, and `craft-backend-image` (backend image + proxy/api restart only).

## How Has This Been Tested?

- `refresh-images.sh --check` and `make craft-check-images` run against a live kind dev cluster and report image build time vs latest `backend/` commit.
- The full rebuild → `kind load` → PodTemplate patch → proxy restart flow is the exact sequence used (manually) to fix the stale-proxy GitHub 401 today; after the proxy restart the same request logged `policy=ALWAYS credential_outcome=headers_injected`.
- `make -n` dry-runs verified for all new targets; `bash -n` + pre-commit shellcheck pass.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds local dev tooling to keep in-cluster services in sync with your worktree. Rebuilds and loads `onyxdotapp/onyx-backend:dev` and `onyxdotapp/sandbox:dev` into `kind`, updates the `sandbox-pod` `PodTemplate`, and restarts `onyx-sandbox-proxy` and `onyx-api-server` to prevent stale code. Fixes the staleness check to compare timestamps in epoch seconds and makes `craft-check-images` informational.

- New Features
  - Added `deployment/helm/dev/refresh-images.sh` with rebuild/load/patch/restart flow; `--check` reports image staleness vs latest `backend/` commit and shows current sandbox `PodTemplate` image using epoch-based compare.
  - Make targets: `craft-backend-image` (backend image + proxy/api restart), `craft-refresh-images` (full refresh), `craft-check-images` (staleness check); supports `CLUSTER_NAME`, `BACKEND_IMAGE`, and `SANDBOX_IMAGE` env overrides.

<sup>Written for commit fe76ef86687b441de4a354fea9187f0d72074420. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12034?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

