### PR TITLE
test(web): deflake command-menu screenshots by masking timestamps

### DIFF
--- a/web/src/sections/sidebar/ChatSearchCommandMenu.tsx
+++ b/web/src/sections/sidebar/ChatSearchCommandMenu.tsx
@@ -264,9 +264,13 @@ export default function ChatSearchCommandMenu({
                             ↵
                           </Text>
                         ) : (
-                          <Text secondaryBody text03>
-                            {timeAgo(chat.time)}
-                          </Text>
+                          // Wrapped so visual-regression screenshots can mask
+                          // the relative timestamp (non-deterministic content).
+                          <span data-testid="command-menu-timestamp">
+                            <Text secondaryBody text03>
+                              {timeAgo(chat.time)}
+                            </Text>
+                          </span>
                         )
                       }
                       onSelect={() => handleChatSelect(chat.id)}
@@ -321,9 +325,13 @@ export default function ChatSearchCommandMenu({
                           ↵
                         </Text>
                       ) : (
-                        <Text secondaryBody text03>
-                          {timeAgo(project.time)}
-                        </Text>
+                        // Wrapped so visual-regression screenshots can mask
+                        // the relative timestamp (non-deterministic content).
+                        <span data-testid="command-menu-timestamp">
+                          <Text secondaryBody text03>
+                            {timeAgo(project.time)}
+                          </Text>
+                        </span>
                       )
                     }
                     onSelect={() => handleProjectSelect(project.id)}

--- a/web/src/sections/sidebar/ChatSearchCommandMenu.tsx
+++ b/web/src/sections/sidebar/ChatSearchCommandMenu.tsx
@@ -264,13 +264,15 @@ export default function ChatSearchCommandMenu({
                             ↵
                           </Text>
                         ) : (
-                          // Wrapped so visual-regression screenshots can mask
+                          // data-testid lets visual-regression screenshots mask
                           // the relative timestamp (non-deterministic content).
-                          <span data-testid="command-menu-timestamp">
-                            <Text secondaryBody text03>
-                              {timeAgo(chat.time)}
-                            </Text>
-                          </span>
+                          <Text
+                            secondaryBody
+                            text03
+                            data-testid="command-menu-timestamp"
+                          >
+                            {timeAgo(chat.time)}
+                          </Text>
                         )
                       }
                       onSelect={() => handleChatSelect(chat.id)}
@@ -325,13 +327,15 @@ export default function ChatSearchCommandMenu({
                           ↵
                         </Text>
                       ) : (
-                        // Wrapped so visual-regression screenshots can mask
+                        // data-testid lets visual-regression screenshots mask
                         // the relative timestamp (non-deterministic content).
-                        <span data-testid="command-menu-timestamp">
-                          <Text secondaryBody text03>
-                            {timeAgo(project.time)}
-                          </Text>
-                        </span>
+                        <Text
+                          secondaryBody
+                          text03
+                          data-testid="command-menu-timestamp"
+                        >
+                          {timeAgo(project.time)}
+                        </Text>
                       )
                     }
                     onSelect={() => handleProjectSelect(project.id)}

--- a/web/src/sections/sidebar/ChatSearchCommandMenu.tsx
+++ b/web/src/sections/sidebar/ChatSearchCommandMenu.tsx
@@ -264,8 +264,6 @@ export default function ChatSearchCommandMenu({
                             ↵
                           </Text>
                         ) : (
-                          // data-testid lets visual-regression screenshots mask
-                          // the relative timestamp (non-deterministic content).
                           <Text
                             secondaryBody
                             text03
@@ -327,8 +325,6 @@ export default function ChatSearchCommandMenu({
                           ↵
                         </Text>
                       ) : (
-                        // data-testid lets visual-regression screenshots mask
-                        // the relative timestamp (non-deterministic content).
                         <Text
                           secondaryBody
                           text03

--- a/web/tests/e2e/chat/chat-search-command-menu.spec.ts
+++ b/web/tests/e2e/chat/chat-search-command-menu.spec.ts
@@ -8,6 +8,11 @@ const TEST_PREFIX = "E2E-CMD";
 let chatSessionIds: string[] = [];
 let projectIds: number[] = [];
 
+// Chat/project rows render a relative timestamp (e.g. "3 seconds ago") whose
+// value depends on the wall clock, making screenshots non-deterministic. Mask
+// it so visual-regression diffs ignore the timestamp cells.
+const TIMESTAMP_MASK = '[data-testid="command-menu-timestamp"]';
+
 /**
  * Helper to get the command menu dialog locator (using the content wrapper)
  */
@@ -90,7 +95,10 @@ test.describe("Chat Search Command Menu", () => {
       dialog.locator('[data-command-item="new-session"]')
     ).toBeVisible();
 
-    await expectScreenshot(page, { name: "command-menu-default-open" });
+    await expectScreenshot(page, {
+      name: "command-menu-default-open",
+      mask: [TIMESTAMP_MASK],
+    });
   });
 
   // -- Preview limits --
@@ -156,7 +164,10 @@ test.describe("Chat Search Command Menu", () => {
       ).toBeVisible();
     }
 
-    await expectScreenshot(page, { name: "command-menu-projects-filter" });
+    await expectScreenshot(page, {
+      name: "command-menu-projects-filter",
+      mask: [TIMESTAMP_MASK],
+    });
   });
 
   test("Filter chip X removes filter and returns to all", async ({ page }) => {
@@ -206,7 +217,10 @@ test.describe("Chat Search Command Menu", () => {
       dialog.locator(`[data-command-item="chat-${chatSessionIds[2]}"]`)
     ).toBeVisible();
 
-    await expectScreenshot(page, { name: "command-menu-search-results" });
+    await expectScreenshot(page, {
+      name: "command-menu-search-results",
+      mask: [TIMESTAMP_MASK],
+    });
   });
 
   test("Search finds matching project", async ({ page }) => {


### PR DESCRIPTION
## Problem

The visual-regression screenshots in `web/tests/e2e/chat/chat-search-command-menu.spec.ts` are non-deterministic. Chat and project rows in the "Search chat sessions, projects…" command menu render a **relative timestamp** via `timeAgo(chat.time)` / `timeAgo(project.time)`, which reads the wall clock at render time. The same row renders as `"3 seconds ago"` on one run and `"1 minute ago"` on the next, so the captured screenshots drift and would produce spurious diffs.

## Fix

- **`ChatSearchCommandMenu.tsx`** — wrap each row's timestamp `<Text>` in a `<span data-testid="command-menu-timestamp">` so the screenshots have a stable selector to mask. Only the non-highlighted branch is wrapped; the highlighted row shows a deterministic `↵` and needs no masking. (A wrapper span is used rather than `data-testid` on `Text` directly, since the deprecated `Text` component doesn't declare `data-*` props — matching the existing `<div data-testid=…>` convention in `AppSidebar.tsx`.)
- **`chat-search-command-menu.spec.ts`** — add a `TIMESTAMP_MASK` constant and pass `mask: [TIMESTAMP_MASK]` to the three screenshots that render rows: `command-menu-default-open`, `command-menu-projects-filter`, and `command-menu-search-results`. `command-menu-no-results` is left untouched since it shows no rows.

## Notes

- No baseline PNGs are committed — `expectScreenshot` is currently in capture-only (non-gating) mode — so there's nothing to regenerate. The mask ensures the timestamp won't cause spurious diffs once baselines are captured / `VISUAL_REGRESSION=true` is enabled.
- `oxfmt --check` and `oxlint` pass on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deflake command menu visual-regression screenshots by masking non-deterministic relative timestamps on chat and project rows. This stabilizes tests and prevents spurious diffs.

- **Bug Fixes**
  - In `ChatSearchCommandMenu.tsx`, add `data-testid="command-menu-timestamp"` to the non-highlighted timestamp `Text` for chat and project rows to enable masking.
  - In `chat-search-command-menu.spec.ts`, add `TIMESTAMP_MASK` and pass `mask: [TIMESTAMP_MASK]` to screenshots that render rows (`command-menu-default-open`, `command-menu-projects-filter`, `command-menu-search-results`).

<sup>Written for commit 3fec95e31b49db9f2a914b9cd81a1d5b89fb321b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

