### PR TITLE
feat(craft): show action description for external app skill commands

### DIFF
--- a/web/src/app/craft/components/tool-cards/CraftToolCard.stories.tsx
+++ b/web/src/app/craft/components/tool-cards/CraftToolCard.stories.tsx
@@ -91,6 +91,33 @@ export const BashCancelled: Story = {
   },
 };
 
+export const SkillScriptInProgress: Story = {
+  args: {
+    toolCall: call({
+      kind: "execute",
+      toolName: "bash",
+      description: "Fetch Linear issue ENG-123",
+      command: "python .opencode/skills/linear/linear_api.py issue ENG-123",
+      skillName: "linear",
+      status: "in_progress",
+    }),
+  },
+};
+
+export const SkillScriptCompleted: Story = {
+  args: {
+    toolCall: call({
+      kind: "execute",
+      toolName: "bash",
+      description: "List all Linear projects",
+      command:
+        "python .opencode/skills/linear/linear_api.py projects --limit 100",
+      skillName: "linear",
+      rawOutput: '[{"id": "proj_1", "name": "Craft"}]',
+    }),
+  },
+};
+
 export const ReadCompleted: Story = {
   args: {
     toolCall: call({

--- a/web/src/app/craft/components/tool-cards/CraftToolCard.tsx
+++ b/web/src/app/craft/components/tool-cards/CraftToolCard.tsx
@@ -80,6 +80,13 @@ function verbWithCode(verb: string, code: string, suffix?: string): ReactNode {
  */
 function renderPrimary(toolCall: ToolCallState): ReactNode {
   if (toolCall.kind === "execute" && toolCall.command) {
+    if (toolCall.skillName && toolCall.description) {
+      return (
+        <Text font="main-ui-muted" color="text-04" nowrap>
+          {toolCall.description}
+        </Text>
+      );
+    }
     return verbWithCode("Running ", toolCall.command);
   }
   if (toolCall.kind === "search" && toolCall.description) {

--- a/web/src/app/craft/utils/packetTypes.ts
+++ b/web/src/app/craft/utils/packetTypes.ts
@@ -113,6 +113,7 @@ export interface ParsedToolCallStart {
   description: string;
   /** Command or task prompt resolved from rawInput, used before progress arrives. */
   command: string;
+  skillName: string | null;
   /** For task tool calls: the subagent type, when provided. */
   subagentType: string | null;
   /** Opencode session this event was emitted on — child's id for subagent child events, else null. */

--- a/web/src/app/craft/utils/parsePacket.test.ts
+++ b/web/src/app/craft/utils/parsePacket.test.ts
@@ -77,18 +77,23 @@ describe("parsePacket", () => {
   });
 
   it("detects gh CLI commands as the github skill", () => {
+    const packet = {
+      tool_call_id: "bash-call-3",
+      kind: "execute",
+      status: "completed",
+      raw_input: {
+        command: "gh api user",
+        description: "Get the connected GitHub user",
+      },
+      _meta: { toolName: "bash" },
+    };
+    expect(parsePacket({ type: "tool_call_start", ...packet })).toMatchObject({
+      type: "tool_call_start",
+      skillName: "github",
+      description: "Get the connected GitHub user",
+    });
     expect(
-      parsePacket({
-        type: "tool_call_progress",
-        tool_call_id: "bash-call-3",
-        kind: "execute",
-        status: "completed",
-        raw_input: {
-          command: "gh api user",
-          description: "Get the connected GitHub user",
-        },
-        _meta: { toolName: "bash" },
-      })
+      parsePacket({ type: "tool_call_progress", ...packet })
     ).toMatchObject({
       type: "tool_call_progress",
       skillName: "github",

--- a/web/src/app/craft/utils/parsePacket.test.ts
+++ b/web/src/app/craft/utils/parsePacket.test.ts
@@ -47,6 +47,72 @@ describe("parsePacket", () => {
     });
   });
 
+  it("detects skill scripts in bash commands and surfaces the description", () => {
+    const packet = {
+      tool_call_id: "bash-call-1",
+      kind: "execute",
+      status: "in_progress",
+      raw_input: {
+        command: "python .opencode/skills/linear/linear_api.py issue ENG-123",
+        description: "Fetch Linear issue ENG-123",
+      },
+      _meta: { toolName: "bash" },
+    };
+    expect(parsePacket({ type: "tool_call_start", ...packet })).toMatchObject({
+      type: "tool_call_start",
+      toolName: "bash",
+      kind: "execute",
+      skillName: "linear",
+      description: "Fetch Linear issue ENG-123",
+    });
+    expect(
+      parsePacket({ type: "tool_call_progress", ...packet })
+    ).toMatchObject({
+      type: "tool_call_progress",
+      toolName: "bash",
+      kind: "execute",
+      skillName: "linear",
+      description: "Fetch Linear issue ENG-123",
+    });
+  });
+
+  it("detects gh CLI commands as the github skill", () => {
+    expect(
+      parsePacket({
+        type: "tool_call_progress",
+        tool_call_id: "bash-call-3",
+        kind: "execute",
+        status: "completed",
+        raw_input: {
+          command: "gh api user",
+          description: "Get the connected GitHub user",
+        },
+        _meta: { toolName: "bash" },
+      })
+    ).toMatchObject({
+      type: "tool_call_progress",
+      skillName: "github",
+      description: "Get the connected GitHub user",
+    });
+  });
+
+  it("does not attach a skill to ordinary bash commands", () => {
+    expect(
+      parsePacket({
+        type: "tool_call_progress",
+        tool_call_id: "bash-call-2",
+        kind: "execute",
+        status: "completed",
+        raw_input: { command: "ls -lah src/", description: "list files" },
+        _meta: { toolName: "bash" },
+      })
+    ).toMatchObject({
+      type: "tool_call_progress",
+      skillName: null,
+      description: "list files",
+    });
+  });
+
   it("extracts subagent session ids from completed task output", () => {
     expect(
       parsePacket({

--- a/web/src/app/craft/utils/parsePacket.ts
+++ b/web/src/app/craft/utils/parsePacket.ts
@@ -119,6 +119,8 @@ function detectSkillScript(command: string): string | null {
   const match = command.match(/\.opencode\/skills\/([\w-]+)\//);
   if (match?.[1]) return match[1];
   // The github skill invokes the gh CLI directly rather than a bundled script.
+  // Any gh call in the sandbox authenticates through the github app's proxy
+  // injection, so attributing all of them to the skill is intentional.
   if (/^gh\s/.test(command)) return "github";
   return null;
 }

--- a/web/src/app/craft/utils/parsePacket.ts
+++ b/web/src/app/craft/utils/parsePacket.ts
@@ -115,6 +115,30 @@ function detectSkillName(
   return match?.[2] ?? null;
 }
 
+function detectSkillScript(command: string): string | null {
+  const match = command.match(/\.opencode\/skills\/([\w-]+)\//);
+  if (match?.[1]) return match[1];
+  // The github skill invokes the gh CLI directly rather than a bundled script.
+  if (/^gh\s/.test(command)) return "github";
+  return null;
+}
+
+function resolveSkillName(
+  p: Record<string, unknown>,
+  toolName: ToolName,
+  kind: ToolKind,
+  ri: Record<string, unknown> | null,
+  command: string
+): string | null {
+  return (
+    detectSkillName(p, toolName) ??
+    (toolName === "skill" && typeof ri?.name === "string"
+      ? (ri.name as string)
+      : null) ??
+    (kind === "execute" ? detectSkillScript(command) : null)
+  );
+}
+
 // ─── Tool Name Resolution ─────────────────────────────────────────
 
 const NAME_MAP: Record<string, ToolName> = {
@@ -332,9 +356,8 @@ function buildDescription(
       return filePath;
     }
   }
-  // Execute: use backend description
   if (kind === "execute") {
-    return sanitizePathsInText(rawDescription) || "Running command";
+    return sanitizePathsInText(rawDescription);
   }
   // Search: show pattern
   if (
@@ -557,6 +580,7 @@ function parseToolCallStart(p: Record<string, unknown>): ParsedToolCallStart {
     ri?.path ??
     "") as string;
   const filePath = rawFilePath ? stripSessionPrefix(rawFilePath) : "";
+  const command = sanitizePathsInText(rawCommand);
   return {
     type: "tool_call_start",
     toolCallId: getToolCallId(p),
@@ -565,7 +589,8 @@ function parseToolCallStart(p: Record<string, unknown>): ParsedToolCallStart {
     isTodo: toolName === "todowrite",
     title: buildTitle(toolName, kind, true),
     description: buildDescription(toolName, kind, filePath, ri, rawDescription),
-    command: sanitizePathsInText(rawCommand),
+    command,
+    skillName: resolveSkillName(p, toolName, kind, ri, command),
     subagentType: (ri?.subagent_type ?? ri?.subagentType ?? null) as
       | string
       | null,
@@ -659,14 +684,7 @@ function parseToolCallProgress(
     | null;
 
   // ── Skill detection ───────────────────────────────────────────
-  // Two shapes: (1) skill-namespaced tool calls with raw names like
-  // "skills.brainstorming" (toolName "unknown"); (2) the dedicated "skill"
-  // tool, whose invoked skill is in rawInput.name (e.g. "company-search").
-  const skillName =
-    detectSkillName(p, toolName) ??
-    (toolName === "skill" && typeof ri?.name === "string"
-      ? (ri.name as string)
-      : null);
+  const skillName = resolveSkillName(p, toolName, kind, ri, command);
   const taskOutput =
     toolName === "task" && status === "completed"
       ? extractTaskOutput(ro)

--- a/web/src/app/craft/utils/subagentRouting.ts
+++ b/web/src/app/craft/utils/subagentRouting.ts
@@ -82,6 +82,7 @@ export function toolCallStateFromStart(
     rawOutput: "",
     toolName: parsed.toolName,
     subagentType: parsed.subagentType ?? undefined,
+    skillName: parsed.skillName ?? undefined,
     isNewFile: true,
     oldContent: "",
     newContent: "",


### PR DESCRIPTION
## Description

External app / skill commands in craft currently render as raw shell invocations, e.g.

> ✓ Running `python .opencode/skills/linear/linear_api.py projects --limit 100`

This PR makes them lead with the model-written action description instead, plus the existing skill treatment (sparkle badge, comet edge while running):

> ⟳ List all Linear projects  ✦ linear

Changes:

- `parsePacket.ts`: detect bash invocations of managed skill scripts (`.opencode/skills/<name>/…`) and direct `gh` CLI commands (the github app has no bundled script), and resolve them to a `skillName`. Consolidated the three skill-detection shapes (namespaced tools, the `skill` tool, skill scripts) into one `resolveSkillName` helper used by both `tool_call_start` and `tool_call_progress`.
- `packetTypes.ts` / `subagentRouting.ts`: carry `skillName` on start packets too, so the badge/comet appear immediately rather than after the first progress packet.
- `CraftToolCard.tsx`: execute rows with a `skillName` + description render the description as the header; the raw command stays one click away in the expandable body. Plain bash rows are unchanged (`Running <command>`).

Because detection lives in `parsePacket`, the same rendering applies to the live stream, reloaded sessions, subagent transcripts, and scheduled-task runs.

## How Has This Been Tested?

- New jest cases in `parsePacket.test.ts`: skill-script detection on start + progress packets, `gh` CLI detection, and a no-false-positive check for ordinary bash commands (7/7 passing).
- `tsc --noEmit` clean; new Storybook stories (`SkillScriptInProgress`, `SkillScriptCompleted`) for the rendering.
- Verified live against a local craft session: linear skill-script rows and `gh` rows render with the description header + skill badge; plain bash rows unchanged.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the model-written action description for external app skill commands in Craft instead of the raw bash command, and display the skill badge/comet from the start. Detects managed skill scripts in `.opencode/skills/<name>/...` and the `gh` CLI, resolving them to a `skillName` across live and replayed sessions.

- New Features
  - Unified skill detection via `resolveSkillName`; include `skillName` on start and progress packets for immediate badge/comet.
  - Execute rows with a `skillName` render the description as the header; raw command remains in the expandable body.
  - Detects `.opencode/skills/<name>/...` scripts and treats all `gh` commands as the `github` skill (intentional heuristic). Applies to live streams, reloads, subagent transcripts, and scheduled tasks; adds Jest tests (including start-packet `gh`) and Storybook stories.

<sup>Written for commit 2bce6e5a58e8c0d593caec9662ad30862e8a5d26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

