### PR TITLE
fix(cli): publish musllinux wheels

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -23,7 +23,16 @@ jobs:
           enable-cache: false
           version: "0.9.9"
       - run: |
-          for goos in linux windows darwin; do
+          GOOS=linux GOARCH=amd64 CGO_ENABLED=0 uv build --wheel
+          GOOS=linux GOARCH=amd64 CGO_ENABLED=0 ONYX_CLI_REUSE_BINARY=1 \
+            ONYX_CLI_WHEEL_PLATFORM_TAG=musllinux_1_2_x86_64 \
+            uv build --wheel
+          GOOS=linux GOARCH=arm64 CGO_ENABLED=0 uv build --wheel
+          GOOS=linux GOARCH=arm64 CGO_ENABLED=0 ONYX_CLI_REUSE_BINARY=1 \
+            ONYX_CLI_WHEEL_PLATFORM_TAG=musllinux_1_2_aarch64 \
+            uv build --wheel
+
+          for goos in windows darwin; do
             for goarch in amd64 arm64; do
               GOOS="$goos" GOARCH="$goarch" uv build --wheel
             done
@@ -247,6 +256,11 @@ jobs:
 
           for wheel in cli/dist/*.whl; do
             wheel_name="$(basename "$wheel" .whl)"
+            if [[ "$wheel_name" == *-musllinux_* ]]; then
+              echo "Skipping duplicate static Linux binary scan for $wheel_name"
+              continue
+            fi
+
             extract_dir="wheel-binaries/${wheel_name}"
             sarif_file="govulncheck-results/raw/${wheel_name}.sarif"
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -235,7 +235,16 @@ git tag cli/v0.1.0
 git push origin cli/v0.1.0
 ```
 
-The workflow builds wheels for: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64, windows/arm64.
+The workflow builds wheels for:
+
+- linux/amd64 manylinux
+- linux/amd64 musllinux
+- linux/arm64 manylinux
+- linux/arm64 musllinux
+- darwin/amd64
+- darwin/arm64
+- windows/amd64
+- windows/arm64
 
 ### Manual release
 
@@ -247,6 +256,11 @@ uv build --wheel
 
 # Cross-compile for a different platform
 GOOS=linux GOARCH=amd64 uv build --wheel
+
+# Build a musllinux-tagged Linux wheel for Alpine/musl environments
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 \
+  ONYX_CLI_WHEEL_PLATFORM_TAG=musllinux_1_2_x86_64 \
+  uv build --wheel
 
 # Upload to PyPI
 uv publish

--- a/cli/hatch_build.py
+++ b/cli/hatch_build.py
@@ -18,7 +18,13 @@ class CustomBuildHook(BuildHookInterface):
         # Set platform tag for cross-compilation
         goos = os.getenv("GOOS")
         goarch = os.getenv("GOARCH")
-        if manygo.is_goos(goos) and manygo.is_goarch(goarch):
+        wheel_platform_tag = os.getenv("ONYX_CLI_WHEEL_PLATFORM_TAG")
+        if wheel_platform_tag:
+            if goos != "linux":
+                msg = "ONYX_CLI_WHEEL_PLATFORM_TAG is only supported with GOOS=linux"
+                raise ValueError(msg)
+            build_data["tag"] = f"py3-none-{wheel_platform_tag}"
+        elif manygo.is_goos(goos) and manygo.is_goarch(goarch):
             build_data["tag"] = "py3-none-" + manygo.get_platform_tag(
                 goos=goos,
                 goarch=goarch,
@@ -30,12 +36,20 @@ class CustomBuildHook(BuildHookInterface):
         tag = os.getenv("GITHUB_REF_NAME", "dev").removeprefix(f"{tag_prefix}/")
         commit = os.getenv("GITHUB_SHA", "none")
 
-        # Always rebuild: release builds invoke this hook once per wheel with different
-        # GOOS/GOARCH
-        print(f"Building Go binary '{binary_name}'...")
-        ldflags = f"-X main.version={tag} -X main.commit={commit} -s -w"
-        subprocess.check_call(  # noqa: S603
-            ["go", "build", f"-ldflags={ldflags}", "-o", binary_name],
-        )
+        if os.getenv("ONYX_CLI_REUSE_BINARY") == "1":
+            if not os.path.exists(binary_name):
+                msg = f"ONYX_CLI_REUSE_BINARY=1 set, but {binary_name!r} does not exist"
+                raise FileNotFoundError(msg)
+            print(f"Reusing Go binary '{binary_name}'...")
+        else:
+            print(f"Building Go binary '{binary_name}'...")
+            ldflags = f"-X main.version={tag} -X main.commit={commit} -s -w"
+            env = os.environ.copy()
+            if goos == "linux":
+                env.setdefault("CGO_ENABLED", "0")
+            subprocess.check_call(  # noqa: S603
+                ["go", "build", f"-ldflags={ldflags}", "-o", binary_name],
+                env=env,
+            )
 
         build_data["shared_scripts"] = {binary_name: binary_name}


### PR DESCRIPTION
## Description

Adds musllinux wheel publishing for `onyx-cli` so Alpine/musl sandbox installs can satisfy the wheel-only dependency policy. The CLI build hook now accepts explicit Linux wheel tags, requires `GOOS=linux` when that override is used, and makes Linux builds static by default.

The release workflow now builds both manylinux and musllinux Linux wheels for amd64/arm64 while preserving macOS and Windows wheels. The musllinux wheel for each Linux architecture reuses the already-built static manylinux binary, and `govulncheck` skips the duplicate musllinux binary scans. The CLI README documents the expanded release targets and manual musllinux build command.

This addresses the sandbox build blocker where `onyx-cli==1.1.0` only had manylinux wheels. A musllinux wheel still needs to be published for the CLI version pinned by the sandbox image.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
