### PR TITLE
fix(security): require USER_AUTH_SECRET on non-dev deployments

### DIFF
--- a/.vscode/env_template.txt
+++ b/.vscode/env_template.txt
@@ -7,7 +7,8 @@
 
 
 AUTH_TYPE=basic
-# Recommended for basic auth - used for signing password reset and verification tokens
+# Signs password reset, email verification, OAuth login state, and captcha cookies.
+# Required in production; an empty value is tolerated here only because DEV_MODE=true is set below.
 # Generate a secure value with: openssl rand -hex 32
 USER_AUTH_SECRET=""
 DEV_MODE=true

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -192,7 +192,7 @@ def verify_user_auth_secret() -> None:
 
     This only runs on app startup, not during migrations/scripts.
     """
-    if USER_AUTH_SECRET:
+    if USER_AUTH_SECRET.strip():
         return
 
     message = (

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -89,7 +89,9 @@ from onyx.auth.signup_rate_limit import enforce_signup_rate_limit
 from onyx.configs.app_configs import AUTH_BACKEND
 from onyx.configs.app_configs import AUTH_COOKIE_EXPIRE_TIME_SECONDS
 from onyx.configs.app_configs import AUTH_TYPE
+from onyx.configs.app_configs import DEV_MODE
 from onyx.configs.app_configs import EMAIL_CONFIGURED
+from onyx.configs.app_configs import INTEGRATION_TESTS_MODE
 from onyx.configs.app_configs import JWT_PUBLIC_KEY_URL
 from onyx.configs.app_configs import REDIS_AUTH_KEY_PREFIX
 from onyx.configs.app_configs import REQUIRE_EMAIL_VERIFICATION
@@ -178,6 +180,34 @@ def verify_auth_setting() -> None:
         )
 
     logger.notice("Using Auth Type: %s", AUTH_TYPE.value)
+
+
+def verify_user_auth_secret() -> None:
+    """Refuse to start a real deployment without a USER_AUTH_SECRET.
+
+    The secret signs password-reset and email-verification tokens, OAuth login
+    state, and captcha cookies. An empty value makes all of them forgeable, so a
+    production deployment must provide one. DEV_MODE / INTEGRATION_TESTS_MODE
+    downgrade this to a warning so local and CI environments keep working.
+
+    This only runs on app startup, not during migrations/scripts.
+    """
+    if USER_AUTH_SECRET:
+        return
+
+    message = (
+        "USER_AUTH_SECRET is empty. It signs password-reset and email-"
+        "verification tokens, OAuth login state, and captcha cookies, so an "
+        "empty value lets attackers forge them. Generate one with "
+        "`openssl rand -hex 32` and set USER_AUTH_SECRET."
+    )
+    if DEV_MODE or INTEGRATION_TESTS_MODE:
+        logger.warning(
+            "%s Allowed because DEV_MODE/INTEGRATION_TESTS_MODE is set.", message
+        )
+        return
+
+    raise ValueError(message)
 
 
 def get_display_email(email: str | None, space_less: bool = False) -> str:

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -269,12 +269,6 @@ JWT_PUBLIC_KEY_URL: str | None = os.getenv("JWT_PUBLIC_KEY_URL", None)
 
 USER_AUTH_SECRET = os.environ.get("USER_AUTH_SECRET", "")
 
-if AUTH_TYPE == AuthType.BASIC and not USER_AUTH_SECRET:
-    logger.warning(
-        "USER_AUTH_SECRET is not set. This is required for secure password reset "
-        "and email verification tokens. Please set USER_AUTH_SECRET in production."
-    )
-
 # Bearer token guarding the API server's /metrics endpoint. Auth is required by
 # default: scrapers must present this token as `Authorization: Bearer <token>`
 # (the standard Prometheus scrape format). If neither this nor

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -32,6 +32,7 @@ from onyx.auth.schemas import UserUpdate
 from onyx.auth.users import auth_backend
 from onyx.auth.users import create_onyx_oauth_router
 from onyx.auth.users import fastapi_users
+from onyx.auth.users import verify_user_auth_secret
 from onyx.cache.interface import CacheBackendType
 from onyx.configs.app_configs import APP_API_PREFIX
 from onyx.configs.app_configs import APP_HOST
@@ -359,6 +360,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:  # noqa: ARG001
 
     # Will throw exception if an issue is found
     verify_auth()
+
+    # Will throw exception if USER_AUTH_SECRET is missing on a real deployment
+    verify_user_auth_secret()
 
     if OAUTH_CLIENT_ID and OAUTH_CLIENT_SECRET:
         logger.notice("Both OAuth Client ID and Secret are configured.")

--- a/backend/tests/unit/onyx/auth/test_verify_auth_setting.py
+++ b/backend/tests/unit/onyx/auth/test_verify_auth_setting.py
@@ -4,6 +4,7 @@ import pytest
 
 import onyx.auth.users as users
 from onyx.auth.users import verify_auth_setting
+from onyx.auth.users import verify_user_auth_secret
 from onyx.configs.constants import AuthType
 
 
@@ -52,3 +53,45 @@ def test_verify_auth_setting_valid_auth_types(
 
     mock_logger.warning.assert_not_called()
     mock_logger.notice.assert_called_once_with("Using Auth Type: %s", auth_type.value)
+
+
+def test_verify_user_auth_secret_rejects_empty_secret_in_production(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty USER_AUTH_SECRET must abort startup outside dev/test modes."""
+    monkeypatch.setattr(users, "USER_AUTH_SECRET", "")
+    monkeypatch.setattr(users, "DEV_MODE", False)
+    monkeypatch.setattr(users, "INTEGRATION_TESTS_MODE", False)
+
+    with pytest.raises(ValueError, match="USER_AUTH_SECRET"):
+        verify_user_auth_secret()
+
+
+@pytest.mark.parametrize("flag", ["DEV_MODE", "INTEGRATION_TESTS_MODE"])
+def test_verify_user_auth_secret_warns_in_dev_modes(
+    monkeypatch: pytest.MonkeyPatch,
+    flag: str,
+) -> None:
+    """DEV_MODE / INTEGRATION_TESTS_MODE downgrade the empty-secret failure to a warning."""
+    mock_logger = MagicMock()
+    monkeypatch.setattr(users, "logger", mock_logger)
+    monkeypatch.setattr(users, "USER_AUTH_SECRET", "")
+    monkeypatch.setattr(users, "DEV_MODE", flag == "DEV_MODE")
+    monkeypatch.setattr(
+        users, "INTEGRATION_TESTS_MODE", flag == "INTEGRATION_TESTS_MODE"
+    )
+
+    verify_user_auth_secret()
+
+    mock_logger.warning.assert_called_once()
+
+
+def test_verify_user_auth_secret_accepts_configured_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A configured secret passes even when no dev/test mode is set."""
+    monkeypatch.setattr(users, "USER_AUTH_SECRET", "a-real-secret")
+    monkeypatch.setattr(users, "DEV_MODE", False)
+    monkeypatch.setattr(users, "INTEGRATION_TESTS_MODE", False)
+
+    verify_user_auth_secret()

--- a/backend/tests/unit/onyx/db/engine/test_engine_disposal.py
+++ b/backend/tests/unit/onyx/db/engine/test_engine_disposal.py
@@ -125,6 +125,7 @@ async def test_lifespan_shutdown_disposes_all_three_engines() -> None:
         stack.enter_context(patch.object(onyx_main, "validate_no_vector_db_settings"))
         stack.enter_context(patch.object(onyx_main, "validate_cache_backend_settings"))
         stack.enter_context(patch.object(onyx_main, "validate_registry"))
+        stack.enter_context(patch.object(onyx_main, "verify_user_auth_secret"))
         stack.enter_context(
             patch.object(
                 onyx_main,

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -53,9 +53,9 @@ IMAGE_TAG=latest
 ### https://docs.onyx.app/deployment/authentication
 AUTH_TYPE=basic
 # SESSION_EXPIRE_TIME_SECONDS=
-### Recommended for basic auth - used for signing password reset and verification tokens
-### If using install.sh, this will be auto-generated
-### If setting manually, run: openssl rand -hex 32
+### Signs password reset, email verification, OAuth login state, and captcha cookies.
+### REQUIRED: the API server refuses to start with an empty value (secure by default).
+### If using install.sh this is auto-generated; if setting manually, run: openssl rand -hex 32
 USER_AUTH_SECRET=""
 ### Recommend to set this for security
 # ENCRYPTION_KEY_SECRET=


### PR DESCRIPTION
- [x] [Optional] Please cherry-pick this PR to the latest release version.

## Description

`USER_AUTH_SECRET` signs password-reset and email-verification tokens, OAuth login state, and captcha cookie HMACs. It defaulted to an empty string (`app_configs.py`) and startup only logged a warning, so a misconfigured deployment would run with predictable/shared signing keys — making reset tokens (account takeover), captcha cookies, and OAuth state forgeable.

This change makes the server **fail closed**:

- New `verify_user_auth_secret()` in `backend/onyx/auth/users.py` raises `ValueError` when the secret is empty, **unless** `DEV_MODE` or `INTEGRATION_TESTS_MODE` is set (in which case it logs a warning, preserving local/CI behavior).
- Called from the FastAPI lifespan in `backend/onyx/main.py`, right after the existing `verify_auth()`. It runs only on real API-server startup (not migrations/scripts) and is shared by CE and EE (EE wraps the base lifespan).
- Removed the now-redundant import-time `BASIC`-only warning in `app_configs.py`; the startup verifier now owns this and covers all auth types.

## Install & developer workflow impact

The runtime behavior change ("empty secret = no boot in prod") ripples into the setup workflows. Summary of what each path does now:

| Setup path | Before | After |
|---|---|---|
| **Guided install** (`install.sh` / `install.ps1`) | auto-generates `USER_AUTH_SECRET` via `openssl rand -hex 32` | unchanged — already produces a non-empty secret ✅ |
| **Manual install** (`deployment/docker_compose/env.template`) | ships `USER_AUTH_SECRET=""`, server boots with a warning | server **refuses to start** until a secret is set — the intended secure-by-default behavior. Template comment updated from "Recommended" → **REQUIRED** with the `openssl rand -hex 32` instruction. |
| **Local dev** (`.vscode/env_template.txt`) | `USER_AUTH_SECRET=""` + `DEV_MODE=true` | unchanged — `DEV_MODE=true` downgrades to a warning, so dev boots fine ✅. Comment clarified that the empty default is tolerated only because `DEV_MODE=true`. |
| **Helm / AWS ECS** | secret supplied via chart values / task env | unchanged if a value is provided; an empty value now fails closed |
| **Search-eval harness** (`docker-compose.search-testing.yml`) | basic auth, no secret, boots | now requires the operator to set `USER_AUTH_SECRET` (or `DEV_MODE=true`) in `.env_eval`. Left unchanged by design — `.env_eval` is operator-supplied and a clear startup error beats silently-insecure signing. |

Net effect on the **developer** day-to-day: none — the standard `.vscode` dev template already sets `DEV_MODE=true`. The change only bites a setup that runs the server with no secret **and** no dev/test flag (i.e. a real/manual deployment), which is exactly the case we want to block.

## How Has This Been Tested?
- [x] New regression tests pass (`backend/tests/unit/onyx/auth/test_verify_auth_setting.py`): empty secret rejected outside dev/test modes; warns under `DEV_MODE`/`INTEGRATION_TESTS_MODE`; configured secret passes. Existing `verify_auth_setting` tests unaffected (10/10).
- [x] `prek` clean (`ty`, `ruff`, `ruff format`)
- [x] `/security-review` — no new vulnerabilities introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)