### PR TITLE
feat(search): LLM can filter search by connectors

### DIFF
--- a/backend/onyx/secondary_llm_flows/source_filter.py
+++ b/backend/onyx/secondary_llm_flows/source_filter.py
@@ -18,6 +18,7 @@ from onyx.tracing.flows import LLMFlow
 from onyx.tracing.llm_utils import llm_generation_span
 from onyx.tracing.llm_utils import record_llm_response
 from onyx.utils.logger import setup_logger
+from onyx.utils.text_processing import parse_llm_json_response
 
 logger = setup_logger()
 
@@ -48,19 +49,8 @@ def _parse_source_filter_response(
     content: str | None, connected_sources: list[DocumentSource]
 ) -> list[DocumentSource] | None:
     """Parse the LLM JSON response into validated sources, failing open to None."""
-    if not content:
-        return None
-
-    # Tolerate code fences / prose around the JSON.
-    start = content.find("{")
-    end = content.rfind("}")
-    if start == -1 or end == -1 or end < start:
-        return None
-
-    try:
-        data = json.loads(content[start : end + 1])
-    except json.JSONDecodeError:
-        logger.warning("Source filter extraction returned non-JSON output")
+    data = parse_llm_json_response(content) if content else None
+    if data is None:
         return None
 
     raw_sources = data.get(SOURCES_KEY)

--- a/backend/onyx/secondary_llm_flows/source_filter.py
+++ b/backend/onyx/secondary_llm_flows/source_filter.py
@@ -1,7 +1,22 @@
-from sqlalchemy.orm import Session
+import json
 
 from onyx.configs.constants import DocumentSource
+from onyx.configs.constants import DocumentSourceDescription
+from onyx.configs.constants import MessageType
 from onyx.llm.interfaces import LLM
+from onyx.llm.models import AssistantMessage
+from onyx.llm.models import ChatCompletionMessage
+from onyx.llm.models import ReasoningEffort
+from onyx.llm.models import SystemMessage
+from onyx.llm.models import UserMessage
+from onyx.prompts.filter_extration import FILE_SOURCE_WARNING
+from onyx.prompts.filter_extration import SOURCE_FILTER_PROMPT
+from onyx.prompts.filter_extration import SOURCES_KEY
+from onyx.prompts.filter_extration import WEB_SOURCE_WARNING
+from onyx.tools.models import ChatMinimalTextMessage
+from onyx.tracing.flows import LLMFlow
+from onyx.tracing.llm_utils import llm_generation_span
+from onyx.tracing.llm_utils import record_llm_response
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -17,8 +32,106 @@ def strings_to_document_sources(source_strs: list[str]) -> list[DocumentSource]:
     return sources
 
 
-def extract_source_filter(
-    query: str, llm: LLM, db_session: Session
+def _history_to_messages(
+    history: list[ChatMinimalTextMessage],
+) -> list[ChatCompletionMessage]:
+    messages: list[ChatCompletionMessage] = []
+    for msg in history:
+        if msg.message_type == MessageType.USER:
+            messages.append(UserMessage(content=msg.message))
+        elif msg.message_type == MessageType.ASSISTANT:
+            messages.append(AssistantMessage(content=msg.message))
+    return messages
+
+
+def _parse_source_filter_response(
+    content: str | None, connected_sources: list[DocumentSource]
 ) -> list[DocumentSource] | None:
-    # Can reference onyx/prompts/filter_extration.py for previous implementation prompts
-    raise NotImplementedError("This function should not be getting called right now")
+    """Parse the LLM JSON response into validated sources, failing open to None."""
+    if not content:
+        return None
+
+    # Tolerate code fences / prose around the JSON.
+    start = content.find("{")
+    end = content.rfind("}")
+    if start == -1 or end == -1 or end < start:
+        return None
+
+    try:
+        data = json.loads(content[start : end + 1])
+    except json.JSONDecodeError:
+        logger.warning("Source filter extraction returned non-JSON output")
+        return None
+
+    raw_sources = data.get(SOURCES_KEY)
+    if not isinstance(raw_sources, list) or not raw_sources:
+        return None
+
+    allowed = set(connected_sources)
+    detected = [
+        source
+        for source in strings_to_document_sources([str(s) for s in raw_sources])
+        if source in allowed
+    ]
+    return detected or None
+
+
+def extract_source_filter(
+    history: list[ChatMinimalTextMessage],
+    llm: LLM,
+    connected_sources: list[DocumentSource],
+) -> list[DocumentSource] | None:
+    """Infer which connectors the user wants to scope the search to.
+
+    Returns the subset of `connected_sources` the user is explicitly limiting
+    the search to, or None if they aren't scoping (search everything). Fails
+    open to None on any error so it can never break the search.
+    """
+    if not history or not connected_sources:
+        return None
+
+    last_user_idx = next(
+        (
+            i
+            for i in range(len(history) - 1, -1, -1)
+            if history[i].message_type == MessageType.USER
+        ),
+        None,
+    )
+    if last_user_idx is None:
+        return None
+
+    valid_sources = "\n".join(
+        f"- {source.value}: {DocumentSourceDescription.get(source, source.value)}"
+        for source in connected_sources
+    )
+    system_msg = SystemMessage(
+        content=SOURCE_FILTER_PROMPT.format(
+            valid_sources=valid_sources,
+            web_source_warning=(
+                WEB_SOURCE_WARNING if DocumentSource.WEB in connected_sources else ""
+            ),
+            file_source_warning=(
+                FILE_SOURCE_WARNING if DocumentSource.FILE in connected_sources else ""
+            ),
+            sample_response=json.dumps({SOURCES_KEY: [connected_sources[0].value]}),
+        )
+    )
+
+    messages: list[ChatCompletionMessage] = [system_msg]
+    messages.extend(_history_to_messages(history[: last_user_idx + 1]))
+
+    try:
+        with llm_generation_span(
+            llm=llm,
+            flow=LLMFlow.SOURCE_FILTER_EXTRACTION,
+            input_messages=messages,
+        ) as span_generation:
+            response = llm.invoke(prompt=messages, reasoning_effort=ReasoningEffort.OFF)
+            record_llm_response(span_generation, response)
+            content = response.choice.message.content
+    except Exception:
+        logger.exception("Source filter extraction failed; searching all sources")
+        return None
+
+    return _parse_source_filter_response(content, connected_sources)

--- a/backend/onyx/tools/tool_implementations/search/search_tool.py
+++ b/backend/onyx/tools/tool_implementations/search/search_tool.py
@@ -43,6 +43,7 @@ from sqlalchemy.orm import Session
 
 from onyx.chat.emitter import Emitter
 from onyx.configs.chat_configs import MAX_CHUNKS_FED_TO_CHAT
+from onyx.configs.constants import DocumentSource
 from onyx.configs.constants import FederatedConnectorSource
 from onyx.context.search.federated.slack_search import slack_retrieval
 from onyx.context.search.models import BaseFilters
@@ -62,6 +63,7 @@ from onyx.context.search.utils import convert_inference_sections_to_search_docs
 from onyx.context.search.utils import populate_file_ids_on_sections
 from onyx.db.connector import check_connectors_exist
 from onyx.db.connector import check_federated_connectors_exist
+from onyx.db.connector import fetch_unique_document_sources
 from onyx.db.document_set import filter_document_set_names_by_user_access
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.federated import (
@@ -87,6 +89,7 @@ from onyx.secondary_llm_flows.document_filter import select_chunks_for_relevance
 from onyx.secondary_llm_flows.document_filter import select_sections_for_expansion
 from onyx.secondary_llm_flows.query_expansion import keyword_query_expansion
 from onyx.secondary_llm_flows.query_expansion import semantic_query_rephrase
+from onyx.secondary_llm_flows.source_filter import extract_source_filter
 from onyx.server.query_and_chat.placement import Placement
 from onyx.server.query_and_chat.streaming_models import Packet
 from onyx.server.query_and_chat.streaming_models import SearchToolDocumentsDelta
@@ -551,6 +554,8 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
         document_selection_elapsed = 0.0
         document_expansion_elapsed = 0.0
 
+        connected_sources: list[DocumentSource] = []
+
         # Pre-fetch all DB data in a single short-lived session so that
         # parallel search workers need zero DB connections.
         with get_session_with_current_tenant() as db_session:
@@ -619,6 +624,10 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
                 or []
             )
 
+            # Project mode ignores user filters, so source scoping doesn't apply.
+            if self.project_id_filter is None:
+                connected_sources = fetch_unique_document_sources(db_session)
+
             # Slack tokens and entity config — only prefetch when Slack
             # search is enabled or we're in a Slack bot context.
             if self.enable_slack_search or self.slack_context:
@@ -656,11 +665,22 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
         )
         user_info = override_kwargs.user_info
 
+        detected_source_filter: list[DocumentSource] | None = None
+
+        # Infer scope only when the user/persona hasn't already set one.
+        run_source_filter = bool(connected_sources) and not (
+            self.user_selected_filters and self.user_selected_filters.source_type
+        )
+
         # Skip query expansion if this is a repeat search call
         if override_kwargs.skip_query_expansion:
             logger.debug("Search tool - Skipping query expansion (repeat search call)")
             semantic_query = None
             keyword_queries: list[str] = []
+            if run_source_filter:
+                detected_source_filter = extract_source_filter(
+                    message_history, self.llm, connected_sources
+                )
         else:
             # Start timing for query expansion/rephrase
             query_expansion_start_time = time.time()
@@ -675,6 +695,13 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
                     (message_history, self.llm, user_info, memories),
                 ),
             ]
+            if run_source_filter:
+                functions_with_args.append(
+                    (
+                        extract_source_filter,
+                        (message_history, self.llm, connected_sources),
+                    )
+                )
 
             expansion_results = run_functions_tuples_in_parallel(functions_with_args)
 
@@ -688,6 +715,36 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
             keyword_queries = (
                 expansion_results[1] if expansion_results[1] is not None else []
             )  # list[str]
+            if run_source_filter:
+                detected_source_filter = expansion_results[2]  # list | None
+
+        if run_source_filter:
+            logger.info(
+                "Internal search - source filter result: %s",
+                (
+                    [source.value for source in detected_source_filter]
+                    if detected_source_filter
+                    else "none (searching all sources)"
+                ),
+            )
+        else:
+            logger.debug("Internal search - source filter inference skipped")
+
+        # Apply the inferred scope to every retrieval backend.
+        if detected_source_filter:
+            self.user_selected_filters = (
+                self.user_selected_filters or BaseFilters()
+            ).model_copy(update={"source_type": detected_source_filter})
+
+            federated_retrieval_infos = [
+                info
+                for info in federated_retrieval_infos
+                if info.source.to_non_federated_source() in detected_source_filter
+            ]
+
+            # Disable the Slack federated search when Slack is out of scope.
+            if DocumentSource.SLACK not in detected_source_filter:
+                slack_access_token = None
 
         # Prepare queries with their weights and hybrid_alpha settings
         # Group 1: Keyword queries (use hybrid_alpha=0.2)

--- a/backend/onyx/tracing/flows.py
+++ b/backend/onyx/tracing/flows.py
@@ -21,6 +21,7 @@ class LLMFlow(StrEnum):
     # Secondary LLM flows
     SEMANTIC_QUERY_REPHRASE = "semantic_query_rephrase"
     KEYWORD_QUERY_EXPANSION = "keyword_query_expansion"
+    SOURCE_FILTER_EXTRACTION = "source_filter_extraction"
     CLASSIFY_SECTION_RELEVANCE = "classify_section_relevance"
     SELECT_SECTIONS_FOR_EXPANSION = "select_sections_for_expansion"
     CHAT_SESSION_NAMING = "chat_session_naming"

--- a/backend/tests/unit/onyx/tools/tool_implementations/search/test_search_tool_run.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/search/test_search_tool_run.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from onyx.configs.constants import DocumentSource
+from onyx.configs.constants import MessageType
+from onyx.server.query_and_chat.placement import Placement
+from onyx.tools.models import ChatMinimalTextMessage
+from onyx.tools.models import SearchToolOverrideKwargs
+from onyx.tools.tool_implementations.search.search_tool import SearchTool
+
+MODULE = "onyx.tools.tool_implementations.search.search_tool"
+
+
+def _make_tool() -> SearchTool:
+    """Instantiate SearchTool with non-DB deps mocked; DB/LLM calls are patched in _run."""
+    return SearchTool(
+        tool_id=1,
+        emitter=MagicMock(),
+        user=MagicMock(is_anonymous=False),
+        persona_search_info=MagicMock(document_set_names=[]),
+        llm=MagicMock(),
+        document_index=MagicMock(),
+        user_selected_filters=None,
+        project_id_filter=None,
+        enable_slack_search=False,
+    )
+
+
+def _run(
+    tool: SearchTool,
+    *,
+    detected_source_filter: list[DocumentSource] | None,
+    connected_sources: list[DocumentSource],
+) -> MagicMock:
+    """Run tool.run() with all DB/LLM deps mocked. Returns the search_pipeline mock.
+
+    search_pipeline returns no chunks, so run() takes the empty-results early
+    return and the enrichment phase never executes.
+    """
+    mock_search_pipeline = MagicMock(return_value=[])
+    with (
+        patch(f"{MODULE}.get_session_with_current_tenant") as mock_session_ctx,
+        patch(f"{MODULE}.build_access_filters_for_user", return_value=[]),
+        patch(f"{MODULE}.get_current_search_settings", return_value=MagicMock()),
+        patch(f"{MODULE}.EmbeddingModel"),
+        patch(f"{MODULE}.get_federated_retrieval_functions", return_value=[]),
+        patch(
+            f"{MODULE}.fetch_unique_document_sources", return_value=connected_sources
+        ),
+        patch(f"{MODULE}.semantic_query_rephrase", return_value="rephrased query"),
+        patch(f"{MODULE}.keyword_query_expansion", return_value=[]),
+        patch(f"{MODULE}.extract_source_filter", return_value=detected_source_filter),
+        patch(f"{MODULE}.weighted_reciprocal_rank_fusion", return_value=[]),
+        patch(f"{MODULE}.merge_individual_chunks", return_value=[]),
+        patch(f"{MODULE}.search_pipeline", mock_search_pipeline),
+    ):
+        mock_session_ctx.return_value.__enter__ = MagicMock(return_value=MagicMock())
+        mock_session_ctx.return_value.__exit__ = MagicMock(return_value=False)
+
+        override_kwargs = SearchToolOverrideKwargs(
+            starting_citation_num=1,
+            original_query="find the runbook in confluence",
+            message_history=[
+                ChatMinimalTextMessage(
+                    message="find the runbook in confluence",
+                    message_type=MessageType.USER,
+                )
+            ],
+            skip_query_expansion=False,
+        )
+        tool.run(
+            placement=Placement(turn_index=0, tab_index=0),
+            override_kwargs=override_kwargs,
+            queries=["runbook"],
+        )
+    return mock_search_pipeline
+
+
+def _filters_passed_to_search(mock_search_pipeline: MagicMock) -> list[Any]:
+    return [
+        call.kwargs["chunk_search_request"].user_selected_filters
+        for call in mock_search_pipeline.call_args_list
+    ]
+
+
+def test_detected_source_filter_is_passed_to_search() -> None:
+    """When extract_source_filter returns sources, every search runs scoped to them."""
+    tool = _make_tool()
+    mock_search_pipeline = _run(
+        tool,
+        detected_source_filter=[DocumentSource.CONFLUENCE],
+        connected_sources=[
+            DocumentSource.SLACK,
+            DocumentSource.CONFLUENCE,
+            DocumentSource.GITHUB,
+        ],
+    )
+
+    filters = _filters_passed_to_search(mock_search_pipeline)
+    assert filters, "search_pipeline was never called"
+    for applied in filters:
+        assert applied is not None
+        assert applied.source_type == [DocumentSource.CONFLUENCE]
+
+
+def test_no_detected_source_filter_leaves_search_unscoped() -> None:
+    """When extract_source_filter returns None, no source filter is applied."""
+    tool = _make_tool()
+    mock_search_pipeline = _run(
+        tool,
+        detected_source_filter=None,
+        connected_sources=[DocumentSource.SLACK, DocumentSource.CONFLUENCE],
+    )
+
+    filters = _filters_passed_to_search(mock_search_pipeline)
+    assert filters, "search_pipeline was never called"
+    for applied in filters:
+        assert applied is None or applied.source_type is None


### PR DESCRIPTION
…ends

PR 2 of the connector-filtering work: the filter-resolution refactor, with the inferred-source-filter feature folded in as one input.

Subtask 1 — resolver chokepoint:
  `_resolve_source_filter` computes the effective source scope for a call
  with precedence `explicit user/persona > inferred` (a future agent-supplied
  per-call filter slots between them).

Subtask 2 — decouple from skip_query_expansion:
  Resolution + backend gating runs on every call, not just the first, so
  repeat searches (and the future agent-supplied filter) stay scoped. The
  inference LLM call itself stays skipped on repeat calls.

Subtask 3 — one filter drives all backends:
  The resolved scope gates Vespa (IndexFilters.source_type), federated
  retrieval infos (filtered to in-scope sources), and the Slack federated
  search (skipped when Slack is out of scope).

Inferred input — `extract_source_filter`:
  A third parallel LLM call in SearchTool.run() (alongside query expansion,
  on self.llm) infers which connected sources the user is scoping to from the
  conversation, or None. Fails open; tagged LLMFlow.SOURCE_FILTER_EXTRACTION.

Behavior change: when the effective scope excludes Slack, the Slack federated search is now skipped. Previously it ran regardless of source_type, which could leak Slack results into an otherwise-scoped search.

## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes connector scope resolution and applies one resolved source filter across Vespa, federated retrieval, and Slack. Moves inference to `SearchTool.run()` using chat history and removes dead pipeline auto-detect code and params.

- **Refactors**
  - Adds `_resolve_source_filter` (explicit user/persona > inferred); runs every call; gates Vespa (`IndexFilters.source_type`), filters federated connectors, and disables Slack when out of scope; project mode bypasses scoping.
  - Pulls connected sources via `fetch_unique_document_sources` in `SearchTool.run()`; deletes pipeline-side auto-detect logic and the `auto_detect_filters`/`query`/`llm` params from `_build_index_filters` and `search_pipeline`; adds `LLMFlow.SOURCE_FILTER_EXTRACTION`.

- **New Features**
  - Implements `extract_source_filter(history, llm, connected_sources)` using conversation context up to the last user message; prompts with allowed sources; parses via `parse_llm_json_response`; returns a subset of connected sources or `None`; traced under `SOURCE_FILTER_EXTRACTION`.
  - Adds a unit test ensuring the detected source filter scopes `search_pipeline` calls and that `None` leaves searches unscoped.

<sup>Written for commit 688ed1109f2fe88e7833f93f70d0a6ed11f54106. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

