### PR TITLE
fix(web): don't shrink custom placeholders in PasswordInputTypeIn

### DIFF
--- a/web/src/app/auth/login/EmailPasswordForm.tsx
+++ b/web/src/app/auth/login/EmailPasswordForm.tsx
@@ -220,6 +220,7 @@ export default function EmailPasswordForm({
                           field.onChange(e);
                         }}
                         placeholder="●●●●●●●●●●●●●●"
+                        shrinkPlaceholder
                         data-testid="password"
                         autoComplete={
                           isSignup ? "new-password" : "current-password"

--- a/web/src/refresh-components/inputs/PasswordInputTypeIn.test.tsx
+++ b/web/src/refresh-components/inputs/PasswordInputTypeIn.test.tsx
@@ -7,20 +7,20 @@
  */
 import React from "react";
 import { render, screen, setupUser } from "@tests/setup/test-utils";
-import PasswordInputTypeIn from "./PasswordInputTypeIn";
+import PasswordInputTypeIn, {
+  type PasswordInputTypeInProps,
+} from "./PasswordInputTypeIn";
 
-interface ControlledPasswordProps {
+interface ControlledPasswordProps extends Omit<
+  PasswordInputTypeInProps,
+  "value" | "onChange"
+> {
   initialValue?: string;
-  isNonRevealable?: boolean;
-  placeholder?: string;
-  shrinkPlaceholder?: boolean;
 }
 
 function ControlledPassword({
   initialValue = "",
-  isNonRevealable,
-  placeholder,
-  shrinkPlaceholder,
+  ...props
 }: ControlledPasswordProps) {
   const [value, setValue] = React.useState(initialValue);
   return (
@@ -28,9 +28,7 @@ function ControlledPassword({
       data-testid="pw"
       value={value}
       onChange={(e) => setValue(e.target.value)}
-      isNonRevealable={isNonRevealable}
-      placeholder={placeholder}
-      shrinkPlaceholder={shrinkPlaceholder}
+      {...props}
     />
   );
 }

--- a/web/src/refresh-components/inputs/PasswordInputTypeIn.test.tsx
+++ b/web/src/refresh-components/inputs/PasswordInputTypeIn.test.tsx
@@ -7,19 +7,18 @@
  */
 import React from "react";
 import { render, screen, setupUser } from "@tests/setup/test-utils";
-import PasswordInputTypeIn, {
-  type PasswordInputTypeInProps,
-} from "./PasswordInputTypeIn";
+import PasswordInputTypeIn from "./PasswordInputTypeIn";
 
-interface ControlledPasswordProps extends Omit<
-  PasswordInputTypeInProps,
-  "value" | "onChange"
-> {
+interface ControlledPasswordProps {
   initialValue?: string;
+  isNonRevealable?: boolean;
+  placeholder?: string;
+  shrinkPlaceholder?: boolean;
 }
 
 function ControlledPassword({
   initialValue = "",
+  isNonRevealable,
   ...props
 }: ControlledPasswordProps) {
   const [value, setValue] = React.useState(initialValue);
@@ -28,6 +27,7 @@ function ControlledPassword({
       data-testid="pw"
       value={value}
       onChange={(e) => setValue(e.target.value)}
+      isNonRevealable={isNonRevealable}
       {...props}
     />
   );

--- a/web/src/refresh-components/inputs/PasswordInputTypeIn.test.tsx
+++ b/web/src/refresh-components/inputs/PasswordInputTypeIn.test.tsx
@@ -12,11 +12,15 @@ import PasswordInputTypeIn from "./PasswordInputTypeIn";
 interface ControlledPasswordProps {
   initialValue?: string;
   isNonRevealable?: boolean;
+  placeholder?: string;
+  shrinkPlaceholder?: boolean;
 }
 
 function ControlledPassword({
   initialValue = "",
   isNonRevealable,
+  placeholder,
+  shrinkPlaceholder,
 }: ControlledPasswordProps) {
   const [value, setValue] = React.useState(initialValue);
   return (
@@ -25,6 +29,8 @@ function ControlledPassword({
       value={value}
       onChange={(e) => setValue(e.target.value)}
       isNonRevealable={isNonRevealable}
+      placeholder={placeholder}
+      shrinkPlaceholder={shrinkPlaceholder}
     />
   );
 }
@@ -76,14 +82,32 @@ describe("PasswordInputTypeIn", () => {
     render(<ControlledPassword initialValue="secret" />);
 
     // Applied whenever hidden (even before typing) so the size is constant
-    // across keystrokes; the placeholder override keeps it matched to the mask.
+    // across keystrokes.
     const wrapper = screen.getByTestId("pw").closest("div.contents");
     expect(wrapper?.className).toContain("[&_input]:!text-[0.6rem]");
-    expect(wrapper?.className).toContain(
-      "[&_input::placeholder]:!text-[0.6rem]"
-    );
 
     await user.click(screen.getByRole("button", { name: "Show password" }));
     expect(wrapper?.className).not.toContain("[&_input]:!text-[0.6rem]");
+  });
+
+  test("shrinks the placeholder when shrinkPlaceholder is set", () => {
+    render(<ControlledPassword placeholder="●●●●●●●●" shrinkPlaceholder />);
+
+    const wrapper = screen.getByTestId("pw").closest("div.contents");
+    expect(wrapper?.className).toContain(
+      "[&_input::placeholder]:!text-[0.6rem]"
+    );
+  });
+
+  test("leaves a custom text placeholder at full size by default", () => {
+    render(<ControlledPassword placeholder="Your long-term API key" />);
+
+    // The input value still shrinks while hidden, but the custom text
+    // placeholder must stay legible at its normal Opal size.
+    const wrapper = screen.getByTestId("pw").closest("div.contents");
+    expect(wrapper?.className).toContain("[&_input]:!text-[0.6rem]");
+    expect(wrapper?.className).not.toContain(
+      "[&_input::placeholder]:!text-[0.6rem]"
+    );
   });
 });

--- a/web/src/refresh-components/inputs/PasswordInputTypeIn.tsx
+++ b/web/src/refresh-components/inputs/PasswordInputTypeIn.tsx
@@ -41,6 +41,14 @@ export interface PasswordInputTypeInProps extends Omit<
    * The input remains editable so users can type a new value.
    */
   isNonRevealable?: boolean;
+  /**
+   * When true, the placeholder is shrunk to the same font-size as the masked
+   * dots while the field is hidden. Use this only with a masked-style
+   * placeholder (all ● glyphs, e.g. the login form) so the empty and filled
+   * states line up. Leave false (the default) for custom text placeholders
+   * (e.g. "AKIA…", "Your long-term API key") so they stay legible.
+   */
+  shrinkPlaceholder?: boolean;
 }
 
 /**
@@ -54,10 +62,11 @@ export interface PasswordInputTypeInProps extends Omit<
  * what lets browsers and password managers recognize the field for autofill /
  * save-password. The browser draws its own mask glyph — a filled dot rendered
  * larger than a literal • bullet (closest to ● U+25CF in Chromium) and much
- * wider than normal text. While masked we shrink the field (and its ●
- * placeholder) to a smaller font-size so the dots are tighter and the empty
- * (placeholder) and filled (masked) states match. Callers that show a
- * masked-style placeholder should use ●.
+ * wider than normal text. While masked we shrink the field's font-size so the
+ * dots are tighter. The placeholder is only shrunk to match when the caller
+ * opts in via `shrinkPlaceholder` (used with a masked-style ● placeholder, e.g.
+ * the login form); custom text placeholders (e.g. "AKIA…", "Your long-term API
+ * key") keep their normal size so they stay legible.
  *
  * Features:
  * - Show/hide toggle button only visible when input has value or is focused
@@ -68,6 +77,7 @@ export interface PasswordInputTypeInProps extends Omit<
 export default function PasswordInputTypeIn({
   ref,
   isNonRevealable = false,
+  shrinkPlaceholder = false,
   value,
   onChange,
   onFocus,
@@ -113,17 +123,19 @@ export default function PasswordInputTypeIn({
     <div
       ref={containerRef}
       // The native mask glyph is much wider than text, so while hidden we shrink
-      // the dots to 0.6rem. We set the size on the input itself (and its ●
-      // placeholder) with !important — beating Opal's `font: inherit` / absolute
-      // placeholder size — rather than on `.opal-input`, which carries Opal's
-      // `transition-all`; keeping the change off that element makes toggling
-      // reveal instant instead of animating. rem (not em) avoids compounding, so
-      // the same value matches on both the placeholder and the mask. Only while
-      // hidden, so revealed text is full-size.
+      // the dots to 0.6rem. We set the size on the input itself with !important —
+      // beating Opal's `font: inherit` — rather than on `.opal-input`, which
+      // carries Opal's `transition-all`; keeping the change off that element
+      // makes toggling reveal instant instead of animating. rem (not em) avoids
+      // compounding. The placeholder carries its own absolute Opal size, so the
+      // input shrink never touches it; we only shrink it (also with !important)
+      // when the caller opts in via `shrinkPlaceholder` (masked-style ●
+      // placeholder), so it matches the dots. Custom text placeholders stay
+      // full-size. Only while hidden, so revealed text is full-size.
       className={cn(
         "contents",
-        isHidden &&
-          "[&_input]:!text-[0.6rem] [&_input::placeholder]:!text-[0.6rem]"
+        isHidden && "[&_input]:!text-[0.6rem]",
+        isHidden && shrinkPlaceholder && "[&_input::placeholder]:!text-[0.6rem]"
       )}
       onFocus={handleContainerFocus}
       onBlur={handleContainerBlur}


### PR DESCRIPTION
- [x] [Optional] Please cherry-pick this PR to the latest release version.

## Problem

`PasswordInputTypeIn` shrinks its font to `0.6rem` while masked so the wide native mask dots stay tight. The same rule also shrank the **placeholder**, which made custom text placeholders render tiny and illegible — e.g. the Bedrock modal's `AWS_SECRET_ACCESS_KEY` ("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY") and Long-term API Key ("Your long-term API key") fields.

The placeholder shrink only makes sense for a masked-style (`●`) placeholder, where it needs to match the dot size. The only caller that does this is the login form.

## Fix

Gate the placeholder shrink behind an explicit `shrinkPlaceholder` prop (default `false`) rather than always applying it:

- The input-value shrink (the actual masked dots) still always applies while hidden — unchanged.
- The placeholder shrink now only applies when `shrinkPlaceholder` is set.
- The login form (the one masked-`●`-placeholder caller) opts in.
- All other callers (Bedrock, WebSearch, Voice, MCP/OpenAPI auth, etc.) automatically keep their custom text placeholders at normal size.

This uses an explicit prop instead of sniffing the placeholder string for `●` glyphs at runtime — no per-render parsing, and no risk of misclassifying a caller's placeholder.

The placeholder carries its own absolute Opal font-size (`font-main-ui-muted`), so the input-value shrink never cascades into it — only the dedicated `[&_input::placeholder]` rule affects it.

## Tests

Updated the component tests:
- masked dots still shrink while hidden, not when revealed
- placeholder shrinks when `shrinkPlaceholder` is set
- custom text placeholder stays full-size by default (input value still shrinks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop shrinking custom text placeholders in PasswordInputTypeIn so they stay readable. Placeholder shrink is now opt-in for masked-style (●) placeholders; the login form opts in, others stay full-size.

- **Bug Fixes**
  - Added `shrinkPlaceholder` prop (default `false`) to control placeholder size while hidden.
  - Masked dots still shrink to 0.6rem; placeholder shrinks only when `shrinkPlaceholder` is set.
  - Updated tests to cover reveal toggling and placeholder behavior; kept `isNonRevealable` explicit and spread only `placeholder`/`shrinkPlaceholder` in the helper.

<sup>Written for commit 03ba1fc8f2b3bf2968a63802000cb7d599c82895. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

