### PR TITLE
fix(web): sanitize docx-preview output in file preview modal

### DIFF
--- a/.secretsignore
+++ b/.secretsignore
@@ -3,3 +3,6 @@
 [secrets]
 # This is from a 50x50 checkered PNG image used in tests.
 iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAIAAACRXR/mAAAAVElEQVR42u3WwQkAIAwDQOP+O9cN+lJUuHylcFApyWhTVc1rkkOzczwZLCwsrN9YuXXH+1lLxMLCwtpz5XV5fwsLC0uX1+WxsLCwdHldHgsLC+uxLK9hJFqMAN43AAAAAElFTkSuQmCC
+# ripsecrets-detected token within the 1x1 PNG data URL used in the
+# docx-preview sanitizer tests (--strict-ignore needs the exact matched token).
+EAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5Erk

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -43,6 +43,7 @@
         "copy-to-clipboard": "^3.3.3",
         "date-fns": "^3.6.0",
         "docx-preview": "^0.3.7",
+        "dompurify": "3.4.8",
         "favicon-fetch": "^1.0.0",
         "formik": "^2.2.9",
         "highlight.js": "^11.11.1",

--- a/web/package.json
+++ b/web/package.json
@@ -67,6 +67,7 @@
     "copy-to-clipboard": "^3.3.3",
     "date-fns": "^3.6.0",
     "docx-preview": "^0.3.7",
+    "dompurify": "3.4.8",
     "favicon-fetch": "^1.0.0",
     "formik": "^2.2.9",
     "highlight.js": "^11.11.1",

--- a/web/src/sections/modals/PreviewModal/variants/docxVariant.tsx
+++ b/web/src/sections/modals/PreviewModal/variants/docxVariant.tsx
@@ -10,6 +10,7 @@ import { PreviewContext } from "@/sections/modals/PreviewModal/interfaces";
 import { PreviewVariant } from "@/sections/modals/PreviewModal/interfaces";
 import { CopyButton } from "@opal/components";
 import { DownloadButton } from "@/sections/modals/PreviewModal/variants/shared";
+import { sanitizeDocxHtml } from "@/sections/modals/PreviewModal/variants/sanitizeDocxHtml";
 
 const DOCX_MIMES = [
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
@@ -68,6 +69,17 @@ function DocxPreview({ fileUrl, onLoad }: DocxPreviewProps) {
             renderFootnotes: true,
             renderEndnotes: true,
           });
+
+          // Sanitize docx-preview's output (it has HTML/href sinks). Runs before
+          // the innerText read below so copied text matches what's displayed.
+          bodyRef.current.innerHTML = sanitizeDocxHtml(bodyRef.current.innerHTML);
+
+          // styleRef should only hold library-generated <style> elements.
+          for (const child of Array.from(styleRef.current.children)) {
+            if (child.tagName !== "STYLE") {
+              child.remove();
+            }
+          }
         }
 
         // Extract plain text from the rendered DOM

--- a/web/src/sections/modals/PreviewModal/variants/docxVariant.tsx
+++ b/web/src/sections/modals/PreviewModal/variants/docxVariant.tsx
@@ -72,7 +72,9 @@ function DocxPreview({ fileUrl, onLoad }: DocxPreviewProps) {
 
           // Sanitize docx-preview's output (it has HTML/href sinks). Runs before
           // the innerText read below so copied text matches what's displayed.
-          bodyRef.current.innerHTML = sanitizeDocxHtml(bodyRef.current.innerHTML);
+          bodyRef.current.innerHTML = sanitizeDocxHtml(
+            bodyRef.current.innerHTML
+          );
 
           // styleRef should only hold library-generated <style> elements.
           for (const child of Array.from(styleRef.current.children)) {

--- a/web/src/sections/modals/PreviewModal/variants/sanitizeDocxHtml.test.tsx
+++ b/web/src/sections/modals/PreviewModal/variants/sanitizeDocxHtml.test.tsx
@@ -12,7 +12,8 @@ describe("sanitizeDocxHtml", () => {
     // Mirrors renderSymbol: span.innerHTML = `&#x${char};` with a malicious char.
     // The (now harmless) <img> may remain, but the onerror handler must be gone
     // so nothing executes.
-    const dirty = '<span>&amp;#x41;<img src="x" onerror="window.__pwned=1"></span>';
+    const dirty =
+      '<span>&amp;#x41;<img src="x" onerror="window.__pwned=1"></span>';
     const clean = sanitizeDocxHtml(dirty);
 
     const img = parse(clean).querySelector("img");
@@ -41,7 +42,7 @@ describe("sanitizeDocxHtml", () => {
 
   it("removes <script> elements", () => {
     const clean = sanitizeDocxHtml(
-      '<div>text<script>window.__pwned=1</script></div>'
+      "<div>text<script>window.__pwned=1</script></div>"
     );
     expect(parse(clean).querySelector("script")).toBeNull();
   });
@@ -49,7 +50,7 @@ describe("sanitizeDocxHtml", () => {
   it("preserves https hyperlinks and basic document formatting", () => {
     const dirty =
       '<a href="https://onyx.app">Onyx</a>' +
-      '<table><tr><td><b>bold</b> <i>italic</i></td></tr></table>' +
+      "<table><tr><td><b>bold</b> <i>italic</i></td></tr></table>" +
       "<h1>Heading</h1>";
     const doc = parse(sanitizeDocxHtml(dirty));
 

--- a/web/src/sections/modals/PreviewModal/variants/sanitizeDocxHtml.test.tsx
+++ b/web/src/sections/modals/PreviewModal/variants/sanitizeDocxHtml.test.tsx
@@ -77,4 +77,15 @@ describe("sanitizeDocxHtml", () => {
     );
     expect(doc.querySelector("img")?.getAttribute("src")).toBe(dataUrl);
   });
+
+  it("blocks data: URLs in anchor hrefs (only permitted in <img src>)", () => {
+    const doc = parse(
+      sanitizeDocxHtml(
+        '<a href="data:text/html,<script>alert(1)</script>">x</a>'
+      )
+    );
+
+    const href = doc.querySelector("a")?.getAttribute("href") ?? "";
+    expect(href).not.toMatch(/^data:/i);
+  });
 });

--- a/web/src/sections/modals/PreviewModal/variants/sanitizeDocxHtml.test.tsx
+++ b/web/src/sections/modals/PreviewModal/variants/sanitizeDocxHtml.test.tsx
@@ -1,0 +1,79 @@
+import { sanitizeDocxHtml } from "@/sections/modals/PreviewModal/variants/sanitizeDocxHtml";
+
+// Routed to the jsdom jest project via the `.test.tsx` extension so DOMPurify
+// has a DOM to work against.
+
+describe("sanitizeDocxHtml", () => {
+  function parse(html: string): Document {
+    return new DOMParser().parseFromString(html, "text/html");
+  }
+
+  it("neutralizes the auto-firing <img onerror> that a crafted <w:sym w:char> injects", () => {
+    // Mirrors renderSymbol: span.innerHTML = `&#x${char};` with a malicious char.
+    // The (now harmless) <img> may remain, but the onerror handler must be gone
+    // so nothing executes.
+    const dirty = '<span>&amp;#x41;<img src="x" onerror="window.__pwned=1"></span>';
+    const clean = sanitizeDocxHtml(dirty);
+
+    const img = parse(clean).querySelector("img");
+    expect(img?.hasAttribute("onerror")).toBe(false);
+    expect(clean).not.toContain("onerror");
+  });
+
+  it("removes javascript: hrefs that flow from document relationship targets", () => {
+    const clean = sanitizeDocxHtml(
+      '<a href="javascript:window.__pwned=1">click</a>'
+    );
+
+    const anchor = parse(clean).querySelector("a");
+    // The anchor text survives, but the dangerous href is dropped.
+    expect(anchor?.getAttribute("href") ?? "").not.toMatch(/javascript:/i);
+    expect(clean.toLowerCase()).not.toContain("javascript:");
+  });
+
+  it("strips inline event-handler attributes from otherwise benign elements", () => {
+    const clean = sanitizeDocxHtml('<p onmouseover="window.__pwned=1">hi</p>');
+
+    const p = parse(clean).querySelector("p");
+    expect(p?.hasAttribute("onmouseover")).toBe(false);
+    expect(p?.textContent).toBe("hi");
+  });
+
+  it("removes <script> elements", () => {
+    const clean = sanitizeDocxHtml(
+      '<div>text<script>window.__pwned=1</script></div>'
+    );
+    expect(parse(clean).querySelector("script")).toBeNull();
+  });
+
+  it("preserves https hyperlinks and basic document formatting", () => {
+    const dirty =
+      '<a href="https://onyx.app">Onyx</a>' +
+      '<table><tr><td><b>bold</b> <i>italic</i></td></tr></table>' +
+      "<h1>Heading</h1>";
+    const doc = parse(sanitizeDocxHtml(dirty));
+
+    expect(doc.querySelector("a")?.getAttribute("href")).toBe(
+      "https://onyx.app"
+    );
+    expect(doc.querySelector("table")).not.toBeNull();
+    expect(doc.querySelector("td b")?.textContent).toBe("bold");
+    expect(doc.querySelector("td i")?.textContent).toBe("italic");
+    expect(doc.querySelector("h1")?.textContent).toBe("Heading");
+  });
+
+  it("keeps mailto links and base64 data-URL images (used by useBase64URL)", () => {
+    const dataUrl =
+      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
+    const doc = parse(
+      sanitizeDocxHtml(
+        `<a href="mailto:hi@onyx.app">mail</a><img src="${dataUrl}">`
+      )
+    );
+
+    expect(doc.querySelector("a")?.getAttribute("href")).toBe(
+      "mailto:hi@onyx.app"
+    );
+    expect(doc.querySelector("img")?.getAttribute("src")).toBe(dataUrl);
+  });
+});

--- a/web/src/sections/modals/PreviewModal/variants/sanitizeDocxHtml.ts
+++ b/web/src/sections/modals/PreviewModal/variants/sanitizeDocxHtml.ts
@@ -1,0 +1,11 @@
+import DOMPurify from "dompurify";
+
+// docx-preview renders document-controlled content into the DOM via a few
+// HTML/href sinks, so we re-sanitize its output. `data:` stays allowed because
+// images are base64 data URLs (useBase64URL); other non-http(s)/mailto schemes
+// (e.g. javascript:) are dropped.
+export function sanitizeDocxHtml(html: string): string {
+  return DOMPurify.sanitize(html, {
+    ALLOWED_URI_REGEXP: /^(?:https?|mailto|data):/i,
+  });
+}

--- a/web/src/sections/modals/PreviewModal/variants/sanitizeDocxHtml.ts
+++ b/web/src/sections/modals/PreviewModal/variants/sanitizeDocxHtml.ts
@@ -1,11 +1,12 @@
 import DOMPurify from "dompurify";
 
 // docx-preview renders document-controlled content into the DOM via a few
-// HTML/href sinks, so we re-sanitize its output. `data:` stays allowed because
-// images are base64 data URLs (useBase64URL); other non-http(s)/mailto schemes
-// (e.g. javascript:) are dropped.
+// HTML/href sinks, so we re-sanitize its output. Only http(s)/mailto schemes
+// are allowed; everything else (e.g. javascript:) is dropped. Base64 images
+// (useBase64URL) still render because DOMPurify's default DATA_URI_TAGS permits
+// `data:` in <img src> — but not in <a href>, which is what we want.
 export function sanitizeDocxHtml(html: string): string {
   return DOMPurify.sanitize(html, {
-    ALLOWED_URI_REGEXP: /^(?:https?|mailto|data):/i,
+    ALLOWED_URI_REGEXP: /^(?:https?|mailto):/i,
   });
 }


### PR DESCRIPTION
- [x] [Optional] Please cherry-pick this PR to the latest release version.

## Summary

The file-preview modal renders user-supplied DOCX files into the live page DOM via `docx-preview`. A DOCX indexed from a connector or shared in a project can originate from someone other than the viewer, so a crafted document is an XSS vector if the library faithfully reproduces active content. It does — `docx-preview@0.3.7` writes document-controlled strings into two HTML/href sinks that both land in the preview body:

- **`renderSymbol`** assigns a `<w:sym w:char>` value into `span.innerHTML` as `&#x${char};`. A crafted `char` injects an **auto-firing `<img onerror>`** (confirmed executing in a real-browser probe).
- **Hyperlink hrefs** come straight from the document's external relationship targets, so a **`javascript:` URL** is written through to `<a href>` unfiltered (confirmed click-triggered).

## Fix

- Add `dompurify` (pinned `3.4.8`, dedupes with the copy `posthog-js` already pulls in).
- After `renderAsync`, re-sanitize `bodyRef.innerHTML` with DOMPurify, allowing only `http(s)`/`mailto`/`data` URIs. `data:` must stay allowed because images are rendered as base64 data URLs (`useBase64URL: true`).
- Drop any non-`<style>` element from the style container.
- The `innerText` copy-to-clipboard read runs after sanitization, so copied text matches what's displayed.

Logic lives in a small pure helper (`sanitizeDocxHtml`) with unit tests.

## Verification

- `bunx oxlint` and `bun run types:check` exit 0.
- New Jest tests (6) — symbol `onerror` neutralized, `javascript:` href dropped, `on*`/`<script>` stripped, while `https`/`mailto`/`data:` images and `<table>`/`<b>`/`<i>`/`<h1>` formatting survive.
- **Real-document fidelity check**: rendered `three_images.docx` through the actual `docx-preview` then applied the real sanitizer — images 3→3 (all base64), copy-text length unchanged, `<style>` tags preserved, no `on*`/`javascript:` in output.
- Existing e2e `file_preview_modal.spec.ts` ("clicking a .docx file link … renders content") exercises this same render path as a regression guard.

## Known residual (intentionally not fixed here)

`docx-preview` emits styles as concatenated CSS text into a `<style>` element; document-controlled font-family/selectors are unescaped, which is a **CSS-injection** surface. This does **not** break out to HTML (the `<style>` content is RAWTEXT), so it's not script execution, but it enables CSS-based tricks. Fixing it properly needs a deliberate design (CSSOM round-trip or a real CSS sanitizer), not a regex — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes `docx-preview` output in the file preview modal to block XSS. Preserves images and formatting while removing dangerous HTML and URLs.

- **Bug Fixes**
  - Re-sanitize rendered HTML with `dompurify` via `sanitizeDocxHtml`; allow only `http(s)` and `mailto` URIs. `data:` is allowed only for images via DOMPurify defaults.
  - Strip `<script>`, inline event handlers, and `javascript:` hrefs; block `data:` in `<a href>`; remove non-`<style>` nodes from the style container.
  - Copy-to-clipboard now matches the sanitized view; added unit tests, including `data:` href stripping.

- **Dependencies**
  - Add `dompurify@3.4.8`.

<sup>Written for commit 6ba59f71355983961e430443c4ce9fd26d59298b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



