### PR TITLE
fix(sandbox): update initial dependencies

### DIFF
--- a/backend/onyx/server/features/build/sandbox/image/initial-requirements.txt
+++ b/backend/onyx/server/features/build/sandbox/image/initial-requirements.txt
@@ -1,7 +1,7 @@
 # Resolved from initial-requirements.in for Python 3.13 Linux with:
 # uv pip compile --upgrade --python-version 3.13 --python-platform linux --no-strip-extras --no-header --annotation-style=line initial-requirements.in -o initial-requirements.txt
 # Wheel-only install validated for x86_64-manylinux_2_28 and aarch64-manylinux_2_28 with:
-# uv pip install --dry-run --only-binary=:all: --python-version 3.13 --python-platform <platform> -r initial-requirements.txt
+# uv pip install --dry-run --refresh --only-binary=:all: --python-version 3.13 --python-platform <platform> -r initial-requirements.txt
 annotated-doc==0.0.4      # via fastapi
 annotated-types==0.7.0    # via pydantic
 anyio==4.13.0             # via google-genai, httpx, starlette, watchfiles
@@ -10,14 +10,14 @@ cffi==2.0.0               # via cryptography
 charset-normalizer==3.4.7  # via pdfminer-six, requests
 click==8.4.1              # via uvicorn
 contourpy==1.3.3          # via matplotlib
-cryptography==48.0.1      # via google-auth, pdfminer-six, --override (workspace), -r initial-requirements.in
+cryptography==49.0.0      # via google-auth, pdfminer-six, --override (workspace), -r initial-requirements.in
 cycler==0.12.1            # via matplotlib
 defusedxml==0.7.1         # via -r initial-requirements.in
 distro==1.9.0             # via google-genai
 et-xmlfile==2.0.0         # via openpyxl
 fastapi==0.136.3          # via -r initial-requirements.in
 fonttools==4.63.0         # via matplotlib
-google-auth[requests]==2.53.0  # via google-genai
+google-auth[requests]==2.54.0  # via google-genai
 google-genai==2.8.0       # via -r initial-requirements.in
 h11==0.16.0               # via httpcore, uvicorn, --override (workspace)
 httpcore==1.0.9           # via httpx
@@ -26,10 +26,10 @@ httpx==0.28.1             # via google-genai
 idna==3.18                # via anyio, httpx, requests
 kiwisolver==1.5.0         # via matplotlib
 lxml==6.1.1               # via python-pptx, -r initial-requirements.in
-matplotlib==3.10.9        # via -r initial-requirements.in
+matplotlib==3.11.0        # via -r initial-requirements.in
 matplotlib-inline==0.2.2  # via -r initial-requirements.in
 numpy==2.4.6              # via contourpy, matplotlib, pandas, -r initial-requirements.in
-onyx-cli==1.1.0           # via -r initial-requirements.in
+onyx-cli==1.1.1           # via -r initial-requirements.in
 openpyxl==3.1.5           # via -r initial-requirements.in
 packaging==26.2           # via matplotlib
 pandas==3.0.3             # via -r initial-requirements.in
@@ -50,7 +50,7 @@ pyyaml==6.0.3             # via uvicorn
 requests==2.34.2          # via google-auth, google-genai
 six==1.17.0               # via python-dateutil
 sniffio==1.3.1            # via google-genai
-starlette==1.3.0          # via fastapi
+starlette==1.3.1          # via fastapi
 tenacity==9.1.4           # via google-genai
 traitlets==5.15.1         # via matplotlib-inline
 typing-extensions==4.15.0  # via fastapi, google-genai, pydantic, pydantic-core, python-pptx, typing-inspection


### PR DESCRIPTION
## Description

Update the sandbox image's preinstalled Python dependency set while keeping the existing Debian/glibc base and release workflow unchanged.

This includes `onyx-cli==1.1.1`, which carries the CLI-side dependency fixes, and keeps the wheel-only validation note for both supported manylinux targets.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
