### PR TITLE
fix(seat-limit): cloud bulk invite self-deadlocks on double advisory lock acquisition

### DIFF
--- a/backend/ee/onyx/db/license.py
+++ b/backend/ee/onyx/db/license.py
@@ -46,10 +46,17 @@ def acquire_seat_lock(db_session: Session, tenant_id: str | None = None) -> None
     same transaction.
     """
     lock_id = seat_lock_id_for_tenant(tenant_id or get_current_tenant_id())
+    # Bounded wait: a double-acquisition bug or wedged holder should fail
+    # fast with lock_not_available, not hang until the idle-in-transaction
+    # reaper kills the session (observed as 10-minute invite freezes).
+    db_session.execute(text("SET LOCAL lock_timeout = '10s'"))
     db_session.execute(
         text("SELECT pg_advisory_xact_lock(:lock_id)"),
         {"lock_id": lock_id},
     )
+    # Restore the session default so the caller's later row-lock waits
+    # aren't capped by the advisory-acquisition bound.
+    db_session.execute(text("SET LOCAL lock_timeout = DEFAULT"))
 
 
 class SeatAvailabilityResult(NamedTuple):

--- a/backend/ee/onyx/server/tenants/billing.py
+++ b/backend/ee/onyx/server/tenants/billing.py
@@ -24,6 +24,11 @@ stripe.api_key = STRIPE_SECRET_KEY
 
 logger = setup_logger()
 
+# Control-plane calls run while the caller holds the tenant seat advisory
+# lock and/or an open transaction; an unbounded hang here parks the session
+# until the DB's idle-in-transaction reaper kills it (10min in prod).
+_CONTROL_PLANE_TIMEOUT_S = 30
+
 
 class SeatBillingDeclineReason(str, PyEnum):
     CARD_DECLINED = "card_declined"
@@ -46,7 +51,9 @@ def fetch_stripe_checkout_session(
         "billing_period": billing_period,
         "seats": seats,
     }
-    response = requests.post(url, headers=headers, json=payload)
+    response = requests.post(
+        url, headers=headers, json=payload, timeout=_CONTROL_PLANE_TIMEOUT_S
+    )
     if not response.ok:
         try:
             data = response.json()
@@ -81,7 +88,9 @@ def fetch_tenant_stripe_information(tenant_id: str) -> dict:
     }
     url = f"{CONTROL_PLANE_API_BASE_URL}/tenant-stripe-information"
     params = {"tenant_id": tenant_id}
-    response = requests.get(url, headers=headers, params=params)
+    response = requests.get(
+        url, headers=headers, params=params, timeout=_CONTROL_PLANE_TIMEOUT_S
+    )
     response.raise_for_status()
     return response.json()
 
@@ -96,7 +105,9 @@ def fetch_billing_information(
     }
     url = f"{CONTROL_PLANE_API_BASE_URL}/billing-information"
     params = {"tenant_id": tenant_id}
-    response = requests.get(url, headers=headers, params=params)
+    response = requests.get(
+        url, headers=headers, params=params, timeout=_CONTROL_PLANE_TIMEOUT_S
+    )
     response.raise_for_status()
 
     response_data = response.json()
@@ -128,7 +139,9 @@ def fetch_customer_portal_session(tenant_id: str, return_url: str | None = None)
     payload = {"tenant_id": tenant_id}
     if return_url:
         payload["return_url"] = return_url
-    response = requests.post(url, headers=headers, json=payload)
+    response = requests.post(
+        url, headers=headers, json=payload, timeout=_CONTROL_PLANE_TIMEOUT_S
+    )
     response.raise_for_status()
     return response.json()["url"]
 

--- a/backend/onyx/server/manage/users.py
+++ b/backend/onyx/server/manage/users.py
@@ -473,8 +473,11 @@ def bulk_invite_users(
     ]
 
     # Must run before the trial counter reservation — a seat-limit
-    # failure must not burn trial quota.
-    if emails_needing_seats:
+    # failure must not burn trial quota. Self-hosted only: the cloud
+    # check runs inside add_users_to_tenant, atomic with the mapping
+    # insert. Locking here too re-acquires the tenant advisory lock on
+    # a second connection and self-deadlocks (#10900).
+    if emails_needing_seats and not MULTI_TENANT:
         enforce_seat_limit_locked(db_session, seats_needed=len(emails_needing_seats))
 
     # Enforce the trial invite cap via the monotonic `tenant_invite_counter`.
@@ -509,7 +512,10 @@ def bulk_invite_users(
             fetch_ee_implementation_or_noop(
                 "onyx.server.tenants.provisioning", "add_users_to_tenant", None
             )(new_invited_emails, tenant_id)
-
+        except OnyxError:
+            # Seat-limit / billing declines from the cloud check must reach
+            # the caller now that this is the only enforcement point.
+            raise
         except Exception as e:
             logger.error("Failed to add users to tenant %s: %s", tenant_id, str(e))
 

--- a/backend/tests/unit/onyx/server/manage/test_bulk_invite_limit.py
+++ b/backend/tests/unit/onyx/server/manage/test_bulk_invite_limit.py
@@ -244,3 +244,68 @@ def test_trial_tenant_hits_remove_invited_rate_limit(
         db_session=MagicMock(),
     )
     mock_rate_limit.assert_called_once()
+
+
+# --- seat-lock placement tests (cloud self-deadlock regression) ---
+
+
+@patch("onyx.server.manage.users.ENABLE_EMAIL_INVITES", False)
+@patch("onyx.server.manage.users.DEV_MODE", True)
+@patch("onyx.server.manage.users.MULTI_TENANT", True)
+@patch("onyx.server.manage.users.is_tenant_on_trial_fn", return_value=False)
+@patch("onyx.server.manage.users.get_current_tenant_id", return_value="test_tenant")
+@patch("onyx.server.manage.users.get_invited_users", return_value=[])
+@patch("onyx.server.manage.users.get_all_users", return_value=[])
+@patch("onyx.server.manage.users.write_invited_users", return_value=1)
+@patch(
+    "onyx.server.manage.users.fetch_ee_implementation_or_noop",
+    return_value=lambda *_args: None,
+)
+@patch("onyx.server.manage.users.enforce_seat_limit_locked")
+def test_cloud_invite_skips_request_session_seat_lock(
+    mock_enforce: MagicMock, *_mocks: MagicMock
+) -> None:
+    """Cloud must not take the seat advisory lock on the request session —
+    enforcement lives in add_users_to_tenant. A second acquisition here
+    self-deadlocks the request (two connections, one tenant lock key)."""
+    bulk_invite_users(emails=["new@example.com"], current_user=MagicMock())
+
+    mock_enforce.assert_not_called()
+
+
+@patch("onyx.server.manage.users.ENABLE_EMAIL_INVITES", False)
+@patch("onyx.server.manage.users.MULTI_TENANT", False)
+@patch("onyx.server.manage.users.get_invited_users", return_value=[])
+@patch("onyx.server.manage.users.get_all_users", return_value=[])
+@patch("onyx.server.manage.users.write_invited_users", return_value=1)
+@patch("onyx.server.manage.users.enforce_seat_limit_locked")
+def test_self_hosted_invite_still_enforces_seat_limit(
+    mock_enforce: MagicMock, *_mocks: MagicMock
+) -> None:
+    """Self-hosted license seats are still enforced on the request session."""
+    bulk_invite_users(emails=["new@example.com"], current_user=MagicMock())
+
+    mock_enforce.assert_called_once()
+
+
+@patch("onyx.server.manage.users.MULTI_TENANT", True)
+@patch("onyx.server.manage.users.is_tenant_on_trial_fn", return_value=False)
+@patch("onyx.server.manage.users.get_current_tenant_id", return_value="test_tenant")
+@patch("onyx.server.manage.users.get_invited_users", return_value=[])
+@patch("onyx.server.manage.users.get_all_users", return_value=[])
+@patch("onyx.server.manage.users.enforce_seat_limit_locked")
+def test_cloud_seat_decline_propagates_from_add_users(*_mocks: MagicMock) -> None:
+    """A seat/billing decline raised inside add_users_to_tenant must reach
+    the caller as OnyxError — the generic except must not swallow it."""
+
+    def _declining_add_users(*_args: object) -> None:
+        raise OnyxError(OnyxErrorCode.SEAT_LIMIT_EXCEEDED, "card declined")
+
+    with patch(
+        "onyx.server.manage.users.fetch_ee_implementation_or_noop",
+        return_value=_declining_add_users,
+    ):
+        with pytest.raises(OnyxError) as exc_info:
+            bulk_invite_users(emails=["new@example.com"], current_user=MagicMock())
+
+    assert exc_info.value.error_code == OnyxErrorCode.SEAT_LIMIT_EXCEEDED


### PR DESCRIPTION
## Description

**Bug**: On cloud, inviting a user to a paid (non-trial) tenant hangs ~10 minutes, then the invite silently reverts. No email, no error, retries fail the same way. 15 tenants affected since 5/14.

**Cause**: `bulk_invite_users` takes the tenant seat advisory lock on the request session (`enforce_seat_limit_locked`), then `add_users_to_tenant` → `enforce_cloud_seat_limit` re-acquires the same lock key on its own session. The two connections deadlock until Postgres' 10-minute idle-in-transaction timeout kills the request session; the endpoint then fails on the dead connection and reverts the invite.

**Fix** (layered):
- Run the bulk-invite `enforce_seat_limit_locked` call only on self-hosted; cloud enforcement already happens inside `add_users_to_tenant`, atomic with the mapping insert
- Re-raise `OnyxError` from `add_users_to_tenant` so seat/billing declines reach the caller (the generic `except` swallowed them)
- Bound advisory-lock waits in `acquire_seat_lock` with a 10s `lock_timeout` so any future double acquisition fails fast instead of hanging
- Bound all control-plane HTTP in `tenants/billing.py` with a 30s timeout — these calls run under the seat lock / an open transaction, so an unbounded hang reproduces the same idle-in-transaction kill cascade

Design notes: no new duplication; cloud seat enforcement consolidated to one site; the lock bound lives once in `acquire_seat_lock`.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check