### PR TITLE
fix(dev): set ENCRYPTION_KEY_SECRET in .env.k8s.template to match localdev cluster

### DIFF
--- a/.vscode/.env.k8s.template
+++ b/.vscode/.env.k8s.template
@@ -71,6 +71,12 @@ POSTGRES_HOST=onyx-pg-rw
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 
+# Decrypts secrets the cluster wrote to Postgres (LLM keys, connector + craft
+# credentials). MUST match the cluster's key in
+# deployment/helm/charts/onyx/values-localdev.yaml — a mismatch surfaces as
+# "Data is not valid UTF-8 — likely encrypted with a different key" on reads.
+ENCRYPTION_KEY_SECRET=6767676767676767
+
 REDIS_HOST=onyx
 REDIS_PASSWORD=password
 


### PR DESCRIPTION
## Description

Set `ENCRYPTION_KEY_SECRET=6767676767676767` in `.vscode/.env.k8s.template` so the telepresence-intercepting local backend uses the same encryption key as the localdev cluster (`deployment/helm/charts/onyx/values-localdev.yaml`).

## Why

Encrypted secrets (LLM keys, connector + craft credentials) are written to the shared cluster Postgres under the cluster's key. A local backend that reads them without that key set has `ENCRYPTION_KEY_SECRET` default to empty, so decryption falls back to a raw UTF-8 decode of AES bytes and raises `UnicodeDecodeError` — the recurring "undecryptable external app credential" error in craft dev. It's a key mismatch, not a code bug.

Production is unaffected: every pod shares one stable key, so there's no user-facing path to an undecryptable blob — only operational events (key rotation without re-encrypt, cross-env DB restore, lost secret). Those already fail loudly with an actionable error (`_decrypt_bytes` → "…likely encrypted with a different key. Run the re-encrypt secrets script") and are recovered with `scripts/reencrypt_secrets.py`.

## How Has This Been Tested?

Config-only change to a dev env template (the gitignored `.env.k8s` is what's actually consumed). The value matches `values-localdev.yaml`; no application code changed.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
