### PR TITLE
fix(craft): mark failing bash commands as failed and persist them

### DIFF
--- a/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
+++ b/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
@@ -190,7 +190,7 @@ def _tool_title(tool: str) -> str:
 
 # opencode's tool status values → ToolCallStatus literal.
 # Onyx schema: "pending" | "in_progress" | "completed" | "failed"
-# opencode emits: "pending", "running", "completed". "running" → "in_progress".
+# opencode emits: "pending", "running", "completed", "error". "running" → "in_progress".
 _TOOL_STATUS_MAP: dict[str, str] = {
     "pending": "pending",
     "running": "in_progress",
@@ -265,10 +265,17 @@ def _wrap_raw_output(state: dict[str, Any]) -> dict[str, Any] | None:
 
     Tools where ``state.output`` is already a dict (none observed in Phase 0
     but possible) get passed through unchanged.
+
+    Error-state tool parts carry their message in ``state.error`` instead of
+    ``state.output``.
     """
     out = state.get("output")
     if out is None:
-        return None
+        err = state.get("error")
+        if isinstance(err, str) and err:
+            out = err
+        else:
+            return None
     if isinstance(out, str):
         wrapped: dict[str, Any] = {"output": out}
         metadata = state.get("metadata")
@@ -757,6 +764,11 @@ def _emit_tool_events(
 
     raw_status = part_state.get("status", "pending")
     status = _tool_status(raw_status)
+    if status == "completed":
+        metadata = part_state.get("metadata")
+        exit_code = metadata.get("exit") if isinstance(metadata, dict) else None
+        if isinstance(exit_code, int) and exit_code != 0:
+            status = "failed"
     raw_input = part_state.get("input") or None
     raw_output = _wrap_raw_output(part_state)
     content = _synthesize_tool_content(tool, part_state)

--- a/backend/onyx/server/features/build/session/streaming.py
+++ b/backend/onyx/server/features/build/session/streaming.py
@@ -570,7 +570,8 @@ def persist_sandbox_event(
         return
 
     if isinstance(sandbox_event, ToolCallStart):
-        # Stream-only; persistence happens on `completed` progress.
+        # Stream-only; persistence happens on terminal (`completed`/`failed`)
+        # progress.
         return
 
     if isinstance(sandbox_event, ToolCallProgress):

--- a/backend/onyx/server/features/build/session/streaming.py
+++ b/backend/onyx/server/features/build/session/streaming.py
@@ -590,7 +590,7 @@ def persist_sandbox_event(
             or raw_input.get("subagentType") is not None
         )
 
-        if is_todo_write or sandbox_event.status == "completed":
+        if is_todo_write or sandbox_event.status in ("completed", "failed"):
             create_message(
                 session_id=session_id,
                 message_type=MessageType.ASSISTANT,

--- a/backend/tests/external_dependency_unit/craft/test_streaming_persistence.py
+++ b/backend/tests/external_dependency_unit/craft/test_streaming_persistence.py
@@ -390,6 +390,46 @@ class TestStreamingPersistence:
         assert len(tool_rows) == 1
         assert tool_rows[0].message_metadata["toolCallId"] == "tc-1"
 
+    def test_failed_tool_call_persisted(
+        self,
+        db_session: Session,
+        test_user: User,
+        build_session: BuildSession,
+        sandbox: Callable[..., Sandbox],
+        session_manager_with_stub: SessionManager,
+        stub_sandbox_manager: StubSandboxManager,
+        tenant_context: None,  # noqa: ARG002
+    ) -> None:
+        """``ToolCallProgress`` with status='failed' → one row, so failed
+        tool calls survive session reload."""
+        sandbox(user=test_user)
+        stub_sandbox_manager.send_message_events = [
+            _tool_call_progress(
+                "tc-1",
+                "Bash",
+                status="failed",
+                raw_output={"output": "ls: cannot access '/x': No such file"},
+            ),
+            _prompt_response(),
+        ]
+        _drive_persisted_turn(
+            db_session=db_session,
+            mgr=session_manager_with_stub,
+            build_session=build_session,
+            user=test_user,
+            content="run it",
+        )
+
+        messages = get_session_messages(build_session.id, db_session)
+        tool_rows = [
+            m
+            for m in messages
+            if (m.message_metadata or {}).get("type") == "tool_call_progress"
+            and (m.message_metadata or {}).get("status") == "failed"
+        ]
+        assert len(tool_rows) == 1
+        assert tool_rows[0].message_metadata["toolCallId"] == "tc-1"
+
     def test_in_progress_tool_call_not_persisted_except_todowrite(
         self,
         db_session: Session,

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_translate_opencode_event.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_translate_opencode_event.py
@@ -1644,3 +1644,95 @@ def test_parent_non_task_tool_event_not_tagged() -> None:
         assert meta is not None
         assert "subagentSessionId" not in meta
         assert meta["toolName"] == "bash"
+
+
+# ───────────────────────── exit-code / error-state mapping ────────
+
+
+def test_bash_completed_with_nonzero_exit_maps_to_failed() -> None:
+    s = _state()
+    _drain(translate_opencode_event(_tool_event("c1", "bash", "pending"), s))
+    out = _drain(
+        translate_opencode_event(
+            _tool_event(
+                "c1",
+                "bash",
+                "completed",
+                input={"command": "sudo do-thing"},
+                output="permission denied",
+                metadata={"exit": 1},
+            ),
+            s,
+        )
+    )
+    assert len(out) == 1
+    assert isinstance(out[0], ToolCallProgress)
+    assert out[0].status == "failed"
+    assert out[0].raw_output is not None
+    assert out[0].raw_output.get("output") == "permission denied"  # type: ignore[union-attr]
+    assert out[0].raw_output.get("metadata") == {"exit": 1}  # type: ignore[union-attr]
+
+
+def test_bash_first_sighting_completed_with_nonzero_exit_dual_emits_failed() -> None:
+    """First sighting that already carries completed-with-nonzero-exit state
+    emits ToolCallStart plus a ToolCallProgress with the overridden status."""
+    s = _state()
+    out = _drain(
+        translate_opencode_event(
+            _tool_event(
+                "c1",
+                "bash",
+                "completed",
+                input={"command": "false"},
+                output="",
+                metadata={"exit": 1},
+            ),
+            s,
+        )
+    )
+    assert len(out) == 2
+    assert isinstance(out[0], ToolCallStart)
+    assert isinstance(out[1], ToolCallProgress)
+    assert out[1].status == "failed"
+
+
+def test_bash_completed_with_zero_exit_stays_completed() -> None:
+    s = _state()
+    _drain(translate_opencode_event(_tool_event("c1", "bash", "pending"), s))
+    out = _drain(
+        translate_opencode_event(
+            _tool_event(
+                "c1",
+                "bash",
+                "completed",
+                input={"command": "ls"},
+                output="file1\nfile2\n",
+                metadata={"exit": 0},
+            ),
+            s,
+        )
+    )
+    assert len(out) == 1
+    assert isinstance(out[0], ToolCallProgress)
+    assert out[0].status == "completed"
+
+
+def test_tool_error_state_maps_to_failed_with_error_output() -> None:
+    s = _state()
+    _drain(translate_opencode_event(_tool_event("c1", "bash", "pending"), s))
+    out = _drain(
+        translate_opencode_event(
+            _tool_event(
+                "c1",
+                "bash",
+                "error",
+                error="sudo: a password is required",
+            ),
+            s,
+        )
+    )
+    assert len(out) == 1
+    assert isinstance(out[0], ToolCallProgress)
+    assert out[0].status == "failed"
+    assert out[0].raw_output is not None
+    assert out[0].raw_output.get("output") == "sudo: a password is required"  # type: ignore[union-attr]


### PR DESCRIPTION
## Description

Three related fixes for failed tool calls in Craft showing a success check with no error output:

1. **Non-zero exit → failed status.** opencode's bash tool reports `status=completed` even when the command exits non-zero — the exit code only lands in `state.metadata.exit` (verified against opencode 1.15.7's `tool/shell.ts` and against live event payloads). The translator now overrides `completed` → `failed` when `metadata.exit` is a non-zero int. The frontend already fully supports `failed` (red alert icon, error styling, auto-expand), so no frontend changes are needed.
2. **Error text surfaced.** opencode error-state tool parts (`state.status=error`) carry their message in `state.error` with no `output` field; `_wrap_raw_output` now falls back to it so failed cards show the actual error instead of an empty body.
3. **Failed calls persisted.** `persist_sandbox_event` only persisted `ToolCallProgress` with `status=completed`, so failed tool calls vanished on session reload. It now persists `failed` too.

## How Has This Been Tested?

- 4 new unit tests in `test_translate_opencode_event.py` (86 pass): non-zero exit → failed (incl. the first-sighting dual-emit path), zero exit stays completed, error state → failed with the error string as rawOutput.
- New `test_failed_tool_call_persisted` in `test_streaming_persistence.py`, mirroring the existing completed-persistence test (external-dependency suite; runs in CI).
- Live end-to-end on a dev stack: a Craft turn running `ls /nonexistent-dir-12345` renders a red failed card, auto-expanded with the stderr, survives page reload, and persists as `status=failed` / `exit=2` in `build_message`.
- 4-lens agent review (correctness, security, tests, regressions); pre-commit (ty, ruff) green.

### Known minor items (deliberately not fixed here)
- `isinstance(exit_code, int)` accepts bools (`exit: true` would read as failure). No opencode tool emits boolean exits; left as-is.
- Failed **task** tools don't get their output extracted into the synthetic `agent_message` / frontend `taskOutput` (both live and on reload are consistent). Pre-existing behavior for error-state tasks; follow-up if it matters.
- `state.error` strings are persisted without a size cap — same pre-existing exposure as `state.output` for completed calls.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Craft bash tool handling so failed commands show as failed, display their error text, and persist across reloads. Corrects status mapping from `opencode` events and surfaces error messages.

- **Bug Fixes**
  - Treat `completed` with non-zero `metadata.exit` as `failed`.
  - When `state.output` is missing, fall back to `state.error` for `rawOutput`.
  - Persist `ToolCallProgress` with `status=failed` (not just `completed`).

- **Refactors**
  - Clarified `ToolCallStart` comment about persistence on terminal (`completed`/`failed`) progress.

<sup>Written for commit 4e6f3222a7a11507125f7e73a9b1fda1a893938e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12050?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

