### PR TITLE
fix(ci): unblock craft compose integration after USER_AUTH_SECRET hardening

### DIFF
--- a/.github/workflows/pr-craft-compose-integration.yml
+++ b/.github/workflows/pr-craft-compose-integration.yml
@@ -157,6 +157,14 @@ jobs:
           docker network create onyx_craft_sandbox
           docker volume create sandbox_proxy_ca
 
+      # install.sh normally generates .env (including USER_AUTH_SECRET) from
+      # env.template; CI skips install.sh, and since #12038 the api server
+      # fail-closes on an empty USER_AUTH_SECRET. Services read .env via
+      # env_file, so a CI-only value here unblocks the stack.
+      - name: Provide USER_AUTH_SECRET (.env)
+        working-directory: deployment/docker_compose
+        run: echo 'USER_AUTH_SECRET=craft-compose-ci-only-dummy-secret' > .env
+
       # TODO(ods): Replace with `ods compose --craft` once that flag is
       # added to tools/ods/cmd/compose.go. Today `ods compose` doesn't support
       # the craft overlay, so we drop to raw docker compose.


### PR DESCRIPTION
## Description

Since #12038, the api server fail-closes at startup when `USER_AUTH_SECRET` is empty. The `craft-compose-integration` workflow boots the compose stack directly (CI doesn't run `install.sh`, which is what normally generates `.env` with a secret), so `onyx-api_server-1` crashloops on the new guard and the **required check fails for every PR touching craft paths** — including merge-queue runs (e.g. pr-12026 at 23:13 UTC) and the `v4.1.0-cloud.1` tag build.

Fix: write a CI-only `.env` with a dummy `USER_AUTH_SECRET` before `docker compose up` — the services already read `.env` via `env_file` (`required: false`), so this mirrors what `install.sh` produces for real deployments. Static literal only; no workflow-input interpolation.

`pr-craft-compose-tests` (config-validation only, never boots the stack) is unaffected.

## How Has This Been Tested?

Failure chain verified from CI logs of three consecutive failures on #12050 (`container onyx-api_server-1 is unhealthy` → api_server tail shows `ValueError: USER_AUTH_SECRET is empty` from `verify_user_auth_secret`). The same workflow on this PR exercises the fix directly.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks the craft compose integration CI by writing a CI-only `.env` with a dummy `USER_AUTH_SECRET`, allowing the API server to start after the hardening in #12038. This restores the required check and merge-queue runs.

- **Bug Fixes**
  - Add a step in `pr-craft-compose-integration.yml` to write `.env` in `deployment/docker_compose` before bring-up.
  - Use a static placeholder: `USER_AUTH_SECRET=craft-compose-ci-only-dummy-secret` (CI only; no interpolation).
  - `pr-craft-compose-tests` is unchanged.

<sup>Written for commit f17a944f0a0455a6be6ba55269c8ee09777ac246. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12051?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

