### PR TITLE
fix(mcp): proactively refresh OAuth tokens so connections don't lapse

### DIFF
--- a/backend/onyx/auth/oauth_token_manager.py
+++ b/backend/onyx/auth/oauth_token_manager.py
@@ -11,10 +11,14 @@ from onyx.db.models import OAuthConfig
 from onyx.db.models import OAuthUserToken
 from onyx.db.oauth_config import get_user_oauth_token
 from onyx.db.oauth_config import upsert_user_oauth_token
+from onyx.external_apps.providers.base import token_response_error
+from onyx.external_apps.providers.base import TokenRefreshTerminalError
+from onyx.external_apps.providers.base import TokenRefreshTransientError
 from onyx.server.security.models import outbound_ssrf_params
 from onyx.server.security.store import get_security_settings
 from onyx.utils.logger import setup_logger
 from onyx.utils.sensitive import SensitiveValue
+from onyx.utils.url import SSRFException
 from onyx.utils.url import validate_outbound_http_url
 
 
@@ -121,6 +125,57 @@ def exchange_oauth_code_for_token(
     return token_data
 
 
+# RFC 6749 §5.2: a dead grant means reconnect is required; any other failure is
+# retryable. Reuses the external_apps refresh classification so all OAuth refreshers
+# (tool, external-app, MCP) agree on terminal-vs-transient.
+_TERMINAL_REFRESH_ERRORS = frozenset({"invalid_grant"})
+
+
+def exchange_refresh_token(
+    params: OAuthFlowParams,
+    refresh_token: str,
+) -> dict[str, Any]:
+    """Exchange a refresh token for a fresh access token, computing `expires_at` and
+    carrying the incoming `refresh_token` forward when the provider doesn't rotate it.
+
+    Raises `TokenRefreshTerminalError` on a dead grant (reconnect required) and
+    `TokenRefreshTransientError` on a retryable failure (network / 5xx / non-JSON)."""
+    data: dict[str, str] = {
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token,
+        "client_id": params.client_id,
+    }
+    if params.client_secret:
+        data["client_secret"] = params.client_secret
+
+    try:
+        validate_oauth_endpoint_url(params.token_url)
+        response = requests.post(
+            params.token_url, data=data, headers={"Accept": "application/json"}
+        )
+    except (requests.RequestException, SSRFException, ValueError) as exc:
+        raise TokenRefreshTransientError(f"refresh request failed: {exc}") from exc
+
+    try:
+        token_data = response.json()
+    except ValueError as exc:
+        raise TokenRefreshTransientError(
+            f"non-JSON token response (status={response.status_code})"
+        ) from exc
+
+    error = token_response_error(response, token_data)
+    if error is not None:
+        if error in _TERMINAL_REFRESH_ERRORS:
+            raise TokenRefreshTerminalError(error)
+        raise TokenRefreshTransientError(error)
+
+    if "expires_in" in token_data:
+        token_data["expires_at"] = int(time.time()) + token_data["expires_in"]
+    if "refresh_token" not in token_data:
+        token_data["refresh_token"] = refresh_token
+    return token_data
+
+
 class OAuthTokenManager:
     """Manages OAuth token retrieval, refresh, and validation"""
 
@@ -172,33 +227,9 @@ class OAuthTokenManager:
 
         token_data = self._unwrap_token_data(user_token.token_data)
 
-        data: dict[str, str] = {
-            "grant_type": "refresh_token",
-            "refresh_token": token_data["refresh_token"],
-            "client_id": self._unwrap_sensitive_str(self.oauth_config.client_id),
-            "client_secret": self._unwrap_sensitive_str(
-                self.oauth_config.client_secret
-            ),
-        }
-        validate_oauth_endpoint_url(self.oauth_config.token_url)
-        response = requests.post(
-            self.oauth_config.token_url,
-            data=data,
-            headers={"Accept": "application/json"},
+        new_token_data = exchange_refresh_token(
+            self._flow_params(self.oauth_config), token_data["refresh_token"]
         )
-        response.raise_for_status()
-
-        new_token_data = response.json()
-
-        # Calculate expires_at if expires_in is present
-        if "expires_in" in new_token_data:
-            new_token_data["expires_at"] = (
-                int(time.time()) + new_token_data["expires_in"]
-            )
-
-        # Preserve refresh_token if not returned (some providers don't return it)
-        if "refresh_token" not in new_token_data and "refresh_token" in token_data:
-            new_token_data["refresh_token"] = token_data["refresh_token"]
 
         # Update token in DB
         upsert_user_oauth_token(

--- a/backend/onyx/auth/oauth_token_manager.py
+++ b/backend/onyx/auth/oauth_token_manager.py
@@ -125,9 +125,7 @@ def exchange_oauth_code_for_token(
     return token_data
 
 
-# RFC 6749 §5.2: a dead grant means reconnect is required; any other failure is
-# retryable. Reuses the external_apps refresh classification so all OAuth refreshers
-# (tool, external-app, MCP) agree on terminal-vs-transient.
+# RFC 6749 §5.2: a dead grant requires reconnect; any other failure is retryable.
 _TERMINAL_REFRESH_ERRORS = frozenset({"invalid_grant"})
 
 

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -389,8 +389,7 @@ class OnyxTokenStorage(TokenStorage):
             config_data["headers"] = {
                 "Authorization": f"{tokens.token_type} {tokens.access_token}"
             }
-            # OAuthToken drops expires_at, so persist absolute expiry separately —
-            # proactive refresh has no other way to tell when this token lapses.
+            # Persist absolute expiry; see MCPOAuthKeys.EXPIRES_AT.
             if tokens.expires_in is not None:
                 config_data[MCPOAuthKeys.EXPIRES_AT.value] = (
                     datetime.datetime.now(datetime.timezone.utc)
@@ -1040,8 +1039,7 @@ async def process_oauth_callback(
         user_config_data["headers"] = {
             "Authorization": f"{oauth_token.token_type} {oauth_token.access_token}"
         }
-        # Persist the refresh inputs (absolute expiry + token endpoint) so proactive
-        # refresh can keep this connection alive without a manual reconnect.
+        # Persist absolute expiry + resolved endpoint for proactive refresh.
         token_expires_at = token_payload.get("expires_at")
         if token_expires_at is not None:
             user_config_data[MCPOAuthKeys.EXPIRES_AT.value] = (

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -389,6 +389,13 @@ class OnyxTokenStorage(TokenStorage):
             config_data["headers"] = {
                 "Authorization": f"{tokens.token_type} {tokens.access_token}"
             }
+            # OAuthToken drops expires_at, so persist absolute expiry separately —
+            # proactive refresh has no other way to tell when this token lapses.
+            if tokens.expires_in is not None:
+                config_data[MCPOAuthKeys.EXPIRES_AT.value] = (
+                    datetime.datetime.now(datetime.timezone.utc)
+                    + datetime.timedelta(seconds=tokens.expires_in)
+                ).isoformat()
             update_connection_config(config.id, db_session, config_data)
 
         # The shared admin row is intentionally NOT written here: it
@@ -1033,6 +1040,19 @@ async def process_oauth_callback(
         user_config_data["headers"] = {
             "Authorization": f"{oauth_token.token_type} {oauth_token.access_token}"
         }
+        # Persist the refresh inputs (absolute expiry + token endpoint) so proactive
+        # refresh can keep this connection alive without a manual reconnect.
+        token_expires_at = token_payload.get("expires_at")
+        if token_expires_at is not None:
+            user_config_data[MCPOAuthKeys.EXPIRES_AT.value] = (
+                datetime.datetime.fromtimestamp(
+                    int(token_expires_at), tz=datetime.timezone.utc
+                ).isoformat()
+            )
+        if mcp_server.oauth_token_endpoint:
+            user_config_data[MCPOAuthKeys.TOKEN_ENDPOINT.value] = (
+                mcp_server.oauth_token_endpoint
+            )
         update_connection_config(user_config.id, db_session, user_config_data)
         redis_client.delete(key_state(user_id))
 
@@ -1143,9 +1163,13 @@ def save_user_credentials(
                 header_substitutions=request.credentials,
             )
             for oauth_field_key in MCPOAuthKeys:
-                field_key: Literal["client_info", "tokens", "metadata"] = (
-                    oauth_field_key.value
-                )
+                field_key: Literal[
+                    "client_info",
+                    "tokens",
+                    "metadata",
+                    "token_expires_at",
+                    "token_endpoint",
+                ] = oauth_field_key.value
                 if field_val := auth_template_dict.get(field_key):
                     config_data[field_key] = field_val
 

--- a/backend/onyx/server/features/mcp/models.py
+++ b/backend/onyx/server/features/mcp/models.py
@@ -59,6 +59,13 @@ class MCPOAuthKeys(str, Enum):
     CLIENT_INFO = "client_info"
     TOKENS = "tokens"
     METADATA = "metadata"
+    # Absolute token expiry (ISO 8601). Stored separately because the SDK's
+    # OAuthToken model has no expires_at field and silently drops it on validation,
+    # leaving only the relative expires_in with no record of when the grant happened.
+    EXPIRES_AT = "token_expires_at"
+    # Resolved OAuth token endpoint, persisted so proactive refresh doesn't need to
+    # re-run discovery on every call (auto-discovery mode leaves the server row null).
+    TOKEN_ENDPOINT = "token_endpoint"
 
 
 class MCPConnectionData(TypedDict):
@@ -80,6 +87,10 @@ class MCPConnectionData(TypedDict):
     client_info: NotRequired[dict[str, Any]]  # OAuthClientInformationFull
     tokens: NotRequired[dict[str, Any]]  # OAuthToken
     metadata: NotRequired[dict[str, Any]]  # OAuthClientMetadata
+    # Absolute expiry (ISO 8601) of the access token in `tokens`, and the resolved
+    # token endpoint used to refresh it. See MCPOAuthKeys for why these are separate.
+    token_expires_at: NotRequired[str]
+    token_endpoint: NotRequired[str]
 
     # the actual models are defined in mcp.shared.auth
     # from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata, OAuthToken

--- a/backend/onyx/server/features/mcp/models.py
+++ b/backend/onyx/server/features/mcp/models.py
@@ -59,12 +59,10 @@ class MCPOAuthKeys(str, Enum):
     CLIENT_INFO = "client_info"
     TOKENS = "tokens"
     METADATA = "metadata"
-    # Absolute token expiry (ISO 8601). Stored separately because the SDK's
-    # OAuthToken model has no expires_at field and silently drops it on validation,
-    # leaving only the relative expires_in with no record of when the grant happened.
+    # Absolute access-token expiry (ISO 8601); persisted separately because the
+    # SDK's OAuthToken keeps only relative expires_in.
     EXPIRES_AT = "token_expires_at"
-    # Resolved OAuth token endpoint, persisted so proactive refresh doesn't need to
-    # re-run discovery on every call (auto-discovery mode leaves the server row null).
+    # Resolved token endpoint, persisted so refresh skips re-discovery each call.
     TOKEN_ENDPOINT = "token_endpoint"
 
 
@@ -87,8 +85,6 @@ class MCPConnectionData(TypedDict):
     client_info: NotRequired[dict[str, Any]]  # OAuthClientInformationFull
     tokens: NotRequired[dict[str, Any]]  # OAuthToken
     metadata: NotRequired[dict[str, Any]]  # OAuthClientMetadata
-    # Absolute expiry (ISO 8601) of the access token in `tokens`, and the resolved
-    # token endpoint used to refresh it. See MCPOAuthKeys for why these are separate.
     token_expires_at: NotRequired[str]
     token_endpoint: NotRequired[str]
 

--- a/backend/onyx/server/features/mcp/oauth_refresh.py
+++ b/backend/onyx/server/features/mcp/oauth_refresh.py
@@ -1,0 +1,291 @@
+"""Proactive, single-flighted OAuth refresh for MCP servers.
+
+The MCP SDK's OAuthClientProvider is rebuilt per tool call and never restores token
+expiry, so it never refreshes proactively and an expired token escalates to a full
+re-auth ("Please Reconnect to the server"). Onyx drives refresh itself instead,
+mirroring `external_apps.token_refresh`: check the persisted expiry before a call and
+exchange the stored refresh token when stale. Never raises for a refresh outcome.
+"""
+
+from datetime import datetime
+from datetime import timezone
+from typing import Any
+from urllib.parse import urljoin
+from urllib.parse import urlparse
+
+import requests
+from mcp.shared.auth import OAuthToken
+from redis.exceptions import RedisError
+from sqlalchemy.exc import SQLAlchemyError
+
+from onyx.auth.oauth_token_manager import exchange_refresh_token
+from onyx.auth.oauth_token_manager import OAuthFlowParams
+from onyx.auth.oauth_token_manager import validate_oauth_endpoint_url
+from onyx.db.engine.sql_engine import get_session_with_tenant
+from onyx.db.enums import MCPAuthenticationType
+from onyx.db.enums import MCPServerStatus
+from onyx.db.mcp import extract_connection_data
+from onyx.db.mcp import get_connection_config_by_id
+from onyx.db.mcp import update_connection_config
+from onyx.db.mcp import update_mcp_server__no_commit
+from onyx.db.models import MCPServer
+from onyx.external_apps.providers.base import TokenRefreshTerminalError
+from onyx.external_apps.providers.base import TokenRefreshTransientError
+from onyx.external_apps.token_utils import needs_refresh
+from onyx.redis.lock_context import redis_shared_lock
+from onyx.redis.lock_context import RedisSharedLockAcquisitionError
+from onyx.server.features.mcp.models import MCPConnectionData
+from onyx.server.features.mcp.models import MCPOAuthKeys
+from onyx.utils.logger import setup_logger
+from onyx.utils.url import SSRFException
+
+logger = setup_logger()
+
+# Held long enough for the refresh POST + DB write; short wait so a contended caller
+# doesn't pin a worker thread (a timed-out waiter proceeds with the current token).
+_LOCK_HELD_S = 30.0
+_LOCK_WAIT_S = 5.0
+
+_DISCOVERY_PATHS = (
+    "/.well-known/oauth-authorization-server",
+    "/.well-known/openid-configuration",
+)
+_DISCOVERY_TIMEOUT_S = 10
+
+
+def ensure_fresh_mcp_token(
+    tenant_id: str,
+    mcp_server: MCPServer,
+    connection_config_id: int,
+) -> dict[str, str] | None:
+    """Refresh the OAuth access token on `connection_config_id` if it's expired or
+    expiring, returning the fresh ``headers`` dict (with the new ``Authorization``)
+    for the caller to apply. Returns None when no refresh was needed or possible —
+    the caller then proceeds with the currently-stored credentials.
+    """
+    if mcp_server.auth_type != MCPAuthenticationType.OAUTH:
+        return None
+
+    # Cheap pre-check before taking the lock; resolution only happens when stale.
+    try:
+        with get_session_with_tenant(tenant_id=tenant_id) as db:
+            config = get_connection_config_by_id(connection_config_id, db)
+            config_data = extract_connection_data(config, apply_mask=False)
+    except SQLAlchemyError as exc:
+        logger.warning(
+            "mcp_token_refresh.read_failed config_id=%s error=%s",
+            connection_config_id,
+            exc,
+        )
+        return None
+
+    if not _needs_refresh(config_data, datetime.now(timezone.utc)):
+        return None
+
+    lock_name = f"mcp_token_refresh:{tenant_id}:{connection_config_id}"
+    try:
+        with redis_shared_lock(
+            lock_name,
+            max_time_lock_held_s=_LOCK_HELD_S,
+            wait_for_lock_s=_LOCK_WAIT_S,
+            logger=logger,
+        ):
+            return _refresh_under_lock(tenant_id, mcp_server, connection_config_id)
+    except RedisSharedLockAcquisitionError:
+        # Another worker is refreshing; proceed with the current token.
+        logger.info(
+            "mcp_token_refresh.lock_contended config_id=%s", connection_config_id
+        )
+        return None
+    except (RedisError, SQLAlchemyError) as exc:
+        # Transient infra failure — keep existing tokens and let the request through.
+        logger.warning(
+            "mcp_token_refresh.infra_unavailable config_id=%s error=%s",
+            connection_config_id,
+            exc,
+        )
+        return None
+
+
+def _refresh_under_lock(
+    tenant_id: str,
+    mcp_server: MCPServer,
+    connection_config_id: int,
+) -> dict[str, str] | None:
+    # Re-read after the lock wait: a concurrent winner may have already refreshed.
+    with get_session_with_tenant(tenant_id=tenant_id) as db:
+        config = get_connection_config_by_id(connection_config_id, db)
+        config_data = extract_connection_data(config, apply_mask=False)
+
+    if not _needs_refresh(config_data, datetime.now(timezone.utc)):
+        # Already refreshed by the lock winner — hand back the fresh headers.
+        return config_data.get("headers")
+
+    tokens = config_data.get(MCPOAuthKeys.TOKENS.value) or {}
+    refresh_token = tokens.get("refresh_token")
+    client = _client_credentials(config_data)
+    if not refresh_token or client is None:
+        return None
+    client_id, client_secret = client
+
+    token_endpoint = _resolve_token_endpoint(mcp_server, config_data)
+    if token_endpoint is None:
+        logger.warning(
+            "mcp_token_refresh.no_token_endpoint server_id=%s config_id=%s",
+            mcp_server.id,
+            connection_config_id,
+        )
+        return None
+
+    params = OAuthFlowParams(
+        # authorization_url is unused by refresh; token_url drives the grant.
+        authorization_url=token_endpoint,
+        token_url=token_endpoint,
+        client_id=client_id,
+        client_secret=client_secret,
+    )
+
+    try:
+        new_token_data = exchange_refresh_token(params, refresh_token)
+    except TokenRefreshTerminalError:
+        # Dead grant — an admin-owned server needs a manual reconnect.
+        logger.warning(
+            "mcp_token_refresh.terminal server_id=%s config_id=%s",
+            mcp_server.id,
+            connection_config_id,
+        )
+        _mark_awaiting_auth_if_admin(tenant_id, mcp_server, connection_config_id)
+        return None
+    except TokenRefreshTransientError as exc:
+        logger.warning(
+            "mcp_token_refresh.transient server_id=%s error=%s", mcp_server.id, exc
+        )
+        return None
+
+    new_token_data.setdefault("token_type", "Bearer")
+    if not new_token_data.get("access_token"):
+        logger.warning("mcp_token_refresh.no_access_token server_id=%s", mcp_server.id)
+        return None
+
+    return _persist_refreshed(
+        tenant_id, connection_config_id, new_token_data, token_endpoint
+    )
+
+
+def _persist_refreshed(
+    tenant_id: str,
+    connection_config_id: int,
+    new_token_data: dict[str, Any],
+    token_endpoint: str,
+) -> dict[str, str] | None:
+    oauth_token = OAuthToken.model_validate(new_token_data)
+    headers = {"Authorization": f"{oauth_token.token_type} {oauth_token.access_token}"}
+    with get_session_with_tenant(tenant_id=tenant_id) as db:
+        config = get_connection_config_by_id(connection_config_id, db)
+        config_data = extract_connection_data(config, apply_mask=False)
+        config_data[MCPOAuthKeys.TOKENS.value] = oauth_token.model_dump(mode="json")
+        config_data["headers"] = headers
+        expires_at = new_token_data.get("expires_at")
+        if expires_at is not None:
+            config_data[MCPOAuthKeys.EXPIRES_AT.value] = datetime.fromtimestamp(
+                int(expires_at), tz=timezone.utc
+            ).isoformat()
+        # Persist the resolved endpoint so auto-discovery configs skip discovery next time.
+        config_data[MCPOAuthKeys.TOKEN_ENDPOINT.value] = token_endpoint
+        update_connection_config(config.id, db, config_data)
+
+    logger.info("mcp_token_refresh.refreshed config_id=%s", connection_config_id)
+    return headers
+
+
+def _needs_refresh(config_data: MCPConnectionData, now: datetime) -> bool:
+    """True iff we hold a refresh token and the access token is expired/expiring.
+
+    A config with a refresh token but no persisted ``token_expires_at`` predates the
+    expiry-persistence fix; we can't tell when it lapses, so refresh once to heal it
+    (after which ``token_expires_at`` is always stored)."""
+    tokens = config_data.get(MCPOAuthKeys.TOKENS.value) or {}
+    if not tokens.get("refresh_token"):
+        # No refresh token: can't refresh. Leave first-auth to the SDK provider.
+        return False
+    expires_at = config_data.get(MCPOAuthKeys.EXPIRES_AT.value)
+    if not expires_at:
+        return True
+    return needs_refresh({"expires_at": expires_at}, now)
+
+
+def _client_credentials(
+    config_data: MCPConnectionData,
+) -> tuple[str, str | None] | None:
+    client_info = config_data.get(MCPOAuthKeys.CLIENT_INFO.value) or {}
+    client_id = client_info.get("client_id")
+    if not client_id:
+        return None
+    return client_id, client_info.get("client_secret")
+
+
+def _resolve_token_endpoint(
+    mcp_server: MCPServer, config_data: MCPConnectionData
+) -> str | None:
+    """The OAuth token endpoint: a previously-persisted value, then the server row
+    (known-provider mode), then a one-shot RFC 8414 discovery (auto-discovery mode)."""
+    persisted = config_data.get(MCPOAuthKeys.TOKEN_ENDPOINT.value)
+    if persisted:
+        return persisted
+    if mcp_server.oauth_token_endpoint:
+        return mcp_server.oauth_token_endpoint
+    return _discover_token_endpoint(mcp_server.server_url)
+
+
+def _discover_token_endpoint(server_url: str) -> str | None:
+    """Fetch the authorization-server metadata and return its ``token_endpoint``.
+
+    Best-effort: probes the standard well-known locations at the server origin and
+    returns None if none resolve. SSRF-guarded via the shared OAuth endpoint policy."""
+    parsed = urlparse(server_url)
+    if not parsed.scheme or not parsed.netloc:
+        return None
+    origin = f"{parsed.scheme}://{parsed.netloc}"
+    for path in _DISCOVERY_PATHS:
+        url = urljoin(origin, path)
+        try:
+            validate_oauth_endpoint_url(url)
+            response = requests.get(
+                url,
+                headers={"Accept": "application/json"},
+                timeout=_DISCOVERY_TIMEOUT_S,
+            )
+            response.raise_for_status()
+            token_endpoint = response.json().get("token_endpoint")
+            if token_endpoint:
+                return str(token_endpoint)
+        except (requests.RequestException, SSRFException, ValueError) as exc:
+            logger.debug("mcp_token_refresh.discovery_miss url=%s error=%s", url, exc)
+            continue
+    return None
+
+
+def _mark_awaiting_auth_if_admin(
+    tenant_id: str,
+    mcp_server: MCPServer,
+    connection_config_id: int,
+) -> None:
+    """Surface a reconnect in the Admin Panel for a dead admin grant. Per-user
+    configs are left alone — one dead grant shouldn't disconnect the server for
+    everyone; that user's next call surfaces the normal auth error instead."""
+    if mcp_server.admin_connection_config_id != connection_config_id:
+        return
+    try:
+        with get_session_with_tenant(tenant_id=tenant_id) as db:
+            update_mcp_server__no_commit(
+                server_id=mcp_server.id,
+                db_session=db,
+                status=MCPServerStatus.AWAITING_AUTH,
+            )
+            db.commit()
+    except SQLAlchemyError as exc:
+        logger.warning(
+            "mcp_token_refresh.status_update_failed server_id=%s error=%s",
+            mcp_server.id,
+            exc,
+        )

--- a/backend/onyx/server/features/mcp/oauth_refresh.py
+++ b/backend/onyx/server/features/mcp/oauth_refresh.py
@@ -1,12 +1,3 @@
-"""Proactive, single-flighted OAuth refresh for MCP servers.
-
-The MCP SDK's OAuthClientProvider is rebuilt per tool call and never restores token
-expiry, so it never refreshes proactively and an expired token escalates to a full
-re-auth ("Please Reconnect to the server"). Onyx drives refresh itself instead,
-mirroring `external_apps.token_refresh`: check the persisted expiry before a call and
-exchange the stored refresh token when stale. Never raises for a refresh outcome.
-"""
-
 from datetime import datetime
 from datetime import timezone
 from typing import Any
@@ -250,11 +241,16 @@ def _discover_token_endpoint(server_url: str) -> str | None:
         url = urljoin(origin, path)
         try:
             validate_oauth_endpoint_url(url)
+            # Don't follow redirects: a 3xx could escape the validated origin to an
+            # internal target. Treat one as a discovery miss.
             response = requests.get(
                 url,
                 headers={"Accept": "application/json"},
                 timeout=_DISCOVERY_TIMEOUT_S,
+                allow_redirects=False,
             )
+            if response.is_redirect or response.is_permanent_redirect:
+                continue
             response.raise_for_status()
             token_endpoint = response.json().get("token_endpoint")
             if token_endpoint:

--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -8,6 +8,7 @@ from onyx.db.enums import MCPAuthenticationType
 from onyx.db.enums import MCPTransport
 from onyx.db.models import MCPConnectionConfig
 from onyx.db.models import MCPServer
+from onyx.server.features.mcp.oauth_refresh import ensure_fresh_mcp_token
 from onyx.server.query_and_chat.placement import Placement
 from onyx.server.query_and_chat.streaming_models import CustomToolDelta
 from onyx.server.query_and_chat.streaming_models import CustomToolStart
@@ -17,6 +18,7 @@ from onyx.tools.models import CustomToolCallSummary
 from onyx.tools.models import ToolResponse
 from onyx.tools.tool_implementations.mcp.mcp_client import call_mcp_tool
 from onyx.utils.logger import setup_logger
+from shared_configs.contextvars import get_current_tenant_id
 
 logger = setup_logger()
 
@@ -121,6 +123,28 @@ class MCPTool(Tool[None]):
             )
         )
 
+    def _maybe_refresh_oauth_headers(self) -> dict[str, str] | None:
+        """Refresh the OAuth access token if it's expired/expiring, returning the
+        fresh Authorization headers to apply. Never raises — a refresh failure must
+        not break the tool call; the request then proceeds with the stored token."""
+        if (
+            self.mcp_server.auth_type != MCPAuthenticationType.OAUTH
+            or self.connection_config is None
+        ):
+            return None
+        try:
+            return ensure_fresh_mcp_token(
+                tenant_id=get_current_tenant_id(),
+                mcp_server=self.mcp_server,
+                connection_config_id=self.connection_config.id,
+            )
+        except Exception:
+            logger.exception(
+                "Proactive OAuth refresh failed for MCP tool '%s'; using stored token",
+                self._name,
+            )
+            return None
+
     def run(
         self,
         placement: Placement,
@@ -162,6 +186,14 @@ class MCPTool(Tool[None]):
             if self.connection_config and self.connection_config.config:
                 config_dict = self.connection_config.config.get_value(apply_mask=False)
                 headers.update(config_dict.get("headers", {}))
+
+                # Proactively refresh an expired OAuth access token before the call.
+                # The SDK auth provider won't do it reliably (it never restores token
+                # expiry on load), so an expired token would otherwise escalate to a
+                # full re-auth and force a manual reconnect in the Admin Panel.
+                refreshed_headers = self._maybe_refresh_oauth_headers()
+                if refreshed_headers:
+                    headers.update(refreshed_headers)
 
             # Priority 3: For pass-through OAuth, use the user's login OAuth token
             if self._user_oauth_token:

--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -187,10 +187,8 @@ class MCPTool(Tool[None]):
                 config_dict = self.connection_config.config.get_value(apply_mask=False)
                 headers.update(config_dict.get("headers", {}))
 
-                # Proactively refresh an expired OAuth access token before the call.
-                # The SDK auth provider won't do it reliably (it never restores token
-                # expiry on load), so an expired token would otherwise escalate to a
-                # full re-auth and force a manual reconnect in the Admin Panel.
+                # Proactively refresh the OAuth token; the SDK provider won't
+                # (see oauth_refresh.ensure_fresh_mcp_token).
                 refreshed_headers = self._maybe_refresh_oauth_headers()
                 if refreshed_headers:
                     headers.update(refreshed_headers)

--- a/backend/tests/unit/onyx/server/features/mcp/test_oauth_refresh.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_oauth_refresh.py
@@ -1,0 +1,280 @@
+"""Unit tests for proactive MCP OAuth token refresh.
+
+Mirrors the seam-mocking style of tests/unit/external_apps/test_token_refresh.py:
+the DB/Redis/HTTP seams of `oauth_refresh` are patched so the orchestration logic
+(staleness, single-flight double-check, terminal-vs-transient, status updates,
+endpoint resolution) is exercised without any external dependency.
+"""
+
+import copy
+import json
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+from redis.exceptions import ConnectionError as RedisConnectionError
+
+from onyx.db.enums import MCPAuthenticationType
+from onyx.db.enums import MCPServerStatus
+from onyx.external_apps.providers.base import TokenRefreshTerminalError
+from onyx.external_apps.providers.base import TokenRefreshTransientError
+from onyx.server.features.mcp import oauth_refresh as orf
+
+TENANT = "public"
+CONFIG_ID = 7
+ADMIN_CONFIG_ID = 7  # equals CONFIG_ID by default → this row IS the admin row
+TOKEN_ENDPOINT = "https://provider.example.com/oauth/token"
+
+
+def _stale_tokens() -> dict[str, Any]:
+    return {"access_token": "old", "token_type": "Bearer", "refresh_token": "rt"}
+
+
+def _stale_config(**overrides: Any) -> dict[str, Any]:
+    """A connection config whose access token expired in the past."""
+    data: dict[str, Any] = {
+        "headers": {"Authorization": "Bearer old"},
+        "tokens": _stale_tokens(),
+        "client_info": {"client_id": "cid", "client_secret": "secret"},
+        "token_expires_at": "2000-01-01T00:00:00+00:00",
+        "token_endpoint": TOKEN_ENDPOINT,
+    }
+    data.update(overrides)
+    return data
+
+
+def _fresh_config() -> dict[str, Any]:
+    data = _stale_config()
+    data["token_expires_at"] = "2999-01-01T00:00:00+00:00"
+    data["headers"] = {"Authorization": "Bearer ok"}
+    return data
+
+
+@contextmanager
+def _noop_cm(*_a: Any, **_k: Any):  # type: ignore[no-untyped-def]
+    yield MagicMock()
+
+
+def _mcp_server(**overrides: Any) -> MagicMock:
+    server = MagicMock()
+    server.auth_type = MCPAuthenticationType.OAUTH
+    server.id = 10
+    server.server_url = "https://mcp.example.com/sse"
+    server.oauth_token_endpoint = None
+    server.admin_connection_config_id = ADMIN_CONFIG_ID
+    for k, v in overrides.items():
+        setattr(server, k, v)
+    return server
+
+
+def _setup(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    config_sequence: list[dict[str, Any]],
+) -> dict[str, MagicMock]:
+    """Patch oauth_refresh's seams. `config_sequence` is the connection-config data
+    returned on successive reads (pre-check, re-read under lock, persist re-read)."""
+    monkeypatch.setattr(orf, "redis_shared_lock", _noop_cm)
+    monkeypatch.setattr(orf, "get_session_with_tenant", _noop_cm)
+    monkeypatch.setattr(
+        orf, "get_connection_config_by_id", lambda cid, _db: MagicMock(id=cid)
+    )
+    monkeypatch.setattr(
+        orf,
+        "extract_connection_data",
+        MagicMock(side_effect=[copy.deepcopy(c) for c in config_sequence]),
+    )
+    update_config = MagicMock()
+    update_server = MagicMock()
+    refresh = MagicMock()
+    monkeypatch.setattr(orf, "update_connection_config", update_config)
+    monkeypatch.setattr(orf, "update_mcp_server__no_commit", update_server)
+    monkeypatch.setattr(orf, "exchange_refresh_token", refresh)
+    return {
+        "update_config": update_config,
+        "update_server": update_server,
+        "refresh": refresh,
+    }
+
+
+def _run(server: MagicMock | None = None) -> dict[str, str] | None:
+    return orf.ensure_fresh_mcp_token(TENANT, server or _mcp_server(), CONFIG_ID)
+
+
+def test_noop_when_token_fresh(monkeypatch: pytest.MonkeyPatch) -> None:
+    spies = _setup(monkeypatch, config_sequence=[_fresh_config()])
+    assert _run() is None
+    spies["refresh"].assert_not_called()
+    spies["update_config"].assert_not_called()
+
+
+def test_noop_for_non_oauth_server(monkeypatch: pytest.MonkeyPatch) -> None:
+    spies = _setup(monkeypatch, config_sequence=[_stale_config()])
+    server = _mcp_server(auth_type=MCPAuthenticationType.API_TOKEN)
+    assert _run(server) is None
+    spies["refresh"].assert_not_called()
+
+
+def test_noop_when_no_refresh_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _stale_config(tokens={"access_token": "old", "token_type": "Bearer"})
+    spies = _setup(monkeypatch, config_sequence=[cfg])
+    assert _run() is None
+    spies["refresh"].assert_not_called()
+
+
+def test_refreshes_and_persists(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Reads: pre-check, re-read under lock, persist re-read.
+    spies = _setup(
+        monkeypatch,
+        config_sequence=[_stale_config(), _stale_config(), _stale_config()],
+    )
+    spies["refresh"].return_value = {
+        "access_token": "new",
+        "token_type": "Bearer",
+        "refresh_token": "rt",
+        "expires_at": 4102444800,  # 2100-01-01, epoch seconds
+    }
+    headers = _run()
+    assert headers == {"Authorization": "Bearer new"}
+    spies["refresh"].assert_called_once()
+    spies["update_config"].assert_called_once()
+    persisted = spies["update_config"].call_args.args[2]
+    assert persisted["tokens"]["access_token"] == "new"
+    assert persisted["headers"] == {"Authorization": "Bearer new"}
+    assert persisted["token_expires_at"].startswith("2100-01-01")
+    assert persisted["token_endpoint"] == TOKEN_ENDPOINT
+
+
+def test_legacy_config_without_expiry_is_refreshed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A config predating the expiry-persistence fix: has refresh_token, no expiry.
+    legacy = _stale_config()
+    del legacy["token_expires_at"]
+    spies = _setup(monkeypatch, config_sequence=[legacy, copy.deepcopy(legacy), legacy])
+    spies["refresh"].return_value = {
+        "access_token": "new",
+        "token_type": "Bearer",
+        "refresh_token": "rt",
+        "expires_at": 4102444800,
+    }
+    assert _run() == {"Authorization": "Bearer new"}
+    spies["refresh"].assert_called_once()
+
+
+def test_double_checked_skips_when_winner_refreshed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Pre-check sees stale; the re-read under the lock sees the winner's fresh token.
+    spies = _setup(monkeypatch, config_sequence=[_stale_config(), _fresh_config()])
+    headers = _run()
+    assert headers == {"Authorization": "Bearer ok"}  # the winner's fresh headers
+    spies["refresh"].assert_not_called()
+    spies["update_config"].assert_not_called()
+
+
+def test_terminal_marks_admin_server_awaiting_auth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spies = _setup(monkeypatch, config_sequence=[_stale_config(), _stale_config()])
+    spies["refresh"].side_effect = TokenRefreshTerminalError("invalid_grant")
+    assert _run() is None  # does not raise
+    spies["update_server"].assert_called_once()
+    assert (
+        spies["update_server"].call_args.kwargs["status"]
+        == MCPServerStatus.AWAITING_AUTH
+    )
+    spies["update_config"].assert_not_called()
+
+
+def test_terminal_does_not_disconnect_per_user_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # This config row is NOT the admin row → don't flip global server status.
+    server = _mcp_server(admin_connection_config_id=CONFIG_ID + 999)
+    spies = _setup(monkeypatch, config_sequence=[_stale_config(), _stale_config()])
+    spies["refresh"].side_effect = TokenRefreshTerminalError("invalid_grant")
+    assert _run(server) is None
+    spies["update_server"].assert_not_called()
+
+
+def test_transient_keeps_existing_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A transient failure (network / 5xx / misconfigured client) must keep the token
+    # and never flip the server to AWAITING_AUTH — reconnecting wouldn't help.
+    spies = _setup(monkeypatch, config_sequence=[_stale_config(), _stale_config()])
+    spies["refresh"].side_effect = TokenRefreshTransientError("server_error")
+    assert _run() is None
+    spies["update_config"].assert_not_called()
+    spies["update_server"].assert_not_called()
+
+
+def test_lock_contention_yields_to_winner(monkeypatch: pytest.MonkeyPatch) -> None:
+    spies = _setup(monkeypatch, config_sequence=[_stale_config()])
+
+    def _boom(*_a: Any, **_k: Any) -> Any:
+        raise orf.RedisSharedLockAcquisitionError("contended")
+
+    monkeypatch.setattr(orf, "redis_shared_lock", _boom)
+    assert _run() is None
+    spies["refresh"].assert_not_called()
+
+
+def test_redis_unavailable_keeps_existing_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spies = _setup(monkeypatch, config_sequence=[_stale_config()])
+
+    def _boom(*_a: Any, **_k: Any) -> Any:
+        raise RedisConnectionError("Error connecting to Redis.")
+
+    monkeypatch.setattr(orf, "redis_shared_lock", _boom)
+    assert _run() is None  # must not raise
+    spies["refresh"].assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Token-endpoint resolution
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_endpoint_prefers_persisted_then_server_row() -> None:
+    server = _mcp_server(oauth_token_endpoint="https://row.example.com/token")
+    # Persisted config value wins.
+    assert (
+        orf._resolve_token_endpoint(
+            server, {"headers": {}, "token_endpoint": TOKEN_ENDPOINT}
+        )
+        == TOKEN_ENDPOINT
+    )
+    # Falls back to the server row when not persisted.
+    assert (
+        orf._resolve_token_endpoint(server, {"headers": {}})
+        == "https://row.example.com/token"
+    )
+
+
+def test_resolve_endpoint_discovers_when_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server = _mcp_server(oauth_token_endpoint=None)
+    monkeypatch.setattr(orf, "validate_oauth_endpoint_url", lambda *_a, **_k: None)
+
+    discovered = requests.Response()
+    discovered.status_code = 200
+    discovered._content = json.dumps({"token_endpoint": TOKEN_ENDPOINT}).encode()
+    monkeypatch.setattr(orf.requests, "get", lambda *_a, **_k: discovered)
+
+    assert orf._resolve_token_endpoint(server, {"headers": {}}) == TOKEN_ENDPOINT
+
+
+def test_no_endpoint_skips_refresh(monkeypatch: pytest.MonkeyPatch) -> None:
+    server = _mcp_server(oauth_token_endpoint=None)
+    cfg = _stale_config()
+    del cfg["token_endpoint"]
+    spies = _setup(monkeypatch, config_sequence=[cfg, copy.deepcopy(cfg)])
+    # Discovery finds nothing.
+    monkeypatch.setattr(orf, "_discover_token_endpoint", lambda _url: None)
+    assert _run(server) is None
+    spies["refresh"].assert_not_called()

--- a/backend/tests/unit/onyx/server/features/mcp/test_oauth_refresh.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_oauth_refresh.py
@@ -269,6 +269,27 @@ def test_resolve_endpoint_discovers_when_unknown(
     assert orf._resolve_token_endpoint(server, {"headers": {}}) == TOKEN_ENDPOINT
 
 
+def test_discovery_does_not_follow_redirects(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A 3xx could escape the validated origin to an internal target: the request must
+    # not follow it, and the redirect is treated as a discovery miss.
+    server = _mcp_server(oauth_token_endpoint=None)
+    monkeypatch.setattr(orf, "validate_oauth_endpoint_url", lambda *_a, **_k: None)
+
+    captured: dict[str, Any] = {}
+    redirect = requests.Response()
+    redirect.status_code = 302
+    redirect.headers["Location"] = "http://169.254.169.254/token"
+
+    def _get(_url: str, **kwargs: Any) -> requests.Response:
+        captured.update(kwargs)
+        return redirect
+
+    monkeypatch.setattr(orf.requests, "get", _get)
+
+    assert orf._resolve_token_endpoint(server, {"headers": {}}) is None
+    assert captured["allow_redirects"] is False
+
+
 def test_no_endpoint_skips_refresh(monkeypatch: pytest.MonkeyPatch) -> None:
     server = _mcp_server(oauth_token_endpoint=None)
     cfg = _stale_config()

--- a/backend/tests/unit/onyx/server/test_mcp_known_provider_oauth_helpers.py
+++ b/backend/tests/unit/onyx/server/test_mcp_known_provider_oauth_helpers.py
@@ -8,8 +8,12 @@ from mcp.shared.auth import OAuthClientInformationFull
 
 from onyx.auth.oauth_token_manager import build_oauth_authorization_url
 from onyx.auth.oauth_token_manager import exchange_oauth_code_for_token
+from onyx.auth.oauth_token_manager import exchange_refresh_token
+from onyx.auth.oauth_token_manager import OAuthFlowParams
 from onyx.db.models import MCPServer as DbMCPServer
 from onyx.error_handling.exceptions import OnyxError
+from onyx.external_apps.providers.base import TokenRefreshTerminalError
+from onyx.external_apps.providers.base import TokenRefreshTransientError
 from onyx.server.features.mcp.api import _mcp_known_provider_flow_params
 
 
@@ -139,3 +143,90 @@ def test_known_provider_code_exchange_sends_code_verifier(
     assert "expires_at" in token_payload
     assert captured["data"]["code_verifier"] == "verifier-123"
     assert captured["data"]["client_secret"] == "secret-123"
+
+
+def _patch_refresh_post(
+    monkeypatch: pytest.MonkeyPatch, body: dict[str, object], *, status: int = 200
+) -> dict[str, dict[str, str]]:
+    captured: dict[str, dict[str, str]] = {}
+
+    class _Response:
+        status_code = status
+
+        @staticmethod
+        def json() -> dict[str, object]:
+            return body
+
+    def _fake_post(url: str, data: dict[str, str], **kwargs: object) -> _Response:
+        del url, kwargs
+        captured["data"] = data
+        return _Response()
+
+    monkeypatch.setattr("onyx.auth.oauth_token_manager.requests.post", _fake_post)
+    monkeypatch.setattr(
+        "onyx.auth.oauth_token_manager.validate_oauth_endpoint_url",
+        lambda url: None,  # noqa: ARG005
+    )
+    return captured
+
+
+def _refresh_params() -> OAuthFlowParams:
+    return _mcp_known_provider_flow_params(
+        _make_mcp_server_stub(), _make_client_info_stub()
+    )
+
+
+def test_exchange_refresh_token_computes_expiry_and_sends_grant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = _patch_refresh_post(
+        monkeypatch,
+        {"access_token": "fresh", "token_type": "Bearer", "expires_in": 3600},
+    )
+    result = exchange_refresh_token(_refresh_params(), "refresh-old")
+    assert result["access_token"] == "fresh"
+    assert "expires_at" in result  # computed from expires_in
+    assert captured["data"]["grant_type"] == "refresh_token"
+    assert captured["data"]["refresh_token"] == "refresh-old"
+    assert captured["data"]["client_secret"] == "secret-123"
+
+
+def test_exchange_refresh_token_preserves_refresh_token_when_omitted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_refresh_post(monkeypatch, {"access_token": "fresh", "token_type": "Bearer"})
+    # Provider didn't rotate the refresh token → carry the incoming one forward.
+    assert (
+        exchange_refresh_token(_refresh_params(), "refresh-old")["refresh_token"]
+        == "refresh-old"
+    )
+
+
+def test_exchange_refresh_token_uses_rotated_refresh_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_refresh_post(
+        monkeypatch,
+        {"access_token": "fresh", "token_type": "Bearer", "refresh_token": "rotated"},
+    )
+    assert (
+        exchange_refresh_token(_refresh_params(), "refresh-old")["refresh_token"]
+        == "rotated"
+    )
+
+
+def test_exchange_refresh_token_dead_grant_is_terminal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_refresh_post(monkeypatch, {"error": "invalid_grant"}, status=400)
+    with pytest.raises(TokenRefreshTerminalError):
+        exchange_refresh_token(_refresh_params(), "refresh-old")
+
+
+def test_exchange_refresh_token_other_4xx_is_transient(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # invalid_client is a misconfig, not a dead grant — reconnecting wouldn't fix it.
+    _patch_refresh_post(monkeypatch, {"error": "invalid_client"}, status=400)
+    with pytest.raises(TokenRefreshTransientError):
+        exchange_refresh_token(_refresh_params(), "refresh-old")


### PR DESCRIPTION
## Problem

OAuth-backed MCP servers (e.g. Asana) disconnect once their access token expires and require a manual admin **reconnect** in the Admin Panel, breaking any Agent actions wired to them in the meantime.

**Root cause (confirmed from a customer traceback + SDK source):** the stored refresh token is never used. Onyx delegates all runtime refresh to the MCP SDK's `OAuthClientProvider`, which is constructed fresh per tool call. Its `_initialize()` loads tokens but never restores `token_expiry_time`, so `is_token_valid()` treats every stored access token as valid forever. The SDK's only refresh-token branch is gated on `not is_token_valid()`, so it never fires — the expired token is sent, the server returns 401, and the SDK escalates to a **full authorization-code re-auth** (not a refresh-token grant). Onyx's `redirect_handler` (built with `UNUSED_RETURN_PATH`) then raises `ValueError("Please Reconnect to the server")`.

Compounding this, the absolute expiry was being discarded: the token exchange computes `expires_at`, but it's validated into the SDK's `OAuthToken` model, which has no such field and silently drops it — leaving nothing to compute staleness from.

## Fix

Make Onyx authoritative for MCP token refresh, mirroring the proven `external_apps.token_refresh` pattern:

- **Persist absolute expiry + token endpoint** (`token_expires_at`, `token_endpoint`) in the connection config, separate from the SDK's lossy `OAuthToken` dump.
- **Shared `refresh_oauth_token` primitive** in `oauth_token_manager.py` (computes `expires_at`, preserves a non-rotated refresh token); `OAuthTokenManager.refresh_token` refactored onto it so the two paths can't drift.
- **`ensure_fresh_mcp_token`** (new `oauth_refresh.py`): single-flighted (Redis lock) proactive refresh that resolves the token endpoint (persisted → server row → RFC 8414 discovery), exchanges the refresh token, persists the result, and flips an **admin-owned** server to `AWAITING_AUTH` only on a genuinely dead grant. Transient failures keep the existing token; a dead per-user grant doesn't disconnect the whole server.
- **Called from `MCPTool.run`** before each call. This also fixes **SSE** transport (where the SDK auth provider is dropped entirely) since refresh now runs header-based regardless of transport.

### Migration behavior

Existing OAuth MCP configs predate the expiry persistence and have a refresh token but no `token_expires_at`. These are treated as stale once and refreshed to heal them — so they self-recover on first use after deploy rather than needing a manual reconnect.

## Tests

- New unit coverage for the refresh orchestration: staleness, single-flight double-check, terminal-vs-transient, admin-only status flip, endpoint resolution/discovery, legacy configs without persisted expiry.
- Unit coverage for the `refresh_oauth_token` primitive (expiry computed, refresh-token preserved/rotated).
- All 266 MCP/external-apps unit tests pass; `ty`, `ruff`, and pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Proactively refresh OAuth tokens for MCP servers before each tool call so connections stay alive without manual reconnects. We persist absolute expiry and the token endpoint, and refresh header auth for both HTTP and SSE.

- **Bug Fixes**
  - Added `ensure_fresh_mcp_token` and call it from `MCPTool.run`; single-flighted via Redis, resolves token endpoint (persisted → server row → RFC 8414), refreshes via shared `exchange_refresh_token`, updates headers/config, and returns fresh Authorization headers.
  - Persist `token_expires_at` and `token_endpoint` on OAuth callback, `set_tokens`, and admin save flow; `OAuthTokenManager.refresh_token` now uses `exchange_refresh_token` with terminal/transient handling.
  - Failure policy: `invalid_grant` marks admin-owned servers AWAITING_AUTH; per-user dead grants don’t flip server status; other failures keep the existing token and never block the call.

- **Migration**
  - Existing OAuth MCP configs without `token_expires_at` refresh once on first use and then persist expiry and endpoint. No manual action needed.

<sup>Written for commit 297c1d042a66a59cd62047f0eb9eb9414f6bacd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

