### PR TITLE
fix(projects): replace empty spacer divs with padding utilities

### DIFF
--- a/web/src/sections/projects/ProjectChatSessionList.tsx
+++ b/web/src/sections/projects/ProjectChatSessionList.tsx
@@ -291,9 +291,7 @@ export default function ProjectChatSessionList() {
   if (!currentProjectId) return null;
 
   return (
-    <div className="flex flex-col gap-6 mx-auto">
-      <div />
-
+    <div className="flex flex-col gap-6 pt-6 mx-auto">
       <div>
         <div className="px-3 py-2">
           <Text as="p" font="secondary-body" color="text-02">

--- a/web/src/sections/projects/ProjectContextPanel.tsx
+++ b/web/src/sections/projects/ProjectContextPanel.tsx
@@ -125,7 +125,7 @@ export default function ProjectContextPanel({
         />
       </projectFilesModal.Provider>
 
-      <div className="w-(--app-page-main-content-width) mx-auto flex flex-col gap-6">
+      <div className="w-(--app-page-main-content-width) mx-auto flex flex-col gap-6 pb-6">
         <Content
           icon={SvgFolderOpen}
           title={projectName}
@@ -164,7 +164,7 @@ export default function ProjectContextPanel({
         />
 
         <div
-          className="flex flex-col gap-2"
+          className="flex flex-col gap-2 pb-2"
           {...getRootProps({ onClick: (e) => e.stopPropagation() })}
         >
           <ContentAction
@@ -281,13 +281,7 @@ export default function ProjectContextPanel({
               </Text>
             </div>
           )}
-
-          {/* Empty div to add an additional layer of gapping */}
-          <div />
         </div>
-
-        {/* Empty div to add an additional layer of gapping */}
-        <div />
       </div>
     </>
   );


### PR DESCRIPTION
## Description

Replaces the empty `div` workarounds used to produce trailing/leading gap in \`ProjectContextPanel\` and \`ProjectChatSessionList\` with equivalent Tailwind padding utilities (\`pt-6\`, \`pb-6\`, \`pb-2\`) on the relevant containers.

No visual change — same spacing, fewer DOM nodes.

## How Has This Been Tested?

Visually verified in the project panel — spacing is unchanged.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced empty spacer divs with Tailwind padding utilities in ProjectContextPanel and ProjectChatSessionList to keep the same spacing while reducing DOM nodes. Spacing is unchanged; containers now use pt-6, pb-6, and pb-2 for leading/trailing gaps.

<sup>Written for commit 5f5ad5ccb3512408f487a5e847ef5fd66993f414. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

