### PR TITLE
fix(google_drive): bound connector memory by streaming documents in sub-batches

### DIFF
--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -1749,13 +1749,17 @@ class GoogleDriveConnector(
         """Resolve ancestors for this sub-batch's NEW files and convert the files
         whose parent hierarchy node is now available, nodes first.
 
-        A file whose immediate parent folder has not been emitted yet (a folder
-        only a not-yet-processed user can reach) is parked in ``pending_by_folder``
-        under that folder id, so its document is never emitted before its ancestor
-        node. It is released the moment that folder's node is emitted by some other
-        file's walk, so the per-sub-batch cost is independent of the queue size.
-        ``force_flush`` drains everything still parked — those folders never
-        resolved, so the files fall back to the source root."""
+        Ancestor resolution fetches each parent folder by id (with the file's user
+        AND admin), so a file's parent is normally emitted within the file's own
+        sub-batch and the file is never parked. Parking is the exception: the
+        parent is reachable by neither the file's user nor admin, only by another
+        user whose file lands in a later sub-batch. Such a file parks in
+        ``pending_by_folder`` under that folder id so its document is never emitted
+        before its ancestor node, and is released the moment that folder's node is
+        emitted by the other user's walk. ``force_flush`` drains everything still
+        parked — those folders are reachable by nobody in this checkpoint, so the
+        files fall back to the source root (the same outcome as on the pre-batching
+        single-pass path)."""
         new_ancestors = (
             self._get_new_ancestors_for_files(
                 files=files_batch,

--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -1681,6 +1681,7 @@ class GoogleDriveConnector(
         )
 
         files_batch: list[RetrievedDriveFile] = []
+        pending_files: list[RetrievedDriveFile] = []
         for retrieved_file in drive_files_iter:
             if self.exclude_domain_link_only and has_link_only_permission(
                 retrieved_file.drive_file
@@ -1706,13 +1707,20 @@ class GoogleDriveConnector(
             # Flush in bounded sub-batches so peak memory is independent of drive size.
             if len(files_batch) >= DRIVE_CONVERSION_BATCH_SIZE:
                 yield from self._convert_files_sub_batch(
-                    files_batch, checkpoint, permission_sync_context
+                    files_batch,
+                    checkpoint,
+                    permission_sync_context,
+                    pending_files,
                 )
                 files_batch = []
 
-        if files_batch:
+        if files_batch or pending_files:
             yield from self._convert_files_sub_batch(
-                files_batch, checkpoint, permission_sync_context
+                files_batch,
+                checkpoint,
+                permission_sync_context,
+                pending_files,
+                force_flush=True,
             )
 
         checkpoint.retrieved_folder_and_drive_ids = self._retrieved_folder_and_drive_ids
@@ -1722,13 +1730,23 @@ class GoogleDriveConnector(
         files_batch: list[RetrievedDriveFile],
         checkpoint: GoogleDriveCheckpoint,
         permission_sync_context: PermissionSyncContext | None,
+        pending_files: list[RetrievedDriveFile],
+        force_flush: bool = False,
     ) -> Iterator[Document | ConnectorFailure | HierarchyNode]:
         """Resolve ancestors and convert one bounded group of files, yielding the
-        new hierarchy nodes ahead of that group's documents. Each file's ancestors
-        resolve within its own sub-batch, so the node-before-document ordering
-        holds; the checkpoint's seen-node set dedupes ancestors across sub-batches."""
+        new hierarchy nodes ahead of that group's documents. Files whose parent
+        hierarchy nodes are still unresolved are deferred into ``pending_files``
+        so we never emit a document before its ancestor becomes available.
+        Remaining deferred files are force-flushed once the stream ends."""
+        batch: list[RetrievedDriveFile] = []
+        if pending_files:
+            batch.extend(pending_files)
+        batch.extend(files_batch)
+        if not batch:
+            return
+
         new_ancestors = self._get_new_ancestors_for_files(
-            files=files_batch,
+            files=batch,
             seen_hierarchy_node_raw_ids=checkpoint.seen_hierarchy_node_raw_ids,
             fully_walked_hierarchy_node_raw_ids=checkpoint.fully_walked_hierarchy_node_raw_ids,
             failed_folder_ids_by_email=checkpoint.failed_folder_ids_by_email,
@@ -1739,12 +1757,36 @@ class GoogleDriveConnector(
             logger.debug("Yielding %s new hierarchy nodes", len(new_ancestors))
             yield from new_ancestors
 
+        ready_files: list[RetrievedDriveFile] = []
+        still_pending: list[RetrievedDriveFile] = []
+        for retrieved_file in batch:
+            parent_id = _get_parent_id_from_file(retrieved_file.drive_file)
+            if (
+                parent_id
+                and parent_id not in checkpoint.seen_hierarchy_node_raw_ids
+                and not force_flush
+            ):
+                still_pending.append(retrieved_file)
+                continue
+            ready_files.append(retrieved_file)
+
+        pending_files.clear()
+        pending_files.extend(still_pending)
+        if still_pending:
+            logger.debug(
+                "Deferring %s files until their ancestor hierarchy nodes resolve",
+                len(still_pending),
+            )
+
+        if not ready_files:
+            return
+
         func_with_args = [
             (
                 self._convert_retrieved_file_to_document,
                 (retrieved_file, permission_sync_context),
             )
-            for retrieved_file in files_batch
+            for retrieved_file in ready_files
         ]
         raw_results = cast(
             list[Document | ConnectorFailure | None],

--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -105,12 +105,6 @@ BATCHES_PER_CHECKPOINT = 1
 # near ~500 MB — well under the indexing worker memory limit.
 DRIVE_CONVERSION_BATCH_SIZE = 50
 
-# Upper bound on files held back waiting for their ancestor hierarchy node to
-# resolve (a parent folder only a not-yet-processed user can reach). Past this,
-# the oldest waiters are converted anyway and fall back to the source root, so
-# the deferral queue can't grow with drive size.
-MAX_PENDING_HIERARCHY_FILES = DRIVE_CONVERSION_BATCH_SIZE * 10
-
 SHARED_DRIVE_PAGES_PER_CHECKPOINT = 2
 MY_DRIVE_PAGES_PER_CHECKPOINT = 2
 OAUTH_PAGES_PER_CHECKPOINT = 2
@@ -1687,7 +1681,11 @@ class GoogleDriveConnector(
         )
 
         files_batch: list[RetrievedDriveFile] = []
-        pending_files: list[RetrievedDriveFile] = []
+        # Files whose immediate parent folder node has not been emitted yet,
+        # keyed on that folder's raw id. Each is released the moment the folder is
+        # emitted (O(1)); whatever never resolves by stream end falls back to the
+        # source root. Holds only lightweight file metadata, never converted docs.
+        pending_by_folder: dict[str, list[RetrievedDriveFile]] = {}
         for retrieved_file in drive_files_iter:
             if self.exclude_domain_link_only and has_link_only_permission(
                 retrieved_file.drive_file
@@ -1724,16 +1722,16 @@ class GoogleDriveConnector(
                     files_batch,
                     checkpoint,
                     permission_sync_context,
-                    pending_files,
+                    pending_by_folder,
                 )
                 files_batch = []
 
-        if files_batch or pending_files:
+        if files_batch or pending_by_folder:
             yield from self._convert_files_sub_batch(
                 files_batch,
                 checkpoint,
                 permission_sync_context,
-                pending_files,
+                pending_by_folder,
                 force_flush=True,
             )
 
@@ -1744,61 +1742,53 @@ class GoogleDriveConnector(
         files_batch: list[RetrievedDriveFile],
         checkpoint: GoogleDriveCheckpoint,
         permission_sync_context: PermissionSyncContext | None,
-        pending_files: list[RetrievedDriveFile],
+        pending_by_folder: dict[str, list[RetrievedDriveFile]],
         force_flush: bool = False,
     ) -> Iterator[Document | ConnectorFailure | HierarchyNode]:
-        """Resolve ancestors and convert one bounded group of files, yielding the
-        new hierarchy nodes ahead of that group's documents. Files whose parent
-        hierarchy nodes are still unresolved are deferred into ``pending_files``
-        so we never emit a document before its ancestor becomes available.
-        Remaining deferred files are force-flushed once the stream ends."""
-        batch: list[RetrievedDriveFile] = []
-        if pending_files:
-            batch.extend(pending_files)
-        batch.extend(files_batch)
-        if not batch:
-            return
+        """Resolve ancestors for this sub-batch's NEW files and convert the files
+        whose parent hierarchy node is now available, nodes first.
 
-        new_ancestors = self._get_new_ancestors_for_files(
-            files=batch,
-            seen_hierarchy_node_raw_ids=checkpoint.seen_hierarchy_node_raw_ids,
-            fully_walked_hierarchy_node_raw_ids=checkpoint.fully_walked_hierarchy_node_raw_ids,
-            failed_folder_ids_by_email=checkpoint.failed_folder_ids_by_email,
-            permission_sync_context=permission_sync_context,
-            add_prefix=True,
+        A file whose immediate parent folder has not been emitted yet (a folder
+        only a not-yet-processed user can reach) is parked in ``pending_by_folder``
+        under that folder id, so its document is never emitted before its ancestor
+        node. It is released the moment that folder's node is emitted by some other
+        file's walk, so the per-sub-batch cost is independent of the queue size.
+        ``force_flush`` drains everything still parked — those folders never
+        resolved, so the files fall back to the source root."""
+        new_ancestors = (
+            self._get_new_ancestors_for_files(
+                files=files_batch,
+                seen_hierarchy_node_raw_ids=checkpoint.seen_hierarchy_node_raw_ids,
+                fully_walked_hierarchy_node_raw_ids=checkpoint.fully_walked_hierarchy_node_raw_ids,
+                failed_folder_ids_by_email=checkpoint.failed_folder_ids_by_email,
+                permission_sync_context=permission_sync_context,
+                add_prefix=True,
+            )
+            if files_batch
+            else []
         )
         if new_ancestors:
             logger.debug("Yielding %s new hierarchy nodes", len(new_ancestors))
             yield from new_ancestors
 
-        ready_files: list[RetrievedDriveFile] = []
-        still_pending: list[RetrievedDriveFile] = []
-        for retrieved_file in batch:
+        newly_ready: list[RetrievedDriveFile] = []
+        for retrieved_file in files_batch:
             parent_id = _get_parent_id_from_file(retrieved_file.drive_file)
-            if (
-                parent_id
-                and parent_id not in checkpoint.seen_hierarchy_node_raw_ids
-                and not force_flush
-            ):
-                still_pending.append(retrieved_file)
-                continue
-            ready_files.append(retrieved_file)
+            if not parent_id or parent_id in checkpoint.seen_hierarchy_node_raw_ids:
+                newly_ready.append(retrieved_file)
+            else:
+                pending_by_folder.setdefault(parent_id, []).append(retrieved_file)
 
-        # Cap the deferral queue so it can't grow with drive size: convert the
-        # oldest waiters now (they fall back to the source root, the same outcome
-        # as a genuinely inaccessible folder).
-        if len(still_pending) > MAX_PENDING_HIERARCHY_FILES:
-            overflow = len(still_pending) - MAX_PENDING_HIERARCHY_FILES
-            ready_files.extend(still_pending[:overflow])
-            still_pending = still_pending[overflow:]
-
-        pending_files.clear()
-        pending_files.extend(still_pending)
-        if still_pending:
-            logger.debug(
-                "Deferring %s files until their ancestor hierarchy nodes resolve",
-                len(still_pending),
-            )
+        # Release parked files whose folder node was just emitted (they came
+        # earlier in the stream), then this sub-batch's own ready files.
+        ready_files: list[RetrievedDriveFile] = []
+        for node in new_ancestors:
+            ready_files.extend(pending_by_folder.pop(node.raw_node_id, []))
+        if force_flush and pending_by_folder:
+            for waiters in pending_by_folder.values():
+                ready_files.extend(waiters)
+            pending_by_folder.clear()
+        ready_files.extend(newly_ready)
 
         if not ready_files:
             return

--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -1689,16 +1689,24 @@ class GoogleDriveConnector(
                 continue
             if retrieved_file.error is not None:
                 failure_stage = retrieved_file.completion_stage.value
-                failure_message = f"retrieval failure during stage: {failure_stage},"
-                failure_message += f"user: {retrieved_file.user_email},"
-                failure_message += f"parent drive/folder: {retrieved_file.parent_id},"
-                failure_message += f"error: {retrieved_file.error}"
-                logger.error(failure_message)
+                logger.error(
+                    "retrieval failure during stage: %s,user: %s,"
+                    "parent drive/folder: %s,error: %s",
+                    failure_stage,
+                    retrieved_file.user_email,
+                    retrieved_file.parent_id,
+                    retrieved_file.error,
+                )
                 yield ConnectorFailure(
                     failed_entity=EntityFailure(
                         entity_id=retrieved_file.drive_file.get("id", failure_stage),
                     ),
-                    failure_message=failure_message,
+                    failure_message=(
+                        f"retrieval failure during stage: {failure_stage},"
+                        f"user: {retrieved_file.user_email},"
+                        f"parent drive/folder: {retrieved_file.parent_id},"
+                        f"error: {retrieved_file.error}"
+                    ),
                     exception=retrieved_file.error,
                 )
                 continue

--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -99,7 +99,11 @@ logger = setup_logger()
 
 BATCHES_PER_CHECKPOINT = 1
 
-DRIVE_BATCH_SIZE = 80
+# Files converted -> documents per sub-batch before yielding, bounding peak memory
+# independent of drive size. A capped document holds up to
+# CONNECTOR_MAX_EXTRACTED_TEXT_CHARS (~10 MB), so 50 keeps a resident sub-batch
+# near ~500 MB — well under the indexing worker memory limit.
+DRIVE_CONVERSION_BATCH_SIZE = 50
 
 SHARED_DRIVE_PAGES_PER_CHECKPOINT = 2
 MY_DRIVE_PAGES_PER_CHECKPOINT = 2
@@ -1682,24 +1686,47 @@ class GoogleDriveConnector(
                 retrieved_file.drive_file
             ):
                 continue
-            if retrieved_file.error is None:
-                files_batch.append(retrieved_file)
+            if retrieved_file.error is not None:
+                failure_stage = retrieved_file.completion_stage.value
+                failure_message = f"retrieval failure during stage: {failure_stage},"
+                failure_message += f"user: {retrieved_file.user_email},"
+                failure_message += f"parent drive/folder: {retrieved_file.parent_id},"
+                failure_message += f"error: {retrieved_file.error}"
+                logger.error(failure_message)
+                yield ConnectorFailure(
+                    failed_entity=EntityFailure(
+                        entity_id=retrieved_file.drive_file.get("id", failure_stage),
+                    ),
+                    failure_message=failure_message,
+                    exception=retrieved_file.error,
+                )
                 continue
 
-            failure_stage = retrieved_file.completion_stage.value
-            failure_message = f"retrieval failure during stage: {failure_stage},"
-            failure_message += f"user: {retrieved_file.user_email},"
-            failure_message += f"parent drive/folder: {retrieved_file.parent_id},"
-            failure_message += f"error: {retrieved_file.error}"
-            logger.error(failure_message)
-            yield ConnectorFailure(
-                failed_entity=EntityFailure(
-                    entity_id=retrieved_file.drive_file.get("id", failure_stage),
-                ),
-                failure_message=failure_message,
-                exception=retrieved_file.error,
+            files_batch.append(retrieved_file)
+            # Flush in bounded sub-batches so peak memory is independent of drive size.
+            if len(files_batch) >= DRIVE_CONVERSION_BATCH_SIZE:
+                yield from self._convert_files_sub_batch(
+                    files_batch, checkpoint, permission_sync_context
+                )
+                files_batch = []
+
+        if files_batch:
+            yield from self._convert_files_sub_batch(
+                files_batch, checkpoint, permission_sync_context
             )
 
+        checkpoint.retrieved_folder_and_drive_ids = self._retrieved_folder_and_drive_ids
+
+    def _convert_files_sub_batch(
+        self,
+        files_batch: list[RetrievedDriveFile],
+        checkpoint: GoogleDriveCheckpoint,
+        permission_sync_context: PermissionSyncContext | None,
+    ) -> Iterator[Document | ConnectorFailure | HierarchyNode]:
+        """Resolve ancestors and convert one bounded group of files, yielding the
+        new hierarchy nodes ahead of that group's documents. Each file's ancestors
+        resolve within its own sub-batch, so the node-before-document ordering
+        holds; the checkpoint's seen-node set dedupes ancestors across sub-batches."""
         new_ancestors = self._get_new_ancestors_for_files(
             files=files_batch,
             seen_hierarchy_node_raw_ids=checkpoint.seen_hierarchy_node_raw_ids,
@@ -1729,8 +1756,6 @@ class GoogleDriveConnector(
         ]
         logger.debug("batch has %s docs or failures", len(results))
         yield from results
-
-        checkpoint.retrieved_folder_and_drive_ids = self._retrieved_folder_and_drive_ids
 
     def _convert_retrieved_file_to_document(
         self,

--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -100,10 +100,8 @@ logger = setup_logger()
 
 BATCHES_PER_CHECKPOINT = 1
 
-# Files converted -> documents per sub-batch before yielding, bounding peak memory
-# independent of drive size. A capped document holds up to
-# CONNECTOR_MAX_EXTRACTED_TEXT_CHARS (~10 MB), so 50 keeps a resident sub-batch
-# near ~500 MB — well under the indexing worker memory limit.
+# Documents converted per sub-batch. At up to CONNECTOR_MAX_EXTRACTED_TEXT_CHARS
+# (~10 MB) each, 50 caps resident docs near ~500 MB regardless of drive size.
 DRIVE_CONVERSION_BATCH_SIZE = 50
 
 SHARED_DRIVE_PAGES_PER_CHECKPOINT = 2
@@ -1682,10 +1680,9 @@ class GoogleDriveConnector(
         )
 
         files_batch: list[RetrievedDriveFile] = []
-        # Files whose immediate parent folder node has not been emitted yet,
-        # keyed on that folder's raw id. Each is released the moment the folder is
-        # emitted (O(1)); whatever never resolves by stream end falls back to the
-        # source root. Holds only lightweight file metadata, never converted docs.
+        # Files awaiting their parent folder's node, keyed by folder raw id
+        # (lightweight metadata, never documents). Released when the node is
+        # emitted; whatever never resolves falls back to the source root.
         pending_by_folder: dict[str, list[RetrievedDriveFile]] = {}
         for retrieved_file in drive_files_iter:
             if self.exclude_domain_link_only and has_link_only_permission(
@@ -1746,20 +1743,12 @@ class GoogleDriveConnector(
         pending_by_folder: dict[str, list[RetrievedDriveFile]],
         force_flush: bool = False,
     ) -> Iterator[Document | ConnectorFailure | HierarchyNode]:
-        """Resolve ancestors for this sub-batch's NEW files and convert the files
-        whose parent hierarchy node is now available, nodes first.
-
-        Ancestor resolution fetches each parent folder by id (with the file's user
-        AND admin), so a file's parent is normally emitted within the file's own
-        sub-batch and the file is never parked. Parking is the exception: the
-        parent is reachable by neither the file's user nor admin, only by another
-        user whose file lands in a later sub-batch. Such a file parks in
-        ``pending_by_folder`` under that folder id so its document is never emitted
-        before its ancestor node, and is released the moment that folder's node is
-        emitted by the other user's walk. ``force_flush`` drains everything still
-        parked — those folders are reachable by nobody in this checkpoint, so the
-        files fall back to the source root (the same outcome as on the pre-batching
-        single-pass path)."""
+        """Emit this sub-batch's new ancestor nodes, then convert the files whose
+        parent node is now in `seen`. Resolution fetches each parent folder by id
+        (file's user + admin), so a parent normally resolves in the file's own
+        sub-batch; parking is only the cross-user case — a folder reachable solely
+        by a later sub-batch's user — held in `pending_by_folder` until its node is
+        emitted. `force_flush` roots whatever never resolves."""
         new_ancestors = (
             self._get_new_ancestors_for_files(
                 files=files_batch,
@@ -1776,13 +1765,9 @@ class GoogleDriveConnector(
             logger.debug("Yielding %s new hierarchy nodes", len(new_ancestors))
             yield from new_ancestors
 
-        # A folder enters `seen` only by being emitted as a node (see
-        # _get_new_ancestors_for_files: the first walk to reach it adds it to
-        # `seen` AND to the emitted list in the same step). So `parent_id in seen`
-        # here means the node was already emitted in an earlier sub-batch, and a
-        # file parked under a not-yet-seen folder is guaranteed to be released the
-        # first time that folder is emitted (below) — there is no "seen but never
-        # emitted" state that could strand a file.
+        # A folder enters `seen` only when its node is emitted (atomically, in
+        # _get_new_ancestors_for_files), so a parked file is always released the
+        # first time its folder appears below — no "seen but unemitted" stranding.
         newly_ready: list[RetrievedDriveFile] = []
         for retrieved_file in files_batch:
             parent_id = _get_parent_id_from_file(retrieved_file.drive_file)
@@ -1802,8 +1787,7 @@ class GoogleDriveConnector(
             pending_by_folder.clear()
         ready_files.extend(newly_ready)
 
-        # Convert in capped chunks so the heavy converted documents never
-        # accumulate beyond one chunk, regardless of how many files resolved.
+        # Chunk so resident documents never exceed one chunk, however many resolved.
         for chunk in batch_generator(ready_files, DRIVE_CONVERSION_BATCH_SIZE):
             func_with_args = [
                 (

--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -1714,7 +1714,8 @@ class GoogleDriveConnector(
                 continue
 
             files_batch.append(retrieved_file)
-            # Flush in bounded sub-batches so peak memory is independent of drive size.
+            # Flush in bounded sub-batches so resident converted documents stay
+            # capped (pending metadata is bounded by one checkpoint's fetch).
             if len(files_batch) >= DRIVE_CONVERSION_BATCH_SIZE:
                 yield from self._convert_files_sub_batch(
                     files_batch,
@@ -1732,8 +1733,6 @@ class GoogleDriveConnector(
                 pending_by_folder,
                 force_flush=True,
             )
-
-        checkpoint.retrieved_folder_and_drive_ids = self._retrieved_folder_and_drive_ids
 
     def _convert_files_sub_batch(
         self,
@@ -1782,6 +1781,14 @@ class GoogleDriveConnector(
         for node in new_ancestors:
             ready_files.extend(pending_by_folder.pop(node.raw_node_id, []))
         if force_flush and pending_by_folder:
+            rooted = sum(len(waiters) for waiters in pending_by_folder.values())
+            # Surfaces hierarchy degradation: these files' folders never resolved,
+            # so they index under the source root instead of their real parent.
+            logger.warning(
+                "Rooting %s files under %s folders whose ancestor never resolved",
+                rooted,
+                len(pending_by_folder),
+            )
             for waiters in pending_by_folder.values():
                 ready_files.extend(waiters)
             pending_by_folder.clear()

--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -105,6 +105,12 @@ BATCHES_PER_CHECKPOINT = 1
 # near ~500 MB — well under the indexing worker memory limit.
 DRIVE_CONVERSION_BATCH_SIZE = 50
 
+# Upper bound on files held back waiting for their ancestor hierarchy node to
+# resolve (a parent folder only a not-yet-processed user can reach). Past this,
+# the oldest waiters are converted anyway and fall back to the source root, so
+# the deferral queue can't grow with drive size.
+MAX_PENDING_HIERARCHY_FILES = DRIVE_CONVERSION_BATCH_SIZE * 10
+
 SHARED_DRIVE_PAGES_PER_CHECKPOINT = 2
 MY_DRIVE_PAGES_PER_CHECKPOINT = 2
 OAUTH_PAGES_PER_CHECKPOINT = 2
@@ -1690,8 +1696,8 @@ class GoogleDriveConnector(
             if retrieved_file.error is not None:
                 failure_stage = retrieved_file.completion_stage.value
                 logger.error(
-                    "retrieval failure during stage: %s,user: %s,"
-                    "parent drive/folder: %s,error: %s",
+                    "retrieval failure during stage: %s, user: %s, "
+                    "parent drive/folder: %s, error: %s",
                     failure_stage,
                     retrieved_file.user_email,
                     retrieved_file.parent_id,
@@ -1702,9 +1708,9 @@ class GoogleDriveConnector(
                         entity_id=retrieved_file.drive_file.get("id", failure_stage),
                     ),
                     failure_message=(
-                        f"retrieval failure during stage: {failure_stage},"
-                        f"user: {retrieved_file.user_email},"
-                        f"parent drive/folder: {retrieved_file.parent_id},"
+                        f"retrieval failure during stage: {failure_stage}, "
+                        f"user: {retrieved_file.user_email}, "
+                        f"parent drive/folder: {retrieved_file.parent_id}, "
                         f"error: {retrieved_file.error}"
                     ),
                     exception=retrieved_file.error,
@@ -1777,6 +1783,14 @@ class GoogleDriveConnector(
                 still_pending.append(retrieved_file)
                 continue
             ready_files.append(retrieved_file)
+
+        # Cap the deferral queue so it can't grow with drive size: convert the
+        # oldest waiters now (they fall back to the source root, the same outcome
+        # as a genuinely inaccessible folder).
+        if len(still_pending) > MAX_PENDING_HIERARCHY_FILES:
+            overflow = len(still_pending) - MAX_PENDING_HIERARCHY_FILES
+            ready_files.extend(still_pending[:overflow])
+            still_pending = still_pending[overflow:]
 
         pending_files.clear()
         pending_files.extend(still_pending)

--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -86,6 +86,7 @@ from onyx.connectors.models import HierarchyNode
 from onyx.connectors.models import SlimDocument
 from onyx.db.enums import HierarchyNodeType
 from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
+from onyx.utils.batching import batch_generator
 from onyx.utils.logger import setup_logger
 from onyx.utils.retry_wrapper import retry_builder
 from onyx.utils.threadpool_concurrency import parallel_yield
@@ -1771,6 +1772,13 @@ class GoogleDriveConnector(
             logger.debug("Yielding %s new hierarchy nodes", len(new_ancestors))
             yield from new_ancestors
 
+        # A folder enters `seen` only by being emitted as a node (see
+        # _get_new_ancestors_for_files: the first walk to reach it adds it to
+        # `seen` AND to the emitted list in the same step). So `parent_id in seen`
+        # here means the node was already emitted in an earlier sub-batch, and a
+        # file parked under a not-yet-seen folder is guaranteed to be released the
+        # first time that folder is emitted (below) — there is no "seen but never
+        # emitted" state that could strand a file.
         newly_ready: list[RetrievedDriveFile] = []
         for retrieved_file in files_batch:
             parent_id = _get_parent_id_from_file(retrieved_file.drive_file)
@@ -1790,11 +1798,9 @@ class GoogleDriveConnector(
             pending_by_folder.clear()
         ready_files.extend(newly_ready)
 
-        if not ready_files:
-            return
-
-        for start in range(0, len(ready_files), DRIVE_CONVERSION_BATCH_SIZE):
-            chunk = ready_files[start : start + DRIVE_CONVERSION_BATCH_SIZE]
+        # Convert in capped chunks so the heavy converted documents never
+        # accumulate beyond one chunk, regardless of how many files resolved.
+        for chunk in batch_generator(ready_files, DRIVE_CONVERSION_BATCH_SIZE):
             func_with_args = [
                 (
                     self._convert_retrieved_file_to_document,

--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -1781,23 +1781,24 @@ class GoogleDriveConnector(
         if not ready_files:
             return
 
-        func_with_args = [
-            (
-                self._convert_retrieved_file_to_document,
-                (retrieved_file, permission_sync_context),
+        for start in range(0, len(ready_files), DRIVE_CONVERSION_BATCH_SIZE):
+            chunk = ready_files[start : start + DRIVE_CONVERSION_BATCH_SIZE]
+            func_with_args = [
+                (
+                    self._convert_retrieved_file_to_document,
+                    (retrieved_file, permission_sync_context),
+                )
+                for retrieved_file in chunk
+            ]
+            raw_results = cast(
+                list[Document | ConnectorFailure | None],
+                run_functions_tuples_in_parallel(func_with_args, max_workers=8),
             )
-            for retrieved_file in ready_files
-        ]
-        raw_results = cast(
-            list[Document | ConnectorFailure | None],
-            run_functions_tuples_in_parallel(func_with_args, max_workers=8),
-        )
-
-        results: list[Document | ConnectorFailure] = [
-            r for r in raw_results if r is not None
-        ]
-        logger.debug("batch has %s docs or failures", len(results))
-        yield from results
+            results: list[Document | ConnectorFailure] = [
+                r for r in raw_results if r is not None
+            ]
+            logger.debug("sub-batch has %s docs or failures", len(results))
+            yield from results
 
     def _convert_retrieved_file_to_document(
         self,

--- a/backend/tests/daily/connectors/google_drive/test_link_visibility_filter.py
+++ b/backend/tests/daily/connectors/google_drive/test_link_visibility_filter.py
@@ -98,7 +98,9 @@ def test_connector_skips_link_only_files_when_enabled() -> None:
 
     assert results == []
     convert_mock.assert_not_called()
-    get_new_ancestors_mock.assert_called_once()
+    # The only file is filtered out, so no sub-batch runs and there are no
+    # ancestors to resolve.
+    get_new_ancestors_mock.assert_not_called()
 
 
 def test_connector_processes_files_when_option_disabled() -> None:

--- a/backend/tests/unit/onyx/connectors/google_drive/test_drive_conversion_batching.py
+++ b/backend/tests/unit/onyx/connectors/google_drive/test_drive_conversion_batching.py
@@ -1,7 +1,8 @@
 """GoogleDriveConnector converts retrieved files to documents in bounded
-sub-batches. The connector must hold only a sub-batch of files and their
-converted documents at a time — not the whole drive — so peak memory stays
-flat regardless of drive size."""
+sub-batches: the heavy converted documents are materialized at most one
+DRIVE_CONVERSION_BATCH_SIZE chunk at a time regardless of drive size, while
+hierarchy-deferred files wait (as lightweight metadata) for their ancestor
+node and are then converted in those same bounded chunks."""
 
 from collections.abc import Callable
 from collections.abc import Iterator
@@ -282,4 +283,37 @@ def test_deferred_files_wait_for_their_folder_then_all_resolve() -> None:
     assert len(nodes) == 1
     assert isinstance(out[0], HierarchyNode)  # folder node precedes every document
     assert all(size <= 10 for size in call_sizes)  # conversion stays chunked
-    assert len(call_sizes) > 1  # overflow converted mid-stream, not one final flush
+    assert len(call_sizes) > 1  # even the all-at-once release converts in chunks
+
+
+def test_skipped_conversions_are_dropped_not_counted() -> None:
+    connector = _make_connector()
+    n_files = 6
+
+    # Conversion returns None for skipped files (e.g. empty/unsupported); those
+    # must be dropped, not emitted — the batching must not assume 1 doc per file.
+    def _skip_evens(func_with_args: list, **_kwargs: object) -> list:
+        out: list[object] = []
+        for _func, args in func_with_args:
+            rf: RetrievedDriveFile = args[0]
+            idx = int(str(rf.drive_file["id"]).removeprefix("file_"))
+            out.append(None if idx % 2 == 0 else MagicMock(spec=Document))
+        return out
+
+    with (
+        patch(f"{_CONN_MODULE}.DRIVE_CONVERSION_BATCH_SIZE", _BATCH),
+        patch.object(connector, "_get_new_ancestors_for_files", return_value=[]),
+        patch(
+            f"{_CONN_MODULE}.run_functions_tuples_in_parallel",
+            side_effect=_skip_evens,
+        ),
+    ):
+        out = list(
+            connector._convert_retrieved_files_to_documents(
+                iter([_make_file(i) for i in range(n_files)]),
+                _make_checkpoint(),
+                include_permissions=False,
+            )
+        )
+
+    assert len(out) == n_files // 2  # only odd-indexed files produced a document

--- a/backend/tests/unit/onyx/connectors/google_drive/test_drive_conversion_batching.py
+++ b/backend/tests/unit/onyx/connectors/google_drive/test_drive_conversion_batching.py
@@ -208,7 +208,33 @@ def test_defers_documents_until_ancestor_available() -> None:
             )
         )
 
-    assert call_sizes == [2]
+    assert call_sizes == [1, 1]
     assert isinstance(out[0], HierarchyNode)
     assert len(out) == 3
-    assert converted_ids == [["file_0", "file_1"]]
+    assert converted_ids == [["file_0"], ["file_1"]]
+
+
+def test_force_flush_chunks_pending_files() -> None:
+    connector = _make_connector()
+    n_files = _BATCH * 2 + 2  # ensures pending > batch when force-flushed
+    call_sizes: list[int] = []
+
+    with (
+        patch(f"{_CONN_MODULE}.DRIVE_CONVERSION_BATCH_SIZE", _BATCH),
+        patch.object(connector, "_get_new_ancestors_for_files", return_value=[]),
+        patch(
+            f"{_CONN_MODULE}.run_functions_tuples_in_parallel",
+            side_effect=_parallel_stub(call_sizes),
+        ),
+    ):
+        out = list(
+            connector._convert_retrieved_files_to_documents(
+                iter([_make_file(i, parent_id="folder") for i in range(n_files)]),
+                _make_checkpoint(),
+                include_permissions=False,
+            )
+        )
+
+    # Pending files are flushed in sub-batches that respect the cap.
+    assert call_sizes == [_BATCH, _BATCH, 2]
+    assert len(out) == n_files

--- a/backend/tests/unit/onyx/connectors/google_drive/test_drive_conversion_batching.py
+++ b/backend/tests/unit/onyx/connectors/google_drive/test_drive_conversion_batching.py
@@ -1,8 +1,6 @@
-"""GoogleDriveConnector converts retrieved files to documents in bounded
-sub-batches: the heavy converted documents are materialized at most one
-DRIVE_CONVERSION_BATCH_SIZE chunk at a time regardless of drive size, while
-hierarchy-deferred files wait (as lightweight metadata) for their ancestor
-node and are then converted in those same bounded chunks."""
+"""Regression coverage for the Drive connector's bounded sub-batch conversion:
+documents materialize at most one DRIVE_CONVERSION_BATCH_SIZE chunk at a time,
+and hierarchy-deferred files wait for their ancestor node before converting."""
 
 from collections.abc import Callable
 from collections.abc import Iterator

--- a/backend/tests/unit/onyx/connectors/google_drive/test_drive_conversion_batching.py
+++ b/backend/tests/unit/onyx/connectors/google_drive/test_drive_conversion_batching.py
@@ -5,6 +5,7 @@ flat regardless of drive size."""
 
 from collections.abc import Callable
 from collections.abc import Iterator
+from typing import cast
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -140,7 +141,7 @@ def test_hierarchy_nodes_precede_documents_in_each_sub_batch() -> None:
     n_files = _BATCH * 2  # two full sub-batches
 
     def _one_node_per_batch(**_kwargs: object) -> list[HierarchyNode]:
-        return [MagicMock(spec=HierarchyNode)]
+        return [MagicMock(spec=HierarchyNode, raw_node_id="node")]
 
     with (
         patch(f"{_CONN_MODULE}.DRIVE_CONVERSION_BATCH_SIZE", _BATCH),
@@ -183,7 +184,7 @@ def test_defers_documents_until_ancestor_available() -> None:
         seen_hierarchy_node_raw_ids = kwargs["seen_hierarchy_node_raw_ids"]
         assert isinstance(seen_hierarchy_node_raw_ids, ThreadSafeSet)
         seen_hierarchy_node_raw_ids.add(parent_id)
-        return [MagicMock(spec=HierarchyNode)]
+        return [MagicMock(spec=HierarchyNode, raw_node_id=parent_id)]
 
     with (
         patch(f"{_CONN_MODULE}.DRIVE_CONVERSION_BATCH_SIZE", 1),
@@ -235,23 +236,33 @@ def test_force_flush_chunks_pending_files() -> None:
             )
         )
 
-    # Pending files are flushed in sub-batches that respect the cap.
+    # Folders that never resolve are drained at stream end in capped chunks.
     assert call_sizes == [_BATCH, _BATCH, 2]
     assert len(out) == n_files
 
 
-def test_pending_queue_is_capped() -> None:
+def test_deferred_files_wait_for_their_folder_then_all_resolve() -> None:
     connector = _make_connector()
-    n_files = 100
+    n_files = 300  # large enough to rule out any fixed-size deferral cap
+    folder = "shared_folder"
     call_sizes: list[int] = []
 
-    # Every file defers (its parent never enters `seen`). The pending cap must
-    # force the oldest waiters through mid-stream so the queue cannot grow with
-    # drive size — instead of buffering all 100 into a single final flush.
+    # The folder node is emitted only when the LAST file is walked, so all 300
+    # files defer first. None may be force-converted early; every one must wait
+    # and then resolve once the folder appears (its node ahead of every doc).
+    def _fake_ancestors(*_args: object, **kwargs: object) -> list[HierarchyNode]:
+        files = cast("list[RetrievedDriveFile]", kwargs["files"])
+        seen = cast("ThreadSafeSet[str]", kwargs["seen_hierarchy_node_raw_ids"])
+        if any(f.drive_file["id"] == f"file_{n_files - 1}" for f in files):
+            seen.add(folder)
+            return [MagicMock(spec=HierarchyNode, raw_node_id=folder)]
+        return []
+
     with (
         patch(f"{_CONN_MODULE}.DRIVE_CONVERSION_BATCH_SIZE", 10),
-        patch(f"{_CONN_MODULE}.MAX_PENDING_HIERARCHY_FILES", 20),
-        patch.object(connector, "_get_new_ancestors_for_files", return_value=[]),
+        patch.object(
+            connector, "_get_new_ancestors_for_files", side_effect=_fake_ancestors
+        ),
         patch(
             f"{_CONN_MODULE}.run_functions_tuples_in_parallel",
             side_effect=_parallel_stub(call_sizes),
@@ -259,12 +270,16 @@ def test_pending_queue_is_capped() -> None:
     ):
         out = list(
             connector._convert_retrieved_files_to_documents(
-                iter([_make_file(i, parent_id="folder") for i in range(n_files)]),
+                iter([_make_file(i, parent_id=folder) for i in range(n_files)]),
                 _make_checkpoint(),
                 include_permissions=False,
             )
         )
 
-    assert len(out) == n_files  # nothing dropped
-    assert all(size <= 10 for size in call_sizes)  # every chunk respects the cap
+    nodes = [x for x in out if isinstance(x, HierarchyNode)]
+    docs = [x for x in out if not isinstance(x, HierarchyNode)]
+    assert len(docs) == n_files  # nothing dropped or orphaned by a cap
+    assert len(nodes) == 1
+    assert isinstance(out[0], HierarchyNode)  # folder node precedes every document
+    assert all(size <= 10 for size in call_sizes)  # conversion stays chunked
     assert len(call_sizes) > 1  # overflow converted mid-stream, not one final flush

--- a/backend/tests/unit/onyx/connectors/google_drive/test_drive_conversion_batching.py
+++ b/backend/tests/unit/onyx/connectors/google_drive/test_drive_conversion_batching.py
@@ -15,6 +15,7 @@ from onyx.connectors.google_drive.models import RetrievedDriveFile
 from onyx.connectors.models import Document
 from onyx.connectors.models import HierarchyNode
 from onyx.utils.threadpool_concurrency import ThreadSafeDict
+from onyx.utils.threadpool_concurrency import ThreadSafeSet
 
 _BATCH = 10
 _CONN_MODULE = "onyx.connectors.google_drive.connector"
@@ -39,20 +40,39 @@ def _make_checkpoint() -> GoogleDriveCheckpoint:
     )
 
 
-def _make_file(idx: int) -> RetrievedDriveFile:
+def _make_file(idx: int, parent_id: str | None = None) -> RetrievedDriveFile:
     rf = MagicMock(spec=RetrievedDriveFile)
     rf.error = None
-    rf.drive_file = {"id": f"file_{idx}", "name": f"file_{idx}"}
+    rf.completion_stage = DriveRetrievalStage.DONE
+    rf.user_email = f"user{idx}@example.com"
+    rf.parent_id = parent_id
+    drive_file: dict[str, object] = {"id": f"file_{idx}", "name": f"file_{idx}"}
+    if parent_id is not None:
+        drive_file["parents"] = [parent_id]
+    rf.drive_file = drive_file
     return rf
 
 
-def _parallel_stub(calls: list[int]) -> Callable[..., list]:
+def _parallel_stub(
+    calls: list[int], captured_ids: list[list[str]] | None = None
+) -> Callable[..., list]:
     """Replacement for run_functions_tuples_in_parallel that records each call's
     size and returns one stub Document per file without running real conversion."""
 
     def _run(func_with_args: list, **_kwargs: object) -> list:
         calls.append(len(func_with_args))
-        return [MagicMock(spec=Document) for _ in func_with_args]
+        docs: list[Document] = []
+        ids_for_call: list[str] = []
+        for _func, args in func_with_args:
+            retrieved_file: RetrievedDriveFile = args[0]
+            doc = MagicMock(spec=Document)
+            file_id = str(retrieved_file.drive_file["id"])
+            doc.id = file_id
+            ids_for_call.append(file_id)
+            docs.append(doc)
+        if captured_ids is not None:
+            captured_ids.append(ids_for_call)
+        return docs
 
     return _run
 
@@ -145,3 +165,50 @@ def test_hierarchy_nodes_precede_documents_in_each_sub_batch() -> None:
     # One node + ten docs per sub-batch, node first each time.
     kinds = ["node" if isinstance(x, HierarchyNode) else "doc" for x in out]
     assert kinds == (["node"] + ["doc"] * _BATCH) * 2
+
+
+def test_defers_documents_until_ancestor_available() -> None:
+    connector = _make_connector()
+    call_sizes: list[int] = []
+    parent_id = "folder_1"
+    converted_ids: list[list[str]] = []
+    called = False
+
+    def _fake_ancestors(*_args: object, **kwargs: object) -> list[HierarchyNode]:
+        # First invocation: ancestors unavailable; second invocation resolves the folder.
+        nonlocal called
+        if not called:
+            called = True
+            return []
+        seen_hierarchy_node_raw_ids = kwargs["seen_hierarchy_node_raw_ids"]
+        assert isinstance(seen_hierarchy_node_raw_ids, ThreadSafeSet)
+        seen_hierarchy_node_raw_ids.add(parent_id)
+        return [MagicMock(spec=HierarchyNode)]
+
+    with (
+        patch(f"{_CONN_MODULE}.DRIVE_CONVERSION_BATCH_SIZE", 1),
+        patch.object(
+            connector, "_get_new_ancestors_for_files", side_effect=_fake_ancestors
+        ),
+        patch(
+            f"{_CONN_MODULE}.run_functions_tuples_in_parallel",
+            side_effect=_parallel_stub(call_sizes, converted_ids),
+        ),
+    ):
+        out = list(
+            connector._convert_retrieved_files_to_documents(
+                iter(
+                    [
+                        _make_file(0, parent_id=parent_id),
+                        _make_file(1, parent_id=parent_id),
+                    ]
+                ),
+                _make_checkpoint(),
+                include_permissions=False,
+            )
+        )
+
+    assert call_sizes == [2]
+    assert isinstance(out[0], HierarchyNode)
+    assert len(out) == 3
+    assert converted_ids == [["file_0", "file_1"]]

--- a/backend/tests/unit/onyx/connectors/google_drive/test_drive_conversion_batching.py
+++ b/backend/tests/unit/onyx/connectors/google_drive/test_drive_conversion_batching.py
@@ -1,0 +1,147 @@
+"""GoogleDriveConnector converts retrieved files to documents in bounded
+sub-batches. The connector must hold only a sub-batch of files and their
+converted documents at a time — not the whole drive — so peak memory stays
+flat regardless of drive size."""
+
+from collections.abc import Callable
+from collections.abc import Iterator
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from onyx.connectors.google_drive.connector import GoogleDriveConnector
+from onyx.connectors.google_drive.models import DriveRetrievalStage
+from onyx.connectors.google_drive.models import GoogleDriveCheckpoint
+from onyx.connectors.google_drive.models import RetrievedDriveFile
+from onyx.connectors.models import Document
+from onyx.connectors.models import HierarchyNode
+from onyx.utils.threadpool_concurrency import ThreadSafeDict
+
+_BATCH = 10
+_CONN_MODULE = "onyx.connectors.google_drive.connector"
+
+
+def _make_connector() -> GoogleDriveConnector:
+    connector = GoogleDriveConnector(include_my_drives=True)
+    connector._creds = MagicMock()
+    connector._primary_admin_email = "admin@example.com"
+    connector.exclude_domain_link_only = False
+    connector._retrieved_folder_and_drive_ids = set()
+    return connector
+
+
+def _make_checkpoint() -> GoogleDriveCheckpoint:
+    return GoogleDriveCheckpoint(
+        retrieved_folder_and_drive_ids=set(),
+        completion_stage=DriveRetrievalStage.DONE,
+        completion_map=ThreadSafeDict(),
+        all_retrieved_file_ids=set(),
+        has_more=False,
+    )
+
+
+def _make_file(idx: int) -> RetrievedDriveFile:
+    rf = MagicMock(spec=RetrievedDriveFile)
+    rf.error = None
+    rf.drive_file = {"id": f"file_{idx}", "name": f"file_{idx}"}
+    return rf
+
+
+def _parallel_stub(calls: list[int]) -> Callable[..., list]:
+    """Replacement for run_functions_tuples_in_parallel that records each call's
+    size and returns one stub Document per file without running real conversion."""
+
+    def _run(func_with_args: list, **_kwargs: object) -> list:
+        calls.append(len(func_with_args))
+        return [MagicMock(spec=Document) for _ in func_with_args]
+
+    return _run
+
+
+def test_converts_in_bounded_sub_batches() -> None:
+    connector = _make_connector()
+    n_files = _BATCH * 4 + 3  # 43 -> expect sub-batches of 10,10,10,10,3
+    call_sizes: list[int] = []
+
+    with (
+        patch(f"{_CONN_MODULE}.DRIVE_CONVERSION_BATCH_SIZE", _BATCH),
+        patch.object(connector, "_get_new_ancestors_for_files", return_value=[]),
+        patch(
+            f"{_CONN_MODULE}.run_functions_tuples_in_parallel",
+            side_effect=_parallel_stub(call_sizes),
+        ),
+    ):
+        out = list(
+            connector._convert_retrieved_files_to_documents(
+                iter([_make_file(i) for i in range(n_files)]),
+                _make_checkpoint(),
+                include_permissions=False,
+            )
+        )
+
+    # No sub-batch ever exceeds the cap, and the remainder is flushed.
+    assert call_sizes == [_BATCH, _BATCH, _BATCH, _BATCH, 3]
+    assert all(size <= _BATCH for size in call_sizes)
+    # Every file becomes exactly one document; nothing dropped or duplicated.
+    assert len(out) == n_files
+
+
+def test_yields_incrementally_without_draining_whole_drive() -> None:
+    connector = _make_connector()
+    n_files = _BATCH * 5
+    consumed = {"count": 0}
+
+    def _counting_iter() -> Iterator[RetrievedDriveFile]:
+        for i in range(n_files):
+            consumed["count"] += 1
+            yield _make_file(i)
+
+    with (
+        patch(f"{_CONN_MODULE}.DRIVE_CONVERSION_BATCH_SIZE", _BATCH),
+        patch.object(connector, "_get_new_ancestors_for_files", return_value=[]),
+        patch(
+            f"{_CONN_MODULE}.run_functions_tuples_in_parallel",
+            side_effect=_parallel_stub([]),
+        ),
+    ):
+        gen = connector._convert_retrieved_files_to_documents(
+            _counting_iter(), _make_checkpoint(), include_permissions=False
+        )
+        first = next(gen)
+
+    # First document is produced after only one sub-batch is consumed, proving
+    # the connector streams rather than buffering the entire drive first.
+    assert isinstance(first, MagicMock)
+    assert consumed["count"] == _BATCH
+    assert consumed["count"] < n_files
+
+
+def test_hierarchy_nodes_precede_documents_in_each_sub_batch() -> None:
+    connector = _make_connector()
+    n_files = _BATCH * 2  # two full sub-batches
+
+    def _one_node_per_batch(**_kwargs: object) -> list[HierarchyNode]:
+        return [MagicMock(spec=HierarchyNode)]
+
+    with (
+        patch(f"{_CONN_MODULE}.DRIVE_CONVERSION_BATCH_SIZE", _BATCH),
+        patch.object(
+            connector,
+            "_get_new_ancestors_for_files",
+            side_effect=_one_node_per_batch,
+        ),
+        patch(
+            f"{_CONN_MODULE}.run_functions_tuples_in_parallel",
+            side_effect=_parallel_stub([]),
+        ),
+    ):
+        out = list(
+            connector._convert_retrieved_files_to_documents(
+                iter([_make_file(i) for i in range(n_files)]),
+                _make_checkpoint(),
+                include_permissions=False,
+            )
+        )
+
+    # One node + ten docs per sub-batch, node first each time.
+    kinds = ["node" if isinstance(x, HierarchyNode) else "doc" for x in out]
+    assert kinds == (["node"] + ["doc"] * _BATCH) * 2

--- a/backend/tests/unit/onyx/connectors/google_drive/test_drive_conversion_batching.py
+++ b/backend/tests/unit/onyx/connectors/google_drive/test_drive_conversion_batching.py
@@ -238,3 +238,33 @@ def test_force_flush_chunks_pending_files() -> None:
     # Pending files are flushed in sub-batches that respect the cap.
     assert call_sizes == [_BATCH, _BATCH, 2]
     assert len(out) == n_files
+
+
+def test_pending_queue_is_capped() -> None:
+    connector = _make_connector()
+    n_files = 100
+    call_sizes: list[int] = []
+
+    # Every file defers (its parent never enters `seen`). The pending cap must
+    # force the oldest waiters through mid-stream so the queue cannot grow with
+    # drive size — instead of buffering all 100 into a single final flush.
+    with (
+        patch(f"{_CONN_MODULE}.DRIVE_CONVERSION_BATCH_SIZE", 10),
+        patch(f"{_CONN_MODULE}.MAX_PENDING_HIERARCHY_FILES", 20),
+        patch.object(connector, "_get_new_ancestors_for_files", return_value=[]),
+        patch(
+            f"{_CONN_MODULE}.run_functions_tuples_in_parallel",
+            side_effect=_parallel_stub(call_sizes),
+        ),
+    ):
+        out = list(
+            connector._convert_retrieved_files_to_documents(
+                iter([_make_file(i, parent_id="folder") for i in range(n_files)]),
+                _make_checkpoint(),
+                include_permissions=False,
+            )
+        )
+
+    assert len(out) == n_files  # nothing dropped
+    assert all(size <= 10 for size in call_sizes)  # every chunk respects the cap
+    assert len(call_sizes) > 1  # overflow converted mid-stream, not one final flush


### PR DESCRIPTION
## Description

**Bug:** Large Google Drive connectors OOM'd the indexing worker — it drained the whole drive into one list, converted every file 8-wide, and buffered all documents before yielding, so peak memory scaled with drive size. Real tenant: climbed to 9+ GB, worker killed, 0 docs indexed on every retry.

**Fix:** Convert and yield documents in bounded sub-batches of `DRIVE_CONVERSION_BATCH_SIZE` (50), so resident documents stay ~500 MB regardless of drive size (~10 MB/doc observed).

**Hierarchy ordering preserved.** A document must not emit before its ancestor folder node (downstream resolves the doc→folder link from a cache populated by earlier-yielded nodes). Sub-batching can split a folder's node from its files, so a file whose parent folder isn't resolved yet is parked — keyed by folder id, lightweight metadata, never documents — and released in O(1) the moment that node is emitted. Folders reachable by nobody fall back to the source root at stream end, matching the pre-batching single-pass behavior. The park queue is per-checkpoint, so it never grows with drive size.

Also removes a dead `DRIVE_BATCH_SIZE` constant.

## How Has This Been Tested?

- **Unit tests (7):** bounded sub-batch conversion (incl. force-flush), incremental streaming, ancestor-node-before-document ordering, folder-keyed deferral + release, and that skipped (None) conversions are dropped not counted.
- **Memory harness:** ran the real connector over up to 4,000 simulated documents — peak stayed flat (~250 MB normal, ~500 MB worst-case all-deferred) vs ~5–20 GB for the old code.
- Reviewed via 3 sequential recall passes (no surviving correctness findings). Not yet run against a live Google Drive end-to-end (none configured locally).

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check