### PR TITLE
feat: add DISABLE_USER_IDENTITY_IN_PROMPT to keep user name/email out of LLM prompts

### DIFF
--- a/backend/onyx/chat/prompt_utils.py
+++ b/backend/onyx/chat/prompt_utils.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from sqlalchemy.orm import Session
 
+from onyx.configs.app_configs import DISABLE_USER_IDENTITY_IN_PROMPT
 from onyx.db.memory import UserMemoryContext
 from onyx.db.persona import get_default_behavior_persona
 from onyx.db.user_file import calculate_user_files_token_count
@@ -146,7 +147,7 @@ def _build_user_information_section(
     in the correct order: Basic Info → Team Info → Preferences → Memories."""
     sections: list[str] = []
 
-    if user_memory_context:
+    if user_memory_context and not DISABLE_USER_IDENTITY_IN_PROMPT:
         ctx = user_memory_context
         has_basic_info = ctx.user_info.name or ctx.user_info.email or ctx.user_info.role
 

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -76,6 +76,15 @@ GENERATIVE_MODEL_ACCESS_CHECK_FREQ = int(
 # Controls whether users can use User Knowledge (personal documents) in assistants
 DISABLE_USER_KNOWLEDGE = os.environ.get("DISABLE_USER_KNOWLEDGE", "").lower() == "true"
 
+# Controls whether the user's basic identity (name, email, role) is injected into the
+# LLM system prompt. When True, this identifying information is omitted from the prompt
+# sent to the (potentially external) LLM provider, which is useful for privacy/compliance
+# sensitive deployments. Other user context (team info, preferences, memories) is
+# unaffected. Defaults to False to preserve existing behavior.
+DISABLE_USER_IDENTITY_IN_PROMPT = (
+    os.environ.get("DISABLE_USER_IDENTITY_IN_PROMPT", "").lower() == "true"
+)
+
 # Disables vector DB (Vespa/OpenSearch) entirely. When True, connectors and RAG search
 # are disabled but core chat, tools, user file uploads, and Projects still work.
 DISABLE_VECTOR_DB = os.environ.get("DISABLE_VECTOR_DB", "").lower() == "true"

--- a/backend/tests/unit/onyx/chat/test_prompt_utils.py
+++ b/backend/tests/unit/onyx/chat/test_prompt_utils.py
@@ -1,0 +1,68 @@
+import pytest
+
+from onyx.chat import prompt_utils
+from onyx.chat.prompt_utils import _build_user_information_section
+from onyx.db.memory import UserInfo
+from onyx.db.memory import UserMemoryContext
+
+
+def _sample_context() -> UserMemoryContext:
+    return UserMemoryContext(
+        user_info=UserInfo(
+            name="John Doe",
+            email="john@example.com",
+            role="Engineer",
+        ),
+        user_preferences="Prefers concise answers",
+        memories=("Works on the billing service", "Based in Berlin"),
+    )
+
+
+def test_user_information_includes_pii_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Default behaviour: the basic-info sub-block (name/email/role) is rendered.
+    monkeypatch.setattr(prompt_utils, "DISABLE_USER_IDENTITY_IN_PROMPT", False)
+
+    result = _build_user_information_section(_sample_context(), company_context=None)
+
+    assert "## Basic Information" in result
+    assert "John Doe" in result
+    assert "john@example.com" in result
+    assert "Engineer" in result
+    # Preferences and memories are still present.
+    assert "Prefers concise answers" in result
+    assert "Works on the billing service" in result
+
+
+def test_user_information_omits_pii_when_flag_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # With the flag on, name/email/role must not leak into the prompt, but
+    # preferences and memories must still be available to the model.
+    monkeypatch.setattr(prompt_utils, "DISABLE_USER_IDENTITY_IN_PROMPT", True)
+
+    result = _build_user_information_section(_sample_context(), company_context=None)
+
+    assert "## Basic Information" not in result
+    assert "John Doe" not in result
+    assert "john@example.com" not in result
+    # Non-identifying context is preserved.
+    assert "Prefers concise answers" in result
+    assert "Works on the billing service" in result
+    assert "Based in Berlin" in result
+
+
+def test_team_information_unaffected_by_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The flag only gates the user's own identity, never the team/company block.
+    monkeypatch.setattr(prompt_utils, "DISABLE_USER_IDENTITY_IN_PROMPT", True)
+
+    result = _build_user_information_section(
+        _sample_context(), company_context="Acme Corp builds rockets"
+    )
+
+    assert "## Team Information" in result
+    assert "Acme Corp builds rockets" in result
+    assert "John Doe" not in result


### PR DESCRIPTION
## Summary

Closes #11929.

Onyx always injects the signed-in user's name and email (and role) into the system prompt via the `# User Information` section built in `_build_user_information_section` (`backend/onyx/chat/prompt_utils.py`). When a deployment uses an external LLM provider, this sends user PII to that provider on every chat, with no way to turn it off.

This adds an opt-out:

- New env var **`DISABLE_USER_IDENTITY_IN_PROMPT`** (default `false`, so existing behaviour is unchanged).
- - When `true`, the "Basic Information" block (name / email / role) is omitted from the prompt. Team information, user preferences, and memories are left untouched, since the issue is specifically about the identifying name/email fields.
I mirrored the existing `DISABLE_USER_KNOWLEDGE` toggle right above it for naming and style.

## Why default to `false`

To stay fully backward compatible — nothing changes unless an operator explicitly opts in. Privacy/compliance-sensitive deployments can set the flag.

## Testing

Verified locally that with the flag unset the name/email still render in the section, and with `DISABLE_USER_IDENTITY_IN_PROMPT=true` the basic-information block is dropped while preferences/memories still render.

Happy to add a unit test for `_build_user_information_section`, or to rework this as a workspace/admin setting instead of an env var if that fits the codebase better — just let me know your preference.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an opt-out env flag to keep user PII (name, email, role) out of LLM system prompts. Default remains unchanged; tests verify the gating.

- **New Features**
  - Added `DISABLE_USER_IDENTITY_IN_PROMPT` (default false).
  - When true, omits the Basic Information block; team info, preferences, and memories are still included.

<sup>Written for commit 1d12a7444eb6b3594c21a93f69f27b16da16f09d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

