### PR TITLE
fix(google_drive): handle heading paragraphs missing headingId (#11418)

### DIFF
--- a/backend/onyx/connectors/google_drive/section_extraction.py
+++ b/backend/onyx/connectors/google_drive/section_extraction.py
@@ -21,9 +21,15 @@ def _build_gdoc_section_link(doc_id: str, tab_id: str, heading_id: str | None) -
     return f"https://docs.google.com/document/d/{doc_id}/edit?tab={tab_id}{heading_str}"
 
 
-def _extract_id_from_heading(paragraph: dict[str, Any]) -> str:
-    """Extracts the id from a heading paragraph element"""
-    return paragraph["paragraphStyle"]["headingId"]
+def _extract_id_from_heading(paragraph: dict[str, Any]) -> str | None:
+    """Extracts the id from a heading paragraph element, if present.
+
+    Google Docs does not always populate ``headingId`` for a heading paragraph
+    (and, defensively, ``paragraphStyle`` may be absent entirely), so fall back
+    to ``None`` instead of raising a ``KeyError`` that would abort indexing of
+    the whole document. A missing id simply yields a section link without a
+    ``#heading=`` anchor (see ``_build_gdoc_section_link``)."""
+    return paragraph.get("paragraphStyle", {}).get("headingId")
 
 
 def _extract_text_from_paragraph(paragraph: dict[str, Any]) -> str:

--- a/backend/tests/unit/onyx/connectors/google_drive/test_section_extraction.py
+++ b/backend/tests/unit/onyx/connectors/google_drive/test_section_extraction.py
@@ -1,0 +1,84 @@
+"""Unit tests for Google Drive section extraction.
+
+Regression coverage for the case where a Google Docs heading paragraph is
+returned without a ``headingId`` (or without ``paragraphStyle`` at all). The
+old code accessed ``paragraph["paragraphStyle"]["headingId"]`` directly, which
+raised a ``KeyError`` and aborted indexing of the entire document. The fix
+falls back to ``None`` so the document is still indexed, just with a section
+link that has no ``#heading=`` anchor.
+"""
+
+from typing import Any
+
+from onyx.connectors.google_drive.section_extraction import _extract_id_from_heading
+from onyx.connectors.google_drive.section_extraction import get_tab_sections
+
+
+def _heading_paragraph(text: str, paragraph_style: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "paragraph": {
+            "paragraphStyle": paragraph_style,
+            "elements": [{"textRun": {"content": text}}],
+        }
+    }
+
+
+def _body_paragraph(text: str) -> dict[str, Any]:
+    return {
+        "paragraph": {
+            "paragraphStyle": {"namedStyleType": "NORMAL_TEXT"},
+            "elements": [{"textRun": {"content": text}}],
+        }
+    }
+
+
+def _make_tab(content: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "tabProperties": {"tabId": "t.0"},
+        "documentTab": {"body": {"content": content}},
+    }
+
+
+def test_extract_id_from_heading_present() -> None:
+    paragraph = {"paragraphStyle": {"headingId": "h.abc123"}}
+    assert _extract_id_from_heading(paragraph) == "h.abc123"
+
+
+def test_extract_id_from_heading_missing_heading_id() -> None:
+    # Heading paragraph whose paragraphStyle lacks headingId (Google omits it
+    # for some headings) — must not raise.
+    paragraph = {"paragraphStyle": {"namedStyleType": "HEADING_1"}}
+    assert _extract_id_from_heading(paragraph) is None
+
+
+def test_extract_id_from_heading_missing_paragraph_style() -> None:
+    # Defensive: paragraphStyle absent entirely — must not raise.
+    assert _extract_id_from_heading({}) is None
+
+
+def test_get_tab_sections_heading_without_heading_id_is_indexed() -> None:
+    """A heading missing headingId should still produce an indexed section."""
+    tab = _make_tab(
+        [
+            _heading_paragraph(
+                "Intro\n", {"namedStyleType": "HEADING_1", "headingId": "h.first"}
+            ),
+            _body_paragraph("Body under intro.\n"),
+            # Heading with no headingId — previously raised KeyError.
+            _heading_paragraph("No Anchor\n", {"namedStyleType": "HEADING_2"}),
+            _body_paragraph("Body under no-anchor heading.\n"),
+        ]
+    )
+
+    sections = get_tab_sections(tab, doc_id="doc1")
+
+    assert len(sections) == 2
+
+    # First heading keeps its anchor.
+    assert "#heading=h.first" in sections[0].link
+    assert "Body under intro." in sections[0].text
+
+    # Second heading has no anchor but its content is still indexed.
+    assert "#heading=" not in sections[1].link
+    assert "No Anchor" in sections[1].text
+    assert "Body under no-anchor heading." in sections[1].text


### PR DESCRIPTION
## Summary

Fixes #11418.

Google Drive indexing could crash on a single document when the Google Docs
API returned a heading paragraph **without** a `headingId`. `_extract_id_from_heading`
accessed `paragraph["paragraphStyle"]["headingId"]` with hard subscripts, so a
missing `headingId` (Google does not populate it for every heading) raised a
`KeyError` that aborted parsing of the whole document — and when the basic-extraction
fallback also failed, the document was silently dropped from the index.

## Fix

`backend/onyx/connectors/google_drive/section_extraction.py`

```python
def _extract_id_from_heading(paragraph: dict[str, Any]) -> str | None:
    return paragraph.get("paragraphStyle", {}).get("headingId")
```

A missing id now falls back to `None` instead of raising. This is type-safe and
fully consistent with the existing downstream code: `CurrentHeading.id` is already
`str | None`, and `_build_gdoc_section_link(..., heading_id: str | None)` already
handles `None` by emitting a section link **without** a `#heading=` anchor. The
document is still indexed; only the deep-link anchor is omitted for that heading.

## Tests

Added `backend/tests/unit/onyx/connectors/google_drive/test_section_extraction.py`:

- `_extract_id_from_heading` returns the id when present, and `None` when
  `headingId` (or `paragraphStyle`) is missing — no exception.
- `get_tab_sections` over a doc that mixes a heading **with** a `headingId` and a
  heading **without** one: both sections are produced (no crash), the first keeps
  its `#heading=` anchor, the second has none, and all body text is still indexed.

No behavior change for documents whose headings all carry a `headingId`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Google Docs indexing from crashing when a heading lacks `headingId` by returning `None` and omitting the `#heading=` anchor only for that heading, so the document still gets indexed.

- **Bug Fixes**
  - Made `_extract_id_from_heading` use `.get` on `paragraphStyle`/`headingId`, returning `None` when missing.
  - Added unit tests to ensure no `KeyError`, both sections are created, and anchors appear only when an id exists.

<sup>Written for commit 6c30c0c3b5715f348be48fe504b0d8c6607f70da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

