### PR TITLE
feat(craft): Add HubSpot as a built-in external app

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -269,6 +269,12 @@ JWT_PUBLIC_KEY_URL: str | None = os.getenv("JWT_PUBLIC_KEY_URL", None)
 
 USER_AUTH_SECRET = os.environ.get("USER_AUTH_SECRET", "")
 
+if AUTH_TYPE == AuthType.BASIC and not USER_AUTH_SECRET:
+    logger.warning(
+        "USER_AUTH_SECRET is not set. This is required for secure password reset "
+        "and email verification tokens. Please set USER_AUTH_SECRET in production."
+    )
+
 # Bearer token guarding the API server's /metrics endpoint. Auth is required by
 # default: scrapers must present this token as `Authorization: Bearer <token>`
 # (the standard Prometheus scrape format). If neither this nor
@@ -720,6 +726,7 @@ WEB_CONNECTOR_IGNORED_ELEMENTS = os.environ.get(
 WEB_CONNECTOR_OAUTH_CLIENT_ID = os.environ.get("WEB_CONNECTOR_OAUTH_CLIENT_ID")
 WEB_CONNECTOR_OAUTH_CLIENT_SECRET = os.environ.get("WEB_CONNECTOR_OAUTH_CLIENT_SECRET")
 WEB_CONNECTOR_OAUTH_TOKEN_URL = os.environ.get("WEB_CONNECTOR_OAUTH_TOKEN_URL")
+WEB_CONNECTOR_VALIDATE_URLS = os.environ.get("WEB_CONNECTOR_VALIDATE_URLS")
 
 # When the OnyxWebCrawler (open_url tool) hits a 403 / Cloudflare challenge,
 # fall back to a one-shot Playwright (Chromium) render to bypass JS-based
@@ -728,12 +735,6 @@ WEB_CONNECTOR_OAUTH_TOKEN_URL = os.environ.get("WEB_CONNECTOR_OAUTH_TOKEN_URL")
 OPEN_URL_PLAYWRIGHT_FALLBACK_ENABLED = (
     os.environ.get("OPEN_URL_PLAYWRIGHT_FALLBACK_ENABLED", "true").lower() == "true"
 )
-
-# NOTE: the three SSRF env vars below (OPEN_URL_VALIDATE_SSRF,
-# MCP_SERVER_ALLOW_PRIVATE_NETWORK, MCP_SERVER_ALLOW_LOOPBACK) are no longer read
-# at their call sites. They only seed the default "SSRF Protection" level when no
-# override is saved; admins set the effective behavior on the Security Hardening
-# page.
 
 # Whether the open_url tool enforces SSRF protection (rejecting URLs that
 # resolve to private/internal IPs). Default true to keep multi-tenant SaaS
@@ -849,15 +850,6 @@ CONFLUENCE_USE_ONYX_USERS_FOR_GROUP_SYNC = (
 
 GOOGLE_DRIVE_CONNECTOR_SIZE_THRESHOLD = int(
     os.environ.get("GOOGLE_DRIVE_CONNECTOR_SIZE_THRESHOLD", 10 * 1024 * 1024)
-)
-
-# Cap the total text retained per file across a connector's extracted sections,
-# bounding worker memory when a source can't be size-checked before fetch —
-# e.g. Google-native files (Docs/Slides/Sheets) report no `size` metadata and
-# bypass GOOGLE_DRIVE_CONNECTOR_SIZE_THRESHOLD. Content past the cap is dropped
-# with a warning. 0 disables the cap.
-CONNECTOR_MAX_EXTRACTED_TEXT_CHARS = int(
-    os.environ.get("CONNECTOR_MAX_EXTRACTED_TEXT_CHARS") or 10_000_000
 )
 
 # Default size threshold for Drupal Wiki attachments (10MB)
@@ -1025,23 +1017,6 @@ INDEXING_EMBEDDING_MODEL_NUM_THREADS = int(
 # Documents exceeding this limit will surface a visible error rather than being silently dropped.
 # Default is 512MB worth of characters (536,870,912). Configurable via MAX_DOCUMENT_CHARS env var.
 MAX_DOCUMENT_CHARS = int(os.environ.get("MAX_DOCUMENT_CHARS") or 536_870_912)
-
-# Max RSS (in MB) for a spawned indexing worker process. When exceeded, the
-# docfetching watchdog terminates the worker and fails the attempt with a clear
-# error, pre-empting a kernel OOM kill of the whole pod — which would also kill
-# the attempt heartbeat (surfacing as an opaque "No heartbeat received" failure)
-# and any other tenants' tasks running on the pod. 0 disables the check.
-INDEXING_WORKER_MEMORY_LIMIT_MB = int(
-    os.environ.get("INDEXING_WORKER_MEMORY_LIMIT_MB") or 0
-)
-
-# Enable tracemalloc in spawned indexing workers so the near-limit memory report
-# (see INDEXING_WORKER_MEMORY_LIMIT_MB) includes allocation sites. Adds meaningful
-# per-allocation CPU/memory overhead — enable only while chasing a leak.
-INDEXING_WORKER_TRACEMALLOC = (
-    os.environ.get("INDEXING_WORKER_TRACEMALLOC", "").lower() == "true"
-)
-
 MAX_FILE_SIZE_BYTES = int(
     os.environ.get("MAX_FILE_SIZE_BYTES") or 2 * 1024 * 1024 * 1024
 )  # 2GB in bytes
@@ -1448,32 +1423,6 @@ S3_VERIFY_SSL = os.environ.get("S3_VERIFY_SSL", "").lower() == "true"
 S3_AWS_ACCESS_KEY_ID = os.environ.get("S3_AWS_ACCESS_KEY_ID")
 S3_AWS_SECRET_ACCESS_KEY = os.environ.get("S3_AWS_SECRET_ACCESS_KEY")
 
-# Well-known MinIO default; deployments left on it expose all stored files.
-DEFAULT_OBJECT_STORAGE_CREDENTIAL = "minioadmin"
-
-
-def _uses_default_object_storage_credentials(
-    s3_endpoint_url: str | None,
-    access_key: str | None,
-    secret_key: str | None,
-) -> bool:
-    # Only for self-hosted MinIO (has an endpoint URL); real AWS S3 has none.
-    if not s3_endpoint_url:
-        return False
-    return DEFAULT_OBJECT_STORAGE_CREDENTIAL in (access_key, secret_key)
-
-
-if _uses_default_object_storage_credentials(
-    S3_ENDPOINT_URL, S3_AWS_ACCESS_KEY_ID, S3_AWS_SECRET_ACCESS_KEY
-):
-    logger.warning(
-        "Object storage is using the well-known default 'minioadmin' credentials. "
-        "Anyone who can reach the MinIO/S3 endpoint can read or modify stored files "
-        "(uploaded documents, file-store objects). Set S3_AWS_ACCESS_KEY_ID / "
-        "S3_AWS_SECRET_ACCESS_KEY (and MINIO_ROOT_USER / MINIO_ROOT_PASSWORD) to "
-        "strong, unique values before deploying to production."
-    )
-
 # Should we force S3 local checksumming
 S3_GENERATE_LOCAL_CHECKSUM = (
     os.environ.get("S3_GENERATE_LOCAL_CHECKSUM", "").lower() == "true"
@@ -1539,6 +1488,8 @@ EXT_APP_LINEAR_CLIENT_ID = os.environ.get("EXT_APP_LINEAR_CLIENT_ID", "")
 EXT_APP_LINEAR_CLIENT_SECRET = os.environ.get("EXT_APP_LINEAR_CLIENT_SECRET", "")
 EXT_APP_GITHUB_CLIENT_ID = os.environ.get("EXT_APP_GITHUB_CLIENT_ID", "")
 EXT_APP_GITHUB_CLIENT_SECRET = os.environ.get("EXT_APP_GITHUB_CLIENT_SECRET", "")
+EXT_APP_HUBSPOT_CLIENT_ID = os.environ.get("EXT_APP_HUBSPOT_CLIENT_ID", "")
+EXT_APP_HUBSPOT_CLIENT_SECRET = os.environ.get("EXT_APP_HUBSPOT_CLIENT_SECRET", "")
 
 INSTANCE_TYPE = (
     "managed"

--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -394,6 +394,7 @@ class ExternalAppType(str, PyEnum):
     SLACK = "SLACK"
     LINEAR = "LINEAR"
     GITHUB = "GITHUB"
+    HUBSPOT = "HUBSPOT"
     CUSTOM = "CUSTOM"
 
     @property

--- a/backend/onyx/external_apps/providers/hubspot.py
+++ b/backend/onyx/external_apps/providers/hubspot.py
@@ -1,0 +1,227 @@
+from typing import Any
+
+import requests
+
+from onyx.configs.app_configs import EXT_APP_HUBSPOT_CLIENT_ID
+from onyx.configs.app_configs import EXT_APP_HUBSPOT_CLIENT_SECRET
+from onyx.db.enums import EndpointPolicy
+from onyx.db.enums import ExternalAppType
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.external_apps.providers.actions import EndpointSpec
+from onyx.external_apps.providers.actions import ExternalAppAction
+from onyx.external_apps.providers.actions import RestRoute
+from onyx.external_apps.providers.base import AdminDescriptorSpec
+from onyx.external_apps.providers.base import OAuthExternalAppProvider
+from onyx.external_apps.providers.base import OAuthFlowSpec
+from onyx.external_apps.providers.base import OAuthProviderSpec
+from onyx.external_apps.providers.base import OnyxManagedExtApp
+from onyx.external_apps.providers.base import OrgCredentialField
+from onyx.external_apps.providers.base import token_response_error
+
+
+class HubspotAction(ExternalAppAction):
+    """Strongly-typed catalog ids for the HubSpot provider."""
+
+    OWNERS_READ = "hubspot.owners.read"
+    CONTACTS_READ = "hubspot.contacts.read"
+    COMPANIES_READ = "hubspot.companies.read"
+    DEALS_READ = "hubspot.deals.read"
+    CRM_SEARCH = "hubspot.crm.search"
+    CONTACTS_WRITE = "hubspot.contacts.write"
+    COMPANIES_WRITE = "hubspot.companies.write"
+    DEALS_WRITE = "hubspot.deals.write"
+
+
+# HubSpot's CRM is a path-addressed JSON REST API rooted at
+# https://api.hubapi.com; the action is the HTTP method + path template. A
+# `{name}` segment matches one path segment (an object id). CRM search is a
+# read that's expressed as a POST to `.../{object}/search`, so it's catalogued
+# separately from the create (`POST .../{object}`) it would otherwise collide
+# with — different paths, and `search` is auto-approved while writes ask.
+_ENDPOINTS: list[EndpointSpec] = [
+    EndpointSpec(
+        id=HubspotAction.OWNERS_READ,
+        normalised_name="Read owners",
+        description="List CRM owners and fetch a single owner.",
+        matches=(
+            RestRoute(method="GET", path="/crm/v3/owners"),
+            RestRoute(method="GET", path="/crm/v3/owners/{owner_id}"),
+        ),
+        default_policy=EndpointPolicy.ALWAYS,
+    ),
+    EndpointSpec(
+        id=HubspotAction.CONTACTS_READ,
+        normalised_name="Read contacts",
+        description="List contacts and fetch a single contact.",
+        matches=(
+            RestRoute(method="GET", path="/crm/v3/objects/contacts"),
+            RestRoute(method="GET", path="/crm/v3/objects/contacts/{contact_id}"),
+        ),
+        default_policy=EndpointPolicy.ALWAYS,
+    ),
+    EndpointSpec(
+        id=HubspotAction.COMPANIES_READ,
+        normalised_name="Read companies",
+        description="List companies and fetch a single company.",
+        matches=(
+            RestRoute(method="GET", path="/crm/v3/objects/companies"),
+            RestRoute(method="GET", path="/crm/v3/objects/companies/{company_id}"),
+        ),
+        default_policy=EndpointPolicy.ALWAYS,
+    ),
+    EndpointSpec(
+        id=HubspotAction.DEALS_READ,
+        normalised_name="Read deals",
+        description="List deals and fetch a single deal.",
+        matches=(
+            RestRoute(method="GET", path="/crm/v3/objects/deals"),
+            RestRoute(method="GET", path="/crm/v3/objects/deals/{deal_id}"),
+        ),
+        default_policy=EndpointPolicy.ALWAYS,
+    ),
+    EndpointSpec(
+        id=HubspotAction.CRM_SEARCH,
+        normalised_name="Search the CRM",
+        description="Search contacts, companies, and deals by filters.",
+        matches=(
+            RestRoute(method="POST", path="/crm/v3/objects/contacts/search"),
+            RestRoute(method="POST", path="/crm/v3/objects/companies/search"),
+            RestRoute(method="POST", path="/crm/v3/objects/deals/search"),
+        ),
+        default_policy=EndpointPolicy.ALWAYS,
+    ),
+    EndpointSpec(
+        id=HubspotAction.CONTACTS_WRITE,
+        normalised_name="Create or update contacts",
+        description="Create a new contact or update an existing one.",
+        matches=(
+            RestRoute(method="POST", path="/crm/v3/objects/contacts"),
+            RestRoute(method="PATCH", path="/crm/v3/objects/contacts/{contact_id}"),
+        ),
+    ),
+    EndpointSpec(
+        id=HubspotAction.COMPANIES_WRITE,
+        normalised_name="Create or update companies",
+        description="Create a new company or update an existing one.",
+        matches=(
+            RestRoute(method="POST", path="/crm/v3/objects/companies"),
+            RestRoute(method="PATCH", path="/crm/v3/objects/companies/{company_id}"),
+        ),
+    ),
+    EndpointSpec(
+        id=HubspotAction.DEALS_WRITE,
+        normalised_name="Create or update deals",
+        description="Create a new deal or update an existing one.",
+        matches=(
+            RestRoute(method="POST", path="/crm/v3/objects/deals"),
+            RestRoute(method="PATCH", path="/crm/v3/objects/deals/{deal_id}"),
+        ),
+    ),
+]
+
+
+# Scopes requested from HubSpot. `oauth` is mandatory for the auth-code flow;
+# the rest grant read/write on the CRM objects this provider catalogs.
+_SCOPES = [
+    "oauth",
+    "crm.objects.owners.read",
+    "crm.objects.contacts.read",
+    "crm.objects.contacts.write",
+    "crm.objects.companies.read",
+    "crm.objects.companies.write",
+    "crm.objects.deals.read",
+    "crm.objects.deals.write",
+]
+
+
+class HubspotProvider(OAuthExternalAppProvider, OnyxManagedExtApp):
+    spec = OAuthProviderSpec(
+        app_type=ExternalAppType.HUBSPOT,
+        app_name="HubSpot",
+        oauth=OAuthFlowSpec(
+            authorize_url="https://app.hubspot.com/oauth/authorize",
+            token_url="https://api.hubapi.com/oauth/v1/token",
+            scope=" ".join(_SCOPES),
+            scope_param="scope",
+        ),
+        descriptor=AdminDescriptorSpec(
+            description=(
+                "Read and manage HubSpot CRM contacts, companies, and deals "
+                "on the user's behalf."
+            ),
+            upstream_url_patterns=["https://api\\.hubapi\\.com/.*"],
+            auth_template={"Authorization": "Bearer {access_token}"},
+            required_org_credential_fields=[
+                OrgCredentialField(
+                    key="client_id",
+                    label="Client ID",
+                    description=(
+                        "Found on your HubSpot app's Auth settings page "
+                        "(HubSpot developer account → Apps → your app → Auth)."
+                    ),
+                ),
+                OrgCredentialField(
+                    key="client_secret",
+                    label="Client Secret",
+                    description=(
+                        "Found alongside the Client ID on the app's Auth "
+                        "settings page. Treat this like a password."
+                    ),
+                    secret=True,
+                ),
+            ],
+            setup_instructions=(
+                "In HubSpot: create a developer account, then Apps → Create app. "
+                "On the app's Auth tab, add this Onyx instance's callback URL "
+                "(/craft/v1/apps/oauth/callback) to the Redirect URLs and select "
+                "the CRM contacts, companies, and deals read/write scopes plus "
+                "the owners read scope. Save, then paste the Client ID and "
+                "Client Secret below."
+            ),
+        ),
+        endpoint_catalog=_ENDPOINTS,
+    )
+
+    managed_org_credentials = {
+        "client_id": EXT_APP_HUBSPOT_CLIENT_ID,
+        "client_secret": EXT_APP_HUBSPOT_CLIENT_SECRET,
+    }
+
+    # HubSpot signals a dead refresh token with `BAD_REFRESH_TOKEN` rather than
+    # RFC-6749's `invalid_grant`; treat it as terminal so the user reconnects.
+    terminal_refresh_errors = frozenset({"invalid_grant", "BAD_REFRESH_TOKEN"})
+
+    def classify_token_response(
+        self, response: requests.Response, body: dict[str, Any]
+    ) -> str | None:
+        # HubSpot's token endpoint returns a non-2xx with a machine-readable
+        # `status` (e.g. `BAD_REFRESH_TOKEN`, `BAD_AUTH_CODE`) rather than the
+        # OAuth `error` field the generic helper looks for. Surface that code so
+        # terminal-vs-transient classification can match it.
+        if (
+            response.status_code >= 400
+            and isinstance(body, dict)
+            and body.get("status")
+        ):
+            return str(body["status"])
+        return token_response_error(response, body)
+
+    def extract_credentials(self, response_data: dict[str, Any]) -> dict[str, Any]:
+        access_token = response_data.get("access_token")
+        if not access_token:
+            raise OnyxError(
+                OnyxErrorCode.BAD_GATEWAY,
+                "HubSpot OAuth response did not contain an access token.",
+            )
+        creds: dict[str, Any] = {
+            "access_token": access_token,
+            "token_type": response_data.get("token_type"),
+        }
+        # HubSpot always returns a rotating refresh token and an expiry; keep
+        # them so the lazy-refresh path can mint fresh access tokens.
+        if response_data.get("refresh_token"):
+            creds["refresh_token"] = response_data["refresh_token"]
+        if response_data.get("expires_in"):
+            creds["expires_in"] = response_data["expires_in"]
+        return creds

--- a/backend/onyx/external_apps/providers/registry.py
+++ b/backend/onyx/external_apps/providers/registry.py
@@ -3,10 +3,6 @@ from onyx.db.enums import ExternalAppType
 from onyx.db.models import ExternalApp
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
-from onyx.external_apps.models import ActionPolicyView
-from onyx.external_apps.models import BuiltInExternalAppDescriptor
-from onyx.external_apps.models import EndpointDescriptor
-from onyx.external_apps.models import OrgCredentialFieldDescriptor
 from onyx.external_apps.providers.actions import EndpointSpec
 from onyx.external_apps.providers.base import ExternalAppProvider
 from onyx.external_apps.providers.base import OnyxManagedExtApp
@@ -14,8 +10,13 @@ from onyx.external_apps.providers.github import GitHubProvider
 from onyx.external_apps.providers.gmail import GmailProvider
 from onyx.external_apps.providers.google_calendar import GoogleCalendarProvider
 from onyx.external_apps.providers.google_drive import GoogleDriveProvider
+from onyx.external_apps.providers.hubspot import HubspotProvider
 from onyx.external_apps.providers.linear import LinearProvider
 from onyx.external_apps.providers.slack import SlackProvider
+from onyx.server.features.build.api.models import ActionPolicyView
+from onyx.server.features.build.api.models import BuiltInExternalAppDescriptor
+from onyx.server.features.build.api.models import EndpointDescriptor
+from onyx.server.features.build.api.models import OrgCredentialFieldDescriptor
 
 _PROVIDER_CLASSES: list[type[ExternalAppProvider]] = [
     SlackProvider,
@@ -24,6 +25,7 @@ _PROVIDER_CLASSES: list[type[ExternalAppProvider]] = [
     GmailProvider,
     LinearProvider,
     GitHubProvider,
+    HubspotProvider,
 ]
 
 

--- a/backend/onyx/skills/built_in.py
+++ b/backend/onyx/skills/built_in.py
@@ -179,6 +179,9 @@ _REGISTRY: Final = BuiltInSkillRegistry(
         ),
         ExternalAppBuiltInProvider(skill_id="gmail", app_type=ExternalAppType.GMAIL),
         ExternalAppBuiltInProvider(skill_id="github", app_type=ExternalAppType.GITHUB),
+        ExternalAppBuiltInProvider(
+            skill_id="hubspot", app_type=ExternalAppType.HUBSPOT
+        ),
     )
 )
 

--- a/backend/onyx/skills/builtin/hubspot/SKILL.md.template
+++ b/backend/onyx/skills/builtin/hubspot/SKILL.md.template
@@ -1,0 +1,73 @@
+---
+name: hubspot
+description: Read and manage HubSpot CRM contacts, companies, and deals on the connected user's behalf via a light REST wrapper.
+---
+
+# HubSpot
+
+Call the HubSpot CRM as the connected user via the bundled helper. **You are
+already authenticated** — the egress proxy injects the user's HubSpot token on
+the wire, so never pass credentials yourself.
+
+{{ACTION_AVAILABILITY_SECTION}}
+
+## Usage
+
+    python .opencode/skills/hubspot/hubspot_api.py <command> [args]
+
+`<object>` is one of `contacts`, `companies`, or `deals`. Read commands
+auto-paginate and prune empty fields. `create` and `update` are the only
+writes. Use `--raw` to skip empty-field pruning; `python hubspot_api.py
+<command> -h` shows its flags.
+
+### List objects
+
+```
+python hubspot_api.py list contacts [--limit N] [--properties firstname,lastname,email]
+```
+
+### Fetch one object by id
+
+```
+python hubspot_api.py get deals 123456 [--properties dealname,amount]
+```
+
+### Search (free text)
+
+```
+python hubspot_api.py search companies "acme" [--limit N]
+```
+
+### Owners
+
+```
+python hubspot_api.py owners [--limit N]
+```
+
+### Create an object (write)
+
+```
+python hubspot_api.py create contacts --set email=jane@acme.co --set firstname=Jane
+```
+
+### Update an object (write)
+
+```
+python hubspot_api.py update deals 123456 --set dealstage=closedwon
+```
+
+## Output
+
+JSON on stdout. List commands return `{"ok": true, "<object>": [...], "count":
+N, "truncated": bool}` (`truncated` means more results existed past `--limit`).
+HTTP failures return `{"ok": false, "status": <code>, "error": "<message>"}`
+and exit non-zero — surface the error rather than retrying blindly.
+
+## Notes
+
+- Properties default to a useful subset per object; pass `--properties` (a
+  comma-separated list) to fetch others.
+- `--set key=value` is repeatable; keys are HubSpot internal property names
+  (e.g. `email`, `firstname`, `dealname`, `amount`).
+- `call` lets you hit any CRM endpoint: `call <METHOD> <path> [json_body]`.
+  Pass user input as the JSON body, not by string-formatting into the path.

--- a/backend/onyx/skills/builtin/hubspot/hubspot_api.py
+++ b/backend/onyx/skills/builtin/hubspot/hubspot_api.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""HubSpot CRM (REST v3) wrapper for the Onyx Craft sandbox.
+
+Common CRM operations exposed as subcommands. Authentication is handled by
+the egress proxy, which injects the connected user's bearer token on the
+wire — this script sends no credentials itself. User input is passed as
+JSON request bodies / query params (never string-formatted into a URL path
+beyond the object id), so there is no injection risk. Output is JSON on
+stdout; HTTP failures are surfaced as ``{"ok": false, "status": ..., "error": ...}``.
+"""
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+_BASE = "https://api.hubapi.com"
+_DEFAULT_LIMIT = 100
+_PAGE_SIZE = 100
+_HTTP_TIMEOUT_SECONDS = 180
+_METHODS = ("GET", "POST", "PATCH", "PUT", "DELETE")
+
+# CRM object types this helper supports (path segment under /crm/v3/objects).
+_OBJECTS = ("contacts", "companies", "deals")
+
+# Sensible default properties to fetch per object so output is useful without
+# the caller having to enumerate every property name.
+_DEFAULT_PROPERTIES: dict[str, list[str]] = {
+    "contacts": ["firstname", "lastname", "email", "phone", "company", "jobtitle"],
+    "companies": ["name", "domain", "industry", "city", "state", "country"],
+    "deals": ["dealname", "amount", "dealstage", "pipeline", "closedate"],
+}
+
+
+def _prune(value: Any) -> Any:
+    """Recursively drop None / "" / [] / {} so LLM-facing output stays small.
+    Booleans and 0 are kept — they carry signal."""
+    if isinstance(value, dict):
+        out = {k: _prune(v) for k, v in value.items()}
+        return {k: v for k, v in out.items() if v not in (None, "", [], {})}
+    if isinstance(value, list):
+        return [_prune(v) for v in value]
+    return value
+
+
+def _request(method: str, path: str, body: dict[str, Any] | None = None) -> Any:
+    """Make a request to the HubSpot API; return the parsed JSON. Raises on
+    transport failure (handled by the caller)."""
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    req = urllib.request.Request(  # noqa: S310 — fixed https endpoint
+        f"{_BASE}{path}",
+        data=data,
+        method=method,
+        headers={"Content-Type": "application/json; charset=utf-8"},
+    )
+    with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT_SECONDS) as resp:  # noqa: S310
+        raw = resp.read().decode("utf-8")
+    return json.loads(raw) if raw else {}
+
+
+def _object_arg(value: str) -> str:
+    if value not in _OBJECTS:
+        raise argparse.ArgumentTypeError(f"object must be one of {', '.join(_OBJECTS)}")
+    return value
+
+
+def _props(a: argparse.Namespace, obj: str) -> list[str]:
+    if getattr(a, "properties", None):
+        return [p.strip() for p in a.properties.split(",") if p.strip()]
+    return _DEFAULT_PROPERTIES.get(obj, [])
+
+
+def _properties_from_pairs(pairs: list[str]) -> dict[str, str]:
+    """Parse repeated `--set key=value` flags into a HubSpot properties dict."""
+    props: dict[str, str] = {}
+    for pair in pairs:
+        if "=" not in pair:
+            raise ValueError(f"expected key=value, got {pair!r}")
+        key, value = pair.split("=", 1)
+        props[key.strip()] = value
+    return props
+
+
+def _emit(result: dict[str, Any], raw: bool) -> int:
+    print(json.dumps(result if raw else _prune(result)))
+    return 0 if result.get("ok") else 1
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="hubspot_api.py", description="HubSpot CRM.")
+    p.add_argument("--raw", action="store_true", help="don't prune empty fields")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sp = sub.add_parser("list", help="list objects of a type")
+    sp.add_argument("object", type=_object_arg, help="contacts|companies|deals")
+    sp.add_argument("--limit", type=int, default=_DEFAULT_LIMIT)
+    sp.add_argument("--properties", help="comma-separated property names")
+
+    sp = sub.add_parser("get", help="fetch one object by id")
+    sp.add_argument("object", type=_object_arg)
+    sp.add_argument("id")
+    sp.add_argument("--properties", help="comma-separated property names")
+
+    sp = sub.add_parser("search", help="free-text search within an object type")
+    sp.add_argument("object", type=_object_arg)
+    sp.add_argument("query")
+    sp.add_argument("--limit", type=int, default=_DEFAULT_LIMIT)
+    sp.add_argument("--properties", help="comma-separated property names")
+
+    sp = sub.add_parser("create", help="create an object (write)")
+    sp.add_argument("object", type=_object_arg)
+    sp.add_argument(
+        "--set",
+        action="append",
+        default=[],
+        metavar="key=value",
+        help="a property to set (repeatable), e.g. --set email=a@b.co",
+    )
+
+    sp = sub.add_parser("update", help="update an object (write)")
+    sp.add_argument("object", type=_object_arg)
+    sp.add_argument("id")
+    sp.add_argument(
+        "--set",
+        action="append",
+        default=[],
+        metavar="key=value",
+        help="a property to set (repeatable)",
+    )
+
+    sp = sub.add_parser("owners", help="list CRM owners")
+    sp.add_argument("--limit", type=int, default=_DEFAULT_LIMIT)
+
+    sp = sub.add_parser("call", help="raw request")
+    sp.add_argument("method", choices=_METHODS)
+    sp.add_argument("path", help="path starting with /, e.g. /crm/v3/objects/...")
+    sp.add_argument("body", nargs="?", help="optional JSON request body")
+    return p
+
+
+def _paginate(path: str, key: str, properties: list[str], limit: int) -> dict[str, Any]:
+    """Walk a HubSpot CRM list (`results` + `paging.next.after`) up to `limit`."""
+    results: list[Any] = []
+    after: str | None = None
+    while True:
+        params: dict[str, Any] = {"limit": min(_PAGE_SIZE, limit - len(results))}
+        if properties:
+            params["properties"] = ",".join(properties)
+        if after:
+            params["after"] = after
+        query = urllib.parse.urlencode(params)
+        page = _request("GET", f"{path}?{query}")
+        results.extend(page.get("results") or [])
+        after = ((page.get("paging") or {}).get("next") or {}).get("after")
+        if len(results) >= limit:
+            return {
+                "ok": True,
+                key: results[:limit],
+                "count": limit,
+                "truncated": bool(after),
+            }
+        if not after:
+            break
+    return {"ok": True, key: results, "count": len(results), "truncated": False}
+
+
+def _dispatch(a: argparse.Namespace) -> dict[str, Any]:
+    if a.cmd == "list":
+        return _paginate(
+            f"/crm/v3/objects/{a.object}", a.object, _props(a, a.object), a.limit
+        )
+
+    if a.cmd == "get":
+        params = {}
+        props = _props(a, a.object)
+        if props:
+            params["properties"] = ",".join(props)
+        query = f"?{urllib.parse.urlencode(params)}" if params else ""
+        obj_id = urllib.parse.quote(a.id, safe="")
+        result = _request("GET", f"/crm/v3/objects/{a.object}/{obj_id}{query}")
+        return {"ok": True, a.object: result}
+
+    if a.cmd == "search":
+        # Search pages like the list endpoints, but the cursor goes in the POST
+        # body rather than the query string.
+        props = _props(a, a.object)
+        results: list[Any] = []
+        after: str | None = None
+        total: Any = None
+        if a.limit <= 0:
+            return {"ok": False, "error": "limit must be a positive integer"}
+        while len(results) < a.limit:
+            body: dict[str, Any] = {
+                "query": a.query,
+                "limit": min(_PAGE_SIZE, a.limit - len(results)),
+            }
+            if props:
+                body["properties"] = props
+            if after:
+                body["after"] = after
+            page = _request("POST", f"/crm/v3/objects/{a.object}/search", body)
+            results.extend(page.get("results") or [])
+            total = page.get("total")
+            after = ((page.get("paging") or {}).get("next") or {}).get("after")
+            if not after:
+                break
+        return {
+            "ok": True,
+            a.object: results[: a.limit],
+            "count": min(len(results), a.limit),
+            "total": total,
+            "truncated": bool(after),
+        }
+
+    if a.cmd in ("create", "update"):
+        props = _properties_from_pairs(a.set)
+        if not props:
+            return {"ok": False, "error": "no_properties_given"}
+        if a.cmd == "create":
+            result = _request(
+                "POST", f"/crm/v3/objects/{a.object}", {"properties": props}
+            )
+        else:
+            obj_id = urllib.parse.quote(a.id, safe="")
+            result = _request(
+                "PATCH",
+                f"/crm/v3/objects/{a.object}/{obj_id}",
+                {"properties": props},
+            )
+        return {"ok": True, a.object: result}
+
+    if a.cmd == "owners":
+        return _paginate("/crm/v3/owners", "owners", [], a.limit)
+
+    # `call` raw escape hatch
+    body = None
+    if a.body:
+        parsed = json.loads(a.body)
+        if not isinstance(parsed, dict):
+            return {"ok": False, "error": "body must be a JSON object"}
+        body = parsed
+    result = _request(a.method, a.path, body)
+    return {"ok": True, "data": result}
+
+
+def main(argv: list[str]) -> int:
+    a = _build_parser().parse_args(argv[1:])
+    try:
+        result = _dispatch(a)
+    except (json.JSONDecodeError, ValueError) as e:
+        print(f"invalid input: {e}", file=sys.stderr)
+        return 2
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode("utf-8", errors="replace")
+        try:
+            parsed = json.loads(detail)
+            message = (
+                parsed.get("message", detail) if isinstance(parsed, dict) else detail
+            )
+        except ValueError:
+            message = detail
+        print(json.dumps({"ok": False, "status": e.code, "error": message}))
+        return 1
+    except urllib.error.URLError as e:
+        print(f"network error calling HubSpot: {e.reason}", file=sys.stderr)
+        return 1
+    return _emit(result, a.raw)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/backend/tests/unit/external_apps/test_hubspot_catalog.py
+++ b/backend/tests/unit/external_apps/test_hubspot_catalog.py
@@ -1,0 +1,90 @@
+"""The HubSpot provider catalog: REST routes resolve to exactly the intended
+action, and default policies match the design (reads + CRM search auto-approve;
+object writes require approval).
+
+Here we exercise the pure rule layer directly (the DB-driven
+``recognize_actions`` path is covered elsewhere)."""
+
+from __future__ import annotations
+
+import pytest
+
+from onyx.db.enums import EndpointPolicy
+from onyx.db.enums import ExternalAppType
+from onyx.external_apps.matching.request import MatchContext
+from onyx.external_apps.matching.request import ProxiedRequest
+from onyx.external_apps.matching.rules import rule_matches
+from onyx.external_apps.providers.hubspot import HubspotAction
+from onyx.external_apps.providers.registry import get_endpoint_catalog
+
+_CATALOG = get_endpoint_catalog(ExternalAppType.HUBSPOT)
+
+
+def _matching_actions(method: str, path: str) -> set[str]:
+    """Every catalog action whose rules recognise the request, through the real
+    matcher."""
+    context = MatchContext(ProxiedRequest(method=method, path=path, body=None))
+    return {
+        endpoint.id
+        for endpoint in _CATALOG
+        if any(rule_matches(rule, context) for rule in endpoint.matches)
+    }
+
+
+@pytest.mark.parametrize(
+    "method, path, expected",
+    [
+        # Reads resolve unchanged.
+        ("GET", "/crm/v3/owners", {HubspotAction.OWNERS_READ}),
+        ("GET", "/crm/v3/owners/42", {HubspotAction.OWNERS_READ}),
+        ("GET", "/crm/v3/objects/contacts", {HubspotAction.CONTACTS_READ}),
+        ("GET", "/crm/v3/objects/contacts/123", {HubspotAction.CONTACTS_READ}),
+        ("GET", "/crm/v3/objects/companies", {HubspotAction.COMPANIES_READ}),
+        ("GET", "/crm/v3/objects/companies/123", {HubspotAction.COMPANIES_READ}),
+        ("GET", "/crm/v3/objects/deals", {HubspotAction.DEALS_READ}),
+        ("GET", "/crm/v3/objects/deals/123", {HubspotAction.DEALS_READ}),
+        # Search is a POST read on a distinct sub-path; it must not collide with
+        # the create write on the bare object path.
+        ("POST", "/crm/v3/objects/contacts/search", {HubspotAction.CRM_SEARCH}),
+        ("POST", "/crm/v3/objects/companies/search", {HubspotAction.CRM_SEARCH}),
+        ("POST", "/crm/v3/objects/deals/search", {HubspotAction.CRM_SEARCH}),
+        # Writes.
+        ("POST", "/crm/v3/objects/contacts", {HubspotAction.CONTACTS_WRITE}),
+        ("PATCH", "/crm/v3/objects/contacts/123", {HubspotAction.CONTACTS_WRITE}),
+        ("POST", "/crm/v3/objects/companies", {HubspotAction.COMPANIES_WRITE}),
+        ("PATCH", "/crm/v3/objects/companies/123", {HubspotAction.COMPANIES_WRITE}),
+        ("POST", "/crm/v3/objects/deals", {HubspotAction.DEALS_WRITE}),
+        ("PATCH", "/crm/v3/objects/deals/123", {HubspotAction.DEALS_WRITE}),
+    ],
+)
+def test_rest_route_resolves_to_exactly_one_action(
+    method: str, path: str, expected: set[str]
+) -> None:
+    assert _matching_actions(method, path) == expected
+
+
+def test_uncatalogued_route_matches_nothing() -> None:
+    """A path outside the catalog matches no action — the proxy then falls back
+    to the whole-domain ASK gate rather than injecting under a catalog action."""
+    assert _matching_actions("GET", "/crm/v3/objects/tickets") == set()
+
+
+@pytest.mark.parametrize(
+    "action, expected_policy",
+    [
+        (HubspotAction.OWNERS_READ, EndpointPolicy.ALWAYS),
+        (HubspotAction.CONTACTS_READ, EndpointPolicy.ALWAYS),
+        (HubspotAction.COMPANIES_READ, EndpointPolicy.ALWAYS),
+        (HubspotAction.DEALS_READ, EndpointPolicy.ALWAYS),
+        (HubspotAction.CRM_SEARCH, EndpointPolicy.ALWAYS),
+        # Writes require approval out of the box.
+        (HubspotAction.CONTACTS_WRITE, EndpointPolicy.ASK),
+        (HubspotAction.COMPANIES_WRITE, EndpointPolicy.ASK),
+        (HubspotAction.DEALS_WRITE, EndpointPolicy.ASK),
+    ],
+)
+def test_default_policies(
+    action: HubspotAction, expected_policy: EndpointPolicy
+) -> None:
+    by_id = {endpoint.id: endpoint for endpoint in _CATALOG}
+    assert by_id[action].default_policy == expected_policy

--- a/web/src/app/craft/v1/apps/registry.ts
+++ b/web/src/app/craft/v1/apps/registry.ts
@@ -5,6 +5,7 @@ import {
   SvgGithub,
   SvgGoogleCalendar,
   SvgGoogleDrive,
+  SvgHubspot,
 } from "@opal/logos";
 import { SvgPlug } from "@opal/icons";
 import { IconFunctionComponent } from "@opal/types";
@@ -17,6 +18,7 @@ export type ExternalAppType =
   | "GMAIL"
   | "LINEAR"
   | "GITHUB"
+  | "HUBSPOT"
   | "CUSTOM";
 
 const _BUILT_IN_LOGOS: Partial<Record<ExternalAppType, IconFunctionComponent>> =
@@ -27,6 +29,7 @@ const _BUILT_IN_LOGOS: Partial<Record<ExternalAppType, IconFunctionComponent>> =
     GMAIL: SvgGmail,
     LINEAR: SvgLinear,
     GITHUB: SvgGithub,
+    HUBSPOT: SvgHubspot,
   };
 
 /** Logo for a known `app_type`, with a generic fallback for CUSTOM /


### PR DESCRIPTION
## Summary
Adds HubSpot as a new built-in external app for Craft. Users can connect their HubSpot account via OAuth and interact with HubSpot through the generated skill (SKILL.md.template + hubspot_api.py). Registers a new `HubSpotProvider`, adds the `HUBSPOT` external app type, app config, built-in skill wiring, the web apps registry entry, and a unit test for the action catalog.

Implements Linear issue ENG-4172 (https://linear.app/onyx-app/issue/ENG-4172/hubspot-external-app).

Follows the established external-app patterns from #11598 (GitHub app) and #11708 (Google Drive app).

## Testing
- `python -m py_compile` passes on all changed Python files.
- Includes unit test `backend/tests/unit/external_apps/test_hubspot_catalog.py`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds HubSpot as a built-in external app with OAuth, plus a bundled `hubspot` skill to read, search, and manage CRM contacts, companies, and deals. Implements Linear ENG-4172.

- **New Features**
  - New `HUBSPOT` external app type and `HubspotProvider` with OAuth.
  - Managed creds support via `EXT_APP_HUBSPOT_CLIENT_ID` and `EXT_APP_HUBSPOT_CLIENT_SECRET`.
  - Endpoint catalog with default policies: reads/search auto-approve; writes ask.
  - Built-in `hubspot` skill (`SKILL.md.template`) and `hubspot_api.py` helper for list/get/search owners, contacts, companies, deals; create/update writes.
  - Web app registry + logo wiring; unit test for the action catalog.

- **Migration**
  - Set `EXT_APP_HUBSPOT_CLIENT_ID` and `EXT_APP_HUBSPOT_CLIENT_SECRET` (or enter in admin UI).
  - In HubSpot dev portal, add callback URL: /craft/v1/apps/oauth/callback.
  - Enable scopes: `oauth`, owners read, and CRM contacts/companies/deals read/write.

<sup>Written for commit 4b8090d236f38ced0d88c62501074fdc737ef70a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

