### PR TITLE
docs(prompt_cache): document PROMPT_CACHE_CHAT_HISTORY env var (#11797)

### DIFF
--- a/backend/onyx/llm/prompt_cache/README.md
+++ b/backend/onyx/llm/prompt_cache/README.md
@@ -113,6 +113,32 @@ processed_prompt, _ = process_with_prompt_cache(
   export ENABLE_PROMPT_CACHING=false  # Disable caching
   ```
 
+- `PROMPT_CACHE_CHAT_HISTORY`: Enable prompt caching of the **chat history** (the
+  prior conversation turns) on chat requests (default: `false`).
+  ```bash
+  export PROMPT_CACHE_CHAT_HISTORY=true  # Cache the conversation history too
+  ```
+
+  This flag is **separate from `ENABLE_PROMPT_CACHING`** and controls a different
+  thing. `ENABLE_PROMPT_CACHING` is the framework-level toggle; even with it on (the
+  default), the chat flow only marks the conversation history as cacheable when
+  `PROMPT_CACHE_CHAT_HISTORY=true`. It is defined in
+  `onyx/configs/app_configs.py` and consumed in `onyx/chat/llm_step.py`, where it
+  gates the detection of the last cacheable history message. When it is `false`
+  (the default), no `cache_control` breakpoint is placed on the chat history, so an
+  Anthropic-backed deployment will keep reporting `cache_creation_input_tokens=0`
+  and `cache_read_input_tokens=0` for the history portion even with
+  `ENABLE_PROMPT_CACHING=true`.
+
+  Enabling it is most impactful for deployments with a large, stable system prompt
+  plus retrieved (RAG) context, where the history is the bulk of the input tokens
+  on follow-up turns. To verify it is working, check the LLM usage on a follow-up
+  message in the same chat session: `cache_creation_input_tokens` should be
+  non-zero on the first request (cache write) and `cache_read_input_tokens`
+  non-zero on the next (cache hit). See the Anthropic section above for the
+  provider-side behavior (`cache_control={"type": "ephemeral"}`, 5-minute default
+  TTL, up to 4 cache breakpoints).
+
 ## Architecture
 
 ### Core Components


### PR DESCRIPTION
## Summary

Documents the `PROMPT_CACHE_CHAT_HISTORY` environment variable in the prompt-cache framework README. Fixes #11797.

The `prompt_cache/` README documents `ENABLE_PROMPT_CACHING` as the toggle, but chat-history caching is gated by a **second, undocumented** flag — `PROMPT_CACHE_CHAT_HISTORY` (default `false`), defined in `onyx/configs/app_configs.py` and consumed in `onyx/chat/llm_step.py`. With `ENABLE_PROMPT_CACHING=true` but `PROMPT_CACHE_CHAT_HISTORY` unset, `last_cacheable_msg_idx` never gets set, `process_with_prompt_cache(...)` is never invoked for the history, and Anthropic never receives a `cache_control` breakpoint — so the conversation history keeps billing at full input price (`cache_creation_input_tokens=0` / `cache_read_input_tokens=0`) even though the framework, flag, and provider adapter are all present and working.

This was surfaced by a user who only discovered the flag by reading the source (#11797).

## What this changes

- Adds a `PROMPT_CACHE_CHAT_HISTORY` entry to **Configuration → Environment Variables** in `backend/onyx/llm/prompt_cache/README.md`, alongside `ENABLE_PROMPT_CACHING`.
- Explicitly notes that it is **separate from** `ENABLE_PROMPT_CACHING` (framework toggle vs. chat-history gate), defaults to `false`, points at the two relevant source files, and explains the `cache_*_input_tokens=0` symptom when it is off.
- Adds a short "how to verify it's working" note (check `cache_creation_input_tokens` / `cache_read_input_tokens` on a follow-up message), cross-referencing the existing Anthropic provider section.

Docs-only — no code changes.

## Notes

This is fix #1 of the three non-code suggestions in #11797 (documentation). The reporter also suggested a startup `INFO` log and a possible default change; those are left out of this PR so it stays a focused, low-risk docs change — happy to follow up on either in a separate PR if maintainers want them.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented the `PROMPT_CACHE_CHAT_HISTORY` env var in `backend/onyx/llm/prompt_cache/README.md` to make chat-history caching discoverable and avoid cases where caching is enabled but history isn’t cached. Clarifies it’s separate from `ENABLE_PROMPT_CACHING` (default `false`), links to `onyx/configs/app_configs.py` and `onyx/chat/llm_step.py`, and adds a quick verification using `cache_creation_input_tokens`/`cache_read_input_tokens`.

<sup>Written for commit f7483870df42295b5ec33dfe7944be279eaac700. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12065?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

