### PR TITLE
chore(web): auto-rebuild opal dist CSS on checkout/pull

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -173,6 +173,20 @@ repos:
         pass_filenames: false
         files: ^web/(package\.json|bun\.lock|lib/opal/package\.json)$
 
+      # `bun install` won't rebuild an already-linked file: dep's gitignored `dist`, so
+      # token / opal-CSS changes from a pull leave opal/dist/root.css stale → the web dev
+      # server serves old radius/spacing/colors (a "boxy" UI). Regenerate it explicitly.
+      # `bun install --frozen-lockfile` first guards the clean-tree case (this hook's file
+      # set is disjoint from bun-install's, so it can fire before node_modules exists).
+      - id: opal-css-rebuild
+        name: rebuild opal token CSS
+        description: "Rebuild opal dist CSS after checkout/pull/rebase so dev gets fresh design tokens"
+        language: system
+        entry: bash -c 'cd web && bun install --frozen-lockfile && bun run --cwd lib/shared build:tokens && node lib/opal/scripts/bundle-css.mjs'
+        pass_filenames: false
+        files: ^web/lib/(opal/src/.*\.css|opal/scripts/bundle-css\.mjs|shared/(tokens/.*\.json|style-dictionary\.config\.mjs))$
+        stages: [post-checkout, post-merge, post-rewrite]
+
       - id: root-bun-install
         name: root bun install
         description: "Automatically run 'bun install' at the repo root after a checkout, pull or rebase"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -182,7 +182,7 @@ repos:
         name: rebuild opal token CSS
         description: "Rebuild opal dist CSS after checkout/pull/rebase so dev gets fresh design tokens"
         language: system
-        entry: bash -c 'cd web && bun install --frozen-lockfile && bun run --cwd lib/shared build:tokens && node lib/opal/scripts/bundle-css.mjs'
+        entry: bash -c 'cd web && bun install --frozen-lockfile && bun run --cwd lib/shared build:tokens && bun lib/opal/scripts/bundle-css.mjs'
         pass_filenames: false
         files: ^web/lib/(opal/src/.*\.css|opal/scripts/bundle-css\.mjs|shared/(tokens/.*\.json|style-dictionary\.config\.mjs))$
         stages: [post-checkout, post-merge, post-rewrite]

--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -2,5 +2,11 @@ node_modules
 .next
 /tests/
 
+# Local build artifacts — opal/shared rebuild these via `prepare` on `bun install`.
+# Excluding them keeps a stale local dist out of hand-built images (CI clones clean,
+# so a stale dist only exists when building the image from a dirty working tree).
+lib/opal/dist
+lib/shared/dist
+
 # Explicitly include src/app/build (overrides .gitignore /build pattern)
 !src/app/build


### PR DESCRIPTION
## Description

- Add an `opal-css-rebuild` pre-commit hook (post-checkout/merge/rewrite) that regenerates opal's `dist` CSS when design tokens or opal CSS change — fixes the "boxy" UI (corners/borders/spacing lose their radius) after pulling token changes without reinstalling, because `bun install` won't rebuild an already-linked `file:` dep's gitignored `dist`, so `var(--radius-*)` resolves to nothing.
- Exclude `lib/opal/dist` + `lib/shared/dist` from the web image build context so a stale local `dist` can't leak into a hand-built image. CI is unaffected (clean clones have no `dist`; `prepare` rebuilds it during `bun install`).

## How Has This Been Tested?

- `pre-commit validate-config` passes; the hook command runs end-to-end and regenerates `dist/root.css` with the `--radius-*` vars. Reproduced the Docker build with `dist` excluded — `prepare` rebuilds it byte-identically and the lockfile stays frozen. The hook never runs in CI (post-* stages only) and writes only to gitignored `dist/` (no tree noise). Local edits remain covered by the shared watcher (`bun run --cwd web/lib/shared dev`).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically rebuild opal’s `dist` CSS after checkout/merge to keep design tokens fresh and fix the “boxy” UI in dev. Also exclude local `dist` folders from the web Docker build context to prevent stale artifacts in hand-built images.

- **Bug Fixes**
  - Added `opal-css-rebuild` hook (post-checkout/merge/rewrite) to regenerate opal CSS when tokens or opal CSS change; keeps `var(--radius-*)` working and avoids the “boxy” UI; runs the bundler with `bun` for toolchain consistency (drops implicit `node`); does not run in CI.
  - Excluded `lib/opal/dist` and `lib/shared/dist` from the web image build context to prevent stale local `dist` from leaking into images; CI remains clean via `prepare` on install.

<sup>Written for commit fe4aacf1d9aa18e6273e326ec3c22895f50a1285. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

