### PR TITLE
feat(auth): add mobile bearer-token auth gateway

### DIFF
--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -45,6 +45,7 @@ from fastapi_users import models
 from fastapi_users import schemas
 from fastapi_users import UUIDIDMixin
 from fastapi_users.authentication import AuthenticationBackend
+from fastapi_users.authentication import BearerTransport
 from fastapi_users.authentication import CookieTransport
 from fastapi_users.authentication import JWTStrategy
 from fastapi_users.authentication import (
@@ -1329,6 +1330,13 @@ cookie_transport = CookieTransport(
     cookie_name=FASTAPI_USERS_AUTH_COOKIE_NAME,
 )
 
+# Native mobile clients can't use the HttpOnly auth cookie above, so they
+# authenticate with the SAME stateful session token returned/refreshed as a
+# Bearer value (Authorization header) via this transport. `tokenUrl` is only
+# used for OpenAPI docs. The token itself is identical to the web cookie value
+# (see `mobile_auth_backend` below). See docs/mobile-auth/.
+bearer_transport = BearerTransport(tokenUrl="auth/mobile/login")
+
 
 T = TypeVar("T", covariant=True)
 ID = TypeVar("ID", contravariant=True)
@@ -1559,6 +1567,17 @@ elif AUTH_BACKEND == AuthBackend.JWT:
 else:
     raise ValueError(f"Invalid auth backend: {AUTH_BACKEND}")
 
+# Second backend for native mobile clients: same strategy (so it mints/reads
+# the exact same stateful session token as the cookie backend), but delivered
+# as a Bearer token. fastapi-users namespaces router names by backend name
+# (`auth:mobile-bearer.*`), so the mobile login/refresh/logout routers never
+# collide with the cookie backend's routes. See docs/mobile-auth/.
+mobile_auth_backend = AuthenticationBackend(
+    name="mobile-bearer",
+    transport=bearer_transport,
+    get_strategy=auth_backend.get_strategy,
+)
+
 
 class FastAPIUserWithLogoutRouter(FastAPIUsers[models.UP, models.ID]):
     def get_logout_router(
@@ -1682,7 +1701,7 @@ class FastAPIUserWithLogoutRouter(FastAPIUsers[models.UP, models.ID]):
 
 
 fastapi_users = FastAPIUserWithLogoutRouter[User, uuid.UUID](
-    get_user_manager, [auth_backend]
+    get_user_manager, [auth_backend, mobile_auth_backend]
 )
 
 

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -1334,7 +1334,7 @@ cookie_transport = CookieTransport(
 # authenticate with the SAME stateful session token returned/refreshed as a
 # Bearer value (Authorization header) via this transport. `tokenUrl` is only
 # used for OpenAPI docs. The token itself is identical to the web cookie value
-# (see `mobile_auth_backend` below). See docs/mobile-auth/.
+# (see `mobile_auth_backend` below).
 #
 # API keys / PATs also ride in the Authorization header; for those the session
 # strategy's read_token simply finds nothing and the request falls through to
@@ -1575,7 +1575,7 @@ else:
 # the exact same stateful session token as the cookie backend), but delivered
 # as a Bearer token. fastapi-users namespaces router names by backend name
 # (`auth:mobile-bearer.*`), so the mobile login/refresh/logout routers never
-# collide with the cookie backend's routes. See docs/mobile-auth/.
+# collide with the cookie backend's routes.
 mobile_auth_backend = AuthenticationBackend(
     name="mobile-bearer",
     transport=bearer_transport,

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -1599,15 +1599,65 @@ elif AUTH_BACKEND == AuthBackend.JWT:
 else:
     raise ValueError(f"Invalid auth backend: {AUTH_BACKEND}")
 
-# Second backend for native mobile clients: same strategy (so it mints/reads
-# the exact same stateful session token as the cookie backend), but delivered
-# as a Bearer token. fastapi-users namespaces router names by backend name
-# (`auth:mobile-bearer.*`), so the mobile login/refresh/logout routers never
-# collide with the cookie backend's routes. See docs/mobile-auth/.
+
+class _DefensiveReadStrategy(Strategy[User, uuid.UUID]):
+    """Wraps the active session strategy for the mobile bearer backend.
+
+    Unlike the web cookie, the Authorization header is also where Onyx API keys
+    and PATs ride, and a client may send an arbitrary/garbage bearer token. Such
+    a token reaches `read_token` and triggers a backing-store lookup that should
+    simply fail closed (no user) — but a transient store error there (e.g. a
+    stale async Redis connection bound to another event loop) would otherwise
+    surface as a 500 on every such request. Treat any read failure as
+    "unauthenticated" so the request falls through to the API-key/PAT handlers
+    (or a clean 401). Issuance / revocation delegate unchanged, so mobile mints
+    and reads the exact same stateful session token as web; the cookie backend
+    keeps the strict strategy. See docs/mobile-auth/.
+    """
+
+    def __init__(self, inner: Strategy[User, uuid.UUID]) -> None:
+        self._inner = inner
+
+    async def read_token(
+        self, token: Optional[str], user_manager: BaseUserManager[User, uuid.UUID]
+    ) -> Optional[User]:
+        try:
+            return await self._inner.read_token(token, user_manager)
+        except Exception:
+            logger.exception(
+                "Mobile bearer token read failed; treating request as unauthenticated"
+            )
+            return None
+
+    async def write_token(self, user: User) -> str:
+        return await self._inner.write_token(user)
+
+    async def destroy_token(self, token: str, user: User) -> None:
+        await self._inner.destroy_token(token, user)
+
+    async def refresh_token(self, token: Optional[str], user: User) -> str:
+        refresh = getattr(self._inner, "refresh_token", None)
+        if refresh is None:
+            return await self._inner.write_token(user)
+        return await refresh(token, user)
+
+
+def get_mobile_bearer_strategy(
+    strategy: Strategy[User, uuid.UUID] = Depends(auth_backend.get_strategy),
+) -> _DefensiveReadStrategy:
+    return _DefensiveReadStrategy(strategy)
+
+
+# Second backend for native mobile clients: reuses the active session strategy
+# (so it mints/reads the exact same stateful session token as the cookie
+# backend) wrapped so a failed bearer read fails closed instead of 500-ing, but
+# delivered as a Bearer token. fastapi-users namespaces router names by backend
+# name (`auth:mobile-bearer.*`), so the mobile login/refresh/logout routers
+# never collide with the cookie backend's routes. See docs/mobile-auth/.
 mobile_auth_backend = AuthenticationBackend(
     name="mobile-bearer",
     transport=bearer_transport,
-    get_strategy=auth_backend.get_strategy,
+    get_strategy=get_mobile_bearer_strategy,
 )
 
 

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -37,7 +37,6 @@ from fastapi import WebSocket
 from fastapi.responses import JSONResponse
 from fastapi.responses import RedirectResponse
 from fastapi.routing import APIRoute
-from fastapi.security import OAuth2PasswordBearer
 from fastapi.security import OAuth2PasswordRequestForm
 from fastapi_users import BaseUserManager
 from fastapi_users import exceptions
@@ -77,9 +76,6 @@ from sqlalchemy.orm import Session
 from starlette.routing import BaseRoute
 
 from onyx.auth.api_key import get_hashed_api_key_from_request
-from onyx.auth.constants import API_KEY_PREFIX
-from onyx.auth.constants import DEPRECATED_API_KEY_PREFIX
-from onyx.auth.constants import PAT_PREFIX
 from onyx.auth.disposable_email_validator import is_disposable_email
 from onyx.auth.email_utils import send_forgot_password_email
 from onyx.auth.email_utils import send_user_verification_email
@@ -1334,40 +1330,16 @@ cookie_transport = CookieTransport(
     cookie_name=FASTAPI_USERS_AUTH_COOKIE_NAME,
 )
 
-# Onyx API keys (`on_`/`dn_`) and PATs (`onyx_pat_`) also arrive in the
-# Authorization header, but they are resolved by Onyx's own dependencies
-# (`get_hashed_api_key_from_request` / `get_hashed_pat_from_request`), NOT the
-# fastapi-users session strategy. Without this filter the mobile bearer backend
-# would extract those tokens and run the session strategy's `read_token` (a
-# Redis/DB lookup) against every API-key/PAT request — a wasteful (and, against
-# a stale Redis connection, failing) lookup. Returning None for them makes
-# fastapi-users skip the strategy entirely, leaving them to their own handlers.
-_NON_SESSION_BEARER_PREFIXES = (
-    API_KEY_PREFIX,
-    DEPRECATED_API_KEY_PREFIX,
-    PAT_PREFIX,
-)
-
-
-class _SessionOnlyBearerScheme(OAuth2PasswordBearer):
-    """Bearer scheme that only surfaces fastapi-users session tokens."""
-
-    async def __call__(self, request: Request) -> str | None:
-        token = await super().__call__(request)
-        if token is not None and token.startswith(_NON_SESSION_BEARER_PREFIXES):
-            return None
-        return token
-
-
 # Native mobile clients can't use the HttpOnly auth cookie above, so they
 # authenticate with the SAME stateful session token returned/refreshed as a
 # Bearer value (Authorization header) via this transport. `tokenUrl` is only
 # used for OpenAPI docs. The token itself is identical to the web cookie value
 # (see `mobile_auth_backend` below). See docs/mobile-auth/.
+#
+# API keys / PATs also ride in the Authorization header; for those the session
+# strategy's read_token simply finds nothing and the request falls through to
+# Onyx's own API-key/PAT handlers (see `optional_user`).
 bearer_transport = BearerTransport(tokenUrl="auth/mobile/login")
-bearer_transport.scheme = _SessionOnlyBearerScheme(
-    tokenUrl="auth/mobile/login", auto_error=False
-)
 
 
 T = TypeVar("T", covariant=True)
@@ -1599,65 +1571,15 @@ elif AUTH_BACKEND == AuthBackend.JWT:
 else:
     raise ValueError(f"Invalid auth backend: {AUTH_BACKEND}")
 
-
-class _DefensiveReadStrategy(Strategy[User, uuid.UUID]):
-    """Wraps the active session strategy for the mobile bearer backend.
-
-    Unlike the web cookie, the Authorization header is also where Onyx API keys
-    and PATs ride, and a client may send an arbitrary/garbage bearer token. Such
-    a token reaches `read_token` and triggers a backing-store lookup that should
-    simply fail closed (no user) — but a transient store error there (e.g. a
-    stale async Redis connection bound to another event loop) would otherwise
-    surface as a 500 on every such request. Treat any read failure as
-    "unauthenticated" so the request falls through to the API-key/PAT handlers
-    (or a clean 401). Issuance / revocation delegate unchanged, so mobile mints
-    and reads the exact same stateful session token as web; the cookie backend
-    keeps the strict strategy. See docs/mobile-auth/.
-    """
-
-    def __init__(self, inner: Strategy[User, uuid.UUID]) -> None:
-        self._inner = inner
-
-    async def read_token(
-        self, token: Optional[str], user_manager: BaseUserManager[User, uuid.UUID]
-    ) -> Optional[User]:
-        try:
-            return await self._inner.read_token(token, user_manager)
-        except Exception:
-            logger.exception(
-                "Mobile bearer token read failed; treating request as unauthenticated"
-            )
-            return None
-
-    async def write_token(self, user: User) -> str:
-        return await self._inner.write_token(user)
-
-    async def destroy_token(self, token: str, user: User) -> None:
-        await self._inner.destroy_token(token, user)
-
-    async def refresh_token(self, token: Optional[str], user: User) -> str:
-        refresh = getattr(self._inner, "refresh_token", None)
-        if refresh is None:
-            return await self._inner.write_token(user)
-        return await refresh(token, user)
-
-
-def get_mobile_bearer_strategy(
-    strategy: Strategy[User, uuid.UUID] = Depends(auth_backend.get_strategy),
-) -> _DefensiveReadStrategy:
-    return _DefensiveReadStrategy(strategy)
-
-
-# Second backend for native mobile clients: reuses the active session strategy
-# (so it mints/reads the exact same stateful session token as the cookie
-# backend) wrapped so a failed bearer read fails closed instead of 500-ing, but
-# delivered as a Bearer token. fastapi-users namespaces router names by backend
-# name (`auth:mobile-bearer.*`), so the mobile login/refresh/logout routers
-# never collide with the cookie backend's routes. See docs/mobile-auth/.
+# Second backend for native mobile clients: same strategy (so it mints/reads
+# the exact same stateful session token as the cookie backend), but delivered
+# as a Bearer token. fastapi-users namespaces router names by backend name
+# (`auth:mobile-bearer.*`), so the mobile login/refresh/logout routers never
+# collide with the cookie backend's routes. See docs/mobile-auth/.
 mobile_auth_backend = AuthenticationBackend(
     name="mobile-bearer",
     transport=bearer_transport,
-    get_strategy=get_mobile_bearer_strategy,
+    get_strategy=auth_backend.get_strategy,
 )
 
 

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -37,6 +37,7 @@ from fastapi import WebSocket
 from fastapi.responses import JSONResponse
 from fastapi.responses import RedirectResponse
 from fastapi.routing import APIRoute
+from fastapi.security import OAuth2PasswordBearer
 from fastapi.security import OAuth2PasswordRequestForm
 from fastapi_users import BaseUserManager
 from fastapi_users import exceptions
@@ -76,6 +77,9 @@ from sqlalchemy.orm import Session
 from starlette.routing import BaseRoute
 
 from onyx.auth.api_key import get_hashed_api_key_from_request
+from onyx.auth.constants import API_KEY_PREFIX
+from onyx.auth.constants import DEPRECATED_API_KEY_PREFIX
+from onyx.auth.constants import PAT_PREFIX
 from onyx.auth.disposable_email_validator import is_disposable_email
 from onyx.auth.email_utils import send_forgot_password_email
 from onyx.auth.email_utils import send_user_verification_email
@@ -1330,12 +1334,40 @@ cookie_transport = CookieTransport(
     cookie_name=FASTAPI_USERS_AUTH_COOKIE_NAME,
 )
 
+# Onyx API keys (`on_`/`dn_`) and PATs (`onyx_pat_`) also arrive in the
+# Authorization header, but they are resolved by Onyx's own dependencies
+# (`get_hashed_api_key_from_request` / `get_hashed_pat_from_request`), NOT the
+# fastapi-users session strategy. Without this filter the mobile bearer backend
+# would extract those tokens and run the session strategy's `read_token` (a
+# Redis/DB lookup) against every API-key/PAT request — a wasteful (and, against
+# a stale Redis connection, failing) lookup. Returning None for them makes
+# fastapi-users skip the strategy entirely, leaving them to their own handlers.
+_NON_SESSION_BEARER_PREFIXES = (
+    API_KEY_PREFIX,
+    DEPRECATED_API_KEY_PREFIX,
+    PAT_PREFIX,
+)
+
+
+class _SessionOnlyBearerScheme(OAuth2PasswordBearer):
+    """Bearer scheme that only surfaces fastapi-users session tokens."""
+
+    async def __call__(self, request: Request) -> str | None:
+        token = await super().__call__(request)
+        if token is not None and token.startswith(_NON_SESSION_BEARER_PREFIXES):
+            return None
+        return token
+
+
 # Native mobile clients can't use the HttpOnly auth cookie above, so they
 # authenticate with the SAME stateful session token returned/refreshed as a
 # Bearer value (Authorization header) via this transport. `tokenUrl` is only
 # used for OpenAPI docs. The token itself is identical to the web cookie value
 # (see `mobile_auth_backend` below). See docs/mobile-auth/.
 bearer_transport = BearerTransport(tokenUrl="auth/mobile/login")
+bearer_transport.scheme = _SessionOnlyBearerScheme(
+    tokenUrl="auth/mobile/login", auto_error=False
+)
 
 
 T = TypeVar("T", covariant=True)

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -601,7 +601,6 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
 
         # Native mobile clients: same email/password auth, but the session
         # token is issued/refreshed/revoked as a Bearer instead of a cookie.
-        # See docs/mobile-auth/.
         include_auth_router_with_prefix(
             application,
             get_mobile_auth_router(),

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -71,6 +71,7 @@ from onyx.server.api_key.api import router as api_key_router
 from onyx.server.auth.captcha_api import CaptchaCookieMiddleware
 from onyx.server.auth.captcha_api import LoginCaptchaMiddleware
 from onyx.server.auth.captcha_api import router as captcha_router
+from onyx.server.auth.mobile import get_mobile_auth_router
 from onyx.server.auth_check import check_router_auth
 from onyx.server.documents.cc_pair import router as cc_pair_router
 from onyx.server.documents.connector import router as connector_router
@@ -596,6 +597,15 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
             application,
             fastapi_users.get_users_router(UserRead, UserUpdate),
             prefix="/users",
+        )
+
+        # Native mobile clients: same email/password auth, but the session
+        # token is issued/refreshed/revoked as a Bearer instead of a cookie.
+        # See docs/mobile-auth/.
+        include_auth_router_with_prefix(
+            application,
+            get_mobile_auth_router(),
+            prefix="/auth/mobile",
         )
 
     # Register Google OAuth when AUTH_TYPE is GOOGLE_OAUTH, or when

--- a/backend/onyx/redis/redis_pool.py
+++ b/backend/onyx/redis/redis_pool.py
@@ -294,57 +294,82 @@ SSL_CERT_REQS_MAP = {
 }
 
 
-_async_redis_connection: aioredis.Redis | None = None
-_async_lock = asyncio.Lock()
+# Async Redis connections are cached PER EVENT LOOP, not globally. redis-py binds
+# a connection's socket and its asyncio Futures to the loop that first used it, so
+# a single client reused across loops raises "got Future attached to a different
+# loop" (e.g. an auth-token lookup running under a loop other than the one that
+# created the client). Keying by the running loop gives each loop its own client;
+# entries for closed loops (e.g. short-lived loops from asyncio.run in tests /
+# sync workers) are pruned so the map can't grow unbounded. The guard is a plain
+# threading.Lock, NOT an asyncio.Lock (which is itself loop-bound); the
+# aioredis.Redis(...) constructor opens no sockets, so building it under a sync
+# lock is safe.
+_async_redis_connections: dict["asyncio.AbstractEventLoop", aioredis.Redis] = {}
+_async_redis_init_lock = threading.Lock()
+
+
+def _build_async_redis_connection() -> aioredis.Redis:
+    connection_kwargs: dict[str, Any] = {
+        "host": REDIS_HOST,
+        "port": REDIS_PORT,
+        "db": REDIS_DB_NUMBER,
+        "password": REDIS_PASSWORD,
+        "max_connections": REDIS_POOL_MAX_CONNECTIONS,
+        "health_check_interval": REDIS_HEALTH_CHECK_INTERVAL,
+        "socket_keepalive": True,
+        "socket_keepalive_options": REDIS_SOCKET_KEEPALIVE_OPTIONS,
+    }
+
+    if USE_REDIS_IAM_AUTH:
+        configure_redis_iam_auth(connection_kwargs)
+    elif REDIS_SSL:
+        ssl_context = ssl.create_default_context()
+
+        if REDIS_SSL_CA_CERTS:
+            ssl_context.load_verify_locations(REDIS_SSL_CA_CERTS)
+        ssl_context.check_hostname = False
+
+        # Map your string to the proper ssl.CERT_* constant
+        ssl_context.verify_mode = SSL_CERT_REQS_MAP.get(
+            REDIS_SSL_CERT_REQS, ssl.CERT_NONE
+        )
+
+        connection_kwargs["ssl"] = ssl_context
+
+    # Create a new Redis connection (or connection pool) with SSL configuration
+    return aioredis.Redis(**connection_kwargs)
 
 
 async def get_async_redis_connection() -> aioredis.Redis:
     """
-    Provides a shared async Redis connection, using the same configs (host, port, SSL, etc.).
-    Ensures that the connection is created only once (lazily) and reused for all future calls.
+    Provides a shared async Redis connection for the current event loop, using the
+    same configs (host, port, SSL, etc.). The connection is created lazily once per
+    loop and reused for all future calls on that loop.
     """
-    global _async_redis_connection
+    loop = asyncio.get_running_loop()
 
-    # If we haven't yet created an async Redis connection, we need to create one
-    if _async_redis_connection is None:
-        # Acquire the lock to ensure that only one coroutine attempts to create the connection
-        async with _async_lock:
-            # Double-check inside the lock to avoid race conditions
-            if _async_redis_connection is None:
-                # Load env vars or your config variables
+    # Fast path: a connection already exists for this loop.
+    existing = _async_redis_connections.get(loop)
+    if existing is not None:
+        return existing
 
-                connection_kwargs: dict[str, Any] = {
-                    "host": REDIS_HOST,
-                    "port": REDIS_PORT,
-                    "db": REDIS_DB_NUMBER,
-                    "password": REDIS_PASSWORD,
-                    "max_connections": REDIS_POOL_MAX_CONNECTIONS,
-                    "health_check_interval": REDIS_HEALTH_CHECK_INTERVAL,
-                    "socket_keepalive": True,
-                    "socket_keepalive_options": REDIS_SOCKET_KEEPALIVE_OPTIONS,
-                }
+    with _async_redis_init_lock:
+        # Double-check inside the lock to avoid creating two clients for the loop.
+        existing = _async_redis_connections.get(loop)
+        if existing is not None:
+            return existing
 
-                if USE_REDIS_IAM_AUTH:
-                    configure_redis_iam_auth(connection_kwargs)
-                elif REDIS_SSL:
-                    ssl_context = ssl.create_default_context()
+        # Drop connections whose loop has been closed so the map stays bounded.
+        for dead_loop in [
+            cached_loop
+            for cached_loop in _async_redis_connections
+            if cached_loop.is_closed()
+        ]:
+            _async_redis_connections.pop(dead_loop, None)
 
-                    if REDIS_SSL_CA_CERTS:
-                        ssl_context.load_verify_locations(REDIS_SSL_CA_CERTS)
-                    ssl_context.check_hostname = False
-
-                    # Map your string to the proper ssl.CERT_* constant
-                    ssl_context.verify_mode = SSL_CERT_REQS_MAP.get(
-                        REDIS_SSL_CERT_REQS, ssl.CERT_NONE
-                    )
-
-                    connection_kwargs["ssl"] = ssl_context
-
-                # Create a new Redis connection (or connection pool) with SSL configuration
-                _async_redis_connection = aioredis.Redis(**connection_kwargs)
-
-    # Return the established connection (or pool) for all future operations
-    return _async_redis_connection
+        connection = _build_async_redis_connection()
+        _async_redis_connections[loop] = connection
+        return connection
 
 
 async def retrieve_auth_token_data(token: str) -> dict | None:

--- a/backend/onyx/redis/redis_pool.py
+++ b/backend/onyx/redis/redis_pool.py
@@ -359,7 +359,10 @@ async def get_async_redis_connection() -> aioredis.Redis:
         if existing is not None:
             return existing
 
-        # Drop connections whose loop has been closed so the map stays bounded.
+        # Drop entries for closed loops to keep the map bounded. We can't
+        # aclose() them (their connections are bound to the now-dead loop), so
+        # we drop the reference and let GC reclaim the sockets. Only the
+        # long-lived server loop matters in prod; it never closes.
         for dead_loop in [
             cached_loop
             for cached_loop in _async_redis_connections

--- a/backend/onyx/server/auth/mobile.py
+++ b/backend/onyx/server/auth/mobile.py
@@ -8,8 +8,6 @@ surface.
 V1 (this PR): email/password login, refresh, and logout, mounted from the
 shared fastapi-users machinery against the `mobile-bearer` backend. The Google
 SSO bridge (`/auth/mobile/sso/exchange`) is added in a later PR.
-
-See docs/mobile-auth/.
 """
 
 from fastapi import APIRouter

--- a/backend/onyx/server/auth/mobile.py
+++ b/backend/onyx/server/auth/mobile.py
@@ -1,0 +1,38 @@
+"""Mobile auth gateway.
+
+Native mobile clients (Expo / React Native) authenticate against the SAME
+backend as web, but receive the existing stateful session token as a Bearer
+value instead of an HttpOnly cookie. This module owns the mobile-facing auth
+surface.
+
+V1 (this PR): email/password login, refresh, and logout, mounted from the
+shared fastapi-users machinery against the `mobile-bearer` backend. The Google
+SSO bridge (`/auth/mobile/sso/exchange`) is added in a later PR.
+
+See docs/mobile-auth/.
+"""
+
+from fastapi import APIRouter
+
+from onyx.auth.users import fastapi_users
+from onyx.auth.users import mobile_auth_backend
+
+
+def get_mobile_auth_router() -> APIRouter:
+    """Build the `/auth/mobile` router (prefix applied at registration).
+
+    Exposes:
+      - POST /auth/mobile/login   email/password -> {access_token, token_type}
+      - POST /auth/mobile/logout  revoke the current session token
+      - POST /auth/mobile/refresh extend / reissue the session token
+
+    All three reuse the existing session strategy (so the Bearer token is the
+    exact same revocable token web gets) — only the transport differs. Routes
+    are namespaced `auth:mobile-bearer.*`, so they never collide with the web
+    cookie backend's `auth:<backend>.*` routes.
+    """
+    router = APIRouter()
+    # get_auth_router provides both /login and /logout for the bearer backend.
+    router.include_router(fastapi_users.get_auth_router(mobile_auth_backend))
+    router.include_router(fastapi_users.get_refresh_router(mobile_auth_backend))
+    return router

--- a/backend/onyx/server/auth_check.py
+++ b/backend/onyx/server/auth_check.py
@@ -47,6 +47,13 @@ PUBLIC_ENDPOINT_SPECS = [
     ("/auth/reset-password", {"POST"}),
     ("/auth/request-verify-token", {"POST"}),
     ("/auth/verify", {"POST"}),
+    # native mobile bearer-token auth — mirrors the basic-auth routes above,
+    # but the session token is delivered as a Bearer instead of a cookie.
+    # (refresh/logout still enforce the token via their own dependencies;
+    # listing them here only satisfies the startup public-route assertion.)
+    ("/auth/mobile/login", {"POST"}),
+    ("/auth/mobile/refresh", {"POST"}),
+    ("/auth/mobile/logout", {"POST"}),
     ("/users/me", {"GET"}),
     ("/users/me", {"PATCH"}),
     ("/users/{id}", {"GET"}),

--- a/backend/tests/integration/tests/mobile_auth/test_mobile_bearer_auth.py
+++ b/backend/tests/integration/tests/mobile_auth/test_mobile_bearer_auth.py
@@ -1,0 +1,94 @@
+"""Integration tests for the mobile bearer-token auth gateway (PR 1).
+
+Verifies that a native client can obtain / use / refresh / revoke the existing
+session token as a Bearer (Authorization header) instead of the web cookie,
+and that the web cookie flow is unaffected. See docs/mobile-auth/.
+"""
+
+import httpx
+
+from onyx.configs.constants import FASTAPI_USERS_AUTH_COOKIE_NAME
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.constants import GENERAL_HEADERS
+from tests.integration.common_utils.http_client import client
+from tests.integration.common_utils.test_models import DATestUser
+
+
+def _mobile_login(email: str, password: str) -> httpx.Response:
+    # Form-encoded credentials, exactly like the web /auth/login.
+    headers = GENERAL_HEADERS.copy()
+    headers.pop("Content-Type", None)
+    return client.post(
+        url=f"{API_SERVER_URL}/auth/mobile/login",
+        data={"username": email, "password": password},
+        headers=headers,
+    )
+
+
+def _bearer(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_mobile_bearer_login_refresh_logout(admin_user: DATestUser) -> None:
+    # 1) Mobile login returns a Bearer token as JSON — and must NOT set the web
+    #    auth cookie (a native client can't use HttpOnly cookies).
+    resp = _mobile_login(admin_user.email, admin_user.password)
+    resp.raise_for_status()
+    body = resp.json()
+    assert body["token_type"].lower() == "bearer"
+    token = body["access_token"]
+    assert token
+    assert FASTAPI_USERS_AUTH_COOKIE_NAME not in resp.cookies
+    # The shared client jar must not carry a session cookie into later calls;
+    # we authenticate purely via the Bearer header.
+    client.cookies.clear()
+
+    # 2) The Bearer token authenticates /me.
+    me = client.get(url=f"{API_SERVER_URL}/me", headers=_bearer(token))
+    me.raise_for_status()
+    assert me.json()["email"] == admin_user.email
+
+    # 3) Refresh returns a usable token (redis/postgres extend the same token;
+    #    either way the returned token must authenticate).
+    refreshed = client.post(
+        url=f"{API_SERVER_URL}/auth/mobile/refresh", headers=_bearer(token)
+    )
+    refreshed.raise_for_status()
+    new_token = refreshed.json()["access_token"]
+    assert new_token
+    client.cookies.clear()
+    me2 = client.get(url=f"{API_SERVER_URL}/me", headers=_bearer(new_token))
+    me2.raise_for_status()
+
+    # 4) Logout revokes the token server-side; reuse is rejected.
+    logout = client.post(
+        url=f"{API_SERVER_URL}/auth/mobile/logout", headers=_bearer(new_token)
+    )
+    logout.raise_for_status()
+    client.cookies.clear()
+    # The revoked token must no longer authenticate (unauthenticated /me is
+    # rejected — 403 in this deployment, 401 in others; both mean "rejected").
+    me3 = client.get(url=f"{API_SERVER_URL}/me", headers=_bearer(new_token))
+    assert me3.status_code in (401, 403)
+
+
+def test_mobile_bearer_login_bad_credentials(admin_user: DATestUser) -> None:
+    resp = _mobile_login(admin_user.email, "definitely-not-the-password")
+    # fastapi-users returns 400 LOGIN_BAD_CREDENTIALS; accept 401 defensively.
+    assert resp.status_code in (400, 401)
+    assert "access_token" not in resp.json()
+
+
+def test_web_cookie_login_still_works(admin_user: DATestUser) -> None:
+    # Regression guard: adding the mobile bearer backend must not disturb the
+    # existing web cookie login.
+    headers = admin_user.headers.copy()
+    headers.pop("Content-Type", None)
+    resp = client.post(
+        url=f"{API_SERVER_URL}/auth/login",
+        data={"username": admin_user.email, "password": admin_user.password},
+        headers=headers,
+    )
+    resp.raise_for_status()
+    assert resp.cookies.get(FASTAPI_USERS_AUTH_COOKIE_NAME)
+    client.cookies.clear()

--- a/backend/tests/integration/tests/mobile_auth/test_mobile_bearer_auth.py
+++ b/backend/tests/integration/tests/mobile_auth/test_mobile_bearer_auth.py
@@ -2,7 +2,7 @@
 
 Verifies that a native client can obtain / use / refresh / revoke the existing
 session token as a Bearer (Authorization header) instead of the web cookie,
-and that the web cookie flow is unaffected. See docs/mobile-auth/.
+and that the web cookie flow is unaffected.
 """
 
 import httpx

--- a/docs/mobile-auth/00-index.md
+++ b/docs/mobile-auth/00-index.md
@@ -1,0 +1,15 @@
+> Status: active · Task: mobile-auth
+
+# Mobile Authentication — Spec Index
+
+Onyx mobile app (Expo / React Native) authentication. **Approach C — Mobile Auth Gateway (BFF)**: native Bearer auth reusing the existing revocable session token behind an `issue_session_credential` seam + a provider registry. **V1 = email/password + Google**, against **Onyx Cloud + self-hosted**, with **PKCE on the deep-link exchange**. SAML / OIDC / Apple Sign In and refresh-token rotation are designed-for and deferred behind the seams.
+
+| # | Doc | What it covers |
+|---|-----|----------------|
+| 01 | [Research](01-research.md) | Requirement, clarifications, codebase scan (exact paths), web/industry findings, 3 approaches, chosen approach (C) |
+| 02 | [High-Level Design](02-high-level-design.md) | Plain-language end-to-end flow, component interaction, key decisions |
+| 03 | [Detailed Design](03-detailed-design.md) | New files, file tree, per-file contents, integration points, important notes (no DB changes in V1) |
+| 04 | [Implementation Plan](04-implementation-plan.md) | CLAUDE.md-format plan + Plan-Challenge results (RFC 8252 / RFC 9700 / BFF verified) |
+| 05 | [PR Roadmap](05-pr-roadmap.md) | 5 review-sized PRs with scope, files, tests, drift checkpoints |
+
+**Key locked decisions:** native Bearer (not webview-cookie) · reuse existing token, rotation deferred · backend SSO-bridge + one-time PKCE-bound code over `onyx://` deep link (host-agnostic) · reuse the already-registered IdP callback (no new redirect URI for self-hosted) · App Store 4.8 (Sign in with Apple) is an accepted V1 risk.

--- a/docs/mobile-auth/01-research.md
+++ b/docs/mobile-auth/01-research.md
@@ -1,0 +1,96 @@
+> Status: draft · Task: mobile-auth
+
+# Mobile Authentication — Research
+
+## Requirement
+
+Build authentication for the Onyx mobile app (Expo / React Native) in the spirit of the desktop app — **email/password + Google OAuth in V1**, with **SAML + OIDC (and Apple Sign In) added later** — validated against industry best practices and security standards.
+
+## Clarifications (verbatim Q&A)
+
+**Q1 — The desktop "pattern" is a thin WebView (cookie auth, no native code); the mobile foundation already chose native + Bearer-token + secure-store. Which path?**
+→ **Native auth.** Native login screens + Bearer token from `expo-secure-store`; reuse the SAME backend, adding small mobile-friendly token endpoints. OAuth/SAML/OIDC run in the system browser and return via deep link. (Explicitly NOT the webview-cookie approach.)
+
+**Q2 — Which backend(s) must V1 target? (Decides the OAuth redirect strategy.)**
+→ **Cloud + self-hosted both first-class in V1**, whatever complexity that adds. (This rules out relying on Universal/App Links alone — they only cover `cloud.onyx.app` — and pushes us to a host-agnostic backend SSO-bridge + deep-link return.)
+
+**Q3 — App Store Guideline 4.8 requires Sign in with Apple if Google is offered. Include SIWA in V1?**
+→ **No.** Google + email/password only for V1; handle Apple later / accept the App Store-rejection risk. (We still build the OAuth layer provider-generic so Apple slots in cheaply.)
+
+## Current status & reuse (from codebase scan — exact paths)
+
+### Backend (`backend/`) — fastapi-users 12.x, **cookie-transport only today**
+- **User model + OAuthAccount**: `backend/onyx/db/models.py:307-463`. `UserManager` + `FastAPIUsers` setup in `backend/onyx/auth/users.py`.
+- **Email/password**: `POST /auth/login` (`OAuth2PasswordRequestForm`) → **Set-Cookie `fastapiusersauth`** (HttpOnly, `samesite=lax`, `secure` if https), 7-day expiry. Router reg `backend/onyx/main.py:572-577`. `cookie_transport` `backend/onyx/auth/users.py:1326-1330`.
+- **⚠️ Transport is cookie-only.** All three auth backends use `CookieTransport`: redis (`users.py:1549`), postgres (`:1553`), jwt (`:1557`). **No `BearerTransport` is mounted.** The session **strategies** are transport-agnostic, though — `write_token`/`read_token`/`destroy_token`/`refresh_token` operate on raw token strings (`users.py:1363/1384/1400/1405`). So a Bearer transport / token-returning endpoint *can* be added cleanly, but it is **net-new work** — the earlier "bearer already supported" note was inaccurate.
+- **Auth backends** via `AUTH_BACKEND` env = `redis|postgres|jwt`; strategy selection `users.py:1539-1560`. Redis/Postgres = **stateful, server-side, revocable** opaque tokens (`secrets.token_urlsafe`, 7-day TTL = `SESSION_EXPIRE_TIME_SECONDS`). JWT = stateless, **not revocable** (its own docstring concedes this, `users.py:1463-1509`); JWT is **forbidden in multi-tenant/cloud** (`users.py:1540`).
+- **Refresh already exists**: `get_refresh_router` `users.py:1600-1681` (`POST /auth/refresh`); `TenantAwareRedisStrategy.refresh_token` `:1405-1428` extends TTL in place; returns via `backend.transport.get_login_response` (`:1661`). Web calls it every 10 min (not for SAML/OIDC).
+- **Google OAuth**: `GET /auth/oauth/authorize` → `{authorization_url}` (sets STATE+CSRF cookies); `GET /auth/oauth/callback` exchanges code, upserts user by email, calls `backend.login()` → cookie. Redirect hardcoded `f'{WEB_DOMAIN}/auth/oauth/callback'`. Code `users.py:2183-2521`; `complete_login_flow` `users.py:2523-2607`; reg `main.py:601-626`. **Google path is non-PKCE** (the client secret lives server-side — correct for a public client).
+- **OIDC**: `GET /auth/oidc/{authorize,callback}`; PKCE optional via `OIDC_PKCE_ENABLED` (gen `users.py:2278-2295`); reg `main.py:636-665`.
+- **SAML** (`backend/onyx/server/saml.py:35-298`): `/auth/saml/authorize` → `{authorization_url}`, `/auth/saml/callback` (GET+POST), `/auth/saml/logout`; extracts email, upserts, `backend.login()` → cookie. Reg `main.py:674-678`. No native mobile SDK exists for SAML.
+- **AUTH_TYPE** enum `{basic, google_oauth, oidc, saml, cloud}` `backend/onyx/configs/constants.py:314-321`. Frontend discovers config via **`GET /auth/type`** (`AuthTypeMetadata`: `auth_type`, `requires_verification`, `password_min_length`, `oauth_enabled`, …) `backend/onyx/server/manage/get_state.py:34-59`.
+- **`/me`**: `backend/onyx/server/manage/users.py:885-954` → `UserInfo` (`models.py:122-202`); checks `oidc_expiry`.
+- **CORS**: `CORS_ALLOWED_ORIGIN` env; `'*'` disables credentials (`shared_configs/configs.py:146-170`, `main.py:699-712`). Irrelevant for a native client (no browser origin), but relevant if a webview were ever used.
+- **House rules** (CLAUDE.md): raise `OnyxError` (not `HTTPException`); new FastAPI endpoints are typed, **no `response_model`**; DB ops only under `backend/onyx/db` / `backend/ee/onyx/db`; alembic migrations written by hand.
+
+### Mobile (`mobile/`) — Expo SDK 56, RN 0.85, React 19.2, Expo Router, TanStack Query v5 + MMKV, Zustand, NativeWind v4, Bun
+- **`apiFetch`** `mobile/src/api/client.ts:41-43` **already injects `Authorization: Bearer <token>`** from `getToken()` (auth=true default); base URL from `EXPO_PUBLIC_API_URL` (`mobile/src/api/config.ts:21`, build-time, "runtime URL is future work"); errors normalized to `ApiError` (`mobile/src/api/errors.ts`, `isAuthError()` → 401/402/403).
+- **Token store** `mobile/src/api/auth/tokenStore.ts`: `expo-secure-store`, key `onyx.auth.access_token`, `getToken()`/`setToken()`. **Documented TODOs**: clear query cache + persister on logout; identity-scope the cache; encrypt the MMKV query cache (PII).
+- **`useCurrentUser`** `mobile/src/hooks/useCurrentUser.ts` → `GET /api/me`, query key `['me']`. `CurrentUser` type minimal (`mobile/src/api/types.ts`).
+- **Routing**: `mobile/src/app/_layout.tsx` is a bare `Stack` (`PersistQueryClientProvider`) — **NO auth-gate, no `(auth)` group, no redirect-to-login** yet. `index.tsx` is home.
+- **Query client** `mobile/src/query/client.ts`: retry skips 401/402/403. `focus.ts`/`online.ts` bridge `AppState`/NetInfo. MMKV instances (app + query-cache) `mobile/src/state/storage.ts`.
+- **`app.json`**: scheme **`onyx`**; bundle `app.onyx.mobile`. Deps present: `expo-secure-store` ~56.0.4, `expo-linking` ~56.0.13, `expo-constants`. **ABSENT**: `expo-auth-session`, `expo-web-browser`, `expo-crypto`.
+- Shared `@onyx-ai/shared/native`: design tokens (`varsLight`/`varsDark`), types `Page<T>`/`Result<T>`.
+
+### Desktop (`desktop/`) — reference only, do NOT copy
+- A **thin Tauri WebView** that loads `server_url` (default `https://cloud.onyx.app`, user-configurable via `config.json`, `src-tauri/src/main.rs:35,285`). **Zero native auth code** — login happens inside the webview via the web app's cookie session. Its one durable lesson for us: **"configurable server URL" (cloud + self-hosted) is an established product expectation.**
+
+## Industry best practices (web research — honor or consciously deviate)
+
+- **Auth Code + PKCE (S256) is MANDATORY** for public native clients (RFC 8252 "OAuth 2.0 for Native Apps"; RFC 9700 OAuth Security BCP, Jan 2025; OAuth 2.1 drops implicit). Never embed a client secret in the app — the secret-bearing token exchange must run on the backend. — https://www.rfc-editor.org/rfc/rfc8252.html , https://datatracker.ietf.org/doc/rfc9700/
+- **System browser only** (ASWebAuthenticationSession iOS / Chrome Custom Tabs Android); **embedded WebViews are forbidden** for OAuth (RFC 8252 §8.12 — host app can keylog). `expo-auth-session` + `expo-web-browser` implement the compliant path. — https://docs.expo.dev/guides/authentication/
+- **Bearer in `Authorization` header, not cookies**, for native. **Never put a token in a deep link** — return a short-lived single-use **code** on the deep link and exchange it over TLS. — https://reactnative.dev/docs/security
+- **Tokens only in `expo-secure-store`** (iOS Keychain / Android Keystore); never AsyncStorage/unencrypted MMKV (OWASP Mobile **M1** Improper Credential Usage / **M9** Insecure Storage). iOS Keychain **persists across app uninstall** and has **no bulk-clear** → delete explicitly on logout; use `keychainAccessible` `*_THIS_DEVICE_ONLY`. — https://mas.owasp.org/MASVS/ , https://docs.expo.dev/versions/latest/sdk/securestore/
+- **Short-lived access tokens (~5–15 min) + refresh-token ROTATION with reuse detection** (revoke the whole token family on replay) is a **MUST for public clients** per RFC 9700 §4.14. Pair with **single-flight** (serialized) refresh + **proactive** pre-expiry refresh (account for clock skew). Logout MUST revoke the refresh token server-side AND delete local secrets. — https://datatracker.ietf.org/doc/html/rfc9700 , https://auth0.com/docs/secure/tokens/refresh-tokens/refresh-token-rotation
+- **SAML has NO native mobile SDK.** Bridge it: open the backend's existing browser SAML/OIDC login in the system browser; on success the backend 302-redirects to the app's deep link with a one-time code the app exchanges for a token. Cheap because Onyx already terminates SAML/OIDC for web. Prefer **SP-initiated** over IdP-initiated. — https://workos.com/docs/integrations/react-native-expo , https://learn.microsoft.com/en-us/entra/identity-platform/scenario-token-exchange-saml-oauth
+- **Redirect URIs**: Universal Links (iOS) / App Links (Android) are safer than custom schemes (scheme hijacking) but **require domain ownership** — works for `cloud.onyx.app`, NOT arbitrary self-hosted. For self-hosted, a **custom scheme (`onyx://`) + PKCE + state + single-use short-TTL code + exact redirect-URI matching** is the pragmatic mitigation. Beware ASWebAuthenticationSession `prompt=none` silent-auth hijack — require user consent. — https://evanconnelly.github.io/post/ios-oauth/
+- **Expo specifics**: OAuth needs an **EAS Dev Build** (not Expo Go); use `AuthSession.makeRedirectUri()`; re-run `prebuild` after changing `expo.scheme`; register exact redirect URIs per build.
+- **Email/password**: never store the password (store only the token); **generic errors** to prevent account enumeration; rate-limit/throttle; optional breached-password check (Pwned Passwords k-anonymity); platform autofill / `textContentType`.
+- **App Store Guideline 4.8**: must offer **Sign in with Apple** if any third-party social login (Google) is offered — V1 Google-only is an accepted **rejection risk**.
+
+## Approaches
+
+### Approach A — Simplicity-First: "Bearer-the-Session"
+Reuse the existing stateful fastapi-users session token **verbatim** as the mobile Bearer value. Add the minimum: a `POST /auth/login/mobile` that returns the same session token as JSON (instead of Set-Cookie), and a one-time-code branch in `complete_login_flow` that, for `client=mobile`, mints a 60 s single-use Redis code and 302s to `onyx://auth/callback?code=…` (the app exchanges it at `POST /auth/oauth/mobile/exchange`). Refresh/logout reuse the existing `/auth/refresh` + `/auth/logout` (sliding 7-day TTL, server-revocable). On mobile: login screens, an auth-gate around the bare `Stack`, a deep-link handler, and the `tokenStore` hardening TODOs. **No new token type, table, or migration.**
+- **Token model**: one opaque 7-day server-side session token = access *and* session; **no separate refresh token, no rotation** in V1 (explicit deviation from RFC 9700, mitigated by server-side revocability + Keychain-only storage + token never in a URL).
+- **Effort**: smallest — backend ~150–250 LOC (no migration), mobile ~500–700 LOC, ~2 PRs.
+- **Risks**: no rotation/reuse-detection (7-day stolen-token window); one-time-code bridge assumes Redis (`AUTH_BACKEND=jwt` self-hosted has no Redis session — must gate or store the code in Postgres); multi-tenant login must run in the tenant middleware context.
+
+### Approach B — Scalability/Security-First: "Sentinel"
+Build a **purpose-built mobile token subsystem**: short-lived (~10 min) opaque access token + **rotating refresh token bound to a per-device token family with reuse detection**, exposed at `/auth/mobile/{token,refresh,revoke,sessions}`. New `mobile_session` table (one row per device → per-device revocation, a device-session list, audit fields: last_ip/UA/last_used_at) + hand-written migration; a `MobileTokenService`; a `BearerTransport`-backed authenticator composed with the existing cookie authenticator. OAuth/SAML/OIDC reuse the existing browser endpoints, swapping only the final "set cookie + 302 to WEB_DOMAIN" step for "mint one-time PKCE-bound code + 302 to the app." Mobile adds single-flight proactive refresh, biometric-gated refresh-token storage, and the auth-gate.
+- **Token model**: full RFC 9700 — ~10 min access + rotating refresh family, replay → revoke family + emit anomaly event; instant per-device server-side revocation; access validated O(1) in Redis, refresh durable in Postgres.
+- **Effort**: largest — backend ~900–1200 LOC (~5 PRs incl. model/migration/service/bridge/cleanup), mobile ~700–1000 LOC (~3–4 PRs); each later provider ~50–150 LOC.
+- **Risks**: reuse-detection false-positives on flaky networks (needs single-flight + server family-lock + grace window); per-refresh Postgres writes need indexing + a Celery cleanup task; biometric enrollment changes can lock users out (needs re-login fallback); most code on a security-critical path.
+
+### Approach C — Flexibility-First: "Mobile Auth Gateway (BFF)"
+Introduce **one thin gateway** in front of the existing machinery rather than forking it: a uniform browser-SSO pair `GET /auth/mobile/sso/{start,exchange}` + native bearer endpoints `POST /auth/mobile/{login,refresh,logout}`. Two seams carry all the variation: a backend **`BrowserSSOProvider` registry** (V1 = Google wrapping the existing OAuth logic; SAML/OIDC/Apple = later registry entries) and a one-function **`issue_session_credential(user)` token seam** (V1 wraps the existing stateful token via a mounted `BearerTransport`; a future rotation subsystem drops in behind it with no gateway/mobile change). Mobile gets one `SessionManager` + a `providerRegistry` (each provider = a tiny descriptor) over the existing `apiFetch`/`tokenStore`. Adding a provider later = one backend provider class + one mobile registry row + a button.
+- **Token model**: V1 reuses the existing **revocable 7-day stateful token as a Bearer** (consciously *not* shortened, since there's no refresh token yet); rotation is a **documented, deferred seam**, not built.
+- **Effort**: medium — backend ~400–600 LOC (~3 PRs: bearer backend + login/refresh/logout, provider registry + SSO start/exchange + code store, hardening), mobile ~600–900 LOC (~3 PRs); later providers well under one PR each.
+- **Risks**: a second `AuthenticationBackend` can collide with the cookie backend's route names (must namespace + not re-mount the stock auth router); same multi-tenant + custom-scheme-hijack caveats as A/B; one extra indirection layer for a 2-provider V1.
+
+## Cross-comparison
+
+- **Common to all three** (the decided, non-negotiable core): native screens; `Authorization: Bearer` (reuse `apiFetch`); `expo-secure-store` only; OAuth in the **system browser** (`expo-web-browser`) with a **host-agnostic backend one-time-code + `onyx://` deep-link** return (the only redirect strategy that serves cloud **and** self-hosted); add an auth-gate + `(auth)` route group; add `expo-auth-session`/`expo-web-browser`/`expo-crypto`; resolve the `tokenStore` logout/cache TODOs; needs an EAS Dev Build.
+- **The real fork is the credential model + how much structure to add**:
+  - **A** ships fastest and is simplest to reason about, but deviates from RFC 9700 (no rotation) and hardcodes the two V1 flows (later providers re-open OAuth code).
+  - **B** is the security/scale end-state (rotation, reuse-detection, per-device revocation, audit) but is the most new security-critical code + DB state for a 2-provider launch.
+  - **C** keeps the proven revocable token for V1 but formalizes a provider-registry + token-issuance seam, so SAML/OIDC/Apple and the rotation upgrade land later as config/one-function swaps rather than rewrites. It is the middle on effort and the best on future-change cost.
+- **All three converge to the same end-state** (B's rotating-family token reachable via A's "upgrade later" note or C's `issue_session_credential` seam) — they differ mainly in whether that security is built now (B) or seamed-for-later (A/C), and in how provider-extensibility is structured (ad-hoc in A, registry in C, generic-bridge in B).
+
+## Chosen approach
+
+**Approach C — Mobile Auth Gateway (BFF) with a Provider Registry + Token-Issuance Seam.**
+
+Rationale: the user's two stated futures — (1) more providers (SAML/OIDC/Apple) and (2) cloud + self-hosted both first-class — are exactly the changes C makes config-shaped (provider registry rows + runtime base URL), while reusing Onyx's existing, battle-tested auth core and keeping B's security as a clean upgrade path behind `issue_session_credential`.
+
+V1 credential decision: **reuse the existing revocable stateful session token, presented as a Bearer** (the seam keeps rotation deferrable). Rotation/reuse-detection (Approach B's subsystem) is explicitly **deferred**, not built — it lands later behind the `issue_session_credential` seam and a new `/auth/mobile/refresh` body, with no gateway or mobile rework.

--- a/docs/mobile-auth/02-high-level-design.md
+++ b/docs/mobile-auth/02-high-level-design.md
@@ -1,0 +1,112 @@
+> Status: active · Task: mobile-auth · Approach: C — Mobile Auth Gateway (BFF) with a Provider Registry + Token-Issuance Seam
+
+# Mobile Authentication — High-Level Design
+
+## What it does
+
+Lets a person sign in to the Onyx mobile app (Expo / React Native) with **email + password** or **Google**, against **either Onyx Cloud or their own self-hosted Onyx server**, and stay signed in securely. It is the first auth the mobile app has ever had: today the app has a token-injecting HTTP client and a `/api/me` hook but no way to *get* a token and no login screen. SAML, OIDC, and Sign in with Apple are designed to slot in later as small additions, not rewrites.
+
+## How it works (end-to-end walkthrough)
+
+The mobile app is a **native** client (not a webview). It authenticates by obtaining a **Bearer token** from the backend and sending it in the `Authorization` header on every request — the app's HTTP client (`mobile/src/api/client.ts`) already does this injection; it just never had a token to inject. The token it gets is the **same stateful, server-side, revocable session token Onyx already issues to the web app** — we simply hand it to the mobile client as a Bearer value instead of a browser cookie.
+
+Three things make this work end-to-end:
+
+1. **A second "transport" on the existing backend auth.** Onyx's auth (fastapi-users) currently returns its session token only as a `Set-Cookie` (a "cookie transport"). We add a parallel **Bearer transport** that returns the *same* token as JSON (`{access_token, token_type}`). This gives the mobile app three endpoints essentially for free — `POST /auth/mobile/login` (email/password → token JSON), `POST /auth/mobile/refresh` (extend the session), `POST /auth/mobile/logout` (revoke it) — because the backend's auth framework already knows how to build these routers for any transport. The token itself is unchanged, so the rest of the backend keeps authenticating requests exactly as before.
+
+2. **A backend "SSO bridge" for Google (and later SAML/OIDC/Apple).** A native app must run OAuth in the **system browser**, never an embedded webview (this is a hard security rule — RFC 8252). So when the user taps "Continue with Google," the app first generates a **PKCE pair** (a random `code_verifier` it keeps in memory + its SHA-256 `code_challenge`), then opens the system browser at the backend's **existing** Google authorize URL with three extra hints: a return address (`onyx://auth/callback`), a one-time random `state`, and the `code_challenge`. The user signs in with Google entirely in the trusted system browser. Google redirects back to the backend's **existing, already-registered** Google callback — so self-hosted admins don't have to register any new redirect URL. The callback recognizes "this login came from mobile," mints the session token, stores it in Redis behind a **single-use 60-second code bound to that `code_challenge`**, and redirects the browser to `onyx://auth/callback?code=…`. The app catches that deep link, checks the `state` matches, and `POST`s the code **plus its `code_verifier`** (over HTTPS) to exchange them for the real token; the backend recomputes the challenge from the verifier and rejects a mismatch. **The token never travels in the deep link — only an opaque, PKCE-bound, one-time code does** (also a hard rule; deep links can be intercepted). The PKCE binding means that even if a malicious co-installed app hijacks the `onyx://` redirect and steals the code, it cannot exchange it — it doesn't hold the verifier. This is the key protection for the self-hosted custom-scheme case (which can't use domain-verified Universal Links).
+
+   > Two-leg note on PKCE: the **app↔backend** exchange leg uses PKCE as just described. The **backend↔Google** OAuth exchange is a separate, confidential-client flow where the client secret lives server-side (the app never sees Google's code), so PKCE there is optional defense-in-depth and is currently off for Google (`enable_pkce=False`; OIDC can enable it via `OIDC_PKCE_ENABLED`).
+
+3. **A native login UI + an auth gate.** The app gains a `(auth)` route group with a login screen and a "connect to server" step (so cloud and self-hosted are both first-class), plus a gate at the app root that sends signed-out users to login and signed-in users to the app. The token lives only in the device keychain (`expo-secure-store`), and logout both revokes it on the server and wipes it (and the cached `/api/me` data) locally.
+
+The "flexibility" of this approach lives in two small seams: a **token-issuance seam** (`issue_session_credential`) that today returns the existing session token but can later return a short-lived access token + rotating refresh token with no change to the gateway or the app; and a **provider registry** (a tiny list of descriptors) so adding SAML/OIDC/Apple is a registry row + a button, reusing the same browser → one-time-code → exchange machinery.
+
+## Component interaction
+
+```
+                         MOBILE APP (Expo / React Native)
+  ┌───────────────────────────────────────────────────────────────────────┐
+  │  (auth) group: Connect screen → Login screen (email/pw + provider btns) │
+  │        │                                   │                            │
+  │        ▼                                    ▼                           │
+  │  runtime base-URL store            SessionManager  ◄── providerRegistry │
+  │  (MMKV appStorage) ── getBaseUrl()    │  login() / logout() / getValidToken()
+  │                                       │            │                    │
+  │                                       │            ▼                    │
+  │                                       │      browserSso runner          │
+  │                                       │   (expo-web-browser + expo-      │
+  │                                       │    crypto PKCE + expo-linking)  │
+  │                                       ▼            │                    │
+  │                                  tokenStore        │                    │
+  │                              (expo-secure-store)    │                   │
+  │                                       │            │                    │
+  │   apiFetch (injects Authorization: Bearer) ◄───────┘                    │
+  │      │  AuthGate (uses useCurrentUser → /api/me)                        │
+  └──────┼──────────────────────────────────────────────────────────────── ┘
+         │  HTTPS (base URL = cloud.onyx.app OR self-hosted)        ▲ system browser
+         ▼                                                          │ (Google login)
+  ┌───────────────────────────── ONYX BACKEND (FastAPI) ───────────────────┐
+  │  Mobile Auth Gateway (new):                                             │
+  │   • bearer AuthenticationBackend  → /auth/mobile/{login,refresh,logout} │
+  │   • POST /auth/mobile/sso/exchange  (code + code_verifier → token JSON) │
+  │   • issue_session_credential(user, strategy)   ◄── token-issuance seam  │
+  │   • one-time SSO code store (Redis, 60s, single-use, PKCE-bound)        │
+  │                                                                         │
+  │  Existing auth (reused, tiny guarded additions):                        │
+  │   • /auth/oauth/authorize  (+ optional mobile_redirect_uri/app_state)   │
+  │   • /auth/oauth/callback → complete_login_flow                          │
+  │        └─ if state.client == "mobile": complete_mobile_sso() ───────────┘
+  │   • fastapi-users UserManager, redis/postgres session strategy          │
+  │   • GET /auth/type (config discovery)   • GET /me (current user)         │
+  └─────────────────────────────────────────────────────────────────────────┘
+```
+
+## Key components
+
+- **Bearer `AuthenticationBackend`** — second backend on the existing `fastapi_users`, same session strategy, Bearer transport. Yields `/auth/mobile/{login,refresh,logout}`. (new)
+- **`issue_session_credential(user, strategy)`** — the token-issuance seam; V1 returns the existing stateful token; future home of access+refresh rotation. (new)
+- **One-time SSO code store** — 60-second, single-use Redis entry mapping `code → {token, code_challenge}`, so the deep link carries only a PKCE-bound code. (new)
+- **`complete_mobile_sso(...)` branch** — the shared "mobile login finished" path called by the existing OAuth callback (later OIDC/SAML) when the login originated from mobile. (modified — small guarded branch in `complete_login_flow`)
+- **Guarded mobile params on `/auth/oauth/authorize`** — optional `mobile_redirect_uri` + `app_state` + `app_code_challenge`, the redirect validated against an allowlist; reuses the already-registered IdP callback. (modified)
+- **`POST /auth/mobile/sso/exchange`** — swaps the one-time code **+ `code_verifier`** for the token JSON over HTTPS, after verifying the PKCE challenge. (new)
+- **Mobile `SessionManager` + provider registry** — `login(method)/logout()/getValidToken()` with single-flight refresh; registry maps `password|google` (later `saml|oidc|apple`) to descriptors. (new)
+- **Browser-SSO runner** — opens the authorize URL in the system browser and captures/validates the `onyx://auth/callback` deep link. (new)
+- **Auth gate + `(auth)` route group + Connect screen** — login/redirect UX and the runtime backend-URL entry that makes cloud + self-hosted first-class. (new + modified `_layout.tsx`, `config.ts`)
+- **`tokenStore` hardening** — `keychainAccessible` THIS_DEVICE_ONLY; logout clears the token *and* the persisted query cache. (modified)
+- **Config discovery** — reuse `GET /auth/type` so the login screen shows the right buttons per backend. (reused)
+
+## End-to-end scenario (primary use case: Google sign-in to a self-hosted server)
+
+1. User opens the app → AuthGate sees no token → routes to the **Connect** screen.
+2. User enters `https://onyx.acme.com` (or picks "Onyx Cloud") → stored in the runtime base-URL store; the app calls `GET /api/auth/type` and learns `google_oauth` is enabled → shows email/password + a **Continue with Google** button.
+3. User taps **Continue with Google** → the app generates a random `state` and a **PKCE pair** (`code_verifier` kept in memory + `code_challenge` = S256(verifier)), then opens the **system browser** at `https://onyx.acme.com/api/auth/oauth/authorize?redirect=true&mobile_redirect_uri=onyx://auth/callback&app_state=<state>&app_code_challenge=<challenge>`.
+4. The backend sets its CSRF cookie in that browser session and redirects to Google. The user authenticates with Google in the trusted browser.
+5. Google redirects to the backend's existing `…/api/auth/oauth/callback`. The callback validates CSRF + state, exchanges the Google code (using the **server-side** client secret), and upserts the user — all existing code.
+6. Because `state` says `client=mobile`, the callback runs `complete_mobile_sso`: it mints the session token (`issue_session_credential`), stores it in Redis under a single-use 60s **code bound to the `app_code_challenge`**, and redirects the browser to `onyx://auth/callback?code=<code>&state=<state>`.
+7. The system browser hands that deep link to the app. The app verifies the returned `state` equals the one it generated, then `POST /api/auth/mobile/sso/exchange {code, code_verifier}` over HTTPS.
+8. The backend deletes-on-read the code, **verifies S256(code_verifier) == the stored challenge** (else 401), and returns `{access_token, token_type:"bearer"}`. The app stores the token in the keychain, invalidates `['me']`, and the gate now routes into the app — `/api/me` succeeds because `apiFetch` attaches the Bearer.
+
+(Email/password is steps 1–2, then: user submits credentials → `POST /api/auth/mobile/login` → token JSON → store → in.)
+
+## Sequence of key operations
+
+1. Resolve backend base URL (cloud default or user-entered self-hosted) and discover auth config (`GET /auth/type`).
+2. Authenticate: either email/password to `/auth/mobile/login`, or the system-browser Google flow (app-generated PKCE pair) that ends in a PKCE-bound one-time code exchanged with its `code_verifier` at `/auth/mobile/sso/exchange`.
+3. Persist the returned Bearer token in `expo-secure-store`; invalidate the `['me']` query.
+4. AuthGate re-checks `/api/me`; on success render the app, on 401 route to login.
+5. Keep the session alive: single-flight proactive refresh via `/auth/mobile/refresh` (on foreground + before expiry); one reactive retry on a 401.
+6. Logout: `/auth/mobile/logout` (server revokes the token) → delete the keychain token → `queryClient.clear()` + purge the persisted cache.
+
+## Key decisions & why
+
+- **Reuse the existing session token as a Bearer, behind an `issue_session_credential` seam — do not build rotation in V1.** The token is already stateful and server-revocable (unlike a stateless JWT), which covers the most important property (real logout / kill-session) for a 2-provider launch. RFC 9700's refresh-token rotation is the correct end-state but is a large security-critical subsystem; the seam lets it land later with no gateway/app rework. (From `01-research.md`: RFC 9700 rotation MUST for public clients, deferred consciously.)
+- **System browser + PKCE-bound one-time code on the deep link (never the token).** RFC 8252 forbids embedded webviews for OAuth and deep links are interceptable; returning a single-use, short-TTL, TLS-exchanged code **bound to an app-generated PKCE challenge** is the standard mitigation and is what makes the flow safe on a **custom scheme**, which we need because self-hosted instances can't use domain-verified Universal Links. The PKCE binding ensures a hijacked code is unusable without the verifier the app never transmitted over the deep link. (The separate backend↔Google leg keeps the client secret server-side, so PKCE there is optional and currently off.)
+- **Reuse the existing, already-registered IdP callback (don't add a new redirect URL).** A small guarded param on `/auth/oauth/authorize` plus a branch in the existing callback means self-hosted admins change nothing in their Google console — critical for "self-hosted first-class." It also keeps the OAuth code-exchange (which needs the client secret) entirely server-side.
+- **Bearer transport as a second backend, not a fork.** fastapi-users namespaces router names by backend, so a second `mobile-bearer` backend gives login/refresh/logout for free with no collision against the web cookie backend, and the existing per-request authenticator validates the Bearer with zero per-route changes.
+
+## What existing behavior changes
+
+- **Web/desktop: none.** The cookie flow, web login, and all existing endpoints are untouched; the only edits to shared code are additive and guarded (a second backend in a list, an optional query param, and a branch that only fires when `client=mobile`).
+- **Mobile: net-new.** The app gains login, an auth gate, and a runtime server-URL step. Users will notice the app now requires sign-in (it previously had no auth and `/api/me` always 401'd).
+- **Backend ops:** three new mobile endpoints + a tiny amount of Redis state (the 60s one-time codes). No new database table, no migration in V1.

--- a/docs/mobile-auth/03-detailed-design.md
+++ b/docs/mobile-auth/03-detailed-design.md
@@ -1,0 +1,168 @@
+> Status: active · Task: mobile-auth · Approach: C — Mobile Auth Gateway (BFF)
+
+# Mobile Authentication — Detailed Design
+
+> Scope: **V1 = email/password + Google**, against **cloud + self-hosted**, native Bearer auth. SAML / OIDC / Apple are designed-for but not built (see "Later providers"). All paths assume the existing `/api` global prefix convention the mobile foundation already uses for `/api/me`.
+
+## Database design
+
+**Database design: N/A for V1 — by design.** Approach C reuses Onyx's existing session-token store: `AUTH_BACKEND=redis` writes the token to Redis with a TTL (`TenantAwareRedisStrategy.write_token`, `backend/onyx/auth/users.py:1363-1382`); `postgres` reuses the existing `access_token` table; `jwt` is stateless. The one-time SSO code is a short-lived **Redis** entry, not a SQL row. No new table, no Alembic migration.
+
+> Forward note (not V1): the deferred rotation subsystem (Approach B) would add a `mobile_session` table (per-device family + reuse-detection + audit). When that lands it goes under `backend/onyx/db/` with a hand-written migration, behind the `issue_session_credential` seam. Out of scope here.
+
+## Class / interface design
+
+### Backend
+
+- **`bearer_transport: BearerTransport`** (new) — `BearerTransport(tokenUrl="auth/mobile/login")`. fastapi-users primitive; its `get_login_response(token)` returns `{access_token, token_type:"bearer"}`. Lives beside `cookie_transport` in `backend/onyx/auth/users.py:1326`.
+- **`mobile_auth_backend: AuthenticationBackend`** (new) — `AuthenticationBackend(name="mobile-bearer", transport=bearer_transport, get_strategy=<same get_strategy as the active cookie backend>)`. Added to the `fastapi_users` backend list: `FastAPIUserWithLogoutRouter[User, uuid.UUID](get_user_manager, [auth_backend, mobile_auth_backend])` (`users.py:1684`). Route names become `auth:mobile-bearer.{login,refresh,logout}` — no collision with `auth:redis.*`.
+- **`issue_session_credential(user: User, strategy: Strategy) -> str`** (new) — the token-issuance seam. V1 body: `return await strategy.write_token(user)` (mints the same stateful token, transport-agnostic). Single indirection point so a future access+refresh-rotation implementation swaps here without touching callers. Lives in `backend/onyx/auth/mobile_sso/tokens.py`.
+- **One-time SSO code store** (new, `backend/onyx/auth/mobile_sso/code_store.py`) — stores a PKCE-bound record, not just the token:
+  - `async def store_sso_code(token: str, code_challenge: str, tenant_id: str | None) -> str` — generate `code = secrets.token_urlsafe()`, `redis.set(f"{MOBILE_SSO_CODE_PREFIX}{code}", json.dumps({"token": token, "code_challenge": code_challenge, "tenant_id": tenant_id}), ex=MOBILE_SSO_CODE_TTL_SECONDS)`, return `code`.
+  - `async def consume_sso_code(code: str, code_verifier: str) -> str | None` — atomic `GETDEL` (single-use); if missing/expired → `None`; recompute `BASE64URL(SHA256(code_verifier))` and constant-time-compare to the stored `code_challenge` (S256) — on mismatch return `None` (the code is already burned). Returns the token on success. Uses `get_async_redis_connection()` (always available — Redis is core infra even when `AUTH_BACKEND=jwt`). PKCE helpers (`generate_pkce_pair`/S256) already exist in the codebase (`users.py:2279`); reuse the verification half.
+- **`complete_mobile_sso(user, state_data, strategy, request) -> RedirectResponse`** (new, in `mobile_sso/`) — the shared SSO completion: validate `state_data["app_redirect_uri"]` is in the allowlist; `token = await issue_session_credential(user, strategy)`; `code = await store_sso_code(token, state_data["app_code_challenge"], ...)`; `return RedirectResponse(add_url_params(app_redirect_uri, {"code": code, "state": state_data["app_state"]}), status_code=302)`. Called by every provider's callback when `state_data.get("client") == "mobile"`. (Reject at this point if `app_code_challenge` is absent — mobile SSO requires PKCE.)
+- **Mobile gateway router** (new, `backend/onyx/server/auth/mobile.py`) — owns `POST /auth/mobile/sso/exchange` and mounts the bearer backend's login/refresh/logout (see "New files"). Typed functions, no `response_model`, raises `OnyxError` (CLAUDE.md).
+
+> The "provider registry" is intentionally **thin on the backend**: Onyx's `get_oauth_router` (`users.py:2204`) is *already* provider-generic (Google + OIDC share it), and SAML has its own router. So provider-genericity is achieved by the single shared `complete_mobile_sso` helper that each callback calls — not a new abstraction layer. The richer registry lives on the **mobile** side (descriptors).
+
+### Mobile
+
+- **`SessionManager`** (new, `mobile/src/api/auth/sessionManager.ts`) — `login(method: LoginMethod): Promise<void>`, `logout(): Promise<void>`, `getValidToken(): Promise<string | null>` (single-flight: concurrent callers share one in-flight refresh promise). Orchestrates `tokenStore` + query-cache purge. `LoginMethod = { kind: "password"; email; password } | { kind: "browser"; provider: ProviderId }`.
+- **`providerRegistry`** (new, `mobile/src/api/auth/providers.ts`) — `Record<ProviderId, ProviderDescriptor>` where `ProviderDescriptor = { id; label; kind: "password" | "browser"; authorizePath?: string }`. V1: `password`, `google` (`authorizePath: "/api/auth/oauth/authorize"`). Later rows: `oidc`, `saml`, `apple`. The login screen renders buttons from this filtered by `GET /auth/type`.
+- **`runBrowserSso(descriptor, baseUrl): Promise<{ code: string; codeVerifier: string }>`** (new, `mobile/src/api/auth/browserSso.ts`) — generates `state` and a **PKCE pair** (`codeVerifier` = random 32-byte base64url via `expo-crypto`; `codeChallenge` = base64url(SHA256(codeVerifier)) via `expo-crypto` `digestStringAsync`), builds `{baseUrl}{authorizePath}?redirect=true&mobile_redirect_uri=onyx://auth/callback&app_state=<state>&app_code_challenge=<challenge>`, opens it via `WebBrowser.openAuthSessionAsync(url, "onyx://auth/callback")`, parses the returned deep link, verifies `state`, and returns `{ code, codeVerifier }` (the verifier never leaves the device until the TLS exchange). Throws `ApiError`-shaped on state mismatch/cancel.
+- **`tokenStore`** (modified) — add `keychainAccessibility` option; keep `getToken`/`setToken`; `setToken(null)` stays the logout primitive (cache purge orchestrated by `SessionManager`).
+- **`useSession()` / `AuthGate`** (new) — gate component reading `useCurrentUser`; `isAuthError` → redirect to `/(auth)/connect` or `/(auth)/login`.
+- **`getBaseUrl()`** (modified, `config.ts`) — read the runtime-stored server URL from `appStorage` (MMKV), falling back to `EXPO_PUBLIC_API_URL` for dev.
+
+## New files
+
+| File | Responsibility |
+|------|----------------|
+| `backend/onyx/server/auth/mobile.py` | Mobile gateway router: mounts bearer-backend login/refresh/logout + `POST /auth/mobile/sso/exchange`. |
+| `backend/onyx/auth/mobile_sso/__init__.py` | Package marker. |
+| `backend/onyx/auth/mobile_sso/tokens.py` | `issue_session_credential(user, strategy)` token-issuance seam. |
+| `backend/onyx/auth/mobile_sso/code_store.py` | `store_sso_code` / `consume_sso_code` (60s single-use Redis codes). |
+| `backend/onyx/auth/mobile_sso/sso_completion.py` | `complete_mobile_sso(...)` shared completion + `app_redirect_uri` allowlist check. |
+| `mobile/src/api/auth/sessionManager.ts` | `login/logout/getValidToken` + single-flight refresh + cache purge. |
+| `mobile/src/api/auth/providers.ts` | Provider registry (descriptors). |
+| `mobile/src/api/auth/browserSso.ts` | System-browser OAuth runner + deep-link capture/validation. |
+| `mobile/src/api/auth/useAuthConfig.ts` | `GET /api/auth/type` discovery hook. |
+| `mobile/src/api/auth/useEmailLogin.ts` | TanStack mutation → `POST /api/auth/mobile/login`. |
+| `mobile/src/api/auth/useLogout.ts` | Mutation → `POST /api/auth/mobile/logout` + cache purge. |
+| `mobile/src/api/auth/useSessionRefresh.ts` | Single-flight `POST /api/auth/mobile/refresh` (foreground + pre-expiry). |
+| `mobile/src/state/session.ts` | Zustand store: `status: "loading" \| "authed" \| "anon"` + serverUrl. |
+| `mobile/src/app/(auth)/_layout.tsx` | Auth route group layout. |
+| `mobile/src/app/(auth)/connect.tsx` | Server-URL entry (cloud default / self-hosted). |
+| `mobile/src/app/(auth)/login.tsx` | Email/password form + provider buttons. |
+| `mobile/src/components/auth/AuthGate.tsx` | Redirect gate based on `useCurrentUser`. |
+
+## File structure (tree)
+
+```
+backend/onyx/
+├── auth/
+│   ├── users.py                         (modified: add bearer_transport + mobile_auth_backend to fastapi_users list;
+│   │                                      add optional mobile_redirect_uri/app_state to /authorize; add
+│   │                                      `if state_data.client == "mobile": return await complete_mobile_sso(...)`
+│   │                                      branch in complete_login_flow before backend.login)
+│   └── mobile_sso/                      (new package)
+│       ├── __init__.py                  (new)
+│       ├── tokens.py                    (new: issue_session_credential)
+│       ├── code_store.py                (new: store/consume one-time SSO codes)
+│       └── sso_completion.py            (new: complete_mobile_sso + redirect allowlist)
+├── server/
+│   ├── auth/
+│   │   └── mobile.py                    (new: mobile gateway router)
+│   ├── manage/get_state.py              (reused: GET /auth/type)
+│   └── saml.py                          (LATER: same mobile branch in callback)
+├── configs/app_configs.py              (modified: MOBILE_SSO_CODE_TTL_SECONDS, MOBILE_ALLOWED_REDIRECT_URIS)
+└── main.py                              (modified: include mobile gateway router; mount bearer
+                                          login/refresh/logout via include_auth_router_with_prefix)
+
+mobile/src/
+├── api/
+│   ├── client.ts                        (modified: optional — call SessionManager.getValidToken before Bearer
+│   │                                      injection so a near-expiry token refreshes; or keep as-is + 401 retry)
+│   ├── config.ts                        (modified: getBaseUrl() reads runtime server URL from appStorage)
+│   ├── query-keys.ts                    (modified: add auth/config keys if needed)
+│   └── auth/
+│       ├── tokenStore.ts                (modified: keychainAccessibility THIS_DEVICE_ONLY; resolve logout TODOs)
+│       ├── sessionManager.ts            (new)
+│       ├── providers.ts                 (new)
+│       ├── browserSso.ts                (new)
+│       ├── useAuthConfig.ts             (new)
+│       ├── useEmailLogin.ts             (new)
+│       ├── useLogout.ts                 (new)
+│       └── useSessionRefresh.ts         (new)
+├── state/
+│   ├── session.ts                       (new: Zustand auth-status + serverUrl store, persisted to appStorage)
+│   └── storage.ts                       (modified: encryptionKey for query-cache MMKV, or PII-dehydrate exclusion)
+├── components/auth/AuthGate.tsx         (new)
+└── app/
+    ├── _layout.tsx                      (modified: wrap Stack in <AuthGate>; mount deep-link listener)
+    ├── index.tsx                        (reused: protected home)
+    └── (auth)/                          (new group)
+        ├── _layout.tsx                  (new)
+        ├── connect.tsx                  (new)
+        └── login.tsx                    (new)
+
+mobile/app.json                          (modified: confirm scheme "onyx"; document auth/callback path)
+mobile/package.json                      (modified: + expo-auth-session, expo-web-browser, expo-crypto)
+```
+
+## What each file will contain
+
+### Backend
+- **`backend/onyx/auth/users.py`** (modified) — (1) `bearer_transport = BearerTransport(tokenUrl="auth/mobile/login")` next to `cookie_transport`; (2) build `mobile_auth_backend` with the same `get_strategy` selected at `:1547-1560` and append it to the `fastapi_users` backend list at `:1684`; (3) in `get_oauth_router.authorize` (`:2251`), accept optional `mobile_redirect_uri: str | None = Query(None)` + `app_state: str | None = Query(None)` + `app_code_challenge: str | None = Query(None)`, and when present add `client="mobile"`, `app_redirect_uri`, `app_state`, `app_code_challenge` into `state_data` (`:2270`) — these ride inside the signed state token, so they're tamper-proof through the Google round-trip; (4) in `complete_login_flow` (`:2523`), immediately before `response = await backend.login(strategy, user)` (`:2573`), add `if state_data.get("client") == "mobile": return await complete_mobile_sso(user, state_data, strategy, request)`. All additive and guarded — the web path is unchanged when the params/marker are absent.
+- **`backend/onyx/auth/mobile_sso/tokens.py`** — `async def issue_session_credential(user, strategy) -> str: return await strategy.write_token(user)`. (Seam; documented as the future rotation insertion point.)
+- **`backend/onyx/auth/mobile_sso/code_store.py`** — `store_sso_code(token, code_challenge, tenant_id)` / `consume_sso_code(code, code_verifier)` using `get_async_redis_connection()` + `MOBILE_SSO_CODE_PREFIX` + `MOBILE_SSO_CODE_TTL_SECONDS`. Stores a JSON record `{token, code_challenge, tenant_id}`. `consume` uses Redis `GETDEL` (or a `pipeline` GET+DEL) for atomic single-use, then S256-verifies `code_verifier` against the stored `code_challenge` (constant-time) before returning the token.
+- **`backend/onyx/auth/mobile_sso/sso_completion.py`** — `complete_mobile_sso(user, state_data, strategy, request)`: require `state_data["app_code_challenge"]` (reject if absent); validate `state_data["app_redirect_uri"]` ∈ `MOBILE_ALLOWED_REDIRECT_URIS`; `token = await issue_session_credential(user, strategy)`; `code = await store_sso_code(token, state_data["app_code_challenge"], ...)`; `return RedirectResponse(add_url_params(app_redirect_uri, {"code": code, "state": state_data["app_state"]}), 302)`. Raises `OnyxError(VALIDATION_ERROR, ...)` on a bad/absent redirect URI or missing challenge.
+- **`backend/onyx/server/auth/mobile.py`** — a router that (a) `include`s `fastapi_users.get_auth_router(mobile_auth_backend)` (→ `/login`), `get_refresh_router(mobile_auth_backend)` (→ `/refresh`), `get_logout_router(mobile_auth_backend)` (→ `/logout`) under the `/auth/mobile` prefix, and (b) defines `@router.post("/auth/mobile/sso/exchange")` → typed `async def sso_exchange(payload: SsoExchangeRequest) -> SsoTokenResponse` where `SsoExchangeRequest = {code: str, code_verifier: str}`: `token = await consume_sso_code(payload.code, payload.code_verifier)`; if `None` raise `OnyxError(UNAUTHENTICATED, "Invalid or expired code")` (same generic error for missing/expired/PKCE-mismatch — no oracle); else return `{"access_token": token, "token_type": "bearer"}`.
+- **`backend/onyx/main.py`** (modified) — register the mobile gateway via `include_auth_router_with_prefix(...)` (inherits the global prefix + auth rate-limiting), gated on `AUTH_TYPE in {basic, google_oauth, oidc, saml, cloud}`, mirroring the existing blocks at `:572-690`.
+- **`backend/onyx/configs/app_configs.py`** (modified) — `MOBILE_SSO_CODE_TTL_SECONDS = int(os.environ.get(..., 60))`; `MOBILE_ALLOWED_REDIRECT_URIS` (default `["onyx://auth/callback"]`, comma-split env override for Universal-Link hardening later).
+
+### Mobile
+- **`sessionManager.ts`** — `login()` routes to `useEmailLogin`'s fetch (`POST /api/auth/mobile/login`, form-encoded) or `runBrowserSso` → `POST /api/auth/mobile/sso/exchange {code, code_verifier}`; both end with `setToken(token)` + `queryClient.invalidateQueries(['me'])`. `logout()` = `POST /api/auth/mobile/logout` → `setToken(null)` → `queryClient.clear()` + `persister.removeClient()`. `getValidToken()` holds a module-level in-flight refresh promise (single-flight).
+- **`browserSso.ts`** — as specified above; uses `expo-crypto` (PKCE pair), `expo-web-browser` `openAuthSessionAsync` + `expo-linking` `parse`. Never reads a token from the deep link — only `code` + `state` — and never sends the `code_verifier` over the deep link (only on the TLS `sso/exchange` POST).
+- **`providers.ts`** — the registry; `visibleProviders(authConfig)` filters by `auth_type`/`oauth_enabled` from `/auth/type`.
+- **`useAuthConfig.ts`** — `useQuery(['auth-config', serverUrl], () => apiFetch('/api/auth/type', { auth:false }))`.
+- **`useEmailLogin.ts` / `useLogout.ts` / `useSessionRefresh.ts`** — thin TanStack mutations wrapping `SessionManager`.
+- **`session.ts`** — Zustand store (`status`, `serverUrl`), `serverUrl` persisted to `appStorage`.
+- **`AuthGate.tsx`** — `useCurrentUser()`; while loading show splash; on `isAuthError`/no-token → `<Redirect href="/(auth)/connect" />` (or `/login` if serverUrl set); else render children.
+- **`(auth)/connect.tsx`** — server-URL field (default "Onyx Cloud" = `https://cloud.onyx.app`), validate reachability via `GET /auth/type`, store, advance to login.
+- **`(auth)/login.tsx`** — email/password (with `textContentType`/`autoComplete` autofill) + provider buttons from `visibleProviders`. Generic error text on failure.
+- **`config.ts`** — `getBaseUrl()` reads `session.ts`/`appStorage` server URL; dev fallback to `EXPO_PUBLIC_API_URL`.
+- **`_layout.tsx`** — wrap `<Stack>` in `<AuthGate>`; register the `onyx://auth/callback` deep-link handler (delegates to the in-progress `runBrowserSso` promise).
+- **`tokenStore.ts`** — pass `{ keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY }` to `setItemAsync`; the logout TODO in the header comment is now satisfied by `SessionManager.logout()`.
+
+## Integration points
+
+- **`backend/onyx/auth/users.py:1684`** — the `fastapi_users` backend list is the single extension point for the bearer backend (the framework already supports multiple backends).
+- **`backend/onyx/auth/users.py:2251` & `:2573`** — the only two edits to shared OAuth code: an optional query-param read in `authorize`, and a guarded branch in `complete_login_flow`. Reuses all existing CSRF/state/PKCE validation and `user_manager.oauth_callback` (`:2549`).
+- **`backend/onyx/main.py:572-690`** — registration site for the mobile gateway, following `include_auth_router_with_prefix` (rate-limiting + global prefix inherited).
+- **`backend/onyx/server/manage/get_state.py:34` (`GET /auth/type`)** — reused for mobile config discovery, unchanged.
+- **`backend/onyx/server/manage/users.py:885-954` (`GET /me`)** — becomes the post-login identity probe for mobile; authenticates the new Bearer because the bearer backend shares the existing strategy.
+- **`mobile/src/api/client.ts:40-43`** — already injects `Authorization: Bearer`; the gateway just supplies a token. Optional enhancement: call `SessionManager.getValidToken()` here for proactive refresh.
+- **`mobile/src/api/errors.ts` `isAuthError()` + `mobile/src/query/client.ts`** — the gate and the single reactive-refresh-and-retry key off the existing 401/402/403 classification (retry already skipped).
+- **`mobile/src/query/focus.ts`** — the existing `AppState`→focus bridge is the hook for proactive foreground refresh.
+- **`mobile/app.json`** — scheme `onyx` already matches `onyx://auth/callback`; bundle `app.onyx.mobile` unchanged.
+
+## Important notes before implementation
+
+- **EAS Dev Build required.** `expo-web-browser` OAuth (ASWebAuthenticationSession / Chrome Custom Tabs) does **not** work in Expo Go. Set up a dev build before testing the Google flow; email/password works without it.
+- **CSRF cookie must live in the system browser, so `sso/start` is browser-opened, not fetched.** The app opens `…/auth/oauth/authorize?redirect=true&mobile_redirect_uri=…` *in the system browser* (a 302), exactly like the web `?redirect=true` path, so the CSRF cookie set on that response is present at the callback. Do **not** fetch the authorize URL as JSON from `apiFetch` and then open it — the CSRF cookie would land on the wrong client and the callback would reject it.
+- **Reuse the registered IdP redirect URI.** The authorization URL must use the same `redirect_uri` (`{WEB_DOMAIN}/api/auth/oauth/callback`) the OAuth code-exchange uses and that Google already has registered. Do not introduce a new callback path — that would force every self-hosted admin to register a new redirect URI.
+- **The deep link carries only a PKCE-bound one-time code, never a token.** Enforce: single-use (`GETDEL`), 60s TTL, TLS-only exchange, **app-generated PKCE** (`app_code_challenge` stored with the code; `sso/exchange` requires the matching `code_verifier`, S256, constant-time compare), `app_state` round-trip verification in the app, and a server-side `app_redirect_uri` allowlist. PKCE is the primary mitigation for custom-scheme hijack on self-hosted (no Universal Links there): a hijacked code is useless without the verifier, which is never transmitted over the deep link. Mobile SSO **requires** `app_code_challenge` — reject the flow if it's absent (don't silently fall back to a non-PKCE code). The backend↔Google leg remains a separate confidential-client exchange (secret server-side); PKCE there stays optional/off for Google.
+- **Multi-tenant / tenant context.** `strategy.write_token` resolves/provisions the tenant from the user's email (`users.py:1366-1370`); the mobile login, refresh, and SSO-completion paths must execute inside the same tenant-resolution middleware as the web flow (they do, since they're mounted on the same app) — verify on the SSO-exchange path specifically.
+- **Works across all three `AUTH_BACKEND`s.** Redis is always available (core infra) so the one-time code store works even when `AUTH_BACKEND=jwt`. `issue_session_credential` → `strategy.write_token` produces a valid Bearer for redis/postgres/jwt alike; the bearer backend's strategy reads it back. Note `jwt` tokens are not server-revocable — logout deletes locally but cannot revoke server-side (documented limitation; redis/postgres revoke properly via `destroy_token`).
+- **Route-name collision avoidance.** Mount the bearer backend's auth/refresh/logout via the framework routers (`auth:mobile-bearer.*`) and do **not** re-mount the stock `/auth/login` — that name belongs to the cookie backend.
+- **Security hygiene (from `01-research.md`):** token only in `expo-secure-store` THIS_DEVICE_ONLY; iOS Keychain survives uninstall + has no bulk-clear → explicit delete on logout; never persist the password; generic auth error messages (no enumeration); rely on existing backend rate-limiting; purge the persisted MMKV query cache on logout and give it an `encryptionKey` (or exclude PII queries) to close the plaintext-PII-at-rest gap flagged in `tokenStore.ts`.
+- **Apple / App Store 4.8 (accepted risk).** Shipping Google without Sign in with Apple risks App Store rejection. The provider registry + shared `complete_mobile_sso` make Apple a small add (one provider descriptor + one button + an Apple OAuth client / native `AuthenticationServices` feeding the same exchange) if review forces it.
+- **`prompt=none` silent-auth.** The Google authorize path already uses `prompt=consent` (`users.py:2300`) — keep interactive consent; do not add silent re-auth, which is the ASWebAuthenticationSession hijack vector.
+
+## Later providers (designed-for, not built)
+
+- **OIDC** — `GET /auth/oidc/{authorize,callback}` share `get_oauth_router`, so the same guarded `mobile_redirect_uri` param + `complete_mobile_sso` branch covers it; mobile adds an `oidc` registry row. PKCE already supported via `OIDC_PKCE_ENABLED`.
+- **SAML** — `backend/onyx/server/saml.py` callback gets the same `if client=="mobile": complete_mobile_sso(...)` branch (SP-initiated); mobile adds a `saml` row. No native SDK needed — the system browser handles the IdP.
+- **Apple** — register an Apple OAuth client through the same generic path, or use native `expo-apple-authentication` feeding the same `/auth/mobile/sso/exchange` seam.
+- **Token rotation (Approach B)** — swap `issue_session_credential` to mint a short access token + rotating refresh family + reuse-detection, add a real `/auth/mobile/refresh` body and a `mobile_session` table. No gateway or mobile-client API change.

--- a/docs/mobile-auth/04-implementation-plan.md
+++ b/docs/mobile-auth/04-implementation-plan.md
@@ -1,0 +1,84 @@
+> Status: active · Task: mobile-auth
+
+# Mobile Authentication — Implementation Plan
+
+> Approach C — Mobile Auth Gateway (BFF). V1 = email/password + Google, cloud + self-hosted, native Bearer auth with Leg-2 PKCE. Full design in `02-high-level-design.md` / `03-detailed-design.md`.
+
+## Issues to Address
+
+The Onyx mobile app (`mobile/`) has no authentication. It ships an HTTP client that injects `Authorization: Bearer <token>` (`mobile/src/api/client.ts:40-43`), a `useCurrentUser` → `/api/me` hook, and an `expo-secure-store` token seam (`mobile/src/api/auth/tokenStore.ts`) — but there is no way to obtain a token, no login UI, and no auth-gated routing (`mobile/src/app/_layout.tsx` is a bare `Stack`). The backend only issues its session token as an HttpOnly cookie (`CookieTransport`, `backend/onyx/auth/users.py:1326`), which a native client can't use cleanly.
+
+Outcome: a user can sign in to the mobile app with **email/password or Google**, against **Onyx Cloud or a self-hosted instance**, receive the existing revocable session token as a **Bearer**, stay signed in (proactive refresh), and log out (server revocation + local wipe). The design adds two seams (`issue_session_credential`, a provider registry) so SAML/OIDC/Apple and token-rotation land later as small additions, not rewrites. All web/desktop behavior is unchanged; backend edits are additive and guarded.
+
+## Important Notes
+
+- **Reuse the existing session token as a Bearer — don't build rotation in V1.** Mint via an `issue_session_credential(user, strategy)` seam that today calls `strategy.write_token(user)` (the same opaque, server-revocable token web gets; `users.py:1363-1382`). RFC 9700 refresh-rotation is the deferred end-state behind that seam. (`01-research.md` → RFC 9700.)
+- **Second `AuthenticationBackend`, not a fork.** `fastapi_users` takes a list of backends (`users.py:1684`) and namespaces router names by backend name, so a `mobile-bearer` backend (same `get_strategy`, `BearerTransport`) yields `/auth/mobile/{login,refresh,logout}` with no collision against the web `auth:redis.*` routes. The existing per-request authenticator validates the Bearer with zero per-route change (`/me` at `backend/onyx/server/manage/users.py:885-954`).
+- **Reuse the already-registered IdP callback.** A guarded optional param on `/auth/oauth/authorize` (`users.py:2251`) plus one branch in `complete_login_flow` before `backend.login` (`users.py:2573`) means self-hosted admins register **no** new Google redirect URI. The secret-bearing Google code exchange stays fully server-side (Leg 1 is a confidential-client flow; PKCE optional/off there).
+- **System browser + PKCE-bound one-time code on the deep link (never the token).** RFC 8252: no embedded webview; deep links are interceptable. App generates a PKCE pair (`expo-crypto`), passes `app_code_challenge` to authorize; the backend mints the token, stores it in Redis under a single-use 60s code **bound to the challenge**, and 302s to `onyx://auth/callback?code=…`. Exchange requires `code_verifier` (S256, constant-time). This is the primary mitigation for custom-scheme hijack on self-hosted (no Universal Links there). (`01-research.md` → RFC 8252 / RFC 9700.)
+- **Works across all `AUTH_BACKEND`s.** Redis is always available (core infra) so the one-time code store works even for `AUTH_BACKEND=jwt`; `write_token` mints a valid Bearer for redis/postgres/jwt. Caveat: `jwt` tokens aren't server-revocable (logout deletes locally only) — documented limitation.
+- **Multi-tenant.** `write_token` resolves/provisions the tenant from the user's email (`users.py:1366-1370`); the mobile login/refresh/SSO-completion paths run inside the same tenant middleware (same app) — verify specifically on the SSO-exchange path.
+- **Runtime base URL is in scope.** "Cloud + self-hosted both first-class" requires the user-entered server URL the `config.ts` comment already anticipates (`mobile/src/api/config.ts:1-19`); auth can't ship without it.
+- **Security hygiene (`01-research.md`):** token only in `expo-secure-store` `THIS_DEVICE_ONLY`; iOS Keychain survives uninstall + has no bulk-clear → explicit delete on logout; never persist the password; generic auth errors (no enumeration); rely on existing backend rate-limiting; purge the persisted MMKV query cache on logout and give it an `encryptionKey` (or exclude PII queries) — closes the plaintext-PII gap flagged in `tokenStore.ts:10-21`.
+- **EAS Dev Build required** for the OAuth/system-browser path (`expo-web-browser` doesn't work in Expo Go). Email/password works without it.
+- **App Store 4.8 (accepted risk):** Google without Sign in with Apple risks rejection; the registry makes Apple a cheap later add.
+- **House rules (CLAUDE.md):** raise `OnyxError` (not `HTTPException`); new endpoints typed, no `response_model`; DB ops only under `backend/onyx/db` (N/A — no DB in V1); strict typing in Python + TS.
+
+## Implementation Strategy
+
+Backend and mobile tracks are largely independent; within each, steps are ordered so each is a coherent, testable change.
+
+**Backend**
+
+1. **Bearer transport + second backend.** Add `bearer_transport = BearerTransport(tokenUrl="auth/mobile/login")` beside `cookie_transport`; build `mobile_auth_backend` (`name="mobile-bearer"`, same `get_strategy` as the active backend at `users.py:1547-1560`); append it to the `fastapi_users` backend list (`users.py:1684`). (`backend/onyx/auth/users.py`)
+2. **Token-issuance seam + one-time PKCE code store + SSO completion.** New `backend/onyx/auth/mobile_sso/` package: `tokens.py` (`issue_session_credential`), `code_store.py` (`store_sso_code(token, code_challenge, tenant_id)` / `consume_sso_code(code, code_verifier)` with atomic `GETDEL` + S256 verify, reusing existing PKCE helpers at `users.py:2279`), `sso_completion.py` (`complete_mobile_sso` — require challenge, validate redirect allowlist, mint, store, 302).
+3. **Guarded mobile params + callback branch on the existing OAuth router.** In `users.py` `authorize` (`:2251`) accept optional `mobile_redirect_uri` / `app_state` / `app_code_challenge` and fold them into the signed `state_data`; in `complete_login_flow` (`:2523`) add `if state_data.get("client") == "mobile": return await complete_mobile_sso(...)` before `backend.login` (`:2573`). Additive/guarded — web path unchanged when absent.
+4. **Mobile gateway router + registration + config.** New `backend/onyx/server/auth/mobile.py`: mount the bearer backend's auth/refresh/logout routers under `/auth/mobile`, plus `POST /auth/mobile/sso/exchange {code, code_verifier}` → `consume_sso_code` → bearer JSON (generic `OnyxError(UNAUTHENTICATED)` on any failure). Register via `include_auth_router_with_prefix` in `backend/onyx/main.py:572-690` (gated on `AUTH_TYPE`). Add `MOBILE_SSO_CODE_TTL_SECONDS` + `MOBILE_ALLOWED_REDIRECT_URIS` to `backend/onyx/configs/app_configs.py`.
+
+**Mobile**
+
+5. **Runtime base URL + session store.** `getBaseUrl()` reads a runtime server URL from `appStorage` (MMKV) with `EXPO_PUBLIC_API_URL` dev fallback (`mobile/src/api/config.ts`); new `mobile/src/state/session.ts` (Zustand: `status`, `serverUrl`, persisted).
+6. **Token + cache hardening.** `tokenStore.ts` — `keychainAccessible: WHEN_UNLOCKED_THIS_DEVICE_ONLY`; resolve the logout TODOs. `mobile/src/state/storage.ts` — `encryptionKey` for the query-cache MMKV (or PII-dehydrate exclusion).
+7. **Email/password + config discovery + SessionManager.** `useAuthConfig.ts` (`GET /api/auth/type`), `useEmailLogin.ts` (`POST /api/auth/mobile/login`, form-encoded), `useLogout.ts`, `useSessionRefresh.ts` (single-flight), and `sessionManager.ts` (`login/logout/getValidToken`) + `providers.ts` registry (password + google).
+8. **Browser SSO (Google) with Leg-2 PKCE.** `browserSso.ts` — generate PKCE pair (`expo-crypto`), open `…/auth/oauth/authorize?redirect=true&mobile_redirect_uri=onyx://auth/callback&app_state=…&app_code_challenge=…` via `expo-web-browser`, capture/validate the `onyx://auth/callback` deep link, return `{code, codeVerifier}`, exchange at `sso/exchange`. Add deps `expo-auth-session`, `expo-web-browser`, `expo-crypto`; confirm `app.json` scheme `onyx`.
+9. **Auth gate + (auth) screens.** `components/auth/AuthGate.tsx` (redirect on `isAuthError`/no-token), wrap `<Stack>` in `_layout.tsx` + mount the deep-link listener; `(auth)/_layout.tsx`, `(auth)/connect.tsx` (server URL), `(auth)/login.tsx` (email/pw + provider buttons from the registry filtered by `/auth/type`).
+
+## Tests
+
+Primary type: **Playwright (E2E) is N/A for a native app**, so the split is:
+
+- **External-dependency unit tests (backend)** — the main coverage. With Postgres/Redis live, call the new paths directly:
+  - `issue_session_credential` + `store_sso_code`/`consume_sso_code`: single-use (second consume → `None`), TTL expiry, **PKCE pass/fail** (correct verifier succeeds; wrong verifier → `None`; missing challenge rejected).
+  - `complete_mobile_sso`: redirect-allowlist enforcement; rejects absent `app_code_challenge`; 302 target shape.
+  - `/auth/mobile/login`: returns Bearer JSON (not Set-Cookie); generic error on bad creds.
+  - `/auth/mobile/sso/exchange`: valid code+verifier → token; expired/replayed/mismatch → generic 401.
+  - Bearer auth end-to-end: a token from `write_token` authenticates `GET /me` via the mobile-bearer backend.
+- **Integration test (backend)** — one happy-path: mobile email/password login → Bearer → authenticated `/me` → refresh → logout (token revoked, subsequent `/me` 401). Asserts the web cookie flow is untouched (regression guard on `complete_login_flow` web branch).
+- **Mobile unit tests (Jest + RTL, mocked `apiFetch`/`expo-secure-store`/`expo-web-browser`)** — only the tricky pure logic: `SessionManager.getValidToken` single-flight (concurrent callers → one refresh), `browserSso` state-mismatch rejection + verifier-never-in-deep-link, logout cache purge, `AuthGate` redirect decisions. Avoid over-testing screen markup.
+- **Manual smoke (documented, not automated):** the full Google system-browser flow on an EAS Dev Build against cloud + a self-hosted instance (deep-link return, PKCE exchange) — the one path that can't be unit-tested without device/browser.
+
+## Plan Challenge Results
+
+### 1. Extendability & Scalability: PASS
+The `issue_session_credential` seam + provider registry + shared `complete_mobile_sso` helper make the two known futures (add SAML/OIDC/Apple; add token rotation) single-point extensions, not rewrites. Scale is the same O(1) Redis session lookup web already does; the one-time code is ephemeral 60s Redis state. No hardcoded limits that break at 10x.
+
+### 2. Fragility: CONCERN (two brittle points, both mitigated — keep as implementation guardrails)
+- **Editing the shared `complete_login_flow` (`users.py:2573`)** is the highest-blast-radius change: a regression there could break **web** Google login. Mitigation: the branch is guarded (`client=="mobile"`) and the integration regression test (web cookie flow untouched) must be treated as **mandatory, not optional**.
+- **CSRF cookie depends on `sso/start` being browser-opened, not fetched.** If an implementer fetches the authorize URL as JSON then opens it, CSRF silently breaks. Documented in `03` "Important notes" — call it out in the PR description for the SSO phase.
+- Note: V1 is *less* fragile than the deferred rotation design — with no refresh-token rotation, there's no reuse-detection false-positive/concurrent-refresh hazard yet; `getValidToken` single-flight is a nicety, not a correctness requirement.
+
+### 3. Industry Standard: VERIFIED (web)
+- **System browser + Authorization Code + PKCE, no secret in app** — RFC 8252 (BCP 212), confirmed current: "Public native app clients MUST implement PKCE… use an external user-agent (the system browser)." ([RFC 8252](https://www.rfc-editor.org/rfc/rfc8252.html), [oauth.com](https://www.oauth.com/oauth2-servers/oauth-native-apps/))
+- **BFF / token-mediating backend with a one-time code over the deep link, swapped for the real token** — this is a documented, named industry pattern, matching our design almost verbatim: "the BFF returns a code (a unique reference UUID) via deep linking, and the app then makes another API call to the BFF to swap that code for the actual JWT." ([FusionAuth](https://fusionauth.io/blog/backend-for-frontend), [Auth0](https://auth0.com/blog/the-backend-for-frontend-pattern-bff/), [WorkOS](https://workos.com/docs/integrations/react-native-expo))
+- **PKCE on the deep-link leg** aligns with RFC 9700's "PKCE required for all public clients, no exceptions." ([RFC 9700](https://datatracker.ietf.org/doc/rfc9700/))
+
+### 4. Fact Check: PASS (one conscious divergence, flagged below)
+- RFC 8252 / RFC 9700 / BFF-one-time-code claims: **verified** above. RFC 9700 confirmed published Jan 2025.
+- Expo/Keychain claims (secure-store only, `THIS_DEVICE_ONLY`, Keychain survives uninstall, no bulk-clear) were sourced from official Expo + OWASP MASVS docs in `01-research.md`.
+- **Divergence (honest):** RFC 9700 states refresh tokens for public clients **MUST** be sender-constrained **or** use refresh-token rotation. V1 reuses the existing long-lived (7-day sliding) server-side token as a Bearer with **no rotation** — a conscious deviation. It is *partially* mitigated (the token is server-revocable, unlike a stateless JWT; never in a URL; Keychain-only) and seamed for a clean later upgrade, but it is a real gap vs the current MUST. See Patch-vs-Fix.
+
+### 5. Maintainability: PASS (one note)
+Reuses existing fastapi-users machinery, OnyxError, the auth-router registration pattern, and TanStack hooks; new backend code is one isolated `mobile_sso/` package + a gateway router. The one non-obvious bit is the **second `AuthenticationBackend`** (multi-backend fastapi-users) — add a short code comment / doc pointer so a future reader doesn't miss why `/auth/mobile/*` exists separately from `/auth/*`.
+
+### 6. Patch vs. Fix: PROPER FIX — with one conscious, already-accepted divergence to reaffirm
+The root problem (no mobile auth) is solved properly: a clean gateway, real Bearer auth, server-side revocation, RFC-8252-compliant OAuth, PKCE on the interceptable leg. This is **not** a symptom-patch. The **single** standards gap is the deferred refresh-token rotation (RFC 9700 MUST) — chosen deliberately at GATE 1 (Approach C reuses the revocable token; rotation deferred behind `issue_session_credential`). Because it touches a security MUST, it is surfaced for explicit reaffirmation rather than decided silently.

--- a/docs/mobile-auth/05-pr-roadmap.md
+++ b/docs/mobile-auth/05-pr-roadmap.md
@@ -1,0 +1,94 @@
+> Status: active · Task: mobile-auth · Source plan: 04-implementation-plan.md
+
+# Mobile Authentication — PR Roadmap
+
+Five review-sized PRs, split by coherent vertical slice. Two independent tracks off a shared backend base: **email/password** (PR1→PR2→PR3, shippable after PR3) and **Google** (PR1→PR4→PR5). Backend edits are additive/guarded; mobile auth stays dormant until PR3 flips the gate. (Mobile is pre-release "Foundations," so no end-user feature flag is needed — dormancy = the gate simply isn't wired until PR3.)
+
+## Overview
+
+| PR | Title | Est. LOC | Depends on | Key deliverable |
+|----|-------|----------|------------|-----------------|
+| 1 | `feat(auth): mobile bearer gateway for email/password` | ~300–400 | — | Native client can log in/refresh/logout via Bearer; web untouched |
+| 2 | `feat(mobile): auth foundation — runtime server URL, secure session, SessionManager` | ~350–450 | PR 1 | Dormant client auth plumbing + hardened token/cache storage |
+| 3 | `feat(mobile): email/password login + auth gate` | ~300–400 | PR 1, 2 | **Email/password sign-in works end-to-end (cloud + self-hosted)** |
+| 4 | `feat(auth): mobile Google SSO bridge with PKCE` | ~300–400 | PR 1 | Backend one-time-code + PKCE deep-link bridge over existing OAuth callback |
+| 5 | `feat(mobile): Google sign-in via system browser` | ~300–450 | PR 3, 4 | **Google sign-in works end-to-end** |
+
+## Sequence
+
+```
+            ┌────────────────────────── PR 1 (backend bearer gateway) ──────────────────────────┐
+            │                                                                                     │
+   email/pw track:   PR 2 (mobile foundation) ──► PR 3 (email/pw login + gate)  ◄── ships email/pw
+            │                                              │
+   google track:     PR 4 (backend Google SSO bridge) ────┴──► PR 5 (mobile Google sign-in) ◄── ships Google
+```
+
+- **PR 1** unlocks everything. **PR 2 and PR 4 can be built in parallel** (both depend only on PR 1).
+- **Email/password is fully shippable after PR 3** — Google can follow whenever.
+- **PR 5** needs both the login screen (PR 3) and the backend bridge (PR 4).
+
+---
+
+## PR 1 — `feat(auth): mobile bearer gateway for email/password`
+- **Goal:** Give a native client a way to obtain/refresh/revoke the existing session token as a Bearer, with zero change to the web cookie flow.
+- **Scope (in):** `BearerTransport` + second `mobile-bearer` `AuthenticationBackend` (same `get_strategy`) added to the `fastapi_users` list; `issue_session_credential` seam (`tokens.py`, used by SSO later but introduced here); mobile gateway router mounting the bearer backend's `/auth/mobile/{login,refresh,logout}`; registration in `main.py`; minimal config.
+- **Out of scope:** All OAuth/SSO (PR 4); the one-time code store (PR 4); any mobile code.
+- **Files:**
+  | File | New/Modified | This PR's slice |
+  |------|--------------|-----------------|
+  | `backend/onyx/auth/users.py` | modified | `bearer_transport`; `mobile_auth_backend`; append to `fastapi_users` list (`:1326`, `:1547-1560`, `:1684`) |
+  | `backend/onyx/auth/mobile_sso/__init__.py` | new | package marker |
+  | `backend/onyx/auth/mobile_sso/tokens.py` | new | `issue_session_credential(user, strategy)` seam |
+  | `backend/onyx/server/auth/mobile.py` | new | mount bearer login/refresh/logout under `/auth/mobile` |
+  | `backend/onyx/main.py` | modified | register gateway via `include_auth_router_with_prefix` (`:572-690`) |
+  | `backend/tests/external_dependency_unit/auth/...` | new | bearer-login/refresh/logout + `/me`-via-Bearer + web-regression tests |
+- **Est. size:** ~300–400 LOC incl. tests.
+- **Depends on:** —
+- **Feature-flag state:** N/A — additive, gated on existing `AUTH_TYPE`; harmless until a client calls it.
+- **Tests on merge:** External-dependency unit — `/auth/mobile/login` returns Bearer JSON (not Set-Cookie); a minted token authenticates `GET /me`; `/refresh` extends; `/logout` revokes (subsequent `/me` 401). Integration happy-path + **web cookie-login regression guard** (mandatory).
+- **Drift checkpoint:** Confirm `AUTH_BACKEND` target (redis/postgres vs jwt) and that the second-backend approach is acceptable vs a hand-rolled bearer endpoint. Re-confirm the multi-backend route-naming (`auth:mobile-bearer.*`) doesn't collide in the current fastapi-users version.
+
+## PR 2 — `feat(mobile): auth foundation — runtime server URL, secure session, SessionManager`
+- **Goal:** Land all client-side auth plumbing (no user-facing screens yet), so PR 3 is just UI + wiring.
+- **Scope (in):** runtime base URL (`config.ts` reads `appStorage`, dev fallback to `EXPO_PUBLIC_API_URL`); `state/session.ts` (Zustand); `tokenStore.ts` hardening (`THIS_DEVICE_ONLY` + logout purge); `storage.ts` query-cache `encryptionKey` (or PII-dehydrate exclusion); `SessionManager` (`login/logout/getValidToken` single-flight); `useAuthConfig`/`useEmailLogin`/`useLogout`/`useSessionRefresh`; `providers.ts` (password row only); add no new deps.
+- **Out of scope:** Screens, the auth gate wiring, Google/browser SSO (PR 3 / PR 5).
+- **Files:** `mobile/src/api/config.ts` (mod), `mobile/src/state/session.ts` (new), `mobile/src/state/storage.ts` (mod), `mobile/src/api/auth/tokenStore.ts` (mod), `sessionManager.ts` / `providers.ts` / `useAuthConfig.ts` / `useEmailLogin.ts` / `useLogout.ts` / `useSessionRefresh.ts` (new), `mobile/src/api/query-keys.ts` (mod). Tests: `mobile/src/api/auth/__tests__/*` (getValidToken single-flight, logout purge).
+- **Est. size:** ~350–450 LOC incl. tests.
+- **Depends on:** PR 1 (endpoints exist to type against).
+- **Feature-flag state:** Dormant — `_layout.tsx` not yet gated; app behaves as today.
+- **Tests on merge:** Mobile unit (Jest + RTL, mocked `apiFetch`/`expo-secure-store`): single-flight refresh collapses concurrent callers; logout clears token + query cache + persister.
+- **Drift checkpoint:** Confirm the runtime-URL UX (does Connect store one URL, or support switching instances?) and the query-cache encryption choice (`encryptionKey` vs PII exclusion) — both touch `01/03`'s security TODOs.
+
+## PR 3 — `feat(mobile): email/password login + auth gate`
+- **Goal:** Complete email/password sign-in end-to-end and turn auth on.
+- **Scope (in):** `AuthGate` (redirect on `isAuthError`/no-token); wrap `<Stack>` in `_layout.tsx`; `(auth)/_layout.tsx`; `(auth)/connect.tsx` (cloud default / self-hosted URL, validated via `GET /auth/type`); `(auth)/login.tsx` (email/password with autofill + generic errors; provider buttons driven by the registry — only `password` visible until PR 5).
+- **Out of scope:** Google button/flow (PR 5).
+- **Files:** `mobile/src/components/auth/AuthGate.tsx` (new), `mobile/src/app/_layout.tsx` (mod), `mobile/src/app/(auth)/{_layout,connect,login}.tsx` (new). Tests: `AuthGate` redirect-decision unit tests.
+- **Est. size:** ~300–400 LOC incl. tests.
+- **Depends on:** PR 1 (login endpoint), PR 2 (foundation).
+- **Feature-flag state:** Gate flips **on** here — auth now required on mobile.
+- **Tests on merge:** Mobile unit (AuthGate routing: loading → splash, no-token → connect/login, authed → app). Manual: email/password login against a local backend (cloud + self-hosted base URLs).
+- **Drift checkpoint:** Re-confirm login-screen scope (signup? forgot-password? email-verification UX — all exist server-side but may be out of V1 mobile scope). Confirm Connect-screen reachability check uses `GET /auth/type`.
+
+## PR 4 — `feat(auth): mobile Google SSO bridge with PKCE`
+- **Goal:** Backend host-agnostic SSO return: a PKCE-bound one-time code over the deep link, reusing the existing registered Google callback.
+- **Scope (in):** `mobile_sso/code_store.py` (store/consume, atomic `GETDEL` + S256 verify); `mobile_sso/sso_completion.py` (`complete_mobile_sso` — require challenge, allowlist, mint via `issue_session_credential`, 302 to deep link); guarded `mobile_redirect_uri`/`app_state`/`app_code_challenge` params on `/auth/oauth/authorize` (`users.py:2251`); `client=="mobile"` branch in `complete_login_flow` (`users.py:2573`); `POST /auth/mobile/sso/exchange {code, code_verifier}` in the gateway router; `MOBILE_SSO_CODE_TTL_SECONDS` + `MOBILE_ALLOWED_REDIRECT_URIS` config.
+- **Out of scope:** OIDC/SAML/Apple branches (later); any mobile code.
+- **Files:** `backend/onyx/auth/mobile_sso/{code_store,sso_completion}.py` (new), `backend/onyx/auth/users.py` (mod — authorize params + callback branch), `backend/onyx/server/auth/mobile.py` (mod — add `/sso/exchange`), `backend/onyx/configs/app_configs.py` (mod). Tests: external-dependency unit.
+- **Est. size:** ~300–400 LOC incl. tests.
+- **Depends on:** PR 1 (gateway + `issue_session_credential`).
+- **Feature-flag state:** N/A — additive; the web OAuth path is unchanged when the mobile params/marker are absent.
+- **Tests on merge:** External-dependency unit — code store single-use + TTL + **PKCE pass/fail**; `complete_mobile_sso` allowlist + reject-missing-challenge + 302 shape; `/sso/exchange` valid vs expired/replayed/mismatch (generic 401). **Web OAuth regression guard** (callback web branch unchanged) — mandatory (highest blast radius).
+- **Drift checkpoint:** Re-confirm the `MOBILE_ALLOWED_REDIRECT_URIS` default + that reusing the registered callback (vs a new path) still holds; verify tenant context on the SSO-exchange path for multi-tenant cloud.
+
+## PR 5 — `feat(mobile): Google sign-in via system browser`
+- **Goal:** Complete Google sign-in end-to-end via the system browser + PKCE deep-link exchange.
+- **Scope (in):** `browserSso.ts` (PKCE pair via `expo-crypto`; open authorize in `expo-web-browser`; capture/validate `onyx://auth/callback`; return `{code, codeVerifier}`; exchange at `/sso/exchange`); deep-link listener in `_layout.tsx`; `providers.ts` google row; Google button in `(auth)/login.tsx`; add deps `expo-auth-session`, `expo-web-browser`, `expo-crypto`; confirm `app.json` scheme `onyx`.
+- **Out of scope:** OIDC/SAML/Apple rows (later, cheap adds).
+- **Files:** `mobile/src/api/auth/browserSso.ts` (new), `mobile/src/api/auth/providers.ts` (mod), `mobile/src/app/_layout.tsx` (mod — deep-link listener), `mobile/src/app/(auth)/login.tsx` (mod — Google button), `mobile/package.json` + `mobile/app.json` (mod). Tests: mobile unit + documented manual smoke.
+- **Est. size:** ~300–450 LOC incl. tests.
+- **Depends on:** PR 3 (login screen), PR 4 (backend bridge).
+- **Feature-flag state:** N/A — Google button appears only when `/auth/type` reports it enabled.
+- **Tests on merge:** Mobile unit — `browserSso` rejects state mismatch; `code_verifier` never placed in the deep link (only the TLS exchange). **Manual smoke (required):** full Google flow on an **EAS Dev Build** against cloud + a self-hosted instance (deep-link return + PKCE exchange). Document the dev-build setup.
+- **Drift checkpoint:** Confirm EAS Dev Build is available in CI/dev; re-confirm the `onyx://auth/callback` scheme/path and that `sso/start` is **browser-opened, not fetched** (CSRF correctness). Decide whether Apple Sign In must land with this PR for App Store submission (Guideline 4.8) or is a separate follow-up.


### PR DESCRIPTION
## Description

- Add a `mobile-bearer` fastapi-users backend that reuses the active session strategy, so native mobile clients get the existing stateful, revocable session token as an `Authorization: Bearer` value instead of an HttpOnly cookie.
- Expose `POST /auth/mobile/{login,refresh,logout}` (registered only under BASIC/CLOUD auth) and allowlist them as public routes.
- Web cookie auth, API keys, PATs, and JWT/SAML header auth are unaffected — the bearer backend is additive and the cookie backend is still tried first.
- Add design docs under `docs/mobile-auth/` describing the V1 scope and the deferred Google SSO bridge.

## How Has This Been Tested?

Integration test (`backend/tests/integration/tests/mobile_auth/`) covering bearer login/refresh/logout, bad credentials, and a regression guard that web cookie login still works.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a mobile bearer-token auth gateway so native apps can send the existing, revocable session token in the Authorization header. Also fixes Redis async client reuse across event loops to prevent 500s; the mobile backend now reuses the session strategy directly.

- **New Features**
  - Added `mobile-bearer` `fastapi-users` backend using `BearerTransport`, sharing the existing session strategy; exposes `POST /auth/mobile/{login,refresh,logout}` and allowlists them as public.
  - Web auth remains unchanged (cookies, API keys, PATs, JWT/SAML); the cookie backend is tried first and non-session Authorization values fall through to their own handlers.
  - Added integration tests for bearer login/refresh/logout and a regression guard that web cookie login still works.
  - Added docs under `docs/mobile-auth/` for V1 and the deferred Google SSO bridge.

- **Bug Fixes**
  - Cache the async Redis client per event loop to eliminate “Future attached to a different loop” errors during token reads; closed-loop clients are pruned safely.
  - Removed earlier mobile-auth workarounds (Authorization prefix filter and defensive read wrapper); the bearer backend now delegates directly to the shared session strategy.
  - Dropped internal design-doc pointers from code comments to keep inline docs self-contained.

<sup>Written for commit 6ee15aeba9ee2f5ca639adc3ca0013a3fee058ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

