### PR TITLE
feat(mobile): load Hanken Grotesk + DM Mono fonts for typeface parity

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -39,7 +39,64 @@
           }
         }
       ],
-      "expo-secure-store"
+      "expo-secure-store",
+      [
+        "expo-font",
+        {
+          "android": {
+            "fonts": [
+              {
+                "fontFamily": "Hanken Grotesk",
+                "fontDefinitions": [
+                  {
+                    "path": "./node_modules/@expo-google-fonts/hanken-grotesk/400Regular/HankenGrotesk_400Regular.ttf",
+                    "weight": 400
+                  },
+                  {
+                    "path": "./node_modules/@expo-google-fonts/hanken-grotesk/500Medium/HankenGrotesk_500Medium.ttf",
+                    "weight": 450
+                  },
+                  {
+                    "path": "./node_modules/@expo-google-fonts/hanken-grotesk/500Medium/HankenGrotesk_500Medium.ttf",
+                    "weight": 500
+                  },
+                  {
+                    "path": "./node_modules/@expo-google-fonts/hanken-grotesk/600SemiBold/HankenGrotesk_600SemiBold.ttf",
+                    "weight": 600
+                  },
+                  {
+                    "path": "./node_modules/@expo-google-fonts/hanken-grotesk/700Bold/HankenGrotesk_700Bold.ttf",
+                    "weight": 700
+                  }
+                ]
+              },
+              {
+                "fontFamily": "DM Mono",
+                "fontDefinitions": [
+                  {
+                    "path": "./node_modules/@expo-google-fonts/dm-mono/400Regular/DMMono_400Regular.ttf",
+                    "weight": 400
+                  },
+                  {
+                    "path": "./node_modules/@expo-google-fonts/dm-mono/500Medium/DMMono_500Medium.ttf",
+                    "weight": 500
+                  }
+                ]
+              }
+            ]
+          },
+          "ios": {
+            "fonts": [
+              "./node_modules/@expo-google-fonts/hanken-grotesk/400Regular/HankenGrotesk_400Regular.ttf",
+              "./node_modules/@expo-google-fonts/hanken-grotesk/500Medium/HankenGrotesk_500Medium.ttf",
+              "./node_modules/@expo-google-fonts/hanken-grotesk/600SemiBold/HankenGrotesk_600SemiBold.ttf",
+              "./node_modules/@expo-google-fonts/hanken-grotesk/700Bold/HankenGrotesk_700Bold.ttf",
+              "./node_modules/@expo-google-fonts/dm-mono/400Regular/DMMono_400Regular.ttf",
+              "./node_modules/@expo-google-fonts/dm-mono/500Medium/DMMono_500Medium.ttf"
+            ]
+          }
+        }
+      ]
     ],
     "experiments": {
       "typedRoutes": true

--- a/mobile/bun.lock
+++ b/mobile/bun.lock
@@ -5,6 +5,8 @@
     "": {
       "name": "mobile",
       "dependencies": {
+        "@expo-google-fonts/dm-mono": "^0.4.2",
+        "@expo-google-fonts/hanken-grotesk": "^0.4.3",
         "@onyx-ai/shared": "file:../web/lib/shared",
         "@react-native-community/netinfo": "12.0.1",
         "@rn-primitives/portal": "^1.4.0",
@@ -234,6 +236,10 @@
     "@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
+
+    "@expo-google-fonts/dm-mono": ["@expo-google-fonts/dm-mono@0.4.2", "", {}, "sha512-loMaZOkQRs1r7yt4rN39zcr9e0J+smwnSx929yuODkuiPfsY4PaW18C9SEZ0BvXfcBKoRhatGoIBl8V2MOYVPQ=="],
+
+    "@expo-google-fonts/hanken-grotesk": ["@expo-google-fonts/hanken-grotesk@0.4.3", "", {}, "sha512-TZn/Ux+nCxEjG/zAenCFbEhOAPxSXN3lo2YU2jHcPsNBPFeicm8feQStL81igJuAwJLCn62VvEOdTtmVEBDl0g=="],
 
     "@expo-google-fonts/material-symbols": ["@expo-google-fonts/material-symbols@0.4.38", "", {}, "sha512-IJkBtN1o8u9BW5fvSii1MyHPQ7Q0HxbWcVBvOrOzgMLpVtZw7R2w94wBTVR7kZwv3w1JNTESMmLA5Sqn1+Z36A=="],
 

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -3,6 +3,8 @@
   "main": "expo-router/entry",
   "version": "1.0.0",
   "dependencies": {
+    "@expo-google-fonts/dm-mono": "^0.4.2",
+    "@expo-google-fonts/hanken-grotesk": "^0.4.3",
     "@onyx-ai/shared": "file:../web/lib/shared",
     "@react-native-community/netinfo": "12.0.1",
     "@rn-primitives/portal": "^1.4.0",

--- a/mobile/src/app/_layout.tsx
+++ b/mobile/src/app/_layout.tsx
@@ -39,10 +39,11 @@ export default function RootLayout() {
     const unbindOnline = bindOnlineManager();
     const unbindFocus = bindAppStateFocus();
 
-    // No async init yet, so hide on the first render.
-    // TODO(Subash-Mohan): once useFonts lands, gate this behind a readiness flag
-    // (return null until ready) so text never flashes in the system font before
-    // custom fonts load.
+    // No async init to await before the first frame. Custom fonts (Hanken Grotesk,
+    // DM Mono, from the @expo-google-fonts/* packages) are embedded into the native
+    // binary at build time via the expo-font config plugin (see app.json), so they're
+    // registered before React mounts — no runtime useFonts / readiness gate is needed
+    // and text never flashes in the system font. Hide the splash on the first render.
     void SplashScreen.hideAsync();
 
     return () => {


### PR DESCRIPTION
## Description

- Load Hanken Grotesk + DM Mono on mobile via the official `@expo-google-fonts` packages, embedded at build time through the `expo-font` config plugin, so the app's typeface matches web (previously text fell back to the system font SF Pro / Roboto).
- Weights are mapped per platform — Android weight→file map (Hanken 400/450/500/600/700, DM Mono 400/500) and iOS `UIAppFonts` — preserving the shared `fontFamily`+`fontWeight` token contract with no `@onyx-ai/shared` change; `main-content-body` (450) rounds to Medium/500 since the static packages ship no variable 450.
- Resolve the `_layout.tsx` font-readiness TODO: fonts register before the first frame, so no runtime `useFonts` or splash gate is needed.

## How Has This Been Tested?

Verified via `expo prebuild` (Android weight-map XML + iOS `UIAppFonts` generated correctly) and pre-commit (mobile typecheck, lint, format all pass); an on-device iOS weight visual check is still recommended before release.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Loads the Hanken Grotesk and DM Mono fonts on mobile using `@expo-google-fonts` and the `expo-font` config plugin, so typography matches web without system font fallback or flash.

- **New Features**
  - Embed `Hanken Grotesk` and `DM Mono` at build time; keep shared `fontFamily`/`fontWeight` tokens.
  - Android: per-weight `fontDefinitions` (Hanken 400/450→500/500/600/700; DM Mono 400/500).
  - iOS: added font files to `UIAppFonts`.
  - Fonts register before React mounts; no runtime `useFonts`; hide splash on first render.

- **Dependencies**
  - Added `@expo-google-fonts/hanken-grotesk`
  - Added `@expo-google-fonts/dm-mono`

<sup>Written for commit 340ebf082e50e211156875f9ba7c31a207db86db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12069?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

