### PR TITLE
fix(voice): strip markdown before TTS read-aloud playback

### DIFF
--- a/web/src/hooks/useVoicePlayback.ts
+++ b/web/src/hooks/useVoicePlayback.ts
@@ -1,6 +1,7 @@
 import { useState, useRef, useCallback, useEffect } from "react";
 import { StreamingTTSPlayer } from "@/lib/streamingTTS";
 import { useVoiceMode } from "@/providers/VoiceModeProvider";
+import { stripMarkdownForTTS } from "@/lib/voice/utils";
 
 export interface UseVoicePlaybackReturn {
   isPlaying: boolean;
@@ -55,6 +56,9 @@ export function useVoicePlayback(): UseVoicePlaybackReturn {
       setError(null);
       setIsLoading(true);
 
+      // Strip markdown so TTS engines don't read syntax (e.g. "#") aloud literally.
+      const cleanedText = stripMarkdownForTTS(text);
+
       try {
         const player = new StreamingTTSPlayer({
           onPlayingChange: (playing) => {
@@ -78,7 +82,7 @@ export function useVoicePlayback(): UseVoicePlaybackReturn {
         playerRef.current = player;
         player.setMuted(isTTSMuted);
 
-        await player.speak(text, voice, speed);
+        await player.speak(cleanedText, voice, speed);
         setIsLoading(false);
       } catch (err) {
         if (err instanceof Error && err.name === "AbortError") {

--- a/web/src/lib/voice/utils.ts
+++ b/web/src/lib/voice/utils.ts
@@ -5,6 +5,25 @@ import type { IconProps } from "@opal/types";
 /** Whether the provider is being configured for speech-to-text or text-to-speech. */
 export type ProviderMode = "stt" | "tts";
 
+/**
+ * Strip markdown formatting so TTS engines don't read syntax (e.g. "#", "*")
+ * aloud literally. Shared by voice-mode auto-playback and the manual "Read
+ * aloud" button so both paths sound identical.
+ */
+export function stripMarkdownForTTS(text: string): string {
+  return text
+    .replace(/\*\*/g, "") // Remove bold markers
+    .replace(/\*/g, "") // Remove italic markers
+    .replace(/__/g, "") // Remove underscore-bold markers
+    .replace(/_/g, "") // Remove underscore-italic markers
+    .replace(/`{1,3}/g, "") // Remove code markers
+    .replace(/^#{1,6}\s*/gm, "") // Remove headers (line-start only)
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1") // Convert links to just text
+    .replace(/\n+/g, " ") // Replace newlines with spaces
+    .replace(/\s+/g, " ") // Normalize whitespace
+    .trim();
+}
+
 /** All static display and configuration data for a single voice provider. */
 export interface VoiceProviderDetail {
   label: string;

--- a/web/src/providers/VoiceModeProvider.tsx
+++ b/web/src/providers/VoiceModeProvider.tsx
@@ -11,6 +11,7 @@ import React, {
 import { useUser } from "@/providers/UserProvider";
 import { useVoiceStatus } from "@/hooks/useVoiceStatus";
 import { INTERNAL_URL, IS_DEV } from "@/lib/constants";
+import { stripMarkdownForTTS as cleanTextForTTS } from "@/lib/voice/utils";
 
 // --- TTS Configuration Constants ---
 
@@ -103,21 +104,6 @@ interface VoiceModeContextType {
 }
 
 const VoiceModeContext = createContext<VoiceModeContextType | null>(null);
-
-/**
- * Clean text for TTS - remove markdown formatting
- */
-function cleanTextForTTS(text: string): string {
-  return text
-    .replace(/\*\*/g, "") // Remove bold markers
-    .replace(/\*/g, "") // Remove italic markers
-    .replace(/`{1,3}/g, "") // Remove code markers
-    .replace(/#{1,6}\s*/g, "") // Remove headers
-    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1") // Convert links to just text
-    .replace(/\n+/g, " ") // Replace newlines with spaces
-    .replace(/\s+/g, " ") // Normalize whitespace
-    .trim();
-}
 
 /**
  * Find the next natural chunk boundary in text.


### PR DESCRIPTION
## Description

- The "Read aloud" button no longer voices markdown syntax (e.g. "#", "*", "`") aloud — it now behaves consistently with voice-mode auto-playback

## How Has This Been Tested?

- Manually verified the Read-aloud button speaks clean prose with no markdown symbols.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops TTS from reading markdown symbols in the Read aloud path. Both Read aloud and voice-mode playback now strip markdown for clean, consistent speech.

- **Bug Fixes**
  - `useVoicePlayback` uses `stripMarkdownForTTS` before TTS, matching auto-playback.

- **Refactors**
  - Extracted shared `stripMarkdownForTTS` to `web/src/lib/voice/utils.ts`.
  - Replaced the private cleaner in `VoiceModeProvider` with the shared helper and removed the duplicate.

<sup>Written for commit 9f3ea473f2e322926502c21e125dd6071cfca25b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



