### PR TITLE
fix(auth): serve anonymous chat to logged-out users on self-hosted (#11935)

### DIFF
--- a/web/src/hooks/useTokenRefresh.ts
+++ b/web/src/hooks/useTokenRefresh.ts
@@ -31,10 +31,8 @@ export function useTokenRefresh(
     if (
       !user ||
       user.id === NO_AUTH_USER_ID ||
-      // Anonymous (self-hosted "anonymous chat") users have no session token to
-      // refresh — the backend has no cookie for them and /api/auth/refresh 401s.
-      // A failed refresh triggers onRefreshFail, which churns the /me query and
-      // can bounce the anonymous visitor to login. Skip them entirely.
+      // Anonymous users have no session to refresh; a failed refresh churns the
+      // /me query and can bounce them to login.
       user.is_anonymous_user ||
       authTypeMetadata.authType === AuthType.OIDC ||
       authTypeMetadata.authType === AuthType.SAML

--- a/web/src/hooks/useTokenRefresh.ts
+++ b/web/src/hooks/useTokenRefresh.ts
@@ -31,6 +31,11 @@ export function useTokenRefresh(
     if (
       !user ||
       user.id === NO_AUTH_USER_ID ||
+      // Anonymous (self-hosted "anonymous chat") users have no session token to
+      // refresh — the backend has no cookie for them and /api/auth/refresh 401s.
+      // A failed refresh triggers onRefreshFail, which churns the /me query and
+      // can bounce the anonymous visitor to login. Skip them entirely.
+      user.is_anonymous_user ||
       authTypeMetadata.authType === AuthType.OIDC ||
       authTypeMetadata.authType === AuthType.SAML
     ) {

--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -10,8 +10,18 @@ import {
 // Authentication cookie names (matches backend constants)
 const ANONYMOUS_USER_COOKIE_NAME = "onyx_anonymous_user";
 
-// Protected route prefixes (require authentication)
-const PROTECTED_ROUTES = ["/app", "/admin", "/agents", "/connector"];
+// Protected route prefixes that require a real authenticated session and never
+// permit anonymous access — safe to fast-fail at the edge when no cookie is
+// present.
+//
+// "/app" (the chat surface) is intentionally NOT listed: it permits anonymous
+// access when an admin enables it, which is a runtime (Redis-backed) setting the
+// edge can't see from cookies. In single-tenant self-hosted mode no anonymous
+// cookie is set either — the backend synthesizes the anonymous user from the
+// setting alone. So "/app" is gated server-side by requireAuth() in
+// web/src/app/app/layout.tsx, which reads the setting via /me and serves the
+// anonymous user when it's on or redirects to login when it's off.
+const PROTECTED_ROUTES = ["/admin", "/agents", "/connector"];
 
 // Public route prefixes (no authentication required)
 const PUBLIC_ROUTES = ["/auth", "/anonymous", "/_next", "/api"];
@@ -79,10 +89,10 @@ export async function proxy(request: NextRequest) {
   // Auth Check: Fast-fail at edge if no cookie (defense in depth)
   // Note: Layouts still do full verification (token validity, roles, etc.)
   const isProtectedRoute = PROTECTED_ROUTES.some((route) =>
-    pathname.startsWith(route)
+    pathname.startsWith(route),
   );
   const isPublicRoute = PUBLIC_ROUTES.some((route) =>
-    pathname.startsWith(route)
+    pathname.startsWith(route),
   );
 
   if (isProtectedRoute && !isPublicRoute) {

--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -7,17 +7,11 @@ import {
   SERVER_SIDE_ONLY__AUTH_COOKIE_NAME,
 } from "./lib/constants";
 
-// Protected route prefixes that require a real authenticated session and never
-// permit anonymous access — safe to fast-fail at the edge when no cookie is
-// present.
-//
-// "/app" (the chat surface) is intentionally NOT listed: it permits anonymous
-// access when an admin enables it, which is a runtime (Redis-backed) setting the
-// edge can't see from cookies. In single-tenant self-hosted mode no anonymous
-// cookie is set either — the backend synthesizes the anonymous user from the
-// setting alone. So "/app" is gated server-side by requireAuth() in
-// web/src/app/app/layout.tsx, which reads the setting via /me and serves the
-// anonymous user when it's on or redirects to login when it's off.
+// Route prefixes that never allow anonymous access, so we fast-fail at the edge
+// when no auth cookie is present. "/app" is intentionally excluded: it allows
+// anonymous access via a runtime (Redis-backed) setting the edge can't read from
+// cookies, so it's gated server-side by requireAuth() in
+// web/src/app/app/layout.tsx instead.
 const PROTECTED_ROUTES = ["/admin", "/agents", "/connector"];
 
 // Public route prefixes (no authentication required)
@@ -95,10 +89,8 @@ export async function proxy(request: NextRequest) {
   if (isProtectedRoute && !isPublicRoute) {
     const authCookie = request.cookies.get(SERVER_SIDE_ONLY__AUTH_COOKIE_NAME);
 
-    // These routes never permit anonymous access, so require a real auth cookie.
-    // The anonymous-user cookie is intentionally not honored here — an anonymous
-    // session must never satisfy the edge gate for /admin, /agents, or
-    // /connector (the server-side role checks reject it anyway).
+    // Require a real auth cookie; the anonymous-user cookie must not satisfy the
+    // edge gate for these routes (the server-side role checks reject it anyway).
     if (!authCookie) {
       const loginUrl = new URL("/auth/login", request.url);
       // Preserve full URL including query params and hash for deep linking

--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -7,9 +7,6 @@ import {
   SERVER_SIDE_ONLY__AUTH_COOKIE_NAME,
 } from "./lib/constants";
 
-// Authentication cookie names (matches backend constants)
-const ANONYMOUS_USER_COOKIE_NAME = "onyx_anonymous_user";
-
 // Protected route prefixes that require a real authenticated session and never
 // permit anonymous access — safe to fast-fail at the edge when no cookie is
 // present.
@@ -89,18 +86,20 @@ export async function proxy(request: NextRequest) {
   // Auth Check: Fast-fail at edge if no cookie (defense in depth)
   // Note: Layouts still do full verification (token validity, roles, etc.)
   const isProtectedRoute = PROTECTED_ROUTES.some((route) =>
-    pathname.startsWith(route),
+    pathname.startsWith(route)
   );
   const isPublicRoute = PUBLIC_ROUTES.some((route) =>
-    pathname.startsWith(route),
+    pathname.startsWith(route)
   );
 
   if (isProtectedRoute && !isPublicRoute) {
     const authCookie = request.cookies.get(SERVER_SIDE_ONLY__AUTH_COOKIE_NAME);
-    const anonymousCookie = request.cookies.get(ANONYMOUS_USER_COOKIE_NAME);
 
-    // Allow access if user has either a regular auth cookie or anonymous user cookie
-    if (!authCookie && !anonymousCookie) {
+    // These routes never permit anonymous access, so require a real auth cookie.
+    // The anonymous-user cookie is intentionally not honored here — an anonymous
+    // session must never satisfy the edge gate for /admin, /agents, or
+    // /connector (the server-side role checks reject it anyway).
+    if (!authCookie) {
       const loginUrl = new URL("/auth/login", request.url);
       // Preserve full URL including query params and hash for deep linking
       const fullPath = pathname + request.nextUrl.search + request.nextUrl.hash;

--- a/web/src/refresh-pages/AppPage.tsx
+++ b/web/src/refresh-pages/AppPage.tsx
@@ -191,14 +191,10 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
   const { data: federatedConnectorsData } = useFederatedConnectors();
 
   const { user } = useUser();
-  // `useUser()` collapses the loading state to `null` (its backing state inits
-  // to null and is populated by an effect). Read the raw /me result so the
-  // auth-gate below only fires once the query has actually resolved to "no
-  // user" — otherwise the brief load window redirects everyone to /auth/login.
-  // Logged-in users silently bounce back, but the synthesized anonymous user is
-  // kept on the login page (it's a deliberate non-redirect there), so anonymous
-  // chat visitors get stranded. `undefined` = still loading, `null` = resolved
-  // signed-out / anonymous-disabled, object = a real or anonymous user.
+  // `useUser()` reports null while loading, so gating on it would redirect during
+  // the /me load window. Read the raw result instead (undefined = loading, null =
+  // resolved signed-out). This matters for anonymous users specifically: they're
+  // kept on the login page, so unlike logged-in users they wouldn't bounce back.
   const { user: resolvedUser } = useCurrentUser();
 
   function processSearchParamsAndSubmitMessage(searchParamsString: string) {

--- a/web/src/refresh-pages/AppPage.tsx
+++ b/web/src/refresh-pages/AppPage.tsx
@@ -23,6 +23,7 @@ import { useDocumentSets } from "@/lib/hooks/useDocumentSets";
 import { useAgents } from "@/lib/agents/hooks";
 import { AppPopup } from "@/app/app/components/AppPopup";
 import { useUser } from "@/providers/UserProvider";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
 import NoAgentModal from "@/sections/modals/NoAgentModal";
 import PreviewModal from "@/sections/modals/PreviewModal";
 import Modal from "@/refresh-components/Modal";
@@ -190,6 +191,15 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
   const { data: federatedConnectorsData } = useFederatedConnectors();
 
   const { user } = useUser();
+  // `useUser()` collapses the loading state to `null` (its backing state inits
+  // to null and is populated by an effect). Read the raw /me result so the
+  // auth-gate below only fires once the query has actually resolved to "no
+  // user" — otherwise the brief load window redirects everyone to /auth/login.
+  // Logged-in users silently bounce back, but the synthesized anonymous user is
+  // kept on the login page (it's a deliberate non-redirect there), so anonymous
+  // chat visitors get stranded. `undefined` = still loading, `null` = resolved
+  // signed-out / anonymous-disabled, object = a real or anonymous user.
+  const { user: resolvedUser } = useCurrentUser();
 
   function processSearchParamsAndSubmitMessage(searchParamsString: string) {
     const newSearchParams = new URLSearchParams(searchParamsString);
@@ -556,7 +566,7 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
     }
   }, [documentSidebarVisible, updateCurrentDocumentSidebarVisible]);
 
-  if (!user) {
+  if (resolvedUser === null) {
     redirect("/auth/login");
   }
 

--- a/web/tests/e2e/auth/anonymous_chat.spec.ts
+++ b/web/tests/e2e/auth/anonymous_chat.spec.ts
@@ -62,9 +62,8 @@ test.describe("Anonymous chat access @exclusive", () => {
     await page.goto("/app");
     await page.waitForLoadState("networkidle");
 
-    // The cookie-less visitor stays on the chat surface instead of being
-    // bounced to login. Use the auto-retrying matcher so a brief client-side
-    // settle after load doesn't flake the assertion.
+    // The cookie-less visitor stays on the chat surface instead of being bounced
+    // to login.
     await expect(page).toHaveURL(/\/app(\/|\?|$)/);
     await expect(page).not.toHaveURL(/\/auth\/login/);
 

--- a/web/tests/e2e/auth/anonymous_chat.spec.ts
+++ b/web/tests/e2e/auth/anonymous_chat.spec.ts
@@ -11,7 +11,7 @@ import { loginAs } from "@tests/e2e/utils/auth";
 // `page` must be authenticated as an admin.
 async function setAnonymousChatEnabled(
   page: Page,
-  enabled: boolean,
+  enabled: boolean
 ): Promise<void> {
   const getRes = await page.request.get("/api/settings");
   expect(getRes.ok()).toBe(true);
@@ -63,8 +63,9 @@ test.describe("Anonymous chat access @exclusive", () => {
     await page.waitForLoadState("networkidle");
 
     // The cookie-less visitor stays on the chat surface instead of being
-    // bounced to login.
-    expect(new URL(page.url()).pathname).toMatch(/^\/app/);
+    // bounced to login. Use the auto-retrying matcher so a brief client-side
+    // settle after load doesn't flake the assertion.
+    await expect(page).toHaveURL(/\/app(\/|\?|$)/);
     await expect(page).not.toHaveURL(/\/auth\/login/);
 
     // The backend serves the synthesized anonymous user.
@@ -87,7 +88,6 @@ test.describe("Anonymous chat access @exclusive", () => {
     await expect(guestLink).toBeVisible();
     await guestLink.click();
 
-    await page.waitForLoadState("networkidle");
-    expect(new URL(page.url()).pathname).toMatch(/^\/app/);
+    await expect(page).toHaveURL(/\/app(\/|\?|$)/);
   });
 });

--- a/web/tests/e2e/auth/anonymous_chat.spec.ts
+++ b/web/tests/e2e/auth/anonymous_chat.spec.ts
@@ -1,0 +1,93 @@
+import { Page, test, expect } from "@playwright/test";
+import { loginAs } from "@tests/e2e/utils/auth";
+
+// Regression coverage for the self-hosted "anonymous chat enabled but can't chat
+// as anonymous user" bug: when an admin enables anonymous chat, a logged-out
+// visitor should reach the chat surface (/app) instead of being redirected to
+// the login page.
+
+// Toggle the global anonymous-chat setting via the admin API, mirroring the
+// admin UI's read-modify-write (web/src/refresh-pages/admin/ChatPreferencesPage.tsx).
+// `page` must be authenticated as an admin.
+async function setAnonymousChatEnabled(
+  page: Page,
+  enabled: boolean,
+): Promise<void> {
+  const getRes = await page.request.get("/api/settings");
+  expect(getRes.ok()).toBe(true);
+  const current = await getRes.json();
+
+  const putRes = await page.request.put("/api/admin/settings", {
+    data: { ...current, anonymous_user_enabled: enabled },
+  });
+  expect(putRes.ok()).toBe(true);
+}
+
+// @exclusive: mutates the global `anonymous_user_enabled` setting, which is
+// shared across the single-tenant backend, so it must run serially in isolation.
+test.describe("Anonymous chat access @exclusive", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.context().clearCookies();
+    await loginAs(page, "admin");
+  });
+
+  test.afterEach(async ({ page }) => {
+    // Restore the default (disabled) so other suites start from a clean state.
+    await loginAs(page, "admin");
+    await setAnonymousChatEnabled(page, false);
+  });
+
+  test("logged-out visitor is redirected to login when anonymous chat is disabled", async ({
+    page,
+  }) => {
+    await setAnonymousChatEnabled(page, false);
+    await page.context().clearCookies();
+
+    await page.goto("/app");
+    await page.waitForLoadState("networkidle");
+
+    await expect(page).toHaveURL(/\/auth\/login/);
+
+    // No anonymous user is synthesized when the setting is off.
+    const me = await page.request.get("/api/me");
+    expect(me.ok()).toBe(false);
+  });
+
+  test("logged-out visitor reaches chat as anonymous user when enabled", async ({
+    page,
+  }) => {
+    await setAnonymousChatEnabled(page, true);
+    await page.context().clearCookies();
+
+    await page.goto("/app");
+    await page.waitForLoadState("networkidle");
+
+    // The cookie-less visitor stays on the chat surface instead of being
+    // bounced to login.
+    expect(new URL(page.url()).pathname).toMatch(/^\/app/);
+    await expect(page).not.toHaveURL(/\/auth\/login/);
+
+    // The backend serves the synthesized anonymous user.
+    const me = await page.request.get("/api/me");
+    expect(me.ok()).toBe(true);
+    const body = await me.json();
+    expect(body.is_anonymous_user).toBe(true);
+  });
+
+  test("'continue as guest' on the login page leads to chat when enabled", async ({
+    page,
+  }) => {
+    await setAnonymousChatEnabled(page, true);
+    await page.context().clearCookies();
+
+    await page.goto("/auth/login");
+    await page.waitForLoadState("networkidle");
+
+    const guestLink = page.getByRole("link", { name: /continue as guest/i });
+    await expect(guestLink).toBeVisible();
+    await guestLink.click();
+
+    await page.waitForLoadState("networkidle");
+    expect(new URL(page.url()).pathname).toMatch(/^\/app/);
+  });
+});


### PR DESCRIPTION
- [x] [Optional] Please cherry-pick this PR to the latest release version.

## Problem

Fixes #11935. On single-tenant self-hosted Onyx, enabling **Anonymous Chat** still redirected logged-out visitors to `/auth/login`, and the "or continue as guest" link did nothing. Worked in 1.6.0 — a regression.

## Root cause (two layers)

This turned out to be **two** independent gates bouncing the anonymous user, not one. The first was found by inspection; the second was caught by CI Playwright after the first fix landed.

### 1. Edge middleware (`web/src/proxy.ts`)

The Next.js edge middleware fast-redirected any cookie-less request to a protected route to `/auth/login`. Cloud/multi-tenant anonymous access sets an `onyx_anonymous_user` cookie so it slipped through; **single-tenant self-hosted sets no cookie** (the backend synthesizes the anonymous user from the enabled setting), so the edge always redirected.

**Fix:** drop `/app` from the edge-gated `PROTECTED_ROUTES` and let `requireAuth()` in `web/src/app/app/layout.tsx` own it (it reads the setting fresh via `/me`: serve the anonymous user when on, redirect when off). `/admin`, `/agents`, and `/connector` never allow anonymous and keep the edge redirect — and now require a **real auth cookie** there (the anonymous cookie no longer satisfies the edge gate; the server-side role checks reject it anyway).

### 2. Client-side gates (`useTokenRefresh`, `AppPage`)

With the edge fixed, `/app` renders server-side for the anonymous user — but two client paths then bounced them back to `/auth/login`:

- **`useTokenRefresh`** ran for the anonymous user (it only bailed for signed-out / OIDC / SAML). Anonymous users have no session token, so `POST /api/auth/refresh` 401s, churning the `/me` query. → now skips anonymous users.
- **`AppPage`** redirected on `!user`, but `useUser()` reports `null` during the `/me` load window. That transient redirect sends everyone to `/auth/login`; logged-in users silently bounce back, but the login page **deliberately keeps anonymous users there**, stranding them. → now gates on the *resolved* `/me` result (`undefined` = loading, `null` = signed-out), so the load window no longer redirects.

The "or continue as guest" link works again as a side effect (its `/app` target is now reachable and sticky).

## Tests

`@exclusive` Playwright suite `web/tests/e2e/auth/anonymous_chat.spec.ts` (toggles the global setting via the admin API, restores it in `afterEach`):
1. logged-out → redirected to login when **disabled**;
2. logged-out → reaches `/app` and `/me` returns `is_anonymous_user: true` when **enabled**;
3. the "continue as guest" link lands on `/app` when enabled.

Verified locally: `oxfmt`, `oxlint`, and `tsgo` type-check all pass. Full-stack e2e is validated by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
