### PR TITLE
chore(cloud): temporarily pause signups

### DIFF
--- a/web/src/app/auth/signup/page.tsx
+++ b/web/src/app/auth/signup/page.tsx
@@ -12,7 +12,9 @@ import AuthFlowContainer from "@/components/auth/AuthFlowContainer";
 import ReferralSourceSelector from "./ReferralSourceSelector";
 import AuthErrorDisplay from "@/components/auth/AuthErrorDisplay";
 import Text from "@/refresh-components/texts/Text";
-import { cn } from "@opal/utils";
+import { Button, Text as OpalText } from "@opal/components";
+import { SvgArrowRightCircle, SvgInfo } from "@opal/icons";
+import { cn, markdown } from "@opal/utils";
 import { AuthType } from "@/lib/constants";
 
 const Page = async (props: {
@@ -49,6 +51,46 @@ const Page = async (props: {
     return redirect("/auth/waiting-on-verification");
   }
   const cloud = authTypeMetadata?.authType === AuthType.CLOUD;
+
+  if (cloud) {
+    return (
+      <AuthFlowContainer authState="signup">
+        <div className="flex w-full flex-col justify-start gap-6">
+          <div className="w-full">
+            <OpalText as="h2" font="heading-h2" color="text-05">
+              Create account
+            </OpalText>
+            <OpalText as="p" font="main-ui-body" color="text-03">
+              Get started with Onyx
+            </OpalText>
+          </div>
+
+          <div className="flex w-full gap-3 rounded-16 border border-border-01 bg-background p-4">
+            <SvgInfo className="mt-0.5 size-5 shrink-0 text-text-03" />
+            <div className="flex min-w-0 flex-col gap-1">
+              <OpalText as="p" font="main-ui-action" color="text-04">
+                New account creation unavailable.
+              </OpalText>
+              <OpalText as="p" font="main-ui-body" color="text-03">
+                {markdown(
+                  "Existing accounts can still [sign in](/auth/login?autoRedirectToSignup=false). New accounts will be available again soon."
+                )}
+              </OpalText>
+              <OpalText as="p" font="main-ui-body" color="text-03">
+                {markdown(
+                  "You can still try Onyx by [self-hosting](https://docs.onyx.app/deployment/overview)."
+                )}
+              </OpalText>
+            </div>
+          </div>
+
+          <Button disabled width="full" rightIcon={SvgArrowRightCircle}>
+            Create Account
+          </Button>
+        </div>
+      </AuthFlowContainer>
+    );
+  }
 
   // only enable this page if basic login is enabled
   if (authTypeMetadata?.authType !== AuthType.BASIC && !cloud) {


### PR DESCRIPTION
<img width="619" height="483" alt="image" src="https://github.com/user-attachments/assets/0bcbc37a-5cec-4087-8b5e-c319bbf95822" />
- **fix(craft): fix /workspace/sessions volume permissions in Docker sandbox**
- **chore(cloud): temporarily pause signups**

## Description

<!--- Provide a brief description of the changes in this PR --->
Temporarily pauses multi-tenant Cloud signups with a clear hold message.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

https://linear.app/onyx-app/issue/ENG-4216/immediate-block-all-new-cloud-sign-ups

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Temporarily pauses Cloud signups when `AuthType.CLOUD` is active by showing an in-page notice and disabling account creation. Existing users can sign in; new users are directed to self-hosting docs.

- **New Features**
  - Show an info banner on Cloud signup with sign-in and self-hosting links; disable the “Create Account” button.
  - Use `@opal/components` (`Button`, `Text`), `@opal/icons` (`SvgInfo`, `SvgArrowRightCircle`), and `@opal/utils` (`markdown`).

<sup>Written for commit be9895d5dcbcfd8dbf31d679b6f1e4dfa7b1ab83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





