### PR TITLE
feat(llm-disablement): disable new LLM provider configuration on cloud

### DIFF
--- a/web/src/refresh-pages/admin/LanguageModelsPage.tsx
+++ b/web/src/refresh-pages/admin/LanguageModelsPage.tsx
@@ -14,7 +14,7 @@ import {
   Text,
   Card,
 } from "@opal/components";
-import { Hoverable } from "@opal/core";
+import { Hoverable, Disabled } from "@opal/core";
 import { SvgArrowExchange, SvgSettings, SvgTrash } from "@opal/icons";
 import { SettingsLayouts } from "@opal/layouts";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
@@ -433,30 +433,32 @@ export default function LanguageModelsPage() {
         )}
 
         {/* ── Add Provider (always visible) ── */}
-        <GeneralLayouts.Section
-          gap={0.75}
-          height="fit"
-          alignItems="stretch"
-          justifyContent="start"
-        >
-          <Content
-            title="Add Provider"
-            description="Onyx supports both popular providers and self-hosted models."
-            sizePreset="main-content"
-            variant="section"
-          />
+        <Disabled disabled={NEXT_PUBLIC_CLOUD_ENABLED}>
+          <GeneralLayouts.Section
+            gap={0.75}
+            height="fit"
+            alignItems="stretch"
+            justifyContent="start"
+          >
+            <Content
+              title="Add Provider"
+              description="Onyx supports both popular providers and self-hosted models."
+              sizePreset="main-content"
+              variant="section"
+            />
 
-          <div className="grid grid-cols-2 gap-2">
-            {PROVIDER_DISPLAY_ORDER.map((name) => (
-              <NewProviderCard
-                key={name}
-                providerName={name}
-                isFirstProvider={isFirstProvider}
-              />
-            ))}
-            <NewCustomProviderCard isFirstProvider={isFirstProvider} />
-          </div>
-        </GeneralLayouts.Section>
+            <div className="grid grid-cols-2 gap-2">
+              {PROVIDER_DISPLAY_ORDER.map((name) => (
+                <NewProviderCard
+                  key={name}
+                  providerName={name}
+                  isFirstProvider={isFirstProvider}
+                />
+              ))}
+              <NewCustomProviderCard isFirstProvider={isFirstProvider} />
+            </div>
+          </GeneralLayouts.Section>
+        </Disabled>
       </SettingsLayouts.Body>
     </SettingsLayouts.Root>
   );

--- a/web/src/refresh-pages/admin/LanguageModelsPage.tsx
+++ b/web/src/refresh-pages/admin/LanguageModelsPage.tsx
@@ -31,6 +31,7 @@ import { useCreateModal } from "@/refresh-components/contexts/ModalContext";
 import { LLMProviderName, LLMProviderView } from "@/lib/languageModels/types";
 import { Section } from "@/layouts/general-layouts";
 import { markdown } from "@opal/utils";
+import { NEXT_PUBLIC_CLOUD_ENABLED } from "@/lib/constants";
 
 const route = ADMIN_ROUTES.LLM_MODELS;
 
@@ -420,6 +421,15 @@ export default function LanguageModelsPage() {
 
             <Divider paddingParallel="fit" paddingPerpendicular="fit" />
           </>
+        )}
+
+        {/* ── Cloud disablement notice ── */}
+        {NEXT_PUBLIC_CLOUD_ENABLED && (
+          <MessageCard
+            variant="info"
+            title="New LLM configuration temporarily unavailable."
+            description="Existing LLM providers can still be used and updated."
+          />
         )}
 
         {/* ── Add Provider (always visible) ── */}

--- a/web/src/refresh-pages/admin/LanguageModelsPage.tsx
+++ b/web/src/refresh-pages/admin/LanguageModelsPage.tsx
@@ -426,9 +426,9 @@ export default function LanguageModelsPage() {
         {/* ── Cloud disablement notice ── */}
         {NEXT_PUBLIC_CLOUD_ENABLED && (
           <MessageCard
-            variant="info"
             title="New LLM configuration temporarily unavailable."
             description="Existing LLM providers can still be used and updated."
+            headerPadding="xs"
           />
         )}
 


### PR DESCRIPTION
## Description

On cloud deployments (`NEXT_PUBLIC_CLOUD_ENABLED=true`), new LLM provider configuration is temporarily unavailable. This PR surfaces that clearly in the admin Language Models page:

- Adds an info banner above the "Add Provider" section: *"New LLM configuration temporarily unavailable. Existing LLM providers can still be used and updated."*
- Wraps the entire "Add Provider" section in `Disabled` so the provider grid is visually greyed out and non-interactive on cloud.

Existing providers remain fully usable and editable — only the addition of new providers is gated.

## Screenshots + Videos

<img width="1457" height="1072" alt="image" src="https://github.com/user-attachments/assets/144fbc94-18c3-46fe-b1bb-0702839dece5" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Temporarily disables adding new LLM providers on cloud (`NEXT_PUBLIC_CLOUD_ENABLED=true`) and clearly communicates this on the Language Models page. Existing providers remain fully usable and editable.

- **New Features**
  - Show info banner: "New LLM configuration temporarily unavailable. Existing LLM providers can still be used and updated."
  - Wrap the "Add Provider" section in `Disabled` when `NEXT_PUBLIC_CLOUD_ENABLED` is true (greyed out and non-interactive).

<sup>Written for commit cb800e9b8c8f1ece7056c4f54307e2747d60996c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12076?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->