### PR TITLE
fix(sentry): reduce captured content in error events

### DIFF
--- a/backend/model_server/main.py
+++ b/backend/model_server/main.py
@@ -5,7 +5,6 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from pathlib import Path
 
-import sentry_sdk
 import torch
 import uvicorn
 from fastapi import FastAPI
@@ -97,16 +96,12 @@ def get_model_app() -> FastAPI:
         title="Onyx Model Server", version=__version__, lifespan=lifespan
     )
     if SENTRY_DSN:
-        from onyx.configs.sentry import _add_instance_tags
+        from onyx.configs.sentry import init_sentry
 
-        sentry_sdk.init(
-            dsn=SENTRY_DSN,
-            integrations=[StarletteIntegration(), FastApiIntegration()],
+        init_sentry(
             traces_sample_rate=SENTRY_TRACES_SAMPLE_RATE,
-            release=__version__,
-            before_send=_add_instance_tags,
+            integrations=[StarletteIntegration(), FastApiIntegration()],
         )
-        logger.info("Sentry initialized")
     else:
         logger.debug("Sentry DSN not provided, skipping Sentry initialization")
 

--- a/backend/onyx/background/celery/apps/app_base.py
+++ b/backend/onyx/background/celery/apps/app_base.py
@@ -6,7 +6,6 @@ import time
 from typing import Any
 from typing import cast
 
-import sentry_sdk
 from celery import bootsteps  # ty: ignore[unresolved-import]
 from celery import Task
 from celery.app import trace  # ty: ignore[unresolved-import]
@@ -22,7 +21,6 @@ from sentry_sdk.integrations.celery import CeleryIntegration
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
-from onyx import __version__
 from onyx.background.celery.apps.task_formatters import CeleryTaskColoredFormatter
 from onyx.background.celery.apps.task_formatters import CeleryTaskJsonFormatter
 from onyx.background.celery.apps.task_formatters import CeleryTaskPlainFormatter
@@ -68,16 +66,12 @@ logger = setup_logger()
 task_logger = get_task_logger(__name__)
 
 if SENTRY_DSN:
-    from onyx.configs.sentry import _add_instance_tags
+    from onyx.configs.sentry import init_sentry
 
-    sentry_sdk.init(
-        dsn=SENTRY_DSN,
-        integrations=[CeleryIntegration()],
+    init_sentry(
         traces_sample_rate=SENTRY_CELERY_TRACES_SAMPLE_RATE,
-        release=__version__,
-        before_send=_add_instance_tags,
+        integrations=[CeleryIntegration()],
     )
-    logger.info("Sentry initialized")
 else:
     logger.debug("Sentry DSN not provided, skipping Sentry initialization")
 

--- a/backend/onyx/background/celery/tasks/docfetching/tasks.py
+++ b/backend/onyx/background/celery/tasks/docfetching/tasks.py
@@ -5,12 +5,10 @@ import traceback
 from time import sleep
 
 import psutil
-import sentry_sdk
 from celery import Celery
 from celery import shared_task
 from celery import Task
 
-from onyx import __version__
 from onyx.background.celery.apps.app_base import task_logger
 from onyx.background.celery.memory_monitoring import emit_process_memory
 from onyx.background.celery.memory_monitoring import start_memory_observer
@@ -145,15 +143,9 @@ def _docfetching_task(
     # Since connector_indexing_proxy_task spawns a new process using this function as
     # the entrypoint, we init Sentry here.
     if SENTRY_DSN:
-        from onyx.configs.sentry import _add_instance_tags
+        from onyx.configs.sentry import init_sentry
 
-        sentry_sdk.init(
-            dsn=SENTRY_DSN,
-            traces_sample_rate=SENTRY_CELERY_TRACES_SAMPLE_RATE,
-            release=__version__,
-            before_send=_add_instance_tags,
-        )
-        logger.info("Sentry initialized")
+        init_sentry(traces_sample_rate=SENTRY_CELERY_TRACES_SAMPLE_RATE)
     else:
         logger.debug("Sentry DSN not provided, skipping Sentry initialization")
 

--- a/backend/onyx/configs/sentry.py
+++ b/backend/onyx/configs/sentry.py
@@ -1,8 +1,16 @@
-from typing import Any
+from __future__ import annotations
 
+from typing import Any
+from typing import TYPE_CHECKING
+
+from sentry_sdk.scrubber import DEFAULT_DENYLIST
+from sentry_sdk.scrubber import EventScrubber
 from sentry_sdk.types import Event
 
 from onyx.utils.logger import setup_logger
+
+if TYPE_CHECKING:
+    from sentry_sdk.integrations import Integration
 
 logger = setup_logger()
 
@@ -46,3 +54,60 @@ def _add_instance_tags(
         logger.debug("Failed to resolve instance_id for Sentry tagging")
 
     return event
+
+
+# Provider API keys ride in litellm's outbound request `headers` dict, which
+# Sentry can capture. Its default denylist only has the underscore `x_api_key`,
+# so the real hyphenated header names slip through — add them here.
+_EXTRA_CREDENTIAL_DENYLIST = [
+    "x-api-key",
+    "api-key",
+    "x-goog-api-key",
+    "proxy-authorization",
+    "anthropic-api-key",
+]
+
+
+def build_event_scrubber() -> EventScrubber:
+    """Recursive credential scrubber shared by every Sentry init.
+
+    ``recursive=True`` so a sensitive key nested under a non-sensitive parent
+    (e.g. ``headers.x-api-key``) is redacted — the default scrubber only
+    inspects top-level keys.
+    """
+    return EventScrubber(
+        denylist=DEFAULT_DENYLIST + _EXTRA_CREDENTIAL_DENYLIST,
+        recursive=True,
+    )
+
+
+def init_sentry(
+    *,
+    traces_sample_rate: float,
+    integrations: list[Integration] | None = None,
+) -> None:
+    """Initialize Sentry with credential-safe defaults for every entrypoint.
+
+    Routing all inits through here keeps the hardening correct-by-construction:
+    no entrypoint can reintroduce the credential leak. Callers guard on
+    SENTRY_DSN and pass only what differs (sample rate, integrations).
+    """
+    import sentry_sdk
+
+    from onyx import __version__
+    from shared_configs.configs import SENTRY_DSN
+
+    sentry_sdk.init(
+        dsn=SENTRY_DSN,
+        integrations=integrations or [],
+        traces_sample_rate=traces_sample_rate,
+        release=__version__,
+        before_send=_add_instance_tags,
+        # Never capture stack-frame locals: litellm holds the provider key in
+        # the outbound request `headers` dict Sentry would otherwise store.
+        # Also scrub nested credential keys (incl. the hyphenated x-api-key).
+        include_local_variables=False,
+        send_default_pii=False,
+        event_scrubber=build_event_scrubber(),
+    )
+    logger.info("Sentry initialized")

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -7,7 +7,6 @@ from contextlib import asynccontextmanager
 from typing import Any
 from typing import cast
 
-import sentry_sdk
 import uvicorn
 from fastapi import APIRouter
 from fastapi import FastAPI
@@ -473,16 +472,12 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
         lifespan=lifespan_override or lifespan,
     )
     if SENTRY_DSN:
-        from onyx.configs.sentry import _add_instance_tags
+        from onyx.configs.sentry import init_sentry
 
-        sentry_sdk.init(
-            dsn=SENTRY_DSN,
-            integrations=[StarletteIntegration(), FastApiIntegration()],
+        init_sentry(
             traces_sample_rate=SENTRY_TRACES_SAMPLE_RATE,
-            release=__version__,
-            before_send=_add_instance_tags,
+            integrations=[StarletteIntegration(), FastApiIntegration()],
         )
-        logger.info("Sentry initialized")
     else:
         logger.debug("Sentry DSN not provided, skipping Sentry initialization")
 

--- a/backend/tests/unit/onyx/configs/test_sentry_scrubber.py
+++ b/backend/tests/unit/onyx/configs/test_sentry_scrubber.py
@@ -1,9 +1,19 @@
-"""Guards the Sentry credential scrubber: a provider API key nested in a
-captured `headers` dict (e.g. litellm's outbound request, where the key lives
-under the hyphenated `x-api-key`) must be redacted, while non-sensitive
-debugging fields are preserved."""
+"""Guards the Sentry credential hardening:
+
+1. ``build_event_scrubber()`` redacts a provider API key nested in a captured
+   ``headers`` dict (e.g. litellm's outbound request, where the key lives under
+   the hyphenated ``x-api-key``) while preserving non-sensitive fields.
+2. ``init_sentry()`` actually wires the credential-safe kwargs into
+   ``sentry_sdk.init`` so a future refactor can't silently drop them.
+"""
+
+from unittest.mock import patch
+
+from sentry_sdk.scrubber import EventScrubber
+from sentry_sdk.utils import AnnotatedValue
 
 from onyx.configs.sentry import build_event_scrubber
+from onyx.configs.sentry import init_sentry
 
 
 def _frame_event(frame_vars: dict) -> dict:
@@ -27,12 +37,14 @@ def test_scrubber_redacts_nested_hyphenated_api_key_header() -> None:
 
     build_event_scrubber().scrub_event(event)
 
-    out = _frame_vars(event)
-    # nested credential under a non-sensitive parent key is gone
-    assert out["headers"]["x-api-key"] != secret
+    headers = _frame_vars(event)["headers"]
+    # key is preserved but swapped for sentry's redaction sentinel (not deleted,
+    # not left as the secret) — pinning the type catches either regression cleanly
+    assert "x-api-key" in headers
+    assert isinstance(headers["x-api-key"], AnnotatedValue)
     # non-sensitive context is retained for debugging
-    assert out["headers"]["content-type"] == "application/json"
-    assert out["model"] == "claude-sonnet-4-6"
+    assert headers["content-type"] == "application/json"
+    assert _frame_vars(event)["model"] == "claude-sonnet-4-6"
 
 
 def test_scrubber_redacts_nested_authorization_header() -> None:
@@ -41,4 +53,16 @@ def test_scrubber_redacts_nested_authorization_header() -> None:
 
     build_event_scrubber().scrub_event(event)
 
-    assert _frame_vars(event)["headers"]["authorization"] != secret
+    headers = _frame_vars(event)["headers"]
+    assert "authorization" in headers
+    assert isinstance(headers["authorization"], AnnotatedValue)
+
+
+def test_init_sentry_wires_credential_safe_kwargs() -> None:
+    with patch("sentry_sdk.init") as mock_init:
+        init_sentry(traces_sample_rate=0.0)
+
+    kwargs = mock_init.call_args.kwargs
+    assert kwargs["include_local_variables"] is False
+    assert kwargs["send_default_pii"] is False
+    assert isinstance(kwargs["event_scrubber"], EventScrubber)

--- a/backend/tests/unit/onyx/configs/test_sentry_scrubber.py
+++ b/backend/tests/unit/onyx/configs/test_sentry_scrubber.py
@@ -1,0 +1,44 @@
+"""Guards the Sentry credential scrubber: a provider API key nested in a
+captured `headers` dict (e.g. litellm's outbound request, where the key lives
+under the hyphenated `x-api-key`) must be redacted, while non-sensitive
+debugging fields are preserved."""
+
+from onyx.configs.sentry import build_event_scrubber
+
+
+def _frame_event(frame_vars: dict) -> dict:
+    return {
+        "exception": {"values": [{"stacktrace": {"frames": [{"vars": frame_vars}]}}]}
+    }
+
+
+def _frame_vars(event: dict) -> dict:
+    return event["exception"]["values"][0]["stacktrace"]["frames"][0]["vars"]
+
+
+def test_scrubber_redacts_nested_hyphenated_api_key_header() -> None:
+    secret = "placeholder-credential-value-1234567890"
+    event = _frame_event(
+        {
+            "headers": {"x-api-key": secret, "content-type": "application/json"},
+            "model": "claude-sonnet-4-6",
+        }
+    )
+
+    build_event_scrubber().scrub_event(event)
+
+    out = _frame_vars(event)
+    # nested credential under a non-sensitive parent key is gone
+    assert out["headers"]["x-api-key"] != secret
+    # non-sensitive context is retained for debugging
+    assert out["headers"]["content-type"] == "application/json"
+    assert out["model"] == "claude-sonnet-4-6"
+
+
+def test_scrubber_redacts_nested_authorization_header() -> None:
+    secret = "Bearer placeholder-token-value-1234567890"
+    event = _frame_event({"headers": {"authorization": secret}})
+
+    build_event_scrubber().scrub_event(event)
+
+    assert _frame_vars(event)["headers"]["authorization"] != secret

--- a/backend/tests/unit/onyx/configs/test_sentry_scrubber.py
+++ b/backend/tests/unit/onyx/configs/test_sentry_scrubber.py
@@ -66,3 +66,11 @@ def test_init_sentry_wires_credential_safe_kwargs() -> None:
     assert kwargs["include_local_variables"] is False
     assert kwargs["send_default_pii"] is False
     assert isinstance(kwargs["event_scrubber"], EventScrubber)
+
+
+def test_build_event_scrubber_is_recursive_and_extends_denylist() -> None:
+    scrubber = build_event_scrubber()
+    # recursive is load-bearing: the stock scrubber only inspects top-level keys,
+    # so a non-recursive one would never reach the nested headers.x-api-key
+    assert scrubber.recursive is True
+    assert "x-api-key" in scrubber.denylist


### PR DESCRIPTION
## Description

Sentry was storing things we dont want them store in plaintext in error events.

- **Bug:** with `include_local_variables` on (the default), a raised `litellm` call captured the outbound request `headers` dict — which holds the protected info — into the event. Sentry's default scrubber doesnt catch everything, so some headers slipped through. Confirmed on a real production event.
- **Fix:** centralize all Sentry setup in one `init_sentry()` helper so no entrypoint can reintroduce the leak. It turns off `include_local_variables` and installs a recursive `EventScrubber` whose denylist adds the hyphenated header names. All four init sites (api server, model server, celery app, docfetching task) route through it.
- **Test:** unit test for the nested-header redaction.

Stops new captures only

## How Has This Been Tested?

<!--- author to fill in --->

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check