### PR TITLE
fix(craft): fix /workspace/sessions volume permissions in Docker sandbox

### DIFF
--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -484,10 +484,12 @@ def build_container_create_kwargs(
       bypassing the init); ``command=["/workspace/entrypoint.sh"]`` becomes the
       arg firewall-init.sh exec's after setpriv drops caps + switches to UID
       1000.
-    - ``cap_add=["NET_ADMIN", "SETPCAP", "SETUID", "SETGID"]`` (NET_ADMIN runs
-      iptables; SETPCAP authorises ``setpriv --bounding-set=-all``;
-      SETUID/SETGID gate setpriv's ``--reuid``/``--regid`` under
-      ``cap_drop=ALL``). All four leave the bounding set before the agent
+    - ``cap_add=["NET_ADMIN", "SETPCAP", "SETUID", "SETGID", "CHOWN"]``
+      (NET_ADMIN runs iptables; SETPCAP authorises
+      ``setpriv --bounding-set=-all``; SETUID/SETGID gate setpriv's
+      ``--reuid``/``--regid`` under ``cap_drop=ALL``; CHOWN repairs the
+      sessions volume mount-point owner). All five leave the bounding set
+      before the agent
       execve, so the running container ends up with no caps at all.
     - ``user="0:0"`` so the init starts as root for iptables. setpriv then drops
       to UID 1000. The root+NET_ADMIN window is bounded by ``firewall-init.sh``
@@ -562,9 +564,10 @@ def build_container_create_kwargs(
         # NET_ADMIN: iptables. SETPCAP: prctl(PR_CAPBSET_DROP) for `setpriv
         # --bounding-set=-all`. SETUID/SETGID: setpriv's --reuid/--regid call
         # setuid()/setgroups(), which are gated on these caps even for UID 0
-        # under cap_drop=ALL. All four leave the bounding set before the agent
-        # execve, so the running container ends up with no caps.
-        cap_add = ["NET_ADMIN", "SETPCAP", "SETUID", "SETGID"]
+        # under cap_drop=ALL. CHOWN: repair /workspace/sessions mount-point
+        # ownership before dropping to UID 1000. All five leave the bounding set
+        # before the agent execve, so the running container ends up with no caps.
+        cap_add = ["NET_ADMIN", "SETPCAP", "SETUID", "SETGID", "CHOWN"]
     else:
         entrypoint = None
         command = ["/workspace/entrypoint.sh"]

--- a/backend/onyx/server/features/build/sandbox/image/firewall-init.sh
+++ b/backend/onyx/server/features/build/sandbox/image/firewall-init.sh
@@ -135,6 +135,16 @@ case "$SANDBOX_PROXY_BOOTSTRAP_MODE" in
         # setpriv (not capsh): capsh's `-- args` form invokes /bin/bash and
         # mangles non-script targets; setpriv execve's directly.
         [[ "$#" -ge 1 ]] || die "entrypoint mode requires the real entrypoint as args"
+
+        # Fix volume mount permissions: Docker volumes are created with default
+        # ownership (root:root). The Dockerfile's chown only affects the image
+        # layer, not mounted volumes. Fix ownership before dropping to UID 1000
+        # so the sandbox user can create sessions.
+        if [ -d /workspace/sessions ]; then
+            chown -R 1000:1000 /workspace/sessions
+            log "fixed /workspace/sessions ownership -> 1000:1000"
+        fi
+
         log "entrypoint mode: clearing bounding set, dropping to UID 1000, exec'ing: $*"
         # HOME/USER must be set explicitly: setpriv switches uid/gid but does
         # not refresh env vars. Inheriting HOME=/root from the root parent

--- a/backend/onyx/server/features/build/sandbox/image/firewall-init.sh
+++ b/backend/onyx/server/features/build/sandbox/image/firewall-init.sh
@@ -130,18 +130,20 @@ case "$SANDBOX_PROXY_BOOTSTRAP_MODE" in
     entrypoint)
         # Compose-only: K8s initcontainer mode exits earlier, never reaches
         # here. Docker manager grants cap_add=[NET_ADMIN, SETPCAP, SETUID,
-        # SETGID]: NET_ADMIN for iptables, SETPCAP for the bounding-set drop,
-        # SETUID/SETGID for setpriv's --reuid/--regid under cap_drop=ALL.
+        # SETGID, CHOWN]: NET_ADMIN for iptables, SETPCAP for the bounding-set
+        # drop, SETUID/SETGID for setpriv's --reuid/--regid under
+        # cap_drop=ALL, and CHOWN for the sessions mount-point repair below.
         # setpriv (not capsh): capsh's `-- args` form invokes /bin/bash and
         # mangles non-script targets; setpriv execve's directly.
         [[ "$#" -ge 1 ]] || die "entrypoint mode requires the real entrypoint as args"
 
         # Fix volume mount permissions: Docker volumes are created with default
         # ownership (root:root). The Dockerfile's chown only affects the image
-        # layer, not mounted volumes. Fix ownership before dropping to UID 1000
-        # so the sandbox user can create sessions.
+        # layer, not mounted volumes. Fix only the mount point before dropping
+        # to UID 1000 so the sandbox user can create sessions without walking
+        # existing saved workspaces on every container restart.
         if [ -d /workspace/sessions ]; then
-            chown -R 1000:1000 /workspace/sessions
+            chown 1000:1000 /workspace/sessions
             log "fixed /workspace/sessions ownership -> 1000:1000"
         else
             log "WARNING: /workspace/sessions not found; session creation will fail"

--- a/backend/onyx/server/features/build/sandbox/image/firewall-init.sh
+++ b/backend/onyx/server/features/build/sandbox/image/firewall-init.sh
@@ -143,6 +143,8 @@ case "$SANDBOX_PROXY_BOOTSTRAP_MODE" in
         if [ -d /workspace/sessions ]; then
             chown -R 1000:1000 /workspace/sessions
             log "fixed /workspace/sessions ownership -> 1000:1000"
+        else
+            log "WARNING: /workspace/sessions not found; session creation will fail"
         fi
 
         log "entrypoint mode: clearing bounding set, dropping to UID 1000, exec'ing: $*"

--- a/backend/tests/integration/tests/craft/docker_e2e/test_approval_gate_docker.py
+++ b/backend/tests/integration/tests/craft/docker_e2e/test_approval_gate_docker.py
@@ -471,6 +471,47 @@ def test_unlabeled_container_gets_unidentified_sandbox_403() -> None:
     )
 
 
+def test_sessions_directory_writable_by_sandbox_user(
+    module_sandbox: tuple[UUID, str],
+) -> None:
+    """
+    The /workspace/sessions volume mount must be writable by UID 1000.
+
+    Regression test: Docker volumes are created with root:root ownership.
+    firewall-init.sh must chown the directory before dropping to UID 1000,
+    otherwise session workspace creation fails with EACCES.
+
+    This test verifies that UID 1000 can create a test directory inside
+    /workspace/sessions, proving the permissions fix in firewall-init.sh
+    works correctly.
+    """
+    _session_id, container = module_sandbox
+
+    # Verify /workspace/sessions exists and is owned by 1000:1000
+    stat_result = _docker_exec(
+        container, ["stat", "-c", "%u:%g", "/workspace/sessions"]
+    )
+    assert stat_result.returncode == 0, (
+        f"/workspace/sessions stat failed: {stat_result.stderr}"
+    )
+    assert stat_result.stdout.strip() == "1000:1000", (
+        f"/workspace/sessions not owned by 1000:1000: {stat_result.stdout.strip()}"
+    )
+
+    # Attempt to create a test directory as UID 1000 (the default user in the
+    # container after setpriv drop). This mimics what setup_session_workspace
+    # does when creating a new session.
+    test_dir = f"/workspace/sessions/test-{uuid4().hex[:8]}"
+    mkdir_result = _docker_exec(container, ["mkdir", "-p", test_dir])
+    assert mkdir_result.returncode == 0, (
+        f"mkdir failed as UID 1000: rc={mkdir_result.returncode} "
+        f"stderr={mkdir_result.stderr!r}"
+    )
+
+    # Clean up
+    _docker_exec(container, ["rm", "-rf", test_dir])
+
+
 # ------------------------------------------------------------------------------
 # Tests 6-7: Gate APPROVE / REJECT flow (analogues of K8s test_approval_gate)
 #

--- a/backend/tests/integration/tests/craft/docker_e2e/test_approval_gate_docker.py
+++ b/backend/tests/integration/tests/craft/docker_e2e/test_approval_gate_docker.py
@@ -500,15 +500,22 @@ def test_sessions_directory_writable_by_sandbox_user(
 
     # Attempt to create a test directory as UID 1000 (the default user in the
     # container after setpriv drop). This mimics what setup_session_workspace
-    # does when creating a new session.
+    # does when creating a new session. Must use --user 1000:1000 explicitly
+    # because in proxy mode the container runs as root initially.
     test_dir = f"/workspace/sessions/test-{uuid4().hex[:8]}"
-    mkdir_result = _docker_exec(container, ["mkdir", "-p", test_dir])
+    mkdir_result = subprocess.run(
+        ["docker", "exec", "--user", "1000:1000", container, "mkdir", "-p", test_dir],
+        capture_output=True,
+        text=True,
+        timeout=10.0,
+        check=False,
+    )
     assert mkdir_result.returncode == 0, (
         f"mkdir failed as UID 1000: rc={mkdir_result.returncode} "
         f"stderr={mkdir_result.stderr!r}"
     )
 
-    # Clean up
+    # Clean up (as root is fine for removal)
     _docker_exec(container, ["rm", "-rf", test_dir])
 
 

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_manager_config.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_manager_config.py
@@ -432,10 +432,17 @@ def test_proxy_kwargs_runs_init_as_root_with_required_caps(
     proxy_kwargs: ContainerCreateKwargs,
 ) -> None:
     """NET_ADMIN for iptables; SETPCAP authorises the bounding-set drop;
-    SETUID + SETGID gate the uid/gid switch under cap_drop=ALL."""
+    SETUID + SETGID gate the uid/gid switch under cap_drop=ALL; CHOWN repairs
+    the sessions mount-point owner."""
     assert proxy_kwargs["user"] == "0:0"
     assert proxy_kwargs["cap_drop"] == ["ALL"]
-    assert proxy_kwargs["cap_add"] == ["NET_ADMIN", "SETPCAP", "SETUID", "SETGID"]
+    assert proxy_kwargs["cap_add"] == [
+        "NET_ADMIN",
+        "SETPCAP",
+        "SETUID",
+        "SETGID",
+        "CHOWN",
+    ]
     # The other invariants must not regress in proxy mode.
     assert proxy_kwargs["privileged"] is False
     assert "no-new-privileges:true" in proxy_kwargs["security_opt"]


### PR DESCRIPTION
## Problem

When running Craft with `ENABLE_CRAFT=true` and the sandbox proxy enabled (standard production docker-compose deployment), sandbox containers fail to create session workspaces with permission denied errors.

**Root cause:** Docker volumes are created with default ownership (root:root). The Dockerfile's `chown -R sandbox:sandbox /workspace` at build time only affects the **image layer**, not **mounted volumes**. When the volume is mounted at `/workspace/sessions`, it shadows the image's directory with root-owned storage.

In proxy-enabled mode, the container starts as root (for iptables setup via firewall-init.sh), then drops to UID 1000. Without fixing the volume ownership before the drop, UID 1000 cannot write to `/workspace/sessions`.
- [x] [Optional] Override Linear Check

## Solution

Add a permissions fix step in `firewall-init.sh` (entrypoint mode only) that runs `chown -R 1000:1000 /workspace/sessions` while still running as root, before `exec setpriv` drops to UID 1000.

This mirrors the pattern already used for other root-only setup tasks (CA installation, iptables configuration) in the same script.

## Changes

- **`firewall-init.sh`**: Added volume permissions fix before dropping to UID 1000
- **`test_approval_gate_docker.py`**: Added `test_sessions_directory_writable_by_sandbox_user()` regression test

## Testing

The new test verifies:
1. `/workspace/sessions` is owned by `1000:1000` after container start
2. UID 1000 can create directories inside `/workspace/sessions`

This regression test runs as part of the existing `pr-craft-compose-integration.yml` CI workflow.
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Docker sandbox permission errors by chowning the `/workspace/sessions` mount point before dropping to UID 1000 so session workspaces can be created. Also adds `CHOWN` capability in proxy mode and a regression test, and warns if the volume is missing.

- **Bug Fixes**
  - In `firewall-init.sh` (entrypoint mode), chown `/workspace/sessions` to `1000:1000` before `setpriv`; log a warning if the directory is missing.
  - In `docker_sandbox_manager.py`, add `CHOWN` to `cap_add` in proxy mode so the init can repair mount ownership before dropping caps; update unit test to assert this.
  - Add `test_sessions_directory_writable_by_sandbox_user` to verify `1000:1000` ownership and that UID 1000 can create a directory via `docker exec --user 1000:1000`.

<sup>Written for commit bf07f87cf7ef5b2082e031a13c7a63c0702ca298. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



