### PR TITLE
fix(llm): return 400 not 502 when an Ollama server is unreachable

### DIFF
--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -1179,12 +1179,28 @@ def get_bedrock_available_models(
 
 
 def _get_ollama_available_model_names(api_base: str) -> set[str]:
-    """Fetch available model names from Ollama server."""
+    """Fetch available model names from an Ollama server.
+
+    An unreachable address surfaces as 400, not 502: the admin supplied the
+    URL, so a server Onyx can't route to is a client misconfiguration.
+    """
     tags_url = f"{api_base}/api/tags"
     try:
         response = httpx.get(tags_url, timeout=5.0)
         response.raise_for_status()
         response_json = response.json()
+    except httpx.HTTPStatusError as e:
+        raise OnyxError(
+            OnyxErrorCode.BAD_GATEWAY,
+            f"Ollama server at {api_base} returned an error "
+            f"({e.response.status_code}).",
+        )
+    except httpx.RequestError as e:
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            f"Could not reach an Ollama server at {api_base}. Check that the URL "
+            f"is correct and reachable from Onyx ({type(e).__name__}).",
+        )
     except Exception as e:
         raise OnyxError(
             OnyxErrorCode.BAD_GATEWAY,

--- a/backend/tests/unit/onyx/server/manage/llm/test_fetch_models_api.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_fetch_models_api.py
@@ -98,7 +98,7 @@ class TestGetOllamaAvailableModels:
 
         with patch(
             "onyx.server.manage.llm.api.httpx.get",
-            side_effect=httpx.ConnectError("connection refused"),
+            side_effect=httpx.ConnectError("connection refused", request=MagicMock()),
         ):
             request = OllamaModelsRequest(api_base="http://localhost:11434")
             with pytest.raises(OnyxError) as exc_info:

--- a/backend/tests/unit/onyx/server/manage/llm/test_fetch_models_api.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_fetch_models_api.py
@@ -87,6 +87,47 @@ class TestGetOllamaAvailableModels:
                 [r.name for r in results], key=str.lower
             )
 
+    def test_unreachable_server_returns_400(self) -> None:
+        """An unreachable Ollama URL maps to 400, not a 502 gateway fault.
+
+        Patch ``httpx.get``, not the whole module, so the real ``httpx``
+        exception classes remain usable in the handler's except clauses.
+        """
+        from onyx.error_handling.error_codes import OnyxErrorCode
+        from onyx.server.manage.llm.api import get_ollama_available_models
+
+        with patch(
+            "onyx.server.manage.llm.api.httpx.get",
+            side_effect=httpx.ConnectError("connection refused"),
+        ):
+            request = OllamaModelsRequest(api_base="http://localhost:11434")
+            with pytest.raises(OnyxError) as exc_info:
+                get_ollama_available_models(request, MagicMock(), MagicMock())
+
+        assert exc_info.value.error_code == OnyxErrorCode.VALIDATION_ERROR
+        assert exc_info.value.status_code == 400
+
+    def test_upstream_error_status_returns_502(self) -> None:
+        """An error *response* from Ollama is a genuine upstream fault → 502."""
+        from onyx.error_handling.error_codes import OnyxErrorCode
+        from onyx.server.manage.llm.api import get_ollama_available_models
+
+        error_response = httpx.Response(
+            status_code=500, request=httpx.Request("GET", "http://localhost:11434")
+        )
+        with patch(
+            "onyx.server.manage.llm.api.httpx.get",
+            side_effect=httpx.HTTPStatusError(
+                "server error", request=error_response.request, response=error_response
+            ),
+        ):
+            request = OllamaModelsRequest(api_base="http://localhost:11434")
+            with pytest.raises(OnyxError) as exc_info:
+                get_ollama_available_models(request, MagicMock(), MagicMock())
+
+        assert exc_info.value.error_code == OnyxErrorCode.BAD_GATEWAY
+        assert exc_info.value.status_code == 502
+
     def test_syncs_to_db_when_provider_name_specified(
         self, mock_ollama_tags_response: dict, mock_ollama_show_response: dict
     ) -> None:


### PR DESCRIPTION
## Description

**Bug:** The admin "available models" endpoint returned `502 BAD_GATEWAY` for *any* failure reaching the user-supplied Ollama URL — including the common case where the URL simply isn't reachable from Onyx (a localhost/private address entered on cloud). That reads as a server fault in metrics and tells the admin nothing actionable.

**Fix:** Distinguish the two failure modes in `_get_ollama_available_model_names`:
- connection / timeout (`httpx.RequestError`) → `400 VALIDATION_ERROR` ("could not reach `<url>`") — a client misconfiguration
- an error *response* from Ollama (`httpx.HTTPStatusError`) → `502 BAD_GATEWAY` — a genuine upstream fault

Added two unit tests for the new mapping.

**Design note:** mirrors the existing `_get_openai_compatible_models_response` error-handling shape. Ollama maps unreachable→400 because it's overwhelmingly self-hosted (see `api.py:1213`). Litellm/bifrost via the shared helper still map unreachable→502; aligning them is a possible follow-up, left out to keep this scoped to the observed defect.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check