### PR TITLE
fix(llm): prevent LLM environment sharing

### DIFF
--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -3,7 +3,6 @@ import os
 import threading
 from collections.abc import Iterator
 from contextlib import contextmanager
-from contextlib import nullcontext
 from typing import Any
 from typing import cast
 from typing import TYPE_CHECKING
@@ -720,13 +719,9 @@ class LitellmLLM(LLM):
             if "api_key" not in passthrough_kwargs:
                 passthrough_kwargs["api_key"] = self._api_key or None
 
-            # We only need to set environment variables if custom config is set
-            env_ctx = (
-                temporary_env_and_lock(self._custom_config)
-                if self._custom_config
-                else nullcontext()
-            )
-            with env_ctx:
+            # Hold _env_lock during the litellm call so no call sees another's
+            # injected secret; an empty config injects nothing, just locks.
+            with temporary_env_and_lock(self._custom_config or {}):
                 messages = _prompt_to_dicts(prompt)
 
                 # Bedrock's Converse API requires toolConfig when messages
@@ -1009,8 +1004,9 @@ class LitellmLLM(LLM):
 def temporary_env_and_lock(env_variables: dict[str, str]) -> Iterator[None]:
     """
     Temporarily sets the environment variables to the given values.
-    Code path is locked while the environment variables are set.
-    Then cleans up the environment and frees the lock.
+    _env_lock is held while the environment variables are set, so no concurrent
+    LLM call can observe them. Then cleans up the environment and releases the
+    lock.
     """
     with _env_lock:
         logger.debug("Acquired lock in temporary_env_and_lock")

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -719,43 +719,37 @@ class LitellmLLM(LLM):
             if "api_key" not in passthrough_kwargs:
                 passthrough_kwargs["api_key"] = self._api_key or None
 
-            # Hold _env_lock during the litellm call so no call sees another's
-            # injected secret; an empty config injects nothing, just locks.
+            messages = _prompt_to_dicts(prompt)
+
+            # Bedrock's Converse API requires toolConfig when messages
+            # contain toolUse/toolResult content blocks. When no tools are
+            # provided for this request but the history contains tool
+            # content from previous turns, strip it to plain text.
+            is_bedrock = self._model_provider in {
+                LlmProviderNames.BEDROCK,
+                LlmProviderNames.BEDROCK_CONVERSE,
+            }
+            if is_bedrock and not tools and _messages_contain_tool_content(messages):
+                messages = _strip_tool_content_from_messages(messages)
+
+            # Some models (e.g. Mistral) reject a user message
+            # immediately after a tool message. Insert a synthetic
+            # assistant bridge message to satisfy the ordering
+            # constraint. Check both the provider and the deployment/
+            # model name to catch Mistral hosted on Azure.
+            model_or_deployment = (
+                self._deployment_name or self._model_version or ""
+            ).lower()
+            is_mistral_model = is_mistral or "mistral" in model_or_deployment
+            if is_mistral_model:
+                messages = _fix_tool_user_message_ordering(messages)
+
+            # Only pass tool_choice when tools are present — some providers (e.g. Fireworks)
+            # reject requests where tool_choice is explicitly null.
+            if tools and tool_choice is not None:
+                optional_kwargs["tool_choice"] = tool_choice
+
             with temporary_env_and_lock(self._custom_config or {}):
-                messages = _prompt_to_dicts(prompt)
-
-                # Bedrock's Converse API requires toolConfig when messages
-                # contain toolUse/toolResult content blocks. When no tools are
-                # provided for this request but the history contains tool
-                # content from previous turns, strip it to plain text.
-                is_bedrock = self._model_provider in {
-                    LlmProviderNames.BEDROCK,
-                    LlmProviderNames.BEDROCK_CONVERSE,
-                }
-                if (
-                    is_bedrock
-                    and not tools
-                    and _messages_contain_tool_content(messages)
-                ):
-                    messages = _strip_tool_content_from_messages(messages)
-
-                # Some models (e.g. Mistral) reject a user message
-                # immediately after a tool message. Insert a synthetic
-                # assistant bridge message to satisfy the ordering
-                # constraint. Check both the provider and the deployment/
-                # model name to catch Mistral hosted on Azure.
-                model_or_deployment = (
-                    self._deployment_name or self._model_version or ""
-                ).lower()
-                is_mistral_model = is_mistral or "mistral" in model_or_deployment
-                if is_mistral_model:
-                    messages = _fix_tool_user_message_ordering(messages)
-
-                # Only pass tool_choice when tools are present — some providers (e.g. Fireworks)
-                # reject requests where tool_choice is explicitly null.
-                if tools and tool_choice is not None:
-                    optional_kwargs["tool_choice"] = tool_choice
-
                 response = litellm.completion(
                     mock_response=get_llm_mock_response() or MOCK_LLM_RESPONSE,
                     model=model,

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -1228,12 +1228,13 @@ def test_multithreaded_custom_config_isolation(
     assert os.environ.get("LLM_B_ONLY") is None
 
 
-def test_multithreaded_invoke_without_custom_config_skips_env_lock() -> None:
-    """Verify that invoke() without custom_config does not acquire the env lock.
+def test_multithreaded_invoke_without_custom_config_does_not_inject_env() -> None:
+    """invoke() without custom_config holds _env_lock but injects no env vars.
 
-    Two LitellmLLM instances without custom_config call invoke concurrently.
-    Both should run with stream=False, never touch the env lock, and complete
-    without blocking each other.
+    Every call goes through temporary_env_and_lock (so it holds the shared
+    _env_lock during its litellm call and can't observe a concurrent
+    custom_config call's injected secrets). Calls without custom_config pass an
+    empty mapping, so they take the lock but never mutate os.environ.
     """
     from onyx.llm import multi_llm as multi_llm_module
 
@@ -1315,8 +1316,136 @@ def test_multithreaded_invoke_without_custom_config_skips_env_lock() -> None:
     assert call_kwargs["A"]["stream"] is True
     assert call_kwargs["B"]["stream"] is True
 
-    # The env lock context manager should never have been called
-    mock_env_lock.assert_not_called()
+    # Each call takes the lock via temporary_env_and_lock but injects nothing.
+    assert mock_env_lock.call_count == 2
+    for call in mock_env_lock.call_args_list:
+        assert call.args[0] == {}
+
+
+def test_keyless_reader_cannot_observe_writer_injected_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cross-tenant credential isolation in the shared process os.environ.
+
+    A "victim" Bedrock call injects AWS creds from custom_config into os.environ
+    for the duration of its litellm call (litellm's SDKs read more from the
+    environment than litellm accepts as kwargs). It does so under the env write
+    lock. A concurrent keyless "attacker" Bedrock call (no custom_config) takes
+    the shared read lock, so it must block until the writer releases the lock and
+    restores os.environ — it can therefore only ever read a clean environment.
+
+    Before the fix the attacker took nullcontext() (no lock) and could read the
+    victim's secret straight out of os.environ. This test pins that the reader is
+    blocked during the writer's window and sees no secret.
+    """
+    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+
+    VICTIM_SECRET = "victim-aws-secret-DO-NOT-LEAK-0001"
+    VICTIM_ACCESS_KEY_ID = "victim-akid-0002"
+
+    # Victim: Bedrock provider whose creds live in custom_config (env-var format).
+    victim_llm = LitellmLLM(
+        api_key=None,
+        timeout=30,
+        model_provider=LlmProviderNames.BEDROCK,
+        model_name="anthropic.claude-3-sonnet-20240229-v1:0",
+        max_input_tokens=200000,
+        custom_config={
+            "AWS_SECRET_ACCESS_KEY": VICTIM_SECRET,
+            "AWS_ACCESS_KEY_ID": VICTIM_ACCESS_KEY_ID,
+            "AWS_REGION_NAME": "us-east-1",
+        },
+    )
+    # Attacker: keyless Bedrock provider, NO custom_config -> shared read lock.
+    attacker_llm = LitellmLLM(
+        api_key=None,
+        timeout=30,
+        model_provider=LlmProviderNames.BEDROCK,
+        model_name="anthropic.claude-3-haiku-20240307-v1:0",
+        max_input_tokens=200000,
+    )
+
+    mock_stream_chunks = [
+        litellm.ModelResponse(
+            id="chatcmpl-123",
+            choices=[
+                litellm.Choices(
+                    delta=_create_delta(role="assistant", content="Hi"),
+                    finish_reason="stop",
+                    index=0,
+                )
+            ],
+            model="anthropic.claude-3-sonnet-20240229-v1:0",
+        ),
+    ]
+
+    writer_inside = threading.Event()
+    release_writer = threading.Event()
+    reader_ran = threading.Event()
+    reader_env_snapshot: dict[str, str | None] = {}
+
+    def fake_completion(**kwargs: Any) -> list[litellm.ModelResponse]:
+        # The victim's custom_config is mapped into explicit kwargs, so its
+        # presence distinguishes the victim (writer) from the keyless attacker.
+        is_writer = "aws_secret_access_key" in kwargs
+        if is_writer:
+            # Holding the env write lock here; the secret is live in os.environ.
+            # Keep it live until released (bounded so a broken lock can't hang).
+            writer_inside.set()
+            release_writer.wait(timeout=5)
+        else:
+            reader_env_snapshot["AWS_SECRET_ACCESS_KEY"] = os.environ.get(
+                "AWS_SECRET_ACCESS_KEY"
+            )
+            reader_env_snapshot["AWS_ACCESS_KEY_ID"] = os.environ.get(
+                "AWS_ACCESS_KEY_ID"
+            )
+            reader_ran.set()
+        return mock_stream_chunks
+
+    errors: list[Exception] = []
+
+    def run_llm(llm: LitellmLLM) -> None:
+        try:
+            llm.invoke([UserMessage(content="Hi")])
+        except Exception as e:
+            errors.append(e)
+
+    with patch("litellm.completion", side_effect=fake_completion):
+        victim_thread = threading.Thread(target=run_llm, args=(victim_llm,))
+        victim_thread.start()
+        assert writer_inside.wait(timeout=5), (
+            "victim never entered the write-locked section"
+        )
+
+        attacker_thread = threading.Thread(target=run_llm, args=(attacker_llm,))
+        attacker_thread.start()
+
+        # While the writer holds the env write lock, the reader must be blocked
+        # on the read lock: it cannot have run its completion yet. A leak (no
+        # lock for readers) would let it read os.environ immediately.
+        reader_ran_during_window = reader_ran.wait(timeout=1.0)
+
+        release_writer.set()
+        victim_thread.join(timeout=10)
+        attacker_thread.join(timeout=10)
+
+    assert not errors, f"Thread errors: {errors}"
+    assert reader_ran.is_set(), "attacker never completed"
+
+    # The attacker was blocked during the writer's env window...
+    assert not reader_ran_during_window, (
+        "Cross-tenant leak: keyless reader ran concurrently with the victim's "
+        "env injection"
+    )
+    # ...and when it finally ran, the environment was clean.
+    assert reader_env_snapshot["AWS_SECRET_ACCESS_KEY"] is None
+    assert reader_env_snapshot["AWS_ACCESS_KEY_ID"] is None
+
+    # Env fully restored after the writer finished.
+    assert os.environ.get("AWS_SECRET_ACCESS_KEY") is None
+    assert os.environ.get("AWS_ACCESS_KEY_ID") is None
 
 
 # ---- Tests for Bedrock tool content stripping ----


### PR DESCRIPTION
## Description
Concurrent LLM calls in the shared multi-tenant process could read another tenant's credentials out of the global os.environ while a custom_config call had its secrets injected there, since calls without custom_config took no lock. This fix makes every litellm call hold the env lock around the request, so no call can observe another tenant's injected credentials mid-flight.

## How Has This Been Tested?
Tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents cross-tenant credential leaks from shared `os.environ` during concurrent LLM calls. All `litellm` requests now take the env lock; calls without `custom_config` take the lock with an empty env and inject nothing.

- **Bug Fixes**
  - Always hold `_env_lock` around `litellm.completion` via `temporary_env_and_lock(self._custom_config or {})`.
  - Remove `nullcontext`; non-configured calls still take the lock but never modify `os.environ`.
  - Add concurrency tests: keyless reader cannot observe writer-injected AWS creds; verify lock usage without changing behavior.

<sup>Written for commit 24bd5bf2892f113b917190b0fd86c3468a1c32ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

