### PR TITLE
feat: structured audit logging for credential access

### DIFF
--- a/backend/onyx/connectors/credentials_provider.py
+++ b/backend/onyx/connectors/credentials_provider.py
@@ -9,6 +9,7 @@ from onyx.connectors.interfaces import CredentialsProviderInterface
 from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.models import Credential
 from onyx.redis.redis_pool import get_redis_client
+from onyx.utils.credential_audit import emit_credential_access
 
 
 class OnyxDBCredentialsProvider(
@@ -67,6 +68,13 @@ class OnyxDBCredentialsProvider(
 
             if credential.credential_json is None:
                 return {}
+
+            # Audit the connector credential decrypt (best-effort, never raises).
+            emit_credential_access(
+                credential_type="connector",
+                provider=self._connector_name,
+                row_id=self._credential_id,
+            )
             return credential.credential_json.get_value(apply_mask=False)
 
     def set_credentials(self, credential_json: dict[str, Any]) -> None:

--- a/backend/onyx/connectors/factory.py
+++ b/backend/onyx/connectors/factory.py
@@ -23,6 +23,7 @@ from onyx.db.credentials import fetch_credential_by_id
 from onyx.db.enums import AccessType
 from onyx.db.models import Credential
 from onyx.file_store.staging import RawFileCallback
+from onyx.utils.credential_audit import emit_credential_access
 from shared_configs.contextvars import get_current_tenant_id
 
 
@@ -120,6 +121,15 @@ def instantiate_connector(
         )
         connector.set_credentials_provider(provider)
     else:
+        if credential.credential_json:
+            # Distinct decrypt site from OnyxDBCredentialsProvider (static /
+            # non-dynamic connectors load creds directly here), so this is not
+            # double-logged. Audit is best-effort and never raises.
+            emit_credential_access(
+                credential_type="connector",
+                provider=str(source),
+                row_id=credential.id,
+            )
         credential_json = (
             credential.credential_json.get_value(apply_mask=False)
             if credential.credential_json

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -155,15 +155,27 @@ class LLMProviderView(LLMProvider):
 
         provider = llm_provider_model.provider
 
+        api_key: str | None = None
+        if llm_provider_model.api_key:
+            # NOTE: this decrypts the stored LLM provider key (chat hot path).
+            # No user is in scope here, so attribution relies on
+            # request_id / client_ip context. Audit is best-effort and never
+            # raises into this read path.
+            from onyx.utils.credential_audit import emit_credential_access
+
+            emit_credential_access(
+                credential_type="llm_provider",
+                provider=provider,
+                row_id=llm_provider_model.id,
+                user_id=None,
+            )
+            api_key = llm_provider_model.api_key.get_value(apply_mask=False)
+
         return cls(
             id=llm_provider_model.id,
             name=llm_provider_model.name,
             provider=provider,
-            api_key=(
-                llm_provider_model.api_key.get_value(apply_mask=False)
-                if llm_provider_model.api_key
-                else None
-            ),
+            api_key=api_key,
             api_base=llm_provider_model.api_base,
             api_version=llm_provider_model.api_version,
             custom_config=llm_provider_model.custom_config,

--- a/backend/onyx/utils/credential_audit.py
+++ b/backend/onyx/utils/credential_audit.py
@@ -1,0 +1,148 @@
+"""Structured audit logging for credential access (log-only).
+
+Emits a single structured JSON line whenever a stored LLM-provider or connector
+credential is decrypted (read in plaintext via ``get_value(apply_mask=False)``
+/ a credentials provider), for observability and audit purposes. Each event
+carries tenant / request / client-IP context so credential reads can be
+reviewed and attributed. The secret value itself is never included.
+
+This module is deliberately defensive: it must NEVER raise into the calling
+code path (credential reads sit on the chat hot path and on connector
+indexing). Every piece of context is best-effort and any failure degrades to
+``None`` or to "always emit".
+
+The emitted line goes to a dedicated logger named ``onyx.audit.credential_access``
+at INFO. To consume the audit trail, filter logs on that logger name and parse
+the JSON payload.
+"""
+
+import json
+import logging
+import time
+from typing import Any
+
+# Dedicated audit logger. We intentionally use a plain ``logging.getLogger``
+# rather than ``setup_logger`` so the record message is exactly one clean JSON
+# object (the Onyx standard formatter prepends a human-readable prefix, which
+# would make machine parsing harder). The logger propagates to the root so it
+# still reaches the configured handlers / log files.
+AUDIT_LOGGER_NAME = "onyx.audit.credential_access"
+_audit_logger = logging.getLogger(AUDIT_LOGGER_NAME)
+_audit_logger.setLevel(logging.INFO)
+
+# Dedup window: emit at most one event per (tenant, credential_type, row, actor)
+# key within this many seconds. Keeps the chat hot path from flooding the log.
+_DEDUP_TTL_SECONDS = 600
+
+
+def _safe_get_tenant_id() -> str | None:
+    try:
+        from shared_configs.contextvars import get_current_tenant_id
+
+        return get_current_tenant_id()
+    except Exception:
+        return None
+
+
+def _safe_get_request_id() -> str | None:
+    try:
+        from shared_configs.contextvars import ONYX_REQUEST_ID_CONTEXTVAR
+
+        return ONYX_REQUEST_ID_CONTEXTVAR.get()
+    except Exception:
+        return None
+
+
+def _safe_get_endpoint() -> str | None:
+    try:
+        from shared_configs.contextvars import CURRENT_ENDPOINT_CONTEXTVAR
+
+        return CURRENT_ENDPOINT_CONTEXTVAR.get()
+    except Exception:
+        return None
+
+
+def _safe_get_client_ip() -> str | None:
+    try:
+        from onyx.utils.client_ip import current_client_ip
+
+        return current_client_ip()
+    except Exception:
+        return None
+
+
+def _should_emit(
+    tenant_id: str | None,
+    credential_type: str,
+    row_id: int | None,
+    actor: str,
+) -> bool:
+    """Best-effort Redis SETNX-with-EX dedup.
+
+    Returns True if this event should be emitted. If Redis is unavailable for
+    any reason we fall back to always emitting (never raise, never silently
+    drop an audit event due to infra issues).
+    """
+    try:
+        from onyx.redis.redis_pool import get_redis_client
+
+        client = get_redis_client(tenant_id=tenant_id)
+        dedup_key = f"audit:cred_access:{tenant_id}:{credential_type}:{row_id}:{actor}"
+        # set(..., nx=True) returns True only when the key did not already
+        # exist; None means a prior event already claimed this window.
+        result = client.set(dedup_key, "1", ex=_DEDUP_TTL_SECONDS, nx=True)
+        return bool(result)
+    except Exception:
+        # Redis down / misconfigured / no tenant context — degrade to emit.
+        return True
+
+
+def emit_credential_access(
+    credential_type: str,
+    provider: str | None,
+    row_id: int | None,
+    *,
+    user_id: str | None = None,
+    auth_type: str | None = None,
+) -> None:
+    """Emit a single structured audit line for a credential decrypt event.
+
+    Args:
+        credential_type: Coarse category, e.g. "llm_provider" or "connector".
+        provider: The provider / source name if known (e.g. "openai", "google_drive").
+        row_id: The DB row id of the credential / LLM provider, if known.
+        user_id: The acting user id, if available. May be None (e.g. at
+            ``LLMProviderView.from_model`` there is no user in scope).
+        auth_type: How the actor authenticated, if known.
+
+    This function never raises. Any failure to gather context, dedup, or even
+    log is swallowed so the credential read path is never disrupted.
+    """
+    try:
+        tenant_id = _safe_get_tenant_id()
+        request_id = _safe_get_request_id()
+        endpoint = _safe_get_endpoint()
+        client_ip = _safe_get_client_ip()
+
+        # Actor for dedup keying: prefer explicit user, then request, then IP.
+        actor = user_id or request_id or client_ip or "unknown"
+
+        if not _should_emit(tenant_id, credential_type, row_id, actor):
+            return
+
+        payload: dict[str, Any] = {
+            "ts": time.time(),
+            "tenant_id": tenant_id,
+            "credential_type": credential_type,
+            "provider": provider,
+            "row_id": row_id,
+            "user_id": user_id,
+            "auth_type": auth_type,
+            "request_id": request_id,
+            "endpoint": endpoint,
+            "client_ip": client_ip,
+        }
+        _audit_logger.info(json.dumps(payload, default=str))
+    except Exception:
+        # Audit must never break the caller. Last-resort swallow.
+        return


### PR DESCRIPTION
## Description

Adds lightweight, log-only audit logging for credential access. Emits a structured JSON event whenever a stored LLM-provider or connector credential is decrypted (read in plaintext), for observability/audit purposes. Each event includes tenant, credential type, provider, endpoint, request id, and client IP — the secret value itself is never included.

- New `backend/onyx/utils/credential_audit.py` — `emit_credential_access(...)` on a dedicated `onyx.audit.credential_access` logger (one JSON line per event).
- Instruments the credential-decrypt sites in `LLMProviderView.from_model`, `connectors/credentials_provider.py`, and `connectors/factory.py`.
- Fail-safe: the emit path is fully wrapped so it can never raise into the request/chat or connector-indexing paths. Redis-backed dedup avoids hot-path log flooding (degrades to always-emit if Redis is unavailable).
- Log-only; no DB or schema changes.

## How Has This Been Tested?

- `ruff` / `ruff format` / `ty` pass via pre-commit.
- Follow-up: unit test (field shape, secret never logged, no-raise on missing context, dedup suppression).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds structured, log-only audit events for credential decrypts across LLM providers and connectors. Emits one JSON line per access to the `onyx.audit.credential_access` logger to trace reads without exposing secrets.

- **New Features**
  - Emit JSON event on credential decrypt with tenant, credential_type, provider, row_id, request_id, endpoint, and client_ip; secret is never logged.
  - Added `backend/onyx/utils/credential_audit.py` with `emit_credential_access(...)`, Redis-backed 10-minute dedup, and fail-safe behavior (never raises; degrades to always-emit if Redis is down).
  - Instrumented decrypt sites in `LLMProviderView.from_model`, `connectors/credentials_provider.py`, and `connectors/factory.py`.
  - No DB or schema changes.

<sup>Written for commit 89127a32255166f4a96d58abda9a6ce51e71997b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12083?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

