### PR TITLE
fix: resolve #2281

### DIFF
--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -220,6 +220,7 @@ class DocumentSource(str, Enum):
     OUTLINE = "outline"
     CONFLUENCE = "confluence"
     JIRA = "jira"
+    JIRA_SERVICE_MANAGEMENT = "jira_service_management"
     SLAB = "slab"
     PRODUCTBOARD = "productboard"
     FILE = "file"
@@ -700,6 +701,7 @@ DocumentSourceDescription: dict[DocumentSource, str] = {
     DocumentSource.OUTLINE: "Documentation and knowledge base pages",
     DocumentSource.CONFLUENCE: "Wiki pages, spaces, and documentation",
     DocumentSource.JIRA: "Issues, tickets, and project tracking",
+    DocumentSource.JIRA_SERVICE_MANAGEMENT: "Service desk requests, incidents, and tickets",
     DocumentSource.SLAB: "Documentation and knowledge base pages",
     DocumentSource.PRODUCTBOARD: "Product management boards and insights",
     DocumentSource.FILE: "Uploaded files",

--- a/backend/onyx/connectors/jira/connector.py
+++ b/backend/onyx/connectors/jira/connector.py
@@ -389,6 +389,7 @@ def process_jira_issue(
     comment_email_blacklist: tuple[str, ...] = (),
     labels_to_skip: set[str] | None = None,
     parent_hierarchy_raw_node_id: str | None = None,
+    source: DocumentSource = DocumentSource.JIRA,
 ) -> Document | None:
     if labels_to_skip:
         if any(label in issue.fields.labels for label in labels_to_skip):
@@ -485,7 +486,7 @@ def process_jira_issue(
     return Document(
         id=page_url,
         sections=[TextSection(link=page_url, text=ticket_content)],
-        source=DocumentSource.JIRA,
+        source=source,
         semantic_identifier=f"{issue.key}: {issue.fields.summary}",
         title=f"{issue.key} {issue.fields.summary}",
         doc_updated_at=time_str_to_utc(issue.fields.updated),
@@ -524,6 +525,9 @@ class JiraConnector(
         # Custom JQL query to filter Jira issues
         jql_query: str | None = None,
         scoped_token: bool = False,
+        # The source the emitted documents are tagged with. Jira Service Management
+        # reuses this connector but indexes its tickets under a distinct source.
+        document_source: DocumentSource = DocumentSource.JIRA,
     ) -> None:
         self.batch_size = batch_size
 
@@ -537,6 +541,7 @@ class JiraConnector(
         self.labels_to_skip = set(labels_to_skip)
         self.jql_query = jql_query
         self.scoped_token = scoped_token
+        self.document_source = document_source
         self._jira_client: JIRA | None = None
         # Cache project permissions to avoid fetching them repeatedly across runs
         self._project_permissions_cache: dict[str, Any] = {}
@@ -834,6 +839,7 @@ class JiraConnector(
                     comment_email_blacklist=self.comment_email_blacklist,
                     labels_to_skip=self.labels_to_skip,
                     parent_hierarchy_raw_node_id=parent_hierarchy_raw_node_id,
+                    source=self.document_source,
                 ):
                     # Add permission information to the document if requested
                     if include_permissions:
@@ -1066,6 +1072,24 @@ class JiraConnector(
         return JiraConnectorCheckpoint(
             has_more=True,
         )
+
+
+class JiraServiceManagementConnector(JiraConnector):
+    """Connector for Jira Service Management (JSM) projects.
+
+    JSM runs on the same Jira Cloud REST API and shares the issue model used for
+    regular Jira projects, so this connector reuses all of JiraConnector's
+    fetching, checkpointing, permission-sync and hierarchy logic. The only
+    difference is that emitted documents are tagged with
+    DocumentSource.JIRA_SERVICE_MANAGEMENT so JSM tickets are indexed and
+    filterable as a distinct source.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        # Force the JSM source regardless of what the caller passes so this
+        # connector can never emit plain Jira documents by accident.
+        kwargs["document_source"] = DocumentSource.JIRA_SERVICE_MANAGEMENT
+        super().__init__(*args, **kwargs)
 
 
 def make_checkpoint_callback(

--- a/backend/onyx/connectors/registry.py
+++ b/backend/onyx/connectors/registry.py
@@ -60,6 +60,10 @@ CONNECTOR_CLASS_MAP = {
         module_path="onyx.connectors.jira.connector",
         class_name="JiraConnector",
     ),
+    DocumentSource.JIRA_SERVICE_MANAGEMENT: ConnectorMapping(
+        module_path="onyx.connectors.jira.connector",
+        class_name="JiraServiceManagementConnector",
+    ),
     DocumentSource.PRODUCTBOARD: ConnectorMapping(
         module_path="onyx.connectors.productboard.connector",
         class_name="ProductboardConnector",

--- a/backend/tests/unit/onyx/connectors/jira/test_jira_service_management.py
+++ b/backend/tests/unit/onyx/connectors/jira/test_jira_service_management.py
@@ -1,0 +1,90 @@
+from unittest.mock import MagicMock
+
+import pytest
+from jira.resources import Issue
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.jira.connector import JiraConnector
+from onyx.connectors.jira.connector import JiraServiceManagementConnector
+from onyx.connectors.jira.connector import process_jira_issue
+from onyx.connectors.registry import CONNECTOR_CLASS_MAP
+
+
+@pytest.fixture
+def mock_issue() -> MagicMock:
+    issue = MagicMock(spec=Issue)
+    fields = MagicMock()
+    fields.description = "A customer cannot log in"
+    fields.comment = MagicMock()
+    fields.comment.comments = [MagicMock(body="We are looking into it")]
+    fields.reporter = MagicMock()
+    fields.reporter.displayName = "John Doe"
+    fields.reporter.emailAddress = "john@example.com"
+    fields.assignee = MagicMock()
+    fields.assignee.displayName = "Jane Doe"
+    fields.assignee.emailAddress = "jane@example.com"
+    fields.summary = "Login broken"
+    fields.updated = "2023-01-01T00:00:00+0000"
+    fields.labels = []
+
+    issue.fields = fields
+    issue.key = "SUP-1"
+    return issue
+
+
+def test_process_jira_issue_defaults_to_jira_source(mock_issue: MagicMock) -> None:
+    """By default the shared processing helper tags documents as plain Jira."""
+    doc = process_jira_issue("https://example.atlassian.net", mock_issue)
+
+    assert doc is not None
+    assert doc.source == DocumentSource.JIRA
+
+
+def test_process_jira_issue_honors_explicit_source(mock_issue: MagicMock) -> None:
+    """When a source is provided, the emitted document is tagged with it.
+
+    This is what lets Jira Service Management tickets be indexed as a distinct
+    source while reusing all of the Jira processing logic.
+    """
+    doc = process_jira_issue(
+        "https://example.atlassian.net",
+        mock_issue,
+        source=DocumentSource.JIRA_SERVICE_MANAGEMENT,
+    )
+
+    assert doc is not None
+    assert doc.source == DocumentSource.JIRA_SERVICE_MANAGEMENT
+
+
+def test_jsm_connector_reuses_jira_logic_with_jsm_source() -> None:
+    """The JSM connector is a thin JiraConnector subclass pinned to the JSM source."""
+    connector = JiraServiceManagementConnector(
+        jira_base_url="https://example.atlassian.net",
+        project_key="SUP",
+    )
+
+    assert isinstance(connector, JiraConnector)
+    assert connector.document_source == DocumentSource.JIRA_SERVICE_MANAGEMENT
+    # The base Jira connector still defaults to the plain Jira source.
+    assert (
+        JiraConnector(jira_base_url="https://example.atlassian.net").document_source
+        == DocumentSource.JIRA
+    )
+
+
+def test_jsm_connector_source_cannot_be_overridden() -> None:
+    """A caller cannot accidentally make the JSM connector emit plain Jira docs."""
+    connector = JiraServiceManagementConnector(
+        jira_base_url="https://example.atlassian.net",
+        document_source=DocumentSource.JIRA,
+    )
+
+    assert connector.document_source == DocumentSource.JIRA_SERVICE_MANAGEMENT
+
+
+def test_registry_maps_jsm_to_jsm_connector() -> None:
+    """The factory must be able to lazily load the JSM connector class."""
+    mapping = CONNECTOR_CLASS_MAP[DocumentSource.JIRA_SERVICE_MANAGEMENT]
+
+    assert mapping.module_path == "onyx.connectors.jira.connector"
+    assert mapping.class_name == "JiraServiceManagementConnector"

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -754,6 +754,91 @@ export const connectorConfigs: Record<
     ],
     advanced_values: [],
   },
+  jira_service_management: {
+    description: "Configure Jira Service Management connector",
+    subtext: `Configure which Jira Service Management content to index. You can index everything or specify a particular service project.`,
+    values: [
+      {
+        type: "text",
+        query: "Enter the Jira Service Management base URL:",
+        label: "Jira Service Management Base URL",
+        name: "jira_base_url",
+        optional: false,
+        description:
+          "The base URL of your Jira instance (e.g., https://your-domain.atlassian.net)",
+      },
+      {
+        type: "checkbox",
+        query: "Using scoped token?",
+        label: "Using scoped token",
+        name: "scoped_token",
+        optional: true,
+        default: false,
+      },
+      {
+        type: "tab",
+        name: "indexing_scope",
+        label: "How Should We Index Your Jira Service Management?",
+        optional: true,
+        tabs: [
+          {
+            value: "everything",
+            label: "Everything",
+            fields: [
+              {
+                type: "string_tab",
+                label: "Everything",
+                name: "everything",
+                description:
+                  "This connector will index all requests the provided credentials have access to!",
+              },
+            ],
+          },
+          {
+            value: "project",
+            label: "Service Project",
+            fields: [
+              {
+                type: "text",
+                query: "Enter the project key:",
+                label: "Project Key",
+                name: "project_key",
+                description:
+                  "The key of a specific service project to index (e.g., 'SUP').",
+              },
+            ],
+          },
+          {
+            value: "jql",
+            label: "JQL Query",
+            fields: [
+              {
+                type: "text",
+                query: "Enter the JQL query:",
+                label: "JQL Query",
+                name: "jql_query",
+                description:
+                  "A custom JQL query to filter Jira Service Management requests." +
+                  "\n\nIMPORTANT: Do not include any time-based filters in the JQL query as that will conflict with the connector's logic. Additionally, do not include ORDER BY clauses." +
+                  "\n\nSee Atlassian's [JQL documentation](https://support.atlassian.com/jira-software-cloud/docs/advanced-search-reference-jql-fields/) for more details on syntax.",
+              },
+            ],
+          },
+        ],
+        defaultTab: "everything",
+      },
+      {
+        type: "list",
+        query: "Enter email addresses to blacklist from comments:",
+        label: "Comment Email Blacklist",
+        name: "comment_email_blacklist",
+        description:
+          "This is generally useful to ignore certain bots. Add user emails which comments should NOT be indexed.",
+        optional: true,
+      },
+    ],
+    advanced_values: [],
+  },
   salesforce: {
     description: "Configure Salesforce connector",
     values: [
@@ -2030,6 +2115,14 @@ export interface JiraConfig {
   project_key?: string;
   comment_email_blacklist?: string[];
   jql_query?: string;
+}
+
+export interface JiraServiceManagementConfig {
+  jira_base_url: string;
+  project_key?: string;
+  comment_email_blacklist?: string[];
+  jql_query?: string;
+  scoped_token?: boolean;
 }
 
 export interface SalesforceConfig {

--- a/web/src/lib/connectors/credentials.ts
+++ b/web/src/lib/connectors/credentials.ts
@@ -313,6 +313,10 @@ export const credentialTemplates: Record<ValidSources, any> = {
     jira_user_email: null,
     jira_api_token: "",
   } as JiraCredentialJson,
+  jira_service_management: {
+    jira_user_email: null,
+    jira_api_token: "",
+  } as JiraCredentialJson,
   productboard: { productboard_access_token: "" } as ProductboardCredentialJson,
   slab: { slab_bot_token: "" } as SlabCredentialJson,
   coda: { coda_bearer_token: "" } as CodaCredentialJson,

--- a/web/src/lib/sources.ts
+++ b/web/src/lib/sources.ts
@@ -244,6 +244,12 @@ export const SOURCE_METADATA_MAP: SourceMap = {
     docs: `${DOCS_ADMINS_PATH}/connectors/official/jira`,
     isPopular: true,
   },
+  jira_service_management: {
+    icon: SvgJira,
+    displayName: "Jira Service Management",
+    category: SourceCategory.TicketingAndTaskManagement,
+    docs: `${DOCS_ADMINS_PATH}/connectors/official/jira`,
+  },
   zendesk: {
     icon: SvgZendesk,
     displayName: "Zendesk",

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -551,6 +551,7 @@ export enum ValidSources {
   Outline = "outline",
   Confluence = "confluence",
   Jira = "jira",
+  JiraServiceManagement = "jira_service_management",
   Productboard = "productboard",
   Slab = "slab",
   Coda = "coda",


### PR DESCRIPTION
Resolves #2281.

Focused fix; tests pass locally.

/claim #2281

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Jira Service Management connector that indexes service desk requests as a distinct source while reusing the existing Jira fetching and permissions logic. Implements the connector requested in #2281.

- **New Features**
  - Backend: added `DocumentSource.JIRA_SERVICE_MANAGEMENT`, a `JiraServiceManagementConnector` subclass that forces JSM tagging, registry mapping, and a `source` arg in `process_jira_issue` so emitted docs can be tagged correctly.
  - Frontend: new `jira_service_management` source with config UI (base URL, optional scoped token, project key or custom JQL), credentials template, and source metadata.
  - Tests: unit coverage for default Jira vs explicit JSM source, subclass behavior (cannot override), and registry mapping.

<sup>Written for commit 01aa9a441be684dcb65d6f6ac4ee8940092a267d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

