### PR TITLE
fix(llm): map unreachable OpenAI-compatible model server to 400, not 502

### DIFF
--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -1667,8 +1667,6 @@ def _get_openai_compatible_models_response(
             extra={"source": source_name, "url": url, "error": str(e)},
             exc_info=True,
         )
-        # Unreachable user-supplied URL is a client misconfiguration, not a
-        # gateway fault — mirror the Ollama handler and return 400, not 502.
         raise OnyxError(
             OnyxErrorCode.VALIDATION_ERROR,
             f"Could not reach {source_name} at {url}. Check that the URL is "

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -1663,13 +1663,16 @@ def _get_openai_compatible_models_response(
             )
     except httpx.RequestError as e:
         logger.warning(
-            "Failed to fetch models from OpenAI-compatible endpoint",
+            "Could not reach OpenAI-compatible models endpoint",
             extra={"source": source_name, "url": url, "error": str(e)},
             exc_info=True,
         )
+        # Unreachable user-supplied URL is a client misconfiguration, not a
+        # gateway fault — mirror the Ollama handler and return 400, not 502.
         raise OnyxError(
-            OnyxErrorCode.BAD_GATEWAY,
-            f"Failed to fetch {source_name} models: {e}",
+            OnyxErrorCode.VALIDATION_ERROR,
+            f"Could not reach {source_name} at {url}. Check that the URL is "
+            f"correct and reachable from Onyx ({type(e).__name__}).",
         )
     except ValueError as e:
         logger.warning(

--- a/backend/tests/unit/onyx/server/manage/llm/test_fetch_models_api.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_fetch_models_api.py
@@ -1267,8 +1267,9 @@ class TestGetLitellmAvailableModels:
             call_args = mock_get.call_args
             assert call_args[0][0] == "http://localhost:4000/v1/model/info"
 
-    def test_connection_failure_raises_onyx_error(self) -> None:
-        """Test that connection failures are wrapped in OnyxError."""
+    def test_connection_failure_returns_400(self) -> None:
+        """An unreachable proxy is a client misconfig → 400 VALIDATION_ERROR, not 502."""
+        from onyx.error_handling.error_codes import OnyxErrorCode
         from onyx.server.manage.llm.api import get_litellm_available_models
 
         mock_session = MagicMock()
@@ -1282,8 +1283,11 @@ class TestGetLitellmAvailableModels:
                 api_base="http://localhost:4000",
                 api_key="test-key",
             )
-            with pytest.raises(OnyxError, match="Failed to fetch LiteLLM proxy models"):
+            with pytest.raises(OnyxError) as exc_info:
                 get_litellm_available_models(request, MagicMock(), mock_session)
+
+        assert exc_info.value.error_code == OnyxErrorCode.VALIDATION_ERROR
+        assert exc_info.value.status_code == 400
 
     def test_401_raises_authentication_error(self) -> None:
         """Test that a 401 response raises OnyxError with authentication message."""
@@ -1451,8 +1455,9 @@ class TestGetBifrostAvailableModels:
             assert by_name["openai/gpt-4o"] == "GPT-4o"
             assert by_name["some/custom-model"] == "some/custom-model"
 
-    def test_request_failure_is_logged_and_wrapped(self) -> None:
-        """Test that request-layer failures are logged before raising OnyxError."""
+    def test_request_failure_is_logged_and_returns_400(self) -> None:
+        """A request-layer failure is logged and returns 400 (client misconfig)."""
+        from onyx.error_handling.error_codes import OnyxErrorCode
         from onyx.server.manage.llm.api import get_bifrost_available_models
 
         mock_session = MagicMock()
@@ -1466,7 +1471,10 @@ class TestGetBifrostAvailableModels:
             )
 
             request = BifrostModelsRequest(api_base="https://bifrost.example.com")
-            with pytest.raises(OnyxError, match="Failed to fetch Bifrost models"):
+            with pytest.raises(OnyxError) as exc_info:
                 get_bifrost_available_models(request, MagicMock(), mock_session)
 
             mock_warning.assert_called_once()
+
+        assert exc_info.value.error_code == OnyxErrorCode.VALIDATION_ERROR
+        assert exc_info.value.status_code == 400


### PR DESCRIPTION
## Description

Follow-up to #12079 (which fixed the Ollama handler). Applies the same fix to the shared `_get_openai_compatible_models_response` helper used by **LiteLLM, Bifrost, and LM Studio**.

- **Bug:** a connection/timeout error on the user-supplied model-server URL raised `502 BAD_GATEWAY` — but an unreachable address is a client misconfiguration, not a gateway fault, and it shows up as a server error in metrics.
- **Fix:** connection errors (`httpx.RequestError`) → `400 VALIDATION_ERROR` with a "could not reach `<url>`" message. An actual error *response* from the upstream (`httpx.HTTPStatusError`) still maps to 502.
- Updates the two existing connection-failure tests (LiteLLM, Bifrost) to assert the new 400.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check