### PR TITLE
fix(file-store): make change_file_id a metadata-only rename

### DIFF
--- a/backend/onyx/file_store/file_store.py
+++ b/backend/onyx/file_store/file_store.py
@@ -516,54 +516,36 @@ class S3BackedFileStore(FileStore):
     def change_file_id(
         self, old_file_id: str, new_file_id: str, db_session: Session | None = None
     ) -> None:
+        """Rename a file by repointing its DB record at the existing object.
+
+        The object is not moved — only file_id changes — and reads resolve via
+        the stored object_key, so they still find it. The object keeps its
+        original key, so a file_id must not be reused for a new save_file after
+        it has been renamed (the new write would overwrite the renamed object).
+        """
+        if old_file_id == new_file_id:
+            return
         with get_session_with_current_tenant_if_none(db_session) as db_session:
             try:
-                # Get the existing file record
                 old_file_record = get_filerecord_by_file_id(
                     file_id=old_file_id, db_session=db_session
                 )
-
-                # Generate new S3 key for the new file ID
-                new_s3_key = self._get_s3_key(new_file_id)
-
-                # Copy S3 object to new key
-                s3_client = self._get_s3_client()
-                bucket_name = self._get_bucket_name()
-
-                copy_source = (
-                    f"{old_file_record.bucket_name}/{old_file_record.object_key}"
-                )
-
-                s3_client.copy_object(
-                    CopySource=copy_source,
-                    Bucket=bucket_name,
-                    Key=new_s3_key,
-                    MetadataDirective="COPY",
-                )
-
-                # Create new file record with new file_id
-                # Cast file_metadata to the expected type
                 file_metadata = cast(
                     dict[Any, Any] | None, old_file_record.file_metadata
                 )
 
+                # Reuse the old record's bucket/object_key — the object stays put.
                 upsert_filerecord(
                     file_id=new_file_id,
                     display_name=old_file_record.display_name,
                     file_origin=old_file_record.file_origin,
                     file_type=old_file_record.file_type,
-                    bucket_name=bucket_name,
-                    object_key=new_s3_key,
+                    bucket_name=old_file_record.bucket_name,
+                    object_key=old_file_record.object_key,
                     db_session=db_session,
                     file_metadata=file_metadata,
                 )
 
-                # Delete old S3 object
-                s3_client.delete_object(
-                    Bucket=old_file_record.bucket_name, Key=old_file_record.object_key
-                )
-
-                # Delete old file record
                 delete_filerecord_by_file_id(file_id=old_file_id, db_session=db_session)
 
                 db_session.commit()

--- a/backend/onyx/file_store/gcs_file_store.py
+++ b/backend/onyx/file_store/gcs_file_store.py
@@ -326,31 +326,32 @@ class GCSBackedFileStore(FileStore):
         new_file_id: str,
         db_session: Session | None = None,
     ) -> None:
+        """Rename a file by repointing its DB record at the existing blob.
+
+        The blob is not moved — only file_id changes — and reads resolve via
+        the stored object_key, so they still find it. The blob keeps its
+        original key, so a file_id must not be reused for a new save_file after
+        it has been renamed (the new write would overwrite the renamed blob).
+        """
+        if old_file_id == new_file_id:
+            return
         with get_session_with_current_tenant_if_none(db_session) as db_session:
             try:
                 old_file_record = get_filerecord_by_file_id(
                     file_id=old_file_id, db_session=db_session
                 )
-                new_object_key = self._get_object_key(new_file_id)
-
-                client = self._get_gcs_client()
-                source_bucket = client.bucket(old_file_record.bucket_name)
-                source_blob = source_bucket.blob(old_file_record.object_key)
-                dest_bucket = client.bucket(self._bucket_name)
-
-                source_bucket.copy_blob(source_blob, dest_bucket, new_object_key)
-
                 file_metadata = cast(
                     dict[Any, Any] | None, old_file_record.file_metadata
                 )
 
+                # Reuse the old record's bucket/object_key — the blob stays put.
                 upsert_filerecord(
                     file_id=new_file_id,
                     display_name=old_file_record.display_name,
                     file_origin=old_file_record.file_origin,
                     file_type=old_file_record.file_type,
-                    bucket_name=self._bucket_name,
-                    object_key=new_object_key,
+                    bucket_name=old_file_record.bucket_name,
+                    object_key=old_file_record.object_key,
                     db_session=db_session,
                     file_metadata=file_metadata,
                 )
@@ -358,17 +359,6 @@ class GCSBackedFileStore(FileStore):
                 delete_filerecord_by_file_id(file_id=old_file_id, db_session=db_session)
 
                 db_session.commit()
-
-                try:
-                    source_blob.delete()
-                except Exception:
-                    logger.warning(
-                        "Failed to delete old GCS blob after changing file ID from "
-                        "%s to %s; blob may be orphaned",
-                        old_file_id,
-                        new_file_id,
-                        exc_info=True,
-                    )
 
             except Exception as e:
                 db_session.rollback()

--- a/backend/onyx/file_store/postgres_file_store.py
+++ b/backend/onyx/file_store/postgres_file_store.py
@@ -279,6 +279,8 @@ class PostgresBackedFileStore(FileStore):
     def change_file_id(
         self, old_file_id: str, new_file_id: str, db_session: Session | None = None
     ) -> None:
+        if old_file_id == new_file_id:
+            return
         with get_session_with_current_tenant_if_none(db_session) as session:
             try:
                 old_record = get_filerecord_by_file_id(

--- a/backend/tests/external_dependency_unit/file_store/test_file_store_non_mocked.py
+++ b/backend/tests/external_dependency_unit/file_store/test_file_store_non_mocked.py
@@ -215,6 +215,45 @@ class TestS3BackedFileStore:
         expected_object_key = f"{file_store._s3_prefix}/{TEST_TENANT_ID}/{file_id}"
         assert file_record.object_key == expected_object_key
 
+    def test_change_file_id_is_metadata_only(
+        self, file_store: S3BackedFileStore
+    ) -> None:
+        """Renaming a file repoints the DB record without moving the S3 object."""
+        old_id = f"{uuid.uuid4()}.txt"
+        new_id = f"{uuid.uuid4()}.txt"
+        content = b"rename me without copying"
+
+        file_store.save_file(
+            content=BytesIO(content),
+            display_name="rename.txt",
+            file_origin=FileOrigin.OTHER,
+            file_type="text/plain",
+            file_id=old_id,
+        )
+        original_object_key = file_store.read_file_record(old_id).object_key
+
+        file_store.change_file_id(old_id, new_id)
+
+        # Old id is gone; new id resolves to the same content.
+        assert not file_store.has_file(old_id, FileOrigin.OTHER, "text/plain")
+        assert file_store.has_file(new_id, FileOrigin.OTHER, "text/plain")
+        assert file_store.read_file(new_id).read() == content
+
+        # The S3 object never moved: the new record still points at the
+        # original object key (derived from the OLD file_id), not a new one.
+        new_record = file_store.read_file_record(new_id)
+        assert new_record.object_key == original_object_key
+        assert new_record.object_key.endswith(old_id)
+
+        # And nothing was copied to the key the new file_id would derive —
+        # guards against a "copy AND repoint" regression that leaks an object.
+        with pytest.raises(ClientError) as exc_info:
+            file_store._get_s3_client().head_object(
+                Bucket=file_store._get_bucket_name(),
+                Key=file_store._get_s3_key(new_id),
+            )
+        assert exc_info.value.response["Error"]["Code"] in ("404", "NoSuchKey")
+
     def test_save_and_read_binary_file(self, file_store: S3BackedFileStore) -> None:
         """Test saving and reading a binary file"""
         file_id = f"{uuid.uuid4()}.bin"

--- a/backend/tests/unit/file_store/test_file_store.py
+++ b/backend/tests/unit/file_store/test_file_store.py
@@ -697,7 +697,7 @@ class TestGCSFileStore:
             mock_db_session.rollback.assert_not_called()
 
     def test_gcs_change_file_id_mock(self) -> None:
-        """Test GCS change_file_id copies blob, upserts new record, and deletes old"""
+        """change_file_id repoints the record at the same blob — no copy/delete."""
         mock_record = Mock(
             bucket_name="test-bucket",
             object_key="onyx-files/public/old-id",
@@ -706,14 +706,7 @@ class TestGCSFileStore:
             file_type="text/plain",
             file_metadata=None,
         )
-        mock_source_blob = Mock()
-        mock_source_bucket = Mock()
-        mock_source_bucket.blob.return_value = mock_source_blob
-        mock_dest_bucket = Mock()
-
         mock_client = Mock()
-        # First call returns source bucket, second returns destination bucket
-        mock_client.bucket.side_effect = [mock_source_bucket, mock_dest_bucket]
 
         mock_db_session = MagicMock()
 
@@ -744,22 +737,19 @@ class TestGCSFileStore:
                 db_session=mock_db_session,
             )
 
-            new_key = "onyx-files/public/new-id"
-            mock_source_bucket.copy_blob.assert_called_once_with(
-                mock_source_blob, mock_dest_bucket, new_key
-            )
+            # New record reuses the old bucket/object — the blob never moves.
             mock_upsert.assert_called_once()
             assert mock_upsert.call_args.kwargs["file_id"] == "new-id"
             assert mock_upsert.call_args.kwargs["bucket_name"] == "test-bucket"
-            assert mock_upsert.call_args.kwargs["object_key"] == new_key
+            assert (
+                mock_upsert.call_args.kwargs["object_key"] == "onyx-files/public/old-id"
+            )
             mock_delete_record.assert_called_once_with(
                 file_id="old-id", db_session=mock_db_session
             )
             mock_db_session.commit.assert_called_once()
-            mock_source_blob.delete.assert_called_once()
-            # Source blob deletion must happen after the DB commit
-            commit_call_order = mock_db_session.commit.call_args_list
-            assert commit_call_order, "expected db_session.commit to have been called"
+            # The GCS client is never touched at all — no copy, no delete.
+            mock_client.bucket.assert_not_called()
 
     def test_gcs_get_file_size_mock(self) -> None:
         """Test GCS get_file_size returns the blob size"""


### PR DESCRIPTION
## Description

**Bug:** On checkpoint resume, reissuing leftover batches renames each via `change_file_id`, which physically copied the underlying object (S3 `copy_object`+`delete_object`, GCS `copy_blob`+delete) before repointing the DB record. A connector with tens of thousands of un-processed batches (e.g. a large Gmail mailbox) spent ~an hour in serial object copies; the DB connection dropped mid-resume and the attempt failed during checkpoint load before indexing anything.

**Fix:** `change_file_id` is now a metadata-only rename — the new file_record points at the same `object_key` as the old; the object never moves. Reads resolve via the stored `object_key` (never re-derived from `file_id`), so this is safe, and the per-batch rename on resume becomes a cheap DB op. Batches still consolidate under the resuming attempt. Postgres already moved only the large-object pointer (unchanged). Added an `old == new` guard (the old copy path would self-destruct on it).

**Constraint:** the object keeps `old_file_id`'s storage key, so `old_file_id` must not be reused for a later `save_file` (it would overwrite the renamed object). The sole caller (batch reissue) never reuses a prior attempt's paths — documented in the docstring.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check