### PR TITLE
chore(opal): bump patch version 0.1.11 → 0.1.12

### DIFF
--- a/web/bun.lock
+++ b/web/bun.lock
@@ -130,7 +130,7 @@
     },
     "lib/opal": {
       "name": "@onyx-ai/opal",
-      "version": "0.1.11",
+      "version": "0.2.0",
       "dependencies": {
         "clsx": "^2.0.0",
         "copy-to-clipboard": "^3.3.3",

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -130,7 +130,7 @@
     },
     "lib/opal": {
       "name": "@onyx-ai/opal",
-      "version": "0.2.0",
+      "version": "0.1.12",
       "dependencies": {
         "clsx": "^2.0.0",
         "copy-to-clipboard": "^3.3.3",

--- a/web/lib/opal/package.json
+++ b/web/lib/opal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onyx-ai/opal",
-  "version": "0.2.0",
+  "version": "0.1.12",
   "description": "Opal — Onyx's Typescript component library and design system.",
   "license": "MIT",
   "repository": {

--- a/web/lib/opal/package.json
+++ b/web/lib/opal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onyx-ai/opal",
-  "version": "0.1.11",
+  "version": "0.2.0",
   "description": "Opal — Onyx's Typescript component library and design system.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Description

Bumps Opal patch version `0.1.11` → `0.1.12` to release the changes landed in the `fix/app-header-sizing` PR (#12082):

- `--chrome-header-height: 3.25rem` added to `sizes.css`
- `RootLayout.Header` now has a defined height via `var(--chrome-header-height)`
- `RootLayout.Header` renders `<header>` (semantic HTML); `RootLayout.Footer` renders `<footer>`
- `SettingsLayout.Header` top spacer updated to `rem={3.25}`

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `@onyx-ai/opal` from 0.1.11 to 0.1.12 to ship header sizing and semantic layout updates.
Adds `--chrome-header-height: 3.25rem`, applies it to `RootLayout.Header`, uses `<header>/<footer>`, and updates `SettingsLayout.Header` spacer to 3.25rem.

<sup>Written for commit 72c7ef0b3858cc7d17e8a77fcfa30c4ce860ebf9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->