### PR TITLE
fix(app-chrome): restore header on "start an agent chat" page

### DIFF
--- a/web/src/layouts/chromes/AppChrome.tsx
+++ b/web/src/layouts/chromes/AppChrome.tsx
@@ -281,6 +281,7 @@ function Header() {
       {(appFocus.isChat() ||
         appFocus.isNewSession() ||
         appFocus.isAgent() ||
+        appFocus.isProject() ||
         isMobile) &&
         !appFocus.isSharedChat() && (
           <RootLayout.Header>

--- a/web/src/layouts/chromes/AppChrome.tsx
+++ b/web/src/layouts/chromes/AppChrome.tsx
@@ -92,7 +92,8 @@ function Header() {
 
   const customHeaderContent =
     settings?.enterpriseSettings?.custom_header_content;
-  const pageWithHeaderContent = appFocus.isChat() || appFocus.isNewSession();
+  const pageWithHeaderContent =
+    appFocus.isChat() || appFocus.isNewSession() || appFocus.isAgent();
 
   const effectiveMode: AppMode =
     appFocus.isNewSession() && state.phase === "idle" ? state.appMode : "chat";

--- a/web/src/layouts/chromes/AppChrome.tsx
+++ b/web/src/layouts/chromes/AppChrome.tsx
@@ -278,7 +278,10 @@ function Header() {
         </ConfirmationModalLayout>
       )}
 
-      {(appFocus.isChat() || appFocus.isNewSession() || isMobile) &&
+      {(appFocus.isChat() ||
+        appFocus.isNewSession() ||
+        appFocus.isAgent() ||
+        isMobile) &&
         !appFocus.isSharedChat() && (
           <RootLayout.Header>
             <div className="w-full h-full flex flex-row flex-wrap justify-center items-center px-4 py-2">


### PR DESCRIPTION
## Description

The header visibility condition introduced in #12082 omitted `isAgent()`, causing the chrome header to be absent entirely on `/app?agentId=` pages. This restores it.

The mode selector was never shown on agent pages anyway (it's gated on `isNewSession()`), so no behavioural change there — only the header bar itself is restored.

## Screenshots + Videos

### Starting a chat w/ an agent

Notice the top-header:

<img width="1800" height="1169" alt="image" src="https://github.com/user-attachments/assets/05c9eef9-9812-4d46-8452-20b811aaed82" />

### Project Page

<img width="1800" height="1169" alt="image" src="https://github.com/user-attachments/assets/050dda72-b2b6-424f-b17d-d0a866ed634f" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore the app header on agent and project pages (/app?agentId=, /app?projectId=) by adding `isAgent()` and `isProject()` to header checks, and show custom header text on agent pages. The mode selector still only appears on new sessions (`isNewSession()`).

<sup>Written for commit 6776f15e7dc43a2d20d58f8789e786aef6616f3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->