### PR TITLE
fix(projects): Fix `CreateProjectModal` and cap description lines

### DIFF
--- a/web/bun.lock
+++ b/web/bun.lock
@@ -130,7 +130,7 @@
     },
     "lib/opal": {
       "name": "@onyx-ai/opal",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "dependencies": {
         "clsx": "^2.0.0",
         "copy-to-clipboard": "^3.3.3",

--- a/web/lib/opal/package.json
+++ b/web/lib/opal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onyx-ai/opal",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Opal — Onyx's Typescript component library and design system.",
   "license": "MIT",
   "repository": {

--- a/web/lib/opal/src/layouts/content/ContentLg.tsx
+++ b/web/lib/opal/src/layouts/content/ContentLg.tsx
@@ -38,6 +38,9 @@ interface ContentLgProps {
   /** Optional description below the title. */
   description?: string | RichStr;
 
+  /** Clamp the description to N lines. Maps to Text's maxLines prop. */
+  descriptionMaxLines?: number;
+
   /** Enable inline editing of the title. */
   editable?: boolean;
 
@@ -81,6 +84,7 @@ function ContentLg({
   icon: Icon,
   title,
   description,
+  descriptionMaxLines,
   editable,
   onTitleChange,
   ref,
@@ -190,7 +194,12 @@ function ContentLg({
               : undefined
           }
         >
-          <Text font="secondary-body" color="text-03" as="p">
+          <Text
+            font="secondary-body"
+            color="text-03"
+            as="p"
+            maxLines={descriptionMaxLines}
+          >
             {description}
           </Text>
         </div>

--- a/web/lib/opal/src/layouts/content/ContentMd.tsx
+++ b/web/lib/opal/src/layouts/content/ContentMd.tsx
@@ -49,6 +49,9 @@ interface ContentMdProps {
   /** Optional description text below the title. */
   description?: string | RichStr;
 
+  /** Clamp the description to N lines. Maps to Text's maxLines prop. */
+  descriptionMaxLines?: number;
+
   /** Enable inline editing of the title. */
   editable?: boolean;
 
@@ -129,6 +132,7 @@ function ContentMd({
   icon: Icon,
   title,
   description,
+  descriptionMaxLines,
   editable,
   onTitleChange,
   suffix,
@@ -270,7 +274,12 @@ function ContentMd({
           className="opal-content-md-description"
           style={Icon ? { paddingLeft: config.descriptionIndent } : undefined}
         >
-          <Text font="secondary-body" color="text-03" as="p">
+          <Text
+            font="secondary-body"
+            color="text-03"
+            as="p"
+            maxLines={descriptionMaxLines}
+          >
             {description}
           </Text>
         </div>

--- a/web/lib/opal/src/layouts/content/ContentXl.tsx
+++ b/web/lib/opal/src/layouts/content/ContentXl.tsx
@@ -44,6 +44,9 @@ interface ContentXlProps {
   /** Optional description below the title. */
   description?: string | RichStr;
 
+  /** Clamp the description to N lines. Maps to Text's maxLines prop. */
+  descriptionMaxLines?: number;
+
   /** Enable inline editing of the title. */
   editable?: boolean;
 
@@ -99,6 +102,7 @@ function ContentXl({
   icon: Icon,
   title,
   description,
+  descriptionMaxLines,
   editable,
   onTitleChange,
   moreIcon1: MoreIcon1,
@@ -232,7 +236,12 @@ function ContentXl({
 
       {description && toPlainString(description) && (
         <div className="opal-content-xl-description">
-          <Text font="secondary-body" color="text-03" as="p">
+          <Text
+            font="secondary-body"
+            color="text-03"
+            as="p"
+            maxLines={descriptionMaxLines}
+          >
             {description}
           </Text>
         </div>

--- a/web/lib/opal/src/layouts/content/components.tsx
+++ b/web/lib/opal/src/layouts/content/components.tsx
@@ -45,6 +45,9 @@ interface ContentBaseProps {
   /** Optional description below the title. */
   description?: string | RichStr;
 
+  /** Clamp the description to N lines. Maps to Text's maxLines prop. */
+  descriptionMaxLines?: number;
+
   /** Enable inline editing of the title. */
   editable?: boolean;
 

--- a/web/src/sections/modals/CreateProjectModal.tsx
+++ b/web/src/sections/modals/CreateProjectModal.tsx
@@ -28,60 +28,59 @@ export default function CreateProjectModal({
   const route = useAppRouter();
 
   return (
-    <>
-      <Modal open={modal.isOpen} onOpenChange={modal.toggle}>
-        <Modal.Content width="sm">
-          <Modal.Header
-            icon={SvgFolderPlus}
-            title="Create New Project"
-            description="Use projects to organize your files and chats in one place, and add custom instructions for ongoing work."
-            onClose={() => modal.toggle(false)}
-          />
-          <Formik
-            initialValues={{ projectName: initialProjectName ?? "" }}
-            validationSchema={validationSchema}
-            enableReinitialize
-            onSubmit={async (values, { setSubmitting }) => {
-              const name = values.projectName.trim();
-              try {
-                const newProject = await createProject(name);
-                route({ projectId: newProject.id });
-                modal.toggle(false);
-              } catch {
-                toast.error(`Failed to create the project ${name}`);
-              } finally {
-                setSubmitting(false);
-              }
-            }}
-          >
-            {({ isSubmitting, isValid }) => (
-              <Form>
-                <Modal.Body>
-                  <InputVertical title="Project Name" withLabel="projectName">
-                    <InputTypeInField
-                      name="projectName"
-                      placeholder="What are you working on?"
-                      clearButton
-                    />
-                  </InputVertical>
-                </Modal.Body>
-                <Modal.Footer>
-                  <Button
-                    prominence="secondary"
-                    type="button"
-                    onClick={() => modal.toggle(false)}
-                  >
-                    Cancel
-                  </Button>
-                  <Button type="submit" disabled={isSubmitting || !isValid}>
-                    Create Project
-                  </Button>
-                </Modal.Footer>
-              </Form>
-            )}
-          </Formik>
-        </Modal.Content>
-      </Modal>
-    </>
+    <Modal open={modal.isOpen} onOpenChange={modal.toggle}>
+      <Modal.Content width="sm">
+        <Modal.Header
+          icon={SvgFolderPlus}
+          title="Create New Project"
+          description="Use projects to organize your files and chats in one place, and add custom instructions for ongoing work."
+          onClose={() => modal.toggle(false)}
+        />
+        <Formik
+          initialValues={{ projectName: initialProjectName ?? "" }}
+          validationSchema={validationSchema}
+          validateOnMount
+          enableReinitialize
+          onSubmit={async (values, { setSubmitting }) => {
+            const name = values.projectName.trim();
+            try {
+              const newProject = await createProject(name);
+              route({ projectId: newProject.id });
+              modal.toggle(false);
+            } catch {
+              toast.error(`Failed to create the project ${name}`);
+            } finally {
+              setSubmitting(false);
+            }
+          }}
+        >
+          {({ isSubmitting, isValid }) => (
+            <Form>
+              <Modal.Body>
+                <InputVertical title="Project Name" withLabel="projectName">
+                  <InputTypeInField
+                    name="projectName"
+                    placeholder="What are you working on?"
+                    clearButton
+                  />
+                </InputVertical>
+              </Modal.Body>
+              <Modal.Footer>
+                <Button
+                  prominence="secondary"
+                  type="button"
+                  onClick={() => modal.toggle(false)}
+                >
+                  Cancel
+                </Button>
+                <Button type="submit" disabled={isSubmitting || !isValid}>
+                  Create Project
+                </Button>
+              </Modal.Footer>
+            </Form>
+          )}
+        </Formik>
+      </Modal.Content>
+    </Modal>
   );
 }

--- a/web/src/sections/projects/ProjectContextPanel.tsx
+++ b/web/src/sections/projects/ProjectContextPanel.tsx
@@ -149,7 +149,7 @@ export default function ProjectContextPanel({
               : currentProjectDetails?.project?.instructions ||
                 "Add instructions to tailor the response in this project."
           }
-          descriptionMaxLines={3}
+          descriptionMaxLines={2}
           padding="fit"
           center
           rightChildren={

--- a/web/src/sections/projects/ProjectContextPanel.tsx
+++ b/web/src/sections/projects/ProjectContextPanel.tsx
@@ -149,6 +149,7 @@ export default function ProjectContextPanel({
               : currentProjectDetails?.project?.instructions ||
                 "Add instructions to tailor the response in this project."
           }
+          descriptionMaxLines={3}
           padding="fit"
           center
           rightChildren={


### PR DESCRIPTION
## Description

`Formik`'s `isValid` defaults to `true` before any user interaction, so the "Create Project" button was never disabled on open even with an empty name field. Adding `validateOnMount` runs the Yup schema immediately on render, correctly setting `isValid` to `false` when `projectName` is empty.

## Screenshots + Videos

### Create Project Modal

#### Before

<img width="1800" height="1169" alt="image" src="https://github.com/user-attachments/assets/e601e428-46c1-4b08-ac7c-076d4f611aa6" />

#### After

<img width="1800" height="1169" alt="image" src="https://github.com/user-attachments/assets/0416dada-083e-449a-883d-2f568d989fa9" />

### Project Instructions

#### Before

<img width="1800" height="1169" alt="image" src="https://github.com/user-attachments/assets/652cc50c-fcd4-43f4-a53b-562f41b1ec45" />

#### After

<img width="1800" height="1169" alt="image" src="https://github.com/user-attachments/assets/a9fa17b0-f58b-4a17-a706-35de044b4971" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable the Create Project button until a name is entered by validating the form on open. Limit Project Context instructions to 2 lines using the new `descriptionMaxLines` prop in `@onyx-ai/opal` content components.

<sup>Written for commit 3f55730d219113b8e3275efe644e9e19f1a69f49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12094?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->