### PR TITLE
fix: flush hold buffer on stream end in DynamicCitationProcessor

### DIFF
--- a/backend/onyx/chat/citation_processor.py
+++ b/backend/onyx/chat/citation_processor.py
@@ -275,10 +275,12 @@ class DynamicCitationProcessor:
             str: Text chunks to display. Citation format depends on citation_mode.
             CitationInfo: Citation metadata (only when citation_mode=HYPERLINK)
         """
-        # None -> end of stream, flush remaining segment
+        # None -> end of stream, flush remaining segment and held tokens
         if token is None:
-            if self.curr_segment:
-                yield self.curr_segment
+            remaining = self.hold + self.curr_segment
+            if remaining:
+                yield remaining
+            self.hold = ""
             return
 
         # Handle stop stream token

--- a/backend/onyx/chat/citation_processor.py
+++ b/backend/onyx/chat/citation_processor.py
@@ -277,10 +277,11 @@ class DynamicCitationProcessor:
         """
         # None -> end of stream, flush remaining segment and held tokens
         if token is None:
-            remaining = self.hold + self.curr_segment
+            remaining = self.curr_segment + self.hold
             if remaining:
                 yield remaining
             self.hold = ""
+            self.curr_segment = ""
             return
 
         # Handle stop stream token

--- a/backend/tests/unit/onyx/chat/test_citation_processor.py
+++ b/backend/tests/unit/onyx/chat/test_citation_processor.py
@@ -2545,21 +2545,22 @@ class TestHoldBufferFlushOnStreamEnd:
 
     def test_hold_and_curr_segment_both_flushed(self) -> None:
         """Both `self.hold` and `self.curr_segment` should be flushed on
-        stream end."""
+        stream end, with correct ordering (curr_segment before hold)."""
         processor = DynamicCitationProcessor(stop_stream="END")
 
         results: list[str | CitationInfo] = []
-        # "EN" partially matches stop stream, held in self.hold
-        for token in ["Prefix ", "EN"]:
+        # "[" starts a citation -> sits in curr_segment
+        # "EN" partially matches stop stream -> held in self.hold
+        # At stream end, output should be "[EN" (curr_segment first, then hold)
+        for token in ["[", "EN"]:
             for result in processor.process_token(token):
                 results.append(result)
-        # End of stream — should flush held "EN"
+        # End of stream — should flush curr_segment + hold in order
         for result in processor.process_token(None):
             results.append(result)
 
         output = "".join(r for r in results if isinstance(r, str))
-        assert "Prefix " in output
-        assert "EN" in output
+        assert output == "[EN"
 
     def test_no_truncation_with_citation_near_end(self) -> None:
         """End-to-end: a well-cited RAG response whose final characters

--- a/backend/tests/unit/onyx/chat/test_citation_processor.py
+++ b/backend/tests/unit/onyx/chat/test_citation_processor.py
@@ -2545,22 +2545,32 @@ class TestHoldBufferFlushOnStreamEnd:
 
     def test_hold_and_curr_segment_both_flushed(self) -> None:
         """Both `self.hold` and `self.curr_segment` should be flushed on
-        stream end, with correct ordering (curr_segment before hold)."""
+        stream end, with correct ordering (curr_segment before hold).
+
+        Scenario: '[' starts a possible citation (held in curr_segment),
+        then 'EN' partially matches stop_stream='END' (held in self.hold).
+        At stream end, both buffers are non-empty and must be flushed
+        in the correct order.
+        """
         processor = DynamicCitationProcessor(stop_stream="END")
 
         results: list[str | CitationInfo] = []
-        # "[" starts a citation -> sits in curr_segment
-        # "EN" partially matches stop stream -> held in self.hold
-        # At stream end, output should be "[EN" (curr_segment first, then hold)
         for token in ["[", "EN"]:
             for result in processor.process_token(token):
                 results.append(result)
+
+        # Verify both buffers are non-empty before stream end
+        assert processor.curr_segment == "[", \
+            f"Expected curr_segment='[', got {processor.curr_segment!r}"
+        assert processor.hold == "EN", \
+            f"Expected hold='EN', got {processor.hold!r}"
+
         # End of stream — should flush curr_segment + hold in order
         for result in processor.process_token(None):
             results.append(result)
 
         output = "".join(r for r in results if isinstance(r, str))
-        assert output == "[EN"
+        assert output == "[EN", f"Expected '[EN', got {output!r}"
 
     def test_no_truncation_with_citation_near_end(self) -> None:
         """End-to-end: a well-cited RAG response whose final characters

--- a/backend/tests/unit/onyx/chat/test_citation_processor.py
+++ b/backend/tests/unit/onyx/chat/test_citation_processor.py
@@ -2504,3 +2504,104 @@ class TestPossibleCitationPatternReDoS:
                 DynamicCitationProcessor().possible_citation_pattern.search(segment)
                 is None
             ), f"expected {segment!r} to NOT be treated as a possible citation"
+
+
+# ============================================================================
+# Hold Buffer Flush on Stream End Tests
+# ============================================================================
+
+
+class TestHoldBufferFlushOnStreamEnd:
+    """Regression tests for the bug where `self.hold` buffer was not flushed
+    when the stream ends (token=None).
+
+    When stop_stream is configured, tokens that partially match the stop
+    pattern are held in `self.hold`. If the stream ends while `self.hold`
+    is non-empty (i.e. the partial match was a false alarm), those held
+    characters were silently dropped, causing the final characters of
+    the LLM output to be truncated.
+
+    See: https://github.com/onyx-dot-app/onyx/issues/11932
+    """
+
+    def test_hold_flushed_on_stream_end_with_stop_stream(self) -> None:
+        """When stream ends with characters held in `self.hold` due to a
+        partial stop-stream match, they should be emitted, not dropped."""
+        processor = DynamicCitationProcessor(stop_stream="STOP")
+
+        # Feed tokens where "ST" partially matches "STOP" but stream ends
+        # before "OP" arrives — the held "ST" must be flushed.
+        results: list[str | CitationInfo] = []
+        for token in ["Hello ", "ST"]:
+            for result in processor.process_token(token):
+                results.append(result)
+        # End of stream
+        for result in processor.process_token(None):
+            results.append(result)
+
+        output = "".join(r for r in results if isinstance(r, str))
+        assert "Hello " in output
+        assert "ST" in output  # Was previously silently dropped
+
+    def test_hold_and_curr_segment_both_flushed(self) -> None:
+        """Both `self.hold` and `self.curr_segment` should be flushed on
+        stream end."""
+        processor = DynamicCitationProcessor(stop_stream="END")
+
+        results: list[str | CitationInfo] = []
+        # "EN" partially matches stop stream, held in self.hold
+        for token in ["Prefix ", "EN"]:
+            for result in processor.process_token(token):
+                results.append(result)
+        # End of stream — should flush held "EN"
+        for result in processor.process_token(None):
+            results.append(result)
+
+        output = "".join(r for r in results if isinstance(r, str))
+        assert "Prefix " in output
+        assert "EN" in output
+
+    def test_no_truncation_with_citation_near_end(self) -> None:
+        """End-to-end: a well-cited RAG response whose final characters
+        happen to partially match the stop pattern should NOT be truncated."""
+        processor = DynamicCitationProcessor(stop_stream="<STOP>")
+        processor.update_citation_mapping({1: create_test_search_doc(
+            document_id="doc_1", link="https://example.com/doc1"
+        )})
+
+        # Simulate LLM output ending with "re" which starts "<STOP>"… wait,
+        # it doesn't. Let's use a realistic scenario: the last token
+        # partially matches the stop-stream pattern.
+        tokens = ["According to research [", "1", "], always redo it: ", "fa"]
+        # "fa" doesn't match "<STOP>", but let's test with a stop pattern
+        # that "fa" could start matching... actually let's just test the
+        # hold buffer directly with a realistic stop-stream.
+        processor2 = DynamicCitationProcessor(stop_stream="</s>")
+        processor2.update_citation_mapping({1: create_test_search_doc(
+            document_id="doc_1", link="https://example.com/doc1"
+        )})
+
+        # Last token "<" could start the stop pattern "</s>"
+        results: list[str | CitationInfo] = []
+        for token in ["Text [", "1", "] more", "<"]:
+            for result in processor2.process_token(token):
+                results.append(result)
+        for result in processor2.process_token(None):
+            results.append(result)
+
+        output = "".join(r for r in results if isinstance(r, str))
+        # The "<" should appear in output since it wasn't actually "</s>"
+        assert "<" in output
+        assert "more" in output
+
+    def test_hold_cleared_after_flush(self) -> None:
+        """After flushing on stream end, self.hold should be reset to empty."""
+        processor = DynamicCitationProcessor(stop_stream="STOP")
+
+        for token in ["Hello ", "ST"]:
+            for _ in processor.process_token(token):
+                pass
+        for _ in processor.process_token(None):
+            pass
+
+        assert processor.hold == ""

--- a/pr_body.md
+++ b/pr_body.md
@@ -1,0 +1,41 @@
+## Summary
+
+Fixes #11932
+
+When the LLM stream ends (token=None), `self.hold` could still contain characters from a partial stop-stream match that turned out to be a false alarm. Previously, only `self.curr_segment` was flushed in the end-of-stream handler, causing the held characters to be silently dropped and the LLM output to be truncated mid-word at the very end.
+
+This is most likely to trigger when an answer ends shortly after a citation, which is common with well-cited RAG responses.
+
+## Changes
+
+```python
+# Before (bug):
+if token is None:
+    if self.curr_segment:
+        yield self.curr_segment
+    return
+
+# After (fix):
+if token is None:
+    remaining = self.hold + self.curr_segment
+    if remaining:
+        yield remaining
+    self.hold = ""
+    return
+```
+
+## Why this fix is safe
+
+- `self.hold` only ever contains characters that partially matched the `stop_stream` pattern prefix. If the stream ends without completing the match, these characters are legitimate output that should be emitted as plain text.
+- Held content is very unlikely to contain a complete citation (it's at most a few characters of a partial stop-pattern match), so emitting it as plain text is acceptable.
+- `self.hold` is reset to empty string after flushing to maintain clean state.
+
+## Testing
+
+Added 4 new test cases in `TestHoldBufferFlushOnStreamEnd`:
+1. `test_hold_flushed_on_stream_end_with_stop_stream` — verifies held characters are emitted
+2. `test_hold_and_curr_segment_both_flushed` — verifies both buffers are combined and flushed
+3. `test_no_truncation_with_citation_near_end` — end-to-end scenario matching the original bug report
+4. `test_hold_cleared_after_flush` — verifies `self.hold` is reset
+
+All existing tests continue to pass.


### PR DESCRIPTION
## Summary

Fixes #11932

When the LLM stream ends (token=None), `self.hold` could still contain characters from a partial stop-stream match that turned out to be a false alarm. Previously, only `self.curr_segment` was flushed in the end-of-stream handler, causing the held characters to be silently dropped and the LLM output to be truncated mid-word at the very end.

This is most likely to trigger when an answer ends shortly after a citation, which is common with well-cited RAG responses.

## Changes

```python
# Before (bug):
if token is None:
    if self.curr_segment:
        yield self.curr_segment
    return

# After (fix):
if token is None:
    remaining = self.hold + self.curr_segment
    if remaining:
        yield remaining
    self.hold = ""
    return
```

## Why this fix is safe

- `self.hold` only ever contains characters that partially matched the `stop_stream` pattern prefix. If the stream ends without completing the match, these characters are legitimate output that should be emitted as plain text.
- Held content is very unlikely to contain a complete citation (it's at most a few characters of a partial stop-pattern match), so emitting it as plain text is acceptable.
- `self.hold` is reset to empty string after flushing to maintain clean state.

## Testing

Added 4 new test cases in `TestHoldBufferFlushOnStreamEnd`:
1. `test_hold_flushed_on_stream_end_with_stop_stream` — verifies held characters are emitted
2. `test_hold_and_curr_segment_both_flushed` — verifies both buffers are combined and flushed
3. `test_no_truncation_with_citation_near_end` — end-to-end scenario matching the original bug report
4. `test_hold_cleared_after_flush` — verifies `self.hold` is reset

All existing tests continue to pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Flushes the hold buffer at stream end in `DynamicCitationProcessor`, emitting `curr_segment` + `hold` in order so partial stop-pattern characters are output instead of dropped. Prevents end-of-output truncation; fixes #11932.

- **Bug Fixes**
  - On `token=None`, yield `self.curr_segment + self.hold` once, then clear `self.hold` and `self.curr_segment`.
  - Adds and strengthens regression tests, including explicit assertions that both buffers are non-empty before stream end, plus checks for ordering, no truncation near citations, and state reset.

<sup>Written for commit 0576d5539b6ef339fc5f940570f105e9e266b7cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12096?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

