### PR TITLE
refactor(oauth): extract the single-flight refresh Template Method

### DIFF
--- a/backend/onyx/external_apps/token_refresh.py
+++ b/backend/onyx/external_apps/token_refresh.py
@@ -1,9 +1,11 @@
-"""Lazy, single-flighted OAuth token refresh, called by the egress gate.
+"""Lazy, single-flighted OAuth token refresh for Craft external apps, called by
+the egress gate.
 
-The caller passes a tenant-scoped session *factory* (not a session) and ids;
-everything else — staleness, the Redis lock, the token POST, persistence — lives
-behind :func:`ensure_fresh_credentials`. Each step takes its own short session, so
-no connection is held across the lock wait or the POST.
+The public entrypoint takes ids; the storage and dead-grant policy live in
+:class:`_ExternalAppTokenRefresher`, while the single-flight skeleton (lock,
+stale pre-check, terminal/transient/contention/infra routing) is the shared
+:class:`onyx.oauth.single_flight.SingleFlightTokenRefresher`. Each step takes its
+own short session, so no connection is held across the lock wait or the POST.
 """
 
 from datetime import datetime
@@ -11,8 +13,6 @@ from datetime import timezone
 from typing import Any
 from uuid import UUID
 
-from redis.exceptions import RedisError
-from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from onyx.db.engine.sql_engine import get_session_with_tenant
@@ -24,22 +24,85 @@ from onyx.db.models import ExternalApp
 from onyx.external_apps.providers.base import OAuthExternalAppProvider
 from onyx.external_apps.providers.registry import get_provider_for_app
 from onyx.oauth.errors import TokenRefreshTerminalError
-from onyx.oauth.errors import TokenRefreshTransientError
 from onyx.oauth.expiry import needs_refresh
 from onyx.oauth.expiry import stamp_expires_at
-from onyx.redis.lock_context import redis_shared_lock
-from onyx.redis.lock_context import RedisSharedLockAcquisitionError
+from onyx.oauth.single_flight import SingleFlightTokenRefresher
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
-# Held long enough for the POST + DB steps; short wait so a waiter doesn't hold a
-# worker thread for long (a timed-out waiter proceeds while the winner refreshes).
-_LOCK_HELD_S = 30.0
-_LOCK_WAIT_S = 5.0
-
 # Gathered inside a session for the POST: provider, stored creds, client id/secret.
 _RefreshInputs = tuple[OAuthExternalAppProvider, dict[str, Any], str, str]
+
+
+class _ExternalAppTokenRefresher(SingleFlightTokenRefresher[None]):
+    """Refresh one user's stored access token for one external app.
+
+    Storage is ``ExternalAppUserCredential``; a dead grant clears the credential
+    so the app reads as disconnected. Returns ``None`` — the egress gate re-reads
+    the credential after a refresh.
+    """
+
+    log_prefix = "ea_token_refresh"
+
+    def __init__(self, tenant_id: str, external_app_id: int, user_id: UUID):
+        self.tenant_id = tenant_id
+        self.external_app_id = external_app_id
+        self.user_id = user_id
+
+    def lock_name(self) -> str:
+        return (
+            f"ea_token_refresh:{self.tenant_id}:{self.external_app_id}:{self.user_id}"
+        )
+
+    def is_stale(self) -> bool:
+        # Cheap pre-check: one cred read for the staleness decision. Provider and
+        # client-cred resolution happen under the lock, only when actually stale.
+        with get_session_with_tenant(tenant_id=self.tenant_id) as db:
+            stored = _read_stored_credentials(db, self.external_app_id, self.user_id)
+        return stored is not None and needs_refresh(stored, datetime.now(timezone.utc))
+
+    def refresh_under_lock(self) -> None:
+        # Re-read in a fresh session — double-check after the lock wait, in case a
+        # concurrent process already refreshed — then release before the POST.
+        with get_session_with_tenant(tenant_id=self.tenant_id) as db:
+            inputs = _load_refresh_inputs(db, self.external_app_id, self.user_id)
+        if inputs is None:
+            return None
+        provider, stored, client_id, client_secret = inputs
+
+        # POST with no DB connection held; raises Terminal/Transient, routed by base.
+        refreshed = provider.refresh_credentials(stored, client_id, client_secret)
+
+        with get_session_with_tenant(tenant_id=self.tenant_id) as db:
+            upsert_external_app_user_credential(
+                db,
+                external_app_id=self.external_app_id,
+                user_id=self.user_id,
+                user_credentials=stamp_expires_at(
+                    refreshed, datetime.now(timezone.utc)
+                ),
+            )
+        logger.info(
+            "ea_token_refresh.refreshed external_app_id=%s user_id=%s",
+            self.external_app_id,
+            self.user_id,
+        )
+        return None
+
+    def on_terminal(self, error: TokenRefreshTerminalError) -> None:
+        # Dead grant: drop the credential so the app reads as disconnected.
+        with get_session_with_tenant(tenant_id=self.tenant_id) as db:
+            delete_external_app_user_credential(
+                db, external_app_id=self.external_app_id, user_id=self.user_id
+            )
+        logger.warning(
+            "ea_token_refresh.terminal_cleared external_app_id=%s user_id=%s error=%s",
+            self.external_app_id,
+            self.user_id,
+            error,
+        )
+        return None
 
 
 def ensure_fresh_credentials(
@@ -48,96 +111,13 @@ def ensure_fresh_credentials(
     user_id: UUID,
 ) -> None:
     """Refresh the user's stored access token if it's expired/expiring; a fast
-    no-op otherwise. Opens its own short sessions, single-flights via a Redis
-    lock, and persists the result.
+    no-op otherwise. Single-flights via a Redis lock and persists the result.
 
-    Never raises for a refresh outcome: a revoked grant clears the credential
-    (app reads disconnected), a transient failure keeps the existing token, and
-    lock contention yields to the concurrent refresher.
+    Never raises for a refresh outcome: a revoked grant clears the credential (app
+    reads disconnected), and a transient / lock-contention / infra failure keeps
+    the existing token so the caller proceeds with the currently-stored credential.
     """
-    lock_name = f"ea_token_refresh:{tenant_id}:{external_app_id}:{user_id}"
-    try:
-        # Cheap pre-check: just the staleness decision (one cred read), no provider
-        # or client-cred resolution — those happen under the lock, only when stale.
-        with get_session_with_tenant(tenant_id=tenant_id) as db:
-            stored = _read_stored_credentials(db, external_app_id, user_id)
-        if stored is None or not needs_refresh(stored, datetime.now(timezone.utc)):
-            return
-
-        with redis_shared_lock(
-            lock_name,
-            max_time_lock_held_s=_LOCK_HELD_S,
-            wait_for_lock_s=_LOCK_WAIT_S,
-            logger=logger,
-        ):
-            _refresh_under_lock(tenant_id, external_app_id, user_id)
-    except RedisSharedLockAcquisitionError:
-        # Lock winner is refreshing; proceed with the current token.
-        logger.info(
-            "ea_token_refresh.lock_contended external_app_id=%s user_id=%s",
-            external_app_id,
-            user_id,
-        )
-    except (RedisError, SQLAlchemyError) as exc:
-        # Transient infra failure — Keep existing tokens and let requests through
-        logger.warning(
-            "ea_token_refresh.infra_unavailable external_app_id=%s user_id=%s error=%s",
-            external_app_id,
-            user_id,
-            exc,
-        )
-
-
-def _refresh_under_lock(
-    tenant_id: str,
-    external_app_id: int,
-    user_id: UUID,
-) -> None:
-    # Re-read in a fresh session — double-check after the lock wait, in case a
-    # concurrent process already refreshed — then release before the POST.
-    with get_session_with_tenant(tenant_id=tenant_id) as db:
-        inputs = _load_refresh_inputs(db, external_app_id, user_id)
-    if inputs is None:
-        return
-    provider, stored, client_id, client_secret = inputs
-
-    # POST with no DB connection held.
-    try:
-        refreshed = provider.refresh_credentials(stored, client_id, client_secret)
-    except TokenRefreshTransientError as exc:
-        # Keep the existing token; retry on a later request.
-        logger.warning(
-            "ea_token_refresh.transient external_app_id=%s error=%s",
-            external_app_id,
-            exc,
-        )
-        return
-    except TokenRefreshTerminalError as exc:
-        # Dead grant: drop the credential so the app reads as disconnected.
-        with get_session_with_tenant(tenant_id=tenant_id) as db:
-            delete_external_app_user_credential(
-                db, external_app_id=external_app_id, user_id=user_id
-            )
-        logger.warning(
-            "ea_token_refresh.terminal_cleared external_app_id=%s user_id=%s error=%s",
-            external_app_id,
-            user_id,
-            exc,
-        )
-        return
-
-    with get_session_with_tenant(tenant_id=tenant_id) as db:
-        upsert_external_app_user_credential(
-            db,
-            external_app_id=external_app_id,
-            user_id=user_id,
-            user_credentials=stamp_expires_at(refreshed, datetime.now(timezone.utc)),
-        )
-    logger.info(
-        "ea_token_refresh.refreshed external_app_id=%s user_id=%s",
-        external_app_id,
-        user_id,
-    )
+    _ExternalAppTokenRefresher(tenant_id, external_app_id, user_id).run()
 
 
 def _load_refresh_inputs(

--- a/backend/onyx/oauth/single_flight.py
+++ b/backend/onyx/oauth/single_flight.py
@@ -1,0 +1,110 @@
+"""Template for proactive, single-flighted OAuth token refresh.
+
+Both Craft external apps and MCP servers refresh the same way: a cheap staleness
+pre-check, then — under a Redis single-flight lock — re-read, exchange the refresh
+token, and persist, with a fixed terminal/transient/contention/infra policy. That
+fixed skeleton lives here (Template Method); each subsystem subclasses it and fills
+in only what genuinely differs (its token store, lock key, dead-grant policy, and
+success return).
+"""
+
+from abc import ABC
+from abc import abstractmethod
+from typing import ClassVar
+from typing import Generic
+from typing import TypeVar
+
+from redis.exceptions import RedisError
+from sqlalchemy.exc import SQLAlchemyError
+
+from onyx.oauth.errors import TokenRefreshTerminalError
+from onyx.oauth.errors import TokenRefreshTransientError
+from onyx.redis.lock_context import redis_shared_lock
+from onyx.redis.lock_context import RedisSharedLockAcquisitionError
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+# The successful-refresh return type: `None` for callers that re-read the store
+# afterwards (the external-apps egress gate), or e.g. the fresh auth headers for
+# callers that apply the result directly (an MCP tool call).
+R = TypeVar("R")
+
+
+class SingleFlightTokenRefresher(ABC, Generic[R]):
+    """Refresh an OAuth access token if it's expired/expiring, single-flighted.
+
+    The fixed algorithm in :meth:`run` — stale pre-check, Redis-locked
+    re-read/exchange/persist, and terminal/transient/contention/infra routing —
+    is shared. Subclasses own everything that varies: :meth:`lock_name`,
+    :meth:`is_stale`, :meth:`refresh_under_lock`, and :meth:`on_terminal`.
+
+    :meth:`run` never raises for a refresh *outcome*: a dead grant runs the
+    subclass's terminal policy; a transient, lock-contention, or infra failure
+    keeps the existing token in place so the caller proceeds with it.
+    """
+
+    # Held long enough for the refresh POST + DB write; short wait so a contended
+    # caller doesn't pin a worker thread (a timed-out waiter proceeds with the
+    # current token rather than blocking on the winner).
+    lock_held_s: ClassVar[float] = 30.0
+    lock_wait_s: ClassVar[float] = 5.0
+
+    # Prefix for this refresher's structured log lines (e.g. "ea_token_refresh").
+    log_prefix: ClassVar[str] = "oauth_token_refresh"
+
+    @abstractmethod
+    def lock_name(self) -> str:
+        """The single-flight key — unique per refreshable credential."""
+
+    @abstractmethod
+    def is_stale(self) -> bool:
+        """Whether the stored token is expired/expiring and refreshable. A cheap
+        check that takes its own short session; run once before taking the lock so
+        a fresh token is a fast no-op."""
+
+    @abstractmethod
+    def refresh_under_lock(self) -> R | None:
+        """Holding the lock: re-read (double-checking against a concurrent winner),
+        exchange the refresh token, and persist. Returns the success value, or
+        ``None`` when there's nothing to do (winner already refreshed, inputs
+        missing, …). Raises :class:`TokenRefreshTerminalError` /
+        :class:`TokenRefreshTransientError` on a failed grant."""
+
+    @abstractmethod
+    def on_terminal(self, error: TokenRefreshTerminalError) -> R | None:
+        """Apply the dead-grant policy (clear the credential / flag a reconnect).
+        The refresh token can't be salvaged; retrying won't help."""
+
+    def on_transient(self, error: TokenRefreshTransientError) -> R | None:
+        """A retryable failure (network / 5xx / non-JSON): keep the existing token
+        and retry on a later request. Override only to surface it differently."""
+        logger.warning("%s.transient error=%s", self.log_prefix, error)
+        return None
+
+    def run(self) -> R | None:
+        try:
+            if not self.is_stale():
+                return None
+            with redis_shared_lock(
+                self.lock_name(),
+                max_time_lock_held_s=self.lock_held_s,
+                wait_for_lock_s=self.lock_wait_s,
+                logger=logger,
+            ):
+                try:
+                    return self.refresh_under_lock()
+                except TokenRefreshTerminalError as exc:
+                    return self.on_terminal(exc)
+                except TokenRefreshTransientError as exc:
+                    return self.on_transient(exc)
+        except RedisSharedLockAcquisitionError:
+            # Another worker holds the lock and is refreshing; proceed with the
+            # current token rather than waiting it out.
+            logger.info("%s.lock_contended lock=%s", self.log_prefix, self.lock_name())
+            return None
+        except (RedisError, SQLAlchemyError) as exc:
+            # Transient infra failure (Redis down / DB blip): keep the existing
+            # token and let the request through, never raise.
+            logger.warning("%s.infra_unavailable error=%s", self.log_prefix, exc)
+            return None

--- a/backend/onyx/server/features/mcp/oauth_refresh.py
+++ b/backend/onyx/server/features/mcp/oauth_refresh.py
@@ -2,9 +2,11 @@
 
 The MCP SDK's OAuthClientProvider is rebuilt per tool call and never restores token
 expiry, so it never refreshes proactively and an expired token escalates to a full
-re-auth ("Please Reconnect to the server"). Onyx drives refresh itself instead,
-mirroring `external_apps.token_refresh`: check the persisted expiry before a call and
-exchange the stored refresh token when stale. Never raises for a refresh outcome.
+re-auth ("Please Reconnect to the server"). Onyx drives refresh itself instead:
+the storage and dead-grant policy live in :class:`_MCPTokenRefresher`, and the
+single-flight skeleton (lock, stale pre-check, terminal/transient/contention/infra
+routing) is the shared :class:`onyx.oauth.single_flight.SingleFlightTokenRefresher`
+— the same one Craft external apps use. Never raises for a refresh outcome.
 """
 
 from datetime import datetime
@@ -15,8 +17,6 @@ from urllib.parse import urlparse
 
 import requests
 from mcp.shared.auth import OAuthToken
-from redis.exceptions import RedisError
-from sqlalchemy.exc import SQLAlchemyError
 
 from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.enums import MCPAuthenticationType
@@ -27,13 +27,11 @@ from onyx.db.mcp import update_connection_config
 from onyx.db.mcp import update_mcp_server__no_commit
 from onyx.db.models import MCPServer
 from onyx.oauth.errors import TokenRefreshTerminalError
-from onyx.oauth.errors import TokenRefreshTransientError
 from onyx.oauth.exchange import exchange_refresh_token
 from onyx.oauth.exchange import OAuthFlowParams
 from onyx.oauth.exchange import validate_oauth_endpoint_url
 from onyx.oauth.expiry import needs_refresh
-from onyx.redis.lock_context import redis_shared_lock
-from onyx.redis.lock_context import RedisSharedLockAcquisitionError
+from onyx.oauth.single_flight import SingleFlightTokenRefresher
 from onyx.server.features.mcp.models import MCPConnectionData
 from onyx.server.features.mcp.models import MCPOAuthKeys
 from onyx.utils.logger import setup_logger
@@ -41,16 +39,101 @@ from onyx.utils.url import SSRFException
 
 logger = setup_logger()
 
-# Held long enough for the refresh POST + DB write; short wait so a contended caller
-# doesn't pin a worker thread (a timed-out waiter proceeds with the current token).
-_LOCK_HELD_S = 30.0
-_LOCK_WAIT_S = 5.0
-
 _DISCOVERY_PATHS = (
     "/.well-known/oauth-authorization-server",
     "/.well-known/openid-configuration",
 )
 _DISCOVERY_TIMEOUT_S = 10
+
+
+class _MCPTokenRefresher(SingleFlightTokenRefresher[dict[str, str]]):
+    """Refresh the OAuth access token on one MCP connection config.
+
+    Storage is ``MCPConnectionConfig``; on success returns the fresh ``headers``
+    dict (new ``Authorization``) for the caller to apply. A dead grant flips an
+    admin-owned server to ``AWAITING_AUTH``; per-user grants are left alone.
+    """
+
+    log_prefix = "mcp_token_refresh"
+
+    def __init__(
+        self, tenant_id: str, mcp_server: MCPServer, connection_config_id: int
+    ):
+        self.tenant_id = tenant_id
+        self.mcp_server = mcp_server
+        self.connection_config_id = connection_config_id
+
+    def lock_name(self) -> str:
+        return f"mcp_token_refresh:{self.tenant_id}:{self.connection_config_id}"
+
+    def is_stale(self) -> bool:
+        if self.mcp_server.auth_type != MCPAuthenticationType.OAUTH:
+            return False
+        # Cheap pre-check before taking the lock; resolution only happens when stale.
+        with get_session_with_tenant(tenant_id=self.tenant_id) as db:
+            config = get_connection_config_by_id(self.connection_config_id, db)
+            config_data = extract_connection_data(config, apply_mask=False)
+        return _needs_refresh(config_data, datetime.now(timezone.utc))
+
+    def refresh_under_lock(self) -> dict[str, str] | None:
+        # Re-read after the lock wait: a concurrent winner may have already refreshed.
+        with get_session_with_tenant(tenant_id=self.tenant_id) as db:
+            config = get_connection_config_by_id(self.connection_config_id, db)
+            config_data = extract_connection_data(config, apply_mask=False)
+
+        if not _needs_refresh(config_data, datetime.now(timezone.utc)):
+            # Already refreshed by the lock winner — hand back the fresh headers.
+            return config_data.get("headers")
+
+        tokens = config_data.get(MCPOAuthKeys.TOKENS.value) or {}
+        refresh_token = tokens.get("refresh_token")
+        client = _client_credentials(config_data)
+        if not refresh_token or client is None:
+            return None
+        client_id, client_secret = client
+
+        token_endpoint = _resolve_token_endpoint(self.mcp_server, config_data)
+        if token_endpoint is None:
+            logger.warning(
+                "mcp_token_refresh.no_token_endpoint server_id=%s config_id=%s",
+                self.mcp_server.id,
+                self.connection_config_id,
+            )
+            return None
+
+        params = OAuthFlowParams(
+            # authorization_url is unused by refresh; token_url drives the grant.
+            authorization_url=token_endpoint,
+            token_url=token_endpoint,
+            client_id=client_id,
+            client_secret=client_secret,
+        )
+        # Raises Terminal/Transient, routed by the base class.
+        new_token_data = exchange_refresh_token(params, refresh_token)
+
+        new_token_data.setdefault("token_type", "Bearer")
+        if not new_token_data.get("access_token"):
+            logger.warning(
+                "mcp_token_refresh.no_access_token server_id=%s", self.mcp_server.id
+            )
+            return None
+
+        return _persist_refreshed(
+            self.tenant_id, self.connection_config_id, new_token_data, token_endpoint
+        )
+
+    def on_terminal(self, error: TokenRefreshTerminalError) -> dict[str, str] | None:
+        # Dead grant — an admin-owned server needs a manual reconnect.
+        logger.warning(
+            "mcp_token_refresh.terminal server_id=%s config_id=%s error=%s",
+            self.mcp_server.id,
+            self.connection_config_id,
+            error,
+        )
+        _mark_awaiting_auth_if_admin(
+            self.tenant_id, self.mcp_server, self.connection_config_id
+        )
+        return None
 
 
 def ensure_fresh_mcp_token(
@@ -63,113 +146,7 @@ def ensure_fresh_mcp_token(
     for the caller to apply. Returns None when no refresh was needed or possible —
     the caller then proceeds with the currently-stored credentials.
     """
-    if mcp_server.auth_type != MCPAuthenticationType.OAUTH:
-        return None
-
-    # Cheap pre-check before taking the lock; resolution only happens when stale.
-    try:
-        with get_session_with_tenant(tenant_id=tenant_id) as db:
-            config = get_connection_config_by_id(connection_config_id, db)
-            config_data = extract_connection_data(config, apply_mask=False)
-    except SQLAlchemyError as exc:
-        logger.warning(
-            "mcp_token_refresh.read_failed config_id=%s error=%s",
-            connection_config_id,
-            exc,
-        )
-        return None
-
-    if not _needs_refresh(config_data, datetime.now(timezone.utc)):
-        return None
-
-    lock_name = f"mcp_token_refresh:{tenant_id}:{connection_config_id}"
-    try:
-        with redis_shared_lock(
-            lock_name,
-            max_time_lock_held_s=_LOCK_HELD_S,
-            wait_for_lock_s=_LOCK_WAIT_S,
-            logger=logger,
-        ):
-            return _refresh_under_lock(tenant_id, mcp_server, connection_config_id)
-    except RedisSharedLockAcquisitionError:
-        # Another worker is refreshing; proceed with the current token.
-        logger.info(
-            "mcp_token_refresh.lock_contended config_id=%s", connection_config_id
-        )
-        return None
-    except (RedisError, SQLAlchemyError) as exc:
-        # Transient infra failure — keep existing tokens and let the request through.
-        logger.warning(
-            "mcp_token_refresh.infra_unavailable config_id=%s error=%s",
-            connection_config_id,
-            exc,
-        )
-        return None
-
-
-def _refresh_under_lock(
-    tenant_id: str,
-    mcp_server: MCPServer,
-    connection_config_id: int,
-) -> dict[str, str] | None:
-    # Re-read after the lock wait: a concurrent winner may have already refreshed.
-    with get_session_with_tenant(tenant_id=tenant_id) as db:
-        config = get_connection_config_by_id(connection_config_id, db)
-        config_data = extract_connection_data(config, apply_mask=False)
-
-    if not _needs_refresh(config_data, datetime.now(timezone.utc)):
-        # Already refreshed by the lock winner — hand back the fresh headers.
-        return config_data.get("headers")
-
-    tokens = config_data.get(MCPOAuthKeys.TOKENS.value) or {}
-    refresh_token = tokens.get("refresh_token")
-    client = _client_credentials(config_data)
-    if not refresh_token or client is None:
-        return None
-    client_id, client_secret = client
-
-    token_endpoint = _resolve_token_endpoint(mcp_server, config_data)
-    if token_endpoint is None:
-        logger.warning(
-            "mcp_token_refresh.no_token_endpoint server_id=%s config_id=%s",
-            mcp_server.id,
-            connection_config_id,
-        )
-        return None
-
-    params = OAuthFlowParams(
-        # authorization_url is unused by refresh; token_url drives the grant.
-        authorization_url=token_endpoint,
-        token_url=token_endpoint,
-        client_id=client_id,
-        client_secret=client_secret,
-    )
-
-    try:
-        new_token_data = exchange_refresh_token(params, refresh_token)
-    except TokenRefreshTerminalError:
-        # Dead grant — an admin-owned server needs a manual reconnect.
-        logger.warning(
-            "mcp_token_refresh.terminal server_id=%s config_id=%s",
-            mcp_server.id,
-            connection_config_id,
-        )
-        _mark_awaiting_auth_if_admin(tenant_id, mcp_server, connection_config_id)
-        return None
-    except TokenRefreshTransientError as exc:
-        logger.warning(
-            "mcp_token_refresh.transient server_id=%s error=%s", mcp_server.id, exc
-        )
-        return None
-
-    new_token_data.setdefault("token_type", "Bearer")
-    if not new_token_data.get("access_token"):
-        logger.warning("mcp_token_refresh.no_access_token server_id=%s", mcp_server.id)
-        return None
-
-    return _persist_refreshed(
-        tenant_id, connection_config_id, new_token_data, token_endpoint
-    )
+    return _MCPTokenRefresher(tenant_id, mcp_server, connection_config_id).run()
 
 
 def _persist_refreshed(
@@ -275,17 +252,10 @@ def _mark_awaiting_auth_if_admin(
     everyone; that user's next call surfaces the normal auth error instead."""
     if mcp_server.admin_connection_config_id != connection_config_id:
         return
-    try:
-        with get_session_with_tenant(tenant_id=tenant_id) as db:
-            update_mcp_server__no_commit(
-                server_id=mcp_server.id,
-                db_session=db,
-                status=MCPServerStatus.AWAITING_AUTH,
-            )
-            db.commit()
-    except SQLAlchemyError as exc:
-        logger.warning(
-            "mcp_token_refresh.status_update_failed server_id=%s error=%s",
-            mcp_server.id,
-            exc,
+    with get_session_with_tenant(tenant_id=tenant_id) as db:
+        update_mcp_server__no_commit(
+            server_id=mcp_server.id,
+            db_session=db,
+            status=MCPServerStatus.AWAITING_AUTH,
         )
+        db.commit()

--- a/backend/tests/unit/external_apps/test_token_refresh.py
+++ b/backend/tests/unit/external_apps/test_token_refresh.py
@@ -11,6 +11,7 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from onyx.external_apps import token_refresh as tr
 from onyx.external_apps.providers.google_calendar import GoogleCalendarProvider
+from onyx.oauth import single_flight as sf
 from onyx.oauth.errors import TokenRefreshTerminalError
 from onyx.oauth.errors import TokenRefreshTransientError
 
@@ -83,7 +84,7 @@ def test_refresh_missing_refresh_token_is_terminal(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     called = MagicMock()
-    monkeypatch.setattr("onyx.oauth.exchange.requests.post", called)
+    monkeypatch.setattr("onyx.external_apps.providers.base.requests.post", called)
     with pytest.raises(TokenRefreshTerminalError):
         GoogleCalendarProvider().refresh_credentials({"access_token": "a"}, "c", "s")
     called.assert_not_called()
@@ -140,7 +141,7 @@ def test_refresh_network_error_is_transient(monkeypatch: pytest.MonkeyPatch) -> 
     def _boom(*_a: Any, **_k: Any) -> None:
         raise requests.RequestException("connection reset")
 
-    monkeypatch.setattr("onyx.oauth.exchange.requests.post", _boom)
+    monkeypatch.setattr("onyx.external_apps.providers.base.requests.post", _boom)
     with pytest.raises(TokenRefreshTransientError):
         GoogleCalendarProvider().refresh_credentials({"refresh_token": "rt"}, "c", "s")
 
@@ -181,7 +182,7 @@ def _capturing_post(
         captured["data"] = kwargs.get("data")
         return response
 
-    monkeypatch.setattr("onyx.oauth.exchange.requests.post", _post)
+    monkeypatch.setattr("onyx.external_apps.providers.base.requests.post", _post)
     return captured
 
 
@@ -272,7 +273,7 @@ def _setup(
     app = MagicMock()
     app.skill.name = "Google Calendar"
 
-    monkeypatch.setattr(tr, "redis_shared_lock", _noop_cm)
+    monkeypatch.setattr(sf, "redis_shared_lock", _noop_cm)
     monkeypatch.setattr(tr, "get_session_with_tenant", _noop_cm)
     monkeypatch.setattr(tr, "get_external_app_by_id", lambda *_a, **_k: app)
     monkeypatch.setattr(tr, "get_provider_for_app", lambda *_a, **_k: provider)
@@ -361,7 +362,7 @@ def test_ensure_fresh_redis_unavailable_keeps_existing_token(
     def _boom(*_a: Any, **_k: Any) -> Any:
         raise RedisConnectionError("Error connecting to Redis.")
 
-    monkeypatch.setattr(tr, "redis_shared_lock", _boom)
+    monkeypatch.setattr(sf, "redis_shared_lock", _boom)
     _run()  # must not raise
     spies["refresh"].assert_not_called()
     spies["upsert"].assert_not_called()

--- a/backend/tests/unit/onyx/server/features/mcp/test_oauth_refresh.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_oauth_refresh.py
@@ -18,8 +18,10 @@ from redis.exceptions import ConnectionError as RedisConnectionError
 
 from onyx.db.enums import MCPAuthenticationType
 from onyx.db.enums import MCPServerStatus
+from onyx.oauth import single_flight as sf
 from onyx.oauth.errors import TokenRefreshTerminalError
 from onyx.oauth.errors import TokenRefreshTransientError
+from onyx.redis.lock_context import RedisSharedLockAcquisitionError
 from onyx.server.features.mcp import oauth_refresh as orf
 
 TENANT = "public"
@@ -76,7 +78,7 @@ def _setup(
 ) -> dict[str, MagicMock]:
     """Patch oauth_refresh's seams. `config_sequence` is the connection-config data
     returned on successive reads (pre-check, re-read under lock, persist re-read)."""
-    monkeypatch.setattr(orf, "redis_shared_lock", _noop_cm)
+    monkeypatch.setattr(sf, "redis_shared_lock", _noop_cm)
     monkeypatch.setattr(orf, "get_session_with_tenant", _noop_cm)
     monkeypatch.setattr(
         orf, "get_connection_config_by_id", lambda cid, _db: MagicMock(id=cid)
@@ -214,9 +216,9 @@ def test_lock_contention_yields_to_winner(monkeypatch: pytest.MonkeyPatch) -> No
     spies = _setup(monkeypatch, config_sequence=[_stale_config()])
 
     def _boom(*_a: Any, **_k: Any) -> Any:
-        raise orf.RedisSharedLockAcquisitionError("contended")
+        raise RedisSharedLockAcquisitionError("contended")
 
-    monkeypatch.setattr(orf, "redis_shared_lock", _boom)
+    monkeypatch.setattr(sf, "redis_shared_lock", _boom)
     assert _run() is None
     spies["refresh"].assert_not_called()
 
@@ -229,7 +231,7 @@ def test_redis_unavailable_keeps_existing_token(
     def _boom(*_a: Any, **_k: Any) -> Any:
         raise RedisConnectionError("Error connecting to Redis.")
 
-    monkeypatch.setattr(orf, "redis_shared_lock", _boom)
+    monkeypatch.setattr(sf, "redis_shared_lock", _boom)
     assert _run() is None  # must not raise
     spies["refresh"].assert_not_called()
 


### PR DESCRIPTION
**Stack: 3 of 3** (base: `refactor/oauth-exchange-unify` / #12098). Review/merge #12097 → #12098 first.

### What
Both Craft external apps and MCP servers refresh the same way:
> cheap stale pre-check → Redis single-flight lock → re-read + exchange + persist → terminal/transient/contention/infra routing.

This hoists that fixed skeleton into `onyx/oauth/single_flight.SingleFlightTokenRefresher[R]` (Template Method) and reduces both orchestrators to ~30-line strategy subclasses that fill in only what differs:

| | `_ExternalAppTokenRefresher` | `_MCPTokenRefresher` |
|---|---|---|
| token store | `ExternalAppUserCredential` | `MCPConnectionConfig` |
| dead-grant policy | clear the credential | flip admin server → `AWAITING_AUTH` (per-user grants left alone) |
| success return | `None` (egress gate re-reads) | fresh `Authorization` headers |

`ensure_fresh_credentials` / `ensure_fresh_mcp_token` keep their signatures.

### Why
The two orchestrators were near-identical copies (the MCP one's docstring literally said "mirroring `external_apps.token_refresh`"). One skeleton means the lock timings, contention/infra handling, and terminal/transient routing live in exactly one place.

### Safety
Behavior preserved — the unit suites assert the same read sequences, lock usage, persistence shape, admin-only status flip, and error routing as before. `ty` + pre-commit clean; 237 affected unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized the single-flight OAuth token refresh into `onyx/oauth/single_flight.SingleFlightTokenRefresher` and refactored external apps and MCP flows to use it, reducing duplication and standardizing behavior. Public APIs stay the same; refresh handling is now consistent and easier to maintain.

- **Refactors**
  - Added `SingleFlightTokenRefresher` in `onyx/oauth/single_flight.py` with a fixed flow: stale pre-check → Redis lock → re-read/exchange/persist → terminal/transient/contention/infra routing.
  - External apps: `_ExternalAppTokenRefresher` uses `ExternalAppUserCredential`; terminal clears the credential; `ensure_fresh_credentials` unchanged and returns `None`.
  - MCP: `_MCPTokenRefresher` uses `MCPConnectionConfig`; terminal flips admin servers to `AWAITING_AUTH`; `ensure_fresh_mcp_token` unchanged and returns fresh `Authorization` headers.
  - Trimmed `backend/onyx/external_apps/token_refresh.py` and `backend/onyx/server/features/mcp/oauth_refresh.py`; tests updated to patch `redis_shared_lock` via `onyx.oauth.single_flight`.
  - Behavior preserved and covered by existing unit tests (read sequences, lock usage, persistence, and error routing).

<sup>Written for commit 7038b24c53e6c06ce7d29b20af47962335524733. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12099?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

