### PR TITLE
feat(mcp): surface MCP tool auth failures as re-authenticatable errors

### DIFF
--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -10,6 +10,7 @@ from onyx.db.models import MCPConnectionConfig
 from onyx.db.models import MCPServer
 from onyx.server.query_and_chat.placement import Placement
 from onyx.server.query_and_chat.streaming_models import CustomToolDelta
+from onyx.server.query_and_chat.streaming_models import CustomToolErrorInfo
 from onyx.server.query_and_chat.streaming_models import CustomToolStart
 from onyx.server.query_and_chat.streaming_models import Packet
 from onyx.tools.interface import Tool
@@ -195,6 +196,15 @@ class MCPTool(Tool[None]):
 
                 error_result = {"error": auth_error_msg}
                 llm_facing_response = json.dumps(error_result)
+                # Tag as an auth error so the chat UI can prompt re-auth (mirrors
+                # custom_tool.py); covers the never-authenticated case. message is
+                # the user-facing label the re-auth UI renders, not the verbose
+                # LLM instruction above.
+                auth_error_info = CustomToolErrorInfo(
+                    is_auth_error=True,
+                    status_code=401,
+                    message=f"Authentication required for {self.mcp_server.name}",
+                )
 
                 # Emit CustomToolDelta packet
                 self.emitter.emit(
@@ -204,6 +214,7 @@ class MCPTool(Tool[None]):
                             tool_name=self._name,
                             response_type="json",
                             data=error_result,
+                            error=auth_error_info,
                         ),
                     )
                 )
@@ -213,6 +224,7 @@ class MCPTool(Tool[None]):
                         tool_name=self._name,
                         response_type="json",
                         tool_result=error_result,
+                        error=auth_error_info,
                     ),
                     llm_facing_response=llm_facing_response,
                 )
@@ -303,6 +315,7 @@ class MCPTool(Tool[None]):
                 indicator in error_str for indicator in auth_error_indicators
             )
 
+            error_info: CustomToolErrorInfo | None = None
             if is_auth_error:
                 auth_error_msg = (
                     f"Authentication failed for the {self._name} tool from {self.mcp_server.name}. "
@@ -310,6 +323,21 @@ class MCPTool(Tool[None]):
                     f"for the {self.mcp_server.name} server. Original error: {str(e)}"
                 )
                 error_result = {"error": auth_error_msg}
+                # Tag as an auth error so the chat UI can prompt re-auth (mirrors
+                # custom_tool.py); a bare message string never reaches that path.
+                # message is the user-facing label the re-auth UI renders, not the
+                # verbose LLM instruction above.
+                error_info = CustomToolErrorInfo(
+                    is_auth_error=True,
+                    status_code=(
+                        403
+                        if "403" in error_str
+                        or "forbidden" in error_str
+                        or "access denied" in error_str
+                        else 401
+                    ),
+                    message=f"Re-authentication required for {self.mcp_server.name}",
+                )
             else:
                 error_result = {"error": f"Tool execution failed: {str(e)}"}
 
@@ -323,6 +351,7 @@ class MCPTool(Tool[None]):
                         tool_name=self._name,
                         response_type="json",
                         data=error_result,
+                        error=error_info,
                     ),
                 )
             )
@@ -332,6 +361,7 @@ class MCPTool(Tool[None]):
                     tool_name=self._name,
                     response_type="json",
                     tool_result=error_result,
+                    error=error_info,
                 ),
                 llm_facing_response=llm_facing_response,
             )

--- a/backend/tests/unit/onyx/tools/tool_implementations/mcp/test_mcp_tool_auth_error.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/mcp/test_mcp_tool_auth_error.py
@@ -1,0 +1,157 @@
+"""Tests that MCPTool.run() flags auth failures on both the emitted
+CustomToolDelta and the returned CustomToolCallSummary.
+
+Two auth-error paths exist in run():
+  1. Never-authenticated (pre-call): the server requires auth but no
+     credentials/headers are configured -> status_code 401.
+  2. Auth failure at call time: the underlying MCP call raises an exception
+     whose message matches an auth indicator -> 401 (or 403 for forbidden).
+
+A non-auth failure (e.g. "connection reset") must NOT be tagged, so the chat
+UI doesn't falsely prompt re-auth.
+"""
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from onyx.db.enums import MCPAuthenticationType
+from onyx.db.enums import MCPTransport
+from onyx.server.query_and_chat.placement import Placement
+from onyx.server.query_and_chat.streaming_models import CustomToolDelta
+from onyx.server.query_and_chat.streaming_models import Packet
+from onyx.tools.models import CustomToolCallSummary
+from onyx.tools.tool_implementations.mcp.mcp_tool import MCPTool
+
+
+def _capturing_emitter() -> MagicMock:
+    """A MagicMock emitter whose emit() records every Packet on .packets.
+
+    MCPTool only calls emitter.emit(); a MagicMock keeps ty happy (Emitter is
+    untyped past the constructor) while letting us inspect what was emitted.
+    """
+    emitter = MagicMock()
+    packets: list[Packet] = []
+    emitter.packets = packets
+    emitter.emit.side_effect = packets.append
+    return emitter
+
+
+def _placement() -> Placement:
+    return Placement(turn_index=0)
+
+
+def _captured_deltas(emitter: MagicMock) -> list[CustomToolDelta]:
+    return [p.obj for p in emitter.packets if isinstance(p.obj, CustomToolDelta)]
+
+
+def _make_tool(
+    emitter: MagicMock,
+    auth_type: MCPAuthenticationType,
+) -> MCPTool:
+    mcp_server = MagicMock()
+    mcp_server.name = "test-mcp"
+    mcp_server.server_url = "https://mcp.example.com/mcp"
+    mcp_server.auth_type = auth_type
+    mcp_server.transport = MCPTransport.STREAMABLE_HTTP
+    return MCPTool(
+        tool_id=1,
+        emitter=emitter,
+        mcp_server=mcp_server,
+        tool_name="do_thing",
+        tool_description="Does a thing",
+        tool_definition={"type": "object", "properties": {}},
+        connection_config=None,
+    )
+
+
+class TestNeverAuthenticatedPath:
+    def test_requires_auth_without_credentials_is_tagged_401(self) -> None:
+        # API_TOKEN auth required, but no connection_config / headers / token ->
+        # has_auth_config is False -> pre-call auth-error branch.
+        emitter = _capturing_emitter()
+        tool = _make_tool(emitter, MCPAuthenticationType.API_TOKEN)
+
+        response = tool.run(_placement())
+
+        deltas = _captured_deltas(emitter)
+        assert len(deltas) == 1
+        assert deltas[0].error is not None
+        assert deltas[0].error.is_auth_error is True
+        assert deltas[0].error.status_code == 401
+
+        summary = response.rich_response
+        assert isinstance(summary, CustomToolCallSummary)
+        assert summary.error is not None
+        assert summary.error.is_auth_error is True
+        assert summary.error.status_code == 401
+
+
+class TestCallTimeAuthFailurePath:
+    def test_401_exception_is_tagged_401(self) -> None:
+        # NONE auth -> skips the pre-call check and reaches call_mcp_tool, which
+        # we make raise an auth-indicating error.
+        emitter = _capturing_emitter()
+        tool = _make_tool(emitter, MCPAuthenticationType.NONE)
+
+        with patch(
+            "onyx.tools.tool_implementations.mcp.mcp_tool.call_mcp_tool",
+            side_effect=Exception("HTTP 401 Unauthorized"),
+        ):
+            response = tool.run(_placement())
+
+        deltas = _captured_deltas(emitter)
+        assert len(deltas) == 1
+        assert deltas[0].error is not None
+        assert deltas[0].error.is_auth_error is True
+        assert deltas[0].error.status_code == 401
+
+        summary = response.rich_response
+        assert isinstance(summary, CustomToolCallSummary)
+        assert summary.error is not None
+        assert summary.error.is_auth_error is True
+        assert summary.error.status_code == 401
+
+    def test_403_forbidden_exception_is_tagged_403(self) -> None:
+        emitter = _capturing_emitter()
+        tool = _make_tool(emitter, MCPAuthenticationType.NONE)
+
+        with patch(
+            "onyx.tools.tool_implementations.mcp.mcp_tool.call_mcp_tool",
+            side_effect=Exception("HTTP 403 Forbidden"),
+        ):
+            response = tool.run(_placement())
+
+        deltas = _captured_deltas(emitter)
+        assert deltas[0].error is not None
+        assert deltas[0].error.is_auth_error is True
+        assert deltas[0].error.status_code == 403
+
+        summary = response.rich_response
+        assert isinstance(summary, CustomToolCallSummary)
+        assert summary.error is not None
+        assert summary.error.status_code == 403
+
+    def test_non_auth_exception_is_not_tagged(self) -> None:
+        # Control: a generic failure must not be mistaken for an auth error.
+        emitter = _capturing_emitter()
+        tool = _make_tool(emitter, MCPAuthenticationType.NONE)
+
+        with patch(
+            "onyx.tools.tool_implementations.mcp.mcp_tool.call_mcp_tool",
+            side_effect=Exception("connection reset by peer"),
+        ):
+            response = tool.run(_placement())
+
+        deltas = _captured_deltas(emitter)
+        assert len(deltas) == 1
+        assert deltas[0].error is None
+
+        summary = response.rich_response
+        assert isinstance(summary, CustomToolCallSummary)
+        assert summary.error is None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-xv"])


### PR DESCRIPTION
## Description

MCP tool calls that fail authentication — a per-user MCP server with no credentials configured, or a 401/403 at call time — only embedded the auth message as a plain string in the tool result. The chat UI's re-authentication prompt keys off `CustomToolDelta.error.is_auth_error`, which the MCP tool never set, so an auth failure on an MCP tool surfaced no re-auth affordance (unlike `custom_tool.py`, which does set it).

This makes `mcp_tool.py` populate `CustomToolErrorInfo(is_auth_error=True, status_code, message)` on both auth-failure paths — the pre-call "requires auth but no credentials" branch and the call-time 401/403 exception branch — and attach it to both the streamed `CustomToolDelta` and the `CustomToolCallSummary`, mirroring `custom_tool.py`. The existing re-authentication UX then works for MCP tools too.

This is **PR 1 of a small stacked series** for surfacing MCP re-authentication needs in the chat UI. The follow-ups are pushed to my fork and build on this commit:
1. (this) backend — emit `is_auth_error` on MCP auth failures
2. frontend — a re-auth badge + "Needs re-authentication" section on the chat-input actions popover
3. backend — a derived per-user auth-status endpoint so the badge can show on page load
4. backend — persist observed 401s so the signal survives a reload

Opening them sequentially since cross-fork PRs can't be stacked against this repo; happy to have the branches pulled and stacked if you prefer.

## How Has This Been Tested?

- Unit test (`backend/tests/unit/onyx/tools/tool_implementations/mcp/test_mcp_tool_auth_error.py`): both auth paths set `error.is_auth_error` (401, and 403 for forbidden); a non-auth failure does not (guards against false positives).
- Manually verified against a local mock MCP server that returns 401 on tool calls — the streamed `CustomToolDelta` now carries `error.is_auth_error: true`.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces MCP tool auth failures as re-authenticatable errors so the chat UI can prompt re-auth for MCP servers. Covers missing credentials and call-time 401/403, matching `custom_tool.py`.

- **Bug Fixes**
  - Populate `CustomToolErrorInfo` (is_auth_error, status_code, message) on both `CustomToolDelta` and `CustomToolCallSummary` for the pre-call “requires auth” path and for auth exceptions.
  - Status codes: 401 for missing creds; 403 when the exception mentions 403/forbidden/access denied; otherwise 401. Added unit tests; non-auth failures are not tagged.

<sup>Written for commit 0b66e57c5ac6f8e951b38545414e333f63208a77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

