### PR TITLE
chore(opal): remove dead RootLayout.Sidebar component

### DIFF
--- a/web/bun.lock
+++ b/web/bun.lock
@@ -130,7 +130,7 @@
     },
     "lib/opal": {
       "name": "@onyx-ai/opal",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "dependencies": {
         "clsx": "^2.0.0",
         "copy-to-clipboard": "^3.3.3",

--- a/web/lib/opal/package.json
+++ b/web/lib/opal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onyx-ai/opal",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Opal — Onyx's Typescript component library and design system.",
   "license": "MIT",
   "repository": {

--- a/web/lib/opal/src/layouts/root/RootLayout.stories.tsx
+++ b/web/lib/opal/src/layouts/root/RootLayout.stories.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import * as RootLayout from "@opal/layouts/root/components";
 
@@ -15,17 +14,13 @@ type Story = StoryObj;
 // Shared demo helpers
 // ---------------------------------------------------------------------------
 
-function DemoSidebar({ folded }: { folded: boolean }) {
+function DemoSidebar() {
   return (
     <div className="h-full w-60 bg-background-neutral-02 border-r border-border-01 p-4 flex flex-col gap-3">
-      {!folded && (
-        <>
-          <div className="h-6 w-24 rounded-04 bg-background-neutral-04" />
-          <div className="h-4 w-full rounded-04 bg-background-neutral-03" />
-          <div className="h-4 w-3/4 rounded-04 bg-background-neutral-03" />
-          <div className="h-4 w-5/6 rounded-04 bg-background-neutral-03" />
-        </>
-      )}
+      <div className="h-6 w-24 rounded-04 bg-background-neutral-04" />
+      <div className="h-4 w-full rounded-04 bg-background-neutral-03" />
+      <div className="h-4 w-3/4 rounded-04 bg-background-neutral-03" />
+      <div className="h-4 w-5/6 rounded-04 bg-background-neutral-03" />
     </div>
   );
 }
@@ -43,27 +38,13 @@ function DemoContent({ label }: { label: string }) {
 // ---------------------------------------------------------------------------
 
 function BasicDemo() {
-  const [folded, setFolded] = useState(false);
   return (
     <div className="w-full h-screen">
       <RootLayout.Root>
-        <RootLayout.Sidebar
-          folded={folded}
-          onFoldToggle={() => setFolded((p) => !p)}
-        >
-          <DemoSidebar folded={folded} />
-        </RootLayout.Sidebar>
+        <DemoSidebar />
         <RootLayout.App>
           <RootLayout.MainContent>
-            <div className="h-full flex flex-col items-center justify-center gap-3">
-              <DemoContent label="Main content" />
-              <button
-                className="px-3 py-1.5 rounded-08 bg-background-neutral-03 text-text-02 text-sm"
-                onClick={() => setFolded((p) => !p)}
-              >
-                Toggle sidebar
-              </button>
-            </div>
+            <DemoContent label="Main content" />
           </RootLayout.MainContent>
         </RootLayout.App>
       </RootLayout.Root>
@@ -76,16 +57,10 @@ export const Basic: Story = {
 };
 
 function WithPanelsDemo() {
-  const [folded, setFolded] = useState(false);
   return (
     <div className="w-full h-screen">
       <RootLayout.Root>
-        <RootLayout.Sidebar
-          folded={folded}
-          onFoldToggle={() => setFolded((p) => !p)}
-        >
-          <DemoSidebar folded={folded} />
-        </RootLayout.Sidebar>
+        <DemoSidebar />
         <RootLayout.LeftPanel className="w-56 bg-background-neutral-02 border-r border-border-01">
           <DemoContent label="Left panel" />
         </RootLayout.LeftPanel>
@@ -107,17 +82,10 @@ export const WithPanels: Story = {
 };
 
 function WithHeaderFooterDemo() {
-  const [folded, setFolded] = useState(false);
-  const [extraPadding, setExtraPadding] = useState(false);
   return (
     <div className="w-full h-screen">
       <RootLayout.Root>
-        <RootLayout.Sidebar
-          folded={folded}
-          onFoldToggle={() => setFolded((p) => !p)}
-        >
-          <DemoSidebar folded={folded} />
-        </RootLayout.Sidebar>
+        <DemoSidebar />
         <RootLayout.App>
           <RootLayout.Header>
             <div className="h-12 px-4 border-b border-border-01 bg-background-neutral-01 flex items-center">
@@ -129,15 +97,9 @@ function WithHeaderFooterDemo() {
           <RootLayout.MainContent>
             <DemoContent label="Scrollable page content" />
           </RootLayout.MainContent>
-          <RootLayout.Footer extraPadding={extraPadding}>
+          <RootLayout.Footer>
             <div className="h-12 px-4 border-t border-border-01 bg-background-neutral-01 flex items-center gap-3">
               <span className="text-text-03 text-xs">App footer</span>
-              <button
-                className="px-2 py-1 rounded-04 bg-background-neutral-03 text-text-02 text-xs"
-                onClick={() => setExtraPadding((p) => !p)}
-              >
-                extraPadding: {extraPadding ? "on" : "off"}
-              </button>
             </div>
           </RootLayout.Footer>
         </RootLayout.App>

--- a/web/lib/opal/src/layouts/root/components.tsx
+++ b/web/lib/opal/src/layouts/root/components.tsx
@@ -13,7 +13,6 @@ import {
   type ReactNode,
   type SetStateAction,
 } from "react";
-import useScreenSize from "@opal/hooks/useScreenSize";
 import type { WithoutStyles } from "@opal/types";
 
 // ---------------------------------------------------------------------------
@@ -112,73 +111,6 @@ interface RootLayoutRootProps {
 
 function RootLayoutRoot({ children }: RootLayoutRootProps) {
   return <div className="opal-root-layout">{children}</div>;
-}
-
-// ---------------------------------------------------------------------------
-// Sidebar — handles mobile / medium / desktop positioning
-// ---------------------------------------------------------------------------
-
-interface RootLayoutSidebarProps {
-  /**
-   * Whether the sidebar is currently folded (collapsed on desktop, hidden on
-   * mobile). Controlled by the consumer — typically read from a persistent
-   * state provider such as `SidebarStateProvider`.
-   */
-  folded: boolean;
-  /** Called when the sidebar fold state should toggle. */
-  onFoldToggle: () => void;
-  children: ReactNode;
-}
-
-function RootLayoutSidebar({
-  folded,
-  onFoldToggle,
-  children,
-}: RootLayoutSidebarProps) {
-  const { isMobile, isMediumScreen } = useScreenSize();
-  const foldedAttr = folded ? "true" : "false";
-
-  if (isMobile) {
-    return (
-      <>
-        <div
-          className="opal-root-layout__sidebar-overlay"
-          data-variant="mobile"
-          data-folded={foldedAttr}
-        >
-          {children}
-        </div>
-        <div
-          className="opal-root-layout__backdrop"
-          data-variant="mobile"
-          data-folded={foldedAttr}
-          onClick={onFoldToggle}
-        />
-      </>
-    );
-  }
-
-  if (isMediumScreen) {
-    return (
-      <>
-        <div className="opal-root-layout__sidebar-spacer" />
-        <div
-          className="opal-root-layout__sidebar-overlay"
-          data-variant="medium"
-        >
-          {children}
-        </div>
-        <div
-          className="opal-root-layout__backdrop"
-          data-variant="medium"
-          data-folded={foldedAttr}
-          onClick={onFoldToggle}
-        />
-      </>
-    );
-  }
-
-  return <>{children}</>;
 }
 
 // ---------------------------------------------------------------------------
@@ -297,7 +229,6 @@ function RootLayoutFooter({
 
 export {
   RootLayoutRoot as Root,
-  RootLayoutSidebar as Sidebar,
   RootLayoutApp as App,
   RootLayoutMainContent as MainContent,
   RootLayoutLeftPanel as LeftPanel,

--- a/web/lib/opal/src/layouts/root/styles.css
+++ b/web/lib/opal/src/layouts/root/styles.css
@@ -5,42 +5,6 @@
   @apply flex flex-row w-full h-full;
 }
 
-/* Sidebar overlay (mobile + medium) — fixed positioning strip */
-.opal-root-layout__sidebar-overlay {
-  @apply fixed inset-y-0 left-0 z-50;
-}
-
-/* Mobile: slides in/out via transform */
-.opal-root-layout__sidebar-overlay[data-variant="mobile"] {
-  @apply transition-transform duration-200;
-}
-.opal-root-layout__sidebar-overlay[data-variant="mobile"][data-folded="true"] {
-  @apply -translate-x-full;
-}
-.opal-root-layout__sidebar-overlay[data-variant="mobile"][data-folded="false"] {
-  @apply translate-x-0;
-}
-
-/* Medium: spacer that holds width in the flex layout flow */
-.opal-root-layout__sidebar-spacer {
-  @apply shrink-0 w-(--sidebar-width-folded);
-}
-
-/* Backdrop — shared fade behavior */
-.opal-root-layout__backdrop {
-  @apply fixed inset-0 z-40 backdrop-blur-03 transition-opacity duration-200;
-}
-/* Mobile gets a tinted mask; medium is blur-only */
-.opal-root-layout__backdrop[data-variant="mobile"] {
-  @apply bg-mask-03;
-}
-.opal-root-layout__backdrop[data-folded="true"] {
-  @apply opacity-0 pointer-events-none;
-}
-.opal-root-layout__backdrop[data-folded="false"] {
-  @apply opacity-100 pointer-events-auto;
-}
-
 /* App — fills remaining flex space; flex-col so Header/Footer pin correctly */
 .opal-root-layout__app {
   @apply flex-1 flex flex-col overflow-hidden h-full w-full;


### PR DESCRIPTION
## Description

Removes the `RootLayoutSidebar` component (`RootLayout.Sidebar`) from `@opal/layouts/root`, which was superseded by `SidebarLayouts.Root` (in `@opal/layouts/sidebar`). The real app never used `RootLayout.Sidebar` — `SidebarLayouts.Root` handles its own mobile/medium/desktop overlay positioning internally. The dead component, its TypeScript interface, and 6 associated CSS classes are deleted. Storybook stories are updated to reflect the actual usage pattern.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the dead `RootLayout.Sidebar` from `@opal/layouts/root` in favor of `SidebarLayouts.Root`. This cleans up unused code with no runtime impact.

- **Refactors**
  - Deleted `RootLayout.Sidebar` and its TypeScript interface.
  - Removed six sidebar-related CSS classes from `@opal/layouts/root/styles.css`.
  - Updated Storybook to render the sidebar directly and drop fold/overlay demos.

- **Dependencies**
  - Bumped `@onyx-ai/opal` to `0.1.14`.

<sup>Written for commit 54f672221c0e5d5b7bbbcef17c32f1e94e7eae7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

