### PR TITLE
fix(voice): log Azure STT cancellations, no-speech, and session end

### DIFF
--- a/backend/onyx/voice/providers/azure.py
+++ b/backend/onyx/voice/providers/azure.py
@@ -160,13 +160,23 @@ class AzureStreamingTranscriber(StreamingTranscriberProtocol):
         def on_canceled(evt: Any) -> None:
             # Surfaces Azure-side failures that were previously swallowed:
             # auth errors, region/endpoint mismatch, quota, blocked outbound
-            # connection to Azure, or bad audio format.
+            # connection to Azure, or bad audio format. The diagnostic fields
+            # live on evt.cancellation_details (code is a CancellationErrorCode),
+            # not on evt itself.
+            details = getattr(evt, "cancellation_details", None)
             transcriber._logger.error(
-                "Azure STT canceled: reason=%s error_code=%s details=%s",
-                getattr(evt, "reason", None),
-                getattr(evt, "error_code", None),
-                getattr(evt, "error_details", None),
+                "Azure STT canceled: reason=%s code=%s details=%s",
+                getattr(details, "reason", None),
+                getattr(details, "code", None),
+                getattr(details, "error_details", None),
             )
+            # A cancel is terminal — no more transcripts will arrive. Signal
+            # end-of-stream so the consumer loop stops polling instead of
+            # spinning on empty results forever.
+            if transcriber._loop and not transcriber._closed:
+                transcriber._loop.call_soon_threadsafe(
+                    transcriber._transcript_queue.put_nowait, None
+                )
 
         def on_session_stopped(_evt: Any) -> None:
             transcriber._logger.info("Azure STT: session stopped")

--- a/backend/onyx/voice/providers/azure.py
+++ b/backend/onyx/voice/providers/azure.py
@@ -73,6 +73,7 @@ class AzureStreamingTranscriber(StreamingTranscriberProtocol):
         input_sample_rate: int = 24000,
         target_sample_rate: int = 16000,
     ):
+        self._logger = setup_logger()
         self.api_key = api_key
         self.region = region
         self.endpoint = endpoint
@@ -136,7 +137,15 @@ class AzureStreamingTranscriber(StreamingTranscriberProtocol):
                 )
 
         def on_recognized(evt: Any) -> None:
-            if evt.result.text and transcriber._loop and not transcriber._closed:
+            if not evt.result.text:
+                # Azure finished a segment but matched no speech. Log the reason
+                # so this isn't a silent empty transcript.
+                transcriber._logger.info(
+                    "Azure STT: no speech recognized in segment (reason=%s)",
+                    getattr(evt.result, "reason", None),
+                )
+                return
+            if transcriber._loop and not transcriber._closed:
                 if transcriber._accumulated_transcript:
                     transcriber._accumulated_transcript += " " + evt.result.text
                 else:
@@ -148,8 +157,24 @@ class AzureStreamingTranscriber(StreamingTranscriberProtocol):
                     ),
                 )
 
+        def on_canceled(evt: Any) -> None:
+            # Surfaces Azure-side failures that were previously swallowed:
+            # auth errors, region/endpoint mismatch, quota, blocked outbound
+            # connection to Azure, or bad audio format.
+            transcriber._logger.error(
+                "Azure STT canceled: reason=%s error_code=%s details=%s",
+                getattr(evt, "reason", None),
+                getattr(evt, "error_code", None),
+                getattr(evt, "error_details", None),
+            )
+
+        def on_session_stopped(_evt: Any) -> None:
+            transcriber._logger.info("Azure STT: session stopped")
+
         self._recognizer.recognizing.connect(on_recognizing)
         self._recognizer.recognized.connect(on_recognized)
+        self._recognizer.canceled.connect(on_canceled)
+        self._recognizer.session_stopped.connect(on_session_stopped)
         self._recognizer.start_continuous_recognition_async()
 
     async def send_audio(self, chunk: bytes) -> None:


### PR DESCRIPTION
## Description

- Adds diagnostic logging to identify why Azure STT transcription is not working (no transcript reaching the user)
- Log Azure STT cancellations (auth, region/endpoint mismatch, quota, blocked outbound, bad audio) that were previously swallowed
- Log when a segment returns no recognized speech, instead of silently emitting an empty transcript
- Log Azure STT session-stopped events to tell a clean shutdown apart from an error-driven one

## How Has This Been Tested?


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add diagnostic logging for Azure STT cancellations, no-speech segments, and session end, and stop streams on cancel. This makes failures visible and prevents empty transcripts or infinite polling.

- **Bug Fixes**
  - Log canceled events using evt.cancellation_details (reason, code, error_details) and signal end-of-stream so consumers stop polling.
  - Log when a segment has no recognized speech instead of emitting an empty transcript.
  - Log session-stopped events to distinguish clean shutdowns from errors.

<sup>Written for commit ff30f018c33175ed4caed69c58f29a46ffd6accd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



