### PR TITLE
fix(connector): only redirect connector detail page on a real 404

### DIFF
--- a/web/src/app/admin/connector/[ccPairId]/page.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/page.tsx
@@ -246,8 +246,10 @@ function Main({ ccPairId }: { ccPairId: number }) {
       setHasLoadedOnce(true);
     }
 
+    // Redirect only when the cc-pair is genuinely gone — a real 404 (deleted)
+    // or DELETING state — never on a transient poll error.
     if (
-      (hasLoadedOnce && (ccPairError || !ccPair)) ||
+      (hasLoadedOnce && ccPairError?.status === 404) ||
       (ccPair?.status === ConnectorCredentialPairStatus.DELETING &&
         !ccPair.connector)
     ) {


### PR DESCRIPTION
## Description

**Bug:** Opening a connector's admin detail view (e.g. `/admin/connector/6`) showed a brief loading state, then bounced back to the connector listing — even though the connector exists and its cc-pair endpoint returns 200.

**Cause:** The detail page polls the cc-pair endpoint. The redirect guard fired on *any* truthy `ccPairError` (or a momentarily absent `ccPair`), so a single transient poll error looked identical to "connector deleted" and kicked the user out.

**Fix:** Redirect only on a genuine 404 (`ccPairError?.status === 404`) or a real `DELETING` state. Transient poll errors now keep the detail view / surface a normal error state instead of silently navigating away.

Surfaced on a customer's Google Drive connector that was stuck in `in_repeated_error_state` (flakier polls), but the redirect defect is connector-agnostic.

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check