### PR TITLE
feat(craft): make Craft runtime-only; drop the craft backend image (#11877) [backport release/v4.1]

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -28,14 +28,12 @@ jobs:
       build-web: ${{ steps.check.outputs.build-web }}
       build-web-cloud: ${{ steps.check.outputs.build-web-cloud }}
       build-backend: ${{ steps.check.outputs.build-backend }}
-      build-backend-craft: ${{ steps.check.outputs.build-backend-craft }}
       build-model-server: ${{ steps.check.outputs.build-model-server }}
       is-cloud-tag: ${{ steps.check.outputs.is-cloud-tag }}
       is-beta: ${{ steps.check.outputs.is-beta }}
       is-beta-standalone: ${{ steps.check.outputs.is-beta-standalone }}
       is-stable: ${{ steps.check.outputs.is-stable }}
       is-latest: ${{ steps.check.outputs.is-latest }}
-      is-experimental-cc4a: ${{ steps.check.outputs.is-experimental-cc4a }}
       is-test-run: ${{ steps.check.outputs.is-test-run }}
       sanitized-tag: ${{ steps.check.outputs.sanitized-tag }}
       short-sha: ${{ steps.check.outputs.short-sha }}
@@ -73,13 +71,11 @@ jobs:
           IS_BETA_STANDALONE=false
           IS_LATEST=false
           IS_PROD_TAG=false
-          IS_EXPERIMENTAL_CC4A=false
           IS_TEST_RUN=false
           BUILD_DESKTOP=false
           BUILD_WEB=false
           BUILD_WEB_CLOUD=false
           BUILD_BACKEND=true
-          BUILD_BACKEND_CRAFT=false
           BUILD_MODEL_SERVER=true
 
           # Determine tag type based on pattern matching (do regex checks once)
@@ -98,16 +94,9 @@ jobs:
           if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-beta(\.[0-9]+)?$ ]]; then
             IS_BETA=true
           fi
-          if [[ "$TAG" == experimental-cc4a.* ]]; then
-            IS_EXPERIMENTAL_CC4A=true
-          fi
 
           # Determine what to build based on tag type
-          if [[ "$IS_EXPERIMENTAL_CC4A" == "true" ]]; then
-            # experimental-cc4a tags: craft backend + web + model-server, no regular backend
-            BUILD_BACKEND=false
-            BUILD_WEB=true
-          elif [[ "$IS_CLOUD" == "true" ]]; then
+          if [[ "$IS_CLOUD" == "true" ]]; then
             BUILD_WEB_CLOUD=true
           else
             BUILD_WEB=true
@@ -134,12 +123,6 @@ jobs:
             fi
           fi
 
-          # Build craft backend for stable releases (tagged craft-latest) and
-          # experimental cc4a tags (tagged craft-edge for dev clusters).
-          if [[ "$IS_LATEST" == "true" ]] || [[ "$IS_EXPERIMENTAL_CC4A" == "true" ]]; then
-            BUILD_BACKEND_CRAFT=true
-          fi
-
           # Determine if this is a production tag
           # Production tags are: version tags (v1.2.3*) or nightly tags
           if [[ "$IS_VERSION_TAG" == "true" ]] || [[ "$IS_NIGHTLY" == "true" ]]; then
@@ -155,14 +138,12 @@ jobs:
             echo "build-web=$BUILD_WEB"
             echo "build-web-cloud=$BUILD_WEB_CLOUD"
             echo "build-backend=$BUILD_BACKEND"
-            echo "build-backend-craft=$BUILD_BACKEND_CRAFT"
             echo "build-model-server=$BUILD_MODEL_SERVER"
             echo "is-cloud-tag=$IS_CLOUD"
             echo "is-beta=$IS_BETA"
             echo "is-beta-standalone=$IS_BETA_STANDALONE"
             echo "is-stable=$IS_STABLE"
             echo "is-latest=$IS_LATEST"
-            echo "is-experimental-cc4a=$IS_EXPERIMENTAL_CC4A"
             echo "is-test-run=$IS_TEST_RUN"
             echo "sanitized-tag=$SANITIZED_TAG"
             echo "short-sha=$SHORT_SHA"
@@ -171,7 +152,7 @@ jobs:
   check-version-tag:
     runs-on: ubuntu-slim
     timeout-minutes: 10
-    if: ${{ !startsWith(github.ref_name, 'nightly-latest') && !startsWith(github.ref_name, 'experimental-') && github.ref_name != 'edge' && github.event_name != 'workflow_dispatch' }}
+    if: ${{ !startsWith(github.ref_name, 'nightly-latest') && github.ref_name != 'edge' && github.event_name != 'workflow_dispatch' }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
@@ -626,8 +607,6 @@ jobs:
           tags: |
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run == 'true' && format('web-{0}', needs.determine-builds.outputs.sanitized-tag) || github.ref_name }}
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-latest == 'true' && 'latest' || '' }}
-            type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-latest == 'true' && 'craft-latest' || '' }}
-            type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-experimental-cc4a == 'true' && 'craft-edge' || '' }}
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && env.EDGE_TAG == 'true' && 'edge' || '' }}
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-beta == 'true' && 'beta' || '' }}
             type=semver,pattern={{version}},enable=${{ needs.determine-builds.outputs.is-stable == 'true' }}
@@ -1078,208 +1057,6 @@ jobs:
             $(printf '%s\n' "${META_TAGS}" | xargs -I {} echo -t {}) \
             $IMAGES
 
-  build-backend-craft-amd64:
-    needs: determine-builds
-    if: needs.determine-builds.outputs.build-backend-craft == 'true'
-    runs-on:
-      - runs-on
-      - runner=2cpu-linux-x64
-      - run-id=${{ github.run_id }}-backend-craft-amd64
-      - extras=ecr-cache
-    timeout-minutes: 90
-    environment: release
-    outputs:
-      digest: ${{ steps.build.outputs.digest }}
-    env:
-      REGISTRY_IMAGE: onyxdotapp/onyx-backend
-    steps:
-      - uses: runs-on/action@d141ef83eb66d096ce8afc767e09115a65c63b60
-
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
-        with:
-          persist-credentials: false
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37
-        with:
-          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
-          aws-region: us-east-2
-
-      - name: Get AWS Secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802
-        with:
-          secret-ids: |
-            DOCKER_USERNAME, deploy/docker-username
-            DOCKER_TOKEN, deploy/docker-token
-          parse-json-secrets: true
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9
-        with:
-          images: ${{ env.REGISTRY_IMAGE }}
-          flavor: |
-            latest=false
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # ratchet:docker/setup-buildx-action@v4
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
-        with:
-          username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ env.DOCKER_TOKEN }}
-
-      - name: Build and push AMD64
-        id: build
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
-        with:
-          context: ./backend
-          file: ./backend/Dockerfile
-          platforms: linux/amd64
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            ONYX_VERSION=${{ github.ref_name }}
-            ENABLE_CRAFT=true
-          cache-from: type=registry,ref=${{ env.REGISTRY_IMAGE }}:latest
-          cache-to: type=inline
-          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
-          no-cache: ${{ vars.DOCKER_NO_CACHE == 'true' }}
-
-  build-backend-craft-arm64:
-    needs: determine-builds
-    if: needs.determine-builds.outputs.build-backend-craft == 'true'
-    runs-on:
-      - runs-on
-      - runner=2cpu-linux-arm64
-      - run-id=${{ github.run_id }}-backend-craft-arm64
-      - extras=ecr-cache
-    timeout-minutes: 90
-    environment: release
-    outputs:
-      digest: ${{ steps.build.outputs.digest }}
-    env:
-      REGISTRY_IMAGE: onyxdotapp/onyx-backend
-    steps:
-      - uses: runs-on/action@d141ef83eb66d096ce8afc767e09115a65c63b60
-
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
-        with:
-          persist-credentials: false
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37
-        with:
-          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
-          aws-region: us-east-2
-
-      - name: Get AWS Secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802
-        with:
-          secret-ids: |
-            DOCKER_USERNAME, deploy/docker-username
-            DOCKER_TOKEN, deploy/docker-token
-          parse-json-secrets: true
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9
-        with:
-          images: ${{ env.REGISTRY_IMAGE }}
-          flavor: |
-            latest=false
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # ratchet:docker/setup-buildx-action@v4
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
-        with:
-          username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ env.DOCKER_TOKEN }}
-
-      - name: Build and push ARM64
-        id: build
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
-        with:
-          context: ./backend
-          file: ./backend/Dockerfile
-          platforms: linux/arm64
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            ONYX_VERSION=${{ github.ref_name }}
-            ENABLE_CRAFT=true
-          cache-from: type=registry,ref=${{ env.REGISTRY_IMAGE }}:latest
-          cache-to: type=inline
-          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
-          no-cache: ${{ vars.DOCKER_NO_CACHE == 'true' }}
-
-  merge-backend-craft:
-    needs:
-      - determine-builds
-      - build-backend-craft-amd64
-      - build-backend-craft-arm64
-    if: needs.determine-builds.outputs.build-backend-craft == 'true'
-    runs-on:
-      - runs-on
-      - runner=2cpu-linux-x64
-      - run-id=${{ github.run_id }}-merge-backend-craft
-      - extras=ecr-cache
-    timeout-minutes: 90
-    environment: release
-    env:
-      REGISTRY_IMAGE: onyxdotapp/onyx-backend
-    steps:
-      - uses: runs-on/action@d141ef83eb66d096ce8afc767e09115a65c63b60
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37
-        with:
-          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
-          aws-region: us-east-2
-
-      - name: Get AWS Secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802
-        with:
-          secret-ids: |
-            DOCKER_USERNAME, deploy/docker-username
-            DOCKER_TOKEN, deploy/docker-token
-          parse-json-secrets: true
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # ratchet:docker/setup-buildx-action@v4
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
-        with:
-          username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ env.DOCKER_TOKEN }}
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9
-        with:
-          images: ${{ env.REGISTRY_IMAGE }}
-          flavor: |
-            latest=false
-          tags: |
-            type=raw,value=${{ needs.determine-builds.outputs.is-experimental-cc4a == 'true' && 'craft-edge' || 'craft-latest' }}
-            type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-experimental-cc4a == 'true' && github.ref_name || '' }}
-
-      - name: Create and push manifest
-        env:
-          IMAGE_REPO: ${{ env.REGISTRY_IMAGE }}
-          AMD64_DIGEST: ${{ needs.build-backend-craft-amd64.outputs.digest }}
-          ARM64_DIGEST: ${{ needs.build-backend-craft-arm64.outputs.digest }}
-          META_TAGS: ${{ steps.meta.outputs.tags }}
-        run: |
-          IMAGES="${IMAGE_REPO}@${AMD64_DIGEST} ${IMAGE_REPO}@${ARM64_DIGEST}"
-          docker buildx imagetools create \
-            $(printf '%s\n' "${META_TAGS}" | xargs -I {} echo -t {}) \
-            $IMAGES
-
   build-model-server-amd64:
     needs: determine-builds
     if: needs.determine-builds.outputs.build-model-server == 'true'
@@ -1484,8 +1261,6 @@ jobs:
           tags: |
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run == 'true' && format('model-server-{0}', needs.determine-builds.outputs.sanitized-tag) || github.ref_name }}
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-latest == 'true' && 'latest' || '' }}
-            type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-latest == 'true' && 'craft-latest' || '' }}
-            type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-experimental-cc4a == 'true' && 'craft-edge' || '' }}
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && env.EDGE_TAG == 'true' && 'edge' || '' }}
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-beta-standalone == 'true' && 'beta' || '' }}
             type=semver,pattern={{version}},enable=${{ needs.determine-builds.outputs.is-stable == 'true' }}
@@ -1555,14 +1330,12 @@ jobs:
       - merge-web
       - merge-web-cloud
       - merge-backend
-      - merge-backend-craft
       - merge-model-server
     if: >-
       always() && !cancelled() &&
       (needs.merge-web.result == 'success' ||
        needs.merge-web-cloud.result == 'success' ||
        needs.merge-backend.result == 'success' ||
-       needs.merge-backend-craft.result == 'success' ||
        needs.merge-model-server.result == 'success')
     runs-on:
       - runs-on
@@ -1593,13 +1366,7 @@ jobs:
           case "$COMPONENT" in
             web) RESULT="$MERGE_WEB" ;;
             web-cloud) RESULT="$MERGE_WEB_CLOUD" ;;
-            backend)
-              if [ "$MERGE_BACKEND" == "success" ] || [ "$MERGE_BACKEND_CRAFT" == "success" ]; then
-                RESULT="success"
-              else
-                RESULT="skipped"
-              fi
-              ;;
+            backend) RESULT="$MERGE_BACKEND" ;;
             model-server) RESULT="$MERGE_MODEL_SERVER" ;;
           esac
           if [ "$RESULT" == "success" ]; then
@@ -1612,7 +1379,6 @@ jobs:
           MERGE_WEB: ${{ needs.merge-web.result }}
           MERGE_WEB_CLOUD: ${{ needs.merge-web-cloud.result }}
           MERGE_BACKEND: ${{ needs.merge-backend.result }}
-          MERGE_BACKEND_CRAFT: ${{ needs.merge-backend-craft.result }}
           MERGE_MODEL_SERVER: ${{ needs.merge-model-server.result }}
 
       - uses: runs-on/action@d141ef83eb66d096ce8afc767e09115a65c63b60
@@ -1672,13 +1438,10 @@ jobs:
       - build-backend-amd64
       - build-backend-arm64
       - merge-backend
-      - build-backend-craft-amd64
-      - build-backend-craft-arm64
-      - merge-backend-craft
       - build-model-server-amd64
       - build-model-server-arm64
       - merge-model-server
-    if: always() && (needs.build-desktop.result == 'failure' || needs.build-web-amd64.result == 'failure' || needs.build-web-arm64.result == 'failure' || needs.merge-web.result == 'failure' || needs.build-web-cloud-amd64.result == 'failure' || needs.build-web-cloud-arm64.result == 'failure' || needs.merge-web-cloud.result == 'failure' || needs.build-backend-amd64.result == 'failure' || needs.build-backend-arm64.result == 'failure' || needs.merge-backend.result == 'failure' || (needs.determine-builds.outputs.build-backend-craft == 'true' && (needs.build-backend-craft-amd64.result == 'failure' || needs.build-backend-craft-arm64.result == 'failure' || needs.merge-backend-craft.result == 'failure')) || needs.build-model-server-amd64.result == 'failure' || needs.build-model-server-arm64.result == 'failure' || needs.merge-model-server.result == 'failure') && needs.determine-builds.outputs.is-test-run != 'true'
+    if: always() && (needs.build-desktop.result == 'failure' || needs.build-web-amd64.result == 'failure' || needs.build-web-arm64.result == 'failure' || needs.merge-web.result == 'failure' || needs.build-web-cloud-amd64.result == 'failure' || needs.build-web-cloud-arm64.result == 'failure' || needs.merge-web-cloud.result == 'failure' || needs.build-backend-amd64.result == 'failure' || needs.build-backend-arm64.result == 'failure' || needs.merge-backend.result == 'failure' || needs.build-model-server-amd64.result == 'failure' || needs.build-model-server-arm64.result == 'failure' || needs.merge-model-server.result == 'failure') && needs.determine-builds.outputs.is-test-run != 'true'
     # NOTE: Github-hosted runners have about 20s faster queue times and are preferred here.
     runs-on: ubuntu-slim
     timeout-minutes: 90

--- a/.github/workflows/sandbox-deployment.yml
+++ b/.github/workflows/sandbox-deployment.yml
@@ -1,9 +1,12 @@
-name: Build and Push Sandbox Image on Tag
+name: Build and Push Sandbox Image
 
+# The sandbox image is the only Craft-specific image. Build a new version on
+# the nightly tag when its build context changed, or manually on demand.
 on:
   push:
     tags:
-      - "experimental-cc4a.*"
+      - "nightly-latest-*"
+  workflow_dispatch:
 
 # Restrictive defaults; jobs declare what they need.
 permissions: {}
@@ -24,36 +27,36 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - name: Check for sandbox-relevant file changes
+      - name: Check for sandbox image changes
         id: check
+        env:
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          # Get the previous tag to diff against
-          CURRENT_TAG="${GITHUB_REF_NAME}"
-          PREVIOUS_TAG=$(git tag --sort=-creatordate | grep '^experimental-cc4a\.' | grep -v "^${CURRENT_TAG}$" | head -n 1)
+          # Manual runs always build.
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "Manual dispatch: building unconditionally"
+            echo "sandbox-changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
+          # Diff the sandbox image build context against the previous nightly tag.
+          CURRENT_TAG="${GITHUB_REF_NAME}"
+          PREVIOUS_TAG=$(git tag --sort=-creatordate | grep '^nightly-latest-' | grep -v "^${CURRENT_TAG}$" | head -n 1)
           if [ -z "$PREVIOUS_TAG" ]; then
-            echo "No previous experimental-cc4a tag found, building unconditionally"
+            echo "No previous nightly tag; building unconditionally"
             echo "sandbox-changed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           echo "Comparing ${PREVIOUS_TAG}..${CURRENT_TAG}"
-
-          # Check if any sandbox-relevant files changed
-          SANDBOX_PATHS=(
-            "backend/onyx/server/features/build/sandbox/"
-          )
-
-          CHANGED=false
-          for path in "${SANDBOX_PATHS[@]}"; do
-            if git diff --name-only "${PREVIOUS_TAG}..${CURRENT_TAG}" -- "$path" | grep -q .; then
-              echo "Changes detected in: $path"
-              CHANGED=true
-              break
-            fi
-          done
-
-          echo "sandbox-changed=$CHANGED" >> "$GITHUB_OUTPUT"
+          if git diff --name-only "${PREVIOUS_TAG}..${CURRENT_TAG}" -- \
+              "backend/onyx/server/features/build/sandbox/image/" | grep -q .; then
+            echo "Sandbox image changed"
+            echo "sandbox-changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No sandbox image changes"
+            echo "sandbox-changed=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Determine new sandbox version
         id: version

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -66,11 +66,6 @@ have a contract or agreement with DanswerAI, you are not permitted to use the En
 Edition features outside of personal development or testing purposes. Please reach out to \
 founders@onyx.app for more information. Please visit https://github.com/onyx-dot-app/onyx"
 
-# Build argument for Craft support (disabled by default)
-# Use --build-arg ENABLE_CRAFT=true to include Node.js and opencode CLI
-# ARGs do not cross build stages, so it must be redeclared here.
-ARG ENABLE_CRAFT=false
-
 # DO_NOT_TRACK is used to disable telemetry for Unstructured
 ENV ONYX_RUNNING_IN_DOCKER="true" \
     DO_NOT_TRACK="true" \
@@ -108,24 +103,6 @@ RUN apt-get update && \
         && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
-
-# Conditionally install Node.js 20 for Craft (required for Next.js)
-# Only installed when ENABLE_CRAFT=true
-RUN if [ "$ENABLE_CRAFT" = "true" ]; then \
-        echo "Installing Node.js 20 for Craft support..." && \
-        curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
-        apt-get install -y nodejs && \
-        rm -rf /var/lib/apt/lists/*; \
-    fi
-
-# Conditionally install opencode CLI for Craft agent functionality
-# Only installed when ENABLE_CRAFT=true
-# TODO: download a specific, versioned release of the opencode CLI
-RUN if [ "$ENABLE_CRAFT" = "true" ]; then \
-        echo "Installing opencode CLI for Craft support..." && \
-        curl -fsSL https://opencode.ai/install | bash; \
-    fi
-ENV PATH="/root/.opencode/bin:${PATH}"
 
 # Copy the compiled Python packages and only the console scripts our services launch (api server,
 # celery workers/beat, alembic migrations, supervisord, Playwright). Both stages share the same base

--- a/deployment/docker_compose/docker-compose.yml
+++ b/deployment/docker_compose/docker-compose.yml
@@ -43,8 +43,6 @@ services:
     build:
       context: ../../backend
       dockerfile: Dockerfile
-      args:
-        - ENABLE_CRAFT=${ENABLE_CRAFT:-false}
     command: >
       /bin/sh -c "alembic upgrade head &&
       echo \"Starting Onyx Api Server\" &&
@@ -124,8 +122,6 @@ services:
     build:
       context: ../../backend
       dockerfile: Dockerfile
-      args:
-        - ENABLE_CRAFT=${ENABLE_CRAFT:-false}
     command: >
       /bin/sh -c "
       if [ -f /etc/ssl/certs/custom-ca.crt ]; then

--- a/deployment/docker_compose/install.ps1
+++ b/deployment/docker_compose/install.ps1
@@ -79,18 +79,13 @@ function Confirm-Action {
 }
 
 function Prompt-VersionTag {
+    # Craft uses the regular backend image (ENABLE_CRAFT is a runtime flag), so
+    # the tag is prompted for normally even with --include-craft.
     Print-Info "Which tag would you like to deploy?"
-    if ($script:IncludeCraftMode) {
-        Write-Host "  - Press Enter for craft-latest (recommended for Craft)"
-        Write-Host "  - Type a specific tag (e.g., craft-v1.0.0)"
-        $version = Prompt-OrDefault "Enter tag [default: craft-latest]" "craft-latest"
-    } else {
-        Write-Host "  - Press Enter for edge (recommended)"
-        Write-Host "  - Type a specific tag (e.g., v0.1.0)"
-        $version = Prompt-OrDefault "Enter tag [default: edge]" "edge"
-    }
-    if     ($script:IncludeCraftMode -and $version -eq "craft-latest") { Print-Info "Selected: craft-latest (Craft enabled)" }
-    elseif ($version -eq "edge") { Print-Info "Selected: edge (latest nightly)" }
+    Write-Host "  - Press Enter for edge (recommended)"
+    Write-Host "  - Type a specific tag (e.g., v0.1.0)"
+    $version = Prompt-OrDefault "Enter tag [default: edge]" "edge"
+    if ($version -eq "edge") { Print-Info "Selected: edge (latest nightly)" }
     else   { Print-Info "Selected: $version" }
     return $version
 }
@@ -110,14 +105,6 @@ function Prompt-DeploymentMode {
         Print-Info "Selected: Lite mode"
         if (-not (Ensure-OnyxFile $LiteOverlayPath "$($script:GitHubRawUrl)/$($script:LiteComposeFile)" $script:LiteComposeFile)) { exit 1 }
     }
-}
-
-function Assert-NotCraftLite {
-    param([string]$Tag)
-    if (-not ($script:LiteMode -and $Tag -match '^craft-')) { return }
-    Print-OnyxError "Cannot use a craft image tag ($Tag) with Lite mode."
-    Print-Info "Craft requires services (Vespa, Redis, background workers) that lite mode disables."
-    exit 1
 }
 
 function Refresh-PathFromRegistry {
@@ -970,18 +957,23 @@ function Main {
         $reply = Prompt-OrDefault "Choose an option [default: restart]" ""
 
         Prompt-DeploymentMode -LiteOverlayPath $liteOverlayPath
+        if ($script:LiteMode -and $script:IncludeCraftMode) {
+            Print-OnyxError "-IncludeCraft cannot be used with Lite mode."
+            exit 1
+        }
 
         if ($reply -eq "update") {
             $version = Prompt-VersionTag
-            Assert-NotCraftLite $version
             Set-EnvFileValue -Path $envFile -Key "IMAGE_TAG" -Value $version
             Print-Success "Updated IMAGE_TAG to $version"
-            if ($version -match '^craft-') {
-                Set-EnvFileValue -Path $envFile -Key "ENABLE_CRAFT" -Value "true" -Uncomment
-            }
         } else {
-            Assert-NotCraftLite (Get-EnvFileValue -Path $envFile -Key "IMAGE_TAG")
             Print-Info "Keeping existing configuration"
+        }
+        # Honor -IncludeCraft on existing installs regardless of update/restart;
+        # ENABLE_CRAFT is a runtime flag, so enabling it doesn't require a new tag.
+        if ($script:IncludeCraftMode) {
+            Set-EnvFileValue -Path $envFile -Key "ENABLE_CRAFT" -Value "true" -Uncomment
+            Print-Success "Onyx Craft enabled (ENABLE_CRAFT=true)"
         }
         if ($script:LiteMode) {
             $profiles = Get-EnvFileValue -Path $envFile -Key "COMPOSE_PROFILES"
@@ -999,7 +991,6 @@ function Main {
         if ($script:LiteMode) { $script:ExpectedDockerRamGB = 4; $script:ExpectedDiskGB = 16 }
 
         $version = Prompt-VersionTag
-        Assert-NotCraftLite $version
 
         Copy-Item -Path $envTemplateDest -Destination $envFile -Force
         Set-EnvFileValue -Path $envFile -Key "IMAGE_TAG" -Value $version
@@ -1009,7 +1000,7 @@ function Main {
         Print-Success "Basic authentication enabled"
         Set-EnvFileValue -Path $envFile -Key "USER_AUTH_SECRET" -Value "`"$(New-SecureSecret)`""
         Print-Success "Generated secure USER_AUTH_SECRET"
-        if ($script:IncludeCraftMode -or $version -match '^craft-') {
+        if ($script:IncludeCraftMode) {
             Set-EnvFileValue -Path $envFile -Key "ENABLE_CRAFT" -Value "true" -Uncomment
             Print-Success "Onyx Craft enabled"
         } else {
@@ -1034,7 +1025,7 @@ function Main {
     Print-Success "Using port $availablePort for nginx"
 
     $currentImageTag = Get-EnvFileValue -Path $envFile -Key "IMAGE_TAG"
-    $useLatest = ($currentImageTag -eq "edge" -or $currentImageTag -eq "latest" -or $currentImageTag -match '^craft-')
+    $useLatest = ($currentImageTag -eq "edge" -or $currentImageTag -eq "latest")
     if ($useLatest) { Print-Info "Using '$currentImageTag' tag - will force pull and recreate containers" }
 
     # For pinned version tags, re-download config files from that tag so the

--- a/deployment/docker_compose/install.sh
+++ b/deployment/docker_compose/install.sh
@@ -198,7 +198,7 @@ fetch_latest_release_tag() {
 # Craft sandbox backend for an image tag. The docker backend exists only in
 # v4.0.6+; older pinned tags get "kubernetes" (rolling tags track newest).
 sandbox_backend_for_tag() {
-    local ver="${1#craft-}"; ver="${ver#v}"; ver="${ver%%-*}"
+    local ver="${1#v}"; ver="${ver%%-*}"
     printf '%s' "$ver" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$' || { echo docker; return; }
     local major="${ver%%.*}" rest="${ver#*.}"
     local minor="${rest%%.*}" patch="${rest#*.}"
@@ -992,27 +992,21 @@ if [ -f "$ENV_FILE" ]; then
     echo ""
 
     if [ "$REPLY" = "update" ]; then
-        if [ "$INCLUDE_CRAFT" = true ]; then
-            # --include-craft requires the craft-tagged backend image (Node.js
-            # + opencode CLI are only built into that image), so the tag is
-            # forced rather than prompted for.
-            VERSION="craft-edge"
-            print_info "Update selected. Using craft-edge (required by --include-craft)."
-        else
-            print_info "Update selected. Which tag would you like to deploy?"
-            echo ""
-            echo "• Press Enter for ${DEFAULT_IMAGE_TAG} (recommended)"
-            echo "• Type a specific tag (e.g., v0.1.0)"
-            echo ""
-            prompt_or_default "Enter tag [default: ${DEFAULT_IMAGE_TAG}]: " "${DEFAULT_IMAGE_TAG}"
-            VERSION="$REPLY"
-            echo ""
+        # Craft uses the regular backend image (ENABLE_CRAFT is a runtime flag),
+        # so the tag is prompted for normally even with --include-craft.
+        print_info "Update selected. Which tag would you like to deploy?"
+        echo ""
+        echo "• Press Enter for ${DEFAULT_IMAGE_TAG} (recommended)"
+        echo "• Type a specific tag (e.g., v0.1.0)"
+        echo ""
+        prompt_or_default "Enter tag [default: ${DEFAULT_IMAGE_TAG}]: " "${DEFAULT_IMAGE_TAG}"
+        VERSION="$REPLY"
+        echo ""
 
-            if [ "$VERSION" = "edge" ]; then
-                print_info "Selected: edge (latest nightly)"
-            else
-                print_info "Selected: $VERSION"
-            fi
+        if [ "$VERSION" = "edge" ]; then
+            print_info "Selected: edge (latest nightly)"
+        else
+            print_info "Selected: $VERSION"
         fi
 
         # Update .env file with new version
@@ -1031,12 +1025,18 @@ if [ -f "$ENV_FILE" ]; then
         print_success "Will restart with current settings"
     fi
 
-    # Keep SANDBOX_BACKEND aligned with the effective image tag (the one just
-    # chosen, or the pinned IMAGE_TAG already in .env on a plain restart).
+    # Honor --include-craft on existing installs regardless of update/restart:
+    # enable Craft at runtime and align SANDBOX_BACKEND with the effective tag
+    # (the one just chosen, or the pinned IMAGE_TAG already in .env on a restart).
     if [ "$INCLUDE_CRAFT" = true ]; then
+        if grep -q "^#* *ENABLE_CRAFT=" "$ENV_FILE"; then
+            sed -i.bak 's/^#* *ENABLE_CRAFT=.*/ENABLE_CRAFT=true/' "$ENV_FILE"
+        else
+            echo "ENABLE_CRAFT=true" >> "$ENV_FILE"
+        fi
         EFFECTIVE_TAG="${VERSION:-$(grep -E '^IMAGE_TAG=' "$ENV_FILE" | head -1 | cut -d= -f2-)}"
         set_sandbox_backend_for_tag "$EFFECTIVE_TAG"
-        print_success "Craft sandbox backend set to $SANDBOX_BACKEND_VALUE (image tag: ${EFFECTIVE_TAG})"
+        print_success "Onyx Craft enabled (ENABLE_CRAFT=true, SANDBOX_BACKEND=$SANDBOX_BACKEND_VALUE, image tag: ${EFFECTIVE_TAG})"
     fi
 
     # Ensure COMPOSE_PROFILES is cleared when running in lite mode on an
@@ -1049,26 +1049,21 @@ else
     print_info "No existing .env file found. Setting up new deployment..."
     echo ""
 
-    # Ask for version (skipped when --include-craft forces the craft-tagged
-    # backend image, which is the only image that ships Node.js + opencode CLI).
-    if [ "$INCLUDE_CRAFT" = true ]; then
-        VERSION="craft-edge"
-        print_info "Using craft-edge (required by --include-craft)."
-    else
-        print_info "Which tag would you like to deploy?"
-        echo ""
-        echo "• Press Enter for ${DEFAULT_IMAGE_TAG} (recommended)"
-        echo "• Type a specific tag (e.g., v0.1.0)"
-        echo ""
-        prompt_or_default "Enter tag [default: ${DEFAULT_IMAGE_TAG}]: " "${DEFAULT_IMAGE_TAG}"
-        VERSION="$REPLY"
-        echo ""
+    # Craft uses the regular backend image (ENABLE_CRAFT is a runtime flag), so
+    # the tag is prompted for normally even with --include-craft.
+    print_info "Which tag would you like to deploy?"
+    echo ""
+    echo "• Press Enter for ${DEFAULT_IMAGE_TAG} (recommended)"
+    echo "• Type a specific tag (e.g., v0.1.0)"
+    echo ""
+    prompt_or_default "Enter tag [default: ${DEFAULT_IMAGE_TAG}]: " "${DEFAULT_IMAGE_TAG}"
+    VERSION="$REPLY"
+    echo ""
 
-        if [ "$VERSION" = "edge" ]; then
-            print_info "Selected: edge (latest nightly)"
-        else
-            print_info "Selected: $VERSION"
-        fi
+    if [ "$VERSION" = "edge" ]; then
+        print_info "Selected: edge (latest nightly)"
+    else
+        print_info "Selected: $VERSION"
     fi
 
     # Ask for authentication schema
@@ -1283,15 +1278,11 @@ print_success "Using port $AVAILABLE_PORT for nginx"
 # Read IMAGE_TAG from .env file and remove any quotes or whitespace.
 CURRENT_IMAGE_TAG=$(grep "^IMAGE_TAG=" "$ENV_FILE" | head -1 | cut -d'=' -f2 | tr -d ' "'"'"'')
 
-if [ "$CURRENT_IMAGE_TAG" = "edge" ] || [ "$CURRENT_IMAGE_TAG" = "latest" ] || [[ "$CURRENT_IMAGE_TAG" == craft-* ]]; then
+if [ "$CURRENT_IMAGE_TAG" = "edge" ] || [ "$CURRENT_IMAGE_TAG" = "latest" ]; then
     USE_LATEST=true
     # Floating tags track main, so configs should come from main.
     CONFIG_REF="main"
-    if [[ "$CURRENT_IMAGE_TAG" == craft-* ]]; then
-        print_info "Using craft tag '$CURRENT_IMAGE_TAG' - will force pull and recreate containers"
-    else
-        print_info "Using '$CURRENT_IMAGE_TAG' tag - will force pull and recreate containers"
-    fi
+    print_info "Using '$CURRENT_IMAGE_TAG' tag - will force pull and recreate containers"
 else
     USE_LATEST=false
     # Pinned release tags use their own ref so configs match the images.

--- a/docs/craft/docker/docker-compose-overview.md
+++ b/docs/craft/docker/docker-compose-overview.md
@@ -68,11 +68,11 @@ These must end up in `~/onyx_data/deployment/.env` after install:
 
 | Variable | Required? | Notes |
 |---|---|---|
-| `ENABLE_CRAFT=true` | yes | Install script sets this only on **fresh-install** path. If you ran `--include-craft` against an existing `.env`, append manually. |
-| `SANDBOX_BACKEND=docker` | yes | Same as above — install script gates on fresh-install. |
+| `ENABLE_CRAFT=true` | yes | `--include-craft` sets this (fresh installs and existing `.env`). |
+| `SANDBOX_BACKEND=docker` | yes | `--include-craft` sets this alongside `ENABLE_CRAFT`. |
 | `SANDBOX_API_SERVER_URL=http://host.docker.internal:3001` | yes | Provision raises `ValueError("SANDBOX_API_SERVER_URL must be set")` without it. Must be a URL the sandbox container can reach **from the `onyx_craft_sandbox` bridge** — compose-internal hostnames (`api_server`, `nginx`) won't resolve there. Match the port to `HOST_PORT`. |
 | `HOST_PORT=3001` | only if 3000 conflicts | Default is 3000; nginx binds this on the host. Free up 3000 or change here. |
-| `IMAGE_TAG=craft-edge` | yes | `craft-latest` lags `main` by weeks and predates the Docker sandbox backend (see [image staleness](#image-staleness--published-tags-lag-main) below). Use `craft-edge`. |
+| `IMAGE_TAG=edge` | recommended | Use a normal tag (`edge` from `main`, or a release `vX.Y.Z`). There are **no** craft-specific images — Craft is enabled at runtime via `ENABLE_CRAFT=true` (above). See [image architecture](../image-architecture.md). |
 | `ONYX_BACKEND_IMAGE` | only when running unreleased PRs | Lets you override just the backend image without forcing model-server / web-server to the same tag. |
 | `SANDBOX_CONTAINER_IMAGE` | only when running unreleased PRs | Same idea for the sandbox image itself. Default is a pinned tag like `onyxdotapp/sandbox:v0.1.44`. |
 | `AGENT_TRANSPORT=serve` | for serve transport | `docker-compose.craft.yml` defaults this to `serve` (post-#11402); override to `acp` for the rollback path. Reaches the sandbox container via env passthrough. |
@@ -122,17 +122,15 @@ adapt the prompts (Standard mode = `2`, keep existing env = blank).
 
 ### 3. Fix the .env
 
-When the installer detects an existing `.env`, it takes the
-"update / restart" branch and skips the Craft-specific env writes. You
-need to append them yourself:
+On an existing `.env`, `--include-craft` writes `ENABLE_CRAFT=true` and
+`SANDBOX_BACKEND=docker` for you (on both the update and restart paths). It
+does **not** set the host-specific values, so append those yourself:
 
 ```bash
 cat >> ~/onyx_data/deployment/.env <<'ENV'
-ENABLE_CRAFT=true
-SANDBOX_BACKEND=docker
 SANDBOX_API_SERVER_URL=http://host.docker.internal:3001
 HOST_PORT=3001
-IMAGE_TAG=craft-edge
+IMAGE_TAG=edge
 ENV
 ```
 
@@ -185,7 +183,7 @@ You should see:
 
 ## Running an unreleased PR (local image builds)
 
-Published `craft-edge` is built from `main`. If you're testing a PR that
+Published `edge` is built from `main`. If you're testing a PR that
 isn't merged yet, the published images **will not contain your code**.
 Build the affected images locally.
 
@@ -376,18 +374,17 @@ environment:
 ### Image staleness: published tags lag main
 
 Symptom A: api_server crashes on boot with
-`ValueError: 'docker' is not a valid SandboxBackend`. Cause: the
-`craft-latest` tag is built off a release (e.g. `v4.0.0`) that predates
-the Docker sandbox backend (PR #11222, May 20). The `SandboxBackend`
-enum in that image only has `LOCAL` and `KUBERNETES`.
+`ValueError: 'docker' is not a valid SandboxBackend`. Cause: you're on a
+release image older than the Docker sandbox backend (PR #11222, May 20) —
+its `SandboxBackend` enum only has `LOCAL`/`KUBERNETES`.
 
-Fix: switch to `craft-edge` (rolling tag built from `main`):
+Fix: use `edge` (built from `main`) or a release new enough to include it:
 
 ```
-IMAGE_TAG=craft-edge
+IMAGE_TAG=edge
 ```
 
-Symptom B: `craft-edge` works for the Docker backend but is missing PR
+Symptom B: `edge` works for the Docker backend but is missing PR
 #11402's serve transport additions. `ensure_opencode_session()`
 returns `None` because base.py's stub never gets overridden by
 `DockerSandboxManager` (which doesn't implement `_serve_base_url` /

--- a/docs/craft/features/docker-sandbox-backend.md
+++ b/docs/craft/features/docker-sandbox-backend.md
@@ -11,7 +11,7 @@ Research checked:
 - Existing `docker-compose.yml` + `install.sh` for Craft wiring:
   - `code-interpreter` already uses Docker-out-of-Docker by mounting `${DOCKER_SOCK_PATH:-/var/run/docker.sock}`.
   - docker-compose currently sets Craft template paths and `ENABLE_CRAFT`, but does not set `SANDBOX_BACKEND`; the code default is `local`.
-  - `--include-craft` selects `craft-latest` and sets `ENABLE_CRAFT=true`, but does not provision an isolated Craft sandbox backend.
+  - `--include-craft` uses the regular image tag and sets `ENABLE_CRAFT=true`, but does not provision an isolated Craft sandbox backend.
 - `KubernetesSandboxManager` (`backend/onyx/server/features/build/sandbox/kubernetes/`):
   - K8s Craft provisions one sandbox pod per user.
   - Each pod contains a `sandbox` container for the agent and a `sidecar` container for push/snapshot HTTP on port `8731`.
@@ -105,7 +105,7 @@ Keep the design compatible with adding sidecars later:
 
 `install.sh`:
 
-- `--include-craft` selects `craft-latest`, sets `ENABLE_CRAFT=true`, sets `SANDBOX_BACKEND=docker`, and ensures Docker socket env guidance exists.
+- `--include-craft` uses the regular image tag, sets `ENABLE_CRAFT=true`, sets `SANDBOX_BACKEND=docker`, and ensures Docker socket env guidance exists.
 - It should warn clearly that api_server/background get Docker socket access, which is root-equivalent on the host.
 - On EC2, either install and verify host-level IMDS blocking or fail unless `CRAFT_ALLOW_UNBLOCKED_IMDS=true` is explicitly set.
 

--- a/docs/craft/image-architecture.md
+++ b/docs/craft/image-architecture.md
@@ -1,0 +1,64 @@
+# Craft image & deployment architecture
+
+**Craft is a runtime feature, not a separate image flavor.** There are no
+`craft-*` images or tags. The regular Onyx images run Craft; you turn it on
+with `ENABLE_CRAFT=true`.
+
+## Why there's no craft backend image
+
+The Craft agent (`opencode`) runs entirely inside the **sandbox container**.
+The api_server is just an HTTP client to `opencode-serve` (it never executes
+`opencode`/`node` itself), and there is no `local` sandbox backend — only
+`docker` and `kubernetes`, both of which run the agent in the sandbox.
+
+So the backend needs nothing craft-specific baked in. `ENABLE_CRAFT` is read
+at runtime (`onyx/server/features/build/configs.py`) to toggle the feature.
+
+## The images
+
+| Image | Craft-specific? | Notes |
+|---|---|---|
+| `onyxdotapp/onyx-backend` | No | Standard image. `ENABLE_CRAFT=true` at runtime enables Craft. |
+| `onyxdotapp/onyx-web-server` | No | Standard image. |
+| `onyxdotapp/onyx-model-server` | No | Standard image. |
+| **`onyxdotapp/sandbox`** | **Yes** | The only Craft-specific image. Bundles Node + the `opencode` CLI; runs the agent. |
+
+## How the sandbox image is built
+
+`.github/workflows/sandbox-deployment.yml` builds it on the **nightly** tag
+(`nightly-latest-*`), but only when its build context
+(`backend/onyx/server/features/build/sandbox/image/`) changed since the
+previous nightly. It publishes `onyxdotapp/sandbox:vX.Y.Z` (auto-incremented
+patch) + `:latest`. Run it manually any time via the workflow's
+`workflow_dispatch` to cut a build on demand.
+
+The backend does **not** track `:latest` — it pins a specific version via
+`SANDBOX_CONTAINER_IMAGE` (default in `configs.py`). Bump that pin to adopt a
+new sandbox version.
+
+## Deploying Craft
+
+Use the **normal** image tags (`latest` / `edge` / `vX.Y.Z`) and turn Craft on:
+
+**docker-compose** (`--include-craft` does this for you):
+```
+ENABLE_CRAFT=true
+SANDBOX_BACKEND=docker
+SANDBOX_CONTAINER_IMAGE=onyxdotapp/sandbox:vX.Y.Z   # optional; defaults to the pinned version
+```
+
+**Kubernetes (helm):**
+```
+ENABLE_CRAFT=true
+SANDBOX_BACKEND=kubernetes
+# global.version / per-component tags use the normal release tags
+```
+
+## What changed (history)
+
+Previously there were `craft-latest` / `craft-edge` images built with a
+`--build-arg ENABLE_CRAFT=true` that installed Node + opencode into the
+backend. That was a leftover from the old `local` sandbox backend (agent in
+the api_server process). With `local` gone, the agent lives only in the
+sandbox image, so the craft backend build, the `craft-*` tags, and the
+`ENABLE_CRAFT` build-arg were all removed.


### PR DESCRIPTION
## Description

Backport of #11877 ("make Craft runtime-only; drop the craft backend image") to `release/v4.1`.

**Why:** The `release/v4.1` line does not contain #11877, so its release builds still run the legacy craft-image tagging logic. Because `craft-latest` is gated on `is-latest` (the highest stable tag), cutting `v4.1.1` on June 12 re-pushed `onyxdotapp/onyx-backend:craft-latest` (+ web-server/model-server) to Docker Hub — a stale tag scheme that was removed from `main`. This backport stops the v4.1 line from pushing `craft-latest` / `craft-edge` and aligns it with the runtime-only Craft model (`ENABLE_CRAFT=true`).

Cherry-pick applied cleanly except for `docs/craft/kubernetes/craft-eks-runbook.md`, which `release/v4.1` had already deleted (modify/delete) — resolved by keeping it deleted.

`release/v4.0` is intentionally **not** backported: its stable releases are no longer `is-latest` (v4.1.x outranks them), so they won't push `craft-latest`, and #11877 cannot be cleanly cherry-picked onto v4.0 (its Dockerfile/install.sh predate unrelated main-only refactors).

## How Has This Been Tested?

CI-only change (release build/tag workflow + Dockerfile/install scripts/docs). Verified post-cherry-pick that no `craft-latest` / `craft-edge` / `build-backend-craft` / `ENABLE_CRAFT` references remain in `deployment.yml` or `backend/Dockerfile`. Will rely on the release workflow's own validation on the next v4.1.x cut.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Craft runtime-only for v4.1 by removing the craft backend image and stopping `craft-latest`/`craft-edge` publishes. Releases now use the normal backend image; Craft is enabled at runtime with `ENABLE_CRAFT=true`.

- **Refactors**
  - Removed craft backend image builds and `craft-*` tagging from the release workflow; dropped the `experimental-cc4a` craft path.
  - Deleted the `ENABLE_CRAFT` build-arg and the Node/opencode installs from `backend/Dockerfile`.
  - Updated docker-compose and installers to use normal image tags and set `ENABLE_CRAFT=true` at runtime; no craft-specific tags or build args.
  - Reworked the sandbox image CI to build on `nightly-latest-*` (or manually) only when its context changes; docs updated with a new image architecture page.

- **Migration**
  - Use normal tags like `edge` or `vX.Y.Z`; stop using `craft-latest`/`craft-edge`.
  - To enable Craft, set `ENABLE_CRAFT=true` (installer `--include-craft` also sets `SANDBOX_BACKEND=docker`).
  - If you pin `SANDBOX_CONTAINER_IMAGE`, bump it when you want a newer sandbox version.

<sup>Written for commit 5c82c68a6c98f3862416c8716e2d34fb01d03dfc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

