### PR TITLE
fix(craft): accept assignment-form basePath in next.config template test

### DIFF
--- a/backend/tests/unit/build/test_rewrite_asset_paths.py
+++ b/backend/tests/unit/build/test_rewrite_asset_paths.py
@@ -46,7 +46,7 @@ class TestNextjsProxyMountContract:
 
         assert "ONYX_WEBAPP_BASE_PATH" in config_source
         assert "assetPrefix" in config_source
-        assert re.search(r"\bbasePath\s*:", config_source)
+        assert re.search(r"\bbasePath\s*[:=]", config_source)
 
     def test_sandbox_start_scripts_export_next_base_path(self) -> None:
         for manager_source in (DOCKER_SANDBOX_MANAGER, KUBERNETES_SANDBOX_MANAGER):


### PR DESCRIPTION
## Description

The webapp-proxy contract test `test_webapp_prefix_is_used_as_next_base_path` fails on `main`. The `next.config.ts` sandbox template sets `basePath` via assignment:

```ts
if (webappBasePath) {
  nextConfig.basePath = webappBasePath;
  nextConfig.assetPrefix = webappBasePath;
}
```

but the test's regex `\bbasePath\s*:` only matched object-literal form (`basePath:`), so it never matched the actual template. Widened the regex to `\bbasePath\s*[:=]` to accept both `:` and `=` — the assertion's intent is to verify `basePath` is configured (not just `assetPrefix`), independent of syntax.

## How Has This Been Tested?

`uv run pytest backend/tests/unit/build/test_rewrite_asset_paths.py` — 18 passed (was 17 passed, 1 failed on main).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the failing webapp-proxy contract test by allowing the regex to detect `basePath` set via assignment or object literal in `next.config.ts`. The test now matches `\bbasePath\s*[:=]`, ensuring `basePath` is configured (not just `assetPrefix`) regardless of syntax.

<sup>Written for commit f7ad6e44b7c7fb3f950b478ffd2149f8929783f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

