### PR TITLE
fix(craft): run docker workspace execs as sandbox user

### DIFF
--- a/.github/workflows/pr-craft-compose-integration.yml
+++ b/.github/workflows/pr-craft-compose-integration.yml
@@ -1,7 +1,8 @@
 # Stands up the full Craft docker-compose stack with the --include-craft overlay
-# once per run and exercises the end-to-end approval-gate flow + the
-# docker-specific posture invariants the K8s lane can't catch by construction
-# (image ENTRYPOINT concat, HOME after setpriv, curl httpoxy on the bridge).
+# once per run and exercises the Docker-backed Craft E2E suite: approval-gate
+# flow, workspace setup, and docker-specific posture invariants the K8s lane
+# can't catch by construction (image ENTRYPOINT concat, HOME after setpriv,
+# curl httpoxy on the bridge).
 #
 # Always triggers on PRs + merge_group so the `craft-compose-required` job below
 # can serve as the single stable required status check in branch protection; the
@@ -229,7 +230,7 @@ jobs:
             -o faulthandler_timeout=90 \
             --tb=short \
             --durations=10 \
-            tests/integration/tests/craft/docker_e2e/test_approval_gate_docker.py \
+            tests/integration/tests/craft/docker_e2e \
             2>&1 | tee ../compose-logs/pytest.log
 
       # Inline tail for fast triage in the GH Actions UI without downloading

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -149,6 +149,7 @@ WORKSPACE_ROOT = "/workspace"
 SESSIONS_ROOT = f"{WORKSPACE_ROOT}/sessions"
 TEMPLATES_OUTPUTS_PATH = f"{WORKSPACE_ROOT}/templates/outputs"
 MANAGED_SKILLS_PATH = f"{WORKSPACE_ROOT}/managed/skills"
+SANDBOX_EXEC_USER = "1000:1000"
 
 # Mirror the K8s constants in ``kubernetes_sandbox_manager`` (POD_READY_*),
 # which are also module-level and not env-tunable.
@@ -999,7 +1000,7 @@ echo "Session workspace setup complete"
             # /workspace/sessions which is owned by sandbox=1000. Exec as
             # sandbox so the script's mkdir/cp on the session workspace succeed.
             run_in_container(
-                container, ["/bin/sh", "-c", setup_script], user="1000:1000"
+                container, ["/bin/sh", "-c", setup_script], user=SANDBOX_EXEC_USER
             )
         except ExecError as e:
             raise RuntimeError(
@@ -1033,7 +1034,11 @@ rm -rf {session_path}
 echo "Session cleanup complete"
 """
         try:
-            run_in_container(container, ["/bin/sh", "-c", cleanup_script])
+            run_in_container(
+                container,
+                ["/bin/sh", "-c", cleanup_script],
+                user=SANDBOX_EXEC_USER,
+            )
         except ExecError as e:
             logger.warning(
                 "cleanup_session_workspace exec failed for session %s: %s",
@@ -1136,7 +1141,9 @@ echo "Session cleanup complete"
             ),
         ]
 
-        stream = stream_stdout_from_container(container, tar_cmd)
+        stream = stream_stdout_from_container(
+            container, tar_cmd, user=SANDBOX_EXEC_USER
+        )
         adapter = _GeneratorReader(stream)
         try:
             # ``_GeneratorReader`` satisfies the structural ``read(n)`` API that
@@ -1178,6 +1185,7 @@ echo "Session cleanup complete"
             run_in_container(
                 container,
                 ["/bin/sh", "-c", f"mkdir -p {session_path}"],
+                user=SANDBOX_EXEC_USER,
             )
         except ExecError as e:
             raise RuntimeError(f"Failed to prepare session dir: {e}") from e
@@ -1198,6 +1206,7 @@ echo "Session cleanup complete"
                     f"cd {session_path} && tar -xzf -",
                 ],
                 payload,
+                user=SANDBOX_EXEC_USER,
             )
         except ExecError as e:
             raise RuntimeError(f"Failed to extract snapshot: {e}") from e
@@ -1222,7 +1231,11 @@ if [ -f "$web_dir/bun.lock" ]; then
 fi
 """
         try:
-            run_in_container(container, ["/bin/sh", "-c", install_script])
+            run_in_container(
+                container,
+                ["/bin/sh", "-c", install_script],
+                user=SANDBOX_EXEC_USER,
+            )
         except ExecError as e:
             raise RuntimeError(f"Failed to reinstall deps after restore: {e}") from e
 
@@ -1239,7 +1252,11 @@ fi
                 session_path, nextjs_port, check_node_modules=True
             )
             try:
-                run_in_container(container, ["/bin/sh", "-c", start_script])
+                run_in_container(
+                    container,
+                    ["/bin/sh", "-c", start_script],
+                    user=SANDBOX_EXEC_USER,
+                )
             except ExecError as e:
                 raise RuntimeError(f"Failed to start Next.js after restore: {e}") from e
 
@@ -1269,7 +1286,11 @@ ln -sfn {MANAGED_SKILLS_PATH} {session_path}/.opencode/skills
 printf '%s' '{agents_md}' > {session_path}/AGENTS.md
 """
         try:
-            run_in_container(container, ["/bin/sh", "-c", script])
+            run_in_container(
+                container,
+                ["/bin/sh", "-c", script],
+                user=SANDBOX_EXEC_USER,
+            )
         except ExecError as e:
             raise RuntimeError(f"Failed to regenerate session config: {e}") from e
 
@@ -1449,7 +1470,10 @@ echo "$base"
 """
         try:
             result = stream_stdin_to_container(
-                container, ["/bin/sh", "-c", script], tar_data
+                container,
+                ["/bin/sh", "-c", script],
+                tar_data,
+                user=SANDBOX_EXEC_USER,
             )
         except ExecError as e:
             raise RuntimeError(f"Failed to upload file: {e}") from e
@@ -1498,7 +1522,12 @@ else
 fi
 """
         try:
-            run_in_container(container, ["/bin/sh", "-c", script], check=False)
+            run_in_container(
+                container,
+                ["/bin/sh", "-c", script],
+                check=False,
+                user=SANDBOX_EXEC_USER,
+            )
         except ExecError as e:
             logger.warning("AGENTS.md attachments section update failed: %s", e)
 
@@ -1521,6 +1550,7 @@ fi
                     f'[ -f "{target}" ] && rm "{target}" && echo "DELETED" || echo "NOT_FOUND"',
                 ],
                 check=False,
+                user=SANDBOX_EXEC_USER,
             )
         except ExecError as e:
             raise RuntimeError(f"Failed to delete file: {e}") from e
@@ -1550,7 +1580,11 @@ mkdir -p {safe_dir}
 printf '%s' '{escaped}' > {safe_path}
 echo WRITE_OK"""
         try:
-            result = run_in_container(container, ["/bin/sh", "-c", script])
+            result = run_in_container(
+                container,
+                ["/bin/sh", "-c", script],
+                user=SANDBOX_EXEC_USER,
+            )
         except ExecError as e:
             raise RuntimeError(f"Failed to write sandbox file {path}: {e}") from e
         if "WRITE_OK" not in result.stdout_text:
@@ -1644,7 +1678,12 @@ echo WRITE_OK"""
             f"trap - EXIT\n"
         )
         try:
-            stream_stdin_to_container(container, ["/bin/sh", "-c", script], tar_bytes)
+            stream_stdin_to_container(
+                container,
+                ["/bin/sh", "-c", script],
+                tar_bytes,
+                user=SANDBOX_EXEC_USER,
+            )
         except ExecError as e:
             raise RuntimeError(f"write_files_to_sandbox failed: {e}") from e
 

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -106,6 +106,7 @@ from onyx.server.features.build.sandbox.docker.dev_mode_serve import (
     published_opencode_serve_base_url,
 )
 from onyx.server.features.build.sandbox.docker.internal.exec_helpers import ExecError
+from onyx.server.features.build.sandbox.docker.internal.exec_helpers import ExecResult
 from onyx.server.features.build.sandbox.docker.internal.exec_helpers import (
     run_in_container,
 )
@@ -150,6 +151,9 @@ SESSIONS_ROOT = f"{WORKSPACE_ROOT}/sessions"
 TEMPLATES_OUTPUTS_PATH = f"{WORKSPACE_ROOT}/templates/outputs"
 MANAGED_SKILLS_PATH = f"{WORKSPACE_ROOT}/managed/skills"
 SANDBOX_EXEC_USER = "1000:1000"
+# Docker exec bypasses firewall-init.sh's setpriv environment workaround, so
+# sandbox-user execs must carry the uid/gid and user HOME together.
+SANDBOX_EXEC_ENV = {"HOME": "/home/sandbox", "USER": "sandbox"}
 
 # Mirror the K8s constants in ``kubernetes_sandbox_manager`` (POD_READY_*),
 # which are also module-level and not env-tunable.
@@ -171,6 +175,57 @@ _PROXY_CA_BUNDLE_FILE = f"{_PROXY_CA_BUNDLE_DIR}/ca-bundle.crt"
 # Registered in the opencode config only when the proxy is wired up; otherwise
 # it would no-op (no HTTP(S)_PROXY to re-tag).
 _OPENCODE_SESSION_TAG_PLUGIN_PATH = "/workspace/opencode-plugins/session-proxy-tag.ts"
+
+
+def _run_in_container_as_sandbox_user(
+    container: Container,
+    command: list[str] | str,
+    *,
+    workdir: str | None = None,
+    check: bool = True,
+) -> ExecResult:
+    return run_in_container(
+        container,
+        command,
+        user=SANDBOX_EXEC_USER,
+        workdir=workdir,
+        environment=SANDBOX_EXEC_ENV,
+        check=check,
+    )
+
+
+def _stream_stdin_to_container_as_sandbox_user(
+    container: Container,
+    command: list[str],
+    payload: bytes,
+    *,
+    workdir: str | None = None,
+) -> ExecResult:
+    return stream_stdin_to_container(
+        container,
+        command,
+        payload,
+        user=SANDBOX_EXEC_USER,
+        workdir=workdir,
+        environment=SANDBOX_EXEC_ENV,
+    )
+
+
+def _stream_stdout_from_container_as_sandbox_user(
+    container: Container,
+    command: list[str],
+    *,
+    workdir: str | None = None,
+    chunk_size: int = 64 * 1024,
+) -> Generator[bytes, None, int]:
+    return stream_stdout_from_container(
+        container,
+        command,
+        user=SANDBOX_EXEC_USER,
+        workdir=workdir,
+        environment=SANDBOX_EXEC_ENV,
+        chunk_size=chunk_size,
+    )
 
 
 def _build_nextjs_start_script(
@@ -999,8 +1054,8 @@ echo "Session workspace setup complete"
             # CAP_DAC_OVERRIDE (cap_drop=ALL), root cannot write to
             # /workspace/sessions which is owned by sandbox=1000. Exec as
             # sandbox so the script's mkdir/cp on the session workspace succeed.
-            run_in_container(
-                container, ["/bin/sh", "-c", setup_script], user=SANDBOX_EXEC_USER
+            _run_in_container_as_sandbox_user(
+                container, ["/bin/sh", "-c", setup_script]
             )
         except ExecError as e:
             raise RuntimeError(
@@ -1034,10 +1089,9 @@ rm -rf {session_path}
 echo "Session cleanup complete"
 """
         try:
-            run_in_container(
+            _run_in_container_as_sandbox_user(
                 container,
                 ["/bin/sh", "-c", cleanup_script],
-                user=SANDBOX_EXEC_USER,
             )
         except ExecError as e:
             logger.warning(
@@ -1056,7 +1110,7 @@ echo "Session cleanup complete"
             return False
         target = f"{SESSIONS_ROOT}/{session_id}/outputs"
         try:
-            result = run_in_container(
+            result = _run_in_container_as_sandbox_user(
                 container,
                 [
                     "/bin/sh",
@@ -1064,7 +1118,6 @@ echo "Session cleanup complete"
                     f'[ -d "{target}" ] && echo "WORKSPACE_FOUND" || echo "WORKSPACE_MISSING"',
                 ],
                 check=False,
-                user=SANDBOX_EXEC_USER,
             )
         except ExecError as e:
             logger.warning(
@@ -1080,11 +1133,10 @@ echo "Session cleanup complete"
         if container is None:
             return []
         try:
-            result = run_in_container(
+            result = _run_in_container_as_sandbox_user(
                 container,
                 ["/bin/sh", "-c", f"ls -1 {SESSIONS_ROOT}/ 2>/dev/null || true"],
                 check=False,
-                user=SANDBOX_EXEC_USER,
             )
         except ExecError as e:
             logger.warning(
@@ -1118,7 +1170,7 @@ echo "Session cleanup complete"
         session_path = f"{SESSIONS_ROOT}/{session_id}"
         # Bail out if there's nothing worth snapshotting.
         try:
-            probe = run_in_container(
+            probe = _run_in_container_as_sandbox_user(
                 container,
                 [
                     "/bin/sh",
@@ -1126,7 +1178,6 @@ echo "Session cleanup complete"
                     f'[ -d "{session_path}/outputs" ] && echo OK || echo EMPTY',
                 ],
                 check=False,
-                user=SANDBOX_EXEC_USER,
             )
         except ExecError:
             return None
@@ -1144,9 +1195,7 @@ echo "Session cleanup complete"
             ),
         ]
 
-        stream = stream_stdout_from_container(
-            container, tar_cmd, user=SANDBOX_EXEC_USER
-        )
+        stream = _stream_stdout_from_container_as_sandbox_user(container, tar_cmd)
         adapter = _GeneratorReader(stream)
         try:
             # ``_GeneratorReader`` satisfies the structural ``read(n)`` API that
@@ -1185,10 +1234,9 @@ echo "Session cleanup complete"
 
         # Make sure the session directory exists before we extract into it.
         try:
-            run_in_container(
+            _run_in_container_as_sandbox_user(
                 container,
                 ["/bin/sh", "-c", f"mkdir -p {session_path}"],
-                user=SANDBOX_EXEC_USER,
             )
         except ExecError as e:
             raise RuntimeError(f"Failed to prepare session dir: {e}") from e
@@ -1201,7 +1249,7 @@ echo "Session cleanup complete"
         payload = buf.getvalue()
 
         try:
-            stream_stdin_to_container(
+            _stream_stdin_to_container_as_sandbox_user(
                 container,
                 [
                     "/bin/sh",
@@ -1209,7 +1257,6 @@ echo "Session cleanup complete"
                     f"cd {session_path} && tar -xzf -",
                 ],
                 payload,
-                user=SANDBOX_EXEC_USER,
             )
         except ExecError as e:
             raise RuntimeError(f"Failed to extract snapshot: {e}") from e
@@ -1234,10 +1281,9 @@ if [ -f "$web_dir/bun.lock" ]; then
 fi
 """
         try:
-            run_in_container(
+            _run_in_container_as_sandbox_user(
                 container,
                 ["/bin/sh", "-c", install_script],
-                user=SANDBOX_EXEC_USER,
             )
         except ExecError as e:
             raise RuntimeError(f"Failed to reinstall deps after restore: {e}") from e
@@ -1255,10 +1301,9 @@ fi
                 session_path, nextjs_port, check_node_modules=True
             )
             try:
-                run_in_container(
+                _run_in_container_as_sandbox_user(
                     container,
                     ["/bin/sh", "-c", start_script],
-                    user=SANDBOX_EXEC_USER,
                 )
             except ExecError as e:
                 raise RuntimeError(f"Failed to start Next.js after restore: {e}") from e
@@ -1289,10 +1334,9 @@ ln -sfn {MANAGED_SKILLS_PATH} {session_path}/.opencode/skills
 printf '%s' '{agents_md}' > {session_path}/AGENTS.md
 """
         try:
-            run_in_container(
+            _run_in_container_as_sandbox_user(
                 container,
                 ["/bin/sh", "-c", script],
-                user=SANDBOX_EXEC_USER,
             )
         except ExecError as e:
             raise RuntimeError(f"Failed to regenerate session config: {e}") from e
@@ -1341,7 +1385,7 @@ printf '%s' '{agents_md}' > {session_path}/AGENTS.md
         quoted = shlex.quote(target_path)
 
         try:
-            result = run_in_container(
+            result = _run_in_container_as_sandbox_user(
                 container,
                 [
                     "/bin/sh",
@@ -1349,7 +1393,6 @@ printf '%s' '{agents_md}' > {session_path}/AGENTS.md
                     f"ls -laL --time-style=+%s {quoted} 2>/dev/null || echo 'ERROR_NOT_FOUND'",
                 ],
                 check=False,
-                user=SANDBOX_EXEC_USER,
             )
         except ExecError as e:
             raise RuntimeError(f"Failed to list directory: {e}") from e
@@ -1409,7 +1452,7 @@ printf '%s' '{agents_md}' > {session_path}/AGENTS.md
         quoted = shlex.quote(target_path)
 
         try:
-            result = run_in_container(
+            result = _run_in_container_as_sandbox_user(
                 container,
                 [
                     "/bin/sh",
@@ -1417,7 +1460,6 @@ printf '%s' '{agents_md}' > {session_path}/AGENTS.md
                     f"if [ -f {quoted} ]; then base64 {quoted}; else echo 'ERROR_NOT_FOUND'; fi",
                 ],
                 check=False,
-                user=SANDBOX_EXEC_USER,
             )
         except ExecError as e:
             raise RuntimeError(f"Failed to read file: {e}") from e
@@ -1474,11 +1516,10 @@ chmod 644 "$target_dir/$base"
 echo "$base"
 """
         try:
-            result = stream_stdin_to_container(
+            result = _stream_stdin_to_container_as_sandbox_user(
                 container,
                 ["/bin/sh", "-c", script],
                 tar_data,
-                user=SANDBOX_EXEC_USER,
             )
         except ExecError as e:
             raise RuntimeError(f"Failed to upload file: {e}") from e
@@ -1527,11 +1568,10 @@ else
 fi
 """
         try:
-            run_in_container(
+            _run_in_container_as_sandbox_user(
                 container,
                 ["/bin/sh", "-c", script],
                 check=False,
-                user=SANDBOX_EXEC_USER,
             )
         except ExecError as e:
             logger.warning("AGENTS.md attachments section update failed: %s", e)
@@ -1547,7 +1587,7 @@ fi
         clean_path = path.lstrip("/")
         target = f"{SESSIONS_ROOT}/{session_id}/{clean_path}"
         try:
-            result = run_in_container(
+            result = _run_in_container_as_sandbox_user(
                 container,
                 [
                     "/bin/sh",
@@ -1555,7 +1595,6 @@ fi
                     f'[ -f "{target}" ] && rm "{target}" && echo "DELETED" || echo "NOT_FOUND"',
                 ],
                 check=False,
-                user=SANDBOX_EXEC_USER,
             )
         except ExecError as e:
             raise RuntimeError(f"Failed to delete file: {e}") from e
@@ -1585,10 +1624,9 @@ mkdir -p {safe_dir}
 printf '%s' '{escaped}' > {safe_path}
 echo WRITE_OK"""
         try:
-            result = run_in_container(
+            result = _run_in_container_as_sandbox_user(
                 container,
                 ["/bin/sh", "-c", script],
-                user=SANDBOX_EXEC_USER,
             )
         except ExecError as e:
             raise RuntimeError(f"Failed to write sandbox file {path}: {e}") from e
@@ -1616,11 +1654,10 @@ echo WRITE_OK"""
             f"fi"
         )
         try:
-            result = run_in_container(
+            result = _run_in_container_as_sandbox_user(
                 container,
                 ["/bin/sh", "-c", cmd],
                 check=False,
-                user=SANDBOX_EXEC_USER,
             )
         except ExecError as e:
             logger.warning("get_upload_stats failed: %s", e)
@@ -1688,11 +1725,10 @@ echo WRITE_OK"""
             f"trap - EXIT\n"
         )
         try:
-            stream_stdin_to_container(
+            _stream_stdin_to_container_as_sandbox_user(
                 container,
                 ["/bin/sh", "-c", script],
                 tar_bytes,
-                user=SANDBOX_EXEC_USER,
             )
         except ExecError as e:
             raise RuntimeError(f"write_files_to_sandbox failed: {e}") from e
@@ -1725,7 +1761,7 @@ echo WRITE_OK"""
         cache_abs = f"{session_root}/{clean_cache}"
 
         try:
-            result = run_in_container(
+            result = _run_in_container_as_sandbox_user(
                 container,
                 [
                     "python",
@@ -1733,7 +1769,6 @@ echo WRITE_OK"""
                     pptx_abs,
                     cache_abs,
                 ],
-                user=SANDBOX_EXEC_USER,
             )
         except ExecError as e:
             raise RuntimeError(f"Failed to generate PPTX preview: {e}") from e

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -1064,6 +1064,7 @@ echo "Session cleanup complete"
                     f'[ -d "{target}" ] && echo "WORKSPACE_FOUND" || echo "WORKSPACE_MISSING"',
                 ],
                 check=False,
+                user=SANDBOX_EXEC_USER,
             )
         except ExecError as e:
             logger.warning(
@@ -1083,6 +1084,7 @@ echo "Session cleanup complete"
                 container,
                 ["/bin/sh", "-c", f"ls -1 {SESSIONS_ROOT}/ 2>/dev/null || true"],
                 check=False,
+                user=SANDBOX_EXEC_USER,
             )
         except ExecError as e:
             logger.warning(
@@ -1124,6 +1126,7 @@ echo "Session cleanup complete"
                     f'[ -d "{session_path}/outputs" ] && echo OK || echo EMPTY',
                 ],
                 check=False,
+                user=SANDBOX_EXEC_USER,
             )
         except ExecError:
             return None
@@ -1346,6 +1349,7 @@ printf '%s' '{agents_md}' > {session_path}/AGENTS.md
                     f"ls -laL --time-style=+%s {quoted} 2>/dev/null || echo 'ERROR_NOT_FOUND'",
                 ],
                 check=False,
+                user=SANDBOX_EXEC_USER,
             )
         except ExecError as e:
             raise RuntimeError(f"Failed to list directory: {e}") from e
@@ -1413,6 +1417,7 @@ printf '%s' '{agents_md}' > {session_path}/AGENTS.md
                     f"if [ -f {quoted} ]; then base64 {quoted}; else echo 'ERROR_NOT_FOUND'; fi",
                 ],
                 check=False,
+                user=SANDBOX_EXEC_USER,
             )
         except ExecError as e:
             raise RuntimeError(f"Failed to read file: {e}") from e
@@ -1611,7 +1616,12 @@ echo WRITE_OK"""
             f"fi"
         )
         try:
-            result = run_in_container(container, ["/bin/sh", "-c", cmd], check=False)
+            result = run_in_container(
+                container,
+                ["/bin/sh", "-c", cmd],
+                check=False,
+                user=SANDBOX_EXEC_USER,
+            )
         except ExecError as e:
             logger.warning("get_upload_stats failed: %s", e)
             return 0, 0
@@ -1723,6 +1733,7 @@ echo WRITE_OK"""
                     pptx_abs,
                     cache_abs,
                 ],
+                user=SANDBOX_EXEC_USER,
             )
         except ExecError as e:
             raise RuntimeError(f"Failed to generate PPTX preview: {e}") from e

--- a/backend/onyx/server/features/build/sandbox/docker/internal/exec_helpers.py
+++ b/backend/onyx/server/features/build/sandbox/docker/internal/exec_helpers.py
@@ -140,6 +140,7 @@ def _open_exec_socket(
     stdin: bool,
     user: str | None,
     workdir: str | None,
+    environment: dict[str, str] | None,
 ) -> Iterator[tuple[str, socket.socket]]:
     """Create + start a docker exec and yield ``(exec_id, raw_socket)``.
 
@@ -159,6 +160,7 @@ def _open_exec_socket(
             tty=False,
             user=user or "",
             workdir=workdir,
+            environment=environment,
         )["Id"]
         sock = api.exec_start(exec_id, socket=True, demux=False)
     except (APIError, NotFound) as e:
@@ -202,13 +204,19 @@ def stream_stdin_to_container(
     *,
     user: str | None = None,
     workdir: str | None = None,
+    environment: dict[str, str] | None = None,
 ) -> ExecResult:
     """Run ``command`` inside ``container`` and feed ``payload`` to its stdin.
 
     Used for tar push (skills + user library) and snapshot restore.
     """
     with _open_exec_socket(
-        container, command, stdin=True, user=user, workdir=workdir
+        container,
+        command,
+        stdin=True,
+        user=user,
+        workdir=workdir,
+        environment=environment,
     ) as (exec_id, sock):
         sock.sendall(payload)
         # Half-close so the remote process sees EOF.
@@ -236,6 +244,7 @@ def stream_stdout_from_container(
     *,
     user: str | None = None,
     workdir: str | None = None,
+    environment: dict[str, str] | None = None,
     chunk_size: int = 64 * 1024,
 ) -> Generator[bytes, None, int]:
     """Run ``command`` and yield stdout chunks to the caller.
@@ -246,7 +255,12 @@ def stream_stdout_from_container(
     """
     stderr_buf = bytearray()
     with _open_exec_socket(
-        container, command, stdin=False, user=user, workdir=workdir
+        container,
+        command,
+        stdin=False,
+        user=user,
+        workdir=workdir,
+        environment=environment,
     ) as (exec_id, sock):
         for stream_type, frame in _iter_frames(sock, chunk_size=chunk_size):
             if stream_type == _FRAME_STDOUT and frame:

--- a/backend/tests/integration/tests/craft/docker_e2e/conftest.py
+++ b/backend/tests/integration/tests/craft/docker_e2e/conftest.py
@@ -32,7 +32,10 @@ tests under ``tests/integration/tests/craft/`` keep the in-process model.
 
 from __future__ import annotations
 
+import subprocess
 from collections.abc import Generator
+from typing import Protocol
+from uuid import UUID
 
 import httpx
 import pytest
@@ -44,8 +47,77 @@ from onyx.db.external_app import create_external_app
 from onyx.db.external_app import get_built_in_external_app
 from tests.integration.common_utils import http_client
 from tests.integration.common_utils.constants import ADMIN_USER_NAME
+from tests.integration.common_utils.managers.build_session import BuildSessionManager
 from tests.integration.common_utils.managers.llm_provider import LLMProviderManager
 from tests.integration.common_utils.managers.user import UserManager
+from tests.integration.common_utils.test_models import DATestUser
+
+
+class DockerExec(Protocol):
+    def __call__(
+        self,
+        container: str,
+        cmd: list[str],
+        *,
+        timeout: float = 30.0,
+        user: str | None = None,
+    ) -> subprocess.CompletedProcess[str]: ...
+
+
+class ProvisionSandbox(Protocol):
+    def __call__(self, user: DATestUser) -> tuple[UUID, str]: ...
+
+
+def _container_name(sandbox_id: str) -> str:
+    """Docker manager names containers ``sandbox-<id8>``."""
+    return f"sandbox-{sandbox_id.split('-')[0]}"
+
+
+def _docker_exec(
+    container: str,
+    cmd: list[str],
+    *,
+    timeout: float = 30.0,
+    user: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Runs ``cmd`` inside ``container`` and captures stdout/stderr."""
+    command = ["docker", "exec"]
+    if user is not None:
+        command.extend(["--user", user])
+    command.extend([container, *cmd])
+    return subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def _provision_sandbox(user: DATestUser) -> tuple[UUID, str]:
+    """
+    Creates a session via the real API and returns its (session_id, container).
+
+    The create endpoint is synchronous -- by the time it returns, the sandbox
+    container is RUNNING and opencode-serve has passed its health check.
+    """
+    session = BuildSessionManager.create(user)
+    sandbox = session["sandbox"]
+    assert sandbox is not None, f"Session response missing sandbox: {session!r}"
+    assert sandbox["status"].upper() == "RUNNING", (
+        f"Sandbox not RUNNING after create: {sandbox['status']!r}"
+    )
+    return UUID(session["id"]), _container_name(sandbox["id"])
+
+
+@pytest.fixture(scope="session")
+def docker_exec() -> DockerExec:
+    return _docker_exec
+
+
+@pytest.fixture(scope="session")
+def provision_sandbox() -> ProvisionSandbox:
+    return _provision_sandbox
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -76,13 +148,14 @@ def _start_celery_workers() -> Generator[None, None, None]:
     yield None
 
 
-@pytest.fixture(scope="module", autouse=True)
+@pytest.fixture(scope="session", autouse=True)
 def _module_reset_and_seed() -> None:
     """
     Override: Skip the parent's ``reset_all()``. The dockerized api_server holds
     pooled postgres connections; an out-of-process ``alembic downgrade base``
-    deadlocks against those. Admin + LLM provider seed is retained because gate
-    tests need a configured provider.
+    deadlocks against those. Admin + LLM provider seeding is session-scoped
+    because this directory has multiple test modules and ``UserManager.create``
+    is not idempotent for the fixed admin email.
     """
     admin = UserManager.create(name=ADMIN_USER_NAME)
     LLMProviderManager.create(user_performing_action=admin, api_key="test-api-key")

--- a/backend/tests/integration/tests/craft/docker_e2e/test_approval_gate_docker.py
+++ b/backend/tests/integration/tests/craft/docker_e2e/test_approval_gate_docker.py
@@ -47,9 +47,10 @@ from onyx.server.features.build.configs import SANDBOX_PROXY_INJECTED_PLACEHOLDE
 from onyx.server.features.build.configs import SandboxBackend
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.http_client import client
-from tests.integration.common_utils.managers.build_session import BuildSessionManager
 from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.test_models import DATestUser
+from tests.integration.tests.craft.docker_e2e.conftest import DockerExec
+from tests.integration.tests.craft.docker_e2e.conftest import ProvisionSandbox
 
 pytestmark = pytest.mark.skipif(
     SANDBOX_BACKEND != SandboxBackend.DOCKER,
@@ -61,61 +62,18 @@ _PROXY_CA_ISSUER_RE = re.compile(r"CN=Onyx Sandbox Proxy CA")
 _SANDBOX_BRIDGE_NETWORK = "onyx_craft_sandbox"
 
 
-# ------------------------------------------------------------------------------
-# Helpers
-# ------------------------------------------------------------------------------
-
-
-def _container_name(sandbox_id: str) -> str:
-    """Docker manager names containers ``sandbox-<id8>``."""
-    return f"sandbox-{sandbox_id.split('-')[0]}"
-
-
-def _docker_exec(
-    container: str,
-    cmd: list[str],
-    *,
-    timeout: float = 30.0,
-) -> subprocess.CompletedProcess[str]:
-    """Runs ``cmd`` inside ``container`` and capture stdout/stderr."""
-    return subprocess.run(
-        ["docker", "exec", container, *cmd],
-        capture_output=True,
-        text=True,
-        timeout=timeout,
-        check=False,
-    )
-
-
-def _provision_sandbox(user: DATestUser) -> tuple[UUID, str]:
-    """
-    Creates a session via the real API and return its (session_id, container).
-
-    The create endpoint is synchronous -- by the time it returns, the sandbox
-    container is RUNNING and opencode-serve has passed its health check. No
-    further wait needed.
-    """
-    session = BuildSessionManager.create(user)
-    sandbox = session["sandbox"]
-    assert sandbox is not None, f"Session response missing sandbox: {session!r}"
-    assert sandbox["status"].upper() == "RUNNING", (
-        f"Sandbox not RUNNING after create: {sandbox['status']!r}"
-    )
-    return UUID(session["id"]), _container_name(sandbox["id"])
-
-
-def _opencode_pid(container: str) -> int:
+def _opencode_pid(container: str, docker_exec: DockerExec) -> int:
     """Finds the opencode-serve PID inside the sandbox.
 
     Returns the integer PID; raises with a diagnostic if not found. We rely on
     this to assert capability + uid invariants on the actual agent process, not
     the entrypoint shell.
     """
-    proc = _docker_exec(container, ["pgrep", "-f", "opencode serve"])
+    proc = docker_exec(container, ["pgrep", "-f", "opencode serve"])
     pids = [int(p) for p in proc.stdout.split() if p.strip()]
     assert pids, (
         f"No opencode-serve PID in {container!r}; entrypoint likely crashed. Docker "
-        f"logs:\n{_docker_exec(container, ['cat', '/proc/1/status']).stdout}"
+        f"logs:\n{docker_exec(container, ['cat', '/proc/1/status']).stdout}"
     )
     return pids[0]
 
@@ -206,9 +164,12 @@ def module_user() -> DATestUser:
 
 
 @pytest.fixture(scope="module")
-def module_sandbox(module_user: DATestUser) -> tuple[UUID, str]:
+def module_sandbox(
+    module_user: DATestUser,
+    provision_sandbox: ProvisionSandbox,
+) -> tuple[UUID, str]:
     """One sandbox provisioned via the real API; reused across posture tests."""
-    return _provision_sandbox(module_user)
+    return provision_sandbox(module_user)
 
 
 @pytest.fixture
@@ -221,9 +182,10 @@ def gated_user() -> DATestUser:
 @pytest.fixture
 def gated_session(
     gated_user: DATestUser,
+    provision_sandbox: ProvisionSandbox,
 ) -> Generator[tuple[DATestUser, UUID, str], None, None]:
     """Provisions a fresh sandbox via the real API for one gate-flow test."""
-    session_id, container = _provision_sandbox(gated_user)
+    session_id, container = provision_sandbox(gated_user)
     yield gated_user, session_id, container
 
 
@@ -234,6 +196,7 @@ def gated_session(
 
 def test_sandbox_runs_with_zero_caps_at_uid_1000(
     module_sandbox: tuple[UUID, str],
+    docker_exec: DockerExec,
 ) -> None:
     """
     The opencode-serve process must run as uid 1000 with an empty bounding set.
@@ -242,9 +205,9 @@ def test_sandbox_runs_with_zero_caps_at_uid_1000(
     bug (opencode-serve never starts -> no pid to check).
     """
     _session_id, container = module_sandbox
-    pid = _opencode_pid(container)
+    pid = _opencode_pid(container, docker_exec)
 
-    status = _docker_exec(container, ["cat", f"/proc/{pid}/status"]).stdout
+    status = docker_exec(container, ["cat", f"/proc/{pid}/status"]).stdout
     uid_line = next(line for line in status.splitlines() if line.startswith("Uid:"))
     cap_lines = {
         line.split(":")[0]: line
@@ -262,6 +225,7 @@ def test_sandbox_runs_with_zero_caps_at_uid_1000(
 
 def test_sandbox_https_is_mitmd_by_proxy_ca(
     module_sandbox: tuple[UUID, str],
+    docker_exec: DockerExec,
 ) -> None:
     """
     Public HTTPS gets MITM'd: leaf cert issued by the Onyx Sandbox Proxy CA.
@@ -269,7 +233,7 @@ def test_sandbox_https_is_mitmd_by_proxy_ca(
     + the proxy's MITM both work end-to-end.
     """
     _session_id, container = module_sandbox
-    proc = _docker_exec(
+    proc = docker_exec(
         container,
         ["curl", "-sS", "-v", "--max-time", "10", "https://example.com"],
         timeout=20.0,
@@ -289,6 +253,7 @@ def test_sandbox_https_is_mitmd_by_proxy_ca(
 def test_credentials_injected_on_wire_returns_real_user(
     module_user: DATestUser,
     module_sandbox: tuple[UUID, str],
+    docker_exec: DockerExec,
 ) -> None:
     """
     Sandbox env carries the placeholder PAT; calling api_server/me via the proxy
@@ -297,12 +262,12 @@ def test_credentials_injected_on_wire_returns_real_user(
     """
     _session_id, container = module_sandbox
 
-    env_check = _docker_exec(container, ["sh", "-c", "echo $ONYX_PAT"])
+    env_check = docker_exec(container, ["sh", "-c", "echo $ONYX_PAT"])
     assert env_check.stdout.strip() == SANDBOX_PROXY_INJECTED_PLACEHOLDER, (
         f"ONYX_PAT in sandbox env was not the placeholder: {env_check.stdout!r}"
     )
 
-    me_call = _docker_exec(
+    me_call = docker_exec(
         container,
         [
             "curl",
@@ -325,6 +290,7 @@ def test_credentials_injected_on_wire_returns_real_user(
 
 def test_iptables_rejects_bypass_attempts(
     module_sandbox: tuple[UUID, str],
+    docker_exec: DockerExec,
 ) -> None:
     """
     All four bypass classes are kernel-level rejected; the loopback embedded
@@ -332,7 +298,7 @@ def test_iptables_rejects_bypass_attempts(
     """
     _session_id, container = module_sandbox
 
-    direct_api = _docker_exec(
+    direct_api = docker_exec(
         container,
         [
             "curl",
@@ -352,7 +318,7 @@ def test_iptables_rejects_bypass_attempts(
         f"stderr={direct_api.stderr!r}"
     )
 
-    direct_internet = _docker_exec(
+    direct_internet = docker_exec(
         container,
         [
             "curl",
@@ -369,7 +335,7 @@ def test_iptables_rejects_bypass_attempts(
     )
     assert direct_internet.returncode == 7, "Direct external IP bypass not rejected."
 
-    udp_dns = _docker_exec(
+    udp_dns = docker_exec(
         container,
         [
             "python3",
@@ -393,7 +359,7 @@ def test_iptables_rejects_bypass_attempts(
         or "PermissionError" in udp_dns.stderr
     )
 
-    ipv6_egress = _docker_exec(
+    ipv6_egress = docker_exec(
         container,
         [
             "curl",
@@ -415,7 +381,7 @@ def test_iptables_rejects_bypass_attempts(
     # via the loopback ACCEPT rule. Required so the sandbox can resolve
     # ``sandbox-proxy``. Asserting positively so a future "close all DNS"
     # over-correction would fail this test.
-    embedded_dns = _docker_exec(
+    embedded_dns = docker_exec(
         container,
         ["getent", "ahosts", "example.com"],
         timeout=10.0,
@@ -535,6 +501,7 @@ def test_sessions_directory_writable_by_sandbox_user(
 def test_approve_decision_forwards_to_slack(
     slack_external_app: None,  # noqa: ARG001 -- side-effect fixture
     gated_session: tuple[DATestUser, UUID, str],
+    docker_exec: DockerExec,
 ) -> None:
     """
     A gated Slack request parks at the proxy, becomes a pending ActionApproval,
@@ -562,7 +529,7 @@ def test_approve_decision_forwards_to_slack(
             f"Forwarded curl did not return slack response (got {http_code!r})."
         )
 
-        body = _docker_exec(container, ["cat", "/tmp/slack_out"]).stdout
+        body = docker_exec(container, ["cat", "/tmp/slack_out"]).stdout
         payload = json.loads(body)
         assert payload.get("ok") is False
         assert payload.get("error") == "invalid_auth", (
@@ -575,6 +542,7 @@ def test_approve_decision_forwards_to_slack(
 def test_reject_decision_returns_403_user_rejected(
     slack_external_app: None,  # noqa: ARG001 -- side-effect fixture
     gated_session: tuple[DATestUser, UUID, str],
+    docker_exec: DockerExec,
 ) -> None:
     """
     REJECT causes the parked sandbox-side curl to return a 403 carrying the
@@ -597,7 +565,7 @@ def test_reject_decision_returns_403_user_rejected(
             f"Rejected forward did not return 403: {stdout!r}"
         )
 
-        body = _docker_exec(container, ["cat", "/tmp/slack_out"]).stdout
+        body = docker_exec(container, ["cat", "/tmp/slack_out"]).stdout
         payload = json.loads(body)
         assert payload.get("error") == "user_rejected", (
             f"Expected error='user_rejected', got {payload!r}"
@@ -609,6 +577,7 @@ def test_reject_decision_returns_403_user_rejected(
 def test_ask_with_uninvokable_app_forwards_bare(
     slack_external_app: None,  # noqa: ARG001 -- side-effect fixture
     gated_session: tuple[DATestUser, UUID, str],
+    docker_exec: DockerExec,
 ) -> None:
     """ASKs on an app whose auth template can't be filled forwards bare.
 
@@ -636,7 +605,7 @@ def test_ask_with_uninvokable_app_forwards_bare(
                 "Uninvokable ASK should forward bare to Slack and Slack should "
                 f"200 with invalid_auth in the body, got {stdout!r}"
             )
-            body = _docker_exec(container, ["cat", "/tmp/slack_out"]).stdout
+            body = docker_exec(container, ["cat", "/tmp/slack_out"]).stdout
             payload = json.loads(body)
             assert payload.get("error") == "invalid_auth", (
                 f"Bare-forwarded request should reach slack.com and get "

--- a/backend/tests/integration/tests/craft/docker_e2e/test_approval_gate_docker.py
+++ b/backend/tests/integration/tests/craft/docker_e2e/test_approval_gate_docker.py
@@ -45,6 +45,9 @@ from onyx.db.external_app import get_built_in_external_app
 from onyx.server.features.build.configs import SANDBOX_BACKEND
 from onyx.server.features.build.configs import SANDBOX_PROXY_INJECTED_PLACEHOLDER
 from onyx.server.features.build.configs import SandboxBackend
+from onyx.server.features.build.sandbox.docker.docker_sandbox_manager import (
+    SANDBOX_EXEC_USER,
+)
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.http_client import client
 from tests.integration.common_utils.managers.user import UserManager
@@ -439,6 +442,7 @@ def test_unlabeled_container_gets_unidentified_sandbox_403() -> None:
 
 def test_sessions_directory_writable_by_sandbox_user(
     module_sandbox: tuple[UUID, str],
+    docker_exec: DockerExec,
 ) -> None:
     """
     The /workspace/sessions volume mount must be writable by UID 1000.
@@ -454,9 +458,7 @@ def test_sessions_directory_writable_by_sandbox_user(
     _session_id, container = module_sandbox
 
     # Verify /workspace/sessions exists and is owned by 1000:1000
-    stat_result = _docker_exec(
-        container, ["stat", "-c", "%u:%g", "/workspace/sessions"]
-    )
+    stat_result = docker_exec(container, ["stat", "-c", "%u:%g", "/workspace/sessions"])
     assert stat_result.returncode == 0, (
         f"/workspace/sessions stat failed: {stat_result.stderr}"
     )
@@ -464,25 +466,22 @@ def test_sessions_directory_writable_by_sandbox_user(
         f"/workspace/sessions not owned by 1000:1000: {stat_result.stdout.strip()}"
     )
 
-    # Attempt to create a test directory as UID 1000 (the default user in the
-    # container after setpriv drop). This mimics what setup_session_workspace
-    # does when creating a new session. Must use --user 1000:1000 explicitly
-    # because in proxy mode the container runs as root initially.
+    # Attempt to create a test directory as UID 1000. Must set the exec user
+    # explicitly because in proxy mode docker exec defaults to the container's
+    # configured root user, not the setpriv-dropped agent user.
     test_dir = f"/workspace/sessions/test-{uuid4().hex[:8]}"
-    mkdir_result = subprocess.run(
-        ["docker", "exec", "--user", "1000:1000", container, "mkdir", "-p", test_dir],
-        capture_output=True,
-        text=True,
+    mkdir_result = docker_exec(
+        container,
+        ["mkdir", "-p", test_dir],
         timeout=10.0,
-        check=False,
+        user=SANDBOX_EXEC_USER,
     )
     assert mkdir_result.returncode == 0, (
         f"mkdir failed as UID 1000: rc={mkdir_result.returncode} "
         f"stderr={mkdir_result.stderr!r}"
     )
 
-    # Clean up (as root is fine for removal)
-    _docker_exec(container, ["rm", "-rf", test_dir])
+    docker_exec(container, ["rm", "-rf", test_dir], user=SANDBOX_EXEC_USER)
 
 
 # ------------------------------------------------------------------------------

--- a/backend/tests/integration/tests/craft/docker_e2e/test_workspace_setup_docker.py
+++ b/backend/tests/integration/tests/craft/docker_e2e/test_workspace_setup_docker.py
@@ -160,6 +160,38 @@ def test_session_setup_creates_user_writable_workspace(
         f"stdout={write_check.stdout!r} stderr={write_check.stderr!r}"
     )
 
+    private_file = "outputs/private/private.txt"
+    private_setup = _docker_exec(
+        container,
+        [
+            "sh",
+            "-c",
+            (
+                "set -e\n"
+                f'mkdir -p "{session_path}/outputs/private"\n'
+                f'printf private > "{session_path}/{private_file}"\n'
+                f'chmod 700 "{session_path}/outputs/private"\n'
+                f'chmod 600 "{session_path}/{private_file}"\n'
+            ),
+        ],
+        user=_SANDBOX_USER,
+    )
+    assert private_setup.returncode == 0, (
+        "Could not seed sandbox-user-private output file. "
+        f"stdout={private_setup.stdout!r} stderr={private_setup.stderr!r}"
+    )
+
+    private_listing = BuildSessionManager.list_files(
+        workspace_user, session_id, "outputs/private"
+    )
+    private_names = {entry["name"] for entry in private_listing["entries"]}
+    assert "private.txt" in private_names
+
+    downloaded = BuildSessionManager.download_artifact(
+        workspace_user, session_id, private_file
+    )
+    assert downloaded == b"private"
+
     upload_name = f"docker-setup-{uuid4().hex[:8]}.txt"
     upload = BuildSessionManager.upload_file(
         workspace_user,

--- a/backend/tests/integration/tests/craft/docker_e2e/test_workspace_setup_docker.py
+++ b/backend/tests/integration/tests/craft/docker_e2e/test_workspace_setup_docker.py
@@ -1,0 +1,182 @@
+"""Docker-backend workspace setup end-to-end tests.
+
+Runs against the full Craft docker-compose stack and provisions a real sandbox
+through the live api_server. This file pins Docker-specific session setup
+behavior that unit and in-process integration tests cannot observe: ownership
+inside the container, user-writable workspace paths, managed workspace
+hydration, and file API operations backed by docker exec.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from uuid import UUID
+from uuid import uuid4
+
+import pytest
+
+from onyx.server.features.build.configs import SANDBOX_BACKEND
+from onyx.server.features.build.configs import SandboxBackend
+from tests.integration.common_utils.managers.build_session import BuildSessionManager
+from tests.integration.common_utils.managers.user import UserManager
+from tests.integration.common_utils.test_models import DATestUser
+
+pytestmark = pytest.mark.skipif(
+    SANDBOX_BACKEND != SandboxBackend.DOCKER,
+    reason="Docker integration tests require SANDBOX_BACKEND=docker.",
+)
+
+_SANDBOX_USER = "1000:1000"
+
+
+def _container_name(sandbox_id: str) -> str:
+    """Docker manager names containers ``sandbox-<id8>``."""
+    return f"sandbox-{sandbox_id.split('-')[0]}"
+
+
+def _docker_exec(
+    container: str,
+    cmd: list[str],
+    *,
+    timeout: float = 30.0,
+    user: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Runs ``cmd`` inside ``container`` and captures stdout/stderr."""
+    command = ["docker", "exec"]
+    if user is not None:
+        command.extend(["--user", user])
+    command.extend([container, *cmd])
+    return subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def _provision_sandbox(user: DATestUser) -> tuple[UUID, str]:
+    """
+    Creates a session via the real API and returns its (session_id, container).
+
+    The create endpoint is synchronous -- by the time it returns, the sandbox
+    container is RUNNING and opencode-serve has passed its health check.
+    """
+    session = BuildSessionManager.create(user)
+    sandbox = session["sandbox"]
+    assert sandbox is not None, f"Session response missing sandbox: {session!r}"
+    assert sandbox["status"].upper() == "RUNNING", (
+        f"Sandbox not RUNNING after create: {sandbox['status']!r}"
+    )
+    return UUID(session["id"]), _container_name(sandbox["id"])
+
+
+@pytest.fixture
+def workspace_user() -> DATestUser:
+    return UserManager.create(name=f"craft_docker_workspace_{uuid4().hex[:8]}")
+
+
+@pytest.fixture
+def workspace_sandbox(workspace_user: DATestUser) -> tuple[UUID, str]:
+    return _provision_sandbox(workspace_user)
+
+
+def test_session_setup_creates_user_writable_workspace(
+    workspace_user: DATestUser,
+    workspace_sandbox: tuple[UUID, str],
+) -> None:
+    """
+    Provisioning must hydrate the managed workspace and per-session directory
+    with uid 1000 ownership. This catches docker-exec setup regressions where
+    the API writes as root, then the sandbox user cannot write or replace files.
+    """
+    session_id, container = workspace_sandbox
+    session_path = f"/workspace/sessions/{session_id}"
+
+    required_paths = [
+        "/workspace",
+        "/workspace/sessions",
+        "/workspace/managed",
+        "/workspace/managed/skills",
+        "/workspace/managed/user_library",
+        session_path,
+        f"{session_path}/outputs",
+        f"{session_path}/outputs/web",
+        f"{session_path}/attachments",
+        f"{session_path}/.opencode",
+    ]
+    stat_script = "\n".join(
+        f'stat -c "%u:%g %F %n" "{path}"' for path in required_paths
+    )
+    stat_result = _docker_exec(container, ["sh", "-c", stat_script])
+    assert stat_result.returncode == 0, (
+        "Required workspace paths missing after provision. "
+        f"stdout={stat_result.stdout!r} stderr={stat_result.stderr!r}"
+    )
+    for line in stat_result.stdout.splitlines():
+        assert line.startswith(f"{_SANDBOX_USER} "), (
+            f"Workspace path not owned by sandbox user: {line!r}"
+        )
+
+    symlink_result = _docker_exec(
+        container,
+        [
+            "sh",
+            "-c",
+            (
+                f'test -f "{session_path}/AGENTS.md" && '
+                f'test -L "{session_path}/.opencode/skills" && '
+                f'test "$(readlink "{session_path}/.opencode/skills")" = '
+                '"/workspace/managed/skills"'
+            ),
+        ],
+    )
+    assert symlink_result.returncode == 0, (
+        "Expected AGENTS.md plus .opencode/skills symlink after provision. "
+        f"stdout={symlink_result.stdout!r} stderr={symlink_result.stderr!r}"
+    )
+
+    write_check = _docker_exec(
+        container,
+        [
+            "sh",
+            "-c",
+            (
+                "set -e\n"
+                'printf ok > "/workspace/managed/.write-check"\n'
+                f'printf ok > "{session_path}/.write-check"\n'
+                f'printf ok > "{session_path}/attachments/.write-check"\n'
+                f'printf ok > "{session_path}/outputs/web/.write-check"\n'
+                'rm -f "/workspace/managed/.write-check"\n'
+                f'rm -f "{session_path}/.write-check"\n'
+                f'rm -f "{session_path}/attachments/.write-check"\n'
+                f'rm -f "{session_path}/outputs/web/.write-check"\n'
+            ),
+        ],
+        user=_SANDBOX_USER,
+    )
+    assert write_check.returncode == 0, (
+        "Sandbox user could not write to provisioned workspace directories. "
+        f"stdout={write_check.stdout!r} stderr={write_check.stderr!r}"
+    )
+
+    upload_name = f"docker-setup-{uuid4().hex[:8]}.txt"
+    upload = BuildSessionManager.upload_file(
+        workspace_user,
+        session_id,
+        filename=upload_name,
+        content=b"docker workspace setup check",
+    )
+    assert upload["filename"] == upload_name
+    assert upload["path"] == f"attachments/{upload_name}"
+
+    listing = BuildSessionManager.list_files(workspace_user, session_id, "attachments")
+    attachment_names = {entry["name"] for entry in listing["entries"]}
+    assert upload_name in attachment_names
+
+    BuildSessionManager.delete_file(workspace_user, session_id, upload["path"])
+    post_delete_listing = BuildSessionManager.list_files(
+        workspace_user, session_id, "attachments"
+    )
+    post_delete_names = {entry["name"] for entry in post_delete_listing["entries"]}
+    assert upload_name not in post_delete_names

--- a/backend/tests/integration/tests/craft/docker_e2e/test_workspace_setup_docker.py
+++ b/backend/tests/integration/tests/craft/docker_e2e/test_workspace_setup_docker.py
@@ -9,7 +9,6 @@ hydration, and file API operations backed by docker exec.
 
 from __future__ import annotations
 
-import subprocess
 from uuid import UUID
 from uuid import uuid4
 
@@ -17,58 +16,19 @@ import pytest
 
 from onyx.server.features.build.configs import SANDBOX_BACKEND
 from onyx.server.features.build.configs import SandboxBackend
+from onyx.server.features.build.sandbox.docker.docker_sandbox_manager import (
+    SANDBOX_EXEC_USER,
+)
 from tests.integration.common_utils.managers.build_session import BuildSessionManager
 from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.test_models import DATestUser
+from tests.integration.tests.craft.docker_e2e.conftest import DockerExec
+from tests.integration.tests.craft.docker_e2e.conftest import ProvisionSandbox
 
 pytestmark = pytest.mark.skipif(
     SANDBOX_BACKEND != SandboxBackend.DOCKER,
     reason="Docker integration tests require SANDBOX_BACKEND=docker.",
 )
-
-_SANDBOX_USER = "1000:1000"
-
-
-def _container_name(sandbox_id: str) -> str:
-    """Docker manager names containers ``sandbox-<id8>``."""
-    return f"sandbox-{sandbox_id.split('-')[0]}"
-
-
-def _docker_exec(
-    container: str,
-    cmd: list[str],
-    *,
-    timeout: float = 30.0,
-    user: str | None = None,
-) -> subprocess.CompletedProcess[str]:
-    """Runs ``cmd`` inside ``container`` and captures stdout/stderr."""
-    command = ["docker", "exec"]
-    if user is not None:
-        command.extend(["--user", user])
-    command.extend([container, *cmd])
-    return subprocess.run(
-        command,
-        capture_output=True,
-        text=True,
-        timeout=timeout,
-        check=False,
-    )
-
-
-def _provision_sandbox(user: DATestUser) -> tuple[UUID, str]:
-    """
-    Creates a session via the real API and returns its (session_id, container).
-
-    The create endpoint is synchronous -- by the time it returns, the sandbox
-    container is RUNNING and opencode-serve has passed its health check.
-    """
-    session = BuildSessionManager.create(user)
-    sandbox = session["sandbox"]
-    assert sandbox is not None, f"Session response missing sandbox: {session!r}"
-    assert sandbox["status"].upper() == "RUNNING", (
-        f"Sandbox not RUNNING after create: {sandbox['status']!r}"
-    )
-    return UUID(session["id"]), _container_name(sandbox["id"])
 
 
 @pytest.fixture
@@ -77,13 +37,17 @@ def workspace_user() -> DATestUser:
 
 
 @pytest.fixture
-def workspace_sandbox(workspace_user: DATestUser) -> tuple[UUID, str]:
-    return _provision_sandbox(workspace_user)
+def workspace_sandbox(
+    workspace_user: DATestUser,
+    provision_sandbox: ProvisionSandbox,
+) -> tuple[UUID, str]:
+    return provision_sandbox(workspace_user)
 
 
 def test_session_setup_creates_user_writable_workspace(
     workspace_user: DATestUser,
     workspace_sandbox: tuple[UUID, str],
+    docker_exec: DockerExec,
 ) -> None:
     """
     Provisioning must hydrate the managed workspace and per-session directory
@@ -108,17 +72,17 @@ def test_session_setup_creates_user_writable_workspace(
     stat_script = "\n".join(
         f'stat -c "%u:%g %F %n" "{path}"' for path in required_paths
     )
-    stat_result = _docker_exec(container, ["sh", "-c", stat_script])
+    stat_result = docker_exec(container, ["sh", "-c", stat_script])
     assert stat_result.returncode == 0, (
         "Required workspace paths missing after provision. "
         f"stdout={stat_result.stdout!r} stderr={stat_result.stderr!r}"
     )
     for line in stat_result.stdout.splitlines():
-        assert line.startswith(f"{_SANDBOX_USER} "), (
+        assert line.startswith(f"{SANDBOX_EXEC_USER} "), (
             f"Workspace path not owned by sandbox user: {line!r}"
         )
 
-    symlink_result = _docker_exec(
+    symlink_result = docker_exec(
         container,
         [
             "sh",
@@ -136,7 +100,7 @@ def test_session_setup_creates_user_writable_workspace(
         f"stdout={symlink_result.stdout!r} stderr={symlink_result.stderr!r}"
     )
 
-    write_check = _docker_exec(
+    write_check = docker_exec(
         container,
         [
             "sh",
@@ -153,7 +117,7 @@ def test_session_setup_creates_user_writable_workspace(
                 f'rm -f "{session_path}/outputs/web/.write-check"\n'
             ),
         ],
-        user=_SANDBOX_USER,
+        user=SANDBOX_EXEC_USER,
     )
     assert write_check.returncode == 0, (
         "Sandbox user could not write to provisioned workspace directories. "
@@ -161,7 +125,7 @@ def test_session_setup_creates_user_writable_workspace(
     )
 
     private_file = "outputs/private/private.txt"
-    private_setup = _docker_exec(
+    private_setup = docker_exec(
         container,
         [
             "sh",
@@ -174,7 +138,7 @@ def test_session_setup_creates_user_writable_workspace(
                 f'chmod 600 "{session_path}/{private_file}"\n'
             ),
         ],
-        user=_SANDBOX_USER,
+        user=SANDBOX_EXEC_USER,
     )
     assert private_setup.returncode == 0, (
         "Could not seed sandbox-user-private output file. "

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_exec_helpers.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_exec_helpers.py
@@ -1,0 +1,82 @@
+"""Unit tests for Docker exec helper plumbing."""
+
+from __future__ import annotations
+
+import socket
+from collections.abc import Iterator
+from unittest.mock import MagicMock
+
+import pytest
+
+import onyx.server.features.build.sandbox.docker.internal.exec_helpers as exec_helpers
+
+
+class _FakeSocket:
+    def __init__(self) -> None:
+        self.sent_payload = b""
+        self.shutdown_how: int | None = None
+        self.closed = False
+
+    def sendall(self, payload: bytes) -> None:
+        self.sent_payload += payload
+
+    def shutdown(self, how: int) -> None:
+        self.shutdown_how = how
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_streamed_exec_passes_environment_to_exec_create(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    env = {"HOME": "/home/sandbox", "USER": "sandbox"}
+    fake_socket = _FakeSocket()
+    api = MagicMock()
+    api.exec_create.return_value = {"Id": "exec-id"}
+    api.exec_start.return_value = fake_socket
+    api.exec_inspect.return_value = {"ExitCode": 0}
+    client = MagicMock()
+    client.api = api
+    container = MagicMock()
+    container.id = "container-id"
+    container.client = client
+
+    def unwrap_socket(sock: object) -> _FakeSocket:
+        assert isinstance(sock, _FakeSocket)
+        return sock
+
+    def iter_frames(
+        sock: socket.socket, *, chunk_size: int
+    ) -> Iterator[tuple[int, bytes]]:
+        assert sock is fake_socket
+        assert chunk_size == 64 * 1024
+        return iter(())
+
+    monkeypatch.setattr(exec_helpers, "_unwrap_socket", unwrap_socket)
+    monkeypatch.setattr(exec_helpers, "_iter_frames", iter_frames)
+
+    result = exec_helpers.stream_stdin_to_container(
+        container,
+        ["tar", "-xzf", "-"],
+        b"payload",
+        user="1000:1000",
+        workdir="/workspace",
+        environment=env,
+    )
+
+    assert result.exit_code == 0
+    api.exec_create.assert_called_once_with(
+        "container-id",
+        cmd=["tar", "-xzf", "-"],
+        stdin=True,
+        stdout=True,
+        stderr=True,
+        tty=False,
+        user="1000:1000",
+        workdir="/workspace",
+        environment=env,
+    )
+    assert fake_socket.sent_payload == b"payload"
+    assert fake_socket.shutdown_how == socket.SHUT_WR
+    assert fake_socket.closed is True

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_manager_config.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_manager_config.py
@@ -9,6 +9,8 @@ env allowlist), so we lock it down here.
 from __future__ import annotations
 
 import re
+from collections.abc import Generator
+from unittest.mock import MagicMock
 from uuid import UUID
 
 import pytest
@@ -165,6 +167,78 @@ def test_container_kwargs_has_required_security_options(
     assert kwargs["cap_drop"] == ["ALL"]
     assert "no-new-privileges:true" in kwargs["security_opt"]
     assert kwargs["privileged"] is False
+
+
+def test_sandbox_exec_wrapper_pairs_uid_with_user_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mock_run = MagicMock(return_value=dsm.ExecResult(0, b"", b""))
+    monkeypatch.setattr(dsm, "run_in_container", mock_run)
+    container = MagicMock()
+
+    result = dsm._run_in_container_as_sandbox_user(
+        container,
+        ["/bin/sh", "-c", "id"],
+        check=False,
+        workdir="/workspace",
+    )
+
+    assert result.exit_code == 0
+    mock_run.assert_called_once_with(
+        container,
+        ["/bin/sh", "-c", "id"],
+        user=dsm.SANDBOX_EXEC_USER,
+        workdir="/workspace",
+        environment=dsm.SANDBOX_EXEC_ENV,
+        check=False,
+    )
+
+
+def _empty_byte_stream() -> Generator[bytes, None, int]:
+    yield from ()
+    return 0
+
+
+def test_sandbox_stream_exec_wrappers_pair_uid_with_user_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mock_stdin = MagicMock(return_value=dsm.ExecResult(0, b"", b""))
+    stream = _empty_byte_stream()
+    mock_stdout = MagicMock(return_value=stream)
+    monkeypatch.setattr(dsm, "stream_stdin_to_container", mock_stdin)
+    monkeypatch.setattr(dsm, "stream_stdout_from_container", mock_stdout)
+    container = MagicMock()
+
+    result = dsm._stream_stdin_to_container_as_sandbox_user(
+        container,
+        ["tar", "-xzf", "-"],
+        b"payload",
+        workdir="/workspace",
+    )
+    returned_stream = dsm._stream_stdout_from_container_as_sandbox_user(
+        container,
+        ["tar", "-czf", "-"],
+        workdir="/workspace",
+    )
+
+    assert result.exit_code == 0
+    assert returned_stream is stream
+    mock_stdin.assert_called_once_with(
+        container,
+        ["tar", "-xzf", "-"],
+        b"payload",
+        user=dsm.SANDBOX_EXEC_USER,
+        workdir="/workspace",
+        environment=dsm.SANDBOX_EXEC_ENV,
+    )
+    mock_stdout.assert_called_once_with(
+        container,
+        ["tar", "-czf", "-"],
+        user=dsm.SANDBOX_EXEC_USER,
+        workdir="/workspace",
+        environment=dsm.SANDBOX_EXEC_ENV,
+        chunk_size=64 * 1024,
+    )
 
 
 def test_container_kwargs_does_not_mount_docker_socket(


### PR DESCRIPTION
## Description

Fixes Docker-backed Craft session setup so workspace execs that read or mutate sandbox-owned paths run as uid/gid 1000. This keeps managed workspace hydration, session workspace setup, snapshots, file listing/download, uploads, attachment section updates, deletes, and PPTX preview behavior aligned with the non-root sandbox process.

Adds Docker compose E2E coverage for workspace setup and permission-sensitive file access, and updates the Craft compose workflow to run the whole Docker E2E directory.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
