### PR TITLE
feat: add SharePoint targeted reindex (Resolver) support

### DIFF
--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -3204,7 +3204,9 @@ class SharepointConnector(
             site = self.graph_client.sites.get_by_url(site_url)
             drives = site.drives.get().execute_query()
             site_drives_cache[site_url] = [
-                SiteDrive(drive_id=cast(str, d.id), name=d.name or "", web_url=d.web_url)
+                SiteDrive(
+                    drive_id=cast(str, d.id), name=d.name or "", web_url=d.web_url
+                )
                 for d in drives
             ]
         return site_drives_cache[site_url]
@@ -3231,7 +3233,9 @@ class SharepointConnector(
         site_url = descriptors[0].url
 
         for drive in self._list_site_drives(site_url, site_drives_cache):
-            item_url = f"{self.graph_api_base}/drives/{drive.drive_id}/items/{document_id}"
+            item_url = (
+                f"{self.graph_api_base}/drives/{drive.drive_id}/items/{document_id}"
+            )
             try:
                 item_json = self._graph_api_get_json(item_url)
             except HTTPError as e:

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -56,6 +56,7 @@ from onyx.connectors.interfaces import CheckpointedConnectorWithPermSync
 from onyx.connectors.interfaces import CheckpointOutput
 from onyx.connectors.interfaces import GenerateSlimDocumentOutput
 from onyx.connectors.interfaces import IndexingHeartbeatInterface
+from onyx.connectors.interfaces import Resolver
 from onyx.connectors.interfaces import SecondsSinceUnixEpoch
 from onyx.connectors.interfaces import SlimConnector
 from onyx.connectors.interfaces import SlimConnectorWithPermSync
@@ -1157,6 +1158,7 @@ class SharepointConnector(
     SlimConnector,
     SlimConnectorWithPermSync,
     CheckpointedConnectorWithPermSync[SharepointConnectorCheckpoint],
+    Resolver,
 ):
     def __init__(
         self,
@@ -2549,6 +2551,118 @@ class SharepointConnector(
         # Document is at drive root
         return drive_web_url
 
+    def _process_drive_item(
+        self,
+        driveitem: DriveItemData,
+        drive_name: str,
+        drive_web_url: str | None,
+        site_url: str,
+        checkpoint: SharepointConnectorCheckpoint,
+        include_permissions: bool,
+        fail_on_exclusion: bool = False,
+    ) -> Generator[Document | ConnectorFailure | HierarchyNode, None, None]:
+        """Process a single drive item into a Document (plus ancestor folder
+        nodes), or a ConnectorFailure on error.
+
+        Shared by the normal crawl (Phase 3b) and the targeted-reindex
+        ``reindex`` path. ``checkpoint`` is used purely as a dedup container
+        (``seen_document_ids`` / ``seen_hierarchy_node_raw_ids``); reindex passes
+        a throwaway checkpoint. When ``fail_on_exclusion`` is True (reindex), a
+        denylist hit yields an informative ConnectorFailure instead of being
+        silently skipped, since the admin explicitly requested the document.
+        """
+        if self._is_driveitem_excluded(driveitem):
+            logger.debug("Excluding by path denylist: %s", driveitem.web_url)
+            if fail_on_exclusion:
+                yield _create_document_failure(driveitem, "excluded by path denylist")
+            return
+
+        if driveitem.id and driveitem.id in checkpoint.seen_document_ids:
+            logger.debug(
+                "Skipping duplicate document %s (%s)",
+                driveitem.id,
+                driveitem.name,
+            )
+            return
+
+        driveitem_extension = get_file_ext(driveitem.name)
+        if driveitem_extension not in OnyxFileExtensions.ALL_ALLOWED_EXTENSIONS:
+            logger.warning(
+                "Skipping %s as it is not a supported file type",
+                driveitem.web_url,
+            )
+            return
+
+        should_yield_if_empty = (
+            driveitem_extension in OnyxFileExtensions.IMAGE_EXTENSIONS
+            or driveitem_extension == ".pdf"
+        )
+
+        folder_path = self._extract_folder_path_from_parent_reference(
+            driveitem.parent_reference_path
+        )
+        if folder_path and drive_web_url:
+            yield from self._yield_folder_hierarchy_nodes(
+                site_url,
+                drive_web_url,
+                drive_name,
+                folder_path,
+                checkpoint,
+            )
+
+        parent_hierarchy_url: str | None = None
+        if drive_web_url:
+            parent_hierarchy_url = self._get_parent_hierarchy_url(
+                site_url,
+                drive_web_url,
+                drive_name,
+                driveitem,
+            )
+
+        try:
+            ctx: ClientContext | None = None
+            if include_permissions:
+                ctx = self._create_rest_client_context(site_url)
+
+            access_token = self._get_graph_access_token()
+            doc_or_failure = _convert_driveitem_to_document_with_permissions(
+                driveitem,
+                drive_name,
+                ctx,
+                self.graph_client,
+                include_permissions=include_permissions,
+                parent_hierarchy_raw_node_id=parent_hierarchy_url,
+                graph_api_base=self.graph_api_base,
+                access_token=access_token,
+                treat_sharing_link_as_public=self.treat_sharing_link_as_public,
+                raw_file_callback=self.raw_file_callback,
+            )
+
+            if isinstance(doc_or_failure, Document):
+                if doc_or_failure.sections:
+                    checkpoint.seen_document_ids.add(doc_or_failure.id)
+                    yield doc_or_failure
+                elif should_yield_if_empty:
+                    doc_or_failure.sections = [
+                        TextSection(link=driveitem.web_url, text="")
+                    ]
+                    checkpoint.seen_document_ids.add(doc_or_failure.id)
+                    yield doc_or_failure
+                else:
+                    logger.warning(
+                        "Skipping %s as it is empty and not a PDF or image",
+                        driveitem.web_url,
+                    )
+            elif isinstance(doc_or_failure, ConnectorFailure):
+                yield doc_or_failure
+        except Exception as e:
+            logger.warning(
+                "Failed to process driveitem %s: %s",
+                driveitem.web_url,
+                e,
+            )
+            yield _create_document_failure(driveitem, f"Failed to process: {str(e)}", e)
+
     def _load_from_checkpoint(
         self,
         start: SecondsSinceUnixEpoch,
@@ -2807,103 +2921,14 @@ class SharepointConnector(
             try:
                 for driveitem in driveitems:
                     item_count += 1
-
-                    if self._is_driveitem_excluded(driveitem):
-                        logger.debug(
-                            "Excluding by path denylist: %s", driveitem.web_url
-                        )
-                        continue
-
-                    if driveitem.id and driveitem.id in checkpoint.seen_document_ids:
-                        logger.debug(
-                            "Skipping duplicate document %s (%s)",
-                            driveitem.id,
-                            driveitem.name,
-                        )
-                        continue
-
-                    driveitem_extension = get_file_ext(driveitem.name)
-                    if (
-                        driveitem_extension
-                        not in OnyxFileExtensions.ALL_ALLOWED_EXTENSIONS
-                    ):
-                        logger.warning(
-                            "Skipping %s as it is not a supported file type",
-                            driveitem.web_url,
-                        )
-                        continue
-
-                    should_yield_if_empty = (
-                        driveitem_extension in OnyxFileExtensions.IMAGE_EXTENSIONS
-                        or driveitem_extension == ".pdf"
+                    yield from self._process_drive_item(
+                        driveitem,
+                        current_drive_name,
+                        drive_web_url,
+                        site_descriptor.url,
+                        checkpoint,
+                        include_permissions,
                     )
-
-                    folder_path = self._extract_folder_path_from_parent_reference(
-                        driveitem.parent_reference_path
-                    )
-                    if folder_path and drive_web_url:
-                        yield from self._yield_folder_hierarchy_nodes(
-                            site_descriptor.url,
-                            drive_web_url,
-                            current_drive_name,
-                            folder_path,
-                            checkpoint,
-                        )
-
-                    parent_hierarchy_url: str | None = None
-                    if drive_web_url:
-                        parent_hierarchy_url = self._get_parent_hierarchy_url(
-                            site_descriptor.url,
-                            drive_web_url,
-                            current_drive_name,
-                            driveitem,
-                        )
-
-                    try:
-                        ctx: ClientContext | None = None
-                        if include_permissions:
-                            ctx = self._create_rest_client_context(site_descriptor.url)
-
-                        access_token = self._get_graph_access_token()
-                        doc_or_failure = _convert_driveitem_to_document_with_permissions(
-                            driveitem,
-                            current_drive_name,
-                            ctx,
-                            self.graph_client,
-                            include_permissions=include_permissions,
-                            parent_hierarchy_raw_node_id=parent_hierarchy_url,
-                            graph_api_base=self.graph_api_base,
-                            access_token=access_token,
-                            treat_sharing_link_as_public=self.treat_sharing_link_as_public,
-                            raw_file_callback=self.raw_file_callback,
-                        )
-
-                        if isinstance(doc_or_failure, Document):
-                            if doc_or_failure.sections:
-                                checkpoint.seen_document_ids.add(doc_or_failure.id)
-                                yield doc_or_failure
-                            elif should_yield_if_empty:
-                                doc_or_failure.sections = [
-                                    TextSection(link=driveitem.web_url, text="")
-                                ]
-                                checkpoint.seen_document_ids.add(doc_or_failure.id)
-                                yield doc_or_failure
-                            else:
-                                logger.warning(
-                                    "Skipping %s as it is empty and not a PDF or image",
-                                    driveitem.web_url,
-                                )
-                        elif isinstance(doc_or_failure, ConnectorFailure):
-                            yield doc_or_failure
-                    except Exception as e:
-                        logger.warning(
-                            "Failed to process driveitem %s: %s",
-                            driveitem.web_url,
-                            e,
-                        )
-                        yield _create_document_failure(
-                            driveitem, f"Failed to process: {str(e)}", e
-                        )
             except Exception as e:
                 logger.exception(
                     "Failed mid-iteration for drive '%s' in site '%s'",
@@ -3114,6 +3139,211 @@ class SharepointConnector(
         return self._load_from_checkpoint(
             start, end, checkpoint, include_permissions=True
         )
+
+    def _list_site_drives(
+        self,
+        site_url: str,
+        site_drives_cache: dict[str, list[tuple[str, str, str | None]]],
+    ) -> list[tuple[str, str, str | None]]:
+        """List (drive_id, drive_name, drive_web_url) for a site, memoized."""
+        if site_url not in site_drives_cache:
+            site = self.graph_client.sites.get_by_url(site_url)
+            drives = site.drives.get().execute_query()
+            site_drives_cache[site_url] = [
+                (cast(str, d.id), d.name or "", d.web_url) for d in drives
+            ]
+        return site_drives_cache[site_url]
+
+    def _resolve_driveitem_by_link(
+        self,
+        document_id: str,
+        document_link: str,
+        site_drives_cache: dict[str, list[tuple[str, str, str | None]]],
+    ) -> tuple[DriveItemData, str, str | None, str]:
+        """Resolve a failed drive item's web URL to what's needed to re-fetch it.
+
+        The recorded link only reliably yields the *site*: Graph returns the
+        ``_layouts/15/Doc.aspx`` form as ``webUrl`` for Office documents, so the
+        library/folder is not recoverable from the URL. We parse the site via
+        ``_extract_site_and_drive_info``, list its drives, and probe each by item
+        id until one resolves — all under the existing ``Sites.Read.All`` grant.
+        ``site_drives_cache`` memoizes the per-site drive listing since targets
+        cluster heavily by site. Raises ``ValueError`` if no drive resolves it.
+
+        Returns (driveitem, display_drive_name, drive_web_url, site_url).
+        """
+        descriptors = self._extract_site_and_drive_info([document_link])
+        if not descriptors:
+            raise ValueError(f"Could not parse a site from link '{document_link}'")
+        site_url = descriptors[0].url
+
+        for drive_id, raw_drive_name, drive_web_url in self._list_site_drives(
+            site_url, site_drives_cache
+        ):
+            item_url = f"{self.graph_api_base}/drives/{drive_id}/items/{document_id}"
+            try:
+                item_json = self._graph_api_get_json(item_url)
+            except HTTPError as e:
+                if e.response is not None and e.response.status_code == 404:
+                    continue
+                raise
+            driveitem = DriveItemData.from_graph_json(item_json)
+            display_drive_name = SHARED_DOCUMENTS_MAP.get(
+                raw_drive_name, raw_drive_name
+            )
+            return driveitem, display_drive_name, drive_web_url, site_url
+
+        raise ValueError(
+            f"Item '{document_id}' not found in any library of site '{site_url}'"
+        )
+
+    def _reindex_drive_item(
+        self,
+        document_id: str,
+        document_link: str,
+        dedup: SharepointConnectorCheckpoint,
+        site_drives_cache: dict[str, list[tuple[str, str, str | None]]],
+        include_permissions: bool,
+    ) -> Generator[Document | ConnectorFailure | HierarchyNode, None, None]:
+        driveitem, drive_name, drive_web_url, site_url = (
+            self._resolve_driveitem_by_link(
+                document_id, document_link, site_drives_cache
+            )
+        )
+        # Emit the ancestor chain (site -> drive). The crawl yields these outside
+        # the per-item loop, so the shared helper only emits folder nodes.
+        yield from self._yield_site_hierarchy_node(
+            SiteDescriptor(url=site_url, drive_name=None, folder_path=None), dedup
+        )
+        if drive_web_url:
+            yield from self._yield_drive_hierarchy_node(
+                site_url, drive_web_url, drive_name, dedup
+            )
+        yield from self._process_drive_item(
+            driveitem,
+            drive_name,
+            drive_web_url,
+            site_url,
+            dedup,
+            include_permissions,
+            fail_on_exclusion=True,
+        )
+
+    def _reindex_site_page(
+        self,
+        document_id: str,
+        document_link: str,
+        dedup: SharepointConnectorCheckpoint,
+        include_permissions: bool,
+    ) -> Generator[Document | ConnectorFailure | HierarchyNode, None, None]:
+        descriptors = self._extract_site_and_drive_info([document_link])
+        if not descriptors:
+            raise ValueError(
+                f"Could not parse a site from site-page link '{document_link}'"
+            )
+        site_descriptor = SiteDescriptor(
+            url=descriptors[0].url, drive_name=None, folder_path=None
+        )
+        site = self.graph_client.sites.get_by_url(site_descriptor.url)
+        site.execute_query()
+        site_id = site.id
+
+        site_pages_base = (
+            f"{self.graph_api_base}/sites/{site_id}/pages/microsoft.graph.sitePage"
+        )
+        pages_collection = site_pages_base.removesuffix("/microsoft.graph.sitePage")
+        # Fetch metadata first so _try_expand_single_page has a valid fallback if
+        # canvasLayout expansion 400s on a corrupt page.
+        metadata = self._graph_api_get_json(
+            f"{pages_collection}/{document_id}/microsoft.graph.sitePage"
+        )
+        page = self._try_expand_single_page(site_pages_base, document_id, metadata)
+
+        yield from self._yield_site_hierarchy_node(site_descriptor, dedup)
+
+        ctx: ClientContext | None = None
+        if include_permissions:
+            ctx = self._create_rest_client_context(site_descriptor.url)
+        yield _convert_sitepage_to_document(
+            page,
+            site_descriptor.drive_name,
+            ctx,
+            self.graph_client,
+            include_permissions=include_permissions,
+            parent_hierarchy_raw_node_id=site_descriptor.url,
+            treat_sharing_link_as_public=self.treat_sharing_link_as_public,
+        )
+
+    def reindex(
+        self,
+        errors: list[ConnectorFailure],
+        include_permissions: bool = False,
+    ) -> Generator[Document | ConnectorFailure | HierarchyNode, None, None]:
+        """Re-fetch and re-index individual failed documents (Resolver).
+
+        SharePoint doc ids are bare Graph driveItem/page ids that can't be fetched
+        without their drive/site, so resolution is driven off each failure's
+        recorded web URL (``document_link``). Targets with no usable link (e.g.
+        admin-typed targets) yield an informative ConnectorFailure.
+        """
+        if self._graph_client is None:
+            raise ConnectorMissingCredentialError("Sharepoint")
+
+        # Throwaway checkpoint used purely as a dedup container for the shared
+        # helpers (seen_document_ids / seen_hierarchy_node_raw_ids).
+        dedup = self.build_dummy_checkpoint()
+        site_drives_cache: dict[str, list[tuple[str, str, str | None]]] = {}
+        # TODO: Resolver.reindex is one-call-per-job and resolves targets
+        # sequentially. If the interface grows batch semantics, Graph $batch
+        # (20 sub-requests) could cut round trips on the per-item fetches.
+
+        for error in errors:
+            failed = error.failed_document
+            if failed is None:
+                continue
+            document_id = failed.document_id
+            document_link = failed.document_link
+            if not document_link:
+                yield ConnectorFailure(
+                    failed_document=DocumentFailure(
+                        document_id=document_id,
+                        document_link=None,
+                    ),
+                    failure_message=(
+                        "SharePoint targeted reindex needs the document's web URL "
+                        "to locate it; none was recorded for this target."
+                    ),
+                )
+                continue
+
+            try:
+                if "/sitepages/" in document_link.lower():
+                    yield from self._reindex_site_page(
+                        document_id, document_link, dedup, include_permissions
+                    )
+                else:
+                    yield from self._reindex_drive_item(
+                        document_id,
+                        document_link,
+                        dedup,
+                        site_drives_cache,
+                        include_permissions,
+                    )
+            except Exception as e:
+                logger.warning(
+                    "Failed to resolve SharePoint target %s (%s): %s",
+                    document_id,
+                    document_link,
+                    e,
+                )
+                yield ConnectorFailure(
+                    failed_document=DocumentFailure(
+                        document_id=document_id,
+                        document_link=document_link,
+                    ),
+                    failure_message=f"Failed to resolve during targeted reindex: {e}",
+                    exception=e,
+                )
 
     def build_dummy_checkpoint(self) -> SharepointConnectorCheckpoint:
         return SharepointConnectorCheckpoint(has_more=True)

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -239,6 +239,23 @@ class SiteDescriptor(BaseModel):
     folder_path: str | None
 
 
+class SiteDrive(BaseModel):
+    """A drive (document library) of a site, as listed from Graph."""
+
+    drive_id: str
+    name: str
+    web_url: str | None
+
+
+class ResolvedDriveItem(BaseModel):
+    """The result of mapping a failed item's link back to a fetchable item."""
+
+    driveitem: DriveItemData
+    drive_name: str  # display name (SHARED_DOCUMENTS_MAP-mapped)
+    drive_web_url: str | None
+    site_url: str
+
+
 class CertificateData(BaseModel):
     """Data class for storing certificate information loaded from PFX file."""
 
@@ -3166,14 +3183,15 @@ class SharepointConnector(
     def _list_site_drives(
         self,
         site_url: str,
-        site_drives_cache: dict[str, list[tuple[str, str, str | None]]],
-    ) -> list[tuple[str, str, str | None]]:
-        """List (drive_id, drive_name, drive_web_url) for a site, memoized."""
+        site_drives_cache: dict[str, list[SiteDrive]],
+    ) -> list[SiteDrive]:
+        """List the drives (document libraries) of a site, memoized."""
         if site_url not in site_drives_cache:
             site = self.graph_client.sites.get_by_url(site_url)
             drives = site.drives.get().execute_query()
             site_drives_cache[site_url] = [
-                (cast(str, d.id), d.name or "", d.web_url) for d in drives
+                SiteDrive(drive_id=cast(str, d.id), name=d.name or "", web_url=d.web_url)
+                for d in drives
             ]
         return site_drives_cache[site_url]
 
@@ -3181,8 +3199,8 @@ class SharepointConnector(
         self,
         document_id: str,
         document_link: str,
-        site_drives_cache: dict[str, list[tuple[str, str, str | None]]],
-    ) -> tuple[DriveItemData, str, str | None, str]:
+        site_drives_cache: dict[str, list[SiteDrive]],
+    ) -> ResolvedDriveItem:
         """Resolve a failed drive item's web URL to what's needed to re-fetch it.
 
         The recorded link only reliably yields the *site*: Graph returns the
@@ -3192,29 +3210,26 @@ class SharepointConnector(
         id until one resolves — all under the existing ``Sites.Read.All`` grant.
         ``site_drives_cache`` memoizes the per-site drive listing since targets
         cluster heavily by site. Raises ``ValueError`` if no drive resolves it.
-
-        Returns (driveitem, display_drive_name, drive_web_url, site_url).
         """
         descriptors = self._extract_site_and_drive_info([document_link])
         if not descriptors:
             raise ValueError(f"Could not parse a site from link '{document_link}'")
         site_url = descriptors[0].url
 
-        for drive_id, raw_drive_name, drive_web_url in self._list_site_drives(
-            site_url, site_drives_cache
-        ):
-            item_url = f"{self.graph_api_base}/drives/{drive_id}/items/{document_id}"
+        for drive in self._list_site_drives(site_url, site_drives_cache):
+            item_url = f"{self.graph_api_base}/drives/{drive.drive_id}/items/{document_id}"
             try:
                 item_json = self._graph_api_get_json(item_url)
             except HTTPError as e:
                 if e.response is not None and e.response.status_code == 404:
                     continue
                 raise
-            driveitem = DriveItemData.from_graph_json(item_json)
-            display_drive_name = SHARED_DOCUMENTS_MAP.get(
-                raw_drive_name, raw_drive_name
+            return ResolvedDriveItem(
+                driveitem=DriveItemData.from_graph_json(item_json),
+                drive_name=SHARED_DOCUMENTS_MAP.get(drive.name, drive.name),
+                drive_web_url=drive.web_url,
+                site_url=site_url,
             )
-            return driveitem, display_drive_name, drive_web_url, site_url
 
         raise ValueError(
             f"Item '{document_id}' not found in any library of site '{site_url}'"
@@ -3225,28 +3240,27 @@ class SharepointConnector(
         document_id: str,
         document_link: str,
         dedup: SharepointConnectorCheckpoint,
-        site_drives_cache: dict[str, list[tuple[str, str, str | None]]],
+        site_drives_cache: dict[str, list[SiteDrive]],
         include_permissions: bool,
     ) -> Generator[Document | ConnectorFailure | HierarchyNode, None, None]:
-        driveitem, drive_name, drive_web_url, site_url = (
-            self._resolve_driveitem_by_link(
-                document_id, document_link, site_drives_cache
-            )
+        resolved = self._resolve_driveitem_by_link(
+            document_id, document_link, site_drives_cache
         )
         # Emit the ancestor chain (site -> drive). The crawl yields these outside
         # the per-item loop, so the shared helper only emits folder nodes.
         yield from self._yield_site_hierarchy_node(
-            SiteDescriptor(url=site_url, drive_name=None, folder_path=None), dedup
+            SiteDescriptor(url=resolved.site_url, drive_name=None, folder_path=None),
+            dedup,
         )
-        if drive_web_url:
+        if resolved.drive_web_url:
             yield from self._yield_drive_hierarchy_node(
-                site_url, drive_web_url, drive_name, dedup
+                resolved.site_url, resolved.drive_web_url, resolved.drive_name, dedup
             )
         yield from self._process_drive_item(
-            driveitem,
-            drive_name,
-            drive_web_url,
-            site_url,
+            resolved.driveitem,
+            resolved.drive_name,
+            resolved.drive_web_url,
+            resolved.site_url,
             dedup,
             include_permissions,
             is_targeted_reindex=True,
@@ -3316,7 +3330,7 @@ class SharepointConnector(
         # Throwaway checkpoint used purely as a dedup container for the shared
         # helpers (seen_document_ids / seen_hierarchy_node_raw_ids).
         dedup = self.build_dummy_checkpoint()
-        site_drives_cache: dict[str, list[tuple[str, str, str | None]]] = {}
+        site_drives_cache: dict[str, list[SiteDrive]] = {}
         # TODO(evan): Resolver.reindex is one-call-per-job and resolves targets
         # sequentially. If the interface grows batch semantics, Graph $batch
         # (20 sub-requests) could cut round trips on the per-item fetches.

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -1852,6 +1852,20 @@ class SharepointConnector(
                 return fallback_page
             raise
 
+    def _fetch_single_site_page(self, site_id: str, page_id: str) -> dict[str, Any]:
+        """Fetch one site page by id with canvasLayout expanded.
+
+        Fetches metadata first so ``_try_expand_single_page`` has a valid
+        fallback if expansion 400s on a corrupt page. Mirrors a single iteration
+        of ``_fetch_site_pages`` for the targeted-reindex path.
+        """
+        pages_collection = f"{self.graph_api_base}/sites/{site_id}/pages"
+        site_pages_base = f"{pages_collection}/microsoft.graph.sitePage"
+        metadata = self._graph_api_get_json(
+            f"{pages_collection}/{page_id}/microsoft.graph.sitePage"
+        )
+        return self._try_expand_single_page(site_pages_base, page_id, metadata)
+
     def _acquire_token(self) -> dict[str, Any]:
         """
         Acquire token via MSAL
@@ -3283,18 +3297,8 @@ class SharepointConnector(
         )
         site = self.graph_client.sites.get_by_url(site_descriptor.url)
         site.execute_query()
-        site_id = site.id
 
-        site_pages_base = (
-            f"{self.graph_api_base}/sites/{site_id}/pages/microsoft.graph.sitePage"
-        )
-        pages_collection = site_pages_base.removesuffix("/microsoft.graph.sitePage")
-        # Fetch metadata first so _try_expand_single_page has a valid fallback if
-        # canvasLayout expansion 400s on a corrupt page.
-        metadata = self._graph_api_get_json(
-            f"{pages_collection}/{document_id}/microsoft.graph.sitePage"
-        )
-        page = self._try_expand_single_page(site_pages_base, document_id, metadata)
+        page = self._fetch_single_site_page(cast(str, site.id), document_id)
 
         yield from self._yield_site_hierarchy_node(site_descriptor, dedup)
 

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -3274,6 +3274,7 @@ class SharepointConnector(
             treat_sharing_link_as_public=self.treat_sharing_link_as_public,
         )
 
+    @override
     def reindex(
         self,
         errors: list[ConnectorFailure],
@@ -3293,7 +3294,7 @@ class SharepointConnector(
         # helpers (seen_document_ids / seen_hierarchy_node_raw_ids).
         dedup = self.build_dummy_checkpoint()
         site_drives_cache: dict[str, list[tuple[str, str, str | None]]] = {}
-        # TODO: Resolver.reindex is one-call-per-job and resolves targets
+        # TODO(evan): Resolver.reindex is one-call-per-job and resolves targets
         # sequentially. If the interface grows batch semantics, Graph $batch
         # (20 sub-requests) could cut round trips on the per-item fetches.
 

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -2559,7 +2559,7 @@ class SharepointConnector(
         site_url: str,
         checkpoint: SharepointConnectorCheckpoint,
         include_permissions: bool,
-        fail_on_exclusion: bool = False,
+        is_targeted_reindex: bool = False,
     ) -> Generator[Document | ConnectorFailure | HierarchyNode, None, None]:
         """Process a single drive item into a Document (plus ancestor folder
         nodes), or a ConnectorFailure on error.
@@ -2567,13 +2567,20 @@ class SharepointConnector(
         Shared by the normal crawl (Phase 3b) and the targeted-reindex
         ``reindex`` path. ``checkpoint`` is used purely as a dedup container
         (``seen_document_ids`` / ``seen_hierarchy_node_raw_ids``); reindex passes
-        a throwaway checkpoint. When ``fail_on_exclusion`` is True (reindex), a
-        denylist hit yields an informative ConnectorFailure instead of being
-        silently skipped, since the admin explicitly requested the document.
+        a throwaway checkpoint.
+
+        When ``is_targeted_reindex`` is True, the branches that the crawl skips
+        silently (denylist, unsupported type, empty non-PDF/image, non-indexable
+        conversion) instead yield an informative ConnectorFailure: the admin
+        explicitly requested the document, so it must end as a Document or a
+        ConnectorFailure rather than silently reporting as still-failing with the
+        stale original message. The duplicate-skip stays silent in both paths —
+        a duplicate target has already been yielded as a Document in this call,
+        so failing it would wrongly mark a landed doc as failed.
         """
         if self._is_driveitem_excluded(driveitem):
             logger.debug("Excluding by path denylist: %s", driveitem.web_url)
-            if fail_on_exclusion:
+            if is_targeted_reindex:
                 yield _create_document_failure(driveitem, "excluded by path denylist")
             return
 
@@ -2591,6 +2598,11 @@ class SharepointConnector(
                 "Skipping %s as it is not a supported file type",
                 driveitem.web_url,
             )
+            if is_targeted_reindex:
+                yield _create_document_failure(
+                    driveitem,
+                    f"unsupported file type '{driveitem_extension}'",
+                )
             return
 
         should_yield_if_empty = (
@@ -2653,8 +2665,19 @@ class SharepointConnector(
                         "Skipping %s as it is empty and not a PDF or image",
                         driveitem.web_url,
                     )
+                    if is_targeted_reindex:
+                        yield _create_document_failure(
+                            driveitem, "document is empty and not a PDF or image"
+                        )
             elif isinstance(doc_or_failure, ConnectorFailure):
                 yield doc_or_failure
+            elif is_targeted_reindex:
+                # Converter returned None: excluded/malformed content type or
+                # over the size threshold (it logs the specifics).
+                yield _create_document_failure(
+                    driveitem,
+                    "not indexable (excluded content type or over size limit)",
+                )
         except Exception as e:
             logger.warning(
                 "Failed to process driveitem %s: %s",
@@ -3226,7 +3249,7 @@ class SharepointConnector(
             site_url,
             dedup,
             include_permissions,
-            fail_on_exclusion=True,
+            is_targeted_reindex=True,
         )
 
     def _reindex_site_page(

--- a/backend/tests/daily/connectors/sharepoint/test_sharepoint_connector.py
+++ b/backend/tests/daily/connectors/sharepoint/test_sharepoint_connector.py
@@ -9,7 +9,9 @@ from unittest.mock import patch
 import pytest
 
 from onyx.configs.constants import DocumentSource
+from onyx.connectors.models import ConnectorFailure
 from onyx.connectors.models import Document
+from onyx.connectors.models import DocumentFailure
 from onyx.connectors.models import HierarchyNode
 from onyx.connectors.models import ImageSection
 from onyx.connectors.sharepoint.connector import SharepointAuthMethod
@@ -577,3 +579,177 @@ def test_resolve_tenant_domain_from_root_site(
 
     assert connector.sp_tenant_domain is not None
     assert len(connector.sp_tenant_domain) > 0
+
+
+# ---------------------------------------------------------------------------
+# Targeted reindex (Resolver.reindex)
+# ---------------------------------------------------------------------------
+
+
+def _failure_for(doc: Document) -> ConnectorFailure:
+    """Build the ConnectorFailure that targeted reindex would hand the connector.
+
+    Mirrors production: the failure's document_link is the item's web_url, which
+    is exactly what a crawled document's section link carries.
+    """
+    return ConnectorFailure(
+        failed_document=DocumentFailure(
+            document_id=doc.id,
+            document_link=doc.sections[0].link,
+        ),
+        failure_message="targeted reindex test",
+    )
+
+
+def _crawl_site(
+    sharepoint_credentials: dict[str, str],
+    *,
+    include_site_pages: bool,
+    include_site_documents: bool,
+) -> list[Document]:
+    connector = SharepointConnector(
+        sites=[os.environ["SHAREPOINT_SITE"]],
+        include_site_pages=include_site_pages,
+        include_site_documents=include_site_documents,
+    )
+    connector.load_credentials(sharepoint_credentials)
+    return load_all_from_connector(
+        connector=connector,
+        start=0,
+        end=time.time(),
+    ).documents
+
+
+def test_sharepoint_connector_reindex_drive_items(
+    mock_get_unstructured_api_key: MagicMock,  # noqa: ARG001
+    mock_store_image: MagicMock,
+    sharepoint_credentials: dict[str, str],
+) -> None:
+    """reindex re-fetches failed drive items across libraries from their links."""
+    with patch(
+        "onyx.connectors.sharepoint.connector.store_image_and_create_section",
+        mock_store_image,
+    ):
+        found = _crawl_site(
+            sharepoint_credentials,
+            include_site_pages=False,
+            include_site_documents=True,
+        )
+        # test1.docx lives in "Shared Documents", other.docx in "Other Library",
+        # so this exercises probing across multiple drives in a site.
+        targets = [
+            find_document(found, "test1.docx"),
+            find_document(found, "other.docx"),
+        ]
+        failures = [_failure_for(doc) for doc in targets]
+
+        connector = SharepointConnector(sites=[os.environ["SHAREPOINT_SITE"]])
+        connector.load_credentials(sharepoint_credentials)
+        results = list(connector.reindex(errors=failures, include_permissions=False))
+
+        docs = [r for r in results if isinstance(r, Document)]
+        connector_failures = [r for r in results if isinstance(r, ConnectorFailure)]
+        assert not connector_failures, "resolvable targets should not fail"
+
+        returned_by_id = {d.id: d for d in docs}
+        for target in targets:
+            assert target.id in returned_by_id, (
+                f"reindex did not return target {target.semantic_identifier}"
+            )
+            assert returned_by_id[target.id].sections, "reindexed doc has no sections"
+
+
+def test_sharepoint_connector_reindex_site_page(
+    mock_get_unstructured_api_key: MagicMock,  # noqa: ARG001
+    mock_store_image: MagicMock,
+    sharepoint_credentials: dict[str, str],
+) -> None:
+    """reindex round-trips a site-page target through the site-page path."""
+    with patch(
+        "onyx.connectors.sharepoint.connector.store_image_and_create_section",
+        mock_store_image,
+    ):
+        found = _crawl_site(
+            sharepoint_credentials,
+            include_site_pages=True,
+            include_site_documents=False,
+        )
+        target = find_document(found, "Home")
+        failures = [_failure_for(target)]
+
+        connector = SharepointConnector(sites=[os.environ["SHAREPOINT_SITE"]])
+        connector.load_credentials(sharepoint_credentials)
+        results = list(connector.reindex(errors=failures, include_permissions=False))
+
+        docs = [r for r in results if isinstance(r, Document)]
+        assert len(docs) == 1, "should resolve exactly the one site-page target"
+        assert docs[0].id == target.id
+        assert docs[0].sections
+
+
+def test_sharepoint_connector_reindex_unresolvable_targets(
+    sharepoint_credentials: dict[str, str],
+) -> None:
+    """Targets with a bogus id or no link yield ConnectorFailure, not raises."""
+    connector = SharepointConnector(sites=[os.environ["SHAREPOINT_SITE"]])
+    connector.load_credentials(sharepoint_credentials)
+
+    bogus_link = os.environ["SHAREPOINT_SITE"] + "/Shared Documents/does-not-exist.docx"
+    failures = [
+        ConnectorFailure(
+            failed_document=DocumentFailure(
+                document_id="01BOGUSITEMIDDOESNOTEXIST0000000",
+                document_link=bogus_link,
+            ),
+            failure_message="bogus id",
+        ),
+        ConnectorFailure(
+            failed_document=DocumentFailure(
+                document_id="no-link-target",
+                document_link=None,
+            ),
+            failure_message="no link",
+        ),
+    ]
+    results = list(connector.reindex(errors=failures, include_permissions=False))
+
+    assert results and all(isinstance(r, ConnectorFailure) for r in results)
+    failed_ids = {
+        r.failed_document.document_id
+        for r in results
+        if isinstance(r, ConnectorFailure) and r.failed_document
+    }
+    assert failed_ids == {"01BOGUSITEMIDDOESNOTEXIST0000000", "no-link-target"}
+
+
+def test_sharepoint_connector_reindex_denylist_excluded(
+    mock_get_unstructured_api_key: MagicMock,  # noqa: ARG001
+    mock_store_image: MagicMock,
+    sharepoint_credentials: dict[str, str],
+) -> None:
+    """A target excluded by the path denylist yields an informative failure
+    rather than being silently dropped."""
+    with patch(
+        "onyx.connectors.sharepoint.connector.store_image_and_create_section",
+        mock_store_image,
+    ):
+        found = _crawl_site(
+            sharepoint_credentials,
+            include_site_pages=False,
+            include_site_documents=True,
+        )
+        target = find_document(found, "test1.docx")
+        failures = [_failure_for(target)]
+
+        connector = SharepointConnector(
+            sites=[os.environ["SHAREPOINT_SITE"]],
+            excluded_paths=["*.docx"],
+        )
+        connector.load_credentials(sharepoint_credentials)
+        results = list(connector.reindex(errors=failures, include_permissions=False))
+
+        docs = [r for r in results if isinstance(r, Document)]
+        connector_failures = [r for r in results if isinstance(r, ConnectorFailure)]
+        assert not docs, "excluded target should not yield a Document"
+        assert len(connector_failures) == 1
+        assert "denylist" in connector_failures[0].failure_message


### PR DESCRIPTION
## Description

Implements `Resolver.reindex` on `SharepointConnector` so the targeted-reindex flow can re-fetch and re-index individual failed documents without a full crawl. Previously SharePoint targets short-circuited as "unsupported".

- Extracts the Phase 3b per-item loop into a shared `_process_drive_item` helper. Crawl behavior is unchanged; `reindex` reuses it (via `is_targeted_reindex`) so skipped targets — denylist, unsupported type, empty non-PDF/image, over-size — surface an informative `ConnectorFailure` instead of being silently dropped.
- Resolves targets from each failure's recorded web URL by parsing the **site**, listing its drives, and probing each by item id. Only the site is recoverable from the link — Graph returns the `_layouts/15/Doc.aspx` form as `webUrl` for Office docs, so the library can't be read off the URL.
- Supports both drive items and site pages (every SharePoint object that becomes a `Document`), emits ancestor hierarchy nodes, and memoizes per-site drive listings. All under the existing `Sites.Read.All` grant.
- Targets without a usable `document_link` (e.g. admin-typed) yield an informative `ConnectorFailure`.

No changes needed in `run_targeted_reindex.py` — it already dispatches to any connector implementing `Resolver`.

## How Has This Been Tested?

- New daily connector tests: drive-item (multi-library) and site-page round-trips, unresolvable/missing-link targets → `ConnectorFailure`, and denylist-excluded target → informative failure.
- Existing SharePoint unit suite passes, confirming the Phase 3b refactor preserves crawl behavior.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


---
## Summary by cubic
Adds targeted reindexing to the SharePoint connector to re-fetch individual failed documents without a full crawl. Supports drive items and site pages, and returns clear failures for unindexable or excluded targets.

- **New Features**
  - Implemented `Resolver.reindex` in `SharepointConnector` to retry failed drive items and site pages.
  - Resolve targets from `document_link`: parse the site, list its drives, probe by item id; memoize per-site drive listings.
  - Emit site/drive/folder hierarchy nodes; works with or without permission sync under `Sites.Read.All`.
  - In reindex mode, yield `ConnectorFailure` for denylisted, unsupported-type, empty non‑PDF/image, over‑size, or missing‑link targets; duplicates stay silent.

- **Refactors**
  - Extracted per-item processing into `_process_drive_item` shared by crawl and reindex.
  - Introduced `SiteDrive` and `ResolvedDriveItem` models to replace tuples.
  - Extracted `_fetch_single_site_page` to reuse existing site-page expand/fallback logic in the reindex path.
  - Applied ruff formatting to the connector.

<sup>Written for commit b7e7245c5b31efd7f1337bd3a8c3979d5c7b5b68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12121?utm_source=github" rel="nofollow noreferrer noopener" target="_blank"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></a>
