### PR TITLE
fix(deployment): alert on create-release failure

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1430,6 +1430,7 @@ jobs:
   notify-slack-on-failure:
     needs:
       - determine-builds
+      - create-release
       - build-desktop
       - build-web-amd64
       - build-web-arm64
@@ -1443,7 +1444,7 @@ jobs:
       - build-model-server-amd64
       - build-model-server-arm64
       - merge-model-server
-    if: always() && (needs.build-desktop.result == 'failure' || needs.build-web-amd64.result == 'failure' || needs.build-web-arm64.result == 'failure' || needs.merge-web.result == 'failure' || needs.build-web-cloud-amd64.result == 'failure' || needs.build-web-cloud-arm64.result == 'failure' || needs.merge-web-cloud.result == 'failure' || needs.build-backend-amd64.result == 'failure' || needs.build-backend-arm64.result == 'failure' || needs.merge-backend.result == 'failure' || needs.build-model-server-amd64.result == 'failure' || needs.build-model-server-arm64.result == 'failure' || needs.merge-model-server.result == 'failure') && needs.determine-builds.outputs.is-test-run != 'true'
+    if: always() && (needs.create-release.result == 'failure' || needs.build-desktop.result == 'failure' || needs.build-web-amd64.result == 'failure' || needs.build-web-arm64.result == 'failure' || needs.merge-web.result == 'failure' || needs.build-web-cloud-amd64.result == 'failure' || needs.build-web-cloud-arm64.result == 'failure' || needs.merge-web-cloud.result == 'failure' || needs.build-backend-amd64.result == 'failure' || needs.build-backend-arm64.result == 'failure' || needs.merge-backend.result == 'failure' || needs.build-model-server-amd64.result == 'failure' || needs.build-model-server-arm64.result == 'failure' || needs.merge-model-server.result == 'failure') && needs.determine-builds.outputs.is-test-run != 'true'
     # NOTE: Github-hosted runners have about 20s faster queue times and are preferred here.
     runs-on: ubuntu-slim
     timeout-minutes: 90
@@ -1459,6 +1460,9 @@ jobs:
         shell: bash
         run: |
           FAILED_JOBS=""
+          if [ "${NEEDS_CREATE_RELEASE_RESULT}" == "failure" ]; then
+            FAILED_JOBS="${FAILED_JOBS}• create-release\\n"
+          fi
           if [ "${NEEDS_BUILD_DESKTOP_RESULT}" == "failure" ]; then
             FAILED_JOBS="${FAILED_JOBS}• build-desktop\\n"
           fi
@@ -1502,6 +1506,7 @@ jobs:
           FAILED_JOBS=$(printf '%s' "$FAILED_JOBS" | sed 's/\\n$//')
           echo "jobs=$FAILED_JOBS" >> "$GITHUB_OUTPUT"
         env:
+          NEEDS_CREATE_RELEASE_RESULT: ${{ needs.create-release.result }}
           NEEDS_BUILD_DESKTOP_RESULT: ${{ needs.build-desktop.result }}
           NEEDS_BUILD_WEB_AMD64_RESULT: ${{ needs.build-web-amd64.result }}
           NEEDS_BUILD_WEB_ARM64_RESULT: ${{ needs.build-web-arm64.result }}


### PR DESCRIPTION
Related to https://github.com/onyx-dot-app/onyx/issues/12118

- [x] [Optional] Please cherry-pick this PR to the latest release version.

## Problem

We weren't getting Slack alerts when the `create-release` step fails in `.github/workflows/deployment.yml`.

The `notify-slack-on-failure` job watches the build/merge jobs but **never watched `create-release`**. Worse, because `build-desktop` declares `needs: create-release`, a `create-release` failure causes `build-desktop` to be **skipped** (`result == 'skipped'`, not `'failure'`) — so the indirect path didn't catch it either. A `create-release` failure went completely silent.

## Fix

Added `create-release` to the three places the notifier tracks jobs:

1. The job's `needs:` list.
2. The `if:` condition (`needs.create-release.result == 'failure'`).
3. The "Determine failed jobs" step — both the bash branch and its `NEEDS_CREATE_RELEASE_RESULT` env var — so it shows up by name in the Slack message.

## Notes

- The existing `is-test-run != 'true'` guard still applies.
- `create-release` is itself gated on `build-desktop == 'true'` (otherwise skipped, not failed), so this won't produce spurious alerts on non-desktop runs.
- Out of scope here: `dispatch-cloud-deployment` and `trivy-scan` are also absent from the notifier. Happy to fold those in if we want them alerted too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send Slack alerts when the `create-release` job fails by having `notify-slack-on-failure` watch it. This prevents silent failures caused by `build-desktop` being skipped.

- **Bug Fixes**
  - Added `create-release` to `notify-slack-on-failure` `needs`.
  - Updated `if:` to include `needs.create-release.result == 'failure'` (keeps `is-test-run` guard).
  - Added `NEEDS_CREATE_RELEASE_RESULT` and included `create-release` in the failed jobs summary.

<sup>Written for commit 23e53256b5382c1d311b612cebca065fa792ae04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

