### PR TITLE
fix(ci): resolve draft release id via list endpoint, not tag lookup

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -228,13 +228,31 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.release-tag.outputs.tag }}
         run: |
-          if ! gh release view "$TAG" >/dev/null 2>&1; then
+          # Look up an existing release (including drafts) by tag name.
+          #
+          # NOTE: a draft release does not create the underlying git tag until
+          # it is published, so `GET /releases/tags/{tag}` (and
+          # `gh release view <tag>`) returns 404 for drafts. We must list
+          # releases instead — that endpoint DOES include drafts — and match
+          # on tag_name.
+          get_release_id() {
+            gh api --paginate "repos/${GITHUB_REPOSITORY}/releases" \
+              --jq ".[] | select(.tag_name == \"${TAG}\") | .id" | head -n1
+          }
+
+          release_id=$(get_release_id)
+          if [ -z "$release_id" ]; then
             gh release create "$TAG" \
               --title "$TAG" \
               --notes "See the assets to download this version and install." \
               --draft
+            release_id=$(get_release_id)
           fi
-          release_id=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" --jq '.id')
+
+          if [ -z "$release_id" ]; then
+            echo "::error::Failed to resolve release id for tag ${TAG}"
+            exit 1
+          fi
           echo "id=${release_id}" >> "$GITHUB_OUTPUT"
 
   build-desktop:


### PR DESCRIPTION
Closes https://github.com/onyx-dot-app/onyx/issues/12118

- [x] [Optional] Please cherry-pick this PR to the latest release version.

## Problem

The `create-release` job in `deployment.yml` failed on the `v4.1.1` tag ([run](https://github.com/onyx-dot-app/onyx/actions/runs/27448572303/job/81139043280)):

```
https://github.com/onyx-dot-app/onyx/releases/tag/untagged-ce2e0123ee169fc93464
gh: Not Found (HTTP 404)
Error: Process completed with exit code 1.
```

The step created a **draft** release, then tried to look it up with `GET /releases/tags/$TAG`:

```bash
gh release create "$TAG" ... --draft
release_id=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" --jq '.id')
```

A draft release has **no underlying git tag** until it's published — GitHub parks it under a temporary `untagged-…` ref. The `GET /releases/tags/{tag}` endpoint (and `gh release view <tag>`) only resolves *published* releases, so it 404s, the step exits 1, and the whole release is aborted.

## Fix

- Resolve the release id via the **list-releases** endpoint (`GET /releases`), which *does* include drafts, matching on `tag_name`.
- Make the step **idempotent**: look up first and only `gh release create` if no release exists, so re-running a failed workflow reuses the existing draft instead of leaving orphaned duplicates.
- Add an explicit empty-id guard that fails loudly (`::error::`) rather than silently emitting an empty `release-id`, which would break the downstream `tauri-action` asset upload.

## Note

The original buggy run left an orphaned draft (`untagged-ce2e0123ee169fc93464`). The new idempotent lookup will find and reuse it on re-run (no duplicate), but it can be deleted manually if you'd prefer a clean start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the `create-release` job by resolving draft release IDs via the releases list instead of tag lookup. Prevents 404s on drafts, avoids duplicate drafts, and fails fast if the ID can’t be resolved.

- **Bug Fixes**
  - List `GET /releases` and match on `tag_name` to find drafts.
  - Create only if not found; re-runs reuse the existing draft.
  - Add empty-ID guard (`::error::` + exit 1) to protect downstream asset uploads.

<sup>Written for commit 13494ff7e2ea00c5ccb8de3ddaa687fcac81a019. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

