### PR TITLE
fix(confluence): anchor attachment link to webui URL

### DIFF
--- a/backend/onyx/connectors/confluence/connector.py
+++ b/backend/onyx/connectors/confluence/connector.py
@@ -636,14 +636,18 @@ class ConfluenceConnector(
                     attachment["title"],
                     page["title"],
                 )
-                # User-facing attachment link: anchor to the browser-friendly
-                # `webui` URL rather than `_links.download`. The download URL is an
-                # Atlassian implementation detail (now a token-only REST endpoint that
-                # no longer carries the filename), whereas the webui URL is the stable,
-                # filename-bearing link we also use as the attachment's document id.
+                # User-facing attachment link: build the canonical download URL
+                # (`/download/attachments/{page_id}/{filename}`) ourselves. Confluence
+                # Cloud changed `_links.download` to a token-only REST endpoint
+                # (`/rest/api/content/{id}/child/attachment/{att}/download`) that no
+                # longer carries the filename, and `_links.webui` points at the
+                # attachments viewer rather than the file, so we reconstruct the stable,
+                # filename-bearing link instead.
                 try:
                     object_url = build_confluence_document_id(
-                        self.wiki_base, attachment["_links"]["webui"], self.is_cloud
+                        self.wiki_base,
+                        f"/download/attachments/{_get_page_id(page)}/{quote(attachment['title'])}",
+                        self.is_cloud,
                     )
                 except Exception as e:
                     logger.warning(
@@ -692,9 +696,9 @@ class ConfluenceConnector(
                         self.wiki_base, page["_links"]["webui"], self.is_cloud
                     )
                     attachment_metadata["parent_page_id"] = page_url
-                    # Same webui-based URL as object_url; the attachment's document id
-                    # and user-facing link are intentionally the same value.
-                    attachment_id = object_url
+                    attachment_id = build_confluence_document_id(
+                        self.wiki_base, attachment["_links"]["webui"], self.is_cloud
+                    )
 
                     primary_owners: list[BasicExpertInfo] | None = None
                     if "version" in attachment and "by" in attachment["version"]:

--- a/backend/onyx/connectors/confluence/connector.py
+++ b/backend/onyx/connectors/confluence/connector.py
@@ -636,10 +636,14 @@ class ConfluenceConnector(
                     attachment["title"],
                     page["title"],
                 )
-                # Attachment document id: use the download URL for stable identity
+                # User-facing attachment link: anchor to the browser-friendly
+                # `webui` URL rather than `_links.download`. The download URL is an
+                # Atlassian implementation detail (now a token-only REST endpoint that
+                # no longer carries the filename), whereas the webui URL is the stable,
+                # filename-bearing link we also use as the attachment's document id.
                 try:
                     object_url = build_confluence_document_id(
-                        self.wiki_base, attachment["_links"]["download"], self.is_cloud
+                        self.wiki_base, attachment["_links"]["webui"], self.is_cloud
                     )
                 except Exception as e:
                     logger.warning(
@@ -688,9 +692,9 @@ class ConfluenceConnector(
                         self.wiki_base, page["_links"]["webui"], self.is_cloud
                     )
                     attachment_metadata["parent_page_id"] = page_url
-                    attachment_id = build_confluence_document_id(
-                        self.wiki_base, attachment["_links"]["webui"], self.is_cloud
-                    )
+                    # Same webui-based URL as object_url; the attachment's document id
+                    # and user-facing link are intentionally the same value.
+                    attachment_id = object_url
 
                     primary_owners: list[BasicExpertInfo] | None = None
                     if "version" in attachment and "by" in attachment["version"]:

--- a/backend/onyx/connectors/confluence/connector.py
+++ b/backend/onyx/connectors/confluence/connector.py
@@ -636,13 +636,9 @@ class ConfluenceConnector(
                     attachment["title"],
                     page["title"],
                 )
-                # User-facing attachment link: build the canonical download URL
-                # (`/download/attachments/{page_id}/{filename}`) ourselves. Confluence
-                # Cloud changed `_links.download` to a token-only REST endpoint
-                # (`/rest/api/content/{id}/child/attachment/{att}/download`) that no
-                # longer carries the filename, and `_links.webui` points at the
-                # attachments viewer rather than the file, so we reconstruct the stable,
-                # filename-bearing link instead.
+                # Build the download URL ourselves for a stable, filename-bearing link:
+                # `_links.download` is a token-only REST endpoint on Cloud and
+                # `_links.webui` points at the attachments viewer, not the file.
                 try:
                     object_url = build_confluence_document_id(
                         self.wiki_base,


### PR DESCRIPTION
## Problem

The `test_confluence_connector_basic` daily test started failing:

```
AssertionError: assert False
 +  where False = 'https://danswerai.atlassian.net/wiki/rest/api/content/52494430/child/attachment/att52527123/download'.endswith('small-file.txt')
```

**Root cause:** Confluence Cloud changed the value it returns for an attachment's `_links.download`. It used to be the classic, filename-bearing path:

```
/download/attachments/{pageId}/small-file.txt?version=...&api=v2
```

and now returns a token-only REST endpoint that no longer carries the filename:

```
/rest/api/content/{pageId}/child/attachment/{attId}/download
```

The connector built the attachment **section link** (`object_url`) from `_links.download`, so the user-facing link stopped ending in the filename, breaking the test's `...split("?")[0].endswith("small-file.txt")` assertion. This is an upstream API change — the branch was clean and even with `main`.

Note: `_links.webui` doesn't help either — for attachments it points at the attachments viewer (`/pages/viewpageattachments.action?...&preview=...`), with the filename only in the query string.

## Fix

Reconstruct the canonical download URL ourselves:

```
{wiki_base}/download/attachments/{page_id}/{quote(filename)}
```

- This is exactly what `_links.download` returned (minus query params) before Atlassian's change, so it restores the original, stable, filename-bearing user-facing link.
- `page_id` is the attachment's container (same id used by `_make_attachment_link` to download the bytes), and the filename comes from `attachment["title"]`.
- `attachment_id` (the **document id**) stays `webui`-based, so document identity is unchanged — **no re-indexing churn**.
- The actual attachment **download** mechanism is untouched — `process_attachment` builds its own REST download link via `_make_attachment_link`.

## Testing

- `ty` type-check + `ruff`/`ruff format` pass (pre-commit clean).
- All 56 Confluence unit tests pass.
- Verified locally that the reconstructed URL ends in the filename (handles URL-encoding of names with spaces).
- The live daily test (`test_confluence_connector_basic` / `_scoped`) runs in the `connectors-check` CI job against the real Confluence API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)