### PR TITLE
feat: allow sandbox agents to write tmp

### DIFF
--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -154,6 +154,8 @@ SANDBOX_EXEC_USER = "1000:1000"
 # Docker exec bypasses firewall-init.sh's setpriv environment workaround, so
 # sandbox-user execs must carry the uid/gid and user HOME together.
 SANDBOX_EXEC_ENV = {"HOME": "/home/sandbox", "USER": "sandbox"}
+SANDBOX_TMP_PATH = "/tmp"  # noqa: S108 - sandbox-local scratch mount.
+SANDBOX_TMPFS_OPTIONS = "rw,nosuid,nodev,size=5g,mode=1777"
 
 # Mirror the K8s constants in ``kubernetes_sandbox_manager`` (POD_READY_*),
 # which are also module-level and not env-tunable.
@@ -469,6 +471,7 @@ class _ContainerCreateKwargsRequired(TypedDict):
     ports: dict[str, tuple[str, int | None]]
     environment: dict[str, str]
     volumes: dict[str, dict[str, str]]
+    tmpfs: dict[str, str]
     mem_limit: str
     nano_cpus: int
     restart_policy: dict[str, str]
@@ -647,6 +650,7 @@ def build_container_create_kwargs(
         "ports": ports,
         "environment": env,
         "volumes": volumes,
+        "tmpfs": {SANDBOX_TMP_PATH: SANDBOX_TMPFS_OPTIONS},
         "mem_limit": memory_limit,
         "nano_cpus": int(cpu_limit * 1_000_000_000),
         "restart_policy": {"Name": "unless-stopped"},

--- a/backend/onyx/server/features/build/sandbox/util/opencode_config.py
+++ b/backend/onyx/server/features/build/sandbox/util/opencode_config.py
@@ -88,6 +88,15 @@ _PERMISSIONS_TEMPLATE: dict[str, Any] = {
     "webfetch": "allow",
 }
 
+_TMP_EXTERNAL_DIRECTORY_RULES: dict[str, str] = {
+    # OpenCode applies granular permission objects by pattern match with the
+    # last matching rule winning. Keep the catch-all first so the /tmp allow
+    # rules override it without opening any other external paths.
+    "*": "deny",
+    "/tmp": "allow",  # noqa: S108 - sandbox-local scratch path.
+    "/tmp/**": "allow",  # noqa: S108 - sandbox-local scratch path.
+}
+
 
 def _build_permissions(
     disabled_tools: list[str] | None, dev_mode: bool
@@ -96,7 +105,9 @@ def _build_permissions(
         k: (v.copy() if isinstance(v, dict) else v)
         for k, v in _PERMISSIONS_TEMPLATE.items()
     }
-    permissions["external_directory"] = "allow" if dev_mode else {"*": "deny"}
+    permissions["external_directory"] = (
+        "allow" if dev_mode else _TMP_EXTERNAL_DIRECTORY_RULES.copy()
+    )
     if disabled_tools:
         for tool in disabled_tools:
             permissions[tool] = "deny"

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_manager_config.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_manager_config.py
@@ -59,6 +59,12 @@ from onyx.server.features.build.sandbox.docker.docker_sandbox_manager import (
 from onyx.server.features.build.sandbox.docker.docker_sandbox_manager import (
     LABEL_USER_ID,
 )
+from onyx.server.features.build.sandbox.docker.docker_sandbox_manager import (
+    SANDBOX_TMP_PATH,
+)
+from onyx.server.features.build.sandbox.docker.docker_sandbox_manager import (
+    SANDBOX_TMPFS_OPTIONS,
+)
 from onyx.server.features.build.sandbox.labels import LABEL_K8S_MANAGED_BY
 from onyx.server.features.build.sandbox.labels import LABEL_K8S_MANAGED_BY_ONYX
 
@@ -411,6 +417,13 @@ def test_container_kwargs_mounts_only_workspace_sessions(
         assert not source.startswith("/"), (
             f"Bind mount detected: {source}; only named volumes are allowed"
         )
+
+
+def test_container_kwargs_mounts_tmp_as_tmpfs(
+    kwargs: ContainerCreateKwargs,
+) -> None:
+    """Expose /tmp as sandbox-local scratch space without adding a host mount."""
+    assert kwargs["tmpfs"] == {SANDBOX_TMP_PATH: SANDBOX_TMPFS_OPTIONS}
 
 
 def test_container_kwargs_warns_on_internal_compose_host(

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_config.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_config.py
@@ -178,17 +178,27 @@ def test_single_provider_wrapper_back_compat() -> None:
     assert direct == wrapped
 
 
-def test_permission_block_includes_external_directory_deny_by_default() -> None:
+def test_permission_block_allows_tmp_external_directory_by_default() -> None:
     """
-    K8s + Docker run in container, so external_directory must default to deny.
-    Only ``dev_mode=True`` opens it up.
+    K8s + Docker run in container, so external_directory stays deny-by-default.
+    ``/tmp`` is the one sandbox-local exception agents need for scratch files.
+    Only ``dev_mode=True`` opens all external paths up.
     """
     config = build_multi_provider_opencode_config(
         providers=[_cfg("anthropic", "claude-opus-4-7")],
         default_provider="anthropic",
         default_model="claude-opus-4-7",
     )
-    assert config["permission"]["external_directory"] == {"*": "deny"}
+    assert config["permission"]["external_directory"] == {
+        "*": "deny",
+        "/tmp": "allow",
+        "/tmp/**": "allow",
+    }
+    assert list(config["permission"]["external_directory"].items()) == [
+        ("*", "deny"),
+        ("/tmp", "allow"),
+        ("/tmp/**", "allow"),
+    ]
 
     dev_config = build_multi_provider_opencode_config(
         providers=[_cfg("anthropic", "claude-opus-4-7")],

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_pod_spec.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_pod_spec.py
@@ -310,6 +310,8 @@ def test_workspace_volume_is_shared_for_session_io(pod: client.V1Pod) -> None:
         "workspace",
         "opencode-data",
         "managed",
+        "tmp",
+        "sidecar-tmp",
         "sandbox-ca-source",
         "sandbox-ca-bundle",
     }
@@ -317,6 +319,31 @@ def test_workspace_volume_is_shared_for_session_io(pod: client.V1Pod) -> None:
         mount = _mount(container, "workspace")
         assert mount.mount_path == "/workspace/sessions"
         assert not mount.read_only
+
+
+def test_tmp_volumes_are_writable_and_isolated_by_container(
+    pod: client.V1Pod,
+) -> None:
+    """Agents need /tmp for scratch files. The sidecar also uses /tmp while
+    restoring snapshot archives, but it must not share that scratch space with
+    the agent after archive checksum verification.
+    """
+    assert pod.spec.security_context.fs_group == 1000
+
+    volumes = {v.name: v for v in pod.spec.volumes}
+    assert volumes["tmp"].empty_dir.size_limit == "5Gi"
+    assert volumes["sidecar-tmp"].empty_dir.size_limit == "5Gi"
+
+    sandbox_tmp = _mount(_container(pod, "sandbox"), "tmp")
+    sidecar_tmp = _mount(_sidecar(pod), "sidecar-tmp")
+    assert sandbox_tmp.mount_path == sidecar_tmp.mount_path == "/tmp"
+    assert not sandbox_tmp.read_only
+    assert not sidecar_tmp.read_only
+
+    sandbox_mount_names = {m.name for m in _container(pod, "sandbox").volume_mounts}
+    sidecar_mount_names = {m.name for m in _sidecar(pod).volume_mounts}
+    assert "sidecar-tmp" not in sandbox_mount_names
+    assert "tmp" not in sidecar_mount_names
 
 
 def test_opencode_data_volume_is_shared_outside_session_tree(

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.6.0
+version: 0.6.1
 appVersion: latest
 annotations:
   category: Productivity
@@ -16,6 +16,9 @@ annotations:
     - name: background
       image: docker.io/onyxdotapp/onyx-backend:latest
   artifacthub.io/changes: |
+    - kind: changed
+      description: Add isolated writable /tmp scratch space for sandboxed
+        OpenCode agents.
     - kind: changed
       description: Preserve Craft opencode history across Kubernetes sandbox
         restarts by restoring it before opencode starts.

--- a/deployment/helm/charts/onyx/templates/sandbox-podtemplate.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-podtemplate.yaml
@@ -101,6 +101,7 @@ template:
           - { name: workspace, mountPath: /workspace/sessions }
           - { name: opencode-data, mountPath: /workspace/opencode-data }
           - { name: managed, mountPath: /workspace/managed }
+          - { name: sidecar-tmp, mountPath: /tmp }
           - { name: sandbox-ca-bundle, mountPath: /etc/ssl/sandbox, readOnly: true }
         resources:
           # Snapshot tar/stream runs through this sidecar, so give it headroom.
@@ -147,6 +148,7 @@ template:
           - { name: workspace, mountPath: /workspace/sessions }
           - { name: opencode-data, mountPath: /workspace/opencode-data }
           - { name: managed, mountPath: /workspace/managed, readOnly: true }
+          - { name: tmp, mountPath: /tmp }
           - { name: sandbox-ca-bundle, mountPath: /etc/ssl/sandbox, readOnly: true }
         resources:
           requests:
@@ -165,6 +167,10 @@ template:
       - name: opencode-data
         emptyDir: { sizeLimit: 5Gi }
       - name: managed
+        emptyDir: { sizeLimit: 5Gi }
+      - name: tmp
+        emptyDir: { sizeLimit: 5Gi }
+      - name: sidecar-tmp
         emptyDir: { sizeLimit: 5Gi }
       - name: sandbox-ca-source
         configMap:


### PR DESCRIPTION
## Description

Allow sandboxed OpenCode agents to use sandbox-local `/tmp` scratch space without exposing host paths. Kubernetes sandboxes now mount a per-pod `5Gi` `emptyDir` at `/tmp` for the sandbox container, while the sidecar gets its own isolated `sidecar-tmp` volume mounted at `/tmp` so verified snapshot archives cannot be modified by the agent between checksum verification and restore. Docker sandboxes mount `/tmp` as a bounded tmpfs.

OpenCode's external directory policy remains deny-by-default and only allows `/tmp` and `/tmp/**` outside the workspace.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
