### PR TITLE
fix(ci): clearer Slack alert when cherry-pick hits workflows permission

### DIFF
--- a/.github/workflows/post-merge-beta-cherry-pick.yml
+++ b/.github/workflows/post-merge-beta-cherry-pick.yml
@@ -160,7 +160,14 @@ jobs:
           echo "status=failure" >> "$GITHUB_OUTPUT"
 
           reason="command-failed"
-          if grep -qiE "merge conflict during cherry-pick|CONFLICT|could not apply|cherry-pick in progress with staged changes" "$output_file"; then
+          # The GitHub App installation token only carries contents + pull-requests
+          # write permissions, not `workflows`. Pushing a cherry-pick that touches
+          # .github/workflows is therefore rejected by the remote. Detect that
+          # specific rejection so the Slack alert can explain it clearly instead of
+          # surfacing a raw git error.
+          if grep -qiE "refusing to allow .* to (create or update|update) workflow|without [^[:space:]]*workflows[^[:space:]]* permission" "$output_file"; then
+            reason="workflow-permission"
+          elif grep -qiE "merge conflict during cherry-pick|CONFLICT|could not apply|cherry-pick in progress with staged changes" "$output_file"; then
             reason="merge-conflict"
           fi
           echo "reason=${reason}" >> "$GITHUB_OUTPUT"
@@ -272,6 +279,8 @@ jobs:
             reason_text="failed to capture cherry-pick output for classification"
           elif [ "${CHERRY_PICK_REASON}" = "merge-conflict" ]; then
             reason_text="merge conflict during cherry-pick"
+          elif [ "${CHERRY_PICK_REASON}" = "workflow-permission" ]; then
+            reason_text="PR changes .github/workflows, which the cherry-pick GitHub App is not permitted to push — please cherry-pick this PR manually"
           fi
 
           details_excerpt="$(printf '%s' "${CHERRY_PICK_DETAILS}" | tail -n 8 | tr '\n' ' ' | sed "s/[[:space:]]\\+/ /g" | sed "s/\"/'/g" | cut -c1-350)"


### PR DESCRIPTION
## Problem

When a merged PR touches `.github/workflows`, the **Post-Merge Beta Cherry-Pick** workflow fails at the `git push` step. The cherry-pick GitHub App token is minted with only `contents: write` + `pull-requests: write` — it has no `workflows` permission, so the remote rejects the push:

> refusing to allow a GitHub App to create or update workflow ... without `workflows` permission

That error bubbles up through `ods cherry-pick` and gets captured, but previously it fell into the generic `command-failed` bucket. The Slack alert just said *"cherry-pick command failed"* with a raw git excerpt — not obvious that the fix is to cherry-pick manually.

## Change

Two small edits mirroring the existing `merge-conflict` classification:

1. **Classification** (`cherry-pick-to-latest-release` → `run_cherry_pick`): a new `grep` ahead of the merge-conflict check sets `reason=workflow-permission` when it detects the App workflows-permission rejection. The pattern avoids literal backticks (which would trigger command substitution in the double-quoted bash string).
2. **Slack message** (`notify-slack-on-cherry-pick-failure` → `failure-summary`): a new branch maps that reason to a digestible line — *"PR changes .github/workflows, which the cherry-pick GitHub App is not permitted to push — please cherry-pick this PR manually"*.

The job still fails (the cherry-pick genuinely didn't happen), but the alert now explains why and what to do.

## Notes

This intentionally does **not** grant the App `workflows` permission. Doing so would let it push these cherry-picks automatically, but that's a larger permissions/security decision — left out of scope here in favor of a clearer failure.

## Testing

Verified the new `grep` pattern matches a realistic remote-rejection message without falsely tripping the merge-conflict branch, and that the workflow YAML still parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add clear detection and Slack alert when cherry-pick push is rejected because the GitHub App lacks `workflows` permission for changes to `.github/workflows`. The job still fails, but the message now explains why and asks for a manual cherry-pick.

- **Bug Fixes**
  - Classify failure as `workflow-permission` in `run_cherry_pick` via a targeted grep before the merge-conflict check.
  - Map this reason to a concise Slack message explaining the missing `workflows` permission and requesting a manual cherry-pick.

<sup>Written for commit bcd31f7c37796777746dffddca6eedcf3d1fbd78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

