### PR TITLE
fix(slack): retry paginated rate limit responses

### DIFF
--- a/backend/onyx/connectors/slack/utils.py
+++ b/backend/onyx/connectors/slack/utils.py
@@ -1,8 +1,8 @@
 import re
+import time
 from collections.abc import Callable
 from collections.abc import Generator
 from functools import lru_cache
-from functools import wraps
 from typing import Any
 from typing import cast
 
@@ -13,14 +13,15 @@ from slack_sdk.web import SlackResponse
 from onyx.connectors.models import BasicExpertInfo
 from onyx.connectors.slack.models import MessageType
 from onyx.utils.logger import setup_logger
-from onyx.utils.retry_wrapper import retry_builder
+from onyx.utils.retry_after import parse_retry_after_seconds
 
 logger = setup_logger()
 
-# retry after 0.1, 1.2, 3.4, 7.8, 16.6, 34.2 seconds
-basic_retry_wrapper = retry_builder(tries=7)
 # number of messages we request per page when fetching paginated slack messages
 _SLACK_LIMIT = 900
+_SLACK_RATE_LIMIT_MAX_RETRIES = 7
+_SLACK_RATE_LIMIT_DEFAULT_RETRY_AFTER_SECONDS = 5.0
+_SLACK_RATE_LIMIT_ERRORS = {"ratelimited", "rate_limited"}
 
 # used to serialize access to the retry TTL
 ONYX_SLACK_LOCK_TTL = 1800  # how long the lock is allowed to idle before it expires
@@ -88,96 +89,66 @@ def make_slack_api_call(
 def make_paginated_slack_api_call(
     call: Callable[..., SlackResponse], **kwargs: Any
 ) -> Generator[dict[str, Any], None, None]:
-    return _make_slack_api_call_paginated(call)(**kwargs)
-
-
-def _make_slack_api_call_paginated(
-    call: Callable[..., SlackResponse],
-) -> Callable[..., Generator[dict[str, Any], None, None]]:
     """Wraps calls to slack API so that they automatically handle pagination"""
 
-    @wraps(call)
-    def paginated_call(**kwargs: Any) -> Generator[dict[str, Any], None, None]:
-        cursor: str | None = None
-        has_more = True
-        while has_more:
-            response = call(cursor=cursor, limit=_SLACK_LIMIT, **kwargs)
-            yield cast(dict[str, Any], response.validate())
-            cursor = cast(dict[str, Any], response.get("response_metadata", {})).get(
-                "next_cursor", ""
-            )
-            has_more = bool(cursor)
+    cursor: str | None = None
+    has_more = True
+    while has_more:
+        for retry_num in range(_SLACK_RATE_LIMIT_MAX_RETRIES + 1):
+            try:
+                response = call(cursor=cursor, limit=_SLACK_LIMIT, **kwargs).validate()
+                response_dict = cast(dict[str, Any], response)
+                yield response_dict
+                cursor = cast(
+                    dict[str, Any], response_dict.get("response_metadata", {})
+                ).get("next_cursor", "")
+                has_more = bool(cursor)
+                break
+            except SlackApiError as e:
+                slack_response = e.response
+                error_code = (
+                    slack_response.get("error") if slack_response is not None else None
+                )
 
-    return paginated_call
+                if (
+                    slack_response is None
+                    or getattr(slack_response, "status_code", None) == 429
+                    or error_code not in _SLACK_RATE_LIMIT_ERRORS
+                    or retry_num >= _SLACK_RATE_LIMIT_MAX_RETRIES
+                ):
+                    raise
 
+                retry_after_header_value = None
+                for header_name, header_value in getattr(
+                    slack_response, "headers", {}
+                ).items():
+                    if header_name.lower() != "retry-after":
+                        continue
+                    if isinstance(header_value, list):
+                        retry_after_header_value = (
+                            header_value[0] if header_value else None
+                        )
+                    else:
+                        retry_after_header_value = header_value
+                    break
 
-# NOTE(rkuo): we may not need this any more if the integrated retry handlers work as
-# expected.  Do we want to keep this around?
+                retry_after = parse_retry_after_seconds(
+                    str(retry_after_header_value)
+                    if retry_after_header_value is not None
+                    else None
+                )
+                if retry_after is None:
+                    retry_after = _SLACK_RATE_LIMIT_DEFAULT_RETRY_AFTER_SECONDS
 
-# def make_slack_api_rate_limited(
-#     call: Callable[..., SlackResponse], max_retries: int = 7
-# ) -> Callable[..., SlackResponse]:
-#     """Wraps calls to slack API so that they automatically handle rate limiting"""
-
-#     @wraps(call)
-#     def rate_limited_call(**kwargs: Any) -> SlackResponse:
-#         last_exception = None
-
-#         for _ in range(max_retries):
-#             try:
-#                 # Make the API call
-#                 response = call(**kwargs)
-
-#                 # Check for errors in the response, will raise `SlackApiError`
-#                 # if anything went wrong
-#                 response.validate()
-#                 return response
-
-#             except SlackApiError as e:
-#                 last_exception = e
-#                 try:
-#                     error = e.response["error"]
-#                 except KeyError:
-#                     error = "unknown error"
-
-#                 if error == "ratelimited":
-#                     # Handle rate limiting: get the 'Retry-After' header value and sleep for that duration
-#                     retry_after = int(e.response.headers.get("Retry-After", 1))
-#                     logger.info(
-#                         f"Slack call rate limited, retrying after {retry_after} seconds. Exception: {e}"
-#                     )
-#                     time.sleep(retry_after)
-#                 elif error in ["already_reacted", "no_reaction", "internal_error"]:
-#                     # Log internal_error and return the response instead of failing
-#                     logger.warning(
-#                         f"Slack call encountered '{error}', skipping and continuing..."
-#                     )
-#                     return e.response
-#                 else:
-#                     # Raise the error for non-transient errors
-#                     raise
-
-#         # If the code reaches this point, all retries have been exhausted
-#         msg = f"Max retries ({max_retries}) exceeded"
-#         if last_exception:
-#             raise Exception(msg) from last_exception
-#         else:
-#             raise Exception(msg)
-
-#     return rate_limited_call
-
-# temporarily disabling due to using a different retry approach
-# might be permanent if everything works out
-# def make_slack_api_call_w_retries(
-#     call: Callable[..., SlackResponse], **kwargs: Any
-# ) -> SlackResponse:
-#     return basic_retry_wrapper(call)(**kwargs)
-
-
-# def make_paginated_slack_api_call_w_retries(
-#     call: Callable[..., SlackResponse], **kwargs: Any
-# ) -> Generator[dict[str, Any], None, None]:
-#     return _make_slack_api_call_paginated(basic_retry_wrapper(call))(**kwargs)
+                logger.warning(
+                    "Slack API returned %s for %s; sleeping %.2fs before retry %s/%s.",
+                    error_code,
+                    getattr(call, "__name__", repr(call)),
+                    retry_after,
+                    retry_num + 1,
+                    _SLACK_RATE_LIMIT_MAX_RETRIES,
+                )
+                time.sleep(retry_after)
 
 
 def expert_info_from_slack_id(

--- a/backend/tests/unit/onyx/connectors/slack/test_utils.py
+++ b/backend/tests/unit/onyx/connectors/slack/test_utils.py
@@ -1,0 +1,158 @@
+from typing import Any
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from slack_sdk.errors import SlackApiError
+
+from onyx.connectors.slack.utils import make_paginated_slack_api_call
+
+
+def _slack_error(
+    error: str,
+    status_code: int = 200,
+    retry_after: str | list[str] | None = "0",
+) -> SlackApiError:
+    response = MagicMock()
+    response.status_code = status_code
+    response.headers = {} if retry_after is None else {"Retry-After": retry_after}
+    response.get.side_effect = lambda key, default=None: {"error": error}.get(
+        key, default
+    )
+    return SlackApiError(error, response)
+
+
+def _rate_limited_error(
+    retry_after: str | list[str] | None = "0",
+) -> SlackApiError:
+    return _slack_error("ratelimited", retry_after=retry_after)
+
+
+class _SlackResponse(dict[str, Any]):
+    def __init__(
+        self,
+        payload: dict[str, Any] | None = None,
+        error: SlackApiError | None = None,
+    ) -> None:
+        super().__init__(payload or {})
+        self.error = error
+
+    def validate(self) -> "_SlackResponse":
+        if self.error:
+            raise self.error
+        return self
+
+
+def test_make_paginated_slack_api_call_retries_validation_rate_limits() -> None:
+    response_payload = {"ok": True, "response_metadata": {"next_cursor": ""}}
+    call = MagicMock(
+        side_effect=[
+            _SlackResponse(error=_rate_limited_error()),
+            _SlackResponse(payload=response_payload),
+        ]
+    )
+
+    with patch("onyx.connectors.slack.utils.time.sleep") as mock_sleep:
+        responses = list(make_paginated_slack_api_call(call, channel="C1"))
+
+    assert responses == [response_payload]
+    assert call.call_count == 2
+    assert call.call_args_list[0].kwargs == {
+        "channel": "C1",
+        "cursor": None,
+        "limit": 900,
+    }
+    mock_sleep.assert_called_once_with(0.0)
+
+
+def test_make_paginated_slack_api_call_retries_api_call_rate_limits() -> None:
+    response_payload = {"ok": True, "response_metadata": {"next_cursor": ""}}
+    call = MagicMock(
+        side_effect=[
+            _rate_limited_error(),
+            _SlackResponse(payload=response_payload),
+        ]
+    )
+
+    with patch("onyx.connectors.slack.utils.time.sleep") as mock_sleep:
+        responses = list(make_paginated_slack_api_call(call, channel="C1"))
+
+    assert responses == [response_payload]
+    assert call.call_count == 2
+    mock_sleep.assert_called_once_with(0.0)
+
+
+def test_make_paginated_slack_api_call_does_not_retry_http_429() -> None:
+    error = _slack_error("ratelimited", status_code=429)
+    call = MagicMock(return_value=_SlackResponse(error=error))
+
+    with patch("onyx.connectors.slack.utils.time.sleep") as mock_sleep:
+        with pytest.raises(SlackApiError) as exc_info:
+            list(make_paginated_slack_api_call(call, channel="C1"))
+
+    assert exc_info.value is error
+    call.assert_called_once_with(channel="C1", cursor=None, limit=900)
+    mock_sleep.assert_not_called()
+
+
+def test_make_paginated_slack_api_call_does_not_retry_non_rate_limit_errors() -> None:
+    error = _slack_error("invalid_auth")
+    call = MagicMock(return_value=_SlackResponse(error=error))
+
+    with patch("onyx.connectors.slack.utils.time.sleep") as mock_sleep:
+        with pytest.raises(SlackApiError) as exc_info:
+            list(make_paginated_slack_api_call(call, channel="C1"))
+
+    assert exc_info.value is error
+    call.assert_called_once_with(channel="C1", cursor=None, limit=900)
+    mock_sleep.assert_not_called()
+
+
+def test_make_paginated_slack_api_call_exhausts_rate_limit_retries() -> None:
+    error = _rate_limited_error()
+    call = MagicMock(return_value=_SlackResponse(error=error))
+
+    with patch("onyx.connectors.slack.utils.time.sleep") as mock_sleep:
+        with pytest.raises(SlackApiError) as exc_info:
+            list(make_paginated_slack_api_call(call, channel="C1"))
+
+    assert exc_info.value is error
+    assert call.call_count == 8
+    assert mock_sleep.call_count == 7
+
+
+def test_make_paginated_slack_api_call_parses_retry_after_headers() -> None:
+    response_payload = {"ok": True, "response_metadata": {"next_cursor": ""}}
+    call = MagicMock(
+        side_effect=[
+            _SlackResponse(error=_rate_limited_error(retry_after=["1.5"])),
+            _SlackResponse(error=_rate_limited_error(retry_after="bad-value")),
+            _SlackResponse(payload=response_payload),
+        ]
+    )
+
+    with patch("onyx.connectors.slack.utils.time.sleep") as mock_sleep:
+        responses = list(make_paginated_slack_api_call(call, channel="C1"))
+
+    assert responses == [response_payload]
+    assert [call_args.args[0] for call_args in mock_sleep.call_args_list] == [1.5, 5.0]
+
+
+def test_make_paginated_slack_api_call_retries_current_cursor_page() -> None:
+    page_one = {"ok": True, "response_metadata": {"next_cursor": "cursor-2"}}
+    page_two = {"ok": True, "response_metadata": {"next_cursor": ""}}
+    call = MagicMock(
+        side_effect=[
+            _SlackResponse(payload=page_one),
+            _SlackResponse(error=_rate_limited_error()),
+            _SlackResponse(payload=page_two),
+        ]
+    )
+
+    with patch("onyx.connectors.slack.utils.time.sleep"):
+        responses = list(make_paginated_slack_api_call(call, channel="C1"))
+
+    assert responses == [page_one, page_two]
+    assert call.call_args_list[0].kwargs["cursor"] is None
+    assert call.call_args_list[1].kwargs["cursor"] == "cursor-2"
+    assert call.call_args_list[2].kwargs["cursor"] == "cursor-2"


### PR DESCRIPTION
## Description

Retries non-HTTP Slack `ratelimited` / `rate_limited` API responses inside `make_paginated_slack_api_call`, while leaving HTTP 429 handling to the existing Slack SDK / Redis retry path.

Also removes stale commented retry helpers from Slack utils and adds focused unit coverage for the paginated retry behavior.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries paginated Slack API calls on non-HTTP rate limit errors to prevent missed pages, while keeping HTTP 429 handling with the existing `slack_sdk`/Redis path. This stabilizes pagination under load and adds focused test coverage.

- **Bug Fixes**
  - Retries up to 7 times on `ratelimited`/`rate_limited` in `make_paginated_slack_api_call`.
  - Uses `Retry-After` header via `parse_retry_after_seconds` with a 5s default; skips retries on HTTP 429.
  - Retries the current page without advancing the cursor; logs and sleeps between attempts.
  - Removed stale commented retry helpers and added unit tests for retry and header parsing behavior.

<sup>Written for commit 5899c250586fbc0bffba0c032166b65c728d4fd0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

