### PR TITLE
feat(craft): make sandbox image publishing manual + tag-driven

### DIFF
--- a/.github/workflows/sandbox-deployment.yml
+++ b/.github/workflows/sandbox-deployment.yml
@@ -51,7 +51,10 @@ jobs:
           # changed: skip if its content hash (src-<tree-hash>) is already published.
           if [ "$EVENT_NAME" = "workflow_dispatch" ] || [ "$GITHUB_REF_NAME" = "sandbox-edge" ]; then
             CONTEXT="backend/onyx/server/features/build/sandbox/image"
-            SRC_TAG="src-$(git rev-parse "HEAD:${CONTEXT}" | cut -c1-16)"
+            # Fingerprint only files Docker builds: exclude README.md (the lone
+            # committed path in this dir's .dockerignore) so docs-only edits don't
+            # cut a spurious version.
+            SRC_TAG="src-$(git ls-tree -r HEAD -- "${CONTEXT}" | grep -v '/README\.md$' | git hash-object --stdin | cut -c1-16)"
             echo "src-tag=${SRC_TAG}" >> "$GITHUB_OUTPUT"
             # Only 200 (exists) / 404 (absent) are conclusive. Fail on anything
             # else (429/5xx/network) so a flaky probe is never misread as
@@ -89,10 +92,14 @@ jobs:
         env:
           SRC_TAG: ${{ steps.check.outputs.src-tag }}
         run: |
-          # Patch-bump off the highest published vX.Y.Z on Docker Hub.
-          LATEST_TAG=$(curl -s "https://hub.docker.com/v2/repositories/onyxdotapp/sandbox/tags?page_size=100" \
+          set -eo pipefail
+          # Patch-bump off the highest published vX.Y.Z. curl -fsS fails loudly on
+          # an HTTP/transport error (rate-limit, 5xx) so a bad response can't parse
+          # to empty and silently reset the version to 0.1.1. grep's no-match (the
+          # legit "no versions yet" bootstrap) is tolerated, not the curl failure.
+          LATEST_TAG=$(curl -fsS "https://hub.docker.com/v2/repositories/onyxdotapp/sandbox/tags?page_size=100" \
             | jq -r '.results[].name' \
-            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+            | { grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || true; } \
             | sort -V \
             | tail -n 1)
 

--- a/.github/workflows/sandbox-deployment.yml
+++ b/.github/workflows/sandbox-deployment.yml
@@ -1,18 +1,22 @@
 name: Build and Push Sandbox Image
 
-# The sandbox image is the only Craft-specific image. Build a new version on
-# the nightly tag when its build context changed, or manually on demand.
+# The sandbox image is the only Craft-specific image, versioned on its own line
+# independent of Onyx releases. Publishing is fully manual:
 #
-# To push an ad-hoc dev build:
-#   git tag -f sandbox-dev && git push -f origin sandbox-dev
-# builds unconditionally and pushes onyxdotapp/sandbox:dev. Dev builds never
-# cut a vX.Y.Z version or move :latest — those only happen on the nightly
-# path. Only sandbox-dev is supported, to keep Docker Hub free of one-off tags.
+#   - sandbox-edge tag (or workflow_dispatch): builds + auto-increments
+#     onyxdotapp/sandbox:vX.Y.Z and moves :edge.
+#       git tag -f sandbox-edge && git push -f origin sandbox-edge
+#   - sandbox-dev tag: builds + pushes the mutable onyxdotapp/sandbox:dev.
+#       git tag -f sandbox-dev && git push -f origin sandbox-dev
+#
+# Onyx deployments pin a specific vX.Y.Z (SANDBOX_CONTAINER_IMAGE in configs.py);
+# bumping the pin to adopt a new sandbox is a deliberate, reviewable change (a
+# future `ods release sandbox` command tags this + bumps the pin).
 on:
   push:
     tags:
-      - "nightly-latest-*"
       - "sandbox-dev"
+      - "sandbox-edge"
   workflow_dispatch:
 
 # Restrictive defaults; jobs declare what they need.
@@ -29,6 +33,8 @@ jobs:
       # metadata-action tags input: set by the check step for dev builds,
       # otherwise by the version step.
       image-tags: ${{ steps.check.outputs.image-tags || steps.version.outputs.image-tags }}
+      # Content-hash dedup key (git tree hash of the build context).
+      src-tag: ${{ steps.check.outputs.src-tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
@@ -41,45 +47,42 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
         run: |
-          # Manual runs always build.
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            echo "Manual dispatch: building unconditionally"
-            echo "sandbox-changed=true" >> "$GITHUB_OUTPUT"
+          # sandbox-edge / dispatch cut a new version only when the build context
+          # changed: skip if its content hash (src-<tree-hash>) is already published.
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] || [ "$GITHUB_REF_NAME" = "sandbox-edge" ]; then
+            CONTEXT="backend/onyx/server/features/build/sandbox/image"
+            SRC_TAG="src-$(git rev-parse "HEAD:${CONTEXT}" | cut -c1-16)"
+            echo "src-tag=${SRC_TAG}" >> "$GITHUB_OUTPUT"
+            HTTP=$(curl -sS -o /dev/null -w '%{http_code}' \
+              "https://hub.docker.com/v2/repositories/onyxdotapp/sandbox/tags/${SRC_TAG}" || true)
+            if [ "$HTTP" = "200" ]; then
+              echo "Build context unchanged (${SRC_TAG} already published); no new version"
+              echo "sandbox-changed=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "Build context changed (${SRC_TAG} not found, HTTP ${HTTP}); cutting a new version"
+              echo "sandbox-changed=true" >> "$GITHUB_OUTPUT"
+            fi
             exit 0
           fi
 
-          # The sandbox-dev tag always builds and pushes the :dev image tag.
+          # sandbox-dev always rebuilds the mutable :dev tag (no dedup).
           if [ "$GITHUB_REF_NAME" = "sandbox-dev" ]; then
-            echo "Dev tag: building and pushing :dev"
             echo "image-tags=type=raw,value=dev" >> "$GITHUB_OUTPUT"
             echo "sandbox-changed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # Diff the sandbox image build context against the previous nightly tag.
-          CURRENT_TAG="${GITHUB_REF_NAME}"
-          PREVIOUS_TAG=$(git tag --sort=-creatordate | grep '^nightly-latest-' | grep -v "^${CURRENT_TAG}$" | head -n 1)
-          if [ -z "$PREVIOUS_TAG" ]; then
-            echo "No previous nightly tag; building unconditionally"
-            echo "sandbox-changed=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "Comparing ${PREVIOUS_TAG}..${CURRENT_TAG}"
-          if git diff --name-only "${PREVIOUS_TAG}..${CURRENT_TAG}" -- \
-              "backend/onyx/server/features/build/sandbox/image/" | grep -q .; then
-            echo "Sandbox image changed"
-            echo "sandbox-changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "No sandbox image changes"
-            echo "sandbox-changed=false" >> "$GITHUB_OUTPUT"
-          fi
+          # Unreachable: the branches above cover every trigger.
+          echo "Unexpected event ${EVENT_NAME}/${GITHUB_REF_NAME}; not building"
+          echo "sandbox-changed=false" >> "$GITHUB_OUTPUT"
 
       - name: Determine new sandbox version
         id: version
         if: steps.check.outputs.sandbox-changed == 'true' && steps.check.outputs.image-tags == ''
+        env:
+          SRC_TAG: ${{ steps.check.outputs.src-tag }}
         run: |
-          # Query Docker Hub for the latest versioned tag
+          # Patch-bump off the highest published vX.Y.Z on Docker Hub.
           LATEST_TAG=$(curl -s "https://hub.docker.com/v2/repositories/onyxdotapp/sandbox/tags?page_size=100" \
             | jq -r '.results[].name' \
             | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
@@ -93,7 +96,6 @@ jobs:
             CURRENT_VERSION="${LATEST_TAG#v}"
             echo "Latest version on Docker Hub: $CURRENT_VERSION"
 
-            # Increment patch version
             MAJOR=$(echo "$CURRENT_VERSION" | cut -d. -f1)
             MINOR=$(echo "$CURRENT_VERSION" | cut -d. -f2)
             PATCH=$(echo "$CURRENT_VERSION" | cut -d. -f3)
@@ -102,10 +104,12 @@ jobs:
           fi
 
           echo "New version: $NEW_VERSION"
+          # src-<hash> is published too: it's the dedup key the next run checks.
           {
             echo "image-tags<<EOF"
             echo "type=raw,value=v${NEW_VERSION}"
-            echo "type=raw,value=latest"
+            echo "type=raw,value=edge"
+            echo "type=raw,value=${SRC_TAG}"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
@@ -174,7 +178,7 @@ jobs:
           platforms: linux/amd64
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: |
-            type=registry,ref=${{ env.REGISTRY_IMAGE }}:latest
+            type=registry,ref=${{ env.REGISTRY_IMAGE }}:edge
           cache-to: |
             type=inline
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
@@ -244,7 +248,7 @@ jobs:
           platforms: linux/arm64
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: |
-            type=registry,ref=${{ env.REGISTRY_IMAGE }}:latest
+            type=registry,ref=${{ env.REGISTRY_IMAGE }}:edge
           cache-to: |
             type=inline
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true

--- a/.github/workflows/sandbox-deployment.yml
+++ b/.github/workflows/sandbox-deployment.yml
@@ -53,15 +53,22 @@ jobs:
             CONTEXT="backend/onyx/server/features/build/sandbox/image"
             SRC_TAG="src-$(git rev-parse "HEAD:${CONTEXT}" | cut -c1-16)"
             echo "src-tag=${SRC_TAG}" >> "$GITHUB_OUTPUT"
+            # Only 200 (exists) / 404 (absent) are conclusive. Fail on anything
+            # else (429/5xx/network) so a flaky probe is never misread as
+            # "changed" and never cuts a spurious version.
             HTTP=$(curl -sS -o /dev/null -w '%{http_code}' \
               "https://hub.docker.com/v2/repositories/onyxdotapp/sandbox/tags/${SRC_TAG}" || true)
-            if [ "$HTTP" = "200" ]; then
-              echo "Build context unchanged (${SRC_TAG} already published); no new version"
-              echo "sandbox-changed=false" >> "$GITHUB_OUTPUT"
-            else
-              echo "Build context changed (${SRC_TAG} not found, HTTP ${HTTP}); cutting a new version"
-              echo "sandbox-changed=true" >> "$GITHUB_OUTPUT"
-            fi
+            case "$HTTP" in
+              200)
+                echo "Build context unchanged (${SRC_TAG} already published); no new version"
+                echo "sandbox-changed=false" >> "$GITHUB_OUTPUT" ;;
+              404)
+                echo "Build context changed (${SRC_TAG} not found); cutting a new version"
+                echo "sandbox-changed=true" >> "$GITHUB_OUTPUT" ;;
+              *)
+                echo "::error::Docker Hub tag probe for ${SRC_TAG} returned ${HTTP}; cannot determine whether it exists. Re-run once the transient error clears."
+                exit 1 ;;
+            esac
             exit 0
           fi
 

--- a/backend/onyx/server/features/build/sandbox/image/README.md
+++ b/backend/onyx/server/features/build/sandbox/image/README.md
@@ -57,8 +57,11 @@ docker build --platform linux/amd64 -t onyxdotapp/sandbox:dev .
 kind load docker-image onyxdotapp/sandbox:dev --name onyx-dev
 ```
 
-Run with `SANDBOX_CONTAINER_IMAGE=onyxdotapp/sandbox:dev` and
-`SANDBOX_IMAGE_PULL_POLICY=Always`. (The repo-root `make` targets automate this.)
+Run with `SANDBOX_CONTAINER_IMAGE=onyxdotapp/sandbox:dev` and the **default**
+`SANDBOX_IMAGE_PULL_POLICY=IfNotPresent`, so Kubernetes uses the `kind load`ed
+image instead of pulling the remote `:dev` (matches `.vscode/.env.k8s.template`).
+`Always` is only for pinning a *remote* mutable tag. (The repo-root `make`
+targets automate this.)
 Build for **amd64** to match the cluster nodes; add `linux/arm64` via
 `docker buildx --platform linux/amd64,linux/arm64` if you need both.
 

--- a/backend/onyx/server/features/build/sandbox/image/README.md
+++ b/backend/onyx/server/features/build/sandbox/image/README.md
@@ -25,16 +25,21 @@ and are pushed into sandboxes at session setup, never baked into the image.
 
 ### Via CI (preferred)
 
-Push the `sandbox-dev` git tag to have `.github/workflows/sandbox-deployment.yml`
-build multi-arch and push `onyxdotapp/sandbox:dev`:
+Sandbox images are published **manually** by
+`.github/workflows/sandbox-deployment.yml` — never on nightly or release tags:
 
-```bash
-git tag -f sandbox-dev && git push -f origin sandbox-dev
-```
-
-Dev builds never cut a `vX.Y.Z` version or move `:latest`. The nightly tag
-still cuts an auto-versioned `vX.Y.Z` + `latest` when the image context changed.
-Only `sandbox-dev` is supported, to keep Docker Hub free of one-off tags.
+- **Push the `sandbox-edge` git tag** (or run the workflow via
+  `workflow_dispatch`) to cut a versioned release. It publishes a new
+  `onyxdotapp/sandbox:vX.Y.Z` + `:edge` **only if the build context changed**
+  (fingerprinted by git tree hash); an unchanged context is a no-op:
+  ```bash
+  git tag -f sandbox-edge && git push -f origin sandbox-edge
+  ```
+- **Push the `sandbox-dev` git tag** for an ad-hoc dev build →
+  `onyxdotapp/sandbox:dev`:
+  ```bash
+  git tag -f sandbox-dev && git push -f origin sandbox-dev
+  ```
 
 Environments that pin `SANDBOX_CONTAINER_IMAGE` to `:dev` must also set
 `SANDBOX_IMAGE_PULL_POLICY=Always` (default `IfNotPresent`) so re-pushed dev
@@ -42,62 +47,34 @@ builds are picked up by new pods. See `docs/craft/image-architecture.md`.
 
 ### Building locally
 
-The sandbox image must be built for **amd64** architecture since our Kubernetes cluster runs on x86_64 nodes.
-
-### Build for amd64 only (fastest)
+For local iteration, build and load straight into your kind cluster as `:dev`
+(don't hand-push `vX.Y.Z` / channel tags — the `sandbox-deployment.yml` workflow
+owns those, and a manual push would desync the auto-increment):
 
 ```bash
 cd backend/onyx/server/features/build/sandbox/image
-docker build --platform linux/amd64 -t onyxdotapp/sandbox:v0.1.x .
-docker push onyxdotapp/sandbox:v0.1.x
+docker build --platform linux/amd64 -t onyxdotapp/sandbox:dev .
+kind load docker-image onyxdotapp/sandbox:dev --name onyx-dev
 ```
 
-### Build multi-arch (recommended for flexibility)
-
-```bash
-docker buildx build --platform linux/amd64,linux/arm64 \
-  -t onyxdotapp/sandbox:v0.1.x \
-  --push .
-```
-
-### Update the `latest` tag
-
-After pushing a versioned tag, update `latest`:
-
-```bash
-docker tag onyxdotapp/sandbox:v0.1.x onyxdotapp/sandbox:latest
-docker push onyxdotapp/sandbox:latest
-```
-
-Or with buildx:
-
-```bash
-docker buildx build --platform linux/amd64,linux/arm64 \
-  -t onyxdotapp/sandbox:v0.1.x \
-  -t onyxdotapp/sandbox:latest \
-  --push .
-```
+Run with `SANDBOX_CONTAINER_IMAGE=onyxdotapp/sandbox:dev` and
+`SANDBOX_IMAGE_PULL_POLICY=Always`. (The repo-root `make` targets automate this.)
+Build for **amd64** to match the cluster nodes; add `linux/arm64` via
+`docker buildx --platform linux/amd64,linux/arm64` if you need both.
 
 ## Deploying a New Version
 
-1. **Build and push** the new image (see above)
+1. **Publish** the new sandbox version — push the `sandbox-edge` tag
+   (`git tag -f sandbox-edge && git push -f origin sandbox-edge`), which cuts the
+   next `vX.Y.Z` + `:edge`.
 
-2. **Update the ConfigMap** in in the internal repo
-   ```yaml
-   SANDBOX_CONTAINER_IMAGE: "onyxdotapp/sandbox:v0.1.x"
-   ```
+2. **Bump the pin** — set `SANDBOX_CONTAINER_IMAGE` in `configs.py` (and the
+   `docker-compose.craft.yml` defaults) to the new `vX.Y.Z`. This is the
+   reviewable step that makes an Onyx version adopt the new sandbox; a future
+   `ods release sandbox` command will do steps 1–2 in one shot.
 
-3. **Apply the ConfigMap**:
-   ```bash
-   kubectl apply -f configmap/env-configmap.yaml
-   ```
-
-4. **Restart the API server** to pick up the new config:
-   ```bash
-   kubectl rollout restart deployment/api-server -n danswer
-   ```
-
-5. **Delete existing sandbox pods** (they will be recreated with the new image):
+3. **Roll out** the new config and recreate sandbox pods so they pull the new
+   image:
    ```bash
    kubectl delete pods -n onyx-sandboxes -l app.kubernetes.io/component=sandbox
    ```

--- a/docs/craft/image-architecture.md
+++ b/docs/craft/image-architecture.md
@@ -23,36 +23,39 @@ at runtime (`onyx/server/features/build/configs.py`) to toggle the feature.
 | `onyxdotapp/onyx-model-server` | No | Standard image. |
 | **`onyxdotapp/sandbox`** | **Yes** | The only Craft-specific image. Bundles Node + the `opencode` CLI; runs the agent. |
 
-## How the sandbox image is built
+## How the sandbox image is built & versioned
 
-`.github/workflows/sandbox-deployment.yml` builds it on the **nightly** tag
-(`nightly-latest-*`), but only when its build context
-(`backend/onyx/server/features/build/sandbox/image/`) changed since the
-previous nightly. It publishes `onyxdotapp/sandbox:vX.Y.Z` (auto-incremented
-patch) + `:latest`. Run it manually any time via the workflow's
-`workflow_dispatch` to cut a build on demand.
+The sandbox is an **independently-versioned dependency** of Onyx, published
+**manually** — it is *not* built on nightly or release tags. This keeps the
+lifecycle consistent: a new sandbox version is a deliberate publish, and adopting
+it is a deliberate pin bump (no auto-publish that you then have to manually adopt).
 
-For an ad-hoc dev build, push the `sandbox-dev` git tag:
+`.github/workflows/sandbox-deployment.yml` is the only thing that publishes it:
 
-```bash
-git tag -f sandbox-dev && git push -f origin sandbox-dev
-```
+- **`sandbox-edge` git tag** (or `workflow_dispatch`) → **if the build context
+  changed**, auto-increments the patch off the highest published tag and pushes
+  `onyxdotapp/sandbox:vX.Y.Z` + `:edge` (+ a `src-<hash>` dedup tag). The context
+  is fingerprinted by its git tree hash, so pushing the tag with no change is a
+  no-op — no new version:
+  ```bash
+  git tag -f sandbox-edge && git push -f origin sandbox-edge
+  ```
+- **`sandbox-dev` git tag** → builds and pushes the mutable `onyxdotapp/sandbox:dev`:
+  ```bash
+  git tag -f sandbox-dev && git push -f origin sandbox-dev
+  ```
 
-This builds unconditionally and pushes `onyxdotapp/sandbox:dev`. Dev builds
-never cut a `vX.Y.Z` version or move `:latest` — those only happen on the
-nightly path. Only `sandbox-dev` is supported, to keep Docker Hub free of
-one-off tags.
+**Onyx pins the sandbox version it requires** via `SANDBOX_CONTAINER_IMAGE`
+(default in `configs.py`, a specific `onyxdotapp/sandbox:vX.Y.Z`). The pin is
+committed, so each Onyx version reproducibly resolves its sandbox. Bumping the
+pin to adopt a newer sandbox is a deliberate, reviewable change — a future
+`ods release sandbox` command will dispatch the publish workflow and bump the
+pin in one step.
 
-Sandbox pods default to `imagePullPolicy: IfNotPresent`, which would keep
-serving a node-cached `:dev` after a re-push. Environments that pin the
-mutable `:dev` tag must also set `SANDBOX_IMAGE_PULL_POLICY=Always` (next to
-`SANDBOX_CONTAINER_IMAGE` in the env config) so new pods always pull the
-latest dev build. Already running sandbox pods are unaffected — delete them
-to pick up the new image.
-
-The backend does **not** track `:latest` — it pins a specific version via
-`SANDBOX_CONTAINER_IMAGE` (default in `configs.py`). Bump that pin to adopt a
-new sandbox version.
+Immutable `:vX.Y.Z` pins are safe with the default `imagePullPolicy: IfNotPresent`.
+Environments pinning a mutable tag (`:dev`, `:edge`) must set
+`SANDBOX_IMAGE_PULL_POLICY=Always` and delete running sandbox pods to pick up a
+re-push.
 
 ## Deploying Craft
 


### PR DESCRIPTION
## Description

Makes the Craft sandbox image (`onyxdotapp/sandbox`) a cleanly **manual, independently-versioned dependency**, instead of being auto-bumped on the nightly tag while deployments manually pin it (the old auto-publish + manual-consume mismatch).

- **No more nightly/release auto-bumps** — the sandbox leaves the release pipeline.
- **Publish on demand via the `sandbox-edge` tag** (or `workflow_dispatch`): auto-increments `vX.Y.Z` and moves `:edge`, **only when the build context changed**. Change is detected by the git tree hash of `backend/onyx/server/features/build/sandbox/image/` (published as a `src-<hash>` dedup tag); pushing the tag with no change is a no-op.
- **`sandbox-dev` tag** still publishes the mutable `:dev` (no dedup), for ad-hoc dev.
- Channels publish `:edge` instead of `:latest`.

Deployments keep pinning a specific `vX.Y.Z` via `SANDBOX_CONTAINER_IMAGE` (`configs.py`); bumping the pin to adopt a new sandbox stays a deliberate, reviewable change. A follow-up `ods release sandbox` command will fold "tag a new version + bump the pin" into one step.

No runtime/behavior change to Onyx itself — the pin default is untouched, so existing deployments resolve the same sandbox version as before. Docs updated (`image-architecture.md`, sandbox image `README.md`).

## How Has This Been Tested?

CI-config-only change. Verified `sandbox-deployment.yml` parses and passes `actionlint`/`zizmor`/YAML checks. The publish path itself (auto-increment, content-hash dedup, `:dev` vs `:edge`/`vX.Y.Z`) is exercised by pushing the `sandbox-edge` / `sandbox-dev` tags after merge (`workflow_dispatch` needs the workflow on the default branch).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Craft sandbox image (`onyxdotapp/sandbox`) manual and tag-driven, independent of Onyx releases. Also hardens CI so version bumps are safe and dedup is accurate.

- **Refactors**
  - Removed nightly auto-publish; use `sandbox-edge` or `workflow_dispatch` to publish.
  - Auto patch-bumps only when the build context changed (content-hash `src-<hash>`); unchanged pushes are no-ops.
  - Switched channel tag from `:latest` to `:edge` (build cache reads from `:edge`); docs updated for pinning `vX.Y.Z` via `SANDBOX_CONTAINER_IMAGE` and local kind flow (`IfNotPresent` for `:dev`).

- **Bug Fixes**
  - Dedup probe now errors on non-200/404 Docker Hub responses to avoid accidental version cuts.
  - Hardened version lookup and dedup key: use `curl -fsS` with `set -eo pipefail` to fail loudly on API errors, and exclude `README.md` from the hash so docs-only edits don't cut a new version.

<sup>Written for commit 1c9f9e4698914471212175ccd2d0bf4176aa5234. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

