### PR TITLE
fix(chat): disable model selector when there are no models to select

### DIFF
--- a/web/src/lib/languageModels/hooks.ts
+++ b/web/src/lib/languageModels/hooks.ts
@@ -4,6 +4,7 @@ import { useCallback, useMemo } from "react";
 import useSWR from "swr";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import { SWR_KEYS } from "@/lib/swr-keys";
+import { useCurrentAgent } from "@/lib/agents/hooks";
 import {
   LLMProviderDescriptor,
   LLMProviderName,
@@ -139,6 +140,17 @@ export function useLLMProviders(agentId?: number) {
       LLMProviderResponse<LLMProviderDescriptor> | undefined
     >,
   };
+}
+
+/**
+ * Resolves the active agent via `useCurrentAgent` and fetches that agent's
+ * LLM providers via `useLLMProviders`. User-facing model UIs (chat model
+ * selectors, popovers) consistently need exactly this pairing, so this hook
+ * keeps the resolution in one place instead of repeating it at each call site.
+ */
+export function useCurrentAgentLLMProviders() {
+  const currentAgent = useCurrentAgent();
+  return useLLMProviders(currentAgent?.id);
 }
 
 /**

--- a/web/src/sections/model-selector/ModelSelector.tsx
+++ b/web/src/sections/model-selector/ModelSelector.tsx
@@ -15,8 +15,7 @@ import {
   LLMOption,
 } from "@/lib/languageModels/options";
 import { useUser } from "@/providers/UserProvider";
-import { useCurrentAgent } from "@/lib/agents/hooks";
-import { useLLMProviders } from "@/lib/languageModels/hooks";
+import { useCurrentAgentLLMProviders } from "@/lib/languageModels/hooks";
 import ModelSelectorContent from "@/sections/model-selector/ModelSelectorContent";
 
 interface TemperatureManager {
@@ -64,8 +63,7 @@ export default function ModelSelector({
   includeGlobalDefault = false,
   side = "top",
 }: ModelSelectorProps) {
-  const currentAgent = useCurrentAgent();
-  const { llmProviders, defaultText } = useLLMProviders(currentAgent?.id);
+  const { llmProviders, defaultText } = useCurrentAgentLLMProviders();
   const [open, setOpen] = useState(false);
   const { user } = useUser();
   const scrollContainerRef = useRef<HTMLDivElement>(null);

--- a/web/src/sections/model-selector/ModelSelectorContent.tsx
+++ b/web/src/sections/model-selector/ModelSelectorContent.tsx
@@ -18,8 +18,7 @@ import {
   buildLlmOptions,
   groupLlmOptions,
 } from "@/lib/languageModels/options";
-import { useCurrentAgent } from "@/lib/agents/hooks";
-import { useLLMProviders } from "@/lib/languageModels/hooks";
+import { useCurrentAgentLLMProviders } from "@/lib/languageModels/hooks";
 import {
   Collapsible,
   CollapsibleContent,
@@ -48,10 +47,8 @@ export default function ModelSelectorContent({
   includeGlobalDefault = false,
   footer,
 }: ModelSelectorContentProps) {
-  const currentAgent = useCurrentAgent();
-  const { llmProviders, isLoading, defaultText } = useLLMProviders(
-    currentAgent?.id
-  );
+  const { llmProviders, isLoading, defaultText } =
+    useCurrentAgentLLMProviders();
 
   const globalDefaultDisplayName = useMemo(() => {
     if (!defaultText || !llmProviders) return null;

--- a/web/src/sections/model-selector/MultiModelSelector.tsx
+++ b/web/src/sections/model-selector/MultiModelSelector.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import "@opal/core/disabled/styles.css";
 import { useState, useMemo, useRef } from "react";
 import { getModelIcon } from "@/lib/languageModels";
 import {
@@ -11,6 +10,7 @@ import {
   Tooltip,
 } from "@opal/components";
 import { SvgPlusCircle, SvgX } from "@opal/icons";
+import { cn } from "@opal/utils";
 import { useSettingsContext } from "@/providers/SettingsProvider";
 import { LLMOption, buildLlmOptions } from "@/lib/languageModels/options";
 import { useCurrentAgent } from "@/lib/agents/hooks";
@@ -62,6 +62,15 @@ export default function MultiModelSelector({
 
   const isMultiModel = selectedModels.length > 1;
   const atMax = selectedModels.length >= MAX_MODELS || !multiModelAllowed;
+
+  // Single tooltip for the whole selector. The disabled reason takes
+  // precedence; otherwise it labels the add affordance. When at max there is
+  // no add action, so the tooltip is omitted.
+  const selectorTooltip = noModelsToSelect
+    ? "No models currently configured"
+    : atMax
+      ? undefined
+      : "Add Model";
 
   const selectedKeys = useMemo(
     () => new Set(selectedModels.map((m) => modelKey(m.provider, m.modelName))),
@@ -141,29 +150,25 @@ export default function MultiModelSelector({
   return (
     <Popover open={open} onOpenChange={handleOpenChange}>
       {/*
-        `data-opal-disabled` greys out the selector and blocks pointer events on
-        its children while leaving the container itself hoverable, so the
-        Tooltip can still surface its message. The Tooltip wrapper is a no-op
-        (children returned as-is) whenever `tooltip` is undefined.
+        When disabled, pointer events are blocked on the children (so the add
+        button / pills are inert) while the container itself stays hoverable, so
+        the Tooltip can still surface its message even in the disabled state.
       */}
-      <Tooltip
-        tooltip={
-          noModelsToSelect ? "No models currently configured" : undefined
-        }
-        side="top"
-      >
+      <Tooltip tooltip={selectorTooltip} side="top">
         <div
           data-testid="model-selector"
           aria-disabled={noModelsToSelect || undefined}
-          data-opal-disabled={noModelsToSelect || undefined}
-          className="flex items-center justify-end gap-1 p-1"
+          className={cn(
+            "flex items-center justify-end gap-1 p-1",
+            noModelsToSelect &&
+              "cursor-not-allowed select-none opacity-50 [&>*]:pointer-events-none"
+          )}
         >
           {!atMax && (
             <Button
               prominence="tertiary"
               icon={SvgPlusCircle}
               size="sm"
-              tooltip="Add Model"
               onClick={(e: React.MouseEvent) => {
                 anchorRef.current = e.currentTarget as HTMLElement;
                 setReplacingIndex(null);

--- a/web/src/sections/model-selector/MultiModelSelector.tsx
+++ b/web/src/sections/model-selector/MultiModelSelector.tsx
@@ -4,8 +4,11 @@ import { useState, useMemo, useRef } from "react";
 import { getModelIcon } from "@/lib/languageModels";
 import { Button, SelectButton, Popover, Divider } from "@opal/components";
 import { SvgPlusCircle, SvgX } from "@opal/icons";
+import { cn } from "@opal/utils";
 import { useSettingsContext } from "@/providers/SettingsProvider";
-import { LLMOption } from "@/lib/languageModels/options";
+import { LLMOption, buildLlmOptions } from "@/lib/languageModels/options";
+import { useCurrentAgent } from "@/lib/agents/hooks";
+import { useLLMProviders } from "@/lib/languageModels/hooks";
 import ModelSelectorContent from "@/sections/model-selector/ModelSelectorContent";
 
 export const MAX_MODELS = 3;
@@ -41,6 +44,15 @@ export default function MultiModelSelector({
   const settings = useSettingsContext();
   const multiModelAllowed =
     settings?.settings?.multi_model_chat_enabled ?? true;
+
+  // Mirror the data source used by `ModelSelectorContent` so the selector is
+  // disabled precisely when the popover would render "No models found".
+  const currentAgent = useCurrentAgent();
+  const { llmProviders, isLoading } = useLLMProviders(currentAgent?.id);
+  const noModelsToSelect = useMemo(
+    () => !isLoading && buildLlmOptions(llmProviders).length === 0,
+    [isLoading, llmProviders]
+  );
 
   const isMultiModel = selectedModels.length > 1;
   const atMax = selectedModels.length >= MAX_MODELS || !multiModelAllowed;
@@ -109,6 +121,7 @@ export default function MultiModelSelector({
   };
 
   const handleOpenChange = (nextOpen: boolean) => {
+    if (nextOpen && noModelsToSelect) return;
     setOpen(nextOpen);
     if (!nextOpen) setReplacingIndex(null);
   };
@@ -123,7 +136,11 @@ export default function MultiModelSelector({
     <Popover open={open} onOpenChange={handleOpenChange}>
       <div
         data-testid="model-selector"
-        className="flex items-center justify-end gap-1 p-1"
+        aria-disabled={noModelsToSelect || undefined}
+        className={cn(
+          "flex items-center justify-end gap-1 p-1",
+          noModelsToSelect && "pointer-events-none opacity-50"
+        )}
       >
         {!atMax && (
           <Button

--- a/web/src/sections/model-selector/MultiModelSelector.tsx
+++ b/web/src/sections/model-selector/MultiModelSelector.tsx
@@ -13,8 +13,7 @@ import { SvgPlusCircle, SvgX } from "@opal/icons";
 import { cn } from "@opal/utils";
 import { useSettingsContext } from "@/providers/SettingsProvider";
 import { LLMOption, buildLlmOptions } from "@/lib/languageModels/options";
-import { useCurrentAgent } from "@/lib/agents/hooks";
-import { useLLMProviders } from "@/lib/languageModels/hooks";
+import { useCurrentAgentLLMProviders } from "@/lib/languageModels/hooks";
 import ModelSelectorContent from "@/sections/model-selector/ModelSelectorContent";
 
 export const MAX_MODELS = 3;
@@ -53,8 +52,7 @@ export default function MultiModelSelector({
 
   // Mirror the data source used by `ModelSelectorContent` so the selector is
   // disabled precisely when the popover would render "No models found".
-  const currentAgent = useCurrentAgent();
-  const { llmProviders, isLoading } = useLLMProviders(currentAgent?.id);
+  const { llmProviders, isLoading } = useCurrentAgentLLMProviders();
   const noModelsToSelect = useMemo(
     () => !isLoading && buildLlmOptions(llmProviders).length === 0,
     [isLoading, llmProviders]
@@ -142,6 +140,8 @@ export default function MultiModelSelector({
   };
 
   const handlePillClick = (index: number, element: HTMLElement) => {
+    // `pointer-events-none` only blocks the mouse; guard the keyboard path too.
+    if (noModelsToSelect) return;
     anchorRef.current = element;
     setReplacingIndex(index);
     setOpen(true);
@@ -170,6 +170,7 @@ export default function MultiModelSelector({
               icon={SvgPlusCircle}
               size="sm"
               onClick={(e: React.MouseEvent) => {
+                if (noModelsToSelect) return;
                 anchorRef.current = e.currentTarget as HTMLElement;
                 setReplacingIndex(null);
                 setOpen(true);

--- a/web/src/sections/model-selector/MultiModelSelector.tsx
+++ b/web/src/sections/model-selector/MultiModelSelector.tsx
@@ -1,10 +1,16 @@
 "use client";
 
+import "@opal/core/disabled/styles.css";
 import { useState, useMemo, useRef } from "react";
 import { getModelIcon } from "@/lib/languageModels";
-import { Button, SelectButton, Popover, Divider } from "@opal/components";
+import {
+  Button,
+  SelectButton,
+  Popover,
+  Divider,
+  Tooltip,
+} from "@opal/components";
 import { SvgPlusCircle, SvgX } from "@opal/icons";
-import { cn } from "@opal/utils";
 import { useSettingsContext } from "@/providers/SettingsProvider";
 import { LLMOption, buildLlmOptions } from "@/lib/languageModels/options";
 import { useCurrentAgent } from "@/lib/agents/hooks";
@@ -134,94 +140,108 @@ export default function MultiModelSelector({
 
   return (
     <Popover open={open} onOpenChange={handleOpenChange}>
-      <div
-        data-testid="model-selector"
-        aria-disabled={noModelsToSelect || undefined}
-        className={cn(
-          "flex items-center justify-end gap-1 p-1",
-          noModelsToSelect && "pointer-events-none opacity-50"
-        )}
+      {/*
+        `data-opal-disabled` greys out the selector and blocks pointer events on
+        its children while leaving the container itself hoverable, so the
+        Tooltip can still surface its message. The Tooltip wrapper is a no-op
+        (children returned as-is) whenever `tooltip` is undefined.
+      */}
+      <Tooltip
+        tooltip={
+          noModelsToSelect ? "No models currently configured" : undefined
+        }
+        side="top"
       >
-        {!atMax && (
-          <Button
-            prominence="tertiary"
-            icon={SvgPlusCircle}
-            size="sm"
-            tooltip="Add Model"
-            onClick={(e: React.MouseEvent) => {
-              anchorRef.current = e.currentTarget as HTMLElement;
-              setReplacingIndex(null);
-              setOpen(true);
-            }}
+        <div
+          data-testid="model-selector"
+          aria-disabled={noModelsToSelect || undefined}
+          data-opal-disabled={noModelsToSelect || undefined}
+          className="flex items-center justify-end gap-1 p-1"
+        >
+          {!atMax && (
+            <Button
+              prominence="tertiary"
+              icon={SvgPlusCircle}
+              size="sm"
+              tooltip="Add Model"
+              onClick={(e: React.MouseEvent) => {
+                anchorRef.current = e.currentTarget as HTMLElement;
+                setReplacingIndex(null);
+                setOpen(true);
+              }}
+            />
+          )}
+
+          <Popover.Anchor
+            virtualRef={anchorRef as React.RefObject<HTMLElement>}
           />
-        )}
+          {selectedModels.length > 0 && (
+            <>
+              {!atMax && (
+                <Divider
+                  orientation="vertical"
+                  paddingParallel="sm"
+                  paddingPerpendicular="sm"
+                />
+              )}
+              <div className="flex items-center shrink-0">
+                {selectedModels.map((model, index) => {
+                  const ProviderIcon = getModelIcon(
+                    model.provider,
+                    model.modelName
+                  );
 
-        <Popover.Anchor
-          virtualRef={anchorRef as React.RefObject<HTMLElement>}
-        />
-        {selectedModels.length > 0 && (
-          <>
-            {!atMax && (
-              <Divider
-                orientation="vertical"
-                paddingParallel="sm"
-                paddingPerpendicular="sm"
-              />
-            )}
-            <div className="flex items-center shrink-0">
-              {selectedModels.map((model, index) => {
-                const ProviderIcon = getModelIcon(
-                  model.provider,
-                  model.modelName
-                );
-
-                return (
-                  <div
-                    key={
-                      isMultiModel
-                        ? modelKey(model.provider, model.modelName)
-                        : "single-model-pill"
-                    }
-                    className="flex items-center"
-                  >
-                    {index > 0 && (
-                      <Divider
-                        orientation="vertical"
-                        paddingParallel="sm"
-                        paddingPerpendicular="sm"
-                      />
-                    )}
-                    <SelectButton
-                      icon={ProviderIcon}
-                      rightIcon={isMultiModel ? SvgX : undefined}
-                      state="empty"
-                      variant="select-input"
-                      size="lg"
-                      onClick={(e: React.MouseEvent) => {
-                        if (isMultiModel) {
-                          const target = e.target as HTMLElement;
-                          const btn = e.currentTarget as HTMLElement;
-                          const icons = btn.querySelectorAll(
-                            ".interactive-foreground-icon"
-                          );
-                          const lastIcon = icons[icons.length - 1];
-                          if (lastIcon && lastIcon.contains(target)) {
-                            onRemove(index);
-                            return;
-                          }
-                        }
-                        handlePillClick(index, e.currentTarget as HTMLElement);
-                      }}
+                  return (
+                    <div
+                      key={
+                        isMultiModel
+                          ? modelKey(model.provider, model.modelName)
+                          : "single-model-pill"
+                      }
+                      className="flex items-center"
                     >
-                      {model.displayName}
-                    </SelectButton>
-                  </div>
-                );
-              })}
-            </div>
-          </>
-        )}
-      </div>
+                      {index > 0 && (
+                        <Divider
+                          orientation="vertical"
+                          paddingParallel="sm"
+                          paddingPerpendicular="sm"
+                        />
+                      )}
+                      <SelectButton
+                        icon={ProviderIcon}
+                        rightIcon={isMultiModel ? SvgX : undefined}
+                        state="empty"
+                        variant="select-input"
+                        size="lg"
+                        onClick={(e: React.MouseEvent) => {
+                          if (isMultiModel) {
+                            const target = e.target as HTMLElement;
+                            const btn = e.currentTarget as HTMLElement;
+                            const icons = btn.querySelectorAll(
+                              ".interactive-foreground-icon"
+                            );
+                            const lastIcon = icons[icons.length - 1];
+                            if (lastIcon && lastIcon.contains(target)) {
+                              onRemove(index);
+                              return;
+                            }
+                          }
+                          handlePillClick(
+                            index,
+                            e.currentTarget as HTMLElement
+                          );
+                        }}
+                      >
+                        {model.displayName}
+                      </SelectButton>
+                    </div>
+                  );
+                })}
+              </div>
+            </>
+          )}
+        </div>
+      </Tooltip>
 
       {!(atMax && replacingIndex === null) && (
         <Popover.Content side="top" align="end" width="xl">


### PR DESCRIPTION

<img width="2862" height="2085" alt="20260616_14h16m19s_grim" src="https://github.com/user-attachments/assets/1c47d700-fcc5-45de-9721-b28274cb230e" />


## Description

Disables the chat model selector (`data-testid="model-selector"`) when there are no models available to choose from.

`MultiModelSelector` now derives whether any selectable models exist using the **same data source as the popover content** (`ModelSelectorContent`): `useCurrentAgent()` + `useLLMProviders(currentAgent?.id)` fed through `buildLlmOptions(...)`. So the selector disables in precisely the cases where opening the popover would otherwise show *"No models found"*. The SWR call dedupes against the popover's identical request (same key, 60s deduping), so there's no extra network cost.

When no models are selectable:
- the container is greyed out (`opacity-50`), marked `aria-disabled`, and made non-interactive (`pointer-events-none`), so the add button and model pills can't be clicked;
- `handleOpenChange` also guards against the popover opening, as defense-in-depth.

The selector stays **enabled while providers are still loading** (`!isLoading` guard) to avoid a flash of the disabled state.

Implementation note: I applied the disabled utilities directly rather than wrapping in Opal's `<Disabled>` component on purpose — `<Disabled>` always renders an extra `self-stretch` wrapper div, which would shift the selector's bottom-alignment in the welcome-screen row (`alignItems="end"`). The direct utilities match exactly what Opal's disabled styling uses while avoiding that layout regression.

## How Has This Been Tested?

- `tsc --noEmit` passes; `oxfmt` and `oxlint` clean on the changed file.
- Manual reasoning against the popover's empty-state logic (the disable condition mirrors the popover's `groupedOptions.length === 0` / "No models found" path).

No automated test added: exercising this requires a deployment with zero configured LLM providers, which is awkward to stand up, and per the repo's "don't overtest" guidance this is a small UI-state change. Happy to add a Playwright test that stubs `/api/llm/provider` (and the per-agent variant) to return an empty list and asserts the selector is `aria-disabled` if desired.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable the chat model selector when no models are available, matching the popover’s “No models found” state. Adds a tooltip and guards to block both mouse and keyboard activation, while keeping the selector enabled during provider loading.

- **Bug Fixes**
  - Prevent opening the popover and activating pills/add via early-return guards; the container stays hoverable to show “No models currently configured”.

- **Refactors**
  - Introduced `useCurrentAgentLLMProviders()` and adopted it in `MultiModelSelector`, `ModelSelector`, and `ModelSelectorContent`. Replaced `data-opal-disabled` with `aria-disabled` + `[&>*]:pointer-events-none`, and consolidated to a single container tooltip (“No models currently configured” or “Add Model”).

<sup>Written for commit df61510864d8dee7671039f0a64137b8308ab076. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



