### PR TITLE
fix(craft): run docker workspace execs as sandbox user (#12116) to release v4.1

### DIFF
--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -106,6 +106,7 @@ from onyx.server.features.build.sandbox.docker.dev_mode_serve import (
     published_opencode_serve_base_url,
 )
 from onyx.server.features.build.sandbox.docker.internal.exec_helpers import ExecError
+from onyx.server.features.build.sandbox.docker.internal.exec_helpers import ExecResult
 from onyx.server.features.build.sandbox.docker.internal.exec_helpers import (
     run_in_container,
 )
@@ -149,6 +150,10 @@ WORKSPACE_ROOT = "/workspace"
 SESSIONS_ROOT = f"{WORKSPACE_ROOT}/sessions"
 TEMPLATES_OUTPUTS_PATH = f"{WORKSPACE_ROOT}/templates/outputs"
 MANAGED_SKILLS_PATH = f"{WORKSPACE_ROOT}/managed/skills"
+SANDBOX_EXEC_USER = "1000:1000"
+# Docker exec bypasses firewall-init.sh's setpriv environment workaround, so
+# sandbox-user execs must carry the uid/gid and user HOME together.
+SANDBOX_EXEC_ENV = {"HOME": "/home/sandbox", "USER": "sandbox"}
 
 # Mirror the K8s constants in ``kubernetes_sandbox_manager`` (POD_READY_*),
 # which are also module-level and not env-tunable.
@@ -170,6 +175,57 @@ _PROXY_CA_BUNDLE_FILE = f"{_PROXY_CA_BUNDLE_DIR}/ca-bundle.crt"
 # Registered in the opencode config only when the proxy is wired up; otherwise
 # it would no-op (no HTTP(S)_PROXY to re-tag).
 _OPENCODE_SESSION_TAG_PLUGIN_PATH = "/workspace/opencode-plugins/session-proxy-tag.ts"
+
+
+def _run_in_container_as_sandbox_user(
+    container: Container,
+    command: list[str] | str,
+    *,
+    workdir: str | None = None,
+    check: bool = True,
+) -> ExecResult:
+    return run_in_container(
+        container,
+        command,
+        user=SANDBOX_EXEC_USER,
+        workdir=workdir,
+        environment=SANDBOX_EXEC_ENV,
+        check=check,
+    )
+
+
+def _stream_stdin_to_container_as_sandbox_user(
+    container: Container,
+    command: list[str],
+    payload: bytes,
+    *,
+    workdir: str | None = None,
+) -> ExecResult:
+    return stream_stdin_to_container(
+        container,
+        command,
+        payload,
+        user=SANDBOX_EXEC_USER,
+        workdir=workdir,
+        environment=SANDBOX_EXEC_ENV,
+    )
+
+
+def _stream_stdout_from_container_as_sandbox_user(
+    container: Container,
+    command: list[str],
+    *,
+    workdir: str | None = None,
+    chunk_size: int = 64 * 1024,
+) -> Generator[bytes, None, int]:
+    return stream_stdout_from_container(
+        container,
+        command,
+        user=SANDBOX_EXEC_USER,
+        workdir=workdir,
+        environment=SANDBOX_EXEC_ENV,
+        chunk_size=chunk_size,
+    )
 
 
 def _build_nextjs_start_script(
@@ -983,7 +1039,14 @@ echo "Session workspace setup complete"
             "Setting up session workspace %s in sandbox %s.", session_id, sandbox_id
         )
         try:
-            run_in_container(container, ["/bin/sh", "-c", setup_script])
+            # user="1000:1000": container's User spec is "0:0" (proxy init needs
+            # root for iptables), so docker exec defaults to root. Without
+            # CAP_DAC_OVERRIDE (cap_drop=ALL), root cannot write to
+            # /workspace/sessions which is owned by sandbox=1000. Exec as
+            # sandbox so the script's mkdir/cp on the session workspace succeed.
+            _run_in_container_as_sandbox_user(
+                container, ["/bin/sh", "-c", setup_script]
+            )
         except ExecError as e:
             raise RuntimeError(
                 f"Failed to setup session workspace {session_id}: {e}"
@@ -1016,7 +1079,10 @@ rm -rf {session_path}
 echo "Session cleanup complete"
 """
         try:
-            run_in_container(container, ["/bin/sh", "-c", cleanup_script])
+            _run_in_container_as_sandbox_user(
+                container,
+                ["/bin/sh", "-c", cleanup_script],
+            )
         except ExecError as e:
             logger.warning(
                 "cleanup_session_workspace exec failed for session %s: %s",
@@ -1034,7 +1100,7 @@ echo "Session cleanup complete"
             return False
         target = f"{SESSIONS_ROOT}/{session_id}/outputs"
         try:
-            result = run_in_container(
+            result = _run_in_container_as_sandbox_user(
                 container,
                 [
                     "/bin/sh",
@@ -1057,7 +1123,7 @@ echo "Session cleanup complete"
         if container is None:
             return []
         try:
-            result = run_in_container(
+            result = _run_in_container_as_sandbox_user(
                 container,
                 ["/bin/sh", "-c", f"ls -1 {SESSIONS_ROOT}/ 2>/dev/null || true"],
                 check=False,
@@ -1094,7 +1160,7 @@ echo "Session cleanup complete"
         session_path = f"{SESSIONS_ROOT}/{session_id}"
         # Bail out if there's nothing worth snapshotting.
         try:
-            probe = run_in_container(
+            probe = _run_in_container_as_sandbox_user(
                 container,
                 [
                     "/bin/sh",
@@ -1120,7 +1186,7 @@ echo "Session cleanup complete"
             ),
         ]
 
-        stream = stream_stdout_from_container(container, tar_cmd)
+        stream = _stream_stdout_from_container_as_sandbox_user(container, tar_cmd)
         adapter = _GeneratorReader(stream)
         try:
             # ``_GeneratorReader`` satisfies the structural ``read(n)`` API that
@@ -1159,7 +1225,7 @@ echo "Session cleanup complete"
 
         # Make sure the session directory exists before we extract into it.
         try:
-            run_in_container(
+            _run_in_container_as_sandbox_user(
                 container,
                 ["/bin/sh", "-c", f"mkdir -p {session_path}"],
             )
@@ -1174,7 +1240,7 @@ echo "Session cleanup complete"
         payload = buf.getvalue()
 
         try:
-            stream_stdin_to_container(
+            _stream_stdin_to_container_as_sandbox_user(
                 container,
                 [
                     "/bin/sh",
@@ -1206,7 +1272,10 @@ if [ -f "$web_dir/bun.lock" ]; then
 fi
 """
         try:
-            run_in_container(container, ["/bin/sh", "-c", install_script])
+            _run_in_container_as_sandbox_user(
+                container,
+                ["/bin/sh", "-c", install_script],
+            )
         except ExecError as e:
             raise RuntimeError(f"Failed to reinstall deps after restore: {e}") from e
 
@@ -1223,7 +1292,10 @@ fi
                 session_path, nextjs_port, check_node_modules=True
             )
             try:
-                run_in_container(container, ["/bin/sh", "-c", start_script])
+                _run_in_container_as_sandbox_user(
+                    container,
+                    ["/bin/sh", "-c", start_script],
+                )
             except ExecError as e:
                 raise RuntimeError(f"Failed to start Next.js after restore: {e}") from e
 
@@ -1253,7 +1325,10 @@ ln -sfn {MANAGED_SKILLS_PATH} {session_path}/.opencode/skills
 printf '%s' '{agents_md}' > {session_path}/AGENTS.md
 """
         try:
-            run_in_container(container, ["/bin/sh", "-c", script])
+            _run_in_container_as_sandbox_user(
+                container,
+                ["/bin/sh", "-c", script],
+            )
         except ExecError as e:
             raise RuntimeError(f"Failed to regenerate session config: {e}") from e
 
@@ -1301,7 +1376,7 @@ printf '%s' '{agents_md}' > {session_path}/AGENTS.md
         quoted = shlex.quote(target_path)
 
         try:
-            result = run_in_container(
+            result = _run_in_container_as_sandbox_user(
                 container,
                 [
                     "/bin/sh",
@@ -1368,7 +1443,7 @@ printf '%s' '{agents_md}' > {session_path}/AGENTS.md
         quoted = shlex.quote(target_path)
 
         try:
-            result = run_in_container(
+            result = _run_in_container_as_sandbox_user(
                 container,
                 [
                     "/bin/sh",
@@ -1432,8 +1507,10 @@ chmod 644 "$target_dir/$base"
 echo "$base"
 """
         try:
-            result = stream_stdin_to_container(
-                container, ["/bin/sh", "-c", script], tar_data
+            result = _stream_stdin_to_container_as_sandbox_user(
+                container,
+                ["/bin/sh", "-c", script],
+                tar_data,
             )
         except ExecError as e:
             raise RuntimeError(f"Failed to upload file: {e}") from e
@@ -1482,7 +1559,11 @@ else
 fi
 """
         try:
-            run_in_container(container, ["/bin/sh", "-c", script], check=False)
+            _run_in_container_as_sandbox_user(
+                container,
+                ["/bin/sh", "-c", script],
+                check=False,
+            )
         except ExecError as e:
             logger.warning("AGENTS.md attachments section update failed: %s", e)
 
@@ -1497,7 +1578,7 @@ fi
         clean_path = path.lstrip("/")
         target = f"{SESSIONS_ROOT}/{session_id}/{clean_path}"
         try:
-            result = run_in_container(
+            result = _run_in_container_as_sandbox_user(
                 container,
                 [
                     "/bin/sh",
@@ -1534,7 +1615,10 @@ mkdir -p {safe_dir}
 printf '%s' '{escaped}' > {safe_path}
 echo WRITE_OK"""
         try:
-            result = run_in_container(container, ["/bin/sh", "-c", script])
+            result = _run_in_container_as_sandbox_user(
+                container,
+                ["/bin/sh", "-c", script],
+            )
         except ExecError as e:
             raise RuntimeError(f"Failed to write sandbox file {path}: {e}") from e
         if "WRITE_OK" not in result.stdout_text:
@@ -1561,7 +1645,11 @@ echo WRITE_OK"""
             f"fi"
         )
         try:
-            result = run_in_container(container, ["/bin/sh", "-c", cmd], check=False)
+            result = _run_in_container_as_sandbox_user(
+                container,
+                ["/bin/sh", "-c", cmd],
+                check=False,
+            )
         except ExecError as e:
             logger.warning("get_upload_stats failed: %s", e)
             return 0, 0
@@ -1628,7 +1716,11 @@ echo WRITE_OK"""
             f"trap - EXIT\n"
         )
         try:
-            stream_stdin_to_container(container, ["/bin/sh", "-c", script], tar_bytes)
+            _stream_stdin_to_container_as_sandbox_user(
+                container,
+                ["/bin/sh", "-c", script],
+                tar_bytes,
+            )
         except ExecError as e:
             raise RuntimeError(f"write_files_to_sandbox failed: {e}") from e
 
@@ -1660,7 +1752,7 @@ echo WRITE_OK"""
         cache_abs = f"{session_root}/{clean_cache}"
 
         try:
-            result = run_in_container(
+            result = _run_in_container_as_sandbox_user(
                 container,
                 [
                     "python",

--- a/backend/onyx/server/features/build/sandbox/docker/internal/exec_helpers.py
+++ b/backend/onyx/server/features/build/sandbox/docker/internal/exec_helpers.py
@@ -140,6 +140,7 @@ def _open_exec_socket(
     stdin: bool,
     user: str | None,
     workdir: str | None,
+    environment: dict[str, str] | None,
 ) -> Iterator[tuple[str, socket.socket]]:
     """Create + start a docker exec and yield ``(exec_id, raw_socket)``.
 
@@ -159,6 +160,7 @@ def _open_exec_socket(
             tty=False,
             user=user or "",
             workdir=workdir,
+            environment=environment,
         )["Id"]
         sock = api.exec_start(exec_id, socket=True, demux=False)
     except (APIError, NotFound) as e:
@@ -202,13 +204,19 @@ def stream_stdin_to_container(
     *,
     user: str | None = None,
     workdir: str | None = None,
+    environment: dict[str, str] | None = None,
 ) -> ExecResult:
     """Run ``command`` inside ``container`` and feed ``payload`` to its stdin.
 
     Used for tar push (skills + user library) and snapshot restore.
     """
     with _open_exec_socket(
-        container, command, stdin=True, user=user, workdir=workdir
+        container,
+        command,
+        stdin=True,
+        user=user,
+        workdir=workdir,
+        environment=environment,
     ) as (exec_id, sock):
         sock.sendall(payload)
         # Half-close so the remote process sees EOF.
@@ -236,6 +244,7 @@ def stream_stdout_from_container(
     *,
     user: str | None = None,
     workdir: str | None = None,
+    environment: dict[str, str] | None = None,
     chunk_size: int = 64 * 1024,
 ) -> Generator[bytes, None, int]:
     """Run ``command`` and yield stdout chunks to the caller.
@@ -246,7 +255,12 @@ def stream_stdout_from_container(
     """
     stderr_buf = bytearray()
     with _open_exec_socket(
-        container, command, stdin=False, user=user, workdir=workdir
+        container,
+        command,
+        stdin=False,
+        user=user,
+        workdir=workdir,
+        environment=environment,
     ) as (exec_id, sock):
         for stream_type, frame in _iter_frames(sock, chunk_size=chunk_size):
             if stream_type == _FRAME_STDOUT and frame:

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_exec_helpers.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_exec_helpers.py
@@ -1,0 +1,82 @@
+"""Unit tests for Docker exec helper plumbing."""
+
+from __future__ import annotations
+
+import socket
+from collections.abc import Iterator
+from unittest.mock import MagicMock
+
+import pytest
+
+import onyx.server.features.build.sandbox.docker.internal.exec_helpers as exec_helpers
+
+
+class _FakeSocket:
+    def __init__(self) -> None:
+        self.sent_payload = b""
+        self.shutdown_how: int | None = None
+        self.closed = False
+
+    def sendall(self, payload: bytes) -> None:
+        self.sent_payload += payload
+
+    def shutdown(self, how: int) -> None:
+        self.shutdown_how = how
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_streamed_exec_passes_environment_to_exec_create(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    env = {"HOME": "/home/sandbox", "USER": "sandbox"}
+    fake_socket = _FakeSocket()
+    api = MagicMock()
+    api.exec_create.return_value = {"Id": "exec-id"}
+    api.exec_start.return_value = fake_socket
+    api.exec_inspect.return_value = {"ExitCode": 0}
+    client = MagicMock()
+    client.api = api
+    container = MagicMock()
+    container.id = "container-id"
+    container.client = client
+
+    def unwrap_socket(sock: object) -> _FakeSocket:
+        assert isinstance(sock, _FakeSocket)
+        return sock
+
+    def iter_frames(
+        sock: socket.socket, *, chunk_size: int
+    ) -> Iterator[tuple[int, bytes]]:
+        assert sock is fake_socket
+        assert chunk_size == 64 * 1024
+        return iter(())
+
+    monkeypatch.setattr(exec_helpers, "_unwrap_socket", unwrap_socket)
+    monkeypatch.setattr(exec_helpers, "_iter_frames", iter_frames)
+
+    result = exec_helpers.stream_stdin_to_container(
+        container,
+        ["tar", "-xzf", "-"],
+        b"payload",
+        user="1000:1000",
+        workdir="/workspace",
+        environment=env,
+    )
+
+    assert result.exit_code == 0
+    api.exec_create.assert_called_once_with(
+        "container-id",
+        cmd=["tar", "-xzf", "-"],
+        stdin=True,
+        stdout=True,
+        stderr=True,
+        tty=False,
+        user="1000:1000",
+        workdir="/workspace",
+        environment=env,
+    )
+    assert fake_socket.sent_payload == b"payload"
+    assert fake_socket.shutdown_how == socket.SHUT_WR
+    assert fake_socket.closed is True

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_manager_config.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_manager_config.py
@@ -9,6 +9,8 @@ env allowlist), so we lock it down here.
 from __future__ import annotations
 
 import re
+from collections.abc import Generator
+from unittest.mock import MagicMock
 from uuid import UUID
 
 import pytest
@@ -166,6 +168,78 @@ def test_container_kwargs_has_required_security_options(
     assert kwargs["cap_drop"] == ["ALL"]
     assert "no-new-privileges:true" in kwargs["security_opt"]
     assert kwargs["privileged"] is False
+
+
+def test_sandbox_exec_wrapper_pairs_uid_with_user_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mock_run = MagicMock(return_value=dsm.ExecResult(0, b"", b""))
+    monkeypatch.setattr(dsm, "run_in_container", mock_run)
+    container = MagicMock()
+
+    result = dsm._run_in_container_as_sandbox_user(
+        container,
+        ["/bin/sh", "-c", "id"],
+        check=False,
+        workdir="/workspace",
+    )
+
+    assert result.exit_code == 0
+    mock_run.assert_called_once_with(
+        container,
+        ["/bin/sh", "-c", "id"],
+        user=dsm.SANDBOX_EXEC_USER,
+        workdir="/workspace",
+        environment=dsm.SANDBOX_EXEC_ENV,
+        check=False,
+    )
+
+
+def _empty_byte_stream() -> Generator[bytes, None, int]:
+    yield from ()
+    return 0
+
+
+def test_sandbox_stream_exec_wrappers_pair_uid_with_user_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mock_stdin = MagicMock(return_value=dsm.ExecResult(0, b"", b""))
+    stream = _empty_byte_stream()
+    mock_stdout = MagicMock(return_value=stream)
+    monkeypatch.setattr(dsm, "stream_stdin_to_container", mock_stdin)
+    monkeypatch.setattr(dsm, "stream_stdout_from_container", mock_stdout)
+    container = MagicMock()
+
+    result = dsm._stream_stdin_to_container_as_sandbox_user(
+        container,
+        ["tar", "-xzf", "-"],
+        b"payload",
+        workdir="/workspace",
+    )
+    returned_stream = dsm._stream_stdout_from_container_as_sandbox_user(
+        container,
+        ["tar", "-czf", "-"],
+        workdir="/workspace",
+    )
+
+    assert result.exit_code == 0
+    assert returned_stream is stream
+    mock_stdin.assert_called_once_with(
+        container,
+        ["tar", "-xzf", "-"],
+        b"payload",
+        user=dsm.SANDBOX_EXEC_USER,
+        workdir="/workspace",
+        environment=dsm.SANDBOX_EXEC_ENV,
+    )
+    mock_stdout.assert_called_once_with(
+        container,
+        ["tar", "-czf", "-"],
+        user=dsm.SANDBOX_EXEC_USER,
+        workdir="/workspace",
+        environment=dsm.SANDBOX_EXEC_ENV,
+        chunk_size=64 * 1024,
+    )
 
 
 def test_container_kwargs_does_not_mount_docker_socket(


### PR DESCRIPTION
## Description

Cherry-pick of commit 55636a5f8c14e83c2baa21eae177861b9c553b3d to release/v4.1 branch.

Original PR: #12116

Stacked on #12131 because this exec-user fix depends on the `/workspace/sessions` volume ownership fix.

Release-specific resolution: omitted `.github/workflows/pr-craft-compose-integration.yml` and the main-branch Docker E2E files because release/v4.1 does not carry that test lane. Kept the runtime changes and unit tests.

## How Has This Been Tested?

- `.venv/bin/pytest -q backend/tests/unit/onyx/server/features/build/sandbox/test_docker_manager_config.py backend/tests/unit/onyx/server/features/build/sandbox/test_docker_exec_helpers.py`
- Built local backend and sandbox images, launched Docker compose project `onyxv41cp20260616135058`, provisioned a real Docker sandbox through the API, verified workspace ownership/writeability as `1000:1000`, and verified upload/list/download/delete through the build-session API.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run all Docker workspace execs as the sandbox user (`1000:1000`) with a proper HOME to fix permission errors on `/workspace/sessions`. This restores reliable file and snapshot operations in v4.1 sandboxes.

- **Bug Fixes**
  - Added exec wrappers that set `user=1000:1000` and `environment={"HOME": "/home/sandbox", "USER": "sandbox"}`.
  - Updated exec helpers to pass `environment` to Docker `exec_create`, and switched all workspace ops to these wrappers (setup/cleanup, list/read/write, upload/delete, snapshot create/restore, Next.js start).
  - Added unit tests for environment propagation and wrapper behavior; omitted E2E workflow files not present in `release/v4.1`.

<sup>Written for commit ac212683e619fc4e108dc0ff92ceb3a52361e43f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

