### PR TITLE
fix(slack): scope permission sync channel fetches

### DIFF
--- a/backend/ee/onyx/external_permissions/slack/doc_sync.py
+++ b/backend/ee/onyx/external_permissions/slack/doc_sync.py
@@ -12,6 +12,7 @@ from onyx.access.models import ExternalAccess
 from onyx.connectors.credentials_provider import OnyxDBCredentialsProvider
 from onyx.connectors.interfaces import SecondsSinceUnixEpoch
 from onyx.connectors.models import HierarchyNode
+from onyx.connectors.slack.connector import filter_channels
 from onyx.connectors.slack.connector import get_channels
 from onyx.connectors.slack.connector import get_channels_across_teams
 from onyx.connectors.slack.connector import list_grid_team_ids
@@ -47,6 +48,10 @@ def _fetch_channel_permissions(
     user_id_to_email_map: dict[str, str],
     team_ids: list[str] | None = None,
     team_id_to_user_emails: dict[str, set[str]] | None = None,
+    channels_to_include: list[str] | None = None,
+    include_regex_enabled: bool = False,
+    channels_to_exclude: list[str] | None = None,
+    exclude_regex_enabled: bool = False,
 ) -> dict[str, ExternalAccess]:
     channel_permissions = {}
     if team_ids:
@@ -73,6 +78,20 @@ def _fetch_channel_permissions(
             get_public=False,
             get_private=True,
         )
+    filtered_channels = filter_channels(
+        public_channels + private_channels,
+        channels_to_include,
+        include_regex_enabled,
+        channels_to_exclude,
+        exclude_regex_enabled,
+    )
+    public_channels = [
+        channel for channel in filtered_channels if not channel.get("is_private")
+    ]
+    private_channels = [
+        channel for channel in filtered_channels if channel.get("is_private")
+    ]
+
     for channel in public_channels:
         channel_id = channel.get("id")
         if not channel_id:
@@ -199,6 +218,8 @@ def slack_doc_sync(
         SlackConnector.MAX_RETRIES,
         r,
     )
+    slack_connector = SlackConnector(**cc_pair.connector.connector_specific_config)
+    slack_connector.set_credentials_provider(provider)
 
     grid_team_ids: list[str] | None = None
     try:
@@ -236,10 +257,12 @@ def slack_doc_sync(
         user_id_to_email_map=user_id_to_email_map,
         team_ids=grid_team_ids,
         team_id_to_user_emails=team_id_to_user_emails,
+        channels_to_include=slack_connector.channels,
+        include_regex_enabled=slack_connector.channel_regex_enabled,
+        channels_to_exclude=slack_connector.exclude_channels,
+        exclude_regex_enabled=slack_connector.exclude_channel_regex_enabled,
     )
 
-    slack_connector = SlackConnector(**cc_pair.connector.connector_specific_config)
-    slack_connector.set_credentials_provider(provider)
     indexing_start_ts: SecondsSinceUnixEpoch | None = (
         cc_pair.connector.indexing_start.timestamp()
         if cc_pair.connector.indexing_start is not None

--- a/backend/ee/onyx/external_permissions/slack/doc_sync.py
+++ b/backend/ee/onyx/external_permissions/slack/doc_sync.py
@@ -18,6 +18,7 @@ from onyx.connectors.slack.connector import get_channels_across_teams
 from onyx.connectors.slack.connector import list_grid_team_ids
 from onyx.connectors.slack.connector import make_paginated_slack_api_call
 from onyx.connectors.slack.connector import SlackConnector
+from onyx.connectors.slack.models import ChannelType
 from onyx.db.models import ConnectorCredentialPair
 from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
 from onyx.redis.redis_pool import get_redis_client
@@ -39,6 +40,43 @@ def _fetch_workspace_permissions(
         external_user_group_ids=set(),
         # No way to determine if slack is invite only without enterprise license
         is_public=False,
+    )
+
+
+def _filter_channels_for_permissions(
+    all_channels: list[ChannelType],
+    channels_to_include: list[str] | None,
+    include_regex_enabled: bool,
+    channels_to_exclude: list[str] | None = None,
+    exclude_regex_enabled: bool = False,
+) -> list[ChannelType]:
+    if channels_to_include and not include_regex_enabled:
+        available_channel_names = {channel["name"] for channel in all_channels}
+        available_channels_to_include = [
+            channel
+            for channel in channels_to_include
+            if channel in available_channel_names
+        ]
+        missing_channels = sorted(
+            set(channels_to_include) - set(available_channels_to_include)
+        )
+        if missing_channels:
+            logger.warning(
+                "Skipping Slack permission sync for configured channels missing "
+                "from Slack API response: %s",
+                missing_channels,
+            )
+        if not available_channels_to_include:
+            return []
+
+        channels_to_include = available_channels_to_include
+
+    return filter_channels(
+        all_channels,
+        channels_to_include,
+        include_regex_enabled,
+        channels_to_exclude,
+        exclude_regex_enabled,
     )
 
 
@@ -78,7 +116,7 @@ def _fetch_channel_permissions(
             get_public=False,
             get_private=True,
         )
-    filtered_channels = filter_channels(
+    filtered_channels = _filter_channels_for_permissions(
         public_channels + private_channels,
         channels_to_include,
         include_regex_enabled,

--- a/backend/tests/unit/ee/onyx/external_permissions/slack/test_grid_perm_sync.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/slack/test_grid_perm_sync.py
@@ -247,6 +247,33 @@ class TestFetchChannelPermissionsGrid:
             )
             assert "C1" not in result
 
+    def test_channel_filter_limits_private_member_fetches(self) -> None:
+        client = MagicMock()
+        included = _channel("C_INCLUDED", name="included", is_private=True)
+        excluded = _channel("C_EXCLUDED", name="excluded", is_private=True)
+        with (
+            patch(
+                "ee.onyx.external_permissions.slack.doc_sync.get_channels"
+            ) as mock_get,
+            patch(
+                "ee.onyx.external_permissions.slack.doc_sync.make_paginated_slack_api_call"
+            ) as mock_paginate,
+        ):
+            mock_get.side_effect = [[], [included, excluded]]  # public, private
+            mock_paginate.return_value = iter([{"members": ["U1"]}])
+            workspace_perm = _fetch_workspace_permissions({"U1": "u1@x.com"})
+            result = _fetch_channel_permissions(
+                slack_client=client,
+                workspace_permissions=workspace_perm,
+                user_id_to_email_map={"U1": "u1@x.com"},
+                channels_to_include=["included"],
+            )
+
+            assert set(result) == {"C_INCLUDED"}
+            assert result["C_INCLUDED"].external_user_emails == {"u1@x.com"}
+            mock_paginate.assert_called_once()
+            assert mock_paginate.call_args.kwargs["channel"] == "C_INCLUDED"
+
 
 class TestEEGetChannelAccessGrid:
     def test_public_channel_non_grid_returns_is_public_true(self) -> None:

--- a/backend/tests/unit/ee/onyx/external_permissions/slack/test_grid_perm_sync.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/slack/test_grid_perm_sync.py
@@ -274,6 +274,62 @@ class TestFetchChannelPermissionsGrid:
             mock_paginate.assert_called_once()
             assert mock_paginate.call_args.kwargs["channel"] == "C_INCLUDED"
 
+    def test_channel_filter_skips_missing_included_channels(self) -> None:
+        client = MagicMock()
+        included = _channel("C_INCLUDED", name="included", is_private=True)
+        with (
+            patch(
+                "ee.onyx.external_permissions.slack.doc_sync.get_channels"
+            ) as mock_get,
+            patch(
+                "ee.onyx.external_permissions.slack.doc_sync.make_paginated_slack_api_call"
+            ) as mock_paginate,
+        ):
+            mock_get.side_effect = [[], [included]]  # public, private
+            mock_paginate.return_value = iter([{"members": ["U1"]}])
+            workspace_perm = _fetch_workspace_permissions({"U1": "u1@x.com"})
+            result = _fetch_channel_permissions(
+                slack_client=client,
+                workspace_permissions=workspace_perm,
+                user_id_to_email_map={"U1": "u1@x.com"},
+                channels_to_include=["included", "missing"],
+            )
+
+            assert set(result) == {"C_INCLUDED"}
+            assert result["C_INCLUDED"].external_user_emails == {"u1@x.com"}
+            mock_paginate.assert_called_once()
+            assert mock_paginate.call_args.kwargs["channel"] == "C_INCLUDED"
+
+    def test_grid_channel_filter_limits_private_member_fetches(self) -> None:
+        client = MagicMock()
+        included = _channel("C_INCLUDED", name="included", is_private=True, team="T1")
+        excluded = _channel("C_EXCLUDED", name="excluded", is_private=True, team="T1")
+        with (
+            patch(
+                "ee.onyx.external_permissions.slack.doc_sync.get_channels_across_teams"
+            ) as mock_get,
+            patch(
+                "ee.onyx.external_permissions.slack.doc_sync.make_paginated_slack_api_call"
+            ) as mock_paginate,
+        ):
+            mock_get.side_effect = [[], [included, excluded]]  # public, private
+            mock_paginate.return_value = iter([{"members": ["U1"]}])
+            workspace_perm = _fetch_workspace_permissions({"U1": "u1@x.com"})
+            result = _fetch_channel_permissions(
+                slack_client=client,
+                workspace_permissions=workspace_perm,
+                user_id_to_email_map={"U1": "u1@x.com"},
+                team_ids=["T1"],
+                team_id_to_user_emails={"T1": {"u1@x.com"}},
+                channels_to_include=["included"],
+            )
+
+            assert set(result) == {"C_INCLUDED"}
+            assert result["C_INCLUDED"].external_user_emails == {"u1@x.com"}
+            assert mock_get.call_count == 2
+            mock_paginate.assert_called_once()
+            assert mock_paginate.call_args.kwargs["channel"] == "C_INCLUDED"
+
 
 class TestEEGetChannelAccessGrid:
     def test_public_channel_non_grid_returns_is_public_true(self) -> None:


### PR DESCRIPTION
## Description

Scopes Slack permission sync channel permission fetching to the connector's configured channel filters before enumerating private channel members. This avoids fetching members for channels that the connector will not index, reducing Slack API load during permission sync.

## How Has This Been Tested?


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes Slack permission sync to the connector’s channel filters and tolerates stale entries. Channels are filtered before fetching private channel members to cut unnecessary Slack API calls.

- **Bug Fixes**
  - Apply `filter_channels` with `SlackConnector` include/exclude lists and regex flags before splitting public/private; skip missing included channels with a warning.
  - Fetch private members only for filtered channels (Grid and non-Grid); added tests to ensure only included channels trigger a member fetch.

<sup>Written for commit a4062a124c392918368aa7c43de7a481d498c60c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

