### PR TITLE
fix(mobile): make onboarding responsive

### DIFF
--- a/web/src/layouts/chromes/AppChrome.tsx
+++ b/web/src/layouts/chromes/AppChrome.tsx
@@ -286,7 +286,7 @@ function Header() {
         isMobile) &&
         !appFocus.isSharedChat() && (
           <RootLayout.Header>
-            <div className="w-full h-full flex flex-row flex-wrap justify-center items-center p-2 md:px-4">
+            <div className="w-full h-full flex flex-row flex-wrap justify-center items-center p-2 sm:px-4">
               {/*
           Left:
           - (mobile) sidebar toggle
@@ -436,7 +436,7 @@ function Footer() {
     <RootLayout.Footer>
       <div
         className={cn(
-          "relative w-full flex flex-row justify-center items-center gap-2 px-2 md:px-4 mt-auto",
+          "relative w-full flex flex-row justify-center items-center gap-2 px-2 sm:px-4 mt-auto",
           // # Note (from @raunakab):
           //
           // The conditional rendering of vertical padding based on the current page is intentional.

--- a/web/src/layouts/chromes/AppChrome.tsx
+++ b/web/src/layouts/chromes/AppChrome.tsx
@@ -286,7 +286,7 @@ function Header() {
         isMobile) &&
         !appFocus.isSharedChat() && (
           <RootLayout.Header>
-            <div className="w-full h-full flex flex-row flex-wrap justify-center items-center px-4 py-2">
+            <div className="w-full h-full flex flex-row flex-wrap justify-center items-center p-2 md:px-4">
               {/*
           Left:
           - (mobile) sidebar toggle
@@ -436,7 +436,7 @@ function Footer() {
     <RootLayout.Footer>
       <div
         className={cn(
-          "relative w-full flex flex-row justify-center items-center gap-2 px-4 mt-auto",
+          "relative w-full flex flex-row justify-center items-center gap-2 px-2 md:px-4 mt-auto",
           // # Note (from @raunakab):
           //
           // The conditional rendering of vertical padding based on the current page is intentional.

--- a/web/src/refresh-pages/AppPage.tsx
+++ b/web/src/refresh-pages/AppPage.tsx
@@ -803,7 +803,7 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                 style={gridStyle}
               >
                 {/* ── Top row: ChatUI / WelcomeMessage / ProjectUI ── */}
-                <div className="row-start-1 min-h-0 overflow-hidden flex flex-col items-center px-2 md:px-4">
+                <div className="row-start-1 min-h-0 overflow-hidden flex flex-col items-center px-2 sm:px-4">
                   {/* ChatUI */}
                   <Fade
                     show={
@@ -928,7 +928,7 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                 {/* ── Middle-center: AppInputBar ── */}
                 <div
                   className={cn(
-                    "row-start-2 flex flex-col items-center px-2 md:px-4",
+                    "row-start-2 flex flex-col items-center px-2 sm:px-4",
                     sessionFetchError && "hidden"
                   )}
                 >
@@ -1043,7 +1043,7 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                 </div>
 
                 {/* ── Bottom: SearchResults + SourceFilter / Suggestions / ProjectChatList ── */}
-                <div className="row-start-3 min-h-0 overflow-hidden flex flex-col items-center w-full px-2 md:px-4">
+                <div className="row-start-3 min-h-0 overflow-hidden flex flex-col items-center w-full px-2 sm:px-4">
                   {/* Agent description below input */}
                   {(appFocus.isNewSession() || appFocus.isAgent()) &&
                     !isDefaultAgent && (

--- a/web/src/refresh-pages/AppPage.tsx
+++ b/web/src/refresh-pages/AppPage.tsx
@@ -708,7 +708,11 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
     (liveAgent?.starter_messages?.length ?? 0) > 0;
 
   const gridStyle = {
-    gridTemplateColumns: "1fr",
+    // minmax(0, 1fr) (instead of "1fr") lets the single column shrink to the
+    // grid's width. A bare "1fr" is minmax(auto, 1fr), whose auto minimum is
+    // the content's min-content — wide content (e.g. the onboarding cards) would
+    // otherwise blow the column past the viewport and clip the right edge.
+    gridTemplateColumns: "minmax(0, 1fr)",
     gridTemplateRows: isSearch
       ? "0fr auto 1fr"
       : appFocus.isChat()
@@ -799,7 +803,7 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                 style={gridStyle}
               >
                 {/* ── Top row: ChatUI / WelcomeMessage / ProjectUI ── */}
-                <div className="row-start-1 min-h-0 overflow-hidden flex flex-col items-center px-4">
+                <div className="row-start-1 min-h-0 overflow-hidden flex flex-col items-center px-2 md:px-4">
                   {/* ChatUI */}
                   <Fade
                     show={
@@ -924,7 +928,7 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                 {/* ── Middle-center: AppInputBar ── */}
                 <div
                   className={cn(
-                    "row-start-2 flex flex-col items-center px-4",
+                    "row-start-2 flex flex-col items-center px-2 md:px-4",
                     sessionFetchError && "hidden"
                   )}
                 >
@@ -1039,7 +1043,7 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                 </div>
 
                 {/* ── Bottom: SearchResults + SourceFilter / Suggestions / ProjectChatList ── */}
-                <div className="row-start-3 min-h-0 overflow-hidden flex flex-col items-center w-full px-4">
+                <div className="row-start-3 min-h-0 overflow-hidden flex flex-col items-center w-full px-2 md:px-4">
                   {/* Agent description below input */}
                   {(appFocus.isNewSession() || appFocus.isAgent()) &&
                     !isDefaultAgent && (

--- a/web/src/sections/onboarding/steps/LLMStep.tsx
+++ b/web/src/sections/onboarding/steps/LLMStep.tsx
@@ -169,12 +169,12 @@ const LLMStep = memo(
               }
             />
             <Divider />
-            <div className="flex flex-wrap gap-1 [&>*:last-child:nth-child(odd)]:basis-full">
+            <div className="@container/llmcards flex flex-wrap gap-1 w-full max-h-[40vh] overflow-y-auto [&>*:last-child:nth-child(odd)]:basis-full">
               {isLoading ? (
                 Array.from({ length: 8 }).map((_, idx) => (
                   <div
                     key={idx}
-                    className="basis-[calc(50%-(--spacing(1))/2)] grow"
+                    className="basis-full @xl/llmcards:basis-[calc(50%-(--spacing(1))/2)] grow"
                   >
                     <LLMProviderSkeleton />
                   </div>
@@ -194,7 +194,7 @@ const LLMStep = memo(
                     return (
                       <div
                         key={llmDescriptor.name}
-                        className="basis-[calc(50%-(--spacing(1))/2)] grow"
+                        className="basis-full @xl/llmcards:basis-[calc(50%-(--spacing(1))/2)] grow"
                       >
                         <LLMProviderCard
                           title={productName}
@@ -213,7 +213,7 @@ const LLMStep = memo(
                   })}
 
                   {/* Custom provider card */}
-                  <div className="basis-[calc(50%-(--spacing(1))/2)] grow">
+                  <div className="basis-full @xl/llmcards:basis-[calc(50%-(--spacing(1))/2)] grow">
                     <LLMProviderCard
                       title="Custom LLM Provider"
                       subtitle="LiteLLM Compatible APIs"


### PR DESCRIPTION
## Description

- Reduces the container padding on mobile
- LLM provider cards wrap in a single column on mobile
- Allows the entire onboarding grid to shrink to stay within the viewport

## How Has This Been Tested?

<img width="2532" height="2085" alt="20260616_15h23m47s_grim" src="https://github.com/user-attachments/assets/fa142c6a-e21a-4848-bd0f-4363bc5a91fd" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes onboarding on mobile by preventing horizontal overflow and adapting the layout to small screens. Cards now stack in a single column on mobile, and the grid stays within the viewport.

- **Bug Fixes**
  - Use `px-2 sm:px-4`/`p-2 sm:px-4` in the header, footer, and onboarding grid rows to keep content within the viewport.
  - Set onboarding grid columns to `minmax(0, 1fr)` to avoid clipping on narrow screens.
  - Make LLM provider cards and skeletons single-column by default with `@container/llmcards` switching to two columns at `@xl`; added `max-h-[40vh]` with scroll.

<sup>Written for commit 3f3b709baa8e56a502b51d1e10546fa308421c50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

