### PR TITLE
refactor(opal-table): put cell height on the cell, inner fills it

### DIFF
--- a/web/lib/opal/src/components/table/TableCell.tsx
+++ b/web/lib/opal/src/components/table/TableCell.tsx
@@ -1,5 +1,3 @@
-import { cn } from "@opal/utils";
-import { useTableSize } from "@opal/components/table/TableSizeContext";
 import type { WithoutStyles } from "@opal/types";
 
 interface TableCellProps extends WithoutStyles<
@@ -15,18 +13,16 @@ export default function TableCell({
   children,
   ...props
 }: TableCellProps) {
-  const resolvedSize = useTableSize();
+  // Size is not declared here — it is read off the parent `.tbl-row[data-size]`
+  // via CSS selectors (see styles.css). The cell owns the height; the inner box
+  // fills it (`h-full`) and centers its content.
   return (
     <td
       className="tbl-cell overflow-hidden"
-      data-size={resolvedSize}
       style={width != null ? { width } : undefined}
       {...props}
     >
-      <div
-        className={cn("tbl-cell-inner", "flex items-center overflow-hidden")}
-        data-size={resolvedSize}
-      >
+      <div className="tbl-cell-inner flex h-full items-center overflow-hidden">
         {children}
       </div>
     </td>

--- a/web/lib/opal/src/components/table/TableRow.tsx
+++ b/web/lib/opal/src/components/table/TableRow.tsx
@@ -59,6 +59,7 @@ function SortableTableRow({
       ref={setNodeRef}
       style={style}
       className="tbl-row group/row"
+      data-size={resolvedSize}
       data-drag-handle={showDragHandle || undefined}
       data-selected={selected || undefined}
       data-disabled={disabled || undefined}
@@ -109,6 +110,8 @@ export default function TableRow({
   ref,
   ...props
 }: TableRowProps) {
+  const resolvedSize = useTableSize();
+
   if (sortableId) {
     return (
       <SortableTableRow
@@ -126,6 +129,7 @@ export default function TableRow({
     <tr
       ref={ref}
       className="tbl-row group/row"
+      data-size={resolvedSize}
       data-selected={selected || undefined}
       data-disabled={disabled || undefined}
       {...props}

--- a/web/lib/opal/src/components/table/styles.css
+++ b/web/lib/opal/src/components/table/styles.css
@@ -10,18 +10,31 @@
 
 /* ---- TableCell ---- */
 
-.tbl-cell[data-size="lg"] {
-  @apply px-1 py-0.5;
+/* Size is declared once on the row (data-size on .tbl-row) and selected down to
+ * its cells: the cell carries the height + padding, and the inner box fills it
+ * with `h-full` and centers its content.
+ *
+ * The height uses `box-content` (content-box) on purpose. A td is border-box by
+ * default, so a plain height would absorb the per-variant td border (4px in
+ * "cards", 1px in "rows") and shrink the content differently per variant.
+ * content-box makes the height the content area, so border + padding add outside
+ * and the previous sizing is reproduced exactly in both variants. Column widths
+ * are unaffected — they are driven by the <colgroup>. Only the data cell gets a
+ * fixed height; qualifier/actions cells keep their own padding and stretch to
+ * the row. */
+
+.tbl-row[data-size="lg"] .tbl-cell {
+  @apply h-10 box-content px-1 py-0.5;
 }
-.tbl-cell[data-size="md"] {
-  @apply pl-0.5 pr-1.5 py-1.5;
+.tbl-row[data-size="md"] .tbl-cell {
+  @apply h-6 box-content pl-0.5 pr-1.5 py-1.5;
 }
 
-.tbl-cell-inner[data-size="lg"] {
-  @apply h-10 px-1;
+.tbl-row[data-size="lg"] .tbl-cell-inner {
+  @apply px-1;
 }
-.tbl-cell-inner[data-size="md"] {
-  @apply h-6 px-0.5;
+.tbl-row[data-size="md"] .tbl-cell-inner {
+  @apply px-0.5;
 }
 
 /* ---- TableHead ---- */


### PR DESCRIPTION
## What

Cell sizing (height + padding) was declared per element via a `data-size` attribute on every `<td>` **and** inner `<div>`, each read from table-size context, with the fixed height on the inner box. This:

- Declares `data-size` **once on the `<tr>`** and selects sizing down to the cells.
- Puts the **height on the cell** (`.tbl-row[data-size] .tbl-cell`); the **inner box fills it** (`h-full`) and centers its content.
- Keeps **padding on the cell**, also keyed by row size.
- Drops the context hook and per-element `data-size` attributes from `TableCell`.

## The box-sizing caveat

The height uses `box-content` (content-box) on the cell. A `<td>` is border-box by default, so a plain height would absorb the per-variant td border and shrink the content differently per variant:

- `cards` has a transparent `border-y-[2px]` → 4px
- `rows` has `border-b` → 1px

That is exactly why the height originally sat on the (border-less) inner box. `box-content` makes the height the content area, so border + padding add *outside* and the previous sizing is reproduced exactly in both variants. Column widths are unaffected (driven by the `<colgroup>`). Only the data cell takes a fixed height — qualifier/actions cells keep their padding and stretch to the row.

Both `<tr>` variants emit `data-size`, so the drag-overlay row (which reuses `TableRow` through a portal) is covered too.

## Verification

Measured a realistic row (qualifier + data + actions) in both variants and sizes — byte-identical to the original, all cells uniform height, column widths preserved:

| | row | inner | original |
|---|---|---|---|
| cards lg | 48 | 40 | 48/40 |
| cards md | 40 | 24 | 40/24 |
| rows lg | 45 | 40 | 45/40 |
| rows md | 37 | 24 | 37/24 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)