### PR TITLE
fix(llm): restore vision detection for custom-config providers (LiteLLM Proxy) (#12136) [v4.0]

### DIFF
--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -233,9 +233,17 @@ class ModelConfigurationView(BaseModel):
                 name=model_configuration_model.name,
                 is_visible=model_configuration_model.is_visible,
                 max_input_tokens=model_configuration_model.max_input_tokens,
+                # Custom-config providers (LiteLLM Proxy, etc.) under-report
+                # vision; fall back to the LiteLLM cost map when no VISION flow.
                 supports_image_input=(
                     LLMModelFlowType.VISION
                     in model_configuration_model.llm_model_flow_types
+                    or (
+                        use_stored_display_name
+                        and litellm_thinks_model_supports_image_input(
+                            model_configuration_model.name, provider_name
+                        )
+                    )
                 ),
                 # Prefer the stored REASONING flow; fall back to a substring
                 # heuristic on model name/display name for legacy rows that

--- a/backend/tests/unit/onyx/server/manage/llm/test_model_configuration.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_model_configuration.py
@@ -78,6 +78,81 @@ class TestModelConfigurationViewFromModelDynamic:
         assert view.supports_reasoning is True
 
 
+# ModelConfigurationView.from_model — vision fallback (custom-config providers)
+
+
+class TestModelConfigurationViewVisionFallback:
+    """supports_image_input resolution in the dynamic/custom-config branch."""
+
+    # In DYNAMIC_LLM_PROVIDERS
+    STRICT_DYNAMIC_PROVIDER = "lm_studio"
+    # NOT in DYNAMIC_LLM_PROVIDERS — reached via use_stored_display_name
+    CUSTOM_CONFIG_PROVIDER = "litellm_proxy"
+
+    def _view(
+        self,
+        mc: MagicMock,
+        provider: str,
+        use_stored_display_name: bool,
+        litellm_vision: bool,
+    ) -> ModelConfigurationView:
+        with patch(
+            "onyx.server.manage.llm.models.litellm_thinks_model_supports_image_input",
+            return_value=litellm_vision,
+        ):
+            return ModelConfigurationView.from_model(
+                mc, provider, use_stored_display_name=use_stored_display_name
+            )
+
+    def test_stored_vision_flow_wins(self) -> None:
+        """Stored VISION flow → True without consulting the cost map."""
+        mc = _make_model_config(
+            name="gpt-4o",
+            display_name="GPT-4o",
+            flow_types=[LLMModelFlowType.CHAT, LLMModelFlowType.VISION],
+        )
+
+        view = self._view(mc, self.CUSTOM_CONFIG_PROVIDER, True, litellm_vision=False)
+
+        assert view.supports_image_input is True
+
+    def test_custom_config_falls_back_to_cost_map(self) -> None:
+        """No VISION flow but cost map knows the model → True (the fix)."""
+        mc = _make_model_config(
+            name="gpt-4o",
+            display_name="GPT-4o",
+            flow_types=[LLMModelFlowType.CHAT],
+        )
+
+        view = self._view(mc, self.CUSTOM_CONFIG_PROVIDER, True, litellm_vision=True)
+
+        assert view.supports_image_input is True
+
+    def test_strict_dynamic_provider_does_not_fall_back(self) -> None:
+        """Strict dynamic providers trust the synced flow — no cost-map fallback."""
+        mc = _make_model_config(
+            name="gpt-4o",
+            display_name="GPT-4o",
+            flow_types=[LLMModelFlowType.CHAT],
+        )
+
+        view = self._view(mc, self.STRICT_DYNAMIC_PROVIDER, False, litellm_vision=True)
+
+        assert view.supports_image_input is False
+
+    def test_custom_config_false_when_cost_map_unaware(self) -> None:
+        """No VISION flow and cost map doesn't know the model → False."""
+        mc = _make_model_config(
+            name="my-internal-model",
+            display_name="My Internal Model",
+            flow_types=[LLMModelFlowType.CHAT],
+        )
+
+        view = self._view(mc, self.CUSTOM_CONFIG_PROVIDER, True, litellm_vision=False)
+
+        assert view.supports_image_input is False
+
+
 # ModelConfigurationView.from_model — static provider branch
 
 


### PR DESCRIPTION
Cherry-pick of #12136 to `release/v4.0`.

## Description

Backports the vision-detection fix for custom-config providers (LiteLLM Proxy, OpenAI-Compatible, Custom). On 4.0.x, vision-capable models served through these providers were reported as text-only, so the chat UI blocked image uploads with *"The current model does not support image input."*

Root cause and fix are detailed in #12136. In short: custom-config providers route through the dynamic-provider branch of `ModelConfigurationView.from_model`, which read `supports_image_input` only from a stored VISION flow with no fallback. Their fetch paths don't reliably populate that flag (LiteLLM's `/v1/model/info` omits `supports_vision`). This restores the LiteLLM cost-map fallback the static branch already uses, scoped to custom-config providers so strict dynamic providers (OpenRouter, Bedrock) keep trusting their synced capabilities.

Clean cherry-pick — the fix lines applied without conflict.

## How Has This Been Tested?

Verified on `main` via #12136 (unit tests in `TestModelConfigurationViewVisionFallback`, full `manage/llm` suite, clean pre-commit). Tests run in CI on this branch.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores vision capability detection for custom-config providers (LiteLLM Proxy, OpenAI-Compatible, Custom) so vision models allow image uploads again. Fixes the chat UI error, “The current model does not support image input.”

- **Bug Fixes**
  - In `ModelConfigurationView.from_model`, set `supports_image_input` to true if the stored VISION flow exists, or (for custom-config providers) when the LiteLLM cost map says the model supports vision via `litellm_thinks_model_supports_image_input`.
  - Scoped to custom-config providers only; strict dynamic providers continue to trust their synced capabilities.
  - Added unit tests covering stored-flow win, custom-config fallback, strict-dynamic no-fallback, and negative cases.

<sup>Written for commit 85ad03a70944fc6fc9f35e0c3d89bfd16c587eca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

