### PR TITLE
fix(groups): search members by service account name

### DIFF
--- a/web/lib/opal/src/components/table/columns.ts
+++ b/web/lib/opal/src/components/table/columns.ts
@@ -56,6 +56,8 @@ interface DataColumnConfig<TData, TValue> {
   icon?: (sorted: SortDirection) => IconFunctionComponent;
   /** Column weight for proportional distribution. @default 20 */
   weight?: number;
+  /** Explicit column ID. Derived from the accessor key; required for function accessors. */
+  id?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -102,6 +104,13 @@ interface TableColumnsBuilder<TData> {
   column<TKey extends DeepKeys<TData>>(
     accessor: TKey,
     config: DataColumnConfig<TData, DeepValue<TData, TKey>>
+  ): OnyxDataColumn<TData>;
+
+  /** Data column from an accessor function whose return value drives sorting and
+   *  search — use to make a column searchable by a derived value. Needs an `id`. */
+  column<TValue>(
+    accessor: (row: TData) => TValue,
+    config: DataColumnConfig<TData, TValue> & { id: string }
   ): OnyxDataColumn<TData>;
 
   /** Create a display (non-accessor) column. */
@@ -166,9 +175,9 @@ export function createTableColumns<TData>(): TableColumnsBuilder<TData> {
       };
     },
 
-    column<TKey extends DeepKeys<TData>>(
-      accessor: TKey,
-      config: DataColumnConfig<TData, DeepValue<TData, TKey>>
+    column(
+      accessor: DeepKeys<TData> | ((row: TData) => unknown),
+      config: DataColumnConfig<TData, any> & { id?: string }
     ): OnyxDataColumn<TData> {
       const {
         header,
@@ -178,9 +187,13 @@ export function createTableColumns<TData>(): TableColumnsBuilder<TData> {
         enableHiding = true,
         icon,
         weight = 20,
+        id: explicitId,
       } = config;
 
+      const id = explicitId ?? (accessor as string);
+
       const def = helper.accessor(accessor as any, {
+        ...(typeof accessor === "function" ? { id } : {}),
         header,
         enableSorting,
         enableResizing,
@@ -193,7 +206,7 @@ export function createTableColumns<TData>(): TableColumnsBuilder<TData> {
 
       return {
         kind: "data",
-        id: accessor as string,
+        id,
         def,
         width: { weight, minWidth: Math.max(header.length * 8 + 40, 80) },
         icon,

--- a/web/src/refresh-pages/admin/GroupsPage/shared.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/shared.tsx
@@ -47,13 +47,14 @@ const ROLE_ICONS: Partial<Record<UserRole, IconFunctionComponent>> = {
 // Column renderers
 // ---------------------------------------------------------------------------
 
-function renderNameColumn(email: string, row: MemberRow) {
+function renderNameColumn(_searchValue: unknown, row: MemberRow) {
+  const { email, personal_name } = row;
   return (
     <Content
       sizePreset="main-ui"
       variant="section"
-      title={row.personal_name ?? email}
-      description={row.personal_name ? email : undefined}
+      title={personal_name ?? email}
+      description={personal_name ? email : undefined}
     />
   );
 }
@@ -78,7 +79,10 @@ export const tc = createTableColumns<MemberRow>();
 
 export const baseColumns = [
   tc.qualifier(),
-  tc.column("email", {
+  // Search/sort by a name+email composite so service accounts — whose email is a
+  // "Service Account" placeholder — are findable by their API-key name.
+  tc.column((row) => [row.personal_name, row.email].filter(Boolean).join(" "), {
+    id: "name",
     header: "Name",
     weight: 25,
     cell: renderNameColumn,


### PR DESCRIPTION
## Description

**Bug:** In the group member tables (add-members picker + member list), text search couldn't find service accounts by name. A service account's `email` is the placeholder "Service Account" and its real name lives in `personal_name` (the API key name), but the "Name" column was only searchable by its `email` accessor — so typing the account's name matched nothing.

**Fix:**
- The "Name" column now searches/sorts on a `personal_name + email` composite, so a row matches by either. Service accounts become findable by their key name; email search for regular users is unchanged.
- Added an accessor-function overload to the Opal `tc.column` builder (previously keys only) so a column's searchable/sortable value can differ from what it renders.

Note: sorting the Name column now orders by name-then-email (was email) — intended for a column titled "Name".

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check