### PR TITLE
feat(mcp): surface servers needing re-authentication in the chat input (2/4)

### DIFF
--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -10,6 +10,7 @@ from onyx.db.models import MCPConnectionConfig
 from onyx.db.models import MCPServer
 from onyx.server.query_and_chat.placement import Placement
 from onyx.server.query_and_chat.streaming_models import CustomToolDelta
+from onyx.server.query_and_chat.streaming_models import CustomToolErrorInfo
 from onyx.server.query_and_chat.streaming_models import CustomToolStart
 from onyx.server.query_and_chat.streaming_models import Packet
 from onyx.tools.interface import Tool
@@ -195,6 +196,15 @@ class MCPTool(Tool[None]):
 
                 error_result = {"error": auth_error_msg}
                 llm_facing_response = json.dumps(error_result)
+                # Tag as an auth error so the chat UI can prompt re-auth (mirrors
+                # custom_tool.py); covers the never-authenticated case. message is
+                # the user-facing label the re-auth UI renders, not the verbose
+                # LLM instruction above.
+                auth_error_info = CustomToolErrorInfo(
+                    is_auth_error=True,
+                    status_code=401,
+                    message=f"Authentication required for {self.mcp_server.name}",
+                )
 
                 # Emit CustomToolDelta packet
                 self.emitter.emit(
@@ -204,6 +214,7 @@ class MCPTool(Tool[None]):
                             tool_name=self._name,
                             response_type="json",
                             data=error_result,
+                            error=auth_error_info,
                         ),
                     )
                 )
@@ -213,6 +224,7 @@ class MCPTool(Tool[None]):
                         tool_name=self._name,
                         response_type="json",
                         tool_result=error_result,
+                        error=auth_error_info,
                     ),
                     llm_facing_response=llm_facing_response,
                 )
@@ -303,6 +315,7 @@ class MCPTool(Tool[None]):
                 indicator in error_str for indicator in auth_error_indicators
             )
 
+            error_info: CustomToolErrorInfo | None = None
             if is_auth_error:
                 auth_error_msg = (
                     f"Authentication failed for the {self._name} tool from {self.mcp_server.name}. "
@@ -310,6 +323,21 @@ class MCPTool(Tool[None]):
                     f"for the {self.mcp_server.name} server. Original error: {str(e)}"
                 )
                 error_result = {"error": auth_error_msg}
+                # Tag as an auth error so the chat UI can prompt re-auth (mirrors
+                # custom_tool.py); a bare message string never reaches that path.
+                # message is the user-facing label the re-auth UI renders, not the
+                # verbose LLM instruction above.
+                error_info = CustomToolErrorInfo(
+                    is_auth_error=True,
+                    status_code=(
+                        403
+                        if "403" in error_str
+                        or "forbidden" in error_str
+                        or "access denied" in error_str
+                        else 401
+                    ),
+                    message=f"Re-authentication required for {self.mcp_server.name}",
+                )
             else:
                 error_result = {"error": f"Tool execution failed: {str(e)}"}
 
@@ -323,6 +351,7 @@ class MCPTool(Tool[None]):
                         tool_name=self._name,
                         response_type="json",
                         data=error_result,
+                        error=error_info,
                     ),
                 )
             )
@@ -332,6 +361,7 @@ class MCPTool(Tool[None]):
                     tool_name=self._name,
                     response_type="json",
                     tool_result=error_result,
+                    error=error_info,
                 ),
                 llm_facing_response=llm_facing_response,
             )

--- a/backend/tests/unit/onyx/tools/tool_implementations/mcp/test_mcp_tool_auth_error.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/mcp/test_mcp_tool_auth_error.py
@@ -1,0 +1,157 @@
+"""Tests that MCPTool.run() flags auth failures on both the emitted
+CustomToolDelta and the returned CustomToolCallSummary.
+
+Two auth-error paths exist in run():
+  1. Never-authenticated (pre-call): the server requires auth but no
+     credentials/headers are configured -> status_code 401.
+  2. Auth failure at call time: the underlying MCP call raises an exception
+     whose message matches an auth indicator -> 401 (or 403 for forbidden).
+
+A non-auth failure (e.g. "connection reset") must NOT be tagged, so the chat
+UI doesn't falsely prompt re-auth.
+"""
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from onyx.db.enums import MCPAuthenticationType
+from onyx.db.enums import MCPTransport
+from onyx.server.query_and_chat.placement import Placement
+from onyx.server.query_and_chat.streaming_models import CustomToolDelta
+from onyx.server.query_and_chat.streaming_models import Packet
+from onyx.tools.models import CustomToolCallSummary
+from onyx.tools.tool_implementations.mcp.mcp_tool import MCPTool
+
+
+def _capturing_emitter() -> MagicMock:
+    """A MagicMock emitter whose emit() records every Packet on .packets.
+
+    MCPTool only calls emitter.emit(); a MagicMock keeps ty happy (Emitter is
+    untyped past the constructor) while letting us inspect what was emitted.
+    """
+    emitter = MagicMock()
+    packets: list[Packet] = []
+    emitter.packets = packets
+    emitter.emit.side_effect = packets.append
+    return emitter
+
+
+def _placement() -> Placement:
+    return Placement(turn_index=0)
+
+
+def _captured_deltas(emitter: MagicMock) -> list[CustomToolDelta]:
+    return [p.obj for p in emitter.packets if isinstance(p.obj, CustomToolDelta)]
+
+
+def _make_tool(
+    emitter: MagicMock,
+    auth_type: MCPAuthenticationType,
+) -> MCPTool:
+    mcp_server = MagicMock()
+    mcp_server.name = "test-mcp"
+    mcp_server.server_url = "https://mcp.example.com/mcp"
+    mcp_server.auth_type = auth_type
+    mcp_server.transport = MCPTransport.STREAMABLE_HTTP
+    return MCPTool(
+        tool_id=1,
+        emitter=emitter,
+        mcp_server=mcp_server,
+        tool_name="do_thing",
+        tool_description="Does a thing",
+        tool_definition={"type": "object", "properties": {}},
+        connection_config=None,
+    )
+
+
+class TestNeverAuthenticatedPath:
+    def test_requires_auth_without_credentials_is_tagged_401(self) -> None:
+        # API_TOKEN auth required, but no connection_config / headers / token ->
+        # has_auth_config is False -> pre-call auth-error branch.
+        emitter = _capturing_emitter()
+        tool = _make_tool(emitter, MCPAuthenticationType.API_TOKEN)
+
+        response = tool.run(_placement())
+
+        deltas = _captured_deltas(emitter)
+        assert len(deltas) == 1
+        assert deltas[0].error is not None
+        assert deltas[0].error.is_auth_error is True
+        assert deltas[0].error.status_code == 401
+
+        summary = response.rich_response
+        assert isinstance(summary, CustomToolCallSummary)
+        assert summary.error is not None
+        assert summary.error.is_auth_error is True
+        assert summary.error.status_code == 401
+
+
+class TestCallTimeAuthFailurePath:
+    def test_401_exception_is_tagged_401(self) -> None:
+        # NONE auth -> skips the pre-call check and reaches call_mcp_tool, which
+        # we make raise an auth-indicating error.
+        emitter = _capturing_emitter()
+        tool = _make_tool(emitter, MCPAuthenticationType.NONE)
+
+        with patch(
+            "onyx.tools.tool_implementations.mcp.mcp_tool.call_mcp_tool",
+            side_effect=Exception("HTTP 401 Unauthorized"),
+        ):
+            response = tool.run(_placement())
+
+        deltas = _captured_deltas(emitter)
+        assert len(deltas) == 1
+        assert deltas[0].error is not None
+        assert deltas[0].error.is_auth_error is True
+        assert deltas[0].error.status_code == 401
+
+        summary = response.rich_response
+        assert isinstance(summary, CustomToolCallSummary)
+        assert summary.error is not None
+        assert summary.error.is_auth_error is True
+        assert summary.error.status_code == 401
+
+    def test_403_forbidden_exception_is_tagged_403(self) -> None:
+        emitter = _capturing_emitter()
+        tool = _make_tool(emitter, MCPAuthenticationType.NONE)
+
+        with patch(
+            "onyx.tools.tool_implementations.mcp.mcp_tool.call_mcp_tool",
+            side_effect=Exception("HTTP 403 Forbidden"),
+        ):
+            response = tool.run(_placement())
+
+        deltas = _captured_deltas(emitter)
+        assert deltas[0].error is not None
+        assert deltas[0].error.is_auth_error is True
+        assert deltas[0].error.status_code == 403
+
+        summary = response.rich_response
+        assert isinstance(summary, CustomToolCallSummary)
+        assert summary.error is not None
+        assert summary.error.status_code == 403
+
+    def test_non_auth_exception_is_not_tagged(self) -> None:
+        # Control: a generic failure must not be mistaken for an auth error.
+        emitter = _capturing_emitter()
+        tool = _make_tool(emitter, MCPAuthenticationType.NONE)
+
+        with patch(
+            "onyx.tools.tool_implementations.mcp.mcp_tool.call_mcp_tool",
+            side_effect=Exception("connection reset by peer"),
+        ):
+            response = tool.run(_placement())
+
+        deltas = _captured_deltas(emitter)
+        assert len(deltas) == 1
+        assert deltas[0].error is None
+
+        summary = response.rich_response
+        assert isinstance(summary, CustomToolCallSummary)
+        assert summary.error is None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-xv"])

--- a/web/src/app/app/message/messageComponents/AgentMessage.tsx
+++ b/web/src/app/app/message/messageComponents/AgentMessage.tsx
@@ -26,6 +26,7 @@ import { useVoiceMode } from "@/providers/VoiceModeProvider";
 import { getTextContent } from "@/app/app/services/packetUtils";
 import { removeThinkingTokens } from "@/app/app/services/thinkingTokens";
 import { cn } from "@opal/utils";
+import { useChatSessionStore } from "@/app/app/stores/useChatSessionStore";
 
 // Type for the regeneration factory function passed from ChatUI
 export type RegenerationFactory = (regenerationRequest: {
@@ -188,6 +189,23 @@ const AgentMessage = React.memo(function AgentMessage({
   );
 
   const authErrors = useAuthErrors(rawPackets);
+
+  // Accumulate MCP auth errors at session scope so the input-bar ActionsPopover
+  // can surface re-auth across messages. The per-message card below is unaffected.
+  const addCurrentMcpServerNeedingReauth = useChatSessionStore(
+    (state) => state.addCurrentMcpServerNeedingReauth
+  );
+  const agentTools = effectiveChatState.agent.tools;
+  useEffect(() => {
+    for (const { toolId, toolName } of authErrors) {
+      const tool = agentTools.find((candidate) =>
+        toolId != null ? candidate.id === toolId : candidate.name === toolName
+      );
+      if (tool?.mcp_server_id != null) {
+        addCurrentMcpServerNeedingReauth(tool.mcp_server_id);
+      }
+    }
+  }, [authErrors, agentTools, addCurrentMcpServerNeedingReauth]);
 
   // Message switching logic
   const {

--- a/web/src/app/app/stores/useChatSessionStore.ts
+++ b/web/src/app/app/stores/useChatSessionStore.ts
@@ -48,6 +48,11 @@ interface ChatSessionData {
   // Queued messages
   queuedMessages: QueuedMessage[];
 
+  // MCP server ids that hit a 401 this session and need (re)auth. Fed by
+  // observed tool-call auth errors; read by the input-bar ActionsPopover.
+  // Client-only for now; a backend signal can prime it on load later.
+  mcpServersNeedingReauth: Set<number>;
+
   // True once the latest assistant message has fully rendered to the
   // user (backend stream done AND smooth-streaming typewriter caught up).
   // Gates queued-message dispatch so a follow-up isn't sent while the
@@ -162,6 +167,12 @@ interface ChatSessionStore {
   ) => void;
   setIsStreamDraining: (sessionId: string, draining: boolean) => void;
 
+  // Actions - MCP re-authentication
+  addMcpServerNeedingReauth: (sessionId: string, serverId: number) => void;
+  clearMcpServerNeedingReauth: (sessionId: string, serverId: number) => void;
+  addCurrentMcpServerNeedingReauth: (serverId: number) => void;
+  clearCurrentMcpServerNeedingReauth: (serverId: number) => void;
+
   // Actions - Abort Controllers
   setAbortController: (sessionId: string, controller: AbortController) => void;
   abortSession: (sessionId: string) => void;
@@ -204,6 +215,7 @@ const createInitialSessionData = (
   queuedMessages: [],
   latestMessageRenderComplete: true,
   isStreamDraining: false,
+  mcpServersNeedingReauth: new Set<number>(),
   ...initialData,
 });
 
@@ -577,6 +589,57 @@ export const useChatSessionStore = create<ChatSessionStore>()((set, get) => ({
     get().updateSessionData(sessionId, { isStreamDraining: draining });
   },
 
+  // MCP Re-authentication Actions
+  addMcpServerNeedingReauth: (sessionId: string, serverId: number) => {
+    set((state) => {
+      const session = state.sessions.get(sessionId);
+      // Guard membership so the Set ref stays stable when nothing changes,
+      // avoiding needless re-renders in subscribers.
+      if (!session || session.mcpServersNeedingReauth.has(serverId)) {
+        return state;
+      }
+      const next = new Set(session.mcpServersNeedingReauth);
+      next.add(serverId);
+      const newSessions = new Map(state.sessions);
+      newSessions.set(sessionId, {
+        ...session,
+        mcpServersNeedingReauth: next,
+      });
+      return { sessions: newSessions };
+    });
+  },
+
+  clearMcpServerNeedingReauth: (sessionId: string, serverId: number) => {
+    set((state) => {
+      const session = state.sessions.get(sessionId);
+      if (!session || !session.mcpServersNeedingReauth.has(serverId)) {
+        return state;
+      }
+      const next = new Set(session.mcpServersNeedingReauth);
+      next.delete(serverId);
+      const newSessions = new Map(state.sessions);
+      newSessions.set(sessionId, {
+        ...session,
+        mcpServersNeedingReauth: next,
+      });
+      return { sessions: newSessions };
+    });
+  },
+
+  addCurrentMcpServerNeedingReauth: (serverId: number) => {
+    const { currentSessionId } = get();
+    if (currentSessionId) {
+      get().addMcpServerNeedingReauth(currentSessionId, serverId);
+    }
+  },
+
+  clearCurrentMcpServerNeedingReauth: (serverId: number) => {
+    const { currentSessionId } = get();
+    if (currentSessionId) {
+      get().clearMcpServerNeedingReauth(currentSessionId, serverId);
+    }
+  },
+
   // Abort Controller Actions
   setAbortController: (sessionId: string, controller: AbortController) => {
     get().updateSessionData(sessionId, { abortController: controller });
@@ -769,4 +832,14 @@ export const useCurrentIsStreamDraining = () =>
       ? sessions.get(currentSessionId)
       : null;
     return currentSession?.isStreamDraining ?? false;
+  });
+
+const EMPTY_REAUTH_SET = new Set<number>();
+export const useCurrentMcpServersNeedingReauth = (): Set<number> =>
+  useChatSessionStore((state) => {
+    const { currentSessionId, sessions } = state;
+    const currentSession = currentSessionId
+      ? sessions.get(currentSessionId)
+      : null;
+    return currentSession?.mcpServersNeedingReauth ?? EMPTY_REAUTH_SET;
   });

--- a/web/src/refresh-components/popovers/ActionsPopover/index.tsx
+++ b/web/src/refresh-components/popovers/ActionsPopover/index.tsx
@@ -47,7 +47,11 @@ import {
   SvgSliders,
   SvgSimpleLoader,
 } from "@opal/icons";
-import { Button } from "@opal/components";
+import { Button, Tag, Text } from "@opal/components";
+import {
+  useChatSessionStore,
+  useCurrentMcpServersNeedingReauth,
+} from "@/app/app/stores/useChatSessionStore";
 
 function buildTooltipMessage(
   actionDescription: string,
@@ -258,6 +262,12 @@ export default function ActionsPopover({
     onSuccess: undefined,
     isAuthenticated: false,
   });
+
+  // Session-scoped MCP servers that hit a 401 this chat session.
+  const mcpServersNeedingReauth = useCurrentMcpServersNeedingReauth();
+  const clearMcpServerNeedingReauth = useChatSessionStore(
+    (state) => state.clearCurrentMcpServerNeedingReauth
+  );
 
   // Get the agent preference for this assistant
   const { agentPreferences, setSpecificAgentPreferences } =
@@ -620,6 +630,7 @@ export default function ActionsPopover({
               isLoading: false,
             },
           }));
+          clearMcpServerNeedingReauth(server.id);
         },
         isAuthenticated: server.user_authenticated,
         existingCredentials: server.user_credentials,
@@ -644,6 +655,18 @@ export default function ActionsPopover({
     const searchLower = searchTerm.toLowerCase();
     return server.name.toLowerCase().includes(searchLower);
   });
+
+  // Servers flagged by a session 401 that the user can actually re-auth.
+  const serversNeedingReauth = useMemo(
+    () =>
+      mcpServers.filter(
+        (server) =>
+          mcpServersNeedingReauth.has(server.id) &&
+          server.auth_performer === MCPAuthenticationPerformer.PER_USER &&
+          server.auth_type !== MCPAuthenticationType.NONE
+      ),
+    [mcpServers, mcpServersNeedingReauth]
+  );
 
   const selectedMcpServerId =
     secondaryView?.type === "mcp" ? secondaryView.serverId : null;
@@ -841,6 +864,32 @@ export default function ActionsPopover({
           variant="internal"
         />,
 
+        // Needs re-authentication: servers that 401'd this session.
+        serversNeedingReauth.length > 0 ? (
+          <div key="reauth-section" className="flex flex-col gap-1 px-2 pt-1">
+            <Text font="secondary-body" color="text-03">
+              Needs re-authentication
+            </Text>
+          </div>
+        ) : undefined,
+        ...serversNeedingReauth.map((server) => (
+          <LineItem
+            key={`reauth-${server.id}`}
+            icon={SvgKey}
+            rightChildren={
+              <Button
+                variant="danger"
+                size="sm"
+                onClick={() => handleServerAuthentication(server)}
+              >
+                Re-authenticate
+              </Button>
+            }
+          >
+            {server.name}
+          </LineItem>
+        )),
+
         // Actions
         ...filteredTools.map((tool) =>
           (() => {
@@ -971,7 +1020,7 @@ export default function ActionsPopover({
     <>
       <Popover open={open} onOpenChange={handleOpenChange}>
         <Popover.Trigger asChild>
-          <div data-testid="action-management-toggle">
+          <div className="relative" data-testid="action-management-toggle">
             <Button
               disabled={disabled}
               icon={SvgSliders}
@@ -979,6 +1028,11 @@ export default function ActionsPopover({
               prominence="tertiary"
               tooltip="Manage Actions"
             />
+            {serversNeedingReauth.length > 0 && (
+              <div className="absolute -right-1 -top-1 pointer-events-none">
+                <Tag color="red" title={String(serversNeedingReauth.length)} />
+              </div>
+            )}
           </div>
         </Popover.Trigger>
         <Popover.Content side="bottom" align="start" width="lg">


### PR DESCRIPTION
## Description

**PR 2 of 4 in the MCP re-authentication stack** (builds on #12104).

Frontend that consumes the `is_auth_error` signal #12104 emits. During a chat session, MCP servers whose tool calls return an auth error are accumulated in a session-scoped store. The manage-actions popover in the chat input then shows a **count badge** on its trigger and a top-level **"Needs re-authentication"** section listing those servers, each wired to the existing re-auth flow. No new endpoints — purely reacts to the streamed tool-call errors.

> Stacked on #12104. GitHub can't target a fork branch as a PR base across forks, so until #12104 merges this PR's diff also shows #12104's commit — **review only the top commit `c4ca8e3502`** (`feat(web): surface MCP servers needing re-authentication…`). The diff collapses to just this layer automatically once #12104 merges.

## How Has This Been Tested?

- Playwright (`web/tests/e2e/mcp/mcp_reauth_badge.spec.ts`): a runtime tool-call auth error makes the badge appear on the manage-actions trigger and the server show in the "Needs re-authentication" section; re-auth clears it.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaced MCP servers that need re-auth in the chat input. MCP tool 401/403 errors now flag the server, show a red count badge on the Actions toggle, and provide one-click re-auth in a "Needs re-authentication" list.

- **New Features**
  - Emit `CustomToolErrorInfo` on `CustomToolDelta` and `CustomToolCallSummary` for MCP auth failures (401/403), covering never-authenticated and call-time exceptions; non-auth errors aren’t tagged.
  - Track affected MCP server IDs per chat session; show only per-user, auth-required servers; clear on successful re-auth.
  - No new endpoints; driven by streamed tool-call errors.

<sup>Written for commit 9335b3a8845a1c87a662bbcb46d0a31c961369dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

