### PR TITLE
feat(mcp): persist observed auth failures so re-auth status survives reload (4/4)

### DIFF
--- a/backend/alembic/versions/12cf8a96ae98_add_last_auth_failure_at_to_mcp_.py
+++ b/backend/alembic/versions/12cf8a96ae98_add_last_auth_failure_at_to_mcp_.py
@@ -1,0 +1,32 @@
+"""add last_auth_failure_at to mcp_connection_config
+
+Revision ID: 12cf8a96ae98
+Revises: f3a9c1d4b7e2
+Create Date: 2026-06-15 15:23:48.360683
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "12cf8a96ae98"
+down_revision = "f3a9c1d4b7e2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "mcp_connection_config",
+        sa.Column(
+            "last_auth_failure_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("mcp_connection_config", "last_auth_failure_at")

--- a/backend/onyx/db/mcp.py
+++ b/backend/onyx/db/mcp.py
@@ -342,6 +342,9 @@ def upsert_user_connection_config(
 
     if existing_config:
         existing_config.config = config_data  # ty: ignore[invalid-assignment]
+        # A credential write is a fresh successful (re)auth: clear any stale
+        # runtime-401 marker so the re-auth badge doesn't stay stuck lit.
+        existing_config.last_auth_failure_at = None
         db_session.flush()  # Don't commit yet, let caller decide when to commit
         return existing_config
     else:
@@ -351,6 +354,34 @@ def upsert_user_connection_config(
             user_email=user_email,
             db_session=db_session,
         )
+
+
+def record_user_connection_auth_failure(
+    config_id: int,
+    db_session: Session,
+) -> None:
+    """Stamp a per-user connection config with the time we just observed a
+    runtime auth failure (401) calling its server. Surfaced by the auth-status
+    endpoint as `recent_failure` until the user re-authenticates (which clears
+    it via `clear_user_connection_auth_failure` / `upsert_user_connection_config`).
+
+    Caller is responsible for committing. Kept separate from the `config` JSON
+    write so it never collides with concurrent token-refresh writes.
+    """
+    config = get_connection_config_by_id(config_id, db_session)
+    config.last_auth_failure_at = datetime.datetime.now(datetime.timezone.utc)
+    db_session.flush()
+
+
+def clear_user_connection_auth_failure(
+    config_id: int,
+    db_session: Session,
+) -> None:
+    """Clear the runtime-401 marker on a per-user connection config after a
+    successful (re)authentication. Caller commits."""
+    config = get_connection_config_by_id(config_id, db_session)
+    config.last_auth_failure_at = None
+    db_session.flush()
 
 
 # TODO: do this in one db call

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5128,6 +5128,16 @@ class MCPConnectionConfig(Base):
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
     )
 
+    # When the runtime last observed a 401 calling this PER_USER server with
+    # these credentials. Set best-effort on a call-time auth error, cleared
+    # (NULL) whenever the user (re)authenticates. Non-NULL => the auth-status
+    # endpoint reports `recent_failure`: a token that was valid but died
+    # mid-session, which the derived never_authenticated/token_expired checks
+    # can't see.
+    last_auth_failure_at: Mapped[datetime.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
     # Relationships
     mcp_server: Mapped["MCPServer | None"] = relationship(
         "MCPServer",

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -46,6 +46,7 @@ from onyx.db.enums import MCPOAuthProviderMode
 from onyx.db.enums import MCPServerStatus
 from onyx.db.enums import MCPTransport
 from onyx.db.enums import Permission
+from onyx.db.mcp import clear_user_connection_auth_failure
 from onyx.db.mcp import create_connection_config
 from onyx.db.mcp import create_mcp_server__no_commit
 from onyx.db.mcp import delete_all_user_connection_configs_for_server_no_commit
@@ -484,6 +485,10 @@ class OnyxTokenStorage(TokenStorage):
             config_data["headers"] = {
                 "Authorization": f"{tokens.token_type} {tokens.access_token}"
             }
+            # Fresh tokens (initial grant or silent refresh) => clear any
+            # runtime-401 marker so the re-auth badge doesn't stay stuck lit.
+            # Clear before the config write so its commit persists both.
+            clear_user_connection_auth_failure(config.id, db_session)
             update_connection_config(config.id, db_session, config_data)
 
         # The shared admin row is intentionally NOT written here: it
@@ -1149,6 +1154,8 @@ async def process_oauth_callback(
             "Authorization": f"{oauth_token.token_type} {oauth_token.access_token}"
         }
         update_connection_config(user_config.id, db_session, user_config_data)
+        # Fresh tokens => clear any runtime-401 marker so the badge unsticks.
+        clear_user_connection_auth_failure(user_config.id, db_session)
         redis_client.delete(key_state(user_id))
 
         db_session.commit()
@@ -1594,13 +1601,30 @@ def _compute_user_reauth_reason(
     using only stored connection config — never a probe of the MCP server.
 
     Conservative by design: only `never_authenticated` is a sure thing.
-    `token_expired` is returned only for OAuth tokens we can confidently
-    judge expired with no usable refresh; any ambiguity yields ``None`` so
-    we never nag a user whose credentials may still be valid.
+    `recent_failure` reflects a runtime 401 the tool path persisted (see
+    `record_user_connection_auth_failure`). `token_expired` is returned only
+    for OAuth tokens we can confidently judge expired with no usable refresh;
+    any ambiguity yields ``None`` so we never nag a user whose credentials may
+    still be valid.
+
+    Precedence: never_authenticated (no row) > recent_failure (observed 401) >
+    token_expired (derived).
     """
     user_config = get_user_connection_config(db_server.id, user_email, db)
     if user_config is None:
         return "never_authenticated"
+
+    # An observed-and-persisted runtime 401. We rely on the marker being NULL
+    # except between a 401 and the next successful (re)auth: every credential
+    # write / OAuth callback clears it (see `upsert_user_connection_config` and
+    # `clear_user_connection_auth_failure`). We deliberately do NOT compare it
+    # against `updated_at`: a credential write bumps `updated_at` via
+    # `onupdate=func.now()`, so a "marker newer than updated_at" test would race
+    # the very write that clears the marker. NULL-on-success is the source of
+    # truth instead, so a non-NULL marker always means "failed since last
+    # success" regardless of timestamps.
+    if user_config.last_auth_failure_at is not None:
+        return "recent_failure"
 
     if db_server.auth_type != MCPAuthenticationType.OAUTH:
         # A stored API_TOKEN config is assumed valid; we can't tell otherwise

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -36,6 +36,7 @@ from onyx.auth.oauth_token_manager import validate_oauth_endpoint_url
 from onyx.auth.permissions import require_permission
 from onyx.auth.schemas import UserRole
 from onyx.auth.users import current_curator_or_admin_user
+from onyx.auth.users import current_user
 from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
@@ -64,6 +65,7 @@ from onyx.db.models import MCPConnectionConfig
 from onyx.db.models import MCPServer as DbMCPServer
 from onyx.db.models import Tool
 from onyx.db.models import User
+from onyx.db.persona import get_persona_by_id
 from onyx.db.tools import create_tool__no_commit
 from onyx.db.tools import delete_tool__no_commit
 from onyx.db.tools import get_tools_by_mcp_server_id
@@ -76,8 +78,11 @@ from onyx.server.features.mcp.models import MCPAuthTemplate
 from onyx.server.features.mcp.models import MCPConnectionData
 from onyx.server.features.mcp.models import MCPOAuthCallbackResponse
 from onyx.server.features.mcp.models import MCPOAuthKeys
+from onyx.server.features.mcp.models import MCPReauthReason
 from onyx.server.features.mcp.models import MCPServer
+from onyx.server.features.mcp.models import MCPServerAuthStatus
 from onyx.server.features.mcp.models import MCPServerCreateResponse
+from onyx.server.features.mcp.models import MCPServersAuthStatusResponse
 from onyx.server.features.mcp.models import MCPServerSimpleCreateRequest
 from onyx.server.features.mcp.models import MCPServerSimpleUpdateRequest
 from onyx.server.features.mcp.models import MCPServersResponse
@@ -1578,6 +1583,124 @@ def get_mcp_servers_for_assistant(
     except Exception as e:
         logger.error("Failed to fetch MCP servers: %s", e)
         raise HTTPException(status_code=500, detail="Failed to fetch MCP servers")
+
+
+def _compute_user_reauth_reason(
+    db_server: DbMCPServer,
+    user_email: str,
+    db: Session,
+) -> MCPReauthReason | None:
+    """Derive whether the caller must (re)authenticate to ``db_server``,
+    using only stored connection config — never a probe of the MCP server.
+
+    Conservative by design: only `never_authenticated` is a sure thing.
+    `token_expired` is returned only for OAuth tokens we can confidently
+    judge expired with no usable refresh; any ambiguity yields ``None`` so
+    we never nag a user whose credentials may still be valid.
+    """
+    user_config = get_user_connection_config(db_server.id, user_email, db)
+    if user_config is None:
+        return "never_authenticated"
+
+    if db_server.auth_type != MCPAuthenticationType.OAUTH:
+        # A stored API_TOKEN config is assumed valid; we can't tell otherwise
+        # without calling the server.
+        return None
+
+    config_data = extract_connection_data(user_config)
+    tokens_raw = config_data.get(MCPOAuthKeys.TOKENS.value)
+    if not tokens_raw:
+        return "never_authenticated"
+
+    try:
+        tokens = OAuthToken.model_validate(tokens_raw)
+    except Exception:
+        # Malformed token blob — don't guess at expiry.
+        return None
+
+    # A usable refresh token means the runtime can renew silently; not a
+    # re-auth case.
+    if tokens.refresh_token:
+        return None
+    if tokens.expires_in is None:
+        return None
+
+    # No explicit obtained-at is stored, so use the config's `updated_at` as
+    # the issued-at proxy (token writes go through `update_connection_config`,
+    # which bumps it). This is imprecise: a later unrelated write would push
+    # the apparent expiry out, biasing us toward NOT flagging — acceptable,
+    # since the runtime 401 path still catches a truly-expired token.
+    issued_at = user_config.updated_at
+    expires_at = issued_at + datetime.timedelta(seconds=tokens.expires_in)
+    if datetime.datetime.now(datetime.timezone.utc) >= expires_at:
+        return "token_expired"
+    return None
+
+
+@router.get("/servers/auth-status/{assistant_id}")
+def get_mcp_servers_auth_status(
+    assistant_id: str,
+    db: Session = Depends(get_session),
+    user: User = Depends(current_user),
+) -> MCPServersAuthStatusResponse:
+    """Caller-scoped re-auth status for the PER_USER MCP servers on an
+    assistant, computed cheaply from stored config (no network probe). Lets
+    the chat UI light the re-auth badge on page load instead of waiting for a
+    runtime 401."""
+    try:
+        persona_id = int(assistant_id)
+    except ValueError:
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, "Invalid assistant ID")
+
+    # get_mcp_servers_for_persona ignores `user`, so gate read access to THIS
+    # persona here before exposing its MCP-server names / auth state. Use
+    # get_persona_by_id (scoped to persona_id, raises when inaccessible) rather
+    # than get_best_persona_id_for_user, which FALLS BACK to the user's next-best
+    # persona for an inaccessible id and would let the check pass.
+    try:
+        get_persona_by_id(persona_id, user, db, is_for_edit=False)
+    except ValueError:
+        raise OnyxError(OnyxErrorCode.PERSONA_NOT_FOUND)
+
+    try:
+        db_mcp_servers = get_mcp_servers_for_persona(persona_id, db, user)
+    except Exception as e:
+        logger.error("Failed to fetch MCP servers for auth status: %s", e)
+        raise OnyxError(OnyxErrorCode.INTERNAL_ERROR, "Failed to fetch MCP servers")
+
+    user_email = user.email
+
+    auth_statuses: list[MCPServerAuthStatus] = []
+    for db_server in db_mcp_servers:
+        # Only servers the caller can act on: per-user, auth actually required.
+        auth_type = db_server.auth_type
+        if db_server.auth_performer != MCPAuthenticationPerformer.PER_USER:
+            continue
+        if (
+            auth_type is None
+            or auth_type == MCPAuthenticationType.NONE
+            # PT_OAUTH authenticates via the user's login token (no per-user
+            # config row exists), so it can never be 'needs re-auth' here; a
+            # runtime 401 is still surfaced in-stream by the tool path.
+            or auth_type == MCPAuthenticationType.PT_OAUTH
+        ):
+            continue
+
+        reason = _compute_user_reauth_reason(db_server, user_email, db)
+        auth_statuses.append(
+            MCPServerAuthStatus(
+                server_id=db_server.id,
+                name=db_server.name,
+                needs_reauth=reason is not None,
+                reason=reason,
+                auth_performer=db_server.auth_performer,
+                auth_type=auth_type,
+            )
+        )
+
+    return MCPServersAuthStatusResponse(
+        assistant_id=assistant_id, auth_statuses=auth_statuses
+    )
 
 
 @router.get("/servers", response_model=MCPServersResponse)

--- a/backend/onyx/server/features/mcp/models.py
+++ b/backend/onyx/server/features/mcp/models.py
@@ -3,6 +3,7 @@ import re
 from enum import Enum
 from typing import Any
 from typing import List
+from typing import Literal
 from typing import NotRequired
 from typing import Optional
 from typing import TypedDict
@@ -491,3 +492,24 @@ class MCPToolListResponse(BaseModel):
     server_name: str
     server_url: str
     tools: list[MCPLibTool]
+
+
+# Why a server needs (re)auth, when it does. `null` means it does not.
+MCPReauthReason = Literal["never_authenticated", "token_expired"]
+
+
+class MCPServerAuthStatus(BaseModel):
+    """Per-server, caller-scoped re-auth signal derived from stored
+    connection config alone — no probe of the MCP server."""
+
+    server_id: int
+    name: str
+    needs_reauth: bool
+    reason: Optional[MCPReauthReason] = None
+    auth_performer: Optional[MCPAuthenticationPerformer] = None
+    auth_type: MCPAuthenticationType
+
+
+class MCPServersAuthStatusResponse(BaseModel):
+    assistant_id: str
+    auth_statuses: List[MCPServerAuthStatus]

--- a/backend/onyx/server/features/mcp/models.py
+++ b/backend/onyx/server/features/mcp/models.py
@@ -495,7 +495,11 @@ class MCPToolListResponse(BaseModel):
 
 
 # Why a server needs (re)auth, when it does. `null` means it does not.
-MCPReauthReason = Literal["never_authenticated", "token_expired"]
+# - never_authenticated: no stored credentials at all
+# - recent_failure: a runtime 401 was observed and persisted since the last
+#   successful (re)auth (catches a token that was valid but died mid-session)
+# - token_expired: a stored OAuth token we can confidently judge expired
+MCPReauthReason = Literal["never_authenticated", "recent_failure", "token_expired"]
 
 
 class MCPServerAuthStatus(BaseModel):

--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -4,8 +4,11 @@ from typing import Any
 from mcp.client.auth import OAuthClientProvider
 
 from onyx.chat.emitter import Emitter
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.enums import MCPAuthenticationPerformer
 from onyx.db.enums import MCPAuthenticationType
 from onyx.db.enums import MCPTransport
+from onyx.db.mcp import record_user_connection_auth_failure
 from onyx.db.models import MCPConnectionConfig
 from onyx.db.models import MCPServer
 from onyx.server.query_and_chat.placement import Placement
@@ -113,6 +116,32 @@ class MCPTool(Tool[None]):
                 "parameters": _normalize_parameters_schema(self._tool_definition),
             },
         }
+
+    def _record_auth_failure_best_effort(self) -> None:
+        """Persist that we just hit a runtime 401 against a PER_USER server, so
+        the auth-status endpoint can report `recent_failure` after a reload —
+        catching a token that was valid but died mid-session.
+
+        Best-effort: only meaningful when there is a per-user config row to
+        stamp (the never-authenticated pre-call path has no row). Any DB error
+        is swallowed so it can never break the chat stream; the in-stream
+        re-auth signal (CustomToolErrorInfo) is unaffected.
+        """
+        if (
+            self.mcp_server.auth_performer != MCPAuthenticationPerformer.PER_USER
+            or self.connection_config is None
+        ):
+            return
+        config_id = self.connection_config.id
+        try:
+            with get_session_with_current_tenant() as db_session:
+                record_user_connection_auth_failure(config_id, db_session)
+                db_session.commit()
+        except Exception:
+            logger.exception(
+                "Best-effort: failed to record MCP auth failure for config %s",
+                config_id,
+            )
 
     def emit_start(self, placement: Placement) -> None:
         self.emitter.emit(
@@ -317,27 +346,39 @@ class MCPTool(Tool[None]):
 
             error_info: CustomToolErrorInfo | None = None
             if is_auth_error:
-                auth_error_msg = (
-                    f"Authentication failed for the {self._name} tool from {self.mcp_server.name}. "
-                    f"Please use the MCP dropdown in the chat bar to update your credentials "
-                    f"for the {self.mcp_server.name} server. Original error: {str(e)}"
+                # A 403 is access-denied with valid credentials (an entitlement
+                # gap): re-auth can't clear it, so surface a plain access error
+                # instead of the re-auth prompt and don't persist a sticky
+                # marker. Only a 401 (missing/expired creds) drives re-auth.
+                is_forbidden = (
+                    "403" in error_str
+                    or "forbidden" in error_str
+                    or "access denied" in error_str
                 )
-                error_result = {"error": auth_error_msg}
-                # Tag as an auth error so the chat UI can prompt re-auth (mirrors
-                # custom_tool.py); a bare message string never reaches that path.
-                # message is the user-facing label the re-auth UI renders, not the
-                # verbose LLM instruction above.
-                error_info = CustomToolErrorInfo(
-                    is_auth_error=True,
-                    status_code=(
-                        403
-                        if "403" in error_str
-                        or "forbidden" in error_str
-                        or "access denied" in error_str
-                        else 401
-                    ),
-                    message=f"Re-authentication required for {self.mcp_server.name}",
-                )
+                if is_forbidden:
+                    error_result = {
+                        "error": (
+                            f"Access denied by {self.mcp_server.name} for the "
+                            f"{self._name} tool — your account lacks permission. "
+                            f"Original error: {str(e)}"
+                        )
+                    }
+                else:
+                    self._record_auth_failure_best_effort()
+                    auth_error_msg = (
+                        f"Authentication failed for the {self._name} tool from {self.mcp_server.name}. "
+                        f"Please use the MCP dropdown in the chat bar to update your credentials "
+                        f"for the {self.mcp_server.name} server. Original error: {str(e)}"
+                    )
+                    error_result = {"error": auth_error_msg}
+                    # Tag as an auth error so the chat UI can prompt re-auth
+                    # (mirrors custom_tool.py); message is the user-facing label
+                    # the re-auth UI renders, not the verbose LLM instruction.
+                    error_info = CustomToolErrorInfo(
+                        is_auth_error=True,
+                        status_code=401,
+                        message=f"Re-authentication required for {self.mcp_server.name}",
+                    )
             else:
                 error_result = {"error": f"Tool execution failed: {str(e)}"}
 

--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -10,6 +10,7 @@ from onyx.db.models import MCPConnectionConfig
 from onyx.db.models import MCPServer
 from onyx.server.query_and_chat.placement import Placement
 from onyx.server.query_and_chat.streaming_models import CustomToolDelta
+from onyx.server.query_and_chat.streaming_models import CustomToolErrorInfo
 from onyx.server.query_and_chat.streaming_models import CustomToolStart
 from onyx.server.query_and_chat.streaming_models import Packet
 from onyx.tools.interface import Tool
@@ -195,6 +196,15 @@ class MCPTool(Tool[None]):
 
                 error_result = {"error": auth_error_msg}
                 llm_facing_response = json.dumps(error_result)
+                # Tag as an auth error so the chat UI can prompt re-auth (mirrors
+                # custom_tool.py); covers the never-authenticated case. message is
+                # the user-facing label the re-auth UI renders, not the verbose
+                # LLM instruction above.
+                auth_error_info = CustomToolErrorInfo(
+                    is_auth_error=True,
+                    status_code=401,
+                    message=f"Authentication required for {self.mcp_server.name}",
+                )
 
                 # Emit CustomToolDelta packet
                 self.emitter.emit(
@@ -204,6 +214,7 @@ class MCPTool(Tool[None]):
                             tool_name=self._name,
                             response_type="json",
                             data=error_result,
+                            error=auth_error_info,
                         ),
                     )
                 )
@@ -213,6 +224,7 @@ class MCPTool(Tool[None]):
                         tool_name=self._name,
                         response_type="json",
                         tool_result=error_result,
+                        error=auth_error_info,
                     ),
                     llm_facing_response=llm_facing_response,
                 )
@@ -303,6 +315,7 @@ class MCPTool(Tool[None]):
                 indicator in error_str for indicator in auth_error_indicators
             )
 
+            error_info: CustomToolErrorInfo | None = None
             if is_auth_error:
                 auth_error_msg = (
                     f"Authentication failed for the {self._name} tool from {self.mcp_server.name}. "
@@ -310,6 +323,21 @@ class MCPTool(Tool[None]):
                     f"for the {self.mcp_server.name} server. Original error: {str(e)}"
                 )
                 error_result = {"error": auth_error_msg}
+                # Tag as an auth error so the chat UI can prompt re-auth (mirrors
+                # custom_tool.py); a bare message string never reaches that path.
+                # message is the user-facing label the re-auth UI renders, not the
+                # verbose LLM instruction above.
+                error_info = CustomToolErrorInfo(
+                    is_auth_error=True,
+                    status_code=(
+                        403
+                        if "403" in error_str
+                        or "forbidden" in error_str
+                        or "access denied" in error_str
+                        else 401
+                    ),
+                    message=f"Re-authentication required for {self.mcp_server.name}",
+                )
             else:
                 error_result = {"error": f"Tool execution failed: {str(e)}"}
 
@@ -323,6 +351,7 @@ class MCPTool(Tool[None]):
                         tool_name=self._name,
                         response_type="json",
                         data=error_result,
+                        error=error_info,
                     ),
                 )
             )
@@ -332,6 +361,7 @@ class MCPTool(Tool[None]):
                     tool_name=self._name,
                     response_type="json",
                     tool_result=error_result,
+                    error=error_info,
                 ),
                 llm_facing_response=llm_facing_response,
             )

--- a/backend/tests/integration/tests/mcp/test_mcp_auth_status.py
+++ b/backend/tests/integration/tests/mcp/test_mcp_auth_status.py
@@ -1,0 +1,212 @@
+"""Integration test for the per-user MCP re-auth status endpoint.
+
+Verifies GET /mcp/servers/auth-status/{assistant_id}: for a PER_USER MCP server
+attached to an assistant, a user with NO stored credentials is told
+needs_reauth=true (never_authenticated); after the user saves credentials the
+same endpoint reports needs_reauth=false. Also asserts the response is
+caller-scoped — it never leaks another user's status or any token material.
+"""
+
+import os
+import socket
+import subprocess
+import sys
+import time
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+
+from onyx.db.enums import MCPAuthenticationPerformer
+from onyx.db.enums import MCPAuthenticationType
+from onyx.db.enums import MCPTransport
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.http_client import client
+from tests.integration.common_utils.managers.persona import PersonaManager
+from tests.integration.common_utils.managers.user import UserManager
+from tests.integration.common_utils.test_models import DATestLLMProvider
+from tests.integration.common_utils.test_models import DATestUser
+
+# Loopback is allowed by the api_server's SSRF guard, so the mock can be
+# registered as a real MCP server. Distinct port to avoid clashing with the
+# Onyx MCP server (8090) and the other mock-server tests.
+MOCK_HOST = os.getenv("TEST_WEB_HOSTNAME", "127.0.0.1")
+MOCK_PORT = int(os.getenv("MCP_AUTH_STATUS_MOCK_PORT", "8902"))
+MOCK_URL = f"http://{MOCK_HOST}:{MOCK_PORT}/mcp"
+
+# Baked into run_mcp_server_per_user_key.py.
+ADMIN_API_KEY = "mcp_live-kid_alice_001-S3cr3tAlice"
+USER_API_KEY = "mcp_live-kid_bob_001-S3cr3tBob"
+
+AUTH_TEMPLATE = {
+    "headers": {"Authorization": "Bearer {api_key}"},
+    "required_fields": ["api_key"],
+}
+
+MOCK_SERVER_SCRIPT = (
+    Path(__file__).resolve().parents[2]
+    / "mock_services"
+    / "mcp_test_server"
+    / "run_mcp_server_per_user_key.py"
+)
+
+
+def _wait_for_port(
+    host: str,
+    port: int,
+    process: subprocess.Popen[bytes],
+    timeout_seconds: float = 15.0,
+) -> None:
+    start = time.monotonic()
+    while time.monotonic() - start < timeout_seconds:
+        if process.poll() is not None:
+            raise RuntimeError("MCP server process exited unexpectedly during startup")
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.settimeout(0.5)
+            try:
+                sock.connect((host, port))
+                return
+            except OSError:
+                time.sleep(0.1)
+    raise TimeoutError("Timed out waiting for MCP server to accept connections")
+
+
+@pytest.fixture(scope="module")
+def mcp_per_user_server() -> Generator[None, None, None]:
+    if not MOCK_SERVER_SCRIPT.exists():
+        raise FileNotFoundError(
+            f"Mock MCP server script not found at {MOCK_SERVER_SCRIPT}"
+        )
+    # Fail loud if something else already owns the port, so we never register
+    # the test server against a stranger's process.
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        if probe.connect_ex((MOCK_HOST, MOCK_PORT)) == 0:
+            raise RuntimeError(
+                f"Port {MOCK_PORT} already in use; set MCP_AUTH_STATUS_MOCK_PORT"
+            )
+    process = subprocess.Popen(
+        [sys.executable, str(MOCK_SERVER_SCRIPT), str(MOCK_PORT)],
+        cwd=MOCK_SERVER_SCRIPT.parent,
+    )
+    try:
+        _wait_for_port(MOCK_HOST, MOCK_PORT, process)
+        yield
+    finally:
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+
+
+def _get_auth_status(persona_id: int, user: DATestUser) -> dict:
+    response = client.get(
+        f"{API_SERVER_URL}/mcp/servers/auth-status/{persona_id}",
+        headers=user.headers,
+        cookies=user.cookies,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def test_mcp_per_user_auth_status_flow(
+    mcp_per_user_server: None,  # noqa: ARG001
+    admin_user: DATestUser,
+    basic_user: DATestUser,
+    llm_provider: DATestLLMProvider,  # noqa: ARG001
+) -> None:
+    # Second credential-less user, to prove caller-scoping (basic_user's saved
+    # creds never leak into another user's status).
+    other_user = UserManager.create(name=f"auth-status-other-{int(time.time())}")
+    # a) Admin registers a PER_USER / API_TOKEN MCP server pointed at the mock.
+    create_response = client.post(
+        f"{API_SERVER_URL}/admin/mcp/servers/create",
+        json={
+            "name": f"auth-status-per-user-{int(time.time())}",
+            "description": "Per-user MCP server for auth-status integration test",
+            "server_url": MOCK_URL,
+            "transport": MCPTransport.STREAMABLE_HTTP.value,
+            "auth_type": MCPAuthenticationType.API_TOKEN.value,
+            "auth_performer": MCPAuthenticationPerformer.PER_USER.value,
+            "auth_template": AUTH_TEMPLATE,
+            "admin_credentials": {"api_key": ADMIN_API_KEY},
+            "admin_credentials_changed": {"api_key": True},
+        },
+        headers=admin_user.headers,
+        cookies=admin_user.cookies,
+    )
+    create_response.raise_for_status()
+    server_id = create_response.json()["server_id"]
+
+    # b) Discover tools (source=mcp also flips the server to CONNECTED).
+    snapshots_response = client.get(
+        f"{API_SERVER_URL}/admin/mcp/server/{server_id}/tools/snapshots",
+        params={"source": "mcp"},
+        headers=admin_user.headers,
+        cookies=admin_user.cookies,
+    )
+    snapshots_response.raise_for_status()
+
+    db_tools_response = client.get(
+        f"{API_SERVER_URL}/admin/mcp/server/{server_id}/db-tools",
+        headers=admin_user.headers,
+        cookies=admin_user.cookies,
+    )
+    db_tools_response.raise_for_status()
+    whoami_tool = next(
+        tool for tool in db_tools_response.json()["tools"] if tool["name"] == "whoami"
+    )
+
+    # c) Public assistant with the per-user MCP tool attached.
+    persona = PersonaManager.create(
+        name=f"auth-status-persona-{int(time.time())}",
+        description="Persona for MCP auth-status integration test",
+        tool_ids=[whoami_tool["id"]],
+        is_public=True,
+        user_performing_action=admin_user,
+    )
+
+    # d) basic_user has no per-user credentials yet -> never_authenticated.
+    before = _get_auth_status(persona.id, basic_user)
+    assert before["assistant_id"] == str(persona.id)
+    statuses = before["auth_statuses"]
+    assert len(statuses) == 1, statuses
+    status = statuses[0]
+    assert status["server_id"] == server_id
+    assert status["name"] is not None
+    assert status["needs_reauth"] is True
+    assert status["reason"] == "never_authenticated"
+    assert status["auth_performer"] == MCPAuthenticationPerformer.PER_USER.value
+    assert status["auth_type"] == MCPAuthenticationType.API_TOKEN.value
+    # No token material is ever surfaced through this endpoint.
+    serialized = before.__repr__() + str(before)
+    assert USER_API_KEY not in serialized
+    assert ADMIN_API_KEY not in serialized
+    assert "api_key" not in {k for s in statuses for k in s.keys()}
+
+    # e) basic_user saves credentials -> needs_reauth flips to false.
+    save_response = client.post(
+        f"{API_SERVER_URL}/mcp/user-credentials",
+        json={
+            "server_id": server_id,
+            "credentials": {"api_key": USER_API_KEY},
+            "transport": MCPTransport.STREAMABLE_HTTP.value,
+        },
+        headers=basic_user.headers,
+        cookies=basic_user.cookies,
+    )
+    save_response.raise_for_status()
+
+    after = _get_auth_status(persona.id, basic_user)
+    after_status = after["auth_statuses"][0]
+    assert after_status["server_id"] == server_id
+    assert after_status["needs_reauth"] is False
+    assert after_status["reason"] is None
+
+    # f) Caller-scoping: other_user saved nothing, so it must still see
+    #    never_authenticated — basic_user's freshly-saved creds never leak across.
+    other = _get_auth_status(persona.id, other_user)
+    other_status = other["auth_statuses"][0]
+    assert other_status["server_id"] == server_id
+    assert other_status["needs_reauth"] is True
+    assert other_status["reason"] == "never_authenticated"

--- a/backend/tests/integration/tests/mcp/test_mcp_recent_failure.py
+++ b/backend/tests/integration/tests/mcp/test_mcp_recent_failure.py
@@ -1,0 +1,219 @@
+"""Integration test for the persisted runtime-401 ("recent_failure") signal.
+
+Verifies that GET /mcp/servers/auth-status/{assistant_id} reports
+needs_reauth=true with reason="recent_failure" once a runtime 401 has been
+persisted against a PER_USER MCP server's per-user connection config (via the
+db helper the tool path uses), that the signal SURVIVES a re-query (simulated
+page reload), and that a subsequent successful credential save clears it
+(needs_reauth=false again).
+
+This complements test_mcp_auth_status.py, which covers the purely-derived
+never_authenticated / (cleared) cases; recent_failure is the case those derived
+checks can't see — a token that was valid but died mid-session.
+"""
+
+import os
+import socket
+import subprocess
+import sys
+import time
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.enums import MCPAuthenticationPerformer
+from onyx.db.enums import MCPAuthenticationType
+from onyx.db.enums import MCPTransport
+from onyx.db.mcp import get_user_connection_config
+from onyx.db.mcp import record_user_connection_auth_failure
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.http_client import client
+from tests.integration.common_utils.managers.persona import PersonaManager
+from tests.integration.common_utils.test_models import DATestLLMProvider
+from tests.integration.common_utils.test_models import DATestUser
+
+MOCK_HOST = os.getenv("TEST_WEB_HOSTNAME", "127.0.0.1")
+MOCK_PORT = int(os.getenv("MCP_RECENT_FAILURE_MOCK_PORT", "8903"))
+MOCK_URL = f"http://{MOCK_HOST}:{MOCK_PORT}/mcp"
+
+# Baked into run_mcp_server_per_user_key.py.
+ADMIN_API_KEY = "mcp_live-kid_alice_001-S3cr3tAlice"
+USER_API_KEY = "mcp_live-kid_bob_001-S3cr3tBob"
+
+AUTH_TEMPLATE = {
+    "headers": {"Authorization": "Bearer {api_key}"},
+    "required_fields": ["api_key"],
+}
+
+MOCK_SERVER_SCRIPT = (
+    Path(__file__).resolve().parents[2]
+    / "mock_services"
+    / "mcp_test_server"
+    / "run_mcp_server_per_user_key.py"
+)
+
+
+def _wait_for_port(
+    host: str,
+    port: int,
+    process: subprocess.Popen[bytes],
+    timeout_seconds: float = 15.0,
+) -> None:
+    start = time.monotonic()
+    while time.monotonic() - start < timeout_seconds:
+        if process.poll() is not None:
+            raise RuntimeError("MCP server process exited unexpectedly during startup")
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.settimeout(0.5)
+            try:
+                sock.connect((host, port))
+                return
+            except OSError:
+                time.sleep(0.1)
+    raise TimeoutError("Timed out waiting for MCP server to accept connections")
+
+
+@pytest.fixture(scope="module")
+def mcp_per_user_server() -> Generator[None, None, None]:
+    if not MOCK_SERVER_SCRIPT.exists():
+        raise FileNotFoundError(
+            f"Mock MCP server script not found at {MOCK_SERVER_SCRIPT}"
+        )
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        if probe.connect_ex((MOCK_HOST, MOCK_PORT)) == 0:
+            raise RuntimeError(
+                f"Port {MOCK_PORT} already in use; set MCP_RECENT_FAILURE_MOCK_PORT"
+            )
+    process = subprocess.Popen(
+        [sys.executable, str(MOCK_SERVER_SCRIPT), str(MOCK_PORT)],
+        cwd=MOCK_SERVER_SCRIPT.parent,
+    )
+    try:
+        _wait_for_port(MOCK_HOST, MOCK_PORT, process)
+        yield
+    finally:
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+
+
+def _get_auth_status(persona_id: int, user: DATestUser) -> dict:
+    response = client.get(
+        f"{API_SERVER_URL}/mcp/servers/auth-status/{persona_id}",
+        headers=user.headers,
+        cookies=user.cookies,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def _save_credentials(server_id: int, user: DATestUser) -> None:
+    response = client.post(
+        f"{API_SERVER_URL}/mcp/user-credentials",
+        json={
+            "server_id": server_id,
+            "credentials": {"api_key": USER_API_KEY},
+            "transport": MCPTransport.STREAMABLE_HTTP.value,
+        },
+        headers=user.headers,
+        cookies=user.cookies,
+    )
+    response.raise_for_status()
+
+
+def test_mcp_recent_failure_persists_and_clears(
+    mcp_per_user_server: None,  # noqa: ARG001
+    admin_user: DATestUser,
+    basic_user: DATestUser,
+    llm_provider: DATestLLMProvider,  # noqa: ARG001
+) -> None:
+    # a) Admin registers a PER_USER / API_TOKEN MCP server pointed at the mock.
+    create_response = client.post(
+        f"{API_SERVER_URL}/admin/mcp/servers/create",
+        json={
+            "name": f"recent-failure-per-user-{int(time.time())}",
+            "description": "Per-user MCP server for recent-failure integration test",
+            "server_url": MOCK_URL,
+            "transport": MCPTransport.STREAMABLE_HTTP.value,
+            "auth_type": MCPAuthenticationType.API_TOKEN.value,
+            "auth_performer": MCPAuthenticationPerformer.PER_USER.value,
+            "auth_template": AUTH_TEMPLATE,
+            "admin_credentials": {"api_key": ADMIN_API_KEY},
+            "admin_credentials_changed": {"api_key": True},
+        },
+        headers=admin_user.headers,
+        cookies=admin_user.cookies,
+    )
+    create_response.raise_for_status()
+    server_id = create_response.json()["server_id"]
+
+    # b) Discover tools (source=mcp also flips the server to CONNECTED).
+    snapshots_response = client.get(
+        f"{API_SERVER_URL}/admin/mcp/server/{server_id}/tools/snapshots",
+        params={"source": "mcp"},
+        headers=admin_user.headers,
+        cookies=admin_user.cookies,
+    )
+    snapshots_response.raise_for_status()
+
+    db_tools_response = client.get(
+        f"{API_SERVER_URL}/admin/mcp/server/{server_id}/db-tools",
+        headers=admin_user.headers,
+        cookies=admin_user.cookies,
+    )
+    db_tools_response.raise_for_status()
+    whoami_tool = next(
+        tool for tool in db_tools_response.json()["tools"] if tool["name"] == "whoami"
+    )
+
+    # c) Public assistant with the per-user MCP tool attached.
+    persona = PersonaManager.create(
+        name=f"recent-failure-persona-{int(time.time())}",
+        description="Persona for MCP recent-failure integration test",
+        tool_ids=[whoami_tool["id"]],
+        is_public=True,
+        user_performing_action=admin_user,
+    )
+
+    # d) basic_user saves credentials -> needs_reauth=false (the valid-token
+    #    starting state, which recent_failure later contradicts).
+    _save_credentials(server_id, basic_user)
+    valid = _get_auth_status(persona.id, basic_user)
+    assert valid["auth_statuses"][0]["needs_reauth"] is False
+
+    # e) Simulate a runtime 401: stamp the per-user config via the db helper the
+    #    tool path uses. The endpoint must now report recent_failure.
+    with get_session_with_current_tenant() as db_session:
+        user_config = get_user_connection_config(
+            server_id, basic_user.email, db_session
+        )
+        assert user_config is not None
+        record_user_connection_auth_failure(user_config.id, db_session)
+        db_session.commit()
+
+    after_failure = _get_auth_status(persona.id, basic_user)
+    failure_status = after_failure["auth_statuses"][0]
+    assert failure_status["server_id"] == server_id
+    assert failure_status["needs_reauth"] is True
+    assert failure_status["reason"] == "recent_failure"
+
+    # f) Survives a re-query (simulated page reload): still recent_failure.
+    reloaded = _get_auth_status(persona.id, basic_user)
+    reloaded_status = reloaded["auth_statuses"][0]
+    assert reloaded_status["needs_reauth"] is True
+    assert reloaded_status["reason"] == "recent_failure"
+
+    # g) basic_user re-authenticates (credential save) -> marker cleared.
+    _save_credentials(server_id, basic_user)
+    cleared = _get_auth_status(persona.id, basic_user)
+    cleared_status = cleared["auth_statuses"][0]
+    assert cleared_status["needs_reauth"] is False
+    assert cleared_status["reason"] is None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-xv"])

--- a/backend/tests/unit/onyx/tools/tool_implementations/mcp/test_mcp_tool_auth_error.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/mcp/test_mcp_tool_auth_error.py
@@ -16,6 +16,7 @@ from unittest.mock import patch
 
 import pytest
 
+from onyx.db.enums import MCPAuthenticationPerformer
 from onyx.db.enums import MCPAuthenticationType
 from onyx.db.enums import MCPTransport
 from onyx.server.query_and_chat.placement import Placement
@@ -49,11 +50,14 @@ def _captured_deltas(emitter: MagicMock) -> list[CustomToolDelta]:
 def _make_tool(
     emitter: MagicMock,
     auth_type: MCPAuthenticationType,
+    auth_performer: MCPAuthenticationPerformer = MCPAuthenticationPerformer.ADMIN,
+    connection_config: MagicMock | None = None,
 ) -> MCPTool:
     mcp_server = MagicMock()
     mcp_server.name = "test-mcp"
     mcp_server.server_url = "https://mcp.example.com/mcp"
     mcp_server.auth_type = auth_type
+    mcp_server.auth_performer = auth_performer
     mcp_server.transport = MCPTransport.STREAMABLE_HTTP
     return MCPTool(
         tool_id=1,
@@ -62,7 +66,7 @@ def _make_tool(
         tool_name="do_thing",
         tool_description="Does a thing",
         tool_definition={"type": "object", "properties": {}},
-        connection_config=None,
+        connection_config=connection_config,
     )
 
 
@@ -151,6 +155,96 @@ class TestCallTimeAuthFailurePath:
         summary = response.rich_response
         assert isinstance(summary, CustomToolCallSummary)
         assert summary.error is None
+
+
+class TestPersistAuthFailureBestEffort:
+    """The call-time 401 path persists `last_auth_failure_at` on a PER_USER
+    config, but the persistence is best-effort: a DB failure must never break
+    the chat stream (the tool still returns its tagged auth-error response)."""
+
+    def _per_user_tool(self, emitter: MagicMock) -> MCPTool:
+        # auth_type NONE skips the pre-call has-auth check so we reach
+        # call_mcp_tool (and thus the call-time except branch). config=None
+        # keeps the header-merge step from choking on a MagicMock dict; the
+        # branch under test only needs auth_performer + a non-None config row.
+        connection_config = MagicMock()
+        connection_config.id = 4242
+        connection_config.config = None
+        return _make_tool(
+            emitter,
+            MCPAuthenticationType.NONE,
+            auth_performer=MCPAuthenticationPerformer.PER_USER,
+            connection_config=connection_config,
+        )
+
+    def test_records_failure_on_call_time_401(self) -> None:
+        emitter = _capturing_emitter()
+        tool = self._per_user_tool(emitter)
+
+        with (
+            patch(
+                "onyx.tools.tool_implementations.mcp.mcp_tool.call_mcp_tool",
+                side_effect=Exception("HTTP 401 Unauthorized"),
+            ),
+            patch.object(tool, "_record_auth_failure_best_effort") as record_mock,
+        ):
+            response = tool.run(_placement())
+
+        # The 401 path stamps the marker exactly once.
+        record_mock.assert_called_once_with()
+        summary = response.rich_response
+        assert isinstance(summary, CustomToolCallSummary)
+        assert summary.error is not None
+        assert summary.error.is_auth_error is True
+
+    def test_db_failure_in_record_path_does_not_raise(self) -> None:
+        # The whole point of best-effort: if getting a session / writing throws,
+        # the tool must still return its auth-error response, not propagate.
+        emitter = _capturing_emitter()
+        tool = self._per_user_tool(emitter)
+
+        with (
+            patch(
+                "onyx.tools.tool_implementations.mcp.mcp_tool.call_mcp_tool",
+                side_effect=Exception("HTTP 401 Unauthorized"),
+            ),
+            patch(
+                "onyx.tools.tool_implementations.mcp.mcp_tool.get_session_with_current_tenant",
+                side_effect=Exception("db is down"),
+            ),
+        ):
+            response = tool.run(_placement())
+
+        # No exception leaked; the tagged auth error still came back.
+        deltas = _captured_deltas(emitter)
+        assert deltas[0].error is not None
+        assert deltas[0].error.is_auth_error is True
+        summary = response.rich_response
+        assert isinstance(summary, CustomToolCallSummary)
+        assert summary.error is not None
+        assert summary.error.is_auth_error is True
+
+    def test_admin_server_does_not_record(self) -> None:
+        # Only PER_USER servers have a per-user row to stamp.
+        emitter = _capturing_emitter()
+        tool = _make_tool(
+            emitter,
+            MCPAuthenticationType.NONE,
+            auth_performer=MCPAuthenticationPerformer.ADMIN,
+        )
+
+        with (
+            patch(
+                "onyx.tools.tool_implementations.mcp.mcp_tool.call_mcp_tool",
+                side_effect=Exception("HTTP 401 Unauthorized"),
+            ),
+            patch(
+                "onyx.tools.tool_implementations.mcp.mcp_tool.record_user_connection_auth_failure"
+            ) as record_mock,
+        ):
+            tool.run(_placement())
+
+        record_mock.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/backend/tests/unit/onyx/tools/tool_implementations/mcp/test_mcp_tool_auth_error.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/mcp/test_mcp_tool_auth_error.py
@@ -1,0 +1,157 @@
+"""Tests that MCPTool.run() flags auth failures on both the emitted
+CustomToolDelta and the returned CustomToolCallSummary.
+
+Two auth-error paths exist in run():
+  1. Never-authenticated (pre-call): the server requires auth but no
+     credentials/headers are configured -> status_code 401.
+  2. Auth failure at call time: the underlying MCP call raises an exception
+     whose message matches an auth indicator -> 401 (or 403 for forbidden).
+
+A non-auth failure (e.g. "connection reset") must NOT be tagged, so the chat
+UI doesn't falsely prompt re-auth.
+"""
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from onyx.db.enums import MCPAuthenticationType
+from onyx.db.enums import MCPTransport
+from onyx.server.query_and_chat.placement import Placement
+from onyx.server.query_and_chat.streaming_models import CustomToolDelta
+from onyx.server.query_and_chat.streaming_models import Packet
+from onyx.tools.models import CustomToolCallSummary
+from onyx.tools.tool_implementations.mcp.mcp_tool import MCPTool
+
+
+def _capturing_emitter() -> MagicMock:
+    """A MagicMock emitter whose emit() records every Packet on .packets.
+
+    MCPTool only calls emitter.emit(); a MagicMock keeps ty happy (Emitter is
+    untyped past the constructor) while letting us inspect what was emitted.
+    """
+    emitter = MagicMock()
+    packets: list[Packet] = []
+    emitter.packets = packets
+    emitter.emit.side_effect = packets.append
+    return emitter
+
+
+def _placement() -> Placement:
+    return Placement(turn_index=0)
+
+
+def _captured_deltas(emitter: MagicMock) -> list[CustomToolDelta]:
+    return [p.obj for p in emitter.packets if isinstance(p.obj, CustomToolDelta)]
+
+
+def _make_tool(
+    emitter: MagicMock,
+    auth_type: MCPAuthenticationType,
+) -> MCPTool:
+    mcp_server = MagicMock()
+    mcp_server.name = "test-mcp"
+    mcp_server.server_url = "https://mcp.example.com/mcp"
+    mcp_server.auth_type = auth_type
+    mcp_server.transport = MCPTransport.STREAMABLE_HTTP
+    return MCPTool(
+        tool_id=1,
+        emitter=emitter,
+        mcp_server=mcp_server,
+        tool_name="do_thing",
+        tool_description="Does a thing",
+        tool_definition={"type": "object", "properties": {}},
+        connection_config=None,
+    )
+
+
+class TestNeverAuthenticatedPath:
+    def test_requires_auth_without_credentials_is_tagged_401(self) -> None:
+        # API_TOKEN auth required, but no connection_config / headers / token ->
+        # has_auth_config is False -> pre-call auth-error branch.
+        emitter = _capturing_emitter()
+        tool = _make_tool(emitter, MCPAuthenticationType.API_TOKEN)
+
+        response = tool.run(_placement())
+
+        deltas = _captured_deltas(emitter)
+        assert len(deltas) == 1
+        assert deltas[0].error is not None
+        assert deltas[0].error.is_auth_error is True
+        assert deltas[0].error.status_code == 401
+
+        summary = response.rich_response
+        assert isinstance(summary, CustomToolCallSummary)
+        assert summary.error is not None
+        assert summary.error.is_auth_error is True
+        assert summary.error.status_code == 401
+
+
+class TestCallTimeAuthFailurePath:
+    def test_401_exception_is_tagged_401(self) -> None:
+        # NONE auth -> skips the pre-call check and reaches call_mcp_tool, which
+        # we make raise an auth-indicating error.
+        emitter = _capturing_emitter()
+        tool = _make_tool(emitter, MCPAuthenticationType.NONE)
+
+        with patch(
+            "onyx.tools.tool_implementations.mcp.mcp_tool.call_mcp_tool",
+            side_effect=Exception("HTTP 401 Unauthorized"),
+        ):
+            response = tool.run(_placement())
+
+        deltas = _captured_deltas(emitter)
+        assert len(deltas) == 1
+        assert deltas[0].error is not None
+        assert deltas[0].error.is_auth_error is True
+        assert deltas[0].error.status_code == 401
+
+        summary = response.rich_response
+        assert isinstance(summary, CustomToolCallSummary)
+        assert summary.error is not None
+        assert summary.error.is_auth_error is True
+        assert summary.error.status_code == 401
+
+    def test_403_forbidden_exception_is_tagged_403(self) -> None:
+        emitter = _capturing_emitter()
+        tool = _make_tool(emitter, MCPAuthenticationType.NONE)
+
+        with patch(
+            "onyx.tools.tool_implementations.mcp.mcp_tool.call_mcp_tool",
+            side_effect=Exception("HTTP 403 Forbidden"),
+        ):
+            response = tool.run(_placement())
+
+        deltas = _captured_deltas(emitter)
+        assert deltas[0].error is not None
+        assert deltas[0].error.is_auth_error is True
+        assert deltas[0].error.status_code == 403
+
+        summary = response.rich_response
+        assert isinstance(summary, CustomToolCallSummary)
+        assert summary.error is not None
+        assert summary.error.status_code == 403
+
+    def test_non_auth_exception_is_not_tagged(self) -> None:
+        # Control: a generic failure must not be mistaken for an auth error.
+        emitter = _capturing_emitter()
+        tool = _make_tool(emitter, MCPAuthenticationType.NONE)
+
+        with patch(
+            "onyx.tools.tool_implementations.mcp.mcp_tool.call_mcp_tool",
+            side_effect=Exception("connection reset by peer"),
+        ):
+            response = tool.run(_placement())
+
+        deltas = _captured_deltas(emitter)
+        assert len(deltas) == 1
+        assert deltas[0].error is None
+
+        summary = response.rich_response
+        assert isinstance(summary, CustomToolCallSummary)
+        assert summary.error is None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-xv"])

--- a/web/src/app/app/message/messageComponents/AgentMessage.tsx
+++ b/web/src/app/app/message/messageComponents/AgentMessage.tsx
@@ -26,6 +26,7 @@ import { useVoiceMode } from "@/providers/VoiceModeProvider";
 import { getTextContent } from "@/app/app/services/packetUtils";
 import { removeThinkingTokens } from "@/app/app/services/thinkingTokens";
 import { cn } from "@opal/utils";
+import { useChatSessionStore } from "@/app/app/stores/useChatSessionStore";
 
 // Type for the regeneration factory function passed from ChatUI
 export type RegenerationFactory = (regenerationRequest: {
@@ -188,6 +189,23 @@ const AgentMessage = React.memo(function AgentMessage({
   );
 
   const authErrors = useAuthErrors(rawPackets);
+
+  // Accumulate MCP auth errors at session scope so the input-bar ActionsPopover
+  // can surface re-auth across messages. The per-message card below is unaffected.
+  const addCurrentMcpServerNeedingReauth = useChatSessionStore(
+    (state) => state.addCurrentMcpServerNeedingReauth
+  );
+  const agentTools = effectiveChatState.agent.tools;
+  useEffect(() => {
+    for (const { toolId, toolName } of authErrors) {
+      const tool = agentTools.find((candidate) =>
+        toolId != null ? candidate.id === toolId : candidate.name === toolName
+      );
+      if (tool?.mcp_server_id != null) {
+        addCurrentMcpServerNeedingReauth(tool.mcp_server_id);
+      }
+    }
+  }, [authErrors, agentTools, addCurrentMcpServerNeedingReauth]);
 
   // Message switching logic
   const {

--- a/web/src/app/app/stores/useChatSessionStore.ts
+++ b/web/src/app/app/stores/useChatSessionStore.ts
@@ -48,9 +48,9 @@ interface ChatSessionData {
   // Queued messages
   queuedMessages: QueuedMessage[];
 
-  // MCP server ids that hit a 401 this session and need (re)auth. Fed by
-  // observed tool-call auth errors; read by the input-bar ActionsPopover.
-  // Client-only for now; a backend signal can prime it on load later.
+  // MCP server ids that need (re)auth this session. Extended at runtime by
+  // observed tool-call auth errors and unioned (in the input-bar
+  // ActionsPopover) with the GET /mcp/servers/auth-status load-time signal.
   mcpServersNeedingReauth: Set<number>;
 
   // True once the latest assistant message has fully rendered to the

--- a/web/src/app/app/stores/useChatSessionStore.ts
+++ b/web/src/app/app/stores/useChatSessionStore.ts
@@ -48,6 +48,11 @@ interface ChatSessionData {
   // Queued messages
   queuedMessages: QueuedMessage[];
 
+  // MCP server ids that hit a 401 this session and need (re)auth. Fed by
+  // observed tool-call auth errors; read by the input-bar ActionsPopover.
+  // Client-only for now; a backend signal can prime it on load later.
+  mcpServersNeedingReauth: Set<number>;
+
   // True once the latest assistant message has fully rendered to the
   // user (backend stream done AND smooth-streaming typewriter caught up).
   // Gates queued-message dispatch so a follow-up isn't sent while the
@@ -162,6 +167,12 @@ interface ChatSessionStore {
   ) => void;
   setIsStreamDraining: (sessionId: string, draining: boolean) => void;
 
+  // Actions - MCP re-authentication
+  addMcpServerNeedingReauth: (sessionId: string, serverId: number) => void;
+  clearMcpServerNeedingReauth: (sessionId: string, serverId: number) => void;
+  addCurrentMcpServerNeedingReauth: (serverId: number) => void;
+  clearCurrentMcpServerNeedingReauth: (serverId: number) => void;
+
   // Actions - Abort Controllers
   setAbortController: (sessionId: string, controller: AbortController) => void;
   abortSession: (sessionId: string) => void;
@@ -204,6 +215,7 @@ const createInitialSessionData = (
   queuedMessages: [],
   latestMessageRenderComplete: true,
   isStreamDraining: false,
+  mcpServersNeedingReauth: new Set<number>(),
   ...initialData,
 });
 
@@ -577,6 +589,57 @@ export const useChatSessionStore = create<ChatSessionStore>()((set, get) => ({
     get().updateSessionData(sessionId, { isStreamDraining: draining });
   },
 
+  // MCP Re-authentication Actions
+  addMcpServerNeedingReauth: (sessionId: string, serverId: number) => {
+    set((state) => {
+      const session = state.sessions.get(sessionId);
+      // Guard membership so the Set ref stays stable when nothing changes,
+      // avoiding needless re-renders in subscribers.
+      if (!session || session.mcpServersNeedingReauth.has(serverId)) {
+        return state;
+      }
+      const next = new Set(session.mcpServersNeedingReauth);
+      next.add(serverId);
+      const newSessions = new Map(state.sessions);
+      newSessions.set(sessionId, {
+        ...session,
+        mcpServersNeedingReauth: next,
+      });
+      return { sessions: newSessions };
+    });
+  },
+
+  clearMcpServerNeedingReauth: (sessionId: string, serverId: number) => {
+    set((state) => {
+      const session = state.sessions.get(sessionId);
+      if (!session || !session.mcpServersNeedingReauth.has(serverId)) {
+        return state;
+      }
+      const next = new Set(session.mcpServersNeedingReauth);
+      next.delete(serverId);
+      const newSessions = new Map(state.sessions);
+      newSessions.set(sessionId, {
+        ...session,
+        mcpServersNeedingReauth: next,
+      });
+      return { sessions: newSessions };
+    });
+  },
+
+  addCurrentMcpServerNeedingReauth: (serverId: number) => {
+    const { currentSessionId } = get();
+    if (currentSessionId) {
+      get().addMcpServerNeedingReauth(currentSessionId, serverId);
+    }
+  },
+
+  clearCurrentMcpServerNeedingReauth: (serverId: number) => {
+    const { currentSessionId } = get();
+    if (currentSessionId) {
+      get().clearMcpServerNeedingReauth(currentSessionId, serverId);
+    }
+  },
+
   // Abort Controller Actions
   setAbortController: (sessionId: string, controller: AbortController) => {
     get().updateSessionData(sessionId, { abortController: controller });
@@ -769,4 +832,14 @@ export const useCurrentIsStreamDraining = () =>
       ? sessions.get(currentSessionId)
       : null;
     return currentSession?.isStreamDraining ?? false;
+  });
+
+const EMPTY_REAUTH_SET = new Set<number>();
+export const useCurrentMcpServersNeedingReauth = (): Set<number> =>
+  useChatSessionStore((state) => {
+    const { currentSessionId, sessions } = state;
+    const currentSession = currentSessionId
+      ? sessions.get(currentSessionId)
+      : null;
+    return currentSession?.mcpServersNeedingReauth ?? EMPTY_REAUTH_SET;
   });

--- a/web/src/lib/swr-keys.ts
+++ b/web/src/lib/swr-keys.ts
@@ -193,6 +193,8 @@ export const SWR_KEYS = {
 
   // ── MCP Server (per-ID) ───────────────────────────────────────────────────
   adminMcpServer: (id: number) => `/api/admin/mcp/servers/${id}`,
+  mcpServersAuthStatus: (assistantId: number) =>
+    `/api/mcp/servers/auth-status/${assistantId}`,
 
   // ── Document Processing ───────────────────────────────────────────────────
   unstructuredApiKeySet: "/api/search-settings/unstructured-api-key-set",

--- a/web/src/refresh-components/popovers/ActionsPopover/index.tsx
+++ b/web/src/refresh-components/popovers/ActionsPopover/index.tsx
@@ -47,7 +47,11 @@ import {
   SvgSliders,
   SvgSimpleLoader,
 } from "@opal/icons";
-import { Button } from "@opal/components";
+import { Button, Tag, Text } from "@opal/components";
+import {
+  useChatSessionStore,
+  useCurrentMcpServersNeedingReauth,
+} from "@/app/app/stores/useChatSessionStore";
 
 function buildTooltipMessage(
   actionDescription: string,
@@ -258,6 +262,12 @@ export default function ActionsPopover({
     onSuccess: undefined,
     isAuthenticated: false,
   });
+
+  // Session-scoped MCP servers that hit a 401 this chat session.
+  const mcpServersNeedingReauth = useCurrentMcpServersNeedingReauth();
+  const clearMcpServerNeedingReauth = useChatSessionStore(
+    (state) => state.clearCurrentMcpServerNeedingReauth
+  );
 
   // Get the agent preference for this assistant
   const { agentPreferences, setSpecificAgentPreferences } =
@@ -620,6 +630,7 @@ export default function ActionsPopover({
               isLoading: false,
             },
           }));
+          clearMcpServerNeedingReauth(server.id);
         },
         isAuthenticated: server.user_authenticated,
         existingCredentials: server.user_credentials,
@@ -644,6 +655,18 @@ export default function ActionsPopover({
     const searchLower = searchTerm.toLowerCase();
     return server.name.toLowerCase().includes(searchLower);
   });
+
+  // Servers flagged by a session 401 that the user can actually re-auth.
+  const serversNeedingReauth = useMemo(
+    () =>
+      mcpServers.filter(
+        (server) =>
+          mcpServersNeedingReauth.has(server.id) &&
+          server.auth_performer === MCPAuthenticationPerformer.PER_USER &&
+          server.auth_type !== MCPAuthenticationType.NONE
+      ),
+    [mcpServers, mcpServersNeedingReauth]
+  );
 
   const selectedMcpServerId =
     secondaryView?.type === "mcp" ? secondaryView.serverId : null;
@@ -841,6 +864,32 @@ export default function ActionsPopover({
           variant="internal"
         />,
 
+        // Needs re-authentication: servers that 401'd this session.
+        serversNeedingReauth.length > 0 ? (
+          <div key="reauth-section" className="flex flex-col gap-1 px-2 pt-1">
+            <Text font="secondary-body" color="text-03">
+              Needs re-authentication
+            </Text>
+          </div>
+        ) : undefined,
+        ...serversNeedingReauth.map((server) => (
+          <LineItem
+            key={`reauth-${server.id}`}
+            icon={SvgKey}
+            rightChildren={
+              <Button
+                variant="danger"
+                size="sm"
+                onClick={() => handleServerAuthentication(server)}
+              >
+                Re-authenticate
+              </Button>
+            }
+          >
+            {server.name}
+          </LineItem>
+        )),
+
         // Actions
         ...filteredTools.map((tool) =>
           (() => {
@@ -971,7 +1020,7 @@ export default function ActionsPopover({
     <>
       <Popover open={open} onOpenChange={handleOpenChange}>
         <Popover.Trigger asChild>
-          <div data-testid="action-management-toggle">
+          <div className="relative" data-testid="action-management-toggle">
             <Button
               disabled={disabled}
               icon={SvgSliders}
@@ -979,6 +1028,11 @@ export default function ActionsPopover({
               prominence="tertiary"
               tooltip="Manage Actions"
             />
+            {serversNeedingReauth.length > 0 && (
+              <div className="absolute -right-1 -top-1 pointer-events-none">
+                <Tag color="red" title={String(serversNeedingReauth.length)} />
+              </div>
+            )}
           </div>
         </Popover.Trigger>
         <Popover.Content side="bottom" align="start" width="lg">

--- a/web/src/refresh-components/popovers/ActionsPopover/index.tsx
+++ b/web/src/refresh-components/popovers/ActionsPopover/index.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import useSWR from "swr";
+import { errorHandlingFetcher } from "@/lib/fetcher";
+import { SWR_KEYS } from "@/lib/swr-keys";
 import {
   CODING_AGENT_TOOL_ID,
   FILE_READER_TOOL_ID,
@@ -267,6 +270,17 @@ export default function ActionsPopover({
   const mcpServersNeedingReauth = useCurrentMcpServersNeedingReauth();
   const clearMcpServerNeedingReauth = useChatSessionStore(
     (state) => state.clearCurrentMcpServerNeedingReauth
+  );
+  // Caller-scoped re-auth status for this agent's PER_USER servers, derived
+  // server-side from stored config. Seeds the badge on load instead of waiting
+  // for a runtime 401.
+  const { data: authStatusData, mutate: mutateAuthStatus } = useSWR<{
+    auth_statuses: { server_id: number; needs_reauth: boolean }[];
+  }>(
+    selectedAgent?.id != null
+      ? SWR_KEYS.mcpServersAuthStatus(selectedAgent.id)
+      : null,
+    errorHandlingFetcher
   );
 
   // Get the agent preference for this assistant
@@ -631,6 +645,8 @@ export default function ActionsPopover({
             },
           }));
           clearMcpServerNeedingReauth(server.id);
+          // Refresh the derived signal so the badge clears immediately.
+          mutateAuthStatus();
         },
         isAuthenticated: server.user_authenticated,
         existingCredentials: server.user_credentials,
@@ -656,17 +672,20 @@ export default function ActionsPopover({
     return server.name.toLowerCase().includes(searchLower);
   });
 
-  // Servers flagged by a session 401 that the user can actually re-auth.
-  const serversNeedingReauth = useMemo(
-    () =>
-      mcpServers.filter(
-        (server) =>
-          mcpServersNeedingReauth.has(server.id) &&
-          server.auth_performer === MCPAuthenticationPerformer.PER_USER &&
-          server.auth_type !== MCPAuthenticationType.NONE
-      ),
-    [mcpServers, mcpServersNeedingReauth]
-  );
+  // Servers the user can re-auth, flagged either by a runtime 401 this session
+  // (session store) or by the derived auth-status endpoint (lights on load).
+  const serversNeedingReauth = useMemo(() => {
+    const flagged = new Set<number>(mcpServersNeedingReauth);
+    authStatusData?.auth_statuses.forEach((status) => {
+      if (status.needs_reauth) flagged.add(status.server_id);
+    });
+    return mcpServers.filter(
+      (server) =>
+        flagged.has(server.id) &&
+        server.auth_performer === MCPAuthenticationPerformer.PER_USER &&
+        server.auth_type !== MCPAuthenticationType.NONE
+    );
+  }, [mcpServers, mcpServersNeedingReauth, authStatusData]);
 
   const selectedMcpServerId =
     secondaryView?.type === "mcp" ? secondaryView.serverId : null;


### PR DESCRIPTION
## Description

**PR 4 of 4 in the MCP re-authentication stack** (builds on #12144).

Persists an observed auth failure so the re-auth status survives a page reload. Adds a nullable `last_auth_failure_at` to `MCPConnectionConfig` (one additive migration). On a call-time 401 against a `PER_USER` server, it best-effort-stamps the marker — a DB failure here can never break the chat stream. The auth-status endpoint (#12144) then reports a `recent_failure` reason until the next successful (re)auth, which clears it (credential save, OAuth token write, OAuth callback). The marker is the source of truth — `NULL` on every success — so it needs no timestamp comparison and can't get stuck lit.

> Stacked on #12144 → #12143 → #12104. Until those merge, this diff includes their commits — **review only the top commit `596584c620`** (`feat(mcp): persist observed auth failures…`). The diff collapses automatically as the lower PRs merge.

## How Has This Been Tested?

- Integration (`backend/tests/integration/tests/mcp/test_mcp_recent_failure.py`): a 401 stamps the marker → endpoint reports `recent_failure`; a successful credential save clears it.
- Unit (`test_mcp_tool_auth_error.py`, extended): the best-effort stamp is attempted on a call-time 401 and a DB error there doesn't propagate into the stream.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist MCP auth failures so the re-auth badge survives reloads and lights on page load. Tag MCP tool 401/403 errors so the chat prompts re-auth and the input bar lists servers needing re-auth.

- **New Features**
  - Add `last_auth_failure_at` to `MCPConnectionConfig` (additive migration).
  - Best-effort stamp on PER_USER 401s during tool calls; 403s are tagged as access denied and not persisted. Clear on credential save, OAuth token write/refresh, and OAuth callback. DB errors never break the stream.
  - New `GET /mcp/servers/auth-status/{assistant_id}`: caller-scoped `needs_reauth` and `reason` (`never_authenticated`, `recent_failure`, `token_expired`) from stored config only.
  - Tag MCP tool auth failures with `CustomToolErrorInfo` on both delta and summary (covers never-authenticated pre-call and call-time 401/403).
  - Web: track servers needing re-auth in a session store; union with the auth-status endpoint on load; show a red count badge and a “Needs re-authentication” section; clear and revalidate after successful re-auth.

- **Tests**
  - Integration: auth-status derivation and caller scoping; `recent_failure` persists across reloads and clears after re-auth.
  - Unit: `MCPTool` auth-error tagging (401 and 403) and best-effort persistence (401 stamped once; DB failure is swallowed).

<sup>Written for commit 63e3b04c097247ca214d4d6d8aee3e5ffdab82f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

