### PR TITLE
feat(skills): attach skills to agents in the agent editor (frontend)

### DIFF
--- a/web/src/lib/agents/svc.ts
+++ b/web/src/lib/agents/svc.ts
@@ -37,6 +37,7 @@ function buildAgentUpsertRequest(
     replace_base_system_prompt: params.replace_base_system_prompt,
     hierarchy_node_ids: params.hierarchy_node_ids ?? [],
     document_ids: params.document_ids ?? [],
+    skill_ids: params.skill_ids ?? [],
   };
 }
 

--- a/web/src/lib/agents/types.ts
+++ b/web/src/lib/agents/types.ts
@@ -100,6 +100,8 @@ export interface FullAgent extends Agent {
   sharing_status: PersonaSharingStatus;
   admin_count: number;
   ownership_vacant: boolean;
+  // Skills attached to this agent, masked to the viewer's visible set.
+  skill_ids: string[];
 }
 
 // ── Upsert / API parameter types ──────────────────────────────────────────────
@@ -129,6 +131,7 @@ export interface AgentUpsertParameters {
   user_file_ids: string[];
   hierarchy_node_ids?: number[];
   document_ids?: string[];
+  skill_ids: string[];
 }
 
 export interface AgentUpsertRequest {
@@ -155,6 +158,7 @@ export interface AgentUpsertRequest {
   replace_base_system_prompt: boolean;
   hierarchy_node_ids: number[];
   document_ids: string[];
+  skill_ids: string[];
 }
 
 export interface PaginatedAgentsResponse {

--- a/web/src/sections/modals/AgentViewerModal.tsx
+++ b/web/src/sections/modals/AgentViewerModal.tsx
@@ -34,6 +34,7 @@ import { formatMmDdYyyy } from "@/lib/dateUtils";
 import { useProjectsContext } from "@/providers/ProjectsContext";
 import { FileCard } from "@/sections/cards/FileCard";
 import DocumentSetCard from "@/sections/cards/DocumentSetCard";
+import useUserSkills from "@/hooks/useUserSkills";
 import { getDisplayName } from "@/lib/languageModels/utils";
 import { useLLMProviders } from "@/lib/languageModels/hooks";
 import { Interactive } from "@opal/core";
@@ -229,6 +230,21 @@ export default function AgentViewerModal({ agent }: AgentViewerModalProps) {
   const hasActions = mcpServersWithTools.length > 0 || openApiTools.length > 0;
   const defaultModel = getDisplayName(agent, llmProviders ?? []);
 
+  // Resolve the agent's attached skills to ones the viewer can see (custom
+  // skills are keyed by UUID); names come from the user's own skill list.
+  const {
+    data: userSkills,
+    isLoading: skillsLoading,
+    error: skillsError,
+  } = useUserSkills();
+  const attachedSkills = useMemo(
+    () =>
+      (userSkills?.customs ?? []).filter((skill) =>
+        agent.skill_ids?.includes(skill.id)
+      ),
+    [userSkills, agent.skill_ids]
+  );
+
   return (
     <Modal
       open={agentViewerModal.isOpen}
@@ -329,6 +345,36 @@ export default function AgentViewerModal({ agent }: AgentViewerModalProps) {
                 </Section>
               ) : (
                 <EmptyMessageCard sizePreset="main-ui" title="No Actions" />
+              )}
+            </SimpleCollapsible.Content>
+          </SimpleCollapsible>
+
+          {/* Skills */}
+          <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+          <SimpleCollapsible>
+            <SimpleCollapsible.Header title="Skills" />
+            <SimpleCollapsible.Content>
+              {skillsLoading ? (
+                <EmptyMessageCard sizePreset="main-ui" title="Loading skills…" />
+              ) : skillsError ? (
+                <EmptyMessageCard
+                  sizePreset="main-ui"
+                  title="Couldn't load skills"
+                />
+              ) : attachedSkills.length > 0 ? (
+                <Section gap={0.5} alignItems="start">
+                  {attachedSkills.map((skill) => (
+                    <Content
+                      key={skill.id}
+                      title={skill.name}
+                      description={skill.description}
+                      sizePreset="main-ui"
+                      variant="section"
+                    />
+                  ))}
+                </Section>
+              ) : (
+                <EmptyMessageCard sizePreset="main-ui" title="No Skills" />
               )}
             </SimpleCollapsible.Content>
           </SimpleCollapsible>

--- a/web/src/views/AgentEditorPage.tsx
+++ b/web/src/views/AgentEditorPage.tsx
@@ -50,6 +50,7 @@ import { Popover, PopoverMenu } from "@opal/components";
 import LineItem from "@/refresh-components/buttons/LineItem";
 import {
   SvgActions,
+  SvgBlocks,
   SvgExpand,
   SvgEye,
   SvgEyeOff,
@@ -78,8 +79,9 @@ import useOpenApiTools from "@/hooks/useOpenApiTools";
 import { useAvailableTools } from "@/hooks/useAvailableTools";
 import { getActionIcon } from "@/lib/tools/mcpUtils";
 import { MCPServer, MCPTool, ToolSnapshot } from "@/lib/tools/interfaces";
-import { InputTypeIn } from "@opal/components";
+import { InputTypeIn, Switch } from "@opal/components";
 import useFilter from "@/hooks/useFilter";
+import useUserSkills from "@/hooks/useUserSkills";
 import EnabledCount from "@/refresh-components/EnabledCount";
 import { useAppRouter } from "@/hooks/appNavigation";
 import { isDateInFuture } from "@/lib/dateUtils";
@@ -436,6 +438,125 @@ function MCPServerCard({
   );
 }
 
+/**
+ * Lets the user attach their visible skills to the agent. Attachment state
+ * lives in the Formik `skill_ids` string array. Skills are created/managed on
+ * the Skills page; this selector only attaches existing ones.
+ */
+function SkillsSelector() {
+  const { values, setFieldValue } = useFormikContext<{ skill_ids: string[] }>();
+  const { data, isLoading, error } = useUserSkills();
+
+  // Only custom skills are attachable; built-ins are always-on and aren't
+  // persisted on the persona.
+  const skills = data?.customs ?? [];
+  const {
+    query,
+    setQuery,
+    filtered: filteredSkills,
+  } = useFilter(skills, (skill) => `${skill.name} ${skill.description}`);
+
+  const attached = new Set(values.skill_ids);
+
+  function toggleSkill(skillId: string, checked: boolean) {
+    const next = new Set(values.skill_ids);
+    if (checked) next.add(skillId);
+    else next.delete(skillId);
+    setFieldValue("skill_ids", Array.from(next));
+  }
+
+  return (
+    <Card border="solid" rounding="lg" padding="sm">
+      <CardLayout.Header
+        bottomChildren={
+          <GeneralLayouts.Section flexDirection="row" gap={0.5}>
+            <InputTypeIn
+              placeholder="Search skills..."
+              variant="internal"
+              searchIcon
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+            />
+          </GeneralLayouts.Section>
+        }
+      >
+        <div className="p-2">
+          <ContentAction
+            icon={SvgBlocks}
+            title="Skills"
+            description="Attach your skills so this agent reaches for them in chat."
+            sizePreset="main-ui"
+            variant="section"
+            padding="fit"
+            rightChildren={
+              <EnabledCount
+                name="skill"
+                enabledCount={attached.size}
+                totalCount={skills.length}
+              />
+            }
+          />
+        </div>
+      </CardLayout.Header>
+
+      <GeneralLayouts.Section gap={0.5} padding={0.5}>
+        {isLoading && (
+          <GeneralLayouts.Section padding={1}>
+            <SvgSimpleLoader />
+          </GeneralLayouts.Section>
+        )}
+
+        {!isLoading && error && (
+          <Text mainUiBody text03 className="p-2">
+            Couldn&apos;t load your skills. Refresh to try again.
+          </Text>
+        )}
+
+        {!isLoading && !error && skills.length === 0 && (
+          <Text mainUiBody text03 className="p-2">
+            You have no skills yet. Create one on the Skills page to attach it
+            here.
+          </Text>
+        )}
+
+        {!isLoading &&
+          !error &&
+          skills.length > 0 &&
+          filteredSkills.length === 0 && (
+            <Text mainUiBody text03 className="p-2">
+              No skills match your search.
+            </Text>
+          )}
+
+        {!isLoading &&
+          !error &&
+          filteredSkills.map((skill) => (
+            <Card key={skill.id} border="solid" rounding="md" padding="sm">
+              <ContentAction
+                icon={SvgBlocks}
+                title={skill.name}
+                description={skill.description}
+                sizePreset="main-ui"
+                variant="section"
+                padding="fit"
+                rightChildren={
+                  <Switch
+                    checked={attached.has(skill.id)}
+                    onCheckedChange={(checked) =>
+                      toggleSkill(skill.id, checked)
+                    }
+                    aria-label={`Attach skill ${skill.name}`}
+                    data-testid={`SkillsSelector/toggle-${skill.slug}`}
+                  />
+                }
+              />
+            </Card>
+          ))}
+      </GeneralLayouts.Section>
+    </Card>
+  );
+}
+
 function AgentStarterMessages() {
   const max_starters = STARTER_MESSAGES_EXAMPLES.length;
 
@@ -643,6 +764,7 @@ export default function AgentEditorPage({
     user_file_ids: existingAgent?.user_file_ids ?? [],
     // Selected sources for the new knowledge UI - derived from document sets
     selected_sources: [] as ValidSources[],
+    skill_ids: existingAgent?.skill_ids ?? [],
 
     // Advanced
     default_model_configuration_id:
@@ -883,6 +1005,7 @@ export default function AgentEditorPage({
           (values as any).default_model_configuration_id ?? null,
         starter_messages: finalAgentStarterMessages,
         tool_ids: toolIds,
+        skill_ids: values.skill_ids,
         // uploaded_image: null, // Already uploaded separately
         remove_image: values.remove_image ?? false,
         uploaded_image_id: values.uploaded_image_id,
@@ -1610,6 +1733,8 @@ export default function AgentEditorPage({
                                   ))}
                                 </GeneralLayouts.Section>
                               )}
+
+                              <SkillsSelector />
                             </>
                           </GeneralLayouts.Section>
                         </SimpleCollapsible.Content>


### PR DESCRIPTION
## Description

**Frontend for #12105.** Adds a **Skills selector** to the agent editor: it lists the user's visible skills (upstream's `useUserSkills`) and toggles attachment through the agent's `skill_ids`; the agent preview lists attached skills. `skill_ids` is threaded through the agent create/update payloads (additive).

Skills are **created/managed on the Skills page** (upstream #11923) — this selector only attaches existing ones, so there's no create flow here. Standalone web-only diff off `main`.

## How Has This Been Tested?

- `tsc --noEmit` clean.
- Manually: attached a skill to an owned agent, saved, reopened — the attachment round-trips and the persona's `skill_ids` reflects it.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check
