### PR TITLE
feat(auth): add mobile SSO bridge with PKCE one-time code exchange

### DIFF
--- a/backend/ee/onyx/server/middleware/tenant_tracking.py
+++ b/backend/ee/onyx/server/middleware/tenant_tracking.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import sys
 from collections.abc import Awaitable
 from collections.abc import Callable
 
@@ -177,13 +178,16 @@ async def _get_tenant_id_from_request(
         raise HTTPException(status_code=500, detail="Internal server error")
 
     finally:
-        if tenant_id:
-            return tenant_id
+        # Don't `return` while an exception is propagating — it would swallow it
+        # and fall back to the wrong tenant. Fall back only on the normal path.
+        if sys.exc_info()[0] is None:
+            if tenant_id:
+                return tenant_id
 
-        # As a final step, check for explicit tenant_id cookie
-        tenant_id_cookie = request.cookies.get(TENANT_ID_COOKIE_NAME)
-        if tenant_id_cookie and is_valid_schema_name(tenant_id_cookie):
-            return tenant_id_cookie
+            # As a final step, check for explicit tenant_id cookie
+            tenant_id_cookie = request.cookies.get(TENANT_ID_COOKIE_NAME)
+            if tenant_id_cookie and is_valid_schema_name(tenant_id_cookie):
+                return tenant_id_cookie
 
-        # If we've reached this point, return the default schema
-        return POSTGRES_DEFAULT_SCHEMA
+            # If we've reached this point, return the default schema
+            return POSTGRES_DEFAULT_SCHEMA

--- a/backend/ee/onyx/server/middleware/tenant_tracking.py
+++ b/backend/ee/onyx/server/middleware/tenant_tracking.py
@@ -19,6 +19,7 @@ from onyx.configs.constants import ANONYMOUS_USER_COOKIE_NAME
 from onyx.configs.constants import TENANT_ID_COOKIE_NAME
 from onyx.db.engine.sql_engine import is_valid_schema_name
 from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.redis.redis_pool import retrieve_auth_token_data_from_bearer
 from onyx.redis.redis_pool import retrieve_auth_token_data_from_redis
 from shared_configs.configs import MULTI_TENANT
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
@@ -108,7 +109,8 @@ async def _get_tenant_id_from_request(
     """
     Attempt to extract tenant_id from:
     1) The API key or PAT (Personal Access Token) header
-    2) The Redis-based token (stored in Cookie: fastapiusersauth)
+    2) The Redis-based session token (Cookie: fastapiusersauth, or the
+       Authorization: Bearer header used by mobile clients)
     3) The anonymous user cookie
     Fallback: POSTGRES_DEFAULT_SCHEMA
     """
@@ -118,9 +120,12 @@ async def _get_tenant_id_from_request(
         return tenant_id
 
     try:
-        # Look up token data in Redis
-
+        # Look up the session token data in Redis. Web clients send it as the
+        # `fastapiusersauth` cookie; mobile clients send the same opaque token as
+        # an Authorization: Bearer header and carry no cookie.
         token_data = await retrieve_auth_token_data_from_redis(request)
+        if token_data is None:
+            token_data = await retrieve_auth_token_data_from_bearer(request)
 
         if token_data:
             tenant_id_from_payload = token_data.get(

--- a/backend/onyx/auth/mobile_sso/__init__.py
+++ b/backend/onyx/auth/mobile_sso/__init__.py
@@ -1,0 +1,13 @@
+"""Mobile SSO bridge.
+
+Backend support for native-mobile (Expo / React Native) OAuth/SSO login. The
+app runs the OAuth dance in the system browser (reusing the existing, already
+registered IdP callback) and the backend returns a single-use, PKCE-bound
+one-time code over a custom-scheme deep link — never a token. The app then swaps
+that code for the existing revocable session token (as a Bearer) at
+``/auth/mobile/sso/exchange``.
+
+Provider-genericity is achieved by the single shared ``complete_mobile_sso``
+helper that each provider callback calls (Google today; OIDC / SAML / Apple
+later), not a new abstraction layer.
+"""

--- a/backend/onyx/auth/mobile_sso/code_store.py
+++ b/backend/onyx/auth/mobile_sso/code_store.py
@@ -1,0 +1,80 @@
+"""One-time, PKCE-bound SSO code store (Redis).
+
+The mobile SSO bridge never puts a session token on the (interceptable)
+custom-scheme deep link. Instead the backend stores the freshly minted token in
+Redis under a short-lived, single-use code bound to an app-supplied PKCE
+challenge, and hands the deep link only that opaque code. The app later swaps the
+code for the token over TLS, proving possession of the matching ``code_verifier``
+— so a hijacked code is useless to an attacker who never saw the verifier.
+
+Security properties enforced here:
+  * single-use  -- atomic ``GETDEL`` burns the code on first read
+  * short TTL   -- ``MOBILE_SSO_CODE_TTL_SECONDS`` (default 60s)
+  * PKCE (S256) -- the verifier is hashed and constant-time-compared to the
+                   stored challenge (RFC 7636)
+
+Redis is core infra (always available, even when ``AUTH_BACKEND=jwt``), so this
+store works across every auth backend. Keys are a single global namespace: a
+code is a high-entropy random value mapping to exactly one already-tenant-bound
+token, so there is no cross-tenant ambiguity.
+"""
+
+import json
+import secrets
+
+from onyx.auth.pkce import compute_s256_challenge
+from onyx.configs.app_configs import MOBILE_SSO_CODE_PREFIX
+from onyx.configs.app_configs import MOBILE_SSO_CODE_TTL_SECONDS
+from onyx.redis.redis_pool import get_async_redis_connection
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+async def store_sso_code(token: str, code_challenge: str) -> str:
+    """Persist ``token`` under a fresh single-use code bound to ``code_challenge``.
+
+    Returns the opaque code to place on the deep link. The token itself already
+    encodes tenant context, so nothing tenant-specific is stored alongside it.
+    """
+    code = secrets.token_urlsafe(32)
+    record = {"token": token, "code_challenge": code_challenge}
+    redis = await get_async_redis_connection()
+    await redis.set(
+        f"{MOBILE_SSO_CODE_PREFIX}{code}",
+        json.dumps(record),
+        ex=MOBILE_SSO_CODE_TTL_SECONDS,
+    )
+    return code
+
+
+async def consume_sso_code(code: str, code_verifier: str) -> str | None:
+    """Atomically redeem ``code`` and return the token, or ``None`` on any failure.
+
+    Returns ``None`` — never raises, never distinguishes the reason — when the
+    code is missing, expired, already used, the verifier is malformed, or the
+    PKCE verifier doesn't match, so the caller can surface one generic error with
+    no oracle. The code is burned (``GETDEL``) before the PKCE check, so a wrong
+    verifier cannot be retried against the same code.
+    """
+    redis = await get_async_redis_connection()
+    # Atomic get-and-delete enforces single use (Redis 6.2+).
+    raw = await redis.getdel(f"{MOBILE_SSO_CODE_PREFIX}{code}")
+    if not raw:
+        return None
+
+    try:
+        record = json.loads(raw)
+        stored_challenge = record["code_challenge"]
+        token = record["token"]
+        # A malformed verifier (e.g. non-ascii) must fail closed as the same
+        # generic miss — compute_s256_challenge raises ValueError on bad input.
+        provided_challenge = compute_s256_challenge(code_verifier)
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+        logger.error("Malformed mobile SSO code record or verifier; rejecting")
+        return None
+
+    if not secrets.compare_digest(provided_challenge, stored_challenge):
+        return None
+
+    return token

--- a/backend/onyx/auth/mobile_sso/code_store.py
+++ b/backend/onyx/auth/mobile_sso/code_store.py
@@ -67,11 +67,22 @@ async def consume_sso_code(code: str, code_verifier: str) -> str | None:
         record = json.loads(raw)
         stored_challenge = record["code_challenge"]
         token = record["token"]
+        # A non-str challenge would make compare_digest raise TypeError below;
+        # treat a malformed record as the same generic miss to keep the
+        # fail-closed contract.
+        if not isinstance(stored_challenge, str) or not isinstance(token, str):
+            raise TypeError("malformed code record")
         # A malformed verifier (e.g. non-ascii) must fail closed as the same
         # generic miss — compute_s256_challenge raises ValueError on bad input.
         provided_challenge = compute_s256_challenge(code_verifier)
-    except (json.JSONDecodeError, KeyError, TypeError, ValueError):
-        logger.error("Malformed mobile SSO code record or verifier; rejecting")
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+        # Log the exception *type* only (never the value — that could leak the
+        # verifier) so a malformed record is distinguishable in logs from a
+        # normal miss.
+        logger.error(
+            "Malformed mobile SSO code record or verifier (%s); rejecting",
+            type(exc).__name__,
+        )
         return None
 
     if not secrets.compare_digest(provided_challenge, stored_challenge):

--- a/backend/onyx/auth/mobile_sso/sso_completion.py
+++ b/backend/onyx/auth/mobile_sso/sso_completion.py
@@ -1,0 +1,101 @@
+"""Shared SSO completion for native mobile clients.
+
+Every OAuth/SSO provider callback (Google today; OIDC / SAML / Apple later)
+funnels through ``complete_mobile_sso`` once the signed state carries the mobile
+marker. It mints the session token, stashes it behind a single-use PKCE-bound
+code, and 302-redirects to the app's custom-scheme deep link carrying ONLY that
+code (plus the app's own ``state`` for round-trip verification).
+
+The mobile params travel inside the signed OAuth state token (see
+``apply_mobile_state``), so they are tamper-proof through the IdP round-trip and
+need no separate cookie. ``is_mobile_sso`` / ``apply_mobile_state`` keep the
+state-key spelling private to this module — callers never touch the raw keys.
+"""
+
+from fastapi.responses import RedirectResponse
+from fastapi_users import models
+from fastapi_users.authentication import Strategy
+
+from onyx.auth.mobile_sso.code_store import store_sso_code
+from onyx.auth.mobile_sso.tokens import issue_session_credential
+from onyx.configs.app_configs import MOBILE_ALLOWED_REDIRECT_URIS
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.utils.logger import setup_logger
+from onyx.utils.url import add_url_params
+
+logger = setup_logger()
+
+# Keys carried (tamper-proof) inside the signed OAuth state token. Private to
+# this module so the spelling lives in exactly one place.
+_STATE_CLIENT_KEY = "client"
+_STATE_APP_REDIRECT_URI_KEY = "app_redirect_uri"
+_STATE_APP_STATE_KEY = "app_state"
+_STATE_APP_CODE_CHALLENGE_KEY = "app_code_challenge"
+_MOBILE_CLIENT_MARKER = "mobile"
+
+
+def apply_mobile_state(
+    state_data: dict[str, str],
+    mobile_redirect_uri: str | None,
+    app_state: str | None,
+    app_code_challenge: str | None,
+) -> None:
+    """Fold guarded mobile-SSO params into the (about-to-be-signed) OAuth state.
+
+    No-op for the web flow (``mobile_redirect_uri`` absent), so the signed state
+    is byte-identical to today's for every non-mobile caller.
+    """
+    if mobile_redirect_uri is None:
+        return
+    state_data[_STATE_CLIENT_KEY] = _MOBILE_CLIENT_MARKER
+    state_data[_STATE_APP_REDIRECT_URI_KEY] = mobile_redirect_uri
+    state_data[_STATE_APP_STATE_KEY] = app_state or ""
+    if app_code_challenge is not None:
+        state_data[_STATE_APP_CODE_CHALLENGE_KEY] = app_code_challenge
+
+
+def is_mobile_sso(state_data: dict[str, str]) -> bool:
+    return state_data.get(_STATE_CLIENT_KEY) == _MOBILE_CLIENT_MARKER
+
+
+async def complete_mobile_sso(
+    user: models.UP,
+    state_data: dict[str, str],
+    strategy: Strategy[models.UP, models.ID],
+) -> RedirectResponse:
+    """Finish an SSO login for a mobile client: mint -> store-under-code -> 302.
+
+    Requires an app-supplied PKCE challenge (mobile SSO is PKCE-only — we never
+    silently fall back to a non-PKCE code) and an allowlisted redirect URI.
+    Raises ``OnyxError(VALIDATION_ERROR)`` otherwise. Notably mints the token but
+    does NOT call ``backend.login``, so no web auth cookie is ever set.
+    """
+    app_redirect_uri = state_data.get(_STATE_APP_REDIRECT_URI_KEY)
+    app_code_challenge = state_data.get(_STATE_APP_CODE_CHALLENGE_KEY)
+    app_state = state_data.get(_STATE_APP_STATE_KEY, "")
+
+    if not app_code_challenge:
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            "Mobile SSO requires a PKCE code challenge",
+        )
+
+    if not app_redirect_uri or app_redirect_uri not in MOBILE_ALLOWED_REDIRECT_URIS:
+        # A redirect URI isn't a secret; log it + the allowlist so a misconfig
+        # is diagnosable instead of a silent 400.
+        logger.warning(
+            "Rejected mobile SSO redirect URI %r; allowed: %s",
+            app_redirect_uri,
+            MOBILE_ALLOWED_REDIRECT_URIS,
+        )
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            "Disallowed mobile redirect URI",
+        )
+
+    token = await issue_session_credential(user, strategy)
+    code = await store_sso_code(token, app_code_challenge)
+
+    deep_link = add_url_params(app_redirect_uri, {"code": code, "state": app_state})
+    return RedirectResponse(deep_link, status_code=302)

--- a/backend/onyx/auth/mobile_sso/sso_completion.py
+++ b/backend/onyx/auth/mobile_sso/sso_completion.py
@@ -12,6 +12,8 @@ need no separate cookie. ``is_mobile_sso`` / ``apply_mobile_state`` keep the
 state-key spelling private to this module — callers never touch the raw keys.
 """
 
+from typing import cast
+
 from fastapi.responses import RedirectResponse
 from fastapi_users import models
 from fastapi_users.authentication import Strategy
@@ -44,15 +46,46 @@ def apply_mobile_state(
     """Fold guarded mobile-SSO params into the (about-to-be-signed) OAuth state.
 
     No-op for the web flow (``mobile_redirect_uri`` absent), so the signed state
-    is byte-identical to today's for every non-mobile caller.
+    is byte-identical to today's for every non-mobile caller. For a mobile caller
+    the params are validated here — failing fast at authorize-time so a bad
+    request is rejected before the IdP round-trip rather than after it. Raises
+    ``OnyxError(VALIDATION_ERROR)`` on a missing challenge / disallowed URI.
     """
     if mobile_redirect_uri is None:
         return
+    _validate_mobile_sso_params(mobile_redirect_uri, app_code_challenge)
     state_data[_STATE_CLIENT_KEY] = _MOBILE_CLIENT_MARKER
     state_data[_STATE_APP_REDIRECT_URI_KEY] = mobile_redirect_uri
     state_data[_STATE_APP_STATE_KEY] = app_state or ""
-    if app_code_challenge is not None:
-        state_data[_STATE_APP_CODE_CHALLENGE_KEY] = app_code_challenge
+    # Non-None and validated above.
+    state_data[_STATE_APP_CODE_CHALLENGE_KEY] = cast(str, app_code_challenge)
+
+
+def _validate_mobile_sso_params(
+    app_redirect_uri: str | None, app_code_challenge: str | None
+) -> None:
+    """Enforce the mobile-SSO invariants (PKCE-only + allowlisted redirect URI).
+
+    Used at authorize-time (fail fast) and again in ``complete_mobile_sso`` as a
+    defensive backstop against any path that fills the state directly.
+    """
+    if not app_code_challenge:
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            "Mobile SSO requires a PKCE code challenge",
+        )
+    if not app_redirect_uri or app_redirect_uri not in MOBILE_ALLOWED_REDIRECT_URIS:
+        # A redirect URI isn't a secret; log it + the allowlist so a misconfig
+        # is diagnosable instead of a silent 400.
+        logger.warning(
+            "Rejected mobile SSO redirect URI %r; allowed: %s",
+            app_redirect_uri,
+            MOBILE_ALLOWED_REDIRECT_URIS,
+        )
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            "Disallowed mobile redirect URI",
+        )
 
 
 def is_mobile_sso(state_data: dict[str, str]) -> bool:
@@ -75,24 +108,11 @@ async def complete_mobile_sso(
     app_code_challenge = state_data.get(_STATE_APP_CODE_CHALLENGE_KEY)
     app_state = state_data.get(_STATE_APP_STATE_KEY, "")
 
-    if not app_code_challenge:
-        raise OnyxError(
-            OnyxErrorCode.VALIDATION_ERROR,
-            "Mobile SSO requires a PKCE code challenge",
-        )
-
-    if not app_redirect_uri or app_redirect_uri not in MOBILE_ALLOWED_REDIRECT_URIS:
-        # A redirect URI isn't a secret; log it + the allowlist so a misconfig
-        # is diagnosable instead of a silent 400.
-        logger.warning(
-            "Rejected mobile SSO redirect URI %r; allowed: %s",
-            app_redirect_uri,
-            MOBILE_ALLOWED_REDIRECT_URIS,
-        )
-        raise OnyxError(
-            OnyxErrorCode.VALIDATION_ERROR,
-            "Disallowed mobile redirect URI",
-        )
+    # Backstop: these are already enforced at authorize-time (apply_mobile_state),
+    # but re-check so any path that fills the state directly still fails closed.
+    _validate_mobile_sso_params(app_redirect_uri, app_code_challenge)
+    app_redirect_uri = cast(str, app_redirect_uri)
+    app_code_challenge = cast(str, app_code_challenge)
 
     token = await issue_session_credential(user, strategy)
     code = await store_sso_code(token, app_code_challenge)

--- a/backend/onyx/auth/mobile_sso/tokens.py
+++ b/backend/onyx/auth/mobile_sso/tokens.py
@@ -1,0 +1,20 @@
+"""Token-issuance seam for mobile auth.
+
+A single indirection point for minting the credential a native client receives.
+Today it mints the SAME session token the web cookie flow uses (via the active
+strategy's ``write_token``) — server-revocable under the redis/postgres backends,
+a self-contained non-revocable JWT under ``AUTH_BACKEND=jwt`` — differing from web
+only in transport (Authorization header vs HttpOnly cookie).
+
+This seam exists so a future access-token + refresh-token-rotation
+implementation (RFC 9700) can swap the body here without touching any caller.
+"""
+
+from fastapi_users import models
+from fastapi_users.authentication import Strategy
+
+
+async def issue_session_credential(
+    user: models.UP, strategy: Strategy[models.UP, models.ID]
+) -> str:
+    return await strategy.write_token(user)

--- a/backend/onyx/auth/pkce.py
+++ b/backend/onyx/auth/pkce.py
@@ -1,0 +1,20 @@
+"""Shared PKCE (RFC 7636) primitives.
+
+A single home for the S256 transform so every PKCE call site agrees byte-for-byte
+on how a verifier maps to a challenge — the OAuth router's IdP-leg challenge
+(`generate_pkce_pair`) and the mobile SSO code store's app-leg verification both
+go through `compute_s256_challenge`.
+"""
+
+import base64
+import hashlib
+
+
+def compute_s256_challenge(code_verifier: str) -> str:
+    """Compute BASE64URL(SHA256(code_verifier)) — the RFC 7636 S256 transform.
+
+    Raises ``ValueError`` (``UnicodeEncodeError``) on a non-ascii verifier; the
+    mobile code store relies on this to fail a malformed verifier closed.
+    """
+    digest = hashlib.sha256(code_verifier.encode("ascii")).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")

--- a/backend/onyx/auth/pkce.py
+++ b/backend/onyx/auth/pkce.py
@@ -1,9 +1,8 @@
-"""Shared PKCE (RFC 7636) primitives.
+"""PKCE (RFC 7636) S256 transform for the mobile SSO bridge.
 
-A single home for the S256 transform so every PKCE call site agrees byte-for-byte
-on how a verifier maps to a challenge — the OAuth router's IdP-leg challenge
-(`generate_pkce_pair`) and the mobile SSO code store's app-leg verification both
-go through `compute_s256_challenge`.
+Used by the mobile SSO code store to verify the app's ``code_verifier``. The web
+OAuth flow computes the same transform independently in
+``users.generate_pkce_pair``; a test pins that the two agree so they can't drift.
 """
 
 import base64

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -1,4 +1,3 @@
-import base64
 import hashlib
 import json
 import os
@@ -82,7 +81,11 @@ from onyx.auth.email_utils import send_user_verification_email
 from onyx.auth.invited_users import get_invited_users
 from onyx.auth.invited_users import remove_user_from_invited_users
 from onyx.auth.jwt import verify_jwt_token
+from onyx.auth.mobile_sso.sso_completion import apply_mobile_state
+from onyx.auth.mobile_sso.sso_completion import complete_mobile_sso
+from onyx.auth.mobile_sso.sso_completion import is_mobile_sso
 from onyx.auth.pat import get_hashed_pat_from_request
+from onyx.auth.pkce import compute_s256_challenge
 from onyx.auth.schemas import AuthBackend
 from onyx.auth.schemas import UserCreate
 from onyx.auth.schemas import UserRole
@@ -2187,14 +2190,9 @@ def generate_csrf_token() -> str:
     return secrets.token_urlsafe(32)
 
 
-def _base64url_encode(data: bytes) -> str:
-    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
-
-
 def generate_pkce_pair() -> tuple[str, str]:
     verifier = secrets.token_urlsafe(64)
-    challenge = _base64url_encode(hashlib.sha256(verifier.encode("ascii")).digest())
-    return verifier, challenge
+    return verifier, compute_s256_challenge(verifier)
 
 
 def get_pkce_cookie_name(state: str) -> str:
@@ -2276,6 +2274,11 @@ def get_oauth_router(
         response: Response,
         redirect: bool = Query(False),
         scopes: List[str] = Query(None),
+        # Native-mobile SSO params (guarded/optional). Present => folded into the
+        # signed state so the callback returns a PKCE one-time code, not a cookie.
+        mobile_redirect_uri: str | None = Query(None),
+        app_state: str | None = Query(None),
+        app_code_challenge: str | None = Query(None),
     ) -> Response | OAuth2AuthorizeResponse:
         referral_source = request.cookies.get("referral_source", None)
 
@@ -2295,6 +2298,10 @@ def get_oauth_router(
             "referral_source": referral_source or "default_referral",
             CSRF_TOKEN_KEY: csrf_token,
         }
+        # No-op for web; for mobile, marks the signed state for complete_mobile_sso.
+        apply_mobile_state(
+            state_data, mobile_redirect_uri, app_state, app_code_challenge
+        )
         state = generate_state_token(state_data, state_secret)
         pkce_cookie: tuple[str, str] | None = None
 
@@ -2591,6 +2598,18 @@ def get_oauth_router(
                     OnyxErrorCode.VALIDATION_ERROR,
                     ErrorCode.LOGIN_BAD_CREDENTIALS,
                 )
+
+            # Mobile clients get a PKCE one-time code over a deep link, not a web
+            # cookie. Guarded on the signed-state marker, so the web path below is
+            # byte-for-byte unchanged.
+            if is_mobile_sso(state_data):
+                redirect_response = await complete_mobile_sso(
+                    user, state_data, strategy
+                )
+                # Fire analytics like the web/bearer-login paths (PostHog
+                # identify). No web response here, so its anon-cookie cleanup no-ops.
+                await user_manager.on_after_login(user, request)
+                return redirect_response
 
             # Login user
             response = await backend.login(strategy, user)

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -1,3 +1,4 @@
+import base64
 import hashlib
 import json
 import os
@@ -85,7 +86,6 @@ from onyx.auth.mobile_sso.sso_completion import apply_mobile_state
 from onyx.auth.mobile_sso.sso_completion import complete_mobile_sso
 from onyx.auth.mobile_sso.sso_completion import is_mobile_sso
 from onyx.auth.pat import get_hashed_pat_from_request
-from onyx.auth.pkce import compute_s256_challenge
 from onyx.auth.schemas import AuthBackend
 from onyx.auth.schemas import UserCreate
 from onyx.auth.schemas import UserRole
@@ -2190,9 +2190,14 @@ def generate_csrf_token() -> str:
     return secrets.token_urlsafe(32)
 
 
+def _base64url_encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
 def generate_pkce_pair() -> tuple[str, str]:
     verifier = secrets.token_urlsafe(64)
-    return verifier, compute_s256_challenge(verifier)
+    challenge = _base64url_encode(hashlib.sha256(verifier.encode("ascii")).digest())
+    return verifier, challenge
 
 
 def get_pkce_cookie_name(state: str) -> str:

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -271,21 +271,23 @@ SAML_CONF_DIR = os.environ.get("SAML_CONF_DIR") or "/app/onyx/configs/saml_confi
 # /auth/mobile/sso/exchange.
 MOBILE_SSO_CODE_PREFIX = "mobile_sso_code:"
 # Lifetime of the one-time code; intentionally short — it only has to survive the
-# system-browser -> app handoff plus the immediate exchange call.
+# system-browser -> app handoff plus the immediate exchange call. A non-positive
+# TTL would make Redis reject the SET, breaking every exchange — fail fast at boot.
 MOBILE_SSO_CODE_TTL_SECONDS = int(os.environ.get("MOBILE_SSO_CODE_TTL_SECONDS") or 60)
+if MOBILE_SSO_CODE_TTL_SECONDS < 1:
+    raise ValueError("MOBILE_SSO_CODE_TTL_SECONDS must be >= 1")
 # Deep-link URIs the SSO completion is allowed to 302 to. Defaults to the app's
 # custom scheme; override (comma-separated) to add Universal/App Links later.
-_MOBILE_ALLOWED_REDIRECT_URIS_STR = os.environ.get(
-    "MOBILE_ALLOWED_REDIRECT_URIS", ""
-).strip()
+_DEFAULT_MOBILE_REDIRECT_URIS = frozenset({"onyx://auth/callback"})
+# A misconfigured value (e.g. just commas/whitespace) parses to an empty set,
+# which would silently reject every mobile redirect — fall back to the default.
 MOBILE_ALLOWED_REDIRECT_URIS: frozenset[str] = (
     frozenset(
         uri.strip()
-        for uri in _MOBILE_ALLOWED_REDIRECT_URIS_STR.split(",")
+        for uri in os.environ.get("MOBILE_ALLOWED_REDIRECT_URIS", "").split(",")
         if uri.strip()
     )
-    if _MOBILE_ALLOWED_REDIRECT_URIS_STR
-    else frozenset({"onyx://auth/callback"})
+    or _DEFAULT_MOBILE_REDIRECT_URIS
 )
 
 # JWT Public Key URL for JWT token verification

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -279,16 +279,22 @@ if MOBILE_SSO_CODE_TTL_SECONDS < 1:
 # Deep-link URIs the SSO completion is allowed to 302 to. Defaults to the app's
 # custom scheme; override (comma-separated) to add Universal/App Links later.
 _DEFAULT_MOBILE_REDIRECT_URIS = frozenset({"onyx://auth/callback"})
-# A misconfigured value (e.g. just commas/whitespace) parses to an empty set,
-# which would silently reject every mobile redirect — fall back to the default.
-MOBILE_ALLOWED_REDIRECT_URIS: frozenset[str] = (
-    frozenset(
-        uri.strip()
-        for uri in os.environ.get("MOBILE_ALLOWED_REDIRECT_URIS", "").split(",")
-        if uri.strip()
-    )
-    or _DEFAULT_MOBILE_REDIRECT_URIS
+_MOBILE_ALLOWED_REDIRECT_URIS_RAW = os.environ.get("MOBILE_ALLOWED_REDIRECT_URIS", "")
+MOBILE_ALLOWED_REDIRECT_URIS: frozenset[str] = frozenset(
+    uri.strip() for uri in _MOBILE_ALLOWED_REDIRECT_URIS_RAW.split(",") if uri.strip()
 )
+if not MOBILE_ALLOWED_REDIRECT_URIS:
+    # An override that was set but parsed empty (e.g. just commas/whitespace) is a
+    # misconfig — warn rather than silently rejecting every mobile redirect. An
+    # unset value is the normal default, so don't warn there.
+    if _MOBILE_ALLOWED_REDIRECT_URIS_RAW.strip():
+        logger.warning(
+            "MOBILE_ALLOWED_REDIRECT_URIS=%r parsed to an empty set; "
+            "falling back to default %s",
+            _MOBILE_ALLOWED_REDIRECT_URIS_RAW,
+            _DEFAULT_MOBILE_REDIRECT_URIS,
+        )
+    MOBILE_ALLOWED_REDIRECT_URIS = _DEFAULT_MOBILE_REDIRECT_URIS
 
 # JWT Public Key URL for JWT token verification
 JWT_PUBLIC_KEY_URL: str | None = os.getenv("JWT_PUBLIC_KEY_URL", None)

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -264,6 +264,30 @@ OIDC_PKCE_ENABLED = os.environ.get("OIDC_PKCE_ENABLED", "").lower() == "true"
 # Applicable for SAML Auth
 SAML_CONF_DIR = os.environ.get("SAML_CONF_DIR") or "/app/onyx/configs/saml_config"
 
+# Native mobile (Expo / React Native) SSO bridge. The app completes OAuth in the
+# system browser (reusing the existing registered IdP callback), then the backend
+# returns a single-use, PKCE-bound one-time code over a custom-scheme deep link —
+# never a token. The app swaps the code for the session token at
+# /auth/mobile/sso/exchange.
+MOBILE_SSO_CODE_PREFIX = "mobile_sso_code:"
+# Lifetime of the one-time code; intentionally short — it only has to survive the
+# system-browser -> app handoff plus the immediate exchange call.
+MOBILE_SSO_CODE_TTL_SECONDS = int(os.environ.get("MOBILE_SSO_CODE_TTL_SECONDS") or 60)
+# Deep-link URIs the SSO completion is allowed to 302 to. Defaults to the app's
+# custom scheme; override (comma-separated) to add Universal/App Links later.
+_MOBILE_ALLOWED_REDIRECT_URIS_STR = os.environ.get(
+    "MOBILE_ALLOWED_REDIRECT_URIS", ""
+).strip()
+MOBILE_ALLOWED_REDIRECT_URIS: frozenset[str] = (
+    frozenset(
+        uri.strip()
+        for uri in _MOBILE_ALLOWED_REDIRECT_URIS_STR.split(",")
+        if uri.strip()
+    )
+    if _MOBILE_ALLOWED_REDIRECT_URIS_STR
+    else frozenset({"onyx://auth/callback"})
+)
+
 # JWT Public Key URL for JWT token verification
 JWT_PUBLIC_KEY_URL: str | None = os.getenv("JWT_PUBLIC_KEY_URL", None)
 

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -70,7 +70,7 @@ from onyx.server.api_key.api import router as api_key_router
 from onyx.server.auth.captcha_api import CaptchaCookieMiddleware
 from onyx.server.auth.captcha_api import LoginCaptchaMiddleware
 from onyx.server.auth.captcha_api import router as captcha_router
-from onyx.server.auth.mobile import get_mobile_auth_router
+from onyx.server.auth.mobile import router as mobile_auth_router
 from onyx.server.auth_check import check_router_auth
 from onyx.server.documents.cc_pair import router as cc_pair_router
 from onyx.server.documents.connector import router as connector_router
@@ -598,7 +598,7 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
         # token is issued/refreshed/revoked as a Bearer instead of a cookie.
         include_auth_router_with_prefix(
             application,
-            get_mobile_auth_router(),
+            mobile_auth_router,
             prefix="/auth/mobile",
         )
 

--- a/backend/onyx/redis/redis_pool.py
+++ b/backend/onyx/redis/redis_pool.py
@@ -17,6 +17,9 @@ from redis.exceptions import TimeoutError as RedisTimeoutError
 from redis.lock import Lock as RedisLock
 from redis.retry import Retry
 
+from onyx.auth.constants import API_KEY_HEADER_ALTERNATIVE_NAME
+from onyx.auth.constants import API_KEY_HEADER_NAME
+from onyx.auth.constants import BEARER_PREFIX
 from onyx.configs.app_configs import REDIS_AUTH_KEY_PREFIX
 from onyx.configs.app_configs import REDIS_DB_NUMBER
 from onyx.configs.app_configs import REDIS_HEALTH_CHECK_INTERVAL
@@ -407,6 +410,27 @@ async def retrieve_auth_token_data_from_redis(request: Request) -> dict | None:
     token = request.cookies.get(FASTAPI_USERS_AUTH_COOKIE_NAME)
     if not token:
         logger.debug("No auth token cookie found")
+        return None
+    return await retrieve_auth_token_data(token)
+
+
+async def retrieve_auth_token_data_from_bearer(request: Request) -> dict | None:
+    """Validate a session auth token sent via the ``Authorization: Bearer`` header.
+
+    Mobile clients can't hold the HttpOnly ``fastapiusersauth`` cookie, so they
+    send the same opaque session token as a Bearer header. The token value is the
+    Redis lookup key, identical to the cookie flow. API keys / PATs are resolved
+    earlier by their prefix-based extractor, so a non-session bearer token simply
+    misses in Redis and returns None here.
+    """
+    auth_header = request.headers.get(
+        API_KEY_HEADER_ALTERNATIVE_NAME
+    ) or request.headers.get(API_KEY_HEADER_NAME)
+    if not auth_header or not auth_header.startswith(BEARER_PREFIX):
+        return None
+
+    token = auth_header[len(BEARER_PREFIX) :].strip()
+    if not token:
         return None
     return await retrieve_auth_token_data(token)
 

--- a/backend/onyx/server/auth/mobile.py
+++ b/backend/onyx/server/auth/mobile.py
@@ -5,32 +5,64 @@ backend as web, but receive the existing stateful session token as a Bearer
 value instead of an HttpOnly cookie. This module owns the mobile-facing auth
 surface.
 
-V1 (this PR): email/password login, refresh, and logout, mounted from the
-shared fastapi-users machinery against the `mobile-bearer` backend. The Google
-SSO bridge (`/auth/mobile/sso/exchange`) is added in a later PR.
+Endpoints:
+  - POST /auth/mobile/login         email/password -> {access_token, token_type}
+  - POST /auth/mobile/logout        revoke the current session token
+  - POST /auth/mobile/refresh       extend / reissue the session token
+  - POST /auth/mobile/sso/exchange  swap a one-time SSO code (+ PKCE verifier)
+                                    for the session token (Google SSO bridge)
 """
 
 from fastapi import APIRouter
+from pydantic import BaseModel
 
+from onyx.auth.mobile_sso.code_store import consume_sso_code
 from onyx.auth.users import fastapi_users
 from onyx.auth.users import mobile_auth_backend
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+
+
+class MobileSsoExchangeRequest(BaseModel):
+    code: str
+    code_verifier: str
+
+
+class MobileSsoTokenResponse(BaseModel):
+    # Same shape as the bearer login/refresh responses so the client has one
+    # token-handling path regardless of how it authenticated.
+    access_token: str
+    token_type: str = "bearer"
 
 
 def get_mobile_auth_router() -> APIRouter:
     """Build the `/auth/mobile` router (prefix applied at registration).
 
-    Exposes:
-      - POST /auth/mobile/login   email/password -> {access_token, token_type}
-      - POST /auth/mobile/logout  revoke the current session token
-      - POST /auth/mobile/refresh extend / reissue the session token
-
-    All three reuse the existing session strategy (so the Bearer token is the
-    exact same revocable token web gets) — only the transport differs. Routes
-    are namespaced `auth:mobile-bearer.*`, so they never collide with the web
-    cookie backend's `auth:<backend>.*` routes.
+    The login/refresh/logout routes reuse the existing session strategy (so the
+    Bearer token is the exact same token web gets — server-revocable under the
+    redis/postgres backends) — only the transport differs. Routes are namespaced
+    `auth:mobile-bearer.*`, so they never collide with the web cookie backend's
+    `auth:<backend>.*` routes.
     """
     router = APIRouter()
     # get_auth_router provides both /login and /logout for the bearer backend.
     router.include_router(fastapi_users.get_auth_router(mobile_auth_backend))
     router.include_router(fastapi_users.get_refresh_router(mobile_auth_backend))
+
+    @router.post("/sso/exchange")
+    async def sso_exchange(
+        payload: MobileSsoExchangeRequest,
+    ) -> MobileSsoTokenResponse:
+        """Swap a one-time SSO code (+ PKCE verifier) for the session token.
+
+        Returns the same `{access_token, token_type}` shape as the bearer login.
+        Any failure — unknown / expired / replayed code, or a verifier that
+        doesn't match the stored PKCE challenge — yields one generic 401 with no
+        oracle (see `consume_sso_code`).
+        """
+        token = await consume_sso_code(payload.code, payload.code_verifier)
+        if token is None:
+            raise OnyxError(OnyxErrorCode.UNAUTHENTICATED, "Invalid or expired code")
+        return MobileSsoTokenResponse(access_token=token)
+
     return router

--- a/backend/onyx/server/auth/mobile.py
+++ b/backend/onyx/server/auth/mobile.py
@@ -22,6 +22,17 @@ from onyx.auth.users import mobile_auth_backend
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 
+# Prefix ("/auth/mobile") is applied at registration in main.py. The bearer
+# login/refresh/logout sub-routers are built from `mobile_auth_backend`, so they
+# reuse the existing session strategy — the Bearer token is the exact same token
+# web gets (server-revocable under the redis/postgres backends); only the
+# transport differs. Their route names are namespaced `auth:mobile-bearer.*`, so
+# they never collide with the web cookie backend's `auth:<backend>.*` routes.
+router = APIRouter()
+# get_auth_router provides both /login and /logout for the bearer backend.
+router.include_router(fastapi_users.get_auth_router(mobile_auth_backend))
+router.include_router(fastapi_users.get_refresh_router(mobile_auth_backend))
+
 
 class MobileSsoExchangeRequest(BaseModel):
     code: str
@@ -35,34 +46,16 @@ class MobileSsoTokenResponse(BaseModel):
     token_type: str = "bearer"
 
 
-def get_mobile_auth_router() -> APIRouter:
-    """Build the `/auth/mobile` router (prefix applied at registration).
+@router.post("/sso/exchange")
+async def sso_exchange(payload: MobileSsoExchangeRequest) -> MobileSsoTokenResponse:
+    """Swap a one-time SSO code (+ PKCE verifier) for the session token.
 
-    The login/refresh/logout routes reuse the existing session strategy (so the
-    Bearer token is the exact same token web gets — server-revocable under the
-    redis/postgres backends) — only the transport differs. Routes are namespaced
-    `auth:mobile-bearer.*`, so they never collide with the web cookie backend's
-    `auth:<backend>.*` routes.
+    Returns the same `{access_token, token_type}` shape as the bearer login. Any
+    failure — unknown / expired / replayed code, or a verifier that doesn't match
+    the stored PKCE challenge — yields one generic 401 with no oracle (see
+    `consume_sso_code`).
     """
-    router = APIRouter()
-    # get_auth_router provides both /login and /logout for the bearer backend.
-    router.include_router(fastapi_users.get_auth_router(mobile_auth_backend))
-    router.include_router(fastapi_users.get_refresh_router(mobile_auth_backend))
-
-    @router.post("/sso/exchange")
-    async def sso_exchange(
-        payload: MobileSsoExchangeRequest,
-    ) -> MobileSsoTokenResponse:
-        """Swap a one-time SSO code (+ PKCE verifier) for the session token.
-
-        Returns the same `{access_token, token_type}` shape as the bearer login.
-        Any failure — unknown / expired / replayed code, or a verifier that
-        doesn't match the stored PKCE challenge — yields one generic 401 with no
-        oracle (see `consume_sso_code`).
-        """
-        token = await consume_sso_code(payload.code, payload.code_verifier)
-        if token is None:
-            raise OnyxError(OnyxErrorCode.UNAUTHENTICATED, "Invalid or expired code")
-        return MobileSsoTokenResponse(access_token=token)
-
-    return router
+    token = await consume_sso_code(payload.code, payload.code_verifier)
+    if token is None:
+        raise OnyxError(OnyxErrorCode.UNAUTHENTICATED, "Invalid or expired code")
+    return MobileSsoTokenResponse(access_token=token)

--- a/backend/onyx/server/auth_check.py
+++ b/backend/onyx/server/auth_check.py
@@ -54,6 +54,10 @@ PUBLIC_ENDPOINT_SPECS = [
     ("/auth/mobile/login", {"POST"}),
     ("/auth/mobile/refresh", {"POST"}),
     ("/auth/mobile/logout", {"POST"}),
+    # swaps a one-time SSO code (+ PKCE verifier) for the session token; it has
+    # no user dependency by design (the code IS the credential), so it must be
+    # declared public to satisfy the startup public-route assertion.
+    ("/auth/mobile/sso/exchange", {"POST"}),
     ("/users/me", {"GET"}),
     ("/users/me", {"PATCH"}),
     ("/users/{id}", {"GET"}),

--- a/backend/tests/external_dependency_unit/auth/test_mobile_sso_bridge.py
+++ b/backend/tests/external_dependency_unit/auth/test_mobile_sso_bridge.py
@@ -1,0 +1,326 @@
+"""External-dependency-unit tests for the mobile SSO bridge on the shared OAuth
+router (`get_oauth_router`), the highest-blast-radius change in the mobile-auth
+work — it edits code that web Google login also runs.
+
+Uses a stub OAuth client + mocked strategy/backend (à la `test_oidc_pkce.py`),
+but a REAL Redis (the one-time code is actually stored/redeemed). Google runs the
+non-PKCE branch (`enable_pkce=False`), so that is what we exercise here.
+
+Coverage:
+  * authorize folds the guarded mobile params into the *signed* state (and is a
+    no-op for web callers — the regression guard against drift),
+  * the callback's `client=="mobile"` branch returns a 302 to the deep link
+    carrying a single-use, PKCE-bound code and NO web auth cookie,
+  * the web cookie path is byte-for-byte unchanged when the marker is absent,
+  * disallowed redirect URI / missing PKCE challenge are rejected (400).
+"""
+
+import asyncio
+from typing import Any
+from typing import cast
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+from urllib.parse import parse_qs
+from urllib.parse import urlparse
+
+import httpx
+from fastapi import FastAPI
+from fastapi import Response
+from fastapi.testclient import TestClient
+from fastapi_users.authentication import AuthenticationBackend
+from fastapi_users.authentication import CookieTransport
+from fastapi_users.jwt import decode_jwt
+from httpx_oauth.oauth2 import BaseOAuth2
+
+from onyx.auth.mobile_sso.code_store import consume_sso_code
+from onyx.auth.users import generate_pkce_pair
+from onyx.auth.users import get_oauth_router
+from onyx.auth.users import STATE_TOKEN_AUDIENCE
+from onyx.error_handling.exceptions import register_onyx_exception_handlers
+
+_STATE_SECRET = "test-secret"
+_MINTED_TOKEN = "minted_session_token"
+_ALLOWED_REDIRECT = "onyx://auth/callback"
+
+
+class _StubOAuthClient:
+    def __init__(self) -> None:
+        self.name = "google"
+        self.authorization_calls: list[dict[str, Any]] = []
+        self.access_token_calls: list[dict[str, Any]] = []
+
+    async def get_authorization_url(
+        self,
+        redirect_uri: str,
+        state: str | None = None,
+        scope: list[str] | None = None,
+        code_challenge: str | None = None,
+        code_challenge_method: str | None = None,
+    ) -> str:
+        self.authorization_calls.append(
+            {
+                "redirect_uri": redirect_uri,
+                "state": state,
+                "scope": scope,
+                "code_challenge": code_challenge,
+                "code_challenge_method": code_challenge_method,
+            }
+        )
+        return f"https://accounts.google.com/o/oauth2/auth?state={state}"
+
+    async def get_access_token(
+        self, code: str, redirect_uri: str, code_verifier: str | None = None
+    ) -> dict[str, str | int]:
+        self.access_token_calls.append(
+            {"code": code, "redirect_uri": redirect_uri, "code_verifier": code_verifier}
+        )
+        return {
+            "access_token": "google_access_token",
+            "refresh_token": "google_refresh_token",
+            "expires_at": 1730000000,
+        }
+
+    async def get_id_email(self, _access_token: str) -> tuple[str, str | None]:
+        return ("google_account_id", "mobile_user@example.com")
+
+
+def _build_test_client(
+    enable_pkce: bool = False,
+) -> tuple[TestClient, _StubOAuthClient, AsyncMock, MagicMock]:
+    oauth_client = _StubOAuthClient()
+    transport = CookieTransport(cookie_name="testsession")
+
+    # The strategy mints the bearer credential (issue_session_credential ->
+    # strategy.write_token). Mock it so we get a deterministic token without a
+    # real session backend.
+    strategy = MagicMock()
+    strategy.write_token = AsyncMock(return_value=_MINTED_TOKEN)
+
+    async def get_strategy() -> MagicMock:
+        return strategy
+
+    backend = AuthenticationBackend(
+        name="test_backend",
+        transport=transport,
+        get_strategy=get_strategy,
+    )
+
+    login_response = Response(status_code=302)
+    login_response.headers["location"] = "/app"
+    login_response.set_cookie("testsession", "session-token")
+    login_mock = AsyncMock(return_value=login_response)
+    backend.login = login_mock  # ty: ignore[invalid-assignment]
+
+    user = MagicMock()
+    user.is_active = True
+    user_manager = MagicMock()
+    user_manager.oauth_callback = AsyncMock(return_value=user)
+    user_manager.on_after_login = AsyncMock()
+
+    async def get_user_manager() -> MagicMock:
+        return user_manager
+
+    # enable_pkce=False mirrors Google's real config; OIDC (enable_pkce=True)
+    # shares this router and the same mobile branch, so we exercise both.
+    router = get_oauth_router(
+        oauth_client=cast(BaseOAuth2[Any], oauth_client),
+        backend=backend,
+        get_user_manager=get_user_manager,
+        state_secret=_STATE_SECRET,
+        redirect_url="http://localhost/auth/oauth/callback",
+        associate_by_email=True,
+        is_verified_by_default=True,
+        enable_pkce=enable_pkce,
+    )
+    app = FastAPI()
+    app.include_router(router, prefix="/auth/oauth")
+    register_onyx_exception_handlers(app)
+
+    client = TestClient(app, raise_server_exceptions=False)
+    return client, oauth_client, login_mock, user_manager
+
+
+def _authorize_and_get_state(client: TestClient, params: dict[str, str]) -> str:
+    response = client.get("/auth/oauth/authorize", params=params)
+    assert response.status_code == 200
+    auth_url = response.json()["authorization_url"]
+    return parse_qs(urlparse(auth_url).query)["state"][0]
+
+
+def _callback(client: TestClient, state: str) -> httpx.Response:
+    # Every callback test resolves the tenant the same way; centralize the patch.
+    with patch(
+        "onyx.auth.users.fetch_ee_implementation_or_noop",
+        return_value=lambda _email: "tenant_1",
+    ):
+        return client.get(
+            "/auth/oauth/callback",
+            params={"code": "idp_code", "state": state},
+            follow_redirects=False,
+        )
+
+
+def test_authorize_folds_mobile_params_into_signed_state() -> None:
+    client, _, _, _ = _build_test_client()
+    _, challenge = generate_pkce_pair()
+
+    state = _authorize_and_get_state(
+        client,
+        {
+            "mobile_redirect_uri": _ALLOWED_REDIRECT,
+            "app_state": "appstate-xyz",
+            "app_code_challenge": challenge,
+        },
+    )
+
+    decoded = decode_jwt(state, _STATE_SECRET, [STATE_TOKEN_AUDIENCE])
+    assert decoded["client"] == "mobile"
+    assert decoded["app_redirect_uri"] == _ALLOWED_REDIRECT
+    assert decoded["app_state"] == "appstate-xyz"
+    assert decoded["app_code_challenge"] == challenge
+
+
+def test_authorize_without_mobile_params_leaves_state_unmarked() -> None:
+    # Web-flow regression: the signed state must not gain any mobile keys.
+    client, _, _, _ = _build_test_client()
+
+    state = _authorize_and_get_state(client, {})
+
+    decoded = decode_jwt(state, _STATE_SECRET, [STATE_TOKEN_AUDIENCE])
+    assert "client" not in decoded
+    assert "app_redirect_uri" not in decoded
+    assert "app_code_challenge" not in decoded
+
+
+def test_mobile_callback_returns_deep_link_with_consumable_code() -> None:
+    client, _, login_mock, _ = _build_test_client()
+    verifier, challenge = generate_pkce_pair()
+    state = _authorize_and_get_state(
+        client,
+        {
+            "mobile_redirect_uri": _ALLOWED_REDIRECT,
+            "app_state": "roundtrip-state",
+            "app_code_challenge": challenge,
+        },
+    )
+
+    response = _callback(client, state)
+
+    assert response.status_code == 302
+    location = response.headers["location"]
+    assert location.startswith(f"{_ALLOWED_REDIRECT}?")
+
+    query = parse_qs(urlparse(location).query)
+    assert query["state"][0] == "roundtrip-state"
+    code = query["code"][0]
+
+    # The deep link must NOT carry the token, and no web auth cookie is set.
+    assert "access_token" not in query
+    assert "testsession" not in response.cookies
+    login_mock.assert_not_awaited()
+
+    # The code redeems exactly once, only with the matching verifier.
+    assert asyncio.run(consume_sso_code(code, verifier)) == _MINTED_TOKEN
+    assert asyncio.run(consume_sso_code(code, verifier)) is None
+
+
+def test_web_callback_unchanged_when_marker_absent() -> None:
+    # The web cookie login path must be untouched by the mobile branch.
+    client, _, login_mock, user_manager = _build_test_client()
+    state = _authorize_and_get_state(client, {})
+
+    response = _callback(client, state)
+
+    assert response.status_code == 302
+    assert response.headers["location"] == "/"
+    assert "testsession" in response.cookies
+    login_mock.assert_awaited_once()
+    user_manager.oauth_callback.assert_awaited_once()
+
+
+def test_mobile_callback_rejects_disallowed_redirect_uri() -> None:
+    client, _, login_mock, _ = _build_test_client()
+    _, challenge = generate_pkce_pair()
+    state = _authorize_and_get_state(
+        client,
+        {
+            "mobile_redirect_uri": "https://evil.example.com/callback",
+            "app_state": "s",
+            "app_code_challenge": challenge,
+        },
+    )
+
+    response = _callback(client, state)
+
+    assert response.status_code == 400
+    assert response.json()["error_code"] == "VALIDATION_ERROR"
+    login_mock.assert_not_awaited()
+
+
+def test_mobile_callback_rejects_missing_pkce_challenge() -> None:
+    # Mobile SSO is PKCE-only — no silent fallback to a non-PKCE code.
+    client, _, login_mock, _ = _build_test_client()
+    state = _authorize_and_get_state(
+        client,
+        {
+            "mobile_redirect_uri": _ALLOWED_REDIRECT,
+            "app_state": "s",
+        },
+    )
+
+    response = _callback(client, state)
+
+    assert response.status_code == 400
+    assert response.json()["error_code"] == "VALIDATION_ERROR"
+    login_mock.assert_not_awaited()
+
+
+# The mobile branch in the shared complete_login_flow also runs for PKCE
+# providers (OIDC), where an OnyxError is funneled through build_error_response
+# (+ delete_pkce_cookie) — a different disposition than the non-PKCE path above.
+
+
+def test_mobile_callback_pkce_path_returns_deep_link_with_consumable_code() -> None:
+    client, _, login_mock, _ = _build_test_client(enable_pkce=True)
+    verifier, challenge = generate_pkce_pair()
+    # authorize sets the IdP-leg PKCE verifier cookie (carried by the client).
+    state = _authorize_and_get_state(
+        client,
+        {
+            "mobile_redirect_uri": _ALLOWED_REDIRECT,
+            "app_state": "pkce-roundtrip",
+            "app_code_challenge": challenge,
+        },
+    )
+
+    response = _callback(client, state)
+
+    assert response.status_code == 302
+    location = response.headers["location"]
+    assert location.startswith(f"{_ALLOWED_REDIRECT}?")
+    query = parse_qs(urlparse(location).query)
+    assert query["state"][0] == "pkce-roundtrip"
+    assert "access_token" not in query
+    assert "testsession" not in response.cookies
+    login_mock.assert_not_awaited()
+    assert asyncio.run(consume_sso_code(query["code"][0], verifier)) == _MINTED_TOKEN
+
+
+def test_mobile_callback_pkce_path_rejects_missing_challenge() -> None:
+    # On the PKCE path the OnyxError flows through build_error_response; assert it
+    # still surfaces as a clean 400 (and doesn't corrupt the response).
+    client, _, login_mock, _ = _build_test_client(enable_pkce=True)
+    state = _authorize_and_get_state(
+        client,
+        {
+            "mobile_redirect_uri": _ALLOWED_REDIRECT,
+            "app_state": "s",
+        },
+    )
+
+    response = _callback(client, state)
+
+    assert response.status_code == 400
+    assert response.json()["error_code"] == "VALIDATION_ERROR"
+    login_mock.assert_not_awaited()

--- a/backend/tests/external_dependency_unit/auth/test_mobile_sso_bridge.py
+++ b/backend/tests/external_dependency_unit/auth/test_mobile_sso_bridge.py
@@ -12,7 +12,8 @@ Coverage:
   * the callback's `client=="mobile"` branch returns a 302 to the deep link
     carrying a single-use, PKCE-bound code and NO web auth cookie,
   * the web cookie path is byte-for-byte unchanged when the marker is absent,
-  * disallowed redirect URI / missing PKCE challenge are rejected (400).
+  * disallowed redirect URI / missing PKCE challenge are rejected at
+    authorize-time (400), before the IdP round-trip.
 """
 
 import asyncio
@@ -239,46 +240,61 @@ def test_web_callback_unchanged_when_marker_absent() -> None:
     user_manager.oauth_callback.assert_awaited_once()
 
 
-def test_mobile_callback_rejects_disallowed_redirect_uri() -> None:
+def test_authorize_rejects_disallowed_redirect_uri() -> None:
+    # Fail fast at authorize-time — before the IdP round-trip — for a redirect
+    # URI that isn't allowlisted, so no signed state is ever minted for it.
     client, _, login_mock, _ = _build_test_client()
     _, challenge = generate_pkce_pair()
-    state = _authorize_and_get_state(
-        client,
-        {
+    response = client.get(
+        "/auth/oauth/authorize",
+        params={
             "mobile_redirect_uri": "https://evil.example.com/callback",
             "app_state": "s",
             "app_code_challenge": challenge,
         },
     )
 
-    response = _callback(client, state)
-
     assert response.status_code == 400
     assert response.json()["error_code"] == "VALIDATION_ERROR"
     login_mock.assert_not_awaited()
 
 
-def test_mobile_callback_rejects_missing_pkce_challenge() -> None:
-    # Mobile SSO is PKCE-only — no silent fallback to a non-PKCE code.
+def test_authorize_rejects_missing_pkce_challenge() -> None:
+    # Mobile SSO is PKCE-only — reject at authorize-time rather than deferring the
+    # failure to the callback (no silent fallback to a non-PKCE code).
     client, _, login_mock, _ = _build_test_client()
-    state = _authorize_and_get_state(
-        client,
-        {
+    response = client.get(
+        "/auth/oauth/authorize",
+        params={
             "mobile_redirect_uri": _ALLOWED_REDIRECT,
             "app_state": "s",
         },
     )
 
-    response = _callback(client, state)
+    assert response.status_code == 400
+    assert response.json()["error_code"] == "VALIDATION_ERROR"
+    login_mock.assert_not_awaited()
+
+
+def test_authorize_pkce_provider_rejects_missing_challenge() -> None:
+    # Same authorize-time rejection on a PKCE provider (OIDC); the raise happens
+    # before any IdP-leg PKCE cookie is issued.
+    client, _, login_mock, _ = _build_test_client(enable_pkce=True)
+    response = client.get(
+        "/auth/oauth/authorize",
+        params={
+            "mobile_redirect_uri": _ALLOWED_REDIRECT,
+            "app_state": "s",
+        },
+    )
 
     assert response.status_code == 400
     assert response.json()["error_code"] == "VALIDATION_ERROR"
     login_mock.assert_not_awaited()
 
 
-# The mobile branch in the shared complete_login_flow also runs for PKCE
-# providers (OIDC), where an OnyxError is funneled through build_error_response
-# (+ delete_pkce_cookie) — a different disposition than the non-PKCE path above.
+# The mobile branch in the shared complete_login_flow also runs the success path
+# for PKCE providers (OIDC), which share this router and the same mobile branch.
 
 
 def test_mobile_callback_pkce_path_returns_deep_link_with_consumable_code() -> None:
@@ -305,22 +321,3 @@ def test_mobile_callback_pkce_path_returns_deep_link_with_consumable_code() -> N
     assert "testsession" not in response.cookies
     login_mock.assert_not_awaited()
     assert asyncio.run(consume_sso_code(query["code"][0], verifier)) == _MINTED_TOKEN
-
-
-def test_mobile_callback_pkce_path_rejects_missing_challenge() -> None:
-    # On the PKCE path the OnyxError flows through build_error_response; assert it
-    # still surfaces as a clean 400 (and doesn't corrupt the response).
-    client, _, login_mock, _ = _build_test_client(enable_pkce=True)
-    state = _authorize_and_get_state(
-        client,
-        {
-            "mobile_redirect_uri": _ALLOWED_REDIRECT,
-            "app_state": "s",
-        },
-    )
-
-    response = _callback(client, state)
-
-    assert response.status_code == 400
-    assert response.json()["error_code"] == "VALIDATION_ERROR"
-    login_mock.assert_not_awaited()

--- a/backend/tests/external_dependency_unit/auth/test_mobile_sso_code_store.py
+++ b/backend/tests/external_dependency_unit/auth/test_mobile_sso_code_store.py
@@ -6,6 +6,7 @@ binding so a hijacked code is useless without the matching verifier.
 """
 
 import asyncio
+import json
 
 import pytest
 
@@ -103,3 +104,18 @@ async def test_non_ascii_verifier_fails_closed_as_generic_miss() -> None:
     _, challenge = generate_pkce_pair()
     code = await store_sso_code("tok_non_ascii", challenge)
     assert await consume_sso_code(code, "naïve-vérifier-✗") is None
+
+
+@pytest.mark.asyncio
+async def test_malformed_record_fails_closed_as_generic_miss() -> None:
+    # A record with a non-str challenge would make compare_digest raise; it must
+    # instead fail closed as the same generic miss (fail-closed contract).
+    verifier, _ = generate_pkce_pair()
+    code = "manually-planted-malformed-code"
+    redis = await get_async_redis_connection()
+    await redis.set(
+        f"{MOBILE_SSO_CODE_PREFIX}{code}",
+        json.dumps({"token": "tok", "code_challenge": 12345}),
+        ex=MOBILE_SSO_CODE_TTL_SECONDS,
+    )
+    assert await consume_sso_code(code, verifier) is None

--- a/backend/tests/external_dependency_unit/auth/test_mobile_sso_code_store.py
+++ b/backend/tests/external_dependency_unit/auth/test_mobile_sso_code_store.py
@@ -1,0 +1,105 @@
+"""External-dependency-unit tests for the mobile SSO one-time code store.
+
+Runs against a real Redis. Pins the security contract that protects the
+custom-scheme deep link: single-use redemption, a short TTL, and PKCE (S256)
+binding so a hijacked code is useless without the matching verifier.
+"""
+
+import asyncio
+
+import pytest
+
+from onyx.auth.mobile_sso.code_store import consume_sso_code
+from onyx.auth.mobile_sso.code_store import store_sso_code
+from onyx.auth.pkce import compute_s256_challenge
+from onyx.auth.users import generate_pkce_pair
+from onyx.configs.app_configs import MOBILE_SSO_CODE_PREFIX
+from onyx.configs.app_configs import MOBILE_SSO_CODE_TTL_SECONDS
+from onyx.redis.redis_pool import get_async_redis_connection
+
+
+@pytest.mark.asyncio
+async def test_store_then_consume_round_trip() -> None:
+    verifier, challenge = generate_pkce_pair()
+    code = await store_sso_code("tok_round_trip", challenge)
+    assert code
+    assert await consume_sso_code(code, verifier) == "tok_round_trip"
+
+
+@pytest.mark.asyncio
+async def test_code_is_single_use() -> None:
+    verifier, challenge = generate_pkce_pair()
+    code = await store_sso_code("tok_single_use", challenge)
+
+    assert await consume_sso_code(code, verifier) == "tok_single_use"
+    # The atomic GETDEL burned the code on first read.
+    assert await consume_sso_code(code, verifier) is None
+
+
+@pytest.mark.asyncio
+async def test_wrong_verifier_rejected_and_burns_code() -> None:
+    verifier, challenge = generate_pkce_pair()
+    wrong_verifier, _ = generate_pkce_pair()
+    code = await store_sso_code("tok_wrong_verifier", challenge)
+
+    # A code without the matching verifier is useless (PKCE) ...
+    assert await consume_sso_code(code, wrong_verifier) is None
+    # ... and the failed attempt still burned the code, so even the correct
+    # verifier cannot redeem it afterwards (no retry oracle).
+    assert await consume_sso_code(code, verifier) is None
+
+
+@pytest.mark.asyncio
+async def test_unknown_code_returns_none() -> None:
+    verifier, _ = generate_pkce_pair()
+    assert await consume_sso_code("this-code-was-never-stored", verifier) is None
+
+
+@pytest.mark.asyncio
+async def test_store_sets_bounded_ttl() -> None:
+    _, challenge = generate_pkce_pair()
+    code = await store_sso_code("tok_ttl", challenge)
+
+    redis = await get_async_redis_connection()
+    ttl = await redis.ttl(f"{MOBILE_SSO_CODE_PREFIX}{code}")
+    # Positive TTL that never exceeds the configured ceiling -> the code self-
+    # expires even if it is never redeemed.
+    assert 0 < ttl <= MOBILE_SSO_CODE_TTL_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_code_expires_after_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "onyx.auth.mobile_sso.code_store.MOBILE_SSO_CODE_TTL_SECONDS", 1
+    )
+    verifier, challenge = generate_pkce_pair()
+    code = await store_sso_code("tok_expiry", challenge)
+
+    await asyncio.sleep(1.5)
+    assert await consume_sso_code(code, verifier) is None
+
+
+def test_s256_matches_generate_pkce_pair() -> None:
+    # The store's S256 transform must agree with the app-facing PKCE generator,
+    # otherwise a verifier produced by the client would never validate.
+    verifier, challenge = generate_pkce_pair()
+    assert compute_s256_challenge(verifier) == challenge
+
+
+def test_s256_matches_rfc7636_fixed_vector() -> None:
+    # Pin the transform against the canonical RFC 7636 Appendix B vector so it is
+    # locked independently of generate_pkce_pair.
+    verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+    assert (
+        compute_s256_challenge(verifier)
+        == "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+    )
+
+
+@pytest.mark.asyncio
+async def test_non_ascii_verifier_fails_closed_as_generic_miss() -> None:
+    # A malformed (non-ascii) verifier must redeem to None — the same generic
+    # miss as any other failure — never raise / leak a distinct error.
+    _, challenge = generate_pkce_pair()
+    code = await store_sso_code("tok_non_ascii", challenge)
+    assert await consume_sso_code(code, "naïve-vérifier-✗") is None

--- a/backend/tests/integration/multitenant_tests/test_mobile_bearer_tenant_resolution.py
+++ b/backend/tests/integration/multitenant_tests/test_mobile_bearer_tenant_resolution.py
@@ -1,0 +1,51 @@
+"""Multi-tenant regression test for mobile bearer-token tenant resolution.
+
+A mobile client authenticates with the opaque session token in the
+``Authorization: Bearer`` header (no cookie). In multi-tenant cloud the EE tenant
+middleware must resolve the tenant from that header — otherwise every authed
+route falls back to the default schema and the user (who lives in their own
+tenant schema) is not found.
+
+This guards against that gap: it fails before the bearer-header path is added to
+``_get_tenant_id_from_request`` and passes after. The single-tenant counterpart
+(``tests/mobile_auth/test_mobile_bearer_auth.py``) can't catch it because the
+middleware short-circuits to the default schema when ``MULTI_TENANT`` is off.
+"""
+
+from uuid import uuid4
+
+from onyx.db.models import UserRole
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.http_client import client
+from tests.integration.common_utils.managers.user import UserManager
+from tests.integration.common_utils.test_models import DATestUser
+from tests.integration.tests.mobile_auth._helpers import bearer
+from tests.integration.tests.mobile_auth._helpers import mobile_login
+
+
+def test_mobile_bearer_resolves_tenant(reset_multitenant: None) -> None:  # noqa: ARG001
+    # A fresh email provisions its own tenant; the first user is ADMIN and lives
+    # in that tenant's schema, not the default/public schema.
+    unique = uuid4().hex
+    user: DATestUser = UserManager.create(
+        name=f"mobile_{unique}", email=f"mobile_{unique}@example.com"
+    )
+    assert UserManager.is_role(user, UserRole.ADMIN)
+
+    # Obtain a Bearer session token via the mobile login endpoint.
+    resp = mobile_login(user.email, user.password)
+    resp.raise_for_status()
+    token = resp.json()["access_token"]
+    assert token
+
+    # Drop every cookie so the Bearer header is the ONLY tenant signal. Without
+    # this, the leftover web session cookie from UserManager.create would resolve
+    # the tenant and mask the bug we're guarding against.
+    client.cookies.clear()
+
+    # /me must resolve to this user's tenant. If the middleware can't read the
+    # tenant from the Bearer header it falls back to the default schema, the user
+    # lookup misses, and this returns 401/403 instead of the user.
+    me = client.get(url=f"{API_SERVER_URL}/me", headers=bearer(token))
+    me.raise_for_status()
+    assert me.json()["email"] == user.email

--- a/backend/tests/integration/tests/mobile_auth/_helpers.py
+++ b/backend/tests/integration/tests/mobile_auth/_helpers.py
@@ -1,0 +1,22 @@
+"""Shared helpers for the mobile-auth integration tests."""
+
+import httpx
+
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.constants import GENERAL_HEADERS
+from tests.integration.common_utils.http_client import client
+
+
+def mobile_login(email: str, password: str) -> httpx.Response:
+    # Form-encoded credentials, exactly like the web /auth/login.
+    headers = GENERAL_HEADERS.copy()
+    headers.pop("Content-Type", None)
+    return client.post(
+        url=f"{API_SERVER_URL}/auth/mobile/login",
+        data={"username": email, "password": password},
+        headers=headers,
+    )
+
+
+def bearer(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}

--- a/backend/tests/integration/tests/mobile_auth/test_mobile_bearer_auth.py
+++ b/backend/tests/integration/tests/mobile_auth/test_mobile_bearer_auth.py
@@ -5,34 +5,18 @@ session token as a Bearer (Authorization header) instead of the web cookie,
 and that the web cookie flow is unaffected.
 """
 
-import httpx
-
 from onyx.configs.constants import FASTAPI_USERS_AUTH_COOKIE_NAME
 from tests.integration.common_utils.constants import API_SERVER_URL
-from tests.integration.common_utils.constants import GENERAL_HEADERS
 from tests.integration.common_utils.http_client import client
 from tests.integration.common_utils.test_models import DATestUser
-
-
-def _mobile_login(email: str, password: str) -> httpx.Response:
-    # Form-encoded credentials, exactly like the web /auth/login.
-    headers = GENERAL_HEADERS.copy()
-    headers.pop("Content-Type", None)
-    return client.post(
-        url=f"{API_SERVER_URL}/auth/mobile/login",
-        data={"username": email, "password": password},
-        headers=headers,
-    )
-
-
-def _bearer(token: str) -> dict[str, str]:
-    return {"Authorization": f"Bearer {token}"}
+from tests.integration.tests.mobile_auth._helpers import bearer
+from tests.integration.tests.mobile_auth._helpers import mobile_login
 
 
 def test_mobile_bearer_login_refresh_logout(admin_user: DATestUser) -> None:
     # 1) Mobile login returns a Bearer token as JSON — and must NOT set the web
     #    auth cookie (a native client can't use HttpOnly cookies).
-    resp = _mobile_login(admin_user.email, admin_user.password)
+    resp = mobile_login(admin_user.email, admin_user.password)
     resp.raise_for_status()
     body = resp.json()
     assert body["token_type"].lower() == "bearer"
@@ -44,36 +28,36 @@ def test_mobile_bearer_login_refresh_logout(admin_user: DATestUser) -> None:
     client.cookies.clear()
 
     # 2) The Bearer token authenticates /me.
-    me = client.get(url=f"{API_SERVER_URL}/me", headers=_bearer(token))
+    me = client.get(url=f"{API_SERVER_URL}/me", headers=bearer(token))
     me.raise_for_status()
     assert me.json()["email"] == admin_user.email
 
     # 3) Refresh returns a usable token (redis/postgres extend the same token;
     #    either way the returned token must authenticate).
     refreshed = client.post(
-        url=f"{API_SERVER_URL}/auth/mobile/refresh", headers=_bearer(token)
+        url=f"{API_SERVER_URL}/auth/mobile/refresh", headers=bearer(token)
     )
     refreshed.raise_for_status()
     new_token = refreshed.json()["access_token"]
     assert new_token
     client.cookies.clear()
-    me2 = client.get(url=f"{API_SERVER_URL}/me", headers=_bearer(new_token))
+    me2 = client.get(url=f"{API_SERVER_URL}/me", headers=bearer(new_token))
     me2.raise_for_status()
 
     # 4) Logout revokes the token server-side; reuse is rejected.
     logout = client.post(
-        url=f"{API_SERVER_URL}/auth/mobile/logout", headers=_bearer(new_token)
+        url=f"{API_SERVER_URL}/auth/mobile/logout", headers=bearer(new_token)
     )
     logout.raise_for_status()
     client.cookies.clear()
     # The revoked token must no longer authenticate (unauthenticated /me is
     # rejected — 403 in this deployment, 401 in others; both mean "rejected").
-    me3 = client.get(url=f"{API_SERVER_URL}/me", headers=_bearer(new_token))
+    me3 = client.get(url=f"{API_SERVER_URL}/me", headers=bearer(new_token))
     assert me3.status_code in (401, 403)
 
 
 def test_mobile_bearer_login_bad_credentials(admin_user: DATestUser) -> None:
-    resp = _mobile_login(admin_user.email, "definitely-not-the-password")
+    resp = mobile_login(admin_user.email, "definitely-not-the-password")
     # fastapi-users returns 400 LOGIN_BAD_CREDENTIALS; accept 401 defensively.
     assert resp.status_code in (400, 401)
     assert "access_token" not in resp.json()

--- a/backend/tests/integration/tests/mobile_auth/test_mobile_sso_exchange.py
+++ b/backend/tests/integration/tests/mobile_auth/test_mobile_sso_exchange.py
@@ -18,16 +18,8 @@ from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.constants import GENERAL_HEADERS
 from tests.integration.common_utils.http_client import client
 from tests.integration.common_utils.test_models import DATestUser
-
-
-def _mobile_login(email: str, password: str) -> httpx.Response:
-    headers = GENERAL_HEADERS.copy()
-    headers.pop("Content-Type", None)
-    return client.post(
-        url=f"{API_SERVER_URL}/auth/mobile/login",
-        data={"username": email, "password": password},
-        headers=headers,
-    )
+from tests.integration.tests.mobile_auth._helpers import bearer
+from tests.integration.tests.mobile_auth._helpers import mobile_login
 
 
 def _exchange(code: str, code_verifier: str) -> httpx.Response:
@@ -40,7 +32,7 @@ def _exchange(code: str, code_verifier: str) -> httpx.Response:
 
 def test_mobile_sso_exchange_round_trip(admin_user: DATestUser) -> None:
     # A real, revocable session token (as a provider callback would mint).
-    login_resp = _mobile_login(admin_user.email, admin_user.password)
+    login_resp = mobile_login(admin_user.email, admin_user.password)
     login_resp.raise_for_status()
     token = login_resp.json()["access_token"]
     assert token
@@ -56,10 +48,7 @@ def test_mobile_sso_exchange_round_trip(admin_user: DATestUser) -> None:
     assert body["token_type"].lower() == "bearer"
     assert body["access_token"] == token
 
-    me = client.get(
-        url=f"{API_SERVER_URL}/me",
-        headers={**GENERAL_HEADERS, "Authorization": f"Bearer {token}"},
-    )
+    me = client.get(url=f"{API_SERVER_URL}/me", headers=bearer(token))
     assert me.status_code == 200
     assert me.json()["email"] == admin_user.email
     client.cookies.clear()
@@ -67,20 +56,3 @@ def test_mobile_sso_exchange_round_trip(admin_user: DATestUser) -> None:
     # Single-use: replaying the same code now fails with a generic 401.
     replay = _exchange(code, verifier)
     assert replay.status_code == 401
-
-
-def test_mobile_sso_exchange_wrong_verifier_is_generic_401(
-    admin_user: DATestUser,
-) -> None:
-    login_resp = _mobile_login(admin_user.email, admin_user.password)
-    login_resp.raise_for_status()
-    token = login_resp.json()["access_token"]
-    client.cookies.clear()
-
-    _, challenge = generate_pkce_pair()
-    code = asyncio.run(store_sso_code(token, challenge))
-
-    # A code without the matching verifier is useless (PKCE), same 401 as a
-    # missing/expired code — no oracle.
-    resp = _exchange(code, "not-the-real-verifier")
-    assert resp.status_code == 401

--- a/backend/tests/integration/tests/mobile_auth/test_mobile_sso_exchange.py
+++ b/backend/tests/integration/tests/mobile_auth/test_mobile_sso_exchange.py
@@ -1,0 +1,86 @@
+"""Integration test for the mobile SSO code-exchange endpoint (PR 4).
+
+Exercises the real `/auth/mobile/sso/exchange` endpoint end-to-end: a real
+session token is stashed behind a one-time PKCE-bound code (as
+`complete_mobile_sso` would do), the app swaps the code for the token, the token
+authenticates `/me`, and replay / wrong-verifier attempts fail with a generic
+401. The Google leg itself can't be driven without a live IdP, so we stash a
+genuine bearer token (minted via `/auth/mobile/login`) and verify the bridge.
+"""
+
+import asyncio
+
+import httpx
+
+from onyx.auth.mobile_sso.code_store import store_sso_code
+from onyx.auth.users import generate_pkce_pair
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.constants import GENERAL_HEADERS
+from tests.integration.common_utils.http_client import client
+from tests.integration.common_utils.test_models import DATestUser
+
+
+def _mobile_login(email: str, password: str) -> httpx.Response:
+    headers = GENERAL_HEADERS.copy()
+    headers.pop("Content-Type", None)
+    return client.post(
+        url=f"{API_SERVER_URL}/auth/mobile/login",
+        data={"username": email, "password": password},
+        headers=headers,
+    )
+
+
+def _exchange(code: str, code_verifier: str) -> httpx.Response:
+    return client.post(
+        url=f"{API_SERVER_URL}/auth/mobile/sso/exchange",
+        json={"code": code, "code_verifier": code_verifier},
+        headers=GENERAL_HEADERS,
+    )
+
+
+def test_mobile_sso_exchange_round_trip(admin_user: DATestUser) -> None:
+    # A real, revocable session token (as a provider callback would mint).
+    login_resp = _mobile_login(admin_user.email, admin_user.password)
+    login_resp.raise_for_status()
+    token = login_resp.json()["access_token"]
+    assert token
+    client.cookies.clear()
+
+    # Stash it behind a one-time PKCE-bound code, exactly like complete_mobile_sso.
+    verifier, challenge = generate_pkce_pair()
+    code = asyncio.run(store_sso_code(token, challenge))
+
+    resp = _exchange(code, verifier)
+    resp.raise_for_status()
+    body = resp.json()
+    assert body["token_type"].lower() == "bearer"
+    assert body["access_token"] == token
+
+    me = client.get(
+        url=f"{API_SERVER_URL}/me",
+        headers={**GENERAL_HEADERS, "Authorization": f"Bearer {token}"},
+    )
+    assert me.status_code == 200
+    assert me.json()["email"] == admin_user.email
+    client.cookies.clear()
+
+    # Single-use: replaying the same code now fails with a generic 401.
+    replay = _exchange(code, verifier)
+    assert replay.status_code == 401
+
+
+def test_mobile_sso_exchange_wrong_verifier_is_generic_401(
+    admin_user: DATestUser,
+) -> None:
+    login_resp = _mobile_login(admin_user.email, admin_user.password)
+    login_resp.raise_for_status()
+    token = login_resp.json()["access_token"]
+    client.cookies.clear()
+
+    _, challenge = generate_pkce_pair()
+    code = asyncio.run(store_sso_code(token, challenge))
+
+    # A code without the matching verifier is useless (PKCE), same 401 as a
+    # missing/expired code — no oracle.
+    resp = _exchange(code, "not-the-real-verifier")
+    assert resp.status_code == 401

--- a/backend/tests/unit/ee/onyx/server/middleware/test_tenant_tracking.py
+++ b/backend/tests/unit/ee/onyx/server/middleware/test_tenant_tracking.py
@@ -1,0 +1,94 @@
+"""Tests for the api-server tenant-resolution middleware.
+
+Focus: tenant resolution must **fail closed**. A transient Redis error during
+the cookie- or Bearer-header session-token lookup must propagate (500), not get
+swallowed into a silent default-schema fallback — otherwise a request could be
+served against the wrong tenant. (Contrast license enforcement, which fails
+*open*; tenant routing is a data-isolation boundary and must not.)
+"""
+
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from ee.onyx.server.middleware import tenant_tracking
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
+
+MODULE = "ee.onyx.server.middleware.tenant_tracking"
+
+
+def _request(headers: dict[str, str] | None = None) -> Request:
+    raw = [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()]
+    return Request({"type": "http", "method": "GET", "path": "/me", "headers": raw})
+
+
+@pytest.mark.asyncio
+@patch(f"{MODULE}.retrieve_auth_token_data_from_bearer")
+@patch(f"{MODULE}.retrieve_auth_token_data_from_redis")
+async def test_bearer_redis_error_propagates_not_default(
+    mock_cookie: AsyncMock,
+    mock_bearer: AsyncMock,
+) -> None:
+    """A Redis failure on the Bearer lookup must surface as 500, not fall back to
+    the default schema (the bug the `finally` block used to mask)."""
+    mock_cookie.return_value = None
+    mock_bearer.side_effect = ValueError("redis down")
+
+    req = _request({"Authorization": "Bearer opaque_session_token"})
+    with pytest.raises(HTTPException) as exc:
+        await tenant_tracking._get_tenant_id_from_request(req, MagicMock())
+    assert exc.value.status_code == 500
+
+
+@pytest.mark.asyncio
+@patch(f"{MODULE}.retrieve_auth_token_data_from_bearer")
+@patch(f"{MODULE}.retrieve_auth_token_data_from_redis")
+async def test_cookie_redis_error_propagates_not_default(
+    mock_cookie: AsyncMock,
+    mock_bearer: AsyncMock,
+) -> None:
+    """Same fail-closed guarantee for the pre-existing cookie path."""
+    mock_cookie.side_effect = ValueError("redis down")
+
+    req = _request()
+    with pytest.raises(HTTPException) as exc:
+        await tenant_tracking._get_tenant_id_from_request(req, MagicMock())
+    assert exc.value.status_code == 500
+    mock_bearer.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch(f"{MODULE}.retrieve_auth_token_data_from_bearer")
+@patch(f"{MODULE}.retrieve_auth_token_data_from_redis")
+async def test_bearer_resolves_tenant(
+    mock_cookie: AsyncMock,
+    mock_bearer: AsyncMock,
+) -> None:
+    """Happy path: a mobile Bearer token resolves its tenant from Redis."""
+    mock_cookie.return_value = None
+    mock_bearer.return_value = {"tenant_id": "tenant_abc123"}
+
+    req = _request({"Authorization": "Bearer opaque_session_token"})
+    tenant_id = await tenant_tracking._get_tenant_id_from_request(req, MagicMock())
+    assert tenant_id == "tenant_abc123"
+
+
+@pytest.mark.asyncio
+@patch(f"{MODULE}.retrieve_auth_token_data_from_bearer")
+@patch(f"{MODULE}.retrieve_auth_token_data_from_redis")
+async def test_no_auth_returns_default_schema(
+    mock_cookie: AsyncMock,
+    mock_bearer: AsyncMock,
+) -> None:
+    """Unauthenticated requests still fall back to the default schema (the normal
+    `finally` path is preserved — the guard only suppresses it on error)."""
+    mock_cookie.return_value = None
+    mock_bearer.return_value = None
+
+    req = _request()
+    tenant_id = await tenant_tracking._get_tenant_id_from_request(req, MagicMock())
+    assert tenant_id == POSTGRES_DEFAULT_SCHEMA


### PR DESCRIPTION
## Description

- Add native-mobile Google SSO: the OAuth callback returns a single-use, PKCE-bound one-time code over a deep link instead of a web cookie/token.
- Add `POST /auth/mobile/sso/exchange` to swap the code (+ PKCE verifier) for the existing revocable session token.
- Carry guarded mobile params inside the signed OAuth state so the web flow is byte-for-byte unchanged when the mobile marker is absent.
- Add a short-lived, single-use Redis code store and a shared RFC 7636 S256 PKCE helper reused by the existing `generate_pkce_pair`.

## How Has This Been Tested?

- External-dependency-unit tests for the bridge + code store, and integration tests for the exchange round-trip and generic-401 failure path.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a native-mobile SSO bridge that returns a PKCE-bound one-time code over a deep link and an exchange endpoint that swaps the code for the existing session token. Also fixes multi-tenant tenant resolution for mobile bearer tokens to fail closed on Redis errors; web SSO remains unchanged and the mobile path is opt-in via the signed OAuth state.

- **New Features**
  - `POST /auth/mobile/sso/exchange` swaps a one-time `code` + `code_verifier` for `{access_token, token_type}`; declared public in `auth_check`.
  - OAuth callbacks detect mobile via the signed state and 302 to `mobile_redirect_uri` with `code` and `state` only (no cookie/token).
  - Redis code store: single-use (`GETDEL`), short TTL (`MOBILE_SSO_CODE_TTL_SECONDS` ≥ 1), PKCE S256 verification; fails closed on malformed records/verifiers; allowlisted redirects via `MOBILE_ALLOWED_REDIRECT_URIS` (falls back to `onyx://auth/callback` and warns if the env parses empty).
  - Authorize-time validation: reject missing PKCE challenge or disallowed redirect before the IdP round-trip (400).
  - Multi-tenant: EE middleware resolves the tenant from `Authorization: Bearer` session tokens and does not silently fall back on Redis errors.

- **Migration**
  - Set `MOBILE_ALLOWED_REDIRECT_URIS` to your app’s deep link (defaults to `onyx://auth/callback`).
  - Mobile flow: call `/auth/oauth/authorize` with `mobile_redirect_uri` and `app_code_challenge` (optional `app_state`), then redeem the deep link `code` at `/auth/mobile/sso/exchange` with `{code, code_verifier}`; use the returned bearer.

<sup>Written for commit 1235b0844127be4135cfd4d97fcbf9c3a65f7302. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

