### PR TITLE
fix(voice): log Azure STT cancellations, no-speech, and session end (#12107) to release v4.2

### DIFF
--- a/backend/onyx/voice/providers/azure.py
+++ b/backend/onyx/voice/providers/azure.py
@@ -73,6 +73,7 @@ class AzureStreamingTranscriber(StreamingTranscriberProtocol):
         input_sample_rate: int = 24000,
         target_sample_rate: int = 16000,
     ):
+        self._logger = setup_logger()
         self.api_key = api_key
         self.region = region
         self.endpoint = endpoint
@@ -136,7 +137,15 @@ class AzureStreamingTranscriber(StreamingTranscriberProtocol):
                 )
 
         def on_recognized(evt: Any) -> None:
-            if evt.result.text and transcriber._loop and not transcriber._closed:
+            if not evt.result.text:
+                # Azure finished a segment but matched no speech. Log the reason
+                # so this isn't a silent empty transcript.
+                transcriber._logger.info(
+                    "Azure STT: no speech recognized in segment (reason=%s)",
+                    getattr(evt.result, "reason", None),
+                )
+                return
+            if transcriber._loop and not transcriber._closed:
                 if transcriber._accumulated_transcript:
                     transcriber._accumulated_transcript += " " + evt.result.text
                 else:
@@ -148,8 +157,34 @@ class AzureStreamingTranscriber(StreamingTranscriberProtocol):
                     ),
                 )
 
+        def on_canceled(evt: Any) -> None:
+            # Surfaces Azure-side failures that were previously swallowed:
+            # auth errors, region/endpoint mismatch, quota, blocked outbound
+            # connection to Azure, or bad audio format. The diagnostic fields
+            # live on evt.cancellation_details (code is a CancellationErrorCode),
+            # not on evt itself.
+            details = getattr(evt, "cancellation_details", None)
+            transcriber._logger.error(
+                "Azure STT canceled: reason=%s code=%s details=%s",
+                getattr(details, "reason", None),
+                getattr(details, "code", None),
+                getattr(details, "error_details", None),
+            )
+            # A cancel is terminal — no more transcripts will arrive. Signal
+            # end-of-stream so the consumer loop stops polling instead of
+            # spinning on empty results forever.
+            if transcriber._loop and not transcriber._closed:
+                transcriber._loop.call_soon_threadsafe(
+                    transcriber._transcript_queue.put_nowait, None
+                )
+
+        def on_session_stopped(_evt: Any) -> None:
+            transcriber._logger.info("Azure STT: session stopped")
+
         self._recognizer.recognizing.connect(on_recognizing)
         self._recognizer.recognized.connect(on_recognized)
+        self._recognizer.canceled.connect(on_canceled)
+        self._recognizer.session_stopped.connect(on_session_stopped)
         self._recognizer.start_continuous_recognition_async()
 
     async def send_audio(self, chunk: bytes) -> None:


### PR DESCRIPTION
Cherry-pick of commit d28e5b1e4cf6c8c15df4b0c4ad1886d819e3bdca to release/v4.2 branch.

Original PR: #12107

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add logging for Azure Speech-to-Text cancellations, no-speech segments, and session end. Also signal end-of-stream on cancel to prevent the consumer loop from spinning.

- **Bug Fixes**
  - Log empty recognition segments with the Azure reason.
  - Log cancellations with reason, code, and error details from `cancellation_details`.
  - Log `session_stopped` events.
  - On cancel, enqueue `None` to `_transcript_queue` to stop polling.
  - Initialize a dedicated logger for the Azure transcriber.

<sup>Written for commit c12154f69256bcf827a2a0971431ad0eacd0b1ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

