### PR TITLE
fix(craft): pin v4.1.3 sandbox image [hotfix v4.1]

### DIFF
--- a/.github/workflows/sandbox-deployment.yml
+++ b/.github/workflows/sandbox-deployment.yml
@@ -113,10 +113,12 @@ jobs:
             exit 0
           fi
 
-          # Query Docker Hub for the latest versioned tag
+          # Auto-increment only the sandbox-internal v0.* stream. App release
+          # tags such as v4.1.3 are published manually and must not seed
+          # future nightly versions.
           LATEST_TAG=$(curl -s "https://hub.docker.com/v2/repositories/onyxdotapp/sandbox/tags?page_size=100" \
             | jq -r '.results[].name' \
-            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+            | grep -E '^v0\.[0-9]+\.[0-9]+$' \
             | sort -V \
             | tail -n 1)
 

--- a/.github/workflows/sandbox-deployment.yml
+++ b/.github/workflows/sandbox-deployment.yml
@@ -113,12 +113,10 @@ jobs:
             exit 0
           fi
 
-          # Auto-increment only the sandbox-internal v0.* stream. App release
-          # tags such as v4.1.3 are published manually and must not seed
-          # future nightly versions.
+          # Query Docker Hub for the latest versioned tag
           LATEST_TAG=$(curl -s "https://hub.docker.com/v2/repositories/onyxdotapp/sandbox/tags?page_size=100" \
             | jq -r '.results[].name' \
-            | grep -E '^v0\.[0-9]+\.[0-9]+$' \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
             | sort -V \
             | tail -n 1)
 

--- a/.github/workflows/sandbox-deployment.yml
+++ b/.github/workflows/sandbox-deployment.yml
@@ -1,12 +1,23 @@
 name: Build and Push Sandbox Image
 
 # The sandbox image is the only Craft-specific image. Build a new version on
-# the nightly tag when its build context changed, or manually on demand.
+# the nightly tag when its build context changed, or manually with an explicit
+# Docker tag for stable release branches.
 on:
   push:
     tags:
       - "nightly-latest-*"
   workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Docker tag to publish, e.g. v4.1.3. Leave blank to auto-increment."
+        required: false
+        type: string
+      update_latest:
+        description: "Also move onyxdotapp/sandbox:latest to this image"
+        required: true
+        default: false
+        type: boolean
 
 # Restrictive defaults; jobs declare what they need.
 permissions: {}
@@ -19,7 +30,8 @@ jobs:
       contents: read
     outputs:
       sandbox-changed: ${{ steps.check.outputs.sandbox-changed }}
-      new-version: ${{ steps.version.outputs.new-version }}
+      image-tag: ${{ steps.version.outputs.image-tag }}
+      publish-latest: ${{ steps.version.outputs.publish-latest }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
@@ -61,7 +73,46 @@ jobs:
       - name: Determine new sandbox version
         id: version
         if: steps.check.outputs.sandbox-changed == 'true'
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REQUESTED_IMAGE_TAG: ${{ github.event.inputs.image_tag }}
+          REQUESTED_UPDATE_LATEST: ${{ github.event.inputs.update_latest }}
         run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            PUBLISH_LATEST="${REQUESTED_UPDATE_LATEST:-false}"
+          else
+            PUBLISH_LATEST="true"
+          fi
+
+          if [ "$PUBLISH_LATEST" != "true" ] && [ "$PUBLISH_LATEST" != "false" ]; then
+            echo "update_latest must be true or false, got '${PUBLISH_LATEST}'" >&2
+            exit 1
+          fi
+
+          if [ -n "$REQUESTED_IMAGE_TAG" ]; then
+            if ! printf '%s' "$REQUESTED_IMAGE_TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+              echo "image_tag must use the form vX.Y.Z, got '${REQUESTED_IMAGE_TAG}'" >&2
+              exit 1
+            fi
+
+            TAG_STATUS=$(curl -sS -o /dev/null -w "%{http_code}" \
+              "https://hub.docker.com/v2/repositories/onyxdotapp/sandbox/tags/${REQUESTED_IMAGE_TAG}")
+            if [ "$TAG_STATUS" = "200" ]; then
+              echo "Docker Hub tag onyxdotapp/sandbox:${REQUESTED_IMAGE_TAG} already exists" >&2
+              exit 1
+            fi
+            if [ "$TAG_STATUS" != "404" ]; then
+              echo "Could not verify Docker Hub tag availability; got HTTP ${TAG_STATUS}" >&2
+              exit 1
+            fi
+
+            IMAGE_TAG="$REQUESTED_IMAGE_TAG"
+            echo "Using requested Docker tag: $IMAGE_TAG"
+            echo "image-tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+            echo "publish-latest=$PUBLISH_LATEST" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           # Query Docker Hub for the latest versioned tag
           LATEST_TAG=$(curl -s "https://hub.docker.com/v2/repositories/onyxdotapp/sandbox/tags?page_size=100" \
             | jq -r '.results[].name' \
@@ -84,8 +135,10 @@ jobs:
             NEW_VERSION="${MAJOR}.${MINOR}.${NEW_PATCH}"
           fi
 
-          echo "New version: $NEW_VERSION"
-          echo "new-version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          IMAGE_TAG="v${NEW_VERSION}"
+          echo "New version: $IMAGE_TAG"
+          echo "image-tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+          echo "publish-latest=$PUBLISH_LATEST" >> "$GITHUB_OUTPUT"
 
   build-sandbox-amd64:
     needs: check-sandbox-changes
@@ -277,8 +330,8 @@ jobs:
           flavor: |
             latest=false
           tags: |
-            type=raw,value=v${{ needs.check-sandbox-changes.outputs.new-version }}
-            type=raw,value=latest
+            type=raw,value=${{ needs.check-sandbox-changes.outputs.image-tag }}
+            type=raw,value=latest,enable=${{ needs.check-sandbox-changes.outputs.publish-latest == 'true' }}
 
       - name: Create and push manifest
         env:

--- a/backend/onyx/server/features/build/configs.py
+++ b/backend/onyx/server/features/build/configs.py
@@ -51,7 +51,7 @@ ATTACHMENTS_DIRECTORY = "attachments"
 SANDBOX_NAMESPACE = os.environ.get("SANDBOX_NAMESPACE", "onyx-sandboxes")
 
 SANDBOX_CONTAINER_IMAGE = os.environ.get(
-    "SANDBOX_CONTAINER_IMAGE", "onyxdotapp/sandbox:v0.1.52"
+    "SANDBOX_CONTAINER_IMAGE", "onyxdotapp/sandbox:v4.1.3"
 )
 
 # Path structure: s3://{bucket}/{tenant_id}/snapshots/{session_id}/{snapshot_id}.tar.gz

--- a/backend/onyx/server/features/build/sandbox/README.md
+++ b/backend/onyx/server/features/build/sandbox/README.md
@@ -158,7 +158,7 @@ OPENCODE_DISABLED_TOOLS=question           # Comma-separated list, default: ques
 SANDBOX_NAMESPACE=onyx-sandboxes          # Default: onyx-sandboxes
 
 # Container image
-SANDBOX_CONTAINER_IMAGE=onyxdotapp/sandbox:latest
+SANDBOX_CONTAINER_IMAGE=onyxdotapp/sandbox:v4.1.3
 
 # S3 bucket for snapshots and files
 SANDBOX_S3_BUCKET=onyx-sandbox-files      # Default: onyx-sandbox-files
@@ -171,7 +171,7 @@ SANDBOX_SERVICE_ACCOUNT_NAME=sandbox-file-sync  # Has S3 access via IRSA for sna
 
 ```bash
 # Container image (defaults to a pinned tag in docker-compose.yml)
-SANDBOX_CONTAINER_IMAGE=onyxdotapp/sandbox:v0.1.52
+SANDBOX_CONTAINER_IMAGE=onyxdotapp/sandbox:v4.1.3
 
 # Public URL the sandbox agent uses to reach Onyx (HTTPS, externally resolvable —
 # compose hostnames like http://api_server:8080 will not resolve from inside the

--- a/deployment/docker_compose/docker-compose.craft.yml
+++ b/deployment/docker_compose/docker-compose.craft.yml
@@ -11,7 +11,7 @@ services:
       # Public Onyx URL; Internal compose hostnames don't resolve from the
       # sandbox bridge.
       - SANDBOX_API_SERVER_URL=${SANDBOX_API_SERVER_URL:-}
-      - SANDBOX_CONTAINER_IMAGE=${SANDBOX_CONTAINER_IMAGE:-onyxdotapp/sandbox:v0.1.52}
+      - SANDBOX_CONTAINER_IMAGE=${SANDBOX_CONTAINER_IMAGE:-onyxdotapp/sandbox:v4.1.3}
       # Pinned: Must match the compose `networks:` block + install.sh literal.
       # An env_file leak would point Python at a non-existent network.
       - SANDBOX_DOCKER_NETWORK=onyx_craft_sandbox
@@ -45,7 +45,7 @@ services:
       # backend to snapshot + terminate sandboxes.
       - SANDBOX_BACKEND=${SANDBOX_BACKEND:-docker}
       - SANDBOX_API_SERVER_URL=${SANDBOX_API_SERVER_URL:-}
-      - SANDBOX_CONTAINER_IMAGE=${SANDBOX_CONTAINER_IMAGE:-onyxdotapp/sandbox:v0.1.52}
+      - SANDBOX_CONTAINER_IMAGE=${SANDBOX_CONTAINER_IMAGE:-onyxdotapp/sandbox:v4.1.3}
       # See api_server above re: Pinned env_file-override vars.
       - SANDBOX_DOCKER_NETWORK=onyx_craft_sandbox
       - SANDBOX_DOCKER_MEMORY_LIMIT=${SANDBOX_DOCKER_MEMORY_LIMIT:-2g}

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -28,7 +28,7 @@ IMAGE_TAG=latest
 # SANDBOX_API_SERVER_URL=https://onyx.your-org.example
 #
 ## Sandbox container image. Pinned by default for reproducibility.
-# SANDBOX_CONTAINER_IMAGE=onyxdotapp/sandbox:v0.1.52
+# SANDBOX_CONTAINER_IMAGE=onyxdotapp/sandbox:v4.1.3
 #
 ## Sandbox bridge network. Created by install.sh (or manually:
 ##   docker network create onyx_craft_sandbox


### PR DESCRIPTION
## Description

- Adds a manual `image_tag` input to the sandbox deployment workflow for stable release branches.
- Allows publishing explicit Docker Hub tags such as `onyxdotapp/sandbox:v4.1.3` without moving `latest` unless requested.
- Updates the Craft sandbox defaults to `onyxdotapp/sandbox:v4.1.3` for backend config and Docker Compose.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the Craft sandbox image to `onyxdotapp/sandbox:v4.1.3` across backend defaults, Docker Compose, and docs. Updates the sandbox deployment workflow to publish explicit `vX.Y.Z` tags and control when `latest` moves.

- **New Features**
  - `workflow_dispatch` accepts `image_tag` (vX.Y.Z) and `update_latest`; validates input and rejects existing tags on Docker Hub.
  - Nightly builds auto-increment a versioned tag and move `latest`; manual runs keep `latest` unless `update_latest` is true.
  - Workflow outputs `image-tag` and `publish-latest`; `latest` tagging is conditional.

<sup>Written for commit 78266f311d1f57d7058dd4aac13c6d383cfce600. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

