### PR TITLE
fix(llm): resolve Bifrost vision support from LiteLLM cost map

### DIFF
--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -51,6 +51,7 @@ from onyx.llm.factory import get_max_input_tokens_from_llm_provider
 from onyx.llm.utils import get_bedrock_token_limit
 from onyx.llm.utils import get_llm_contextual_cost
 from onyx.llm.utils import is_sensitive_custom_config_key
+from onyx.llm.utils import litellm_thinks_model_supports_image_input
 from onyx.llm.utils import test_llm
 from onyx.llm.well_known_providers.auto_update_service import (
     fetch_llm_recommendations_from_github,
@@ -1727,7 +1728,10 @@ def get_bifrost_available_models(
                     name=model_id,
                     display_name=model_name,
                     max_input_tokens=model.get("context_length"),
-                    supports_image_input=infer_vision_support(model_id),
+                    # Vision support from the LiteLLM cost map, not a hardcoded list
+                    supports_image_input=litellm_thinks_model_supports_image_input(
+                        model_id, LlmProviderNames.BIFROST
+                    ),
                     supports_reasoning=is_reasoning_model(model_id, model_name),
                 )
             )


### PR DESCRIPTION
## Description

The Bifrost model-fetch handler determined image-input (vision) support via a hand-curated substring list of model families. Any model whose id did not match those hardcoded patterns was reported as non-vision — notably Anthropic's newer `claude-<tier>-<version>` id format, which the version-first patterns missed. The result: affected models showed no Vision tag and rejected image uploads in chat.

This switches the Bifrost path to resolve vision support from the LiteLLM model cost map — the same authoritative, continuously-updated capability source already used for static providers — so detection stays correct without manual list upkeep.

Scope is intentionally limited to Bifrost. Bedrock (which uses its provider's native modality metadata) and the OpenAI-compatible path are unchanged.

## How Has This Been Tested?

- Existing unit tests for the Bifrost fetch handler pass; the vision-support test now exercises the real cost map (vision-capable chat models resolve True, text-only models resolve False).
- Ran the provider-utils and model-configuration unit suites (70 tests) — all pass.
- `ruff` and `ty` type checks pass.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the `LiteLLM` cost map to detect vision support for Bifrost models instead of a substring list. This fixes missing Vision tags and blocked image uploads for newer Anthropic `claude-<tier>-<version>` models.

- **Bug Fixes**
  - Resolve `supports_image_input` via `litellm_thinks_model_supports_image_input(model_id, LlmProviderNames.BIFROST)`.
  - Scope limited to Bifrost; Bedrock and OpenAI-compatible paths unchanged.

<sup>Written for commit a24925702d36d94acf3cb455309753079d6a0f73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


