### PR TITLE
feat(branding): derive `logoUrl` in `useSettings` hook

### DIFF
--- a/web/src/lib/settings/hooks.ts
+++ b/web/src/lib/settings/hooks.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import useSWR from "swr";
+import { useMemo } from "react";
 import useCCPairs from "@/hooks/useCCPairs";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import { SWR_KEYS } from "@/lib/swr-keys";
@@ -74,10 +75,21 @@ export function useSettings(): AppSettings {
     }
   );
 
+  // Cache-buster: the logo endpoint URL never changes, so the browser serves
+  // a cached image even after an admin uploads a new logo. Regenerating this
+  // timestamp whenever the enterprise settings reference changes forces a
+  // re-fetch. We use referential equality on the SWR data (compare: a===b),
+  // so this only fires when SWR actually receives new enterprise data.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const logoBuster = useMemo(() => Date.now(), [enterprise]);
+
   return {
     ...core,
     enterprise: enterprise ?? null,
     appName: enterprise?.application_name?.trim() || "Onyx",
+    logoUrl: enterprise?.use_custom_logo
+      ? `/api/enterprise-settings/logo?v=${logoBuster}`
+      : null,
     vectorDbEnabled:
       !settingsLoading && !settingsError && core.vector_db_enabled !== false,
     isLoading:

--- a/web/src/lib/settings/types.ts
+++ b/web/src/lib/settings/types.ts
@@ -176,6 +176,13 @@ export interface AppSettings extends Settings {
   enterprise: EnterpriseSettings | null;
   /** Resolved display name: enterprise.application_name || "Onyx". */
   appName: string;
+  /**
+   * URL of the logo image to render, or `null` to use the default Onyx SVG.
+   * Includes a cache-buster that updates whenever enterprise settings are
+   * revalidated, forcing the browser to re-fetch after an admin uploads a
+   * new logo.
+   */
+  logoUrl: string | null;
   /** False when DISABLE_VECTOR_DB is set server-side. */
   vectorDbEnabled: boolean;
   isLoading: boolean;

--- a/web/src/providers/DynamicMetadata.tsx
+++ b/web/src/providers/DynamicMetadata.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { useEffect, useMemo } from "react";
+import { useEffect } from "react";
 import { useSettings } from "@/lib/settings/hooks";
 
 export default function DynamicMetadata() {
-  const settings = useSettings();
-  const { appName } = settings;
+  const { appName, logoUrl } = useSettings();
 
   useEffect(() => {
     if (document.title !== appName) {
@@ -13,16 +12,5 @@ export default function DynamicMetadata() {
     }
   }, [appName]);
 
-  // Cache-buster so the favicon re-fetches after an admin uploads a new logo.
-  const cacheBuster = useMemo(
-    () => Date.now(),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [settings.enterprise]
-  );
-
-  const favicon = settings.enterprise?.use_custom_logo
-    ? `/api/enterprise-settings/logo?v=${cacheBuster}`
-    : "/onyx.ico";
-
-  return <link rel="icon" href={favicon} />;
+  return <link rel="icon" href={logoUrl ?? "/onyx.ico"} />;
 }

--- a/web/src/refresh-components/Logo.tsx
+++ b/web/src/refresh-components/Logo.tsx
@@ -8,7 +8,6 @@ import {
 import { cn } from "@opal/utils";
 import Text from "@/refresh-components/texts/Text";
 import Truncated from "@/refresh-components/texts/Truncated";
-import { useMemo } from "react";
 import { SvgOnyxLogo, SvgOnyxLogoTyped } from "@opal/logos";
 
 export interface LogoProps {
@@ -28,20 +27,9 @@ export default function Logo({
 }: LogoProps) {
   const resolvedSize = size ?? DEFAULT_LOGO_SIZE_PX;
   const settings = useSettings();
-  const enterpriseSettings = settings.enterprise;
+  const { enterprise: enterpriseSettings, logoUrl } = settings;
   const logoDisplayStyle = enterpriseSettings?.logo_display_style;
   const applicationName = enterpriseSettings?.application_name;
-
-  // Cache-buster: the logo URL never changes (/api/enterprise-settings/logo)
-  // so the browser serves the in-memory cached image even after an admin
-  // uploads a new one. Generating a fresh timestamp each time enterprise
-  // settings are revalidated by SWR appends a unique query param to force
-  // the browser to re-fetch the image.
-  const logoBuster = useMemo(
-    () => Date.now(),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [enterpriseSettings]
-  );
 
   if (onyxBranded) {
     return folded ? (
@@ -51,7 +39,7 @@ export default function Logo({
     );
   }
 
-  const logo = enterpriseSettings?.use_custom_logo ? (
+  const logo = logoUrl ? (
     <div
       className={cn(
         "aspect-square rounded-full overflow-hidden relative shrink-0",
@@ -62,7 +50,7 @@ export default function Logo({
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
         alt="Logo"
-        src={`/api/enterprise-settings/logo?v=${logoBuster}`}
+        src={logoUrl}
         className="object-cover object-center w-full h-full"
       />
     </div>

--- a/web/src/refresh-components/Logo.tsx
+++ b/web/src/refresh-components/Logo.tsx
@@ -26,10 +26,9 @@ export default function Logo({
   onyxBranded,
 }: LogoProps) {
   const resolvedSize = size ?? DEFAULT_LOGO_SIZE_PX;
-  const settings = useSettings();
-  const { enterprise: enterpriseSettings, logoUrl } = settings;
-  const logoDisplayStyle = enterpriseSettings?.logo_display_style;
-  const applicationName = enterpriseSettings?.application_name;
+  const { enterprise, logoUrl } = useSettings();
+  const logoDisplayStyle = enterprise?.logo_display_style;
+  const applicationName = enterprise?.application_name;
 
   if (onyxBranded) {
     return folded ? (
@@ -72,7 +71,7 @@ export default function Logo({
               <Truncated headingH3>{applicationName}</Truncated>
             )}
             {!NEXT_PUBLIC_DO_NOT_USE_TOGGLE_OFF_DANSWER_POWERED &&
-              !enterpriseSettings?.hide_onyx_branding && (
+              !enterprise?.hide_onyx_branding && (
                 <Text
                   secondaryBody
                   text03


### PR DESCRIPTION
## Description

Fixes the favicon not updating when a custom enterprise logo is set, and eliminates duplicated logo-URL derivation logic.

Both `Logo.tsx` and `DynamicMetadata` were independently checking `enterprise?.use_custom_logo` and constructing the custom logo URL with separate `useMemo`-based cache-busters. This meant:

- The favicon and the sidebar logo could diverge (different cache-buster timestamps)
- Any future logo-rendering surface would have to replicate the same derivation
- The favicon was not guaranteed to update when a new logo was uploaded

**Fix:** add `logoUrl: string | null` to `AppSettings`. `useSettings()` now derives it once — `null` means "use the default Onyx SVG", non-null is the custom logo endpoint URL with a single cache-buster that regenerates only when SWR revalidates enterprise settings (referential equality comparison ensures this fires exactly when new data arrives, not on every render).

`Logo.tsx` and `DynamicMetadata` both consume `settings.logoUrl` directly — one decision point, no duplication. Same principle as `appName` from the base PR.

## Screenshots + Videos

Notice how the favicon in the browser tab is the custom logo that I have set:

<img width="1800" height="1169" alt="image" src="https://github.com/user-attachments/assets/636b6153-0cce-413a-af8f-a4fbe82e9d13" />

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derives a single `logoUrl` in `useSettings()` and uses it for both the sidebar logo and favicon. This keeps branding in sync and ensures custom logos update reliably.

- **Bug Fixes**
  - Sidebar logo and favicon now refresh together after a new enterprise logo upload via a single cache-buster that updates only when enterprise settings revalidate.

- **Refactors**
  - Added `logoUrl: string | null` to `AppSettings`; `Logo.tsx` and `DynamicMetadata` now consume it to remove duplicate derivation/cache-busters; renamed local `enterpriseSettings` to `enterprise` for consistency.

<sup>Written for commit 4057750262c9448495755c9d9383648e910ded52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

