### PR TITLE
ci: right-size PR workflow job timeouts from historical runtimes

### DIFF
--- a/.github/workflows/pr-craft-compose-tests.yml
+++ b/.github/workflows/pr-craft-compose-tests.yml
@@ -41,7 +41,7 @@ env:
 jobs:
   craft-compose-tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 8
 
     env:
       PYTHONPATH: ./backend

--- a/.github/workflows/pr-database-tests.yml
+++ b/.github/workflows/pr-database-tests.yml
@@ -54,7 +54,7 @@ jobs:
       - runs-on
       - runner=2cpu-linux-arm64
       - "run-id=${{ github.run_id }}-database-tests"
-    timeout-minutes: 45
+    timeout-minutes: 12
     steps:
       - uses: runs-on/action@d141ef83eb66d096ce8afc767e09115a65c63b60
 

--- a/.github/workflows/pr-external-dependency-unit-tests.yml
+++ b/.github/workflows/pr-external-dependency-unit-tests.yml
@@ -62,7 +62,7 @@ jobs:
   discover-test-dirs:
     # NOTE: Github-hosted runners have about 20s faster queue times and are preferred here.
     runs-on: ubuntu-slim
-    timeout-minutes: 45
+    timeout-minutes: 5
     outputs:
       test-dirs: ${{ steps.set-matrix.outputs.test-dirs }}
     steps:
@@ -86,7 +86,7 @@ jobs:
       - runner=2cpu-linux-arm64
       - ${{ format('run-id={0}-external-dependency-unit-tests-job-{1}', github.run_id, strategy['job-index']) }}
       - extras=s3-cache
-    timeout-minutes: 45
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -88,7 +88,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.integration == 'true'
     runs-on: ubuntu-slim
-    timeout-minutes: 45
+    timeout-minutes: 5
     outputs:
       test-dirs: ${{ steps.set-matrix.outputs.test-dirs }}
       editions: ${{ steps.set-editions.outputs.editions }}
@@ -140,7 +140,7 @@ jobs:
         "run-id=${{ github.run_id }}-build-model-server-image",
         "extras=ecr-cache",
       ]
-    timeout-minutes: 45
+    timeout-minutes: 10
     steps:
       - uses: runs-on/action@d141ef83eb66d096ce8afc767e09115a65c63b60
       - name: Checkout code
@@ -199,7 +199,7 @@ jobs:
         "run-id=${{ github.run_id }}-build-devcontainer-image",
         "extras=ecr-cache",
       ]
-    timeout-minutes: 45
+    timeout-minutes: 10
     steps:
       - uses: runs-on/action@d141ef83eb66d096ce8afc767e09115a65c63b60
       - name: Checkout code
@@ -264,7 +264,7 @@ jobs:
       - runner=4cpu-linux-arm64
       - ${{ format('run-id={0}-integration-tests-{1}-job-{2}', github.run_id, matrix.edition, strategy['job-index']) }}
       - extras=ecr-cache
-    timeout-minutes: 45
+    timeout-minutes: 25
 
     strategy:
       fail-fast: false
@@ -471,7 +471,7 @@ jobs:
         "run-id=${{ github.run_id }}-onyx-lite-tests",
         "extras=ecr-cache",
       ]
-    timeout-minutes: 45
+    timeout-minutes: 10
 
     steps:
       - uses: runs-on/action@d141ef83eb66d096ce8afc767e09115a65c63b60
@@ -578,7 +578,7 @@ jobs:
         "run-id=${{ github.run_id }}-multitenant-tests",
         "extras=ecr-cache",
       ]
-    timeout-minutes: 45
+    timeout-minutes: 15
 
     steps:
       - uses: runs-on/action@d141ef83eb66d096ce8afc767e09115a65c63b60

--- a/.github/workflows/pr-jest-tests.yml
+++ b/.github/workflows/pr-jest-tests.yml
@@ -20,7 +20,7 @@ jobs:
   jest-tests:
     name: Jest Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6

--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -137,7 +137,7 @@ jobs:
         "run-id=${{ github.run_id }}-build-web-image",
         "extras=ecr-cache",
       ]
-    timeout-minutes: 45
+    timeout-minutes: 10
     steps:
       - uses: runs-on/action@d141ef83eb66d096ce8afc767e09115a65c63b60
 
@@ -199,7 +199,7 @@ jobs:
         "run-id=${{ github.run_id }}-build-backend-image",
         "extras=ecr-cache",
       ]
-    timeout-minutes: 45
+    timeout-minutes: 15
     steps:
       - uses: runs-on/action@d141ef83eb66d096ce8afc767e09115a65c63b60
 
@@ -261,7 +261,7 @@ jobs:
         "run-id=${{ github.run_id }}-build-model-server-image",
         "extras=ecr-cache",
       ]
-    timeout-minutes: 45
+    timeout-minutes: 10
     steps:
       - uses: runs-on/action@d141ef83eb66d096ce8afc767e09115a65c63b60
 
@@ -325,7 +325,7 @@ jobs:
       - "run-id=${{ github.run_id }}-playwright-tests-${{ matrix.project }}-${{ matrix.shard }}"
       - "extras=ecr-cache"
       - volume=50gb
-    timeout-minutes: 45
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       # Each entry is one parallel runner. `admin` (the bulk of the suite) is
@@ -525,7 +525,7 @@ jobs:
       - "run-id=${{ github.run_id }}-playwright-tests-oauth-okta"
       - "extras=ecr-cache"
       - volume=50gb
-    timeout-minutes: 45
+    timeout-minutes: 15
     steps:
       - uses: runs-on/action@d141ef83eb66d096ce8afc767e09115a65c63b60
 
@@ -683,7 +683,7 @@ jobs:
       - runner=4cpu-linux-arm64
       - "run-id=${{ github.run_id }}-playwright-tests-lite"
       - "extras=ecr-cache"
-    timeout-minutes: 30
+    timeout-minutes: 10
     steps:
       - uses: runs-on/action@d141ef83eb66d096ce8afc767e09115a65c63b60
 
@@ -805,7 +805,7 @@ jobs:
       - runs-on
       - runner=2cpu-linux-arm64
       - "run-id=${{ github.run_id }}-visual-regression-${{ matrix.project }}"
-    timeout-minutes: 20
+    timeout-minutes: 5
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pr-python-checks.yml
+++ b/.github/workflows/pr-python-checks.yml
@@ -56,7 +56,7 @@ jobs:
         "run-id=${{ github.run_id }}-mypy-check",
         "extras=s3-cache",
       ]
-    timeout-minutes: 15
+    timeout-minutes: 8
 
     steps:
       - uses: runs-on/action@d141ef83eb66d096ce8afc767e09115a65c63b60

--- a/.github/workflows/pr-python-connector-tests.yml
+++ b/.github/workflows/pr-python-connector-tests.yml
@@ -86,7 +86,7 @@ jobs:
         "run-id=${{ github.run_id }}-build-backend-image",
         "extras=ecr-cache",
       ]
-    timeout-minutes: 45
+    timeout-minutes: 10
     environment: ci-protected
 
     steps:
@@ -126,7 +126,7 @@ jobs:
         "run-id=${{ github.run_id }}-connectors-check",
         "extras=ecr-cache",
       ]
-    timeout-minutes: 60
+    timeout-minutes: 40
     environment: ci-protected
 
     steps:

--- a/.github/workflows/pr-python-model-tests.yml
+++ b/.github/workflows/pr-python-model-tests.yml
@@ -30,7 +30,7 @@ jobs:
       - "run-id=${{ github.run_id }}-model-check"
       - "extras=ecr-cache"
     environment: ci-protected
-    timeout-minutes: 45
+    timeout-minutes: 20
 
     env:
       PYTHONPATH: ./backend

--- a/.github/workflows/pr-python-tests.yml
+++ b/.github/workflows/pr-python-tests.yml
@@ -48,7 +48,7 @@ jobs:
     if: needs.changes.outputs.python == 'true'
     # See https://runs-on.com/runners/linux/
     runs-on: [runs-on, runner=4cpu-linux-arm64, "run-id=${{ github.run_id }}-backend-check"]
-    timeout-minutes: 45
+    timeout-minutes: 10
 
 
     env:

--- a/.github/workflows/pr-quality-checks.yml
+++ b/.github/workflows/pr-quality-checks.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   quality-checks:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
         with:


### PR DESCRIPTION
## Why

A `Jest Tests` job [hung for ~35 minutes](https://github.com/onyx-dot-app/onyx/actions/runs/27718886115/job/81998836616) recently. The hang was actually in the `Install node dependencies` step (`bun install`, which normally finishes in ~30s); it only stopped because a new push cancelled the run before the **45-minute** job timeout would have fired.

Nearly every PR job carried the same copy-pasted **45-minute** `timeout-minutes` regardless of how long it actually runs, so a hang burns up to 45 min of runner time and delays the failure signal.

## What

Right-sized job-level `timeout-minutes` using **real historical data** — the wall-clock duration of the **last 40 successful runs** of each workflow (per-job, via the GitHub Actions API). New values target roughly **2× the observed max**, with extra cushion on image-build and live-external jobs whose warm-cache samples understate cold runs.

| Workflow | Job | p50 | p95 | max | Old → New |
|---|---|--:|--:|--:|--:|
| pr-jest-tests | Jest Tests | 1.3 | 1.6 | 2.8 | 45 → **10** |
| pr-python-tests | backend-check | 3.4 | 3.6 | 3.6 | 45 → **10** |
| pr-python-checks | mypy-check | 2.2 | 2.4 | 2.5 | 15 → **8** |
| pr-quality-checks | quality-checks | 2.2 | 5.9 | 7.7 | 45 → **15** |
| pr-database-tests | database-tests | 4.4 | 4.7 | 4.8 | 45 → **12** |
| pr-external-dependency-unit-tests | discover-test-dirs | 0.2 | 0.4 | 0.6 | 45 → **5** |
| pr-external-dependency-unit-tests | external-dependency-unit-tests *(matrix)* | 4.5 | 5.5 | 9.2 | 45 → **15** |
| pr-python-connector-tests | build-backend-image | 1.7 | 2.9 | 3.1 | 45 → **10** |
| pr-python-connector-tests | connectors-check *(live external)* | 7.5 | 21.7 | 25.4 | 60 → **40** |
| pr-python-model-tests | model-check | 7.1 | 9.0 | 10.6 | 45 → **20** |
| pr-integration-tests | discover-test-dirs | 0.2 | 0.3 | 0.3 | 45 → **5** |
| pr-integration-tests | build-model-server-image | 0.6 | 3.6 | 3.6 | 45 → **10** |
| pr-integration-tests | build-devcontainer-image | 0.5 | 0.5 | 0.5 | 45 → **10** |
| pr-integration-tests | integration-tests *(matrix)* | ~5 | 15.2 | 16.0 | 45 → **25** |
| pr-integration-tests | onyx-lite-tests | 2.6 | 3.1 | 3.1 | 45 → **10** |
| pr-integration-tests | multitenant-tests | 6.8 | 7.1 | 7.2 | 45 → **15** |
| pr-playwright-tests | build-web-image | 2.5 | 4.2 | 4.3 | 45 → **10** |
| pr-playwright-tests | build-backend-image | 3.7 | 6.1 | 6.3 | 45 → **15** |
| pr-playwright-tests | build-model-server-image | 0.6 | 3.5 | 3.6 | 45 → **10** |
| pr-playwright-tests | playwright-tests *(matrix)* | ~6 | 6.7 | 10.9 | 45 → **20** |
| pr-playwright-tests | playwright-tests-oauth-okta *(real Okta, n=2)* | 3.8 | 3.9 | 3.9 | 45 → **15** |
| pr-playwright-tests | playwright-tests-lite | 2.5 | 2.9 | 3.0 | 30 → **10** |
| pr-playwright-tests | visual-regression | 0.6 | 0.8 | 0.8 | 20 → **5** |
| pr-craft-compose-tests | craft-compose-tests | 0.9 | 1.1 | 1.1 | 15 → **8** |

*(all values in minutes; data = 40 most recent successful runs per workflow)*

## Deliberately left unchanged

- **`changes` / `required` / `discover` gate jobs** already at 5 min.
- **`pr-golang-tests`** (10 min) — already low; jobs run <1 min.
- **`pr-craft-k8s-tests`** (30 min) — ⚠️ this one is the *opposite* problem: it runs right up against its cap (p50 **26.4**, p90 **29.9** min) and will start flaking into timeouts as the suite grows. Left as-is in this PR; worth a separate look at whether to **raise** it or speed the job up.

## Follow-up (not in this PR)

The original incident was a network-bound step hanging with no step-level guard. A natural follow-up is adding step-level `timeout-minutes` to the install steps (`bun install` ~0.5 min, the `uv` install in `setup-python-and-install-dependencies` ~2 min), which would catch that failure mode in minutes across every workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Right-sized GitHub Actions job timeouts using historical runtimes so hung jobs fail fast and don’t burn runner time. Most PR jobs drop from 45 minutes to targeted caps (~5–25 min; 40 min for live-external) based on the last 40 successful runs per job.

- **Refactors**
  - Set per-job `timeout-minutes` to ~2× the observed max for each workflow.
  - Examples: Jest 10, Python backend 10, Integration matrix 25, Playwright 20, Okta 15, DB tests 12, MyPy 8, Craft Compose 8, image builds 10–15, connectors live-external 40.
  - Left unchanged: gate jobs at 5, `pr-golang-tests` at 10, `pr-craft-k8s-tests` at 30.

<sup>Written for commit 99a1f84916e4b29eb43284f8e516207c168036c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

