### PR TITLE
fix(chat): surface context-window errors on long threads + overflow guard

### DIFF
--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -28,6 +28,7 @@ from onyx.configs.app_configs import INTEGRATION_TESTS_MODE
 from onyx.configs.chat_configs import MAX_LLM_CYCLES
 from onyx.configs.constants import DocumentSource
 from onyx.configs.constants import MessageType
+from onyx.configs.model_configs import GEN_AI_INPUT_TOKEN_SAFETY_MARGIN
 from onyx.context.search.models import SearchDoc
 from onyx.context.search.models import SearchDocsResponse
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
@@ -669,8 +670,14 @@ def run_llm_loop(
             raw_answer=None,
         )
 
-        # Pass the total budget to construct_message_history, which will handle token allocation
-        available_tokens = llm.config.max_input_tokens
+        # Pass the budget to construct_message_history, which handles token
+        # allocation. Hold back a safety margin below the advertised limit:
+        # our tiktoken estimate can undercount vs the provider's real tokenizer,
+        # so fitting right up to max_input_tokens risks a context-window
+        # rejection on long threads.
+        available_tokens = int(
+            llm.config.max_input_tokens * (1 - GEN_AI_INPUT_TOKEN_SAFETY_MARGIN)
+        )
         tool_choice: ToolChoiceOptions = ToolChoiceOptions.AUTO
         # Initialize gathered_documents with project files if present
         gathered_documents: list[SearchDoc] | None = (

--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -670,11 +670,8 @@ def run_llm_loop(
             raw_answer=None,
         )
 
-        # Pass the budget to construct_message_history, which handles token
-        # allocation. Hold back a safety margin below the advertised limit:
-        # our tiktoken estimate can undercount vs the provider's real tokenizer,
-        # so fitting right up to max_input_tokens risks a context-window
-        # rejection on long threads.
+        # Hold back a margin below max_input_tokens: our tiktoken estimate can
+        # undercount the provider's tokenizer and overflow the context window.
         available_tokens = int(
             llm.config.max_input_tokens * (1 - GEN_AI_INPUT_TOKEN_SAFETY_MARGIN)
         )

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -1103,9 +1103,8 @@ def _run_models(
     # Set to True when a model raises an exception (distinct from "still running").
     # Used in the stop-button path to avoid calling completion for errored models.
     model_errored: list[bool] = [False] * n_models
-    # Classified (message, error_code, is_retryable) for a model that errored,
-    # computed once in _run_model where the exception + llm are in scope, then
-    # reused by both the streamed error packet and the persisted message.
+    # Per-model classified (message, error_code, is_retryable), set in _run_model
+    # and reused by the streamed packet and the persisted message.
     model_error_info: list[tuple[str, str, bool] | None] = [None] * n_models
     persist_lock = threading.Lock()
     persisted: list[bool] = [False] * n_models
@@ -1292,11 +1291,8 @@ def _run_models(
             message, error_code, is_retryable = litellm_exception_to_error_msg(
                 e, model_llm, fallback_to_error_msg=True
             )
-            # Redact the API key at the source so every consumer of
-            # model_error_info is safe — both the streamed StreamingError and
-            # the message persisted to the DB in _save_errored_message. The
-            # fallback_to_error_msg path returns str(e) verbatim, which can
-            # embed the key for exceptions outside the classifier's branches.
+            # Redact here so both the streamed and persisted error are safe:
+            # the fallback path returns str(e) verbatim, which can embed the key.
             if model_llm.config.api_key and len(model_llm.config.api_key) > 2:
                 message = message.replace(
                     model_llm.config.api_key, "[REDACTED_API_KEY]"
@@ -1404,8 +1400,7 @@ def _run_models(
                     # _run_model's finally always posts _MODEL_DONE, which is
                     # the sole completion signal.
                     model_llm = setup.llms[model_idx]
-                    # Classified in _run_model (where the llm is in scope);
-                    # fall back to a generic model error if missing.
+                    # Classified in _run_model; fall back to a generic error.
                     info = model_error_info[model_idx]
                     if info is not None:
                         error_msg, err_code, err_retryable = info

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -1103,6 +1103,10 @@ def _run_models(
     # Set to True when a model raises an exception (distinct from "still running").
     # Used in the stop-button path to avoid calling completion for errored models.
     model_errored: list[bool] = [False] * n_models
+    # Classified (message, error_code, is_retryable) for a model that errored,
+    # computed once in _run_model where the exception + llm are in scope, then
+    # reused by both the streamed error packet and the persisted message.
+    model_error_info: list[tuple[str, str, bool] | None] = [None] * n_models
     persist_lock = threading.Lock()
     persisted: list[bool] = [False] * n_models
     post_steps_done = threading.Event()
@@ -1285,6 +1289,9 @@ def _run_models(
 
         except Exception as e:
             model_errored[model_idx] = True
+            model_error_info[model_idx] = litellm_exception_to_error_msg(
+                e, model_llm, fallback_to_error_msg=True
+            )
             merged_queue.put((model_idx, e))
 
         finally:
@@ -1299,9 +1306,15 @@ def _run_models(
                     ChatMessage, setup.reserved_messages[model_idx].id
                 )
                 if msg is not None:
-                    error_text = (
-                        "Error from %s: model encountered an error during generation."
-                        % setup.model_display_names[model_idx]
+                    info = model_error_info[model_idx]
+                    detail = (
+                        info[0]
+                        if info is not None
+                        else "model encountered an error during generation."
+                    )
+                    error_text = "Error from %s: %s" % (
+                        setup.model_display_names[model_idx],
+                        detail,
                     )
                     msg.message = error_text
                     msg.error = error_text
@@ -1380,11 +1393,21 @@ def _run_models(
                     # models running. Do NOT decrement models_remaining —
                     # _run_model's finally always posts _MODEL_DONE, which is
                     # the sole completion signal.
-                    error_msg = str(item)
+                    model_llm = setup.llms[model_idx]
+                    # Classified in _run_model (where the llm is in scope);
+                    # fall back to a generic model error if missing.
+                    info = model_error_info[model_idx]
+                    if info is not None:
+                        error_msg, err_code, err_retryable = info
+                    else:
+                        error_msg, err_code, err_retryable = (
+                            str(item),
+                            "MODEL_ERROR",
+                            True,
+                        )
                     stack_trace = "".join(
                         traceback.format_exception(type(item), item, item.__traceback__)
                     )
-                    model_llm = setup.llms[model_idx]
                     if model_llm.config.api_key and len(model_llm.config.api_key) > 2:
                         error_msg = error_msg.replace(
                             model_llm.config.api_key, "[REDACTED_API_KEY]"
@@ -1396,8 +1419,8 @@ def _run_models(
                         StreamingError(
                             error=error_msg,
                             stack_trace=stack_trace,
-                            error_code="MODEL_ERROR",
-                            is_retryable=True,
+                            error_code=err_code,
+                            is_retryable=err_retryable,
                             details={
                                 "model": model_llm.config.model_name,
                                 "provider": model_llm.config.model_provider,

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -1289,9 +1289,19 @@ def _run_models(
 
         except Exception as e:
             model_errored[model_idx] = True
-            model_error_info[model_idx] = litellm_exception_to_error_msg(
+            message, error_code, is_retryable = litellm_exception_to_error_msg(
                 e, model_llm, fallback_to_error_msg=True
             )
+            # Redact the API key at the source so every consumer of
+            # model_error_info is safe — both the streamed StreamingError and
+            # the message persisted to the DB in _save_errored_message. The
+            # fallback_to_error_msg path returns str(e) verbatim, which can
+            # embed the key for exceptions outside the classifier's branches.
+            if model_llm.config.api_key and len(model_llm.config.api_key) > 2:
+                message = message.replace(
+                    model_llm.config.api_key, "[REDACTED_API_KEY]"
+                )
+            model_error_info[model_idx] = (message, error_code, is_retryable)
             merged_queue.put((model_idx, e))
 
         finally:

--- a/backend/onyx/configs/model_configs.py
+++ b/backend/onyx/configs/model_configs.py
@@ -70,6 +70,15 @@ GEN_AI_MODEL_FALLBACK_MAX_TOKENS = int(
     os.environ.get("GEN_AI_MODEL_FALLBACK_MAX_TOKENS") or 32000
 )
 
+# Fraction of a model's max_input_tokens to hold back when fitting chat history,
+# as headroom for token-count drift: Onyx estimates with tiktoken, but providers
+# (e.g. Anthropic/Vertex) tokenize differently and can count higher, so filling
+# right up to the limit risks a provider context-window rejection on long
+# threads. Truncating against (1 - margin) * max_input_tokens absorbs that drift.
+GEN_AI_INPUT_TOKEN_SAFETY_MARGIN = float(
+    os.environ.get("GEN_AI_INPUT_TOKEN_SAFETY_MARGIN") or 0.05
+)
+
 # This is used when computing how much context space is available for documents
 # ahead of time in order to let the user know if they can "select" more documents
 # It represents a maximum "expected" number of input tokens from the latest user

--- a/backend/onyx/configs/model_configs.py
+++ b/backend/onyx/configs/model_configs.py
@@ -70,17 +70,13 @@ GEN_AI_MODEL_FALLBACK_MAX_TOKENS = int(
     os.environ.get("GEN_AI_MODEL_FALLBACK_MAX_TOKENS") or 32000
 )
 
-# Fraction of a model's max_input_tokens to hold back when fitting chat history,
-# as headroom for token-count drift: Onyx estimates with tiktoken, but providers
-# (e.g. Anthropic/Vertex) tokenize differently and can count higher, so filling
-# right up to the limit risks a provider context-window rejection on long
-# threads. Truncating against (1 - margin) * max_input_tokens absorbs that drift.
+# Fraction of max_input_tokens to hold back when fitting history: headroom for
+# tiktoken undercounting the provider's tokenizer and overflowing the context.
 GEN_AI_INPUT_TOKEN_SAFETY_MARGIN = float(
     os.environ.get("GEN_AI_INPUT_TOKEN_SAFETY_MARGIN") or 0.05
 )
-# Must be in [0, 1): a value >= 1 drives available_tokens to <= 0 (history
-# construction breaks), and a negative value silently expands the budget past
-# the model's real limit. Fail loudly on misconfiguration.
+# Must be in [0, 1): >= 1 zeroes available_tokens; negative inflates the budget
+# past the real limit.
 if not 0.0 <= GEN_AI_INPUT_TOKEN_SAFETY_MARGIN < 1.0:
     raise ValueError(
         "GEN_AI_INPUT_TOKEN_SAFETY_MARGIN must be in [0, 1), got "

--- a/backend/onyx/configs/model_configs.py
+++ b/backend/onyx/configs/model_configs.py
@@ -78,6 +78,14 @@ GEN_AI_MODEL_FALLBACK_MAX_TOKENS = int(
 GEN_AI_INPUT_TOKEN_SAFETY_MARGIN = float(
     os.environ.get("GEN_AI_INPUT_TOKEN_SAFETY_MARGIN") or 0.05
 )
+# Must be in [0, 1): a value >= 1 drives available_tokens to <= 0 (history
+# construction breaks), and a negative value silently expands the budget past
+# the model's real limit. Fail loudly on misconfiguration.
+if not 0.0 <= GEN_AI_INPUT_TOKEN_SAFETY_MARGIN < 1.0:
+    raise ValueError(
+        "GEN_AI_INPUT_TOKEN_SAFETY_MARGIN must be in [0, 1), got "
+        f"{GEN_AI_INPUT_TOKEN_SAFETY_MARGIN}"
+    )
 
 # This is used when computing how much context space is available for documents
 # ahead of time in order to let the user know if they can "select" more documents

--- a/backend/onyx/llm/utils.py
+++ b/backend/onyx/llm/utils.py
@@ -174,10 +174,8 @@ def litellm_exception_to_error_msg(
             if error_msg_pattern in error_msg:
                 return custom_error_msg, "CUSTOM_ERROR", True
 
-    # ContextWindowExceededError and ContentPolicyViolationError both subclass
-    # BadRequestError, so they MUST be checked before the generic BadRequestError
-    # branch — otherwise they'd be misclassified as BAD_REQUEST (and the
-    # context-length case would never surface as CONTEXT_TOO_LONG).
+    # Both subclass BadRequestError, so they must precede the BadRequestError
+    # branch or they'd be misclassified as BAD_REQUEST.
     if isinstance(core_exception, ContextWindowExceededError):
         error_msg = (
             "Context window exceeded: Your input is too long for the model to process."

--- a/backend/onyx/llm/utils.py
+++ b/backend/onyx/llm/utils.py
@@ -136,7 +136,7 @@ def _unwrap_nested_exception(error: Exception) -> Exception:
 
 def litellm_exception_to_error_msg(
     e: Exception,
-    llm: LLM,
+    llm: LLM | None,
     fallback_to_error_msg: bool = False,
     custom_error_msg_mappings: (
         dict[str, str] | None
@@ -174,7 +174,32 @@ def litellm_exception_to_error_msg(
             if error_msg_pattern in error_msg:
                 return custom_error_msg, "CUSTOM_ERROR", True
 
-    if isinstance(core_exception, BadRequestError):
+    # ContextWindowExceededError and ContentPolicyViolationError both subclass
+    # BadRequestError, so they MUST be checked before the generic BadRequestError
+    # branch — otherwise they'd be misclassified as BAD_REQUEST (and the
+    # context-length case would never surface as CONTEXT_TOO_LONG).
+    if isinstance(core_exception, ContextWindowExceededError):
+        error_msg = (
+            "Context window exceeded: Your input is too long for the model to process."
+        )
+        if llm is not None:
+            try:
+                max_context = get_max_input_tokens(
+                    model_name=llm.config.model_name,
+                    model_provider=llm.config.model_provider,
+                )
+                error_msg += f" Your invoked model ({llm.config.model_name}) has a maximum context size of {max_context}."
+            except Exception:
+                logger.warning(
+                    "Unable to get maximum input token for LiteLLM exception handling"
+                )
+        error_code = "CONTEXT_TOO_LONG"
+        is_retryable = False
+    elif isinstance(core_exception, ContentPolicyViolationError):
+        error_msg = "Content policy violation: Your request violates the content policy. Please revise your input."
+        error_code = "CONTENT_POLICY"
+        is_retryable = False
+    elif isinstance(core_exception, BadRequestError):
         error_msg = "Bad request: The server couldn't process your request. Please check your input."
         error_code = "BAD_REQUEST"
         is_retryable = True
@@ -261,27 +286,6 @@ def litellm_exception_to_error_msg(
             error_msg = f"{provider_name} service error: {str(core_exception)}"
         error_code = "SERVICE_UNAVAILABLE"
         is_retryable = True
-    elif isinstance(core_exception, ContextWindowExceededError):
-        error_msg = (
-            "Context window exceeded: Your input is too long for the model to process."
-        )
-        if llm is not None:
-            try:
-                max_context = get_max_input_tokens(
-                    model_name=llm.config.model_name,
-                    model_provider=llm.config.model_provider,
-                )
-                error_msg += f" Your invoked model ({llm.config.model_name}) has a maximum context size of {max_context}."
-            except Exception:
-                logger.warning(
-                    "Unable to get maximum input token for LiteLLM exception handling"
-                )
-        error_code = "CONTEXT_TOO_LONG"
-        is_retryable = False
-    elif isinstance(core_exception, ContentPolicyViolationError):
-        error_msg = "Content policy violation: Your request violates the content policy. Please revise your input."
-        error_code = "CONTENT_POLICY"
-        is_retryable = False
     elif isinstance(core_exception, APIConnectionError):
         error_msg = "API connection error: Failed to connect to the API. Please check your internet connection."
         error_code = "CONNECTION_ERROR"

--- a/backend/tests/unit/onyx/chat/test_multi_model_streaming.py
+++ b/backend/tests/unit/onyx/chat/test_multi_model_streaming.py
@@ -433,16 +433,14 @@ class TestRunModels:
 
         errors = [p for p in packets if isinstance(p, StreamingError)]
         assert len(errors) == 1
-        # The worker error is now classified via litellm_exception_to_error_msg
-        # rather than hardcoded to MODEL_ERROR; a generic (non-litellm) exception
-        # maps to UNKNOWN_ERROR while preserving the original message.
+        # A generic (non-litellm) worker exception surfaces as UNKNOWN_ERROR
+        # with the original message preserved.
         assert errors[0].error_code == "UNKNOWN_ERROR"
         assert "intentional test failure" in errors[0].error
 
     def test_context_window_overflow_surfaces_as_context_too_long(self) -> None:
-        """The long-thread failure mode: a provider context-window rejection
-        inside a worker must surface as CONTEXT_TOO_LONG (not MODEL_ERROR) and
-        be marked non-retryable, end-to-end through _run_model -> drain loop."""
+        """A provider context-window rejection in a worker surfaces as
+        CONTEXT_TOO_LONG and non-retryable through the _run_model -> drain path."""
 
         def overflow(**_kwargs: Any) -> None:
             raise ContextWindowExceededError(

--- a/backend/tests/unit/onyx/chat/test_multi_model_streaming.py
+++ b/backend/tests/unit/onyx/chat/test_multi_model_streaming.py
@@ -15,6 +15,7 @@ from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
+from litellm.exceptions import ContextWindowExceededError
 
 from onyx.chat.models import StreamingError
 from onyx.configs.constants import MessageType
@@ -437,6 +438,35 @@ class TestRunModels:
         # maps to UNKNOWN_ERROR while preserving the original message.
         assert errors[0].error_code == "UNKNOWN_ERROR"
         assert "intentional test failure" in errors[0].error
+
+    def test_context_window_overflow_surfaces_as_context_too_long(self) -> None:
+        """The long-thread failure mode: a provider context-window rejection
+        inside a worker must surface as CONTEXT_TOO_LONG (not MODEL_ERROR) and
+        be marked non-retryable, end-to-end through _run_model -> drain loop."""
+
+        def overflow(**_kwargs: Any) -> None:
+            raise ContextWindowExceededError(
+                "This model's maximum context length is 8192 tokens",
+                model="gpt-4",
+                llm_provider="openai",
+            )
+
+        with (
+            patch("onyx.chat.process_message.run_llm_loop", side_effect=overflow),
+            patch("onyx.chat.process_message.run_deep_research_llm_loop"),
+            patch("onyx.chat.process_message.construct_tools", return_value={}),
+            patch("onyx.chat.process_message.llm_loop_completion_handle"),
+            patch(
+                "onyx.chat.process_message.get_llm_token_counter",
+                return_value=lambda _: 0,
+            ),
+        ):
+            packets = _run_models_collect(_make_setup(n_models=1))
+
+        errors = [p for p in packets if isinstance(p, StreamingError)]
+        assert len(errors) == 1
+        assert errors[0].error_code == "CONTEXT_TOO_LONG"
+        assert errors[0].is_retryable is False
 
     def test_one_model_error_does_not_stop_other_models(self) -> None:
         """A failing model yields StreamingError; the surviving model's packets still arrive."""

--- a/backend/tests/unit/onyx/chat/test_multi_model_streaming.py
+++ b/backend/tests/unit/onyx/chat/test_multi_model_streaming.py
@@ -432,7 +432,10 @@ class TestRunModels:
 
         errors = [p for p in packets if isinstance(p, StreamingError)]
         assert len(errors) == 1
-        assert errors[0].error_code == "MODEL_ERROR"
+        # The worker error is now classified via litellm_exception_to_error_msg
+        # rather than hardcoded to MODEL_ERROR; a generic (non-litellm) exception
+        # maps to UNKNOWN_ERROR while preserving the original message.
+        assert errors[0].error_code == "UNKNOWN_ERROR"
         assert "intentional test failure" in errors[0].error
 
     def test_one_model_error_does_not_stop_other_models(self) -> None:

--- a/backend/tests/unit/onyx/llm/test_llm_exception_classification.py
+++ b/backend/tests/unit/onyx/llm/test_llm_exception_classification.py
@@ -1,9 +1,7 @@
-"""Regression guards for litellm_exception_to_error_msg classification order.
-
-ContextWindowExceededError and ContentPolicyViolationError both subclass
-BadRequestError, so they must be checked before the generic BadRequestError
-branch — otherwise context-window overflow (the long-thread failure) is
-mislabeled BAD_REQUEST and never surfaces as CONTEXT_TOO_LONG.
+"""Guards classification order in litellm_exception_to_error_msg:
+ContextWindowExceededError and ContentPolicyViolationError subclass
+BadRequestError and must be matched first, or context overflow is mislabeled
+BAD_REQUEST instead of CONTEXT_TOO_LONG.
 """
 
 from litellm.exceptions import BadRequestError

--- a/backend/tests/unit/onyx/llm/test_llm_exception_classification.py
+++ b/backend/tests/unit/onyx/llm/test_llm_exception_classification.py
@@ -1,0 +1,35 @@
+"""Regression guards for litellm_exception_to_error_msg classification order.
+
+ContextWindowExceededError and ContentPolicyViolationError both subclass
+BadRequestError, so they must be checked before the generic BadRequestError
+branch — otherwise context-window overflow (the long-thread failure) is
+mislabeled BAD_REQUEST and never surfaces as CONTEXT_TOO_LONG.
+"""
+
+from litellm.exceptions import BadRequestError
+from litellm.exceptions import ContentPolicyViolationError
+from litellm.exceptions import ContextWindowExceededError
+
+from onyx.llm.utils import litellm_exception_to_error_msg
+
+
+def _err(exc_cls: type[BadRequestError]) -> BadRequestError:
+    return exc_cls("boom", model="m", llm_provider="p")
+
+
+def test_context_window_exceeded_classified_before_bad_request() -> None:
+    _, code, is_retryable = litellm_exception_to_error_msg(
+        _err(ContextWindowExceededError), None
+    )
+    assert code == "CONTEXT_TOO_LONG"
+    assert is_retryable is False
+
+
+def test_content_policy_classified_before_bad_request() -> None:
+    _, code, _ = litellm_exception_to_error_msg(_err(ContentPolicyViolationError), None)
+    assert code == "CONTENT_POLICY"
+
+
+def test_plain_bad_request_still_bad_request() -> None:
+    _, code, _ = litellm_exception_to_error_msg(_err(BadRequestError), None)
+    assert code == "BAD_REQUEST"


### PR DESCRIPTION
## Description

Long chat threads could overflow a model's context window and fail with an **opaque** error ("There was an error with the response" / "model encountered an error during generation"), with no indication that the input was too long. This fixes it at three levels:

**1. Classifier ordering (`llm/utils.py`).** `ContextWindowExceededError` and `ContentPolicyViolationError` both subclass `BadRequestError`, but `BadRequestError` was checked first — so the `CONTEXT_TOO_LONG` / `CONTENT_POLICY` branches were **unreachable** and context overflow was mislabeled `BAD_REQUEST`. Check the subclasses first.

**2. Generation-path error surfacing (`chat/process_message.py`).** The per-model worker error was hardcoded to `error_code="MODEL_ERROR"` with a fixed "model encountered an error during generation" message, **bypassing the classifier** (a long-standing issue: the classifier is only wired on the outer/setup path, which generation errors never reach — present since at least v4.0, not a recent regression). Now the exception is classified once (in `_run_model`, where the llm is in scope) and the real code/message flows into **both** the streamed error packet and the persisted message. Context overflow now surfaces as `CONTEXT_TOO_LONG` + "Your input is too long…", `is_retryable=false`.

**3. Overflow guard (`chat/llm_loop.py` + `configs/model_configs.py`).** Hold back a safety margin (`GEN_AI_INPUT_TOKEN_SAFETY_MARGIN`, default 5%) below `max_input_tokens` when fitting history — headroom for tiktoken-vs-provider tokenizer drift, the common long-thread overflow cause.

## How Has This Been Tested?

- New unit tests (`tests/unit/onyx/llm/test_llm_exception_classification.py`) assert the classification order: `ContextWindowExceededError → CONTEXT_TOO_LONG` (was `BAD_REQUEST`), `ContentPolicyViolationError → CONTENT_POLICY`, plain `BadRequestError → BAD_REQUEST`. **3 pass.**
- Reproduced the original failure deterministically with a load-test mock that simulates a provider context-window rejection on long prompts; the error packet came back as `error_code=MODEL_ERROR` (the bug). With the classifier fix verified in isolation, that path now resolves to `CONTEXT_TOO_LONG`.
- Full end-to-end re-run against a main-based stack is pending (local dev stack is currently on an unrelated branch with a shared DB).

- [x] Override Linear Check

## Notes
- The margin mitigates tokenizer-drift overflow; a genuinely mis-configured `max_input_tokens` (advertised >> real) still needs correct model config. Proactive pre-call compression is a possible follow-up for the deepest robustness.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces context-window overflows on long chats and adds a safety margin to prevent them. Worker errors now use classifier-derived codes/messages, with provider API keys redacted and margin config validated.

- **Bug Fixes**
  - Fixed exception classification order in `llm/utils.py` (`ContextWindowExceededError` → `CONTEXT_TOO_LONG`, `ContentPolicyViolationError` → `CONTENT_POLICY`; plain `BadRequestError` stays `BAD_REQUEST`).
  - Classify generation-path errors once in `_run_model` and reuse for streamed and persisted errors; generic exceptions now surface as `UNKNOWN_ERROR`.
  - Redact provider API keys at the source in `_run_model` so both streamed and persisted errors are safe.
  - Added `GEN_AI_INPUT_TOKEN_SAFETY_MARGIN` (default 0.05) and apply it in `chat/llm_loop.py` when fitting history; validate it in `[0, 1)`.

<sup>Written for commit 7fa50dc4a446275236138fa3248acb3c79c05287. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




