### PR TITLE
fix(security): skip security_settings DB read on the shared schema

### DIFF
--- a/backend/onyx/server/security/store.py
+++ b/backend/onyx/server/security/store.py
@@ -212,14 +212,17 @@ def invalidate_security_cache(tenant_id: str) -> None:
 def get_security_settings() -> SecuritySettings:
     """Effective, env-merged, immutable settings for the current tenant.
 
-    Pre-tenant safe: returns env defaults (uncached) when the contextvar is
-    unset in multi-tenant. DB errors fall back to env defaults so a Postgres
-    outage never bricks the auth path. Returned ``SecuritySettings`` is frozen.
+    Pre-tenant safe: returns env defaults (uncached) when there is no real
+    tenant schema to read from. DB errors fall back to env defaults so a
+    Postgres outage never bricks the auth path. Returned ``SecuritySettings``
+    is frozen.
     """
     tenant_id = CURRENT_TENANT_ID_CONTEXTVAR.get()
-    if tenant_id is None:
-        # Single-tenant defaults the contextvar at module import; this branch
-        # fires only in multi-tenant before tenant resolution.
+    # In multi-tenant the shared/default schema carries no per-tenant
+    # security_settings row, so reading it raises UndefinedTable. Unmapped users
+    # (registration, login for an email with no tenant) and pre-resolution
+    # requests land here; fall back to env defaults rather than a doomed query.
+    if tenant_id is None or (MULTI_TENANT and tenant_id == POSTGRES_DEFAULT_SCHEMA):
         return _build_env_defaults()
 
     with _CACHE_LOCK:

--- a/backend/tests/external_dependency_unit/server/security/test_security_settings_store.py
+++ b/backend/tests/external_dependency_unit/server/security/test_security_settings_store.py
@@ -19,6 +19,7 @@ from onyx.server.security.store import _install_cache_for_test
 from onyx.server.security.store import apply_patch
 from onyx.server.security.store import get_security_settings
 from onyx.server.security.store import invalidate_security_cache
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 from tests.external_dependency_unit.constants import TEST_TENANT_ID
 
@@ -166,6 +167,24 @@ def test_pre_tenant_returns_env_defaults_without_raising(
     """Multi-tenant + contextvar unset must short-circuit to env defaults
     without touching the DB."""
     token = CURRENT_TENANT_ID_CONTEXTVAR.set(None)
+    try:
+        monkeypatch.setattr(security_store, "MULTI_TENANT", True)
+
+        with patch.object(security_store, "_load_raw_overrides_unlocked") as spy:
+            effective = get_security_settings()
+            spy.assert_not_called()
+        assert effective == _build_env_defaults()
+    finally:
+        CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+
+
+def test_multi_tenant_default_schema_returns_env_defaults_without_raising(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Multi-tenant + contextvar resolved to the shared/default schema (an
+    unprovisioned/unmapped user) must short-circuit to env defaults without
+    touching the DB — ``public`` never carries the per-tenant table."""
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set(POSTGRES_DEFAULT_SCHEMA)
     try:
         monkeypatch.setattr(security_store, "MULTI_TENANT", True)
 


### PR DESCRIPTION
## Problem

Production logs were filling with per-request ERRORs on the auth path:

```
store.py 232: Failed to load security settings, using env defaults:
(psycopg2.errors.UndefinedTable) relation "public.security_settings" does not exist
[SQL: SELECT ... FROM public.security_settings]
```

The `public.` schema qualifier is the tell. In multi-tenant, `POSTGRES_DEFAULT_SCHEMA` (`public`) is the **shared** schema — it holds cross-tenant tables (e.g. the user→tenant mapping), **not** the per-tenant `security_settings` row. So the read fails with `UndefinedTable` even though every real tenant schema is fully migrated.

## Root cause

`get_security_settings()` only short-circuited to env defaults when the tenant contextvar was `None`. But for an **unprovisioned / unmapped user** — registration, or a login attempt for an email with no tenant mapping — the contextvar resolves to `POSTGRES_DEFAULT_SCHEMA` (`public`), not `None`. That bypassed the guard and ran `SELECT ... FROM public.security_settings`.

The error was caught and we fell back to env defaults (auth keeps working), but the failure path never populates the cache, so **every** such request re-queried and re-logged at ERROR — log spam on a hot path. The `[API:...]` request id in the original log confirms the per-request nature.

## Fix

Treat `POSTGRES_DEFAULT_SCHEMA` like "no tenant" in multi-tenant: return env defaults without the doomed query or the per-request ERROR log. Single-tenant is unaffected (its tenant legitimately *is* `public` and the table exists there) because the new condition is gated on `MULTI_TENANT`.

```python
if tenant_id is None or (MULTI_TENANT and tenant_id == POSTGRES_DEFAULT_SCHEMA):
    return _build_env_defaults()
```

## Tests

Added `test_multi_tenant_default_schema_returns_env_defaults_without_raising` to the existing external-dependency-unit store tests, asserting that a `public`/default-schema tenant in multi-tenant returns env defaults **without** touching the DB (spies on `_load_raw_overrides_unlocked` and asserts it isn't called). Full security suite passes (`backend/tests/external_dependency_unit/server/security/`, 24 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip reading per-tenant security settings from the shared `public` schema in multi-tenant and return env defaults instead, stopping `UndefinedTable` errors and log spam. Single-tenant is unchanged.

- **Bug Fixes**
  - In `get_security_settings()`, short-circuit to env defaults when `MULTI_TENANT` and the tenant is `POSTGRES_DEFAULT_SCHEMA`.
  - Added a unit test to ensure no DB call on this path and correct fallback.

<sup>Written for commit 2510c2aa42aee2da3ce0e8cae482ce946bd58f70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

