### PR TITLE
docs(agents): add comment-writing guideline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,9 @@ pre-commit run --all-files
 
 NOTE: Always make sure everything is strictly typed (both in Python and Typescript).
 
+NOTE: Keep comments brief and focused on information that stays relevant long-term. Don't write
+comments that only describe the instantaneous change (e.g. what was just added/removed/refactored).
+
 ## Architecture Overview
 
 ### Technology Stack


### PR DESCRIPTION
## Summary
Adds a guideline to `AGENTS.md` (mirrored in `CLAUDE.md`) instructing agents to keep comments brief and focused on information that stays relevant long-term, rather than describing the instantaneous change.

The new note lands in the **Code Quality** section:

> NOTE: Keep comments brief and focused on information that stays relevant long-term. Don't write comments that only describe the instantaneous change (e.g. what was just added/removed/refactored).

## Test plan
Docs-only change; no code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a note to the Code Quality section of `AGENTS.md` asking contributors to keep comments brief and focused on long-term relevance, not on the immediate change. Docs-only; no code changes.

<sup>Written for commit 2b04d213540dc52b6f357aef99f328094ac08923. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

