### PR TITLE
fix(tenant): skip tenant resolution for /health and /metrics probes

### DIFF
--- a/backend/ee/onyx/server/middleware/tenant_tracking.py
+++ b/backend/ee/onyx/server/middleware/tenant_tracking.py
@@ -24,6 +24,10 @@ from shared_configs.configs import MULTI_TENANT
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 
+# Unauthenticated, non-tenant-scoped endpoints (LB/Prometheus probes, API docs),
+# so tenant resolution is skipped for them.
+TENANT_RESOLUTION_SKIP_PATHS = frozenset({"/health", "/metrics", "/openapi.json"})
+
 
 def add_api_server_tenant_id_middleware(
     app: FastAPI, logger: logging.LoggerAdapter
@@ -38,6 +42,10 @@ def add_api_server_tenant_id_middleware(
         to use elsewhere.
         """
         try:
+            if request.url.path in TENANT_RESOLUTION_SKIP_PATHS:
+                CURRENT_TENANT_ID_CONTEXTVAR.set(POSTGRES_DEFAULT_SCHEMA)
+                return await call_next(request)
+
             if MULTI_TENANT:
                 tenant_id = await _get_tenant_id_from_request(request, logger)
             else:


### PR DESCRIPTION
## Problem

In multi-tenant mode the EE tenant-tracking middleware runs on **every** request, including the unauthenticated `/health` and `/metrics` endpoints that load balancers and Prometheus poll on a tight loop. For each probe it did a Redis cookie lookup that always missed, then defaulted to `POSTGRES_DEFAULT_SCHEMA` — emitting two debug log lines every time:

```
redis_pool.py:409      No auth token cookie found
tenant_tracking.py:161 Token data not found or expired in Redis, defaulting to POSTGRES_DEFAULT_SCHEMA
```

At debug log level this is a constant stream of noise (one pair per health check, from every LB node), plus a wasted Redis round-trip per probe.

## Fix

Short-circuit `/health` and `/metrics` to the default schema **before** touching Redis, via a new `TENANT_RESOLUTION_SKIP_PATHS` set (mirrors the `_EXCLUDED_HANDLERS` list in `prometheus_setup.py`).

Behavior is unchanged: these paths already resolved to `POSTGRES_DEFAULT_SCHEMA` and were never subject to tenant gating (which only fires for non-default tenants). The change just removes the wasted lookup and the log spam.

## Notes

- The `latency_logging` debug line and the uvicorn access log line for `/health` are out of scope here — those would need a logging filter (a separate, optional change).
- Requires an **api_server** restart to take effect.

## Test plan

- [ ] `curl /health` and confirm `redis_pool`/`tenant_tracking` debug lines no longer appear in `api_server_debug.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip tenant resolution for unauthenticated `/health`, `/metrics`, and `/openapi.json` endpoints to remove wasted Redis lookups and cut debug log noise. These requests now set the tenant context to POSTGRES_DEFAULT_SCHEMA and return early, preserving behavior and bypassing tenant gating.

<sup>Written for commit 0ec9717e4a333fab0b52f55d4be6f0868319a3f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

