### PR TITLE
feat(admin): replace three-dots loader with animated Onyx mark

### DIFF
--- a/web/.claude/settings.local.json
+++ b/web/.claude/settings.local.json
@@ -1,7 +1,0 @@
-{
-  "enabledMcpjsonServers": [
-    "playwright",
-    "agent-wiki",
-    "linear"
-  ]
-}

--- a/web/.claude/settings.local.json
+++ b/web/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "enabledMcpjsonServers": [
+    "playwright",
+    "agent-wiki",
+    "linear"
+  ]
+}

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -66,7 +66,6 @@
         "react-dom": "19.2.4",
         "react-dropzone": "^14.2.3",
         "react-icons": "^4.8.0",
-        "react-loader-spinner": "^8.0.0",
         "react-markdown": "^9.0.1",
         "react-select": "^5.8.0",
         "recharts": "^2.13.1",
@@ -302,7 +301,7 @@
 
     "@emotion/stylis": ["@emotion/stylis@0.8.5", "", {}, ""],
 
-    "@emotion/unitless": ["@emotion/unitless@0.8.1", "", {}, ""],
+    "@emotion/unitless": ["@emotion/unitless@0.10.0", "", {}, ""],
 
     "@emotion/use-insertion-effect-with-fallbacks": ["@emotion/use-insertion-effect-with-fallbacks@1.2.0", "", { "peerDependencies": { "react": ">=16.8.0" } }, ""],
 
@@ -1068,8 +1067,6 @@
 
     "@types/stats.js": ["@types/stats.js@0.17.4", "", {}, "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA=="],
 
-    "@types/stylis": ["@types/stylis@4.2.5", "", {}, ""],
-
     "@types/tough-cookie": ["@types/tough-cookie@4.0.5", "", {}, "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="],
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
@@ -1230,8 +1227,6 @@
 
     "camelcase": ["camelcase@6.3.0", "", {}, ""],
 
-    "camelize": ["camelize@1.0.1", "", {}, ""],
-
     "caniuse-lite": ["caniuse-lite@1.0.30001768", "", {}, "sha512-qY3aDRZC5nWPgHUgIB84WL+nySuo19wk0VJpp/XI9T34lrvkyhRvNVOFJOp2kxClQhiFBu+TaUSudf6oa3vkSA=="],
 
     "ccount": ["ccount@2.0.1", "", {}, ""],
@@ -1311,10 +1306,6 @@
     "create-jest": ["create-jest@29.7.0", "", { "dependencies": { "@jest/types": "^29.6.3", "chalk": "^4.0.0", "exit": "^0.1.2", "graceful-fs": "^4.2.9", "jest-config": "^29.7.0", "jest-util": "^29.7.0", "prompts": "^2.0.1" }, "bin": "bin/create-jest.js" }, ""],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, ""],
-
-    "css-color-keywords": ["css-color-keywords@1.0.0", "", {}, ""],
-
-    "css-to-react-native": ["css-to-react-native@3.2.0", "", { "dependencies": { "camelize": "^1.0.0", "css-color-keywords": "^1.0.0", "postcss-value-parser": "^4.0.2" } }, ""],
 
     "css.escape": ["css.escape@1.5.1", "", {}, ""],
 
@@ -2068,8 +2059,6 @@
 
     "postcss-selector-parser": ["postcss-selector-parser@6.0.10", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, ""],
 
-    "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, ""],
-
     "posthog-js": ["posthog-js@1.376.3", "", { "dependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/api-logs": "^0.208.0", "@opentelemetry/exporter-logs-otlp-http": "^0.208.0", "@opentelemetry/resources": "^2.2.0", "@opentelemetry/sdk-logs": "^0.208.0", "@posthog/core": "1.29.12", "@posthog/types": "1.376.3", "core-js": "^3.38.1", "dompurify": "^3.3.2", "fflate": "^0.4.8", "preact": "^10.28.2", "query-selector-shadow-dom": "^1.0.1", "web-vitals": "^5.1.0" } }, "sha512-Wmj4N6E352b8aWt/AjRYIOfagQgOlkb8LCD/r7i1eGj8WPBhrYLEXojQeZ+jndbiPbRo21l24bFJso7fyNafWQ=="],
 
     "pptxgenjs": ["pptxgenjs@4.0.1", "", { "dependencies": { "@types/node": "^22.8.1", "https": "^1.0.0", "image-size": "^1.2.1", "jszip": "^3.10.1" } }, "sha512-TeJISr8wouAuXw4C1F/mC33xbZs/FuEG6nH9FG1Zj+nuPcGMP5YRHl6X+j3HSUnS1f3at6k75ZZXPMZlA5Lj9A=="],
@@ -2127,8 +2116,6 @@
     "react-icons": ["react-icons@4.12.0", "", { "peerDependencies": { "react": "*" } }, ""],
 
     "react-is": ["react-is@19.2.0", "", {}, ""],
-
-    "react-loader-spinner": ["react-loader-spinner@8.0.0", "", { "dependencies": { "styled-components": "^6.1.19", "tinycolor2": "^1.6.0" }, "peerDependencies": { "react": ">=17.0.0 <20.0.0", "react-dom": ">=17.0.0 <20.0.0" } }, ""],
 
     "react-markdown": ["react-markdown@9.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "html-url-attributes": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "unified": "^11.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" }, "peerDependencies": { "@types/react": ">=18", "react": ">=18" } }, ""],
 
@@ -2210,8 +2197,6 @@
 
     "setimmediate": ["setimmediate@1.0.5", "", {}, "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="],
 
-    "shallowequal": ["shallowequal@1.1.0", "", {}, ""],
-
     "sharp": ["sharp@0.33.5", "", { "dependencies": { "color": "^4.2.3", "detect-libc": "^2.0.3", "semver": "^7.6.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.33.5", "@img/sharp-darwin-x64": "0.33.5", "@img/sharp-libvips-darwin-arm64": "1.0.4", "@img/sharp-libvips-darwin-x64": "1.0.4", "@img/sharp-libvips-linux-arm": "1.0.5", "@img/sharp-libvips-linux-arm64": "1.0.4", "@img/sharp-libvips-linux-s390x": "1.0.4", "@img/sharp-libvips-linux-x64": "1.0.4", "@img/sharp-libvips-linuxmusl-arm64": "1.0.4", "@img/sharp-libvips-linuxmusl-x64": "1.0.4", "@img/sharp-linux-arm": "0.33.5", "@img/sharp-linux-arm64": "0.33.5", "@img/sharp-linux-s390x": "0.33.5", "@img/sharp-linux-x64": "0.33.5", "@img/sharp-linuxmusl-arm64": "0.33.5", "@img/sharp-linuxmusl-x64": "0.33.5", "@img/sharp-wasm32": "0.33.5", "@img/sharp-win32-ia32": "0.33.5", "@img/sharp-win32-x64": "0.33.5" } }, ""],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, ""],
@@ -2284,11 +2269,9 @@
 
     "style-to-object": ["style-to-object@1.0.12", "", { "dependencies": { "inline-style-parser": "0.2.6" } }, ""],
 
-    "styled-components": ["styled-components@6.1.19", "", { "dependencies": { "@emotion/is-prop-valid": "1.2.2", "@emotion/unitless": "0.8.1", "@types/stylis": "4.2.5", "css-to-react-native": "3.2.0", "csstype": "3.1.3", "postcss": "8.4.49", "shallowequal": "1.1.0", "stylis": "4.3.2", "tslib": "2.6.2" }, "peerDependencies": { "react": ">= 16.8.0", "react-dom": ">= 16.8.0" } }, ""],
-
     "styled-jsx": ["styled-jsx@5.1.6", "", { "dependencies": { "client-only": "0.0.1" }, "peerDependencies": { "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0" } }, ""],
 
-    "stylis": ["stylis@4.3.2", "", {}, ""],
+    "stylis": ["stylis@4.2.0", "", {}, ""],
 
     "sucrase": ["sucrase@3.35.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.2", "commander": "^4.0.0", "glob": "^10.3.10", "lines-and-columns": "^1.1.6", "mz": "^2.7.0", "pirates": "^4.0.1", "ts-interface-checker": "^0.1.9" }, "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" } }, ""],
 
@@ -2520,15 +2503,9 @@
 
     "@emotion/babel-plugin/source-map": ["source-map@0.5.7", "", {}, ""],
 
-    "@emotion/babel-plugin/stylis": ["stylis@4.2.0", "", {}, ""],
-
     "@emotion/cache/@emotion/memoize": ["@emotion/memoize@0.9.0", "", {}, ""],
 
-    "@emotion/cache/stylis": ["stylis@4.2.0", "", {}, ""],
-
     "@emotion/serialize/@emotion/memoize": ["@emotion/memoize@0.9.0", "", {}, ""],
-
-    "@emotion/serialize/@emotion/unitless": ["@emotion/unitless@0.10.0", "", {}, ""],
 
     "@emotion/serialize/csstype": ["csstype@3.1.3", "", {}, ""],
 
@@ -2753,12 +2730,6 @@
     "style-dictionary/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "style-dictionary/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
-
-    "styled-components/csstype": ["csstype@3.1.3", "", {}, ""],
-
-    "styled-components/postcss": ["postcss@8.4.49", "", { "dependencies": { "nanoid": "^3.3.7", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, ""],
-
-    "styled-components/tslib": ["tslib@2.6.2", "", {}, ""],
 
     "sucrase/commander": ["commander@4.1.1", "", {}, ""],
 

--- a/web/package.json
+++ b/web/package.json
@@ -92,7 +92,6 @@
     "react-dom": "19.2.4",
     "react-dropzone": "^14.2.3",
     "react-icons": "^4.8.0",
-    "react-loader-spinner": "^8.0.0",
     "react-markdown": "^9.0.1",
     "react-select": "^5.8.0",
     "recharts": "^2.13.1",

--- a/web/src/app/admin/bots/page.tsx
+++ b/web/src/app/admin/bots/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ErrorCallout } from "@/components/ErrorCallout";
-import { ThreeDotsLoader } from "@/components/Loading";
+import { OnyxLoader } from "@/refresh-components/OnyxLoader";
 import { InstantSSRAutoRefresh } from "@/components/SSRAutoRefresh";
 import { SlackBotTable } from "./SlackBotTable";
 import { useSlackBots } from "./[bot-id]/hooks";
@@ -21,7 +21,7 @@ function Main() {
   } = useSlackBots();
 
   if (isSlackBotsLoading) {
-    return <ThreeDotsLoader />;
+    return <OnyxLoader />;
   }
 
   if (slackBotsError || !slackBots) {

--- a/web/src/app/admin/bots/page.tsx
+++ b/web/src/app/admin/bots/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ErrorCallout } from "@/components/ErrorCallout";
-import { OnyxLoader } from "@/refresh-components/OnyxLoader";
+import { PageLoader } from "@/refresh-components/PageLoader";
 import { InstantSSRAutoRefresh } from "@/components/SSRAutoRefresh";
 import { SlackBotTable } from "./SlackBotTable";
 import { useSlackBots } from "./[bot-id]/hooks";
@@ -21,7 +21,7 @@ function Main() {
   } = useSlackBots();
 
   if (isSlackBotsLoading) {
-    return <OnyxLoader />;
+    return <PageLoader />;
   }
 
   if (slackBotsError || !slackBots) {

--- a/web/src/app/admin/configuration/document-processing/page.tsx
+++ b/web/src/app/admin/configuration/document-processing/page.tsx
@@ -6,7 +6,7 @@ import { Button } from "@opal/components";
 import { InputTypeIn } from "@opal/components";
 import useSWR from "swr";
 import { SWR_KEYS } from "@/lib/swr-keys";
-import { ThreeDotsLoader } from "@/components/Loading";
+import { OnyxLoader } from "@/refresh-components/OnyxLoader";
 import { SettingsLayouts } from "@opal/layouts";
 import Text from "@/refresh-components/texts/Text";
 import { cn } from "@opal/utils";
@@ -56,7 +56,7 @@ function Main() {
   };
 
   if (isLoading) {
-    return <ThreeDotsLoader />;
+    return <OnyxLoader />;
   }
   return (
     <div className="pb-36">

--- a/web/src/app/admin/configuration/document-processing/page.tsx
+++ b/web/src/app/admin/configuration/document-processing/page.tsx
@@ -6,7 +6,7 @@ import { Button } from "@opal/components";
 import { InputTypeIn } from "@opal/components";
 import useSWR from "swr";
 import { SWR_KEYS } from "@/lib/swr-keys";
-import { OnyxLoader } from "@/refresh-components/OnyxLoader";
+import { PageLoader } from "@/refresh-components/PageLoader";
 import { SettingsLayouts } from "@opal/layouts";
 import Text from "@/refresh-components/texts/Text";
 import { cn } from "@opal/utils";
@@ -56,7 +56,7 @@ function Main() {
   };
 
   if (isLoading) {
-    return <OnyxLoader />;
+    return <PageLoader />;
   }
   return (
     <div className="pb-36">

--- a/web/src/app/admin/connector/[ccPairId]/InlineFileManagement.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/InlineFileManagement.tsx
@@ -18,7 +18,7 @@ import {
 import { toast } from "@/hooks/useToast";
 import useSWR from "swr";
 import { errorHandlingFetcher } from "@/lib/fetcher";
-import { ThreeDotsLoader } from "@/components/Loading";
+import { OnyxLoader } from "@/refresh-components/OnyxLoader";
 import Modal from "@/refresh-components/Modal";
 import Text from "@/refresh-components/texts/Text";
 import {
@@ -147,7 +147,7 @@ export default function InlineFileManagement({
   if (isLoading) {
     return (
       <div className="flex justify-center py-12">
-        <ThreeDotsLoader />
+        <OnyxLoader />
       </div>
     );
   }

--- a/web/src/app/admin/connector/[ccPairId]/InlineFileManagement.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/InlineFileManagement.tsx
@@ -18,7 +18,7 @@ import {
 import { toast } from "@/hooks/useToast";
 import useSWR from "swr";
 import { errorHandlingFetcher } from "@/lib/fetcher";
-import { OnyxLoader } from "@/refresh-components/OnyxLoader";
+import SvgSimpleLoader from "@opal/icons/simple-loader";
 import Modal from "@/refresh-components/Modal";
 import Text from "@/refresh-components/texts/Text";
 import {
@@ -147,7 +147,7 @@ export default function InlineFileManagement({
   if (isLoading) {
     return (
       <div className="flex justify-center py-12">
-        <OnyxLoader />
+        <SvgSimpleLoader className="h-6 w-6" />
       </div>
     );
   }

--- a/web/src/app/admin/connector/[ccPairId]/page.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/page.tsx
@@ -2,7 +2,7 @@
 
 import BackButton from "@/refresh-components/buttons/BackButton";
 import { ErrorCallout } from "@/components/ErrorCallout";
-import { ThreeDotsLoader } from "@/components/Loading";
+import { OnyxLoader } from "@/refresh-components/OnyxLoader";
 import { SourceIcon } from "@/components/SourceIcon";
 import { CCPairStatus, PermissionSyncStatus } from "@/components/Status";
 import { toast } from "@/hooks/useToast";
@@ -348,7 +348,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
   };
 
   if (isLoadingCCPair || isLoadingIndexAttempts) {
-    return <ThreeDotsLoader />;
+    return <OnyxLoader />;
   }
 
   if (!ccPair || (!hasLoadedOnce && ccPairError)) {

--- a/web/src/app/admin/connector/[ccPairId]/page.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/page.tsx
@@ -2,7 +2,7 @@
 
 import BackButton from "@/refresh-components/buttons/BackButton";
 import { ErrorCallout } from "@/components/ErrorCallout";
-import { OnyxLoader } from "@/refresh-components/OnyxLoader";
+import { PageLoader } from "@/refresh-components/PageLoader";
 import { SourceIcon } from "@/components/SourceIcon";
 import { CCPairStatus, PermissionSyncStatus } from "@/components/Status";
 import { toast } from "@/hooks/useToast";
@@ -348,7 +348,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
   };
 
   if (isLoadingCCPair || isLoadingIndexAttempts) {
-    return <OnyxLoader />;
+    return <PageLoader />;
   }
 
   if (!ccPair || (!hasLoadedOnce && ccPairError)) {

--- a/web/src/app/admin/debug/page.tsx
+++ b/web/src/app/admin/debug/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { SettingsLayouts } from "@opal/layouts";
-import { ThreeDotsLoader } from "@/components/Loading";
+import { OnyxLoader } from "@/refresh-components/OnyxLoader";
 import {
   Table,
   TableBody,
@@ -69,7 +69,7 @@ function Main() {
   };
 
   if (isLoading) {
-    return <ThreeDotsLoader />;
+    return <OnyxLoader />;
   }
 
   return (

--- a/web/src/app/admin/debug/page.tsx
+++ b/web/src/app/admin/debug/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { SettingsLayouts } from "@opal/layouts";
-import { OnyxLoader } from "@/refresh-components/OnyxLoader";
+import { PageLoader } from "@/refresh-components/PageLoader";
 import {
   Table,
   TableBody,
@@ -69,7 +69,7 @@ function Main() {
   };
 
   if (isLoading) {
-    return <OnyxLoader />;
+    return <PageLoader />;
   }
 
   return (

--- a/web/src/app/admin/discord-bot/BotConfigCard.tsx
+++ b/web/src/app/admin/discord-bot/BotConfigCard.tsx
@@ -49,7 +49,7 @@ export function BotConfigCard() {
             Bot Token
           </Text>
         </Section>
-        <OnyxLoader />
+        <div className="flex justify-center"><OnyxLoader /></div>
       </Card>
     );
   }

--- a/web/src/app/admin/discord-bot/BotConfigCard.tsx
+++ b/web/src/app/admin/discord-bot/BotConfigCard.tsx
@@ -49,7 +49,9 @@ export function BotConfigCard() {
             Bot Token
           </Text>
         </Section>
-        <div className="flex justify-center"><SvgSimpleLoader className="h-6 w-6" /></div>
+        <div className="flex justify-center">
+          <SvgSimpleLoader className="h-6 w-6" />
+        </div>
       </Card>
     );
   }

--- a/web/src/app/admin/discord-bot/BotConfigCard.tsx
+++ b/web/src/app/admin/discord-bot/BotConfigCard.tsx
@@ -7,7 +7,7 @@ import Card from "@/refresh-components/cards/Card";
 import { Button } from "@opal/components";
 import { Badge } from "@/components/ui/badge";
 import PasswordInputTypeIn from "@/refresh-components/inputs/PasswordInputTypeIn";
-import { OnyxLoader } from "@/refresh-components/OnyxLoader";
+import SvgSimpleLoader from "@opal/icons/simple-loader";
 import { Tooltip } from "@opal/components";
 import {
   useDiscordBotConfig,
@@ -49,7 +49,7 @@ export function BotConfigCard() {
             Bot Token
           </Text>
         </Section>
-        <div className="flex justify-center"><OnyxLoader /></div>
+        <div className="flex justify-center"><SvgSimpleLoader className="h-6 w-6" /></div>
       </Card>
     );
   }

--- a/web/src/app/admin/discord-bot/BotConfigCard.tsx
+++ b/web/src/app/admin/discord-bot/BotConfigCard.tsx
@@ -7,7 +7,7 @@ import Card from "@/refresh-components/cards/Card";
 import { Button } from "@opal/components";
 import { Badge } from "@/components/ui/badge";
 import PasswordInputTypeIn from "@/refresh-components/inputs/PasswordInputTypeIn";
-import { ThreeDotsLoader } from "@/components/Loading";
+import { OnyxLoader } from "@/refresh-components/OnyxLoader";
 import { Tooltip } from "@opal/components";
 import {
   useDiscordBotConfig,
@@ -49,7 +49,7 @@ export function BotConfigCard() {
             Bot Token
           </Text>
         </Section>
-        <ThreeDotsLoader />
+        <OnyxLoader />
       </Card>
     );
   }

--- a/web/src/app/admin/discord-bot/[guild-id]/page.tsx
+++ b/web/src/app/admin/discord-bot/[guild-id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { use, useState, useEffect, useCallback, useMemo } from "react";
 import { cn } from "@opal/utils";
-import { OnyxLoader } from "@/refresh-components/OnyxLoader";
+import SvgSimpleLoader from "@opal/icons/simple-loader";
 import { PageLoader } from "@/refresh-components/PageLoader";
 import { ErrorCallout } from "@/components/ErrorCallout";
 import { toast } from "@/hooks/useToast";
@@ -130,7 +130,7 @@ function GuildDetailContent({
           </Text>
         ) : channelsLoading ? (
           <div className="flex justify-center py-12">
-            <OnyxLoader />
+            <SvgSimpleLoader className="h-6 w-6" />
           </div>
         ) : channelsError ? (
           <ErrorCallout

--- a/web/src/app/admin/discord-bot/[guild-id]/page.tsx
+++ b/web/src/app/admin/discord-bot/[guild-id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { use, useState, useEffect, useCallback, useMemo } from "react";
 import { cn } from "@opal/utils";
-import { ThreeDotsLoader } from "@/components/Loading";
+import { OnyxLoader } from "@/refresh-components/OnyxLoader";
 import { ErrorCallout } from "@/components/ErrorCallout";
 import { toast } from "@/hooks/useToast";
 import { Section } from "@/layouts/general-layouts";
@@ -65,7 +65,7 @@ function GuildDetailContent({
     useDiscordChannels(guildId);
 
   if (guildLoading) {
-    return <ThreeDotsLoader />;
+    return <OnyxLoader />;
   }
 
   if (guildError || !guild) {
@@ -128,7 +128,7 @@ function GuildDetailContent({
             registered.
           </Text>
         ) : channelsLoading ? (
-          <ThreeDotsLoader />
+          <OnyxLoader />
         ) : channelsError ? (
           <ErrorCallout
             errorTitle="Failed to load channels"

--- a/web/src/app/admin/discord-bot/[guild-id]/page.tsx
+++ b/web/src/app/admin/discord-bot/[guild-id]/page.tsx
@@ -3,6 +3,7 @@
 import { use, useState, useEffect, useCallback, useMemo } from "react";
 import { cn } from "@opal/utils";
 import { OnyxLoader } from "@/refresh-components/OnyxLoader";
+import { PageLoader } from "@/refresh-components/PageLoader";
 import { ErrorCallout } from "@/components/ErrorCallout";
 import { toast } from "@/hooks/useToast";
 import { Section } from "@/layouts/general-layouts";
@@ -65,7 +66,7 @@ function GuildDetailContent({
     useDiscordChannels(guildId);
 
   if (guildLoading) {
-    return <OnyxLoader />;
+    return <PageLoader />;
   }
 
   if (guildError || !guild) {
@@ -128,7 +129,9 @@ function GuildDetailContent({
             registered.
           </Text>
         ) : channelsLoading ? (
-          <OnyxLoader />
+          <div className="flex justify-center py-12">
+            <OnyxLoader />
+          </div>
         ) : channelsError ? (
           <ErrorCallout
             errorTitle="Failed to load channels"

--- a/web/src/app/admin/discord-bot/page.tsx
+++ b/web/src/app/admin/discord-bot/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { OnyxLoader } from "@/refresh-components/OnyxLoader";
+import { PageLoader } from "@/refresh-components/PageLoader";
 import { ErrorCallout } from "@/components/ErrorCallout";
 import { toast } from "@/hooks/useToast";
 import { Section } from "@/layouts/general-layouts";
@@ -51,7 +51,7 @@ function DiscordBotContent() {
   };
 
   if (isLoading) {
-    return <OnyxLoader />;
+    return <PageLoader />;
   }
 
   if (error || !guilds) {

--- a/web/src/app/admin/discord-bot/page.tsx
+++ b/web/src/app/admin/discord-bot/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { ThreeDotsLoader } from "@/components/Loading";
+import { OnyxLoader } from "@/refresh-components/OnyxLoader";
 import { ErrorCallout } from "@/components/ErrorCallout";
 import { toast } from "@/hooks/useToast";
 import { Section } from "@/layouts/general-layouts";
@@ -51,7 +51,7 @@ function DiscordBotContent() {
   };
 
   if (isLoading) {
-    return <ThreeDotsLoader />;
+    return <OnyxLoader />;
   }
 
   if (error || !guilds) {

--- a/web/src/app/admin/documents/explorer/Explorer.tsx
+++ b/web/src/app/admin/documents/explorer/Explorer.tsx
@@ -19,7 +19,7 @@ import { SourceIcon } from "@/components/SourceIcon";
 import { Connector } from "@/lib/connectors/connectors";
 import { HorizontalFilters } from "@/components/filters/SourceSelector";
 import { InputTypeIn } from "@opal/components";
-import { OnyxLoader } from "@/refresh-components/OnyxLoader";
+import SvgSimpleLoader from "@opal/icons/simple-loader";
 
 const DocumentDisplay = ({
   document,
@@ -209,7 +209,7 @@ export function Explorer({
       )}
       {isLoading && (
         <div className="flex justify-center py-12">
-          <OnyxLoader />
+          <SvgSimpleLoader className="h-6 w-6" />
         </div>
       )}
     </div>

--- a/web/src/app/admin/documents/explorer/Explorer.tsx
+++ b/web/src/app/admin/documents/explorer/Explorer.tsx
@@ -207,7 +207,11 @@ export function Explorer({
           })}
         </div>
       )}
-      {isLoading && <OnyxLoader />}
+      {isLoading && (
+        <div className="flex justify-center py-12">
+          <OnyxLoader />
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/app/admin/documents/explorer/Explorer.tsx
+++ b/web/src/app/admin/documents/explorer/Explorer.tsx
@@ -19,7 +19,7 @@ import { SourceIcon } from "@/components/SourceIcon";
 import { Connector } from "@/lib/connectors/connectors";
 import { HorizontalFilters } from "@/components/filters/SourceSelector";
 import { InputTypeIn } from "@opal/components";
-import { ThreeDotsLoader } from "@/components/Loading";
+import { OnyxLoader } from "@/refresh-components/OnyxLoader";
 
 const DocumentDisplay = ({
   document,
@@ -207,7 +207,7 @@ export function Explorer({
           })}
         </div>
       )}
-      {isLoading && <ThreeDotsLoader />}
+      {isLoading && <OnyxLoader />}
     </div>
   );
 }

--- a/web/src/app/admin/documents/sets/[documentSetId]/page.tsx
+++ b/web/src/app/admin/documents/sets/[documentSetId]/page.tsx
@@ -4,7 +4,7 @@ import { use } from "react";
 import { ErrorCallout } from "@/components/ErrorCallout";
 import { refreshDocumentSets, useDocumentSets } from "../hooks";
 import { useConnectorStatus, useUserGroups } from "@/lib/hooks";
-import { OnyxLoader } from "@/refresh-components/OnyxLoader";
+import { PageLoader } from "@/refresh-components/PageLoader";
 import { SettingsLayouts } from "@opal/layouts";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 import CardSection from "@/components/admin/CardSection";
@@ -40,7 +40,7 @@ function Main({ documentSetId }: { documentSetId: number }) {
   ) {
     return (
       <div className="flex justify-center items-center min-h-[400px]">
-        <OnyxLoader />
+        <PageLoader />
       </div>
     );
   }

--- a/web/src/app/admin/documents/sets/[documentSetId]/page.tsx
+++ b/web/src/app/admin/documents/sets/[documentSetId]/page.tsx
@@ -4,7 +4,7 @@ import { use } from "react";
 import { ErrorCallout } from "@/components/ErrorCallout";
 import { refreshDocumentSets, useDocumentSets } from "../hooks";
 import { useConnectorStatus, useUserGroups } from "@/lib/hooks";
-import { ThreeDotsLoader } from "@/components/Loading";
+import { OnyxLoader } from "@/refresh-components/OnyxLoader";
 import { SettingsLayouts } from "@opal/layouts";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 import CardSection from "@/components/admin/CardSection";
@@ -40,7 +40,7 @@ function Main({ documentSetId }: { documentSetId: number }) {
   ) {
     return (
       <div className="flex justify-center items-center min-h-[400px]">
-        <ThreeDotsLoader />
+        <OnyxLoader />
       </div>
     );
   }

--- a/web/src/app/admin/documents/sets/new/page.tsx
+++ b/web/src/app/admin/documents/sets/new/page.tsx
@@ -4,7 +4,7 @@ import { SettingsLayouts } from "@opal/layouts";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 import { DocumentSetCreationForm } from "../DocumentSetCreationForm";
 import { useConnectorStatus, useUserGroups } from "@/lib/hooks";
-import { OnyxLoader } from "@/refresh-components/OnyxLoader";
+import { PageLoader } from "@/refresh-components/PageLoader";
 import { ErrorCallout } from "@/components/ErrorCallout";
 import { useRouter } from "next/navigation";
 import { refreshDocumentSets } from "../hooks";
@@ -29,7 +29,7 @@ function Main() {
   if ((vectorDbEnabled && isCCPairsLoading) || userGroupsIsLoading) {
     return (
       <div className="flex justify-center items-center min-h-[400px]">
-        <OnyxLoader />
+        <PageLoader />
       </div>
     );
   }

--- a/web/src/app/admin/documents/sets/new/page.tsx
+++ b/web/src/app/admin/documents/sets/new/page.tsx
@@ -4,7 +4,7 @@ import { SettingsLayouts } from "@opal/layouts";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 import { DocumentSetCreationForm } from "../DocumentSetCreationForm";
 import { useConnectorStatus, useUserGroups } from "@/lib/hooks";
-import { ThreeDotsLoader } from "@/components/Loading";
+import { OnyxLoader } from "@/refresh-components/OnyxLoader";
 import { ErrorCallout } from "@/components/ErrorCallout";
 import { useRouter } from "next/navigation";
 import { refreshDocumentSets } from "../hooks";
@@ -29,7 +29,7 @@ function Main() {
   if ((vectorDbEnabled && isCCPairsLoading) || userGroupsIsLoading) {
     return (
       <div className="flex justify-center items-center min-h-[400px]">
-        <ThreeDotsLoader />
+        <OnyxLoader />
       </div>
     );
   }

--- a/web/src/app/admin/documents/sets/page.tsx
+++ b/web/src/app/admin/documents/sets/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { OnyxLoader } from "@/refresh-components/OnyxLoader";
+import { PageLoader } from "@/refresh-components/PageLoader";
 import { PageSelector } from "@/components/PageSelector";
 import { SvgInfo, SvgPlusCircle } from "@opal/icons";
 import {
@@ -366,7 +366,7 @@ function Main() {
   if (isDocumentSetsLoading || isEditableDocumentSetsLoading) {
     return (
       <div className="flex justify-center items-center min-h-[400px]">
-        <OnyxLoader />
+        <PageLoader />
       </div>
     );
   }

--- a/web/src/app/admin/documents/sets/page.tsx
+++ b/web/src/app/admin/documents/sets/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ThreeDotsLoader } from "@/components/Loading";
+import { OnyxLoader } from "@/refresh-components/OnyxLoader";
 import { PageSelector } from "@/components/PageSelector";
 import { SvgInfo, SvgPlusCircle } from "@opal/icons";
 import {
@@ -366,7 +366,7 @@ function Main() {
   if (isDocumentSetsLoading || isEditableDocumentSetsLoading) {
     return (
       <div className="flex justify-center items-center min-h-[400px]">
-        <ThreeDotsLoader />
+        <OnyxLoader />
       </div>
     );
   }

--- a/web/src/app/admin/scim/page.tsx
+++ b/web/src/app/admin/scim/page.tsx
@@ -8,7 +8,7 @@ import { useScimToken } from "@/hooks/useScimToken";
 import { useCreateModal } from "@/refresh-components/contexts/ModalContext";
 import { SettingsLayouts } from "@opal/layouts";
 import Text from "@/refresh-components/texts/Text";
-import { ThreeDotsLoader } from "@/components/Loading";
+import { OnyxLoader } from "@/refresh-components/OnyxLoader";
 
 import type { ScimTokenCreatedResponse, ScimModalView } from "./interfaces";
 import { generateScimToken } from "./svc";
@@ -31,7 +31,7 @@ function ScimContent() {
   const isConnected = hasToken && token.last_used_at !== null;
 
   if (isLoading) {
-    return <ThreeDotsLoader />;
+    return <OnyxLoader />;
   }
 
   if (tokenError) {

--- a/web/src/app/admin/scim/page.tsx
+++ b/web/src/app/admin/scim/page.tsx
@@ -8,7 +8,7 @@ import { useScimToken } from "@/hooks/useScimToken";
 import { useCreateModal } from "@/refresh-components/contexts/ModalContext";
 import { SettingsLayouts } from "@opal/layouts";
 import Text from "@/refresh-components/texts/Text";
-import { OnyxLoader } from "@/refresh-components/OnyxLoader";
+import { PageLoader } from "@/refresh-components/PageLoader";
 
 import type { ScimTokenCreatedResponse, ScimModalView } from "./interfaces";
 import { generateScimToken } from "./svc";
@@ -31,7 +31,7 @@ function ScimContent() {
   const isConnected = hasToken && token.last_used_at !== null;
 
   if (isLoading) {
-    return <OnyxLoader />;
+    return <PageLoader />;
   }
 
   if (tokenError) {

--- a/web/src/app/admin/token-rate-limits/TokenRateLimitTables.tsx
+++ b/web/src/app/admin/token-rate-limits/TokenRateLimitTables.tsx
@@ -10,7 +10,7 @@ import {
 import Title from "@/components/ui/title";
 import { DeleteButton } from "@/components/DeleteButton";
 import { deleteTokenRateLimit, updateTokenRateLimit } from "./lib";
-import { OnyxLoader } from "@/refresh-components/OnyxLoader";
+import { PageLoader } from "@/refresh-components/PageLoader";
 import { TokenRateLimitDisplay } from "./types";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import useSWR, { mutate } from "swr";
@@ -193,7 +193,7 @@ export const GenericTokenRateLimitTable = ({
   );
 
   if (isLoading) {
-    return <OnyxLoader />;
+    return <PageLoader />;
   }
 
   if (!isLoading && error) {

--- a/web/src/app/admin/token-rate-limits/TokenRateLimitTables.tsx
+++ b/web/src/app/admin/token-rate-limits/TokenRateLimitTables.tsx
@@ -10,7 +10,7 @@ import {
 import Title from "@/components/ui/title";
 import { DeleteButton } from "@/components/DeleteButton";
 import { deleteTokenRateLimit, updateTokenRateLimit } from "./lib";
-import { ThreeDotsLoader } from "@/components/Loading";
+import { OnyxLoader } from "@/refresh-components/OnyxLoader";
 import { TokenRateLimitDisplay } from "./types";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import useSWR, { mutate } from "swr";
@@ -193,7 +193,7 @@ export const GenericTokenRateLimitTable = ({
   );
 
   if (isLoading) {
-    return <ThreeDotsLoader />;
+    return <OnyxLoader />;
   }
 
   if (!isLoading && error) {

--- a/web/src/app/ee/admin/performance/query-history/QueryHistoryTable.tsx
+++ b/web/src/app/ee/admin/performance/query-history/QueryHistoryTable.tsx
@@ -345,7 +345,7 @@ export function QueryHistoryTable() {
               <TableBody>
                 <TableRow>
                   <TableCell colSpan={6} className="text-center">
-                    <OnyxLoader />
+                    <div className="flex justify-center"><OnyxLoader /></div>
                   </TableCell>
                 </TableRow>
               </TableBody>

--- a/web/src/app/ee/admin/performance/query-history/QueryHistoryTable.tsx
+++ b/web/src/app/ee/admin/performance/query-history/QueryHistoryTable.tsx
@@ -345,7 +345,9 @@ export function QueryHistoryTable() {
               <TableBody>
                 <TableRow>
                   <TableCell colSpan={6} className="text-center">
-                    <div className="flex justify-center"><SvgSimpleLoader className="h-6 w-6" /></div>
+                    <div className="flex justify-center">
+                      <SvgSimpleLoader className="h-6 w-6" />
+                    </div>
                   </TableCell>
                 </TableRow>
               </TableBody>

--- a/web/src/app/ee/admin/performance/query-history/QueryHistoryTable.tsx
+++ b/web/src/app/ee/admin/performance/query-history/QueryHistoryTable.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/components/ui/table";
 import Text from "@/refresh-components/texts/Text";
 import InputSelect from "@/refresh-components/inputs/InputSelect";
-import { ThreeDotsLoader } from "@/components/Loading";
+import { OnyxLoader } from "@/refresh-components/OnyxLoader";
 import { ChatSessionMinimal } from "@/app/ee/admin/performance/usage/types";
 import { Section } from "@/layouts/general-layouts";
 import { timestampToReadableDate } from "@/lib/dateUtils";
@@ -345,7 +345,7 @@ export function QueryHistoryTable() {
               <TableBody>
                 <TableRow>
                   <TableCell colSpan={6} className="text-center">
-                    <ThreeDotsLoader />
+                    <OnyxLoader />
                   </TableCell>
                 </TableRow>
               </TableBody>

--- a/web/src/app/ee/admin/performance/query-history/QueryHistoryTable.tsx
+++ b/web/src/app/ee/admin/performance/query-history/QueryHistoryTable.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/components/ui/table";
 import Text from "@/refresh-components/texts/Text";
 import InputSelect from "@/refresh-components/inputs/InputSelect";
-import { OnyxLoader } from "@/refresh-components/OnyxLoader";
+import SvgSimpleLoader from "@opal/icons/simple-loader";
 import { ChatSessionMinimal } from "@/app/ee/admin/performance/usage/types";
 import { Section } from "@/layouts/general-layouts";
 import { timestampToReadableDate } from "@/lib/dateUtils";
@@ -345,7 +345,7 @@ export function QueryHistoryTable() {
               <TableBody>
                 <TableRow>
                   <TableCell colSpan={6} className="text-center">
-                    <div className="flex justify-center"><OnyxLoader /></div>
+                    <div className="flex justify-center"><SvgSimpleLoader className="h-6 w-6" /></div>
                   </TableCell>
                 </TableRow>
               </TableBody>

--- a/web/src/app/ee/admin/performance/query-history/[id]/page.tsx
+++ b/web/src/app/ee/admin/performance/query-history/[id]/page.tsx
@@ -13,7 +13,7 @@ import { errorHandlingFetcher } from "@/lib/fetcher";
 import useSWR from "swr";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import { ErrorCallout } from "@/components/ErrorCallout";
-import { ThreeDotsLoader } from "@/components/Loading";
+import { OnyxLoader } from "@/refresh-components/OnyxLoader";
 import CardSection from "@/components/admin/CardSection";
 
 function MessageDisplay({ message }: { message: MessageSnapshot }) {
@@ -77,7 +77,7 @@ export default function QueryPage(props: { params: Promise<{ id: string }> }) {
   );
 
   if (isLoading) {
-    return <ThreeDotsLoader />;
+    return <OnyxLoader />;
   }
 
   if (!chatSessionSnapshot || error) {

--- a/web/src/app/ee/admin/performance/query-history/[id]/page.tsx
+++ b/web/src/app/ee/admin/performance/query-history/[id]/page.tsx
@@ -13,7 +13,7 @@ import { errorHandlingFetcher } from "@/lib/fetcher";
 import useSWR from "swr";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import { ErrorCallout } from "@/components/ErrorCallout";
-import { OnyxLoader } from "@/refresh-components/OnyxLoader";
+import { PageLoader } from "@/refresh-components/PageLoader";
 import CardSection from "@/components/admin/CardSection";
 
 function MessageDisplay({ message }: { message: MessageSnapshot }) {
@@ -77,7 +77,7 @@ export default function QueryPage(props: { params: Promise<{ id: string }> }) {
   );
 
   if (isLoading) {
-    return <OnyxLoader />;
+    return <PageLoader />;
   }
 
   if (!chatSessionSnapshot || error) {

--- a/web/src/app/ee/admin/performance/usage/FeedbackChart.tsx
+++ b/web/src/app/ee/admin/performance/usage/FeedbackChart.tsx
@@ -1,4 +1,4 @@
-import { ThreeDotsLoader } from "@/components/Loading";
+import { OnyxLoader } from "@/refresh-components/OnyxLoader";
 import { getDatesList, useQueryAnalytics } from "../lib";
 import { Text } from "@opal/components";
 import Title from "@/components/ui/title";
@@ -22,7 +22,7 @@ export function FeedbackChart({
   if (isQueryAnalyticsLoading) {
     chart = (
       <div className="h-80 flex flex-col">
-        <ThreeDotsLoader />
+        <OnyxLoader />
       </div>
     );
   } else if (

--- a/web/src/app/ee/admin/performance/usage/FeedbackChart.tsx
+++ b/web/src/app/ee/admin/performance/usage/FeedbackChart.tsx
@@ -21,7 +21,7 @@ export function FeedbackChart({
   let chart;
   if (isQueryAnalyticsLoading) {
     chart = (
-      <div className="h-80 flex flex-col">
+      <div className="h-80 flex flex-col items-center justify-center">
         <OnyxLoader />
       </div>
     );

--- a/web/src/app/ee/admin/performance/usage/FeedbackChart.tsx
+++ b/web/src/app/ee/admin/performance/usage/FeedbackChart.tsx
@@ -1,4 +1,4 @@
-import { OnyxLoader } from "@/refresh-components/OnyxLoader";
+import SvgSimpleLoader from "@opal/icons/simple-loader";
 import { getDatesList, useQueryAnalytics } from "../lib";
 import { Text } from "@opal/components";
 import Title from "@/components/ui/title";
@@ -22,7 +22,7 @@ export function FeedbackChart({
   if (isQueryAnalyticsLoading) {
     chart = (
       <div className="h-80 flex flex-col items-center justify-center">
-        <OnyxLoader />
+        <SvgSimpleLoader className="h-6 w-6" />
       </div>
     );
   } else if (

--- a/web/src/app/ee/admin/performance/usage/OnyxBotChart.tsx
+++ b/web/src/app/ee/admin/performance/usage/OnyxBotChart.tsx
@@ -20,7 +20,7 @@ export function OnyxBotChart({
   let chart;
   if (isOnyxBotAnalyticsLoading) {
     chart = (
-      <div className="h-80 flex flex-col">
+      <div className="h-80 flex flex-col items-center justify-center">
         <OnyxLoader />
       </div>
     );

--- a/web/src/app/ee/admin/performance/usage/OnyxBotChart.tsx
+++ b/web/src/app/ee/admin/performance/usage/OnyxBotChart.tsx
@@ -1,4 +1,4 @@
-import { ThreeDotsLoader } from "@/components/Loading";
+import { OnyxLoader } from "@/refresh-components/OnyxLoader";
 import { getDatesList, useOnyxBotAnalytics } from "../lib";
 import { DateRangePickerValue } from "@/components/dateRangeSelectors/AdminDateRangeSelector";
 import { Text } from "@opal/components";
@@ -21,7 +21,7 @@ export function OnyxBotChart({
   if (isOnyxBotAnalyticsLoading) {
     chart = (
       <div className="h-80 flex flex-col">
-        <ThreeDotsLoader />
+        <OnyxLoader />
       </div>
     );
   } else if (

--- a/web/src/app/ee/admin/performance/usage/OnyxBotChart.tsx
+++ b/web/src/app/ee/admin/performance/usage/OnyxBotChart.tsx
@@ -1,4 +1,4 @@
-import { OnyxLoader } from "@/refresh-components/OnyxLoader";
+import SvgSimpleLoader from "@opal/icons/simple-loader";
 import { getDatesList, useOnyxBotAnalytics } from "../lib";
 import { DateRangePickerValue } from "@/components/dateRangeSelectors/AdminDateRangeSelector";
 import { Text } from "@opal/components";
@@ -21,7 +21,7 @@ export function OnyxBotChart({
   if (isOnyxBotAnalyticsLoading) {
     chart = (
       <div className="h-80 flex flex-col items-center justify-center">
-        <OnyxLoader />
+        <SvgSimpleLoader className="h-6 w-6" />
       </div>
     );
   } else if (

--- a/web/src/app/ee/admin/performance/usage/PersonaMessagesChart.tsx
+++ b/web/src/app/ee/admin/performance/usage/PersonaMessagesChart.tsx
@@ -1,4 +1,4 @@
-import { OnyxLoader } from "@/refresh-components/OnyxLoader";
+import SvgSimpleLoader from "@opal/icons/simple-loader";
 import { X, Search } from "lucide-react";
 import {
   getDatesList,
@@ -140,7 +140,7 @@ export function PersonaMessagesChart({
   if (isLoading) {
     content = (
       <div className="h-80 flex flex-col items-center justify-center">
-        <OnyxLoader />
+        <SvgSimpleLoader className="h-6 w-6" />
       </div>
     );
   } else if (!availablePersonas || hasError) {

--- a/web/src/app/ee/admin/performance/usage/PersonaMessagesChart.tsx
+++ b/web/src/app/ee/admin/performance/usage/PersonaMessagesChart.tsx
@@ -1,4 +1,4 @@
-import { PageLoader } from "@/refresh-components/PageLoader";
+import SvgSimpleLoader from "@opal/icons/simple-loader";
 import { X, Search } from "lucide-react";
 import {
   getDatesList,
@@ -138,7 +138,11 @@ export function PersonaMessagesChart({
 
   let content;
   if (isLoading) {
-    content = <PageLoader />;
+    content = (
+      <div className="h-80 flex flex-col items-center justify-center">
+        <SvgSimpleLoader className="h-6 w-6" />
+      </div>
+    );
   } else if (!availablePersonas || hasError) {
     content = (
       <div className="h-80 text-red-600 text-bold flex flex-col">

--- a/web/src/app/ee/admin/performance/usage/PersonaMessagesChart.tsx
+++ b/web/src/app/ee/admin/performance/usage/PersonaMessagesChart.tsx
@@ -1,4 +1,4 @@
-import SvgSimpleLoader from "@opal/icons/simple-loader";
+import { PageLoader } from "@/refresh-components/PageLoader";
 import { X, Search } from "lucide-react";
 import {
   getDatesList,
@@ -138,11 +138,7 @@ export function PersonaMessagesChart({
 
   let content;
   if (isLoading) {
-    content = (
-      <div className="h-80 flex flex-col items-center justify-center">
-        <SvgSimpleLoader className="h-6 w-6" />
-      </div>
-    );
+    content = <PageLoader />;
   } else if (!availablePersonas || hasError) {
     content = (
       <div className="h-80 text-red-600 text-bold flex flex-col">

--- a/web/src/app/ee/admin/performance/usage/PersonaMessagesChart.tsx
+++ b/web/src/app/ee/admin/performance/usage/PersonaMessagesChart.tsx
@@ -139,7 +139,7 @@ export function PersonaMessagesChart({
   let content;
   if (isLoading) {
     content = (
-      <div className="h-80 flex flex-col">
+      <div className="h-80 flex flex-col items-center justify-center">
         <OnyxLoader />
       </div>
     );

--- a/web/src/app/ee/admin/performance/usage/PersonaMessagesChart.tsx
+++ b/web/src/app/ee/admin/performance/usage/PersonaMessagesChart.tsx
@@ -1,4 +1,4 @@
-import { ThreeDotsLoader } from "@/components/Loading";
+import { OnyxLoader } from "@/refresh-components/OnyxLoader";
 import { X, Search } from "lucide-react";
 import {
   getDatesList,
@@ -140,7 +140,7 @@ export function PersonaMessagesChart({
   if (isLoading) {
     content = (
       <div className="h-80 flex flex-col">
-        <ThreeDotsLoader />
+        <OnyxLoader />
       </div>
     );
   } else if (!availablePersonas || hasError) {

--- a/web/src/app/ee/admin/performance/usage/QueryPerformanceChart.tsx
+++ b/web/src/app/ee/admin/performance/usage/QueryPerformanceChart.tsx
@@ -2,7 +2,7 @@
 
 import { DateRangePickerValue } from "@/components/dateRangeSelectors/AdminDateRangeSelector";
 import { getDatesList, useQueryAnalytics, useUserAnalytics } from "../lib";
-import { ThreeDotsLoader } from "@/components/Loading";
+import { OnyxLoader } from "@/refresh-components/OnyxLoader";
 import { AreaChartDisplay } from "@/components/ui/areaChart";
 import Title from "@/components/ui/title";
 import { Text } from "@opal/components";
@@ -28,7 +28,7 @@ export function QueryPerformanceChart({
   if (isQueryAnalyticsLoading || isUserAnalyticsLoading) {
     chart = (
       <div className="h-80 flex flex-col">
-        <ThreeDotsLoader />
+        <OnyxLoader />
       </div>
     );
   } else if (

--- a/web/src/app/ee/admin/performance/usage/QueryPerformanceChart.tsx
+++ b/web/src/app/ee/admin/performance/usage/QueryPerformanceChart.tsx
@@ -27,7 +27,7 @@ export function QueryPerformanceChart({
   let chart;
   if (isQueryAnalyticsLoading || isUserAnalyticsLoading) {
     chart = (
-      <div className="h-80 flex flex-col">
+      <div className="h-80 flex flex-col items-center justify-center">
         <OnyxLoader />
       </div>
     );

--- a/web/src/app/ee/admin/performance/usage/QueryPerformanceChart.tsx
+++ b/web/src/app/ee/admin/performance/usage/QueryPerformanceChart.tsx
@@ -2,7 +2,7 @@
 
 import { DateRangePickerValue } from "@/components/dateRangeSelectors/AdminDateRangeSelector";
 import { getDatesList, useQueryAnalytics, useUserAnalytics } from "../lib";
-import { OnyxLoader } from "@/refresh-components/OnyxLoader";
+import SvgSimpleLoader from "@opal/icons/simple-loader";
 import { AreaChartDisplay } from "@/components/ui/areaChart";
 import Title from "@/components/ui/title";
 import { Text } from "@opal/components";
@@ -28,7 +28,7 @@ export function QueryPerformanceChart({
   if (isQueryAnalyticsLoading || isUserAnalyticsLoading) {
     chart = (
       <div className="h-80 flex flex-col items-center justify-center">
-        <OnyxLoader />
+        <SvgSimpleLoader className="h-6 w-6" />
       </div>
     );
   } else if (

--- a/web/src/app/ee/admin/performance/usage/UsageReports.tsx
+++ b/web/src/app/ee/admin/performance/usage/UsageReports.tsx
@@ -21,7 +21,7 @@ import useSWR from "swr";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import React, { useState } from "react";
 import { UsageReport } from "./types";
-import { ThreeDotsLoader } from "@/components/Loading";
+import { OnyxLoader } from "@/refresh-components/OnyxLoader";
 import Link from "next/link";
 import { humanReadableFormat, humanReadableFormatWithTime } from "@opal/time";
 import { ErrorCallout } from "@/components/ErrorCallout";
@@ -285,7 +285,7 @@ function UsageReportsTable({
       <Title className="mb-2 mt-6 mx-auto"> Previous Reports </Title>
       {usageReportsIsLoading && !isWaitingForReport ? (
         <div className="flex justify-center w-full">
-          <ThreeDotsLoader />
+          <OnyxLoader />
         </div>
       ) : usageReportsError ? (
         <ErrorCallout

--- a/web/src/app/ee/admin/performance/usage/UsageReports.tsx
+++ b/web/src/app/ee/admin/performance/usage/UsageReports.tsx
@@ -21,7 +21,7 @@ import useSWR from "swr";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import React, { useState } from "react";
 import { UsageReport } from "./types";
-import { OnyxLoader } from "@/refresh-components/OnyxLoader";
+import SvgSimpleLoader from "@opal/icons/simple-loader";
 import Link from "next/link";
 import { humanReadableFormat, humanReadableFormatWithTime } from "@opal/time";
 import { ErrorCallout } from "@/components/ErrorCallout";
@@ -285,7 +285,7 @@ function UsageReportsTable({
       <Title className="mb-2 mt-6 mx-auto"> Previous Reports </Title>
       {usageReportsIsLoading && !isWaitingForReport ? (
         <div className="flex justify-center w-full">
-          <OnyxLoader />
+          <SvgSimpleLoader className="h-6 w-6" />
         </div>
       ) : usageReportsError ? (
         <ErrorCallout

--- a/web/src/app/ee/admin/standard-answer/page.tsx
+++ b/web/src/app/ee/admin/standard-answer/page.tsx
@@ -3,7 +3,7 @@
 import { SettingsLayouts } from "@opal/layouts";
 import { toast } from "@/hooks/useToast";
 import { useStandardAnswers, useStandardAnswerCategories } from "./hooks";
-import { ThreeDotsLoader } from "@/components/Loading";
+import { OnyxLoader } from "@/refresh-components/OnyxLoader";
 import { ErrorCallout } from "@/components/ErrorCallout";
 import { Divider } from "@opal/components";
 import {
@@ -359,7 +359,7 @@ function Main() {
   } = useStandardAnswerCategories();
 
   if (standardAnswersIsLoading || standardAnswerCategoriesIsLoading) {
-    return <ThreeDotsLoader />;
+    return <OnyxLoader />;
   }
 
   if (standardAnswersError || !standardAnswers) {

--- a/web/src/app/ee/admin/standard-answer/page.tsx
+++ b/web/src/app/ee/admin/standard-answer/page.tsx
@@ -3,7 +3,7 @@
 import { SettingsLayouts } from "@opal/layouts";
 import { toast } from "@/hooks/useToast";
 import { useStandardAnswers, useStandardAnswerCategories } from "./hooks";
-import { OnyxLoader } from "@/refresh-components/OnyxLoader";
+import { PageLoader } from "@/refresh-components/PageLoader";
 import { ErrorCallout } from "@/components/ErrorCallout";
 import { Divider } from "@opal/components";
 import {
@@ -359,7 +359,7 @@ function Main() {
   } = useStandardAnswerCategories();
 
   if (standardAnswersIsLoading || standardAnswerCategoriesIsLoading) {
-    return <OnyxLoader />;
+    return <PageLoader />;
   }
 
   if (standardAnswersError || !standardAnswers) {

--- a/web/src/app/ee/agents/stats/[id]/AgentStats.tsx
+++ b/web/src/app/ee/agents/stats/[id]/AgentStats.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { OnyxLoader } from "@/refresh-components/OnyxLoader";
+import SvgSimpleLoader from "@opal/icons/simple-loader";
 import { getDatesList } from "@/app/ee/admin/performance/lib";
 import { useEffect, useState, useMemo } from "react";
 import {
@@ -112,7 +112,7 @@ export function AgentStats({ agentId }: { agentId: number }) {
   if (isLoading || !agent) {
     content = (
       <div className="h-80 flex flex-col items-center justify-center">
-        <OnyxLoader />
+        <SvgSimpleLoader className="h-6 w-6" />
       </div>
     );
   } else if (error) {

--- a/web/src/app/ee/agents/stats/[id]/AgentStats.tsx
+++ b/web/src/app/ee/agents/stats/[id]/AgentStats.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ThreeDotsLoader } from "@/components/Loading";
+import { OnyxLoader } from "@/refresh-components/OnyxLoader";
 import { getDatesList } from "@/app/ee/admin/performance/lib";
 import { useEffect, useState, useMemo } from "react";
 import {
@@ -112,7 +112,7 @@ export function AgentStats({ agentId }: { agentId: number }) {
   if (isLoading || !agent) {
     content = (
       <div className="h-80 flex flex-col">
-        <ThreeDotsLoader />
+        <OnyxLoader />
       </div>
     );
   } else if (error) {

--- a/web/src/app/ee/agents/stats/[id]/AgentStats.tsx
+++ b/web/src/app/ee/agents/stats/[id]/AgentStats.tsx
@@ -111,7 +111,7 @@ export function AgentStats({ agentId }: { agentId: number }) {
   let content;
   if (isLoading || !agent) {
     content = (
-      <div className="h-80 flex flex-col">
+      <div className="h-80 flex flex-col items-center justify-center">
         <OnyxLoader />
       </div>
     );

--- a/web/src/components/Loading.tsx
+++ b/web/src/components/Loading.tsx
@@ -2,7 +2,6 @@
 
 import React, { useState, useEffect } from "react";
 import "./loading.css";
-import { ThreeDots } from "react-loader-spinner";
 import { cn } from "@opal/utils";
 
 interface LoadingAnimationProps {
@@ -42,24 +41,5 @@ export const LoadingAnimation: React.FC<LoadingAnimationProps> = ({
         <span className="dots">{dots}</span>
       </span>
     </span>
-  );
-};
-
-export const ThreeDotsLoader = () => {
-  return (
-    <div className="flex my-auto">
-      <div className="mx-auto">
-        <ThreeDots
-          height="30"
-          width="50"
-          color="#3b82f6"
-          ariaLabel="grid-loading"
-          radius="12.5"
-          wrapperStyle={{}}
-          wrapperClass=""
-          visible={true}
-        />
-      </div>
-    </div>
   );
 };

--- a/web/src/refresh-components/OnyxLoader.tsx
+++ b/web/src/refresh-components/OnyxLoader.tsx
@@ -1,60 +1,85 @@
 import React from "react";
 import { cn } from "@opal/utils";
-import { Text } from "@opal/components";
-import SvgOnyxOctagon from "@opal/icons/onyx-octagon";
-import SvgOnyxLogo from "@opal/icons/onyx-logo";
 import "./onyx-loader.css";
 
 interface OnyxLoaderProps {
   /** Size of the animated mark, in pixels. Default: 64 (matches the design). */
   size?: number;
-  /**
-   * Label rendered below the mark. Defaults to "Loading …".
-   * Pass `null` to render the mark on its own.
-   */
-  text?: string | null;
   className?: string;
 }
 
+// Onyx mark geometry (16-unit viewBox), matching the @opal/icons `onyx-octagon`
+// and `onyx-logo` paths. The stroke is defined here (rather than reusing those
+// icon components) so its weight can be tuned: at the default 64px size it
+// renders ~2.5px (Figma "Weight/Icon/Headline") and scales with `size`.
+const STROKE_WIDTH = 0.625;
+
+const OUTLINE_PATH =
+  "M4.5 2.50002L8 1.00002L11.5 2.50002M13.5 4.50002L15 8.00001L13.5 11.5M11.5 13.5L8 15L4.5 13.5M2.5 11.5L1 8L2.5 4.50002";
+
+const MARK_PATHS = [
+  "M8 4.00001L4.5 2.50002L8 1.00002L11.5 2.50002L8 4.00001Z",
+  "M8 12L11.5 13.5L8 15L4.5 13.5L8 12Z",
+  "M4 8L2.5 11.5L1 8L2.5 4.50002L4 8Z",
+  "M12 8.00002L13.5 4.50002L15 8.00001L13.5 11.5L12 8.00002Z",
+];
+
 /**
- * Onyx-branded loading indicator.
+ * Onyx-branded loading mark.
  *
  * Renders the Onyx mark rotating a full turn while crossfading between the
  * octagon outline and the diamond logo (2s loop), per the Onyx UI Library
- * design. Both layers use `currentColor`, so the loader adapts to the
+ * design. Both layers use `currentColor`, so the mark adapts to the
  * surrounding theme via `colors.css`.
+ *
+ * This is just the mark — for a full-page loading state with a "Loading …"
+ * label, use `PageLoader`.
  */
-export function OnyxLoader({
-  size = 64,
-  text = "Loading …",
-  className,
-}: OnyxLoaderProps) {
+export function OnyxLoader({ size = 64, className }: OnyxLoaderProps) {
   return (
     <div
       role="status"
-      aria-label={text ?? "Loading"}
-      className={cn(
-        "flex w-full flex-col items-center justify-center gap-3 p-5 my-auto text-text-03",
-        className
-      )}
+      aria-label="Loading"
+      className={cn("relative shrink-0 text-border-02", className)}
+      style={{ width: size, height: size }}
     >
-      <div className="relative shrink-0" style={{ width: size, height: size }}>
-        <div className="onyx-loader__rotator">
-          <SvgOnyxOctagon
-            size={size}
-            className="onyx-loader__layer onyx-loader__outline"
+      <div className="onyx-loader__rotator">
+        <svg
+          width={size}
+          height={size}
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          xmlns="http://www.w3.org/2000/svg"
+          className="onyx-loader__layer onyx-loader__outline"
+        >
+          <path
+            d={OUTLINE_PATH}
+            strokeWidth={STROKE_WIDTH}
+            strokeLinecap="round"
+            strokeLinejoin="round"
           />
-          <SvgOnyxLogo
-            size={size}
-            className="onyx-loader__layer onyx-loader__mark"
-          />
-        </div>
+        </svg>
+        <svg
+          width={size}
+          height={size}
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          xmlns="http://www.w3.org/2000/svg"
+          className="onyx-loader__layer onyx-loader__mark"
+        >
+          {MARK_PATHS.map((d) => (
+            <path
+              key={d}
+              d={d}
+              strokeWidth={STROKE_WIDTH}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          ))}
+        </svg>
       </div>
-      {text !== null && (
-        <Text font="main-ui-muted" color="text-03">
-          {text}
-        </Text>
-      )}
     </div>
   );
 }

--- a/web/src/refresh-components/OnyxLoader.tsx
+++ b/web/src/refresh-components/OnyxLoader.tsx
@@ -1,11 +1,9 @@
 import React from "react";
-import { cn } from "@opal/utils";
 import "./onyx-loader.css";
 
 interface OnyxLoaderProps {
   /** Size of the animated mark, in pixels. Default: 64 (matches the design). */
   size?: number;
-  className?: string;
 }
 
 // Onyx mark geometry (16-unit viewBox), matching the @opal/icons `onyx-octagon`
@@ -35,12 +33,12 @@ const MARK_PATHS = [
  * This is just the mark — for a full-page loading state with a "Loading …"
  * label, use `PageLoader`.
  */
-export function OnyxLoader({ size = 64, className }: OnyxLoaderProps) {
+export function OnyxLoader({ size = 64 }: OnyxLoaderProps) {
   return (
     <div
       role="status"
       aria-label="Loading"
-      className={cn("relative shrink-0 text-border-02", className)}
+      className="relative shrink-0 text-border-02"
       style={{ width: size, height: size }}
     >
       <div className="onyx-loader__rotator">

--- a/web/src/refresh-components/OnyxLoader.tsx
+++ b/web/src/refresh-components/OnyxLoader.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { cn } from "@opal/utils";
+import { Text } from "@opal/components";
+import SvgOnyxOctagon from "@opal/icons/onyx-octagon";
+import SvgOnyxLogo from "@opal/icons/onyx-logo";
+import "./onyx-loader.css";
+
+interface OnyxLoaderProps {
+  /** Size of the animated mark, in pixels. Default: 64 (matches the design). */
+  size?: number;
+  /**
+   * Label rendered below the mark. Defaults to "Loading …".
+   * Pass `null` to render the mark on its own.
+   */
+  text?: string | null;
+  className?: string;
+}
+
+/**
+ * Onyx-branded loading indicator.
+ *
+ * Renders the Onyx mark rotating a full turn while crossfading between the
+ * octagon outline and the diamond logo (2s loop), per the Onyx UI Library
+ * design. Both layers use `currentColor`, so the loader adapts to the
+ * surrounding theme via `colors.css`.
+ */
+export function OnyxLoader({
+  size = 64,
+  text = "Loading …",
+  className,
+}: OnyxLoaderProps) {
+  return (
+    <div
+      role="status"
+      aria-label={text ?? "Loading"}
+      className={cn(
+        "flex w-full flex-col items-center justify-center gap-3 p-5 my-auto text-text-03",
+        className
+      )}
+    >
+      <div className="relative shrink-0" style={{ width: size, height: size }}>
+        <div className="onyx-loader__rotator">
+          <SvgOnyxOctagon
+            size={size}
+            className="onyx-loader__layer onyx-loader__outline"
+          />
+          <SvgOnyxLogo
+            size={size}
+            className="onyx-loader__layer onyx-loader__mark"
+          />
+        </div>
+      </div>
+      {text !== null && (
+        <Text font="main-ui-muted" color="text-03">
+          {text}
+        </Text>
+      )}
+    </div>
+  );
+}
+
+export default OnyxLoader;

--- a/web/src/refresh-components/PageLoader.tsx
+++ b/web/src/refresh-components/PageLoader.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { cn } from "@opal/utils";
+import { Text } from "@opal/components";
+import { OnyxLoader } from "@/refresh-components/OnyxLoader";
+
+interface PageLoaderProps {
+  /** Label shown beneath the mark. Default: "Loading …". */
+  text?: string;
+  className?: string;
+}
+
+/**
+ * Full-page loading state: the animated Onyx mark with a "Loading …" label,
+ * centered within the available space. Use this for page/route-level loading
+ * (e.g. while a page's data is being fetched). For an inline or section-level
+ * loader without a label, use `OnyxLoader` directly.
+ */
+export function PageLoader({ text = "Loading …", className }: PageLoaderProps) {
+  return (
+    <div
+      className={cn(
+        "flex h-full min-h-[60vh] w-full flex-col items-center justify-center gap-3 p-5",
+        className
+      )}
+    >
+      <OnyxLoader />
+      <Text font="main-ui-muted" color="text-03">
+        {text}
+      </Text>
+    </div>
+  );
+}
+
+export default PageLoader;

--- a/web/src/refresh-components/PageLoader.tsx
+++ b/web/src/refresh-components/PageLoader.tsx
@@ -1,12 +1,10 @@
 import React from "react";
-import { cn } from "@opal/utils";
 import { Text } from "@opal/components";
 import { OnyxLoader } from "@/refresh-components/OnyxLoader";
 
 interface PageLoaderProps {
   /** Label shown beneath the mark. Default: "Loading …". */
   text?: string;
-  className?: string;
 }
 
 /**
@@ -15,14 +13,9 @@ interface PageLoaderProps {
  * (e.g. while a page's data is being fetched). For an inline or section-level
  * loader without a label, use `OnyxLoader` directly.
  */
-export function PageLoader({ text = "Loading …", className }: PageLoaderProps) {
+export function PageLoader({ text = "Loading …" }: PageLoaderProps) {
   return (
-    <div
-      className={cn(
-        "flex h-full min-h-[60vh] w-full flex-col items-center justify-center gap-3 p-5",
-        className
-      )}
-    >
+    <div className="flex h-full min-h-[60vh] w-full flex-col items-center justify-center gap-3 p-5">
       <OnyxLoader />
       <Text font="main-ui-muted" color="text-03">
         {text}

--- a/web/src/refresh-components/onyx-loader.css
+++ b/web/src/refresh-components/onyx-loader.css
@@ -1,0 +1,87 @@
+/**
+ * Onyx loading indicator animation.
+ *
+ * The Onyx mark rotates a full turn while crossfading between the octagon
+ * outline and the diamond logo, then briefly holds before looping. Timing
+ * mirrors the Onyx UI Library design:
+ *   0ms  – 900ms : rotate 0deg  -> 180deg (ease in),  outline -> logo
+ *   900ms – 1800ms: rotate 180deg -> 360deg (ease out), logo -> outline
+ *   1800ms – 2000ms: hold at 360deg (== 0deg) before the loop resets
+ */
+
+.onyx-loader__rotator {
+  position: absolute;
+  inset: 0;
+  animation: onyx-loader-spin 2000ms infinite;
+}
+
+.onyx-loader__layer {
+  position: absolute;
+  inset: 0;
+}
+
+.onyx-loader__outline {
+  animation: onyx-loader-outline 2000ms infinite;
+}
+
+.onyx-loader__mark {
+  animation: onyx-loader-mark 2000ms infinite;
+}
+
+@keyframes onyx-loader-spin {
+  0% {
+    transform: rotate(0deg);
+    animation-timing-function: ease-in;
+  }
+  45% {
+    transform: rotate(180deg);
+    animation-timing-function: ease-out;
+  }
+  90%,
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes onyx-loader-outline {
+  0% {
+    opacity: 1;
+    animation-timing-function: ease-in;
+  }
+  45% {
+    opacity: 0;
+    animation-timing-function: ease-out;
+  }
+  90%,
+  100% {
+    opacity: 1;
+  }
+}
+
+@keyframes onyx-loader-mark {
+  0% {
+    opacity: 0;
+    animation-timing-function: ease-in;
+  }
+  45% {
+    opacity: 1;
+    animation-timing-function: ease-out;
+  }
+  90%,
+  100% {
+    opacity: 0;
+  }
+}
+
+/* Respect reduced-motion: hold the static octagon outline, no rotation. */
+@media (prefers-reduced-motion: reduce) {
+  .onyx-loader__rotator,
+  .onyx-loader__outline,
+  .onyx-loader__mark {
+    animation: none;
+  }
+
+  .onyx-loader__mark {
+    opacity: 0;
+  }
+}

--- a/web/src/refresh-pages/admin/AgentsPage/AgentsTable.tsx
+++ b/web/src/refresh-pages/admin/AgentsPage/AgentsTable.tsx
@@ -5,6 +5,7 @@ import { Table, createTableColumns } from "@opal/components";
 import { Content, IllustrationContent } from "@opal/layouts";
 import SvgNoResult from "@opal/illustrations/no-result";
 import Text from "@/refresh-components/texts/Text";
+import { PageLoader } from "@/refresh-components/PageLoader";
 import { InputTypeIn } from "@opal/components";
 import type { MinimalUserSnapshot } from "@/lib/types";
 import AgentAvatar from "@/refresh-components/avatars/AgentAvatar";
@@ -13,7 +14,7 @@ import { useAdminAgents } from "@/lib/agents/hooks";
 import { toast } from "@/hooks/useToast";
 import AgentRowActions from "@/refresh-pages/admin/AgentsPage/AgentRowActions";
 import { updateAgentDisplayPriorities } from "@/lib/agents/svc";
-import { SvgUser, SvgSimpleLoader } from "@opal/icons";
+import { SvgUser } from "@opal/icons";
 import { DEFAULT_PAGE_SIZE } from "@/lib/constants";
 import { Section } from "@/layouts/general-layouts";
 import { useAgentsFilters } from "@/sections/agents/AgentsFilters";
@@ -139,11 +140,7 @@ export default function AgentsTable() {
   }
 
   if (isLoading) {
-    return (
-      <div className="flex justify-center py-12">
-        <SvgSimpleLoader className="h-6 w-6" />
-      </div>
-    );
+    return <PageLoader />;
   }
 
   return (

--- a/web/src/refresh-pages/admin/IndexSettingsPage/index.tsx
+++ b/web/src/refresh-pages/admin/IndexSettingsPage/index.tsx
@@ -5,7 +5,7 @@ import { Formik } from "formik";
 import { markdown } from "@opal/utils";
 import { useRouter } from "next/navigation";
 import { mutate } from "swr";
-import { ThreeDotsLoader } from "@/components/Loading";
+import { OnyxLoader } from "@/refresh-components/OnyxLoader";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import { Content, IllustrationContent } from "@opal/layouts";
 import SvgNoResult from "@opal/illustrations/no-result";
@@ -791,7 +791,7 @@ export default function IndexSettingsPage() {
       <SettingsLayouts.Root>
         <SettingsLayouts.Header icon={route.icon} title={route.title} divider />
         <SettingsLayouts.Body>
-          <ThreeDotsLoader />
+          <OnyxLoader />
         </SettingsLayouts.Body>
       </SettingsLayouts.Root>
     );

--- a/web/src/refresh-pages/admin/IndexSettingsPage/index.tsx
+++ b/web/src/refresh-pages/admin/IndexSettingsPage/index.tsx
@@ -5,7 +5,7 @@ import { Formik } from "formik";
 import { markdown } from "@opal/utils";
 import { useRouter } from "next/navigation";
 import { mutate } from "swr";
-import { OnyxLoader } from "@/refresh-components/OnyxLoader";
+import { PageLoader } from "@/refresh-components/PageLoader";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import { Content, IllustrationContent } from "@opal/layouts";
 import SvgNoResult from "@opal/illustrations/no-result";
@@ -791,7 +791,7 @@ export default function IndexSettingsPage() {
       <SettingsLayouts.Root>
         <SettingsLayouts.Header icon={route.icon} title={route.title} divider />
         <SettingsLayouts.Body>
-          <OnyxLoader />
+          <PageLoader />
         </SettingsLayouts.Body>
       </SettingsLayouts.Root>
     );

--- a/web/src/refresh-pages/admin/LanguageModelsPage.tsx
+++ b/web/src/refresh-pages/admin/LanguageModelsPage.tsx
@@ -4,7 +4,7 @@ import { useState, useMemo } from "react";
 import { useSWRConfig } from "swr";
 import { toast } from "@/hooks/useToast";
 import { useAdminLLMProviders } from "@/lib/languageModels/hooks";
-import { OnyxLoader } from "@/refresh-components/OnyxLoader";
+import { PageLoader } from "@/refresh-components/PageLoader";
 import { Content, ContentAction, InputHorizontal } from "@opal/layouts";
 import {
   Button,
@@ -319,7 +319,7 @@ export default function LanguageModelsPage() {
   }, [defaultText, existingLlmProviders]);
 
   if (!existingLlmProviders) {
-    return <OnyxLoader />;
+    return <PageLoader />;
   }
 
   const hasProviders = existingLlmProviders.length > 0;

--- a/web/src/refresh-pages/admin/LanguageModelsPage.tsx
+++ b/web/src/refresh-pages/admin/LanguageModelsPage.tsx
@@ -4,7 +4,7 @@ import { useState, useMemo } from "react";
 import { useSWRConfig } from "swr";
 import { toast } from "@/hooks/useToast";
 import { useAdminLLMProviders } from "@/lib/languageModels/hooks";
-import { ThreeDotsLoader } from "@/components/Loading";
+import { OnyxLoader } from "@/refresh-components/OnyxLoader";
 import { Content, ContentAction, InputHorizontal } from "@opal/layouts";
 import {
   Button,
@@ -319,7 +319,7 @@ export default function LanguageModelsPage() {
   }, [defaultText, existingLlmProviders]);
 
   if (!existingLlmProviders) {
-    return <ThreeDotsLoader />;
+    return <OnyxLoader />;
   }
 
   const hasProviders = existingLlmProviders.length > 0;

--- a/web/src/refresh-pages/admin/VoicePage/index.tsx
+++ b/web/src/refresh-pages/admin/VoicePage/index.tsx
@@ -8,7 +8,7 @@ import {
   activateVoiceProvider,
   deactivateVoiceProvider,
 } from "@/lib/voice/svc";
-import { ThreeDotsLoader } from "@/components/Loading";
+import { OnyxLoader } from "@/refresh-components/OnyxLoader";
 import { Content } from "@opal/layouts";
 import { MessageCard, Text } from "@opal/components";
 import { Section } from "@/layouts/general-layouts";
@@ -203,7 +203,7 @@ export default function VoicePage() {
           divider
         />
         <SettingsLayouts.Body>
-          <ThreeDotsLoader />
+          <OnyxLoader />
         </SettingsLayouts.Body>
       </SettingsLayouts.Root>
     );

--- a/web/src/refresh-pages/admin/VoicePage/index.tsx
+++ b/web/src/refresh-pages/admin/VoicePage/index.tsx
@@ -8,7 +8,7 @@ import {
   activateVoiceProvider,
   deactivateVoiceProvider,
 } from "@/lib/voice/svc";
-import { OnyxLoader } from "@/refresh-components/OnyxLoader";
+import { PageLoader } from "@/refresh-components/PageLoader";
 import { Content } from "@opal/layouts";
 import { MessageCard, Text } from "@opal/components";
 import { Section } from "@/layouts/general-layouts";
@@ -203,7 +203,7 @@ export default function VoicePage() {
           divider
         />
         <SettingsLayouts.Body>
-          <OnyxLoader />
+          <PageLoader />
         </SettingsLayouts.Body>
       </SettingsLayouts.Root>
     );

--- a/web/src/refresh-pages/admin/WebSearchPage/index.tsx
+++ b/web/src/refresh-pages/admin/WebSearchPage/index.tsx
@@ -5,7 +5,7 @@ import { SettingsLayouts } from "@opal/layouts";
 import { Content } from "@opal/layouts";
 import ProviderCard from "@/sections/admin/ProviderCard";
 import { FetchError } from "@/lib/fetcher";
-import { ThreeDotsLoader } from "@/components/Loading";
+import { OnyxLoader } from "@/refresh-components/OnyxLoader";
 import { useWebSearchProviders } from "@/lib/webSearch/hooks";
 import { useCreateModal } from "@/refresh-components/contexts/ModalContext";
 import { toast } from "@/hooks/useToast";
@@ -262,7 +262,7 @@ export default function WebSearchPage() {
           divider
         />
         <SettingsLayouts.Body>
-          <ThreeDotsLoader />
+          <OnyxLoader />
         </SettingsLayouts.Body>
       </SettingsLayouts.Root>
     );

--- a/web/src/refresh-pages/admin/WebSearchPage/index.tsx
+++ b/web/src/refresh-pages/admin/WebSearchPage/index.tsx
@@ -5,7 +5,7 @@ import { SettingsLayouts } from "@opal/layouts";
 import { Content } from "@opal/layouts";
 import ProviderCard from "@/sections/admin/ProviderCard";
 import { FetchError } from "@/lib/fetcher";
-import { OnyxLoader } from "@/refresh-components/OnyxLoader";
+import { PageLoader } from "@/refresh-components/PageLoader";
 import { useWebSearchProviders } from "@/lib/webSearch/hooks";
 import { useCreateModal } from "@/refresh-components/contexts/ModalContext";
 import { toast } from "@/hooks/useToast";
@@ -262,7 +262,7 @@ export default function WebSearchPage() {
           divider
         />
         <SettingsLayouts.Body>
-          <OnyxLoader />
+          <PageLoader />
         </SettingsLayouts.Body>
       </SettingsLayouts.Root>
     );

--- a/web/tests/e2e/admin/discord-bot/guilds-list.spec.ts
+++ b/web/tests/e2e/admin/discord-bot/guilds-list.spec.ts
@@ -275,10 +275,10 @@ test.describe("Guilds List Page", () => {
 
     await adminPage.goto("/admin/discord-bot");
 
-    // Should show loading indicator (ThreeDotsLoader)
-    // The loader should appear while data is being fetched
-    // ThreeDotsLoader uses react-loader-spinner's ThreeDots with ariaLabel="grid-loading"
-    const loader = adminPage.locator('[aria-label="grid-loading"]');
+    // Should show loading indicator (OnyxLoader)
+    // The loader should appear while data is being fetched.
+    // OnyxLoader exposes role="status" on its wrapper.
+    const loader = adminPage.getByRole("status");
     // Give it a moment to appear
     await expect(loader).toBeVisible({ timeout: 5000 });
 


### PR DESCRIPTION
## What

Replaces the legacy blue three-dots loading animation (`react-loader-spinner`'s `ThreeDots`) on the admin pages with a branded Onyx loading experience, split by context:

- **Page / route-level loads** → new **`PageLoader`**: the animated Onyx mark + a `Loading …` label, centered in the content area.
- **Inline / section loaders** (charts, table cells, cards, inline panels) → the existing **`SvgSimpleLoader`** spinner — the established pattern for non-page loading across the app.

The page-level mark rotates a full turn while crossfading between the **octagon outline** and the **diamond logo**, then briefly holds before looping, per the [Onyx UI Library design](https://www.figma.com/design/Fms9uHkizpBuDEfsB8ujCc/Onyx-UI-Library?node-id=9357-115278&m=dev):

| | Layer | Rotation | Timing |
|---|---|---|---|
| Frame 1 | octagon outline | 0° | → ease-in, 900ms |
| Frame 2 | diamond logo | 180° | → ease-out, 900ms |
| Frame 3 | octagon outline (== frame 1) | 360° | hold 200ms → reset |

Full cycle **2000ms** (900 ease-in + 900 ease-out + 200ms pause).


https://github.com/user-attachments/assets/bf239ed8-d6da-41f0-94ea-3c3a9e0d1427



## How

**New components** (`web/src/refresh-components/`):
- **`OnyxLoader`** (+ `onyx-loader.css`) — the animated mark only. The octagon/logo geometry is inlined (rather than reusing the fixed-weight `@opal/icons` components) so the stroke can be tuned to ~2.5px (`Weight/Icon/Headline`). Colored with `border-02` (`#cccccc`, **theme-aware** via `colors.css` — no hardcoded hex, no `dark:`). Respects `prefers-reduced-motion` (falls back to a static octagon). Prop: `size`.
- **`PageLoader`** — composes `OnyxLoader` + the `Loading …` label (`main-ui-muted` / `text-03`), vertically centered (`h-full` + a `min-h` fallback for auto-height `SettingsLayouts` bodies). Exposes `role="status"`. Prop: `text`.

**Wiring** — replaced every `ThreeDotsLoader` usage (all were admin-scoped):
- **17 page-level** admin / ee-admin / refresh-pages-admin sites → `PageLoader`.
- **11 inline / section** sites → `SvgSimpleLoader` at `h-6 w-6`.

**Cleanup**
- Removed the now-unused `ThreeDotsLoader` and dropped `react-loader-spinner` from `package.json` / `bun.lock`.
- Updated the discord-bot `guilds-list` e2e loading-state test to locate the loader by `role="status"` (was keyed off the old `grid-loading` aria-label).
- Stopped tracking `web/.claude/settings.local.json` (the root `.gitignore` rule is root-anchored and missed the nested path).

## Testing

- `tsc --noEmit` ✅ and `oxlint` ✅ pass.
- Color (`#cccccc`), stroke weight (~2.5px), and vertical centering verified against the Figma frames in both light and dark, using faithful reproductions of the real layout chains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the legacy three-dots loader with a branded Onyx loading experience across admin. Page-level screens now use `PageLoader` (animated Onyx mark + label) and inline/section states use `SvgSimpleLoader`; removed `react-loader-spinner`.

- **New Features**
  - Added `OnyxLoader` (2s rotating/crossfading Onyx mark). Prop: `size`. Theme-aware via `currentColor`; respects `prefers-reduced-motion`. Exposes `role="status"`.
  - Added `PageLoader` (centers mark with “Loading …”). Prop: `text`.

- **Refactors**
  - Replaced admin page-level loaders with `PageLoader` and inline/section loaders with `SvgSimpleLoader` (`@opal/icons/simple-loader`) at `h-6 w-6` (e.g., Agents table now uses `PageLoader`; analytics charts use `SvgSimpleLoader`).
  - Removed `ThreeDotsLoader`; dropped `react-loader-spinner` from `package.json` and cleaned `bun.lock`. Updated the discord-bot e2e to locate the loader via `role="status"`.
  - Inlined mark geometry and tuned stroke (~2.5px) and color (`text-border-02`) to match design; removed unused `className` prop from both loaders.

<sup>Written for commit 591d7c2a43ec94e05cdb98d505a19284a386faaf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

