### PR TITLE
feat(craft): Persist opencode session for docker compose path

### DIFF
--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -887,12 +887,20 @@ class DockerSandboxManager(SandboxManager):
             # starting the container, so entrypoint.sh's opencode-serve opens
             # the restored database instead of racing an extraction on top of a
             # live process. Mirrors the K8s init-sidecar restore handshake.
-            self._maybe_restore_opencode_history(container, sandbox_id, tenant_id)
+            #
+            # On any failure here, remove the half-provisioned container so it
+            # doesn't strand in 'created' state -- a retry's
+            # _reuse_existing_container would otherwise just start it and skip
+            # the restore, booting opencode against an empty data home while a
+            # good snapshot still sits in the FileStore. Restore failures are
+            # fatal (re-raised), matching the K8s fail-closed restore.
             try:
+                self._maybe_restore_opencode_history(container, sandbox_id, tenant_id)
                 container.start()
-            except APIError as e:
+            except Exception as e:
+                self._remove_incomplete_container(container)
                 raise RuntimeError(
-                    f"Failed to start sandbox container {container.name}: {e}"
+                    f"Failed to provision sandbox container {container.name}: {e}"
                 ) from e
 
         if not self._wait_for_container_running(container):
@@ -916,7 +924,19 @@ class DockerSandboxManager(SandboxManager):
         )
 
     def _reuse_existing_container(self, sandbox_id: UUID) -> Container | None:
-        """Returns a running/restarted container if one exists, else None."""
+        """Returns a reusable running/stopped container, else None.
+
+        A ``created`` container is never reusable: the only code that creates
+        without starting is ``provision``'s fresh-container path, so ``created``
+        always means a prior provision died mid-flight, before the opencode
+        history restore + start. Just starting it would skip the restore and
+        boot opencode against an empty data home while a good snapshot still
+        sits in the FileStore (which the next idle reap would then overwrite).
+        Remove it so the caller re-creates and restores cleanly; the per-sandbox
+        volume is left intact, so session workspaces survive -- only the empty
+        writable layer is dropped. This also covers a hard kill mid-provision,
+        which the provision-side cleanup can't.
+        """
         existing = self._get_container(sandbox_id)
         if existing is None:
             return None
@@ -925,11 +945,31 @@ class DockerSandboxManager(SandboxManager):
         if status == "running":
             logger.info("Reusing existing running sandbox %s.", sandbox_id)
             return existing
-        if status in ("exited", "created"):
+        if status == "exited":
             logger.info("Starting existing stopped sandbox %s.", existing.name)
             existing.start()
             return existing
+        if status == "created":
+            logger.warning(
+                "Sandbox %s container is in 'created' state (incomplete prior "
+                "provision); removing so it can be re-created and restored.",
+                sandbox_id,
+            )
+            self._remove_incomplete_container(existing)
+            return None
         return None
+
+    @staticmethod
+    def _remove_incomplete_container(container: Container) -> None:
+        """Best-effort force-remove of a container we failed to fully provision."""
+        try:
+            container.remove(force=True)
+        except (APIError, NotFound) as e:
+            logger.warning(
+                "Failed to remove incomplete sandbox container %s: %s",
+                container.name,
+                e,
+            )
 
     def _create_sandbox_container(
         self,

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -184,9 +184,9 @@ _PROXY_CA_BUNDLE_FILE = f"{_PROXY_CA_BUNDLE_DIR}/ca-bundle.crt"
 # it would no-op (no HTTP(S)_PROXY to re-tag).
 _OPENCODE_SESSION_TAG_PLUGIN_PATH = "/workspace/opencode-plugins/session-proxy-tag.ts"
 
-# In-container opencode-history archive builder: reuses the sandbox_daemon helper
-# (sqlite-safe backup + symlink guards) and prints the temp archive path, or
-# nothing when there's no history. Exec it with OPENCODE_DATA_HOME set.
+# In-container opencode-history archive builder: reuses the sandbox_daemon
+# helper (sqlite-safe backup + symlink guards) and prints the temp archive path,
+# or nothing when there's no history. Exec it with OPENCODE_DATA_HOME set.
 _OPENCODE_HISTORY_CREATE_SCRIPT = (
     "import sys; "
     "from sandbox_daemon.opencode_history import create_opencode_history_archive_file; "
@@ -878,7 +878,8 @@ class DockerSandboxManager(SandboxManager):
         if created_fresh:
             # Restore history into the empty writable layer before starting, so
             # opencode-serve opens the restored DB instead of creating an empty
-            # one. On failure, remove the container so a retry re-creates cleanly.
+            # one. On failure, remove the container so a retry re-creates
+            # cleanly.
             try:
                 self._maybe_restore_opencode_history(container, sandbox_id, tenant_id)
                 container.start()
@@ -909,7 +910,7 @@ class DockerSandboxManager(SandboxManager):
         )
 
     def _reuse_existing_container(self, sandbox_id: UUID) -> Container | None:
-        """Return a reusable running/exited container, else None.
+        """Returns a reusable running/exited container, else None.
 
         A ``created`` container means a prior provision died before start;
         starting it would skip the opencode-history restore, so remove it and
@@ -961,7 +962,9 @@ class DockerSandboxManager(SandboxManager):
         opencode_password: str,
         opencode_config_json: str,
     ) -> tuple[Container, bool]:
-        """Create (not start) the container; returns ``(container, created_fresh)``.
+        """
+        Creates (not starts) the container; returns ``(container,
+        created_fresh)``.
 
         ``created_fresh`` is False only when a concurrent provision already
         created it (409 conflict); the caller then skips restore/start and lets
@@ -1292,7 +1295,7 @@ echo "Session cleanup complete"
         tenant_id: str,
         timeout_seconds: float = 300.0,  # noqa: ARG002 - exec uses the docker client timeout
     ) -> bool:
-        """Capture sandbox-global opencode history to the FileStore.
+        """Captures sandbox-global opencode history to the FileStore.
 
         Returns False when opencode has written no data yet, leaving any
         existing durable archive untouched.
@@ -1365,8 +1368,10 @@ echo "Session cleanup complete"
         sandbox_id: UUID,
         tenant_id: str,
     ) -> None:
-        """Restore durable opencode history into a freshly-created, not-yet-started
-        container, before opencode-serve opens its DB. No-op when no snapshot exists.
+        """
+        Restores durable opencode history into a freshly-created,
+        not-yet-started container, before opencode-serve opens its DB. No-op
+        when no snapshot exists.
 
         Writing the stopped container's writable layer avoids racing a live
         opencode process over the DB file.

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -148,14 +148,11 @@ LABEL_USER_ID = "onyx.app/user-id"
 # Path conventions inside the sandbox container — must match the K8s image.
 WORKSPACE_ROOT = "/workspace"
 SESSIONS_ROOT = f"{WORKSPACE_ROOT}/sessions"
-# Opencode's XDG data home inside the container. The container leaves
-# OPENCODE_DATA_HOME unset, so this matches ``entrypoint.sh``'s default. Unlike
-# K8s (shared ``opencode-data`` emptyDir), only ``/workspace/sessions`` is a
-# persistent volume here, so this lives in the writable layer: it survives a
-# container restart but not a re-creation. Durability across re-provision comes
-# from the FileStore history snapshot. Its basename must equal the daemon's
-# archive root (``.opencode-data``) so ``put_archive`` at WORKSPACE_ROOT lands
-# the restored tree here -- see ``_maybe_restore_opencode_history``.
+# Opencode's data home (its XDG_DATA_HOME); matches entrypoint.sh's default. It
+# lives in the container writable layer, not the per-sandbox volume, so it is
+# durable only via the FileStore history snapshot. Its basename must equal the
+# daemon archive's root dir, so put_archive at WORKSPACE_ROOT lands the restored
+# tree here (see _maybe_restore_opencode_history).
 OPENCODE_DATA_DIR = f"{WORKSPACE_ROOT}/.opencode-data"
 TEMPLATES_OUTPUTS_PATH = f"{WORKSPACE_ROOT}/templates/outputs"
 MANAGED_SKILLS_PATH = f"{WORKSPACE_ROOT}/managed/skills"
@@ -187,12 +184,9 @@ _PROXY_CA_BUNDLE_FILE = f"{_PROXY_CA_BUNDLE_DIR}/ca-bundle.crt"
 # it would no-op (no HTTP(S)_PROXY to re-tag).
 _OPENCODE_SESSION_TAG_PLUGIN_PATH = "/workspace/opencode-plugins/session-proxy-tag.ts"
 
-# Builds the opencode-history archive in-container via the shared sandbox_daemon
-# helper (sqlite-consistent backup + symlink/traversal guards), reusing the same
-# code path as the K8s sidecar. Prints the archive's temp path to stdout, or
-# nothing when there is no history to capture. ``sandbox_daemon`` is importable
-# via the image's PYTHONPATH=/workspace; OPENCODE_DATA_HOME (set on the exec)
-# points the helper at the container's writable-layer data home.
+# In-container opencode-history archive builder: reuses the sandbox_daemon helper
+# (sqlite-safe backup + symlink guards) and prints the temp archive path, or
+# nothing when there's no history. Exec it with OPENCODE_DATA_HOME set.
 _OPENCODE_HISTORY_CREATE_SCRIPT = (
     "import sys; "
     "from sandbox_daemon.opencode_history import create_opencode_history_archive_file; "
@@ -882,18 +876,9 @@ class DockerSandboxManager(SandboxManager):
             )
 
         if created_fresh:
-            # A fresh container's opencode-data lives in the empty writable
-            # layer. Repopulate it from the durable history snapshot *before*
-            # starting the container, so entrypoint.sh's opencode-serve opens
-            # the restored database instead of racing an extraction on top of a
-            # live process. Mirrors the K8s init-sidecar restore handshake.
-            #
-            # On any failure here, remove the half-provisioned container so it
-            # doesn't strand in 'created' state -- a retry's
-            # _reuse_existing_container would otherwise just start it and skip
-            # the restore, booting opencode against an empty data home while a
-            # good snapshot still sits in the FileStore. Restore failures are
-            # fatal (re-raised), matching the K8s fail-closed restore.
+            # Restore history into the empty writable layer before starting, so
+            # opencode-serve opens the restored DB instead of creating an empty
+            # one. On failure, remove the container so a retry re-creates cleanly.
             try:
                 self._maybe_restore_opencode_history(container, sandbox_id, tenant_id)
                 container.start()
@@ -924,18 +909,12 @@ class DockerSandboxManager(SandboxManager):
         )
 
     def _reuse_existing_container(self, sandbox_id: UUID) -> Container | None:
-        """Returns a reusable running/stopped container, else None.
+        """Return a reusable running/exited container, else None.
 
-        A ``created`` container is never reusable: the only code that creates
-        without starting is ``provision``'s fresh-container path, so ``created``
-        always means a prior provision died mid-flight, before the opencode
-        history restore + start. Just starting it would skip the restore and
-        boot opencode against an empty data home while a good snapshot still
-        sits in the FileStore (which the next idle reap would then overwrite).
-        Remove it so the caller re-creates and restores cleanly; the per-sandbox
-        volume is left intact, so session workspaces survive -- only the empty
-        writable layer is dropped. This also covers a hard kill mid-provision,
-        which the provision-side cleanup can't.
+        A ``created`` container means a prior provision died before start;
+        starting it would skip the opencode-history restore, so remove it and
+        let the caller re-create. The per-sandbox volume survives, so session
+        workspaces are kept.
         """
         existing = self._get_container(sandbox_id)
         if existing is None:
@@ -982,16 +961,11 @@ class DockerSandboxManager(SandboxManager):
         opencode_password: str,
         opencode_config_json: str,
     ) -> tuple[Container, bool]:
-        """Create (but do not start) the sandbox container.
+        """Create (not start) the container; returns ``(container, created_fresh)``.
 
-        Returns ``(container, created_fresh)``. ``created_fresh`` is True when
-        this call created the container -- the caller restores opencode history
-        into the still-stopped writable layer and starts it. On a concurrent
-        provision (409 conflict) we reuse the racing provisioner's container and
-        return False, leaving its start/restore to that provisioner.
-
-        Applies our security/network/labels invariants via
-        ``build_container_create_kwargs``.
+        ``created_fresh`` is False only when a concurrent provision already
+        created it (409 conflict); the caller then skips restore/start and lets
+        that provisioner finish.
         """
         # Proxy posture is gated on SANDBOX_PROXY_HOST; threaded through
         # build_container_create_kwargs to layer on the legacy posture without
@@ -1014,9 +988,8 @@ class DockerSandboxManager(SandboxManager):
             sandbox_proxy_host=proxy_host,
             proxy_ca_volume_name=(SANDBOX_PROXY_CA_VOLUME_NAME if proxy_host else None),
         )
-        # ``create`` rather than ``run`` so we can put_archive the opencode
-        # history into the writable layer before the entrypoint launches.
-        # ``detach`` is a run-only flag; create starts nothing.
+        # create (not run) so the caller can put_archive history before start.
+        # detach is run-only.
         run_kwargs = dict(create_kwargs)
         run_kwargs.pop("detach", None)
         try:
@@ -1319,12 +1292,10 @@ echo "Session cleanup complete"
         tenant_id: str,
         timeout_seconds: float = 300.0,  # noqa: ARG002 - exec uses the docker client timeout
     ) -> bool:
-        """Capture sandbox-global opencode history (chat DB + sessions).
+        """Capture sandbox-global opencode history to the FileStore.
 
-        Builds a sqlite-consistent archive in-container via the shared
-        sandbox_daemon helper, then streams it into the FileStore. Returns
-        False when opencode has not written any data yet (leaving any existing
-        durable archive untouched).
+        Returns False when opencode has written no data yet, leaving any
+        existing durable archive untouched.
         """
         container = self._get_container(sandbox_id)
         if container is None:
@@ -1334,8 +1305,7 @@ echo "Session cleanup complete"
             )
             return False
 
-        # OPENCODE_DATA_HOME points the daemon helper at the Docker data home
-        # (the container leaves it unset, so the helper's default would miss it).
+        # Point the daemon helper at the Docker data home (unset in the container).
         history_env = {**SANDBOX_EXEC_ENV, "OPENCODE_DATA_HOME": OPENCODE_DATA_DIR}
         try:
             built = run_in_container(
@@ -1356,9 +1326,8 @@ echo "Session cleanup complete"
             stream = _stream_stdout_from_container_as_sandbox_user(
                 container, ["cat", archive_path]
             )
+            # _GeneratorReader gives the read(n) API persist_* needs (not a typing.IO).
             adapter = _GeneratorReader(stream)
-            # ``_GeneratorReader`` satisfies the structural ``read(n)`` API that
-            # ``SnapshotManager``/``FileStore`` use without subclassing IO[bytes].
             storage_path, size_bytes = (
                 self._snapshot_manager.persist_opencode_snapshot_from_stream(
                     stream=adapter,  # ty: ignore[invalid-argument-type]
@@ -1396,15 +1365,11 @@ echo "Session cleanup complete"
         sandbox_id: UUID,
         tenant_id: str,
     ) -> None:
-        """Extract any durable opencode history into a freshly-created (not yet
-        started) container before opencode-serve opens its database.
+        """Restore durable opencode history into a freshly-created, not-yet-started
+        container, before opencode-serve opens its DB. No-op when no snapshot exists.
 
-        Only ``/workspace/sessions`` is a persistent volume, so a fresh
-        container's opencode-data is empty. ``put_archive`` into the stopped
-        container writes the writable layer with no live opencode process racing
-        the DB file -- the Docker analogue of the K8s init-sidecar restore. The
-        archive's top-level member is the daemon's ``.opencode-data`` root, so
-        extracting at WORKSPACE_ROOT lands it at OPENCODE_DATA_DIR.
+        Writing the stopped container's writable layer avoids racing a live
+        opencode process over the DB file.
         """
         if not self._snapshot_manager.has_opencode_history_snapshot(
             tenant_id, str(sandbox_id)
@@ -1425,8 +1390,7 @@ echo "Session cleanup complete"
             return
 
         try:
-            # Docker untars (including gzip) at the destination path. put_archive
-            # works on a created-but-unstarted container's filesystem.
+            # put_archive untars (gzip ok) into the stopped container's writable layer.
             if not container.put_archive(WORKSPACE_ROOT, archive_bytes):
                 raise RuntimeError("docker put_archive reported failure")
         except (APIError, NotFound) as e:

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -148,6 +148,15 @@ LABEL_USER_ID = "onyx.app/user-id"
 # Path conventions inside the sandbox container — must match the K8s image.
 WORKSPACE_ROOT = "/workspace"
 SESSIONS_ROOT = f"{WORKSPACE_ROOT}/sessions"
+# Opencode's XDG data home inside the container. The container leaves
+# OPENCODE_DATA_HOME unset, so this matches ``entrypoint.sh``'s default. Unlike
+# K8s (shared ``opencode-data`` emptyDir), only ``/workspace/sessions`` is a
+# persistent volume here, so this lives in the writable layer: it survives a
+# container restart but not a re-creation. Durability across re-provision comes
+# from the FileStore history snapshot. Its basename must equal the daemon's
+# archive root (``.opencode-data``) so ``put_archive`` at WORKSPACE_ROOT lands
+# the restored tree here -- see ``_maybe_restore_opencode_history``.
+OPENCODE_DATA_DIR = f"{WORKSPACE_ROOT}/.opencode-data"
 TEMPLATES_OUTPUTS_PATH = f"{WORKSPACE_ROOT}/templates/outputs"
 MANAGED_SKILLS_PATH = f"{WORKSPACE_ROOT}/managed/skills"
 SANDBOX_EXEC_USER = "1000:1000"
@@ -177,6 +186,19 @@ _PROXY_CA_BUNDLE_FILE = f"{_PROXY_CA_BUNDLE_DIR}/ca-bundle.crt"
 # Registered in the opencode config only when the proxy is wired up; otherwise
 # it would no-op (no HTTP(S)_PROXY to re-tag).
 _OPENCODE_SESSION_TAG_PLUGIN_PATH = "/workspace/opencode-plugins/session-proxy-tag.ts"
+
+# Builds the opencode-history archive in-container via the shared sandbox_daemon
+# helper (sqlite-consistent backup + symlink/traversal guards), reusing the same
+# code path as the K8s sidecar. Prints the archive's temp path to stdout, or
+# nothing when there is no history to capture. ``sandbox_daemon`` is importable
+# via the image's PYTHONPATH=/workspace; OPENCODE_DATA_HOME (set on the exec)
+# points the helper at the container's writable-layer data home.
+_OPENCODE_HISTORY_CREATE_SCRIPT = (
+    "import sys; "
+    "from sandbox_daemon.opencode_history import create_opencode_history_archive_file; "
+    "p = create_opencode_history_archive_file(); "
+    "sys.stdout.write('' if p is None else str(p))"
+)
 
 
 def _run_in_container_as_sandbox_user(
@@ -672,6 +694,8 @@ class DockerSandboxManager(SandboxManager):
     _instance: "DockerSandboxManager | None" = None
     _lock = threading.Lock()
 
+    supports_opencode_history_persistence = True
+
     def __new__(cls) -> "DockerSandboxManager":
         if cls._instance is None:
             with cls._lock:
@@ -815,6 +839,7 @@ class DockerSandboxManager(SandboxManager):
         self._invalidate_serve_connection_info(sandbox_id)
 
         container = self._reuse_existing_container(sandbox_id)
+        created_fresh = False
         if container is None:
             # opencode-serve reads provider config from env at startup; must be
             # in create_kwargs before the container ever runs.
@@ -846,7 +871,7 @@ class DockerSandboxManager(SandboxManager):
             )
             self._ensure_sandbox_network()
             volume_name = self._ensure_sandbox_volume(sandbox_id, tenant_id)
-            container = self._create_sandbox_container(
+            container, created_fresh = self._create_sandbox_container(
                 sandbox_id=sandbox_id,
                 user_id=user_id,
                 tenant_id=tenant_id,
@@ -855,6 +880,20 @@ class DockerSandboxManager(SandboxManager):
                 opencode_password=opencode_password,
                 opencode_config_json=opencode_config_json,
             )
+
+        if created_fresh:
+            # A fresh container's opencode-data lives in the empty writable
+            # layer. Repopulate it from the durable history snapshot *before*
+            # starting the container, so entrypoint.sh's opencode-serve opens
+            # the restored database instead of racing an extraction on top of a
+            # live process. Mirrors the K8s init-sidecar restore handshake.
+            self._maybe_restore_opencode_history(container, sandbox_id, tenant_id)
+            try:
+                container.start()
+            except APIError as e:
+                raise RuntimeError(
+                    f"Failed to start sandbox container {container.name}: {e}"
+                ) from e
 
         if not self._wait_for_container_running(container):
             raise RuntimeError(
@@ -902,9 +941,17 @@ class DockerSandboxManager(SandboxManager):
         volume_name: str,
         opencode_password: str,
         opencode_config_json: str,
-    ) -> Container:
-        """
-        Runs docker create + start with our security/network/labels invariants.
+    ) -> tuple[Container, bool]:
+        """Create (but do not start) the sandbox container.
+
+        Returns ``(container, created_fresh)``. ``created_fresh`` is True when
+        this call created the container -- the caller restores opencode history
+        into the still-stopped writable layer and starts it. On a concurrent
+        provision (409 conflict) we reuse the racing provisioner's container and
+        return False, leaving its start/restore to that provisioner.
+
+        Applies our security/network/labels invariants via
+        ``build_container_create_kwargs``.
         """
         # Proxy posture is gated on SANDBOX_PROXY_HOST; threaded through
         # build_container_create_kwargs to layer on the legacy posture without
@@ -927,14 +974,17 @@ class DockerSandboxManager(SandboxManager):
             sandbox_proxy_host=proxy_host,
             proxy_ca_volume_name=(SANDBOX_PROXY_CA_VOLUME_NAME if proxy_host else None),
         )
+        # ``create`` rather than ``run`` so we can put_archive the opencode
+        # history into the writable layer before the entrypoint launches.
+        # ``detach`` is a run-only flag; create starts nothing.
+        run_kwargs = dict(create_kwargs)
+        run_kwargs.pop("detach", None)
         try:
-            # Types pinned by ContainerCreateKwargs; ty can't match run's
-            # overloads.
-            return self._docker.containers.run(**create_kwargs)  # ty: ignore[no-matching-overload]
+            return self._docker.containers.create(**run_kwargs), True
         except APIError as e:
             if "Conflict" in str(e) or getattr(e, "status_code", None) == 409:
                 logger.info("Sandbox container %s already exists, reusing.", sandbox_id)
-                return self._require_container(sandbox_id)
+                return self._require_container(sandbox_id), False
             raise RuntimeError(f"Failed to create sandbox container: {e}") from e
 
     def terminate(self, sandbox_id: UUID) -> None:
@@ -1222,6 +1272,133 @@ echo "Session cleanup complete"
             size_bytes,
         )
         return SnapshotResult(storage_path=storage_path, size_bytes=size_bytes)
+
+    def create_opencode_history_snapshot(
+        self,
+        sandbox_id: UUID,
+        tenant_id: str,
+        timeout_seconds: float = 300.0,  # noqa: ARG002 - exec uses the docker client timeout
+    ) -> bool:
+        """Capture sandbox-global opencode history (chat DB + sessions).
+
+        Builds a sqlite-consistent archive in-container via the shared
+        sandbox_daemon helper, then streams it into the FileStore. Returns
+        False when opencode has not written any data yet (leaving any existing
+        durable archive untouched).
+        """
+        container = self._get_container(sandbox_id)
+        if container is None:
+            logger.info(
+                "create_opencode_history_snapshot: sandbox %s has no container.",
+                sandbox_id,
+            )
+            return False
+
+        # OPENCODE_DATA_HOME points the daemon helper at the Docker data home
+        # (the container leaves it unset, so the helper's default would miss it).
+        history_env = {**SANDBOX_EXEC_ENV, "OPENCODE_DATA_HOME": OPENCODE_DATA_DIR}
+        try:
+            built = run_in_container(
+                container,
+                ["python3", "-c", _OPENCODE_HISTORY_CREATE_SCRIPT],
+                user=SANDBOX_EXEC_USER,
+                environment=history_env,
+            )
+        except ExecError as e:
+            raise RuntimeError(f"Failed to build opencode history archive: {e}") from e
+
+        archive_path = built.stdout_text.strip()
+        if not archive_path:
+            logger.info("No opencode history to snapshot for sandbox %s.", sandbox_id)
+            return False
+
+        try:
+            stream = _stream_stdout_from_container_as_sandbox_user(
+                container, ["cat", archive_path]
+            )
+            adapter = _GeneratorReader(stream)
+            # ``_GeneratorReader`` satisfies the structural ``read(n)`` API that
+            # ``SnapshotManager``/``FileStore`` use without subclassing IO[bytes].
+            storage_path, size_bytes = (
+                self._snapshot_manager.persist_opencode_snapshot_from_stream(
+                    stream=adapter,  # ty: ignore[invalid-argument-type]
+                    sandbox_id=str(sandbox_id),
+                    tenant_id=tenant_id,
+                )
+            )
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to persist opencode history snapshot: {e}"
+            ) from e
+        finally:
+            # Drop the in-container temp archive regardless of outcome.
+            try:
+                run_in_container(
+                    container,
+                    ["rm", "-f", archive_path],
+                    user=SANDBOX_EXEC_USER,
+                    check=False,
+                )
+            except ExecError:
+                pass
+
+        logger.info(
+            "Created opencode history snapshot for sandbox %s (path=%s size=%s bytes).",
+            sandbox_id,
+            storage_path,
+            size_bytes,
+        )
+        return True
+
+    def _maybe_restore_opencode_history(
+        self,
+        container: Container,
+        sandbox_id: UUID,
+        tenant_id: str,
+    ) -> None:
+        """Extract any durable opencode history into a freshly-created (not yet
+        started) container before opencode-serve opens its database.
+
+        Only ``/workspace/sessions`` is a persistent volume, so a fresh
+        container's opencode-data is empty. ``put_archive`` into the stopped
+        container writes the writable layer with no live opencode process racing
+        the DB file -- the Docker analogue of the K8s init-sidecar restore. The
+        archive's top-level member is the daemon's ``.opencode-data`` root, so
+        extracting at WORKSPACE_ROOT lands it at OPENCODE_DATA_DIR.
+        """
+        if not self._snapshot_manager.has_opencode_history_snapshot(
+            tenant_id, str(sandbox_id)
+        ):
+            return
+
+        storage_path = SnapshotManager.opencode_history_storage_path(
+            tenant_id, str(sandbox_id)
+        )
+        buf = io.BytesIO()
+        self._snapshot_manager.restore_snapshot_to_stream(storage_path, buf)
+        archive_bytes = buf.getvalue()
+        if not archive_bytes:
+            logger.warning(
+                "Opencode history snapshot for sandbox %s was empty; skipping restore.",
+                sandbox_id,
+            )
+            return
+
+        try:
+            # Docker untars (including gzip) at the destination path. put_archive
+            # works on a created-but-unstarted container's filesystem.
+            if not container.put_archive(WORKSPACE_ROOT, archive_bytes):
+                raise RuntimeError("docker put_archive reported failure")
+        except (APIError, NotFound) as e:
+            raise RuntimeError(
+                f"Failed to restore opencode history into sandbox {sandbox_id}: {e}"
+            ) from e
+
+        logger.info(
+            "Restored opencode history into sandbox %s (%s bytes).",
+            sandbox_id,
+            len(archive_bytes),
+        )
 
     def restore_snapshot(
         self,

--- a/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/opencode_history.py
+++ b/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/opencode_history.py
@@ -11,7 +11,14 @@ from pathlib import Path
 from sandbox_daemon.snapshot import SESSIONS_ROOT
 from sandbox_daemon.snapshot import SnapshotError
 
-OPENCODE_DATA_DIR = Path("/workspace/opencode-data")
+# Opencode's data home. K8s mounts a shared ``opencode-data`` emptyDir here and
+# sets OPENCODE_DATA_HOME on the app container to match; the sidecar leaves the
+# env unset and falls back to this same default. The Docker backend execs this
+# module with OPENCODE_DATA_HOME pointed at its writable-layer data home, which
+# the entrypoint keeps at ``/workspace/.opencode-data``.
+OPENCODE_DATA_DIR = Path(
+    os.environ.get("OPENCODE_DATA_HOME", "/workspace/opencode-data")
+)
 OPENCODE_HISTORY_RESTORED_SENTINEL = Path(
     "/workspace/managed/.onyx/opencode-history-restored"
 )

--- a/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/opencode_history.py
+++ b/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/opencode_history.py
@@ -11,11 +11,8 @@ from pathlib import Path
 from sandbox_daemon.snapshot import SESSIONS_ROOT
 from sandbox_daemon.snapshot import SnapshotError
 
-# Opencode's data home. K8s mounts a shared ``opencode-data`` emptyDir here and
-# sets OPENCODE_DATA_HOME on the app container to match; the sidecar leaves the
-# env unset and falls back to this same default. The Docker backend execs this
-# module with OPENCODE_DATA_HOME pointed at its writable-layer data home, which
-# the entrypoint keeps at ``/workspace/.opencode-data``.
+# Opencode's data home. Defaults to the K8s shared-volume mount; the Docker
+# backend execs this module with OPENCODE_DATA_HOME set to its own data home.
 OPENCODE_DATA_DIR = Path(
     os.environ.get("OPENCODE_DATA_HOME", "/workspace/opencode-data")
 )

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_serve_plumbing.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_serve_plumbing.py
@@ -285,8 +285,8 @@ def test_provision_generates_fresh_password_and_injects_into_container_env(
     mgr._snapshot_manager = MagicMock()  # type: ignore[attr-defined]
     mgr._snapshot_manager.has_opencode_history_snapshot.return_value = False
 
-    # Capture the kwargs passed to containers.create (provision now creates the
-    # container stopped, restores opencode history, then starts it).
+    # Provision creates the container stopped, restores history, then starts it;
+    # capture the create kwargs.
     fake_container = MagicMock()
     fake_container.name = "sandbox-12345678"
     fake_container.attrs = {"State": {"Status": "running"}}

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_serve_plumbing.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_serve_plumbing.py
@@ -281,19 +281,23 @@ def test_provision_generates_fresh_password_and_injects_into_container_env(
     mgr._docker.networks.get.return_value = MagicMock()
     # _ensure_sandbox_volume — pretend it exists already.
     mgr._docker.volumes.get.return_value = MagicMock()
+    # No durable opencode history, so the fresh-container restore is a no-op.
+    mgr._snapshot_manager = MagicMock()  # type: ignore[attr-defined]
+    mgr._snapshot_manager.has_opencode_history_snapshot.return_value = False
 
-    # Capture the kwargs passed to containers.run.
+    # Capture the kwargs passed to containers.create (provision now creates the
+    # container stopped, restores opencode history, then starts it).
     fake_container = MagicMock()
     fake_container.name = "sandbox-12345678"
     fake_container.attrs = {"State": {"Status": "running"}}
 
     run_calls: list[dict[str, Any]] = []
 
-    def _capture_run(**kwargs: Any) -> Any:
+    def _capture_create(**kwargs: Any) -> Any:
         run_calls.append(kwargs)
         return fake_container
 
-    mgr._docker.containers.run.side_effect = _capture_run
+    mgr._docker.containers.create.side_effect = _capture_create
 
     info = mgr.provision(
         sandbox_id=_SBX,
@@ -305,6 +309,8 @@ def test_provision_generates_fresh_password_and_injects_into_container_env(
 
     assert info.status.value == "running"
     assert len(run_calls) == 1
+    # Created stopped, then started explicitly after the (no-op) history restore.
+    fake_container.start.assert_called_once()
     env = run_calls[0]["environment"]
     assert set(env.keys()) == {
         "ONYX_PAT",

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_serve_plumbing.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_serve_plumbing.py
@@ -34,9 +34,11 @@ _SBX = UUID("12345678-1234-1234-1234-1234567890ab")
 
 
 def _bare_manager() -> DockerSandboxManager:
-    """DockerSandboxManager without touching the Docker socket: skips
+    """
+    DockerSandboxManager without touching the Docker socket: skips
     ``_initialize`` so contributors without docker running can still run
-    these tests."""
+    these tests.
+    """
     DockerSandboxManager._instance = None
     mgr: DockerSandboxManager = object.__new__(DockerSandboxManager)
     mgr._agent_instructions_template_path = (  # type: ignore[attr-defined]
@@ -62,7 +64,9 @@ def test_load_serve_connection_info_uses_container_name_and_port() -> None:
 def test_load_serve_connection_info_prefers_localhost_published_port_in_dev(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Host-run workers cannot resolve Docker bridge DNS; use the published port."""
+    """
+    Host-run workers cannot resolve Docker bridge DNS; use the published port.
+    """
     monkeypatch.setattr(dsm, "DEV_MODE", True)
     mgr = _bare_manager()
     fake_container = MagicMock()
@@ -109,7 +113,9 @@ def test_load_serve_connection_info_ignores_published_port_outside_dev() -> None
 def test_load_serve_connection_info_normalizes_wildcard_host_ip_in_dev(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Docker may report wildcard binds; clients should connect via localhost."""
+    """
+    Docker may report wildcard binds; clients should connect via localhost.
+    """
     monkeypatch.setattr(dsm, "DEV_MODE", True)
     mgr = _bare_manager()
     fake_container = MagicMock()
@@ -132,9 +138,11 @@ def test_load_serve_connection_info_normalizes_wildcard_host_ip_in_dev(
 
 
 def test_load_serve_connection_info_parses_password_from_container_env() -> None:
-    """The cleartext password lives in the container's env (Docker
-    Engine API). Decoded on every load; cached by the mixin so the hot
-    path doesn't re-hit ``docker inspect``."""
+    """
+    The cleartext password lives in the container's env (Docker Engine API).
+    Decoded on every load; cached by the mixin so the hot path doesn't re-hit
+    ``docker inspect``.
+    """
     mgr = _bare_manager()
     fake_container = MagicMock()
     fake_container.attrs = {
@@ -155,9 +163,11 @@ def test_load_serve_connection_info_parses_password_from_container_env() -> None
 
 
 def test_load_serve_connection_info_yields_none_password_for_legacy() -> None:
-    """A container provisioned before this code landed has no
-    ``OPENCODE_SERVER_PASSWORD`` in env. The bus then falls back to
-    no-auth and logs a warning."""
+    """
+    A container provisioned before this code landed has no
+    ``OPENCODE_SERVER_PASSWORD`` in env. The bus then falls back to no-auth and
+    logs a warning.
+    """
     mgr = _bare_manager()
     fake_container = MagicMock()
     fake_container.attrs = {
@@ -172,8 +182,10 @@ def test_load_serve_connection_info_yields_none_password_for_legacy() -> None:
 
 
 def test_load_serve_connection_info_returns_none_when_container_missing() -> None:
-    """terminate() races provision() — looking up a deleted container
-    should fail gracefully, not raise."""
+    """
+    terminate() races provision() — looking up a deleted container should fail
+    gracefully, not raise.
+    """
     mgr = _bare_manager()
     mgr._docker = MagicMock()  # type: ignore[attr-defined]
     mgr._docker.containers.get.side_effect = dsm.NotFound("gone")
@@ -182,8 +194,10 @@ def test_load_serve_connection_info_returns_none_when_container_missing() -> Non
 
 
 def test_load_serve_connection_info_handles_password_with_equals_sign() -> None:
-    """``token_urlsafe(32)`` can produce ``=`` chars at the tail. The
-    parser must split on the FIRST equals only."""
+    """
+    ``token_urlsafe(32)`` can produce ``=`` chars at the tail. The parser must
+    split on the FIRST equals only.
+    """
     mgr = _bare_manager()
     weird_password = "tail==padding=="
     fake_container = MagicMock()
@@ -215,8 +229,10 @@ def llm_config() -> LLMProviderConfig:
 def test_render_agents_md_returns_escaped_string(
     llm_config: LLMProviderConfig,
 ) -> None:
-    """opencode.json is not rendered per-session; only AGENTS.md is, with
-    single quotes shell-escaped for ``printf '%s' '...'``."""
+    """
+    opencode.json is not rendered per-session; only AGENTS.md is, with single
+    quotes shell-escaped for ``printf '%s' '...'``.
+    """
     mgr = _bare_manager()
     agents_md = mgr._render_agents_md(
         llm_config=llm_config,
@@ -229,8 +245,10 @@ def test_render_agents_md_returns_escaped_string(
 
 
 def test_init_serve_state_is_idempotent() -> None:
-    """``_init_serve_state`` is called from ``_initialize``; provision
-    paths must not blow up if called twice."""
+    """
+    ``_init_serve_state`` is called from ``_initialize``; provision paths must
+    not blow up if called twice.
+    """
     mgr = _bare_manager()
     first_lock = mgr._event_buses_lock
     mgr._init_serve_state()  # second call
@@ -240,8 +258,10 @@ def test_init_serve_state_is_idempotent() -> None:
 
 
 def test_prompt_slot_serializes_on_docker() -> None:
-    """Pins the prompt-slot lock contract on Docker — same as the K8s
-    test, catches a regression if Docker skips ``_init_serve_state``."""
+    """
+    Pins the prompt-slot lock contract on Docker — same as the K8s test, catches
+    a regression if Docker skips ``_init_serve_state``.
+    """
     mgr = _bare_manager()
 
     other_session = UUID("00000000-0000-0000-0000-000000000001")
@@ -255,9 +275,11 @@ def test_provision_generates_fresh_password_and_injects_into_container_env(
     monkeypatch: pytest.MonkeyPatch,
     llm_config: LLMProviderConfig,
 ) -> None:
-    """``provision()`` must mint a per-call HTTP Basic password and
-    thread it through ``build_container_create_kwargs`` into the
-    container env — otherwise every later request 401s."""
+    """
+    ``provision()`` must mint a per-call HTTP Basic password and thread it
+    through ``build_container_create_kwargs`` into the container env — otherwise
+    every later request 401s.
+    """
     monkeypatch.setattr(dsm, "DEV_MODE", True)
     monkeypatch.setattr(dsm, "SANDBOX_API_SERVER_URL", "https://onyx.example.com")
     # Skip the actual readiness HTTP probe — that needs a real container.
@@ -309,7 +331,8 @@ def test_provision_generates_fresh_password_and_injects_into_container_env(
 
     assert info.status.value == "running"
     assert len(run_calls) == 1
-    # Created stopped, then started explicitly after the (no-op) history restore.
+    # Created stopped, then started explicitly after the (no-op) history
+    # restore.
     fake_container.start.assert_called_once()
     # A successful provision must not remove the container it just started.
     fake_container.remove.assert_not_called()
@@ -339,8 +362,10 @@ def test_provision_generates_fresh_password_and_injects_into_container_env(
 
 
 def test_terminate_closes_event_bus_and_tombstones_sandbox() -> None:
-    """terminate must close every per-directory bus and add the sandbox
-    to ``_terminated_sandboxes`` so a late subscribe can't race in."""
+    """
+    terminate must close every per-directory bus and add the sandbox to
+    ``_terminated_sandboxes`` so a late subscribe can't race in.
+    """
     mgr = _bare_manager()
     mgr._docker = MagicMock()  # type: ignore[attr-defined]
     mgr._docker.containers.get.return_value = None
@@ -363,9 +388,11 @@ def test_terminate_closes_event_bus_and_tombstones_sandbox() -> None:
 
 
 def test_reuse_existing_container_removes_created_state() -> None:
-    """A container stranded in 'created' state is an incomplete prior provision.
+    """
+    A container stranded in 'created' state is an incomplete prior provision.
     Reuse must remove it (not start it) so the retry re-creates and restores
-    opencode history -- starting it would skip the restore."""
+    opencode history -- starting it would skip the restore.
+    """
     mgr = _bare_manager()
     mgr._docker = MagicMock()  # type: ignore[attr-defined]
 
@@ -382,8 +409,10 @@ def test_reuse_existing_container_removes_created_state() -> None:
 
 
 def test_reuse_existing_container_starts_exited() -> None:
-    """An 'exited' container ran before, so its writable-layer data home is
-    populated; reuse should start it rather than discard it."""
+    """
+    An 'exited' container ran before, so its writable-layer data home is
+    populated; reuse should start it rather than discard it.
+    """
     mgr = _bare_manager()
     mgr._docker = MagicMock()  # type: ignore[attr-defined]
 
@@ -403,10 +432,12 @@ def test_provision_removes_container_when_history_restore_fails(
     monkeypatch: pytest.MonkeyPatch,
     llm_config: LLMProviderConfig,
 ) -> None:
-    """If opencode-history restore fails on a fresh container, provision must
-    remove the half-provisioned container (so a retry re-creates + restores)
-    and propagate the failure -- it must not start opencode against an empty
-    data home."""
+    """
+    If opencode-history restore fails on a fresh container, provision must
+    remove the half-provisioned container (so a retry re-creates + restores) and
+    propagate the failure -- it must not start opencode against an empty data
+    home.
+    """
     monkeypatch.setattr(dsm, "DEV_MODE", True)
     monkeypatch.setattr(dsm, "SANDBOX_API_SERVER_URL", "https://onyx.example.com")
 

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_serve_plumbing.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_serve_plumbing.py
@@ -311,6 +311,8 @@ def test_provision_generates_fresh_password_and_injects_into_container_env(
     assert len(run_calls) == 1
     # Created stopped, then started explicitly after the (no-op) history restore.
     fake_container.start.assert_called_once()
+    # A successful provision must not remove the container it just started.
+    fake_container.remove.assert_not_called()
     env = run_calls[0]["environment"]
     assert set(env.keys()) == {
         "ONYX_PAT",
@@ -358,3 +360,86 @@ def test_terminate_closes_event_bus_and_tombstones_sandbox() -> None:
     assert all(k[0] != _SBX for k in mgr._event_buses)
     fake_bus_a.close.assert_called_once()
     fake_bus_b.close.assert_called_once()
+
+
+def test_reuse_existing_container_removes_created_state() -> None:
+    """A container stranded in 'created' state is an incomplete prior provision.
+    Reuse must remove it (not start it) so the retry re-creates and restores
+    opencode history -- starting it would skip the restore."""
+    mgr = _bare_manager()
+    mgr._docker = MagicMock()  # type: ignore[attr-defined]
+
+    stranded = MagicMock()
+    stranded.name = "sandbox-12345678"
+    stranded.attrs = {"State": {"Status": "created"}}
+    mgr._docker.containers.get.return_value = stranded
+
+    result = mgr._reuse_existing_container(_SBX)
+
+    assert result is None, "A 'created' container must not be reused."
+    stranded.remove.assert_called_once_with(force=True)
+    stranded.start.assert_not_called()
+
+
+def test_reuse_existing_container_starts_exited() -> None:
+    """An 'exited' container ran before, so its writable-layer data home is
+    populated; reuse should start it rather than discard it."""
+    mgr = _bare_manager()
+    mgr._docker = MagicMock()  # type: ignore[attr-defined]
+
+    exited = MagicMock()
+    exited.name = "sandbox-12345678"
+    exited.attrs = {"State": {"Status": "exited"}}
+    mgr._docker.containers.get.return_value = exited
+
+    result = mgr._reuse_existing_container(_SBX)
+
+    assert result is exited
+    exited.start.assert_called_once()
+    exited.remove.assert_not_called()
+
+
+def test_provision_removes_container_when_history_restore_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    llm_config: LLMProviderConfig,
+) -> None:
+    """If opencode-history restore fails on a fresh container, provision must
+    remove the half-provisioned container (so a retry re-creates + restores)
+    and propagate the failure -- it must not start opencode against an empty
+    data home."""
+    monkeypatch.setattr(dsm, "DEV_MODE", True)
+    monkeypatch.setattr(dsm, "SANDBOX_API_SERVER_URL", "https://onyx.example.com")
+
+    mgr = _bare_manager()
+    mgr._docker = MagicMock()  # type: ignore[attr-defined]
+    mgr._image = "onyxdotapp/sandbox:test"  # type: ignore[attr-defined]
+    mgr._network_name = "onyx_craft_sandbox"  # type: ignore[attr-defined]
+    mgr._memory_limit = "2g"  # type: ignore[attr-defined]
+    mgr._cpu_limit = 1.0  # type: ignore[attr-defined]
+    mgr._compose_project = None  # type: ignore[attr-defined]
+    mgr._docker.containers.get.side_effect = dsm.NotFound("none")
+    mgr._docker.networks.get.return_value = MagicMock()
+    mgr._docker.volumes.get.return_value = MagicMock()
+
+    # FileStore lookup blows up partway through the history restore.
+    mgr._snapshot_manager = MagicMock()  # type: ignore[attr-defined]
+    mgr._snapshot_manager.has_opencode_history_snapshot.side_effect = RuntimeError(
+        "filestore unavailable"
+    )
+
+    fake_container = MagicMock()
+    fake_container.name = "sandbox-12345678"
+    mgr._docker.containers.create.return_value = fake_container
+
+    with pytest.raises(RuntimeError):
+        mgr.provision(
+            sandbox_id=_SBX,
+            user_id=UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+            tenant_id="tenant-abc",
+            llm_config=llm_config,
+            onyx_pat="pat-redacted",
+        )
+
+    # Half-provisioned container is force-removed; opencode never started.
+    fake_container.remove.assert_called_once_with(force=True)
+    fake_container.start.assert_not_called()


### PR DESCRIPTION
## Description
Docker sandboxes lost all opencode chat history when a container was reaped -- only K8s persisted it. This brings the Docker backend to parity.

- Capture (`create_opencode_history_snapshot`): docker-execs the shared `sandbox_daemon` archive helper (sqlite-safe backup) and streams the tarball to the FileStore. The helper's data home is now `OPENCODE_DATA_HOME`-configurable, so K8s and Docker share one code path.
- Restore (`_maybe_restore_opencode_history`): on a fresh provision, `put_archive`s the snapshot into the still stopped container before start, so opencode-serve opens the restored DB instead of an empty one. Provision is now create -> restore -> start.
- Reliability: a `created`-state container (an incomplete prior provision) is removed and rebuilt rather than blindly started, so an interrupted/failed restore can't silently boot opencode against an empty data home. Restore failures are fatal and remove the half-built container.

## How Has This Been Tested?

Unit tests cover the provision/cleanup paths and the `created`-container handling. #12171 adds an integration test.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist opencode history (chat DB and sessions) for Docker Compose sandboxes. We snapshot from the running container and restore into new containers before start so sessions survive rebuilds.

- **New Features**
  - Added snapshot/restore via `sandbox_daemon.opencode_history`: build an in-container archive (Python exec), stream it to FileStore, and restore with Docker `put_archive` so it lands under `/workspace/.opencode-data`. The daemon now honors `OPENCODE_DATA_HOME` (Docker uses `/workspace/.opencode-data`; default stays `/workspace/opencode-data`).
  - Provision now does `docker create`, restores history into the stopped container, then starts it. If restore fails, the half-provisioned container is force-removed. Containers stuck in `'created'` are removed so we can re-create and restore; `'exited'` containers are started. Exposes `create_opencode_history_snapshot` and sets `supports_opencode_history_persistence = True`.

<sup>Written for commit d17549ca93c0399cf33f4ba40811b9001f50515e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
