### PR TITLE
fix(craft): keep restored file pane populated

### DIFF
--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -1447,7 +1447,12 @@ printf '%s' '{agents_md}' > {session_path}/AGENTS.md
                 [
                     "/bin/sh",
                     "-c",
-                    f"ls -laL --time-style=+%s {quoted} 2>/dev/null || echo 'ERROR_NOT_FOUND'",
+                    (
+                        f"target={quoted}; "
+                        'if [ -d "$target" ]; then '
+                        'ls -la --time-style=+%s "$target"/ 2>/dev/null; '
+                        "else echo 'ERROR_NOT_FOUND'; fi"
+                    ),
                 ],
                 check=False,
             )
@@ -1483,7 +1488,9 @@ printf '%s' '{agents_md}' > {session_path}/AGENTS.md
             if name in (".", ".."):
                 continue
 
-            is_directory = line.startswith("d")
+            # Managed workspace links point at directories. Keep them navigable
+            # when listing without -L, and let navigation fail if a target is gone.
+            is_directory = line.startswith("d") or is_symlink
             size_str = parts[4]
             try:
                 size = int(size_str) if not is_directory else None

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -150,6 +150,7 @@ WORKSPACE_ROOT = "/workspace"
 SESSIONS_ROOT = f"{WORKSPACE_ROOT}/sessions"
 TEMPLATES_OUTPUTS_PATH = f"{WORKSPACE_ROOT}/templates/outputs"
 MANAGED_SKILLS_PATH = f"{WORKSPACE_ROOT}/managed/skills"
+MANAGED_USER_LIBRARY_PATH = f"{WORKSPACE_ROOT}/managed/user_library"
 SANDBOX_EXEC_USER = "1000:1000"
 # Docker exec bypasses firewall-init.sh's setpriv environment workaround, so
 # sandbox-user execs must carry the uid/gid and user HOME together.
@@ -1097,6 +1098,7 @@ else
     mkdir -p {session_path}/outputs/web
 fi
 ln -sf {MANAGED_SKILLS_PATH} {session_path}/.opencode/skills
+ln -sf {MANAGED_USER_LIBRARY_PATH} {session_path}/user_library
 printf '%s' '{agents_md}' > {session_path}/AGENTS.md
 {nextjs_start}
 echo "Session workspace setup complete"
@@ -1388,6 +1390,7 @@ fi
 set -e
 mkdir -p {session_path}/.opencode
 ln -sfn {MANAGED_SKILLS_PATH} {session_path}/.opencode/skills
+ln -sfn {MANAGED_USER_LIBRARY_PATH} {session_path}/user_library
 printf '%s' '{agents_md}' > {session_path}/AGENTS.md
 """
         try:
@@ -1447,12 +1450,7 @@ printf '%s' '{agents_md}' > {session_path}/AGENTS.md
                 [
                     "/bin/sh",
                     "-c",
-                    (
-                        f"target={quoted}; "
-                        'if [ -d "$target" ]; then '
-                        'ls -la --time-style=+%s "$target"/ 2>/dev/null; '
-                        "else echo 'ERROR_NOT_FOUND'; fi"
-                    ),
+                    f"ls -la --time-style=+%s {quoted}/ 2>/dev/null || echo 'ERROR_NOT_FOUND'",
                 ],
                 check=False,
             )
@@ -1475,22 +1473,22 @@ printf '%s' '{agents_md}' > {session_path}/AGENTS.md
             if len(parts) < 7:
                 continue
             is_symlink = line.startswith("l")
+            link_target: str | None = None
             if is_symlink and " -> " in line:
                 name_and_target = " ".join(parts[6:])
-                name = (
-                    name_and_target.split(" -> ")[0]
-                    if " -> " in name_and_target
-                    else parts[-1]
-                )
+                if " -> " in name_and_target:
+                    name, link_target = name_and_target.split(" -> ", 1)
+                else:
+                    name = parts[-1]
             else:
                 name = " ".join(parts[6:])
 
             if name in (".", ".."):
                 continue
 
-            # Managed workspace links point at directories. Keep them navigable
-            # when listing without -L, and let navigation fail if a target is gone.
-            is_directory = line.startswith("d") or is_symlink
+            is_directory = line.startswith("d") or (
+                is_symlink and link_target == MANAGED_USER_LIBRARY_PATH
+            )
             size_str = parts[4]
             try:
                 size = int(size_str) if not is_directory else None

--- a/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/contract.py
+++ b/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/contract.py
@@ -15,6 +15,7 @@ SIDECAR_HEALTH_PATH = "/health"
 SIDECAR_READY_PATH = "/ready"
 SIDECAR_PUSH_PATH = "/push"
 PUSH_DAEMON_PORT = 8731
+SIDECAR_FILESYSTEM_LIST_PATH = "/filesystem/list"
 SIDECAR_SNAPSHOT_CREATE_PATH = "/snapshot/create"
 SIDECAR_SNAPSHOT_RESTORE_PREFIX = "/snapshot/restore"
 SIDECAR_SNAPSHOT_RESTORE_ROUTE = f"{SIDECAR_SNAPSHOT_RESTORE_PREFIX}/{{session_id}}"
@@ -32,6 +33,29 @@ class SnapshotCreateRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     session_id: UUID
+
+
+class FilesystemListRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    session_id: UUID
+    path: str = ""
+
+
+class SidecarFilesystemEntry(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    path: str
+    is_directory: bool
+    size: int | None = None
+    mime_type: str | None = None
+
+
+class FilesystemListResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    entries: list[SidecarFilesystemEntry]
 
 
 # Restore has no response body — failures raise, success is the 204.

--- a/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/filesystem.py
+++ b/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/filesystem.py
@@ -1,0 +1,156 @@
+"""Filesystem listing operations for the sandbox sidecar."""
+
+from __future__ import annotations
+
+import mimetypes
+from pathlib import Path
+from uuid import UUID
+
+from sandbox_daemon.contract import FilesystemListResponse
+from sandbox_daemon.contract import SidecarFilesystemEntry
+from sandbox_daemon.snapshot import SESSIONS_ROOT
+
+_USER_LIBRARY_LINK_TARGET = Path("/workspace/managed/user_library")
+
+
+class FilesystemPathError(RuntimeError):
+    """Raised for invalid, missing, or non-directory paths."""
+
+
+def _clean_relative_path(path: str) -> Path:
+    if "\x00" in path:
+        raise FilesystemPathError("path not found or not a directory")
+
+    path_obj = Path(path.lstrip("/"))
+    if any(part == ".." for part in path_obj.parts):
+        raise FilesystemPathError("path traversal is not allowed")
+
+    parts = [part for part in path_obj.parts if part not in ("", ".")]
+    return Path(*parts) if parts else Path(".")
+
+
+def _is_managed_user_library_link(entry: Path) -> bool:
+    if not entry.is_symlink() or entry.name != "user_library":
+        return False
+    try:
+        return entry.readlink() == _USER_LIBRARY_LINK_TARGET
+    except OSError:
+        return False
+
+
+def _is_user_library_request(relative_path: Path, session_root: Path) -> bool:
+    return relative_path.parts[:1] == (
+        "user_library",
+    ) and _is_managed_user_library_link(session_root / "user_library")
+
+
+def _resolved_user_library_root() -> Path | None:
+    try:
+        resolved = _USER_LIBRARY_LINK_TARGET.resolve(strict=True)
+        versions_root = (_USER_LIBRARY_LINK_TARGET.parent / ".versions").resolve(
+            strict=True
+        )
+    except (OSError, ValueError):
+        return None
+
+    if resolved.is_dir() and resolved.is_relative_to(versions_root):
+        return resolved
+    return None
+
+
+def _resolve_allowed_directory(
+    path: Path,
+    session_root_resolved: Path,
+    *,
+    allow_user_library: bool,
+) -> Path | None:
+    try:
+        resolved = path.resolve(strict=True)
+    except (OSError, ValueError):
+        return None
+
+    if not resolved.is_dir():
+        return None
+
+    if resolved.is_relative_to(session_root_resolved):
+        return resolved
+
+    if allow_user_library:
+        user_library_root = _resolved_user_library_root()
+        if user_library_root is not None and resolved.is_relative_to(user_library_root):
+            return resolved
+
+    return None
+
+
+def _entry_size(entry: Path, is_directory: bool) -> int | None:
+    if is_directory:
+        return None
+    try:
+        stat_result = entry.lstat() if entry.is_symlink() else entry.stat()
+        return stat_result.st_size
+    except OSError:
+        return None
+
+
+def list_session_directory(session_id: UUID, path: str) -> FilesystemListResponse:
+    relative_path = _clean_relative_path(path)
+    try:
+        session_root_resolved = SESSIONS_ROOT.resolve(strict=True) / str(session_id)
+    except OSError as e:
+        raise FilesystemPathError("path not found or not a directory") from e
+
+    session_root = SESSIONS_ROOT / str(session_id)
+    if session_root.is_symlink():
+        raise FilesystemPathError("session path is a symlink")
+    target = session_root / relative_path
+    allow_user_library = _is_user_library_request(relative_path, session_root)
+
+    target_directory = _resolve_allowed_directory(
+        target,
+        session_root_resolved,
+        allow_user_library=allow_user_library,
+    )
+    if target_directory is None:
+        raise FilesystemPathError("path not found or not a directory")
+
+    base_path = "" if relative_path == Path(".") else relative_path.as_posix()
+    entries: list[SidecarFilesystemEntry] = []
+    is_listing_session_root = target_directory == session_root_resolved
+    for entry_path_on_disk in target_directory.iterdir():
+        name = entry_path_on_disk.name
+        is_managed_user_library = (
+            is_listing_session_root
+            and _is_managed_user_library_link(entry_path_on_disk)
+        )
+        child_allow_user_library = allow_user_library or is_managed_user_library
+        is_directory = (
+            _resolve_allowed_directory(
+                entry_path_on_disk,
+                session_root_resolved,
+                allow_user_library=child_allow_user_library,
+            )
+            is not None
+        )
+        if (
+            not is_directory
+            and is_managed_user_library
+            and not _USER_LIBRARY_LINK_TARGET.exists()
+        ):
+            # Keep restored-session placeholders visible as folders while
+            # hydration recreates the managed user library target.
+            is_directory = True
+
+        entry_path = f"{base_path}/{name}".lstrip("/")
+        entries.append(
+            SidecarFilesystemEntry(
+                name=name,
+                path=entry_path,
+                is_directory=is_directory,
+                size=_entry_size(entry_path_on_disk, is_directory),
+                mime_type=None if is_directory else mimetypes.guess_type(name)[0],
+            )
+        )
+
+    entries.sort(key=lambda e: (not e.is_directory, e.name.lower(), e.name))
+    return FilesystemListResponse(entries=entries)

--- a/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/server.py
+++ b/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/server.py
@@ -20,7 +20,9 @@ from fastapi import Query
 from fastapi import Request
 from fastapi import Response
 from fastapi.responses import StreamingResponse
+from sandbox_daemon.contract import FilesystemListRequest
 from sandbox_daemon.contract import PUSH_DAEMON_PORT
+from sandbox_daemon.contract import SIDECAR_FILESYSTEM_LIST_PATH
 from sandbox_daemon.contract import SIDECAR_HEALTH_PATH
 from sandbox_daemon.contract import SIDECAR_OPENCODE_HISTORY_CREATE_PATH
 from sandbox_daemon.contract import SIDECAR_OPENCODE_HISTORY_MARK_RESTORED_PATH
@@ -34,6 +36,8 @@ from sandbox_daemon.contract import SIDECAR_SNAPSHOT_RESTORE_ROUTE
 from sandbox_daemon.contract import SnapshotCreateRequest
 from sandbox_daemon.extract import MAX_BUNDLE_BYTES
 from sandbox_daemon.extract import safe_extract_then_atomic_swap
+from sandbox_daemon.filesystem import FilesystemPathError
+from sandbox_daemon.filesystem import list_session_directory
 from sandbox_daemon.opencode_history import create_opencode_history_archive_file
 from sandbox_daemon.opencode_history import mark_opencode_history_restored
 from sandbox_daemon.opencode_history import opencode_history_restored
@@ -143,6 +147,41 @@ def ready() -> dict[str, str]:
     if not opencode_history_restored():
         raise HTTPException(status_code=503, detail="opencode history not restored")
     return {"status": "ok"}
+
+
+@app.post(SIDECAR_FILESYSTEM_LIST_PATH)
+async def filesystem_list(
+    request: Request,
+    x_push_signature: str = Header(..., alias="X-Push-Signature"),
+    x_push_timestamp: str = Header(..., alias="X-Push-Timestamp"),
+) -> dict[str, object]:
+    body = await request.body()
+    _verify_signature(
+        SIDECAR_FILESYSTEM_LIST_PATH,
+        hashlib.sha256(body).hexdigest(),
+        x_push_signature,
+        x_push_timestamp,
+    )
+
+    try:
+        payload = FilesystemListRequest.model_validate_json(body)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=f"Invalid request body: {e}")
+
+    try:
+        listing = await asyncio.to_thread(
+            list_session_directory,
+            session_id=payload.session_id,
+            path=payload.path,
+        )
+    except FilesystemPathError as e:
+        detail = str(e)
+        status_code = 400 if "traversal" in detail else 404
+        raise HTTPException(status_code=status_code, detail=detail)
+    except OSError as e:
+        raise HTTPException(status_code=500, detail=f"filesystem list OS error: {e}")
+
+    return listing.model_dump()
 
 
 @app.post(SIDECAR_PUSH_PATH)

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -41,7 +41,6 @@ import hashlib
 import io
 import ipaddress
 import json
-import mimetypes
 import os
 import re
 import secrets
@@ -1989,14 +1988,15 @@ printf '%s' '{agent_instructions_escaped}' > {session_path}/AGENTS.md
     def list_directory(
         self, sandbox_id: UUID, session_id: UUID, path: str
     ) -> list[FilesystemEntry]:
-        """List contents of a directory in the session's outputs directory.
+        """List contents of a directory in the session workspace.
 
-        For Kubernetes backend, we exec into the pod to list files.
+        For Kubernetes backend, the sandbox sidecar owns pod-local filesystem
+        access and returns structured entries.
 
         Args:
             sandbox_id: The sandbox ID
             session_id: The session ID
-            path: Relative path within sessions/$session_id/outputs/
+            path: Relative path within sessions/$session_id/
 
         Returns:
             List of FilesystemEntry objects sorted by directory first, then name
@@ -2004,126 +2004,25 @@ printf '%s' '{agent_instructions_escaped}' > {session_path}/AGENTS.md
         Raises:
             ValueError: If path traversal attempted or path is not a directory
         """
-        # _get_pod_name needs string
-        pod_name = self._get_pod_name(str(sandbox_id))
-
-        # Security: sanitize path by removing '..' components individually
-        path_obj = Path(path.lstrip("/"))
-        clean_parts = [p for p in path_obj.parts if p != ".."]
-        clean_path = str(Path(*clean_parts)) if clean_parts else "."
-        target_path = f"/workspace/sessions/{session_id}/{clean_path}"
-        # Use shlex.quote to prevent command injection
-        quoted_path = shlex.quote(target_path)
-
-        logger.info("Listing directory %s in pod %s", target_path, pod_name)
-
-        # List the requested directory without dereferencing every child symlink.
-        # A dangling managed symlink should not make the whole directory look empty.
-        exec_command = [
-            "/bin/sh",
-            "-c",
-            (
-                f"target={quoted_path}; "
-                'if [ -d "$target" ]; then '
-                'ls -la --time-style=+%s "$target"/ 2>/dev/null; '
-                "else echo 'ERROR_NOT_FOUND'; fi"
-            ),
-        ]
-
         try:
-            resp = k8s_stream(
-                self._stream_core_api.connect_get_namespaced_pod_exec,
-                name=pod_name,
-                namespace=self._namespace,
-                container=_SANDBOX_CONTAINER_NAME,
-                command=exec_command,
-                stderr=True,
-                stdin=False,
-                stdout=True,
-                tty=False,
+            return self._sidecar_client.list_directory(
+                sandbox_id=sandbox_id,
+                session_id=session_id,
+                path=path,
             )
-
-            if "ERROR_NOT_FOUND" in resp:
-                raise ValueError(f"Path not found or not a directory: {path}")
-
-            entries = self._parse_ls_output(resp, clean_path)
-            return sorted(entries, key=lambda e: (not e.is_directory, e.name.lower()))
-
-        except ApiException as e:
-            raise RuntimeError(f"Failed to list directory: {e}") from e
-
-    def _parse_ls_output(self, ls_output: str, base_path: str) -> list[FilesystemEntry]:
-        """Parse ls -la output into FilesystemEntry objects.
-
-        Handles regular files, directories, and symlinks. Symlinks to directories
-        are treated as directories for navigation purposes.
-        """
-        entries = []
-        lines = ls_output.strip().split("\n")
-
-        logger.debug("Parsing %s lines of ls output for %s", len(lines), base_path)
-
-        for line in lines:
-            logger.debug("Parsing line: %s", line)
-
-            # Skip header line and . / .. entries
-            if line.startswith("total") or not line:
-                continue
-
-            parts = line.split()
-            # ls -la --time-style=+%s format: perms links owner group size timestamp name
-            # Minimum 7 parts for a simple filename
-            if len(parts) < 7:
-                continue
-
-            # Handle symlinks: format is "name -> target"
-            # For symlinks, parts[-1] is the target, not the name
-            is_symlink = line.startswith("l")
-            if is_symlink and " -> " in line:
-                # Extract name from the "name -> target" portion
-                # Filename starts at index 6 (after perms, links, owner, group, size, timestamp)
-                try:
-                    # Rejoin from index 6 onwards to handle names with spaces
-                    name_and_target = " ".join(parts[6:])
-                    if " -> " in name_and_target:
-                        name = name_and_target.split(" -> ")[0]
-                    else:
-                        name = parts[-1]
-                except (IndexError, ValueError):
-                    name = parts[-1]
-            else:
-                # For regular files/directories, name is at index 6 or later (with spaces)
-                name = " ".join(parts[6:])
-
-            if name in (".", ".."):
-                continue
-
-            # Directories start with 'd', symlinks start with 'l'
-            # Treat symlinks as directories (they typically point to directories
-            # in our sandbox setup)
-            is_directory = line.startswith("d") or is_symlink
-            size_str = parts[4]
-
+        except SidecarStatusError as e:
             try:
-                size = int(size_str) if not is_directory else None
-            except ValueError:
-                size = None
+                detail = json.loads(e.body).get("detail", "")
+            except (TypeError, ValueError):
+                detail = ""
 
-            # Guess MIME type for files based on extension
-            mime_type = mimetypes.guess_type(name)[0] if not is_directory else None
-
-            entry_path = f"{base_path}/{name}".lstrip("/")
-            entries.append(
-                FilesystemEntry(
-                    name=name,
-                    path=entry_path,
-                    is_directory=is_directory,
-                    size=size,
-                    mime_type=mime_type,
-                )
-            )
-
-        return entries
+            if e.status_code == 400 and detail == "path traversal is not allowed":
+                raise ValueError(f"path traversal attempted: {path}") from e
+            if e.status_code == 404 and detail == "path not found or not a directory":
+                raise ValueError(f"Path not found or not a directory: {path}") from e
+            raise RuntimeError(f"Failed to list directory: {e}") from e
+        except SidecarRequestError as e:
+            raise RuntimeError(f"Failed to list directory: {e}") from e
 
     def read_file(self, sandbox_id: UUID, session_id: UUID, path: str) -> bytes:
         """Read a file from the session's workspace.

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -2017,12 +2017,17 @@ printf '%s' '{agent_instructions_escaped}' > {session_path}/AGENTS.md
 
         logger.info("Listing directory %s in pod %s", target_path, pod_name)
 
-        # Use exec to list directory
-        # -L follows symlinks
+        # List the requested directory without dereferencing every child symlink.
+        # A dangling managed symlink should not make the whole directory look empty.
         exec_command = [
             "/bin/sh",
             "-c",
-            f"ls -laL --time-style=+%s {quoted_path} 2>/dev/null || echo 'ERROR_NOT_FOUND'",
+            (
+                f"target={quoted_path}; "
+                'if [ -d "$target" ]; then '
+                'ls -la --time-style=+%s "$target"/ 2>/dev/null; '
+                "else echo 'ERROR_NOT_FOUND'; fi"
+            ),
         ]
 
         try:

--- a/backend/onyx/server/features/build/sandbox/kubernetes/sidecar_client.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/sidecar_client.py
@@ -21,7 +21,16 @@ from cryptography.hazmat.primitives.serialization import PublicFormat
 
 from onyx.server.features.build.configs import SANDBOX_PUSH_PRIVATE_KEY
 from onyx.server.features.build.sandbox.image.sandbox_daemon.contract import (
+    FilesystemListRequest,
+)
+from onyx.server.features.build.sandbox.image.sandbox_daemon.contract import (
+    FilesystemListResponse,
+)
+from onyx.server.features.build.sandbox.image.sandbox_daemon.contract import (
     PUSH_DAEMON_PORT,
+)
+from onyx.server.features.build.sandbox.image.sandbox_daemon.contract import (
+    SIDECAR_FILESYSTEM_LIST_PATH,
 )
 from onyx.server.features.build.sandbox.image.sandbox_daemon.contract import (
     SIDECAR_HEALTH_PATH,
@@ -29,6 +38,7 @@ from onyx.server.features.build.sandbox.image.sandbox_daemon.contract import (
 from onyx.server.features.build.sandbox.image.sandbox_daemon.contract import (
     SIDECAR_PUSH_PATH,
 )
+from onyx.server.features.build.sandbox.models import FilesystemEntry
 
 _SIDECAR_CHUNK_SIZE = 8 * 1024 * 1024
 
@@ -131,6 +141,55 @@ class SidecarClient:
             except httpx.TransportError:
                 continue
         return False
+
+    def list_directory(
+        self,
+        *,
+        sandbox_id: UUID,
+        session_id: UUID,
+        path: str,
+        timeout_seconds: float = 30.0,
+    ) -> list[FilesystemEntry]:
+        payload = FilesystemListRequest(session_id=session_id, path=path)
+        body = payload.model_dump_json().encode()
+        sha256_hex = hashlib.sha256(body).hexdigest()
+        last_exc: httpx.TransportError | None = None
+
+        for host in self._hosts(sandbox_id):
+            try:
+                with httpx.Client(timeout=timeout_seconds) as http_client:
+                    resp = http_client.post(
+                        self._url(host, SIDECAR_FILESYSTEM_LIST_PATH),
+                        content=body,
+                        headers=self._signed_headers(
+                            signing_path=SIDECAR_FILESYSTEM_LIST_PATH,
+                            sha256_hex=sha256_hex,
+                            content_type="application/json",
+                        ),
+                    )
+            except httpx.TransportError as e:
+                last_exc = e
+                continue
+
+            if resp.status_code != 200:
+                raise SidecarStatusError("filesystem list", resp.status_code, resp.text)
+
+            listing = FilesystemListResponse.model_validate_json(resp.content)
+            return [
+                FilesystemEntry(
+                    name=entry.name,
+                    path=entry.path,
+                    is_directory=entry.is_directory,
+                    size=entry.size,
+                    mime_type=entry.mime_type,
+                )
+                for entry in listing.entries
+            ]
+
+        raise SidecarRequestError(
+            "filesystem list request failed: "
+            f"{last_exc or 'no sandbox pod host reachable'}"
+        )
 
     @contextmanager
     def request_and_stream_new_snapshot(

--- a/backend/onyx/server/features/build/session/api.py
+++ b/backend/onyx/server/features/build/session/api.py
@@ -42,6 +42,7 @@ from onyx.server.features.build.db.sandbox import update_sandbox_status__no_comm
 from onyx.server.features.build.models import UploadResponse
 from onyx.server.features.build.sandbox.factory import get_sandbox_manager
 from onyx.server.features.build.sandbox.models import DirectoryListing
+from onyx.server.features.build.sandbox.user_library import hydrate_user_library
 from onyx.server.features.build.session.errors import UploadLimitExceededError
 from onyx.server.features.build.session.manager import SessionManager
 from onyx.server.features.build.session.models import ArtifactResponse
@@ -476,6 +477,15 @@ def restore_session(
                 except Exception:
                     logger.warning(
                         "Failed to push skills to sandbox %s",
+                        sandbox.id,
+                        exc_info=True,
+                    )
+
+                try:
+                    hydrate_user_library(sandbox.id, user.id, db_session)
+                except Exception:
+                    logger.warning(
+                        "Failed to push user library to sandbox %s",
                         sandbox.id,
                         exc_info=True,
                     )

--- a/backend/tests/external_dependency_unit/craft/test_kubernetes_sandbox_file_ops.py
+++ b/backend/tests/external_dependency_unit/craft/test_kubernetes_sandbox_file_ops.py
@@ -98,12 +98,6 @@ class TestListDirectory:
         pool_session: tuple[UUID, UUID, str],
     ) -> None:
         sandbox_id, session_id, pod_name = pool_session
-        # ``list_directory`` walks ``sessions/{id}/{path}`` with ``ls -laL``.
-        # The session root contains ``user_library`` (a symlink into the RO
-        # managed/ mount) which fails ``-L`` dereference and trips the
-        # function's ``ERROR_NOT_FOUND`` branch, so the contract in
-        # production is "list a subpath under outputs/" (the docstring's
-        # documented path). Seed + assert inside outputs/.
         outputs_dir = f"/workspace/sessions/{session_id}/outputs"
         pod_exec(
             k8s_client,

--- a/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
@@ -36,6 +36,7 @@ from onyx.server.features.build.db.build_session import allocate_nextjs_port
 from onyx.server.features.build.db.build_session import get_user_build_sessions
 from onyx.server.features.build.db.sandbox import get_sandbox_by_user_id
 from onyx.server.features.build.sandbox.models import SandboxInfo
+from onyx.server.features.build.sandbox.user_library import USER_LIBRARY_MOUNT_PATH
 from onyx.server.features.build.session.api import restore_session
 from onyx.server.features.build.session.manager import SessionManager
 from tests.external_dependency_unit.constants import TEST_TENANT_ID
@@ -1057,6 +1058,11 @@ class TestRestoreSession:
         assert (
             stub_sandbox_manager.last_restore_snapshot_payload["snapshot_storage_path"]
             == snapshot.storage_path
+        )
+        assert stub_sandbox_manager.last_write_files_to_sandbox_payload is not None
+        assert (
+            stub_sandbox_manager.last_write_files_to_sandbox_payload["mount_path"]
+            == USER_LIBRARY_MOUNT_PATH
         )
 
 

--- a/backend/tests/unit/onyx/server/features/build/sandbox/sandbox_daemon/test_sandbox_daemon.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/sandbox_daemon/test_sandbox_daemon.py
@@ -32,6 +32,12 @@ from cryptography.hazmat.primitives.serialization import PublicFormat
 from fastapi.testclient import TestClient
 
 from onyx.server.features.build.sandbox.image.sandbox_daemon.contract import (
+    FilesystemListRequest,
+)
+from onyx.server.features.build.sandbox.image.sandbox_daemon.contract import (
+    SIDECAR_FILESYSTEM_LIST_PATH,
+)
+from onyx.server.features.build.sandbox.image.sandbox_daemon.contract import (
     SIDECAR_HEALTH_PATH,
 )
 from onyx.server.features.build.sandbox.image.sandbox_daemon.contract import (
@@ -76,6 +82,7 @@ def _load_sandbox_daemon_modules() -> tuple[ModuleType, ModuleType]:
         "sandbox_daemon.server" in sys.modules
         and "sandbox_daemon.contract" in sys.modules
         and "sandbox_daemon.extract" in sys.modules
+        and "sandbox_daemon.filesystem" in sys.modules
     ):
         return sys.modules["sandbox_daemon.extract"], sys.modules[
             "sandbox_daemon.server"
@@ -84,7 +91,14 @@ def _load_sandbox_daemon_modules() -> tuple[ModuleType, ModuleType]:
     if "sandbox_daemon" not in sys.modules:
         sys.modules["sandbox_daemon"] = types.ModuleType("sandbox_daemon")
 
-    for name in ("contract", "extract", "snapshot", "opencode_history", "server"):
+    for name in (
+        "contract",
+        "extract",
+        "snapshot",
+        "opencode_history",
+        "filesystem",
+        "server",
+    ):
         spec = importlib.util.spec_from_file_location(
             f"sandbox_daemon.{name}", str(_DAEMON_DIR / f"{name}.py")
         )
@@ -253,6 +267,51 @@ def _push_request(
     )
 
 
+def _signed_json_request(
+    client: TestClient,
+    *,
+    priv: Ed25519PrivateKey,
+    endpoint_path: str,
+    body: bytes,
+) -> httpx.Response:
+    sha = hashlib.sha256(body).hexdigest()
+    ts = str(int(time.time()))
+    return client.post(
+        endpoint_path,
+        content=body,
+        headers={
+            "Content-Type": "application/json",
+            "X-Push-Signature": _sign(
+                priv,
+                mount_path=endpoint_path,
+                sha256_hex=sha,
+                timestamp=ts,
+            ),
+            "X-Push-Timestamp": ts,
+        },
+    )
+
+
+def _filesystem_list_request(
+    client: TestClient,
+    *,
+    priv: Ed25519PrivateKey,
+    session_id: UUID,
+    path: str = ".",
+) -> httpx.Response:
+    body = (
+        FilesystemListRequest(session_id=session_id, path=path)
+        .model_dump_json()
+        .encode()
+    )
+    return _signed_json_request(
+        client,
+        priv=priv,
+        endpoint_path=SIDECAR_FILESYSTEM_LIST_PATH,
+        body=body,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -262,6 +321,162 @@ def test_health_returns_200(client: TestClient) -> None:
     resp = client.get(SIDECAR_HEALTH_PATH)
     assert resp.status_code == 200
     assert resp.json() == {"status": "ok"}
+
+
+def test_filesystem_list_classifies_symlinks_and_expands_valid_directory(
+    configured_sandbox_daemon: tuple[ModuleType, ModuleType, Ed25519PrivateKey, Path],
+    client: TestClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, _, priv, _ = configured_sandbox_daemon
+    filesystem_mod = sys.modules["sandbox_daemon.filesystem"]
+    sessions_root = tmp_path / "sessions"
+    managed_root = tmp_path / "managed"
+    user_library_link = managed_root / "user_library"
+    user_library_version = managed_root / ".versions" / "user-library"
+    skills_root = managed_root / "skills"
+    monkeypatch.setattr(filesystem_mod, "SESSIONS_ROOT", sessions_root)
+    monkeypatch.setattr(filesystem_mod, "_USER_LIBRARY_LINK_TARGET", user_library_link)
+
+    session_id = UUID("903a9a86-b7b1-4b49-9269-1fe558b243ee")
+    session_root = sessions_root / str(session_id)
+    session_root.mkdir(parents=True)
+    user_library_version.mkdir(parents=True)
+    user_library_link.symlink_to(user_library_version)
+    skills_root.mkdir(parents=True)
+    (session_root / "outputs").mkdir()
+    (session_root / "docs").mkdir()
+    (session_root / "docs" / "readme.md").write_text("# hi\n")
+    (session_root / "data.csv").write_text("a,b\n1,2\n")
+    (user_library_version / "notes.txt").write_text("notes\n")
+    (skills_root / "skill.txt").write_text("private\n")
+    (session_root / "docs_link").symlink_to("docs")
+    (session_root / "link.csv").symlink_to("data.csv")
+    (session_root / "user_library").symlink_to(user_library_link)
+    (session_root / "skills_link").symlink_to(skills_root)
+    (session_root / "managed_link").symlink_to(managed_root)
+
+    resp = _filesystem_list_request(
+        client,
+        priv=priv,
+        session_id=session_id,
+    )
+
+    assert resp.status_code == 200, resp.text
+    entries = {entry["name"]: entry for entry in resp.json()["entries"]}
+    assert entries["outputs"]["is_directory"]
+    assert entries["docs_link"]["is_directory"]
+    assert not entries["link.csv"]["is_directory"]
+    assert entries["user_library"]["is_directory"]
+    assert not entries["skills_link"]["is_directory"]
+    assert not entries["managed_link"]["is_directory"]
+
+    resp = _filesystem_list_request(
+        client,
+        priv=priv,
+        session_id=session_id,
+        path="docs_link",
+    )
+
+    assert resp.status_code == 200, resp.text
+    entries = {entry["name"]: entry for entry in resp.json()["entries"]}
+    assert entries["readme.md"]["path"] == "docs_link/readme.md"
+    assert not entries["readme.md"]["is_directory"]
+
+    resp = _filesystem_list_request(
+        client,
+        priv=priv,
+        session_id=session_id,
+        path="user_library",
+    )
+
+    assert resp.status_code == 200, resp.text
+    entries = {entry["name"]: entry for entry in resp.json()["entries"]}
+    assert entries["notes.txt"]["path"] == "user_library/notes.txt"
+
+    resp = _filesystem_list_request(
+        client,
+        priv=priv,
+        session_id=session_id,
+        path="skills_link",
+    )
+
+    assert resp.status_code == 404
+
+
+def test_filesystem_list_keeps_broken_user_library_link_visible(
+    configured_sandbox_daemon: tuple[ModuleType, ModuleType, Ed25519PrivateKey, Path],
+    client: TestClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, _, priv, _ = configured_sandbox_daemon
+    filesystem_mod = sys.modules["sandbox_daemon.filesystem"]
+    sessions_root = tmp_path / "sessions"
+    managed_root = tmp_path / "managed"
+    user_library_link = managed_root / "user_library"
+    monkeypatch.setattr(filesystem_mod, "SESSIONS_ROOT", sessions_root)
+    monkeypatch.setattr(filesystem_mod, "_USER_LIBRARY_LINK_TARGET", user_library_link)
+
+    session_id = UUID("903a9a86-b7b1-4b49-9269-1fe558b243ee")
+    session_root = sessions_root / str(session_id)
+    session_root.mkdir(parents=True)
+    (session_root / "outputs").mkdir()
+    (session_root / "user_library").symlink_to(user_library_link)
+
+    resp = _filesystem_list_request(
+        client,
+        priv=priv,
+        session_id=session_id,
+    )
+
+    assert resp.status_code == 200, resp.text
+    entries = {entry["name"]: entry for entry in resp.json()["entries"]}
+    assert entries["user_library"]["is_directory"]
+
+    resp = _filesystem_list_request(
+        client,
+        priv=priv,
+        session_id=session_id,
+        path="user_library",
+    )
+
+    assert resp.status_code == 404
+
+
+def test_filesystem_list_rejects_user_library_target_outside_versions(
+    configured_sandbox_daemon: tuple[ModuleType, ModuleType, Ed25519PrivateKey, Path],
+    client: TestClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, _, priv, _ = configured_sandbox_daemon
+    filesystem_mod = sys.modules["sandbox_daemon.filesystem"]
+    sessions_root = tmp_path / "sessions"
+    managed_root = tmp_path / "managed"
+    user_library_link = managed_root / "user_library"
+    outside_root = tmp_path / "outside"
+    monkeypatch.setattr(filesystem_mod, "SESSIONS_ROOT", sessions_root)
+    monkeypatch.setattr(filesystem_mod, "_USER_LIBRARY_LINK_TARGET", user_library_link)
+
+    session_id = UUID("903a9a86-b7b1-4b49-9269-1fe558b243ee")
+    session_root = sessions_root / str(session_id)
+    session_root.mkdir(parents=True)
+    managed_root.mkdir(exist_ok=True)
+    outside_root.mkdir()
+    (outside_root / "secret.txt").write_text("secret\n")
+    user_library_link.symlink_to(outside_root)
+    (session_root / "user_library").symlink_to(user_library_link)
+
+    resp = _filesystem_list_request(
+        client,
+        priv=priv,
+        session_id=session_id,
+        path="user_library",
+    )
+
+    assert resp.status_code == 404
 
 
 def test_push_with_valid_signature_extracts(

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_file_listing.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_file_listing.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from uuid import UUID
+
+import pytest
+
+import onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager as ksm
+from onyx.server.features.build.sandbox.docker.docker_sandbox_manager import (
+    DockerSandboxManager,
+)
+from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager import (
+    KubernetesSandboxManager,
+)
+
+_SANDBOX_ID = UUID("9a5c81d5-931e-4348-b034-3ebd13bcba44")
+_SESSION_ID = UUID("903a9a86-b7b1-4b49-9269-1fe558b243ee")
+
+_ROOT_LS_WITH_DANGLING_SYMLINK = """total 16
+drwxr-sr-x. 4 sandbox sandbox  111 1781733405 .
+drwxrwsrwx. 4 root    sandbox   91 1781733401 ..
+-rw-r--r--. 1 sandbox sandbox 6944 1781733405 AGENTS.md
+drwxr-xr-x. 3 sandbox sandbox   17 1781733401 outputs
+lrwxrwxrwx. 1 sandbox sandbox   31 1781733405 user_library -> /workspace/managed/user_library
+"""
+
+
+def test_kubernetes_list_directory_does_not_follow_child_symlinks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager: KubernetesSandboxManager = object.__new__(KubernetesSandboxManager)
+    manager._namespace = "sandbox-test"  # type: ignore[attr-defined]
+    manager._stream_core_api = SimpleNamespace(  # type: ignore[attr-defined]
+        connect_get_namespaced_pod_exec=object()
+    )
+
+    monkeypatch.setattr(
+        KubernetesSandboxManager,
+        "_get_pod_name",
+        lambda _self, _sandbox_id: "sandbox-9a5c81d5",
+    )
+
+    captured_command: list[str] = []
+
+    def fake_k8s_stream(*_args: Any, **kwargs: Any) -> str:
+        captured_command.extend(kwargs["command"])
+        return _ROOT_LS_WITH_DANGLING_SYMLINK
+
+    monkeypatch.setattr(ksm, "k8s_stream", fake_k8s_stream)
+
+    entries = manager.list_directory(_SANDBOX_ID, _SESSION_ID, ".")
+
+    entry_by_name = {entry.name: entry for entry in entries}
+    assert entry_by_name["outputs"].is_directory
+    assert entry_by_name["user_library"].is_directory
+    assert not entry_by_name["AGENTS.md"].is_directory
+
+    shell_script = " ".join(captured_command)
+    assert "ls -la --time-style=+%s" in shell_script
+    assert "ls -laL" not in shell_script
+    assert '"$target"/' in shell_script
+
+
+def test_docker_parse_ls_treats_workspace_symlinks_as_directories() -> None:
+    manager: DockerSandboxManager = object.__new__(DockerSandboxManager)
+
+    entries = manager._parse_ls_output(_ROOT_LS_WITH_DANGLING_SYMLINK, ".")
+
+    entry_by_name = {entry.name: entry for entry in entries}
+    assert entry_by_name["outputs"].is_directory
+    assert entry_by_name["user_library"].is_directory
+    assert not entry_by_name["AGENTS.md"].is_directory

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_file_listing.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_file_listing.py
@@ -1,73 +1,88 @@
 from __future__ import annotations
 
-from types import SimpleNamespace
-from typing import Any
 from uuid import UUID
 
 import pytest
 
-import onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager as ksm
-from onyx.server.features.build.sandbox.docker.docker_sandbox_manager import (
-    DockerSandboxManager,
-)
 from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager import (
     KubernetesSandboxManager,
 )
+from onyx.server.features.build.sandbox.kubernetes.sidecar_client import (
+    SidecarStatusError,
+)
+from onyx.server.features.build.sandbox.models import FilesystemEntry
 
 _SANDBOX_ID = UUID("9a5c81d5-931e-4348-b034-3ebd13bcba44")
 _SESSION_ID = UUID("903a9a86-b7b1-4b49-9269-1fe558b243ee")
 
-_ROOT_LS_WITH_DANGLING_SYMLINK = """total 16
-drwxr-sr-x. 4 sandbox sandbox  111 1781733405 .
-drwxrwsrwx. 4 root    sandbox   91 1781733401 ..
--rw-r--r--. 1 sandbox sandbox 6944 1781733405 AGENTS.md
-drwxr-xr-x. 3 sandbox sandbox   17 1781733401 outputs
-lrwxrwxrwx. 1 sandbox sandbox   31 1781733405 user_library -> /workspace/managed/user_library
-"""
+
+class _FakeSidecarClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[UUID, UUID, str]] = []
+
+    def list_directory(
+        self,
+        *,
+        sandbox_id: UUID,
+        session_id: UUID,
+        path: str,
+    ) -> list[FilesystemEntry]:
+        self.calls.append((sandbox_id, session_id, path))
+        return [
+            FilesystemEntry(
+                name="outputs",
+                path="outputs",
+                is_directory=True,
+            )
+        ]
 
 
-def test_kubernetes_list_directory_does_not_follow_child_symlinks(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_kubernetes_list_directory_delegates_to_sidecar() -> None:
     manager: KubernetesSandboxManager = object.__new__(KubernetesSandboxManager)
-    manager._namespace = "sandbox-test"  # type: ignore[attr-defined]
-    manager._stream_core_api = SimpleNamespace(  # type: ignore[attr-defined]
-        connect_get_namespaced_pod_exec=object()
-    )
-
-    monkeypatch.setattr(
-        KubernetesSandboxManager,
-        "_get_pod_name",
-        lambda _self, _sandbox_id: "sandbox-9a5c81d5",
-    )
-
-    captured_command: list[str] = []
-
-    def fake_k8s_stream(*_args: Any, **kwargs: Any) -> str:
-        captured_command.extend(kwargs["command"])
-        return _ROOT_LS_WITH_DANGLING_SYMLINK
-
-    monkeypatch.setattr(ksm, "k8s_stream", fake_k8s_stream)
+    sidecar_client = _FakeSidecarClient()
+    manager._sidecar_client = sidecar_client  # type: ignore[attr-defined]
 
     entries = manager.list_directory(_SANDBOX_ID, _SESSION_ID, ".")
 
-    entry_by_name = {entry.name: entry for entry in entries}
-    assert entry_by_name["outputs"].is_directory
-    assert entry_by_name["user_library"].is_directory
-    assert not entry_by_name["AGENTS.md"].is_directory
-
-    shell_script = " ".join(captured_command)
-    assert "ls -la --time-style=+%s" in shell_script
-    assert "ls -laL" not in shell_script
-    assert '"$target"/' in shell_script
+    assert sidecar_client.calls == [(_SANDBOX_ID, _SESSION_ID, ".")]
+    assert entries == [
+        FilesystemEntry(name="outputs", path="outputs", is_directory=True)
+    ]
 
 
-def test_docker_parse_ls_treats_workspace_symlinks_as_directories() -> None:
-    manager: DockerSandboxManager = object.__new__(DockerSandboxManager)
+def test_kubernetes_list_directory_maps_sidecar_not_found() -> None:
+    class NotFoundSidecarClient:
+        def list_directory(self, **_kwargs: object) -> list[FilesystemEntry]:
+            raise SidecarStatusError(
+                "filesystem list",
+                404,
+                '{"detail":"path not found or not a directory"}',
+            )
 
-    entries = manager._parse_ls_output(_ROOT_LS_WITH_DANGLING_SYMLINK, ".")
+    manager: KubernetesSandboxManager = object.__new__(KubernetesSandboxManager)
+    manager._sidecar_client = NotFoundSidecarClient()  # type: ignore[attr-defined]
 
-    entry_by_name = {entry.name: entry for entry in entries}
-    assert entry_by_name["outputs"].is_directory
-    assert entry_by_name["user_library"].is_directory
-    assert not entry_by_name["AGENTS.md"].is_directory
+    with pytest.raises(ValueError, match="not found or not a directory"):
+        manager.list_directory(_SANDBOX_ID, _SESSION_ID, "missing")
+
+
+@pytest.mark.parametrize(
+    ("status_code", "body"),
+    [
+        (400, '{"detail":"Invalid request body"}'),
+        (404, '{"detail":"Not Found"}'),
+    ],
+)
+def test_kubernetes_list_directory_surfaces_unexpected_sidecar_errors(
+    status_code: int,
+    body: str,
+) -> None:
+    class ErrorSidecarClient:
+        def list_directory(self, **_kwargs: object) -> list[FilesystemEntry]:
+            raise SidecarStatusError("filesystem list", status_code, body)
+
+    manager: KubernetesSandboxManager = object.__new__(KubernetesSandboxManager)
+    manager._sidecar_client = ErrorSidecarClient()  # type: ignore[attr-defined]
+
+    with pytest.raises(RuntimeError, match="Failed to list directory"):
+        manager.list_directory(_SANDBOX_ID, _SESSION_ID, "missing")


### PR DESCRIPTION
## Description

Fixes a Craft restore/file-pane failure where a restored session could have a dangling `user_library` symlink. The session root existed and outputs were restored, but the file browser used `ls -L`, so one broken child symlink caused the entire root listing to fail and the UI showed an empty directory.

Changes:
- Hydrate the user-library mount after session restore, matching fresh session setup.
- List sandbox directories without dereferencing every child symlink, while still allowing explicit navigation into valid symlinked directories.
- Add focused unit coverage for dangling symlink listings and pin restore hydration in the existing lifecycle test.

## How Has This Been Tested?

- `pytest -q backend/tests/unit/onyx/server/features/build/sandbox/test_file_listing.py`
- `ruff check backend/onyx/server/features/build/session/api.py backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py backend/tests/unit/onyx/server/features/build/sandbox/test_file_listing.py backend/tests/external_dependency_unit/craft/test_session_lifecycle.py backend/tests/external_dependency_unit/craft/test_kubernetes_sandbox_file_ops.py`
- `ty check backend/onyx/server/features/build/session/api.py backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py backend/tests/unit/onyx/server/features/build/sandbox/test_file_listing.py backend/tests/external_dependency_unit/craft/test_session_lifecycle.py`
- Local kind smoke via `http://localhost:3000`: logged in as `wenxi@onyx.app`, created a Craft session, temporarily pointed that session's `user_library` symlink at a missing target, confirmed old-style `ls -laL` failed in the sandbox, and confirmed `GET /api/build/sessions/{id}/files?path=` still returned the full root entries. Restored the symlink and deleted the smoke session afterward.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the Craft file pane populated after restore by listing session directories without dereferencing child symlinks and by hydrating the user library. Works across Docker and Kubernetes; symlinked folders stay navigable, file symlinks stay files, and a broken `user_library` no longer blanks the root.

- **Bug Fixes**
  - Added a sandbox sidecar POST endpoint (`/filesystem/list`) that returns entries without following child symlinks, treats the managed `user_library` symlink as a directory (keeps it visible while hydration runs), blocks traversal, and only allows navigation into session-internal symlinked directories or a valid user library.
  - Switched Kubernetes to use the sidecar client for workspace listings and map traversal (400) and not-found (404) to user-facing errors; Docker now runs `ls -la` (no `-L`), requires directories via a trailing slash, classifies only the managed `user_library` symlink as a folder, and links it during setup/regenerate.
  - Hydrates the user library during restore; expanded tests to cover sidecar listings and symlink classification, Kubernetes delegation and error mapping, Docker parsing, and `USER_LIBRARY_MOUNT_PATH` writes.

<sup>Written for commit 0e072cd85f065ffe64c6a41761ed2a519ded361c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

