### PR TITLE
fix(craft): let celery-worker-heavy create sandbox snapshots (NetworkPolicy + push key)

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.6.2
+version: 0.6.3
 appVersion: latest
 annotations:
   category: Productivity
@@ -17,14 +17,9 @@ annotations:
       image: docker.io/onyxdotapp/onyx-backend:latest
   artifacthub.io/changes: |
     - kind: changed
-      description: Default Craft sandbox images to the application chart
-        version and app image pull policy.
-    - kind: changed
-      description: Add isolated writable /tmp scratch space for sandboxed
-        OpenCode agents.
-    - kind: changed
-      description: Preserve Craft opencode history across Kubernetes sandbox
-        restarts by restoring it before opencode starts.
+      description: Allow the heavy Celery worker to reach sandbox sidecars so
+        Craft opencode-history snapshots are created on clusters that enforce
+        NetworkPolicy.
 dependencies:
   - name: cloudnative-pg
     version: 0.26.0

--- a/deployment/helm/charts/onyx/templates/celery-worker-heavy.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-heavy.yaml
@@ -90,6 +90,13 @@ spec:
             {{- end }}
           env:
             {{- include "onyx.envSecrets" . | nindent 12}}
+            {{- /* The heavy worker runs the `sandbox` queue (cleanup_idle_sandboxes →
+                   create_snapshot / create_opencode_history_snapshot). Those POSTs are
+                   signed with ONYX_SANDBOX_PUSH_PRIVATE_KEY, which (with the default
+                   sandboxPushSecret.allPods=false) is only emitted via envSecretsRestricted.
+                   Without it the sidecar client raises before sending and no snapshots are
+                   created. Pairs with the heavy-worker rule in network-policy-sandbox-push. */}}
+            {{- include "onyx.envSecretsRestricted" . | nindent 12}}
             {{- with include "onyx.customCACerts.env" . }}
             {{- . | nindent 12 }}
             {{- end }}

--- a/deployment/helm/charts/onyx/templates/network-policy-sandbox-push.yaml
+++ b/deployment/helm/charts/onyx/templates/network-policy-sandbox-push.yaml
@@ -53,4 +53,23 @@ spec:
         - protocol: TCP
           port: {{ .Values.configMap.SANDBOX_NEXTJS_PORT_START | default 3010 }}
           endPort: {{ sub (int (.Values.configMap.SANDBOX_NEXTJS_PORT_END | default 3100)) 1 }}
+    # The heavy worker consumes the `sandbox` Celery queue (cleanup_idle_sandboxes
+    # → create_snapshot / create_opencode_history_snapshot), which only POSTs to
+    # the in-pod sidecar — it never drives opencode serve or the Next.js dev
+    # servers. Grant it the sidecar port ONLY (least privilege). Without this,
+    # on clusters that ENFORCE NetworkPolicy the heavy worker's snapshot-create
+    # requests are dropped → connect timeout → NO snapshots are created →
+    # reopened sessions restore nothing ("agent starts fresh"). Long-term, move
+    # the `sandbox` queue to a dedicated craft worker and grant that worker here
+    # instead of heavy (see docs/craft/infra/sandbox-worker-network-policy.md).
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ $.Release.Namespace }}
+          podSelector:
+            matchLabels:
+              app: celery-worker-heavy
+      ports:
+        - protocol: TCP
+          port: {{ include "onyx.sandboxPushDaemonPort" . }}
 {{- end }}

--- a/docs/craft/infra/sandbox-worker-network-policy.md
+++ b/docs/craft/infra/sandbox-worker-network-policy.md
@@ -1,0 +1,97 @@
+# Sandbox snapshot worker ↔ NetworkPolicy
+
+How Craft snapshot creation reaches sandbox pods, what access the snapshot worker
+needs, and where this is headed.
+
+## Background
+
+opencode-history and per-session workspace snapshots are created by the
+`cleanup_idle_sandboxes` Celery task, which POSTs to the in-pod **sidecar
+(port 8731)** to produce the archive. That task runs on whichever worker consumes
+the **`sandbox` Celery queue** — currently `celery-worker-heavy`.
+
+Sandbox pods are guarded by the `onyx-sandbox-push` NetworkPolicy
+(`templates/network-policy-sandbox-push.yaml`), which allow-lists who may reach the
+sidecar (`:8731`), opencode serve (`:4096`), and the per-session Next.js dev
+servers. A NetworkPolicy only takes effect on clusters whose CNI enforces
+NetworkPolicies; where it isn't enforced the policy is inert (a pod can reach the
+sidecar even if it isn't allow-listed). Keep the allow-list correct so behavior is
+the same regardless of enforcement.
+
+## Current state (as of 2026-06-17)
+
+The `sandbox` queue runs on `celery-worker-heavy`, so that worker needs sidecar
+access to create snapshots. It is granted a dedicated, least-privilege ingress rule
+(sidecar port only), separate from the full api-server / scheduled-tasks block:
+
+```
+ingress:
+  # api-server + scheduled-tasks (full sandbox driving)
+  - from: [api-server, celery-worker-scheduled-tasks, (ambassador local-dev)]
+    ports: [8731, 4096, 3010–3099]
+  # heavy worker — snapshot creation only
+  - from: [celery-worker-heavy]
+    ports: [8731]
+```
+
+- `api-server` and `celery-worker-scheduled-tasks` drive sandboxes end-to-end
+  (provision, restore, opencode serve, dev-server preview), so they get the full
+  port set.
+- `celery-worker-heavy` only POSTs to the sidecar for snapshot creation, so it gets
+  the sidecar port (`:8731`) only.
+
+Network access alone isn't enough: snapshot POSTs are **signed**
+(`SidecarClient._signed_headers` → `get_push_key_pair`), so the worker also needs
+`ONYX_SANDBOX_PUSH_PRIVATE_KEY`. With the default `sandboxPushSecret.allPods=false`
+that key is emitted only via `onyx.envSecretsRestricted`, so `celery-worker-heavy`
+must include that block (as `api-server` and `celery-worker-scheduled-tasks` do) —
+otherwise `get_push_key_pair` raises before the request is even sent. Both the
+allow-list rule and the restricted secret must point at whatever worker runs the
+`sandbox` queue.
+
+If a cluster enforces NetworkPolicy and the worker that runs the `sandbox` queue is
+not in this allow-list, snapshot creates connect-time-out
+(`Snapshot create request failed: timed out`) and no snapshots are produced — so
+this allow-list must track wherever the `sandbox` queue runs.
+
+## Future direction: a dedicated sandbox/craft worker
+
+`celery-worker-heavy` also runs the heavy connector queues (`connector_pruning`,
+`connector_doc_permissions_sync`, `connector_external_group_sync`,
+`csv_generation`), so Craft snapshotting currently shares a worker with bursty
+connector load. A cleaner setup is a dedicated worker (e.g. `celery-worker-sandbox`)
+that:
+
+- consumes only the `sandbox` queue (isolated from connector/indexing load),
+- is the one granted in `onyx-sandbox-push` (replacing `celery-worker-heavy`),
+- carries the sandbox RBAC, and
+- is sized / HPA'd for bursty snapshot I/O (tar+gzip of webapp source + attachments;
+  `node_modules`/`.next` are excluded, so it's MB-scale, not GB).
+
+That keeps `celery-worker-scheduled-tasks` lean for timely cron dispatch and keeps
+Craft snapshotting off the contended connector worker. When it lands, point the
+`onyx-sandbox-push` allow-list at the new worker instead of heavy.
+
+## NetworkPolicy enforcement is a cluster/CNI concern
+
+Whether NetworkPolicies are enforced at all is a property of the cluster's CNI,
+configured at the infrastructure layer — not something the Onyx app chart can
+toggle. The chart's job is to keep the allow-list correct so the policy behaves the
+same whether or not enforcement is on. Enforcement should be consistent across
+environments so connectivity gaps surface everywhere, not only on enforcing
+clusters.
+
+## Monitoring
+
+`celery-worker-heavy` is the prime suspect when snapshotting breaks:
+
+1. **Connectivity** — if it can't reach the sidecar (allow-list missing it, or
+   enforcement turned on without the allow-list), snapshot creates connect-time-out
+   and no snapshots are produced. Detect: `Snapshot create request failed: timed out`
+   in the heavy worker logs; missing/stale
+   `sandbox-snapshots/.../opencode-history.tar.gz` objects in the file store; or a
+   session's `opencode_session_id` absent from its sandbox snapshot.
+2. **Contention** — heavy also runs the connector queues above; a large connector
+   job can saturate it and starve/slow the `sandbox` sweep. Watch
+   `onyx_celery_task_duration_seconds` / queue wait for the `sandbox` queue and the
+   heavy worker's active-task mix.


### PR DESCRIPTION
## Description

On clusters that **enforce** NetworkPolicy with the **default chart config**, Craft sessions "start fresh" on reopen — no opencode-history snapshot is ever created. The snapshot task (`cleanup_idle_sandboxes` → `create_snapshot` / `create_opencode_history_snapshot`) runs on **`celery-worker-heavy`** and POSTs **signed** requests to the in-pod sidecar (`:8731`). Two things block that on a default deployment:

1. **NetworkPolicy** — `onyx-sandbox-push` only allowed `api-server` and `celery-worker-scheduled-tasks` to reach the sidecar, so the heavy worker's connections were dropped (connect timeout) where NetworkPolicy is enforced.
2. **Signing key** — the POST is signed via `SidecarClient._signed_headers` → `get_push_key_pair`, which needs `ONYX_SANDBOX_PUSH_PRIVATE_KEY`. With `sandboxPushSecret.allPods=false` (default) that key is emitted only via `onyx.envSecretsRestricted`, which `celery-worker-heavy` didn't include — so `get_push_key_pair()` raised before sending.

This PR fixes both:
- Adds a **dedicated, least-privilege** `onyx-sandbox-push` ingress rule granting `celery-worker-heavy` the sidecar port (`:8731`) only.
- Adds `onyx.envSecretsRestricted` to `celery-worker-heavy` so it receives the push key under the default config.
- Adds `docs/craft/infra/sandbox-worker-network-policy.md`, bumps the chart to `0.6.3`, and adds an `artifacthub.io/changes` entry.

Note: this is the app-side fix. A separate infra change enforces NetworkPolicy consistently across clusters; this PR must be deployed before that so enforcement doesn't break snapshotting.

## How Has This Been Tested?

- Root cause confirmed live: from a `celery-worker-heavy` pod on an enforcing cluster, `curl <sidecar>:8731/health` times out; from `api-server` it returns 200. Confirmed the signing path (`request_and_stream_new_snapshot` → `_signed_headers` → `get_push_key_pair`) requires the push key, and that `celery-worker-heavy` lacks `envSecretsRestricted` under default `allPods=false`.
- Chart wiring to be validated by `pr-helm-chart-testing` (ct lint + ct install).
- Behavior fix (snapshot creation succeeds on an enforcing cluster) to be validated by deploying to an enforcing cluster and confirming `Created opencode history snapshot` in the heavy-worker logs + fresh snapshot objects + reopened sessions keeping history.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
