### PR TITLE
fix(admin): prevent clipped action button in admin list header

### DIFF
--- a/web/src/sections/admin/AdminListHeader.tsx
+++ b/web/src/sections/admin/AdminListHeader.tsx
@@ -59,10 +59,14 @@ export default function AdminListHeader({
   onAction,
   actionLabel,
 }: AdminListHeaderProps) {
+  // Pin the button to its label width — the flexible sibling (search input /
+  // empty-state text) absorbs the row shrink; otherwise the button clips its label.
   const actionButton = (
-    <Button rightIcon={SvgPlusCircle} onClick={onAction}>
-      {actionLabel}
-    </Button>
+    <div className="shrink-0">
+      <Button rightIcon={SvgPlusCircle} onClick={onAction}>
+        {actionLabel}
+      </Button>
+    </div>
   );
 
   if (!hasItems) {


### PR DESCRIPTION
## Description

**Bug:** On admin list pages (Service Accounts, Groups, MCP Servers, OpenAPI Actions) the action button's label was clipped — e.g. "New Service Account" rendered as "lew Service Accoun".

**Why:** The button shares a flex row with a full-width search input. When space got tight, flexbox shrank the button below its label width, and the button's `overflow-clip` + centered content clipped the text on both sides.

**Fix:** Wrap the button in a `shrink-0` div so the search input (and empty-state text) absorbs the shrink instead. One change in the shared `AdminListHeader`, so all four admin pages are fixed.

## How Has This Been Tested?

old:

<img width="925" height="278" alt="Screenshot 2026-06-17 at 8 27 25 AM" src="https://github.com/user-attachments/assets/08d40d34-ceb2-40e3-bc01-7ba5a91ca01e" />


now:
<img width="917" height="469" alt="Screenshot 2026-06-17 at 5 33 20 PM" src="https://github.com/user-attachments/assets/6753b478-c128-4190-a895-4b318d015e5c" />


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check