### PR TITLE
fix(chat): surface context-window errors on long threads + overflow guard [v4.2] (#12165)

### DIFF
--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -28,6 +28,7 @@ from onyx.configs.app_configs import INTEGRATION_TESTS_MODE
 from onyx.configs.chat_configs import MAX_LLM_CYCLES
 from onyx.configs.constants import DocumentSource
 from onyx.configs.constants import MessageType
+from onyx.configs.model_configs import GEN_AI_INPUT_TOKEN_SAFETY_MARGIN
 from onyx.context.search.models import SearchDoc
 from onyx.context.search.models import SearchDocsResponse
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
@@ -669,8 +670,11 @@ def run_llm_loop(
             raw_answer=None,
         )
 
-        # Pass the total budget to construct_message_history, which will handle token allocation
-        available_tokens = llm.config.max_input_tokens
+        # Hold back a margin below max_input_tokens: our tiktoken estimate can
+        # undercount the provider's tokenizer and overflow the context window.
+        available_tokens = int(
+            llm.config.max_input_tokens * (1 - GEN_AI_INPUT_TOKEN_SAFETY_MARGIN)
+        )
         tool_choice: ToolChoiceOptions = ToolChoiceOptions.AUTO
         # Initialize gathered_documents with project files if present
         gathered_documents: list[SearchDoc] | None = (

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -1103,6 +1103,9 @@ def _run_models(
     # Set to True when a model raises an exception (distinct from "still running").
     # Used in the stop-button path to avoid calling completion for errored models.
     model_errored: list[bool] = [False] * n_models
+    # Per-model classified (message, error_code, is_retryable), set in _run_model
+    # and reused by the streamed packet and the persisted message.
+    model_error_info: list[tuple[str, str, bool] | None] = [None] * n_models
     persist_lock = threading.Lock()
     persisted: list[bool] = [False] * n_models
     post_steps_done = threading.Event()
@@ -1285,6 +1288,16 @@ def _run_models(
 
         except Exception as e:
             model_errored[model_idx] = True
+            message, error_code, is_retryable = litellm_exception_to_error_msg(
+                e, model_llm, fallback_to_error_msg=True
+            )
+            # Redact here so both the streamed and persisted error are safe:
+            # the fallback path returns str(e) verbatim, which can embed the key.
+            if model_llm.config.api_key and len(model_llm.config.api_key) > 2:
+                message = message.replace(
+                    model_llm.config.api_key, "[REDACTED_API_KEY]"
+                )
+            model_error_info[model_idx] = (message, error_code, is_retryable)
             merged_queue.put((model_idx, e))
 
         finally:
@@ -1299,9 +1312,15 @@ def _run_models(
                     ChatMessage, setup.reserved_messages[model_idx].id
                 )
                 if msg is not None:
-                    error_text = (
-                        "Error from %s: model encountered an error during generation."
-                        % setup.model_display_names[model_idx]
+                    info = model_error_info[model_idx]
+                    detail = (
+                        info[0]
+                        if info is not None
+                        else "model encountered an error during generation."
+                    )
+                    error_text = "Error from %s: %s" % (
+                        setup.model_display_names[model_idx],
+                        detail,
                     )
                     msg.message = error_text
                     msg.error = error_text
@@ -1380,11 +1399,20 @@ def _run_models(
                     # models running. Do NOT decrement models_remaining —
                     # _run_model's finally always posts _MODEL_DONE, which is
                     # the sole completion signal.
-                    error_msg = str(item)
+                    model_llm = setup.llms[model_idx]
+                    # Classified in _run_model; fall back to a generic error.
+                    info = model_error_info[model_idx]
+                    if info is not None:
+                        error_msg, err_code, err_retryable = info
+                    else:
+                        error_msg, err_code, err_retryable = (
+                            str(item),
+                            "MODEL_ERROR",
+                            True,
+                        )
                     stack_trace = "".join(
                         traceback.format_exception(type(item), item, item.__traceback__)
                     )
-                    model_llm = setup.llms[model_idx]
                     if model_llm.config.api_key and len(model_llm.config.api_key) > 2:
                         error_msg = error_msg.replace(
                             model_llm.config.api_key, "[REDACTED_API_KEY]"
@@ -1396,8 +1424,8 @@ def _run_models(
                         StreamingError(
                             error=error_msg,
                             stack_trace=stack_trace,
-                            error_code="MODEL_ERROR",
-                            is_retryable=True,
+                            error_code=err_code,
+                            is_retryable=err_retryable,
                             details={
                                 "model": model_llm.config.model_name,
                                 "provider": model_llm.config.model_provider,

--- a/backend/onyx/configs/model_configs.py
+++ b/backend/onyx/configs/model_configs.py
@@ -70,6 +70,19 @@ GEN_AI_MODEL_FALLBACK_MAX_TOKENS = int(
     os.environ.get("GEN_AI_MODEL_FALLBACK_MAX_TOKENS") or 32000
 )
 
+# Fraction of max_input_tokens to hold back when fitting history: headroom for
+# tiktoken undercounting the provider's tokenizer and overflowing the context.
+GEN_AI_INPUT_TOKEN_SAFETY_MARGIN = float(
+    os.environ.get("GEN_AI_INPUT_TOKEN_SAFETY_MARGIN") or 0.05
+)
+# Must be in [0, 1): >= 1 zeroes available_tokens; negative inflates the budget
+# past the real limit.
+if not 0.0 <= GEN_AI_INPUT_TOKEN_SAFETY_MARGIN < 1.0:
+    raise ValueError(
+        "GEN_AI_INPUT_TOKEN_SAFETY_MARGIN must be in [0, 1), got "
+        f"{GEN_AI_INPUT_TOKEN_SAFETY_MARGIN}"
+    )
+
 # This is used when computing how much context space is available for documents
 # ahead of time in order to let the user know if they can "select" more documents
 # It represents a maximum "expected" number of input tokens from the latest user

--- a/backend/onyx/llm/utils.py
+++ b/backend/onyx/llm/utils.py
@@ -136,7 +136,7 @@ def _unwrap_nested_exception(error: Exception) -> Exception:
 
 def litellm_exception_to_error_msg(
     e: Exception,
-    llm: LLM,
+    llm: LLM | None,
     fallback_to_error_msg: bool = False,
     custom_error_msg_mappings: (
         dict[str, str] | None
@@ -174,7 +174,30 @@ def litellm_exception_to_error_msg(
             if error_msg_pattern in error_msg:
                 return custom_error_msg, "CUSTOM_ERROR", True
 
-    if isinstance(core_exception, BadRequestError):
+    # Both subclass BadRequestError, so they must precede the BadRequestError
+    # branch or they'd be misclassified as BAD_REQUEST.
+    if isinstance(core_exception, ContextWindowExceededError):
+        error_msg = (
+            "Context window exceeded: Your input is too long for the model to process."
+        )
+        if llm is not None:
+            try:
+                max_context = get_max_input_tokens(
+                    model_name=llm.config.model_name,
+                    model_provider=llm.config.model_provider,
+                )
+                error_msg += f" Your invoked model ({llm.config.model_name}) has a maximum context size of {max_context}."
+            except Exception:
+                logger.warning(
+                    "Unable to get maximum input token for LiteLLM exception handling"
+                )
+        error_code = "CONTEXT_TOO_LONG"
+        is_retryable = False
+    elif isinstance(core_exception, ContentPolicyViolationError):
+        error_msg = "Content policy violation: Your request violates the content policy. Please revise your input."
+        error_code = "CONTENT_POLICY"
+        is_retryable = False
+    elif isinstance(core_exception, BadRequestError):
         error_msg = "Bad request: The server couldn't process your request. Please check your input."
         error_code = "BAD_REQUEST"
         is_retryable = True
@@ -261,27 +284,6 @@ def litellm_exception_to_error_msg(
             error_msg = f"{provider_name} service error: {str(core_exception)}"
         error_code = "SERVICE_UNAVAILABLE"
         is_retryable = True
-    elif isinstance(core_exception, ContextWindowExceededError):
-        error_msg = (
-            "Context window exceeded: Your input is too long for the model to process."
-        )
-        if llm is not None:
-            try:
-                max_context = get_max_input_tokens(
-                    model_name=llm.config.model_name,
-                    model_provider=llm.config.model_provider,
-                )
-                error_msg += f" Your invoked model ({llm.config.model_name}) has a maximum context size of {max_context}."
-            except Exception:
-                logger.warning(
-                    "Unable to get maximum input token for LiteLLM exception handling"
-                )
-        error_code = "CONTEXT_TOO_LONG"
-        is_retryable = False
-    elif isinstance(core_exception, ContentPolicyViolationError):
-        error_msg = "Content policy violation: Your request violates the content policy. Please revise your input."
-        error_code = "CONTENT_POLICY"
-        is_retryable = False
     elif isinstance(core_exception, APIConnectionError):
         error_msg = "API connection error: Failed to connect to the API. Please check your internet connection."
         error_code = "CONNECTION_ERROR"

--- a/backend/tests/unit/onyx/chat/test_multi_model_streaming.py
+++ b/backend/tests/unit/onyx/chat/test_multi_model_streaming.py
@@ -15,6 +15,7 @@ from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
+from litellm.exceptions import ContextWindowExceededError
 
 from onyx.chat.models import StreamingError
 from onyx.configs.constants import MessageType
@@ -432,8 +433,38 @@ class TestRunModels:
 
         errors = [p for p in packets if isinstance(p, StreamingError)]
         assert len(errors) == 1
-        assert errors[0].error_code == "MODEL_ERROR"
+        # A generic (non-litellm) worker exception surfaces as UNKNOWN_ERROR
+        # with the original message preserved.
+        assert errors[0].error_code == "UNKNOWN_ERROR"
         assert "intentional test failure" in errors[0].error
+
+    def test_context_window_overflow_surfaces_as_context_too_long(self) -> None:
+        """A provider context-window rejection in a worker surfaces as
+        CONTEXT_TOO_LONG and non-retryable through the _run_model -> drain path."""
+
+        def overflow(**_kwargs: Any) -> None:
+            raise ContextWindowExceededError(
+                "This model's maximum context length is 8192 tokens",
+                model="gpt-4",
+                llm_provider="openai",
+            )
+
+        with (
+            patch("onyx.chat.process_message.run_llm_loop", side_effect=overflow),
+            patch("onyx.chat.process_message.run_deep_research_llm_loop"),
+            patch("onyx.chat.process_message.construct_tools", return_value={}),
+            patch("onyx.chat.process_message.llm_loop_completion_handle"),
+            patch(
+                "onyx.chat.process_message.get_llm_token_counter",
+                return_value=lambda _: 0,
+            ),
+        ):
+            packets = _run_models_collect(_make_setup(n_models=1))
+
+        errors = [p for p in packets if isinstance(p, StreamingError)]
+        assert len(errors) == 1
+        assert errors[0].error_code == "CONTEXT_TOO_LONG"
+        assert errors[0].is_retryable is False
 
     def test_one_model_error_does_not_stop_other_models(self) -> None:
         """A failing model yields StreamingError; the surviving model's packets still arrive."""

--- a/backend/tests/unit/onyx/llm/test_llm_exception_classification.py
+++ b/backend/tests/unit/onyx/llm/test_llm_exception_classification.py
@@ -1,0 +1,33 @@
+"""Guards classification order in litellm_exception_to_error_msg:
+ContextWindowExceededError and ContentPolicyViolationError subclass
+BadRequestError and must be matched first, or context overflow is mislabeled
+BAD_REQUEST instead of CONTEXT_TOO_LONG.
+"""
+
+from litellm.exceptions import BadRequestError
+from litellm.exceptions import ContentPolicyViolationError
+from litellm.exceptions import ContextWindowExceededError
+
+from onyx.llm.utils import litellm_exception_to_error_msg
+
+
+def _err(exc_cls: type[BadRequestError]) -> BadRequestError:
+    return exc_cls("boom", model="m", llm_provider="p")
+
+
+def test_context_window_exceeded_classified_before_bad_request() -> None:
+    _, code, is_retryable = litellm_exception_to_error_msg(
+        _err(ContextWindowExceededError), None
+    )
+    assert code == "CONTEXT_TOO_LONG"
+    assert is_retryable is False
+
+
+def test_content_policy_classified_before_bad_request() -> None:
+    _, code, _ = litellm_exception_to_error_msg(_err(ContentPolicyViolationError), None)
+    assert code == "CONTENT_POLICY"
+
+
+def test_plain_bad_request_still_bad_request() -> None:
+    _, code, _ = litellm_exception_to_error_msg(_err(BadRequestError), None)
+    assert code == "BAD_REQUEST"


### PR DESCRIPTION
- [x] Override Linear Check

## Description

Cherry-pick of #12165 to `release/v4.2`.

Long chat threads could overflow a model's context window and fail with an opaque error ("There was an error with the response" / "model encountered an error during generation"). This backports the three-part fix:

1. **Classifier ordering** (`llm/utils.py`) — `ContextWindowExceededError` / `ContentPolicyViolationError` are matched before their parent `BadRequestError`, so context overflow surfaces as `CONTEXT_TOO_LONG` instead of `BAD_REQUEST`.
2. **Generation-path surfacing** (`chat/process_message.py`) — the per-model worker error is classified (and API-key-redacted at the source) instead of hardcoded to `MODEL_ERROR`; the real code/message flows into both the streamed packet and the persisted message.
3. **Overflow guard** (`chat/llm_loop.py` + `configs/model_configs.py`) — `GEN_AI_INPUT_TOKEN_SAFETY_MARGIN` (default 5%) holds back headroom for tiktoken-vs-provider tokenizer drift.

Clean cherry-pick of `01f9bb4e1d` (no conflicts). Affected unit tests pass (34).

## How Has This Been Tested?

Cherry-pick applied without conflict; `test_multi_model_streaming.py` + `test_llm_exception_classification.py` pass on this branch.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backport to v4.2 that surfaces clear context-window overflow errors in chat and adds a 5% input-token safety margin to prevent overflows. Errors now stream and persist with correct codes instead of a generic model error.

- **Bug Fixes**
  - Classify `ContextWindowExceededError`/`ContentPolicyViolationError` before `BadRequestError`, mapping to `CONTEXT_TOO_LONG`/`CONTENT_POLICY` in `onyx/llm/utils.py`.
  - Propagate per-model classified errors (with API key redaction) through streamed packets and persisted messages in `chat/process_message.py`; generic worker exceptions map to `UNKNOWN_ERROR`.
  - Hold back input tokens by `GEN_AI_INPUT_TOKEN_SAFETY_MARGIN` (env; default 0.05) when fitting history in `llm_loop.py`/`model_configs.py` to avoid provider tokenizer drift.
  - Tests added to guard classification order and verify `CONTEXT_TOO_LONG` surfacing in streaming.

<sup>Written for commit 872b7eb4033d1c908d5f4931a0ae30a3b3207038. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

