### PR TITLE
fix(search): restrict project chat search to project files

### DIFF
--- a/backend/onyx/document_index/FILTER_SEMANTICS.md
+++ b/backend/onyx/document_index/FILTER_SEMANTICS.md
@@ -1,6 +1,8 @@
 # Vector DB Filter Semantics
 
-How `IndexFilters` fields combine into the final query filter. Applies to both Vespa and OpenSearch.
+How `IndexFilters` fields combine into the final query filter. Describes the active
+**OpenSearch** backend. The deprecated **Vespa** backend differs in one respect:
+`project_id_filter` there remains *additive* (see "project_id_filter" notes below).
 
 ## Filter categories
 
@@ -10,8 +12,7 @@ How `IndexFilters` fields combine into the final query filter. Applies to both V
 | **Tenant** | `tenant_id` | AND (multi-tenant only) |
 | **ACL** | `access_control_list` | OR within, AND with rest |
 | **Narrowing** | `source_type`, `tags`, `time_cutoff` | Each OR within, AND with rest |
-| **Knowledge scope** | `document_set`, `attached_document_ids`, `hierarchy_node_ids`, `persona_id_filter` | OR within group, AND with rest |
-| **Additive scope** | `project_id_filter` | OR'd into knowledge scope **only when** a knowledge scope filter already exists |
+| **Knowledge scope** | `document_set`, `attached_document_ids`, `hierarchy_node_ids`, `persona_id_filter`, `project_id_filter` | OR within group, AND with rest |
 
 ## How filters combine
 
@@ -31,22 +32,25 @@ AND time >= cutoff                      -- if set
 
 The knowledge scope filter controls **what knowledge an assistant can access**.
 
-### Primary vs additive triggers
+### Primary triggers
+
+Each of these can start a knowledge scope on its own:
 
 - **`persona_id_filter`** is a **primary** trigger. A persona with user files IS explicit
   knowledge, so `persona_id_filter` alone can start a knowledge scope. Note: this is
   NOT the raw ID of the persona being used — it is only set when the persona's
   user files overflowed the LLM context window.
-- **`project_id_filter`** is **additive**. It widens an existing scope to include project
-  files but never restricts on its own — a chat inside a project should still search
-  team knowledge when no other knowledge is attached.
+- **`project_id_filter`** is a **primary** trigger. A chat inside a project is scoped to
+  that project, so `project_id_filter` alone restricts the search to the project's files —
+  project chats do not search team knowledge. (Deprecated Vespa backend: `project_id_filter`
+  is still *additive* there and only widens an existing scope.)
 
 ### No explicit knowledge attached
 
-When `document_set`, `attached_document_ids`, `hierarchy_node_ids`, and `persona_id_filter` are all empty/None:
+When `document_set`, `attached_document_ids`, `hierarchy_node_ids`, `persona_id_filter`,
+and `project_id_filter` are all empty/None:
 
 - **No knowledge scope filter is applied.** The assistant can see everything (subject to ACL).
-- `project_id_filter` is ignored — it never restricts on its own.
 
 ### One explicit knowledge type
 
@@ -87,14 +91,15 @@ AND (
 )
 ```
 
-### Only project_id_filter (no explicit knowledge)
+### Only project_id_filter (no other explicit knowledge)
 
-No knowledge scope filter. The assistant searches everything.
+The search is restricted to the project's files.
 
 ```
--- Just ACL, no restriction
+-- Restricted to project files
 NOT hidden
 AND (acl contains ...)
+AND (user_project contains 7)
 ```
 
 ## Field reference
@@ -105,7 +110,7 @@ AND (acl contains ...)
 | `attached_document_ids` | `document_id` | `string` | Documents explicitly attached (OpenSearch only) |
 | `hierarchy_node_ids` | `ancestor_hierarchy_node_ids` | `array<int>` | Folder/space nodes (OpenSearch only) |
 | `persona_id_filter` | `personas` | `array<int>` | Persona tag for overflowing user files (**primary** trigger) |
-| `project_id_filter` | `user_project` | `array<int>` | Project tag for overflowing project files (**additive** only) |
+| `project_id_filter` | `user_project` | `array<int>` | Project tag for overflowing project files (**primary** trigger; restricts to project files — OpenSearch. Vespa keeps it additive, see notes) |
 | `access_control_list` | `access_control_list` | `weightedset<string>` | ACL entries for the requesting user |
 | `source_type` | `source_type` | `string` | Connector source type (e.g. `web`, `jira`) |
 | `tags` | `metadata_list` | `array<string>` | Document metadata tags |

--- a/backend/onyx/document_index/opensearch/search.py
+++ b/backend/onyx/document_index/opensearch/search.py
@@ -1226,14 +1226,16 @@ class DocumentQuery:
         # persona_id_filter is a primary trigger — a persona with user files IS
         # explicit knowledge, so it can start a knowledge scope on its own.
         #
-        # project_id_filter is additive — it widens the scope to also cover
-        # overflowing project files but never restricts on its own (a chat
-        # inside a project should still search team knowledge).
+        # project_id_filter is a primary trigger — a chat inside a project is
+        # scoped to that project, so project_id_filter restricts the search to
+        # the project's files on its own (project chats do not search team
+        # knowledge).
         has_knowledge_scope = (
             attached_document_ids
             or hierarchy_node_ids
             or document_sets
             or persona_id_filter is not None
+            or project_id_filter is not None
         )
 
         if has_knowledge_scope:

--- a/backend/tests/external_dependency_unit/opensearch/test_assistant_knowledge_filter.py
+++ b/backend/tests/external_dependency_unit/opensearch/test_assistant_knowledge_filter.py
@@ -14,17 +14,20 @@ from onyx.document_index.opensearch.schema import ANCESTOR_HIERARCHY_NODE_IDS_FI
 from onyx.document_index.opensearch.schema import DOCUMENT_ID_FIELD_NAME
 from onyx.document_index.opensearch.schema import DOCUMENT_SETS_FIELD_NAME
 from onyx.document_index.opensearch.schema import PERSONAS_FIELD_NAME
+from onyx.document_index.opensearch.schema import USER_PROJECTS_FIELD_NAME
 from onyx.document_index.opensearch.search import DocumentQuery
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
 
 ATTACHED_DOCUMENT_ID = "https://docs.google.com/document/d/test-doc-id"
 HIERARCHY_NODE_ID = 42
 PERSONA_ID = 7
+PROJECT_ID = 99
 KNOWLEDGE_FILTER_SCHEMA_FIELDS = {
     DOCUMENT_ID_FIELD_NAME,
     ANCESTOR_HIERARCHY_NODE_IDS_FIELD_NAME,
     DOCUMENT_SETS_FIELD_NAME,
     PERSONAS_FIELD_NAME,
+    USER_PROJECTS_FIELD_NAME,
 }
 
 
@@ -34,6 +37,7 @@ def _get_search_filters(
     hierarchy_node_ids: list[int] | None,
     persona_id_filter: int | None = None,
     document_sets: list[str] | None = None,
+    project_id_filter: int | None = None,
 ) -> list[dict[str, Any]]:
     return DocumentQuery._get_search_filters(
         tenant_state=TenantState(tenant_id=POSTGRES_DEFAULT_SCHEMA, multitenant=False),
@@ -42,7 +46,7 @@ def _get_search_filters(
         source_types=source_types,
         tags=[],
         document_sets=document_sets or [],
-        project_id_filter=None,
+        project_id_filter=project_id_filter,
         persona_id_filter=persona_id_filter,
         time_cutoff=None,
         min_chunk_index=None,
@@ -52,6 +56,31 @@ def _get_search_filters(
         attached_document_ids=attached_document_ids,
         hierarchy_node_ids=hierarchy_node_ids,
     )
+
+
+def _find_knowledge_filter(
+    filter_clauses: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    """Locate the knowledge-scope clause.
+
+    It is the bool/should clause with ``minimum_should_match == 1`` where ANY
+    should-element targets a knowledge field. Scanning every element (not just
+    the first) keeps detection robust to clause reordering — the ACL and
+    time-cutoff clauses use non-knowledge fields, so they are never matched.
+    """
+    for clause in filter_clauses:
+        bool_clause = clause.get("bool")
+        if not isinstance(bool_clause, dict):
+            continue
+        should = bool_clause.get("should")
+        if not should or bool_clause.get("minimum_should_match") != 1:
+            continue
+        for sub in should:
+            for key in ("term", "terms"):
+                field = sub.get(key)
+                if field and next(iter(field), None) in KNOWLEDGE_FILTER_SCHEMA_FIELDS:
+                    return clause
+    return None
 
 
 class TestAssistantKnowledgeFilter:
@@ -68,31 +97,7 @@ class TestAssistantKnowledgeFilter:
             persona_id_filter=PERSONA_ID,
         )
 
-        knowledge_filter = None
-        for clause in filter_clauses:
-            if "bool" in clause and "should" in clause["bool"]:
-                if (
-                    clause["bool"].get("minimum_should_match") == 1
-                    and len(clause["bool"]["should"]) > 0
-                    and (
-                        (
-                            clause["bool"]["should"][0].get("term", {}).keys()
-                            and list(
-                                clause["bool"]["should"][0].get("term", {}).keys()
-                            )[0]
-                            in KNOWLEDGE_FILTER_SCHEMA_FIELDS
-                        )
-                        or (
-                            clause["bool"]["should"][0].get("terms", {}).keys()
-                            and list(
-                                clause["bool"]["should"][0].get("terms", {}).keys()
-                            )[0]
-                            in KNOWLEDGE_FILTER_SCHEMA_FIELDS
-                        )
-                    )
-                ):
-                    knowledge_filter = clause
-                    break
+        knowledge_filter = _find_knowledge_filter(filter_clauses)
 
         assert knowledge_filter is not None, (
             "Expected to find an assistant knowledge filter with "
@@ -121,31 +126,7 @@ class TestAssistantKnowledgeFilter:
             persona_id_filter=PERSONA_ID,
         )
 
-        knowledge_filter = None
-        for clause in filter_clauses:
-            if "bool" in clause and "should" in clause["bool"]:
-                if (
-                    clause["bool"].get("minimum_should_match") == 1
-                    and len(clause["bool"]["should"]) > 0
-                    and (
-                        (
-                            clause["bool"]["should"][0].get("term", {}).keys()
-                            and list(
-                                clause["bool"]["should"][0].get("term", {}).keys()
-                            )[0]
-                            in KNOWLEDGE_FILTER_SCHEMA_FIELDS
-                        )
-                        or (
-                            clause["bool"]["should"][0].get("terms", {}).keys()
-                            and list(
-                                clause["bool"]["should"][0].get("terms", {}).keys()
-                            )[0]
-                            in KNOWLEDGE_FILTER_SCHEMA_FIELDS
-                        )
-                    )
-                ):
-                    knowledge_filter = clause
-                    break
+        knowledge_filter = _find_knowledge_filter(filter_clauses)
 
         assert knowledge_filter is not None, (
             "Expected persona_id_filter alone to create a knowledge scope filter"
@@ -171,31 +152,7 @@ class TestAssistantKnowledgeFilter:
             document_sets=["engineering"],
         )
 
-        knowledge_filter = None
-        for clause in filter_clauses:
-            if "bool" in clause and "should" in clause["bool"]:
-                if (
-                    clause["bool"].get("minimum_should_match") == 1
-                    and len(clause["bool"]["should"]) > 0
-                    and (
-                        (
-                            clause["bool"]["should"][0].get("term", {}).keys()
-                            and list(
-                                clause["bool"]["should"][0].get("term", {}).keys()
-                            )[0]
-                            in KNOWLEDGE_FILTER_SCHEMA_FIELDS
-                        )
-                        or (
-                            clause["bool"]["should"][0].get("terms", {}).keys()
-                            and list(
-                                clause["bool"]["should"][0].get("terms", {}).keys()
-                            )[0]
-                            in KNOWLEDGE_FILTER_SCHEMA_FIELDS
-                        )
-                    )
-                ):
-                    knowledge_filter = clause
-                    break
+        knowledge_filter = _find_knowledge_filter(filter_clauses)
 
         assert knowledge_filter is not None, (
             "Expected knowledge filter when document_sets is provided"
@@ -207,4 +164,89 @@ class TestAssistantKnowledgeFilter:
         )
         assert str(PERSONA_ID) in filter_str, (
             f"Expected persona_id_filter {PERSONA_ID} in knowledge filter"
+        )
+
+    def test_project_id_filter_alone_creates_knowledge_scope(self) -> None:
+        """project_id_filter IS a primary knowledge scope trigger — a chat
+        inside a project is scoped to that project, so project_id_filter alone
+        should restrict the search to the project's files (project chats do not
+        search team knowledge)."""
+        filter_clauses = _get_search_filters(
+            source_types=[],
+            attached_document_ids=None,
+            hierarchy_node_ids=None,
+            project_id_filter=PROJECT_ID,
+        )
+
+        knowledge_filter = _find_knowledge_filter(filter_clauses)
+
+        assert knowledge_filter is not None, (
+            "Expected project_id_filter alone to create a knowledge scope filter "
+            "that restricts search to the project's files"
+        )
+        project_found = any(
+            clause.get("term", {}).get(USER_PROJECTS_FIELD_NAME, {}).get("value")
+            == PROJECT_ID
+            for clause in knowledge_filter["bool"]["should"]
+        )
+        assert project_found, (
+            f"Expected project_id={PROJECT_ID} filter on {USER_PROJECTS_FIELD_NAME} "
+            f"in knowledge scope. Got: {knowledge_filter}"
+        )
+
+    def test_knowledge_filter_with_document_sets_and_project_filter(self) -> None:
+        """document_sets and project_id_filter should be OR'd together in the
+        knowledge scope filter (the default-persona-with-document-sets-in-a-
+        project path) — both participate as a single should-list, widening the
+        scope rather than intersecting."""
+        filter_clauses = _get_search_filters(
+            source_types=[],
+            attached_document_ids=None,
+            hierarchy_node_ids=None,
+            document_sets=["engineering"],
+            project_id_filter=PROJECT_ID,
+        )
+
+        knowledge_filter = _find_knowledge_filter(filter_clauses)
+        assert knowledge_filter is not None, (
+            "Expected knowledge filter when document_sets and project_id_filter "
+            "are both provided"
+        )
+
+        should_clauses = knowledge_filter["bool"]["should"]
+        document_set_found = any(
+            "engineering" in str(clause) for clause in should_clauses
+        )
+        project_found = any(
+            clause.get("term", {}).get(USER_PROJECTS_FIELD_NAME, {}).get("value")
+            == PROJECT_ID
+            for clause in should_clauses
+        )
+        assert document_set_found, (
+            f"Expected document_set 'engineering' OR'd into the knowledge scope. "
+            f"Got: {should_clauses}"
+        )
+        assert project_found, (
+            f"Expected project_id={PROJECT_ID} OR'd into the knowledge scope. "
+            f"Got: {should_clauses}"
+        )
+
+    def test_no_knowledge_scope_when_all_filters_empty(self) -> None:
+        """When no knowledge-scope inputs are set, NO knowledge bool/should
+        clause should be produced — the search is unrestricted (subject to ACL).
+
+        Guards against a regression that would append an empty should-list with
+        ``minimum_should_match: 1`` (which would match nothing)."""
+        filter_clauses = _get_search_filters(
+            source_types=[],
+            attached_document_ids=None,
+            hierarchy_node_ids=None,
+            persona_id_filter=None,
+            document_sets=None,
+            project_id_filter=None,
+        )
+
+        assert _find_knowledge_filter(filter_clauses) is None, (
+            "No knowledge-scope clause should be produced when every knowledge "
+            "input is empty/None"
         )

--- a/backend/tests/external_dependency_unit/opensearch/test_opensearch_client.py
+++ b/backend/tests/external_dependency_unit/opensearch/test_opensearch_client.py
@@ -141,6 +141,8 @@ def _create_test_document_chunk(
     ),
     source_type: DocumentSource = DocumentSource.FILE,
     last_updated: datetime | None = None,
+    user_projects: list[int] | None = None,
+    document_sets: list[str] | None = None,
 ) -> DocumentChunk:
     if content_vector is None:
         # Generate dummy vector - 128 dimensions for fast testing.
@@ -172,8 +174,8 @@ def _create_test_document_chunk(
         blurb="Test blurb",
         doc_summary="Test doc summary",
         chunk_context="Test chunk context",
-        document_sets=None,
-        user_projects=None,
+        document_sets=document_sets,
+        user_projects=user_projects,
         primary_owners=None,
         secondary_owners=None,
         tenant_id=tenant_state,
@@ -1508,6 +1510,187 @@ class TestOpenSearchClient:
         )
         assert results[1].score
         assert results[1].match_highlights.get(CONTENT_FIELD_NAME, [])
+
+    def test_project_id_filter_restricts_search_to_project_files(
+        self,
+        test_client: OpenSearchIndexClient,
+        search_pipeline: None,  # noqa: ARG002
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """End-to-end proof that ``project_id_filter`` restricts search to the
+        project's files.
+
+        Three equally-relevant docs are indexed: a file in the target project, a
+        file in a DIFFERENT project, and a connector doc with no project tag.
+        Searching with ``project_id_filter`` for the target project must return
+        ONLY the target project's file — proving the filter matches by project
+        value (not merely "has any project tag"), and excludes both the other
+        project and untagged connector content.
+        """
+        # Precondition.
+        _patch_global_tenant_state(monkeypatch, False)
+        tenant_state = TenantState(tenant_id=POSTGRES_DEFAULT_SCHEMA, multitenant=False)
+        mappings = DocumentSchema.get_document_schema(
+            vector_dimension=128, multitenant=tenant_state.multitenant
+        )
+        settings = DocumentSchema.get_index_settings_based_on_environment()
+        test_client.create_index(mappings=mappings, settings=settings)
+
+        project_id = 99
+        other_project_id = 100
+        # Three equally-relevant docs distinguished only by their project tag.
+        project_file = _create_test_document_chunk(
+            document_id="project-file",
+            chunk_index=0,
+            content="Quarterly planning notes",
+            content_vector=_generate_test_vector(0.1),
+            tenant_state=tenant_state,
+            user_projects=[project_id],
+        )
+        other_project_file = _create_test_document_chunk(
+            document_id="other-project-file",
+            chunk_index=0,
+            content="Quarterly planning notes",
+            content_vector=_generate_test_vector(0.1),
+            tenant_state=tenant_state,
+            user_projects=[other_project_id],
+        )
+        connector_doc = _create_test_document_chunk(
+            document_id="connector-doc",
+            chunk_index=0,
+            content="Quarterly planning notes",
+            content_vector=_generate_test_vector(0.1),
+            tenant_state=tenant_state,
+            user_projects=None,
+        )
+        for doc in (project_file, other_project_file, connector_doc):
+            test_client.index_document(document=doc, tenant_state=tenant_state)
+        test_client.refresh_index()
+
+        pipeline_name, _ = get_normalization_pipeline_name_and_config()
+        query_text = "quarterly planning notes"
+        query_vector = _generate_test_vector(0.1)
+
+        def _search(index_filters: IndexFilters) -> set[str]:
+            search_body = DocumentQuery.get_hybrid_search_query(
+                query_text=query_text,
+                query_vector=query_vector,
+                num_hits=5,
+                tenant_state=tenant_state,
+                index_filters=index_filters,
+                include_hidden=False,
+            )
+            return {
+                chunk.document_chunk.document_id
+                for chunk in test_client.search(
+                    body=search_body, search_pipeline_id=pipeline_name
+                )
+            }
+
+        # Control: no project filter → all three docs are searchable.
+        unfiltered_ids = _search(IndexFilters(access_control_list=None, tenant_id=None))
+        assert unfiltered_ids == {
+            "project-file",
+            "other-project-file",
+            "connector-doc",
+        }, "All docs should match the query when no project filter is applied"
+
+        # Under test: project_id_filter alone restricts to the target project's
+        # files — excluding both the OTHER project and the untagged connector doc.
+        filtered_ids = _search(
+            IndexFilters(
+                access_control_list=None,
+                tenant_id=None,
+                project_id_filter=project_id,
+            )
+        )
+
+        # Postcondition.
+        assert filtered_ids == {"project-file"}, (
+            "project_id_filter must restrict search to the target project's files "
+            "only; the other project's file and the connector doc must be "
+            f"excluded. Got: {filtered_ids}"
+        )
+
+    def test_project_id_filter_combined_with_document_sets_widens_search(
+        self,
+        test_client: OpenSearchIndexClient,
+        search_pipeline: None,  # noqa: ARG002
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """End-to-end proof that ``project_id_filter`` is OR'd with another
+        knowledge scope rather than intersected.
+
+        With both ``project_id_filter`` and ``document_set`` set (the default
+        persona + document-sets-in-a-project path), the search must return the
+        project's files AND the document-set's docs, while still excluding
+        untagged content.
+        """
+        # Precondition.
+        _patch_global_tenant_state(monkeypatch, False)
+        tenant_state = TenantState(tenant_id=POSTGRES_DEFAULT_SCHEMA, multitenant=False)
+        mappings = DocumentSchema.get_document_schema(
+            vector_dimension=128, multitenant=tenant_state.multitenant
+        )
+        settings = DocumentSchema.get_index_settings_based_on_environment()
+        test_client.create_index(mappings=mappings, settings=settings)
+
+        project_id = 99
+        document_set = "engineering"
+        project_file = _create_test_document_chunk(
+            document_id="project-file",
+            chunk_index=0,
+            content="Quarterly planning notes",
+            content_vector=_generate_test_vector(0.1),
+            tenant_state=tenant_state,
+            user_projects=[project_id],
+        )
+        doc_set_doc = _create_test_document_chunk(
+            document_id="doc-set-doc",
+            chunk_index=0,
+            content="Quarterly planning notes",
+            content_vector=_generate_test_vector(0.1),
+            tenant_state=tenant_state,
+            document_sets=[document_set],
+        )
+        untagged_doc = _create_test_document_chunk(
+            document_id="untagged-doc",
+            chunk_index=0,
+            content="Quarterly planning notes",
+            content_vector=_generate_test_vector(0.1),
+            tenant_state=tenant_state,
+        )
+        for doc in (project_file, doc_set_doc, untagged_doc):
+            test_client.index_document(document=doc, tenant_state=tenant_state)
+        test_client.refresh_index()
+
+        pipeline_name, _ = get_normalization_pipeline_name_and_config()
+        search_body = DocumentQuery.get_hybrid_search_query(
+            query_text="quarterly planning notes",
+            query_vector=_generate_test_vector(0.1),
+            num_hits=5,
+            tenant_state=tenant_state,
+            index_filters=IndexFilters(
+                access_control_list=None,
+                tenant_id=None,
+                project_id_filter=project_id,
+                document_set=[document_set],
+            ),
+            include_hidden=False,
+        )
+        result_ids = {
+            chunk.document_chunk.document_id
+            for chunk in test_client.search(
+                body=search_body, search_pipeline_id=pipeline_name
+            )
+        }
+
+        # Postcondition: project files OR document-set docs, but not untagged.
+        assert result_ids == {"project-file", "doc-set-doc"}, (
+            "project_id_filter combined with document_set must OR (widen) — "
+            "returning both the project file and the document-set doc, while "
+            f"excluding untagged content. Got: {result_ids}"
+        )
 
     def test_hybrid_search_with_pipeline_and_filters_returns_chunks_with_related_content_first(
         self,

--- a/backend/tests/unit/onyx/chat/test_context_files.py
+++ b/backend/tests/unit/onyx/chat/test_context_files.py
@@ -605,3 +605,41 @@ class TestSearchFilterDetermination:
             extracted_context_files=self._make_context(),
         )
         assert result.search_usage == SearchToolUsage.DISABLED
+
+    def test_persona_and_project_filters_are_mutually_exclusive(self) -> None:
+        """persona_id_filter and project_id_filter must never both be set.
+
+        The two are knowledge-scope triggers for different ownership models
+        (custom-persona files vs. project files); the precedence rule routes to
+        exactly one. This invariant guards against a future refactor of the
+        if/else in determine_search_params silently setting both — which would
+        OR a custom persona's files together with project files.
+        """
+        scenarios = [
+            # (persona_id, project_id, use_as_search_filter)
+            (42, 99, True),  # custom persona in a project, files overflow
+            (42, 99, False),  # custom persona in a project, files fit
+            (42, None, True),  # custom persona, no project, files overflow
+            (DEFAULT_PERSONA_ID, 99, True),  # default persona, project overflow
+            (DEFAULT_PERSONA_ID, 99, False),  # default persona, project fits
+            (DEFAULT_PERSONA_ID, None, True),  # default persona, no project
+        ]
+        for persona_id, project_id, overflow in scenarios:
+            result = determine_search_params(
+                persona_id=persona_id,
+                project_id=project_id,
+                extracted_context_files=self._make_context(
+                    use_as_search_filter=overflow,
+                    uncapped_token_count=7000 if overflow else 100,
+                ),
+            )
+            assert not (
+                result.persona_id_filter is not None
+                and result.project_id_filter is not None
+            ), (
+                "persona_id_filter and project_id_filter must never both be set "
+                f"(persona_id={persona_id}, project_id={project_id}, "
+                f"overflow={overflow}): got persona_id_filter="
+                f"{result.persona_id_filter}, project_id_filter="
+                f"{result.project_id_filter}"
+            )


### PR DESCRIPTION
## Description

- Chats inside a Project now search only that Project's files — they no longer surface connector / team-knowledge docs (OpenSearch backend).
- When a Project chat also has document sets in scope, those are still included; the change only removes the unintended "search everything" case.
- Documents the intentional backend divergence: the deprecated Vespa backend keeps its prior (additive) behavior.

## How Has This Been Tested?

- Added unit and real-OpenSearch tests (project-only exclusion by value, OR-widening with document sets, no-scope, and persona/project mutual-exclusivity); all affected suites pass.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check