### PR TITLE
feat(settings): add 60 days chat retention option

### DIFF
--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -1009,6 +1009,9 @@ export default function ChatPreferencesPage() {
                             <InputSelect.Item value="30">
                               30 days
                             </InputSelect.Item>
+                            <InputSelect.Item value="60">
+                              60 days
+                            </InputSelect.Item>
                             <InputSelect.Item value="90">
                               90 days
                             </InputSelect.Item>


### PR DESCRIPTION
## Description

Adds a **60 days** preset to the Chat History retention dropdown on the admin **Chat Preferences** page (`web/src/refresh-pages/admin/ChatPreferencesPage.tsx`).

A customer asked to align chat retention with their org policy (60 days), which the existing dropdown (Forever / 7 / 30 / 90 / 365) didn't offer.

This is frontend-only — the backend already accepts arbitrary retention durations:
- `maximum_chat_retention_days` is stored as `float | None` (`backend/onyx/server/settings/models.py`)
- The settings API only gates on the Enterprise tier, with no preset-only validation (`backend/onyx/server/settings/api.py`)
- The TTL cleanup task reads whatever value is stored (`backend/ee/onyx/background/celery/tasks/ttl_management/tasks.py`)

Selecting "60 days" persists `maximum_chat_retention_days: 60` and works end-to-end with no backend change.

## How Has This Been Tested?

No automated tests added — this is a single static dropdown option. The save handler (`parseInt`) and the value round-trip (`s.maximum_chat_retention_days?.toString()`) already handle this value identically to the other presets.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check