### PR TITLE
[v4.2 cherry-pick] feat(settings): add 60 days chat retention option

### DIFF
--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -1009,6 +1009,9 @@ export default function ChatPreferencesPage() {
                             <InputSelect.Item value="30">
                               30 days
                             </InputSelect.Item>
+                            <InputSelect.Item value="60">
+                              60 days
+                            </InputSelect.Item>
                             <InputSelect.Item value="90">
                               90 days
                             </InputSelect.Item>


### PR DESCRIPTION
## Description

Cherry-pick of #12186 onto `release/v4.2`.

Adds a **60 days** preset to the Chat History retention dropdown on the admin **Chat Preferences** page (`web/src/refresh-pages/admin/ChatPreferencesPage.tsx`). Customer request to align chat retention with their org policy.

Frontend-only — the backend already accepts arbitrary retention durations (`maximum_chat_retention_days` is `float | None`, no preset-only validation). Cherry-pick applied cleanly with an identical diff to the main PR.

## How Has This Been Tested?

No automated tests — single static dropdown option, handled identically to the existing presets. Same change as #12186.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cherry-pick to `release/v4.2`: add a 60-day preset to the Chat History retention dropdown on the admin Chat Preferences page. Frontend-only change; the backend already supports arbitrary retention durations.

<sup>Written for commit 5cbe2c08d856106a821d676330184d2759c12d57. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

