### PR TITLE
[v4.1 cherry-pick] feat(settings): add 60 days chat retention option

### DIFF
--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -1009,6 +1009,9 @@ export default function ChatPreferencesPage() {
                             <InputSelect.Item value="30">
                               30 days
                             </InputSelect.Item>
+                            <InputSelect.Item value="60">
+                              60 days
+                            </InputSelect.Item>
                             <InputSelect.Item value="90">
                               90 days
                             </InputSelect.Item>


### PR DESCRIPTION
## Description

Cherry-pick of #12186 onto `release/v4.1`.

Adds a **60 days** preset to the Chat History retention dropdown on the admin **Chat Preferences** page (`web/src/refresh-pages/admin/ChatPreferencesPage.tsx`). Customer request to align chat retention with their org policy.

Frontend-only — the backend already accepts arbitrary retention durations (`maximum_chat_retention_days` is `float | None`, no preset-only validation). Cherry-pick applied cleanly with an identical diff to the main PR.

## How Has This Been Tested?

No automated tests — single static dropdown option, handled identically to the existing presets. Same change as #12186.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a 60 days option to the Chat History retention dropdown on the admin Chat Preferences page to match common org policies. Frontend-only change; the backend already supports arbitrary retention durations.

<sup>Written for commit 06b4350d379e2600b867c900679971cb496293f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

