### PR TITLE
feat(settings): add custom chat retention duration option

### DIFF
--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -469,11 +469,11 @@ function RetentionField({ value, disabled, onSave }: RetentionFieldProps) {
           <InputSelect.Item value={FOREVER_RETENTION_VALUE}>
             Forever
           </InputSelect.Item>
-          <InputSelect.Item value="7">7 days</InputSelect.Item>
-          <InputSelect.Item value="30">30 days</InputSelect.Item>
-          <InputSelect.Item value="60">60 days</InputSelect.Item>
-          <InputSelect.Item value="90">90 days</InputSelect.Item>
-          <InputSelect.Item value="365">365 days</InputSelect.Item>
+          {RETENTION_PRESETS.map((d) => (
+            <InputSelect.Item key={d} value={String(d)}>
+              {d} days
+            </InputSelect.Item>
+          ))}
           <InputSelect.Item value={CUSTOM_RETENTION_VALUE}>
             Custom…
           </InputSelect.Item>

--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -379,6 +379,19 @@ const MAX_RETENTION_DAYS = 36500; // ~100 years
 const CUSTOM_RETENTION_VALUE = "custom";
 const FOREVER_RETENTION_VALUE = "forever";
 
+// Pure predicate — lives at module scope so it can be referenced inside
+// useEffect without an exhaustive-deps suppression.
+const valueIsCustomRetention = (v: number | null): v is number =>
+  v !== null && !RETENTION_PRESETS.includes(v);
+
+// True only when the string is one or more digits within the allowed range.
+// parseInt alone would silently accept "1.5" → 1 or "7abc" → 7, so guard with
+// a digits-only check before persisting.
+const isValidCustomRetention = (raw: string): boolean =>
+  /^\d+$/.test(raw) &&
+  parseInt(raw, 10) > 0 &&
+  parseInt(raw, 10) <= MAX_RETENTION_DAYS;
+
 interface RetentionFieldProps {
   value: number | null;
   disabled: boolean;
@@ -390,12 +403,9 @@ interface RetentionFieldProps {
 // <InputSelect>; the persisted shape (number | null) is unchanged, so any
 // existing value — preset or not — round-trips correctly.
 function RetentionField({ value, disabled, onSave }: RetentionFieldProps) {
-  const valueIsCustom = (v: number | null): v is number =>
-    v !== null && !RETENTION_PRESETS.includes(v);
-
-  const [showCustom, setShowCustom] = useState(valueIsCustom(value));
+  const [showCustom, setShowCustom] = useState(valueIsCustomRetention(value));
   const [customDays, setCustomDays] = useState(
-    valueIsCustom(value) ? String(value) : ""
+    valueIsCustomRetention(value) ? String(value) : ""
   );
 
   // Re-sync when the stored value changes externally (e.g. another admin),
@@ -404,9 +414,9 @@ function RetentionField({ value, disabled, onSave }: RetentionFieldProps) {
   useEffect(() => {
     if (value === lastSavedRef.current) return;
     lastSavedRef.current = value;
-    setShowCustom(valueIsCustom(value));
-    setCustomDays(valueIsCustom(value) ? String(value) : "");
-  }, [value]); // eslint-disable-line react-hooks/exhaustive-deps
+    setShowCustom(valueIsCustomRetention(value));
+    setCustomDays(valueIsCustomRetention(value) ? String(value) : "");
+  }, [value]);
 
   const selectValue = showCustom
     ? CUSTOM_RETENTION_VALUE
@@ -431,28 +441,21 @@ function RetentionField({ value, disabled, onSave }: RetentionFieldProps) {
   };
 
   const handleCustomBlur = () => {
-    const parsed = parseInt(customDays, 10);
-    const isValid =
-      !isNaN(parsed) && parsed > 0 && parsed <= MAX_RETENTION_DAYS;
-
     // Empty/invalid input reverts to the last persisted selection.
-    if (!isValid) {
-      setShowCustom(valueIsCustom(value));
-      setCustomDays(valueIsCustom(value) ? String(value) : "");
+    if (!isValidCustomRetention(customDays)) {
+      setShowCustom(valueIsCustomRetention(value));
+      setCustomDays(valueIsCustomRetention(value) ? String(value) : "");
       return;
     }
 
+    const parsed = parseInt(customDays, 10);
     const normalized = String(parsed);
     if (normalized !== customDays) setCustomDays(normalized);
     if (parsed !== value) persist(parsed);
   };
 
-  const parsedCustom = parseInt(customDays, 10);
   const customInvalid =
-    customDays !== "" &&
-    (isNaN(parsedCustom) ||
-      parsedCustom <= 0 ||
-      parsedCustom > MAX_RETENTION_DAYS);
+    customDays !== "" && !isValidCustomRetention(customDays);
 
   return (
     <div className="flex flex-col gap-2 w-full">

--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -370,6 +370,142 @@ function FileSizeLimitFields({
   );
 }
 
+// Retention presets offered directly in the dropdown. Any other (positive)
+// value is surfaced via the "Custom…" option. The backend stores
+// maximum_chat_retention_days as a free-form number, so these are purely UI.
+const RETENTION_PRESETS: number[] = [7, 30, 60, 90, 365];
+// FE-only guard: the backend imposes no upper bound, so cap absurd input.
+const MAX_RETENTION_DAYS = 36500; // ~100 years
+const CUSTOM_RETENTION_VALUE = "custom";
+const FOREVER_RETENTION_VALUE = "forever";
+
+interface RetentionFieldProps {
+  value: number | null;
+  disabled: boolean;
+  onSave: (value: number | null) => void;
+}
+
+// Chat-retention control: a preset dropdown plus a "Custom…" option that
+// reveals a numeric "days" input. Drop-in replacement for the bare
+// <InputSelect>; the persisted shape (number | null) is unchanged, so any
+// existing value — preset or not — round-trips correctly.
+function RetentionField({ value, disabled, onSave }: RetentionFieldProps) {
+  const valueIsCustom = (v: number | null): v is number =>
+    v !== null && !RETENTION_PRESETS.includes(v);
+
+  const [showCustom, setShowCustom] = useState(valueIsCustom(value));
+  const [customDays, setCustomDays] = useState(
+    valueIsCustom(value) ? String(value) : ""
+  );
+
+  // Re-sync when the stored value changes externally (e.g. another admin),
+  // but only when our local state matches the last value we persisted.
+  const lastSavedRef = useRef(value);
+  useEffect(() => {
+    if (value === lastSavedRef.current) return;
+    lastSavedRef.current = value;
+    setShowCustom(valueIsCustom(value));
+    setCustomDays(valueIsCustom(value) ? String(value) : "");
+  }, [value]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const selectValue = showCustom
+    ? CUSTOM_RETENTION_VALUE
+    : value === null
+      ? FOREVER_RETENTION_VALUE
+      : String(value);
+
+  const persist = (next: number | null) => {
+    lastSavedRef.current = next;
+    onSave(next);
+  };
+
+  const handleSelectChange = (next: string) => {
+    if (next === CUSTOM_RETENTION_VALUE) {
+      // Reveal the input; don't persist until a valid number is entered.
+      setShowCustom(true);
+      return;
+    }
+    setShowCustom(false);
+    setCustomDays("");
+    persist(next === FOREVER_RETENTION_VALUE ? null : parseInt(next, 10));
+  };
+
+  const handleCustomBlur = () => {
+    const parsed = parseInt(customDays, 10);
+    const isValid =
+      !isNaN(parsed) && parsed > 0 && parsed <= MAX_RETENTION_DAYS;
+
+    // Empty/invalid input reverts to the last persisted selection.
+    if (!isValid) {
+      setShowCustom(valueIsCustom(value));
+      setCustomDays(valueIsCustom(value) ? String(value) : "");
+      return;
+    }
+
+    const normalized = String(parsed);
+    if (normalized !== customDays) setCustomDays(normalized);
+    if (parsed !== value) persist(parsed);
+  };
+
+  const parsedCustom = parseInt(customDays, 10);
+  const customInvalid =
+    customDays !== "" &&
+    (isNaN(parsedCustom) ||
+      parsedCustom <= 0 ||
+      parsedCustom > MAX_RETENTION_DAYS);
+
+  return (
+    <div className="flex flex-col gap-2 w-full">
+      <InputSelect
+        value={selectValue}
+        onValueChange={handleSelectChange}
+        disabled={disabled}
+      >
+        <InputSelect.Trigger />
+        <InputSelect.Content>
+          <InputSelect.Item value={FOREVER_RETENTION_VALUE}>
+            Forever
+          </InputSelect.Item>
+          <InputSelect.Item value="7">7 days</InputSelect.Item>
+          <InputSelect.Item value="30">30 days</InputSelect.Item>
+          <InputSelect.Item value="60">60 days</InputSelect.Item>
+          <InputSelect.Item value="90">90 days</InputSelect.Item>
+          <InputSelect.Item value="365">365 days</InputSelect.Item>
+          <InputSelect.Item value={CUSTOM_RETENTION_VALUE}>
+            Custom…
+          </InputSelect.Item>
+        </InputSelect.Content>
+      </InputSelect>
+
+      {showCustom && (
+        <div className="flex flex-col gap-1 w-full">
+          <InputTypeIn
+            inputMode="numeric"
+            pattern="[0-9]*"
+            placeholder="Enter number of days"
+            value={customDays}
+            onChange={(e) => setCustomDays(e.target.value)}
+            onBlur={handleCustomBlur}
+            variant={
+              disabled ? "disabled" : customInvalid ? "error" : undefined
+            }
+            rightChildren={
+              <Text font="secondary-body" color="text-03">
+                days
+              </Text>
+            }
+          />
+          {customInvalid && (
+            <Text font="secondary-body" color="text-03">
+              {`Enter a whole number of days between 1 and ${MAX_RETENTION_DAYS}.`}
+            </Text>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export default function ChatPreferencesPage() {
   const router = useRouter();
   const settings = useSettings();
@@ -983,43 +1119,13 @@ export default function ChatPreferencesPage() {
                         disabled={!enterpriseTier}
                         withLabel
                       >
-                        <InputSelect
-                          value={
-                            s.maximum_chat_retention_days?.toString() ??
-                            "forever"
-                          }
-                          onValueChange={(value) => {
-                            void saveSettings({
-                              maximum_chat_retention_days:
-                                value === "forever"
-                                  ? null
-                                  : parseInt(value, 10),
-                            });
-                          }}
+                        <RetentionField
+                          value={s.maximum_chat_retention_days ?? null}
                           disabled={!enterpriseTier}
-                        >
-                          <InputSelect.Trigger />
-                          <InputSelect.Content>
-                            <InputSelect.Item value="forever">
-                              Forever
-                            </InputSelect.Item>
-                            <InputSelect.Item value="7">
-                              7 days
-                            </InputSelect.Item>
-                            <InputSelect.Item value="30">
-                              30 days
-                            </InputSelect.Item>
-                            <InputSelect.Item value="60">
-                              60 days
-                            </InputSelect.Item>
-                            <InputSelect.Item value="90">
-                              90 days
-                            </InputSelect.Item>
-                            <InputSelect.Item value="365">
-                              365 days
-                            </InputSelect.Item>
-                          </InputSelect.Content>
-                        </InputSelect>
+                          onSave={(maximum_chat_retention_days) =>
+                            void saveSettings({ maximum_chat_retention_days })
+                          }
+                        />
                       </InputHorizontal>
                     </Disabled>
 


### PR DESCRIPTION
## Description

Adds a **Custom…** option to the Chat History retention dropdown on the admin **Chat Preferences** page. Selecting it reveals a numeric **days** input, so admins can set any retention period to match their org policy — not just the presets.

This is a follow-up to #12186 (which added a 60-day preset); a customer asked for arbitrary durations. Putting it up so we can align on the UX before finalizing.

### Approach

Implemented as a self-contained `RetentionField` component that **drop-in replaces** the bare `<InputSelect>`. Frontend-only and backward compatible:

- The persisted shape (`maximum_chat_retention_days: number | null`) is **unchanged** — the backend already stores it as a free-form `float | None` with no preset validation, and the TTL cleanup task reads it raw. No backend/API/migration work.
- Any existing value round-trips correctly. A non-preset value (e.g. set via API) previously rendered **blank** in the trigger; it now displays under **Custom…**, so this also fixes a latent display gap.
- The `RetentionField` is the only place in the FE that interprets the value — every other reference treats it as `number | null`.
<img width="856" height="226" alt="Screenshot 2026-06-18 at 10 09 23 AM" src="https://github.com/user-attachments/assets/0d1d34b7-fa7d-468f-b54f-69255ad0d430" />

### Behavior / decisions to confirm

- **Presets retained** (Forever / 7 / 30 / 60 / 90 / 365) for one-click use, with **Custom…** added at the bottom. (Alternative: drop presets for a pure numeric field — happy to change.)
- **Save-on-blur** for the custom input; selecting "Custom…" does **not** persist until a valid number is entered, so the stored value isn't wiped mid-edit.
- **FE guard:** positive whole number, capped at **36500 days** (~100 years; the backend has no upper bound). Invalid/empty input reverts to the last saved value and shows an inline hint.
- **Enterprise-tier gating** is carried through to the numeric input.

## How Has This Been Tested?

Manual verification (the diff is FE-only and self-contained):
- `tsc --noEmit` — clean (exit 0, 0 errors).
- `oxfmt --check` and `oxlint` on the file — clean.
- Logic traced for the key paths: preset↔custom switching, blur with invalid/empty input (reverts), external value re-sync, and that selecting "Custom…" defers persistence.

No automated tests added (consistent with the existing untested presets). Happy to add a Playwright e2e if we want coverage on the save round-trip — flagging as an open question.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Custom…” option to Chat History retention on the admin Chat Preferences page so admins can set any number of days. Presets remain; change is frontend-only and backward compatible.

- **New Features**
  - Introduced `RetentionField` that replaces the select and reveals a numeric days input when “Custom…” is chosen.
  - Persists `maximum_chat_retention_days` as-is (`number | null`); non-preset values now display under “Custom…”.
  - Save-on-blur with digits-only validation for positive whole numbers up to 36,500; invalid input reverts with an inline hint.
  - Enterprise-tier gating applies to the numeric input.

- **Refactors**
  - Rendered retention presets via a map over `RETENTION_PRESETS`.
  - Hoisted helper predicates to module scope for cleaner effects and consistent external value sync.

<sup>Written for commit 609e68303c35f6d7e68ed986670ef2198c0e6180. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



