### PR TITLE
ci: avoid buildx setup in sandbox prepare job

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1344,10 +1344,6 @@ jobs:
             DOCKER_TOKEN, deploy/docker-token
           parse-json-secrets: true
 
-      - name: Set up Docker Buildx
-        if: needs.determine-builds.outputs.is-test-run != 'true' && vars.DOCKER_NO_CACHE != 'true'
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # ratchet:docker/setup-buildx-action@v4
-
       - name: Login to Docker Hub
         if: needs.determine-builds.outputs.is-test-run != 'true' && vars.DOCKER_NO_CACHE != 'true'
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121


### PR DESCRIPTION
## Description

Remove the Docker Buildx setup step from `prepare-sandbox` in the tag deployment workflow.

`prepare-sandbox` only computes the sandbox context tag and checks whether the registry already has that image. It runs on `ubuntu-slim`, where the Docker CLI is present but the Docker daemon is not. Initializing Buildx therefore fails before the registry-only image existence check can run.

## How Has This Been Tested?


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the Buildx setup step from the `prepare-sandbox` job to avoid failures on ubuntu-slim, which lacks a Docker daemon. This lets the job compute the sandbox tag and check the registry for the image without error.

<sup>Written for commit 398bedf194ecb693f2100569f30b6d576cbc3104. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

