### PR TITLE
fix(chat): give pre-tool narration and tool calls distinct placement

### DIFF
--- a/backend/onyx/chat/llm_step.py
+++ b/backend/onyx/chat/llm_step.py
@@ -376,6 +376,7 @@ def _extract_tool_call_kickoffs(
     turn_index: int,
     tab_index: int | None = None,
     sub_turn_index: int | None = None,
+    tab_index_start: int = 0,
 ) -> list[ToolCallKickoff]:
     """Extract ToolCallKickoff objects from the tool call map.
 
@@ -387,9 +388,10 @@ def _extract_tool_call_kickoffs(
         turn_index: The turn index for this set of tool calls
         tab_index: If provided, use this tab_index for all tool calls (otherwise auto-increment)
         sub_turn_index: The sub-turn index for nested tool calls
+        tab_index_start: First auto-assigned tab_index (default 0).
     """
     tool_calls: list[ToolCallKickoff] = []
-    tab_index_calculated = 0
+    tab_index_calculated = tab_index_start
     for tool_call_data in id_to_tool_call_map.values():
         if tool_call_data.get("id") and tool_call_data.get("name"):
             tool_args = _parse_tool_args_to_dict(tool_call_data.get("arguments"))
@@ -1381,11 +1383,16 @@ def run_llm_step_pkt_generator(
                 for tool_call_delta in flush_delta.tool_calls:
                     _update_tool_call_with_delta(id_to_tool_call_map, tool_call_delta)
 
+        # Narration emitted before these tool calls occupies the base tab; start
+        # tool calls at the next tab so they render as their own group instead of
+        # merging with the narration (which would hide them in the chat area).
+        tab_index_start = 1 if (answer_start and not use_existing_tab_index) else 0
         tool_calls = _extract_tool_call_kickoffs(
             id_to_tool_call_map=id_to_tool_call_map,
             turn_index=turn_index,
             tab_index=tab_index if use_existing_tab_index else None,
             sub_turn_index=sub_turn_index,
+            tab_index_start=tab_index_start,
         )
         # Run the flush + recovery below while the span is still open, so the
         # span output recorded afterward reflects the answer the user received.

--- a/backend/tests/unit/onyx/chat/test_narration_tool_placement.py
+++ b/backend/tests/unit/onyx/chat/test_narration_tool_placement.py
@@ -1,0 +1,115 @@
+"""Regression test for the "disappearing search step" bug.
+
+When the model narrates AND calls a tool in the same LLM cycle (e.g.
+"Let me search Zendesk first." followed by an internal_search call), the
+narration streams as the assistant message and the tool call is extracted as a
+kickoff. Both must NOT share the same (turn_index, tab_index): the frontend
+buckets packets by that pair and routes a bucket whose first packet is a
+message to the chat area, which swallows the tool's timeline step.
+
+The fix (onyx/chat/llm_step.py) shifts the tool call to the next tab_index when
+pre-tool answer content was emitted, so it forms its own render group.
+"""
+
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from onyx.chat.llm_step import run_llm_step_pkt_generator
+from onyx.llm.interfaces import ToolChoiceOptions
+from onyx.llm.model_response import ChatCompletionDeltaToolCall
+from onyx.llm.model_response import Delta
+from onyx.llm.model_response import FunctionCall
+from onyx.llm.model_response import ModelResponseStream
+from onyx.llm.model_response import StreamingChoice
+from onyx.server.query_and_chat.placement import Placement
+from onyx.server.query_and_chat.streaming_models import AgentResponseDelta
+from onyx.server.query_and_chat.streaming_models import AgentResponseStart
+
+
+def _chunk(delta: Delta) -> ModelResponseStream:
+    return ModelResponseStream(id="c", created="0", choice=StreamingChoice(delta=delta))
+
+
+def _narration_then_tool_stream() -> Iterator[ModelResponseStream]:
+    # 1) The model narrates before acting -> streamed as answer content.
+    yield _chunk(Delta(content="Let me search Zendesk first."))
+    # 2) ...then, in the SAME cycle, it calls the search tool.
+    yield _chunk(
+        Delta(
+            tool_calls=[
+                ChatCompletionDeltaToolCall(
+                    id="call_1",
+                    index=0,
+                    function=FunctionCall(name="internal_search", arguments=""),
+                )
+            ]
+        )
+    )
+    yield _chunk(
+        Delta(
+            tool_calls=[
+                ChatCompletionDeltaToolCall(
+                    index=0,
+                    id=None,
+                    function=FunctionCall(name=None, arguments='{"queries": ["x"]}'),
+                )
+            ]
+        )
+    )
+
+
+def _make_llm() -> MagicMock:
+    llm = MagicMock()
+    llm.config.model_name = "test-model"
+    llm.config.model_provider = "openai"
+    llm.config.api_base = None
+    llm.stream.return_value = _narration_then_tool_stream()
+    return llm
+
+
+def _drive() -> tuple[list[Any], Any]:
+    """Run the streaming step and return (emitted_packets, LlmStepResult)."""
+    gen = run_llm_step_pkt_generator(
+        history=[],
+        tool_definitions=[],
+        tool_choice=ToolChoiceOptions.AUTO,
+        llm=_make_llm(),
+        placement=Placement(turn_index=1, tab_index=0),
+        state_container=None,
+        citation_processor=None,
+    )
+    packets: list[Any] = []
+    result: Any = None
+    try:
+        while True:
+            packets.append(next(gen))
+    except StopIteration as stop:
+        result, _has_reasoned = stop.value
+    return packets, result
+
+
+@patch("onyx.chat.llm_step.translate_history_to_llm_format", return_value=[])
+def test_narration_and_tool_call_get_distinct_tabs(_translate: MagicMock) -> None:
+    packets, result = _drive()
+
+    # The narration streamed as the assistant message at the cycle's base tab.
+    narration = [
+        p
+        for p in packets
+        if isinstance(p.obj, (AgentResponseStart, AgentResponseDelta))
+    ]
+    assert narration, "expected the model's narration to stream as answer content"
+    narration_turn = narration[0].placement.turn_index
+    assert all(p.placement.tab_index == 0 for p in narration)
+
+    # The tool call must land in its own render group: same turn, distinct tab.
+    assert result.tool_calls is not None and len(result.tool_calls) == 1
+    tool_placement = result.tool_calls[0].placement
+    assert tool_placement.turn_index == narration_turn
+    assert tool_placement.tab_index == 1, (
+        "tool call collided with the narration's placement (same turn_index AND "
+        "tab_index) — the frontend would route the shared group to the chat area "
+        "and the search step would never render in the timeline"
+    )


### PR DESCRIPTION
## Problem

When the model emits **answer content *and* a tool call in the same LLM cycle** (e.g. an agent that narrates "Let me search Zendesk first." and then calls `internal_search`), both inherited the same placement: `turn_index=N, tab_index=0`.

The frontend buckets packets by `(turn_index, tab_index)` and routes each bucket based on its **first** packet — a message → chat area, a tool → thinking timeline. Because the narration's `message_start` came first, the whole bucket (search packets included) was routed to the chat area and rendered by the message renderer, which ignores tool packets. **The search step silently disappeared from the timeline.**

Reasoning never hit this because it already carves its own turn (`_close_reasoning_if_active → _increment_turns`); answer-before-tool had no equivalent, so it collided.

Example internal search is ran but nothing is displayed. You can also see the pre-ample speaking leaking into the main chat
<img width="954" height="575" alt="Screenshot 2026-06-18 at 10 53 14 AM" src="https://github.com/user-attachments/assets/c385aafc-caaf-44c4-b038-c3ffbdf98476" />


## Fix

In `run_llm_step_pkt_generator`, when pre-tool answer content was emitted in the cycle, start the tool calls' auto `tab_index` at `1` instead of `0`. The narration stays at `(N, 0)` → chat area; the tool lands at `(N, 1)` → its own group → timeline.

Replay-safe: the persisted `ToolCallInfo.tab_index` is read from this same kickoff placement (`llm_loop.py` → `session_loading.py`), so live streaming and page reload reconstruct identically. `turn_index` is untouched. Gated on `answer_start` (false in the deep-research/reasoning path) and `not use_existing_tab_index` (leaves nested agent calls alone); tool-only and final-answer cycles are unaffected.

## Test

`backend/tests/unit/onyx/chat/test_narration_tool_placement.py` drives the real streaming step with a fake LLM emitting narration-then-tool-call and asserts the tool call lands on a distinct `tab_index` (same `turn_index`). Verified to fail before the fix (`assert 0 == 1`) and pass after. Pure unit test, no external services.


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the “disappearing tool step” when narration and a tool call happen in the same LLM cycle by giving them different tab placements. Tool steps now reliably show up in the thinking timeline.

- **Bug Fixes**
  - In `run_llm_step_pkt_generator`, start auto tool-call `tab_index` at 1 when pre-tool narration streamed in the same cycle; narration stays at `(N,0)`, tools at `(N,1)`.
  - Added `tab_index_start` to `_extract_tool_call_kickoffs` and gated logic on `answer_start` and `not use_existing_tab_index`; `turn_index` unchanged and replay-safe; added regression test `backend/tests/unit/onyx/chat/test_narration_tool_placement.py`.

<sup>Written for commit 5668cdc4a9b8c7c70efe61d6f98b265f259da498. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

