### PR TITLE
feat(settings): re-expose temperature control toggle in admin chat preferences

### DIFF
--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -776,6 +776,20 @@ export default function ChatPreferencesPage() {
                   }}
                 />
               </InputHorizontal>
+              <InputHorizontal
+                title="Temperature Control"
+                description="Let users adjust the temperature (creativity) of model responses from the model picker in chat."
+                withLabel
+              >
+                <Switch
+                  checked={s.temperature_override_enabled ?? false}
+                  onCheckedChange={(checked) => {
+                    void saveSettings({
+                      temperature_override_enabled: checked,
+                    });
+                  }}
+                />
+              </InputHorizontal>
             </Section>
           </Card>
 


### PR DESCRIPTION
## Description

The temperature override feature is fully implemented end-to-end — backend setting (`Settings.temperature_override_enabled`), the `PATCH /api/temperature-override-enabled` endpoint, the `UserProvider` workspace→user merge, and the temperature slider in the model-picker popover all still exist. The only thing missing is the UI control to turn it on.

It used to be a per-user `Enable Temperature Override` switch (introduced in #3867), but that switch was dropped during the 2025 settings-page refactors. Since then the setting defaults to off with **no way to enable it short of calling the settings API directly**, so the chat temperature slider never appears.

This adds a workspace-level **Temperature Control** toggle to the admin Chat Preferences page, mirroring the existing **Chat Auto-Scroll** toggle and wired to the same `temperature_override_enabled` setting via `saveSettings`. When an admin enables it, it cascades to all users through the existing user-preference merge (`user pref ?? workspace ?? false`), restoring the temperature slider in the model picker.

## How Has This Been Tested?

- `tsc --noEmit` passes (0 errors); pre-commit (oxlint, oxfmt, type check) passes.
- Manually traced the wiring: the toggle writes `temperature_override_enabled` via the existing `PUT /api/admin/settings`; `UserProvider` already merges the workspace value into `user.preferences`, which is what gates the slider in the model-selector popover.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-exposes temperature control by adding a workspace-level “Temperature Control” toggle in Admin → Chat Preferences. Enabling it lets users adjust model temperature in the chat model picker.

- **New Features**
  - Added toggle mirroring Chat Auto-Scroll, wired to `temperature_override_enabled` via `saveSettings`.
  - Cascades to all users through the existing workspace→user merge, restoring the temperature slider.

<sup>Written for commit c77781d8438bf89a6c50f639bce67b4e3d0d76cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

