### PR TITLE
feat(branding): cherry-pick `logoUrl` derivation to release/v4.1 (#12159)

### DIFF
--- a/web/src/refresh-components/Logo.tsx
+++ b/web/src/refresh-components/Logo.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useMemo } from "react";
 import { useSettingsContext } from "@/providers/SettingsProvider";
 import {
   DEFAULT_LOGO_SIZE_PX,
@@ -8,7 +9,6 @@ import {
 import { cn } from "@opal/utils";
 import Text from "@/refresh-components/texts/Text";
 import Truncated from "@/refresh-components/texts/Truncated";
-import { useMemo } from "react";
 import { SvgOnyxLogo, SvgOnyxLogoTyped } from "@opal/logos";
 
 export interface LogoProps {
@@ -28,19 +28,14 @@ export default function Logo({
 }: LogoProps) {
   const resolvedSize = size ?? DEFAULT_LOGO_SIZE_PX;
   const settings = useSettingsContext();
-  const logoDisplayStyle = settings.enterpriseSettings?.logo_display_style;
-  const applicationName = settings.enterpriseSettings?.application_name;
-
-  // Cache-buster: the logo URL never changes (/api/enterprise-settings/logo)
-  // so the browser serves the in-memory cached image even after an admin
-  // uploads a new one. Generating a fresh timestamp each time enterprise
-  // settings are revalidated by SWR appends a unique query param to force
-  // the browser to re-fetch the image.
-  const logoBuster = useMemo(
-    () => Date.now(),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [settings.enterpriseSettings]
-  );
+  const enterpriseSettings = settings.enterpriseSettings;
+  const logoDisplayStyle = enterpriseSettings?.logo_display_style;
+  const applicationName = enterpriseSettings?.application_name;
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const logoBuster = useMemo(() => Date.now(), [enterpriseSettings]);
+  const logoUrl = enterpriseSettings?.use_custom_logo
+    ? `/api/enterprise-settings/logo?v=${logoBuster}`
+    : null;
 
   if (onyxBranded) {
     return folded ? (
@@ -50,7 +45,7 @@ export default function Logo({
     );
   }
 
-  const logo = settings.enterpriseSettings?.use_custom_logo ? (
+  const logo = logoUrl ? (
     <div
       className={cn(
         "aspect-square rounded-full overflow-hidden relative shrink-0",
@@ -61,7 +56,7 @@ export default function Logo({
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
         alt="Logo"
-        src={`/api/enterprise-settings/logo?v=${logoBuster}`}
+        src={logoUrl}
         className="object-cover object-center w-full h-full"
       />
     </div>
@@ -83,7 +78,7 @@ export default function Logo({
               <Truncated headingH3>{applicationName}</Truncated>
             )}
             {!NEXT_PUBLIC_DO_NOT_USE_TOGGLE_OFF_DANSWER_POWERED &&
-              !settings.enterpriseSettings?.hide_onyx_branding && (
+              !enterpriseSettings?.hide_onyx_branding && (
                 <Text
                   secondaryBody
                   text03


### PR DESCRIPTION
## Description

Cherry-pick of commit `f74788ac3ee7efec528efd8ecdf52f4a8ec2f635` (PR #12159) onto `release/v4.1`.

Derives `logoUrl` (including a cache-buster that regenerates when enterprise settings are revalidated) and uses it in `DynamicMetadata.tsx` and `Logo.tsx` to avoid stale favicon/logo images after an admin uploads a new logo.

Conflict resolution notes:
- `interfaces/settings.ts`: Kept v4.1's `CombinedSettings` fields; discarded the commit's `AppSettings` additions (those belong in `lib/settings/types.ts` which doesn't exist in v4.1)
- `lib/settings/hooks.ts`: Kept deleted — `useSettings()` doesn't exist in v4.1; `logoUrl` is computed inline instead
- `DynamicMetadata.tsx`: Kept `useSettingsContext` + inline `cacheBuster`/`favicon` computation (functionally equivalent)
- `Logo.tsx`: Kept `useSettingsContext` + `logoBuster` but also derived `logoUrl` from it to match the commit's `src={logoUrl}` on the img tag

## How Has This Been Tested?

- TypeScript type check (`bun run types:check`) passes cleanly with zero errors
- Pre-commit hooks (oxfmt, oxlint, TypeScript) all pass

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents stale custom logos by deriving a cache-busted `logoUrl` in v4.1 and using it in the UI so new uploads show immediately.

- **Bug Fixes**
  - In `Logo.tsx`, memoize a timestamp tied to `enterpriseSettings` and build `logoUrl` (`/api/enterprise-settings/logo?v=...`) only when `use_custom_logo` is enabled.
  - Use `logoUrl` for the image `src` and simplify references via a local `enterpriseSettings`.

<sup>Written for commit 3ffabd25e875273053f7e60b7a9e4e02e90ffd89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

