### PR TITLE
fix(craft): send tenant_id to PostHog so Craft flags can target one tenant

### DIFF
--- a/backend/onyx/server/features/build/rate_limit.py
+++ b/backend/onyx/server/features/build/rate_limit.py
@@ -8,9 +8,10 @@ from typing import Literal
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
+from onyx.configs.app_configs import AUTH_TYPE
+from onyx.configs.constants import AuthType
 from onyx.db.models import User
 from onyx.feature_flags.factory import get_default_feature_flag_provider
-from onyx.feature_flags.interface import NoOpFeatureFlagProvider
 from onyx.server.features.build.configs import CRAFT_PAID_USER_RATE_LIMIT
 from onyx.server.features.build.db.rate_limit import count_user_messages_in_window
 from onyx.server.features.build.db.rate_limit import count_user_messages_total
@@ -38,8 +39,9 @@ def _should_skip_rate_limiting(user: User) -> bool:
     """
     Check if rate limiting should be skipped for this user.
 
-    Currently grants unlimited usage to dev tenant users (tenant_dev).
-    Controlled via PostHog feature flag.
+    Grants unlimited usage to tenants/users whose `craft-has-usage-limits`
+    PostHog flag is off (e.g. tenant_dev). Only reached on Onyx Cloud, where
+    PostHog is configured.
 
     Returns:
         True to skip rate limiting (unlimited), False to apply normal limits
@@ -51,17 +53,11 @@ def _should_skip_rate_limiting(user: User) -> bool:
     feature_flag_provider = get_default_feature_flag_provider()
     # Flag returns True for users who SHOULD be rate limited
     # We negate to get: True = skip rate limiting
-    if isinstance(feature_flag_provider, NoOpFeatureFlagProvider):
-        has_rate_limit = feature_flag_provider.feature_enabled(
-            CRAFT_HAS_USAGE_LIMITS,
-            user.id,
-        )
-    else:
-        has_rate_limit = feature_flag_provider.feature_enabled_for_user_tenant(
-            CRAFT_HAS_USAGE_LIMITS,
-            user,
-            get_current_tenant_id(),
-        )
+    has_rate_limit = feature_flag_provider.feature_enabled_for_user_tenant(
+        CRAFT_HAS_USAGE_LIMITS,
+        user,
+        get_current_tenant_id(),
+    )
     return not has_rate_limit
 
 
@@ -72,14 +68,13 @@ def get_user_rate_limit_status(
     """
     Get the rate limit status for a user.
 
-    Rate limits:
-        - Cloud (MULTI_TENANT=true):
-            - Subscribed users: CRAFT_PAID_USER_RATE_LIMIT messages per week
-              (configurable, default 25)
-            - Non-subscribed users: 5 messages (lifetime total)
-            - Per-user overrides via PostHog feature flag
-        - Self-hosted (MULTI_TENANT=false):
-            - Unlimited (no rate limiting)
+    Rate limits apply on Onyx Cloud only:
+        - Subscribed users: CRAFT_PAID_USER_RATE_LIMIT messages per week
+          (configurable, default 25)
+        - Non-subscribed users: 5 messages (lifetime total)
+        - Per-tenant/user overrides via the `craft-has-usage-limits` PostHog flag
+
+    All non-cloud deployments (self-hosted, managed) are unlimited.
 
     Args:
         user: The authenticated user
@@ -88,8 +83,9 @@ def get_user_rate_limit_status(
     Returns:
         RateLimitResponse with current limit status
     """
-    # Self-hosted deployments have no rate limits
-    if not MULTI_TENANT:
+    # Rate limits apply only on Onyx Cloud (multi-tenant); all other deployments
+    # are unlimited.
+    if not MULTI_TENANT or AUTH_TYPE != AuthType.CLOUD:
         return RateLimitResponse(
             is_limited=False,
             limit_type="weekly",

--- a/backend/onyx/server/features/build/rate_limit.py
+++ b/backend/onyx/server/features/build/rate_limit.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 
 from onyx.db.models import User
 from onyx.feature_flags.factory import get_default_feature_flag_provider
+from onyx.feature_flags.interface import NoOpFeatureFlagProvider
 from onyx.server.features.build.configs import CRAFT_PAID_USER_RATE_LIMIT
 from onyx.server.features.build.db.rate_limit import count_user_messages_in_window
 from onyx.server.features.build.db.rate_limit import count_user_messages_total
@@ -49,14 +50,18 @@ def _should_skip_rate_limiting(user: User) -> bool:
 
     feature_flag_provider = get_default_feature_flag_provider()
     # Flag returns True for users who SHOULD be rate limited
-    # We negate to get: True = skip rate limiting.
-    # Pass tenant in the person properties so the flag can be targeted at a
-    # specific tenant (e.g. grant unlimited usage to tenant_dev).
-    has_rate_limit = feature_flag_provider.feature_enabled_for_user_tenant(
-        CRAFT_HAS_USAGE_LIMITS,
-        user,
-        get_current_tenant_id(),
-    )
+    # We negate to get: True = skip rate limiting
+    if isinstance(feature_flag_provider, NoOpFeatureFlagProvider):
+        has_rate_limit = feature_flag_provider.feature_enabled(
+            CRAFT_HAS_USAGE_LIMITS,
+            user.id,
+        )
+    else:
+        has_rate_limit = feature_flag_provider.feature_enabled_for_user_tenant(
+            CRAFT_HAS_USAGE_LIMITS,
+            user,
+            get_current_tenant_id(),
+        )
     return not has_rate_limit
 
 

--- a/backend/onyx/server/features/build/rate_limit.py
+++ b/backend/onyx/server/features/build/rate_limit.py
@@ -17,6 +17,7 @@ from onyx.server.features.build.db.rate_limit import get_oldest_message_timestam
 from onyx.server.features.build.subscription_check import is_user_subscribed
 from onyx.server.features.build.utils import CRAFT_HAS_USAGE_LIMITS
 from shared_configs.configs import MULTI_TENANT
+from shared_configs.contextvars import get_current_tenant_id
 
 # Default limit for free/non-subscribed users (not configurable)
 FREE_USER_RATE_LIMIT = 5
@@ -48,10 +49,13 @@ def _should_skip_rate_limiting(user: User) -> bool:
 
     feature_flag_provider = get_default_feature_flag_provider()
     # Flag returns True for users who SHOULD be rate limited
-    # We negate to get: True = skip rate limiting
-    has_rate_limit = feature_flag_provider.feature_enabled(
+    # We negate to get: True = skip rate limiting.
+    # Pass tenant in the person properties so the flag can be targeted at a
+    # specific tenant (e.g. grant unlimited usage to tenant_dev).
+    has_rate_limit = feature_flag_provider.feature_enabled_for_user_tenant(
         CRAFT_HAS_USAGE_LIMITS,
-        user.id,
+        user,
+        get_current_tenant_id(),
     )
     return not has_rate_limit
 

--- a/backend/onyx/server/features/build/utils.py
+++ b/backend/onyx/server/features/build/utils.py
@@ -13,6 +13,7 @@ from onyx.feature_flags.interface import NoOpFeatureFlagProvider
 from onyx.server.features.build.configs import ENABLE_CRAFT
 from onyx.server.features.build.configs import MAX_UPLOAD_FILE_SIZE_BYTES
 from onyx.utils.logger import setup_logger
+from shared_configs.contextvars import get_current_tenant_id
 
 logger = setup_logger()
 
@@ -126,10 +127,12 @@ def is_onyx_craft_enabled(user: User) -> bool:
     if isinstance(feature_flag_provider, NoOpFeatureFlagProvider):
         return ENABLE_CRAFT
 
-    # Use the feature flag provider
-    is_enabled = feature_flag_provider.feature_enabled(
+    # Evaluate with the user's tenant in the person properties so the flag can
+    # be targeted at a specific tenant (e.g. enable Craft only for tenant_dev).
+    is_enabled = feature_flag_provider.feature_enabled_for_user_tenant(
         ONYX_CRAFT_ENABLED_FLAG,
-        user.id,
+        user,
+        get_current_tenant_id(),
     )
 
     if is_enabled:

--- a/backend/onyx/server/features/build/utils.py
+++ b/backend/onyx/server/features/build/utils.py
@@ -127,8 +127,6 @@ def is_onyx_craft_enabled(user: User) -> bool:
     if isinstance(feature_flag_provider, NoOpFeatureFlagProvider):
         return ENABLE_CRAFT
 
-    # Evaluate with the user's tenant in the person properties so the flag can
-    # be targeted at a specific tenant (e.g. enable Craft only for tenant_dev).
     is_enabled = feature_flag_provider.feature_enabled_for_user_tenant(
         ONYX_CRAFT_ENABLED_FLAG,
         user,

--- a/backend/tests/unit/onyx/server/features/build/test_feature_gate.py
+++ b/backend/tests/unit/onyx/server/features/build/test_feature_gate.py
@@ -23,26 +23,32 @@ from onyx.server.features.build.utils import is_onyx_craft_enabled
 
 
 class _StubPostHogProvider(FeatureFlagProvider):
-    """A non-NoOp provider that returns a fixed answer for the craft flag."""
+    """A non-NoOp provider that returns a fixed answer for the craft flag.
+
+    Inherits the base `feature_enabled_for_user_tenant`, which is the method the
+    gate calls — so `calls` captures the `user_properties` (including
+    `tenant_id`) that get forwarded to PostHog.
+    """
 
     def __init__(self, enabled: bool) -> None:
         self._enabled = enabled
-        self.calls: list[tuple[str, UUID]] = []
+        self.calls: list[tuple[str, UUID, dict[str, Any] | None]] = []
 
     def feature_enabled(
         self,
         flag_key: str,
         user_id: UUID,
-        user_properties: dict[str, Any] | None = None,  # noqa: ARG002
+        user_properties: dict[str, Any] | None = None,
     ) -> bool:
-        self.calls.append((flag_key, user_id))
+        self.calls.append((flag_key, user_id, user_properties))
         return self._enabled
 
 
 def _make_user() -> MagicMock:
-    """Build a minimal stand-in for `User` - only `.id` is read."""
+    """Build a minimal stand-in for `User` - only `.id` and `.email` are read."""
     user = MagicMock()
     user.id = uuid4()
+    user.email = "user@tenant-dev.example"
     return user
 
 
@@ -70,6 +76,15 @@ def test_enabled_via_env_when_no_flag_provider(
         "get_default_feature_flag_provider",
         lambda: NoOpFeatureFlagProvider(),
     )
+    # The env/NoOp path must not touch the tenant contextvar, which can raise
+    # in multi-tenant mode when no tenant is set.
+    monkeypatch.setattr(
+        build_utils,
+        "get_current_tenant_id",
+        lambda: pytest.fail(
+            "get_current_tenant_id should not be called on the env path"
+        ),
+    )
 
     assert is_onyx_craft_enabled(_make_user()) is True
 
@@ -77,6 +92,7 @@ def test_enabled_via_env_when_no_flag_provider(
 def test_posthog_flag_overrides_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """A real provider's verdict wins regardless of ENABLE_CRAFT."""
     monkeypatch.setattr(build_utils, "ENABLE_CRAFT", False)
+    monkeypatch.setattr(build_utils, "get_current_tenant_id", lambda: "tenant_dev")
     provider = _StubPostHogProvider(enabled=True)
     monkeypatch.setattr(
         build_utils, "get_default_feature_flag_provider", lambda: provider
@@ -84,5 +100,33 @@ def test_posthog_flag_overrides_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
     user = _make_user()
     assert is_onyx_craft_enabled(user) is True
-    # The provider was consulted with the craft-enabled flag key for this user.
-    assert provider.calls == [("onyx-craft-enabled", user.id)]
+    # The provider was consulted with the craft-enabled flag key for this user,
+    # and the current tenant was forwarded as a person property so the flag can
+    # be targeted per-tenant.
+    assert provider.calls == [
+        (
+            "onyx-craft-enabled",
+            user.id,
+            {"tenant_id": "tenant_dev", "email": "user@tenant-dev.example"},
+        )
+    ]
+
+
+def test_posthog_flag_disables_when_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A real provider returning False disables Craft even if ENABLE_CRAFT=True."""
+    monkeypatch.setattr(build_utils, "ENABLE_CRAFT", True)
+    monkeypatch.setattr(build_utils, "get_current_tenant_id", lambda: "tenant_other")
+    provider = _StubPostHogProvider(enabled=False)
+    monkeypatch.setattr(
+        build_utils, "get_default_feature_flag_provider", lambda: provider
+    )
+
+    user = _make_user()
+    assert is_onyx_craft_enabled(user) is False
+    assert provider.calls == [
+        (
+            "onyx-craft-enabled",
+            user.id,
+            {"tenant_id": "tenant_other", "email": "user@tenant-dev.example"},
+        )
+    ]

--- a/backend/tests/unit/onyx/server/features/build/test_feature_gate.py
+++ b/backend/tests/unit/onyx/server/features/build/test_feature_gate.py
@@ -100,9 +100,7 @@ def test_posthog_flag_overrides_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
     user = _make_user()
     assert is_onyx_craft_enabled(user) is True
-    # The provider was consulted with the craft-enabled flag key for this user,
-    # and the current tenant was forwarded as a person property so the flag can
-    # be targeted per-tenant.
+    # The provider was consulted with the craft-enabled flag key for this user.
     assert provider.calls == [
         (
             "onyx-craft-enabled",


### PR DESCRIPTION
## Description

Onyx Craft is gated by the PostHog flag `onyx-craft-enabled`, and per-user usage limits by `craft-has-usage-limits`. Both checks evaluated their flags with **only the user's UUID and no person properties**, so PostHog never received a `tenant_id`. As a result a flag could not be targeted at a single tenant — enabling Craft (or unlimited usage) for `tenant_dev` would have required flipping the flag on for every individual user UUID. This blocks rolling Craft out to just one tenant.

This PR routes both checks through the existing (previously-unused) `FeatureFlagProvider.feature_enabled_for_user_tenant(flag, user, tenant_id)` helper, passing `get_current_tenant_id()`. That forwards `{tenant_id, email}` to PostHog as person properties, so a flag can now be scoped with a condition like `tenant_id = tenant_dev`.

- `backend/onyx/server/features/build/utils.py` — `is_onyx_craft_enabled`
- `backend/onyx/server/features/build/rate_limit.py` — `_should_skip_rate_limiting` (its docstring already states it "grants unlimited usage to dev tenant users (tenant_dev)", which this makes actually work)

The gate remains **fail-closed** (no client / `None` / exception → `False`), and the NoOp/env (`ENABLE_CRAFT`) fallback path is unchanged and never touches the tenant contextvar.

> Follow-up (config, not code): in the PostHog `onyx-craft-enabled` flag, add a release condition `tenant_id = tenant_dev`. The property is now sent on every evaluation, so the condition will match.

## How Has This Been Tested?

`backend/tests/unit/onyx/server/features/build/test_feature_gate.py` (4 tests, all passing):
- env/NoOp disable + enable paths (and a guard that the env path does **not** call `get_current_tenant_id`)
- PostHog flag overrides env, asserting `tenant_id` + email are forwarded as person properties
- PostHog flag returning `False` disables Craft even when `ENABLE_CRAFT=True`

Also ran `pre-commit` on all changed files: `ty` (type check), `ruff`, `ruff format`, secrets — all pass.

### Known minor items (for reviewer; not fixed here)
- `interface.feature_enabled_for_user_tenant` sends `email` as well as `tenant_id` to PostHog. Only `tenant_id` is needed for tenant targeting; dropping `email` would minimize PII egress. Left as-is since it's an existing helper-level behavior, out of this diff's scope.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send `tenant_id` to PostHog when evaluating Craft flags so we can target a single tenant. Also gate Craft rate limits to Onyx Cloud only; self-hosted and managed deployments are unlimited.

- **Bug Fixes**
  - Evaluate `is_onyx_craft_enabled` via `feature_enabled_for_user_tenant(..., get_current_tenant_id())`.
  - Evaluate `_should_skip_rate_limiting` the same way; rate limits apply only when `MULTI_TENANT` and `AUTH_TYPE == CLOUD`.
  - Forward `tenant_id` (and email) as person properties to PostHog.
  - Per-tenant unlimited usage now works (e.g., `tenant_dev`).

- **Migration**
  - In PostHog, add a release condition to `onyx-craft-enabled` and/or `craft-has-usage-limits`: `tenant_id = tenant_dev` as needed.

<sup>Written for commit 57fcabd7bf8b64bf6683855b27ad36ec4aa05db7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

