### PR TITLE
ci(cherry-pick): request workflows permission for app token

### DIFF
--- a/.github/workflows/post-merge-beta-cherry-pick.yml
+++ b/.github/workflows/post-merge-beta-cherry-pick.yml
@@ -102,6 +102,7 @@ jobs:
           private-key: ${{ secrets.CHERRY_PICK_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
+          permission-workflows: write
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -160,11 +161,12 @@ jobs:
           echo "status=failure" >> "$GITHUB_OUTPUT"
 
           reason="command-failed"
-          # The GitHub App installation token only carries contents + pull-requests
-          # write permissions, not `workflows`. Pushing a cherry-pick that touches
-          # .github/workflows is therefore rejected by the remote. Detect that
-          # specific rejection so the Slack alert can explain it clearly instead of
-          # surfacing a raw git error.
+          # The token requests `workflows` write (see the create-github-app-token
+          # step), but that only takes effect if the GitHub App installation has
+          # actually been granted the Workflows permission. If it hasn't, pushing a
+          # cherry-pick that touches .github/workflows is still rejected by the
+          # remote. Keep detecting that specific rejection so the Slack alert can
+          # explain it clearly instead of surfacing a raw git error.
           if grep -qiE "refusing to allow .* to (create or update|update) workflow|without [^[:space:]]*workflows[^[:space:]]* permission" "$output_file"; then
             reason="workflow-permission"
           elif grep -qiE "merge conflict during cherry-pick|CONFLICT|could not apply|cherry-pick in progress with staged changes" "$output_file"; then


### PR DESCRIPTION
## What

The post-merge cherry-pick workflow mints a GitHub App installation token scoped to only `contents` + `pull-requests` write. When a cherry-picked PR touches `.github/workflows`, the push is rejected with errors like:

> Unable to determine if workflow can be created or updated due to timeout; `workflows` scope may be required.

This adds `permission-workflows: write` to the `actions/create-github-app-token` step so the minted token is allowed to push workflow changes.

## Important caveat

`actions/create-github-app-token` can only mint a token scoped to a **subset** of what the App installation already holds — it cannot grant a permission the App lacks. For this to take effect:

1. In the cherry-pick App's settings → **Permissions**, set **Workflows** to **Read and write**.
2. An admin must approve the newly-requested permission on the installation.

Until that's done, the token mint would fail outright, so the existing `workflow-permission` failure detection is kept as a fallback (its comment was updated to reflect the new state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow the post-merge cherry-pick workflow to push changes to `.github/workflows` by requesting `permission-workflows: write` when minting the GitHub App token via `actions/create-github-app-token`. Keeps the workflow-permission failure detection as a fallback with updated messaging.

- **Migration**
  - In the cherry-pick App settings, set Workflows to Read and write.
  - An admin must approve the new permission on the installation.

<sup>Written for commit 63f2438fe77826616cfd941c1d24a2c7751073b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

