### PR TITLE
fix: set cloud PostHog tenant id from user mapping

### DIFF
--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -143,9 +143,7 @@ from onyx.server.security.store import get_security_settings
 from onyx.server.settings.store import load_settings
 from onyx.server.utils import BasicAuthenticationError
 from onyx.utils.logger import setup_logger
-from onyx.utils.telemetry import mt_cloud_alias
-from onyx.utils.telemetry import mt_cloud_get_anon_id
-from onyx.utils.telemetry import mt_cloud_identify
+from onyx.utils.telemetry import mt_cloud_identify_user
 from onyx.utils.telemetry import mt_cloud_telemetry
 from onyx.utils.telemetry import optional_telemetry
 from onyx.utils.telemetry import RecordType
@@ -1057,16 +1055,10 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         except Exception:
             logger.exception("Error deleting anonymous user cookie")
 
-        tenant_id = CURRENT_TENANT_ID_CONTEXTVAR.get()
-
-        # Link the anonymous PostHog session to the identified user so that
-        # pre-login session recordings and events merge into one person profile.
-        if anon_id := mt_cloud_get_anon_id(request):
-            mt_cloud_alias(distinct_id=str(user.id), anonymous_id=anon_id)
-
-        mt_cloud_identify(
+        mt_cloud_identify_user(
             distinct_id=str(user.id),
-            properties={"email": user.email, "tenant_id": tenant_id},
+            email=user.email,
+            request=request,
         )
 
     async def on_after_register(
@@ -1087,15 +1079,11 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             user_count = await get_user_count()
             logger.debug("Current tenant user count: %s", user_count)
 
-            # Link the anonymous PostHog session to the identified user so
-            # that pre-signup session recordings merge into one person profile.
-            if anon_id := mt_cloud_get_anon_id(request):
-                mt_cloud_alias(distinct_id=str(user.id), anonymous_id=anon_id)
-
-            # Ensure a PostHog person profile exists for this user.
-            mt_cloud_identify(
+            mt_cloud_identify_user(
                 distinct_id=str(user.id),
-                properties={"email": user.email, "tenant_id": tenant_id},
+                email=user.email,
+                request=request,
+                tenant_id=tenant_id,
             )
 
             mt_cloud_telemetry(

--- a/backend/onyx/utils/telemetry.py
+++ b/backend/onyx/utils/telemetry.py
@@ -22,6 +22,7 @@ from onyx.utils.variable_functionality import (
 )
 from onyx.utils.variable_functionality import noop_fallback
 from shared_configs.configs import MULTI_TENANT
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
 from shared_configs.contextvars import get_current_tenant_id
 
 logger = setup_logger()
@@ -178,43 +179,50 @@ def mt_cloud_telemetry(
     )(distinct_id, event, all_properties)
 
 
-def mt_cloud_identify(
+def _get_tenant_id_for_user_identify(user_email: str) -> str | None:
+    try:
+        return fetch_versioned_implementation_with_fallback(
+            module="onyx.server.tenants.user_mapping",
+            attribute="get_tenant_id_for_email",
+            fallback=lambda _email: POSTGRES_DEFAULT_SCHEMA,
+        )(user_email)
+    except Exception:
+        logger.exception("Failed to resolve tenant id for user %s", user_email)
+
+    return None
+
+
+def mt_cloud_identify_user(
+    *,
     distinct_id: str,
-    properties: dict[str, Any] | None = None,
+    email: str,
+    request: Any = None,
+    tenant_id: str | None = None,
 ) -> None:
-    """Create/update a PostHog person profile (Cloud only)."""
+    """Create/update a Cloud PostHog user profile and link any anonymous session."""
     if not MULTI_TENANT:
         return
+
+    if request:
+        anon_id = fetch_versioned_implementation_with_fallback(
+            module="onyx.utils.posthog_client",
+            attribute="get_anon_id_from_request",
+            fallback=noop_fallback,
+        )(request)
+        if anon_id:
+            fetch_versioned_implementation_with_fallback(
+                module="onyx.utils.posthog_client",
+                attribute="alias_user",
+                fallback=noop_fallback,
+            )(distinct_id, anon_id)
+
+    resolved_tenant_id = tenant_id or _get_tenant_id_for_user_identify(email)
+    properties: dict[str, str] = {"email": email}
+    if resolved_tenant_id and resolved_tenant_id != POSTGRES_DEFAULT_SCHEMA:
+        properties["tenant_id"] = resolved_tenant_id
 
     fetch_versioned_implementation_with_fallback(
         module="onyx.utils.telemetry",
         attribute="identify_user",
         fallback=noop_fallback,
     )(distinct_id, properties)
-
-
-def mt_cloud_alias(
-    distinct_id: str,
-    anonymous_id: str,
-) -> None:
-    """Link an anonymous distinct_id to an identified user (Cloud only)."""
-    if not MULTI_TENANT:
-        return
-
-    fetch_versioned_implementation_with_fallback(
-        module="onyx.utils.posthog_client",
-        attribute="alias_user",
-        fallback=noop_fallback,
-    )(distinct_id, anonymous_id)
-
-
-def mt_cloud_get_anon_id(request: Any) -> str | None:
-    """Extract the anonymous distinct_id from the app PostHog cookie (Cloud only)."""
-    if not MULTI_TENANT or not request:
-        return None
-
-    return fetch_versioned_implementation_with_fallback(
-        module="onyx.utils.posthog_client",
-        attribute="get_anon_id_from_request",
-        fallback=noop_fallback,
-    )(request)

--- a/backend/tests/unit/onyx/utils/test_telemetry.py
+++ b/backend/tests/unit/onyx/utils/test_telemetry.py
@@ -5,6 +5,49 @@ from onyx.configs.constants import MilestoneRecordType
 from onyx.utils import telemetry as telemetry_utils
 
 
+class CloudIdentifyHarness:
+    def __init__(
+        self,
+        *,
+        mapped_tenant_id: str = "tenant_dev",
+        anon_id: str | None = None,
+    ) -> None:
+        self.mapped_tenant_id = mapped_tenant_id
+        self.anon_id = anon_id
+        self.lookup_emails: list[str] = []
+        self.alias_calls: list[tuple[str, str]] = []
+        self.identify_calls: list[tuple[str, dict[str, str]]] = []
+
+    def fetch_versioned_implementation_with_fallback(
+        self, module: str, attribute: str, fallback: Any
+    ) -> Any:
+        if (
+            module == "onyx.server.tenants.user_mapping"
+            and attribute == "get_tenant_id_for_email"
+        ):
+            return self.get_tenant_id_for_email
+        if (
+            module == "onyx.utils.posthog_client"
+            and attribute == "get_anon_id_from_request"
+        ):
+            return lambda _request: self.anon_id
+        if module == "onyx.utils.posthog_client" and attribute == "alias_user":
+            return self.alias_user
+        if module == "onyx.utils.telemetry" and attribute == "identify_user":
+            return self.identify_user
+        return fallback
+
+    def get_tenant_id_for_email(self, email: str) -> str:
+        self.lookup_emails.append(email)
+        return self.mapped_tenant_id
+
+    def alias_user(self, distinct_id: str, anonymous_id: str) -> None:
+        self.alias_calls.append((distinct_id, anonymous_id))
+
+    def identify_user(self, distinct_id: str, properties: dict[str, str]) -> None:
+        self.identify_calls.append((distinct_id, properties))
+
+
 def test_mt_cloud_telemetry_noop_when_not_multi_tenant(monkeypatch: Any) -> None:
     fetch_impl = Mock()
     monkeypatch.setattr(
@@ -57,46 +100,88 @@ def test_mt_cloud_telemetry_calls_event_telemetry_when_multi_tenant(
     )
 
 
-def test_mt_cloud_identify_noop_when_not_multi_tenant(monkeypatch: Any) -> None:
-    fetch_impl = Mock()
-    monkeypatch.setattr(
-        telemetry_utils,
-        "fetch_versioned_implementation_with_fallback",
-        fetch_impl,
-    )
-    monkeypatch.setattr("onyx.utils.telemetry.MULTI_TENANT", False)
-
-    telemetry_utils.mt_cloud_identify(
-        distinct_id="12345678-1234-1234-1234-123456789abc",
-        properties={"email": "user@example.com"},
-    )
-
-    fetch_impl.assert_not_called()
-
-
-def test_mt_cloud_identify_calls_identify_user_when_multi_tenant(
+def test_mt_cloud_identify_user_resolves_tenant_by_email_when_not_provided(
     monkeypatch: Any,
 ) -> None:
-    identify_user = Mock()
-    fetch_impl = Mock(return_value=identify_user)
+    harness = CloudIdentifyHarness(mapped_tenant_id="tenant_dev")
+
+    monkeypatch.setattr("onyx.utils.telemetry.MULTI_TENANT", True)
     monkeypatch.setattr(
         telemetry_utils,
         "fetch_versioned_implementation_with_fallback",
-        fetch_impl,
+        harness.fetch_versioned_implementation_with_fallback,
     )
+
+    telemetry_utils.mt_cloud_identify_user(
+        distinct_id="user-id",
+        email="wenxi@onyx.app",
+    )
+
+    assert harness.lookup_emails == ["wenxi@onyx.app"]
+    assert harness.identify_calls == [
+        ("user-id", {"email": "wenxi@onyx.app", "tenant_id": "tenant_dev"})
+    ]
+
+
+def test_mt_cloud_identify_user_uses_provided_tenant_without_lookup(
+    monkeypatch: Any,
+) -> None:
+    harness = CloudIdentifyHarness(anon_id="anon-id")
+    request = object()
+
     monkeypatch.setattr("onyx.utils.telemetry.MULTI_TENANT", True)
-
-    telemetry_utils.mt_cloud_identify(
-        distinct_id="12345678-1234-1234-1234-123456789abc",
-        properties={"email": "user@example.com"},
+    monkeypatch.setattr(
+        telemetry_utils,
+        "fetch_versioned_implementation_with_fallback",
+        harness.fetch_versioned_implementation_with_fallback,
     )
 
-    fetch_impl.assert_called_once_with(
-        module="onyx.utils.telemetry",
-        attribute="identify_user",
-        fallback=telemetry_utils.noop_fallback,
+    telemetry_utils.mt_cloud_identify_user(
+        distinct_id="user-id",
+        email="wenxi@onyx.app",
+        request=request,
+        tenant_id="tenant_dev",
     )
-    identify_user.assert_called_once_with(
-        "12345678-1234-1234-1234-123456789abc",
-        {"email": "user@example.com"},
+
+    assert harness.lookup_emails == []
+    assert harness.alias_calls == [("user-id", "anon-id")]
+    assert harness.identify_calls == [
+        ("user-id", {"email": "wenxi@onyx.app", "tenant_id": "tenant_dev"})
+    ]
+
+
+def test_mt_cloud_identify_user_omits_public_tenant(
+    monkeypatch: Any,
+) -> None:
+    harness = CloudIdentifyHarness(
+        mapped_tenant_id=telemetry_utils.POSTGRES_DEFAULT_SCHEMA
+    )
+
+    monkeypatch.setattr("onyx.utils.telemetry.MULTI_TENANT", True)
+    monkeypatch.setattr(
+        telemetry_utils,
+        "fetch_versioned_implementation_with_fallback",
+        harness.fetch_versioned_implementation_with_fallback,
+    )
+
+    telemetry_utils.mt_cloud_identify_user(
+        distinct_id="user-id",
+        email="wenxi@onyx.app",
+    )
+
+    assert harness.lookup_emails == ["wenxi@onyx.app"]
+    assert harness.identify_calls == [("user-id", {"email": "wenxi@onyx.app"})]
+
+
+def test_mt_cloud_identify_user_noop_when_not_multi_tenant(monkeypatch: Any) -> None:
+    monkeypatch.setattr("onyx.utils.telemetry.MULTI_TENANT", False)
+    monkeypatch.setattr(
+        telemetry_utils,
+        "fetch_versioned_implementation_with_fallback",
+        Mock(side_effect=AssertionError("tenant mapping should not be looked up")),
+    )
+
+    telemetry_utils.mt_cloud_identify_user(
+        distinct_id="user-id",
+        email="wenxi@onyx.app",
     )


### PR DESCRIPTION
## Description

Fixes cloud PostHog identify so user profiles get the tenant id resolved from the user mapping rather than the current tenant context.

This consolidates the login/register PostHog identify flow in the telemetry helper, links anonymous sessions there, skips duplicate tenant lookup when the tenant id is already known, and avoids writing `tenant_id=public` to PostHog person properties.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the Cloud PostHog `tenant_id` from the user’s email-to-tenant mapping during identify via `mt_cloud_identify_user`. Fixes wrong tenants on person profiles and links pre-login sessions to the user.

- **Bug Fixes**
  - Resolve `tenant_id` via the email-to-tenant mapping; omit `tenant_id=public`.
  - Automatically alias the anonymous session from the request on login/register.
  - Skip tenant lookup when a `tenant_id` is already provided.

- **Refactors**
  - Replaced `mt_cloud_identify`, `mt_cloud_alias`, and `mt_cloud_get_anon_id` with `onyx.utils.telemetry.mt_cloud_identify_user` and updated auth flows.
  - Added unit tests for tenant resolution, aliasing, and non-multi-tenant no-op.

<sup>Written for commit 8be46d15411682a639c9416bd6fbad01218f8f26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

