### PR TITLE
feat(analytics): enable PostHog via runtime config instead of build-time env

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -123,6 +123,11 @@ HIDE_QUERY_HISTORY_FROM_ADMIN_PANEL = (
 # fixes it)
 WEB_DOMAIN = os.environ.get("WEB_DOMAIN") or "http://localhost:3000"
 
+# Surfaced to the web app via /api/settings so analytics can be enabled by env
+# var instead of a NEXT_PUBLIC_POSTHOG_KEY build arg. Client-side project key.
+POSTHOG_API_KEY = os.environ.get("POSTHOG_API_KEY")
+POSTHOG_HOST = os.environ.get("POSTHOG_HOST") or "https://us.i.posthog.com"
+
 
 #####
 # Auth Configs

--- a/backend/onyx/server/settings/api.py
+++ b/backend/onyx/server/settings/api.py
@@ -11,6 +11,8 @@ from onyx.auth.users import is_user_admin
 from onyx.configs.app_configs import DEFAULT_USER_FILE_MAX_UPLOAD_SIZE_MB
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
 from onyx.configs.app_configs import MAX_ALLOWED_UPLOAD_SIZE_MB
+from onyx.configs.app_configs import POSTHOG_API_KEY
+from onyx.configs.app_configs import POSTHOG_HOST
 from onyx.configs.constants import KV_REINDEX_KEY
 from onyx.configs.constants import NotificationType
 from onyx.db.engine.sql_engine import get_session
@@ -150,6 +152,8 @@ def fetch_settings(
             else DEFAULT_FILE_TOKEN_COUNT_THRESHOLD_K_VECTOR_DB
         ),
         is_containerized=is_running_in_container(),
+        posthog_key=POSTHOG_API_KEY,
+        posthog_host=POSTHOG_HOST,
     )
 
 

--- a/backend/onyx/server/settings/models.py
+++ b/backend/onyx/server/settings/models.py
@@ -128,3 +128,6 @@ class UserSettings(Settings):
     # The frontend uses this to default local-service URLs (e.g. Ollama,
     # LM Studio) to host.docker.internal instead of localhost.
     is_containerized: bool = False
+    # PostHog client key + host for the web app; None = analytics off.
+    posthog_key: str | None = None
+    posthog_host: str | None = None

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -6,6 +6,7 @@ import DynamicMetadata from "@/providers/DynamicMetadata";
 import { PHProvider } from "./providers";
 import {
   PostHogPageTracker,
+  PostHogRuntimeInitializer,
   CustomAnalyticsScript,
   WebVitals,
 } from "@/lib/analytics/shared";
@@ -104,12 +105,13 @@ export default function Layout({ children }: LayoutProps) {
                   <LicenseExpiryBanner />
                   <AppProvider>
                     <DynamicMetadata />
+                    <PostHogRuntimeInitializer />
                     <CustomAnalyticsScript />
                     <PostHogPageTracker />
                     <div id={MODAL_ROOT_ID} className="h-screen w-screen">
                       <ProductGatingWrapper>{children}</ProductGatingWrapper>
                     </div>
-                    {process.env.NEXT_PUBLIC_POSTHOG_KEY && <WebVitals />}
+                    <WebVitals />
                     {process.env.NEXT_PUBLIC_ENABLE_STATS === "true" && (
                       <StatsOverlayLoader />
                     )}

--- a/web/src/app/providers.tsx
+++ b/web/src/app/providers.tsx
@@ -3,30 +3,36 @@ import posthog from "posthog-js";
 import { PostHogProvider } from "posthog-js/react";
 import { useEffect } from "react";
 
-const isPostHogEnabled = !!process.env.NEXT_PUBLIC_POSTHOG_KEY;
+/**
+ * Initialize PostHog. Idempotent, so the build-time path (PHProvider) and the
+ * runtime path (PostHogRuntimeInitializer) can both call it safely.
+ */
+export function initPostHog(key: string, host?: string | null): void {
+  if (posthog.__loaded) return;
+  posthog.init(key, {
+    api_host: "/ph_ingest",
+    ui_host: host || "https://us.posthog.com",
+    person_profiles: "identified_only",
+    capture_pageview: false,
+    session_recording: {
+      // Sensitive inputs should use data-ph-no-capture attribute
+      maskAllInputs: false,
+    },
+  });
+}
 
-type PHProviderProps = { children: React.ReactNode };
+interface PHProviderProps {
+  children: React.ReactNode;
+}
 
 export function PHProvider({ children }: PHProviderProps) {
   useEffect(() => {
-    if (isPostHogEnabled) {
-      posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
-        api_host: "/ph_ingest",
-        ui_host:
-          process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://us.posthog.com",
-        person_profiles: "identified_only",
-        capture_pageview: false,
-        session_recording: {
-          // Sensitive inputs should use data-ph-no-capture attribute
-          maskAllInputs: false,
-        },
-      });
+    // Build-time key (Onyx Cloud); otherwise PostHogRuntimeInitializer handles it.
+    const buildTimeKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+    if (buildTimeKey) {
+      initPostHog(buildTimeKey, process.env.NEXT_PUBLIC_POSTHOG_HOST);
     }
   }, []);
-
-  if (!isPostHogEnabled) {
-    return <>{children}</>;
-  }
 
   return <PostHogProvider client={posthog}>{children}</PostHogProvider>;
 }

--- a/web/src/lib/analytics/shared.tsx
+++ b/web/src/lib/analytics/shared.tsx
@@ -12,19 +12,41 @@ import { useEffect, useRef, Suspense, type ReactElement } from "react";
 import { usePostHog } from "posthog-js/react";
 import { useReportWebVitals } from "next/web-vitals";
 import { useCustomAnalyticsScript } from "@/lib/analytics/hooks";
+import { useSettings } from "@/lib/settings/hooks";
+import { initPostHog } from "@/app/providers";
+
+// ─── PostHogRuntimeInitializer ──────────────────────────────────────────────
+
+/**
+ * Initializes PostHog from the runtime key in `/api/settings`, for deployments
+ * that don't bake one into the web image. Must render inside the settings
+ * provider. No-ops if a build-time key already initialized PostHog.
+ */
+export function PostHogRuntimeInitializer(): null {
+  const { posthog_key, posthog_host } = useSettings();
+
+  useEffect(() => {
+    if (posthog_key) {
+      initPostHog(posthog_key, posthog_host);
+    }
+  }, [posthog_key, posthog_host]);
+
+  return null;
+}
 
 // ─── WebVitals ─────────────────────────────────────────────────────────────
 
 /**
  * Captures Core Web Vitals (LCP, FID, CLS, INP, TTFB) as PostHog events.
- *
- * Only rendered when `NEXT_PUBLIC_POSTHOG_KEY` is set — callers are
- * responsible for that guard so this component is never mounted in
- * self-hosted / MIT installs where PostHog is absent.
+ * Self-guards on PostHog being initialized, so it's safe to mount always.
  */
 export function WebVitals(): null {
   const posthog = usePostHog();
-  useReportWebVitals((metric) => posthog.capture(metric.name, metric));
+  useReportWebVitals((metric) => {
+    if (posthog.__loaded) {
+      posthog.capture(metric.name, metric);
+    }
+  });
   return null;
 }
 

--- a/web/src/lib/settings/types.ts
+++ b/web/src/lib/settings/types.ts
@@ -98,6 +98,10 @@ export interface Settings {
   // True when the backend runs inside a container (Docker/Podman).
   // Used to default local-service URLs to host.docker.internal.
   is_containerized?: boolean;
+
+  // PostHog client key + host for the web app; null = analytics off.
+  posthog_key?: string | null;
+  posthog_host?: string | null;
 }
 
 export interface NavigationItem {


### PR DESCRIPTION
## Description

Makes frontend PostHog enablement a runtime config switch instead of a build-time concern.

Today, frontend analytics only works if the web image is built with a `NEXT_PUBLIC_POSTHOG_KEY` build arg (this is why only the `onyx-web-server-cloud` image reports to PostHog — the stock `onyx-web-server` image has no key baked in, since `process.env.NEXT_PUBLIC_POSTHOG_KEY` is inlined by webpack at build time in the `"use client"` provider).

This PR surfaces the PostHog project key + host through the existing `/api/settings` payload (populated from the `POSTHOG_API_KEY` / `POSTHOG_HOST` env vars, the same vars that already drive the backend PostHog client). The web app initializes PostHog from either:

- the **build-time** `NEXT_PUBLIC_POSTHOG_KEY` (baked into the cloud image — **unchanged**), or
- the **runtime** key from settings, when no build-time key is present.

`initPostHog()` guards against double-init, so the cloud path is fully backward compatible. Net result: any deployment (self-hosted, Helm, single-tenant customer clusters) can turn on full client + server analytics by setting **one env var** — `POSTHOG_API_KEY` — with no custom image, no build args, and no ingress changes (the `/ph_ingest` reverse-proxy is already a native `next.config.js` rewrite).

The PostHog project key is a client-side (publishable) key, so serving it to the browser is expected and safe.

### Notes
- `/api/settings` requires auth, so deployments relying solely on the runtime key begin capturing after login. The cloud image keeps pre-login capture via its build-time key fallback.
- `WebVitals` now self-guards on PostHog being initialized rather than relying on a build-time mount gate, so it works for the runtime path too.

## How Has This Been Tested?

- Backend: confirmed `POSTHOG_API_KEY`/`POSTHOG_HOST` resolve and `posthog_key`/`posthog_host` are populated on `UserSettings` from `fetch_settings()`.
- Frontend: `tsc --noEmit` clean; `pre-commit` (ty, ruff, oxlint, TypeScript type check) passes on all changed files.
- Manual browser verification of the runtime-key path is still recommended before rollout.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable PostHog analytics via runtime config instead of a build-time env. Any deployment can turn on client + server analytics by setting `POSTHOG_API_KEY`, with full back-compat for cloud builds.

- New Features
  - Backend exposes `posthog_key`/`posthog_host` in `/api/settings` from `POSTHOG_API_KEY`/`POSTHOG_HOST` (default host `https://us.i.posthog.com`).
  - Frontend initializes PostHog from either `NEXT_PUBLIC_POSTHOG_KEY` (build-time) or `/api/settings` (runtime) via a new `PostHogRuntimeInitializer` and idempotent `initPostHog()`.
  - `WebVitals` is always mounted and only captures after PostHog loads.
  - Uses `/ph_ingest` for API host; UI host defaults to `https://us.posthog.com`.

- Migration
  - Set `POSTHOG_API_KEY` (and optionally `POSTHOG_HOST`) on the server; no web image rebuild needed.
  - Runtime key initializes after login because `/api/settings` requires auth; cloud builds with a baked `NEXT_PUBLIC_POSTHOG_KEY` keep pre-login capture.

<sup>Written for commit a19388368c85e5129605a4cff93db583aac5fe15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

