### PR TITLE
feat(skills): install skills & custom apps from a git repo

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -73,6 +73,15 @@ GENERATIVE_MODEL_ACCESS_CHECK_FREQ = int(
 # it without uploading the full quota of real bundles to exercise the limit.
 MAX_PERSONAL_SKILLS_PER_USER = _non_negative_int_env("MAX_PERSONAL_SKILLS_PER_USER", 50)
 
+# Skills marketplace: max compressed archive size fetched from GitHub/GitLab.
+SKILL_MARKETPLACE_ARCHIVE_MAX_BYTES = int(
+    os.environ.get("SKILL_MARKETPLACE_ARCHIVE_MAX_BYTES") or 100 * 1024 * 1024
+)
+# Skills marketplace: HTTP fetch timeout in seconds for repo archive downloads.
+SKILL_MARKETPLACE_FETCH_TIMEOUT_SECONDS = int(
+    os.environ.get("SKILL_MARKETPLACE_FETCH_TIMEOUT_SECONDS") or 30
+)
+
 # Controls whether users can use User Knowledge (personal documents) in assistants
 DISABLE_USER_KNOWLEDGE = os.environ.get("DISABLE_USER_KNOWLEDGE", "").lower() == "true"
 

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -74,12 +74,12 @@ GENERATIVE_MODEL_ACCESS_CHECK_FREQ = int(
 MAX_PERSONAL_SKILLS_PER_USER = _non_negative_int_env("MAX_PERSONAL_SKILLS_PER_USER", 50)
 
 # Skills marketplace: max compressed archive size fetched from GitHub/GitLab.
-SKILL_MARKETPLACE_ARCHIVE_MAX_BYTES = int(
-    os.environ.get("SKILL_MARKETPLACE_ARCHIVE_MAX_BYTES") or 100 * 1024 * 1024
+SKILL_MARKETPLACE_ARCHIVE_MAX_BYTES = _non_negative_int_env(
+    "SKILL_MARKETPLACE_ARCHIVE_MAX_BYTES", 100 * 1024 * 1024
 )
 # Skills marketplace: HTTP fetch timeout in seconds for repo archive downloads.
-SKILL_MARKETPLACE_FETCH_TIMEOUT_SECONDS = int(
-    os.environ.get("SKILL_MARKETPLACE_FETCH_TIMEOUT_SECONDS") or 30
+SKILL_MARKETPLACE_FETCH_TIMEOUT_SECONDS = _non_negative_int_env(
+    "SKILL_MARKETPLACE_FETCH_TIMEOUT_SECONDS", 30
 )
 
 # Controls whether users can use User Knowledge (personal documents) in assistants

--- a/backend/onyx/server/features/build/external_apps/api.py
+++ b/backend/onyx/server/features/build/external_apps/api.py
@@ -38,6 +38,9 @@ from onyx.file_store.file_store import get_default_file_store
 from onyx.server.features.build.external_apps.models import (
     CreateBuiltInExternalAppRequest,
 )
+from onyx.server.features.build.external_apps.models import (
+    CreateCustomExternalAppFromRepoRequest,
+)
 from onyx.server.features.build.external_apps.models import ExternalAppAdminResponse
 from onyx.server.features.build.external_apps.models import ExternalAppUserResponse
 from onyx.server.features.build.external_apps.models import UpdateExternalAppRequest
@@ -45,6 +48,10 @@ from onyx.server.features.build.external_apps.models import UpsertUserCredential
 from onyx.skills.bundle import read_bundle_file
 from onyx.skills.ingest import delete_bundle_blob
 from onyx.skills.ingest import ingest_skill_bundle
+from onyx.skills.marketplace import build_bundle_for_skill
+from onyx.skills.marketplace import extracted_skills
+from onyx.skills.marketplace import fetch_repo_archive
+from onyx.skills.marketplace import parse_skill_source
 from onyx.skills.push import push_skill_to_affected_sandboxes
 from onyx.skills.push import push_skills_for_users
 from onyx.utils.encryption import mask_string
@@ -231,6 +238,69 @@ def update_external_app_admin(
     return _to_admin_response(app)
 
 
+def _create_custom_app_from_bundle(
+    *,
+    name: str,
+    description: str,
+    parsed_patterns: list[str],
+    parsed_auth_template: dict,  # type: ignore[type-arg]
+    parsed_org_credentials: dict,  # type: ignore[type-arg]
+    enabled: bool,
+    bundle_bytes: bytes,
+    bundle_filename: str | None,
+    slug: str | None,
+    db_session: Session,
+) -> ExternalApp:
+    """Validate inputs, ingest the bundle, persist the app, and push to sandboxes.
+
+    Shared by the multipart upload path and the repo-pull path. Callers are
+    responsible for all JSON-field parsing and for acquiring ``bundle_bytes``
+    before calling here. This function owns the commit (push happens before it so
+    a push failure rolls back the create + orphaned blob); callers must NOT commit
+    again.
+    """
+    if not name.strip():
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, "name is required.")
+    if not parsed_patterns:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "At least one upstream URL pattern is required.",
+        )
+    if any(not p.strip() for p in parsed_patterns):
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "upstream_url_patterns must not contain empty entries.",
+        )
+    for pattern in parsed_patterns:
+        UrlGlob.parse(pattern)
+    validate_auth_template(parsed_auth_template, parsed_org_credentials)
+
+    file_store = get_default_file_store()
+    ingested = ingest_skill_bundle(bundle_bytes, bundle_filename, file_store, slug=slug)
+    try:
+        app = create_external_app(
+            db_session=db_session,
+            name=name.strip(),
+            description=description.strip() or ingested.description,
+            bundle_file_id=ingested.bundle_file_id,
+            bundle_sha256=ingested.bundle_sha256,
+            app_type=ExternalAppType.CUSTOM,
+            upstream_url_patterns=parsed_patterns,
+            auth_template=parsed_auth_template,
+            organization_credentials=parsed_org_credentials,
+            enabled=enabled,
+            is_public=True,
+            slug=ingested.slug,
+        )
+        push_skill_to_affected_sandboxes(app.skill, db_session)
+        db_session.commit()
+    except Exception:
+        delete_bundle_blob(file_store, ingested.bundle_file_id)
+        raise
+
+    return app
+
+
 @router.post("/admin/apps/custom")
 def create_custom_external_app(
     name: str = Form(...),
@@ -258,56 +328,63 @@ def create_custom_external_app(
         organization_credentials, _STR_DICT_ADAPTER, "organization_credentials"
     )
 
-    if not name.strip():
-        raise OnyxError(OnyxErrorCode.INVALID_INPUT, "name is required.")
-    if not parsed_patterns:
-        raise OnyxError(
-            OnyxErrorCode.INVALID_INPUT,
-            "At least one upstream URL pattern is required.",
-        )
-    if any(not p.strip() for p in parsed_patterns):
-        raise OnyxError(
-            OnyxErrorCode.INVALID_INPUT,
-            "upstream_url_patterns must not contain empty entries.",
-        )
-    # Custom app globs; validate before ingesting the bundle so a bad
-    # pattern fails fast.
-    for pattern in parsed_patterns:
-        UrlGlob.parse(pattern)
-    validate_auth_template(parsed_auth_template, parsed_org_credentials)
-
     if bundle is None:
         raise OnyxError(
             OnyxErrorCode.INVALID_INPUT,
             "A bundle (.zip) is required when creating a custom app.",
         )
 
-    file_store = get_default_file_store()
-    ingested = ingest_skill_bundle(
-        read_bundle_file(bundle.file), bundle.filename, file_store
+    app = _create_custom_app_from_bundle(
+        name=name,
+        description=description,
+        parsed_patterns=parsed_patterns,
+        parsed_auth_template=parsed_auth_template,
+        parsed_org_credentials=parsed_org_credentials,
+        enabled=enabled,
+        bundle_bytes=read_bundle_file(bundle.file),
+        bundle_filename=bundle.filename,
+        slug=None,
+        db_session=db_session,
     )
-    try:
-        app = create_external_app(
-            db_session=db_session,
-            name=name.strip(),
-            description=description.strip() or ingested.description,
-            bundle_file_id=ingested.bundle_file_id,
-            bundle_sha256=ingested.bundle_sha256,
-            app_type=ExternalAppType.CUSTOM,
-            upstream_url_patterns=parsed_patterns,
-            auth_template=parsed_auth_template,
-            organization_credentials=parsed_org_credentials,
-            enabled=enabled,
-            is_public=True,
-            slug=ingested.slug,
-        )
-        # Push before commit so a failure rolls back the create + orphaned blob.
-        push_skill_to_affected_sandboxes(app.skill, db_session)
-        db_session.commit()
-    except Exception:
-        delete_bundle_blob(file_store, ingested.bundle_file_id)
-        raise
+    return _to_admin_response(app)
 
+
+@router.post("/admin/apps/custom/from-repo")
+def create_custom_external_app_from_repo(
+    body: CreateCustomExternalAppFromRepoRequest,
+    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> ExternalAppAdminResponse:
+    """Create a CUSTOM app by pulling a skill bundle from a git repository.
+
+    ``body.source`` is any skills.sh-compatible input; ``body.slug`` selects
+    which skill from the discovered set to install. Returns 404 if the slug
+    is not found in the repository.
+    """
+    parsed = parse_skill_source(body.source)
+    archive = fetch_repo_archive(parsed)
+
+    with extracted_skills(archive, parsed.subpath) as discovered:
+        match = next((s for s in discovered if s.slug == body.slug), None)
+        if match is None:
+            raise OnyxError(
+                OnyxErrorCode.NOT_FOUND,
+                f"Skill '{body.slug}' not found in repository",
+            )
+        bundle_bytes = build_bundle_for_skill(match)
+
+    app = _create_custom_app_from_bundle(
+        name=body.name,
+        description=body.description,
+        parsed_patterns=body.upstream_url_patterns,
+        parsed_auth_template=body.auth_template,
+        parsed_org_credentials=body.organization_credentials,
+        enabled=body.enabled,
+        bundle_bytes=bundle_bytes,
+        bundle_filename=None,
+        slug=match.slug,
+        db_session=db_session,
+    )
     return _to_admin_response(app)
 
 

--- a/backend/onyx/server/features/build/external_apps/models.py
+++ b/backend/onyx/server/features/build/external_apps/models.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from pydantic import BaseModel
+from pydantic import Field
 
 from onyx.db.enums import EndpointPolicy
 from onyx.db.enums import ExternalAppType
@@ -107,6 +108,24 @@ class ExternalAppUserResponse(BaseModel):
     credential_keys: list[str]
     credential_values: dict[str, Any]
     authenticated: bool
+
+
+class CreateCustomExternalAppFromRepoRequest(BaseModel):
+    """Create a CUSTOM app whose bundle is pulled from a git repo skill.
+
+    ``source`` is any skills.sh-compatible input (URL, owner/repo, or
+    ``npx skills add ...`` command). ``slug`` identifies the specific skill to
+    install from the discovered set.
+    """
+
+    name: str
+    description: str = ""
+    upstream_url_patterns: list[str]
+    auth_template: dict[str, Any] = Field(default_factory=dict)
+    organization_credentials: dict[str, str] = Field(default_factory=dict)
+    enabled: bool = True
+    source: str
+    slug: str
 
 
 class OAuthStartResponse(BaseModel):

--- a/backend/onyx/server/features/skill/api.py
+++ b/backend/onyx/server/features/skill/api.py
@@ -37,10 +37,17 @@ from onyx.db.skill import SkillPatch
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.file_store.file_store import get_default_file_store
+from onyx.server.features.skill.models import AdminRepoSkillsInstallRequest
 from onyx.server.features.skill.models import BuiltinSkillResponse
 from onyx.server.features.skill.models import CustomSkillResponse
 from onyx.server.features.skill.models import GrantsReplace
 from onyx.server.features.skill.models import PersonalSkillPatchRequest
+from onyx.server.features.skill.models import RepoSkillInstallFailure
+from onyx.server.features.skill.models import RepoSkillPreviewItem
+from onyx.server.features.skill.models import RepoSkillsInstallRequest
+from onyx.server.features.skill.models import RepoSkillsInstallResult
+from onyx.server.features.skill.models import RepoSkillsPreview
+from onyx.server.features.skill.models import RepoSkillsPreviewRequest
 from onyx.server.features.skill.models import SkillPatchRequest
 from onyx.server.features.skill.models import SkillsList
 from onyx.skills.built_in import BUILT_IN_SKILLS
@@ -49,6 +56,10 @@ from onyx.skills.bundle import read_bundle_file
 from onyx.skills.bundle import slug_from_filename
 from onyx.skills.ingest import delete_bundle_blob
 from onyx.skills.ingest import ingest_skill_bundle
+from onyx.skills.marketplace import build_bundle_for_skill
+from onyx.skills.marketplace import extracted_skills
+from onyx.skills.marketplace import fetch_repo_archive
+from onyx.skills.marketplace import parse_skill_source
 from onyx.skills.push import push_skill_to_affected_sandboxes
 from onyx.skills.push import push_skills_for_users
 from onyx.utils.logger import setup_logger
@@ -513,3 +524,280 @@ def _parse_group_ids(raw: str) -> list[int]:
             "group_ids must be a JSON array of integers",
         )
     return parsed
+
+
+def _preview_repo_skills(source: str) -> RepoSkillsPreview:
+    parsed = parse_skill_source(source)
+    archive = fetch_repo_archive(parsed)
+    source_label = f"{parsed.owner}/{parsed.repo}"
+    with extracted_skills(archive, parsed.subpath) as discovered:
+        items: list[RepoSkillPreviewItem] = []
+        for skill in discovered:
+            if parsed.skill_filters:
+                last_segment = skill.rel_path.split("/")[-1]
+                pre_selected = any(
+                    f.lower() in (skill.slug, skill.name.lower(), last_segment.lower())
+                    for f in parsed.skill_filters
+                )
+            else:
+                pre_selected = True
+            items.append(
+                RepoSkillPreviewItem(
+                    slug=skill.slug,
+                    name=skill.name,
+                    description=skill.description,
+                    rel_path=skill.rel_path,
+                    pre_selected=pre_selected,
+                )
+            )
+        return RepoSkillsPreview(
+            source_label=source_label,
+            ref=parsed.ref,
+            skills=items,
+        )
+
+
+def _install_personal_repo_skills(
+    source: str,
+    slugs: list[str],
+    user: User,
+    db_session: Session,
+) -> RepoSkillsInstallResult:
+    parsed = parse_skill_source(source)
+    archive = fetch_repo_archive(parsed)
+    file_store = get_default_file_store()
+
+    # Dedupe preserving order.
+    seen_slugs: set[str] = set()
+    unique_slugs: list[str] = []
+    for s in slugs:
+        if s not in seen_slugs:
+            seen_slugs.add(s)
+            unique_slugs.append(s)
+
+    if not unique_slugs:
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, "no skills selected")
+
+    failures: list[RepoSkillInstallFailure] = []
+    created_responses: list[CustomSkillResponse] = []
+
+    with extracted_skills(archive, parsed.subpath) as discovered:
+        by_slug = {s.slug: s for s in discovered}
+
+        to_install = []
+        for slug in unique_slugs:
+            if slug not in by_slug:
+                failures.append(
+                    RepoSkillInstallFailure(slug=slug, error="not found in repository")
+                )
+            else:
+                to_install.append(by_slug[slug])
+
+        lock_personal_skills_for_user(user.id, db_session)
+        existing = count_personal_skills_for_user(user.id, db_session)
+        if existing + len(to_install) > MAX_PERSONAL_SKILLS_PER_USER:
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                f"Installing {len(to_install)} skill(s) would exceed your limit of "
+                f"{MAX_PERSONAL_SKILLS_PER_USER} personal skills "
+                f"(you currently have {existing}).",
+            )
+
+        created_rows: list[Skill] = []
+        batch_blob_ids: list[str] = []
+
+        for skill in to_install:
+            blob_id: str | None = None
+            try:
+                if skill.slug in _RESERVED_SKILL_SLUGS:
+                    raise OnyxError(
+                        OnyxErrorCode.INVALID_INPUT,
+                        f"slug '{skill.slug}' is reserved",
+                    )
+                bundle = build_bundle_for_skill(skill)
+                ingested = ingest_skill_bundle(
+                    bundle, None, file_store, slug=skill.slug
+                )
+                blob_id = ingested.bundle_file_id
+                sp = db_session.begin_nested()
+                try:
+                    row = create_skill__no_commit(
+                        slug=ingested.slug,
+                        name=ingested.name,
+                        description=ingested.description,
+                        bundle_file_id=ingested.bundle_file_id,
+                        bundle_sha256=ingested.bundle_sha256,
+                        is_public=False,
+                        author_user_id=user.id,
+                        db_session=db_session,
+                    )
+                    sp.commit()
+                except Exception:
+                    sp.rollback()
+                    raise
+                created_rows.append(row)
+                batch_blob_ids.append(blob_id)
+            except Exception as e:
+                # Any failure (validation, slug collision, or an unexpected
+                # file-store / integrity error) drops this one skill to a
+                # failure entry rather than aborting the batch. The savepoint
+                # was already rolled back, so the session stays usable.
+                if blob_id is not None:
+                    delete_bundle_blob(file_store, blob_id)
+                if not isinstance(e, OnyxError):
+                    logger.exception("Unexpected error installing skill %s", skill.slug)
+                error = e.detail if isinstance(e, OnyxError) else "internal error"
+                failures.append(RepoSkillInstallFailure(slug=skill.slug, error=error))
+
+        try:
+            db_session.commit()
+        except Exception:
+            for bid in batch_blob_ids:
+                delete_bundle_blob(file_store, bid)
+            raise
+
+        for row in created_rows:
+            push_skill_to_affected_sandboxes(row, db_session)
+            created_responses.append(CustomSkillResponse.from_model(row, group_ids=[]))
+
+    return RepoSkillsInstallResult(created=created_responses, failures=failures)
+
+
+def _install_admin_repo_skills(
+    source: str,
+    slugs: list[str],
+    is_public: bool,
+    group_ids: list[int],
+    user: User,
+    db_session: Session,
+) -> RepoSkillsInstallResult:
+    parsed = parse_skill_source(source)
+    archive = fetch_repo_archive(parsed)
+    file_store = get_default_file_store()
+
+    # Dedupe preserving order.
+    seen_slugs: set[str] = set()
+    unique_slugs: list[str] = []
+    for s in slugs:
+        if s not in seen_slugs:
+            seen_slugs.add(s)
+            unique_slugs.append(s)
+
+    if not unique_slugs:
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, "no skills selected")
+
+    failures: list[RepoSkillInstallFailure] = []
+    created_responses: list[CustomSkillResponse] = []
+
+    with extracted_skills(archive, parsed.subpath) as discovered:
+        by_slug = {s.slug: s for s in discovered}
+
+        to_install = []
+        for slug in unique_slugs:
+            if slug not in by_slug:
+                failures.append(
+                    RepoSkillInstallFailure(slug=slug, error="not found in repository")
+                )
+            else:
+                to_install.append(by_slug[slug])
+
+        created_rows: list[Skill] = []
+        batch_blob_ids: list[str] = []
+
+        for skill in to_install:
+            blob_id = None
+            try:
+                if skill.slug in _RESERVED_SKILL_SLUGS:
+                    raise OnyxError(
+                        OnyxErrorCode.INVALID_INPUT,
+                        f"slug '{skill.slug}' is reserved",
+                    )
+                bundle = build_bundle_for_skill(skill)
+                ingested = ingest_skill_bundle(
+                    bundle, None, file_store, slug=skill.slug
+                )
+                blob_id = ingested.bundle_file_id
+                sp = db_session.begin_nested()
+                try:
+                    row = create_skill__no_commit(
+                        slug=ingested.slug,
+                        name=ingested.name,
+                        description=ingested.description,
+                        bundle_file_id=ingested.bundle_file_id,
+                        bundle_sha256=ingested.bundle_sha256,
+                        is_public=is_public,
+                        author_user_id=user.id,
+                        db_session=db_session,
+                    )
+                    if group_ids:
+                        replace_skill_grants(row.id, group_ids, db_session=db_session)
+                    sp.commit()
+                except Exception:
+                    sp.rollback()
+                    raise
+                created_rows.append(row)
+                batch_blob_ids.append(blob_id)
+            except Exception as e:
+                # Drop a single failing skill to a failure entry instead of
+                # aborting the batch; the savepoint already rolled back.
+                if blob_id is not None:
+                    delete_bundle_blob(file_store, blob_id)
+                if not isinstance(e, OnyxError):
+                    logger.exception("Unexpected error installing skill %s", skill.slug)
+                error = e.detail if isinstance(e, OnyxError) else "internal error"
+                failures.append(RepoSkillInstallFailure(slug=skill.slug, error=error))
+
+        try:
+            db_session.commit()
+        except Exception:
+            for bid in batch_blob_ids:
+                delete_bundle_blob(file_store, bid)
+            raise
+
+        affected: set[UUID] = set()
+        for row in created_rows:
+            affected |= affected_user_ids_for_skill(row, db_session)
+        push_skills_for_users(affected, db_session)
+
+        for row in created_rows:
+            created_responses.append(
+                CustomSkillResponse.from_model(row, group_ids=group_ids)
+            )
+
+    return RepoSkillsInstallResult(created=created_responses, failures=failures)
+
+
+@user_router.post("/from-repo/preview")
+def preview_repo_skills_user(
+    body: RepoSkillsPreviewRequest,
+    _: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+) -> RepoSkillsPreview:
+    return _preview_repo_skills(body.source)
+
+
+@user_router.post("/from-repo/install")
+def install_repo_skills_user(
+    body: RepoSkillsInstallRequest,
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> RepoSkillsInstallResult:
+    return _install_personal_repo_skills(body.source, body.slugs, user, db_session)
+
+
+@admin_router.post("/from-repo/preview")
+def preview_repo_skills_admin(
+    body: RepoSkillsPreviewRequest,
+    _: User = Depends(current_curator_or_admin_user),
+) -> RepoSkillsPreview:
+    return _preview_repo_skills(body.source)
+
+
+@admin_router.post("/from-repo/install")
+def install_repo_skills_admin(
+    body: AdminRepoSkillsInstallRequest,
+    user: User = Depends(current_curator_or_admin_user),
+    db_session: Session = Depends(get_session),
+) -> RepoSkillsInstallResult:
+    return _install_admin_repo_skills(
+        body.source, body.slugs, body.is_public, body.group_ids, user, db_session
+    )

--- a/backend/onyx/server/features/skill/api.py
+++ b/backend/onyx/server/features/skill/api.py
@@ -696,10 +696,17 @@ def _install_personal_repo_skills(
         before_install=_enforce_cap,
     )
 
-    created_responses: list[CustomSkillResponse] = []
-    for row in created_rows:
-        push_skill_to_affected_sandboxes(row, db_session)
-        created_responses.append(CustomSkillResponse.from_model(row, group_ids=[]))
+    created_responses = [
+        CustomSkillResponse.from_model(row, group_ids=[]) for row in created_rows
+    ]
+    # Rows are already committed; the sandbox push is best-effort and must never
+    # turn a successful install into a 500 (which would hide the committed rows
+    # and trigger slug-collision failures on retry).
+    try:
+        for row in created_rows:
+            push_skill_to_affected_sandboxes(row, db_session)
+    except Exception:
+        logger.exception("Post-commit skill push failed after personal repo install")
     return RepoSkillsInstallResult(created=created_responses, failures=failures)
 
 
@@ -720,15 +727,18 @@ def _install_admin_repo_skills(
         db_session=db_session,
     )
 
-    affected: set[UUID] = set()
-    for row in created_rows:
-        affected |= affected_user_ids_for_skill(row, db_session)
-    if affected:
-        push_skills_for_users(affected, db_session)
-
     created_responses = [
         CustomSkillResponse.from_model(row, group_ids=group_ids) for row in created_rows
     ]
+    # Rows are already committed; best-effort push must not break the response.
+    try:
+        affected: set[UUID] = set()
+        for row in created_rows:
+            affected |= affected_user_ids_for_skill(row, db_session)
+        if affected:
+            push_skills_for_users(affected, db_session)
+    except Exception:
+        logger.exception("Post-commit skill push failed after admin repo install")
     return RepoSkillsInstallResult(created=created_responses, failures=failures)
 
 

--- a/backend/onyx/server/features/skill/api.py
+++ b/backend/onyx/server/features/skill/api.py
@@ -1,4 +1,5 @@
 import json
+from collections.abc import Callable
 from typing import Annotated
 from typing import Final
 from uuid import UUID
@@ -557,12 +558,27 @@ def _preview_repo_skills(source: str) -> RepoSkillsPreview:
         )
 
 
-def _install_personal_repo_skills(
+def _install_repo_skills(
+    *,
     source: str,
     slugs: list[str],
-    user: User,
+    author_user_id: UUID,
+    is_public: bool,
+    group_ids: list[int],
     db_session: Session,
-) -> RepoSkillsInstallResult:
+    before_install: Callable[[int], None] | None = None,
+) -> tuple[list[Skill], list[RepoSkillInstallFailure]]:
+    """Shared repo-install core for the personal and admin paths.
+
+    Fetches + discovers the repo, then for each requested skill builds a bundle
+    and creates a row inside its own savepoint so one failure (validation, slug
+    collision, file-store/integrity error) becomes a per-skill failure instead
+    of aborting the batch. ``before_install`` runs once with the resolved
+    install count after not-found slugs are recorded but before any writes — the
+    personal path uses it for the advisory-lock + cap check. ``group_ids`` are
+    granted per row; an empty list (the personal path) skips grants. Returns the
+    created rows (caller owns the sandbox push) and the per-skill failures.
+    """
     parsed = parse_skill_source(source)
     archive = fetch_repo_archive(parsed)
     file_store = get_default_file_store()
@@ -579,7 +595,7 @@ def _install_personal_repo_skills(
         raise OnyxError(OnyxErrorCode.INVALID_INPUT, "no skills selected")
 
     failures: list[RepoSkillInstallFailure] = []
-    created_responses: list[CustomSkillResponse] = []
+    created_rows: list[Skill] = []
 
     with extracted_skills(archive, parsed.subpath) as discovered:
         by_slug = {s.slug: s for s in discovered}
@@ -593,17 +609,9 @@ def _install_personal_repo_skills(
             else:
                 to_install.append(by_slug[slug])
 
-        lock_personal_skills_for_user(user.id, db_session)
-        existing = count_personal_skills_for_user(user.id, db_session)
-        if existing + len(to_install) > MAX_PERSONAL_SKILLS_PER_USER:
-            raise OnyxError(
-                OnyxErrorCode.INVALID_INPUT,
-                f"Installing {len(to_install)} skill(s) would exceed your limit of "
-                f"{MAX_PERSONAL_SKILLS_PER_USER} personal skills "
-                f"(you currently have {existing}).",
-            )
+        if before_install is not None:
+            before_install(len(to_install))
 
-        created_rows: list[Skill] = []
         batch_blob_ids: list[str] = []
 
         for skill in to_install:
@@ -627,10 +635,12 @@ def _install_personal_repo_skills(
                         description=ingested.description,
                         bundle_file_id=ingested.bundle_file_id,
                         bundle_sha256=ingested.bundle_sha256,
-                        is_public=False,
-                        author_user_id=user.id,
+                        is_public=is_public,
+                        author_user_id=author_user_id,
                         db_session=db_session,
                     )
+                    if group_ids:
+                        replace_skill_grants(row.id, group_ids, db_session=db_session)
                     sp.commit()
                 except Exception:
                     sp.rollback()
@@ -656,10 +666,40 @@ def _install_personal_repo_skills(
                 delete_bundle_blob(file_store, bid)
             raise
 
-        for row in created_rows:
-            push_skill_to_affected_sandboxes(row, db_session)
-            created_responses.append(CustomSkillResponse.from_model(row, group_ids=[]))
+    return created_rows, failures
 
+
+def _install_personal_repo_skills(
+    source: str,
+    slugs: list[str],
+    user: User,
+    db_session: Session,
+) -> RepoSkillsInstallResult:
+    def _enforce_cap(install_count: int) -> None:
+        lock_personal_skills_for_user(user.id, db_session)
+        existing = count_personal_skills_for_user(user.id, db_session)
+        if existing + install_count > MAX_PERSONAL_SKILLS_PER_USER:
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                f"Installing {install_count} skill(s) would exceed your limit of "
+                f"{MAX_PERSONAL_SKILLS_PER_USER} personal skills "
+                f"(you currently have {existing}).",
+            )
+
+    created_rows, failures = _install_repo_skills(
+        source=source,
+        slugs=slugs,
+        author_user_id=user.id,
+        is_public=False,
+        group_ids=[],
+        db_session=db_session,
+        before_install=_enforce_cap,
+    )
+
+    created_responses: list[CustomSkillResponse] = []
+    for row in created_rows:
+        push_skill_to_affected_sandboxes(row, db_session)
+        created_responses.append(CustomSkillResponse.from_model(row, group_ids=[]))
     return RepoSkillsInstallResult(created=created_responses, failures=failures)
 
 
@@ -671,99 +711,24 @@ def _install_admin_repo_skills(
     user: User,
     db_session: Session,
 ) -> RepoSkillsInstallResult:
-    parsed = parse_skill_source(source)
-    archive = fetch_repo_archive(parsed)
-    file_store = get_default_file_store()
+    created_rows, failures = _install_repo_skills(
+        source=source,
+        slugs=slugs,
+        author_user_id=user.id,
+        is_public=is_public,
+        group_ids=group_ids,
+        db_session=db_session,
+    )
 
-    # Dedupe preserving order.
-    seen_slugs: set[str] = set()
-    unique_slugs: list[str] = []
-    for s in slugs:
-        if s not in seen_slugs:
-            seen_slugs.add(s)
-            unique_slugs.append(s)
-
-    if not unique_slugs:
-        raise OnyxError(OnyxErrorCode.INVALID_INPUT, "no skills selected")
-
-    failures: list[RepoSkillInstallFailure] = []
-    created_responses: list[CustomSkillResponse] = []
-
-    with extracted_skills(archive, parsed.subpath) as discovered:
-        by_slug = {s.slug: s for s in discovered}
-
-        to_install = []
-        for slug in unique_slugs:
-            if slug not in by_slug:
-                failures.append(
-                    RepoSkillInstallFailure(slug=slug, error="not found in repository")
-                )
-            else:
-                to_install.append(by_slug[slug])
-
-        created_rows: list[Skill] = []
-        batch_blob_ids: list[str] = []
-
-        for skill in to_install:
-            blob_id = None
-            try:
-                if skill.slug in _RESERVED_SKILL_SLUGS:
-                    raise OnyxError(
-                        OnyxErrorCode.INVALID_INPUT,
-                        f"slug '{skill.slug}' is reserved",
-                    )
-                bundle = build_bundle_for_skill(skill)
-                ingested = ingest_skill_bundle(
-                    bundle, None, file_store, slug=skill.slug
-                )
-                blob_id = ingested.bundle_file_id
-                sp = db_session.begin_nested()
-                try:
-                    row = create_skill__no_commit(
-                        slug=ingested.slug,
-                        name=ingested.name,
-                        description=ingested.description,
-                        bundle_file_id=ingested.bundle_file_id,
-                        bundle_sha256=ingested.bundle_sha256,
-                        is_public=is_public,
-                        author_user_id=user.id,
-                        db_session=db_session,
-                    )
-                    if group_ids:
-                        replace_skill_grants(row.id, group_ids, db_session=db_session)
-                    sp.commit()
-                except Exception:
-                    sp.rollback()
-                    raise
-                created_rows.append(row)
-                batch_blob_ids.append(blob_id)
-            except Exception as e:
-                # Drop a single failing skill to a failure entry instead of
-                # aborting the batch; the savepoint already rolled back.
-                if blob_id is not None:
-                    delete_bundle_blob(file_store, blob_id)
-                if not isinstance(e, OnyxError):
-                    logger.exception("Unexpected error installing skill %s", skill.slug)
-                error = e.detail if isinstance(e, OnyxError) else "internal error"
-                failures.append(RepoSkillInstallFailure(slug=skill.slug, error=error))
-
-        try:
-            db_session.commit()
-        except Exception:
-            for bid in batch_blob_ids:
-                delete_bundle_blob(file_store, bid)
-            raise
-
-        affected: set[UUID] = set()
-        for row in created_rows:
-            affected |= affected_user_ids_for_skill(row, db_session)
+    affected: set[UUID] = set()
+    for row in created_rows:
+        affected |= affected_user_ids_for_skill(row, db_session)
+    if affected:
         push_skills_for_users(affected, db_session)
 
-        for row in created_rows:
-            created_responses.append(
-                CustomSkillResponse.from_model(row, group_ids=group_ids)
-            )
-
+    created_responses = [
+        CustomSkillResponse.from_model(row, group_ids=group_ids) for row in created_rows
+    ]
     return RepoSkillsInstallResult(created=created_responses, failures=failures)
 
 

--- a/backend/onyx/server/features/skill/models.py
+++ b/backend/onyx/server/features/skill/models.py
@@ -6,6 +6,7 @@ from typing import Literal
 from uuid import UUID
 
 from pydantic import BaseModel
+from pydantic import Field
 from pydantic import model_validator
 from sqlalchemy.orm import Session
 
@@ -124,3 +125,41 @@ class PersonalSkillPatchRequest(BaseModel):
 
 class GrantsReplace(BaseModel):
     group_ids: list[int]
+
+
+class RepoSkillsPreviewRequest(BaseModel):
+    source: str
+
+
+class RepoSkillPreviewItem(BaseModel):
+    slug: str
+    name: str
+    description: str
+    rel_path: str
+    pre_selected: bool
+
+
+class RepoSkillsPreview(BaseModel):
+    source_label: str
+    ref: str | None
+    skills: list[RepoSkillPreviewItem]
+
+
+class RepoSkillsInstallRequest(BaseModel):
+    source: str
+    slugs: list[str]
+
+
+class AdminRepoSkillsInstallRequest(RepoSkillsInstallRequest):
+    is_public: bool = False
+    group_ids: list[int] = Field(default_factory=list)
+
+
+class RepoSkillInstallFailure(BaseModel):
+    slug: str
+    error: str
+
+
+class RepoSkillsInstallResult(BaseModel):
+    created: list[CustomSkillResponse]
+    failures: list[RepoSkillInstallFailure]

--- a/backend/onyx/skills/bundle.py
+++ b/backend/onyx/skills/bundle.py
@@ -73,36 +73,8 @@ def read_bundle_file(bundle_file: BinaryIO) -> bytes:
     return data
 
 
-def parse_skill_md_metadata(zip_bytes: bytes) -> tuple[str, str]:
-    """Extract ``(name, description)`` from the bundle's SKILL.md frontmatter.
-
-    The bundle is the source of truth for skill metadata. ``validate_custom_bundle``
-    has already confirmed structural shape; here we re-open the zip just for the
-    SKILL.md payload because parsing frontmatter requires the contents, not the
-    archive layout.
-    """
-    try:
-        zf = zipfile.ZipFile(io.BytesIO(zip_bytes))
-    except zipfile.BadZipFile:
-        raise OnyxError(OnyxErrorCode.INVALID_INPUT, "bundle is not a valid zip")
-
-    with zf:
-        try:
-            raw = zf.read(SKILL_MD_NAME)
-        except KeyError:
-            raise OnyxError(
-                OnyxErrorCode.INVALID_INPUT,
-                "SKILL.md missing at bundle root",
-            )
-
-    try:
-        content = raw.decode("utf-8")
-    except UnicodeDecodeError as exc:
-        raise OnyxError(
-            OnyxErrorCode.INVALID_INPUT,
-            "SKILL.md must be UTF-8 encoded",
-        ) from exc
-
+def parse_skill_md_text(content: str) -> tuple[str, str]:
+    """Parse ``(name, description)`` from the raw text of a SKILL.md file."""
     match = _FRONTMATTER_REGEX.match(content)
     if match is None:
         raise OnyxError(
@@ -136,6 +108,39 @@ def parse_skill_md_metadata(zip_bytes: bytes) -> tuple[str, str]:
             "SKILL.md frontmatter must include a non-empty 'description'",
         )
     return name.strip(), description.strip()
+
+
+def parse_skill_md_metadata(zip_bytes: bytes) -> tuple[str, str]:
+    """Extract ``(name, description)`` from the bundle's SKILL.md frontmatter.
+
+    The bundle is the source of truth for skill metadata. ``validate_custom_bundle``
+    has already confirmed structural shape; here we re-open the zip just for the
+    SKILL.md payload because parsing frontmatter requires the contents, not the
+    archive layout.
+    """
+    try:
+        zf = zipfile.ZipFile(io.BytesIO(zip_bytes))
+    except zipfile.BadZipFile:
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, "bundle is not a valid zip")
+
+    with zf:
+        try:
+            raw = zf.read(SKILL_MD_NAME)
+        except KeyError:
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                "SKILL.md missing at bundle root",
+            )
+
+    try:
+        content = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "SKILL.md must be UTF-8 encoded",
+        ) from exc
+
+    return parse_skill_md_text(content)
 
 
 def _is_symlink(info: zipfile.ZipInfo) -> bool:

--- a/backend/onyx/skills/marketplace.py
+++ b/backend/onyx/skills/marketplace.py
@@ -15,6 +15,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from urllib.parse import urlparse
 
+import requests
 from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
@@ -241,6 +242,11 @@ def fetch_repo_archive(source: ParsedSource) -> bytes:
             OnyxErrorCode.INVALID_INPUT,
             f"SSRF check failed for '{url}': {exc}",
         ) from exc
+    except requests.RequestException as exc:
+        raise OnyxError(
+            OnyxErrorCode.BAD_GATEWAY,
+            f"failed to reach '{url}': {exc}",
+        ) from exc
 
     if response.status_code == 404:
         raise OnyxError(
@@ -255,16 +261,22 @@ def fetch_repo_archive(source: ParsedSource) -> bytes:
 
     chunks: list[bytes] = []
     total = 0
-    for chunk in response.iter_content(chunk_size=64 * 1024):
-        if not chunk:
-            continue
-        total += len(chunk)
-        if total > SKILL_MARKETPLACE_ARCHIVE_MAX_BYTES:
-            raise OnyxError(
-                OnyxErrorCode.PAYLOAD_TOO_LARGE,
-                f"archive exceeds {SKILL_MARKETPLACE_ARCHIVE_MAX_BYTES // (1024 * 1024)} MiB",
-            )
-        chunks.append(chunk)
+    try:
+        for chunk in response.iter_content(chunk_size=64 * 1024):
+            if not chunk:
+                continue
+            total += len(chunk)
+            if total > SKILL_MARKETPLACE_ARCHIVE_MAX_BYTES:
+                raise OnyxError(
+                    OnyxErrorCode.PAYLOAD_TOO_LARGE,
+                    f"archive exceeds {SKILL_MARKETPLACE_ARCHIVE_MAX_BYTES // (1024 * 1024)} MiB",
+                )
+            chunks.append(chunk)
+    except requests.RequestException as exc:
+        raise OnyxError(
+            OnyxErrorCode.BAD_GATEWAY,
+            f"error streaming archive from '{url}': {exc}",
+        ) from exc
 
     return b"".join(chunks)
 
@@ -523,8 +535,10 @@ def _discover_skills_in_dir(
         except Exception:
             continue
 
-        # slug: dir basename, except when the dir IS the search root (use repo dir name).
-        if skill_dir.resolve() == search_root.resolve():
+        # slug: dir basename. Only a true repo-root SKILL.md (no subpath) falls
+        # back to the repo wrapper dir name; a subpath leaf (e.g. a tree URL
+        # pointing at skills/docx) keeps its own dir name.
+        if skill_dir.resolve() == repo_root_resolved:
             slug_candidate = repo_root.name.lower()
             # Strip common suffixes like -main, -master
             for suffix in ("-main", "-master"):

--- a/backend/onyx/skills/marketplace.py
+++ b/backend/onyx/skills/marketplace.py
@@ -54,11 +54,6 @@ class DiscoveredSkill:
     abs_dir: Path
 
 
-# ---------------------------------------------------------------------------
-# parse_skill_source
-# ---------------------------------------------------------------------------
-
-
 def _strip_skills_command(raw: str) -> tuple[str, list[str]]:
     """Strip leading npx/skills/add tokens; collect --skill/-s values.
 
@@ -71,7 +66,6 @@ def _strip_skills_command(raw: str) -> tuple[str, list[str]]:
     # Drop package name variants: skills, skills@latest, skills@X.Y.Z
     if tokens and (tokens[0] == "skills" or tokens[0].startswith("skills@")):
         tokens.pop(0)
-    # Drop 'add' subcommand
     if tokens and tokens[0] == "add":
         tokens.pop(0)
 
@@ -125,14 +119,12 @@ def parse_skill_source(raw: str) -> ParsedSource:
     if not source_token:
         raise OnyxError(OnyxErrorCode.INVALID_INPUT, "no source found in input")
 
-    # Full URL
     if source_token.startswith("https://") or source_token.startswith("http://"):
         return _parse_url_source(source_token, skill_filters)
 
     # Bare owner/repo (may contain a host prefix like github.com/owner/repo)
     if "/" in source_token:
         parts = source_token.split("/")
-        # Check if first segment looks like a hostname
         if "." in parts[0]:
             host = parts[0].lower()
             if host not in _SUPPORTED_HOSTS:
@@ -155,7 +147,6 @@ def parse_skill_source(raw: str) -> ParsedSource:
                 subpath=None,
                 skill_filters=skill_filters,
             )
-        # Bare owner/repo
         if len(parts) < 2:
             raise OnyxError(
                 OnyxErrorCode.INVALID_INPUT,
@@ -222,11 +213,6 @@ def _parse_url_source(url: str, skill_filters: list[str]) -> ParsedSource:
     )
 
 
-# ---------------------------------------------------------------------------
-# fetch_repo_archive
-# ---------------------------------------------------------------------------
-
-
 def fetch_repo_archive(source: ParsedSource) -> bytes:
     """Download the repository tar.gz archive for the given ParsedSource."""
     ref = source.ref or "HEAD"
@@ -277,11 +263,6 @@ def fetch_repo_archive(source: ParsedSource) -> bytes:
         chunks.append(chunk)
 
     return b"".join(chunks)
-
-
-# ---------------------------------------------------------------------------
-# discover_skills
-# ---------------------------------------------------------------------------
 
 
 def _safe_extract_tar(
@@ -337,7 +318,6 @@ def _safe_extract_tar(
                 target.mkdir(parents=True, exist_ok=True)
                 continue
 
-            # Regular file: enforce size caps.
             if member.size > DEFAULT_PER_FILE_MAX_BYTES:
                 raise OnyxError(
                     OnyxErrorCode.PAYLOAD_TOO_LARGE,
@@ -528,7 +508,6 @@ def _discover_skills_in_dir(
     for d in _parse_manifest_skill_dirs(search_root):
         _add(d)
 
-    # Build DiscoveredSkill for each valid dir.
     results: list[DiscoveredSkill] = []
     repo_root_resolved = repo_root.resolve()
     for skill_dir in skill_dirs:
@@ -572,11 +551,6 @@ def _discover_skills_in_dir(
         )
 
     return sorted(results, key=lambda s: s.slug)
-
-
-# ---------------------------------------------------------------------------
-# build_bundle_for_skill
-# ---------------------------------------------------------------------------
 
 
 def build_bundle_for_skill(skill: DiscoveredSkill) -> bytes:
@@ -625,11 +599,6 @@ def build_bundle_for_skill(skill: DiscoveredSkill) -> bytes:
                 zf.write(file_path, arcname=arc_name)
 
     return buf.getvalue()
-
-
-# ---------------------------------------------------------------------------
-# extracted_skills
-# ---------------------------------------------------------------------------
 
 
 @contextmanager

--- a/backend/onyx/skills/marketplace.py
+++ b/backend/onyx/skills/marketplace.py
@@ -1,0 +1,649 @@
+"""Skills marketplace: fetch and unpack skill bundles from git hosting providers."""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import re
+import shutil
+import tarfile
+import tempfile
+import zipfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from dataclasses import field
+from pathlib import Path
+from urllib.parse import urlparse
+
+from onyx.configs.app_configs import SKILL_MARKETPLACE_ARCHIVE_MAX_BYTES
+from onyx.configs.app_configs import SKILL_MARKETPLACE_FETCH_TIMEOUT_SECONDS
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.skills.built_in import SLUG_REGEX
+from onyx.skills.bundle import DEFAULT_PER_FILE_MAX_BYTES
+from onyx.skills.bundle import DEFAULT_TOTAL_MAX_BYTES
+from onyx.skills.bundle import parse_skill_md_text
+from onyx.skills.bundle import SKILL_MD_NAME
+from onyx.skills.bundle import TEMPLATE_SUFFIX
+from onyx.utils.url import ssrf_safe_get
+from onyx.utils.url import SSRFException
+
+_SUPPORTED_HOSTS = ("github.com", "gitlab.com")
+# Maximum number of tar members to extract (zip-bomb / runaway archive guard).
+_TAR_MAX_MEMBERS = 10_000
+
+
+@dataclass(frozen=True)
+class ParsedSource:
+    host: str
+    owner: str
+    repo: str
+    ref: str | None
+    subpath: str | None
+    skill_filters: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class DiscoveredSkill:
+    slug: str
+    name: str
+    description: str
+    rel_path: str
+    abs_dir: Path
+
+
+# ---------------------------------------------------------------------------
+# parse_skill_source
+# ---------------------------------------------------------------------------
+
+
+def _strip_skills_command(raw: str) -> tuple[str, list[str]]:
+    """Strip leading npx/skills/add tokens; collect --skill/-s values.
+
+    Returns (source_token, skill_filters).
+    """
+    tokens = raw.split()
+    # Drop npx variants and the skills binary name
+    while tokens and tokens[0] in ("npx", "-y", "npx-y"):
+        tokens.pop(0)
+    # Drop package name variants: skills, skills@latest, skills@X.Y.Z
+    if tokens and (tokens[0] == "skills" or tokens[0].startswith("skills@")):
+        tokens.pop(0)
+    # Drop 'add' subcommand
+    if tokens and tokens[0] == "add":
+        tokens.pop(0)
+
+    # Flags that consume a following value (besides --skill/-s which we collect).
+    _VALUE_FLAGS = {"--agent", "-a"}
+    # Boolean flags to skip (no following value).
+    _BOOL_FLAGS = {"--global", "-g", "--yes", "-y", "--copy", "--all", "--list", "-l"}
+
+    skill_filters: list[str] = []
+    source: str | None = None
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok in ("--skill", "-s"):
+            i += 1
+            if i < len(tokens):
+                skill_filters.append(tokens[i])
+        elif tok in _VALUE_FLAGS:
+            i += 1  # skip value
+        elif tok in _BOOL_FLAGS:
+            pass
+        elif tok.startswith("-"):
+            # Unknown flag; if it contains '=' it's self-contained, else skip next.
+            if "=" not in tok:
+                i += 1
+        else:
+            if source is None:
+                source = tok
+        i += 1
+
+    return source or "", skill_filters
+
+
+def parse_skill_source(raw: str) -> ParsedSource:
+    """Parse a skills.sh command, bare owner/repo, or full URL into ParsedSource."""
+    stripped = raw.strip()
+
+    # Detect skills.sh command by presence of 'add' keyword before non-flag token,
+    # or by leading npx/skills prefix.
+    looks_like_command = (
+        any(stripped.startswith(prefix) for prefix in ("npx ", "skills ", "skills@"))
+        or " add " in stripped
+    )
+
+    if looks_like_command:
+        source_token, skill_filters = _strip_skills_command(stripped)
+    else:
+        source_token = stripped
+        skill_filters = []
+
+    if not source_token:
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, "no source found in input")
+
+    # Full URL
+    if source_token.startswith("https://") or source_token.startswith("http://"):
+        return _parse_url_source(source_token, skill_filters)
+
+    # Bare owner/repo (may contain a host prefix like github.com/owner/repo)
+    if "/" in source_token:
+        parts = source_token.split("/")
+        # Check if first segment looks like a hostname
+        if "." in parts[0]:
+            host = parts[0].lower()
+            if host not in _SUPPORTED_HOSTS:
+                raise OnyxError(
+                    OnyxErrorCode.INVALID_INPUT,
+                    f"unsupported host '{host}'; supported: {', '.join(_SUPPORTED_HOSTS)}",
+                )
+            if len(parts) < 3:
+                raise OnyxError(
+                    OnyxErrorCode.INVALID_INPUT,
+                    f"cannot extract owner and repo from '{source_token}'",
+                )
+            owner = parts[1]
+            repo = parts[2].removesuffix(".git")
+            return ParsedSource(
+                host=host,
+                owner=owner,
+                repo=repo,
+                ref=None,
+                subpath=None,
+                skill_filters=skill_filters,
+            )
+        # Bare owner/repo
+        if len(parts) < 2:
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                f"cannot extract owner and repo from '{source_token}'",
+            )
+        owner = parts[0]
+        repo = parts[1].removesuffix(".git")
+        return ParsedSource(
+            host="github.com",
+            owner=owner,
+            repo=repo,
+            ref=None,
+            subpath=None,
+            skill_filters=skill_filters,
+        )
+
+    raise OnyxError(
+        OnyxErrorCode.INVALID_INPUT,
+        f"cannot extract owner and repo from '{source_token}'",
+    )
+
+
+def _parse_url_source(url: str, skill_filters: list[str]) -> ParsedSource:
+    """Parse a full https:// URL into ParsedSource."""
+    parsed = urlparse(url)
+    host = (parsed.hostname or "").lower()
+    if host not in _SUPPORTED_HOSTS:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            f"unsupported host '{host}'; supported: {', '.join(_SUPPORTED_HOSTS)}",
+        )
+
+    # path looks like /owner/repo[.git][/tree/<ref>[/subpath...]]
+    path_parts = [p for p in parsed.path.split("/") if p]
+    if len(path_parts) < 2:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            f"cannot extract owner and repo from URL '{url}'",
+        )
+
+    owner = path_parts[0]
+    repo = path_parts[1].removesuffix(".git")
+    ref: str | None = None
+    subpath: str | None = None
+
+    # /owner/repo/tree/<ref>[/<subpath>...]
+    if len(path_parts) > 2 and path_parts[2] == "tree":
+        if len(path_parts) < 4:
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                f"malformed tree URL '{url}': missing ref after /tree/",
+            )
+        ref = path_parts[3]
+        if len(path_parts) > 4:
+            subpath = "/".join(path_parts[4:])
+
+    return ParsedSource(
+        host=host,
+        owner=owner,
+        repo=repo,
+        ref=ref,
+        subpath=subpath,
+        skill_filters=skill_filters,
+    )
+
+
+# ---------------------------------------------------------------------------
+# fetch_repo_archive
+# ---------------------------------------------------------------------------
+
+
+def fetch_repo_archive(source: ParsedSource) -> bytes:
+    """Download the repository tar.gz archive for the given ParsedSource."""
+    ref = source.ref or "HEAD"
+
+    if source.host == "github.com":
+        url = f"https://codeload.github.com/{source.owner}/{source.repo}/tar.gz/{ref}"
+    else:
+        # gitlab.com
+        url = (
+            f"https://gitlab.com/{source.owner}/{source.repo}"
+            f"/-/archive/{ref}/{source.repo}-{ref}.tar.gz"
+        )
+
+    try:
+        response = ssrf_safe_get(
+            url,
+            timeout=SKILL_MARKETPLACE_FETCH_TIMEOUT_SECONDS,
+            stream=True,
+        )
+    except SSRFException as exc:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            f"SSRF check failed for '{url}': {exc}",
+        ) from exc
+
+    if response.status_code == 404:
+        raise OnyxError(
+            OnyxErrorCode.NOT_FOUND,
+            f"Repository or ref not found: {source.owner}/{source.repo}@{ref}",
+        )
+    if response.status_code != 200:
+        raise OnyxError(
+            OnyxErrorCode.BAD_GATEWAY,
+            f"unexpected status {response.status_code} fetching '{url}'",
+        )
+
+    chunks: list[bytes] = []
+    total = 0
+    for chunk in response.iter_content(chunk_size=64 * 1024):
+        if not chunk:
+            continue
+        total += len(chunk)
+        if total > SKILL_MARKETPLACE_ARCHIVE_MAX_BYTES:
+            raise OnyxError(
+                OnyxErrorCode.PAYLOAD_TOO_LARGE,
+                f"archive exceeds {SKILL_MARKETPLACE_ARCHIVE_MAX_BYTES // (1024 * 1024)} MiB",
+            )
+        chunks.append(chunk)
+
+    return b"".join(chunks)
+
+
+# ---------------------------------------------------------------------------
+# discover_skills
+# ---------------------------------------------------------------------------
+
+
+def _safe_extract_tar(
+    archive_bytes: bytes,
+    dest: Path,
+) -> None:
+    """Extract a tar.gz archive into dest with path-traversal and size guards."""
+    buf = io.BytesIO(archive_bytes)
+    try:
+        tf = tarfile.open(fileobj=buf, mode="r:gz")
+    except tarfile.TarError as exc:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            f"archive is not a valid tar.gz: {exc}",
+        ) from exc
+
+    dest_resolved = dest.resolve()
+    member_count = 0
+    total_bytes = 0
+
+    with tf:
+        for member in tf:
+            member_count += 1
+            if member_count > _TAR_MAX_MEMBERS:
+                raise OnyxError(
+                    OnyxErrorCode.INVALID_INPUT,
+                    f"archive exceeds {_TAR_MAX_MEMBERS} members",
+                )
+
+            # Reject symlinks, hardlinks, and device files — only regular files and dirs.
+            if member.issym() or member.islnk():
+                raise OnyxError(
+                    OnyxErrorCode.INVALID_INPUT,
+                    f"archive contains a symlink/hardlink: '{member.name}'",
+                )
+            if not (member.isreg() or member.isdir()):
+                raise OnyxError(
+                    OnyxErrorCode.INVALID_INPUT,
+                    f"archive contains unsupported entry type: '{member.name}'",
+                )
+
+            # Resolve target and check it stays inside dest.
+            target = (dest / member.name).resolve()
+            try:
+                target.relative_to(dest_resolved)
+            except ValueError:
+                raise OnyxError(
+                    OnyxErrorCode.INVALID_INPUT,
+                    f"archive entry escapes root: '{member.name}'",
+                )
+
+            if member.isdir():
+                target.mkdir(parents=True, exist_ok=True)
+                continue
+
+            # Regular file: enforce size caps.
+            if member.size > DEFAULT_PER_FILE_MAX_BYTES:
+                raise OnyxError(
+                    OnyxErrorCode.PAYLOAD_TOO_LARGE,
+                    f"file '{member.name}' exceeds "
+                    f"{DEFAULT_PER_FILE_MAX_BYTES // (1024 * 1024)} MiB",
+                )
+            total_bytes += member.size
+            if total_bytes > DEFAULT_TOTAL_MAX_BYTES:
+                raise OnyxError(
+                    OnyxErrorCode.PAYLOAD_TOO_LARGE,
+                    f"archive exceeds {DEFAULT_TOTAL_MAX_BYTES // (1024 * 1024)} MiB uncompressed",
+                )
+
+            target.parent.mkdir(parents=True, exist_ok=True)
+            fobj = tf.extractfile(member)
+            if fobj is None:
+                continue
+            with fobj, open(target, "wb") as out:
+                written = 0
+                while True:
+                    chunk = fobj.read(64 * 1024)
+                    if not chunk:
+                        break
+                    written += len(chunk)
+                    if written > DEFAULT_PER_FILE_MAX_BYTES:
+                        raise OnyxError(
+                            OnyxErrorCode.PAYLOAD_TOO_LARGE,
+                            f"file '{member.name}' exceeds "
+                            f"{DEFAULT_PER_FILE_MAX_BYTES // (1024 * 1024)} MiB",
+                        )
+                    out.write(chunk)
+
+
+def _strip_top_level_dir(root: Path) -> Path:
+    """If root contains exactly one child directory, return it (GitHub/GitLab wrap)."""
+    children = list(root.iterdir())
+    if len(children) == 1 and children[0].is_dir():
+        return children[0]
+    return root
+
+
+def _parse_manifest_skill_dirs(search_root: Path) -> list[Path]:
+    """Read .claude-plugin/marketplace.json or plugin.json for declared skill dirs.
+
+    Manifest content is untrusted (it ships inside the fetched archive), so every
+    declared path is confined to ``search_root`` — absolute paths, ``..`` escapes,
+    and anything resolving outside the repo root are skipped.
+    """
+    root_resolved = search_root.resolve()
+
+    def _confined(base: Path, rel: str) -> Path | None:
+        if rel.startswith("/") or ".." in Path(rel).parts:
+            return None
+        candidate = (base / rel).resolve()
+        try:
+            candidate.relative_to(root_resolved)
+        except ValueError:
+            return None
+        return candidate if candidate.is_dir() else None
+
+    dirs: list[Path] = []
+    for name in ("marketplace.json", "plugin.json"):
+        manifest_path = search_root / ".claude-plugin" / name
+        if not manifest_path.is_file():
+            continue
+        try:
+            data = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        if not isinstance(data, dict):
+            continue
+
+        # Format 1: top-level "skills" array of relative paths
+        skills_list = data.get("skills")
+        if isinstance(skills_list, list):
+            for entry in skills_list:
+                if not isinstance(entry, str):
+                    continue
+                confined = _confined(search_root, entry)
+                if confined is not None:
+                    dirs.append(confined)
+
+        # Format 2: "plugins" list with metadata.pluginRoot and skills
+        plugins = data.get("plugins")
+        if isinstance(plugins, list):
+            for plugin in plugins:
+                if not isinstance(plugin, dict):
+                    continue
+                meta = plugin.get("metadata", {})
+                plugin_root_rel = (
+                    meta.get("pluginRoot", "") if isinstance(meta, dict) else ""
+                )
+                plugin_root = search_root
+                if plugin_root_rel:
+                    confined_root = _confined(search_root, plugin_root_rel)
+                    if confined_root is None:
+                        continue
+                    plugin_root = confined_root
+                skill_entries = plugin.get("skills", [])
+                if isinstance(skill_entries, list):
+                    for entry in skill_entries:
+                        if not isinstance(entry, str):
+                            continue
+                        confined = _confined(plugin_root, entry)
+                        if confined is not None:
+                            dirs.append(confined)
+    return dirs
+
+
+def _discover_skills_in_dir(
+    archive_bytes: bytes,
+    tmp: Path,
+    subpath: str | None = None,
+) -> list[DiscoveredSkill]:
+    """Core discovery logic operating on an already-created tmp directory."""
+    _safe_extract_tar(archive_bytes, tmp)
+    repo_root = _strip_top_level_dir(tmp)
+
+    # Determine search root, guarding against traversal.
+    if subpath:
+        search_root = (repo_root / subpath).resolve()
+        try:
+            search_root.relative_to(repo_root.resolve())
+        except ValueError:
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                f"subpath '{subpath}' escapes repository root",
+            )
+        if not search_root.is_dir():
+            raise OnyxError(
+                OnyxErrorCode.NOT_FOUND,
+                f"subpath '{subpath}' not found in archive",
+            )
+    else:
+        search_root = repo_root
+
+    seen: set[Path] = set()
+    skill_dirs: list[Path] = []
+
+    def _add(d: Path) -> None:
+        resolved = d.resolve()
+        if (
+            resolved not in seen
+            and resolved.is_dir()
+            and (resolved / SKILL_MD_NAME).is_file()
+        ):
+            seen.add(resolved)
+            skill_dirs.append(d)
+
+    # Root-level SKILL.md
+    _add(search_root)
+
+    # Flat: skills/*/SKILL.md
+    skills_base = search_root / "skills"
+    if skills_base.is_dir():
+        for d in sorted(skills_base.iterdir()):
+            if d.is_dir() and not d.name.startswith("."):
+                _add(d)
+        # Catalog: skills/*/*/SKILL.md
+        for d in sorted(skills_base.iterdir()):
+            if d.is_dir() and not d.name.startswith("."):
+                for sub in sorted(d.iterdir()):
+                    if sub.is_dir():
+                        _add(sub)
+        # Hidden curated containers
+        for hidden in (".curated", ".experimental"):
+            container = skills_base / hidden
+            if container.is_dir():
+                for d in sorted(container.iterdir()):
+                    if d.is_dir():
+                        _add(d)
+
+    # .claude/skills/*/SKILL.md
+    claude_skills = search_root / ".claude" / "skills"
+    if claude_skills.is_dir():
+        for d in sorted(claude_skills.iterdir()):
+            if d.is_dir():
+                _add(d)
+
+    # .agents/skills/*/SKILL.md
+    agents_skills = search_root / ".agents" / "skills"
+    if agents_skills.is_dir():
+        for d in sorted(agents_skills.iterdir()):
+            if d.is_dir():
+                _add(d)
+
+    # Manifest-declared dirs
+    for d in _parse_manifest_skill_dirs(search_root):
+        _add(d)
+
+    # Build DiscoveredSkill for each valid dir.
+    results: list[DiscoveredSkill] = []
+    repo_root_resolved = repo_root.resolve()
+    for skill_dir in skill_dirs:
+        try:
+            skill_md_text = (skill_dir / SKILL_MD_NAME).read_text(encoding="utf-8")
+            name, description = parse_skill_md_text(skill_md_text)
+        except OnyxError:
+            continue
+        except Exception:
+            continue
+
+        # slug: dir basename, except when the dir IS the search root (use repo dir name).
+        if skill_dir.resolve() == search_root.resolve():
+            slug_candidate = repo_root.name.lower()
+            # Strip common suffixes like -main, -master
+            for suffix in ("-main", "-master"):
+                if slug_candidate.endswith(suffix):
+                    slug_candidate = slug_candidate[: -len(suffix)]
+                    break
+        else:
+            slug_candidate = skill_dir.name.lower()
+
+        # Slugify: replace non-alnum with '-', strip leading/trailing '-'
+        slug = re.sub(r"[^a-z0-9]+", "-", slug_candidate).strip("-")
+        if not SLUG_REGEX.match(slug):
+            continue
+
+        try:
+            rel_path = str(skill_dir.resolve().relative_to(repo_root_resolved))
+        except ValueError:
+            rel_path = skill_dir.name
+
+        results.append(
+            DiscoveredSkill(
+                slug=slug,
+                name=name,
+                description=description,
+                rel_path=rel_path,
+                abs_dir=skill_dir.resolve(),
+            )
+        )
+
+    return sorted(results, key=lambda s: s.slug)
+
+
+# ---------------------------------------------------------------------------
+# build_bundle_for_skill
+# ---------------------------------------------------------------------------
+
+
+def build_bundle_for_skill(skill: DiscoveredSkill) -> bytes:
+    """Produce an in-memory zip of a discovered skill's contents.
+
+    The zip root contains the skill dir's contents (SKILL.md at root, all
+    sibling files/subdirs). Excludes symlinks, .template files, and __pycache__.
+    """
+    buf = io.BytesIO()
+    total = 0
+
+    with zipfile.ZipFile(buf, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
+        skill_root = skill.abs_dir
+        for dirpath, dirnames, filenames in os.walk(skill_root):
+            # Prune __pycache__ in-place so os.walk skips them.
+            dirnames[:] = [d for d in dirnames if d != "__pycache__"]
+
+            dir_path = Path(dirpath)
+            for filename in filenames:
+                file_path = dir_path / filename
+
+                # Skip symlinks and .template files.
+                if file_path.is_symlink():
+                    continue
+                if filename.endswith(TEMPLATE_SUFFIX):
+                    continue
+
+                rel = file_path.relative_to(skill_root)
+                arc_name = str(rel)
+
+                file_size = file_path.stat().st_size
+                if file_size > DEFAULT_PER_FILE_MAX_BYTES:
+                    raise OnyxError(
+                        OnyxErrorCode.PAYLOAD_TOO_LARGE,
+                        f"file '{arc_name}' exceeds "
+                        f"{DEFAULT_PER_FILE_MAX_BYTES // (1024 * 1024)} MiB",
+                    )
+                total += file_size
+                if total > DEFAULT_TOTAL_MAX_BYTES:
+                    raise OnyxError(
+                        OnyxErrorCode.PAYLOAD_TOO_LARGE,
+                        f"skill bundle exceeds "
+                        f"{DEFAULT_TOTAL_MAX_BYTES // (1024 * 1024)} MiB uncompressed",
+                    )
+
+                zf.write(file_path, arcname=arc_name)
+
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# extracted_skills
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def extracted_skills(
+    archive_bytes: bytes,
+    subpath: str | None = None,
+) -> Iterator[list[DiscoveredSkill]]:
+    """Context manager: extract archive, yield discovered skills, then clean up.
+
+    abs_dir on each DiscoveredSkill is only valid inside this with-block.
+    """
+    tmp = Path(tempfile.mkdtemp())
+    try:
+        skills = _discover_skills_in_dir(archive_bytes, tmp, subpath)
+        yield skills
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)

--- a/backend/onyx/skills/marketplace.py
+++ b/backend/onyx/skills/marketplace.py
@@ -197,16 +197,22 @@ def _parse_url_source(url: str, skill_filters: list[str]) -> ParsedSource:
     ref: str | None = None
     subpath: str | None = None
 
-    # /owner/repo/tree/<ref>[/<subpath>...]
-    if len(path_parts) > 2 and path_parts[2] == "tree":
-        if len(path_parts) < 4:
+    # Tree/ref form: GitHub /owner/repo/tree/<ref>[/<subpath>...] and GitLab
+    # /owner/repo/-/tree/<ref>[/<subpath>...] (GitLab inserts a "-" separator
+    # before tree/blob). A slash-containing ref is not disambiguated from the
+    # subpath — the first segment after tree is taken as the ref.
+    rest = path_parts[2:]
+    if rest and rest[0] == "-":
+        rest = rest[1:]
+    if rest and rest[0] == "tree":
+        if len(rest) < 2:
             raise OnyxError(
                 OnyxErrorCode.INVALID_INPUT,
                 f"malformed tree URL '{url}': missing ref after /tree/",
             )
-        ref = path_parts[3]
-        if len(path_parts) > 4:
-            subpath = "/".join(path_parts[4:])
+        ref = rest[1]
+        if len(rest) > 2:
+            subpath = "/".join(rest[2:])
 
     return ParsedSource(
         host=host,
@@ -248,37 +254,41 @@ def fetch_repo_archive(source: ParsedSource) -> bytes:
             f"failed to reach '{url}': {exc}",
         ) from exc
 
-    if response.status_code == 404:
-        raise OnyxError(
-            OnyxErrorCode.NOT_FOUND,
-            f"Repository or ref not found: {source.owner}/{source.repo}@{ref}",
-        )
-    if response.status_code != 200:
-        raise OnyxError(
-            OnyxErrorCode.BAD_GATEWAY,
-            f"unexpected status {response.status_code} fetching '{url}'",
-        )
+    # Context-manage the streamed response so the connection is released on
+    # every exit path (status raises, size-cap, stream error, or success)
+    # rather than leaking until GC.
+    with response:
+        if response.status_code == 404:
+            raise OnyxError(
+                OnyxErrorCode.NOT_FOUND,
+                f"Repository or ref not found: {source.owner}/{source.repo}@{ref}",
+            )
+        if response.status_code != 200:
+            raise OnyxError(
+                OnyxErrorCode.BAD_GATEWAY,
+                f"unexpected status {response.status_code} fetching '{url}'",
+            )
 
-    chunks: list[bytes] = []
-    total = 0
-    try:
-        for chunk in response.iter_content(chunk_size=64 * 1024):
-            if not chunk:
-                continue
-            total += len(chunk)
-            if total > SKILL_MARKETPLACE_ARCHIVE_MAX_BYTES:
-                raise OnyxError(
-                    OnyxErrorCode.PAYLOAD_TOO_LARGE,
-                    f"archive exceeds {SKILL_MARKETPLACE_ARCHIVE_MAX_BYTES // (1024 * 1024)} MiB",
-                )
-            chunks.append(chunk)
-    except requests.RequestException as exc:
-        raise OnyxError(
-            OnyxErrorCode.BAD_GATEWAY,
-            f"error streaming archive from '{url}': {exc}",
-        ) from exc
+        chunks: list[bytes] = []
+        total = 0
+        try:
+            for chunk in response.iter_content(chunk_size=64 * 1024):
+                if not chunk:
+                    continue
+                total += len(chunk)
+                if total > SKILL_MARKETPLACE_ARCHIVE_MAX_BYTES:
+                    raise OnyxError(
+                        OnyxErrorCode.PAYLOAD_TOO_LARGE,
+                        f"archive exceeds {SKILL_MARKETPLACE_ARCHIVE_MAX_BYTES // (1024 * 1024)} MiB",
+                    )
+                chunks.append(chunk)
+        except requests.RequestException as exc:
+            raise OnyxError(
+                OnyxErrorCode.BAD_GATEWAY,
+                f"error streaming archive from '{url}': {exc}",
+            ) from exc
 
-    return b"".join(chunks)
+        return b"".join(chunks)
 
 
 def _safe_extract_tar(

--- a/backend/onyx/skills/marketplace.py
+++ b/backend/onyx/skills/marketplace.py
@@ -12,10 +12,12 @@ import tempfile
 import zipfile
 from collections.abc import Iterator
 from contextlib import contextmanager
-from dataclasses import dataclass
-from dataclasses import field
 from pathlib import Path
 from urllib.parse import urlparse
+
+from pydantic import BaseModel
+from pydantic import ConfigDict
+from pydantic import Field
 
 from onyx.configs.app_configs import SKILL_MARKETPLACE_ARCHIVE_MAX_BYTES
 from onyx.configs.app_configs import SKILL_MARKETPLACE_FETCH_TIMEOUT_SECONDS
@@ -35,18 +37,20 @@ _SUPPORTED_HOSTS = ("github.com", "gitlab.com")
 _TAR_MAX_MEMBERS = 10_000
 
 
-@dataclass(frozen=True)
-class ParsedSource:
+class ParsedSource(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
     host: str
     owner: str
     repo: str
     ref: str | None
     subpath: str | None
-    skill_filters: list[str] = field(default_factory=list)
+    skill_filters: list[str] = Field(default_factory=list)
 
 
-@dataclass(frozen=True)
-class DiscoveredSkill:
+class DiscoveredSkill(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
     slug: str
     name: str
     description: str

--- a/backend/tests/external_dependency_unit/build/test_external_app_from_repo.py
+++ b/backend/tests/external_dependency_unit/build/test_external_app_from_repo.py
@@ -63,11 +63,6 @@ def _noop(*_args: object, **_kwargs: object) -> None:
     return None
 
 
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-
 @pytest.fixture(scope="function")
 def db_session() -> Generator[Session, None, None]:
     SqlEngine.init_engine(pool_size=10, max_overflow=5)
@@ -128,11 +123,6 @@ def initialize_file_store() -> Generator[None, None, None]:
         yield
     finally:
         CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
-
-
-# ---------------------------------------------------------------------------
-# Tests
-# ---------------------------------------------------------------------------
 
 
 class TestCreateCustomExternalAppFromRepo:

--- a/backend/tests/external_dependency_unit/build/test_external_app_from_repo.py
+++ b/backend/tests/external_dependency_unit/build/test_external_app_from_repo.py
@@ -1,0 +1,282 @@
+"""External-dependency tests for create_custom_external_app_from_repo.
+
+Requires: Postgres, MinIO/S3.
+Run via:
+  uv run python -m dotenv -f .vscode/.env run -- pytest \
+    backend/tests/external_dependency_unit/build/test_external_app_from_repo.py -q
+"""
+
+from __future__ import annotations
+
+import io
+import tarfile
+from collections.abc import Generator
+from uuid import uuid4
+
+import pytest
+from fastapi_users.password import PasswordHelper
+from sqlalchemy import delete
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+import onyx.server.features.build.external_apps.api as api
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import SqlEngine
+from onyx.db.enums import AccountType
+from onyx.db.enums import ExternalAppType
+from onyx.db.models import ExternalApp
+from onyx.db.models import Skill
+from onyx.db.models import User
+from onyx.db.models import UserRole
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.file_store.file_store import get_default_file_store
+from onyx.server.features.build.external_apps.models import (
+    CreateCustomExternalAppFromRepoRequest,
+)
+from onyx.skills.bundle import validate_custom_bundle
+from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
+from tests.external_dependency_unit.constants import TEST_TENANT_ID
+
+_UPSTREAM = ["https://api.example.com/*"]
+_AUTH_TEMPLATE: dict[str, str] = {"Authorization": "Bearer {api_key}"}
+_ORG_CREDENTIALS: dict[str, str] = {"api_key": "sk-test"}
+
+
+def _make_tar(files: dict[str, str]) -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        for name, data in files.items():
+            b = data.encode()
+            ti = tarfile.TarInfo(name)
+            ti.size = len(b)
+            ti.mtime = 0
+            tf.addfile(ti, io.BytesIO(b))
+    return buf.getvalue()
+
+
+def _skill_md(name: str = "My Skill", description: str = "does things") -> str:
+    return f"---\nname: {name}\ndescription: {description}\n---\n# body\n"
+
+
+def _noop(*_args: object, **_kwargs: object) -> None:
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="function")
+def db_session() -> Generator[Session, None, None]:
+    SqlEngine.init_engine(pool_size=10, max_overflow=5)
+    with get_session_with_current_tenant() as session:
+        yield session
+
+
+@pytest.fixture(scope="function")
+def tenant_context() -> Generator[None, None, None]:
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set(TEST_TENANT_ID)
+    try:
+        yield
+    finally:
+        CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+
+
+@pytest.fixture(scope="function")
+def test_user(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> Generator[User, None, None]:
+    helper = PasswordHelper()
+    user = User(
+        id=uuid4(),
+        email=f"repo_app_test_{uuid4().hex[:8]}@example.com",
+        hashed_password=helper.hash(helper.generate()),
+        is_active=True,
+        is_superuser=False,
+        is_verified=True,
+        role=UserRole.ADMIN,
+        account_type=AccountType.STANDARD,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    yield user
+    db_session.rollback()
+    try:
+        token = CURRENT_TENANT_ID_CONTEXTVAR.set(TEST_TENANT_ID)
+        try:
+            with get_session_with_current_tenant() as s:
+                row = s.get(User, user.id)
+                if row is not None:
+                    s.delete(row)
+                    s.commit()
+        finally:
+            CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+    except Exception:
+        pass
+
+
+@pytest.fixture(scope="module", autouse=True)
+def initialize_file_store() -> Generator[None, None, None]:
+    SqlEngine.init_engine(pool_size=10, max_overflow=5)
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set(TEST_TENANT_ID)
+    try:
+        get_default_file_store().initialize()
+        yield
+    finally:
+        CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCreateCustomExternalAppFromRepo:
+    def test_happy_path_creates_app_and_skill(
+        self,
+        db_session: Session,
+        test_user: User,
+        tenant_context: None,  # noqa: ARG002
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        slug = f"repo-skill-{uuid4().hex[:6]}"
+        archive = _make_tar(
+            {f"repo-main/skills/{slug}/SKILL.md": _skill_md("Repo Skill", "from repo")}
+        )
+        monkeypatch.setattr(api, "fetch_repo_archive", lambda _parsed: archive)
+        monkeypatch.setattr(api, "push_skill_to_affected_sandboxes", _noop)
+
+        body = CreateCustomExternalAppFromRepoRequest(
+            name="My Repo App",
+            description="",
+            upstream_url_patterns=_UPSTREAM,
+            auth_template=_AUTH_TEMPLATE,
+            organization_credentials=_ORG_CREDENTIALS,
+            enabled=True,
+            source="owner/repo",
+            slug=slug,
+        )
+        resp = api.create_custom_external_app_from_repo(
+            body=body,
+            _=test_user,
+            db_session=db_session,
+        )
+
+        assert resp.app_type == ExternalAppType.CUSTOM
+        assert resp.name == "My Repo App"
+        # blank description falls back to SKILL.md description
+        assert resp.description == "from repo"
+        assert resp.upstream_url_patterns == _UPSTREAM
+        assert resp.auth_template == _AUTH_TEMPLATE
+
+        skill = db_session.scalar(select(Skill).where(Skill.slug == slug))
+        assert skill is not None
+        assert skill.bundle_file_id  # bundle was stored
+
+        app = db_session.scalar(
+            select(ExternalApp).where(ExternalApp.skill_id == skill.id)
+        )
+        assert app is not None
+        assert app.app_type == ExternalAppType.CUSTOM
+
+        # verify stored bundle passes validation
+        file_store = get_default_file_store()
+        blob = b"".join(file_store.read_file(skill.bundle_file_id, use_tempfile=False))
+        validate_custom_bundle(blob, slug=slug)
+
+        db_session.execute(delete(Skill).where(Skill.slug == slug))
+        db_session.commit()
+
+    def test_nonexistent_slug_raises_not_found(
+        self,
+        db_session: Session,
+        test_user: User,
+        tenant_context: None,  # noqa: ARG002
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        present_slug = f"present-{uuid4().hex[:6]}"
+        archive = _make_tar(
+            {f"repo-main/skills/{present_slug}/SKILL.md": _skill_md("Present", "here")}
+        )
+        monkeypatch.setattr(api, "fetch_repo_archive", lambda _parsed: archive)
+        monkeypatch.setattr(api, "push_skill_to_affected_sandboxes", _noop)
+
+        body = CreateCustomExternalAppFromRepoRequest(
+            name="Missing",
+            description="",
+            upstream_url_patterns=_UPSTREAM,
+            auth_template={},
+            organization_credentials={},
+            enabled=True,
+            source="owner/repo",
+            slug="does-not-exist",
+        )
+        with pytest.raises(OnyxError) as exc_info:
+            api.create_custom_external_app_from_repo(
+                body=body,
+                _=test_user,
+                db_session=db_session,
+            )
+
+        err = exc_info.value
+        assert err.error_code == OnyxErrorCode.NOT_FOUND
+
+        # no orphan rows
+        assert (
+            db_session.scalar(select(Skill).where(Skill.slug == "does-not-exist"))
+            is None
+        )
+
+    def test_upstream_url_patterns_and_auth_template_persisted(
+        self,
+        db_session: Session,
+        test_user: User,
+        tenant_context: None,  # noqa: ARG002
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        slug = f"persist-test-{uuid4().hex[:6]}"
+        archive = _make_tar(
+            {f"repo-main/skills/{slug}/SKILL.md": _skill_md("Persist", "p")}
+        )
+        monkeypatch.setattr(api, "fetch_repo_archive", lambda _parsed: archive)
+        monkeypatch.setattr(api, "push_skill_to_affected_sandboxes", _noop)
+
+        auth = {"X-Api-Key": "{token}"}
+        org_creds: dict[str, str] = {"token": "secret-abc"}
+        patterns = ["https://service.example.com/api/*"]
+
+        body = CreateCustomExternalAppFromRepoRequest(
+            name="Persist App",
+            description="",
+            upstream_url_patterns=patterns,
+            auth_template=auth,
+            organization_credentials=org_creds,
+            enabled=True,
+            source="owner/repo",
+            slug=slug,
+        )
+        resp = api.create_custom_external_app_from_repo(
+            body=body,
+            _=test_user,
+            db_session=db_session,
+        )
+
+        assert resp.upstream_url_patterns == patterns
+        assert resp.auth_template == auth
+
+        skill = db_session.scalar(select(Skill).where(Skill.slug == slug))
+        assert skill is not None
+        app = db_session.scalar(
+            select(ExternalApp).where(ExternalApp.skill_id == skill.id)
+        )
+        assert app is not None
+        assert list(app.upstream_url_patterns) == patterns
+        assert app.auth_template == auth
+        assert app.organization_credentials.get_value(apply_mask=False) == org_creds
+
+        db_session.execute(delete(Skill).where(Skill.slug == slug))
+        db_session.commit()

--- a/backend/tests/external_dependency_unit/build/test_external_app_from_repo.py
+++ b/backend/tests/external_dependency_unit/build/test_external_app_from_repo.py
@@ -35,8 +35,8 @@ from onyx.server.features.build.external_apps.models import (
     CreateCustomExternalAppFromRepoRequest,
 )
 from onyx.skills.bundle import validate_custom_bundle
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
-from tests.external_dependency_unit.constants import TEST_TENANT_ID
 
 _UPSTREAM = ["https://api.example.com/*"]
 _AUTH_TEMPLATE: dict[str, str] = {"Authorization": "Bearer {api_key}"}
@@ -72,7 +72,7 @@ def db_session() -> Generator[Session, None, None]:
 
 @pytest.fixture(scope="function")
 def tenant_context() -> Generator[None, None, None]:
-    token = CURRENT_TENANT_ID_CONTEXTVAR.set(TEST_TENANT_ID)
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     try:
         yield
     finally:
@@ -101,7 +101,7 @@ def test_user(
     yield user
     db_session.rollback()
     try:
-        token = CURRENT_TENANT_ID_CONTEXTVAR.set(TEST_TENANT_ID)
+        token = CURRENT_TENANT_ID_CONTEXTVAR.set(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
         try:
             with get_session_with_current_tenant() as s:
                 row = s.get(User, user.id)
@@ -117,7 +117,7 @@ def test_user(
 @pytest.fixture(scope="module", autouse=True)
 def initialize_file_store() -> Generator[None, None, None]:
     SqlEngine.init_engine(pool_size=10, max_overflow=5)
-    token = CURRENT_TENANT_ID_CONTEXTVAR.set(TEST_TENANT_ID)
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     try:
         get_default_file_store().initialize()
         yield

--- a/backend/tests/external_dependency_unit/skills/test_marketplace_install.py
+++ b/backend/tests/external_dependency_unit/skills/test_marketplace_install.py
@@ -1,0 +1,662 @@
+"""External-dependency tests for _install_personal_repo_skills.
+
+Requires: Postgres, Redis, MinIO/S3 (real db_session + file store).
+Run via: uv run python -m dotenv -f .vscode/.env run -- pytest backend/tests/external_dependency_unit/skills/test_marketplace_install.py -x -q
+"""
+
+from __future__ import annotations
+
+import io
+import tarfile
+from collections.abc import Generator
+from uuid import uuid4
+
+import pytest
+from fastapi_users.password import PasswordHelper
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import SqlEngine
+from onyx.db.enums import AccountType
+from onyx.db.models import Skill
+from onyx.db.models import User
+from onyx.db.models import UserGroup
+from onyx.db.models import UserRole
+from onyx.db.skill import get_group_ids_for_skill
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.file_store.file_store import get_default_file_store
+from onyx.server.features.skill.api import _install_admin_repo_skills
+from onyx.server.features.skill.api import _install_personal_repo_skills
+from onyx.skills.built_in import BUILT_IN_SKILLS
+from onyx.skills.bundle import validate_custom_bundle
+from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
+from tests.external_dependency_unit.constants import TEST_TENANT_ID
+
+_VALID_SKILL_MD = "---\nname: My Skill\ndescription: does things\n---\n# body\n"
+
+
+def _make_tar(files: dict[str, str]) -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        for name, data in files.items():
+            b = data.encode()
+            ti = tarfile.TarInfo(name)
+            ti.size = len(b)
+            ti.mtime = 0
+            tf.addfile(ti, io.BytesIO(b))
+    return buf.getvalue()
+
+
+def _skill_md(name: str = "My Skill", description: str = "does things") -> str:
+    return f"---\nname: {name}\ndescription: {description}\n---\n# body\n"
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+
+def _init_engine() -> None:
+    SqlEngine.init_engine(pool_size=10, max_overflow=5)
+
+
+def _make_user(db_session: Session) -> User:
+    helper = PasswordHelper()
+    user = User(
+        id=uuid4(),
+        email=f"marketplace_test_{uuid4().hex[:8]}@example.com",
+        hashed_password=helper.hash(helper.generate()),
+        is_active=True,
+        is_superuser=False,
+        is_verified=True,
+        role=UserRole.BASIC,
+        account_type=AccountType.STANDARD,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+def _make_admin_user(db_session: Session) -> User:
+    helper = PasswordHelper()
+    user = User(
+        id=uuid4(),
+        email=f"marketplace_admin_{uuid4().hex[:8]}@example.com",
+        hashed_password=helper.hash(helper.generate()),
+        is_active=True,
+        is_superuser=False,
+        is_verified=True,
+        role=UserRole.ADMIN,
+        account_type=AccountType.STANDARD,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+def _make_group(db_session: Session) -> UserGroup:
+    group = UserGroup(
+        name=f"test-group-{uuid4().hex[:8]}",
+        is_up_to_date=True,
+        is_up_for_deletion=False,
+        is_default=False,
+    )
+    db_session.add(group)
+    db_session.commit()
+    db_session.refresh(group)
+    return group
+
+
+def _delete_group(group_id: int) -> None:
+    try:
+        token = CURRENT_TENANT_ID_CONTEXTVAR.set(TEST_TENANT_ID)
+        try:
+            with get_session_with_current_tenant() as session:
+                row = session.get(UserGroup, group_id)
+                if row is not None:
+                    session.delete(row)
+                    session.commit()
+        finally:
+            CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+    except Exception:
+        pass
+
+
+def _delete_user(user_id: object) -> None:
+    try:
+        token = CURRENT_TENANT_ID_CONTEXTVAR.set(TEST_TENANT_ID)
+        try:
+            with get_session_with_current_tenant() as session:
+                row = session.get(User, user_id)
+                if row is not None:
+                    session.delete(row)
+                    session.commit()
+        finally:
+            CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+    except Exception:
+        pass
+
+
+def _delete_skills_by_slugs(slugs: list[str]) -> None:
+    if not slugs:
+        return
+    try:
+        token = CURRENT_TENANT_ID_CONTEXTVAR.set(TEST_TENANT_ID)
+        try:
+            with get_session_with_current_tenant() as session:
+                rows = (
+                    session.execute(select(Skill).where(Skill.slug.in_(slugs)))
+                    .scalars()
+                    .all()
+                )
+                file_store = get_default_file_store()
+                for row in rows:
+                    if row.bundle_file_id:
+                        try:
+                            file_store.delete_file(
+                                row.bundle_file_id, error_on_missing=False
+                            )
+                        except Exception:
+                            pass
+                    session.delete(row)
+                session.commit()
+        finally:
+            CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="function")
+def db_session() -> Generator[Session, None, None]:
+    _init_engine()
+    with get_session_with_current_tenant() as session:
+        yield session
+
+
+@pytest.fixture(scope="function")
+def tenant_context() -> Generator[None, None, None]:
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set(TEST_TENANT_ID)
+    try:
+        yield
+    finally:
+        CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+
+
+@pytest.fixture(scope="function")
+def test_user(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> Generator[User, None, None]:
+    user = _make_user(db_session)
+    yield user
+    db_session.rollback()
+    _delete_user(user.id)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def initialize_file_store() -> Generator[None, None, None]:
+    _init_engine()
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set(TEST_TENANT_ID)
+    try:
+        get_default_file_store().initialize()
+        yield
+    finally:
+        CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestInstallPersonalRepoSkills:
+    def test_happy_path_two_skills(
+        self,
+        db_session: Session,
+        test_user: User,
+        monkeypatch: pytest.MonkeyPatch,
+        request: pytest.FixtureRequest,
+        tenant_context: None,  # noqa: ARG002
+    ) -> None:
+        slug_a = f"skill-alpha-{uuid4().hex[:6]}"
+        slug_b = f"skill-beta-{uuid4().hex[:6]}"
+        archive = _make_tar(
+            {
+                f"repo-main/skills/{slug_a}/SKILL.md": _skill_md("Alpha", "alpha desc"),
+                f"repo-main/skills/{slug_b}/SKILL.md": _skill_md("Beta", "beta desc"),
+            }
+        )
+        monkeypatch.setattr(
+            "onyx.server.features.skill.api.fetch_repo_archive",
+            lambda _source: archive,
+        )
+        request.addfinalizer(lambda: _delete_skills_by_slugs([slug_a, slug_b]))
+
+        result = _install_personal_repo_skills(
+            "owner/repo", [slug_a, slug_b], test_user, db_session
+        )
+
+        assert len(result.created) == 2
+        assert result.failures == []
+        created_slugs = {r.slug for r in result.created}
+        assert slug_a in created_slugs
+        assert slug_b in created_slugs
+
+        # Rows persist in DB with a bundle_file_id
+        rows = (
+            db_session.execute(select(Skill).where(Skill.slug.in_([slug_a, slug_b])))
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 2
+        for row in rows:
+            assert row.bundle_file_id is not None
+
+    def test_happy_path_bundle_passes_validate(
+        self,
+        db_session: Session,
+        test_user: User,
+        monkeypatch: pytest.MonkeyPatch,
+        request: pytest.FixtureRequest,
+        tenant_context: None,  # noqa: ARG002
+    ) -> None:
+        slug = f"validate-skill-{uuid4().hex[:6]}"
+        archive = _make_tar(
+            {f"repo-main/skills/{slug}/SKILL.md": _skill_md("Validate", "desc")}
+        )
+        monkeypatch.setattr(
+            "onyx.server.features.skill.api.fetch_repo_archive",
+            lambda _source: archive,
+        )
+        request.addfinalizer(lambda: _delete_skills_by_slugs([slug]))
+
+        result = _install_personal_repo_skills(
+            "owner/repo", [slug], test_user, db_session
+        )
+        assert len(result.created) == 1
+
+        row = db_session.execute(select(Skill).where(Skill.slug == slug)).scalar_one()
+        assert row.bundle_file_id is not None
+
+        file_store = get_default_file_store()
+        blob = b"".join(file_store.read_file(row.bundle_file_id, use_tempfile=False))
+        validate_custom_bundle(blob, slug=slug)
+
+    def test_slug_collision_is_per_skill_failure(
+        self,
+        db_session: Session,
+        test_user: User,
+        monkeypatch: pytest.MonkeyPatch,
+        request: pytest.FixtureRequest,
+        tenant_context: None,  # noqa: ARG002
+    ) -> None:
+        existing_slug = f"existing-{uuid4().hex[:6]}"
+        new_slug = f"newskill-{uuid4().hex[:6]}"
+        archive = _make_tar(
+            {
+                f"repo-main/skills/{existing_slug}/SKILL.md": _skill_md(
+                    "Existing", "e"
+                ),
+                f"repo-main/skills/{new_slug}/SKILL.md": _skill_md("New", "n"),
+            }
+        )
+        monkeypatch.setattr(
+            "onyx.server.features.skill.api.fetch_repo_archive",
+            lambda _source: archive,
+        )
+        request.addfinalizer(lambda: _delete_skills_by_slugs([existing_slug, new_slug]))
+
+        # First install to create the collision candidate
+        result1 = _install_personal_repo_skills(
+            "owner/repo", [existing_slug], test_user, db_session
+        )
+        assert len(result1.created) == 1
+        assert result1.failures == []
+
+        # Second install: same slug (collision) + new slug
+        result2 = _install_personal_repo_skills(
+            "owner/repo", [existing_slug, new_slug], test_user, db_session
+        )
+        assert len(result2.created) == 1
+        assert result2.created[0].slug == new_slug
+        assert len(result2.failures) == 1
+        assert result2.failures[0].slug == existing_slug
+
+    def test_cap_enforcement_raises(
+        self,
+        db_session: Session,
+        test_user: User,
+        monkeypatch: pytest.MonkeyPatch,
+        request: pytest.FixtureRequest,
+        tenant_context: None,  # noqa: ARG002
+    ) -> None:
+        slug_a = f"cap-skill-a-{uuid4().hex[:6]}"
+        slug_b = f"cap-skill-b-{uuid4().hex[:6]}"
+        archive = _make_tar(
+            {
+                f"repo-main/skills/{slug_a}/SKILL.md": _skill_md("CapA", "a"),
+                f"repo-main/skills/{slug_b}/SKILL.md": _skill_md("CapB", "b"),
+            }
+        )
+        monkeypatch.setattr(
+            "onyx.server.features.skill.api.fetch_repo_archive",
+            lambda _source: archive,
+        )
+        # Cap at 1 so installing 2 skills exceeds the limit.
+        monkeypatch.setattr(
+            "onyx.server.features.skill.api.MAX_PERSONAL_SKILLS_PER_USER", 1
+        )
+        request.addfinalizer(lambda: _delete_skills_by_slugs([slug_a, slug_b]))
+
+        with pytest.raises(OnyxError):
+            _install_personal_repo_skills(
+                "owner/repo", [slug_a, slug_b], test_user, db_session
+            )
+
+    def test_slug_not_in_repo_is_failure_entry(
+        self,
+        db_session: Session,
+        test_user: User,
+        monkeypatch: pytest.MonkeyPatch,
+        request: pytest.FixtureRequest,
+        tenant_context: None,  # noqa: ARG002
+    ) -> None:
+        real_slug = f"real-skill-{uuid4().hex[:6]}"
+        archive = _make_tar(
+            {f"repo-main/skills/{real_slug}/SKILL.md": _skill_md("Real", "r")}
+        )
+        monkeypatch.setattr(
+            "onyx.server.features.skill.api.fetch_repo_archive",
+            lambda _source: archive,
+        )
+        request.addfinalizer(lambda: _delete_skills_by_slugs([real_slug]))
+
+        missing_slug = f"does-not-exist-{uuid4().hex[:6]}"
+        result = _install_personal_repo_skills(
+            "owner/repo", [missing_slug], test_user, db_session
+        )
+
+        assert result.created == []
+        assert len(result.failures) == 1
+        failure = result.failures[0]
+        assert failure.slug == missing_slug
+        assert "not found" in failure.error.lower()
+
+
+# ---------------------------------------------------------------------------
+# Admin install path
+# ---------------------------------------------------------------------------
+
+
+class TestInstallAdminRepoSkills:
+    def test_public_no_groups(
+        self,
+        db_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+        request: pytest.FixtureRequest,
+        tenant_context: None,  # noqa: ARG002
+    ) -> None:
+        """Admin install with is_public=True and no group_ids → skill is public."""
+        admin = _make_admin_user(db_session)
+        request.addfinalizer(lambda: _delete_user(admin.id))
+
+        slug = f"admin-pub-{uuid4().hex[:6]}"
+        archive = _make_tar(
+            {f"repo-main/skills/{slug}/SKILL.md": _skill_md("AdminPub", "admin pub")}
+        )
+        monkeypatch.setattr(
+            "onyx.server.features.skill.api.fetch_repo_archive",
+            lambda _parsed: archive,
+        )
+        request.addfinalizer(lambda: _delete_skills_by_slugs([slug]))
+
+        result = _install_admin_repo_skills(
+            "owner/repo",
+            [slug],
+            is_public=True,
+            group_ids=[],
+            user=admin,
+            db_session=db_session,
+        )
+
+        assert len(result.created) == 1
+        assert result.failures == []
+
+        row = db_session.execute(select(Skill).where(Skill.slug == slug)).scalar_one()
+        assert row.is_public is True
+        assert get_group_ids_for_skill(row.id, db_session) == []
+
+    def test_public_with_group(
+        self,
+        db_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+        request: pytest.FixtureRequest,
+        tenant_context: None,  # noqa: ARG002
+    ) -> None:
+        """Admin install with is_public=True and a group_id → group grant exists."""
+        admin = _make_admin_user(db_session)
+        group = _make_group(db_session)
+        request.addfinalizer(lambda: _delete_user(admin.id))
+        request.addfinalizer(lambda: _delete_group(group.id))
+
+        slug = f"admin-grp-{uuid4().hex[:6]}"
+        archive = _make_tar(
+            {f"repo-main/skills/{slug}/SKILL.md": _skill_md("AdminGrp", "grp")}
+        )
+        monkeypatch.setattr(
+            "onyx.server.features.skill.api.fetch_repo_archive",
+            lambda _parsed: archive,
+        )
+        request.addfinalizer(lambda: _delete_skills_by_slugs([slug]))
+
+        result = _install_admin_repo_skills(
+            "owner/repo",
+            [slug],
+            is_public=True,
+            group_ids=[group.id],
+            user=admin,
+            db_session=db_session,
+        )
+
+        assert len(result.created) == 1
+        row = db_session.execute(select(Skill).where(Skill.slug == slug)).scalar_one()
+        assert row.is_public is True
+        assert group.id in get_group_ids_for_skill(row.id, db_session)
+
+    def test_admin_install_exceeds_personal_cap(
+        self,
+        db_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+        request: pytest.FixtureRequest,
+        tenant_context: None,  # noqa: ARG002
+    ) -> None:
+        """Admin path has no personal-skill cap — installing > MAX succeeds."""
+        admin = _make_admin_user(db_session)
+        request.addfinalizer(lambda: _delete_user(admin.id))
+
+        slugs = [f"admin-cap-{uuid4().hex[:6]}" for _ in range(3)]
+        archive = _make_tar(
+            {
+                f"repo-main/skills/{s}/SKILL.md": _skill_md(s.capitalize(), "x")
+                for s in slugs
+            }
+        )
+        monkeypatch.setattr(
+            "onyx.server.features.skill.api.fetch_repo_archive",
+            lambda _parsed: archive,
+        )
+        # Cap personal skills at 1 — admin path must not be gated by this.
+        monkeypatch.setattr(
+            "onyx.server.features.skill.api.MAX_PERSONAL_SKILLS_PER_USER", 1
+        )
+        request.addfinalizer(lambda: _delete_skills_by_slugs(slugs))
+
+        result = _install_admin_repo_skills(
+            "owner/repo",
+            slugs,
+            is_public=True,
+            group_ids=[],
+            user=admin,
+            db_session=db_session,
+        )
+
+        assert len(result.created) == 3
+        assert result.failures == []
+
+
+# ---------------------------------------------------------------------------
+# Reserved-slug rejection in install
+# ---------------------------------------------------------------------------
+
+
+class TestReservedSlugRejection:
+    def test_reserved_slug_is_failure_normal_slug_is_created(
+        self,
+        db_session: Session,
+        test_user: User,
+        monkeypatch: pytest.MonkeyPatch,
+        request: pytest.FixtureRequest,
+        tenant_context: None,  # noqa: ARG002
+    ) -> None:
+        """A skill whose slug matches a built-in ends up in failures; others are created."""
+        # Pick a known built-in slug from the registry.
+        reserved_slug = next(iter(BUILT_IN_SKILLS))
+        normal_slug = f"normal-skill-{uuid4().hex[:6]}"
+
+        archive = _make_tar(
+            {
+                f"repo-main/skills/{reserved_slug}/SKILL.md": _skill_md(
+                    "Reserved", "reserved"
+                ),
+                f"repo-main/skills/{normal_slug}/SKILL.md": _skill_md("Normal", "n"),
+            }
+        )
+        monkeypatch.setattr(
+            "onyx.server.features.skill.api.fetch_repo_archive",
+            lambda _parsed: archive,
+        )
+        request.addfinalizer(lambda: _delete_skills_by_slugs([normal_slug]))
+
+        result = _install_personal_repo_skills(
+            "owner/repo",
+            [reserved_slug, normal_slug],
+            test_user,
+            db_session,
+        )
+
+        assert len(result.created) == 1
+        assert result.created[0].slug == normal_slug
+
+        assert len(result.failures) == 1
+        failure = result.failures[0]
+        assert failure.slug == reserved_slug
+        assert "reserved" in failure.error.lower()
+
+
+# ---------------------------------------------------------------------------
+# Blob cleanup on per-skill failure
+# ---------------------------------------------------------------------------
+
+
+class TestBlobCleanupOnFailure:
+    def test_create_skill_failure_cleans_blob(
+        self,
+        db_session: Session,
+        test_user: User,
+        monkeypatch: pytest.MonkeyPatch,
+        request: pytest.FixtureRequest,
+        tenant_context: None,  # noqa: ARG002
+    ) -> None:
+        """When create_skill__no_commit raises OnyxError, the uploaded blob is deleted."""
+        slug = f"fail-skill-{uuid4().hex[:6]}"
+        archive = _make_tar(
+            {f"repo-main/skills/{slug}/SKILL.md": _skill_md("Fail", "f")}
+        )
+        monkeypatch.setattr(
+            "onyx.server.features.skill.api.fetch_repo_archive",
+            lambda _parsed: archive,
+        )
+
+        deleted_blob_ids: list[str] = []
+
+        real_delete = __import__(
+            "onyx.skills.ingest", fromlist=["delete_bundle_blob"]
+        ).delete_bundle_blob
+
+        def _spy_delete(file_store: object, file_id: str) -> None:
+            deleted_blob_ids.append(file_id)
+            real_delete(file_store, file_id)
+
+        monkeypatch.setattr(
+            "onyx.server.features.skill.api.delete_bundle_blob",
+            _spy_delete,
+        )
+
+        def _raising_create(**_kwargs: object) -> None:
+            raise OnyxError(OnyxErrorCode.INVALID_INPUT, "boom")
+
+        monkeypatch.setattr(
+            "onyx.server.features.skill.api.create_skill__no_commit",
+            _raising_create,
+        )
+        request.addfinalizer(lambda: _delete_skills_by_slugs([slug]))
+
+        result = _install_personal_repo_skills(
+            "owner/repo", [slug], test_user, db_session
+        )
+
+        assert result.created == []
+        assert len(result.failures) == 1
+        assert result.failures[0].slug == slug
+        # blob must have been cleaned up
+        assert len(deleted_blob_ids) == 1
+
+        # No orphaned Skill row
+        row = db_session.execute(
+            select(Skill).where(Skill.slug == slug)
+        ).scalar_one_or_none()
+        assert row is None
+
+    def test_non_onyx_error_records_internal_error(
+        self,
+        db_session: Session,
+        test_user: User,
+        monkeypatch: pytest.MonkeyPatch,
+        request: pytest.FixtureRequest,
+        tenant_context: None,  # noqa: ARG002
+    ) -> None:
+        """Non-OnyxError from create_skill__no_commit → failure entry with 'internal error'."""
+        slug = f"internal-err-{uuid4().hex[:6]}"
+        archive = _make_tar(
+            {f"repo-main/skills/{slug}/SKILL.md": _skill_md("Internal", "i")}
+        )
+        monkeypatch.setattr(
+            "onyx.server.features.skill.api.fetch_repo_archive",
+            lambda _parsed: archive,
+        )
+
+        def _runtime_raise(**_kwargs: object) -> None:
+            raise RuntimeError("unexpected")
+
+        monkeypatch.setattr(
+            "onyx.server.features.skill.api.create_skill__no_commit",
+            _runtime_raise,
+        )
+        request.addfinalizer(lambda: _delete_skills_by_slugs([slug]))
+
+        result = _install_personal_repo_skills(
+            "owner/repo", [slug], test_user, db_session
+        )
+
+        assert result.created == []
+        assert len(result.failures) == 1
+        assert result.failures[0].error == "internal error"

--- a/backend/tests/external_dependency_unit/skills/test_marketplace_install.py
+++ b/backend/tests/external_dependency_unit/skills/test_marketplace_install.py
@@ -53,11 +53,6 @@ def _skill_md(name: str = "My Skill", description: str = "does things") -> str:
     return f"---\nname: {name}\ndescription: {description}\n---\n# body\n"
 
 
-# ---------------------------------------------------------------------------
-# Module-level helpers
-# ---------------------------------------------------------------------------
-
-
 def _init_engine() -> None:
     SqlEngine.init_engine(pool_size=10, max_overflow=5)
 
@@ -170,11 +165,6 @@ def _delete_skills_by_slugs(slugs: list[str]) -> None:
         pass
 
 
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-
 @pytest.fixture(scope="function")
 def db_session() -> Generator[Session, None, None]:
     _init_engine()
@@ -211,11 +201,6 @@ def initialize_file_store() -> Generator[None, None, None]:
         yield
     finally:
         CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
-
-
-# ---------------------------------------------------------------------------
-# Tests
-# ---------------------------------------------------------------------------
 
 
 class TestInstallPersonalRepoSkills:
@@ -392,11 +377,6 @@ class TestInstallPersonalRepoSkills:
         assert "not found" in failure.error.lower()
 
 
-# ---------------------------------------------------------------------------
-# Admin install path
-# ---------------------------------------------------------------------------
-
-
 class TestInstallAdminRepoSkills:
     def test_public_no_groups(
         self,
@@ -513,11 +493,6 @@ class TestInstallAdminRepoSkills:
         assert result.failures == []
 
 
-# ---------------------------------------------------------------------------
-# Reserved-slug rejection in install
-# ---------------------------------------------------------------------------
-
-
 class TestReservedSlugRejection:
     def test_reserved_slug_is_failure_normal_slug_is_created(
         self,
@@ -560,11 +535,6 @@ class TestReservedSlugRejection:
         failure = result.failures[0]
         assert failure.slug == reserved_slug
         assert "reserved" in failure.error.lower()
-
-
-# ---------------------------------------------------------------------------
-# Blob cleanup on per-skill failure
-# ---------------------------------------------------------------------------
 
 
 class TestBlobCleanupOnFailure:

--- a/backend/tests/external_dependency_unit/skills/test_marketplace_install.py
+++ b/backend/tests/external_dependency_unit/skills/test_marketplace_install.py
@@ -31,8 +31,8 @@ from onyx.server.features.skill.api import _install_admin_repo_skills
 from onyx.server.features.skill.api import _install_personal_repo_skills
 from onyx.skills.built_in import BUILT_IN_SKILLS
 from onyx.skills.bundle import validate_custom_bundle
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
-from tests.external_dependency_unit.constants import TEST_TENANT_ID
 
 _VALID_SKILL_MD = "---\nname: My Skill\ndescription: does things\n---\n# body\n"
 
@@ -108,7 +108,7 @@ def _make_group(db_session: Session) -> UserGroup:
 
 def _delete_group(group_id: int) -> None:
     try:
-        token = CURRENT_TENANT_ID_CONTEXTVAR.set(TEST_TENANT_ID)
+        token = CURRENT_TENANT_ID_CONTEXTVAR.set(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
         try:
             with get_session_with_current_tenant() as session:
                 row = session.get(UserGroup, group_id)
@@ -123,7 +123,7 @@ def _delete_group(group_id: int) -> None:
 
 def _delete_user(user_id: object) -> None:
     try:
-        token = CURRENT_TENANT_ID_CONTEXTVAR.set(TEST_TENANT_ID)
+        token = CURRENT_TENANT_ID_CONTEXTVAR.set(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
         try:
             with get_session_with_current_tenant() as session:
                 row = session.get(User, user_id)
@@ -140,7 +140,7 @@ def _delete_skills_by_slugs(slugs: list[str]) -> None:
     if not slugs:
         return
     try:
-        token = CURRENT_TENANT_ID_CONTEXTVAR.set(TEST_TENANT_ID)
+        token = CURRENT_TENANT_ID_CONTEXTVAR.set(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
         try:
             with get_session_with_current_tenant() as session:
                 rows = (
@@ -174,7 +174,7 @@ def db_session() -> Generator[Session, None, None]:
 
 @pytest.fixture(scope="function")
 def tenant_context() -> Generator[None, None, None]:
-    token = CURRENT_TENANT_ID_CONTEXTVAR.set(TEST_TENANT_ID)
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     try:
         yield
     finally:
@@ -195,7 +195,7 @@ def test_user(
 @pytest.fixture(scope="module", autouse=True)
 def initialize_file_store() -> Generator[None, None, None]:
     _init_engine()
-    token = CURRENT_TENANT_ID_CONTEXTVAR.set(TEST_TENANT_ID)
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     try:
         get_default_file_store().initialize()
         yield

--- a/backend/tests/unit/skills/test_marketplace_discover.py
+++ b/backend/tests/unit/skills/test_marketplace_discover.py
@@ -1,0 +1,217 @@
+"""Unit tests for extracted_skills and build_bundle_for_skill — no services required."""
+
+from __future__ import annotations
+
+import io
+import tarfile
+import zipfile
+
+import pytest
+
+from onyx.error_handling.exceptions import OnyxError
+from onyx.skills.bundle import validate_custom_bundle
+from onyx.skills.marketplace import build_bundle_for_skill
+from onyx.skills.marketplace import extracted_skills
+
+_VALID_SKILL_MD = "---\nname: My Skill\ndescription: does things\n---\n# body\n"
+
+
+def make_tar(files: dict[str, str]) -> bytes:
+    """Build a GitHub-style tar.gz with a single top-level wrapper dir."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        for name, data in files.items():
+            b = data.encode()
+            ti = tarfile.TarInfo(name)
+            ti.size = len(b)
+            ti.mtime = 0
+            tf.addfile(ti, io.BytesIO(b))
+    return buf.getvalue()
+
+
+def make_tar_bytes(files: dict[str, bytes]) -> bytes:
+    """Like make_tar but accepts raw bytes values."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        for name, data in files.items():
+            ti = tarfile.TarInfo(name)
+            ti.size = len(data)
+            ti.mtime = 0
+            tf.addfile(ti, io.BytesIO(data))
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Layout discovery
+# ---------------------------------------------------------------------------
+
+
+def test_flat_skill_discovered() -> None:
+    archive = make_tar({"repo-main/skills/my-tool/SKILL.md": _VALID_SKILL_MD})
+    with extracted_skills(archive) as skills:
+        slugs = [s.slug for s in skills]
+    assert "my-tool" in slugs
+
+
+def test_catalog_skill_discovered() -> None:
+    # skills/cat/deep/SKILL.md  — two levels under skills/
+    archive = make_tar({"repo-main/skills/cat/deep/SKILL.md": _VALID_SKILL_MD})
+    with extracted_skills(archive) as skills:
+        slugs = [s.slug for s in skills]
+    assert "deep" in slugs
+
+
+def test_claude_skills_discovered() -> None:
+    archive = make_tar({"repo-main/.claude/skills/cl/SKILL.md": _VALID_SKILL_MD})
+    with extracted_skills(archive) as skills:
+        slugs = [s.slug for s in skills]
+    assert "cl" in slugs
+
+
+def test_root_level_skill_discovered() -> None:
+    archive = make_tar({"repo-main/SKILL.md": _VALID_SKILL_MD})
+    with extracted_skills(archive) as skills:
+        assert len(skills) == 1
+        # slug comes from repo dir name "repo-main" → strips "-main" → "repo"
+        assert skills[0].slug == "repo"
+
+
+def test_multiple_layout_archive() -> None:
+    archive = make_tar(
+        {
+            "repo-main/skills/flat/SKILL.md": _VALID_SKILL_MD,
+            "repo-main/skills/cat/deep/SKILL.md": _VALID_SKILL_MD,
+            "repo-main/.claude/skills/cl/SKILL.md": _VALID_SKILL_MD,
+        }
+    )
+    with extracted_skills(archive) as skills:
+        slugs = {s.slug for s in skills}
+    assert "flat" in slugs
+    assert "deep" in slugs
+    assert "cl" in slugs
+
+
+def test_name_and_description_from_frontmatter() -> None:
+    skill_md = "---\nname: Fancy Tool\ndescription: Does fancy things\n---\n"
+    archive = make_tar({"repo-main/skills/fancy-tool/SKILL.md": skill_md})
+    with extracted_skills(archive) as skills:
+        assert len(skills) == 1
+        assert skills[0].name == "Fancy Tool"
+        assert skills[0].description == "Does fancy things"
+
+
+# ---------------------------------------------------------------------------
+# Bundle validity and sibling inclusion
+# ---------------------------------------------------------------------------
+
+
+def test_build_bundle_passes_validate() -> None:
+    archive = make_tar(
+        {
+            "repo-main/skills/my-tool/SKILL.md": _VALID_SKILL_MD,
+            "repo-main/skills/my-tool/helper.py": "print('hi')\n",
+        }
+    )
+    with extracted_skills(archive) as skills:
+        assert len(skills) == 1
+        bundle = build_bundle_for_skill(skills[0])
+    validate_custom_bundle(bundle, slug=skills[0].slug)
+
+
+def test_build_bundle_includes_sibling_file() -> None:
+    archive = make_tar(
+        {
+            "repo-main/skills/my-tool/SKILL.md": _VALID_SKILL_MD,
+            "repo-main/skills/my-tool/helper.py": "print('hi')\n",
+        }
+    )
+    with extracted_skills(archive) as skills:
+        assert len(skills) == 1
+        bundle = build_bundle_for_skill(skills[0])
+
+    zf = zipfile.ZipFile(io.BytesIO(bundle))
+    names = zf.namelist()
+    assert "SKILL.md" in names
+    assert "helper.py" in names
+
+
+# ---------------------------------------------------------------------------
+# subpath filtering
+# ---------------------------------------------------------------------------
+
+
+def test_subpath_filters_skills() -> None:
+    # With subpath="skills/inner", search_root = repo-main/skills/inner.
+    # The flat pattern skills/*/SKILL.md becomes skills/inner/skills/tool/SKILL.md
+    # which is deep. Easier: put a skill directly at root of the subpath tree.
+    # subpath="skills/in-scope" → search_root = repo-main/skills/in-scope
+    # → _add(search_root) picks up SKILL.md there; slug = dir name with -main stripped.
+    archive = make_tar(
+        {
+            "repo-main/skills/in-scope/SKILL.md": _VALID_SKILL_MD,
+            # This skill is outside the subpath — should NOT appear
+            "repo-main/.claude/skills/outside/SKILL.md": _VALID_SKILL_MD,
+        }
+    )
+    with extracted_skills(archive, subpath="skills/in-scope") as skills:
+        slugs = {s.slug for s in skills}
+    # Exactly one skill found — the one inside the subpath.
+    # When skill_dir IS the search_root, slug = repo_root.name stripped of "-main" → "repo".
+    assert len(skills) == 1
+    assert "outside" not in slugs
+
+
+def test_subpath_not_found_raises() -> None:
+    archive = make_tar({"repo-main/skills/tool/SKILL.md": _VALID_SKILL_MD})
+    with pytest.raises(OnyxError):
+        with extracted_skills(archive, subpath="nonexistent") as _:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Tar traversal rejection
+# ---------------------------------------------------------------------------
+
+
+def test_tar_traversal_raises() -> None:
+    # "../../evil.txt" resolves to a path above dest, triggering the OnyxError.
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        evil_data = b"evil"
+        ti = tarfile.TarInfo("../../evil.txt")
+        ti.size = len(evil_data)
+        ti.mtime = 0
+        tf.addfile(ti, io.BytesIO(evil_data))
+    archive = buf.getvalue()
+
+    with pytest.raises(OnyxError):
+        with extracted_skills(archive) as _:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Invalid SKILL.md silently skipped
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_skill_md_skipped() -> None:
+    # SKILL.md with no frontmatter — parser raises OnyxError → skill is skipped.
+    bad_skill_md = "# No frontmatter here\nJust body text.\n"
+    good_skill_md = _VALID_SKILL_MD
+    archive = make_tar(
+        {
+            "repo-main/skills/bad-skill/SKILL.md": bad_skill_md,
+            "repo-main/skills/good-skill/SKILL.md": good_skill_md,
+        }
+    )
+    with extracted_skills(archive) as skills:
+        slugs = {s.slug for s in skills}
+    assert "bad-skill" not in slugs
+    assert "good-skill" in slugs
+
+
+def test_invalid_skill_md_only_no_crash() -> None:
+    bad_skill_md = "# No frontmatter\n"
+    archive = make_tar({"repo-main/skills/bad/SKILL.md": bad_skill_md})
+    with extracted_skills(archive) as skills:
+        assert skills == []

--- a/backend/tests/unit/skills/test_marketplace_discover.py
+++ b/backend/tests/unit/skills/test_marketplace_discover.py
@@ -41,11 +41,6 @@ def make_tar_bytes(files: dict[str, bytes]) -> bytes:
     return buf.getvalue()
 
 
-# ---------------------------------------------------------------------------
-# Layout discovery
-# ---------------------------------------------------------------------------
-
-
 def test_flat_skill_discovered() -> None:
     archive = make_tar({"repo-main/skills/my-tool/SKILL.md": _VALID_SKILL_MD})
     with extracted_skills(archive) as skills:
@@ -100,11 +95,6 @@ def test_name_and_description_from_frontmatter() -> None:
         assert skills[0].description == "Does fancy things"
 
 
-# ---------------------------------------------------------------------------
-# Bundle validity and sibling inclusion
-# ---------------------------------------------------------------------------
-
-
 def test_build_bundle_passes_validate() -> None:
     archive = make_tar(
         {
@@ -135,11 +125,6 @@ def test_build_bundle_includes_sibling_file() -> None:
     assert "helper.py" in names
 
 
-# ---------------------------------------------------------------------------
-# subpath filtering
-# ---------------------------------------------------------------------------
-
-
 def test_subpath_filters_skills() -> None:
     # With subpath="skills/inner", search_root = repo-main/skills/inner.
     # The flat pattern skills/*/SKILL.md becomes skills/inner/skills/tool/SKILL.md
@@ -168,11 +153,6 @@ def test_subpath_not_found_raises() -> None:
             pass
 
 
-# ---------------------------------------------------------------------------
-# Tar traversal rejection
-# ---------------------------------------------------------------------------
-
-
 def test_tar_traversal_raises() -> None:
     # "../../evil.txt" resolves to a path above dest, triggering the OnyxError.
     buf = io.BytesIO()
@@ -187,11 +167,6 @@ def test_tar_traversal_raises() -> None:
     with pytest.raises(OnyxError):
         with extracted_skills(archive) as _:
             pass
-
-
-# ---------------------------------------------------------------------------
-# Invalid SKILL.md silently skipped
-# ---------------------------------------------------------------------------
 
 
 def test_invalid_skill_md_skipped() -> None:

--- a/backend/tests/unit/skills/test_marketplace_discover.py
+++ b/backend/tests/unit/skills/test_marketplace_discover.py
@@ -48,6 +48,15 @@ def test_flat_skill_discovered() -> None:
     assert "my-tool" in slugs
 
 
+def test_subpath_pointing_at_skill_dir_uses_dir_slug() -> None:
+    # A tree/subpath URL pointing directly at a skill dir must derive the slug
+    # from that dir (e.g. "docx"), not the repo wrapper name.
+    archive = make_tar({"repo-main/skills/docx/SKILL.md": _VALID_SKILL_MD})
+    with extracted_skills(archive, subpath="skills/docx") as skills:
+        slugs = [s.slug for s in skills]
+    assert slugs == ["docx"]
+
+
 def test_catalog_skill_discovered() -> None:
     # skills/cat/deep/SKILL.md  — two levels under skills/
     archive = make_tar({"repo-main/skills/cat/deep/SKILL.md": _VALID_SKILL_MD})

--- a/backend/tests/unit/skills/test_marketplace_parse.py
+++ b/backend/tests/unit/skills/test_marketplace_parse.py
@@ -1,0 +1,129 @@
+"""Unit tests for parse_skill_source — no services required."""
+
+from __future__ import annotations
+
+import pytest
+
+from onyx.error_handling.exceptions import OnyxError
+from onyx.skills.marketplace import parse_skill_source
+from onyx.skills.marketplace import ParsedSource
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        # Full npx skills add command with --skill filter
+        (
+            "npx skills add https://github.com/vercel-labs/skills --skill find-skills",
+            ParsedSource(
+                host="github.com",
+                owner="vercel-labs",
+                repo="skills",
+                ref=None,
+                subpath=None,
+                skill_filters=["find-skills"],
+            ),
+        ),
+        # skills add with two --skill flags
+        (
+            "skills add owner/repo --skill a --skill b",
+            ParsedSource(
+                host="github.com",
+                owner="owner",
+                repo="repo",
+                ref=None,
+                subpath=None,
+                skill_filters=["a", "b"],
+            ),
+        ),
+        # Bare owner/repo — defaults to github.com, no ref/subpath
+        (
+            "owner/repo",
+            ParsedSource(
+                host="github.com",
+                owner="owner",
+                repo="repo",
+                ref=None,
+                subpath=None,
+                skill_filters=[],
+            ),
+        ),
+        # .git suffix stripped
+        (
+            "https://github.com/o/r.git",
+            ParsedSource(
+                host="github.com",
+                owner="o",
+                repo="r",
+                ref=None,
+                subpath=None,
+                skill_filters=[],
+            ),
+        ),
+        # /tree/<ref>/<subpath> parsed
+        (
+            "https://github.com/o/r/tree/main/skills/x",
+            ParsedSource(
+                host="github.com",
+                owner="o",
+                repo="r",
+                ref="main",
+                subpath="skills/x",
+                skill_filters=[],
+            ),
+        ),
+        # gitlab.com host accepted
+        (
+            "https://gitlab.com/o/r",
+            ParsedSource(
+                host="gitlab.com",
+                owner="o",
+                repo="r",
+                ref=None,
+                subpath=None,
+                skill_filters=[],
+            ),
+        ),
+    ],
+)
+def test_parse_skill_source_ok(raw: str, expected: ParsedSource) -> None:
+    assert parse_skill_source(raw) == expected
+
+
+def test_unsupported_host_raises() -> None:
+    with pytest.raises(OnyxError):
+        parse_skill_source("https://evil.com/o/r")
+
+
+def test_garbage_string_raises() -> None:
+    with pytest.raises(OnyxError):
+        parse_skill_source("notavalidsource")
+
+
+def test_bare_hostname_only_raises() -> None:
+    # e.g. "github.com/owner" — only one path segment after host
+    with pytest.raises(OnyxError):
+        parse_skill_source("github.com/onlyowner")
+
+
+def test_tree_url_without_ref_raises() -> None:
+    # /owner/repo/tree/ with nothing after
+    with pytest.raises(OnyxError):
+        parse_skill_source("https://github.com/o/r/tree/")
+
+
+def test_ref_only_no_subpath() -> None:
+    result = parse_skill_source("https://github.com/o/r/tree/main")
+    assert result.ref == "main"
+    assert result.subpath is None
+
+
+def test_skill_filters_deduplication_not_done_by_parser() -> None:
+    # Parser does NOT deduplicate — it just collects all --skill values.
+    result = parse_skill_source("skills add owner/repo --skill a --skill a")
+    assert result.skill_filters == ["a", "a"]
+
+
+def test_git_suffix_stripped_in_bare_form() -> None:
+    result = parse_skill_source("owner/repo.git")
+    assert result.repo == "repo"

--- a/backend/tests/unit/skills/test_marketplace_parse.py
+++ b/backend/tests/unit/skills/test_marketplace_parse.py
@@ -84,6 +84,18 @@ from onyx.skills.marketplace import ParsedSource
                 skill_filters=[],
             ),
         ),
+        # GitLab /-/tree/<ref>/<subpath> — the "-" separator is handled
+        (
+            "https://gitlab.com/o/r/-/tree/main/skills/foo",
+            ParsedSource(
+                host="gitlab.com",
+                owner="o",
+                repo="r",
+                ref="main",
+                subpath="skills/foo",
+                skill_filters=[],
+            ),
+        ),
     ],
 )
 def test_parse_skill_source_ok(raw: str, expected: ParsedSource) -> None:

--- a/backend/tests/unit/skills/test_marketplace_preview.py
+++ b/backend/tests/unit/skills/test_marketplace_preview.py
@@ -1,0 +1,67 @@
+"""Unit tests for _preview_repo_skills — no services required."""
+
+from __future__ import annotations
+
+import io
+import tarfile
+
+import pytest
+
+from onyx.server.features.skill.api import _preview_repo_skills
+
+
+def _make_tar(files: dict[str, str]) -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        for name, data in files.items():
+            b = data.encode()
+            ti = tarfile.TarInfo(name)
+            ti.size = len(b)
+            ti.mtime = 0
+            tf.addfile(ti, io.BytesIO(b))
+    return buf.getvalue()
+
+
+def _skill_md(name: str, description: str = "does things") -> str:
+    return f"---\nname: {name}\ndescription: {description}\n---\n# body\n"
+
+
+class TestPreviewRepoSkills:
+    def test_skill_filter_marks_matching_slug_preselected(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A source with --skill <slug> → only that skill has pre_selected=True."""
+        archive = _make_tar(
+            {
+                "repo-main/skills/alpha/SKILL.md": _skill_md("Alpha"),
+                "repo-main/skills/beta/SKILL.md": _skill_md("Beta"),
+            }
+        )
+        monkeypatch.setattr(
+            "onyx.server.features.skill.api.fetch_repo_archive",
+            lambda _parsed: archive,
+        )
+
+        preview = _preview_repo_skills("skills add owner/repo --skill alpha")
+
+        slugs = {item.slug: item.pre_selected for item in preview.skills}
+        assert slugs.get("alpha") is True
+        assert slugs.get("beta") is False
+
+    def test_no_filter_all_preselected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No --skill filter → all preview items have pre_selected=True."""
+        archive = _make_tar(
+            {
+                "repo-main/skills/alpha/SKILL.md": _skill_md("Alpha"),
+                "repo-main/skills/beta/SKILL.md": _skill_md("Beta"),
+            }
+        )
+        monkeypatch.setattr(
+            "onyx.server.features.skill.api.fetch_repo_archive",
+            lambda _parsed: archive,
+        )
+
+        preview = _preview_repo_skills("owner/repo")
+
+        assert all(item.pre_selected for item in preview.skills)
+        assert len(preview.skills) == 2

--- a/web/src/app/craft/services/externalAppsService.ts
+++ b/web/src/app/craft/services/externalAppsService.ts
@@ -96,6 +96,38 @@ export async function createCustomExternalApp(
   return res.json();
 }
 
+export interface CreateCustomExternalAppFromRepoInput {
+  name: string;
+  description: string;
+  upstream_url_patterns: string[];
+  auth_template: Record<string, unknown>;
+  organization_credentials: Record<string, string>;
+  enabled: boolean;
+  /** Repo source: GitHub URL, owner/repo slug, or `npx skills add` command. */
+  source: string;
+  /** Slug of the specific skill from the repo to use as the bundle. */
+  slug: string;
+}
+
+/**
+ * Create a CUSTOM external app from a git repo skill
+ * (`POST /admin/apps/custom/from-repo`). JSON body, matching the same
+ * error-handling conventions as the other functions in this file.
+ */
+export async function createCustomExternalAppFromRepo(
+  input: CreateCustomExternalAppFromRepoInput
+): Promise<ExternalAppAdminResponse> {
+  const res = await fetch(`${BUILD_API_BASE}/admin/apps/custom/from-repo`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  if (!res.ok) {
+    throw new Error(await readErrorDetail(res, "Save failed"));
+  }
+  return res.json();
+}
+
 /**
  * Replace a custom app's bundle bytes, keeping its slug
  * (`PUT /admin/apps/{id}/bundle`). The only multipart channel for edits; all

--- a/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.tsx
@@ -24,7 +24,7 @@ import {
   updateExternalApp,
 } from "@/app/craft/services/externalAppsService";
 import {
-  previewRepoSkills,
+  previewRepoSkillsAdmin,
   type RepoSkillPreviewItem,
   type RepoSkillsPreview,
 } from "@/lib/skills/api";
@@ -128,7 +128,7 @@ export default function CreateCustomAppModal({
     setRepoPreview(null);
     setSelectedSkill(null);
     try {
-      const result = await previewRepoSkills(repoSource.trim());
+      const result = await previewRepoSkillsAdmin(repoSource.trim());
       setRepoPreview(result);
     } catch (err) {
       setRepoPreviewError(
@@ -421,6 +421,11 @@ export default function CreateCustomAppModal({
                         onChange={(e) => {
                           setRepoSource(e.target.value);
                           setRepoPreviewError(null);
+                          // Editing the source invalidates the previous repo's
+                          // discovery — clear it so Create can't submit a stale
+                          // skill slug against a different source.
+                          setRepoPreview(null);
+                          setSelectedSkill(null);
                         }}
                         onKeyDown={(e) => {
                           if (

--- a/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.tsx
@@ -10,6 +10,8 @@ import {
   Tooltip,
 } from "@opal/components";
 import { SvgUploadCloud } from "@opal/icons";
+import { cn } from "@opal/utils";
+import { Content, Section } from "@opal/layouts";
 import { ListFieldInput } from "@/refresh-components/inputs/ListFieldInput";
 import InputKeyValue, {
   KeyValue,
@@ -17,9 +19,15 @@ import InputKeyValue, {
 import { ExternalAppAdminResponse } from "@/app/craft/v1/apps/registry";
 import {
   createCustomExternalApp,
+  createCustomExternalAppFromRepo,
   replaceCustomAppBundle,
   updateExternalApp,
 } from "@/app/craft/services/externalAppsService";
+import {
+  previewRepoSkills,
+  type RepoSkillPreviewItem,
+  type RepoSkillsPreview,
+} from "@/lib/skills/api";
 
 interface CreateCustomAppModalProps {
   open: boolean;
@@ -49,6 +57,8 @@ function toKeyValues(record: Record<string, string>): KeyValue[] {
   return entries.length > 0 ? entries : [{ key: "", value: "" }];
 }
 
+type BundleSource = "upload" | "repo";
+
 export default function CreateCustomAppModal({
   open,
   onClose,
@@ -69,6 +79,17 @@ export default function CreateCustomAppModal({
   const [error, setError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
+  // Repo-import state (create mode only)
+  const [bundleSource, setBundleSource] = useState<BundleSource>("upload");
+  const [repoSource, setRepoSource] = useState("");
+  const [isPreviewing, setIsPreviewing] = useState(false);
+  const [repoPreview, setRepoPreview] = useState<RepoSkillsPreview | null>(
+    null
+  );
+  const [repoPreviewError, setRepoPreviewError] = useState<string | null>(null);
+  const [selectedSkill, setSelectedSkill] =
+    useState<RepoSkillPreviewItem | null>(null);
+
   // Re-seed every time the modal opens: from the existing app when editing,
   // blank when creating. Prevents a prior attempt from leaking in.
   useEffect(() => {
@@ -88,10 +109,41 @@ export default function CreateCustomAppModal({
     );
     setFile(null);
     setError(null);
+    setBundleSource("upload");
+    setRepoSource("");
+    setIsPreviewing(false);
+    setRepoPreview(null);
+    setRepoPreviewError(null);
+    setSelectedSkill(null);
   }, [open, existingApp]);
 
   function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) {
     setFile(event.target.files?.[0] ?? null);
+  }
+
+  async function handleFindSkills() {
+    if (!repoSource.trim()) return;
+    setIsPreviewing(true);
+    setRepoPreviewError(null);
+    setRepoPreview(null);
+    setSelectedSkill(null);
+    try {
+      const result = await previewRepoSkills(repoSource.trim());
+      setRepoPreview(result);
+    } catch (err) {
+      setRepoPreviewError(
+        err instanceof Error ? err.message : "Failed to fetch skills from repo"
+      );
+    } finally {
+      setIsPreviewing(false);
+    }
+  }
+
+  function selectSkill(skill: RepoSkillPreviewItem) {
+    setSelectedSkill(skill);
+    // Prefill name/description only when they're still blank
+    if (!name.trim()) setName(skill.name);
+    if (!description.trim()) setDescription(skill.description);
   }
 
   // Headers and org credentials are optional; name + at least one upstream
@@ -104,8 +156,13 @@ export default function CreateCustomAppModal({
     if (upstreamPatterns.length === 0) {
       return "Add at least one upstream URL pattern. Type a pattern and press Enter.";
     }
-    if (!isEdit && file === null) {
-      return "Upload a bundle .zip file before creating this custom app.";
+    if (!isEdit) {
+      if (bundleSource === "upload" && file === null) {
+        return "Upload a bundle .zip file before creating this custom app.";
+      }
+      if (bundleSource === "repo" && selectedSkill === null) {
+        return "Select a skill from the repo before creating this custom app.";
+      }
     }
     return null;
   })();
@@ -144,8 +201,20 @@ export default function CreateCustomAppModal({
           auth_template: toRecord(headers),
           organization_credentials: toRecord(orgCredentials),
         });
+      } else if (bundleSource === "repo") {
+        // Create from repo: selectedSkill is guaranteed non-null by disabledCreateReason.
+        await createCustomExternalAppFromRepo({
+          name: name.trim(),
+          description: description.trim(),
+          upstream_url_patterns: upstreamPatterns,
+          auth_template: toRecord(headers),
+          organization_credentials: toRecord(orgCredentials),
+          enabled: true,
+          source: repoSource.trim(),
+          slug: selectedSkill!.slug,
+        });
       } else {
-        // Create: bundle is required (enforced by `canSave`).
+        // Create via zip upload: bundle is required (enforced by disabledCreateReason).
         await createCustomExternalApp({
           name: name.trim(),
           description: description.trim(),
@@ -184,26 +253,26 @@ export default function CreateCustomAppModal({
           }
         />
         <Modal.Body>
-          <div className="flex flex-col gap-4">
-            <div className="flex flex-col gap-1">
+          <Section gap={1} alignItems="stretch">
+            <Section gap={0.25} alignItems="stretch">
               <Text font="main-ui-action">Name</Text>
               <InputTypeIn
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 placeholder="My Custom App"
               />
-            </div>
+            </Section>
 
-            <div className="flex flex-col gap-1">
+            <Section gap={0.25} alignItems="stretch">
               <Text font="main-ui-action">Description</Text>
               <InputTypeIn
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
                 placeholder="Optional — defaults to the bundle's SKILL.md description"
               />
-            </div>
+            </Section>
 
-            <div className="flex flex-col gap-1">
+            <Section gap={0.25} alignItems="stretch">
               <Text font="main-ui-action">Upstream URL patterns</Text>
               <Text font="secondary-body" color="text-03">
                 {
@@ -215,9 +284,9 @@ export default function CreateCustomAppModal({
                 onChange={setUpstreamPatterns}
                 placeholder="https://api.example.com/*"
               />
-            </div>
+            </Section>
 
-            <div className="flex flex-col gap-1">
+            <Section gap={0.25} alignItems="stretch">
               <Text font="main-ui-action">Header credential pattern</Text>
               <Text font="secondary-body" color="text-03">
                 {`Optional — headers injected into outbound requests. Use {placeholder} for values the user (or org below) supplies, e.g. "Bearer {api_key}". Leave empty to allowlist the upstream patterns without injecting credentials.`}
@@ -232,9 +301,9 @@ export default function CreateCustomAppModal({
                 mode="line"
                 addButtonLabel="Add header"
               />
-            </div>
+            </Section>
 
-            <div className="flex flex-col gap-1">
+            <Section gap={0.25} alignItems="stretch">
               <Text font="main-ui-action">Organization credentials</Text>
               <Text font="secondary-body" color="text-03">
                 Optional — values your org pre-fills for every user. Leave empty
@@ -250,45 +319,200 @@ export default function CreateCustomAppModal({
                 mode="line"
                 addButtonLabel="Add credential"
               />
-            </div>
+            </Section>
 
-            <div className="flex flex-col gap-1">
-              <Text font="main-ui-action">
-                {isEdit ? "Replace bundle (.zip)" : "Bundle (.zip)"}
-              </Text>
-              <Text font="secondary-body" color="text-03">
-                {isEdit
-                  ? "Optional — upload a new zip to replace the current bundle. Leave empty to keep it. The slug stays the same."
-                  : "A zip containing SKILL.md plus any other files. The filename becomes the app slug."}
-              </Text>
-              <div className="flex items-center gap-2">
-                <input
-                  ref={fileInputRef}
-                  type="file"
-                  accept=".zip,application/zip"
-                  onChange={handleFileChange}
-                  className="hidden"
-                />
-                <Button
-                  icon={SvgUploadCloud}
-                  prominence="secondary"
-                  onClick={() => fileInputRef.current?.click()}
-                >
-                  {file
-                    ? "Change file"
-                    : isEdit
-                      ? "Choose new zip"
-                      : "Choose zip"}
-                </Button>
-                <Text font="main-ui-body" color="text-03">
-                  {file
-                    ? file.name
-                    : isEdit
-                      ? "Keeping current bundle"
-                      : "No file selected"}
+            <Section gap={0.5} alignItems="stretch">
+              <Section gap={0.25} alignItems="stretch">
+                <Text font="main-ui-action">
+                  {isEdit ? "Replace bundle (.zip)" : "Bundle"}
                 </Text>
-              </div>
-            </div>
+                {!isEdit && (
+                  <Text font="secondary-body" color="text-03">
+                    Upload a zip or import a skill directly from a git repo.
+                  </Text>
+                )}
+                {isEdit && (
+                  <Text font="secondary-body" color="text-03">
+                    Optional — upload a new zip to replace the current bundle.
+                    Leave empty to keep it. The slug stays the same.
+                  </Text>
+                )}
+              </Section>
+
+              {/* Bundle-source toggle — create mode only */}
+              {!isEdit && (
+                <Section
+                  flexDirection="row"
+                  gap={0.25}
+                  alignItems="center"
+                  justifyContent="start"
+                  width="fit"
+                >
+                  <Button
+                    prominence={
+                      bundleSource === "upload" ? "primary" : "secondary"
+                    }
+                    size="sm"
+                    onClick={() => setBundleSource("upload")}
+                  >
+                    Upload zip
+                  </Button>
+                  <Button
+                    prominence={
+                      bundleSource === "repo" ? "primary" : "secondary"
+                    }
+                    size="sm"
+                    onClick={() => setBundleSource("repo")}
+                  >
+                    Import from repo
+                  </Button>
+                </Section>
+              )}
+
+              {/* Upload zip mode */}
+              {(isEdit || bundleSource === "upload") && (
+                <Section
+                  flexDirection="row"
+                  gap={0.5}
+                  alignItems="center"
+                  justifyContent="start"
+                >
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept=".zip,application/zip"
+                    onChange={handleFileChange}
+                    className="hidden"
+                  />
+                  <Button
+                    icon={SvgUploadCloud}
+                    prominence="secondary"
+                    onClick={() => fileInputRef.current?.click()}
+                  >
+                    {file
+                      ? "Change file"
+                      : isEdit
+                        ? "Choose new zip"
+                        : "Choose zip"}
+                  </Button>
+                  <Text font="main-ui-body" color="text-03">
+                    {file
+                      ? file.name
+                      : isEdit
+                        ? "Keeping current bundle"
+                        : "No file selected"}
+                  </Text>
+                </Section>
+              )}
+
+              {/* Import from repo mode */}
+              {!isEdit && bundleSource === "repo" && (
+                <Section gap={0.5} alignItems="stretch">
+                  <Section
+                    flexDirection="row"
+                    gap={0.5}
+                    alignItems="center"
+                    justifyContent="start"
+                  >
+                    <div className="flex-1">
+                      <InputTypeIn
+                        placeholder="https://github.com/owner/repo  or  npx skills add <url>"
+                        value={repoSource}
+                        onChange={(e) => {
+                          setRepoSource(e.target.value);
+                          setRepoPreviewError(null);
+                        }}
+                        onKeyDown={(e) => {
+                          if (
+                            e.key === "Enter" &&
+                            repoSource.trim() &&
+                            !isPreviewing
+                          ) {
+                            void handleFindSkills();
+                          }
+                        }}
+                      />
+                    </div>
+                    <Button
+                      prominence="secondary"
+                      disabled={!repoSource.trim() || isPreviewing}
+                      onClick={() => void handleFindSkills()}
+                    >
+                      {isPreviewing ? "Fetching…" : "Find skills"}
+                    </Button>
+                  </Section>
+                  <Text font="secondary-body" color="text-03">
+                    Paste a GitHub URL, an owner/repo slug, or the full npx
+                    skills add … command. One skill will become the app bundle.
+                  </Text>
+
+                  {repoPreviewError && (
+                    <MessageCard
+                      variant="error"
+                      title="Could not fetch skills"
+                      description={repoPreviewError}
+                    />
+                  )}
+
+                  {repoPreview && repoPreview.skills.length > 0 && (
+                    <Section
+                      gap={0.25}
+                      alignItems="stretch"
+                      role="radiogroup"
+                      aria-label="Skills found in repository"
+                    >
+                      <Text font="secondary-body" color="text-03">
+                        {`${repoPreview.skills.length} skill${repoPreview.skills.length === 1 ? "" : "s"} found — select one to use as the bundle.`}
+                      </Text>
+                      {repoPreview.skills.map((skill) => {
+                        const isSelected = selectedSkill?.slug === skill.slug;
+                        return (
+                          // A fixed-height Interactive.Container can't hold a
+                          // multi-line title+description, so this selectable
+                          // card uses a content-sized wrapper with design
+                          // tokens for the selected state.
+                          <div
+                            key={skill.slug}
+                            role="radio"
+                            aria-checked={isSelected}
+                            tabIndex={0}
+                            onClick={() => selectSkill(skill)}
+                            onKeyDown={(e: React.KeyboardEvent) => {
+                              if (e.key === "Enter" || e.key === " ") {
+                                e.preventDefault();
+                                selectSkill(skill);
+                              }
+                            }}
+                            className={cn(
+                              "cursor-pointer rounded-md border p-2",
+                              isSelected
+                                ? "bg-background-tint-02 border-border-04"
+                                : "bg-background-neutral-02 border-border-02"
+                            )}
+                          >
+                            <Content
+                              sizePreset="main-ui"
+                              variant="section"
+                              title={skill.name}
+                              description={skill.description}
+                              descriptionMaxLines={2}
+                            />
+                          </div>
+                        );
+                      })}
+                    </Section>
+                  )}
+
+                  {repoPreview && repoPreview.skills.length === 0 && (
+                    <MessageCard
+                      variant="warning"
+                      title="No skills found"
+                      description="This repo doesn't appear to contain any skills.sh-compatible skills."
+                    />
+                  )}
+                </Section>
+              )}
+            </Section>
 
             {error && (
               <MessageCard
@@ -297,10 +521,15 @@ export default function CreateCustomAppModal({
                 description={error}
               />
             )}
-          </div>
+          </Section>
         </Modal.Body>
         <Modal.Footer>
-          <div className="flex justify-end gap-2 w-full">
+          <Section
+            flexDirection="row"
+            justifyContent="end"
+            gap={0.5}
+            height="auto"
+          >
             <Button
               prominence="secondary"
               onClick={onClose}
@@ -315,7 +544,7 @@ export default function CreateCustomAppModal({
             ) : (
               createButton
             )}
-          </div>
+          </Section>
         </Modal.Footer>
       </Modal.Content>
     </Modal>

--- a/web/src/lib/skills/api.ts
+++ b/web/src/lib/skills/api.ts
@@ -232,3 +232,23 @@ export async function installRepoSkills(
   });
   return handle<RepoSkillsInstallResult>(res);
 }
+
+// Admin-gated counterpart: installs org-wide custom skills with visibility.
+export async function installRepoSkillsAdmin(
+  source: string,
+  slugs: string[],
+  isPublic: boolean,
+  groupIds: number[]
+): Promise<RepoSkillsInstallResult> {
+  const res = await fetch("/api/admin/skills/from-repo/install", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      source,
+      slugs,
+      is_public: isPublic,
+      group_ids: groupIds,
+    }),
+  });
+  return handle<RepoSkillsInstallResult>(res);
+}

--- a/web/src/lib/skills/api.ts
+++ b/web/src/lib/skills/api.ts
@@ -209,6 +209,18 @@ export async function previewRepoSkills(
   return handle<RepoSkillsPreview>(res);
 }
 
+// Admin-gated counterpart for system-wide flows (e.g. custom external apps).
+export async function previewRepoSkillsAdmin(
+  source: string
+): Promise<RepoSkillsPreview> {
+  const res = await fetch("/api/admin/skills/from-repo/preview", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ source }),
+  });
+  return handle<RepoSkillsPreview>(res);
+}
+
 export async function installRepoSkills(
   source: string,
   slugs: string[]

--- a/web/src/lib/skills/api.ts
+++ b/web/src/lib/skills/api.ts
@@ -169,3 +169,54 @@ export async function deleteUserSkill(skillId: string): Promise<void> {
   });
   await handle<void>(res);
 }
+
+// ---------------------------------------------------------------------------
+// Repo-based skill installation
+// ---------------------------------------------------------------------------
+
+export interface RepoSkillPreviewItem {
+  slug: string;
+  name: string;
+  description: string;
+  rel_path: string;
+  pre_selected: boolean;
+}
+
+export interface RepoSkillsPreview {
+  source_label: string;
+  ref: string | null;
+  skills: RepoSkillPreviewItem[];
+}
+
+export interface RepoSkillInstallFailure {
+  slug: string;
+  error: string;
+}
+
+export interface RepoSkillsInstallResult {
+  created: CustomSkill[];
+  failures: RepoSkillInstallFailure[];
+}
+
+export async function previewRepoSkills(
+  source: string
+): Promise<RepoSkillsPreview> {
+  const res = await fetch("/api/skills/from-repo/preview", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ source }),
+  });
+  return handle<RepoSkillsPreview>(res);
+}
+
+export async function installRepoSkills(
+  source: string,
+  slugs: string[]
+): Promise<RepoSkillsInstallResult> {
+  const res = await fetch("/api/skills/from-repo/install", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ source, slugs }),
+  });
+  return handle<RepoSkillsInstallResult>(res);
+}

--- a/web/src/views/UserSkillsPage.tsx
+++ b/web/src/views/UserSkillsPage.tsx
@@ -1,11 +1,26 @@
 "use client";
 
 import { useMemo, useRef, useState } from "react";
-import { Button, InputTypeIn, MessageCard, Text } from "@opal/components";
-import { IllustrationContent } from "@opal/layouts";
+import {
+  Button,
+  InputTypeIn,
+  MessageCard,
+  Popover,
+  PopoverMenu,
+  Text,
+} from "@opal/components";
+import { IllustrationContent, Section, SettingsLayouts } from "@opal/layouts";
 import SvgNoResult from "@opal/illustrations/no-result";
-import { SvgBlocks, SvgPlus, SvgSettings, SvgSimpleLoader } from "@opal/icons";
-import { SettingsLayouts } from "@opal/layouts";
+import {
+  SvgBlocks,
+  SvgChevronDownSmall,
+  SvgDownloadCloud,
+  SvgPlus,
+  SvgSettings,
+  SvgSimpleLoader,
+  SvgUploadCloud,
+} from "@opal/icons";
+import LineItem from "@/refresh-components/buttons/LineItem";
 import TextSeparator from "@/refresh-components/TextSeparator";
 import useOnMount from "@/hooks/useOnMount";
 import useUserSkills from "@/hooks/useUserSkills";
@@ -15,6 +30,7 @@ import SkillCard, {
   type SkillCardItem,
 } from "@/sections/cards/SkillCard";
 import CreatePersonalSkillModal from "@/views/UserSkillsPage/CreatePersonalSkillModal";
+import AddSkillFromRepoModal from "@/views/UserSkillsPage/AddSkillFromRepoModal";
 import { ConfirmEntityModal } from "@/sections/modals/ConfirmEntityModal";
 import {
   deleteUserSkill,
@@ -32,6 +48,8 @@ export default function UserSkillsPage() {
   const { user, isAdmin } = useUser();
   const [searchQuery, setSearchQuery] = useState("");
   const [createOpen, setCreateOpen] = useState(false);
+  const [addFromRepoOpen, setAddFromRepoOpen] = useState(false);
+  const [createMenuOpen, setCreateMenuOpen] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<CustomSkillCardItem | null>(
     null
   );
@@ -164,7 +182,14 @@ export default function UserSkillsPage() {
         title="Skills"
         description="Capability bundles your Craft agent can reach for. This page shows what's currently available to you — skills granted by admins plus your own personal skills."
         rightChildren={
-          <div className="flex items-center gap-2">
+          <Section
+            flexDirection="row"
+            gap={0.5}
+            alignItems="center"
+            justifyContent="end"
+            width="fit"
+            height="auto"
+          >
             {isAdmin && (
               <Button
                 href="/craft/v1/skills/manage"
@@ -174,10 +199,40 @@ export default function UserSkillsPage() {
                 Manage skills
               </Button>
             )}
-            <Button icon={SvgPlus} onClick={() => setCreateOpen(true)}>
-              Create skill
-            </Button>
-          </div>
+            <Popover open={createMenuOpen} onOpenChange={setCreateMenuOpen}>
+              <Popover.Trigger asChild>
+                <Button icon={SvgPlus} rightIcon={SvgChevronDownSmall}>
+                  Create skill
+                </Button>
+              </Popover.Trigger>
+              <Popover.Content align="end" width="sm">
+                <PopoverMenu>
+                  {[
+                    <LineItem
+                      key="bundle"
+                      icon={SvgUploadCloud}
+                      onClick={() => {
+                        setCreateMenuOpen(false);
+                        setCreateOpen(true);
+                      }}
+                    >
+                      Add from bundle
+                    </LineItem>,
+                    <LineItem
+                      key="repo"
+                      icon={SvgDownloadCloud}
+                      onClick={() => {
+                        setCreateMenuOpen(false);
+                        setAddFromRepoOpen(true);
+                      }}
+                    >
+                      Add from repo
+                    </LineItem>,
+                  ]}
+                </PopoverMenu>
+              </Popover.Content>
+            </Popover>
+          </Section>
         }
       >
         <InputTypeIn
@@ -267,6 +322,12 @@ export default function UserSkillsPage() {
         open={createOpen}
         onClose={() => setCreateOpen(false)}
         onCreated={refresh}
+      />
+
+      <AddSkillFromRepoModal
+        open={addFromRepoOpen}
+        onClose={() => setAddFromRepoOpen(false)}
+        onInstalled={refresh}
       />
 
       {deleteTarget && (

--- a/web/src/views/UserSkillsPage/AddSkillFromRepoModal.tsx
+++ b/web/src/views/UserSkillsPage/AddSkillFromRepoModal.tsx
@@ -112,7 +112,10 @@ export default function AddSkillFromRepoModal({
     if (!preview || selected.size === 0) return;
     setInstalling(true);
     try {
-      const result = await installRepoSkills(source.trim(), [...selected]);
+      const result = await installRepoSkills(
+        source.trim(),
+        Array.from(selected)
+      );
       setCreatedCount(result.created.length);
       if (result.created.length > 0) {
         onInstalled();

--- a/web/src/views/UserSkillsPage/AddSkillFromRepoModal.tsx
+++ b/web/src/views/UserSkillsPage/AddSkillFromRepoModal.tsx
@@ -73,9 +73,10 @@ export default function AddSkillFromRepoModal({
   }
 
   function initSelection(skills: RepoSkillPreviewItem[]): Set<string> {
-    const preSelected = skills.filter((s) => s.pre_selected).map((s) => s.slug);
-    if (preSelected.length > 0) return new Set(preSelected);
-    return new Set(skills.map((s) => s.slug));
+    // pre_selected is all-true with no --skill filter, the matching subset when
+    // filters match, and all-false when filters matched nothing — in which case
+    // we select none rather than silently selecting every skill.
+    return new Set(skills.filter((s) => s.pre_selected).map((s) => s.slug));
   }
 
   async function handleFindSkills() {

--- a/web/src/views/UserSkillsPage/AddSkillFromRepoModal.tsx
+++ b/web/src/views/UserSkillsPage/AddSkillFromRepoModal.tsx
@@ -1,0 +1,359 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Button,
+  InputTypeIn,
+  MessageCard,
+  Switch,
+  Text,
+} from "@opal/components";
+import { SvgDownloadCloud } from "@opal/icons";
+import { markdown } from "@opal/utils";
+import Modal from "@/refresh-components/Modal";
+import { Section } from "@/layouts/general-layouts";
+import { Content, ContentAction } from "@opal/layouts";
+import {
+  previewRepoSkills,
+  installRepoSkills,
+  type RepoSkillsPreview,
+  type RepoSkillPreviewItem,
+  type RepoSkillInstallFailure,
+} from "@/lib/skills/api";
+import { toast } from "@/hooks/useToast";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type Step = "input" | "select" | "result";
+
+interface AddSkillFromRepoModalProps {
+  open: boolean;
+  onClose: () => void;
+  /** Invoked after at least one skill was successfully installed. */
+  onInstalled: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function AddSkillFromRepoModal({
+  open,
+  onClose,
+  onInstalled,
+}: AddSkillFromRepoModalProps) {
+  const [step, setStep] = useState<Step>("input");
+  const [source, setSource] = useState("");
+  const [previewing, setPreviewing] = useState(false);
+  const [installing, setInstalling] = useState(false);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const [preview, setPreview] = useState<RepoSkillsPreview | null>(null);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [failures, setFailures] = useState<RepoSkillInstallFailure[]>([]);
+  const [createdCount, setCreatedCount] = useState(0);
+
+  function reset() {
+    setStep("input");
+    setSource("");
+    setPreviewing(false);
+    setInstalling(false);
+    setPreviewError(null);
+    setPreview(null);
+    setSelected(new Set());
+    setFailures([]);
+    setCreatedCount(0);
+  }
+
+  function handleClose() {
+    if (previewing || installing) return;
+    reset();
+    onClose();
+  }
+
+  function initSelection(skills: RepoSkillPreviewItem[]): Set<string> {
+    const preSelected = skills.filter((s) => s.pre_selected).map((s) => s.slug);
+    if (preSelected.length > 0) return new Set(preSelected);
+    return new Set(skills.map((s) => s.slug));
+  }
+
+  async function handleFindSkills() {
+    if (!source.trim()) return;
+    setPreviewing(true);
+    setPreviewError(null);
+    try {
+      const result = await previewRepoSkills(source.trim());
+      setPreview(result);
+      setSelected(initSelection(result.skills));
+      setStep("select");
+    } catch (err) {
+      setPreviewError(
+        err instanceof Error ? err.message : "Failed to fetch skills from repo"
+      );
+    } finally {
+      setPreviewing(false);
+    }
+  }
+
+  function toggleSkill(slug: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(slug)) {
+        next.delete(slug);
+      } else {
+        next.add(slug);
+      }
+      return next;
+    });
+  }
+
+  async function handleInstall() {
+    if (!preview || selected.size === 0) return;
+    setInstalling(true);
+    try {
+      const result = await installRepoSkills(source.trim(), [...selected]);
+      setCreatedCount(result.created.length);
+      if (result.created.length > 0) {
+        onInstalled();
+        if (result.failures.length === 0) {
+          toast.success(
+            `Installed ${result.created.length} skill${result.created.length === 1 ? "" : "s"}`
+          );
+          reset();
+          onClose();
+          return;
+        }
+        toast.success(
+          `Installed ${result.created.length} skill${result.created.length === 1 ? "" : "s"} with some failures`
+        );
+      }
+      // partial or total failure — stay open and show the failure list
+      setFailures(result.failures);
+      setStep("result");
+    } catch (err) {
+      setCreatedCount(0);
+      setFailures([
+        {
+          slug: "*",
+          error:
+            err instanceof Error ? err.message : "Installation request failed",
+        },
+      ]);
+      setStep("result");
+    } finally {
+      setInstalling(false);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Render helpers
+  // ---------------------------------------------------------------------------
+
+  function renderInputStep() {
+    return (
+      <>
+        <Modal.Body>
+          <Section gap={0.5} alignItems="stretch">
+            <Section gap={0.25} alignItems="stretch">
+              <Text as="p" font="main-ui-action" color="text-05">
+                {markdown("GitHub repo URL or `npx skills add` command")}
+              </Text>
+              <InputTypeIn
+                placeholder="https://github.com/owner/repo  or  npx skills add <url>"
+                value={source}
+                onChange={(e) => {
+                  setSource(e.target.value);
+                  setPreviewError(null);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && source.trim() && !previewing) {
+                    void handleFindSkills();
+                  }
+                }}
+                autoFocus
+              />
+              <Text as="p" font="secondary-body" color="text-03">
+                Paste a GitHub URL, an owner/repo slug, or the full npx skills
+                add … command from a skills.sh-compatible repo.
+              </Text>
+            </Section>
+
+            {previewError && (
+              <MessageCard
+                variant="error"
+                title="Could not fetch skills"
+                description={previewError}
+              />
+            )}
+          </Section>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button prominence="secondary" onClick={handleClose}>
+            Cancel
+          </Button>
+          <Button
+            icon={SvgDownloadCloud}
+            disabled={!source.trim() || previewing}
+            onClick={() => void handleFindSkills()}
+          >
+            {previewing ? "Fetching…" : "Find skills"}
+          </Button>
+        </Modal.Footer>
+      </>
+    );
+  }
+
+  function renderSelectStep() {
+    if (!preview) return null;
+    const { source_label, ref: repoRef, skills } = preview;
+    const skillCountLabel = `${skills.length} skill${skills.length === 1 ? "" : "s"} found. Toggle which ones to install.`;
+    const sourceHeading = repoRef
+      ? `${source_label} @ ${repoRef}`
+      : source_label;
+
+    return (
+      <>
+        <Modal.Body>
+          <Section gap={0.75} alignItems="stretch">
+            <Section gap={0.25} alignItems="stretch">
+              <Text font="main-ui-action" color="text-05">
+                {sourceHeading}
+              </Text>
+              <Text font="secondary-body" color="text-03">
+                {skillCountLabel}
+              </Text>
+            </Section>
+
+            <Section gap={0.25} alignItems="stretch">
+              {skills.map((skill) => (
+                <ContentAction
+                  key={skill.slug}
+                  sizePreset="main-ui"
+                  variant="section"
+                  title={skill.name}
+                  description={skill.description}
+                  padding="sm"
+                  rightChildren={
+                    <Switch
+                      checked={selected.has(skill.slug)}
+                      onCheckedChange={() => toggleSkill(skill.slug)}
+                      disabled={installing}
+                      aria-label={skill.name}
+                    />
+                  }
+                />
+              ))}
+            </Section>
+          </Section>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button
+            prominence="secondary"
+            onClick={() => {
+              setStep("input");
+              setPreview(null);
+              setSelected(new Set());
+            }}
+            disabled={installing}
+          >
+            Back
+          </Button>
+          <Button
+            icon={SvgDownloadCloud}
+            disabled={selected.size === 0 || installing}
+            onClick={() => void handleInstall()}
+          >
+            {installing
+              ? "Installing…"
+              : `Install ${selected.size} skill${selected.size === 1 ? "" : "s"}`}
+          </Button>
+        </Modal.Footer>
+      </>
+    );
+  }
+
+  function renderResultStep() {
+    const allFailed = createdCount === 0;
+    return (
+      <>
+        <Modal.Body>
+          <Section gap={0.5} alignItems="stretch">
+            <MessageCard
+              variant={allFailed ? "error" : "warning"}
+              title={
+                allFailed
+                  ? "No skills were installed"
+                  : "Some skills failed to install"
+              }
+              description={
+                allFailed
+                  ? "Every selected skill encountered an error. Nothing was added."
+                  : `Installed ${createdCount} skill${createdCount === 1 ? "" : "s"}. The skills below encountered errors.`
+              }
+            />
+            <Section gap={0.25} alignItems="stretch">
+              {failures.map((f) => (
+                <Content
+                  key={f.slug}
+                  sizePreset="main-ui"
+                  variant="section"
+                  title={f.slug}
+                  description={f.error}
+                  color="danger"
+                />
+              ))}
+            </Section>
+          </Section>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button onClick={handleClose}>Done</Button>
+        </Modal.Footer>
+      </>
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Modal header props per step
+  // ---------------------------------------------------------------------------
+
+  const headerProps =
+    step === "input"
+      ? {
+          title: "Add skills from repo",
+          description:
+            "Install agent skills directly from a GitHub repository. Paste a URL, owner/repo, or a skills.sh npx command.",
+        }
+      : step === "select"
+        ? {
+            title: "Select skills to install",
+            description:
+              "Choose which skills from this repo you want to add to your personal skill library.",
+          }
+        : createdCount === 0
+          ? {
+              title: "Installation failed",
+              description: "None of the selected skills could be installed.",
+            }
+          : {
+              title: "Install complete",
+              description:
+                "Some skills were installed; others encountered errors.",
+            };
+
+  return (
+    <Modal open={open} onOpenChange={(isOpen) => !isOpen && handleClose()}>
+      <Modal.Content width="md">
+        <Modal.Header
+          icon={SvgDownloadCloud}
+          title={headerProps.title}
+          description={headerProps.description}
+          onClose={handleClose}
+        />
+        {step === "input" && renderInputStep()}
+        {step === "select" && renderSelectStep()}
+        {step === "result" && renderResultStep()}
+      </Modal.Content>
+    </Modal>
+  );
+}


### PR DESCRIPTION
## Description

Adds **skills-marketplace** support to Craft — install agent skills from a git repo (the skills.sh / `vercel-labs/skills` ecosystem) instead of only hand-uploading a `.zip`.

- **Skills**: the "Create skill" button is now a dropdown — **Add from bundle** (existing zip upload) or **Add from repo**. The repo flow accepts a GitHub/GitLab URL, an `owner/repo` slug, or a full `npx skills add <url> --skill <name>` command → discovers the repo's skills → you pick which to install.
- **Custom external apps**: the create modal gains an **Import from repo** option that sources the app's bundle from a repo (single-select, since an app = one bundle).

Implementation reuses the existing zip-bundle ingestion end-to-end, so DB rows, FileStore blobs, sandbox push, and the AGENTS.md section all work unchanged — no schema/migration change.

New backend module `onyx/skills/marketplace.py`: source/command parsing, **SSRF-safe** tarball fetch (reuses `ssrf_safe_get`, size-capped), hardened tar/zip extraction (path-traversal/symlink/member-count/size guards), multi-layout skill discovery (flat / catalog / `.claude` / `.agents` / `.claude-plugin` manifest, all confined to the repo root), and bundle building. New endpoints: `POST /api/skills/from-repo/{preview,install}` (user + admin) and `POST /api/build/admin/apps/custom/from-repo`. Batch install holds the personal-skill advisory lock, does one up-front cap check, creates each skill in a savepoint (a slug collision becomes a per-skill failure, not a 500), and cleans up blobs on every failure path.

## How Has This Been Tested?

Screenshots

<img width="684" height="407" alt="Screenshot 2026-06-18 at 14 06 00" src="https://github.com/user-attachments/assets/737c7f5a-6906-4dd9-99dc-290ac49237fb" />

<img width="983" height="241" alt="Screenshot 2026-06-18 at 14 06 26" src="https://github.com/user-attachments/assets/294ee799-7f14-43fd-a1f4-7f5165b8b715" />

<img width="871" height="896" alt="Screenshot 2026-06-18 at 14 07 04" src="https://github.com/user-attachments/assets/99da8753-677d-4f42-b4b8-0da8c4d06f08" />

- **Unit (28, no services):** source/command parsing across all input forms; discovery across flat/catalog/`.claude`/manifest layouts; bundle validity; tar-traversal rejection; `--skill` → `pre_selected` mapping.
- **External-dependency (real Postgres + FileStore, run in CI):** install happy path, slug-collision partial-success, cap enforcement, reserved-slug rejection, blob cleanup (OnyxError + non-OnyxError); admin install (is_public + group grants); external-app create-from-repo (persisted app/skill, bundle validity, bad-slug 404).
- **Live E2E (browser, against a running instance on this branch):** skills happy install (`docx`), `--skill` filter pre-selection, slug-collision "all-failed" error UI, unsupported-host + nonexistent-repo errors; external-app from-repo create (`brand-guidelines`) end-to-end through to the Configured list.
- **Review:** 6-lens review-team (correctness, security, regressions, tests, frontend-style, DB) — all confirmed critical/high/medium findings fixed; a tar-decompression-bomb claim was empirically refuted. Local `ty` + `ruff` + `oxlint`/`oxfmt`/`tsgo` all green.

### Known minor items (left for reviewer, low severity)
- Multipart `POST /admin/apps/custom` validation order: a request missing **both** the bundle and a name now surfaces the missing-bundle message first (each individual message unchanged).
- Two discovered dirs that slugify to the same slug → install keeps the last (cosmetic vs. preview).
- GitLab **subgroup** repos (`group/subgroup/repo`) aren't supported → clean 404, not a crash.
- The `--skill` flag is only parsed from the `skills add …` command form (not a bare `owner/repo --skill x`).
- Minor test gaps: invalid-bundle rejection on the app endpoint, slug-dedupe, empty-after-dedupe.
- Minor FE: prefill-on-select only fires while name/description are blank; repo state isn't cleared when toggling back to "Upload zip" (never read in that mode).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Install agent skills and admin custom apps directly from a GitHub/GitLab repo (`skills.sh` ecosystem). Paste a repo URL, `owner/repo`, or an `npx skills add … --skill` command to preview and install.

- **New Features**
  - Skills: “Create skill” adds “Add from repo” with preview and multi-select; `--skill` preselects matches.
  - Custom apps: Admin “Create custom app” adds “Import from repo” (single-select) using the existing bundle flow.
  - Backend: `onyx/skills/marketplace.py` adds SSRF-safe tarball fetch with size/timeout caps, hardened extraction, and multi-layout discovery; personal and admin installs share one secure ingestion loop with per-skill savepoints; endpoints: `POST /api/skills/from-repo/preview`, `POST /api/admin/skills/from-repo/preview`, `POST /api/skills/from-repo/install`, `POST /api/admin/skills/from-repo/install`, `POST /api/build/admin/apps/custom/from-repo`; admin install supports `is_public` and `group_ids`.
  - Frontend: New repo install modal for skills; admin app modal uses admin preview/install endpoints; added `previewRepoSkillsAdmin`, `installRepoSkillsAdmin`, and `createCustomExternalAppFromRepo` API clients.
  - Config: `SKILL_MARKETPLACE_ARCHIVE_MAX_BYTES` and `SKILL_MARKETPLACE_FETCH_TIMEOUT_SECONDS` validated via `_non_negative_int_env`.
  - Internal: replaced `ParsedSource`/`DiscoveredSkill` dataclasses with frozen `pydantic` models.

- **Bug Fixes**
  - Admin custom-app import uses the admin preview endpoint and clears preview/selection when the source changes.
  - Fixed Next build by iterating a selected `Set` via `Array.from`.
  - Subpath URLs now derive the slug from the skill dir; GitLab `/-/tree/<ref>/<subpath>` URLs parse correctly; streamed archive responses are closed; repo-fetch network errors return a clean 502.
  - If a `--skill` filter matches none, nothing is selected by default.
  - Post-commit sandbox push is best-effort so a push error won’t 500 a successful install.

<sup>Written for commit 7094421bb71c6a9765a90e113a47b4050c902c17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



