### PR TITLE
fix(branding): restore custom app name in browser title after navigation (#12162)

### DIFF
--- a/web/src/app/ee/admin/theme/AppearanceThemeSettings.tsx
+++ b/web/src/app/ee/admin/theme/AppearanceThemeSettings.tsx
@@ -9,7 +9,7 @@ import {
   Tabs,
   Tag,
 } from "@opal/components";
-import { Preview } from "./Preview";
+import Preview from "@/app/ee/admin/theme/Preview";
 import InputTextArea from "@/refresh-components/inputs/InputTextArea";
 import CharacterCount from "@/refresh-components/CharacterCount";
 import InputImage from "@/refresh-components/inputs/InputImage";

--- a/web/src/app/ee/admin/theme/Preview.tsx
+++ b/web/src/app/ee/admin/theme/Preview.tsx
@@ -55,17 +55,6 @@ export type PreviewHighlightTarget =
   | "chat_header"
   | "chat_footer";
 
-export interface PreviewProps {
-  logoDisplayStyle: "logo_and_name" | "logo_only" | "name_only";
-  applicationDisplayName: string;
-  chat_footer_content: string;
-  chat_header_content: string;
-  greeting_message: string;
-  className?: string;
-  logoSrc?: string;
-  highlightTarget?: PreviewHighlightTarget | null;
-}
-
 function PreviewLogo({
   logoSrc,
   forceOnyxIcon,
@@ -93,12 +82,94 @@ function PreviewLogo({
   );
 }
 
-export function InputPreview() {
+function InputPreview() {
   return (
     <div className="bg-background-neutral-00 border border-border-01 flex flex-col gap-1.5 items-end pb-1 pl-2.5 pr-1 pt-2.5 rounded-08 w-full h-14">
       <div className="h-5 w-5 bg-theme-primary-05 mt-auto rounded-sm"></div>
     </div>
   );
+}
+
+function PreviewChat({
+  chat_header_content,
+  chat_footer_content,
+  highlightTarget,
+}: {
+  chat_header_content: string;
+  chat_footer_content: string;
+  highlightTarget?: PreviewHighlightTarget | null;
+}) {
+  return (
+    <div className="flex flex-col h-60 relative bg-background-tint-01 rounded-12 shadow-00">
+      {/* Header */}
+      <div className="flex justify-center w-full">
+        <div className="flex w-full max-w-[300px] justify-center">
+          <div
+            className={cn(
+              "inline-flex max-w-full items-center justify-center rounded-08 border border-transparent p-0.5 text-center",
+              highlightTarget === "chat_header" && "bg-highlight-match"
+            )}
+          >
+            <Text
+              figureSmallLabel
+              text03
+              className="max-w-full whitespace-normal wrap-break-word text-center"
+            >
+              {chat_header_content}
+            </Text>
+          </div>
+        </div>
+      </div>
+
+      {/* Main Content */}
+      <div className="flex flex-1 flex-col gap-2 items-center justify-end max-w-[300px] w-full px-3 py-0 mx-auto">
+        {/* User message bubble (right side) */}
+        <div className="flex flex-col items-end w-full">
+          <div className="bg-background-tint-02 flex flex-col items-start px-2.5 py-2 rounded-bl-[10px] rounded-tl-[10px] rounded-tr-[10px]">
+            <div className="bg-background-neutral-03 h-1.5 rounded-04 w-20" />
+          </div>
+        </div>
+
+        {/* AI response bubble (left side) */}
+        <div className="flex flex-col gap-1.5 items-start pl-2 pr-16 py-2 w-full">
+          <div className="bg-background-neutral-03 h-1.5 rounded-04 w-full" />
+          <div className="bg-background-neutral-03 h-1.5 rounded-04 w-full" />
+          <div className="bg-background-neutral-03 h-1.5 rounded-04 w-12" />
+        </div>
+
+        {/* Input field */}
+        <InputPreview />
+      </div>
+
+      {/* Footer */}
+      <div className="flex flex-col items-center justify-end w-full">
+        <div className="flex w-full max-w-[300px] justify-center">
+          <div
+            className={cn(
+              "inline-flex max-w-full items-start justify-center rounded-04 border border-transparent p-0.5 text-center",
+              highlightTarget === "chat_footer" && "bg-highlight-match"
+            )}
+          >
+            <PreviewMinimalMarkdown
+              content={chat_footer_content}
+              className={cn("max-w-full text-center origin-center")}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export interface PreviewProps {
+  logoDisplayStyle: "logo_and_name" | "logo_only" | "name_only";
+  applicationDisplayName: string;
+  chat_footer_content: string;
+  chat_header_content: string;
+  greeting_message: string;
+  className?: string;
+  logoSrc?: string;
+  highlightTarget?: PreviewHighlightTarget | null;
 }
 
 function PreviewStart({
@@ -184,77 +255,7 @@ function PreviewStart({
   );
 }
 
-function PreviewChat({
-  chat_header_content,
-  chat_footer_content,
-  highlightTarget,
-}: {
-  chat_header_content: string;
-  chat_footer_content: string;
-  highlightTarget?: PreviewHighlightTarget | null;
-}) {
-  return (
-    <div className="flex flex-col h-60 relative bg-background-tint-01 rounded-12 shadow-00">
-      {/* Header */}
-      <div className="flex justify-center w-full">
-        <div className="flex w-full max-w-[300px] justify-center">
-          <div
-            className={cn(
-              "inline-flex max-w-full items-center justify-center rounded-08 border border-transparent p-0.5 text-center",
-              highlightTarget === "chat_header" && "bg-highlight-match"
-            )}
-          >
-            <Text
-              figureSmallLabel
-              text03
-              className="max-w-full whitespace-normal wrap-break-word text-center"
-            >
-              {chat_header_content}
-            </Text>
-          </div>
-        </div>
-      </div>
-
-      {/* Main Content */}
-      <div className="flex flex-1 flex-col gap-2 items-center justify-end max-w-[300px] w-full px-3 py-0 mx-auto">
-        {/* User message bubble (right side) */}
-        <div className="flex flex-col items-end w-full">
-          <div className="bg-background-tint-02 flex flex-col items-start px-2.5 py-2 rounded-bl-[10px] rounded-tl-[10px] rounded-tr-[10px]">
-            <div className="bg-background-neutral-03 h-1.5 rounded-04 w-20" />
-          </div>
-        </div>
-
-        {/* AI response bubble (left side) */}
-        <div className="flex flex-col gap-1.5 items-start pl-2 pr-16 py-2 w-full">
-          <div className="bg-background-neutral-03 h-1.5 rounded-04 w-full" />
-          <div className="bg-background-neutral-03 h-1.5 rounded-04 w-full" />
-          <div className="bg-background-neutral-03 h-1.5 rounded-04 w-12" />
-        </div>
-
-        {/* Input field */}
-        <InputPreview />
-      </div>
-
-      {/* Footer */}
-      <div className="flex flex-col items-center justify-end w-full">
-        <div className="flex w-full max-w-[300px] justify-center">
-          <div
-            className={cn(
-              "inline-flex max-w-full items-start justify-center rounded-04 border border-transparent p-0.5 text-center",
-              highlightTarget === "chat_footer" && "bg-highlight-match"
-            )}
-          >
-            <PreviewMinimalMarkdown
-              content={chat_footer_content}
-              className={cn("max-w-full text-center origin-center")}
-            />
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
-export function Preview({
+export default function Preview({
   logoDisplayStyle,
   applicationDisplayName,
   chat_footer_content,

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,7 +1,6 @@
 import "./globals.css";
 
 import { GTM_ENABLED, MODAL_ROOT_ID } from "@/lib/constants";
-import { Metadata } from "next";
 import AppProvider from "@/providers/AppProvider";
 import DynamicMetadata from "@/providers/DynamicMetadata";
 import { PHProvider } from "./providers";
@@ -48,11 +47,6 @@ const dmMono = DM_Mono({
     "monospace",
   ],
 });
-
-export const metadata: Metadata = {
-  title: "Onyx",
-  description: "Question answering for your documents",
-};
 
 // force-dynamic prevents Next.js from statically prerendering pages at build
 // time — many child routes use cookies() which requires dynamic rendering.

--- a/web/src/providers/DynamicMetadata.tsx
+++ b/web/src/providers/DynamicMetadata.tsx
@@ -1,16 +1,18 @@
 "use client";
 
 import { useEffect } from "react";
+import { usePathname } from "next/navigation";
 import { useSettings } from "@/lib/settings/hooks";
 
 export default function DynamicMetadata() {
   const { appName, logoUrl } = useSettings();
+  const pathname = usePathname();
 
   useEffect(() => {
     if (document.title !== appName) {
       document.title = appName;
     }
-  }, [appName]);
+  }, [appName, pathname]);
 
   return <link rel="icon" href={logoUrl ?? "/onyx.ico"} />;
 }


### PR DESCRIPTION
## Description

Cherry-picks fix(branding): restore custom app name in browser title after navigation (#12162) onto `hotfix/f74788a-v4.1`.

## How Has This Been Tested?

Cherry-pick of existing PR.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore the custom app name in the browser tab after navigation by moving title control into dynamic metadata and removing the hardcoded layout title.

- **Bug Fixes**
  - In `DynamicMetadata`, set `document.title` from settings and re-run on route changes via `usePathname` from `next/navigation`.
  - Remove the static `metadata` export in `web/src/app/layout.tsx`.

- **Refactors**
  - Make `Preview` a default export and update its import in `AppearanceThemeSettings` to `@/app/ee/admin/theme/Preview` (no behavior change).

<sup>Written for commit c65f37020dc804e50ed0584018faa3c56042493a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

