### PR TITLE
fix(indexing): count index-attempt errors via grouped query to stop api-server OOM

### DIFF
--- a/backend/onyx/db/index_attempt.py
+++ b/backend/onyx/db/index_attempt.py
@@ -747,6 +747,24 @@ def count_index_attempts_for_cc_pair(
     return total_count
 
 
+def get_error_counts_for_index_attempts(
+    db_session: Session,
+    index_attempt_ids: list[int],
+) -> dict[int, int]:
+    """Per-attempt error-row counts via one grouped query; attempt ids with no
+    errors are absent (callers treat missing as 0). Counts in SQL because
+    ``error_rows`` is unbounded per attempt and must not be materialized here."""
+    if not index_attempt_ids:
+        return {}
+
+    stmt = (
+        select(IndexAttemptError.index_attempt_id, func.count())
+        .where(IndexAttemptError.index_attempt_id.in_(index_attempt_ids))
+        .group_by(IndexAttemptError.index_attempt_id)
+    )
+    return {attempt_id: count for attempt_id, count in db_session.execute(stmt).all()}
+
+
 def get_paginated_index_attempts_for_cc_pair_id(
     db_session: Session,
     cc_pair_id: int,

--- a/backend/onyx/server/documents/cc_pair.py
+++ b/backend/onyx/server/documents/cc_pair.py
@@ -42,6 +42,7 @@ from onyx.db.enums import Permission
 from onyx.db.enums import PermissionSyncStatus
 from onyx.db.index_attempt import count_index_attempt_errors_for_cc_pair
 from onyx.db.index_attempt import count_index_attempts_for_cc_pair
+from onyx.db.index_attempt import get_error_counts_for_index_attempts
 from onyx.db.index_attempt import get_index_attempt
 from onyx.db.index_attempt import get_index_attempt_errors_for_cc_pair
 from onyx.db.index_attempt import get_latest_index_attempt_for_cc_pair_id
@@ -116,9 +117,16 @@ def get_cc_pair_index_attempts(
         page=page_num,
         page_size=page_size,
     )
+    error_counts = get_error_counts_for_index_attempts(
+        db_session=db_session,
+        index_attempt_ids=[index_attempt.id for index_attempt in index_attempts],
+    )
     return PaginatedReturn(
         items=[
-            IndexAttemptSnapshot.from_index_attempt_db_model(index_attempt)
+            IndexAttemptSnapshot.from_index_attempt_db_model(
+                index_attempt,
+                error_count=error_counts.get(index_attempt.id, 0),
+            )
             for index_attempt in index_attempts
         ],
         total_items=total_count,

--- a/backend/onyx/server/documents/models.py
+++ b/backend/onyx/server/documents/models.py
@@ -192,7 +192,7 @@ class IndexAttemptSnapshot(BaseModel):
 
     @classmethod
     def from_index_attempt_db_model(
-        cls, index_attempt: IndexAttempt
+        cls, index_attempt: IndexAttempt, error_count: int
     ) -> "IndexAttemptSnapshot":
         return IndexAttemptSnapshot(
             id=index_attempt.id,
@@ -202,7 +202,7 @@ class IndexAttemptSnapshot(BaseModel):
             total_docs_indexed=index_attempt.total_docs_indexed or 0,
             docs_removed_from_index=index_attempt.docs_removed_from_index or 0,
             error_msg=index_attempt.error_msg,
-            error_count=len(index_attempt.error_rows),
+            error_count=error_count,
             full_exception_trace=index_attempt.full_exception_trace,
             time_started=(
                 index_attempt.time_started.isoformat()


### PR DESCRIPTION
## Description

**Bug:** `GET /manage/admin/cc-pair/{id}/index-attempts` built every `IndexAttemptSnapshot` with `error_count=len(index_attempt.error_rows)`, which lazy-loads every `IndexAttemptError` row for the attempt just to count them.

**Why it OOM'd:** For a connector whose attempt has thousands of errors (one had 4,253), a single request materializes thousands of heavy ORM rows (~13s). The connector detail page polls this endpoint every 5s, so requests overlap and stack — exhausting api-server memory on the shared multi-tenant pod, leading to OOMKilled / CrashLoopBackOff (fleet-wide 502s). Memory was bumped 6Gi to 12Gi as a band-aid; this is the real fix.

**Fix:**
- New `get_error_counts_for_index_attempts()` — one grouped `COUNT ... GROUP BY index_attempt_id` for the whole page (the FK is indexed).
- `from_index_attempt_db_model` now takes `error_count` as a required param; no lazy relationship load.
- `error_count` is display-only, so the returned value is unchanged.

Per-page cost drops from `1 + N` row-materializations to 2 queries.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
