### PR TITLE
fix(chat): keep processing indicator until user files finish indexing

### DIFF
--- a/web/src/sections/input/AppInputBar.tsx
+++ b/web/src/sections/input/AppInputBar.tsx
@@ -280,6 +280,9 @@ const AppInputBar = React.memo(
       );
     }, [currentMessageFiles]);
 
+    // A file isn't queryable until indexing completes, so gate send on it.
+    const hasIndexingFiles = currentIndexingFiles.length > 0;
+
     // Convert ProjectFile to MinimalOnyxDocument format for viewing
     const handleFileClick = useCallback(
       (file: ProjectFile) => {
@@ -456,6 +459,14 @@ const AppInputBar = React.memo(
     // Determine if we should hide processing state based on context limits
     const hideProcessingState = useMemo(() => {
       if (currentMessageFiles.length > 0 && currentIndexingFiles.length > 0) {
+        // token_count is null until indexing finishes; don't hide the
+        // processing indicator while a file's size is still unknown.
+        const allTokenCountsKnown = currentIndexingFiles.every(
+          (file) => (file.token_count ?? 0) > 0
+        );
+        if (!allTokenCountsKnown) {
+          return false;
+        }
         const currentFilesTokenTotal = currentMessageFiles.reduce(
           (acc, file) => acc + (file.token_count || 0),
           0
@@ -702,7 +713,13 @@ const AppInputBar = React.memo(
                 !isVoicePlaybackControllable &&
                 !message) ||
               hasUploadingFiles ||
+              hasIndexingFiles ||
               isClassifying
+            }
+            tooltip={
+              hasUploadingFiles || hasIndexingFiles
+                ? "Waiting for attached file(s) to finish processing"
+                : undefined
             }
             id="onyx-chat-input-send-button"
             icon={

--- a/web/src/sections/input/AppInputBar.tsx
+++ b/web/src/sections/input/AppInputBar.tsx
@@ -462,7 +462,7 @@ const AppInputBar = React.memo(
         // token_count is null until indexing finishes; don't hide the
         // processing indicator while a file's size is still unknown.
         const allTokenCountsKnown = currentIndexingFiles.every(
-          (file) => (file.token_count ?? 0) > 0
+          (file) => file.token_count !== null
         );
         if (!allTokenCountsKnown) {
           return false;

--- a/web/tests/e2e/chat/chat_file_uploads.spec.ts
+++ b/web/tests/e2e/chat/chat_file_uploads.spec.ts
@@ -40,6 +40,29 @@ async function uploadFilesToChat(
   page: Page,
   files: UploadFile[]
 ): Promise<void> {
+  // Report every tracked file as COMPLETED so the chat input treats uploads
+  // as ready. The send button is disabled while a file is still processing,
+  // and a file that fails to index is dropped from the message — so without
+  // this stub these tests would race (or depend on) the real indexing
+  // pipeline. UI rendering is what's under test here, not indexing.
+  await page.route("**/api/user/projects/file/statuses", async (route) => {
+    const ids =
+      (route.request().postDataJSON() as { file_ids?: string[] })?.file_ids ??
+      [];
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(
+        ids.map((id) => ({
+          id,
+          status: "COMPLETED",
+          token_count: 1,
+          chunk_count: 1,
+        }))
+      ),
+    });
+  });
+
   const fileInput = page.locator('input[type="file"]').first();
   const chooserPromise = page.waitForEvent("filechooser");
   await fileInput.dispatchEvent("click");


### PR DESCRIPTION
## Description

When a user uploads a file in chat, the backend reports `token_count = null` until indexing finishes. The chat input treated a `null` token count as "0 tokens → fits in the context window → ready" and hid the **"Processing…"** indicator early. The file then looked ready while it was still being indexed, so a user could send a message referencing a not-yet-queryable file and get a degraded answer — it only worked correctly once indexing had finished (e.g. in a later session). This was especially visible for image-bearing PDFs, where image summarization can push processing to several minutes.

This keeps the processing state accurate and prevents premature sends:

- Don't hide the processing indicator until **every** still-processing attached file reports a real (non-null) token count.
- Disable the send button while any attached file is still uploading **or** processing, with a tooltip explaining why — mirroring the existing in-progress-upload gate.

Frontend-only change in `web/src/sections/input/AppInputBar.tsx`.

## How Has This Been Tested?

Manually against a local instance. Pinned the `/api/user/projects/file/statuses` poll to `PROCESSING` (`token_count: null`) and confirmed the file card keeps its spinner/"Processing…" label and the send button stays disabled with the explanatory tooltip. Releasing to `COMPLETED` clears the spinner and re-enables send. Also confirmed the inverse (`token_count` set while `PROCESSING`) reproduces the old premature-hide behavior. `tsc`, `oxlint`, and `oxfmt` all pass.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the chat input showing files as ready before indexing completes. Keeps the “Processing…” indicator and disables Send until all attached files finish indexing and return a non-null token count, with a tooltip explaining the wait.

- **Bug Fixes**
  - Use an explicit null check (`token_count !== null`) so not-yet-indexed files don’t look ready.
  - Stub `/api/user/projects/file/statuses` in e2e tests to return `COMPLETED` to avoid racing the real indexing pipeline.

<sup>Written for commit ea0cfb7d8f61d868c0750769e4e52fa29b908869. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

