### PR TITLE
feat(search): surface connector filter in the UI

### DIFF
--- a/backend/onyx/server/query_and_chat/streaming_models.py
+++ b/backend/onyx/server/query_and_chat/streaming_models.py
@@ -24,6 +24,7 @@ class StreamingType(Enum):
     MESSAGE_DELTA = "message_delta"
     SEARCH_TOOL_START = "search_tool_start"
     SEARCH_TOOL_QUERIES_DELTA = "search_tool_queries_delta"
+    SEARCH_TOOL_FILTER_DELTA = "search_tool_filter_delta"
     SEARCH_TOOL_DOCUMENTS_DELTA = "search_tool_documents_delta"
     OPEN_URL_START = "open_url_start"
     OPEN_URL_URLS = "open_url_urls"
@@ -176,6 +177,16 @@ class SearchToolQueriesDelta(BaseObj):
     )
 
     queries: list[str]
+
+
+# The connector/source filter applied to this internal search (which sources are
+# being searched). Absent == no filter applied (searched everything).
+class SearchToolFilterDelta(BaseObj):
+    type: Literal["search_tool_filter_delta"] = (
+        StreamingType.SEARCH_TOOL_FILTER_DELTA.value
+    )
+
+    sources: list[str]
 
 
 # Documents coming through as the system knows what to add to the context
@@ -434,6 +445,7 @@ PacketObj = Union[
     # Tool Packets
     SearchToolStart,
     SearchToolQueriesDelta,
+    SearchToolFilterDelta,
     SearchToolDocumentsDelta,
     ImageGenerationToolStart,
     ImageGenerationToolHeartbeat,

--- a/backend/onyx/tools/tool_implementations/search/search_tool.py
+++ b/backend/onyx/tools/tool_implementations/search/search_tool.py
@@ -94,6 +94,7 @@ from onyx.secondary_llm_flows.source_filter import SearchCycle
 from onyx.server.query_and_chat.placement import Placement
 from onyx.server.query_and_chat.streaming_models import Packet
 from onyx.server.query_and_chat.streaming_models import SearchToolDocumentsDelta
+from onyx.server.query_and_chat.streaming_models import SearchToolFilterDelta
 from onyx.server.query_and_chat.streaming_models import SearchToolQueriesDelta
 from onyx.server.query_and_chat.streaming_models import SearchToolStart
 from onyx.tools.interface import Tool
@@ -783,6 +784,22 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
                 ),
             )
         )
+
+        # Surface the scope to the UI only when it narrows to a strict subset of
+        # the connected sources — scoping to all of them is equivalent to an
+        # unscoped search, so the UI keeps its default "internal documents" label.
+        scopes_all_sources = bool(connected_sources) and set(
+            connected_sources
+        ).issubset(resolved_scope or [])
+        if resolved_scope and not scopes_all_sources:
+            self.emitter.emit(
+                Packet(
+                    placement=placement,
+                    obj=SearchToolFilterDelta(
+                        sources=[source.value for source in resolved_scope]
+                    ),
+                )
+            )
 
         queries_run = list(
             dict.fromkeys(

--- a/backend/tests/unit/onyx/tools/tool_implementations/search/test_search_tool_run.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/search/test_search_tool_run.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any
+from typing import cast
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -8,6 +9,7 @@ from onyx.configs.constants import DocumentSource
 from onyx.configs.constants import MessageType
 from onyx.context.search.models import BaseFilters
 from onyx.server.query_and_chat.placement import Placement
+from onyx.server.query_and_chat.streaming_models import SearchToolFilterDelta
 from onyx.tools.models import ChatMinimalTextMessage
 from onyx.tools.models import SearchToolOverrideKwargs
 from onyx.tools.tool_implementations.search.search_tool import SearchTool
@@ -101,6 +103,13 @@ def _queries_sent(mock_search_pipeline: MagicMock) -> list[str]:
     ]
 
 
+def _emitted_filter_sources(tool: SearchTool) -> list[list[str]]:
+    """Sources of each SearchToolFilterDelta the tool emitted to the UI."""
+    emit_mock = cast(MagicMock, tool.emitter.emit)
+    emitted = [call.args[0].obj for call in emit_mock.call_args_list]
+    return [obj.sources for obj in emitted if isinstance(obj, SearchToolFilterDelta)]
+
+
 def test_decided_scope_is_passed_to_search() -> None:
     """When the filter flow decides a source, every search runs scoped to it."""
     tool = _make_tool()
@@ -119,6 +128,26 @@ def test_decided_scope_is_passed_to_search() -> None:
     for applied in filters:
         assert applied is not None
         assert applied.source_type == [DocumentSource.CONFLUENCE]
+
+
+def test_filter_delta_emitted_for_a_subset_scope() -> None:
+    """A scope narrower than the connected sources surfaces a filter to the UI."""
+    tool = _make_tool()
+    _run(
+        tool,
+        decision=[DocumentSource.CONFLUENCE],
+        connected_sources=[DocumentSource.CONFLUENCE, DocumentSource.GITHUB],
+    )
+    assert _emitted_filter_sources(tool) == [["confluence"]]
+
+
+def test_no_filter_delta_when_scope_covers_all_sources() -> None:
+    """Scoping to every connected source is equivalent to an unscoped search, so
+    no filter is surfaced (the UI keeps its default 'internal documents' label)."""
+    tool = _make_tool()
+    connected = [DocumentSource.CONFLUENCE, DocumentSource.GITHUB]
+    _run(tool, decision=connected, connected_sources=connected)
+    assert _emitted_filter_sources(tool) == []
 
 
 def test_no_decided_scope_leaves_search_unscoped() -> None:

--- a/web/src/app/app/message/messageComponents/timeline/hooks/useTimelineHeader.ts
+++ b/web/src/app/app/message/messageComponents/timeline/hooks/useTimelineHeader.ts
@@ -6,7 +6,10 @@ import {
   StopReason,
   CustomToolStart,
 } from "@/app/app/services/streamingModels";
-import { constructCurrentSearchState } from "@/app/app/message/messageComponents/timeline/renderers/search/searchStateUtils";
+import {
+  formatSearchHeader,
+  constructCurrentSearchState,
+} from "@/app/app/message/messageComponents/timeline/renderers/search/searchStateUtils";
 
 export interface TimelineHeaderResult {
   headerText: string;
@@ -62,10 +65,11 @@ export function useTimelineHeader(
       let headerText: string;
       if (searchState.hasResults && !searchState.isInternetSearch) {
         headerText = "Reading";
+      } else if (searchState.isInternetSearch) {
+        headerText = "Searching the web";
       } else {
-        headerText = searchState.isInternetSearch
-          ? "Searching the web"
-          : "Searching internal documents";
+        // A source filter overrides the header with the connector(s).
+        headerText = formatSearchHeader(searchState.sourceFilters);
       }
       return { headerText, hasPackets, userStopped };
     }

--- a/web/src/app/app/message/messageComponents/timeline/renderers/search/InternalSearchToolRenderer.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/renderers/search/InternalSearchToolRenderer.tsx
@@ -9,6 +9,7 @@ import { OnyxDocument } from "@/lib/search/interfaces";
 import { ValidSources } from "@/lib/types";
 import { SearchChipList, SourceInfo } from "./SearchChipList";
 import {
+  formatSearchHeader,
   constructCurrentSearchState,
   INITIAL_QUERIES_TO_SHOW,
   QUERIES_PER_EXPANSION,
@@ -61,7 +62,7 @@ export const InternalSearchToolRenderer: MessageRenderer<
   children,
 }) => {
   const searchState = constructCurrentSearchState(packets);
-  const { queries, results, isComplete } = searchState;
+  const { queries, results, sourceFilters, isComplete } = searchState;
 
   const isCompact = renderType === RenderType.COMPACT;
   const isHighlight = renderType === RenderType.HIGHLIGHT;
@@ -69,7 +70,8 @@ export const InternalSearchToolRenderer: MessageRenderer<
 
   const hasResults = results.length > 0;
 
-  const queriesHeader = "Searching internal documents";
+  // A source filter overrides the header with the connector(s) it scoped to.
+  const queriesHeader = formatSearchHeader(sourceFilters);
 
   if (queries.length === 0) {
     return children([

--- a/web/src/app/app/message/messageComponents/timeline/renderers/search/searchStateUtils.ts
+++ b/web/src/app/app/message/messageComponents/timeline/renderers/search/searchStateUtils.ts
@@ -3,10 +3,13 @@ import {
   SearchToolPacket,
   SearchToolStart,
   SearchToolQueriesDelta,
+  SearchToolFilterDelta,
   SearchToolDocumentsDelta,
   SectionEnd,
 } from "@/app/app/services/streamingModels";
 import { OnyxDocument } from "@/lib/search/interfaces";
+import { getSourceDisplayName } from "@/lib/sources";
+import { ValidSources } from "@/lib/types";
 
 export const MAX_TITLE_LENGTH = 25;
 
@@ -29,11 +32,25 @@ export const RESULTS_PER_EXPANSION = 10;
 export interface SearchState {
   queries: string[];
   results: OnyxDocument[];
+  // Connectors a source filter was applied to (deduped). Empty == no filter.
+  sourceFilters: string[];
   isSearching: boolean;
   hasResults: boolean;
   isComplete: boolean;
   isInternetSearch: boolean;
 }
+
+/**
+ * Header text for an internal search step. When a source filter was applied,
+ * overrides the default "Searching internal documents" with the connector(s).
+ */
+export const formatSearchHeader = (sourceFilters: string[]): string => {
+  if (sourceFilters.length === 0) return "Searching internal documents";
+  const names = sourceFilters.map(
+    (source) => getSourceDisplayName(source as ValidSources) ?? source
+  );
+  return `Searching ${names.join(", ")}`;
+};
 
 /** Constructs the current search state from search tool packets. */
 export const constructCurrentSearchState = (
@@ -48,6 +65,10 @@ export const constructCurrentSearchState = (
       (packet) => packet.obj.type === PacketType.SEARCH_TOOL_QUERIES_DELTA
     )
     .map((packet) => packet.obj as SearchToolQueriesDelta);
+
+  const filterDeltas = packets
+    .filter((packet) => packet.obj.type === PacketType.SEARCH_TOOL_FILTER_DELTA)
+    .map((packet) => packet.obj as SearchToolFilterDelta);
 
   const documentDeltas = packets
     .filter(
@@ -71,6 +92,16 @@ export const constructCurrentSearchState = (
       return true;
     });
 
+  // Deduped union of every connector a filter was applied to this search block.
+  const seenSources = new Set<string>();
+  const sourceFilters = filterDeltas
+    .flatMap((delta) => delta?.sources || [])
+    .filter((source) => {
+      if (seenSources.has(source)) return false;
+      seenSources.add(source);
+      return true;
+    });
+
   const seenDocIds = new Set<string>();
   const results = documentDeltas
     .flatMap((delta) => delta?.documents || [])
@@ -89,6 +120,7 @@ export const constructCurrentSearchState = (
   return {
     queries,
     results,
+    sourceFilters,
     isSearching,
     hasResults,
     isComplete,

--- a/web/src/app/app/message/messageComponents/timeline/renderers/search/searchStateUtils.ts
+++ b/web/src/app/app/message/messageComponents/timeline/renderers/search/searchStateUtils.ts
@@ -8,7 +8,7 @@ import {
   SectionEnd,
 } from "@/app/app/services/streamingModels";
 import { OnyxDocument } from "@/lib/search/interfaces";
-import { getSourceDisplayName } from "@/lib/sources";
+import { getSourceDisplayName, isValidSource } from "@/lib/sources";
 import { ValidSources } from "@/lib/types";
 
 export const MAX_TITLE_LENGTH = 25;
@@ -32,7 +32,6 @@ export const RESULTS_PER_EXPANSION = 10;
 export interface SearchState {
   queries: string[];
   results: OnyxDocument[];
-  // Connectors a source filter was applied to (deduped). Empty == no filter.
   sourceFilters: string[];
   isSearching: boolean;
   hasResults: boolean;
@@ -44,12 +43,20 @@ export interface SearchState {
  * Header text for an internal search step. When a source filter was applied,
  * overrides the default "Searching internal documents" with the connector(s).
  */
+const MAX_HEADER_SOURCES = 3;
+
 export const formatSearchHeader = (sourceFilters: string[]): string => {
   if (sourceFilters.length === 0) return "Searching internal documents";
-  const names = sourceFilters.map(
-    (source) => getSourceDisplayName(source as ValidSources) ?? source
+  const names = sourceFilters.map((source) =>
+    isValidSource(source)
+      ? getSourceDisplayName(source as ValidSources)
+      : source
   );
-  return `Searching ${names.join(", ")}`;
+  const shown = names.slice(0, MAX_HEADER_SOURCES);
+  const overflow = names.length - shown.length;
+  const label =
+    overflow > 0 ? `${shown.join(", ")} +${overflow} more` : shown.join(", ");
+  return `Searching ${label}`;
 };
 
 /** Constructs the current search state from search tool packets. */

--- a/web/src/app/app/services/packetUtils.ts
+++ b/web/src/app/app/services/packetUtils.ts
@@ -13,6 +13,7 @@ export function isToolPacket(
   let toolPacketTypes = [
     PacketType.SEARCH_TOOL_START,
     PacketType.SEARCH_TOOL_QUERIES_DELTA,
+    PacketType.SEARCH_TOOL_FILTER_DELTA,
     PacketType.SEARCH_TOOL_DOCUMENTS_DELTA,
     PacketType.PYTHON_TOOL_START,
     PacketType.PYTHON_TOOL_DELTA,
@@ -73,6 +74,7 @@ export function isSearchToolPacket(packet: Packet): boolean {
   return (
     packet.obj.type === PacketType.SEARCH_TOOL_START ||
     packet.obj.type === PacketType.SEARCH_TOOL_QUERIES_DELTA ||
+    packet.obj.type === PacketType.SEARCH_TOOL_FILTER_DELTA ||
     packet.obj.type === PacketType.SEARCH_TOOL_DOCUMENTS_DELTA
   );
 }

--- a/web/src/app/app/services/streamingModels.ts
+++ b/web/src/app/app/services/streamingModels.ts
@@ -18,6 +18,7 @@ export enum PacketType {
   // Specific tool packets
   SEARCH_TOOL_START = "search_tool_start",
   SEARCH_TOOL_QUERIES_DELTA = "search_tool_queries_delta",
+  SEARCH_TOOL_FILTER_DELTA = "search_tool_filter_delta",
   SEARCH_TOOL_DOCUMENTS_DELTA = "search_tool_documents_delta",
   IMAGE_GENERATION_TOOL_START = "image_generation_start",
   IMAGE_GENERATION_TOOL_DELTA = "image_generation_final",
@@ -129,6 +130,12 @@ export interface SearchToolStart extends BaseObj {
 export interface SearchToolQueriesDelta extends BaseObj {
   type: "search_tool_queries_delta";
   queries: string[];
+}
+
+export interface SearchToolFilterDelta extends BaseObj {
+  type: "search_tool_filter_delta";
+  // Connector/source values this search is scoped to (empty/absent == all).
+  sources: string[];
 }
 
 export interface SearchToolDocumentsDelta extends BaseObj {
@@ -360,6 +367,7 @@ export type PacketErrorObj = PacketError;
 export type SearchToolObj =
   | SearchToolStart
   | SearchToolQueriesDelta
+  | SearchToolFilterDelta
   | SearchToolDocumentsDelta
   | SectionEnd
   | PacketError;

--- a/web/src/app/app/services/streamingModels.ts
+++ b/web/src/app/app/services/streamingModels.ts
@@ -134,7 +134,7 @@ export interface SearchToolQueriesDelta extends BaseObj {
 
 export interface SearchToolFilterDelta extends BaseObj {
   type: "search_tool_filter_delta";
-  // Connector/source values this search is scoped to (empty/absent == all).
+  // Connector/source values this search is scoped to (empty == all)
   sources: string[];
 }
 


### PR DESCRIPTION
## What

When an internal search is scoped to a connector, show it in the thinking timeline: **"Searching Zendesk"** instead of the generic **"Searching internal documents"**. Unscoped searches are unchanged.

## How

- **Backend:** new `SearchToolFilterDelta` streaming packet; `SearchTool` emits it with the resolved scope — **only when a filter was actually applied** (an unscoped search emits nothing, so the default path is untouched).
- **Frontend:** the filter delta's sources are collected into the search state and rendered in the step header via `formatSearchHeader` (`searchStateUtils.ts`, `InternalSearchToolRenderer.tsx`, `useTimelineHeader.ts`); `packetUtils.ts` / `streamingModels.ts` register the new packet type.

## Stacking / dependencies

- **Stacked on #12212** (the source-filtering implementation) — base branch is `feat/internal-search-source-filtering`. Review/merge that first; this diff is just the packet + emit + FE.
- Renders best **after the placement fix #12191**: without it, a search that follows agent narration in the same turn renders in the chat area, so the chip would appear there rather than the timeline. Not a hard dependency, but the intended UX assumes it.

## Notes

- The applied filter is **live-only** — it's not persisted, so on page reload the chip falls back to "Searching internal documents" (same as query-expansion display today). Persisting it would need a column on the tool call; out of scope here.

<img width="789" height="672" alt="Screenshot 2026-06-23 at 11 27 26 AM" src="https://github.com/user-attachments/assets/4ad0d812-09d6-4c41-9be9-b95dd4a7b54a" />

 - [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the applied connector scope in the internal search timeline, e.g., “Searching Zendesk” instead of “Searching internal documents.” Unscoped and “all-sources” scopes keep the default header; web searches still show “Searching the web.”

- New Features
  - Emit `SearchToolFilterDelta` only when the resolved scope narrows the search; unscoped/all-sources emit nothing.
  - Frontend aggregates `sources` into `sourceFilters`, maps to display names, and formats the header via `formatSearchHeader` in `useTimelineHeader` and `InternalSearchToolRenderer` (shows up to 3 connectors, then “+N more”). Completed internal searches show “Reading”; web searches show “Searching the web.”
  - Register the packet in backend streaming models and web `streamingModels.ts` / `packetUtils.ts`. Display is live-only; reload falls back to the default header.

<sup>Written for commit 703828515687952a4fc5924ae52020b50bcacf23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



