### PR TITLE
feat(audit): generalized SIEM-exportable audit-event subsystem

### DIFF
--- a/backend/onyx/utils/audit.py
+++ b/backend/onyx/utils/audit.py
@@ -1,0 +1,260 @@
+"""Structured, SIEM-exportable audit-event subsystem (log-only).
+
+Emits one JSON line per security-relevant action (auth, admin-config /
+access-control change, credential access) on the ``onyx.audit`` logger tree.
+Field names and the action taxonomy are shaped toward OCSF so the stream maps
+onto OCSF event classes (Authentication / Account Change / API Activity) and
+drops into any SIEM. See ``docs/AUDIT_LOGGING.md`` for the schema + export path.
+
+Invariants (from the ``credential_audit`` seed): never raise into the caller
+(emission sits on hot paths), never log a secret, always tenant-tag, and dedup
+hot event classes via Redis (degrade to always-emit if Redis is down).
+"""
+
+import json
+import logging
+import time
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+AUDIT_SCHEMA_VERSION = "1.0"
+
+# Root of the audit logger tree; per-class children propagate up to it. Plain
+# ``getLogger`` (not ``setup_logger``) keeps the record message a bare JSON
+# object with no human-readable prefix.
+AUDIT_LOGGER_ROOT = "onyx.audit"
+
+_DEFAULT_DEDUP_TTL_SECONDS = 600
+
+
+class OCSFEventClass(str, Enum):
+    """OCSF event class carried on every event (lets consumers route by class)."""
+
+    AUTHENTICATION = "authentication"  # OCSF class_uid 3002
+    ACCOUNT_CHANGE = "account_change"  # OCSF class_uid 3001
+    API_ACTIVITY = "api_activity"  # OCSF class_uid 6003
+
+
+class AuditOutcome(str, Enum):
+    SUCCESS = "success"
+    FAILURE = "failure"
+    DENIED = "denied"  # authn/authz refusal, distinct from an operational error
+
+
+class AuditAction(str, Enum):
+    """Audited-action taxonomy. Values are an append-only schema contract
+    (consumers filter on them); only ``CREDENTIAL_ACCESS`` is wired up so far,
+    the rest land on call sites in follow-up PRs."""
+
+    # Authentication
+    LOGIN = "auth.login"
+    LOGIN_FAILURE = "auth.login_failure"
+    LOGOUT = "auth.logout"
+    REGISTER = "auth.register"
+    PASSWORD_FORGOT = "auth.password_forgot"
+    PASSWORD_RESET = "auth.password_reset"
+    EMAIL_VERIFY = "auth.email_verify"
+
+    # Account change
+    USER_CREATE = "user.create"
+    USER_DELETE = "user.delete"
+    USER_DEACTIVATE = "user.deactivate"
+    USER_REACTIVATE = "user.reactivate"
+    USER_ROLE_CHANGE = "user.role_change"
+    USER_GROUP_CHANGE = "user.group_change"
+
+    # API activity (admin config + resource CRUD)
+    LLM_PROVIDER_CREATE = "llm_provider.create"
+    LLM_PROVIDER_UPDATE = "llm_provider.update"
+    LLM_PROVIDER_DELETE = "llm_provider.delete"
+    CONNECTOR_CREATE = "connector.create"
+    CONNECTOR_UPDATE = "connector.update"
+    CONNECTOR_DELETE = "connector.delete"
+    CC_PAIR_CREATE = "cc_pair.create"
+    CC_PAIR_UPDATE = "cc_pair.update"
+    CC_PAIR_DELETE = "cc_pair.delete"
+    API_KEY_CREATE = "api_key.create"
+    API_KEY_REGENERATE = "api_key.regenerate"
+    API_KEY_DELETE = "api_key.delete"
+    CREDENTIAL_CREATE = "credential.create"
+    CREDENTIAL_UPDATE = "credential.update"
+    CREDENTIAL_DELETE = "credential.delete"
+    CREDENTIAL_ACCESS = "credential.access"
+
+
+_OCSF_CLASS_BY_ACTION: dict[AuditAction, OCSFEventClass] = {
+    AuditAction.LOGIN: OCSFEventClass.AUTHENTICATION,
+    AuditAction.LOGIN_FAILURE: OCSFEventClass.AUTHENTICATION,
+    AuditAction.LOGOUT: OCSFEventClass.AUTHENTICATION,
+    AuditAction.REGISTER: OCSFEventClass.AUTHENTICATION,
+    AuditAction.PASSWORD_FORGOT: OCSFEventClass.AUTHENTICATION,
+    AuditAction.PASSWORD_RESET: OCSFEventClass.AUTHENTICATION,
+    AuditAction.EMAIL_VERIFY: OCSFEventClass.AUTHENTICATION,
+    AuditAction.USER_CREATE: OCSFEventClass.ACCOUNT_CHANGE,
+    AuditAction.USER_DELETE: OCSFEventClass.ACCOUNT_CHANGE,
+    AuditAction.USER_DEACTIVATE: OCSFEventClass.ACCOUNT_CHANGE,
+    AuditAction.USER_REACTIVATE: OCSFEventClass.ACCOUNT_CHANGE,
+    AuditAction.USER_ROLE_CHANGE: OCSFEventClass.ACCOUNT_CHANGE,
+    AuditAction.USER_GROUP_CHANGE: OCSFEventClass.ACCOUNT_CHANGE,
+    AuditAction.LLM_PROVIDER_CREATE: OCSFEventClass.API_ACTIVITY,
+    AuditAction.LLM_PROVIDER_UPDATE: OCSFEventClass.API_ACTIVITY,
+    AuditAction.LLM_PROVIDER_DELETE: OCSFEventClass.API_ACTIVITY,
+    AuditAction.CONNECTOR_CREATE: OCSFEventClass.API_ACTIVITY,
+    AuditAction.CONNECTOR_UPDATE: OCSFEventClass.API_ACTIVITY,
+    AuditAction.CONNECTOR_DELETE: OCSFEventClass.API_ACTIVITY,
+    AuditAction.CC_PAIR_CREATE: OCSFEventClass.API_ACTIVITY,
+    AuditAction.CC_PAIR_UPDATE: OCSFEventClass.API_ACTIVITY,
+    AuditAction.CC_PAIR_DELETE: OCSFEventClass.API_ACTIVITY,
+    AuditAction.API_KEY_CREATE: OCSFEventClass.API_ACTIVITY,
+    AuditAction.API_KEY_REGENERATE: OCSFEventClass.API_ACTIVITY,
+    AuditAction.API_KEY_DELETE: OCSFEventClass.API_ACTIVITY,
+    AuditAction.CREDENTIAL_CREATE: OCSFEventClass.API_ACTIVITY,
+    AuditAction.CREDENTIAL_UPDATE: OCSFEventClass.API_ACTIVITY,
+    AuditAction.CREDENTIAL_DELETE: OCSFEventClass.API_ACTIVITY,
+    AuditAction.CREDENTIAL_ACCESS: OCSFEventClass.API_ACTIVITY,
+}
+
+# Guard: every action must map to a class, so a new action can't ship untagged.
+_unmapped = set(AuditAction) - set(_OCSF_CLASS_BY_ACTION)
+if _unmapped:
+    raise RuntimeError(
+        f"AuditAction members missing an OCSF class mapping: "
+        f"{sorted(a.value for a in _unmapped)}"
+    )
+
+
+@dataclass(frozen=True)
+class AuditActor:
+    """Who performed the action; all fields optional. Never a secret —
+    ``api_key_id`` is the key's id, never its value."""
+
+    user_id: str | None = None
+    email: str | None = None
+    api_key_id: str | None = None
+    auth_type: str | None = None  # e.g. "password", "oauth", "saml", "api_key"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "user_id": self.user_id,
+            "email": self.email,
+            "api_key_id": self.api_key_id,
+            "auth_type": self.auth_type,
+        }
+
+
+# Best-effort context gathering: each degrades to ``None`` rather than raising,
+# so emission works off the request path (e.g. a connector thread) too.
+
+
+def _safe_get_tenant_id() -> str | None:
+    try:
+        from shared_configs.contextvars import get_current_tenant_id
+
+        return get_current_tenant_id()
+    except Exception:
+        return None
+
+
+def _safe_get_request_id() -> str | None:
+    try:
+        from shared_configs.contextvars import ONYX_REQUEST_ID_CONTEXTVAR
+
+        return ONYX_REQUEST_ID_CONTEXTVAR.get()
+    except Exception:
+        return None
+
+
+def _safe_get_endpoint() -> str | None:
+    try:
+        from shared_configs.contextvars import CURRENT_ENDPOINT_CONTEXTVAR
+
+        return CURRENT_ENDPOINT_CONTEXTVAR.get()
+    except Exception:
+        return None
+
+
+def _safe_get_client_ip() -> str | None:
+    try:
+        from onyx.utils.client_ip import current_client_ip
+
+        return current_client_ip()
+    except Exception:
+        return None
+
+
+def should_emit(dedup_key: str, ttl_seconds: int, tenant_id: str | None) -> bool:
+    """Redis ``SETNX``-with-``EX`` dedup. ``True`` if the window wasn't already
+    claimed; degrades to always-emit (``True``) if Redis is unavailable."""
+    try:
+        from onyx.redis.redis_pool import get_redis_client
+
+        client = get_redis_client(tenant_id=tenant_id)
+        # nx=True returns truthy only when the key didn't exist (window is free).
+        result = client.set(f"audit:{dedup_key}", "1", ex=ttl_seconds, nx=True)
+        return bool(result)
+    except Exception:
+        return True
+
+
+def emit_audit_event(
+    action: AuditAction,
+    outcome: AuditOutcome,
+    *,
+    actor: AuditActor | None = None,
+    resource_type: str | None = None,
+    resource_id: str | int | None = None,
+    dedup_key: str | None = None,
+    dedup_ttl_seconds: int = _DEFAULT_DEDUP_TTL_SECONDS,
+    extra: dict[str, Any] | None = None,
+) -> None:
+    """Emit one structured audit line. Never raises.
+
+    Tenant / request / endpoint / client-IP context is gathered automatically.
+    Pass ``dedup_key`` for high-volume actions to suppress duplicates within
+    ``dedup_ttl_seconds`` (omit it for low-volume config/access changes). Never
+    put secrets in ``extra``.
+    """
+    try:
+        tenant_id = _safe_get_tenant_id()
+
+        if dedup_key is not None and not should_emit(
+            dedup_key, dedup_ttl_seconds, tenant_id
+        ):
+            return
+
+        ocsf_class = _OCSF_CLASS_BY_ACTION.get(action)
+
+        payload: dict[str, Any] = {
+            "audit_schema_version": AUDIT_SCHEMA_VERSION,
+            "ts": time.time(),
+            "action": action.value,
+            "ocsf_class": ocsf_class.value if ocsf_class else None,
+            "outcome": outcome.value,
+            "tenant_id": tenant_id,
+            "actor": actor.to_dict() if actor else None,
+            "resource_type": resource_type,
+            "resource_id": str(resource_id) if resource_id is not None else None,
+            "request_id": _safe_get_request_id(),
+            "endpoint": _safe_get_endpoint(),
+            "source_ip": _safe_get_client_ip(),
+            "extra": extra or None,
+        }
+
+        # JSON as the message body so it parses identically under plain/json
+        # LOG_FORMAT; default=str keeps a stray value from raising.
+        _logger_for(ocsf_class).info(json.dumps(payload, default=str))
+    except Exception:
+        # Audit must never break the caller.
+        return
+
+
+def _logger_for(ocsf_class: OCSFEventClass | None) -> logging.Logger:
+    name = (
+        AUDIT_LOGGER_ROOT
+        if ocsf_class is None
+        else f"{AUDIT_LOGGER_ROOT}.{ocsf_class.value}"
+    )
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.INFO)
+    return logger

--- a/backend/tests/unit/onyx/utils/test_audit.py
+++ b/backend/tests/unit/onyx/utils/test_audit.py
@@ -1,0 +1,172 @@
+"""Unit tests for the generalized audit-event subsystem (``onyx.utils.audit``).
+
+These cover the invariants the subsystem must never violate: a stable
+OCSF-shaped schema, never logging a secret, never raising on missing context,
+and Redis-backed dedup that degrades safely when Redis is unavailable.
+"""
+
+import json
+import logging
+from typing import Any
+
+import pytest
+
+from onyx.utils import audit
+from onyx.utils.audit import _OCSF_CLASS_BY_ACTION
+from onyx.utils.audit import AuditAction
+from onyx.utils.audit import AuditActor
+from onyx.utils.audit import AuditOutcome
+from onyx.utils.audit import emit_audit_event
+from onyx.utils.audit import OCSFEventClass
+
+
+def _capture(caplog: pytest.LogCaptureFixture) -> list[dict[str, Any]]:
+    """Parse every captured ``onyx.audit`` JSON message into a dict."""
+    events: list[dict[str, Any]] = []
+    for record in caplog.records:
+        if record.name.startswith("onyx.audit"):
+            events.append(json.loads(record.getMessage()))
+    return events
+
+
+def test_every_action_has_an_ocsf_class() -> None:
+    # The import-time guard already enforces this, but assert it explicitly so a
+    # regression is a clear test failure rather than an import error.
+    for action in AuditAction:
+        assert action in _OCSF_CLASS_BY_ACTION
+        assert isinstance(_OCSF_CLASS_BY_ACTION[action], OCSFEventClass)
+
+
+def test_emits_stable_ocsf_shaped_schema(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.INFO, logger="onyx.audit"):
+        emit_audit_event(
+            AuditAction.LLM_PROVIDER_UPDATE,
+            AuditOutcome.SUCCESS,
+            actor=AuditActor(user_id="u-1", email="a@example.com", auth_type="oauth"),
+            resource_type="llm_provider",
+            resource_id=42,
+        )
+
+    events = _capture(caplog)
+    assert len(events) == 1
+    event = events[0]
+
+    # Stable top-level schema contract.
+    assert set(event.keys()) == {
+        "audit_schema_version",
+        "ts",
+        "action",
+        "ocsf_class",
+        "outcome",
+        "tenant_id",
+        "actor",
+        "resource_type",
+        "resource_id",
+        "request_id",
+        "endpoint",
+        "source_ip",
+        "extra",
+    }
+    assert event["action"] == "llm_provider.update"
+    assert event["ocsf_class"] == "api_activity"
+    assert event["outcome"] == "success"
+    assert event["resource_type"] == "llm_provider"
+    # resource_id is normalized to a string regardless of input type.
+    assert event["resource_id"] == "42"
+    assert event["actor"] == {
+        "user_id": "u-1",
+        "email": "a@example.com",
+        "api_key_id": None,
+        "auth_type": "oauth",
+    }
+
+
+def test_routes_to_per_class_child_logger(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.INFO, logger="onyx.audit"):
+        emit_audit_event(AuditAction.LOGIN, AuditOutcome.SUCCESS)
+
+    auth_records = [r for r in caplog.records if r.name == "onyx.audit.authentication"]
+    assert len(auth_records) == 1
+
+
+def test_never_logs_a_secret_passed_nowhere(caplog: pytest.LogCaptureFixture) -> None:
+    # The emitter only serializes the fields it is handed; a secret that is never
+    # passed can never appear. Assert the rendered line for a typical event does
+    # not contain anything resembling a credential value.
+    secret = "sk-super-secret-value"
+    with caplog.at_level(logging.INFO, logger="onyx.audit"):
+        emit_audit_event(
+            AuditAction.CREDENTIAL_ACCESS,
+            AuditOutcome.SUCCESS,
+            actor=AuditActor(user_id="u-1"),
+            resource_type="llm_provider",
+            resource_id=7,
+            extra={"provider": "openai"},
+        )
+
+    rendered = "\n".join(r.getMessage() for r in caplog.records)
+    assert secret not in rendered
+
+
+def test_never_raises_on_missing_context(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Force every context helper to blow up; emission must still succeed.
+    def _boom() -> str:
+        raise RuntimeError("no context")
+
+    monkeypatch.setattr(audit, "_safe_get_tenant_id", lambda: _boom())
+    monkeypatch.setattr(audit, "_safe_get_request_id", lambda: _boom())
+    monkeypatch.setattr(audit, "_safe_get_endpoint", lambda: _boom())
+    monkeypatch.setattr(audit, "_safe_get_client_ip", lambda: _boom())
+
+    # Must not raise.
+    with caplog.at_level(logging.INFO, logger="onyx.audit"):
+        emit_audit_event(AuditAction.LOGOUT, AuditOutcome.SUCCESS)
+
+
+def test_dedup_suppresses_within_window(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # First call claims the window, second is suppressed.
+    seen: set[str] = set()
+
+    def fake_should_emit(dedup_key: str, _ttl: int, _tenant_id: str | None) -> bool:
+        if dedup_key in seen:
+            return False
+        seen.add(dedup_key)
+        return True
+
+    monkeypatch.setattr(audit, "should_emit", fake_should_emit)
+
+    with caplog.at_level(logging.INFO, logger="onyx.audit"):
+        emit_audit_event(
+            AuditAction.CREDENTIAL_ACCESS, AuditOutcome.SUCCESS, dedup_key="k1"
+        )
+        emit_audit_event(
+            AuditAction.CREDENTIAL_ACCESS, AuditOutcome.SUCCESS, dedup_key="k1"
+        )
+
+    assert len(_capture(caplog)) == 1
+
+
+def test_dedup_degrades_to_emit_when_redis_down(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # ``should_emit`` must return True (always-emit) when the Redis client raises.
+    def boom_get_client(*_args: Any, **_kwargs: Any) -> Any:
+        raise RuntimeError("redis down")
+
+    import onyx.redis.redis_pool as redis_pool
+
+    monkeypatch.setattr(redis_pool, "get_redis_client", boom_get_client)
+    assert audit.should_emit("any-key", 600, "tenant-1") is True
+
+
+def test_no_dedup_key_always_emits(caplog: pytest.LogCaptureFixture) -> None:
+    # Low-volume events omit dedup_key and should always emit, even repeated.
+    with caplog.at_level(logging.INFO, logger="onyx.audit"):
+        emit_audit_event(AuditAction.USER_ROLE_CHANGE, AuditOutcome.SUCCESS)
+        emit_audit_event(AuditAction.USER_ROLE_CHANGE, AuditOutcome.SUCCESS)
+
+    assert len(_capture(caplog)) == 2

--- a/docs/AUDIT_LOGGING.md
+++ b/docs/AUDIT_LOGGING.md
@@ -1,0 +1,150 @@
+# Audit Logging
+
+Onyx emits a normalized, structured **audit-event stream** for security-relevant
+actions (authentication, admin-config changes, access-control changes,
+credential access). The stream is designed to be exported to any SIEM
+(Splunk, Microsoft Sentinel, Elastic, Google Chronicle, AWS Security Lake) with
+**no per-SIEM integration on Onyx's side** — you point your log shipper at the
+container stdout / log file, filter on the audit logger names, and parse the
+JSON.
+
+This maps directly onto common compliance controls: SOC 2 CC7 and the
+FedRAMP/NIST 800-53 **AU** family (AU-2 auditable events, AU-3 record content,
+AU-6 review, AU-12 generation).
+
+## How it works
+
+Audit events are plain `INFO` log records emitted on a dedicated **`onyx.audit`**
+logger tree. The **message body of each record is a single JSON object** — we
+serialize the event to JSON ourselves rather than relying on the structured log
+formatter, so the audit line is byte-identical whether the app runs in
+`LOG_FORMAT=plain` or `LOG_FORMAT=json`. (Setting `LOG_FORMAT=json` is still
+recommended so *all* logs are machine-parseable and tenant/request context is
+promoted to top-level fields — see `backend/shared_configs/configs.py`.)
+
+Emission is **fail-safe and never raises into the caller**: it sits on request
+and connector hot paths, so any failure to gather context, dedup, or log is
+swallowed. High-volume event classes (e.g. credential access) are **deduped via
+Redis** within a short window; if Redis is unavailable, emission degrades to
+always-emit (an audit event is never silently dropped because of infra trouble).
+
+### Logger names
+
+| Logger | Contents |
+|---|---|
+| `onyx.audit` | Root of the audit tree (filter on this prefix to capture everything). |
+| `onyx.audit.authentication` | OCSF Authentication class events. |
+| `onyx.audit.account_change` | OCSF Account Change class events. |
+| `onyx.audit.api_activity` | OCSF API Activity class events. |
+| `onyx.audit.credential_access` | Credential-decrypt events (predates the generalized schema; see note below). |
+
+## Event schema
+
+Field names and the action taxonomy are shaped toward **OCSF** (the Open
+Cybersecurity Schema Framework) so events map cleanly onto OCSF event classes.
+We emit plain JSON today; every event carries an `ocsf_class` hint so a future
+OCSF-native emitter mode is a formatting change, not a re-instrumentation.
+
+Generalized events (`emit_audit_event`, `backend/onyx/utils/audit.py`):
+
+| Field | Type | Description |
+|---|---|---|
+| `audit_schema_version` | string | Schema version (currently `"1.0"`). |
+| `ts` | float | Event time, epoch seconds. |
+| `action` | string | Action taxonomy value, `<domain>.<verb>` (e.g. `llm_provider.update`). Append-only contract. |
+| `ocsf_class` | string | `authentication` \| `account_change` \| `api_activity`. |
+| `outcome` | string | `success` \| `failure` \| `denied`. |
+| `tenant_id` | string \| null | Tenant the action occurred in (best-effort). |
+| `actor` | object \| null | `{ user_id, email, api_key_id, auth_type }`. Never contains a secret. |
+| `resource_type` | string \| null | Affected resource type (e.g. `llm_provider`, `user`, `api_key`). |
+| `resource_id` | string \| null | Affected resource identifier (row id or name), normalized to string. |
+| `request_id` | string \| null | Onyx request id, correlates with the rest of the request's logs. |
+| `endpoint` | string \| null | Route handler that produced the event. |
+| `source_ip` | string \| null | Globally-routable client IP (from `X-Forwarded-For`). |
+| `extra` | object \| null | Additional non-secret context. **Never put secrets here.** |
+
+### Action taxonomy
+
+The `action` values are a stable, append-only contract (consumers filter on
+them). Current taxonomy (`AuditAction` in `backend/onyx/utils/audit.py`):
+
+- **Authentication:** `auth.login`, `auth.login_failure`, `auth.logout`,
+  `auth.register`, `auth.password_forgot`, `auth.password_reset`,
+  `auth.email_verify`
+- **Account change:** `user.create`, `user.delete`, `user.deactivate`,
+  `user.reactivate`, `user.role_change`, `user.group_change`
+- **API activity (admin config / resource CRUD):** `llm_provider.{create,update,delete}`,
+  `connector.{create,update,delete}`, `cc_pair.{create,update,delete}`,
+  `api_key.{create,regenerate,delete}`, `credential.{create,update,delete}`,
+  `credential.access`
+
+> Not every action is wired to a call site yet — the taxonomy is defined ahead
+> of the call-site instrumentation so consumers can build dashboards against the
+> full set.
+
+### Example event
+
+```json
+{
+  "audit_schema_version": "1.0",
+  "ts": 1750000000.123,
+  "action": "llm_provider.update",
+  "ocsf_class": "api_activity",
+  "outcome": "success",
+  "tenant_id": "tenant_abc",
+  "actor": {"user_id": "u-42", "email": "admin@example.com", "api_key_id": null, "auth_type": "oauth"},
+  "resource_type": "llm_provider",
+  "resource_id": "7",
+  "request_id": "01J...",
+  "endpoint": "PUT /admin/llm/provider",
+  "source_ip": "203.0.113.5",
+  "extra": null
+}
+```
+
+### Credential-access events (legacy shape)
+
+`onyx.audit.credential_access` predates the generalized schema and keeps its own
+(slightly different) field set for backward compatibility with existing
+consumers — notably `credential_type`, `provider`, `row_id`, `client_ip`,
+`user_id` at the top level (no nested `actor`). It shares the same fail-safe
+plumbing and Redis dedup as the generalized emitter. See
+`backend/onyx/utils/credential_audit.py`.
+
+## Exporting to a SIEM
+
+Because audit events are just JSON log lines on a known logger prefix, any log
+shipper works. The general pattern:
+
+1. Run Onyx with `LOG_FORMAT=json` so the surrounding log records are structured.
+2. Ship container stdout (or the `backend/log/*.log` files) with Fluent Bit /
+   Vector / the CloudWatch agent / Filebeat.
+3. Filter to audit events by `logger` prefix `onyx.audit` and parse the
+   `message` field as JSON.
+
+Example **Vector** transform that isolates the audit stream:
+
+```toml
+[transforms.onyx_audit]
+type = "filter"
+inputs = ["onyx_logs"]
+condition = '''starts_with(string!(.logger), "onyx.audit")'''
+
+[transforms.onyx_audit_parsed]
+type = "remap"
+inputs = ["onyx_audit"]
+source = '. = parse_json!(.message)'
+```
+
+Example **Fluent Bit** grep filter:
+
+```ini
+[FILTER]
+    Name    grep
+    Match   onyx.*
+    Regex   logger ^onyx\.audit
+```
+
+> Roadmap: a syslog/CEF formatter, an OCSF-native emitter mode, and an in-product
+> `audit_event` table + read API are planned follow-ups. The JSON export path
+> documented here is the supported MVP.


### PR DESCRIPTION
## Description

Adds the generalized, SIEM-exportable **audit-event subsystem** — the core layer that the auth / admin-config / access-control call sites land on in follow-up PRs. This is the foundation for emitting a normalized, exportable audit-event stream so any customer's SIEM (Splunk / Sentinel / Elastic / Chronicle / AWS Security Lake) can ingest it with no per-SIEM integration on our side.

It builds directly on the patterns introduced by the credential-access audit seed (#12083), generalizing them into a reusable subsystem.

**`backend/onyx/utils/audit.py`** — `emit_audit_event(...)`:
- **Fail-safe** — never raises into the caller (sits on request/connector hot paths); every step is best-effort.
- **OCSF-shaped schema** — stable field names (`action`, `ocsf_class`, `outcome`, `actor`, `resource_type`/`resource_id`, `tenant_id`, `request_id`, `endpoint`, `source_ip`, `extra`, …) mapping cleanly onto OCSF event classes, so a future OCSF-native emitter is a formatting change, not re-instrumentation. Emits one JSON line per event on a dedicated `onyx.audit.<class>` logger tree — identical under `LOG_FORMAT=plain` and `json`.
- **`AuditAction` taxonomy enum** (Authentication / Account Change / API Activity), with an import-time guard so a new action can't ship without an OCSF-class mapping.
- **Redis-backed dedup** — opt-in per call via `dedup_key`; degrades to always-emit when Redis is unavailable (never silently drops an event).

**`docs/AUDIT_LOGGING.md`** — schema reference + JSON/SIEM export path, with sample Vector and Fluent Bit configs.

The credential-access seed (#12083) is intentionally left untouched here; refolding it onto this shared plumbing is a small, separate follow-up. Auth events and admin-config/access-control events are independent follow-up PRs that depend on this one.

## How Has This Been Tested?

New unit tests in `backend/tests/unit/onyx/utils/test_audit.py` (8, all passing) covering the non-negotiable invariants:
- Stable OCSF-shaped schema and per-class logger routing.
- Secret values never appear in output.
- Emitter never raises when request context is missing.
- Redis dedup suppresses within the window and degrades safely to always-emit when Redis is down.

`ty` and `ruff` (check + format) pass clean via pre-commit.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a generalized, SIEM-exportable audit-event subsystem that emits OCSF-shaped JSON logs under `onyx.audit`. Provides fail-safe emission and optional Redis-backed dedup, forming the core for upcoming auth/admin/access-control instrumentation.

- New Features
  - `emit_audit_event(...)` in `backend/onyx/utils/audit.py`: never raises; emits one JSON line with an OCSF-shaped schema (audit_schema_version, ts, action, ocsf_class, outcome, actor, resource_type/id, tenant_id, request_id, endpoint, source_ip, extra).
  - `AuditAction` taxonomy with an import-time guard mapping every action to an OCSF class.
  - Per-class logger routing: `onyx.audit.authentication`, `onyx.audit.account_change`, `onyx.audit.api_activity`.
  - Optional Redis-backed dedup via `dedup_key`; degrades to always-emit if Redis is unavailable.
  - `docs/AUDIT_LOGGING.md` (schema + export examples) and unit tests covering schema stability, per-class routing, secret-safety, no-raise on missing context, and dedup (including Redis-down degradation).

<sup>Written for commit a7bbb89dce72877ea4cb182aa32c4f45d3a3a6ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

