### PR TITLE
fix(file-processing): fall back to pypdf when PDFium text extraction fails

### DIFF
--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -307,6 +307,7 @@ def read_pdf_file(
     """
     from pypdf import PdfReader
     from pypdf.errors import PdfStreamError
+    from pypdfium2 import PdfiumError
 
     metadata: dict[str, Any] = {}
     extracted_images: list[tuple[bytes, str]] = []
@@ -352,7 +353,7 @@ def read_pdf_file(
         # GIL-releasing extraction so a large PDF can't pin the worker — see helper.
         try:
             text = _extract_pdf_text_pdfium(file_bytes, decrypt_password)
-        except Exception as pdfium_err:
+        except PdfiumError as pdfium_err:
             # PDFium rejects some malformed PDFs that pypdf can still read; fall
             # back so those docs aren't dropped. Only failing files take this path.
             logger.warning(

--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -350,7 +350,18 @@ def read_pdf_file(
                     metadata[clean_key] = ", ".join(value)
 
         # GIL-releasing extraction so a large PDF can't pin the worker — see helper.
-        text = _extract_pdf_text_pdfium(file_bytes, decrypt_password)
+        try:
+            text = _extract_pdf_text_pdfium(file_bytes, decrypt_password)
+        except Exception as pdfium_err:
+            # PDFium rejects some malformed PDFs that pypdf can still read; fall
+            # back so those docs aren't dropped. Only failing files take this path.
+            logger.warning(
+                "PDFium text extraction failed (%s); falling back to pypdf",
+                pdfium_err,
+            )
+            text = TEXT_SECTION_SEPARATOR.join(
+                page.extract_text() for page in pdf_reader.pages
+            )
 
         if extract_images:
             image_cap = MAX_EMBEDDED_IMAGES_PER_FILE

--- a/backend/tests/unit/onyx/file_processing/test_pdf.py
+++ b/backend/tests/unit/onyx/file_processing/test_pdf.py
@@ -56,8 +56,10 @@ class TestReadPdfFile:
         When PDFium raises, text extraction falls back to pypdf so the document
         is still indexed rather than silently dropped."""
 
+        from pypdfium2 import PdfiumError
+
         def _raise(*_args: object, **_kwargs: object) -> str:
-            raise RuntimeError("Failed to load document (PDFium: Data format error).")
+            raise PdfiumError("Failed to load document (PDFium: Data format error).")
 
         monkeypatch.setattr(extract_file_text, "_extract_pdf_text_pdfium", _raise)
         text, _, _ = read_pdf_file(_load("multipage.pdf"))

--- a/backend/tests/unit/onyx/file_processing/test_pdf.py
+++ b/backend/tests/unit/onyx/file_processing/test_pdf.py
@@ -49,6 +49,21 @@ class TestReadPdfFile:
         assert "Page one content" in text
         assert "Page two content" in text
 
+    def test_falls_back_to_pypdf_when_pdfium_fails(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """PDFium is stricter than pypdf and rejects some PDFs pypdf can read.
+        When PDFium raises, text extraction falls back to pypdf so the document
+        is still indexed rather than silently dropped."""
+
+        def _raise(*_args: object, **_kwargs: object) -> str:
+            raise RuntimeError("Failed to load document (PDFium: Data format error).")
+
+        monkeypatch.setattr(extract_file_text, "_extract_pdf_text_pdfium", _raise)
+        text, _, _ = read_pdf_file(_load("multipage.pdf"))
+        assert "Page one content" in text
+        assert "Page two content" in text
+
     def test_metadata_extraction(self) -> None:
         _, pdf_metadata, _ = read_pdf_file(_load("with_metadata.pdf"))
         assert pdf_metadata.get("Title") == "My Title"


### PR DESCRIPTION
## Description

**Bug:** Since the switch to pypdfium2 (#12102), PDFs that pypdf can read but PDFium rejects (`FPDF_ERR_FORMAT`, "Data format error") get indexed with **no text** — their content is silently dropped.

**Why:** PDFium is stricter than pypdf. On a Google Drive connector, 100+ files per indexing window logged "PDFium: Data format error" while pypdf accepted the same files (0 pypdf-level rejections), so their text never reached the index.

**Fix:** When PDFium raises, fall back to pypdf's `extract_text()`. PDFium stays the primary path (keeps the GIL-release / heartbeat protection from #12102); only PDFium-rejected files take the slower pypdf path.

**Test:** unit test asserting the fallback extracts text when PDFium raises.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check