### PR TITLE
chore(install): Rename Vespa to OpenSearch

### DIFF
--- a/deployment/docker_compose/install.ps1
+++ b/deployment/docker_compose/install.ps1
@@ -94,7 +94,7 @@ function Prompt-DeploymentMode {
     param([string]$LiteOverlayPath)
     if ($script:LiteMode) { Print-Info "Deployment mode: Lite (set via -Lite flag)"; return }
     Print-Info "Which deployment mode would you like?"
-    Write-Host "  1) Lite      - Minimal deployment (no Vespa, Redis, or model servers)"
+    Write-Host "  1) Lite      - Minimal deployment (no OpenSearch, Redis, or model servers)"
     Write-Host "                  LLM chat, tools, file uploads, and Projects still work"
     Write-Host "  2) Standard  - Full deployment with search, connectors, and RAG"
     $modeChoice = Prompt-OrDefault "Choose a mode (1 or 2) [default: 1]" "1"

--- a/deployment/docker_compose/install.sh
+++ b/deployment/docker_compose/install.sh
@@ -892,7 +892,7 @@ fi
 if [[ "$LITE_MODE" = false ]]; then
     print_info "Which deployment mode would you like?"
     echo ""
-    echo "  1) Lite      - Minimal deployment (no Vespa, Redis, or model servers)"
+    echo "  1) Lite      - Minimal deployment (no OpenSearch, Redis, or model servers)"
     echo "                  LLM chat, tools, file uploads, and Projects still work"
     echo "  2) Standard  - Full deployment with search, connectors, and RAG"
     echo ""


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed "Vespa" to "OpenSearch" in Lite mode prompts to match the current search backend. Text-only change in `deployment/docker_compose/install.sh` and `install.ps1`; no functional impact.

<sup>Written for commit 7d7b384f309f535fe0ddd5a21af5388cccf3f539. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

