### PR TITLE
fix(connectors/imap): resilient indexing and email update time

### DIFF
--- a/backend/onyx/connectors/imap/connector.py
+++ b/backend/onyx/connectors/imap/connector.py
@@ -193,13 +193,24 @@ class ImapConnector(
                 )
                 continue
 
-            email_headers = EmailHeaders.from_email_msg(email_msg=email_msg)
+            # A single malformed or unparseable email (bad headers, missing
+            # required fields, etc.) shouldn't abort indexing for the rest of
+            # the mailbox; log it and move on to the next email instead.
+            try:
+                email_headers = EmailHeaders.from_email_msg(email_msg=email_msg)
+                document = _convert_email_headers_and_body_into_document(
+                    email_msg=email_msg,
+                    email_headers=email_headers,
+                    include_perm_sync=include_perm_sync,
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to parse email into a document; skipping email_id=%r",
+                    email_id,
+                )
+                continue
 
-            yield _convert_email_headers_and_body_into_document(
-                email_msg=email_msg,
-                email_headers=email_headers,
-                include_perm_sync=include_perm_sync,
-            )
+            yield document
 
         return checkpoint
 

--- a/backend/onyx/connectors/imap/connector.py
+++ b/backend/onyx/connectors/imap/connector.py
@@ -388,6 +388,7 @@ def _convert_email_headers_and_body_into_document(
         sections=[TextSection(text=email_body)],
         primary_owners=primary_owners,
         external_access=external_access,
+        doc_updated_at=email_headers.date,
     )
 
 

--- a/backend/onyx/connectors/imap/connector.py
+++ b/backend/onyx/connectors/imap/connector.py
@@ -6,7 +6,7 @@ import re
 from datetime import datetime
 from datetime import timezone
 from email.message import Message
-from email.utils import parseaddr
+from email.utils import getaddresses
 from enum import Enum
 from typing import Any
 from typing import cast
@@ -429,9 +429,12 @@ def _sanitize_mailbox_names(mailboxes: list[str]) -> list[str]:
 
 
 def _parse_addrs(raw_header: str) -> list[tuple[str, str]]:
-    addrs = raw_header.split(",")
-    name_addr_pairs = [parseaddr(addr=addr) for addr in addrs if addr]
-    return [(name, addr) for name, addr in name_addr_pairs if addr]
+    if not raw_header:
+        return []
+    # `getaddresses` parses per RFC 5322 and correctly handles commas inside
+    # quoted display names (e.g. `"Halvantzis, Savvas" <s@example.com>`), which a
+    # naive `raw_header.split(",")` would break into two malformed addresses.
+    return [(name, addr) for name, addr in getaddresses([raw_header]) if addr]
 
 
 def _parse_singular_addr(raw_header: str) -> tuple[str, str]:
@@ -440,9 +443,15 @@ def _parse_singular_addr(raw_header: str) -> tuple[str, str]:
         raise RuntimeError(
             f"Parsing email header resulted in no addresses being found; {raw_header=}"
         )
-    elif len(addrs) >= 2:
-        raise RuntimeError(
-            f"Expected a singular address, but instead got multiple; {raw_header=} {addrs=}"
+    if len(addrs) >= 2:
+        # A singular field (e.g. Sender/From) occasionally carries multiple
+        # addresses. Don't abort the whole indexing run over it; log a warning
+        # and use the first parsed address instead.
+        logger.warning(
+            "Expected a singular address but got multiple; using the first. "
+            "raw_header=%r addrs=%r",
+            raw_header,
+            addrs,
         )
 
     return addrs[0]

--- a/backend/onyx/connectors/imap/models.py
+++ b/backend/onyx/connectors/imap/models.py
@@ -39,7 +39,14 @@ class EmailHeaders(BaseModel):
             decoded_value, encoding = email.header.decode_header(value)[0]
             if isinstance(decoded_value, bytes):
                 encoding = encoding or "utf-8"
-                return decoded_value.decode(encoding, errors="replace")
+                try:
+                    return decoded_value.decode(encoding, errors="replace")
+                except LookupError:
+                    # Some senders emit non-standard charset labels (e.g. the
+                    # RFC 1428 placeholder `unknown-8bit`) that Python's codec
+                    # registry doesn't recognize. Fall back to latin-1, which
+                    # maps every byte 0-255 to a code point and never raises.
+                    return decoded_value.decode("latin-1", errors="replace")
             elif isinstance(decoded_value, str):
                 return decoded_value
             else:

--- a/backend/onyx/connectors/imap/models.py
+++ b/backend/onyx/connectors/imap/models.py
@@ -6,6 +6,8 @@ from enum import Enum
 
 from pydantic import BaseModel
 
+from onyx.utils.datetime import datetime_to_utc
+
 
 class Header(str, Enum):
     SUBJECT_HEADER = "subject"
@@ -27,7 +29,8 @@ class EmailHeaders(BaseModel):
     subject: str
     sender: str
     recipients: str | None
-    date: datetime
+    # `None` when the email has no (or an unparseable) `Date` header.
+    date: datetime | None
 
     @classmethod
     def from_email_msg(cls, email_msg: Message) -> "EmailHeaders":
@@ -56,9 +59,13 @@ class EmailHeaders(BaseModel):
             if not date_str:
                 return None
             try:
-                return email.utils.parsedate_to_datetime(date_str)
+                parsed = email.utils.parsedate_to_datetime(date_str)
             except (TypeError, ValueError):
                 return None
+            # `Document.doc_updated_at` must be tz-aware UTC; `parsedate_to_datetime`
+            # returns the sender's own offset (or a naive datetime for `-0000`),
+            # so normalize with the repo's canonical UTC helper.
+            return datetime_to_utc(parsed)
 
         message_id = _decode(header=Header.MESSAGE_ID_HEADER)
         # It's possible for the subject line to not exist or be an empty string.

--- a/backend/tests/unit/onyx/connectors/imap/test_connector.py
+++ b/backend/tests/unit/onyx/connectors/imap/test_connector.py
@@ -1,0 +1,68 @@
+"""Unit tests for the IMAP connector's address, charset, and date handling.
+
+Regression coverage for:
+- https://github.com/onyx-dot-app/onyx/issues/7620: a display name containing a
+  comma (e.g. `"Halvantzis, Savvas"`) used to be split on the comma, producing
+  multiple bogus addresses and crashing the whole indexing run with a
+  RuntimeError.
+"""
+
+import pytest
+
+from onyx.connectors.imap.connector import _parse_addrs
+from onyx.connectors.imap.connector import _parse_singular_addr
+
+# _parse_addrs / _parse_singular_addr (comma-in-quoted-name handling)
+
+
+def test_parse_addrs_plain():
+    assert _parse_addrs("john@example.com") == [("", "john@example.com")]
+
+
+def test_parse_addrs_with_display_name():
+    assert _parse_addrs("John Doe <john@example.com>") == [
+        ("John Doe", "john@example.com")
+    ]
+
+
+def test_parse_addrs_empty_returns_empty_list():
+    assert _parse_addrs("") == []
+
+
+def test_parse_addrs_multiple_recipients():
+    header = "John Doe <john@example.com>, jane@example.com"
+    assert _parse_addrs(header) == [
+        ("John Doe", "john@example.com"),
+        ("", "jane@example.com"),
+    ]
+
+
+def test_parse_addrs_comma_in_quoted_display_name():
+    # The bug: a comma inside a quoted display name must NOT split the address.
+    header = '"Halvantzis, Savvas" <savvas@example.com>'
+    assert _parse_addrs(header) == [("Halvantzis, Savvas", "savvas@example.com")]
+
+
+def test_parse_addrs_multiple_with_commas_in_names():
+    header = '"Halvantzis, Savvas" <savvas@example.com>, "Doe, John" <john@example.com>'
+    assert _parse_addrs(header) == [
+        ("Halvantzis, Savvas", "savvas@example.com"),
+        ("Doe, John", "john@example.com"),
+    ]
+
+
+def test_parse_singular_addr_comma_in_quoted_name_does_not_raise():
+    # Previously raised RuntimeError("Expected a singular address, but ...")
+    # and aborted indexing for the whole mailbox.
+    header = '"Halvantzis, Savvas" <savvas@example.com>'
+    assert _parse_singular_addr(header) == ("Halvantzis, Savvas", "savvas@example.com")
+
+
+def test_parse_singular_addr_multiple_returns_first_without_raising():
+    header = "first@example.com, second@example.com"
+    assert _parse_singular_addr(header) == ("", "first@example.com")
+
+
+def test_parse_singular_addr_empty_raises():
+    with pytest.raises(RuntimeError):
+        _parse_singular_addr("")

--- a/backend/tests/unit/onyx/connectors/imap/test_connector.py
+++ b/backend/tests/unit/onyx/connectors/imap/test_connector.py
@@ -9,15 +9,20 @@ Regression coverage for:
   `_load_from_checkpoint` and abort indexing for the rest of the mailbox.
 - An unrecognized header charset label (e.g. the RFC 1428 `unknown-8bit`
   placeholder) used to raise `LookupError` out of header decoding.
+- `doc_updated_at` was never populated on the resulting `Document`, and the
+  parsed `Date` header was never normalized to UTC.
 """
 
 import email
+from datetime import datetime
+from datetime import timezone
 from email.message import Message
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pytest
 
+from onyx.connectors.imap.connector import _convert_email_headers_and_body_into_document
 from onyx.connectors.imap.connector import _parse_addrs
 from onyx.connectors.imap.connector import _parse_singular_addr
 from onyx.connectors.imap.connector import ImapConnector
@@ -160,3 +165,58 @@ def test_from_email_msg_unknown_8bit_charset_does_not_crash():
     msg = _make_email_msg({"Subject": "=?unknown-8bit?B?SGVsbG8=?="})
     headers = EmailHeaders.from_email_msg(email_msg=msg)
     assert headers.subject == "Hello"
+
+
+# EmailHeaders.from_email_msg: date parsing + UTC normalization
+
+
+def test_from_email_msg_date_with_positive_offset_normalized_to_utc():
+    msg = _make_email_msg({"Date": "Mon, 01 Jan 2024 10:00:00 +0100"})
+    headers = EmailHeaders.from_email_msg(email_msg=msg)
+    assert headers.date == datetime(2024, 1, 1, 9, 0, 0, tzinfo=timezone.utc)
+    assert headers.date is not None
+    assert headers.date.tzinfo == timezone.utc
+
+
+def test_from_email_msg_date_with_naive_offset_treated_as_utc():
+    # A `-0000` offset means "no timezone information" per RFC 5322 and
+    # `parsedate_to_datetime` returns a naive `datetime` for it; it must still
+    # be normalized to UTC rather than staying naive.
+    msg = _make_email_msg({"Date": "Mon, 01 Jan 2024 10:00:00 -0000"})
+    headers = EmailHeaders.from_email_msg(email_msg=msg)
+    assert headers.date == datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+    assert headers.date is not None
+    assert headers.date.tzinfo == timezone.utc
+
+
+def test_from_email_msg_missing_date_header_is_none():
+    msg = _make_email_msg(omit={"Date"})
+    headers = EmailHeaders.from_email_msg(email_msg=msg)
+    assert headers.date is None
+
+
+# _convert_email_headers_and_body_into_document: doc_updated_at wiring
+
+
+def test_convert_email_headers_and_body_into_document_sets_doc_updated_at_utc():
+    msg = _make_email_msg({"Date": "Mon, 01 Jan 2024 10:00:00 +0100"})
+    headers = EmailHeaders.from_email_msg(email_msg=msg)
+
+    document = _convert_email_headers_and_body_into_document(
+        email_msg=msg, email_headers=headers, include_perm_sync=False
+    )
+
+    assert document.doc_updated_at == datetime(2024, 1, 1, 9, 0, 0, tzinfo=timezone.utc)
+    assert document.doc_updated_at is not None
+    assert document.doc_updated_at.tzinfo == timezone.utc
+
+
+def test_convert_email_headers_and_body_into_document_missing_date_is_none():
+    msg = _make_email_msg(omit={"Date"})
+    headers = EmailHeaders.from_email_msg(email_msg=msg)
+
+    document = _convert_email_headers_and_body_into_document(
+        email_msg=msg, email_headers=headers, include_perm_sync=False
+    )
+
+    assert document.doc_updated_at is None

--- a/backend/tests/unit/onyx/connectors/imap/test_connector.py
+++ b/backend/tests/unit/onyx/connectors/imap/test_connector.py
@@ -5,12 +5,49 @@ Regression coverage for:
   comma (e.g. `"Halvantzis, Savvas"`) used to be split on the comma, producing
   multiple bogus addresses and crashing the whole indexing run with a
   RuntimeError.
+- A single malformed email (unparseable headers, etc.) used to raise out of
+  `_load_from_checkpoint` and abort indexing for the rest of the mailbox.
 """
+
+import email
+from email.message import Message
+from unittest.mock import MagicMock
+from unittest.mock import patch
 
 import pytest
 
 from onyx.connectors.imap.connector import _parse_addrs
 from onyx.connectors.imap.connector import _parse_singular_addr
+from onyx.connectors.imap.connector import ImapConnector
+from onyx.connectors.models import Document
+from tests.unit.onyx.connectors.utils import (
+    load_everything_from_checkpoint_connector_from_checkpoint,
+)
+
+_DEFAULT_HEADERS = {
+    "Subject": "Test Subject",
+    "From": "sender@example.com",
+    "To": "recipient@example.com",
+    "Message-ID": "<default-id@example.com>",
+    "Date": "Mon, 01 Jan 2024 10:00:00 +0000",
+}
+
+
+def _make_email_msg(
+    overrides: dict[str, str] | None = None,
+    omit: set[str] | None = None,
+    body: str = "Hello world",
+) -> Message:
+    """Build a real `email.message.Message` from default + overridden headers."""
+    headers = dict(_DEFAULT_HEADERS)
+    headers.update(overrides or {})
+    for key in omit or set():
+        headers.pop(key, None)
+
+    raw = "".join(f"{name}: {value}\r\n" for name, value in headers.items())
+    raw += f"\r\n{body}\r\n"
+    return email.message_from_string(raw)
+
 
 # _parse_addrs / _parse_singular_addr (comma-in-quoted-name handling)
 
@@ -66,3 +103,45 @@ def test_parse_singular_addr_multiple_returns_first_without_raising():
 def test_parse_singular_addr_empty_raises():
     with pytest.raises(RuntimeError):
         _parse_singular_addr("")
+
+
+# _load_from_checkpoint: one malformed email must not abort the whole mailbox
+
+
+def test_load_from_checkpoint_skips_email_that_fails_to_parse():
+    connector = ImapConnector(host="imap.example.com", mailboxes=["INBOX"])
+
+    # Missing "From" fails `EmailHeaders` pydantic validation (sender is
+    # required), which is exactly the kind of per-email failure Fix 2 guards.
+    bad_msg = _make_email_msg(omit={"From"})
+    good_msg = _make_email_msg({"Message-ID": "<good@example.com>"})
+
+    with (
+        patch.object(ImapConnector, "_get_mail_client", return_value=MagicMock()),
+        patch("onyx.connectors.imap.connector._select_mailbox"),
+        patch(
+            "onyx.connectors.imap.connector._fetch_email_ids_in_mailbox",
+            return_value=["1", "2"],
+        ),
+        patch(
+            "onyx.connectors.imap.connector._fetch_email",
+            side_effect=[bad_msg, good_msg],
+        ),
+    ):
+        checkpoint = connector.build_dummy_checkpoint()
+        outputs = load_everything_from_checkpoint_connector_from_checkpoint(
+            connector=connector, start=0, end=1_000, checkpoint=checkpoint
+        )
+
+    documents = [
+        item
+        for output in outputs
+        for item in output.items
+        if isinstance(item, Document)
+    ]
+
+    # The bad email is skipped (logged, not raised); the good one still comes
+    # through, and the checkpoint still runs to completion.
+    assert len(documents) == 1
+    assert documents[0].id == "<good@example.com>"
+    assert outputs[-1].next_checkpoint.has_more is False

--- a/backend/tests/unit/onyx/connectors/imap/test_connector.py
+++ b/backend/tests/unit/onyx/connectors/imap/test_connector.py
@@ -7,6 +7,8 @@ Regression coverage for:
   RuntimeError.
 - A single malformed email (unparseable headers, etc.) used to raise out of
   `_load_from_checkpoint` and abort indexing for the rest of the mailbox.
+- An unrecognized header charset label (e.g. the RFC 1428 `unknown-8bit`
+  placeholder) used to raise `LookupError` out of header decoding.
 """
 
 import email
@@ -19,6 +21,7 @@ import pytest
 from onyx.connectors.imap.connector import _parse_addrs
 from onyx.connectors.imap.connector import _parse_singular_addr
 from onyx.connectors.imap.connector import ImapConnector
+from onyx.connectors.imap.models import EmailHeaders
 from onyx.connectors.models import Document
 from tests.unit.onyx.connectors.utils import (
     load_everything_from_checkpoint_connector_from_checkpoint,
@@ -145,3 +148,15 @@ def test_load_from_checkpoint_skips_email_that_fails_to_parse():
     assert len(documents) == 1
     assert documents[0].id == "<good@example.com>"
     assert outputs[-1].next_checkpoint.has_more is False
+
+
+# EmailHeaders.from_email_msg: charset decoding (models._decode)
+
+
+def test_from_email_msg_unknown_8bit_charset_does_not_crash():
+    # "=?unknown-8bit?B?SGVsbG8=?=" is the RFC 2047 encoded form of "Hello"
+    # tagged with the non-standard `unknown-8bit` charset label, which is not
+    # a registered Python codec and used to raise LookupError.
+    msg = _make_email_msg({"Subject": "=?unknown-8bit?B?SGVsbG8=?="})
+    headers = EmailHeaders.from_email_msg(email_msg=msg)
+    assert headers.subject == "Hello"


### PR DESCRIPTION
## Description

Makes IMAP mailbox indexing resilient to real-world "dirty" emails, and starts tracking each email's update time. Four self-contained commits:

1. **Handle commas in quoted display names** (fixes #7620) — `_parse_addrs` split address headers on `,`, so a quoted display name like `"Halvantzis, Savvas" <s@example.com>` became two bogus addresses and `_parse_singular_addr` raised `RuntimeError`, aborting indexing for the **entire mailbox** — a single such email blocked all the others. Now parses with `email.utils.getaddresses` (RFC 5322-aware); a singular field carrying multiple addresses logs a warning and uses the first instead of raising.

2. **Don't abort the whole mailbox on one bad email** — building a `Document` from a single malformed message is now wrapped in `try/except`: the offending email is logged and skipped, and the rest of the mailbox still indexes.

3. **Tolerate unknown header charsets** — non-standard charset labels (e.g. the RFC 1428 `unknown-8bit` placeholder) made `_decode` raise `LookupError`. Falls back to `latin-1`, which maps every byte and never raises.

4. **Set `doc_updated_at` from the email `Date` header** — the IMAP connector never populated `doc_updated_at` (unlike, e.g., Gmail), so indexed emails had no update time. It now does, normalized with the repo's `datetime_to_utc` helper. This is required because the Vespa indexer rejects a non-UTC `doc_updated_at`, and `parsedate_to_datetime` returns the sender's own offset (or a naive datetime for `-0000`).

## How Has This Been Tested?

Added `backend/tests/unit/onyx/connectors/imap/test_connector.py` (16 unit tests, no live server needed) covering: plain/display-name parsing, a comma in a quoted display name, multiple recipients with commas, multiple addresses in a singular field → first (no raise), an empty header still raising, one malformed email being skipped without aborting the mailbox, an `unknown-8bit` charset header, a `Date` with a numeric offset and with `-0000` both normalized to UTC, a missing `Date` header → `None`, and `doc_updated_at` set as tz-aware UTC on the resulting `Document`.

```
uv run pytest backend/tests/unit/onyx/connectors/imap/test_connector.py
```

All 16 pass. `ruff check` and `ruff format --check` are clean, and there are no new `ty` diagnostics versus `main`.
