### PR TITLE
Include image filename in the multimodal text marker

### DIFF
--- a/backend/onyx/chat/llm_step.py
+++ b/backend/onyx/chat/llm_step.py
@@ -932,7 +932,7 @@ def translate_history_to_llm_format(
                         content_parts.append(
                             TextContentPart(
                                 type="text",
-                                text=f"[attached image — file_id: {img_file.file_id}]",
+                                text=f"[attached image — filename: {img_file.filename or 'unknown'}, file_id: {img_file.file_id}]",
                             )
                         )
                         image_part = ImageContentPart(


### PR DESCRIPTION
Uploaded images are sent to the model with a text marker that only carries the file_id (a UUID). When a user asks the model for the filename it echoes the UUID or says it can't tell, because the name isn't in the payload.

Text-file attachments already inject `File: {filename}` into the prompt (`chat_utils`), so this does the same for images: include the filename next to the existing file_id in the marker built by `translate_history_to_llm_format`. `filename` is already present on the `ChatLoadedFile`, so it's a one-line change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the image filename to the multimodal text marker sent to the model, alongside the file_id. This lets the model return a readable filename when asked, aligning behavior with text-file attachments and falling back to "unknown" if missing.

<sup>Written for commit 6b437102dcd825a57f6f7dc598b4168ce959c0eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

