### PR TITLE
fix(craft): add egress NetworkPolicy on the sandbox proxy (block IMDS/link-local)

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.6.5
+version: 0.6.6
 appVersion: latest
 annotations:
   category: Productivity
@@ -16,11 +16,10 @@ annotations:
     - name: background
       image: docker.io/onyxdotapp/onyx-backend:latest
   artifacthub.io/changes: |
-    - kind: added
-      description: Add the api.runStartupMigrations value (defaults on, including
-        on helm upgrade --reuse-values where the key is absent) to allow
-        disabling API-server startup migrations when a coordinated deployment
-        step runs them instead.
+    - kind: security
+      description: Add an egress NetworkPolicy on the Craft sandbox egress proxy that blocks the
+        link-local / cloud-metadata range (169.254.0.0/16), so a sandbox can't use the proxy as an
+        SSRF pivot to the node's IMDS credentials. Internet, DNS, and datastores remain reachable.
 dependencies:
   - name: cloudnative-pg
     version: 0.26.0

--- a/deployment/helm/charts/onyx/templates/sandbox-proxy/networkpolicy-egress.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-proxy/networkpolicy-egress.yaml
@@ -1,0 +1,45 @@
+{{- if eq (include "onyx.craftEnabled" .) "true" }}
+# Egress lockdown for the sandbox egress proxy.
+#
+# The proxy forwards arbitrary sandbox traffic to the internet (LLM providers, GitHub, package
+# registries, etc.), so its egress CANNOT be a fixed allow-list. What we DO block is the
+# link-local / cloud-metadata range so a sandbox can't use the proxy as an SSRF pivot to the
+# node's instance metadata service (IMDS) and steal the node IAM role credentials.
+#
+# Why not also block internal-cluster egress: on EKS with the VPC CNI, pods + RDS + ElastiCache +
+# OpenSearch all share the VPC private CIDR, so internal egress can't be CIDR-blocked without also
+# cutting off the proxy's own datastores. 169.254.0.0/16 (link-local) is outside the VPC range, so
+# it's the one block that's both safe and high-value. DNS, datastores, api-server, and the public
+# internet remain reachable via the 0.0.0.0/0 allow.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "onyx.fullname" . }}-sandbox-proxy-egress
+  labels:
+    {{- include "onyx.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sandbox-proxy
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "onyx.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: sandbox-proxy
+  policyTypes: [Egress]
+  # IPv4 and IPv6 are kept in SEPARATE egress rules on purpose. AWS VPC CNI fails the
+  # whole policy closed (drops ALL egress) when both an IPv4 and an IPv6 ipBlock share a
+  # single `to:` peer list; splitting them into distinct rules programs correctly.
+  # Verified on the craft-dev EKS cluster (VPC CNI enforcing).
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 169.254.0.0/16 # link-local incl. cloud metadata (IMDS) — SSRF block
+    # IPv6: once an Egress policy selects the pod, unmatched IPv6 is denied, so an
+    # IPv4-only allow would silently drop all IPv6 egress on dual-stack clusters.
+    - to:
+        - ipBlock:
+            cidr: ::/0
+            except:
+              - fe80::/10         # link-local
+              - fd00:ec2::254/128 # IPv6 cloud metadata (IMDS) — SSRF block
+{{- end }}


### PR DESCRIPTION
> 📚 **Stacked PR — Craft proxy egress lockdown (1 of 2 · base of the stack)**
>
> This is the **CNI-layer** control: an egress NetworkPolicy that stops the proxy *pod* from reaching the link-local / cloud-metadata range (IMDS). Stacked on top of it:
>
> - **#12242** — the **app-layer** companion: the proxy refuses to *relay* a sandbox to any internal destination (RDS / Redis / OpenSearch / IMDS), not just link-local.
>
> The two are complementary defense-in-depth against the same SSRF-pivot threat, at different layers and attacker positions: this PR protects against a compromised **proxy process** reaching IMDS; #12242 protects against a malicious **sandbox** using the proxy as an open relay. #12242 is also the control that is effective on prod **today**, since CNI NetworkPolicy enforcement is currently off on `managed_services` (this policy is enforced on the dev clusters).
>
> **Merge order:** this PR first, then #12242.

---

## Description

Hardens the Craft **sandbox egress proxy** (Helm clusters: st-dev / craft-dev) by adding an **egress** NetworkPolicy. The proxy holds every tenant's decryptable credentials and forwards sandbox traffic outbound; today it has no egress restriction, so a sandbox could use it as an **SSRF pivot to the node's instance metadata service (IMDS)** and exfiltrate the node IAM role credentials.

The policy allows all egress **except the link-local / cloud-metadata range (`169.254.0.0/16`)** — so DNS, datastores, the api-server, and the public internet stay reachable, but the IMDS pivot is blocked.

**Why not also block internal-cluster egress:** on EKS with the VPC CNI, pods + RDS + ElastiCache + OpenSearch all share the VPC private CIDR, so a CIDR-based internal block would also cut off the proxy's own datastores. Link-local is outside the VPC range, so it's the one block that's both safe and high-value.

- New template: `templates/sandbox-proxy/networkpolicy-egress.yaml` (gated on `craftEnabled`, selects the proxy).
- Bump chart `0.6.4` → `0.6.5` + `artifacthub.io/changes` entry.

(The equivalent egress NetworkPolicy for the multi-tenant `danswer/` Kustomize manifests is handled separately.)

## How Has This Been Tested?

The Craft validation guards pass under `helm template` with craft-enabled values; the policy is a minimal variant of the existing, merged `sandbox-proxy` ingress NetworkPolicy (same selector/gating, `policyTypes: [Egress]` + an `ipBlock` egress rule). Validated the same egress shape on a local k3d cluster earlier: NetworkPolicy enforcement is active and the proxy continues to function with its required egress (DNS/datastores/internet) intact.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an egress NetworkPolicy to the Craft sandbox egress proxy that allows all outbound traffic except cloud‑metadata/link‑local ranges (IPv4 169.254.0.0/16; IPv6 fe80::/10, fd00:ec2::254/128) to block SSRF to node IMDS while keeping DNS, datastores, the API server, and the internet reachable. Uses separate IPv4/IPv6 rules for AWS VPC CNI, is gated by `craftEnabled` for `sandbox-proxy` only, and bumps the `onyx` chart to `0.6.6` (artifacthub security note).

<sup>Written for commit 92915ba448b5b6670932d17cbde9f2dad695b7ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

