### PR TITLE
feat(cherry-pick): add --dispatch to run the cherry-pick workflow remotely

### DIFF
--- a/.github/workflows/post-merge-beta-cherry-pick.yml
+++ b/.github/workflows/post-merge-beta-cherry-pick.yml
@@ -4,6 +4,20 @@ on:
   pull_request:
     types:
       - closed
+  workflow_dispatch:
+    inputs:
+      merge_commit_sha:
+        description: "Commit SHA to cherry-pick to the latest release branch"
+        required: true
+        type: string
+      pr_number:
+        description: "Source PR number (optional; used for Slack notifications)"
+        required: false
+        type: string
+      release:
+        description: "Target release version, e.g. 2.5 (optional; blank auto-detects the latest release)"
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -11,14 +25,18 @@ permissions:
 jobs:
   resolve-cherry-pick-request:
     if: >-
-      github.event.pull_request.merged == true
-      && github.event.pull_request.base.ref == 'main'
-      && github.event.pull_request.head.repo.full_name == github.repository
+      github.event_name == 'workflow_dispatch'
+      || (
+        github.event.pull_request.merged == true
+        && github.event.pull_request.base.ref == 'main'
+        && github.event.pull_request.head.repo.full_name == github.repository
+      )
     outputs:
       should_cherrypick: ${{ steps.gate.outputs.should_cherrypick }}
       pr_number: ${{ steps.gate.outputs.pr_number }}
       merge_commit_sha: ${{ steps.gate.outputs.merge_commit_sha }}
       merged_by: ${{ steps.gate.outputs.merged_by }}
+      release: ${{ steps.gate.outputs.release }}
       gate_error: ${{ steps.gate.outputs.gate_error }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -26,13 +44,21 @@ jobs:
       - name: Resolve merged PR and checkbox state
         id: gate
         env:
+          EVENT_NAME: ${{ github.event_name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_BODY: ${{ github.event.pull_request.body }}
           MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
           MERGED_BY: ${{ github.event.pull_request.merged_by.login }}
+          # workflow_dispatch inputs (empty for the pull_request path). The
+          # dispatcher is github.actor, used as both assignee and allowlist key.
+          DISPATCH_MERGE_COMMIT_SHA: ${{ github.event.inputs.merge_commit_sha }}
+          DISPATCH_PR_NUMBER: ${{ github.event.inputs.pr_number }}
+          DISPATCH_RELEASE: ${{ github.event.inputs.release }}
+          DISPATCH_ACTOR: ${{ github.actor }}
           # Explicit merger allowlist kept as defense-in-depth even though the
           # cherry-pick job runs with a GitHub App installation token rather
-          # than the default GITHUB_TOKEN.
+          # than the default GITHUB_TOKEN. Also enforced for workflow_dispatch
+          # against the dispatching actor.
           ALLOWED_MERGERS: |
             acaprau
             bo-onyx
@@ -50,23 +76,39 @@ jobs:
             weves
             yuhongsun96
         run: |
-          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
-          echo "merged_by=${MERGED_BY}" >> "$GITHUB_OUTPUT"
+          release=""
+          # workflow_dispatch is an explicit request, so there is no PR body /
+          # checkbox to inspect. Source the gate inputs from the dispatch inputs
+          # and treat the dispatching actor as the merger.
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            PR_NUMBER="${DISPATCH_PR_NUMBER}"
+            MERGE_COMMIT_SHA="${DISPATCH_MERGE_COMMIT_SHA}"
+            MERGED_BY="${DISPATCH_ACTOR}"
+            release="${DISPATCH_RELEASE}"
+          fi
 
-          if ! echo "${PR_BODY}" | grep -qiE "\\[x\\][[:space:]]*(\\[[^]]+\\][[:space:]]*)?Please cherry-pick this PR to the latest release version"; then
-            echo "should_cherrypick=false" >> "$GITHUB_OUTPUT"
-            echo "Cherry-pick checkbox not checked for PR #${PR_NUMBER}. Skipping."
-            exit 0
+          {
+            echo "pr_number=${PR_NUMBER}"
+            echo "merged_by=${MERGED_BY}"
+            echo "release=${release}"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ "${EVENT_NAME}" != "workflow_dispatch" ]; then
+            if ! echo "${PR_BODY}" | grep -qiE "\\[x\\][[:space:]]*(\\[[^]]+\\][[:space:]]*)?Please cherry-pick this PR to the latest release version"; then
+              echo "should_cherrypick=false" >> "$GITHUB_OUTPUT"
+              echo "Cherry-pick checkbox not checked for PR #${PR_NUMBER}. Skipping."
+              exit 0
+            fi
           fi
 
           # Keep should_cherrypick output before any possible exit 1 below so
           # notify-slack can still gate on this output even if this job fails.
           echo "should_cherrypick=true" >> "$GITHUB_OUTPUT"
-          echo "Cherry-pick checkbox checked for PR #${PR_NUMBER}."
+          echo "Cherry-pick requested (event: ${EVENT_NAME}, PR #${PR_NUMBER})."
 
           if [ -z "${MERGE_COMMIT_SHA}" ] || [ "${MERGE_COMMIT_SHA}" = "null" ]; then
             echo "gate_error=missing-merge-commit-sha" >> "$GITHUB_OUTPUT"
-            echo "::error::PR #${PR_NUMBER} requested cherry-pick, but merge_commit_sha is missing."
+            echo "::error::Cherry-pick requested, but merge_commit_sha is missing."
             exit 1
           fi
 
@@ -134,10 +176,15 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           CHERRY_PICK_ASSIGNEE: ${{ needs.resolve-cherry-pick-request.outputs.merged_by }}
           MERGE_COMMIT_SHA: ${{ needs.resolve-cherry-pick-request.outputs.merge_commit_sha }}
+          RELEASE: ${{ needs.resolve-cherry-pick-request.outputs.release }}
         run: |
           output_file="$(mktemp)"
+          release_args=()
+          if [ -n "${RELEASE}" ]; then
+            release_args+=(--release "${RELEASE}")
+          fi
           set +e
-          uv run --no-sync --with onyx-devtools ods cherry-pick "${MERGE_COMMIT_SHA}" --yes --no-verify 2>&1 | tee "$output_file"
+          uv run --no-sync --with onyx-devtools ods cherry-pick "${MERGE_COMMIT_SHA}" "${release_args[@]}" --yes --no-verify 2>&1 | tee "$output_file"
           pipe_statuses=("${PIPESTATUS[@]}")
           exit_code="${pipe_statuses[0]}"
           tee_exit="${pipe_statuses[1]:-0}"
@@ -218,8 +265,11 @@ jobs:
           MERGE_COMMIT_SHA: ${{ needs.resolve-cherry-pick-request.outputs.merge_commit_sha }}
           CHERRY_PICK_PR_URL: ${{ needs.cherry-pick-to-latest-release.outputs.cherry_pick_pr_url }}
         run: |
-          source_pr_url="https://github.com/${GITHUB_REPOSITORY}/pull/${SOURCE_PR_NUMBER}"
-          details="*Cherry-pick PR opened successfully.*\\n• author: {mention}\\n• source PR: ${source_pr_url}"
+          details="*Cherry-pick PR opened successfully.*\\n• author: {mention}"
+          if [ -n "${SOURCE_PR_NUMBER}" ]; then
+            source_pr_url="https://github.com/${GITHUB_REPOSITORY}/pull/${SOURCE_PR_NUMBER}"
+            details="${details}\\n• source PR: ${source_pr_url}"
+          fi
           if [ -n "${CHERRY_PICK_PR_URL}" ]; then
             details="${details}\\n• cherry-pick PR: ${CHERRY_PICK_PR_URL}"
           fi
@@ -270,8 +320,6 @@ jobs:
           CHERRY_PICK_REASON: ${{ needs.cherry-pick-to-latest-release.outputs.cherry_pick_reason }}
           CHERRY_PICK_DETAILS: ${{ needs.cherry-pick-to-latest-release.outputs.cherry_pick_details }}
         run: |
-          source_pr_url="https://github.com/${GITHUB_REPOSITORY}/pull/${SOURCE_PR_NUMBER}"
-
           reason_text="cherry-pick command failed"
           if [ "${GATE_ERROR}" = "missing-merge-commit-sha" ]; then
             reason_text="requested cherry-pick but merge commit SHA was missing"
@@ -291,7 +339,12 @@ jobs:
           else
             failed_job_label="cherry-pick-to-latest-release"
           fi
-          details="• author: {mention}\\n• ${failed_job_label}\\n• source PR: ${source_pr_url}\\n• reason: ${reason_text}"
+          details="• author: {mention}\\n• ${failed_job_label}"
+          if [ -n "${SOURCE_PR_NUMBER}" ]; then
+            source_pr_url="https://github.com/${GITHUB_REPOSITORY}/pull/${SOURCE_PR_NUMBER}"
+            details="${details}\\n• source PR: ${source_pr_url}"
+          fi
+          details="${details}\\n• reason: ${reason_text}"
           if [ -n "${MERGE_COMMIT_SHA}" ]; then
             details="${details}\\n• merge SHA: ${MERGE_COMMIT_SHA}"
           fi

--- a/tools/ods/cmd/cherry-pick.go
+++ b/tools/ods/cmd/cherry-pick.go
@@ -21,12 +21,13 @@ const cherryPickPRLabel = "cherry-pick 🍒"
 
 // CherryPickOptions holds options for the cherry-pick command
 type CherryPickOptions struct {
-	Releases []string
+	Releases  []string
 	Assignees []string
-	DryRun   bool
-	Yes      bool
-	NoVerify bool
-	Continue bool
+	DryRun    bool
+	Yes       bool
+	NoVerify  bool
+	Continue  bool
+	Dispatch  bool
 }
 
 // NewCherryPickCommand creates a new cherry-pick command
@@ -56,13 +57,24 @@ The --release flag can be specified multiple times to cherry-pick to multiple re
 If a cherry-pick hits a merge conflict, resolve it manually, then run:
   $ ods cherry-pick --continue
 
+With --dispatch, the commit(s)/PR(s) are resolved locally and the
+post-merge-beta-cherry-pick GitHub workflow is triggered to perform the
+cherry-pick in CI instead of running locally. The workflow auto-detects the
+latest release unless --release is supplied. Requires the workflow (with its
+workflow_dispatch trigger) to already be on the default branch.
+
 Example usage:
 
 	$ ods cherry-pick foo123 bar456 --release 2.5 --release 2.6
 	$ ods cp foo123 --release 2.5
-	$ ods cp 1234 --release 2.5   # cherry-pick merge commit of PR #1234`,
+	$ ods cp 1234 --release 2.5   # cherry-pick merge commit of PR #1234
+	$ ods cp 1234 --dispatch      # trigger the cherry-pick workflow for PR #1234`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			cont, _ := cmd.Flags().GetBool("continue")
+			dispatch, _ := cmd.Flags().GetBool("dispatch")
+			if cont && dispatch {
+				return fmt.Errorf("--continue and --dispatch cannot be used together")
+			}
 			if cont {
 				if len(args) > 0 {
 					return fmt.Errorf("--continue does not accept positional arguments")
@@ -75,9 +87,12 @@ Example usage:
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			if opts.Continue {
+			switch {
+			case opts.Continue:
 				runCherryPickContinue()
-			} else {
+			case opts.Dispatch:
+				runCherryPickDispatch(args, opts)
+			default:
 				runCherryPick(cmd, args, opts)
 			}
 		},
@@ -89,6 +104,7 @@ Example usage:
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Perform all local operations but skip pushing to remote and creating PRs")
 	cmd.Flags().BoolVar(&opts.Yes, "yes", false, "Skip confirmation prompts and automatically proceed")
 	cmd.Flags().BoolVar(&opts.NoVerify, "no-verify", false, "Skip pre-commit and commit-msg hooks for cherry-pick and push")
+	cmd.Flags().BoolVar(&opts.Dispatch, "dispatch", false, "Resolve the commit(s) locally, then trigger the post-merge-beta-cherry-pick GitHub workflow instead of cherry-picking locally")
 
 	return cmd
 }
@@ -318,6 +334,51 @@ func runCherryPickContinue() {
 	// "branch exists → skip applied commits → push → create PR"
 	stashResult := &git.StashResult{Stashed: state.Stashed}
 	finishCherryPick(state, stashResult)
+}
+
+// runCherryPickDispatch resolves the given commit(s)/PR(s) locally, then triggers
+// the post-merge-beta-cherry-pick GitHub workflow for each — instead of performing
+// the cherry-pick on the local machine. The workflow auto-detects the latest
+// release unless --release is supplied.
+func runCherryPickDispatch(args []string, opts *CherryPickOptions) {
+	git.CheckGitHubCLI()
+
+	if len(opts.Releases) > 1 {
+		log.Fatal("--dispatch supports at most one --release")
+	}
+	release := ""
+	if len(opts.Releases) == 1 {
+		release = opts.Releases[0]
+	}
+
+	if opts.DryRun {
+		log.Warning("=== DRY RUN MODE: No workflow will be dispatched ===")
+	}
+
+	// Resolve any PR numbers (e.g. "1234") to their merge commit SHAs
+	commitSHAs, labels := resolveArgs(args)
+
+	for i, sha := range commitSHAs {
+		// Prefer the PR number we already have from the argument; otherwise
+		// resolve it from the commit (best-effort, only used for Slack notifications).
+		prNumber := ""
+		if isPRNumber(args[i]) {
+			prNumber = args[i]
+		} else if resolved, err := git.ResolveCommitToPR(sha); err != nil {
+			log.Debugf("Could not resolve PR for %s: %v", sha, err)
+		} else {
+			prNumber = resolved
+		}
+
+		log.Infof("Dispatching cherry-pick workflow for %s (%s)", labels[i], sha)
+		if err := git.DispatchCherryPickWorkflow(sha, prNumber, release, opts.DryRun); err != nil {
+			log.Fatalf("Failed to dispatch cherry-pick workflow for %s: %v", labels[i], err)
+		}
+	}
+
+	if !opts.DryRun {
+		log.Infof("Dispatched %d cherry-pick workflow run(s). Track them with: gh run list --workflow post-merge-beta-cherry-pick.yml", len(commitSHAs))
+	}
 }
 
 // cherryPickToRelease cherry-picks one or more commits to a specific release branch

--- a/tools/ods/internal/git/git.go
+++ b/tools/ods/internal/git/git.go
@@ -254,6 +254,60 @@ func ResolvePRToMergeCommit(prNumber string) (string, error) {
 	return sha, nil
 }
 
+// ResolveCommitToPR resolves a commit SHA to the number of the PR that
+// introduced it (best-effort; the GitHub API returns associated PRs for a
+// commit). Returns an error if no associated PR is found.
+func ResolveCommitToPR(commitSHA string) (string, error) {
+	cmd := exec.Command("gh", "api", fmt.Sprintf("repos/{owner}/{repo}/commits/%s/pulls", commitSHA), "--jq", ".[0].number")
+	output, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return "", fmt.Errorf("gh api commits/pulls failed: %w: %s", err, string(exitErr.Stderr))
+		}
+		return "", fmt.Errorf("gh api commits/pulls failed: %w", err)
+	}
+	prNumber := strings.TrimSpace(string(output))
+	if prNumber == "" || prNumber == "null" {
+		return "", fmt.Errorf("no associated PR found for commit %s", commitSHA)
+	}
+	return prNumber, nil
+}
+
+// cherryPickWorkflowFile is the workflow file name dispatched by --dispatch.
+const cherryPickWorkflowFile = "post-merge-beta-cherry-pick.yml"
+
+// DispatchCherryPickWorkflow triggers the post-merge beta cherry-pick workflow
+// via `gh workflow run`. mergeCommitSHA is required; prNumber and release are
+// optional (empty values are omitted). When dryRun is true the gh command is
+// logged but not executed.
+func DispatchCherryPickWorkflow(mergeCommitSHA, prNumber, release string, dryRun bool) error {
+	args := []string{
+		"workflow", "run", cherryPickWorkflowFile,
+		"-f", fmt.Sprintf("merge_commit_sha=%s", mergeCommitSHA),
+	}
+	if prNumber != "" {
+		args = append(args, "-f", fmt.Sprintf("pr_number=%s", prNumber))
+	}
+	if release != "" {
+		args = append(args, "-f", fmt.Sprintf("release=%s", release))
+	}
+
+	if dryRun {
+		log.Warnf("[DRY RUN] Would run: gh %s", strings.Join(args, " "))
+		return nil
+	}
+
+	cmd := exec.Command("gh", args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		if len(output) > 0 {
+			return fmt.Errorf("%w: %s", err, strings.TrimSpace(string(output)))
+		}
+		return err
+	}
+	return nil
+}
+
 // RunCherryPickContinue runs git cherry-pick --continue --no-edit
 func RunCherryPickContinue() error {
 	return RunCommandVerboseOnError("cherry-pick", "--continue", "--no-edit")


### PR DESCRIPTION
## What

Adds a `--dispatch` flag to `ods cherry-pick`. Instead of cherry-picking on the local machine, it resolves the commit(s)/PR(s) locally and triggers the **post-merge-beta-cherry-pick** GitHub workflow to perform the cherry-pick in CI.

```
ods cp 1234 --dispatch              # auto-detect latest release
ods cp 1234 --dispatch --release 2.5
ods cp <sha> --dispatch --dry-run   # print the gh command only
```

## Changes

**`tools/ods/cmd/cherry-pick.go`**
- New `--dispatch` flag; `Run` branches `continue` → `dispatch` → local.
- `runCherryPickDispatch` reuses `resolveArgs` to resolve each arg to a merge-commit SHA, derives a PR number (the arg itself when it's a PR; otherwise best-effort via the GitHub API), and dispatches one workflow run per arg.
- Honors `--release` (threaded to the workflow; capped at one for dispatch) and `--dry-run` (prints the `gh workflow run` command without executing).
- `--continue` and `--dispatch` are mutually exclusive; help text/examples updated.

**`tools/ods/internal/git/git.go`**
- `ResolveCommitToPR` — best-effort commit → PR number.
- `DispatchCherryPickWorkflow` — wraps `gh workflow run post-merge-beta-cherry-pick.yml -f merge_commit_sha=… [-f pr_number=…] [-f release=…]`, with dry-run support.

**`.github/workflows/post-merge-beta-cherry-pick.yml`**
- Added a `workflow_dispatch` trigger: `merge_commit_sha` (required), `pr_number` (optional), `release` (optional).
- `resolve-cherry-pick-request` now fires for `workflow_dispatch` too. On dispatch it skips the PR-body checkbox check, sources inputs from the dispatch payload, treats `github.actor` as the merger, and **still enforces the `ALLOWED_MERGERS` allowlist**.
- New `release` output threaded into the cherry-pick step (`--release` added only when non-blank; blank = auto-detect, unchanged).
- Slack success/failure summaries tolerate a missing `pr_number` (no broken source-PR link on dispatched runs).

## Notes

- `workflow_dispatch` triggers only become available once the workflow carrying the trigger is on the **default branch**. So `--dispatch` only works after this merges to `main`; running it from a feature branch returns gh's "workflow does not have 'workflow_dispatch' trigger" error until then.

## Testing

- `go build`, `go vet`, and `gofmt` clean.
- Existing `internal/git` and `cmd` package tests pass (git tests require commit signing disabled in this sandbox).
- Workflow YAML validated.

- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `--dispatch` to `ods cherry-pick` to resolve commits locally and run the cherry-pick in CI by triggering `post-merge-beta-cherry-pick.yml`. Supports `--release` and `--dry-run` for remote runs.

- **New Features**
  - `--dispatch` sends one CI workflow run per arg after resolving commits/PRs.
  - Forwards `--release` (max one); `--dry-run` prints the `gh workflow run` command.
  - `--continue` and `--dispatch` are mutually exclusive.
  - Best-effort commit → PR resolution for notifications.

- **Workflow**
  - Adds `workflow_dispatch` with inputs: `merge_commit_sha` (required), `pr_number`, `release`.
  - Dispatch path skips the PR checkbox, uses `github.actor`, and still enforces `ALLOWED_MERGERS`.
  - Threads `release` to the cherry-pick step; blank means auto-detect.
  - Slack summaries tolerate missing `pr_number`.
  - Note: dispatch works only after this workflow (with `workflow_dispatch`) is on the default branch.

<sup>Written for commit 42c5b7ca41549b85f566ffb70dc43084b3afb67e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

