### PR TITLE
fix(ci): namespace uv cache per arch + requirement set (no prune)

### DIFF
--- a/.github/actions/setup-python-and-install-dependencies/action.yml
+++ b/.github/actions/setup-python-and-install-dependencies/action.yml
@@ -19,22 +19,36 @@ runs:
       run: |
         # Hash the contents of the specified requirement files
         hash=""
+        files=()
         while IFS= read -r req; do
           if [ -n "$req" ] && [ -f "$req" ]; then
             hash="$hash$(sha256sum "$req")"
+            files+=("$req")
           fi
         done <<< "$REQUIREMENTS"
         echo "hash=$(echo "$hash" | sha256sum | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+        # set_id namespaces the cache by *which* requirement files are installed
+        # (sorted list of paths, not their contents) so e.g. a default+dev job
+        # never restores or re-saves a default+dev+model_server+ee cache through
+        # restore-keys.
+        set_id=$(printf '%s\n' "${files[@]}" | sort | sha256sum | cut -c1-12)
+        echo "set_id=$set_id" >> "$GITHUB_OUTPUT"
 
-    # NOTE: This comes before Setup uv since clean-ups run in reverse chronological order
-    # such that Setup uv's prune-cache is able to prune the cache before we upload.
+    # The key is scoped by arch + set_id so a job only warm-starts from a cache
+    # built for the same architecture and the same set of requirement files.
+    # Otherwise a small (e.g. default+dev) job restores and then re-saves a
+    # larger job's full cache, and an arm64 job could restore x86_64 wheels.
+    # We deliberately do NOT run `uv cache prune` here: uv installs by
+    # hardlinking from the unzipped wheels in ~/.cache/uv/archive-v0, and it
+    # does not retain the zipped wheels separately, so pruning archive-v0 guts
+    # the cache and forces a full re-download from PyPI on the next run.
     - name: Cache uv cache directory
       uses: runs-on/cache@a5f51d6f3fece787d03b7b4e981c82538a0654ed
       with:
         path: ~/.cache/uv
-        key: ${{ runner.os }}-uv-${{ steps.req-hash.outputs.hash }}
+        key: ${{ runner.os }}-${{ runner.arch }}-uv-${{ steps.req-hash.outputs.set_id }}-${{ steps.req-hash.outputs.hash }}
         restore-keys: |
-          ${{ runner.os }}-uv-
+          ${{ runner.os }}-${{ runner.arch }}-uv-${{ steps.req-hash.outputs.set_id }}-
 
     - name: Setup uv
       uses: astral-sh/setup-uv@ed21f2f24f8dd64503750218de024bcf64c7250a # ratchet:astral-sh/setup-uv@v7


### PR DESCRIPTION
## Problem

The uv cache (`~/.cache/uv`) cached via `runs-on/cache` in `setup-python-and-install-dependencies` was being restored at **~1.6GB** for jobs that only need a few hundred MB — e.g. the **database-tests** job, which installs only `default.txt + dev.txt` ([example run](https://github.com/onyx-dot-app/onyx/actions/runs/27843429346/job/82407377572)).

## Root cause

`restore-keys: ${{ runner.os }}-uv-` is a shared prefix. On a primary-key miss, a small job (default+dev) restores whatever `Linux-uv-*` cache was written most recently — almost always a **full-set** job (`default+dev+model_server+ee`, e.g. `pr-python-tests` / `pr-python-checks`) — then re-saves that bloat under its own key. `runner.os` is just `Linux`, so the prefix distinguishes neither requirement sets nor architectures.

## Fix

Scope the cache key by **architecture** and by **which requirement files** are installed:

```
key:          <os>-<arch>-uv-<set_id>-<content_hash>
restore-keys: <os>-<arch>-uv-<set_id>-
```

where `set_id` is a short hash of the *sorted list of requirement file paths* (order-independent). A job now only warm-starts from a cache built for the same arch and the same requirement set:
- `default+dev` → `set_id=17b2edb1b6db`
- `default+dev+ee+model_server` → `set_id=4ab0c1dd871d`

The `model_server` job's large but **pinned, ~100%-hit** nvidia/torch cache stays in its own namespace and never bleeds into light jobs — and an S3 restore of it beats re-downloading multi-GB from PyPI. Changing the key also guarantees a fresh write on the first run after merge (`runs-on/cache` only saves on a key miss).

## Why NOT prune (`uv cache prune --ci`)

An earlier revision of this PR added `uv cache prune --ci`. **That was a regression** — reverted. uv installs by hardlinking from the unzipped wheels in `~/.cache/uv/archive-v0`, and this uv version does **not** retain the zipped wheels separately, so `archive-v0` *is* the cache payload. Verified empirically:

- A clean `pandas` cache = 100MB `archive-v0`; `wheels-v*` holds only ~56KB of pointers.
- `uv cache prune --ci` removed 92.6MB (all of `archive-v0`), and an **offline reinstall then failed** — i.e. prune forces a full *re-download* from PyPI, not just a re-unzip.
- The default+dev cache this PR's prior CI run actually produced was **30MB** containing `archive-v0: 0 bytes`, `wheels: 0 bytes`, and 140MB of useless PyPI index metadata — **zero installable packages**.

So pruning would make every CI run re-download all deps from PyPI. Keeping `archive-v0` lets uv install by hardlink (fast) and keeps each (now-namespaced) cache at its natural size.

## Expected effect

- database-tests cache stops inheriting `model_server + ee` wheels → drops from ~1.6GB toward its natural few-hundred-MB.
- Installs stay fast (hardlink from `archive-v0`), no forced PyPI re-downloads.
- model_server's heavy cache is isolated in its own arch+set namespace.

## Notes

- `uv.lock` now exists at the repo root, so the line-57 `TODO: Enable caching once there is a uv.lock file checked in` is stale. Left as-is — switching to setup-uv's native cache would move the backend off the `runs-on` S3 bucket; worth a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)