### PR TITLE
chore: ee codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,3 +7,8 @@
 
 # Beta cherry-pick workflow owners
 /.github/workflows/post-merge-beta-cherry-pick.yml @justin-tahara @jmelahman
+
+# Enterprise Edition code owners
+/backend/ee/ @evan-onyx @Weves
+/web/src/ee/ @evan-onyx @Weves
+/web/src/app/ee/ @evan-onyx @Weves


### PR DESCRIPTION
## Description

adding me and chris to ee codeowners

## How Has This Been Tested?

n/a

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add CODEOWNERS entries for Enterprise Edition code so `@evan-onyx` and `@Weves` are automatically requested on changes to `/backend/ee/`, `/web/src/ee/`, and `/web/src/app/ee/`.

<sup>Written for commit 48fc2756e20e2100fbbcf724c99e9c7cb0dfc6c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

