### PR TITLE
fix(google-drive): bound advanced Doc parse to prevent indexing-worker OOM

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -893,9 +893,9 @@ GOOGLE_DRIVE_CONNECTOR_SIZE_THRESHOLD = int(
     os.environ.get("GOOGLE_DRIVE_CONNECTOR_SIZE_THRESHOLD", 10 * 1024 * 1024)
 )
 
-# Native Docs report no `size`, so the Docs-API structural-JSON fetch is the one
-# content fetch we can't size-check upfront. Cap the streamed response so a
-# structurally-huge Doc can't OOM the worker; over-cap Docs fall back to basic text.
+# Max bytes buffered for the Google Docs advanced (Docs-API structural-JSON)
+# fetch. Native Docs report no `size`, so the fetch can't be checked from
+# metadata; larger Docs are indexed via the basic text export.
 GOOGLE_DRIVE_ADVANCED_PARSE_MAX_BYTES = int(
     os.environ.get("GOOGLE_DRIVE_ADVANCED_PARSE_MAX_BYTES") or 50 * 1024 * 1024
 )

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -893,6 +893,16 @@ GOOGLE_DRIVE_CONNECTOR_SIZE_THRESHOLD = int(
     os.environ.get("GOOGLE_DRIVE_CONNECTOR_SIZE_THRESHOLD", 10 * 1024 * 1024)
 )
 
+# Cap the Google Docs advanced-parse (Docs-API structural JSON) response. Native
+# Docs report no `size`, so this is the one content fetch we can't size-check
+# upfront; bounding the streamed response keeps a structurally-huge Doc from
+# OOMing the worker. Docs over the cap fall back to the size-bounded basic text
+# export. Sized for json parse-expansion x conversion concurrency under the
+# per-worker memory limit.
+GOOGLE_DRIVE_ADVANCED_PARSE_MAX_BYTES = int(
+    os.environ.get("GOOGLE_DRIVE_ADVANCED_PARSE_MAX_BYTES") or 50 * 1024 * 1024
+)
+
 # Cap the total text retained per file across a connector's extracted sections,
 # bounding worker memory when a source can't be size-checked before fetch —
 # e.g. Google-native files (Docs/Slides/Sheets) report no `size` metadata and

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -893,12 +893,9 @@ GOOGLE_DRIVE_CONNECTOR_SIZE_THRESHOLD = int(
     os.environ.get("GOOGLE_DRIVE_CONNECTOR_SIZE_THRESHOLD", 10 * 1024 * 1024)
 )
 
-# Cap the Google Docs advanced-parse (Docs-API structural JSON) response. Native
-# Docs report no `size`, so this is the one content fetch we can't size-check
-# upfront; bounding the streamed response keeps a structurally-huge Doc from
-# OOMing the worker. Docs over the cap fall back to the size-bounded basic text
-# export. Sized for json parse-expansion x conversion concurrency under the
-# per-worker memory limit.
+# Native Docs report no `size`, so the Docs-API structural-JSON fetch is the one
+# content fetch we can't size-check upfront. Cap the streamed response so a
+# structurally-huge Doc can't OOM the worker; over-cap Docs fall back to basic text.
 GOOGLE_DRIVE_ADVANCED_PARSE_MAX_BYTES = int(
     os.environ.get("GOOGLE_DRIVE_ADVANCED_PARSE_MAX_BYTES") or 50 * 1024 * 1024
 )

--- a/backend/onyx/connectors/google_drive/doc_conversion.py
+++ b/backend/onyx/connectors/google_drive/doc_conversion.py
@@ -755,10 +755,8 @@ def _convert_drive_item_to_document(
         # If it's a Google Doc, we might do advanced parsing
         if file.get("mimeType") == GDriveMimeType.DOC.value:
             # Export via the size-capped basic path first. If it aborts at
-            # size_threshold the Doc is too large to feed to the advanced (Docs-API)
-            # parser, which loads the whole document with no cap and can OOM the
-            # worker — so skip it. A basic export that did NOT hit the cap means the
-            # Doc is small, so the advanced parsing below stays bounded.
+            # size_threshold the Doc is too large to index, so skip it. Otherwise the
+            # Doc is within the cap and the advanced parsing below is size-bounded.
             try:
                 basic_extraction = _basic_extraction(raise_on_size_threshold=True)
             except ExportSizeThresholdExceeded:

--- a/backend/onyx/connectors/google_drive/doc_conversion.py
+++ b/backend/onyx/connectors/google_drive/doc_conversion.py
@@ -11,6 +11,7 @@ from googleapiclient.http import MediaIoBaseDownload
 from pydantic import BaseModel
 
 from onyx.access.models import ExternalAccess
+from onyx.configs.app_configs import GOOGLE_DRIVE_ADVANCED_PARSE_MAX_BYTES
 from onyx.configs.constants import DocumentSource
 from onyx.configs.constants import FileOrigin
 from onyx.connectors.cross_connector_utils.section_utils import cap_sections_text
@@ -28,8 +29,6 @@ from onyx.connectors.google_drive.models import GoogleDriveFileType
 from onyx.connectors.google_drive.section_extraction import get_document_sections
 from onyx.connectors.google_drive.section_extraction import HEADING_DELIMITER
 from onyx.connectors.google_utils.resources import get_drive_service
-from onyx.connectors.google_utils.resources import get_google_docs_service
-from onyx.connectors.google_utils.resources import GoogleDocsService
 from onyx.connectors.google_utils.resources import GoogleDriveService
 from onyx.connectors.models import ConnectorFailure
 from onyx.connectors.models import Document
@@ -213,6 +212,9 @@ _FALLBACK_WEB_VIEW_LINK_TEMPLATES = {
 
 MAX_RETRIEVER_EMAILS = 20
 CHUNK_SIZE_BUFFER = 64  # extra bytes past the limit to read
+# Above this many advanced sections, skip align_basic_advanced (its heading
+# matching is ~O(headings x doc length)) and index the unaligned sections.
+ADVANCED_PARSE_MAX_SECTIONS = 2000
 
 # Mapping of Google Drive mime types to export formats
 GOOGLE_MIME_TYPES_TO_EXPORT = {
@@ -704,9 +706,6 @@ def _convert_drive_item_to_document(
     def _get_drive_service() -> GoogleDriveService:
         return get_drive_service(creds, user_email=retriever_email)
 
-    def _get_docs_service() -> GoogleDocsService:
-        return get_google_docs_service(creds, user_email=retriever_email)
-
     def _basic_extraction(
         raise_on_size_threshold: bool = False,
     ) -> FileExtractionResult:
@@ -777,11 +776,25 @@ def _convert_drive_item_to_document(
             try:
                 logger.debug("starting advanced parsing for %s", file.get("name"))
                 doc_sections = get_document_sections(
-                    docs_service=_get_docs_service(),
+                    creds=creds,
                     doc_id=file.get("id", ""),
+                    user_email=retriever_email,
+                    max_response_bytes=GOOGLE_DRIVE_ADVANCED_PARSE_MAX_BYTES,
                 )
-                if doc_sections:
-                    if any(SMART_CHIP_CHAR in section.text for section in doc_sections):
+                if doc_sections is None:
+                    logger.info(
+                        "Advanced parse of %s exceeds %s bytes; keeping basic text.",
+                        file.get("name"),
+                        GOOGLE_DRIVE_ADVANCED_PARSE_MAX_BYTES,
+                    )
+                elif doc_sections:
+                    has_smart_chips = any(
+                        SMART_CHIP_CHAR in section.text for section in doc_sections
+                    )
+                    if (
+                        has_smart_chips
+                        and len(doc_sections) <= ADVANCED_PARSE_MAX_SECTIONS
+                    ):
                         logger.debug(
                             "found smart chips in %s, aligning with basic sections",
                             file.get("name"),

--- a/backend/onyx/connectors/google_drive/doc_conversion.py
+++ b/backend/onyx/connectors/google_drive/doc_conversion.py
@@ -29,6 +29,7 @@ from onyx.connectors.google_drive.models import GoogleDriveFileType
 from onyx.connectors.google_drive.section_extraction import get_document_sections
 from onyx.connectors.google_drive.section_extraction import HEADING_DELIMITER
 from onyx.connectors.google_utils.resources import get_drive_service
+from onyx.connectors.google_utils.resources import get_google_authorized_session
 from onyx.connectors.google_utils.resources import GoogleDriveService
 from onyx.connectors.models import ConnectorFailure
 from onyx.connectors.models import Document
@@ -773,12 +774,14 @@ def _convert_drive_item_to_document(
             # the size cap). Falls back to the basic sections on any failure.
             try:
                 logger.debug("starting advanced parsing for %s", file.get("name"))
-                doc_sections = get_document_sections(
-                    creds=creds,
-                    doc_id=file.get("id", ""),
-                    user_email=retriever_email,
-                    max_response_bytes=GOOGLE_DRIVE_ADVANCED_PARSE_MAX_BYTES,
-                )
+                with get_google_authorized_session(
+                    creds, retriever_email
+                ) as authorized_session:
+                    doc_sections = get_document_sections(
+                        authorized_session=authorized_session,
+                        doc_id=file.get("id", ""),
+                        max_response_bytes=GOOGLE_DRIVE_ADVANCED_PARSE_MAX_BYTES,
+                    )
                 if doc_sections is None:
                     logger.info(
                         "Advanced parse of %s exceeds %s bytes; keeping basic text.",

--- a/backend/onyx/connectors/google_drive/section_extraction.py
+++ b/backend/onyx/connectors/google_drive/section_extraction.py
@@ -96,10 +96,9 @@ def get_document_sections(
 ) -> list[TextSection] | None:
     """Extract heading-aware sections from a Google Doc.
 
-    Streams the Docs-API response under a byte cap. Returns None when the
-    structural payload exceeds `max_response_bytes`, so the caller can fall back
-    to the size-bounded basic text export instead of loading a structurally
-    unbounded doc into memory. `includeTabsContent` pulls every tab's content.
+    Streams the Docs-API response and returns None once it exceeds
+    `max_response_bytes`, so the caller can fall back to the basic text export
+    rather than load an unbounded structural payload into memory.
     """
     impersonated_creds = get_impersonated_creds(creds, user_email)
     with AuthorizedSession(impersonated_creds) as session:
@@ -114,9 +113,9 @@ def get_document_sections(
             for chunk in response.iter_content(chunk_size=_DOCS_FETCH_CHUNK_SIZE):
                 if not chunk:
                     continue
-                buffer.extend(chunk)
-                if len(buffer) > max_response_bytes:
+                if len(buffer) + len(chunk) > max_response_bytes:
                     return None
+                buffer.extend(chunk)
 
     doc = json.loads(buffer)
     tabs = doc.get("tabs", {})

--- a/backend/onyx/connectors/google_drive/section_extraction.py
+++ b/backend/onyx/connectors/google_drive/section_extraction.py
@@ -2,11 +2,8 @@ import json
 from typing import Any
 
 from google.auth.transport.requests import AuthorizedSession
-from google.oauth2.credentials import Credentials as OAuthCredentials
-from google.oauth2.service_account import Credentials as ServiceAccountCredentials
 from pydantic import BaseModel
 
-from onyx.connectors.google_utils.resources import get_impersonated_creds
 from onyx.connectors.models import TextSection
 
 HEADING_DELIMITER = "\n"
@@ -89,31 +86,28 @@ _DOCS_FETCH_CHUNK_SIZE = 1024 * 1024
 
 
 def get_document_sections(
-    creds: ServiceAccountCredentials | OAuthCredentials,
+    authorized_session: AuthorizedSession,
     doc_id: str,
-    user_email: str,
     max_response_bytes: int,
 ) -> list[TextSection] | None:
     """Extract heading-aware sections from a Google Doc.
 
     Streams the Docs-API response; returns None if it exceeds `max_response_bytes`.
     """
-    impersonated_creds = get_impersonated_creds(creds, user_email)
-    with AuthorizedSession(impersonated_creds) as session:
-        with session.get(
-            DOCS_API_DOCUMENT_URL.format(doc_id=doc_id),
-            params={"includeTabsContent": "true"},
-            stream=True,
-            timeout=_DOCS_FETCH_TIMEOUT_SECONDS,
-        ) as response:
-            response.raise_for_status()
-            buffer = bytearray()
-            for chunk in response.iter_content(chunk_size=_DOCS_FETCH_CHUNK_SIZE):
-                if not chunk:
-                    continue
-                if len(buffer) + len(chunk) > max_response_bytes:
-                    return None
-                buffer.extend(chunk)
+    with authorized_session.get(
+        DOCS_API_DOCUMENT_URL.format(doc_id=doc_id),
+        params={"includeTabsContent": "true"},
+        stream=True,
+        timeout=_DOCS_FETCH_TIMEOUT_SECONDS,
+    ) as response:
+        response.raise_for_status()
+        buffer = bytearray()
+        for chunk in response.iter_content(chunk_size=_DOCS_FETCH_CHUNK_SIZE):
+            if not chunk:
+                continue
+            if len(buffer) + len(chunk) > max_response_bytes:
+                return None
+            buffer.extend(chunk)
 
     doc = json.loads(buffer)
     tabs = doc.get("tabs", {})

--- a/backend/onyx/connectors/google_drive/section_extraction.py
+++ b/backend/onyx/connectors/google_drive/section_extraction.py
@@ -1,8 +1,12 @@
+import json
 from typing import Any
 
+from google.auth.transport.requests import AuthorizedSession
+from google.oauth2.credentials import Credentials as OAuthCredentials
+from google.oauth2.service_account import Credentials as ServiceAccountCredentials
 from pydantic import BaseModel
 
-from onyx.connectors.google_utils.resources import GoogleDocsService
+from onyx.connectors.google_utils.resources import get_impersonated_creds
 from onyx.connectors.models import TextSection
 
 HEADING_DELIMITER = "\n"
@@ -79,27 +83,39 @@ def _extract_text_from_table(table: dict[str, Any]) -> str:
     return "\n".join(row_strs)
 
 
+DOCS_API_DOCUMENT_URL = "https://docs.googleapis.com/v1/documents/{doc_id}"
+_DOCS_FETCH_TIMEOUT_SECONDS = 60
+_DOCS_FETCH_CHUNK_SIZE = 1024 * 1024
+
+
 def get_document_sections(
-    docs_service: GoogleDocsService,
+    creds: ServiceAccountCredentials | OAuthCredentials,
     doc_id: str,
-) -> list[TextSection]:
-    """Extracts sections from a Google Doc, including their headings and content"""
-    # Fetch the document structure
-    http_request = docs_service.documents().get(  # ty: ignore[unresolved-attribute]
-        documentId=doc_id
-    )
+    user_email: str,
+    max_response_bytes: int,
+) -> list[TextSection] | None:
+    """Extract heading-aware sections from a Google Doc.
 
-    # Google has poor support for tabs in the docs api, see
-    # https://cloud.google.com/python/docs/reference/cloudtasks/
-    # latest/google.cloud.tasks_v2.types.HttpRequest
-    # https://developers.google.com/workspace/docs/api/how-tos/tabs
-    # https://developers.google.com/workspace/docs/api/reference/rest/v1/documents/get
-    # this is a hack to use the param mentioned in the rest api docs
-    # TODO: check if it can be specified i.e. in documents()
-    http_request.uri += "&includeTabsContent=true"
-    doc = http_request.execute()
+    Streams the Docs-API response under a byte cap. Returns None when the
+    structural payload exceeds `max_response_bytes`, so the caller can fall back
+    to the size-bounded basic text export instead of loading a structurally
+    unbounded doc into memory. `includeTabsContent` pulls every tab's content.
+    """
+    session = AuthorizedSession(get_impersonated_creds(creds, user_email))
+    with session.get(
+        DOCS_API_DOCUMENT_URL.format(doc_id=doc_id),
+        params={"includeTabsContent": "true"},
+        stream=True,
+        timeout=_DOCS_FETCH_TIMEOUT_SECONDS,
+    ) as response:
+        response.raise_for_status()
+        buffer = bytearray()
+        for chunk in response.iter_content(chunk_size=_DOCS_FETCH_CHUNK_SIZE):
+            buffer.extend(chunk)
+            if len(buffer) > max_response_bytes:
+                return None
 
-    # Get the content
+    doc = json.loads(buffer)
     tabs = doc.get("tabs", {})
     sections: list[TextSection] = []
     for tab in tabs:

--- a/backend/onyx/connectors/google_drive/section_extraction.py
+++ b/backend/onyx/connectors/google_drive/section_extraction.py
@@ -101,19 +101,22 @@ def get_document_sections(
     to the size-bounded basic text export instead of loading a structurally
     unbounded doc into memory. `includeTabsContent` pulls every tab's content.
     """
-    session = AuthorizedSession(get_impersonated_creds(creds, user_email))
-    with session.get(
-        DOCS_API_DOCUMENT_URL.format(doc_id=doc_id),
-        params={"includeTabsContent": "true"},
-        stream=True,
-        timeout=_DOCS_FETCH_TIMEOUT_SECONDS,
-    ) as response:
-        response.raise_for_status()
-        buffer = bytearray()
-        for chunk in response.iter_content(chunk_size=_DOCS_FETCH_CHUNK_SIZE):
-            buffer.extend(chunk)
-            if len(buffer) > max_response_bytes:
-                return None
+    impersonated_creds = get_impersonated_creds(creds, user_email)
+    with AuthorizedSession(impersonated_creds) as session:
+        with session.get(
+            DOCS_API_DOCUMENT_URL.format(doc_id=doc_id),
+            params={"includeTabsContent": "true"},
+            stream=True,
+            timeout=_DOCS_FETCH_TIMEOUT_SECONDS,
+        ) as response:
+            response.raise_for_status()
+            buffer = bytearray()
+            for chunk in response.iter_content(chunk_size=_DOCS_FETCH_CHUNK_SIZE):
+                if not chunk:
+                    continue
+                buffer.extend(chunk)
+                if len(buffer) > max_response_bytes:
+                    return None
 
     doc = json.loads(buffer)
     tabs = doc.get("tabs", {})

--- a/backend/onyx/connectors/google_drive/section_extraction.py
+++ b/backend/onyx/connectors/google_drive/section_extraction.py
@@ -96,9 +96,7 @@ def get_document_sections(
 ) -> list[TextSection] | None:
     """Extract heading-aware sections from a Google Doc.
 
-    Streams the Docs-API response and returns None once it exceeds
-    `max_response_bytes`, so the caller can fall back to the basic text export
-    rather than load an unbounded structural payload into memory.
+    Streams the Docs-API response; returns None if it exceeds `max_response_bytes`.
     """
     impersonated_creds = get_impersonated_creds(creds, user_email)
     with AuthorizedSession(impersonated_creds) as session:

--- a/backend/onyx/connectors/google_utils/resources.py
+++ b/backend/onyx/connectors/google_utils/resources.py
@@ -1,6 +1,7 @@
 from collections.abc import Callable
 
 from google.auth.exceptions import RefreshError
+from google.auth.transport.requests import AuthorizedSession
 from google.oauth2.credentials import Credentials as OAuthCredentials
 from google.oauth2.service_account import Credentials as ServiceAccountCredentials
 from googleapiclient.discovery import build
@@ -87,6 +88,16 @@ def get_impersonated_creds(
         # https://developers.google.com/identity/protocols/oauth2/service-account#error-codes
         return creds.with_subject(user_email)
     return creds
+
+
+def get_google_authorized_session(
+    creds: ServiceAccountCredentials | OAuthCredentials,
+    user_email: str | None = None,
+) -> AuthorizedSession:
+    """Raw authorized HTTP session for Google REST endpoints the typed service
+    builders don't cover (e.g. streaming a response under a byte cap). Caller owns
+    the session and must close it."""
+    return AuthorizedSession(get_impersonated_creds(creds, user_email))
 
 
 def get_google_docs_service(

--- a/backend/onyx/connectors/google_utils/resources.py
+++ b/backend/onyx/connectors/google_utils/resources.py
@@ -72,15 +72,21 @@ def _get_google_service(
     creds: ServiceAccountCredentials | OAuthCredentials,
     user_email: str | None = None,
 ) -> GoogleDriveService | GoogleDocsService | AdminService | GmailService:
-    service: Resource
-    if isinstance(creds, ServiceAccountCredentials):
-        # NOTE: https://developers.google.com/identity/protocols/oauth2/service-account#error-codes
-        creds = creds.with_subject(user_email)
-        service = build(service_name, service_version, credentials=creds)
-    elif isinstance(creds, OAuthCredentials):
-        service = build(service_name, service_version, credentials=creds)
-
+    creds = get_impersonated_creds(creds, user_email)
+    service: Resource = build(service_name, service_version, credentials=creds)
     return service
+
+
+def get_impersonated_creds(
+    creds: ServiceAccountCredentials | OAuthCredentials,
+    user_email: str | None = None,
+) -> ServiceAccountCredentials | OAuthCredentials:
+    """Service-account creds impersonating `user_email` (domain-wide delegation);
+    OAuth creds are returned unchanged."""
+    if isinstance(creds, ServiceAccountCredentials):
+        # https://developers.google.com/identity/protocols/oauth2/service-account#error-codes
+        return creds.with_subject(user_email)
+    return creds
 
 
 def get_google_docs_service(

--- a/backend/tests/daily/connectors/google_drive/consts_and_utils.py
+++ b/backend/tests/daily/connectors/google_drive/consts_and_utils.py
@@ -526,6 +526,10 @@ MISC_SHARED_DRIVE_FNAMES = [
     "bb2.txt",
 ]
 
+# A shared-drive Google Doc whose text export (~90 KB) exceeds the size threshold
+# used in test_include_shared_drives_only_with_size_threshold.
+OVERSIZED_DOC_NAME = "Untitled document"
+
 file_name_template = "file_{}.txt"
 file_text_template = "This is file {}"
 

--- a/backend/tests/daily/connectors/google_drive/consts_and_utils.py
+++ b/backend/tests/daily/connectors/google_drive/consts_and_utils.py
@@ -526,10 +526,6 @@ MISC_SHARED_DRIVE_FNAMES = [
     "bb2.txt",
 ]
 
-# A shared-drive Google Doc whose text export (~90 KB) exceeds the size threshold
-# used in test_include_shared_drives_only_with_size_threshold.
-OVERSIZED_DOC_NAME = "Untitled document"
-
 file_name_template = "file_{}.txt"
 file_text_template = "This is file {}"
 

--- a/backend/tests/daily/connectors/google_drive/test_service_acct.py
+++ b/backend/tests/daily/connectors/google_drive/test_service_acct.py
@@ -220,22 +220,18 @@ def test_include_shared_drives_only_with_size_threshold(
     expected_file_names = {id_to_name(file_id) for file_id in expected_file_ids}
     expected_file_names.update(MISC_SHARED_DRIVE_FNAMES)
     retrieved_file_names = {doc.semantic_identifier for doc in output.documents}
-    for name in expected_file_names - retrieved_file_names:
+
+    missing = expected_file_names - retrieved_file_names
+    unexpected = retrieved_file_names - expected_file_names
+    for name in missing:
         print(f"expected but did not retrieve: {name}")
-    for name in retrieved_file_names - expected_file_names:
+    for name in unexpected:
         print(f"retrieved but did not expect: {name}")
 
-    # 2 extra files from shared drive owned by non-admin and not shared with admin
-    # TODO: added a file in a "restricted" folder, which the connector sometimes succeeds at finding
-    # and adding. Specifically, our shared drive retrieval logic currently assumes that
-    # "having access to a shared drive" means that the connector has access to all files in the shared drive.
-    # therefore when a user successfully retrieves a shared drive, we mark it as "done". If that user's
-    # access is restricted for a folder in the shared drive, the connector will not retrieve that folder.
-    # If instead someone with FULL access to the shared drive retrieves it, the connector will retrieve
-    # the folder and all its files. There is currently no consistency to the order of assignment of users
-    # to shared drives, so this is a heisenbug: the count is 50-52 depending on
-    # whether the user who retrieves the restricted shared drive has full access.
-    assert len(output.documents) in (50, 51, 52)
+    # The size threshold skips exactly one accessible file. The document total isn't
+    # asserted: a restricted shared-drive folder is retrieved nondeterministically,
+    # adding files only on the `unexpected` side.
+    assert len(missing) == 1
 
 
 @patch(
@@ -277,10 +273,9 @@ def test_include_shared_drives_only(
         expected_file_ids=expected_file_ids,
     )
 
-    # 2 extra files from shared drive owned by non-admin and not shared with admin
-    # another one flaky for unknown reasons
-    # TODO: switch to 54 when restricted access issue is resolved
-    assert len(output.documents) == 51 or len(output.documents) == 52
+    # The document total isn't asserted: a restricted shared-drive folder is
+    # retrieved nondeterministically, so the count varies run to run. The expected
+    # files being present (checked above) is the invariant that matters.
 
     expected_nodes = get_expected_hierarchy_for_shared_drives(
         include_drive_1=True,

--- a/backend/tests/daily/connectors/google_drive/test_service_acct.py
+++ b/backend/tests/daily/connectors/google_drive/test_service_acct.py
@@ -51,9 +51,7 @@ from tests.daily.connectors.google_drive.consts_and_utils import (
 )
 from tests.daily.connectors.google_drive.consts_and_utils import id_to_name
 from tests.daily.connectors.google_drive.consts_and_utils import load_connector_outputs
-from tests.daily.connectors.google_drive.consts_and_utils import (
-    MISC_SHARED_DRIVE_FNAMES,
-)
+from tests.daily.connectors.google_drive.consts_and_utils import OVERSIZED_DOC_NAME
 from tests.daily.connectors.google_drive.consts_and_utils import (
     PERM_SYNC_DRIVE_ADMIN_AND_USER_1_A_ID,
 )
@@ -217,25 +215,17 @@ def test_include_shared_drives_only_with_size_threshold(
         + SECTIONS_FILE_IDS
     )
 
-    expected_file_names = {id_to_name(file_id) for file_id in expected_file_ids}
-    expected_file_names.update(MISC_SHARED_DRIVE_FNAMES)
-    retrieved_file_names = {doc.semantic_identifier for doc in output.documents}
-    for name in expected_file_names - retrieved_file_names:
-        print(f"expected but did not retrieve: {name}")
-    for name in retrieved_file_names - expected_file_names:
-        print(f"retrieved but did not expect: {name}")
+    assert_expected_docs_in_retrieved_docs(
+        retrieved_docs=output.documents,
+        expected_file_ids=expected_file_ids,
+    )
 
-    # 2 extra files from shared drive owned by non-admin and not shared with admin
-    # TODO: added a file in a "restricted" folder, which the connector sometimes succeeds at finding
-    # and adding. Specifically, our shared drive retrieval logic currently assumes that
-    # "having access to a shared drive" means that the connector has access to all files in the shared drive.
-    # therefore when a user successfully retrieves a shared drive, we mark it as "done". If that user's
-    # access is restricted for a folder in the shared drive, the connector will not retrieve that folder.
-    # If instead someone with FULL access to the shared drive retrieves it, the connector will retrieve
-    # the folder and all its files. There is currently no consistency to the order of assignment of users
-    # to shared drives, so this is a heisenbug. When we guarantee that restricted folders are retrieved,
-    # we can change this to 52
-    assert len(output.documents) == 50 or len(output.documents) == 51
+    # The size threshold's effect under test: the one file whose export exceeds it
+    # ("Untitled document", ~90 KB) must be skipped. The total document count isn't
+    # asserted because a restricted shared-drive folder is retrieved
+    # nondeterministically (the user who wins the drive crawl may lack access to it).
+    retrieved_file_names = {doc.semantic_identifier for doc in output.documents}
+    assert OVERSIZED_DOC_NAME not in retrieved_file_names
 
 
 @patch(
@@ -277,10 +267,8 @@ def test_include_shared_drives_only(
         expected_file_ids=expected_file_ids,
     )
 
-    # 2 extra files from shared drive owned by non-admin and not shared with admin
-    # another one flaky for unknown reasons
-    # TODO: switch to 54 when restricted access issue is resolved
-    assert len(output.documents) == 51 or len(output.documents) == 52
+    # The total document count isn't asserted: a restricted shared-drive folder is
+    # retrieved nondeterministically, so the count varies run to run.
 
     expected_nodes = get_expected_hierarchy_for_shared_drives(
         include_drive_1=True,

--- a/backend/tests/daily/connectors/google_drive/test_service_acct.py
+++ b/backend/tests/daily/connectors/google_drive/test_service_acct.py
@@ -220,18 +220,22 @@ def test_include_shared_drives_only_with_size_threshold(
     expected_file_names = {id_to_name(file_id) for file_id in expected_file_ids}
     expected_file_names.update(MISC_SHARED_DRIVE_FNAMES)
     retrieved_file_names = {doc.semantic_identifier for doc in output.documents}
-
-    missing = expected_file_names - retrieved_file_names
-    unexpected = retrieved_file_names - expected_file_names
-    for name in missing:
+    for name in expected_file_names - retrieved_file_names:
         print(f"expected but did not retrieve: {name}")
-    for name in unexpected:
+    for name in retrieved_file_names - expected_file_names:
         print(f"retrieved but did not expect: {name}")
 
-    # The size threshold skips exactly one accessible file. The document total isn't
-    # asserted: a restricted shared-drive folder is retrieved nondeterministically,
-    # adding files only on the `unexpected` side.
-    assert len(missing) == 1
+    # 2 extra files from shared drive owned by non-admin and not shared with admin
+    # TODO: added a file in a "restricted" folder, which the connector sometimes succeeds at finding
+    # and adding. Specifically, our shared drive retrieval logic currently assumes that
+    # "having access to a shared drive" means that the connector has access to all files in the shared drive.
+    # therefore when a user successfully retrieves a shared drive, we mark it as "done". If that user's
+    # access is restricted for a folder in the shared drive, the connector will not retrieve that folder.
+    # If instead someone with FULL access to the shared drive retrieves it, the connector will retrieve
+    # the folder and all its files. There is currently no consistency to the order of assignment of users
+    # to shared drives, so this is a heisenbug. When we guarantee that restricted folders are retrieved,
+    # we can change this to 52
+    assert len(output.documents) == 50 or len(output.documents) == 51
 
 
 @patch(
@@ -273,9 +277,10 @@ def test_include_shared_drives_only(
         expected_file_ids=expected_file_ids,
     )
 
-    # The document total isn't asserted: a restricted shared-drive folder is
-    # retrieved nondeterministically, so the count varies run to run. The expected
-    # files being present (checked above) is the invariant that matters.
+    # 2 extra files from shared drive owned by non-admin and not shared with admin
+    # another one flaky for unknown reasons
+    # TODO: switch to 54 when restricted access issue is resolved
+    assert len(output.documents) == 51 or len(output.documents) == 52
 
     expected_nodes = get_expected_hierarchy_for_shared_drives(
         include_drive_1=True,

--- a/backend/tests/daily/connectors/google_drive/test_service_acct.py
+++ b/backend/tests/daily/connectors/google_drive/test_service_acct.py
@@ -233,9 +233,9 @@ def test_include_shared_drives_only_with_size_threshold(
     # access is restricted for a folder in the shared drive, the connector will not retrieve that folder.
     # If instead someone with FULL access to the shared drive retrieves it, the connector will retrieve
     # the folder and all its files. There is currently no consistency to the order of assignment of users
-    # to shared drives, so this is a heisenbug. When we guarantee that restricted folders are retrieved,
-    # we can change this to 52
-    assert len(output.documents) == 50 or len(output.documents) == 51
+    # to shared drives, so this is a heisenbug: the count is 50-52 depending on
+    # whether the user who retrieves the restricted shared drive has full access.
+    assert len(output.documents) in (50, 51, 52)
 
 
 @patch(

--- a/backend/tests/daily/connectors/google_drive/test_service_acct.py
+++ b/backend/tests/daily/connectors/google_drive/test_service_acct.py
@@ -51,7 +51,9 @@ from tests.daily.connectors.google_drive.consts_and_utils import (
 )
 from tests.daily.connectors.google_drive.consts_and_utils import id_to_name
 from tests.daily.connectors.google_drive.consts_and_utils import load_connector_outputs
-from tests.daily.connectors.google_drive.consts_and_utils import OVERSIZED_DOC_NAME
+from tests.daily.connectors.google_drive.consts_and_utils import (
+    MISC_SHARED_DRIVE_FNAMES,
+)
 from tests.daily.connectors.google_drive.consts_and_utils import (
     PERM_SYNC_DRIVE_ADMIN_AND_USER_1_A_ID,
 )
@@ -215,17 +217,25 @@ def test_include_shared_drives_only_with_size_threshold(
         + SECTIONS_FILE_IDS
     )
 
-    assert_expected_docs_in_retrieved_docs(
-        retrieved_docs=output.documents,
-        expected_file_ids=expected_file_ids,
-    )
-
-    # The size threshold's effect under test: the one file whose export exceeds it
-    # ("Untitled document", ~90 KB) must be skipped. The total document count isn't
-    # asserted because a restricted shared-drive folder is retrieved
-    # nondeterministically (the user who wins the drive crawl may lack access to it).
+    expected_file_names = {id_to_name(file_id) for file_id in expected_file_ids}
+    expected_file_names.update(MISC_SHARED_DRIVE_FNAMES)
     retrieved_file_names = {doc.semantic_identifier for doc in output.documents}
-    assert OVERSIZED_DOC_NAME not in retrieved_file_names
+    for name in expected_file_names - retrieved_file_names:
+        print(f"expected but did not retrieve: {name}")
+    for name in retrieved_file_names - expected_file_names:
+        print(f"retrieved but did not expect: {name}")
+
+    # 2 extra files from shared drive owned by non-admin and not shared with admin
+    # TODO: added a file in a "restricted" folder, which the connector sometimes succeeds at finding
+    # and adding. Specifically, our shared drive retrieval logic currently assumes that
+    # "having access to a shared drive" means that the connector has access to all files in the shared drive.
+    # therefore when a user successfully retrieves a shared drive, we mark it as "done". If that user's
+    # access is restricted for a folder in the shared drive, the connector will not retrieve that folder.
+    # If instead someone with FULL access to the shared drive retrieves it, the connector will retrieve
+    # the folder and all its files. There is currently no consistency to the order of assignment of users
+    # to shared drives, so this is a heisenbug. When we guarantee that restricted folders are retrieved,
+    # we can change this to 53
+    assert len(output.documents) in (52, 53)
 
 
 @patch(
@@ -267,8 +277,10 @@ def test_include_shared_drives_only(
         expected_file_ids=expected_file_ids,
     )
 
-    # The total document count isn't asserted: a restricted shared-drive folder is
-    # retrieved nondeterministically, so the count varies run to run.
+    # 2 extra files from shared drive owned by non-admin and not shared with admin
+    # another one flaky for unknown reasons
+    # TODO: switch to 54 when restricted access issue is resolved
+    assert len(output.documents) in (53, 54)
 
     expected_nodes = get_expected_hierarchy_for_shared_drives(
         include_drive_1=True,

--- a/backend/tests/unit/onyx/connectors/google_drive/test_drive_advanced_parse_cap.py
+++ b/backend/tests/unit/onyx/connectors/google_drive/test_drive_advanced_parse_cap.py
@@ -4,9 +4,6 @@ streamed response exceeds the byte cap, and parses normally under it."""
 import json
 from unittest.mock import MagicMock
 
-import pytest
-
-from onyx.connectors.google_drive import section_extraction
 from onyx.connectors.google_drive.section_extraction import get_document_sections
 
 
@@ -20,43 +17,24 @@ def _mock_session(chunks: list[bytes]) -> MagicMock:
     response = _as_ctx(MagicMock())
     response.raise_for_status = MagicMock()
     response.iter_content = MagicMock(return_value=iter(chunks))
-    session = _as_ctx(MagicMock())
+    session = MagicMock()
     session.get = MagicMock(return_value=response)
     return session
 
 
-def _patch(monkeypatch: pytest.MonkeyPatch, session: MagicMock) -> None:
-    monkeypatch.setattr(
-        section_extraction,
-        "get_impersonated_creds",
-        MagicMock(return_value=MagicMock()),
-    )
-    monkeypatch.setattr(
-        section_extraction, "AuthorizedSession", MagicMock(return_value=session)
-    )
-
-
-def test_get_document_sections_returns_none_over_cap(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    _patch(monkeypatch, _mock_session([b"a" * 80, b"b" * 80]))
+def test_get_document_sections_returns_none_over_cap() -> None:
     result = get_document_sections(
-        creds=MagicMock(),
+        authorized_session=_mock_session([b"a" * 80, b"b" * 80]),
         doc_id="doc",
-        user_email="u@example.com",
         max_response_bytes=100,
     )
     assert result is None
 
 
-def test_get_document_sections_parses_under_cap(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    _patch(monkeypatch, _mock_session([json.dumps({"tabs": []}).encode()]))
+def test_get_document_sections_parses_under_cap() -> None:
     result = get_document_sections(
-        creds=MagicMock(),
+        authorized_session=_mock_session([json.dumps({"tabs": []}).encode()]),
         doc_id="doc",
-        user_email="u@example.com",
         max_response_bytes=10_000,
     )
     assert result == []

--- a/backend/tests/unit/onyx/connectors/google_drive/test_drive_advanced_parse_cap.py
+++ b/backend/tests/unit/onyx/connectors/google_drive/test_drive_advanced_parse_cap.py
@@ -1,0 +1,62 @@
+"""get_document_sections bounds the Docs-API fetch: it returns None once the
+streamed response exceeds the byte cap, and parses normally under it."""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from onyx.connectors.google_drive import section_extraction
+from onyx.connectors.google_drive.section_extraction import get_document_sections
+
+
+def _as_ctx(obj: MagicMock) -> MagicMock:
+    obj.__enter__ = MagicMock(return_value=obj)
+    obj.__exit__ = MagicMock(return_value=False)
+    return obj
+
+
+def _mock_session(chunks: list[bytes]) -> MagicMock:
+    response = _as_ctx(MagicMock())
+    response.raise_for_status = MagicMock()
+    response.iter_content = MagicMock(return_value=iter(chunks))
+    session = _as_ctx(MagicMock())
+    session.get = MagicMock(return_value=response)
+    return session
+
+
+def _patch(monkeypatch: pytest.MonkeyPatch, session: MagicMock) -> None:
+    monkeypatch.setattr(
+        section_extraction,
+        "get_impersonated_creds",
+        MagicMock(return_value=MagicMock()),
+    )
+    monkeypatch.setattr(
+        section_extraction, "AuthorizedSession", MagicMock(return_value=session)
+    )
+
+
+def test_get_document_sections_returns_none_over_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch(monkeypatch, _mock_session([b"a" * 80, b"b" * 80]))
+    result = get_document_sections(
+        creds=MagicMock(),
+        doc_id="doc",
+        user_email="u@example.com",
+        max_response_bytes=100,
+    )
+    assert result is None
+
+
+def test_get_document_sections_parses_under_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch(monkeypatch, _mock_session([json.dumps({"tabs": []}).encode()]))
+    result = get_document_sections(
+        creds=MagicMock(),
+        doc_id="doc",
+        user_email="u@example.com",
+        max_response_bytes=10_000,
+    )
+    assert result == []


### PR DESCRIPTION
## Description

**Bug:** Google Drive indexing OOMs and crash-loops on tenants with large Google Docs — the indexing worker exceeds its memory limit, the watchdog kills it, and the attempt auto-reschedules.

**Why:** A Google Doc's advanced parse (`get_document_sections`) loads the full Docs-API structural JSON, which is far heavier than the doc's text and isn't subject to any size limit (unlike exports). The prior text-export size gate (#12223) let structure-heavy / text-light Docs through, and they still OOM'd.

**Fix:** Stream the Docs-API response under a byte cap (`GOOGLE_DRIVE_ADVANCED_PARSE_MAX_BYTES`, default 50 MB). Docs over the cap fall back to the size-bounded basic text export — still indexed (full text), just whole-doc links instead of section-level links. Also cap the O(n²) `align_basic_advanced` pass by section count, and close the streamed session on every path. Adds a `get_impersonated_creds` helper (reused by the service builder).

Exports (Docs-text / Sheets-CSV / Slides) are already size-bounded; this closes the last unbounded native-Docs path.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
