### PR TITLE
fix(agent-sharing): "Your Agents" tab lists owned + shared-edit agents

### DIFF
--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -45,6 +45,7 @@ from onyx.db.notification import create_notification
 from onyx.db.persona_sharing import get_persona_access_level
 from onyx.db.persona_sharing import get_user_group_ids_for_user
 from onyx.db.persona_sharing import persona_ownership_is_vacant
+from onyx.db.persona_sharing import user_owns_or_directly_edits
 from onyx.server.features.persona.models import FullPersonaSnapshot
 from onyx.server.features.persona.models import MinimalPersonaSnapshot
 from onyx.server.features.persona.models import PersonaSharedNotificationData
@@ -759,6 +760,52 @@ def _user_may_view_persona_owner_email(user: User, persona: Persona) -> bool:
     return user.role == UserRole.ADMIN or persona.user_id == user.id
 
 
+# Eager-load set MinimalPersonaSnapshot.from_model needs. Shared by the list and
+# paginated minimal-snapshot queries.
+_MINIMAL_SNAPSHOT_LOAD_OPTIONS = (
+    selectinload(Persona.tools),
+    selectinload(Persona.labels),
+    selectinload(Persona.document_sets).options(
+        selectinload(DocumentSet.connector_credential_pairs).selectinload(
+            ConnectorCredentialPair.connector
+        ),
+        selectinload(DocumentSet.users),
+        selectinload(DocumentSet.groups),
+        selectinload(DocumentSet.federated_connectors).selectinload(
+            FederatedConnector__DocumentSet.federated_connector
+        ),
+    ),
+    selectinload(Persona.hierarchy_nodes),
+    selectinload(Persona.attached_documents).selectinload(
+        Document.parent_hierarchy_node
+    ),
+    selectinload(Persona.user),
+    selectinload(Persona.owner_group),
+    selectinload(Persona.user_shares),
+    selectinload(Persona.group_shares),
+)
+
+
+def _minimal_persona_snapshots_from_stmt(
+    db_session: Session, stmt: Select[tuple[Persona]], user: User
+) -> list[MinimalPersonaSnapshot]:
+    """Materialize the query as MinimalPersonaSnapshots, computing each persona's
+    per-user access fields."""
+    personas = db_session.scalars(stmt).all()
+    user_group_ids = get_user_group_ids_for_user(db_session, user.id)
+    return [
+        MinimalPersonaSnapshot.from_model(
+            persona,
+            user_permission=get_persona_access_level(persona, user, user_group_ids),
+            user_is_owner_or_editor=user_owns_or_directly_edits(
+                persona, user, user_group_ids
+            ),
+            include_owner_email=_user_may_view_persona_owner_email(user, persona),
+        )
+        for persona in personas
+    ]
+
+
 def get_minimal_persona_snapshots_for_user(
     user: User,
     db_session: Session,
@@ -772,38 +819,8 @@ def get_minimal_persona_snapshots_for_user(
     stmt = _build_persona_filters(
         stmt, include_default, include_slack_bot_personas, include_deleted
     )
-    stmt = stmt.options(
-        selectinload(Persona.tools),
-        selectinload(Persona.labels),
-        selectinload(Persona.document_sets).options(
-            selectinload(DocumentSet.connector_credential_pairs).selectinload(
-                ConnectorCredentialPair.connector
-            ),
-            selectinload(DocumentSet.users),
-            selectinload(DocumentSet.groups),
-            selectinload(DocumentSet.federated_connectors).selectinload(
-                FederatedConnector__DocumentSet.federated_connector
-            ),
-        ),
-        selectinload(Persona.hierarchy_nodes),
-        selectinload(Persona.attached_documents).selectinload(
-            Document.parent_hierarchy_node
-        ),
-        selectinload(Persona.user),
-        selectinload(Persona.owner_group),
-        selectinload(Persona.user_shares),
-        selectinload(Persona.group_shares),
-    )
-    results = db_session.scalars(stmt).all()
-    user_group_ids = get_user_group_ids_for_user(db_session, user.id)
-    return [
-        MinimalPersonaSnapshot.from_model(
-            persona,
-            user_permission=get_persona_access_level(persona, user, user_group_ids),
-            include_owner_email=_user_may_view_persona_owner_email(user, persona),
-        )
-        for persona in results
-    ]
+    stmt = stmt.options(*_MINIMAL_SNAPSHOT_LOAD_OPTIONS)
+    return _minimal_persona_snapshots_from_stmt(db_session, stmt, user)
 
 
 def get_persona_snapshots_for_user(
@@ -926,41 +943,8 @@ def get_minimal_persona_snapshots_paginated(
         include_slack_bot_personas,
         include_deleted,
     )
-    # Do eager loading of columns we know MinimalPersonaSnapshot.from_model will
-    # need.
-    stmt = stmt.options(
-        selectinload(Persona.tools),
-        selectinload(Persona.hierarchy_nodes),
-        selectinload(Persona.attached_documents).selectinload(
-            Document.parent_hierarchy_node
-        ),
-        selectinload(Persona.labels),
-        selectinload(Persona.document_sets).options(
-            selectinload(DocumentSet.connector_credential_pairs).selectinload(
-                ConnectorCredentialPair.connector
-            ),
-            selectinload(DocumentSet.users),
-            selectinload(DocumentSet.groups),
-            selectinload(DocumentSet.federated_connectors).selectinload(
-                FederatedConnector__DocumentSet.federated_connector
-            ),
-        ),
-        selectinload(Persona.user),
-        selectinload(Persona.owner_group),
-        selectinload(Persona.user_shares),
-        selectinload(Persona.group_shares),
-    )
-
-    results = db_session.scalars(stmt).all()
-    user_group_ids = get_user_group_ids_for_user(db_session, user.id)
-    return [
-        MinimalPersonaSnapshot.from_model(
-            persona,
-            user_permission=get_persona_access_level(persona, user, user_group_ids),
-            include_owner_email=_user_may_view_persona_owner_email(user, persona),
-        )
-        for persona in results
-    ]
+    stmt = stmt.options(*_MINIMAL_SNAPSHOT_LOAD_OPTIONS)
+    return _minimal_persona_snapshots_from_stmt(db_session, stmt, user)
 
 
 def get_persona_snapshots_paginated(

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -45,6 +45,7 @@ from onyx.db.persona_sharing import (
     get_persona_access_level,
     get_user_group_ids_for_user,
     persona_ownership_is_vacant,
+    user_owns_or_directly_edits,
 )
 from onyx.db.scoped_permissions import (
     fetch_managed_group_ids,
@@ -1029,6 +1030,57 @@ def _user_may_view_persona_owner_email(user: User, persona: Persona) -> bool:
     )
 
 
+# Eager-load set MinimalPersonaSnapshot.from_model needs. Shared by the list and
+# paginated minimal-snapshot queries.
+_MINIMAL_SNAPSHOT_LOAD_OPTIONS = (
+    selectinload(Persona.tools),
+    selectinload(Persona.labels),
+    selectinload(Persona.document_sets).options(
+        selectinload(DocumentSet.connector_credential_pairs).selectinload(
+            ConnectorCredentialPair.connector
+        ),
+        selectinload(DocumentSet.users),
+        selectinload(DocumentSet.groups),
+        selectinload(DocumentSet.federated_connectors).selectinload(
+            FederatedConnector__DocumentSet.federated_connector
+        ),
+    ),
+    selectinload(Persona.hierarchy_nodes),
+    selectinload(Persona.attached_documents).selectinload(
+        Document.parent_hierarchy_node
+    ),
+    selectinload(Persona.user),
+    # groups feeds the per-agent edit affordance (persona_edit_within_scope).
+    # Eager-load it so stamping the page's permissions isn't an N+1.
+    selectinload(Persona.groups),
+    selectinload(Persona.owner_group),
+    selectinload(Persona.user_shares),
+    selectinload(Persona.group_shares),
+)
+
+
+def _minimal_persona_snapshots_from_stmt(
+    db_session: Session, stmt: Select[tuple[Persona]], user: User
+) -> list[MinimalPersonaSnapshot]:
+    """Materialize the query as MinimalPersonaSnapshots, computing each persona's
+    per-user access fields and stamping scoped edit permissions."""
+    personas = db_session.scalars(stmt).all()
+    user_group_ids = get_user_group_ids_for_user(db_session, user.id)
+    snapshots = [
+        MinimalPersonaSnapshot.from_model(
+            persona,
+            user_permission=get_persona_access_level(persona, user, user_group_ids),
+            user_is_owner_or_editor=user_owns_or_directly_edits(
+                persona, user, user_group_ids
+            ),
+            include_owner_email=_user_may_view_persona_owner_email(user, persona),
+        )
+        for persona in personas
+    ]
+    stamp_persona_permissions(snapshots, personas, user, db_session, user_group_ids)
+    return snapshots
+
+
 def get_minimal_persona_snapshots_for_user(
     user: User,
     db_session: Session,
@@ -1042,43 +1094,8 @@ def get_minimal_persona_snapshots_for_user(
     stmt = _build_persona_filters(
         stmt, include_default, include_slack_bot_personas, include_deleted
     )
-    stmt = stmt.options(
-        selectinload(Persona.tools),
-        selectinload(Persona.labels),
-        selectinload(Persona.document_sets).options(
-            selectinload(DocumentSet.connector_credential_pairs).selectinload(
-                ConnectorCredentialPair.connector
-            ),
-            selectinload(DocumentSet.users),
-            selectinload(DocumentSet.groups),
-            selectinload(DocumentSet.federated_connectors).selectinload(
-                FederatedConnector__DocumentSet.federated_connector
-            ),
-        ),
-        selectinload(Persona.hierarchy_nodes),
-        selectinload(Persona.attached_documents).selectinload(
-            Document.parent_hierarchy_node
-        ),
-        selectinload(Persona.user),
-        # groups feeds the per-agent edit affordance (persona_edit_within_scope);
-        # eager-load it so stamping the page's permissions isn't an N+1.
-        selectinload(Persona.groups),
-        selectinload(Persona.owner_group),
-        selectinload(Persona.user_shares),
-        selectinload(Persona.group_shares),
-    )
-    results = db_session.scalars(stmt).all()
-    user_group_ids = get_user_group_ids_for_user(db_session, user.id)
-    snapshots = [
-        MinimalPersonaSnapshot.from_model(
-            persona,
-            user_permission=get_persona_access_level(persona, user, user_group_ids),
-            include_owner_email=_user_may_view_persona_owner_email(user, persona),
-        )
-        for persona in results
-    ]
-    stamp_persona_permissions(snapshots, results, user, db_session, user_group_ids)
-    return snapshots
+    stmt = stmt.options(*_MINIMAL_SNAPSHOT_LOAD_OPTIONS)
+    return _minimal_persona_snapshots_from_stmt(db_session, stmt, user)
 
 
 def get_persona_snapshots_for_user(
@@ -1204,46 +1221,8 @@ def get_minimal_persona_snapshots_paginated(
         include_slack_bot_personas,
         include_deleted,
     )
-    # Do eager loading of columns we know MinimalPersonaSnapshot.from_model will
-    # need.
-    stmt = stmt.options(
-        selectinload(Persona.tools),
-        selectinload(Persona.hierarchy_nodes),
-        selectinload(Persona.attached_documents).selectinload(
-            Document.parent_hierarchy_node
-        ),
-        selectinload(Persona.labels),
-        selectinload(Persona.document_sets).options(
-            selectinload(DocumentSet.connector_credential_pairs).selectinload(
-                ConnectorCredentialPair.connector
-            ),
-            selectinload(DocumentSet.users),
-            selectinload(DocumentSet.groups),
-            selectinload(DocumentSet.federated_connectors).selectinload(
-                FederatedConnector__DocumentSet.federated_connector
-            ),
-        ),
-        selectinload(Persona.user),
-        # groups feeds the per-agent edit affordance (persona_edit_within_scope);
-        # eager-load it so stamping the page's permissions isn't an N+1.
-        selectinload(Persona.groups),
-        selectinload(Persona.owner_group),
-        selectinload(Persona.user_shares),
-        selectinload(Persona.group_shares),
-    )
-
-    results = db_session.scalars(stmt).all()
-    user_group_ids = get_user_group_ids_for_user(db_session, user.id)
-    snapshots = [
-        MinimalPersonaSnapshot.from_model(
-            persona,
-            user_permission=get_persona_access_level(persona, user, user_group_ids),
-            include_owner_email=_user_may_view_persona_owner_email(user, persona),
-        )
-        for persona in results
-    ]
-    stamp_persona_permissions(snapshots, results, user, db_session, user_group_ids)
-    return snapshots
+    stmt = stmt.options(*_MINIMAL_SNAPSHOT_LOAD_OPTIONS)
+    return _minimal_persona_snapshots_from_stmt(db_session, stmt, user)
 
 
 def get_persona_snapshots_paginated(

--- a/backend/onyx/db/persona_sharing.py
+++ b/backend/onyx/db/persona_sharing.py
@@ -51,16 +51,23 @@ def get_persona_access_level(
     persona: Persona,
     user: User,
     user_group_ids: set[int],
+    include_blanket_editor_grants: bool = True,
 ) -> PersonaAccessLevel | None:
     """Computed access for ``user`` over loaded share relations. OWNER outranks
-    everything; admins report EDITOR on personas they don't own. Curators'
-    group-attachment edit rights are not reflected here — this level drives
-    the sharing UI, not the editable fetch."""
+    everything. Admins report EDITOR on personas they don't own, and org-wide
+    public-editor personas report EDITOR for everyone. Curators' group-attachment
+    edit rights are not reflected here. This level drives the sharing UI, not the
+    editable fetch.
+
+    Pass ``include_blanket_editor_grants=False`` for the user's personal access
+    (ownership plus direct user/group shares) without the org-wide EDITOR grants
+    everyone holds: admin role and public-editor. Used by the "Your Agents"
+    gallery."""
     if persona.user_id == user.id or (
         persona.owner_group_id is not None and persona.owner_group_id in user_group_ids
     ):
         return PersonaAccessLevel.OWNER
-    if user.role == UserRole.ADMIN:
+    if include_blanket_editor_grants and user.role == UserRole.ADMIN:
         return PersonaAccessLevel.EDITOR
 
     has_viewer_access = False
@@ -75,10 +82,26 @@ def get_persona_access_level(
                 return PersonaAccessLevel.EDITOR
             has_viewer_access = True
     if persona.is_public:
-        if persona.public_permission == PersonaSharePermission.EDITOR:
+        if (
+            include_blanket_editor_grants
+            and persona.public_permission == PersonaSharePermission.EDITOR
+        ):
             return PersonaAccessLevel.EDITOR
         has_viewer_access = True
     return PersonaAccessLevel.VIEWER if has_viewer_access else None
+
+
+def user_owns_or_directly_edits(
+    persona: Persona,
+    user: User,
+    user_group_ids: set[int],
+) -> bool:
+    """True when the user owns the persona or holds a direct user/group EDITOR
+    share, excluding the org-wide EDITOR grants everyone holds (admin role,
+    public-editor). Drives the "Your Agents" gallery, which stays personal."""
+    return get_persona_access_level(
+        persona, user, user_group_ids, include_blanket_editor_grants=False
+    ) in (PersonaAccessLevel.OWNER, PersonaAccessLevel.EDITOR)
 
 
 def derive_persona_sharing_status(persona: Persona) -> PersonaSharingStatus:

--- a/backend/onyx/db/persona_sharing.py
+++ b/backend/onyx/db/persona_sharing.py
@@ -42,16 +42,25 @@ def get_persona_access_level(
     persona: Persona,
     user: User,
     user_group_ids: set[int],
+    include_blanket_editor_grants: bool = True,
 ) -> PersonaAccessLevel | None:
     """Computed access for ``user`` over loaded share relations. OWNER outranks
-    everything; admins report EDITOR on personas they don't own. Curators'
-    group-attachment edit rights are not reflected here — this level drives
-    the sharing UI, not the editable fetch."""
+    everything. Users with the manage-agents permission report EDITOR on personas
+    they don't own, and org-wide public-editor personas report EDITOR for everyone.
+    Curators' group-attachment edit rights are not reflected here. This level
+    drives the sharing UI, not the editable fetch.
+
+    Pass ``include_blanket_editor_grants=False`` for the user's personal access
+    (ownership plus direct user/group shares) without the org-wide EDITOR grants
+    everyone holds: the manage-agents permission and public-editor. Used by the
+    "Your Agents" gallery."""
     if persona.user_id == user.id or (
         persona.owner_group_id is not None and persona.owner_group_id in user_group_ids
     ):
         return PersonaAccessLevel.OWNER
-    if has_global_permission(user, Permission.MANAGE_AGENTS):
+    if include_blanket_editor_grants and has_global_permission(
+        user, Permission.MANAGE_AGENTS
+    ):
         return PersonaAccessLevel.EDITOR
 
     has_viewer_access = False
@@ -66,10 +75,26 @@ def get_persona_access_level(
                 return PersonaAccessLevel.EDITOR
             has_viewer_access = True
     if persona.is_public:
-        if persona.public_permission == PersonaSharePermission.EDITOR:
+        if (
+            include_blanket_editor_grants
+            and persona.public_permission == PersonaSharePermission.EDITOR
+        ):
             return PersonaAccessLevel.EDITOR
         has_viewer_access = True
     return PersonaAccessLevel.VIEWER if has_viewer_access else None
+
+
+def user_owns_or_directly_edits(
+    persona: Persona,
+    user: User,
+    user_group_ids: set[int],
+) -> bool:
+    """True when the user owns the persona or holds a direct user/group EDITOR
+    share, excluding the org-wide EDITOR grants everyone holds (manage-agents
+    permission, public-editor). Drives the "Your Agents" gallery, stays personal."""
+    return get_persona_access_level(
+        persona, user, user_group_ids, include_blanket_editor_grants=False
+    ) in (PersonaAccessLevel.OWNER, PersonaAccessLevel.EDITOR)
 
 
 def derive_persona_sharing_status(persona: Persona) -> PersonaSharingStatus:

--- a/backend/onyx/server/features/persona/models.py
+++ b/backend/onyx/server/features/persona/models.py
@@ -229,6 +229,9 @@ class MinimalPersonaSnapshot(BaseModel):
     owner_group: PersonaOwnerGroupSnapshot | None
     # Computed for the requesting user when the list endpoint provides it
     user_permission: PersonaAccessLevel | None = None
+    # Owner or direct user/group editor, excluding org-wide grants (admin,
+    # public-editor). Drives the "Your Agents" gallery filter
+    user_is_owner_or_editor: bool = False
 
     @classmethod
     def from_model(
@@ -238,6 +241,7 @@ class MinimalPersonaSnapshot(BaseModel):
         # Fail closed: the owner email is PII and is only included when a caller
         # explicitly opts in (owner / admin paths). See the DB-layer callers.
         include_owner_email: bool = False,
+        user_is_owner_or_editor: bool = False,
     ) -> "MinimalPersonaSnapshot":
         # Collect unique sources from document sets, hierarchy nodes, and attached documents
         sources: set[DocumentSource] = set()
@@ -302,6 +306,7 @@ class MinimalPersonaSnapshot(BaseModel):
             ),
             owner_group=_owner_group_from_model(persona),
             user_permission=user_permission,
+            user_is_owner_or_editor=user_is_owner_or_editor,
         )
 
 

--- a/backend/onyx/server/features/persona/models.py
+++ b/backend/onyx/server/features/persona/models.py
@@ -236,6 +236,9 @@ class MinimalPersonaSnapshot(BaseModel):
     # stamp it (fail-closed on the client). List endpoints stamp it so each card
     # doesn't refetch the full agent just to gate its icons.
     permissions: dict[str, bool] = Field(default_factory=dict)
+    # Owner or direct user/group editor, excluding org-wide grants (manage-agents,
+    # public-editor). Drives the "Your Agents" gallery filter.
+    user_is_owner_or_editor: bool = False
 
     @classmethod
     def from_model(
@@ -245,6 +248,7 @@ class MinimalPersonaSnapshot(BaseModel):
         # Fail closed: the owner email is PII and is only included when a caller
         # explicitly opts in (owner / admin paths). See the DB-layer callers.
         include_owner_email: bool = False,
+        user_is_owner_or_editor: bool = False,
     ) -> "MinimalPersonaSnapshot":
         # Collect unique sources from document sets, hierarchy nodes, and attached documents
         sources: set[DocumentSource] = set()
@@ -309,6 +313,7 @@ class MinimalPersonaSnapshot(BaseModel):
             ),
             owner_group=_owner_group_from_model(persona),
             user_permission=user_permission,
+            user_is_owner_or_editor=user_is_owner_or_editor,
         )
 
 

--- a/backend/tests/external_dependency_unit/db/test_agent_sharing_permissions.py
+++ b/backend/tests/external_dependency_unit/db/test_agent_sharing_permissions.py
@@ -17,6 +17,7 @@ from onyx.db.persona import fetch_persona_by_id_for_user
 from onyx.db.persona import update_persona_access
 from onyx.db.persona_sharing import derive_persona_sharing_status
 from onyx.db.persona_sharing import get_persona_access_level
+from onyx.db.persona_sharing import user_owns_or_directly_edits
 from tests.external_dependency_unit.conftest import create_test_user
 from tests.external_dependency_unit.db.agent_sharing_helpers import create_test_persona
 from tests.external_dependency_unit.db.agent_sharing_helpers import (
@@ -200,6 +201,75 @@ def test_access_level_admin_and_stranger(db_session: Session) -> None:
 
     assert get_persona_access_level(persona, admin, set()) == PersonaAccessLevel.EDITOR
     assert get_persona_access_level(persona, stranger, set()) is None
+
+
+def test_your_agents_excludes_admin_only_access(db_session: Session) -> None:
+    """The "Your Agents" gallery lists owned + explicitly-shared-editor agents,
+    not the blanket EDITOR access admins hold on every persona."""
+    owner = create_test_user(db_session, "owner")
+    admin = create_test_user(db_session, "admin", role=UserRole.ADMIN)
+    persona = create_test_persona(db_session, owner)
+    db_session.refresh(persona)
+
+    # Admin still reports EDITOR for the sharing UI...
+    assert get_persona_access_level(persona, admin, set()) == PersonaAccessLevel.EDITOR
+    # ...but admin-only access is excluded from the intrinsic level and gallery.
+    assert (
+        get_persona_access_level(
+            persona, admin, set(), include_blanket_editor_grants=False
+        )
+        is None
+    )
+    assert not user_owns_or_directly_edits(persona, admin, set())
+    assert user_owns_or_directly_edits(persona, owner, set())
+
+
+def test_your_agents_includes_explicit_editor_even_for_admin(
+    db_session: Session,
+) -> None:
+    owner = create_test_user(db_session, "owner")
+    admin_editor = create_test_user(db_session, "admin_editor", role=UserRole.ADMIN)
+    persona = create_test_persona(db_session, owner)
+    share_persona_with_user(
+        db_session, persona, admin_editor, PersonaSharePermission.EDITOR
+    )
+    db_session.refresh(persona)
+
+    # An admin who also holds an explicit editor share belongs in their gallery.
+    assert user_owns_or_directly_edits(persona, admin_editor, set())
+
+
+def test_your_agents_excludes_viewer_share(db_session: Session) -> None:
+    owner = create_test_user(db_session, "owner")
+    viewer = create_test_user(db_session, "viewer")
+    persona = create_test_persona(db_session, owner)
+    share_persona_with_user(db_session, persona, viewer, PersonaSharePermission.VIEWER)
+    db_session.refresh(persona)
+
+    # View-only shares are not "your" agents.
+    assert not user_owns_or_directly_edits(persona, viewer, set())
+
+
+def test_your_agents_excludes_public_editor(db_session: Session) -> None:
+    """Org-wide public-editor grants edit to everyone, so it is a blanket grant
+    like admin access and must not put the agent in every user's gallery."""
+    owner = create_test_user(db_session, "owner")
+    stranger = create_test_user(db_session, "stranger")
+    persona = create_test_persona(
+        db_session,
+        owner,
+        is_public=True,
+        public_permission=PersonaSharePermission.EDITOR,
+    )
+    db_session.refresh(persona)
+
+    # The stranger can edit it org-wide (sharing UI reports EDITOR)...
+    assert (
+        get_persona_access_level(persona, stranger, set()) == PersonaAccessLevel.EDITOR
+    )
+    # ...but a blanket public-editor grant is not a "your" agent.
+    assert not user_owns_or_directly_edits(persona, stranger, set())
+    assert user_owns_or_directly_edits(persona, owner, set())
 
 
 def test_sharing_status_derivation(db_session: Session) -> None:

--- a/backend/tests/external_dependency_unit/db/test_agent_sharing_permissions.py
+++ b/backend/tests/external_dependency_unit/db/test_agent_sharing_permissions.py
@@ -23,6 +23,7 @@ from onyx.db.persona import (
 from onyx.db.persona_sharing import (
     derive_persona_sharing_status,
     get_persona_access_level,
+    user_owns_or_directly_edits,
 )
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
@@ -230,6 +231,75 @@ def test_access_level_admin_and_stranger(db_session: Session) -> None:
 
     assert get_persona_access_level(persona, admin, set()) == PersonaAccessLevel.EDITOR
     assert get_persona_access_level(persona, stranger, set()) is None
+
+
+def test_your_agents_excludes_admin_only_access(db_session: Session) -> None:
+    """The "Your Agents" gallery lists owned + explicitly-shared-editor agents,
+    not the blanket EDITOR access admins hold on every persona."""
+    owner = create_test_user(db_session, "owner")
+    admin = create_test_user(db_session, "admin", is_admin=True)
+    persona = create_test_persona(db_session, owner)
+    db_session.refresh(persona)
+
+    # Admin still reports EDITOR for the sharing UI...
+    assert get_persona_access_level(persona, admin, set()) == PersonaAccessLevel.EDITOR
+    # ...but admin-only access is excluded from the intrinsic level and gallery.
+    assert (
+        get_persona_access_level(
+            persona, admin, set(), include_blanket_editor_grants=False
+        )
+        is None
+    )
+    assert not user_owns_or_directly_edits(persona, admin, set())
+    assert user_owns_or_directly_edits(persona, owner, set())
+
+
+def test_your_agents_includes_explicit_editor_even_for_admin(
+    db_session: Session,
+) -> None:
+    owner = create_test_user(db_session, "owner")
+    admin_editor = create_test_user(db_session, "admin_editor", is_admin=True)
+    persona = create_test_persona(db_session, owner)
+    share_persona_with_user(
+        db_session, persona, admin_editor, PersonaSharePermission.EDITOR
+    )
+    db_session.refresh(persona)
+
+    # An admin who also holds an explicit editor share belongs in their gallery.
+    assert user_owns_or_directly_edits(persona, admin_editor, set())
+
+
+def test_your_agents_excludes_viewer_share(db_session: Session) -> None:
+    owner = create_test_user(db_session, "owner")
+    viewer = create_test_user(db_session, "viewer")
+    persona = create_test_persona(db_session, owner)
+    share_persona_with_user(db_session, persona, viewer, PersonaSharePermission.VIEWER)
+    db_session.refresh(persona)
+
+    # View-only shares are not "your" agents.
+    assert not user_owns_or_directly_edits(persona, viewer, set())
+
+
+def test_your_agents_excludes_public_editor(db_session: Session) -> None:
+    """Org-wide public-editor grants edit to everyone, so it is a blanket grant
+    like admin access and must not put the agent in every user's gallery."""
+    owner = create_test_user(db_session, "owner")
+    stranger = create_test_user(db_session, "stranger")
+    persona = create_test_persona(
+        db_session,
+        owner,
+        is_public=True,
+        public_permission=PersonaSharePermission.EDITOR,
+    )
+    db_session.refresh(persona)
+
+    # The stranger can edit it org-wide (sharing UI reports EDITOR)...
+    assert (
+        get_persona_access_level(persona, stranger, set()) == PersonaAccessLevel.EDITOR
+    )
+    # ...but a blanket public-editor grant is not a "your" agent.
+    assert not user_owns_or_directly_edits(persona, stranger, set())
+    assert user_owns_or_directly_edits(persona, owner, set())
 
 
 def test_sharing_status_derivation(db_session: Session) -> None:

--- a/web/src/lib/agents/types.ts
+++ b/web/src/lib/agents/types.ts
@@ -78,6 +78,9 @@ export interface MinimalAgent {
   owner_group: PersonaOwnerGroup | null;
   // Requesting user's computed access, set by the list/detail endpoints
   user_permission: PersonaAccessLevel | null;
+  // Owner or direct user/group editor, excluding org-wide grants (admin,
+  // public-editor). Set by the list endpoint to populate the "Your Agents" tab
+  user_is_owner_or_editor?: boolean;
 }
 
 export interface Agent extends MinimalAgent {

--- a/web/src/lib/agents/types.ts
+++ b/web/src/lib/agents/types.ts
@@ -81,6 +81,9 @@ export interface MinimalAgent {
   owner_group: PersonaOwnerGroup | null;
   // Requesting user's computed access, set by the list/detail endpoints
   user_permission: PersonaAccessLevel | null;
+  // Owner or direct user/group editor, excluding org-wide grants (manage-agents,
+  // public-editor). Set by the list endpoint to populate the "Your Agents" tab.
+  user_is_owner_or_editor?: boolean;
 }
 
 export interface Agent extends MinimalAgent {

--- a/web/src/lib/agents/utils.ts
+++ b/web/src/lib/agents/utils.ts
@@ -39,6 +39,22 @@ export function checkUserCanEditAgent(
   return agent.owner?.id === user.id;
 }
 
+/**
+ * Returns true if the user owns the agent or holds a direct user/group edit
+ * share, the basis for the "Your Agents" tab. Org-wide edit grants everyone
+ * holds (admin role, public-editor) are excluded via the server-computed
+ * `user_is_owner_or_editor` flag. Builtin agents are never "yours". The no-auth
+ * user owns everything.
+ */
+export function checkUserOwnsOrEditsAgent(
+  user: User | null,
+  agent: MinimalAgent | Agent
+): boolean {
+  if (!user || agent.builtin_persona) return false;
+  if (checkUserIsNoAuthUser(user.id)) return true;
+  return agent.user_is_owner_or_editor ?? false;
+}
+
 // TODO(ENG-3766): rename to agent
 /** Returns the URL for an agent's avatar image. */
 export function buildAgentAvatarUrl(agentId: number) {

--- a/web/src/lib/agents/utils.ts
+++ b/web/src/lib/agents/utils.ts
@@ -40,6 +40,25 @@ export function checkUserCanEditAgent(
   return agent.owner?.id === user.id;
 }
 
+/**
+ * Returns true if the user owns the agent or holds a direct user/group edit
+ * share, the basis for the "Your Agents" tab. Org-wide edit grants everyone
+ * holds (manage-agents, public-editor) are excluded via the server-computed
+ * `user_is_owner_or_editor` flag. Builtin agents are never "yours". The no-auth
+ * user owns everything.
+ */
+export function checkUserOwnsOrEditsAgent(
+  user: User | null,
+  agent: MinimalAgent | Agent
+): boolean {
+  if (!user || agent.builtin_persona) return false;
+  if (checkUserIsNoAuthUser(user.id)) return true;
+  // Payloads that don't stamp the flag (e.g. the detail endpoint) fall back to
+  // ownership so owners never see an empty tab. Ownership only, so manage-agents
+  // holders don't get every agent.
+  return agent.user_is_owner_or_editor ?? agent.owner?.id === user.id;
+}
+
 // TODO(ENG-3766): rename to agent
 /** Returns the URL for an agent's avatar image. */
 export function buildAgentAvatarUrl(agentId: number) {

--- a/web/src/views/AgentsNavigationPage.tsx
+++ b/web/src/views/AgentsNavigationPage.tsx
@@ -3,7 +3,7 @@
 import { useMemo, useState, useRef } from "react";
 import AgentCard from "@/sections/agents/AgentCard";
 import { useUser } from "@/providers/UserProvider";
-import { checkUserOwnsAgent } from "@/lib/agents/utils";
+import { checkUserOwnsOrEditsAgent } from "@/lib/agents/utils";
 import { useAgents } from "@/lib/agents/hooks";
 import { MinimalAgent } from "@/lib/agents/types";
 import Text from "@/refresh-components/texts/Text";
@@ -73,7 +73,7 @@ export default function AgentsNavigationPage() {
       );
 
       const mineFilter =
-        activeTab === "your" ? checkUserOwnsAgent(user, agent) : true;
+        activeTab === "your" ? checkUserOwnsOrEditsAgent(user, agent) : true;
 
       return (nameMatches || labelMatches) && mineFilter;
     });
@@ -82,11 +82,11 @@ export default function AgentsNavigationPage() {
   const featuredAgents = memoizedCurrentlyVisibleAgents.filter(
     (agent) => agent.is_featured
   );
-  const allAgents = memoizedCurrentlyVisibleAgents.filter(
+  const nonFeaturedAgents = memoizedCurrentlyVisibleAgents.filter(
     (agent) => !agent.is_featured
   );
 
-  const agentCount = featuredAgents.length + allAgents.length;
+  const agentCount = featuredAgents.length + nonFeaturedAgents.length;
 
   return (
     <SettingsLayouts.Root
@@ -151,7 +151,10 @@ export default function AgentsNavigationPage() {
               description="Curated by your team"
               agents={featuredAgents}
             />
-            <AgentsSection title="All Agents" agents={allAgents} />
+            <AgentsSection
+              title={activeTab === "your" ? "Your Agents" : "All Agents"}
+              agents={nonFeaturedAgents}
+            />
             <TextSeparator
               count={agentCount}
               text={agentCount === 1 ? "Agent" : "Agents"}

--- a/web/src/views/AgentsNavigationPage.tsx
+++ b/web/src/views/AgentsNavigationPage.tsx
@@ -5,7 +5,7 @@ import AgentCard from "@/sections/agents/AgentCard";
 import { useUser } from "@/providers/UserProvider";
 import { hasPermission } from "@/lib/permissions";
 import { Permission } from "@/lib/types";
-import { checkUserOwnsAgent } from "@/lib/agents/utils";
+import { checkUserOwnsOrEditsAgent } from "@/lib/agents/utils";
 import { useAgents } from "@/lib/agents/hooks";
 import { MinimalAgent } from "@/lib/agents/types";
 import Text from "@/refresh-components/texts/Text";
@@ -76,7 +76,7 @@ export default function AgentsNavigationPage() {
       );
 
       const mineFilter =
-        activeTab === "your" ? checkUserOwnsAgent(user, agent) : true;
+        activeTab === "your" ? checkUserOwnsOrEditsAgent(user, agent) : true;
 
       return (nameMatches || labelMatches) && mineFilter;
     });
@@ -85,11 +85,11 @@ export default function AgentsNavigationPage() {
   const featuredAgents = memoizedCurrentlyVisibleAgents.filter(
     (agent) => agent.is_featured
   );
-  const allAgents = memoizedCurrentlyVisibleAgents.filter(
+  const nonFeaturedAgents = memoizedCurrentlyVisibleAgents.filter(
     (agent) => !agent.is_featured
   );
 
-  const agentCount = featuredAgents.length + allAgents.length;
+  const agentCount = featuredAgents.length + nonFeaturedAgents.length;
 
   return (
     <SettingsLayouts.Root
@@ -160,7 +160,10 @@ export default function AgentsNavigationPage() {
               description="Curated by your team"
               agents={featuredAgents}
             />
-            <AgentsSection title="All Agents" agents={allAgents} />
+            <AgentsSection
+              title={activeTab === "your" ? "Your Agents" : "All Agents"}
+              agents={nonFeaturedAgents}
+            />
             <TextSeparator
               count={agentCount}
               text={agentCount === 1 ? "Agent" : "Agents"}


### PR DESCRIPTION
## Description

The "Your Agents" tab listed only agents you *own*, and its section header always read "All Agents". Filtering by edit-access alone doesn't work — admins are EDITOR on every agent, so that would list every agent for an admin.

Fix:
- Backend: new server-computed `user_is_owner_or_editor` flag on the agent-list payload — true for owners and explicit editor shares, with admins' blanket access excluded (`get_persona_access_level(..., treat_admin_as_editor=False)`).
- Frontend: the "your" tab filters by that flag; the section header reads "Your Agents" on that tab.

Note: a public agent with `public_permission=EDITOR` counts as "yours" for everyone (literal reading of "have EDIT access"). Trivial to drop if undesired.

## How Has This Been Tested?

<!--- reviewer to fill --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check