### PR TITLE
fix(agent-sharing): owner and current user can't be added as a share

### DIFF
--- a/web/src/sections/modals/ShareAgentModal.tsx
+++ b/web/src/sections/modals/ShareAgentModal.tsx
@@ -343,14 +343,20 @@ export default function ShareAgentModal({
     serializeDraftState(effectiveState) !==
     serializeDraftState(modalInitialState);
 
-  const existingUserIds = useMemo(
-    () => new Set(draftState.userShares.map((share) => share.user.id)),
-    [draftState.userShares]
-  );
-  const existingGroupIds = useMemo(
-    () => new Set(draftState.groupShares.map((share) => share.group_id)),
-    [draftState.groupShares]
-  );
+  // Owner / Edit / View are mutually exclusive: the owner, owner group, and
+  // current user (the implicit owner in create mode) can't also be a share, so
+  // seed their ids to keep the picker from offering them again.
+  const existingUserIds = useMemo(() => {
+    const ids = new Set(draftState.userShares.map((share) => share.user.id));
+    if (agent?.owner) ids.add(agent.owner.id);
+    if (currentUser) ids.add(currentUser.id);
+    return ids;
+  }, [agent?.owner, currentUser, draftState.userShares]);
+  const existingGroupIds = useMemo(() => {
+    const ids = new Set(draftState.groupShares.map((share) => share.group_id));
+    if (agent?.owner_group) ids.add(agent.owner_group.id);
+    return ids;
+  }, [agent?.owner_group, draftState.groupShares]);
 
   const agentName = agent?.name ?? "Agent";
 


### PR DESCRIPTION
## Description

The Add People picker only deduped against existing draft shares, so the agent owner — or yourself in create mode — could be added as an editor/viewer. Owner / Edit / View are meant to be mutually exclusive.

Seed the owner, owner group, and current user into the picker's existing-id sets so they're treated as already-shared and can't be added twice.

## How Has This Been Tested?

<!--- reviewer to fill --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check