### PR TITLE
fix(craft): preserve contextvars in announce-merge producer threads

### DIFF
--- a/backend/onyx/server/features/build/session/streaming.py
+++ b/backend/onyx/server/features/build/session/streaming.py
@@ -54,6 +54,7 @@ from onyx.server.features.build.sandbox.opencode.serve_client import _merge_fiel
 from onyx.server.features.build.sandbox.sse import SSEKeepalive
 from onyx.utils.logger import setup_logger
 from onyx.utils.threadpool_concurrency import start_thread_with_context
+from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 
 logger = setup_logger()
 
@@ -275,6 +276,12 @@ def merge_events_with_announces(
     done_sentinel = object()
 
     def drive_events() -> None:
+        logger.debug(
+            "[ANNOUNCE-MERGE] drive_events thread=%s session_id=%s observed_tenant=%s",
+            threading.current_thread().name,
+            session_id,
+            CURRENT_TENANT_ID_CONTEXTVAR.get(),
+        )
         try:
             for evt in event_iter:
                 output.put(evt)
@@ -305,6 +312,12 @@ def merge_events_with_announces(
     # Spawn via the context-preserving helper so the event iterator's lazy
     # tenant-scoped DB access (e.g. event-bus creation) sees the caller's
     # contextvars instead of raising "Tenant ID is not set".
+    logger.debug(
+        "[ANNOUNCE-MERGE] spawning producers thread=%s session_id=%s expected_tenant=%s",
+        threading.current_thread().name,
+        session_id,
+        tenant_id,
+    )
     start_thread_with_context(
         drive_events, name=f"events-pump-{session_id}", daemon=True
     )

--- a/backend/onyx/server/features/build/session/streaming.py
+++ b/backend/onyx/server/features/build/session/streaming.py
@@ -53,7 +53,7 @@ from onyx.server.features.build.sandbox.event_schema import ToolCallStart
 from onyx.server.features.build.sandbox.opencode.serve_client import _merge_field_meta
 from onyx.server.features.build.sandbox.sse import SSEKeepalive
 from onyx.utils.logger import setup_logger
-from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
+from onyx.utils.threadpool_concurrency import start_thread_with_context
 
 logger = setup_logger()
 
@@ -275,17 +275,12 @@ def merge_events_with_announces(
     done_sentinel = object()
 
     def drive_events() -> None:
-        # New threads don't inherit contextvars; re-set the tenant so DB access
-        # inside the event iterator (e.g. lazy event-bus creation) resolves the
-        # right schema instead of raising "Tenant ID is not set".
-        token = CURRENT_TENANT_ID_CONTEXTVAR.set(tenant_id)
         try:
             for evt in event_iter:
                 output.put(evt)
         except Exception as e:
             output.put(e)
         finally:
-            CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
             output.put(done_sentinel)
 
     def drive_announces() -> None:
@@ -307,16 +302,15 @@ def merge_events_with_announces(
                 ApprovalRequestedPacket(approval_id=approval_id, session_id=session_id)
             )
 
-    events_thread = threading.Thread(
-        target=drive_events, name=f"events-pump-{session_id}", daemon=True
+    # Spawn via the context-preserving helper so the event iterator's lazy
+    # tenant-scoped DB access (e.g. event-bus creation) sees the caller's
+    # contextvars instead of raising "Tenant ID is not set".
+    start_thread_with_context(
+        drive_events, name=f"events-pump-{session_id}", daemon=True
     )
-    announce_thread = threading.Thread(
-        target=drive_announces,
-        name=f"announce-pump-{session_id}",
-        daemon=True,
+    start_thread_with_context(
+        drive_announces, name=f"announce-pump-{session_id}", daemon=True
     )
-    events_thread.start()
-    announce_thread.start()
     try:
         while True:
             item = output.get()

--- a/backend/onyx/server/features/build/session/streaming.py
+++ b/backend/onyx/server/features/build/session/streaming.py
@@ -53,6 +53,7 @@ from onyx.server.features.build.sandbox.event_schema import ToolCallStart
 from onyx.server.features.build.sandbox.opencode.serve_client import _merge_field_meta
 from onyx.server.features.build.sandbox.sse import SSEKeepalive
 from onyx.utils.logger import setup_logger
+from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 
 logger = setup_logger()
 
@@ -274,12 +275,17 @@ def merge_events_with_announces(
     done_sentinel = object()
 
     def drive_events() -> None:
+        # New threads don't inherit contextvars; re-set the tenant so DB access
+        # inside the event iterator (e.g. lazy event-bus creation) resolves the
+        # right schema instead of raising "Tenant ID is not set".
+        token = CURRENT_TENANT_ID_CONTEXTVAR.set(tenant_id)
         try:
             for evt in event_iter:
                 output.put(evt)
         except Exception as e:
             output.put(e)
         finally:
+            CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
             output.put(done_sentinel)
 
     def drive_announces() -> None:

--- a/backend/onyx/utils/threadpool_concurrency.py
+++ b/backend/onyx/utils/threadpool_concurrency.py
@@ -482,6 +482,32 @@ def run_multiple_in_background(
     return executor
 
 
+def start_thread_with_context(
+    target: Callable[..., Any],
+    *,
+    name: str | None = None,
+    daemon: bool = False,
+    args: tuple[Any, ...] = (),
+    kwargs: dict[str, Any] | None = None,
+) -> threading.Thread:
+    """Spawn a fire-and-forget thread that inherits the caller's contextvars
+    (tenant id, request id, trace context). A raw ``threading.Thread`` starts
+    with an empty context, so tenant-scoped DB access inside the thread would
+    raise "Tenant ID is not set".
+
+    Unlike ``run_in_background`` / ``run_multiple_in_background``, this is for
+    daemon producer threads that are never joined.
+    """
+    ctx = contextvars.copy_context()
+    thread = threading.Thread(
+        target=lambda: ctx.run(target, *args, **(kwargs or {})),
+        name=name,
+        daemon=daemon,
+    )
+    thread.start()
+    return thread
+
+
 class TimeoutThread(threading.Thread, Generic[R]):
     def __init__(
         self, timeout: float, func: Callable[..., R], *args: Any, **kwargs: Any

--- a/backend/tests/unit/onyx/server/features/build/session/test_streaming_announce_merge.py
+++ b/backend/tests/unit/onyx/server/features/build/session/test_streaming_announce_merge.py
@@ -1,0 +1,51 @@
+"""Tests for tenant-contextvar propagation in the announce-merge stream."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from onyx.server.features.build.session import streaming
+from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
+
+
+def test_drive_events_thread_inherits_tenant_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The events-pump thread must re-set the tenant contextvar so lazy DB
+    access inside the event iterator (e.g. event-bus creation) resolves the
+    right schema instead of raising "Tenant ID is not set"."""
+    monkeypatch.setattr(streaming, "get_cache_backend", lambda **_: object())
+    monkeypatch.setattr(
+        streaming.approval_cache,
+        "pop_announcement",
+        lambda *_a, **_k: None,
+    )
+
+    tenant_id = "tenant_abc"
+    seen_in_thread: list[str | None] = []
+
+    def event_iter() -> Generator[Any, None, None]:
+        # Runs in the spawned drive_events thread.
+        seen_in_thread.append(CURRENT_TENANT_ID_CONTEXTVAR.get())
+        yield "event-1"
+
+    # Ensure the calling thread has no tenant set so we only observe what
+    # drive_events explicitly propagated.
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set(None)
+    try:
+        events = list(
+            streaming.merge_events_with_announces(
+                event_iter(),
+                session_id=uuid4(),
+                tenant_id=tenant_id,
+            )
+        )
+    finally:
+        CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+
+    assert events == ["event-1"]
+    assert seen_in_thread == [tenant_id]

--- a/backend/tests/unit/onyx/server/features/build/session/test_streaming_announce_merge.py
+++ b/backend/tests/unit/onyx/server/features/build/session/test_streaming_announce_merge.py
@@ -12,12 +12,12 @@ from onyx.server.features.build.session import streaming
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 
 
-def test_drive_events_thread_inherits_tenant_id(
+def test_drive_events_thread_inherits_caller_tenant(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The events-pump thread must re-set the tenant contextvar so lazy DB
-    access inside the event iterator (e.g. event-bus creation) resolves the
-    right schema instead of raising "Tenant ID is not set"."""
+    """The events-pump thread is spawned via the context-preserving helper, so
+    lazy DB access inside the event iterator (e.g. event-bus creation) sees the
+    caller's tenant contextvar instead of raising "Tenant ID is not set"."""
     monkeypatch.setattr(streaming, "get_cache_backend", lambda **_: object())
     monkeypatch.setattr(
         streaming.approval_cache,
@@ -33,9 +33,9 @@ def test_drive_events_thread_inherits_tenant_id(
         seen_in_thread.append(CURRENT_TENANT_ID_CONTEXTVAR.get())
         yield "event-1"
 
-    # Ensure the calling thread has no tenant set so we only observe what
-    # drive_events explicitly propagated.
-    token = CURRENT_TENANT_ID_CONTEXTVAR.set(None)
+    # The helper snapshots the caller's context, so the spawned thread must
+    # observe the tenant set here — not the contextvar's default.
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set(tenant_id)
     try:
         events = list(
             streaming.merge_events_with_announces(

--- a/backend/tests/unit/onyx/utils/test_threadpool_contextvars.py
+++ b/backend/tests/unit/onyx/utils/test_threadpool_contextvars.py
@@ -6,6 +6,7 @@ from onyx.utils.threadpool_concurrency import run_functions_in_parallel
 from onyx.utils.threadpool_concurrency import run_functions_tuples_in_parallel
 from onyx.utils.threadpool_concurrency import run_in_background
 from onyx.utils.threadpool_concurrency import run_with_timeout
+from onyx.utils.threadpool_concurrency import start_thread_with_context
 from onyx.utils.threadpool_concurrency import wait_on_background
 
 # Create a test contextvar
@@ -167,3 +168,37 @@ def test_run_in_background_preserves_contextvar() -> None:
     finally:
         # Clean up
         test_var.reset(token)
+
+
+def test_start_thread_with_context_preserves_contextvar() -> None:
+    """Test that start_thread_with_context propagates the caller's contextvars
+    into the spawned daemon thread."""
+    seen: list[str] = []
+
+    def capture() -> None:
+        time.sleep(0.1)  # ensure we're really on another thread
+        seen.append(test_var.get())
+
+    token = test_var.set("background_value")
+    try:
+        thread = start_thread_with_context(capture, name="ctx-test", daemon=True)
+        thread.join(timeout=2.0)
+    finally:
+        test_var.reset(token)
+
+    assert seen == ["background_value"]
+
+
+def test_start_thread_with_context_passes_args() -> None:
+    """Test that args/kwargs are forwarded to the target."""
+    seen: list[tuple[str, str]] = []
+
+    def capture(positional: str, *, keyword: str) -> None:
+        seen.append((positional, keyword))
+
+    thread = start_thread_with_context(
+        capture, args=("pos",), kwargs={"keyword": "kw"}, daemon=True
+    )
+    thread.join(timeout=2.0)
+
+    assert seen == [("pos", "kw")]


### PR DESCRIPTION
## Description

Fixes the intermittent `RuntimeError: Tenant ID is not set` raised on the Craft SSE attach stream (`subscribe_to_opencode_session → get_session_with_current_tenant`).

**Root cause:** `merge_events_with_announces` (`backend/onyx/server/features/build/session/streaming.py`) drives the sandbox-event iterator in a spawned daemon thread. A raw `threading.Thread(target=fn)` starts with an **empty** contextvar context — it carries nothing from the caller. When the iterator lazily reached `get_session_with_current_tenant()` (e.g. `_get_or_create_event_bus` creating the pod event bus on first subscribe), the tenant was unset and `get_current_tenant_id()` raised in `MULTI_TENANT` mode. It was intermittent because the DB access only happens when the bus must be *created* in that thread.

**Fix:** Add `start_thread_with_context` to `threadpool_concurrency.py` — a fire-and-forget sibling to the existing `run_in_background` / `run_multiple_in_background`. It spawns the thread via `contextvars.copy_context().run(...)`, so the thread inherits **all** of the caller's contextvars (tenant id, request id, trace context), not just tenant. `merge_events_with_announces` now spawns both producer threads through it, and the manual single-contextvar `set/reset` disappears.

This matches the copy-context pattern already used throughout the codebase (`run_in_background`, `run_with_timeout`, `run_functions_*_in_parallel`, `run_async_sync_no_cancel`) and makes a raw `threading.Thread(target=...)` the thing to avoid — the next person spawning a producer thread gets context propagation for free instead of rediscovering this footgun per contextvar (it would otherwise have silently regressed trace/request-id observability next).

**Note on semantics:** `copy_context()` snapshots at spawn time, so the tenant must be set in the spawning thread — which it is here (the generator iterates on the request-context thread). `tenant_id` stays a parameter of `merge_events_with_announces` only because `drive_announces` passes it explicitly to `get_cache_backend(tenant_id=...)`.

## How Has This Been Tested?

- New `test_start_thread_with_context_preserves_contextvar` + `_passes_args` in `test_threadpool_contextvars.py` (alongside the existing copy-context tests) verify the helper propagates contextvars and forwards args/kwargs.
- `test_streaming_announce_merge.py` asserts the spawned `drive_events` thread observes the caller's tenant contextvar. Verified it **fails with a raw `threading.Thread`** (`'public' != 'tenant_abc'`) and passes with the helper.
- Full `build/session/` + `serve_transport` + `threadpool` unit suites: 94 passed.
- `ruff format`, `ruff check`, pre-commit (`ty` type check, lazy-imports) all clean.

### Follow-up (out of scope, noted for a reviewer)
Other raw-spawn sites have the same latent footgun and could migrate to `start_thread_with_context` later: `image_generation_tool.py`, `event_bus.py`, and `periodic_poller.py` (which currently re-sets tenant manually inside). Not touched here to keep the diff focused.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check