### PR TITLE
fix(craft): require ENABLE_CRAFT AND the PostHog flag to enable Craft

### DIFF
--- a/backend/onyx/server/features/build/utils.py
+++ b/backend/onyx/server/features/build/utils.py
@@ -114,18 +114,27 @@ def is_onyx_craft_enabled(user: User) -> bool:
     """
     Check if Onyx Craft (Build Mode) is enabled for the user.
 
-    Flag logic for "onyx-craft-enabled":
-    - Flag = True → enabled (Onyx Craft is available)
-    - Flag = False → disabled (Onyx Craft is not available)
-    - Flag = null/not found → disabled (Onyx Craft is not available)
+    Craft requires BOTH:
+    - ENABLE_CRAFT=true: the deployment wired the Craft infra (sandbox
+      namespace, RBAC, PodTemplate, egress proxy). Without it the feature
+      cannot function, so it gates everything.
+    - The "onyx-craft-enabled" PostHog flag (when a real provider is
+      configured): per-user/tenant rollout control. Only explicit True enables;
+      False/null/not-found disables.
 
-    Only explicit True enables the feature.
+    When no PostHog provider is configured (NoOp, e.g. self-hosted without
+    POSTHOG_API_KEY), ENABLE_CRAFT alone gates the feature.
     """
+    # ENABLE_CRAFT is a hard precondition: without the deploy-time infra,
+    # honoring the PostHog flag would expose a broken Craft experience.
+    if not ENABLE_CRAFT:
+        return False
+
     feature_flag_provider = get_default_feature_flag_provider()
 
-    # If no PostHog configured (NoOp provider), use ENABLE_CRAFT env var
+    # No PostHog configured (NoOp provider): ENABLE_CRAFT alone gates Craft.
     if isinstance(feature_flag_provider, NoOpFeatureFlagProvider):
-        return ENABLE_CRAFT
+        return True
 
     is_enabled = feature_flag_provider.feature_enabled_for_user_tenant(
         ONYX_CRAFT_ENABLED_FLAG,

--- a/backend/tests/unit/onyx/server/features/build/test_feature_gate.py
+++ b/backend/tests/unit/onyx/server/features/build/test_feature_gate.py
@@ -126,7 +126,6 @@ def test_env_false_short_circuits_without_consulting_provider(
             "get_current_tenant_id should not be called when ENABLE_CRAFT=False"
         ),
     )
-    provider = _StubPostHogProvider(enabled=True)
     monkeypatch.setattr(
         build_utils,
         "get_default_feature_flag_provider",
@@ -136,7 +135,6 @@ def test_env_false_short_circuits_without_consulting_provider(
     )
 
     assert is_onyx_craft_enabled(_make_user()) is False
-    assert provider.calls == []
 
 
 def test_posthog_flag_disables_when_false(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/backend/tests/unit/onyx/server/features/build/test_feature_gate.py
+++ b/backend/tests/unit/onyx/server/features/build/test_feature_gate.py
@@ -1,10 +1,12 @@
 """Feature gating tests.
 
-`is_onyx_craft_enabled` decides whether a user sees Craft. The decision
-collapses two inputs: the `ENABLE_CRAFT` env var (used when no real feature
-flag provider is configured) and the PostHog `onyx-craft-enabled` flag
-(used otherwise). These tests pin the precedence: PostHog wins when present,
-env is the fallback when no provider is wired up.
+`is_onyx_craft_enabled` decides whether a user sees Craft. The decision ANDs
+two inputs: the `ENABLE_CRAFT` env var (a hard precondition — the deploy must
+have wired the Craft infra) and the PostHog `onyx-craft-enabled` flag (per-user
+rollout, consulted only when a real provider is configured). These tests pin
+that contract: ENABLE_CRAFT=False short-circuits to disabled without consulting
+PostHog; when ENABLE_CRAFT=True the PostHog verdict decides (or env alone gates
+when no provider is wired up).
 """
 
 from __future__ import annotations
@@ -89,9 +91,11 @@ def test_enabled_via_env_when_no_flag_provider(
     assert is_onyx_craft_enabled(_make_user()) is True
 
 
-def test_posthog_flag_overrides_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A real provider's verdict wins regardless of ENABLE_CRAFT."""
-    monkeypatch.setattr(build_utils, "ENABLE_CRAFT", False)
+def test_enabled_when_env_and_flag_both_true(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ENABLE_CRAFT=True and a real provider returning True -> enabled."""
+    monkeypatch.setattr(build_utils, "ENABLE_CRAFT", True)
     monkeypatch.setattr(build_utils, "get_current_tenant_id", lambda: "tenant_dev")
     provider = _StubPostHogProvider(enabled=True)
     monkeypatch.setattr(
@@ -108,6 +112,31 @@ def test_posthog_flag_overrides_env(monkeypatch: pytest.MonkeyPatch) -> None:
             {"tenant_id": "tenant_dev", "email": "user@tenant-dev.example"},
         )
     ]
+
+
+def test_env_false_short_circuits_without_consulting_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ENABLE_CRAFT=False disables Craft and never consults PostHog."""
+    monkeypatch.setattr(build_utils, "ENABLE_CRAFT", False)
+    monkeypatch.setattr(
+        build_utils,
+        "get_current_tenant_id",
+        lambda: pytest.fail(
+            "get_current_tenant_id should not be called when ENABLE_CRAFT=False"
+        ),
+    )
+    provider = _StubPostHogProvider(enabled=True)
+    monkeypatch.setattr(
+        build_utils,
+        "get_default_feature_flag_provider",
+        lambda: pytest.fail(
+            "the flag provider should not be consulted when ENABLE_CRAFT=False"
+        ),
+    )
+
+    assert is_onyx_craft_enabled(_make_user()) is False
+    assert provider.calls == []
 
 
 def test_posthog_flag_disables_when_false(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Description

`is_onyx_craft_enabled` is the single gate for Craft (Build Mode) — it backs the `/build/*` router dependency, the `onyx_craft_enabled` field in `/settings`, and the build-mode intro notification.

Today, when a real PostHog provider is configured (multi-tenant / cloud), the gate consults **only** the `onyx-craft-enabled` flag and **ignores `ENABLE_CRAFT` entirely**. So on a cluster with `POSTHOG_API_KEY` set, `ENABLE_CRAFT=true` is effectively a no-op for user access — the flag alone decides.

The problem: `ENABLE_CRAFT` is what wires the deploy-time Craft infra (the `onyx-sandboxes` namespace, sandbox RBAC, the `sandbox-pod` PodTemplate, and the egress proxy — all rendered conditionally on `ENABLE_CRAFT=true` in the Helm chart). If the PostHog flag is flipped on for a deployment where `ENABLE_CRAFT=false`, users get Craft UI but sandbox provisioning fails — a broken experience.

This PR makes `ENABLE_CRAFT` a hard precondition that is **ANDed** with the flag:

- `ENABLE_CRAFT=false` → disabled, short-circuit (PostHog is **not** consulted — also saves a network round-trip)
- `ENABLE_CRAFT=true` + NoOp provider (no `POSTHOG_API_KEY`) → env alone gates (unchanged behavior)
- `ENABLE_CRAFT=true` + real provider → the `onyx-craft-enabled` flag decides (per-user/tenant rollout)

No infra changes — the Helm chart already gates sandbox infra on `ENABLE_CRAFT`. This just aligns the runtime access check with that precondition.

## How Has This Been Tested?

Updated unit tests in `backend/tests/unit/onyx/server/features/build/test_feature_gate.py` to pin the AND contract, including a new test asserting `ENABLE_CRAFT=false` short-circuits without consulting the provider. All 5 pass; `test_startup_validation.py` (also touches `ENABLE_CRAFT`) still green; ruff format + check clean.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require both `ENABLE_CRAFT` and the PostHog `onyx-craft-enabled` flag to enable Craft, so the UI only appears when the deploy-time sandbox infra is present. Short-circuits when `ENABLE_CRAFT=false` and skips PostHog.

- **Bug Fixes**
  - With NoOp provider (no `POSTHOG_API_KEY`), `ENABLE_CRAFT=true` alone enables Craft; PostHog isn’t consulted.
  - With a real provider, the flag decides when `ENABLE_CRAFT=true`; only explicit True enables.
  - Tests: added a short-circuit test and removed a dead provider-stub assertion.

<sup>Written for commit 3a17542a8bad5bc9ff182ddba8b6158fe570ed26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

