### PR TITLE
fix(sandbox-proxy): block sandbox egress relay to internal destinations

### DIFF
--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -122,33 +122,24 @@ def _ip_is_internal(ip_str: str) -> bool:
     return not ip.is_global
 
 
-def classify_destination(host: str, port: int) -> tuple[bool, str | None]:
-    """Resolve ``host`` once and classify it for egress.
+def destination_is_blocked(host: str, port: int) -> bool:
+    """True if the sandbox must not be relayed to ``host:port``.
 
-    Returns ``(blocked, pin_ip)``:
-
-    - ``blocked`` — the sandbox must not be relayed here. Denied: anything that
-      is, or resolves to, an internal address. Allowed: the api-server (host +
-      port) and any public address. Fail closed: a resolution failure denies
-      (with a warning) — a transient resolver error must not become an opening
-      to an internal service.
-    - ``pin_ip`` — the single vetted public IP the caller should pin the upstream
-      connection to so mitmproxy can't re-resolve the name to an internal address
-      (DNS rebinding). ``None`` when there is nothing to pin: a literal-IP
-      destination, the api-server, or a blocked/unresolvable host.
-
-    Resolving here exactly once — and connecting to the returned ``pin_ip`` — is
-    what makes the guard rebinding-proof: there is no second name lookup between
-    the check and the connect.
+    Denied: anything that is, or resolves to, an internal address. Allowed: the
+    api-server (host + port) and any public address. Fail closed: a resolution
+    failure denies (with a warning) — a transient resolver error must not become
+    an opening to an internal service. If a name resolves to a mix of public and
+    internal addresses, deny — an attacker could otherwise steer the connection
+    to the internal one.
     """
     host = (host or "").strip().lower()
     if not host:
-        return False, None
+        return False
     if _is_api_server(host, port):
-        return False, None
+        return False
     try:
         ipaddress.ip_address(host)  # literal-IP destination: check directly, no DNS
-        return _ip_is_internal(host), None
+        return _ip_is_internal(host)
     except ValueError:
         pass
     try:
@@ -157,18 +148,10 @@ def classify_destination(host: str, port: int) -> tuple[bool, str | None]:
         logger.warning(
             "egress_destination_resolution_failed host=%s error=%s", host, exc
         )
-        return True, None
+        return True
     # getaddrinfo types sockaddr[0] as `str | int`; the address element is always
     # a str at runtime (AF_INET/AF_INET6), so coerce to satisfy the type checker.
-    ips = [str(info[4][0]) for info in infos]
-    if any(_ip_is_internal(ip) for ip in ips):
-        return True, None
-    return False, ips[0] if ips else None
-
-
-def destination_is_blocked(host: str, port: int) -> bool:
-    """True if the sandbox must not be relayed to ``host:port``."""
-    return classify_destination(host, port)[0]
+    return any(_ip_is_internal(str(info[4][0])) for info in infos)
 
 
 class _IdentityResolver(Protocol):
@@ -322,29 +305,31 @@ class GateAddon:
             self._conn_session_tags.pop(conn_id, None)
 
     async def server_connect(self, data: server_hooks.ServerConnectionHookData) -> None:
-        """Authoritatively enforce the internal-destination boundary, rebinding-proof.
+        """Deny internal destinations at connection-setup time (backstop).
 
-        This is the last hook before mitmproxy opens the upstream socket. We resolve
-        the destination here exactly once and act on that single result:
+        Last hook before mitmproxy opens the upstream. Re-checking here — closer to
+        the actual connect than the earlier `http_connect`/`request` denies — shrinks
+        the DNS-rebinding window where a host that vetted as public re-resolves to an
+        internal address. A deny is a TCP-level kill (`server.error`); the structured
+        `destination_blocked` 403 is delivered by the `http_connect`/`request` checks
+        for every normal request.
 
-        - internal → kill the connection (`server.error`). This is a TCP-level deny;
-          the structured `destination_blocked` 403 is delivered by the earlier
-          `http_connect`/`request` checks for every normal request. Reaching a deny
-          *here* means the name re-resolved to an internal address after those checks
-          saw it as public (a genuine DNS-rebind) — a rare backstop case where a
-          connection error, not a 403, is the only signal available at this layer.
-        - public → pin `server.address` to the resolved IP so mitmproxy connects to
-          exactly the address we vetted instead of re-resolving the name (which is
-          what the rebinding attack exploits). `server.sni` was already set to the
-          hostname before this hook fires, so TLS interception — and therefore
-          credential injection — keeps working even though we connect by IP.
+        We deliberately do NOT pin `server.address` to the resolved IP. Under the
+        default `eager` connection strategy mitmproxy completes the upstream TLS
+        handshake before the client's ClientHello is available; connecting by bare IP
+        makes the upstream cert check fail and mitmproxy silently falls back to a raw
+        passthrough tunnel — which skips credential injection (the LLM provider key is
+        never swapped in, so the sandbox's placeholder leaks and the call 401s).
+        Leaving the hostname in place keeps interception (and key injection) working.
+        The cost is a residual rebind window between this resolution and mitmproxy's
+        own: accepted as the safe trade-off versus breaking credential injection.
         """
         server = data.server
         if server.error or not server.address:
             return
         host, port = server.address[0], server.address[1]
-        blocked, pin_ip = await asyncio.get_running_loop().run_in_executor(
-            None, classify_destination, host, port
+        blocked = await asyncio.get_running_loop().run_in_executor(
+            None, destination_is_blocked, host, port
         )
         if blocked:
             logger.info(
@@ -353,10 +338,6 @@ class GateAddon:
                 port,
             )
             server.error = "destination_blocked: internal address"
-            return
-        if pin_ip is not None and pin_ip != host:
-            server.sni = server.sni or host
-            server.address = (pin_ip, port)
 
     def responseheaders(self, flow: http.HTTPFlow) -> None:
         """

--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -7,16 +7,20 @@ Fail-open: `RequestEvaluator` exceptions and non-matching action types.
 import asyncio
 import base64
 import binascii
+import ipaddress
 import operator
+import socket
 import threading
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Protocol
+from urllib.parse import urlparse
 from uuid import UUID
 
 from cachetools import cachedmethod
 from cachetools import TTLCache
 from mitmproxy import http
+from mitmproxy.proxy import server_hooks
 from sqlalchemy.orm import Session
 
 from onyx.cache.interface import CACHE_TRANSIENT_ERRORS
@@ -54,6 +58,7 @@ from onyx.sandbox_proxy.logging_utils import full_log_id
 from onyx.sandbox_proxy.logging_utils import sandbox_log_label
 from onyx.sandbox_proxy.logging_utils import short_log_id
 from onyx.sandbox_proxy.request_evaluator import RequestEvaluator
+from onyx.server.features.build.configs import SANDBOX_API_SERVER_URL
 from onyx.server.features.build.db import action_approval
 from onyx.utils.logger import setup_logger
 
@@ -61,6 +66,71 @@ logger = setup_logger()
 
 # Bodies over this cap are fail-closed (rejected), not parsed by the matcher.
 PARSER_MAX_BODY_BYTES = 1_048_576
+
+
+# --- internal-destination egress lockdown (Fix 1: closes the proxy-relay path) ---
+# A sandbox can only egress via the proxy, so the proxy is the single layer that can
+# stop it relaying (CONNECT-tunneling) to internal services (databases, caches, search,
+# metadata endpoints) — that destination is invisible at the sandbox's own egress (it sees
+# "TCP to proxy:8080"). Deny any forwarded destination that is, or resolves to, an
+# internal address; allow the one legitimate internal exception (the api-server) plus
+# the public internet. Keying off "not globally routable" — not a hostname allow-list —
+# catches internal services we never enumerated. The proxy's OWN cred-resolution DB
+# client connects directly (not through the mitmproxy listener), so it is unaffected here.
+
+# The single allowed internal destination: the api-server the sandbox calls via the
+# proxy (PAT-injected). Matched by hostname so it works even when it's an in-cluster
+# name resolving to an internal IP.
+_API_SERVER_HOST = (
+    ((urlparse(SANDBOX_API_SERVER_URL).hostname or "").lower() or None)
+    if SANDBOX_API_SERVER_URL
+    else None
+)
+
+
+def _ip_is_internal(ip_str: str) -> bool:
+    """True if ``ip_str`` is not a globally-routable public address.
+
+    `is_global` covers far more than RFC1918: CGNAT (100.64.0.0/10 — EKS pod IPs
+    under custom networking), loopback, link-local (incl. cloud metadata / IMDS),
+    IPv6 ULA (fc00::/7) + link-local (fe80::/10) + loopback (::1), and reserved
+    ranges. IPv4-mapped IPv6 (``::ffff:10.0.0.1``) is judged by its embedded IPv4
+    so it can't be used to smuggle an internal v4 address past the check.
+    """
+    try:
+        ip = ipaddress.ip_address(ip_str)
+    except ValueError:
+        return False
+    mapped = getattr(ip, "ipv4_mapped", None)
+    if mapped is not None:
+        ip = mapped
+    return not ip.is_global
+
+
+def destination_is_blocked(host: str) -> bool:
+    """True if the sandbox must not be relayed to ``host``.
+
+    Allowed: the api-server host and any public address. Denied: anything that is,
+    or resolves to, an internal address. An unresolvable host is allowed — the
+    upstream connection would fail anyway, so there is no internal target to protect.
+    """
+    host = (host or "").strip().lower()
+    if not host:
+        return False
+    if _API_SERVER_HOST and host == _API_SERVER_HOST:
+        return False
+    try:
+        ipaddress.ip_address(host)  # literal-IP destination: check directly, no DNS
+        return _ip_is_internal(host)
+    except ValueError:
+        pass
+    try:
+        infos = socket.getaddrinfo(host, None, proto=socket.IPPROTO_TCP)
+    except OSError:
+        return False
+    # getaddrinfo types sockaddr[0] as `str | int`; the address element is always
+    # a str at runtime (AF_INET/AF_INET6), so coerce to satisfy the type checker.
+    return any(_ip_is_internal(str(info[4][0])) for info in infos)
 
 
 class _IdentityResolver(Protocol):
@@ -173,6 +243,21 @@ class GateAddon:
         connection id (one tunnel per subprocess = one session); evicted in
         `client_disconnected`. Best-effort.
         """
+        # Fix 1: refuse to open a tunnel to an internal address, with a clear 403 the
+        # agent can act on. This is a best-effort early deny on the CONNECT host; the
+        # authoritative, rebinding-proof enforcement + IP pin runs in `server_connect`
+        # on the actually-resolved peer. We do NOT rewrite flow.request.host here:
+        # repointing the CONNECT to a bare IP disables mitmproxy's TLS interception,
+        # which would skip credential injection on the decrypted inner request.
+        if destination_is_blocked(flow.request.host):
+            logger.info(
+                "egress_denied_internal_destination phase=connect host=%s port=%s",
+                flow.request.host,
+                flow.request.port,
+            )
+            flow.response = http_403(SandboxProxyError.DESTINATION_BLOCKED)
+            return
+
         conn_id = getattr(flow.client_conn, "id", None)
         auth_header = flow.request.headers.get("Proxy-Authorization")
         tag = _parse_proxy_auth_username(auth_header)
@@ -197,6 +282,37 @@ class GateAddon:
         if conn_id is not None:
             self._conn_session_tags.pop(conn_id, None)
 
+    async def server_connect(self, data: server_hooks.ServerConnectionHookData) -> None:
+        """Fix 1: deny internal destinations at connection-setup time (backstop).
+
+        Runs for every upstream connection, just before mitmproxy resolves and opens
+        it. Re-checking the destination here — closer to the actual connect than the
+        earlier `http_connect`/`request` deny — shrinks the DNS-rebinding window in
+        which a host that vetted as public could re-resolve to an internal address.
+
+        We do NOT override `connection.address` to pin the resolved IP: under this
+        proxy's eager connection strategy mitmproxy opens the upstream (and, for an
+        intercepted host, completes its TLS handshake) before the client's ClientHello
+        is available, so a bare-IP address has no SNI, the upstream cert check fails,
+        and mitmproxy silently falls back to a raw passthrough tunnel — which skips
+        credential injection on the decrypted request. Leaving the hostname in place
+        keeps interception (and key injection) working; this hook only denies.
+        """
+        server = data.server
+        if server.error or not server.address:
+            return
+        host, port = server.address[0], server.address[1]
+        blocked = await asyncio.get_event_loop().run_in_executor(
+            None, destination_is_blocked, host
+        )
+        if blocked:
+            logger.info(
+                "egress_denied_internal_destination phase=server_connect host=%s port=%s",
+                host,
+                port,
+            )
+            server.error = "destination_blocked: internal address"
+
     def responseheaders(self, flow: http.HTTPFlow) -> None:
         """
         Streams the response body to the sandbox instead of buffering it whole.
@@ -213,6 +329,23 @@ class GateAddon:
         if task is not None:
             self._inflight_tasks.add(task)
             task.add_done_callback(self._inflight_tasks.discard)
+
+        # Fix 1: deny plain-HTTP forwards (GET http://internal/...) to internal
+        # addresses, with a clear 403. Best-effort early deny on the request host;
+        # `server_connect` is the authoritative rebinding-proof backstop + pin.
+        # Resolution can block, so run it off the event loop.
+        if (
+            flow.request.scheme == "http"
+            and await asyncio.get_event_loop().run_in_executor(
+                None, destination_is_blocked, flow.request.host
+            )
+        ):
+            logger.info(
+                "egress_denied_internal_destination phase=request host=%s",
+                flow.request.host,
+            )
+            flow.response = http_403(SandboxProxyError.DESTINATION_BLOCKED)
+            return
 
         gate_target = await self._resolve_and_match(flow)
         # Strip the in-band session tag so it never reaches the origin

--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -68,7 +68,7 @@ logger = setup_logger()
 PARSER_MAX_BODY_BYTES = 1_048_576
 
 
-# --- internal-destination egress lockdown (Fix 1: closes the proxy-relay path) ---
+# --- internal-destination egress lockdown: closes the proxy-relay path ---
 # A sandbox can only egress via the proxy, so the proxy is the single layer that can
 # stop it relaying (CONNECT-tunneling) to internal services (databases, caches, search,
 # metadata endpoints) — that destination is invisible at the sandbox's own egress (it sees
@@ -243,7 +243,7 @@ class GateAddon:
         connection id (one tunnel per subprocess = one session); evicted in
         `client_disconnected`. Best-effort.
         """
-        # Fix 1: refuse to open a tunnel to an internal address, with a clear 403 the
+        # Refuse to open a tunnel to an internal address, with a clear 403 the
         # agent can act on. This is a best-effort early deny on the CONNECT host; the
         # authoritative, rebinding-proof enforcement + IP pin runs in `server_connect`
         # on the actually-resolved peer. We do NOT rewrite flow.request.host here:
@@ -283,7 +283,7 @@ class GateAddon:
             self._conn_session_tags.pop(conn_id, None)
 
     async def server_connect(self, data: server_hooks.ServerConnectionHookData) -> None:
-        """Fix 1: deny internal destinations at connection-setup time (backstop).
+        """Deny internal destinations at connection-setup time (backstop).
 
         Runs for every upstream connection, just before mitmproxy resolves and opens
         it. Re-checking the destination here — closer to the actual connect than the
@@ -330,7 +330,7 @@ class GateAddon:
             self._inflight_tasks.add(task)
             task.add_done_callback(self._inflight_tasks.discard)
 
-        # Fix 1: deny plain-HTTP forwards (GET http://internal/...) to internal
+        # Deny plain-HTTP forwards (GET http://internal/...) to internal
         # addresses, with a clear 403. Best-effort early deny on the request host;
         # `server_connect` is the authoritative rebinding-proof backstop + pin.
         # Resolution can block, so run it off the event loop.

--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -111,8 +111,9 @@ def destination_is_blocked(host: str) -> bool:
     """True if the sandbox must not be relayed to ``host``.
 
     Allowed: the api-server host and any public address. Denied: anything that is,
-    or resolves to, an internal address. An unresolvable host is allowed — the
-    upstream connection would fail anyway, so there is no internal target to protect.
+    or resolves to, an internal address. Fail closed: a resolution failure denies
+    (with a warning) rather than allowing relay — a transient resolver error must
+    not become an opening to an internal service.
     """
     host = (host or "").strip().lower()
     if not host:
@@ -126,8 +127,11 @@ def destination_is_blocked(host: str) -> bool:
         pass
     try:
         infos = socket.getaddrinfo(host, None, proto=socket.IPPROTO_TCP)
-    except OSError:
-        return False
+    except OSError as exc:
+        logger.warning(
+            "egress_destination_resolution_failed host=%s error=%s", host, exc
+        )
+        return True
     # getaddrinfo types sockaddr[0] as `str | int`; the address element is always
     # a str at runtime (AF_INET/AF_INET6), so coerce to satisfy the type checker.
     return any(_ip_is_internal(str(info[4][0])) for info in infos)
@@ -235,7 +239,7 @@ class GateAddon:
     # mitmproxy hooks
     # ------------------------------------------------------------------
 
-    def http_connect(self, flow: http.HTTPFlow) -> None:
+    async def http_connect(self, flow: http.HTTPFlow) -> None:
         """Capture the per-session tag from the CONNECT's Proxy-Authorization.
 
         For MITM'd HTTPS the header rides on the CONNECT, not the decrypted
@@ -245,11 +249,14 @@ class GateAddon:
         """
         # Refuse to open a tunnel to an internal address, with a clear 403 the
         # agent can act on. This is a best-effort early deny on the CONNECT host; the
-        # authoritative, rebinding-proof enforcement + IP pin runs in `server_connect`
-        # on the actually-resolved peer. We do NOT rewrite flow.request.host here:
-        # repointing the CONNECT to a bare IP disables mitmproxy's TLS interception,
-        # which would skip credential injection on the decrypted inner request.
-        if destination_is_blocked(flow.request.host):
+        # authoritative, rebinding-proof enforcement runs in `server_connect` on the
+        # actually-resolved peer. We do NOT rewrite flow.request.host here: repointing
+        # the CONNECT to a bare IP disables mitmproxy's TLS interception, which would
+        # skip credential injection on the decrypted inner request. The check can do a
+        # blocking DNS lookup, so run it off the event loop.
+        if await asyncio.get_running_loop().run_in_executor(
+            None, destination_is_blocked, flow.request.host
+        ):
             logger.info(
                 "egress_denied_internal_destination phase=connect host=%s port=%s",
                 flow.request.host,
@@ -302,7 +309,7 @@ class GateAddon:
         if server.error or not server.address:
             return
         host, port = server.address[0], server.address[1]
-        blocked = await asyncio.get_event_loop().run_in_executor(
+        blocked = await asyncio.get_running_loop().run_in_executor(
             None, destination_is_blocked, host
         )
         if blocked:
@@ -336,7 +343,7 @@ class GateAddon:
         # Resolution can block, so run it off the event loop.
         if (
             flow.request.scheme == "http"
-            and await asyncio.get_event_loop().run_in_executor(
+            and await asyncio.get_running_loop().run_in_executor(
                 None, destination_is_blocked, flow.request.host
             )
         ):

--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -78,14 +78,29 @@ PARSER_MAX_BODY_BYTES = 1_048_576
 # catches internal services we never enumerated. The proxy's OWN cred-resolution DB
 # client connects directly (not through the mitmproxy listener), so it is unaffected here.
 
+
 # The single allowed internal destination: the api-server the sandbox calls via the
-# proxy (PAT-injected). Matched by hostname so it works even when it's an in-cluster
-# name resolving to an internal IP.
-_API_SERVER_HOST = (
-    ((urlparse(SANDBOX_API_SERVER_URL).hostname or "").lower() or None)
-    if SANDBOX_API_SERVER_URL
-    else None
-)
+# proxy (PAT-injected). Matched by host AND port so it works even when it's an
+# in-cluster name resolving to an internal IP, while still denying every other port
+# on that host (e.g. a co-located Redis/Postgres reachable at the same hostname).
+def _parse_api_server() -> tuple[str | None, int | None]:
+    if not SANDBOX_API_SERVER_URL:
+        return None, None
+    parsed = urlparse(SANDBOX_API_SERVER_URL)
+    host = (parsed.hostname or "").lower() or None
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    return host, port
+
+
+_API_SERVER_HOST, _API_SERVER_PORT = _parse_api_server()
+
+
+def _is_api_server(host: str, port: int) -> bool:
+    return (
+        _API_SERVER_HOST is not None
+        and host == _API_SERVER_HOST
+        and port == _API_SERVER_PORT
+    )
 
 
 def _ip_is_internal(ip_str: str) -> bool:
@@ -107,34 +122,53 @@ def _ip_is_internal(ip_str: str) -> bool:
     return not ip.is_global
 
 
-def destination_is_blocked(host: str) -> bool:
-    """True if the sandbox must not be relayed to ``host``.
+def classify_destination(host: str, port: int) -> tuple[bool, str | None]:
+    """Resolve ``host`` once and classify it for egress.
 
-    Allowed: the api-server host and any public address. Denied: anything that is,
-    or resolves to, an internal address. Fail closed: a resolution failure denies
-    (with a warning) rather than allowing relay — a transient resolver error must
-    not become an opening to an internal service.
+    Returns ``(blocked, pin_ip)``:
+
+    - ``blocked`` — the sandbox must not be relayed here. Denied: anything that
+      is, or resolves to, an internal address. Allowed: the api-server (host +
+      port) and any public address. Fail closed: a resolution failure denies
+      (with a warning) — a transient resolver error must not become an opening
+      to an internal service.
+    - ``pin_ip`` — the single vetted public IP the caller should pin the upstream
+      connection to so mitmproxy can't re-resolve the name to an internal address
+      (DNS rebinding). ``None`` when there is nothing to pin: a literal-IP
+      destination, the api-server, or a blocked/unresolvable host.
+
+    Resolving here exactly once — and connecting to the returned ``pin_ip`` — is
+    what makes the guard rebinding-proof: there is no second name lookup between
+    the check and the connect.
     """
     host = (host or "").strip().lower()
     if not host:
-        return False
-    if _API_SERVER_HOST and host == _API_SERVER_HOST:
-        return False
+        return False, None
+    if _is_api_server(host, port):
+        return False, None
     try:
         ipaddress.ip_address(host)  # literal-IP destination: check directly, no DNS
-        return _ip_is_internal(host)
+        return _ip_is_internal(host), None
     except ValueError:
         pass
     try:
-        infos = socket.getaddrinfo(host, None, proto=socket.IPPROTO_TCP)
+        infos = socket.getaddrinfo(host, port, proto=socket.IPPROTO_TCP)
     except OSError as exc:
         logger.warning(
             "egress_destination_resolution_failed host=%s error=%s", host, exc
         )
-        return True
+        return True, None
     # getaddrinfo types sockaddr[0] as `str | int`; the address element is always
     # a str at runtime (AF_INET/AF_INET6), so coerce to satisfy the type checker.
-    return any(_ip_is_internal(str(info[4][0])) for info in infos)
+    ips = [str(info[4][0]) for info in infos]
+    if any(_ip_is_internal(ip) for ip in ips):
+        return True, None
+    return False, ips[0] if ips else None
+
+
+def destination_is_blocked(host: str, port: int) -> bool:
+    """True if the sandbox must not be relayed to ``host:port``."""
+    return classify_destination(host, port)[0]
 
 
 class _IdentityResolver(Protocol):
@@ -248,14 +282,12 @@ class GateAddon:
         `client_disconnected`. Best-effort.
         """
         # Refuse to open a tunnel to an internal address, with a clear 403 the
-        # agent can act on. This is a best-effort early deny on the CONNECT host; the
-        # authoritative, rebinding-proof enforcement runs in `server_connect` on the
-        # actually-resolved peer. We do NOT rewrite flow.request.host here: repointing
-        # the CONNECT to a bare IP disables mitmproxy's TLS interception, which would
-        # skip credential injection on the decrypted inner request. The check can do a
-        # blocking DNS lookup, so run it off the event loop.
+        # agent can act on. Best-effort early deny on the CONNECT host; the decrypted
+        # inner request is re-checked in `request`, and `server_connect` is the
+        # authoritative rebinding-proof enforcement (resolve-once + IP pin). The check
+        # can do a blocking DNS lookup, so run it off the event loop.
         if await asyncio.get_running_loop().run_in_executor(
-            None, destination_is_blocked, flow.request.host
+            None, destination_is_blocked, flow.request.host, flow.request.port
         ):
             logger.info(
                 "egress_denied_internal_destination phase=connect host=%s port=%s",
@@ -290,27 +322,29 @@ class GateAddon:
             self._conn_session_tags.pop(conn_id, None)
 
     async def server_connect(self, data: server_hooks.ServerConnectionHookData) -> None:
-        """Deny internal destinations at connection-setup time (backstop).
+        """Authoritatively enforce the internal-destination boundary, rebinding-proof.
 
-        Runs for every upstream connection, just before mitmproxy resolves and opens
-        it. Re-checking the destination here — closer to the actual connect than the
-        earlier `http_connect`/`request` deny — shrinks the DNS-rebinding window in
-        which a host that vetted as public could re-resolve to an internal address.
+        This is the last hook before mitmproxy opens the upstream socket. We resolve
+        the destination here exactly once and act on that single result:
 
-        We do NOT override `connection.address` to pin the resolved IP: under this
-        proxy's eager connection strategy mitmproxy opens the upstream (and, for an
-        intercepted host, completes its TLS handshake) before the client's ClientHello
-        is available, so a bare-IP address has no SNI, the upstream cert check fails,
-        and mitmproxy silently falls back to a raw passthrough tunnel — which skips
-        credential injection on the decrypted request. Leaving the hostname in place
-        keeps interception (and key injection) working; this hook only denies.
+        - internal → kill the connection (`server.error`). This is a TCP-level deny;
+          the structured `destination_blocked` 403 is delivered by the earlier
+          `http_connect`/`request` checks for every normal request. Reaching a deny
+          *here* means the name re-resolved to an internal address after those checks
+          saw it as public (a genuine DNS-rebind) — a rare backstop case where a
+          connection error, not a 403, is the only signal available at this layer.
+        - public → pin `server.address` to the resolved IP so mitmproxy connects to
+          exactly the address we vetted instead of re-resolving the name (which is
+          what the rebinding attack exploits). `server.sni` was already set to the
+          hostname before this hook fires, so TLS interception — and therefore
+          credential injection — keeps working even though we connect by IP.
         """
         server = data.server
         if server.error or not server.address:
             return
         host, port = server.address[0], server.address[1]
-        blocked = await asyncio.get_running_loop().run_in_executor(
-            None, destination_is_blocked, host
+        blocked, pin_ip = await asyncio.get_running_loop().run_in_executor(
+            None, classify_destination, host, port
         )
         if blocked:
             logger.info(
@@ -319,6 +353,10 @@ class GateAddon:
                 port,
             )
             server.error = "destination_blocked: internal address"
+            return
+        if pin_ip is not None and pin_ip != host:
+            server.sni = server.sni or host
+            server.address = (pin_ip, port)
 
     def responseheaders(self, flow: http.HTTPFlow) -> None:
         """
@@ -337,19 +375,18 @@ class GateAddon:
             self._inflight_tasks.add(task)
             task.add_done_callback(self._inflight_tasks.discard)
 
-        # Deny plain-HTTP forwards (GET http://internal/...) to internal
-        # addresses, with a clear 403. Best-effort early deny on the request host;
-        # `server_connect` is the authoritative rebinding-proof backstop + pin.
-        # Resolution can block, so run it off the event loop.
-        if (
-            flow.request.scheme == "http"
-            and await asyncio.get_running_loop().run_in_executor(
-                None, destination_is_blocked, flow.request.host
-            )
+        # Deny forwards to internal addresses with a clear 403 — both plain-HTTP
+        # (GET http://internal/...) and the decrypted inner request of a MITM'd
+        # HTTPS tunnel, so the structured error reaches the agent regardless of
+        # scheme. `server_connect` is the authoritative rebinding-proof backstop +
+        # pin. Resolution can block, so run it off the event loop.
+        if await asyncio.get_running_loop().run_in_executor(
+            None, destination_is_blocked, flow.request.host, flow.request.port
         ):
             logger.info(
-                "egress_denied_internal_destination phase=request host=%s",
+                "egress_denied_internal_destination phase=request host=%s port=%s",
                 flow.request.host,
+                flow.request.port,
             )
             flow.response = http_403(SandboxProxyError.DESTINATION_BLOCKED)
             return

--- a/backend/onyx/sandbox_proxy/errors.py
+++ b/backend/onyx/sandbox_proxy/errors.py
@@ -27,6 +27,7 @@ class SandboxProxyError(str, Enum):
     INTERNAL_ERROR = "internal_error"
     POLICY_DENIED = "policy_denied"
     CREDENTIAL_ERROR = "credential_error"
+    DESTINATION_BLOCKED = "destination_blocked"
 
     @property
     def message(self) -> str:
@@ -91,6 +92,13 @@ _SANDBOX_ERROR_MESSAGES: dict[SandboxProxyError, str] = {
         "its saved credentials have expired or been revoked. Ask the user to "
         "connect or reconnect this integration in their Craft settings, then "
         "retry."
+    ),
+    SandboxProxyError.DESTINATION_BLOCKED: (
+        "This request targets an internal network address that sandboxes are not "
+        "allowed to reach, so it was blocked before any connection was made. Only "
+        "the public internet and the Onyx API server are reachable from here. "
+        "This is a fixed security boundary, not a transient error — do not retry "
+        "against internal hosts (databases, caches, metadata endpoints, etc.)."
     ),
 }
 

--- a/backend/tests/unit/sandbox_proxy/test_gate.py
+++ b/backend/tests/unit/sandbox_proxy/test_gate.py
@@ -25,7 +25,9 @@ from uuid import UUID
 from uuid import uuid4
 
 import pytest
+from mitmproxy import connection
 from mitmproxy import http
+from mitmproxy.proxy import server_hooks
 from redis.exceptions import RedisError
 
 from onyx.db.enums import ApprovalDecidedVia
@@ -1006,7 +1008,7 @@ def test_parse_proxy_auth_username(header: str | None, expected: str | None) -> 
 async def test_http_connect_caches_tag_and_client_disconnected_evicts(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(gate, "destination_is_blocked", lambda _host: False)
+    monkeypatch.setattr(gate, "destination_is_blocked", lambda _host, _port: False)
     addon = _build(resolver=StubResolver(), matcher=_StubMatcher())
     flow = make_flow(conn_id="conn-xyz", proxy_auth=_basic_auth(_TAG_UUID))
 
@@ -1021,7 +1023,7 @@ async def test_http_connect_caches_tag_and_client_disconnected_evicts(
 async def test_http_connect_ignores_missing_or_garbled_header(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(gate, "destination_is_blocked", lambda _host: False)
+    monkeypatch.setattr(gate, "destination_is_blocked", lambda _host, _port: False)
     addon = _build(resolver=StubResolver(), matcher=_StubMatcher())
     await addon.http_connect(make_flow(conn_id="c1"))  # no Proxy-Authorization
     await addon.http_connect(make_flow(conn_id="c2", proxy_auth="Bearer nope"))
@@ -1033,16 +1035,16 @@ async def test_http_connect_ignores_missing_or_garbled_header(
 # ---------------------------------------------------------------------------
 
 
-def _addrinfo(ip: str) -> list[Any]:
-    return [(2, 1, 6, "", (ip, 0))]
+def _addrinfo(*ips: str) -> list[Any]:
+    return [(2, 1, 6, "", (ip, 0)) for ip in ips]
 
 
 def test_destination_is_blocked_literal_ips() -> None:
-    assert gate.destination_is_blocked("10.0.0.1") is True
-    assert gate.destination_is_blocked("169.254.169.254") is True  # IMDS
-    assert gate.destination_is_blocked("::ffff:10.0.0.1") is True  # mapped v4
-    assert gate.destination_is_blocked("8.8.8.8") is False
-    assert gate.destination_is_blocked("") is False
+    assert gate.destination_is_blocked("10.0.0.1", 443) is True
+    assert gate.destination_is_blocked("169.254.169.254", 80) is True  # IMDS
+    assert gate.destination_is_blocked("::ffff:10.0.0.1", 443) is True  # mapped v4
+    assert gate.destination_is_blocked("8.8.8.8", 443) is False
+    assert gate.destination_is_blocked("", 443) is False
 
 
 def test_destination_is_blocked_resolves_to_internal(
@@ -1051,7 +1053,7 @@ def test_destination_is_blocked_resolves_to_internal(
     monkeypatch.setattr(
         gate.socket, "getaddrinfo", lambda *_a, **_k: _addrinfo("10.1.2.3")
     )
-    assert gate.destination_is_blocked("intra.svc.cluster.local") is True
+    assert gate.destination_is_blocked("intra.svc.cluster.local", 443) is True
 
 
 def test_destination_is_blocked_resolves_to_public(
@@ -1060,7 +1062,7 @@ def test_destination_is_blocked_resolves_to_public(
     monkeypatch.setattr(
         gate.socket, "getaddrinfo", lambda *_a, **_k: _addrinfo("93.184.216.34")
     )
-    assert gate.destination_is_blocked("example.com") is False
+    assert gate.destination_is_blocked("example.com", 443) is False
 
 
 def test_destination_is_blocked_fails_closed_on_resolution_error(
@@ -1072,7 +1074,92 @@ def test_destination_is_blocked_fails_closed_on_resolution_error(
         raise OSError("temporary DNS failure")
 
     monkeypatch.setattr(gate.socket, "getaddrinfo", _boom)
-    assert gate.destination_is_blocked("flaky-host.example") is True
+    assert gate.destination_is_blocked("flaky-host.example", 443) is True
+
+
+def test_api_server_exception_is_port_scoped(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The api-server bypass must match host AND port; other ports on the same
+    internal host (Redis/Postgres) stay blocked."""
+    monkeypatch.setattr(gate, "_API_SERVER_HOST", "api.internal")
+    monkeypatch.setattr(gate, "_API_SERVER_PORT", 443)
+    # api host resolves to an internal IP, like a real in-cluster service name.
+    monkeypatch.setattr(
+        gate.socket, "getaddrinfo", lambda *_a, **_k: _addrinfo("10.5.5.5")
+    )
+    assert gate.destination_is_blocked("api.internal", 443) is False  # allowed
+    assert gate.destination_is_blocked("api.internal", 6379) is True  # Redis: blocked
+    assert gate.destination_is_blocked("api.internal", 5432) is True  # PG: blocked
+
+
+def test_classify_destination_pins_public_ip(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A public hostname returns a pin IP so the caller can connect by IP and
+    defeat DNS rebinding; internal/literal/api destinations return no pin."""
+    monkeypatch.setattr(
+        gate.socket, "getaddrinfo", lambda *_a, **_k: _addrinfo("93.184.216.34")
+    )
+    assert gate.classify_destination("example.com", 443) == (False, "93.184.216.34")
+    # literal IP: nothing to pin (already an address)
+    assert gate.classify_destination("8.8.8.8", 443) == (False, None)
+    # internal resolution: blocked, no pin
+    monkeypatch.setattr(
+        gate.socket, "getaddrinfo", lambda *_a, **_k: _addrinfo("10.1.2.3")
+    )
+    assert gate.classify_destination("intra.example", 443) == (True, None)
+
+
+def test_classify_destination_blocks_if_any_resolved_ip_internal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If a name resolves to a mix of public and internal IPs, deny — an attacker
+    can otherwise steer mitmproxy to the internal one."""
+    monkeypatch.setattr(
+        gate.socket,
+        "getaddrinfo",
+        lambda *_a, **_k: _addrinfo("93.184.216.34", "10.0.0.9"),
+    )
+    assert gate.classify_destination("rebind.example", 443) == (True, None)
+
+
+def _server_hook_data(host: str, port: int) -> server_hooks.ServerConnectionHookData:
+    server = connection.Server(address=(host, port))
+    server.sni = host  # mitmproxy sets sni to the hostname before server_connect
+    return server_hooks.ServerConnectionHookData(
+        server=server, client=connection.Client(peername=("c", 0), sockname=("s", 0))
+    )
+
+
+@pytest.mark.asyncio
+async def test_server_connect_pins_public_ip(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Public host: connection is pinned to the resolved IP (rebinding-proof) and
+    the hostname is preserved as SNI so TLS interception still works."""
+    monkeypatch.setattr(
+        gate.socket, "getaddrinfo", lambda *_a, **_k: _addrinfo("93.184.216.34")
+    )
+    addon = _build(resolver=StubResolver(), matcher=_StubMatcher())
+    data = _server_hook_data("example.com", 443)
+
+    await addon.server_connect(data)
+
+    assert data.server.error is None
+    assert data.server.address == ("93.184.216.34", 443)
+    assert data.server.sni == "example.com"
+
+
+@pytest.mark.asyncio
+async def test_server_connect_blocks_rebind_to_internal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Backstop: a name that resolves to internal at connect-time is killed."""
+    monkeypatch.setattr(
+        gate.socket, "getaddrinfo", lambda *_a, **_k: _addrinfo("10.1.2.3")
+    )
+    addon = _build(resolver=StubResolver(), matcher=_StubMatcher())
+    data = _server_hook_data("rebind.example", 443)
+
+    await addon.server_connect(data)
+
+    assert data.server.error is not None
+    assert data.server.address == ("rebind.example", 443)  # not pinned
 
 
 # ---------------------------------------------------------------------------
@@ -1107,7 +1194,7 @@ async def test_resolve_and_match_exact_tag_on_https_connect(
 ) -> None:
     """HTTPS: the tag rode on the CONNECT (captured via http_connect)
     and is read back off the connection, not the MITM'd request."""
-    monkeypatch.setattr(gate, "destination_is_blocked", lambda _host: False)
+    monkeypatch.setattr(gate, "destination_is_blocked", lambda _host, _port: False)
     user_id = uuid4()
     tagged_id = UUID(_TAG_UUID)
     sandbox = make_resolved_sandbox(user_id=user_id)

--- a/backend/tests/unit/sandbox_proxy/test_gate.py
+++ b/backend/tests/unit/sandbox_proxy/test_gate.py
@@ -1002,22 +1002,77 @@ def test_parse_proxy_auth_username(header: str | None, expected: str | None) -> 
     assert gate._parse_proxy_auth_username(header) == expected
 
 
-def test_http_connect_caches_tag_and_client_disconnected_evicts() -> None:
+@pytest.mark.asyncio
+async def test_http_connect_caches_tag_and_client_disconnected_evicts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(gate, "destination_is_blocked", lambda _host: False)
     addon = _build(resolver=StubResolver(), matcher=_StubMatcher())
     flow = make_flow(conn_id="conn-xyz", proxy_auth=_basic_auth(_TAG_UUID))
 
-    addon.http_connect(flow)
+    await addon.http_connect(flow)
     assert addon._conn_session_tags == {"conn-xyz": _TAG_UUID}
 
     addon.client_disconnected(flow.client_conn)
     assert addon._conn_session_tags == {}
 
 
-def test_http_connect_ignores_missing_or_garbled_header() -> None:
+@pytest.mark.asyncio
+async def test_http_connect_ignores_missing_or_garbled_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(gate, "destination_is_blocked", lambda _host: False)
     addon = _build(resolver=StubResolver(), matcher=_StubMatcher())
-    addon.http_connect(make_flow(conn_id="c1"))  # no Proxy-Authorization
-    addon.http_connect(make_flow(conn_id="c2", proxy_auth="Bearer nope"))
+    await addon.http_connect(make_flow(conn_id="c1"))  # no Proxy-Authorization
+    await addon.http_connect(make_flow(conn_id="c2", proxy_auth="Bearer nope"))
     assert addon._conn_session_tags == {}
+
+
+# ---------------------------------------------------------------------------
+# destination_is_blocked — internal-egress guard
+# ---------------------------------------------------------------------------
+
+
+def _addrinfo(ip: str) -> list[Any]:
+    return [(2, 1, 6, "", (ip, 0))]
+
+
+def test_destination_is_blocked_literal_ips() -> None:
+    assert gate.destination_is_blocked("10.0.0.1") is True
+    assert gate.destination_is_blocked("169.254.169.254") is True  # IMDS
+    assert gate.destination_is_blocked("::ffff:10.0.0.1") is True  # mapped v4
+    assert gate.destination_is_blocked("8.8.8.8") is False
+    assert gate.destination_is_blocked("") is False
+
+
+def test_destination_is_blocked_resolves_to_internal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        gate.socket, "getaddrinfo", lambda *_a, **_k: _addrinfo("10.1.2.3")
+    )
+    assert gate.destination_is_blocked("intra.svc.cluster.local") is True
+
+
+def test_destination_is_blocked_resolves_to_public(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        gate.socket, "getaddrinfo", lambda *_a, **_k: _addrinfo("93.184.216.34")
+    )
+    assert gate.destination_is_blocked("example.com") is False
+
+
+def test_destination_is_blocked_fails_closed_on_resolution_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A resolver failure must deny (fail closed), not allow relay."""
+
+    def _boom(*_args: Any, **_kwargs: Any) -> Any:
+        raise OSError("temporary DNS failure")
+
+    monkeypatch.setattr(gate.socket, "getaddrinfo", _boom)
+    assert gate.destination_is_blocked("flaky-host.example") is True
 
 
 # ---------------------------------------------------------------------------
@@ -1047,9 +1102,12 @@ async def test_resolve_and_match_exact_tag_on_http_request() -> None:
 
 
 @pytest.mark.asyncio
-async def test_resolve_and_match_exact_tag_on_https_connect() -> None:
+async def test_resolve_and_match_exact_tag_on_https_connect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """HTTPS: the tag rode on the CONNECT (captured via http_connect)
     and is read back off the connection, not the MITM'd request."""
+    monkeypatch.setattr(gate, "destination_is_blocked", lambda _host: False)
     user_id = uuid4()
     tagged_id = UUID(_TAG_UUID)
     sandbox = make_resolved_sandbox(user_id=user_id)
@@ -1057,7 +1115,7 @@ async def test_resolve_and_match_exact_tag_on_https_connect() -> None:
     addon = _build(resolver=resolver, matcher=_StubMatcher(result=_MATCH))
 
     connect_flow = make_flow(conn_id="conn-1", proxy_auth=_basic_auth(_TAG_UUID))
-    addon.http_connect(connect_flow)
+    await addon.http_connect(connect_flow)
     # Decrypted request has no Proxy-Authorization of its own.
     request_flow = make_flow(conn_id="conn-1")
 

--- a/backend/tests/unit/sandbox_proxy/test_gate.py
+++ b/backend/tests/unit/sandbox_proxy/test_gate.py
@@ -1091,23 +1091,7 @@ def test_api_server_exception_is_port_scoped(monkeypatch: pytest.MonkeyPatch) ->
     assert gate.destination_is_blocked("api.internal", 5432) is True  # PG: blocked
 
 
-def test_classify_destination_pins_public_ip(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A public hostname returns a pin IP so the caller can connect by IP and
-    defeat DNS rebinding; internal/literal/api destinations return no pin."""
-    monkeypatch.setattr(
-        gate.socket, "getaddrinfo", lambda *_a, **_k: _addrinfo("93.184.216.34")
-    )
-    assert gate.classify_destination("example.com", 443) == (False, "93.184.216.34")
-    # literal IP: nothing to pin (already an address)
-    assert gate.classify_destination("8.8.8.8", 443) == (False, None)
-    # internal resolution: blocked, no pin
-    monkeypatch.setattr(
-        gate.socket, "getaddrinfo", lambda *_a, **_k: _addrinfo("10.1.2.3")
-    )
-    assert gate.classify_destination("intra.example", 443) == (True, None)
-
-
-def test_classify_destination_blocks_if_any_resolved_ip_internal(
+def test_destination_is_blocked_blocks_if_any_resolved_ip_internal(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """If a name resolves to a mix of public and internal IPs, deny — an attacker
@@ -1117,7 +1101,7 @@ def test_classify_destination_blocks_if_any_resolved_ip_internal(
         "getaddrinfo",
         lambda *_a, **_k: _addrinfo("93.184.216.34", "10.0.0.9"),
     )
-    assert gate.classify_destination("rebind.example", 443) == (True, None)
+    assert gate.destination_is_blocked("rebind.example", 443) is True
 
 
 def _server_hook_data(host: str, port: int) -> server_hooks.ServerConnectionHookData:
@@ -1129,9 +1113,11 @@ def _server_hook_data(host: str, port: int) -> server_hooks.ServerConnectionHook
 
 
 @pytest.mark.asyncio
-async def test_server_connect_pins_public_ip(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Public host: connection is pinned to the resolved IP (rebinding-proof) and
-    the hostname is preserved as SNI so TLS interception still works."""
+async def test_server_connect_allows_public_without_pinning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Public host: allowed through untouched. We must NOT pin the IP or alter
+    sni — pinning breaks eager-mode TLS interception and credential injection."""
     monkeypatch.setattr(
         gate.socket, "getaddrinfo", lambda *_a, **_k: _addrinfo("93.184.216.34")
     )
@@ -1141,7 +1127,7 @@ async def test_server_connect_pins_public_ip(monkeypatch: pytest.MonkeyPatch) ->
     await addon.server_connect(data)
 
     assert data.server.error is None
-    assert data.server.address == ("93.184.216.34", 443)
+    assert data.server.address == ("example.com", 443)  # hostname left intact
     assert data.server.sni == "example.com"
 
 
@@ -1159,7 +1145,7 @@ async def test_server_connect_blocks_rebind_to_internal(
     await addon.server_connect(data)
 
     assert data.server.error is not None
-    assert data.server.address == ("rebind.example", 443)  # not pinned
+    assert data.server.address == ("rebind.example", 443)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/sandbox_proxy/test_response_streaming.py
+++ b/backend/tests/unit/sandbox_proxy/test_response_streaming.py
@@ -166,9 +166,7 @@ def _allow_loopback_egress(monkeypatch: pytest.MonkeyPatch) -> None:
     """These tests route through 127.0.0.1 (loopback = internal), which the egress
     guard correctly blocks in production. They exercise response streaming, not the
     egress boundary, so bypass the guard here."""
-    monkeypatch.setattr(
-        gate, "classify_destination", lambda _host, _port: (False, None)
-    )
+    monkeypatch.setattr(gate, "destination_is_blocked", lambda _host, _port: False)
 
 
 def _start_proxy(

--- a/backend/tests/unit/sandbox_proxy/test_response_streaming.py
+++ b/backend/tests/unit/sandbox_proxy/test_response_streaming.py
@@ -32,6 +32,7 @@ from mitmproxy import http as mitm_http
 from mitmproxy.options import Options
 from mitmproxy.tools.dump import DumpMaster
 
+from onyx.sandbox_proxy.addons import gate
 from onyx.sandbox_proxy.addons.gate import _IdentityResolver
 from onyx.sandbox_proxy.addons.gate import GateAddon
 from onyx.sandbox_proxy.credential_injection import CredentialInjectionDispatcher
@@ -158,6 +159,16 @@ def upstream() -> Iterator[int]:
     finally:
         server.shutdown()
         server.server_close()
+
+
+@pytest.fixture(autouse=True)
+def _allow_loopback_egress(monkeypatch: pytest.MonkeyPatch) -> None:
+    """These tests route through 127.0.0.1 (loopback = internal), which the egress
+    guard correctly blocks in production. They exercise response streaming, not the
+    egress boundary, so bypass the guard here."""
+    monkeypatch.setattr(
+        gate, "classify_destination", lambda _host, _port: (False, None)
+    )
 
 
 def _start_proxy(


### PR DESCRIPTION
> 📚 **Companion to #12229 (now merged).** Two-layer proxy egress lockdown:
> - **#12229** — the **CNI/network-layer** control: a NetworkPolicy blocking the proxy *pod* from reaching link-local / IMDS.
> - **This PR** — the **app-layer** control: the proxy refuses to relay a sandbox to any internal destination. It catches what the NetworkPolicy doesn't (RFC1918 datastores, and it can tell relayed sandbox traffic apart from the proxy's own DB client) and is enforced **regardless of CNI NetworkPolicy state** — so it's the control that's effective on prod today (where CNI NetworkPolicy enforcement is off).

---

## Description

**Defense-in-depth for sandbox egress.** Craft sandboxes run untrusted agent code and are network-isolated so their only egress path is the proxy (which injects credentials on the way out, so those secrets never live in the sandbox). That makes the proxy a *trusted bridge that can reach internal infrastructure*.

The concern this addresses: **if an attacker obtained datastore credentials (e.g. Postgres) inside a sandbox, they still must not be able to reach the cluster's internal services through the proxy.** Real access to internal infra should require being on the network (Tailscale) — holding credentials alone shouldn't be enough.

The sandbox's own egress lockdown can't enforce this: from the sandbox, every request is just "TCP to `proxy:8080`" — the real destination is chosen *inside* the proxy. So the proxy is the single layer that can refuse an internal destination.

This adds an internal-destination egress lockdown to the gate addon: any forwarded destination that **is, or resolves to,** a non-globally-routable address (RFC1918, CGNAT, loopback, link-local/IMDS; IPv4 **and** IPv6 incl. v4-mapped) is denied with `403 destination_blocked`. Only the **api-server (host + port** — the sandbox's legitimate PAT-injected call) and the **public internet** are allowed. Keying off IP ranges rather than a hostname allow-list catches internal services nobody enumerated. DNS resolution failures **fail closed**.

Enforced at three points:
- `http_connect` — early deny for HTTPS `CONNECT` tunnels before the upstream socket opens (also covers raw TCP-over-`CONNECT`, e.g. a hand-rolled Postgres client tunneling `:5432`).
- `request` — deny for plain-HTTP and the decrypted inner request of MITM'd HTTPS, with a structured 403.
- `server_connect` — a **deny-only** backstop re-checked just before mitmproxy opens the upstream, which shrinks the DNS-rebinding window.

### Scope & known residual (DNS rebinding)

`server_connect` deliberately does **not** pin the resolved IP onto the connection. Pinning would *fully* close the DNS-rebinding window, but under mitmproxy's default **`eager`** connection strategy it breaks TLS interception — the upstream handshake completes before the client's ClientHello, a bare-IP connection fails the cert path, and mitmproxy silently falls back to a **passthrough tunnel that skips credential injection**. The sandbox's placeholder LLM key then leaks and every agent call 401s. **Confirmed live on craft-dev** (pinned build → broken LLM; deny-only build → works).

So DNS rebinding (an attacker who controls a domain's DNS and flips it public→internal *between* the check and the connect) is an **accepted residual**, not the threat this PR targets. The driver is a *direct* connection to a known internal host, which the deny-check stops outright. Closing the rebinding window without breaking interception (reject-on-**connected-peer**, i.e. validate the actual socket peer post-connect) is a possible follow-up; the strongest version is a network-layer egress rule (AWS Network Firewall in prod / extended egress NetworkPolicy where CNI enforces it).

The proxy's own credential-resolution DB client connects directly (not through the mitmproxy listener), so it's unaffected. `errors.py` adds the `DESTINATION_BLOCKED` code + a non-retryable message.

## How Has This Been Tested?

- **Unit** (`test_gate.py`): `destination_is_blocked` over literal internal/public/IMDS/v4-mapped IPs, internal/public hostname resolution, **mixed public+internal A-records → deny**, **port-scoped api-server exception**, **fail-closed** on resolver error; `server_connect` allow-without-pinning and block-on-internal. Full `sandbox_proxy` unit suite green.
- **Live on craft-dev** (real Craft agent session through the deployed proxy):
  - *Internal blocked* — IMDS `169.254.169.254` and a ClusterIP `172.20.x` → `403 destination_blocked`, logged at both `phase=connect` and `phase=request`.
  - *Public allowed* — `example.com` → 200; `api.anthropic.com` CONNECT intercepted.
  - *Credential injection intact* — agent LLM calls succeed (`credential_injected x-api-key`, `egress_allow ... headers_injected`), confirming the deny-only design preserves TLS interception. (An earlier IP-pinning attempt broke this and was reverted — see above.)
- **Static:** `ty` (strict typing) + `ruff` via pre-commit.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks sandbox egress through the proxy to internal destinations with a rebinding‑aware, deny‑only backstop. Only the Onyx API server (host+port) and the public internet are allowed; blocked attempts return 403 with a non‑retryable `destination_blocked` error.

- **Bug Fixes**
  - Deny targets that are, or resolve to, non‑global IPs (RFC1918, link‑local, loopback; IPv4/IPv6 incl. v4‑mapped). DNS resolution errors fail closed.
  - Allow only the public internet and the Onyx API server from `SANDBOX_API_SERVER_URL`, matched by hostname and port.
  - Enforce at `http_connect` (async check), `request` (also covers decrypted HTTPS), and `server_connect` deny‑only backstop that resolves once and leaves the hostname/SNI intact to preserve TLS interception and credential injection; internal at connect‑time kills the connection.
  - Return 403 with `SandboxProxyError.DESTINATION_BLOCKED`; the proxy’s direct DB client path is unchanged.

<sup>Written for commit 45258e76dccf8781f9527b864fe48af94dc91749. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-light.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
