### PR TITLE
fix(agent-sharing): show display names in the share dialog

### DIFF
--- a/backend/onyx/server/features/persona/models.py
+++ b/backend/onyx/server/features/persona/models.py
@@ -43,7 +43,11 @@ class PersonaOwnerGroupSnapshot(BaseModel):
 def _user_shares_from_model(persona: Persona) -> list[PersonaUserShare]:
     return [
         PersonaUserShare(
-            user=MinimalUserSnapshot(id=share.user.id, email=share.user.email),
+            user=MinimalUserSnapshot(
+                id=share.user.id,
+                email=share.user.email,
+                personal_name=share.user.personal_name,
+            ),
             permission=share.permission,
         )
         for share in persona.user_shares
@@ -291,11 +295,15 @@ class MinimalPersonaSnapshot(BaseModel):
             builtin_persona=persona.builtin_persona,
             labels=[PersonaLabelSnapshot.from_model(label) for label in persona.labels],
             owner=(
-                # Owner email is PII: keep the id (needed for ownership/creator
-                # filtering) but blank the email for non-owner/non-admin callers.
+                # Owner email and display name are PII: keep the id (needed for
+                # ownership/creator filtering) but blank them for
+                # non-owner/non-admin callers.
                 MinimalUserSnapshot(
                     id=persona.user.id,
                     email=persona.user.email if include_owner_email else "",
+                    personal_name=(
+                        persona.user.personal_name if include_owner_email else None
+                    ),
                 )
                 if persona.user
                 else None
@@ -372,13 +380,19 @@ class PersonaSnapshot(BaseModel):
                 for doc in persona.attached_documents
             ],
             owner=(
-                MinimalUserSnapshot(id=persona.user.id, email=persona.user.email)
+                MinimalUserSnapshot(
+                    id=persona.user.id,
+                    email=persona.user.email,
+                    personal_name=persona.user.personal_name,
+                )
                 if persona.user
                 else None
             ),
             owner_group=_owner_group_from_model(persona),
             users=[
-                MinimalUserSnapshot(id=user.id, email=user.email)
+                MinimalUserSnapshot(
+                    id=user.id, email=user.email, personal_name=user.personal_name
+                )
                 for user in persona.users
             ],
             groups=[user_group.id for user_group in persona.groups],
@@ -432,7 +446,9 @@ class FullPersonaSnapshot(PersonaSnapshot):
             builtin_persona=persona.builtin_persona,
             starter_messages=persona.starter_messages,
             users=[
-                MinimalUserSnapshot(id=user.id, email=user.email)
+                MinimalUserSnapshot(
+                    id=user.id, email=user.email, personal_name=user.personal_name
+                )
                 for user in persona.users
             ],
             groups=[user_group.id for user_group in persona.groups],
@@ -455,7 +471,11 @@ class FullPersonaSnapshot(PersonaSnapshot):
                 for doc in persona.attached_documents
             ],
             owner=(
-                MinimalUserSnapshot(id=persona.user.id, email=persona.user.email)
+                MinimalUserSnapshot(
+                    id=persona.user.id,
+                    email=persona.user.email,
+                    personal_name=persona.user.personal_name,
+                )
                 if persona.user
                 else None
             ),

--- a/backend/onyx/server/manage/users.py
+++ b/backend/onyx/server/manage/users.py
@@ -875,7 +875,7 @@ def list_all_users_basic_info(
 
     users = get_all_users(db_session)
     return [
-        MinimalUserSnapshot(id=u.id, email=u.email)
+        MinimalUserSnapshot(id=u.id, email=u.email, personal_name=u.personal_name)
         for u in users
         if u.account_type != AccountType.BOT
         and (include_api_keys or not is_api_key_email_address(u.email))

--- a/backend/onyx/server/models.py
+++ b/backend/onyx/server/models.py
@@ -30,6 +30,8 @@ class IdReturn(BaseModel):
 class MinimalUserSnapshot(BaseModel):
     id: UUID
     email: str
+    # User.personal_name, or None when unset. Callers fall back to email.
+    personal_name: str | None = None
 
 
 class UserGroupInfo(BaseModel):

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -161,6 +161,8 @@ export interface InvitedUserSnapshot {
 export interface MinimalUserSnapshot {
   id: string;
   email: string;
+  // User.personal_name, or null when unset. Callers fall back to email.
+  personal_name?: string | null;
 }
 
 export type ValidInputTypes =

--- a/web/src/lib/users/svc.ts
+++ b/web/src/lib/users/svc.ts
@@ -1,10 +1,22 @@
 import { mutate } from "swr";
-import { User, UserPersonalization } from "@/lib/types";
+import { MinimalUserSnapshot, User, UserPersonalization } from "@/lib/types";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import { CustomRefreshTokenResponse } from "@/lib/users/types";
 
 export function checkUserIsNoAuthUser(userId: string): boolean {
   return userId === "__no_auth_user__";
+}
+
+// A user's display name, falling back to email when personal_name is unset.
+export function userDisplayName(user: MinimalUserSnapshot): string {
+  return user.personal_name ?? user.email;
+}
+
+// Email for a secondary line, shown only when a display name holds the primary.
+export function userSecondaryEmail(
+  user: MinimalUserSnapshot
+): string | undefined {
+  return user.personal_name ? user.email : undefined;
 }
 
 export async function getCurrentUser(): Promise<User | null> {

--- a/web/src/sections/modals/AddPeoplePicker.tsx
+++ b/web/src/sections/modals/AddPeoplePicker.tsx
@@ -6,6 +6,7 @@ import { SvgUser, SvgUsers, SvgX } from "@opal/icons";
 import { cn } from "@opal/utils";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import type { MinimalUserSnapshot } from "@/lib/types";
+import { userDisplayName, userSecondaryEmail } from "@/lib/users/svc";
 import type { MinimalUserGroupSnapshot } from "@/hooks/useShareableGroups";
 import { SharePermissionMenu } from "@/sections/modals/SharePermissionMenu";
 import {
@@ -16,6 +17,7 @@ import {
 interface Suggestion {
   id: string;
   label: string;
+  description?: string;
   shared: boolean;
   type: "group" | "user";
 }
@@ -69,11 +71,16 @@ export function AddPeoplePicker({
     }
 
     const userSuggestions = users
-      .filter((user) => user.email.toLowerCase().includes(trimmedQuery))
+      .filter(
+        (user) =>
+          user.email.toLowerCase().includes(trimmedQuery) ||
+          (user.personal_name?.toLowerCase().includes(trimmedQuery) ?? false)
+      )
       .filter((user) => !stagedUserIds.has(user.id))
       .map((user) => ({
         id: user.id,
-        label: user.email,
+        label: userDisplayName(user),
+        description: userSecondaryEmail(user),
         shared: existingUserIds.has(user.id),
         type: "user" as const,
       }));
@@ -84,6 +91,7 @@ export function AddPeoplePicker({
       .map((group) => ({
         id: String(group.id),
         label: group.name,
+        description: "Group",
         shared: existingGroupIds.has(group.id),
         type: "group" as const,
       }));
@@ -137,7 +145,7 @@ export function AddPeoplePicker({
             >
               <SvgUser className="h-4 w-4 stroke-text-03" />
               <Text color="text-04" font="main-ui-body">
-                {user.email}
+                {userDisplayName(user)}
               </Text>
               <Button
                 icon={SvgX}
@@ -189,9 +197,7 @@ export function AddPeoplePicker({
                     key={`${suggestion.type}-${suggestion.id}`}
                   >
                     <LineItemButton
-                      description={
-                        suggestion.type === "group" ? "Group" : undefined
-                      }
+                      description={suggestion.description}
                       icon={suggestion.type === "group" ? SvgUsers : SvgUser}
                       onClick={() => handleSelectSuggestion(suggestion)}
                       rightChildren={

--- a/web/src/sections/modals/ShareAgentModal.tsx
+++ b/web/src/sections/modals/ShareAgentModal.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/lib/agents/svc";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import type { MinimalUserSnapshot } from "@/lib/types";
+import { userDisplayName, userSecondaryEmail } from "@/lib/users/svc";
 import { useUser } from "@/providers/UserProvider";
 import { useSettings } from "@/lib/settings/hooks";
 import Modal from "@/refresh-components/Modal";
@@ -598,7 +599,8 @@ export default function ShareAgentModal({
 
         {agent?.owner ? (
           <ShareAccessRow
-            avatarInitial={agent.owner.email.charAt(0).toUpperCase()}
+            avatarInitial={userDisplayName(agent.owner).charAt(0).toUpperCase()}
+            description={userSecondaryEmail(agent.owner)}
             icon={SvgUser}
             rightChildren={
               <StaticPermissionLabel
@@ -616,8 +618,8 @@ export default function ShareAgentModal({
             }
             title={
               currentUser && agent.owner.id === currentUser.id
-                ? `${agent.owner.email} (you)`
-                : agent.owner.email
+                ? `${userDisplayName(agent.owner)} (you)`
+                : userDisplayName(agent.owner)
             }
           />
         ) : null}
@@ -649,7 +651,10 @@ export default function ShareAgentModal({
 
           return (
             <ShareAccessRow
-              avatarInitial={share.user.email.charAt(0).toUpperCase()}
+              avatarInitial={userDisplayName(share.user)
+                .charAt(0)
+                .toUpperCase()}
+              description={userSecondaryEmail(share.user)}
               icon={SvgUser}
               key={share.user.id}
               rightChildren={
@@ -674,7 +679,9 @@ export default function ShareAgentModal({
                 />
               }
               title={
-                isCurrentUser ? `${share.user.email} (you)` : share.user.email
+                isCurrentUser
+                  ? `${userDisplayName(share.user)} (you)`
+                  : userDisplayName(share.user)
               }
             />
           );


### PR DESCRIPTION
## Description

The share dialog and Add People picker rendered raw emails for every user. Now they show the user's display name when set, with the email as the secondary line.

- Backend: `MinimalUserSnapshot` gains `personal_name` (from `User.personal_name`), populated in the persona share snapshots and the `/users` picker source.
- Frontend: name-over-email in the owner row, user-share rows, picker suggestions, and staged tags; falls back to email when no name is set.

## How Has This Been Tested?

<!--- reviewer to fill --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check