### PR TITLE
feat(craft): Add HubSpot as a built-in external app

### DIFF
--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -394,6 +394,7 @@ class ExternalAppType(str, PyEnum):
     SLACK = "SLACK"
     LINEAR = "LINEAR"
     GITHUB = "GITHUB"
+    HUBSPOT = "HUBSPOT"
     CUSTOM = "CUSTOM"
 
     @property

--- a/backend/onyx/external_apps/providers/hubspot.py
+++ b/backend/onyx/external_apps/providers/hubspot.py
@@ -1,0 +1,173 @@
+from typing import Any
+
+from onyx.db.enums import EndpointPolicy
+from onyx.db.enums import ExternalAppType
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.external_apps.providers.actions import EndpointSpec
+from onyx.external_apps.providers.actions import ExternalAppAction
+from onyx.external_apps.providers.actions import RestRoute
+from onyx.external_apps.providers.base import AdminDescriptorSpec
+from onyx.external_apps.providers.base import OAuthExternalAppProvider
+from onyx.external_apps.providers.base import OAuthFlowSpec
+from onyx.external_apps.providers.base import OAuthProviderSpec
+from onyx.external_apps.providers.base import OrgCredentialField
+
+
+class HubSpotAction(ExternalAppAction):
+    """Strongly-typed catalog ids for the HubSpot provider."""
+
+    ACCOUNT_READ = "hubspot.account.read"
+    CONTACTS_READ = "hubspot.contacts.read"
+    COMPANIES_READ = "hubspot.companies.read"
+    DEALS_READ = "hubspot.deals.read"
+    SEARCH_READ = "hubspot.search.read"
+    CONTACTS_CREATE = "hubspot.contacts.create"
+    CONTACTS_UPDATE = "hubspot.contacts.update"
+
+
+# HubSpot's CRM is a path-addressed JSON REST API rooted at
+# https://api.hubapi.com; the action is the HTTP method + path template. A
+# `{name}` segment matches one path segment (an object id, etc.). HubSpot's
+# `search` endpoints are POSTs that only read, so they carry an ALWAYS policy
+# even though they are POSTs — the catalog keys on intent, not on the verb.
+_ENDPOINTS: list[EndpointSpec] = [
+    EndpointSpec(
+        id=HubSpotAction.ACCOUNT_READ,
+        normalised_name="Read the connected account",
+        description="Read the authenticated HubSpot account's details.",
+        matches=(RestRoute(method="GET", path="/account-info/v3/details"),),
+        default_policy=EndpointPolicy.ALWAYS,
+    ),
+    EndpointSpec(
+        id=HubSpotAction.CONTACTS_READ,
+        normalised_name="Read contacts",
+        description="List contacts and fetch a single contact.",
+        matches=(
+            RestRoute(method="GET", path="/crm/v3/objects/contacts"),
+            RestRoute(method="GET", path="/crm/v3/objects/contacts/{contactId}"),
+        ),
+        default_policy=EndpointPolicy.ALWAYS,
+    ),
+    EndpointSpec(
+        id=HubSpotAction.COMPANIES_READ,
+        normalised_name="Read companies",
+        description="List companies and fetch a single company.",
+        matches=(
+            RestRoute(method="GET", path="/crm/v3/objects/companies"),
+            RestRoute(method="GET", path="/crm/v3/objects/companies/{companyId}"),
+        ),
+        default_policy=EndpointPolicy.ALWAYS,
+    ),
+    EndpointSpec(
+        id=HubSpotAction.DEALS_READ,
+        normalised_name="Read deals",
+        description="List deals and fetch a single deal.",
+        matches=(
+            RestRoute(method="GET", path="/crm/v3/objects/deals"),
+            RestRoute(method="GET", path="/crm/v3/objects/deals/{dealId}"),
+        ),
+        default_policy=EndpointPolicy.ALWAYS,
+    ),
+    EndpointSpec(
+        id=HubSpotAction.SEARCH_READ,
+        normalised_name="Search CRM objects",
+        description="Search contacts, companies, and deals (a read-only POST).",
+        matches=(
+            RestRoute(method="POST", path="/crm/v3/objects/contacts/search"),
+            RestRoute(method="POST", path="/crm/v3/objects/companies/search"),
+            RestRoute(method="POST", path="/crm/v3/objects/deals/search"),
+        ),
+        default_policy=EndpointPolicy.ALWAYS,
+    ),
+    EndpointSpec(
+        id=HubSpotAction.CONTACTS_CREATE,
+        normalised_name="Create a contact",
+        description="Create a new contact.",
+        matches=(RestRoute(method="POST", path="/crm/v3/objects/contacts"),),
+    ),
+    EndpointSpec(
+        id=HubSpotAction.CONTACTS_UPDATE,
+        normalised_name="Update a contact",
+        description="Update an existing contact's properties.",
+        matches=(
+            RestRoute(method="PATCH", path="/crm/v3/objects/contacts/{contactId}"),
+        ),
+    ),
+]
+
+
+class HubSpotProvider(OAuthExternalAppProvider):
+    spec = OAuthProviderSpec(
+        app_type=ExternalAppType.HUBSPOT,
+        app_name="HubSpot",
+        oauth=OAuthFlowSpec(
+            authorize_url="https://app.hubspot.com/oauth/authorize",
+            token_url="https://api.hubapi.com/oauth/v1/token",
+            scope=" ".join(
+                [
+                    "crm.objects.contacts.read",
+                    "crm.objects.contacts.write",
+                    "crm.objects.companies.read",
+                    "crm.objects.deals.read",
+                    "oauth",
+                ]
+            ),
+            scope_param="scope",
+        ),
+        descriptor=AdminDescriptorSpec(
+            description=(
+                "Read contacts, companies, and deals, search the CRM, and "
+                "create or update contacts in HubSpot on the user's behalf."
+            ),
+            upstream_url_patterns=["https://api\\.hubapi\\.com/.*"],
+            auth_template={"Authorization": "Bearer {access_token}"},
+            required_org_credential_fields=[
+                OrgCredentialField(
+                    key="client_id",
+                    label="Client ID",
+                    description=(
+                        "Found on your HubSpot app's Auth settings page "
+                        "(HubSpot developer account → Apps → your app → Auth)."
+                    ),
+                ),
+                OrgCredentialField(
+                    key="client_secret",
+                    label="Client Secret",
+                    description=(
+                        "Found alongside the Client ID on the same Auth "
+                        "settings page. Treat this like a password."
+                    ),
+                    secret=True,
+                ),
+            ],
+            setup_instructions=(
+                "In HubSpot: create a developer account, then Apps → Create app. "
+                "On the Auth tab, add this Onyx instance's callback URL "
+                "(/craft/v1/apps/oauth/callback) to Redirect URLs and select the "
+                "CRM scopes (contacts read/write, companies read, deals read, "
+                "oauth). Save, then paste the Client ID and Client Secret below."
+            ),
+        ),
+        endpoint_catalog=_ENDPOINTS,
+    )
+
+    def extract_credentials(self, response_data: dict[str, Any]) -> dict[str, Any]:
+        access_token = response_data.get("access_token")
+        if not access_token:
+            raise OnyxError(
+                OnyxErrorCode.BAD_GATEWAY,
+                "HubSpot OAuth response did not contain an access token.",
+            )
+        creds: dict[str, Any] = {
+            "access_token": access_token,
+            "token_type": response_data.get("token_type"),
+        }
+        # HubSpot issues a rotating refresh token and a short-lived access
+        # token (typically 30 minutes); both are present on the initial grant
+        # and on refresh.
+        if response_data.get("refresh_token"):
+            creds["refresh_token"] = response_data["refresh_token"]
+        if response_data.get("expires_in"):
+            creds["expires_in"] = response_data["expires_in"]
+        return creds

--- a/backend/onyx/external_apps/providers/registry.py
+++ b/backend/onyx/external_apps/providers/registry.py
@@ -14,6 +14,7 @@ from onyx.external_apps.providers.github import GitHubProvider
 from onyx.external_apps.providers.gmail import GmailProvider
 from onyx.external_apps.providers.google_calendar import GoogleCalendarProvider
 from onyx.external_apps.providers.google_drive import GoogleDriveProvider
+from onyx.external_apps.providers.hubspot import HubSpotProvider
 from onyx.external_apps.providers.linear import LinearProvider
 from onyx.external_apps.providers.slack import SlackProvider
 
@@ -24,6 +25,7 @@ _PROVIDER_CLASSES: list[type[ExternalAppProvider]] = [
     GmailProvider,
     LinearProvider,
     GitHubProvider,
+    HubSpotProvider,
 ]
 
 

--- a/backend/onyx/skills/built_in.py
+++ b/backend/onyx/skills/built_in.py
@@ -179,6 +179,9 @@ _REGISTRY: Final = BuiltInSkillRegistry(
         ),
         ExternalAppBuiltInProvider(skill_id="gmail", app_type=ExternalAppType.GMAIL),
         ExternalAppBuiltInProvider(skill_id="github", app_type=ExternalAppType.GITHUB),
+        ExternalAppBuiltInProvider(
+            skill_id="hubspot", app_type=ExternalAppType.HUBSPOT
+        ),
     )
 )
 

--- a/backend/onyx/skills/builtin/hubspot/SKILL.md.template
+++ b/backend/onyx/skills/builtin/hubspot/SKILL.md.template
@@ -1,0 +1,90 @@
+---
+name: hubspot
+description: Read contacts, companies, and deals, search the CRM, and create or update contacts in HubSpot on the connected user's behalf via a light REST wrapper.
+---
+
+# HubSpot
+
+Call HubSpot's CRM as the connected user via the bundled helper. **You are
+already authenticated** — the egress proxy injects the user's HubSpot bearer
+token on the wire. Never send credentials from the script.
+
+{{ACTION_AVAILABILITY_SECTION}}
+
+## Usage
+
+    python .opencode/skills/hubspot/hubspot_api.py <command> [args]
+
+Read commands auto-paginate and prune empty fields. `create-contact` and
+`update-contact` are the only writes. Use `--raw` to skip empty-field pruning;
+`python hubspot_api.py <command> -h` shows its flags.
+
+### The connected account
+
+```
+python hubspot_api.py me
+```
+
+### Contacts
+
+```
+python hubspot_api.py contacts [--limit N] [--properties email,firstname,lastname]
+python hubspot_api.py contact <contact_id> [--properties email,firstname]
+```
+
+### Companies
+
+```
+python hubspot_api.py companies [--limit N] [--properties name,domain]
+python hubspot_api.py company <company_id> [--properties name,domain]
+```
+
+### Deals
+
+```
+python hubspot_api.py deals [--limit N] [--properties dealname,amount]
+python hubspot_api.py deal <deal_id> [--properties dealname,amount]
+```
+
+### Search contacts
+
+```
+python hubspot_api.py search-contacts "acme" [--limit N]
+```
+
+### Create a contact (write)
+
+```
+python hubspot_api.py create-contact --property email=a@b.com --property firstname=Ada
+```
+
+### Update a contact (write)
+
+```
+python hubspot_api.py update-contact <contact_id> --property lastname=Lovelace
+```
+
+### Arbitrary API calls
+
+`call` reaches any HubSpot REST endpoint. Pass a JSON object body as the last
+argument for POST/PATCH/PUT.
+
+```
+python hubspot_api.py call GET /crm/v3/objects/deals
+python hubspot_api.py call POST /crm/v3/objects/contacts/search '{"query":"acme"}'
+```
+
+## Output
+
+JSON on stdout. List commands return `{"ok": true, "results": [...], "count": N,
+"truncated": bool}` (`truncated` means more results existed past `--limit`).
+Failures print to stderr and exit non-zero — surface the error rather than
+retrying blindly.
+
+## Notes
+
+- **Scopes are fixed** by the admin (contacts read/write, companies read,
+  deals read). An operation needing a scope you don't have returns `403`; tell
+  the user rather than retrying.
+- A write that isn't pre-approved may pause for the user's approval; if a call
+  is blocked or returns `401`, report it instead of looping.

--- a/backend/onyx/skills/builtin/hubspot/hubspot_api.py
+++ b/backend/onyx/skills/builtin/hubspot/hubspot_api.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""HubSpot (CRM v3) wrapper for the Onyx Craft sandbox.
+
+Common operations exposed as subcommands. Output is JSON on stdout. No auth is
+handled here: the sandbox egress proxy injects the connected user's bearer
+token on the wire. Writes (create/update) may pause for user approval at the
+proxy.
+"""
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+_BASE = "https://api.hubapi.com"
+_PAGE_SIZE = 100
+_DEFAULT_LIMIT = 100
+_HTTP_TIMEOUT_SECONDS = 180
+
+
+def _prune(value: Any) -> Any:
+    """Recursively drop None / "" / [] / {} so LLM-facing output stays small.
+    Booleans and 0 are kept — they carry signal."""
+    if isinstance(value, dict):
+        out = {k: _prune(v) for k, v in value.items()}
+        return {k: v for k, v in out.items() if v not in (None, "", [], {})}
+    if isinstance(value, list):
+        return [_prune(v) for v in value]
+    return value
+
+
+def _seg(value: str) -> str:
+    """URL-encode a single path segment (ids may contain special chars)."""
+    return urllib.parse.quote(value, safe="")
+
+
+def _url(path: str, params: dict[str, Any] | None = None) -> str:
+    url = _BASE + path
+    if params:
+        clean = {k: v for k, v in params.items() if v is not None}
+        url += "?" + urllib.parse.urlencode(clean, doseq=True)
+    return url
+
+
+def _req_json(
+    path: str,
+    params: dict[str, Any] | None = None,
+    method: str = "GET",
+    body: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Call a HubSpot JSON endpoint; return parsed JSON ({} on empty/204)."""
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    headers = {"Content-Type": "application/json; charset=utf-8"} if data else {}
+    req = urllib.request.Request(  # noqa: S310 — fixed https base url
+        _url(path, params), data=data, method=method, headers=headers
+    )
+    with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT_SECONDS) as resp:  # noqa: S310
+        raw = resp.read().decode("utf-8")
+    return json.loads(raw) if raw.strip() else {}
+
+
+def _paginate(
+    path: str, params: dict[str, Any], limit: int
+) -> dict[str, Any]:
+    """Walk a HubSpot list endpoint (`results` + `paging.next.after`) up to
+    `limit`."""
+    items: list[Any] = []
+    after: str | None = None
+    while True:
+        q = dict(params, limit=min(_PAGE_SIZE, limit - len(items)))
+        if after:
+            q["after"] = after
+        resp = _req_json(path, params=q)
+        items.extend(resp.get("results") or [])
+        after = ((resp.get("paging") or {}).get("next") or {}).get("after")
+        if len(items) >= limit:
+            return {
+                "ok": True,
+                "results": items[:limit],
+                "count": limit,
+                "truncated": bool(after),
+            }
+        if not after:
+            break
+    return {"ok": True, "results": items, "count": len(items), "truncated": False}
+
+
+def _properties(pairs: list[str] | None) -> dict[str, str]:
+    """Parse repeated ``key=value`` flags into a HubSpot properties dict."""
+    props: dict[str, str] = {}
+    for pair in pairs or []:
+        key, sep, val = pair.partition("=")
+        if not sep:
+            raise ValueError(f"property must be key=value, got {pair!r}")
+        props[key] = val
+    return props
+
+
+def _emit(result: dict[str, Any], raw: bool) -> int:
+    print(json.dumps(result if raw else _prune(result)))
+    return 0 if result.get("ok") else 1
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="hubspot_api.py", description="HubSpot CRM.")
+    p.add_argument("--raw", action="store_true", help="don't prune empty fields")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    def with_limit(sp: argparse.ArgumentParser) -> None:
+        sp.add_argument("--limit", type=int, default=_DEFAULT_LIMIT)
+        sp.add_argument(
+            "--properties",
+            help="comma-separated property names to return",
+        )
+
+    sub.add_parser("me", help="the connected HubSpot account")
+
+    with_limit(sub.add_parser("contacts", help="list contacts"))
+
+    sp = sub.add_parser("contact", help="one contact by id")
+    sp.add_argument("contact_id")
+    sp.add_argument("--properties", help="comma-separated property names to return")
+
+    with_limit(sub.add_parser("companies", help="list companies"))
+
+    sp = sub.add_parser("company", help="one company by id")
+    sp.add_argument("company_id")
+    sp.add_argument("--properties", help="comma-separated property names to return")
+
+    with_limit(sub.add_parser("deals", help="list deals"))
+
+    sp = sub.add_parser("deal", help="one deal by id")
+    sp.add_argument("deal_id")
+    sp.add_argument("--properties", help="comma-separated property names to return")
+
+    sp = sub.add_parser("search-contacts", help="full-text contact search")
+    sp.add_argument("query")
+    sp.add_argument("--limit", type=int, default=_DEFAULT_LIMIT)
+
+    # --- writes (may prompt for approval) ---
+    sp = sub.add_parser("create-contact", help="create a contact (write)")
+    sp.add_argument(
+        "--property",
+        dest="props",
+        action="append",
+        metavar="KEY=VALUE",
+        help="contact property (repeatable), e.g. --property email=a@b.com",
+    )
+
+    sp = sub.add_parser("update-contact", help="update a contact (write)")
+    sp.add_argument("contact_id")
+    sp.add_argument(
+        "--property",
+        dest="props",
+        action="append",
+        metavar="KEY=VALUE",
+        help="contact property to set (repeatable)",
+    )
+
+    sp = sub.add_parser("call", help="raw HubSpot request")
+    sp.add_argument("method", choices=("GET", "POST", "PATCH", "PUT", "DELETE"))
+    sp.add_argument("path", help="appended to https://api.hubapi.com")
+    sp.add_argument("json_body", nargs="?", help="JSON object for the request body")
+    return p
+
+
+def _list_params(a: argparse.Namespace) -> dict[str, Any]:
+    params: dict[str, Any] = {}
+    if getattr(a, "properties", None):
+        params["properties"] = a.properties
+    return params
+
+
+def _dispatch(a: argparse.Namespace) -> dict[str, Any]:
+    if a.cmd == "me":
+        return {"ok": True, "account": _req_json("/account-info/v3/details")}
+
+    if a.cmd == "contacts":
+        return _paginate("/crm/v3/objects/contacts", _list_params(a), a.limit)
+
+    if a.cmd == "contact":
+        obj = _req_json(
+            f"/crm/v3/objects/contacts/{_seg(a.contact_id)}", _list_params(a)
+        )
+        return {"ok": True, "contact": obj}
+
+    if a.cmd == "companies":
+        return _paginate("/crm/v3/objects/companies", _list_params(a), a.limit)
+
+    if a.cmd == "company":
+        obj = _req_json(
+            f"/crm/v3/objects/companies/{_seg(a.company_id)}", _list_params(a)
+        )
+        return {"ok": True, "company": obj}
+
+    if a.cmd == "deals":
+        return _paginate("/crm/v3/objects/deals", _list_params(a), a.limit)
+
+    if a.cmd == "deal":
+        obj = _req_json(f"/crm/v3/objects/deals/{_seg(a.deal_id)}", _list_params(a))
+        return {"ok": True, "deal": obj}
+
+    if a.cmd == "search-contacts":
+        body = {"query": a.query, "limit": min(_PAGE_SIZE, a.limit)}
+        resp = _req_json(
+            "/crm/v3/objects/contacts/search", method="POST", body=body
+        )
+        results = resp.get("results") or []
+        return {
+            "ok": True,
+            "results": results[: a.limit],
+            "count": min(len(results), a.limit),
+            "total": resp.get("total"),
+        }
+
+    if a.cmd == "create-contact":
+        contact = _req_json(
+            "/crm/v3/objects/contacts",
+            method="POST",
+            body={"properties": _properties(a.props)},
+        )
+        return {"ok": True, "contact": contact}
+
+    if a.cmd == "update-contact":
+        contact = _req_json(
+            f"/crm/v3/objects/contacts/{_seg(a.contact_id)}",
+            method="PATCH",
+            body={"properties": _properties(a.props)},
+        )
+        return {"ok": True, "contact": contact}
+
+    # `call` raw escape hatch
+    parsed_body = None
+    if a.json_body:
+        parsed_body = json.loads(a.json_body)
+        if not isinstance(parsed_body, dict):
+            return {"ok": False, "error": "json_body_not_object"}
+    resp = _req_json("/" + a.path.lstrip("/"), method=a.method, body=parsed_body)
+    return {"ok": True, "data": resp}
+
+
+def main(argv: list[str]) -> int:
+    a = _build_parser().parse_args(argv[1:])
+    try:
+        result = _dispatch(a)
+    except ValueError as e:
+        print(f"invalid input: {e}", file=sys.stderr)
+        return 2
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode("utf-8", errors="replace")
+        print(f"HTTP {e.code} calling HubSpot: {detail}", file=sys.stderr)
+        return 1
+    except urllib.error.URLError as e:
+        print(f"network error calling HubSpot: {e.reason}", file=sys.stderr)
+        return 1
+    return _emit(result, a.raw)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/backend/tests/unit/external_apps/test_hubspot_provider.py
+++ b/backend/tests/unit/external_apps/test_hubspot_provider.py
@@ -1,0 +1,123 @@
+"""The HubSpot built-in provider: it is registered and resolvable, its action
+catalog claims the request paths the bundled ``hubspot_api.py`` helper calls,
+its OAuth token response maps to stored credentials, and reads auto-approve
+(ALWAYS) while writes default to ASK (require approval)."""
+
+from __future__ import annotations
+
+import pytest
+
+from onyx.db.enums import EndpointPolicy
+from onyx.db.enums import ExternalAppType
+from onyx.error_handling.exceptions import OnyxError
+from onyx.external_apps.providers.actions import path_matches
+from onyx.external_apps.providers.actions import RestRoute
+from onyx.external_apps.providers.hubspot import HubSpotAction
+from onyx.external_apps.providers.hubspot import HubSpotProvider
+from onyx.external_apps.providers.registry import get_endpoint_catalog
+from onyx.external_apps.providers.registry import PROVIDERS
+
+_READ_ACTIONS = {
+    HubSpotAction.ACCOUNT_READ,
+    HubSpotAction.CONTACTS_READ,
+    HubSpotAction.COMPANIES_READ,
+    HubSpotAction.DEALS_READ,
+    HubSpotAction.SEARCH_READ,
+}
+
+_WRITE_ACTIONS = {
+    HubSpotAction.CONTACTS_CREATE,
+    HubSpotAction.CONTACTS_UPDATE,
+}
+
+
+def _provider() -> HubSpotProvider:
+    provider = PROVIDERS[ExternalAppType.HUBSPOT]
+    assert isinstance(provider, HubSpotProvider)
+    return provider
+
+
+def test_registered_and_resolvable() -> None:
+    provider = _provider()
+    assert provider.spec.app_type == ExternalAppType.HUBSPOT
+    assert provider.spec.app_name == "HubSpot"
+
+
+def test_oauth_and_patterns() -> None:
+    spec = _provider().spec
+    assert spec.oauth.authorize_url == "https://app.hubspot.com/oauth/authorize"
+    assert spec.oauth.token_url == "https://api.hubapi.com/oauth/v1/token"
+    assert spec.oauth.scope_param == "scope"
+    assert "oauth" in spec.oauth.scope.split()
+    assert spec.descriptor.upstream_url_patterns == ["https://api\\.hubapi\\.com/.*"]
+    assert spec.descriptor.auth_template == {"Authorization": "Bearer {access_token}"}
+
+
+def test_required_org_credential_fields() -> None:
+    fields = {f.key: f for f in _provider().spec.descriptor.required_org_credential_fields}
+    assert set(fields) == {"client_id", "client_secret"}
+    assert fields["client_secret"].secret is True
+    assert fields["client_id"].secret is False
+
+
+@pytest.mark.parametrize(
+    "method, path, expected",
+    [
+        ("GET", "/account-info/v3/details", HubSpotAction.ACCOUNT_READ),
+        ("GET", "/crm/v3/objects/contacts", HubSpotAction.CONTACTS_READ),
+        ("GET", "/crm/v3/objects/contacts/123", HubSpotAction.CONTACTS_READ),
+        ("GET", "/crm/v3/objects/companies", HubSpotAction.COMPANIES_READ),
+        ("GET", "/crm/v3/objects/companies/456", HubSpotAction.COMPANIES_READ),
+        ("GET", "/crm/v3/objects/deals", HubSpotAction.DEALS_READ),
+        ("GET", "/crm/v3/objects/deals/789", HubSpotAction.DEALS_READ),
+        ("POST", "/crm/v3/objects/contacts/search", HubSpotAction.SEARCH_READ),
+        ("POST", "/crm/v3/objects/companies/search", HubSpotAction.SEARCH_READ),
+        ("POST", "/crm/v3/objects/deals/search", HubSpotAction.SEARCH_READ),
+        ("POST", "/crm/v3/objects/contacts", HubSpotAction.CONTACTS_CREATE),
+        ("PATCH", "/crm/v3/objects/contacts/123", HubSpotAction.CONTACTS_UPDATE),
+    ],
+)
+def test_catalog_resolves_to_exactly_one_action(
+    method: str, path: str, expected: HubSpotAction
+) -> None:
+    """Each path the helper hits is claimed by exactly one action, so per-action
+    policy resolution can't silently misfire."""
+    catalog = get_endpoint_catalog(ExternalAppType.HUBSPOT)
+    matched = [
+        endpoint.id
+        for endpoint in catalog
+        for rule in endpoint.matches
+        if isinstance(rule, RestRoute)
+        and rule.method == method
+        and path_matches(rule.path, path)
+    ]
+    assert matched == [expected], f"{method} {path} matched {matched}"
+
+
+def test_reads_always_writes_ask() -> None:
+    """Reads auto-approve; writes require approval out of the box."""
+    by_id = {e.id: e for e in _provider().spec.endpoint_catalog}
+    for action in _READ_ACTIONS:
+        assert by_id[action].default_policy == EndpointPolicy.ALWAYS
+    for action in _WRITE_ACTIONS:
+        assert by_id[action].default_policy == EndpointPolicy.ASK
+
+
+def test_extract_credentials_happy_path() -> None:
+    creds = _provider().extract_credentials(
+        {
+            "access_token": "tok-123",
+            "refresh_token": "refresh-456",
+            "expires_in": 1800,
+            "token_type": "bearer",
+        }
+    )
+    assert creds["access_token"] == "tok-123"
+    assert creds["refresh_token"] == "refresh-456"
+    assert creds["expires_in"] == 1800
+    assert creds["token_type"] == "bearer"
+
+
+def test_extract_credentials_missing_token_raises() -> None:
+    with pytest.raises(OnyxError):
+        _provider().extract_credentials({"refresh_token": "r", "expires_in": 1800})

--- a/web/src/app/craft/v1/apps/registry.ts
+++ b/web/src/app/craft/v1/apps/registry.ts
@@ -5,6 +5,7 @@ import {
   SvgGithub,
   SvgGoogleCalendar,
   SvgGoogleDrive,
+  SvgHubspot,
 } from "@opal/logos";
 import { SvgPlug } from "@opal/icons";
 import { IconFunctionComponent } from "@opal/types";
@@ -17,6 +18,7 @@ export type ExternalAppType =
   | "GMAIL"
   | "LINEAR"
   | "GITHUB"
+  | "HUBSPOT"
   | "CUSTOM";
 
 const _BUILT_IN_LOGOS: Partial<Record<ExternalAppType, IconFunctionComponent>> =
@@ -27,6 +29,7 @@ const _BUILT_IN_LOGOS: Partial<Record<ExternalAppType, IconFunctionComponent>> =
     GMAIL: SvgGmail,
     LINEAR: SvgLinear,
     GITHUB: SvgGithub,
+    HUBSPOT: SvgHubspot,
   };
 
 /** Logo for a known `app_type`, with a generic fallback for CUSTOM /


### PR DESCRIPTION
Closes https://linear.app/onyx-app/issue/ENG-4172/hubspot-external-app

## Description

Adds HubSpot as a built-in OAuth external app for Craft, mirroring the recently-merged GitHub integration (#11598).

- `ExternalAppType.HUBSPOT` added to the enum.
- `HubSpotProvider(OAuthExternalAppProvider)` with HubSpot's real OAuth + REST surface:
  - authorize `https://app.hubspot.com/oauth/authorize`, token `https://api.hubapi.com/oauth/v1/token`, API base `https://api.hubapi.com`, upstream pattern `https://api\.hubapi\.com/.*`, bearer auth template.
  - Scopes: `crm.objects.contacts.read crm.objects.contacts.write crm.objects.companies.read crm.objects.deals.read oauth` (space-joined, `scope_param="scope"`).
  - Action catalog: read endpoints (account, contacts, companies, deals, CRM search) default to `ALWAYS`; write endpoints (create/update contact) default to `ASK` (require approval).
  - `extract_credentials` maps `access_token` (required), `refresh_token`, `expires_in`, `token_type`. HubSpot uses standard form-encoded refresh, so no `build_refresh_request`/`classify_token_response` override is needed.
  - `AdminDescriptorSpec` with `client_id` / `client_secret` (secret) org-credential fields and setup instructions referencing the `/craft/v1/apps/oauth/callback` callback URL.
- Registered the provider in `providers/registry.py` and the built-in skill in `skills/built_in.py`.
- Bundled sandbox skill `skills/builtin/hubspot/`: `SKILL.md.template` (frontmatter + `{{ACTION_AVAILABILITY_SECTION}}`) and a urllib-based `hubspot_api.py` REST wrapper exposing `me`, `contacts`, `contact`, `companies`, `company`, `deals`, `deal`, `search-contacts`, `create-contact`, `update-contact`, and a raw `call` escape hatch. No credentials are sent by the script (the egress proxy injects the bearer token).
- Frontend `web/src/app/craft/v1/apps/registry.ts`: added `"HUBSPOT"` to the `ExternalAppType` union and mapped it to `SvgHubspot` from `@opal/logos`.

Note: HubSpot is wired as a plain (admin-configurable) `OAuthExternalAppProvider`, not an `OnyxManagedExtApp`, so it requires no `EXT_APP_HUBSPOT_*` managed-credential constants.

## How Has This Been Tested

Run from `backend/`:

- `python -m pytest tests/unit/external_apps/test_hubspot_provider.py -q` → **18 passed**
- `python -m pytest tests/unit/external_apps -q` → **194 passed**
- `python -m pytest tests/unit/onyx/skills -q` → **68 passed**
- `python -c "import onyx.external_apps.providers.registry"` → registry includes HUBSPOT; `EXTERNAL_APP_BUILT_IN_SKILL_IDS[HUBSPOT] == "hubspot"`
- `python onyx/skills/builtin/hubspot/hubspot_api.py -h` → CLI parses

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds HubSpot as a built-in OAuth external app for Craft so users can read/search CRM data and create/update contacts. Addresses ENG-4172 and includes a bundled `hubspot` skill with a simple CLI helper and a new UI icon.

- **New Features**
  - Added `ExternalAppType.HUBSPOT` and registered `HubSpotProvider` with HubSpot OAuth endpoints, scopes, upstream URL pattern, and bearer auth template.
  - Action catalog: reads (account, contacts, companies, deals, search) default to `ALWAYS`; writes (create/update contact) default to `ASK`.
  - Credential extraction maps `access_token`, `refresh_token`, `expires_in`, `token_type`.
  - Bundled `hubspot` skill with `SKILL.md.template` and `hubspot_api.py` commands: `me`, `contacts`, `contact`, `companies`, `company`, `deals`, `deal`, `search-contacts`, `create-contact`, `update-contact`, `call`.
  - Frontend: added `"HUBSPOT"` to the `ExternalAppType` union and mapped to `SvgHubspot` from `@opal/logos`.

- **Migration**
  - In HubSpot, create an app and add the callback URL `/craft/v1/apps/oauth/callback`.
  - In Craft admin, enter `client_id` and `client_secret`, then connect and grant the CRM scopes.

<sup>Written for commit 8ba8deb9560b4295b260b6d82fc7f09841cb3fd6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

