### PR TITLE
fix(gong): configurable API base URL for non-US data residency

### DIFF
--- a/backend/onyx/connectors/gong/connector.py
+++ b/backend/onyx/connectors/gong/connector.py
@@ -419,9 +419,10 @@ class GongConnector(CheckpointedConnector[GongConnectorCheckpoint]):
         base_url = credentials.get("gong_base_url")
         if base_url:
             base_url = base_url.strip().rstrip("/")
-            if base_url.startswith("http://"):
+            lower_url = base_url.lower()
+            if lower_url.startswith("http://"):
                 raise ValueError("gong_base_url must use https")
-            if not base_url.startswith("https://"):
+            if not lower_url.startswith("https://"):
                 base_url = f"https://{base_url}"
             # Restrict to Gong API hosts to avoid pointing requests (which carry
             # the credential) at arbitrary or internal addresses.

--- a/backend/onyx/connectors/gong/connector.py
+++ b/backend/onyx/connectors/gong/connector.py
@@ -7,6 +7,7 @@ from datetime import timedelta
 from datetime import timezone
 from typing import Any
 from typing import cast
+from urllib.parse import urlparse
 
 import requests
 from pydantic import BaseModel
@@ -77,7 +78,10 @@ class _CursorExpiredError(Exception):
 
 
 class GongConnector(CheckpointedConnector[GongConnectorCheckpoint]):
-    BASE_URL = "https://api.gong.io"
+    # Default US host. Overridable per-credential via `gong_base_url` for
+    # non-US data-residency tenants (region-specific host like
+    # https://<region>.api.gong.io).
+    DEFAULT_BASE_URL = "https://api.gong.io"
     # Max number of attempts to resolve missing call details across checkpoint
     # invocations before giving up and emitting ConnectorFailure.
     MAX_CALL_DETAILS_ATTEMPTS = 6
@@ -99,24 +103,29 @@ class GongConnector(CheckpointedConnector[GongConnectorCheckpoint]):
         self.auth_token_basic: str | None = None
         self.hide_user_info = hide_user_info
         self._last_request_time: float = 0.0
+        self.base_url = GongConnector.DEFAULT_BASE_URL
 
         # urllib3 Retry already respects the Retry-After header by default
         # (respect_retry_after_header=True), so on 429 it will sleep for the
         # duration Gong specifies before retrying.
-        retry_strategy = Retry(
+        self._retry_strategy = Retry(
             total=10,
             backoff_factor=2,
             status_forcelist=[429, 500, 502, 503, 504],
         )
 
-        session = requests.Session()
-        session.mount(GongConnector.BASE_URL, HTTPAdapter(max_retries=retry_strategy))
-        self._session = session
+        self._session = requests.Session()
+        self._mount_retry_adapter()
 
-    @staticmethod
-    def make_url(endpoint: str) -> str:
-        url = f"{GongConnector.BASE_URL}{endpoint}"
-        return url
+    def _mount_retry_adapter(self) -> None:
+        # Retry adapters are matched by URL prefix, so the mount must track
+        # base_url whenever it changes (e.g. an EU host from credentials).
+        self._session.mount(
+            self.base_url, HTTPAdapter(max_retries=self._retry_strategy)
+        )
+
+    def make_url(self, endpoint: str) -> str:
+        return f"{self.base_url}{endpoint}"
 
     def _throttled_request(
         self, method: str, url: str, **kwargs: Any
@@ -133,9 +142,7 @@ class GongConnector(CheckpointedConnector[GongConnectorCheckpoint]):
         return response
 
     def _get_workspace_id_map(self) -> dict[str, str]:
-        response = self._throttled_request(
-            "GET", GongConnector.make_url("/v2/workspaces")
-        )
+        response = self._throttled_request("GET", self.make_url("/v2/workspaces"))
         response.raise_for_status()
 
         workspaces_details = response.json().get("workspaces")
@@ -172,7 +179,7 @@ class GongConnector(CheckpointedConnector[GongConnectorCheckpoint]):
             body["cursor"] = cursor
 
         response = self._throttled_request(
-            "POST", GongConnector.make_url("/v2/calls/transcript"), json=body
+            "POST", self.make_url("/v2/calls/transcript"), json=body
         )
         # If no calls in the range, return empty
         if response.status_code == 404:
@@ -199,7 +206,7 @@ class GongConnector(CheckpointedConnector[GongConnectorCheckpoint]):
         }
 
         response = self._throttled_request(
-            "POST", GongConnector.make_url("/v2/calls/extensive"), json=body
+            "POST", self.make_url("/v2/calls/extensive"), json=body
         )
         response.raise_for_status()
 
@@ -409,6 +416,24 @@ class GongConnector(CheckpointedConnector[GongConnectorCheckpoint]):
             checkpoint.pending_retry_after = time.time() + self._next_retry_delay(1)
 
     def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
+        base_url = credentials.get("gong_base_url")
+        if base_url:
+            base_url = base_url.strip().rstrip("/")
+            if base_url.startswith("http://"):
+                raise ValueError("gong_base_url must use https")
+            if not base_url.startswith("https://"):
+                base_url = f"https://{base_url}"
+            # Restrict to Gong API hosts to avoid pointing requests (which carry
+            # the credential) at arbitrary or internal addresses.
+            host = (urlparse(base_url).hostname or "").rstrip(".").lower()
+            if host != "api.gong.io" and not host.endswith(".api.gong.io"):
+                raise ValueError(
+                    "gong_base_url must be a Gong API host "
+                    "(api.gong.io or a region-specific *.api.gong.io host)"
+                )
+            self.base_url = base_url
+            self._mount_retry_adapter()
+
         combined = (
             f"{credentials['gong_access_key']}:{credentials['gong_access_key_secret']}"
         )

--- a/backend/tests/unit/onyx/connectors/gong/test_gong_checkpoint.py
+++ b/backend/tests/unit/onyx/connectors/gong/test_gong_checkpoint.py
@@ -639,3 +639,56 @@ class TestGongConnectorCheckpoint:
         assert checkpoint.cursor is None
         assert checkpoint.workspace_index == 0
         assert checkpoint.has_more is True
+
+
+_GONG_CREDS = {"gong_access_key": "key", "gong_access_key_secret": "secret"}
+
+
+def test_default_base_url_when_not_overridden() -> None:
+    connector = GongConnector()
+    connector.load_credentials(_GONG_CREDS)
+    assert connector.base_url == "https://api.gong.io"
+    assert connector.make_url("/v2/workspaces") == "https://api.gong.io/v2/workspaces"
+
+
+def test_base_url_override_normalizes_scheme_and_trailing_slash() -> None:
+    connector = GongConnector()
+    # No scheme and a trailing slash — both should be normalized.
+    connector.load_credentials(
+        {**_GONG_CREDS, "gong_base_url": "eu-99999.api.gong.io/"}
+    )
+    assert connector.base_url == "https://eu-99999.api.gong.io"
+    assert (
+        connector.make_url("/v2/calls/transcript")
+        == "https://eu-99999.api.gong.io/v2/calls/transcript"
+    )
+
+
+def test_empty_base_url_falls_back_to_default() -> None:
+    connector = GongConnector()
+    connector.load_credentials({**_GONG_CREDS, "gong_base_url": ""})
+    assert connector.base_url == "https://api.gong.io"
+
+
+def test_base_url_rejects_non_gong_host() -> None:
+    connector = GongConnector()
+    with pytest.raises(ValueError):
+        connector.load_credentials(
+            {**_GONG_CREDS, "gong_base_url": "https://attacker.example.com"}
+        )
+
+
+def test_base_url_rejects_host_spoofing_gong_suffix() -> None:
+    connector = GongConnector()
+    with pytest.raises(ValueError):
+        connector.load_credentials(
+            {**_GONG_CREDS, "gong_base_url": "https://api.gong.io.attacker.com"}
+        )
+
+
+def test_base_url_rejects_http_scheme() -> None:
+    connector = GongConnector()
+    with pytest.raises(ValueError):
+        connector.load_credentials(
+            {**_GONG_CREDS, "gong_base_url": "http://eu-99999.api.gong.io"}
+        )

--- a/backend/tests/unit/onyx/connectors/gong/test_gong_checkpoint.py
+++ b/backend/tests/unit/onyx/connectors/gong/test_gong_checkpoint.py
@@ -686,9 +686,10 @@ def test_base_url_rejects_host_spoofing_gong_suffix() -> None:
         )
 
 
-def test_base_url_rejects_http_scheme() -> None:
+@pytest.mark.parametrize("scheme", ["http", "HTTP", "HtTp"])
+def test_base_url_rejects_http_scheme(scheme: str) -> None:
     connector = GongConnector()
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="must use https"):
         connector.load_credentials(
-            {**_GONG_CREDS, "gong_base_url": "http://eu-99999.api.gong.io"}
+            {**_GONG_CREDS, "gong_base_url": f"{scheme}://eu-99999.api.gong.io"}
         )

--- a/web/src/lib/connectors/credentials.ts
+++ b/web/src/lib/connectors/credentials.ts
@@ -141,6 +141,7 @@ export interface GuruCredentialJson {
 export interface GongCredentialJson {
   gong_access_key: string;
   gong_access_key_secret: string;
+  gong_base_url: string | null;
 }
 
 export interface LoopioCredentialJson {
@@ -321,6 +322,7 @@ export const credentialTemplates: Record<ValidSources, any> = {
   gong: {
     gong_access_key: "",
     gong_access_key_secret: "",
+    gong_base_url: null,
   } as GongCredentialJson,
   zulip: { zuliprc_content: "" } as ZulipCredentialJson,
   linear: { linear_access_token: "" } as LinearCredentialJson,
@@ -556,6 +558,8 @@ export const credentialDisplayNames: Record<string, string> = {
   // Gong
   gong_access_key: "Gong Access Key",
   gong_access_key_secret: "Gong Access Key Secret",
+  gong_base_url:
+    "Gong API Base URL (optional; set your region-specific host like https://<region>.api.gong.io for non-US data residency)",
 
   // Loopio
   loopio_subdomain: "Loopio Subdomain",


### PR DESCRIPTION
## Description

Gong connectors hardcoded the API host to `https://api.gong.io`. Gong tenants on a non-US data-residency region live on a region-specific host (e.g. `*.api.gong.io`), so for those tenants valid credentials were being sent to the wrong region and rejected with a `401 Unauthorized` on every indexing run. There was no way to configure the host from the credential dialog.

This adds an optional **Gong API Base URL** credential field (`gong_base_url`) that overrides the default host. When unset, behavior is unchanged (defaults to `https://api.gong.io`).

Handling/hardening:
- Input is normalized — scheme defaults to `https://` and a trailing slash is stripped.
- HTTPS-only — an `http://` value is rejected.
- The host is restricted to `api.gong.io` / `*.api.gong.io`, so the credential can't be pointed at an arbitrary or internal address (SSRF guard).
- The retry adapter is re-mounted on the configured host (adapters are matched by URL prefix).

## How Has This Been Tested?

Added unit tests in `backend/tests/unit/onyx/connectors/gong/test_gong_checkpoint.py` covering:
- default host when no override is set,
- override normalization (missing scheme + trailing slash),
- empty value falling back to the default,
- rejection of a non-Gong host, a suffix-spoofing host (`api.gong.io.attacker.com`), and an `http://` scheme.

All Gong unit tests pass (`pytest backend/tests/unit/onyx/connectors/gong`).

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Gong connector’s API base URL configurable to support non‑US data residency. Fixes 401s for region-hosted tenants by allowing a region-specific `*.api.gong.io` host.

- **Bug Fixes**
  - Added optional `gong_base_url` credential; defaults to `https://api.gong.io` when unset.
  - Input hardening: HTTPS only (case-insensitive), auto-add scheme, strip trailing slash, restrict to `api.gong.io` or `*.api.gong.io`.
  - Remount retry adapter for the configured host; added unit tests and updated web credential schema/display.

- **Migration**
  - For non‑US Gong tenants, set `gong_base_url` to your region host (e.g., https://<region>.api.gong.io). No action needed for US tenants.

<sup>Written for commit f85565eab506f3231959797a37eca4b94844d0cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

