### PR TITLE
fix(llm): resolve vision support for dynamic-provider models + clearer 413

### DIFF
--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -367,8 +367,10 @@ def sync_model_configurations(
 ) -> int:
     """Sync model configurations for a dynamic provider (OpenRouter, Bedrock, Ollama, etc.).
 
-    This inserts NEW models from the source API without overwriting existing ones.
-    User preferences (is_visible, max_input_tokens) are preserved for existing models.
+    Inserts NEW models from the source API and, for models that already exist,
+    upgrades their capability flows (VISION/REASONING) when the source newly
+    reports support. Flags are only ever added, never removed, so admin overrides
+    and user preferences (is_visible, max_input_tokens) are preserved.
 
     Args:
         db_session: Database session
@@ -382,12 +384,13 @@ def sync_model_configurations(
     if not provider:
         raise ValueError(f"LLM Provider '{provider_name}' not found")
 
-    # Get existing model names to count new additions
-    existing_names = {mc.name for mc in provider.model_configurations}
+    existing_by_name = {mc.name: mc for mc in provider.model_configurations}
 
     new_count = 0
+    upgraded_flow_count = 0
     for model in models:
-        if model.name not in existing_names:
+        existing = existing_by_name.get(model.name)
+        if existing is None:
             # Insert new model with is_visible=False (user must explicitly enable)
             supported_flows = [LLMModelFlowType.CHAT]
             if model.supports_image_input:
@@ -405,8 +408,29 @@ def sync_model_configurations(
                 display_name=model.display_name,
             )
             new_count += 1
+            continue
 
-    if new_count > 0:
+        # Existing model: add any newly-reported capability flows so a re-fetch
+        # repairs rows that were synced before the source exposed the capability.
+        existing_flows = set(existing.llm_model_flow_types)
+        missing_flows: list[LLMModelFlowType] = []
+        if model.supports_image_input and LLMModelFlowType.VISION not in existing_flows:
+            missing_flows.append(LLMModelFlowType.VISION)
+        if (
+            model.supports_reasoning
+            and LLMModelFlowType.REASONING not in existing_flows
+        ):
+            missing_flows.append(LLMModelFlowType.REASONING)
+
+        for flow_type in missing_flows:
+            create_new_flow_mapping__no_commit(
+                db_session=db_session,
+                model_configuration_id=existing.id,
+                flow_type=flow_type,
+            )
+            upgraded_flow_count += 1
+
+    if new_count > 0 or upgraded_flow_count > 0:
         db_session.commit()
 
     return new_count

--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -367,10 +367,10 @@ def sync_model_configurations(
 ) -> int:
     """Sync model configurations for a dynamic provider (OpenRouter, Bedrock, Ollama, etc.).
 
-    Inserts NEW models from the source API and, for models that already exist,
-    upgrades their capability flows (VISION/REASONING) when the source newly
-    reports support. Flags are only ever added, never removed, so admin overrides
-    and user preferences (is_visible, max_input_tokens) are preserved.
+    Inserts NEW models and, for existing ones, adds any newly-reported capability
+    flag (VISION/REASONING). Flags are only added, never removed; is_visible and
+    max_input_tokens are preserved. Caveat: an admin-removed flow is re-added on
+    the next sync (ENG-4233).
 
     Args:
         db_session: Database session
@@ -410,8 +410,8 @@ def sync_model_configurations(
             new_count += 1
             continue
 
-        # Existing model: add any newly-reported capability flows so a re-fetch
-        # repairs rows that were synced before the source exposed the capability.
+        # Existing model: add newly-reported capability flags (additive only).
+        # TODO(ENG-4233): durable admin flow removals; avoid per-model lazy-load.
         existing_flows = set(existing.llm_model_flow_types)
         missing_flows: list[LLMModelFlowType] = []
         if model.supports_image_input and LLMModelFlowType.VISION not in existing_flows:

--- a/backend/onyx/llm/utils.py
+++ b/backend/onyx/llm/utils.py
@@ -298,6 +298,20 @@ def litellm_exception_to_error_msg(
         error_msg = "Request timed out: The operation took too long to complete. Please try again."
         error_code = "CONNECTION_ERROR"
         is_retryable = True
+    elif str(getattr(core_exception, "status_code", "")) == "413" or (
+        "413" in error_msg and "request entity too large" in error_msg.lower()
+    ):
+        # An upstream proxy/gateway (e.g. nginx) rejected the request body as too
+        # large. Most common when sending images to a model behind a gateway.
+        error_msg = (
+            "Request too large: The LLM endpoint rejected the request because it "
+            "exceeded the maximum allowed size (HTTP 413). This commonly happens "
+            "when sending images to a model behind a proxy/gateway. Increase the "
+            "maximum request body size on the gateway in front of your LLM "
+            "endpoint (e.g. nginx `client_max_body_size`)."
+        )
+        error_code = "REQUEST_TOO_LARGE"
+        is_retryable = False
     elif isinstance(core_exception, APIError):
         error_msg = f"API error: An error occurred while communicating with the API. Details: {str(core_exception)}"
         error_code = "API_ERROR"

--- a/backend/onyx/llm/utils.py
+++ b/backend/onyx/llm/utils.py
@@ -301,8 +301,7 @@ def litellm_exception_to_error_msg(
     elif str(getattr(core_exception, "status_code", "")) == "413" or (
         "413" in error_msg and "request entity too large" in error_msg.lower()
     ):
-        # An upstream proxy/gateway (e.g. nginx) rejected the request body as too
-        # large. Most common when sending images to a model behind a gateway.
+        # Upstream proxy/gateway (e.g. nginx) rejected the request body as too large.
         error_msg = (
             "Request too large: The LLM endpoint rejected the request because it "
             "exceeded the maximum allowed size (HTTP 413). This commonly happens "

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -257,9 +257,8 @@ class ModelConfigurationView(BaseModel):
                 name=model_configuration_model.name,
                 is_visible=model_configuration_model.is_visible,
                 max_input_tokens=model_configuration_model.max_input_tokens,
-                # Dynamic/aggregator providers (Bifrost, OpenRouter, etc.) and
-                # custom-config providers (LiteLLM Proxy) under-report vision;
-                # fall back to the LiteLLM cost map when no VISION flow is stored.
+                # Dynamic/custom-config providers under-report vision; fall back
+                # to the LiteLLM cost map when no VISION flow is stored.
                 supports_image_input=(
                     LLMModelFlowType.VISION
                     in model_configuration_model.llm_model_flow_types

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -257,16 +257,14 @@ class ModelConfigurationView(BaseModel):
                 name=model_configuration_model.name,
                 is_visible=model_configuration_model.is_visible,
                 max_input_tokens=model_configuration_model.max_input_tokens,
-                # Custom-config providers (LiteLLM Proxy, etc.) under-report
-                # vision; fall back to the LiteLLM cost map when no VISION flow.
+                # Dynamic/aggregator providers (Bifrost, OpenRouter, etc.) and
+                # custom-config providers (LiteLLM Proxy) under-report vision;
+                # fall back to the LiteLLM cost map when no VISION flow is stored.
                 supports_image_input=(
                     LLMModelFlowType.VISION
                     in model_configuration_model.llm_model_flow_types
-                    or (
-                        use_stored_display_name
-                        and litellm_thinks_model_supports_image_input(
-                            model_configuration_model.name, provider_name
-                        )
+                    or litellm_thinks_model_supports_image_input(
+                        model_configuration_model.name, provider_name
                     )
                 ),
                 # Prefer the stored REASONING flow; fall back to a substring

--- a/backend/tests/unit/onyx/db/test_llm_sync.py
+++ b/backend/tests/unit/onyx/db/test_llm_sync.py
@@ -5,9 +5,18 @@ from unittest.mock import patch
 
 import pytest
 
+from onyx.db.enums import LLMModelFlowType
 from onyx.db.llm import sync_model_configurations
 from onyx.llm.constants import LlmProviderNames
 from onyx.server.manage.llm.models import SyncModelEntry
+
+
+def _make_existing_model(name: str, flow_types: list[LLMModelFlowType]) -> MagicMock:
+    model = MagicMock()
+    model.id = 42
+    model.name = name
+    model.llm_model_flow_types = flow_types
+    return model
 
 
 class TestSyncModelConfigurations:
@@ -53,10 +62,11 @@ class TestSyncModelConfigurations:
             mock_session.commit.assert_called_once()
 
     def test_skips_existing_models(self) -> None:
-        """Test that existing models are not overwritten."""
-        # Mock existing model
-        mock_existing_model = MagicMock()
-        mock_existing_model.name = "gpt-4"
+        """Existing models with up-to-date flows are left untouched."""
+        # Existing model already has the capabilities the source reports.
+        mock_existing_model = _make_existing_model(
+            "gpt-4", [LLMModelFlowType.CHAT, LLMModelFlowType.VISION]
+        )
 
         mock_provider = MagicMock()
         mock_provider.id = 1
@@ -92,9 +102,10 @@ class TestSyncModelConfigurations:
             assert mock_session.execute.call_count == 3
 
     def test_no_commit_when_no_new_models(self) -> None:
-        """Test that commit is not called when no new models."""
-        mock_existing_model = MagicMock()
-        mock_existing_model.name = "gpt-4"
+        """Test that commit is not called when nothing new or upgraded."""
+        mock_existing_model = _make_existing_model(
+            "gpt-4", [LLMModelFlowType.CHAT, LLMModelFlowType.VISION]
+        )
 
         mock_provider = MagicMock()
         mock_provider.id = 1
@@ -196,3 +207,73 @@ class TestSyncModelConfigurations:
             # Verify execute was called with correct defaults
             call_args = mock_session.execute.call_args
             assert call_args is not None
+
+    def test_upgrades_existing_model_vision_flow(self) -> None:
+        """Existing model gains a VISION flow when the source newly reports it.
+
+        Repairs rows synced before the source exposed vision (e.g. a Bifrost
+        model added before vision detection resolved correctly). Returns 0 new
+        models but commits the added flow.
+        """
+        mock_existing_model = _make_existing_model("gemini", [LLMModelFlowType.CHAT])
+
+        mock_provider = MagicMock()
+        mock_provider.id = 1
+        mock_provider.model_configurations = [mock_existing_model]
+
+        mock_session = MagicMock()
+
+        with patch(
+            "onyx.db.llm.fetch_existing_llm_provider", return_value=mock_provider
+        ):
+            models = [
+                SyncModelEntry(
+                    name="gemini",
+                    display_name="Gemini",
+                    supports_image_input=True,
+                ),
+            ]
+
+            result = sync_model_configurations(
+                db_session=mock_session,
+                provider_name=LlmProviderNames.BIFROST,
+                models=models,
+            )
+
+            assert result == 0  # No new models, only an upgraded flow
+            assert mock_session.execute.call_count == 1  # One VISION flow insert
+            mock_session.commit.assert_called_once()
+
+    def test_does_not_remove_flows(self) -> None:
+        """Capability flags are only added, never removed: a model that already
+        has VISION keeps it even if the source omits it this fetch."""
+        mock_existing_model = _make_existing_model(
+            "gemini", [LLMModelFlowType.CHAT, LLMModelFlowType.VISION]
+        )
+
+        mock_provider = MagicMock()
+        mock_provider.id = 1
+        mock_provider.model_configurations = [mock_existing_model]
+
+        mock_session = MagicMock()
+
+        with patch(
+            "onyx.db.llm.fetch_existing_llm_provider", return_value=mock_provider
+        ):
+            models = [
+                SyncModelEntry(
+                    name="gemini",
+                    display_name="Gemini",
+                    supports_image_input=False,
+                ),
+            ]
+
+            result = sync_model_configurations(
+                db_session=mock_session,
+                provider_name=LlmProviderNames.BIFROST,
+                models=models,
+            )
+
+            assert result == 0
+            mock_session.execute.assert_not_called()
+            mock_session.commit.assert_not_called()

--- a/backend/tests/unit/onyx/llm/test_llm_exception_classification.py
+++ b/backend/tests/unit/onyx/llm/test_llm_exception_classification.py
@@ -4,6 +4,7 @@ BadRequestError and must be matched first, or context overflow is mislabeled
 BAD_REQUEST instead of CONTEXT_TOO_LONG.
 """
 
+from litellm.exceptions import APIError
 from litellm.exceptions import BadRequestError
 from litellm.exceptions import ContentPolicyViolationError
 from litellm.exceptions import ContextWindowExceededError
@@ -13,6 +14,13 @@ from onyx.llm.utils import litellm_exception_to_error_msg
 
 def _err(exc_cls: type[BadRequestError]) -> BadRequestError:
     return exc_cls("boom", model="m", llm_provider="p")
+
+
+_NGINX_413_HTML = (
+    "<html>\n<head><title>413 Request Entity Too Large</title></head>\n"
+    "<body>\n<center><h1>413 Request Entity Too Large</h1></center>\n"
+    "<hr><center>nginx</center>\n</body>\n</html>"
+)
 
 
 def test_context_window_exceeded_classified_before_bad_request() -> None:
@@ -31,3 +39,34 @@ def test_content_policy_classified_before_bad_request() -> None:
 def test_plain_bad_request_still_bad_request() -> None:
     _, code, _ = litellm_exception_to_error_msg(_err(BadRequestError), None)
     assert code == "BAD_REQUEST"
+
+
+def test_413_status_code_classified_as_request_too_large() -> None:
+    """A gateway 413 (e.g. nginx rejecting a large image payload) maps to an
+    actionable message instead of dumping the raw HTML."""
+    exc = APIError(
+        status_code=413,
+        message=_NGINX_413_HTML,
+        llm_provider="bifrost",
+        model="vertex/gemini-3-pro-image-preview",
+    )
+    msg, code, is_retryable = litellm_exception_to_error_msg(exc, None)
+    assert code == "REQUEST_TOO_LARGE"
+    assert is_retryable is False
+    assert "413" in msg
+    assert "client_max_body_size" in msg
+    # Raw nginx HTML should not be surfaced to the user.
+    assert "<html>" not in msg
+
+
+def test_413_in_message_classified_when_status_code_absent() -> None:
+    """Some upstreams surface the 413 only in the body; match on text too."""
+    exc = APIError(
+        status_code=500,  # upstream mislabels; body is the source of truth
+        message=_NGINX_413_HTML,
+        llm_provider="bifrost",
+        model="m",
+    )
+    # status_code 500 won't match the numeric branch, but the body text will.
+    _, code, _ = litellm_exception_to_error_msg(exc, None)
+    assert code == "REQUEST_TOO_LARGE"

--- a/backend/tests/unit/onyx/server/manage/llm/test_fetch_models_api.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_fetch_models_api.py
@@ -411,9 +411,15 @@ class TestGetOpenRouterAvailableModels:
 
         mock_session = MagicMock()
 
-        # Provider already has claude model
+        # Provider already has claude model, with capability flows already
+        # up to date so the sync leaves it untouched.
         existing_model = MagicMock()
         existing_model.name = "anthropic/claude-3.5-sonnet"
+        existing_model.llm_model_flow_types = [
+            LLMModelFlowType.CHAT,
+            LLMModelFlowType.VISION,
+            LLMModelFlowType.REASONING,
+        ]
 
         mock_provider = MagicMock()
         mock_provider.id = 1

--- a/backend/tests/unit/onyx/server/manage/llm/test_model_configuration.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_model_configuration.py
@@ -129,15 +129,30 @@ class TestModelConfigurationViewVisionFallback:
 
         assert view.supports_image_input is True
 
-    def test_strict_dynamic_provider_does_not_fall_back(self) -> None:
-        """Strict dynamic providers trust the synced flow — no cost-map fallback."""
+    def test_strict_dynamic_provider_falls_back_to_cost_map(self) -> None:
+        """Dynamic/aggregator providers (e.g. Bifrost) also fall back to the cost
+        map when no VISION flow is stored — a model synced before the source
+        reported vision still resolves to True."""
         mc = _make_model_config(
-            name="gpt-4o",
-            display_name="GPT-4o",
+            name="vertex/gemini-3-pro-image-preview",
+            display_name="Gemini 3 Pro Image Preview",
             flow_types=[LLMModelFlowType.CHAT],
         )
 
         view = self._view(mc, self.STRICT_DYNAMIC_PROVIDER, False, litellm_vision=True)
+
+        assert view.supports_image_input is True
+
+    def test_strict_dynamic_provider_false_when_cost_map_unaware(self) -> None:
+        """Dynamic provider with no VISION flow and a cost map that doesn't know
+        the model → False (no spurious vision support)."""
+        mc = _make_model_config(
+            name="my-internal-model",
+            display_name="My Internal Model",
+            flow_types=[LLMModelFlowType.CHAT],
+        )
+
+        view = self._view(mc, self.STRICT_DYNAMIC_PROVIDER, False, litellm_vision=False)
 
         assert view.supports_image_input is False
 


### PR DESCRIPTION
## Description

Fixes image input being blocked for models served through dynamic/aggregator LLM providers (Bifrost, OpenRouter, custom OpenAI-compatible gateways), reported on v4.1.4 with `vertex/gemini-3-pro-image-preview` via a Bifrost provider.

Two distinct failures were happening on the same model:

1. **"The current model does not support image input" toast on new uploads.** The model was stored with only a `CHAT` capability flow, so the model-config API reported `supports_image_input=false`. A prior fix (#12157) corrected the *fetch* path to consult the LiteLLM cost map, but it never reached models that were already configured.
2. **`413 Request Entity Too Large` on previously-uploaded images.** This originates from nginx in front of the customer's gateway rejecting the base64 image payload — it surfaced as a raw nginx HTML blob in the UI.

This PR addresses the Onyx side of both:

- **`ModelConfigurationView.from_model`** — fall back to the LiteLLM cost map for vision on *all* dynamic providers, not only `custom_config` ones. The previously-synced model now resolves `supports_image_input` correctly at read time, so an upgrade fixes the toast with **no admin action required** (no delete/recreate).
- **`sync_model_configurations`** — on re-fetch, upgrade an existing model's capability flows (`VISION`/`REASONING`) when the source newly reports support. Flags are only ever *added*, never removed, so admin overrides and user prefs are preserved. Previously re-fetch only inserted new models, so a stale row stayed broken forever — the reason #12157 didn't help already-configured models.
- **`litellm_exception_to_error_msg`** — map an upstream HTTP 413 to an actionable message ("increase the gateway's max request body size, e.g. nginx `client_max_body_size`") instead of dumping raw nginx HTML.

Note: the 413 itself is a gateway-side limit (the operator must raise `client_max_body_size`); this PR makes the failure self-explanatory rather than silently downscaling image-edit inputs.

## How Has This Been Tested?

Unit tests (all passing):
- `test_model_configuration.py` — dynamic provider with no stored `VISION` flow but cost-map vision support → `supports_image_input=true`; and stays `false` when the cost map is unaware.
- `test_llm_sync.py` — existing model gains a `VISION` flow on re-fetch when newly reported; flags are never removed; no commit when nothing changes.
- `test_llm_exception_classification.py` — upstream 413 (by status code and by body text) → `REQUEST_TOO_LARGE` with an actionable message, raw HTML not surfaced.
- `test_fetch_models_api.py` — updated existing-model sync expectation for flow reconciliation.

`pre-commit run --files` (ty, ruff, ruff format) passes on all changed files.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes blocked image uploads for models behind dynamic providers (Bifrost, OpenRouter, OpenAI-compatible gateways) and shows a clear, actionable message for HTTP 413 errors. Existing models now resolve vision support correctly without admin action; re-syncs add missing capability flows.

- **Bug Fixes**
  - `ModelConfigurationView.from_model`: fall back to the LiteLLM cost map for vision on all dynamic/aggregator providers so `supports_image_input` is correct even when no `VISION` flow is stored.
  - `sync_model_configurations`: on re-fetch, add missing capability flows (`VISION`, `REASONING`) to existing models; never remove flags; commit when new or upgraded. Caveat: admin-removed flows are re-added on sync (Linear ENG-4233).
  - `litellm_exception_to_error_msg`: classify HTTP 413 as `REQUEST_TOO_LARGE` (including when only present in the body) and advise increasing the gateway’s max body size instead of surfacing raw HTML.

- **Migration**
  - No admin changes needed for vision support; upgrade and re-fetch will reconcile flows.
  - If you hit 413 errors, increase the gateway’s request body limit (e.g., `nginx` `client_max_body_size`).

<sup>Written for commit 642309066fbedf591988dbc343c835dbe20471f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

