### PR TITLE
refactor(comments): replace mentions of `mypy` with app-agnostic comment

### DIFF
--- a/backend/ee/onyx/server/tenants/provisioning.py
+++ b/backend/ee/onyx/server/tenants/provisioning.py
@@ -106,7 +106,7 @@ async def get_or_provision_tenant(
         if tenant_id:
             # Run migrations to ensure the pre-provisioned tenant schema is current.
             # Pool tenants may have been created before a new migration was deployed.
-            # Capture as a non-optional local so mypy can type the lambda correctly.
+            # Capture as a non-optional local so type-checking can type the lambda correctly.
             _tenant_id: str = tenant_id
             loop = asyncio.get_running_loop()
             try:

--- a/backend/onyx/chat/llm_step.py
+++ b/backend/onyx/chat/llm_step.py
@@ -1015,7 +1015,7 @@ def translate_history_to_llm_format(
             suffix=messages[last_cacheable_msg_idx + 1 :],
             continuation=False,
         )
-        assert isinstance(processed_messages, list)  # for mypy
+        assert isinstance(processed_messages, list)  # for type-checking
         messages = processed_messages
 
     return messages

--- a/backend/onyx/chat/models.py
+++ b/backend/onyx/chat/models.py
@@ -101,7 +101,7 @@ class ChatLoadedFile(InMemoryChatFile):
 
     # Named distinctly from the base ``lazy_from_descriptor`` so the subclass
     # can require ``content_text`` / ``token_count`` without violating LSP on
-    # the override (ty/mypy correctly flag the broader subclass signature).
+    # the override (ty correctly flag the broader subclass signature).
     @classmethod
     def lazy_loaded(
         cls,

--- a/backend/onyx/connectors/github/connector.py
+++ b/backend/onyx/connectors/github/connector.py
@@ -698,7 +698,7 @@ class GithubConnector(
         Returns:
             list[Repository.Repository]: The configured repositories.
         """
-        assert self.github_client is not None  # mypy
+        assert self.github_client is not None  # for type-checking
         if self.repositories:
             if "," in self.repositories:
                 return self.get_github_repos(self.github_client)
@@ -735,7 +735,7 @@ class GithubConnector(
                 "Re-tried listing repo files too many times. "
                 "Something is going wrong with fetching objects from Github"
             )
-        assert self.github_client is not None  # mypy
+        assert self.github_client is not None  # for type-checking
         try:
             git_tree = repo.get_git_tree(repo.default_branch, recursive=True)
             truncated = bool(git_tree.raw_data.get("truncated"))
@@ -765,7 +765,7 @@ class GithubConnector(
                 "Re-tried fetching file content too many times. "
                 "Something is going wrong with fetching objects from Github"
             )
-        assert self.github_client is not None  # mypy
+        assert self.github_client is not None  # for type-checking
         try:
             content = repo.get_contents(path, ref=repo.default_branch)
             if isinstance(content, list):

--- a/backend/onyx/connectors/notion/connector.py
+++ b/backend/onyx/connectors/notion/connector.py
@@ -986,7 +986,7 @@ class NotionConnector(LoadConnector, PollConnector):
         res.raise_for_status()
         return NotionSearchResponse(**res.json())
 
-    # The | Document is needed for mypy type checking
+    # The | Document is needed for type-checking
     def _yield_database_hierarchy_nodes(
         self,
     ) -> Generator[HierarchyNode | Document, None, None]:

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -2020,7 +2020,7 @@ class SharepointConnector(
 
         initial_url = f"{self.graph_api_base}/drives/{drive_id}/root/delta"
         if use_timestamp_token:
-            assert start is not None  # mypy
+            assert start is not None  # for type-checking
             token = quote(start.isoformat(timespec="seconds"))
             initial_url += f"?token={token}"
 

--- a/backend/onyx/natural_language_processing/search_nlp_models.py
+++ b/backend/onyx/natural_language_processing/search_nlp_models.py
@@ -880,7 +880,7 @@ class EmbeddingModel:
         if self.embed_server_endpoint is None:
             raise ValueError("Model server endpoint is not configured for local models")
 
-        # Store the endpoint in a local variable to help mypy understand it's not None
+        # Store the endpoint in a local variable to help the type-checker understand it's not None
         endpoint = self.embed_server_endpoint
 
         def _make_request() -> Response:

--- a/backend/onyx/onyxbot/discord/client.py
+++ b/backend/onyx/onyxbot/discord/client.py
@@ -118,7 +118,7 @@ class OnyxDiscordClient(commands.Bot):
 
     async def on_message(self, message: discord.Message) -> None:
         """Main message handler."""
-        # mypy
+        # for type-checking
         if not self.user:
             raise RuntimeError("Critical error: Discord Bot user not found")
 

--- a/backend/onyx/onyxbot/discord/handle_commands.py
+++ b/backend/onyx/onyxbot/discord/handle_commands.py
@@ -160,7 +160,7 @@ async def _register_guild(
 ) -> None:
     """Register a guild with a registration key."""
     if not message.guild:
-        # mypy, even though we already know that message.guild is not None
+        # for type-checking, even though we already know that message.guild is not None
         raise RegistrationError("This command can only be used in a server.")
 
     logger.info("Guild '%s' attempting to register Discord bot", message.guild.name)

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -1807,7 +1807,7 @@ def _list_mcp_tools_by_id(
 
     if mcp_server.auth_type == MCPAuthenticationType.OAUTH:
         # TODO: just pass this in, but should work when auth is set already
-        assert connection_config  # for mypy
+        assert connection_config  # for type-checking
         auth = make_oauth_provider(
             mcp_server,
             user_id,
@@ -2139,7 +2139,7 @@ def _upsert_mcp_server(
 
     elif request.auth_performer == MCPAuthenticationPerformer.PER_USER:
         if request.auth_type == MCPAuthenticationType.API_TOKEN:
-            # handled by model validation, this is just for mypy
+            # handled by model validation, this is just for type-checking
             assert request.auth_template and request.admin_credentials
 
             # Per-user server: create template and save creator's per-user config

--- a/backend/onyx/tools/tool_implementations/mcp/mcp_client.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_client.py
@@ -135,7 +135,7 @@ def _create_mcp_client_function_runner(
     # with SSE (infinite stream). Avoid passing auth for SSE; rely on headers.
     auth_for_request = auth if transport == MCPTransport.STREAMABLE_HTTP else None
 
-    # doing this here for mypy
+    # doing this here for type-checking
     client_func = (
         streamablehttp_client
         if transport == MCPTransport.STREAMABLE_HTTP
@@ -152,7 +152,7 @@ def _create_mcp_client_function_runner(
             if len(client_tuple) == 3:
                 read, write, _ = client_tuple
             elif len(client_tuple) == 2:
-                assert isinstance(client_tuple, tuple)  # mypy
+                assert isinstance(client_tuple, tuple)  # for type-checking
                 read, write = client_tuple  # ty: ignore[invalid-assignment]
             else:
                 raise ValueError(

--- a/backend/onyx/tracing/framework/provider.py
+++ b/backend/onyx/tracing/framework/provider.py
@@ -304,7 +304,7 @@ class DefaultTraceProvider(TraceProvider):
             parent_id = parent.span_id
             trace_id = parent.trace_id
         else:
-            # This should never happen, but mypy needs it
+            # This should never happen, but type-checking needs it
             raise ValueError(f"Invalid parent type: {type(parent)}")
 
         return SpanImpl(

--- a/backend/scripts/tenant_cleanup/on_pod_scripts/check_documents_deleted.py
+++ b/backend/scripts/tenant_cleanup/on_pod_scripts/check_documents_deleted.py
@@ -47,7 +47,7 @@ def check_documents_deleted(tenant_id: str) -> dict:
             # Count Documents
             doc_count = db_session.scalar(select(func.count()).select_from(Document))
 
-        # Handle None values from scalar (should not happen but mypy needs it)
+        # Handle None values from scalar (should not happen but the type-checker needs it)
         cc_count = cc_count or 0
         doc_count = doc_count or 0
 

--- a/backend/tests/integration/tests/pat/test_pat_api.py
+++ b/backend/tests/integration/tests/pat/test_pat_api.py
@@ -364,7 +364,7 @@ def test_pat_role_based_access_control(reset: None) -> None:  # noqa: ARG001
         user_performing_action=global_curator_user,
     )
 
-    # Verify all tokens are present (type narrowing for mypy)
+    # Verify all tokens are present (type narrowing for the type-checker)
     assert admin_pat.token is not None
     assert basic_pat.token is not None
     assert curator_pat.token is not None

--- a/backend/tests/unit/onyx/connectors/jira/test_jira_large_ticket_handling.py
+++ b/backend/tests/unit/onyx/connectors/jira/test_jira_large_ticket_handling.py
@@ -97,7 +97,7 @@ def test_fetch_jira_issues_batch_small_ticket(
 
     assert len(docs) == 1
     doc = docs[0]
-    assert doc is not None  # Type assertion for mypy
+    assert doc is not None  # for type-checking
     assert doc.id.endswith("/SMALL-1")
     assert doc.sections[0].text is not None
     assert "Small description" in doc.sections[0].text
@@ -141,7 +141,7 @@ def test_fetch_jira_issues_batch_mixed_tickets(
 
     assert len(docs) == 1  # Only the small ticket should be included
     doc = docs[0]
-    assert doc is not None  # Type assertion for mypy
+    assert doc is not None  # for type-checking
     assert doc.id.endswith("/SMALL-1")
 
 

--- a/backend/tests/unit/onyx/llm/test_tracing_wrap.py
+++ b/backend/tests/unit/onyx/llm/test_tracing_wrap.py
@@ -204,7 +204,7 @@ def test_outer_guard_false_for_finished_span_leaked_into_contextvar() -> None:
 
 # `functools.wraps` sets __wrapped__ on the auto-wrapped methods so the
 # underlying (undecorated) function is reachable for signature introspection.
-# mypy doesn't know about this attribute on the Callable type, so we access
+# The type-checker doesn't know about this attribute on the Callable type, so we access
 # it via getattr below.
 
 


### PR DESCRIPTION
## Description

Claude routinely defaults to `mypy` for validation and inevitably gets command not found errors, so trying to help steer it away a bit beforehand (without changing a more load-bearing file like `CLAUDE.md`).

## How Has This Been Tested?

no-op

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced "mypy" mentions in comments with generic "type-checking" language across the backend to keep the codebase tool-agnostic. No functional changes; comments only.

<sup>Written for commit bf0630f1c1b7cb6fcd4445bc7ddf1cc2e7961c7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12267?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

