### PR TITLE
feat(helm): allow disabling API startup migrations

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.6.4
+version: 0.6.5
 appVersion: latest
 annotations:
   category: Productivity
@@ -16,11 +16,11 @@ annotations:
     - name: background
       image: docker.io/onyxdotapp/onyx-backend:latest
   artifacthub.io/changes: |
-    - kind: security
-      description: Set readOnlyRootFilesystem on the Craft sandbox egress proxy
-        (it holds tenant credentials) so an RCE cannot drop or persist a binary.
-        The proxy logs to stdout only (LOG_TO_FILE=false), leaving the mitmproxy
-        CA confdir as the single writable mount, which also serves as TMPDIR.
+    - kind: added
+      description: Add the api.runStartupMigrations value (defaults on, including
+        on helm upgrade --reuse-values where the key is absent) to allow
+        disabling API-server startup migrations when a coordinated deployment
+        step runs them instead.
 dependencies:
   - name: cloudnative-pg
     version: 0.26.0

--- a/deployment/helm/charts/onyx/templates/api-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/api-deployment.yaml
@@ -70,7 +70,9 @@ spec:
               {{- if or .Values.api.runUpdateCaCertificates (include "onyx.customCACerts.enabled" .) }}
               update-ca-certificates &&
               {{- end }}
+              {{- if or (not (hasKey .Values.api "runStartupMigrations")) .Values.api.runStartupMigrations }}
               alembic upgrade head &&
+              {{- end }}
               echo "Starting Onyx Api Server" &&
               uvicorn onyx.main:app --host {{ .Values.global.host }} --port {{ .Values.api.containerPorts.server }}
           ports:

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -501,6 +501,8 @@ api:
   tolerations: []
   affinity: {}
 
+  # Disable only when a separate deployment step runs migrations.
+  runStartupMigrations: true
   # Run update-ca-certificates before starting the server.
   # DEPRECATED: prefer the top-level customCACerts block, which covers all
   # outbound-TLS pods. This flag only affects the API server; useful when


### PR DESCRIPTION
## Description

Adds an `api.runStartupMigrations` Helm value that defaults to running API startup migrations, while allowing coordinated deployment flows to disable the API pod's `alembic upgrade head` startup step.

The template keeps the default-on behavior for existing installs, including `helm upgrade --reuse-values` cases where the key is absent.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Helm toggle to control API startup migrations. New `api.runStartupMigrations` (default true) conditionally runs `alembic upgrade head` in the API pod and preserves default-on behavior, including when the key is absent on `helm upgrade --reuse-values`.

<sup>Written for commit 18c2a6f8c3a6798fea1d72932e270c584565c82b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

