### PR TITLE
test(craft): factor shared test helpers

### DIFF
--- a/backend/tests/common/craft/payloads.py
+++ b/backend/tests/common/craft/payloads.py
@@ -1,0 +1,50 @@
+"""Pure Craft test payload builders."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from onyx.db.enums import EndpointPolicy
+from onyx.external_apps.matching.engine import MatchedAction
+from onyx.server.features.build.sandbox.models import LLMProviderConfig
+
+
+def default_llm_config(
+    provider: str = "openai",
+    model_name: str = "gpt-5-mini",
+    api_key: str = "test-key",
+) -> LLMProviderConfig:
+    """Standard ``LLMProviderConfig`` for tests that don't care about specifics."""
+    return LLMProviderConfig(
+        provider=provider,
+        model_name=model_name,
+        api_key=api_key,
+        api_base=None,
+    )
+
+
+def action_entry(
+    action_type: str,
+    *,
+    display_name: str = "Action",
+    description: str = "An action.",
+    policy: EndpointPolicy = EndpointPolicy.ASK,
+) -> dict[str, Any]:
+    """JSONB-shape dict for one ``ActionApproval.actions`` entry."""
+    return MatchedAction(
+        action_type=action_type,
+        display_name=display_name,
+        description=description,
+        policy=policy,
+    ).model_dump(mode="json")
+
+
+def default_action_entries() -> list[dict[str, Any]]:
+    """Single ASK entry for tests that don't care about catalog specifics."""
+    return [
+        action_entry(
+            "shell.exec",
+            display_name="Run command",
+            description="Run a shell command.",
+        )
+    ]

--- a/backend/tests/common/craft/skill_table_isolation.py
+++ b/backend/tests/common/craft/skill_table_isolation.py
@@ -30,7 +30,13 @@ def _column_keys(model: type[Any]) -> list[str]:
 
 
 def _pk_keys(model: type[Any]) -> list[str]:
-    return [col.key for col in class_mapper(model).primary_key]  # ty: ignore[invalid-return-type]
+    mapper = class_mapper(model)
+    pk_columns = set(mapper.primary_key)
+    return [
+        attr.key
+        for attr in mapper.column_attrs
+        if any(column in pk_columns for column in attr.columns)
+    ]
 
 
 def snapshot_skill_tables(

--- a/backend/tests/common/craft/skill_table_isolation.py
+++ b/backend/tests/common/craft/skill_table_isolation.py
@@ -1,0 +1,69 @@
+"""Skill/external-app table snapshot helpers for Craft tests."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.orm import class_mapper
+from sqlalchemy.orm import Session
+
+from onyx.db.models import ExternalApp
+from onyx.db.models import ExternalAppPolicy
+from onyx.db.models import ExternalAppUserCredential
+from onyx.db.models import Skill
+from onyx.db.models import Skill__UserGroup
+
+# Parent -> child order (FKs all point child -> parent). Restore/insert in this
+# order; delete in reverse so FK constraints stay satisfied.
+_SKILL_ISOLATION_MODELS: tuple[type[Any], ...] = (
+    Skill,
+    ExternalApp,
+    Skill__UserGroup,
+    ExternalAppPolicy,
+    ExternalAppUserCredential,
+)
+
+
+def _column_keys(model: type[Any]) -> list[str]:
+    return [attr.key for attr in class_mapper(model).column_attrs]
+
+
+def _pk_keys(model: type[Any]) -> list[str]:
+    return [col.key for col in class_mapper(model).primary_key]  # ty: ignore[invalid-return-type]
+
+
+def snapshot_skill_tables(
+    session: Session,
+) -> dict[type[Any], list[dict[str, Any]]]:
+    snapshot: dict[type[Any], list[dict[str, Any]]] = {}
+    for model in _SKILL_ISOLATION_MODELS:
+        keys = _column_keys(model)
+        snapshot[model] = [
+            {key: getattr(row, key) for key in keys}
+            for row in session.execute(select(model)).scalars().all()
+        ]
+    return snapshot
+
+
+def restore_skill_tables(
+    session: Session, snapshot: dict[type[Any], list[dict[str, Any]]]
+) -> None:
+    # Delete rows created during the test (children first so FKs stay valid).
+    for model in reversed(_SKILL_ISOLATION_MODELS):
+        pk_keys = _pk_keys(model)
+        baseline_pks = {tuple(row[key] for key in pk_keys) for row in snapshot[model]}
+        for row in session.execute(select(model)).scalars().all():
+            if tuple(getattr(row, key) for key in pk_keys) not in baseline_pks:
+                session.delete(row)
+        session.flush()
+
+    # Re-insert baseline rows the test deleted and restore any it mutated
+    # (parents first). ``merge`` keys on PK: insert when absent, update when
+    # present.
+    for model in _SKILL_ISOLATION_MODELS:
+        for row in snapshot[model]:
+            session.merge(model(**row))
+        session.flush()
+
+    session.commit()

--- a/backend/tests/daily/targeted_reindex/conftest.py
+++ b/backend/tests/daily/targeted_reindex/conftest.py
@@ -18,8 +18,8 @@ from sqlalchemy.orm import Session
 
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.engine.sql_engine import SqlEngine
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
-from tests.external_dependency_unit.constants import TEST_TENANT_ID
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -42,7 +42,7 @@ def db_session() -> Generator[Session, None, None]:
 
 @pytest.fixture(scope="function")
 def tenant_context() -> Generator[None, None, None]:
-    token = CURRENT_TENANT_ID_CONTEXTVAR.set(TEST_TENANT_ID)
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     try:
         yield
     finally:

--- a/backend/tests/external_dependency_unit/background/test_periodic_task_claim.py
+++ b/backend/tests/external_dependency_unit/background/test_periodic_task_claim.py
@@ -27,8 +27,8 @@ from onyx.background.periodic_poller import PERIODIC_TASK_KV_PREFIX
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.engine.sql_engine import SqlEngine
 from onyx.db.models import KVStore
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
-from tests.external_dependency_unit.constants import TEST_TENANT_ID
 
 _TEST_LOCK_BASE = 90_000
 
@@ -182,7 +182,7 @@ class TestClaimConcurrency:
         lock_id = _TEST_LOCK_BASE + 20
 
         def claim() -> bool:
-            CURRENT_TENANT_ID_CONTEXTVAR.set(TEST_TENANT_ID)
+            CURRENT_TENANT_ID_CONTEXTVAR.set(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
             return _try_claim_task(
                 _PeriodicTaskDef(
                     name=task_name,
@@ -209,7 +209,7 @@ class TestClaimConcurrency:
         counter = MagicMock()
 
         def run() -> None:
-            CURRENT_TENANT_ID_CONTEXTVAR.set(TEST_TENANT_ID)
+            CURRENT_TENANT_ID_CONTEXTVAR.set(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
             _try_run_periodic_task(
                 _PeriodicTaskDef(
                     name=task_name,
@@ -236,7 +236,7 @@ class TestClaimConcurrency:
         errors: list[Exception] = []
 
         def claim() -> bool:
-            CURRENT_TENANT_ID_CONTEXTVAR.set(TEST_TENANT_ID)
+            CURRENT_TENANT_ID_CONTEXTVAR.set(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
             return _try_claim_task(
                 _PeriodicTaskDef(
                     name=task_name,

--- a/backend/tests/external_dependency_unit/background/test_startup_recovery.py
+++ b/backend/tests/external_dependency_unit/background/test_startup_recovery.py
@@ -23,8 +23,8 @@ from sqlalchemy.orm import Session
 from onyx.background.periodic_poller import recover_stuck_user_files
 from onyx.db.enums import UserFileStatus
 from onyx.db.models import UserFile
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from tests.external_dependency_unit.conftest import create_test_user
-from tests.external_dependency_unit.constants import TEST_TENANT_ID
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -119,7 +119,7 @@ class TestRecoverProcessingFiles:
 
         mock_impl = MagicMock()
         with patch(f"{_IMPL_MODULE}.process_user_file_impl", mock_impl):
-            recover_stuck_user_files(TEST_TENANT_ID)
+            recover_stuck_user_files(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
 
         called_ids = [call.kwargs["user_file_id"] for call in mock_impl.call_args_list]
         assert str(uf.id) in called_ids, (
@@ -138,7 +138,7 @@ class TestRecoverProcessingFiles:
 
         mock_impl = MagicMock()
         with patch(f"{_IMPL_MODULE}.process_user_file_impl", mock_impl):
-            recover_stuck_user_files(TEST_TENANT_ID)
+            recover_stuck_user_files(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
 
         called_ids = [call.kwargs["user_file_id"] for call in mock_impl.call_args_list]
         assert str(uf.id) not in called_ids, (
@@ -161,7 +161,7 @@ class TestRecoverDeletingFiles:
 
         mock_impl = MagicMock(side_effect=_fake_delete_impl)
         with patch(f"{_IMPL_MODULE}.delete_user_file_impl", mock_impl):
-            recover_stuck_user_files(TEST_TENANT_ID)
+            recover_stuck_user_files(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
 
         called_ids = [call.kwargs["user_file_id"] for call in mock_impl.call_args_list]
         assert str(uf.id) in called_ids, (
@@ -189,7 +189,7 @@ class TestRecoverSyncFiles:
 
         mock_impl = MagicMock(side_effect=_fake_sync_impl)
         with patch(f"{_IMPL_MODULE}.project_sync_user_file_impl", mock_impl):
-            recover_stuck_user_files(TEST_TENANT_ID)
+            recover_stuck_user_files(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
 
         called_ids = [call.kwargs["user_file_id"] for call in mock_impl.call_args_list]
         assert str(uf.id) in called_ids, (
@@ -213,7 +213,7 @@ class TestRecoverSyncFiles:
 
         mock_impl = MagicMock(side_effect=_fake_sync_impl)
         with patch(f"{_IMPL_MODULE}.project_sync_user_file_impl", mock_impl):
-            recover_stuck_user_files(TEST_TENANT_ID)
+            recover_stuck_user_files(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
 
         called_ids = [call.kwargs["user_file_id"] for call in mock_impl.call_args_list]
         assert str(uf.id) in called_ids, (
@@ -241,7 +241,7 @@ class TestRecoveryMultipleFiles:
 
         mock_impl = MagicMock()
         with patch(f"{_IMPL_MODULE}.process_user_file_impl", mock_impl):
-            recover_stuck_user_files(TEST_TENANT_ID)
+            recover_stuck_user_files(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
 
         called_ids = {call.kwargs["user_file_id"] for call in mock_impl.call_args_list}
         expected_ids = {str(uf.id) for uf in files}
@@ -279,7 +279,7 @@ class TestTransientFailures:
 
         mock_impl = MagicMock(side_effect=side_effect)
         with patch(f"{_IMPL_MODULE}.process_user_file_impl", mock_impl):
-            recover_stuck_user_files(TEST_TENANT_ID)
+            recover_stuck_user_files(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
 
         called_ids = [call.kwargs["user_file_id"] for call in mock_impl.call_args_list]
         assert fail_id in called_ids, "Failed file should have been attempted"
@@ -309,7 +309,7 @@ class TestTransientFailures:
 
         mock_impl = MagicMock(side_effect=side_effect)
         with patch(f"{_IMPL_MODULE}.delete_user_file_impl", mock_impl):
-            recover_stuck_user_files(TEST_TENANT_ID)
+            recover_stuck_user_files(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
 
         called_ids = [call.kwargs["user_file_id"] for call in mock_impl.call_args_list]
         assert fail_id in called_ids, "Failed file should have been attempted"
@@ -349,7 +349,7 @@ class TestTransientFailures:
 
         mock_impl = MagicMock(side_effect=side_effect)
         with patch(f"{_IMPL_MODULE}.project_sync_user_file_impl", mock_impl):
-            recover_stuck_user_files(TEST_TENANT_ID)
+            recover_stuck_user_files(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
 
         called_ids = [call.kwargs["user_file_id"] for call in mock_impl.call_args_list]
         assert fail_id in called_ids, "Failed file should have been attempted"

--- a/backend/tests/external_dependency_unit/cache/conftest.py
+++ b/backend/tests/external_dependency_unit/cache/conftest.py
@@ -14,8 +14,8 @@ from onyx.cache.interface import CacheBackend
 from onyx.cache.postgres_backend import PostgresCacheBackend
 from onyx.cache.redis_backend import RedisCacheBackend
 from onyx.db.engine.sql_engine import SqlEngine
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
-from tests.external_dependency_unit.constants import TEST_TENANT_ID
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -27,7 +27,7 @@ def _init_db() -> Generator[None, None, None]:
 
 @pytest.fixture(autouse=True)
 def _tenant_context() -> Generator[None, None, None]:
-    token = CURRENT_TENANT_ID_CONTEXTVAR.set(TEST_TENANT_ID)
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     try:
         yield
     finally:
@@ -36,14 +36,16 @@ def _tenant_context() -> Generator[None, None, None]:
 
 @pytest.fixture
 def pg_cache() -> PostgresCacheBackend:
-    return PostgresCacheBackend(TEST_TENANT_ID)
+    return PostgresCacheBackend(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
 
 
 @pytest.fixture
 def redis_cache() -> RedisCacheBackend:
     from onyx.redis.redis_pool import redis_pool
 
-    return RedisCacheBackend(redis_pool.get_client(TEST_TENANT_ID))
+    return RedisCacheBackend(
+        redis_pool.get_client(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
+    )
 
 
 @pytest.fixture(params=["postgres", "redis"], ids=["postgres", "redis"])

--- a/backend/tests/external_dependency_unit/cache/test_kv_store_cache_layer.py
+++ b/backend/tests/external_dependency_unit/cache/test_kv_store_cache_layer.py
@@ -23,13 +23,15 @@ from onyx.db.models import KVStore
 from onyx.key_value_store.interface import KvKeyNotFoundError
 from onyx.key_value_store.store import PgRedisKVStore
 from onyx.key_value_store.store import REDIS_KEY_PREFIX
-from tests.external_dependency_unit.constants import TEST_TENANT_ID
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 
 
 @pytest.fixture(autouse=True)
 def _clean_kv() -> Generator[None, None, None]:
     yield
-    with get_session_with_tenant(tenant_id=TEST_TENANT_ID) as session:
+    with get_session_with_tenant(
+        tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+    ) as session:
         session.execute(delete(KVStore))
         session.execute(delete(CacheStore))
         session.commit()

--- a/backend/tests/external_dependency_unit/celery/test_docfetching_priority.py
+++ b/backend/tests/external_dependency_unit/celery/test_docfetching_priority.py
@@ -32,7 +32,7 @@ from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import Credential
 from onyx.db.models import SearchSettings
 from onyx.redis.redis_pool import get_redis_client
-from tests.external_dependency_unit.constants import TEST_TENANT_ID
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 
 
 def _create_test_connector(db_session: Session, name: str) -> Connector:
@@ -176,7 +176,9 @@ class TestDocfetchingTaskPriorityWithRealObjects:
         mock_celery_app.send_task.return_value = MagicMock()
 
         # Use real Redis client
-        redis_client = get_redis_client(tenant_id=TEST_TENANT_ID)
+        redis_client = get_redis_client(
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+        )
 
         # Call the function with real objects
         result = try_creating_docfetching_task(
@@ -186,7 +188,7 @@ class TestDocfetchingTaskPriorityWithRealObjects:
             reindex=False,
             db_session=db_session,
             r=redis_client,
-            tenant_id=TEST_TENANT_ID,
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
         )
 
         # Verify task was created
@@ -227,7 +229,9 @@ class TestDocfetchingTaskPriorityWithRealObjects:
         )
 
         mock_celery_app = MagicMock()
-        redis_client = get_redis_client(tenant_id=TEST_TENANT_ID)
+        redis_client = get_redis_client(
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+        )
 
         result = try_creating_docfetching_task(
             celery_app=mock_celery_app,
@@ -236,7 +240,7 @@ class TestDocfetchingTaskPriorityWithRealObjects:
             reindex=False,
             db_session=db_session,
             r=redis_client,
-            tenant_id=TEST_TENANT_ID,
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
         )
 
         # Verify no task was created
@@ -280,7 +284,9 @@ class TestDocfetchingTaskPriorityWithRealObjects:
         mock_celery_app = MagicMock()
         mock_celery_app.send_task.return_value = MagicMock()
 
-        redis_client = get_redis_client(tenant_id=TEST_TENANT_ID)
+        redis_client = get_redis_client(
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+        )
 
         # Acquire the lock before calling the function
         from onyx.configs.constants import DANSWER_REDIS_FUNCTION_LOCK_PREFIX
@@ -302,7 +308,7 @@ class TestDocfetchingTaskPriorityWithRealObjects:
                 reindex=False,
                 db_session=db_session,
                 r=redis_client,
-                tenant_id=TEST_TENANT_ID,
+                tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
             )
 
             # Should return None because lock couldn't be acquired
@@ -348,7 +354,9 @@ class TestDocfetchingTaskPriorityWithRealObjects:
         mock_celery_app = MagicMock()
         mock_celery_app.send_task.return_value = MagicMock()
 
-        redis_client = get_redis_client(tenant_id=TEST_TENANT_ID)
+        redis_client = get_redis_client(
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+        )
 
         # First call should succeed
         result1 = try_creating_docfetching_task(
@@ -358,7 +366,7 @@ class TestDocfetchingTaskPriorityWithRealObjects:
             reindex=False,
             db_session=db_session,
             r=redis_client,
-            tenant_id=TEST_TENANT_ID,
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
         )
         assert result1 == 12345
 
@@ -375,7 +383,7 @@ class TestDocfetchingTaskPriorityWithRealObjects:
             reindex=False,
             db_session=db_session,
             r=redis_client,
-            tenant_id=TEST_TENANT_ID,
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
         )
         assert result2 == 67890
 

--- a/backend/tests/external_dependency_unit/celery/test_docprocessing_priority.py
+++ b/backend/tests/external_dependency_unit/celery/test_docprocessing_priority.py
@@ -30,7 +30,7 @@ from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import Credential
 from onyx.db.models import IndexAttempt
 from onyx.db.models import SearchSettings
-from tests.external_dependency_unit.constants import TEST_TENANT_ID
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 
 
 def _create_test_connector(db_session: Session, name: str) -> Connector:
@@ -288,7 +288,7 @@ class TestDocprocessingPriorityInDocumentExtraction:
                 index_attempt_id=index_attempt.id,
                 cc_pair_id=cc_pair.id,
                 search_settings_id=search_settings.id,
-                tenant_id=TEST_TENANT_ID,
+                tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
                 callback=None,
             )
 

--- a/backend/tests/external_dependency_unit/celery/test_persona_file_sync.py
+++ b/backend/tests/external_dependency_unit/celery/test_persona_file_sync.py
@@ -44,8 +44,8 @@ from onyx.db.models import UserFile
 from onyx.db.persona import upsert_persona
 from onyx.document_index.interfaces_new import MetadataUpdateRequest
 from onyx.redis.redis_pool import get_redis_client
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from tests.external_dependency_unit.conftest import create_test_user
-from tests.external_dependency_unit.constants import TEST_TENANT_ID
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -157,7 +157,9 @@ class TestCheckSweepIncludesPersonaSync:
         mock_app = MagicMock()
 
         with _patch_task_app(check_for_user_file_project_sync, mock_app):
-            check_for_user_file_project_sync.run(tenant_id=TEST_TENANT_ID)
+            check_for_user_file_project_sync.run(
+                tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+            )
 
         enqueued_ids = {
             call.kwargs["kwargs"]["user_file_id"]
@@ -177,7 +179,9 @@ class TestCheckSweepIncludesPersonaSync:
         mock_app = MagicMock()
 
         with _patch_task_app(check_for_user_file_project_sync, mock_app):
-            check_for_user_file_project_sync.run(tenant_id=TEST_TENANT_ID)
+            check_for_user_file_project_sync.run(
+                tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+            )
 
         enqueued_ids = {
             call.kwargs["kwargs"]["user_file_id"]
@@ -199,7 +203,9 @@ class TestCheckSweepIncludesPersonaSync:
         mock_app = MagicMock()
 
         with _patch_task_app(check_for_user_file_project_sync, mock_app):
-            check_for_user_file_project_sync.run(tenant_id=TEST_TENANT_ID)
+            check_for_user_file_project_sync.run(
+                tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+            )
 
         matching_calls = [
             call
@@ -246,7 +252,9 @@ class TestSyncTaskWritesPersonaIds:
         mock_search_settings.primary = MagicMock()
         mock_search_settings.secondary = None
 
-        redis_client = get_redis_client(tenant_id=TEST_TENANT_ID)
+        redis_client = get_redis_client(
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+        )
         lock_key = user_file_project_sync_lock_key(str(uf.id))
         redis_client.delete(lock_key)
 
@@ -257,7 +265,8 @@ class TestSyncTaskWritesPersonaIds:
             patch(_PATCH_GET_INDICES, return_value=[mock_doc_index]),
         ):
             process_single_user_file_project_sync.run(
-                user_file_id=str(uf.id), tenant_id=TEST_TENANT_ID
+                user_file_id=str(uf.id),
+                tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
             )
 
         mock_doc_index.update.assert_called_once()
@@ -278,13 +287,16 @@ class TestSyncTaskWritesPersonaIds:
         user = create_test_user(db_session, "sync_clear")
         uf = _create_completed_user_file(db_session, user, needs_persona_sync=True)
 
-        redis_client = get_redis_client(tenant_id=TEST_TENANT_ID)
+        redis_client = get_redis_client(
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+        )
         lock_key = user_file_project_sync_lock_key(str(uf.id))
         redis_client.delete(lock_key)
 
         with patch(_PATCH_DISABLE_VDB, True):
             process_single_user_file_project_sync.run(
-                user_file_id=str(uf.id), tenant_id=TEST_TENANT_ID
+                user_file_id=str(uf.id),
+                tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
             )
 
         db_session.refresh(uf)
@@ -320,7 +332,9 @@ class TestSyncTaskWritesPersonaIds:
         mock_search_settings.primary = MagicMock()
         mock_search_settings.secondary = None
 
-        redis_client = get_redis_client(tenant_id=TEST_TENANT_ID)
+        redis_client = get_redis_client(
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+        )
         lock_key = user_file_project_sync_lock_key(str(uf.id))
         redis_client.delete(lock_key)
 
@@ -331,7 +345,8 @@ class TestSyncTaskWritesPersonaIds:
             patch(_PATCH_GET_INDICES, return_value=[mock_doc_index]),
         ):
             process_single_user_file_project_sync.run(
-                user_file_id=str(uf.id), tenant_id=TEST_TENANT_ID
+                user_file_id=str(uf.id),
+                tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
             )
 
         update_requests: list[MetadataUpdateRequest] = (
@@ -368,7 +383,9 @@ class TestSyncTaskWritesPersonaIds:
         mock_search_settings.primary = MagicMock()
         mock_search_settings.secondary = None
 
-        redis_client = get_redis_client(tenant_id=TEST_TENANT_ID)
+        redis_client = get_redis_client(
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+        )
         lock_key = user_file_project_sync_lock_key(str(uf.id))
         redis_client.delete(lock_key)
 
@@ -379,7 +396,8 @@ class TestSyncTaskWritesPersonaIds:
             patch(_PATCH_GET_INDICES, return_value=[mock_doc_index]),
         ):
             process_single_user_file_project_sync.run(
-                user_file_id=str(uf.id), tenant_id=TEST_TENANT_ID
+                user_file_id=str(uf.id),
+                tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
             )
 
         update_requests: list[MetadataUpdateRequest] = (

--- a/backend/tests/external_dependency_unit/celery/test_user_file_delete_queue.py
+++ b/backend/tests/external_dependency_unit/celery/test_user_file_delete_queue.py
@@ -51,8 +51,8 @@ from onyx.configs.constants import USER_FILE_DELETE_MAX_QUEUE_DEPTH
 from onyx.db.enums import UserFileStatus
 from onyx.db.models import UserFile
 from onyx.redis.redis_pool import get_redis_client
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from tests.external_dependency_unit.conftest import create_test_user
-from tests.external_dependency_unit.constants import TEST_TENANT_ID
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -131,7 +131,9 @@ class TestDeleteQueueDepthBackpressure:
             _patch_task_app(check_for_user_file_delete, mock_app),
             patch(_PATCH_QUEUE_LEN, return_value=USER_FILE_DELETE_MAX_QUEUE_DEPTH + 1),
         ):
-            check_for_user_file_delete.run(tenant_id=TEST_TENANT_ID)
+            check_for_user_file_delete.run(
+                tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+            )
 
         mock_app.send_task.assert_not_called()
 
@@ -148,7 +150,9 @@ class TestDeletePerFileGuardKey:
         user = create_test_user(db_session, "del_guard_user")
         uf = _create_deleting_user_file(db_session, user.id)
 
-        redis_client = get_redis_client(tenant_id=TEST_TENANT_ID)
+        redis_client = get_redis_client(
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+        )
         guard_key = _user_file_delete_queued_key(uf.id)
         redis_client.setex(guard_key, CELERY_USER_FILE_DELETE_TASK_EXPIRES, 1)
 
@@ -159,7 +163,9 @@ class TestDeletePerFileGuardKey:
                 _patch_task_app(check_for_user_file_delete, mock_app),
                 patch(_PATCH_QUEUE_LEN, return_value=0),
             ):
-                check_for_user_file_delete.run(tenant_id=TEST_TENANT_ID)
+                check_for_user_file_delete.run(
+                    tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+                )
 
             # send_task must not have been called with this specific file's ID
             for call in mock_app.send_task.call_args_list:
@@ -179,7 +185,9 @@ class TestDeletePerFileGuardKey:
         user = create_test_user(db_session, "del_guard_set_user")
         uf = _create_deleting_user_file(db_session, user.id)
 
-        redis_client = get_redis_client(tenant_id=TEST_TENANT_ID)
+        redis_client = get_redis_client(
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+        )
         guard_key = _user_file_delete_queued_key(uf.id)
         redis_client.delete(guard_key)  # clean slate
 
@@ -190,7 +198,9 @@ class TestDeletePerFileGuardKey:
                 _patch_task_app(check_for_user_file_delete, mock_app),
                 patch(_PATCH_QUEUE_LEN, return_value=0),
             ):
-                check_for_user_file_delete.run(tenant_id=TEST_TENANT_ID)
+                check_for_user_file_delete.run(
+                    tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+                )
 
             assert redis_client.exists(guard_key), (
                 "Guard key should be set in Redis after enqueue"
@@ -215,7 +225,9 @@ class TestDeleteTaskExpiry:
         user = create_test_user(db_session, "del_expires_user")
         uf = _create_deleting_user_file(db_session, user.id)
 
-        redis_client = get_redis_client(tenant_id=TEST_TENANT_ID)
+        redis_client = get_redis_client(
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+        )
         guard_key = _user_file_delete_queued_key(uf.id)
         redis_client.delete(guard_key)
 
@@ -226,7 +238,9 @@ class TestDeleteTaskExpiry:
                 _patch_task_app(check_for_user_file_delete, mock_app),
                 patch(_PATCH_QUEUE_LEN, return_value=0),
             ):
-                check_for_user_file_delete.run(tenant_id=TEST_TENANT_ID)
+                check_for_user_file_delete.run(
+                    tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+                )
 
             # At least one task should have been submitted (for our file)
             assert mock_app.send_task.call_count >= 1, (
@@ -260,7 +274,9 @@ class TestDeleteWorkerClearsGuardKey:
         """
         user_file_id = str(uuid4())
 
-        redis_client = get_redis_client(tenant_id=TEST_TENANT_ID)
+        redis_client = get_redis_client(
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+        )
         guard_key = _user_file_delete_queued_key(user_file_id)
 
         # Simulate the guard key set when the beat enqueued the task
@@ -277,7 +293,7 @@ class TestDeleteWorkerClearsGuardKey:
         try:
             process_single_user_file_delete.run(
                 user_file_id=user_file_id,
-                tenant_id=TEST_TENANT_ID,
+                tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
             )
         finally:
             if delete_lock.owned():

--- a/backend/tests/external_dependency_unit/celery/test_user_file_indexing_adapter.py
+++ b/backend/tests/external_dependency_unit/celery/test_user_file_indexing_adapter.py
@@ -29,8 +29,8 @@ from onyx.indexing.adapters.user_file_indexing_adapter import UserFileIndexingAd
 from onyx.indexing.indexing_pipeline import DocumentBatchPrepareContext
 from onyx.indexing.models import ChunkEmbedding
 from onyx.indexing.models import IndexChunk
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from tests.external_dependency_unit.conftest import create_test_user
-from tests.external_dependency_unit.constants import TEST_TENANT_ID
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -147,7 +147,7 @@ class TestAdapterWritesBothMetadataFields:
         db_session.commit()
 
         adapter = UserFileIndexingAdapter(
-            tenant_id=TEST_TENANT_ID, db_session=db_session
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE, db_session=db_session
         )
         chunk = _make_index_chunk(uf)
         doc = chunk.source_document
@@ -155,7 +155,7 @@ class TestAdapterWritesBothMetadataFields:
 
         enricher = adapter.prepare_enrichment(
             context=context,
-            tenant_id=TEST_TENANT_ID,
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
             chunks=[chunk],
             db_session=db_session,
         )
@@ -182,7 +182,7 @@ class TestAdapterWritesBothMetadataFields:
         db_session.commit()
 
         adapter = UserFileIndexingAdapter(
-            tenant_id=TEST_TENANT_ID, db_session=db_session
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE, db_session=db_session
         )
         chunk = _make_index_chunk(uf)
         context = DocumentBatchPrepareContext(
@@ -191,7 +191,7 @@ class TestAdapterWritesBothMetadataFields:
 
         enricher = adapter.prepare_enrichment(
             context=context,
-            tenant_id=TEST_TENANT_ID,
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
             chunks=[chunk],
             db_session=db_session,
         )
@@ -220,7 +220,7 @@ class TestAdapterWritesBothMetadataFields:
         db_session.commit()
 
         adapter = UserFileIndexingAdapter(
-            tenant_id=TEST_TENANT_ID, db_session=db_session
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE, db_session=db_session
         )
         chunk = _make_index_chunk(uf)
         context = DocumentBatchPrepareContext(
@@ -229,7 +229,7 @@ class TestAdapterWritesBothMetadataFields:
 
         enricher = adapter.prepare_enrichment(
             context=context,
-            tenant_id=TEST_TENANT_ID,
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
             chunks=[chunk],
             db_session=db_session,
         )
@@ -252,7 +252,7 @@ class TestAdapterWritesBothMetadataFields:
         uf = _create_user_file(db_session, user)
 
         adapter = UserFileIndexingAdapter(
-            tenant_id=TEST_TENANT_ID, db_session=db_session
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE, db_session=db_session
         )
         chunk = _make_index_chunk(uf)
         context = DocumentBatchPrepareContext(
@@ -261,7 +261,7 @@ class TestAdapterWritesBothMetadataFields:
 
         enricher = adapter.prepare_enrichment(
             context=context,
-            tenant_id=TEST_TENANT_ID,
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
             chunks=[chunk],
             db_session=db_session,
         )
@@ -291,7 +291,7 @@ class TestAdapterWritesBothMetadataFields:
         db_session.commit()
 
         adapter = UserFileIndexingAdapter(
-            tenant_id=TEST_TENANT_ID, db_session=db_session
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE, db_session=db_session
         )
         chunk = _make_index_chunk(uf)
         context = DocumentBatchPrepareContext(
@@ -300,7 +300,7 @@ class TestAdapterWritesBothMetadataFields:
 
         enricher = adapter.prepare_enrichment(
             context=context,
-            tenant_id=TEST_TENANT_ID,
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
             chunks=[chunk],
             db_session=db_session,
         )

--- a/backend/tests/external_dependency_unit/celery/test_user_file_processing_queue.py
+++ b/backend/tests/external_dependency_unit/celery/test_user_file_processing_queue.py
@@ -49,8 +49,8 @@ from onyx.configs.constants import USER_FILE_PROCESSING_MAX_QUEUE_DEPTH
 from onyx.db.enums import UserFileStatus
 from onyx.db.models import UserFile
 from onyx.redis.redis_pool import get_redis_client
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from tests.external_dependency_unit.conftest import create_test_user
-from tests.external_dependency_unit.constants import TEST_TENANT_ID
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -128,7 +128,9 @@ class TestQueueDepthBackpressure:
                 _PATCH_QUEUE_LEN, return_value=USER_FILE_PROCESSING_MAX_QUEUE_DEPTH + 1
             ),
         ):
-            check_user_file_processing.run(tenant_id=TEST_TENANT_ID)
+            check_user_file_processing.run(
+                tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+            )
 
         mock_app.send_task.assert_not_called()
 
@@ -145,7 +147,9 @@ class TestPerFileGuardKey:
         user = create_test_user(db_session, "guard_user")
         uf = _create_processing_user_file(db_session, user.id)
 
-        redis_client = get_redis_client(tenant_id=TEST_TENANT_ID)
+        redis_client = get_redis_client(
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+        )
         guard_key = _user_file_queued_key(uf.id)
         redis_client.setex(guard_key, CELERY_USER_FILE_PROCESSING_TASK_EXPIRES, 1)
 
@@ -156,7 +160,9 @@ class TestPerFileGuardKey:
                 _patch_task_app(check_user_file_processing, mock_app),
                 patch(_PATCH_QUEUE_LEN, return_value=0),
             ):
-                check_user_file_processing.run(tenant_id=TEST_TENANT_ID)
+                check_user_file_processing.run(
+                    tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+                )
 
             # send_task must not have been called with this specific file's ID
             for call in mock_app.send_task.call_args_list:
@@ -176,7 +182,9 @@ class TestPerFileGuardKey:
         user = create_test_user(db_session, "guard_set_user")
         uf = _create_processing_user_file(db_session, user.id)
 
-        redis_client = get_redis_client(tenant_id=TEST_TENANT_ID)
+        redis_client = get_redis_client(
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+        )
         guard_key = _user_file_queued_key(uf.id)
         redis_client.delete(guard_key)  # clean slate
 
@@ -187,7 +195,9 @@ class TestPerFileGuardKey:
                 _patch_task_app(check_user_file_processing, mock_app),
                 patch(_PATCH_QUEUE_LEN, return_value=0),
             ):
-                check_user_file_processing.run(tenant_id=TEST_TENANT_ID)
+                check_user_file_processing.run(
+                    tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+                )
 
             assert redis_client.exists(guard_key), (
                 "Guard key should be set in Redis after enqueue"
@@ -212,7 +222,9 @@ class TestTaskExpiry:
         user = create_test_user(db_session, "expires_user")
         uf = _create_processing_user_file(db_session, user.id)
 
-        redis_client = get_redis_client(tenant_id=TEST_TENANT_ID)
+        redis_client = get_redis_client(
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+        )
         guard_key = _user_file_queued_key(uf.id)
         redis_client.delete(guard_key)
 
@@ -223,7 +235,9 @@ class TestTaskExpiry:
                 _patch_task_app(check_user_file_processing, mock_app),
                 patch(_PATCH_QUEUE_LEN, return_value=0),
             ):
-                check_user_file_processing.run(tenant_id=TEST_TENANT_ID)
+                check_user_file_processing.run(
+                    tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+                )
 
             # At least one task should have been submitted (for our file)
             assert mock_app.send_task.call_count >= 1, (
@@ -258,7 +272,9 @@ class TestWorkerClearsGuardKey:
         """
         user_file_id = str(uuid4())
 
-        redis_client = get_redis_client(tenant_id=TEST_TENANT_ID)
+        redis_client = get_redis_client(
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+        )
         guard_key = _user_file_queued_key(user_file_id)
 
         # Simulate the guard key set when the beat enqueued the task
@@ -275,7 +291,7 @@ class TestWorkerClearsGuardKey:
         try:
             process_single_user_file.run(
                 user_file_id=user_file_id,
-                tenant_id=TEST_TENANT_ID,
+                tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
             )
         finally:
             if processing_lock.owned():

--- a/backend/tests/external_dependency_unit/conftest.py
+++ b/backend/tests/external_dependency_unit/conftest.py
@@ -11,8 +11,8 @@ from onyx.db.enums import AccountType
 from onyx.db.models import User
 from onyx.db.models import UserRole
 from onyx.file_store.file_store import get_default_file_store
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
-from tests.external_dependency_unit.constants import TEST_TENANT_ID
 from tests.external_dependency_unit.full_setup import ensure_full_deployment_setup
 
 # Opt into the shared @pytest.mark.secrets / test_secrets infrastructure.
@@ -50,7 +50,7 @@ def full_deployment_setup() -> Generator[None, None, None]:
 def tenant_context() -> Generator[None, None, None]:
     """Set up tenant context for testing"""
     # Set the tenant context for the test
-    token = CURRENT_TENANT_ID_CONTEXTVAR.set(TEST_TENANT_ID)
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     try:
         yield
     finally:

--- a/backend/tests/external_dependency_unit/connectors/google_drive/test_google_drive_group_sync.py
+++ b/backend/tests/external_dependency_unit/connectors/google_drive/test_google_drive_group_sync.py
@@ -22,8 +22,8 @@ from onyx.db.models import PublicExternalUserGroup
 from onyx.db.models import User
 from onyx.db.models import User__ExternalUserGroupId
 from onyx.db.models import UserRole
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from tests.external_dependency_unit.conftest import create_test_user
-from tests.external_dependency_unit.constants import TEST_TENANT_ID
 
 
 def _create_ext_perm_user(db_session: Session, name: str) -> User:
@@ -151,7 +151,9 @@ class TestPerformExternalGroupSync:
             mock_config.return_value = mock_sync_config
 
             # Run the sync
-            _perform_external_group_sync(cc_pair.id, TEST_TENANT_ID)
+            _perform_external_group_sync(
+                cc_pair.id, POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+            )
 
             # Verify user groups were created
             user_groups = _get_user_external_groups(db_session, cc_pair.id)
@@ -217,7 +219,9 @@ class TestPerformExternalGroupSync:
             mock_config.return_value = mock_sync_config
 
             # Run initial sync
-            _perform_external_group_sync(cc_pair.id, TEST_TENANT_ID)
+            _perform_external_group_sync(
+                cc_pair.id, POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+            )
 
             # Verify initial state
             initial_user_groups = _get_user_external_groups(db_session, cc_pair.id)
@@ -243,7 +247,9 @@ class TestPerformExternalGroupSync:
             mock_group_config.group_sync_func = updated_group_sync_func
 
             # Run updated sync
-            _perform_external_group_sync(cc_pair.id, TEST_TENANT_ID)
+            _perform_external_group_sync(
+                cc_pair.id, POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+            )
 
             # Verify updated state
             updated_user_groups = _get_user_external_groups(db_session, cc_pair.id)
@@ -316,7 +322,9 @@ class TestPerformExternalGroupSync:
             mock_config.return_value = mock_sync_config
 
             # Run initial sync
-            _perform_external_group_sync(cc_pair.id, TEST_TENANT_ID)
+            _perform_external_group_sync(
+                cc_pair.id, POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+            )
 
             # Verify initial state
             initial_user_groups = _get_user_external_groups(db_session, cc_pair.id)
@@ -340,7 +348,9 @@ class TestPerformExternalGroupSync:
             mock_group_config.group_sync_func = updated_group_sync_func
 
             # Run updated sync
-            _perform_external_group_sync(cc_pair.id, TEST_TENANT_ID)
+            _perform_external_group_sync(
+                cc_pair.id, POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+            )
 
             # Verify updated state
             updated_user_groups = _get_user_external_groups(db_session, cc_pair.id)
@@ -393,7 +403,9 @@ class TestPerformExternalGroupSync:
             mock_config.return_value = mock_sync_config
 
             # Run initial sync
-            _perform_external_group_sync(cc_pair.id, TEST_TENANT_ID)
+            _perform_external_group_sync(
+                cc_pair.id, POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+            )
 
             # Verify initial state
             initial_user_groups = _get_user_external_groups(db_session, cc_pair.id)
@@ -412,7 +424,9 @@ class TestPerformExternalGroupSync:
             mock_group_config.group_sync_func = empty_group_sync_func
 
             # Run updated sync
-            _perform_external_group_sync(cc_pair.id, TEST_TENANT_ID)
+            _perform_external_group_sync(
+                cc_pair.id, POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+            )
 
             # Verify all groups were removed
             updated_user_groups = _get_user_external_groups(db_session, cc_pair.id)
@@ -452,7 +466,9 @@ class TestPerformExternalGroupSync:
             mock_config.return_value = mock_sync_config
 
             # Run the sync
-            _perform_external_group_sync(cc_pair.id, TEST_TENANT_ID)
+            _perform_external_group_sync(
+                cc_pair.id, POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+            )
 
             # Verify all users were added to the group
             user_groups = _get_user_external_groups(db_session, cc_pair.id)
@@ -498,7 +514,9 @@ class TestPerformExternalGroupSync:
             mock_config.return_value = mock_sync_config
 
             # Run the sync
-            _perform_external_group_sync(cc_pair.id, TEST_TENANT_ID)
+            _perform_external_group_sync(
+                cc_pair.id, POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+            )
 
             # Verify user groups
             user_groups = _get_user_external_groups(db_session, cc_pair.id)

--- a/backend/tests/external_dependency_unit/constants.py
+++ b/backend/tests/external_dependency_unit/constants.py
@@ -1,1 +1,0 @@
-TEST_TENANT_ID: str = "public"

--- a/backend/tests/external_dependency_unit/craft/conftest.py
+++ b/backend/tests/external_dependency_unit/craft/conftest.py
@@ -11,7 +11,6 @@ import io
 import json
 import os
 import shlex
-import threading
 import time
 import zipfile
 from collections.abc import Callable
@@ -34,10 +33,7 @@ from fastapi_users.password import PasswordHelper
 
 if TYPE_CHECKING:
     from kubernetes import client as k8s_client_module
-from redis import Redis
-from sqlalchemy import select
 from sqlalchemy import text
-from sqlalchemy.orm import class_mapper
 from sqlalchemy.orm import Session
 
 from onyx.configs.constants import FileOrigin
@@ -52,8 +48,6 @@ from onyx.db.llm import remove_llm_provider
 from onyx.db.llm import update_default_provider
 from onyx.db.llm import upsert_llm_provider
 from onyx.db.models import BuildSession
-from onyx.db.models import ExternalApp
-from onyx.db.models import ExternalAppUserCredential
 from onyx.db.models import Sandbox
 from onyx.db.models import Skill
 from onyx.db.models import Skill__UserGroup
@@ -63,7 +57,6 @@ from onyx.db.models import UserGroup
 from onyx.db.models import UserRole
 from onyx.file_store.file_store import get_default_file_store
 from onyx.llm.constants import LlmProviderNames
-from onyx.redis.tenant_redis_client import TenantRedisClient
 from onyx.server.features.build.configs import SANDBOX_NAMESPACE
 from onyx.server.features.build.db.sandbox import create_sandbox__no_commit
 from onyx.server.features.build.db.sandbox import update_sandbox_status__no_commit
@@ -74,10 +67,12 @@ from onyx.server.features.build.sandbox.models import LLMProviderConfig
 from onyx.server.features.build.session.manager import SessionManager
 from onyx.server.manage.llm.models import LLMProviderUpsertRequest
 from onyx.server.manage.llm.models import ModelConfigurationUpsertRequest
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
-from tests.external_dependency_unit.constants import TEST_TENANT_ID
-from tests.external_dependency_unit.craft._test_helpers import default_llm_config
-from tests.external_dependency_unit.craft.stubs import StubSandboxManager
+from tests.common.craft.payloads import default_llm_config
+from tests.common.craft.skill_table_isolation import restore_skill_tables
+from tests.common.craft.skill_table_isolation import snapshot_skill_tables
+from tests.common.craft.stubs import StubSandboxManager
 
 _DEV_PUSH_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 
@@ -107,73 +102,20 @@ def _sandbox_push_key() -> Generator[None, None, None]:
 # Skill-table isolation
 # ---------------------------------------------------------------------------
 #
-# These tests run against the shared ``public`` schema (``TEST_TENANT_ID ==
-# "public"``) — the very schema a self-hosted / local dev deployment uses. The
-# fixtures and helpers below commit ``Skill`` / ``ExternalApp`` rows directly
-# and nothing rolled them back, so every committed row leaked into the
-# developer's live craft skill list (and into the next test's view of the
-# table). Tests also delete/mutate the migration-seeded built-in rows
-# (``pptx``, ``image-generation``, ``company-search``), corrupting them for the
-# live app.
+# These tests run against the shared ``public`` schema
+# (``POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE == "public"``) — the very schema a
+# self-hosted / local dev deployment uses. The fixtures and helpers below
+# commit ``Skill`` / ``ExternalApp`` rows directly and nothing rolled them back,
+# so every committed row leaked into the developer's live craft skill list (and
+# into the next test's view of the table). Tests also delete/mutate the
+# migration-seeded built-in rows (``pptx``, ``image-generation``,
+# ``company-search``), corrupting them for the live app.
 #
-# The ``_test_helpers`` contract states "the surrounding test owns transaction
+# The ``db_helpers`` contract states "the surrounding test owns transaction
 # boundaries"; this autouse fixture is that boundary for the skill tables. It
 # snapshots their committed state before each test and restores it afterward,
 # so a run leaves these tables exactly as it found them (the canonical
 # built-ins on a freshly-migrated DB).
-
-# Parent -> child order (FKs all point child -> parent). Restore/insert in this
-# order; delete in reverse so FK constraints stay satisfied.
-_SKILL_ISOLATION_MODELS: tuple[type[Any], ...] = (
-    Skill,
-    Skill__UserGroup,
-    ExternalApp,
-    ExternalAppUserCredential,
-)
-
-
-def _skill_table_column_keys(model: type[Any]) -> list[str]:
-    return [attr.key for attr in class_mapper(model).column_attrs]
-
-
-def _skill_table_pk_keys(model: type[Any]) -> list[str]:
-    return [col.key for col in class_mapper(model).primary_key]  # ty: ignore[invalid-return-type]
-
-
-def _snapshot_skill_tables(
-    session: Session,
-) -> dict[type[Any], list[dict[str, Any]]]:
-    snapshot: dict[type[Any], list[dict[str, Any]]] = {}
-    for model in _SKILL_ISOLATION_MODELS:
-        keys = _skill_table_column_keys(model)
-        snapshot[model] = [
-            {key: getattr(row, key) for key in keys}
-            for row in session.execute(select(model)).scalars().all()
-        ]
-    return snapshot
-
-
-def _restore_skill_tables(
-    session: Session, snapshot: dict[type[Any], list[dict[str, Any]]]
-) -> None:
-    # Delete rows created during the test (children first so FKs stay valid).
-    for model in reversed(_SKILL_ISOLATION_MODELS):
-        pk_keys = _skill_table_pk_keys(model)
-        baseline_pks = {tuple(row[key] for key in pk_keys) for row in snapshot[model]}
-        for row in session.execute(select(model)).scalars().all():
-            if tuple(getattr(row, key) for key in pk_keys) not in baseline_pks:
-                session.delete(row)
-        session.flush()
-
-    # Re-insert baseline rows the test deleted and restore any it mutated
-    # (parents first). ``merge`` keys on PK: insert when absent, update when
-    # present.
-    for model in _SKILL_ISOLATION_MODELS:
-        for row in snapshot[model]:
-            session.merge(model(**row))
-        session.flush()
-
-    session.commit()
 
 
 def _best_effort_delete(model: type[Any], ids: Iterable[Any]) -> None:
@@ -186,7 +128,7 @@ def _best_effort_delete(model: type[Any], ids: Iterable[Any]) -> None:
     if not ids:
         return
     try:
-        token = CURRENT_TENANT_ID_CONTEXTVAR.set(TEST_TENANT_ID)
+        token = CURRENT_TENANT_ID_CONTEXTVAR.set(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
         try:
             with get_session_with_current_tenant() as session:
                 # Fail fast instead of hanging if another (uncommitted) test
@@ -209,7 +151,7 @@ def _best_effort_delete_memberships(group_ids: list[int]) -> None:
     if not group_ids:
         return
     try:
-        token = CURRENT_TENANT_ID_CONTEXTVAR.set(TEST_TENANT_ID)
+        token = CURRENT_TENANT_ID_CONTEXTVAR.set(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
         try:
             with get_session_with_current_tenant() as session:
                 session.execute(text("SET lock_timeout = '10s'"))
@@ -233,12 +175,12 @@ def _isolate_skill_tables(
     Shares the test's ``db_session`` so there is a single transaction holder —
     no second connection that could block on row locks the test still holds.
     """
-    snapshot = _snapshot_skill_tables(db_session)
+    snapshot = snapshot_skill_tables(db_session)
     yield
     # Drop any uncommitted state a failing/early-exiting test left open before
     # reconciling against the committed baseline.
     db_session.rollback()
-    _restore_skill_tables(db_session, snapshot)
+    restore_skill_tables(db_session, snapshot)
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -249,7 +191,7 @@ def _seed_default_llm_provider() -> Generator[None, None, None]:
     never invoked — tests forward the resolved config to ``provision()`` only.
     """
     SqlEngine.init_engine(pool_size=10, max_overflow=5)
-    token = CURRENT_TENANT_ID_CONTEXTVAR.set(TEST_TENANT_ID)
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     seeded_name: str | None = None
     try:
         with get_session_with_current_tenant() as session:
@@ -299,7 +241,7 @@ def db_session() -> Generator[Session, None, None]:
 @pytest.fixture(scope="function")
 def tenant_context() -> Generator[None, None, None]:
     """Set up tenant context for testing."""
-    token = CURRENT_TENANT_ID_CONTEXTVAR.set(TEST_TENANT_ID)
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     try:
         yield
     finally:
@@ -916,7 +858,7 @@ def _pool_pod(
         )
 
     SqlEngine.init_engine(pool_size=10, max_overflow=5)
-    token = CURRENT_TENANT_ID_CONTEXTVAR.set(TEST_TENANT_ID)
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     manager = KubernetesSandboxManager()
 
     try:
@@ -1283,55 +1225,6 @@ def session_manager_with_stub(
     return sm
 
 
-def assert_lock_serializes_two_threads(
-    redis_client: Redis | TenantRedisClient,  # type: ignore[type-arg]
-    lock_key: str,
-) -> None:
-    """Verify two concurrent acquirers contend on ``lock_key`` — one waits.
-
-    Spawns two threads that race for the same Redis lock; the first
-    thread acquires + holds, the second observes that a non-blocking
-    acquire fails (the serialization point). Cleans the key before and
-    after.
-    """
-    redis_client.delete(lock_key)
-
-    first_holds_lock = threading.Event()
-    release_event = threading.Event()
-    second_saw_lock_held: list[bool] = []
-
-    def first() -> None:
-        lock = redis_client.lock(lock_key, timeout=30)
-        assert lock.acquire(blocking=True, blocking_timeout=5) is True
-        first_holds_lock.set()
-        try:
-            release_event.wait(timeout=5)
-        finally:
-            lock.release()
-
-    def second() -> None:
-        assert first_holds_lock.wait(timeout=5)
-        lock = redis_client.lock(lock_key, timeout=30)
-        acquired_immediately = lock.acquire(blocking=False)
-        second_saw_lock_held.append(not acquired_immediately)
-        if acquired_immediately:
-            lock.release()
-            return
-        release_event.set()
-        assert lock.acquire(blocking=True, blocking_timeout=5) is True
-        lock.release()
-
-    t1 = threading.Thread(target=first)
-    t2 = threading.Thread(target=second)
-    t1.start()
-    t2.start()
-    t1.join(timeout=10)
-    t2.join(timeout=10)
-
-    assert second_saw_lock_held == [True]
-    redis_client.delete(lock_key)
-
-
 # ---------------------------------------------------------------------------
 # Kubernetes helpers (Part V.1)
 #
@@ -1576,7 +1469,7 @@ def k8s_manager() -> Generator[KubernetesSandboxManager, None, None]:
     ``SANDBOX_BACKEND == KUBERNETES`` via ``pytestmark``.
     """
     SqlEngine.init_engine(pool_size=10, max_overflow=5)
-    token = CURRENT_TENANT_ID_CONTEXTVAR.set(TEST_TENANT_ID)
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     try:
         yield KubernetesSandboxManager()
     finally:

--- a/backend/tests/external_dependency_unit/craft/db_helpers.py
+++ b/backend/tests/external_dependency_unit/craft/db_helpers.py
@@ -1,8 +1,9 @@
-"""Shared row factories for craft external-dependency tests.
+"""Shared Craft database row factories.
 
-Underscore-prefixed module so pytest does not collect it. Helpers live here
-(not in ``conftest.py``) because they're plain functions — callers want to
-import them, not receive them as fixtures.
+Helpers live here, not in a ``conftest.py``, because they're plain functions:
+external-dependency tests import row factories directly. Pure payload builders
+live in ``tests.common.craft.payloads`` so integration tests do not depend on
+DB factory modules for value construction.
 
 Conventions:
 
@@ -47,11 +48,9 @@ from onyx.db.models import User__UserGroup
 from onyx.db.models import UserGroup
 from onyx.db.models import UserGroup__ConnectorCredentialPair
 from onyx.db.models import UserRole
-from onyx.external_apps.matching.engine import MatchedAction
-from onyx.server.features.build.sandbox.models import LLMProviderConfig
 
 
-def _set_created_at(
+def set_session_created_at(
     db_session: Session,
     model: type[ActionApproval],
     pk: UUID,
@@ -336,46 +335,3 @@ def make_cc_pair(
         db_session.flush()
 
     return cc_pair
-
-
-def default_llm_config(
-    provider: str = "openai",
-    model_name: str = "gpt-5-mini",
-    api_key: str = "test-key",
-) -> LLMProviderConfig:
-    """Standard ``LLMProviderConfig`` for tests that don't care about specifics."""
-    return LLMProviderConfig(
-        provider=provider,
-        model_name=model_name,
-        api_key=api_key,
-        api_base=None,
-    )
-
-
-def action_entry(
-    action_type: str,
-    *,
-    display_name: str = "Action",
-    description: str = "An action.",
-    policy: EndpointPolicy = EndpointPolicy.ASK,
-) -> dict[str, Any]:
-    """JSONB-shape dict for one `ActionApproval.actions` entry. Routes
-    through `MatchedAction` so the shape can't drift from the production
-    model."""
-    return MatchedAction(
-        action_type=action_type,
-        display_name=display_name,
-        description=description,
-        policy=policy,
-    ).model_dump(mode="json")
-
-
-def default_action_entries() -> list[dict[str, Any]]:
-    """Single ASK entry for tests that don't care about catalog specifics."""
-    return [
-        action_entry(
-            "shell.exec",
-            display_name="Run command",
-            description="Run a shell command.",
-        )
-    ]

--- a/backend/tests/external_dependency_unit/craft/db_helpers.py
+++ b/backend/tests/external_dependency_unit/craft/db_helpers.py
@@ -50,15 +50,16 @@ from onyx.db.models import UserGroup__ConnectorCredentialPair
 from onyx.db.models import UserRole
 
 
-def set_session_created_at(
+def force_approval_created_at(
     db_session: Session,
-    model: type[ActionApproval],
-    pk: UUID,
+    approval_id: UUID,
     when: datetime,
 ) -> None:
-    """Force a row's ``created_at`` to ``when``, bypassing ``server_default``."""
+    """Force an ``ActionApproval`` row's ``created_at`` timestamp."""
     db_session.execute(
-        update(model).where(model.approval_id == pk).values(created_at=when)
+        update(ActionApproval)
+        .where(ActionApproval.approval_id == approval_id)
+        .values(created_at=when)
     )
     db_session.commit()
 

--- a/backend/tests/external_dependency_unit/craft/redis_helpers.py
+++ b/backend/tests/external_dependency_unit/craft/redis_helpers.py
@@ -1,0 +1,58 @@
+"""Redis helper assertions shared by Craft tests."""
+
+from __future__ import annotations
+
+import threading
+
+from redis import Redis
+
+from onyx.redis.tenant_redis_client import TenantRedisClient
+
+
+def assert_lock_serializes_two_threads(
+    redis_client: Redis | TenantRedisClient,  # type: ignore[type-arg]
+    lock_key: str,
+) -> None:
+    """Verify two concurrent acquirers contend on ``lock_key`` — one waits.
+
+    Spawns two threads that race for the same Redis lock; the first
+    thread acquires + holds, the second observes that a non-blocking
+    acquire fails (the serialization point). Cleans the key before and
+    after.
+    """
+    redis_client.delete(lock_key)
+
+    first_holds_lock = threading.Event()
+    release_event = threading.Event()
+    second_saw_lock_held: list[bool] = []
+
+    def first() -> None:
+        lock = redis_client.lock(lock_key, timeout=30)
+        assert lock.acquire(blocking=True, blocking_timeout=5) is True
+        first_holds_lock.set()
+        try:
+            release_event.wait(timeout=5)
+        finally:
+            lock.release()
+
+    def second() -> None:
+        assert first_holds_lock.wait(timeout=5)
+        lock = redis_client.lock(lock_key, timeout=30)
+        acquired_immediately = lock.acquire(blocking=False)
+        second_saw_lock_held.append(not acquired_immediately)
+        if acquired_immediately:
+            lock.release()
+            return
+        release_event.set()
+        assert lock.acquire(blocking=True, blocking_timeout=5) is True
+        lock.release()
+
+    t1 = threading.Thread(target=first)
+    t2 = threading.Thread(target=second)
+    t1.start()
+    t2.start()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+
+    assert second_saw_lock_held == [True]
+    redis_client.delete(lock_key)

--- a/backend/tests/external_dependency_unit/craft/stubs.py
+++ b/backend/tests/external_dependency_unit/craft/stubs.py
@@ -1,8 +1,0 @@
-"""Re-exports the canonical StubSandboxManager from the shared location.
-
-The canonical implementation lives in ``tests/common/craft/stubs.py`` so
-both ``external_dependency_unit`` and ``unit`` test layers can import the
-same stub without crossing layer boundaries inappropriately.
-"""
-
-from tests.common.craft.stubs import StubSandboxManager  # noqa: F401

--- a/backend/tests/external_dependency_unit/craft/test_action_approval_db.py
+++ b/backend/tests/external_dependency_unit/craft/test_action_approval_db.py
@@ -28,8 +28,8 @@ from onyx.server.features.build.db.action_approval import (
 from onyx.server.features.build.db.action_approval import try_record_decision
 from tests.common.craft.payloads import action_entry
 from tests.common.craft.payloads import default_action_entries
+from tests.external_dependency_unit.craft.db_helpers import force_approval_created_at
 from tests.external_dependency_unit.craft.db_helpers import make_user
-from tests.external_dependency_unit.craft.db_helpers import set_session_created_at
 
 
 def _seed_pending(
@@ -215,9 +215,7 @@ def test_list_session_pending_action_approvals_filters_by_created_after(
     new_row = _seed_pending(db_session, bs.id, payload={"cmd": "new"})
 
     one_hour_ago = dt.datetime.now(dt.timezone.utc) - dt.timedelta(hours=1)
-    set_session_created_at(
-        db_session, ActionApproval, old_row.approval_id, one_hour_ago
-    )
+    force_approval_created_at(db_session, old_row.approval_id, one_hour_ago)
 
     cutoff = dt.datetime.now(dt.timezone.utc) - dt.timedelta(minutes=5)
     rows = list_session_pending_action_approvals(

--- a/backend/tests/external_dependency_unit/craft/test_action_approval_db.py
+++ b/backend/tests/external_dependency_unit/craft/test_action_approval_db.py
@@ -26,10 +26,10 @@ from onyx.server.features.build.db.action_approval import (
     list_session_pending_action_approvals,
 )
 from onyx.server.features.build.db.action_approval import try_record_decision
-from tests.external_dependency_unit.craft._test_helpers import _set_created_at
-from tests.external_dependency_unit.craft._test_helpers import action_entry
-from tests.external_dependency_unit.craft._test_helpers import default_action_entries
-from tests.external_dependency_unit.craft._test_helpers import make_user
+from tests.common.craft.payloads import action_entry
+from tests.common.craft.payloads import default_action_entries
+from tests.external_dependency_unit.craft.db_helpers import make_user
+from tests.external_dependency_unit.craft.db_helpers import set_session_created_at
 
 
 def _seed_pending(
@@ -215,7 +215,9 @@ def test_list_session_pending_action_approvals_filters_by_created_after(
     new_row = _seed_pending(db_session, bs.id, payload={"cmd": "new"})
 
     one_hour_ago = dt.datetime.now(dt.timezone.utc) - dt.timedelta(hours=1)
-    _set_created_at(db_session, ActionApproval, old_row.approval_id, one_hour_ago)
+    set_session_created_at(
+        db_session, ActionApproval, old_row.approval_id, one_hour_ago
+    )
 
     cutoff = dt.datetime.now(dt.timezone.utc) - dt.timedelta(minutes=5)
     rows = list_session_pending_action_approvals(

--- a/backend/tests/external_dependency_unit/craft/test_action_matching.py
+++ b/backend/tests/external_dependency_unit/craft/test_action_matching.py
@@ -41,8 +41,8 @@ from onyx.external_apps.matching.engine import WHOLE_DOMAIN_ACTION_TYPE
 from onyx.external_apps.matching.request import ProxiedRequest
 from onyx.sandbox_proxy import request_evaluator as request_evaluator_mod
 from onyx.sandbox_proxy.request_evaluator import ExternalAppRequestEvaluator
-from tests.external_dependency_unit.craft._test_helpers import make_external_app
-from tests.external_dependency_unit.craft._test_helpers import make_skill
+from tests.external_dependency_unit.craft.db_helpers import make_external_app
+from tests.external_dependency_unit.craft.db_helpers import make_skill
 
 
 def _connect_app(

--- a/backend/tests/external_dependency_unit/craft/test_affected_users.py
+++ b/backend/tests/external_dependency_unit/craft/test_affected_users.py
@@ -11,12 +11,12 @@ from onyx.db.models import OAuthAccount
 from onyx.db.models import User
 from onyx.db.skill import affected_user_ids_for_skill
 from onyx.server.features.build.db.sandbox import get_sandbox_user_map
-from tests.external_dependency_unit.craft._test_helpers import add_user_to_group
-from tests.external_dependency_unit.craft._test_helpers import grant_skill_to_group
-from tests.external_dependency_unit.craft._test_helpers import make_group
-from tests.external_dependency_unit.craft._test_helpers import make_sandbox
-from tests.external_dependency_unit.craft._test_helpers import make_skill
-from tests.external_dependency_unit.craft._test_helpers import make_user
+from tests.external_dependency_unit.craft.db_helpers import add_user_to_group
+from tests.external_dependency_unit.craft.db_helpers import grant_skill_to_group
+from tests.external_dependency_unit.craft.db_helpers import make_group
+from tests.external_dependency_unit.craft.db_helpers import make_sandbox
+from tests.external_dependency_unit.craft.db_helpers import make_skill
+from tests.external_dependency_unit.craft.db_helpers import make_user
 
 
 class TestAffectedUserIdsForSkill:

--- a/backend/tests/external_dependency_unit/craft/test_approval_gate.py
+++ b/backend/tests/external_dependency_unit/craft/test_approval_gate.py
@@ -58,9 +58,9 @@ from onyx.server.features.build.configs import SANDBOX_PROXY_NAMESPACE
 from onyx.server.features.build.configs import SANDBOX_PROXY_PORT
 from onyx.server.features.build.configs import SandboxBackend
 from onyx.utils.logger import setup_logger
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
-from tests.external_dependency_unit.constants import TEST_TENANT_ID
-from tests.external_dependency_unit.craft._test_helpers import action_entry
+from tests.common.craft.payloads import action_entry
 from tests.external_dependency_unit.craft.conftest import pod_exec
 from tests.external_dependency_unit.craft.conftest import pod_exec_async
 from tests.external_dependency_unit.craft.conftest import wait_for_pod_exec_output
@@ -99,7 +99,7 @@ def _seed_slack_external_app() -> Generator[None, None, None]:
     Slack row already exists.
     """
     SqlEngine.init_engine(pool_size=10, max_overflow=5)
-    token = CURRENT_TENANT_ID_CONTEXTVAR.set(TEST_TENANT_ID)
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     try:
         with get_session_with_current_tenant() as session:
             if get_built_in_external_app(session, ExternalAppType.SLACK) is None:
@@ -622,7 +622,7 @@ def test_sse_merger_emits_approval_requested_packet(
 
     pending = _wait_for_pending_approval(db_session, session_id)
 
-    cache = get_cache_backend(tenant_id=TEST_TENANT_ID)
+    cache = get_cache_backend(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     popped = approval_cache.pop_announcement(session_id, timeout_s=5, cache=cache)
     assert popped == pending.approval_id, (
         f"announce list should contain the parked approval id "

--- a/backend/tests/external_dependency_unit/craft/test_approvals_api.py
+++ b/backend/tests/external_dependency_unit/craft/test_approvals_api.py
@@ -29,15 +29,13 @@ from onyx.server.features.build.approvals.api import list_live_approvals
 from onyx.server.features.build.approvals.api import submit_decision
 from onyx.server.features.build.approvals.api import submit_session_grant
 from onyx.server.features.build.db import action_approval
-from tests.external_dependency_unit.constants import TEST_TENANT_ID
-from tests.external_dependency_unit.craft._test_helpers import _set_created_at
-from tests.external_dependency_unit.craft._test_helpers import action_entry
-from tests.external_dependency_unit.craft._test_helpers import (
-    default_action_entries as _default_actions,
-)
-from tests.external_dependency_unit.craft._test_helpers import make_external_app
-from tests.external_dependency_unit.craft._test_helpers import make_skill
-from tests.external_dependency_unit.craft._test_helpers import make_user
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+from tests.common.craft.payloads import action_entry
+from tests.common.craft.payloads import default_action_entries as _default_actions
+from tests.external_dependency_unit.craft.db_helpers import make_external_app
+from tests.external_dependency_unit.craft.db_helpers import make_skill
+from tests.external_dependency_unit.craft.db_helpers import make_user
+from tests.external_dependency_unit.craft.db_helpers import set_session_created_at
 
 
 def _stub_send_wake_noop(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -97,7 +95,7 @@ def test_list_live_approvals_filter_logic(
 
     # Push the stale row just past the 180s spec cutoff (hardcoded, not derived).
     stale_when = datetime.now(timezone.utc) - timedelta(seconds=190)
-    _set_created_at(db_session, ActionApproval, stale.approval_id, stale_when)
+    set_session_created_at(db_session, ActionApproval, stale.approval_id, stale_when)
 
     response = list_live_approvals(
         session_id=session.id, user=user, db_session=db_session
@@ -323,7 +321,7 @@ def test_submit_decision_pushes_wake_on_redis(
     )
     db_session.commit()
 
-    cache = get_cache_backend(tenant_id=TEST_TENANT_ID)
+    cache = get_cache_backend(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     # Pre-clean so a leftover from a prior failed run can't mask the bug.
     cache.delete(approval_cache._wake_key(approval.approval_id))
 
@@ -425,7 +423,7 @@ def test_submit_session_grant_approves_matching_pending_rows(
         (str(matching.approval_id), ApprovalDecision.APPROVED),
     ]
 
-    cache = get_cache_backend(tenant_id=TEST_TENANT_ID)
+    cache = get_cache_backend(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     assert approval_cache.cached_session_grants_cover(
         session_id=session.id,
         external_app_id=app.id,
@@ -458,7 +456,7 @@ def test_submit_decision_swallows_transient_wake_failure(
     )
     db_session.commit()
 
-    cache = get_cache_backend(tenant_id=TEST_TENANT_ID)
+    cache = get_cache_backend(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     # Pre-clean so the post-call assertion isn't poisoned by a leftover.
     cache.delete(approval_cache._wake_key(approval.approval_id))
 

--- a/backend/tests/external_dependency_unit/craft/test_approvals_api.py
+++ b/backend/tests/external_dependency_unit/craft/test_approvals_api.py
@@ -18,7 +18,6 @@ from onyx.cache.factory import get_cache_backend
 from onyx.db.enums import ApprovalDecidedVia
 from onyx.db.enums import ApprovalDecision
 from onyx.db.enums import EndpointPolicy
-from onyx.db.models import ActionApproval
 from onyx.db.models import BuildSession
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
@@ -32,10 +31,10 @@ from onyx.server.features.build.db import action_approval
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from tests.common.craft.payloads import action_entry
 from tests.common.craft.payloads import default_action_entries as _default_actions
+from tests.external_dependency_unit.craft.db_helpers import force_approval_created_at
 from tests.external_dependency_unit.craft.db_helpers import make_external_app
 from tests.external_dependency_unit.craft.db_helpers import make_skill
 from tests.external_dependency_unit.craft.db_helpers import make_user
-from tests.external_dependency_unit.craft.db_helpers import set_session_created_at
 
 
 def _stub_send_wake_noop(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -95,7 +94,7 @@ def test_list_live_approvals_filter_logic(
 
     # Push the stale row just past the 180s spec cutoff (hardcoded, not derived).
     stale_when = datetime.now(timezone.utc) - timedelta(seconds=190)
-    set_session_created_at(db_session, ActionApproval, stale.approval_id, stale_when)
+    force_approval_created_at(db_session, stale.approval_id, stale_when)
 
     response = list_live_approvals(
         session_id=session.id, user=user, db_session=db_session

--- a/backend/tests/external_dependency_unit/craft/test_background_snapshots.py
+++ b/backend/tests/external_dependency_unit/craft/test_background_snapshots.py
@@ -35,10 +35,10 @@ from onyx.db.models import Snapshot
 from onyx.db.models import User
 from onyx.redis.redis_pool import get_redis_client
 from onyx.server.features.build.sandbox.models import SnapshotResult
-from tests.external_dependency_unit.constants import TEST_TENANT_ID
-from tests.external_dependency_unit.craft._test_helpers import make_sandbox
-from tests.external_dependency_unit.craft._test_helpers import make_user
-from tests.external_dependency_unit.craft.stubs import StubSandboxManager
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+from tests.common.craft.stubs import StubSandboxManager
+from tests.external_dependency_unit.craft.db_helpers import make_sandbox
+from tests.external_dependency_unit.craft.db_helpers import make_user
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -93,7 +93,7 @@ def _quiesce_leaked_sandboxes(db_session: Session) -> None:
 @pytest.fixture(autouse=True)
 def _isolated_redis_lock() -> Generator[None, None, None]:
     """Make sure the sweep beat lock is free before + after."""
-    redis_client = get_redis_client(tenant_id=TEST_TENANT_ID)
+    redis_client = get_redis_client(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     redis_client.delete(OnyxRedisLocks.CLEANUP_IDLE_SANDBOXES_BEAT_LOCK)
     try:
         yield
@@ -162,7 +162,7 @@ def test_running_sandbox_snapshotted_without_termination(
         size_bytes=4321,
     )
 
-    cleanup_idle_sandboxes_task.run(tenant_id=TEST_TENANT_ID)
+    cleanup_idle_sandboxes_task.run(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
 
     db_session.expire_all()
     snapshots = (
@@ -193,7 +193,7 @@ def test_fresh_snapshot_skipped_by_age_gate(
     session_row = _make_session(db_session, user)
     _add_snapshot(db_session, session_row.id, age_seconds=10)
 
-    cleanup_idle_sandboxes_task.run(tenant_id=TEST_TENANT_ID)
+    cleanup_idle_sandboxes_task.run(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
 
     assert stubbed_sweep.list_session_workspaces_count == 0
     assert stubbed_sweep.create_snapshot_count == 0
@@ -222,7 +222,7 @@ def test_stale_session_defeats_prefilter(
         size_bytes=55,
     )
 
-    cleanup_idle_sandboxes_task.run(tenant_id=TEST_TENANT_ID)
+    cleanup_idle_sandboxes_task.run(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
 
     assert stubbed_sweep.list_session_workspaces_count == 1
     # The per-session age gate still protects the fresh session.
@@ -256,7 +256,7 @@ def test_stale_snapshot_resnapshotted_and_priors_pruned(
         size_bytes=999,
     )
 
-    cleanup_idle_sandboxes_task.run(tenant_id=TEST_TENANT_ID)
+    cleanup_idle_sandboxes_task.run(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
 
     assert stubbed_sweep.create_snapshot_count == 1
     db_session.expire_all()
@@ -297,7 +297,9 @@ def test_snapshot_failure_continues_other_sessions(
     monkeypatch.setattr(stubbed_sweep, "create_snapshot", _snapshot)
 
     with caplog.at_level(logging.WARNING):
-        cleanup_idle_sandboxes_task.run(tenant_id=TEST_TENANT_ID)
+        cleanup_idle_sandboxes_task.run(
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+        )
 
     db_session.expire_all()
     snapshots_a = (
@@ -321,7 +323,7 @@ def test_no_running_sandboxes_is_a_noop(
     make_sandbox(db_session, user, status=SandboxStatus.SLEEPING)
     db_session.commit()
 
-    cleanup_idle_sandboxes_task.run(tenant_id=TEST_TENANT_ID)
+    cleanup_idle_sandboxes_task.run(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
 
     assert stubbed_sweep.list_session_workspaces_count == 0
     assert stubbed_sweep.create_snapshot_count == 0

--- a/backend/tests/external_dependency_unit/craft/test_build_llm_provider_access.py
+++ b/backend/tests/external_dependency_unit/craft/test_build_llm_provider_access.py
@@ -20,9 +20,9 @@ from onyx.server.features.build.db.build_session import (
 )
 from onyx.server.manage.llm.models import LLMProviderUpsertRequest
 from onyx.server.manage.llm.models import ModelConfigurationUpsertRequest
-from tests.external_dependency_unit.craft._test_helpers import add_user_to_group
-from tests.external_dependency_unit.craft._test_helpers import make_group
-from tests.external_dependency_unit.craft._test_helpers import make_user
+from tests.external_dependency_unit.craft.db_helpers import add_user_to_group
+from tests.external_dependency_unit.craft.db_helpers import make_group
+from tests.external_dependency_unit.craft.db_helpers import make_user
 
 
 def _make_group_restricted_anthropic_provider(

--- a/backend/tests/external_dependency_unit/craft/test_built_in_skill_seeding.py
+++ b/backend/tests/external_dependency_unit/craft/test_built_in_skill_seeding.py
@@ -32,8 +32,8 @@ from onyx.server.features.skill.api import _ensure_custom
 from onyx.skills import built_in as built_in_module
 from onyx.skills.built_in import BUILT_IN_SKILLS
 from onyx.skills.built_in import BuiltInSkillDefinition
-from tests.external_dependency_unit.craft._test_helpers import make_built_in_skill_row
-from tests.external_dependency_unit.craft._test_helpers import make_skill
+from tests.external_dependency_unit.craft.db_helpers import make_built_in_skill_row
+from tests.external_dependency_unit.craft.db_helpers import make_skill
 
 
 @pytest.fixture(autouse=True)

--- a/backend/tests/external_dependency_unit/craft/test_bun_node_modules_dedup.py
+++ b/backend/tests/external_dependency_unit/craft/test_bun_node_modules_dedup.py
@@ -20,8 +20,8 @@ from onyx.server.features.build.sandbox.base import BUN_CACHE_DIR
 from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager import (
     KubernetesSandboxManager,
 )
-from tests.external_dependency_unit.constants import TEST_TENANT_ID
-from tests.external_dependency_unit.craft._test_helpers import default_llm_config
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+from tests.common.craft.payloads import default_llm_config
 from tests.external_dependency_unit.craft.conftest import pod_exec
 from tests.external_dependency_unit.craft.conftest import wait_for_pod_deletion
 
@@ -93,7 +93,7 @@ def two_session_pod(
     info = k8s_manager.provision(
         sandbox_id=sandbox_id,
         user_id=_TEST_USER_ID,
-        tenant_id=TEST_TENANT_ID,
+        tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
         llm_config=default_llm_config(
             api_key=os.environ.get("OPENAI_API_KEY", "test-key"),
         ),
@@ -207,7 +207,9 @@ def test_snapshot_excludes_node_modules(
     with the destination pod's bun cache.
     """
     sandbox_id, session_id, _ = pool_session
-    result = k8s_manager.create_snapshot(sandbox_id, session_id, TEST_TENANT_ID)
+    result = k8s_manager.create_snapshot(
+        sandbox_id, session_id, POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+    )
     assert result is not None, "snapshot should succeed for populated session"
     assert result.size_bytes < _MAX_SNAPSHOT_BYTES, (
         f"snapshot for one session was {result.size_bytes / 1e6:.1f} MB — "
@@ -229,7 +231,9 @@ def test_restored_session_hardlinks_to_cache(
     woken sandbox starts at ~840 MB/session of disk before any work.
     """
     sandbox_id, session_id, pod_name = pool_session
-    result = k8s_manager.create_snapshot(sandbox_id, session_id, TEST_TENANT_ID)
+    result = k8s_manager.create_snapshot(
+        sandbox_id, session_id, POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+    )
     assert result is not None
 
     # Wipe the session locally to force a real restore.
@@ -306,7 +310,9 @@ def test_agent_added_package_survives_snapshot_restore(
     ).strip()
     assert int(in_lockfile) >= 1, "bun add must write lodash into bun.lock"
 
-    result = k8s_manager.create_snapshot(sandbox_id, session_id, TEST_TENANT_ID)
+    result = k8s_manager.create_snapshot(
+        sandbox_id, session_id, POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+    )
     assert result is not None
     k8s_manager.cleanup_session_workspace(sandbox_id, session_id)
     k8s_manager.restore_snapshot(

--- a/backend/tests/external_dependency_unit/craft/test_company_search_skill.py
+++ b/backend/tests/external_dependency_unit/craft/test_company_search_skill.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 from onyx.configs.constants import DocumentSource
 from onyx.db.models import User
 from onyx.skills.rendering import build_available_sources_section
-from tests.external_dependency_unit.craft._test_helpers import make_cc_pair
+from tests.external_dependency_unit.craft.db_helpers import make_cc_pair
 
 
 class TestBuildAvailableSourcesSection:

--- a/backend/tests/external_dependency_unit/craft/test_company_search_skill.py
+++ b/backend/tests/external_dependency_unit/craft/test_company_search_skill.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 from onyx.configs.constants import DocumentSource
 from onyx.db.models import User
 from onyx.skills.rendering import build_available_sources_section
-from tests.external_dependency_unit.craft.db_helpers import make_cc_pair
+from tests.external_dependency_unit.indexing_helpers import make_cc_pair
 
 
 class TestBuildAvailableSourcesSection:
@@ -25,7 +25,7 @@ class TestBuildAvailableSourcesSection:
         db_session: Session,
         test_user: User,
     ) -> None:
-        make_cc_pair(db_session, source=DocumentSource.GOOGLE_DRIVE)
+        make_cc_pair(db_session, source=DocumentSource.GOOGLE_DRIVE, commit=False)
 
         result = build_available_sources_section(db_session, test_user)
         assert "google_drive" in result
@@ -36,9 +36,9 @@ class TestBuildAvailableSourcesSection:
         db_session: Session,
         test_user: User,
     ) -> None:
-        make_cc_pair(db_session, source=DocumentSource.GOOGLE_DRIVE)
-        make_cc_pair(db_session, source=DocumentSource.SLACK)
-        make_cc_pair(db_session, source=DocumentSource.LINEAR)
+        make_cc_pair(db_session, source=DocumentSource.GOOGLE_DRIVE, commit=False)
+        make_cc_pair(db_session, source=DocumentSource.SLACK, commit=False)
+        make_cc_pair(db_session, source=DocumentSource.LINEAR, commit=False)
 
         result = build_available_sources_section(db_session, test_user)
         lines = result.strip().split("\n")
@@ -52,8 +52,8 @@ class TestBuildAvailableSourcesSection:
         db_session: Session,
         test_user: User,
     ) -> None:
-        make_cc_pair(db_session, source=DocumentSource.SLACK)
-        make_cc_pair(db_session, source=DocumentSource.SLACK)
+        make_cc_pair(db_session, source=DocumentSource.SLACK, commit=False)
+        make_cc_pair(db_session, source=DocumentSource.SLACK, commit=False)
 
         result = build_available_sources_section(db_session, test_user)
         assert result.count("slack") == 1
@@ -63,7 +63,7 @@ class TestBuildAvailableSourcesSection:
         db_session: Session,
         test_user: User,
     ) -> None:
-        make_cc_pair(db_session, source=DocumentSource.MOCK_CONNECTOR)
+        make_cc_pair(db_session, source=DocumentSource.MOCK_CONNECTOR, commit=False)
 
         result = build_available_sources_section(db_session, test_user)
         assert "Mock Connector" in result
@@ -78,7 +78,7 @@ class TestBuildAvailableSourcesSection:
         test_user: User,
         source: DocumentSource,
     ) -> None:
-        make_cc_pair(db_session, source=source)
+        make_cc_pair(db_session, source=source, commit=False)
         result = build_available_sources_section(db_session, test_user)
         assert result.startswith("- `")
         assert "` — " in result

--- a/backend/tests/external_dependency_unit/craft/test_credential_encryption.py
+++ b/backend/tests/external_dependency_unit/craft/test_credential_encryption.py
@@ -15,10 +15,10 @@ from sqlalchemy.orm import Session
 from onyx.db.enums import ExternalAppType
 from onyx.db.models import User
 from onyx.utils.sensitive import SensitiveValue
-from tests.external_dependency_unit.craft._test_helpers import make_external_app
-from tests.external_dependency_unit.craft._test_helpers import make_skill
-from tests.external_dependency_unit.craft._test_helpers import make_user
-from tests.external_dependency_unit.craft._test_helpers import make_user_credential
+from tests.external_dependency_unit.craft.db_helpers import make_external_app
+from tests.external_dependency_unit.craft.db_helpers import make_skill
+from tests.external_dependency_unit.craft.db_helpers import make_user
+from tests.external_dependency_unit.craft.db_helpers import make_user_credential
 
 
 def _raw_column_bytes(db_session: Session, query: str, **params: object) -> bytes:

--- a/backend/tests/external_dependency_unit/craft/test_credential_injection.py
+++ b/backend/tests/external_dependency_unit/craft/test_credential_injection.py
@@ -4,10 +4,10 @@ from sqlalchemy.orm import Session
 
 from onyx.db.enums import ExternalAppType
 from onyx.external_apps.credentials import resolve_injection_headers
-from tests.external_dependency_unit.craft._test_helpers import make_external_app
-from tests.external_dependency_unit.craft._test_helpers import make_skill
-from tests.external_dependency_unit.craft._test_helpers import make_user
-from tests.external_dependency_unit.craft._test_helpers import make_user_credential
+from tests.external_dependency_unit.craft.db_helpers import make_external_app
+from tests.external_dependency_unit.craft.db_helpers import make_skill
+from tests.external_dependency_unit.craft.db_helpers import make_user
+from tests.external_dependency_unit.craft.db_helpers import make_user_credential
 
 _BEARER = {"Authorization": "Bearer {access_token}"}
 

--- a/backend/tests/external_dependency_unit/craft/test_docker_sandbox_serve_streaming.py
+++ b/backend/tests/external_dependency_unit/craft/test_docker_sandbox_serve_streaming.py
@@ -62,7 +62,7 @@ from onyx.server.features.build.sandbox.event_schema import ToolCallStart
 from onyx.server.features.build.sandbox.models import LLMProviderConfig
 from onyx.server.features.build.sandbox.serve_transport import ServeConnectionInfo
 from onyx.server.features.build.sandbox.sse import SSEKeepalive
-from tests.external_dependency_unit.craft._test_helpers import default_llm_config
+from tests.common.craft.payloads import default_llm_config
 
 # ----------------------------------------------------------------------
 # Module-wide skip gate

--- a/backend/tests/external_dependency_unit/craft/test_ensure_sandbox_running.py
+++ b/backend/tests/external_dependency_unit/craft/test_ensure_sandbox_running.py
@@ -33,7 +33,7 @@ from onyx.server.features.build.sandbox.factory import get_sandbox_manager
 from onyx.server.features.build.sandbox.models import LLMProviderConfig
 from onyx.server.features.build.session.errors import SandboxProvisioningError
 from onyx.server.features.build.session.manager import SessionManager
-from tests.external_dependency_unit.constants import TEST_TENANT_ID
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 
 pytestmark = pytest.mark.skipif(
     SANDBOX_BACKEND != SandboxBackend.KUBERNETES,
@@ -79,7 +79,7 @@ def _provision_real(
     mgr.provision(
         sandbox_id=sandbox.id,
         user_id=user_id,
-        tenant_id=TEST_TENANT_ID,
+        tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
         llm_config=LLMProviderConfig(
             provider="test",
             model_name="test-model",

--- a/backend/tests/external_dependency_unit/craft/test_external_app_admin_update.py
+++ b/backend/tests/external_dependency_unit/craft/test_external_app_admin_update.py
@@ -18,8 +18,8 @@ from onyx.db.models import ExternalApp
 from onyx.db.models import Skill
 from onyx.db.models import User
 from onyx.server.features.build.external_apps.models import UpdateExternalAppRequest
-from tests.external_dependency_unit.craft._test_helpers import make_external_app
-from tests.external_dependency_unit.craft._test_helpers import reset_built_in_skill_row
+from tests.external_dependency_unit.craft.db_helpers import make_external_app
+from tests.external_dependency_unit.craft.db_helpers import reset_built_in_skill_row
 
 _AUTH_TEMPLATE = {"Authorization": "Bearer {token}"}
 _PATTERNS = ["https://slack.com/api/.*"]

--- a/backend/tests/external_dependency_unit/craft/test_external_app_fileset.py
+++ b/backend/tests/external_dependency_unit/craft/test_external_app_fileset.py
@@ -25,10 +25,10 @@ from onyx.db.models import User
 from onyx.external_apps.providers.slack import SlackAction
 from onyx.skills.built_in import SLACK
 from onyx.skills.push import build_skills_fileset_for_user
-from tests.external_dependency_unit.craft._test_helpers import make_external_app
-from tests.external_dependency_unit.craft._test_helpers import make_user
-from tests.external_dependency_unit.craft._test_helpers import make_user_credential
-from tests.external_dependency_unit.craft._test_helpers import reset_built_in_skill_row
+from tests.external_dependency_unit.craft.db_helpers import make_external_app
+from tests.external_dependency_unit.craft.db_helpers import make_user
+from tests.external_dependency_unit.craft.db_helpers import make_user_credential
+from tests.external_dependency_unit.craft.db_helpers import reset_built_in_skill_row
 
 # Slack ships on-disk skill content; require a single user-supplied key.
 _AUTH_TEMPLATE = {"Authorization": "Bearer {token}"}

--- a/backend/tests/external_dependency_unit/craft/test_external_app_sandbox_push.py
+++ b/backend/tests/external_dependency_unit/craft/test_external_app_sandbox_push.py
@@ -31,9 +31,9 @@ from onyx.server.features.build.external_apps.models import (
     CreateBuiltInExternalAppRequest,
 )
 from onyx.server.features.build.external_apps.models import UpsertUserCredentialsRequest
-from tests.external_dependency_unit.craft._test_helpers import make_external_app
-from tests.external_dependency_unit.craft._test_helpers import make_user
-from tests.external_dependency_unit.craft._test_helpers import reset_built_in_skill_row
+from tests.external_dependency_unit.craft.db_helpers import make_external_app
+from tests.external_dependency_unit.craft.db_helpers import make_user
+from tests.external_dependency_unit.craft.db_helpers import reset_built_in_skill_row
 
 _AUTH_TEMPLATE = {"Authorization": "Bearer {token}"}
 

--- a/backend/tests/external_dependency_unit/craft/test_external_app_skill_visibility.py
+++ b/backend/tests/external_dependency_unit/craft/test_external_app_skill_visibility.py
@@ -28,10 +28,10 @@ from onyx.db.skill import fetch_skill_for_user
 from onyx.db.skill import fetch_skill_for_user_by_slug
 from onyx.db.skill import list_skills_for_sandbox_injection
 from onyx.db.skill import list_skills_for_user
-from tests.external_dependency_unit.craft._test_helpers import make_external_app
-from tests.external_dependency_unit.craft._test_helpers import make_skill
-from tests.external_dependency_unit.craft._test_helpers import make_user
-from tests.external_dependency_unit.craft._test_helpers import make_user_credential
+from tests.external_dependency_unit.craft.db_helpers import make_external_app
+from tests.external_dependency_unit.craft.db_helpers import make_skill
+from tests.external_dependency_unit.craft.db_helpers import make_user
+from tests.external_dependency_unit.craft.db_helpers import make_user_credential
 
 # Required keys are top-level auth_template keys not covered by
 # organization_credentials (mirrors `is_user_authenticated_for_app`).

--- a/backend/tests/external_dependency_unit/craft/test_idle_cleanup.py
+++ b/backend/tests/external_dependency_unit/craft/test_idle_cleanup.py
@@ -29,11 +29,11 @@ from onyx.db.models import Snapshot
 from onyx.db.models import User
 from onyx.redis.redis_pool import get_redis_client
 from onyx.server.features.build.sandbox.models import SnapshotResult
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
-from tests.external_dependency_unit.constants import TEST_TENANT_ID
-from tests.external_dependency_unit.craft._test_helpers import make_sandbox
-from tests.external_dependency_unit.craft._test_helpers import make_user
-from tests.external_dependency_unit.craft.stubs import StubSandboxManager
+from tests.common.craft.stubs import StubSandboxManager
+from tests.external_dependency_unit.craft.db_helpers import make_sandbox
+from tests.external_dependency_unit.craft.db_helpers import make_user
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -93,7 +93,7 @@ def _isolated_redis_lock() -> Generator[None, None, None]:
     A leftover lock would cause the task to short-circuit at the
     ``lock.acquire`` step and silently skip the work we want to assert.
     """
-    redis_client = get_redis_client(tenant_id=TEST_TENANT_ID)
+    redis_client = get_redis_client(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     redis_client.delete(OnyxRedisLocks.CLEANUP_IDLE_SANDBOXES_BEAT_LOCK)
     try:
         yield
@@ -158,7 +158,7 @@ def test_idle_sandbox_snapshotted_then_terminated_then_sleep_status(
     )
     stubbed_cleanup.terminate_silent = True
 
-    cleanup_idle_sandboxes_task.run(tenant_id=TEST_TENANT_ID)
+    cleanup_idle_sandboxes_task.run(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
 
     db_session.expire_all()
     refreshed = db_session.get(Sandbox, sandbox.id)
@@ -175,7 +175,7 @@ def test_idle_sandbox_snapshotted_then_terminated_then_sleep_status(
     assert all(s.size_bytes == 1234 for s in snapshots)
     assert {
         "sandbox_id": sandbox.id,
-        "tenant_id": TEST_TENANT_ID,
+        "tenant_id": POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
         "timeout_seconds": 300.0,
     } in stubbed_cleanup.create_opencode_history_snapshot_payloads
     assert stubbed_cleanup.terminate_count >= 1
@@ -198,7 +198,7 @@ def test_active_sandbox_within_threshold_not_touched(
     # workspace listing makes it a no-op so we can assert "not touched".
     stubbed_cleanup.list_session_workspaces_returns = []
 
-    cleanup_idle_sandboxes_task.run(tenant_id=TEST_TENANT_ID)
+    cleanup_idle_sandboxes_task.run(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
 
     db_session.expire_all()
     refreshed = db_session.get(Sandbox, sandbox.id)
@@ -227,7 +227,7 @@ def test_null_heartbeat_sandbox_past_created_at_included(
     stubbed_cleanup.list_session_workspaces_returns = []
     stubbed_cleanup.terminate_silent = True
 
-    cleanup_idle_sandboxes_task.run(tenant_id=TEST_TENANT_ID)
+    cleanup_idle_sandboxes_task.run(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
 
     db_session.expire_all()
     refreshed = db_session.get(Sandbox, sandbox.id)
@@ -273,7 +273,9 @@ def test_snapshot_failure_on_healthy_pod_aborts_sleep(
     stubbed_cleanup.health_check_returns = True  # pod still reachable
 
     with caplog.at_level(logging.WARNING):
-        cleanup_idle_sandboxes_task.run(tenant_id=TEST_TENANT_ID)
+        cleanup_idle_sandboxes_task.run(
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+        )
 
     db_session.expire_all()
     refreshed = db_session.get(Sandbox, sandbox.id)
@@ -312,7 +314,7 @@ def test_opencode_history_snapshot_failure_on_healthy_pod_aborts_sleep(
         stubbed_cleanup.create_opencode_history_snapshot_payloads.append(
             {
                 "sandbox_id": sandbox_id,
-                "tenant_id": TEST_TENANT_ID,
+                "tenant_id": POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
                 "timeout_seconds": 300.0,
             }
         )
@@ -321,7 +323,9 @@ def test_opencode_history_snapshot_failure_on_healthy_pod_aborts_sleep(
     monkeypatch.setattr(stubbed_cleanup, "create_opencode_history_snapshot", _boom)
 
     with caplog.at_level(logging.ERROR):
-        cleanup_idle_sandboxes_task.run(tenant_id=TEST_TENANT_ID)
+        cleanup_idle_sandboxes_task.run(
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+        )
 
     db_session.expire_all()
     refreshed = db_session.get(Sandbox, sandbox.id)
@@ -333,7 +337,7 @@ def test_opencode_history_snapshot_failure_on_healthy_pod_aborts_sleep(
     assert sandbox.id not in stubbed_cleanup.terminated_sandbox_ids
     assert {
         "sandbox_id": sandbox.id,
-        "tenant_id": TEST_TENANT_ID,
+        "tenant_id": POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
         "timeout_seconds": 300.0,
     } in stubbed_cleanup.create_opencode_history_snapshot_payloads
     assert any(
@@ -365,7 +369,7 @@ def test_opencode_history_snapshot_failure_on_unreachable_pod_still_terminates(
         stubbed_cleanup.create_opencode_history_snapshot_payloads.append(
             {
                 "sandbox_id": sandbox_id,
-                "tenant_id": TEST_TENANT_ID,
+                "tenant_id": POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
                 "timeout_seconds": 300.0,
             }
         )
@@ -373,7 +377,7 @@ def test_opencode_history_snapshot_failure_on_unreachable_pod_still_terminates(
 
     monkeypatch.setattr(stubbed_cleanup, "create_opencode_history_snapshot", _boom)
 
-    cleanup_idle_sandboxes_task.run(tenant_id=TEST_TENANT_ID)
+    cleanup_idle_sandboxes_task.run(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
 
     db_session.expire_all()
     refreshed = db_session.get(Sandbox, sandbox.id)
@@ -420,7 +424,7 @@ def test_snapshot_failure_on_unreachable_pod_still_terminates(
     stubbed_cleanup.health_check_returns = False  # pod unreachable
     stubbed_cleanup.terminate_silent = True
 
-    cleanup_idle_sandboxes_task.run(tenant_id=TEST_TENANT_ID)
+    cleanup_idle_sandboxes_task.run(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
 
     db_session.expire_all()
     refreshed = db_session.get(Sandbox, sandbox.id)
@@ -462,7 +466,7 @@ def test_sessions_marked_idle_and_nextjs_ports_cleared(
     stubbed_cleanup.list_session_workspaces_returns = []
     stubbed_cleanup.terminate_silent = True
 
-    cleanup_idle_sandboxes_task.run(tenant_id=TEST_TENANT_ID)
+    cleanup_idle_sandboxes_task.run(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
 
     db_session.expire_all()
     refreshed_a = db_session.get(BuildSession, session_a.id)
@@ -492,9 +496,11 @@ def test_task_holds_redis_lock_for_duration(
     _backdate_heartbeat(db_session, sandbox, seconds_ago=short_idle_threshold * 4)
 
     # Bind tenant context for the redis client lookup.
-    token = CURRENT_TENANT_ID_CONTEXTVAR.set(TEST_TENANT_ID)
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     try:
-        redis_client = get_redis_client(tenant_id=TEST_TENANT_ID)
+        redis_client = get_redis_client(
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+        )
         external_lock = redis_client.lock(
             OnyxRedisLocks.CLEANUP_IDLE_SANDBOXES_BEAT_LOCK,
             timeout=60,
@@ -502,7 +508,9 @@ def test_task_holds_redis_lock_for_duration(
         assert external_lock.acquire(blocking=False) is True
 
         try:
-            cleanup_idle_sandboxes_task.run(tenant_id=TEST_TENANT_ID)
+            cleanup_idle_sandboxes_task.run(
+                tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+            )
 
             # Task must have bailed without doing any work.
             assert stubbed_cleanup.terminate_count == 0

--- a/backend/tests/external_dependency_unit/craft/test_kubernetes_sandbox.py
+++ b/backend/tests/external_dependency_unit/craft/test_kubernetes_sandbox.py
@@ -43,8 +43,8 @@ from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager im
 )
 from onyx.server.features.build.sandbox.models import LLMProviderConfig
 from onyx.utils.logger import setup_logger
-from tests.external_dependency_unit.constants import TEST_TENANT_ID
-from tests.external_dependency_unit.craft._test_helpers import default_llm_config
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+from tests.common.craft.payloads import default_llm_config
 from tests.external_dependency_unit.craft.conftest import pod_exec
 from tests.external_dependency_unit.craft.conftest import wait_for_pod_deletion
 
@@ -91,7 +91,7 @@ def _provisioned_sandbox(
     info = manager.provision(
         sandbox_id=sandbox_id,
         user_id=TEST_USER_ID,
-        tenant_id=TEST_TENANT_ID,
+        tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
         llm_config=config,
         onyx_pat="ci-test-pat",
     )

--- a/backend/tests/external_dependency_unit/craft/test_kubernetes_sandbox_file_ops.py
+++ b/backend/tests/external_dependency_unit/craft/test_kubernetes_sandbox_file_ops.py
@@ -31,7 +31,7 @@ from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager im
     KubernetesSandboxManager,
 )
 from onyx.server.features.build.sandbox.models import FilesystemEntry
-from tests.external_dependency_unit.craft._test_helpers import default_llm_config
+from tests.common.craft.payloads import default_llm_config
 from tests.external_dependency_unit.craft.conftest import pod_exec
 from tests.external_dependency_unit.craft.conftest import wait_for_pod_deletion
 

--- a/backend/tests/external_dependency_unit/craft/test_opencode_serve_streaming.py
+++ b/backend/tests/external_dependency_unit/craft/test_opencode_serve_streaming.py
@@ -47,7 +47,7 @@ from onyx.server.features.build.sandbox.event_schema import ToolCallProgress
 from onyx.server.features.build.sandbox.event_schema import ToolCallStart
 from onyx.server.features.build.sandbox.models import LLMProviderConfig
 from onyx.server.features.build.sandbox.sse import SSEKeepalive
-from tests.external_dependency_unit.craft._test_helpers import default_llm_config
+from tests.common.craft.payloads import default_llm_config
 
 # Skip the entire module unless we have a real OpenAI key — these tests
 # need to make real LLM calls.

--- a/backend/tests/external_dependency_unit/craft/test_sandbox_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_sandbox_lifecycle.py
@@ -36,14 +36,14 @@ from onyx.server.features.build.sandbox.models import SandboxInfo
 from onyx.server.features.build.session.api import restore_session
 from onyx.server.features.build.session.manager import SessionManager
 from onyx.server.features.build.session.sandbox_lifecycle import provision_sandbox
-from tests.external_dependency_unit.constants import TEST_TENANT_ID
-from tests.external_dependency_unit.craft._test_helpers import default_llm_config
-from tests.external_dependency_unit.craft._test_helpers import make_sandbox
-from tests.external_dependency_unit.craft._test_helpers import make_user
-from tests.external_dependency_unit.craft.conftest import (
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+from tests.common.craft.payloads import default_llm_config
+from tests.common.craft.stubs import StubSandboxManager
+from tests.external_dependency_unit.craft.db_helpers import make_sandbox
+from tests.external_dependency_unit.craft.db_helpers import make_user
+from tests.external_dependency_unit.craft.redis_helpers import (
     assert_lock_serializes_two_threads,
 )
-from tests.external_dependency_unit.craft.stubs import StubSandboxManager
 
 
 class TestProvisionTransitions:
@@ -73,7 +73,7 @@ class TestProvisionTransitions:
             sandbox=sandbox,
             user=test_user,
             user_id=test_user.id,
-            tenant_id=TEST_TENANT_ID,
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
             all_llm_configs=[default_llm_config()],
         )
         db_session.commit()
@@ -107,7 +107,7 @@ class TestProvisionFailureRollback:
                 sandbox=sandbox,
                 user=test_user,
                 user_id=test_user.id,
-                tenant_id=TEST_TENANT_ID,
+                tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
                 all_llm_configs=[default_llm_config()],
             )
 
@@ -266,7 +266,7 @@ class TestHealthCheckFailureRecovery:
         assert refreshed.status == SandboxStatus.RUNNING
         assert {
             "sandbox_id": row.id,
-            "tenant_id": TEST_TENANT_ID,
+            "tenant_id": POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
             "timeout_seconds": 30.0,
         } in stub_sandbox_manager.create_opencode_history_snapshot_payloads
 
@@ -303,7 +303,7 @@ class TestRestoreFailureRecovery:
         create_snapshot__no_commit(
             db_session,
             session_id,
-            f"{TEST_TENANT_ID}/snapshots/{session_id}/snap.tar.gz",
+            f"{POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE}/snapshots/{session_id}/snap.tar.gz",
             size_bytes=123,
         )
         db_session.commit()
@@ -470,7 +470,9 @@ class TestConcurrentProvisionLock:
         # Real Redis lock under the same key shape used by sessions_api.py
         # (``session_create:{user_id}``). Two threads race for the lock; the
         # second observes that the first held it and therefore had to wait.
-        redis_client = get_redis_client(tenant_id=TEST_TENANT_ID)
+        redis_client = get_redis_client(
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+        )
         lock_key = f"session_create:{test_user.id}"
 
         assert_lock_serializes_two_threads(redis_client, lock_key)

--- a/backend/tests/external_dependency_unit/craft/test_sandbox_pat.py
+++ b/backend/tests/external_dependency_unit/craft/test_sandbox_pat.py
@@ -24,8 +24,8 @@ from onyx.server.features.build.db.sandbox import ensure_sandbox_pat
 from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager import (
     KubernetesSandboxManager,
 )
-from tests.external_dependency_unit.constants import TEST_TENANT_ID
-from tests.external_dependency_unit.craft._test_helpers import default_llm_config
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+from tests.common.craft.payloads import default_llm_config
 
 
 @pytest.fixture()
@@ -307,7 +307,7 @@ class TestEnsureSandboxPat:
             manager.provision(
                 sandbox_id=uuid4(),
                 user_id=uuid4(),
-                tenant_id=TEST_TENANT_ID,
+                tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
                 llm_config=llm_config,
                 onyx_pat="",
             )

--- a/backend/tests/external_dependency_unit/craft/test_scheduled_task_executor.py
+++ b/backend/tests/external_dependency_unit/craft/test_scheduled_task_executor.py
@@ -44,10 +44,10 @@ from onyx.db.models import User
 from onyx.server.features.build.configs import SANDBOX_BACKEND
 from onyx.server.features.build.configs import SandboxBackend
 from onyx.server.features.build.scheduled_tasks.executor import run_scheduled_task_logic
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
-from tests.external_dependency_unit.constants import TEST_TENANT_ID
-from tests.external_dependency_unit.craft._test_helpers import make_sandbox
-from tests.external_dependency_unit.craft._test_helpers import make_user
+from tests.external_dependency_unit.craft.db_helpers import make_sandbox
+from tests.external_dependency_unit.craft.db_helpers import make_user
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -193,10 +193,12 @@ def test_dispatch_uses_skip_locked_to_avoid_dupes(
     fake_app = _FakeApp()
 
     def _dispatch_in_thread(idx: int) -> None:
-        token = CURRENT_TENANT_ID_CONTEXTVAR.set(TEST_TENANT_ID)
+        token = CURRENT_TENANT_ID_CONTEXTVAR.set(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
         try:
             barrier.wait(timeout=5)
-            results[idx] = dispatch_due_scheduled_tasks.run(tenant_id=TEST_TENANT_ID)
+            results[idx] = dispatch_due_scheduled_tasks.run(
+                tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+            )
         finally:
             CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
 
@@ -272,7 +274,9 @@ def test_cleanup_stuck_runs_marks_queued_over_threshold_failed(
     db_session.add(run)
     db_session.commit()
 
-    marked = cleanup_stuck_scheduled_runs.run(tenant_id=TEST_TENANT_ID)
+    marked = cleanup_stuck_scheduled_runs.run(
+        tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+    )
     assert marked >= 1
 
     db_session.expire_all()
@@ -317,7 +321,9 @@ def test_cleanup_stuck_runs_marks_running_over_threshold_failed(
     db_session.add(run)
     db_session.commit()
 
-    marked = cleanup_stuck_scheduled_runs.run(tenant_id=TEST_TENANT_ID)
+    marked = cleanup_stuck_scheduled_runs.run(
+        tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+    )
     assert marked >= 1
 
     db_session.expire_all()

--- a/backend/tests/external_dependency_unit/craft/test_scheduled_task_pre_approvals.py
+++ b/backend/tests/external_dependency_unit/craft/test_scheduled_task_pre_approvals.py
@@ -34,10 +34,10 @@ from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server.features.build.db.action_approval import insert_action_approval
 from onyx.server.features.build.scheduled_tasks import api as scheduled_tasks_api
-from tests.external_dependency_unit.craft._test_helpers import default_action_entries
-from tests.external_dependency_unit.craft._test_helpers import make_external_app
-from tests.external_dependency_unit.craft._test_helpers import make_skill
-from tests.external_dependency_unit.craft._test_helpers import make_user
+from tests.common.craft.payloads import default_action_entries
+from tests.external_dependency_unit.craft.db_helpers import make_external_app
+from tests.external_dependency_unit.craft.db_helpers import make_skill
+from tests.external_dependency_unit.craft.db_helpers import make_user
 
 
 def _make_app(db_session: Session) -> int:

--- a/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
@@ -39,11 +39,11 @@ from onyx.server.features.build.sandbox.models import SandboxInfo
 from onyx.server.features.build.sandbox.user_library import USER_LIBRARY_MOUNT_PATH
 from onyx.server.features.build.session.api import restore_session
 from onyx.server.features.build.session.manager import SessionManager
-from tests.external_dependency_unit.constants import TEST_TENANT_ID
-from tests.external_dependency_unit.craft.conftest import (
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+from tests.common.craft.stubs import StubSandboxManager
+from tests.external_dependency_unit.craft.redis_helpers import (
     assert_lock_serializes_two_threads,
 )
-from tests.external_dependency_unit.craft.stubs import StubSandboxManager
 
 # Built-in skill rows are seeded by ``setup_postgres`` (run once per
 # tenant in ``full_setup``) and persist across tests. The session
@@ -882,7 +882,9 @@ class TestConcurrentCreateLock:
         # Same lock contract as sessions_api.create_session: lock key is
         # ``session_create:{user_id}``. Two threads contend; the second
         # observes the first holding it.
-        redis_client = get_redis_client(tenant_id=TEST_TENANT_ID)
+        redis_client = get_redis_client(
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+        )
         lock_key = f"session_create:{test_user.id}"
 
         assert_lock_serializes_two_threads(redis_client, lock_key)
@@ -971,7 +973,7 @@ class TestRestoreSession:
         snapshot = Snapshot(
             id=uuid4(),
             session_id=idle_session.id,
-            storage_path=f"{TEST_TENANT_ID}/snapshots/{idle_session.id}/latest.tar.gz",
+            storage_path=f"{POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE}/snapshots/{idle_session.id}/latest.tar.gz",
             size_bytes=123,
         )
         db_session.add(snapshot)

--- a/backend/tests/external_dependency_unit/craft/test_skill_push.py
+++ b/backend/tests/external_dependency_unit/craft/test_skill_push.py
@@ -50,15 +50,15 @@ from onyx.skills.built_in import BuiltInSkillDefinition
 from onyx.skills.push import hydrate_sandbox_skills
 from onyx.skills.push import push_skill_to_affected_sandboxes
 from onyx.skills.push import push_skills_for_users
-from tests.external_dependency_unit.craft._test_helpers import add_user_to_group
-from tests.external_dependency_unit.craft._test_helpers import make_built_in_skill_row
-from tests.external_dependency_unit.craft._test_helpers import make_cc_pair
-from tests.external_dependency_unit.craft._test_helpers import make_group
-from tests.external_dependency_unit.craft._test_helpers import make_user
-from tests.external_dependency_unit.craft._test_helpers import reset_built_in_skill_row
+from tests.common.craft.stubs import StubSandboxManager
 from tests.external_dependency_unit.craft.conftest import SandboxHandle
 from tests.external_dependency_unit.craft.conftest import WorkspaceProxy
-from tests.external_dependency_unit.craft.stubs import StubSandboxManager
+from tests.external_dependency_unit.craft.db_helpers import add_user_to_group
+from tests.external_dependency_unit.craft.db_helpers import make_built_in_skill_row
+from tests.external_dependency_unit.craft.db_helpers import make_cc_pair
+from tests.external_dependency_unit.craft.db_helpers import make_group
+from tests.external_dependency_unit.craft.db_helpers import make_user
+from tests.external_dependency_unit.craft.db_helpers import reset_built_in_skill_row
 
 
 def _skill_file_path(

--- a/backend/tests/external_dependency_unit/craft/test_skill_visibility.py
+++ b/backend/tests/external_dependency_unit/craft/test_skill_visibility.py
@@ -12,11 +12,11 @@ from onyx.db.skill import fetch_skill_for_user
 from onyx.db.skill import fetch_skill_for_user_by_slug
 from onyx.db.skill import list_skills_for_admin
 from onyx.db.skill import list_skills_for_user
-from tests.external_dependency_unit.craft._test_helpers import add_user_to_group
-from tests.external_dependency_unit.craft._test_helpers import grant_skill_to_group
-from tests.external_dependency_unit.craft._test_helpers import make_group
-from tests.external_dependency_unit.craft._test_helpers import make_skill
-from tests.external_dependency_unit.craft._test_helpers import make_user
+from tests.external_dependency_unit.craft.db_helpers import add_user_to_group
+from tests.external_dependency_unit.craft.db_helpers import grant_skill_to_group
+from tests.external_dependency_unit.craft.db_helpers import make_group
+from tests.external_dependency_unit.craft.db_helpers import make_skill
+from tests.external_dependency_unit.craft.db_helpers import make_user
 
 
 class TestSkillVisibility:

--- a/backend/tests/external_dependency_unit/craft/test_skills_fileset.py
+++ b/backend/tests/external_dependency_unit/craft/test_skills_fileset.py
@@ -18,9 +18,9 @@ from onyx.skills.built_in import BuiltInSkillDefinition
 from onyx.skills.push import build_skills_fileset_for_user
 from tests.external_dependency_unit.craft.db_helpers import add_user_to_group
 from tests.external_dependency_unit.craft.db_helpers import make_built_in_skill_row
-from tests.external_dependency_unit.craft.db_helpers import make_cc_pair
 from tests.external_dependency_unit.craft.db_helpers import make_group
 from tests.external_dependency_unit.craft.db_helpers import reset_built_in_skill_row
+from tests.external_dependency_unit.indexing_helpers import make_cc_pair
 
 _FRONTMATTER = "---\nname: {slug}\ndescription: {slug}\n---\n"
 
@@ -153,7 +153,7 @@ class TestBuiltInTemplate:
         _write_skill_dir(tmp_path, "company-search", template_body=template_body)
         reset_built_in_skill_row(db_session, built_in_skill_id="company-search")
         db_session.commit()
-        make_cc_pair(db_session, DocumentSource.SLACK)
+        make_cc_pair(db_session, DocumentSource.SLACK, commit=False)
 
         files = build_skills_fileset_for_user(test_user, db_session)
 
@@ -181,7 +181,7 @@ class TestBuiltInTemplate:
         )
         reset_built_in_skill_row(db_session, built_in_skill_id="company-search")
         db_session.commit()
-        make_cc_pair(db_session, DocumentSource.GOOGLE_DRIVE)
+        make_cc_pair(db_session, DocumentSource.GOOGLE_DRIVE, commit=False)
 
         files = build_skills_fileset_for_user(test_user, db_session)
 

--- a/backend/tests/external_dependency_unit/craft/test_skills_fileset.py
+++ b/backend/tests/external_dependency_unit/craft/test_skills_fileset.py
@@ -16,11 +16,11 @@ from onyx.db.models import UserGroup
 from onyx.skills import built_in as built_in_module
 from onyx.skills.built_in import BuiltInSkillDefinition
 from onyx.skills.push import build_skills_fileset_for_user
-from tests.external_dependency_unit.craft._test_helpers import add_user_to_group
-from tests.external_dependency_unit.craft._test_helpers import make_built_in_skill_row
-from tests.external_dependency_unit.craft._test_helpers import make_cc_pair
-from tests.external_dependency_unit.craft._test_helpers import make_group
-from tests.external_dependency_unit.craft._test_helpers import reset_built_in_skill_row
+from tests.external_dependency_unit.craft.db_helpers import add_user_to_group
+from tests.external_dependency_unit.craft.db_helpers import make_built_in_skill_row
+from tests.external_dependency_unit.craft.db_helpers import make_cc_pair
+from tests.external_dependency_unit.craft.db_helpers import make_group
+from tests.external_dependency_unit.craft.db_helpers import reset_built_in_skill_row
 
 _FRONTMATTER = "---\nname: {slug}\ndescription: {slug}\n---\n"
 

--- a/backend/tests/external_dependency_unit/craft/test_snapshot_restore.py
+++ b/backend/tests/external_dependency_unit/craft/test_snapshot_restore.py
@@ -32,8 +32,8 @@ from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager im
     KubernetesSandboxManager,
 )
 from onyx.server.features.build.sandbox.snapshot_manager import SNAPSHOT_FILE_TYPE
-from tests.external_dependency_unit.constants import TEST_TENANT_ID
-from tests.external_dependency_unit.craft._test_helpers import default_llm_config
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+from tests.common.craft.payloads import default_llm_config
 from tests.external_dependency_unit.craft.conftest import pod_exec
 from tests.external_dependency_unit.craft.conftest import wait_for_pod_deletion
 
@@ -149,7 +149,9 @@ def test_snapshot_includes_outputs_and_attachments_only(
 
     _populate_session_workspace(k8s_client, pod_name, session_id)
 
-    result = k8s_manager.create_snapshot(sandbox_id, session_id, TEST_TENANT_ID)
+    result = k8s_manager.create_snapshot(
+        sandbox_id, session_id, POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+    )
     assert result is not None, "create_snapshot returned None for populated session"
 
     archive = tmp_path / "snapshot.tar.gz"
@@ -188,7 +190,9 @@ def test_snapshot_excludes_managed_skills_agents_md_opencode_json(
         k8s_client, pod_name, session_id, include_managed_skills=True
     )
 
-    result = k8s_manager.create_snapshot(sandbox_id, session_id, TEST_TENANT_ID)
+    result = k8s_manager.create_snapshot(
+        sandbox_id, session_id, POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+    )
     assert result is not None
 
     archive = tmp_path / "snapshot.tar.gz"
@@ -222,7 +226,9 @@ def test_restore_from_snapshot_recreates_workspace(
     sandbox_id, session_id, pod_name = pool_session
 
     payload = _populate_session_workspace(k8s_client, pod_name, session_id)
-    result = k8s_manager.create_snapshot(sandbox_id, session_id, TEST_TENANT_ID)
+    result = k8s_manager.create_snapshot(
+        sandbox_id, session_id, POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+    )
     assert result is not None
 
     # Capture the file hashes before tearing down the workspace.
@@ -291,7 +297,9 @@ def test_restore_re_pushes_skills(
     sandbox_id, session_id, pod_name = pool_session
 
     _populate_session_workspace(k8s_client, pod_name, session_id)
-    result = k8s_manager.create_snapshot(sandbox_id, session_id, TEST_TENANT_ID)
+    result = k8s_manager.create_snapshot(
+        sandbox_id, session_id, POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+    )
     assert result is not None
 
     # Wipe the managed/skills tree to simulate a fresh post-restore state.
@@ -402,7 +410,7 @@ def test_opencode_history_snapshot_restores_into_reprovisioned_pod(
 
     assert k8s_manager.create_opencode_history_snapshot(
         sandbox_id,
-        TEST_TENANT_ID,
+        POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
     )
 
     k8s_manager.terminate(sandbox_id)
@@ -411,7 +419,7 @@ def test_opencode_history_snapshot_restores_into_reprovisioned_pod(
     k8s_manager.provision(
         sandbox_id=sandbox_id,
         user_id=uuid4(),
-        tenant_id=TEST_TENANT_ID,
+        tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
         llm_config=default_llm_config(),
         onyx_pat="test-onyx-pat",
     )
@@ -469,7 +477,7 @@ def test_restore_uses_data_filter_to_block_traversal(
         evil_info.size = len(evil_payload)
         tar.addfile(evil_info, fileobj=io.BytesIO(evil_payload))
 
-    storage_path = f"{TEST_TENANT_ID}/snapshots/{session_id}/traversal.tar.gz"
+    storage_path = f"{POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE}/snapshots/{session_id}/traversal.tar.gz"
     _put_snapshot_bytes(storage_path, archive_local.read_bytes())
 
     # Attempt to restore. Traversal must be rejected before extraction.
@@ -534,7 +542,7 @@ def test_snapshot_corruption_detected_on_restore(
 
     # Forge a truncated gzip blob — valid gzip header, garbage body.
     corrupt_bytes = b"\x1f\x8b\x08\x00" + b"\x00" * 8 + b"truncated-mid-stream"
-    storage_path = f"{TEST_TENANT_ID}/snapshots/{session_id}/corrupt.tar.gz"
+    storage_path = f"{POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE}/snapshots/{session_id}/corrupt.tar.gz"
     _put_snapshot_bytes(storage_path, corrupt_bytes)
 
     # Restore should raise a SnapshotCorruption-class error (or at minimum

--- a/backend/tests/external_dependency_unit/craft/test_streaming_persistence.py
+++ b/backend/tests/external_dependency_unit/craft/test_streaming_persistence.py
@@ -31,7 +31,7 @@ from onyx.server.features.build.sandbox.event_schema import ToolCallStart
 from onyx.server.features.build.sandbox.sse import SSEKeepalive
 from onyx.server.features.build.session.manager import SessionManager
 from onyx.server.features.build.session.streaming import BuildStreamingState
-from tests.external_dependency_unit.craft.stubs import StubSandboxManager
+from tests.common.craft.stubs import StubSandboxManager
 
 
 def _text_chunk(text: str) -> AgentMessageChunk:

--- a/backend/tests/external_dependency_unit/craft/test_terminated_sandbox_fast_fail.py
+++ b/backend/tests/external_dependency_unit/craft/test_terminated_sandbox_fast_fail.py
@@ -16,7 +16,7 @@ from onyx.db.enums import SandboxStatus
 from onyx.db.models import Sandbox
 from onyx.db.models import User
 from onyx.server.features.build.sandbox.opencode.event_bus import PodEventBus
-from tests.external_dependency_unit.craft.stubs import StubSandboxManager
+from tests.common.craft.stubs import StubSandboxManager
 
 
 class TestTerminatedSandboxFastFail:

--- a/backend/tests/external_dependency_unit/craft/test_user_library_sync.py
+++ b/backend/tests/external_dependency_unit/craft/test_user_library_sync.py
@@ -30,9 +30,9 @@ from onyx.server.features.build.sandbox.user_library import hydrate_user_library
 from onyx.server.features.build.sandbox.user_library import (
     sync_user_library_to_active_sandboxes,
 )
-from tests.external_dependency_unit.craft._test_helpers import make_user
 from tests.external_dependency_unit.craft.conftest import SandboxHandle
 from tests.external_dependency_unit.craft.conftest import WorkspaceProxy
+from tests.external_dependency_unit.craft.db_helpers import make_user
 
 
 def _library_path(workspace: WorkspaceProxy, file_path: str) -> WorkspaceProxy:

--- a/backend/tests/external_dependency_unit/db/test_run_targeted_reindex.py
+++ b/backend/tests/external_dependency_unit/db/test_run_targeted_reindex.py
@@ -40,7 +40,7 @@ from onyx.db.targeted_reindex import create_targeted_reindex_job
 from onyx.db.targeted_reindex import resolve_error_ids_to_targets
 from onyx.db.targeted_reindex import targets_to_connector_failures
 from onyx.db.targeted_reindex import TargetSpec
-from tests.external_dependency_unit.constants import TEST_TENANT_ID
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair
 from tests.external_dependency_unit.indexing_helpers import make_cc_pair
 
@@ -150,7 +150,7 @@ def test_unsupported_connector_marks_all_targets_failed(
             cc_pair_id=cc_pair.id,
             targets=target_rows,
             attempts=attempts,
-            tenant_id=TEST_TENANT_ID,
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
             db_session=db_session,
         )
 
@@ -190,7 +190,7 @@ def test_resolver_yields_all_docs_lands_them_all(
             cc_pair_id=cc_pair.id,
             targets=target_rows,
             attempts=attempts,
-            tenant_id=TEST_TENANT_ID,
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
             db_session=db_session,
         )
 
@@ -237,7 +237,7 @@ def test_connector_failure_yields_route_to_failed_doc_ids(
             cc_pair_id=cc_pair.id,
             targets=target_rows,
             attempts=attempts,
-            tenant_id=TEST_TENANT_ID,
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
             db_session=db_session,
         )
 
@@ -279,7 +279,7 @@ def test_doc_never_yielded_is_marked_failed(
             cc_pair_id=cc_pair.id,
             targets=target_rows,
             attempts=attempts,
-            tenant_id=TEST_TENANT_ID,
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
             db_session=db_session,
         )
 

--- a/backend/tests/external_dependency_unit/document_index/conftest.py
+++ b/backend/tests/external_dependency_unit/document_index/conftest.py
@@ -20,9 +20,9 @@ from onyx.document_index.opensearch.opensearch_document_index import (
 )
 from onyx.indexing.models import ChunkEmbedding
 from onyx.indexing.models import DocMetadataAwareIndexChunk
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 from shared_configs.contextvars import get_current_tenant_id
-from tests.external_dependency_unit.constants import TEST_TENANT_ID
 
 EMBEDDING_DIM = 128
 
@@ -111,7 +111,7 @@ def make_indexing_metadata(
 @pytest.fixture(scope="module")
 def tenant_context() -> Generator[None, None, None]:
     """Sets up tenant context for testing."""
-    token = CURRENT_TENANT_ID_CONTEXTVAR.set(TEST_TENANT_ID)
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     try:
         yield
     finally:
@@ -133,7 +133,9 @@ def opensearch_index(
         pytest.fail("OpenSearch is not available.")
 
     opensearch_idx = OpenSearchDocumentIndex(
-        tenant_state=TenantState(tenant_id=TEST_TENANT_ID, multitenant=False),
+        tenant_state=TenantState(
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE, multitenant=False
+        ),
         index_name=test_index_name,
         embedding_dim=EMBEDDING_DIM,
         embedding_precision=EmbeddingPrecision.FLOAT,

--- a/backend/tests/external_dependency_unit/document_index/test_document_index.py
+++ b/backend/tests/external_dependency_unit/document_index/test_document_index.py
@@ -23,7 +23,7 @@ from onyx.document_index.opensearch.opensearch_document_index import (
     OpenSearchDocumentIndex,
 )
 from onyx.indexing.models import DocMetadataAwareIndexChunk
-from tests.external_dependency_unit.constants import TEST_TENANT_ID
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from tests.external_dependency_unit.document_index.conftest import EMBEDDING_DIM
 from tests.external_dependency_unit.document_index.conftest import make_chunk
 from tests.external_dependency_unit.document_index.conftest import (
@@ -77,7 +77,9 @@ def opensearch_document_index(
     test_index_name: str,
 ) -> Generator[OpenSearchDocumentIndex, None, None]:
     yield OpenSearchDocumentIndex(
-        tenant_state=TenantState(tenant_id=TEST_TENANT_ID, multitenant=False),
+        tenant_state=TenantState(
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE, multitenant=False
+        ),
         index_name=test_index_name,
         embedding_dim=EMBEDDING_DIM,
         embedding_precision=EmbeddingPrecision.FLOAT,
@@ -299,7 +301,9 @@ class TestDocumentIndexNew:
             assert mock_verify_and_create_index_if_necessary.call_count == 0
 
             test_index_name = "test_index_name_for_mt_cloud_index_verification"
-            tenant_state = TenantState(tenant_id=TEST_TENANT_ID, multitenant=True)
+            tenant_state = TenantState(
+                tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE, multitenant=True
+            )
             _ = OpenSearchDocumentIndex(
                 tenant_state=tenant_state,
                 index_name=test_index_name,
@@ -361,7 +365,7 @@ class TestDocumentIndexNew:
             # OpenSearch's ~1s refresh window.
             filters = IndexFilters(
                 access_control_list=[PUBLIC_DOC_PAT],
-                tenant_id=TEST_TENANT_ID,
+                tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
             )
             retrieved_doc1 = _retrieve_chunks_with_expected_boost(
                 document_index=document_index,
@@ -426,7 +430,7 @@ class TestDocumentIndexNew:
             # OpenSearch's ~1s refresh window.
             filters = IndexFilters(
                 access_control_list=[PUBLIC_DOC_PAT],
-                tenant_id=TEST_TENANT_ID,
+                tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
             )
             retrieved_doc1 = _retrieve_chunks_with_expected_boost(
                 document_index=document_index,
@@ -480,7 +484,7 @@ class TestDocumentIndexNew:
             # Postcondition - chunks still retrievable with their default boost.
             filters = IndexFilters(
                 access_control_list=[PUBLIC_DOC_PAT],
-                tenant_id=TEST_TENANT_ID,
+                tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
             )
             retrieved = document_index.id_based_retrieval(
                 chunk_requests=[DocumentSectionRequest(document_id=doc_id)],
@@ -530,7 +534,7 @@ class TestDocumentIndexNew:
             # doc being skipped.
             filters = IndexFilters(
                 access_control_list=[PUBLIC_DOC_PAT],
-                tenant_id=TEST_TENANT_ID,
+                tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
             )
             retrieved = _retrieve_chunks_with_expected_boost(
                 document_index=document_index,
@@ -583,7 +587,7 @@ class TestDocumentIndexNew:
             # doc being skipped.
             filters = IndexFilters(
                 access_control_list=[PUBLIC_DOC_PAT],
-                tenant_id=TEST_TENANT_ID,
+                tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
             )
             retrieved = _retrieve_chunks_with_expected_boost(
                 document_index=document_index,

--- a/backend/tests/external_dependency_unit/ee/onyx/db/test_license_cache.py
+++ b/backend/tests/external_dependency_unit/ee/onyx/db/test_license_cache.py
@@ -23,7 +23,7 @@ from ee.onyx.server.license.models import LicensePayload
 from ee.onyx.server.license.models import LicenseSource
 from ee.onyx.server.license.models import PlanType
 from onyx.redis.redis_pool import get_redis_client
-from tests.external_dependency_unit.constants import TEST_TENANT_ID
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 
 
 @pytest.fixture(autouse=True)
@@ -40,7 +40,7 @@ def _setup(
       resolves to the test tenant.
     - We wipe the license cache before and after each test for isolation.
     """
-    redis_client = get_redis_client(tenant_id=TEST_TENANT_ID)
+    redis_client = get_redis_client(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     redis_client.delete(LICENSE_METADATA_KEY)
     yield
     redis_client.delete(LICENSE_METADATA_KEY)
@@ -66,18 +66,22 @@ def _payload(
 def test_writes_under_expected_key() -> None:
     """The cache layer writes to the documented LICENSE_METADATA_KEY."""
     update_license_cache(
-        _payload(), source=LicenseSource.MANUAL_UPLOAD, tenant_id=TEST_TENANT_ID
+        _payload(),
+        source=LicenseSource.MANUAL_UPLOAD,
+        tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
     )
-    redis_client = get_redis_client(tenant_id=TEST_TENANT_ID)
+    redis_client = get_redis_client(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     assert redis_client.exists(LICENSE_METADATA_KEY) == 1
 
 
 def test_sets_24h_ttl() -> None:
     """The cache entry expires after LICENSE_CACHE_TTL_SECONDS (24h)."""
     update_license_cache(
-        _payload(), source=LicenseSource.AUTO_FETCH, tenant_id=TEST_TENANT_ID
+        _payload(),
+        source=LicenseSource.AUTO_FETCH,
+        tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
     )
-    redis_client = get_redis_client(tenant_id=TEST_TENANT_ID)
+    redis_client = get_redis_client(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     ttl = redis_client.ttl(LICENSE_METADATA_KEY)
     # Allow a few seconds of drift between SET and TTL read.
     assert LICENSE_CACHE_TTL_SECONDS - 10 <= ttl <= LICENSE_CACHE_TTL_SECONDS
@@ -88,9 +92,11 @@ def test_round_trip_preserves_tier_and_source() -> None:
     update_license_cache(
         _payload(CustomerTier.BUSINESS),
         source=LicenseSource.AUTO_FETCH,
-        tenant_id=TEST_TENANT_ID,
+        tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
     )
-    metadata = get_cached_license_metadata(tenant_id=TEST_TENANT_ID)
+    metadata = get_cached_license_metadata(
+        tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+    )
     assert metadata is not None
     assert metadata.customer_tier == CustomerTier.BUSINESS
     assert metadata.source == LicenseSource.AUTO_FETCH
@@ -102,14 +108,16 @@ def test_singleton_subsequent_write_overwrites() -> None:
     update_license_cache(
         _payload(CustomerTier.BUSINESS),
         source=LicenseSource.MANUAL_UPLOAD,
-        tenant_id=TEST_TENANT_ID,
+        tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
     )
     update_license_cache(
         _payload(CustomerTier.ENTERPRISE),
         source=LicenseSource.AUTO_FETCH,
-        tenant_id=TEST_TENANT_ID,
+        tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
     )
-    metadata = get_cached_license_metadata(tenant_id=TEST_TENANT_ID)
+    metadata = get_cached_license_metadata(
+        tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+    )
     assert metadata is not None
     assert metadata.customer_tier == CustomerTier.ENTERPRISE
     assert metadata.source == LicenseSource.AUTO_FETCH
@@ -123,8 +131,10 @@ def test_legacy_payload_keeps_customer_tier_none_through_cache() -> None:
     update_license_cache(
         _payload(customer_tier=None),
         source=LicenseSource.MANUAL_UPLOAD,
-        tenant_id=TEST_TENANT_ID,
+        tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
     )
-    metadata = get_cached_license_metadata(tenant_id=TEST_TENANT_ID)
+    metadata = get_cached_license_metadata(
+        tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+    )
     assert metadata is not None
     assert metadata.customer_tier is None

--- a/backend/tests/external_dependency_unit/ee/onyx/utils/test_trial_promotion.py
+++ b/backend/tests/external_dependency_unit/ee/onyx/utils/test_trial_promotion.py
@@ -24,13 +24,13 @@ from ee.onyx.server.tenants.tier_management import update_tenant_tier
 from ee.onyx.utils import tier as tier_module
 from onyx.redis.redis_pool import get_redis_client
 from onyx.server.settings.models import Tier
-from tests.external_dependency_unit.constants import TEST_TENANT_ID
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 
 
 @pytest.fixture(autouse=True)
 def _clean_tier_cache() -> Generator[None, None, None]:
     """Wipe the tier cache before and after each test so runs are isolated."""
-    redis_client = get_redis_client(tenant_id=TEST_TENANT_ID)
+    redis_client = get_redis_client(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     redis_client.delete(TENANT_TIER_KEY)
     yield
     redis_client.delete(TENANT_TIER_KEY)
@@ -73,9 +73,13 @@ def _billing_info(
 def test_trial_business_resolves_to_enterprise() -> None:
     """A BUSINESS tenant with a future trial_end is promoted to ENTERPRISE."""
     future = datetime.now(timezone.utc) + timedelta(days=1)
-    update_tenant_tier(TEST_TENANT_ID, CustomerTier.BUSINESS, future)
+    update_tenant_tier(
+        POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE, CustomerTier.BUSINESS, future
+    )
 
-    assert tier_module.get_tier(TEST_TENANT_ID) == Tier.ENTERPRISE
+    assert (
+        tier_module.get_tier(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE) == Tier.ENTERPRISE
+    )
 
 
 def test_expired_trial_business_drops_back_to_business() -> None:
@@ -83,32 +87,44 @@ def test_expired_trial_business_drops_back_to_business() -> None:
     without waiting on the next webhook — this is the core defense against
     a delayed CP push."""
     past = datetime.now(timezone.utc) - timedelta(days=1)
-    update_tenant_tier(TEST_TENANT_ID, CustomerTier.BUSINESS, past)
+    update_tenant_tier(
+        POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE, CustomerTier.BUSINESS, past
+    )
 
-    assert tier_module.get_tier(TEST_TENANT_ID) == Tier.BUSINESS
+    assert tier_module.get_tier(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE) == Tier.BUSINESS
 
 
 def test_non_trial_business_resolves_to_business() -> None:
     """BUSINESS with no trial_end is unaffected by the promotion rule."""
-    update_tenant_tier(TEST_TENANT_ID, CustomerTier.BUSINESS, None)
+    update_tenant_tier(
+        POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE, CustomerTier.BUSINESS, None
+    )
 
-    assert tier_module.get_tier(TEST_TENANT_ID) == Tier.BUSINESS
+    assert tier_module.get_tier(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE) == Tier.BUSINESS
 
 
 def test_enterprise_without_trial_resolves_to_enterprise() -> None:
     """A contractual ENTERPRISE tenant is unaffected by the rule (no-op)."""
-    update_tenant_tier(TEST_TENANT_ID, CustomerTier.ENTERPRISE, None)
+    update_tenant_tier(
+        POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE, CustomerTier.ENTERPRISE, None
+    )
 
-    assert tier_module.get_tier(TEST_TENANT_ID) == Tier.ENTERPRISE
+    assert (
+        tier_module.get_tier(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE) == Tier.ENTERPRISE
+    )
 
 
 def test_enterprise_with_future_trial_remains_enterprise() -> None:
     """ENTERPRISE + a (nonsense in practice) future trial_end is still
     ENTERPRISE — the promotion rule only fires on BUSINESS."""
     future = datetime.now(timezone.utc) + timedelta(days=1)
-    update_tenant_tier(TEST_TENANT_ID, CustomerTier.ENTERPRISE, future)
+    update_tenant_tier(
+        POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE, CustomerTier.ENTERPRISE, future
+    )
 
-    assert tier_module.get_tier(TEST_TENANT_ID) == Tier.ENTERPRISE
+    assert (
+        tier_module.get_tier(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE) == Tier.ENTERPRISE
+    )
 
 
 def test_cache_miss_lazy_refresh_promotes_and_caches() -> None:
@@ -118,11 +134,11 @@ def test_cache_miss_lazy_refresh_promotes_and_caches() -> None:
     billing = _billing_info(CustomerTier.BUSINESS, future)
 
     with patch.object(tier_module, "fetch_billing_information", return_value=billing):
-        result = tier_module.get_tier(TEST_TENANT_ID)
+        result = tier_module.get_tier(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
 
     assert result == Tier.ENTERPRISE
 
-    cached = get_cached_tier(TEST_TENANT_ID)
+    cached = get_cached_tier(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     assert cached is not None
     assert cached.customer_tier == CustomerTier.BUSINESS
     # Allow microsecond drift from ISO round-trip.
@@ -134,7 +150,7 @@ def test_cached_naive_trial_end_is_treated_as_none() -> None:
     """A cache entry with a naive `trial_end` ISO string must not crash the
     tz-aware comparison in `_effective_tier`. It should be parsed as `None`
     (logged) and the tenant should resolve to their unpromoted tier."""
-    redis_client = get_redis_client(tenant_id=TEST_TENANT_ID)
+    redis_client = get_redis_client(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     payload = json.dumps(
         {
             "customer_tier": CustomerTier.BUSINESS.value,
@@ -144,13 +160,13 @@ def test_cached_naive_trial_end_is_treated_as_none() -> None:
     )
     redis_client.set(TENANT_TIER_KEY, payload)
 
-    cached = get_cached_tier(TEST_TENANT_ID)
+    cached = get_cached_tier(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     assert cached is not None
     assert cached.customer_tier == CustomerTier.BUSINESS
     assert cached.trial_end is None
 
     # End-to-end: must not raise, must fall back to unpromoted BUSINESS.
-    assert tier_module.get_tier(TEST_TENANT_ID) == Tier.BUSINESS
+    assert tier_module.get_tier(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE) == Tier.BUSINESS
 
 
 def test_cp_returns_naive_trial_end_falls_back_to_business() -> None:
@@ -174,7 +190,7 @@ def test_cp_returns_naive_trial_end_falls_back_to_business() -> None:
     )
 
     with patch.object(tier_module, "fetch_billing_information", return_value=billing):
-        result = tier_module.get_tier(TEST_TENANT_ID)
+        result = tier_module.get_tier(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
 
     assert result == Tier.BUSINESS
 
@@ -185,9 +201,9 @@ def test_cache_miss_subscription_status_response_falls_back_to_business() -> Non
     response = SubscriptionStatusResponse(subscribed=False, customer_tier=None)
 
     with patch.object(tier_module, "fetch_billing_information", return_value=response):
-        result = tier_module.get_tier(TEST_TENANT_ID)
+        result = tier_module.get_tier(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
 
     assert result == Tier.BUSINESS
     # No-op cache write expected on this path.
-    redis_client = get_redis_client(tenant_id=TEST_TENANT_ID)
+    redis_client = get_redis_client(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     assert redis_client.get(TENANT_TIER_KEY) is None

--- a/backend/tests/external_dependency_unit/file_store/test_file_store_non_mocked.py
+++ b/backend/tests/external_dependency_unit/file_store/test_file_store_non_mocked.py
@@ -21,8 +21,8 @@ from onyx.configs.constants import FileOrigin
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.file_store.file_store import S3BackedFileStore
 from onyx.utils.logger import setup_logger
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
-from tests.external_dependency_unit.constants import TEST_TENANT_ID
 
 logger = setup_logger()
 
@@ -212,7 +212,7 @@ class TestS3BackedFileStore:
             file_record.bucket_name == file_store._get_bucket_name()
         )  # Use actual bucket name
         # The object key should include the tenant ID
-        expected_object_key = f"{file_store._s3_prefix}/{TEST_TENANT_ID}/{file_id}"
+        expected_object_key = f"{file_store._s3_prefix}/{POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE}/{file_id}"
         assert file_record.object_key == expected_object_key
 
     def test_change_file_id_is_metadata_only(
@@ -866,7 +866,9 @@ class TestS3BackedFileStore:
             """Worker function to save a file with its own database session"""
             try:
                 # Set up tenant context for this worker
-                token = CURRENT_TENANT_ID_CONTEXTVAR.set(TEST_TENANT_ID)
+                token = CURRENT_TENANT_ID_CONTEXTVAR.set(
+                    POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+                )
                 try:
                     # Create a new database session for each worker to avoid conflicts
                     with get_session_with_current_tenant() as worker_session:

--- a/backend/tests/external_dependency_unit/file_store/test_staging_concurrent_attempt_skip.py
+++ b/backend/tests/external_dependency_unit/file_store/test_staging_concurrent_attempt_skip.py
@@ -21,7 +21,7 @@ from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import IndexAttempt
 from onyx.file_store.staging import reap_prior_attempt_staged_files
 from onyx.file_store.staging import stage_raw_file
-from tests.external_dependency_unit.constants import TEST_TENANT_ID
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair
 from tests.external_dependency_unit.indexing_helpers import make_cc_pair
 
@@ -98,13 +98,22 @@ def test_sweep_skips_files_owned_by_non_terminal_attempt(
     )
 
     file_for_terminal = _stage_file(
-        cc_pair.id, terminal_old.id, TEST_TENANT_ID, b"terminal payload"
+        cc_pair.id,
+        terminal_old.id,
+        POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
+        b"terminal payload",
     )
     file_for_in_progress = _stage_file(
-        cc_pair.id, in_progress_concurrent.id, TEST_TENANT_ID, b"concurrent payload"
+        cc_pair.id,
+        in_progress_concurrent.id,
+        POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
+        b"concurrent payload",
     )
     file_for_current = _stage_file(
-        cc_pair.id, current.id, TEST_TENANT_ID, b"current payload"
+        cc_pair.id,
+        current.id,
+        POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
+        b"current payload",
     )
     db_session.commit()
 
@@ -112,7 +121,7 @@ def test_sweep_skips_files_owned_by_non_terminal_attempt(
     deleted_count = reap_prior_attempt_staged_files(
         current_attempt_id=current.id,
         cc_pair_id=cc_pair.id,
-        tenant_id=TEST_TENANT_ID,
+        tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
         db_session=db_session,
     )
 
@@ -164,14 +173,17 @@ def test_sweep_skips_files_owned_by_not_started_attempt(
     )
 
     file_for_not_started = _stage_file(
-        cc_pair.id, not_started.id, TEST_TENANT_ID, b"not started payload"
+        cc_pair.id,
+        not_started.id,
+        POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
+        b"not started payload",
     )
     db_session.commit()
 
     deleted_count = reap_prior_attempt_staged_files(
         current_attempt_id=current.id,
         cc_pair_id=cc_pair.id,
-        tenant_id=TEST_TENANT_ID,
+        tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
         db_session=db_session,
     )
 
@@ -213,14 +225,17 @@ def test_sweep_reaps_orphan_with_no_owning_attempt(
     # Use an attempt id that doesn't correspond to any IndexAttempt row.
     orphan_attempt_id = 999_999_999
     file_for_orphan = _stage_file(
-        cc_pair.id, orphan_attempt_id, TEST_TENANT_ID, b"orphan payload"
+        cc_pair.id,
+        orphan_attempt_id,
+        POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
+        b"orphan payload",
     )
     db_session.commit()
 
     deleted_count = reap_prior_attempt_staged_files(
         current_attempt_id=current.id,
         cc_pair_id=cc_pair.id,
-        tenant_id=TEST_TENANT_ID,
+        tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
         db_session=db_session,
     )
 

--- a/backend/tests/external_dependency_unit/full_setup.py
+++ b/backend/tests/external_dependency_unit/full_setup.py
@@ -14,8 +14,8 @@ from onyx.indexing.models import IndexingSetting
 from onyx.setup import setup_document_indices
 from onyx.setup import setup_postgres
 from shared_configs import configs as shared_configs_module
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
-from tests.external_dependency_unit.constants import TEST_TENANT_ID
 
 _SETUP_COMPLETE: bool = False
 
@@ -39,7 +39,7 @@ def ensure_full_deployment_setup(
     if os.environ.get("SKIP_EXTERNAL_DEPENDENCY_UNIT_SETUP", "").lower() == "true":
         return
 
-    tenant = tenant_id or TEST_TENANT_ID
+    tenant = tenant_id or POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 
     # Initialize engine (noop if already initialized)
     SqlEngine.init_engine(pool_size=10, max_overflow=5)

--- a/backend/tests/external_dependency_unit/indexing/test_docfetching_orphan_cleanup.py
+++ b/backend/tests/external_dependency_unit/indexing/test_docfetching_orphan_cleanup.py
@@ -55,7 +55,7 @@ from onyx.file_store.file_store import get_default_file_store
 from onyx.file_store.staging import build_raw_file_callback
 from onyx.file_store.staging import cleanup_staged_files_for_attempt
 from onyx.file_store.staging import reap_prior_attempt_staged_files
-from tests.external_dependency_unit.constants import TEST_TENANT_ID
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair
 from tests.external_dependency_unit.indexing_helpers import make_cc_pair
 
@@ -153,9 +153,9 @@ def tenant_and_cc_pair_ids(
     synthetic id is sufficient and avoids seeding a full cc_pair just to
     satisfy schema constraints the test doesn't exercise.
     """
-    from tests.external_dependency_unit.constants import TEST_TENANT_ID
+    from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 
-    return TEST_TENANT_ID, abs(hash(uuid4().hex)) % 10_000_000
+    return POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE, abs(hash(uuid4().hex)) % 10_000_000
 
 
 @pytest.fixture
@@ -567,7 +567,7 @@ def test_run_docfetching_entrypoint_leaves_crash_orphans_for_next_sweep(
             run_docfetching_entrypoint(
                 app=mock_app,
                 index_attempt_id=attempt_id,
-                tenant_id=TEST_TENANT_ID,
+                tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
                 connector_credential_pair_id=cc_pair.id,
             )
 
@@ -597,7 +597,7 @@ def test_run_docfetching_entrypoint_leaves_crash_orphans_for_next_sweep(
         reaped = reap_prior_attempt_staged_files(
             current_attempt_id=attempt_id + 1,
             cc_pair_id=cc_pair.id,
-            tenant_id=TEST_TENANT_ID,
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
             db_session=db_session,
         )
         assert reaped == 1

--- a/backend/tests/external_dependency_unit/indexing/test_document_deletion_file_cleanup.py
+++ b/backend/tests/external_dependency_unit/indexing/test_document_deletion_file_cleanup.py
@@ -25,7 +25,7 @@ from onyx.db.document import upsert_document_by_connector_credential_pair
 from onyx.db.models import ConnectorCredentialPair
 from onyx.indexing.indexing_pipeline import index_doc_batch_prepare
 from onyx.server.onyx_api.ingestion import delete_ingestion_doc
-from tests.external_dependency_unit.constants import TEST_TENANT_ID
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair
 from tests.external_dependency_unit.indexing_helpers import get_doc_row
 from tests.external_dependency_unit.indexing_helpers import get_filerecord
@@ -223,7 +223,7 @@ class TestDocumentByCcPairCleanupTask:
                     doc.id,
                     cc_pair.connector_id,
                     cc_pair.credential_id,
-                    TEST_TENANT_ID,
+                    POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
                 ),
             )
 
@@ -264,7 +264,7 @@ class TestDocumentByCcPairCleanupTask:
                     doc.id,
                     cc_pair.connector_id,
                     cc_pair.credential_id,
-                    TEST_TENANT_ID,
+                    POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
                 ),
             )
 

--- a/backend/tests/external_dependency_unit/indexing/test_persistent_indexing.py
+++ b/backend/tests/external_dependency_unit/indexing/test_persistent_indexing.py
@@ -44,7 +44,7 @@ from onyx.db.index_attempt import get_index_attempt_errors
 from onyx.db.models import IndexAttempt
 from onyx.db.models import IndexAttemptError
 from onyx.db.models import SearchSettings
-from tests.external_dependency_unit.constants import TEST_TENANT_ID
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair
 from tests.external_dependency_unit.indexing_helpers import make_cc_pair
 
@@ -247,7 +247,7 @@ def test_unhandled_exception_default_marks_attempt_failed(
             run_docfetching_entrypoint(
                 app=mock_app,
                 index_attempt_id=attempt_id,
-                tenant_id=TEST_TENANT_ID,
+                tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
                 connector_credential_pair_id=cc_pair_id,
             )
 
@@ -291,7 +291,7 @@ def test_unhandled_exception_persistent_mode_still_marks_failed(
             run_docfetching_entrypoint(
                 app=mock_app,
                 index_attempt_id=attempt_id,
-                tenant_id=TEST_TENANT_ID,
+                tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
                 connector_credential_pair_id=cc_pair_id,
             )
 
@@ -335,7 +335,7 @@ def test_threshold_disabled_in_persistent_mode(
         run_docfetching_entrypoint(
             app=mock_app,
             index_attempt_id=attempt_id,
-            tenant_id=TEST_TENANT_ID,
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
             connector_credential_pair_id=cc_pair_id,
         )
 
@@ -375,7 +375,7 @@ def test_threshold_default_aborts_attempt(
             run_docfetching_entrypoint(
                 app=mock_app,
                 index_attempt_id=attempt_id,
-                tenant_id=TEST_TENANT_ID,
+                tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
                 connector_credential_pair_id=cc_pair_id,
             )
 

--- a/backend/tests/external_dependency_unit/indexing_helpers.py
+++ b/backend/tests/external_dependency_unit/indexing_helpers.py
@@ -76,14 +76,23 @@ def get_filerecord(db_session: Session, file_id: str) -> FileRecord | None:
     return get_filerecord_by_file_id_optional(file_id=file_id, db_session=db_session)
 
 
-def make_cc_pair(db_session: Session) -> ConnectorCredentialPair:
+def make_cc_pair(
+    db_session: Session,
+    source: DocumentSource = DocumentSource.MOCK_CONNECTOR,
+    *,
+    commit: bool = True,
+) -> ConnectorCredentialPair:
     """Create a Connector + Credential + ConnectorCredentialPair for a test.
 
-    All names are UUID-suffixed so parallel test runs don't collide.
+    All names are UUID-suffixed so parallel test runs don't collide. Pass
+    ``commit=False`` to flush only (no commit) for lanes that rely on the
+    surrounding transaction rollback for cleanup; the default commits +
+    refreshes for callers whose work spans separate sessions.
     """
+    suffix = uuid4().hex[:8]
     connector = Connector(
-        name=f"test-connector-{uuid4().hex[:8]}",
-        source=DocumentSource.MOCK_CONNECTOR,
+        name=f"test-connector-{suffix}",
+        source=source,
         input_type=InputType.LOAD_STATE,
         connector_specific_config={},
         refresh_freq=None,
@@ -94,7 +103,7 @@ def make_cc_pair(db_session: Session) -> ConnectorCredentialPair:
     db_session.flush()
 
     credential = Credential(
-        source=DocumentSource.MOCK_CONNECTOR,
+        source=source,
         credential_json={},
     )
     db_session.add(credential)
@@ -103,14 +112,17 @@ def make_cc_pair(db_session: Session) -> ConnectorCredentialPair:
     pair = ConnectorCredentialPair(
         connector_id=connector.id,
         credential_id=credential.id,
-        name=f"test-cc-pair-{uuid4().hex[:8]}",
+        name=f"test-cc-pair-{suffix}",
         status=ConnectorCredentialPairStatus.ACTIVE,
         access_type=AccessType.PUBLIC,
         auto_sync_options=None,
     )
     db_session.add(pair)
-    db_session.commit()
-    db_session.refresh(pair)
+    if commit:
+        db_session.commit()
+        db_session.refresh(pair)
+    else:
+        db_session.flush()
     return pair
 
 

--- a/backend/tests/external_dependency_unit/sandbox_proxy/test_approval_cache.py
+++ b/backend/tests/external_dependency_unit/sandbox_proxy/test_approval_cache.py
@@ -19,7 +19,7 @@ from onyx.sandbox_proxy.approval_cache import cached_session_grants_cover
 from onyx.sandbox_proxy.approval_cache import pop_announcement
 from onyx.sandbox_proxy.approval_cache import send_wake
 from onyx.sandbox_proxy.approval_cache import wait_for_wake
-from tests.external_dependency_unit.constants import TEST_TENANT_ID
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 
 # ---------------------------------------------------------------------------
 # announce_approval / pop_announcement
@@ -27,7 +27,7 @@ from tests.external_dependency_unit.constants import TEST_TENANT_ID
 
 
 def test_announce_then_pop_round_trip() -> None:
-    cache = get_cache_backend(tenant_id=TEST_TENANT_ID)
+    cache = get_cache_backend(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     approval_id = uuid4()
     session_id = uuid4()
 
@@ -39,7 +39,7 @@ def test_announce_then_pop_round_trip() -> None:
 
 
 def test_announce_applies_ttl() -> None:
-    cache = get_cache_backend(tenant_id=TEST_TENANT_ID)
+    cache = get_cache_backend(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     session_id = uuid4()
 
     announce_approval(uuid4(), session_id, cache)
@@ -50,13 +50,13 @@ def test_announce_applies_ttl() -> None:
 
 
 def test_pop_announcement_timeout_returns_none() -> None:
-    cache = get_cache_backend(tenant_id=TEST_TENANT_ID)
+    cache = get_cache_backend(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     assert pop_announcement(uuid4(), timeout_s=1, cache=cache) is None
 
 
 def test_pop_announcement_unparseable_returns_none() -> None:
     """A malformed payload must not crash the merger thread."""
-    cache = get_cache_backend(tenant_id=TEST_TENANT_ID)
+    cache = get_cache_backend(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     session_id = uuid4()
 
     cache.rpush(announce_key(session_id), b"not-a-uuid")
@@ -70,7 +70,7 @@ def test_pop_announcement_unparseable_returns_none() -> None:
 
 @pytest.mark.asyncio
 async def test_wait_for_wake_receives_send_wake() -> None:
-    cache = get_cache_backend(tenant_id=TEST_TENANT_ID)
+    cache = get_cache_backend(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     approval_id = uuid4()
 
     def _produce() -> None:
@@ -90,7 +90,7 @@ async def test_wait_for_wake_receives_send_wake() -> None:
 
 @pytest.mark.asyncio
 async def test_wait_for_wake_timeout_returns_none() -> None:
-    cache = get_cache_backend(tenant_id=TEST_TENANT_ID)
+    cache = get_cache_backend(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     decision = await wait_for_wake(uuid4(), timeout_s=1, cache=cache)
     assert decision is None
 
@@ -98,7 +98,7 @@ async def test_wait_for_wake_timeout_returns_none() -> None:
 @pytest.mark.asyncio
 async def test_wait_for_wake_unparseable_returns_none() -> None:
     """Pins the `except ValueError` branch in `wait_for_wake`."""
-    cache = get_cache_backend(tenant_id=TEST_TENANT_ID)
+    cache = get_cache_backend(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     approval_id = uuid4()
 
     cache.rpush(_wake_key(approval_id), b"BANANA")
@@ -107,7 +107,7 @@ async def test_wait_for_wake_unparseable_returns_none() -> None:
 
 
 def test_send_wake_applies_ttl() -> None:
-    cache = get_cache_backend(tenant_id=TEST_TENANT_ID)
+    cache = get_cache_backend(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     approval_id = uuid4()
 
     send_wake(approval_id, ApprovalDecision.APPROVED, cache)
@@ -123,7 +123,7 @@ def test_send_wake_applies_ttl() -> None:
 
 
 def test_cached_session_grants_cover_requires_every_action() -> None:
-    cache = get_cache_backend(tenant_id=TEST_TENANT_ID)
+    cache = get_cache_backend(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     session_id = uuid4()
     approval_id = uuid4()
     external_app_id = 42
@@ -172,7 +172,7 @@ def test_cached_session_grants_cover_requires_every_action() -> None:
 async def test_decision_value_round_trips() -> None:
     """Pins the enum → bytes → enum encoding; the completeness check below
     independently pins the full enum value set."""
-    cache = get_cache_backend(tenant_id=TEST_TENANT_ID)
+    cache = get_cache_backend(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     approval_id = uuid4()
 
     send_wake(approval_id, ApprovalDecision.APPROVED, cache)

--- a/backend/tests/external_dependency_unit/sandbox_proxy/test_gate_claim_arbiter.py
+++ b/backend/tests/external_dependency_unit/sandbox_proxy/test_gate_claim_arbiter.py
@@ -24,8 +24,8 @@ from onyx.sandbox_proxy.credential_injection import CredentialInjectionDispatche
 from onyx.sandbox_proxy.identity import ResolvedSandbox
 from onyx.sandbox_proxy.request_evaluator import RequestEvaluator
 from shared_configs.contextvars import POSTGRES_DEFAULT_SCHEMA
+from tests.common.craft.payloads import action_entry
 from tests.external_dependency_unit.conftest import create_test_user
-from tests.external_dependency_unit.craft._test_helpers import action_entry
 
 
 def _seed_build_session(db_session: Session) -> UUID:

--- a/backend/tests/external_dependency_unit/server/security/test_security_settings_put.py
+++ b/backend/tests/external_dependency_unit/server/security/test_security_settings_put.py
@@ -30,8 +30,8 @@ from onyx.server.security.models import SecuritySettingsOverrides
 from onyx.server.security.store import _build_env_defaults
 from onyx.server.security.store import _install_cache_for_test
 from onyx.server.security.store import invalidate_security_cache
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
-from tests.external_dependency_unit.constants import TEST_TENANT_ID
 
 
 class _FakeRequest:
@@ -76,13 +76,13 @@ def _clean_db_and_cache(
     tenant_context: None,  # noqa: ARG001 — requested for side-effect (tenant contextvar)
 ) -> Generator[None, None, None]:
     _delete_security_settings_row()
-    invalidate_security_cache(TEST_TENANT_ID)
+    invalidate_security_cache(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     import time as _time
 
     _install_cache_for_test(ttl=10.0, timer=_time.monotonic)
     yield
     _delete_security_settings_row()
-    invalidate_security_cache(TEST_TENANT_ID)
+    invalidate_security_cache(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
 
 
 # -----------------------------------------------------------------------------
@@ -205,7 +205,7 @@ def test_put_multi_tenant_accepts_tenant_editable_field(
 
 def _put_in_thread(body: dict[str, Any], errors: list[BaseException]) -> None:
     # Threads don't inherit contextvars; re-establish before the PUT.
-    token = CURRENT_TENANT_ID_CONTEXTVAR.set(TEST_TENANT_ID)
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     try:
         _put(body)
     except BaseException as e:  # noqa: BLE001

--- a/backend/tests/external_dependency_unit/server/security/test_security_settings_store.py
+++ b/backend/tests/external_dependency_unit/server/security/test_security_settings_store.py
@@ -20,8 +20,8 @@ from onyx.server.security.store import apply_patch
 from onyx.server.security.store import get_security_settings
 from onyx.server.security.store import invalidate_security_cache
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
-from tests.external_dependency_unit.constants import TEST_TENANT_ID
 
 
 def _delete_security_settings_row() -> None:
@@ -36,14 +36,14 @@ def _clean_db_and_cache(
     tenant_context: None,  # noqa: ARG001 — requested for side-effect (tenant contextvar)
 ) -> Generator[None, None, None]:
     _delete_security_settings_row()
-    invalidate_security_cache(TEST_TENANT_ID)
+    invalidate_security_cache(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     # Reset to a real-clock cache so fake-clock tests don't leak state across.
     import time as _time
 
     _install_cache_for_test(ttl=10.0, timer=_time.monotonic)
     yield
     _delete_security_settings_row()
-    invalidate_security_cache(TEST_TENANT_ID)
+    invalidate_security_cache(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
 
 
 def test_empty_db_returns_env_defaults() -> None:
@@ -203,6 +203,6 @@ def test_db_error_falls_back_to_env_defaults() -> None:
         "_load_raw_overrides_unlocked",
         side_effect=RuntimeError("simulated DB outage"),
     ):
-        invalidate_security_cache(TEST_TENANT_ID)
+        invalidate_security_cache(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
         effective = get_security_settings()
         assert effective == _build_env_defaults()

--- a/backend/tests/external_dependency_unit/server/security/test_security_settings_store.py
+++ b/backend/tests/external_dependency_unit/server/security/test_security_settings_store.py
@@ -20,7 +20,6 @@ from onyx.server.security.store import apply_patch
 from onyx.server.security.store import get_security_settings
 from onyx.server.security.store import invalidate_security_cache
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
-from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 
 
@@ -36,14 +35,14 @@ def _clean_db_and_cache(
     tenant_context: None,  # noqa: ARG001 — requested for side-effect (tenant contextvar)
 ) -> Generator[None, None, None]:
     _delete_security_settings_row()
-    invalidate_security_cache(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
+    invalidate_security_cache(POSTGRES_DEFAULT_SCHEMA)
     # Reset to a real-clock cache so fake-clock tests don't leak state across.
     import time as _time
 
     _install_cache_for_test(ttl=10.0, timer=_time.monotonic)
     yield
     _delete_security_settings_row()
-    invalidate_security_cache(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
+    invalidate_security_cache(POSTGRES_DEFAULT_SCHEMA)
 
 
 def test_empty_db_returns_env_defaults() -> None:
@@ -203,6 +202,6 @@ def test_db_error_falls_back_to_env_defaults() -> None:
         "_load_raw_overrides_unlocked",
         side_effect=RuntimeError("simulated DB outage"),
     ):
-        invalidate_security_cache(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
+        invalidate_security_cache(POSTGRES_DEFAULT_SCHEMA)
         effective = get_security_settings()
         assert effective == _build_env_defaults()


### PR DESCRIPTION
## Description

Factors shared Craft test utilities so later Craft integration-test splits can reuse pure payload builders, skill-table isolation helpers, Redis lock assertions, and DB row factories without depending on the external-dependency Craft conftest.

Also replaces the external-dependency-only `TEST_TENANT_ID` constant with the standard public-schema constant and updates affected tests accordingly.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Factors shared Craft test helpers into reusable modules, standardizes tenant handling to `POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE`, and clarifies helper names. This enables Craft integration-test splits and reduces cross-layer coupling in tests.

- **Refactors**
  - Added `tests/common/craft/payloads.py` with pure builders (`default_llm_config`, `action_entry`, `default_action_entries`).
  - Added `tests/common/craft/skill_table_isolation.py` for skill/external-app table snapshots.
  - Added `tests/external_dependency_unit/craft/redis_helpers.py` with `assert_lock_serializes_two_threads`.
  - Consolidated row factories in `tests/external_dependency_unit/craft/db_helpers.py`; renamed `_set_created_at` to `force_approval_created_at`.
  - Replaced `TEST_TENANT_ID` with `shared_configs.configs.POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE` across tests; removed `tests/external_dependency_unit/constants.py`.
  - Switched `StubSandboxManager` imports to `tests.common.craft.stubs`; removed `tests/external_dependency_unit/craft/stubs.py`.
  - Extended `tests.external_dependency_unit.indexing_helpers.make_cc_pair` to accept `source` and a `commit` flag; updated callers.

<sup>Written for commit 5c28842379214a8e90152ae895bf7c1339ff4f1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

