### PR TITLE
feat(captcha): add Prometheus metrics for reCAPTCHA verification

### DIFF
--- a/backend/onyx/auth/captcha.py
+++ b/backend/onyx/auth/captcha.py
@@ -34,6 +34,10 @@ from onyx.configs.app_configs import RECAPTCHA_SCORE_THRESHOLD
 from onyx.configs.app_configs import RECAPTCHA_SITE_KEY
 from onyx.configs.app_configs import USER_AUTH_SECRET
 from onyx.redis.redis_pool import get_async_redis_connection
+from onyx.server.metrics.captcha_metrics import record_captcha_failure
+from onyx.server.metrics.captcha_metrics import record_captcha_flaky_recovery
+from onyx.server.metrics.captcha_metrics import record_captcha_success
+from onyx.utils.client_ip import current_client_ip
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -60,6 +64,12 @@ _TOKEN_MAX_AGE_SECONDS = 120
 _REPLAY_CACHE_TTL_SECONDS = 120
 _REPLAY_KEY_PREFIX = "captcha:replay:"
 
+# Window after a failure during which a subsequent success by the same
+# individual is counted as a "flaky" recovery. Longer than the token
+# freshness window since a real user may retry minutes after being bounced.
+_FLAKY_FAIL_TTL_SECONDS = 3600
+_FLAKY_KEY_PREFIX = "captcha:recent_fail:"
+
 
 class CaptchaAction(StrEnum):
     """Distinct per-endpoint action names. Enforced against
@@ -72,7 +82,13 @@ class CaptchaAction(StrEnum):
 
 
 class CaptchaVerificationError(Exception):
-    """Raised when captcha verification fails."""
+    """Raised when captcha verification fails. ``reason`` is a bounded,
+    low-cardinality category used as a Prometheus label (see
+    ``onyx/server/metrics/captcha_metrics.py``)."""
+
+    def __init__(self, message: str, reason: str = "unknown") -> None:
+        super().__init__(message)
+        self.reason = reason
 
 
 class _TokenProperties(BaseModel):
@@ -127,7 +143,7 @@ async def _reserve_token_or_raise(token: str) -> None:
         if not claimed:
             logger.warning("Captcha replay detected: token already used")
             raise CaptchaVerificationError(
-                "Captcha verification failed: token already used"
+                "Captcha verification failed: token already used", reason="replay"
             )
     except CaptchaVerificationError:
         raise
@@ -146,22 +162,75 @@ async def _release_token(token: str) -> None:
         logger.error("Captcha replay cache release error (ignored): %s", e)
 
 
+def _flaky_state_key(action: CaptchaAction, individual: str) -> str:
+    """HMAC the (action, individual) pair so the raw client IP is never stored
+    in Redis and the low-entropy value cannot be trivially recovered."""
+    digest = hmac.new(
+        _flaky_state_signing_key(),
+        f"{action.value}:{individual}".encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    return f"{_FLAKY_KEY_PREFIX}{digest}"
+
+
+def _flaky_state_signing_key() -> bytes:
+    return hashlib.sha256(
+        f"onyx-captcha-flaky-v1::{USER_AUTH_SECRET}".encode("utf-8")
+    ).digest()
+
+
+async def _note_failure_for_flaky_tracking(action: CaptchaAction) -> None:
+    """Mark that the current individual just failed so a later success can be
+    counted as flaky. Keyed by client IP — the only identifier available across
+    all three flows. No IP (e.g. outside a request) → nothing to attribute."""
+    individual = current_client_ip()
+    if not individual:
+        return
+    try:
+        redis = await get_async_redis_connection()
+        await redis.set(
+            _flaky_state_key(action, individual), "1", ex=_FLAKY_FAIL_TTL_SECONDS
+        )
+    except Exception as e:
+        logger.debug("Captcha flaky-state write failed (ignored): %s", e)
+
+
+async def _consume_flaky_recovery(action: CaptchaAction) -> bool:
+    """On success, return True (and clear the marker) if this individual failed
+    within the flaky window. The delete makes it one-shot: one recovery is
+    counted per fail→pass transition, not per subsequent success."""
+    individual = current_client_ip()
+    if not individual:
+        return False
+    try:
+        redis = await get_async_redis_connection()
+        deleted = await redis.delete(_flaky_state_key(action, individual))
+        return bool(deleted)
+    except Exception as e:
+        logger.debug("Captcha flaky-state read failed (ignored): %s", e)
+        return False
+
+
 def _check_token_freshness(create_time: str | None) -> None:
     if create_time is None:
         raise CaptchaVerificationError(
-            "Captcha verification failed: missing createTime"
+            "Captcha verification failed: missing createTime",
+            reason="missing_create_time",
         )
     try:
         ts = datetime.fromisoformat(create_time.replace("Z", "+00:00"))
     except ValueError:
         logger.warning("Captcha createTime unparseable: %r", create_time)
         raise CaptchaVerificationError(
-            "Captcha verification failed: malformed createTime"
+            "Captcha verification failed: malformed createTime",
+            reason="malformed_create_time",
         )
     age_seconds = (datetime.now(timezone.utc) - ts).total_seconds()
     if age_seconds > _TOKEN_MAX_AGE_SECONDS:
         logger.warning("Captcha token stale: age=%ss", format(age_seconds, ".1f"))
-        raise CaptchaVerificationError("Captcha verification failed: token expired")
+        raise CaptchaVerificationError(
+            "Captcha verification failed: token expired", reason="expired"
+        )
 
 
 def _evaluate_assessment(
@@ -173,13 +242,18 @@ def _evaluate_assessment(
     if not tp.valid:
         reason = tp.invalid_reason or "INVALID"
         logger.warning("Captcha token invalid: reason=%s", reason)
-        raise CaptchaVerificationError(f"Captcha verification failed: {reason}")
+        raise CaptchaVerificationError(
+            f"Captcha verification failed: {reason}", reason="invalid_token"
+        )
 
     if RECAPTCHA_HOSTNAME_ALLOWLIST and (
         tp.hostname is None or tp.hostname not in RECAPTCHA_HOSTNAME_ALLOWLIST
     ):
         logger.warning("Captcha hostname mismatch: %r", tp.hostname)
-        raise CaptchaVerificationError("Captcha verification failed: hostname mismatch")
+        raise CaptchaVerificationError(
+            "Captcha verification failed: hostname mismatch",
+            reason="hostname_mismatch",
+        )
 
     _check_token_freshness(tp.create_time)
 
@@ -187,7 +261,9 @@ def _evaluate_assessment(
         logger.warning(
             "Captcha action mismatch: got=%r expected=%r", tp.action, action.value
         )
-        raise CaptchaVerificationError("Captcha verification failed: action mismatch")
+        raise CaptchaVerificationError(
+            "Captcha verification failed: action mismatch", reason="action_mismatch"
+        )
 
     hard = _HARD_REJECT_REASONS.intersection(ra.reasons)
     if hard:
@@ -195,7 +271,8 @@ def _evaluate_assessment(
             "Captcha hard reject: reasons=%s score=%s", sorted(hard), ra.score
         )
         raise CaptchaVerificationError(
-            f"Captcha verification failed: {', '.join(sorted(hard))}"
+            f"Captcha verification failed: {', '.join(sorted(hard))}",
+            reason="hard_reject",
         )
 
     if ra.score < RECAPTCHA_SCORE_THRESHOLD:
@@ -206,7 +283,8 @@ def _evaluate_assessment(
             ra.reasons,
         )
         raise CaptchaVerificationError(
-            "Captcha verification failed: suspicious activity detected"
+            "Captcha verification failed: suspicious activity detected",
+            reason="low_score",
         )
 
     logger.info(
@@ -225,39 +303,57 @@ async def verify_captcha_token(token: str, action: CaptchaAction) -> None:
     if not is_captcha_enabled():
         return
 
-    if not token:
-        raise CaptchaVerificationError("Captcha token is required")
-
-    # Claim before the Google round-trip so a concurrent replay of the
-    # same token is rejected without both callers hitting the API.
-    await _reserve_token_or_raise(token)
-
     try:
-        async with httpx.AsyncClient() as client:
-            response = await client.post(
-                (
-                    f"https://recaptchaenterprise.googleapis.com/v1/projects/{RECAPTCHA_ENTERPRISE_PROJECT_ID}/assessments"
-                ),
-                params={"key": RECAPTCHA_ENTERPRISE_API_KEY},
-                json={
-                    "event": {
-                        "token": token,
-                        "siteKey": RECAPTCHA_SITE_KEY,
-                        "expectedAction": action.value,
-                    }
-                },
-                timeout=10.0,
+        if not token:
+            raise CaptchaVerificationError(
+                "Captcha token is required", reason="missing_token"
             )
-            response.raise_for_status()
-            result = RecaptchaAssessmentResponse(**response.json())
-            _evaluate_assessment(result, action)
 
-    except CaptchaVerificationError:
+        # Claim before the Google round-trip so a concurrent replay of the
+        # same token is rejected without both callers hitting the API.
+        await _reserve_token_or_raise(token)
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(
+                    (
+                        f"https://recaptchaenterprise.googleapis.com/v1/projects/{RECAPTCHA_ENTERPRISE_PROJECT_ID}/assessments"
+                    ),
+                    params={"key": RECAPTCHA_ENTERPRISE_API_KEY},
+                    json={
+                        "event": {
+                            "token": token,
+                            "siteKey": RECAPTCHA_SITE_KEY,
+                            "expectedAction": action.value,
+                        }
+                    },
+                    timeout=10.0,
+                )
+                response.raise_for_status()
+                result = RecaptchaAssessmentResponse(**response.json())
+                _evaluate_assessment(result, action)
+
+        except CaptchaVerificationError:
+            raise
+        except Exception as e:
+            logger.error("Captcha verification failed unexpectedly: %s", e)
+            await _release_token(token)
+            raise CaptchaVerificationError(
+                "Captcha verification service unavailable",
+                reason="service_unavailable",
+            )
+    except CaptchaVerificationError as err:
+        record_captcha_failure(action.value, err.reason)
+        await _note_failure_for_flaky_tracking(action)
         raise
-    except Exception as e:
-        logger.error("Captcha verification failed unexpectedly: %s", e)
-        await _release_token(token)
-        raise CaptchaVerificationError("Captcha verification service unavailable")
+
+    record_captcha_success(action.value)
+    if await _consume_flaky_recovery(action):
+        record_captcha_flaky_recovery(action.value)
+        logger.info(
+            "Captcha flaky recovery: action=%s passed after a recent failure",
+            action.value,
+        )
 
 
 def _cookie_signing_key() -> bytes:

--- a/backend/onyx/server/metrics/captcha_metrics.py
+++ b/backend/onyx/server/metrics/captcha_metrics.py
@@ -1,0 +1,69 @@
+"""reCAPTCHA verification Prometheus metrics.
+
+Tracks every ``verify_captcha_token`` outcome across all three guarded flows
+(signup, login, oauth):
+
+  1. Verification volume + pass/fail rate (``onyx_captcha_verifications_total``)
+  2. Failure breakdown by reason (``onyx_captcha_failures_total``)
+  3. "Flaky" recoveries — an individual that recently failed and then passed
+     (``onyx_captcha_flaky_recoveries_total``)
+
+The flaky signal answers "how often does a real user get bounced once and then
+get through": a high count relative to total verifications suggests the score
+threshold is too aggressive for legitimate traffic. The per-individual state
+that drives it lives in Redis (see ``onyx/auth/captcha.py``); only the bounded
+``action`` label reaches Prometheus so cardinality stays flat.
+
+Usage:
+    from onyx.server.metrics.captcha_metrics import (
+        record_captcha_success,
+        record_captcha_failure,
+        record_captcha_flaky_recovery,
+    )
+"""
+
+from prometheus_client import Counter
+
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+CAPTCHA_VERIFICATIONS = Counter(
+    "onyx_captcha_verifications_total",
+    "Total reCAPTCHA verification attempts by action and outcome",
+    ["action", "outcome"],
+)
+
+CAPTCHA_FAILURES = Counter(
+    "onyx_captcha_failures_total",
+    "reCAPTCHA verification failures broken down by reject reason",
+    ["action", "reason"],
+)
+
+CAPTCHA_FLAKY_RECOVERIES = Counter(
+    "onyx_captcha_flaky_recoveries_total",
+    "Verifications that passed after the same individual recently failed (flaky)",
+    ["action"],
+)
+
+
+def record_captcha_success(action: str) -> None:
+    try:
+        CAPTCHA_VERIFICATIONS.labels(action=action, outcome="success").inc()
+    except Exception:
+        logger.debug("Failed to record captcha success metric", exc_info=True)
+
+
+def record_captcha_failure(action: str, reason: str) -> None:
+    try:
+        CAPTCHA_VERIFICATIONS.labels(action=action, outcome="failure").inc()
+        CAPTCHA_FAILURES.labels(action=action, reason=reason).inc()
+    except Exception:
+        logger.debug("Failed to record captcha failure metric", exc_info=True)
+
+
+def record_captcha_flaky_recovery(action: str) -> None:
+    try:
+        CAPTCHA_FLAKY_RECOVERIES.labels(action=action).inc()
+    except Exception:
+        logger.debug("Failed to record captcha flaky recovery metric", exc_info=True)

--- a/backend/tests/unit/onyx/auth/test_captcha_metrics.py
+++ b/backend/tests/unit/onyx/auth/test_captcha_metrics.py
@@ -1,0 +1,209 @@
+"""Unit tests for reCAPTCHA Prometheus metrics, focused on the "flaky"
+fail-then-pass recovery signal."""
+
+from collections.abc import Iterator
+from datetime import datetime
+from datetime import timezone
+from typing import Any
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from prometheus_client import Counter
+
+from onyx.auth import captcha as captcha_module
+from onyx.auth.captcha import CaptchaAction
+from onyx.auth.captcha import CaptchaVerificationError
+from onyx.auth.captcha import verify_captcha_token
+from onyx.server.metrics import captcha_metrics
+
+
+class _FakeRedis:
+    """Minimal dict-backed async Redis supporting the SETNX + delete surface
+    used by the replay cache and the flaky-state helpers."""
+
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+
+    async def set(self, key: str, value: str, nx: bool = False, **_: object) -> bool:
+        if nx and key in self.store:
+            return False
+        self.store[key] = value
+        return True
+
+    async def delete(self, key: str) -> int:
+        if key in self.store:
+            del self.store[key]
+            return 1
+        return 0
+
+
+def _assessment(*, score: float = 0.9) -> dict[str, Any]:
+    return {
+        "name": "projects/154649423065/assessments/abc",
+        "tokenProperties": {
+            "valid": True,
+            "invalidReason": None,
+            "action": "login",
+            "hostname": "cloud.onyx.app",
+            "createTime": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        },
+        "riskAnalysis": {"score": score, "reasons": []},
+    }
+
+
+def _fake_client(payload: dict[str, Any]) -> MagicMock:
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json = MagicMock(return_value=payload)
+    client = MagicMock()
+    client.post = AsyncMock(return_value=resp)
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+    return client
+
+
+def _value(counter: Counter, **labels: str) -> float:
+    return counter.labels(**labels)._value.get()
+
+
+@pytest.fixture
+def fake_redis() -> Iterator[None]:
+    """Enable captcha and back it with a single shared fake Redis so state set
+    by one verification call is visible to the next (mirrors the real
+    cross-request behavior). Client IP is fixed so flaky tracking can attribute."""
+    redis = _FakeRedis()
+    with (
+        patch.object(captcha_module, "is_captcha_enabled", return_value=True),
+        patch.object(
+            captcha_module,
+            "get_async_redis_connection",
+            AsyncMock(return_value=redis),
+        ),
+        patch.object(captcha_module, "current_client_ip", return_value="203.0.113.7"),
+    ):
+        yield
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("fake_redis")
+async def test_success_records_success_metric() -> None:
+    before = _value(
+        captcha_metrics.CAPTCHA_VERIFICATIONS, action="login", outcome="success"
+    )
+    with patch.object(
+        captcha_module.httpx, "AsyncClient", return_value=_fake_client(_assessment())
+    ):
+        await verify_captcha_token("tok-ok", CaptchaAction.LOGIN)
+    after = _value(
+        captcha_metrics.CAPTCHA_VERIFICATIONS, action="login", outcome="success"
+    )
+    assert after == before + 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("fake_redis")
+async def test_failure_records_failure_metric_with_reason() -> None:
+    fail_before = _value(
+        captcha_metrics.CAPTCHA_FAILURES, action="login", reason="low_score"
+    )
+    outcome_before = _value(
+        captcha_metrics.CAPTCHA_VERIFICATIONS, action="login", outcome="failure"
+    )
+    with patch.object(
+        captcha_module.httpx,
+        "AsyncClient",
+        return_value=_fake_client(_assessment(score=0.1)),
+    ):
+        with pytest.raises(CaptchaVerificationError):
+            await verify_captcha_token("tok-low", CaptchaAction.LOGIN)
+    assert (
+        _value(captcha_metrics.CAPTCHA_FAILURES, action="login", reason="low_score")
+        == fail_before + 1
+    )
+    assert (
+        _value(captcha_metrics.CAPTCHA_VERIFICATIONS, action="login", outcome="failure")
+        == outcome_before + 1
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("fake_redis")
+async def test_flaky_recovery_counted_once_on_fail_then_pass() -> None:
+    """An individual that fails and then passes increments the flaky counter
+    exactly once — a second pass does not double-count."""
+    before = _value(captcha_metrics.CAPTCHA_FLAKY_RECOVERIES, action="login")
+
+    # 1) Fail — leaves a recent-fail marker for this individual.
+    with patch.object(
+        captcha_module.httpx,
+        "AsyncClient",
+        return_value=_fake_client(_assessment(score=0.1)),
+    ):
+        with pytest.raises(CaptchaVerificationError):
+            await verify_captcha_token("tok-fail", CaptchaAction.LOGIN)
+    assert _value(captcha_metrics.CAPTCHA_FLAKY_RECOVERIES, action="login") == before
+
+    # 2) Pass — consumes the marker → flaky recovery.
+    with patch.object(
+        captcha_module.httpx, "AsyncClient", return_value=_fake_client(_assessment())
+    ):
+        await verify_captcha_token("tok-pass-1", CaptchaAction.LOGIN)
+    assert (
+        _value(captcha_metrics.CAPTCHA_FLAKY_RECOVERIES, action="login") == before + 1
+    )
+
+    # 3) Second pass — marker already consumed → no further increment.
+    with patch.object(
+        captcha_module.httpx, "AsyncClient", return_value=_fake_client(_assessment())
+    ):
+        await verify_captcha_token("tok-pass-2", CaptchaAction.LOGIN)
+    assert (
+        _value(captcha_metrics.CAPTCHA_FLAKY_RECOVERIES, action="login") == before + 1
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("fake_redis")
+async def test_clean_pass_is_not_flaky() -> None:
+    """A first-try success with no prior failure is not a flaky recovery."""
+    before = _value(captcha_metrics.CAPTCHA_FLAKY_RECOVERIES, action="login")
+    with patch.object(
+        captcha_module.httpx, "AsyncClient", return_value=_fake_client(_assessment())
+    ):
+        await verify_captcha_token("tok-clean", CaptchaAction.LOGIN)
+    assert _value(captcha_metrics.CAPTCHA_FLAKY_RECOVERIES, action="login") == before
+
+
+@pytest.mark.asyncio
+async def test_flaky_tracking_skipped_without_client_ip() -> None:
+    """No client IP (e.g. outside a request) → nothing to attribute, so a
+    fail then pass is not counted as flaky."""
+    redis = _FakeRedis()
+    with (
+        patch.object(captcha_module, "is_captcha_enabled", return_value=True),
+        patch.object(
+            captcha_module,
+            "get_async_redis_connection",
+            AsyncMock(return_value=redis),
+        ),
+        patch.object(captcha_module, "current_client_ip", return_value=None),
+    ):
+        before = _value(captcha_metrics.CAPTCHA_FLAKY_RECOVERIES, action="login")
+        with patch.object(
+            captcha_module.httpx,
+            "AsyncClient",
+            return_value=_fake_client(_assessment(score=0.1)),
+        ):
+            with pytest.raises(CaptchaVerificationError):
+                await verify_captcha_token("tok-fail", CaptchaAction.LOGIN)
+        with patch.object(
+            captcha_module.httpx,
+            "AsyncClient",
+            return_value=_fake_client(_assessment()),
+        ):
+            await verify_captcha_token("tok-pass", CaptchaAction.LOGIN)
+        assert (
+            _value(captcha_metrics.CAPTCHA_FLAKY_RECOVERIES, action="login") == before
+        )


### PR DESCRIPTION
## Summary

Adds basic Prometheus metrics for the reCAPTCHA feature, with a focus on detecting **flaky** verifications — cases where an individual fails reCAPTCHA and then passes.

All three counters are incremented from the single verification chokepoint `verify_captcha_token`, so they cover every guarded flow (signup, login, oauth) and are exposed at the existing `/metrics` endpoint:

| Metric | Labels | Meaning |
|---|---|---|
| `onyx_captcha_verifications_total` | `action`, `outcome` (`success`/`failure`) | Volume + pass/fail rate |
| `onyx_captcha_failures_total` | `action`, `reason` | Failure breakdown (`low_score`, `hard_reject`, `replay`, `expired`, `action_mismatch`, `hostname_mismatch`, `invalid_token`, `missing_token`, `service_unavailable`, …) |
| `onyx_captcha_flaky_recoveries_total` | `action` | An individual that recently failed and then passed |

## Flaky detection

When an individual **fails**, a short-lived marker keyed to them is written to Redis (1-hour window). When that same individual later **passes**, the marker is consumed and `onyx_captcha_flaky_recoveries_total` is incremented — once per fail→pass transition (repeated passes don't double-count).

"Individual" = **client IP** (`current_client_ip()`), the only identifier available across all three flows (login middleware sees no email; the OAuth check has no user yet). `ClientIPMiddleware` is the outermost middleware, so the IP is populated before every captcha path runs. The IP is HMAC'd (salted with `USER_AUTH_SECRET`) before use as a Redis key, so the raw IP is never stored — mirroring the existing replay-cache and cookie-signing hygiene. No IP (e.g. outside a request) → flaky tracking is skipped.

Example query — flaky rate as a fraction of successful logins:
```promql
rate(onyx_captcha_flaky_recoveries_total{action="login"}[5m])
  / rate(onyx_captcha_verifications_total{action="login",outcome="success"}[5m])
```

## Changes

- **`backend/onyx/server/metrics/captcha_metrics.py`** (new) — the three counters + thin, exception-swallowing record helpers (so metrics can never break auth), following the existing `pruning_metrics.py` pattern.
- **`backend/onyx/auth/captcha.py`** — `CaptchaVerificationError` gained a bounded `reason` field (set at each raise site); added Redis flaky-state helpers; wrapped `verify_captcha_token` to record on every exit path. Verification behavior is unchanged — only instrumentation was added.
- **`backend/tests/unit/onyx/auth/test_captcha_metrics.py`** (new) — covers success/failure recording, fail-then-pass counts once, second pass doesn't re-count, clean pass isn't flaky, and no-IP is skipped.

## Notes

- The OAuth metric is recorded at the `/auth/captcha/oauth-verify` verification, not the subsequent signed-cookie re-check (the cookie middleware does no fresh verification).
- Counters live in the API-server process registry. This matches the codebase convention of one process per pod; multi-process-per-pod would need `prometheus_client` multiproc mode, which the repo does not currently use anywhere.

## Testing

- New tests: 5 passed. Full auth unit suite: 245 passed, 1 skipped (no regressions).
- `ruff check` + `ruff format`, `ty` type check, and the lazy-imports check all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Prometheus metrics for reCAPTCHA verification to track success, failures by reason, and fail→pass “flaky” recoveries across signup, login, and OAuth. Improves visibility into pass/fail rates and false positives without changing auth behavior.

- **New Features**
  - Counters: `onyx_captcha_verifications_total{action,outcome}`, `onyx_captcha_failures_total{action,reason}`, `onyx_captcha_flaky_recoveries_total{action}`.
  - Recorded at the single `verify_captcha_token` chokepoint; exported via `/metrics`.
  - Flaky detection via Redis: a 1-hour marker per HMAC’d client IP on failure; consumed on next success; no IP → skipped.
  - Bounded failure `reason` label (e.g., `low_score`, `hard_reject`, `replay`, `expired`, `action_mismatch`, `hostname_mismatch`, `invalid_token`, `missing_token`, `service_unavailable`).
  - Metrics are best-effort and never block auth; added unit tests for success, failure reasons, flaky once-only, and no-IP skip.

<sup>Written for commit 93e3d89cc16d50d8a0f6c79afee8289c16426cb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

