### PR TITLE
feat(audit): emit auth audit events (login, logout, register, password reset, verify)

### DIFF
--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -142,6 +142,10 @@ from onyx.redis.redis_pool import retrieve_ws_token_data
 from onyx.server.security.store import get_security_settings
 from onyx.server.settings.store import load_settings
 from onyx.server.utils import BasicAuthenticationError
+from onyx.utils.audit import AuditAction
+from onyx.utils.audit import AuditActor
+from onyx.utils.audit import AuditOutcome
+from onyx.utils.audit import emit_audit_event
 from onyx.utils.logger import setup_logger
 from onyx.utils.telemetry import mt_cloud_identify_user
 from onyx.utils.telemetry import mt_cloud_telemetry
@@ -1061,6 +1065,12 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             request=request,
         )
 
+        emit_audit_event(
+            AuditAction.LOGIN,
+            AuditOutcome.SUCCESS,
+            actor=AuditActor(user_id=str(user.id), email=user.email),
+        )
+
     async def on_after_register(
         self, user: User, request: Optional[Request] = None
     ) -> None:
@@ -1175,6 +1185,12 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             user_id=str(user.id),
         )
 
+        emit_audit_event(
+            AuditAction.REGISTER,
+            AuditOutcome.SUCCESS,
+            actor=AuditActor(user_id=str(user.id), email=user.email),
+        )
+
     async def on_after_forgot_password(
         self,
         user: User,
@@ -1197,6 +1213,12 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
 
         send_forgot_password_email(user.email, tenant_id=tenant_id, token=token)
 
+        emit_audit_event(
+            AuditAction.PASSWORD_FORGOT,
+            AuditOutcome.SUCCESS,
+            actor=AuditActor(user_id=str(user.id), email=user.email),
+        )
+
     async def on_after_request_verify(
         self,
         user: User,
@@ -1216,11 +1238,26 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             user.email, token, new_organization=user_count == 1
         )
 
+        emit_audit_event(
+            AuditAction.EMAIL_VERIFY,
+            AuditOutcome.SUCCESS,
+            actor=AuditActor(user_id=str(user.id), email=user.email),
+        )
+
     @log_function_time(print_only=True)
     async def authenticate(
         self, credentials: OAuth2PasswordRequestForm
     ) -> Optional[User]:
         email = credentials.username
+
+        def _audit_login_failure(
+            outcome: AuditOutcome = AuditOutcome.FAILURE,
+        ) -> None:
+            emit_audit_event(
+                AuditAction.LOGIN_FAILURE,
+                outcome,
+                actor=AuditActor(email=email),
+            )
 
         tenant_id: str | None = None
         try:
@@ -1239,6 +1276,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         if not tenant_id:
             # User not found in mapping
             self.password_helper.hash(credentials.password)
+            _audit_login_failure()
             return None
 
         # Create a tenant-specific session
@@ -1254,9 +1292,11 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
 
             except exceptions.UserNotExists:
                 self.password_helper.hash(credentials.password)
+                _audit_login_failure()
                 return None
 
             if not user.account_type.is_web_login():
+                _audit_login_failure(AuditOutcome.DENIED)
                 raise BasicAuthenticationError(
                     detail="NO_WEB_LOGIN_AND_HAS_NO_PASSWORD",
                 )
@@ -1265,6 +1305,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                 credentials.password, user.hashed_password
             )
             if not verified:
+                _audit_login_failure()
                 return None
 
             if updated_password_hash is not None:
@@ -1607,7 +1648,13 @@ class FastAPIUserWithLogoutRouter(FastAPIUsers[models.UP, models.ID]):
             strategy: Strategy[models.UP, models.ID] = Depends(backend.get_strategy),
         ) -> Response:
             user, token = user_token
-            return await backend.logout(strategy, user, token)
+            result = await backend.logout(strategy, user, token)
+            emit_audit_event(
+                AuditAction.LOGOUT,
+                AuditOutcome.SUCCESS,
+                actor=AuditActor(user_id=str(user.id), email=user.email),
+            )
+            return result
 
         return router
 

--- a/backend/tests/unit/onyx/auth/test_auth_audit_events.py
+++ b/backend/tests/unit/onyx/auth/test_auth_audit_events.py
@@ -1,0 +1,116 @@
+"""Unit tests for audit-event emission from the auth seams in UserManager.
+
+Verifies the right AuditAction / outcome / actor is emitted on login success,
+login failure, forgot-password, and email-verify, without coupling to the
+heavier register/logout flows (their emit calls follow the same one-line
+pattern). Emission itself is covered in tests/unit/onyx/utils/test_audit.py.
+"""
+
+import json
+import logging
+from typing import Any
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from fastapi.security import OAuth2PasswordRequestForm
+
+from onyx.auth.users import UserManager
+
+
+def _audit_events(caplog: pytest.LogCaptureFixture) -> list[dict[str, Any]]:
+    return [
+        json.loads(r.getMessage())
+        for r in caplog.records
+        if r.name.startswith("onyx.audit")
+    ]
+
+
+@pytest.mark.asyncio
+@patch("onyx.auth.users.mt_cloud_identify_user")
+async def test_on_after_login_emits_login_success(
+    _mock_identify: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    user = MagicMock(id="u-1", email="user@example.com")
+    manager = UserManager(MagicMock())
+
+    with caplog.at_level(logging.INFO, logger="onyx.audit"):
+        await manager.on_after_login(user, request=None, response=None)
+
+    events = _audit_events(caplog)
+    assert len(events) == 1
+    assert events[0]["action"] == "auth.login"
+    assert events[0]["outcome"] == "success"
+    assert events[0]["actor"]["email"] == "user@example.com"
+
+
+@pytest.mark.asyncio
+@patch("onyx.auth.users.fetch_ee_implementation_or_noop")
+async def test_authenticate_unknown_user_emits_login_failure(
+    mock_fetch: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # No tenant mapping -> authenticate() returns None on the unknown-user path.
+    mock_fetch.return_value = lambda **_kw: None
+    manager = UserManager(MagicMock())
+    creds = OAuth2PasswordRequestForm(username="user@example.com", password="wrong")
+
+    with caplog.at_level(logging.INFO, logger="onyx.audit"):
+        result = await manager.authenticate(creds)
+
+    assert result is None
+    events = _audit_events(caplog)
+    assert len(events) == 1
+    assert events[0]["action"] == "auth.login_failure"
+    assert events[0]["outcome"] == "failure"
+    assert events[0]["actor"]["email"] == "user@example.com"
+
+
+@pytest.mark.asyncio
+@patch("onyx.auth.users.send_forgot_password_email")
+@patch("onyx.auth.users.fetch_ee_implementation_or_noop")
+@patch("onyx.auth.users.EMAIL_CONFIGURED", True)
+async def test_on_after_forgot_password_emits_event(
+    mock_fetch: MagicMock,
+    _mock_send: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    mock_fetch.return_value = AsyncMock(return_value="tenant_1")
+    user = MagicMock(id="u-1", email="user@example.com")
+    manager = UserManager(MagicMock())
+
+    with caplog.at_level(logging.INFO, logger="onyx.audit"):
+        await manager.on_after_forgot_password(user, token="tok", request=None)
+
+    events = _audit_events(caplog)
+    assert len(events) == 1
+    assert events[0]["action"] == "auth.password_forgot"
+    assert events[0]["outcome"] == "success"
+
+
+@pytest.mark.asyncio
+@patch("onyx.auth.users.send_user_verification_email")
+@patch("onyx.auth.users.get_user_count", new_callable=AsyncMock)
+@patch("onyx.auth.users.get_security_settings")
+@patch("onyx.auth.users.verify_email_domain")
+async def test_on_after_request_verify_emits_event(
+    _mock_verify_domain: MagicMock,
+    mock_settings: MagicMock,
+    mock_count: AsyncMock,
+    _mock_send: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    mock_settings.return_value = MagicMock(valid_email_domains=[])
+    mock_count.return_value = 1
+    user = MagicMock(id="u-1", email="user@example.com")
+    manager = UserManager(MagicMock())
+
+    with caplog.at_level(logging.INFO, logger="onyx.audit"):
+        await manager.on_after_request_verify(user, token="tok", request=None)
+
+    events = _audit_events(caplog)
+    assert len(events) == 1
+    assert events[0]["action"] == "auth.email_verify"
+    assert events[0]["outcome"] == "success"


### PR DESCRIPTION
## Description

Wires the authentication seams onto the audit-event subsystem from #12219 (**stacked on that PR — review/merge #12219 first**). Each security-relevant auth action now emits a structured, OCSF-shaped audit event:

| Seam (`UserManager`) | Action | Outcome |
|---|---|---|
| `on_after_login` | `auth.login` | success |
| `authenticate` failure paths | `auth.login_failure` | failure (denied for non-web-login accounts) |
| logout route | `auth.logout` | success |
| `on_after_register` | `auth.register` | success |
| `on_after_forgot_password` | `auth.password_forgot` | success |
| `on_after_request_verify` | `auth.email_verify` | success |

Every event carries the actor (user id / email) and is fully fail-safe — emission never raises into the auth path (the emitter swallows all errors internally). No secrets are ever passed.

## How Has This Been Tested?

New unit tests in `backend/tests/unit/onyx/auth/test_auth_audit_events.py` (4, all passing) assert the correct action / outcome / actor is emitted for login success, login failure, forgot-password, and email-verify — mirroring the existing heavily-mocked `UserManager` unit-test pattern. The register/logout emits follow the same one-line pattern; emitter mechanics are covered by the subsystem's own tests in #12219.

`ruff` (check + format) and `ty` pass clean; the full `tests/unit/onyx/auth` + audit suite is green (250 passed, 1 pre-existing skip).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emits structured audit events for key auth actions (login, logout, register, forgot password, email verify) to improve security visibility without affecting the auth flow.

- **New Features**
  - OCSF-shaped events: auth.login (success), auth.login_failure (failure; denied for non-web-login), auth.logout (success), auth.register (success), auth.password_forgot (success), auth.email_verify (success).
  - Includes actor (user id, email); emission is fail-safe and never bubbles into auth; no secrets logged.

<sup>Written for commit 8e4b60689da720fc62b05a4996d096134dec47a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

