### PR TITLE
chore(web): clear stale Turbopack .next dev cache on checkout/pull/rebase

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -187,6 +187,22 @@ repos:
         files: ^web/lib/(opal/src/.*\.css|opal/scripts/bundle-css\.mjs|shared/(tokens/.*\.json|style-dictionary\.config\.mjs))$
         stages: [post-checkout, post-merge, post-rewrite]
 
+      # Turbopack's persistent dev cache (.next) tracks file content, but can't see
+      # dependency / build-config changes that cross its boundary: a checkout, pull, or
+      # rebase that changes deps, design tokens, opal CSS, or the Next/Tailwind build
+      # config leaves stale compiled output + CSS in .next — the phantom compile errors
+      # and stale styles that otherwise need a manual `rm -rf .next`. Drop it here, in
+      # lockstep with bun-install / opal-css-rebuild. Plain source edits are left alone:
+      # Turbopack invalidates those incrementally, so same-deps switches keep a warm cache.
+      - id: clear-web-build-cache
+        name: clear stale web build cache
+        description: "Drop the Turbopack .next dev cache after checkout/pull/rebase when deps, tokens, opal CSS, or build config change"
+        language: system
+        entry: bash -c 'rm -rf web/.next'
+        pass_filenames: false
+        files: ^web/(package\.json|bun\.lock|lib/opal/package\.json|lib/opal/src/.*\.css|lib/shared/tokens/.*\.json|next\.config\.js|postcss\.config\.js|tailwind\.config\.js|tailwind-themes/)
+        stages: [post-checkout, post-merge, post-rewrite]
+
       - id: root-bun-install
         name: root bun install
         description: "Automatically run 'bun install' at the repo root after a checkout, pull or rebase"

--- a/web/package.json
+++ b/web/package.json
@@ -9,6 +9,8 @@
   "scripts": {
     "dev": "next dev",
     "dev:profile": "NEXT_PUBLIC_ENABLE_STATS=true next dev",
+    "dev:clean": "bun run clean && next dev",
+    "clean": "rm -rf .next node_modules/.cache *.tsbuildinfo",
     "build": "next build",
     "start": "next start",
     "lint": "oxlint",


### PR DESCRIPTION
## Description

Next 16.1+ turns on Turbopack's persistent dev cache (`web/.next`) by default. It tracks file content but can't see dependency / token / build-config changes, so after a checkout, pull, or rebase that changes those, the dev server serves stale compiled output and CSS — the phantom compile errors and stale styling people clear by hand with `rm -rf .next`.

Our hooks already reinstall deps (`bun-install`) and rebuild opal CSS (`opal-css-rebuild`) on checkout/pull/rebase, but nothing drops the Turbopack cache.

**Fix**
- New `clear-web-build-cache` pre-commit hook (post-checkout/merge/rewrite, beside `opal-css-rebuild`): drops `web/.next` only when deps, tokens, opal CSS, or build config change. Plain source edits are left alone — Turbopack invalidates those incrementally — so same-deps switches keep a warm cache and dev stays fast.
- `clean` / `dev:clean` scripts in `web/package.json` for manual resets.

Keeps the cache's speed; only resets it when it would otherwise be stale.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
