### PR TITLE
feat(celery): self-heal wedged consumers via liveness probe

### DIFF
--- a/backend/onyx/background/celery/apps/app_base.py
+++ b/backend/onyx/background/celery/apps/app_base.py
@@ -24,10 +24,21 @@ from sqlalchemy.orm import Session
 from onyx.background.celery.apps.task_formatters import CeleryTaskColoredFormatter
 from onyx.background.celery.apps.task_formatters import CeleryTaskJsonFormatter
 from onyx.background.celery.apps.task_formatters import CeleryTaskPlainFormatter
+from onyx.background.celery.celery_consumer_liveness import active_request_count
+from onyx.background.celery.celery_consumer_liveness import BACKLOG_UNKNOWN
+from onyx.background.celery.celery_consumer_liveness import mark_task_consumed
+from onyx.background.celery.celery_consumer_liveness import reserved_request_count
+from onyx.background.celery.celery_consumer_liveness import seconds_since_last_consumed
+from onyx.background.celery.celery_consumer_liveness import (
+    should_withhold_liveness_touch,
+)
+from onyx.background.celery.celery_redis import celery_get_broker_client
+from onyx.background.celery.celery_redis import celery_get_queue_length
 from onyx.background.celery.celery_utils import celery_is_worker_primary
 from onyx.background.celery.celery_utils import make_probe_path
 from onyx.background.celery.tasks.vespa.document_sync import DOCUMENT_SYNC_PREFIX
 from onyx.background.celery.tasks.vespa.document_sync import DOCUMENT_SYNC_TASKSET_KEY
+from onyx.configs.app_configs import CELERY_LIVENESS_WEDGE_STALE_THRESHOLD_S
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
 from onyx.configs.app_configs import ENABLE_OPENSEARCH_INDEXING_FOR_ONYX
 from onyx.configs.app_configs import ONYX_DISABLE_VESPA
@@ -124,6 +135,10 @@ def on_task_prerun(
     # runs in the same process.
 
     LoggerContextVars.reset()
+
+    # Record that this worker just started a task; the liveness probe uses this
+    # to tell a wedged consumer apart from a healthy idle one.
+    mark_task_consumed()
 
 
 def on_task_postrun(
@@ -643,8 +658,22 @@ class LivenessProbe(bootsteps.StartStopStep):
         self.requests: list[Any] = []
         self.task_tref = None
         self.path = make_probe_path("liveness", worker.hostname)
+        self._wedge_threshold_s = CELERY_LIVENESS_WEDGE_STALE_THRESHOLD_S
+        # The worker's own -Q set, snapshotted in start() once Celery has
+        # selected it. Empty leaves wedge detection off.
+        self._wedge_queues: list[str] = []
 
     def start(self, worker: Any) -> None:
+        # Reset the consumption clock so a slow first task after boot isn't read
+        # as a wedge, and snapshot the queues this worker consumes.
+        mark_task_consumed()
+        if self._wedge_threshold_s > 0:
+            self._wedge_queues = sorted(worker.app.amqp.queues.consume_from.keys())
+            task_logger.info(
+                "Consumer-wedge liveness enabled: threshold=%ss queues=%s",
+                self._wedge_threshold_s,
+                self._wedge_queues,
+            )
         self.task_tref = worker.timer.call_repeatedly(
             15.0,
             self.update_liveness_file,
@@ -657,8 +686,61 @@ class LivenessProbe(bootsteps.StartStopStep):
         if self.task_tref:
             self.task_tref.cancel()
 
-    def update_liveness_file(self, worker: Any) -> None:  # noqa: ARG002
+    def update_liveness_file(self, worker: Any) -> None:
+        try:
+            wedged = self._consumer_wedged(worker)
+        except Exception:
+            # Fail open: any error in the wedge check must not stop the touch.
+            task_logger.warning(
+                "Consumer-wedge liveness: wedge check errored; "
+                "treating worker as healthy.",
+                exc_info=True,
+            )
+            wedged = False
+        if wedged:
+            task_logger.error(
+                "Consumer-wedge liveness: no task started in %.0fs, nothing "
+                "running, and work is queued; withholding liveness touch so "
+                "Kubernetes restarts this pod.",
+                seconds_since_last_consumed(),
+            )
+            return
         self.path.touch()
+
+    def _consumer_wedged(self, worker: Any) -> bool:
+        if self._wedge_threshold_s <= 0 or not self._wedge_queues:
+            return False
+        age = seconds_since_last_consumed()
+        if age <= self._wedge_threshold_s:
+            # Fast path: a task started recently — no broker round-trip.
+            return False
+        active = active_request_count()
+        if active != 0:
+            # Threads are busy (or the count is unreadable): not wedged.
+            return False
+        broker_backlog = self._queue_backlog(worker)
+        if broker_backlog == BACKLOG_UNKNOWN:
+            return False
+        return should_withhold_liveness_touch(
+            seconds_since_consumed=age,
+            stale_threshold_s=self._wedge_threshold_s,
+            active_requests=active,
+            backlog=broker_backlog + reserved_request_count(),
+        )
+
+    def _queue_backlog(self, worker: Any) -> int:
+        """Total tasks queued across this worker's queues, or BACKLOG_UNKNOWN if
+        the broker can't be reached (so the check fails open)."""
+        try:
+            r = celery_get_broker_client(worker.app)
+            return sum(celery_get_queue_length(q, r) for q in self._wedge_queues)
+        except Exception:
+            task_logger.warning(
+                "Consumer-wedge liveness: broker queue check failed; "
+                "treating worker as healthy.",
+                exc_info=True,
+            )
+            return BACKLOG_UNKNOWN
 
 
 def get_bootsteps() -> list[type]:

--- a/backend/onyx/background/celery/apps/app_base.py
+++ b/backend/onyx/background/celery/apps/app_base.py
@@ -708,23 +708,18 @@ class LivenessProbe(bootsteps.StartStopStep):
         self.path.touch()
 
     def _consumer_wedged(self, worker: Any) -> bool:
+        # Only enabled fleets pay for the broker check; disabled ones (the
+        # default) short-circuit here. should_withhold_liveness_touch owns the
+        # wedge decision so the logic lives in one place.
         if self._wedge_threshold_s <= 0 or not self._wedge_queues:
-            return False
-        age = seconds_since_last_consumed()
-        if age <= self._wedge_threshold_s:
-            # Fast path: a task started recently — no broker round-trip.
-            return False
-        active = active_request_count()
-        if active != 0:
-            # Threads are busy (or the count is unreadable): not wedged.
             return False
         broker_backlog = self._queue_backlog(worker)
         if broker_backlog == BACKLOG_UNKNOWN:
-            return False
+            return False  # broker unreachable — fail open
         return should_withhold_liveness_touch(
-            seconds_since_consumed=age,
+            seconds_since_consumed=seconds_since_last_consumed(),
             stale_threshold_s=self._wedge_threshold_s,
-            active_requests=active,
+            active_requests=active_request_count(),
             backlog=broker_backlog + reserved_request_count(),
         )
 

--- a/backend/onyx/background/celery/celery_consumer_liveness.py
+++ b/backend/onyx/background/celery/celery_consumer_liveness.py
@@ -1,0 +1,85 @@
+"""Detects an in-process Celery consumer wedge so Kubernetes can restart the pod.
+
+A worker can wedge while staying alive: the pod keeps running and its timer
+threads keep firing (so the timer-touched liveness file stays fresh), but the
+Celery consumer stops fetching from the broker — tasks pile up while every pool
+thread sits idle. The file-mtime liveness probe can't see this on its own.
+
+Here the worker withholds the liveness-file touch when it looks wedged, so the
+stale file trips the existing k8s liveness probe and the pod is restarted. The
+wedge signature is narrow on purpose, because a false positive restarts a
+healthy pod: no task started within the threshold, AND nothing is currently
+executing (a saturated worker busy on long tasks is NOT wedged), AND work is
+still waiting. Every "can't tell" reading fails open and keeps the worker alive.
+
+The "last consumed" signal is kept in process (not in Redis) so the restart
+decision never depends on an external store that can blip or evict the key.
+Detection is opt-in per deployment via CELERY_LIVENESS_WEDGE_STALE_THRESHOLD_S.
+"""
+
+import time
+
+from celery.worker import state as worker_state  # ty: ignore[unresolved-import]
+
+# Sentinels meaning "could not determine". Both fail open (never restart).
+BACKLOG_UNKNOWN = -1
+ACTIVE_REQUESTS_UNKNOWN = -1
+
+# Monotonic timestamp of the last task this worker started. Written from task
+# threads (task_prerun), read from the liveness timer thread; a bare float is
+# safe to share under the GIL.
+_last_consumed_monotonic: float = time.monotonic()
+
+
+def mark_task_consumed() -> None:
+    """Record that the worker just started executing a task."""
+    global _last_consumed_monotonic
+    _last_consumed_monotonic = time.monotonic()
+
+
+def seconds_since_last_consumed() -> float:
+    return time.monotonic() - _last_consumed_monotonic
+
+
+def active_request_count() -> int:
+    """Tasks this worker is currently executing, or ACTIVE_REQUESTS_UNKNOWN if it
+    can't be read. Unknown fails open: a worker that might be busy is never
+    treated as wedged."""
+    try:
+        return len(worker_state.active_requests)
+    except Exception:
+        return ACTIVE_REQUESTS_UNKNOWN
+
+
+def reserved_request_count() -> int:
+    """Tasks prefetched into this worker but not yet started — a wedge that
+    happens after prefetch drains the broker's ready lists but leaves these
+    stranded. 0 if unreadable, which only omits this evidence (never invents
+    work)."""
+    try:
+        return len(worker_state.reserved_requests)
+    except Exception:
+        return 0
+
+
+def should_withhold_liveness_touch(
+    *,
+    seconds_since_consumed: float,
+    stale_threshold_s: int,
+    active_requests: int,
+    backlog: int,
+) -> bool:
+    """Whether to skip the liveness touch (→ k8s restarts the pod).
+
+    Withhold only when no task has started within the threshold, no task is
+    currently running, and work is still queued. A non-positive threshold means
+    detection is off. A non-zero ``active_requests`` (busy, or the unknown
+    sentinel) and any non-positive ``backlog`` (incl. BACKLOG_UNKNOWN) fail open.
+    """
+    if stale_threshold_s <= 0:
+        return False
+    if seconds_since_consumed <= stale_threshold_s:
+        return False
+    if active_requests != 0:
+        return False
+    return backlog > 0

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -667,6 +667,15 @@ except ValueError:
         _CELERY_WORKER_LIGHT_PREFETCH_MULTIPLIER_DEFAULT
     )
 
+# Consumer-wedge liveness detection (see celery_consumer_liveness.py). A worker
+# that stops consuming while its queues still hold work withholds its k8s
+# liveness touch so the pod gets restarted. This value is both the opt-in switch
+# and the per-fleet staleness threshold in seconds; 0 (default) disables it. The
+# queues to watch are derived from the worker's own -Q at runtime.
+CELERY_LIVENESS_WEDGE_STALE_THRESHOLD_S = int(
+    os.environ.get("CELERY_LIVENESS_WEDGE_STALE_THRESHOLD_S", "0")
+)
+
 _CELERY_WORKER_DOCPROCESSING_CONCURRENCY_DEFAULT = 6
 try:
     env_value = os.environ.get("CELERY_WORKER_DOCPROCESSING_CONCURRENCY")

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -672,9 +672,20 @@ except ValueError:
 # liveness touch so the pod gets restarted. This value is both the opt-in switch
 # and the per-fleet staleness threshold in seconds; 0 (default) disables it. The
 # queues to watch are derived from the worker's own -Q at runtime.
-CELERY_LIVENESS_WEDGE_STALE_THRESHOLD_S = int(
-    os.environ.get("CELERY_LIVENESS_WEDGE_STALE_THRESHOLD_S", "0")
+_CELERY_LIVENESS_WEDGE_STALE_THRESHOLD = os.environ.get(
+    "CELERY_LIVENESS_WEDGE_STALE_THRESHOLD_S", "0"
 )
+try:
+    CELERY_LIVENESS_WEDGE_STALE_THRESHOLD_S = int(
+        _CELERY_LIVENESS_WEDGE_STALE_THRESHOLD
+    )
+except ValueError:
+    logger.warning(
+        "CELERY_LIVENESS_WEDGE_STALE_THRESHOLD_S=%s is invalid; disabling "
+        "consumer-wedge liveness.",
+        _CELERY_LIVENESS_WEDGE_STALE_THRESHOLD,
+    )
+    CELERY_LIVENESS_WEDGE_STALE_THRESHOLD_S = 0
 
 _CELERY_WORKER_DOCPROCESSING_CONCURRENCY_DEFAULT = 6
 try:

--- a/backend/tests/unit/onyx/background/celery/test_celery_consumer_liveness.py
+++ b/backend/tests/unit/onyx/background/celery/test_celery_consumer_liveness.py
@@ -1,0 +1,83 @@
+"""Unit coverage for the consumer-wedge liveness decision: a worker withholds
+its k8s liveness touch (so the pod is restarted) only when detection is on, no
+task has started within the threshold, nothing is currently running, and work is
+still queued. Every other case — a busy/saturated worker, an unreadable active
+count, an unreadable broker, or recent activity — keeps it alive."""
+
+from onyx.background.celery.celery_consumer_liveness import ACTIVE_REQUESTS_UNKNOWN
+from onyx.background.celery.celery_consumer_liveness import BACKLOG_UNKNOWN
+from onyx.background.celery.celery_consumer_liveness import mark_task_consumed
+from onyx.background.celery.celery_consumer_liveness import seconds_since_last_consumed
+from onyx.background.celery.celery_consumer_liveness import (
+    should_withhold_liveness_touch,
+)
+
+
+def _withhold(
+    seconds_since: float,
+    threshold: int,
+    backlog: int,
+    active_requests: int = 0,
+) -> bool:
+    return should_withhold_liveness_touch(
+        seconds_since_consumed=seconds_since,
+        stale_threshold_s=threshold,
+        active_requests=active_requests,
+        backlog=backlog,
+    )
+
+
+def test_withholds_when_stale_idle_with_backlog() -> None:
+    assert _withhold(seconds_since=301, threshold=300, backlog=5) is True
+
+
+def test_keeps_alive_when_threads_busy() -> None:
+    # Saturated worker: all threads running long tasks, backlog waiting — healthy.
+    assert (
+        _withhold(seconds_since=9999, threshold=300, backlog=5000, active_requests=48)
+        is False
+    )
+
+
+def test_keeps_alive_when_active_count_unknown() -> None:
+    # Can't tell if threads are busy: fail open.
+    assert (
+        _withhold(
+            seconds_since=9999,
+            threshold=300,
+            backlog=5000,
+            active_requests=ACTIVE_REQUESTS_UNKNOWN,
+        )
+        is False
+    )
+
+
+def test_keeps_alive_when_recently_consumed() -> None:
+    assert _withhold(seconds_since=10, threshold=300, backlog=5000) is False
+
+
+def test_keeps_alive_when_stale_but_no_backlog() -> None:
+    # An idle worker with empty queues is healthy, not wedged.
+    assert _withhold(seconds_since=9999, threshold=300, backlog=0) is False
+
+
+def test_fails_open_when_backlog_unknown() -> None:
+    # Broker unreachable: a stale reading must never trigger a restart.
+    assert (
+        _withhold(seconds_since=9999, threshold=300, backlog=BACKLOG_UNKNOWN) is False
+    )
+
+
+def test_disabled_when_threshold_non_positive() -> None:
+    assert _withhold(seconds_since=9999, threshold=0, backlog=5000) is False
+    assert _withhold(seconds_since=9999, threshold=-1, backlog=5000) is False
+
+
+def test_boundary_at_exact_threshold_keeps_alive() -> None:
+    # Exactly at the threshold is not yet stale.
+    assert _withhold(seconds_since=300, threshold=300, backlog=5) is False
+
+
+def test_mark_task_consumed_resets_clock() -> None:
+    mark_task_consumed()
+    assert seconds_since_last_consumed() < 1.0


### PR DESCRIPTION
## Description

**What this fixes:**

Background workers pull small jobs off queues and run them. Kubernetes decides whether a worker pod is healthy by watching a "liveness" file the worker keeps touching — if that file goes stale, k8s restarts the pod.

The bug: a worker can end up **alive but not working**. The process keeps running, keeps touching the liveness file on a timer, and still gossips with the other workers — but it has silently **stopped pulling jobs off the queue**. Work piles up while every thread sits idle. Because the timer keeps the file fresh, k8s never notices, so the pod is never restarted.

This isn't hypothetical — a light-worker fleet got stuck exactly like this for **~51 hours**, with its queue climbing into the hundreds of thousands and nothing draining, until someone manually restarted it. The liveness check was effectively lying: it confirmed "the process is running," not "the worker is doing its job."

**The fix:** make liveness actually mean something. A worker now reports healthy only if it's genuinely consuming work — or has nothing to do. If it has gone too long without starting a job **while jobs are clearly waiting and nothing is running**, it stops touching the liveness file and k8s restarts it automatically (~10 minutes instead of 51 hours / a human noticing).

It is **opt-in per deployment** (off by default) and **fails open** — any uncertainty leaves the worker alive, so a healthy pod is never restarted.

### How it works (technical)

- `on_task_prerun` stamps a monotonic timestamp every time the worker *starts* a task (`mark_task_consumed`).
- The existing `LivenessProbe` bootstep (15s timer) withholds the file touch only when **all three** hold:
  1. no task has started within `CELERY_LIVENESS_WEDGE_STALE_THRESHOLD_S` (the opt-in knob; `0` = off),
  2. `celery.worker.state.active_requests == 0` — nothing is actually running, so a *busy/saturated* worker on long tasks is never mistaken for a wedged one,
  3. there is queued work — broker `LLEN` over the worker's own queues **+** `reserved_requests` (already prefetched).
- Watched queues are derived from the worker's runtime `-Q` (`amqp.queues.consume_from`) — no separate list to keep in sync.
- **Fails open** on every "can't tell" (broker unreachable, unreadable counts, malformed env) → keep the worker alive.
- The stale file then trips the existing k8s liveness probe (mtime > 60s, x5) → pod restart.

**Scope:** off by default, so other fleets are unaffected. The cloud light deployment sets the env var separately (deploy repo) — lands after this image builds.

**What this does NOT do:** it's a self-healing safety net for the *symptom* (a wedged consumer). It does not fix the root cause of the wedge, and is unrelated to the prune-queue / monitoring-OOM issues tracked elsewhere.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check