### PR TITLE
feat(opal): add `titleMaxLines` to `Content` + refactor `@opal/layouts.inputs`'s error layout

### DIFF
--- a/web/lib/opal/src/components/cards/message-card/components.tsx
+++ b/web/lib/opal/src/components/cards/message-card/components.tsx
@@ -35,8 +35,8 @@ interface MessageCardBaseProps {
   /** Optional description below the title. */
   description?: string | RichStr;
 
-  /** Let the title wrap to multiple lines instead of truncating to one. */
-  titleWrap?: boolean;
+  /** Clamp the title to N lines with ellipsis. Default: `1`. Pass `undefined` to wrap freely. */
+  titleMaxLines?: number;
 
   /** Padding preset. @default "sm" */
   padding?: Extract<PaddingVariants, "sm" | "xs">;
@@ -127,7 +127,7 @@ function MessageCard({
   icon: iconOverride,
   title,
   description,
-  titleWrap,
+  titleMaxLines,
   padding = "sm",
   headerPadding = "fit",
   bottomChildren,
@@ -164,7 +164,7 @@ function MessageCard({
           )}
           title={title}
           description={description}
-          titleWrap={titleWrap}
+          titleMaxLines={titleMaxLines}
           sizePreset="main-ui"
           variant="section"
           padding="md"

--- a/web/lib/opal/src/layouts/content/ContentLg.tsx
+++ b/web/lib/opal/src/layouts/content/ContentLg.tsx
@@ -87,7 +87,7 @@ function ContentLg({
   icon: Icon,
   title,
   description,
-  titleMaxLines = 1,
+  titleMaxLines,
   descriptionMaxLines,
   editable,
   onTitleChange,

--- a/web/lib/opal/src/layouts/content/ContentLg.tsx
+++ b/web/lib/opal/src/layouts/content/ContentLg.tsx
@@ -38,6 +38,9 @@ interface ContentLgProps {
   /** Optional description below the title. */
   description?: string | RichStr;
 
+  /** Clamp the title to N lines with ellipsis. Default: `1`. Pass `undefined` to wrap freely. */
+  titleMaxLines?: number;
+
   /** Clamp the description to N lines. Maps to Text's maxLines prop. */
   descriptionMaxLines?: number;
 
@@ -84,6 +87,7 @@ function ContentLg({
   icon: Icon,
   title,
   description,
+  titleMaxLines = 1,
   descriptionMaxLines,
   editable,
   onTitleChange,
@@ -157,7 +161,7 @@ function ContentLg({
             <Text
               font={config.titleFont}
               color="inherit"
-              maxLines={1}
+              maxLines={titleMaxLines}
               title={toPlainString(title)}
               onClick={editable ? startEditing : undefined}
             >

--- a/web/lib/opal/src/layouts/content/ContentLg.tsx
+++ b/web/lib/opal/src/layouts/content/ContentLg.tsx
@@ -38,7 +38,7 @@ interface ContentLgProps {
   /** Optional description below the title. */
   description?: string | RichStr;
 
-  /** Clamp the title to N lines with ellipsis. Default: `1`. Pass `undefined` to wrap freely. */
+  /** Clamp the title to N lines with ellipsis. Omit to wrap freely. */
   titleMaxLines?: number;
 
   /** Clamp the description to N lines. Maps to Text's maxLines prop. */

--- a/web/lib/opal/src/layouts/content/ContentMd.tsx
+++ b/web/lib/opal/src/layouts/content/ContentMd.tsx
@@ -70,7 +70,7 @@ interface ContentMdProps {
   /** Tag rendered beside the title. */
   tag?: TagProps;
 
-  /** Clamp the title to N lines with ellipsis. Default: `1`. Pass `undefined` to wrap freely. */
+  /** Clamp the title to N lines with ellipsis. Omit to wrap freely. */
   titleMaxLines?: number;
 
   /** Size preset. Default: `"main-ui"`. */

--- a/web/lib/opal/src/layouts/content/ContentMd.tsx
+++ b/web/lib/opal/src/layouts/content/ContentMd.tsx
@@ -70,8 +70,8 @@ interface ContentMdProps {
   /** Tag rendered beside the title. */
   tag?: TagProps;
 
-  /** Let the title wrap to multiple lines instead of truncating to one. */
-  titleWrap?: boolean;
+  /** Clamp the title to N lines with ellipsis. Default: `1`. Pass `undefined` to wrap freely. */
+  titleMaxLines?: number;
 
   /** Size preset. Default: `"main-ui"`. */
   sizePreset?: ContentMdSizePreset;
@@ -141,7 +141,7 @@ function ContentMd({
   suffix,
   auxIcon,
   tag,
-  titleWrap,
+  titleMaxLines = 1,
   sizePreset = "main-ui",
   ref,
 }: ContentMdProps) {
@@ -218,7 +218,7 @@ function ContentMd({
             <Text
               font={config.titleFont}
               color="inherit"
-              maxLines={titleWrap ? undefined : 1}
+              maxLines={titleMaxLines}
               title={toPlainString(title)}
               onClick={editable ? startEditing : undefined}
             >

--- a/web/lib/opal/src/layouts/content/ContentMd.tsx
+++ b/web/lib/opal/src/layouts/content/ContentMd.tsx
@@ -141,7 +141,7 @@ function ContentMd({
   suffix,
   auxIcon,
   tag,
-  titleMaxLines = 1,
+  titleMaxLines,
   sizePreset = "main-ui",
   ref,
 }: ContentMdProps) {

--- a/web/lib/opal/src/layouts/content/ContentSm.tsx
+++ b/web/lib/opal/src/layouts/content/ContentSm.tsx
@@ -76,7 +76,7 @@ function ContentSm({
   title,
   sizePreset = "main-ui",
   orientation = "inline",
-  titleMaxLines = 1,
+  titleMaxLines,
   role,
   ref,
 }: ContentSmProps) {

--- a/web/lib/opal/src/layouts/content/ContentSm.tsx
+++ b/web/lib/opal/src/layouts/content/ContentSm.tsx
@@ -35,7 +35,7 @@ interface ContentSmProps {
   /** Layout orientation. Default: `"inline"`. */
   orientation?: ContentSmOrientation;
 
-  /** Clamp the title to N lines with ellipsis. Default: `1`. Pass `undefined` to wrap freely. */
+  /** Clamp the title to N lines with ellipsis. Omit to wrap freely. */
   titleMaxLines?: number;
 
   /** ARIA role forwarded to the title text element. */

--- a/web/lib/opal/src/layouts/content/ContentSm.tsx
+++ b/web/lib/opal/src/layouts/content/ContentSm.tsx
@@ -35,6 +35,12 @@ interface ContentSmProps {
   /** Layout orientation. Default: `"inline"`. */
   orientation?: ContentSmOrientation;
 
+  /** Clamp the title to N lines with ellipsis. Default: `1`. Pass `undefined` to wrap freely. */
+  titleMaxLines?: number;
+
+  /** ARIA role forwarded to the title text element. */
+  role?: string;
+
   /** Ref forwarded to the root `<div>`. */
   ref?: React.Ref<HTMLDivElement>;
 }
@@ -70,6 +76,8 @@ function ContentSm({
   title,
   sizePreset = "main-ui",
   orientation = "inline",
+  titleMaxLines = 1,
+  role,
   ref,
 }: ContentSmProps) {
   const config = CONTENT_SM_PRESETS[sizePreset];
@@ -96,8 +104,9 @@ function ContentSm({
       <Text
         font={config.titleFont}
         color="inherit"
-        maxLines={1}
+        maxLines={titleMaxLines}
         title={toPlainString(title)}
+        role={role}
       >
         {title}
       </Text>

--- a/web/lib/opal/src/layouts/content/ContentXl.tsx
+++ b/web/lib/opal/src/layouts/content/ContentXl.tsx
@@ -44,6 +44,9 @@ interface ContentXlProps {
   /** Optional description below the title. */
   description?: string | RichStr;
 
+  /** Clamp the title to N lines with ellipsis. Default: `1`. Pass `undefined` to wrap freely. */
+  titleMaxLines?: number;
+
   /** Clamp the description to N lines. Maps to Text's maxLines prop. */
   descriptionMaxLines?: number;
 
@@ -102,6 +105,7 @@ function ContentXl({
   icon: Icon,
   title,
   description,
+  titleMaxLines = 1,
   descriptionMaxLines,
   editable,
   onTitleChange,
@@ -207,7 +211,7 @@ function ContentXl({
           <Text
             font={config.titleFont}
             color="inherit"
-            maxLines={1}
+            maxLines={titleMaxLines}
             title={toPlainString(title)}
             onClick={editable ? startEditing : undefined}
           >

--- a/web/lib/opal/src/layouts/content/ContentXl.tsx
+++ b/web/lib/opal/src/layouts/content/ContentXl.tsx
@@ -105,7 +105,7 @@ function ContentXl({
   icon: Icon,
   title,
   description,
-  titleMaxLines = 1,
+  titleMaxLines,
   descriptionMaxLines,
   editable,
   onTitleChange,

--- a/web/lib/opal/src/layouts/content/ContentXl.tsx
+++ b/web/lib/opal/src/layouts/content/ContentXl.tsx
@@ -44,7 +44,7 @@ interface ContentXlProps {
   /** Optional description below the title. */
   description?: string | RichStr;
 
-  /** Clamp the title to N lines with ellipsis. Default: `1`. Pass `undefined` to wrap freely. */
+  /** Clamp the title to N lines with ellipsis. Omit to wrap freely. */
   titleMaxLines?: number;
 
   /** Clamp the description to N lines. Maps to Text's maxLines prop. */

--- a/web/lib/opal/src/layouts/content/components.tsx
+++ b/web/lib/opal/src/layouts/content/components.tsx
@@ -45,6 +45,9 @@ interface ContentBaseProps {
   /** Optional description below the title. */
   description?: string | RichStr;
 
+  /** Clamp the title to N lines with ellipsis. Default: `1`. Pass `undefined` to wrap freely. */
+  titleMaxLines?: number;
+
   /** Clamp the description to N lines. Maps to Text's maxLines prop. */
   descriptionMaxLines?: number;
 
@@ -113,8 +116,6 @@ type MdContentProps = ContentBaseProps & {
   auxIcon?: "info-gray" | "info-blue" | "warning" | "error";
   /** Tag rendered beside the title. */
   tag?: TagProps;
-  /** Let the title wrap to multiple lines instead of truncating to one. */
-  titleWrap?: boolean;
 };
 
 /** ContentSm does not support descriptions or inline editing. */
@@ -126,6 +127,8 @@ type SmContentProps = Omit<
   variant: "body";
   /** Layout orientation. Default: `"inline"`. */
   orientation?: ContentSmOrientation;
+  /** ARIA role forwarded to the title text element. */
+  role?: string;
 };
 
 type ContentProps =

--- a/web/lib/opal/src/layouts/content/components.tsx
+++ b/web/lib/opal/src/layouts/content/components.tsx
@@ -45,7 +45,7 @@ interface ContentBaseProps {
   /** Optional description below the title. */
   description?: string | RichStr;
 
-  /** Clamp the title to N lines with ellipsis. Default: `1`. Pass `undefined` to wrap freely. */
+  /** Clamp the title to N lines with ellipsis. Omit to wrap freely. */
   titleMaxLines?: number;
 
   /** Clamp the description to N lines. Maps to Text's maxLines prop. */

--- a/web/lib/opal/src/layouts/content/styles.css
+++ b/web/lib/opal/src/layouts/content/styles.css
@@ -47,6 +47,12 @@
   color: var(--content-foreground);
 }
 
+[data-content-color="warning"] {
+  --content-foreground: var(--status-warning-05);
+  --content-foreground-icon: var(--status-warning-05);
+  color: var(--content-foreground);
+}
+
 [data-content-color="interactive"] {
   color: inherit;
   --content-foreground-icon: var(--interactive-foreground-icon);

--- a/web/lib/opal/src/layouts/inputs/components.tsx
+++ b/web/lib/opal/src/layouts/inputs/components.tsx
@@ -234,7 +234,6 @@ function InputErrorText({
         title={children}
         color={color}
         role="alert"
-        titleMaxLines={undefined}
       />
     </div>
   );

--- a/web/lib/opal/src/layouts/inputs/components.tsx
+++ b/web/lib/opal/src/layouts/inputs/components.tsx
@@ -70,7 +70,7 @@ interface InputLayoutProps {
 // Vertical
 // ---------------------------------------------------------------------------
 
-export interface VerticalProps extends InputLayoutProps {
+interface VerticalProps extends InputLayoutProps {
   subDescription?: string | RichStr;
 }
 
@@ -120,7 +120,7 @@ function Vertical({
 // Horizontal
 // ---------------------------------------------------------------------------
 
-export interface HorizontalProps extends InputLayoutProps {
+interface HorizontalProps extends InputLayoutProps {
   /** Align input to the center (middle) of the label/description. */
   center?: boolean;
   /** Optional icon rendered beside the title. */
@@ -199,7 +199,7 @@ function FormikInputErrorInner({ name }: FormikInputErrorProps) {
   const hasWarning = warning;
 
   if (hasError)
-    return <InputErrorText type="error">{meta.error}</InputErrorText>;
+    return <InputErrorText type="error">{meta.error!}</InputErrorText>;
   else if (hasWarning)
     return <InputErrorText type="warning">{warning}</InputErrorText>;
   else return null;
@@ -209,10 +209,10 @@ function FormikInputErrorInner({ name }: FormikInputErrorProps) {
 // InputErrorText
 // ---------------------------------------------------------------------------
 
-export type InputErrorType = "error" | "warning";
+type InputErrorType = "error" | "warning";
 
 interface InputErrorTextProps {
-  children?: string | RichStr;
+  children: string | RichStr;
   type?: InputErrorType;
   ref?: React.Ref<HTMLDivElement>;
 }
@@ -231,7 +231,7 @@ function InputErrorText({
         sizePreset="secondary"
         variant="body"
         icon={Icon}
-        title={children ?? ""}
+        title={children}
         color={color}
         role="alert"
         titleMaxLines={undefined}
@@ -267,12 +267,15 @@ function InputPadder({ ref, ...props }: InputPadderProps) {
 export {
   Label,
   type LabelProps,
+  type VerticalProps,
   Vertical,
+  type HorizontalProps,
   Horizontal,
   FormikInputError,
   type FormikInputErrorProps,
-  InputErrorText,
+  type InputErrorType,
   type InputErrorTextProps,
+  InputErrorText,
   InputDivider,
   InputPadder,
   type InputPadderProps,

--- a/web/lib/opal/src/layouts/inputs/components.tsx
+++ b/web/lib/opal/src/layouts/inputs/components.tsx
@@ -1,18 +1,17 @@
 "use client";
 
 import "@opal/layouts/inputs/styles.css";
+import { useContext } from "react";
+import { useField, FormikContext } from "formik";
 import type {
+  ColorTypes,
   IconFunctionComponent,
   RichStr,
   WithoutStyles,
 } from "@opal/types";
-import { Text, Divider } from "@opal/components";
-import type { TagProps } from "@opal/components";
+import { Text, Divider, type TagProps } from "@opal/components";
 import { SvgXOctagon, SvgAlertCircle } from "@opal/icons";
-import { useContext } from "react";
-import { useField, FormikContext } from "formik";
-import { Section } from "@opal/layouts/general/components";
-import { Content, ContentAction } from "@opal/layouts";
+import { Content, ContentAction, Section } from "@opal/layouts";
 
 // ---------------------------------------------------------------------------
 // Label
@@ -213,7 +212,7 @@ function FormikInputErrorInner({ name }: FormikInputErrorProps) {
 export type InputErrorType = "error" | "warning";
 
 interface InputErrorTextProps {
-  children?: React.ReactNode;
+  children?: string | RichStr;
   type?: InputErrorType;
   ref?: React.Ref<HTMLDivElement>;
 }
@@ -224,26 +223,19 @@ function InputErrorText({
   ref,
 }: InputErrorTextProps) {
   const Icon = type === "error" ? SvgXOctagon : SvgAlertCircle;
-  const colorClass =
-    type === "error" ? "text-status-error-05" : "text-status-warning-05";
-  const strokeClass =
-    type === "error" ? "stroke-status-error-05" : "stroke-status-warning-05";
+  const color: ColorTypes = type === "error" ? "danger" : "warning";
 
   return (
     <div ref={ref} className="px-1">
-      {/* TODO(@raunakab): update this with `Content` when it supports custom colours */}
-      <Section flexDirection="row" justifyContent="start" gap={0.25}>
-        <Icon size={12} className={strokeClass} />
-        <span className={colorClass} role="alert">
-          {typeof children === "string" ? (
-            <Text font="secondary-body" color="inherit">
-              {children}
-            </Text>
-          ) : (
-            children
-          )}
-        </span>
-      </Section>
+      <Content
+        sizePreset="secondary"
+        variant="body"
+        icon={Icon}
+        title={children ?? ""}
+        color={color}
+        role="alert"
+        titleMaxLines={undefined}
+      />
     </div>
   );
 }

--- a/web/lib/opal/src/types.ts
+++ b/web/lib/opal/src/types.ts
@@ -135,7 +135,12 @@ export type BackgroundVariants = "none" | "light" | "heavy";
  * - `"danger"` — destructive / error state
  * - `"interactive"` — follows the interactive coloring system (`currentColor` / `--interactive-foreground`)
  */
-export type ColorTypes = "default" | "muted" | "danger" | "interactive";
+export type ColorTypes =
+  | "default"
+  | "muted"
+  | "danger"
+  | "warning"
+  | "interactive";
 
 // ---------------------------------------------------------------------------
 // Status Variants

--- a/web/src/app/admin/billing/BillingDetailsView.tsx
+++ b/web/src/app/admin/billing/BillingDetailsView.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
+import { markdown } from "@opal/utils";
 import { Section } from "@/layouts/general-layouts";
 import { Content, InputErrorText, InputVertical } from "@opal/layouts";
 import Card from "@/refresh-components/cards/Card";
@@ -484,16 +485,9 @@ function SeatsCard({
 
             {isBelowMinimum ? (
               <InputErrorText type="error">
-                You cannot set seats below current{" "}
-                <span className="font-semibold">{minRequiredSeats}</span> seats
-                in use/pending.{" "}
-                <Link
-                  href="/admin/users"
-                  className="underline hover:no-underline"
-                >
-                  Remove users
-                </Link>{" "}
-                first before adjusting seats.
+                {markdown(
+                  `You cannot set seats below current **${minRequiredSeats}** seats in use/pending. [Remove users](/admin/users) first before adjusting seats.`
+                )}
               </InputErrorText>
             ) : seatDifference !== 0 ? (
               <Text secondaryBody text03>

--- a/web/src/app/admin/billing/BillingDetailsView.tsx
+++ b/web/src/app/admin/billing/BillingDetailsView.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import Link from "next/link";
 import { markdown } from "@opal/utils";
 import { Section } from "@/layouts/general-layouts";
 import { Content, InputErrorText, InputVertical } from "@opal/layouts";

--- a/web/src/providers/ToastProvider.tsx
+++ b/web/src/providers/ToastProvider.tsx
@@ -123,7 +123,7 @@ function ToastContainer() {
             <MessageCard
               variant={LEVEL_TO_VARIANT[t.level ?? "info"]}
               title={truncatedTitle}
-              titleWrap
+              titleMaxLines={undefined}
               description={buildDescription(t)}
               padding="xs"
               onClose={t.dismissible ? () => handleClose(t.id) : undefined}

--- a/web/src/providers/ToastProvider.tsx
+++ b/web/src/providers/ToastProvider.tsx
@@ -123,7 +123,6 @@ function ToastContainer() {
             <MessageCard
               variant={LEVEL_TO_VARIANT[t.level ?? "info"]}
               title={truncatedTitle}
-              titleMaxLines={undefined}
               description={buildDescription(t)}
               padding="xs"
               onClose={t.dismissible ? () => handleClose(t.id) : undefined}


### PR DESCRIPTION
## Description

Three related Opal improvements that unblock the auth layout work, plus a follow-up tightening of `InputErrorText` types.

**`titleMaxLines` on `Content`**
- Adds `titleMaxLines?: number` to `ContentBaseProps` (default `1`, preserving existing truncation behaviour)
- Threads through `ContentXl`, `ContentLg`, `ContentMd`, `ContentSm`
- Replaces the ad-hoc `titleWrap?: boolean` that existed on `ContentMd` and `MessageCard` with a uniform numeric prop

**`"warning"` `ColorType`**
- Adds `"warning"` to `ColorTypes` union in `types.ts`
- Adds `[data-content-color="warning"]` CSS rule mapping to `--status-warning-05`

**`InputErrorText` TODO resolved**
- Replaces the manual `Section + Icon + span + Text` layout with `Content sizePreset="secondary" variant="body"`
- Uses `color="danger" | "warning"`, `role="alert"`, `titleMaxLines={undefined}` (free wrapping)
- Narrows `children` from optional `ReactNode` to required `string | RichStr`; removes the `?? ""` null-coalescing fallback on `title`
- Adds `meta.error!` non-null assertion inside the `hasError` guard (TypeScript can't narrow through it otherwise)
- Also adds `role?: string` to `ContentSm` so ARIA roles can be forwarded to the title text element
- Migrates `BillingDetailsView` JSX children → `markdown()` RichStr
- Migrates `ToastProvider` `titleWrap` → `titleMaxLines={undefined}`

**Export/type cleanup in `inputs/components.tsx`**
- `VerticalProps`, `HorizontalProps`, and `InputErrorType` are no longer `export`-prefixed on their declarations; they are collected into a single explicit export block at the bottom of the file, consistent with the rest of Opal

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds line clamping to titles across `Content` and `MessageCard` with a new `titleMaxLines` prop, defaulting to free wrapping. Adds a `warning` color and refactors input error UI to use `Content` for better accessibility and consistency, and removes a dead import.

- **New Features**
  - `titleMaxLines?: number` on `ContentXl`, `ContentLg`, `ContentMd`, `ContentSm`, and `MessageCard` (default free-wrap; pass a number to clamp).
  - Added `warning` to `ColorTypes` with `[data-content-color="warning"]` styles.
  - `ContentSm` now accepts `role` to forward ARIA roles to the title text.

- **Migration**
  - Replace `titleWrap` with `titleMaxLines` where used.
  - `InputErrorText` now renders via `Content` with `color="danger" | "warning"`, `role="alert"`, and free title wrapping; its `children` is now required and typed as `string | RichStr`.
  - Updated call sites: billing error copy uses `markdown()`, and `ToastProvider` relies on the default free-wrap behavior (no prop needed).

<sup>Written for commit a5a2774109da0219bd029a5b2131baab3fe18fd0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

