### PR TITLE
fix(opensearch): skip metadata update for unknown/zero chunk count (#12137) to release v4.1

### DIFF
--- a/backend/onyx/document_index/opensearch/opensearch_document_index.py
+++ b/backend/onyx/document_index/opensearch/opensearch_document_index.py
@@ -79,14 +79,6 @@ VERIFY_INDEX_LOCK_BLOCKING_TIMEOUT_S = 60
 _verified_index_names_for_current_process: set[str] = set()
 
 
-class ChunkCountNotFoundError(ValueError):
-    """Raised when a document has no chunk count."""
-
-
-class ChunkCountZeroError(ValueError):
-    """Raised when a document has a chunk count of 0."""
-
-
 def generate_opensearch_filtered_access_control_list(
     access: DocumentAccess,
 ) -> list[str]:
@@ -549,8 +541,9 @@ class OpenSearchDocumentIndex(DocumentIndex):
         This may be due to a concurrent ongoing indexing operation. In that
         event callers are expected to retry after a bit once the state of the
         document index is updated.
-        NOTE: Requires document chunk count be known; will raise if it is not.
-        This may be caused by the same situation outlined above.
+        NOTE: Documents whose chunk count is unknown (not yet indexed) or 0
+        (e.g. concurrently deleted) are skipped with a warning rather than
+        raising. The indexing pipeline will write the latest metadata shortly.
         NOTE: Will no-op if an update request has no fields to update.
 
         TODO(andrei): Consider exploring a batch API for OpenSearch for this
@@ -615,26 +608,30 @@ class OpenSearchDocumentIndex(DocumentIndex):
             for doc_id in update_request.document_ids:
                 doc_chunk_count = update_request.doc_id_to_chunk_cnt.get(doc_id, -1)
                 if doc_chunk_count < 0:
-                    # This means the chunk count is not known. This is due to a
-                    # race condition between doc indexing and updating steps
-                    # which run concurrently when a doc is indexed. The indexing
-                    # step should update chunk count shortly. This could also
-                    # have been due to an older version of the indexing pipeline
-                    # which did not compute chunk count, but that codepath has
-                    # since been deprecated and should no longer be the case
-                    # here.
+                    # The chunk count is not known. This is a benign race between
+                    # doc indexing and this update step, which run concurrently
+                    # when a doc is indexed. The indexing step will set the chunk
+                    # count (and write the latest metadata/permissions) shortly,
+                    # so skip this doc rather than failing the whole update.
                     # TODO(andrei): Fix the aforementioned race condition.
-                    raise ChunkCountNotFoundError(
-                        f"Tried to update document {doc_id} but its chunk count is not known. "
-                        "Older versions of the application used to permit this but is not a "
-                        "supported state for a document when using OpenSearch. The document was "
-                        "likely just added to the indexing pipeline and the chunk count will be "
-                        "updated shortly."
+                    logger.warning(
+                        "[OpenSearchDocumentIndex] Skipping update for document %s: "
+                        "its chunk count is not yet known. The document was likely just "
+                        "added to the indexing pipeline and the chunk count will be "
+                        "updated shortly.",
+                        doc_id,
                     )
+                    continue
                 if doc_chunk_count == 0:
-                    raise ChunkCountZeroError(
-                        f"Tried to update document {doc_id} but its chunk count was 0."
+                    # A chunk count of 0 typically reflects a concurrent delete +
+                    # metadata sync. There are no chunks to update, so skip this
+                    # doc rather than failing the whole update.
+                    logger.warning(
+                        "[OpenSearchDocumentIndex] Skipping update for document %s: "
+                        "its chunk count is 0.",
+                        doc_id,
                     )
+                    continue
 
                 for chunk_index in range(doc_chunk_count):
                     document_chunk_id = get_opensearch_doc_chunk_id(

--- a/backend/tests/external_dependency_unit/document_index/test_document_index.py
+++ b/backend/tests/external_dependency_unit/document_index/test_document_index.py
@@ -489,3 +489,109 @@ class TestDocumentIndexNew:
             assert len(retrieved) == 2
             for chunk in retrieved:
                 assert chunk.boost == 0
+
+    def test_update_skips_doc_with_unknown_chunk_count(
+        self,
+        document_indices: list[DocumentIndexNew],
+        tenant_context: None,  # noqa: ARG002
+    ) -> None:
+        """
+        Tests that a doc whose chunk count is unknown (the perm-synced-but-not-
+        yet-indexed race) is skipped with a warning instead of raising, and that
+        other docs in the same request are still updated.
+        """
+        # Precondition - index one real doc; pair it with a phantom doc whose
+        # chunk count is unknown (absent from doc_id_to_chunk_cnt -> -1).
+        for document_index in document_indices:
+            real_doc = f"test_update_unknown_real_{uuid.uuid4().hex[:8]}"
+            phantom_doc = f"test_update_unknown_phantom_{uuid.uuid4().hex[:8]}"
+            chunks = [
+                make_chunk(real_doc, chunk_id=0),
+                make_chunk(real_doc, chunk_id=1),
+            ]
+            metadata = make_indexing_metadata(
+                [real_doc], old_counts=[0], new_counts=[2]
+            )
+            document_index.index(chunks=chunks, indexing_metadata=metadata)
+
+            # Allow OpenSearch refresh interval to settle.
+            time.sleep(1)
+
+            # Under test - phantom_doc has no entry in doc_id_to_chunk_cnt, so
+            # its chunk count resolves to -1 (unknown). This must not raise.
+            update_request = MetadataUpdateRequest(
+                document_ids=[real_doc, phantom_doc],
+                doc_id_to_chunk_cnt={real_doc: 2},
+                boost=5,
+            )
+            document_index.update([update_request])
+
+            # Postcondition - the real doc is still updated despite the phantom
+            # doc being skipped.
+            filters = IndexFilters(
+                access_control_list=[PUBLIC_DOC_PAT],
+                tenant_id=TEST_TENANT_ID,
+            )
+            retrieved = _retrieve_chunks_with_expected_boost(
+                document_index=document_index,
+                document_id=real_doc,
+                expected_chunk_count=2,
+                expected_boost=5,
+                filters=filters,
+            )
+            assert len(retrieved) == 2
+            for chunk in retrieved:
+                assert chunk.boost == 5
+
+    def test_update_skips_doc_with_zero_chunk_count(
+        self,
+        document_indices: list[DocumentIndexNew],
+        tenant_context: None,  # noqa: ARG002
+    ) -> None:
+        """
+        Tests that a doc with a chunk count of 0 (e.g. concurrent delete +
+        metadata sync) is skipped with a warning instead of raising, and that
+        other docs in the same request are still updated.
+        """
+        # Precondition - index one real doc; pair it with a phantom doc whose
+        # chunk count is explicitly 0.
+        for document_index in document_indices:
+            real_doc = f"test_update_zero_real_{uuid.uuid4().hex[:8]}"
+            phantom_doc = f"test_update_zero_phantom_{uuid.uuid4().hex[:8]}"
+            chunks = [
+                make_chunk(real_doc, chunk_id=0),
+                make_chunk(real_doc, chunk_id=1),
+            ]
+            metadata = make_indexing_metadata(
+                [real_doc], old_counts=[0], new_counts=[2]
+            )
+            document_index.index(chunks=chunks, indexing_metadata=metadata)
+
+            # Allow OpenSearch refresh interval to settle.
+            time.sleep(1)
+
+            # Under test - phantom_doc has a chunk count of 0. This must not
+            # raise.
+            update_request = MetadataUpdateRequest(
+                document_ids=[real_doc, phantom_doc],
+                doc_id_to_chunk_cnt={real_doc: 2, phantom_doc: 0},
+                boost=6,
+            )
+            document_index.update([update_request])
+
+            # Postcondition - the real doc is still updated despite the phantom
+            # doc being skipped.
+            filters = IndexFilters(
+                access_control_list=[PUBLIC_DOC_PAT],
+                tenant_id=TEST_TENANT_ID,
+            )
+            retrieved = _retrieve_chunks_with_expected_boost(
+                document_index=document_index,
+                document_id=real_doc,
+                expected_chunk_count=2,
+                expected_boost=6,
+                filters=filters,
+            )
+            assert len(retrieved) == 2
+            for chunk in retrieved:
+                assert chunk.boost == 6


### PR DESCRIPTION
Cherry-pick of commit df3be37308144f4e16265043c228fd4ee64c1e65 to release/v4.1 branch.

Original PR: #12137

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent OpenSearch metadata updates from failing when a document’s chunk count is unknown or zero by skipping those docs and logging a warning. This avoids race-condition errors during indexing and ensures other documents in the request are still updated.

- **Bug Fixes**
  - Skip updates for docs with unknown (-1) or zero chunk count; log a warning instead of raising.
  - Remove `ChunkCountNotFoundError` and `ChunkCountZeroError`; continue processing remaining docs.
  - Add unit tests covering both cases to confirm other docs in the same request still update.

<sup>Written for commit 86602be7834f9d7a653d7a8727c443349acf356c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

