### PR TITLE
feat(tracing): Show available tools in llm trace

### DIFF
--- a/backend/onyx/chat/llm_step.py
+++ b/backend/onyx/chat/llm_step.py
@@ -1156,6 +1156,9 @@ def run_llm_step_pkt_generator(
         span_generation.span_data.input = cast(
             Sequence[Mapping[str, Any]], llm_msg_history
         )
+        span_generation.span_data.tools = cast(
+            Sequence[Mapping[str, Any]], tool_definitions
+        )
         stream_start_time = time.monotonic()
         first_action_recorded = False
 

--- a/backend/onyx/llm/tracing_wrap.py
+++ b/backend/onyx/llm/tracing_wrap.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
 
 _ALREADY_WRAPPED_ATTR = "_onyx_tracing_wrapped"
 _PROMPT_PARAM_NAME = "prompt"
+_TOOLS_PARAM_NAME = "tools"
 
 
 def _outer_generation_span_active() -> bool:
@@ -101,25 +102,28 @@ def _validate_prompt_param(fn: Callable[..., Any]) -> inspect.Signature:
     return sig
 
 
-def _extract_prompt(
+def _extract_prompt_and_tools(
     sig: inspect.Signature,
     self_: "LLM",
     args: tuple[Any, ...],
     kwargs: dict[str, Any],
-) -> Any | None:
-    """Bind ``args`` / ``kwargs`` against ``sig`` and return the ``prompt`` value.
+) -> tuple[Any | None, Any | None]:
+    """Bind ``args`` / ``kwargs`` against ``sig`` and return ``(prompt, tools)``.
 
     Uses ``Signature.bind`` so extraction is robust to any mix of positional
     / keyword argument passing and immune to future parameter reordering.
-    Returns ``None`` if the arguments don't match the signature — the
-    fallback span will simply omit input messages rather than fail the
+    Returns ``(None, None)`` if the arguments don't match the signature — the
+    fallback span will simply omit input messages / tools rather than fail the
     request.
     """
     try:
         bound = sig.bind(self_, *args, **kwargs)
     except TypeError:
-        return None
-    return bound.arguments.get(_PROMPT_PARAM_NAME)
+        return None, None
+    return (
+        bound.arguments.get(_PROMPT_PARAM_NAME),
+        bound.arguments.get(_TOOLS_PARAM_NAME),
+    )
 
 
 def wrap_invoke(
@@ -140,9 +144,9 @@ def wrap_invoke(
         from onyx.tracing.llm_utils import llm_generation_span
         from onyx.tracing.llm_utils import record_llm_response
 
-        prompt = _extract_prompt(sig, self, args, kwargs)
+        prompt, tools = _extract_prompt_and_tools(sig, self, args, kwargs)
         with llm_generation_span(
-            self, flow=LLMFlow.UNTAGGED_INVOKE, input_messages=prompt
+            self, flow=LLMFlow.UNTAGGED_INVOKE, input_messages=prompt, tools=tools
         ) as span:
             try:
                 response = invoke_fn(self, *args, **kwargs)
@@ -197,9 +201,9 @@ def wrap_stream(
         from onyx.tracing.llm_utils import llm_generation_span
         from onyx.tracing.llm_utils import record_llm_span_output
 
-        prompt = _extract_prompt(sig, self, args, kwargs)
+        prompt, tools = _extract_prompt_and_tools(sig, self, args, kwargs)
         with llm_generation_span(
-            self, flow=LLMFlow.UNTAGGED_STREAM, input_messages=prompt
+            self, flow=LLMFlow.UNTAGGED_STREAM, input_messages=prompt, tools=tools
         ) as span:
             accumulated_content: list[str] = []
             final_usage: Usage | None = None

--- a/backend/onyx/tracing/braintrust_tracing_processor.py
+++ b/backend/onyx/tracing/braintrust_tracing_processor.py
@@ -182,6 +182,11 @@ class BraintrustTracingProcessor(TracingProcessor):
         if span.span_data.reasoning:
             metadata["reasoning"] = span.span_data.reasoning
 
+        # Include the full tool catalog (name, description, parameters) offered
+        # to the model on this call, if any.
+        if span.span_data.tools:
+            metadata["tools"] = span.span_data.tools
+
         return {
             "input": span.span_data.input,
             "output": span.span_data.output,

--- a/backend/onyx/tracing/framework/create.py
+++ b/backend/onyx/tracing/framework/create.py
@@ -182,6 +182,7 @@ def generation_span(
     model_config: Mapping[str, Any] | None = None,
     usage: dict[str, Any] | None = None,
     time_to_first_action_seconds: float | None = None,
+    tools: Sequence[Mapping[str, Any]] | None = None,
     span_id: str | None = None,
     parent: Trace | Span[Any] | None = None,
     disabled: bool = False,
@@ -202,6 +203,7 @@ def generation_span(
         model_config: The model configuration (hyperparameters) used.
         usage: A dictionary of usage information (input tokens, output tokens, etc.).
         time_to_first_action_seconds: Time elapsed before the first model action is observed.
+        tools: The full tool schemas (name, description, parameters) offered to the model on this call.
         span_id: The ID of the span. Optional. If not provided, we will generate an ID. We
             recommend using `util.gen_span_id()` to generate a span ID, to guarantee that IDs are
             correctly formatted.
@@ -221,6 +223,7 @@ def generation_span(
             model_config=model_config,
             usage=usage,
             time_to_first_action_seconds=time_to_first_action_seconds,
+            tools=tools,
         ),
         span_id=span_id,
         parent=parent,

--- a/backend/onyx/tracing/framework/span_data.py
+++ b/backend/onyx/tracing/framework/span_data.py
@@ -101,6 +101,7 @@ class GenerationSpanData(SpanData):
         "model_config",
         "usage",
         "time_to_first_action_seconds",
+        "tools",
     )
 
     def __init__(
@@ -112,6 +113,7 @@ class GenerationSpanData(SpanData):
         model_config: Mapping[str, Any] | None = None,
         usage: dict[str, Any] | None = None,
         time_to_first_action_seconds: float | None = None,
+        tools: Sequence[Mapping[str, Any]] | None = None,
     ):
         self.input = input
         self.output = output
@@ -120,6 +122,7 @@ class GenerationSpanData(SpanData):
         self.model_config = model_config
         self.usage = usage
         self.time_to_first_action_seconds = time_to_first_action_seconds
+        self.tools = tools
 
     @property
     def type(self) -> str:
@@ -135,4 +138,5 @@ class GenerationSpanData(SpanData):
             "model_config": self.model_config,
             "usage": self.usage,
             "time_to_first_action_seconds": self.time_to_first_action_seconds,
+            "tools": self.tools,
         }

--- a/backend/onyx/tracing/langfuse_tracing_processor.py
+++ b/backend/onyx/tracing/langfuse_tracing_processor.py
@@ -291,8 +291,13 @@ class LangfuseTracingProcessor(TracingProcessor):
                     update_kwargs["usage_details"] = usage
                 if cost is not None:
                     update_kwargs["cost_details"] = {"total": cost}
+                generation_metadata: dict[str, Any] = {}
                 if data.reasoning:
-                    update_kwargs["metadata"] = {"reasoning": data.reasoning}
+                    generation_metadata["reasoning"] = data.reasoning
+                if data.tools:
+                    generation_metadata["tools"] = data.tools
+                if generation_metadata:
+                    update_kwargs["metadata"] = generation_metadata
                 if data.time_to_first_action_seconds is not None:
                     update_kwargs["completion_start_time"] = _timestamp_from_maybe_iso(
                         span.started_at

--- a/backend/onyx/tracing/llm_utils.py
+++ b/backend/onyx/tracing/llm_utils.py
@@ -31,11 +31,13 @@ def llm_generation_span(
     llm: LLM,
     flow: LLMFlow | None,
     input_messages: Sequence[Any] | Any | None = None,
+    tools: Sequence[Mapping[str, Any]] | None = None,
     parent: Any | None = None,
 ) -> Iterator[Span[GenerationSpanData]]:
     with generation_span(
         model=llm.config.model_name,
         model_config=build_llm_model_config(llm, flow),
+        tools=tools,
         parent=parent,
     ) as span:
         if input_messages is not None:
@@ -58,6 +60,7 @@ def traced_llm_call(
     provider: str,
     extra_config: Mapping[str, str] | None = None,
     input_messages: Sequence[Any] | Any | None = None,
+    tools: Sequence[Mapping[str, Any]] | None = None,
     parent: Any | None = None,
 ) -> Iterator[Span[GenerationSpanData]]:
     """Open a generation span for call sites that don't go through ``LLM``.
@@ -76,6 +79,7 @@ def traced_llm_call(
     with generation_span(
         model=model,
         model_config=model_config,
+        tools=tools,
         parent=parent,
     ) as span:
         if input_messages is not None:

--- a/backend/tests/unit/onyx/llm/test_tracing_wrap.py
+++ b/backend/tests/unit/onyx/llm/test_tracing_wrap.py
@@ -9,7 +9,7 @@ Cover:
 - Stale-span guard: a finished ``GenerationSpanData`` in the contextvar does
   not suppress fallback tracing (regression guard for the ``GeneratorExit``
   corner case)
-- `_extract_prompt` helper reads positional and keyword arguments
+- `_extract_prompt_and_tools` helper reads positional and keyword arguments
 
 The `_FakeLLM` test double's `invoke` / `stream` signatures intentionally
 mirror the `LLM` abstract interface, which means many parameters are
@@ -44,7 +44,7 @@ from onyx.llm.models import ReasoningEffort
 from onyx.llm.models import ToolChoiceOptions
 from onyx.llm.models import UserMessage
 from onyx.llm.tracing_wrap import _ALREADY_WRAPPED_ATTR
-from onyx.llm.tracing_wrap import _extract_prompt
+from onyx.llm.tracing_wrap import _extract_prompt_and_tools
 from onyx.llm.tracing_wrap import _finalize_tool_calls
 from onyx.llm.tracing_wrap import _merge_tool_call_delta
 from onyx.llm.tracing_wrap import _outer_generation_span_active
@@ -211,21 +211,39 @@ def test_outer_guard_false_for_finished_span_leaked_into_contextvar() -> None:
 def test_extract_prompt_reads_positional_arg() -> None:
     llm = _FakeLLM()
     sig = _validate_prompt_param(getattr(_FakeLLM.invoke, "__wrapped__"))
-    assert _extract_prompt(sig, llm, ("hi",), {}) == "hi"
+    prompt, tools = _extract_prompt_and_tools(sig, llm, ("hi",), {})
+    assert prompt == "hi"
+    assert tools is None
 
 
 def test_extract_prompt_reads_keyword_arg() -> None:
     llm = _FakeLLM()
     sig = _validate_prompt_param(getattr(_FakeLLM.invoke, "__wrapped__"))
-    assert _extract_prompt(sig, llm, (), {"prompt": "hi"}) == "hi"
+    prompt, tools = _extract_prompt_and_tools(sig, llm, (), {"prompt": "hi"})
+    assert prompt == "hi"
+    assert tools is None
+
+
+def test_extract_tools_reads_keyword_arg() -> None:
+    llm = _FakeLLM()
+    sig = _validate_prompt_param(getattr(_FakeLLM.invoke, "__wrapped__"))
+    tool_defs = [{"type": "function", "function": {"name": "search"}}]
+    prompt, tools = _extract_prompt_and_tools(
+        sig, llm, (), {"prompt": "hi", "tools": tool_defs}
+    )
+    assert prompt == "hi"
+    assert tools == tool_defs
 
 
 def test_extract_prompt_returns_none_on_signature_mismatch() -> None:
     """Unknown keyword arguments don't match the signature → bind fails →
-    extraction returns None rather than raising."""
+    extraction returns (None, None) rather than raising."""
     llm = _FakeLLM()
     sig = _validate_prompt_param(getattr(_FakeLLM.invoke, "__wrapped__"))
-    assert _extract_prompt(sig, llm, (), {"not_a_real_param": "hi"}) is None
+    assert _extract_prompt_and_tools(sig, llm, (), {"not_a_real_param": "hi"}) == (
+        None,
+        None,
+    )
 
 
 def test_validate_prompt_param_rejects_signature_without_prompt() -> None:


### PR DESCRIPTION
## Description
Currently tracing does not include what tools are available to the agent.

This change attaches the tool description + other attributes for each tool available to the agent

<img width="585" height="642" alt="Screenshot 2026-06-22 at 1 22 38 PM" src="https://github.com/user-attachments/assets/22dc56af-555c-4653-851f-212936282583" />


## How Has This Been Tested?
Tests + Manual

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds available tool schemas to LLM generation traces so you can see what the agent could use on each call. Propagates this metadata to Braintrust and Langfuse.

- **New Features**
  - Capture tool catalogs (name, description, parameters) on generation spans.
  - Extract `tools` from LLM `invoke`/`stream` and forward via `llm_generation_span` and `traced_llm_call`.
  - Export `tools` in `GenerationSpanData`; processors add it to Braintrust and Langfuse metadata.
  - Unit tests cover prompt/tools extraction and tracing behavior.

<sup>Written for commit 19a843a6f61e00f9754fa28f554ce7335252d55c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

