### PR TITLE
fix(fe): disallow `Interactive.Container` from flex shrinking

### DIFF
--- a/web/lib/opal/src/core/interactive/shared.css
+++ b/web/lib/opal/src/core/interactive/shared.css
@@ -40,7 +40,7 @@
 
 /* Container — structural box */
 .interactive-container {
-  @apply flex items-center justify-center overflow-clip;
+  @apply flex shrink-0 items-center justify-center overflow-clip;
 }
 .interactive-container[data-border="true"] {
   @apply border;


### PR DESCRIPTION
## Description

Possibly scary change. Some buttons unexpectedly shrink on mobile which this tries to address.

**before**
<img width="1902" height="2085" alt="20260622_13h53m41s_grim" src="https://github.com/user-attachments/assets/35db100a-3eed-47f6-8cf7-08bda2bf5e3f" />

**after**
<img width="1902" height="2085" alt="20260622_13h53m31s_grim" src="https://github.com/user-attachments/assets/105608c4-7e68-41a2-82f5-917c3416cbb7" />


## How Has This Been Tested?

Captured by visual regression hopefully

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop `Interactive.Container` from flex-shrinking so buttons and controls don't compress on small screens. Adds `shrink-0` to the container to preserve intended size in flex layouts.

<sup>Written for commit a1e438b3f6840392018da8b9b4ae348470ed4d4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

