### PR TITLE
fix(voice): backend markdown stripping for TTS + optional REST STT toggle

### DIFF
--- a/backend/onyx/server/manage/voice/text_utils.py
+++ b/backend/onyx/server/manage/voice/text_utils.py
@@ -1,0 +1,32 @@
+import re
+
+# [label](url) -> label
+_MD_LINK = re.compile(r"\[([^\]]+)\]\([^)]+\)")
+# Leading header hashes at the start of a line. Line-anchored so inline text such
+# as "C#" or "#1" is left untouched.
+_MD_HEADER = re.compile(r"(?m)^[ \t]*#{1,6}[ \t]*")
+# Inline code / code-fence backticks.
+_MD_CODE = re.compile(r"`{1,3}")
+# Runs of whitespace (including newlines).
+_WS = re.compile(r"\s+")
+
+
+def strip_markdown_for_tts(text: str) -> str:
+    """Remove common markdown markers so TTS does not read them aloud.
+
+    Mirrors the frontend ``stripMarkdownForTTS`` and is applied server-side as a
+    version-independent safety net: the web bundle may lag the backend, and not
+    every TTS entry point strips on the client.
+
+    Removes bold/italic markers, inline-code and code-fence backticks, and leading
+    header hashes (line-anchored to avoid mangling text like ``C#`` or ``#1``),
+    and converts ``[label](url)`` to ``label``. Whitespace runs are collapsed so
+    the synthesized speech does not contain odd pauses.
+    """
+    text = text.replace("**", "").replace("__", "")
+    text = text.replace("*", "").replace("_", "")
+    text = _MD_CODE.sub("", text)
+    text = _MD_HEADER.sub("", text)
+    text = _MD_LINK.sub(r"\1", text)
+    text = _WS.sub(" ", text)
+    return text.strip()

--- a/backend/onyx/server/manage/voice/text_utils.py
+++ b/backend/onyx/server/manage/voice/text_utils.py
@@ -1,43 +1,31 @@
-import re
+from markdown_it import MarkdownIt
+from markdown_it.token import Token
 
-# [label](url) -> label. The url may contain one level of balanced parens
-# (e.g. Wikipedia "..._(programming_language)" links).
-_MD_LINK = re.compile(r"\[([^\]]+)\]\((?:[^()]|\([^()]*\))*\)")
-# Paired emphasis markers only, so literal "*" and intraword underscores
-# (snake_case) survive. Delimiters must hug non-whitespace (CommonMark flanking),
-# and underscore variants additionally require non-word boundaries.
-_MD_BOLD_STAR = re.compile(r"\*\*(?=\S)(.+?)(?<=\S)\*\*")
-_MD_ITALIC_STAR = re.compile(r"\*(?=\S)(.+?)(?<=\S)\*")
-_MD_BOLD_UNDERSCORE = re.compile(r"(?<!\w)__(?=\S)(.+?)(?<=\S)__(?!\w)")
-_MD_ITALIC_UNDERSCORE = re.compile(r"(?<!\w)_(?=\S)(.+?)(?<=\S)_(?!\w)")
-# Inline-code / code-fence backticks.
-_MD_CODE = re.compile(r"`{1,3}")
-# Leading header hashes at the start of a line. Line-anchored so inline text
-# such as "C#" or "#1" is left untouched.
-_MD_HEADER = re.compile(r"(?m)^[ \t]*#{1,6}[ \t]*")
-# Runs of whitespace (including newlines).
-_WS = re.compile(r"\s+")
+_md = MarkdownIt("commonmark")
+
+
+def _render(tokens: list[Token]) -> str:
+    out: list[str] = []
+    for tok in tokens:
+        if tok.type == "inline":
+            out.append(_render(tok.children or []))
+        elif tok.type in ("text", "code_inline"):
+            out.append(tok.content)
+        elif tok.type in ("softbreak", "hardbreak"):
+            out.append(" ")
+        elif tok.type.endswith("_close") and tok.block:
+            # Block boundary (paragraph, heading, list item, ...) -> a space.
+            out.append(" ")
+    return "".join(out)
 
 
 def strip_markdown_for_tts(text: str) -> str:
-    """Remove common markdown markers so TTS does not read them aloud.
+    """Reduce markdown to plain text so TTS does not read markup aloud.
 
-    Mirrors the frontend ``stripMarkdownForTTS`` and is applied server-side as a
-    version-independent safety net: the web bundle may lag the backend, and not
-    every TTS entry point strips on the client.
-
-    Only paired emphasis delimiters are removed, so literal ``*`` and intraword
-    underscores (``snake_case``) survive. Also drops code/code-fence backticks
-    and leading header hashes (line-anchored to spare ``C#``/``#1``), and converts
-    ``[label](url)`` to ``label``. Whitespace runs are collapsed so the
-    synthesized speech does not contain odd pauses.
+    Parses with markdown-it (CommonMark) and keeps only readable text: emphasis,
+    headers and links are unwrapped, code fences are dropped, and whitespace is
+    collapsed. Applied server-side as a version-independent safety net, since the
+    web bundle may lag the backend and not every TTS entry point strips on the
+    client.
     """
-    text = _MD_LINK.sub(r"\1", text)
-    text = _MD_BOLD_STAR.sub(r"\1", text)
-    text = _MD_ITALIC_STAR.sub(r"\1", text)
-    text = _MD_BOLD_UNDERSCORE.sub(r"\1", text)
-    text = _MD_ITALIC_UNDERSCORE.sub(r"\1", text)
-    text = _MD_CODE.sub("", text)
-    text = _MD_HEADER.sub("", text)
-    text = _WS.sub(" ", text)
-    return text.strip()
+    return " ".join(_render(_md.parse(text)).split())

--- a/backend/onyx/server/manage/voice/text_utils.py
+++ b/backend/onyx/server/manage/voice/text_utils.py
@@ -1,12 +1,20 @@
 import re
 
-# [label](url) -> label
-_MD_LINK = re.compile(r"\[([^\]]+)\]\([^)]+\)")
-# Leading header hashes at the start of a line. Line-anchored so inline text such
-# as "C#" or "#1" is left untouched.
-_MD_HEADER = re.compile(r"(?m)^[ \t]*#{1,6}[ \t]*")
-# Inline code / code-fence backticks.
+# [label](url) -> label. The url may contain one level of balanced parens
+# (e.g. Wikipedia "..._(programming_language)" links).
+_MD_LINK = re.compile(r"\[([^\]]+)\]\((?:[^()]|\([^()]*\))*\)")
+# Paired emphasis markers only, so literal "*" and intraword underscores
+# (snake_case) survive. Delimiters must hug non-whitespace (CommonMark flanking),
+# and underscore variants additionally require non-word boundaries.
+_MD_BOLD_STAR = re.compile(r"\*\*(?=\S)(.+?)(?<=\S)\*\*")
+_MD_ITALIC_STAR = re.compile(r"\*(?=\S)(.+?)(?<=\S)\*")
+_MD_BOLD_UNDERSCORE = re.compile(r"(?<!\w)__(?=\S)(.+?)(?<=\S)__(?!\w)")
+_MD_ITALIC_UNDERSCORE = re.compile(r"(?<!\w)_(?=\S)(.+?)(?<=\S)_(?!\w)")
+# Inline-code / code-fence backticks.
 _MD_CODE = re.compile(r"`{1,3}")
+# Leading header hashes at the start of a line. Line-anchored so inline text
+# such as "C#" or "#1" is left untouched.
+_MD_HEADER = re.compile(r"(?m)^[ \t]*#{1,6}[ \t]*")
 # Runs of whitespace (including newlines).
 _WS = re.compile(r"\s+")
 
@@ -18,15 +26,18 @@ def strip_markdown_for_tts(text: str) -> str:
     version-independent safety net: the web bundle may lag the backend, and not
     every TTS entry point strips on the client.
 
-    Removes bold/italic markers, inline-code and code-fence backticks, and leading
-    header hashes (line-anchored to avoid mangling text like ``C#`` or ``#1``),
-    and converts ``[label](url)`` to ``label``. Whitespace runs are collapsed so
-    the synthesized speech does not contain odd pauses.
+    Only paired emphasis delimiters are removed, so literal ``*`` and intraword
+    underscores (``snake_case``) survive. Also drops code/code-fence backticks
+    and leading header hashes (line-anchored to spare ``C#``/``#1``), and converts
+    ``[label](url)`` to ``label``. Whitespace runs are collapsed so the
+    synthesized speech does not contain odd pauses.
     """
-    text = text.replace("**", "").replace("__", "")
-    text = text.replace("*", "").replace("_", "")
+    text = _MD_LINK.sub(r"\1", text)
+    text = _MD_BOLD_STAR.sub(r"\1", text)
+    text = _MD_ITALIC_STAR.sub(r"\1", text)
+    text = _MD_BOLD_UNDERSCORE.sub(r"\1", text)
+    text = _MD_ITALIC_UNDERSCORE.sub(r"\1", text)
     text = _MD_CODE.sub("", text)
     text = _MD_HEADER.sub("", text)
-    text = _MD_LINK.sub(r"\1", text)
     text = _WS.sub(" ", text)
     return text.strip()

--- a/backend/onyx/server/manage/voice/user_api.py
+++ b/backend/onyx/server/manage/voice/user_api.py
@@ -24,6 +24,7 @@ from onyx.error_handling.exceptions import OnyxError
 from onyx.redis.redis_pool import store_ws_token
 from onyx.redis.redis_pool import WsTokenRateLimitExceeded
 from onyx.server.manage.models import VoiceSettingsUpdateRequest
+from onyx.server.manage.voice.text_utils import strip_markdown_for_tts
 from onyx.utils.logger import setup_logger
 from onyx.voice.factory import get_voice_provider
 
@@ -151,7 +152,7 @@ async def synthesize_speech(
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
 ) -> StreamingResponse:
     """Synthesize text to speech using the default TTS provider."""
-    text = body.text
+    text = strip_markdown_for_tts(body.text)
     voice = body.voice
     speed = body.speed
     logger.info(

--- a/backend/onyx/server/manage/voice/websocket_api.py
+++ b/backend/onyx/server/manage/voice/websocket_api.py
@@ -18,6 +18,7 @@ from onyx.db.engine.sql_engine import get_sqlalchemy_engine
 from onyx.db.models import User
 from onyx.db.voice import fetch_default_stt_provider
 from onyx.db.voice import fetch_default_tts_provider
+from onyx.server.manage.voice.text_utils import strip_markdown_for_tts
 from onyx.utils.logger import setup_logger
 from onyx.voice.factory import get_voice_provider
 from onyx.voice.interface import StreamingSynthesizerProtocol
@@ -33,6 +34,11 @@ router = APIRouter(prefix="/voice")
 MIN_CHUNK_BYTES = 1500
 VOICE_DISABLE_STREAMING_FALLBACK = (
     os.environ.get("VOICE_DISABLE_STREAMING_FALLBACK", "").lower() == "true"
+)
+# Force STT onto the chunked/REST path where a provider's native streaming SDK
+# transport is unavailable in the runtime (else it yields empty transcripts).
+VOICE_DISABLE_STREAMING_STT = (
+    os.environ.get("VOICE_DISABLE_STREAMING_STT", "").lower() == "true"
 )
 
 # WebSocket size limits to prevent memory exhaustion attacks
@@ -410,8 +416,8 @@ async def websocket_transcribe(
                 await websocket.send_json({"type": "error", "message": str(e)})
                 return
 
-        # Use native streaming if provider supports it
-        if provider.supports_streaming_stt():
+        # Use native streaming if provider supports it (unless forced off)
+        if provider.supports_streaming_stt() and not VOICE_DISABLE_STREAMING_STT:
             logger.info("WebSocket transcribe: using native streaming STT")
             try:
                 streaming_transcriber = await provider.create_streaming_transcriber()
@@ -573,7 +579,7 @@ async def handle_streaming_synthesis(
                                 "Streaming synthesis: forwarding text chunk (%s chars)",
                                 len(text),
                             )
-                            await synthesizer.send_text(text)
+                            await synthesizer.send_text(strip_markdown_for_tts(text))
 
                     elif data.get("type") == "end":
                         logger.info("Streaming synthesis: end signal received")
@@ -707,7 +713,7 @@ async def handle_chunked_synthesis(
                     speed = float(data["speed"])
             elif msg_data_type == "end":
                 logger.info("Chunked synthesis: end signal received")
-                full_text = " ".join(text_buffer).strip()
+                full_text = strip_markdown_for_tts(" ".join(text_buffer))
                 if not full_text:
                     await websocket.send_json({"type": "audio_done"})
                     logger.info("Chunked synthesis: no text, sent audio_done")

--- a/backend/onyx/server/manage/voice/websocket_api.py
+++ b/backend/onyx/server/manage/voice/websocket_api.py
@@ -416,46 +416,36 @@ async def websocket_transcribe(
                 await websocket.send_json({"type": "error", "message": str(e)})
                 return
 
-        # Use native streaming if provider supports it (unless forced off)
-        if provider.supports_streaming_stt() and not VOICE_DISABLE_STREAMING_STT:
-            logger.info("WebSocket transcribe: using native streaming STT")
+        # Prefer native streaming; use the chunked/REST path when the provider
+        # lacks it or it's disabled via VOICE_DISABLE_STREAMING_STT.
+        use_streaming = (
+            provider.supports_streaming_stt() and not VOICE_DISABLE_STREAMING_STT
+        )
+
+        if use_streaming:
             try:
                 streaming_transcriber = await provider.create_streaming_transcriber()
-                logger.info(
-                    "WebSocket transcribe: streaming transcriber created successfully"
-                )
+                logger.info("WebSocket transcribe: streaming transcriber created")
                 await handle_streaming_transcription(websocket, streaming_transcriber)
+                return
             except Exception as e:
-                logger.error(
-                    "WebSocket transcribe: failed to create streaming transcriber: %s",
-                    e,
-                )
+                logger.error("WebSocket transcribe: streaming STT failed: %s", e)
                 if VOICE_DISABLE_STREAMING_FALLBACK:
                     await websocket.send_json(
                         {"type": "error", "message": f"Streaming STT failed: {e}"}
                     )
                     return
                 logger.info("WebSocket transcribe: falling back to chunked STT")
-                # Browser stream provides raw PCM16 chunks over WebSocket.
-                chunked_transcriber = ChunkedTranscriber(provider, audio_format="pcm16")
-                await handle_chunked_transcription(websocket, chunked_transcriber)
-        else:
-            # Here either the provider lacks streaming support, or streaming was
-            # explicitly disabled via VOICE_DISABLE_STREAMING_STT. In the latter
-            # case chunked/REST is the intended path, so the no-fallback guard
-            # (which is about not silently degrading from streaming) must not turn
-            # it into an error.
-            if VOICE_DISABLE_STREAMING_FALLBACK and not VOICE_DISABLE_STREAMING_STT:
-                await websocket.send_json(
-                    {
-                        "type": "error",
-                        "message": "Provider doesn't support streaming STT",
-                    }
-                )
-                return
-            logger.info("WebSocket transcribe: using chunked STT")
-            chunked_transcriber = ChunkedTranscriber(provider, audio_format="pcm16")
-            await handle_chunked_transcription(websocket, chunked_transcriber)
+        elif VOICE_DISABLE_STREAMING_FALLBACK and not VOICE_DISABLE_STREAMING_STT:
+            # Provider can't stream and chunked fallback is disabled.
+            await websocket.send_json(
+                {"type": "error", "message": "Provider doesn't support streaming STT"}
+            )
+            return
+
+        # Chunked/REST path; browser sends raw PCM16 chunks.
+        chunked_transcriber = ChunkedTranscriber(provider, audio_format="pcm16")
+        await handle_chunked_transcription(websocket, chunked_transcriber)
 
     except WebSocketDisconnect:
         logger.debug("WebSocket transcribe: client disconnected")

--- a/backend/onyx/server/manage/voice/websocket_api.py
+++ b/backend/onyx/server/manage/voice/websocket_api.py
@@ -440,8 +440,12 @@ async def websocket_transcribe(
                 chunked_transcriber = ChunkedTranscriber(provider, audio_format="pcm16")
                 await handle_chunked_transcription(websocket, chunked_transcriber)
         else:
-            # Fall back to chunked transcription
-            if VOICE_DISABLE_STREAMING_FALLBACK:
+            # Here either the provider lacks streaming support, or streaming was
+            # explicitly disabled via VOICE_DISABLE_STREAMING_STT. In the latter
+            # case chunked/REST is the intended path, so the no-fallback guard
+            # (which is about not silently degrading from streaming) must not turn
+            # it into an error.
+            if VOICE_DISABLE_STREAMING_FALLBACK and not VOICE_DISABLE_STREAMING_STT:
                 await websocket.send_json(
                     {
                         "type": "error",
@@ -449,9 +453,7 @@ async def websocket_transcribe(
                     }
                 )
                 return
-            logger.info(
-                "WebSocket transcribe: using chunked STT (provider doesn't support streaming)"
-            )
+            logger.info("WebSocket transcribe: using chunked STT")
             chunked_transcriber = ChunkedTranscriber(provider, audio_format="pcm16")
             await handle_chunked_transcription(websocket, chunked_transcriber)
 

--- a/backend/tests/unit/onyx/server/manage/voice/test_text_utils.py
+++ b/backend/tests/unit/onyx/server/manage/voice/test_text_utils.py
@@ -53,5 +53,18 @@ def test_collapses_whitespace_and_trims() -> None:
     assert strip_markdown_for_tts("  hello\n\n   world  ") == "hello world"
 
 
+def test_drops_fenced_code_blocks() -> None:
+    # Reading a code block aloud is noise; keep the surrounding prose only.
+    assert strip_markdown_for_tts("Run this:\n```python\nprint(1)\n```\nDone.") == (
+        "Run this: Done."
+    )
+
+
+def test_flattens_lists() -> None:
+    assert strip_markdown_for_tts("Steps:\n- first\n- second") == (
+        "Steps: first second"
+    )
+
+
 def test_empty_string() -> None:
     assert strip_markdown_for_tts("") == ""

--- a/backend/tests/unit/onyx/server/manage/voice/test_text_utils.py
+++ b/backend/tests/unit/onyx/server/manage/voice/test_text_utils.py
@@ -21,9 +21,31 @@ def test_preserves_inline_hash_text() -> None:
     )
 
 
+def test_preserves_intraword_underscores_and_lone_asterisks() -> None:
+    # Only paired emphasis is stripped; literal delimiters in normal text survive.
+    assert strip_markdown_for_tts("call user_id and file_name_here") == (
+        "call user_id and file_name_here"
+    )
+    assert strip_markdown_for_tts("2 * 3 = 6") == "2 * 3 = 6"
+    # A lone "5*" next to real italics must not be paired with the italic opener.
+    assert strip_markdown_for_tts("Rated 5* overall; see *italics* here") == (
+        "Rated 5* overall; see italics here"
+    )
+
+
 def test_converts_links_to_label() -> None:
     assert strip_markdown_for_tts("see [the docs](https://example.com/x)") == (
         "see the docs"
+    )
+
+
+def test_link_url_with_balanced_parens() -> None:
+    # URLs containing parentheses must not leak a trailing ")".
+    assert (
+        strip_markdown_for_tts(
+            "[C](https://en.wikipedia.org/wiki/C_(programming_language)) rules"
+        )
+        == "C rules"
     )
 
 

--- a/backend/tests/unit/onyx/server/manage/voice/test_text_utils.py
+++ b/backend/tests/unit/onyx/server/manage/voice/test_text_utils.py
@@ -1,0 +1,35 @@
+from onyx.server.manage.voice.text_utils import strip_markdown_for_tts
+
+
+def test_strips_bold_italic_and_code() -> None:
+    assert strip_markdown_for_tts("**bold** and *italic* and `code`") == (
+        "bold and italic and code"
+    )
+    assert strip_markdown_for_tts("__bold__ and _italic_") == "bold and italic"
+
+
+def test_strips_headers_at_line_start() -> None:
+    assert strip_markdown_for_tts("# Title\n## Subtitle\nbody") == (
+        "Title Subtitle body"
+    )
+
+
+def test_preserves_inline_hash_text() -> None:
+    # Hashes not at the start of a line (e.g. "C#", "#1") must be left alone.
+    assert strip_markdown_for_tts("C# is great and #1 ranked") == (
+        "C# is great and #1 ranked"
+    )
+
+
+def test_converts_links_to_label() -> None:
+    assert strip_markdown_for_tts("see [the docs](https://example.com/x)") == (
+        "see the docs"
+    )
+
+
+def test_collapses_whitespace_and_trims() -> None:
+    assert strip_markdown_for_tts("  hello\n\n   world  ") == "hello world"
+
+
+def test_empty_string() -> None:
+    assert strip_markdown_for_tts("") == ""


### PR DESCRIPTION
## Description

Two fixes for Azure-backed voice mode (both surfaced on a self-hosted deployment whose backend runs on aarch64).

**1. TTS narrated markdown aloud (`**`, `##`, backticks, links).**
Markdown stripping previously lived only in the web client, so any backend TTS entry point — and any web bundle older than that client change — synthesized raw markdown. This adds a shared `strip_markdown_for_tts()` and applies it at every backend synthesis entry point:
- `POST /voice/synthesize` (`user_api.py`) — the non-streaming REST endpoint
- both websocket handlers in `websocket_api.py` (`handle_streaming_synthesis`, `handle_chunked_synthesis`)

The helper is line-anchored for headers so inline text like `C#` or `#1` is left intact.

**2. `VOICE_DISABLE_STREAMING_STT` env flag to force STT onto the chunked/REST path.**
In some runtimes a provider's native streaming SDK transport cannot initialize (the recognizer connects, the session starts and stops, but no audio is ever recognized — empty transcripts with **no error**). The provider's REST transcription path works in the same environment. This flag (sibling of the existing `VOICE_DISABLE_STREAMING_FALLBACK`) lets an operator route STT through the working REST path per-deployment, without affecting environments where native streaming works.

## How Has This Been Tested?

- New unit tests for `strip_markdown_for_tts` (bold/italic/code/headers/links, inline-hash preservation, whitespace collapsing): `backend/tests/unit/onyx/server/manage/voice/test_text_utils.py` — all passing.
- Verified live on a staging deployment: with the flag set, STT returns correct transcripts via REST; TTS no longer speaks markdown markers. Provider REST round-trip (TTS→STT) confirmed end-to-end for the affected Azure resource.
- `ruff`, `ruff format`, and `ty` pass on the changed files.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

## Notes / follow-ups

- The chunked/REST STT path transcribes the full utterance on stop; it does not emit native VAD auto-stop, and `MIN_CHUNK_BYTES` is tuned for compressed (webm/opus) audio rather than raw PCM. A follow-up can make the interim threshold format-aware to reduce redundant REST calls.
- `AzureVoiceProvider.transcribe()` hardcodes `language=en-US`; making recognition language configurable is a sensible follow-up for non-English users.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strips markdown for TTS on the server using `markdown-it-py` across all synthesis paths so we don’t speak markup, and adds a toggle to force STT over REST when native streaming is unreliable. Also simplifies STT branching so disabling streaming cleanly falls back without errors.

- **Bug Fixes**
  - TTS: parse CommonMark with `markdown-it-py` and emit readable text only; drop fenced code, collapse whitespace, preserve inline hashes (e.g., C#, #1), strip only paired emphasis so `*` and `snake_case` survive, and turn `[label](url)` into `label` (handles balanced-paren URLs). Applied to `POST /voice/synthesize`, websocket streaming, and chunked synthesis.
  - STT: respect `VOICE_DISABLE_STREAMING_STT` even when `VOICE_DISABLE_STREAMING_FALLBACK` is true; flattened streaming/chunked logic routes to chunked/REST without the “provider doesn't support streaming STT” error.

- **New Features**
  - `VOICE_DISABLE_STREAMING_STT` env flag to force STT through the chunked/REST path instead of native streaming.

<sup>Written for commit 91508f60a84e6a84c08901981dc2a750941a7995. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

