### PR TITLE
fix: notion orphaned dbs

### DIFF
--- a/backend/onyx/connectors/notion/connector.py
+++ b/backend/onyx/connectors/notion/connector.py
@@ -41,6 +41,21 @@ _NOTION_PAGE_SIZE = 100
 _NOTION_CALL_TIMEOUT = 30  # 30 seconds
 _MAX_PAGES = 1000
 
+# Per-workspace bucket for databases whose real parent page never became a node.
+# Raw id derives from the workspace id so re-syncs update one row per workspace.
+_UNFILED_NODE_SUFFIX = "__unfiled"
+_UNFILED_DATABASES_DISPLAY_NAME = "Unfiled databases"
+
+
+def _notion_link(raw_id: str) -> str:
+    """Notion web URL for an object; Notion URLs omit the UUID's dashes."""
+    return f"https://notion.so/{raw_id.replace('-', '')}"
+
+
+def _unfiled_node_raw_id(workspace_id: str) -> str:
+    """Stable raw id for a workspace's Unfiled-databases node."""
+    return f"{workspace_id}{_UNFILED_NODE_SUFFIX}"
+
 
 # TODO: Pages need to have their metadata ingested
 
@@ -66,6 +81,16 @@ class NotionDataSource(BaseModel):
 
     id: str
     name: str = ""
+
+
+class _TrackedDatabase(BaseModel):
+    """A non-workspace-parented database held from the prepass so its parent can be
+    re-resolved once every page node for the run exists."""
+
+    raw_node_id: str
+    parent_raw_id: str
+    display_name: str
+    link: str | None
 
 
 class NotionBlock(BaseModel):
@@ -157,6 +182,9 @@ class NotionConnector(LoadConnector, PollConnector):
         # Maps data_source_id -> database_id (populated in _read_pages_from_database).
         # Used to resolve data_source_id parent types back to the database.
         self._data_source_to_database_map: dict[str, str] = {}
+        # Non-workspace-parented databases discovered in the prepass, held so their
+        # parent can be re-resolved at end-of-run (see _reconcile_database_parents).
+        self._tracked_databases: list[_TrackedDatabase] = []
 
     @classmethod
     @override
@@ -407,7 +435,7 @@ class NotionConnector(LoadConnector, PollConnector):
             raw_node_id=self.workspace_id,
             raw_parent_id=None,  # Parent is SOURCE (auto-created by system)
             display_name=self.workspace_name or "Notion Workspace",
-            link=f"https://notion.so/{self.workspace_id.replace('-', '')}",
+            link=_notion_link(self.workspace_id),
             node_type=HierarchyNodeType.WORKSPACE,
         )
 
@@ -588,12 +616,11 @@ class NotionConnector(LoadConnector, PollConnector):
         hierarchy_nodes: list[HierarchyNode] = []
 
         # Create hierarchy node for this database if not already yielded.
-        # Notion URLs omit dashes from UUIDs: https://notion.so/17ab3186873d418fb899c3f6a43f68de
         db_node = self._maybe_yield_hierarchy_node(
             raw_node_id=database_id,
             raw_parent_id=database_parent_raw_id or self.workspace_id,
             display_name=database_name or f"Database {database_id}",
-            link=f"https://notion.so/{database_id.replace('-', '')}",
+            link=_notion_link(database_id),
             node_type=HierarchyNodeType.DATABASE,
         )
         if db_node:
@@ -1025,9 +1052,7 @@ class NotionConnector(LoadConnector, PollConnector):
                     db_page = self._fetch_database_as_page(db_id)
                     db_name = db_page.database_name or f"Database {db_id}"
                     parent_raw_id = self._get_parent_raw_id(db_page.parent)
-                    db_url = (
-                        db_page.url or f"https://notion.so/{db_id.replace('-', '')}"
-                    )
+                    db_url = db_page.url or _notion_link(db_id)
                 except requests.exceptions.RequestException as e:
                     logger.warning(
                         "Could not fetch database '%s', "
@@ -1037,24 +1062,75 @@ class NotionConnector(LoadConnector, PollConnector):
                     )
                     db_name = f"Database {db_id}"
                     parent_raw_id = self.workspace_id
-                    db_url = f"https://notion.so/{db_id.replace('-', '')}"
+                    db_url = _notion_link(db_id)
 
                 # _maybe_yield_hierarchy_node deduplicates by raw_node_id,
                 # so multiple data sources under one database produce one node.
+                effective_parent = parent_raw_id or self.workspace_id
                 node = self._maybe_yield_hierarchy_node(
                     raw_node_id=db_id,
-                    raw_parent_id=parent_raw_id or self.workspace_id,
+                    raw_parent_id=effective_parent,
                     display_name=db_name,
                     link=db_url,
                     node_type=HierarchyNodeType.DATABASE,
                 )
-                if node:
-                    yield node
+                if not node:
+                    continue
+                yield node
+
+                # Workspace-parented databases already resolve; others need their
+                # parent re-resolved at end-of-run (parent page may come later, or never).
+                if effective_parent and effective_parent != self.workspace_id:
+                    self._tracked_databases.append(
+                        _TrackedDatabase(
+                            raw_node_id=db_id,
+                            parent_raw_id=effective_parent,
+                            display_name=db_name,
+                            link=db_url,
+                        )
+                    )
 
             if not db_res.has_more:
                 break
             query_dict["start_cursor"] = db_res.next_cursor
             pages_seen += 1
+
+    def _reconcile_database_parents(
+        self,
+    ) -> Generator[HierarchyNode, None, None]:
+        """Re-emit tracked databases with their final parent once every page node
+        exists: the real page if it became a node, else a synthetic per-workspace
+        "Unfiled" node so orphans sit under the workspace instead of SOURCE.
+
+        The re-emit (idempotent on ``(raw_node_id, source)``) also corrects the
+        prepass-before-pages ordering that otherwise strands page-parented databases.
+        """
+        if not self._tracked_databases:
+            return
+
+        seen = self.seen_hierarchy_node_raw_ids
+        has_orphan = any(td.parent_raw_id not in seen for td in self._tracked_databases)
+
+        unfiled_raw_id: str | None = None
+        if has_orphan and self.workspace_id:
+            unfiled_raw_id = _unfiled_node_raw_id(self.workspace_id)
+            yield HierarchyNode(
+                raw_node_id=unfiled_raw_id,
+                raw_parent_id=self.workspace_id,
+                display_name=_UNFILED_DATABASES_DISPLAY_NAME,
+                link=_notion_link(self.workspace_id),
+                node_type=HierarchyNodeType.PAGE,
+            )
+
+        for td in self._tracked_databases:
+            resolved = td.parent_raw_id in seen
+            yield HierarchyNode(
+                raw_node_id=td.raw_node_id,
+                raw_parent_id=td.parent_raw_id if resolved else unfiled_raw_id,
+                display_name=td.display_name,
+                link=td.link,
+                node_type=HierarchyNodeType.DATABASE,
+            )
 
     def _filter_pages_by_time(
         self,
@@ -1141,6 +1217,10 @@ class NotionConnector(LoadConnector, PollConnector):
             else:
                 break
 
+        # Re-emit database nodes now that all page nodes exist, fixing parent
+        # ordering and collecting unparentable databases under the Unfiled node.
+        yield from batch_generator(self._reconcile_database_parents(), self.batch_size)
+
     def poll_source(
         self, start: SecondsSinceUnixEpoch, end: SecondsSinceUnixEpoch
     ) -> GenerateDocumentsOutput:
@@ -1185,6 +1265,10 @@ class NotionConnector(LoadConnector, PollConnector):
                     break
             else:
                 break
+
+        # Re-emit database nodes now that all page nodes exist, fixing parent
+        # ordering and collecting unparentable databases under the Unfiled node.
+        yield from batch_generator(self._reconcile_database_parents(), self.batch_size)
 
     def validate_connector_settings(self) -> None:
         if not self.headers.get("Authorization"):

--- a/backend/onyx/connectors/notion/connector.py
+++ b/backend/onyx/connectors/notion/connector.py
@@ -1098,12 +1098,15 @@ class NotionConnector(LoadConnector, PollConnector):
     def _reconcile_database_parents(
         self,
     ) -> Generator[HierarchyNode, None, None]:
-        """Re-emit tracked databases with their final parent once every page node
-        exists: the real page if it became a node, else a synthetic per-workspace
-        "Unfiled" node so orphans sit under the workspace instead of SOURCE.
+        """Re-emit tracked databases with their final parent: the real page if it
+        became a node this run, else a synthetic per-workspace "Unfiled" node so
+        orphans sit under the workspace instead of SOURCE. The re-emit (idempotent
+        on ``(raw_node_id, source)``) also corrects the prepass-before-pages
+        ordering that otherwise strands page-parented databases.
 
-        The re-emit (idempotent on ``(raw_node_id, source)``) also corrects the
-        prepass-before-pages ordering that otherwise strands page-parented databases.
+        Only valid after a full page pass (load_from_state): orphan detection uses
+        ``seen_hierarchy_node_raw_ids``, so a partial pass (poll) would misclassify
+        unchanged parents as orphans.
         """
         if not self._tracked_databases:
             return
@@ -1124,9 +1127,14 @@ class NotionConnector(LoadConnector, PollConnector):
 
         for td in self._tracked_databases:
             resolved = td.parent_raw_id in seen
+            # Orphans go under Unfiled when it exists; without a workspace_id we
+            # can't build it, so keep the original parent rather than yield None.
+            final_parent = (
+                td.parent_raw_id if resolved else (unfiled_raw_id or td.parent_raw_id)
+            )
             yield HierarchyNode(
                 raw_node_id=td.raw_node_id,
-                raw_parent_id=td.parent_raw_id if resolved else unfiled_raw_id,
+                raw_parent_id=final_parent,
                 display_name=td.display_name,
                 link=td.link,
                 node_type=HierarchyNodeType.DATABASE,
@@ -1266,9 +1274,11 @@ class NotionConnector(LoadConnector, PollConnector):
             else:
                 break
 
-        # Re-emit database nodes now that all page nodes exist, fixing parent
-        # ordering and collecting unparentable databases under the Unfiled node.
-        yield from batch_generator(self._reconcile_database_parents(), self.batch_size)
+        # No reconciliation here: poll only processes recently-edited pages, so
+        # `seen` is incomplete and can't distinguish a true orphan from a parent
+        # page that simply wasn't edited this window. The prepass already parents
+        # databases via their real page id, which resolves against page nodes
+        # persisted by a prior full sync. Reconciliation runs in load_from_state.
 
     def validate_connector_settings(self) -> None:
         if not self.headers.get("Authorization"):

--- a/backend/tests/unit/onyx/connectors/notion/test_notion_unfiled_databases.py
+++ b/backend/tests/unit/onyx/connectors/notion/test_notion_unfiled_databases.py
@@ -1,0 +1,248 @@
+"""Unit tests for the Notion connector's end-of-run database reconciliation.
+
+Covers re-emitting database hierarchy nodes with their final parent:
+- databases whose parent page became a node nest under that page (ordering fix)
+- databases whose parent never materialized are collected under a synthetic
+  per-workspace "Unfiled" node instead of scattering under SOURCE.
+"""
+
+from unittest.mock import patch
+
+from onyx.connectors.models import HierarchyNode
+from onyx.connectors.notion.connector import _TrackedDatabase
+from onyx.connectors.notion.connector import _UNFILED_DATABASES_DISPLAY_NAME
+from onyx.connectors.notion.connector import _unfiled_node_raw_id
+from onyx.connectors.notion.connector import _UNFILED_NODE_SUFFIX
+from onyx.connectors.notion.connector import NotionConnector
+from onyx.connectors.notion.connector import NotionPage
+from onyx.connectors.notion.connector import NotionSearchResponse
+from onyx.db.enums import HierarchyNodeType
+
+
+def _make_connector() -> NotionConnector:
+    connector = NotionConnector()
+    connector.load_credentials({"notion_integration_token": "fake-token"})
+    return connector
+
+
+def _make_db_page(
+    db_id: str, parent: dict, name: str = "My DB", url: str = "https://notion.so/db"
+) -> NotionPage:
+    return NotionPage(
+        id=db_id,
+        created_time="2024-01-01T00:00:00.000Z",
+        last_edited_time="2024-01-01T00:00:00.000Z",
+        in_trash=False,
+        properties={},
+        url=url,
+        database_name=name,
+        parent=parent,
+    )
+
+
+class TestReconcileDatabaseParents:
+    def test_orphan_routed_to_unfiled(self) -> None:
+        connector = _make_connector()
+        connector.workspace_id = "ws-1"
+        connector.seen_hierarchy_node_raw_ids = {"ws-1", "db-1"}
+        connector._tracked_databases = [
+            _TrackedDatabase(
+                raw_node_id="db-1",
+                parent_raw_id="page-x",  # never became a node
+                display_name="My DB",
+                link="https://notion.so/db1",
+            )
+        ]
+
+        nodes = list(connector._reconcile_database_parents())
+
+        unfiled_id = _unfiled_node_raw_id("ws-1")
+        unfiled = [n for n in nodes if n.raw_node_id == unfiled_id]
+        assert len(unfiled) == 1
+        assert unfiled[0].raw_parent_id == "ws-1"
+        assert unfiled[0].node_type == HierarchyNodeType.PAGE
+        assert unfiled[0].display_name == _UNFILED_DATABASES_DISPLAY_NAME
+
+        db_node = [n for n in nodes if n.raw_node_id == "db-1"]
+        assert len(db_node) == 1
+        assert db_node[0].raw_parent_id == unfiled_id
+        assert db_node[0].node_type == HierarchyNodeType.DATABASE
+
+        # Unfiled node must be emitted before the database that references it.
+        assert nodes[0].raw_node_id == unfiled_id
+
+    def test_resolved_parent_kept_no_unfiled(self) -> None:
+        """Ordering fix: a database whose parent page DID become a node this run
+        nests under that page, and no Unfiled node is created."""
+        connector = _make_connector()
+        connector.workspace_id = "ws-1"
+        connector.seen_hierarchy_node_raw_ids = {"ws-1", "db-1", "page-x"}
+        connector._tracked_databases = [
+            _TrackedDatabase(
+                raw_node_id="db-1",
+                parent_raw_id="page-x",  # became a node this run
+                display_name="My DB",
+                link="https://notion.so/db1",
+            )
+        ]
+
+        nodes = list(connector._reconcile_database_parents())
+
+        assert all(not n.raw_node_id.endswith(_UNFILED_NODE_SUFFIX) for n in nodes)
+        db_node = [n for n in nodes if n.raw_node_id == "db-1"]
+        assert len(db_node) == 1
+        assert db_node[0].raw_parent_id == "page-x"
+
+    def test_mixed_resolved_and_orphan(self) -> None:
+        connector = _make_connector()
+        connector.workspace_id = "ws-1"
+        connector.seen_hierarchy_node_raw_ids = {"ws-1", "db-1", "db-2", "page-x"}
+        connector._tracked_databases = [
+            _TrackedDatabase(
+                raw_node_id="db-1",
+                parent_raw_id="page-x",
+                display_name="Resolved DB",
+                link=None,
+            ),
+            _TrackedDatabase(
+                raw_node_id="db-2",
+                parent_raw_id="page-missing",
+                display_name="Orphan DB",
+                link=None,
+            ),
+        ]
+
+        nodes = list(connector._reconcile_database_parents())
+        by_id = {n.raw_node_id: n for n in nodes}
+        unfiled_id = _unfiled_node_raw_id("ws-1")
+
+        assert unfiled_id in by_id
+        assert by_id["db-1"].raw_parent_id == "page-x"
+        assert by_id["db-2"].raw_parent_id == unfiled_id
+
+    def test_no_tracked_databases_is_noop(self) -> None:
+        connector = _make_connector()
+        connector.workspace_id = "ws-1"
+        assert list(connector._reconcile_database_parents()) == []
+
+    def test_unfiled_id_is_workspace_scoped(self) -> None:
+        connector_a = _make_connector()
+        connector_a.workspace_id = "ws-a"
+        connector_a.seen_hierarchy_node_raw_ids = {"ws-a", "db-1"}
+        connector_a._tracked_databases = [
+            _TrackedDatabase(
+                raw_node_id="db-1", parent_raw_id="page-x", display_name="A", link=None
+            )
+        ]
+        connector_b = _make_connector()
+        connector_b.workspace_id = "ws-b"
+        connector_b.seen_hierarchy_node_raw_ids = {"ws-b", "db-1"}
+        connector_b._tracked_databases = [
+            _TrackedDatabase(
+                raw_node_id="db-1", parent_raw_id="page-x", display_name="B", link=None
+            )
+        ]
+
+        nodes_a = list(connector_a._reconcile_database_parents())
+        nodes_b = list(connector_b._reconcile_database_parents())
+
+        unfiled_a = next(
+            n for n in nodes_a if n.raw_node_id.endswith(_UNFILED_NODE_SUFFIX)
+        )
+        unfiled_b = next(
+            n for n in nodes_b if n.raw_node_id.endswith(_UNFILED_NODE_SUFFIX)
+        )
+        assert unfiled_a.raw_node_id == _unfiled_node_raw_id("ws-a")
+        assert unfiled_b.raw_node_id == _unfiled_node_raw_id("ws-b")
+        assert unfiled_a.raw_node_id != unfiled_b.raw_node_id
+
+
+class TestYieldDatabaseHierarchyNodesTracking:
+    def test_tracks_non_workspace_parent_skips_workspace_parent(self) -> None:
+        connector = _make_connector()
+        connector.workspace_id = "ws-1"
+
+        search_resp = NotionSearchResponse(
+            results=[
+                {"id": "ds-1", "parent": {"database_id": "db-page"}},
+                {"id": "ds-2", "parent": {"database_id": "db-top"}},
+            ],
+            next_cursor=None,
+            has_more=False,
+        )
+
+        def fake_fetch_db_as_page(db_id: str) -> NotionPage:
+            if db_id == "db-page":
+                return _make_db_page(db_id, {"type": "page_id", "page_id": "page-x"})
+            return _make_db_page(db_id, {"type": "workspace"})
+
+        with (
+            patch.object(connector, "_search_notion", return_value=search_resp),
+            patch.object(
+                connector, "_fetch_database_as_page", side_effect=fake_fetch_db_as_page
+            ),
+        ):
+            nodes = [
+                n
+                for n in connector._yield_database_hierarchy_nodes()
+                if isinstance(n, HierarchyNode)
+            ]
+
+        # Both databases are yielded in the prepass.
+        assert {n.raw_node_id for n in nodes} == {"db-page", "db-top"}
+        # Only the page-parented database is tracked for reconciliation.
+        tracked_ids = {td.raw_node_id for td in connector._tracked_databases}
+        assert tracked_ids == {"db-page"}
+        tracked = connector._tracked_databases[0]
+        assert tracked.parent_raw_id == "page-x"
+
+
+class TestLoadFromStateReconciliation:
+    def test_orphan_database_reemitted_under_unfiled(self) -> None:
+        connector = _make_connector()
+
+        def fake_search(query_dict: dict) -> NotionSearchResponse:
+            value = query_dict["filter"]["value"]
+            if value == "data_source":
+                return NotionSearchResponse(
+                    results=[{"id": "ds-1", "parent": {"database_id": "db-1"}}],
+                    next_cursor=None,
+                    has_more=False,
+                )
+            # No pages returned -> parent page never becomes a node.
+            return NotionSearchResponse(results=[], next_cursor=None, has_more=False)
+
+        def fake_fetch_db_as_page(db_id: str) -> NotionPage:
+            return _make_db_page(db_id, {"type": "page_id", "page_id": "page-x"})
+
+        with (
+            patch.object(
+                connector,
+                "_fetch_workspace_info",
+                return_value=("ws-1", "My Workspace"),
+            ),
+            patch.object(connector, "_search_notion", side_effect=fake_search),
+            patch.object(
+                connector, "_fetch_database_as_page", side_effect=fake_fetch_db_as_page
+            ),
+        ):
+            nodes: list[HierarchyNode] = [
+                item
+                for batch in connector.load_from_state()
+                for item in batch
+                if isinstance(item, HierarchyNode)
+            ]
+
+        # Workspace node is emitted first.
+        assert nodes[0].raw_node_id == "ws-1"
+        assert nodes[0].node_type == HierarchyNodeType.WORKSPACE
+
+        unfiled_id = _unfiled_node_raw_id("ws-1")
+        assert any(n.raw_node_id == unfiled_id for n in nodes)
+
+        # db-1 is yielded twice: once in the prepass (parent page-x) and once
+        # re-emitted at the end under the Unfiled node.
+        db_nodes = [n for n in nodes if n.raw_node_id == "db-1"]
+        assert len(db_nodes) == 2
+        assert db_nodes[0].raw_parent_id == "page-x"
+        assert db_nodes[-1].raw_parent_id == unfiled_id

--- a/backend/tests/unit/onyx/connectors/notion/test_notion_unfiled_databases.py
+++ b/backend/tests/unit/onyx/connectors/notion/test_notion_unfiled_databases.py
@@ -125,6 +125,28 @@ class TestReconcileDatabaseParents:
         connector.workspace_id = "ws-1"
         assert list(connector._reconcile_database_parents()) == []
 
+    def test_missing_workspace_id_keeps_original_parent_not_none(self) -> None:
+        """Without a workspace_id we can't build the Unfiled node; orphans must
+        keep their original parent rather than be re-parented to None (SOURCE)."""
+        connector = _make_connector()
+        connector.workspace_id = None
+        connector.seen_hierarchy_node_raw_ids = {"db-1"}
+        connector._tracked_databases = [
+            _TrackedDatabase(
+                raw_node_id="db-1",
+                parent_raw_id="page-x",
+                display_name="Orphan DB",
+                link=None,
+            )
+        ]
+
+        nodes = list(connector._reconcile_database_parents())
+
+        assert all(not n.raw_node_id.endswith(_UNFILED_NODE_SUFFIX) for n in nodes)
+        db_node = [n for n in nodes if n.raw_node_id == "db-1"]
+        assert len(db_node) == 1
+        assert db_node[0].raw_parent_id == "page-x"
+
     def test_unfiled_id_is_workspace_scoped(self) -> None:
         connector_a = _make_connector()
         connector_a.workspace_id = "ws-a"
@@ -246,3 +268,45 @@ class TestLoadFromStateReconciliation:
         assert len(db_nodes) == 2
         assert db_nodes[0].raw_parent_id == "page-x"
         assert db_nodes[-1].raw_parent_id == unfiled_id
+
+
+class TestPollSourceReconciliation:
+    def test_poll_does_not_orphan_unchanged_parents(self) -> None:
+        """Poll only sees recently-edited pages, so reconciliation must NOT run:
+        a database whose parent page is unchanged this window keeps its real page
+        parent and is never routed under Unfiled."""
+        connector = _make_connector()
+
+        def fake_search(query_dict: dict) -> NotionSearchResponse:
+            if query_dict["filter"]["value"] == "data_source":
+                return NotionSearchResponse(
+                    results=[{"id": "ds-1", "parent": {"database_id": "db-1"}}],
+                    next_cursor=None,
+                    has_more=False,
+                )
+            # No recently-edited pages this window.
+            return NotionSearchResponse(results=[], next_cursor=None, has_more=False)
+
+        def fake_fetch_db_as_page(db_id: str) -> NotionPage:
+            return _make_db_page(db_id, {"type": "page_id", "page_id": "page-x"})
+
+        with (
+            patch.object(
+                connector, "_fetch_workspace_info", return_value=("ws-1", "WS")
+            ),
+            patch.object(connector, "_search_notion", side_effect=fake_search),
+            patch.object(
+                connector, "_fetch_database_as_page", side_effect=fake_fetch_db_as_page
+            ),
+        ):
+            nodes: list[HierarchyNode] = [
+                item
+                for batch in connector.poll_source(0, 1_000_000_000)
+                for item in batch
+                if isinstance(item, HierarchyNode)
+            ]
+
+        assert all(not n.raw_node_id.endswith(_UNFILED_NODE_SUFFIX) for n in nodes)
+        db_nodes = [n for n in nodes if n.raw_node_id == "db-1"]
+        assert len(db_nodes) == 1
+        assert db_nodes[0].raw_parent_id == "page-x"


### PR DESCRIPTION
## Description

We don't know a priori where dbs are parented in notion, so rather than try to carefully order the hierarchy node returns and ending up with no parents, we just reconcile parents at the end of each index attempt. We also give each db that ends up without a parent (due to fetching restrictions, for example) a single fake "unfiled" parent to make it easier to navigate the hierarchy if this is prevalent

## How Has This Been Tested?

added unit tests

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes orphaned Notion databases by reconciling parents after a full sync and moving unresolved ones under a per‑workspace "Unfiled databases" page. This fixes ordering issues when parent pages arrive later and avoids scattering under SOURCE.

- **Bug Fixes**
  - Re-emit database nodes at the end of `load_from_state`; attach to the real parent page when available, else to a synthetic "Unfiled databases" page (stable id `${workspace_id}__unfiled`).
  - Track only non‑workspace‑parented databases during the prepass and resolve against `seen_hierarchy_node_raw_ids`.
  - Skip reconciliation in `poll_source` to avoid false orphans; prepass still uses the real parent page id from prior full syncs.
  - Standardize Notion URLs via `_notion_link`; update workspace and database links.
  - Add unit tests for resolved and orphan cases, workspace‑scoped unfiled ids, and poll behavior.

<sup>Written for commit 2aa6d9fc94d12ad09aa57d11792ed8225765fe2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

