### PR TITLE
test(craft): add HTTP API integration lane

### DIFF
--- a/backend/tests/integration/tests/craft/user_library_http.py
+++ b/backend/tests/integration/tests/craft/user_library_http.py
@@ -1,0 +1,92 @@
+"""Shared HTTP helpers for the user-library endpoints.
+
+Used by both the integration user-library tests and the k8s user-library
+sync tests, which hit the same ``onyx.server.features.build.user_library.api``
+endpoints but assert on different effects (DB/tree rows vs. on-pod files).
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from collections.abc import Iterable
+from typing import Any
+
+import httpx
+
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.http_client import client
+from tests.integration.common_utils.test_models import DATestUser
+
+
+def _url(*parts: str) -> str:
+    return f"{API_SERVER_URL}/build/user-library/" + "/".join(parts)
+
+
+def _multipart_headers(user: DATestUser) -> dict[str, str]:
+    """Drop the JSON Content-Type so the client can set the multipart one."""
+    return {k: v for k, v in user.headers.items() if k.lower() != "content-type"}
+
+
+def upload_user_library_files(
+    user: DATestUser,
+    files: Iterable[tuple[str, bytes, str | None]],
+    path: str = "/",
+) -> httpx.Response:
+    multipart = [
+        (
+            "files",
+            (name, io.BytesIO(content), content_type or "application/octet-stream"),
+        )
+        for name, content, content_type in files
+    ]
+    return client.post(
+        _url("upload"),
+        files=multipart,
+        data={"path": path},
+        headers=_multipart_headers(user),
+        cookies=user.cookies,
+    )
+
+
+def upload_user_library_zip(
+    user: DATestUser,
+    zip_bytes: bytes,
+    path: str = "/",
+    filename: str = "bundle.zip",
+) -> httpx.Response:
+    return client.post(
+        _url("upload-zip"),
+        files={"file": (filename, io.BytesIO(zip_bytes), "application/zip")},
+        data={"path": path},
+        headers=_multipart_headers(user),
+        cookies=user.cookies,
+    )
+
+
+def list_user_library_tree(user: DATestUser) -> list[dict[str, Any]]:
+    response = client.get(
+        _url("tree"),
+        headers=user.headers,
+        cookies=user.cookies,
+    )
+    response.raise_for_status()
+    body = response.json()
+    assert isinstance(body, list)
+    return body
+
+
+def delete_user_library_file(user: DATestUser, document_id: str) -> httpx.Response:
+    return client.delete(
+        _url("files", document_id),
+        headers=user.headers,
+        cookies=user.cookies,
+    )
+
+
+def make_zip_bytes(members: dict[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, data in members.items():
+            zf.writestr(name, data)
+    return buf.getvalue()

--- a/backend/tests/integration/tests/craft_api/conftest.py
+++ b/backend/tests/integration/tests/craft_api/conftest.py
@@ -1,0 +1,147 @@
+"""Fixtures for the Craft HTTP-contract integration lane (``craft_api``).
+
+Unlike the sibling ``craft`` suite (which needs a real Docker/K8s sandbox and
+runs in the compose lane against an out-of-process api_server), this directory
+runs in the STANDARD integration matrix: the global
+``backend/tests/integration/conftest.py`` builds an in-process
+``TestClient(app)`` against real Postgres + Redis, and these tests drive the
+Craft build/session HTTP endpoints through it.
+
+No real sandbox is provisioned. An autouse fixture installs a configured
+``StubSandboxManager`` as the process-wide sandbox manager singleton, so every
+build endpoint that would otherwise provision/health-check/read a container
+instead gets deterministic in-memory responses. This keeps the lane fast and
+hermetic while still exercising the real FastAPI routing, auth, DB writes, and
+SessionManager orchestration.
+
+The stub is configured for the full surface the moved Class-A tests reach:
+session create/delete, file listing/read, upload stats + writes, the user-
+library cold-start push, opencode-session prewarm, and the webapp proxy's
+``get_webapp_url`` (pointed at an unreachable URL so the proxy falls back to
+its branded offline page — which the webapp tests assert).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from datetime import datetime
+from datetime import timezone
+from uuid import UUID
+from uuid import uuid4
+
+import pytest
+
+from onyx.db.enums import SandboxStatus
+from onyx.server.features.build.sandbox import factory
+from onyx.server.features.build.sandbox.models import SandboxInfo
+from onyx.server.features.build.scheduled_tasks import api as scheduled_tasks_api
+from tests.common.craft.stubs import StubSandboxManager
+from tests.integration.common_utils.managers.build_session import BuildSessionManager
+from tests.integration.common_utils.managers.llm_provider import LLMProviderManager
+from tests.integration.common_utils.managers.user import UserManager
+from tests.integration.common_utils.test_models import DATestLLMProvider
+from tests.integration.common_utils.test_models import DATestUser
+
+# An intentionally unreachable internal URL. The webapp proxy resolves this via
+# ``get_webapp_url`` and then tries to connect; the connection fails fast and
+# the proxy renders its offline page — exactly the path the webapp tests pin.
+_UNREACHABLE_WEBAPP_URL = "http://127.0.0.1:1/unreachable"
+
+
+def _make_configured_stub() -> StubSandboxManager:
+    """Build a ``StubSandboxManager`` covering every method the Craft build and
+    session endpoints invoke in this lane.
+
+    Provisioning is instant and in-memory, so tests create per-test sessions
+    cheaply rather than sharing one.
+    """
+    stub = StubSandboxManager()
+
+    # Provisioning + lifecycle.
+    stub.provision_returns = SandboxInfo(
+        sandbox_id=uuid4(),
+        directory_path="/workspace",
+        status=SandboxStatus.RUNNING,
+        last_heartbeat=datetime.now(tz=timezone.utc),
+    )
+    stub.health_check_returns = True
+    stub.session_workspace_exists_returns = True
+    stub.setup_session_workspace_silent = True
+    stub.cleanup_session_workspace_silent = True
+    stub.terminate_silent = True
+    stub.restore_snapshot_silent = True
+
+    # Skills + user-library cold-start hydration both flow through
+    # ``push_to_sandbox`` -> ``write_files_to_sandbox`` on session create.
+    stub.write_files_to_sandbox_silent = True
+    stub.write_sandbox_file_silent = True
+
+    # Filesystem reads (list/download/upload/stats).
+    stub.list_directory_returns = []
+    stub.read_file_returns = b""
+    stub.upload_file_returns = "attachments/file"
+    stub.get_upload_stats_returns = (0, 0)
+
+    # ``ensure_opencode_session`` is already defaulted on the stub; leave it.
+
+    # Webapp proxy: resolvable but unreachable so the proxy serves its offline page.
+    stub.get_webapp_url_returns = _UNREACHABLE_WEBAPP_URL
+
+    return stub
+
+
+@pytest.fixture(autouse=True)
+def _disable_scheduled_task_executor_enqueue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep scheduled-task HTTP tests from starting real worker execution."""
+
+    def _noop_enqueue(_run_id: UUID) -> None:
+        return None
+
+    monkeypatch.setattr(scheduled_tasks_api, "_enqueue_executor", _noop_enqueue)
+
+
+@pytest.fixture(autouse=True)
+def _stub_sandbox_manager(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Generator[StubSandboxManager, None, None]:
+    """Install a configured stub as the process-wide sandbox manager.
+
+    Setting ``factory._sandbox_manager_instance`` is sufficient because every
+    caller goes through ``factory.get_sandbox_manager()`` (which returns the
+    cached instance). Patching ``factory.get_sandbox_manager`` too is
+    belt-and-suspenders for any direct reference.
+    """
+    stub = _make_configured_stub()
+    monkeypatch.setattr(factory, "_sandbox_manager_instance", stub)
+    monkeypatch.setattr(factory, "get_sandbox_manager", lambda: stub)
+    yield stub
+
+
+@pytest.fixture
+def llm_provider(admin_user: DATestUser) -> DATestLLMProvider:
+    """Seed a default LLM provider without requiring a real provider key."""
+    return LLMProviderManager.create(
+        user_performing_action=admin_user,
+        api_key="test-api-key",
+    )
+
+
+@pytest.fixture
+def shared_session(
+    llm_provider: object,  # noqa: ARG001 — ensures a default LLM provider (and admin) exist
+) -> tuple[DATestUser, UUID]:
+    """A single created session owned by a dedicated user, for read-only /
+    validation / ownership / offline-proxy checks.
+
+    Provisioning is instant under the stub, so this is created fresh per test
+    (function scope) rather than shared across a module. Owned by a per-test
+    user isolated from the function-scoped ``admin_user`` / ``basic_user``
+    fixtures so a sibling create/delete can't disturb it. ``llm_provider``
+    transitively guarantees an admin user exists, so the created user lands as
+    a non-admin basic account.
+    """
+    owner = UserManager.create(name=f"craft-api-shared-{uuid4().hex[:8]}")
+    body = BuildSessionManager.create(owner)
+    return owner, UUID(body["id"])

--- a/backend/tests/integration/tests/craft_api/test_file_ops_api.py
+++ b/backend/tests/integration/tests/craft_api/test_file_ops_api.py
@@ -1,0 +1,112 @@
+"""File ops security boundary tests (HTTP contract half).
+
+Pins the hidden-entry, opencode.json-hiding, and cross-user rules across the
+build session file-ops endpoints. These checks are resolved before (or
+independently of) any real filesystem access, so they run in the standard
+integration matrix against the in-process app with a stubbed sandbox manager
+(see ``conftest.py``). The path-traversal / metachar / null-byte validation
+and the real upload-stats assertions need the real sandbox manager and stay in
+the compose lane.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.http_client import client
+from tests.integration.common_utils.managers.build_session import BuildSessionManager
+from tests.integration.common_utils.test_models import DATestLLMProvider
+from tests.integration.common_utils.test_models import DATestUser
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _create_session_id(user: DATestUser) -> UUID:
+    session = BuildSessionManager.create(user)
+    return UUID(session["id"])
+
+
+def _files_url(session_id: UUID) -> str:
+    return f"{API_SERVER_URL}/build/sessions/{session_id}/files"
+
+
+def _artifact_url(session_id: UUID, path: str) -> str:
+    return f"{API_SERVER_URL}/build/sessions/{session_id}/artifacts/{path}"
+
+
+# ---------------------------------------------------------------------------
+# download_artifact — opencode.json hiding
+# ---------------------------------------------------------------------------
+
+
+def test_download_artifact_hides_opencode_json(
+    shared_session: tuple[DATestUser, UUID],
+) -> None:
+    """Direct download of ``opencode.json`` returns 404 even if the file exists."""
+    owner, session_id = shared_session
+    response = client.get(
+        _artifact_url(session_id, "opencode.json"),
+        headers=owner.headers,
+        cookies=owner.cookies,
+    )
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# list_directory — hidden-entry filtering
+# ---------------------------------------------------------------------------
+
+
+def test_list_directory_filters_hidden_entries(
+    shared_session: tuple[DATestUser, UUID],
+) -> None:
+    """``opencode.json``, ``.env`` and other HIDDEN_PATTERNS entries are never
+    surfaced by the list endpoint.
+
+    The upload API blocks creation of dotted/system files (sanitiser strips
+    the leading dot, and ``.env`` is on the BLOCKED list at the filename
+    level via the SAFE_FILENAME_PATTERN). We rely on the actual hidden
+    filters baked into the manager — we just assert that no listing ever
+    returns the forbidden names.
+    """
+    owner, session_id = shared_session
+    # Seed a couple of normal files so the listing isn't trivially empty.
+    BuildSessionManager.upload_file(
+        owner, session_id, filename="alpha.txt", content=b"a"
+    )
+    BuildSessionManager.upload_file(
+        owner, session_id, filename="beta.txt", content=b"b"
+    )
+
+    listing = BuildSessionManager.list_files(owner, session_id)
+    entries = listing.get("entries", [])
+    names = {entry["name"] for entry in entries}
+
+    forbidden = {".venv", ".git", "node_modules", ".DS_Store", "opencode.json", ".env"}
+    assert names.isdisjoint(forbidden), (
+        f"Listing returned hidden entries: {names & forbidden}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cross-user isolation
+# ---------------------------------------------------------------------------
+
+
+def test_cross_user_file_access_returns_404(
+    admin_user: DATestUser,
+    basic_user: DATestUser,
+    llm_provider: DATestLLMProvider,  # noqa: ARG001
+) -> None:
+    """User A asking for User B's session via any file-op endpoint sees 404."""
+    foreign_session_id = _create_session_id(basic_user)
+
+    response = client.get(
+        _files_url(foreign_session_id),
+        headers=admin_user.headers,
+        cookies=admin_user.cookies,
+    )
+    assert response.status_code == 404

--- a/backend/tests/integration/tests/craft_api/test_messages_api.py
+++ b/backend/tests/integration/tests/craft_api/test_messages_api.py
@@ -1,0 +1,109 @@
+"""Interactive Craft turn API tests (HTTP contract half).
+
+These tests exercise the HTTP boundary for the background-turn flow:
+``POST /send-message`` starts work and returns turn metadata, while
+``GET /turns/{turn_id}/events`` is attach-only. They run in the standard
+integration matrix against the in-process app with a stubbed sandbox manager
+(see ``conftest.py``).
+
+The turn runner executes in a background thread. To keep the
+concurrent-turn-rejection assertion deterministic in-process, that test pins
+the runner inside the stub's ``send_message`` until it has issued the second
+request, so the active-turn marker is guaranteed to still be present.
+"""
+
+from __future__ import annotations
+
+import threading
+import uuid
+from collections.abc import Generator
+from uuid import UUID
+
+import pytest
+
+from onyx.server.features.build.sandbox.base import SandboxEvent
+from tests.common.craft.stubs import StubSandboxManager
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.http_client import client
+from tests.integration.common_utils.managers.build_session import BuildSessionManager
+from tests.integration.common_utils.managers.user import UserManager
+from tests.integration.common_utils.test_models import DATestLLMProvider
+from tests.integration.common_utils.test_models import DATestUser
+
+
+def test_send_message_rejects_concurrent_active_turn(
+    admin_user: DATestUser,
+    _stub_sandbox_manager: StubSandboxManager,
+    llm_provider: DATestLLMProvider,  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    body = BuildSessionManager.create(admin_user)
+    session_id = uuid.UUID(body["id"])
+
+    # Pin the background runner inside send_message so the first turn stays
+    # active while we fire the second request. The runner thread blocks on
+    # ``release`` (yielding nothing) until we let it finish.
+    release = threading.Event()
+
+    def _blocking_send_message(
+        *_args: object, **_kwargs: object
+    ) -> Generator[SandboxEvent, None, None]:
+        release.wait(timeout=30.0)
+        return
+        yield  # pragma: no cover — makes this a generator
+
+    monkeypatch.setattr(_stub_sandbox_manager, "send_message", _blocking_send_message)
+
+    try:
+        BuildSessionManager.start_turn(
+            admin_user,
+            session_id,
+            "hello",
+            client_request_id=f"req-{uuid.uuid4()}",
+        )
+
+        response = client.post(
+            f"{API_SERVER_URL}/build/sessions/{session_id}/send-message",
+            json={
+                "content": "again",
+                "client_request_id": f"req-{uuid.uuid4()}",
+            },
+            headers=admin_user.headers,
+            cookies=admin_user.cookies,
+        )
+
+        assert response.status_code == 409
+        assert response.json()["detail"] == "This session is busy with a previous turn."
+    finally:
+        release.set()
+
+
+def test_send_message_404_for_other_users_session(
+    shared_session: tuple[DATestUser, UUID],
+) -> None:
+    _owner, session_id = shared_session
+    other_user = UserManager.create(name=f"otheruser-{uuid.uuid4().hex[:8]}")
+
+    response = client.post(
+        f"{API_SERVER_URL}/build/sessions/{session_id}/send-message",
+        json={"content": "hello"},
+        headers=other_user.headers,
+        cookies=other_user.cookies,
+    )
+
+    assert response.status_code == 404
+
+
+def test_turn_events_requires_active_turn(
+    shared_session: tuple[DATestUser, UUID],
+) -> None:
+    owner, session_id = shared_session
+
+    response = client.get(
+        f"{API_SERVER_URL}/build/sessions/{session_id}/turns/{uuid.uuid4()}/events",
+        headers=owner.headers,
+        cookies=owner.cookies,
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Interactive turn is not running"

--- a/backend/tests/integration/tests/craft_api/test_scheduled_tasks_api.py
+++ b/backend/tests/integration/tests/craft_api/test_scheduled_tasks_api.py
@@ -1,0 +1,325 @@
+"""Scheduled tasks tests (HTTP contract).
+
+Integration tests for the user-facing scheduled-tasks HTTP API in
+``onyx.server.features.build.scheduled_tasks.api``.
+
+Runs in the standard integration matrix against the in-process ``TestClient``
+with a stubbed sandbox manager (see ``conftest.py``). None of these tests touch
+the sandbox at all — they only exercise task CRUD, cron compilation, run-row
+side effects, and pagination. Internal dispatcher and cleanup contracts are
+covered in
+``tests/external_dependency_unit/craft/test_scheduled_task_executor.py``; this
+file deliberately stays at the HTTP boundary and never invokes the executor
+directly.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+from uuid import UUID
+from uuid import uuid4
+
+import httpx
+from sqlalchemy import select
+
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.enums import ScheduledTaskRunStatus
+from onyx.db.enums import ScheduledTaskStatus
+from onyx.db.enums import ScheduledTaskTriggerSource
+from onyx.db.models import ScheduledTask
+from onyx.db.models import ScheduledTaskRun
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.http_client import client
+from tests.integration.common_utils.test_models import DATestUser
+
+# ---------------------------------------------------------------------------
+# Inline HTTP wrapper — kept here per the task spec (no separate manager).
+# ---------------------------------------------------------------------------
+
+
+def _url(*parts: str) -> str:
+    base = f"{API_SERVER_URL}/build/scheduled-tasks"
+    if not parts:
+        return base
+    return base + "/" + "/".join(parts)
+
+
+def _create_task(
+    user: DATestUser,
+    *,
+    name: str | None = None,
+    prompt: str = "Run the daily check.",
+    editor_mode: str = "interval",
+    editor_payload: dict[str, Any] | None = None,
+    status: ScheduledTaskStatus = ScheduledTaskStatus.ACTIVE,
+    run_immediately: bool = False,
+) -> httpx.Response:
+    body: dict[str, Any] = {
+        "name": name or f"task-{uuid4().hex[:8]}",
+        "prompt": prompt,
+        "editor_mode": editor_mode,
+        "editor_payload": editor_payload or {"unit": "hours", "every": 1},
+        "status": status.value,
+        "run_immediately": run_immediately,
+    }
+    return client.post(
+        _url(),
+        json=body,
+        headers=user.headers,
+        cookies=user.cookies,
+    )
+
+
+def _patch_task(
+    user: DATestUser, task_id: UUID, body: dict[str, Any]
+) -> httpx.Response:
+    return client.patch(
+        _url(str(task_id)),
+        json=body,
+        headers=user.headers,
+        cookies=user.cookies,
+    )
+
+
+def _delete_task(user: DATestUser, task_id: UUID) -> httpx.Response:
+    return client.delete(
+        _url(str(task_id)),
+        headers=user.headers,
+        cookies=user.cookies,
+    )
+
+
+def _run_now(user: DATestUser, task_id: UUID) -> httpx.Response:
+    return client.post(
+        _url(str(task_id), "run-now"),
+        headers=user.headers,
+        cookies=user.cookies,
+    )
+
+
+def _list_runs(
+    user: DATestUser,
+    task_id: UUID,
+    *,
+    cursor: str | None = None,
+    limit: int | None = None,
+) -> httpx.Response:
+    params: dict[str, Any] = {}
+    if cursor is not None:
+        params["cursor"] = cursor
+    if limit is not None:
+        params["limit"] = limit
+    return client.get(
+        _url(str(task_id), "runs"),
+        params=params or None,
+        headers=user.headers,
+        cookies=user.cookies,
+    )
+
+
+def _get_task_row(task_id: UUID) -> ScheduledTask | None:
+    with get_session_with_current_tenant() as db_session:
+        return db_session.execute(
+            select(ScheduledTask).where(ScheduledTask.id == task_id)
+        ).scalar_one_or_none()
+
+
+def _get_runs_for_task(task_id: UUID) -> list[ScheduledTaskRun]:
+    with get_session_with_current_tenant() as db_session:
+        return list(
+            db_session.execute(
+                select(ScheduledTaskRun)
+                .where(ScheduledTaskRun.task_id == task_id)
+                .order_by(ScheduledTaskRun.started_at.desc())
+            )
+            .scalars()
+            .all()
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_create_task_compiles_cron(admin_user: DATestUser) -> None:
+    """POST with ``editor_mode=interval`` compiles to a 5-field cron string."""
+    response = _create_task(
+        admin_user,
+        editor_mode="interval",
+        editor_payload={"unit": "hours", "every": 6},
+    )
+    response.raise_for_status()
+    body = response.json()
+    assert body["editor_mode"] == "interval"
+    # Cron is canonical 5-field; "every 6 hours" compiles to "0 */6 * * *".
+    cron = body["cron_expression"]
+    assert isinstance(cron, str)
+    assert len(cron.split()) == 5
+    # DB row carries the same cron.
+    row = _get_task_row(UUID(body["id"]))
+    assert row is not None
+    assert row.cron_expression == cron
+
+
+def test_create_task_requires_paired_editor_fields(admin_user: DATestUser) -> None:
+    """A missing required payload field is rejected.
+
+    ``editor_mode=daily_weekly`` requires ``time_of_day`` in the payload;
+    omitting it yields a Pydantic validation error → 422. The master
+    plan describes this as 400 because most validation errors emerge as
+    400, but Pydantic-level errors from FastAPI surface as 422.
+    """
+    response = _create_task(
+        admin_user,
+        editor_mode="daily_weekly",
+        editor_payload={"weekdays": [1, 3, 5]},  # missing time_of_day
+    )
+    # Pydantic-level validation errors from FastAPI surface as 422.
+    assert response.status_code == 422
+
+
+def test_create_with_run_immediately_enqueues(admin_user: DATestUser) -> None:
+    """``run_immediately=true`` creates a ``MANUAL_RUN_NOW`` run row in DB.
+
+    We don't wait for the executor; we just verify the side effect of
+    the POST: a ScheduledTaskRun row exists with
+    ``trigger_source=MANUAL_RUN_NOW`` and ``status=QUEUED``.
+    """
+    response = _create_task(admin_user, run_immediately=True)
+    response.raise_for_status()
+    task_id = UUID(response.json()["id"])
+
+    runs = _get_runs_for_task(task_id)
+    assert len(runs) >= 1
+    [run] = [
+        r for r in runs if r.trigger_source == ScheduledTaskTriggerSource.MANUAL_RUN_NOW
+    ]
+    # ``QUEUED`` is the insert-side state; the executor may have already
+    # picked it up if running. Accept anything past QUEUED, but most
+    # commonly QUEUED on freshly created.
+    assert run.status in {
+        ScheduledTaskRunStatus.QUEUED,
+        ScheduledTaskRunStatus.RUNNING,
+        ScheduledTaskRunStatus.SUCCEEDED,
+        ScheduledTaskRunStatus.FAILED,
+        ScheduledTaskRunStatus.SKIPPED,
+    }
+
+
+def test_patch_task_recomputes_next_run_at_on_schedule_change(
+    admin_user: DATestUser,
+) -> None:
+    """A schedule edit recomputes ``next_run_at``."""
+    response = _create_task(
+        admin_user,
+        editor_mode="interval",
+        editor_payload={"unit": "hours", "every": 1},
+    )
+    response.raise_for_status()
+    task_id = UUID(response.json()["id"])
+    before = _get_task_row(task_id)
+    assert before is not None
+    before_next = before.next_run_at
+
+    # PATCH the schedule to interval=days requiring time_of_day.
+    patch = _patch_task(
+        admin_user,
+        task_id,
+        {
+            "editor_mode": "interval",
+            "editor_payload": {
+                "unit": "days",
+                "every": 1,
+                "time_of_day": "03:00",
+            },
+        },
+    )
+    patch.raise_for_status()
+    after = _get_task_row(task_id)
+    assert after is not None
+    # The cron changes, and next_run_at is freshly computed by
+    # update_scheduled_task. We don't pin a specific value (it depends
+    # on now() at PATCH time and the requested schedule), but it must
+    # be either ``None`` (paused) or a UTC datetime that differs from
+    # the pre-patch value.
+    assert after.cron_expression != before.cron_expression
+    if after.status == ScheduledTaskStatus.ACTIVE:
+        assert after.next_run_at is not None
+        assert after.next_run_at != before_next
+
+
+def test_run_now_on_paused_task_allowed(admin_user: DATestUser) -> None:
+    """PAUSED task → ``run-now`` still works."""
+    response = _create_task(admin_user, status=ScheduledTaskStatus.PAUSED)
+    response.raise_for_status()
+    task_id = UUID(response.json()["id"])
+
+    response = _run_now(admin_user, task_id)
+    response.raise_for_status()
+    body = response.json()
+    assert "run_id" in body
+    assert body["status"] in {s.value for s in ScheduledTaskRunStatus}
+
+    runs = _get_runs_for_task(task_id)
+    assert any(
+        r.trigger_source == ScheduledTaskTriggerSource.MANUAL_RUN_NOW for r in runs
+    )
+
+
+def test_delete_task_is_idempotent_soft_delete(admin_user: DATestUser) -> None:
+    """Two consecutive DELETEs both succeed."""
+    response = _create_task(admin_user)
+    response.raise_for_status()
+    task_id = UUID(response.json()["id"])
+
+    first = _delete_task(admin_user, task_id)
+    assert first.status_code == 204
+
+    second = _delete_task(admin_user, task_id)
+    # The handler is documented as idempotent — second DELETE on a
+    # missing or already-deleted task returns 204.
+    assert second.status_code == 204
+
+    row = _get_task_row(task_id)
+    # Soft delete: row still exists with deleted=True.
+    assert row is not None, (
+        "Row was hard-deleted; expected soft-delete to preserve the row"
+    )
+    assert row.deleted is True
+
+
+def test_list_runs_paginates_by_started_at_cursor(admin_user: DATestUser) -> None:
+    """``GET /runs?cursor=...`` works.
+
+    Insert a couple of run rows by issuing ``run-now`` twice, then ask
+    for page-size=1 to force a non-null next cursor.
+    """
+    response = _create_task(admin_user)
+    response.raise_for_status()
+    task_id = UUID(response.json()["id"])
+
+    # Fire two manual runs so we have at least two run rows. A small
+    # sleep between them gives them distinct ``started_at`` values
+    # (server_default=now() has microsecond resolution but identical
+    # timestamps would still page correctly via the index).
+    run_one = _run_now(admin_user, task_id)
+    run_one.raise_for_status()
+    time.sleep(0.05)
+    run_two = _run_now(admin_user, task_id)
+    run_two.raise_for_status()
+
+    page_one = _list_runs(admin_user, task_id, limit=1)
+    page_one.raise_for_status()
+    page_one_body = page_one.json()
+    assert len(page_one_body["items"]) == 1
+    cursor = page_one_body["next_cursor"]
+    assert isinstance(cursor, str) and cursor
+
+    page_two = _list_runs(admin_user, task_id, cursor=cursor, limit=1)
+    page_two.raise_for_status()
+    page_two_body = page_two.json()
+    assert len(page_two_body["items"]) >= 1
+    # The two pages do not return the same run row.
+    assert page_one_body["items"][0]["id"] != page_two_body["items"][0]["id"]

--- a/backend/tests/integration/tests/craft_api/test_sessions_api.py
+++ b/backend/tests/integration/tests/craft_api/test_sessions_api.py
@@ -1,0 +1,241 @@
+"""Session lifecycle tests (HTTP contract half).
+
+These tests exercise the FE-visible session HTTP API at ``/build/sessions``.
+They run in the standard integration matrix against the in-process
+``TestClient`` with a stubbed sandbox manager (see ``conftest.py``), so session
+create/delete provision instantly without a real container.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.http_client import client
+from tests.integration.common_utils.managers.build_session import BuildSessionManager
+from tests.integration.common_utils.managers.settings import SettingsManager
+from tests.integration.common_utils.managers.user import UserManager
+from tests.integration.common_utils.test_models import DATestLLMProvider
+from tests.integration.common_utils.test_models import DATestSettings
+from tests.integration.common_utils.test_models import DATestUser
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _create_session(user: DATestUser) -> dict[str, Any]:
+    """Create a session and return the parsed response body."""
+    return BuildSessionManager.create(user)
+
+
+def _send_one_message(user: DATestUser, session_id: uuid.UUID) -> None:
+    """Send a message and wait only until the USER row is persisted.
+
+    The background-turn endpoint commits the USER message row before returning
+    turn metadata. Tests using this helper must not depend on assistant-message
+    rows being persisted.
+    """
+    BuildSessionManager.start_turn(
+        user,
+        session_id,
+        "hello",
+        client_request_id=f"session-list-{uuid.uuid4()}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_create_session_requires_auth() -> None:
+    """POST /build/sessions without an auth cookie/header is rejected."""
+    response = client.post(
+        f"{API_SERVER_URL}/build/sessions",
+        json={},
+        headers={"Content-Type": "application/json"},
+    )
+    # The build router gates access through ``require_onyx_craft_enabled`` →
+    # ``require_permission(BASIC_ACCESS)`` → ``current_user``. Onyx's
+    # ``BasicAuthenticationError`` returns 403 for unauthenticated callers
+    # (not 401). Either is acceptable so long as it's a 4xx auth failure.
+    assert response.status_code in (401, 403)
+
+
+def test_get_session_404_for_other_users_session(
+    shared_session: tuple[DATestUser, uuid.UUID],
+) -> None:
+    """Fetching another user's session by id returns 404 (ownership-gated).
+
+    Ownership-gated and scope-independent (``get_session`` filters by user id),
+    so the shared session is fine here even if a sibling flips its
+    sharing scope.
+    """
+    _owner, session_id = shared_session
+
+    other_user = UserManager.create(name=f"other-{uuid.uuid4().hex[:8]}")
+    response = client.get(
+        f"{API_SERVER_URL}/build/sessions/{session_id}",
+        headers=other_user.headers,
+        cookies=other_user.cookies,
+    )
+    assert response.status_code == 404
+
+
+def test_list_sessions_only_returns_callers_interactive_sessions(
+    admin_user: DATestUser,
+    llm_provider: DATestLLMProvider,  # noqa: ARG001
+) -> None:
+    """The sidebar listing is per-user and excludes other users' sessions.
+
+    ``get_user_build_sessions`` also filters to ``origin=INTERACTIVE`` and
+    sessions with at least one message — both are exercised here implicitly:
+    the foreign session is INTERACTIVE-with-message yet still excluded.
+    """
+    mine = _create_session(admin_user)
+    _send_one_message(admin_user, uuid.UUID(mine["id"]))
+
+    other_user = UserManager.create(name=f"other-{uuid.uuid4().hex[:8]}")
+    theirs = _create_session(other_user)
+    _send_one_message(other_user, uuid.UUID(theirs["id"]))
+
+    sessions = BuildSessionManager.list_sessions(admin_user)
+    ids = {s["id"] for s in sessions}
+    assert mine["id"] in ids
+    assert theirs["id"] not in ids
+
+
+def test_delete_session_returns_204_and_actually_deletes(
+    admin_user: DATestUser,
+    llm_provider: DATestLLMProvider,  # noqa: ARG001
+) -> None:
+    """DELETE returns 204 and a follow-up GET on the same id returns 404."""
+    body = _create_session(admin_user)
+    session_id = body["id"]
+
+    response = client.delete(
+        f"{API_SERVER_URL}/build/sessions/{session_id}",
+        headers=admin_user.headers,
+        cookies=admin_user.cookies,
+    )
+    assert response.status_code == 204
+
+    follow_up = client.get(
+        f"{API_SERVER_URL}/build/sessions/{session_id}",
+        headers=admin_user.headers,
+        cookies=admin_user.cookies,
+    )
+    assert follow_up.status_code == 404
+
+
+def test_pre_provisioned_check_returns_valid_for_empty_session(
+    admin_user: DATestUser,
+    llm_provider: DATestLLMProvider,  # noqa: ARG001
+) -> None:
+    """An empty (just-created) session reports ``valid=true`` with its id."""
+    body = _create_session(admin_user)
+    session_id = body["id"]
+
+    response = client.get(
+        f"{API_SERVER_URL}/build/sessions/{session_id}/pre-provisioned-check",
+        headers=admin_user.headers,
+        cookies=admin_user.cookies,
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["valid"] is True
+    assert payload["session_id"] == session_id
+
+
+def test_pre_provisioned_check_returns_invalid_after_first_message(
+    admin_user: DATestUser,
+    llm_provider: DATestLLMProvider,  # noqa: ARG001
+) -> None:
+    """Once a USER message exists, the same session is no longer "valid"."""
+    body = _create_session(admin_user)
+    session_id = body["id"]
+
+    _send_one_message(admin_user, uuid.UUID(session_id))
+
+    response = client.get(
+        f"{API_SERVER_URL}/build/sessions/{session_id}/pre-provisioned-check",
+        headers=admin_user.headers,
+        cookies=admin_user.cookies,
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["valid"] is False
+    assert payload["session_id"] is None
+
+
+def test_rename_session_with_null_name_uses_llm_then_fallback_chain(
+    admin_user: DATestUser,
+    llm_provider: DATestLLMProvider,  # noqa: ARG001
+) -> None:
+    """PUT /name with ``{name: null}`` resolves a non-empty name via the chain.
+
+    ``_generate_session_name`` walks three branches:
+      1. If there's no first user message → ``Build Session {id[:8]}``.
+      2. If the LLM call succeeds → the generated name (truncated to 50 chars).
+      3. If the LLM call raises → first 40 chars of the user message.
+
+    Without messages we must hit branch 1; we assert exactly that, because
+    it's the only branch with a deterministic output an HTTP-only test can
+    pin. The chain itself is unit-tested at the manager level.
+    """
+    body = _create_session(admin_user)
+    session_id = body["id"]
+
+    response = client.put(
+        f"{API_SERVER_URL}/build/sessions/{session_id}/name",
+        json={"name": None},
+        headers=admin_user.headers,
+        cookies=admin_user.cookies,
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    # Branch 1 fallback: "Build Session {id[:8]}".
+    assert payload["name"] == f"Build Session {session_id[:8]}"
+
+
+def test_limited_role_check_uses_account_type_not_permission_flags(
+    admin_user: DATestUser,  # noqa: ARG001 — needed so admin exists for SettingsManager
+) -> None:
+    """Account-type-restricted users are blocked from Craft regardless of any
+    permission grant they might have. Regression for SHA ``ac89b42b38``: that
+    commit moved the limited check off the role bit and onto ``account_type``,
+    via ``current_user`` → ``is_limited_user``.
+
+    We use the anonymous user (``account_type=AccountType.ANONYMOUS``), which
+    ``is_limited_user`` always rejects. Even with ``anonymous_user_enabled``
+    flipped to True (so the anonymous user is otherwise allowed to hit
+    public endpoints), the Craft router must still 401/403 them out.
+    """
+    try:
+        # Enable anonymous browsing so the request reaches require_permission;
+        # if we left it off, the request would fail authentication before the
+        # is_limited_user check ever ran — different regression branch.
+        SettingsManager.update_settings(
+            DATestSettings(anonymous_user_enabled=True),
+            user_performing_action=admin_user,
+        )
+
+        anon_user = UserManager.get_anonymous_user()
+
+        response = client.post(
+            f"{API_SERVER_URL}/build/sessions",
+            json={},
+            headers=anon_user.headers,
+            cookies=anon_user.cookies,
+        )
+        # current_user rejects limited account types with BasicAuthenticationError
+        # (HTTP 403); some auth-failure paths surface as 401.
+        assert response.status_code in (401, 403)
+    finally:
+        # Restore the default so subsequent tests see the normal config.
+        SettingsManager.update_settings(
+            DATestSettings(anonymous_user_enabled=False),
+            user_performing_action=admin_user,
+        )

--- a/backend/tests/integration/tests/craft_api/test_upload_api.py
+++ b/backend/tests/integration/tests/craft_api/test_upload_api.py
@@ -1,0 +1,57 @@
+"""File upload tests (HTTP contract half).
+
+Pins the upload endpoint's auth and cross-user-ownership boundaries. Both are
+resolved before any file write, so they run in the standard integration matrix
+against the in-process app with a stubbed sandbox manager (see ``conftest.py``).
+The cap enforcement (per-file / count / cumulative) and the real round-trip
+write+download checks need the real sandbox manager and stay in the compose
+lane.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.http_client import client
+from tests.integration.common_utils.test_models import DATestUser
+
+
+def _upload_url(session_id: UUID) -> str:
+    return f"{API_SERVER_URL}/build/sessions/{session_id}/upload"
+
+
+def test_upload_endpoint_requires_auth(
+    shared_session: tuple[DATestUser, UUID],
+) -> None:
+    """POST with no auth token returns 401 (or 403)."""
+    # The session just needs to exist; we then strip auth.
+    _owner, session_id = shared_session
+
+    response = client.post(
+        _upload_url(session_id),
+        files={"file": ("hello.txt", b"hello", "application/octet-stream")},
+        headers={},
+        cookies=None,
+    )
+    # Onyx auth middleware returns either 401 or 403 for unauthenticated
+    # requests against BASIC_ACCESS endpoints.
+    assert response.status_code in (401, 403)
+
+
+def test_upload_endpoint_404_for_other_users_session(
+    shared_session: tuple[DATestUser, UUID], basic_user: DATestUser
+) -> None:
+    """Uploading to another user's session returns 404."""
+    _owner, foreign_session_id = shared_session
+
+    headers = {
+        k: v for k, v in basic_user.headers.items() if k.lower() != "content-type"
+    }
+    response = client.post(
+        _upload_url(foreign_session_id),
+        files={"file": ("hello.txt", b"hi", "application/octet-stream")},
+        headers=headers,
+        cookies=basic_user.cookies,
+    )
+    assert response.status_code == 404

--- a/backend/tests/integration/tests/craft_api/test_user_library_api.py
+++ b/backend/tests/integration/tests/craft_api/test_user_library_api.py
@@ -1,0 +1,56 @@
+"""User library tests (HTTP contract half).
+
+Pins the cross-user ownership boundary on the user-library endpoints in
+``onyx.server.features.build.user_library.api``. The ownership check resolves
+without any sandbox interaction, so it runs in the standard integration matrix
+against the in-process app with a stubbed sandbox manager (see ``conftest.py``).
+The real S3/zip persistence + extraction-cap tests stay in the compose lane.
+
+Reuses the shared HTTP helpers in ``tests.integration.tests.craft`` so the two
+lanes drive the user-library endpoints identically.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import uuid4
+
+from tests.integration.common_utils.test_models import DATestUser
+from tests.integration.tests.craft.user_library_http import delete_user_library_file
+from tests.integration.tests.craft.user_library_http import list_user_library_tree
+from tests.integration.tests.craft.user_library_http import upload_user_library_files
+
+
+def _find_doc_by_name(
+    entries: list[dict[str, Any]], name: str
+) -> dict[str, Any] | None:
+    return next((e for e in entries if e.get("name") == name), None)
+
+
+def test_cross_user_access_returns_404(
+    admin_user: DATestUser, basic_user: DATestUser
+) -> None:
+    """Foreign user → 404 on any file op.
+
+    The ownership check in ``_verify_ownership_and_get_document`` rejects
+    requests whose document id doesn't carry the calling user's id in
+    the ``CRAFT_FILE__{user_id}__{hash}`` prefix. The user-facing code
+    raises 403 for "not your file" and 404 for "doesn't exist" — the
+    test plan calls out 404 (the safer choice, since revealing 403
+    leaks existence). We accept either; the security-critical assertion
+    is that the foreign user cannot read or mutate the file.
+    """
+    filename = f"cross-{uuid4().hex[:6]}.txt"
+    response = upload_user_library_files(
+        admin_user, [(filename, b"private", "text/plain")]
+    )
+    response.raise_for_status()
+    document_id = response.json()["entries"][0]["id"]
+
+    # basic_user cannot delete admin's file.
+    delete_response = delete_user_library_file(basic_user, document_id)
+    assert delete_response.status_code in (403, 404)
+
+    # And basic_user's tree does not contain admin's row.
+    basic_tree = list_user_library_tree(basic_user)
+    assert all(e["id"] != document_id for e in basic_tree)

--- a/backend/tests/integration/tests/craft_api/test_webapp_proxy.py
+++ b/backend/tests/integration/tests/craft_api/test_webapp_proxy.py
@@ -1,0 +1,325 @@
+"""Webapp proxy tests (security + UX).
+
+The proxy lives at ``GET /api/build/sessions/{session_id}/webapp/{path:path}``
+and proxies to the per-session Next.js server inside the sandbox. The auth
+checks (``_check_webapp_access``) and the offline-page rendering are
+exercised here against the in-process app with a stubbed sandbox manager.
+
+Runs in the standard integration matrix. No real sandbox or Next.js process
+exists: the stub's ``get_webapp_url`` returns an unreachable URL, so every
+proxy request beyond the auth/access check surfaces as the branded offline
+fallback. That's enough to assert routing, scope checks, and the offline path.
+The full upstream body-rewrite/HMR happy path is covered in the real-sandbox
+k8s lane.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+from uuid import uuid4
+
+import httpx
+
+from onyx.db.enums import SharingScope
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.http_client import client
+from tests.integration.common_utils.managers.build_session import BuildSessionManager
+from tests.integration.common_utils.test_models import DATestLLMProvider
+from tests.integration.common_utils.test_models import DATestUser
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _webapp_url(session_id: UUID, path: str = "") -> str:
+    base = f"{API_SERVER_URL}/build/sessions/{session_id}/webapp"
+    return f"{base}/{path.lstrip('/')}" if path else base
+
+
+def _create_session(user: DATestUser) -> dict[str, Any]:
+    """Create an empty build session for ``user``. Returns the session dict.
+
+    The session has a sandbox row + an allocated ``nextjs_port``, but the
+    stubbed ``get_webapp_url`` points at an unreachable host — so every proxy
+    request beyond the auth/access check surfaces as the branded offline
+    fallback. That's enough to assert routing, scope checks, and the offline
+    path.
+    """
+    return BuildSessionManager.create(user)
+
+
+def _set_scope(user: DATestUser, session_id: UUID, scope: SharingScope) -> None:
+    BuildSessionManager.set_sharing(user, session_id, scope)
+
+
+def _unauth_get(
+    session_id: UUID,
+    path: str = "",
+    follow_redirects: bool = False,
+) -> httpx.Response:
+    """GET the proxy URL with no auth headers/cookies."""
+    return client.get(
+        _webapp_url(session_id, path),
+        follow_redirects=follow_redirects,
+    )
+
+
+def _auth_get(
+    user: DATestUser,
+    session_id: UUID,
+    path: str = "",
+    follow_redirects: bool = False,
+) -> httpx.Response:
+    """GET the proxy URL with ``user``'s auth headers/cookies."""
+    return client.get(
+        _webapp_url(session_id, path),
+        headers=user.headers,
+        cookies=user.cookies,
+        follow_redirects=follow_redirects,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Auth / scope checks (the part of the proxy that doesn't need an upstream)
+# ---------------------------------------------------------------------------
+
+
+def test_proxy_requires_auth_when_private(
+    shared_session: tuple[DATestUser, UUID],
+) -> None:
+    """Private session + no token → proxy returns 401-equivalent.
+
+    The handler raises ``HTTPException(401)`` from ``_check_webapp_access``;
+    the surrounding code catches that and issues a 302 to ``/auth/login``
+    instead of bubbling the bare 401 so the browser UX is sensible.
+    Either response (401 status or 302 to login) means "auth required."
+    """
+    owner, session_id = shared_session
+    # Default scope is PRIVATE; assert + be explicit anyway.
+    _set_scope(owner, session_id, SharingScope.PRIVATE)
+
+    response = _unauth_get(session_id, follow_redirects=False)
+
+    if response.status_code == 302:
+        assert "/auth/login" in response.headers.get("location", "")
+    else:
+        assert response.status_code == 401
+
+
+def test_proxy_allows_org_user_when_public_org(
+    shared_session: tuple[DATestUser, UUID],
+    basic_user: DATestUser,
+) -> None:
+    """Different user in same tenant + ``public_org`` → access check passes.
+
+    Auth check passing means the request reaches ``_proxy_request``;
+    since the upstream Next.js pod is not running, the proxy returns the
+    branded offline HTML (status 503, ``text/html``). What we are
+    asserting is that the request was *not* rejected by the access check
+    (no 401, no 302 to login).
+    """
+    owner, session_id = shared_session
+    _set_scope(owner, session_id, SharingScope.PUBLIC_ORG)
+
+    response = client.get(
+        _webapp_url(session_id),
+        headers=basic_user.headers,
+        cookies=basic_user.cookies,
+        follow_redirects=False,
+    )
+
+    assert response.status_code != 401
+    # Not a redirect to login either.
+    location = response.headers.get("location", "")
+    assert "/auth/login" not in location
+
+
+def test_proxy_blocks_other_tenant_when_public_org(
+    shared_session: tuple[DATestUser, UUID],
+) -> None:
+    """Cross-tenant access on ``public_org`` → blocked.
+
+    The integration test deployment is single-tenant, so there is no
+    real "other tenant" we can construct here. We approximate the same
+    code path by hitting the proxy with a forged but otherwise valid
+    auth cookie shape that does not resolve to a real user — the auth
+    middleware treats this as anonymous and the proxy applies the same
+    ``public_org`` rule (anonymous request → 401, since
+    ``public_org`` requires auth).
+    """
+    owner, session_id = shared_session
+    _set_scope(owner, session_id, SharingScope.PUBLIC_ORG)
+
+    # Forged cookie: present but not a valid session for any user.
+    response = client.get(
+        _webapp_url(session_id),
+        cookies={"fastapiusersauth": "not-a-real-token"},
+        follow_redirects=False,
+    )
+
+    # Either 401, or a redirect to login — both mean "not allowed."
+    if response.status_code == 302:
+        assert "/auth/login" in response.headers.get("location", "")
+    else:
+        assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Header stripping + offline page (no upstream required)
+# ---------------------------------------------------------------------------
+
+
+def test_proxy_strips_set_cookie_header(
+    shared_session: tuple[DATestUser, UUID],
+) -> None:
+    """``set-cookie`` is never forwarded from upstream.
+
+    Without a live upstream, the proxy falls back to the offline HTML
+    response. That response is generated locally by ``_offline_html_response``
+    and never contains a ``Set-Cookie`` header — which is exactly the
+    invariant we care about for security: no upstream-controlled cookie
+    can ever reach the parent Onyx origin via this path.
+    """
+    owner, session_id = shared_session
+
+    response = _auth_get(owner, session_id, follow_redirects=False)
+
+    # Lowercased header name lookup (requests does case-insensitive matching).
+    assert "set-cookie" not in {k.lower() for k in response.headers}
+
+
+def test_proxy_offline_html_does_not_leak_nextjs_asset_paths(
+    shared_session: tuple[DATestUser, UUID],
+) -> None:
+    """The offline fallback must not leak root-scoped Next.js asset URLs."""
+    owner, session_id = shared_session
+
+    response = _auth_get(owner, session_id, follow_redirects=False)
+    assert "text/html" in response.headers.get("content-type", "").lower()
+    body = response.text
+    assert '"/_next/' not in body
+    assert "'/_next/" not in body
+
+
+def test_proxy_offline_html_does_not_include_hmr_shim(
+    shared_session: tuple[DATestUser, UUID],
+) -> None:
+    """The offline fallback should stay independent of Next.js dev HMR."""
+    owner, session_id = shared_session
+
+    response = _auth_get(owner, session_id, follow_redirects=False)
+    body = response.text
+    assert "__WEBAPP_BASE__" not in body
+
+
+def test_proxy_502_renders_branded_offline_page(
+    shared_session: tuple[DATestUser, UUID],
+) -> None:
+    """Pod down → branded offline HTML.
+
+    The session has a sandbox row + allocated port but the stubbed
+    ``get_webapp_url`` resolves to an unreachable host; that's exactly the
+    condition the offline fallback was written for. The response is HTML with
+    a 5xx status. The exact status (503 by ``_offline_html_response``) is what
+    the proxy returns when it can't reach the upstream — the underlying
+    ``HTTPException`` raised inside ``_proxy_request`` carries 502 before the
+    offline page converts it to a 503 HTML response.
+    """
+    owner, session_id = shared_session
+
+    response = _auth_get(owner, session_id, follow_redirects=False)
+
+    assert response.status_code in (502, 503, 504)
+    assert "text/html" in response.headers.get("content-type", "").lower()
+    # Branded marker: the template is a Craft-styled offline page. We
+    # don't pin exact copy (would couple to the template too tightly);
+    # instead assert the page is non-trivial HTML.
+    body = response.text
+    assert "<html" in body.lower() or "<body" in body.lower()
+
+
+# ---------------------------------------------------------------------------
+# Route precedence + cross-session isolation regressions
+# ---------------------------------------------------------------------------
+
+
+def test_webapp_download_route_not_shadowed_by_catchall(
+    shared_session: tuple[DATestUser, UUID],
+) -> None:
+    """``/webapp-download`` resolves to the zip endpoint, not the catch-all.
+
+    Regression for SHA ``e213853f63``: the catch-all proxy route
+    ``/{session_id}/webapp/{path:path}`` once shadowed the specific
+    ``/{session_id}/webapp-download`` route. The two are visually
+    similar but functionally distinct — one returns the offline page,
+    the other a zip.
+
+    We hit ``/webapp-download`` as the *owner* with auth, so the
+    download endpoint can be reached. The catch-all proxy would return
+    HTML (the offline page) or a 5xx; the zip endpoint returns either
+    a zip (200, ``application/zip``) or a 404 with JSON detail. Either
+    is acceptable evidence that the *zip* endpoint matched.
+    """
+    owner, session_id = shared_session
+
+    response = client.get(
+        f"{API_SERVER_URL}/build/sessions/{session_id}/webapp-download",
+        headers=owner.headers,
+        cookies=owner.cookies,
+        follow_redirects=False,
+    )
+
+    content_type = response.headers.get("content-type", "").lower()
+    # If the catch-all proxy had shadowed us we'd get text/html (offline
+    # page). The zip endpoint returns application/zip on success or
+    # application/json on a 404. Either rules out the proxy match.
+    assert "text/html" not in content_type, (
+        "webapp-download was shadowed by the catch-all proxy route "
+        "(regression for e213853f63)"
+    )
+
+
+def test_webapp_assets_isolated_across_sessions(
+    admin_user: DATestUser,
+    basic_user: DATestUser,
+    llm_provider: DATestLLMProvider,  # noqa: ARG001
+) -> None:
+    """User A's webapp asset URL cannot leak into user B's session.
+
+    Regression for SHA ``ab9e3e5338``. Two sessions owned by two users
+    each carry their own ``session_id`` in the proxy URL; an asset URL
+    issued for session A must not be servable as part of session B's
+    proxy mount, because each session's filesystem (and Next.js port)
+    is owned by a different sandbox.
+
+    Concretely: build a "leaky" asset URL by taking session A's proxy
+    path and substituting session B's id. Hitting that URL as user B
+    (the owner of B) must not transparently fetch A's bytes — at best
+    it triggers B's own offline page or its own routing logic, but it
+    must not serve content from A's sandbox.
+
+    Provisions its own two sessions (two distinct users), so it does not
+    use ``shared_session``.
+    """
+    session_a = _create_session(admin_user)
+    session_b = _create_session(basic_user)
+    session_a_id = UUID(session_a["id"])
+    session_b_id = UUID(session_b["id"])
+
+    asset_path = f"_next/static/{uuid4().hex}/leak.js"
+
+    response_a = _auth_get(admin_user, session_a_id, asset_path)
+    response_b = _auth_get(basic_user, session_b_id, asset_path)
+
+    # Each session's proxy must respond from its own sandbox; the two
+    # responses share a *structure* (both offline pages, no upstream)
+    # but neither must be the literal content of the other session's
+    # asset. The check we *can* make at this layer is that each
+    # response's body, if non-trivial, mentions only its own session
+    # id in any HMR/asset rewriting, and neither leaks the other's id.
+    body_a = response_a.text
+    body_b = response_b.text
+    assert str(session_b_id) not in body_a
+    assert str(session_a_id) not in body_b


### PR DESCRIPTION
## Description

Adds a split HTTP-only Craft API integration test lane covering sessions, messages, uploads/file ops, scheduled tasks, webapp proxy behavior, and user library APIs.

This keeps the API-facing tests reviewable independently from the larger Craft k8s integration work and limits the shared surface to the user library HTTP helper.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new HTTP-only Craft API integration lane that runs against the in-process app with a stubbed sandbox to validate endpoint contracts and security boundaries. This keeps API-facing tests fast, hermetic, and separate from the k8s lane.

- **New Features**
  - Added `backend/tests/integration/tests/craft_api` suite with `conftest.py` installing a configured `StubSandboxManager` and disabling executor enqueue for scheduled tasks.
  - Sessions and messages: create/get/list/delete, pre-provisioned check, rename fallback, auth/ownership checks, concurrent-turn rejection, and event preconditions.
  - Uploads, file ops, and user library: auth and cross-user isolation, hidden-entry filtering, `opencode.json` hiding; shared HTTP helpers (`upload_user_library_files`, `list_user_library_tree`, `delete_user_library_file`). 
  - Scheduled tasks and webapp proxy: task CRUD, cron compilation, `run-now` enqueue with DB assertions, cursor pagination; proxy auth/scope rules, offline fallback HTML, header stripping, route precedence, and cross-session isolation.

<sup>Written for commit b4c42bc31f907c418acfb2ff4db0558ef252eaf6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

