### PR TITLE
feat(db): support TLS for Postgres with server certificate verification

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,5 +1,6 @@
 from typing import Any
 from onyx.db.engine.iam_auth import get_iam_auth_token
+from onyx.db.engine.pg_ssl import create_pg_ssl_context
 from onyx.configs.app_configs import USE_IAM_AUTH
 from onyx.configs.app_configs import POSTGRES_HOST
 from onyx.configs.app_configs import POSTGRES_PORT
@@ -270,6 +271,7 @@ async def run_async_migrations() -> None:
     engine = create_async_engine(
         build_connection_string(),
         poolclass=pool.NullPool,
+        connect_args={"ssl": create_pg_ssl_context()},
     )
 
     if USE_IAM_AUTH:

--- a/backend/alembic_tenants/env.py
+++ b/backend/alembic_tenants/env.py
@@ -6,6 +6,7 @@ from sqlalchemy.engine import Connection
 from sqlalchemy.ext.asyncio import create_async_engine
 
 from alembic import context
+from onyx.db.engine.pg_ssl import create_pg_ssl_context
 from onyx.db.engine.sql_engine import build_connection_string
 from onyx.db.models import PublicBase
 
@@ -77,6 +78,7 @@ async def run_async_migrations() -> None:
     connectable = create_async_engine(
         build_connection_string(),
         poolclass=pool.NullPool,
+        connect_args={"ssl": create_pg_ssl_context()},
     )
 
     async with connectable.connect() as connection:

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -614,6 +614,15 @@ elif POSTGRES_SSLMODE:
             "verify the server certificate; use verify-ca or verify-full to "
             "verify against the CA bundle."
         )
+elif POSTGRES_SSLROOTCERT:
+    # A CA bundle without a mode is dead config: SSL stays off and the
+    # connection runs unverified despite the operator supplying a cert. Fail
+    # loudly so this can't masquerade as a verified connection.
+    raise ValueError(
+        "POSTGRES_SSLROOTCERT is set but POSTGRES_SSLMODE is not. The CA bundle "
+        "is only used by a verifying mode; set POSTGRES_SSLMODE=verify-ca or "
+        "verify-full (or unset POSTGRES_SSLROOTCERT)."
+    )
 
 # Redis IAM authentication - enables IAM-based authentication for Redis ElastiCache
 # Note: This is separate from RDS IAM auth as they use different authentication mechanisms

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -559,29 +559,61 @@ POSTGRES_TCP_KEEPALIVES_COUNT = int(
     os.environ.get("POSTGRES_TCP_KEEPALIVES_COUNT") or 5
 )
 
+# RDS IAM authentication - enables IAM-based authentication for PostgreSQL
+USE_IAM_AUTH = os.getenv("USE_IAM_AUTH", "False").lower() == "true"
+
 # TLS for non-IAM PostgreSQL connections.
 #
 # POSTGRES_SSLMODE follows libpq's vocabulary. Only `verify-ca` / `verify-full`
-# actually authenticate the server (and need a CA bundle to verify against);
-# `require` encrypts but does NOT protect against a man-in-the-middle.
-# Ignored when USE_IAM_AUTH is true (IAM already enforces its own TLS).
+# authenticate the server (and require POSTGRES_SSLROOTCERT to verify against);
+# `require` encrypts but does NOT protect against a man-in-the-middle. All of
+# this is ignored when USE_IAM_AUTH is true (IAM enforces its own TLS).
 POSTGRES_SSLMODE: str | None = os.environ.get("POSTGRES_SSLMODE") or None
-# Path to the CA bundle used to verify the server certificate for
-# `verify-ca` / `verify-full`. Required by most managed providers (RDS, Cloud
-# SQL, Azure) whose server certs don't chain to a system-trusted CA.
+# Path to the CA bundle used to verify the server certificate for `verify-ca` /
+# `verify-full`. Required by managed providers (RDS, Cloud SQL, Azure) whose
+# server certs don't chain to a system-trusted CA; point it at the system bundle
+# if the server uses a publicly-trusted certificate.
 POSTGRES_SSLROOTCERT: str | None = os.environ.get("POSTGRES_SSLROOTCERT") or None
 
 _VALID_POSTGRES_SSLMODES = frozenset(
     {"disable", "allow", "prefer", "require", "verify-ca", "verify-full"}
 )
-if POSTGRES_SSLMODE and POSTGRES_SSLMODE not in _VALID_POSTGRES_SSLMODES:
-    raise ValueError(
-        f"Invalid POSTGRES_SSLMODE={POSTGRES_SSLMODE!r}. "
-        f"Must be one of: {sorted(_VALID_POSTGRES_SSLMODES)}"
-    )
+_CA_VERIFYING_SSLMODES = frozenset({"verify-ca", "verify-full"})
 
-# RDS IAM authentication - enables IAM-based authentication for PostgreSQL
-USE_IAM_AUTH = os.getenv("USE_IAM_AUTH", "False").lower() == "true"
+if USE_IAM_AUTH:
+    # IAM auth manages the database TLS connection itself, so the explicit
+    # POSTGRES_SSL* settings are ignored — warn rather than silently drop them.
+    if POSTGRES_SSLMODE or POSTGRES_SSLROOTCERT:
+        logger.warning(
+            "USE_IAM_AUTH is enabled; ignoring POSTGRES_SSLMODE / "
+            "POSTGRES_SSLROOTCERT (IAM auth manages the database TLS connection)."
+        )
+elif POSTGRES_SSLMODE:
+    if POSTGRES_SSLMODE not in _VALID_POSTGRES_SSLMODES:
+        raise ValueError(
+            f"Invalid POSTGRES_SSLMODE={POSTGRES_SSLMODE!r}. "
+            f"Must be one of: {sorted(_VALID_POSTGRES_SSLMODES)}"
+        )
+    if POSTGRES_SSLMODE in _CA_VERIFYING_SSLMODES and not POSTGRES_SSLROOTCERT:
+        # Without a CA bundle these modes can't verify the server cert: libpq
+        # errors out and asyncpg silently falls back to the system trust store.
+        # Fail loudly so the intended CA-pinned trust model is explicit.
+        raise ValueError(
+            f"POSTGRES_SSLMODE={POSTGRES_SSLMODE!r} verifies the server "
+            "certificate and requires POSTGRES_SSLROOTCERT (path to the CA "
+            "bundle). Set it to your provider's CA, or to the system CA bundle "
+            "if the server uses a publicly-trusted certificate."
+        )
+    if POSTGRES_SSLROOTCERT and not os.path.exists(POSTGRES_SSLROOTCERT):
+        raise ValueError(
+            f"POSTGRES_SSLROOTCERT={POSTGRES_SSLROOTCERT!r} does not exist."
+        )
+    if POSTGRES_SSLMODE == "require" and POSTGRES_SSLROOTCERT:
+        logger.warning(
+            "POSTGRES_SSLROOTCERT is set but POSTGRES_SSLMODE=require does not "
+            "verify the server certificate; use verify-ca or verify-full to "
+            "verify against the CA bundle."
+        )
 
 # Redis IAM authentication - enables IAM-based authentication for Redis ElastiCache
 # Note: This is separate from RDS IAM auth as they use different authentication mechanisms

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -559,6 +559,27 @@ POSTGRES_TCP_KEEPALIVES_COUNT = int(
     os.environ.get("POSTGRES_TCP_KEEPALIVES_COUNT") or 5
 )
 
+# TLS for non-IAM PostgreSQL connections.
+#
+# POSTGRES_SSLMODE follows libpq's vocabulary. Only `verify-ca` / `verify-full`
+# actually authenticate the server (and need a CA bundle to verify against);
+# `require` encrypts but does NOT protect against a man-in-the-middle.
+# Ignored when USE_IAM_AUTH is true (IAM already enforces its own TLS).
+POSTGRES_SSLMODE: str | None = os.environ.get("POSTGRES_SSLMODE") or None
+# Path to the CA bundle used to verify the server certificate for
+# `verify-ca` / `verify-full`. Required by most managed providers (RDS, Cloud
+# SQL, Azure) whose server certs don't chain to a system-trusted CA.
+POSTGRES_SSLROOTCERT: str | None = os.environ.get("POSTGRES_SSLROOTCERT") or None
+
+_VALID_POSTGRES_SSLMODES = frozenset(
+    {"disable", "allow", "prefer", "require", "verify-ca", "verify-full"}
+)
+if POSTGRES_SSLMODE and POSTGRES_SSLMODE not in _VALID_POSTGRES_SSLMODES:
+    raise ValueError(
+        f"Invalid POSTGRES_SSLMODE={POSTGRES_SSLMODE!r}. "
+        f"Must be one of: {sorted(_VALID_POSTGRES_SSLMODES)}"
+    )
+
 # RDS IAM authentication - enables IAM-based authentication for PostgreSQL
 USE_IAM_AUTH = os.getenv("USE_IAM_AUTH", "False").lower() == "true"
 

--- a/backend/onyx/db/engine/async_sql_engine.py
+++ b/backend/onyx/db/engine/async_sql_engine.py
@@ -19,8 +19,8 @@ from onyx.configs.app_configs import POSTGRES_POOL_RECYCLE
 from onyx.configs.app_configs import POSTGRES_PORT
 from onyx.configs.app_configs import POSTGRES_USE_NULL_POOL
 from onyx.configs.app_configs import POSTGRES_USER
-from onyx.db.engine.iam_auth import create_ssl_context_if_iam
 from onyx.db.engine.iam_auth import get_iam_auth_token
+from onyx.db.engine.pg_ssl import create_pg_ssl_context
 from onyx.db.engine.sql_engine import ASYNC_DB_API
 from onyx.db.engine.sql_engine import build_connection_string
 from onyx.db.engine.sql_engine import is_valid_schema_name
@@ -47,7 +47,7 @@ def get_sqlalchemy_async_engine() -> AsyncEngine:
         if app_name:
             connect_args["server_settings"] = {"application_name": app_name}
 
-        connect_args["ssl"] = create_ssl_context_if_iam()
+        connect_args["ssl"] = create_pg_ssl_context()
 
         # Disable asyncpg's named prepared-statement cache. Cache-vs-server
         # desync produces intermittent `MissingGreenlet` /
@@ -87,7 +87,7 @@ def get_sqlalchemy_async_engine() -> AsyncEngine:
                 user = POSTGRES_USER
                 token = get_iam_auth_token(host, port, user, AWS_REGION_NAME)
                 cparams["password"] = token
-                cparams["ssl"] = create_ssl_context_if_iam()
+                cparams["ssl"] = create_pg_ssl_context()
 
     return _ASYNC_ENGINE
 

--- a/backend/onyx/db/engine/pg_ssl.py
+++ b/backend/onyx/db/engine/pg_ssl.py
@@ -63,15 +63,19 @@ def create_pg_ssl_context() -> ssl.SSLContext | str | None:
         # allow / prefer — let asyncpg decide, with plaintext fallback.
         return POSTGRES_SSLMODE
 
-    context = ssl.create_default_context(cafile=POSTGRES_SSLROOTCERT or None)
-    if POSTGRES_SSLMODE == "verify-full":
-        context.check_hostname = True
-        context.verify_mode = ssl.CERT_REQUIRED
-    elif POSTGRES_SSLMODE == "verify-ca":
-        context.check_hostname = False
-        context.verify_mode = ssl.CERT_REQUIRED
-    else:  # require — encrypt without verifying the server identity.
-        # check_hostname must be cleared before relaxing verify_mode.
+    if POSTGRES_SSLMODE == "require":
+        # Encrypt without verifying the server identity. No CA bundle is loaded
+        # because `require` never verifies it. check_hostname must be cleared
+        # before relaxing verify_mode.
+        context = ssl.create_default_context()
         context.check_hostname = False
         context.verify_mode = ssl.CERT_NONE
+        return context
+
+    # verify-ca / verify-full — verify the server cert against the CA bundle.
+    # POSTGRES_SSLROOTCERT is guaranteed set for these modes by the config
+    # validation in app_configs.
+    context = ssl.create_default_context(cafile=POSTGRES_SSLROOTCERT)
+    context.check_hostname = POSTGRES_SSLMODE == "verify-full"
+    context.verify_mode = ssl.CERT_REQUIRED
     return context

--- a/backend/onyx/db/engine/pg_ssl.py
+++ b/backend/onyx/db/engine/pg_ssl.py
@@ -1,0 +1,77 @@
+"""Single source of truth for PostgreSQL TLS configuration.
+
+Two drivers, two mechanisms:
+
+- psycopg2 (sync) speaks libpq directly, so it takes ``sslmode`` / ``sslrootcert``
+  as ``connect_args`` keys.
+- asyncpg (async) does NOT accept libpq ``sslmode`` keys. Verifying against a
+  custom CA requires an ``ssl.SSLContext`` passed as ``connect_args["ssl"]``;
+  passing the bare mode string would only use the system CA store and ignore our
+  bundle.
+
+IAM auth (when enabled) always takes precedence — it enforces its own TLS — so
+the explicit ``POSTGRES_SSLMODE`` / ``POSTGRES_SSLROOTCERT`` settings only apply
+when IAM is off.
+"""
+
+import functools
+import ssl
+
+from onyx.configs.app_configs import POSTGRES_SSLMODE
+from onyx.configs.app_configs import POSTGRES_SSLROOTCERT
+from onyx.configs.app_configs import USE_IAM_AUTH
+from onyx.db.engine.iam_auth import create_ssl_context_if_iam
+
+# Modes that require an encrypted connection and therefore an explicit
+# SSLContext on the asyncpg side.
+_ENFORCED_SSL_MODES = frozenset({"require", "verify-ca", "verify-full"})
+
+
+def pg_ssl_psycopg2_connect_args() -> dict[str, str]:
+    """libpq SSL params for the sync psycopg2 engine.
+
+    Empty when IAM auth is enabled (the IAM ``do_connect`` listener sets
+    ``sslmode`` / ``sslrootcert`` itself) or when no explicit SSL is configured.
+    """
+    if USE_IAM_AUTH or not POSTGRES_SSLMODE:
+        return {}
+    args = {"sslmode": POSTGRES_SSLMODE}
+    if POSTGRES_SSLROOTCERT:
+        args["sslrootcert"] = POSTGRES_SSLROOTCERT
+    return args
+
+
+@functools.cache
+def create_pg_ssl_context() -> ssl.SSLContext | str | None:
+    """SSL config for the asyncpg engine (and async Alembic), assigned to
+    ``connect_args["ssl"]``.
+
+    Returns:
+      - an ``ssl.SSLContext`` for IAM auth and for ``require`` / ``verify-ca`` /
+        ``verify-full`` (the latter two verifying against ``POSTGRES_SSLROOTCERT``)
+      - the raw mode string for ``allow`` / ``prefer`` so asyncpg performs its
+        native opportunistic-TLS-with-plaintext-fallback
+      - ``None`` for ``disable`` / unset (no SSL)
+    """
+    if USE_IAM_AUTH:
+        return create_ssl_context_if_iam()
+
+    if not POSTGRES_SSLMODE or POSTGRES_SSLMODE == "disable":
+        return None
+
+    if POSTGRES_SSLMODE not in _ENFORCED_SSL_MODES:
+        # allow / prefer — let asyncpg decide, with plaintext fallback.
+        return POSTGRES_SSLMODE
+
+    context = ssl.create_default_context(cafile=POSTGRES_SSLROOTCERT or None)
+    if POSTGRES_SSLMODE == "verify-full":
+        context.check_hostname = True
+        context.verify_mode = ssl.CERT_REQUIRED
+    elif POSTGRES_SSLMODE == "verify-ca":
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_REQUIRED
+    else:  # require — encrypt without verifying the server identity.
+        # check_hostname must be cleared before relaxing verify_mode.
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_NONE
+    return context

--- a/backend/onyx/db/engine/sql_engine.py
+++ b/backend/onyx/db/engine/sql_engine.py
@@ -32,6 +32,7 @@ from onyx.configs.app_configs import POSTGRES_USE_NULL_POOL
 from onyx.configs.app_configs import POSTGRES_USER
 from onyx.configs.constants import POSTGRES_UNKNOWN_APP_NAME
 from onyx.db.engine.iam_auth import provide_iam_token
+from onyx.db.engine.pg_ssl import pg_ssl_psycopg2_connect_args
 from onyx.server.utils import BasicAuthenticationError
 from onyx.utils.logger import setup_logger
 from shared_configs.configs import MULTI_TENANT
@@ -89,6 +90,7 @@ def _merge_psycopg2_connect_args(
     caller_connect_args = extra_engine_kwargs.pop("connect_args", None) or {}
     merged: dict[str, Any] = {
         **psycopg2_keepalive_connect_args(),
+        **pg_ssl_psycopg2_connect_args(),
         **caller_connect_args,
     }
     return merged or None

--- a/backend/tests/unit/onyx/db/engine/test_postgres_ssl.py
+++ b/backend/tests/unit/onyx/db/engine/test_postgres_ssl.py
@@ -1,0 +1,164 @@
+import importlib
+import os
+import ssl
+from types import ModuleType
+from unittest.mock import patch
+
+import certifi
+import pytest
+
+# A real, parseable CA bundle so `verify-ca` / `verify-full` can actually load
+# certs (the resolution logic refuses to fabricate a context without one).
+_CA_BUNDLE = certifi.where()
+
+
+def _reload_pg_ssl() -> ModuleType:
+    """Reload app_configs then pg_ssl so both pick up freshly-parsed env vars
+    (each binds the POSTGRES_SSL* constants at import time)."""
+    import onyx.configs.app_configs as app_configs
+
+    importlib.reload(app_configs)
+    import onyx.db.engine.pg_ssl as module
+
+    return importlib.reload(module)
+
+
+def _clear_ssl_env() -> None:
+    for var in ("POSTGRES_SSLMODE", "POSTGRES_SSLROOTCERT", "USE_IAM_AUTH"):
+        os.environ.pop(var, None)
+
+
+@pytest.fixture(autouse=True)
+def _restore_modules_after_test() -> object:
+    """These tests reload app_configs / pg_ssl with custom env bound at import
+    time. Restore both to their default (clean-env) state afterwards so the
+    module-level constants don't leak into other test files in the session."""
+    yield
+    _clear_ssl_env()
+    _reload_pg_ssl()
+
+
+# --- psycopg2 (sync) connect_args ----------------------------------------
+
+
+def test_psycopg2_args_empty_when_unset() -> None:
+    with patch.dict(os.environ, {}, clear=False):
+        _clear_ssl_env()
+        module = _reload_pg_ssl()
+        assert module.pg_ssl_psycopg2_connect_args() == {}
+
+
+def test_psycopg2_args_require_has_no_rootcert() -> None:
+    with patch.dict(os.environ, {}, clear=False):
+        _clear_ssl_env()
+        os.environ["POSTGRES_SSLMODE"] = "require"
+        module = _reload_pg_ssl()
+        assert module.pg_ssl_psycopg2_connect_args() == {"sslmode": "require"}
+
+
+def test_psycopg2_args_verify_full_includes_rootcert() -> None:
+    with patch.dict(os.environ, {}, clear=False):
+        _clear_ssl_env()
+        os.environ["POSTGRES_SSLMODE"] = "verify-full"
+        os.environ["POSTGRES_SSLROOTCERT"] = "/etc/ssl/rds-ca.pem"
+        module = _reload_pg_ssl()
+        assert module.pg_ssl_psycopg2_connect_args() == {
+            "sslmode": "verify-full",
+            "sslrootcert": "/etc/ssl/rds-ca.pem",
+        }
+
+
+def test_psycopg2_args_empty_when_iam_takes_precedence() -> None:
+    """IAM enforces its own TLS via the do_connect listener, so the explicit
+    SSL config must not also be injected as connect_args."""
+    with patch.dict(os.environ, {}, clear=False):
+        _clear_ssl_env()
+        os.environ["USE_IAM_AUTH"] = "true"
+        os.environ["POSTGRES_SSLMODE"] = "verify-full"
+        module = _reload_pg_ssl()
+        assert module.pg_ssl_psycopg2_connect_args() == {}
+
+
+# --- asyncpg SSLContext ---------------------------------------------------
+
+
+def test_asyncpg_none_when_unset_or_disabled() -> None:
+    for mode in (None, "disable"):
+        with patch.dict(os.environ, {}, clear=False):
+            _clear_ssl_env()
+            if mode:
+                os.environ["POSTGRES_SSLMODE"] = mode
+            module = _reload_pg_ssl()
+            assert module.create_pg_ssl_context() is None
+
+
+def test_asyncpg_prefer_passes_mode_string_through() -> None:
+    """allow/prefer have no custom-CA semantics; asyncpg handles the
+    opportunistic-with-fallback behavior natively from the mode string."""
+    with patch.dict(os.environ, {}, clear=False):
+        _clear_ssl_env()
+        os.environ["POSTGRES_SSLMODE"] = "prefer"
+        module = _reload_pg_ssl()
+        assert module.create_pg_ssl_context() == "prefer"
+
+
+def test_asyncpg_require_encrypts_without_verifying() -> None:
+    with patch.dict(os.environ, {}, clear=False):
+        _clear_ssl_env()
+        os.environ["POSTGRES_SSLMODE"] = "require"
+        module = _reload_pg_ssl()
+        ctx = module.create_pg_ssl_context()
+        assert isinstance(ctx, ssl.SSLContext)
+        assert ctx.check_hostname is False
+        assert ctx.verify_mode == ssl.CERT_NONE
+
+
+def test_asyncpg_verify_ca_verifies_cert_not_hostname() -> None:
+    with patch.dict(os.environ, {}, clear=False):
+        _clear_ssl_env()
+        os.environ["POSTGRES_SSLMODE"] = "verify-ca"
+        os.environ["POSTGRES_SSLROOTCERT"] = _CA_BUNDLE
+        module = _reload_pg_ssl()
+        ctx = module.create_pg_ssl_context()
+        assert isinstance(ctx, ssl.SSLContext)
+        assert ctx.check_hostname is False
+        assert ctx.verify_mode == ssl.CERT_REQUIRED
+        assert ctx.get_ca_certs(), "CA bundle should be loaded for verification"
+
+
+def test_asyncpg_verify_full_verifies_cert_and_hostname() -> None:
+    with patch.dict(os.environ, {}, clear=False):
+        _clear_ssl_env()
+        os.environ["POSTGRES_SSLMODE"] = "verify-full"
+        os.environ["POSTGRES_SSLROOTCERT"] = _CA_BUNDLE
+        module = _reload_pg_ssl()
+        ctx = module.create_pg_ssl_context()
+        assert isinstance(ctx, ssl.SSLContext)
+        assert ctx.check_hostname is True
+        assert ctx.verify_mode == ssl.CERT_REQUIRED
+        assert ctx.get_ca_certs(), "CA bundle should be loaded for verification"
+
+
+def test_asyncpg_not_none_with_explicit_ssl_regression_guard() -> None:
+    """Regression guard for the silent-plaintext footgun: when SSL is explicitly
+    configured, the value handed to asyncpg's connect_args["ssl"] must not be
+    None (which would otherwise drop the connection to plaintext)."""
+    with patch.dict(os.environ, {}, clear=False):
+        _clear_ssl_env()
+        os.environ["POSTGRES_SSLMODE"] = "verify-full"
+        os.environ["POSTGRES_SSLROOTCERT"] = _CA_BUNDLE
+        module = _reload_pg_ssl()
+        assert module.create_pg_ssl_context() is not None
+
+
+# --- config validation ----------------------------------------------------
+
+
+def test_invalid_sslmode_raises_at_config_import() -> None:
+    with patch.dict(os.environ, {"POSTGRES_SSLMODE": "bogus"}):
+        import onyx.configs.app_configs as app_configs
+
+        with pytest.raises(ValueError, match="Invalid POSTGRES_SSLMODE"):
+            importlib.reload(app_configs)
+    # restore a clean module for any later tests in the session
+    importlib.reload(app_configs)

--- a/backend/tests/unit/onyx/db/engine/test_postgres_ssl.py
+++ b/backend/tests/unit/onyx/db/engine/test_postgres_ssl.py
@@ -60,11 +60,11 @@ def test_psycopg2_args_verify_full_includes_rootcert() -> None:
     with patch.dict(os.environ, {}, clear=False):
         _clear_ssl_env()
         os.environ["POSTGRES_SSLMODE"] = "verify-full"
-        os.environ["POSTGRES_SSLROOTCERT"] = "/etc/ssl/rds-ca.pem"
+        os.environ["POSTGRES_SSLROOTCERT"] = _CA_BUNDLE
         module = _reload_pg_ssl()
         assert module.pg_ssl_psycopg2_connect_args() == {
             "sslmode": "verify-full",
-            "sslrootcert": "/etc/ssl/rds-ca.pem",
+            "sslrootcert": _CA_BUNDLE,
         }
 
 
@@ -155,10 +155,52 @@ def test_asyncpg_not_none_with_explicit_ssl_regression_guard() -> None:
 
 
 def test_invalid_sslmode_raises_at_config_import() -> None:
-    with patch.dict(os.environ, {"POSTGRES_SSLMODE": "bogus"}):
+    with patch.dict(os.environ, {}, clear=False):
+        _clear_ssl_env()
+        os.environ["POSTGRES_SSLMODE"] = "bogus"
         import onyx.configs.app_configs as app_configs
 
         with pytest.raises(ValueError, match="Invalid POSTGRES_SSLMODE"):
             importlib.reload(app_configs)
     # restore a clean module for any later tests in the session
+    importlib.reload(app_configs)
+
+
+def test_verify_full_without_rootcert_raises() -> None:
+    """verify-ca/verify-full must fail loudly without a CA bundle rather than
+    silently fall back to the system trust store."""
+    import onyx.configs.app_configs as app_configs
+
+    for mode in ("verify-ca", "verify-full"):
+        with patch.dict(os.environ, {}, clear=False):
+            _clear_ssl_env()
+            os.environ["POSTGRES_SSLMODE"] = mode
+            with pytest.raises(ValueError, match="requires POSTGRES_SSLROOTCERT"):
+                importlib.reload(app_configs)
+    importlib.reload(app_configs)
+
+
+def test_nonexistent_rootcert_raises() -> None:
+    with patch.dict(os.environ, {}, clear=False):
+        _clear_ssl_env()
+        os.environ["POSTGRES_SSLMODE"] = "verify-full"
+        os.environ["POSTGRES_SSLROOTCERT"] = "/no/such/ca-bundle.pem"
+        import onyx.configs.app_configs as app_configs
+
+        with pytest.raises(ValueError, match="does not exist"):
+            importlib.reload(app_configs)
+    importlib.reload(app_configs)
+
+
+def test_invalid_sslmode_ignored_under_iam() -> None:
+    """IAM enforces its own TLS, so an ignored (even invalid) POSTGRES_SSLMODE
+    must not fail startup — validation is gated behind the non-IAM path."""
+    with patch.dict(os.environ, {}, clear=False):
+        _clear_ssl_env()
+        os.environ["USE_IAM_AUTH"] = "true"
+        os.environ["POSTGRES_SSLMODE"] = "bogus"
+        import onyx.configs.app_configs as app_configs
+
+        importlib.reload(app_configs)  # must NOT raise
+        assert app_configs.USE_IAM_AUTH is True
     importlib.reload(app_configs)

--- a/backend/tests/unit/onyx/db/engine/test_postgres_ssl.py
+++ b/backend/tests/unit/onyx/db/engine/test_postgres_ssl.py
@@ -192,6 +192,19 @@ def test_nonexistent_rootcert_raises() -> None:
     importlib.reload(app_configs)
 
 
+def test_rootcert_without_sslmode_raises() -> None:
+    """A CA bundle with no mode is dead config (SSL stays off); fail loudly so
+    it can't masquerade as a verified connection."""
+    with patch.dict(os.environ, {}, clear=False):
+        _clear_ssl_env()
+        os.environ["POSTGRES_SSLROOTCERT"] = _CA_BUNDLE
+        import onyx.configs.app_configs as app_configs
+
+        with pytest.raises(ValueError, match="POSTGRES_SSLMODE is not"):
+            importlib.reload(app_configs)
+    importlib.reload(app_configs)
+
+
 def test_invalid_sslmode_ignored_under_iam() -> None:
     """IAM enforces its own TLS, so an ignored (even invalid) POSTGRES_SSLMODE
     must not fail startup — validation is gated behind the non-IAM path."""

--- a/backend/tests/unit/onyx/db/engine/test_postgres_tcp_keepalives.py
+++ b/backend/tests/unit/onyx/db/engine/test_postgres_tcp_keepalives.py
@@ -14,8 +14,13 @@ def _reload_app_configs() -> ModuleType:
 def _reload_sql_engine() -> ModuleType:
     """Reload sql_engine after app_configs has been reloaded so it picks up
     the freshly parsed constants. Required because sql_engine binds them at
+    import time. pg_ssl is reloaded in between because sql_engine's merged
+    connect_args now compose pg_ssl's SSL params, which also bind config at
     import time."""
     _reload_app_configs()
+    import onyx.db.engine.pg_ssl as pg_ssl_module
+
+    importlib.reload(pg_ssl_module)
     import onyx.db.engine.sql_engine as module
 
     return importlib.reload(module)

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -111,6 +111,11 @@ POSTGRES_PASSWORD=password
 # POSTGRES_TCP_KEEPALIVES_IDLE=
 # POSTGRES_TCP_KEEPALIVES_INTERVAL=
 # POSTGRES_TCP_KEEPALIVES_COUNT=
+# TLS for the database connection (libpq sslmode vocabulary). Only verify-ca /
+# verify-full authenticate the server; both need a CA bundle to verify against.
+# Mounted path must be readable by the app containers. Ignored when USE_IAM_AUTH=true.
+# POSTGRES_SSLMODE=          # disable | allow | prefer | require | verify-ca | verify-full
+# POSTGRES_SSLROOTCERT=      # e.g. /etc/ssl/certs/rds-ca-bundle.pem
 # DB_READONLY_USER=
 # DB_READONLY_PASSWORD=
 

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -112,8 +112,9 @@ POSTGRES_PASSWORD=password
 # POSTGRES_TCP_KEEPALIVES_INTERVAL=
 # POSTGRES_TCP_KEEPALIVES_COUNT=
 # TLS for the database connection (libpq sslmode vocabulary). Only verify-ca /
-# verify-full authenticate the server; both need a CA bundle to verify against.
-# Mounted path must be readable by the app containers. Ignored when USE_IAM_AUTH=true.
+# verify-full authenticate the server, and they REQUIRE POSTGRES_SSLROOTCERT (a
+# readable CA bundle path; use the system bundle for publicly-trusted certs).
+# Ignored when USE_IAM_AUTH=true.
 # POSTGRES_SSLMODE=          # disable | allow | prefer | require | verify-ca | verify-full
 # POSTGRES_SSLROOTCERT=      # e.g. /etc/ssl/certs/rds-ca-bundle.pem
 # DB_READONLY_USER=


### PR DESCRIPTION
## Description

Adds first-class TLS for non-IAM PostgreSQL connections so deployments can both **encrypt** the connection and **verify the server certificate** against a provider CA bundle (the capability a security/compliance review cares about — `require` alone encrypts but does not stop a MITM).

Two new env vars (libpq vocabulary):
- `POSTGRES_SSLMODE` — `disable | allow | prefer | require | verify-ca | verify-full` (validated at config import).
- `POSTGRES_SSLROOTCERT` — path to the CA bundle used by `verify-ca` / `verify-full` (required by most managed providers — RDS/Cloud SQL/Azure — whose server certs don't chain to a system-trusted CA).

Implementation notes:
- New `onyx/db/engine/pg_ssl.py` is the single source of truth, applied through `connect_args` for **both** drivers: libpq `sslmode`/`sslrootcert` keys for psycopg2, and a built `ssl.SSLContext` for asyncpg (which does not accept libpq sslmode keys — verifying a custom CA requires a context).
- SSL is intentionally **not** placed in the connection URL. asyncpg's `connect_args["ssl"]` takes precedence over URL query params, so a URL-based `ssl=` would be silently overridden and the connection would drop to plaintext.
- IAM auth keeps precedence (it already enforces its own TLS); the explicit settings only apply when IAM is off.
- Wired into all engine-creation sites: primary sync, readonly sync, async, and both Alembic envs.
- Mirrors the existing Redis TLS pattern in `redis_pool.py`.
- docker-compose passes the vars automatically via `env_file`; documented in `env.template`. On Helm, mount the CA via the existing `customCACerts` block and set the vars through per-service `extraEnv` (no chart change required).

This supersedes community PR #9442, which put SSL in the URL (hits the silent-plaintext issue above) and had no way to supply a CA bundle. Client-certificate mTLS (`SSLCERT`/`SSLKEY`) is intentionally out of scope here; the design leaves it as a small follow-up.

## How Has This Been Tested?

- New unit tests in `backend/tests/unit/onyx/db/engine/test_postgres_ssl.py` (10 cases, no live DB) covering: psycopg2 connect_args per mode, asyncpg `SSLContext` resolution (`require` → `CERT_NONE`; `verify-ca` → `CERT_REQUIRED` + hostname off; `verify-full` → `CERT_REQUIRED` + hostname on; CA bundle actually loaded), `allow`/`prefer` passthrough, IAM precedence, config validation, and a regression guard that explicitly-configured SSL never resolves to `None` (the silent-plaintext footgun).
- Full db unit suite green: `pytest backend/tests/unit/onyx/db` → **176 passed**.
- `ty`, `ruff`, `ruff format`, and the full `pre-commit` set pass on all changed files.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds TLS for non-IAM PostgreSQL connections with server certificate verification across sync/async engines and Alembic. Enforces safe config and prevents silent plaintext fallbacks.

- **New Features**
  - Adds `POSTGRES_SSLMODE` (`disable|allow|prefer|require|verify-ca|verify-full`) and `POSTGRES_SSLROOTCERT` (CA bundle path).
  - `verify-ca`/`verify-full` require `POSTGRES_SSLROOTCERT` and verify the file exists; `require` encrypts without CA or hostname checks.
  - Fails fast if `POSTGRES_SSLROOTCERT` is set without `POSTGRES_SSLMODE`.
  - Central `pg_ssl.py` applies TLS: `psycopg2` via `sslmode`/`sslrootcert`; `asyncpg` via an `ssl.SSLContext`; never via URL.
  - IAM auth remains authoritative; SSL validation is skipped when `USE_IAM_AUTH=true`, with warnings if IAM overrides explicit SSL or if `POSTGRES_SSLROOTCERT` is set with `require`.
  - Applied to primary/readonly sync engines, async engine, and both Alembic envs; Docker Compose env template updated.

- **Migration**
  - For managed providers, set `POSTGRES_SSLMODE=verify-full` (or `verify-ca`) and `POSTGRES_SSLROOTCERT` to the provider CA bundle path.
  - Helm: mount CA with `customCACerts` and set env via `extraEnv`; Docker Compose reads from `env_file`. No action when `USE_IAM_AUTH=true`.

<sup>Written for commit 5047320bf7e8dfc9d065f8159f0114b1968657d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

