### PR TITLE
feat(indexing): stream large spreadsheets via file-backed TabularSection

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -1127,6 +1127,15 @@ MAX_XLSX_CELLS_PER_SHEET = max(
     0, int(os.environ.get("MAX_XLSX_CELLS_PER_SHEET") or 10_000_000)
 )
 
+# A worksheet whose uncompressed XML exceeds this is streamed to a file-backed
+# TabularSection (CSV staged in the file store, streamed at chunk time) instead
+# of being rendered to an in-memory string. Keeps a huge sheet off the worker
+# heap end to end rather than truncating it. Checked cheaply from the xlsx zip
+# directory before any parse.
+XLSX_STREAM_SHEET_BYTES = max(
+    0, int(os.environ.get("XLSX_STREAM_SHEET_BYTES") or 50 * 1024 * 1024)
+)
+
 # Use document summary for contextual rag
 USE_DOCUMENT_SUMMARY = os.environ.get("USE_DOCUMENT_SUMMARY", "true").lower() == "true"
 # Use chunk summary for contextual rag

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -1128,10 +1128,8 @@ MAX_XLSX_CELLS_PER_SHEET = max(
 )
 
 # A worksheet whose uncompressed XML exceeds this is streamed to a file-backed
-# TabularSection (CSV staged in the file store, streamed at chunk time) instead
-# of being rendered to an in-memory string. Keeps a huge sheet off the worker
-# heap end to end rather than truncating it. Checked cheaply from the xlsx zip
-# directory before any parse.
+# TabularSection (CSV staged in the file store) instead of an in-memory string,
+# so a huge sheet stays off the worker heap rather than being truncated.
 XLSX_STREAM_SHEET_BYTES = max(
     0, int(os.environ.get("XLSX_STREAM_SHEET_BYTES") or 50 * 1024 * 1024)
 )

--- a/backend/onyx/connectors/cross_connector_utils/section_utils.py
+++ b/backend/onyx/connectors/cross_connector_utils/section_utils.py
@@ -21,6 +21,10 @@ def cap_sections_text(
     for i, section in enumerate(sections):
         if isinstance(section, ImageSection):
             continue
+        if section.text is None:
+            # File-backed (e.g. streamed TabularSection) — content lives in the
+            # file store and is already bounded; nothing inline to cap.
+            continue
         if len(section.text) > remaining:
             logger.warning(
                 "Extracted text for %s exceeds %s chars. Truncating.",

--- a/backend/onyx/connectors/cross_connector_utils/tabular_section_utils.py
+++ b/backend/onyx/connectors/cross_connector_utils/tabular_section_utils.py
@@ -55,7 +55,10 @@ def _xlsx_to_streamed_sections(
             heading=f"{file_name} :: {sheet.title}",
         )
         for sheet in stage_or_inline_xlsx_sheets(
-            file, raw_file_callback, XLSX_STREAM_SHEET_BYTES
+            file,
+            raw_file_callback,
+            XLSX_STREAM_SHEET_BYTES,
+            file_name=file_name,
         )
     ]
 

--- a/backend/onyx/connectors/cross_connector_utils/tabular_section_utils.py
+++ b/backend/onyx/connectors/cross_connector_utils/tabular_section_utils.py
@@ -4,9 +4,10 @@ from typing import IO
 
 from pydantic import BaseModel
 
+from onyx.configs.app_configs import XLSX_STREAM_SHEET_BYTES
 from onyx.connectors.models import TabularSection
 from onyx.file_processing.extract_file_text import file_io_to_text
-from onyx.file_processing.extract_file_text import iter_xlsx_sheets_streamed
+from onyx.file_processing.extract_file_text import stage_or_inline_xlsx_sheets
 from onyx.file_processing.extract_file_text import xlsx_has_large_sheet
 from onyx.file_processing.extract_file_text import xlsx_sheet_extraction
 from onyx.file_processing.file_types import OnyxFileExtensions
@@ -36,25 +37,27 @@ def _tsv_to_csv(tsv_text: str) -> str:
     return out.getvalue().rstrip("\n")
 
 
-def _xlsx_to_file_backed_sections(
+def _xlsx_to_streamed_sections(
     file: IO[bytes],
     file_name: str,
     link: str,
     raw_file_callback: RawFileCallback,
 ) -> list[TabularSection]:
-    """Stream each worksheet's CSV to the file store and reference it from a
-    file-backed TabularSection, so a huge sheet never lands on the worker heap."""
-    sections: list[TabularSection] = []
-    for sheet_title, csv_bytes in iter_xlsx_sheets_streamed(file):
-        csv_file_id = raw_file_callback(csv_bytes, "text/csv")
-        sections.append(
-            TabularSection(
-                link=link or file_name,
-                csv_file_id=csv_file_id,
-                heading=f"{file_name} :: {sheet_title}",
-            )
+    """Render each worksheet's CSV with bounded memory: small sheets stay inline
+    (keeping their descriptor chunks downstream); sheets larger than
+    `XLSX_STREAM_SHEET_BYTES` are file-backed in the file store so a huge sheet
+    never lands on the worker heap."""
+    return [
+        TabularSection(
+            link=link or file_name,
+            text=sheet.text,
+            csv_file_id=sheet.csv_file_id,
+            heading=f"{file_name} :: {sheet.title}",
         )
-    return sections
+        for sheet in stage_or_inline_xlsx_sheets(
+            file, raw_file_callback, XLSX_STREAM_SHEET_BYTES
+        )
+    ]
 
 
 def tabular_file_to_sections(
@@ -66,8 +69,9 @@ def tabular_file_to_sections(
     """Convert a tabular file into one or more TabularSections.
 
     - .xlsx → one TabularSection per non-empty sheet. A workbook with a very
-      large sheet (and a `raw_file_callback`) is streamed to file-backed
-      sections; otherwise it's rendered inline.
+      large sheet (and a `raw_file_callback`) is streamed per sheet — small
+      sheets stay inline, oversized sheets are file-backed; otherwise the whole
+      workbook is rendered inline.
     - .csv / .tsv → a single TabularSection containing the full decoded file.
 
     Returns an empty list when the file yields no extractable content.
@@ -79,7 +83,7 @@ def tabular_file_to_sections(
 
     if lowered.endswith(tuple(OnyxFileExtensions.SPREADSHEET_EXTENSIONS)):
         if raw_file_callback is not None and xlsx_has_large_sheet(file):
-            return _xlsx_to_file_backed_sections(
+            return _xlsx_to_streamed_sections(
                 file,
                 file_name=file_name,
                 link=link,

--- a/backend/onyx/connectors/cross_connector_utils/tabular_section_utils.py
+++ b/backend/onyx/connectors/cross_connector_utils/tabular_section_utils.py
@@ -6,6 +6,8 @@ from pydantic import BaseModel
 
 from onyx.connectors.models import TabularSection
 from onyx.file_processing.extract_file_text import file_io_to_text
+from onyx.file_processing.extract_file_text import iter_xlsx_sheets_streamed
+from onyx.file_processing.extract_file_text import xlsx_has_large_sheet
 from onyx.file_processing.extract_file_text import xlsx_sheet_extraction
 from onyx.file_processing.file_types import OnyxFileExtensions
 from onyx.file_store.staging import RawFileCallback
@@ -34,16 +36,39 @@ def _tsv_to_csv(tsv_text: str) -> str:
     return out.getvalue().rstrip("\n")
 
 
+def _xlsx_to_file_backed_sections(
+    file: IO[bytes],
+    file_name: str,
+    link: str,
+    raw_file_callback: RawFileCallback,
+) -> list[TabularSection]:
+    """Stream each worksheet's CSV to the file store and reference it from a
+    file-backed TabularSection, so a huge sheet never lands on the worker heap."""
+    sections: list[TabularSection] = []
+    for sheet_title, csv_bytes in iter_xlsx_sheets_streamed(file):
+        csv_file_id = raw_file_callback(csv_bytes, "text/csv")
+        sections.append(
+            TabularSection(
+                link=link or file_name,
+                csv_file_id=csv_file_id,
+                heading=f"{file_name} :: {sheet_title}",
+            )
+        )
+    return sections
+
+
 def tabular_file_to_sections(
     file: IO[bytes],
     file_name: str,
     link: str = "",
+    raw_file_callback: RawFileCallback | None = None,
 ) -> list[TabularSection]:
     """Convert a tabular file into one or more TabularSections.
 
-    - .xlsx → one TabularSection per non-empty sheet.
-    - .csv / .tsv → a single TabularSection containing the full decoded
-      file.
+    - .xlsx → one TabularSection per non-empty sheet. A workbook with a very
+      large sheet (and a `raw_file_callback`) is streamed to file-backed
+      sections; otherwise it's rendered inline.
+    - .csv / .tsv → a single TabularSection containing the full decoded file.
 
     Returns an empty list when the file yields no extractable content.
     """
@@ -53,6 +78,13 @@ def tabular_file_to_sections(
         raise ValueError(f"{file_name!r} is not a tabular file")
 
     if lowered.endswith(tuple(OnyxFileExtensions.SPREADSHEET_EXTENSIONS)):
+        if raw_file_callback is not None and xlsx_has_large_sheet(file):
+            return _xlsx_to_file_backed_sections(
+                file,
+                file_name=file_name,
+                link=link,
+                raw_file_callback=raw_file_callback,
+            )
         return [
             TabularSection(
                 link=link or file_name,
@@ -89,6 +121,7 @@ def extract_and_stage_tabular_file(
         file=file,
         file_name=file_name,
         link=link,
+        raw_file_callback=raw_file_callback,
     )
     # rewind so the callback can re-read what extraction consumed
     file.seek(0)

--- a/backend/onyx/connectors/models.py
+++ b/backend/onyx/connectors/models.py
@@ -77,14 +77,32 @@ class ImageSection(Section):
 
 class TabularSection(Section):
     """Section containing tabular data (csv/tsv content, or one sheet of
-    an xlsx workbook rendered as CSV)."""
+    an xlsx workbook rendered as CSV).
+
+    Exactly one of `text` (inline CSV) or `csv_file_id` (CSV staged in the file
+    store, streamed at chunk time) carries the content. The file-backed form
+    keeps a large sheet off the worker heap end to end.
+    """
 
     type: Literal[SectionType.TABULAR] = SectionType.TABULAR
-    text: str  # CSV representation in a string
+    text: str | None = None  # inline CSV; None when file-backed
+    csv_file_id: str | None = None  # file store id of staged CSV; None when inline
     link: str
 
+    @model_validator(mode="after")
+    def _exactly_one_source(self) -> "TabularSection":
+        if (self.text is None) == (self.csv_file_id is None):
+            raise ValueError(
+                "TabularSection requires exactly one of `text` or `csv_file_id`"
+            )
+        return self
+
     def __sizeof__(self) -> int:
-        return sys.getsizeof(self.text) + sys.getsizeof(self.link)
+        return (
+            sys.getsizeof(self.text)
+            + sys.getsizeof(self.csv_file_id)
+            + sys.getsizeof(self.link)
+        )
 
 
 class BasicExpertInfo(BaseModel):

--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -751,11 +751,13 @@ def stage_or_inline_xlsx_sheets(
     max_inline_bytes: int,
     file_name: str = "",
 ) -> list[StreamedSheet]:
-    """Render each non-empty worksheet to a temp CSV, streaming rows so peak RAM
-    is one row rather than the whole sheet. A sheet whose CSV is at most
-    `max_inline_bytes` is returned inline; a larger one is staged via `stage` and
-    referenced by id. The temp handle never escapes this function. No column
-    trimming or empty-run collapsing — those need a full in-memory pass."""
+    """Render each non-empty worksheet to a temp CSV, writing rows one at a time
+    so no worksheet is fully held in memory during conversion. A worksheet whose
+    CSV is at most `max_inline_bytes` is read back inline; a larger one is staged
+    via `stage` and referenced by `csv_file_id` so it stays off the heap
+    downstream. The returned list thus holds full CSV text for inline sheets
+    (each bounded by `max_inline_bytes`) and only an id for file-backed ones.
+    Empty rows are dropped; columns are not trimmed (that needs a second pass)."""
     sheets: list[StreamedSheet] = []
     workbook = _load_readonly_workbook(file, file_name)
     if workbook is None:

--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -745,6 +745,14 @@ class StreamedSheet(NamedTuple):
     csv_file_id: str | None
 
 
+def _row_has_content(row: tuple[Any, ...]) -> bool:
+    return any(v is not None and v != "" for v in row)
+
+
+def _cell(value: Any) -> str:
+    return "" if value is None else str(value)
+
+
 def stage_or_inline_xlsx_sheets(
     file: IO[bytes],
     stage: Callable[[IO[bytes], str], str],
@@ -768,27 +776,23 @@ def stage_or_inline_xlsx_sheets(
             ro_sheet.reset_dimensions()
             with tempfile.TemporaryFile(mode="w+", encoding="utf-8", newline="") as tmp:
                 writer = csv.writer(tmp, lineterminator="\n")
-                wrote = False
                 for row in ro_sheet.iter_rows(values_only=True):
-                    if not any(v is not None and v != "" for v in row):
-                        continue
-                    writer.writerow(["" if v is None else str(v) for v in row])
-                    wrote = True
-                if not wrote:
-                    continue
+                    if _row_has_content(row):
+                        writer.writerow([_cell(v) for v in row])
                 tmp.flush()
                 binary = cast(IO[bytes], tmp.buffer)
                 size = binary.seek(0, io.SEEK_END)
-                binary.seek(0)
-                if size <= max_inline_bytes:
-                    text = binary.read().decode("utf-8").strip()
-                    if not text:
-                        continue
-                    sheets.append(StreamedSheet(ro_sheet.title, text, None))
-                else:
+                if size > max_inline_bytes:
+                    binary.seek(0)
                     sheets.append(
                         StreamedSheet(ro_sheet.title, None, stage(binary, "text/csv"))
                     )
+                    continue
+                binary.seek(0)
+                text = binary.read().decode("utf-8").strip()
+                if not text:
+                    continue
+                sheets.append(StreamedSheet(ro_sheet.title, text, None))
     finally:
         workbook.close()
     return sheets

--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -4,6 +4,7 @@ import io
 import json
 import os
 import re
+import tempfile
 import zipfile
 from collections.abc import Callable
 from collections.abc import Iterator
@@ -26,6 +27,7 @@ from PIL import Image
 
 from onyx.configs.app_configs import MAX_EMBEDDED_IMAGES_PER_FILE
 from onyx.configs.app_configs import MAX_XLSX_CELLS_PER_SHEET
+from onyx.configs.app_configs import XLSX_STREAM_SHEET_BYTES
 from onyx.configs.constants import ONYX_METADATA_FILENAME
 from onyx.configs.llm_configs import get_image_extraction_and_analysis_enabled
 from onyx.file_processing.file_types import OnyxFileExtensions
@@ -701,6 +703,63 @@ def xlsx_sheet_extraction(file: IO[Any], file_name: str = "") -> list[tuple[str,
         workbook.close()
 
     return sheets
+
+
+def xlsx_has_large_sheet(
+    file: IO[bytes], threshold: int = XLSX_STREAM_SHEET_BYTES
+) -> bool:
+    """True if any worksheet's *uncompressed* XML exceeds `threshold` — a cheap
+    pre-parse check read straight from the xlsx zip directory (no decompression).
+    Routes a huge workbook to streamed, file-backed extraction."""
+    try:
+        file.seek(0)
+        with zipfile.ZipFile(file) as zf:
+            return any(
+                info.file_size > threshold
+                for info in zf.infolist()
+                if info.filename.startswith("xl/worksheets/")
+                and info.filename.endswith(".xml")
+            )
+    except BadZipFile:
+        return False
+    finally:
+        file.seek(0)
+
+
+def iter_xlsx_sheets_streamed(file: IO[bytes]) -> Iterator[tuple[str, IO[bytes]]]:
+    """Stream each non-empty worksheet to a temp CSV file and yield
+    `(sheet_title, csv_bytes)` — peak RAM is one row, not the whole sheet.
+
+    Each yielded handle is a binary temp file positioned at 0; consume it before
+    requesting the next sheet (it is closed afterward). Unlike
+    `xlsx_sheet_extraction`, this does no column trimming or empty-run collapsing
+    — those need a full in-memory pass, which is exactly what this avoids.
+    """
+    workbook = openpyxl.load_workbook(file, read_only=True)
+    try:
+        for sheet in workbook.worksheets:
+            ro_sheet = cast(ReadOnlyWorksheet, sheet)
+            ro_sheet.reset_dimensions()
+            tmp = tempfile.TemporaryFile(mode="w+", encoding="utf-8", newline="")
+            writer = csv.writer(tmp, lineterminator="\n")
+            wrote = False
+            for row in ro_sheet.iter_rows(values_only=True):
+                if not any(v is not None and v != "" for v in row):
+                    continue
+                writer.writerow(["" if v is None else str(v) for v in row])
+                wrote = True
+            tmp.flush()
+            if not wrote:
+                tmp.close()
+                continue
+            binary = cast(IO[bytes], tmp.buffer)
+            binary.seek(0)
+            try:
+                yield ro_sheet.title, binary
+            finally:
+                tmp.close()
+    finally:
+        workbook.close()
 
 
 def xlsx_to_text(file: IO[Any], file_name: str = "") -> str:

--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -740,6 +740,7 @@ def stage_or_inline_xlsx_sheets(
     file: IO[bytes],
     stage: Callable[[IO[bytes], str], str],
     max_inline_bytes: int,
+    file_name: str = "",
 ) -> list[StreamedSheet]:
     """Render each non-empty worksheet to a temp CSV, streaming rows so peak RAM
     is one row rather than the whole sheet. A sheet whose CSV is at most
@@ -747,7 +748,24 @@ def stage_or_inline_xlsx_sheets(
     referenced by id. The temp handle never escapes this function. No column
     trimming or empty-run collapsing — those need a full in-memory pass."""
     sheets: list[StreamedSheet] = []
-    workbook = openpyxl.load_workbook(file, read_only=True)
+    try:
+        workbook = openpyxl.load_workbook(file, read_only=True)
+    except BadZipFile as e:
+        error_str = f"Failed to extract text from {file_name or 'xlsx file'}: {e}"
+        if file_name.startswith("~"):
+            logger.debug(error_str + " (this is expected for files with ~)")
+        else:
+            logger.warning(error_str)
+        return []
+    except Exception as e:
+        if any(s in str(e) for s in KNOWN_OPENPYXL_BUGS):
+            logger.warning(
+                "Failed to extract text from %s. This happens due to a bug in openpyxl. %s",
+                file_name or "xlsx file",
+                e,
+            )
+            return []
+        raise
     try:
         for sheet in workbook.worksheets:
             ro_sheet = cast(ReadOnlyWorksheet, sheet)

--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -726,40 +726,58 @@ def xlsx_has_large_sheet(
         file.seek(0)
 
 
-def iter_xlsx_sheets_streamed(file: IO[bytes]) -> Iterator[tuple[str, IO[bytes]]]:
-    """Stream each non-empty worksheet to a temp CSV file and yield
-    `(sheet_title, csv_bytes)` — peak RAM is one row, not the whole sheet.
+class StreamedSheet(NamedTuple):
+    """One worksheet rendered to CSV. Small sheets are returned inline (`text`);
+    larger ones are staged in the file store (`csv_file_id`) so they never land
+    on the heap. Exactly one of the two is populated."""
 
-    Each yielded handle is a binary temp file positioned at 0; consume it before
-    requesting the next sheet (it is closed afterward). Unlike
-    `xlsx_sheet_extraction`, this does no column trimming or empty-run collapsing
-    — those need a full in-memory pass, which is exactly what this avoids.
-    """
+    title: str
+    text: str | None
+    csv_file_id: str | None
+
+
+def stage_or_inline_xlsx_sheets(
+    file: IO[bytes],
+    stage: Callable[[IO[bytes], str], str],
+    max_inline_bytes: int,
+) -> list[StreamedSheet]:
+    """Render each non-empty worksheet to a temp CSV, streaming rows so peak RAM
+    is one row rather than the whole sheet. A sheet whose CSV is at most
+    `max_inline_bytes` is returned inline; a larger one is staged via `stage` and
+    referenced by id. The temp handle never escapes this function. No column
+    trimming or empty-run collapsing — those need a full in-memory pass."""
+    sheets: list[StreamedSheet] = []
     workbook = openpyxl.load_workbook(file, read_only=True)
     try:
         for sheet in workbook.worksheets:
             ro_sheet = cast(ReadOnlyWorksheet, sheet)
             ro_sheet.reset_dimensions()
-            tmp = tempfile.TemporaryFile(mode="w+", encoding="utf-8", newline="")
-            writer = csv.writer(tmp, lineterminator="\n")
-            wrote = False
-            for row in ro_sheet.iter_rows(values_only=True):
-                if not any(v is not None and v != "" for v in row):
+            with tempfile.TemporaryFile(mode="w+", encoding="utf-8", newline="") as tmp:
+                writer = csv.writer(tmp, lineterminator="\n")
+                wrote = False
+                for row in ro_sheet.iter_rows(values_only=True):
+                    if not any(v is not None and v != "" for v in row):
+                        continue
+                    writer.writerow(["" if v is None else str(v) for v in row])
+                    wrote = True
+                if not wrote:
                     continue
-                writer.writerow(["" if v is None else str(v) for v in row])
-                wrote = True
-            tmp.flush()
-            if not wrote:
-                tmp.close()
-                continue
-            binary = cast(IO[bytes], tmp.buffer)
-            binary.seek(0)
-            try:
-                yield ro_sheet.title, binary
-            finally:
-                tmp.close()
+                tmp.flush()
+                binary = cast(IO[bytes], tmp.buffer)
+                size = binary.seek(0, io.SEEK_END)
+                binary.seek(0)
+                if size <= max_inline_bytes:
+                    text = binary.read().decode("utf-8").strip()
+                    if not text:
+                        continue
+                    sheets.append(StreamedSheet(ro_sheet.title, text, None))
+                else:
+                    sheets.append(
+                        StreamedSheet(ro_sheet.title, None, stage(binary, "text/csv"))
+                    )
     finally:
         workbook.close()
+    return sheets
 
 
 def xlsx_to_text(file: IO[Any], file_name: str = "") -> str:

--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -665,22 +665,19 @@ def _sheet_to_csv(rows: Iterator[tuple[Any, ...]]) -> str:
     return buf.getvalue().rstrip("\n")
 
 
-def xlsx_sheet_extraction(file: IO[Any], file_name: str = "") -> list[tuple[str, str]]:
-    """
-    Converts each sheet in the excel file to a csv condensed string.
-    Returns a string and the worksheet title for each worksheet
-
-    Returns a list of (csv_text, sheet)
-    """
+def _load_readonly_workbook(file: IO[Any], file_name: str) -> openpyxl.Workbook | None:
+    """Load a read-only workbook, returning None (and logging) for the BadZipFile
+    / known-openpyxl-bug cases the xlsx indexers treat as skip-and-continue rather
+    than a hard failure."""
     try:
-        workbook = openpyxl.load_workbook(file, read_only=True)
+        return openpyxl.load_workbook(file, read_only=True)
     except BadZipFile as e:
         error_str = f"Failed to extract text from {file_name or 'xlsx file'}: {e}"
         if file_name.startswith("~"):
             logger.debug(error_str + " (this is expected for files with ~)")
         else:
             logger.warning(error_str)
-        return []
+        return None
     except Exception as e:
         if any(s in str(e) for s in KNOWN_OPENPYXL_BUGS):
             logger.warning(
@@ -688,8 +685,20 @@ def xlsx_sheet_extraction(file: IO[Any], file_name: str = "") -> list[tuple[str,
                 file_name or "xlsx file",
                 e,
             )
-            return []
+            return None
         raise
+
+
+def xlsx_sheet_extraction(file: IO[Any], file_name: str = "") -> list[tuple[str, str]]:
+    """
+    Converts each sheet in the excel file to a csv condensed string.
+    Returns a string and the worksheet title for each worksheet
+
+    Returns a list of (csv_text, sheet)
+    """
+    workbook = _load_readonly_workbook(file, file_name)
+    if workbook is None:
+        return []
 
     sheets: list[tuple[str, str]] = []
     try:
@@ -748,24 +757,9 @@ def stage_or_inline_xlsx_sheets(
     referenced by id. The temp handle never escapes this function. No column
     trimming or empty-run collapsing — those need a full in-memory pass."""
     sheets: list[StreamedSheet] = []
-    try:
-        workbook = openpyxl.load_workbook(file, read_only=True)
-    except BadZipFile as e:
-        error_str = f"Failed to extract text from {file_name or 'xlsx file'}: {e}"
-        if file_name.startswith("~"):
-            logger.debug(error_str + " (this is expected for files with ~)")
-        else:
-            logger.warning(error_str)
-        return []
-    except Exception as e:
-        if any(s in str(e) for s in KNOWN_OPENPYXL_BUGS):
-            logger.warning(
-                "Failed to extract text from %s. This happens due to a bug in openpyxl. %s",
-                file_name or "xlsx file",
-                e,
-            )
-            return []
-        raise
+    workbook = _load_readonly_workbook(file, file_name)
+    if workbook is None:
+        return sheets
     try:
         for sheet in workbook.worksheets:
             ro_sheet = cast(ReadOnlyWorksheet, sheet)

--- a/backend/onyx/indexing/chunking/document_chunker.py
+++ b/backend/onyx/indexing/chunking/document_chunker.py
@@ -3,6 +3,7 @@ from chonkie import SentenceChunker
 from onyx.connectors.models import IndexingDocument
 from onyx.connectors.models import Section
 from onyx.connectors.models import SectionType
+from onyx.connectors.models import TabularSection
 from onyx.indexing.chunking.image_section_chunker import ImageChunker
 from onyx.indexing.chunking.section_chunker import AccumulatorState
 from onyx.indexing.chunking.section_chunker import ChunkPayload
@@ -84,8 +85,17 @@ class DocumentChunker:
 
         for section_idx, section in enumerate(sections):
             section_text = clean_text(str(section.text or ""))
+            # File-backed tabular sections hold their content in csv_file_id, not
+            # text, so they look empty here — keep them for the tabular chunker.
+            is_file_backed = (
+                isinstance(section, TabularSection) and section.csv_file_id is not None
+            )
 
-            if not section_text and (not document.title or section_idx > 0):
+            if (
+                not section_text
+                and not is_file_backed
+                and (not document.title or section_idx > 0)
+            ):
                 logger.warning(
                     "Skipping empty or irrelevant section in doc %s, link=%s",
                     document.semantic_identifier,

--- a/backend/onyx/indexing/chunking/tabular_section_chunker/analysis.py
+++ b/backend/onyx/indexing/chunking/tabular_section_chunker/analysis.py
@@ -1,6 +1,6 @@
 from collections import Counter
+from collections.abc import Iterable
 from datetime import date
-from itertools import zip_longest
 
 from dateutil.parser import parse as parse_dt
 from pydantic import BaseModel
@@ -12,6 +12,26 @@ from onyx.utils.csv_utils import ParsedRow
 CATEGORICAL_DISTINCT_THRESHOLD = 20
 ID_NAME_TOKENS = {"id", "uuid", "uid", "guid", "key"}
 
+# Caps that keep analysis memory flat regardless of sheet size. A column with
+# more distinct values than the categorical cap is treated as high-cardinality
+# (not categorical, since a "most frequent value" is not useful there); id
+# uniqueness tracking stops after the id cap (assume unique if no duplicate was
+# seen). Both sit well above CATEGORICAL_DISTINCT_THRESHOLD so smaller sheets
+# keep their exact classification.
+_CATEGORICAL_TRACK_CAP = 1000
+_ID_TRACK_CAP = 10000
+
+
+class NumericAggregate(BaseModel):
+    total: float
+    count: int
+    minimum: float
+    maximum: float
+
+    @property
+    def average(self) -> float:
+        return self.total / self.count if self.count else 0.0
+
 
 class SheetAnalysis(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -20,7 +40,7 @@ class SheetAnalysis(BaseModel):
     num_cols: int
     numeric_cols: list[int] = Field(default_factory=list)
     categorical_cols: list[int] = Field(default_factory=list)
-    numeric_values: dict[int, list[float]] = Field(default_factory=dict)
+    numeric_stats: dict[int, NumericAggregate] = Field(default_factory=dict)
     categorical_counts: dict[int, Counter[str]] = Field(default_factory=dict)
     id_col: int | None = None
     date_min: date | None = None
@@ -31,51 +51,135 @@ class SheetAnalysis(BaseModel):
         return {ci: list(c.keys()) for ci, c in self.categorical_counts.items()}
 
 
-def analyze_sheet(headers: list[str], parsed_rows: list[ParsedRow]) -> SheetAnalysis:
-    a = SheetAnalysis(row_count=len(parsed_rows), num_cols=len(headers))
-    columns = zip_longest(*(pr.row for pr in parsed_rows), fillvalue="")
-    for idx, (header, raw_values) in enumerate(zip(headers, columns)):
-        values = [v.strip() for v in raw_values if v.strip()]
-        if not values:
+class _ColumnAccumulator:
+    """Running state for one column during a single streaming pass. Numeric and
+    date stats are O(1); categorical and id-uniqueness tracking are capped, so a
+    high-cardinality column can't grow memory with the row count."""
+
+    __slots__ = (
+        "is_id_named",
+        "non_empty",
+        "is_numeric",
+        "total",
+        "minimum",
+        "maximum",
+        "is_date",
+        "date_min",
+        "date_max",
+        "counts",
+        "id_seen",
+        "has_duplicate",
+    )
+
+    def __init__(self, is_id_named: bool) -> None:
+        self.is_id_named = is_id_named
+        self.non_empty = 0
+        self.is_numeric = True
+        self.total = 0.0
+        self.minimum: float | None = None
+        self.maximum: float | None = None
+        self.is_date = True
+        self.date_min: date | None = None
+        self.date_max: date | None = None
+        self.counts: Counter[str] | None = Counter()
+        self.id_seen: set[str] | None = set() if is_id_named else None
+        self.has_duplicate = False
+
+    def observe(self, value: str) -> None:
+        self.non_empty += 1
+
+        if self.is_numeric:
+            n = _parse_num(value)
+            if n is None:
+                self.is_numeric = False
+            else:
+                self.total += n
+                self.minimum = n if self.minimum is None else min(self.minimum, n)
+                self.maximum = n if self.maximum is None else max(self.maximum, n)
+
+        if self.is_date:
+            d = _try_date(value)
+            if d is None:
+                self.is_date = False
+            else:
+                self.date_min = d if self.date_min is None else min(self.date_min, d)
+                self.date_max = d if self.date_max is None else max(self.date_max, d)
+
+        counts = self.counts
+        if counts is not None:
+            if value in counts or len(counts) < _CATEGORICAL_TRACK_CAP:
+                counts[value] += 1
+            else:
+                # Past the cap: high cardinality, not a categorical column.
+                self.counts = None
+
+        seen = self.id_seen
+        if seen is not None and not self.has_duplicate:
+            if value in seen:
+                self.has_duplicate = True
+            elif len(seen) < _ID_TRACK_CAP:
+                seen.add(value)
+
+
+def analyze_sheet(
+    headers: list[str], parsed_rows: Iterable[ParsedRow]
+) -> SheetAnalysis:
+    """Summarize a sheet's columns — types, numeric aggregates, top categorical
+    values, date range, identifier — in a single streaming pass over the rows so
+    memory stays flat regardless of sheet size."""
+    num_cols = len(headers)
+    cols = [_ColumnAccumulator(_is_id_name(h)) for h in headers]
+
+    row_count = 0
+    for pr in parsed_rows:
+        row_count += 1
+        row = pr.row
+        for idx in range(num_cols):
+            value = row[idx].strip() if idx < len(row) else ""
+            if value:
+                cols[idx].observe(value)
+
+    analysis = SheetAnalysis(row_count=row_count, num_cols=num_cols)
+    for idx, col in enumerate(cols):
+        if col.non_empty == 0:
             continue
 
-        # Identifier: id-named column whose values are all unique. Detected
-        # before classification so a numeric `id` column still gets flagged.
-        distinct = set(values)
-        if a.id_col is None and len(distinct) == len(values) and _is_id_name(header):
-            a.id_col = idx
+        # Identifier: id-named column with no duplicates. Detected before
+        # classification so a numeric `id` column still gets flagged.
+        if analysis.id_col is None and col.is_id_named and not col.has_duplicate:
+            analysis.id_col = idx
 
-        # Numeric: every value parses as a number.
-        nums = _try_all_numeric(values)
-        if nums is not None:
-            a.numeric_cols.append(idx)
-            a.numeric_values[idx] = nums
+        if col.is_numeric:
+            analysis.numeric_cols.append(idx)
+            analysis.numeric_stats[idx] = NumericAggregate(
+                total=col.total,
+                count=col.non_empty,
+                minimum=col.minimum if col.minimum is not None else 0.0,
+                maximum=col.maximum if col.maximum is not None else 0.0,
+            )
             continue
 
-        # Date: every value parses as a date — fold into the sheet-wide range.
-        dates = _try_all_dates(values)
-        if dates:
-            dmin = min(dates)
-            dmax = max(dates)
-            a.date_min = dmin if a.date_min is None else min(a.date_min, dmin)
-            a.date_max = dmax if a.date_max is None else max(a.date_max, dmax)
+        if col.is_date and col.date_min is not None and col.date_max is not None:
+            analysis.date_min = (
+                col.date_min
+                if analysis.date_min is None
+                else min(analysis.date_min, col.date_min)
+            )
+            analysis.date_max = (
+                col.date_max
+                if analysis.date_max is None
+                else max(analysis.date_max, col.date_max)
+            )
             continue
 
-        # Categorical: low-cardinality column — keep counts for samples + top values.
-        if len(distinct) <= max(CATEGORICAL_DISTINCT_THRESHOLD, len(values) // 2):
-            a.categorical_cols.append(idx)
-            a.categorical_counts[idx] = Counter(values)
-    return a
+        counts = col.counts
+        if counts is not None and len(counts) <= max(
+            CATEGORICAL_DISTINCT_THRESHOLD, col.non_empty // 2
+        ):
+            analysis.categorical_cols.append(idx)
+            analysis.categorical_counts[idx] = counts
 
-
-def _try_all_numeric(values: list[str]) -> list[float] | None:
-    parsed: list[float] = []
-    for v in values:
-        n = _parse_num(v)
-        if n is None:
-            return None
-        parsed.append(n)
-    return parsed
+    return analysis
 
 
 def _parse_num(value: str) -> float | None:
@@ -83,16 +187,6 @@ def _parse_num(value: str) -> float | None:
         return float(value.replace(",", ""))
     except ValueError:
         return None
-
-
-def _try_all_dates(values: list[str]) -> list[date] | None:
-    parsed: list[date] = []
-    for v in values:
-        d = _try_date(v)
-        if d is None:
-            return None
-        parsed.append(d)
-    return parsed
 
 
 def _try_date(value: str) -> date | None:

--- a/backend/onyx/indexing/chunking/tabular_section_chunker/tabular_section_chunker.py
+++ b/backend/onyx/indexing/chunking/tabular_section_chunker/tabular_section_chunker.py
@@ -326,8 +326,11 @@ class TabularChunker(SectionChunker):
         content_token_limit: int,
     ) -> SectionChunkerOutput:
         """Stream the CSV staged at ``csv_file_id`` straight into row chunks so a
-        huge sheet is never materialized. Descriptor/analysis chunks are skipped
-        here — those would need a second full pass over the rows."""
+        huge sheet is never materialized. A section is only file-backed when its
+        CSV exceeds the inline threshold, so descriptor/analysis chunks are
+        skipped: ``analyze_sheet`` transposes the whole sheet into memory, which
+        would defeat the streaming bound. Smaller sheets keep the inline path and
+        its descriptor chunks."""
         heading = section.heading or ""
         file_store = get_default_file_store()
         with file_store.read_file(csv_file_id, use_tempfile=True) as raw:

--- a/backend/onyx/indexing/chunking/tabular_section_chunker/tabular_section_chunker.py
+++ b/backend/onyx/indexing/chunking/tabular_section_chunker/tabular_section_chunker.py
@@ -12,6 +12,7 @@ from onyx.indexing.chunking.section_chunker import ChunkPayload
 from onyx.indexing.chunking.section_chunker import SectionChunker
 from onyx.indexing.chunking.section_chunker import SectionChunkerOutput
 from onyx.indexing.chunking.tabular_section_chunker.analysis import analyze_sheet
+from onyx.indexing.chunking.tabular_section_chunker.analysis import SheetAnalysis
 from onyx.indexing.chunking.tabular_section_chunker.sheet_descriptor import (
     build_sheet_descriptor_chunks,
 )
@@ -247,20 +248,28 @@ class TabularChunker(SectionChunker):
             section.csv_file_id if isinstance(section, TabularSection) else None
         )
         if csv_file_id:
-            # Huge sheet: stream rows straight from the staged CSV so it is never
-            # fully materialized. Descriptor/analysis chunks are omitted here —
-            # analyze_sheet needs the whole sheet in memory, which would defeat
-            # the streaming bound. Smaller sheets stay inline and keep them.
+            # Huge sheet: never fully materialized. One streaming pass over the
+            # staged CSV for row chunks, plus a second bounded streaming pass
+            # through analyze_sheet for descriptor/total chunks.
             file_store = get_default_file_store()
+            chunk_texts: list[str] = []
             with file_store.read_file(csv_file_id, use_tempfile=True) as raw:
                 rows = io.TextIOWrapper(raw, encoding="utf-8", newline="")
-                streamed_chunks = parse_to_chunks(
-                    rows=parse_csv_stream(rows),
-                    sheet_header=heading,
-                    tokenizer=self.tokenizer,
-                    max_tokens=content_token_limit,
+                chunk_texts.extend(
+                    parse_to_chunks(
+                        rows=parse_csv_stream(rows),
+                        sheet_header=heading,
+                        tokenizer=self.tokenizer,
+                        max_tokens=content_token_limit,
+                    )
                 )
-            return self._build_output(streamed_chunks, section, payloads)
+            if not self.ignore_metadata_chunks:
+                chunk_texts.extend(
+                    self._streamed_descriptor_chunks(
+                        csv_file_id, heading, content_token_limit
+                    )
+                )
+            return self._build_output(chunk_texts, section, payloads)
 
         # Inline sheet: small enough to materialize, so it also gets descriptors.
         text = section.text or ""
@@ -280,24 +289,53 @@ class TabularChunker(SectionChunker):
         if not self.ignore_metadata_chunks and headers:
             analysis = analyze_sheet(headers, parsed_rows)
             inline_chunks.extend(
-                build_sheet_descriptor_chunks(
-                    headers=headers,
-                    analysis=analysis,
-                    heading=heading,
-                    tokenizer=self.tokenizer,
-                    max_tokens=content_token_limit,
-                )
-            )
-            inline_chunks.extend(
-                build_total_descriptor_chunks(
-                    headers=headers,
-                    analysis=analysis,
-                    heading=heading,
-                    tokenizer=self.tokenizer,
-                    max_tokens=content_token_limit,
-                )
+                self._descriptor_chunks(headers, analysis, heading, content_token_limit)
             )
         return self._build_output(inline_chunks, section, payloads)
+
+    def _descriptor_chunks(
+        self,
+        headers: list[str],
+        analysis: SheetAnalysis,
+        heading: str,
+        content_token_limit: int,
+    ) -> list[str]:
+        chunks = list(
+            build_sheet_descriptor_chunks(
+                headers=headers,
+                analysis=analysis,
+                heading=heading,
+                tokenizer=self.tokenizer,
+                max_tokens=content_token_limit,
+            )
+        )
+        chunks.extend(
+            build_total_descriptor_chunks(
+                headers=headers,
+                analysis=analysis,
+                heading=heading,
+                tokenizer=self.tokenizer,
+                max_tokens=content_token_limit,
+            )
+        )
+        return chunks
+
+    def _streamed_descriptor_chunks(
+        self, csv_file_id: str, heading: str, content_token_limit: int
+    ) -> list[str]:
+        """Second bounded streaming pass over the staged CSV: derive descriptor
+        and total chunks via analyze_sheet (one row plus capped per-column state
+        in memory)."""
+        file_store = get_default_file_store()
+        with file_store.read_file(csv_file_id, use_tempfile=True) as raw:
+            rows = parse_csv_stream(io.TextIOWrapper(raw, encoding="utf-8", newline=""))
+            try:
+                first = next(rows)
+            except StopIteration:
+                return []
+            headers = first.header
+            analysis = analyze_sheet(headers, chain([first], rows))
+        return self._descriptor_chunks(headers, analysis, heading, content_token_limit)
 
     def _build_output(
         self,

--- a/backend/onyx/indexing/chunking/tabular_section_chunker/tabular_section_chunker.py
+++ b/backend/onyx/indexing/chunking/tabular_section_chunker/tabular_section_chunker.py
@@ -1,8 +1,13 @@
+import csv
+import io
 from collections.abc import Iterable
+from collections.abc import Iterator
+from itertools import chain
 
 from pydantic import BaseModel
 
 from onyx.connectors.models import Section
+from onyx.file_store.file_store import get_default_file_store
 from onyx.indexing.chunking.section_chunker import AccumulatorState
 from onyx.indexing.chunking.section_chunker import ChunkPayload
 from onyx.indexing.chunking.section_chunker import SectionChunker
@@ -166,11 +171,13 @@ def parse_to_chunks(
     tokenizer: BaseTokenizer,
     max_tokens: int,
 ) -> list[str]:
-    rows_list = list(rows)
-    if not rows_list:
+    row_iter = iter(rows)
+    try:
+        first_row = next(row_iter)
+    except StopIteration:
         return []
 
-    column_header = format_columns_header(rows_list[0].header)
+    column_header = format_columns_header(first_row.header)
     column_header_tokens = count_tokens(column_header, tokenizer)
     sheet_header_tokens = count_tokens(sheet_header, tokenizer) if sheet_header else 0
 
@@ -178,7 +185,7 @@ def parse_to_chunks(
     current_chunk = ""
     current_chunk_tokens = 0
 
-    for row in rows_list:
+    for row in chain([first_row], row_iter):
         pairs: list[tuple[str, str]] = _row_to_pairs(row.header, row.row)
         formatted = format_row(row.header, row.row)
         row_tokens = count_tokens(formatted, tokenizer)
@@ -218,6 +225,21 @@ def parse_to_chunks(
     return chunks
 
 
+def _iter_parsed_rows_streamed(lines: Iterable[str]) -> Iterator[ParsedRow]:
+    """Stream ParsedRows from a CSV line source (e.g. a file handle), header
+    first, without materializing the file — the file-backed counterpart to
+    ``parse_csv_string`` (which buffers the whole string into a list)."""
+    reader = csv.reader(lines)
+    header: list[str] | None = None
+    for row in reader:
+        if not any(cell.strip() for cell in row):
+            continue
+        if header is None:
+            header = row
+            continue
+        yield ParsedRow(header=header, row=row)
+
+
 class TabularChunker(SectionChunker):
     def __init__(
         self,
@@ -234,6 +256,12 @@ class TabularChunker(SectionChunker):
         content_token_limit: int,
     ) -> SectionChunkerOutput:
         payloads = accumulator.flush_to_list()
+
+        csv_file_id = getattr(section, "csv_file_id", None)
+        if csv_file_id:
+            return self._chunk_file_backed_section(
+                section, csv_file_id, payloads, content_token_limit
+            )
 
         text = section.text or ""
         parsed_rows = list(parse_csv_string(text))
@@ -275,6 +303,46 @@ class TabularChunker(SectionChunker):
         if not chunk_texts:
             logger.warning(
                 "TabularChunker: skipping unparseable section (link=%s)", section.link
+            )
+            return SectionChunkerOutput(
+                payloads=payloads, accumulator=AccumulatorState()
+            )
+
+        for i, text in enumerate(chunk_texts):
+            payloads.append(
+                ChunkPayload(
+                    text=text,
+                    links={0: section.link or ""},
+                    is_continuation=(i > 0),
+                )
+            )
+        return SectionChunkerOutput(payloads=payloads, accumulator=AccumulatorState())
+
+    def _chunk_file_backed_section(
+        self,
+        section: Section,
+        csv_file_id: str,
+        payloads: list[ChunkPayload],
+        content_token_limit: int,
+    ) -> SectionChunkerOutput:
+        """Stream the CSV staged at ``csv_file_id`` straight into row chunks so a
+        huge sheet is never materialized. Descriptor/analysis chunks are skipped
+        here — those would need a second full pass over the rows."""
+        heading = section.heading or ""
+        file_store = get_default_file_store()
+        with file_store.read_file(csv_file_id, use_tempfile=True) as raw:
+            text_stream = io.TextIOWrapper(raw, encoding="utf-8", newline="")
+            chunk_texts = parse_to_chunks(
+                rows=_iter_parsed_rows_streamed(text_stream),
+                sheet_header=heading,
+                tokenizer=self.tokenizer,
+                max_tokens=content_token_limit,
+            )
+
+        if not chunk_texts:
+            logger.warning(
+                "TabularChunker: file-backed section yielded no chunks (link=%s)",
+                section.link,
             )
             return SectionChunkerOutput(
                 payloads=payloads, accumulator=AccumulatorState()

--- a/backend/onyx/indexing/chunking/tabular_section_chunker/tabular_section_chunker.py
+++ b/backend/onyx/indexing/chunking/tabular_section_chunker/tabular_section_chunker.py
@@ -1,12 +1,11 @@
-import csv
 import io
 from collections.abc import Iterable
-from collections.abc import Iterator
 from itertools import chain
 
 from pydantic import BaseModel
 
 from onyx.connectors.models import Section
+from onyx.connectors.models import TabularSection
 from onyx.file_store.file_store import get_default_file_store
 from onyx.indexing.chunking.section_chunker import AccumulatorState
 from onyx.indexing.chunking.section_chunker import ChunkPayload
@@ -22,6 +21,7 @@ from onyx.indexing.chunking.tabular_section_chunker.total_descriptor import (
 from onyx.natural_language_processing.utils import BaseTokenizer
 from onyx.natural_language_processing.utils import count_tokens
 from onyx.natural_language_processing.utils import split_text_by_tokens
+from onyx.utils.csv_utils import parse_csv_stream
 from onyx.utils.csv_utils import parse_csv_string
 from onyx.utils.csv_utils import ParsedRow
 from onyx.utils.csv_utils import read_csv_header
@@ -225,20 +225,6 @@ def parse_to_chunks(
     return chunks
 
 
-def _iter_parsed_rows_streamed(lines: Iterable[str]) -> Iterator[ParsedRow]:
-    """Stream ParsedRows from a CSV line source (e.g. a file handle), header
-    first, without buffering the whole file into memory."""
-    reader = csv.reader(lines)
-    header: list[str] | None = None
-    for row in reader:
-        if not any(cell.strip() for cell in row):
-            continue
-        if header is None:
-            header = row
-            continue
-        yield ParsedRow(header=header, row=row)
-
-
 class TabularChunker(SectionChunker):
     def __init__(
         self,
@@ -255,21 +241,35 @@ class TabularChunker(SectionChunker):
         content_token_limit: int,
     ) -> SectionChunkerOutput:
         payloads = accumulator.flush_to_list()
+        heading = section.heading or ""
 
-        csv_file_id = getattr(section, "csv_file_id", None)
+        csv_file_id = (
+            section.csv_file_id if isinstance(section, TabularSection) else None
+        )
         if csv_file_id:
-            return self._chunk_file_backed_section(
-                section, csv_file_id, payloads, content_token_limit
-            )
+            # Huge sheet: stream rows straight from the staged CSV so it is never
+            # fully materialized. Descriptor/analysis chunks are omitted here —
+            # analyze_sheet needs the whole sheet in memory, which would defeat
+            # the streaming bound. Smaller sheets stay inline and keep them.
+            file_store = get_default_file_store()
+            with file_store.read_file(csv_file_id, use_tempfile=True) as raw:
+                rows = io.TextIOWrapper(raw, encoding="utf-8", newline="")
+                streamed_chunks = parse_to_chunks(
+                    rows=parse_csv_stream(rows),
+                    sheet_header=heading,
+                    tokenizer=self.tokenizer,
+                    max_tokens=content_token_limit,
+                )
+            return self._build_output(streamed_chunks, section, payloads)
 
+        # Inline sheet: small enough to materialize, so it also gets descriptors.
         text = section.text or ""
         parsed_rows = list(parse_csv_string(text))
         headers = parsed_rows[0].header if parsed_rows else read_csv_header(text)
-        heading = section.heading or ""
 
-        chunk_texts: list[str] = []
+        inline_chunks: list[str] = []
         if parsed_rows:
-            chunk_texts.extend(
+            inline_chunks.extend(
                 parse_to_chunks(
                     rows=parsed_rows,
                     sheet_header=heading,
@@ -277,10 +277,9 @@ class TabularChunker(SectionChunker):
                     max_tokens=content_token_limit,
                 )
             )
-
         if not self.ignore_metadata_chunks and headers:
             analysis = analyze_sheet(headers, parsed_rows)
-            chunk_texts.extend(
+            inline_chunks.extend(
                 build_sheet_descriptor_chunks(
                     headers=headers,
                     analysis=analysis,
@@ -289,7 +288,7 @@ class TabularChunker(SectionChunker):
                     max_tokens=content_token_limit,
                 )
             )
-            chunk_texts.extend(
+            inline_chunks.extend(
                 build_total_descriptor_chunks(
                     headers=headers,
                     analysis=analysis,
@@ -298,56 +297,21 @@ class TabularChunker(SectionChunker):
                     max_tokens=content_token_limit,
                 )
             )
+        return self._build_output(inline_chunks, section, payloads)
 
-        if not chunk_texts:
-            logger.warning(
-                "TabularChunker: skipping unparseable section (link=%s)", section.link
-            )
-            return SectionChunkerOutput(
-                payloads=payloads, accumulator=AccumulatorState()
-            )
-
-        for i, text in enumerate(chunk_texts):
-            payloads.append(
-                ChunkPayload(
-                    text=text,
-                    links={0: section.link or ""},
-                    is_continuation=(i > 0),
-                )
-            )
-        return SectionChunkerOutput(payloads=payloads, accumulator=AccumulatorState())
-
-    def _chunk_file_backed_section(
+    def _build_output(
         self,
+        chunk_texts: list[str],
         section: Section,
-        csv_file_id: str,
         payloads: list[ChunkPayload],
-        content_token_limit: int,
     ) -> SectionChunkerOutput:
-        """Stream the staged CSV straight into row chunks so a huge sheet is never
-        materialized. Descriptor/analysis chunks are skipped: ``analyze_sheet``
-        transposes the whole sheet into memory, which would defeat the streaming
-        bound. Small sheets keep the inline path and its descriptors."""
-        heading = section.heading or ""
-        file_store = get_default_file_store()
-        with file_store.read_file(csv_file_id, use_tempfile=True) as raw:
-            text_stream = io.TextIOWrapper(raw, encoding="utf-8", newline="")
-            chunk_texts = parse_to_chunks(
-                rows=_iter_parsed_rows_streamed(text_stream),
-                sheet_header=heading,
-                tokenizer=self.tokenizer,
-                max_tokens=content_token_limit,
-            )
-
         if not chunk_texts:
             logger.warning(
-                "TabularChunker: file-backed section yielded no chunks (link=%s)",
-                section.link,
+                "TabularChunker: section yielded no chunks (link=%s)", section.link
             )
             return SectionChunkerOutput(
                 payloads=payloads, accumulator=AccumulatorState()
             )
-
         for i, text in enumerate(chunk_texts):
             payloads.append(
                 ChunkPayload(

--- a/backend/onyx/indexing/chunking/tabular_section_chunker/tabular_section_chunker.py
+++ b/backend/onyx/indexing/chunking/tabular_section_chunker/tabular_section_chunker.py
@@ -227,8 +227,7 @@ def parse_to_chunks(
 
 def _iter_parsed_rows_streamed(lines: Iterable[str]) -> Iterator[ParsedRow]:
     """Stream ParsedRows from a CSV line source (e.g. a file handle), header
-    first, without materializing the file — the file-backed counterpart to
-    ``parse_csv_string`` (which buffers the whole string into a list)."""
+    first, without buffering the whole file into memory."""
     reader = csv.reader(lines)
     header: list[str] | None = None
     for row in reader:
@@ -325,12 +324,10 @@ class TabularChunker(SectionChunker):
         payloads: list[ChunkPayload],
         content_token_limit: int,
     ) -> SectionChunkerOutput:
-        """Stream the CSV staged at ``csv_file_id`` straight into row chunks so a
-        huge sheet is never materialized. A section is only file-backed when its
-        CSV exceeds the inline threshold, so descriptor/analysis chunks are
-        skipped: ``analyze_sheet`` transposes the whole sheet into memory, which
-        would defeat the streaming bound. Smaller sheets keep the inline path and
-        its descriptor chunks."""
+        """Stream the staged CSV straight into row chunks so a huge sheet is never
+        materialized. Descriptor/analysis chunks are skipped: ``analyze_sheet``
+        transposes the whole sheet into memory, which would defeat the streaming
+        bound. Small sheets keep the inline path and its descriptors."""
         heading = section.heading or ""
         file_store = get_default_file_store()
         with file_store.read_file(csv_file_id, use_tempfile=True) as raw:

--- a/backend/onyx/indexing/chunking/tabular_section_chunker/total_descriptor.py
+++ b/backend/onyx/indexing/chunking/tabular_section_chunker/total_descriptor.py
@@ -1,5 +1,6 @@
 from collections import Counter
 
+from onyx.indexing.chunking.tabular_section_chunker.analysis import NumericAggregate
 from onyx.indexing.chunking.tabular_section_chunker.analysis import SheetAnalysis
 from onyx.indexing.chunking.tabular_section_chunker.util import label
 from onyx.indexing.chunking.tabular_section_chunker.util import pack_lines
@@ -24,7 +25,7 @@ def build_total_descriptor_chunks(
 
     lines: list[str] = []
     for idx in analysis.numeric_cols:
-        lines.append(_numeric_totals_line(headers[idx], analysis.numeric_values[idx]))
+        lines.append(_numeric_totals_line(headers[idx], analysis.numeric_stats[idx]))
     for idx in analysis.categorical_cols:
         line = _categorical_top_line(headers[idx], analysis.categorical_counts[idx])
         if line:
@@ -45,13 +46,11 @@ def build_total_descriptor_chunks(
     )
 
 
-def _numeric_totals_line(name: str, values: list[float]) -> str:
-    total = sum(values)
-    avg = total / len(values)
+def _numeric_totals_line(name: str, agg: NumericAggregate) -> str:
     return (
-        f"Column {label(name)}: total (sum across all rows) = {_fmt(total)}, "
-        f"average = {_fmt(avg)}, minimum = {_fmt(min(values))}, "
-        f"maximum = {_fmt(max(values))}, count = {len(values)}."
+        f"Column {label(name)}: total (sum across all rows) = {_fmt(agg.total)}, "
+        f"average = {_fmt(agg.average)}, minimum = {_fmt(agg.minimum)}, "
+        f"maximum = {_fmt(agg.maximum)}, count = {agg.count}."
     )
 
 

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -31,6 +31,7 @@ from onyx.connectors.models import IndexAttemptMetadata
 from onyx.connectors.models import IndexingDocument
 from onyx.connectors.models import Section
 from onyx.connectors.models import SectionType
+from onyx.connectors.models import TabularSection
 from onyx.connectors.models import TextSection
 from onyx.db.connector_credential_pair import get_connector_credential_pair
 from onyx.db.document import get_documents_by_ids
@@ -720,6 +721,17 @@ def process_image_sections(documents: list[Document]) -> list[IndexingDocument]:
         # Only get the vision LLM if image processing is enabled
         llm = get_default_llm_with_vision()
 
+    def _clone_non_image_section(section: Section) -> Section:
+        if isinstance(section, TabularSection):
+            return section.model_copy()
+        return Section(
+            type=section.type,
+            text=section.text or "",
+            link=section.link,
+            image_file_id=None,
+            heading=section.heading,
+        )
+
     if not llm:
         if get_image_extraction_and_analysis_enabled():
             logger.warning(
@@ -732,15 +744,16 @@ def process_image_sections(documents: list[Document]) -> list[IndexingDocument]:
             IndexingDocument(
                 **document.model_dump(),
                 processed_sections=[
-                    Section(
-                        type=section.type,
-                        text="" if isinstance(section, ImageSection) else section.text,
-                        link=section.link,
-                        image_file_id=(
-                            section.image_file_id
-                            if isinstance(section, ImageSection)
-                            else None
-                        ),
+                    (
+                        Section(
+                            type=section.type,
+                            text="",
+                            link=section.link,
+                            image_file_id=section.image_file_id,
+                            heading=section.heading,
+                        )
+                        if isinstance(section, ImageSection)
+                        else _clone_non_image_section(section)
                     )
                     for section in document.sections
                 ],
@@ -760,14 +773,7 @@ def process_image_sections(documents: list[Document]) -> list[IndexingDocument]:
 
         for section in document.sections:
             if not isinstance(section, ImageSection):
-                processed_sections.append(
-                    Section(
-                        type=section.type,
-                        text=section.text or "",
-                        link=section.link,
-                        image_file_id=None,
-                    )
-                )
+                processed_sections.append(_clone_non_image_section(section))
                 continue
 
             processed_section = Section(
@@ -775,6 +781,7 @@ def process_image_sections(documents: list[Document]) -> list[IndexingDocument]:
                 link=section.link,
                 image_file_id=section.image_file_id,
                 text="",
+                heading=section.heading,
             )
             processed_sections.append(processed_section)
 

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -722,6 +722,8 @@ def process_image_sections(documents: list[Document]) -> list[IndexingDocument]:
         llm = get_default_llm_with_vision()
 
     def _clone_non_image_section(section: Section) -> Section:
+        """Copy a non-image section, preserving a TabularSection (and its
+        csv_file_id) rather than flattening it to a base Section."""
         if isinstance(section, TabularSection):
             return section.model_copy()
         return Section(

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -31,7 +31,6 @@ from onyx.connectors.models import IndexAttemptMetadata
 from onyx.connectors.models import IndexingDocument
 from onyx.connectors.models import Section
 from onyx.connectors.models import SectionType
-from onyx.connectors.models import TabularSection
 from onyx.connectors.models import TextSection
 from onyx.db.connector_credential_pair import get_connector_credential_pair
 from onyx.db.document import get_documents_by_ids
@@ -721,19 +720,6 @@ def process_image_sections(documents: list[Document]) -> list[IndexingDocument]:
         # Only get the vision LLM if image processing is enabled
         llm = get_default_llm_with_vision()
 
-    def _clone_non_image_section(section: Section) -> Section:
-        """Copy a non-image section, preserving a TabularSection (and its
-        csv_file_id) rather than flattening it to a base Section."""
-        if isinstance(section, TabularSection):
-            return section.model_copy()
-        return Section(
-            type=section.type,
-            text=section.text or "",
-            link=section.link,
-            image_file_id=None,
-            heading=section.heading,
-        )
-
     if not llm:
         if get_image_extraction_and_analysis_enabled():
             logger.warning(
@@ -755,7 +741,7 @@ def process_image_sections(documents: list[Document]) -> list[IndexingDocument]:
                             heading=section.heading,
                         )
                         if isinstance(section, ImageSection)
-                        else _clone_non_image_section(section)
+                        else section.model_copy()
                     )
                     for section in document.sections
                 ],
@@ -775,7 +761,9 @@ def process_image_sections(documents: list[Document]) -> list[IndexingDocument]:
 
         for section in document.sections:
             if not isinstance(section, ImageSection):
-                processed_sections.append(_clone_non_image_section(section))
+                # model_copy keeps the concrete section (incl. a TabularSection's
+                # csv_file_id) intact; rebuilding as a base Section would drop it.
+                processed_sections.append(section.model_copy())
                 continue
 
             processed_section = Section(

--- a/backend/onyx/utils/csv_utils.py
+++ b/backend/onyx/utils/csv_utils.py
@@ -1,6 +1,8 @@
 import csv
 import io
 from collections.abc import Generator
+from collections.abc import Iterable
+from collections.abc import Iterator
 from collections.abc import Mapping
 
 from pydantic import BaseModel
@@ -86,35 +88,39 @@ def read_csv_header(csv_text: str) -> list[str]:
         raise csv.Error(f"read_csv_header failed: {e}") from e
 
 
+def parse_csv_stream(lines: Iterable[str]) -> Iterator[ParsedRow]:
+    """Stream each data row paired with its header from a CSV line source (a file
+    handle or any iterable of lines), header first, without buffering the input.
+
+    Assumes clean line endings; `parse_csv_string` wraps this for in-memory
+    strings that may use bare-``\\r`` (old Mac) row separators.
+    """
+    reader = csv.reader(lines)
+    header: list[str] | None = None
+    for row in reader:
+        if not any(cell.strip() for cell in row):
+            continue
+        if header is None:
+            header = row
+            continue
+        yield ParsedRow(header=header, row=row)
+
+
 def parse_csv_string(csv_text: str) -> Generator[ParsedRow, None, None]:
     """Yield each data row paired with its header from a CSV string.
 
     Falls back to normalized line endings when csv.reader raises the
     specific "new-line character" error (e.g. old Mac-format CSVs).
     """
-
-    def _parse(text: str) -> list[ParsedRow]:
-        reader = csv.reader(io.StringIO(text))
-        header: list[str] | None = None
-        rows: list[ParsedRow] = []
-        for row in reader:
-            if not any(cell.strip() for cell in row):
-                continue
-            if header is None:
-                header = row
-                continue
-            rows.append(ParsedRow(header=header, row=row))
-        return rows
-
     if not csv_text.strip():
         return
     try:
-        rows = _parse(csv_text)
+        rows = list(parse_csv_stream(io.StringIO(csv_text)))
     except csv.Error as e:
         if _NEWLINE_CSV_ERROR not in str(e):
             raise csv.Error(f"parse_csv_string failed: {e}") from e
         try:
-            rows = _parse(normalize_csv_newlines(csv_text))
+            rows = list(parse_csv_stream(io.StringIO(normalize_csv_newlines(csv_text))))
         except csv.Error as e2:
             raise csv.Error(f"parse_csv_string failed: {e2}") from e2
     yield from rows

--- a/backend/tests/daily/connectors/blob/test_blob_connector.py
+++ b/backend/tests/daily/connectors/blob/test_blob_connector.py
@@ -135,7 +135,7 @@ def test_blob_s3_connector(
 
         if is_tabular_file(doc.semantic_identifier):
             assert isinstance(section, TabularSection)
-            assert len(section.text) > 0
+            assert len(section.text or "") > 0
             continue
 
         assert isinstance(section, TextSection)

--- a/backend/tests/unit/onyx/connectors/braintrust/test_braintrust_connector.py
+++ b/backend/tests/unit/onyx/connectors/braintrust/test_braintrust_connector.py
@@ -188,7 +188,7 @@ def test_dataset_doc_has_text_and_tabular_sections(
     assert "merge-cases" in (text.text or "")
     assert "1 rows" in (text.text or "")
     assert isinstance(tabular, TabularSection)
-    header, row = tabular.text.split("\n")
+    header, row = (tabular.text or "").split("\n")
     assert header == "id,created,input,expected,metadata,tags"
     assert row.startswith("row-1,")
     assert '""doc"": ""a.md""' in row
@@ -210,7 +210,7 @@ def test_experiment_doc_combines_summary_and_score_table(
     assert "+0.05" in body
     assert "3 improvements / 1 regressions" in body
     assert isinstance(tabular, TabularSection)
-    header, row = tabular.text.split("\n")
+    header, row = (tabular.text or "").split("\n")
     assert header == "id,created,input,output,expected,correctness"
     assert row.startswith("row-2,") and row.endswith(",0.9")
     assert tabular.link == _SUMMARY["experiment_url"]
@@ -297,7 +297,7 @@ def test_btql_keyset_pagination_accumulates_table() -> None:
 
     tabular = doc.sections[1]
     assert isinstance(tabular, TabularSection)
-    assert len(tabular.text.split("\n")) == 1 + 501
+    assert len((tabular.text or "").split("\n")) == 1 + 501
     assert len(seen_filters) == 2
     assert "_pagination_key < 'p401'" in seen_filters[1]
 

--- a/backend/tests/unit/onyx/connectors/cross_connector_utils/test_tabular_section_utils.py
+++ b/backend/tests/unit/onyx/connectors/cross_connector_utils/test_tabular_section_utils.py
@@ -1,5 +1,6 @@
 import io
 from typing import cast
+from typing import IO
 
 import openpyxl
 import pytest
@@ -59,9 +60,62 @@ class TestTabularFileToSections:
             file_name="budget.xlsm",
         )
         assert len(sections) == 1
-        assert "Alice" in sections[0].text
+        assert "Alice" in (sections[0].text or "")
         assert sections[0].heading == "budget.xlsm :: Sheet1"
 
     def test_unknown_extension_raises(self) -> None:
         with pytest.raises(ValueError):
             tabular_file_to_sections(io.BytesIO(b""), file_name="notes.pdf")
+
+
+class TestFileBackedXlsx:
+    """A workbook with a large sheet streams to file-backed TabularSections
+    (CSV staged via the callback, no inline text) and is not truncated."""
+
+    def test_large_xlsx_routes_to_file_backed_no_truncation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import onyx.connectors.cross_connector_utils.tabular_section_utils as mod
+
+        rows = [["name", "score"]] + [[f"user{i}", str(i)] for i in range(200)]
+        xlsx = _make_xlsx_bytes({"Sheet1": rows})
+        # Force the large-sheet route without needing a multi-MB fixture.
+        monkeypatch.setattr(mod, "xlsx_has_large_sheet", lambda _f: True)
+
+        staged: dict[str, tuple[bytes, str]] = {}
+
+        def fake_callback(content: IO[bytes], content_type: str) -> str:
+            file_id = f"csv-{len(staged)}"
+            staged[file_id] = (content.read(), content_type)
+            return file_id
+
+        sections = mod.tabular_file_to_sections(
+            xlsx, file_name="big.xlsx", raw_file_callback=fake_callback
+        )
+
+        assert len(sections) == 1
+        section = sections[0]
+        assert section.text is None
+        assert section.csv_file_id is not None
+        assert section.heading == "big.xlsx :: Sheet1"
+
+        csv_bytes, content_type = staged[section.csv_file_id]
+        assert content_type == "text/csv"
+        csv_text = csv_bytes.decode("utf-8")
+        assert "name,score" in csv_text
+        assert "user0,0" in csv_text
+        assert "user199,199" in csv_text  # last row present -> no truncation
+        data_rows = [line for line in csv_text.splitlines() if line.strip()]
+        assert len(data_rows) == 201  # header + 200 rows
+
+    def test_small_xlsx_stays_inline(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import onyx.connectors.cross_connector_utils.tabular_section_utils as mod
+
+        xlsx = _make_xlsx_bytes({"Sheet1": [["a", "b"], ["1", "2"]]})
+        monkeypatch.setattr(mod, "xlsx_has_large_sheet", lambda _f: False)
+        sections = mod.tabular_file_to_sections(
+            xlsx, file_name="small.xlsx", raw_file_callback=lambda _c, _t: "unused"
+        )
+        assert len(sections) == 1
+        assert sections[0].csv_file_id is None
+        assert "a,b" in (sections[0].text or "")

--- a/backend/tests/unit/onyx/connectors/cross_connector_utils/test_tabular_section_utils.py
+++ b/backend/tests/unit/onyx/connectors/cross_connector_utils/test_tabular_section_utils.py
@@ -69,18 +69,21 @@ class TestTabularFileToSections:
 
 
 class TestFileBackedXlsx:
-    """A workbook with a large sheet streams to file-backed TabularSections
-    (CSV staged via the callback, no inline text) and is not truncated."""
+    """Within a workbook routed to streaming, each sheet is handled by size:
+    oversized sheets are file-backed (no inline text, not truncated); small
+    sheets stay inline so they keep their descriptor chunks downstream."""
 
-    def test_large_xlsx_routes_to_file_backed_no_truncation(
+    def test_oversized_sheet_is_file_backed_no_truncation(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         import onyx.connectors.cross_connector_utils.tabular_section_utils as mod
 
         rows = [["name", "score"]] + [[f"user{i}", str(i)] for i in range(200)]
         xlsx = _make_xlsx_bytes({"Sheet1": rows})
-        # Force the large-sheet route without needing a multi-MB fixture.
+        # Enter the streaming path and force this sheet over the inline threshold
+        # without needing a multi-MB fixture.
         monkeypatch.setattr(mod, "xlsx_has_large_sheet", lambda _f: True)
+        monkeypatch.setattr(mod, "XLSX_STREAM_SHEET_BYTES", 10)
 
         staged: dict[str, tuple[bytes, str]] = {}
 
@@ -108,7 +111,24 @@ class TestFileBackedXlsx:
         data_rows = [line for line in csv_text.splitlines() if line.strip()]
         assert len(data_rows) == 201  # header + 200 rows
 
-    def test_small_xlsx_stays_inline(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_small_sheet_in_streaming_workbook_stays_inline(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import onyx.connectors.cross_connector_utils.tabular_section_utils as mod
+
+        xlsx = _make_xlsx_bytes({"Sheet1": [["a", "b"], ["1", "2"]]})
+        # Streaming path, but this sheet is tiny -> inline (keeps descriptors).
+        monkeypatch.setattr(mod, "xlsx_has_large_sheet", lambda _f: True)
+        sections = mod.tabular_file_to_sections(
+            xlsx, file_name="mixed.xlsx", raw_file_callback=lambda _c, _t: "unused"
+        )
+        assert len(sections) == 1
+        assert sections[0].csv_file_id is None
+        assert "a,b" in (sections[0].text or "")
+
+    def test_small_workbook_uses_inline_path(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         import onyx.connectors.cross_connector_utils.tabular_section_utils as mod
 
         xlsx = _make_xlsx_bytes({"Sheet1": [["a", "b"], ["1", "2"]]})

--- a/backend/tests/unit/onyx/indexing/test_document_chunker.py
+++ b/backend/tests/unit/onyx/indexing/test_document_chunker.py
@@ -1,3 +1,5 @@
+import io
+
 import pytest
 from chonkie import SentenceChunker
 
@@ -6,6 +8,7 @@ from onyx.configs.constants import SECTION_SEPARATOR
 from onyx.connectors.models import IndexingDocument
 from onyx.connectors.models import Section
 from onyx.connectors.models import SectionType
+from onyx.connectors.models import TabularSection
 from onyx.indexing.chunking import DocumentChunker
 from onyx.indexing.chunking import text_section_chunker as text_chunker_module
 from onyx.natural_language_processing.utils import BaseTokenizer
@@ -785,3 +788,45 @@ def test_no_trailing_empty_chunk_when_last_section_was_oversized() -> None:
 
     # Every chunk should be non-empty — no dangling "" chunk at the tail.
     assert all(c.content.strip() for c in chunks)
+
+
+# --- File-backed tabular sections are not filtered as empty ------------------
+
+
+def test_file_backed_tabular_section_in_untitled_doc_is_chunked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A file-backed TabularSection holds its content in csv_file_id, not text,
+    so the empty-section guard would otherwise drop it in a no-title doc. It
+    must instead reach the tabular chunker and produce row chunks."""
+    import onyx.indexing.chunking.tabular_section_chunker.tabular_section_chunker as tab_mod
+
+    csv_text = "name,score\n" + "\n".join(f"rowval{i},{i}" for i in range(30))
+
+    class _FakeStore:
+        def read_file(
+            self, file_id: str, mode: str | None = None, use_tempfile: bool = False
+        ) -> io.BytesIO:
+            del file_id, mode, use_tempfile  # stub: signature parity only
+            return io.BytesIO(csv_text.encode("utf-8"))
+
+    monkeypatch.setattr(tab_mod, "get_default_file_store", lambda: _FakeStore())
+
+    dc = _make_document_chunker()
+    doc = _make_doc(
+        sections=[TabularSection(link="x", csv_file_id="csv-1", heading="Sheet1")],
+        title=None,
+    )
+
+    chunks = dc.chunk(
+        document=doc,
+        sections=doc.processed_sections,
+        title_prefix="",
+        metadata_suffix_semantic="",
+        metadata_suffix_keyword="",
+        content_token_limit=CHUNK_LIMIT,
+    )
+
+    joined = "\n".join(c.content for c in chunks)
+    assert "rowval0" in joined
+    assert "rowval29" in joined

--- a/backend/tests/unit/onyx/indexing/test_indexing_pipeline.py
+++ b/backend/tests/unit/onyx/indexing/test_indexing_pipeline.py
@@ -15,6 +15,7 @@ import pytest
 from onyx.connectors.models import Document
 from onyx.connectors.models import DocumentSource
 from onyx.connectors.models import ImageSection
+from onyx.connectors.models import TabularSection
 from onyx.connectors.models import TextSection
 from onyx.hooks.executor import HookSkipped
 from onyx.hooks.executor import HookSoftFailed
@@ -600,6 +601,17 @@ def _make_image_doc(
     )
 
 
+def _make_tabular_doc(doc_id: str, section: TabularSection) -> Document:
+    return Document(
+        id=doc_id,
+        title=f"Doc {doc_id}",
+        semantic_identifier=doc_id,
+        sections=[section],
+        source=DocumentSource.FILE,
+        metadata={},
+    )
+
+
 class TestProcessImageSections:
     """Validate that parallel image summarization places results in the
     correct section positions — especially under concurrent execution."""
@@ -637,6 +649,31 @@ class TestProcessImageSections:
             ),
         ):
             return process_image_sections(documents)
+
+    def test_file_backed_tabular_preserved_with_llm(self) -> None:
+        """A file-backed TabularSection keeps its csv_file_id through the
+        image-processing rebuild (vision-LLM path)."""
+        doc = _make_tabular_doc(
+            "doc-fb", TabularSection(link="l", csv_file_id="fid-1", heading="Sheet1")
+        )
+        section = self._run([doc], image_map={})[0].processed_sections[0]
+        assert isinstance(section, TabularSection)
+        assert section.csv_file_id == "fid-1"
+        assert section.text is None
+
+    def test_file_backed_tabular_preserved_without_llm(self) -> None:
+        """Same guarantee on the no-LLM path (image analysis disabled)."""
+        doc = _make_tabular_doc(
+            "doc-fb", TabularSection(link="l", csv_file_id="fid-2", heading="Sheet1")
+        )
+        with patch(
+            f"{_PATCH_PREFIX}.get_image_extraction_and_analysis_enabled",
+            return_value=False,
+        ):
+            section = process_image_sections([doc])[0].processed_sections[0]
+        assert isinstance(section, TabularSection)
+        assert section.csv_file_id == "fid-2"
+        assert section.text is None
 
     def test_interleaved_sections_preserve_order(self) -> None:
         """Text and image sections must stay in their original positions."""

--- a/backend/tests/unit/onyx/indexing/test_tabular_section_chunker.py
+++ b/backend/tests/unit/onyx/indexing/test_tabular_section_chunker.py
@@ -11,6 +11,10 @@ arithmetic is deterministic and expected chunks can be spelled out
 exactly.
 """
 
+import io
+
+import pytest
+
 from onyx.connectors.models import Section
 from onyx.connectors.models import TabularSection
 from onyx.indexing.chunking.section_chunker import AccumulatorState
@@ -934,6 +938,36 @@ class TestBuildTotalDescriptorChunks:
 
         # --- ACT / ASSERT ---------------------------------------------
         assert self._build(csv_text) == expected
+
+
+def test_file_backed_section_streams_all_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A file-backed TabularSection (csv_file_id) is chunked by streaming the
+    staged CSV from the file store — every row appears, nothing is truncated."""
+    import onyx.indexing.chunking.tabular_section_chunker.tabular_section_chunker as mod
+
+    csv_text = "name,score\n" + "\n".join(f"user{i},{i}" for i in range(60))
+
+    class _FakeStore:
+        def read_file(
+            self, file_id: str, mode: str | None = None, use_tempfile: bool = False
+        ) -> io.BytesIO:
+            del file_id, mode, use_tempfile  # stub: signature parity only
+            return io.BytesIO(csv_text.encode("utf-8"))
+
+    monkeypatch.setattr(mod, "get_default_file_store", lambda: _FakeStore())
+
+    chunker = _make_chunker_no_metadata()
+    section = TabularSection(link="x", csv_file_id="csv-1", heading="big :: Sheet1")
+    out = chunker.chunk_section(
+        section, AccumulatorState(), content_token_limit=100_000
+    )
+
+    assert out.payloads
+    joined = "\n".join(p.text for p in out.payloads)
+    assert "user0" in joined
+    assert "user59" in joined  # last row present -> no truncation
 
     def test_numeric_only_sheet_has_no_categorical_line(self) -> None:
         # --- INPUT -----------------------------------------------------

--- a/backend/tests/unit/onyx/indexing/test_tabular_section_chunker.py
+++ b/backend/tests/unit/onyx/indexing/test_tabular_section_chunker.py
@@ -1094,3 +1094,35 @@ def test_file_backed_section_streams_all_rows(
     joined = "\n".join(p.text for p in out.payloads)
     assert "user0" in joined
     assert "user59" in joined  # last row present -> no truncation
+
+
+def test_file_backed_section_emits_descriptor_chunks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A file-backed (streamed) section also gets descriptor/total chunks, built
+    by the bounded streaming analyze pass — not just row chunks."""
+    import onyx.indexing.chunking.tabular_section_chunker.tabular_section_chunker as mod
+
+    rows = ["1,US,10", "2,US,20", "3,EU,30", "4,US,40", "5,EU,50", "6,US,60"]
+    csv_text = "id,region,amount\n" + "\n".join(rows)
+
+    class _FakeStore:
+        def read_file(
+            self, file_id: str, mode: str | None = None, use_tempfile: bool = False
+        ) -> io.BytesIO:
+            del file_id, mode, use_tempfile  # stub: signature parity only
+            return io.BytesIO(csv_text.encode("utf-8"))
+
+    monkeypatch.setattr(mod, "get_default_file_store", lambda: _FakeStore())
+
+    chunker = _make_chunker_with_metadata()
+    section = TabularSection(link="x", csv_file_id="csv-1", heading="S")
+    out = chunker.chunk_section(
+        section, AccumulatorState(), content_token_limit=100_000
+    )
+
+    joined = "\n".join(p.text for p in out.payloads)
+    assert "id=1" in joined  # row chunks
+    assert "Sheet overview." in joined  # sheet descriptor
+    assert "total (sum across all rows)" in joined  # numeric totals
+    assert "most frequent value: US (4 occurrences)" in joined  # categorical top

--- a/backend/tests/unit/onyx/indexing/test_tabular_section_chunker.py
+++ b/backend/tests/unit/onyx/indexing/test_tabular_section_chunker.py
@@ -939,36 +939,6 @@ class TestBuildTotalDescriptorChunks:
         # --- ACT / ASSERT ---------------------------------------------
         assert self._build(csv_text) == expected
 
-
-def test_file_backed_section_streams_all_rows(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A file-backed TabularSection (csv_file_id) is chunked by streaming the
-    staged CSV from the file store — every row appears, nothing is truncated."""
-    import onyx.indexing.chunking.tabular_section_chunker.tabular_section_chunker as mod
-
-    csv_text = "name,score\n" + "\n".join(f"user{i},{i}" for i in range(60))
-
-    class _FakeStore:
-        def read_file(
-            self, file_id: str, mode: str | None = None, use_tempfile: bool = False
-        ) -> io.BytesIO:
-            del file_id, mode, use_tempfile  # stub: signature parity only
-            return io.BytesIO(csv_text.encode("utf-8"))
-
-    monkeypatch.setattr(mod, "get_default_file_store", lambda: _FakeStore())
-
-    chunker = _make_chunker_no_metadata()
-    section = TabularSection(link="x", csv_file_id="csv-1", heading="big :: Sheet1")
-    out = chunker.chunk_section(
-        section, AccumulatorState(), content_token_limit=100_000
-    )
-
-    assert out.payloads
-    joined = "\n".join(p.text for p in out.payloads)
-    assert "user0" in joined
-    assert "user59" in joined  # last row present -> no truncation
-
     def test_numeric_only_sheet_has_no_categorical_line(self) -> None:
         # --- INPUT -----------------------------------------------------
         # Both columns are all-numeric → no "most frequent value" lines.
@@ -1094,3 +1064,33 @@ def test_file_backed_section_streams_all_rows(
         assert "Column b: total (sum across all rows) = 7" in body
         assert "Column c: total (sum across all rows) = 9" in body
         assert "Total row count: 2." in body
+
+
+def test_file_backed_section_streams_all_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A file-backed TabularSection (csv_file_id) is chunked by streaming the
+    staged CSV from the file store — every row appears, nothing is truncated."""
+    import onyx.indexing.chunking.tabular_section_chunker.tabular_section_chunker as mod
+
+    csv_text = "name,score\n" + "\n".join(f"user{i},{i}" for i in range(60))
+
+    class _FakeStore:
+        def read_file(
+            self, file_id: str, mode: str | None = None, use_tempfile: bool = False
+        ) -> io.BytesIO:
+            del file_id, mode, use_tempfile  # stub: signature parity only
+            return io.BytesIO(csv_text.encode("utf-8"))
+
+    monkeypatch.setattr(mod, "get_default_file_store", lambda: _FakeStore())
+
+    chunker = _make_chunker_no_metadata()
+    section = TabularSection(link="x", csv_file_id="csv-1", heading="big :: Sheet1")
+    out = chunker.chunk_section(
+        section, AccumulatorState(), content_token_limit=100_000
+    )
+
+    assert out.payloads
+    joined = "\n".join(p.text for p in out.payloads)
+    assert "user0" in joined
+    assert "user59" in joined  # last row present -> no truncation


### PR DESCRIPTION
## Description

### The bug
A single oversized Google Drive `.xlsx` OOMs the indexing worker (~8 GB / 8192 MB limit). Extraction renders the **whole** sheet into one in-memory CSV string, and docfetching converts 8 files at once → 8 large sheets ≈ 8 GB. The old `MAX_XLSX_CELLS_PER_SHEET` cap truncated data **and** (verified live on cc7) didn't even bound peak — multi-sheet workbooks and wide rows slip past a cell-count cap.

### The fix — never hold a whole sheet in memory
Like reading a huge book one page at a time instead of photocopying the whole stack. Each stage is bounded:

1. **Extraction** (`extract_file_text.stage_or_inline_xlsx_sheets`) — stream the worksheet row by row to a temp CSV. A sheet whose CSV is ≤ `XLSX_STREAM_SHEET_BYTES` (50 MB) is kept inline; a larger one is staged in the file store and referenced by `csv_file_id` (no giant text on the heap or in the doc batch).
2. **Chunking** (`TabularChunker`) — one CSV row-parsing core (`parse_csv_stream`). Inline sheets parse from memory; file-backed sheets stream rows back from the file store (`read_file(use_tempfile=True)`), a row at a time.
3. **Descriptors** (`analyze_sheet`) — a single **bounded streaming pass** (running numeric/date aggregates, a cardinality-capped Counter, capped id-uniqueness) instead of transposing the sheet. So column-stat / total chunks are produced for **every** sheet, huge ones included, at flat memory.

**Result:** the *entire* sheet is indexed (no truncation), with full descriptor metadata, and worker memory stays flat regardless of sheet size.

### Routing
`xlsx_has_large_sheet` does a cheap xlsx zip-directory size check (no parse) to decide whether a workbook takes the streaming path; small workbooks keep the existing inline `xlsx_sheet_extraction` path untouched.

### What to review
- **`models.py` `TabularSection`** — `text` optional + new `csv_file_id`; validator enforces exactly one.
- **`analysis.py`** — `analyze_sheet` rewritten as a bounded single pass; `SheetAnalysis` now carries `NumericAggregate` (total/count/min/max) instead of a full value list. Inline output is unchanged (existing descriptor tests pass verbatim); huge sheets drop only very-high-cardinality categoricals (> cap), where a "most frequent value" isn't useful anyway.
- **`indexing_pipeline.py`** — non-image sections are copied with `model_copy()` so a file-backed `TabularSection`'s `csv_file_id` survives the pre-chunk rebuild (regression-tested; without it the streamed sheet reached the chunker empty).
- **`document_chunker.py`** — the empty-section filter keyed off `section.text`, which is `None` for a file-backed `TabularSection`, so an untitled doc's sheet (Drive files carry no title) was dropped before `TabularChunker` ran → indexed with **0 chunks**. File-backed sections now bypass the empty check. Caught end-to-end testing a 52.9 MB sheet on a live Drive connector; regression-tested.
- **Rolling deploy** — a new docfetching pod can emit `text=None` + `csv_file_id`; an old docprocessing pod would reject that on deserialize, so the attempt fails and **self-heals to full data on retry** (chosen over a partial-preview shim). Only large-xlsx attempts caught mid-rollout are affected.

### Tests
Unit coverage for: streamed extraction (large → file-backed + no truncation; small → inline), the chunker streaming a file-backed section (rows **and** descriptor/total chunks), `process_image_sections` preserving `csv_file_id`, and the DocumentChunker keeping a file-backed section in an untitled doc.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
