### PR TITLE
feat: hierarchy nodes have copyable links

### DIFF
--- a/web/src/sections/knowledge/SourceHierarchyBrowser.tsx
+++ b/web/src/sections/knowledge/SourceHierarchyBrowser.tsx
@@ -9,7 +9,8 @@ import React, {
 } from "react";
 import * as GeneralLayouts from "@/layouts/general-layouts";
 import * as TableLayouts from "@/layouts/table-layouts";
-import { Button, Divider as OpalDivider } from "@opal/components";
+import { Button, CopyButton, Divider as OpalDivider } from "@opal/components";
+import { Hoverable } from "@opal/core";
 import Text from "@/refresh-components/texts/Text";
 import Truncated from "@/refresh-components/texts/Truncated";
 import { Checkbox } from "@opal/components";
@@ -46,6 +47,18 @@ import {
 import { AgentAttachedDocument } from "@/lib/agents/types";
 import { timeAgo } from "@opal/time";
 import { Spacer } from "@opal/components";
+
+// Compact, human-readable form of a node/document link, used as a secondary
+// label so siblings that share a display name (common for orphaned nodes that
+// fall back to the source root) remain distinguishable.
+function formatLinkSubtitle(link: string | null): string | null {
+  if (!link) return null;
+  const stripped = link
+    .replace(/^https?:\/\//i, "")
+    .replace(/^www\./i, "")
+    .replace(/\/+$/, "");
+  return stripped || null;
+}
 
 // ============================================================================
 // HIERARCHY BREADCRUMB - Navigation path for folder hierarchy
@@ -849,6 +862,7 @@ export default function SourceHierarchyBrowser({
               const isSelected = isFolder
                 ? selectedFolderIds.includes(item.data.id as number)
                 : selectedDocumentIds.includes(item.data.id as string);
+              const subtitle = formatLinkSubtitle(item.data.link);
 
               return (
                 <TableLayouts.TableRow
@@ -860,29 +874,56 @@ export default function SourceHierarchyBrowser({
                     {getItemIcon(item, isSelected)}
                   </TableLayouts.CheckboxCell>
                   <TableLayouts.TableCell flex>
-                    <GeneralLayouts.Section
-                      flexDirection="row"
-                      justifyContent="start"
-                      alignItems="center"
-                      gap={0.25}
-                      height="auto"
-                      width="fit"
-                    >
-                      <Truncated>{item.data.title}</Truncated>
-                      {isFolder && (
-                        <Button
-                          icon={SvgChevronRight}
-                          prominence="tertiary"
-                          size="sm"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            handleClickIntoFolder(
-                              item.data as HierarchyNodeSummary
-                            );
-                          }}
-                        />
-                      )}
-                    </GeneralLayouts.Section>
+                    <Hoverable.Root group="hierarchy-row" width="full">
+                      <GeneralLayouts.Section
+                        flexDirection="row"
+                        justifyContent="start"
+                        alignItems="center"
+                        gap={0.25}
+                        height="auto"
+                      >
+                        <GeneralLayouts.Section
+                          flexDirection="column"
+                          justifyContent="start"
+                          alignItems="start"
+                          gap={0}
+                          height="auto"
+                          className="min-w-0 grow"
+                        >
+                          <Truncated>{item.data.title}</Truncated>
+                          {subtitle && (
+                            <Truncated text03 secondaryBody>
+                              {subtitle}
+                            </Truncated>
+                          )}
+                        </GeneralLayouts.Section>
+                        {item.data.link && (
+                          <Hoverable.Item
+                            group="hierarchy-row"
+                            onClick={(e) => e.stopPropagation()}
+                          >
+                            <CopyButton
+                              size="sm"
+                              getCopyText={() => item.data.link ?? ""}
+                              tooltip="Copy link"
+                            />
+                          </Hoverable.Item>
+                        )}
+                        {isFolder && (
+                          <Button
+                            icon={SvgChevronRight}
+                            prominence="tertiary"
+                            size="sm"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handleClickIntoFolder(
+                                item.data as HierarchyNodeSummary
+                              );
+                            }}
+                          />
+                        )}
+                      </GeneralLayouts.Section>
+                    </Hoverable.Root>
                   </TableLayouts.TableCell>
                   <TableLayouts.TableCell width={8}>
                     <Text text03 secondaryBody>


### PR DESCRIPTION
## Description

We want a way for users to distinguish hierarchy elements with the same title, so I added a copyable link to each item to let people inspect each page

<img width="846" height="476" alt="Screenshot 2026-06-22 at 4 51 00 PM" src="https://github.com/user-attachments/assets/306cec77-fac1-41ea-9981-da65264597b0" />


## How Has This Been Tested?

tested in UI

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds copyable links to items in the knowledge hierarchy to help distinguish entries with the same title and make sharing easier. Shows a compact, human-readable link under each title with a quick copy action.

- **New Features**
  - Display a compact link subtitle (protocol/“www” stripped, no trailing slash) under each item title.
  - Add a hover-only `CopyButton` (via `@opal/components` and `@opal/core`) to copy the full link without selecting the row or navigating.

<sup>Written for commit 5a3c75a3dfb426d25157832ad796f7e23a5d5dca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

