### PR TITLE
fix: lowercase model name when deriving OpenSearch index name

### DIFF
--- a/backend/onyx/natural_language_processing/search_nlp_models.py
+++ b/backend/onyx/natural_language_processing/search_nlp_models.py
@@ -193,7 +193,7 @@ WARM_UP_STRINGS = [
 
 
 def clean_model_name(model_str: str) -> str:
-    return model_str.replace("/", "_").replace("-", "_").replace(".", "_")
+    return model_str.replace("/", "_").replace("-", "_").replace(".", "_").lower()
 
 
 def build_model_server_url(

--- a/backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py
+++ b/backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py
@@ -12,6 +12,7 @@ from litellm.exceptions import RateLimitError
 from tenacity import wait_none
 
 from onyx.llm.constants import LlmProviderNames
+from onyx.natural_language_processing.search_nlp_models import clean_model_name
 from onyx.natural_language_processing.search_nlp_models import CloudEmbedding
 from onyx.natural_language_processing.search_nlp_models import EmbeddingModel
 from shared_configs.enums import EmbeddingProvider
@@ -33,6 +34,15 @@ async def mock_http_client() -> AsyncGenerator[AsyncMock, None]:
 @pytest.fixture
 def sample_embeddings() -> list[list[float]]:
     return [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+
+
+def test_clean_model_name_lowercases_names_for_opensearch_index() -> None:
+    cleaned_model_name = clean_model_name("Qwen3-VL-Embedding-8B")
+
+    assert cleaned_model_name == "qwen3_vl_embedding_8b"
+    assert (
+        f"danswer_chunk_{cleaned_model_name}" == "danswer_chunk_qwen3_vl_embedding_8b"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
OpenSearch index names must be lowercase. `clean_model_name` replaced `/`, `-`, and `.` with `_` but never lowercased, so an uppercase embedding model name like `Qwen3-VL-Embedding-8B` produced `danswer_chunk_Qwen3_VL_Embedding_8B`, which OpenSearch rejects on index creation.

## Changes
Lowercase the cleaned name. Added a test asserting `Qwen3-VL-Embedding-8B` → `qwen3_vl_embedding_8b` and the resulting `danswer_chunk_` index name.

Fixes #12149

AI was used for assistance.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lowercase cleaned embedding model names when building OpenSearch index names to meet the lowercase requirement and prevent index creation failures. Adds a unit test verifying "Qwen3-VL-Embedding-8B" becomes "qwen3_vl_embedding_8b" and the final "danswer_chunk_qwen3_vl_embedding_8b" index.

<sup>Written for commit 7fb8a02d68b54058b55c3b51938d8494fd5ecbaa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

