### PR TITLE
fix: delete cc_pair dependencies before deleting connector

### DIFF
--- a/backend/onyx/db/cc_pair_deletion.py
+++ b/backend/onyx/db/cc_pair_deletion.py
@@ -1,0 +1,36 @@
+from sqlalchemy.orm import Session
+
+from onyx.db.index_attempt import delete_index_attempts
+from onyx.db.permission_sync_attempt import (
+    delete_doc_permission_sync_attempts__no_commit,
+)
+from onyx.db.permission_sync_attempt import (
+    delete_external_group_permission_sync_attempts__no_commit,
+)
+from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
+
+
+def delete_cc_pair_dependencies__no_commit(
+    db_session: Session,
+    cc_pair_id: int,
+) -> None:
+    fetch_ee_implementation_or_noop(
+        "onyx.db.external_perm",
+        "delete_user__ext_group_for_cc_pair__no_commit",
+    )(
+        db_session=db_session,
+        cc_pair_id=cc_pair_id,
+    )
+
+    delete_index_attempts(
+        db_session=db_session,
+        cc_pair_id=cc_pair_id,
+    )
+    delete_doc_permission_sync_attempts__no_commit(
+        db_session=db_session,
+        cc_pair_id=cc_pair_id,
+    )
+    delete_external_group_permission_sync_attempts__no_commit(
+        db_session=db_session,
+        cc_pair_id=cc_pair_id,
+    )

--- a/backend/onyx/db/connector.py
+++ b/backend/onyx/db/connector.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 from onyx.configs.app_configs import DEFAULT_PRUNING_FREQ
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.models import InputType
+from onyx.db.cc_pair_deletion import delete_cc_pair_dependencies__no_commit
 from onyx.db.enums import IndexingMode
 from onyx.db.models import Connector
 from onyx.db.models import ConnectorCredentialPair
@@ -167,6 +168,12 @@ def delete_connector(
     if connector is None:
         return StatusResponse(
             success=True, message="Connector was already deleted", data=connector_id
+        )
+
+    for cc_pair in connector.credentials:
+        delete_cc_pair_dependencies__no_commit(
+            db_session=db_session,
+            cc_pair_id=cc_pair.id,
         )
 
     db_session.delete(connector)

--- a/backend/onyx/db/connector_credential_pair.py
+++ b/backend/onyx/db/connector_credential_pair.py
@@ -15,6 +15,7 @@ from sqlalchemy.orm import selectinload
 from sqlalchemy.orm import Session
 
 from onyx.configs.constants import DocumentSource
+from onyx.db.cc_pair_deletion import delete_cc_pair_dependencies__no_commit
 from onyx.db.connector import fetch_connector_by_id
 from onyx.db.credentials import fetch_credential_by_id
 from onyx.db.credentials import fetch_credential_by_id_for_user
@@ -648,10 +649,7 @@ def remove_credential_from_connector(
     )
 
     if association is not None:
-        fetch_ee_implementation_or_noop(
-            "onyx.db.external_perm",
-            "delete_user__ext_group_for_cc_pair__no_commit",
-        )(
+        delete_cc_pair_dependencies__no_commit(
             db_session=db_session,
             cc_pair_id=association.id,
         )

--- a/backend/tests/external_dependency_unit/db/test_connector_delete_cascade.py
+++ b/backend/tests/external_dependency_unit/db/test_connector_delete_cascade.py
@@ -1,0 +1,193 @@
+from sqlalchemy.orm import Session
+
+from onyx.auth.schemas import UserRole
+from onyx.db.connector import delete_connector
+from onyx.db.connector_credential_pair import remove_credential_from_connector
+from onyx.db.enums import IndexingStatus
+from onyx.db.models import Connector
+from onyx.db.models import ConnectorCredentialPair
+from onyx.db.models import Credential
+from onyx.db.models import IndexAttempt
+from onyx.db.models import IndexAttemptError
+from tests.external_dependency_unit.conftest import create_test_user
+from tests.external_dependency_unit.indexing_helpers import make_cc_pair
+
+
+def _add_index_attempt_with_error(
+    db_session: Session,
+    cc_pair_id: int,
+) -> tuple[int, int]:
+    index_attempt = IndexAttempt(
+        connector_credential_pair_id=cc_pair_id,
+        search_settings_id=None,
+        from_beginning=False,
+        status=IndexingStatus.COMPLETED_WITH_ERRORS,
+    )
+    db_session.add(index_attempt)
+    db_session.flush()
+
+    index_attempt_error = IndexAttemptError(
+        index_attempt_id=index_attempt.id,
+        connector_credential_pair_id=cc_pair_id,
+        failure_message="test failure",
+    )
+    db_session.add(index_attempt_error)
+    db_session.commit()
+
+    return index_attempt.id, index_attempt_error.id
+
+
+def _cleanup_connector_rows(
+    db_session: Session,
+    connector_id: int,
+    credential_id: int,
+    cc_pair_id: int,
+) -> None:
+    db_session.rollback()
+    db_session.query(IndexAttemptError).filter(
+        IndexAttemptError.connector_credential_pair_id == cc_pair_id
+    ).delete(synchronize_session="fetch")
+    db_session.query(IndexAttempt).filter(
+        IndexAttempt.connector_credential_pair_id == cc_pair_id
+    ).delete(synchronize_session="fetch")
+    db_session.query(ConnectorCredentialPair).filter(
+        ConnectorCredentialPair.id == cc_pair_id
+    ).delete(synchronize_session="fetch")
+    db_session.query(Connector).filter(Connector.id == connector_id).delete(
+        synchronize_session="fetch"
+    )
+    db_session.query(Credential).filter(Credential.id == credential_id).delete(
+        synchronize_session="fetch"
+    )
+    db_session.commit()
+
+
+def _assert_index_attempt_rows_deleted(
+    db_session: Session,
+    cc_pair_id: int,
+    index_attempt_id: int,
+    index_attempt_error_id: int,
+) -> None:
+    db_session.expire_all()
+    assert (
+        db_session.query(IndexAttempt)
+        .filter(
+            IndexAttempt.id == index_attempt_id,
+            IndexAttempt.connector_credential_pair_id == cc_pair_id,
+        )
+        .one_or_none()
+        is None
+    )
+    assert (
+        db_session.query(IndexAttemptError)
+        .filter(
+            IndexAttemptError.id == index_attempt_error_id,
+            IndexAttemptError.connector_credential_pair_id == cc_pair_id,
+        )
+        .one_or_none()
+        is None
+    )
+    assert (
+        db_session.query(IndexAttempt)
+        .filter(IndexAttempt.connector_credential_pair_id == cc_pair_id)
+        .count()
+        == 0
+    )
+    assert (
+        db_session.query(IndexAttemptError)
+        .filter(IndexAttemptError.connector_credential_pair_id == cc_pair_id)
+        .count()
+        == 0
+    )
+
+
+def test_remove_credential_from_connector_deletes_index_attempt_rows(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    admin_user = create_test_user(db_session, "cc_pair_delete", role=UserRole.ADMIN)
+    cc_pair = make_cc_pair(db_session)
+    connector_id = cc_pair.connector_id
+    credential_id = cc_pair.credential_id
+    cc_pair_id = cc_pair.id
+    index_attempt_id, index_attempt_error_id = _add_index_attempt_with_error(
+        db_session=db_session,
+        cc_pair_id=cc_pair_id,
+    )
+
+    try:
+        response = remove_credential_from_connector(
+            connector_id=connector_id,
+            credential_id=credential_id,
+            user=admin_user,
+            db_session=db_session,
+        )
+
+        assert response.success is True
+        assert (
+            db_session.query(ConnectorCredentialPair)
+            .filter(ConnectorCredentialPair.id == cc_pair_id)
+            .one_or_none()
+            is None
+        )
+        _assert_index_attempt_rows_deleted(
+            db_session=db_session,
+            cc_pair_id=cc_pair_id,
+            index_attempt_id=index_attempt_id,
+            index_attempt_error_id=index_attempt_error_id,
+        )
+    finally:
+        _cleanup_connector_rows(
+            db_session=db_session,
+            connector_id=connector_id,
+            credential_id=credential_id,
+            cc_pair_id=cc_pair_id,
+        )
+
+
+def test_delete_connector_deletes_index_attempt_rows(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    cc_pair = make_cc_pair(db_session)
+    connector_id = cc_pair.connector_id
+    credential_id = cc_pair.credential_id
+    cc_pair_id = cc_pair.id
+    index_attempt_id, index_attempt_error_id = _add_index_attempt_with_error(
+        db_session=db_session,
+        cc_pair_id=cc_pair_id,
+    )
+
+    try:
+        response = delete_connector(
+            db_session=db_session,
+            connector_id=connector_id,
+        )
+        db_session.commit()
+
+        assert response.success is True
+        assert (
+            db_session.query(Connector)
+            .filter(Connector.id == connector_id)
+            .one_or_none()
+            is None
+        )
+        assert (
+            db_session.query(ConnectorCredentialPair)
+            .filter(ConnectorCredentialPair.id == cc_pair_id)
+            .one_or_none()
+            is None
+        )
+        _assert_index_attempt_rows_deleted(
+            db_session=db_session,
+            cc_pair_id=cc_pair_id,
+            index_attempt_id=index_attempt_id,
+            index_attempt_error_id=index_attempt_error_id,
+        )
+    finally:
+        _cleanup_connector_rows(
+            db_session=db_session,
+            connector_id=connector_id,
+            credential_id=credential_id,
+            cc_pair_id=cc_pair_id,
+        )


### PR DESCRIPTION
## Summary
Synchronous connector delete and "remove credential from connector" raised HTTP 500 (`NotNullViolation`) whenever the cc_pair had `index_attempt` rows: `IndexAttempt.connector_credential_pair_id` is `NOT NULL` with a plain FK (no cascade), and the delete went straight to `db_session.delete(...)`.

## Changes
Extract `delete_cc_pair_dependencies__no_commit` (index attempts, doc/external-group permission-sync attempts, and the existing EE external-group cleanup) and call it before deleting the cc_pair in both `delete_connector` and `remove_credential_from_connector`. The credential path now reuses the same helper instead of the inline EE-only cleanup, so both paths stay in sync.

## Testing
Added `test_connector_delete_cascade.py` covering delete of a connector whose cc_pair has index attempts.

Fixes #12180

AI was used for assistance.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented 500 errors when deleting a connector or removing a credential by cleaning up `cc_pair` dependencies (e.g., `IndexAttempt` rows) before deletion.

- **Bug Fixes**
  - Added `delete_cc_pair_dependencies__no_commit` to delete `IndexAttempt`, doc/external-group permission-sync attempts, and run EE external-group cleanup.
  - Called this helper from both `delete_connector` and `remove_credential_from_connector` to avoid FK `NotNullViolation` and keep logic in sync.
  - Added tests to verify index attempt and error rows are removed in both delete paths.

<sup>Written for commit daa894d04970623cdd596464d05410fb8776999b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

