### PR TITLE
feat(opensearch): server certificate verification + mutual TLS

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -388,6 +388,39 @@ OPENSEARCH_ADMIN_PASSWORD = os.environ.get(
     "OPENSEARCH_ADMIN_PASSWORD", "StrongPassword123!"
 )
 OPENSEARCH_USE_SSL = os.environ.get("OPENSEARCH_USE_SSL", "true").lower() == "true"
+# Verify the OpenSearch server certificate. Defaults to False to preserve the
+# existing behavior (the bundled OpenSearch ships self-signed certs). Set True —
+# with OPENSEARCH_CA_CERTS for a private CA — to actually authenticate the
+# server instead of merely encrypting the connection.
+OPENSEARCH_VERIFY_CERTS = (
+    os.environ.get("OPENSEARCH_VERIFY_CERTS", "").lower() == "true"
+)
+# CA bundle to verify the server cert against when OPENSEARCH_VERIFY_CERTS=true.
+# Falls back to the system trust store if unset.
+OPENSEARCH_CA_CERTS: str | None = os.environ.get("OPENSEARCH_CA_CERTS") or None
+# Client certificate + key for mutual TLS (OpenSearch authenticating us). Both
+# must be set together.
+OPENSEARCH_CLIENT_CERT: str | None = os.environ.get("OPENSEARCH_CLIENT_CERT") or None
+OPENSEARCH_CLIENT_KEY: str | None = os.environ.get("OPENSEARCH_CLIENT_KEY") or None
+
+if OPENSEARCH_VERIFY_CERTS and not OPENSEARCH_USE_SSL:
+    logger.warning(
+        "OPENSEARCH_VERIFY_CERTS=true has no effect when OPENSEARCH_USE_SSL is "
+        "false (the connection is not encrypted)."
+    )
+if bool(OPENSEARCH_CLIENT_CERT) != bool(OPENSEARCH_CLIENT_KEY):
+    raise ValueError(
+        "OPENSEARCH_CLIENT_CERT and OPENSEARCH_CLIENT_KEY must both be set "
+        "(mutual TLS needs a client certificate and its private key)."
+    )
+for _os_name, _os_path in (
+    ("OPENSEARCH_CA_CERTS", OPENSEARCH_CA_CERTS),
+    ("OPENSEARCH_CLIENT_CERT", OPENSEARCH_CLIENT_CERT),
+    ("OPENSEARCH_CLIENT_KEY", OPENSEARCH_CLIENT_KEY),
+):
+    if _os_path and not os.path.exists(_os_path):
+        raise ValueError(f"{_os_name}={_os_path!r} does not exist.")
+
 USING_AWS_MANAGED_OPENSEARCH = (
     os.environ.get("USING_AWS_MANAGED_OPENSEARCH", "").lower() == "true"
 )

--- a/backend/onyx/document_index/opensearch/client.py
+++ b/backend/onyx/document_index/opensearch/client.py
@@ -15,9 +15,13 @@ from pydantic import BaseModel
 from onyx.configs.app_configs import DEFAULT_OPENSEARCH_CLIENT_TIMEOUT_S
 from onyx.configs.app_configs import OPENSEARCH_ADMIN_PASSWORD
 from onyx.configs.app_configs import OPENSEARCH_ADMIN_USERNAME
+from onyx.configs.app_configs import OPENSEARCH_CA_CERTS
+from onyx.configs.app_configs import OPENSEARCH_CLIENT_CERT
+from onyx.configs.app_configs import OPENSEARCH_CLIENT_KEY
 from onyx.configs.app_configs import OPENSEARCH_HOST
 from onyx.configs.app_configs import OPENSEARCH_REST_API_PORT
 from onyx.configs.app_configs import OPENSEARCH_USE_SSL
+from onyx.configs.app_configs import OPENSEARCH_VERIFY_CERTS
 from onyx.document_index.interfaces_new import TenantState
 from onyx.document_index.opensearch.constants import OpenSearchSearchType
 from onyx.document_index.opensearch.schema import DocumentChunk
@@ -148,8 +152,11 @@ class OpenSearchClient(AbstractContextManager):
             of (username, password).
         use_ssl: Whether to use SSL for the OpenSearch cluster. Defaults to
             True.
-        verify_certs: Whether to verify the SSL certificates for the OpenSearch
-            cluster. Defaults to False.
+        verify_certs: Whether to verify the server certificate. Defaults to
+            OPENSEARCH_VERIFY_CERTS.
+        ca_certs: CA bundle path used to verify the server certificate.
+        client_cert: Client certificate path for mutual TLS.
+        client_key: Client private key path for mutual TLS.
         ssl_show_warn: Whether to show warnings for SSL certificates. Defaults
             to False.
         timeout: The timeout for the OpenSearch cluster. Defaults to
@@ -162,7 +169,10 @@ class OpenSearchClient(AbstractContextManager):
         port: int = OPENSEARCH_REST_API_PORT,
         auth: tuple[str, str] = (OPENSEARCH_ADMIN_USERNAME, OPENSEARCH_ADMIN_PASSWORD),
         use_ssl: bool = OPENSEARCH_USE_SSL,
-        verify_certs: bool = False,
+        verify_certs: bool = OPENSEARCH_VERIFY_CERTS,
+        ca_certs: str | None = OPENSEARCH_CA_CERTS,
+        client_cert: str | None = OPENSEARCH_CLIENT_CERT,
+        client_key: str | None = OPENSEARCH_CLIENT_KEY,
         ssl_show_warn: bool = False,
         timeout: int = DEFAULT_OPENSEARCH_CLIENT_TIMEOUT_S,
     ):
@@ -177,6 +187,9 @@ class OpenSearchClient(AbstractContextManager):
             http_auth=auth,
             use_ssl=use_ssl,
             verify_certs=verify_certs,
+            ca_certs=ca_certs,
+            client_cert=client_cert,
+            client_key=client_key,
             ssl_show_warn=ssl_show_warn,
             # NOTE: This timeout applies to all requests the client makes,
             # including bulk indexing. When exceeded, the client will raise a
@@ -418,8 +431,11 @@ class OpenSearchIndexClient(OpenSearchClient):
             of (username, password).
         use_ssl: Whether to use SSL for the OpenSearch cluster. Defaults to
             True.
-        verify_certs: Whether to verify the SSL certificates for the OpenSearch
-            cluster. Defaults to False.
+        verify_certs: Whether to verify the server certificate. Defaults to
+            OPENSEARCH_VERIFY_CERTS.
+        ca_certs: CA bundle path used to verify the server certificate.
+        client_cert: Client certificate path for mutual TLS.
+        client_key: Client private key path for mutual TLS.
         ssl_show_warn: Whether to show warnings for SSL certificates. Defaults
             to False.
         timeout: The timeout for the OpenSearch cluster. Defaults to
@@ -433,7 +449,10 @@ class OpenSearchIndexClient(OpenSearchClient):
         port: int = OPENSEARCH_REST_API_PORT,
         auth: tuple[str, str] = (OPENSEARCH_ADMIN_USERNAME, OPENSEARCH_ADMIN_PASSWORD),
         use_ssl: bool = OPENSEARCH_USE_SSL,
-        verify_certs: bool = False,
+        verify_certs: bool = OPENSEARCH_VERIFY_CERTS,
+        ca_certs: str | None = OPENSEARCH_CA_CERTS,
+        client_cert: str | None = OPENSEARCH_CLIENT_CERT,
+        client_key: str | None = OPENSEARCH_CLIENT_KEY,
         ssl_show_warn: bool = False,
         timeout: int = DEFAULT_OPENSEARCH_CLIENT_TIMEOUT_S,
         emit_metrics: bool = True,
@@ -444,6 +463,9 @@ class OpenSearchIndexClient(OpenSearchClient):
             auth=auth,
             use_ssl=use_ssl,
             verify_certs=verify_certs,
+            ca_certs=ca_certs,
+            client_cert=client_cert,
+            client_key=client_key,
             ssl_show_warn=ssl_show_warn,
             timeout=timeout,
         )

--- a/backend/tests/unit/onyx/document_index/opensearch/test_opensearch_tls.py
+++ b/backend/tests/unit/onyx/document_index/opensearch/test_opensearch_tls.py
@@ -1,0 +1,77 @@
+import importlib
+import os
+from unittest.mock import patch
+
+import certifi
+import pytest
+
+from onyx.document_index.opensearch.client import OpenSearchClient
+
+_OS_TLS_ENV = (
+    "OPENSEARCH_VERIFY_CERTS",
+    "OPENSEARCH_CA_CERTS",
+    "OPENSEARCH_CLIENT_CERT",
+    "OPENSEARCH_CLIENT_KEY",
+)
+
+
+# --- client wiring --------------------------------------------------------
+
+
+def test_client_forwards_tls_kwargs() -> None:
+    """The TLS settings must reach the underlying opensearch-py client — today
+    verify_certs/ca_certs/client_cert/client_key aren't plumbed through at all."""
+    with patch("onyx.document_index.opensearch.client.OpenSearch") as mock_os:
+        OpenSearchClient(
+            host="h",
+            port=9200,
+            use_ssl=True,
+            verify_certs=True,
+            ca_certs="/etc/ssl/os-ca.pem",
+            client_cert="/etc/ssl/os-client.crt",
+            client_key="/etc/ssl/os-client.key",
+        )
+        kwargs = mock_os.call_args.kwargs
+        assert kwargs["use_ssl"] is True
+        assert kwargs["verify_certs"] is True
+        assert kwargs["ca_certs"] == "/etc/ssl/os-ca.pem"
+        assert kwargs["client_cert"] == "/etc/ssl/os-client.crt"
+        assert kwargs["client_key"] == "/etc/ssl/os-client.key"
+
+
+def test_client_defaults_to_no_verification() -> None:
+    """Back-compat: verification stays off by default so the bundled
+    self-signed OpenSearch keeps working without opt-in config."""
+    with patch("onyx.document_index.opensearch.client.OpenSearch") as mock_os:
+        OpenSearchClient()
+        assert mock_os.call_args.kwargs["verify_certs"] is False
+
+
+# --- config validation ----------------------------------------------------
+
+
+def _clear_os_tls_env() -> None:
+    for var in _OS_TLS_ENV:
+        os.environ.pop(var, None)
+
+
+def test_client_cert_without_key_raises() -> None:
+    with patch.dict(os.environ, {}, clear=False):
+        _clear_os_tls_env()
+        os.environ["OPENSEARCH_CLIENT_CERT"] = certifi.where()
+        import onyx.configs.app_configs as app_configs
+
+        with pytest.raises(ValueError, match="must both be set"):
+            importlib.reload(app_configs)
+    importlib.reload(app_configs)
+
+
+def test_nonexistent_ca_raises() -> None:
+    with patch.dict(os.environ, {}, clear=False):
+        _clear_os_tls_env()
+        os.environ["OPENSEARCH_CA_CERTS"] = "/no/such/os-ca.pem"
+        import onyx.configs.app_configs as app_configs
+
+        with pytest.raises(ValueError, match="does not exist"):
+            importlib.reload(app_configs)
+    importlib.reload(app_configs)


### PR DESCRIPTION
## Description

The OpenSearch client hardcoded `verify_certs=False` and passed no `ca_certs`, so connections to OpenSearch could be **encrypted but never authenticated** — i.e. TLS with no protection against a man-in-the-middle. This was flagged in a customer security review (the same "encrypt but can't verify the cert" gap addressed for Postgres).

New env vars, threaded into the opensearch-py client (`document_index/opensearch/client.py`, both the base and document-index `__init__`s):
- `OPENSEARCH_VERIFY_CERTS` — verify the server cert. **Defaults to `False`** to preserve current behavior, since the bundled OpenSearch ships self-signed certs; operators opt in.
- `OPENSEARCH_CA_CERTS` — CA bundle to verify against (falls back to the system trust store if unset).
- `OPENSEARCH_CLIENT_CERT` / `OPENSEARCH_CLIENT_KEY` — client certificate for mutual TLS.

Validated loudly at startup (same fail-loud style as the Postgres TLS work): client cert and key must be set together, and any provided CA/cert/key file must exist. A warning fires if `OPENSEARCH_VERIFY_CERTS=true` while `OPENSEARCH_USE_SSL=false`.

Note: opensearch-py accepts `verify_certs`/`ca_certs`/`client_cert`/`client_key` as direct kwargs and builds its own `SSLContext`, so this intentionally does **not** use the shared `build_ssl_context` helper — there'd be nothing to hand it.

Configured via `extraEnv` on the Helm deployment (the OpenSearch component isn't in the docker-compose env.template), documented inline in `app_configs.py`.

## How Has This Been Tested?

- `test_opensearch_tls.py`: the client forwards `verify_certs`/`ca_certs`/`client_cert`/`client_key` to opensearch-py; defaults to no verification (back-compat); config validation rejects a client cert without its key and a nonexistent CA path.
- `backend/tests/unit/onyx/document_index/opensearch` → 30 passed; `ty` + `ruff` + `pre-commit` clean.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add server certificate verification and optional mutual TLS for the OpenSearch client to authenticate connections and prevent MITM. Keeps current behavior by default; operators can opt in via env vars.

- **New Features**
  - Added env vars: `OPENSEARCH_VERIFY_CERTS`, `OPENSEARCH_CA_CERTS`, `OPENSEARCH_CLIENT_CERT`, `OPENSEARCH_CLIENT_KEY`.
  - Threaded through to `opensearch-py` (`verify_certs`, `ca_certs`, `client_cert`, `client_key`).
  - Startup validation: client cert/key must be set together; provided paths must exist; warn if `OPENSEARCH_VERIFY_CERTS=true` while `OPENSEARCH_USE_SSL=false`.
  - Tests added to cover TLS arg forwarding and config validation.

- **Migration**
  - To verify server certs: set `OPENSEARCH_USE_SSL=true` and `OPENSEARCH_VERIFY_CERTS=true`; set `OPENSEARCH_CA_CERTS` if using a private CA (system store used if unset).
  - To enable mTLS: set both `OPENSEARCH_CLIENT_CERT` and `OPENSEARCH_CLIENT_KEY`.
  - Configure via Helm `extraEnv`.

<sup>Written for commit f56a1abe805e26669b65244cf899822c1f780a66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

