### PR TITLE
chore(deps): use uv ecosystem for dependabot python updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,8 @@ updates:
       - "jmelahman"
     labels:
       - "dependabot:actions"
-  - package-ecosystem: "pip"
-    directory: "/backend"
+  - package-ecosystem: "uv"
+    directory: "/"
     schedule:
       interval: "weekly"
     cooldown:


### PR DESCRIPTION
## Summary

Replaces the `pip` / `/backend` Dependabot entry with a `uv` / `/` entry. Dependabot natively supports the `uv` ecosystem, so this points it at the root `uv.lock` (the real lockfile; `/backend/uv.lock` is just a 52-byte stub).

```diff
-  - package-ecosystem: "pip"
-    directory: "/backend"
+  - package-ecosystem: "uv"
+    directory: "/"
```

All other settings (weekly schedule, 7-day cooldown, PR limit of 3, `jmelahman` assignee, `dependabot:python` label) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Dependabot Python updates from `pip` in `/backend` to `uv` at the repo root, targeting the real `uv.lock`.
This ensures Dependabot tracks the actual lockfile; all other Dependabot settings remain unchanged.

<sup>Written for commit 1950ec85c9e5df5480d28eb0e97b2f1efbb6864a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

