### PR TITLE
feat(redis): mutual TLS (client certificate) for Redis connections

### DIFF
--- a/backend/onyx/background/celery/configs/base.py
+++ b/backend/onyx/background/celery/configs/base.py
@@ -12,6 +12,8 @@ from onyx.configs.app_configs import REDIS_PORT
 from onyx.configs.app_configs import REDIS_SSL
 from onyx.configs.app_configs import REDIS_SSL_CA_CERTS
 from onyx.configs.app_configs import REDIS_SSL_CERT_REQS
+from onyx.configs.app_configs import REDIS_SSL_CERTFILE
+from onyx.configs.app_configs import REDIS_SSL_KEYFILE
 from onyx.configs.app_configs import USE_REDIS_IAM_AUTH
 from onyx.configs.constants import OnyxCeleryPriority
 from onyx.configs.constants import REDIS_SOCKET_KEEPALIVE_OPTIONS
@@ -31,6 +33,12 @@ if REDIS_SSL and not USE_REDIS_IAM_AUTH:
     SSL_QUERY_PARAMS = f"?ssl_cert_reqs={REDIS_SSL_CERT_REQS}"
     if REDIS_SSL_CA_CERTS:
         SSL_QUERY_PARAMS += f"&ssl_ca_certs={REDIS_SSL_CA_CERTS}"
+    # Client certificate for mutual TLS — the broker URL is how the Celery
+    # workers get their Redis SSL config, so they need this too.
+    if REDIS_SSL_CERTFILE:
+        SSL_QUERY_PARAMS += (
+            f"&ssl_certfile={REDIS_SSL_CERTFILE}&ssl_keyfile={REDIS_SSL_KEYFILE}"
+        )
 
 # region Broker settings
 # example celery_broker_url: "redis://:password@localhost:6379/15"

--- a/backend/onyx/background/celery/configs/base.py
+++ b/backend/onyx/background/celery/configs/base.py
@@ -34,10 +34,13 @@ if REDIS_SSL and not USE_REDIS_IAM_AUTH:
     if REDIS_SSL_CA_CERTS:
         SSL_QUERY_PARAMS += f"&ssl_ca_certs={REDIS_SSL_CA_CERTS}"
     # Client certificate for mutual TLS — the broker URL is how the Celery
-    # workers get their Redis SSL config, so they need this too.
-    if REDIS_SSL_CERTFILE:
+    # workers get their Redis SSL config, so they need this too. Percent-encode
+    # the paths (like REDIS_PASSWORD above) so URL-special characters in a path
+    # can't corrupt the query string.
+    if REDIS_SSL_CERTFILE and REDIS_SSL_KEYFILE:
         SSL_QUERY_PARAMS += (
-            f"&ssl_certfile={REDIS_SSL_CERTFILE}&ssl_keyfile={REDIS_SSL_KEYFILE}"
+            f"&ssl_certfile={urllib.parse.quote(REDIS_SSL_CERTFILE, safe='')}"
+            f"&ssl_keyfile={urllib.parse.quote(REDIS_SSL_KEYFILE, safe='')}"
         )
 
 # region Broker settings

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -732,6 +732,29 @@ REDIS_POOL_MAX_CONNECTIONS = int(os.environ.get("REDIS_POOL_MAX_CONNECTIONS", 12
 # should be one of "required", "optional", or "none"
 REDIS_SSL_CERT_REQS = os.getenv("REDIS_SSL_CERT_REQS", "none")
 REDIS_SSL_CA_CERTS = os.getenv("REDIS_SSL_CA_CERTS", None)
+# Client certificate + key for Redis mutual TLS (the server authenticating us).
+# Both must be set together and require REDIS_SSL=true. A managed Redis may hand
+# these out base64-encoded — decode them to files (e.g. a mounted secret) and
+# point these at the paths.
+REDIS_SSL_CERTFILE: str | None = os.getenv("REDIS_SSL_CERTFILE") or None
+REDIS_SSL_KEYFILE: str | None = os.getenv("REDIS_SSL_KEYFILE") or None
+
+if bool(REDIS_SSL_CERTFILE) != bool(REDIS_SSL_KEYFILE):
+    raise ValueError(
+        "REDIS_SSL_CERTFILE and REDIS_SSL_KEYFILE must both be set (mutual TLS "
+        "needs a client certificate and its private key)."
+    )
+if (REDIS_SSL_CERTFILE or REDIS_SSL_KEYFILE) and not REDIS_SSL:
+    raise ValueError(
+        "REDIS_SSL_CERTFILE / REDIS_SSL_KEYFILE require REDIS_SSL=true so a TLS "
+        "connection is negotiated."
+    )
+for _redis_tls_name, _redis_tls_path in (
+    ("REDIS_SSL_CERTFILE", REDIS_SSL_CERTFILE),
+    ("REDIS_SSL_KEYFILE", REDIS_SSL_KEYFILE),
+):
+    if _redis_tls_path and not os.path.exists(_redis_tls_path):
+        raise ValueError(f"{_redis_tls_name}={_redis_tls_path!r} does not exist.")
 
 CELERY_RESULT_EXPIRES = int(os.environ.get("CELERY_RESULT_EXPIRES", 86400))  # seconds
 

--- a/backend/onyx/redis/redis_pool.py
+++ b/backend/onyx/redis/redis_pool.py
@@ -31,6 +31,8 @@ from onyx.configs.app_configs import REDIS_REPLICA_HOST
 from onyx.configs.app_configs import REDIS_SSL
 from onyx.configs.app_configs import REDIS_SSL_CA_CERTS
 from onyx.configs.app_configs import REDIS_SSL_CERT_REQS
+from onyx.configs.app_configs import REDIS_SSL_CERTFILE
+from onyx.configs.app_configs import REDIS_SSL_KEYFILE
 from onyx.configs.app_configs import USE_REDIS_IAM_AUTH
 from onyx.configs.constants import FASTAPI_USERS_AUTH_COOKIE_NAME
 from onyx.configs.constants import REDIS_SOCKET_KEEPALIVE_OPTIONS
@@ -119,6 +121,8 @@ class RedisPool:
         max_connections: int = REDIS_POOL_MAX_CONNECTIONS,
         ssl_ca_certs: str | None = REDIS_SSL_CA_CERTS,
         ssl_cert_reqs: str = REDIS_SSL_CERT_REQS,
+        ssl_certfile: str | None = REDIS_SSL_CERTFILE,
+        ssl_keyfile: str | None = REDIS_SSL_KEYFILE,
         ssl: bool = False,
     ) -> redis.BlockingConnectionPool:
         """
@@ -170,6 +174,8 @@ class RedisPool:
                 connection_class=redis.SSLConnection,
                 ssl_ca_certs=ssl_ca_certs,
                 ssl_cert_reqs=ssl_cert_reqs,
+                ssl_certfile=ssl_certfile,
+                ssl_keyfile=ssl_keyfile,
             )
 
         return redis.BlockingConnectionPool(
@@ -336,6 +342,10 @@ def _build_async_redis_connection() -> aioredis.Redis:
         ssl_context.verify_mode = SSL_CERT_REQS_MAP.get(
             REDIS_SSL_CERT_REQS, ssl.CERT_NONE
         )
+
+        # Present a client certificate for mutual TLS, if configured.
+        if REDIS_SSL_CERTFILE:
+            ssl_context.load_cert_chain(REDIS_SSL_CERTFILE, REDIS_SSL_KEYFILE)
 
         connection_kwargs["ssl"] = ssl_context
 

--- a/backend/tests/unit/onyx/redis/test_redis_mtls.py
+++ b/backend/tests/unit/onyx/redis/test_redis_mtls.py
@@ -1,7 +1,9 @@
 import importlib
 import os
+from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import patch
+from urllib.parse import quote
 
 import pytest
 
@@ -22,14 +24,18 @@ def _clear_redis_tls_env() -> None:
 
 
 @pytest.fixture(autouse=True)
-def _restore_app_configs() -> object:
+def _restore_app_configs() -> Generator[None, None, None]:
     """Config-reload tests bind REDIS_SSL* at import time; restore the default
-    state afterwards so they don't leak into other test files."""
+    state afterwards so they don't leak into other test files. celery_base is
+    reloaded too since it derives broker_url / result_backend from those."""
     yield
     _clear_redis_tls_env()
     import onyx.configs.app_configs as app_configs
 
     importlib.reload(app_configs)
+    import onyx.background.celery.configs.base as celery_base
+
+    importlib.reload(celery_base)
 
 
 # --- connection wiring ----------------------------------------------------
@@ -81,11 +87,14 @@ def test_celery_broker_and_result_urls_include_client_cert(tmp_path: Path) -> No
 
         importlib.reload(app_configs)
         importlib.reload(celery_base)
+        # Paths are percent-encoded in the URL (safe='') so special characters
+        # can't corrupt the query string.
+        enc_cert = quote(str(cert), safe="")
+        enc_key = quote(str(key), safe="")
         for url in (celery_base.broker_url, celery_base.result_backend):
             assert url.startswith("rediss://")
-            assert f"ssl_certfile={cert}" in url
-            assert f"ssl_keyfile={key}" in url
-    importlib.reload(app_configs)
+            assert f"ssl_certfile={enc_cert}" in url
+            assert f"ssl_keyfile={enc_key}" in url
 
 
 # --- config validation ----------------------------------------------------

--- a/backend/tests/unit/onyx/redis/test_redis_mtls.py
+++ b/backend/tests/unit/onyx/redis/test_redis_mtls.py
@@ -1,0 +1,134 @@
+import importlib
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import onyx.redis.redis_pool as redis_pool
+
+_REDIS_TLS_ENV = (
+    "REDIS_SSL",
+    "REDIS_SSL_CERTFILE",
+    "REDIS_SSL_KEYFILE",
+    "REDIS_SSL_CA_CERTS",
+    "USE_REDIS_IAM_AUTH",
+)
+
+
+def _clear_redis_tls_env() -> None:
+    for var in _REDIS_TLS_ENV:
+        os.environ.pop(var, None)
+
+
+@pytest.fixture(autouse=True)
+def _restore_app_configs() -> object:
+    """Config-reload tests bind REDIS_SSL* at import time; restore the default
+    state afterwards so they don't leak into other test files."""
+    yield
+    _clear_redis_tls_env()
+    import onyx.configs.app_configs as app_configs
+
+    importlib.reload(app_configs)
+
+
+# --- connection wiring ----------------------------------------------------
+
+
+def test_sync_pool_forwards_client_cert() -> None:
+    """The sync pool must hand the client cert/key to redis-py — today only the
+    CA + cert_reqs are passed."""
+    with patch("redis.BlockingConnectionPool") as mock_pool:
+        redis_pool.RedisPool.create_pool(
+            ssl=True,
+            ssl_certfile="/etc/redis/tls/client.crt",
+            ssl_keyfile="/etc/redis/tls/client.key",
+        )
+        kwargs = mock_pool.call_args.kwargs
+        assert kwargs["ssl_certfile"] == "/etc/redis/tls/client.crt"
+        assert kwargs["ssl_keyfile"] == "/etc/redis/tls/client.key"
+
+
+def test_async_connection_loads_client_cert() -> None:
+    """The async client builds an SSLContext manually, so the client cert is
+    applied via load_cert_chain."""
+    with (
+        patch.object(redis_pool, "USE_REDIS_IAM_AUTH", False),
+        patch.object(redis_pool, "REDIS_SSL", True),
+        patch.object(redis_pool, "REDIS_SSL_CA_CERTS", None),
+        patch.object(redis_pool, "REDIS_SSL_CERTFILE", "/c.crt"),
+        patch.object(redis_pool, "REDIS_SSL_KEYFILE", "/c.key"),
+        patch.object(redis_pool, "ssl") as mock_ssl,
+        patch.object(redis_pool, "aioredis"),
+    ):
+        redis_pool._build_async_redis_connection()
+        ctx = mock_ssl.create_default_context.return_value
+        ctx.load_cert_chain.assert_called_once_with("/c.crt", "/c.key")
+
+
+def test_celery_broker_and_result_urls_include_client_cert(tmp_path: Path) -> None:
+    cert = tmp_path / "client.crt"
+    key = tmp_path / "client.key"
+    cert.write_text("x")
+    key.write_text("x")
+    with patch.dict(os.environ, {}, clear=False):
+        _clear_redis_tls_env()
+        os.environ["REDIS_SSL"] = "true"
+        os.environ["REDIS_SSL_CERTFILE"] = str(cert)
+        os.environ["REDIS_SSL_KEYFILE"] = str(key)
+        import onyx.background.celery.configs.base as celery_base
+        import onyx.configs.app_configs as app_configs
+
+        importlib.reload(app_configs)
+        importlib.reload(celery_base)
+        for url in (celery_base.broker_url, celery_base.result_backend):
+            assert url.startswith("rediss://")
+            assert f"ssl_certfile={cert}" in url
+            assert f"ssl_keyfile={key}" in url
+    importlib.reload(app_configs)
+
+
+# --- config validation ----------------------------------------------------
+
+
+def test_certfile_without_keyfile_raises(tmp_path: Path) -> None:
+    cert = tmp_path / "client.crt"
+    cert.write_text("x")
+    with patch.dict(os.environ, {}, clear=False):
+        _clear_redis_tls_env()
+        os.environ["REDIS_SSL"] = "true"
+        os.environ["REDIS_SSL_CERTFILE"] = str(cert)
+        import onyx.configs.app_configs as app_configs
+
+        with pytest.raises(ValueError, match="must both be set"):
+            importlib.reload(app_configs)
+    importlib.reload(app_configs)
+
+
+def test_client_cert_without_redis_ssl_raises(tmp_path: Path) -> None:
+    cert = tmp_path / "client.crt"
+    key = tmp_path / "client.key"
+    cert.write_text("x")
+    key.write_text("x")
+    with patch.dict(os.environ, {}, clear=False):
+        _clear_redis_tls_env()
+        os.environ["REDIS_SSL_CERTFILE"] = str(cert)
+        os.environ["REDIS_SSL_KEYFILE"] = str(key)
+        import onyx.configs.app_configs as app_configs
+
+        with pytest.raises(ValueError, match="require REDIS_SSL=true"):
+            importlib.reload(app_configs)
+    importlib.reload(app_configs)
+
+
+def test_nonexistent_certfile_raises() -> None:
+    with patch.dict(os.environ, {}, clear=False):
+        _clear_redis_tls_env()
+        os.environ["REDIS_SSL"] = "true"
+        os.environ["REDIS_SSL_CERTFILE"] = "/no/such/client.crt"
+        os.environ["REDIS_SSL_KEYFILE"] = "/no/such/client.key"
+        import onyx.configs.app_configs as app_configs
+
+        with pytest.raises(ValueError, match="does not exist"):
+            importlib.reload(app_configs)
+    importlib.reload(app_configs)


### PR DESCRIPTION
## Description

Onyx supports one-way Redis TLS (`REDIS_SSL`, `REDIS_SSL_CA_CERTS`, `REDIS_SSL_CERT_REQS`) but has no way to present a **client certificate**, so deployments whose managed Redis requires **mutual TLS** can't connect.

Adds `REDIS_SSL_CERTFILE` / `REDIS_SSL_KEYFILE`, threaded into **every** Redis connection path:
- **Sync pool** (`redis_pool.py` `RedisPool.create_pool`) — `ssl_certfile`/`ssl_keyfile` kwargs on `BlockingConnectionPool`.
- **Async client** (`_build_async_redis_connection`) — `SSLContext.load_cert_chain(...)`.
- **Celery broker + result backend** (`celery/configs/base.py`) — appended to the `rediss://` URL query so the **workers** get mTLS too, not just the API/app (easy to miss otherwise).

Validated loudly at startup (same style as the Postgres/OpenSearch TLS work): cert and key must be set together, require `REDIS_SSL=true`, and the files must exist. IAM auth keeps precedence.

Certs are referenced by **file path** (consistent with the existing `REDIS_SSL_CA_CERTS`); a managed Redis that hands out base64-encoded certs decodes them into a mounted secret and points these vars at the paths — matching the `redis.Redis(ssl_certfile=..., ssl_keyfile=...)` shape.

## How Has This Been Tested?

- `test_redis_mtls.py`: the sync pool forwards `ssl_certfile`/`ssl_keyfile`; the async client calls `load_cert_chain`; the Celery broker **and** result-backend URLs include the cert params; config validation rejects cert-without-key, client-cert-without-`REDIS_SSL`, and a nonexistent cert path.
- `backend/tests/unit/onyx/redis` + `db` + `utils` → 494 passed; `ty` + `ruff` + `pre-commit` clean.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds mutual TLS support for Redis so the app and Celery workers can present a client certificate. This enables connecting to managed Redis that require mTLS.

- **New Features**
  - Adds `REDIS_SSL_CERTFILE` and `REDIS_SSL_KEYFILE` (must be set together, require `REDIS_SSL=true`; paths are validated at startup).
  - Threads client cert/key through all Redis paths: sync via `redis.BlockingConnectionPool`, async via `ssl.SSLContext.load_cert_chain`, and `Celery` broker/result URLs via `rediss://` query with percent-encoded paths so special characters don’t break the URL.
  - IAM auth continues to take precedence when enabled.

- **Migration**
  - Provide file paths for the client cert and key via `REDIS_SSL_CERTFILE` and `REDIS_SSL_KEYFILE` and set `REDIS_SSL=true`.
  - If your provider gives base64 certs, decode to files (e.g., mounted secrets) and point the env vars to those paths.
  - Startup will fail if only one is set or the files do not exist.

<sup>Written for commit eafc24c1a6fc98f6f55118e7eac8a70fcdb3e395. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

