### PR TITLE
Pin code-interpreter image to 0.4.4

### DIFF
--- a/deployment/docker_compose/docker-compose.multitenant-dev.yml
+++ b/deployment/docker_compose/docker-compose.multitenant-dev.yml
@@ -524,7 +524,7 @@ services:
       - /data
 
   code-interpreter:
-    image: onyxdotapp/code-interpreter:${CODE_INTERPRETER_IMAGE_TAG:-latest}
+    image: onyxdotapp/code-interpreter:${CODE_INTERPRETER_IMAGE_TAG:-0.4.4}
     command: ["bash", "./entrypoint.sh", "code-interpreter-api"]
     restart: unless-stopped
     env_file:

--- a/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
+++ b/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
@@ -334,7 +334,7 @@ services:
       - /data
 
   code-interpreter:
-    image: onyxdotapp/code-interpreter:${CODE_INTERPRETER_IMAGE_TAG:-latest}
+    image: onyxdotapp/code-interpreter:${CODE_INTERPRETER_IMAGE_TAG:-0.4.4}
     command: ["bash", "./entrypoint.sh", "code-interpreter-api"]
     restart: unless-stopped
     env_file:

--- a/deployment/docker_compose/docker-compose.prod.yml
+++ b/deployment/docker_compose/docker-compose.prod.yml
@@ -382,7 +382,7 @@ services:
       - /data
 
   code-interpreter:
-    image: onyxdotapp/code-interpreter:${CODE_INTERPRETER_IMAGE_TAG:-latest}
+    image: onyxdotapp/code-interpreter:${CODE_INTERPRETER_IMAGE_TAG:-0.4.4}
     command: ["bash", "./entrypoint.sh", "code-interpreter-api"]
     restart: unless-stopped
     env_file:

--- a/deployment/docker_compose/docker-compose.yml
+++ b/deployment/docker_compose/docker-compose.yml
@@ -532,7 +532,7 @@ services:
       retries: 3
 
   code-interpreter:
-    image: onyxdotapp/code-interpreter:${CODE_INTERPRETER_IMAGE_TAG:-latest}
+    image: onyxdotapp/code-interpreter:${CODE_INTERPRETER_IMAGE_TAG:-0.4.4}
     command: ["bash", "./entrypoint.sh", "code-interpreter-api"]
     restart: unless-stopped
     env_file:

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1089,7 +1089,7 @@ codeInterpreter:
   image:
     repository: onyxdotapp/code-interpreter
     pullPolicy: Always
-    tag: ""  # Empty uses chart appVersion
+    tag: "0.4.4"  # Pinned code-interpreter release; empty would fall back to chart appVersion
 
   # Service configuration
   service:


### PR DESCRIPTION
## What

Pins the code-interpreter service to the **0.4.4** release of [python-sandbox](https://github.com/onyx-dot-app/python-sandbox) instead of tracking `:latest`, for reproducible deployments.

- `deployment/docker_compose/*.yml` (×4): default tag `${CODE_INTERPRETER_IMAGE_TAG:-latest}` → `${CODE_INTERPRETER_IMAGE_TAG:-0.4.4}`. The env override still works for anyone who wants a different tag.
- `deployment/helm/charts/onyx/values.yaml`: `codeInterpreter.image.tag` `""` → `"0.4.4"`.

## Dependency / ordering

Requires `onyxdotapp/code-interpreter:0.4.4` to be published first. That comes from **onyx-dot-app/python-sandbox#63**, which bumps the version and updates the publish workflow to emit a versioned tag (today it only pushes `:latest`).

**Merge order:** python-sandbox#63 → tag/release `code-interpreter-0.4.4` → run the Docker build (publishes `:0.4.4`) → merge this PR.

## Notes

- The executor image (`onyxdotapp/python-executor-sci`) is pulled by the code-interpreter container at runtime and still resolves to `:latest` (via `PYTHON_EXECUTOR_DOCKER_IMAGE` / `kubernetesExecutor.image`). If you want that pinned to `0.4.4` too for full reproducibility, that can be a follow-up — happy to add it here if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin the `onyxdotapp/code-interpreter` image to 0.4.4 to stop tracking :latest and make deployments reproducible. Updates docker-compose defaults and the Helm `codeInterpreter.image.tag` to 0.4.4.

- **Dependencies**
  - Publish `onyxdotapp/code-interpreter:0.4.4` before merging. Overrides still work (`CODE_INTERPRETER_IMAGE_TAG`, `codeInterpreter.image.tag`).

<sup>Written for commit 5c9a13fa71e18a6c7a5f0574fea6a390c0586691. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

