### PR TITLE
fix(chat): suppress open_url reminder when the tool is disabled

### DIFF
--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -60,6 +60,7 @@ from onyx.tools.models import ToolCallKickoff
 from onyx.tools.models import ToolResponse
 from onyx.tools.tool_implementations.images.models import FinalImageGenerationResponse
 from onyx.tools.tool_implementations.memory.models import MemoryToolResponse
+from onyx.tools.tool_implementations.open_url.open_url_tool import OpenURLTool
 from onyx.tools.tool_implementations.python.python_tool import PythonTool
 from onyx.tools.tool_implementations.search.search_tool import SearchTool
 from onyx.tools.tool_implementations.web_search.utils import extract_url_snippet_map
@@ -603,6 +604,36 @@ def _create_context_files_message(
     )
 
 
+def select_reminder_text(
+    *,
+    ran_image_gen: bool,
+    just_ran_web_search: bool,
+    has_open_url_tool: bool,
+    out_of_cycles: bool,
+    persona_task_prompt: str | None,
+    include_citation_reminder: bool,
+    include_file_reminder: bool,
+) -> str | None:
+    """Choose the reminder appended after a tool cycle.
+
+    The open_url nudge is only emitted when the open_url tool is actually
+    available this session; otherwise the model gets told to call a tool it
+    doesn't have, which leaks confusing "open_url is not available" replies.
+    """
+    if ran_image_gen:
+        # Some models are trained to hand images back to the user via a similar
+        # tool; this prevents output like [Cute Cat](attachment://a_cute_cat.png).
+        return IMAGE_GEN_REMINDER
+    if just_ran_web_search and has_open_url_tool and not out_of_cycles:
+        return OPEN_URL_REMINDER
+    return build_reminder_message(
+        reminder_text=persona_task_prompt,
+        include_citation_reminder=include_citation_reminder,
+        include_file_reminder=include_file_reminder,
+        is_last_cycle=out_of_cycles,
+    )
+
+
 def run_llm_loop(
     emitter: Emitter,
     state_container: ChatStateContainer,
@@ -690,6 +721,9 @@ def run_llm_loop(
         should_cite_documents: bool = False
         ran_image_gen: bool = False
         just_ran_web_search: bool = False
+        # Only nudge the model toward open_url if that tool is actually available
+        # this session; otherwise it gets told to call a tool it doesn't have.
+        has_open_url_tool: bool = any(isinstance(tool, OpenURLTool) for tool in tools)
         has_called_search_tool: bool = False
         code_interpreter_file_generated: bool = False
         fallback_extraction_attempted: bool = False
@@ -785,26 +819,18 @@ def run_llm_loop(
                     )
                     custom_agent_prompt_msg = None
 
-            reminder_message_text: str | None
-            if ran_image_gen:
-                # Some models are trained to give back images to the user for some similar tool
-                # This is to prevent it generating things like:
-                # [Cute Cat](attachment://a_cute_cat_sitting_playfully.png)
-                reminder_message_text = IMAGE_GEN_REMINDER
-            elif just_ran_web_search and not out_of_cycles:
-                reminder_message_text = OPEN_URL_REMINDER
-            else:
-                # This is the default case, the LLM at this point may answer so it is important
-                # to include the reminder. Potentially this should also mention citation
-                reminder_message_text = build_reminder_message(
-                    reminder_text=(
-                        persona.task_prompt if persona and persona.task_prompt else None
-                    ),
-                    include_citation_reminder=should_cite_documents
-                    or always_cite_documents,
-                    include_file_reminder=code_interpreter_file_generated,
-                    is_last_cycle=out_of_cycles,
-                )
+            reminder_message_text = select_reminder_text(
+                ran_image_gen=ran_image_gen,
+                just_ran_web_search=just_ran_web_search,
+                has_open_url_tool=has_open_url_tool,
+                out_of_cycles=out_of_cycles,
+                persona_task_prompt=(
+                    persona.task_prompt if persona and persona.task_prompt else None
+                ),
+                include_citation_reminder=should_cite_documents
+                or always_cite_documents,
+                include_file_reminder=code_interpreter_file_generated,
+            )
 
             reminder_msg = (
                 ChatMessageSimple(

--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -616,13 +616,11 @@ def select_reminder_text(
 ) -> str | None:
     """Choose the reminder appended after a tool cycle.
 
-    The open_url nudge is only emitted when the open_url tool is actually
-    available this session; otherwise the model gets told to call a tool it
-    doesn't have, which leaks confusing "open_url is not available" replies.
+    The open_url nudge is gated on the tool actually being available; otherwise
+    the model is told to call a tool it doesn't have and leaks confusing
+    "open_url is not available" replies.
     """
     if ran_image_gen:
-        # Some models are trained to hand images back to the user via a similar
-        # tool; this prevents output like [Cute Cat](attachment://a_cute_cat.png).
         return IMAGE_GEN_REMINDER
     if just_ran_web_search and has_open_url_tool and not out_of_cycles:
         return OPEN_URL_REMINDER
@@ -721,8 +719,6 @@ def run_llm_loop(
         should_cite_documents: bool = False
         ran_image_gen: bool = False
         just_ran_web_search: bool = False
-        # Only nudge the model toward open_url if that tool is actually available
-        # this session; otherwise it gets told to call a tool it doesn't have.
         has_open_url_tool: bool = any(isinstance(tool, OpenURLTool) for tool in tools)
         has_called_search_tool: bool = False
         code_interpreter_file_generated: bool = False

--- a/backend/onyx/tools/fake_tools/research_agent.py
+++ b/backend/onyx/tools/fake_tools/research_agent.py
@@ -313,8 +313,7 @@ def run_research_agent_call(
                     message_type=MessageType.SYSTEM,
                 )
 
-                # Only remind the model to open_url when that tool is actually
-                # available; otherwise it gets nudged toward a tool it doesn't have.
+                # Gate the open_url nudge on the tool actually being available.
                 if just_ran_web_search and has_open_url_tool:
                     reminder_message = ChatMessageSimple(
                         message=OPEN_URL_REMINDER_RESEARCH_AGENT,

--- a/backend/onyx/tools/fake_tools/research_agent.py
+++ b/backend/onyx/tools/fake_tools/research_agent.py
@@ -286,7 +286,7 @@ def run_research_agent_call(
                     if any(isinstance(tool, WebSearchTool) for tool in current_tools)
                     else ""
                 )
-                has_open_url_tool = any(
+                has_open_url_tool: bool = any(
                     isinstance(tool, OpenURLTool) for tool in current_tools
                 )
                 open_urls_tip = OPEN_URLS_TOOL_DESCRIPTION if has_open_url_tool else ""

--- a/backend/onyx/tools/fake_tools/research_agent.py
+++ b/backend/onyx/tools/fake_tools/research_agent.py
@@ -286,11 +286,10 @@ def run_research_agent_call(
                     if any(isinstance(tool, WebSearchTool) for tool in current_tools)
                     else ""
                 )
-                open_urls_tip = (
-                    OPEN_URLS_TOOL_DESCRIPTION
-                    if any(isinstance(tool, OpenURLTool) for tool in current_tools)
-                    else ""
+                has_open_url_tool = any(
+                    isinstance(tool, OpenURLTool) for tool in current_tools
                 )
+                open_urls_tip = OPEN_URLS_TOOL_DESCRIPTION if has_open_url_tool else ""
                 if is_reasoning_model and open_urls_tip:
                     open_urls_tip = OPEN_URLS_TOOL_DESCRIPTION_REASONING
 
@@ -314,7 +313,9 @@ def run_research_agent_call(
                     message_type=MessageType.SYSTEM,
                 )
 
-                if just_ran_web_search:
+                # Only remind the model to open_url when that tool is actually
+                # available; otherwise it gets nudged toward a tool it doesn't have.
+                if just_ran_web_search and has_open_url_tool:
                     reminder_message = ChatMessageSimple(
                         message=OPEN_URL_REMINDER_RESEARCH_AGENT,
                         token_count=100,

--- a/backend/tests/unit/onyx/chat/test_llm_loop.py
+++ b/backend/tests/unit/onyx/chat/test_llm_loop.py
@@ -1,5 +1,6 @@
 """Tests for llm_loop.py, including history construction and empty-response paths."""
 
+from typing import Any
 from unittest.mock import Mock
 
 import pytest
@@ -8,6 +9,7 @@ from onyx.chat.llm_loop import _build_empty_llm_response_error
 from onyx.chat.llm_loop import _try_fallback_tool_extraction
 from onyx.chat.llm_loop import construct_message_history
 from onyx.chat.llm_loop import EmptyLLMResponseError
+from onyx.chat.llm_loop import select_reminder_text
 from onyx.chat.models import ChatLoadedFile
 from onyx.chat.models import ChatMessageSimple
 from onyx.chat.models import ContextFileMetadata
@@ -19,6 +21,8 @@ from onyx.configs.constants import MessageType
 from onyx.file_store.models import ChatFileType
 from onyx.llm.interfaces import LLMConfig
 from onyx.llm.interfaces import ToolChoiceOptions
+from onyx.prompts.chat_prompts import IMAGE_GEN_REMINDER
+from onyx.prompts.chat_prompts import OPEN_URL_REMINDER
 from onyx.server.query_and_chat.placement import Placement
 from onyx.tools.models import ToolCallKickoff
 
@@ -1298,3 +1302,44 @@ class TestEmptyLlmResponseClassification:
         assert err.error_code == "EMPTY_LLM_RESPONSE"
         assert err.is_retryable is True
         assert "quota" not in err.client_error_msg.lower()
+
+
+class TestSelectReminderText:
+    """The open_url nudge must be suppressed when the open_url tool is disabled,
+    otherwise the model is told to call a tool it doesn't have (confusing
+    "open_url is not available" replies)."""
+
+    def _select(self, **overrides: Any) -> str | None:
+        kwargs: dict[str, Any] = dict(
+            ran_image_gen=False,
+            just_ran_web_search=False,
+            has_open_url_tool=True,
+            out_of_cycles=False,
+            persona_task_prompt=None,
+            include_citation_reminder=False,
+            include_file_reminder=False,
+        )
+        kwargs.update(overrides)
+        return select_reminder_text(**kwargs)
+
+    def test_open_url_reminder_when_tool_available(self) -> None:
+        result = self._select(just_ran_web_search=True, has_open_url_tool=True)
+        assert result == OPEN_URL_REMINDER
+
+    def test_no_open_url_reminder_when_tool_disabled(self) -> None:
+        """Web search ran but open_url is disabled -> fall back, never nudge open_url."""
+        result = self._select(just_ran_web_search=True, has_open_url_tool=False)
+        assert result != OPEN_URL_REMINDER
+        assert result is None  # nothing else to remind about in this scenario
+
+    def test_open_url_reminder_suppressed_on_last_cycle(self) -> None:
+        result = self._select(
+            just_ran_web_search=True, has_open_url_tool=True, out_of_cycles=True
+        )
+        assert result != OPEN_URL_REMINDER
+
+    def test_image_gen_reminder_takes_precedence(self) -> None:
+        result = self._select(
+            ran_image_gen=True, just_ran_web_search=True, has_open_url_tool=True
+        )
+        assert result == IMAGE_GEN_REMINDER


### PR DESCRIPTION
## Description

When **Web Search** is enabled but **Open Url** (web fetch) is disabled, the agent intermittently surfaces confusing replies such as *"I don't have an `open_url` tool available in this session (only `web_search`, `internal_search`, and a few others)"*.

Root cause: after a successful `web_search`, the chat loop unconditionally injects `OPEN_URL_REMINDER`, whose text explicitly tells the model to *"call the open_url tool with an array of URLs"* — even when the `OpenURLTool` was never registered for the session. The **system-prompt** guidance (`prompt_utils.py`) was already correctly gated on `has_open_urls`, but the **post-search reminders** were not. This is why it only happens on turns where web search returns results.

This change gates both reminder paths on the `OpenURLTool` actually being present in the session's tool list:
- `onyx/chat/llm_loop.py` — standard chat loop (extracted the selection into a pure `select_reminder_text` helper).
- `onyx/tools/fake_tools/research_agent.py` — deep-research agent (`OPEN_URL_REMINDER_RESEARCH_AGENT`).

When `open_url` is disabled, the model now just answers from the search snippets instead of being nudged toward a tool it can't call.

## How Has This Been Tested?

Added unit tests in `backend/tests/unit/onyx/chat/test_llm_loop.py` (`TestSelectReminderText`) covering: reminder present when the tool is available, suppressed when disabled, suppressed on the last cycle, and image-gen precedence. Full file: 41 passed.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppress the “open_url” reminder when the `OpenURLTool` is not enabled to avoid confusing replies after web search. Applies to both the standard chat loop and the deep-research agent.

- **Bug Fixes**
  - Gate the post-search “open_url” nudge on `OpenURLTool` being present in the session (chat loop and research agent).
  - Centralize reminder selection in `select_reminder_text`; add unit tests for gating, last-cycle suppression, and image-gen precedence.

- **Refactors**
  - Annotate `has_open_url_tool: bool` and trim duplicate reminder comments.

<sup>Written for commit 3fbfbcd64303d8ff12738fb0eb796a627e77d477. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

