### PR TITLE
fix(chat): suppress open_url reminder when the tool is disabled (cherry-pick #12323 to v4.1)

### DIFF
--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -60,6 +60,7 @@ from onyx.tools.models import ToolCallKickoff
 from onyx.tools.models import ToolResponse
 from onyx.tools.tool_implementations.images.models import FinalImageGenerationResponse
 from onyx.tools.tool_implementations.memory.models import MemoryToolResponse
+from onyx.tools.tool_implementations.open_url.open_url_tool import OpenURLTool
 from onyx.tools.tool_implementations.python.python_tool import PythonTool
 from onyx.tools.tool_implementations.search.search_tool import SearchTool
 from onyx.tools.tool_implementations.web_search.utils import extract_url_snippet_map
@@ -603,6 +604,36 @@ def _create_context_files_message(
     )
 
 
+def select_reminder_text(
+    *,
+    ran_image_gen: bool,
+    just_ran_web_search: bool,
+    has_open_url_tool: bool,
+    out_of_cycles: bool,
+    persona_task_prompt: str | None,
+    include_citation_reminder: bool,
+    include_file_reminder: bool,
+) -> str | None:
+    """Choose the reminder appended after a tool cycle.
+
+    The open_url nudge is only emitted when the open_url tool is actually
+    available this session; otherwise the model gets told to call a tool it
+    doesn't have, which leaks confusing "open_url is not available" replies.
+    """
+    if ran_image_gen:
+        # Some models are trained to hand images back to the user via a similar
+        # tool; this prevents output like [Cute Cat](attachment://a_cute_cat.png).
+        return IMAGE_GEN_REMINDER
+    if just_ran_web_search and has_open_url_tool and not out_of_cycles:
+        return OPEN_URL_REMINDER
+    return build_reminder_message(
+        reminder_text=persona_task_prompt,
+        include_citation_reminder=include_citation_reminder,
+        include_file_reminder=include_file_reminder,
+        is_last_cycle=out_of_cycles,
+    )
+
+
 def run_llm_loop(
     emitter: Emitter,
     state_container: ChatStateContainer,
@@ -690,6 +721,9 @@ def run_llm_loop(
         should_cite_documents: bool = False
         ran_image_gen: bool = False
         just_ran_web_search: bool = False
+        # Only nudge the model toward open_url if that tool is actually available
+        # this session; otherwise it gets told to call a tool it doesn't have.
+        has_open_url_tool: bool = any(isinstance(tool, OpenURLTool) for tool in tools)
         has_called_search_tool: bool = False
         code_interpreter_file_generated: bool = False
         fallback_extraction_attempted: bool = False
@@ -785,26 +819,18 @@ def run_llm_loop(
                     )
                     custom_agent_prompt_msg = None
 
-            reminder_message_text: str | None
-            if ran_image_gen:
-                # Some models are trained to give back images to the user for some similar tool
-                # This is to prevent it generating things like:
-                # [Cute Cat](attachment://a_cute_cat_sitting_playfully.png)
-                reminder_message_text = IMAGE_GEN_REMINDER
-            elif just_ran_web_search and not out_of_cycles:
-                reminder_message_text = OPEN_URL_REMINDER
-            else:
-                # This is the default case, the LLM at this point may answer so it is important
-                # to include the reminder. Potentially this should also mention citation
-                reminder_message_text = build_reminder_message(
-                    reminder_text=(
-                        persona.task_prompt if persona and persona.task_prompt else None
-                    ),
-                    include_citation_reminder=should_cite_documents
-                    or always_cite_documents,
-                    include_file_reminder=code_interpreter_file_generated,
-                    is_last_cycle=out_of_cycles,
-                )
+            reminder_message_text = select_reminder_text(
+                ran_image_gen=ran_image_gen,
+                just_ran_web_search=just_ran_web_search,
+                has_open_url_tool=has_open_url_tool,
+                out_of_cycles=out_of_cycles,
+                persona_task_prompt=(
+                    persona.task_prompt if persona and persona.task_prompt else None
+                ),
+                include_citation_reminder=should_cite_documents
+                or always_cite_documents,
+                include_file_reminder=code_interpreter_file_generated,
+            )
 
             reminder_msg = (
                 ChatMessageSimple(

--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -616,13 +616,11 @@ def select_reminder_text(
 ) -> str | None:
     """Choose the reminder appended after a tool cycle.
 
-    The open_url nudge is only emitted when the open_url tool is actually
-    available this session; otherwise the model gets told to call a tool it
-    doesn't have, which leaks confusing "open_url is not available" replies.
+    The open_url nudge is gated on the tool actually being available; otherwise
+    the model is told to call a tool it doesn't have and leaks confusing
+    "open_url is not available" replies.
     """
     if ran_image_gen:
-        # Some models are trained to hand images back to the user via a similar
-        # tool; this prevents output like [Cute Cat](attachment://a_cute_cat.png).
         return IMAGE_GEN_REMINDER
     if just_ran_web_search and has_open_url_tool and not out_of_cycles:
         return OPEN_URL_REMINDER
@@ -721,8 +719,6 @@ def run_llm_loop(
         should_cite_documents: bool = False
         ran_image_gen: bool = False
         just_ran_web_search: bool = False
-        # Only nudge the model toward open_url if that tool is actually available
-        # this session; otherwise it gets told to call a tool it doesn't have.
         has_open_url_tool: bool = any(isinstance(tool, OpenURLTool) for tool in tools)
         has_called_search_tool: bool = False
         code_interpreter_file_generated: bool = False

--- a/backend/onyx/tools/fake_tools/research_agent.py
+++ b/backend/onyx/tools/fake_tools/research_agent.py
@@ -313,8 +313,7 @@ def run_research_agent_call(
                     message_type=MessageType.SYSTEM,
                 )
 
-                # Only remind the model to open_url when that tool is actually
-                # available; otherwise it gets nudged toward a tool it doesn't have.
+                # Gate the open_url nudge on the tool actually being available.
                 if just_ran_web_search and has_open_url_tool:
                     reminder_message = ChatMessageSimple(
                         message=OPEN_URL_REMINDER_RESEARCH_AGENT,

--- a/backend/onyx/tools/fake_tools/research_agent.py
+++ b/backend/onyx/tools/fake_tools/research_agent.py
@@ -286,7 +286,7 @@ def run_research_agent_call(
                     if any(isinstance(tool, WebSearchTool) for tool in current_tools)
                     else ""
                 )
-                has_open_url_tool = any(
+                has_open_url_tool: bool = any(
                     isinstance(tool, OpenURLTool) for tool in current_tools
                 )
                 open_urls_tip = OPEN_URLS_TOOL_DESCRIPTION if has_open_url_tool else ""

--- a/backend/onyx/tools/fake_tools/research_agent.py
+++ b/backend/onyx/tools/fake_tools/research_agent.py
@@ -286,11 +286,10 @@ def run_research_agent_call(
                     if any(isinstance(tool, WebSearchTool) for tool in current_tools)
                     else ""
                 )
-                open_urls_tip = (
-                    OPEN_URLS_TOOL_DESCRIPTION
-                    if any(isinstance(tool, OpenURLTool) for tool in current_tools)
-                    else ""
+                has_open_url_tool = any(
+                    isinstance(tool, OpenURLTool) for tool in current_tools
                 )
+                open_urls_tip = OPEN_URLS_TOOL_DESCRIPTION if has_open_url_tool else ""
                 if is_reasoning_model and open_urls_tip:
                     open_urls_tip = OPEN_URLS_TOOL_DESCRIPTION_REASONING
 
@@ -314,7 +313,9 @@ def run_research_agent_call(
                     message_type=MessageType.SYSTEM,
                 )
 
-                if just_ran_web_search:
+                # Only remind the model to open_url when that tool is actually
+                # available; otherwise it gets nudged toward a tool it doesn't have.
+                if just_ran_web_search and has_open_url_tool:
                     reminder_message = ChatMessageSimple(
                         message=OPEN_URL_REMINDER_RESEARCH_AGENT,
                         token_count=100,

--- a/backend/tests/unit/onyx/chat/test_llm_loop.py
+++ b/backend/tests/unit/onyx/chat/test_llm_loop.py
@@ -1,5 +1,6 @@
 """Tests for llm_loop.py, including history construction and empty-response paths."""
 
+from typing import Any
 from unittest.mock import Mock
 
 import pytest
@@ -8,6 +9,7 @@ from onyx.chat.llm_loop import _build_empty_llm_response_error
 from onyx.chat.llm_loop import _try_fallback_tool_extraction
 from onyx.chat.llm_loop import construct_message_history
 from onyx.chat.llm_loop import EmptyLLMResponseError
+from onyx.chat.llm_loop import select_reminder_text
 from onyx.chat.models import ChatLoadedFile
 from onyx.chat.models import ChatMessageSimple
 from onyx.chat.models import ContextFileMetadata
@@ -19,6 +21,8 @@ from onyx.configs.constants import MessageType
 from onyx.file_store.models import ChatFileType
 from onyx.llm.interfaces import LLMConfig
 from onyx.llm.interfaces import ToolChoiceOptions
+from onyx.prompts.chat_prompts import IMAGE_GEN_REMINDER
+from onyx.prompts.chat_prompts import OPEN_URL_REMINDER
 from onyx.server.query_and_chat.placement import Placement
 from onyx.tools.models import ToolCallKickoff
 
@@ -1298,3 +1302,44 @@ class TestEmptyLlmResponseClassification:
         assert err.error_code == "EMPTY_LLM_RESPONSE"
         assert err.is_retryable is True
         assert "quota" not in err.client_error_msg.lower()
+
+
+class TestSelectReminderText:
+    """The open_url nudge must be suppressed when the open_url tool is disabled,
+    otherwise the model is told to call a tool it doesn't have (confusing
+    "open_url is not available" replies)."""
+
+    def _select(self, **overrides: Any) -> str | None:
+        kwargs: dict[str, Any] = dict(
+            ran_image_gen=False,
+            just_ran_web_search=False,
+            has_open_url_tool=True,
+            out_of_cycles=False,
+            persona_task_prompt=None,
+            include_citation_reminder=False,
+            include_file_reminder=False,
+        )
+        kwargs.update(overrides)
+        return select_reminder_text(**kwargs)
+
+    def test_open_url_reminder_when_tool_available(self) -> None:
+        result = self._select(just_ran_web_search=True, has_open_url_tool=True)
+        assert result == OPEN_URL_REMINDER
+
+    def test_no_open_url_reminder_when_tool_disabled(self) -> None:
+        """Web search ran but open_url is disabled -> fall back, never nudge open_url."""
+        result = self._select(just_ran_web_search=True, has_open_url_tool=False)
+        assert result != OPEN_URL_REMINDER
+        assert result is None  # nothing else to remind about in this scenario
+
+    def test_open_url_reminder_suppressed_on_last_cycle(self) -> None:
+        result = self._select(
+            just_ran_web_search=True, has_open_url_tool=True, out_of_cycles=True
+        )
+        assert result != OPEN_URL_REMINDER
+
+    def test_image_gen_reminder_takes_precedence(self) -> None:
+        result = self._select(
+            ran_image_gen=True, just_ran_web_search=True, has_open_url_tool=True
+        )
+        assert result == IMAGE_GEN_REMINDER


### PR DESCRIPTION
## Description

Cherry-pick of #12323 to `release/v4.1`.

When **Web Search** is enabled but **Open Url** (web fetch) is disabled, the agent intermittently replies *"I don't have an `open_url` tool available in this session..."*. Root cause: the post-`web_search` reminder (`OPEN_URL_REMINDER`) unconditionally tells the model to call `open_url`, even when `OpenURLTool` isn't registered for the session. The system-prompt guidance was already gated on tool availability; the reminders were not. This gates both reminder paths (standard chat loop + deep-research agent) on the tool actually being present.

Targeted at v4.1 because a customer hit this on **v4.1.4**.

## How Has This Been Tested?

Clean cherry-pick (no conflicts). Unit tests (`TestSelectReminderText` in `backend/tests/unit/onyx/chat/test_llm_loop.py`) pass on `main` with byte-identical code; the diff vs the v4.1 base is identical to the merged main change.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppresses the `open_url` reminder when the tool is disabled to stop confusing “I don’t have an open_url tool” replies after web search. Cherry-pick to `release/v4.1`.

- **Bug Fixes**
  - Gate `OPEN_URL_REMINDER` on `OpenURLTool` availability in both the standard chat loop and the deep-research agent.
  - Introduce `select_reminder_text` to centralize reminder selection and preserve existing image-gen/last-cycle behavior.
  - Add unit tests (`TestSelectReminderText`) to verify gating and precedence rules.

- **Refactors**
  - Annotate `has_open_url_tool: bool` for consistency.
  - Trim duplicated comments around the open_url reminder logic.

<sup>Written for commit b2b7787a4819d10bdef988119a6c782144c12508. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

