### PR TITLE
feat(audit): emit admin-config and access-control audit events

### DIFF
--- a/backend/onyx/server/api_key/api.py
+++ b/backend/onyx/server/api_key/api.py
@@ -13,6 +13,10 @@ from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
 from onyx.db.models import User
 from onyx.server.api_key.models import APIKeyArgs
+from onyx.utils.audit import actor_from_user
+from onyx.utils.audit import AuditAction
+from onyx.utils.audit import AuditOutcome
+from onyx.utils.audit import emit_audit_event
 
 router = APIRouter(prefix="/admin/api-key")
 
@@ -31,16 +35,32 @@ def create_api_key(
     user: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> ApiKeyDescriptor:
-    return insert_api_key(db_session, api_key_args, user.id)
+    api_key = insert_api_key(db_session, api_key_args, user.id)
+    emit_audit_event(
+        AuditAction.API_KEY_CREATE,
+        AuditOutcome.SUCCESS,
+        actor=actor_from_user(user),
+        resource_type="api_key",
+        resource_id=api_key.api_key_id,
+    )
+    return api_key
 
 
 @router.post("/{api_key_id}/regenerate")
 def regenerate_existing_api_key(
     api_key_id: int,
-    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    user: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> ApiKeyDescriptor:
-    return regenerate_api_key(db_session, api_key_id)
+    api_key = regenerate_api_key(db_session, api_key_id)
+    emit_audit_event(
+        AuditAction.API_KEY_REGENERATE,
+        AuditOutcome.SUCCESS,
+        actor=actor_from_user(user),
+        resource_type="api_key",
+        resource_id=api_key_id,
+    )
+    return api_key
 
 
 @router.patch("/{api_key_id}")
@@ -56,7 +76,14 @@ def update_existing_api_key(
 @router.delete("/{api_key_id}")
 def delete_api_key(
     api_key_id: int,
-    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    user: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> None:
     remove_api_key(db_session, api_key_id)
+    emit_audit_event(
+        AuditAction.API_KEY_DELETE,
+        AuditOutcome.SUCCESS,
+        actor=actor_from_user(user),
+        resource_type="api_key",
+        resource_id=api_key_id,
+    )

--- a/backend/onyx/server/documents/cc_pair.py
+++ b/backend/onyx/server/documents/cc_pair.py
@@ -83,6 +83,10 @@ from onyx.server.documents.models import PaginatedReturn
 from onyx.server.documents.models import synthesize_unaccounted
 from onyx.server.models import StatusResponse
 from onyx.server.security.store import get_security_settings
+from onyx.utils.audit import actor_from_user
+from onyx.utils.audit import AuditAction
+from onyx.utils.audit import AuditOutcome
+from onyx.utils.audit import emit_audit_event
 from onyx.utils.logger import setup_logger
 from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
 from shared_configs.contextvars import get_current_tenant_id
@@ -508,6 +512,15 @@ def update_cc_pair_status(
 
     db_session.commit()
 
+    emit_audit_event(
+        AuditAction.CC_PAIR_UPDATE,
+        AuditOutcome.SUCCESS,
+        actor=actor_from_user(user),
+        resource_type="cc_pair",
+        resource_id=cc_pair_id,
+        extra={"status": str(status_update_request.status)},
+    )
+
     # this speeds up the start of indexing by firing the check immediately
     client_app.send_task(
         OnyxCeleryTask.CHECK_FOR_INDEXING,
@@ -779,6 +792,14 @@ def associate_credential_to_connector(
             response.data,
         )
 
+        emit_audit_event(
+            AuditAction.CC_PAIR_CREATE,
+            AuditOutcome.SUCCESS,
+            actor=actor_from_user(user),
+            resource_type="cc_pair",
+            resource_id=response.data,
+            extra={"connector_id": connector_id, "credential_id": credential_id},
+        )
         return response
     except ValidationError as e:
         # If validation fails, delete the connector and commit the changes
@@ -813,6 +834,14 @@ def dissociate_credential_from_connector(
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> StatusResponse[int]:
-    return remove_credential_from_connector(
+    result = remove_credential_from_connector(
         connector_id, credential_id, user, db_session
     )
+    emit_audit_event(
+        AuditAction.CC_PAIR_DELETE,
+        AuditOutcome.SUCCESS,
+        actor=actor_from_user(user),
+        resource_type="cc_pair",
+        extra={"connector_id": connector_id, "credential_id": credential_id},
+    )
+    return result

--- a/backend/onyx/server/documents/cc_pair.py
+++ b/backend/onyx/server/documents/cc_pair.py
@@ -26,6 +26,7 @@ from onyx.connectors.interfaces import Resolver
 from onyx.connectors.models import InputType
 from onyx.db.connector import delete_connector
 from onyx.db.connector_credential_pair import add_credential_to_connector
+from onyx.db.connector_credential_pair import get_connector_credential_pair_for_user
 from onyx.db.connector_credential_pair import (
     get_connector_credential_pair_from_id_for_user,
 )
@@ -792,14 +793,17 @@ def associate_credential_to_connector(
             response.data,
         )
 
-        emit_audit_event(
-            AuditAction.CC_PAIR_CREATE,
-            AuditOutcome.SUCCESS,
-            actor=actor_from_user(user),
-            resource_type="cc_pair",
-            resource_id=response.data,
-            extra={"connector_id": connector_id, "credential_id": credential_id},
-        )
+        # response.data is the cc_pair id only when the association was actually
+        # created; a no-op (credential already linked) returns success=False.
+        if response.success:
+            emit_audit_event(
+                AuditAction.CC_PAIR_CREATE,
+                AuditOutcome.SUCCESS,
+                actor=actor_from_user(user),
+                resource_type="cc_pair",
+                resource_id=response.data,
+                extra={"connector_id": connector_id, "credential_id": credential_id},
+            )
         return response
     except ValidationError as e:
         # If validation fails, delete the connector and commit the changes
@@ -834,14 +838,30 @@ def dissociate_credential_from_connector(
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> StatusResponse[int]:
+    # Capture the cc_pair id before removal — remove_credential_from_connector
+    # returns the connector_id (not the cc_pair id) in its StatusResponse.
+    cc_pair = get_connector_credential_pair_for_user(
+        db_session=db_session,
+        connector_id=connector_id,
+        credential_id=credential_id,
+        user=user,
+        get_editable=True,
+    )
+    cc_pair_id = cc_pair.id if cc_pair else None
+
     result = remove_credential_from_connector(
         connector_id, credential_id, user, db_session
     )
-    emit_audit_event(
-        AuditAction.CC_PAIR_DELETE,
-        AuditOutcome.SUCCESS,
-        actor=actor_from_user(user),
-        resource_type="cc_pair",
-        extra={"connector_id": connector_id, "credential_id": credential_id},
-    )
+
+    # Only emit when something was actually dissociated (a no-op returns
+    # success=False without raising).
+    if result.success:
+        emit_audit_event(
+            AuditAction.CC_PAIR_DELETE,
+            AuditOutcome.SUCCESS,
+            actor=actor_from_user(user),
+            resource_type="cc_pair",
+            resource_id=cc_pair_id,
+            extra={"connector_id": connector_id, "credential_id": credential_id},
+        )
     return result

--- a/backend/onyx/server/documents/cc_pair.py
+++ b/backend/onyx/server/documents/cc_pair.py
@@ -519,7 +519,7 @@ def update_cc_pair_status(
         actor=actor_from_user(user),
         resource_type="cc_pair",
         resource_id=cc_pair_id,
-        extra={"status": str(status_update_request.status)},
+        extra={"status": status_update_request.status.value},
     )
 
     # this speeds up the start of indexing by firing the check immediately

--- a/backend/onyx/server/documents/connector.py
+++ b/backend/onyx/server/documents/connector.py
@@ -135,6 +135,10 @@ from onyx.server.federated.models import FederatedConnectorStatus
 from onyx.server.models import StatusResponse
 from onyx.server.security.store import get_security_settings
 from onyx.server.utils_vector_db import require_vector_db
+from onyx.utils.audit import actor_from_user
+from onyx.utils.audit import AuditAction
+from onyx.utils.audit import AuditOutcome
+from onyx.utils.audit import emit_audit_event
 from onyx.utils.logger import setup_logger
 from onyx.utils.telemetry import mt_cloud_telemetry
 from onyx.utils.threadpool_concurrency import CallableProtocol
@@ -1568,6 +1572,14 @@ def create_connector_from_model(
             event=MilestoneRecordType.CREATED_CONNECTOR,
         )
 
+        emit_audit_event(
+            AuditAction.CONNECTOR_CREATE,
+            AuditOutcome.SUCCESS,
+            actor=actor_from_user(user),
+            resource_type="connector",
+            resource_id=connector_response.id,
+            extra={"source": str(connector_data.source)},
+        )
         return connector_response
     except ValueError as e:
         logger.error("Error creating connector: %s", e)
@@ -1690,6 +1702,14 @@ def update_connector_from_model(
             status_code=404, detail=f"Connector {connector_id} does not exist"
         )
 
+    emit_audit_event(
+        AuditAction.CONNECTOR_UPDATE,
+        AuditOutcome.SUCCESS,
+        actor=actor_from_user(user),
+        resource_type="connector",
+        resource_id=updated_connector.id,
+    )
+
     return ConnectorSnapshot(
         id=updated_connector.id,
         name=updated_connector.name,
@@ -1714,17 +1734,26 @@ def update_connector_from_model(
 )
 def delete_connector_by_id(
     connector_id: int,
-    _: User = Depends(current_curator_or_admin_user),
+    user: User = Depends(current_curator_or_admin_user),
     db_session: Session = Depends(get_session),
 ) -> StatusResponse[int]:
     try:
         with db_session.begin():
-            return delete_connector(
+            result = delete_connector(
                 db_session=db_session,
                 connector_id=connector_id,
             )
     except AssertionError:
         raise HTTPException(status_code=400, detail="Connector is not deletable")
+
+    emit_audit_event(
+        AuditAction.CONNECTOR_DELETE,
+        AuditOutcome.SUCCESS,
+        actor=actor_from_user(user),
+        resource_type="connector",
+        resource_id=connector_id,
+    )
+    return result
 
 
 @router.post("/admin/connector/run-once", tags=PUBLIC_API_TAGS)

--- a/backend/onyx/server/documents/connector.py
+++ b/backend/onyx/server/documents/connector.py
@@ -1578,7 +1578,7 @@ def create_connector_from_model(
             actor=actor_from_user(user),
             resource_type="connector",
             resource_id=connector_response.id,
-            extra={"source": str(connector_data.source)},
+            extra={"source": connector_data.source.value},
         )
         return connector_response
     except ValueError as e:

--- a/backend/onyx/server/documents/credential.py
+++ b/backend/onyx/server/documents/credential.py
@@ -38,6 +38,10 @@ from onyx.server.documents.private_key_types import PrivateKeyFileTypes
 from onyx.server.documents.private_key_types import ProcessPrivateKeyFileProtocol
 from onyx.server.models import StatusResponse
 from onyx.server.security.store import get_security_settings
+from onyx.utils.audit import actor_from_user
+from onyx.utils.audit import AuditAction
+from onyx.utils.audit import AuditOutcome
+from onyx.utils.audit import emit_audit_event
 from onyx.utils.logger import setup_logger
 from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
 
@@ -102,11 +106,18 @@ def get_cc_source_full_info(
 @router.delete("/admin/credential/{credential_id}")
 def delete_credential_by_id_admin(
     credential_id: int,
-    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    user: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> StatusResponse:
     """Same as the user endpoint, but can delete any credential (not just the user's own)"""
     delete_credential(db_session=db_session, credential_id=credential_id)
+    emit_audit_event(
+        AuditAction.CREDENTIAL_DELETE,
+        AuditOutcome.SUCCESS,
+        actor=actor_from_user(user),
+        resource_type="credential",
+        resource_id=credential_id,
+    )
     return StatusResponse(
         success=True, message="Credential deleted successfully", data=credential_id
     )
@@ -160,6 +171,14 @@ def create_credential_from_model(
         cleanup_gmail_credentials(db_session=db_session)
 
     credential = create_credential(credential_info, user, db_session)
+    emit_audit_event(
+        AuditAction.CREDENTIAL_CREATE,
+        AuditOutcome.SUCCESS,
+        actor=actor_from_user(user),
+        resource_type="credential",
+        resource_id=credential.id,
+        extra={"source": str(credential_info.source)},
+    )
     return ObjectCreationIdResponse(
         id=credential.id,
         credential=CredentialSnapshot.from_credential_db_model(
@@ -227,6 +246,14 @@ def create_credential_with_private_key(
         cleanup_gmail_credentials(db_session=db_session)
 
     credential = create_credential(credential_info, user, db_session)
+    emit_audit_event(
+        AuditAction.CREDENTIAL_CREATE,
+        AuditOutcome.SUCCESS,
+        actor=actor_from_user(user),
+        resource_type="credential",
+        resource_id=credential.id,
+        extra={"source": str(credential_info.source)},
+    )
     return ObjectCreationIdResponse(
         id=credential.id,
         credential=CredentialSnapshot.from_credential_db_model(
@@ -371,6 +398,14 @@ def update_credential_from_model(
             detail=f"Credential {credential_id} does not exist or does not belong to user",
         )
 
+    emit_audit_event(
+        AuditAction.CREDENTIAL_UPDATE,
+        AuditOutcome.SUCCESS,
+        actor=actor_from_user(user),
+        resource_type="credential",
+        resource_id=credential_id,
+    )
+
     mask_credential_prefix = get_security_settings().mask_credential_prefix
     credential_json_value = (
         updated_credential.credential_json.get_value(apply_mask=mask_credential_prefix)
@@ -403,6 +438,14 @@ def delete_credential_by_id(
         db_session,
     )
 
+    emit_audit_event(
+        AuditAction.CREDENTIAL_DELETE,
+        AuditOutcome.SUCCESS,
+        actor=actor_from_user(user),
+        resource_type="credential",
+        resource_id=credential_id,
+    )
+
     return StatusResponse(
         success=True, message="Credential deleted successfully", data=credential_id
     )
@@ -415,6 +458,14 @@ def force_delete_credential_by_id(
     db_session: Session = Depends(get_session),
 ) -> StatusResponse:
     delete_credential_for_user(credential_id, user, db_session, True)
+
+    emit_audit_event(
+        AuditAction.CREDENTIAL_DELETE,
+        AuditOutcome.SUCCESS,
+        actor=actor_from_user(user),
+        resource_type="credential",
+        resource_id=credential_id,
+    )
 
     return StatusResponse(
         success=True, message="Credential deleted successfully", data=credential_id

--- a/backend/onyx/server/documents/credential.py
+++ b/backend/onyx/server/documents/credential.py
@@ -177,7 +177,7 @@ def create_credential_from_model(
         actor=actor_from_user(user),
         resource_type="credential",
         resource_id=credential.id,
-        extra={"source": str(credential_info.source)},
+        extra={"source": credential_info.source.value},
     )
     return ObjectCreationIdResponse(
         id=credential.id,
@@ -252,7 +252,7 @@ def create_credential_with_private_key(
         actor=actor_from_user(user),
         resource_type="credential",
         resource_id=credential.id,
-        extra={"source": str(credential_info.source)},
+        extra={"source": credential_info.source.value},
     )
     return ObjectCreationIdResponse(
         id=credential.id,

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -110,6 +110,10 @@ from onyx.server.manage.llm.utils import is_reasoning_model
 from onyx.server.manage.llm.utils import is_valid_bedrock_model
 from onyx.server.manage.llm.utils import ModelMetadata
 from onyx.server.manage.llm.utils import strip_openrouter_vendor_prefix
+from onyx.utils.audit import actor_from_user
+from onyx.utils.audit import AuditAction
+from onyx.utils.audit import AuditOutcome
+from onyx.utils.audit import emit_audit_event
 from onyx.utils.encryption import mask_string as mask_with_ellipsis
 from onyx.utils.logger import setup_logger
 from shared_configs.configs import MULTI_TENANT
@@ -536,7 +540,7 @@ def put_llm_provider(
         False,
         description="True if creating a new one, False if updating an existing provider",
     ),
-    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    user: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> LLMProviderView:
     # validate request (e.g. if we're intending to create but the name already exists we should throw an error)
@@ -652,6 +656,16 @@ def put_llm_provider(
                     result = LLMProviderView.from_model(updated_provider)
 
         _mask_provider_credentials(result)
+        emit_audit_event(
+            AuditAction.LLM_PROVIDER_CREATE
+            if is_creation
+            else AuditAction.LLM_PROVIDER_UPDATE,
+            AuditOutcome.SUCCESS,
+            actor=actor_from_user(user),
+            resource_type="llm_provider",
+            resource_id=result.id,
+            extra={"name": result.name, "provider": result.provider},
+        )
         return result
     except ValueError as e:
         logger.exception("Failed to upsert LLM Provider")
@@ -666,7 +680,7 @@ def put_llm_provider(
 def delete_llm_provider(
     provider_id: int,
     force: bool = Query(False),
-    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    user: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> None:
     if not force:
@@ -683,6 +697,13 @@ def delete_llm_provider(
     except ValueError as e:
         raise OnyxError(OnyxErrorCode.NOT_FOUND, str(e))
 
+    emit_audit_event(
+        AuditAction.LLM_PROVIDER_DELETE,
+        AuditOutcome.SUCCESS,
+        actor=actor_from_user(user),
+        resource_type="llm_provider",
+        resource_id=provider_id,
+    )
     invalidate_provider_listing_cache()
 
 

--- a/backend/onyx/server/manage/users.py
+++ b/backend/onyx/server/manage/users.py
@@ -119,6 +119,10 @@ from onyx.server.models import UserGroupInfo
 from onyx.server.security.store import get_security_settings
 from onyx.server.usage_limits import is_tenant_on_trial_fn
 from onyx.server.utils import BasicAuthenticationError
+from onyx.utils.audit import actor_from_user
+from onyx.utils.audit import AuditAction
+from onyx.utils.audit import AuditOutcome
+from onyx.utils.audit import emit_audit_event
 from onyx.utils.csv_utils import sanitize_csv_cell
 from onyx.utils.logger import setup_logger
 from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
@@ -174,6 +178,19 @@ def set_user_role(
         )(db_session, user_to_update)
 
     update_user_role(user_to_update, requested_role, db_session)
+
+    emit_audit_event(
+        AuditAction.USER_ROLE_CHANGE,
+        AuditOutcome.SUCCESS,
+        actor=actor_from_user(current_user),
+        resource_type="user",
+        resource_id=str(user_to_update.id),
+        extra={
+            "target_email": user_to_update.email,
+            "old_role": current_role.value,
+            "new_role": requested_role.value,
+        },
+    )
 
 
 class TestUpsertRequest(BaseModel):
@@ -663,6 +680,15 @@ def deactivate_user_api(
 
     deactivate_user(user_to_deactivate, db_session)
 
+    emit_audit_event(
+        AuditAction.USER_DEACTIVATE,
+        AuditOutcome.SUCCESS,
+        actor=actor_from_user(current_user),
+        resource_type="user",
+        resource_id=str(user_to_deactivate.id),
+        extra={"target_email": user_to_deactivate.email},
+    )
+
     # Invalidate license cache so used_seats reflects the new count
     # Only for self-hosted (non-multi-tenant) deployments
     if not MULTI_TENANT:
@@ -674,7 +700,9 @@ def deactivate_user_api(
 @router.delete("/manage/admin/delete-user", tags=PUBLIC_API_TAGS)
 async def delete_user(
     user_email: UserByEmail,
-    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    current_user: User = Depends(
+        require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)
+    ),
     db_session: Session = Depends(get_session),
 ) -> None:
     user_to_delete = get_user_by_email(
@@ -689,6 +717,10 @@ async def delete_user(
             status_code=400, detail="User must be deactivated before deleting"
         )
 
+    # Capture identifiers before the row is detached/deleted below.
+    deleted_user_id = str(user_to_delete.id)
+    deleted_user_email = user_to_delete.email
+
     # Detach the user from the current session
     db_session.expunge(user_to_delete)
 
@@ -699,6 +731,15 @@ async def delete_user(
         )([user_email.user_email], tenant_id)
         delete_user_from_db(user_to_delete, db_session)
         logger.info("Deleted user %s", user_to_delete.email)
+
+        emit_audit_event(
+            AuditAction.USER_DELETE,
+            AuditOutcome.SUCCESS,
+            actor=actor_from_user(current_user),
+            resource_type="user",
+            resource_id=deleted_user_id,
+            extra={"target_email": deleted_user_email},
+        )
 
         # Invalidate license cache so used_seats reflects the new count
         # Only for self-hosted (non-multi-tenant) deployments
@@ -716,7 +757,9 @@ async def delete_user(
 @router.patch("/manage/admin/activate-user", tags=PUBLIC_API_TAGS)
 def activate_user_api(
     user_email: UserByEmail,
-    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    current_user: User = Depends(
+        require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)
+    ),
     db_session: Session = Depends(get_session),
 ) -> None:
     user_to_activate = get_user_by_email(
@@ -732,6 +775,15 @@ def activate_user_api(
     enforce_seat_limit_locked(db_session)
 
     activate_user(user_to_activate, db_session)
+
+    emit_audit_event(
+        AuditAction.USER_REACTIVATE,
+        AuditOutcome.SUCCESS,
+        actor=actor_from_user(current_user),
+        resource_type="user",
+        resource_id=str(user_to_activate.id),
+        extra={"target_email": user_to_activate.email},
+    )
 
     # Invalidate license cache so used_seats reflects the new count
     # Only for self-hosted (non-multi-tenant) deployments

--- a/backend/onyx/utils/audit.py
+++ b/backend/onyx/utils/audit.py
@@ -44,8 +44,9 @@ class AuditOutcome(str, Enum):
 
 class AuditAction(str, Enum):
     """Audited-action taxonomy. Values are an append-only schema contract
-    (consumers filter on them); only ``CREDENTIAL_ACCESS`` is wired up so far,
-    the rest land on call sites in follow-up PRs."""
+    (consumers filter on them). A few members (``USER_CREATE``,
+    ``USER_GROUP_CHANGE``, ``PASSWORD_RESET``) are defined ahead of their call
+    sites and land in follow-up PRs."""
 
     # Authentication
     LOGIN = "auth.login"
@@ -141,6 +142,25 @@ class AuditActor:
             "api_key_id": self.api_key_id,
             "auth_type": self.auth_type,
         }
+
+
+def actor_from_user(
+    user: Any | None, *, auth_type: str | None = None
+) -> AuditActor | None:
+    """Build an ``AuditActor`` from a fastapi-users ``User`` (best-effort).
+
+    Returns ``None`` when there's no user. Typed ``Any`` so this module stays
+    free of an import dependency on the ORM/User model. Never raises."""
+    if user is None:
+        return None
+    try:
+        return AuditActor(
+            user_id=str(user.id),
+            email=getattr(user, "email", None),
+            auth_type=auth_type,
+        )
+    except Exception:
+        return None
 
 
 # Best-effort context gathering: each degrades to ``None`` rather than raising,

--- a/backend/onyx/utils/audit.py
+++ b/backend/onyx/utils/audit.py
@@ -25,6 +25,10 @@ AUDIT_SCHEMA_VERSION = "1.0"
 # object with no human-readable prefix.
 AUDIT_LOGGER_ROOT = "onyx.audit"
 
+# Diagnostics logger for the subsystem's own failures. Deliberately NOT under
+# ``onyx.audit`` so internal warnings never land in the parsed audit stream.
+_internal_logger = logging.getLogger(__name__)
+
 _DEFAULT_DEDUP_TTL_SECONDS = 600
 
 
@@ -160,6 +164,9 @@ def actor_from_user(
             auth_type=auth_type,
         )
     except Exception:
+        # Don't raise into the caller, but surface the failure for diagnosis
+        # (distinguishes an internal error from a genuinely absent user).
+        _internal_logger.warning("actor_from_user failed to build actor", exc_info=True)
         return None
 
 

--- a/backend/tests/external_dependency_unit/llm/test_llm_provider_api_base.py
+++ b/backend/tests/external_dependency_unit/llm/test_llm_provider_api_base.py
@@ -105,7 +105,7 @@ class TestLLMProviderChanges:
                     put_llm_provider(
                         llm_provider_upsert_request=update_request,
                         is_creation=False,
-                        _=_create_mock_admin(),
+                        user=_create_mock_admin(),
                         db_session=db_session,
                     )
 
@@ -140,7 +140,7 @@ class TestLLMProviderChanges:
                 result = put_llm_provider(
                     llm_provider_upsert_request=update_request,
                     is_creation=False,
-                    _=_create_mock_admin(),
+                    user=_create_mock_admin(),
                     db_session=db_session,
                 )
 
@@ -174,7 +174,7 @@ class TestLLMProviderChanges:
                 result = put_llm_provider(
                     llm_provider_upsert_request=update_request,
                     is_creation=False,
-                    _=_create_mock_admin(),
+                    user=_create_mock_admin(),
                     db_session=db_session,
                 )
 
@@ -205,7 +205,7 @@ class TestLLMProviderChanges:
                 result = put_llm_provider(
                     llm_provider_upsert_request=update_request,
                     is_creation=False,
-                    _=_create_mock_admin(),
+                    user=_create_mock_admin(),
                     db_session=db_session,
                 )
 
@@ -241,7 +241,7 @@ class TestLLMProviderChanges:
                     put_llm_provider(
                         llm_provider_upsert_request=update_request,
                         is_creation=False,
-                        _=_create_mock_admin(),
+                        user=_create_mock_admin(),
                         db_session=db_session,
                     )
 
@@ -276,7 +276,7 @@ class TestLLMProviderChanges:
                 result = put_llm_provider(
                     llm_provider_upsert_request=update_request,
                     is_creation=False,
-                    _=_create_mock_admin(),
+                    user=_create_mock_admin(),
                     db_session=db_session,
                 )
 
@@ -306,7 +306,7 @@ class TestLLMProviderChanges:
                 result = put_llm_provider(
                     llm_provider_upsert_request=create_request,
                     is_creation=True,
-                    _=_create_mock_admin(),
+                    user=_create_mock_admin(),
                     db_session=db_session,
                 )
 
@@ -344,7 +344,7 @@ class TestLLMProviderChanges:
                     put_llm_provider(
                         llm_provider_upsert_request=update_request,
                         is_creation=False,
-                        _=_create_mock_admin(),
+                        user=_create_mock_admin(),
                         db_session=db_session,
                     )
 
@@ -380,7 +380,7 @@ class TestLLMProviderChanges:
                     put_llm_provider(
                         llm_provider_upsert_request=update_request,
                         is_creation=False,
-                        _=_create_mock_admin(),
+                        user=_create_mock_admin(),
                         db_session=db_session,
                     )
 
@@ -422,7 +422,7 @@ class TestLLMProviderChanges:
                 result = put_llm_provider(
                     llm_provider_upsert_request=update_request,
                     is_creation=False,
-                    _=_create_mock_admin(),
+                    user=_create_mock_admin(),
                     db_session=db_session,
                 )
 
@@ -457,7 +457,7 @@ class TestLLMProviderChanges:
                 result = put_llm_provider(
                     llm_provider_upsert_request=update_request,
                     is_creation=False,
-                    _=_create_mock_admin(),
+                    user=_create_mock_admin(),
                     db_session=db_session,
                 )
 
@@ -495,7 +495,7 @@ class TestLLMProviderChanges:
                 result = put_llm_provider(
                     llm_provider_upsert_request=update_request,
                     is_creation=False,
-                    _=_create_mock_admin(),
+                    user=_create_mock_admin(),
                     db_session=db_session,
                 )
 
@@ -558,7 +558,7 @@ def test_upload_with_custom_config_then_change(
                     is_auto_mode=False,
                 ),
                 is_creation=True,
-                _=_create_mock_admin(),
+                user=_create_mock_admin(),
                 db_session=db_session,
             )
 
@@ -593,7 +593,7 @@ def test_upload_with_custom_config_then_change(
                     is_auto_mode=False,
                 ),
                 is_creation=False,
-                _=_create_mock_admin(),
+                user=_create_mock_admin(),
                 db_session=db_session,
             )
 
@@ -646,7 +646,7 @@ def test_preserves_masked_sensitive_custom_config_on_provider_update(
                 is_auto_mode=False,
             ),
             is_creation=True,
-            _=_create_mock_admin(),
+            user=_create_mock_admin(),
             db_session=db_session,
         )
 
@@ -672,7 +672,7 @@ def test_preserves_masked_sensitive_custom_config_on_provider_update(
                     is_auto_mode=False,
                 ),
                 is_creation=False,
-                _=_create_mock_admin(),
+                user=_create_mock_admin(),
                 db_session=db_session,
             )
 
@@ -722,7 +722,7 @@ def test_preserves_masked_sensitive_custom_config_on_test_request(
                 is_auto_mode=False,
             ),
             is_creation=True,
-            _=_create_mock_admin(),
+            user=_create_mock_admin(),
             db_session=db_session,
         )
 
@@ -793,7 +793,7 @@ def test_vertex_workload_identity_provider_create(
                 is_auto_mode=False,
             ),
             is_creation=True,
-            _=_create_mock_admin(),
+            user=_create_mock_admin(),
             db_session=db_session,
         )
 
@@ -857,7 +857,7 @@ def test_vertex_workload_identity_rejects_missing_project(
                     is_auto_mode=False,
                 ),
                 is_creation=True,
-                _=_create_mock_admin(),
+                user=_create_mock_admin(),
                 db_session=db_session,
             )
         assert excinfo.value.error_code == OnyxErrorCode.VALIDATION_ERROR
@@ -900,7 +900,7 @@ def test_vertex_service_account_backwards_compat_routes_credentials(
                 is_auto_mode=False,
             ),
             is_creation=True,
-            _=_create_mock_admin(),
+            user=_create_mock_admin(),
             db_session=db_session,
         )
 

--- a/backend/tests/external_dependency_unit/llm/test_llm_provider_auto_mode.py
+++ b/backend/tests/external_dependency_unit/llm/test_llm_provider_auto_mode.py
@@ -140,7 +140,7 @@ class TestAutoModeSyncFeature:
                         model_configurations=[],  # No model configs provided
                     ),
                     is_creation=True,
-                    _=_create_mock_admin(),
+                    user=_create_mock_admin(),
                     db_session=db_session,
                 )
 
@@ -237,7 +237,7 @@ class TestAutoModeSyncFeature:
                         model_configurations=[],
                     ),
                     is_creation=True,
-                    _=_create_mock_admin(),
+                    user=_create_mock_admin(),
                     db_session=db_session,
                 )
 
@@ -315,7 +315,7 @@ class TestAutoModeSyncFeature:
                     model_configurations=initial_models,
                 ),
                 is_creation=True,
-                _=_create_mock_admin(),
+                user=_create_mock_admin(),
                 db_session=db_session,
             )
 
@@ -347,7 +347,7 @@ class TestAutoModeSyncFeature:
                         model_configurations=[],  # Auto mode will sync from config
                     ),
                     is_creation=False,  # This is an update
-                    _=_create_mock_admin(),
+                    user=_create_mock_admin(),
                     db_session=db_session,
                 )
 
@@ -431,7 +431,7 @@ class TestAutoModeSyncFeature:
                         ],
                     ),
                     is_creation=True,
-                    _=_create_mock_admin(),
+                    user=_create_mock_admin(),
                     db_session=db_session,
                 )
 
@@ -533,7 +533,7 @@ class TestAutoModeSyncFeature:
                         model_configurations=[],
                     ),
                     is_creation=True,
-                    _=_create_mock_admin(),
+                    user=_create_mock_admin(),
                     db_session=db_session,
                 )
 
@@ -560,7 +560,7 @@ class TestAutoModeSyncFeature:
                         model_configurations=[],
                     ),
                     is_creation=True,
-                    _=_create_mock_admin(),
+                    user=_create_mock_admin(),
                     db_session=db_session,
                 )
 
@@ -640,7 +640,7 @@ class TestAutoModeMissingFlows:
                     model_configurations=[],
                 ),
                 is_creation=True,
-                _=_create_mock_admin(),
+                user=_create_mock_admin(),
                 db_session=db_session,
             )
 
@@ -735,7 +735,7 @@ class TestAutoModeTransitionsAndResync:
                     model_configurations=initial_models,
                 ),
                 is_creation=True,
-                _=_create_mock_admin(),
+                user=_create_mock_admin(),
                 db_session=db_session,
             )
 
@@ -767,7 +767,7 @@ class TestAutoModeTransitionsAndResync:
                         model_configurations=[],
                     ),
                     is_creation=False,
-                    _=_create_mock_admin(),
+                    user=_create_mock_admin(),
                     db_session=db_session,
                 )
 
@@ -827,7 +827,7 @@ class TestAutoModeTransitionsAndResync:
                         model_configurations=[],
                     ),
                     is_creation=True,
-                    _=_create_mock_admin(),
+                    user=_create_mock_admin(),
                     db_session=db_session,
                 )
 
@@ -858,7 +858,7 @@ class TestAutoModeTransitionsAndResync:
                     ],
                 ),
                 is_creation=False,
-                _=_create_mock_admin(),
+                user=_create_mock_admin(),
                 db_session=db_session,
             )
 
@@ -925,7 +925,7 @@ class TestAutoModeTransitionsAndResync:
                         model_configurations=[],
                     ),
                     is_creation=True,
-                    _=_create_mock_admin(),
+                    user=_create_mock_admin(),
                     db_session=db_session,
                 )
 
@@ -994,7 +994,7 @@ class TestAutoModeTransitionsAndResync:
                         model_configurations=[],
                     ),
                     is_creation=True,
-                    _=_create_mock_admin(),
+                    user=_create_mock_admin(),
                     db_session=db_session,
                 )
 
@@ -1090,7 +1090,7 @@ class TestAutoModeTransitionsAndResync:
                         model_configurations=[],
                     ),
                     is_creation=True,
-                    _=_create_mock_admin(),
+                    user=_create_mock_admin(),
                     db_session=db_session,
                 )
 
@@ -1191,7 +1191,7 @@ class TestAutoModeTransitionsAndResync:
                         model_configurations=[],
                     ),
                     is_creation=True,
-                    _=_create_mock_admin(),
+                    user=_create_mock_admin(),
                     db_session=db_session,
                 )
 
@@ -1276,7 +1276,7 @@ class TestAutoModeTransitionsAndResync:
                         model_configurations=[],
                     ),
                     is_creation=True,
-                    _=_create_mock_admin(),
+                    user=_create_mock_admin(),
                     db_session=db_session,
                 )
 

--- a/backend/tests/unit/onyx/server/test_admin_audit_events.py
+++ b/backend/tests/unit/onyx/server/test_admin_audit_events.py
@@ -1,0 +1,104 @@
+"""Unit tests for audit-event emission from admin-config / access-control seams.
+
+The API-key endpoints are the thinnest admin endpoints (each just calls one DB
+function then emits), so they're used here as representatives of the uniform
+emit-on-success wiring shared by the LLM-provider, connector, cc-pair,
+credential, and user endpoints. Emission itself is covered in
+tests/unit/onyx/utils/test_audit.py.
+"""
+
+import json
+import logging
+from typing import Any
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from onyx.server.api_key.api import create_api_key
+from onyx.server.api_key.api import delete_api_key
+from onyx.server.api_key.api import regenerate_existing_api_key
+from onyx.server.manage.llm.api import delete_llm_provider
+
+
+def _audit_events(caplog: pytest.LogCaptureFixture) -> list[dict[str, Any]]:
+    return [
+        json.loads(r.getMessage())
+        for r in caplog.records
+        if r.name.startswith("onyx.audit")
+    ]
+
+
+@patch("onyx.server.api_key.api.insert_api_key")
+def test_create_api_key_emits_event(
+    mock_insert: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    mock_insert.return_value = MagicMock(api_key_id=7)
+    user = MagicMock(id="admin-1", email="admin@example.com")
+
+    with caplog.at_level(logging.INFO, logger="onyx.audit"):
+        create_api_key(MagicMock(), user=user, db_session=MagicMock())
+
+    events = _audit_events(caplog)
+    assert len(events) == 1
+    assert events[0]["action"] == "api_key.create"
+    assert events[0]["outcome"] == "success"
+    assert events[0]["resource_type"] == "api_key"
+    assert events[0]["resource_id"] == "7"
+    assert events[0]["actor"]["email"] == "admin@example.com"
+
+
+@patch("onyx.server.api_key.api.regenerate_api_key")
+def test_regenerate_api_key_emits_event(
+    _mock_regen: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    user = MagicMock(id="admin-1", email="admin@example.com")
+
+    with caplog.at_level(logging.INFO, logger="onyx.audit"):
+        regenerate_existing_api_key(api_key_id=42, user=user, db_session=MagicMock())
+
+    events = _audit_events(caplog)
+    assert len(events) == 1
+    assert events[0]["action"] == "api_key.regenerate"
+    assert events[0]["resource_id"] == "42"
+
+
+@patch("onyx.server.api_key.api.remove_api_key")
+def test_delete_api_key_emits_event(
+    _mock_remove: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    user = MagicMock(id="admin-1", email="admin@example.com")
+
+    with caplog.at_level(logging.INFO, logger="onyx.audit"):
+        delete_api_key(api_key_id=99, user=user, db_session=MagicMock())
+
+    events = _audit_events(caplog)
+    assert len(events) == 1
+    assert events[0]["action"] == "api_key.delete"
+    assert events[0]["outcome"] == "success"
+    assert events[0]["resource_id"] == "99"
+
+
+@patch("onyx.server.manage.llm.api.invalidate_provider_listing_cache")
+@patch("onyx.server.manage.llm.api.remove_llm_provider")
+def test_delete_llm_provider_emits_event(
+    _mock_remove: MagicMock,
+    _mock_invalidate: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    user = MagicMock(id="admin-1", email="admin@example.com")
+
+    with caplog.at_level(logging.INFO, logger="onyx.audit"):
+        # force=True skips the default-provider lookup so no DB is needed.
+        delete_llm_provider(
+            provider_id=5, force=True, user=user, db_session=MagicMock()
+        )
+
+    events = _audit_events(caplog)
+    assert len(events) == 1
+    assert events[0]["action"] == "llm_provider.delete"
+    assert events[0]["ocsf_class"] == "api_activity"
+    assert events[0]["resource_id"] == "5"

--- a/backend/tests/unit/onyx/utils/test_audit.py
+++ b/backend/tests/unit/onyx/utils/test_audit.py
@@ -8,11 +8,13 @@ and Redis-backed dedup that degrades safely when Redis is unavailable.
 import json
 import logging
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 
 from onyx.utils import audit
 from onyx.utils.audit import _OCSF_CLASS_BY_ACTION
+from onyx.utils.audit import actor_from_user
 from onyx.utils.audit import AuditAction
 from onyx.utils.audit import AuditActor
 from onyx.utils.audit import AuditOutcome
@@ -170,3 +172,23 @@ def test_no_dedup_key_always_emits(caplog: pytest.LogCaptureFixture) -> None:
         emit_audit_event(AuditAction.USER_ROLE_CHANGE, AuditOutcome.SUCCESS)
 
     assert len(_capture(caplog)) == 2
+
+
+def test_actor_from_user_none_returns_none() -> None:
+    assert actor_from_user(None) is None
+
+
+def test_actor_from_user_builds_actor() -> None:
+    user = MagicMock(id="u-1", email="user@example.com")
+    actor = actor_from_user(user, auth_type="password")
+    assert actor is not None
+    assert actor.user_id == "u-1"
+    assert actor.email == "user@example.com"
+    assert actor.auth_type == "password"
+
+
+def test_actor_from_user_never_raises() -> None:
+    # A user object whose ``id`` access blows up must degrade to None, not raise.
+    broken = MagicMock()
+    type(broken).id = property(lambda _self: (_ for _ in ()).throw(RuntimeError()))
+    assert actor_from_user(broken) is None

--- a/docs/AUDIT_LOGGING.md
+++ b/docs/AUDIT_LOGGING.md
@@ -78,9 +78,10 @@ them). Current taxonomy (`AuditAction` in `backend/onyx/utils/audit.py`):
   `api_key.{create,regenerate,delete}`, `credential.{create,update,delete}`,
   `credential.access`
 
-> Not every action is wired to a call site yet — the taxonomy is defined ahead
-> of the call-site instrumentation so consumers can build dashboards against the
-> full set.
+> Most actions are wired to call sites. A few (`user.create`,
+> `user.group_change`, `auth.password_reset`) are defined ahead of their
+> instrumentation and land in follow-up PRs, so consumers can build dashboards
+> against the full taxonomy now.
 
 ### Example event
 


### PR DESCRIPTION
## Description

Phase 2 (final MVP piece) of the SIEM-compatible audit-event subsystem: wires `emit_audit_event` into the **admin-config** and **access-control** endpoints. Builds directly on the core subsystem (#12219) and auth events (#12271).

Events emitted (on the success path only, after the DB op commits):

- **LLM provider** — create / update (upsert toggles on `is_creation`) / delete
- **Connector** — create / update / delete
- **Connector-credential pair** — create (associate) / update (status) / delete (dissociate)
- **API key** — create / regenerate / delete
- **Credential** — create / update / delete (all delete variants, incl. admin + force)
- **User access-control** — role change / deactivate / reactivate / delete

Each event carries the acting admin (`actor`), the affected `resource_type` / `resource_id`, OCSF class, and the usual tenant / request / source-IP context. All actions already exist in the `AuditAction` taxonomy shipped in #12219 — this PR is pure call-site wiring.

Adds a small `actor_from_user()` helper to `onyx.utils.audit` so each call site stays a single emit. The helper is best-effort and never raises; it's typed `Any` to keep `audit.py` free of an ORM import dependency. Audit emission remains fully fail-safe — it never raises into the request path.

No secret values are ever logged (only ids, names, and coarse source/status metadata).

## How Has This Been Tested?

- Unit tests for `actor_from_user` (None, populated, exception-safety) in `test_audit.py`.
- New `test_admin_audit_events.py` exercises representative wired endpoints (API key create/regenerate/delete + LLM provider delete) via `caplog`, asserting the right `action` / `outcome` / `actor` / `resource_id`.
- `ty` + `ruff` clean; all pre-commit hooks pass.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SIEM-ready audit events to admin-config and access-control endpoints to track changes across providers, connectors, keys, and users. Also stabilizes audit payloads and stops chat from nudging `open_url` when the tool is disabled.

- **New Features**
  - Emit post-commit audit events for LLM providers, connectors, cc-pairs, API keys, credentials, and user access control; cc-pair create/delete only on actual changes and delete records the cc-pair id.
  - Events include actor/resource ids and OCSF class; fail-safe and no secrets. Added `actor_from_user()` with a diagnostic warning on failure; updated docs.

- **Bug Fixes**
  - Gate `open_url` reminders on `OpenURLTool` availability and centralize via `select_reminder_text`.
  - Serialize enum fields in audit `extra` using `.value` for stable SIEM strings.

<sup>Written for commit d90a422453ac926b26d2c24cecc9dbebf22f9ebb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

