### PR TITLE
fix(sidebar-tab): clamp title to 1 line

### DIFF
--- a/web/lib/opal/src/components/buttons/sidebar-tab/components.tsx
+++ b/web/lib/opal/src/components/buttons/sidebar-tab/components.tsx
@@ -123,6 +123,7 @@ function SidebarTab({
               width="full"
               padding="fit"
               rightChildren={truncationSpacer}
+              titleMaxLines={1}
             />
           ) : (
             <div className="flex flex-row items-center gap-2 w-full">


### PR DESCRIPTION
## Description

Passes `titleMaxLines={1}` to the `Content` inside `SidebarTab` so long chat/session titles are clamped to a single line with ellipsis instead of wrapping across multiple lines.

## Screenshots + Videos

### Before

<img width="247" height="82" alt="image" src="https://github.com/user-attachments/assets/5c9755af-58cb-426d-9cbb-cee8378a22c7" />

<br>

<img width="245" height="73" alt="image" src="https://github.com/user-attachments/assets/54d617ea-cce9-4989-9bf9-4fd288539473" />

### After

<img width="243" height="77" alt="image" src="https://github.com/user-attachments/assets/6c3b1922-5d92-4218-a02f-742005d163f1" />

<br>

<img width="239" height="76" alt="image" src="https://github.com/user-attachments/assets/12bab10b-47fe-4c08-90c4-9585399741a0" />

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clamp long sidebar tab titles to a single line with ellipsis to prevent wrapping and layout shifts. Sets titleMaxLines to 1 on the title content inside SidebarTab.

<sup>Written for commit 3bd9f55c36ffc803e737b053d7b379512a1da57f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->