### PR TITLE
fix(craft): mark scheduled-task run FAILED on turn timeout (ENG-4234)

### DIFF
--- a/backend/onyx/server/features/build/sandbox/event_schema.py
+++ b/backend/onyx/server/features/build/sandbox/event_schema.py
@@ -17,6 +17,14 @@ from acp.schema import RequestPermissionRequest
 from acp.schema import ToolCallProgress
 from acp.schema import ToolCallStart
 
+# Onyx-synthesized ``Error.code`` sentinels for turn-terminating failures.
+# Negative so they never collide with opencode / JSON-RPC error codes.
+# Consumers (the scheduled-task executor, the interactive frontend) branch on
+# these to classify *why* a turn ended without a ``PromptResponse``.
+TURN_ERROR_CODE_SESSION = -1  # opencode reported an error during the turn
+TURN_ERROR_CODE_TIMEOUT = -2  # wall-clock turn timeout: no response within budget
+TURN_ERROR_CODE_TRANSPORT = -3  # event-bus / stream transport failure
+
 __all__ = [
     "AgentMessageChunk",
     "AgentPlanUpdate",
@@ -27,4 +35,7 @@ __all__ = [
     "RequestPermissionRequest",
     "ToolCallProgress",
     "ToolCallStart",
+    "TURN_ERROR_CODE_SESSION",
+    "TURN_ERROR_CODE_TIMEOUT",
+    "TURN_ERROR_CODE_TRANSPORT",
 ]

--- a/backend/onyx/server/features/build/sandbox/event_schema.py
+++ b/backend/onyx/server/features/build/sandbox/event_schema.py
@@ -19,11 +19,9 @@ from acp.schema import ToolCallStart
 
 # Onyx-synthesized ``Error.code`` sentinels for turn-terminating failures.
 # Negative so they never collide with opencode / JSON-RPC error codes.
-# Consumers (the scheduled-task executor, the interactive frontend) branch on
-# these to classify *why* a turn ended without a ``PromptResponse``.
 TURN_ERROR_CODE_SESSION = -1  # opencode reported an error during the turn
-TURN_ERROR_CODE_TIMEOUT = -2  # wall-clock turn timeout: no response within budget
-TURN_ERROR_CODE_TRANSPORT = -3  # event-bus / stream transport failure
+TURN_ERROR_CODE_TIMEOUT = -2
+TURN_ERROR_CODE_TRANSPORT = -3
 
 __all__ = [
     "AgentMessageChunk",

--- a/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
+++ b/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
@@ -37,6 +37,9 @@ from onyx.server.features.build.sandbox.event_schema import Error
 from onyx.server.features.build.sandbox.event_schema import PromptResponse
 from onyx.server.features.build.sandbox.event_schema import ToolCallProgress
 from onyx.server.features.build.sandbox.event_schema import ToolCallStart
+from onyx.server.features.build.sandbox.event_schema import TURN_ERROR_CODE_SESSION
+from onyx.server.features.build.sandbox.event_schema import TURN_ERROR_CODE_TIMEOUT
+from onyx.server.features.build.sandbox.event_schema import TURN_ERROR_CODE_TRANSPORT
 from onyx.server.features.build.sandbox.opencode.event_bus import _Subscription
 from onyx.server.features.build.sandbox.opencode.event_bus import BUS_CLOSED_SENTINEL
 from onyx.server.features.build.sandbox.opencode.event_bus import PodEventBus
@@ -830,7 +833,7 @@ def _emit_terminator(
             msg = str(data.get("message") or "")
         if not msg:
             msg = str(error.get("name") or "session error")
-        yield Error.model_validate({"code": -1, "message": msg})
+        yield Error.model_validate({"code": TURN_ERROR_CODE_SESSION, "message": msg})
         return
 
     stop_reason = "end_turn"
@@ -1285,7 +1288,10 @@ class OpencodeServeClient:
                 return
             except httpx.HTTPError as e:
                 yield Error.model_validate(
-                    {"code": -3, "message": f"prompt_async failed: {e}"}
+                    {
+                        "code": TURN_ERROR_CODE_TRANSPORT,
+                        "message": f"prompt_async failed: {e}",
+                    }
                 )
                 return
 
@@ -1330,7 +1336,7 @@ class OpencodeServeClient:
             if self._event_bus is None:
                 yield Error.model_validate(
                     {
-                        "code": -3,
+                        "code": TURN_ERROR_CODE_TRANSPORT,
                         "message": "opencode /event bus is unavailable",
                     }
                 )
@@ -1339,7 +1345,7 @@ class OpencodeServeClient:
             if self._event_bus.closed:
                 yield Error.model_validate(
                     {
-                        "code": -3,
+                        "code": TURN_ERROR_CODE_TRANSPORT,
                         "message": "event bus closed before /event stream became ready",
                     }
                 )
@@ -1359,7 +1365,7 @@ class OpencodeServeClient:
             if remaining <= 0:
                 yield Error.model_validate(
                     {
-                        "code": -3,
+                        "code": TURN_ERROR_CODE_TRANSPORT,
                         "message": "opencode /event stream did not become ready",
                     }
                 )
@@ -1380,7 +1386,7 @@ class OpencodeServeClient:
             if raw is BUS_CLOSED_SENTINEL:
                 yield Error.model_validate(
                     {
-                        "code": -3,
+                        "code": TURN_ERROR_CODE_TRANSPORT,
                         "message": "event bus closed before /event stream became ready",
                     }
                 )
@@ -1428,7 +1434,10 @@ class OpencodeServeClient:
             if remaining <= 0:
                 self.abort(opencode_session_id, directory=directory)
                 yield Error.model_validate(
-                    {"code": -1, "message": "Timeout waiting for response"}
+                    {
+                        "code": TURN_ERROR_CODE_TIMEOUT,
+                        "message": "Timeout waiting for response",
+                    }
                 )
                 return
 
@@ -1447,7 +1456,7 @@ class OpencodeServeClient:
                 if not terminated_locally:
                     yield Error.model_validate(
                         {
-                            "code": -3,
+                            "code": TURN_ERROR_CODE_TRANSPORT,
                             "message": "event bus closed before terminator",
                         }
                     )

--- a/backend/onyx/server/features/build/scheduled_tasks/executor.py
+++ b/backend/onyx/server/features/build/scheduled_tasks/executor.py
@@ -377,12 +377,8 @@ def _drive_agent(
         # that lets scheduled and interactive runs share a build_session
         # inherits the protection without needing to remember to add it.
         approval_required = False
-        # A turn ends with exactly one terminal event from the sandbox stream:
-        # a PromptResponse (the agent finished) or an Error (timeout / session
-        # / transport failure). persist_sandbox_event drops both, so without
-        # tracking them here a timed-out turn — whose only stream output is a
-        # terminal Error — would fall through to the SUCCEEDED path with an
-        # empty transcript (ENG-4234).
+        # persist_sandbox_event drops Error/PromptResponse, so a timed-out turn
+        # (terminal Error only) would otherwise be recorded SUCCEEDED (ENG-4234).
         terminal_error: Error | None = None
         got_prompt_response = False
         final_event_count = 0
@@ -420,14 +416,11 @@ def _drive_agent(
                     approval_required = True
                     break
 
-                # Error is terminal (the stream's last event), so break and let
-                # the post-loop branch classify the failure.
                 if isinstance(sandbox_event, Error):
                     terminal_error = sandbox_event
                     break
-                # PromptResponse is terminal too: break before the budget check
-                # so a deadline that trips exactly as the agent finishes can't
-                # mis-mark a successful turn as timed-out.
+                # Break before the budget check: a deadline tripping exactly as
+                # the agent finishes must not mis-mark a success as timed-out.
                 if isinstance(sandbox_event, PromptResponse):
                     got_prompt_response = True
                     break
@@ -487,8 +480,6 @@ def _drive_agent(
                 db_session.commit()
                 return True
 
-            # Failure path: terminal Error, or the stream ended with no
-            # PromptResponse. Flush any partial output, then FAIL + notify.
             if terminal_error is not None or not got_prompt_response:
                 session_manager.finalize_persist(session_id, state)
                 db_session.commit()

--- a/backend/onyx/server/features/build/scheduled_tasks/executor.py
+++ b/backend/onyx/server/features/build/scheduled_tasks/executor.py
@@ -52,7 +52,10 @@ from onyx.db.scheduled_task import get_run
 from onyx.db.scheduled_task import mark_run_status
 from onyx.server.features.build.db.build_session import create_message
 from onyx.server.features.build.db.build_session import get_session_messages
+from onyx.server.features.build.sandbox.event_schema import Error
+from onyx.server.features.build.sandbox.event_schema import PromptResponse
 from onyx.server.features.build.sandbox.event_schema import RequestPermissionRequest
+from onyx.server.features.build.sandbox.event_schema import TURN_ERROR_CODE_TIMEOUT
 from onyx.server.features.build.session.manager import SessionManager
 from onyx.server.features.build.session.streaming import BuildStreamingState
 from onyx.utils.logger import setup_logger
@@ -374,6 +377,14 @@ def _drive_agent(
         # that lets scheduled and interactive runs share a build_session
         # inherits the protection without needing to remember to add it.
         approval_required = False
+        # A turn ends with exactly one terminal event from the sandbox stream:
+        # a PromptResponse (the agent finished) or an Error (timeout / session
+        # / transport failure). persist_sandbox_event drops both, so without
+        # tracking them here a timed-out turn — whose only stream output is a
+        # terminal Error — would fall through to the SUCCEEDED path with an
+        # empty transcript (ENG-4234).
+        terminal_error: Error | None = None
+        got_prompt_response = False
         final_event_count = 0
         # Acquire the per-build_session lock for the duration of the
         # agent loop. __enter__/__exit__ used directly (rather than a
@@ -407,6 +418,18 @@ def _drive_agent(
                 # "terminal for display" until it ships.
                 if isinstance(sandbox_event, RequestPermissionRequest):
                     approval_required = True
+                    break
+
+                # Error is terminal (the stream's last event), so break and let
+                # the post-loop branch classify the failure.
+                if isinstance(sandbox_event, Error):
+                    terminal_error = sandbox_event
+                    break
+                # PromptResponse is terminal too: break before the budget check
+                # so a deadline that trips exactly as the agent finishes can't
+                # mis-mark a successful turn as timed-out.
+                if isinstance(sandbox_event, PromptResponse):
+                    got_prompt_response = True
                     break
 
                 # Budget check happens before persistence so a runaway
@@ -463,6 +486,48 @@ def _drive_agent(
                 )
                 db_session.commit()
                 return True
+
+            # Failure path: terminal Error, or the stream ended with no
+            # PromptResponse. Flush any partial output, then FAIL + notify.
+            if terminal_error is not None or not got_prompt_response:
+                session_manager.finalize_persist(session_id, state)
+                db_session.commit()
+                if terminal_error is not None:
+                    error_class = (
+                        ScheduledTaskErrorClass.TIMEOUT
+                        if terminal_error.code == TURN_ERROR_CODE_TIMEOUT
+                        else ScheduledTaskErrorClass.AGENT_EXCEPTION
+                    )
+                    error_detail = (
+                        terminal_error.message or "agent turn ended with an error"
+                    )
+                else:
+                    error_class = ScheduledTaskErrorClass.AGENT_EXCEPTION
+                    error_detail = "agent stream ended without a completion response"
+                mark_run_status(
+                    db_session=db_session,
+                    run_id=run_id,
+                    status=ScheduledTaskRunStatus.FAILED,
+                    error_class=error_class,
+                    error_detail=error_detail[:1000],
+                )
+                _notify(
+                    db_session=db_session,
+                    user_id=task_user_id,
+                    task_name=task_name,
+                    task_id=task_id,
+                    run_id=run_id,
+                    notif_type=NotificationType.SCHEDULED_TASK_FAILED,
+                )
+                db_session.commit()
+                logger.warning(
+                    "Scheduled run %s failed (events=%d, error_class=%s): %s",
+                    run_id,
+                    final_event_count,
+                    error_class.value,
+                    error_detail,
+                )
+                return False
 
             # Clean completion path.
             summary_from_chunks = _summary_from_state(state)

--- a/backend/tests/external_dependency_unit/craft/test_scheduled_task_executor.py
+++ b/backend/tests/external_dependency_unit/craft/test_scheduled_task_executor.py
@@ -347,18 +347,8 @@ def test_timeout_error_event_marks_run_failed_with_timeout_class(
     stub_sandbox_manager: StubSandboxManager,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Regression for ENG-4234: terminal timeout Error → FAILED/timeout.
-
-    When the sandbox event stream yields only a terminal ``Error`` with
-    ``code == TURN_ERROR_CODE_TIMEOUT`` (and never a ``PromptResponse``),
-    ``run_scheduled_task_logic`` must mark the run ``FAILED`` with
-    ``error_class == ScheduledTaskErrorClass.TIMEOUT.value``.
-
-    Before the fix the run fell through to the SUCCEEDED path because the
-    terminal Error was the last event and ``persist_sandbox_event`` drops it.
-    """
-    # Bypass skill-payload assembly — it reads ExternalApp rows that may
-    # have encrypted credentials incompatible with the local MIT key.
+    """Regression for ENG-4234: terminal timeout Error → FAILED/timeout."""
+    # Bypass skill-payload: encrypted ExternalApp creds break local MIT decryption.
     monkeypatch.setattr(
         "onyx.server.features.build.session.manager.build_user_skills_payload",
         lambda *_: ("", {}),
@@ -393,14 +383,8 @@ def test_prompt_response_marks_run_succeeded(
     stub_sandbox_manager: StubSandboxManager,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Happy-path regression: clean PromptResponse → SUCCEEDED.
-
-    Ensures the ENG-4234 fix did not break the clean-completion path: a
-    stream that yields exactly one ``PromptResponse`` (and no ``Error``) must
-    still transition the run to ``SUCCEEDED``.
-    """
-    # Bypass skill-payload assembly — it reads ExternalApp rows that may
-    # have encrypted credentials incompatible with the local MIT key.
+    """Happy-path regression: clean PromptResponse → SUCCEEDED, not FAILED."""
+    # Bypass skill-payload: encrypted ExternalApp creds break local MIT decryption.
     monkeypatch.setattr(
         "onyx.server.features.build.session.manager.build_user_skills_payload",
         lambda *_: ("", {}),
@@ -433,14 +417,8 @@ def test_transport_error_event_marks_run_failed_with_agent_exception_class(
     stub_sandbox_manager: StubSandboxManager,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Non-timeout terminal Error → FAILED with ``error_class=agent_exception``.
-
-    The TIMEOUT class is reserved for ``TURN_ERROR_CODE_TIMEOUT``; any other
-    terminal Error (here a transport failure) falls into the default
-    AGENT_EXCEPTION branch.
-    """
-    # Bypass skill-payload assembly — it reads ExternalApp rows that may
-    # have encrypted credentials incompatible with the local MIT key.
+    """Non-timeout terminal Error → FAILED with error_class=agent_exception."""
+    # Bypass skill-payload: encrypted ExternalApp creds break local MIT decryption.
     monkeypatch.setattr(
         "onyx.server.features.build.session.manager.build_user_skills_payload",
         lambda *_: ("", {}),
@@ -475,13 +453,8 @@ def test_stream_without_prompt_response_marks_run_failed(
     stub_sandbox_manager: StubSandboxManager,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A stream that ends with no PromptResponse (and no Error) → FAILED.
-
-    Guards the ``not got_prompt_response`` half of the failure branch: an
-    empty/truncated stream must not be recorded as SUCCEEDED.
-    """
-    # Bypass skill-payload assembly — it reads ExternalApp rows that may
-    # have encrypted credentials incompatible with the local MIT key.
+    """Stream ending with no PromptResponse (and no Error) → FAILED, not SUCCEEDED."""
+    # Bypass skill-payload: encrypted ExternalApp creds break local MIT decryption.
     monkeypatch.setattr(
         "onyx.server.features.build.session.manager.build_user_skills_payload",
         lambda *_: ("", {}),

--- a/backend/tests/external_dependency_unit/craft/test_scheduled_task_executor.py
+++ b/backend/tests/external_dependency_unit/craft/test_scheduled_task_executor.py
@@ -43,9 +43,15 @@ from onyx.db.models import ScheduledTaskRun
 from onyx.db.models import User
 from onyx.server.features.build.configs import SANDBOX_BACKEND
 from onyx.server.features.build.configs import SandboxBackend
+from onyx.server.features.build.sandbox.event_schema import Error
+from onyx.server.features.build.sandbox.event_schema import PromptResponse
+from onyx.server.features.build.sandbox.event_schema import TURN_ERROR_CODE_TIMEOUT
+from onyx.server.features.build.sandbox.event_schema import TURN_ERROR_CODE_TRANSPORT
 from onyx.server.features.build.scheduled_tasks.executor import run_scheduled_task_logic
+from onyx.server.features.build.session.manager import SessionManager
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
+from tests.common.craft.stubs import StubSandboxManager
 from tests.external_dependency_unit.craft.db_helpers import make_sandbox
 from tests.external_dependency_unit.craft.db_helpers import make_user
 
@@ -331,3 +337,168 @@ def test_cleanup_stuck_runs_marks_running_over_threshold_failed(
     assert refreshed is not None
     assert refreshed.status == ScheduledTaskRunStatus.FAILED
     assert refreshed.error_class == "stuck"
+
+
+def test_timeout_error_event_marks_run_failed_with_timeout_class(
+    db_session: Session,
+    test_user: User,
+    sandbox: Any,  # noqa: ARG001
+    session_manager_with_stub: SessionManager,  # noqa: ARG001
+    stub_sandbox_manager: StubSandboxManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for ENG-4234: terminal timeout Error → FAILED/timeout.
+
+    When the sandbox event stream yields only a terminal ``Error`` with
+    ``code == TURN_ERROR_CODE_TIMEOUT`` (and never a ``PromptResponse``),
+    ``run_scheduled_task_logic`` must mark the run ``FAILED`` with
+    ``error_class == ScheduledTaskErrorClass.TIMEOUT.value``.
+
+    Before the fix the run fell through to the SUCCEEDED path because the
+    terminal Error was the last event and ``persist_sandbox_event`` drops it.
+    """
+    # Bypass skill-payload assembly — it reads ExternalApp rows that may
+    # have encrypted credentials incompatible with the local MIT key.
+    monkeypatch.setattr(
+        "onyx.server.features.build.session.manager.build_user_skills_payload",
+        lambda *_: ("", {}),
+    )
+
+    sandbox(user=test_user, status=SandboxStatus.RUNNING)
+    _, run = _seed_task_and_queued_run(db_session, test_user)
+
+    stub_sandbox_manager.health_check_returns = True
+    stub_sandbox_manager.setup_session_workspace_silent = True
+    stub_sandbox_manager.write_files_to_sandbox_silent = True
+    stub_sandbox_manager.send_message_events = [
+        Error.model_validate(
+            {"code": TURN_ERROR_CODE_TIMEOUT, "message": "Timeout waiting for response"}
+        ),
+    ]
+
+    run_scheduled_task_logic(run.id)
+
+    db_session.expire_all()
+    refreshed = db_session.get(ScheduledTaskRun, run.id)
+    assert refreshed is not None
+    assert refreshed.status == ScheduledTaskRunStatus.FAILED
+    assert refreshed.error_class == ScheduledTaskErrorClass.TIMEOUT.value
+
+
+def test_prompt_response_marks_run_succeeded(
+    db_session: Session,
+    test_user: User,
+    sandbox: Any,  # noqa: ARG001
+    session_manager_with_stub: SessionManager,  # noqa: ARG001
+    stub_sandbox_manager: StubSandboxManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Happy-path regression: clean PromptResponse → SUCCEEDED.
+
+    Ensures the ENG-4234 fix did not break the clean-completion path: a
+    stream that yields exactly one ``PromptResponse`` (and no ``Error``) must
+    still transition the run to ``SUCCEEDED``.
+    """
+    # Bypass skill-payload assembly — it reads ExternalApp rows that may
+    # have encrypted credentials incompatible with the local MIT key.
+    monkeypatch.setattr(
+        "onyx.server.features.build.session.manager.build_user_skills_payload",
+        lambda *_: ("", {}),
+    )
+
+    sandbox(user=test_user, status=SandboxStatus.RUNNING)
+    _, run = _seed_task_and_queued_run(db_session, test_user)
+
+    stub_sandbox_manager.health_check_returns = True
+    stub_sandbox_manager.setup_session_workspace_silent = True
+    stub_sandbox_manager.write_files_to_sandbox_silent = True
+    stub_sandbox_manager.send_message_events = [
+        PromptResponse.model_validate({"stopReason": "end_turn"}),
+    ]
+
+    run_scheduled_task_logic(run.id)
+
+    db_session.expire_all()
+    refreshed = db_session.get(ScheduledTaskRun, run.id)
+    assert refreshed is not None
+    assert refreshed.status == ScheduledTaskRunStatus.SUCCEEDED
+    assert refreshed.error_class is None
+
+
+def test_transport_error_event_marks_run_failed_with_agent_exception_class(
+    db_session: Session,
+    test_user: User,
+    sandbox: Any,  # noqa: ARG001
+    session_manager_with_stub: SessionManager,  # noqa: ARG001
+    stub_sandbox_manager: StubSandboxManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-timeout terminal Error → FAILED with ``error_class=agent_exception``.
+
+    The TIMEOUT class is reserved for ``TURN_ERROR_CODE_TIMEOUT``; any other
+    terminal Error (here a transport failure) falls into the default
+    AGENT_EXCEPTION branch.
+    """
+    # Bypass skill-payload assembly — it reads ExternalApp rows that may
+    # have encrypted credentials incompatible with the local MIT key.
+    monkeypatch.setattr(
+        "onyx.server.features.build.session.manager.build_user_skills_payload",
+        lambda *_: ("", {}),
+    )
+
+    sandbox(user=test_user, status=SandboxStatus.RUNNING)
+    _, run = _seed_task_and_queued_run(db_session, test_user)
+
+    stub_sandbox_manager.health_check_returns = True
+    stub_sandbox_manager.setup_session_workspace_silent = True
+    stub_sandbox_manager.write_files_to_sandbox_silent = True
+    stub_sandbox_manager.send_message_events = [
+        Error.model_validate(
+            {"code": TURN_ERROR_CODE_TRANSPORT, "message": "event bus closed"}
+        ),
+    ]
+
+    run_scheduled_task_logic(run.id)
+
+    db_session.expire_all()
+    refreshed = db_session.get(ScheduledTaskRun, run.id)
+    assert refreshed is not None
+    assert refreshed.status == ScheduledTaskRunStatus.FAILED
+    assert refreshed.error_class == ScheduledTaskErrorClass.AGENT_EXCEPTION.value
+
+
+def test_stream_without_prompt_response_marks_run_failed(
+    db_session: Session,
+    test_user: User,
+    sandbox: Any,  # noqa: ARG001
+    session_manager_with_stub: SessionManager,  # noqa: ARG001
+    stub_sandbox_manager: StubSandboxManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stream that ends with no PromptResponse (and no Error) → FAILED.
+
+    Guards the ``not got_prompt_response`` half of the failure branch: an
+    empty/truncated stream must not be recorded as SUCCEEDED.
+    """
+    # Bypass skill-payload assembly — it reads ExternalApp rows that may
+    # have encrypted credentials incompatible with the local MIT key.
+    monkeypatch.setattr(
+        "onyx.server.features.build.session.manager.build_user_skills_payload",
+        lambda *_: ("", {}),
+    )
+
+    sandbox(user=test_user, status=SandboxStatus.RUNNING)
+    _, run = _seed_task_and_queued_run(db_session, test_user)
+
+    stub_sandbox_manager.health_check_returns = True
+    stub_sandbox_manager.setup_session_workspace_silent = True
+    stub_sandbox_manager.write_files_to_sandbox_silent = True
+    stub_sandbox_manager.send_message_events = []
+
+    run_scheduled_task_logic(run.id)
+
+    db_session.expire_all()
+    refreshed = db_session.get(ScheduledTaskRun, run.id)
+    assert refreshed is not None
+    assert refreshed.status == ScheduledTaskRunStatus.FAILED
+    assert refreshed.error_class == ScheduledTaskErrorClass.AGENT_EXCEPTION.value

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_send_message_with_bus.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_send_message_with_bus.py
@@ -32,6 +32,8 @@ from onyx.server.features.build.sandbox.event_schema import AgentMessageChunk
 from onyx.server.features.build.sandbox.event_schema import AgentThoughtChunk
 from onyx.server.features.build.sandbox.event_schema import Error
 from onyx.server.features.build.sandbox.event_schema import PromptResponse
+from onyx.server.features.build.sandbox.event_schema import TURN_ERROR_CODE_TIMEOUT
+from onyx.server.features.build.sandbox.event_schema import TURN_ERROR_CODE_TRANSPORT
 from onyx.server.features.build.sandbox.opencode.event_bus import PodEventBus
 from onyx.server.features.build.sandbox.opencode.serve_client import ClientTimeouts
 from onyx.server.features.build.sandbox.opencode.serve_client import OpencodeServeClient
@@ -477,7 +479,7 @@ def test_send_message_yields_error_on_prompt_async_connection_error(
     )
     assert len(events) == 1
     assert isinstance(events[0], Error)
-    assert events[0].code == -3
+    assert events[0].code == TURN_ERROR_CODE_TRANSPORT
     assert "prompt_async failed" in events[0].message
 
 
@@ -524,7 +526,7 @@ def test_send_message_errors_when_stream_ready_never_set(
     )
     assert len(events) == 1
     assert isinstance(events[0], Error)
-    assert events[0].code == -3
+    assert events[0].code == TURN_ERROR_CODE_TRANSPORT
     assert "did not become ready" in events[0].message
     assert not any(
         request.url.path.endswith("/prompt_async") for request in transport.requests
@@ -614,7 +616,9 @@ def test_send_message_wall_clock_timeout_aborts(bus: PodEventBus) -> None:
     events = list(
         client.send_message(_SESSION, "hi", directory=_DIRECTORY, timeout=0.3)
     )
-    assert any(isinstance(e, Error) and e.code == -1 for e in events)
+    assert any(
+        isinstance(e, Error) and e.code == TURN_ERROR_CODE_TIMEOUT for e in events
+    )
     assert any("/abort" in p for p in aborts)
 
 


### PR DESCRIPTION
## Description

Fixes [ENG-4234](https://linear.app/onyx-app/issue/ENG-4234). When a scheduled Craft run's agent turn hit its 900s wall-clock timeout, the executor recorded the run as **SUCCEEDED** instead of FAILED — with only the turn-0 user message persisted, no assistant content, and **no failure notification**. The failure was completely silent.

**Root cause:** a timed-out turn ends its sandbox event stream with a terminal `Error` event (not a `PromptResponse`). `persist_sandbox_event` deliberately drops both `Error` and `PromptResponse`, so the executor's clean-completion path fell through to `mark_run_status(SUCCEEDED)` with an empty transcript.

**Fix:**
- `scheduled_tasks/executor.py` — the drive loop now tracks the terminal event. A terminal `Error`, or a stream that ends with **no** `PromptResponse`, marks the run **FAILED** and emits `SCHEDULED_TASK_FAILED`. `error_class = TIMEOUT` for the wall-clock timeout, `AGENT_EXCEPTION` otherwise. Partial streamed output is still flushed via `finalize_persist`. `PromptResponse` now `break`s before the budget check, closing a (pre-existing) race where a deadline tripping at the exact moment of completion could mis-mark a *successful* turn as timed-out.
- `sandbox/event_schema.py` — added named `Error.code` sentinels. The code `-1` was previously **overloaded** for both the wall-clock timeout and generic opencode session errors, making timeouts indistinguishable for triage. Split into `TURN_ERROR_CODE_SESSION` (-1), `TURN_ERROR_CODE_TIMEOUT` (-2), `TURN_ERROR_CODE_TRANSPORT` (-3).
- `opencode/serve_client.py` — replaced all magic `-1`/`-3` literals with the named constants; the wall-clock timeout now emits the dedicated `TURN_ERROR_CODE_TIMEOUT`.

No frontend/SSE consumer keys on the numeric `Error.code` (verified — the craft event parser reads only `message`), so the code change is transparent to the UI.

## How Has This Been Tested?

- **New ext-dep tests** (`test_scheduled_task_executor.py`): timeout `Error` → FAILED/`timeout`; clean `PromptResponse` → SUCCEEDED (asserts `error_class is None`); transport `Error` → FAILED/`agent_exception`; empty stream → FAILED/`agent_exception`. All 4 pass against the dev cluster Postgres.
- **Updated unit tests** (`test_send_message_with_bus.py`): the wall-clock-timeout assertion now expects `TURN_ERROR_CODE_TIMEOUT`; transport assertions use `TURN_ERROR_CODE_TRANSPORT`. All 18 pass.
- `ruff`, `ruff format`, `ty`, and pre-commit pass on all changed files.

## Known minor items (left for reviewer)

- The existing `session_manager_with_stub` fixture is load-bearing via a side-effect (it monkeypatches `get_sandbox_manager`) but is annotated `# noqa: ARG001` per this file's established convention — kept consistent rather than special-casing the two new tests.
- A pre-existing, environment-specific test teardown error (`skill_table_isolation` `UnicodeDecodeError`) affects **all** tests in `test_scheduled_task_executor.py` when run against a DB whose `ExternalApp.organization_credentials` were encrypted with a different key. The test bodies pass; only teardown errors. Unrelated to this change (tracked separately).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks scheduled Craft runs as FAILED when an agent turn times out and sends a failure notification, addressing ENG-4234. Adds named error codes so timeouts are distinct from session and transport errors.

- **Bug Fixes**
  - Executor marks run FAILED on terminal `Error` or when no `PromptResponse`; emits `SCHEDULED_TASK_FAILED`.
  - Sets `error_class` to `timeout` for `TURN_ERROR_CODE_TIMEOUT`, otherwise `agent_exception`; preserves partial output.
  - Breaks on `PromptResponse` before budget checks to avoid a race that could mis-mark success as timeout.
  - Introduces `TURN_ERROR_CODE_SESSION`, `TURN_ERROR_CODE_TIMEOUT`, `TURN_ERROR_CODE_TRANSPORT`; `serve_client` emits these instead of magic codes. UI remains unchanged.

- **Refactors**
  - Trimmed comments to essential rationale and shortened test docstrings.

<sup>Written for commit 4dd1933bf7b1ae2258ed53d3cd9a405202993b88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

