### PR TITLE
chore: [Running GitHub actions for #12306]

### DIFF
--- a/backend/onyx/llm/constants.py
+++ b/backend/onyx/llm/constants.py
@@ -27,6 +27,7 @@ class LlmProviderNames(str, Enum):
     LITELLM_PROXY = "litellm_proxy"
     BIFROST = "bifrost"
     OPENAI_COMPATIBLE = "openai_compatible"
+    NEBIUS_TOKENFACTORY = "nebius_tokenfactory"
 
     def __str__(self) -> str:
         """Needed so things like:
@@ -48,6 +49,7 @@ WELL_KNOWN_PROVIDER_NAMES = [
     LlmProviderNames.LITELLM_PROXY,
     LlmProviderNames.BIFROST,
     LlmProviderNames.OPENAI_COMPATIBLE,
+    LlmProviderNames.NEBIUS_TOKENFACTORY,
 ]
 
 
@@ -67,6 +69,7 @@ PROVIDER_DISPLAY_NAMES: dict[str, str] = {
     LlmProviderNames.LITELLM_PROXY: "LiteLLM Proxy",
     LlmProviderNames.BIFROST: "Bifrost",
     LlmProviderNames.OPENAI_COMPATIBLE: "OpenAI-Compatible",
+    LlmProviderNames.NEBIUS_TOKENFACTORY: "Nebius TokenFactory",
     "groq": "Groq",
     "anyscale": "Anyscale",
     "deepseek": "DeepSeek",
@@ -158,6 +161,7 @@ AGGREGATOR_PROVIDERS: set[str] = {
     LlmProviderNames.LITELLM_PROXY,
     LlmProviderNames.BIFROST,
     LlmProviderNames.OPENAI_COMPATIBLE,
+    LlmProviderNames.NEBIUS_TOKENFACTORY,
 }
 
 # Model family name mappings for display name generation

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -406,6 +406,7 @@ class LitellmLLM(LLM):
         if model_provider in (
             LlmProviderNames.BIFROST,
             LlmProviderNames.OPENAI_COMPATIBLE,
+            LlmProviderNames.NEBIUS_TOKENFACTORY,
         ):
             self._custom_llm_provider = "openai"
             # LiteLLM's OpenAI client requires an api_key to be set.
@@ -534,6 +535,7 @@ class LitellmLLM(LLM):
         is_openai_compatible_proxy = self._model_provider in (
             LlmProviderNames.BIFROST,
             LlmProviderNames.OPENAI_COMPATIBLE,
+            LlmProviderNames.NEBIUS_TOKENFACTORY,
         )
         model_provider = (
             f"{self.config.model_provider}/responses"

--- a/backend/onyx/llm/well_known_providers/constants.py
+++ b/backend/onyx/llm/well_known_providers/constants.py
@@ -17,6 +17,8 @@ BIFROST_PROVIDER_NAME = "bifrost"
 
 OPENAI_COMPATIBLE_PROVIDER_NAME = "openai_compatible"
 
+NEBIUS_TOKENFACTORY_PROVIDER_NAME = "nebius_tokenfactory"
+
 # Providers that use optional Bearer auth from custom_config
 PROVIDERS_WITH_SPECIAL_API_KEY_HANDLING: dict[str, str] = {
     LlmProviderNames.OLLAMA_CHAT: OLLAMA_API_KEY_CONFIG_KEY,

--- a/backend/onyx/llm/well_known_providers/llm_provider_options.py
+++ b/backend/onyx/llm/well_known_providers/llm_provider_options.py
@@ -18,6 +18,7 @@ from onyx.llm.well_known_providers.constants import BEDROCK_PROVIDER_NAME
 from onyx.llm.well_known_providers.constants import BIFROST_PROVIDER_NAME
 from onyx.llm.well_known_providers.constants import LITELLM_PROXY_PROVIDER_NAME
 from onyx.llm.well_known_providers.constants import LM_STUDIO_PROVIDER_NAME
+from onyx.llm.well_known_providers.constants import NEBIUS_TOKENFACTORY_PROVIDER_NAME
 from onyx.llm.well_known_providers.constants import OLLAMA_PROVIDER_NAME
 from onyx.llm.well_known_providers.constants import OPENAI_COMPATIBLE_PROVIDER_NAME
 from onyx.llm.well_known_providers.constants import OPENAI_PROVIDER_NAME
@@ -53,6 +54,7 @@ def _get_provider_to_models_map() -> dict[str, list[str]]:
         LITELLM_PROXY_PROVIDER_NAME: [],  # Dynamic - fetched from LiteLLM proxy API
         BIFROST_PROVIDER_NAME: [],  # Dynamic - fetched from Bifrost API
         OPENAI_COMPATIBLE_PROVIDER_NAME: [],  # Dynamic - fetched from OpenAI-compatible API
+        NEBIUS_TOKENFACTORY_PROVIDER_NAME: [],  # Dynamic - fetched from /v1/models
     }
 
 
@@ -347,6 +349,7 @@ def get_provider_display_name(provider_name: str) -> str:
         OPENROUTER_PROVIDER_NAME: "OpenRouter",
         LITELLM_PROXY_PROVIDER_NAME: "LiteLLM Proxy",
         OPENAI_COMPATIBLE_PROVIDER_NAME: "OpenAI-Compatible",
+        NEBIUS_TOKENFACTORY_PROVIDER_NAME: "Nebius TokenFactory",
     }
 
     if provider_name in _ONYX_PROVIDER_DISPLAY_NAMES:

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -88,6 +88,8 @@ from onyx.server.manage.llm.models import LLMProviderView
 from onyx.server.manage.llm.models import LMStudioFinalModelResponse
 from onyx.server.manage.llm.models import LMStudioModelsRequest
 from onyx.server.manage.llm.models import ModelConfigurationUpsertRequest
+from onyx.server.manage.llm.models import NebiusTokenfactoryFinalModelResponse
+from onyx.server.manage.llm.models import NebiusTokenfactoryModelsRequest
 from onyx.server.manage.llm.models import OllamaFinalModelResponse
 from onyx.server.manage.llm.models import OllamaModelDetails
 from onyx.server.manage.llm.models import OllamaModelsRequest
@@ -132,22 +134,27 @@ def _resolve_api_key(
     provider_name: str | None,
     api_base: str | None,
     db_session: Session,
+    provider_id: int | None = None,
 ) -> str | None:
     """Return the real API key for model-fetch endpoints.
 
     When editing an existing provider the form value is masked (e.g.
-    ``sk-a****b1c2``).  If *provider_name* is supplied we can look up
-    the unmasked key from the database so the external request succeeds.
+    ``sk-a****b1c2``). We look up the unmasked key from the database so the
+    external request succeeds; a freshly typed (non-masked) key is used as-is.
 
-    The stored key is only returned when the request's *api_base*
-    matches the value stored in the database.
+    The provider is resolved by *provider_id* when given (reliable — the edit
+    form always has it, and well-known providers are frequently saved with a
+    NULL name), otherwise by *provider_name*. The stored key is only returned
+    when the request's *api_base* matches the value stored in the database.
     """
-    if not provider_name:
-        return api_key
+    existing_provider = None
+    if provider_id is not None:
+        existing_provider = fetch_existing_llm_provider_by_id(provider_id, db_session)
+    elif provider_name:
+        existing_provider = fetch_existing_llm_provider(
+            name=provider_name, db_session=db_session
+        )
 
-    existing_provider = fetch_existing_llm_provider(
-        name=provider_name, db_session=db_session
-    )
     if existing_provider and existing_provider.api_key:
         # Normalise both URLs before comparing so trailing-slash
         # differences don't cause a false mismatch.
@@ -1856,6 +1863,153 @@ def _get_bifrost_models_response(api_base: str, api_key: str | None = None) -> d
         source_name="Bifrost",
         api_key=api_key,
     )
+
+
+def _get_nebius_tokenfactory_models_response(
+    api_base: str, api_key: str | None = None
+) -> dict:
+    """GET Nebius TokenFactory /v1/models?verbose=true and return parsed JSON.
+
+    The verbose flag is what surfaces per-model `context_length`,
+    `architecture.modality`, and `supported_features` (which lists "tools",
+    "reasoning", etc.).
+    """
+    cleaned_api_base = api_base.strip().rstrip("/")
+    if cleaned_api_base.endswith("/v1"):
+        url = f"{cleaned_api_base}/models"
+    else:
+        url = f"{cleaned_api_base}/v1/models"
+
+    return _get_openai_compatible_models_response(
+        url=f"{url}?verbose=true",
+        source_name="Nebius TokenFactory",
+        api_key=api_key,
+    )
+
+
+def _nebius_modality_supports_image(model: dict) -> bool:
+    """Vision support = the model's input modality includes images.
+
+    `architecture.modality` looks like "text->text" or "text+image->text".
+    """
+    architecture = model.get("architecture") or {}
+    modality = architecture.get("modality") or ""
+    input_modality = modality.split("->")[0] if "->" in modality else modality
+    return "image" in input_modality.lower()
+
+
+@admin_router.post("/nebius-tokenfactory/available-models")
+def get_nebius_tokenfactory_available_models(
+    request: NebiusTokenfactoryModelsRequest,
+    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> list[NebiusTokenfactoryFinalModelResponse]:
+    """Fetch chat models from Nebius TokenFactory, with per-model context
+    length and tool/vision capabilities read straight from the source API."""
+    api_key = _resolve_api_key(
+        request.api_key,
+        request.provider_name,
+        request.api_base,
+        db_session,
+        provider_id=request.provider_id,
+    )
+
+    response_json = _get_nebius_tokenfactory_models_response(
+        api_base=request.api_base, api_key=api_key
+    )
+
+    models = response_json.get("data", [])
+    if not isinstance(models, list) or len(models) == 0:
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            "No models found from your Nebius TokenFactory endpoint",
+        )
+
+    results: list[NebiusTokenfactoryFinalModelResponse] = []
+    for model in models:
+        try:
+            model_id = model.get("id", "")
+            if not model_id:
+                continue
+            if is_embedding_model(model_id):
+                continue
+
+            # Only keep models whose output modality is text (chat / vision-chat);
+            # this drops embeddings/rerankers that slip past the name check.
+            architecture = model.get("architecture") or {}
+            modality = architecture.get("modality") or "text->text"
+            output_modality = modality.split("->")[-1] if "->" in modality else "text"
+            if output_modality.strip().lower() != "text":
+                continue
+
+            display_name = model.get("name") or model_id
+            context_length = model.get("context_length") or None
+
+            features = model.get("supported_features")
+            if isinstance(features, list):
+                feature_list = [str(f) for f in features]
+                supports_reasoning = "reasoning" in feature_list
+            else:
+                feature_list = []
+                supports_reasoning = is_reasoning_model(model_id, display_name)
+
+            # Display-only metadata for the model picker.
+            regions = model.get("regions") or []
+            country_code = (
+                regions[0].get("country_code")
+                if regions and isinstance(regions[0], dict)
+                else None
+            )
+            limits = model.get("per_request_limits") or {}
+            requests_per_minute = (
+                limits.get("requests_per_minute") if isinstance(limits, dict) else None
+            )
+
+            results.append(
+                NebiusTokenfactoryFinalModelResponse(
+                    name=model_id,
+                    display_name=display_name,
+                    max_input_tokens=context_length,
+                    supports_image_input=_nebius_modality_supports_image(model),
+                    supports_reasoning=supports_reasoning,
+                    quantization=model.get("quantization"),
+                    country_code=country_code,
+                    requests_per_minute=requests_per_minute,
+                    supported_features=feature_list,
+                )
+            )
+        except Exception as e:
+            logger.warning(
+                "Failed to parse Nebius TokenFactory model entry",
+                extra={"error": str(e), "item": str(model)[:1000]},
+            )
+
+    if not results:
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            "No compatible models found from Nebius TokenFactory",
+        )
+
+    sorted_results = sorted(results, key=lambda m: m.name.lower())
+
+    if request.provider_name:
+        _sync_fetched_models(
+            db_session=db_session,
+            provider_name=request.provider_name,
+            models=[
+                SyncModelEntry(
+                    name=r.name,
+                    display_name=r.display_name,
+                    max_input_tokens=r.max_input_tokens,
+                    supports_image_input=r.supports_image_input,
+                    supports_reasoning=r.supports_reasoning,
+                )
+                for r in sorted_results
+            ],
+            source_label="Nebius TokenFactory",
+        )
+
+    return sorted_results
 
 
 @admin_router.post("/openai-compatible/available-models")

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -614,6 +614,27 @@ class BifrostFinalModelResponse(BaseModel):
     supports_reasoning: bool
 
 
+# Nebius Token Factory dynamic models fetch
+class NebiusTokenfactoryModelsRequest(BaseModel):
+    api_base: str
+    api_key: str | None = None
+    provider_name: str | None = None  # Optional: to save models to existing provider
+    provider_id: int | None = None  # Reliable id for resolving the stored key on edit
+
+
+class NebiusTokenfactoryFinalModelResponse(BaseModel):
+    name: str  # Model ID (e.g. "meta-llama/Llama-3.3-70B-Instruct")
+    display_name: str
+    max_input_tokens: int | None
+    supports_image_input: bool
+    supports_reasoning: bool
+    # Display-only metadata shown in the model picker (not persisted).
+    quantization: str | None = None
+    country_code: str | None = None
+    requests_per_minute: float | None = None
+    supported_features: list[str] = []
+
+
 # OpenAI Compatible dynamic models fetch
 class OpenAICompatibleModelsRequest(BaseModel):
     api_base: str

--- a/backend/tests/unit/onyx/server/manage/llm/test_nebius_tokenfactory_models.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_nebius_tokenfactory_models.py
@@ -1,0 +1,113 @@
+"""Tests for the Nebius Token Factory model fetcher.
+
+Verifies the mapping from the provider's /v1/models?verbose response to
+Onyx model configs: context length and vision (from architecture.modality).
+"""
+
+from unittest.mock import patch
+
+from onyx.server.manage.llm.api import get_nebius_tokenfactory_available_models
+from onyx.server.manage.llm.models import NebiusTokenfactoryModelsRequest
+
+# Trimmed real /v1/models?verbose=true payload plus a vision and an embedding
+# entry to exercise modality handling and filtering.
+_SAMPLE = {
+    "object": "list",
+    "data": [
+        {
+            # features present but NO "tools" -> explicitly does not support tools
+            "id": "nvidia/Llama-3_1-Nemotron-Ultra-253B-v1",
+            "name": "llama-3-1-nemotron-ultra-253b-v1-m",
+            "context_length": 8000,
+            "architecture": {"modality": "text->text"},
+            "supported_features": ["json_mode", "structured_outputs", "reasoning"],
+        },
+        {
+            "id": "meta-llama/Llama-3.3-70B-Instruct",
+            "name": "Llama-3.3-70B-Instruct",
+            "created": 1781351620,
+            "context_length": 131072,
+            "architecture": {"modality": "text->text"},
+            "quantization": "fp8",
+            "regions": [{"country_code": "FI", "name": "eu-north1"}],
+            "per_request_limits": {"requests_per_minute": 1200.0},
+            "supported_features": ["tools"],
+        },
+        {
+            "id": "Qwen/Qwen3-32B",
+            "name": "Qwen3-32B",
+            "context_length": 40960,
+            "architecture": {"modality": "text->text"},
+            "supported_features": ["tools", "json_mode", "reasoning"],
+        },
+        {
+            # vision model (image on the input side)
+            "id": "some-vendor/VisionChat",
+            "name": "VisionChat",
+            "context_length": 32000,
+            "architecture": {"modality": "text+image->text"},
+            "supported_features": ["tools"],
+        },
+        {
+            # embedding model -> must be dropped
+            "id": "BAAI/bge-en-icl",
+            "name": "bge-en-icl",
+            "context_length": 4096,
+            "architecture": {"modality": "text->embedding"},
+            "supported_features": [],
+        },
+    ],
+}
+
+
+def _fetch() -> dict:
+    with (
+        patch("onyx.server.manage.llm.api._resolve_api_key", return_value="k"),
+        patch(
+            "onyx.server.manage.llm.api._get_nebius_tokenfactory_models_response",
+            return_value=_SAMPLE,
+        ),
+    ):
+        results = get_nebius_tokenfactory_available_models(
+            request=NebiusTokenfactoryModelsRequest(
+                api_base="https://api.tokenfactory.nebius.com/v1",
+                api_key="k",
+                provider_name=None,  # skip DB sync
+            ),
+            _=None,  # type: ignore[arg-type]
+            db_session=None,  # type: ignore[arg-type]
+        )
+    return {r.name: r for r in results}
+
+
+def test_embedding_model_is_dropped() -> None:
+    by_name = _fetch()
+    assert "BAAI/bge-en-icl" not in by_name
+    # the four chat/vision models remain
+    assert len(by_name) == 4
+
+
+def test_context_length_mapped() -> None:
+    by_name = _fetch()
+    assert by_name["meta-llama/Llama-3.3-70B-Instruct"].max_input_tokens == 131072
+    assert by_name["nvidia/Llama-3_1-Nemotron-Ultra-253B-v1"].max_input_tokens == 8000
+
+
+def test_vision_from_modality() -> None:
+    by_name = _fetch()
+    assert by_name["some-vendor/VisionChat"].supports_image_input is True
+    assert by_name["meta-llama/Llama-3.3-70B-Instruct"].supports_image_input is False
+
+
+def test_reasoning_from_features() -> None:
+    by_name = _fetch()
+    assert by_name["Qwen/Qwen3-32B"].supports_reasoning is True
+    assert by_name["meta-llama/Llama-3.3-70B-Instruct"].supports_reasoning is False
+
+
+def test_display_metadata_mapped() -> None:
+    m = _fetch()["meta-llama/Llama-3.3-70B-Instruct"]
+    assert m.quantization == "fp8"
+    assert m.country_code == "FI"
+    assert m.requests_per_minute == 1200.0
+    assert m.supported_features == ["tools"]

--- a/backend/tests/unit/onyx/server/manage/llm/test_nebius_tokenfactory_models.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_nebius_tokenfactory_models.py
@@ -4,8 +4,12 @@ Verifies the mapping from the provider's /v1/models?verbose response to
 Onyx model configs: context length and vision (from architecture.modality).
 """
 
+from typing import cast
 from unittest.mock import patch
 
+from sqlalchemy.orm import Session
+
+from onyx.db.models import User
 from onyx.server.manage.llm.api import get_nebius_tokenfactory_available_models
 from onyx.server.manage.llm.models import NebiusTokenfactoryModelsRequest
 
@@ -74,8 +78,8 @@ def _fetch() -> dict:
                 api_key="k",
                 provider_name=None,  # skip DB sync
             ),
-            _=None,  # type: ignore[arg-type]
-            db_session=None,  # type: ignore[arg-type]
+            _=cast(User, None),
+            db_session=cast(Session, None),
         )
     return {r.name: r for r in results}
 

--- a/backend/tests/unit/onyx/server/manage/llm/test_resolve_api_key.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_resolve_api_key.py
@@ -1,0 +1,89 @@
+"""_resolve_api_key resolves a masked key (admin editing a saved provider) back
+to the stored key — by provider_id when a well-known provider was saved with a
+NULL name, or by provider_name otherwise. A freshly typed key is used as-is, and
+the stored key is only returned when the request's api_base matches the stored
+one."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from onyx.server.manage.llm.api import _resolve_api_key
+
+_STORED = "v1.Crealsecretkeyda0A"
+_MASKED = "v1.C****da0A"  # _mask_string(_STORED)
+_BASE = "https://api.tokenfactory.nebius.com/v1"
+
+
+def _provider() -> SimpleNamespace:
+    return SimpleNamespace(
+        api_base=_BASE,
+        api_key=SimpleNamespace(get_value=lambda **_: _STORED),
+    )
+
+
+def test_masked_key_resolves_to_stored_by_name() -> None:
+    with patch(
+        "onyx.server.manage.llm.api.fetch_existing_llm_provider",
+        return_value=_provider(),
+    ):
+        assert (
+            _resolve_api_key(_MASKED, "Nebius TokenFactory", _BASE, db_session=None)  # type: ignore[arg-type]
+            == _STORED
+        )
+
+
+def test_masked_key_resolves_to_stored_by_id_when_name_is_null() -> None:
+    # Well-known providers are often saved with name=None; the masked key must
+    # still resolve via the reliable provider id.
+    with patch(
+        "onyx.server.manage.llm.api.fetch_existing_llm_provider_by_id",
+        return_value=_provider(),
+    ):
+        assert (
+            _resolve_api_key(
+                _MASKED,
+                None,
+                _BASE,
+                db_session=None,  # type: ignore[arg-type]
+                provider_id=7,
+            )
+            == _STORED
+        )
+
+
+def test_fresh_key_used_as_is() -> None:
+    with patch(
+        "onyx.server.manage.llm.api.fetch_existing_llm_provider",
+        return_value=_provider(),
+    ):
+        assert (
+            _resolve_api_key(
+                "sk-brand-new-key-123456",
+                "Nebius TokenFactory",
+                _BASE,
+                db_session=None,  # type: ignore[arg-type]
+            )
+            == "sk-brand-new-key-123456"
+        )
+
+
+def test_no_provider_returns_input() -> None:
+    assert (
+        _resolve_api_key(_MASKED, None, _BASE, db_session=None) == _MASKED  # type: ignore[arg-type]
+    )
+
+
+def test_mismatched_api_base_returns_input() -> None:
+    with patch(
+        "onyx.server.manage.llm.api.fetch_existing_llm_provider",
+        return_value=_provider(),
+    ):
+        assert (
+            _resolve_api_key(
+                _MASKED,
+                "Nebius TokenFactory",
+                "https://other.example/v1",
+                db_session=None,  # type: ignore[arg-type]
+            )
+            == _MASKED
+        )

--- a/backend/tests/unit/onyx/server/manage/llm/test_resolve_api_key.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_resolve_api_key.py
@@ -5,7 +5,10 @@ the stored key is only returned when the request's api_base matches the stored
 one."""
 
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import patch
+
+from sqlalchemy.orm import Session
 
 from onyx.server.manage.llm.api import _resolve_api_key
 
@@ -27,7 +30,9 @@ def test_masked_key_resolves_to_stored_by_name() -> None:
         return_value=_provider(),
     ):
         assert (
-            _resolve_api_key(_MASKED, "Nebius TokenFactory", _BASE, db_session=None)  # type: ignore[arg-type]
+            _resolve_api_key(
+                _MASKED, "Nebius TokenFactory", _BASE, db_session=cast(Session, None)
+            )
             == _STORED
         )
 
@@ -44,7 +49,7 @@ def test_masked_key_resolves_to_stored_by_id_when_name_is_null() -> None:
                 _MASKED,
                 None,
                 _BASE,
-                db_session=None,  # type: ignore[arg-type]
+                db_session=cast(Session, None),
                 provider_id=7,
             )
             == _STORED
@@ -61,7 +66,7 @@ def test_fresh_key_used_as_is() -> None:
                 "sk-brand-new-key-123456",
                 "Nebius TokenFactory",
                 _BASE,
-                db_session=None,  # type: ignore[arg-type]
+                db_session=cast(Session, None),
             )
             == "sk-brand-new-key-123456"
         )
@@ -69,7 +74,8 @@ def test_fresh_key_used_as_is() -> None:
 
 def test_no_provider_returns_input() -> None:
     assert (
-        _resolve_api_key(_MASKED, None, _BASE, db_session=None) == _MASKED  # type: ignore[arg-type]
+        _resolve_api_key(_MASKED, None, _BASE, db_session=cast(Session, None))
+        == _MASKED
     )
 
 
@@ -83,7 +89,7 @@ def test_mismatched_api_base_returns_input() -> None:
                 _MASKED,
                 "Nebius TokenFactory",
                 "https://other.example/v1",
-                db_session=None,  # type: ignore[arg-type]
+                db_session=cast(Session, None),
             )
             == _MASKED
         )

--- a/web/lib/opal/src/logos/index.ts
+++ b/web/lib/opal/src/logos/index.ts
@@ -53,6 +53,7 @@ export { default as SvgMediawiki } from "@opal/logos/mediawiki";
 export { default as SvgMicrosoft } from "@opal/logos/microsoft";
 export { default as SvgMistral } from "@opal/logos/mistral";
 export { default as SvgMixedbread } from "@opal/logos/mixedbread";
+export { default as SvgNebius } from "@opal/logos/nebius";
 export { default as SvgNetflix } from "@opal/logos/netflix";
 export { default as SvgNomic } from "@opal/logos/nomic";
 export { default as SvgNotion } from "@opal/logos/notion";

--- a/web/lib/opal/src/logos/nebius.tsx
+++ b/web/lib/opal/src/logos/nebius.tsx
@@ -1,0 +1,24 @@
+import { cn } from "@opal/utils";
+import type { IconProps } from "@opal/types";
+
+// Nebius Token Factory mark — the lime rounded-square-with-plus glyph from the
+// official Nebius Token Factory lockup. The viewBox crops to just that mark.
+const SvgNebius = ({ size, className, ...props }: IconProps) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="103 0 28 28"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    className={cn(className, "text-[#E0FF4F]!")}
+    {...props}
+  >
+    <title>Nebius TokenFactory</title>
+    <path
+      d="M124.041 0c3.842 0 6.958 3.16 6.958 7.06v13.88l-.009.364c-.186 3.73-3.226 6.696-6.949 6.696h-14.083l-.357-.01c-3.558-.183-6.412-3.077-6.592-6.686L103 20.94V7.06c0-3.9 3.115-7.06 6.958-7.06h14.083Zm-14.083.916c-3.324 0-6.042 2.738-6.042 6.144v13.88c0 3.405 2.718 6.144 6.042 6.144h14.083c3.324 0 6.042-2.738 6.042-6.144V7.06c0-3.3-2.551-5.971-5.732-6.135l-.31-.009h-14.083Zm5.244 4.78c.301 0 .544.244.544.544V8.63c0 .214.173.389.388.389h2.389c.301 0 .544.243.544.544v2.388a.39.39 0 0 0 .389.389h2.389c.301 0 .545.244.545.545v2.233a.546.546 0 0 1-.545.544h-2.389a.39.39 0 0 0-.389.389v2.389c0 .3-.243.543-.544.543h-2.389a.389.389 0 0 0-.388.39v2.388c0 .3-.243.543-.544.544h-2.233a.543.543 0 0 1-.544-.544v-2.234c0-.3.243-.544.544-.544h2.388a.389.389 0 0 0 .389-.388v-2.389c0-.3.243-.544.544-.544h2.39a.388.388 0 0 0 .387-.388v-2.544a.389.389 0 0 0-.387-.39h-2.39a.543.543 0 0 1-.544-.544V9.406a.389.389 0 0 0-.389-.388h-2.388a.543.543 0 0 1-.544-.544V6.24c0-.3.243-.544.544-.544h2.233Z"
+      fill="currentColor"
+    />
+  </svg>
+);
+
+export default SvgNebius;

--- a/web/src/lib/languageModels/index.ts
+++ b/web/src/lib/languageModels/index.ts
@@ -16,6 +16,7 @@ import {
   SvgDeepseek,
   SvgQwen,
   SvgGoogle,
+  SvgNebius,
 } from "@opal/logos";
 import { ZAIIcon } from "@/components/icons/icons";
 import {
@@ -35,6 +36,7 @@ import LMStudioModal from "@/sections/modals/languageModels/LMStudioModal";
 import LiteLLMProxyModal from "@/sections/modals/languageModels/LiteLLMProxyModal";
 import BifrostModal from "@/sections/modals/languageModels/BifrostModal";
 import OpenAICompatibleModal from "@/sections/modals/languageModels/OpenAICompatibleModal";
+import NebiusTokenfactoryModal from "@/sections/modals/languageModels/NebiusTokenfactoryModal";
 
 // ─── Text (LLM) providers ────────────────────────────────────────────────────
 
@@ -118,6 +120,12 @@ const PROVIDERS: Record<string, ProviderEntry> = {
     companyName: "OpenAI-Compatible",
     Modal: OpenAICompatibleModal,
   },
+  [LLMProviderName.NEBIUS_TOKENFACTORY]: {
+    icon: SvgNebius,
+    productName: "Nebius TokenFactory",
+    companyName: "Nebius",
+    Modal: NebiusTokenfactoryModal,
+  },
   [LLMProviderName.CUSTOM]: {
     icon: SvgServer,
     productName: "Custom Models",
@@ -175,6 +183,7 @@ export const AGGREGATOR_PROVIDERS = new Set([
   LLMProviderName.LITELLM_PROXY,
   LLMProviderName.BIFROST,
   LLMProviderName.OPENAI_COMPATIBLE,
+  LLMProviderName.NEBIUS_TOKENFACTORY,
   LLMProviderName.VERTEX_AI,
 ]);
 

--- a/web/src/lib/languageModels/index.ts
+++ b/web/src/lib/languageModels/index.ts
@@ -200,6 +200,7 @@ const MODEL_ICON_MAP: Record<string, IconFunctionComponent> = {
   [LLMProviderName.LITELLM_PROXY]: SvgLitellm,
   [LLMProviderName.BIFROST]: SvgBifrost,
   [LLMProviderName.OPENAI_COMPATIBLE]: SvgPlug,
+  [LLMProviderName.NEBIUS_TOKENFACTORY]: SvgNebius,
 
   amazon: SvgAws,
   phi: SvgMicrosoft,

--- a/web/src/lib/languageModels/svc.ts
+++ b/web/src/lib/languageModels/svc.ts
@@ -28,6 +28,8 @@ import {
   type BifrostFetchParams,
   type OpenAICompatibleFetchParams,
   type OpenAICompatibleModelResponse,
+  type NebiusTokenfactoryFetchParams,
+  type NebiusTokenfactoryModelResponse,
 } from "@/lib/languageModels/types";
 
 /**
@@ -595,7 +597,82 @@ export const fetchModels = async (
         provider_name: formValues.name,
         signal,
       });
+    case LLMProviderName.NEBIUS_TOKENFACTORY:
+      return fetchNebiusTokenfactoryModels({
+        api_base: formValues.api_base,
+        api_key: formValues.api_key,
+        provider_name: formValues.name,
+        signal,
+      });
     default:
       return { models: [], error: `Unknown provider: ${providerName}` };
+  }
+};
+
+/**
+ * Fetches models from a Nebius Token Factory provider (/v1/models). Carries
+ * the per-model tool/function-calling capability so the chat path can skip
+ * tools for models that don't support them.
+ */
+export const fetchNebiusTokenfactoryModels = async (
+  params: NebiusTokenfactoryFetchParams
+): Promise<{ models: ModelConfiguration[]; error?: string }> => {
+  const apiBase = params.api_base;
+  if (!apiBase) {
+    return { models: [], error: "API Base is required" };
+  }
+
+  try {
+    const response = await fetch(
+      "/api/admin/llm/nebius-tokenfactory/available-models",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          api_base: apiBase,
+          api_key: params.api_key,
+          provider_name: params.provider_name,
+          provider_id: params.provider_id,
+        }),
+        signal: params.signal,
+      }
+    );
+
+    if (!response.ok) {
+      let errorMessage = "Failed to fetch models";
+      try {
+        const errorData = await response.json();
+        errorMessage = errorData.detail || errorData.message || errorMessage;
+      } catch (jsonError) {
+        console.warn(
+          "Failed to parse Nebius Token Factory model fetch error response",
+          jsonError
+        );
+      }
+      return { models: [], error: errorMessage };
+    }
+
+    const data: NebiusTokenfactoryModelResponse[] = await response.json();
+    const models: ModelConfiguration[] = data.map((modelData) => ({
+      name: modelData.name,
+      display_name: modelData.display_name,
+      is_visible: true,
+      max_input_tokens: modelData.max_input_tokens,
+      supports_image_input: modelData.supports_image_input,
+      supports_reasoning: modelData.supports_reasoning,
+      quantization: modelData.quantization,
+      country_code: modelData.country_code,
+      requests_per_minute: modelData.requests_per_minute,
+      supported_features: modelData.supported_features,
+      effectiveDisplayName: modelData.display_name || modelData.name,
+    }));
+
+    return { models };
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : "Unknown error";
+    return { models: [], error: errorMessage };
   }
 };

--- a/web/src/lib/languageModels/types.ts
+++ b/web/src/lib/languageModels/types.ts
@@ -7,6 +7,11 @@ export interface ModelConfiguration {
   max_input_tokens: number | null;
   supports_image_input: boolean;
   supports_reasoning: boolean;
+  /** Display-only metadata surfaced in the model picker (Nebius TokenFactory). */
+  quantization?: string | null;
+  country_code?: string | null;
+  requests_per_minute?: number | null;
+  supported_features?: string[];
   /** True when this is the provider's recommended default model. */
   is_recommended_default?: boolean;
   display_name?: string;
@@ -38,6 +43,7 @@ export enum LLMProviderName {
   LITELLM_PROXY = "litellm_proxy",
   BIFROST = "bifrost",
   OPENAI_COMPATIBLE = "openai_compatible",
+  NEBIUS_TOKENFACTORY = "nebius_tokenfactory",
   CUSTOM = "custom",
 }
 
@@ -204,6 +210,26 @@ export interface OpenAICompatibleModelResponse {
   max_input_tokens: number | null;
   supports_image_input: boolean;
   supports_reasoning: boolean;
+}
+
+export interface NebiusTokenfactoryFetchParams {
+  api_base?: string;
+  api_key?: string;
+  provider_name?: string;
+  provider_id?: number;
+  signal?: AbortSignal;
+}
+
+export interface NebiusTokenfactoryModelResponse {
+  name: string;
+  display_name: string;
+  max_input_tokens: number | null;
+  supports_image_input: boolean;
+  supports_reasoning: boolean;
+  quantization: string | null;
+  country_code: string | null;
+  requests_per_minute: number | null;
+  supported_features: string[];
 }
 
 export interface VertexAIFetchParams {

--- a/web/src/refresh-pages/admin/LanguageModelsPage.tsx
+++ b/web/src/refresh-pages/admin/LanguageModelsPage.tsx
@@ -58,6 +58,7 @@ const PROVIDER_DISPLAY_ORDER: string[] = [
   LLMProviderName.LM_STUDIO,
   LLMProviderName.BIFROST,
   LLMProviderName.OPENAI_COMPATIBLE,
+  LLMProviderName.NEBIUS_TOKENFACTORY,
 ];
 
 // ============================================================================

--- a/web/src/sections/modals/languageModels/NebiusTokenfactoryModal.tsx
+++ b/web/src/sections/modals/languageModels/NebiusTokenfactoryModal.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { markdown } from "@opal/utils";
+import { useSWRConfig } from "swr";
+import { useFormikContext } from "formik";
+import { InputDivider } from "@opal/layouts";
+import {
+  LLMProviderFormProps,
+  LLMProviderName,
+  LLMProviderView,
+} from "@/lib/languageModels/types";
+import { fetchNebiusTokenfactoryModels } from "@/lib/languageModels/svc";
+import {
+  useInitialValues,
+  buildValidationSchema,
+  BaseLLMFormValues,
+  mergeFetchedModelConfigurations,
+} from "@/sections/modals/languageModels/utils";
+import { submitProvider } from "@/sections/modals/languageModels/svc";
+import { LLMProviderConfiguredSource } from "@/lib/analytics/utils";
+import {
+  APIBaseField,
+  APIKeyField,
+  ModelSelectionField,
+  DisplayNameField,
+  ModelAccessField,
+  ModalWrapper,
+} from "@/sections/modals/languageModels/shared";
+import { toast } from "@/hooks/useToast";
+import { refreshLlmProviderCaches } from "@/lib/languageModels/cache";
+
+const DEFAULT_API_BASE = "https://api.tokenfactory.nebius.com/v1";
+
+interface NebiusTokenfactoryModalValues extends BaseLLMFormValues {
+  api_key: string;
+  api_base: string;
+}
+
+interface NebiusTokenfactoryModalInternalsProps {
+  existingLlmProvider: LLMProviderView | undefined;
+  isOnboarding: boolean;
+}
+
+function NebiusTokenfactoryModalInternals({
+  existingLlmProvider,
+  isOnboarding,
+}: NebiusTokenfactoryModalInternalsProps) {
+  const formikProps = useFormikContext<NebiusTokenfactoryModalValues>();
+  const { setFieldValue } = formikProps;
+
+  const isFetchDisabled = !formikProps.values.api_base;
+
+  const handleFetchModels = async () => {
+    const { models, error } = await fetchNebiusTokenfactoryModels({
+      api_base: formikProps.values.api_base,
+      api_key: formikProps.values.api_key || undefined,
+      provider_name: existingLlmProvider?.name ?? undefined,
+      provider_id: existingLlmProvider?.id ?? undefined,
+    });
+    if (error) {
+      throw new Error(error);
+    }
+    formikProps.setFieldValue(
+      "model_configurations",
+      mergeFetchedModelConfigurations(
+        models,
+        formikProps.values.model_configurations
+      )
+    );
+  };
+
+  // When editing a saved provider, the models load from the DB without the
+  // per-model metadata (context/flag/quantization/features) — so refetch once
+  // on open to make the picker match the "add" view. Best-effort: ignore
+  // errors so the modal still works if the provider is unreachable.
+  const autoRefetched = useRef(false);
+  useEffect(() => {
+    if (autoRefetched.current || !existingLlmProvider?.id) return;
+    if (!formikProps.values.api_base) return;
+    autoRefetched.current = true;
+    fetchNebiusTokenfactoryModels({
+      api_base: formikProps.values.api_base,
+      api_key: formikProps.values.api_key || undefined,
+      provider_name: existingLlmProvider.name ?? undefined,
+      provider_id: existingLlmProvider.id,
+    })
+      .then(({ models }) => {
+        if (models.length > 0) {
+          setFieldValue(
+            "model_configurations",
+            mergeFetchedModelConfigurations(
+              models,
+              formikProps.values.model_configurations
+            )
+          );
+        }
+      })
+      .catch(() => undefined);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <>
+      <APIBaseField
+        subDescription="Nebius TokenFactory endpoint URL (including API version)."
+        placeholder={DEFAULT_API_BASE}
+      />
+
+      <APIKeyField
+        subDescription={markdown(
+          "Paste your API key from [Nebius TokenFactory](https://tokenfactory.nebius.com/) to load the available models."
+        )}
+      />
+
+      {!isOnboarding && (
+        <>
+          <InputDivider />
+          <DisplayNameField />
+        </>
+      )}
+
+      <InputDivider />
+      <ModelSelectionField
+        shouldShowAutoUpdateToggle={false}
+        onRefetch={isFetchDisabled ? undefined : handleFetchModels}
+      />
+
+      {!isOnboarding && (
+        <>
+          <InputDivider />
+          <ModelAccessField />
+        </>
+      )}
+    </>
+  );
+}
+
+export default function NebiusTokenfactoryModal({
+  variant = "llm-configuration",
+  existingLlmProvider,
+  shouldMarkAsDefault,
+  onOpenChange,
+  onSuccess,
+}: LLMProviderFormProps) {
+  const isOnboarding = variant === "onboarding";
+  const { mutate } = useSWRConfig();
+
+  const onClose = () => onOpenChange?.(false);
+
+  const initialValues: NebiusTokenfactoryModalValues = useInitialValues(
+    isOnboarding,
+    LLMProviderName.NEBIUS_TOKENFACTORY,
+    existingLlmProvider
+  ) as NebiusTokenfactoryModalValues;
+
+  // Nebius TokenFactory always uses the same base; default it whenever it's
+  // missing (new provider, or an edit where the base wasn't persisted) so the
+  // model refetch always has a valid endpoint.
+  if (!initialValues.api_base) {
+    initialValues.api_base = DEFAULT_API_BASE;
+  }
+
+  const validationSchema = buildValidationSchema(isOnboarding, {
+    apiBase: true,
+    apiKey: true,
+  });
+
+  return (
+    <ModalWrapper
+      providerName={LLMProviderName.NEBIUS_TOKENFACTORY}
+      llmProvider={existingLlmProvider}
+      onClose={onClose}
+      initialValues={initialValues}
+      validationSchema={validationSchema}
+      onSubmit={async (values, { setSubmitting, setStatus }) => {
+        await submitProvider({
+          analyticsSource: isOnboarding
+            ? LLMProviderConfiguredSource.CHAT_ONBOARDING
+            : LLMProviderConfiguredSource.ADMIN_PAGE,
+          providerName: LLMProviderName.NEBIUS_TOKENFACTORY,
+          values,
+          initialValues,
+          existingLlmProvider,
+          shouldMarkAsDefault,
+          setStatus,
+          setSubmitting,
+          onClose,
+          onSuccess: async () => {
+            if (onSuccess) {
+              await onSuccess();
+            } else {
+              await refreshLlmProviderCaches(mutate);
+              toast.success(
+                existingLlmProvider
+                  ? "Provider updated successfully!"
+                  : "Provider enabled successfully!"
+              );
+            }
+          },
+        });
+      }}
+    >
+      <NebiusTokenfactoryModalInternals
+        existingLlmProvider={existingLlmProvider}
+        isOnboarding={isOnboarding}
+      />
+    </ModalWrapper>
+  );
+}

--- a/web/src/sections/modals/languageModels/shared.tsx
+++ b/web/src/sections/modals/languageModels/shared.tsx
@@ -428,6 +428,68 @@ function RefetchButton({ onRefetch }: RefetchButtonProps) {
 
 const FOLD_THRESHOLD = 3;
 
+// ─── Model metadata helpers (Nebius TokenFactory picker) ────────────────────
+
+function formatContextSize(tokens: number | null | undefined): string {
+  if (!tokens || tokens <= 0) return "";
+  if (tokens >= 1_000_000) {
+    const m = tokens / 1_000_000;
+    return `${Number.isInteger(m) ? m : m.toFixed(1)}M`;
+  }
+  if (tokens >= 1000) return `${Math.round(tokens / 1000)}K`;
+  return String(tokens);
+}
+
+// Common non-ISO-3166 codes the provider may report → the ISO alpha-2 code
+// whose regional-indicator sequence actually has a flag glyph.
+const COUNTRY_CODE_ALIASES: Record<string, string> = {
+  UK: "GB", // United Kingdom is "GB" in ISO 3166-1; "UK" has no flag glyph
+};
+
+function countryCodeToFlag(code: string | null | undefined): string {
+  if (!code || code.length !== 2) return "";
+  const upper = code.toUpperCase();
+  const normalized = COUNTRY_CODE_ALIASES[upper] ?? upper;
+  const first = 0x1f1e6 + normalized.charCodeAt(0) - 65;
+  const second = 0x1f1e6 + normalized.charCodeAt(1) - 65;
+  return String.fromCodePoint(first, second);
+}
+
+/** Models that ship extra picker metadata (e.g. Nebius TokenFactory); most
+ *  providers don't, in which case the row renders without a metadata line. */
+function hasModelMetadata(model: ModelConfiguration): boolean {
+  return (
+    model.quantization != null ||
+    model.country_code != null ||
+    (model.supported_features?.length ?? 0) > 0
+  );
+}
+
+/** Compact "128K · 🇫🇮 · fp8 · tools, reasoning" metadata line. */
+function buildModelDescription(model: ModelConfiguration): string | undefined {
+  if (!hasModelMetadata(model)) return undefined;
+  const parts: string[] = [];
+  const context = formatContextSize(model.max_input_tokens);
+  if (context) parts.push(context);
+  const flag = countryCodeToFlag(model.country_code);
+  if (flag) parts.push(flag);
+  if (model.quantization) parts.push(model.quantization);
+  if (model.supported_features?.length) {
+    parts.push(model.supported_features.join(", "));
+  }
+  return parts.length > 0 ? parts.join("  ·  ") : undefined;
+}
+
+/** Eye marker for vision models, shown on the right of the picker row. */
+function modelRightChildren(model: ModelConfiguration): React.ReactNode {
+  if (!hasModelMetadata(model) || !model.supports_image_input) return undefined;
+  return (
+    <Text secondaryBody text03 title="Vision">
+      👁
+    </Text>
+  );
+}
+
 interface ModelRowProps {
   model: ModelConfiguration;
   isAutoMode: boolean;
@@ -490,6 +552,8 @@ function ModelRow({
               sizePreset="main-ui"
               icon={() => <Checkbox checked={isSelected} />}
               title={displayName}
+              description={buildModelDescription(model)}
+              rightChildren={modelRightChildren(model)}
               editable
               onTitleChange={(newTitle) => onRename(newTitle || undefined)}
               padding="fit"
@@ -604,7 +668,13 @@ export function ModelSelectionField({
         ) : (
           <Section gap={0.25} alignItems="stretch">
             {(() => {
-              const displayModels = isAutoMode ? visibleModels : models;
+              const baseModels = isAutoMode ? visibleModels : models;
+              // Sort alphabetically by id for providers that ship rich model
+              // metadata (Nebius TokenFactory) so the order is stable across
+              // refetches; otherwise keep the given order.
+              const displayModels = baseModels.some((m) => hasModelMetadata(m))
+                ? [...baseModels].sort((a, b) => a.name.localeCompare(b.name))
+                : baseModels;
               const isFoldable = displayModels.length > FOLD_THRESHOLD;
               const shownModels =
                 isFoldable && !isExpanded


### PR DESCRIPTION
This PR runs GitHub Actions CI for #12306.

- [x] Override Linear Check

**This PR should be closed (not merged) after CI completes.**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Nebius TokenFactory as a first-class LLM provider with OpenAI-compatible model fetching and a new admin modal that surfaces per-model metadata. Also fixes masked API key resolution when editing saved providers and maps the provider to its icon by name.

- **New Features**
  - Added provider `nebius_tokenfactory` routed through the OpenAI-compatible path.
  - Backend: POST `/api/admin/llm/nebius-tokenfactory/available-models` calls `/v1/models?verbose=true`, filters out embeddings/rerankers, and maps context length, vision, reasoning, quantization, region, and per-request RPM; syncs fetched models when `provider_name` is set.
  - Frontend: new Nebius TokenFactory modal and icon; model picker shows compact metadata (context, country flag, quantization, features) with a vision marker, and sorts models by id; provider name now maps to the correct icon in model lists.

- **Bug Fixes**
  - `_resolve_api_key` now restores masked keys by `provider_id` (or by `provider_name`), only when `api_base` matches; fresh keys pass through unchanged. Tests added for key resolution and model mapping.
  - Tightened web types for Nebius responses and fetch params.

<sup>Written for commit 836d3536ee6372d9b64875237bdf91e25b85f7ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

