### PR TITLE
fix(search): bound document_filter LLM calls with a timeout (ENG-4238)

### DIFF
--- a/backend/onyx/configs/chat_configs.py
+++ b/backend/onyx/configs/chat_configs.py
@@ -41,6 +41,13 @@ LLM_FIRST_CHUNK_MAX_RETRIES = max(
 # Socket-read timeout for deep-research report calls — bounds inter-chunk gaps
 # (including a zero-chunk stall), not total generation time.
 DR_REPORT_LLM_TIMEOUT_S = int(os.environ.get("DR_REPORT_LLM_TIMEOUT_S") or "60")
+# Timeout for non-streaming secondary LLM flows (e.g. search section-relevance
+# classification and section-expansion selection). These are short, low-effort
+# calls; the bound exists so a stalled provider connection fails fast into the
+# existing graceful fallback instead of hanging a worker until liveness kills it.
+SECONDARY_LLM_FLOW_TIMEOUT_S = int(
+    os.environ.get("SECONDARY_LLM_FLOW_TIMEOUT_S") or "60"
+)
 # Live buffer TTL. Refreshed per write.
 CHAT_STREAM_BUFFER_TTL_S = int(os.environ.get("CHAT_STREAM_BUFFER_TTL_S") or 3600)
 # Retention after the run is done.

--- a/backend/onyx/secondary_llm_flows/document_filter.py
+++ b/backend/onyx/secondary_llm_flows/document_filter.py
@@ -1,6 +1,7 @@
 import json
 import re
 
+from onyx.configs.chat_configs import SECONDARY_LLM_FLOW_TIMEOUT_S
 from onyx.context.search.models import ContextExpansionType
 from onyx.context.search.models import InferenceChunk
 from onyx.context.search.models import InferenceSection
@@ -15,6 +16,7 @@ from onyx.tracing.flows import LLMFlow
 from onyx.tracing.llm_utils import llm_generation_span
 from onyx.tracing.llm_utils import record_llm_response
 from onyx.utils.logger import setup_logger
+from onyx.utils.timing import log_function_time
 
 logger = setup_logger()
 
@@ -90,6 +92,7 @@ def select_chunks_for_relevance(
     return all_chunks[start_index:end_index]
 
 
+@log_function_time(print_only=True)
 def classify_section_relevance(
     document_title: str,
     section_text: str,
@@ -133,6 +136,7 @@ def classify_section_relevance(
             response = llm.invoke(
                 prompt=prompt_msg,
                 reasoning_effort=ReasoningEffort.OFF,
+                timeout_override=SECONDARY_LLM_FLOW_TIMEOUT_S,
             )
             record_llm_response(span_generation, response)
             llm_response = response.choice.message.content
@@ -179,6 +183,7 @@ def classify_section_relevance(
     return classification
 
 
+@log_function_time(print_only=True)
 def select_sections_for_expansion(
     sections: list[InferenceSection],
     user_query: str,
@@ -283,7 +288,9 @@ def select_sections_for_expansion(
             input_messages=[prompt_text],
         ) as span_generation:
             response = llm.invoke(
-                prompt=[prompt_text], reasoning_effort=ReasoningEffort.OFF
+                prompt=[prompt_text],
+                reasoning_effort=ReasoningEffort.OFF,
+                timeout_override=SECONDARY_LLM_FLOW_TIMEOUT_S,
             )
             record_llm_response(span_generation, response)
             llm_response = response.choice.message.content

--- a/backend/tests/unit/onyx/secondary_llm_flows/test_document_filter.py
+++ b/backend/tests/unit/onyx/secondary_llm_flows/test_document_filter.py
@@ -4,15 +4,46 @@ from unittest.mock import MagicMock
 from unittest.mock import patch
 
 from onyx.configs.chat_configs import SECONDARY_LLM_FLOW_TIMEOUT_S
+from onyx.configs.constants import DocumentSource
 from onyx.context.search.models import ContextExpansionType
+from onyx.context.search.models import InferenceChunk
+from onyx.context.search.models import InferenceSection
 from onyx.llm.interfaces import LLM
 from onyx.llm.multi_llm import LLMTimeoutError
 from onyx.secondary_llm_flows.document_filter import classify_section_relevance
+from onyx.secondary_llm_flows.document_filter import select_sections_for_expansion
 
 
 @contextmanager
 def _noop_span() -> Iterator[MagicMock]:
     yield MagicMock()
+
+
+def _make_section() -> InferenceSection:
+    chunk = InferenceChunk(
+        document_id="doc-1",
+        chunk_id=0,
+        content="section content",
+        source_type=DocumentSource.MOCK_CONNECTOR,
+        semantic_identifier="sem-doc-1",
+        title="doc-1",
+        boost=1,
+        score=0.5,
+        hidden=False,
+        metadata={},
+        match_highlights=[],
+        doc_summary="",
+        chunk_context="",
+        updated_at=None,
+        image_file_id=None,
+        source_links={},
+        section_continuation=False,
+        blurb="blurb",
+        file_id=None,
+    )
+    return InferenceSection(
+        center_chunk=chunk, chunks=[chunk], combined_content=chunk.content
+    )
 
 
 def _make_llm(invoke: MagicMock) -> LLM:
@@ -72,4 +103,49 @@ def test_classify_section_relevance_passes_timeout_on_success(
     )
 
     assert result == ContextExpansionType.FULL_DOCUMENT
+    assert invoke.call_args.kwargs["timeout_override"] == SECONDARY_LLM_FLOW_TIMEOUT_S
+
+
+@patch("onyx.secondary_llm_flows.document_filter.record_llm_response")
+@patch(
+    "onyx.secondary_llm_flows.document_filter.llm_generation_span",
+    return_value=_noop_span(),
+)
+def test_select_sections_for_expansion_timeout_falls_back(
+    _span: MagicMock, _record: MagicMock
+) -> None:
+    """A timed-out selection call must degrade to returning the input sections
+    (capped) instead of propagating and hanging the worker."""
+    sections = [_make_section()]
+    invoke = MagicMock(side_effect=LLMTimeoutError("timed out"))
+    llm = _make_llm(invoke)
+
+    selected, doc_ids = select_sections_for_expansion(
+        sections=sections, user_query="q", llm=llm, max_sections=10
+    )
+
+    assert selected == sections
+    assert doc_ids is None
+    assert invoke.call_args.kwargs["timeout_override"] == SECONDARY_LLM_FLOW_TIMEOUT_S
+
+
+@patch("onyx.secondary_llm_flows.document_filter.record_llm_response")
+@patch(
+    "onyx.secondary_llm_flows.document_filter.llm_generation_span",
+    return_value=_noop_span(),
+)
+def test_select_sections_for_expansion_passes_timeout_on_success(
+    _span: MagicMock, _record: MagicMock
+) -> None:
+    sections = [_make_section()]
+    response = MagicMock()
+    response.choice.message.content = "[0]"
+    invoke = MagicMock(return_value=response)
+    llm = _make_llm(invoke)
+
+    selected, _doc_ids = select_sections_for_expansion(
+        sections=sections, user_query="q", llm=llm, max_sections=10
+    )
+
+    assert selected == sections
     assert invoke.call_args.kwargs["timeout_override"] == SECONDARY_LLM_FLOW_TIMEOUT_S

--- a/backend/tests/unit/onyx/secondary_llm_flows/test_document_filter.py
+++ b/backend/tests/unit/onyx/secondary_llm_flows/test_document_filter.py
@@ -1,0 +1,75 @@
+from collections.abc import Iterator
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from onyx.configs.chat_configs import SECONDARY_LLM_FLOW_TIMEOUT_S
+from onyx.context.search.models import ContextExpansionType
+from onyx.llm.interfaces import LLM
+from onyx.llm.multi_llm import LLMTimeoutError
+from onyx.secondary_llm_flows.document_filter import classify_section_relevance
+
+
+@contextmanager
+def _noop_span() -> Iterator[MagicMock]:
+    yield MagicMock()
+
+
+def _make_llm(invoke: MagicMock) -> LLM:
+    llm = MagicMock(spec=LLM)
+    llm.invoke = invoke
+    return llm
+
+
+@patch("onyx.secondary_llm_flows.document_filter.record_llm_response")
+@patch(
+    "onyx.secondary_llm_flows.document_filter.llm_generation_span",
+    return_value=_noop_span(),
+)
+def test_classify_section_relevance_timeout_falls_back(
+    _span: MagicMock, _record: MagicMock
+) -> None:
+    """A timed-out classification call must degrade to the safe default instead
+    of propagating, so a stalled provider can't hang the worker."""
+    invoke = MagicMock(side_effect=LLMTimeoutError("timed out"))
+    llm = _make_llm(invoke)
+
+    result = classify_section_relevance(
+        document_title="Doc",
+        section_text="body",
+        user_query="q",
+        llm=llm,
+        # surrounding text present so the no-context post-adjustment is not applied
+        section_above_text="above",
+        section_below_text="below",
+    )
+
+    assert result == ContextExpansionType.MAIN_SECTION_ONLY
+    # the bound that makes the call fail fast must actually be passed through
+    assert invoke.call_args.kwargs["timeout_override"] == SECONDARY_LLM_FLOW_TIMEOUT_S
+
+
+@patch("onyx.secondary_llm_flows.document_filter.record_llm_response")
+@patch(
+    "onyx.secondary_llm_flows.document_filter.llm_generation_span",
+    return_value=_noop_span(),
+)
+def test_classify_section_relevance_passes_timeout_on_success(
+    _span: MagicMock, _record: MagicMock
+) -> None:
+    response = MagicMock()
+    response.choice.message.content = "3"  # FULL_DOCUMENT
+    invoke = MagicMock(return_value=response)
+    llm = _make_llm(invoke)
+
+    result = classify_section_relevance(
+        document_title="Doc",
+        section_text="body",
+        user_query="q",
+        llm=llm,
+        section_above_text="above",
+        section_below_text="below",
+    )
+
+    assert result == ContextExpansionType.FULL_DOCUMENT
+    assert invoke.call_args.kwargs["timeout_override"] == SECONDARY_LLM_FLOW_TIMEOUT_S


### PR DESCRIPTION
## Description

`classify_section_relevance()` and `select_sections_for_expansion()` in `backend/onyx/secondary_llm_flows/document_filter.py` called `llm.invoke()` with **no timeout**. A stalled provider connection (`litellm.Timeout: Connection timed out after None seconds`) hangs the worker until the api-server liveness probe SIGKILLs the pod (exit 137, not OOM), dropping all in-flight chat/search streams — observed in prod as "Claude Internal Search errors." Present in v4.0.7 and v4.2.0; an upgrade does not fix it.

Changes:
- New config `SECONDARY_LLM_FLOW_TIMEOUT_S` (default **60s**, env-overridable) in `configs/chat_configs.py`.
- Pass `timeout_override=SECONDARY_LLM_FLOW_TIMEOUT_S` to **both** `llm.invoke()` calls. Both already sit in `try/except` that degrades to a safe default, so a timeout now **fails fast into the existing fallback** (search still returns, just without LLM-optimized section selection) instead of hanging a worker.
- Added `@log_function_time(print_only=True)` to both flows so per-call latency lands in Loki/Prometheus (it was previously only in Braintrust, tagged by flow) — lets us tune the timeout on data.

Why 60s is safe regardless of exact percentiles: the failure mode is graceful degradation, and 60s is already more lenient than the current ~30s liveness-kill window (3×10s), so it can only reduce blast radius. These are `ReasoningEffort.OFF` classification calls (single-digit-second p50), so 60s only ever catches the pathological hang.

Linear: ENG-4238 (related: ENG-4236 streaming-consumer bound).

## How Has This Been Tested?

New unit test `backend/tests/unit/onyx/secondary_llm_flows/test_document_filter.py` (2 cases, passing): a timed-out `invoke` (`LLMTimeoutError`) degrades to the default classification, and `timeout_override` is passed on both the timeout and success paths. `ruff check` / `ruff format` clean; mypy clean on changed files.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a 60s timeout to document-filter secondary LLM calls so stalled providers fail fast and search degrades gracefully instead of dropping streams. Addresses Linear ENG-4238.

- **Bug Fixes**
  - Introduced `SECONDARY_LLM_FLOW_TIMEOUT_S` (default 60s; env-overridable) and passed `timeout_override` to `llm.invoke()` in `classify_section_relevance` and `select_sections_for_expansion`.
  - Timeouts now fall into existing try/except fallbacks, preventing liveness-kill-induced stream drops; added `@log_function_time(print_only=True)` on both flows for per-call latency.
  - Added unit tests covering timeout fallback and success-path timeout propagation for both flows, including the `select_sections_for_expansion` timeout path.

<sup>Written for commit 560c46664423c5d2e33723f8368c6e61b9f74a18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

