### PR TITLE
feat(craft): add sandbox-pod egress NetworkPolicy

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.6.6
+version: 0.6.7
 appVersion: latest
 annotations:
   category: Productivity
@@ -17,9 +17,11 @@ annotations:
       image: docker.io/onyxdotapp/onyx-backend:latest
   artifacthub.io/changes: |
     - kind: security
-      description: Add an egress NetworkPolicy on the Craft sandbox egress proxy that blocks the
-        link-local / cloud-metadata range (169.254.0.0/16), so a sandbox can't use the proxy as an
-        SSRF pivot to the node's IMDS credentials. Internet, DNS, and datastores remain reachable.
+      description: Add an egress NetworkPolicy on the Craft sandbox pods restricting their egress to
+        the sandbox proxy (:8080) and kube-dns (:53) only. CNI-layer backstop to the in-pod iptables
+        in firewall-init.sh, so a sandbox that bypasses that iptables still cannot reach anything but
+        the proxy. DNS is allowed because sandbox-init resolves the proxy FQDN before its iptables
+        closes DNS.
 dependencies:
   - name: cloudnative-pg
     version: 0.26.0

--- a/deployment/helm/charts/onyx/templates/network-policy-sandbox-egress.yaml
+++ b/deployment/helm/charts/onyx/templates/network-policy-sandbox-egress.yaml
@@ -1,26 +1,11 @@
 {{- if eq (include "onyx.craftEnabled" .) "true" }}
 {{- $sandboxNs := (index (.Values.configMap | default (dict)) "SANDBOX_NAMESPACE") | default "onyx-sandboxes" }}
 {{- $proxyNs := (index (.Values.configMap | default (dict)) "SANDBOX_PROXY_NAMESPACE") | default $.Release.Namespace }}
-# Egress lockdown for the Craft sandbox pods themselves (CNI-layer defense-in-depth).
-#
-# A sandbox is only supposed to reach the network through the egress proxy. At runtime that is
-# enforced by the in-pod iptables the sandbox-init container installs (firewall-init.sh, NET_ADMIN):
-# OUTPUT policy DROP, allowing only the resolved proxy IP on its port. This NetworkPolicy makes the
-# same "only talks to the proxy (+ DNS)" property a declarative, auditable network fact at the CNI
-# layer, so it still holds if the in-pod iptables is ever bypassed. It only takes effect on clusters
-# whose CNI enforces NetworkPolicy; where it isn't enforced it is inert (the in-pod iptables still
-# applies). Companion to the proxy-side egress policy (templates/sandbox-proxy/networkpolicy-egress.yaml).
-#
-# Egress is allowed ONLY to:
-#   1. the egress proxy (release ns / component=sandbox-proxy : 8080) — all sandbox HTTP(S) funnels
-#      here via HTTPS_PROXY + the in-pod iptables redirect; the proxy resolves & fetches real targets.
-#   2. kube-dns (UDP+TCP 53) — firewall-init.sh resolves the proxy FQDN (SANDBOX_PROXY_HOST) via
-#      getent before it closes DNS in its own iptables; that lookup runs in the pod netns this policy
-#      governs (NetworkPolicy egress applies to init containers too), so blocking DNS bricks every
-#      sandbox at init.
-# Everything else is denied by the default-deny this policy establishes. Enforced per pod IP, so it
-# does NOT cover a host-netns escape (egresses via the node IP) — that is handled by node-level
-# IMDSv2 + hop-limit=1.
+# CNI-layer egress allow-list for Craft sandbox pods: proxy + DNS only, default-deny. Declarative
+# backstop to the in-pod iptables, which is the authoritative runtime control (see firewall-init.sh);
+# only enforced where the CNI honors NetworkPolicy, inert otherwise. DNS must stay allowed or
+# sandbox-init's proxy-FQDN resolution breaks. Each ipBlock is its own egress rule per the IPv4/IPv6
+# fail-closed caveat documented in the proxy-side policy (templates/sandbox-proxy/networkpolicy-egress.yaml).
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -32,11 +17,7 @@ spec:
       app.kubernetes.io/component: sandbox
   policyTypes: [Egress]
   egress:
-    # 1. The egress proxy. Defaults to the release namespace but honors a SANDBOX_PROXY_NAMESPACE
-    #    override (shared proxy outside the release ns), matching the derivation in sandbox-rbac.yaml.
-    #    Selects the proxy POD by label (the Service is named *-sandbox-proxy; NetworkPolicy matches
-    #    pod labels, not Service names). The CNI evaluates egress on the post-DNAT pod IP, so
-    #    sandbox -> proxy ClusterIP -> proxy pod matches.
+    # Egress proxy pod ($proxyNs = SANDBOX_PROXY_NAMESPACE or release ns; matched by pod label, not Service).
     - to:
         - namespaceSelector:
             matchLabels:
@@ -47,14 +28,7 @@ spec:
       ports:
         - protocol: TCP
           port: {{ include "onyx.sandboxProxyPort" . }}
-    # 1b. Proxy reached as a non-pod peer, when configured. The rule above selects the proxy by pod
-    #     label, but SANDBOX_PROXY_HOST may be overridden to a target that isn't a chart-labeled pod —
-    #     an external proxy (FQDN/IP) or a Service whose backing pods lack app.kubernetes.io/component:
-    #     sandbox-proxy. firewall-init.sh resolves and allows whatever the env var points at, but a
-    #     NetworkPolicy can't follow a hostname, so on those topologies the podSelector misses and all
-    #     sandbox egress is dropped. Operators using such a proxy set craft.proxyExtraCIDRs to its
-    #     CIDR(s); empty by default (the chart-deployed proxy is covered by the podSelector). Each CIDR
-    #     is its OWN egress rule per the IPv4/IPv6 ipBlock fail-closed caveat on AWS VPC CNI.
+    # Proxy by CIDR (craft.proxyExtraCIDRs) when SANDBOX_PROXY_HOST points at a non-chart-labeled target.
     {{- range (index (.Values.craft | default (dict)) "proxyExtraCIDRs" | default list) }}
     - to:
         - ipBlock:
@@ -63,7 +37,7 @@ spec:
         - protocol: TCP
           port: {{ include "onyx.sandboxProxyPort" $ }}
     {{- end }}
-    # 2. kube-dns (CoreDNS in kube-system) — needed by firewall-init.sh to resolve the proxy FQDN.
+    # kube-dns.
     - to:
         - namespaceSelector:
             matchLabels:
@@ -76,14 +50,7 @@ spec:
           port: 53
         - protocol: TCP
           port: 53
-    # 2b. NodeLocal DNS (or any non-pod cluster DNS listener), when configured. A NodeLocal DNS
-    #     cache is a hostNetwork endpoint, NOT a CoreDNS pod, so the kube-dns podSelector above
-    #     can't match it; its listen IP is cluster-specific (commonly 169.254.20.10 but not fixed).
-    #     Without an allow here its query hits the default-deny, failing firewall-init.sh's getent
-    #     and bricking sandbox init. Operators on such clusters set craft.dnsExtraCIDRs to the
-    #     actual listener IP(s); empty by default (plain CoreDNS resolves via the podSelector alone).
-    #     Each CIDR is its OWN egress rule per the IPv4/IPv6 ipBlock fail-closed caveat on AWS VPC
-    #     CNI (one IPv4+IPv6 `to:` list drops all egress) — see the proxy-side policy.
+    # NodeLocal DNS / non-pod DNS listeners (craft.dnsExtraCIDRs), e.g. 169.254.20.10/32.
     {{- range (index (.Values.craft | default (dict)) "dnsExtraCIDRs" | default list) }}
     - to:
         - ipBlock:

--- a/deployment/helm/charts/onyx/templates/network-policy-sandbox-egress.yaml
+++ b/deployment/helm/charts/onyx/templates/network-policy-sandbox-egress.yaml
@@ -1,5 +1,5 @@
 {{- if eq (include "onyx.craftEnabled" .) "true" }}
-{{- $sandboxNs := .Values.configMap.SANDBOX_NAMESPACE | default "onyx-sandboxes" }}
+{{- $sandboxNs := (index (.Values.configMap | default (dict)) "SANDBOX_NAMESPACE") | default "onyx-sandboxes" }}
 # Egress lockdown for the Craft sandbox pods themselves (CNI-layer defense-in-depth).
 #
 # A sandbox is only supposed to reach the network through the egress proxy. At runtime that is

--- a/deployment/helm/charts/onyx/templates/network-policy-sandbox-egress.yaml
+++ b/deployment/helm/charts/onyx/templates/network-policy-sandbox-egress.yaml
@@ -47,6 +47,22 @@ spec:
       ports:
         - protocol: TCP
           port: {{ include "onyx.sandboxProxyPort" . }}
+    # 1b. Proxy reached as a non-pod peer, when configured. The rule above selects the proxy by pod
+    #     label, but SANDBOX_PROXY_HOST may be overridden to a target that isn't a chart-labeled pod —
+    #     an external proxy (FQDN/IP) or a Service whose backing pods lack app.kubernetes.io/component:
+    #     sandbox-proxy. firewall-init.sh resolves and allows whatever the env var points at, but a
+    #     NetworkPolicy can't follow a hostname, so on those topologies the podSelector misses and all
+    #     sandbox egress is dropped. Operators using such a proxy set craft.proxyExtraCIDRs to its
+    #     CIDR(s); empty by default (the chart-deployed proxy is covered by the podSelector). Each CIDR
+    #     is its OWN egress rule per the IPv4/IPv6 ipBlock fail-closed caveat on AWS VPC CNI.
+    {{- range (index (.Values.craft | default (dict)) "proxyExtraCIDRs" | default list) }}
+    - to:
+        - ipBlock:
+            cidr: {{ . | quote }}
+      ports:
+        - protocol: TCP
+          port: {{ include "onyx.sandboxProxyPort" $ }}
+    {{- end }}
     # 2. kube-dns (CoreDNS in kube-system) — needed by firewall-init.sh to resolve the proxy FQDN.
     - to:
         - namespaceSelector:

--- a/deployment/helm/charts/onyx/templates/network-policy-sandbox-egress.yaml
+++ b/deployment/helm/charts/onyx/templates/network-policy-sandbox-egress.yaml
@@ -1,5 +1,6 @@
 {{- if eq (include "onyx.craftEnabled" .) "true" }}
 {{- $sandboxNs := (index (.Values.configMap | default (dict)) "SANDBOX_NAMESPACE") | default "onyx-sandboxes" }}
+{{- $proxyNs := (index (.Values.configMap | default (dict)) "SANDBOX_PROXY_NAMESPACE") | default $.Release.Namespace }}
 # Egress lockdown for the Craft sandbox pods themselves (CNI-layer defense-in-depth).
 #
 # A sandbox is only supposed to reach the network through the egress proxy. At runtime that is
@@ -31,13 +32,15 @@ spec:
       app.kubernetes.io/component: sandbox
   policyTypes: [Egress]
   egress:
-    # 1. The egress proxy in the release namespace. Selects the proxy POD by label (the Service is
-    #    named *-sandbox-proxy; NetworkPolicy matches pod labels, not Service names). The CNI
-    #    evaluates egress on the post-DNAT pod IP, so sandbox -> proxy ClusterIP -> proxy pod matches.
+    # 1. The egress proxy. Defaults to the release namespace but honors a SANDBOX_PROXY_NAMESPACE
+    #    override (shared proxy outside the release ns), matching the derivation in sandbox-rbac.yaml.
+    #    Selects the proxy POD by label (the Service is named *-sandbox-proxy; NetworkPolicy matches
+    #    pod labels, not Service names). The CNI evaluates egress on the post-DNAT pod IP, so
+    #    sandbox -> proxy ClusterIP -> proxy pod matches.
     - to:
         - namespaceSelector:
             matchLabels:
-              kubernetes.io/metadata.name: {{ $.Release.Namespace }}
+              kubernetes.io/metadata.name: {{ $proxyNs }}
           podSelector:
             matchLabels:
               app.kubernetes.io/component: sandbox-proxy

--- a/deployment/helm/charts/onyx/templates/network-policy-sandbox-egress.yaml
+++ b/deployment/helm/charts/onyx/templates/network-policy-sandbox-egress.yaml
@@ -57,4 +57,22 @@ spec:
           port: 53
         - protocol: TCP
           port: 53
+    # 2b. NodeLocal DNS (or any non-pod cluster DNS listener), when configured. A NodeLocal DNS
+    #     cache is a hostNetwork endpoint, NOT a CoreDNS pod, so the kube-dns podSelector above
+    #     can't match it; its listen IP is cluster-specific (commonly 169.254.20.10 but not fixed).
+    #     Without an allow here its query hits the default-deny, failing firewall-init.sh's getent
+    #     and bricking sandbox init. Operators on such clusters set craft.dnsExtraCIDRs to the
+    #     actual listener IP(s); empty by default (plain CoreDNS resolves via the podSelector alone).
+    #     Each CIDR is its OWN egress rule per the IPv4/IPv6 ipBlock fail-closed caveat on AWS VPC
+    #     CNI (one IPv4+IPv6 `to:` list drops all egress) — see the proxy-side policy.
+    {{- range (index (.Values.craft | default (dict)) "dnsExtraCIDRs" | default list) }}
+    - to:
+        - ipBlock:
+            cidr: {{ . | quote }}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    {{- end }}
 {{- end }}

--- a/deployment/helm/charts/onyx/templates/network-policy-sandbox-egress.yaml
+++ b/deployment/helm/charts/onyx/templates/network-policy-sandbox-egress.yaml
@@ -1,0 +1,60 @@
+{{- if eq (include "onyx.craftEnabled" .) "true" }}
+{{- $sandboxNs := .Values.configMap.SANDBOX_NAMESPACE | default "onyx-sandboxes" }}
+# Egress lockdown for the Craft sandbox pods themselves (CNI-layer defense-in-depth).
+#
+# A sandbox is only supposed to reach the network through the egress proxy. At runtime that is
+# enforced by the in-pod iptables the sandbox-init container installs (firewall-init.sh, NET_ADMIN):
+# OUTPUT policy DROP, allowing only the resolved proxy IP on its port. This NetworkPolicy makes the
+# same "only talks to the proxy (+ DNS)" property a declarative, auditable network fact at the CNI
+# layer, so it still holds if the in-pod iptables is ever bypassed. It only takes effect on clusters
+# whose CNI enforces NetworkPolicy; where it isn't enforced it is inert (the in-pod iptables still
+# applies). Companion to the proxy-side egress policy (templates/sandbox-proxy/networkpolicy-egress.yaml).
+#
+# Egress is allowed ONLY to:
+#   1. the egress proxy (release ns / component=sandbox-proxy : 8080) — all sandbox HTTP(S) funnels
+#      here via HTTPS_PROXY + the in-pod iptables redirect; the proxy resolves & fetches real targets.
+#   2. kube-dns (UDP+TCP 53) — firewall-init.sh resolves the proxy FQDN (SANDBOX_PROXY_HOST) via
+#      getent before it closes DNS in its own iptables; that lookup runs in the pod netns this policy
+#      governs (NetworkPolicy egress applies to init containers too), so blocking DNS bricks every
+#      sandbox at init.
+# Everything else is denied by the default-deny this policy establishes. Enforced per pod IP, so it
+# does NOT cover a host-netns escape (egresses via the node IP) — that is handled by node-level
+# IMDSv2 + hop-limit=1.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "onyx.fullname" . }}-sandbox-egress
+  namespace: {{ $sandboxNs }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: sandbox
+  policyTypes: [Egress]
+  egress:
+    # 1. The egress proxy in the release namespace. Selects the proxy POD by label (the Service is
+    #    named *-sandbox-proxy; NetworkPolicy matches pod labels, not Service names). The CNI
+    #    evaluates egress on the post-DNAT pod IP, so sandbox -> proxy ClusterIP -> proxy pod matches.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ $.Release.Namespace }}
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/component: sandbox-proxy
+      ports:
+        - protocol: TCP
+          port: {{ include "onyx.sandboxProxyPort" . }}
+    # 2. kube-dns (CoreDNS in kube-system) — needed by firewall-init.sh to resolve the proxy FQDN.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+{{- end }}

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1543,6 +1543,15 @@ craft:
   # listener IP(s), e.g. ["169.254.20.10/32"]. Empty (default) = standard CoreDNS, resolved via
   # the podSelector alone (no NodeLocal DNS).
   dnsExtraCIDRs: []
+  # CIDR(s) of the egress proxy when it is NOT a chart-labeled pod. The sandbox-egress NetworkPolicy
+  # selects the proxy by pod label (app.kubernetes.io/component: sandbox-proxy), but
+  # configMap.SANDBOX_PROXY_HOST may be overridden to an external proxy (FQDN/IP) or a Service whose
+  # pods don't carry that label. firewall-init.sh allows whatever the host resolves to, but a
+  # NetworkPolicy can't follow a hostname, so on NP-enforcing clusters such a proxy is dropped and
+  # all sandbox egress breaks. Set this to the proxy CIDR(s), e.g. ["10.0.5.6/32"], on those setups.
+  # Empty (default) = the chart-deployed proxy, covered by the podSelector (incl. the
+  # SANDBOX_PROXY_NAMESPACE shared-proxy path); leave empty unless you point at a non-pod proxy.
+  proxyExtraCIDRs: []
 
 # -- Sandbox Pod scheduling (rendered into the sandbox-pod PodTemplate).
 # Image/resources/ports come from the configMap.SANDBOX_* keys.

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1535,6 +1535,14 @@ configMap:
 craft:
   # Extra SAs (release ns) to also grant sandbox RBAC, e.g. a separate worker SA.
   extraBoundServiceAccounts: []
+  # CIDR(s) of any non-pod cluster DNS listener the sandbox must reach for firewall-init.sh's
+  # proxy-FQDN getent lookup. A NodeLocal DNS cache is a hostNetwork endpoint (its listen IP is
+  # cluster-specific — commonly 169.254.20.10, but configurable), so it is not a CoreDNS pod and
+  # the kube-dns podSelector in the sandbox-egress NetworkPolicy can't match it; without an allow
+  # here its DNS query hits the default-deny and bricks sandbox init. Set this to the actual
+  # listener IP(s), e.g. ["169.254.20.10/32"]. Empty (default) = standard CoreDNS, resolved via
+  # the podSelector alone (no NodeLocal DNS).
+  dnsExtraCIDRs: []
 
 # -- Sandbox Pod scheduling (rendered into the sandbox-pod PodTemplate).
 # Image/resources/ports come from the configMap.SANDBOX_* keys.


### PR DESCRIPTION
## Description

Companion to #12229 (proxy egress) on the **other side** of the sandbox boundary, and the missing
network-layer half that pairs with #12242 (the proxy's app-layer internal-destination block).

A Craft sandbox is only supposed to reach the network through the egress proxy. At runtime that is
enforced by the in-pod iptables the `sandbox-init` container installs (`firewall-init.sh`, `NET_ADMIN`):
`OUTPUT` policy `DROP`, allowing only the resolved proxy IP. This PR adds a **CNI-layer NetworkPolicy on
the sandbox pods** restricting egress to:

1. the egress proxy — `app.kubernetes.io/component: sandbox-proxy`, TCP `8080`, in the **proxy namespace**
   (defaults to the release namespace, honors a `SANDBOX_PROXY_NAMESPACE` override; plus any
   `craft.proxyExtraCIDRs` for a non-pod proxy, see below);
2. kube-dns — `kube-system`, `k8s-app: kube-dns`, UDP+TCP `53` (plus any `craft.dnsExtraCIDRs` for
   NodeLocal DNS, see below).

Everything else is denied. It's a declarative backstop so "only talks to the proxy (+ DNS)" still holds
if the in-pod iptables is ever bypassed (e.g. `NET_ADMIN` regained in-container). Gated on
`ENABLE_CRAFT`; inert on clusters whose CNI doesn't enforce NetworkPolicy (the in-pod iptables still
applies there).

**DNS must be allowed:** `sandbox-init` resolves the proxy FQDN via `getent` before its iptables closes
DNS, and NetworkPolicy egress applies to init containers — so denying DNS would brick every sandbox at
init.

### Proxy-host override behavior

The egress proxy is the Onyx-managed mitmproxy (trusted via the Onyx CA baked into the sandbox image,
injects credentials server-side) — not a swappable generic proxy. So the only **supported** override of
`SANDBOX_PROXY_HOST` is relocating *that same chart proxy* (e.g. a shared instance in another namespace),
which is a chart-labeled `component=sandbox-proxy` pod and is fully covered by the proxy podSelector +
`SANDBOX_PROXY_NAMESPACE`. Pointing the host at an arbitrary external/non-chart proxy is not a supported
topology (it breaks TLS interception and credential injection regardless of any NetworkPolicy).

`craft.proxyExtraCIDRs` is therefore just a **safety valve**, not an endorsed config: the two enforcement
layers source "where the proxy is" differently (`firewall-init.sh` resolves the host at runtime and allows
the IP; a NetworkPolicy is static/label-based and can't follow a hostname), so if someone does point the
host at a non-pod target, this lets them re-open egress to it rather than silently breaking.

| `SANDBOX_PROXY_HOST` target | Supported? | NetworkPolicy |
| --- | --- | --- |
| Default chart Service DNS | ✅ yes | matches (chart-labeled pods) |
| Chart-deployed proxy in another ns (+ `SANDBOX_PROXY_NAMESPACE`) | ✅ yes | matches |
| Service w/o `component=sandbox-proxy` pods / external proxy | ⚠️ not a supported topology | misses → safety valve: set `craft.proxyExtraCIDRs` |

### Portability / robustness (review follow-ups)

- **Proxy namespace is configurable.** The proxy egress rule derives its namespace from
  `configMap.SANDBOX_PROXY_NAMESPACE` (default `$.Release.Namespace`), matching the existing derivation in
  `sandbox-rbac.yaml`. Without this, a shared proxy in another namespace (reached via `SANDBOX_PROXY_HOST`)
  would be dropped once the policy selects sandbox pods, breaking all sandbox egress.
- **Non-pod proxy safety valve.** Added a `craft.proxyExtraCIDRs` list (empty by default) for the
  not-officially-supported case where `SANDBOX_PROXY_HOST` is pointed at a target the label selector can't
  match (external proxy or a Service without `component=sandbox-proxy` pods). iptables allows it but the
  static, label-based policy can't follow a hostname, so egress would otherwise be dropped on NP-enforcing
  clusters; listing the proxy CIDR(s) re-opens it (one ipBlock egress rule each, on the proxy port). Empty
  default = the supported chart-deployed proxy stays covered by the podSelector (incl. the
  `SANDBOX_PROXY_NAMESPACE` path) and nothing changes.
- **NodeLocal DNS support.** Added a `craft.dnsExtraCIDRs` list (empty by default). The `kube-dns`
  podSelector can't match a NodeLocal DNS cache (a hostNetwork endpoint, not a CoreDNS pod, with a
  cluster-specific listen IP); operators on such clusters list the listener CIDR(s) and each renders as its
  own ipBlock egress rule on `53`. Empty default = standard CoreDNS resolves via the podSelector alone.
- **Nil-safe Helm lookups.** `SANDBOX_NAMESPACE` / `SANDBOX_PROXY_NAMESPACE` reads are guarded with
  `default (dict)` so render can't nil-deref when `.Values.configMap` is absent (e.g. `helm --reuse-values`).

Each ipBlock above is kept in its own egress rule per the IPv4/IPv6 ipBlock fail-closed caveat on AWS VPC
CNI (one IPv4+IPv6 `to:` list drops all egress).

Chart bumped `0.6.6` -> `0.6.7`.

> Why this wasn't in #12229: that PR locked down the proxy's egress; the sandbox pod's own egress had no
> CNI policy (only the in-pod iptables). This closes that gap.

## How Has This Been Tested?

- `helm template` (`ENABLE_CRAFT=true`) renders the policy; craft disabled renders nothing (gated).
  Verified rendering of the follow-ups: default proxy nsSelector = release ns and follows
  `SANDBOX_PROXY_NAMESPACE` when set; `craft.proxyExtraCIDRs` / `craft.dnsExtraCIDRs` each render one
  isolated ipBlock egress rule per CIDR (on the proxy port / `53` respectively, none by default);
  rendering succeeds with `.Values.configMap` absent.
- **Live on `onyx-craft-dev` (EKS, VPC CNI enforcing)** — before/after on a `component=sandbox` test pod:
  - **Default config:** DNS resolves, `proxy:8080` (release ns) reachable, external egress (`1.1.1.1:443`,
    `example.com`) blocked; all open with the policy removed (control).
  - **`SANDBOX_PROXY_NAMESPACE` override (causal, both directions):** with the override pointing at a proxy
    pod in a second namespace, the sandbox reaches **that** proxy (allowed) while the proxy in the release
    namespace is now **blocked** — proving the selector tracks the override (the old hardcoded version would
    invert this and break egress). DNS allowed, external blocked throughout.
  - The `proxyExtraCIDRs` ipBlock path uses the same ipBlock primitive already validated on this cluster
    (proxy-side policy + `dnsExtraCIDRs`); verified by render + YAML parse.
- **End-to-end on a live provisioned sandbox** (earlier validation): LLM/web fetches (`example.com`,
  GitHub, npm, pypi, `api.openai.com`) return `200` both at baseline and with the egress policy enforced —
  no regression.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a NetworkPolicy that locks down Craft sandbox pod egress to the sandbox proxy and DNS as a CNI-layer backstop to in-pod iptables. Gated behind `ENABLE_CRAFT`; no effect if the cluster’s CNI doesn’t enforce NetworkPolicy.

- **New Features**
  - Allow egress only to the sandbox proxy (TCP 8080) and DNS (UDP/TCP 53); deny all other egress.

- **Bug Fixes**
  - Honor `SANDBOX_PROXY_NAMESPACE` when selecting the proxy; default to the release namespace.
  - Add `craft.dnsExtraCIDRs` to allow NodeLocal DNS IPs (UDP/TCP 53) when present; empty by default.
  - Make `SANDBOX_NAMESPACE` Helm lookup nil-safe when `.Values.configMap` is absent.

<sup>Written for commit fd884a087a00b7856719768021b9e38a60710e73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-light.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
