### PR TITLE
docs(audit): customer-facing SIEM integration guide + Splunk/Sentinel/Elastic shipper configs

### DIFF
--- a/docs/AUDIT_LOGGING.md
+++ b/docs/AUDIT_LOGGING.md
@@ -78,10 +78,13 @@ them). Current taxonomy (`AuditAction` in `backend/onyx/utils/audit.py`):
   `api_key.{create,regenerate,delete}`, `credential.{create,update,delete}`,
   `credential.access`
 
-> Most actions are wired to call sites. A few (`user.create`,
-> `user.group_change`, `auth.password_reset`) are defined ahead of their
-> instrumentation and land in follow-up PRs, so consumers can build dashboards
-> against the full taxonomy now.
+**Emitted today.** All of the above fire at real call sites **except** three
+that are defined ahead of their instrumentation and land in follow-up work:
+`auth.password_reset`, `user.create` (admin-invite flow), and
+`user.group_change` (Enterprise user groups). Everything else — every auth,
+admin-config, access-control, and credential event listed — is live. Building
+dashboards/alerts against the full taxonomy is safe; those three simply won't
+appear until wired.
 
 ### Example event
 
@@ -145,6 +148,68 @@ Example **Fluent Bit** grep filter:
     Match   onyx.*
     Regex   logger ^onyx\.audit
 ```
+
+### Splunk (HTTP Event Collector)
+
+Ship the filtered audit stream to a Splunk HEC endpoint, e.g. via Fluent Bit.
+Set `sourcetype` to `_json` so Splunk parses the event body, and route to a
+dedicated index (e.g. `onyx_audit`) for retention/RBAC:
+
+```ini
+[OUTPUT]
+    Name             splunk
+    Match            onyx.*
+    Host             splunk-hec.example.com
+    Port             8088
+    Splunk_Token     ${SPLUNK_HEC_TOKEN}
+    Splunk_Send_Raw  On
+    event_sourcetype _json
+    event_index      onyx_audit
+```
+
+Then in Splunk, e.g.: `index=onyx_audit action=auth.login_failure | stats count by actor.email, source_ip`.
+
+### Microsoft Sentinel (Azure Monitor)
+
+Use the Azure Monitor / Log Analytics agent (or a Vector `azure_monitor_logs`
+sink) to send the parsed JSON to a custom table (`OnyxAudit_CL`). With Vector:
+
+```toml
+[sinks.sentinel]
+type = "azure_monitor_logs"
+inputs = ["onyx_audit_parsed"]
+customer_id = "${LOG_ANALYTICS_WORKSPACE_ID}"
+shared_key = "${LOG_ANALYTICS_SHARED_KEY}"
+log_type = "OnyxAudit"
+```
+
+Query with KQL: `OnyxAudit_CL | where action_s == "user.role_change" | project TimeGenerated, actor_email_s, resource_id_s, extra_new_role_s`.
+
+### Elastic (Filebeat / Elastic Agent)
+
+Tail the `backend/log/*.log` files (or container stdout) and decode the JSON body:
+
+```yaml
+filebeat.inputs:
+  - type: filestream
+    paths: ["/app/backend/log/*.log"]
+    parsers:
+      - ndjson:
+          target: ""
+          message_key: message
+processors:
+  - drop_event:
+      when:
+        not:
+          regexp:
+            logger: "^onyx\\.audit"
+```
+
+### Generic syslog
+
+If your collector only speaks syslog, forward the JSON line as the syslog
+`MSG` and parse downstream — the event body is self-contained JSON, so any
+SIEM that can JSON-decode a syslog message works without a custom parser.
 
 > Roadmap: a syslog/CEF formatter, an OCSF-native emitter mode, and an in-product
 > `audit_event` table + read API are planned follow-ups. The JSON export path

--- a/docs/SIEM_INTEGRATION.md
+++ b/docs/SIEM_INTEGRATION.md
@@ -1,0 +1,121 @@
+# Onyx Audit Logging & SIEM Integration
+
+Onyx emits a **normalized, structured audit-event stream** for security-relevant
+activity. Every event is a single JSON object on a dedicated audit log channel,
+so you can forward it into your existing SIEM — **Splunk, Microsoft Sentinel,
+Elastic, Google Chronicle, AWS Security Lake** — with no Onyx-specific
+integration to build and maintain. You point your log shipper at Onyx's output,
+filter to the audit channel, and parse the JSON.
+
+The schema and event taxonomy are shaped toward **OCSF** (the Open Cybersecurity
+Schema Framework), so events map cleanly onto the categories your SIEM already
+understands.
+
+## What gets audited
+
+Onyx records security-relevant actions across four areas. Each event captures
+**who** did it (user / API key, with email and auth method), **what** they acted
+on (resource type + id), the **outcome** (success / failure / denied), the
+**tenant**, the originating **client IP**, and a **request id** that correlates
+the event with the rest of that request's logs.
+
+| Category | Events |
+|---|---|
+| **Authentication** | login, login failure, logout, registration, password-reset request, email verification |
+| **Access control** | user role change, deactivate, reactivate, delete |
+| **Admin configuration** | LLM provider create/update/delete; connector create/update/delete; connector-credential link create/update/delete; API key create/regenerate/delete |
+| **Credentials** | create, update, delete, **and every decrypt/access** of a stored credential |
+
+> Credential **access** events are notable: Onyx logs each time a stored secret
+> is decrypted for use, attributed to the actor and tenant — without ever
+> logging the secret value. This is the kind of trail that catches credential
+> misuse that infrastructure-level tooling can't see.
+
+## What an event looks like
+
+```json
+{
+  "audit_schema_version": "1.0",
+  "ts": 1750000000.123,
+  "action": "user.role_change",
+  "ocsf_class": "account_change",
+  "outcome": "success",
+  "tenant_id": "tenant_abc",
+  "actor": { "user_id": "u-42", "email": "admin@example.com", "auth_type": "oauth" },
+  "resource_type": "user",
+  "resource_id": "u-99",
+  "request_id": "01J...",
+  "endpoint": "PATCH /manage/set-user-role",
+  "source_ip": "203.0.113.5",
+  "extra": { "target_email": "bob@example.com", "old_role": "basic", "new_role": "admin" }
+}
+```
+
+Field highlights:
+
+- **`action`** — a stable `<domain>.<verb>` value (e.g. `auth.login`,
+  `llm_provider.update`, `credential.access`). These are an append-only contract
+  you can safely build dashboards and alerts against.
+- **`ocsf_class`** — `authentication`, `account_change`, or `api_activity`, so
+  you can route by OCSF category.
+- **`outcome`** — `success`, `failure`, or `denied` (a `denied` is an
+  authentication/authorization refusal, distinct from an operational error).
+- **`actor`** — never contains a secret; an `api_key_id` is the key's identifier,
+  never its value.
+- **`extra`** — additional non-secret context relevant to the specific action.
+
+## How to enable and forward it
+
+1. **Run Onyx with `LOG_FORMAT=json`.** This makes all log records structured and
+   promotes tenant/request context to top-level fields. (Audit event bodies are
+   already self-contained JSON regardless of this setting.)
+2. **Ship Onyx's logs** (container stdout, or the on-disk log files) with your
+   collector of choice — Fluent Bit, Vector, the CloudWatch agent, Filebeat, the
+   Azure Monitor agent, etc.
+3. **Filter to the audit channel** by the logger-name prefix **`onyx.audit`**,
+   and parse each record's `message` as JSON.
+
+Drop-in shipper configurations for **Splunk (HEC)**, **Microsoft Sentinel
+(Azure Monitor)**, **Elastic (Filebeat)**, **Vector**, and **Fluent Bit** are in
+the engineering reference, [`AUDIT_LOGGING.md`](./AUDIT_LOGGING.md).
+
+The audit channel is split into sub-channels by OCSF class
+(`onyx.audit.authentication`, `onyx.audit.account_change`,
+`onyx.audit.api_activity`, `onyx.audit.credential_access`) if you prefer to route
+categories to different indexes.
+
+## Reliability guarantees
+
+- **Never disrupts the application.** Audit emission sits on request and indexing
+  hot paths and is fully fail-safe — a failure to gather context or write a log
+  is swallowed, never raised into the user's request.
+- **No silent drops from infrastructure trouble.** High-volume event classes are
+  de-duplicated through Redis within a short window; if Redis is unavailable,
+  emission falls back to always-emit rather than dropping events.
+- **Tenant-tagged.** Every event carries its tenant, so multi-tenant deployments
+  can segregate audit trails per customer.
+
+## Compliance mapping
+
+The audit stream directly supports common control requirements:
+
+- **SOC 2** — CC7 (system monitoring).
+- **FedRAMP / NIST 800-53 AU family** — AU-2 (auditable events), AU-3 (content of
+  audit records), AU-6 (review/analysis), AU-12 (audit generation).
+
+Because the events are normalized and exportable, the review/retention/alerting
+controls (AU-6, AU-11) are satisfied by your SIEM's existing capabilities.
+
+## Scope today, and what's on the roadmap
+
+**Available now:** the full audit-event stream described above, exportable to any
+SIEM via standard log forwarding, with the schema and shipper configs documented.
+
+**On the roadmap (ask if any are a requirement for your deployment):**
+
+- An in-product audit viewer with a queryable `audit_event` store and retention
+  controls (today the trail is exported to your SIEM, not browsed inside Onyx).
+- A native **syslog/CEF** formatter and a full **OCSF-envelope** emitter mode for
+  SIEMs that prefer those wire formats over JSON.
+- Optional high-volume **document-access** auditing, gated behind a flag for
+  customers with AU-level data-access requirements.


### PR DESCRIPTION
## Description

Sales-enablement follow-up to the audit-logging MVP (PRs #12083 / #12219 / #12271 / #12325). The audit subsystem is now complete and emitting; this PR makes it sharable with prospects' security teams.

- **New `docs/SIEM_INTEGRATION.md`** — a customer-facing one-pager: positioning ("forward Onyx's audit stream to your SIEM, no per-SIEM integration to build"), the **live** event catalog, schema + a representative example event, enable-and-forward steps, reliability guarantees (fail-safe, no silent drops, tenant-tagged), and the SOC 2 CC7 / FedRAMP-AU compliance mapping. Deliberately free of internal source paths so it can be handed to a customer.
- **`docs/AUDIT_LOGGING.md`** (engineering reference) — added drop-in shipper configs for **Splunk (HEC)**, **Microsoft Sentinel (Azure Monitor)**, **Elastic (Filebeat)**, and generic syslog (it previously only had Vector + Fluent Bit), and corrected the taxonomy note to state exactly which actions emit today vs the three still-unwired (`auth.password_reset`, `user.create`, `user.group_change`).

No code changes — docs only.

## How Has This Been Tested?

N/A (documentation). Example JSON and field names verified against the emitted schema (e.g. `UserRole` values are lowercase; the role-change `extra` example matches what the code emits).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a customer-facing SIEM integration guide and drop-in shipper configs so teams can forward Onyx’s audit stream to Splunk, Microsoft Sentinel, or Elastic with minimal setup. Clarifies which audit events emit today.

- **New Features**
  - New `docs/SIEM_INTEGRATION.md`: event catalog, schema + example, enable/forward steps, reliability guarantees, and SOC 2 / FedRAMP-AU mapping for customers.
  - Updated `docs/AUDIT_LOGGING.md`: adds shipper configs for Splunk (HEC), Microsoft Sentinel (Azure Monitor), Elastic (Filebeat), and generic syslog.
  - Clarifies taxonomy: all listed actions emit except `auth.password_reset`, `user.create`, and `user.group_change` (pending).

<sup>Written for commit 321a76031cd9015a63424d9b969d6e60e45fd6f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

