### PR TITLE
fix(helm): drop privileged from model-server and celery default securityContext

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.6.6
+version: 0.6.7
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -164,7 +164,10 @@ inferenceCapability:
   livenessProbe: {}
   podSecurityContext: {}
   securityContext:
-    privileged: true
+    # `privileged` is not needed by this workload and is intentionally omitted.
+    # root is kept only so the optional customCACerts feature can run
+    # update-ca-certificates; to run non-root, override this and
+    # podSecurityContext (see codeInterpreter below for the pattern).
     runAsUser: 0
   nodeSelector: {}
   tolerations: []
@@ -222,7 +225,10 @@ indexCapability:
   livenessProbe: {}
   podSecurityContext: {}
   securityContext:
-    privileged: true
+    # `privileged` is not needed by this workload and is intentionally omitted.
+    # root is kept only so the optional customCACerts feature can run
+    # update-ca-certificates; to run non-root, override this and
+    # podSecurityContext (see codeInterpreter below for the pattern).
     runAsUser: 0
   nodeSelector: {}
   tolerations: []
@@ -550,7 +556,10 @@ celery_shared:
     timeoutSeconds: 3
   podSecurityContext: {}
   securityContext:
-    privileged: true
+    # `privileged` is not needed by this workload and is intentionally omitted.
+    # root is kept only so the optional customCACerts feature can run
+    # update-ca-certificates; to run non-root, override this and
+    # podSecurityContext (see codeInterpreter below for the pattern).
     runAsUser: 0
 
 celery_beat:


### PR DESCRIPTION
## Description

Flagged in a customer security review: the inference/index **model servers** and the **celery workers** default to `securityContext: { privileged: true, runAsUser: 0 }`.

`privileged: true` grants full host-device access and all Linux capabilities — none of which these workloads use (GPUs are accessed via the NVIDIA device plugin + resource requests, **not** privileged; no host mounts, devices, or kernel modules). So it's removed from the defaults for all three components (`inferenceCapability`, `indexCapability`, `celery_shared`).

`runAsUser: 0` (root) is **kept** as the default because the optional `customCACerts` feature runs `update-ca-certificates` at startup, which needs root (and `customCACerts` already documents this requirement). Non-root operation is supported by overriding `securityContext` / `podSecurityContext` per component — the chart already renders these from values, and `codeInterpreter` is an in-chart hardened example (`runAsNonRoot`, `fsGroup`, `drop: [ALL]`). Added a comment to each block pointing at that path.

Chart bumped `0.6.6` → `0.6.7`.

Removing a privilege a workload never exercises can't break it, so this is low-risk; the non-root default is left as a follow-up since it's coupled to `customCACerts` and warrants in-cluster testing.

## How Has This Been Tested?

- `helm lint` passes; `helm template` renders cleanly with secrets supplied, and `privileged` no longer appears anywhere in the rendered manifests (the three components render with only `runAsUser: 0`).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed privileged: true from the default securityContext for `inferenceCapability`, `indexCapability`, and `celery_shared` to drop unnecessary privileges. Kept runAsUser: 0 for the optional `customCACerts` step; bumped the chart to 0.6.7.

<sup>Written for commit 29cde4482fa7ea80fe852a690bf1e4a78d3a4855. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

