### PR TITLE
fix(search): bound document_filter LLM calls with a timeout (ENG-4238) (#12333) to release v4.0

### DIFF
--- a/backend/onyx/configs/chat_configs.py
+++ b/backend/onyx/configs/chat_configs.py
@@ -30,6 +30,13 @@ CONTEXT_CHUNKS_BELOW = int(os.environ.get("CONTEXT_CHUNKS_BELOW") or 1)
 LLM_SOCKET_READ_TIMEOUT = int(
     os.environ.get("LLM_SOCKET_READ_TIMEOUT") or "60"
 )  # 60 seconds
+# Timeout for non-streaming secondary LLM flows (e.g. search section-relevance
+# classification and section-expansion selection). These are short, low-effort
+# calls; the bound exists so a stalled provider connection fails fast into the
+# existing graceful fallback instead of hanging a worker until liveness kills it.
+SECONDARY_LLM_FLOW_TIMEOUT_S = int(
+    os.environ.get("SECONDARY_LLM_FLOW_TIMEOUT_S") or "60"
+)
 # Weighting factor between vector and keyword Search; 1 for completely vector
 # search, 0 for keyword. Enforces a valid range of [0, 1]. A supplied value from
 # the env outside of this range will be clipped to the respective end of the

--- a/backend/onyx/secondary_llm_flows/document_filter.py
+++ b/backend/onyx/secondary_llm_flows/document_filter.py
@@ -1,6 +1,7 @@
 import json
 import re
 
+from onyx.configs.chat_configs import SECONDARY_LLM_FLOW_TIMEOUT_S
 from onyx.context.search.models import ContextExpansionType
 from onyx.context.search.models import InferenceChunk
 from onyx.context.search.models import InferenceSection
@@ -15,6 +16,7 @@ from onyx.tracing.flows import LLMFlow
 from onyx.tracing.llm_utils import llm_generation_span
 from onyx.tracing.llm_utils import record_llm_response
 from onyx.utils.logger import setup_logger
+from onyx.utils.timing import log_function_time
 
 logger = setup_logger()
 
@@ -90,6 +92,7 @@ def select_chunks_for_relevance(
     return all_chunks[start_index:end_index]
 
 
+@log_function_time(print_only=True)
 def classify_section_relevance(
     document_title: str,
     section_text: str,
@@ -133,6 +136,7 @@ def classify_section_relevance(
             response = llm.invoke(
                 prompt=prompt_msg,
                 reasoning_effort=ReasoningEffort.OFF,
+                timeout_override=SECONDARY_LLM_FLOW_TIMEOUT_S,
             )
             record_llm_response(span_generation, response)
             llm_response = response.choice.message.content
@@ -179,6 +183,7 @@ def classify_section_relevance(
     return classification
 
 
+@log_function_time(print_only=True)
 def select_sections_for_expansion(
     sections: list[InferenceSection],
     user_query: str,
@@ -283,7 +288,9 @@ def select_sections_for_expansion(
             input_messages=[prompt_text],
         ) as span_generation:
             response = llm.invoke(
-                prompt=[prompt_text], reasoning_effort=ReasoningEffort.OFF
+                prompt=[prompt_text],
+                reasoning_effort=ReasoningEffort.OFF,
+                timeout_override=SECONDARY_LLM_FLOW_TIMEOUT_S,
             )
             record_llm_response(span_generation, response)
             llm_response = response.choice.message.content

--- a/backend/tests/unit/onyx/secondary_llm_flows/test_document_filter.py
+++ b/backend/tests/unit/onyx/secondary_llm_flows/test_document_filter.py
@@ -1,0 +1,151 @@
+from collections.abc import Iterator
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from onyx.configs.chat_configs import SECONDARY_LLM_FLOW_TIMEOUT_S
+from onyx.configs.constants import DocumentSource
+from onyx.context.search.models import ContextExpansionType
+from onyx.context.search.models import InferenceChunk
+from onyx.context.search.models import InferenceSection
+from onyx.llm.interfaces import LLM
+from onyx.llm.multi_llm import LLMTimeoutError
+from onyx.secondary_llm_flows.document_filter import classify_section_relevance
+from onyx.secondary_llm_flows.document_filter import select_sections_for_expansion
+
+
+@contextmanager
+def _noop_span() -> Iterator[MagicMock]:
+    yield MagicMock()
+
+
+def _make_section() -> InferenceSection:
+    chunk = InferenceChunk(
+        document_id="doc-1",
+        chunk_id=0,
+        content="section content",
+        source_type=DocumentSource.MOCK_CONNECTOR,
+        semantic_identifier="sem-doc-1",
+        title="doc-1",
+        boost=1,
+        score=0.5,
+        hidden=False,
+        metadata={},
+        match_highlights=[],
+        doc_summary="",
+        chunk_context="",
+        updated_at=None,
+        image_file_id=None,
+        source_links={},
+        section_continuation=False,
+        blurb="blurb",
+        file_id=None,
+    )
+    return InferenceSection(
+        center_chunk=chunk, chunks=[chunk], combined_content=chunk.content
+    )
+
+
+def _make_llm(invoke: MagicMock) -> LLM:
+    llm = MagicMock(spec=LLM)
+    llm.invoke = invoke
+    return llm
+
+
+@patch("onyx.secondary_llm_flows.document_filter.record_llm_response")
+@patch(
+    "onyx.secondary_llm_flows.document_filter.llm_generation_span",
+    return_value=_noop_span(),
+)
+def test_classify_section_relevance_timeout_falls_back(
+    _span: MagicMock, _record: MagicMock
+) -> None:
+    """A timed-out classification call must degrade to the safe default instead
+    of propagating, so a stalled provider can't hang the worker."""
+    invoke = MagicMock(side_effect=LLMTimeoutError("timed out"))
+    llm = _make_llm(invoke)
+
+    result = classify_section_relevance(
+        document_title="Doc",
+        section_text="body",
+        user_query="q",
+        llm=llm,
+        # surrounding text present so the no-context post-adjustment is not applied
+        section_above_text="above",
+        section_below_text="below",
+    )
+
+    assert result == ContextExpansionType.MAIN_SECTION_ONLY
+    # the bound that makes the call fail fast must actually be passed through
+    assert invoke.call_args.kwargs["timeout_override"] == SECONDARY_LLM_FLOW_TIMEOUT_S
+
+
+@patch("onyx.secondary_llm_flows.document_filter.record_llm_response")
+@patch(
+    "onyx.secondary_llm_flows.document_filter.llm_generation_span",
+    return_value=_noop_span(),
+)
+def test_classify_section_relevance_passes_timeout_on_success(
+    _span: MagicMock, _record: MagicMock
+) -> None:
+    response = MagicMock()
+    response.choice.message.content = "3"  # FULL_DOCUMENT
+    invoke = MagicMock(return_value=response)
+    llm = _make_llm(invoke)
+
+    result = classify_section_relevance(
+        document_title="Doc",
+        section_text="body",
+        user_query="q",
+        llm=llm,
+        section_above_text="above",
+        section_below_text="below",
+    )
+
+    assert result == ContextExpansionType.FULL_DOCUMENT
+    assert invoke.call_args.kwargs["timeout_override"] == SECONDARY_LLM_FLOW_TIMEOUT_S
+
+
+@patch("onyx.secondary_llm_flows.document_filter.record_llm_response")
+@patch(
+    "onyx.secondary_llm_flows.document_filter.llm_generation_span",
+    return_value=_noop_span(),
+)
+def test_select_sections_for_expansion_timeout_falls_back(
+    _span: MagicMock, _record: MagicMock
+) -> None:
+    """A timed-out selection call must degrade to returning the input sections
+    (capped) instead of propagating and hanging the worker."""
+    sections = [_make_section()]
+    invoke = MagicMock(side_effect=LLMTimeoutError("timed out"))
+    llm = _make_llm(invoke)
+
+    selected, doc_ids = select_sections_for_expansion(
+        sections=sections, user_query="q", llm=llm, max_sections=10
+    )
+
+    assert selected == sections
+    assert doc_ids is None
+    assert invoke.call_args.kwargs["timeout_override"] == SECONDARY_LLM_FLOW_TIMEOUT_S
+
+
+@patch("onyx.secondary_llm_flows.document_filter.record_llm_response")
+@patch(
+    "onyx.secondary_llm_flows.document_filter.llm_generation_span",
+    return_value=_noop_span(),
+)
+def test_select_sections_for_expansion_passes_timeout_on_success(
+    _span: MagicMock, _record: MagicMock
+) -> None:
+    sections = [_make_section()]
+    response = MagicMock()
+    response.choice.message.content = "[0]"
+    invoke = MagicMock(return_value=response)
+    llm = _make_llm(invoke)
+
+    selected, _doc_ids = select_sections_for_expansion(
+        sections=sections, user_query="q", llm=llm, max_sections=10
+    )
+
+    assert selected == sections
+    assert invoke.call_args.kwargs["timeout_override"] == SECONDARY_LLM_FLOW_TIMEOUT_S


### PR DESCRIPTION
Cherry-pick of #12333 (squash `2415cff`) to **release/v4.0** — this is the line **playlist-prod runs (v4.0.7)**, where api-server pods are currently being liveness-killed (exit 137) by this exact hang. See ENG-4238.

Bounds the `document_filter` secondary-LLM `invoke()` calls with `SECONDARY_LLM_FLOW_TIMEOUT_S` (default 60s) so a stalled provider connection fails fast into the existing graceful fallback instead of hanging a worker until liveness SIGKILLs the pod and drops in-flight chat/search streams. Verified `LLM.invoke` accepts `timeout_override` on this release line.

Conflict resolved in `configs/chat_configs.py`: kept only the new `SECONDARY_LLM_FLOW_TIMEOUT_S` constant; the `CHAT_HEARTBEAT_INTERVAL_S` / `LLM_FIRST_CHUNK_MAX_RETRIES` / `DR_REPORT_LLM_TIMEOUT_S` / `CHAT_STREAM_BUFFER_*` / `CHAT_RESUME_POLL_INTERVAL_S` constants git pulled in as context do not exist on v4.0 and were excluded. `document_filter.py` and the tests applied cleanly.

Note: local unit-test run was blocked by a pre-existing v4.0 import-time issue unrelated to this change (`onyx/utils/text_processing.py` surrogate regex fails to load under the local toolchain); `py_compile` is clean and the diff is identical to #12333 / the v4.1 cherry-pick (#12339) where the 4 tests pass. CI runs the tests in the v4.0 env.

Companion cherry-picks: #12336 (v4.2), #12339 (v4.1).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound secondary LLM calls in `document_filter` with a 60s timeout to fail fast and keep chat/search streams responsive. Addresses ENG-4238 by preventing worker hangs that caused api-server liveness kills.

- **Bug Fixes**
  - Added `SECONDARY_LLM_FLOW_TIMEOUT_S` (default 60s; env-overridable).
  - Passed `timeout_override` to both `LLM.invoke()` calls in `classify_section_relevance` and `select_sections_for_expansion`, leveraging the existing safe fallback on timeout.
  - Added `@log_function_time(print_only=True)` for per-call latency and unit tests to confirm the timeout is applied and fallbacks work.

<sup>Written for commit 88e4d71718fc94bbd027ac3b827d5a901859f6e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

