### PR TITLE
fix(redis): async TLS/IAM passed an unsupported ssl_context — use native ssl_* kwargs

### DIFF
--- a/backend/onyx/redis/iam_auth.py
+++ b/backend/onyx/redis/iam_auth.py
@@ -14,19 +14,26 @@ from typing import Any
 
 def configure_redis_iam_auth(connection_kwargs: dict[str, Any]) -> None:
     """
-    Configure Redis connection parameters for IAM authentication.
+    Configure async Redis connection kwargs for IAM authentication.
     Modifies the connection_kwargs dict in-place to:
     1. Remove password (not needed with IAM)
-    2. Enable SSL with system CA certificates
-    3. Set proper SSL context for secure connections
+    2. Enable TLS with server-cert verification against the system trust store
+       (ElastiCache uses a publicly-trusted CA)
+
+    Uses redis-py's native async ssl_* kwargs. The async client has no
+    ``ssl_context`` parameter, so passing one raises
+    ``TypeError: ... unexpected keyword argument 'ssl_context'`` — i.e. every
+    async IAM connection would crash.
     """
     # Remove password as it's not needed with IAM authentication
     if "password" in connection_kwargs:
         del connection_kwargs["password"]
 
-    # Ensure SSL is enabled for IAM authentication
+    # Enable TLS with verification (mirrors create_redis_ssl_context_if_iam:
+    # CERT_REQUIRED + hostname check, system CA store).
     connection_kwargs["ssl"] = True
-    connection_kwargs["ssl_context"] = create_redis_ssl_context_if_iam()
+    connection_kwargs["ssl_cert_reqs"] = "required"
+    connection_kwargs["ssl_check_hostname"] = True
 
 
 def create_redis_ssl_context_if_iam() -> ssl.SSLContext:

--- a/backend/onyx/redis/redis_pool.py
+++ b/backend/onyx/redis/redis_pool.py
@@ -1,6 +1,5 @@
 import asyncio
 import json
-import ssl
 import threading
 from typing import Any
 from typing import cast
@@ -296,13 +295,6 @@ def get_raw_redis_replica_client() -> Redis:
     return redis_pool.get_raw_replica_client()
 
 
-SSL_CERT_REQS_MAP = {
-    "none": ssl.CERT_NONE,
-    "optional": ssl.CERT_OPTIONAL,
-    "required": ssl.CERT_REQUIRED,
-}
-
-
 # Async Redis connections are cached PER EVENT LOOP, not globally. redis-py binds
 # a connection's socket and its asyncio Futures to the loop that first used it, so
 # a single client reused across loops raises "got Future attached to a different
@@ -332,22 +324,19 @@ def _build_async_redis_connection() -> aioredis.Redis:
     if USE_REDIS_IAM_AUTH:
         configure_redis_iam_auth(connection_kwargs)
     elif REDIS_SSL:
-        ssl_context = ssl.create_default_context()
-
+        # redis-py's async client builds its own SSLContext from these kwargs;
+        # unlike the sync SSLConnection it does NOT accept a prebuilt
+        # ssl_context, so passing one is silently ignored (TLS still negotiates
+        # but the CA / client cert are dropped). Hand it the native ssl_* params.
+        connection_kwargs["ssl"] = True
+        connection_kwargs["ssl_cert_reqs"] = REDIS_SSL_CERT_REQS
+        connection_kwargs["ssl_check_hostname"] = False
         if REDIS_SSL_CA_CERTS:
-            ssl_context.load_verify_locations(REDIS_SSL_CA_CERTS)
-        ssl_context.check_hostname = False
-
-        # Map your string to the proper ssl.CERT_* constant
-        ssl_context.verify_mode = SSL_CERT_REQS_MAP.get(
-            REDIS_SSL_CERT_REQS, ssl.CERT_NONE
-        )
-
-        # Present a client certificate for mutual TLS, if configured.
+            connection_kwargs["ssl_ca_certs"] = REDIS_SSL_CA_CERTS
+        # Client certificate for mutual TLS, if configured.
         if REDIS_SSL_CERTFILE:
-            ssl_context.load_cert_chain(REDIS_SSL_CERTFILE, REDIS_SSL_KEYFILE)
-
-        connection_kwargs["ssl"] = ssl_context
+            connection_kwargs["ssl_certfile"] = REDIS_SSL_CERTFILE
+            connection_kwargs["ssl_keyfile"] = REDIS_SSL_KEYFILE
 
     # Create a new Redis connection (or connection pool) with SSL configuration
     return aioredis.Redis(**connection_kwargs)

--- a/backend/tests/unit/onyx/redis/test_redis_mtls.py
+++ b/backend/tests/unit/onyx/redis/test_redis_mtls.py
@@ -77,6 +77,26 @@ def test_async_connection_passes_native_ssl_kwargs() -> None:
         assert "ssl_context" not in kwargs
 
 
+def test_iam_auth_uses_native_async_ssl_kwargs() -> None:
+    """The async IAM path must use native ssl_* kwargs, not ssl_context — the
+    async Redis client rejects ssl_context with a TypeError, so passing one
+    crashes every async IAM connection."""
+    import redis.asyncio as aioredis
+
+    from onyx.redis.iam_auth import configure_redis_iam_auth
+
+    kwargs: dict = {"host": "h", "port": 6379, "password": "pw"}
+    configure_redis_iam_auth(kwargs)
+    assert "ssl_context" not in kwargs
+    assert "password" not in kwargs  # IAM drops the password
+    assert kwargs["ssl"] is True
+    assert kwargs["ssl_cert_reqs"] == "required"
+    assert kwargs["ssl_check_hostname"] is True
+    # Regression guard: constructing the async client must not raise the
+    # "unexpected keyword argument 'ssl_context'" TypeError.
+    aioredis.Redis(**kwargs)
+
+
 def test_celery_broker_and_result_urls_include_client_cert(tmp_path: Path) -> None:
     cert = tmp_path / "client.crt"
     key = tmp_path / "client.key"

--- a/backend/tests/unit/onyx/redis/test_redis_mtls.py
+++ b/backend/tests/unit/onyx/redis/test_redis_mtls.py
@@ -55,21 +55,26 @@ def test_sync_pool_forwards_client_cert() -> None:
         assert kwargs["ssl_keyfile"] == "/etc/redis/tls/client.key"
 
 
-def test_async_connection_loads_client_cert() -> None:
-    """The async client builds an SSLContext manually, so the client cert is
-    applied via load_cert_chain."""
+def test_async_connection_passes_native_ssl_kwargs() -> None:
+    """The async client must get redis-py's native ssl_* kwargs — it ignores a
+    prebuilt ssl_context, so the client cert / CA have to flow through these."""
     with (
         patch.object(redis_pool, "USE_REDIS_IAM_AUTH", False),
         patch.object(redis_pool, "REDIS_SSL", True),
-        patch.object(redis_pool, "REDIS_SSL_CA_CERTS", None),
+        patch.object(redis_pool, "REDIS_SSL_CA_CERTS", "/ca.crt"),
+        patch.object(redis_pool, "REDIS_SSL_CERT_REQS", "required"),
         patch.object(redis_pool, "REDIS_SSL_CERTFILE", "/c.crt"),
         patch.object(redis_pool, "REDIS_SSL_KEYFILE", "/c.key"),
-        patch.object(redis_pool, "ssl") as mock_ssl,
-        patch.object(redis_pool, "aioredis"),
+        patch.object(redis_pool, "aioredis") as mock_aioredis,
     ):
         redis_pool._build_async_redis_connection()
-        ctx = mock_ssl.create_default_context.return_value
-        ctx.load_cert_chain.assert_called_once_with("/c.crt", "/c.key")
+        kwargs = mock_aioredis.Redis.call_args.kwargs
+        assert kwargs["ssl"] is True
+        assert kwargs["ssl_cert_reqs"] == "required"
+        assert kwargs["ssl_ca_certs"] == "/ca.crt"
+        assert kwargs["ssl_certfile"] == "/c.crt"
+        assert kwargs["ssl_keyfile"] == "/c.key"
+        assert "ssl_context" not in kwargs
 
 
 def test_celery_broker_and_result_urls_include_client_cert(tmp_path: Path) -> None:

--- a/backend/tests/unit/onyx/redis/test_redis_mtls.py
+++ b/backend/tests/unit/onyx/redis/test_redis_mtls.py
@@ -71,6 +71,7 @@ def test_async_connection_passes_native_ssl_kwargs() -> None:
         kwargs = mock_aioredis.Redis.call_args.kwargs
         assert kwargs["ssl"] is True
         assert kwargs["ssl_cert_reqs"] == "required"
+        assert kwargs["ssl_check_hostname"] is False
         assert kwargs["ssl_ca_certs"] == "/ca.crt"
         assert kwargs["ssl_certfile"] == "/c.crt"
         assert kwargs["ssl_keyfile"] == "/c.key"


### PR DESCRIPTION
## Description

Fixes two async Redis bugs with the **same root cause**: redis-py's async client (5.0.8) has **no `ssl_context` parameter** (only the sync `SSLConnection` does), so passing one is either silently dropped or raises a `TypeError`. Both surfaced via live end-to-end TLS testing.

**1. `REDIS_SSL` path (mTLS / CA silently dropped).** `_build_async_redis_connection` set `connection_kwargs["ssl"] = <prebuilt ssl_context>`. The context — including the CA bundle and the mTLS client cert (`load_cert_chain`) — was ignored: TLS negotiated but **unverified and with no client cert**. Masked because `REDIS_SSL_CERT_REQS` defaults to `none`. (Follow-up to #12321, which merged before this fix.)

**2. `USE_REDIS_IAM_AUTH` path (hard crash).** `configure_redis_iam_auth` set `connection_kwargs["ssl_context"]`, which the async client rejects with `TypeError: Redis.__init__() got an unexpected keyword argument 'ssl_context'` — **every async Redis connection under ElastiCache IAM auth crashed at construction.**

**Fix (both):** pass redis-py's native async `ssl_*` kwargs (`ssl`, `ssl_cert_reqs`, `ssl_ca_certs`, `ssl_certfile`, `ssl_keyfile`, `ssl_check_hostname`) — the same mechanism the sync pool already uses. The sync paths are unchanged (sync `SSLConnection` does support `ssl_context`).

## How Has This Been Tested?

- **Live e2e** against a TLS + mTLS Redis (`tls-auth-clients yes`): async client PINGs with CA + client cert; rejected on wrong CA / missing client cert.
- Direct repro confirming the IAM path no longer raises the `ssl_context` `TypeError` and now sets verifying native kwargs.
- Unit tests assert native kwargs reach the async client for both the `REDIS_SSL` and IAM paths; `backend/tests/unit/onyx/redis` green; `ty` + `ruff` + `pre-commit` clean.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check