### PR TITLE
fix(craft): validate scheduled task app preapprovals

### DIFF
--- a/backend/onyx/external_apps/credentials.py
+++ b/backend/onyx/external_apps/credentials.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Session
 from onyx.db.external_app import get_external_app_by_id
 from onyx.db.external_app import get_external_app_user_credential
 from onyx.db.models import ExternalApp
+from onyx.db.models import ExternalAppUserCredential
 
 
 def build_auth_headers(
@@ -33,6 +34,36 @@ def build_auth_headers(
     return headers
 
 
+def _combined_credentials(
+    app: ExternalApp,
+    user_cred: ExternalAppUserCredential | None,
+) -> dict[str, Any]:
+    credentials: dict[str, Any] = dict(
+        app.organization_credentials.get_value(apply_mask=False)
+    )
+    if user_cred is not None:
+        credentials.update(user_cred.user_credentials.get_value(apply_mask=False))
+    return credentials
+
+
+def app_is_available_for_user_credential(
+    app: ExternalApp,
+    user_cred: ExternalAppUserCredential | None,
+) -> bool:
+    """Whether ``app`` is enabled and has enough credentials to serve a user.
+
+    This is the non-querying form of :func:`app_is_available` for callers that
+    already loaded the ``ExternalApp`` and credential row.
+    """
+    if not app.skill.enabled:
+        return False
+    if not app.auth_template:
+        return True
+    return bool(
+        build_auth_headers(app.auth_template, _combined_credentials(app, user_cred))
+    )
+
+
 def resolve_injection_headers(
     db_session: Session,
     external_app_id: int,
@@ -51,16 +82,13 @@ def resolve_injection_headers(
     if app is None or not app.skill.enabled:
         return {}
 
-    credentials: dict[str, Any] = dict(
-        app.organization_credentials.get_value(apply_mask=False)
-    )
     user_cred = get_external_app_user_credential(
         db_session, external_app_id=external_app_id, user_id=user_id
     )
-    if user_cred is not None:
-        credentials.update(user_cred.user_credentials.get_value(apply_mask=False))
-
-    return build_auth_headers(app.auth_template, credentials)
+    return build_auth_headers(
+        app.auth_template,
+        _combined_credentials(app, user_cred),
+    )
 
 
 def app_is_available(db_session: Session, app: ExternalApp, user_id: UUID) -> bool:
@@ -74,8 +102,7 @@ def app_is_available(db_session: Session, app: ExternalApp, user_id: UUID) -> bo
     re-resolves later with an OAuth refresh, so this verdict-time render is the
     cheap presence check, not the final one.
     """
-    if not app.skill.enabled:
-        return False
-    if not app.auth_template:
-        return True
-    return bool(resolve_injection_headers(db_session, app.id, user_id))
+    user_cred = get_external_app_user_credential(
+        db_session, external_app_id=app.id, user_id=user_id
+    )
+    return app_is_available_for_user_credential(app, user_cred)

--- a/backend/onyx/server/features/build/scheduled_tasks/api.py
+++ b/backend/onyx/server/features/build/scheduled_tasks/api.py
@@ -40,6 +40,8 @@ from onyx.db.enums import ScheduledTaskRunStatus
 from onyx.db.enums import ScheduledTaskStatus
 from onyx.db.enums import ScheduledTaskTriggerSource
 from onyx.db.external_app import get_external_apps
+from onyx.db.external_app import get_user_credentials_by_app_id
+from onyx.db.models import ExternalApp
 from onyx.db.models import ScheduledTask
 from onyx.db.models import ScheduledTaskRun
 from onyx.db.models import User
@@ -52,7 +54,7 @@ from onyx.db.scheduled_task import soft_delete_scheduled_task
 from onyx.db.scheduled_task import update_scheduled_task
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
-from onyx.external_apps.credentials import app_is_available
+from onyx.external_apps.credentials import app_is_available_for_user_credential
 from onyx.server.features.build.scheduled_tasks.schedule import compile_to_cron
 from onyx.server.features.build.scheduled_tasks.schedule import EDITOR_PAYLOAD_MODELS
 from onyx.server.features.build.scheduled_tasks.schedule import EditorMode
@@ -299,6 +301,7 @@ def _detail(
     db_session: Session,
     task: ScheduledTask,
     user_id: UUID,
+    external_apps: list[ExternalApp] | None = None,
 ) -> ScheduledTaskDetail:
     last_run = _latest_run(db_session, task, user_id)
     next_runs: list[datetime] = []
@@ -308,6 +311,9 @@ def _detail(
             datetime.now(tz=timezone.utc),
             NEXT_RUNS_PREVIEW_COUNT,
         )
+    pre_approved_app_ids = task.pre_approved_app_ids
+    if external_apps is None and pre_approved_app_ids:
+        external_apps = get_external_apps(db_session)
     return ScheduledTaskDetail(
         id=str(task.id),
         name=task.name,
@@ -319,9 +325,9 @@ def _detail(
         next_run_at=task.next_run_at,
         next_runs=next_runs,
         last_run=RunSummary.from_model(last_run) if last_run is not None else None,
-        pre_approved_app_ids=task.pre_approved_app_ids,
+        pre_approved_app_ids=pre_approved_app_ids,
         pre_approved_apps=_pre_approved_app_display_metadata(
-            db_session, task.pre_approved_app_ids
+            pre_approved_app_ids, external_apps or []
         ),
         created_at=task.created_at,
         updated_at=task.updated_at,
@@ -329,8 +335,8 @@ def _detail(
 
 
 def _pre_approved_app_display_metadata(
-    db_session: Session,
     app_ids: list[int],
+    external_apps: list[ExternalApp],
 ) -> list[ScheduledTaskPreApprovedAppDisplay]:
     """Return grant display metadata in grant order.
 
@@ -340,7 +346,7 @@ def _pre_approved_app_display_metadata(
     if not app_ids:
         return []
     ids = set(app_ids)
-    apps_by_id = {app.id: app for app in get_external_apps(db_session) if app.id in ids}
+    apps_by_id = {app.id: app for app in external_apps if app.id in ids}
     return [
         ScheduledTaskPreApprovedAppDisplay(
             id=app.id,
@@ -356,7 +362,10 @@ def _pre_approved_app_display_metadata(
 
 
 def _validated_app_ids(
-    db_session: Session, app_ids: list[int], user_id: UUID
+    db_session: Session,
+    app_ids: list[int],
+    user_id: UUID,
+    external_apps: list[ExternalApp] | None = None,
 ) -> list[int]:
     """Dedupe (order-preserving) and verify each id is available to the user.
 
@@ -366,10 +375,17 @@ def _validated_app_ids(
     deduped = list(dict.fromkeys(app_ids))
     if not deduped:
         return []
+    external_apps = (
+        external_apps if external_apps is not None else get_external_apps(db_session)
+    )
+    user_creds_by_app = get_user_credentials_by_app_id(
+        db_session=db_session,
+        user_id=user_id,
+    )
     available_ids = {
         app.id
-        for app in get_external_apps(db_session)
-        if app_is_available(db_session, app, user_id)
+        for app in external_apps
+        if app_is_available_for_user_credential(app, user_creds_by_app.get(app.id))
     }
     unavailable = [app_id for app_id in deduped if app_id not in available_ids]
     if unavailable:
@@ -452,6 +468,9 @@ def create_task(
          and enqueue the executor. Does NOT touch ``next_run_at``.
     """
     cron_expression = compile_to_cron(request.editor_payload)
+    external_apps = (
+        get_external_apps(db_session) if request.pre_approved_app_ids else []
+    )
 
     task = create_scheduled_task(
         db_session=db_session,
@@ -462,7 +481,10 @@ def create_task(
         editor_mode=request.editor_mode,
         status=request.status,
         pre_approved_app_ids=_validated_app_ids(
-            db_session, request.pre_approved_app_ids, user.id
+            db_session,
+            request.pre_approved_app_ids,
+            user.id,
+            external_apps=external_apps,
         ),
     )
 
@@ -481,7 +503,7 @@ def create_task(
         db_session.commit()
 
     db_session.refresh(task)
-    return _detail(db_session, task, user.id)
+    return _detail(db_session, task, user.id, external_apps=external_apps)
 
 
 @router.get("/{task_id}")
@@ -515,6 +537,11 @@ def patch_task(
         # whenever editor_payload is — no runtime check needed here.
         cron_expression = compile_to_cron(request.editor_payload)
 
+    external_apps = (
+        get_external_apps(db_session)
+        if request.pre_approved_app_ids is not None
+        else None
+    )
     task = update_scheduled_task(
         db_session=db_session,
         task_id=task_id,
@@ -525,14 +552,19 @@ def patch_task(
         editor_mode=request.editor_mode,
         status=request.status,
         pre_approved_app_ids=(
-            _validated_app_ids(db_session, request.pre_approved_app_ids, user.id)
+            _validated_app_ids(
+                db_session,
+                request.pre_approved_app_ids,
+                user.id,
+                external_apps=external_apps,
+            )
             if request.pre_approved_app_ids is not None
             else None
         ),
     )
     db_session.commit()
     db_session.refresh(task)
-    return _detail(db_session, task, user.id)
+    return _detail(db_session, task, user.id, external_apps=external_apps)
 
 
 @router.delete("/{task_id}")

--- a/backend/onyx/server/features/build/scheduled_tasks/api.py
+++ b/backend/onyx/server/features/build/scheduled_tasks/api.py
@@ -366,15 +366,19 @@ def _validated_app_ids(
     app_ids: list[int],
     user_id: UUID,
     external_apps: list[ExternalApp] | None = None,
+    already_approved_app_ids: set[int] | None = None,
 ) -> list[int]:
     """Dedupe (order-preserving) and verify each id is available to the user.
 
     This mirrors the sandbox gateway's availability predicate: enabled apps
-    with everything needed to inject credentials, or credentialless apps.
+    with everything needed to inject credentials, or credentialless apps. PATCH
+    callers may pass existing grants so stale task state can be preserved while
+    newly added unavailable apps are still rejected.
     """
     deduped = list(dict.fromkeys(app_ids))
     if not deduped:
         return []
+    already_approved_app_ids = already_approved_app_ids or set()
     external_apps = (
         external_apps if external_apps is not None else get_external_apps(db_session)
     )
@@ -387,7 +391,11 @@ def _validated_app_ids(
         for app in external_apps
         if app_is_available_for_user_credential(app, user_creds_by_app.get(app.id))
     }
-    unavailable = [app_id for app_id in deduped if app_id not in available_ids]
+    unavailable = [
+        app_id
+        for app_id in deduped
+        if app_id not in available_ids and app_id not in already_approved_app_ids
+    ]
     if unavailable:
         raise OnyxError(
             OnyxErrorCode.INVALID_INPUT,
@@ -542,6 +550,15 @@ def patch_task(
         if request.pre_approved_app_ids is not None
         else None
     )
+    existing_pre_approved_app_ids: set[int] = set()
+    if request.pre_approved_app_ids is not None:
+        existing_task = get_scheduled_task(
+            db_session=db_session,
+            task_id=task_id,
+            user_id=user.id,
+        )
+        existing_pre_approved_app_ids = set(existing_task.pre_approved_app_ids)
+
     task = update_scheduled_task(
         db_session=db_session,
         task_id=task_id,
@@ -557,6 +574,7 @@ def patch_task(
                 request.pre_approved_app_ids,
                 user.id,
                 external_apps=external_apps,
+                already_approved_app_ids=existing_pre_approved_app_ids,
             )
             if request.pre_approved_app_ids is not None
             else None

--- a/backend/onyx/server/features/build/scheduled_tasks/api.py
+++ b/backend/onyx/server/features/build/scheduled_tasks/api.py
@@ -34,6 +34,7 @@ from onyx.configs.constants import OnyxCeleryPriority
 from onyx.configs.constants import OnyxCeleryQueues
 from onyx.configs.constants import OnyxCeleryTask
 from onyx.db.engine.sql_engine import get_session
+from onyx.db.enums import ExternalAppType
 from onyx.db.enums import Permission
 from onyx.db.enums import ScheduledTaskRunStatus
 from onyx.db.enums import ScheduledTaskStatus
@@ -51,6 +52,7 @@ from onyx.db.scheduled_task import soft_delete_scheduled_task
 from onyx.db.scheduled_task import update_scheduled_task
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
+from onyx.external_apps.credentials import app_is_available
 from onyx.server.features.build.scheduled_tasks.schedule import compile_to_cron
 from onyx.server.features.build.scheduled_tasks.schedule import EDITOR_PAYLOAD_MODELS
 from onyx.server.features.build.scheduled_tasks.schedule import EditorMode
@@ -202,6 +204,17 @@ class ScheduledTaskListItem(BaseModel):
     updated_at: datetime
 
 
+class ScheduledTaskPreApprovedAppDisplay(BaseModel):
+    """Stable display metadata for a task's stored app grants."""
+
+    id: int
+    name: str
+    description: str
+    slug: str
+    app_type: ExternalAppType
+    enabled: bool
+
+
 class ScheduledTaskDetail(BaseModel):
     """Response for ``GET /scheduled-tasks/{id}`` and the mutating endpoints
     that return the full task.
@@ -218,6 +231,7 @@ class ScheduledTaskDetail(BaseModel):
     next_runs: list[datetime]
     last_run: RunSummary | None
     pre_approved_app_ids: list[int]
+    pre_approved_apps: list[ScheduledTaskPreApprovedAppDisplay]
     created_at: datetime
     updated_at: datetime
 
@@ -306,26 +320,62 @@ def _detail(
         next_runs=next_runs,
         last_run=RunSummary.from_model(last_run) if last_run is not None else None,
         pre_approved_app_ids=task.pre_approved_app_ids,
+        pre_approved_apps=_pre_approved_app_display_metadata(
+            db_session, task.pre_approved_app_ids
+        ),
         created_at=task.created_at,
         updated_at=task.updated_at,
     )
 
 
-def _validated_app_ids(db_session: Session, app_ids: list[int]) -> list[int]:
-    """Dedupe (order-preserving) and verify each id is a configured app.
+def _pre_approved_app_display_metadata(
+    db_session: Session,
+    app_ids: list[int],
+) -> list[ScheduledTaskPreApprovedAppDisplay]:
+    """Return grant display metadata in grant order.
 
-    Existence-only: a grant on an app that never produces an ASK match is
-    inert, so credential / has-ASK-action filtering stays editor-side.
+    Uses the unfiltered app list so already-saved grants still render names
+    when an app is later disabled or unavailable to the author.
+    """
+    if not app_ids:
+        return []
+    ids = set(app_ids)
+    apps_by_id = {app.id: app for app in get_external_apps(db_session) if app.id in ids}
+    return [
+        ScheduledTaskPreApprovedAppDisplay(
+            id=app.id,
+            name=app.skill.name,
+            description=app.skill.description,
+            slug=app.skill.slug,
+            app_type=app.app_type,
+            enabled=app.skill.enabled,
+        )
+        for app_id in app_ids
+        if (app := apps_by_id.get(app_id)) is not None
+    ]
+
+
+def _validated_app_ids(
+    db_session: Session, app_ids: list[int], user_id: UUID
+) -> list[int]:
+    """Dedupe (order-preserving) and verify each id is available to the user.
+
+    This mirrors the sandbox gateway's availability predicate: enabled apps
+    with everything needed to inject credentials, or credentialless apps.
     """
     deduped = list(dict.fromkeys(app_ids))
     if not deduped:
         return []
-    known_ids = {app.id for app in get_external_apps(db_session)}
-    unknown = [app_id for app_id in deduped if app_id not in known_ids]
-    if unknown:
+    available_ids = {
+        app.id
+        for app in get_external_apps(db_session)
+        if app_is_available(db_session, app, user_id)
+    }
+    unavailable = [app_id for app_id in deduped if app_id not in available_ids]
+    if unavailable:
         raise OnyxError(
             OnyxErrorCode.INVALID_INPUT,
-            f"Unknown external app id(s): {unknown}",
+            f"Unavailable external app id(s): {unavailable}",
         )
     return deduped
 
@@ -412,7 +462,7 @@ def create_task(
         editor_mode=request.editor_mode,
         status=request.status,
         pre_approved_app_ids=_validated_app_ids(
-            db_session, request.pre_approved_app_ids
+            db_session, request.pre_approved_app_ids, user.id
         ),
     )
 
@@ -475,7 +525,7 @@ def patch_task(
         editor_mode=request.editor_mode,
         status=request.status,
         pre_approved_app_ids=(
-            _validated_app_ids(db_session, request.pre_approved_app_ids)
+            _validated_app_ids(db_session, request.pre_approved_app_ids, user.id)
             if request.pre_approved_app_ids is not None
             else None
         ),

--- a/backend/tests/external_dependency_unit/craft/test_scheduled_task_pre_approvals.py
+++ b/backend/tests/external_dependency_unit/craft/test_scheduled_task_pre_approvals.py
@@ -481,6 +481,39 @@ def test_detail_includes_metadata_for_disabled_granted_apps(
     assert display_app.enabled is False
 
 
+def test_patch_allows_preserving_existing_unavailable_grant(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    user = make_user(db_session)
+    app = make_external_app(
+        db_session,
+        skill=make_skill(db_session),
+        auth_template={},
+        app_type=ExternalAppType.CUSTOM,
+    )
+    task = _seed_task(db_session, user, pre_approved_app_ids=[app.id], prompt="orig")
+
+    app.skill.enabled = False
+    db_session.commit()
+
+    response = scheduled_tasks_api.patch_task(
+        task_id=task.id,
+        request=scheduled_tasks_api.ScheduledTaskPatch.model_validate(
+            {
+                "prompt": "updated",
+                "pre_approved_app_ids": [app.id],
+            }
+        ),
+        user=user,
+        db_session=db_session,
+    )
+
+    assert response.prompt == "updated"
+    assert response.pre_approved_app_ids == [app.id]
+    assert response.pre_approved_apps[0].enabled is False
+
+
 def test_create_task_route_returns_detail_shape(
     db_session: Session,
     tenant_context: None,  # noqa: ARG001

--- a/backend/tests/external_dependency_unit/craft/test_scheduled_task_pre_approvals.py
+++ b/backend/tests/external_dependency_unit/craft/test_scheduled_task_pre_approvals.py
@@ -9,6 +9,7 @@ this file pins the queries those stubs stand in for.
 from __future__ import annotations
 
 from typing import Callable
+from uuid import uuid4
 
 import pytest
 from sqlalchemy import delete
@@ -17,6 +18,7 @@ from sqlalchemy.orm import Session
 
 from onyx.db.enums import ApprovalDecidedVia
 from onyx.db.enums import ApprovalDecision
+from onyx.db.enums import ExternalAppType
 from onyx.db.enums import ScheduledTaskRunStatus
 from onyx.db.enums import ScheduledTaskStatus
 from onyx.db.enums import ScheduledTaskTriggerSource
@@ -38,6 +40,7 @@ from tests.common.craft.payloads import default_action_entries
 from tests.external_dependency_unit.craft.db_helpers import make_external_app
 from tests.external_dependency_unit.craft.db_helpers import make_skill
 from tests.external_dependency_unit.craft.db_helpers import make_user
+from tests.external_dependency_unit.craft.db_helpers import make_user_credential
 
 
 def _make_app(db_session: Session) -> int:
@@ -356,17 +359,17 @@ def test_deleting_app_nulls_action_approval_fk(
 
 
 # ---------------------------------------------------------------------------
-# API validation helper
+# API helpers
 # ---------------------------------------------------------------------------
 
 
-def test_validated_app_ids_rejects_unknown_and_dedupes(
+def test_validated_app_ids_rejects_unavailable_and_dedupes(
     db_session: Session,
     tenant_context: None,  # noqa: ARG001
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Dedupe is order-preserving; any id outside the tenant's apps raises
-    INVALID_INPUT. Apps are stubbed — only the validation logic is under
+    """Dedupe is order-preserving; any id outside the user's available apps
+    raises INVALID_INPUT. Apps are stubbed — only the validation logic is under
     test, not ``get_external_apps``'s SQL."""
 
     class _App:
@@ -376,12 +379,130 @@ def test_validated_app_ids_rejects_unknown_and_dedupes(
     monkeypatch.setattr(
         scheduled_tasks_api,
         "get_external_apps",
-        lambda _db: [_App(7), _App(9)],
+        lambda _db: [_App(7), _App(9), _App(11)],
+    )
+    monkeypatch.setattr(
+        scheduled_tasks_api,
+        "app_is_available",
+        lambda _db, app, _user_id: app.id in {7, 9},
     )
 
-    assert scheduled_tasks_api._validated_app_ids(db_session, []) == []
-    assert scheduled_tasks_api._validated_app_ids(db_session, [9, 7, 9]) == [9, 7]
+    user_id = make_user(db_session).id
+
+    assert scheduled_tasks_api._validated_app_ids(db_session, [], user_id) == []
+    assert scheduled_tasks_api._validated_app_ids(db_session, [9, 7, 9], user_id) == [
+        9,
+        7,
+    ]
 
     with pytest.raises(OnyxError) as exc_info:
-        scheduled_tasks_api._validated_app_ids(db_session, [7, 123])
+        scheduled_tasks_api._validated_app_ids(db_session, [7, 11, 123], user_id)
     assert exc_info.value.error_code == OnyxErrorCode.INVALID_INPUT
+
+
+def test_validated_app_ids_uses_gateway_availability(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    user = make_user(db_session)
+    credentialless_app = make_external_app(
+        db_session,
+        skill=make_skill(db_session),
+        auth_template={},
+        app_type=ExternalAppType.CUSTOM,
+    )
+    disabled_app = make_external_app(
+        db_session,
+        skill=make_skill(db_session, enabled=False),
+        auth_template={},
+        app_type=ExternalAppType.CUSTOM,
+    )
+    missing_credential_app = make_external_app(
+        db_session,
+        skill=make_skill(db_session),
+        auth_template={"Authorization": "Bearer {access_token}"},
+        app_type=ExternalAppType.CUSTOM,
+    )
+    user_credential_app = make_external_app(
+        db_session,
+        skill=make_skill(db_session),
+        auth_template={"Authorization": "Bearer {access_token}"},
+        app_type=ExternalAppType.CUSTOM,
+    )
+    make_user_credential(
+        db_session,
+        app=user_credential_app,
+        user=user,
+        user_credentials={"access_token": "test-token"},
+    )
+    db_session.commit()
+
+    assert scheduled_tasks_api._validated_app_ids(
+        db_session,
+        [credentialless_app.id, user_credential_app.id, credentialless_app.id],
+        user.id,
+    ) == [credentialless_app.id, user_credential_app.id]
+
+    with pytest.raises(OnyxError) as exc_info:
+        scheduled_tasks_api._validated_app_ids(
+            db_session,
+            [credentialless_app.id, disabled_app.id, missing_credential_app.id],
+            user.id,
+        )
+    assert exc_info.value.error_code == OnyxErrorCode.INVALID_INPUT
+
+
+def test_detail_includes_metadata_for_disabled_granted_apps(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    user = make_user(db_session)
+    app = make_external_app(
+        db_session,
+        skill=make_skill(
+            db_session,
+            slug=f"disabled-preapproved-app-{uuid4().hex[:8]}",
+            enabled=False,
+        ),
+        auth_template={},
+        app_type=ExternalAppType.CUSTOM,
+    )
+    task = _seed_task(db_session, user, pre_approved_app_ids=[app.id])
+
+    detail = scheduled_tasks_api._detail(db_session, task, user.id)
+
+    assert detail.pre_approved_app_ids == [app.id]
+    assert len(detail.pre_approved_apps) == 1
+    [display_app] = detail.pre_approved_apps
+    assert display_app.id == app.id
+    assert display_app.name == app.skill.name
+    assert display_app.slug == app.skill.slug
+    assert display_app.app_type == ExternalAppType.CUSTOM
+    assert display_app.enabled is False
+
+
+def test_create_task_route_returns_detail_shape(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    user = make_user(db_session)
+    request = scheduled_tasks_api.ScheduledTaskCreate.model_validate(
+        {
+            "name": "route-contract",
+            "prompt": "Run the route contract check",
+            "editor_mode": "interval",
+            "editor_payload": {"unit": "hours", "every": 1},
+        }
+    )
+
+    response = scheduled_tasks_api.create_task(
+        request=request,
+        user=user,
+        db_session=db_session,
+    )
+
+    assert isinstance(response, scheduled_tasks_api.ScheduledTaskDetail)
+    assert response.prompt == "Run the route contract check"
+    assert response.next_runs
+    assert response.pre_approved_app_ids == []
+    assert response.pre_approved_apps == []

--- a/backend/tests/external_dependency_unit/craft/test_scheduled_task_pre_approvals.py
+++ b/backend/tests/external_dependency_unit/craft/test_scheduled_task_pre_approvals.py
@@ -383,8 +383,8 @@ def test_validated_app_ids_rejects_unavailable_and_dedupes(
     )
     monkeypatch.setattr(
         scheduled_tasks_api,
-        "app_is_available",
-        lambda _db, app, _user_id: app.id in {7, 9},
+        "app_is_available_for_user_credential",
+        lambda app, _user_cred: app.id in {7, 9},
     )
 
     user_id = make_user(db_session).id

--- a/web/src/app/craft/v1/tasks/api.ts
+++ b/web/src/app/craft/v1/tasks/api.ts
@@ -7,7 +7,6 @@
  */
 
 import type {
-  ScheduledTaskListItem,
   ScheduledTaskDetail,
   ScheduledTaskCreateBody,
   ScheduledTaskPatchBody,
@@ -40,14 +39,14 @@ async function readError(res: Response, fallback: string): Promise<never> {
 
 export async function createScheduledTask(
   body: ScheduledTaskCreateBody
-): Promise<ScheduledTaskListItem> {
+): Promise<ScheduledTaskDetail> {
   const res = await fetch(API_BASE, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
   });
   if (!res.ok) await readError(res, "Failed to create scheduled task");
-  return (await res.json()) as ScheduledTaskListItem;
+  return (await res.json()) as ScheduledTaskDetail;
 }
 
 export async function updateScheduledTask(

--- a/web/src/app/craft/v1/tasks/interfaces.ts
+++ b/web/src/app/craft/v1/tasks/interfaces.ts
@@ -19,6 +19,15 @@ export type ScheduledTaskTriggerSource = "SCHEDULED" | "MANUAL_RUN_NOW";
 
 export type EditorMode = "interval" | "daily_weekly" | "advanced";
 
+export type ExternalAppType =
+  | "SLACK"
+  | "GOOGLE_CALENDAR"
+  | "GOOGLE_DRIVE"
+  | "GMAIL"
+  | "LINEAR"
+  | "GITHUB"
+  | "CUSTOM";
+
 export type IntervalUnit = "minutes" | "hours" | "days";
 
 export interface IntervalPayload {
@@ -67,6 +76,15 @@ export interface ScheduledTaskListItem {
   updated_at: string;
 }
 
+export interface ScheduledTaskPreApprovedAppDisplay {
+  id: number;
+  name: string;
+  description: string;
+  slug: string;
+  app_type: ExternalAppType;
+  enabled: boolean;
+}
+
 export interface ScheduledTaskDetail {
   id: string;
   name: string;
@@ -79,6 +97,7 @@ export interface ScheduledTaskDetail {
   next_runs: string[];
   last_run: ScheduledRunSummary | null;
   pre_approved_app_ids: number[];
+  pre_approved_apps: ScheduledTaskPreApprovedAppDisplay[];
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## Description

- Validate scheduled task pre-approved app IDs with the same availability predicate used by the external-app gateway.
- Include stable pre-approved app display metadata on scheduled task detail/create responses, including stored grants for apps that later become disabled or filtered out of the user app list.
- Align the scheduled task create client type with the backend detail response.

## How Has This Been Tested?


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates scheduled task pre-approved app IDs using the gateway’s availability check and preserves previously granted apps even if they later become unavailable. The create and patch APIs return full task detail, and the web client consumes it.

- **Bug Fixes**
  - Validate pre-approvals via `app_is_available_for_user_credential`, dedupe IDs, and reject unavailable IDs with `INVALID_INPUT`.
  - Pass `user.id` into validation for create and patch to match gateway behavior.
  - Preserve existing unavailable app grants on PATCH; only newly added unavailable IDs are rejected.

- **New Features**
  - Add `pre_approved_apps` to `ScheduledTaskDetail` with id, name, description, slug, `app_type`, and `enabled` (shown even if the app later becomes disabled).
  - Web: `createScheduledTask` now returns `ScheduledTaskDetail`; add `ExternalAppType` and `ScheduledTaskPreApprovedAppDisplay` types.

<sup>Written for commit e9b89d7a0f3989cb3160f4605b147ad5664d3ece. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

