### PR TITLE
fix(audit): attach dedicated stdout handler so api-server audit events aren't dropped

### DIFF
--- a/backend/onyx/utils/audit.py
+++ b/backend/onyx/utils/audit.py
@@ -13,6 +13,7 @@ hot event classes via Redis (degrade to always-emit if Redis is down).
 
 import json
 import logging
+import sys
 import time
 from dataclasses import dataclass
 from enum import Enum
@@ -20,10 +21,10 @@ from typing import Any
 
 AUDIT_SCHEMA_VERSION = "1.0"
 
-# Root of the audit logger tree; per-class children propagate up to it. Plain
-# ``getLogger`` (not ``setup_logger``) keeps the record message a bare JSON
-# object with no human-readable prefix.
+# Root of the audit logger tree; children propagate up to the dedicated stdout
+# handler configured in ``_configure_audit_logging``.
 AUDIT_LOGGER_ROOT = "onyx.audit"
+AUDIT_HANDLER_NAME = "onyx_audit_stdout"
 
 # Diagnostics logger for the subsystem's own failures. Deliberately NOT under
 # ``onyx.audit`` so internal warnings never land in the parsed audit stream.
@@ -274,6 +275,33 @@ def emit_audit_event(
     except Exception:
         # Audit must never break the caller.
         return
+
+
+def _configure_audit_logging() -> None:
+    """Own an INFO stdout handler on ``onyx.audit`` so events reach stdout
+    regardless of host-process logging. Relying on root propagation dropped
+    every event under uvicorn (root unconfigured -> WARNING ``lastResort``).
+    ``propagate=False`` keeps output identical across processes and avoids
+    double-logging where root is configured (celery). Idempotent.
+    """
+    audit_root = logging.getLogger(AUDIT_LOGGER_ROOT)
+    if any(h.name == AUDIT_HANDLER_NAME for h in audit_root.handlers):
+        return
+    handler = logging.StreamHandler(sys.stdout)
+    handler.name = AUDIT_HANDLER_NAME
+    handler.setLevel(logging.INFO)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    audit_root.addHandler(handler)
+    audit_root.setLevel(logging.INFO)
+    audit_root.propagate = False
+
+
+# IMPORT-TIME SIDE EFFECT (deliberate): configure the audit handler on import
+# so the subsystem is self-contained in every process that imports it. A
+# startup-hook entrypoint would reintroduce the bug this fixes -- a process
+# emitting events without having called it drops them silently. Idempotent and
+# inert until an event is actually emitted.
+_configure_audit_logging()
 
 
 def _logger_for(ocsf_class: OCSFEventClass | None) -> logging.Logger:

--- a/backend/tests/unit/onyx/conftest.py
+++ b/backend/tests/unit/onyx/conftest.py
@@ -1,0 +1,22 @@
+"""Shared fixtures for onyx unit tests."""
+
+import logging
+from collections.abc import Generator
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _capture_audit_logger(
+    caplog: pytest.LogCaptureFixture,
+) -> Generator[None, None, None]:
+    """Attach caplog's handler to ``onyx.audit`` so audit tests can assert on
+    caplog: the subsystem sets ``propagate=False``, so records don't reach
+    pytest's root handler. No-op for tests that emit no audit events.
+    """
+    audit_logger = logging.getLogger("onyx.audit")
+    audit_logger.addHandler(caplog.handler)
+    try:
+        yield
+    finally:
+        audit_logger.removeHandler(caplog.handler)

--- a/backend/tests/unit/onyx/utils/test_audit.py
+++ b/backend/tests/unit/onyx/utils/test_audit.py
@@ -5,9 +5,12 @@ OCSF-shaped schema, never logging a secret, never raising on missing context,
 and Redis-backed dedup that degrades safely when Redis is unavailable.
 """
 
+import io
 import json
 import logging
 from typing import Any
+from typing import cast
+from typing import TextIO
 from unittest.mock import MagicMock
 
 import pytest
@@ -15,6 +18,8 @@ import pytest
 from onyx.utils import audit
 from onyx.utils.audit import _OCSF_CLASS_BY_ACTION
 from onyx.utils.audit import actor_from_user
+from onyx.utils.audit import AUDIT_HANDLER_NAME
+from onyx.utils.audit import AUDIT_LOGGER_ROOT
 from onyx.utils.audit import AuditAction
 from onyx.utils.audit import AuditActor
 from onyx.utils.audit import AuditOutcome
@@ -172,6 +177,39 @@ def test_no_dedup_key_always_emits(caplog: pytest.LogCaptureFixture) -> None:
         emit_audit_event(AuditAction.USER_ROLE_CHANGE, AuditOutcome.SUCCESS)
 
     assert len(_capture(caplog)) == 2
+
+
+def test_audit_logger_self_contained_without_root_handler() -> None:
+    """Regression: events must reach the subsystem's handler even with no root
+    handler (the uvicorn condition that silently dropped every api-server event).
+    """
+    audit_root = logging.getLogger(AUDIT_LOGGER_ROOT)
+
+    own_handlers = [h for h in audit_root.handlers if h.name == AUDIT_HANDLER_NAME]
+    assert own_handlers, "onyx.audit must attach its own handler"
+    assert audit_root.propagate is False
+
+    # Simulate uvicorn (no root handlers); capture via a temporary handler.
+    buf = io.StringIO()
+    capture = logging.StreamHandler(cast(TextIO, buf))
+    audit_root.addHandler(capture)
+    root = logging.getLogger()
+    saved_root_handlers = root.handlers[:]
+    root.handlers = []
+    try:
+        emit_audit_event(
+            AuditAction.LOGIN,
+            AuditOutcome.SUCCESS,
+            actor=AuditActor(user_id="u-1", email="a@example.com"),
+        )
+    finally:
+        root.handlers = saved_root_handlers
+        audit_root.removeHandler(capture)
+
+    lines = [ln for ln in buf.getvalue().splitlines() if ln.strip()]
+    assert lines, "audit event must reach onyx.audit handlers without root"
+    payload = json.loads(lines[-1])
+    assert payload["action"] == "auth.login"
 
 
 def test_actor_from_user_none_returns_none() -> None:


### PR DESCRIPTION
## Description

**Fixes a bug where audit events emitted from the api-server are silently dropped and never reach stdout / a SIEM.** Found by live-testing the audit subsystem on st-dev.

The audit loggers (`onyx.audit.*`) used a bare `getLogger` with **no handler** and relied on propagating to the root logger. In processes that don't configure root — notably the **uvicorn-based api-server**, which is where *all* auth / admin-config / access-control events are emitted — records fall through to Python's `lastResort` handler (level `WARNING`), so the `INFO` audit lines are **discarded**. Only celery-emitted events surfaced, because the celery bootstrap configures the root logger.

### How it was found
On st-dev (running an `edge` build with the audit code), an OAuth login produced `GET /auth/oauth/callback … 302`, which runs `on_after_login` and its unconditional `auth.login` emit — yet the api-server had emitted **0** `onyx.audit` lines ever. Logger introspection in the running pod confirmed it:
```
<root>                     handlers=0  eff=WARNING
onyx.audit                 handlers=0  eff=WARNING
lastResort_level=WARNING
```
The existing unit tests missed this because pytest's `caplog` attaches its own root handler, so emission "works" under test but not under uvicorn.

### Fix
`onyx.audit` now owns a dedicated `INFO` `StreamHandler(stdout)` that emits the bare JSON message, with `propagate=False` so the line is byte-identical across processes (matching the documented schema) and never double-logged where root *is* configured (celery). Idempotent. The `credential_audit.py` seed is covered automatically via the shared `onyx.audit` parent — its api-server emissions were being dropped too and are now fixed (seed file untouched).

## How Has This Been Tested?

- New regression test (`test_audit_logger_self_contained_without_root_handler`) asserts the subsystem owns a handler, sets `propagate=False`, and delivers an event with **no root handler present** — it fails on the pre-fix code.
- Added an autouse conftest fixture so the existing `caplog`-based audit tests capture the now-non-propagating logger.
- `backend/tests/unit/onyx/utils/test_audit.py`, `test_auth_audit_events.py`, `test_admin_audit_events.py` all pass (20); broader `unit/onyx/{utils,auth}` slice green (549 passed). `ty` + `ruff` clean.
- Next: redeploy `edge` to st-dev and re-run the OAuth-login test to confirm `auth.login` lands in the api-server logs.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dropped api-server audit events by giving `onyx.audit` its own `INFO` stdout handler and disabling propagation so JSON audit lines always reach stdout/SIEM. Removes reliance on `uvicorn`’s root logger that was discarding `INFO` records.

- **Bug Fixes**
  - Attached `onyx_audit_stdout` `StreamHandler(sys.stdout)` to `onyx.audit` with `%(message)s`, `level=INFO`; set logger `level=INFO`, `propagate=False` (idempotent at import).
  - Added regression test to verify delivery with no root handler; added autouse `pytest` fixture to route `caplog` to `onyx.audit`.
  - Child loggers (including the credential audit seed) inherit the handler; no emitter changes needed.

<sup>Written for commit 39779513248761db5d4dcffc8513879e000c4b91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

