### PR TITLE
feat(redis): Redis Sentinel (HA) support — app Redis + Celery, TLS-aware

### DIFF
--- a/backend/onyx/background/celery/configs/base.py
+++ b/backend/onyx/background/celery/configs/base.py
@@ -69,13 +69,23 @@ _SENTINEL_NODES = ";".join(
     for host, port in REDIS_SENTINEL_HOSTS
 )
 _SENTINEL_TRANSPORT_OPTIONS: dict = {}
+# Celery TLS settings for the Sentinel data connections. Always defined (empty =
+# no SSL, matching Celery's default) so they're not conditionally-present module
+# globals.
+broker_use_ssl: dict[str, str] = {}
+redis_backend_use_ssl: dict[str, str] = {}
 if USE_SENTINEL:
     _SENTINEL_TRANSPORT_OPTIONS["master_name"] = REDIS_SENTINEL_MASTER_NAME
     _sentinel_kwargs: dict = {}
     if REDIS_SENTINEL_PASSWORD:
         _sentinel_kwargs["password"] = REDIS_SENTINEL_PASSWORD
     if _SENTINEL_USE_SSL:
+        # sentinel_kwargs are redis-py connection kwargs, so they need the
+        # explicit `ssl` flag to actually negotiate TLS (the cert settings are
+        # inert without it). broker_use_ssl below is a Celery setting whose mere
+        # presence enables TLS, so it must NOT carry the `ssl` key.
         _sentinel_kwargs.update(_redis_ssl_settings())
+        _sentinel_kwargs["ssl"] = True
     if _sentinel_kwargs:
         _SENTINEL_TRANSPORT_OPTIONS["sentinel_kwargs"] = _sentinel_kwargs
     # TLS for the master/replica data connections.

--- a/backend/onyx/background/celery/configs/base.py
+++ b/backend/onyx/background/celery/configs/base.py
@@ -123,6 +123,7 @@ task_acks_late = True
 # region Task result backend settings
 # It's possible we don't even need celery's result backend, in which case all of the optimization below
 # might be irrelevant
+result_backend_transport_options: dict = {}
 if USE_SENTINEL:
     result_backend = f"{_SENTINEL_NODES}/{REDIS_DB_NUMBER_CELERY_RESULT_BACKEND}"
     result_backend_transport_options = _SENTINEL_TRANSPORT_OPTIONS

--- a/backend/onyx/background/celery/configs/base.py
+++ b/backend/onyx/background/celery/configs/base.py
@@ -9,6 +9,9 @@ from onyx.configs.app_configs import REDIS_HEALTH_CHECK_INTERVAL
 from onyx.configs.app_configs import REDIS_HOST
 from onyx.configs.app_configs import REDIS_PASSWORD
 from onyx.configs.app_configs import REDIS_PORT
+from onyx.configs.app_configs import REDIS_SENTINEL_HOSTS
+from onyx.configs.app_configs import REDIS_SENTINEL_MASTER_NAME
+from onyx.configs.app_configs import REDIS_SENTINEL_PASSWORD
 from onyx.configs.app_configs import REDIS_SSL
 from onyx.configs.app_configs import REDIS_SSL_CA_CERTS
 from onyx.configs.app_configs import REDIS_SSL_CERT_REQS
@@ -43,9 +46,49 @@ if REDIS_SSL and not USE_REDIS_IAM_AUTH:
             f"&ssl_keyfile={urllib.parse.quote(REDIS_SSL_KEYFILE, safe='')}"
         )
 
+# Redis Sentinel (HA): Celery/kombu use one `sentinel://` URL per node, the
+# master name in transport options, and `broker_use_ssl` for TLS. The URL
+# password authenticates the master/replica; sentinel-node auth + TLS go in
+# `sentinel_kwargs`.
+USE_SENTINEL = bool(REDIS_SENTINEL_HOSTS)
+_SENTINEL_USE_SSL = REDIS_SSL and not USE_REDIS_IAM_AUTH
+
+
+def _redis_ssl_settings() -> dict[str, str]:
+    settings: dict[str, str] = {"ssl_cert_reqs": REDIS_SSL_CERT_REQS}
+    if REDIS_SSL_CA_CERTS:
+        settings["ssl_ca_certs"] = REDIS_SSL_CA_CERTS
+    if REDIS_SSL_CERTFILE and REDIS_SSL_KEYFILE:
+        settings["ssl_certfile"] = REDIS_SSL_CERTFILE
+        settings["ssl_keyfile"] = REDIS_SSL_KEYFILE
+    return settings
+
+
+_SENTINEL_NODES = ";".join(
+    f"sentinel://{CELERY_PASSWORD_PART}{host}:{port}"
+    for host, port in REDIS_SENTINEL_HOSTS
+)
+_SENTINEL_TRANSPORT_OPTIONS: dict = {}
+if USE_SENTINEL:
+    _SENTINEL_TRANSPORT_OPTIONS["master_name"] = REDIS_SENTINEL_MASTER_NAME
+    _sentinel_kwargs: dict = {}
+    if REDIS_SENTINEL_PASSWORD:
+        _sentinel_kwargs["password"] = REDIS_SENTINEL_PASSWORD
+    if _SENTINEL_USE_SSL:
+        _sentinel_kwargs.update(_redis_ssl_settings())
+    if _sentinel_kwargs:
+        _SENTINEL_TRANSPORT_OPTIONS["sentinel_kwargs"] = _sentinel_kwargs
+    # TLS for the master/replica data connections.
+    if _SENTINEL_USE_SSL:
+        broker_use_ssl = _redis_ssl_settings()
+        redis_backend_use_ssl = _redis_ssl_settings()
+
 # region Broker settings
 # example celery_broker_url: "redis://:password@localhost:6379/15"
-broker_url = f"{REDIS_SCHEME}://{CELERY_PASSWORD_PART}{REDIS_HOST}:{REDIS_PORT}/{REDIS_DB_NUMBER_CELERY}{SSL_QUERY_PARAMS}"
+if USE_SENTINEL:
+    broker_url = f"{_SENTINEL_NODES}/{REDIS_DB_NUMBER_CELERY}"
+else:
+    broker_url = f"{REDIS_SCHEME}://{CELERY_PASSWORD_PART}{REDIS_HOST}:{REDIS_PORT}/{REDIS_DB_NUMBER_CELERY}{SSL_QUERY_PARAMS}"
 
 broker_connection_retry_on_startup = True
 broker_pool_limit = CELERY_BROKER_POOL_LIMIT
@@ -61,6 +104,8 @@ broker_transport_options = {
     "socket_keepalive": True,
     "socket_keepalive_options": REDIS_SOCKET_KEEPALIVE_OPTIONS,
 }
+if USE_SENTINEL:
+    broker_transport_options.update(_SENTINEL_TRANSPORT_OPTIONS)
 # endregion
 
 # redis backend settings
@@ -78,7 +123,11 @@ task_acks_late = True
 # region Task result backend settings
 # It's possible we don't even need celery's result backend, in which case all of the optimization below
 # might be irrelevant
-result_backend = f"{REDIS_SCHEME}://{CELERY_PASSWORD_PART}{REDIS_HOST}:{REDIS_PORT}/{REDIS_DB_NUMBER_CELERY_RESULT_BACKEND}{SSL_QUERY_PARAMS}"
+if USE_SENTINEL:
+    result_backend = f"{_SENTINEL_NODES}/{REDIS_DB_NUMBER_CELERY_RESULT_BACKEND}"
+    result_backend_transport_options = _SENTINEL_TRANSPORT_OPTIONS
+else:
+    result_backend = f"{REDIS_SCHEME}://{CELERY_PASSWORD_PART}{REDIS_HOST}:{REDIS_PORT}/{REDIS_DB_NUMBER_CELERY_RESULT_BACKEND}{SSL_QUERY_PARAMS}"
 result_expires = CELERY_RESULT_EXPIRES  # 86400 seconds is the default
 # endregion
 

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -714,6 +714,26 @@ REDIS_PASSWORD = os.environ.get("REDIS_PASSWORD") or ""
 # this assumes that other redis settings remain the same as the primary
 REDIS_REPLICA_HOST = os.environ.get("REDIS_REPLICA_HOST") or REDIS_HOST
 
+# Redis Sentinel for high availability. When REDIS_SENTINEL_HOSTS is set, the app
+# (and Celery) connect via Sentinel — which discovers the current master and
+# follows failover — instead of REDIS_HOST/REDIS_PORT directly. Format is a
+# comma-separated list of host:port sentinel nodes. REDIS_PASSWORD still
+# authenticates the master/replica; REDIS_SENTINEL_PASSWORD (optional) is for the
+# sentinel nodes themselves if they require separate auth. TLS (REDIS_SSL +
+# certs) applies to both the sentinel and the data connections.
+_REDIS_SENTINEL_HOSTS_STR = os.environ.get("REDIS_SENTINEL_HOSTS", "").strip()
+REDIS_SENTINEL_HOSTS: list[tuple[str, int]] = [
+    (host.rsplit(":", 1)[0], int(host.rsplit(":", 1)[1]))
+    for host in (h.strip() for h in _REDIS_SENTINEL_HOSTS_STR.split(",") if h.strip())
+]
+REDIS_SENTINEL_MASTER_NAME = os.environ.get("REDIS_SENTINEL_MASTER_NAME", "mymaster")
+REDIS_SENTINEL_PASSWORD = os.environ.get("REDIS_SENTINEL_PASSWORD") or None
+
+if REDIS_SENTINEL_HOSTS and not REDIS_SENTINEL_MASTER_NAME:
+    raise ValueError(
+        "REDIS_SENTINEL_HOSTS is set but REDIS_SENTINEL_MASTER_NAME is empty."
+    )
+
 REDIS_AUTH_KEY_PREFIX = "fastapi_users_token:"
 
 # Rate limiting for auth endpoints

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -732,14 +732,21 @@ def _parse_sentinel_hosts(raw: str) -> list[tuple[str, int]]:
             raise ValueError(
                 f"Invalid REDIS_SENTINEL_HOSTS entry {entry!r}; expected host:port."
             )
-        hosts.append((host, int(port)))
+        port_num = int(port)
+        if not 1 <= port_num <= 65535:
+            raise ValueError(
+                f"Invalid REDIS_SENTINEL_HOSTS port {port!r}; must be 1-65535."
+            )
+        hosts.append((host, port_num))
     return hosts
 
 
 REDIS_SENTINEL_HOSTS: list[tuple[str, int]] = _parse_sentinel_hosts(
     _REDIS_SENTINEL_HOSTS_STR
 )
-REDIS_SENTINEL_MASTER_NAME = os.environ.get("REDIS_SENTINEL_MASTER_NAME", "mymaster")
+REDIS_SENTINEL_MASTER_NAME = os.environ.get(
+    "REDIS_SENTINEL_MASTER_NAME", "mymaster"
+).strip()
 REDIS_SENTINEL_PASSWORD = os.environ.get("REDIS_SENTINEL_PASSWORD") or None
 
 # Fail loudly rather than silently falling back to a direct connection when the

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -722,16 +722,41 @@ REDIS_REPLICA_HOST = os.environ.get("REDIS_REPLICA_HOST") or REDIS_HOST
 # sentinel nodes themselves if they require separate auth. TLS (REDIS_SSL +
 # certs) applies to both the sentinel and the data connections.
 _REDIS_SENTINEL_HOSTS_STR = os.environ.get("REDIS_SENTINEL_HOSTS", "").strip()
-REDIS_SENTINEL_HOSTS: list[tuple[str, int]] = [
-    (host.rsplit(":", 1)[0], int(host.rsplit(":", 1)[1]))
-    for host in (h.strip() for h in _REDIS_SENTINEL_HOSTS_STR.split(",") if h.strip())
-]
+
+
+def _parse_sentinel_hosts(raw: str) -> list[tuple[str, int]]:
+    hosts: list[tuple[str, int]] = []
+    for entry in (h.strip() for h in raw.split(",") if h.strip()):
+        host, sep, port = entry.rpartition(":")
+        if not sep or not host or not port.isdigit():
+            raise ValueError(
+                f"Invalid REDIS_SENTINEL_HOSTS entry {entry!r}; expected host:port."
+            )
+        hosts.append((host, int(port)))
+    return hosts
+
+
+REDIS_SENTINEL_HOSTS: list[tuple[str, int]] = _parse_sentinel_hosts(
+    _REDIS_SENTINEL_HOSTS_STR
+)
 REDIS_SENTINEL_MASTER_NAME = os.environ.get("REDIS_SENTINEL_MASTER_NAME", "mymaster")
 REDIS_SENTINEL_PASSWORD = os.environ.get("REDIS_SENTINEL_PASSWORD") or None
 
+# Fail loudly rather than silently falling back to a direct connection when the
+# operator clearly intended Sentinel.
+if _REDIS_SENTINEL_HOSTS_STR and not REDIS_SENTINEL_HOSTS:
+    raise ValueError(
+        "REDIS_SENTINEL_HOSTS is set but no valid host:port pairs were parsed."
+    )
 if REDIS_SENTINEL_HOSTS and not REDIS_SENTINEL_MASTER_NAME:
     raise ValueError(
         "REDIS_SENTINEL_HOSTS is set but REDIS_SENTINEL_MASTER_NAME is empty."
+    )
+if REDIS_SENTINEL_HOSTS and USE_REDIS_IAM_AUTH:
+    raise ValueError(
+        "REDIS_SENTINEL_HOSTS and USE_REDIS_IAM_AUTH cannot be combined: Sentinel "
+        "is for self-managed HA Redis, while IAM auth targets AWS ElastiCache "
+        "(which manages failover itself)."
     )
 
 REDIS_AUTH_KEY_PREFIX = "fastapi_users_token:"

--- a/backend/onyx/redis/redis_pool.py
+++ b/backend/onyx/redis/redis_pool.py
@@ -8,6 +8,7 @@ from typing import Optional
 import redis
 from fastapi import Request
 from redis import asyncio as aioredis
+from redis.asyncio.sentinel import Sentinel as AsyncSentinel
 from redis.backoff import ExponentialBackoff
 from redis.client import Redis
 from redis.exceptions import BusyLoadingError
@@ -15,6 +16,7 @@ from redis.exceptions import ConnectionError as RedisConnectionError
 from redis.exceptions import TimeoutError as RedisTimeoutError
 from redis.lock import Lock as RedisLock
 from redis.retry import Retry
+from redis.sentinel import Sentinel
 
 from onyx.auth.constants import API_KEY_HEADER_ALTERNATIVE_NAME
 from onyx.auth.constants import API_KEY_HEADER_NAME
@@ -27,6 +29,9 @@ from onyx.configs.app_configs import REDIS_PASSWORD
 from onyx.configs.app_configs import REDIS_POOL_MAX_CONNECTIONS
 from onyx.configs.app_configs import REDIS_PORT
 from onyx.configs.app_configs import REDIS_REPLICA_HOST
+from onyx.configs.app_configs import REDIS_SENTINEL_HOSTS
+from onyx.configs.app_configs import REDIS_SENTINEL_MASTER_NAME
+from onyx.configs.app_configs import REDIS_SENTINEL_PASSWORD
 from onyx.configs.app_configs import REDIS_SSL
 from onyx.configs.app_configs import REDIS_SSL_CA_CERTS
 from onyx.configs.app_configs import REDIS_SSL_CERT_REQS
@@ -65,11 +70,50 @@ def _client_retry_kwargs() -> dict[str, Any]:
     }
 
 
+def _redis_ssl_connect_kwargs() -> dict[str, Any]:
+    """Native redis-py ssl_* kwargs for a TLS Redis connection, shared by the
+    Sentinel sync + async paths (the direct pool builds these inline)."""
+    kwargs: dict[str, Any] = {
+        "ssl": True,
+        "ssl_cert_reqs": REDIS_SSL_CERT_REQS,
+        "ssl_check_hostname": False,
+    }
+    if REDIS_SSL_CA_CERTS:
+        kwargs["ssl_ca_certs"] = REDIS_SSL_CA_CERTS
+    if REDIS_SSL_CERTFILE:
+        kwargs["ssl_certfile"] = REDIS_SSL_CERTFILE
+        kwargs["ssl_keyfile"] = REDIS_SSL_KEYFILE
+    return kwargs
+
+
+def _sentinel_connection_kwargs() -> tuple[dict[str, Any], dict[str, Any]]:
+    """Build (connection_kwargs, sentinel_kwargs) for a Sentinel.
+
+    connection_kwargs apply to the master/replica data connections;
+    sentinel_kwargs apply to the connections to the sentinel nodes themselves.
+    TLS (when enabled) and the relevant auth apply to both.
+    """
+    connection_kwargs: dict[str, Any] = {
+        "password": REDIS_PASSWORD or None,
+        "socket_keepalive": True,
+        "socket_keepalive_options": REDIS_SOCKET_KEEPALIVE_OPTIONS,
+        "health_check_interval": REDIS_HEALTH_CHECK_INTERVAL,
+    }
+    sentinel_kwargs: dict[str, Any] = {}
+    if REDIS_SENTINEL_PASSWORD:
+        sentinel_kwargs["password"] = REDIS_SENTINEL_PASSWORD
+    if REDIS_SSL:
+        ssl_kwargs = _redis_ssl_connect_kwargs()
+        connection_kwargs.update(ssl_kwargs)
+        sentinel_kwargs.update(ssl_kwargs)
+    return connection_kwargs, sentinel_kwargs
+
+
 class RedisPool:
     _instance: Optional["RedisPool"] = None
     _lock: threading.Lock = threading.Lock()
-    _pool: redis.BlockingConnectionPool
-    _replica_pool: redis.BlockingConnectionPool
+    _pool: redis.ConnectionPool
+    _replica_pool: redis.ConnectionPool
 
     def __new__(cls) -> "RedisPool":
         if not cls._instance:
@@ -82,7 +126,7 @@ class RedisPool:
     def _init_pools(self) -> None:
         self._pool = RedisPool.create_pool(ssl=REDIS_SSL)
         self._replica_pool = RedisPool.create_pool(
-            host=REDIS_REPLICA_HOST, ssl=REDIS_SSL
+            host=REDIS_REPLICA_HOST, ssl=REDIS_SSL, replica=True
         )
 
     def get_client(self, tenant_id: str) -> TenantRedisClient:
@@ -123,22 +167,32 @@ class RedisPool:
         ssl_certfile: str | None = REDIS_SSL_CERTFILE,
         ssl_keyfile: str | None = REDIS_SSL_KEYFILE,
         ssl: bool = False,
-    ) -> redis.BlockingConnectionPool:
+        replica: bool = False,
+    ) -> redis.ConnectionPool:
         """
         Create a Redis connection pool with appropriate SSL configuration.
         SSL Configuration Priority:
-        1. IAM Authentication (USE_REDIS_IAM_AUTH=true): Uses system CA certificates
-        2. Regular SSL (REDIS_SSL=true): Uses custom SSL configuration
-        3. No SSL: Standard connection without encryption
+        1. Sentinel (REDIS_SENTINEL_HOSTS set): connect through Sentinel, which
+           discovers the current master/replica and follows failover.
+        2. IAM Authentication (USE_REDIS_IAM_AUTH=true): Uses system CA certificates
+        3. Regular SSL (REDIS_SSL=true): Uses custom SSL configuration
+        4. No SSL: Standard connection without encryption
         Note: IAM authentication automatically enables SSL and takes precedence
         over regular SSL configuration to ensure proper security.
 
         We use BlockingConnectionPool because it will block and wait for a connection
         rather than error if max_connections is reached. This is far more deterministic
-        behavior and aligned with how we want to use Redis."""
+        behavior and aligned with how we want to use Redis (Sentinel mode uses
+        redis-py's SentinelConnectionPool instead)."""
 
         # Using ConnectionPool is not well documented.
         # Useful examples: https://github.com/redis/redis-py/issues/780
+
+        # Handle Sentinel (HA) first — it owns master/replica discovery.
+        if REDIS_SENTINEL_HOSTS:
+            return RedisPool._create_sentinel_pool(
+                db=db, max_connections=max_connections, replica=replica
+            )
 
         # Handle IAM authentication
         if USE_REDIS_IAM_AUTH:
@@ -188,6 +242,26 @@ class RedisPool:
             socket_keepalive=True,
             socket_keepalive_options=REDIS_SOCKET_KEEPALIVE_OPTIONS,
         )
+
+    @staticmethod
+    def _create_sentinel_pool(
+        db: int, max_connections: int, replica: bool
+    ) -> redis.ConnectionPool:
+        """Return a SentinelConnectionPool for the master (or a replica) of
+        REDIS_SENTINEL_MASTER_NAME. Sentinel discovers the node and re-resolves
+        it on failover; the pool plugs into ``redis.Redis(connection_pool=...)``
+        like the direct pool."""
+        connection_kwargs, sentinel_kwargs = _sentinel_connection_kwargs()
+        sentinel = Sentinel(
+            REDIS_SENTINEL_HOSTS,
+            sentinel_kwargs=sentinel_kwargs,
+            **connection_kwargs,
+        )
+        node = sentinel.slave_for if replica else sentinel.master_for
+        client = node(
+            REDIS_SENTINEL_MASTER_NAME, db=db, max_connections=max_connections
+        )
+        return client.connection_pool
 
 
 redis_pool = RedisPool()
@@ -309,7 +383,27 @@ _async_redis_connections: dict["asyncio.AbstractEventLoop", aioredis.Redis] = {}
 _async_redis_init_lock = threading.Lock()
 
 
+def _build_async_sentinel_connection() -> aioredis.Redis:
+    """Async Redis for the current master of REDIS_SENTINEL_MASTER_NAME, via
+    Sentinel (HA / failover-aware)."""
+    connection_kwargs, sentinel_kwargs = _sentinel_connection_kwargs()
+    sentinel = AsyncSentinel(
+        REDIS_SENTINEL_HOSTS,
+        sentinel_kwargs=sentinel_kwargs,
+        **connection_kwargs,
+    )
+    return sentinel.master_for(
+        REDIS_SENTINEL_MASTER_NAME,
+        db=REDIS_DB_NUMBER,
+        max_connections=REDIS_POOL_MAX_CONNECTIONS,
+    )
+
+
 def _build_async_redis_connection() -> aioredis.Redis:
+    # Sentinel (HA) takes precedence — it owns master discovery.
+    if REDIS_SENTINEL_HOSTS:
+        return _build_async_sentinel_connection()
+
     connection_kwargs: dict[str, Any] = {
         "host": REDIS_HOST,
         "port": REDIS_PORT,

--- a/backend/tests/unit/onyx/redis/test_redis_sentinel.py
+++ b/backend/tests/unit/onyx/redis/test_redis_sentinel.py
@@ -1,0 +1,111 @@
+import importlib
+import os
+from unittest.mock import patch
+
+import onyx.redis.redis_pool as redis_pool
+
+_SENTINELS = [("s1", 26379), ("s2", 26379)]
+
+
+# --- app Redis (sync + async) connection routing --------------------------
+
+
+def test_sync_create_pool_routes_through_sentinel_master() -> None:
+    with (
+        patch.object(redis_pool, "REDIS_SENTINEL_HOSTS", _SENTINELS),
+        patch.object(redis_pool, "REDIS_SENTINEL_MASTER_NAME", "mymaster"),
+        patch.object(redis_pool, "REDIS_SSL", False),
+        patch.object(redis_pool, "Sentinel") as mock_sentinel_cls,
+    ):
+        pool = redis_pool.RedisPool.create_pool(db=5, replica=False)
+        # built a Sentinel over the configured nodes
+        assert mock_sentinel_cls.call_args.args[0] == _SENTINELS
+        sentinel = mock_sentinel_cls.return_value
+        sentinel.master_for.assert_called_once()
+        assert sentinel.master_for.call_args.args[0] == "mymaster"
+        sentinel.slave_for.assert_not_called()
+        # returns the master client's connection pool (plugs into redis.Redis)
+        assert pool is sentinel.master_for.return_value.connection_pool
+
+
+def test_sync_create_pool_replica_uses_slave() -> None:
+    with (
+        patch.object(redis_pool, "REDIS_SENTINEL_HOSTS", _SENTINELS),
+        patch.object(redis_pool, "REDIS_SSL", False),
+        patch.object(redis_pool, "Sentinel") as mock_sentinel_cls,
+    ):
+        redis_pool.RedisPool.create_pool(replica=True)
+        sentinel = mock_sentinel_cls.return_value
+        sentinel.slave_for.assert_called_once()
+        sentinel.master_for.assert_not_called()
+
+
+def test_async_connection_routes_through_sentinel_master() -> None:
+    with (
+        patch.object(redis_pool, "REDIS_SENTINEL_HOSTS", _SENTINELS),
+        patch.object(redis_pool, "REDIS_SENTINEL_MASTER_NAME", "mymaster"),
+        patch.object(redis_pool, "REDIS_SSL", False),
+        patch.object(redis_pool, "AsyncSentinel") as mock_async_sentinel_cls,
+    ):
+        conn = redis_pool._build_async_redis_connection()
+        assert mock_async_sentinel_cls.call_args.args[0] == _SENTINELS
+        sentinel = mock_async_sentinel_cls.return_value
+        sentinel.master_for.assert_called_once()
+        assert sentinel.master_for.call_args.args[0] == "mymaster"
+        assert conn is sentinel.master_for.return_value
+
+
+# --- TLS + auth applied to both sentinel and data connections -------------
+
+
+def test_sentinel_tls_and_auth_apply_to_both_connection_sets() -> None:
+    with (
+        patch.object(redis_pool, "REDIS_SSL", True),
+        patch.object(redis_pool, "REDIS_SSL_CERT_REQS", "required"),
+        patch.object(redis_pool, "REDIS_SSL_CA_CERTS", "/ca.crt"),
+        patch.object(redis_pool, "REDIS_SSL_CERTFILE", "/c.crt"),
+        patch.object(redis_pool, "REDIS_SSL_KEYFILE", "/c.key"),
+        patch.object(redis_pool, "REDIS_PASSWORD", "datapw"),
+        patch.object(redis_pool, "REDIS_SENTINEL_PASSWORD", "sentinelpw"),
+    ):
+        connection_kwargs, sentinel_kwargs = redis_pool._sentinel_connection_kwargs()
+        # data (master/replica) connections: master auth + TLS
+        assert connection_kwargs["password"] == "datapw"
+        assert connection_kwargs["ssl"] is True
+        assert connection_kwargs["ssl_ca_certs"] == "/ca.crt"
+        assert connection_kwargs["ssl_certfile"] == "/c.crt"
+        # sentinel-node connections: sentinel auth + TLS
+        assert sentinel_kwargs["password"] == "sentinelpw"
+        assert sentinel_kwargs["ssl"] is True
+        assert sentinel_kwargs["ssl_ca_certs"] == "/ca.crt"
+
+
+# --- Celery broker / result backend ---------------------------------------
+
+
+def test_celery_uses_sentinel_urls_and_master_name() -> None:
+    env = {
+        "REDIS_SENTINEL_HOSTS": "s1:26379,s2:26379",
+        "REDIS_SENTINEL_MASTER_NAME": "mymaster",
+    }
+    with patch.dict(os.environ, env):
+        import onyx.background.celery.configs.base as celery_base
+        import onyx.configs.app_configs as app_configs
+
+        importlib.reload(app_configs)
+        importlib.reload(celery_base)
+        try:
+            assert celery_base.broker_url == (
+                "sentinel://s1:26379;sentinel://s2:26379/15"
+            )
+            assert celery_base.result_backend.startswith(
+                "sentinel://s1:26379;sentinel://s2:26379/"
+            )
+            assert celery_base.broker_transport_options["master_name"] == "mymaster"
+            assert (
+                celery_base.result_backend_transport_options["master_name"]
+                == "mymaster"
+            )
+        finally:
+            importlib.reload(app_configs)
+            importlib.reload(celery_base)

--- a/backend/tests/unit/onyx/redis/test_redis_sentinel.py
+++ b/backend/tests/unit/onyx/redis/test_redis_sentinel.py
@@ -1,5 +1,6 @@
 import importlib
 import os
+from typing import cast
 from unittest.mock import patch
 
 import onyx.redis.redis_pool as redis_pool
@@ -106,6 +107,52 @@ def test_celery_uses_sentinel_urls_and_master_name() -> None:
                 celery_base.result_backend_transport_options["master_name"]
                 == "mymaster"
             )
+        finally:
+            importlib.reload(app_configs)
+            importlib.reload(celery_base)
+
+
+# --- config validation + Celery TLS ---------------------------------------
+
+
+def test_malformed_sentinel_hosts_raises() -> None:
+    import pytest
+
+    with patch.dict(os.environ, {"REDIS_SENTINEL_HOSTS": "no-port-here"}):
+        import onyx.configs.app_configs as app_configs
+
+        with pytest.raises(ValueError, match="expected host:port"):
+            importlib.reload(app_configs)
+    importlib.reload(app_configs)
+
+
+def test_sentinel_with_iam_auth_raises() -> None:
+    import pytest
+
+    env = {"REDIS_SENTINEL_HOSTS": "s1:26379", "USE_REDIS_IAM_AUTH": "true"}
+    with patch.dict(os.environ, env):
+        import onyx.configs.app_configs as app_configs
+
+        with pytest.raises(ValueError, match="cannot be combined"):
+            importlib.reload(app_configs)
+    importlib.reload(app_configs)
+
+
+def test_celery_sentinel_kwargs_enable_ssl_under_tls() -> None:
+    env = {"REDIS_SENTINEL_HOSTS": "s1:26379", "REDIS_SSL": "true"}
+    with patch.dict(os.environ, env):
+        import onyx.background.celery.configs.base as celery_base
+        import onyx.configs.app_configs as app_configs
+
+        importlib.reload(app_configs)
+        importlib.reload(celery_base)
+        try:
+            sk = cast(dict, celery_base.broker_transport_options["sentinel_kwargs"])
+            # cert params are inert without the explicit ssl flag
+            assert sk["ssl"] is True
+            # broker_use_ssl is a Celery setting; its presence enables TLS and it
+            # must NOT carry the ssl key
+            assert "ssl" not in celery_base.broker_use_ssl
         finally:
             importlib.reload(app_configs)
             importlib.reload(celery_base)

--- a/backend/tests/unit/onyx/redis/test_redis_sentinel.py
+++ b/backend/tests/unit/onyx/redis/test_redis_sentinel.py
@@ -156,3 +156,26 @@ def test_celery_sentinel_kwargs_enable_ssl_under_tls() -> None:
         finally:
             importlib.reload(app_configs)
             importlib.reload(celery_base)
+
+
+def test_out_of_range_sentinel_port_raises() -> None:
+    import pytest
+
+    with patch.dict(os.environ, {"REDIS_SENTINEL_HOSTS": "s1:99999"}):
+        import onyx.configs.app_configs as app_configs
+
+        with pytest.raises(ValueError, match="must be 1-65535"):
+            importlib.reload(app_configs)
+    importlib.reload(app_configs)
+
+
+def test_whitespace_master_name_raises() -> None:
+    import pytest
+
+    env = {"REDIS_SENTINEL_HOSTS": "s1:26379", "REDIS_SENTINEL_MASTER_NAME": "   "}
+    with patch.dict(os.environ, env):
+        import onyx.configs.app_configs as app_configs
+
+        with pytest.raises(ValueError, match="MASTER_NAME is empty"):
+            importlib.reload(app_configs)
+    importlib.reload(app_configs)


### PR DESCRIPTION
## Description

Adds Redis Sentinel support so Onyx can connect to a highly-available Redis (Sentinel discovers the current master and follows failover) instead of a fixed host. Requested by a customer running a Sentinel-fronted Redis.

**Config** — `REDIS_SENTINEL_HOSTS` (comma-separated `host:port` nodes) switches on Sentinel mode; `REDIS_SENTINEL_MASTER_NAME` (default `mymaster`); optional `REDIS_SENTINEL_PASSWORD` for the sentinel nodes (the master/replica still use `REDIS_PASSWORD`).

**App Redis (`redis_pool.py`)** — sync `create_pool` returns `Sentinel(...).master_for(...).connection_pool` (or `slave_for` for the replica), which plugs into the existing `redis.Redis(connection_pool=...)` flow unchanged; async `_build_async_redis_connection` uses `redis.asyncio.sentinel`. TLS (the native `ssl_*` kwargs from the mTLS work) is applied to **both** the sentinel-node connections and the master/replica data connections.

**Celery (`celery/configs/base.py`)** — `sentinel://` URLs (one per node) for the broker and result backend, `master_name` in the transport options, and `broker_use_ssl` / `redis_backend_use_ssl` for TLS; sentinel-node auth + TLS go in `sentinel_kwargs`.

IAM auth and the direct (non-sentinel) path are unchanged.

> **Stacked on #12342** (async Redis TLS fix) — built on that branch so the Sentinel TLS path uses the corrected native-kwargs async mechanism. Rebase onto main once #12342 merges.

## How Has This Been Tested?

- **Unit tests** (`test_redis_sentinel.py`): sync `create_pool` routes through `Sentinel.master_for` (and `slave_for` for the replica); async routes through `redis.asyncio.sentinel`; TLS + auth apply to both the sentinel and data connection sets; the Celery broker + result backend render `sentinel://` URLs with `master_name`. The existing direct-path tests still pass.
- **Live validation status:** the app-Redis routing is unit-tested against the real redis-py Sentinel API (mocked transport). A full live failover test against a running master/replica/sentinel cluster — and live validation of the Celery `sentinel://` + `broker_use_ssl` path (kombu has some quirks here) — is recommended before relying on it in production; I can add that as a follow-up.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Redis Sentinel HA support for app Redis (sync + async) and Celery with full TLS/mTLS. Also adds strict config validation, blocks Sentinel+IAM, and fixes Celery Sentinel TLS negotiation.

- **New Features**
  - HA via REDIS_SENTINEL_HOSTS with REDIS_SENTINEL_MASTER_NAME (default mymaster) and optional REDIS_SENTINEL_PASSWORD.
  - App Redis uses `redis-py` Sentinel for master/replica discovery and failover; TLS applies to both sentinel-node and data connections.
  - Celery broker/result backend use sentinel:// URLs with master_name; TLS via broker_use_ssl/redis_backend_use_ssl; sentinel_kwargs carries sentinel auth/TLS.

- **Bug Fixes**
  - Async Redis TLS uses native ssl_* kwargs; async IAM auth no longer crashes on ssl_context.
  - Celery Sentinel TLS sets ssl=True in sentinel_kwargs; result_backend_transport_options is always defined.
  - Config validation: REDIS_SENTINEL_HOSTS entries must be valid host:port with port 1–65535; set-but-empty or malformed raises; empty/whitespace REDIS_SENTINEL_MASTER_NAME is rejected; Sentinel cannot be combined with USE_REDIS_IAM_AUTH.

<sup>Written for commit b678710d263afff0b583098d3e7d3f666bc53cfa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

