### PR TITLE
refactor(llm): resolve provider by id in model-fetch requests

### DIFF
--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -382,7 +382,7 @@ def sync_model_configurations(
     """
     provider = fetch_existing_llm_provider_by_id(provider_id, db_session)
     if not provider:
-        raise ValueError(f"LLM Provider '{provider_id}' not found")
+        raise ValueError(f"LLM Provider with id={provider_id} not found")
 
     existing_by_name = {mc.name: mc for mc in provider.model_configurations}
 

--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -362,7 +362,7 @@ def upsert_llm_provider(
 
 def sync_model_configurations(
     db_session: Session,
-    provider_name: str,
+    provider_id: int,
     models: list[SyncModelEntry],
 ) -> int:
     """Sync model configurations for a dynamic provider (OpenRouter, Bedrock, Ollama, etc.).
@@ -374,15 +374,15 @@ def sync_model_configurations(
 
     Args:
         db_session: Database session
-        provider_name: Name of the LLM provider
+        provider_id: Id of the LLM provider
         models: List of SyncModelEntry objects describing the fetched models
 
     Returns:
         Number of new models added
     """
-    provider = fetch_existing_llm_provider(name=provider_name, db_session=db_session)
+    provider = fetch_existing_llm_provider_by_id(provider_id, db_session)
     if not provider:
-        raise ValueError(f"LLM Provider '{provider_name}' not found")
+        raise ValueError(f"LLM Provider '{provider_id}' not found")
 
     existing_by_name = {mc.name: mc for mc in provider.model_configurations}
 

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -218,7 +218,7 @@ def _sync_fetched_models(
         )
         if new_count > 0:
             logger.info(
-                "Added %s new %s models to provider '%s'",
+                "Added %s new %s models to provider id=%s",
                 new_count,
                 source_label,
                 provider_id,

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -27,7 +27,6 @@ from onyx.db.enums import Permission
 from onyx.db.llm import can_user_access_llm_provider
 from onyx.db.llm import fetch_default_llm_model
 from onyx.db.llm import fetch_default_vision_model
-from onyx.db.llm import fetch_existing_llm_provider
 from onyx.db.llm import fetch_existing_llm_provider_by_id
 from onyx.db.llm import fetch_existing_llm_providers
 from onyx.db.llm import fetch_existing_models
@@ -135,10 +134,9 @@ def _mask_string(value: str) -> str:
 
 def _resolve_api_key(
     api_key: str | None,
-    provider_name: str | None,
+    provider_id: int | None,
     api_base: str | None,
     db_session: Session,
-    provider_id: int | None = None,
 ) -> str | None:
     """Return the real API key for model-fetch endpoints.
 
@@ -146,19 +144,15 @@ def _resolve_api_key(
     ``sk-a****b1c2``). We look up the unmasked key from the database so the
     external request succeeds; a freshly typed (non-masked) key is used as-is.
 
-    The provider is resolved by *provider_id* when given (reliable — the edit
-    form always has it, and well-known providers are frequently saved with a
-    NULL name), otherwise by *provider_name*. The stored key is only returned
-    when the request's *api_base* matches the value stored in the database.
+    The provider is resolved by *provider_id* — reliable, since the edit form
+    always has it (well-known providers are frequently saved with a NULL name).
+    The stored key is only returned when the request's *api_base* matches the
+    value stored in the database.
     """
-    existing_provider = None
-    if provider_id is not None:
-        existing_provider = fetch_existing_llm_provider_by_id(provider_id, db_session)
-    elif provider_name:
-        existing_provider = fetch_existing_llm_provider(
-            name=provider_name, db_session=db_session
-        )
+    if provider_id is None:
+        return api_key
 
+    existing_provider = fetch_existing_llm_provider_by_id(provider_id, db_session)
     if existing_provider and existing_provider.api_key:
         # Normalise both URLs before comparing so trailing-slash
         # differences don't cause a false mismatch.
@@ -177,22 +171,20 @@ def _resolve_api_key(
 
 def _resolve_bedrock_bearer_token(
     bearer_token: str | None,
-    provider_name: str | None,
+    provider_id: int | None,
     db_session: Session,
 ) -> str | None:
     """Return the real Bedrock bearer token for the model-fetch endpoint.
 
     When editing an existing provider the form value is masked (e.g.
-    ``abcd****wxyz``). If *provider_name* is supplied we look up the unmasked
+    ``abcd****wxyz``). If *provider_id* is supplied we look up the unmasked
     token from the provider's stored ``custom_config`` so the AWS request
     succeeds instead of being rejected for using the masked placeholder.
     """
-    if not bearer_token or not provider_name:
+    if not bearer_token or provider_id is None:
         return bearer_token
 
-    existing_provider = fetch_existing_llm_provider(
-        name=provider_name, db_session=db_session
-    )
+    existing_provider = fetch_existing_llm_provider_by_id(provider_id, db_session)
     if not existing_provider or not existing_provider.custom_config:
         return bearer_token
 
@@ -206,7 +198,7 @@ def _resolve_bedrock_bearer_token(
 
 def _sync_fetched_models(
     db_session: Session,
-    provider_name: str,
+    provider_id: int,
     models: list[SyncModelEntry],
     source_label: str,
 ) -> None:
@@ -214,14 +206,14 @@ def _sync_fetched_models(
 
     Args:
         db_session: Database session
-        provider_name: Name of the LLM provider
+        provider_id: Id of the LLM provider
         models: List of SyncModelEntry objects describing the fetched models
         source_label: Human-readable label for log messages (e.g. "Bedrock", "LiteLLM")
     """
     try:
         new_count = sync_model_configurations(
             db_session=db_session,
-            provider_name=provider_name,
+            provider_id=provider_id,
             models=models,
         )
         if new_count > 0:
@@ -229,7 +221,7 @@ def _sync_fetched_models(
                 "Added %s new %s models to provider '%s'",
                 new_count,
                 source_label,
-                provider_name,
+                provider_id,
             )
         invalidate_provider_listing_cache()
     except ValueError as e:
@@ -1130,7 +1122,7 @@ def get_bedrock_available_models(
     # When editing an existing provider the form sends the masked bearer token;
     # swap it back for the stored value so the AWS call uses real credentials.
     bearer_token = _resolve_bedrock_bearer_token(
-        request.aws_bearer_token_bedrock, request.provider_name, db_session
+        request.aws_bearer_token_bedrock, request.provider_id, db_session
     )
 
     try:
@@ -1248,11 +1240,11 @@ def get_bedrock_available_models(
                 )
             )
 
-        # Sync new models to DB if provider_name is specified
-        if request.provider_name:
+        # Sync new models to DB if provider_id is specified
+        if request.provider_id is not None:
             _sync_fetched_models(
                 db_session=db_session,
-                provider_name=request.provider_name,
+                provider_id=request.provider_id,
                 models=[
                     SyncModelEntry(
                         name=r.name,
@@ -1396,11 +1388,11 @@ def get_ollama_available_models(
         key=lambda m: m.name.lower(),
     )
 
-    # Sync new models to DB if provider_name is specified
-    if request.provider_name:
+    # Sync new models to DB if provider_id is specified
+    if request.provider_id is not None:
         _sync_fetched_models(
             db_session=db_session,
-            provider_name=request.provider_name,
+            provider_id=request.provider_id,
             models=[
                 SyncModelEntry(
                     name=r.name,
@@ -1450,7 +1442,7 @@ def get_openrouter_available_models(
     """
 
     api_key = _resolve_api_key(
-        request.api_key, request.provider_name, request.api_base, db_session
+        request.api_key, request.provider_id, request.api_base, db_session
     )
 
     response_json = _get_openrouter_models_response(
@@ -1503,11 +1495,11 @@ def get_openrouter_available_models(
 
     sorted_results = sorted(results, key=lambda m: m.name.lower())
 
-    # Sync new models to DB if provider_name is specified
-    if request.provider_name:
+    # Sync new models to DB if provider_id is specified
+    if request.provider_id is not None:
         _sync_fetched_models(
             db_session=db_session,
-            provider_name=request.provider_name,
+            provider_id=request.provider_id,
             models=[
                 SyncModelEntry(
                     name=r.name,
@@ -1545,13 +1537,13 @@ def get_lm_studio_available_models(
             "API base URL is required to fetch LM Studio models.",
         )
 
-    # If provider_name is given and the api_key hasn't been changed by the user,
+    # If provider_id is given and the api_key hasn't been changed by the user,
     # fall back to the stored API key from the database (the form value is masked).
     # Only do so when the api_base matches what is stored.
     api_key = request.api_key
-    if request.provider_name and not request.api_key_changed:
-        existing_provider = fetch_existing_llm_provider(
-            name=request.provider_name, db_session=db_session
+    if request.provider_id is not None and not request.api_key_changed:
+        existing_provider = fetch_existing_llm_provider_by_id(
+            request.provider_id, db_session
         )
         if existing_provider and existing_provider.custom_config:
             stored_base = (existing_provider.api_base or "").strip().rstrip("/")
@@ -1615,11 +1607,11 @@ def get_lm_studio_available_models(
 
     sorted_results = sorted(results, key=lambda m: m.name.lower())
 
-    # Sync new models to DB if provider_name is specified
-    if request.provider_name:
+    # Sync new models to DB if provider_id is specified
+    if request.provider_id is not None:
         _sync_fetched_models(
             db_session=db_session,
-            provider_name=request.provider_name,
+            provider_id=request.provider_id,
             models=[
                 SyncModelEntry(
                     name=r.name,
@@ -1644,7 +1636,7 @@ def get_litellm_available_models(
 ) -> list[LitellmFinalModelResponse]:
     """Fetch available models from LiteLLM proxy /v1/model/info endpoint."""
     api_key = _resolve_api_key(
-        request.api_key, request.provider_name, request.api_base, db_session
+        request.api_key, request.provider_id, request.api_base, db_session
     )
 
     response_json = _get_litellm_models_response(
@@ -1695,11 +1687,11 @@ def get_litellm_available_models(
 
     sorted_results = sorted(results, key=lambda m: m.model_name.lower())
 
-    # Sync new models to DB if provider_name is specified
-    if request.provider_name:
+    # Sync new models to DB if provider_id is specified
+    if request.provider_id is not None:
         _sync_fetched_models(
             db_session=db_session,
-            provider_name=request.provider_name,
+            provider_id=request.provider_id,
             models=[
                 SyncModelEntry(
                     name=r.model_name,
@@ -1793,7 +1785,7 @@ def get_bifrost_available_models(
 ) -> list[BifrostFinalModelResponse]:
     """Fetch available models from Bifrost gateway /v1/models endpoint."""
     api_key = _resolve_api_key(
-        request.api_key, request.provider_name, request.api_base, db_session
+        request.api_key, request.provider_id, request.api_base, db_session
     )
 
     response_json = _get_bifrost_models_response(
@@ -1849,11 +1841,11 @@ def get_bifrost_available_models(
 
     sorted_results = sorted(results, key=lambda m: m.name.lower())
 
-    # Sync new models to DB if provider_name is specified
-    if request.provider_name:
+    # Sync new models to DB if provider_id is specified
+    if request.provider_id is not None:
         _sync_fetched_models(
             db_session=db_session,
-            provider_name=request.provider_name,
+            provider_id=request.provider_id,
             models=[
                 SyncModelEntry(
                     name=r.name,
@@ -1928,11 +1920,7 @@ def get_nebius_tokenfactory_available_models(
     """Fetch chat models from Nebius TokenFactory, with per-model context
     length and tool/vision capabilities read straight from the source API."""
     api_key = _resolve_api_key(
-        request.api_key,
-        request.provider_name,
-        request.api_base,
-        db_session,
-        provider_id=request.provider_id,
+        request.api_key, request.provider_id, request.api_base, db_session
     )
 
     response_json = _get_nebius_tokenfactory_models_response(
@@ -2013,10 +2001,10 @@ def get_nebius_tokenfactory_available_models(
 
     sorted_results = sorted(results, key=lambda m: m.name.lower())
 
-    if request.provider_name:
+    if request.provider_id is not None:
         _sync_fetched_models(
             db_session=db_session,
-            provider_name=request.provider_name,
+            provider_id=request.provider_id,
             models=[
                 SyncModelEntry(
                     name=r.name,
@@ -2041,7 +2029,7 @@ def get_openai_compatible_server_available_models(
 ) -> list[OpenAICompatibleFinalModelResponse]:
     """Fetch available models from a generic OpenAI-compatible /v1/models endpoint."""
     api_key = _resolve_api_key(
-        request.api_key, request.provider_name, request.api_base, db_session
+        request.api_key, request.provider_id, request.api_base, db_session
     )
 
     response_json = _get_openai_compatible_server_response(
@@ -2091,11 +2079,11 @@ def get_openai_compatible_server_available_models(
 
     sorted_results = sorted(results, key=lambda m: m.name.lower())
 
-    # Sync new models to DB if provider_name is specified
-    if request.provider_name:
+    # Sync new models to DB if provider_id is specified
+    if request.provider_id is not None:
         _sync_fetched_models(
             db_session=db_session,
-            provider_name=request.provider_name,
+            provider_id=request.provider_id,
             models=[
                 SyncModelEntry(
                     name=r.name,

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -357,7 +357,8 @@ class BedrockModelsRequest(BaseModel):
     aws_access_key_id: str | None = None
     aws_secret_access_key: str | None = None
     aws_bearer_token_bedrock: str | None = None
-    provider_name: str | None = None  # Optional: to save models to existing provider
+    # Existing provider id; resolves the stored key and syncs fetched models on edit
+    provider_id: int | None = None
 
 
 class BedrockFinalModelResponse(BaseModel):
@@ -369,7 +370,8 @@ class BedrockFinalModelResponse(BaseModel):
 
 class OllamaModelsRequest(BaseModel):
     api_base: str
-    provider_name: str | None = None  # Optional: to save models to existing provider
+    # Existing provider id; resolves the stored key and syncs fetched models on edit
+    provider_id: int | None = None
 
 
 class OllamaFinalModelResponse(BaseModel):
@@ -420,7 +422,8 @@ class OllamaModelDetails(BaseModel):
 class OpenRouterModelsRequest(BaseModel):
     api_base: str
     api_key: str
-    provider_name: str | None = None  # Optional: to save models to existing provider
+    # Existing provider id; resolves the stored key and syncs fetched models on edit
+    provider_id: int | None = None
 
 
 class OpenRouterModelDetails(BaseModel):
@@ -461,7 +464,8 @@ class LMStudioModelsRequest(BaseModel):
     api_base: str
     api_key: str | None = None
     api_key_changed: bool = False
-    provider_name: str | None = None  # Optional: to save models to existing provider
+    # Existing provider id; resolves the stored key and syncs fetched models on edit
+    provider_id: int | None = None
 
 
 class LMStudioFinalModelResponse(BaseModel):
@@ -520,7 +524,8 @@ class SyncModelEntry(BaseModel):
 class LitellmModelsRequest(BaseModel):
     api_key: str
     api_base: str
-    provider_name: str | None = None  # Optional: to save models to existing provider
+    # Existing provider id; resolves the stored key and syncs fetched models on edit
+    provider_id: int | None = None
 
 
 class LitellmModelDetails(BaseModel):
@@ -603,7 +608,8 @@ class LitellmFinalModelResponse(BaseModel):
 class BifrostModelsRequest(BaseModel):
     api_base: str
     api_key: str | None = None
-    provider_name: str | None = None  # Optional: to save models to existing provider
+    # Existing provider id; resolves the stored key and syncs fetched models on edit
+    provider_id: int | None = None
 
 
 class BifrostFinalModelResponse(BaseModel):
@@ -618,8 +624,8 @@ class BifrostFinalModelResponse(BaseModel):
 class NebiusTokenfactoryModelsRequest(BaseModel):
     api_base: str
     api_key: str | None = None
-    provider_name: str | None = None  # Optional: to save models to existing provider
-    provider_id: int | None = None  # Reliable id for resolving the stored key on edit
+    # Existing provider id; resolves the stored key and syncs fetched models on edit
+    provider_id: int | None = None
 
 
 class NebiusTokenfactoryFinalModelResponse(BaseModel):
@@ -639,7 +645,8 @@ class NebiusTokenfactoryFinalModelResponse(BaseModel):
 class OpenAICompatibleModelsRequest(BaseModel):
     api_base: str
     api_key: str | None = None
-    provider_name: str | None = None  # Optional: to save models to existing provider
+    # Existing provider id; resolves the stored key and syncs fetched models on edit
+    provider_id: int | None = None
 
 
 class OpenAICompatibleFinalModelResponse(BaseModel):

--- a/backend/tests/unit/onyx/db/test_llm_sync.py
+++ b/backend/tests/unit/onyx/db/test_llm_sync.py
@@ -7,7 +7,6 @@ import pytest
 
 from onyx.db.enums import LLMModelFlowType
 from onyx.db.llm import sync_model_configurations
-from onyx.llm.constants import LlmProviderNames
 from onyx.server.manage.llm.models import SyncModelEntry
 
 
@@ -32,7 +31,7 @@ class TestSyncModelConfigurations:
         mock_session = MagicMock()
 
         with patch(
-            "onyx.db.llm.fetch_existing_llm_provider", return_value=mock_provider
+            "onyx.db.llm.fetch_existing_llm_provider_by_id", return_value=mock_provider
         ):
             models = [
                 SyncModelEntry(
@@ -51,7 +50,7 @@ class TestSyncModelConfigurations:
 
             result = sync_model_configurations(
                 db_session=mock_session,
-                provider_name=LlmProviderNames.OPENAI,
+                provider_id=1,
                 models=models,
             )
 
@@ -75,7 +74,7 @@ class TestSyncModelConfigurations:
         mock_session = MagicMock()
 
         with patch(
-            "onyx.db.llm.fetch_existing_llm_provider", return_value=mock_provider
+            "onyx.db.llm.fetch_existing_llm_provider_by_id", return_value=mock_provider
         ):
             models = [
                 SyncModelEntry(
@@ -94,7 +93,7 @@ class TestSyncModelConfigurations:
 
             result = sync_model_configurations(
                 db_session=mock_session,
-                provider_name=LlmProviderNames.OPENAI,
+                provider_id=1,
                 models=models,
             )
 
@@ -114,7 +113,7 @@ class TestSyncModelConfigurations:
         mock_session = MagicMock()
 
         with patch(
-            "onyx.db.llm.fetch_existing_llm_provider", return_value=mock_provider
+            "onyx.db.llm.fetch_existing_llm_provider_by_id", return_value=mock_provider
         ):
             models = [
                 SyncModelEntry(
@@ -127,7 +126,7 @@ class TestSyncModelConfigurations:
 
             result = sync_model_configurations(
                 db_session=mock_session,
-                provider_name=LlmProviderNames.OPENAI,
+                provider_id=1,
                 models=models,
             )
 
@@ -138,11 +137,11 @@ class TestSyncModelConfigurations:
         """Test that ValueError is raised when provider not found."""
         mock_session = MagicMock()
 
-        with patch("onyx.db.llm.fetch_existing_llm_provider", return_value=None):
+        with patch("onyx.db.llm.fetch_existing_llm_provider_by_id", return_value=None):
             with pytest.raises(ValueError, match="not found"):
                 sync_model_configurations(
                     db_session=mock_session,
-                    provider_name="nonexistent",
+                    provider_id=999,
                     models=[SyncModelEntry(name="model", display_name="Model")],
                 )
 
@@ -155,7 +154,7 @@ class TestSyncModelConfigurations:
         mock_session = MagicMock()
 
         with patch(
-            "onyx.db.llm.fetch_existing_llm_provider", return_value=mock_provider
+            "onyx.db.llm.fetch_existing_llm_provider_by_id", return_value=mock_provider
         ):
             models = [
                 SyncModelEntry(
@@ -169,7 +168,7 @@ class TestSyncModelConfigurations:
 
             result = sync_model_configurations(
                 db_session=mock_session,
-                provider_name=LlmProviderNames.OPENAI,
+                provider_id=1,
                 models=models,
             )
 
@@ -187,7 +186,7 @@ class TestSyncModelConfigurations:
         mock_session = MagicMock()
 
         with patch(
-            "onyx.db.llm.fetch_existing_llm_provider", return_value=mock_provider
+            "onyx.db.llm.fetch_existing_llm_provider_by_id", return_value=mock_provider
         ):
             # Model with only required fields (max_input_tokens and supports_image_input default)
             models = [
@@ -199,7 +198,7 @@ class TestSyncModelConfigurations:
 
             result = sync_model_configurations(
                 db_session=mock_session,
-                provider_name="custom",
+                provider_id=1,
                 models=models,
             )
 
@@ -224,7 +223,7 @@ class TestSyncModelConfigurations:
         mock_session = MagicMock()
 
         with patch(
-            "onyx.db.llm.fetch_existing_llm_provider", return_value=mock_provider
+            "onyx.db.llm.fetch_existing_llm_provider_by_id", return_value=mock_provider
         ):
             models = [
                 SyncModelEntry(
@@ -236,7 +235,7 @@ class TestSyncModelConfigurations:
 
             result = sync_model_configurations(
                 db_session=mock_session,
-                provider_name=LlmProviderNames.BIFROST,
+                provider_id=1,
                 models=models,
             )
 
@@ -258,7 +257,7 @@ class TestSyncModelConfigurations:
         mock_session = MagicMock()
 
         with patch(
-            "onyx.db.llm.fetch_existing_llm_provider", return_value=mock_provider
+            "onyx.db.llm.fetch_existing_llm_provider_by_id", return_value=mock_provider
         ):
             models = [
                 SyncModelEntry(
@@ -270,7 +269,7 @@ class TestSyncModelConfigurations:
 
             result = sync_model_configurations(
                 db_session=mock_session,
-                provider_name=LlmProviderNames.BIFROST,
+                provider_id=1,
                 models=models,
             )
 

--- a/backend/tests/unit/onyx/server/manage/llm/test_fetch_models_api.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_fetch_models_api.py
@@ -2,7 +2,7 @@
 
 These tests verify the full request/response flow for fetching models
 from dynamic providers (Ollama, OpenRouter, Litellm), including the
-sync-to-DB behavior when provider_name is specified.
+sync-to-DB behavior when provider_id is specified.
 """
 
 import os
@@ -131,10 +131,10 @@ class TestGetOllamaAvailableModels:
         assert exc_info.value.error_code == OnyxErrorCode.BAD_GATEWAY
         assert exc_info.value.status_code == 502
 
-    def test_syncs_to_db_when_provider_name_specified(
+    def test_syncs_to_db_when_provider_id_specified(
         self, mock_ollama_tags_response: dict, mock_ollama_show_response: dict
     ) -> None:
-        """Test that models are synced to DB when provider_name is given."""
+        """Test that models are synced to DB when provider_id is given."""
         from onyx.server.manage.llm.api import get_ollama_available_models
 
         mock_session = MagicMock()
@@ -145,7 +145,8 @@ class TestGetOllamaAvailableModels:
         with (
             patch("onyx.server.manage.llm.api.httpx") as mock_httpx,
             patch(
-                "onyx.db.llm.fetch_existing_llm_provider", return_value=mock_provider
+                "onyx.db.llm.fetch_existing_llm_provider_by_id",
+                return_value=mock_provider,
             ),
         ):
             mock_get_response = MagicMock()
@@ -160,7 +161,7 @@ class TestGetOllamaAvailableModels:
 
             request = OllamaModelsRequest(
                 api_base="http://localhost:11434",
-                provider_name="my-ollama",
+                provider_id=1,
             )
             get_ollama_available_models(request, MagicMock(), mock_session)
 
@@ -168,10 +169,10 @@ class TestGetOllamaAvailableModels:
             assert mock_session.execute.call_count == 6
             mock_session.commit.assert_called_once()
 
-    def test_no_sync_when_provider_name_not_specified(
+    def test_no_sync_when_provider_id_not_specified(
         self, mock_ollama_tags_response: dict, mock_ollama_show_response: dict
     ) -> None:
-        """Test that models are NOT synced when provider_name is None."""
+        """Test that models are NOT synced when provider_id is None."""
         from onyx.server.manage.llm.api import get_ollama_available_models
 
         mock_session = MagicMock()
@@ -373,10 +374,10 @@ class TestGetOpenRouterAvailableModels:
             assert claude.supports_image_input is True
             assert llama.supports_image_input is False
 
-    def test_syncs_to_db_when_provider_name_specified(
+    def test_syncs_to_db_when_provider_id_specified(
         self, mock_openrouter_response: dict
     ) -> None:
-        """Test that models are synced to DB when provider_name is given."""
+        """Test that models are synced to DB when provider_id is given."""
         from onyx.server.manage.llm.api import get_openrouter_available_models
 
         mock_session = MagicMock()
@@ -387,7 +388,8 @@ class TestGetOpenRouterAvailableModels:
         with (
             patch("onyx.server.manage.llm.api.httpx.get") as mock_get,
             patch(
-                "onyx.db.llm.fetch_existing_llm_provider", return_value=mock_provider
+                "onyx.db.llm.fetch_existing_llm_provider_by_id",
+                return_value=mock_provider,
             ),
         ):
             mock_response = MagicMock()
@@ -398,7 +400,7 @@ class TestGetOpenRouterAvailableModels:
             request = OpenRouterModelsRequest(
                 api_base="https://openrouter.ai/api/v1",
                 api_key="test-key",
-                provider_name="my-openrouter",
+                provider_id=1,
             )
             get_openrouter_available_models(request, MagicMock(), mock_session)
 
@@ -431,7 +433,8 @@ class TestGetOpenRouterAvailableModels:
         with (
             patch("onyx.server.manage.llm.api.httpx.get") as mock_get,
             patch(
-                "onyx.db.llm.fetch_existing_llm_provider", return_value=mock_provider
+                "onyx.db.llm.fetch_existing_llm_provider_by_id",
+                return_value=mock_provider,
             ),
         ):
             mock_response = MagicMock()
@@ -442,17 +445,17 @@ class TestGetOpenRouterAvailableModels:
             request = OpenRouterModelsRequest(
                 api_base="https://openrouter.ai/api/v1",
                 api_key="test-key",
-                provider_name="my-openrouter",
+                provider_id=1,
             )
             get_openrouter_available_models(request, MagicMock(), mock_session)
 
             # Only 2 new models should be inserted (claude already exists)
             assert mock_session.execute.call_count == 5
 
-    def test_no_sync_when_provider_name_not_specified(
+    def test_no_sync_when_provider_id_not_specified(
         self, mock_openrouter_response: dict
     ) -> None:
-        """Test that models are NOT synced when provider_name is None."""
+        """Test that models are NOT synced when provider_id is None."""
         from onyx.server.manage.llm.api import get_openrouter_available_models
 
         mock_session = MagicMock()
@@ -670,7 +673,7 @@ class TestGetLMStudioAvailableModels:
         with (
             patch("onyx.server.manage.llm.api.httpx") as mock_httpx,
             patch(
-                "onyx.server.manage.llm.api.fetch_existing_llm_provider",
+                "onyx.server.manage.llm.api.fetch_existing_llm_provider_by_id",
                 return_value=mock_provider,
             ),
         ):
@@ -683,7 +686,7 @@ class TestGetLMStudioAvailableModels:
                 api_base="http://localhost:1234",
                 api_key="masked-value",
                 api_key_changed=False,
-                provider_name="my-lm-studio",
+                provider_id=1,
             )
             get_lm_studio_available_models(request, MagicMock(), mock_session)
 
@@ -717,7 +720,7 @@ class TestGetLMStudioAvailableModels:
                 api_base="http://localhost:1234",
                 api_key="new-secret",
                 api_key_changed=True,
-                provider_name="my-lm-studio",
+                provider_id=1,
             )
             get_lm_studio_available_models(request, MagicMock(), mock_session)
 
@@ -794,7 +797,8 @@ class TestGetLMStudioAvailableModels:
         with (
             patch("onyx.server.manage.llm.api.httpx") as mock_httpx,
             patch(
-                "onyx.db.llm.fetch_existing_llm_provider", return_value=mock_provider
+                "onyx.db.llm.fetch_existing_llm_provider_by_id",
+                return_value=mock_provider,
             ),
         ):
             mock_response = MagicMock()
@@ -804,7 +808,7 @@ class TestGetLMStudioAvailableModels:
 
             request = LMStudioModelsRequest(
                 api_base="http://localhost:1234",
-                provider_name="my-lm-studio",
+                provider_id=1,
             )
             get_lm_studio_available_models(request, MagicMock(), mock_session)
 
@@ -1599,7 +1603,7 @@ class TestGetBedrockAvailableModels:
                 return_value=mock_session,
             ) as mock_session_cls,
             patch(
-                "onyx.server.manage.llm.api.fetch_existing_llm_provider",
+                "onyx.server.manage.llm.api.fetch_existing_llm_provider_by_id",
                 return_value=existing_provider,
             ),
             patch("onyx.server.manage.llm.api._sync_fetched_models"),
@@ -1607,7 +1611,7 @@ class TestGetBedrockAvailableModels:
             request = BedrockModelsRequest(
                 aws_region_name="us-west-2",
                 aws_bearer_token_bedrock=masked_token,
-                provider_name="my-bedrock",
+                provider_id=1,
             )
             get_bedrock_available_models(request, MagicMock(), MagicMock())
 

--- a/backend/tests/unit/onyx/server/manage/llm/test_nebius_tokenfactory_models.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_nebius_tokenfactory_models.py
@@ -76,7 +76,7 @@ def _fetch() -> dict:
             request=NebiusTokenfactoryModelsRequest(
                 api_base="https://api.tokenfactory.nebius.com/v1",
                 api_key="k",
-                provider_name=None,  # skip DB sync
+                provider_id=None,  # skip DB sync
             ),
             _=cast(User, None),
             db_session=cast(Session, None),

--- a/backend/tests/unit/onyx/server/manage/llm/test_resolve_api_key.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_resolve_api_key.py
@@ -1,8 +1,7 @@
 """_resolve_api_key resolves a masked key (admin editing a saved provider) back
-to the stored key — by provider_id when a well-known provider was saved with a
-NULL name, or by provider_name otherwise. A freshly typed key is used as-is, and
-the stored key is only returned when the request's api_base matches the stored
-one."""
+to the stored key — looked up by the reliable provider_id. A freshly typed key
+is used as-is, and the stored key is only returned when the request's api_base
+matches the stored one."""
 
 from types import SimpleNamespace
 from typing import cast
@@ -24,55 +23,31 @@ def _provider() -> SimpleNamespace:
     )
 
 
-def test_masked_key_resolves_to_stored_by_name() -> None:
-    with patch(
-        "onyx.server.manage.llm.api.fetch_existing_llm_provider",
-        return_value=_provider(),
-    ):
-        assert (
-            _resolve_api_key(
-                _MASKED, "Nebius TokenFactory", _BASE, db_session=cast(Session, None)
-            )
-            == _STORED
-        )
-
-
-def test_masked_key_resolves_to_stored_by_id_when_name_is_null() -> None:
-    # Well-known providers are often saved with name=None; the masked key must
-    # still resolve via the reliable provider id.
+def test_masked_key_resolves_to_stored_by_id() -> None:
     with patch(
         "onyx.server.manage.llm.api.fetch_existing_llm_provider_by_id",
         return_value=_provider(),
     ):
         assert (
-            _resolve_api_key(
-                _MASKED,
-                None,
-                _BASE,
-                db_session=cast(Session, None),
-                provider_id=7,
-            )
+            _resolve_api_key(_MASKED, 7, _BASE, db_session=cast(Session, None))
             == _STORED
         )
 
 
 def test_fresh_key_used_as_is() -> None:
     with patch(
-        "onyx.server.manage.llm.api.fetch_existing_llm_provider",
+        "onyx.server.manage.llm.api.fetch_existing_llm_provider_by_id",
         return_value=_provider(),
     ):
         assert (
             _resolve_api_key(
-                "sk-brand-new-key-123456",
-                "Nebius TokenFactory",
-                _BASE,
-                db_session=cast(Session, None),
+                "sk-brand-new-key-123456", 7, _BASE, db_session=cast(Session, None)
             )
             == "sk-brand-new-key-123456"
         )
 
 
-def test_no_provider_returns_input() -> None:
+def test_no_provider_id_returns_input() -> None:
     assert (
         _resolve_api_key(_MASKED, None, _BASE, db_session=cast(Session, None))
         == _MASKED
@@ -81,13 +56,13 @@ def test_no_provider_returns_input() -> None:
 
 def test_mismatched_api_base_returns_input() -> None:
     with patch(
-        "onyx.server.manage.llm.api.fetch_existing_llm_provider",
+        "onyx.server.manage.llm.api.fetch_existing_llm_provider_by_id",
         return_value=_provider(),
     ):
         assert (
             _resolve_api_key(
                 _MASKED,
-                "Nebius TokenFactory",
+                7,
                 "https://other.example/v1",
                 db_session=cast(Session, None),
             )

--- a/web/src/lib/languageModels/svc.ts
+++ b/web/src/lib/languageModels/svc.ts
@@ -140,7 +140,7 @@ export const fetchBedrockModels = async (
         aws_access_key_id: params.aws_access_key_id,
         aws_secret_access_key: params.aws_secret_access_key,
         aws_bearer_token_bedrock: params.aws_bearer_token_bedrock,
-        provider_name: params.provider_name,
+        provider_id: params.provider_id,
       }),
     });
 
@@ -194,7 +194,7 @@ export const fetchOllamaModels = async (
       },
       body: JSON.stringify({
         api_base: apiBase,
-        provider_name: params.provider_name,
+        provider_id: params.provider_id,
       }),
       signal: params.signal,
     });
@@ -254,7 +254,7 @@ export const fetchOpenRouterModels = async (
       body: JSON.stringify({
         api_base: apiBase,
         api_key: apiKey,
-        provider_name: params.provider_name,
+        provider_id: params.provider_id,
       }),
     });
 
@@ -313,7 +313,7 @@ export const fetchLMStudioModels = async (
         api_base: apiBase,
         api_key: params.api_key,
         api_key_changed: params.api_key_changed ?? false,
-        provider_name: params.provider_name,
+        provider_id: params.provider_id,
       }),
       signal: params.signal,
     });
@@ -372,7 +372,7 @@ export const fetchBifrostModels = async (
       body: JSON.stringify({
         api_base: apiBase,
         api_key: params.api_key,
-        provider_name: params.provider_name,
+        provider_id: params.provider_id,
       }),
       signal: params.signal,
     });
@@ -433,7 +433,7 @@ export const fetchOpenAICompatibleModels = async (
         body: JSON.stringify({
           api_base: apiBase,
           api_key: params.api_key,
-          provider_name: params.provider_name,
+          provider_id: params.provider_id,
         }),
         signal: params.signal,
       }
@@ -494,7 +494,7 @@ export const fetchLiteLLMProxyModels = async (
       body: JSON.stringify({
         api_base: apiBase,
         api_key: apiKey,
-        provider_name: params.provider_name,
+        provider_id: params.provider_id,
       }),
       signal: params.signal,
     });
@@ -539,7 +539,7 @@ export const fetchModels = async (
     api_base?: string;
     api_key?: string;
     api_key_changed?: boolean;
-    name?: string;
+    id?: number;
     custom_config?: Record<string, string>;
     model_configurations?: ModelConfiguration[];
   },
@@ -554,12 +554,12 @@ export const fetchModels = async (
         aws_access_key_id: customConfig.AWS_ACCESS_KEY_ID,
         aws_secret_access_key: customConfig.AWS_SECRET_ACCESS_KEY,
         aws_bearer_token_bedrock: customConfig.AWS_BEARER_TOKEN_BEDROCK,
-        provider_name: formValues.name,
+        provider_id: formValues.id,
       });
     case LLMProviderName.OLLAMA_CHAT:
       return fetchOllamaModels({
         api_base: formValues.api_base,
-        provider_name: formValues.name,
+        provider_id: formValues.id,
         signal,
       });
     case LLMProviderName.LM_STUDIO:
@@ -567,41 +567,41 @@ export const fetchModels = async (
         api_base: formValues.api_base,
         api_key: formValues.custom_config?.LM_STUDIO_API_KEY,
         api_key_changed: formValues.api_key_changed ?? false,
-        provider_name: formValues.name,
+        provider_id: formValues.id,
         signal,
       });
     case LLMProviderName.OPENROUTER:
       return fetchOpenRouterModels({
         api_base: formValues.api_base,
         api_key: formValues.api_key,
-        provider_name: formValues.name,
+        provider_id: formValues.id,
       });
     case LLMProviderName.LITELLM_PROXY:
       return fetchLiteLLMProxyModels({
         api_base: formValues.api_base,
         api_key: formValues.api_key,
-        provider_name: formValues.name,
+        provider_id: formValues.id,
         signal,
       });
     case LLMProviderName.BIFROST:
       return fetchBifrostModels({
         api_base: formValues.api_base,
         api_key: formValues.api_key,
-        provider_name: formValues.name,
+        provider_id: formValues.id,
         signal,
       });
     case LLMProviderName.OPENAI_COMPATIBLE:
       return fetchOpenAICompatibleModels({
         api_base: formValues.api_base,
         api_key: formValues.api_key,
-        provider_name: formValues.name,
+        provider_id: formValues.id,
         signal,
       });
     case LLMProviderName.NEBIUS_TOKENFACTORY:
       return fetchNebiusTokenfactoryModels({
         api_base: formValues.api_base,
         api_key: formValues.api_key,
-        provider_name: formValues.name,
+        provider_id: formValues.id,
         signal,
       });
     default:
@@ -633,7 +633,6 @@ export const fetchNebiusTokenfactoryModels = async (
         body: JSON.stringify({
           api_base: apiBase,
           api_key: params.api_key,
-          provider_name: params.provider_name,
           provider_id: params.provider_id,
         }),
         signal: params.signal,

--- a/web/src/lib/languageModels/types.ts
+++ b/web/src/lib/languageModels/types.ts
@@ -151,25 +151,25 @@ export interface BedrockFetchParams {
   aws_access_key_id?: string;
   aws_secret_access_key?: string;
   aws_bearer_token_bedrock?: string;
-  provider_name?: string;
+  provider_id?: number;
 }
 
 export interface OllamaFetchParams {
   api_base?: string;
-  provider_name?: string;
+  provider_id?: number;
   signal?: AbortSignal;
 }
 
 export interface OpenRouterFetchParams {
   api_base?: string;
   api_key?: string;
-  provider_name?: string;
+  provider_id?: number;
 }
 
 export interface LiteLLMProxyFetchParams {
   api_base?: string;
   api_key?: string;
-  provider_name?: string;
+  provider_id?: number;
   signal?: AbortSignal;
 }
 
@@ -185,7 +185,7 @@ export interface LiteLLMProxyModelResponse {
 export interface BifrostFetchParams {
   api_base?: string;
   api_key?: string;
-  provider_name?: string;
+  provider_id?: number;
   signal?: AbortSignal;
 }
 
@@ -200,7 +200,7 @@ export interface BifrostModelResponse {
 export interface OpenAICompatibleFetchParams {
   api_base?: string;
   api_key?: string;
-  provider_name?: string;
+  provider_id?: number;
   signal?: AbortSignal;
 }
 
@@ -215,7 +215,6 @@ export interface OpenAICompatibleModelResponse {
 export interface NebiusTokenfactoryFetchParams {
   api_base?: string;
   api_key?: string;
-  provider_name?: string;
   provider_id?: number;
   signal?: AbortSignal;
 }
@@ -240,7 +239,7 @@ export interface LMStudioFetchParams {
   api_base?: string;
   api_key?: string;
   api_key_changed?: boolean;
-  provider_name?: string;
+  provider_id?: number;
   signal?: AbortSignal;
 }
 

--- a/web/src/sections/modals/languageModels/BedrockModal.tsx
+++ b/web/src/sections/modals/languageModels/BedrockModal.tsx
@@ -113,7 +113,7 @@ function BedrockModalInternals({
         formikProps.values.custom_config?.AWS_SECRET_ACCESS_KEY,
       aws_bearer_token_bedrock:
         formikProps.values.custom_config?.AWS_BEARER_TOKEN_BEDROCK,
-      provider_name: LLMProviderName.BEDROCK,
+      provider_id: existingLlmProvider?.id ?? undefined,
     });
     if (error) {
       throw new Error(error);

--- a/web/src/sections/modals/languageModels/BifrostModal.tsx
+++ b/web/src/sections/modals/languageModels/BifrostModal.tsx
@@ -51,7 +51,7 @@ function BifrostModalInternals({
     const { models, error } = await fetchBifrostModels({
       api_base: formikProps.values.api_base,
       api_key: formikProps.values.api_key || undefined,
-      provider_name: existingLlmProvider?.name ?? undefined,
+      provider_id: existingLlmProvider?.id ?? undefined,
     });
     if (error) {
       throw new Error(error);

--- a/web/src/sections/modals/languageModels/LMStudioModal.tsx
+++ b/web/src/sections/modals/languageModels/LMStudioModal.tsx
@@ -59,7 +59,7 @@ function LMStudioModalInternals({
       api_base: formikProps.values.api_base,
       custom_config: apiKey ? { LM_STUDIO_API_KEY: apiKey } : {},
       api_key_changed: apiKey !== initialApiKey,
-      name: existingLlmProvider?.name ?? undefined,
+      id: existingLlmProvider?.id ?? undefined,
     });
     if (data.error) {
       throw new Error(data.error);

--- a/web/src/sections/modals/languageModels/LiteLLMProxyModal.tsx
+++ b/web/src/sections/modals/languageModels/LiteLLMProxyModal.tsx
@@ -53,7 +53,7 @@ function LiteLLMProxyModalInternals({
     const { models, error } = await fetchLiteLLMProxyModels({
       api_base: formikProps.values.api_base,
       api_key: formikProps.values.api_key,
-      provider_name: existingLlmProvider?.name ?? undefined,
+      provider_id: existingLlmProvider?.id ?? undefined,
     });
     if (error) {
       throw new Error(error);

--- a/web/src/sections/modals/languageModels/NebiusTokenfactoryModal.tsx
+++ b/web/src/sections/modals/languageModels/NebiusTokenfactoryModal.tsx
@@ -55,7 +55,6 @@ function NebiusTokenfactoryModalInternals({
     const { models, error } = await fetchNebiusTokenfactoryModels({
       api_base: formikProps.values.api_base,
       api_key: formikProps.values.api_key || undefined,
-      provider_name: existingLlmProvider?.name ?? undefined,
       provider_id: existingLlmProvider?.id ?? undefined,
     });
     if (error) {
@@ -82,7 +81,6 @@ function NebiusTokenfactoryModalInternals({
     fetchNebiusTokenfactoryModels({
       api_base: formikProps.values.api_base,
       api_key: formikProps.values.api_key || undefined,
-      provider_name: existingLlmProvider.name ?? undefined,
       provider_id: existingLlmProvider.id,
     })
       .then(({ models }) => {

--- a/web/src/sections/modals/languageModels/OllamaModal.tsx
+++ b/web/src/sections/modals/languageModels/OllamaModal.tsx
@@ -78,7 +78,7 @@ function OllamaModalInternals({
       : formikProps.values.api_base;
     const { models, error } = await fetchOllamaModels({
       api_base: apiBase,
-      provider_name: existingLlmProvider?.name ?? undefined,
+      provider_id: existingLlmProvider?.id ?? undefined,
       signal,
     });
     if (signal?.aborted) return;

--- a/web/src/sections/modals/languageModels/OpenAICompatibleModal.tsx
+++ b/web/src/sections/modals/languageModels/OpenAICompatibleModal.tsx
@@ -51,7 +51,7 @@ function OpenAICompatibleModalInternals({
     const { models, error } = await fetchOpenAICompatibleModels({
       api_base: formikProps.values.api_base,
       api_key: formikProps.values.api_key || undefined,
-      provider_name: existingLlmProvider?.name ?? undefined,
+      provider_id: existingLlmProvider?.id ?? undefined,
     });
     if (error) {
       throw new Error(error);

--- a/web/src/sections/modals/languageModels/OpenRouterModal.tsx
+++ b/web/src/sections/modals/languageModels/OpenRouterModal.tsx
@@ -53,7 +53,7 @@ function OpenRouterModalInternals({
     const { models: fetched, error } = await fetchOpenRouterModels({
       api_base: formikProps.values.api_base,
       api_key: formikProps.values.api_key,
-      provider_name: existingLlmProvider?.name ?? undefined,
+      provider_id: existingLlmProvider?.id ?? undefined,
     });
     if (error) {
       throw new Error(error);


### PR DESCRIPTION
## Summary

Drive all backend provider lookups in the LLM **model-fetch** endpoints off the reliable `provider_id` instead of `provider_name`. This started as a cleanup of `_resolve_api_key` and grew into the natural end state the user asked for: `provider_id` is the single backend driver, and `provider_name` is a frontend-only display concern.

`provider_name` was a weak key — well-known providers are frequently saved with a **NULL name** (the exact reason `_resolve_api_key` had already grown a `provider_id` fallback). Both model-sync and the Bedrock/LM Studio key-resolution paths still keyed off name and would silently no-op for those providers. Keying everything off `provider_id` closes that gap.

## Changes

**Backend**
- `_resolve_api_key` — drops the `provider_name` param; resolves purely by `provider_id`.
- `_resolve_bedrock_bearer_token`, `_sync_fetched_models`, and `db.llm.sync_model_configurations` — now take `provider_id` and look up via `fetch_existing_llm_provider_by_id`.
- LM Studio inline key resolution now uses `provider_id`.
- All 8 `*ModelsRequest` models (Bedrock, Ollama, OpenRouter, LM Studio, LiteLLM, Bifrost, Nebius, OpenAI-compatible) drop `provider_name` and carry `provider_id`. Sync gates switch from `if request.provider_name:` to `if request.provider_id is not None:`.
- Removed the now-unused `fetch_existing_llm_provider` (by-name) import from the manage API.

**Frontend**
- Fetch-param types, the 8 `svc.ts` request bodies, the `fetchModels` dispatcher, and all 8 provider modals now send `provider_id` (sourced from `existingLlmProvider?.id`) instead of `provider_name`.

> Note: the per-model `provider_name` on response types (e.g. `LitellmFinalModelResponse`) is unrelated and untouched.

## Tests

- Updated `test_resolve_api_key.py`, `test_llm_sync.py`, `test_fetch_models_api.py`, and `test_nebius_tokenfactory_models.py` to the `provider_id` contract.
- All 140 LLM unit tests pass; `ruff`/`ruff format`/`ty`/`oxlint`/`oxfmt` pass on changed files.
- The repo-wide `tsc` pre-commit hook fails only on **pre-existing** `Button` prop errors in unrelated files; none of the files in this PR have type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch all LLM model-fetch and model-sync endpoints to resolve providers by provider_id instead of provider_name for reliable key/token lookup and syncing. Frontend now sends provider_id; provider_name is display-only.

- **Refactors**
  - Backend: `_resolve_api_key`, `_resolve_bedrock_bearer_token`, `_sync_fetched_models`, and `db.llm.sync_model_configurations` now take `provider_id` and use `fetch_existing_llm_provider_by_id` (LM Studio path included). Sync logs and not-found errors now label the provider as `id=N`.
  - Requests: all eight `*ModelsRequest` types drop `provider_name` and add `provider_id`; syncing is gated on `provider_id` being present.
  - Frontend: request types, `svc.ts`, the dispatcher, and all provider modals send `provider_id` from `existingLlmProvider.id`.

- **Migration**
  - If you call these endpoints directly, send `provider_id` instead of `provider_name`.
  - When editing an existing provider, keep `api_base` unchanged so masked keys/tokens resolve from stored values.

<sup>Written for commit a06384920c3718b1945d15acae6e2eff39cc5082. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

