### PR TITLE
fix(craft): skip hidden entries in webapp downloads

### DIFF
--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -90,14 +90,16 @@ HIDDEN_PATTERNS = {
     ".gitignore",
 }
 
-ZIP_EXCLUDED_DIR_NAMES = frozenset({"node_modules"})
-
 
 def _sanitize_zip_basename(name: str, *, allow_dots: bool) -> str:
     """Replace filesystem-unsafe characters in a zip filename stem. ``allow_dots``
     keeps version-suffixed directory names like ``my.lib`` intact."""
     safe = {"-", "_", "."} if allow_dots else {"-", "_"}
     return "".join(c if c.isalnum() or c in safe else "_" for c in name)
+
+
+def _is_hidden_workspace_entry(entry: FilesystemEntry) -> bool:
+    return entry.name in HIDDEN_PATTERNS or entry.name.startswith(".")
 
 
 class SessionManager:
@@ -910,9 +912,9 @@ class SessionManager:
             except ValueError:
                 return
             for entry in entries:
+                if _is_hidden_workspace_entry(entry):
+                    continue
                 if entry.is_directory:
-                    if entry.name in ZIP_EXCLUDED_DIR_NAMES:
-                        continue
                     _walk(entry.path)
                 else:
                     collected.append((entry.path, arcname_for(entry.path)))
@@ -1340,9 +1342,7 @@ class SessionManager:
 
         # Filter hidden files and directories
         entries: list[FilesystemEntry] = [
-            entry
-            for entry in raw_entries
-            if entry.name not in HIDDEN_PATTERNS and not entry.name.startswith(".")
+            entry for entry in raw_entries if not _is_hidden_workspace_entry(entry)
         ]
 
         # Sort: directories first, then files, both alphabetically

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -90,6 +90,8 @@ HIDDEN_PATTERNS = {
     ".gitignore",
 }
 
+ZIP_EXCLUDED_DIR_NAMES = frozenset({"node_modules"})
+
 
 def _sanitize_zip_basename(name: str, *, allow_dots: bool) -> str:
     """Replace filesystem-unsafe characters in a zip filename stem. ``allow_dots``
@@ -909,6 +911,8 @@ class SessionManager:
                 return
             for entry in entries:
                 if entry.is_directory:
+                    if entry.name in ZIP_EXCLUDED_DIR_NAMES:
+                        continue
                     _walk(entry.path)
                 else:
                     collected.append((entry.path, arcname_for(entry.path)))

--- a/backend/tests/common/craft/stubs.py
+++ b/backend/tests/common/craft/stubs.py
@@ -96,11 +96,12 @@ class StubSandboxManager(SandboxManager):
       by ``subscribe_to_opencode_session``.
     - ``create_snapshot_returns``: ``SnapshotResult | None`` returned by
       ``create_snapshot``.
-    - ``list_directory_returns``, ``read_file_returns``,
-      ``upload_file_returns``, ``delete_file_returns``,
+    - ``list_directory_returns`` or ``list_directory_returns_by_path``,
+      ``read_file_returns``, ``upload_file_returns``, ``delete_file_returns``,
       ``get_upload_stats_returns``, ``get_webapp_url_returns``,
       ``generate_pptx_preview_returns``: return values for the matching
-      filesystem / utility methods.
+      filesystem / utility methods. Use ``list_directory_returns_by_path`` for
+      recursive directory-walk tests.
 
     Silent no-op opt-ins
     --------------------
@@ -134,6 +135,9 @@ class StubSandboxManager(SandboxManager):
         self.create_snapshot_returns: SnapshotResult | None | object = _UNSET
         self.create_opencode_history_snapshot_returns: bool | object = _UNSET
         self.list_directory_returns: list[FilesystemEntry] | None = None
+        self.list_directory_returns_by_path: dict[str, list[FilesystemEntry]] | None = (
+            None
+        )
         self.read_file_returns: bytes | None = None
         self.upload_file_returns: str | None = None
         self.delete_file_returns: bool | None = None
@@ -207,6 +211,7 @@ class StubSandboxManager(SandboxManager):
         self.last_send_message_payload: dict[str, Any] | None = None
         self.last_subscribe_to_opencode_session_payload: dict[str, Any] | None = None
         self.last_list_directory_payload: dict[str, Any] | None = None
+        self.list_directory_payloads: list[dict[str, Any]] = []
         self.last_read_file_payload: dict[str, Any] | None = None
         self.last_upload_file_payload: dict[str, Any] | None = None
         self.last_delete_file_payload: dict[str, Any] | None = None
@@ -483,6 +488,12 @@ class StubSandboxManager(SandboxManager):
             "session_id": session_id,
             "path": path,
         }
+        self.list_directory_payloads.append(self.last_list_directory_payload)
+        if self.list_directory_returns_by_path is not None:
+            entries = self.list_directory_returns_by_path.get(path)
+            if entries is None:
+                raise ValueError(f"Directory not found: {path}")
+            return entries
         if self.list_directory_returns is None:
             raise _not_configured("list_directory")
         return self.list_directory_returns

--- a/backend/tests/unit/onyx/server/features/build/session/test_archive_walk.py
+++ b/backend/tests/unit/onyx/server/features/build/session/test_archive_walk.py
@@ -13,11 +13,12 @@ def _manager(sandbox_manager: StubSandboxManager) -> SessionManager:
     return manager
 
 
-def test_archive_walk_skips_node_modules_directories() -> None:
+def test_archive_walk_skips_hidden_entries() -> None:
     sandbox_manager = StubSandboxManager()
     sandbox_manager.list_directory_returns_by_path = {
         "outputs/web": [
             FilesystemEntry(name="app", path="outputs/web/app", is_directory=True),
+            FilesystemEntry(name=".next", path="outputs/web/.next", is_directory=True),
             FilesystemEntry(
                 name="node_modules",
                 path="outputs/web/node_modules",
@@ -31,9 +32,21 @@ def test_archive_walk_skips_node_modules_directories() -> None:
                 is_directory=False,
             ),
             FilesystemEntry(
+                name=".env",
+                path="outputs/web/app/.env",
+                is_directory=False,
+            ),
+            FilesystemEntry(
                 name="node_modules",
                 path="outputs/web/app/node_modules",
                 is_directory=True,
+            ),
+        ],
+        "outputs/web/.next": [
+            FilesystemEntry(
+                name="server.js",
+                path="outputs/web/.next/server.js",
+                is_directory=False,
             ),
         ],
         "outputs/web/node_modules": [

--- a/backend/tests/unit/onyx/server/features/build/session/test_archive_walk.py
+++ b/backend/tests/unit/onyx/server/features/build/session/test_archive_walk.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+from onyx.server.features.build.sandbox.models import FilesystemEntry
+from onyx.server.features.build.session.manager import SessionManager
+from tests.common.craft.stubs import StubSandboxManager
+
+
+def _manager(sandbox_manager: StubSandboxManager) -> SessionManager:
+    manager = SessionManager.__new__(SessionManager)
+    manager._sandbox_manager = sandbox_manager
+    return manager
+
+
+def test_archive_walk_skips_node_modules_directories() -> None:
+    sandbox_manager = StubSandboxManager()
+    sandbox_manager.list_directory_returns_by_path = {
+        "outputs/web": [
+            FilesystemEntry(name="app", path="outputs/web/app", is_directory=True),
+            FilesystemEntry(
+                name="node_modules",
+                path="outputs/web/node_modules",
+                is_directory=True,
+            ),
+        ],
+        "outputs/web/app": [
+            FilesystemEntry(
+                name="page.tsx",
+                path="outputs/web/app/page.tsx",
+                is_directory=False,
+            ),
+            FilesystemEntry(
+                name="node_modules",
+                path="outputs/web/app/node_modules",
+                is_directory=True,
+            ),
+        ],
+        "outputs/web/node_modules": [
+            FilesystemEntry(
+                name="next.js",
+                path="outputs/web/node_modules/next.js",
+                is_directory=False,
+            ),
+        ],
+        "outputs/web/app/node_modules": [
+            FilesystemEntry(
+                name="react.js",
+                path="outputs/web/app/node_modules/react.js",
+                is_directory=False,
+            ),
+        ],
+    }
+
+    files = _manager(sandbox_manager)._walk_sandbox_dir(
+        uuid4(),
+        uuid4(),
+        "outputs/web",
+        arcname_for=lambda path: path.removeprefix("outputs/web/"),
+    )
+
+    assert files == [("outputs/web/app/page.tsx", "app/page.tsx")]
+    assert [payload["path"] for payload in sandbox_manager.list_directory_payloads] == [
+        "outputs/web",
+        "outputs/web/app",
+    ]


### PR DESCRIPTION
## Description

- Reuse the Craft hidden workspace entry policy when recursively collecting webapp/download-directory zip entries.
- Prevent webapp downloads from hanging while walking generated dependency trees like `node_modules`.
- Keep hidden/generated entries such as `node_modules`, `.next`, and `.env` out of downloaded archives.
- Extend the shared Craft `StubSandboxManager` with path-keyed directory listings for recursive filesystem tests.
- Add unit coverage that verifies archive walking skips hidden files and directories.

## How Has This Been Tested?


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
