### PR TITLE
fix(model_server): cap torch threads to cgroup CPU quota

### DIFF
--- a/backend/model_server/main.py
+++ b/backend/model_server/main.py
@@ -15,6 +15,7 @@ from transformers import logging as transformer_logging
 
 from model_server.encoders import router as encoders_router
 from model_server.management_endpoints import router as management_router
+from model_server.utils import get_cgroup_cpu_limit
 from model_server.utils import get_gpu_type
 from onyx import __version__
 from onyx.utils.logger import setup_logger
@@ -85,8 +86,24 @@ async def lifespan(app: FastAPI) -> AsyncGenerator:
             e,
         )
 
-    torch.set_num_threads(max(MIN_THREADS_ML_MODELS, torch.get_num_threads()))
-    logger.notice("Torch Threads: %s", torch.get_num_threads())
+    # torch sizes its intra-op thread pool from the host core count, ignoring the
+    # container's cgroup CPU quota. On a large node this oversubscribes threads against
+    # a small quota, causing thread thrash and CFS throttling. Cap to the quota (while
+    # keeping the historical MIN_THREADS_ML_MODELS floor).
+    torch_default_threads = torch.get_num_threads()
+    cpu_limit = get_cgroup_cpu_limit()
+    num_threads = (
+        torch_default_threads
+        if cpu_limit is None
+        else min(torch_default_threads, cpu_limit)
+    )
+    torch.set_num_threads(max(MIN_THREADS_ML_MODELS, num_threads))
+    logger.notice(
+        "Torch Threads: %s (torch default: %s, cgroup cpu limit: %s)",
+        torch.get_num_threads(),
+        torch_default_threads,
+        cpu_limit,
+    )
 
     yield
 

--- a/backend/model_server/utils.py
+++ b/backend/model_server/utils.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from collections.abc import Generator
 from collections.abc import Iterator
 from functools import wraps
+from pathlib import Path
 from typing import Any
 from typing import cast
 from typing import TypeVar
@@ -70,3 +71,45 @@ def get_gpu_type() -> str:
         return GPUStatus.MAC_MPS
 
     return GPUStatus.NONE
+
+
+CGROUP_V2_CPU_MAX = Path("/sys/fs/cgroup/cpu.max")
+CGROUP_V1_CPU_QUOTA = Path("/sys/fs/cgroup/cpu/cpu.cfs_quota_us")
+CGROUP_V1_CPU_PERIOD = Path("/sys/fs/cgroup/cpu/cpu.cfs_period_us")
+
+
+def get_cgroup_cpu_limit(
+    v2_cpu_max: Path = CGROUP_V2_CPU_MAX,
+    v1_cpu_quota: Path = CGROUP_V1_CPU_QUOTA,
+    v1_cpu_period: Path = CGROUP_V1_CPU_PERIOD,
+) -> int | None:
+    """Number of CPU cores available to this container per its cgroup CFS quota.
+
+    torch and the underlying OpenMP/BLAS runtimes size their thread pools from the
+    host's core count and are unaware of cgroup limits. On a large node a CPU-limited
+    container therefore spins up far more threads than its quota allows, which thrashes
+    and gets CFS-throttled. We read the quota directly so callers can cap thread counts
+    to the budget the container actually has.
+
+    Returns None when no quota is set (unlimited) or the cgroup files are unavailable.
+    """
+    # cgroup v2: single file formatted as "<quota> <period>"; "max" means unlimited.
+    try:
+        quota_str, period_str = v2_cpu_max.read_text().split()
+        if quota_str != "max":
+            period = int(period_str)
+            if period > 0:
+                return max(1, round(int(quota_str) / period))
+    except (OSError, ValueError):
+        pass
+
+    # cgroup v1: separate quota/period files; quota <= 0 means unlimited.
+    try:
+        quota = int(v1_cpu_quota.read_text())
+        period = int(v1_cpu_period.read_text())
+        if quota > 0 and period > 0:
+            return max(1, round(quota / period))
+    except (OSError, ValueError):
+        pass
+
+    return None

--- a/backend/model_server/utils.py
+++ b/backend/model_server/utils.py
@@ -91,29 +91,35 @@ def get_cgroup_cpu_limit(
     and gets CFS-throttled. We read the quota directly so callers can cap thread counts
     to the budget the container actually has.
 
-    Returns None when no quota is set (unlimited) or the cgroup files are unavailable.
+    Returns None when no quota is set (unlimited) or the cgroup files are unavailable
+    or unreadable. Quotas are floored to whole cores so the cap never exceeds the
+    container's actual CPU budget.
     """
     # cgroup v2: single file formatted as "<quota> <period>"; "max" means unlimited.
-    # When the v2 file is present it is authoritative, so we never fall back to v1
-    # (a hybrid host can have stale non-zero v1 quota files that don't reflect reality).
+    # When the v2 file is present it is authoritative: we never fall back to v1, since a
+    # hybrid host can carry stale v1 quota files that don't reflect the real limit.
     try:
         quota_str, period_str = v2_cpu_max.read_text().split()
         if quota_str == "max":
             return None
         period = int(period_str)
         if period > 0:
-            return max(1, round(int(quota_str) / period))
+            return max(1, int(quota_str) // period)
+        return None
     except FileNotFoundError:
-        pass  # not a cgroup v2 host; try v1
+        pass  # not a cgroup v2 host; fall back to v1
     except (OSError, ValueError) as e:
+        # v2 is present but unreadable/malformed; it remains authoritative, so do not
+        # trust v1 — report undetectable rather than apply a possibly-stale quota.
         logger.debug("Could not parse cgroup v2 cpu.max (%s): %s", v2_cpu_max, e)
+        return None
 
     # cgroup v1: separate quota/period files; quota <= 0 means unlimited.
     try:
         quota = int(v1_cpu_quota.read_text())
         period = int(v1_cpu_period.read_text())
         if quota > 0 and period > 0:
-            return max(1, round(quota / period))
+            return max(1, quota // period)
     except FileNotFoundError:
         pass  # no cgroup cpu controller available; treat as unlimited
     except (OSError, ValueError) as e:

--- a/backend/model_server/utils.py
+++ b/backend/model_server/utils.py
@@ -94,14 +94,19 @@ def get_cgroup_cpu_limit(
     Returns None when no quota is set (unlimited) or the cgroup files are unavailable.
     """
     # cgroup v2: single file formatted as "<quota> <period>"; "max" means unlimited.
+    # When the v2 file is present it is authoritative, so we never fall back to v1
+    # (a hybrid host can have stale non-zero v1 quota files that don't reflect reality).
     try:
         quota_str, period_str = v2_cpu_max.read_text().split()
-        if quota_str != "max":
-            period = int(period_str)
-            if period > 0:
-                return max(1, round(int(quota_str) / period))
-    except (OSError, ValueError):
-        pass
+        if quota_str == "max":
+            return None
+        period = int(period_str)
+        if period > 0:
+            return max(1, round(int(quota_str) / period))
+    except FileNotFoundError:
+        pass  # not a cgroup v2 host; try v1
+    except (OSError, ValueError) as e:
+        logger.debug("Could not parse cgroup v2 cpu.max (%s): %s", v2_cpu_max, e)
 
     # cgroup v1: separate quota/period files; quota <= 0 means unlimited.
     try:
@@ -109,7 +114,9 @@ def get_cgroup_cpu_limit(
         period = int(v1_cpu_period.read_text())
         if quota > 0 and period > 0:
             return max(1, round(quota / period))
-    except (OSError, ValueError):
-        pass
+    except FileNotFoundError:
+        pass  # no cgroup cpu controller available; treat as unlimited
+    except (OSError, ValueError) as e:
+        logger.debug("Could not parse cgroup v1 cpu quota/period: %s", e)
 
     return None

--- a/backend/tests/unit/model_server/test_cgroup_cpu_limit.py
+++ b/backend/tests/unit/model_server/test_cgroup_cpu_limit.py
@@ -1,0 +1,115 @@
+from pathlib import Path
+
+from model_server.utils import get_cgroup_cpu_limit
+
+
+def _missing(tmp_path: Path) -> Path:
+    return tmp_path / "does_not_exist"
+
+
+def test_cgroup_v2_quota(tmp_path: Path) -> None:
+    v2 = tmp_path / "cpu.max"
+    v2.write_text("800000 100000")
+    assert (
+        get_cgroup_cpu_limit(
+            v2_cpu_max=v2,
+            v1_cpu_quota=_missing(tmp_path),
+            v1_cpu_period=_missing(tmp_path),
+        )
+        == 8
+    )
+
+
+def test_cgroup_v2_unlimited(tmp_path: Path) -> None:
+    v2 = tmp_path / "cpu.max"
+    v2.write_text("max 100000")
+    assert (
+        get_cgroup_cpu_limit(
+            v2_cpu_max=v2,
+            v1_cpu_quota=_missing(tmp_path),
+            v1_cpu_period=_missing(tmp_path),
+        )
+        is None
+    )
+
+
+def test_cgroup_v2_rounds_to_nearest_core(tmp_path: Path) -> None:
+    v2 = tmp_path / "cpu.max"
+    # 6.5 cores -> rounds to 6 (banker's rounding); the point is it never returns 0.
+    v2.write_text("650000 100000")
+    assert (
+        get_cgroup_cpu_limit(
+            v2_cpu_max=v2,
+            v1_cpu_quota=_missing(tmp_path),
+            v1_cpu_period=_missing(tmp_path),
+        )
+        == 6
+    )
+
+
+def test_cgroup_v2_sub_core_floors_to_one(tmp_path: Path) -> None:
+    v2 = tmp_path / "cpu.max"
+    # 0.1 cores would round to 0; we floor to 1 so torch always gets a usable count.
+    v2.write_text("10000 100000")
+    assert (
+        get_cgroup_cpu_limit(
+            v2_cpu_max=v2,
+            v1_cpu_quota=_missing(tmp_path),
+            v1_cpu_period=_missing(tmp_path),
+        )
+        == 1
+    )
+
+
+def test_cgroup_v1_fallback(tmp_path: Path) -> None:
+    quota = tmp_path / "cpu.cfs_quota_us"
+    period = tmp_path / "cpu.cfs_period_us"
+    quota.write_text("400000")
+    period.write_text("100000")
+    assert (
+        get_cgroup_cpu_limit(
+            v2_cpu_max=_missing(tmp_path),
+            v1_cpu_quota=quota,
+            v1_cpu_period=period,
+        )
+        == 4
+    )
+
+
+def test_cgroup_v1_unlimited(tmp_path: Path) -> None:
+    quota = tmp_path / "cpu.cfs_quota_us"
+    period = tmp_path / "cpu.cfs_period_us"
+    quota.write_text("-1")
+    period.write_text("100000")
+    assert (
+        get_cgroup_cpu_limit(
+            v2_cpu_max=_missing(tmp_path),
+            v1_cpu_quota=quota,
+            v1_cpu_period=period,
+        )
+        is None
+    )
+
+
+def test_no_cgroup_files(tmp_path: Path) -> None:
+    assert (
+        get_cgroup_cpu_limit(
+            v2_cpu_max=_missing(tmp_path),
+            v1_cpu_quota=_missing(tmp_path),
+            v1_cpu_period=_missing(tmp_path),
+        )
+        is None
+    )
+
+
+def test_malformed_contents(tmp_path: Path) -> None:
+    v2 = tmp_path / "cpu.max"
+    v2.write_text("garbage")
+    assert (
+        get_cgroup_cpu_limit(
+            v2_cpu_max=v2,
+            v1_cpu_quota=_missing(tmp_path),
+            v1_cpu_period=_missing(tmp_path),
+        )
+        is None
+    )

--- a/backend/tests/unit/model_server/test_cgroup_cpu_limit.py
+++ b/backend/tests/unit/model_server/test_cgroup_cpu_limit.py
@@ -33,17 +33,17 @@ def test_cgroup_v2_unlimited(tmp_path: Path) -> None:
     )
 
 
-def test_cgroup_v2_rounds_to_nearest_core(tmp_path: Path) -> None:
+def test_cgroup_v2_floors_fractional_quota(tmp_path: Path) -> None:
     v2 = tmp_path / "cpu.max"
-    # 6.5 cores -> rounds to 6 (banker's rounding); the point is it never returns 0.
-    v2.write_text("650000 100000")
+    # 7.5 cores -> floors to 7 so the cap never exceeds the quota (round would give 8).
+    v2.write_text("750000 100000")
     assert (
         get_cgroup_cpu_limit(
             v2_cpu_max=v2,
             v1_cpu_quota=_missing(tmp_path),
             v1_cpu_period=_missing(tmp_path),
         )
-        == 6
+        == 7
     )
 
 
@@ -66,6 +66,20 @@ def test_cgroup_v2_max_does_not_fall_through_to_v1(tmp_path: Path) -> None:
     # the v2 hierarchy is authoritative.
     v2 = tmp_path / "cpu.max"
     v2.write_text("max 100000")
+    quota = tmp_path / "cpu.cfs_quota_us"
+    period = tmp_path / "cpu.cfs_period_us"
+    quota.write_text("400000")
+    period.write_text("100000")
+    assert (
+        get_cgroup_cpu_limit(v2_cpu_max=v2, v1_cpu_quota=quota, v1_cpu_period=period)
+        is None
+    )
+
+
+def test_cgroup_v2_malformed_does_not_fall_through_to_v1(tmp_path: Path) -> None:
+    # A present-but-unparseable v2 file is still authoritative: we must not consult v1.
+    v2 = tmp_path / "cpu.max"
+    v2.write_text("garbage")
     quota = tmp_path / "cpu.cfs_quota_us"
     period = tmp_path / "cpu.cfs_period_us"
     quota.write_text("400000")

--- a/backend/tests/unit/model_server/test_cgroup_cpu_limit.py
+++ b/backend/tests/unit/model_server/test_cgroup_cpu_limit.py
@@ -61,6 +61,21 @@ def test_cgroup_v2_sub_core_floors_to_one(tmp_path: Path) -> None:
     )
 
 
+def test_cgroup_v2_max_does_not_fall_through_to_v1(tmp_path: Path) -> None:
+    # When v2 reports unlimited, a populated v1 quota (hybrid host) must be ignored:
+    # the v2 hierarchy is authoritative.
+    v2 = tmp_path / "cpu.max"
+    v2.write_text("max 100000")
+    quota = tmp_path / "cpu.cfs_quota_us"
+    period = tmp_path / "cpu.cfs_period_us"
+    quota.write_text("400000")
+    period.write_text("100000")
+    assert (
+        get_cgroup_cpu_limit(v2_cpu_max=v2, v1_cpu_quota=quota, v1_cpu_period=period)
+        is None
+    )
+
+
 def test_cgroup_v1_fallback(tmp_path: Path) -> None:
     quota = tmp_path / "cpu.cfs_quota_us"
     period = tmp_path / "cpu.cfs_period_us"


### PR DESCRIPTION
## Description

The indexing model server periodically pegs its CPU limit and gets heavily CFS-throttled. Root cause is PyTorch thread oversubscription: `torch.set_num_threads(max(MIN_THREADS_ML_MODELS, torch.get_num_threads()))` sizes the intra-op thread pool from the **host** core count, ignoring the container's cgroup CPU quota. On a large node (observed: 384-core host, 8-core pod limit) this launches ~192 BLAS/OMP threads against an 8-core quota — they thrash, peg the limit, and get throttled ~95% of scheduler periods, slowing indexing throughput.

This makes the model server cgroup-aware:

- New `get_cgroup_cpu_limit()` helper in `model_server/utils.py` reads the CFS quota (cgroup v2 `cpu.max`, falling back to v1 `cpu.cfs_quota_us`/`cpu.cfs_period_us`). Returns `None` when unlimited/unreadable.
- `main.py` now caps `torch.set_num_threads` to that quota while preserving the historical `MIN_THREADS_ML_MODELS` floor. Startup log now prints torch default + detected cgroup limit for diagnosability.

Fixes both the indexing and inference model servers (shared entrypoint), for every deployment, with no values/env changes required.

## How Has This Been Tested?

- **Unit tests** (`tests/unit/model_server/test_cgroup_cpu_limit.py`): cgroup v2/v1 parsing, unlimited (`max` / `-1`), sub-core floor-to-1, rounding, missing files, and malformed contents. 8 cases, all pass.
- **Real cgroup smoke test**: ran the read logic in a Linux container under `docker run --cpus=N`. Host reports 14 cores, but the helper correctly reads the quota — `--cpus=2` → `2`, `--cpus=6` → `6` — i.e. it caps to the container budget rather than the host count.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cap `torch` intra‑op threads to the container’s cgroup CPU quota to stop CPU thrash and CFS throttling, improving throughput for indexing and inference with no config changes. cgroup v2 is authoritative; parse failures are debug‑logged.

- **Bug Fixes**
  - Added `get_cgroup_cpu_limit()` that reads v2 `cpu.max` as authoritative (return `None` on `max` or unreadable), falling back to v1 `cpu.cfs_quota_us`/`cpu.cfs_period_us` only if the v2 file is missing; fractional quotas are floored (never over‑allocate) and sub‑core quotas floor to 1.
  - Updated `model_server/main.py` to cap `torch.set_num_threads` to the detected limit with the `MIN_THREADS_ML_MODELS` floor; logs torch default, detected quota, and final value.
  - Added tests for v2/v1 parsing, v2 `max` not falling through to v1, unreadable v2 remaining authoritative, unlimited quotas, fractional‑quota flooring, floor‑to‑1, and missing/malformed files.

<sup>Written for commit effc49d43e1550e10a9e2fa3658da81c77a5aaaf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

