### PR TITLE
ci: allow Craft workflow runner labels

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -14,6 +14,7 @@ self-hosted-runner:
     - runner=8cpu-linux-x64
     - runner=16cpu-linux-arm64
     - runner=16cpu-linux-x64
+    - spot=false # On-demand (no spot reclamation) for long-running lanes
     - ubuntu-slim # Currently in public preview
     - volume=40gb
     - volume=50gb


### PR DESCRIPTION
## Description

Allows `spot=false` as a valid self-hosted runner label so long-running Craft workflow lanes can request on-demand runners without actionlint failures.

## How Has This Been Tested?


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `spot=false` to the allowed self-hosted runner labels in `.github/actionlint.yml`. This lets long-running Craft lanes use on-demand runners without actionlint errors.

<sup>Written for commit 823065700cbe440f83331b7862783dcd7a99a4da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

