### PR TITLE
test(craft): add isolated unit and EDU contract coverage

### DIFF
--- a/backend/tests/external_dependency_unit/craft/test_skill_push_fault.py
+++ b/backend/tests/external_dependency_unit/craft/test_skill_push_fault.py
@@ -1,0 +1,62 @@
+"""Skill-push fault-injection: one failing sandbox must not abort pushes to others."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.db.enums import SandboxStatus
+from onyx.db.models import Skill
+from onyx.server.features.build.sandbox.models import FatalWriteError
+from onyx.skills.push import push_skills_for_users
+from tests.common.craft.stubs import StubSandboxManager
+from tests.external_dependency_unit.craft.db_helpers import make_sandbox
+from tests.external_dependency_unit.craft.db_helpers import make_user
+
+
+def test_one_failing_sandbox_does_not_abort_push_to_others(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    seeded_skill: Callable[..., Skill],
+    failing_sandbox_manager: Callable[..., StubSandboxManager],
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    user_a = make_user(db_session)
+    user_b = make_user(db_session)
+    user_c = make_user(db_session)
+    make_sandbox(db_session, user_a, status=SandboxStatus.RUNNING)
+    sandbox_b = make_sandbox(db_session, user_b, status=SandboxStatus.RUNNING)
+    make_sandbox(db_session, user_c, status=SandboxStatus.RUNNING)
+    db_session.commit()
+
+    stub = failing_sandbox_manager(
+        fail_on={sandbox_b.id: FatalWriteError("Pod not found")}
+    )
+
+    monkeypatch.setattr(
+        "onyx.skills.push.get_sandbox_manager",
+        lambda: stub,
+    )
+
+    seeded_skill(
+        slug=f"partial-{uuid4().hex[:6]}",
+        public=True,
+        bundle_files={"SKILL.md": "p\n"},
+    )
+
+    with caplog.at_level(logging.WARNING):
+        push_skills_for_users({user_a.id, user_b.id, user_c.id}, db_session)
+
+    assert stub.write_files_to_sandbox_count == 3
+
+    warning_messages = [
+        r.getMessage() for r in caplog.records if r.levelno == logging.WARNING
+    ]
+    assert any("1/3 targets failed" in m for m in warning_messages), (
+        f"Expected a '1/3 targets failed' partial-failure warning; got: {warning_messages!r}"
+    )

--- a/backend/tests/external_dependency_unit/craft/test_user_library_fileset.py
+++ b/backend/tests/external_dependency_unit/craft/test_user_library_fileset.py
@@ -1,0 +1,139 @@
+"""External-dependency unit tests for user-library sandbox sync helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.db.enums import SandboxStatus
+from onyx.db.models import Sandbox
+from onyx.db.models import User
+from onyx.server.features.build.db.user_library import create_directory_record
+from onyx.server.features.build.db.user_library import fetch_user_file_for_user
+from onyx.server.features.build.db.user_library import get_or_create_craft_connector
+from onyx.server.features.build.db.user_library import set_sync_disabled
+from onyx.server.features.build.db.user_library import store_user_file
+from onyx.server.features.build.sandbox.user_library import build_user_library_fileset
+from onyx.server.features.build.sandbox.user_library import hydrate_user_library
+from onyx.server.features.build.sandbox.user_library import (
+    sync_user_library_to_active_sandboxes,
+)
+from onyx.server.features.build.sandbox.user_library import USER_LIBRARY_MOUNT_PATH
+from tests.common.craft.stubs import StubSandboxManager
+
+
+def _seed_file(
+    db_session: Session,
+    user: User,
+    file_path: str,
+    content: bytes,
+) -> str:
+    connector_id, credential_id = get_or_create_craft_connector(db_session, user)
+    doc_id, _, _ = store_user_file(
+        db_session=db_session,
+        user_id=user.id,
+        connector_id=connector_id,
+        credential_id=credential_id,
+        file_path=file_path,
+        content=content,
+        mime_type="application/octet-stream",
+    )
+    db_session.commit()
+    return doc_id
+
+
+def _patch_user_library_manager(
+    monkeypatch: pytest.MonkeyPatch,
+    stub: StubSandboxManager,
+) -> None:
+    monkeypatch.setattr(
+        "onyx.server.features.build.sandbox.user_library.get_sandbox_manager",
+        lambda: stub,
+    )
+
+
+class TestUserLibraryFileset:
+    def test_sync_disabled_files_excluded(
+        self,
+        db_session: Session,
+        test_user: User,
+    ) -> None:
+        _seed_file(db_session, test_user, "enabled.txt", b"yes")
+        disabled_id = _seed_file(db_session, test_user, "disabled.txt", b"no")
+
+        doc = fetch_user_file_for_user(db_session, disabled_id, test_user.id)
+        set_sync_disabled(db_session, test_user.id, doc, sync_disabled=True)
+        db_session.commit()
+
+        fileset = build_user_library_fileset(test_user.id, db_session)
+
+        assert fileset == {"enabled.txt": b"yes"}
+
+    def test_directories_excluded_from_fileset(
+        self,
+        db_session: Session,
+        test_user: User,
+    ) -> None:
+        connector_id, credential_id = get_or_create_craft_connector(
+            db_session, test_user
+        )
+        create_directory_record(
+            db_session=db_session,
+            user_id=test_user.id,
+            connector_id=connector_id,
+            credential_id=credential_id,
+            dir_path="/my_folder",
+        )
+        _seed_file(db_session, test_user, "real_file.csv", b"data")
+        db_session.commit()
+
+        fileset = build_user_library_fileset(test_user.id, db_session)
+
+        assert fileset == {"real_file.csv": b"data"}
+
+    def test_hydrate_user_library_pushes_current_fileset_to_one_sandbox(
+        self,
+        db_session: Session,
+        test_user: User,
+        sandbox: Callable[..., Sandbox],
+        stub_sandbox_manager: StubSandboxManager,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        sandbox_row = sandbox(user=test_user, status=SandboxStatus.RUNNING)
+        _seed_file(db_session, test_user, "docs/readme.md", b"hello")
+        stub_sandbox_manager.write_files_to_sandbox_silent = True
+        _patch_user_library_manager(monkeypatch, stub_sandbox_manager)
+
+        result = hydrate_user_library(sandbox_row.id, test_user.id, db_session)
+
+        assert result.succeeded == 1
+        assert stub_sandbox_manager.write_files_to_sandbox_count == 1
+        assert stub_sandbox_manager.last_write_files_to_sandbox_payload == {
+            "sandbox_id": sandbox_row.id,
+            "mount_path": USER_LIBRARY_MOUNT_PATH,
+            "files": {"docs/readme.md": b"hello"},
+        }
+
+    def test_sync_user_library_pushes_to_running_sandbox(
+        self,
+        db_session: Session,
+        test_user: User,
+        sandbox: Callable[..., Sandbox],
+        stub_sandbox_manager: StubSandboxManager,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        running = sandbox(user=test_user, status=SandboxStatus.RUNNING)
+        _seed_file(db_session, test_user, "active.txt", b"active")
+        stub_sandbox_manager.write_files_to_sandbox_silent = True
+        _patch_user_library_manager(monkeypatch, stub_sandbox_manager)
+
+        sync_user_library_to_active_sandboxes(test_user.id, db_session)
+
+        assert stub_sandbox_manager.write_files_to_sandbox_count == 1
+        assert stub_sandbox_manager.last_write_files_to_sandbox_payload == {
+            "sandbox_id": running.id,
+            "mount_path": USER_LIBRARY_MOUNT_PATH,
+            "files": {"active.txt": b"active"},
+        }

--- a/backend/tests/unit/build/test_kubernetes_sandbox_manager.py
+++ b/backend/tests/unit/build/test_kubernetes_sandbox_manager.py
@@ -1,0 +1,28 @@
+"""Unit coverage for Kubernetes sandbox manager helpers."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager import (
+    KubernetesSandboxManager,
+)
+
+# K8s object names must be a DNS label: <=63 chars, lowercase alphanumerics
+# and hyphens. ``_get_pod_name`` is the prefix for the pod, service, and the
+# ``-opencode-auth`` secret, so the longest derived name must still fit.
+_DNS_LABEL_MAX = 63
+_LONGEST_SUFFIX = "-opencode-auth"
+
+
+def test_pod_name_stays_within_dns_label_limit() -> None:
+    manager = KubernetesSandboxManager.__new__(KubernetesSandboxManager)
+
+    # The name length is constant (``_get_pod_name`` truncates to the first 8
+    # hex chars); this all-f UUID just exercises the full alphanumeric range so
+    # the lowercase / DNS-label character-set assertions below are meaningful.
+    pod_name = manager._get_pod_name(UUID("ffffffff-ffff-ffff-ffff-ffffffffffff"))
+
+    assert len(pod_name) + len(_LONGEST_SUFFIX) <= _DNS_LABEL_MAX
+    assert pod_name == pod_name.lower()
+    assert all(c.isalnum() or c == "-" for c in pod_name)

--- a/backend/tests/unit/build/test_webapp_proxy_header_stripping.py
+++ b/backend/tests/unit/build/test_webapp_proxy_header_stripping.py
@@ -1,0 +1,68 @@
+"""The webapp proxy must strip Set-Cookie from upstream responses."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+from uuid import uuid4
+
+import httpx
+from starlette.requests import Request
+from starlette.responses import Response
+
+from onyx.server.features.build import webapp_proxy
+
+
+def _make_request() -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "scheme": "http",
+            "path": "/",
+            "query_string": b"",
+            "headers": [],
+        }
+    )
+
+
+async def _no_bytes(chunk_size: int = 8192) -> AsyncGenerator[bytes, None]:  # noqa: ARG001
+    return
+    yield b""  # pragma: no cover
+
+
+def test_proxy_strips_set_cookie_keeps_other_headers() -> None:
+    upstream = MagicMock(spec=httpx.Response)
+    upstream.status_code = 200
+    upstream.headers = httpx.Headers(
+        {
+            "content-type": "text/html",
+            "set-cookie": "sid=leak; Path=/",
+            "x-upstream": "kept",
+        }
+    )
+    upstream.aiter_bytes = _no_bytes
+    upstream.aclose = AsyncMock()
+
+    client = MagicMock()
+    client.build_request = MagicMock()
+    client.send = AsyncMock(return_value=upstream)
+
+    with (
+        patch.object(
+            webapp_proxy,
+            "_get_sandbox_url",
+            AsyncMock(return_value="http://sandbox-x:3000"),
+        ),
+        patch.object(webapp_proxy, "_get_proxy_client", return_value=client),
+    ):
+        response: Response = asyncio.run(
+            webapp_proxy._proxy_request("", _make_request(), uuid4())
+        )
+
+    header_names = {name.lower() for name in response.headers}
+    assert "set-cookie" not in header_names
+    assert response.headers.get("x-upstream") == "kept"


### PR DESCRIPTION
## Description

Adds focused test coverage that can be reviewed independently before moving Craft's heavier real-sandbox tests into integration lanes:

- unit regression coverage for Kubernetes sandbox pod naming and webapp proxy `Set-Cookie` stripping
- external-dependency unit contract coverage for user-library fileset hydration/sync filtering and skill push partial failures

No existing EDU fixtures or live sandbox tests are pruned in this PR.

## How Has This Been Tested?


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds isolated unit and external-dependency unit tests for Craft covering Kubernetes pod name validity, webapp proxy `Set-Cookie` stripping, user library fileset/sync behavior, and resilient skill pushes. Enables independent review before shifting heavier sandbox tests to integration lanes.

- **New Tests**
  - Kubernetes: pod name is lowercase DNS-label (alnum/hyphen only) and fits 63-char limit with `-opencode-auth` suffix.
  - Webapp proxy: strips `Set-Cookie` while keeping other headers.
  - User library: excludes sync-disabled files and directories; `hydrate_user_library` and active sync push the correct payload to running sandboxes.
  - Skill push: a single sandbox write failure does not abort others; logs partial failure count.

<sup>Written for commit 453b7cbc3dadd8d8833a74f0ac0f2c622cca05da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

