### PR TITLE
feat(tenants): feature-flag the impersonation endpoint, disabled by default

### DIFF
--- a/backend/ee/onyx/configs/app_configs.py
+++ b/backend/ee/onyx/configs/app_configs.py
@@ -117,6 +117,10 @@ JWT_PUBLIC_KEY_URL: str | None = os.getenv("JWT_PUBLIC_KEY_URL", None)
 SUPER_USERS = json.loads(os.environ.get("SUPER_USERS", "[]"))
 SUPER_CLOUD_API_KEY = os.environ.get("SUPER_CLOUD_API_KEY", "api_key")
 
+# Gates the cloud-superuser impersonation endpoint. Disabled by default; must be
+# explicitly opted into via env var.
+IMPERSONATION_ENABLED = os.environ.get("IMPERSONATION_ENABLED", "").lower() == "true"
+
 POSTHOG_API_KEY = os.environ.get("POSTHOG_API_KEY")
 POSTHOG_HOST = os.environ.get("POSTHOG_HOST") or "https://us.i.posthog.com"
 POSTHOG_DEBUG_LOGS_ENABLED = (

--- a/backend/ee/onyx/server/tenants/admin_api.py
+++ b/backend/ee/onyx/server/tenants/admin_api.py
@@ -5,6 +5,7 @@ from fastapi import Response
 from fastapi_users import exceptions
 
 from ee.onyx.auth.users import current_cloud_superuser
+from ee.onyx.configs.app_configs import IMPERSONATION_ENABLED
 from ee.onyx.server.tenants.models import ImpersonateRequest
 from ee.onyx.server.tenants.user_mapping import get_tenant_id_for_email
 from onyx.auth.users import auth_backend
@@ -13,6 +14,8 @@ from onyx.auth.users import User
 from onyx.configs.constants import FASTAPI_USERS_AUTH_COOKIE_NAME
 from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.users import get_user_by_email
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -20,10 +23,24 @@ logger = setup_logger()
 router = APIRouter(prefix="/tenants")
 
 
+def require_impersonation_enabled() -> None:
+    """FastAPI dependency that gates the impersonation endpoint.
+
+    Impersonation is disabled by default and must be explicitly enabled via the
+    IMPERSONATION_ENABLED env var.
+    """
+    if not IMPERSONATION_ENABLED:
+        raise OnyxError(
+            OnyxErrorCode.ENV_VAR_GATED,
+            "Impersonation is disabled (IMPERSONATION_ENABLED is not set)",
+        )
+
+
 @router.post("/impersonate")
 async def impersonate_user(
     impersonate_request: ImpersonateRequest,
     _: User = Depends(current_cloud_superuser),
+    __: None = Depends(require_impersonation_enabled),
 ) -> Response:
     """Allows a cloud superuser to impersonate another user by generating an impersonation JWT token"""
     try:

--- a/backend/ee/onyx/server/tenants/admin_api.py
+++ b/backend/ee/onyx/server/tenants/admin_api.py
@@ -5,7 +5,6 @@ from fastapi import Response
 from fastapi_users import exceptions
 
 from ee.onyx.auth.users import current_cloud_superuser
-from ee.onyx.configs.app_configs import IMPERSONATION_ENABLED
 from ee.onyx.server.tenants.models import ImpersonateRequest
 from ee.onyx.server.tenants.user_mapping import get_tenant_id_for_email
 from onyx.auth.users import auth_backend
@@ -14,8 +13,6 @@ from onyx.auth.users import User
 from onyx.configs.constants import FASTAPI_USERS_AUTH_COOKIE_NAME
 from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.users import get_user_by_email
-from onyx.error_handling.error_codes import OnyxErrorCode
-from onyx.error_handling.exceptions import OnyxError
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -23,24 +20,10 @@ logger = setup_logger()
 router = APIRouter(prefix="/tenants")
 
 
-def require_impersonation_enabled() -> None:
-    """FastAPI dependency that gates the impersonation endpoint.
-
-    Impersonation is disabled by default and must be explicitly enabled via the
-    IMPERSONATION_ENABLED env var.
-    """
-    if not IMPERSONATION_ENABLED:
-        raise OnyxError(
-            OnyxErrorCode.ENV_VAR_GATED,
-            "Impersonation is disabled (IMPERSONATION_ENABLED is not set)",
-        )
-
-
 @router.post("/impersonate")
 async def impersonate_user(
     impersonate_request: ImpersonateRequest,
     _: User = Depends(current_cloud_superuser),
-    __: None = Depends(require_impersonation_enabled),
 ) -> Response:
     """Allows a cloud superuser to impersonate another user by generating an impersonation JWT token"""
     try:

--- a/backend/ee/onyx/server/tenants/api.py
+++ b/backend/ee/onyx/server/tenants/api.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter
 
+from ee.onyx.configs.app_configs import IMPERSONATION_ENABLED
 from ee.onyx.server.tenants.admin_api import router as admin_router
 from ee.onyx.server.tenants.anonymous_users_api import router as anonymous_users_router
 from ee.onyx.server.tenants.billing_api import router as billing_router
@@ -12,15 +13,29 @@ from ee.onyx.server.tenants.user_invitations_api import (
     router as user_invitations_router,
 )
 
-# Create a main router to include all sub-routers
-# Note: We don't add a prefix here as each router already has the /tenants prefix
-router = APIRouter()
 
-# Include all the individual routers
-router.include_router(admin_router)
-router.include_router(anonymous_users_router)
-router.include_router(billing_router)
-router.include_router(team_membership_router)
-router.include_router(tenant_management_router)
-router.include_router(user_invitations_router)
-router.include_router(proxy_router)
+def build_tenants_router(
+    impersonation_enabled: bool = IMPERSONATION_ENABLED,
+) -> APIRouter:
+    """Assemble the composite tenants router.
+
+    The impersonation endpoint (admin_router) is gated behind a feature flag and
+    is only registered when explicitly enabled. When disabled it is not mounted
+    at all, so requests 404 rather than reaching the handler or the auth layer.
+
+    Note: we don't add a prefix here as each sub-router already has the /tenants
+    prefix.
+    """
+    router = APIRouter()
+    router.include_router(anonymous_users_router)
+    router.include_router(billing_router)
+    router.include_router(team_membership_router)
+    router.include_router(tenant_management_router)
+    router.include_router(user_invitations_router)
+    router.include_router(proxy_router)
+    if impersonation_enabled:
+        router.include_router(admin_router)
+    return router
+
+
+router = build_tenants_router()

--- a/backend/tests/unit/ee/onyx/server/tenants/test_impersonation_gate.py
+++ b/backend/tests/unit/ee/onyx/server/tenants/test_impersonation_gate.py
@@ -1,22 +1,58 @@
-"""Unit tests for the impersonation feature gate."""
+"""Tests for the impersonation feature gate.
+
+Exercises the gate through the actual endpoint (in-process via TestClient) so we
+verify both the gate logic *and* that the dependency is wired to the route. The
+cloud-superuser auth dependency is overridden so we test the feature flag in
+isolation, and the flag itself is toggled via monkeypatch (works because the
+endpoint runs in this same process).
+"""
 
 from unittest.mock import patch
 
 import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from fastapi_users import exceptions
 
-from ee.onyx.server.tenants.admin_api import require_impersonation_enabled
-from onyx.error_handling.error_codes import OnyxErrorCode
-from onyx.error_handling.exceptions import OnyxError
+from ee.onyx.auth.users import current_cloud_superuser
+from ee.onyx.server.tenants import admin_api
+from onyx.error_handling.exceptions import register_onyx_exception_handlers
 
 
-class TestRequireImpersonationEnabled:
-    def test_raises_when_disabled(self) -> None:
-        with patch("ee.onyx.server.tenants.admin_api.IMPERSONATION_ENABLED", False):
-            with pytest.raises(OnyxError) as exc_info:
-                require_impersonation_enabled()
-        assert exc_info.value.error_code is OnyxErrorCode.ENV_VAR_GATED
-        assert exc_info.value.status_code == 403
+@pytest.fixture
+def client() -> TestClient:
+    app = FastAPI()
+    app.include_router(admin_api.router)
+    register_onyx_exception_handlers(app)
+    # Bypass the cloud-superuser auth gate; we're testing the feature flag here.
+    app.dependency_overrides[current_cloud_superuser] = lambda: None
+    return TestClient(app)
 
-    def test_passes_when_enabled(self) -> None:
-        with patch("ee.onyx.server.tenants.admin_api.IMPERSONATION_ENABLED", True):
-            require_impersonation_enabled()  # must not raise
+
+def test_returns_403_env_var_gated_when_disabled(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(admin_api, "IMPERSONATION_ENABLED", False)
+
+    resp = client.post("/tenants/impersonate", json={"email": "user@example.com"})
+
+    assert resp.status_code == 403
+    assert resp.json()["error_code"] == "ENV_VAR_GATED"
+
+
+def test_passes_gate_when_enabled(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(admin_api, "IMPERSONATION_ENABLED", True)
+
+    # Stop in the handler body right after the gate so we don't touch the DB;
+    # reaching this code proves the request got past the feature gate.
+    with patch.object(
+        admin_api,
+        "get_tenant_id_for_email",
+        side_effect=exceptions.UserNotExists,
+    ):
+        resp = client.post("/tenants/impersonate", json={"email": "user@example.com"})
+
+    assert resp.status_code == 422
+    assert resp.json().get("error_code") != "ENV_VAR_GATED"

--- a/backend/tests/unit/ee/onyx/server/tenants/test_impersonation_gate.py
+++ b/backend/tests/unit/ee/onyx/server/tenants/test_impersonation_gate.py
@@ -1,58 +1,34 @@
 """Tests for the impersonation feature gate.
 
-Exercises the gate through the actual endpoint (in-process via TestClient) so we
-verify both the gate logic *and* that the dependency is wired to the route. The
-cloud-superuser auth dependency is overridden so we test the feature flag in
-isolation, and the flag itself is toggled via monkeypatch (works because the
-endpoint runs in this same process).
+Impersonation is gated at the router level: the endpoint is only registered when
+IMPERSONATION_ENABLED is set. When disabled it is not mounted at all, so a
+request 404s rather than reaching the handler or the auth layer.
 """
 
-from unittest.mock import patch
+from fastapi import APIRouter
+from fastapi.routing import APIRoute
 
-import pytest
-from fastapi import FastAPI
-from fastapi.testclient import TestClient
-from fastapi_users import exceptions
+from ee.onyx.server.tenants import api
+from ee.onyx.server.tenants.api import build_tenants_router
 
-from ee.onyx.auth.users import current_cloud_superuser
-from ee.onyx.server.tenants import admin_api
-from onyx.error_handling.exceptions import register_onyx_exception_handlers
+IMPERSONATE_PATH = "/tenants/impersonate"
 
 
-@pytest.fixture
-def client() -> TestClient:
-    app = FastAPI()
-    app.include_router(admin_api.router)
-    register_onyx_exception_handlers(app)
-    # Bypass the cloud-superuser auth gate; we're testing the feature flag here.
-    app.dependency_overrides[current_cloud_superuser] = lambda: None
-    return TestClient(app)
+def _paths(router: APIRouter) -> set[str]:
+    return {route.path for route in router.routes if isinstance(route, APIRoute)}
 
 
-def test_returns_403_env_var_gated_when_disabled(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setattr(admin_api, "IMPERSONATION_ENABLED", False)
-
-    resp = client.post("/tenants/impersonate", json={"email": "user@example.com"})
-
-    assert resp.status_code == 403
-    assert resp.json()["error_code"] == "ENV_VAR_GATED"
+def test_impersonate_not_registered_when_disabled() -> None:
+    router = build_tenants_router(impersonation_enabled=False)
+    assert IMPERSONATE_PATH not in _paths(router)
 
 
-def test_passes_gate_when_enabled(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setattr(admin_api, "IMPERSONATION_ENABLED", True)
+def test_impersonate_registered_when_enabled() -> None:
+    router = build_tenants_router(impersonation_enabled=True)
+    assert IMPERSONATE_PATH in _paths(router)
 
-    # Stop in the handler body right after the gate so we don't touch the DB;
-    # reaching this code proves the request got past the feature gate.
-    with patch.object(
-        admin_api,
-        "get_tenant_id_for_email",
-        side_effect=exceptions.UserNotExists,
-    ):
-        resp = client.post("/tenants/impersonate", json={"email": "user@example.com"})
 
-    assert resp.status_code == 422
-    assert resp.json().get("error_code") != "ENV_VAR_GATED"
+def test_disabled_by_default() -> None:
+    # The module-level router is built from the real env, which leaves the flag
+    # off by default — guards against the route being wired in unconditionally.
+    assert IMPERSONATE_PATH not in _paths(api.router)

--- a/backend/tests/unit/ee/onyx/server/tenants/test_impersonation_gate.py
+++ b/backend/tests/unit/ee/onyx/server/tenants/test_impersonation_gate.py
@@ -1,0 +1,22 @@
+"""Unit tests for the impersonation feature gate."""
+
+from unittest.mock import patch
+
+import pytest
+
+from ee.onyx.server.tenants.admin_api import require_impersonation_enabled
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+
+
+class TestRequireImpersonationEnabled:
+    def test_raises_when_disabled(self) -> None:
+        with patch("ee.onyx.server.tenants.admin_api.IMPERSONATION_ENABLED", False):
+            with pytest.raises(OnyxError) as exc_info:
+                require_impersonation_enabled()
+        assert exc_info.value.error_code is OnyxErrorCode.ENV_VAR_GATED
+        assert exc_info.value.status_code == 403
+
+    def test_passes_when_enabled(self) -> None:
+        with patch("ee.onyx.server.tenants.admin_api.IMPERSONATION_ENABLED", True):
+            require_impersonation_enabled()  # must not raise


### PR DESCRIPTION
## Summary

Feature-flags the cloud-superuser impersonation endpoint (`POST /tenants/impersonate`) and **disables it by default**.

The route is gated at **registration**, not at runtime: a new `IMPERSONATION_ENABLED` env var controls whether `admin_router` is mounted onto the composite tenants router. When the flag is off (the default):

- the endpoint is **not registered at all** — requests return a generic **404**,
- it does **not** appear in the OpenAPI schema, and
- no handler or auth code runs for it.

This matches the existing `if MULTI_TENANT: include_router(...)` precedent in `ee/onyx/main.py` and avoids leaking the endpoint's existence. Set `IMPERSONATION_ENABLED=true` to mount it. (It remains additionally gated behind `MULTI_TENANT` at the outer registration, so this is a second, independent switch within cloud deployments.)

Router assembly now lives in `build_tenants_router(impersonation_enabled=...)` so the gating is unit-testable without process restarts.

## Test plan

`backend/tests/unit/ee/onyx/server/tenants/test_impersonation_gate.py`:
- `impersonation_enabled=False` → `/tenants/impersonate` is **not** in the router's routes
- `impersonation_enabled=True` → the route **is** present
- the module-level router (built from the real env) omits the route by default

`pre-commit` (ruff, ruff format, ty) passes on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)