### PR TITLE
fix(model_server): cap torch threads to cgroup CPU quota (#12351) to release v4.1

### DIFF
--- a/backend/model_server/main.py
+++ b/backend/model_server/main.py
@@ -16,6 +16,7 @@ from transformers import logging as transformer_logging
 
 from model_server.encoders import router as encoders_router
 from model_server.management_endpoints import router as management_router
+from model_server.utils import get_cgroup_cpu_limit
 from model_server.utils import get_gpu_type
 from onyx import __version__
 from onyx.utils.logger import setup_logger
@@ -86,8 +87,24 @@ async def lifespan(app: FastAPI) -> AsyncGenerator:
             e,
         )
 
-    torch.set_num_threads(max(MIN_THREADS_ML_MODELS, torch.get_num_threads()))
-    logger.notice("Torch Threads: %s", torch.get_num_threads())
+    # torch sizes its intra-op thread pool from the host core count, ignoring the
+    # container's cgroup CPU quota. On a large node this oversubscribes threads against
+    # a small quota, causing thread thrash and CFS throttling. Cap to the quota (while
+    # keeping the historical MIN_THREADS_ML_MODELS floor).
+    torch_default_threads = torch.get_num_threads()
+    cpu_limit = get_cgroup_cpu_limit()
+    num_threads = (
+        torch_default_threads
+        if cpu_limit is None
+        else min(torch_default_threads, cpu_limit)
+    )
+    torch.set_num_threads(max(MIN_THREADS_ML_MODELS, num_threads))
+    logger.notice(
+        "Torch Threads: %s (torch default: %s, cgroup cpu limit: %s)",
+        torch.get_num_threads(),
+        torch_default_threads,
+        cpu_limit,
+    )
 
     yield
 

--- a/backend/model_server/utils.py
+++ b/backend/model_server/utils.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from collections.abc import Generator
 from collections.abc import Iterator
 from functools import wraps
+from pathlib import Path
 from typing import Any
 from typing import cast
 from typing import TypeVar
@@ -70,3 +71,58 @@ def get_gpu_type() -> str:
         return GPUStatus.MAC_MPS
 
     return GPUStatus.NONE
+
+
+CGROUP_V2_CPU_MAX = Path("/sys/fs/cgroup/cpu.max")
+CGROUP_V1_CPU_QUOTA = Path("/sys/fs/cgroup/cpu/cpu.cfs_quota_us")
+CGROUP_V1_CPU_PERIOD = Path("/sys/fs/cgroup/cpu/cpu.cfs_period_us")
+
+
+def get_cgroup_cpu_limit(
+    v2_cpu_max: Path = CGROUP_V2_CPU_MAX,
+    v1_cpu_quota: Path = CGROUP_V1_CPU_QUOTA,
+    v1_cpu_period: Path = CGROUP_V1_CPU_PERIOD,
+) -> int | None:
+    """Number of CPU cores available to this container per its cgroup CFS quota.
+
+    torch and the underlying OpenMP/BLAS runtimes size their thread pools from the
+    host's core count and are unaware of cgroup limits. On a large node a CPU-limited
+    container therefore spins up far more threads than its quota allows, which thrashes
+    and gets CFS-throttled. We read the quota directly so callers can cap thread counts
+    to the budget the container actually has.
+
+    Returns None when no quota is set (unlimited) or the cgroup files are unavailable
+    or unreadable. Quotas are floored to whole cores so the cap never exceeds the
+    container's actual CPU budget.
+    """
+    # cgroup v2: single file formatted as "<quota> <period>"; "max" means unlimited.
+    # When the v2 file is present it is authoritative: we never fall back to v1, since a
+    # hybrid host can carry stale v1 quota files that don't reflect the real limit.
+    try:
+        quota_str, period_str = v2_cpu_max.read_text().split()
+        if quota_str == "max":
+            return None
+        period = int(period_str)
+        if period > 0:
+            return max(1, int(quota_str) // period)
+        return None
+    except FileNotFoundError:
+        pass  # not a cgroup v2 host; fall back to v1
+    except (OSError, ValueError) as e:
+        # v2 is present but unreadable/malformed; it remains authoritative, so do not
+        # trust v1 — report undetectable rather than apply a possibly-stale quota.
+        logger.debug("Could not parse cgroup v2 cpu.max (%s): %s", v2_cpu_max, e)
+        return None
+
+    # cgroup v1: separate quota/period files; quota <= 0 means unlimited.
+    try:
+        quota = int(v1_cpu_quota.read_text())
+        period = int(v1_cpu_period.read_text())
+        if quota > 0 and period > 0:
+            return max(1, quota // period)
+    except FileNotFoundError:
+        pass  # no cgroup cpu controller available; treat as unlimited
+    except (OSError, ValueError) as e:
+        logger.debug("Could not parse cgroup v1 cpu quota/period: %s", e)
+
+    return None

--- a/backend/tests/unit/model_server/test_cgroup_cpu_limit.py
+++ b/backend/tests/unit/model_server/test_cgroup_cpu_limit.py
@@ -1,0 +1,144 @@
+from pathlib import Path
+
+from model_server.utils import get_cgroup_cpu_limit
+
+
+def _missing(tmp_path: Path) -> Path:
+    return tmp_path / "does_not_exist"
+
+
+def test_cgroup_v2_quota(tmp_path: Path) -> None:
+    v2 = tmp_path / "cpu.max"
+    v2.write_text("800000 100000")
+    assert (
+        get_cgroup_cpu_limit(
+            v2_cpu_max=v2,
+            v1_cpu_quota=_missing(tmp_path),
+            v1_cpu_period=_missing(tmp_path),
+        )
+        == 8
+    )
+
+
+def test_cgroup_v2_unlimited(tmp_path: Path) -> None:
+    v2 = tmp_path / "cpu.max"
+    v2.write_text("max 100000")
+    assert (
+        get_cgroup_cpu_limit(
+            v2_cpu_max=v2,
+            v1_cpu_quota=_missing(tmp_path),
+            v1_cpu_period=_missing(tmp_path),
+        )
+        is None
+    )
+
+
+def test_cgroup_v2_floors_fractional_quota(tmp_path: Path) -> None:
+    v2 = tmp_path / "cpu.max"
+    # 7.5 cores -> floors to 7 so the cap never exceeds the quota (round would give 8).
+    v2.write_text("750000 100000")
+    assert (
+        get_cgroup_cpu_limit(
+            v2_cpu_max=v2,
+            v1_cpu_quota=_missing(tmp_path),
+            v1_cpu_period=_missing(tmp_path),
+        )
+        == 7
+    )
+
+
+def test_cgroup_v2_sub_core_floors_to_one(tmp_path: Path) -> None:
+    v2 = tmp_path / "cpu.max"
+    # 0.1 cores would round to 0; we floor to 1 so torch always gets a usable count.
+    v2.write_text("10000 100000")
+    assert (
+        get_cgroup_cpu_limit(
+            v2_cpu_max=v2,
+            v1_cpu_quota=_missing(tmp_path),
+            v1_cpu_period=_missing(tmp_path),
+        )
+        == 1
+    )
+
+
+def test_cgroup_v2_max_does_not_fall_through_to_v1(tmp_path: Path) -> None:
+    # When v2 reports unlimited, a populated v1 quota (hybrid host) must be ignored:
+    # the v2 hierarchy is authoritative.
+    v2 = tmp_path / "cpu.max"
+    v2.write_text("max 100000")
+    quota = tmp_path / "cpu.cfs_quota_us"
+    period = tmp_path / "cpu.cfs_period_us"
+    quota.write_text("400000")
+    period.write_text("100000")
+    assert (
+        get_cgroup_cpu_limit(v2_cpu_max=v2, v1_cpu_quota=quota, v1_cpu_period=period)
+        is None
+    )
+
+
+def test_cgroup_v2_malformed_does_not_fall_through_to_v1(tmp_path: Path) -> None:
+    # A present-but-unparseable v2 file is still authoritative: we must not consult v1.
+    v2 = tmp_path / "cpu.max"
+    v2.write_text("garbage")
+    quota = tmp_path / "cpu.cfs_quota_us"
+    period = tmp_path / "cpu.cfs_period_us"
+    quota.write_text("400000")
+    period.write_text("100000")
+    assert (
+        get_cgroup_cpu_limit(v2_cpu_max=v2, v1_cpu_quota=quota, v1_cpu_period=period)
+        is None
+    )
+
+
+def test_cgroup_v1_fallback(tmp_path: Path) -> None:
+    quota = tmp_path / "cpu.cfs_quota_us"
+    period = tmp_path / "cpu.cfs_period_us"
+    quota.write_text("400000")
+    period.write_text("100000")
+    assert (
+        get_cgroup_cpu_limit(
+            v2_cpu_max=_missing(tmp_path),
+            v1_cpu_quota=quota,
+            v1_cpu_period=period,
+        )
+        == 4
+    )
+
+
+def test_cgroup_v1_unlimited(tmp_path: Path) -> None:
+    quota = tmp_path / "cpu.cfs_quota_us"
+    period = tmp_path / "cpu.cfs_period_us"
+    quota.write_text("-1")
+    period.write_text("100000")
+    assert (
+        get_cgroup_cpu_limit(
+            v2_cpu_max=_missing(tmp_path),
+            v1_cpu_quota=quota,
+            v1_cpu_period=period,
+        )
+        is None
+    )
+
+
+def test_no_cgroup_files(tmp_path: Path) -> None:
+    assert (
+        get_cgroup_cpu_limit(
+            v2_cpu_max=_missing(tmp_path),
+            v1_cpu_quota=_missing(tmp_path),
+            v1_cpu_period=_missing(tmp_path),
+        )
+        is None
+    )
+
+
+def test_malformed_contents(tmp_path: Path) -> None:
+    v2 = tmp_path / "cpu.max"
+    v2.write_text("garbage")
+    assert (
+        get_cgroup_cpu_limit(
+            v2_cpu_max=v2,
+            v1_cpu_quota=_missing(tmp_path),
+            v1_cpu_period=_missing(tmp_path),
+        )
+        is None
+    )


### PR DESCRIPTION
Cherry-pick of commit 97b98eb3389ea021d8ee405e38edcab96a60708b to release/v4.1 branch.

Original PR: #12351

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cap `torch` threads to the container’s cgroup CPU quota in `model_server` to prevent oversubscription and CFS throttling. Detects CPU limits from cgroup v2 `cpu.max` (or v1 quota/period) and applies them with the existing minimum.

- **Bug Fixes**
  - Added `get_cgroup_cpu_limit()` that reads cgroup v2 (authoritative) or falls back to v1; returns None for unlimited; floors to whole cores with a minimum of 1.
  - Uses this limit to set `torch` threads (min of torch default and quota, respecting `MIN_THREADS_ML_MODELS`) and logs the applied values; added unit tests for v2/v1, unlimited, malformed, and flooring cases.

<sup>Written for commit 9df5c688a979dfd488ee28ea3a7ae8896739534f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

