### PR TITLE
fix(craft): raise sandbox-proxy request body cap to 32 MB

### DIFF
--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -65,7 +65,10 @@ from onyx.utils.logger import setup_logger
 logger = setup_logger()
 
 # Bodies over this cap are fail-closed (rejected), not parsed by the matcher.
-PARSER_MAX_BODY_BYTES = 1_048_576
+# 32 MiB = Anthropic's Messages API request-body limit, so the proxy is never
+# the false blocker: anything the upstream would accept passes through, and a
+# genuinely oversized request gets the upstream's own 413, not an opaque 403.
+PARSER_MAX_BODY_BYTES = 32 * 1024 * 1024
 
 
 # --- internal-destination egress lockdown: closes the proxy-relay path ---

--- a/backend/onyx/sandbox_proxy/errors.py
+++ b/backend/onyx/sandbox_proxy/errors.py
@@ -54,7 +54,7 @@ _SANDBOX_ERROR_MESSAGES: dict[SandboxProxyError, str] = {
         "action could not be authorized and ask how they want to proceed."
     ),
     SandboxProxyError.BODY_TOO_LARGE: (
-        "The request body is larger than the 1 MiB limit the proxy allows, so it "
+        "The request body is larger than the size limit the proxy allows, so it "
         "was blocked. Shrink the payload and try again — for example, send fewer "
         "items per request, paginate, or break the work into smaller calls. "
         "Large file uploads should go through a dedicated upload flow rather "

--- a/backend/tests/external_dependency_unit/craft/test_approval_gate.py
+++ b/backend/tests/external_dependency_unit/craft/test_approval_gate.py
@@ -645,7 +645,7 @@ def test_body_too_large_returns_403(
     gated_session: tuple[User, UUID, str],
     db_session: Session,
 ) -> None:
-    """Body exceeding ``PARSER_MAX_BODY_BYTES`` (1 MiB) is rejected pre-match.
+    """Body exceeding ``PARSER_MAX_BODY_BYTES`` (32 MiB) is rejected pre-match.
 
     The gate rejects before the matcher runs, so no approval row is minted.
     """
@@ -653,16 +653,16 @@ def test_body_too_large_returns_403(
 
     output_path = f"/tmp/curl_oversize_{uuid4().hex[:8]}"
     body_path = f"/tmp/body_oversize_{uuid4().hex[:8]}.json"
-    # Generate the 1.5 MiB body in-pod -- inlining it through pod_exec_async
-    # would push the full payload into the apiserver's exec URL query params and
-    # trip a 431 Request Header Fields Too Large at the websocket handshake.
+    # Generate a 33 MiB body in-pod -- inlining it through pod_exec_async would
+    # push the full payload into the apiserver's exec URL query params and trip a
+    # 431 Request Header Fields Too Large at the websocket handshake.
     pod_exec(
         k8s_client,
         pod_name,
         SANDBOX_NAMESPACE,
         (
             f'printf \'{{"channel":"#general","text":"\' > {body_path} && '
-            f'head -c 1572864 /dev/zero | tr "\\0" x >> {body_path} && '
+            f'head -c 34603008 /dev/zero | tr "\\0" x >> {body_path} && '
             f"printf '\"}}' >> {body_path}"
         ),
     )

--- a/backend/tests/unit/sandbox_proxy/test_gate.py
+++ b/backend/tests/unit/sandbox_proxy/test_gate.py
@@ -218,8 +218,7 @@ async def test_resolve_and_match_body_at_cap_is_allowed() -> None:
     resolver = StubResolver(sandbox=make_resolved_sandbox())
     matcher = _StubMatcher(result=None)
     addon = _build(resolver=resolver, matcher=matcher)
-    # Sized off the cap constant so the test follows it, not a literal. Built
-    # inside the test so the multi-MB allocation is deferred past collection.
+    # Built inside the test so the multi-MB allocation is deferred past collection.
     flow = make_flow(raw_content=b"\x00" * gate.PARSER_MAX_BODY_BYTES)
 
     result = await addon._resolve_and_match(flow)

--- a/backend/tests/unit/sandbox_proxy/test_gate.py
+++ b/backend/tests/unit/sandbox_proxy/test_gate.py
@@ -213,17 +213,14 @@ async def test_resolve_and_match_sandbox_resolution_fails_closed(
     assert matcher.calls == 0
 
 
-# Sized off the cap constant so the test follows it, not a literal.
-_MAX_BODY = b"\x00" * gate.PARSER_MAX_BODY_BYTES
-_OVERSIZE_BODY = b"\x00" * (gate.PARSER_MAX_BODY_BYTES + 1)
-
-
 @pytest.mark.asyncio
 async def test_resolve_and_match_body_at_cap_is_allowed() -> None:
     resolver = StubResolver(sandbox=make_resolved_sandbox())
     matcher = _StubMatcher(result=None)
     addon = _build(resolver=resolver, matcher=matcher)
-    flow = make_flow(raw_content=_MAX_BODY)
+    # Sized off the cap constant so the test follows it, not a literal. Built
+    # inside the test so the multi-MB allocation is deferred past collection.
+    flow = make_flow(raw_content=b"\x00" * gate.PARSER_MAX_BODY_BYTES)
 
     result = await addon._resolve_and_match(flow)
 
@@ -232,19 +229,18 @@ async def test_resolve_and_match_body_at_cap_is_allowed() -> None:
     assert matcher.calls == 1
 
 
-@pytest.mark.parametrize(
-    "raw_content",
-    [None, _OVERSIZE_BODY],
-    ids=["streamed", "oversize"],
-)
+@pytest.mark.parametrize("oversize", [False, True], ids=["streamed", "oversize"])
 @pytest.mark.asyncio
 async def test_resolve_and_match_body_too_large_fails_closed(
-    raw_content: bytes | None,
+    oversize: bool,
 ) -> None:
     """Streamed (None) and oversize bodies both fail closed."""
     resolver = StubResolver(sandbox=make_resolved_sandbox())
     matcher = _StubMatcher(result=_MATCH)
     addon = _build(resolver=resolver, matcher=matcher)
+    # Built here, not at module scope, so the over-cap allocation only happens
+    # for the test that needs it.
+    raw_content = b"\x00" * (gate.PARSER_MAX_BODY_BYTES + 1) if oversize else None
     flow = make_flow(raw_content=raw_content)
 
     result = await addon._resolve_and_match(flow)

--- a/backend/tests/unit/sandbox_proxy/test_gate.py
+++ b/backend/tests/unit/sandbox_proxy/test_gate.py
@@ -213,9 +213,9 @@ async def test_resolve_and_match_sandbox_resolution_fails_closed(
     assert matcher.calls == 0
 
 
-# Spec value hardcoded so this test exercises the documented 1 MiB cap.
-_MAX_BODY = b"\x00" * 1_048_576
-_OVERSIZE_BODY = b"\x00" * 1_048_577
+# Sized off the cap constant so the test follows it, not a literal.
+_MAX_BODY = b"\x00" * gate.PARSER_MAX_BODY_BYTES
+_OVERSIZE_BODY = b"\x00" * (gate.PARSER_MAX_BODY_BYTES + 1)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

The sandbox egress proxy buffers and parses each request body (to gate it and inject credentials), so it caps body size and fails closed over the cap. The cap was hardcoded at **1 MiB**, which blocked legitimate LLM calls — e.g. building a PowerPoint — once the conversation context crossed ~1 MiB. It surfaced as an opaque proxy `403 body_too_large` that wedged the turn (the session kept re-sending the same oversized body).

This raises the hardcoded cap to **32 MB** = Anthropic's Messages API request-body limit. Sizing it at the upstream's own limit means the proxy is never the false blocker: anything the model would accept passes through, and a genuinely oversized request gets the upstream's own `413` instead of an opaque proxy `403`.

- `gate.py`: bump `PARSER_MAX_BODY_BYTES` 1 MiB → 32 MiB (hardcoded constant)
- `errors.py`: make the `body_too_large` message cap-agnostic (no longer says "1 MiB")

## How Has This Been Tested?

- `pytest backend/tests/unit/sandbox_proxy/test_gate.py` — cap tests size off the constant (at-cap allowed; over-cap and streamed bodies fail closed). All pass.
- Updated `test_approval_gate.py` (external dependency) to generate a body exceeding the new 32 MiB cap.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)