### PR TITLE
feat(audit): wire the 3 remaining audit actions (password_reset, user.create, user.group_change)

### DIFF
--- a/backend/ee/onyx/db/user_group.py
+++ b/backend/ee/onyx/db/user_group.py
@@ -43,6 +43,10 @@ from onyx.db.models import UserRole
 from onyx.db.permissions import recompute_permissions_for_group__no_commit
 from onyx.db.permissions import recompute_user_permissions__no_commit
 from onyx.db.users import fetch_user_by_id
+from onyx.utils.audit import actor_from_user
+from onyx.utils.audit import AuditAction
+from onyx.utils.audit import AuditOutcome
+from onyx.utils.audit import emit_audit_event
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -772,7 +776,7 @@ def add_users_to_user_group(
 
 def update_user_group(
     db_session: Session,
-    user: User,  # noqa: ARG001
+    user: User,
     user_group_id: int,
     user_group_update: UserGroupUpdate,
 ) -> UserGroup:
@@ -864,6 +868,20 @@ def update_user_group(
     )
 
     db_session.commit()
+
+    if added_user_ids or removed_user_ids:
+        emit_audit_event(
+            AuditAction.USER_GROUP_CHANGE,
+            AuditOutcome.SUCCESS,
+            actor=actor_from_user(user),
+            resource_type="user_group",
+            resource_id=user_group_id,
+            extra={
+                "added_user_ids": [str(uid) for uid in added_user_ids],
+                "removed_user_ids": [str(uid) for uid in removed_user_ids],
+            },
+        )
+
     return db_user_group
 
 

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -1219,6 +1219,17 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             actor=AuditActor(user_id=str(user.id), email=user.email),
         )
 
+    async def on_after_reset_password(
+        self,
+        user: User,
+        request: Optional[Request] = None,  # noqa: ARG002
+    ) -> None:
+        emit_audit_event(
+            AuditAction.PASSWORD_RESET,
+            AuditOutcome.SUCCESS,
+            actor=AuditActor(user_id=str(user.id), email=user.email),
+        )
+
     async def on_after_request_verify(
         self,
         user: User,

--- a/backend/onyx/server/manage/users.py
+++ b/backend/onyx/server/manage/users.py
@@ -616,6 +616,17 @@ def bulk_invite_users(
                         )
             raise e
 
+    # Genuinely-new invites (not existing or already-invited) are the accounts
+    # an admin is provisioning access for; re-invites of known emails are no-ops.
+    if emails_needing_seats:
+        emit_audit_event(
+            AuditAction.USER_CREATE,
+            AuditOutcome.SUCCESS,
+            actor=actor_from_user(current_user),
+            resource_type="user",
+            extra={"invited_emails": emails_needing_seats},
+        )
+
     return BulkInviteResponse(
         invited_count=number_of_invited_users,
         email_invite_status=email_invite_status,

--- a/backend/onyx/utils/audit.py
+++ b/backend/onyx/utils/audit.py
@@ -49,9 +49,7 @@ class AuditOutcome(str, Enum):
 
 class AuditAction(str, Enum):
     """Audited-action taxonomy. Values are an append-only schema contract
-    (consumers filter on them). A few members (``USER_CREATE``,
-    ``USER_GROUP_CHANGE``, ``PASSWORD_RESET``) are defined ahead of their call
-    sites and land in follow-up PRs."""
+    (consumers filter on them)."""
 
     # Authentication
     LOGIN = "auth.login"

--- a/backend/tests/unit/ee/conftest.py
+++ b/backend/tests/unit/ee/conftest.py
@@ -1,8 +1,27 @@
 """Auto-enable EE mode for all tests under tests/unit/ee/."""
 
+import logging
+from collections.abc import Generator
+
 import pytest
 
 
 @pytest.fixture(autouse=True)
 def _enable_ee_for_directory(enable_ee: None) -> None:
     """Wraps the shared enable_ee fixture with autouse for this directory."""
+
+
+@pytest.fixture(autouse=True)
+def _capture_audit_logger(
+    caplog: pytest.LogCaptureFixture,
+) -> Generator[None, None, None]:
+    """Attach caplog's handler to ``onyx.audit`` so audit tests can assert on
+    caplog: the subsystem sets ``propagate=False``, so records don't reach
+    pytest's root handler. No-op for tests that emit no audit events.
+    """
+    audit_logger = logging.getLogger("onyx.audit")
+    audit_logger.addHandler(caplog.handler)
+    try:
+        yield
+    finally:
+        audit_logger.removeHandler(caplog.handler)

--- a/backend/tests/unit/ee/onyx/db/test_user_group_audit.py
+++ b/backend/tests/unit/ee/onyx/db/test_user_group_audit.py
@@ -1,0 +1,105 @@
+"""Unit tests for user.group_change audit emission from update_user_group.
+
+The emit is guarded on an actual membership delta, so a pure cc_pair update
+must emit nothing while an add/remove of users must emit exactly one event.
+"""
+
+import json
+import logging
+from typing import Any
+from unittest.mock import MagicMock
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+
+from ee.onyx.db.user_group import update_user_group
+from ee.onyx.server.user_group.models import UserGroupUpdate
+
+
+def _audit_events(caplog: pytest.LogCaptureFixture) -> list[dict[str, Any]]:
+    return [
+        json.loads(r.getMessage())
+        for r in caplog.records
+        if r.name.startswith("onyx.audit")
+    ]
+
+
+def _make_db_session(
+    existing_user_ids: list[Any], existing_cc_pair_ids: list[int]
+) -> MagicMock:
+    group = MagicMock()
+    group.users = [MagicMock(id=uid) for uid in existing_user_ids]
+    group.cc_pairs = [MagicMock(id=cid) for cid in existing_cc_pair_ids]
+    db_session = MagicMock()
+    db_session.scalar.return_value = group
+    # No users are removed in these cases, so the removed-users lookup is empty.
+    db_session.scalars.return_value.unique.return_value = []
+    return db_session
+
+
+@patch("ee.onyx.db.user_group.recompute_user_permissions__no_commit")
+@patch("ee.onyx.db.user_group._add_user__user_group_relationships__no_commit")
+@patch("ee.onyx.db.user_group.fetch_user_by_id", return_value=MagicMock())
+@patch("ee.onyx.db.user_group._check_user_group_is_modifiable")
+def test_update_user_group_emits_on_membership_change(
+    _modifiable: MagicMock,
+    _fetch: MagicMock,
+    _add_rel: MagicMock,
+    _recompute: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    existing = uuid4()
+    added = uuid4()
+    db_session = _make_db_session([existing], [10])
+    admin = MagicMock(id="admin-1", email="admin@example.com")
+
+    with caplog.at_level(logging.INFO, logger="onyx.audit"):
+        update_user_group(
+            db_session=db_session,
+            user=admin,
+            user_group_id=7,
+            user_group_update=UserGroupUpdate(
+                user_ids=[existing, added], cc_pair_ids=[10]
+            ),
+        )
+
+    events = _audit_events(caplog)
+    assert len(events) == 1
+    assert events[0]["action"] == "user.group_change"
+    assert events[0]["outcome"] == "success"
+    assert events[0]["resource_id"] == "7"
+    assert events[0]["actor"]["email"] == "admin@example.com"
+    assert events[0]["extra"]["added_user_ids"] == [str(added)]
+    assert events[0]["extra"]["removed_user_ids"] == []
+
+
+@patch("ee.onyx.db.user_group.recompute_user_permissions__no_commit")
+@patch("ee.onyx.db.user_group._add_user_group__cc_pair_relationships__no_commit")
+@patch(
+    "ee.onyx.db.user_group._mark_user_group__cc_pair_relationships_outdated__no_commit"
+)
+@patch("ee.onyx.db.user_group._check_user_group_is_modifiable")
+def test_update_user_group_cc_pair_only_emits_nothing(
+    _modifiable: MagicMock,
+    _mark: MagicMock,
+    _add_cc: MagicMock,
+    _recompute: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    existing = uuid4()
+    db_session = _make_db_session([existing], [10])
+    admin = MagicMock(id="admin-1", email="admin@example.com")
+
+    with caplog.at_level(logging.INFO, logger="onyx.audit"):
+        update_user_group(
+            db_session=db_session,
+            user=admin,
+            user_group_id=7,
+            # Same members, different cc_pairs -> no membership delta.
+            user_group_update=UserGroupUpdate(
+                user_ids=[existing], cc_pair_ids=[10, 11]
+            ),
+        )
+
+    assert _audit_events(caplog) == []

--- a/backend/tests/unit/onyx/auth/test_auth_audit_events.py
+++ b/backend/tests/unit/onyx/auth/test_auth_audit_events.py
@@ -114,3 +114,20 @@ async def test_on_after_request_verify_emits_event(
     assert len(events) == 1
     assert events[0]["action"] == "auth.email_verify"
     assert events[0]["outcome"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_on_after_reset_password_emits_event(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    user = MagicMock(id="u-1", email="user@example.com")
+    manager = UserManager(MagicMock())
+
+    with caplog.at_level(logging.INFO, logger="onyx.audit"):
+        await manager.on_after_reset_password(user, request=None)
+
+    events = _audit_events(caplog)
+    assert len(events) == 1
+    assert events[0]["action"] == "auth.password_reset"
+    assert events[0]["outcome"] == "success"
+    assert events[0]["actor"]["email"] == "user@example.com"

--- a/backend/tests/unit/onyx/server/manage/test_bulk_invite_limit.py
+++ b/backend/tests/unit/onyx/server/manage/test_bulk_invite_limit.py
@@ -146,14 +146,8 @@ def _with_common_patches(fn: object) -> object:
     return fn
 
 
-@patch("onyx.server.manage.users.MULTI_TENANT", False)
+@_with_common_patches
 @patch("onyx.server.manage.users.ENABLE_EMAIL_INVITES", False)
-@patch("onyx.server.manage.users.get_current_tenant_id", return_value="test_tenant")
-@patch("onyx.server.manage.users.get_invited_users", return_value=[])
-@patch("onyx.server.manage.users.get_all_users", return_value=[])
-@patch("onyx.server.manage.users.write_invited_users", return_value=1)
-@patch("onyx.server.manage.users.enforce_seat_limit_locked")
-@patch("onyx.server.manage.users.enforce_invite_rate_limit")
 def test_bulk_invite_emits_user_create(
     _rate_limit: MagicMock,
     _seat_limit: MagicMock,
@@ -180,6 +174,9 @@ def test_bulk_invite_emits_user_create(
     assert events[0]["extra"]["invited_emails"] == ["new@example.com"]
 
 
+# Explicit patches (not _with_common_patches): this case needs
+# get_invited_users to report the email as already-invited, which the helper
+# hardcodes to [] and re-patching from inside the stack doesn't override.
 @patch("onyx.server.manage.users.MULTI_TENANT", False)
 @patch("onyx.server.manage.users.ENABLE_EMAIL_INVITES", False)
 @patch("onyx.server.manage.users.get_current_tenant_id", return_value="test_tenant")

--- a/backend/tests/unit/onyx/server/manage/test_bulk_invite_limit.py
+++ b/backend/tests/unit/onyx/server/manage/test_bulk_invite_limit.py
@@ -1,7 +1,10 @@
 """Test bulk invite limit for free trial tenants."""
 
+import json
+import logging
 from collections.abc import Iterator
 from contextlib import contextmanager
+from typing import Any
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -141,6 +144,65 @@ def _with_common_patches(fn: object) -> object:
     for p in reversed(_COMMON_PATCHES):
         fn = p(fn)  # ty: ignore[no-matching-overload]
     return fn
+
+
+@patch("onyx.server.manage.users.MULTI_TENANT", False)
+@patch("onyx.server.manage.users.ENABLE_EMAIL_INVITES", False)
+@patch("onyx.server.manage.users.get_current_tenant_id", return_value="test_tenant")
+@patch("onyx.server.manage.users.get_invited_users", return_value=[])
+@patch("onyx.server.manage.users.get_all_users", return_value=[])
+@patch("onyx.server.manage.users.write_invited_users", return_value=1)
+@patch("onyx.server.manage.users.enforce_seat_limit_locked")
+@patch("onyx.server.manage.users.enforce_invite_rate_limit")
+def test_bulk_invite_emits_user_create(
+    _rate_limit: MagicMock,
+    _seat_limit: MagicMock,
+    _write_invited: MagicMock,
+    _get_all_users: MagicMock,
+    _get_invited_users: MagicMock,
+    _get_tenant_id: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    admin = MagicMock(id="admin-1", email="admin@example.com")
+
+    with caplog.at_level(logging.INFO, logger="onyx.audit"):
+        bulk_invite_users(emails=["new@example.com"], current_user=admin)
+
+    events: list[dict[str, Any]] = [
+        json.loads(r.getMessage())
+        for r in caplog.records
+        if r.name.startswith("onyx.audit")
+    ]
+    assert len(events) == 1
+    assert events[0]["action"] == "user.create"
+    assert events[0]["outcome"] == "success"
+    assert events[0]["actor"]["email"] == "admin@example.com"
+    assert events[0]["extra"]["invited_emails"] == ["new@example.com"]
+
+
+@patch("onyx.server.manage.users.MULTI_TENANT", False)
+@patch("onyx.server.manage.users.ENABLE_EMAIL_INVITES", False)
+@patch("onyx.server.manage.users.get_current_tenant_id", return_value="test_tenant")
+@patch("onyx.server.manage.users.get_invited_users", return_value=["known@example.com"])
+@patch("onyx.server.manage.users.get_all_users", return_value=[])
+@patch("onyx.server.manage.users.write_invited_users", return_value=1)
+@patch("onyx.server.manage.users.enforce_seat_limit_locked")
+@patch("onyx.server.manage.users.enforce_invite_rate_limit")
+def test_bulk_invite_reinvite_emits_nothing(
+    _rate_limit: MagicMock,
+    _seat_limit: MagicMock,
+    _write_invited: MagicMock,
+    _get_all_users: MagicMock,
+    _get_invited_users: MagicMock,
+    _get_tenant_id: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Re-inviting an already-invited email provisions no new access -> no event.
+    with caplog.at_level(logging.INFO, logger="onyx.audit"):
+        bulk_invite_users(emails=["known@example.com"], current_user=MagicMock())
+
+    events = [r for r in caplog.records if r.name.startswith("onyx.audit")]
+    assert events == []
 
 
 @_with_common_patches

--- a/docs/AUDIT_LOGGING.md
+++ b/docs/AUDIT_LOGGING.md
@@ -78,10 +78,7 @@ them). Current taxonomy (`AuditAction` in `backend/onyx/utils/audit.py`):
   `api_key.{create,regenerate,delete}`, `credential.{create,update,delete}`,
   `credential.access`
 
-> Most actions are wired to call sites. A few (`user.create`,
-> `user.group_change`, `auth.password_reset`) are defined ahead of their
-> instrumentation and land in follow-up PRs, so consumers can build dashboards
-> against the full taxonomy now.
+> All actions in the taxonomy are wired to call sites.
 
 ### Example event
 


### PR DESCRIPTION
## Description

Completes the audit-event taxonomy from the SIEM-compatible audit-logging work — **every `AuditAction` now has a call site** (these 3 were defined ahead of their instrumentation). With this, the audit subsystem covers the full authentication / account-change / API-activity surface.

- **`auth.password_reset`** — new `on_after_reset_password` hook in `UserManager` (`onyx/auth/users.py`), matching the existing `on_after_forgot_password` hook; actor is the user resetting their password.
- **`user.create`** — emitted from `bulk_invite_users` (`onyx/server/manage/users.py`) when an admin provisions **genuinely-new** invites. Re-invites of already-existing / already-invited emails provision no new access, so they emit nothing. Actor is the acting admin; the new emails are in `extra.invited_emails`.
- **`user.group_change`** — emitted from `update_user_group` (`ee/onyx/db/user_group.py`), the single chokepoint both the `add-users` and `patch-group` endpoints converge on. Emitted **after commit**, guarded on an actual membership delta (pure cc_pair updates don't fire), with the exact `added_user_ids` / `removed_user_ids` and the acting admin in scope.

Also drops the now-stale "defined ahead of their call sites" notes in `audit.py` and `docs/AUDIT_LOGGING.md`.

This is the last functional gap before we can position audit logging as a GA capability (targeting v4.3).

## How Has This Been Tested?

- New unit tests in `test_auth_audit_events.py` (password_reset emits) and `test_bulk_invite_limit.py` (user.create emits on a new invite; emits **nothing** on a re-invite).
- Full audit unit suite green (`test_audit.py`, `test_auth_audit_events.py`, `test_bulk_invite_limit.py` — 31 passed).
- `ty check`, `ruff`, and full pre-commit clean.

Emission mechanics (schema, dedup, never-raise, secret-safety) are covered centrally in `test_audit.py`; `user.group_change` follows the same one-line guarded-emit pattern as the other DB-adjacent sites.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Connect the last three audit actions to real call sites so every `AuditAction` now emits: `auth.password_reset`, `user.create`, and `user.group_change`. Adds unit tests for these emits and removes stale notes in code and docs.

- **New Features**
  - `auth.password_reset`: new `on_after_reset_password` in `UserManager`; actor is the user.
  - `user.create`: emitted in `bulk_invite_users` for genuinely new invites only; actor is the admin; emails in `extra.invited_emails`.
  - `user.group_change`: emitted post-commit in `update_user_group` only when membership changes; includes `added_user_ids` and `removed_user_ids`; actor is the admin.

<sup>Written for commit c696fd92d39fa7a3fdc8d7e6e6b9416888c95201. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

