### PR TITLE
fix(ee): unset default SUPER_CLOUD_API_KEY, fail closed when unconfigured

### DIFF
--- a/backend/ee/onyx/auth/users.py
+++ b/backend/ee/onyx/auth/users.py
@@ -1,4 +1,5 @@
 import os
+import secrets
 from datetime import datetime
 from datetime import timezone
 
@@ -42,8 +43,13 @@ async def current_cloud_superuser(
     request: Request,
     user: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
 ) -> User:
+    if SUPER_CLOUD_API_KEY is None:
+        raise HTTPException(
+            status_code=401, detail="Cloud superuser API key not configured"
+        )
+
     api_key = request.headers.get("Authorization", "").replace("Bearer ", "")
-    if api_key != SUPER_CLOUD_API_KEY:
+    if not secrets.compare_digest(api_key, SUPER_CLOUD_API_KEY):
         raise HTTPException(status_code=401, detail="Invalid API key")
 
     if user and user.email not in SUPER_USERS:

--- a/backend/ee/onyx/auth/users.py
+++ b/backend/ee/onyx/auth/users.py
@@ -43,7 +43,7 @@ async def current_cloud_superuser(
     request: Request,
     user: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
 ) -> User:
-    if SUPER_CLOUD_API_KEY is None:
+    if not SUPER_CLOUD_API_KEY:
         raise HTTPException(
             status_code=401, detail="Cloud superuser API key not configured"
         )

--- a/backend/ee/onyx/auth/users.py
+++ b/backend/ee/onyx/auth/users.py
@@ -44,9 +44,10 @@ async def current_cloud_superuser(
     user: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
 ) -> User:
     if not SUPER_CLOUD_API_KEY:
-        raise HTTPException(
-            status_code=401, detail="Cloud superuser API key not configured"
-        )
+        # Fail closed, but return the same 401 as a bad key so callers can't
+        # distinguish "unconfigured" from "wrong key". Log the real reason for operators.
+        logger.error("SUPER_CLOUD_API_KEY is not configured; rejecting request")
+        raise HTTPException(status_code=401, detail="Invalid API key")
 
     api_key = request.headers.get("Authorization", "").replace("Bearer ", "")
     if not secrets.compare_digest(api_key, SUPER_CLOUD_API_KEY):

--- a/backend/ee/onyx/auth/users.py
+++ b/backend/ee/onyx/auth/users.py
@@ -46,7 +46,7 @@ async def current_cloud_superuser(
     if not SUPER_CLOUD_API_KEY:
         # Fail closed, but return the same 401 as a bad key so callers can't
         # distinguish "unconfigured" from "wrong key". Log the real reason for operators.
-        logger.error("SUPER_CLOUD_API_KEY is not configured; rejecting request")
+        logger.warning("SUPER_CLOUD_API_KEY is not configured; rejecting request")
         raise HTTPException(status_code=401, detail="Invalid API key")
 
     api_key = request.headers.get("Authorization", "").replace("Bearer ", "")

--- a/backend/ee/onyx/auth/users.py
+++ b/backend/ee/onyx/auth/users.py
@@ -44,8 +44,6 @@ async def current_cloud_superuser(
     user: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
 ) -> User:
     if not SUPER_CLOUD_API_KEY:
-        # Fail closed, but return the same 401 as a bad key so callers can't
-        # distinguish "unconfigured" from "wrong key". Log the real reason for operators.
         logger.warning("SUPER_CLOUD_API_KEY is not configured; rejecting request")
         raise HTTPException(status_code=401, detail="Invalid API key")
 

--- a/backend/ee/onyx/configs/app_configs.py
+++ b/backend/ee/onyx/configs/app_configs.py
@@ -115,7 +115,7 @@ JWT_PUBLIC_KEY_URL: str | None = os.getenv("JWT_PUBLIC_KEY_URL", None)
 
 # Super Users
 SUPER_USERS = json.loads(os.environ.get("SUPER_USERS", "[]"))
-SUPER_CLOUD_API_KEY = os.environ.get("SUPER_CLOUD_API_KEY", "api_key")
+SUPER_CLOUD_API_KEY: str | None = os.environ.get("SUPER_CLOUD_API_KEY")
 
 POSTHOG_API_KEY = os.environ.get("POSTHOG_API_KEY")
 POSTHOG_HOST = os.environ.get("POSTHOG_HOST") or "https://us.i.posthog.com"


### PR DESCRIPTION
## Problem

`SUPER_CLOUD_API_KEY` fell back to the hardcoded string `"api_key"` when the env var was unset:

```python
SUPER_CLOUD_API_KEY = os.environ.get("SUPER_CLOUD_API_KEY", "api_key")
```

This key is the only API-key layer gating `current_cloud_superuser`, which protects two cloud-control-plane endpoints:

- `POST /tenants/impersonate` — mints an impersonation JWT for **any** user
- the evals API (`ee/onyx/server/evals/api.py`)

Any deployment that didn't explicitly set the env var (no repo config does) accepted the well-known default, leaving only `SUPER_USERS` membership + `FULL_ADMIN_PANEL_ACCESS` as protection.

## Change

- Drop the default → `SUPER_CLOUD_API_KEY: str | None`. An unconfigured deployment now **fails closed** (rejects every request).
- Add an explicit guard that 401s when the key is unconfigured, instead of relying on the `str != None` quirk.
- Switch the comparison to `secrets.compare_digest` (timing-safe), matching the existing pattern in `metrics_auth.py`.

## Impact

- No repo deployment config, env template, or test references this key — the real value comes from external secret management, so production is unaffected as long as the secret is set (which it must be for impersonation/evals to work).
- No tests exercise the affected endpoints.

## Test plan

- [x] `pre-commit run` on changed files (ty type check, ruff, format) passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the default "api_key" for `SUPER_CLOUD_API_KEY` and now fail closed when unset, returning a generic 401 identical to a bad key. Unconfigured deployments reject `POST /tenants/impersonate` and the evals API.

- **Bug Fixes**
  - Return a generic 401 when `SUPER_CLOUD_API_KEY` is missing; log the real reason for operators.
  - Use `secrets.compare_digest` to validate the Bearer token for timing-safe checks.

<sup>Written for commit 4c3e899e56e08f5bcf745a9128fb580367828b8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

