### PR TITLE
feat(opensearch): Support IAM auth

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -9,6 +9,7 @@ from onyx.auth.schemas import AuthBackend
 from onyx.cache.interface import CacheBackendType
 from onyx.configs.constants import AuthType
 from onyx.configs.constants import QueryHistoryType
+from onyx.document_index.opensearch.constants import OpenSearchAuthMethod
 from onyx.file_processing.enums import HtmlBasedConnectorTransformLinksStrategy
 from onyx.prompts.image_analysis import DEFAULT_IMAGE_SUMMARIZATION_SYSTEM_PROMPT
 from onyx.prompts.image_analysis import DEFAULT_IMAGE_SUMMARIZATION_USER_PROMPT
@@ -409,6 +410,24 @@ OPENSEARCH_CA_CERTS: str | None = os.environ.get("OPENSEARCH_CA_CERTS") or None
 OPENSEARCH_CLIENT_CERT: str | None = os.environ.get("OPENSEARCH_CLIENT_CERT") or None
 OPENSEARCH_CLIENT_KEY: str | None = os.environ.get("OPENSEARCH_CLIENT_KEY") or None
 
+# Authentication method for connecting to OpenSearch. "basic" uses
+# OPENSEARCH_ADMIN_USERNAME / OPENSEARCH_ADMIN_PASSWORD (HTTP basic auth); the
+# default and the only option for self-hosted / docker-compose OpenSearch. "iam"
+# uses AWS SigV4 request signing and is only valid against an AWS managed domain
+# whose fine-grained access control master is an IAM ARN. This is independent of
+# USING_AWS_MANAGED_OPENSEARCH: AWS managed domains can use a master user too.
+OPENSEARCH_AUTH_METHOD = OpenSearchAuthMethod(
+    (
+        os.environ.get("OPENSEARCH_AUTH_METHOD") or OpenSearchAuthMethod.BASIC.value
+    ).lower()
+)
+# AWS region of the managed OpenSearch domain. Required when
+# OPENSEARCH_AUTH_METHOD=iam; used to compute the SigV4 signature.
+OPENSEARCH_AWS_REGION: str | None = os.environ.get("OPENSEARCH_AWS_REGION") or None
+# AWS service name for SigV4 signing: "es" for managed OpenSearch domains,
+# "aoss" for OpenSearch Serverless.
+OPENSEARCH_AWS_SERVICE = os.environ.get("OPENSEARCH_AWS_SERVICE") or "es"
+
 if OPENSEARCH_VERIFY_CERTS and not OPENSEARCH_USE_SSL:
     logger.warning(
         "OPENSEARCH_VERIFY_CERTS=true has no effect when OPENSEARCH_USE_SSL is "
@@ -427,9 +446,25 @@ for _os_name, _os_path in (
     if _os_path and not os.path.exists(_os_path):
         raise ValueError(f"{_os_name}={_os_path!r} does not exist.")
 
+if OPENSEARCH_AUTH_METHOD == OpenSearchAuthMethod.IAM and not OPENSEARCH_AWS_REGION:
+    raise ValueError(
+        "OPENSEARCH_AWS_REGION must be set when OPENSEARCH_AUTH_METHOD=iam "
+        "(AWS SigV4 signing needs the domain's region)."
+    )
+
 USING_AWS_MANAGED_OPENSEARCH = (
     os.environ.get("USING_AWS_MANAGED_OPENSEARCH", "").lower() == "true"
 )
+
+if (
+    OPENSEARCH_AUTH_METHOD == OpenSearchAuthMethod.IAM
+    and not USING_AWS_MANAGED_OPENSEARCH
+):
+    raise ValueError(
+        "OPENSEARCH_AUTH_METHOD=iam is only supported for "
+        "AWS-managed instances of OpenSearch."
+    )
+
 # Profiling adds some overhead to OpenSearch operations. This overhead is
 # unknown right now. Defaults to True.
 OPENSEARCH_PROFILING_DISABLED = (

--- a/backend/onyx/document_index/opensearch/client.py
+++ b/backend/onyx/document_index/opensearch/client.py
@@ -7,14 +7,19 @@ from typing import Any
 from typing import Generic
 from typing import TypeVar
 
+import boto3
 from opensearchpy import OpenSearch
 from opensearchpy import TransportError
+from opensearchpy import Urllib3AWSV4SignerAuth
 from opensearchpy.helpers import bulk
 from pydantic import BaseModel
 
 from onyx.configs.app_configs import DEFAULT_OPENSEARCH_CLIENT_TIMEOUT_S
 from onyx.configs.app_configs import OPENSEARCH_ADMIN_PASSWORD
 from onyx.configs.app_configs import OPENSEARCH_ADMIN_USERNAME
+from onyx.configs.app_configs import OPENSEARCH_AUTH_METHOD
+from onyx.configs.app_configs import OPENSEARCH_AWS_REGION
+from onyx.configs.app_configs import OPENSEARCH_AWS_SERVICE
 from onyx.configs.app_configs import OPENSEARCH_CA_CERTS
 from onyx.configs.app_configs import OPENSEARCH_CLIENT_CERT
 from onyx.configs.app_configs import OPENSEARCH_CLIENT_KEY
@@ -23,6 +28,7 @@ from onyx.configs.app_configs import OPENSEARCH_REST_API_PORT
 from onyx.configs.app_configs import OPENSEARCH_USE_SSL
 from onyx.configs.app_configs import OPENSEARCH_VERIFY_CERTS
 from onyx.document_index.interfaces_new import TenantState
+from onyx.document_index.opensearch.constants import OpenSearchAuthMethod
 from onyx.document_index.opensearch.constants import OpenSearchSearchType
 from onyx.document_index.opensearch.schema import DocumentChunk
 from onyx.document_index.opensearch.schema import DocumentChunkWithoutVectors
@@ -148,8 +154,9 @@ class OpenSearchClient(AbstractContextManager):
     Args:
         host: The host of the OpenSearch cluster.
         port: The port of the OpenSearch cluster.
-        auth: The authentication credentials for the OpenSearch cluster. A tuple
-            of (username, password).
+        auth: The basic-auth credentials for the OpenSearch cluster, a tuple of
+            (username, password). Used only when auth_method is BASIC; ignored
+            for IAM.
         use_ssl: Whether to use SSL for the OpenSearch cluster. Defaults to
             True.
         verify_certs: Whether to verify the server certificate. Defaults to
@@ -161,6 +168,12 @@ class OpenSearchClient(AbstractContextManager):
             to False.
         timeout: The timeout for the OpenSearch cluster. Defaults to
             DEFAULT_OPENSEARCH_CLIENT_TIMEOUT_S.
+        auth_method: Whether to authenticate with HTTP basic auth or AWS SigV4
+            (IAM). Defaults to OPENSEARCH_AUTH_METHOD.
+        aws_region: AWS region used for SigV4 signing. Required when auth_method
+            is IAM. Defaults to OPENSEARCH_AWS_REGION.
+        aws_service: AWS service name for SigV4 signing ("es" for managed
+            domains, "aoss" for Serverless). Defaults to OPENSEARCH_AWS_SERVICE.
     """
 
     def __init__(
@@ -175,16 +188,39 @@ class OpenSearchClient(AbstractContextManager):
         client_key: str | None = OPENSEARCH_CLIENT_KEY,
         ssl_show_warn: bool = False,
         timeout: int = DEFAULT_OPENSEARCH_CLIENT_TIMEOUT_S,
+        auth_method: OpenSearchAuthMethod = OPENSEARCH_AUTH_METHOD,
+        aws_region: str | None = OPENSEARCH_AWS_REGION,
+        aws_service: str = OPENSEARCH_AWS_SERVICE,
     ):
         logger.debug(
-            "Creating OpenSearch client with host %s, port %s and timeout %s seconds.",
+            "Creating OpenSearch client with host %s, port %s, auth method "
+            "%s and timeout %s seconds.",
             host,
             port,
+            auth_method.value,
             timeout,
         )
+        http_auth: tuple[str, str] | Urllib3AWSV4SignerAuth
+        if auth_method == OpenSearchAuthMethod.IAM:
+            if not aws_region:
+                raise ValueError(
+                    "aws_region is required for IAM authentication to OpenSearch."
+                )
+            # SigV4 signing for an AWS managed domain whose FGAC master is an
+            # IAM ARN. Credentials come from the default boto3 chain (env, IRSA,
+            # instance/task role); the signer refreshes them per request.
+            credentials = boto3.Session().get_credentials()
+            if credentials is None:
+                raise ValueError(
+                    "OpenSearch IAM authentication is enabled but no AWS credentials "
+                    "could be resolved from the environment."
+                )
+            http_auth = Urllib3AWSV4SignerAuth(credentials, aws_region, aws_service)
+        else:
+            http_auth = auth
         self._client = OpenSearch(
             hosts=[{"host": host, "port": port}],
-            http_auth=auth,
+            http_auth=http_auth,
             use_ssl=use_ssl,
             verify_certs=verify_certs,
             ca_certs=ca_certs,
@@ -427,8 +463,9 @@ class OpenSearchIndexClient(OpenSearchClient):
         index_name: The name of the index to interact with.
         host: The host of the OpenSearch cluster.
         port: The port of the OpenSearch cluster.
-        auth: The authentication credentials for the OpenSearch cluster. A tuple
-            of (username, password).
+        auth: The basic-auth credentials for the OpenSearch cluster, a tuple of
+            (username, password). Used only when auth_method is BASIC; ignored
+            for IAM.
         use_ssl: Whether to use SSL for the OpenSearch cluster. Defaults to
             True.
         verify_certs: Whether to verify the server certificate. Defaults to
@@ -440,6 +477,12 @@ class OpenSearchIndexClient(OpenSearchClient):
             to False.
         timeout: The timeout for the OpenSearch cluster. Defaults to
             DEFAULT_OPENSEARCH_CLIENT_TIMEOUT_S.
+        auth_method: Whether to authenticate with HTTP basic auth or AWS SigV4
+            (IAM). Defaults to OPENSEARCH_AUTH_METHOD.
+        aws_region: AWS region used for SigV4 signing. Required when auth_method
+            is IAM. Defaults to OPENSEARCH_AWS_REGION.
+        aws_service: AWS service name for SigV4 signing ("es" for managed
+            domains, "aoss" for Serverless). Defaults to OPENSEARCH_AWS_SERVICE.
     """
 
     def __init__(
@@ -456,6 +499,9 @@ class OpenSearchIndexClient(OpenSearchClient):
         ssl_show_warn: bool = False,
         timeout: int = DEFAULT_OPENSEARCH_CLIENT_TIMEOUT_S,
         emit_metrics: bool = True,
+        auth_method: OpenSearchAuthMethod = OPENSEARCH_AUTH_METHOD,
+        aws_region: str | None = OPENSEARCH_AWS_REGION,
+        aws_service: str = OPENSEARCH_AWS_SERVICE,
     ):
         super().__init__(
             host=host,
@@ -468,6 +514,9 @@ class OpenSearchIndexClient(OpenSearchClient):
             client_key=client_key,
             ssl_show_warn=ssl_show_warn,
             timeout=timeout,
+            auth_method=auth_method,
+            aws_region=aws_region,
+            aws_service=aws_service,
         )
         self._index_name = index_name
         self._emit_metrics = emit_metrics

--- a/backend/onyx/document_index/opensearch/constants.py
+++ b/backend/onyx/document_index/opensearch/constants.py
@@ -52,6 +52,19 @@ DEFAULT_NUM_HYBRID_SUBQUERY_CANDIDATES = int(
 EF_SEARCH = DEFAULT_NUM_HYBRID_SUBQUERY_CANDIDATES
 
 
+class OpenSearchAuthMethod(str, Enum):
+    """Authentication method for connecting to OpenSearch.
+
+    BASIC uses HTTP basic auth (username/password); the only option for
+    self-hosted / docker-compose OpenSearch. IAM uses AWS SigV4 request signing
+    and is only valid against an AWS managed domain whose fine-grained access
+    control master is an IAM ARN.
+    """
+
+    BASIC = "basic"
+    IAM = "iam"
+
+
 class OpenSearchSearchType(str, Enum):
     """Search type label used for Prometheus metrics."""
 

--- a/backend/scripts/debugging/opensearch/opensearch_debug.py
+++ b/backend/scripts/debugging/opensearch/opensearch_debug.py
@@ -28,6 +28,7 @@ from typing import Any
 
 from onyx.document_index.opensearch.client import OpenSearchClient
 from onyx.document_index.opensearch.client import OpenSearchIndexClient
+from onyx.document_index.opensearch.constants import OpenSearchAuthMethod
 from shared_configs.configs import MULTI_TENANT
 
 
@@ -205,6 +206,36 @@ def main() -> None:
             default=os.environ.get("OPENSEARCH_ADMIN_PASSWORD", ""),
         )
         parser.add_argument(
+            "--auth-method",
+            help=(
+                "Authentication method: 'basic' (username/password) or 'iam' (AWS SigV4). Falls back to OPENSEARCH_AUTH_METHOD, "
+                "then 'basic'."
+            ),
+            type=str,
+            choices=[m.value for m in OpenSearchAuthMethod],
+            default=(
+                os.environ.get("OPENSEARCH_AUTH_METHOD")
+                or OpenSearchAuthMethod.BASIC.value
+            ).lower(),
+        )
+        parser.add_argument(
+            "--aws-region",
+            help=(
+                "AWS region for SigV4 signing. Required for --auth-method iam. Falls back to OPENSEARCH_AWS_REGION."
+            ),
+            type=str,
+            default=os.environ.get("OPENSEARCH_AWS_REGION", ""),
+        )
+        parser.add_argument(
+            "--aws-service",
+            help=(
+                "AWS service for SigV4 signing ('es' for managed domains, 'aoss' for Serverless). Falls back to "
+                "OPENSEARCH_AWS_SERVICE, then 'es'."
+            ),
+            type=str,
+            default=os.environ.get("OPENSEARCH_AWS_SERVICE") or "es",
+        )
+        parser.add_argument(
             "--no-ssl", help="Disable SSL.", action="store_true", default=False
         )
         parser.add_argument(
@@ -302,35 +333,46 @@ def main() -> None:
     if not (port := args.port or int(input("Enter the OpenSearch port: "))):
         print("Error: OpenSearch port is required.")
         sys.exit(1)
-    if not (username := args.username or input("Enter the OpenSearch username: ")):
-        print("Error: OpenSearch username is required.")
-        sys.exit(1)
-    if not (password := args.password or input("Enter the OpenSearch password: ")):
-        print("Error: OpenSearch password is required.")
-        sys.exit(1)
+
+    auth_method = OpenSearchAuthMethod(args.auth_method)
+    username = ""
+    password = ""
+    aws_region = args.aws_region or None
+    aws_service = args.aws_service
+    if auth_method == OpenSearchAuthMethod.IAM:
+        # SigV4 credentials come from the boto3 default chain (env vars /
+        # profile / role); only the region is needed here.
+        if not (aws_region := args.aws_region or input("Enter the AWS region: ")):
+            print("Error: AWS region is required for IAM auth.")
+            sys.exit(1)
+    else:
+        if not (username := args.username or input("Enter the OpenSearch username: ")):
+            print("Error: OpenSearch username is required.")
+            sys.exit(1)
+        if not (password := args.password or input("Enter the OpenSearch password: ")):
+            print("Error: OpenSearch password is required.")
+            sys.exit(1)
+    print(f"Auth method: {auth_method.value}")
     print("Using AWS-managed OpenSearch: ", args.use_aws_managed_opensearch)
     print(f"MULTI_TENANT: {MULTI_TENANT}")
     print()
 
     cluster_only_commands = {"list", "health", "reroute-retry-failed"}
 
+    common_kwargs: dict[str, Any] = dict(
+        host=host,
+        port=port,
+        auth=(username, password),
+        use_ssl=not args.no_ssl,
+        verify_certs=not args.no_verify_certs,
+        auth_method=auth_method,
+        aws_region=aws_region,
+        aws_service=aws_service,
+    )
     with (
-        OpenSearchClient(
-            host=host,
-            port=port,
-            auth=(username, password),
-            use_ssl=not args.no_ssl,
-            verify_certs=not args.no_verify_certs,
-        )
+        OpenSearchClient(**common_kwargs)
         if args.command in cluster_only_commands
-        else OpenSearchIndexClient(
-            index_name=args.index,
-            host=host,
-            port=port,
-            auth=(username, password),
-            use_ssl=not args.no_ssl,
-            verify_certs=not args.no_verify_certs,
-        )
+        else OpenSearchIndexClient(index_name=args.index, **common_kwargs)
     ) as client:
         if not client.ping():
             print("Error: Could not connect to OpenSearch.")

--- a/backend/tests/unit/onyx/document_index/opensearch/test_opensearch_auth.py
+++ b/backend/tests/unit/onyx/document_index/opensearch/test_opensearch_auth.py
@@ -1,0 +1,85 @@
+import importlib
+import os
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from opensearchpy import Urllib3AWSV4SignerAuth
+
+import onyx.configs.app_configs as app_configs
+from onyx.document_index.opensearch.client import OpenSearchClient
+from onyx.document_index.opensearch.constants import OpenSearchAuthMethod
+
+_OS_AUTH_ENV = (
+    "OPENSEARCH_AUTH_METHOD",
+    "OPENSEARCH_AWS_REGION",
+    "OPENSEARCH_AWS_SERVICE",
+)
+
+
+def test_iam_auth_uses_sigv4_signer() -> None:
+    """
+    IAM auth must hand opensearch-py a SigV4 signer built from boto3
+    credentials, not a username/password tuple.
+    """
+    with (
+        patch("onyx.document_index.opensearch.client.OpenSearch") as mock_os,
+        patch("onyx.document_index.opensearch.client.boto3.Session") as mock_session,
+    ):
+        mock_session.return_value.get_credentials.return_value = MagicMock()
+        OpenSearchClient(
+            host="h",
+            auth_method=OpenSearchAuthMethod.IAM,
+            aws_region="us-east-1",
+            aws_service="es",
+        )
+        assert isinstance(mock_os.call_args.kwargs["http_auth"], Urllib3AWSV4SignerAuth)
+
+
+def test_basic_auth_uses_tuple() -> None:
+    """
+    Back-compat: basic auth keeps passing the (username, password) tuple
+    straight through to opensearch-py.
+    """
+    with patch("onyx.document_index.opensearch.client.OpenSearch") as mock_os:
+        OpenSearchClient(
+            host="h",
+            auth=("u", "p"),
+            auth_method=OpenSearchAuthMethod.BASIC,
+        )
+        assert mock_os.call_args.kwargs["http_auth"] == ("u", "p")
+
+
+def test_iam_without_region_raises() -> None:
+    with pytest.raises(ValueError, match="aws_region is required"):
+        OpenSearchClient(
+            host="h",
+            auth_method=OpenSearchAuthMethod.IAM,
+            aws_region=None,
+        )
+
+
+def test_iam_without_credentials_raises() -> None:
+    with patch("onyx.document_index.opensearch.client.boto3.Session") as mock_session:
+        mock_session.return_value.get_credentials.return_value = None
+        with pytest.raises(ValueError, match="no AWS credentials"):
+            OpenSearchClient(
+                host="h",
+                auth_method=OpenSearchAuthMethod.IAM,
+                aws_region="us-east-1",
+            )
+
+
+def _clear_os_auth_env() -> None:
+    for var in _OS_AUTH_ENV:
+        os.environ.pop(var, None)
+
+
+def test_iam_config_without_region_raises() -> None:
+    with patch.dict(os.environ, {}, clear=False):
+        _clear_os_auth_env()
+        os.environ["OPENSEARCH_AUTH_METHOD"] = "iam"
+
+        with pytest.raises(ValueError, match="OPENSEARCH_AWS_REGION must be set"):
+            importlib.reload(app_configs)
+    importlib.reload(app_configs)


### PR DESCRIPTION
## Description

Adds the ability to authenticate to OpenSearch via IAM.

## How Has This Been Tested?

Besides unit tests, I created a dummy OpenSearch domain with public access and with IAM fine-grained access control. I also created a new dummy user and an access key for that user. Locally I then configured an AWS profile using that key and secret key, and was able to successfully reach the OpenSearch cluster using the `opensearch_debug.py` script.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds IAM (AWS SigV4) authentication to the OpenSearch client, so we can connect to AWS-managed domains without storing passwords. Default remains basic auth; no changes needed for self-hosted or existing setups.

- **New Features**
  - Added `iam` auth via `opensearchpy` `Urllib3AWSV4SignerAuth`; creds come from the default `boto3` chain.
  - New envs: `OPENSEARCH_AUTH_METHOD` (`basic`|`iam`), `OPENSEARCH_AWS_REGION` (required for `iam`), `OPENSEARCH_AWS_SERVICE` (`es` default, `aoss` for Serverless).
  - Validation: `iam` requires `USING_AWS_MANAGED_OPENSEARCH=true` and a region.
  - Debug script supports `--auth-method`, `--aws-region`, and `--aws-service`.
  - Unit tests cover signer wiring, config validation, and fallbacks.

- **Migration**
  - To use IAM: set `USING_AWS_MANAGED_OPENSEARCH=true`, `OPENSEARCH_AUTH_METHOD=iam`, and `OPENSEARCH_AWS_REGION=<region>`.
  - Ensure AWS creds are available to `boto3` (env, profile, or role).
  - Optionally set `OPENSEARCH_AWS_SERVICE=aoss` for OpenSearch Serverless.

<sup>Written for commit bcbab8ec5d3cb2607204867772a1de86164d340f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

