### PR TITLE
fix: hierarchy node cross batch stubs

### DIFF
--- a/backend/ee/onyx/db/hierarchy.py
+++ b/backend/ee/onyx/db/hierarchy.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy.sql.elements import ColumnElement
 
 from onyx.configs.constants import DocumentSource
+from onyx.db.enums import HierarchyNodeType
 from onyx.db.models import HierarchyNode
 
 
@@ -63,7 +64,10 @@ def _get_accessible_hierarchy_nodes_for_source(
     Returns:
         List of HierarchyNode objects the user has access to
     """
-    stmt = select(HierarchyNode).where(HierarchyNode.source == source)
+    stmt = select(HierarchyNode).where(
+        HierarchyNode.source == source,
+        HierarchyNode.node_type != HierarchyNodeType.STUB,
+    )
     stmt = stmt.where(_build_hierarchy_access_filter(user_email, external_group_ids))
     stmt = stmt.order_by(HierarchyNode.display_name)
     return list(db_session.execute(stmt).scalars().all())

--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -447,6 +447,10 @@ class HierarchyNodeType(str, PyEnum):
     # Root-level type
     SOURCE = "source"  # Root node for a source (e.g., "Google Drive")
 
+    # Placeholder created when a child is indexed before its parent exists in the DB.
+    # Promoted to the real type when the parent page is later processed.
+    STUB = "stub"
+
     # Google Drive
     SHARED_DRIVE = "shared_drive"
     MY_DRIVE = "my_drive"

--- a/backend/onyx/db/hierarchy.py
+++ b/backend/onyx/db/hierarchy.py
@@ -6,6 +6,7 @@ from sqlalchemy import delete
 from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.engine import CursorResult
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from onyx.configs.constants import DocumentSource
@@ -135,33 +136,6 @@ def ensure_source_node_exists(
     return source_node
 
 
-def resolve_parent_hierarchy_node_id(
-    db_session: Session,
-    raw_parent_id: str | None,
-    source: DocumentSource,
-) -> int | None:
-    """
-    Resolve a raw_parent_id to a database HierarchyNode ID.
-
-    If raw_parent_id is None, returns the SOURCE node ID for backward compatibility.
-    If the parent node doesn't exist, returns the SOURCE node ID as fallback.
-    """
-    if raw_parent_id is None:
-        # No parent specified - use the SOURCE node
-        source_node = get_source_hierarchy_node(db_session, source)
-        return source_node.id if source_node else None
-
-    parent_node = get_hierarchy_node_by_raw_id(db_session, raw_parent_id, source)
-    if parent_node:
-        return parent_node.id
-
-    # Parent not found - fall back to SOURCE node.
-    # Callers that want stub creation (upsert_hierarchy_node) detect this via the
-    # returned value equalling source_node_id and create a STUB in that case.
-    source_node = get_source_hierarchy_node(db_session, source)
-    return source_node.id if source_node else None
-
-
 def _create_stub_hierarchy_node(
     db_session: Session,
     raw_node_id: str,
@@ -184,8 +158,16 @@ def _create_stub_hierarchy_node(
         is_public=False,
     )
     db_session.add(stub)
-    db_session.flush()
-    return stub
+    try:
+        with db_session.begin_nested():
+            db_session.flush()
+        return stub
+    except IntegrityError:
+        # A concurrent worker inserted this stub first; return theirs.
+        existing = get_hierarchy_node_by_raw_id(db_session, raw_node_id, source)
+        if existing is not None:
+            return existing
+        raise
 
 
 def upsert_parents(
@@ -283,22 +265,23 @@ def upsert_hierarchy_node(
         source_node_id: DB id of the SOURCE root node for this source, used to
             detect and replace the fallback with a STUB for missing cross-batch parents.
     """
-    # Resolve parent_id from raw_parent_id
-    parent_id = (
-        None
-        if node.node_type == HierarchyNodeType.SOURCE
-        else resolve_parent_hierarchy_node_id(db_session, node.raw_parent_id, source)
-    )
-
     ret: list[HierarchyNode] = []
-    # If a specific parent was requested but resolve fell back to SOURCE, create a stub
-    # so the child points to a real placeholder rather than the wrong root node.
-    if node.raw_parent_id is not None and parent_id == source_node_id:
-        created_stub = _create_stub_hierarchy_node(
-            db_session, node.raw_parent_id, source, source_node_id
+    if node.node_type == HierarchyNodeType.SOURCE:
+        parent_id: int | None = None
+    elif node.raw_parent_id is None:
+        parent_id = source_node_id
+    else:
+        parent_node = get_hierarchy_node_by_raw_id(
+            db_session, node.raw_parent_id, source
         )
-        parent_id = created_stub.id
-        ret.append(created_stub)
+        if parent_node is not None:
+            parent_id = parent_node.id
+        else:
+            stub = _create_stub_hierarchy_node(
+                db_session, node.raw_parent_id, source, source_node_id
+            )
+            parent_id = stub.id
+            ret.append(stub)
 
     # For public connectors, all nodes are public
     # Otherwise, extract permission fields from external_access if present

--- a/backend/onyx/db/hierarchy.py
+++ b/backend/onyx/db/hierarchy.py
@@ -155,24 +155,48 @@ def resolve_parent_hierarchy_node_id(
     if parent_node:
         return parent_node.id
 
-    # Parent not found - fall back to SOURCE node
-    logger.warning(
-        "Parent hierarchy node not found: raw_id=%s, source=%s. Falling back to SOURCE node.",
-        raw_parent_id,
-        source,
-    )
+    # Parent not found - fall back to SOURCE node.
+    # Callers that want stub creation (upsert_hierarchy_node) detect this via the
+    # returned value equalling source_node_id and create a STUB in that case.
     source_node = get_source_hierarchy_node(db_session, source)
     return source_node.id if source_node else None
+
+
+def _create_stub_hierarchy_node(
+    db_session: Session,
+    raw_node_id: str,
+    source: DocumentSource,
+    source_node_id: int,
+) -> HierarchyNode:
+    """Create a STUB placeholder for a parent that hasn't been indexed yet.
+
+    Flushed immediately so subsequent lookups in the same session find it,
+    preventing duplicate stubs when multiple children share the same missing parent.
+    The stub is promoted to the real node type when the parent page is processed.
+    """
+    stub = HierarchyNode(
+        raw_node_id=raw_node_id,
+        display_name="__stub__",
+        link=None,
+        source=source,
+        node_type=HierarchyNodeType.STUB,
+        parent_id=source_node_id,
+        is_public=False,
+    )
+    db_session.add(stub)
+    db_session.flush()
+    return stub
 
 
 def upsert_parents(
     db_session: Session,
     node: PydanticHierarchyNode,
+    source_node_id: int,
     source: DocumentSource,
     node_by_id: dict[str, PydanticHierarchyNode],
     done_ids: set[str],
     is_connector_public: bool = False,
-) -> None:
+) -> list[HierarchyNode]:
     """
     Upsert the in-batch ancestors of ``node`` in oldest-to-newest order.
 
@@ -213,29 +237,39 @@ def upsert_parents(
         current = parent_node
 
     # Drain oldest-first so each parent is persisted before its children.
+    created: list[HierarchyNode] = []
     for parent_node in reversed(pending):
-        upsert_hierarchy_node(
-            db_session,
-            parent_node,
-            source,
-            commit=False,
-            is_connector_public=is_connector_public,
+        created.extend(
+            upsert_hierarchy_node(
+                db_session,
+                parent_node,
+                source_node_id,
+                source,
+                commit=False,
+                is_connector_public=is_connector_public,
+            )
         )
         done_ids.add(parent_node.raw_node_id)
+    return created
 
 
 def upsert_hierarchy_node(
     db_session: Session,
     node: PydanticHierarchyNode,
+    source_node_id: int,
     source: DocumentSource,
     commit: bool = True,
     is_connector_public: bool = False,
-) -> HierarchyNode:
+) -> list[HierarchyNode]:
     """
     Upsert a hierarchy node from a Pydantic model.
 
     If a node with the same raw_node_id and source exists, updates it.
     Otherwise, creates a new node.
+
+    Returns a list containing the upserted node, plus a STUB node if one was
+    created for a missing parent. The STUB is promoted when the real parent is
+    later processed.
 
     Args:
         db_session: SQLAlchemy session
@@ -246,6 +280,8 @@ def upsert_hierarchy_node(
             and all hierarchy nodes should be marked as public regardless of their
             external_access settings. This ensures nodes from public connectors are
             accessible to all users.
+        source_node_id: DB id of the SOURCE root node for this source, used to
+            detect and replace the fallback with a STUB for missing cross-batch parents.
     """
     # Resolve parent_id from raw_parent_id
     parent_id = (
@@ -253,6 +289,16 @@ def upsert_hierarchy_node(
         if node.node_type == HierarchyNodeType.SOURCE
         else resolve_parent_hierarchy_node_id(db_session, node.raw_parent_id, source)
     )
+
+    ret: list[HierarchyNode] = []
+    # If a specific parent was requested but resolve fell back to SOURCE, create a stub
+    # so the child points to a real placeholder rather than the wrong root node.
+    if node.raw_parent_id is not None and parent_id == source_node_id:
+        created_stub = _create_stub_hierarchy_node(
+            db_session, node.raw_parent_id, source, source_node_id
+        )
+        parent_id = created_stub.id
+        ret.append(created_stub)
 
     # For public connectors, all nodes are public
     # Otherwise, extract permission fields from external_access if present
@@ -305,13 +351,14 @@ def upsert_hierarchy_node(
             external_user_group_ids=external_user_group_ids,
         )
         db_session.add(hierarchy_node)
+    ret.append(hierarchy_node)
 
     if commit:
         db_session.commit()
     else:
         db_session.flush()
 
-    return hierarchy_node
+    return ret
 
 
 def upsert_hierarchy_nodes_batch(
@@ -324,10 +371,12 @@ def upsert_hierarchy_nodes_batch(
     """
     Batch upsert hierarchy nodes.
 
-    Note: This function requires that for each node passed in, all
-    its ancestors exist in either the database or elsewhere in the nodes list.
-    This function handles parent dependencies for you as long as that condition is met
-    (so you don't need to worry about parent nodes appearing before their children in the list).
+    Handles parent dependencies automatically: in-batch ancestors are upserted
+    before their children, and cross-batch missing parents get a STUB placeholder
+    that is promoted when the real parent is later processed.
+
+    Returns all upserted nodes including any STUB nodes created for missing parents,
+    so callers can cache and register them all uniformly.
 
     Args:
         db_session: SQLAlchemy session
@@ -338,38 +387,46 @@ def upsert_hierarchy_nodes_batch(
             and all hierarchy nodes should be marked as public regardless of their
             external_access settings.
     """
+    source_node = ensure_source_node_exists(db_session, source)
+    source_node_id = source_node.id
+
     node_by_id = {}
     for node in nodes:
         if node.node_type != HierarchyNodeType.SOURCE:
             node_by_id[node.raw_node_id] = node
-    done_ids = set[str]()
+    done_ids: set[str] = set()
 
-    results = []
+    all_nodes: list[HierarchyNode] = []
     for node in nodes:
         if node.raw_node_id in done_ids:
             continue
-        upsert_parents(
-            db_session,
-            node,
-            source,
-            node_by_id,
-            done_ids,
-            is_connector_public=is_connector_public,
+        all_nodes.extend(
+            upsert_parents(
+                db_session,
+                node,
+                source_node_id,
+                source,
+                node_by_id,
+                done_ids,
+                is_connector_public=is_connector_public,
+            )
         )
-        hierarchy_node = upsert_hierarchy_node(
-            db_session,
-            node,
-            source,
-            commit=False,
-            is_connector_public=is_connector_public,
+        all_nodes.extend(
+            upsert_hierarchy_node(
+                db_session,
+                node,
+                source_node_id,
+                source,
+                commit=False,
+                is_connector_public=is_connector_public,
+            )
         )
         done_ids.add(node.raw_node_id)
-        results.append(hierarchy_node)
 
     if commit:
         db_session.commit()
 
-    return results
+    return all_nodes
 
 
 def link_hierarchy_nodes_to_documents(
@@ -508,7 +565,10 @@ def _get_accessible_hierarchy_nodes_for_source(
     Returns:
         List of all HierarchyNode objects for the source
     """
-    stmt = select(HierarchyNode).where(HierarchyNode.source == source)
+    stmt = select(HierarchyNode).where(
+        HierarchyNode.source == source,
+        HierarchyNode.node_type != HierarchyNodeType.STUB,
+    )
     stmt = stmt.order_by(HierarchyNode.display_name)
     return list(db_session.execute(stmt).scalars().all())
 

--- a/backend/tests/external_dependency_unit/connectors/google_drive/test_google_drive_hierarchy_walker.py
+++ b/backend/tests/external_dependency_unit/connectors/google_drive/test_google_drive_hierarchy_walker.py
@@ -55,6 +55,7 @@ from onyx.connectors.models import HierarchyNode as PydanticHierarchyNode
 from onyx.connectors.models import InputType
 from onyx.db.enums import AccessType
 from onyx.db.enums import ConnectorCredentialPairStatus
+from onyx.db.enums import HierarchyNodeType
 from onyx.db.hierarchy import ensure_source_node_exists
 from onyx.db.hierarchy import get_hierarchy_node_by_raw_id
 from onyx.db.hierarchy import get_source_hierarchy_node
@@ -424,25 +425,19 @@ def test_off_by_one_batch_split_misparents_child(db_session: Session) -> None:
         _cleanup_cc_pair_triple(db_session, db_connector, db_credential)
 
 
-def test_cross_yield_walk_does_not_heal_misparented_child(
+def test_cross_yield_walk_heals_misparented_child_via_stub(
     db_session: Session,
 ) -> None:
-    """Issue 2: a node yielded with an unresolvable parent in one walk stays
-    mis-parented to SOURCE forever because `seen_hierarchy_node_raw_ids`
-    prevents re-yield even after a later walk discovers the missing
-    ancestor.
+    """A node whose parent is inaccessible in yield 1 is correctly parented
+    after yield 2 discovers the missing ancestor, via stub promotion.
 
     Setup:
       - Chain: ROOT (shared drive) → A → B → C → F
-      - Yield 1 (user X): cannot fetch A. Walker emits [C, B], leaves
-        ``fully_walked`` empty. Upsert: B is mis-parented to SOURCE
-        because A is unknown.
-      - Yield 2 (user Y, broader access): can fetch A. Walker climbs
-        starting from B (the parent of file F2), but skips re-yielding B
-        because it's already in ``seen``. Upsert: A and ROOT land
-        correctly, but B's row never gets touched again.
-
-    Expected after the fix: B's stored parent is updated to A in yield 2.
+      - Yield 1 (user X): cannot fetch A. Walker emits [C, B]. Upsert:
+        a STUB is created for A, and B is parented to that stub.
+      - Yield 2 (user Y, broader access): can fetch A. A is upserted,
+        promoting the existing STUB in-place. B's parent_id already points
+        to the stub's DB id, which now resolves to the real A node.
     """
     test_id = "issue2_crossyield"
     a_id = f"{test_id}_A"
@@ -507,14 +502,15 @@ def test_cross_yield_walk_does_not_heal_misparented_child(
 
             db_session.expire_all()
             b_after_yield_1 = get_hierarchy_node_by_raw_id(db_session, b_id, SOURCE)
+            a_stub = get_hierarchy_node_by_raw_id(db_session, a_id, SOURCE)
             assert b_after_yield_1 is not None
-            assert b_after_yield_1.parent_id == source_node_id, (
-                "Setup invariant: B should be mis-parented to SOURCE after "
-                "yield 1 (its parent A is inaccessible). Got "
-                f"parent_id={b_after_yield_1.parent_id}, SOURCE id={source_node_id}."
+            assert a_stub is not None, (
+                "A STUB should be created for the inaccessible parent A after yield 1."
             )
-            assert get_hierarchy_node_by_raw_id(db_session, a_id, SOURCE) is None, (
-                "Setup invariant: A should not exist in the DB after yield 1."
+            assert a_stub.node_type == HierarchyNodeType.STUB
+            assert b_after_yield_1.parent_id == a_stub.id, (
+                "B should be parented to the STUB for A after yield 1, not SOURCE. "
+                f"Got parent_id={b_after_yield_1.parent_id}, stub id={a_stub.id}."
             )
 
             with patch.object(

--- a/backend/tests/external_dependency_unit/hierarchy/test_stub_cross_batch.py
+++ b/backend/tests/external_dependency_unit/hierarchy/test_stub_cross_batch.py
@@ -1,0 +1,214 @@
+"""Tests for STUB hierarchy node creation when a child is indexed before its parent.
+
+During Notion full syncs the search API returns pages in arbitrary order.
+When a child page lands in batch N and its parent in batch N+K, the child's
+hierarchy node must point to a STUB placeholder rather than SOURCE. The stub
+is promoted (display_name, node_type, parent_id all updated) when the real
+parent page is later processed, and the child's FK stays correct throughout.
+"""
+
+from typing import Generator
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.models import HierarchyNode as PydanticHierarchyNode
+from onyx.db.enums import HierarchyNodeType
+from onyx.db.hierarchy import ensure_source_node_exists
+from onyx.db.hierarchy import get_hierarchy_node_by_raw_id
+from onyx.db.hierarchy import get_source_hierarchy_node
+from onyx.db.hierarchy import upsert_hierarchy_nodes_batch
+
+
+@pytest.fixture()
+def notion_source_node(db_session: Session) -> Generator[None, None, None]:
+    ensure_source_node_exists(db_session, DocumentSource.NOTION, commit=False)
+    db_session.flush()
+    yield
+    db_session.rollback()
+
+
+@pytest.mark.usefixtures("notion_source_node")
+def test_child_before_parent_creates_stub_then_promotes(db_session: Session) -> None:
+    """Child in batch 1 gets a STUB parent; real parent in batch 2 promotes it."""
+    tag = uuid4().hex[:8]
+    child_id = f"child_{tag}"
+    parent_id = f"parent_{tag}"
+
+    source_node = get_source_hierarchy_node(db_session, DocumentSource.NOTION)
+    assert source_node is not None
+
+    # Batch 1: child only — parent doesn't exist yet.
+    upsert_hierarchy_nodes_batch(
+        db_session,
+        [
+            PydanticHierarchyNode(
+                raw_node_id=child_id,
+                raw_parent_id=parent_id,
+                display_name="Child",
+                node_type=HierarchyNodeType.PAGE,
+            )
+        ],
+        DocumentSource.NOTION,
+        commit=False,
+    )
+
+    child = get_hierarchy_node_by_raw_id(db_session, child_id, DocumentSource.NOTION)
+    stub = get_hierarchy_node_by_raw_id(db_session, parent_id, DocumentSource.NOTION)
+
+    assert child is not None
+    assert stub is not None
+    assert stub.node_type == HierarchyNodeType.STUB
+    assert stub.display_name == "__stub__"
+    # Child points to stub, not SOURCE.
+    assert child.parent_id == stub.id
+    assert child.parent_id != source_node.id
+
+    stub_db_id = stub.id  # must remain unchanged after promotion
+
+    # Batch 2: real parent page arrives.
+    upsert_hierarchy_nodes_batch(
+        db_session,
+        [
+            PydanticHierarchyNode(
+                raw_node_id=parent_id,
+                raw_parent_id=None,
+                display_name="Real Parent",
+                node_type=HierarchyNodeType.PAGE,
+            )
+        ],
+        DocumentSource.NOTION,
+        commit=False,
+    )
+
+    # Stub is promoted in-place — same DB id, real fields now.
+    promoted = get_hierarchy_node_by_raw_id(
+        db_session, parent_id, DocumentSource.NOTION
+    )
+    assert promoted is not None
+    assert promoted.id == stub_db_id
+    assert promoted.node_type == HierarchyNodeType.PAGE
+    assert promoted.display_name == "Real Parent"
+    assert promoted.parent_id == source_node.id
+
+    # Child's FK is unchanged — it still points to the promoted node.
+    child_after = get_hierarchy_node_by_raw_id(
+        db_session, child_id, DocumentSource.NOTION
+    )
+    assert child_after is not None
+    assert child_after.parent_id == stub_db_id
+
+
+@pytest.mark.usefixtures("notion_source_node")
+def test_stub_promoted_alongside_new_child_in_same_batch(db_session: Session) -> None:
+    """Real parent and a new child arrive together in the same batch as the promotion.
+
+    A strict within-call stub-then-promotion can't occur because node_by_id covers
+    all non-SOURCE nodes in the batch, so upsert_parents processes the real node
+    before any child would trigger stub creation.  This test covers the realistic
+    cross-call variant: stub created in batch 1, then batch 2 contains both the real
+    parent and a new child that hasn't been seen before.
+    """
+    tag = uuid4().hex[:8]
+    child1_id = f"child1_{tag}"
+    child2_id = f"child2_{tag}"
+    parent_id = f"parent_{tag}"
+
+    source_node = get_source_hierarchy_node(db_session, DocumentSource.NOTION)
+    assert source_node is not None
+
+    # Batch 1: child1 only — parent doesn't exist, stub created.
+    upsert_hierarchy_nodes_batch(
+        db_session,
+        [
+            PydanticHierarchyNode(
+                raw_node_id=child1_id,
+                raw_parent_id=parent_id,
+                display_name="Child 1",
+                node_type=HierarchyNodeType.PAGE,
+            )
+        ],
+        DocumentSource.NOTION,
+        commit=False,
+    )
+
+    stub = get_hierarchy_node_by_raw_id(db_session, parent_id, DocumentSource.NOTION)
+    assert stub is not None
+    assert stub.node_type == HierarchyNodeType.STUB
+    stub_db_id = stub.id
+
+    # Batch 2: real parent + a brand-new child2, both arrive together.
+    upsert_hierarchy_nodes_batch(
+        db_session,
+        [
+            PydanticHierarchyNode(
+                raw_node_id=child2_id,
+                raw_parent_id=parent_id,
+                display_name="Child 2",
+                node_type=HierarchyNodeType.PAGE,
+            ),
+            PydanticHierarchyNode(
+                raw_node_id=parent_id,
+                raw_parent_id=None,
+                display_name="Real Parent",
+                node_type=HierarchyNodeType.PAGE,
+            ),
+        ],
+        DocumentSource.NOTION,
+        commit=False,
+    )
+
+    promoted = get_hierarchy_node_by_raw_id(
+        db_session, parent_id, DocumentSource.NOTION
+    )
+    assert promoted is not None
+    assert promoted.id == stub_db_id
+    assert promoted.node_type == HierarchyNodeType.PAGE
+    assert promoted.display_name == "Real Parent"
+
+    # Both children point to the promoted parent.
+    child1 = get_hierarchy_node_by_raw_id(db_session, child1_id, DocumentSource.NOTION)
+    child2 = get_hierarchy_node_by_raw_id(db_session, child2_id, DocumentSource.NOTION)
+    assert child1 is not None and child1.parent_id == stub_db_id
+    assert child2 is not None and child2.parent_id == stub_db_id
+
+
+@pytest.mark.usefixtures("notion_source_node")
+def test_multiple_children_same_missing_parent_creates_one_stub(
+    db_session: Session,
+) -> None:
+    """Multiple children in the same batch pointing to the same missing parent
+    produce exactly one STUB, not one per child."""
+    tag = uuid4().hex[:8]
+    parent_id = f"parent_{tag}"
+    child_ids = [f"child_{tag}_{i}" for i in range(3)]
+
+    upsert_hierarchy_nodes_batch(
+        db_session,
+        [
+            PydanticHierarchyNode(
+                raw_node_id=cid,
+                raw_parent_id=parent_id,
+                display_name=f"Child {i}",
+                node_type=HierarchyNodeType.PAGE,
+            )
+            for i, cid in enumerate(child_ids)
+        ],
+        DocumentSource.NOTION,
+        commit=False,
+    )
+
+    stub = get_hierarchy_node_by_raw_id(db_session, parent_id, DocumentSource.NOTION)
+    assert stub is not None
+    assert stub.node_type == HierarchyNodeType.STUB
+
+    # Every child must point to the same stub, not SOURCE.
+    source_node = get_source_hierarchy_node(db_session, DocumentSource.NOTION)
+    assert source_node is not None
+    for cid in child_ids:
+        child = get_hierarchy_node_by_raw_id(db_session, cid, DocumentSource.NOTION)
+        assert child is not None
+        assert child.parent_id == stub.id
+        assert child.parent_id != source_node.id


### PR DESCRIPTION
## Description

We were previously enforcing that hierarchynodes needed to be yielded parent-before-child, and then worst case picking up those relationships on the next indexing or pruning attempt. This worst case wasn't ideal, since if the child wasn't reindexed in a future run (i.e. it didn't get modified), users might have to wait until the pruning run kicked in for nodes to be parented correctly. Notion in particular was consistently hitting this worst case, as the connector structure makes it very inconvenient to actually yield parent-before-child.

Now we're adding a reasonably efficient mechanism for handling the case of "child before parent" in docfetching. Basically we make a stub node when a child is yielded without its parent, then update the node with its real info when it becomes available.



## How Has This Been Tested?

added tests
## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect parenting when a child node is indexed before its parent by creating `STUB` placeholders and promoting them when the parent arrives. Adds concurrency-safe stub creation and hides stubs from user-facing queries, improving Notion and Google Drive syncs.

- **Bug Fixes**
  - Added `HierarchyNodeType.STUB` for missing parents; promote in place on parent upsert so child links stay correct.
  - Updated batch upsert to upsert in-batch ancestors first and create cross-batch stubs; returns all upserted nodes (including stubs); prevents duplicate stubs within a session and across concurrent workers.
  - Excluded `STUB` nodes from accessible/source listing queries in both `backend/onyx` and `backend/ee/onyx`.
  - Added tests for cross-batch stub creation/promotion and one-stub-for-many-children; updated Google Drive walker test to validate stub-based healing across yields.

<sup>Written for commit c7818a1447b49af647695bcdc850dc32f0003b60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

