### PR TITLE
feat(web): shared AppBanner host for top-of-app banners

### DIFF
--- a/web/src/hooks/useBannerDismiss.ts
+++ b/web/src/hooks/useBannerDismiss.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+/**
+ * Per-device dismissal for a banner, persisted in localStorage under `key`.
+ * Pass `undefined` for a non-dismissible banner (always visible, no close
+ * button). The key encodes whatever should re-show the banner — e.g. a license
+ * stage or a banner id — so a new value resurfaces it.
+ */
+export function useBannerDismiss(key: string | undefined): {
+  dismissed: boolean;
+  dismiss: () => void;
+} {
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !key) {
+      setDismissed(false);
+      return;
+    }
+    setDismissed(window.localStorage.getItem(key) === "1");
+  }, [key]);
+
+  const dismiss = useCallback(() => {
+    if (typeof window !== "undefined" && key) {
+      window.localStorage.setItem(key, "1");
+    }
+    setDismissed(true);
+  }, [key]);
+
+  return { dismissed, dismiss };
+}

--- a/web/src/hooks/useMainContainerOffset.ts
+++ b/web/src/hooks/useMainContainerOffset.ts
@@ -1,0 +1,59 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
+
+/**
+ * Tracks the on-screen box of the main content container so a fixed-position
+ * banner can align to it (rather than the full viewport) as the sidebar opens
+ * and closes. Falls back to the full window width when no
+ * `[data-main-container]` element is present.
+ */
+export function useMainContainerOffset(): { left: number; width: number } {
+  const pathname = usePathname();
+  const [bounds, setBounds] = useState<{ left: number; width: number }>({
+    left: 0,
+    width: 0,
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    let target: HTMLElement | null = null;
+    let frame = 0;
+
+    function update() {
+      const el = document.querySelector<HTMLElement>("[data-main-container]");
+      if (el) {
+        const rect = el.getBoundingClientRect();
+        setBounds({ left: rect.left, width: rect.width });
+        if (target !== el) {
+          ro.disconnect();
+          ro.observe(el);
+          target = el;
+        }
+      } else {
+        setBounds({ left: 0, width: window.innerWidth });
+        target = null;
+      }
+    }
+
+    const ro = new ResizeObserver(update);
+    const mo = new MutationObserver(() => {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(update);
+    });
+
+    update();
+    mo.observe(document.body, { childList: true, subtree: true });
+    window.addEventListener("resize", update);
+
+    return () => {
+      cancelAnimationFrame(frame);
+      ro.disconnect();
+      mo.disconnect();
+      window.removeEventListener("resize", update);
+    };
+  }, [pathname]);
+
+  return bounds;
+}

--- a/web/src/sections/AppBanner.tsx
+++ b/web/src/sections/AppBanner.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { MessageCard } from "@opal/components";
+import type { RichStr, StatusVariants } from "@opal/types";
+
+import { useBannerDismiss } from "@/hooks/useBannerDismiss";
+import { useMainContainerOffset } from "@/hooks/useMainContainerOffset";
+
+interface AppBannerProps {
+  variant: StatusVariants;
+  title: string | RichStr;
+  description?: string | RichStr;
+  /**
+   * localStorage key for per-device dismissal. Omit for a non-dismissible
+   * banner (no close button).
+   */
+  dismissKey?: string;
+}
+
+/**
+ * Shared host for top-of-app status banners. Owns the "where/how" — aligning a
+ * fixed Opal `MessageCard` to the main content container and persisting
+ * dismissal — so each caller only owns the "what/when" (copy, variant, and the
+ * visibility condition that decides whether to render it at all).
+ */
+export default function AppBanner({
+  variant,
+  title,
+  description,
+  dismissKey,
+}: AppBannerProps) {
+  const { left, width } = useMainContainerOffset();
+  const { dismissed, dismiss } = useBannerDismiss(dismissKey);
+
+  if (dismissed) return null;
+
+  return (
+    <div
+      className="fixed top-3 z-toast flex justify-center px-3 pointer-events-none"
+      style={{ left, width: width || undefined }}
+    >
+      <div className="w-full max-w-3xl pointer-events-auto">
+        <MessageCard
+          variant={variant}
+          title={title}
+          description={description}
+          onClose={dismissKey ? dismiss : undefined}
+        />
+      </div>
+    </div>
+  );
+}

--- a/web/src/sections/LicenseExpiryBanner.tsx
+++ b/web/src/sections/LicenseExpiryBanner.tsx
@@ -1,10 +1,8 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { usePathname } from "next/navigation";
-import { MessageCard } from "@opal/components";
 import type { ExpiryWarningStage } from "@/lib/billing/interfaces";
 import { useLicense } from "@/hooks/useLicense";
+import AppBanner from "@/sections/AppBanner";
 
 const DISMISS_STORAGE_KEY = "license-expiry-banner-dismissed";
 
@@ -74,127 +72,36 @@ function dismissKey(
 ): string {
   const base = `${DISMISS_STORAGE_KEY}:${stage}:${expiresAt ?? "unknown"}`;
   if (stage === "grace") {
+    // Re-show once per day during the grace period so the countdown stays seen.
     const today = new Date().toISOString().slice(0, 10);
     return `${base}:${today}`;
   }
   return base;
 }
 
-interface LicenseExpiryBannerViewProps {
-  stage: ExpiryWarningStage;
-  expiresAt: string | null;
-  graceDaysRemaining: number;
-  onDismiss?: () => void;
-}
-
-export function LicenseExpiryBannerView({
-  stage,
-  expiresAt,
-  graceDaysRemaining,
-  onDismiss,
-}: LicenseExpiryBannerViewProps) {
-  const copy = buildCopy(stage, expiresAt, graceDaysRemaining);
-  if (!copy) return null;
-
-  return (
-    <MessageCard
-      variant={copy.variant}
-      title={copy.title}
-      description={copy.description}
-      onClose={onDismiss}
-    />
-  );
-}
-
-function useMainContainerOffset(): { left: number; width: number } {
-  const pathname = usePathname();
-  const [bounds, setBounds] = useState<{ left: number; width: number }>({
-    left: 0,
-    width: 0,
-  });
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    let target: HTMLElement | null = null;
-    let frame = 0;
-
-    function update() {
-      const el = document.querySelector<HTMLElement>("[data-main-container]");
-      if (el) {
-        const rect = el.getBoundingClientRect();
-        setBounds({ left: rect.left, width: rect.width });
-        if (target !== el) {
-          ro.disconnect();
-          ro.observe(el);
-          target = el;
-        }
-      } else {
-        setBounds({ left: 0, width: window.innerWidth });
-        target = null;
-      }
-    }
-
-    const ro = new ResizeObserver(update);
-    const mo = new MutationObserver(() => {
-      cancelAnimationFrame(frame);
-      frame = requestAnimationFrame(update);
-    });
-
-    update();
-    mo.observe(document.body, { childList: true, subtree: true });
-    window.addEventListener("resize", update);
-
-    return () => {
-      cancelAnimationFrame(frame);
-      ro.disconnect();
-      mo.disconnect();
-      window.removeEventListener("resize", update);
-    };
-  }, [pathname]);
-
-  return bounds;
-}
-
 export default function LicenseExpiryBanner() {
   const { data } = useLicense();
-  const [dismissed, setDismissed] = useState(false);
-  const { left, width } = useMainContainerOffset();
 
   const stage = data?.expiry_warning_stage ?? "none";
   const expiresAt = data?.expires_at ?? null;
   const graceDays = computeGraceDaysRemaining(data?.grace_period_end ?? null);
   const hasLicense = data?.has_license ?? false;
-  const key = dismissKey(stage, expiresAt);
 
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    setDismissed(window.localStorage.getItem(key) === "1");
-  }, [key]);
-
-  if (!hasLicense || stage === "none" || dismissed) {
+  if (!hasLicense || stage === "none") {
     return null;
   }
 
-  function handleDismiss() {
-    if (typeof window !== "undefined") {
-      window.localStorage.setItem(key, "1");
-    }
-    setDismissed(true);
+  const copy = buildCopy(stage, expiresAt, graceDays);
+  if (!copy) {
+    return null;
   }
 
   return (
-    <div
-      className="fixed top-3 z-toast flex justify-center px-3 pointer-events-none"
-      style={{ left, width: width || undefined }}
-    >
-      <div className="w-full max-w-3xl pointer-events-auto">
-        <LicenseExpiryBannerView
-          stage={stage}
-          expiresAt={expiresAt}
-          graceDaysRemaining={graceDays}
-          onDismiss={handleDismiss}
-        />
-      </div>
-    </div>
+    <AppBanner
+      variant={copy.variant}
+      title={copy.title}
+      description={copy.description}
+      dismissKey={dismissKey(stage, expiresAt)}
+    />
   );
 }


### PR DESCRIPTION
## Description

Extract the top-of-app banner shell into one reusable host.

- **What:** new `AppBanner` host renders an Opal `MessageCard` and owns the two things every banner re-implemented — aligning to the main content container (`useMainContainerOffset`) and per-device localStorage dismissal (`useBannerDismiss`). `LicenseExpiryBanner` now renders through it and drops its copy-pasted offset hook, positioning wrapper, and dismiss state.
- **Why:** multiple top-of-app banners had forked the identical positioning + dismiss logic. This collapses them to one host so new banners reuse it instead of copying it again.
- Pure refactor — no behavior change.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check