### PR TITLE
fix(craft): sanitize message metadata before jsonb writes

### DIFF
--- a/backend/onyx/server/features/build/db/build_session.py
+++ b/backend/onyx/server/features/build/db/build_session.py
@@ -31,6 +31,7 @@ from onyx.server.features.build.configs import SANDBOX_NEXTJS_PORT_END
 from onyx.server.features.build.configs import SANDBOX_NEXTJS_PORT_START
 from onyx.server.manage.llm.models import LLMProviderView
 from onyx.utils.logger import setup_logger
+from onyx.utils.postgres_sanitization import sanitize_json_like
 
 logger = setup_logger()
 
@@ -327,11 +328,12 @@ def create_message(
         message_metadata: Required structured data (the raw sandbox event packet JSON)
         db_session: Database session
     """
+    sanitized_metadata = sanitize_json_like(message_metadata)
     message = BuildMessage(
         session_id=session_id,
         turn_index=turn_index,
         type=message_type,
-        message_metadata=message_metadata,
+        message_metadata=sanitized_metadata,
     )
     db_session.add(message)
     db_session.commit()
@@ -343,7 +345,7 @@ def create_message(
         message.id,
         session_id,
         turn_index,
-        message_metadata.get("type"),
+        sanitized_metadata.get("type"),
     )
     return message
 
@@ -383,12 +385,15 @@ def update_message(
     if message is None:
         return None
 
-    message.message_metadata = message_metadata
+    sanitized_metadata = sanitize_json_like(message_metadata)
+    message.message_metadata = sanitized_metadata
     db_session.commit()
     db_session.refresh(message)
 
     logger.info(
-        "Updated message %s metadata type=%s", message_id, message_metadata.get("type")
+        "Updated message %s metadata type=%s",
+        message_id,
+        sanitized_metadata.get("type"),
     )
     return message
 
@@ -433,7 +438,8 @@ def upsert_agent_plan(
     )
 
     if existing_plan:
-        existing_plan.message_metadata = plan_metadata
+        sanitized_metadata = sanitize_json_like(plan_metadata)
+        existing_plan.message_metadata = sanitized_metadata
         db_session.commit()
         db_session.refresh(existing_plan)
         logger.info(

--- a/backend/tests/external_dependency_unit/craft/test_streaming_persistence.py
+++ b/backend/tests/external_dependency_unit/craft/test_streaming_persistence.py
@@ -237,6 +237,26 @@ class TestStreamingPersistence:
         assert messages[3].type == MessageType.ASSISTANT
         assert messages[3].message_metadata["content"]["text"] == "Done with tool."
 
+    def test_tool_output_with_nul_byte_is_stripped_for_postgres_jsonb(
+        self,
+        db_session: Session,
+        build_session: BuildSession,
+        tenant_context: None,  # noqa: ARG002
+    ) -> None:
+        create_message(
+            session_id=build_session.id,
+            message_type=MessageType.ASSISTANT,
+            turn_index=0,
+            message_metadata={
+                "type": "tool_call_progress",
+                "rawOutput": {"output": "prefix\x00suffix"},
+            },
+            db_session=db_session,
+        )
+
+        messages = get_session_messages(build_session.id, db_session)
+        assert messages[-1].message_metadata["rawOutput"]["output"] == "prefixsuffix"
+
     def test_agent_thought_chunks_persist_as_single_collapsed_row(
         self,
         db_session: Session,


### PR DESCRIPTION
## Description

Sanitize Craft build message metadata with the shared `sanitize_json_like` helper before writing to JSONB. This prevents an interactive turn from failing and abort-cleaning the sandbox when tool output contains characters Postgres cannot store, such as NUL bytes from binary Google Drive/Office payloads captured in `rawOutput`.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitize Craft build message metadata before writing to Postgres JSONB to prevent crashes from invalid characters like NUL bytes in tool outputs. This avoids failed interactive turns and sandbox aborts when binary payloads appear in `rawOutput`.

- **Bug Fixes**
  - Apply `sanitize_json_like` to metadata in message create, update, and agent plan upsert paths.
  - Add test to verify NUL bytes in `rawOutput` are stripped and messages persist successfully.

<sup>Written for commit a33ec9b464d6506b6b2c6a6d9c436bed2f44c7e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

