### PR TITLE
fix(craft): keep latest session snapshot safely

### DIFF
--- a/backend/onyx/background/celery/tasks/build/tasks.py
+++ b/backend/onyx/background/celery/tasks/build/tasks.py
@@ -6,7 +6,6 @@ import time
 from celery import shared_task
 from celery import Task
 from redis.lock import Lock as RedisLock
-from sqlalchemy.orm import Session
 
 from onyx.background.celery.apps.app_base import task_logger
 from onyx.configs.constants import OnyxCeleryTask
@@ -14,8 +13,6 @@ from onyx.configs.constants import OnyxRedisLocks
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import SandboxStatus
 from onyx.db.models import Sandbox
-from onyx.db.models import Snapshot
-from onyx.file_store.file_store import get_default_file_store
 from onyx.redis.redis_pool import get_redis_client
 from onyx.redis.redis_tenant_work_gating import maybe_mark_tenant_active
 from onyx.server.features.build.configs import SANDBOX_IDLE_TIMEOUT_SECONDS
@@ -23,14 +20,14 @@ from onyx.server.features.build.db.build_session import clear_nextjs_ports_for_u
 from onyx.server.features.build.db.build_session import (
     mark_user_sessions_idle__no_commit,
 )
-from onyx.server.features.build.db.sandbox import create_snapshot__no_commit
 from onyx.server.features.build.db.sandbox import get_latest_snapshot_for_session
 from onyx.server.features.build.db.sandbox import get_running_sandboxes
-from onyx.server.features.build.db.sandbox import get_snapshots_for_session
 from onyx.server.features.build.db.sandbox import update_sandbox_status__no_commit
 from onyx.server.features.build.db.sandbox import user_has_stale_active_session
 from onyx.server.features.build.sandbox.factory import get_sandbox_manager
-from onyx.server.features.build.sandbox.snapshot_manager import SnapshotManager
+from onyx.server.features.build.session.sandbox_lifecycle import (
+    persist_session_snapshot_keep_latest,
+)
 
 # 100 minutes - snapshotting can take time
 TIMEOUT_SECONDS = 6000
@@ -39,29 +36,6 @@ TIMEOUT_SECONDS = 6000
 # its latest snapshot is older than idle_timeout/4 (15 min at the default 1h),
 # so the data-loss bound scales with the pace of sandboxes going to sleep.
 SNAPSHOT_INTERVAL_DIVISOR = 4
-
-
-def _prune_prior_session_snapshots(
-    db_session: Session,
-    snapshot_manager: SnapshotManager,
-    prior_snapshots: list[Snapshot],
-) -> None:
-    """Delete a session's now-superseded snapshots (blob then row).
-
-    We keep only the latest snapshot per session; once a fresh one is written,
-    the prior ones are pruned. Blob deletes are idempotent and best-effort: a
-    failed delete leaves that row in place to be retried on the session's next
-    reap, so a blob and its row never leak out of sync.
-    """
-    for old in prior_snapshots:
-        try:
-            snapshot_manager.delete_snapshot(old.storage_path)
-        except Exception as e:
-            task_logger.warning(
-                f"Skipping prune of snapshot {old.id}; blob delete failed: {e}"
-            )
-            continue
-        db_session.delete(old)
 
 
 def is_sandbox_idle(sandbox: Sandbox, now: datetime.datetime) -> bool:
@@ -103,7 +77,6 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
 
     try:
         sandbox_manager = get_sandbox_manager()
-        snapshot_manager = SnapshotManager(get_default_file_store())
 
         with get_session_with_current_tenant() as db_session:
             running_sandboxes = get_running_sandboxes(db_session)
@@ -184,27 +157,18 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
                             ):
                                 continue
 
-                            # Capture priors before the new snapshot so we can
-                            # prune them once the fresh one lands (keep-latest).
-                            prior_snapshots = get_snapshots_for_session(
-                                db_session, session_id
-                            )
                             snapshot_start = time.monotonic()
                             snapshot_result = sandbox_manager.create_snapshot(
                                 sandbox_id, session_id, tenant_id
                             )
                             snapshot_elapsed = time.monotonic() - snapshot_start
                             if snapshot_result:
-                                create_snapshot__no_commit(
-                                    db_session,
-                                    session_id,
-                                    snapshot_result.storage_path,
-                                    snapshot_result.size_bytes,
+                                persist_session_snapshot_keep_latest(
+                                    db_session=db_session,
+                                    session_id=session_id,
+                                    storage_path=snapshot_result.storage_path,
+                                    size_bytes=snapshot_result.size_bytes,
                                 )
-                                _prune_prior_session_snapshots(
-                                    db_session, snapshot_manager, prior_snapshots
-                                )
-                                db_session.commit()
                                 snapshots_created += 1
                                 task_logger.info(
                                     f"Snapshot created for session {session_id}: "

--- a/backend/onyx/background/celery/tasks/build/tasks.py
+++ b/backend/onyx/background/celery/tasks/build/tasks.py
@@ -26,7 +26,7 @@ from onyx.server.features.build.db.sandbox import update_sandbox_status__no_comm
 from onyx.server.features.build.db.sandbox import user_has_stale_active_session
 from onyx.server.features.build.sandbox.factory import get_sandbox_manager
 from onyx.server.features.build.session.sandbox_lifecycle import (
-    persist_session_snapshot_keep_latest,
+    create_session_snapshot_keep_latest,
 )
 
 # 100 minutes - snapshotting can take time
@@ -158,17 +158,15 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
                                 continue
 
                             snapshot_start = time.monotonic()
-                            snapshot_result = sandbox_manager.create_snapshot(
-                                sandbox_id, session_id, tenant_id
+                            snapshot_result = create_session_snapshot_keep_latest(
+                                sandbox_manager=sandbox_manager,
+                                db_session=db_session,
+                                sandbox_id=sandbox_id,
+                                session_id=session_id,
+                                tenant_id=tenant_id,
                             )
                             snapshot_elapsed = time.monotonic() - snapshot_start
                             if snapshot_result:
-                                persist_session_snapshot_keep_latest(
-                                    db_session=db_session,
-                                    session_id=session_id,
-                                    storage_path=snapshot_result.storage_path,
-                                    size_bytes=snapshot_result.size_bytes,
-                                )
                                 snapshots_created += 1
                                 task_logger.info(
                                     f"Snapshot created for session {session_id}: "

--- a/backend/onyx/server/features/build/db/sandbox.py
+++ b/backend/onyx/server/features/build/db/sandbox.py
@@ -231,6 +231,12 @@ def get_snapshots_for_session(db_session: Session, session_id: UUID) -> list[Sna
     return list(db_session.execute(stmt).scalars().all())
 
 
+def delete_snapshot__no_commit(db_session: Session, snapshot: Snapshot) -> None:
+    """Delete a snapshot row. Caller owns the transaction boundary."""
+    db_session.delete(snapshot)
+    db_session.flush()
+
+
 def delete_snapshot(db_session: Session, snapshot_id: UUID) -> bool:
     """Delete a specific snapshot by ID. Returns True if deleted, False if not found."""
     stmt = select(Snapshot).where(Snapshot.id == snapshot_id)

--- a/backend/onyx/server/features/build/db/sandbox.py
+++ b/backend/onyx/server/features/build/db/sandbox.py
@@ -234,7 +234,6 @@ def get_snapshots_for_session(db_session: Session, session_id: UUID) -> list[Sna
 def delete_snapshot__no_commit(db_session: Session, snapshot: Snapshot) -> None:
     """Delete a snapshot row. Caller owns the transaction boundary."""
     db_session.delete(snapshot)
-    db_session.flush()
 
 
 def delete_snapshot(db_session: Session, snapshot_id: UUID) -> bool:

--- a/backend/onyx/server/features/build/session/api.py
+++ b/backend/onyx/server/features/build/session/api.py
@@ -13,6 +13,7 @@ from fastapi import File
 from fastapi import HTTPException
 from fastapi import Response
 from fastapi import UploadFile
+from fastapi.responses import JSONResponse
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from sqlalchemy import exists
@@ -31,22 +32,18 @@ from onyx.db.models import User
 from onyx.db.scheduled_task import get_scheduled_run_context
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
-from onyx.file_store.file_store import get_default_file_store
 from onyx.redis.redis_pool import get_redis_client
 from onyx.server.features.build.db.build_session import allocate_nextjs_port
 from onyx.server.features.build.db.build_session import get_build_session
 from onyx.server.features.build.db.build_session import set_build_session_sharing_scope
-from onyx.server.features.build.db.sandbox import create_snapshot__no_commit
 from onyx.server.features.build.db.sandbox import ensure_sandbox_pat
 from onyx.server.features.build.db.sandbox import get_latest_snapshot_for_session
 from onyx.server.features.build.db.sandbox import get_sandbox_by_user_id
-from onyx.server.features.build.db.sandbox import get_snapshots_for_session
 from onyx.server.features.build.db.sandbox import update_sandbox_heartbeat
 from onyx.server.features.build.db.sandbox import update_sandbox_status__no_commit
 from onyx.server.features.build.models import UploadResponse
 from onyx.server.features.build.sandbox.factory import get_sandbox_manager
 from onyx.server.features.build.sandbox.models import DirectoryListing
-from onyx.server.features.build.sandbox.snapshot_manager import SnapshotManager
 from onyx.server.features.build.sandbox.user_library import hydrate_user_library
 from onyx.server.features.build.session.errors import UploadLimitExceededError
 from onyx.server.features.build.session.manager import SessionManager
@@ -64,6 +61,9 @@ from onyx.server.features.build.session.models import SetSessionSharingRequest
 from onyx.server.features.build.session.models import SetSessionSharingResponse
 from onyx.server.features.build.session.models import SnapshotResponse
 from onyx.server.features.build.session.models import WebappInfo
+from onyx.server.features.build.session.sandbox_lifecycle import (
+    persist_session_snapshot_keep_latest,
+)
 from onyx.server.features.build.session.sandbox_lifecycle import (
     snapshot_opencode_history_before_recovery,
 )
@@ -565,57 +565,43 @@ def _owned_session_sandbox(
     return sandbox
 
 
-def _persist_session_snapshot(
-    db_session: Session,
-    session_id: UUID,
-    storage_path: str,
-    size_bytes: int,
-) -> None:
-    """Record the snapshot and prune the session's prior ones (keep-latest)."""
-    prior_snapshots = get_snapshots_for_session(db_session, session_id)
-    create_snapshot__no_commit(db_session, session_id, storage_path, size_bytes)
-    snapshot_manager = SnapshotManager(get_default_file_store())
-    for old in prior_snapshots:
-        try:
-            snapshot_manager.delete_snapshot(old.storage_path)
-        except Exception as e:
-            logger.warning(
-                "Skipping prune of snapshot %s; blob delete failed: %s", old.id, e
-            )
-            continue
-        db_session.delete(old)
-    db_session.commit()
-
-
-@router.post("/{session_id}/snapshot", response_model=None)
+@router.post("/{session_id}/snapshot")
 def create_session_snapshot(
     session_id: UUID,
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
-) -> SnapshotResponse | Response:
+) -> Response:
     """Snapshot the owned session's outputs/attachments and record it. Returns
     204 when there is nothing to snapshot (no outputs) or snapshots are
     disabled."""
     sandbox = _owned_session_sandbox(session_id, user, db_session)
+    sandbox_manager = get_sandbox_manager()
 
     try:
-        result = get_sandbox_manager().create_snapshot(
+        result = sandbox_manager.create_snapshot(
             sandbox_id=sandbox.id,
             session_id=session_id,
             tenant_id=get_current_tenant_id(),
         )
-    except (ValueError, RuntimeError) as e:
-        raise OnyxError(OnyxErrorCode.INVALID_INPUT, str(e))
+    except ValueError as e:
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, str(e)) from e
+    except RuntimeError as e:
+        raise OnyxError(OnyxErrorCode.SERVICE_UNAVAILABLE, str(e)) from e
     if result is None:
         return Response(status_code=204)
 
-    _persist_session_snapshot(
-        db_session, session_id, result.storage_path, result.size_bytes
-    )
-
-    return SnapshotResponse(
+    persist_session_snapshot_keep_latest(
+        db_session=db_session,
+        session_id=session_id,
         storage_path=result.storage_path,
         size_bytes=result.size_bytes,
+    )
+
+    return JSONResponse(
+        content=SnapshotResponse(
+            storage_path=result.storage_path,
+            size_bytes=result.size_bytes,
+        ).model_dump()
     )
 
 
@@ -637,8 +623,10 @@ def create_session_opencode_history_snapshot(
             sandbox.id,
             get_current_tenant_id(),
         )
-    except (ValueError, RuntimeError) as e:
-        raise OnyxError(OnyxErrorCode.INVALID_INPUT, str(e))
+    except ValueError as e:
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, str(e)) from e
+    except RuntimeError as e:
+        raise OnyxError(OnyxErrorCode.SERVICE_UNAVAILABLE, str(e)) from e
     return OpencodeHistorySnapshotResponse(created=created)
 
 

--- a/backend/onyx/server/features/build/session/api.py
+++ b/backend/onyx/server/features/build/session/api.py
@@ -62,7 +62,7 @@ from onyx.server.features.build.session.models import SetSessionSharingResponse
 from onyx.server.features.build.session.models import SnapshotResponse
 from onyx.server.features.build.session.models import WebappInfo
 from onyx.server.features.build.session.sandbox_lifecycle import (
-    persist_session_snapshot_keep_latest,
+    create_session_snapshot_keep_latest,
 )
 from onyx.server.features.build.session.sandbox_lifecycle import (
     snapshot_opencode_history_before_recovery,
@@ -578,7 +578,9 @@ def create_session_snapshot(
     sandbox_manager = get_sandbox_manager()
 
     try:
-        result = sandbox_manager.create_snapshot(
+        result = create_session_snapshot_keep_latest(
+            sandbox_manager=sandbox_manager,
+            db_session=db_session,
             sandbox_id=sandbox.id,
             session_id=session_id,
             tenant_id=get_current_tenant_id(),
@@ -589,13 +591,6 @@ def create_session_snapshot(
         raise OnyxError(OnyxErrorCode.SERVICE_UNAVAILABLE, str(e)) from e
     if result is None:
         return Response(status_code=204)
-
-    persist_session_snapshot_keep_latest(
-        db_session=db_session,
-        session_id=session_id,
-        storage_path=result.storage_path,
-        size_bytes=result.size_bytes,
-    )
 
     return JSONResponse(
         content=SnapshotResponse(

--- a/backend/onyx/server/features/build/session/sandbox_lifecycle.py
+++ b/backend/onyx/server/features/build/session/sandbox_lifecycle.py
@@ -10,16 +10,22 @@ from sqlalchemy.orm import Session as DBSession
 
 from onyx.db.enums import SandboxStatus
 from onyx.db.models import Sandbox
+from onyx.db.models import Snapshot
 from onyx.db.models import User
 from onyx.db.users import fetch_user_by_id
+from onyx.file_store.file_store import get_default_file_store
 from onyx.server.features.build.configs import SANDBOX_MAX_CONCURRENT_PER_ORG
 from onyx.server.features.build.db.sandbox import create_sandbox__no_commit
+from onyx.server.features.build.db.sandbox import create_snapshot__no_commit
+from onyx.server.features.build.db.sandbox import delete_snapshot__no_commit
 from onyx.server.features.build.db.sandbox import ensure_sandbox_pat
 from onyx.server.features.build.db.sandbox import get_running_sandbox_count
 from onyx.server.features.build.db.sandbox import get_sandbox_by_user_id
+from onyx.server.features.build.db.sandbox import get_snapshots_for_session
 from onyx.server.features.build.db.sandbox import update_sandbox_status__no_commit
 from onyx.server.features.build.sandbox.base import SandboxManager
 from onyx.server.features.build.sandbox.models import LLMProviderConfig
+from onyx.server.features.build.sandbox.snapshot_manager import SnapshotManager
 from onyx.server.features.build.session.errors import SandboxProvisioningError
 from onyx.utils.logger import setup_logger
 from shared_configs.configs import MULTI_TENANT
@@ -52,6 +58,36 @@ def snapshot_opencode_history_before_recovery(
             sandbox_id,
             exc_info=True,
         )
+
+
+def persist_session_snapshot_keep_latest(
+    db_session: DBSession,
+    session_id: UUID,
+    storage_path: str,
+    size_bytes: int,
+) -> Snapshot:
+    """Record a new snapshot and prune the session's prior blobs/rows."""
+    prior_snapshots = get_snapshots_for_session(db_session, session_id)
+    snapshot = create_snapshot__no_commit(
+        db_session=db_session,
+        session_id=session_id,
+        storage_path=storage_path,
+        size_bytes=size_bytes,
+    )
+
+    snapshot_manager = SnapshotManager(get_default_file_store())
+    for old in prior_snapshots:
+        try:
+            snapshot_manager.delete_snapshot(old.storage_path)
+        except Exception as e:
+            logger.warning(
+                "Skipping prune of snapshot %s; blob delete failed: %s", old.id, e
+            )
+            continue
+        delete_snapshot__no_commit(db_session, old)
+
+    db_session.commit()
+    return snapshot
 
 
 class ProvisioningPolicy(str, Enum):

--- a/backend/onyx/server/features/build/session/sandbox_lifecycle.py
+++ b/backend/onyx/server/features/build/session/sandbox_lifecycle.py
@@ -10,7 +10,6 @@ from sqlalchemy.orm import Session as DBSession
 
 from onyx.db.enums import SandboxStatus
 from onyx.db.models import Sandbox
-from onyx.db.models import Snapshot
 from onyx.db.models import User
 from onyx.db.users import fetch_user_by_id
 from onyx.file_store.file_store import get_default_file_store
@@ -25,6 +24,7 @@ from onyx.server.features.build.db.sandbox import get_snapshots_for_session
 from onyx.server.features.build.db.sandbox import update_sandbox_status__no_commit
 from onyx.server.features.build.sandbox.base import SandboxManager
 from onyx.server.features.build.sandbox.models import LLMProviderConfig
+from onyx.server.features.build.sandbox.models import SnapshotResult
 from onyx.server.features.build.sandbox.snapshot_manager import SnapshotManager
 from onyx.server.features.build.session.errors import SandboxProvisioningError
 from onyx.utils.logger import setup_logger
@@ -60,19 +60,28 @@ def snapshot_opencode_history_before_recovery(
         )
 
 
-def persist_session_snapshot_keep_latest(
+def create_session_snapshot_keep_latest(
+    sandbox_manager: SandboxManager,
     db_session: DBSession,
+    sandbox_id: UUID,
     session_id: UUID,
-    storage_path: str,
-    size_bytes: int,
-) -> Snapshot:
-    """Record a new snapshot and prune the session's prior blobs/rows."""
+    tenant_id: str,
+) -> SnapshotResult | None:
+    """Create a sandbox archive, record it, and prune snapshots older than it."""
     prior_snapshots = get_snapshots_for_session(db_session, session_id)
-    snapshot = create_snapshot__no_commit(
+    result = sandbox_manager.create_snapshot(
+        sandbox_id=sandbox_id,
+        session_id=session_id,
+        tenant_id=tenant_id,
+    )
+    if result is None:
+        return None
+
+    create_snapshot__no_commit(
         db_session=db_session,
         session_id=session_id,
-        storage_path=storage_path,
-        size_bytes=size_bytes,
+        storage_path=result.storage_path,
+        size_bytes=result.size_bytes,
     )
 
     snapshot_manager = SnapshotManager(get_default_file_store())
@@ -87,7 +96,7 @@ def persist_session_snapshot_keep_latest(
         delete_snapshot__no_commit(db_session, old)
 
     db_session.commit()
-    return snapshot
+    return result
 
 
 class ProvisioningPolicy(str, Enum):

--- a/backend/tests/common/craft/stubs.py
+++ b/backend/tests/common/craft/stubs.py
@@ -96,6 +96,8 @@ class StubSandboxManager(SandboxManager):
       by ``subscribe_to_opencode_session``.
     - ``create_snapshot_returns``: ``SnapshotResult | None`` returned by
       ``create_snapshot``.
+    - ``create_snapshot_results_by_session``: per-session ``SnapshotResult``,
+      ``None``, or exception for ``create_snapshot``.
     - ``list_directory_returns`` or ``list_directory_returns_by_path``,
       ``read_file_returns``, ``upload_file_returns``, ``delete_file_returns``,
       ``get_upload_stats_returns``, ``get_webapp_url_returns``,
@@ -133,6 +135,9 @@ class StubSandboxManager(SandboxManager):
         self.health_check_returns: bool | None = None
         self.session_workspace_exists_returns: bool | None = None
         self.create_snapshot_returns: SnapshotResult | None | object = _UNSET
+        self.create_snapshot_results_by_session: dict[
+            UUID, SnapshotResult | None | Exception
+        ] = {}
         self.create_opencode_history_snapshot_returns: bool | object = _UNSET
         self.list_directory_returns: list[FilesystemEntry] | None = None
         self.list_directory_returns_by_path: dict[str, list[FilesystemEntry]] | None = (
@@ -325,6 +330,12 @@ class StubSandboxManager(SandboxManager):
             "session_id": session_id,
             "tenant_id": tenant_id,
         }
+        if session_id in self.create_snapshot_results_by_session:
+            outcome = self.create_snapshot_results_by_session[session_id]
+            if isinstance(outcome, Exception):
+                raise outcome
+            return outcome
+
         if self.create_snapshot_returns is _UNSET:
             raise _not_configured("create_snapshot")
         return cast("SnapshotResult | None", self.create_snapshot_returns)

--- a/backend/tests/external_dependency_unit/craft/test_background_snapshots.py
+++ b/backend/tests/external_dependency_unit/craft/test_background_snapshots.py
@@ -265,7 +265,6 @@ def test_stale_snapshot_resnapshotted_and_priors_pruned(
 
     cleanup_idle_sandboxes_task.run(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
 
-    assert stubbed_sweep.create_snapshot_count == 1
     db_session.expire_all()
     snapshots = (
         db_session.query(Snapshot).filter(Snapshot.session_id == session_row.id).all()
@@ -279,7 +278,6 @@ def test_snapshot_failure_continues_other_sessions(
     db_session: Session,
     test_user: User,  # noqa: ARG001
     stubbed_sweep: StubSandboxManager,
-    monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """A failing ``create_snapshot`` is logged and the sweep continues."""
@@ -293,15 +291,10 @@ def test_snapshot_failure_continues_other_sessions(
     real_result = SnapshotResult(
         storage_path=f"s3://snapshots/{uuid4()}.tar.gz", size_bytes=55
     )
-
-    def _snapshot(
-        _sandbox_id: object, session_id: object, _tenant_id: object
-    ) -> SnapshotResult:
-        if session_id == session_a.id:
-            raise RuntimeError("FileStore unreachable")
-        return real_result
-
-    monkeypatch.setattr(stubbed_sweep, "create_snapshot", _snapshot)
+    stubbed_sweep.create_snapshot_results_by_session = {
+        session_a.id: RuntimeError("FileStore unreachable"),
+        session_b.id: real_result,
+    }
 
     with caplog.at_level(logging.WARNING):
         cleanup_idle_sandboxes_task.run(

--- a/backend/tests/external_dependency_unit/craft/test_background_snapshots.py
+++ b/backend/tests/external_dependency_unit/craft/test_background_snapshots.py
@@ -35,6 +35,9 @@ from onyx.db.models import Snapshot
 from onyx.db.models import User
 from onyx.redis.redis_pool import get_redis_client
 from onyx.server.features.build.sandbox.models import SnapshotResult
+from onyx.server.features.build.session import (
+    sandbox_lifecycle as sandbox_lifecycle_module,
+)
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from tests.common.craft.stubs import StubSandboxManager
 from tests.external_dependency_unit.craft.db_helpers import make_sandbox
@@ -58,8 +61,12 @@ class _FakeSnapshotManager:
 @pytest.fixture
 def fake_snapshot_manager(monkeypatch: pytest.MonkeyPatch) -> _FakeSnapshotManager:
     fake = _FakeSnapshotManager()
-    monkeypatch.setattr(tasks_module, "SnapshotManager", lambda _file_store: fake)
-    monkeypatch.setattr(tasks_module, "get_default_file_store", lambda: None)
+    monkeypatch.setattr(
+        sandbox_lifecycle_module, "SnapshotManager", lambda _file_store: fake
+    )
+    monkeypatch.setattr(
+        sandbox_lifecycle_module, "get_default_file_store", lambda: None
+    )
     return fake
 
 

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_prune_prior_snapshots.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_prune_prior_snapshots.py
@@ -6,9 +6,10 @@ from uuid import uuid4
 import pytest
 
 from onyx.db.models import Snapshot
+from onyx.server.features.build.sandbox.models import SnapshotResult
 from onyx.server.features.build.session import sandbox_lifecycle
 from onyx.server.features.build.session.sandbox_lifecycle import (
-    persist_session_snapshot_keep_latest,
+    create_session_snapshot_keep_latest,
 )
 
 
@@ -17,12 +18,6 @@ def _snap() -> Snapshot:
     return Snapshot(
         id=sid, session_id=uuid4(), storage_path=f"snap/{sid}.tar.gz", size_bytes=1
     )
-
-
-def _db_session_with_priors(priors: list[Snapshot]) -> MagicMock:
-    db_session = MagicMock()
-    db_session.execute.return_value.scalars.return_value.all.return_value = priors
-    return db_session
 
 
 def _stub_snapshot_manager(
@@ -34,24 +29,50 @@ def _stub_snapshot_manager(
     )
 
 
-def test_prunes_blob_then_row_for_each_prior(monkeypatch: pytest.MonkeyPatch) -> None:
-    session_id = uuid4()
-    priors = [_snap(), _snap(), _snap()]
-    db_session = _db_session_with_priors(priors)
-    snapshot_manager = MagicMock()
-    _stub_snapshot_manager(monkeypatch, snapshot_manager)
+def _stub_prior_snapshots(
+    monkeypatch: pytest.MonkeyPatch,
+    db_session: MagicMock,
+    session_id: object,
+    priors: list[Snapshot],
+) -> None:
+    def _get_snapshots_for_session(
+        _db_session: MagicMock, requested_session_id: object
+    ) -> list[Snapshot]:
+        assert _db_session is db_session
+        assert requested_session_id == session_id
+        return priors
 
-    snapshot = persist_session_snapshot_keep_latest(
-        db_session=db_session,
-        session_id=session_id,
-        storage_path="snap/new.tar.gz",
-        size_bytes=123,
+    monkeypatch.setattr(
+        sandbox_lifecycle, "get_snapshots_for_session", _get_snapshots_for_session
     )
 
-    assert snapshot.session_id == session_id
-    assert snapshot.storage_path == "snap/new.tar.gz"
-    assert snapshot.size_bytes == 123
-    db_session.add.assert_called_once_with(snapshot)
+
+def test_prunes_blob_then_row_for_each_prior(monkeypatch: pytest.MonkeyPatch) -> None:
+    session_id = uuid4()
+    sandbox_id = uuid4()
+    priors = [_snap(), _snap(), _snap()]
+    db_session = MagicMock()
+    sandbox_manager = MagicMock()
+    sandbox_manager.create_snapshot.return_value = SnapshotResult(
+        storage_path="snap/new.tar.gz", size_bytes=123
+    )
+    snapshot_manager = MagicMock()
+    _stub_prior_snapshots(monkeypatch, db_session, session_id, priors)
+    _stub_snapshot_manager(monkeypatch, snapshot_manager)
+
+    result = create_session_snapshot_keep_latest(
+        sandbox_manager=sandbox_manager,
+        db_session=db_session,
+        sandbox_id=sandbox_id,
+        session_id=session_id,
+        tenant_id="tenant-a",
+    )
+
+    assert result == SnapshotResult(storage_path="snap/new.tar.gz", size_bytes=123)
+    created_snapshot = db_session.add.call_args.args[0]
+    assert created_snapshot.session_id == session_id
+    assert created_snapshot.storage_path == "snap/new.tar.gz"
+    assert created_snapshot.size_bytes == 123
     db_session.commit.assert_called_once()
     assert snapshot_manager.delete_snapshot.call_count == 3
     snapshot_manager.delete_snapshot.assert_any_call(priors[0].storage_path)
@@ -60,15 +81,22 @@ def test_prunes_blob_then_row_for_each_prior(monkeypatch: pytest.MonkeyPatch) ->
 
 
 def test_empty_priors_is_a_noop(monkeypatch: pytest.MonkeyPatch) -> None:
-    db_session = _db_session_with_priors([])
+    session_id = uuid4()
+    db_session = MagicMock()
+    sandbox_manager = MagicMock()
+    sandbox_manager.create_snapshot.return_value = SnapshotResult(
+        storage_path="snap/new.tar.gz", size_bytes=123
+    )
     snapshot_manager = MagicMock()
+    _stub_prior_snapshots(monkeypatch, db_session, session_id, [])
     _stub_snapshot_manager(monkeypatch, snapshot_manager)
 
-    persist_session_snapshot_keep_latest(
+    create_session_snapshot_keep_latest(
+        sandbox_manager=sandbox_manager,
         db_session=db_session,
-        session_id=uuid4(),
-        storage_path="snap/new.tar.gz",
-        size_bytes=123,
+        sandbox_id=uuid4(),
+        session_id=session_id,
+        tenant_id="tenant-a",
     )
 
     snapshot_manager.delete_snapshot.assert_not_called()
@@ -79,21 +107,78 @@ def test_empty_priors_is_a_noop(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_blob_delete_failure_keeps_that_row_but_continues(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    session_id = uuid4()
     priors = [_snap(), _snap(), _snap()]
-    db_session = _db_session_with_priors(priors)
+    db_session = MagicMock()
+    sandbox_manager = MagicMock()
+    sandbox_manager.create_snapshot.return_value = SnapshotResult(
+        storage_path="snap/new.tar.gz", size_bytes=123
+    )
     snapshot_manager = MagicMock()
+    _stub_prior_snapshots(monkeypatch, db_session, session_id, priors)
     _stub_snapshot_manager(monkeypatch, snapshot_manager)
     # Second blob delete fails; its row must be kept, the rest still pruned.
     snapshot_manager.delete_snapshot.side_effect = [None, RuntimeError("s3 down"), None]
 
-    persist_session_snapshot_keep_latest(
+    create_session_snapshot_keep_latest(
+        sandbox_manager=sandbox_manager,
         db_session=db_session,
-        session_id=uuid4(),
-        storage_path="snap/new.tar.gz",
-        size_bytes=123,
+        sandbox_id=uuid4(),
+        session_id=session_id,
+        tenant_id="tenant-a",
     )
 
     deleted_rows = [c.args[0] for c in db_session.delete.call_args_list]
     assert deleted_rows == [priors[0], priors[2]]
     assert priors[1] not in deleted_rows
     db_session.commit.assert_called_once()
+
+
+def test_create_snapshot_does_not_prune_snapshots_created_during_archive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_session = MagicMock()
+    sandbox_manager = MagicMock()
+    sandbox_id = uuid4()
+    session_id = uuid4()
+    old_snapshot = _snap()
+    concurrent_snapshot = _snap()
+    visible_snapshots = [old_snapshot]
+    snapshot_manager = MagicMock()
+    _stub_snapshot_manager(monkeypatch, snapshot_manager)
+
+    def _get_snapshots_for_session(
+        _db_session: MagicMock, requested_session_id: object
+    ) -> list[Snapshot]:
+        assert _db_session is db_session
+        assert requested_session_id == session_id
+        return list(visible_snapshots)
+
+    def _create_snapshot(**kwargs: object) -> SnapshotResult:
+        assert kwargs == {
+            "sandbox_id": sandbox_id,
+            "session_id": session_id,
+            "tenant_id": "tenant-a",
+        }
+        visible_snapshots.append(concurrent_snapshot)
+        return SnapshotResult(storage_path="snap/new.tar.gz", size_bytes=123)
+
+    monkeypatch.setattr(
+        sandbox_lifecycle, "get_snapshots_for_session", _get_snapshots_for_session
+    )
+    monkeypatch.setattr(sandbox_manager, "create_snapshot", _create_snapshot)
+
+    result = create_session_snapshot_keep_latest(
+        sandbox_manager=sandbox_manager,
+        db_session=db_session,
+        sandbox_id=sandbox_id,
+        session_id=session_id,
+        tenant_id="tenant-a",
+    )
+
+    assert result is not None
+    assert result.storage_path == "snap/new.tar.gz"
+    assert result.size_bytes == 123
+    deleted_rows = [c.args[0] for c in db_session.delete.call_args_list]
+    assert deleted_rows == [old_snapshot]
+    assert concurrent_snapshot not in deleted_rows

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_prune_prior_snapshots.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_prune_prior_snapshots.py
@@ -3,8 +3,13 @@
 from unittest.mock import MagicMock
 from uuid import uuid4
 
-from onyx.background.celery.tasks.build.tasks import _prune_prior_session_snapshots
+import pytest
+
 from onyx.db.models import Snapshot
+from onyx.server.features.build.session import sandbox_lifecycle
+from onyx.server.features.build.session.sandbox_lifecycle import (
+    persist_session_snapshot_keep_latest,
+)
 
 
 def _snap() -> Snapshot:
@@ -14,38 +19,81 @@ def _snap() -> Snapshot:
     )
 
 
-def test_prunes_blob_then_row_for_each_prior() -> None:
+def _db_session_with_priors(priors: list[Snapshot]) -> MagicMock:
     db_session = MagicMock()
-    snapshot_manager = MagicMock()
+    db_session.execute.return_value.scalars.return_value.all.return_value = priors
+    return db_session
+
+
+def _stub_snapshot_manager(
+    monkeypatch: pytest.MonkeyPatch, snapshot_manager: MagicMock
+) -> None:
+    monkeypatch.setattr(sandbox_lifecycle, "get_default_file_store", lambda: object())
+    monkeypatch.setattr(
+        sandbox_lifecycle, "SnapshotManager", lambda _file_store: snapshot_manager
+    )
+
+
+def test_prunes_blob_then_row_for_each_prior(monkeypatch: pytest.MonkeyPatch) -> None:
+    session_id = uuid4()
     priors = [_snap(), _snap(), _snap()]
+    db_session = _db_session_with_priors(priors)
+    snapshot_manager = MagicMock()
+    _stub_snapshot_manager(monkeypatch, snapshot_manager)
 
-    _prune_prior_session_snapshots(db_session, snapshot_manager, priors)
+    snapshot = persist_session_snapshot_keep_latest(
+        db_session=db_session,
+        session_id=session_id,
+        storage_path="snap/new.tar.gz",
+        size_bytes=123,
+    )
 
+    assert snapshot.session_id == session_id
+    assert snapshot.storage_path == "snap/new.tar.gz"
+    assert snapshot.size_bytes == 123
+    db_session.add.assert_called_once_with(snapshot)
+    db_session.commit.assert_called_once()
     assert snapshot_manager.delete_snapshot.call_count == 3
     snapshot_manager.delete_snapshot.assert_any_call(priors[0].storage_path)
     deleted_rows = [c.args[0] for c in db_session.delete.call_args_list]
     assert deleted_rows == priors
 
 
-def test_empty_priors_is_a_noop() -> None:
-    db_session = MagicMock()
+def test_empty_priors_is_a_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    db_session = _db_session_with_priors([])
     snapshot_manager = MagicMock()
+    _stub_snapshot_manager(monkeypatch, snapshot_manager)
 
-    _prune_prior_session_snapshots(db_session, snapshot_manager, [])
+    persist_session_snapshot_keep_latest(
+        db_session=db_session,
+        session_id=uuid4(),
+        storage_path="snap/new.tar.gz",
+        size_bytes=123,
+    )
 
     snapshot_manager.delete_snapshot.assert_not_called()
     db_session.delete.assert_not_called()
+    db_session.commit.assert_called_once()
 
 
-def test_blob_delete_failure_keeps_that_row_but_continues() -> None:
-    db_session = MagicMock()
-    snapshot_manager = MagicMock()
+def test_blob_delete_failure_keeps_that_row_but_continues(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     priors = [_snap(), _snap(), _snap()]
+    db_session = _db_session_with_priors(priors)
+    snapshot_manager = MagicMock()
+    _stub_snapshot_manager(monkeypatch, snapshot_manager)
     # Second blob delete fails; its row must be kept, the rest still pruned.
     snapshot_manager.delete_snapshot.side_effect = [None, RuntimeError("s3 down"), None]
 
-    _prune_prior_session_snapshots(db_session, snapshot_manager, priors)
+    persist_session_snapshot_keep_latest(
+        db_session=db_session,
+        session_id=uuid4(),
+        storage_path="snap/new.tar.gz",
+        size_bytes=123,
+    )
 
     deleted_rows = [c.args[0] for c in db_session.delete.call_args_list]
     assert deleted_rows == [priors[0], priors[2]]
     assert priors[1] not in deleted_rows
+    db_session.commit.assert_called_once()

--- a/backend/tests/unit/onyx/server/features/build/session/test_snapshot_api.py
+++ b/backend/tests/unit/onyx/server/features/build/session/test_snapshot_api.py
@@ -1,0 +1,119 @@
+"""Unit coverage for on-demand build-session snapshot endpoints."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.db.models import Sandbox
+from onyx.db.models import User
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.features.build.sandbox.models import SnapshotResult
+from onyx.server.features.build.session import api as session_api
+
+
+def _mock_owned_sandbox(monkeypatch: pytest.MonkeyPatch, sandbox_id: object) -> None:
+    monkeypatch.setattr(
+        session_api,
+        "_owned_session_sandbox",
+        lambda *_args, **_kwargs: cast(Sandbox, SimpleNamespace(id=sandbox_id)),
+    )
+
+
+def test_create_session_snapshot_persists_and_returns_json(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session_id = uuid4()
+    sandbox_id = uuid4()
+    user = cast(User, SimpleNamespace(id=uuid4()))
+    db_session = cast(Session, MagicMock())
+    sandbox_manager = MagicMock()
+    sandbox_manager.create_snapshot.return_value = SnapshotResult(
+        storage_path="snapshots/session.tar.gz",
+        size_bytes=123,
+    )
+    persist_snapshot = MagicMock()
+
+    _mock_owned_sandbox(monkeypatch, sandbox_id)
+    monkeypatch.setattr(session_api, "get_sandbox_manager", lambda: sandbox_manager)
+    monkeypatch.setattr(session_api, "get_current_tenant_id", lambda: "tenant-a")
+    monkeypatch.setattr(
+        session_api,
+        "persist_session_snapshot_keep_latest",
+        persist_snapshot,
+    )
+
+    response = session_api.create_session_snapshot(
+        session_id=session_id,
+        user=user,
+        db_session=db_session,
+    )
+
+    assert response.status_code == 200
+    assert json.loads(bytes(response.body)) == {
+        "storage_path": "snapshots/session.tar.gz",
+        "size_bytes": 123,
+    }
+    sandbox_manager.create_snapshot.assert_called_once_with(
+        sandbox_id=sandbox_id,
+        session_id=session_id,
+        tenant_id="tenant-a",
+    )
+    persist_snapshot.assert_called_once_with(
+        db_session=db_session,
+        session_id=session_id,
+        storage_path="snapshots/session.tar.gz",
+        size_bytes=123,
+    )
+
+
+def test_create_session_snapshot_maps_runtime_failure_to_5xx(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sandbox_manager = MagicMock()
+    sandbox_manager.create_snapshot.side_effect = RuntimeError("sidecar unavailable")
+
+    _mock_owned_sandbox(monkeypatch, uuid4())
+    monkeypatch.setattr(session_api, "get_sandbox_manager", lambda: sandbox_manager)
+    monkeypatch.setattr(session_api, "get_current_tenant_id", lambda: "tenant-a")
+
+    with pytest.raises(OnyxError) as exc_info:
+        session_api.create_session_snapshot(
+            session_id=uuid4(),
+            user=cast(User, SimpleNamespace(id=uuid4())),
+            db_session=cast(Session, MagicMock()),
+        )
+
+    assert exc_info.value.error_code == OnyxErrorCode.SERVICE_UNAVAILABLE
+    assert exc_info.value.status_code == 503
+
+
+def test_create_opencode_history_snapshot_maps_runtime_failure_to_5xx(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sandbox_manager = MagicMock()
+    sandbox_manager.supports_opencode_history_persistence = True
+    sandbox_manager.create_opencode_history_snapshot.side_effect = RuntimeError(
+        "file store unavailable"
+    )
+
+    _mock_owned_sandbox(monkeypatch, uuid4())
+    monkeypatch.setattr(session_api, "get_sandbox_manager", lambda: sandbox_manager)
+    monkeypatch.setattr(session_api, "get_current_tenant_id", lambda: "tenant-a")
+
+    with pytest.raises(OnyxError) as exc_info:
+        session_api.create_session_opencode_history_snapshot(
+            session_id=uuid4(),
+            user=cast(User, SimpleNamespace(id=uuid4())),
+            db_session=cast(Session, MagicMock()),
+        )
+
+    assert exc_info.value.error_code == OnyxErrorCode.SERVICE_UNAVAILABLE
+    assert exc_info.value.status_code == 503

--- a/backend/tests/unit/onyx/server/features/build/session/test_snapshot_api.py
+++ b/backend/tests/unit/onyx/server/features/build/session/test_snapshot_api.py
@@ -35,19 +35,20 @@ def test_create_session_snapshot_persists_and_returns_json(
     user = cast(User, SimpleNamespace(id=uuid4()))
     db_session = cast(Session, MagicMock())
     sandbox_manager = MagicMock()
-    sandbox_manager.create_snapshot.return_value = SnapshotResult(
-        storage_path="snapshots/session.tar.gz",
-        size_bytes=123,
+    create_snapshot = MagicMock(
+        return_value=SnapshotResult(
+            storage_path="snapshots/session.tar.gz",
+            size_bytes=123,
+        )
     )
-    persist_snapshot = MagicMock()
 
     _mock_owned_sandbox(monkeypatch, sandbox_id)
     monkeypatch.setattr(session_api, "get_sandbox_manager", lambda: sandbox_manager)
     monkeypatch.setattr(session_api, "get_current_tenant_id", lambda: "tenant-a")
     monkeypatch.setattr(
         session_api,
-        "persist_session_snapshot_keep_latest",
-        persist_snapshot,
+        "create_session_snapshot_keep_latest",
+        create_snapshot,
     )
 
     response = session_api.create_session_snapshot(
@@ -61,16 +62,12 @@ def test_create_session_snapshot_persists_and_returns_json(
         "storage_path": "snapshots/session.tar.gz",
         "size_bytes": 123,
     }
-    sandbox_manager.create_snapshot.assert_called_once_with(
+    create_snapshot.assert_called_once_with(
+        sandbox_manager=sandbox_manager,
+        db_session=db_session,
         sandbox_id=sandbox_id,
         session_id=session_id,
         tenant_id="tenant-a",
-    )
-    persist_snapshot.assert_called_once_with(
-        db_session=db_session,
-        session_id=session_id,
-        storage_path="snapshots/session.tar.gz",
-        size_bytes=123,
     )
 
 
@@ -78,11 +75,16 @@ def test_create_session_snapshot_maps_runtime_failure_to_5xx(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     sandbox_manager = MagicMock()
-    sandbox_manager.create_snapshot.side_effect = RuntimeError("sidecar unavailable")
+    create_snapshot = MagicMock(side_effect=RuntimeError("sidecar unavailable"))
 
     _mock_owned_sandbox(monkeypatch, uuid4())
     monkeypatch.setattr(session_api, "get_sandbox_manager", lambda: sandbox_manager)
     monkeypatch.setattr(session_api, "get_current_tenant_id", lambda: "tenant-a")
+    monkeypatch.setattr(
+        session_api,
+        "create_session_snapshot_keep_latest",
+        create_snapshot,
+    )
 
     with pytest.raises(OnyxError) as exc_info:
         session_api.create_session_snapshot(


### PR DESCRIPTION
## Description

Addresses unresolved review feedback from #12361 for the on-demand Craft snapshot endpoints:

- share keep-latest snapshot persistence between the API path and the background sweep
- keep DB row deletion behind the build DB helper while keeping FileStore pruning in feature orchestration
- remove `response_model=None` from the new snapshot route by returning explicit response objects
- map sandbox/runtime snapshot failures to `SERVICE_UNAVAILABLE` instead of `INVALID_INPUT`
- add focused unit coverage for snapshot route behavior and keep-latest pruning

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes keep-latest snapshot creation and pruning in `create_session_snapshot_keep_latest`, used by both the session API and idle-sandbox cleanup. Snapshot endpoints now return explicit JSON and map runtime failures to 503; pruning is concurrency-safe and covered by tests.

- **Refactors**
  - Introduced `create_session_snapshot_keep_latest(...)` in session lifecycle; API and Celery task now delegate to it.
  - Added `delete_snapshot__no_commit`; removed duplicate prune logic and direct `SnapshotManager` usage from API/task; API returns `JSONResponse`.

- **Bug Fixes**
  - Map runtime failures to `SERVICE_UNAVAILABLE` (503) for session snapshot and opencode-history; validation errors stay `INVALID_INPUT`.
  - Snapshot route returns explicit JSON (`storage_path`, `size_bytes`) and 204 when there’s nothing to snapshot.
  - Preserve snapshots created concurrently during archive; only prune those captured before snapshot starts.
  - Stabilized background snapshot failure test with per-session outcomes in `StubSandboxManager`.

<sup>Written for commit ea4bf2774ecf6ffb213c4afd8ed687bb041a2036. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

