### PR TITLE
refactor(indexing): require csv_file_id for TabularSection

### DIFF
--- a/backend/onyx/background/celery/celery_utils.py
+++ b/backend/onyx/background/celery/celery_utils.py
@@ -146,10 +146,9 @@ def extract_ids_from_runnable_connector(
     all_raw_id_to_parent: dict[str, str | None] = {}
     all_hierarchy_nodes: list[HierarchyNode] = []
 
-    # Non-slim connectors run full extraction here, and tabular sections need a
-    # staging callback to be produced at all. This path only uses the doc ids, so
-    # stage to a tracked list and reap it in the finally — there's no index
-    # attempt for the standard staging reapers to key on.
+    # Pruning only needs doc ids, but non-slim tabular connectors won't yield a
+    # doc without staging its CSV. Stage to a tracked list and reap in the finally
+    # — no index attempt for the standard staging reapers to key on.
     staging_callback, staged_csv_ids = build_tracking_raw_file_callback(
         metadata={
             "context": "pruning-id-enumeration",

--- a/backend/onyx/background/celery/celery_utils.py
+++ b/backend/onyx/background/celery/celery_utils.py
@@ -27,6 +27,8 @@ from onyx.connectors.models import ConnectorFailure
 from onyx.connectors.models import Document
 from onyx.connectors.models import HierarchyNode
 from onyx.connectors.models import SlimDocument
+from onyx.file_store.staging import build_tracking_raw_file_callback
+from onyx.file_store.staging import delete_files_best_effort
 from onyx.httpx.httpx_pool import HttpxPool
 from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
 from onyx.server.metrics.pruning_metrics import inc_pruning_rate_limit_error
@@ -144,6 +146,18 @@ def extract_ids_from_runnable_connector(
     all_raw_id_to_parent: dict[str, str | None] = {}
     all_hierarchy_nodes: list[HierarchyNode] = []
 
+    # Non-slim connectors run full extraction here, and tabular sections need a
+    # staging callback to be produced at all. This path only uses the doc ids, so
+    # stage to a tracked list and reap it in the finally — there's no index
+    # attempt for the standard staging reapers to key on.
+    staging_callback, staged_csv_ids = build_tracking_raw_file_callback(
+        metadata={
+            "context": "pruning-id-enumeration",
+            "connector_type": connector_type,
+        }
+    )
+    runnable_connector.set_raw_file_callback(staging_callback)
+
     # Sequence (covariant) lets all the specific list[...] iterator types unify here
     raw_batch_generator: (
         Iterator[Sequence[Document | SlimDocument | HierarchyNode | ConnectorFailure]]
@@ -209,6 +223,10 @@ def extract_ids_from_runnable_connector(
             inc_pruning_rate_limit_error(connector_type)
         raise
     finally:
+        delete_files_best_effort(
+            staged_csv_ids,
+            context=f"pruning-id-enumeration cleanup ({connector_type})",
+        )
         observe_pruning_enumeration_duration(
             time.monotonic() - enumeration_start, connector_type
         )

--- a/backend/onyx/background/celery/tasks/user_file_processing/tasks.py
+++ b/backend/onyx/background/celery/tasks/user_file_processing/tasks.py
@@ -37,6 +37,7 @@ from onyx.configs.constants import USER_FILE_PROJECT_SYNC_MAX_QUEUE_DEPTH
 from onyx.connectors.file.connector import LocalFileConnector
 from onyx.connectors.models import Document
 from onyx.connectors.models import HierarchyNode
+from onyx.connectors.models import TabularSection
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import UserFileStatus
 from onyx.db.models import UserFile
@@ -273,10 +274,22 @@ def _process_user_file_without_vector_db(
 
     user_file_uuid = _as_uuid(user_file_id)
 
-    # Combine section text from all document sections
-    combined_text = " ".join(
-        section.text for doc in documents for section in doc.sections if section.text
-    )
+    # Combine section text from all document sections. Tabular sections are
+    # file-backed (no inline text), so read their staged CSV from the file store.
+    file_store = get_default_file_store()
+    text_parts: list[str] = []
+    for doc in documents:
+        for section in doc.sections:
+            if isinstance(section, TabularSection):
+                with file_store.read_file(
+                    section.csv_file_id, use_tempfile=True
+                ) as raw:
+                    csv_text = raw.read().decode("utf-8", errors="replace").strip()
+                if csv_text:
+                    text_parts.append(csv_text)
+            elif section.text:
+                text_parts.append(section.text)
+    combined_text = " ".join(text_parts)
 
     # Compute token count using the user's default LLM tokenizer
     try:

--- a/backend/onyx/background/celery/tasks/user_file_processing/tasks.py
+++ b/backend/onyx/background/celery/tasks/user_file_processing/tasks.py
@@ -275,16 +275,12 @@ def _process_user_file_without_vector_db(
     user_file_uuid = _as_uuid(user_file_id)
 
     # Combine section text from all document sections. Tabular sections are
-    # file-backed (no inline text), so read their staged CSV from the file store.
-    file_store = get_default_file_store()
+    # file-backed; read their staged CSV on demand.
     text_parts: list[str] = []
     for doc in documents:
         for section in doc.sections:
             if isinstance(section, TabularSection):
-                with file_store.read_file(
-                    section.csv_file_id, use_tempfile=True
-                ) as raw:
-                    csv_text = raw.read().decode("utf-8", errors="replace").strip()
+                csv_text = section.read_csv_text().strip()
                 if csv_text:
                     text_parts.append(csv_text)
             elif section.text:

--- a/backend/onyx/background/celery/tasks/user_file_processing/tasks.py
+++ b/backend/onyx/background/celery/tasks/user_file_processing/tasks.py
@@ -46,6 +46,8 @@ from onyx.db.user_file import fetch_user_files_with_access_relationships
 from onyx.document_index.factory import get_all_document_indices
 from onyx.document_index.interfaces_new import MetadataUpdateRequest
 from onyx.file_store.file_store import get_default_file_store
+from onyx.file_store.staging import build_tracking_raw_file_callback
+from onyx.file_store.staging import delete_files_best_effort
 from onyx.file_store.utils import store_user_file_plaintext
 from onyx.file_store.utils import user_file_id_to_plaintext_file_name
 from onyx.httpx.httpx_pool import HttpxPool
@@ -440,6 +442,14 @@ def process_user_file_impl(
         )
         connector.load_credentials({})
 
+        # User files aren't attempt-scoped, so the docfetching staging reapers
+        # don't cover them. Track CSVs staged for tabular sections and reap them
+        # ourselves once indexing (which reads them) has run.
+        staging_callback, staged_csv_ids = build_tracking_raw_file_callback(
+            metadata={"user_file_id": str(user_file_id), "tenant_id": tenant_id}
+        )
+        connector.set_raw_file_callback(staging_callback)
+
         try:
             for batch in connector.load_from_state():
                 documents.extend(
@@ -476,6 +486,11 @@ def process_user_file_impl(
                     db_session.add(current_user_file)
                     db_session.commit()
             return
+        finally:
+            delete_files_best_effort(
+                staged_csv_ids,
+                context=f"user-file tabular staging cleanup uf={user_file_id}",
+            )
 
         elapsed = time.monotonic() - start
         task_logger.info(

--- a/backend/onyx/background/celery/tasks/user_file_processing/tasks.py
+++ b/backend/onyx/background/celery/tasks/user_file_processing/tasks.py
@@ -37,7 +37,6 @@ from onyx.configs.constants import USER_FILE_PROJECT_SYNC_MAX_QUEUE_DEPTH
 from onyx.connectors.file.connector import LocalFileConnector
 from onyx.connectors.models import Document
 from onyx.connectors.models import HierarchyNode
-from onyx.connectors.models import TabularSection
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import UserFileStatus
 from onyx.db.models import UserFile
@@ -275,16 +274,13 @@ def _process_user_file_without_vector_db(
     user_file_uuid = _as_uuid(user_file_id)
 
     # Combine section text from all document sections. Tabular sections are
-    # file-backed; read their staged CSV on demand.
+    # file-backed and materialize their staged CSV on demand.
     text_parts: list[str] = []
     for doc in documents:
         for section in doc.sections:
-            if isinstance(section, TabularSection):
-                csv_text = section.read_csv_text().strip()
-                if csv_text:
-                    text_parts.append(csv_text)
-            elif section.text:
-                text_parts.append(section.text)
+            text = section.materialize_text()
+            if text:
+                text_parts.append(text)
     combined_text = " ".join(text_parts)
 
     # Compute token count using the user's default LLM tokenizer

--- a/backend/onyx/background/indexing/run_targeted_reindex.py
+++ b/backend/onyx/background/indexing/run_targeted_reindex.py
@@ -39,6 +39,7 @@ from onyx.db.models import IndexAttempt
 from onyx.db.models import TargetedReindexJobTarget
 from onyx.db.targeted_reindex import targets_to_connector_failures
 from onyx.document_index.factory import get_all_document_indices
+from onyx.file_store.staging import build_raw_file_callback
 from onyx.httpx.httpx_pool import HttpxPool
 from onyx.indexing.adapters.document_indexing_adapter import (
     DocumentIndexingBatchAdapter,
@@ -263,6 +264,16 @@ def process_targets_for_cc_pair(
 
     include_permissions = cc_pair.access_type == AccessType.SYNC
     failures = targets_to_connector_failures(targets, db_session)
+
+    # Tabular sections stage their CSV via this callback. Tag it with one of the
+    # cc_pair's attempts so the standard staging reaper reclaims the files.
+    connector.set_raw_file_callback(
+        build_raw_file_callback(
+            index_attempt_id=cc_pair_attempts[0].id,
+            cc_pair_id=cc_pair_id,
+            tenant_id=tenant_id,
+        )
+    )
 
     # Materialize the connector output once. MAX_TARGETS_PER_REQUEST caps
     # the universe at 100 docs total per job, so this is bounded.

--- a/backend/onyx/background/indexing/run_targeted_reindex.py
+++ b/backend/onyx/background/indexing/run_targeted_reindex.py
@@ -39,7 +39,8 @@ from onyx.db.models import IndexAttempt
 from onyx.db.models import TargetedReindexJobTarget
 from onyx.db.targeted_reindex import targets_to_connector_failures
 from onyx.document_index.factory import get_all_document_indices
-from onyx.file_store.staging import build_raw_file_callback
+from onyx.file_store.staging import build_tracking_raw_file_callback
+from onyx.file_store.staging import delete_files_best_effort
 from onyx.httpx.httpx_pool import HttpxPool
 from onyx.indexing.adapters.document_indexing_adapter import (
     DocumentIndexingBatchAdapter,
@@ -265,63 +266,66 @@ def process_targets_for_cc_pair(
     include_permissions = cc_pair.access_type == AccessType.SYNC
     failures = targets_to_connector_failures(targets, db_session)
 
-    # Tabular sections stage their CSV via this callback. Tag it with one of the
-    # cc_pair's attempts so the standard staging reaper reclaims the files.
-    connector.set_raw_file_callback(
-        build_raw_file_callback(
-            index_attempt_id=cc_pair_attempts[0].id,
-            cc_pair_id=cc_pair_id,
-            tenant_id=tenant_id,
-        )
+    # Tabular sections stage their CSV via this callback; this path has no
+    # attempt-end reaper, so track the staged ids and reap them in the finally.
+    staging_callback, staged_csv_ids = build_tracking_raw_file_callback(
+        metadata={"cc_pair_id": str(cc_pair_id), "tenant_id": tenant_id}
     )
+    connector.set_raw_file_callback(staging_callback)
 
-    # Materialize the connector output once. MAX_TARGETS_PER_REQUEST caps
-    # the universe at 100 docs total per job, so this is bounded.
     docs: list[Document] = []
-    hierarchy_nodes: list[HierarchyNode] = []
     failed_from_connector: set[str] = set()
-    for item in connector.reindex(
-        errors=failures, include_permissions=include_permissions
-    ):
-        if isinstance(item, ConnectorFailure):
-            if item.failed_document is not None:
-                failed_from_connector.add(item.failed_document.document_id)
-            continue
-        if isinstance(item, Document):
-            docs.append(item)
-            continue
-        if isinstance(item, HierarchyNode):
-            hierarchy_nodes.append(item)
-            continue
-
-    if hierarchy_nodes:
-        _persist_hierarchy_nodes(
-            nodes=hierarchy_nodes,
-            cc_pair=cc_pair,
-            tenant_id=tenant_id,
-            db_session=db_session,
-        )
-        logger.debug(
-            "Persisted and cached %s hierarchy nodes for cc_pair_id=%s",
-            len(hierarchy_nodes),
-            cc_pair_id,
-        )
-
-    # Per-attempt pipeline run. Each attempt commits to its own
-    # search_settings's document_indices.
     landed_overall: set[str] = set()
     failed_pipeline_overall: set[str] = set()
-    for attempt in cc_pair_attempts:
-        for batch_num, batch in enumerate(chunked(docs, INDEX_BATCH_SIZE)):
-            landed, failed = _flush_batch(
-                documents=list(batch),
-                attempt=attempt,
+    try:
+        # Materialize the connector output once. MAX_TARGETS_PER_REQUEST caps
+        # the universe at 100 docs total per job, so this is bounded.
+        hierarchy_nodes: list[HierarchyNode] = []
+        for item in connector.reindex(
+            errors=failures, include_permissions=include_permissions
+        ):
+            if isinstance(item, ConnectorFailure):
+                if item.failed_document is not None:
+                    failed_from_connector.add(item.failed_document.document_id)
+                continue
+            if isinstance(item, Document):
+                docs.append(item)
+                continue
+            if isinstance(item, HierarchyNode):
+                hierarchy_nodes.append(item)
+                continue
+
+        if hierarchy_nodes:
+            _persist_hierarchy_nodes(
+                nodes=hierarchy_nodes,
+                cc_pair=cc_pair,
                 tenant_id=tenant_id,
                 db_session=db_session,
-                batch_num=batch_num,
             )
-            landed_overall |= landed
-            failed_pipeline_overall |= failed
+            logger.debug(
+                "Persisted and cached %s hierarchy nodes for cc_pair_id=%s",
+                len(hierarchy_nodes),
+                cc_pair_id,
+            )
+
+        # Per-attempt pipeline run. Each attempt commits to its own
+        # search_settings's document_indices.
+        for attempt in cc_pair_attempts:
+            for batch_num, batch in enumerate(chunked(docs, INDEX_BATCH_SIZE)):
+                landed, failed = _flush_batch(
+                    documents=list(batch),
+                    attempt=attempt,
+                    tenant_id=tenant_id,
+                    db_session=db_session,
+                    batch_num=batch_num,
+                )
+                landed_overall |= landed
+                failed_pipeline_overall |= failed
+    finally:
+        delete_files_best_effort(
+            staged_csv_ids,
+            context=f"targeted-reindex staging cleanup cc_pair={cc_pair_id}",
+        )
 
     # Conservative landing: a doc is only "landed" if some attempt
     # accepted it AND no attempt or upstream phase failed it. The set

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -1386,13 +1386,6 @@ MAX_XLSX_CELLS_PER_SHEET = max(
     0, int(os.environ.get("MAX_XLSX_CELLS_PER_SHEET") or 10_000_000)
 )
 
-# A worksheet whose uncompressed XML exceeds this is streamed to a file-backed
-# TabularSection (CSV staged in the file store) instead of an in-memory string,
-# so a huge sheet stays off the worker heap rather than being truncated.
-XLSX_STREAM_SHEET_BYTES = max(
-    0, int(os.environ.get("XLSX_STREAM_SHEET_BYTES") or 50 * 1024 * 1024)
-)
-
 # PDF text extraction runs isolated (a malformed PDF can make PDFium hard-abort
 # or hang); this is the timeout before the subprocess is killed and pypdf runs.
 PDF_TEXT_EXTRACTION_TIMEOUT_SECONDS = float(

--- a/backend/onyx/connectors/blob/connector.py
+++ b/backend/onyx/connectors/blob/connector.py
@@ -31,9 +31,6 @@ from onyx.connectors.cross_connector_utils.tabular_section_utils import (
     extract_and_stage_tabular_file,
 )
 from onyx.connectors.cross_connector_utils.tabular_section_utils import is_tabular_file
-from onyx.connectors.cross_connector_utils.tabular_section_utils import (
-    tabular_file_to_sections,
-)
 from onyx.connectors.exceptions import ConnectorValidationError
 from onyx.connectors.exceptions import CredentialExpiredError
 from onyx.connectors.exceptions import InsufficientPermissionsError
@@ -506,19 +503,20 @@ class BlobStorageConnector(LoadConnector, PollConnector):
                             tabular_sections = result.sections
                             staged_file_id = result.staged_file_id
                         else:
-                            tabular_sections = tabular_file_to_sections(
-                                BytesIO(downloaded_file),
-                                file_name=file_name,
-                                link=link,
+                            logger.warning(
+                                "Skipping tabular file %s because raw_file_callback is not set",
+                                file_name,
                             )
+                            continue
+                        if not tabular_sections:
+                            logger.warning(
+                                "No content extracted from tabular file %s", file_name
+                            )
+                            continue
                         batch.append(
                             Document(
                                 id=f"{self.bucket_type}:{self.bucket_name}:{key}",
-                                sections=(
-                                    tabular_sections
-                                    if tabular_sections
-                                    else [TabularSection(link=link, text="")]
-                                ),
+                                sections=tabular_sections,
                                 source=DocumentSource(self.bucket_type.value),
                                 semantic_identifier=file_name,
                                 doc_updated_at=last_modified,

--- a/backend/onyx/connectors/braintrust/connector.py
+++ b/backend/onyx/connectors/braintrust/connector.py
@@ -30,7 +30,10 @@ from onyx.connectors.models import Document
 from onyx.connectors.models import EntityFailure
 from onyx.connectors.models import TabularSection
 from onyx.connectors.models import TextSection
+from onyx.utils.logger import setup_logger
 from onyx.utils.retry_wrapper import retry_builder
+
+logger = setup_logger()
 
 _BASE_URL = "https://api.braintrust.dev"
 _API_KEY = "braintrust_api_key"
@@ -349,15 +352,23 @@ class BraintrustConnector(CheckpointedConnector[BraintrustCheckpoint]):
         if len(rows) >= _MAX_TABLE_ROWS:
             lines.append(f"Table truncated to the {_MAX_TABLE_ROWS} most recent rows.")
         csv_text = _rows_to_csv(_DATASET_COLUMNS, rows)
+        csv_file_id = self._stage_csv(csv_text)
+        sections: list[TextSection | TabularSection] = [
+            TextSection(text="\n".join(lines))
+        ]
+        if csv_file_id is None:
+            logger.warning(
+                "Skipping tabular section for Braintrust dataset %s because raw_file_callback is not set",
+                ref.id,
+            )
+        else:
+            sections.append(TabularSection(csv_file_id=csv_file_id, link=""))
         return Document(
             id=f"braintrust:ds:{ref.id}",
             source=DocumentSource.BRAINTRUST,
             title=f"Braintrust dataset: {ref.name}",
             semantic_identifier=f"Dataset: {ref.name}",
-            sections=[
-                TextSection(text="\n".join(lines)),
-                TabularSection(text=csv_text, link=""),
-            ],
+            sections=sections,
             metadata=_coerce_metadata(
                 {
                     "object_type": "dataset",
@@ -367,7 +378,7 @@ class BraintrustConnector(CheckpointedConnector[BraintrustCheckpoint]):
                 }
             ),
             doc_updated_at=_parse_time(ref.created),
-            file_id=self._stage_csv(csv_text),
+            file_id=csv_file_id,
         )
 
     def _experiment_summary_lines(
@@ -441,10 +452,19 @@ class BraintrustConnector(CheckpointedConnector[BraintrustCheckpoint]):
                     f"Table truncated to the {_MAX_TABLE_ROWS} most recent rows."
                 )
             csv_text = _rows_to_csv(columns, flat_rows)
-            sections.append(
-                TabularSection(text=csv_text, link=summary.get("experiment_url") or "")
-            )
             file_id = self._stage_csv(csv_text)
+            if file_id is None:
+                logger.warning(
+                    "Skipping tabular section for Braintrust experiment %s because raw_file_callback is not set",
+                    ref.id,
+                )
+            else:
+                sections.append(
+                    TabularSection(
+                        csv_file_id=file_id,
+                        link=summary.get("experiment_url") or "",
+                    )
+                )
         sections.insert(
             0,
             TextSection(text="\n".join(lines), link=summary.get("experiment_url")),

--- a/backend/onyx/connectors/cross_connector_utils/tabular_section_utils.py
+++ b/backend/onyx/connectors/cross_connector_utils/tabular_section_utils.py
@@ -4,12 +4,9 @@ from typing import IO
 
 from pydantic import BaseModel
 
-from onyx.configs.app_configs import XLSX_STREAM_SHEET_BYTES
 from onyx.connectors.models import TabularSection
 from onyx.file_processing.extract_file_text import file_io_to_text
-from onyx.file_processing.extract_file_text import stage_or_inline_xlsx_sheets
-from onyx.file_processing.extract_file_text import xlsx_has_large_sheet
-from onyx.file_processing.extract_file_text import xlsx_sheet_extraction
+from onyx.file_processing.extract_file_text import stage_xlsx_sheets
 from onyx.file_processing.file_types import OnyxFileExtensions
 from onyx.file_store.staging import RawFileCallback
 from onyx.utils.logger import setup_logger
@@ -37,47 +34,17 @@ def _tsv_to_csv(tsv_text: str) -> str:
     return out.getvalue().rstrip("\n")
 
 
-def _xlsx_to_streamed_sections(
-    file: IO[bytes],
-    file_name: str,
-    link: str,
-    raw_file_callback: RawFileCallback,
-) -> list[TabularSection]:
-    """Render each worksheet's CSV with bounded memory: small sheets stay inline
-    (keeping their descriptor chunks downstream); sheets larger than
-    `XLSX_STREAM_SHEET_BYTES` are file-backed in the file store so a huge sheet
-    never lands on the worker heap."""
-    return [
-        TabularSection(
-            link=link or file_name,
-            text=sheet.text,
-            csv_file_id=sheet.csv_file_id,
-            heading=f"{file_name} :: {sheet.title}",
-        )
-        for sheet in stage_or_inline_xlsx_sheets(
-            file,
-            raw_file_callback,
-            XLSX_STREAM_SHEET_BYTES,
-            file_name=file_name,
-        )
-    ]
-
-
 def tabular_file_to_sections(
     file: IO[bytes],
     file_name: str,
+    stage: RawFileCallback,
     link: str = "",
-    raw_file_callback: RawFileCallback | None = None,
 ) -> list[TabularSection]:
     """Convert a tabular file into one or more TabularSections.
 
-    - .xlsx → one TabularSection per non-empty sheet. A workbook with a very
-      large sheet (and a `raw_file_callback`) is streamed per sheet — small
-      sheets stay inline, oversized sheets are file-backed; otherwise the whole
-      workbook is rendered inline.
-    - .csv / .tsv → a single TabularSection containing the full decoded file.
-
-    Returns an empty list when the file yields no extractable content.
+    - .xlsx → one staged TabularSection per non-empty sheet.
+    - .csv / .tsv → one staged TabularSection for the whole file.
+    - empty input → `[]`.
     """
     lowered = file_name.lower()
 
@@ -85,21 +52,16 @@ def tabular_file_to_sections(
         raise ValueError(f"{file_name!r} is not a tabular file")
 
     if lowered.endswith(tuple(OnyxFileExtensions.SPREADSHEET_EXTENSIONS)):
-        if raw_file_callback is not None and xlsx_has_large_sheet(file):
-            return _xlsx_to_streamed_sections(
-                file,
-                file_name=file_name,
-                link=link,
-                raw_file_callback=raw_file_callback,
-            )
         return [
             TabularSection(
+                csv_file_id=sheet.csv_file_id,
                 link=link or file_name,
-                text=csv_text,
-                heading=f"{file_name} :: {sheet_title}",
+                heading=f"{file_name} :: {sheet.title}",
             )
-            for csv_text, sheet_title in xlsx_sheet_extraction(
-                file, file_name=file_name
+            for sheet in stage_xlsx_sheets(
+                file,
+                stage,
+                file_name=file_name,
             )
         ]
 
@@ -113,7 +75,8 @@ def tabular_file_to_sections(
         return []
     if lowered.endswith(".tsv"):
         text = _tsv_to_csv(text)
-    return [TabularSection(link=link or file_name, text=text)]
+    csv_file_id = stage(io.BytesIO(text.encode("utf-8")), "text/csv")
+    return [TabularSection(csv_file_id=csv_file_id, link=link or file_name)]
 
 
 def extract_and_stage_tabular_file(
@@ -127,8 +90,8 @@ def extract_and_stage_tabular_file(
     sections = tabular_file_to_sections(
         file=file,
         file_name=file_name,
+        stage=raw_file_callback,
         link=link,
-        raw_file_callback=raw_file_callback,
     )
     # rewind so the callback can re-read what extraction consumed
     file.seek(0)

--- a/backend/onyx/connectors/drupal_wiki/connector.py
+++ b/backend/onyx/connectors/drupal_wiki/connector.py
@@ -284,11 +284,18 @@ class DrupalWikiConnector(
             # Tabular attachments (xlsx, csv, tsv) — produce
             # TabularSections instead of a flat TextSection.
             if is_tabular_file(file_name):
+                if self.raw_file_callback is None:
+                    logger.warning(
+                        "Skipping tabular attachment %s because raw_file_callback is not set",
+                        file_name,
+                    )
+                    return [], f"No content extracted from tabular file {file_name}"
                 try:
                     sections.extend(
                         tabular_file_to_sections(
                             BytesIO(raw_bytes),
                             file_name=file_name,
+                            stage=self.raw_file_callback,
                             link=download_url,
                         )
                     )

--- a/backend/onyx/connectors/file/connector.py
+++ b/backend/onyx/connectors/file/connector.py
@@ -29,6 +29,7 @@ from onyx.file_processing.extract_file_text import get_file_ext
 from onyx.file_processing.file_types import OnyxFileExtensions
 from onyx.file_processing.image_utils import store_image_and_create_section
 from onyx.file_store.file_store import get_default_file_store
+from onyx.file_store.staging import RawFileCallback
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -84,6 +85,7 @@ def _process_file(
     metadata: dict[str, Any] | None,
     pdf_pass: str | None,
     file_type: str | None,
+    stage: RawFileCallback | None,
 ) -> list[Document]:
     """
     Process a file and return a list of Documents.
@@ -201,6 +203,12 @@ def _process_file(
     doc_file_id = None
     if is_tabular_file(file_name):
         doc_file_id = file_id
+        if stage is None:
+            logger.warning(
+                "Skipping tabular file %s because raw_file_callback is not set",
+                file_name,
+            )
+            return []
 
         # Produce TabularSections
         lowered_name = file_name.lower()
@@ -216,6 +224,7 @@ def _process_file(
                 tabular_file_to_sections(
                     file=tabular_source,
                     file_name=file_name,
+                    stage=stage,
                     link=link or "",
                 )
             )
@@ -354,6 +363,7 @@ class LocalFileConnector(LoadConnector):
                 metadata=metadata,
                 pdf_pass=self.pdf_pass,
                 file_type=file_record.file_type,
+                stage=self.raw_file_callback,
             )
             documents.extend(new_docs)
 

--- a/backend/onyx/connectors/google_drive/doc_conversion.py
+++ b/backend/onyx/connectors/google_drive/doc_conversion.py
@@ -19,9 +19,6 @@ from onyx.connectors.cross_connector_utils.tabular_section_utils import (
     extract_and_stage_tabular_file,
 )
 from onyx.connectors.cross_connector_utils.tabular_section_utils import is_tabular_file
-from onyx.connectors.cross_connector_utils.tabular_section_utils import (
-    tabular_file_to_sections,
-)
 from onyx.connectors.google_drive.constants import DRIVE_FOLDER_TYPE
 from onyx.connectors.google_drive.constants import DRIVE_SHORTCUT_TYPE
 from onyx.connectors.google_drive.file_retrieval import add_drive_resource_key_header
@@ -348,11 +345,11 @@ def _download_and_extract_sections_basic(
             tabular_sections = result.sections
             staged_file_id = result.staged_file_id
         else:
-            tabular_sections = tabular_file_to_sections(
-                io.BytesIO(raw_bytes),
-                file_name=name,
-                link=link,
+            logger.warning(
+                "Skipping tabular file %s because raw_file_callback is not set",
+                name,
             )
+            return FileExtractionResult(sections=[], staged_file_id=None)
         sections: list[TextSection | ImageSection | TabularSection] = list(
             tabular_sections
         )

--- a/backend/onyx/connectors/models.py
+++ b/backend/onyx/connectors/models.py
@@ -54,6 +54,11 @@ class Section(BaseModel):
     image_file_id: str | None = None
     heading: str | None = None
 
+    def materialize_text(self) -> str:
+        """This section's content as text. Subclasses with non-inline content
+        (e.g. file-backed tabular data) override this to fetch it on demand."""
+        return self.text or ""
+
 
 class TextSection(Section):
     """Section containing text content"""
@@ -87,12 +92,10 @@ class TabularSection(Section):
     def __sizeof__(self) -> int:
         return sys.getsizeof(self.csv_file_id) + sys.getsizeof(self.link)
 
-    def read_csv_text(self) -> str:
-        """Full staged-CSV content as text, read from the file store on demand.
-
-        The indexing path never calls this — it streams the CSV row-by-row at
-        chunk time so a large sheet stays off the heap. Use only for
-        non-streaming consumers (e.g. the no-vector-db plaintext path)."""
+    def materialize_text(self) -> str:
+        """Read the staged CSV from the file store on demand. The indexing path
+        streams the CSV row by row at chunk time and does not call this; only
+        non-streaming consumers (the no-vector-db plaintext path) do."""
         from onyx.file_store.file_store import get_default_file_store
 
         with get_default_file_store().read_file(

--- a/backend/onyx/connectors/models.py
+++ b/backend/onyx/connectors/models.py
@@ -76,13 +76,9 @@ class ImageSection(Section):
 
 
 class TabularSection(Section):
-    """Section containing tabular data (csv/tsv content, or one sheet of an
-    xlsx workbook rendered as CSV).
-
-    The CSV is always staged in the file store and referenced by `csv_file_id`,
-    streamed back a row at a time at chunk time, so a large sheet never sits on
-    the worker heap.
-    """
+    """Tabular data — a csv/tsv file or one xlsx sheet rendered as CSV. The CSV is
+    always staged in the file store (`csv_file_id`) and streamed a row at a time
+    at chunk time, so a large sheet never sits on the worker heap."""
 
     type: Literal[SectionType.TABULAR] = SectionType.TABULAR
     csv_file_id: str  # file store id of the staged CSV

--- a/backend/onyx/connectors/models.py
+++ b/backend/onyx/connectors/models.py
@@ -76,33 +76,20 @@ class ImageSection(Section):
 
 
 class TabularSection(Section):
-    """Section containing tabular data (csv/tsv content, or one sheet of
-    an xlsx workbook rendered as CSV).
+    """Section containing tabular data (csv/tsv content, or one sheet of an
+    xlsx workbook rendered as CSV).
 
-    Exactly one of `text` (inline CSV) or `csv_file_id` (CSV staged in the file
-    store, streamed at chunk time) carries the content. The file-backed form
-    keeps a large sheet off the worker heap end to end.
+    The CSV is always staged in the file store and referenced by `csv_file_id`,
+    streamed back a row at a time at chunk time, so a large sheet never sits on
+    the worker heap.
     """
 
     type: Literal[SectionType.TABULAR] = SectionType.TABULAR
-    text: str | None = None  # inline CSV; None when file-backed
-    csv_file_id: str | None = None  # file store id of staged CSV; None when inline
+    csv_file_id: str  # file store id of the staged CSV
     link: str
 
-    @model_validator(mode="after")
-    def _exactly_one_source(self) -> "TabularSection":
-        if (self.text is None) == (self.csv_file_id is None):
-            raise ValueError(
-                "TabularSection requires exactly one of `text` or `csv_file_id`"
-            )
-        return self
-
     def __sizeof__(self) -> int:
-        return (
-            sys.getsizeof(self.text)
-            + sys.getsizeof(self.csv_file_id)
-            + sys.getsizeof(self.link)
-        )
+        return sys.getsizeof(self.csv_file_id) + sys.getsizeof(self.link)
 
 
 class BasicExpertInfo(BaseModel):

--- a/backend/onyx/connectors/models.py
+++ b/backend/onyx/connectors/models.py
@@ -87,6 +87,19 @@ class TabularSection(Section):
     def __sizeof__(self) -> int:
         return sys.getsizeof(self.csv_file_id) + sys.getsizeof(self.link)
 
+    def read_csv_text(self) -> str:
+        """Full staged-CSV content as text, read from the file store on demand.
+
+        The indexing path never calls this — it streams the CSV row-by-row at
+        chunk time so a large sheet stays off the heap. Use only for
+        non-streaming consumers (e.g. the no-vector-db plaintext path)."""
+        from onyx.file_store.file_store import get_default_file_store
+
+        with get_default_file_store().read_file(
+            self.csv_file_id, use_tempfile=True
+        ) as raw:
+            return raw.read().decode("utf-8", errors="replace")
+
 
 class BasicExpertInfo(BaseModel):
     """Basic Information for the owner of a document, any of the fields can be left as None

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -48,9 +48,6 @@ from onyx.connectors.cross_connector_utils.tabular_section_utils import (
     extract_and_stage_tabular_file,
 )
 from onyx.connectors.cross_connector_utils.tabular_section_utils import is_tabular_file
-from onyx.connectors.cross_connector_utils.tabular_section_utils import (
-    tabular_file_to_sections,
-)
 from onyx.connectors.exceptions import ConnectorValidationError
 from onyx.connectors.interfaces import CheckpointedConnectorWithPermSync
 from onyx.connectors.interfaces import CheckpointOutput
@@ -894,12 +891,9 @@ def _convert_driveitem_to_document_with_permissions(
                 sections.extend(result.sections)
                 staged_file_id = result.staged_file_id
             else:
-                sections.extend(
-                    tabular_file_to_sections(
-                        file=io.BytesIO(content_bytes),
-                        file_name=driveitem.name,
-                        link=driveitem.web_url or "",
-                    )
+                logger.warning(
+                    "Skipping tabular file %s because raw_file_callback is not set",
+                    driveitem.name,
                 )
         except Exception as e:
             logger.warning(

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -879,25 +879,29 @@ def _convert_driveitem_to_document_with_permissions(
         image_section.link = driveitem.web_url
         sections.append(image_section)
     elif is_tabular_file(driveitem.name):
+        # Tabular content is always staged via the callback; without it we can't
+        # produce the section, so fail the item rather than emit an empty-section
+        # Document that could overwrite indexed content.
+        if raw_file_callback is None:
+            return _create_document_failure(
+                driveitem,
+                f"raw_file_callback not set; cannot stage tabular file {driveitem.name}",
+            )
         try:
-            if raw_file_callback is not None:
-                result = extract_and_stage_tabular_file(
-                    file=io.BytesIO(content_bytes),
-                    file_name=driveitem.name,
-                    content_type=mime_type or "application/octet-stream",
-                    raw_file_callback=raw_file_callback,
-                    link=driveitem.web_url or "",
-                )
-                sections.extend(result.sections)
-                staged_file_id = result.staged_file_id
-            else:
-                logger.warning(
-                    "Skipping tabular file %s because raw_file_callback is not set",
-                    driveitem.name,
-                )
+            result = extract_and_stage_tabular_file(
+                file=io.BytesIO(content_bytes),
+                file_name=driveitem.name,
+                content_type=mime_type or "application/octet-stream",
+                raw_file_callback=raw_file_callback,
+                link=driveitem.web_url or "",
+            )
+            sections.extend(result.sections)
+            staged_file_id = result.staged_file_id
         except Exception as e:
-            logger.warning(
-                "Failed to extract tabular sections for '%s': %s", driveitem.name, e
+            return _create_document_failure(
+                driveitem,
+                f"Failed to extract tabular sections for {driveitem.name}: {e}",
+                e,
             )
     else:
         extraction_result = extract_text_and_images(

--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -741,10 +741,9 @@ def stage_xlsx_sheets(
     stage: Callable[[IO[bytes], str], str],
     file_name: str = "",
 ) -> list[StreamedSheet]:
-    """Render each non-empty worksheet to a temp CSV, writing rows one at a
-    time so no worksheet is fully held in memory during conversion. Each sheet
-    is then staged via `stage` and referenced by `csv_file_id` downstream.
-    Empty rows are dropped; columns are not trimmed (that needs a second pass)."""
+    """Stream each non-empty worksheet to a temp CSV row by row (never holding a
+    full sheet in memory), then stage it via `stage` and reference it by
+    `csv_file_id`. Empty rows are dropped; columns are not trimmed."""
     sheets: list[StreamedSheet] = []
     workbook = _load_readonly_workbook(file, file_name)
     if workbook is None:

--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -28,7 +28,6 @@ from PIL import Image
 from onyx.configs.app_configs import MAX_EMBEDDED_IMAGES_PER_FILE
 from onyx.configs.app_configs import MAX_XLSX_CELLS_PER_SHEET
 from onyx.configs.app_configs import PDF_TEXT_EXTRACTION_TIMEOUT_SECONDS
-from onyx.configs.app_configs import XLSX_STREAM_SHEET_BYTES
 from onyx.configs.constants import ONYX_METADATA_FILENAME
 from onyx.configs.llm_configs import get_image_extraction_and_analysis_enabled
 from onyx.file_processing.file_types import OnyxFileExtensions
@@ -721,35 +720,12 @@ def xlsx_sheet_extraction(file: IO[Any], file_name: str = "") -> list[tuple[str,
     return sheets
 
 
-def xlsx_has_large_sheet(
-    file: IO[bytes], threshold: int = XLSX_STREAM_SHEET_BYTES
-) -> bool:
-    """True if any worksheet's *uncompressed* XML exceeds `threshold` — a cheap
-    pre-parse check read straight from the xlsx zip directory (no decompression).
-    Routes a huge workbook to streamed, file-backed extraction."""
-    try:
-        file.seek(0)
-        with zipfile.ZipFile(file) as zf:
-            return any(
-                info.file_size > threshold
-                for info in zf.infolist()
-                if info.filename.startswith("xl/worksheets/")
-                and info.filename.endswith(".xml")
-            )
-    except BadZipFile:
-        return False
-    finally:
-        file.seek(0)
-
-
 class StreamedSheet(NamedTuple):
-    """One worksheet rendered to CSV. Small sheets are returned inline (`text`);
-    larger ones are staged in the file store (`csv_file_id`) so they never land
-    on the heap. Exactly one of the two is populated."""
+    """One worksheet rendered to CSV, staged in the file store, and referenced
+    by `csv_file_id`."""
 
     title: str
-    text: str | None
-    csv_file_id: str | None
+    csv_file_id: str
 
 
 def _row_has_content(row: tuple[Any, ...]) -> bool:
@@ -760,18 +736,14 @@ def _cell(value: Any) -> str:
     return "" if value is None else str(value)
 
 
-def stage_or_inline_xlsx_sheets(
+def stage_xlsx_sheets(
     file: IO[bytes],
     stage: Callable[[IO[bytes], str], str],
-    max_inline_bytes: int,
     file_name: str = "",
 ) -> list[StreamedSheet]:
-    """Render each non-empty worksheet to a temp CSV, writing rows one at a time
-    so no worksheet is fully held in memory during conversion. A worksheet whose
-    CSV is at most `max_inline_bytes` is read back inline; a larger one is staged
-    via `stage` and referenced by `csv_file_id` so it stays off the heap
-    downstream. The returned list thus holds full CSV text for inline sheets
-    (each bounded by `max_inline_bytes`) and only an id for file-backed ones.
+    """Render each non-empty worksheet to a temp CSV, writing rows one at a
+    time so no worksheet is fully held in memory during conversion. Each sheet
+    is then staged via `stage` and referenced by `csv_file_id` downstream.
     Empty rows are dropped; columns are not trimmed (that needs a second pass)."""
     sheets: list[StreamedSheet] = []
     workbook = _load_readonly_workbook(file, file_name)
@@ -788,18 +760,10 @@ def stage_or_inline_xlsx_sheets(
                         writer.writerow([_cell(v) for v in row])
                 tmp.flush()
                 binary = cast(IO[bytes], tmp.buffer)
-                size = binary.seek(0, io.SEEK_END)
-                if size > max_inline_bytes:
-                    binary.seek(0)
-                    sheets.append(
-                        StreamedSheet(ro_sheet.title, None, stage(binary, "text/csv"))
-                    )
+                if binary.seek(0, io.SEEK_END) == 0:
                     continue
                 binary.seek(0)
-                text = binary.read().decode("utf-8").strip()
-                if not text:
-                    continue
-                sheets.append(StreamedSheet(ro_sheet.title, text, None))
+                sheets.append(StreamedSheet(ro_sheet.title, stage(binary, "text/csv")))
     finally:
         workbook.close()
     return sheets

--- a/backend/onyx/file_store/document_batch_storage.py
+++ b/backend/onyx/file_store/document_batch_storage.py
@@ -20,6 +20,20 @@ from onyx.utils.logger import setup_logger
 logger = setup_logger()
 
 
+def _has_legacy_tabular_section(doc_dict: dict) -> bool:
+    """True if a section is a pre-`csv_file_id` tabular section (inline text only).
+    Such a section was staged by an older docfetcher and the current file-backed-only
+    `TabularSection` can't validate it; during rolling-deploy skew we skip the doc
+    rather than fail the whole batch on `model_validate`."""
+    sections = doc_dict.get("sections")
+    if not isinstance(sections, list):
+        return False
+    return any(
+        isinstance(s, dict) and s.get("type") == "tabular" and not s.get("csv_file_id")
+        for s in sections
+    )
+
+
 class DocumentBatchStorageStateType(str, Enum):
     EXTRACTION = "extraction"
     INDEXING = "indexing"
@@ -91,10 +105,19 @@ class DocumentBatchStorage(ABC):
     def _deserialize_documents(self, data: str) -> list[Document]:
         """Deserialize documents from JSON string."""
         doc_dicts = json.loads(data)
-        return [
-            Document.model_validate(self._normalize_doc_dict(doc_dict))
-            for doc_dict in doc_dicts
-        ]
+        documents: list[Document] = []
+        for doc_dict in doc_dicts:
+            if _has_legacy_tabular_section(doc_dict):
+                logger.warning(
+                    "Skipping doc %s with a legacy inline tabular section "
+                    "(no csv_file_id); it re-indexes on the next attempt",
+                    doc_dict.get("id", "unknown"),
+                )
+                continue
+            documents.append(
+                Document.model_validate(self._normalize_doc_dict(doc_dict))
+            )
+        return documents
 
     def _normalize_doc_dict(self, doc_dict: dict) -> dict:
         """Normalize document dict to handle legacy data with non-string metadata values.

--- a/backend/onyx/file_store/staging.py
+++ b/backend/onyx/file_store/staging.py
@@ -71,11 +71,9 @@ def build_raw_file_callback(
 def build_tracking_raw_file_callback(
     *, metadata: dict[str, Any]
 ) -> tuple[RawFileCallback, list[str]]:
-    """Staging callback for connector runs with no attempt-end reaper — user-file
-    processing and the pruning id-enumeration. Returns the callback plus the list
-    it records staged ids in, so the caller reaps them once it has finished
-    reading them (these contexts have no index attempt for the standard reapers
-    to key on)."""
+    """Staging callback for connector runs that have no index attempt for the
+    standard staging reapers to key on. Returns the callback plus the list of ids
+    it stages, so the caller can reap them once it has read them."""
     staged_ids: list[str] = []
 
     def _callback(content: IO[bytes], content_type: str) -> str:

--- a/backend/onyx/file_store/staging.py
+++ b/backend/onyx/file_store/staging.py
@@ -68,6 +68,24 @@ def build_raw_file_callback(
     return _callback
 
 
+def build_tracking_raw_file_callback(
+    *, metadata: dict[str, Any]
+) -> tuple[RawFileCallback, list[str]]:
+    """Staging callback for connector runs with no attempt-end reaper — user-file
+    processing and the pruning id-enumeration. Returns the callback plus the list
+    it records staged ids in, so the caller reaps them once it has finished
+    reading them (these contexts have no index attempt for the standard reapers
+    to key on)."""
+    staged_ids: list[str] = []
+
+    def _callback(content: IO[bytes], content_type: str) -> str:
+        file_id = stage_raw_file(content, content_type, metadata=metadata)
+        staged_ids.append(file_id)
+        return file_id
+
+    return _callback, staged_ids
+
+
 def delete_files_best_effort(
     file_ids: list[str],
     context: str = "document cleanup",

--- a/backend/onyx/indexing/chunking/tabular_section_chunker/tabular_section_chunker.py
+++ b/backend/onyx/indexing/chunking/tabular_section_chunker/tabular_section_chunker.py
@@ -23,7 +23,6 @@ from onyx.natural_language_processing.utils import BaseTokenizer
 from onyx.natural_language_processing.utils import count_tokens
 from onyx.natural_language_processing.utils import split_text_by_tokens
 from onyx.utils.csv_utils import parse_csv_stream
-from onyx.utils.csv_utils import parse_csv_string
 from onyx.utils.csv_utils import ParsedRow
 from onyx.utils.csv_utils import read_csv_header
 from onyx.utils.logger import setup_logger
@@ -244,54 +243,34 @@ class TabularChunker(SectionChunker):
         payloads = accumulator.flush_to_list()
         heading = section.heading or ""
 
-        csv_file_id = (
-            section.csv_file_id if isinstance(section, TabularSection) else None
-        )
-        if csv_file_id:
-            # Huge sheet: never fully materialized. One streaming pass over the
-            # staged CSV for row chunks, plus a second bounded streaming pass
-            # through analyze_sheet for descriptor/total chunks.
-            file_store = get_default_file_store()
-            chunk_texts: list[str] = []
-            with file_store.read_file(csv_file_id, use_tempfile=True) as raw:
-                rows = io.TextIOWrapper(raw, encoding="utf-8", newline="")
-                chunk_texts.extend(
-                    parse_to_chunks(
-                        rows=parse_csv_stream(rows),
-                        sheet_header=heading,
-                        tokenizer=self.tokenizer,
-                        max_tokens=content_token_limit,
-                    )
-                )
-            if not self.ignore_metadata_chunks:
-                chunk_texts.extend(
-                    self._streamed_descriptor_chunks(
-                        csv_file_id, heading, content_token_limit
-                    )
-                )
-            return self._build_output(chunk_texts, section, payloads)
+        if not isinstance(section, TabularSection):
+            raise ValueError(
+                "TabularChunker received a non-tabular section: "
+                f"{type(section).__name__}"
+            )
 
-        # Inline sheet: small enough to materialize, so it also gets descriptors.
-        text = section.text or ""
-        parsed_rows = list(parse_csv_string(text))
-        headers = parsed_rows[0].header if parsed_rows else read_csv_header(text)
-
-        inline_chunks: list[str] = []
-        if parsed_rows:
-            inline_chunks.extend(
+        # The CSV is always staged. One streaming pass over it yields the row
+        # chunks; a second bounded pass through analyze_sheet yields descriptor
+        # and total chunks. The sheet is never fully materialized.
+        file_store = get_default_file_store()
+        chunk_texts: list[str] = []
+        with file_store.read_file(section.csv_file_id, use_tempfile=True) as raw:
+            rows = io.TextIOWrapper(raw, encoding="utf-8", newline="")
+            chunk_texts.extend(
                 parse_to_chunks(
-                    rows=parsed_rows,
+                    rows=parse_csv_stream(rows),
                     sheet_header=heading,
                     tokenizer=self.tokenizer,
                     max_tokens=content_token_limit,
                 )
             )
-        if not self.ignore_metadata_chunks and headers:
-            analysis = analyze_sheet(headers, parsed_rows)
-            inline_chunks.extend(
-                self._descriptor_chunks(headers, analysis, heading, content_token_limit)
+        if not self.ignore_metadata_chunks:
+            chunk_texts.extend(
+                self._streamed_descriptor_chunks(
+                    section.csv_file_id, heading, content_token_limit
+                )
             )
-        return self._build_output(inline_chunks, section, payloads)
+        return self._build_output(chunk_texts, section, payloads)
 
     def _descriptor_chunks(
         self,
@@ -325,17 +304,30 @@ class TabularChunker(SectionChunker):
     ) -> list[str]:
         """Second bounded streaming pass over the staged CSV: derive descriptor
         and total chunks via analyze_sheet (one row plus capped per-column state
-        in memory)."""
+        in memory). A header-only sheet still yields a zero-row descriptor."""
         file_store = get_default_file_store()
         with file_store.read_file(csv_file_id, use_tempfile=True) as raw:
             rows = parse_csv_stream(io.TextIOWrapper(raw, encoding="utf-8", newline=""))
             try:
                 first = next(rows)
             except StopIteration:
-                return []
-            headers = first.header
-            analysis = analyze_sheet(headers, chain([first], rows))
-        return self._descriptor_chunks(headers, analysis, heading, content_token_limit)
+                first = None
+            if first is not None:
+                headers = first.header
+                analysis = analyze_sheet(headers, chain([first], rows))
+                return self._descriptor_chunks(
+                    headers, analysis, heading, content_token_limit
+                )
+
+        # No data rows — re-read just the header so column names alone still
+        # produce a zero-row descriptor chunk.
+        with file_store.read_file(csv_file_id, use_tempfile=True) as raw:
+            headers = read_csv_header(raw.read().decode("utf-8"))
+        if not headers:
+            return []
+        return self._descriptor_chunks(
+            headers, analyze_sheet(headers, []), heading, content_token_limit
+        )
 
     def _build_output(
         self,

--- a/backend/tests/daily/connectors/blob/test_blob_connector.py
+++ b/backend/tests/daily/connectors/blob/test_blob_connector.py
@@ -16,6 +16,7 @@ from onyx.connectors.models import TabularSection
 from onyx.connectors.models import TextSection
 from onyx.file_processing.extract_file_text import get_file_ext
 from onyx.file_processing.file_types import OnyxFileExtensions
+from tests.daily.connectors.utils import set_test_staging_callback
 from tests.utils.secret_names import TestSecret
 
 pytestmark = pytest.mark.secrets(
@@ -120,6 +121,7 @@ def test_blob_s3_connector(
     This is intentional in order to allow searching by just the title even if we can't
     index the file content.
     """
+    staged_csvs = set_test_staging_callback(blob_connector)
     all_docs: list[Document] = []
     document_batches = blob_connector.load_from_state()
     for doc_batch in document_batches:
@@ -135,7 +137,8 @@ def test_blob_s3_connector(
 
         if is_tabular_file(doc.semantic_identifier):
             assert isinstance(section, TabularSection)
-            assert len(section.text or "") > 0
+            assert section.csv_file_id
+            assert len(staged_csvs[section.csv_file_id]) > 0
             continue
 
         assert isinstance(section, TextSection)

--- a/backend/tests/daily/connectors/file/test_file_connector.py
+++ b/backend/tests/daily/connectors/file/test_file_connector.py
@@ -9,6 +9,7 @@ import pytest
 
 from onyx.connectors.file.connector import LocalFileConnector
 from onyx.connectors.models import HierarchyNode
+from tests.daily.connectors.utils import set_test_staging_callback
 
 
 @pytest.fixture
@@ -191,6 +192,7 @@ def test_tabular_file_sets_file_id_on_document(
         connector = LocalFileConnector(
             file_locations=[file_id], file_names=["data.csv"], zip_metadata={}
         )
+        set_test_staging_callback(connector)
         batches = list(connector.load_from_state())
 
     assert len(batches) == 1
@@ -273,6 +275,7 @@ def test_mixed_batch_only_tabular_gets_file_id(
             file_names=["data.csv", "notes.txt"],
             zip_metadata={},
         )
+        set_test_staging_callback(connector)
         batches = list(connector.load_from_state())
 
     assert len(batches) == 1

--- a/backend/tests/daily/connectors/utils.py
+++ b/backend/tests/daily/connectors/utils.py
@@ -1,9 +1,11 @@
 from collections.abc import Iterator
+from typing import IO
 from typing import TypeVar
 
 from pydantic import BaseModel
 
 from onyx.connectors.connector_runner import CheckpointOutputWrapper
+from onyx.connectors.interfaces import BaseConnector
 from onyx.connectors.interfaces import CheckpointedConnector
 from onyx.connectors.interfaces import CheckpointedConnectorWithPermSync
 from onyx.connectors.interfaces import SecondsSinceUnixEpoch
@@ -30,6 +32,21 @@ class ConnectorOutput(BaseModel):
     model_config = {"arbitrary_types_allowed": True}
 
 
+def set_test_staging_callback(connector: BaseConnector) -> dict[str, bytes]:
+    """Install an in-memory staging callback so tabular files produce file-backed
+    sections in tests, the way docfetching does in production. Returns the
+    {csv_file_id: bytes} map for content assertions."""
+    staged: dict[str, bytes] = {}
+
+    def _callback(content: IO[bytes], content_type: str) -> str:  # noqa: ARG001
+        file_id = f"test-staged-csv-{len(staged)}"
+        staged[file_id] = content.read()
+        return file_id
+
+    connector.set_raw_file_callback(_callback)
+    return staged
+
+
 def load_all_from_connector(
     connector: CheckpointedConnector[CT],
     start: SecondsSinceUnixEpoch,
@@ -53,6 +70,10 @@ def load_all_from_connector(
         connector, CheckpointedConnectorWithPermSync
     ):
         raise ValueError("Connector does not support permission syncing")
+
+    # Tabular files need a staging callback to produce file-backed sections;
+    # docfetching installs one in production, so mirror that here.
+    set_test_staging_callback(connector)
 
     checkpoint = connector.build_dummy_checkpoint()
     documents: list[Document] = []

--- a/backend/tests/unit/onyx/connectors/braintrust/test_braintrust_connector.py
+++ b/backend/tests/unit/onyx/connectors/braintrust/test_braintrust_connector.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
 from typing import Any
+from typing import IO
 from unittest.mock import patch
 
 import pytest
@@ -153,9 +154,22 @@ def _docs(outputs: list[Any]) -> dict[str, Document]:
 
 
 @pytest.fixture
-def connector() -> BraintrustConnector:
+def staged_csvs() -> dict[str, bytes]:
+    return {}
+
+
+@pytest.fixture
+def connector(staged_csvs: dict[str, bytes]) -> BraintrustConnector:
     connector = BraintrustConnector(experiment_row_lookback_days=0)
     connector.load_credentials({"braintrust_api_key": "test-key"})
+
+    def raw_file_callback(content: IO[bytes], content_type: str) -> str:
+        assert content_type == "text/csv"
+        file_id = f"csv-{len(staged_csvs)}"
+        staged_csvs[file_id] = content.read()
+        return file_id
+
+    connector.set_raw_file_callback(raw_file_callback)
     return connector
 
 
@@ -177,6 +191,7 @@ def test_full_sweep_produces_prompt_dataset_experiment_docs(
 
 def test_dataset_doc_has_text_and_tabular_sections(
     connector: BraintrustConnector,
+    staged_csvs: dict[str, bytes],
 ) -> None:
     """The dataset doc carries a prose header section plus a CSV table of all
     rows."""
@@ -188,7 +203,8 @@ def test_dataset_doc_has_text_and_tabular_sections(
     assert "merge-cases" in (text.text or "")
     assert "1 rows" in (text.text or "")
     assert isinstance(tabular, TabularSection)
-    header, row = (tabular.text or "").split("\n")
+    assert doc.file_id == tabular.csv_file_id
+    header, row = staged_csvs[tabular.csv_file_id].decode("utf-8").strip().split("\n")
     assert header == "id,created,input,expected,metadata,tags"
     assert row.startswith("row-1,")
     assert '""doc"": ""a.md""' in row
@@ -196,6 +212,7 @@ def test_dataset_doc_has_text_and_tabular_sections(
 
 def test_experiment_doc_combines_summary_and_score_table(
     connector: BraintrustConnector,
+    staged_csvs: dict[str, bytes],
 ) -> None:
     """The experiment doc leads with the prose score summary and includes a
     table with one flattened column per score."""
@@ -210,7 +227,8 @@ def test_experiment_doc_combines_summary_and_score_table(
     assert "+0.05" in body
     assert "3 improvements / 1 regressions" in body
     assert isinstance(tabular, TabularSection)
-    header, row = (tabular.text or "").split("\n")
+    assert doc.file_id == tabular.csv_file_id
+    header, row = staged_csvs[tabular.csv_file_id].decode("utf-8").strip().split("\n")
     assert header == "id,created,input,output,expected,correctness"
     assert row.startswith("row-2,") and row.endswith(",0.9")
     assert tabular.link == _SUMMARY["experiment_url"]
@@ -266,10 +284,20 @@ def test_lookback_drops_table_but_keeps_summary() -> None:
     assert "correctness 0.9" in (doc.sections[0].text or "")
 
 
-def test_btql_keyset_pagination_accumulates_table() -> None:
+def test_btql_keyset_pagination_accumulates_table(
+    staged_csvs: dict[str, bytes],
+) -> None:
     """Full pages chain via `_pagination_key <` filters until a short page."""
     connector = BraintrustConnector(experiment_row_lookback_days=0)
     connector.load_credentials({"braintrust_api_key": "test-key"})
+
+    def raw_file_callback(content: IO[bytes], content_type: str) -> str:
+        assert content_type == "text/csv"
+        file_id = f"csv-{len(staged_csvs)}"
+        staged_csvs[file_id] = content.read()
+        return file_id
+
+    connector.set_raw_file_callback(raw_file_callback)
     page1 = [
         {**_DATASET_ROW, "id": f"row-{i}", "_pagination_key": f"p{900 - i}"}
         for i in range(500)
@@ -297,7 +325,11 @@ def test_btql_keyset_pagination_accumulates_table() -> None:
 
     tabular = doc.sections[1]
     assert isinstance(tabular, TabularSection)
-    assert len((tabular.text or "").split("\n")) == 1 + 501
+    assert doc.file_id == tabular.csv_file_id
+    assert (
+        len(staged_csvs[tabular.csv_file_id].decode("utf-8").strip().split("\n"))
+        == 1 + 501
+    )
     assert len(seen_filters) == 2
     assert "_pagination_key < 'p401'" in seen_filters[1]
 

--- a/backend/tests/unit/onyx/connectors/cross_connector_utils/test_tabular_section_utils.py
+++ b/backend/tests/unit/onyx/connectors/cross_connector_utils/test_tabular_section_utils.py
@@ -1,4 +1,5 @@
 import io
+from collections.abc import Callable
 from typing import cast
 from typing import IO
 
@@ -10,6 +11,20 @@ from onyx.connectors.cross_connector_utils.tabular_section_utils import is_tabul
 from onyx.connectors.cross_connector_utils.tabular_section_utils import (
     tabular_file_to_sections,
 )
+
+
+def _make_stage_callback() -> tuple[
+    dict[str, tuple[bytes, str]],
+    Callable[[IO[bytes], str], str],
+]:
+    staged: dict[str, tuple[bytes, str]] = {}
+
+    def fake_stage(content: IO[bytes], content_type: str) -> str:
+        file_id = f"csv-{len(staged)}"
+        staged[file_id] = (content.read(), content_type)
+        return file_id
+
+    return staged, fake_stage
 
 
 def _make_xlsx_bytes(sheets: dict[str, list[list[str]]]) -> io.BytesIO:
@@ -55,50 +70,51 @@ class TestTabularFileToSections:
             }
         )
 
+        staged, fake_stage = _make_stage_callback()
         sections = tabular_file_to_sections(
             xlsm_bytes,
             file_name="budget.xlsm",
+            stage=fake_stage,
         )
         assert len(sections) == 1
-        assert "Alice" in (sections[0].text or "")
+        assert "Alice" in staged[sections[0].csv_file_id][0].decode("utf-8")
         assert sections[0].heading == "budget.xlsm :: Sheet1"
 
     def test_unknown_extension_raises(self) -> None:
         with pytest.raises(ValueError):
-            tabular_file_to_sections(io.BytesIO(b""), file_name="notes.pdf")
+            tabular_file_to_sections(
+                io.BytesIO(b""),
+                file_name="notes.pdf",
+                stage=lambda _content, _content_type: "unused",
+            )
+
+    def test_empty_csv_returns_no_sections(self) -> None:
+        _staged, fake_stage = _make_stage_callback()
+
+        sections = tabular_file_to_sections(
+            io.BytesIO(b"\n\n"),
+            file_name="empty.csv",
+            stage=fake_stage,
+        )
+
+        assert sections == []
 
 
 class TestFileBackedXlsx:
-    """Within a workbook routed to streaming, each sheet is handled by size:
-    oversized sheets are file-backed (no inline text, not truncated); small
-    sheets stay inline so they keep their descriptor chunks downstream."""
+    """Every non-empty workbook sheet is staged as CSV and referenced by
+    `csv_file_id`."""
 
-    def test_oversized_sheet_is_file_backed_no_truncation(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        import onyx.connectors.cross_connector_utils.tabular_section_utils as mod
-
+    def test_sheet_is_staged_no_truncation(self) -> None:
         rows = [["name", "score"]] + [[f"user{i}", str(i)] for i in range(200)]
         xlsx = _make_xlsx_bytes({"Sheet1": rows})
-        # Enter the streaming path and force this sheet over the inline threshold
-        # without needing a multi-MB fixture.
-        monkeypatch.setattr(mod, "xlsx_has_large_sheet", lambda _f: True)
-        monkeypatch.setattr(mod, "XLSX_STREAM_SHEET_BYTES", 10)
+        staged, fake_stage = _make_stage_callback()
 
-        staged: dict[str, tuple[bytes, str]] = {}
-
-        def fake_callback(content: IO[bytes], content_type: str) -> str:
-            file_id = f"csv-{len(staged)}"
-            staged[file_id] = (content.read(), content_type)
-            return file_id
-
-        sections = mod.tabular_file_to_sections(
-            xlsx, file_name="big.xlsx", raw_file_callback=fake_callback
+        sections = tabular_file_to_sections(
+            xlsx, file_name="big.xlsx", stage=fake_stage
         )
 
         assert len(sections) == 1
         section = sections[0]
-        assert section.text is None
         assert section.csv_file_id is not None
         assert section.heading == "big.xlsx :: Sheet1"
 
@@ -111,31 +127,13 @@ class TestFileBackedXlsx:
         data_rows = [line for line in csv_text.splitlines() if line.strip()]
         assert len(data_rows) == 201  # header + 200 rows
 
-    def test_small_sheet_in_streaming_workbook_stays_inline(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        import onyx.connectors.cross_connector_utils.tabular_section_utils as mod
-
+    def test_small_workbook_also_stages_sheet(self) -> None:
         xlsx = _make_xlsx_bytes({"Sheet1": [["a", "b"], ["1", "2"]]})
-        # Streaming path, but this sheet is tiny -> inline (keeps descriptors).
-        monkeypatch.setattr(mod, "xlsx_has_large_sheet", lambda _f: True)
-        sections = mod.tabular_file_to_sections(
-            xlsx, file_name="mixed.xlsx", raw_file_callback=lambda _c, _t: "unused"
+        staged, fake_stage = _make_stage_callback()
+
+        sections = tabular_file_to_sections(
+            xlsx, file_name="small.xlsx", stage=fake_stage
         )
         assert len(sections) == 1
-        assert sections[0].csv_file_id is None
-        assert "a,b" in (sections[0].text or "")
-
-    def test_small_workbook_uses_inline_path(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        import onyx.connectors.cross_connector_utils.tabular_section_utils as mod
-
-        xlsx = _make_xlsx_bytes({"Sheet1": [["a", "b"], ["1", "2"]]})
-        monkeypatch.setattr(mod, "xlsx_has_large_sheet", lambda _f: False)
-        sections = mod.tabular_file_to_sections(
-            xlsx, file_name="small.xlsx", raw_file_callback=lambda _c, _t: "unused"
-        )
-        assert len(sections) == 1
-        assert sections[0].csv_file_id is None
-        assert "a,b" in (sections[0].text or "")
+        assert sections[0].csv_file_id is not None
+        assert staged[sections[0].csv_file_id][0].decode("utf-8") == "a,b\n1,2\n"

--- a/backend/tests/unit/onyx/indexing/test_tabular_section_chunker.py
+++ b/backend/tests/unit/onyx/indexing/test_tabular_section_chunker.py
@@ -12,6 +12,7 @@ exactly.
 """
 
 import io
+from collections.abc import Iterator
 
 import pytest
 
@@ -54,14 +55,49 @@ def _make_chunker_with_metadata() -> TabularChunker:
 
 
 _DEFAULT_LINK = "https://example.com/doc"
+_STAGED_CSVS: dict[str, bytes] = {}
+_NEXT_STAGED_CSV_INDEX = 0
+
+
+@pytest.fixture(autouse=True)
+def _fake_tabular_file_store(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    import onyx.indexing.chunking.tabular_section_chunker.tabular_section_chunker as mod
+
+    global _STAGED_CSVS
+    global _NEXT_STAGED_CSV_INDEX
+    _STAGED_CSVS = {}
+    _NEXT_STAGED_CSV_INDEX = 0
+
+    class _FakeStore:
+        def read_file(
+            self, file_id: str, mode: str | None = None, use_tempfile: bool = False
+        ) -> io.BytesIO:
+            del mode, use_tempfile
+            return io.BytesIO(_STAGED_CSVS[file_id])
+
+    monkeypatch.setattr(mod, "get_default_file_store", lambda: _FakeStore())
+    yield
+
+
+def _stage_csv(csv_text: str) -> str:
+    global _NEXT_STAGED_CSV_INDEX
+
+    file_id = f"csv-{_NEXT_STAGED_CSV_INDEX}"
+    _NEXT_STAGED_CSV_INDEX += 1
+    _STAGED_CSVS[file_id] = csv_text.encode("utf-8")
+    return file_id
 
 
 def _tabular_section(
-    text: str,
+    csv_text: str,
     link: str = _DEFAULT_LINK,
     heading: str | None = "sheet:Test",
 ) -> Section:
-    return TabularSection(text=text, link=link, heading=heading)
+    return TabularSection(
+        csv_file_id=_stage_csv(csv_text),
+        link=link,
+        heading=heading,
+    )
 
 
 class TestTabularChunkerChunkSection:
@@ -1066,26 +1102,13 @@ class TestBuildTotalDescriptorChunks:
         assert "Total row count: 2." in body
 
 
-def test_file_backed_section_streams_all_rows(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_file_backed_section_streams_all_rows() -> None:
     """A file-backed TabularSection (csv_file_id) is chunked by streaming the
     staged CSV from the file store — every row appears, nothing is truncated."""
-    import onyx.indexing.chunking.tabular_section_chunker.tabular_section_chunker as mod
-
     csv_text = "name,score\n" + "\n".join(f"user{i},{i}" for i in range(60))
 
-    class _FakeStore:
-        def read_file(
-            self, file_id: str, mode: str | None = None, use_tempfile: bool = False
-        ) -> io.BytesIO:
-            del file_id, mode, use_tempfile  # stub: signature parity only
-            return io.BytesIO(csv_text.encode("utf-8"))
-
-    monkeypatch.setattr(mod, "get_default_file_store", lambda: _FakeStore())
-
     chunker = _make_chunker_no_metadata()
-    section = TabularSection(link="x", csv_file_id="csv-1", heading="big :: Sheet1")
+    section = _tabular_section(csv_text, link="x", heading="big :: Sheet1")
     out = chunker.chunk_section(
         section, AccumulatorState(), content_token_limit=100_000
     )
@@ -1096,27 +1119,14 @@ def test_file_backed_section_streams_all_rows(
     assert "user59" in joined  # last row present -> no truncation
 
 
-def test_file_backed_section_emits_descriptor_chunks(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_file_backed_section_emits_descriptor_chunks() -> None:
     """A file-backed (streamed) section also gets descriptor/total chunks, built
     by the bounded streaming analyze pass — not just row chunks."""
-    import onyx.indexing.chunking.tabular_section_chunker.tabular_section_chunker as mod
-
     rows = ["1,US,10", "2,US,20", "3,EU,30", "4,US,40", "5,EU,50", "6,US,60"]
     csv_text = "id,region,amount\n" + "\n".join(rows)
 
-    class _FakeStore:
-        def read_file(
-            self, file_id: str, mode: str | None = None, use_tempfile: bool = False
-        ) -> io.BytesIO:
-            del file_id, mode, use_tempfile  # stub: signature parity only
-            return io.BytesIO(csv_text.encode("utf-8"))
-
-    monkeypatch.setattr(mod, "get_default_file_store", lambda: _FakeStore())
-
     chunker = _make_chunker_with_metadata()
-    section = TabularSection(link="x", csv_file_id="csv-1", heading="S")
+    section = _tabular_section(csv_text, link="x", heading="S")
     out = chunker.chunk_section(
         section, AccumulatorState(), content_token_limit=100_000
     )


### PR DESCRIPTION
## Description

Builds on #12292. Removes the inline `text` option from `TabularSection`: a sheet's CSV is now **always** staged in the file store and streamed at chunk time — one mechanism instead of `text`-or-`csv_file_id` (per Dane's review). Non-docfetching connector runs lack the docfetching staging callback, so they're wired up or tabular files vanish — notably **pruning**, where non-slim tabular connectors (blob/file) would otherwise lose doc ids and pruning would **delete the indexed docs**. The batch-handoff deserialize is made tolerant so the model change survives a rolling deploy.

### Changes by location

**Model**
- `connectors/models.py` — `TabularSection`: drop `text`, `csv_file_id: str` required, remove the runtime "exactly one of" validator.

**Extraction & staging**
- `file_processing/extract_file_text.py` — `StreamedSheet` is now `(title, csv_file_id)`; `stage_or_inline_xlsx_sheets` → `stage_xlsx_sheets` (always stages, no inline branch); remove dead `xlsx_has_large_sheet`.
- `configs/app_configs.py` — remove dead `XLSX_STREAM_SHEET_BYTES`.
- `connectors/cross_connector_utils/tabular_section_utils.py` — `tabular_file_to_sections` takes a required `stage` callback and stages each sheet/file CSV → `csv_file_id`; `extract_and_stage_tabular_file` threads it through.
- `file_store/staging.py` — add `build_tracking_raw_file_callback` (returns the callback + the list of staged ids) for paths with no attempt-end reaper.

**Chunking**
- `indexing/chunking/tabular_section_chunker/tabular_section_chunker.py` — `chunk_section` file-backed only (inline branch removed); header-only sheets still get a descriptor.

**Connectors (docfetching producers)**
- `braintrust` — stage via `_stage_csv` → `csv_file_id`; skip only the tabular section (keep the TextSection) if no callback.
- `blob` — stage via `extract_and_stage_tabular_file`; drop the empty `text=""` fallback; skip+warn if no callback.
- `file` — `_process_file` takes `stage`; `LocalFileConnector` passes `self.raw_file_callback`; skip+warn if None.
- `sharepoint` — return a `ConnectorFailure` when no callback (and on tabular extraction error) instead of emitting an empty-section `Document`.
- `drupal_wiki`, `google_drive/doc_conversion` — drop the no-callback inline fallback (warn + skip).

**Non-docfetching connector runs (the "everywhere" fixes)**
- `background/celery/tasks/user_file_processing/tasks.py` — tracking callback on the file connector; reap staged CSVs in `finally`.
- `background/celery/celery_utils.py` (`extract_ids_from_runnable_connector`, the pruning enumeration) — tracking callback + reap in `finally`; without it non-slim tabular connectors lose doc ids → pruning deletes them.
- `background/indexing/run_targeted_reindex.py` — tracking callback + reap staged CSVs in `finally` (this path has no attempt-end reaper).

**Rolling-deploy safety**
- `file_store/document_batch_storage.py` — on deserialize, skip a doc carrying a legacy inline tabular section (no `csv_file_id`) instead of crashing the whole batch on `Document.model_validate`. During a rolling deploy an old docfetcher can stage a text-only section; the doc is skipped (logged) and re-indexes on the next attempt rather than failing the batch.

**Tests** — `test_tabular_section_chunker.py`, `test_tabular_section_utils.py`, `test_braintrust_connector.py` updated to file-backed (mock file store / fake stage).

## How Has This Been Tested?

## Additional Options
- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
