### PR TITLE
chore: more ee codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,6 @@
 /.github/workflows/post-merge-beta-cherry-pick.yml @justin-tahara @jmelahman
 
 # Enterprise Edition code owners
-/backend/ee/ @evan-onyx @Weves
-/web/src/ee/ @evan-onyx @Weves
-/web/src/app/ee/ @evan-onyx @Weves
+/backend/ee/ @evan-onyx @Weves @jmelahman @justin-tahara
+/web/src/ee/ @evan-onyx @Weves @jmelahman @justin-tahara
+/web/src/app/ee/ @evan-onyx @Weves @jmelahman @justin-tahara


### PR DESCRIPTION
## Description

Adding more folks who handle contributor PRs more frequently

## How Has This Been Tested?

n/a

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand Enterprise Edition CODEOWNERS to include `@jmelahman` and `@justin-tahara` for `/backend/ee`, `/web/src/ee`, and `/web/src/app/ee`. This speeds up contributor PR reviews and spreads the workload.

<sup>Written for commit e747025f903f35cb113072d27633dbefe7146f00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

