### PR TITLE
test(craft): run compose API contract tests

### DIFF
--- a/.github/workflows/pr-craft-compose-integration.yml
+++ b/.github/workflows/pr-craft-compose-integration.yml
@@ -84,6 +84,8 @@ jobs:
               - 'deployment/docker_compose/docker-compose.yml'
               - 'deployment/docker_compose/docker-compose.dev.yml'
               - 'deployment/docker_compose/docker-compose.craft.yml'
+              - 'backend/tests/integration/conftest.py'
+              - 'backend/tests/integration/common_utils/**'
               - 'backend/tests/integration/tests/craft/*.py'
               - 'backend/tests/integration/tests/craft/docker_e2e/**'
               - '.github/workflows/pr-craft-compose-integration.yml'

--- a/.github/workflows/pr-craft-compose-integration.yml
+++ b/.github/workflows/pr-craft-compose-integration.yml
@@ -78,8 +78,7 @@ jobs:
             craft_compose:
               - 'backend/Dockerfile'
               - 'backend/onyx/sandbox_proxy/**'
-              - 'backend/onyx/server/features/build/sandbox/**'
-              - 'backend/onyx/server/features/build/approvals/**'
+              - 'backend/onyx/server/features/build/**'
               - 'backend/onyx/skills/**'
               - 'deployment/docker_compose/docker-compose.yml'
               - 'deployment/docker_compose/docker-compose.dev.yml'

--- a/.github/workflows/pr-craft-compose-integration.yml
+++ b/.github/workflows/pr-craft-compose-integration.yml
@@ -84,6 +84,7 @@ jobs:
               - 'deployment/docker_compose/docker-compose.yml'
               - 'deployment/docker_compose/docker-compose.dev.yml'
               - 'deployment/docker_compose/docker-compose.craft.yml'
+              - 'backend/tests/integration/tests/craft/*.py'
               - 'backend/tests/integration/tests/craft/docker_e2e/**'
               - '.github/workflows/pr-craft-compose-integration.yml'
               - '.github/actions/setup-python-and-install-dependencies/**'
@@ -91,16 +92,14 @@ jobs:
   craft-compose-integration-test:
     needs: changes
     if: needs.changes.outputs.craft_compose == 'true'
-    # Self-hosted runs-on pool (matches pr-craft-k8s-tests /
-    # pr-integration-tests / pr-playwright-tests). Github's runners do not have
-    # sufficient disk space by default.
     runs-on:
       - runs-on
       - runner=4cpu-linux-x64
+      - spot=false
       - volume=100gb
       - run-id=${{ github.run_id }}-craft-compose-integration
       - extras=ecr-cache
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     env:
       PYTHONPATH: ./backend
@@ -154,22 +153,21 @@ jobs:
           docker network create onyx_craft_sandbox
           docker volume create sandbox_proxy_ca
 
-      # install.sh normally generates .env (including USER_AUTH_SECRET) from
-      # env.template; CI skips install.sh, and since #12038 the api server
-      # fail-closes on an empty USER_AUTH_SECRET. Services read .env via
-      # env_file, so a CI-only value here unblocks the stack.
-      - name: Provide USER_AUTH_SECRET (.env)
+      # CI skips install.sh, so these have to be added explicitly.
+      - name: Provide USER_AUTH_SECRET + upload caps (.env)
         working-directory: deployment/docker_compose
-        run: echo 'USER_AUTH_SECRET=craft-compose-ci-only-dummy-secret' > .env
+        run: |
+          {
+            echo 'USER_AUTH_SECRET=craft-compose-ci-only-dummy-secret'
+            echo 'BUILD_MAX_UPLOAD_FILE_SIZE_MB=2'
+            echo 'BUILD_MAX_UPLOAD_FILES_PER_SESSION=5'
+            echo 'BUILD_MAX_TOTAL_UPLOAD_SIZE_MB=4'
+            echo 'USER_LIBRARY_MAX_FILES_PER_UPLOAD=5'
+          } > .env
 
-      # TODO(ods): Replace with `ods compose --craft` once that flag is added to
-      # tools/ods/cmd/compose.go. Today `ods compose` doesn't support the craft
-      # overlay, so we drop to raw docker compose.
-      #
-      # Service list: Only what the gate + posture tests need. compose's
-      # depends_on graph pulls in relational_db / cache / opensearch / model
-      # servers / minio transitively. Deliberately excludes web_server and nginx
-      # -- the tests hit api_server on localhost:8080 directly.
+      # Raw docker compose (ods compose has no craft overlay yet). Only
+      # api_server/background/sandbox-proxy are named; depends_on pulls in db /
+      # cache / opensearch / model servers / minio. web_server + nginx omitted.
       - name: Bring up the stack (yml + dev + craft)
         working-directory: deployment/docker_compose
         run: |
@@ -190,14 +188,10 @@ jobs:
             http://localhost:8080/health
 
       - name: Run integration tests
-        timeout-minutes: 10
+        timeout-minutes: 25
         shell: bash
-        # Working dir = backend/ so alembic.ini is a relative path for the
-        # reset_all() fixture.
         working-directory: backend
         env:
-          # API_SERVER_URL and POSTGRES_* must point at the compose-published
-          # host ports (set by docker-compose.dev.yml).
           API_SERVER_HOST: "127.0.0.1"
           API_SERVER_PORT: "8080"
           POSTGRES_DB: "postgres"
@@ -205,35 +199,33 @@ jobs:
           POSTGRES_PORT: "5432"
           REDIS_HOST: "127.0.0.1"
           REDIS_PORT: "6379"
-          # The integration framework imports onyx.* at module load and needs
-          # craft + proxy env in place so DockerSandboxManager initializes.
+          S3_ENDPOINT_URL: "http://127.0.0.1:9004"
+          S3_AWS_ACCESS_KEY_ID: "minioadmin"
+          S3_AWS_SECRET_ACCESS_KEY: "minioadmin"
+          # onyx.* reads these at import; DockerSandboxManager needs the
+          # proxy/docker env. USER_AUTH_SECRET must match the stack's .env.
           ENABLE_CRAFT: "true"
           ENABLE_PAID_ENTERPRISE_EDITION_FEATURES: "true"
+          USER_AUTH_SECRET: "craft-compose-ci-only-dummy-secret"
           SANDBOX_BACKEND: "docker"
           SANDBOX_PROXY_HOST: "sandbox-proxy"
           SANDBOX_PROXY_PORT: "8080"
           SANDBOX_DOCKER_NETWORK: "onyx_craft_sandbox"
           SANDBOX_DOCKER_SOCKET: "/var/run/docker.sock"
         run: |
-          # pipefail + tee so pytest output survives a step-timeout kill;
-          # line-buffered flush so the file is up to date when that happens.
           set -o pipefail
           mkdir -p ../compose-logs
           PYTHONUNBUFFERED=1 stdbuf -oL -eL py.test \
             -v \
-            -s \
-            --setup-show \
-            -o faulthandler_timeout=90 \
             --tb=short \
+            -rs \
             --durations=10 \
-            tests/integration/tests/craft/docker_e2e \
+            tests/integration/tests/craft \
+            --ignore=tests/integration/tests/craft/k8s \
             2>&1 | tee ../compose-logs/pytest.log
 
-      # Inline tail for fast triage in the GH Actions UI without downloading
-      # artifacts. Truncated; the full per-container logs land in compose-logs/
-      # via the next step and ship as an uploaded artifact.
       - name: Stack state + log tails on failure
-        if: ${{ failure() || cancelled() }}
+        if: ${{ !success() }}
         run: |
           echo "=== docker ps -a ==="; docker ps -a || true
           echo "=== api_server tail ==="; docker logs --tail 200 onyx-api_server-1 || true
@@ -244,11 +236,8 @@ jobs:
               echo "--- $c ---"; docker logs --tail 200 "$c" || true; \
             done
 
-      # Full per-container logs to disk so failures are debuggable after the
-      # runner shuts down. Captures both compose-managed services AND the
-      # dynamically-created sandbox-<id> containers the tests provision.
       - name: Collect Docker logs on failure
-        if: ${{ failure() || cancelled() }}
+        if: ${{ !success() }}
         run: |
           mkdir -p compose-logs
           # Compose-managed services (api_server, background, sandbox-proxy
@@ -272,16 +261,15 @@ jobs:
           done
 
       - name: Upload logs
-        if: ${{ failure() || cancelled() }}
+        if: ${{ !success() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: craft-compose-integration-logs
           path: compose-logs/
           retention-days: 7
 
-      # Tear down. -v removes named volumes inside the compose project but the
-      # externally-declared sandbox_proxy_ca + onyx_craft_sandbox survive
-      # (compose down doesn't touch external resources).
+      # -v drops the project's named volumes; the external sandbox_proxy_ca /
+      # onyx_craft_sandbox are removed explicitly below.
       - name: Teardown
         if: always()
         working-directory: deployment/docker_compose

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -103,7 +103,6 @@ jobs:
         run: |
           # Find all leaf-level directories in both test directories.
           # ``craft`` excluded: needs sandbox infra this lane doesn't set up;
-          # coverage lives in pr-craft-k8s-tests.yml + external_dependency_unit.
           tests_dirs=$(find backend/tests/integration/tests -mindepth 1 -maxdepth 1 -type d ! -name "__pycache__" ! -name "mcp" ! -name "no_vectordb" ! -name "migrations" ! -name "craft" -exec basename {} \; | sort)
           connector_dirs=$(find backend/tests/integration/connector_job_tests -mindepth 1 -maxdepth 1 -type d ! -name "__pycache__" -exec basename {} \; | sort)
 

--- a/backend/tests/integration/common_utils/http_client.py
+++ b/backend/tests/integration/common_utils/http_client.py
@@ -1,14 +1,16 @@
-"""Module-level proxy to the active FastAPI ``TestClient``.
+"""Module-level proxy to the active integration HTTP client.
 
-The integration ``conftest.py`` builds one ``TestClient`` per test session and
-registers it via :func:`set_test_client`. Test code imports ``client`` from this
-module and calls it like a normal ``TestClient`` / ``httpx.Client``:
+The default integration ``conftest.py`` builds one in-process FastAPI
+``TestClient`` per test session and registers it via :func:`set_test_client`.
+Directory-specific suites can install a raw ``httpx.Client`` instead when they
+need to hit an out-of-process API server. Test code imports ``client`` from this
+module and calls it like a normal client:
 ``client.get("/foo")``, ``client.post("/foo", json=...)``, ``with
 client.stream("GET", "/sse") as r: ...``.
 
-The indirection (proxy instead of the bare TestClient) exists because the client
-is created lazily by a session-scoped fixture, after test modules have already
-been imported and bound their ``client`` reference.
+The indirection exists because the client is created lazily by a session-scoped
+fixture, after test modules have already imported and bound their ``client``
+reference.
 """
 
 from __future__ import annotations
@@ -19,9 +21,8 @@ import httpx
 
 from tests.integration.common_utils.constants import API_SERVER_URL
 
-# Typed as ``httpx.Client`` so both FastAPI's ``TestClient`` (in-process, the
-# default) and a raw ``httpx.Client`` (used by the docker e2e to hit a real
-# dockerized api_server) satisfy the signature.
+# Typed as ``httpx.Client`` so both FastAPI's ``TestClient`` and a raw
+# ``httpx.Client`` satisfy the signature.
 _test_client: httpx.Client | None = None
 
 

--- a/backend/tests/integration/tests/craft/conftest.py
+++ b/backend/tests/integration/tests/craft/conftest.py
@@ -2,16 +2,143 @@
 
 from __future__ import annotations
 
+import contextlib
+import time
+from collections.abc import Generator
+from uuid import UUID
+
+import httpx
 import pytest
 
+from onyx.db.engine.sql_engine import get_session_with_tenant
+from onyx.db.engine.sql_engine import SqlEngine
+from onyx.server.features.build.configs import SANDBOX_BACKEND
+from onyx.server.features.build.configs import SandboxBackend
+from onyx.server.features.build.db.sandbox import get_running_sandboxes
+from onyx.server.features.build.sandbox.factory import get_sandbox_manager
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+from tests.integration.common_utils import http_client
 from tests.integration.common_utils.constants import ADMIN_USER_NAME
+from tests.integration.common_utils.managers.build_session import BuildSessionManager
 from tests.integration.common_utils.managers.llm_provider import LLMProviderManager
 from tests.integration.common_utils.managers.user import UserManager
-from tests.integration.common_utils.reset import reset_all
+from tests.integration.common_utils.test_models import DATestLLMProvider
+from tests.integration.common_utils.test_models import DATestUser
 
 
 @pytest.fixture(scope="module", autouse=True)
+def _reap_module_sandboxes() -> Generator[None, None, None]:
+    yield
+    if SANDBOX_BACKEND != SandboxBackend.DOCKER:
+        return
+    SqlEngine.init_engine(pool_size=2, max_overflow=2)
+    with get_session_with_tenant(
+        tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+    ) as db:
+        running = get_running_sandboxes(db)
+    manager = get_sandbox_manager()
+    for sandbox in running:
+        with contextlib.suppress(Exception):
+            manager.terminate(sandbox.id)
+
+
+_RETRY_EXCEPTIONS = (
+    httpx.ConnectError,
+    httpx.ConnectTimeout,
+    httpx.ReadTimeout,
+    httpx.PoolTimeout,
+    httpx.RemoteProtocolError,
+)
+_RETRY_STATUSES = {500, 502, 504}
+_MAX_ATTEMPTS = 3
+
+
+class _RetryingTransport(httpx.HTTPTransport):
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        backoff = 0.5
+        for attempt in range(_MAX_ATTEMPTS):
+            last = attempt == _MAX_ATTEMPTS - 1
+            try:
+                response = super().handle_request(request)
+            except _RETRY_EXCEPTIONS:
+                if last:
+                    raise
+                time.sleep(backoff)
+                backoff *= 2
+                continue
+            if response.status_code in _RETRY_STATUSES and not last:
+                response.close()
+                time.sleep(backoff)
+                backoff *= 2
+                continue
+            return response
+        raise AssertionError("unreachable")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _test_client() -> Generator[httpx.Client, None, None]:
+    """httpx client targeting the real out-of-process api_server."""
+    real_client = httpx.Client(
+        transport=_RetryingTransport(),
+        timeout=httpx.Timeout(60.0, connect=10.0),
+    )
+    http_client.set_test_client(real_client)
+    try:
+        yield real_client
+    finally:
+        real_client.close()
+        http_client.set_test_client(None)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _install_playwright() -> None:
+    """No-op override: craft API-boundary tests don't use playwright."""
+    return None
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _start_celery_workers() -> Generator[None, None, None]:
+    """No-op override: the deployed ``background`` worker runs the celery tasks."""
+    yield None
+
+
+@pytest.fixture(scope="session", autouse=True)
 def _module_reset_and_seed() -> None:
-    reset_all()
+    """Skip the parent's reset_all() (out-of-process downgrade deadlocks against
+    the api_server's pooled connections); seed an admin + LLM provider."""
     admin = UserManager.create(name=ADMIN_USER_NAME)
     LLMProviderManager.create(user_performing_action=admin, api_key="test-api-key")
+
+
+@pytest.fixture
+def llm_provider(admin_user: DATestUser) -> DATestLLMProvider:
+    """Override the global fixture: seed a provider with a fake key (the compose
+    lane has no OPENAI_API_KEY and craft tests make no live call)."""
+    return LLMProviderManager.create(
+        user_performing_action=admin_user, api_key="test-api-key"
+    )
+
+
+@pytest.fixture(scope="module")
+def shared_session(
+    request: pytest.FixtureRequest,
+) -> Generator[tuple[DATestUser, UUID], None, None]:
+    """One provisioned session + sandbox, shared across a module's tests.
+
+    Owned by a per-module user isolated from the function-scoped
+    admin_user/basic_user so a sibling's create/delete can't terminate its
+    sandbox. Use only for read-only / validation / ownership checks; tests that
+    mutate-and-assert session state must create their own session.
+    """
+    slug = request.module.__name__.rsplit(".", 1)[-1].replace("_", "-")
+    owner = UserManager.create(name=f"craft-shared-{slug}")
+    body = BuildSessionManager.create(owner)
+    sandbox = body.get("sandbox")
+    try:
+        yield owner, UUID(body["id"])
+    finally:
+        if sandbox and sandbox.get("id"):
+            try:
+                get_sandbox_manager().terminate(UUID(sandbox["id"]))
+            except Exception:
+                pass

--- a/backend/tests/integration/tests/craft/conftest.py
+++ b/backend/tests/integration/tests/craft/conftest.py
@@ -6,10 +6,12 @@ import contextlib
 import time
 from collections.abc import Generator
 from uuid import UUID
+from uuid import uuid4
 
 import httpx
 import pytest
 
+from onyx.auth.schemas import UserRole
 from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.engine.sql_engine import SqlEngine
 from onyx.server.features.build.configs import SANDBOX_BACKEND
@@ -19,8 +21,11 @@ from onyx.server.features.build.sandbox.factory import get_sandbox_manager
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from tests.integration.common_utils import http_client
 from tests.integration.common_utils.constants import ADMIN_USER_NAME
+from tests.integration.common_utils.constants import GENERAL_HEADERS
 from tests.integration.common_utils.managers.build_session import BuildSessionManager
 from tests.integration.common_utils.managers.llm_provider import LLMProviderManager
+from tests.integration.common_utils.managers.user import build_email
+from tests.integration.common_utils.managers.user import DEFAULT_PASSWORD
 from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.test_models import DATestLLMProvider
 from tests.integration.common_utils.test_models import DATestUser
@@ -42,14 +47,17 @@ def _reap_module_sandboxes() -> Generator[None, None, None]:
             manager.terminate(sandbox.id)
 
 
-_RETRY_EXCEPTIONS = (
+_CONNECT_RETRY_EXCEPTIONS = (
     httpx.ConnectError,
     httpx.ConnectTimeout,
-    httpx.ReadTimeout,
     httpx.PoolTimeout,
+)
+_SAFE_RETRY_EXCEPTIONS = (
+    httpx.ReadTimeout,
     httpx.RemoteProtocolError,
 )
-_RETRY_STATUSES = {500, 502, 504}
+_RETRY_STATUSES = {502, 504}
+_SAFE_RETRY_METHODS = {"GET", "HEAD", "OPTIONS"}
 _MAX_ATTEMPTS = 3
 
 
@@ -60,19 +68,52 @@ class _RetryingTransport(httpx.HTTPTransport):
             last = attempt == _MAX_ATTEMPTS - 1
             try:
                 response = super().handle_request(request)
-            except _RETRY_EXCEPTIONS:
+            except _CONNECT_RETRY_EXCEPTIONS:
                 if last:
                     raise
                 time.sleep(backoff)
                 backoff *= 2
                 continue
-            if response.status_code in _RETRY_STATUSES and not last:
+            except _SAFE_RETRY_EXCEPTIONS:
+                if last or request.method.upper() not in _SAFE_RETRY_METHODS:
+                    raise
+                time.sleep(backoff)
+                backoff *= 2
+                continue
+            if (
+                response.status_code in _RETRY_STATUSES
+                and request.method.upper() in _SAFE_RETRY_METHODS
+                and not last
+            ):
                 response.close()
                 time.sleep(backoff)
                 backoff *= 2
                 continue
             return response
         raise AssertionError("unreachable")
+
+
+def _create_or_login_user(name: str, expected_role: UserRole) -> DATestUser:
+    try:
+        user = UserManager.create(name=name)
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code != 400:
+            raise
+        user = UserManager.login_as_user(
+            DATestUser(
+                id="",
+                email=build_email(name),
+                password=DEFAULT_PASSWORD,
+                headers=GENERAL_HEADERS.copy(),
+                role=expected_role,
+                is_active=True,
+            )
+        )
+    if user.role != expected_role:
+        raise AssertionError(
+            f"Expected {name} to have role {expected_role.value}, got {user.role.value}"
+        )
+    return user
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -106,7 +147,7 @@ def _start_celery_workers() -> Generator[None, None, None]:
 def _module_reset_and_seed() -> None:
     """Skip the parent's reset_all() (out-of-process downgrade deadlocks against
     the api_server's pooled connections); seed an admin + LLM provider."""
-    admin = UserManager.create(name=ADMIN_USER_NAME)
+    admin = _create_or_login_user(ADMIN_USER_NAME, UserRole.ADMIN)
     LLMProviderManager.create(user_performing_action=admin, api_key="test-api-key")
 
 
@@ -131,7 +172,7 @@ def shared_session(
     mutate-and-assert session state must create their own session.
     """
     slug = request.module.__name__.rsplit(".", 1)[-1].replace("_", "-")
-    owner = UserManager.create(name=f"craft-shared-{slug}")
+    owner = UserManager.create(name=f"craft-shared-{slug}-{uuid4().hex[:8]}")
     body = BuildSessionManager.create(owner)
     sandbox = body.get("sandbox")
     try:

--- a/backend/tests/integration/tests/craft/docker_e2e/conftest.py
+++ b/backend/tests/integration/tests/craft/docker_e2e/conftest.py
@@ -1,43 +1,11 @@
-"""
-Overrides the integration framework's in-process ``_test_client`` autouse with a
-real httpx.Client, plus seeds a Slack ``external_app`` so the gate flow can
-fire.
-
-The default ``tests/integration/conftest.py::_test_client`` builds an in-process
-FastAPI ``TestClient``. That works for tests where the "api_server" being
-asserted against is the test process itself. It does NOT work for the docker e2e
--- those tests provision real sandbox containers via the docker socket, and
-``DockerSandboxManager.provision`` blocks on a health-check against
-``http://sandbox-<id8>:4096``, a hostname that only resolves inside the
-``onyx_craft_sandbox`` bridge network. The in-process api_server lives on the
-host net and can never resolve it.
-
-The fix: hit the dockerized api_server (port-published at host 8080 by
-``docker-compose.dev.yml``) instead. From the host, ``localhost:8080`` -> the
-api_server container, which is on both the default and ``onyx_craft_sandbox``
-networks and CAN resolve sandbox hostnames.
-
-The Slack seeding is needed because the default deployment has no external apps
-configured. ``ExternalAppActionMatcher`` only claims a request if some app's
-``upstream_url_patterns`` matches the URL; without a Slack row,
-``chat.postMessage`` is treated as off-catalog and not gated.
-``AUTO_PROVISION_DEFAULT_EXTERNAL_APPS`` defaults to off and the K8s lane
-doesn't actually run ``test_approval_gate.py`` either (it's not listed in the
-lane's paths filter or pytest args), so this fixture is the first place to wire
-the seeding in CI.
-
-This conftest is intentionally scoped to ``docker_e2e/`` only. Sibling craft
-tests under ``tests/integration/tests/craft/`` keep the in-process model.
-"""
+"""Docker-e2e fixtures layered on the craft base conftest."""
 
 from __future__ import annotations
 
 import subprocess
-from collections.abc import Generator
 from typing import Protocol
 from uuid import UUID
 
-import httpx
 import pytest
 
 from onyx.db.engine.sql_engine import get_session_with_tenant
@@ -45,11 +13,7 @@ from onyx.db.enums import EndpointPolicy
 from onyx.db.enums import ExternalAppType
 from onyx.db.external_app import create_external_app
 from onyx.db.external_app import get_built_in_external_app
-from tests.integration.common_utils import http_client
-from tests.integration.common_utils.constants import ADMIN_USER_NAME
 from tests.integration.common_utils.managers.build_session import BuildSessionManager
-from tests.integration.common_utils.managers.llm_provider import LLMProviderManager
-from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.test_models import DATestUser
 
 
@@ -69,7 +33,6 @@ class ProvisionSandbox(Protocol):
 
 
 def _container_name(sandbox_id: str) -> str:
-    """Docker manager names containers ``sandbox-<id8>``."""
     return f"sandbox-{sandbox_id.split('-')[0]}"
 
 
@@ -80,7 +43,6 @@ def _docker_exec(
     timeout: float = 30.0,
     user: str | None = None,
 ) -> subprocess.CompletedProcess[str]:
-    """Runs ``cmd`` inside ``container`` and captures stdout/stderr."""
     command = ["docker", "exec"]
     if user is not None:
         command.extend(["--user", user])
@@ -95,12 +57,6 @@ def _docker_exec(
 
 
 def _provision_sandbox(user: DATestUser) -> tuple[UUID, str]:
-    """
-    Creates a session via the real API and returns its (session_id, container).
-
-    The create endpoint is synchronous -- by the time it returns, the sandbox
-    container is RUNNING and opencode-serve has passed its health check.
-    """
     session = BuildSessionManager.create(user)
     sandbox = session["sandbox"]
     assert sandbox is not None, f"Session response missing sandbox: {session!r}"
@@ -118,47 +74,6 @@ def docker_exec() -> DockerExec:
 @pytest.fixture(scope="session")
 def provision_sandbox() -> ProvisionSandbox:
     return _provision_sandbox
-
-
-@pytest.fixture(scope="session", autouse=True)
-def _test_client() -> Generator[httpx.Client, None, None]:
-    """
-    Replaces the parent ``_test_client`` with an httpx.Client targeting the
-    dockerized api_server. Same fixture name + scope so pytest picks the child
-    override per directory.
-    """
-    real_client = httpx.Client(timeout=httpx.Timeout(60.0, connect=10.0))
-    http_client.set_test_client(real_client)
-    try:
-        yield real_client
-    finally:
-        real_client.close()
-        http_client.set_test_client(None)
-
-
-@pytest.fixture(scope="session", autouse=True)
-def _install_playwright() -> None:
-    """No-op override: No docker_e2e test uses playwright."""
-    return None
-
-
-@pytest.fixture(scope="session", autouse=True)
-def _start_celery_workers() -> Generator[None, None, None]:
-    """No-op override: The ``background`` container already runs the workers."""
-    yield None
-
-
-@pytest.fixture(scope="session", autouse=True)
-def _module_reset_and_seed() -> None:
-    """
-    Override: Skip the parent's ``reset_all()``. The dockerized api_server holds
-    pooled postgres connections; an out-of-process ``alembic downgrade base``
-    deadlocks against those. Admin + LLM provider seeding is session-scoped
-    because this directory has multiple test modules and ``UserManager.create``
-    is not idempotent for the fixed admin email.
-    """
-    admin = UserManager.create(name=ADMIN_USER_NAME)
-    LLMProviderManager.create(user_performing_action=admin, api_key="test-api-key")
 
 
 @pytest.fixture(scope="module")
@@ -184,8 +99,6 @@ def slack_external_app() -> None:
                 app_type=ExternalAppType.SLACK,
                 upstream_url_patterns=["https://slack\\.com/api/.*"],
                 auth_template={"Authorization": "Bearer {access_token}"},
-                # Fake token. An unfillable template short-circuits the ASK gate
-                # (forwards bare, no DB row), which breaks every gate-flow test.
                 organization_credentials={"access_token": "fake-test-token"},
                 enabled=True,
                 is_public=True,

--- a/backend/tests/integration/tests/craft/test_file_ops_api.py
+++ b/backend/tests/integration/tests/craft/test_file_ops_api.py
@@ -1,9 +1,4 @@
-"""File ops security boundary tests (integration / HTTP boundary half).
-
-Pins the path-traversal, hidden-entry, cross-user, and content-type rules
-across the build session file-ops endpoints (list / read / delete /
-download_artifact / download_directory / pptx-preview / export-docx).
-"""
+"""File ops security boundary tests (HTTP boundary half)."""
 
 from __future__ import annotations
 
@@ -12,14 +7,11 @@ from uuid import UUID
 
 import pytest
 
+from onyx.server.features.build.sandbox.factory import get_sandbox_manager
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.http_client import client
 from tests.integration.common_utils.managers.build_session import BuildSessionManager
 from tests.integration.common_utils.test_models import DATestUser
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
 
 
 def _create_session_id(user: DATestUser) -> UUID:
@@ -27,14 +19,18 @@ def _create_session_id(user: DATestUser) -> UUID:
     return UUID(session["id"])
 
 
+def _create_session_with_sandbox(user: DATestUser) -> tuple[UUID, UUID]:
+    session = BuildSessionManager.create(user)
+    sandbox = session["sandbox"]
+    assert sandbox is not None, "session create did not return a sandbox"
+    return UUID(session["id"]), UUID(sandbox["id"])
+
+
 def _files_url(session_id: UUID) -> str:
     return f"{API_SERVER_URL}/build/sessions/{session_id}/files"
 
 
 def _delete_file_url(session_id: UUID, path: str) -> str:
-    # ``path`` is intentionally not URL-encoded by some tests so that the
-    # raw bytes reach the server; FastAPI's ``{path:path}`` matcher accepts
-    # additional slashes but special chars need encoding by the caller.
     return f"{API_SERVER_URL}/build/sessions/{session_id}/files/{path}"
 
 
@@ -55,52 +51,36 @@ def _export_docx_url(session_id: UUID, path: str) -> str:
 
 
 def _seed_file(user: DATestUser, session_id: UUID, name: str = "seed.txt") -> str:
-    """Upload a file so the session has at least one attachment for read/delete tests."""
     body = BuildSessionManager.upload_file(
         user, session_id, filename=name, content=b"seed-content"
     )
     return str(body["path"])
 
 
-# ---------------------------------------------------------------------------
-# list_directory
-# ---------------------------------------------------------------------------
-
-
-def test_list_directory_rejects_path_traversal(admin_user: DATestUser) -> None:
-    """GET /files?path=../etc must not leak content from outside the sandbox.
-
-    The sandbox manager sanitizes the path (strips ``..``) which resolves
-    to a non-existent path within the session — returning 200 with empty
-    entries. An explicit 403 is also acceptable.
-    """
-    session_id = _create_session_id(admin_user)
+def test_list_directory_rejects_path_traversal(
+    shared_session: tuple[DATestUser, UUID],
+) -> None:
+    owner, session_id = shared_session
     response = client.get(
         _files_url(session_id),
         params={"path": "../etc"},
-        headers=admin_user.headers,
-        cookies=admin_user.cookies,
+        headers=owner.headers,
+        cookies=owner.cookies,
     )
     assert response.status_code in (200, 403)
     if response.status_code == 200:
-        # No leaked entries from outside the sandbox
         assert response.json()["entries"] == []
 
 
-def test_list_directory_returns_200_for_missing_dir(admin_user: DATestUser) -> None:
-    """GET /files?path=does-not-exist returns 200 with an empty entries list.
-
-    Non-traversal paths that don't exist on disk are caught by the sandbox
-    manager as ``ValueError("Not a directory: ...")``. The session manager
-    treats all non-traversal ValueErrors as "nothing to show" and returns an
-    empty ``DirectoryListing`` (200).
-    """
-    session_id = _create_session_id(admin_user)
+def test_list_directory_returns_200_for_missing_dir(
+    shared_session: tuple[DATestUser, UUID],
+) -> None:
+    owner, session_id = shared_session
     response = client.get(
         _files_url(session_id),
         params={"path": "definitely-not-a-real-subdir"},
-        headers=admin_user.headers,
-        cookies=admin_user.cookies,
+        headers=owner.headers,
+        cookies=owner.cookies,
     )
     assert response.status_code == 200
     body = response.json()
@@ -108,22 +88,14 @@ def test_list_directory_returns_200_for_missing_dir(admin_user: DATestUser) -> N
 
 
 def test_list_directory_returns_empty_when_workspace_missing(
-    admin_user: DATestUser,
+    shared_session: tuple[DATestUser, UUID],
 ) -> None:
-    """When the sandbox workspace itself is missing, list_directory returns 200 + empty.
+    owner, session_id = shared_session
 
-    Pins the manager.py:2179-2182 behaviour: a missing workspace short-circuits
-    to an empty listing rather than surfacing as 404.
-    """
-    session_id = _create_session_id(admin_user)
-
-    # Empty path = workspace root. A freshly-created session may not have its
-    # workspace loaded into the sandbox yet; either way the endpoint must not
-    # 404 on a path that's not a traversal attempt.
     response = client.get(
         _files_url(session_id),
-        headers=admin_user.headers,
-        cookies=admin_user.cookies,
+        headers=owner.headers,
+        cookies=owner.cookies,
     )
     assert response.status_code == 200
     body = response.json()
@@ -131,61 +103,38 @@ def test_list_directory_returns_empty_when_workspace_missing(
     assert isinstance(body["entries"], list)
 
 
-# ---------------------------------------------------------------------------
-# read_file (via artifact download — the build router exposes reads through
-# the same /artifacts/{path} endpoint)
-# ---------------------------------------------------------------------------
-
-
-def test_read_file_rejects_path_traversal(admin_user: DATestUser) -> None:
-    """Downloading a path-traversal artifact must not leak external files.
-
-    The exact status code depends on whether the sandbox manager rejects
-    (403) or normalizes-and-misses (400/404) — either is acceptable as long
-    as no file content escapes the sandbox.
-    """
-    session_id = _create_session_id(admin_user)
+def test_read_file_rejects_path_traversal(
+    shared_session: tuple[DATestUser, UUID],
+) -> None:
+    owner, session_id = shared_session
     response = client.get(
         _artifact_url(session_id, "..%2Fetc%2Fpasswd"),
-        headers=admin_user.headers,
-        cookies=admin_user.cookies,
+        headers=owner.headers,
+        cookies=owner.cookies,
     )
     assert response.status_code in (400, 403, 404)
 
 
-# ---------------------------------------------------------------------------
-# delete_file
-# ---------------------------------------------------------------------------
-
-
-def test_delete_file_rejects_path_traversal(admin_user: DATestUser) -> None:
-    """DELETE with a path-traversal segment must not delete files outside the sandbox.
-
-    The HTTP routing layer may collapse ``..`` before the handler runs
-    (resulting in 404 for a missing file), or the sandbox manager may
-    detect ``..`` and reject explicitly (403). Either is acceptable as
-    long as 204 (success) is NOT returned.
-    """
-    session_id = _create_session_id(admin_user)
+def test_delete_file_rejects_path_traversal(
+    shared_session: tuple[DATestUser, UUID],
+) -> None:
+    owner, session_id = shared_session
     response = client.delete(
         _delete_file_url(session_id, "attachments/../../etc/passwd"),
-        headers=admin_user.headers,
-        cookies=admin_user.cookies,
+        headers=owner.headers,
+        cookies=owner.cookies,
     )
     assert response.status_code in (403, 404)
 
 
-def test_delete_file_rejects_url_encoded_traversal(admin_user: DATestUser) -> None:
-    """DELETE /files/%2e%2e/etc returns 403 (URL-encoded ``..`` still rejected).
-
-    Starlette decodes ``%2e%2e`` to ``..`` before the handler runs, so the
-    sandbox manager's ``..`` regex fires and the API maps the error to 403.
-    """
-    session_id = _create_session_id(admin_user)
+def test_delete_file_rejects_url_encoded_traversal(
+    shared_session: tuple[DATestUser, UUID],
+) -> None:
+    owner, session_id = shared_session
     response = client.delete(
         _delete_file_url(session_id, "attachments/%2e%2e/etc/passwd"),
-        headers=admin_user.headers,
-        cookies=admin_user.cookies,
+        headers=owner.headers,
+        cookies=owner.cookies,
     )
     assert response.status_code == 403
 
@@ -195,66 +144,119 @@ def test_delete_file_rejects_url_encoded_traversal(admin_user: DATestUser) -> No
     [";", "|", "`", "$()", "&"],
 )
 def test_delete_file_rejects_shell_metachars(
-    admin_user: DATestUser, metachar: str
+    shared_session: tuple[DATestUser, UUID], metachar: str
 ) -> None:
-    """Shell metacharacters in the delete path are rejected with 400.
-
-    The sandbox manager's shell-metacharacter regex raises
-    ``ValueError("...disallowed characters...")``, which does not contain
-    "path traversal" so the API's catch-all maps it to 400.
-    """
-    session_id = _create_session_id(admin_user)
-    # Embed the metacharacter into an otherwise innocuous path. URL-encode so
-    # that special chars (e.g. ``;``, ``&``, ``$``) survive routing intact.
+    owner, session_id = shared_session
     encoded = quote(f"attachments/foo{metachar}bar.txt", safe="/")
     response = client.delete(
         f"{API_SERVER_URL}/build/sessions/{session_id}/files/{encoded}",
-        headers=admin_user.headers,
-        cookies=admin_user.cookies,
+        headers=owner.headers,
+        cookies=owner.cookies,
     )
     assert response.status_code == 400
 
 
-def test_delete_file_rejects_null_byte(admin_user: DATestUser) -> None:
-    """A NUL byte in the delete path is rejected with 403.
-
-    Starlette decodes ``%00`` to ``\\x00``. The sandbox manager's null-byte
-    check raises ``ValueError("...path traversal...")``, mapped to 403.
-    """
-    session_id = _create_session_id(admin_user)
-    # ``%00`` is the URL-encoded NUL byte. requests will pass it through
-    # raw so the server sees the actual byte.
+def test_delete_file_rejects_null_byte(
+    shared_session: tuple[DATestUser, UUID],
+) -> None:
+    owner, session_id = shared_session
     response = client.delete(
         f"{API_SERVER_URL}/build/sessions/{session_id}/files/attachments/foo%00bar.txt",
-        headers=admin_user.headers,
-        cookies=admin_user.cookies,
+        headers=owner.headers,
+        cookies=owner.cookies,
     )
     assert response.status_code == 403
 
 
-# ---------------------------------------------------------------------------
-# download_artifact (path traversal + opencode.json hiding)
-# ---------------------------------------------------------------------------
-
-
-def test_download_artifact_rejects_path_traversal(admin_user: DATestUser) -> None:
-    """GET /artifacts/..%2Fetc must not leak content from outside the sandbox.
-
-    Sandbox manager either rejects (403) or normalizes-and-misses (400/404)
-    — both prevent escape; only a 2xx with external content would be a bug.
-    """
-    session_id = _create_session_id(admin_user)
+def test_download_artifact_rejects_path_traversal(
+    shared_session: tuple[DATestUser, UUID],
+) -> None:
+    owner, session_id = shared_session
     response = client.get(
         _artifact_url(session_id, "..%2F..%2Fetc%2Fpasswd"),
-        headers=admin_user.headers,
-        cookies=admin_user.cookies,
+        headers=owner.headers,
+        cookies=owner.cookies,
     )
     assert response.status_code in (400, 403, 404)
 
 
-def test_download_artifact_hides_opencode_json(admin_user: DATestUser) -> None:
-    """Direct download of ``opencode.json`` returns 404 even if the file exists."""
+def test_upload_stats_empty_session_has_no_attachments(
+    admin_user: DATestUser,
+) -> None:
     session_id = _create_session_id(admin_user)
+
+    listing = BuildSessionManager.list_files(admin_user, session_id, path="attachments")
+    files = [e for e in listing.get("entries", []) if not e["is_directory"]]
+    assert files == []
+
+
+def test_upload_stats_reflect_uploaded_files(admin_user: DATestUser) -> None:
+    session_id = _create_session_id(admin_user)
+
+    first = b"hello"
+    second = b"world!"
+    BuildSessionManager.upload_file(
+        admin_user, session_id, filename="file1.txt", content=first
+    )
+    BuildSessionManager.upload_file(
+        admin_user, session_id, filename="file2.txt", content=second
+    )
+
+    listing = BuildSessionManager.list_files(admin_user, session_id, path="attachments")
+    files = [e for e in listing.get("entries", []) if not e["is_directory"]]
+    sizes_by_name = {e["name"]: e["size"] for e in files}
+
+    assert sizes_by_name == {"file1.txt": len(first), "file2.txt": len(second)}
+
+
+def test_download_directory_zip_respects_traversal_rules(
+    shared_session: tuple[DATestUser, UUID],
+) -> None:
+    owner, session_id = shared_session
+    response = client.get(
+        _download_directory_url(session_id, "..%2Fetc"),
+        headers=owner.headers,
+        cookies=owner.cookies,
+    )
+    assert response.status_code == 404
+
+
+def test_pptx_preview_rejects_non_pptx(
+    shared_session: tuple[DATestUser, UUID],
+) -> None:
+    owner, session_id = shared_session
+    response = client.get(
+        _pptx_preview_url(session_id, "outputs/report.docx"),
+        headers=owner.headers,
+        cookies=owner.cookies,
+    )
+    assert response.status_code == 400
+
+
+def test_export_docx_rejects_non_md(
+    shared_session: tuple[DATestUser, UUID],
+) -> None:
+    owner, session_id = shared_session
+    # Seed a real .txt so the endpoint reaches the extension check, not "not found".
+    seed_path = _seed_file(owner, session_id, name="notes.txt")
+    response = client.get(
+        _export_docx_url(session_id, seed_path),
+        headers=owner.headers,
+        cookies=owner.cookies,
+    )
+    assert response.status_code == 400
+
+
+def test_download_artifact_hides_opencode_json(
+    admin_user: DATestUser,
+) -> None:
+    session_id, sandbox_id = _create_session_with_sandbox(admin_user)
+    get_sandbox_manager().write_sandbox_file(
+        sandbox_id,
+        f"sessions/{session_id}/opencode.json",
+        '{"model": "test"}',
+    )
+
     response = client.get(
         _artifact_url(session_id, "opencode.json"),
         headers=admin_user.headers,
@@ -263,49 +265,35 @@ def test_download_artifact_hides_opencode_json(admin_user: DATestUser) -> None:
     assert response.status_code == 404
 
 
-# ---------------------------------------------------------------------------
-# list_directory — hidden-entry filtering
-# ---------------------------------------------------------------------------
+def test_list_directory_filters_hidden_entries(
+    admin_user: DATestUser,
+) -> None:
+    session_id, sandbox_id = _create_session_with_sandbox(admin_user)
+    manager = get_sandbox_manager()
 
+    hidden_names = {".venv/keep", "node_modules/keep", "opencode.json", ".env"}
+    visible_names = {"alpha.txt", "beta.txt"}
 
-def test_list_directory_filters_hidden_entries(admin_user: DATestUser) -> None:
-    """``opencode.json``, ``.env`` and other HIDDEN_PATTERNS entries are never
-    surfaced by the list endpoint.
-
-    The upload API blocks creation of dotted/system files (sanitiser strips
-    the leading dot, and ``.env`` is on the BLOCKED list at the filename
-    level via the SAFE_FILENAME_PATTERN). We rely on the actual hidden
-    filters baked into the manager — we just assert that no listing ever
-    returns the forbidden names.
-    """
-    session_id = _create_session_id(admin_user)
-    # Seed a couple of normal files so the listing isn't trivially empty.
-    BuildSessionManager.upload_file(
-        admin_user, session_id, filename="alpha.txt", content=b"a"
-    )
-    BuildSessionManager.upload_file(
-        admin_user, session_id, filename="beta.txt", content=b"b"
-    )
+    for rel in hidden_names | visible_names:
+        manager.write_sandbox_file(
+            sandbox_id,
+            f"sessions/{session_id}/{rel}",
+            "x",
+        )
 
     listing = BuildSessionManager.list_files(admin_user, session_id)
-    entries = listing.get("entries", [])
-    names = {entry["name"] for entry in entries}
+    names = {entry["name"] for entry in listing.get("entries", [])}
 
-    forbidden = {".venv", ".git", "node_modules", ".DS_Store", "opencode.json", ".env"}
-    assert names.isdisjoint(forbidden), (
-        f"Listing returned hidden entries: {names & forbidden}"
-    )
-
-
-# ---------------------------------------------------------------------------
-# Cross-user isolation
-# ---------------------------------------------------------------------------
+    assert ".venv" not in names
+    assert "node_modules" not in names
+    assert "opencode.json" not in names
+    assert ".env" not in names
+    assert visible_names <= names
 
 
 def test_cross_user_file_access_returns_404(
     admin_user: DATestUser, basic_user: DATestUser
 ) -> None:
-    """User A asking for User B's session via any file-op endpoint sees 404."""
     foreign_session_id = _create_session_id(basic_user)
 
     response = client.get(
@@ -314,56 +302,3 @@ def test_cross_user_file_access_returns_404(
         cookies=admin_user.cookies,
     )
     assert response.status_code == 404
-
-
-# ---------------------------------------------------------------------------
-# download_directory zip
-# ---------------------------------------------------------------------------
-
-
-def test_download_directory_zip_respects_traversal_rules(
-    admin_user: DATestUser,
-) -> None:
-    """download-directory returns 404 for a traversal path.
-
-    ``session_manager.download_directory`` calls ``sandbox_manager.list_directory``
-    which sanitises ``..`` away.  The resulting path doesn't exist on disk, so
-    the manager catches the ``ValueError`` and returns ``None`` -> 404.
-    """
-    session_id = _create_session_id(admin_user)
-    response = client.get(
-        _download_directory_url(session_id, "..%2Fetc"),
-        headers=admin_user.headers,
-        cookies=admin_user.cookies,
-    )
-    assert response.status_code == 404
-
-
-# ---------------------------------------------------------------------------
-# pptx-preview / export-docx content-type checks
-# ---------------------------------------------------------------------------
-
-
-def test_pptx_preview_rejects_non_pptx(admin_user: DATestUser) -> None:
-    """pptx-preview returns 400 for a .docx file."""
-    session_id = _create_session_id(admin_user)
-    response = client.get(
-        _pptx_preview_url(session_id, "outputs/report.docx"),
-        headers=admin_user.headers,
-        cookies=admin_user.cookies,
-    )
-    assert response.status_code == 400
-
-
-def test_export_docx_rejects_non_md(admin_user: DATestUser) -> None:
-    """export-docx returns 400 for a .txt file."""
-    session_id = _create_session_id(admin_user)
-    # Seed an actual .txt file so the endpoint reaches the extension check
-    # rather than short-circuiting on "file not found".
-    seed_path = _seed_file(admin_user, session_id, name="notes.txt")
-    response = client.get(
-        _export_docx_url(session_id, seed_path),
-        headers=admin_user.headers,
-        cookies=admin_user.cookies,
-    )
-    assert response.status_code == 400

--- a/backend/tests/integration/tests/craft/test_messages_api.py
+++ b/backend/tests/integration/tests/craft/test_messages_api.py
@@ -1,13 +1,9 @@
-"""Interactive Craft turn API tests.
-
-These tests exercise the HTTP boundary for the no-migration background-turn
-flow: ``POST /send-message`` starts work and returns turn metadata, while
-``GET /turns/{turn_id}/events`` is attach-only.
-"""
+"""Interactive Craft turn API tests against a real sandbox."""
 
 from __future__ import annotations
 
 import uuid
+from uuid import UUID
 
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.http_client import client
@@ -79,10 +75,9 @@ def test_send_message_rejects_concurrent_active_turn(
 
 
 def test_send_message_404_for_other_users_session(
-    admin_user: DATestUser,
+    shared_session: tuple[DATestUser, UUID],
 ) -> None:
-    body = BuildSessionManager.create(admin_user)
-    session_id = body["id"]
+    _owner, session_id = shared_session
     other_user = UserManager.create(name=f"otheruser-{uuid.uuid4().hex[:8]}")
 
     response = client.post(
@@ -96,15 +91,14 @@ def test_send_message_404_for_other_users_session(
 
 
 def test_turn_events_requires_active_turn(
-    admin_user: DATestUser,
+    shared_session: tuple[DATestUser, UUID],
 ) -> None:
-    body = BuildSessionManager.create(admin_user)
-    session_id = uuid.UUID(body["id"])
+    owner, session_id = shared_session
 
     response = client.get(
         f"{API_SERVER_URL}/build/sessions/{session_id}/turns/{uuid.uuid4()}/events",
-        headers=admin_user.headers,
-        cookies=admin_user.cookies,
+        headers=owner.headers,
+        cookies=owner.cookies,
     )
 
     assert response.status_code == 409

--- a/backend/tests/integration/tests/craft/test_scheduled_tasks_api.py
+++ b/backend/tests/integration/tests/craft/test_scheduled_tasks_api.py
@@ -1,38 +1,39 @@
-"""Scheduled tasks tests (integration / HTTP half).
-
-Integration tests for the user-facing scheduled-tasks HTTP API in
-``onyx.server.features.build.scheduled_tasks.api``.
-
-Hits the real backend over HTTP. The executor / dispatch state-machine
-half is covered in
-``tests/external_dependency_unit/craft/test_scheduled_task_executor.py``
-— this file deliberately stays at the HTTP boundary and never invokes
-the executor directly.
-"""
+"""Scheduled tasks tests (HTTP contract)."""
 
 from __future__ import annotations
 
 import time
+from collections.abc import Generator
 from typing import Any
 from uuid import UUID
 from uuid import uuid4
 
 import httpx
+import pytest
 from sqlalchemy import select
 
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import SqlEngine
 from onyx.db.enums import ScheduledTaskRunStatus
 from onyx.db.enums import ScheduledTaskStatus
 from onyx.db.enums import ScheduledTaskTriggerSource
 from onyx.db.models import ScheduledTask
 from onyx.db.models import ScheduledTaskRun
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.http_client import client
 from tests.integration.common_utils.test_models import DATestUser
 
-# ---------------------------------------------------------------------------
-# Inline HTTP wrapper — kept here per the task spec (no separate manager).
-# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _db_access() -> Generator[None, None, None]:
+    SqlEngine.init_engine(pool_size=10, max_overflow=5)
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
+    try:
+        yield
+    finally:
+        CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
 
 
 def _url(*parts: str) -> str:
@@ -135,13 +136,7 @@ def _get_runs_for_task(task_id: UUID) -> list[ScheduledTaskRun]:
         )
 
 
-# ---------------------------------------------------------------------------
-# Tests
-# ---------------------------------------------------------------------------
-
-
 def test_create_task_compiles_cron(admin_user: DATestUser) -> None:
-    """POST with ``editor_mode=interval`` compiles to a 5-field cron string."""
     response = _create_task(
         admin_user,
         editor_mode="interval",
@@ -150,40 +145,24 @@ def test_create_task_compiles_cron(admin_user: DATestUser) -> None:
     response.raise_for_status()
     body = response.json()
     assert body["editor_mode"] == "interval"
-    # Cron is canonical 5-field; "every 6 hours" compiles to "0 */6 * * *".
     cron = body["cron_expression"]
     assert isinstance(cron, str)
     assert len(cron.split()) == 5
-    # DB row carries the same cron.
     row = _get_task_row(UUID(body["id"]))
     assert row is not None
     assert row.cron_expression == cron
 
 
-def test_create_task_requires_paired_editor_fields(admin_user: DATestUser) -> None:
-    """A missing required payload field is rejected.
-
-    ``editor_mode=daily_weekly`` requires ``time_of_day`` in the payload;
-    omitting it yields a Pydantic validation error → 422. The master
-    plan describes this as 400 because most validation errors emerge as
-    400, but Pydantic-level errors from FastAPI surface as 422.
-    """
+def test_create_task_interval_days_requires_time_of_day(admin_user: DATestUser) -> None:
     response = _create_task(
         admin_user,
-        editor_mode="daily_weekly",
-        editor_payload={"weekdays": [1, 3, 5]},  # missing time_of_day
+        editor_mode="interval",
+        editor_payload={"unit": "days", "every": 1},
     )
-    # Pydantic-level validation errors from FastAPI surface as 422.
     assert response.status_code == 422
 
 
 def test_create_with_run_immediately_enqueues(admin_user: DATestUser) -> None:
-    """``run_immediately=true`` creates a ``MANUAL_RUN_NOW`` run row in DB.
-
-    We don't wait for the executor; we just verify the side effect of
-    the POST: a ScheduledTaskRun row exists with
-    ``trigger_source=MANUAL_RUN_NOW`` and ``status=QUEUED``.
-    """
     response = _create_task(admin_user, run_immediately=True)
     response.raise_for_status()
     task_id = UUID(response.json()["id"])
@@ -193,9 +172,7 @@ def test_create_with_run_immediately_enqueues(admin_user: DATestUser) -> None:
     [run] = [
         r for r in runs if r.trigger_source == ScheduledTaskTriggerSource.MANUAL_RUN_NOW
     ]
-    # ``QUEUED`` is the insert-side state; the executor may have already
-    # picked it up if running. Accept anything past QUEUED, but most
-    # commonly QUEUED on freshly created.
+    # Executor may have advanced the run past QUEUED already.
     assert run.status in {
         ScheduledTaskRunStatus.QUEUED,
         ScheduledTaskRunStatus.RUNNING,
@@ -208,7 +185,6 @@ def test_create_with_run_immediately_enqueues(admin_user: DATestUser) -> None:
 def test_patch_task_recomputes_next_run_at_on_schedule_change(
     admin_user: DATestUser,
 ) -> None:
-    """A schedule edit recomputes ``next_run_at``."""
     response = _create_task(
         admin_user,
         editor_mode="interval",
@@ -220,7 +196,6 @@ def test_patch_task_recomputes_next_run_at_on_schedule_change(
     assert before is not None
     before_next = before.next_run_at
 
-    # PATCH the schedule to interval=days requiring time_of_day.
     patch = _patch_task(
         admin_user,
         task_id,
@@ -236,11 +211,6 @@ def test_patch_task_recomputes_next_run_at_on_schedule_change(
     patch.raise_for_status()
     after = _get_task_row(task_id)
     assert after is not None
-    # The cron changes, and next_run_at is freshly computed by
-    # update_scheduled_task. We don't pin a specific value (it depends
-    # on now() at PATCH time and the requested schedule), but it must
-    # be either ``None`` (paused) or a UTC datetime that differs from
-    # the pre-patch value.
     assert after.cron_expression != before.cron_expression
     if after.status == ScheduledTaskStatus.ACTIVE:
         assert after.next_run_at is not None
@@ -248,7 +218,6 @@ def test_patch_task_recomputes_next_run_at_on_schedule_change(
 
 
 def test_run_now_on_paused_task_allowed(admin_user: DATestUser) -> None:
-    """PAUSED task → ``run-now`` still works."""
     response = _create_task(admin_user, status=ScheduledTaskStatus.PAUSED)
     response.raise_for_status()
     task_id = UUID(response.json()["id"])
@@ -257,7 +226,7 @@ def test_run_now_on_paused_task_allowed(admin_user: DATestUser) -> None:
     response.raise_for_status()
     body = response.json()
     assert "run_id" in body
-    assert body["status"] in {s.value for s in ScheduledTaskRunStatus}
+    assert body["status"] == ScheduledTaskRunStatus.QUEUED.value
 
     runs = _get_runs_for_task(task_id)
     assert any(
@@ -266,7 +235,6 @@ def test_run_now_on_paused_task_allowed(admin_user: DATestUser) -> None:
 
 
 def test_delete_task_is_idempotent_soft_delete(admin_user: DATestUser) -> None:
-    """Two consecutive DELETEs both succeed."""
     response = _create_task(admin_user)
     response.raise_for_status()
     task_id = UUID(response.json()["id"])
@@ -275,12 +243,9 @@ def test_delete_task_is_idempotent_soft_delete(admin_user: DATestUser) -> None:
     assert first.status_code == 204
 
     second = _delete_task(admin_user, task_id)
-    # The handler is documented as idempotent — second DELETE on a
-    # missing or already-deleted task returns 204.
     assert second.status_code == 204
 
     row = _get_task_row(task_id)
-    # Soft delete: row still exists with deleted=True.
     assert row is not None, (
         "Row was hard-deleted; expected soft-delete to preserve the row"
     )
@@ -288,19 +253,11 @@ def test_delete_task_is_idempotent_soft_delete(admin_user: DATestUser) -> None:
 
 
 def test_list_runs_paginates_by_started_at_cursor(admin_user: DATestUser) -> None:
-    """``GET /runs?cursor=...`` works.
-
-    Insert a couple of run rows by issuing ``run-now`` twice, then ask
-    for page-size=1 to force a non-null next cursor.
-    """
     response = _create_task(admin_user)
     response.raise_for_status()
     task_id = UUID(response.json()["id"])
 
-    # Fire two manual runs so we have at least two run rows. A small
-    # sleep between them gives them distinct ``started_at`` values
-    # (server_default=now() has microsecond resolution but identical
-    # timestamps would still page correctly via the index).
+    # Small sleep gives the two runs distinct started_at values for the cursor.
     run_one = _run_now(admin_user, task_id)
     run_one.raise_for_status()
     time.sleep(0.05)
@@ -318,20 +275,4 @@ def test_list_runs_paginates_by_started_at_cursor(admin_user: DATestUser) -> Non
     page_two.raise_for_status()
     page_two_body = page_two.json()
     assert len(page_two_body["items"]) >= 1
-    # The two pages do not return the same run row.
     assert page_one_body["items"][0]["id"] != page_two_body["items"][0]["id"]
-
-
-# NOTE: ``test_scheduled_run_session_excluded_from_sidebar`` was relocated
-# to ``backend/tests/external_dependency_unit/craft/test_session_lifecycle.py``
-# (``TestSidebarOriginFilter.test_scheduled_origin_session_excluded_from_sidebar_listing``).
-#
-# The original test inserted ``BuildSession`` + ``BuildMessage`` rows
-# directly via ``get_session_with_current_tenant`` — an integration-shaped
-# ext-dep assertion that bypasses the API. Moving it to ext-dep keeps the
-# DB-row-visibility check at the right layer; ``GET /api/build/sessions``
-# HTTP-shape is covered by the sidebar listing tests elsewhere.
-#
-# Driving this through the API in integration would require a running
-# celery worker to execute the scheduled-task fire and insert the
-# ``origin=SCHEDULED`` row — not currently guaranteed in integration CI.

--- a/backend/tests/integration/tests/craft/test_sessions_api.py
+++ b/backend/tests/integration/tests/craft/test_sessions_api.py
@@ -34,18 +34,18 @@ def _send_one_message(user: DATestUser, session_id: uuid.UUID) -> None:
 
 
 def test_create_session_returns_200_with_session_and_sandbox_shape(
-    admin_user: DATestUser,
     llm_provider: DATestLLMProvider,  # noqa: ARG001 — ensures a default LLM exists
 ) -> None:
+    owner = UserManager.create(name=f"craft-session-shape-{uuid.uuid4().hex[:8]}")
     response = client.post(
         f"{API_SERVER_URL}/build/sessions",
         json={"headless": False},
-        headers=admin_user.headers,
-        cookies=admin_user.cookies,
+        headers=owner.headers,
+        cookies=owner.cookies,
     )
     assert response.status_code == 200
     body = response.json()
-    assert body["user_id"] == admin_user.id
+    assert body["user_id"] == owner.id
     assert body["sandbox"] is not None
 
 

--- a/backend/tests/integration/tests/craft/test_sessions_api.py
+++ b/backend/tests/integration/tests/craft/test_sessions_api.py
@@ -1,19 +1,15 @@
-"""Session lifecycle tests (HTTP boundary half).
-
-These tests exercise the FE-visible session HTTP API at ``/build/sessions``.
-They run against a real Onyx deployment (Postgres + Redis + the local
-sandbox backend) using the :class:`BuildSessionManager` HTTP wrapper.
-"""
+"""Session lifecycle tests against a real provisioned sandbox."""
 
 from __future__ import annotations
 
-import threading
 import uuid
 from typing import Any
-
-import httpx
+from uuid import UUID
 
 from onyx.db.enums import SharingScope
+from onyx.redis.redis_pool import get_redis_client
+from onyx.server.features.build.session.api import RESTORE_LOCK_TIMEOUT_SECONDS
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.http_client import client
 from tests.integration.common_utils.managers.build_session import BuildSessionManager
@@ -23,23 +19,12 @@ from tests.integration.common_utils.test_models import DATestLLMProvider
 from tests.integration.common_utils.test_models import DATestSettings
 from tests.integration.common_utils.test_models import DATestUser
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
 
 def _create_session(user: DATestUser) -> dict[str, Any]:
-    """Create a session and return the parsed response body."""
     return BuildSessionManager.create(user)
 
 
 def _send_one_message(user: DATestUser, session_id: uuid.UUID) -> None:
-    """Send a message and wait only until the USER row is persisted.
-
-    The background-turn endpoint commits the USER message row before returning
-    turn metadata. Tests using this helper must not depend on assistant-message
-    rows being persisted.
-    """
     BuildSessionManager.start_turn(
         user,
         session_id,
@@ -48,56 +33,93 @@ def _send_one_message(user: DATestUser, session_id: uuid.UUID) -> None:
     )
 
 
-# ---------------------------------------------------------------------------
-# Tests
-# ---------------------------------------------------------------------------
+def test_create_session_returns_200_with_session_and_sandbox_shape(
+    admin_user: DATestUser,
+    llm_provider: DATestLLMProvider,  # noqa: ARG001 — ensures a default LLM exists
+) -> None:
+    response = client.post(
+        f"{API_SERVER_URL}/build/sessions",
+        json={"headless": False},
+        headers=admin_user.headers,
+        cookies=admin_user.cookies,
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["user_id"] == admin_user.id
+    assert body["sandbox"] is not None
+
+
+def test_set_sharing_scope_changes_webapp_visibility(
+    admin_user: DATestUser,
+    basic_user: DATestUser,
+    llm_provider: DATestLLMProvider,  # noqa: ARG001
+) -> None:
+    body = _create_session(admin_user)
+    session_uuid = uuid.UUID(body["id"])
+    webapp_url = f"{API_SERVER_URL}/build/sessions/{body['id']}/webapp"
+
+    private_response = client.get(
+        webapp_url,
+        headers=basic_user.headers,
+        cookies=basic_user.cookies,
+        follow_redirects=False,
+    )
+    assert private_response.status_code == 404
+
+    BuildSessionManager.set_sharing(admin_user, session_uuid, SharingScope.PUBLIC_ORG)
+
+    public_response = client.get(
+        webapp_url,
+        headers=basic_user.headers,
+        cookies=basic_user.cookies,
+        follow_redirects=False,
+    )
+    assert public_response.status_code in (200, 502, 503, 504)
+    assert "text/html" in public_response.headers.get("content-type", "").lower()
+
+
+def test_restore_session_returns_409_when_lock_held(
+    admin_user: DATestUser,
+    llm_provider: DATestLLMProvider,  # noqa: ARG001
+) -> None:
+    body = _create_session(admin_user)
+    session_id = body["id"]
+    sandbox_id = body["sandbox"]["id"]
+
+    redis_client = get_redis_client(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
+    lock = redis_client.lock(
+        f"sandbox_restore:{sandbox_id}", timeout=RESTORE_LOCK_TIMEOUT_SECONDS
+    )
+    assert lock.acquire(blocking=False)
+    try:
+        response = client.post(
+            f"{API_SERVER_URL}/build/sessions/{session_id}/restore",
+            headers=admin_user.headers,
+            cookies=admin_user.cookies,
+        )
+        assert response.status_code == 409
+        assert response.json()["detail"] == "Restore already in progress"
+    finally:
+        lock.release()
 
 
 def test_create_session_requires_auth() -> None:
-    """POST /build/sessions without an auth cookie/header is rejected."""
     response = client.post(
         f"{API_SERVER_URL}/build/sessions",
         json={},
         headers={"Content-Type": "application/json"},
     )
-    # The build router gates access through ``require_onyx_craft_enabled`` →
-    # ``require_permission(BASIC_ACCESS)`` → ``current_user``. Onyx's
-    # ``BasicAuthenticationError`` returns 403 for unauthenticated callers
-    # (not 401). Either is acceptable so long as it's a 4xx auth failure.
     assert response.status_code in (401, 403)
 
 
-def test_create_session_returns_201_with_session_and_sandbox_shape(
-    admin_user: DATestUser,
-    llm_provider: DATestLLMProvider,  # noqa: ARG001 — ensures a default LLM exists
-) -> None:
-    """POST returns a body matching ``DetailedSessionResponse``."""
-    body = _create_session(admin_user)
-    # The endpoint declares ``response_model=DetailedSessionResponse``; FastAPI
-    # validates the shape on the way out. We just pin the fields the FE relies
-    # on so we'll notice if any are silently dropped.
-    assert body["id"]
-    assert body["user_id"] == admin_user.id
-    assert "status" in body
-    assert "created_at" in body
-    assert "sandbox" in body and body["sandbox"] is not None
-    assert "id" in body["sandbox"]
-    assert "status" in body["sandbox"]
-    assert body["session_loaded_in_sandbox"] is True
-    assert "sharing_scope" in body
-    assert body["artifacts"] == [] or isinstance(body["artifacts"], list)
-
-
 def test_get_session_404_for_other_users_session(
-    admin_user: DATestUser,
-    llm_provider: DATestLLMProvider,  # noqa: ARG001
+    shared_session: tuple[DATestUser, UUID],
 ) -> None:
-    """Fetching another user's session by id returns 404 (ownership-gated)."""
-    owner_session = _create_session(admin_user)
+    _owner, session_id = shared_session
 
     other_user = UserManager.create(name=f"other-{uuid.uuid4().hex[:8]}")
     response = client.get(
-        f"{API_SERVER_URL}/build/sessions/{owner_session['id']}",
+        f"{API_SERVER_URL}/build/sessions/{session_id}",
         headers=other_user.headers,
         cookies=other_user.cookies,
     )
@@ -108,12 +130,6 @@ def test_list_sessions_only_returns_callers_interactive_sessions(
     admin_user: DATestUser,
     llm_provider: DATestLLMProvider,  # noqa: ARG001
 ) -> None:
-    """The sidebar listing is per-user and excludes other users' sessions.
-
-    ``get_user_build_sessions`` also filters to ``origin=INTERACTIVE`` and
-    sessions with at least one message — both are exercised here implicitly:
-    the foreign session is INTERACTIVE-with-message yet still excluded.
-    """
     mine = _create_session(admin_user)
     _send_one_message(admin_user, uuid.UUID(mine["id"]))
 
@@ -131,7 +147,6 @@ def test_delete_session_returns_204_and_actually_deletes(
     admin_user: DATestUser,
     llm_provider: DATestLLMProvider,  # noqa: ARG001
 ) -> None:
-    """DELETE returns 204 and a follow-up GET on the same id returns 404."""
     body = _create_session(admin_user)
     session_id = body["id"]
 
@@ -150,97 +165,10 @@ def test_delete_session_returns_204_and_actually_deletes(
     assert follow_up.status_code == 404
 
 
-def test_set_sharing_scope_changes_webapp_visibility(
-    admin_user: DATestUser,
-    basic_user: DATestUser,
-    llm_provider: DATestLLMProvider,  # noqa: ARG001
-) -> None:
-    """PATCH to public_org opens the webapp to other org members.
-
-    With the default ``private`` scope, only the session owner can hit the
-    webapp; another org user gets the auth-gate response (302/401/403/404).
-    Flipping the scope to ``public_org`` via the PATCH endpoint must
-    propagate to ``_check_webapp_access`` so the same other-user call now
-    reaches the proxy. We don't pin a 200 from that call — the local
-    sandbox has no Next.js dev server running and the proxy returns the
-    offline page (status 5xx HTML), which still proves the auth gate is
-    no longer applied.
-    """
-    body = _create_session(admin_user)
-    session_id = body["id"]
-    webapp_url = f"{API_SERVER_URL}/build/sessions/{session_id}/webapp"
-
-    # Private (default): an authenticated non-owner gets 404 (existence-hiding).
-    private_response = client.get(
-        webapp_url,
-        headers=basic_user.headers,
-        cookies=basic_user.cookies,
-        follow_redirects=False,
-    )
-    assert private_response.status_code == 404
-
-    BuildSessionManager.set_sharing(
-        admin_user, uuid.UUID(session_id), SharingScope.PUBLIC_ORG
-    )
-
-    # public_org: same other org user reaches the proxy; with no upstream
-    # Next.js dev server, the proxy returns the branded offline HTML (5xx).
-    public_response = client.get(
-        webapp_url,
-        headers=basic_user.headers,
-        cookies=basic_user.cookies,
-        follow_redirects=False,
-    )
-    assert public_response.status_code in (200, 502, 503, 504)
-    assert "text/html" in public_response.headers.get("content-type", "").lower()
-
-
-def test_restore_session_returns_409_when_lock_held(
-    admin_user: DATestUser,
-    llm_provider: DATestLLMProvider,  # noqa: ARG001
-) -> None:
-    """Two concurrent restores on the same sandbox: the second receives 409.
-
-    The restore endpoint takes a non-blocking Redis lock keyed on
-    ``sandbox_restore:{sandbox.id}``. We fire two restore POSTs in parallel
-    threads and require at least one to come back 409. We can't reliably
-    pin *which* request loses the race, so we assert the count instead.
-    """
-    body = _create_session(admin_user)
-    session_id = body["id"]
-
-    results: list[int] = []
-
-    def _restore() -> None:
-        try:
-            r = client.post(
-                f"{API_SERVER_URL}/build/sessions/{session_id}/restore",
-                headers=admin_user.headers,
-                cookies=admin_user.cookies,
-            )
-            results.append(r.status_code)
-        except httpx.RequestError:
-            results.append(-1)
-
-    threads = [threading.Thread(target=_restore) for _ in range(2)]
-    for t in threads:
-        t.start()
-    for t in threads:
-        t.join()
-
-    assert all(r != -1 for r in results), (
-        f"Thread(s) failed with transport error: {results}"
-    )
-    assert 409 in results, (
-        f"Expected at least one 409 from concurrent restore, got {results}"
-    )
-
-
 def test_pre_provisioned_check_returns_valid_for_empty_session(
     admin_user: DATestUser,
     llm_provider: DATestLLMProvider,  # noqa: ARG001
 ) -> None:
-    """An empty (just-created) session reports ``valid=true`` with its id."""
     body = _create_session(admin_user)
     session_id = body["id"]
 
@@ -259,7 +187,6 @@ def test_pre_provisioned_check_returns_invalid_after_first_message(
     admin_user: DATestUser,
     llm_provider: DATestLLMProvider,  # noqa: ARG001
 ) -> None:
-    """Once a USER message exists, the same session is no longer "valid"."""
     body = _create_session(admin_user)
     session_id = body["id"]
 
@@ -276,21 +203,10 @@ def test_pre_provisioned_check_returns_invalid_after_first_message(
     assert payload["session_id"] is None
 
 
-def test_rename_session_with_null_name_uses_llm_then_fallback_chain(
+def test_rename_session_with_null_name_no_message_uses_id_fallback(
     admin_user: DATestUser,
     llm_provider: DATestLLMProvider,  # noqa: ARG001
 ) -> None:
-    """PUT /name with ``{name: null}`` resolves a non-empty name via the chain.
-
-    ``_generate_session_name`` walks three branches:
-      1. If there's no first user message → ``Build Session {id[:8]}``.
-      2. If the LLM call succeeds → the generated name (truncated to 50 chars).
-      3. If the LLM call raises → first 40 chars of the user message.
-
-    Without messages we must hit branch 1; we assert exactly that, because
-    it's the only branch with a deterministic output an HTTP-only test can
-    pin. The chain itself is unit-tested at the manager level.
-    """
     body = _create_session(admin_user)
     session_id = body["id"]
 
@@ -302,45 +218,54 @@ def test_rename_session_with_null_name_uses_llm_then_fallback_chain(
     )
     assert response.status_code == 200
     payload = response.json()
-    # Branch 1 fallback: "Build Session {id[:8]}".
     assert payload["name"] == f"Build Session {session_id[:8]}"
+
+
+def test_rename_session_with_null_name_falls_back_when_llm_call_fails(
+    admin_user: DATestUser,
+    llm_provider: DATestLLMProvider,  # noqa: ARG001
+) -> None:
+    body = _create_session(admin_user)
+    session_id = body["id"]
+
+    prompt = "hello"
+    BuildSessionManager.start_turn(
+        admin_user,
+        uuid.UUID(session_id),
+        prompt,
+        client_request_id=f"rename-{uuid.uuid4()}",
+    )
+
+    response = client.put(
+        f"{API_SERVER_URL}/build/sessions/{session_id}/name",
+        json={"name": None},
+        headers=admin_user.headers,
+        cookies=admin_user.cookies,
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["name"] != f"Build Session {session_id[:8]}"
+    assert payload["name"] == prompt
 
 
 def test_limited_role_check_uses_account_type_not_permission_flags(
     admin_user: DATestUser,  # noqa: ARG001 — needed so admin exists for SettingsManager
 ) -> None:
-    """Account-type-restricted users are blocked from Craft regardless of any
-    permission grant they might have. Regression for SHA ``ac89b42b38``: that
-    commit moved the limited check off the role bit and onto ``account_type``,
-    via ``current_user`` → ``is_limited_user``.
-
-    We use the anonymous user (``account_type=AccountType.ANONYMOUS``), which
-    ``is_limited_user`` always rejects. Even with ``anonymous_user_enabled``
-    flipped to True (so the anonymous user is otherwise allowed to hit
-    public endpoints), the Craft router must still 401/403 them out.
-    """
-    # Enable anonymous browsing so the request reaches require_permission;
-    # if we left it off, the request would fail authentication before the
-    # is_limited_user check ever ran — different regression branch.
     SettingsManager.update_settings(
         DATestSettings(anonymous_user_enabled=True),
         user_performing_action=admin_user,
     )
-
-    anon_user = UserManager.get_anonymous_user()
-
-    response = client.post(
-        f"{API_SERVER_URL}/build/sessions",
-        json={},
-        headers=anon_user.headers,
-        cookies=anon_user.cookies,
-    )
-    # current_user rejects limited account types with BasicAuthenticationError
-    # (HTTP 403); some auth-failure paths surface as 401.
-    assert response.status_code in (401, 403)
-
-    # Restore the default so subsequent tests see the normal config.
-    SettingsManager.update_settings(
-        DATestSettings(anonymous_user_enabled=False),
-        user_performing_action=admin_user,
-    )
+    try:
+        anon_user = UserManager.get_anonymous_user()
+        response = client.post(
+            f"{API_SERVER_URL}/build/sessions",
+            json={},
+            headers=anon_user.headers,
+            cookies=anon_user.cookies,
+        )
+        assert response.status_code in (401, 403)
+    finally:
+        SettingsManager.update_settings(
+            DATestSettings(anonymous_user_enabled=False),
+            user_performing_action=admin_user,
+        )

--- a/backend/tests/integration/tests/craft/test_upload_api.py
+++ b/backend/tests/integration/tests/craft/test_upload_api.py
@@ -1,9 +1,4 @@
-"""File upload tests (integration / HTTP half).
-
-Exercises the upload endpoint via the live API server so we pin both the
-happy-path response shape and the boundary error mapping (auth, foreign
-session, size/count/cumulative caps, arbitrary extensions, Unicode filenames).
-"""
+"""File upload tests (HTTP half)."""
 
 from __future__ import annotations
 
@@ -16,7 +11,6 @@ from tests.integration.common_utils.test_models import DATestUser
 
 
 def _create_session_id(user: DATestUser) -> UUID:
-    """Create a build session and return its UUID."""
     session = BuildSessionManager.create(user)
     return UUID(session["id"])
 
@@ -25,8 +19,7 @@ def _upload_url(session_id: UUID) -> str:
     return f"{API_SERVER_URL}/build/sessions/{session_id}/upload"
 
 
-def test_upload_endpoint_201(admin_user: DATestUser) -> None:
-    """POST returns 201 with a body containing {filename, path, size_bytes}."""
+def test_upload_endpoint_returns_file_metadata(admin_user: DATestUser) -> None:
     session_id = _create_session_id(admin_user)
     body = BuildSessionManager.upload_file(
         admin_user,
@@ -40,70 +33,24 @@ def test_upload_endpoint_201(admin_user: DATestUser) -> None:
     assert body["size_bytes"] == len(b"hello world")
 
 
-def test_upload_endpoint_requires_auth(admin_user: DATestUser) -> None:
-    """POST with no auth token returns 401 (or 403)."""
-    # admin_user is just used to ensure a session exists; we then strip auth.
-    session_id = _create_session_id(admin_user)
-
-    response = client.post(
-        _upload_url(session_id),
-        files={"file": ("hello.txt", b"hello", "application/octet-stream")},
-        headers={},
-        cookies=None,
-    )
-    # Onyx auth middleware returns either 401 or 403 for unauthenticated
-    # requests against BASIC_ACCESS endpoints.
-    assert response.status_code in (401, 403)
-
-
-def test_upload_endpoint_404_for_other_users_session(
-    admin_user: DATestUser, basic_user: DATestUser
+def test_upload_over_per_file_cap_returns_400(
+    shared_session: tuple[DATestUser, UUID],
 ) -> None:
-    """Uploading to another user's session returns 404."""
-    foreign_session_id = _create_session_id(admin_user)
-
-    headers = {
-        k: v for k, v in basic_user.headers.items() if k.lower() != "content-type"
-    }
-    response = client.post(
-        _upload_url(foreign_session_id),
-        files={"file": ("hello.txt", b"hi", "application/octet-stream")},
-        headers=headers,
-        cookies=basic_user.cookies,
-    )
-    assert response.status_code == 404
-
-
-def test_upload_over_per_file_cap_returns_400(admin_user: DATestUser) -> None:
-    """A file exceeding the per-file cap is rejected with 400.
-
-    The ``validate_file`` helper catches oversized files and the endpoint
-    returns 400 (not 413) because the check is application-level, not a
-    framework payload-size guard.
-    """
-    session_id = _create_session_id(admin_user)
+    owner, session_id = shared_session
 
     # CI lowers BUILD_MAX_UPLOAD_FILE_SIZE_MB to 2; a 3 MiB payload trips it.
     oversized = b"\x00" * (3 * 1024 * 1024)
-    headers = {
-        k: v for k, v in admin_user.headers.items() if k.lower() != "content-type"
-    }
+    headers = {k: v for k, v in owner.headers.items() if k.lower() != "content-type"}
     response = client.post(
         _upload_url(session_id),
         files={"file": ("big.txt", oversized, "application/octet-stream")},
         headers=headers,
-        cookies=admin_user.cookies,
+        cookies=owner.cookies,
     )
-    # Per-file cap → 400 from validate_file.
     assert response.status_code == 400
 
 
 def test_upload_at_count_cap_returns_429(admin_user: DATestUser) -> None:
-    """An upload exceeding MAX_UPLOAD_FILES_PER_SESSION is rejected with 429.
-
-    ``UploadLimitExceededError`` is mapped to 429 (Too Many Requests) by the
-    upload endpoint.
-    """
     session_id = _create_session_id(admin_user)
 
     # CI lowers BUILD_MAX_UPLOAD_FILES_PER_SESSION to 5.
@@ -115,7 +62,6 @@ def test_upload_at_count_cap_returns_429(admin_user: DATestUser) -> None:
             content=b"x",
         )
 
-    # 6th upload should hit the count cap.
     headers = {
         k: v for k, v in admin_user.headers.items() if k.lower() != "content-type"
     }
@@ -125,20 +71,13 @@ def test_upload_at_count_cap_returns_429(admin_user: DATestUser) -> None:
         headers=headers,
         cookies=admin_user.cookies,
     )
-    # Count cap → 429 from UploadLimitExceededError.
     assert response.status_code == 429
 
 
 def test_upload_over_cumulative_cap_returns_429(admin_user: DATestUser) -> None:
-    """Pushing total session usage past MAX_TOTAL_UPLOAD_SIZE_BYTES is rejected with 429.
-
-    ``UploadLimitExceededError`` is mapped to 429 (Too Many Requests) by the
-    upload endpoint.
-    """
     session_id = _create_session_id(admin_user)
 
-    # CI lowers per-file cap to 2 MiB and total cap to 4 MiB.
-    # Two 1.5 MiB uploads (3 MiB) succeed; the third tips total past 4 MiB.
+    # CI lowers per-file cap to 2 MiB and total cap to 4 MiB; the third tips past 4.
     chunk = b"\x00" * (1024 * 1024 + 512 * 1024)  # 1.5 MiB
     for i in range(2):
         BuildSessionManager.upload_file(
@@ -157,17 +96,11 @@ def test_upload_over_cumulative_cap_returns_429(admin_user: DATestUser) -> None:
         headers=headers,
         cookies=admin_user.cookies,
     )
-    # Cumulative cap → 429 from UploadLimitExceededError.
     assert response.status_code == 429
 
 
 def test_upload_accepts_any_extension_via_http(admin_user: DATestUser) -> None:
-    """Uploads are not restricted by extension/MIME; a .exe uploads fine.
-
-    The sandbox is the security boundary, not an extension allow/blocklist, so
-    a previously-blocked type (here ``evil.exe``) must now succeed. This guards
-    against any reintroduction of extension filtering.
-    """
+    """Uploads are not restricted by extension/MIME; a .exe uploads fine."""
     session_id = _create_session_id(admin_user)
 
     headers = {
@@ -179,24 +112,17 @@ def test_upload_accepts_any_extension_via_http(admin_user: DATestUser) -> None:
         headers=headers,
         cookies=admin_user.cookies,
     )
-    assert response.status_code == 201
+    assert response.status_code == 200
 
 
 def test_upload_with_unicode_filename_persists_correctly(
     admin_user: DATestUser,
 ) -> None:
-    """A Unicode filename round-trips through upload + download.
-
-    The Content-Disposition response header for download uses RFC 5987 for
-    non-Latin-1 filenames; here we confirm the file is reachable and its
-    bytes survive the round trip.
-    """
+    """A Unicode filename round-trips through upload + download."""
     session_id = _create_session_id(admin_user)
 
     original_bytes = "héllo wörld 你好 🌍".encode("utf-8")
-    # The upload endpoint sanitizes filenames (replaces non [a-zA-Z0-9._-]
-    # with underscores), so we focus the round-trip assertion on the bytes;
-    # the response also tells us where the file ended up.
+    # The endpoint sanitizes filenames, so assert on the round-tripped bytes.
     upload_response = BuildSessionManager.upload_file(
         admin_user,
         session_id,
@@ -206,7 +132,6 @@ def test_upload_with_unicode_filename_persists_correctly(
     sanitized_name = upload_response["filename"]
     relative_path = upload_response["path"]
 
-    # The sanitizer keeps the .txt suffix.
     assert sanitized_name.endswith(".txt")
     assert relative_path.endswith(sanitized_name)
 
@@ -214,3 +139,36 @@ def test_upload_with_unicode_filename_persists_correctly(
         admin_user, session_id, relative_path
     )
     assert downloaded == original_bytes
+
+
+def test_upload_endpoint_requires_auth(
+    shared_session: tuple[DATestUser, UUID],
+) -> None:
+    """POST with no auth token returns 401 (or 403)."""
+    _owner, session_id = shared_session
+
+    response = client.post(
+        _upload_url(session_id),
+        files={"file": ("hello.txt", b"hello", "application/octet-stream")},
+        headers={},
+        cookies=None,
+    )
+    assert response.status_code in (401, 403)
+
+
+def test_upload_endpoint_404_for_other_users_session(
+    shared_session: tuple[DATestUser, UUID], basic_user: DATestUser
+) -> None:
+    """Uploading to another user's session returns 404 (existence-hiding)."""
+    _owner, foreign_session_id = shared_session
+
+    headers = {
+        k: v for k, v in basic_user.headers.items() if k.lower() != "content-type"
+    }
+    response = client.post(
+        _upload_url(foreign_session_id),
+        files={"file": ("hello.txt", b"hi", "application/octet-stream")},
+        headers=headers,
+        cookies=basic_user.cookies,
+    )
+    assert response.status_code == 404

--- a/backend/tests/integration/tests/craft/test_user_library_api.py
+++ b/backend/tests/integration/tests/craft/test_user_library_api.py
@@ -1,94 +1,16 @@
-"""User library tests.
-
-Integration tests for the user-library HTTP endpoints in
-``onyx.server.features.build.user_library.api``. Each test hits the real
-backend and either asserts the response shape or verifies the resulting
-document row + storage blob via the tree-listing endpoint.
-"""
+"""User library tests."""
 
 from __future__ import annotations
 
-import io
-import zipfile
-from collections.abc import Iterable
 from typing import Any
 from uuid import uuid4
 
-import httpx
-import pytest
-
-from tests.integration.common_utils.constants import API_SERVER_URL
-from tests.integration.common_utils.http_client import client
 from tests.integration.common_utils.test_models import DATestUser
-
-# ---------------------------------------------------------------------------
-# Small HTTP wrapper (kept inline per task description — no separate manager).
-# ---------------------------------------------------------------------------
-
-
-def _url(*parts: str) -> str:
-    return f"{API_SERVER_URL}/build/user-library/" + "/".join(parts)
-
-
-def _multipart_headers(user: DATestUser) -> dict[str, str]:
-    """Drop the JSON Content-Type so ``requests`` can set the multipart one."""
-    return {k: v for k, v in user.headers.items() if k.lower() != "content-type"}
-
-
-def _upload(
-    user: DATestUser,
-    files: Iterable[tuple[str, bytes, str | None]],
-    path: str = "/",
-) -> httpx.Response:
-    multipart = [
-        (
-            "files",
-            (name, io.BytesIO(content), content_type or "application/octet-stream"),
-        )
-        for name, content, content_type in files
-    ]
-    return client.post(
-        _url("upload"),
-        files=multipart,
-        data={"path": path},
-        headers=_multipart_headers(user),
-        cookies=user.cookies,
-    )
-
-
-def _upload_zip(
-    user: DATestUser,
-    zip_bytes: bytes,
-    path: str = "/",
-    filename: str = "bundle.zip",
-) -> httpx.Response:
-    return client.post(
-        _url("upload-zip"),
-        files={"file": (filename, io.BytesIO(zip_bytes), "application/zip")},
-        data={"path": path},
-        headers=_multipart_headers(user),
-        cookies=user.cookies,
-    )
-
-
-def _tree(user: DATestUser) -> list[dict[str, Any]]:
-    response = client.get(
-        _url("tree"),
-        headers=user.headers,
-        cookies=user.cookies,
-    )
-    response.raise_for_status()
-    body = response.json()
-    assert isinstance(body, list)
-    return body
-
-
-def _delete(user: DATestUser, document_id: str) -> httpx.Response:
-    return client.delete(
-        _url("files", document_id),
-        headers=user.headers,
-        cookies=user.cookies,
-    )
+from tests.integration.tests.craft.user_library_http import delete_user_library_file
+from tests.integration.tests.craft.user_library_http import list_user_library_tree
+from tests.integration.tests.craft.user_library_http import make_zip_bytes
+from tests.integration.tests.craft.user_library_http import upload_user_library_files
+from tests.integration.tests.craft.user_library_http import upload_user_library_zip
 
 
 def _find_doc_by_name(
@@ -97,142 +19,13 @@ def _find_doc_by_name(
     return next((e for e in entries if e.get("name") == name), None)
 
 
-def _make_zip(members: dict[str, bytes]) -> bytes:
-    buf = io.BytesIO()
-    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
-        for name, data in members.items():
-            zf.writestr(name, data)
-    return buf.getvalue()
-
-
-# ---------------------------------------------------------------------------
-# Synthetic PDF builder for the embedded-image cap test.
-# ---------------------------------------------------------------------------
-
-
-def _build_pdf_with_n_images(n: int) -> bytes:
-    """Return a minimal valid PDF whose single page references ``n`` images.
-
-    The image XObjects are tiny placeholders (1x1 raw grayscale stream),
-    which is enough for ``pypdf.PageObject.images`` to enumerate them
-    via the ``/XObject /Subtype /Image`` dict structure that
-    ``count_pdf_embedded_images`` walks.
-    """
-    # 1x1 raw grayscale pixel — one byte of image data.
-    pixel = b"\x00"
-
-    objects: list[bytes] = []
-    # Build N image XObjects.
-    image_obj_indices: list[int] = []
-    # We reserve obj nums for catalog/pages/page later; build images first.
-    # The final layout: obj 1 = Catalog, obj 2 = Pages, obj 3 = Page,
-    # then N image objects starting at obj 4, then content stream.
-    catalog_num = 1
-    pages_num = 2
-    page_num = 3
-    image_start = 4
-    for i in range(n):
-        obj_num = image_start + i
-        image_obj_indices.append(obj_num)
-
-    content_obj_num = image_start + n
-
-    # /Resources XObject dict mapping /Im{i} → indirect ref to image obj.
-    xobject_entries = " ".join(
-        f"/Im{i} {idx} 0 R" for i, idx in enumerate(image_obj_indices)
-    )
-    resources = f"/Resources << /XObject << {xobject_entries} >> >>"
-
-    page = (
-        f"{page_num} 0 obj\n"
-        f"<< /Type /Page /Parent {pages_num} 0 R "
-        f"/MediaBox [0 0 10 10] "
-        f"{resources} "
-        f"/Contents {content_obj_num} 0 R "
-        f">>\nendobj\n"
-    )
-
-    catalog = (
-        f"{catalog_num} 0 obj\n<< /Type /Catalog /Pages {pages_num} 0 R >>\nendobj\n"
-    )
-
-    pages = (
-        f"{pages_num} 0 obj\n"
-        f"<< /Type /Pages /Kids [{page_num} 0 R] /Count 1 >>\nendobj\n"
-    )
-
-    content_stream_body = b"q Q"  # trivial valid content stream
-    content = (
-        (
-            f"{content_obj_num} 0 obj\n"
-            f"<< /Length {len(content_stream_body)} >>\n"
-            f"stream\n"
-        ).encode("latin-1")
-        + content_stream_body
-        + b"\nendstream\nendobj\n"
-    )
-
-    image_blobs: list[bytes] = []
-    for idx in image_obj_indices:
-        body = (
-            (
-                f"{idx} 0 obj\n"
-                f"<< /Type /XObject /Subtype /Image /Width 1 /Height 1 "
-                f"/ColorSpace /DeviceGray /BitsPerComponent 8 "
-                f"/Length {len(pixel)} /Filter [] >>\n"
-                f"stream\n"
-            ).encode("latin-1")
-            + pixel
-            + b"\nendstream\nendobj\n"
-        )
-        image_blobs.append(body)
-
-    header = b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n"
-    body = (
-        catalog.encode("latin-1")
-        + pages.encode("latin-1")
-        + page.encode("latin-1")
-        + b"".join(image_blobs)
-        + content
-    )
-
-    # Build xref (very minimal — pypdf is lenient about offsets as long
-    # as the trailer points at the catalog).
-    pdf = header + body
-    xref_offset = len(pdf)
-    n_objs = content_obj_num
-    xref_lines = [f"xref\n0 {n_objs + 1}\n", "0000000000 65535 f \n"]
-    # We don't track precise offsets — most readers accept zeros and
-    # parse the trailer's /Root indirect ref. pypdf's lenient mode
-    # reconstructs xref when needed.
-    for _ in range(n_objs):
-        xref_lines.append("0000000000 00000 n \n")
-    trailer = (
-        f"trailer\n<< /Size {n_objs + 1} /Root {catalog_num} 0 R >>\n"
-        f"startxref\n{xref_offset}\n%%EOF\n"
-    )
-    pdf = pdf + "".join(xref_lines).encode("latin-1") + trailer.encode("latin-1")
-    objects.append(pdf)
-    return pdf
-
-
-# ---------------------------------------------------------------------------
-# Tests
-# ---------------------------------------------------------------------------
-
-
 def test_upload_persists_file_to_s3(admin_user: DATestUser) -> None:
-    """POST → ``CRAFT_FILE`` document + storage blob.
-
-    Assert on the side effect observable through the user-library tree
-    endpoint: a row appears whose ``id`` starts with ``CRAFT_FILE__``
-    and whose ``file_size`` matches the uploaded bytes. The storage
-    side (S3 in K8s mode, local FS in dev) is exercised inside the
-    request handler — if the writer failed the upload would have raised.
-    """
+    """POST → ``CRAFT_FILE`` document + storage blob."""
     filename = f"persist-{uuid4().hex[:8]}.bin"
     payload = b"persisted-bytes-" + uuid4().hex.encode()
-    response = _upload(admin_user, [(filename, payload, "application/octet-stream")])
+    response = upload_user_library_files(
+        admin_user, [(filename, payload, "application/octet-stream")]
+    )
     response.raise_for_status()
     body = response.json()
 
@@ -243,38 +36,14 @@ def test_upload_persists_file_to_s3(admin_user: DATestUser) -> None:
     assert entry["file_size"] == len(payload)
     assert entry["id"].startswith("CRAFT_FILE__")
 
-    # Reachable in the tree listing — confirms the document row was
-    # actually upserted, not just returned in the response body.
-    tree = _tree(admin_user)
+    tree = list_user_library_tree(admin_user)
     assert any(e["id"] == entry["id"] for e in tree)
 
 
 def test_upload_batch_over_count_cap_rejects(admin_user: DATestUser) -> None:
-    """A batch upload exceeding ``USER_LIBRARY_MAX_FILES_PER_UPLOAD`` is rejected with 400."""
     # CI lowers USER_LIBRARY_MAX_FILES_PER_UPLOAD to 5.
     files = [(f"tiny-{i}-{uuid4().hex[:6]}.txt", b"x", "text/plain") for i in range(6)]
-    response = _upload(admin_user, files)
-
-    assert response.status_code == 400
-
-
-@pytest.mark.xfail(
-    strict=False,
-    reason=(
-        "pypdf doesn't reliably enumerate images in our hand-built synthetic "
-        "PDF — returns 0 → upload succeeds. Need a reportlab-built PDF or a "
-        "fixture file to exercise this path."
-    ),
-)
-def test_upload_pdf_with_too_many_embedded_images_rejected(
-    admin_user: DATestUser,
-) -> None:
-    """A PDF with more embedded images than the per-file cap is rejected with 400."""
-    pdf_bytes = _build_pdf_with_n_images(51)
-    response = _upload(
-        admin_user,
-        [(f"manyimages-{uuid4().hex[:6]}.pdf", pdf_bytes, "application/pdf")],
-    )
+    response = upload_user_library_files(admin_user, files)
 
     assert response.status_code == 400
 
@@ -283,72 +52,52 @@ def test_upload_zip_extracts_and_applies_caps_recursively(
     admin_user: DATestUser,
 ) -> None:
     """Zip upload extracts inner files; same caps apply."""
-    # First verify the happy zip path: a small zip uploads and yields
-    # one entry per file in the tree.
     small_member_name = f"inner-{uuid4().hex[:6]}.txt"
-    small_zip = _make_zip({small_member_name: b"hello"})
-    response = _upload_zip(admin_user, small_zip, filename="small.zip")
+    small_zip = make_zip_bytes({small_member_name: b"hello"})
+    response = upload_user_library_zip(admin_user, small_zip, filename="small.zip")
     response.raise_for_status()
     body = response.json()
     assert body["total_uploaded"] == 1
     [entry] = body["entries"]
-    # Inner file should be present in the tree.
-    tree = _tree(admin_user)
+    tree = list_user_library_tree(admin_user)
     assert any(small_member_name in e.get("name", "") for e in tree)
 
     # CI lowers USER_LIBRARY_MAX_FILES_PER_UPLOAD to 5; a 6-member zip trips it.
     over_cap_members = {f"file-{i}-{uuid4().hex[:4]}.txt": b"x" for i in range(6)}
-    zip_bytes = _make_zip(over_cap_members)
-    response = _upload_zip(admin_user, zip_bytes)
+    zip_bytes = make_zip_bytes(over_cap_members)
+    response = upload_user_library_zip(admin_user, zip_bytes)
     assert response.status_code == 400
 
 
 def test_delete_file_removes_s3_blob(admin_user: DATestUser) -> None:
-    """DELETE → row gone from tree, storage blob deleted.
-
-    Storage-blob deletion happens inside ``delete_file``; we verify the
-    observable effect (tree listing no longer includes the row). The
-    blob-delete side is exercised by the handler — a failure there
-    would log a warning but the row would still be deleted, so absence
-    from the tree confirms the happy path of the chain at least up to
-    the writer call.
-    """
+    """DELETE → row gone from tree, storage blob deleted."""
     filename = f"delete-{uuid4().hex[:6]}.txt"
-    response = _upload(admin_user, [(filename, b"bye", "text/plain")])
+    response = upload_user_library_files(admin_user, [(filename, b"bye", "text/plain")])
     response.raise_for_status()
     document_id = response.json()["entries"][0]["id"]
 
-    assert _find_doc_by_name(_tree(admin_user), filename) is not None
+    assert _find_doc_by_name(list_user_library_tree(admin_user), filename) is not None
 
-    delete_response = _delete(admin_user, document_id)
+    delete_response = delete_user_library_file(admin_user, document_id)
     delete_response.raise_for_status()
     assert delete_response.json()["deleted"] == document_id
 
-    assert _find_doc_by_name(_tree(admin_user), filename) is None
+    assert _find_doc_by_name(list_user_library_tree(admin_user), filename) is None
 
 
 def test_cross_user_access_returns_404(
     admin_user: DATestUser, basic_user: DATestUser
 ) -> None:
-    """Foreign user → 404 on any file op.
-
-    The ownership check in ``_verify_ownership_and_get_document`` rejects
-    requests whose document id doesn't carry the calling user's id in
-    the ``CRAFT_FILE__{user_id}__{hash}`` prefix. The user-facing code
-    raises 403 for "not your file" and 404 for "doesn't exist" — the
-    test plan calls out 404 (the safer choice, since revealing 403
-    leaks existence). We accept either; the security-critical assertion
-    is that the foreign user cannot read or mutate the file.
-    """
+    """Foreign user -> 404 (or 403) on any file op."""
     filename = f"cross-{uuid4().hex[:6]}.txt"
-    response = _upload(admin_user, [(filename, b"private", "text/plain")])
+    response = upload_user_library_files(
+        admin_user, [(filename, b"private", "text/plain")]
+    )
     response.raise_for_status()
     document_id = response.json()["entries"][0]["id"]
 
-    # basic_user cannot delete admin's file.
-    delete_response = _delete(basic_user, document_id)
+    delete_response = delete_user_library_file(basic_user, document_id)
     assert delete_response.status_code in (403, 404)
 
-    # And basic_user's tree does not contain admin's row.
-    basic_tree = _tree(basic_user)
+    basic_tree = list_user_library_tree(basic_user)
     assert all(e["id"] != document_id for e in basic_tree)

--- a/backend/tests/integration/tests/craft/test_webapp_proxy.py
+++ b/backend/tests/integration/tests/craft/test_webapp_proxy.py
@@ -1,25 +1,8 @@
-"""Webapp proxy tests (security + UX).
-
-The proxy lives at ``GET /api/build/sessions/{session_id}/webapp/{path:path}``
-and proxies to the per-session Next.js server inside the sandbox. The auth
-checks (``_check_webapp_access``) and the offline-page rendering are
-exercised here against the real backend.
-
-Reaching the actual upstream Next.js pod for the full happy-path body
-rewrite/HMR-shim tests would require provisioning a sandbox and waiting
-for the pod's webapp to be up — that's not feasible in the integration
-layer because no session created by the tests has a running Next.js
-process. Those tests instead assert the observable proxy fallback path
-(offline HTML / status code) which is what the proxy returns whenever
-the upstream is unreachable, which is the case for any session created
-purely via the HTTP API in this layer.
-"""
+"""Webapp proxy tests (security + UX)."""
 
 from __future__ import annotations
 
-from typing import Any
 from uuid import UUID
-from uuid import uuid4
 
 import httpx
 
@@ -29,25 +12,10 @@ from tests.integration.common_utils.http_client import client
 from tests.integration.common_utils.managers.build_session import BuildSessionManager
 from tests.integration.common_utils.test_models import DATestUser
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
 
 def _webapp_url(session_id: UUID, path: str = "") -> str:
     base = f"{API_SERVER_URL}/build/sessions/{session_id}/webapp"
     return f"{base}/{path.lstrip('/')}" if path else base
-
-
-def _create_session(user: DATestUser) -> dict[str, Any]:
-    """Create an empty build session for ``user``. Returns the session dict.
-
-    The session has a sandbox row + an allocated ``nextjs_port``, but no
-    running Next.js process — so every proxy request beyond the
-    auth/access check will surface as the branded offline fallback. That's
-    enough to assert routing, scope checks, and the offline path.
-    """
-    return BuildSessionManager.create(user)
 
 
 def _set_scope(user: DATestUser, session_id: UUID, scope: SharingScope) -> None:
@@ -59,7 +27,6 @@ def _unauth_get(
     path: str = "",
     follow_redirects: bool = False,
 ) -> httpx.Response:
-    """GET the proxy URL with no auth headers/cookies."""
     return client.get(
         _webapp_url(session_id, path),
         follow_redirects=follow_redirects,
@@ -72,7 +39,6 @@ def _auth_get(
     path: str = "",
     follow_redirects: bool = False,
 ) -> httpx.Response:
-    """GET the proxy URL with ``user``'s auth headers/cookies."""
     return client.get(
         _webapp_url(session_id, path),
         headers=user.headers,
@@ -81,23 +47,12 @@ def _auth_get(
     )
 
 
-# ---------------------------------------------------------------------------
-# Auth / scope checks (the part of the proxy that doesn't need an upstream)
-# ---------------------------------------------------------------------------
-
-
-def test_proxy_requires_auth_when_private(admin_user: DATestUser) -> None:
-    """Private session + no token → proxy returns 401-equivalent.
-
-    The handler raises ``HTTPException(401)`` from ``_check_webapp_access``;
-    the surrounding code catches that and issues a 302 to ``/auth/login``
-    instead of bubbling the bare 401 so the browser UX is sensible.
-    Either response (401 status or 302 to login) means "auth required."
-    """
-    session = _create_session(admin_user)
-    session_id = UUID(session["id"])
-    # Default scope is PRIVATE; assert + be explicit anyway.
-    _set_scope(admin_user, session_id, SharingScope.PRIVATE)
+def test_proxy_requires_auth_when_private(
+    shared_session: tuple[DATestUser, UUID],
+) -> None:
+    """Auth-required surfaces as either 401 or a 302 to /auth/login."""
+    owner, session_id = shared_session
+    _set_scope(owner, session_id, SharingScope.PRIVATE)
 
     response = _unauth_get(session_id, follow_redirects=False)
 
@@ -107,166 +62,46 @@ def test_proxy_requires_auth_when_private(admin_user: DATestUser) -> None:
         assert response.status_code == 401
 
 
-def test_proxy_allows_org_user_when_public_org(
-    admin_user: DATestUser,
-    basic_user: DATestUser,
+def test_proxy_rejects_forged_auth_cookie(
+    shared_session: tuple[DATestUser, UUID],
 ) -> None:
-    """Different user in same tenant + ``public_org`` → access check passes.
+    """A forged cookie resolves to no user; public_org still requires auth."""
+    owner, session_id = shared_session
+    _set_scope(owner, session_id, SharingScope.PUBLIC_ORG)
 
-    Auth check passing means the request reaches ``_proxy_request``;
-    since the upstream Next.js pod is not running, the proxy returns the
-    branded offline HTML (status 503, ``text/html``). What we are
-    asserting is that the request was *not* rejected by the access check
-    (no 401, no 302 to login).
-    """
-    session = _create_session(admin_user)
-    session_id = UUID(session["id"])
-    _set_scope(admin_user, session_id, SharingScope.PUBLIC_ORG)
-
-    response = client.get(
-        _webapp_url(session_id),
-        headers=basic_user.headers,
-        cookies=basic_user.cookies,
-        follow_redirects=False,
-    )
-
-    assert response.status_code != 401
-    # Not a redirect to login either.
-    location = response.headers.get("location", "")
-    assert "/auth/login" not in location
-
-
-def test_proxy_blocks_other_tenant_when_public_org(
-    admin_user: DATestUser,
-) -> None:
-    """Cross-tenant access on ``public_org`` → blocked.
-
-    The integration test deployment is single-tenant, so there is no
-    real "other tenant" we can construct here. We approximate the same
-    code path by hitting the proxy with a forged but otherwise valid
-    auth cookie shape that does not resolve to a real user — the auth
-    middleware treats this as anonymous and the proxy applies the same
-    ``public_org`` rule (anonymous request → 401, since
-    ``public_org`` requires auth).
-    """
-    session = _create_session(admin_user)
-    session_id = UUID(session["id"])
-    _set_scope(admin_user, session_id, SharingScope.PUBLIC_ORG)
-
-    # Forged cookie: present but not a valid session for any user.
     response = client.get(
         _webapp_url(session_id),
         cookies={"fastapiusersauth": "not-a-real-token"},
         follow_redirects=False,
     )
 
-    # Either 401, or a redirect to login — both mean "not allowed."
     if response.status_code == 302:
         assert "/auth/login" in response.headers.get("location", "")
     else:
         assert response.status_code == 401
 
 
-# ---------------------------------------------------------------------------
-# Header stripping + offline page (no upstream required)
-# ---------------------------------------------------------------------------
-
-
-def test_proxy_strips_set_cookie_header(admin_user: DATestUser) -> None:
-    """``set-cookie`` is never forwarded from upstream.
-
-    Without a live upstream, the proxy falls back to the offline HTML
-    response. That response is generated locally by ``_offline_html_response``
-    and never contains a ``Set-Cookie`` header — which is exactly the
-    invariant we care about for security: no upstream-controlled cookie
-    can ever reach the parent Onyx origin via this path.
-    """
-    session = _create_session(admin_user)
-    session_id = UUID(session["id"])
-
-    response = _auth_get(admin_user, session_id, follow_redirects=False)
-
-    # Lowercased header name lookup (requests does case-insensitive matching).
-    assert "set-cookie" not in {k.lower() for k in response.headers}
-
-
-def test_proxy_offline_html_does_not_leak_nextjs_asset_paths(
-    admin_user: DATestUser,
+def test_proxy_no_webapp_port_renders_branded_offline_page(
+    shared_session: tuple[DATestUser, UUID],
 ) -> None:
-    """The offline fallback must not leak root-scoped Next.js asset URLs."""
-    session = _create_session(admin_user)
-    session_id = UUID(session["id"])
+    # Headless session -> no allocated nextjs_port -> the proxy's
+    # "port not allocated" branch renders the branded offline page.
+    owner, session_id = shared_session
 
-    response = _auth_get(admin_user, session_id, follow_redirects=False)
-    assert "text/html" in response.headers.get("content-type", "").lower()
-    body = response.text
-    assert '"/_next/' not in body
-    assert "'/_next/" not in body
-
-
-def test_proxy_offline_html_does_not_include_hmr_shim(
-    admin_user: DATestUser,
-) -> None:
-    """The offline fallback should stay independent of Next.js dev HMR."""
-    session = _create_session(admin_user)
-    session_id = UUID(session["id"])
-
-    response = _auth_get(admin_user, session_id, follow_redirects=False)
-    body = response.text
-    assert "__WEBAPP_BASE__" not in body
-
-
-def test_proxy_502_renders_branded_offline_page(
-    admin_user: DATestUser,
-) -> None:
-    """Pod down → branded offline HTML.
-
-    A freshly created session has a sandbox row + allocated port but no
-    running pod; that's exactly the condition the offline fallback was
-    written for. The response is HTML with a 5xx status. The exact
-    status (503 by ``_offline_html_response``) is what the proxy
-    returns when it can't reach the upstream — the underlying
-    ``HTTPException`` raised inside ``_proxy_request`` carries 502
-    before the offline page converts it to a 503 HTML response.
-    """
-    session = _create_session(admin_user)
-    session_id = UUID(session["id"])
-
-    response = _auth_get(admin_user, session_id, follow_redirects=False)
+    response = _auth_get(owner, session_id, follow_redirects=False)
 
     assert response.status_code in (502, 503, 504)
     assert "text/html" in response.headers.get("content-type", "").lower()
-    # Branded marker: the template is a Craft-styled offline page. We
-    # don't pin exact copy (would couple to the template too tightly);
-    # instead assert the page is non-trivial HTML.
     body = response.text
-    assert "<html" in body.lower() or "<body" in body.lower()
-
-
-# ---------------------------------------------------------------------------
-# Route precedence + cross-session isolation regressions
-# ---------------------------------------------------------------------------
+    assert "Craft" in body
+    assert "crafting_table" in body
 
 
 def test_webapp_download_route_not_shadowed_by_catchall(
     admin_user: DATestUser,
 ) -> None:
-    """``/webapp-download`` resolves to the zip endpoint, not the catch-all.
-
-    Regression for SHA ``e213853f63``: the catch-all proxy route
-    ``/{session_id}/webapp/{path:path}`` once shadowed the specific
-    ``/{session_id}/webapp-download`` route. The two are visually
-    similar but functionally distinct — one returns the offline page,
-    the other a zip.
-
-    We hit ``/webapp-download`` as the *owner* with auth, so the
-    download endpoint can be reached. The catch-all proxy would return
-    HTML (the offline page) or a 5xx; the zip endpoint returns either
-    a zip (200, ``application/zip``) or a 404 with JSON detail. Either
-    is acceptable evidence that the *zip* endpoint matched.
-    """
-    session = _create_session(admin_user)
-    session_id = UUID(session["id"])
+    """``/webapp-download`` resolves to the zip endpoint, not the catch-all proxy."""
+    session_id = BuildSessionManager.create(admin_user)["id"]
 
     response = client.get(
         f"{API_SERVER_URL}/build/sessions/{session_id}/webapp-download",
@@ -276,50 +111,6 @@ def test_webapp_download_route_not_shadowed_by_catchall(
     )
 
     content_type = response.headers.get("content-type", "").lower()
-    # If the catch-all proxy had shadowed us we'd get text/html (offline
-    # page). The zip endpoint returns application/zip on success or
-    # application/json on a 404. Either rules out the proxy match.
     assert "text/html" not in content_type, (
-        "webapp-download was shadowed by the catch-all proxy route "
-        "(regression for e213853f63)"
+        "webapp-download was shadowed by the catch-all proxy route"
     )
-
-
-def test_webapp_assets_isolated_across_sessions(
-    admin_user: DATestUser,
-    basic_user: DATestUser,
-) -> None:
-    """User A's webapp asset URL cannot leak into user B's session.
-
-    Regression for SHA ``ab9e3e5338``. Two sessions owned by two users
-    each carry their own ``session_id`` in the proxy URL; an asset URL
-    issued for session A must not be servable as part of session B's
-    proxy mount, because each session's filesystem (and Next.js port)
-    is owned by a different sandbox.
-
-    Concretely: build a "leaky" asset URL by taking session A's proxy
-    path and substituting session B's id. Hitting that URL as user B
-    (the owner of B) must not transparently fetch A's bytes — at best
-    it triggers B's own offline page or its own routing logic, but it
-    must not serve content from A's sandbox.
-    """
-    session_a = _create_session(admin_user)
-    session_b = _create_session(basic_user)
-    session_a_id = UUID(session_a["id"])
-    session_b_id = UUID(session_b["id"])
-
-    asset_path = f"_next/static/{uuid4().hex}/leak.js"
-
-    response_a = _auth_get(admin_user, session_a_id, asset_path)
-    response_b = _auth_get(basic_user, session_b_id, asset_path)
-
-    # Each session's proxy must respond from its own sandbox; the two
-    # responses share a *structure* (both offline pages, no upstream)
-    # but neither must be the literal content of the other session's
-    # asset. The check we *can* make at this layer is that each
-    # response's body, if non-trivial, mentions only its own session
-    # id in any HMR/asset rewriting, and neither leaks the other's id.
-    body_a = response_a.text
-    body_b = response_b.text
-    assert str(session_b_id) not in body_a
-    assert str(session_a_id) not in body_b

--- a/backend/tests/integration/tests/craft/test_webapp_proxy.py
+++ b/backend/tests/integration/tests/craft/test_webapp_proxy.py
@@ -84,8 +84,7 @@ def test_proxy_rejects_forged_auth_cookie(
 def test_proxy_no_webapp_port_renders_branded_offline_page(
     shared_session: tuple[DATestUser, UUID],
 ) -> None:
-    # Headless session -> no allocated nextjs_port -> the proxy's
-    # "port not allocated" branch renders the branded offline page.
+    # shared_session is headless, so no Next.js port is allocated.
     owner, session_id = shared_session
 
     response = _auth_get(owner, session_id, follow_redirects=False)

--- a/backend/tests/integration/tests/craft/user_library_http.py
+++ b/backend/tests/integration/tests/craft/user_library_http.py
@@ -1,0 +1,87 @@
+"""Shared HTTP helpers for the user-library endpoints."""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from collections.abc import Iterable
+from typing import Any
+
+import httpx
+
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.http_client import client
+from tests.integration.common_utils.test_models import DATestUser
+
+
+def _url(*parts: str) -> str:
+    return f"{API_SERVER_URL}/build/user-library/" + "/".join(parts)
+
+
+def _multipart_headers(user: DATestUser) -> dict[str, str]:
+    """Drop the JSON Content-Type so the client can set the multipart one."""
+    return {k: v for k, v in user.headers.items() if k.lower() != "content-type"}
+
+
+def upload_user_library_files(
+    user: DATestUser,
+    files: Iterable[tuple[str, bytes, str | None]],
+    path: str = "/",
+) -> httpx.Response:
+    multipart = [
+        (
+            "files",
+            (name, io.BytesIO(content), content_type or "application/octet-stream"),
+        )
+        for name, content, content_type in files
+    ]
+    return client.post(
+        _url("upload"),
+        files=multipart,
+        data={"path": path},
+        headers=_multipart_headers(user),
+        cookies=user.cookies,
+    )
+
+
+def upload_user_library_zip(
+    user: DATestUser,
+    zip_bytes: bytes,
+    path: str = "/",
+    filename: str = "bundle.zip",
+) -> httpx.Response:
+    return client.post(
+        _url("upload-zip"),
+        files={"file": (filename, io.BytesIO(zip_bytes), "application/zip")},
+        data={"path": path},
+        headers=_multipart_headers(user),
+        cookies=user.cookies,
+    )
+
+
+def list_user_library_tree(user: DATestUser) -> list[dict[str, Any]]:
+    response = client.get(
+        _url("tree"),
+        headers=user.headers,
+        cookies=user.cookies,
+    )
+    response.raise_for_status()
+    body = response.json()
+    assert isinstance(body, list)
+    return body
+
+
+def delete_user_library_file(user: DATestUser, document_id: str) -> httpx.Response:
+    return client.delete(
+        _url("files", document_id),
+        headers=user.headers,
+        cookies=user.cookies,
+    )
+
+
+def make_zip_bytes(members: dict[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, data in members.items():
+            zf.writestr(name, data)
+    return buf.getvalue()


### PR DESCRIPTION
## Description

This is the compose/API-boundary split from the larger Craft integration-test branch.

It changes the top-level Craft integration tests under `backend/tests/integration/tests/craft/*.py` to run against the real Docker Compose `api_server` instead of the in-process FastAPI test client. To support that, it adds a shared Craft test fixture that installs a real `httpx` client, seeds the admin user and fake LLM provider without `reset_all()`, and cleans up Docker-backed sandboxes after each module.

It also adds shared user-library HTTP helpers and updates `pr-craft-compose-integration.yml` so the compose lane runs the top-level Craft API tests while still excluding the Kubernetes subdirectory.

The goal is to review the compose API-contract migration separately from the later Docker e2e, Kubernetes Helm, and EDU cleanup splits.

## How Has This Been Tested?


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
