### PR TITLE
fix: notion db parents

### DIFF
--- a/backend/onyx/connectors/notion/connector.py
+++ b/backend/onyx/connectors/notion/connector.py
@@ -157,6 +157,11 @@ class NotionConnector(LoadConnector, PollConnector):
         # Maps data_source_id -> database_id (populated in _read_pages_from_database).
         # Used to resolve data_source_id parent types back to the database.
         self._data_source_to_database_map: dict[str, str] = {}
+        # Page IDs that are parents of standalone databases (discovered via the search
+        # API in _yield_database_hierarchy_nodes). These pages must emit a hierarchy
+        # node in _read_pages even if they have no block-detected children, so that the
+        # STUB created for them during database upsert gets promoted.
+        self._database_parent_page_ids: set[str] = set()
 
     @classmethod
     @override
@@ -885,9 +890,14 @@ class NotionConnector(LoadConnector, PollConnector):
                 page_title = raw_page_title or f"Untitled Page with ID {page.id}"
                 parent_raw_id = self._get_parent_raw_id(page.parent, page_id=page.id)
 
-                # If this page has children (pages or databases), yield it as a hierarchy node FIRST
-                # This ensures parent nodes are created before child documents reference them
-                if block_output.child_page_ids or block_output.hierarchy_nodes:
+                # Yield as a hierarchy node if this page has block-detected children,
+                # OR if it was discovered as the parent of a standalone database (in
+                # which case a STUB exists for it and needs to be promoted here).
+                if (
+                    block_output.child_page_ids
+                    or block_output.hierarchy_nodes
+                    or page.id in self._database_parent_page_ids
+                ):
                     hierarchy_node = self._maybe_yield_hierarchy_node(
                         raw_node_id=page.id,
                         raw_parent_id=parent_raw_id,
@@ -1028,6 +1038,15 @@ class NotionConnector(LoadConnector, PollConnector):
                     db_url = (
                         db_page.url or f"https://notion.so/{db_id.replace('-', '')}"
                     )
+                    # Track page parents so _read_pages can emit their hierarchy nodes
+                    # even when those pages have no block-detected children.
+                    db_parent = db_page.parent
+                    if (
+                        db_parent
+                        and db_parent.get("type") == "page_id"
+                        and parent_raw_id
+                    ):
+                        self._database_parent_page_ids.add(parent_raw_id)
                 except requests.exceptions.RequestException as e:
                     logger.warning(
                         "Could not fetch database '%s', "

--- a/backend/tests/unit/onyx/connectors/notion/test_notion_database_parent_hierarchy.py
+++ b/backend/tests/unit/onyx/connectors/notion/test_notion_database_parent_hierarchy.py
@@ -1,0 +1,166 @@
+"""Tests for standalone-database parent page hierarchy node emission.
+
+When _yield_database_hierarchy_nodes discovers that a database's parent is a
+page, it records that page ID in _database_parent_page_ids.  _read_pages then
+emits a hierarchy node for that page even if its BlockReadOutput is empty
+(no child pages, no inline databases), so the STUB created during database
+upsert can be promoted.
+"""
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from onyx.connectors.models import HierarchyNode
+from onyx.connectors.notion.connector import BlockReadOutput
+from onyx.connectors.notion.connector import NotionConnector
+from onyx.connectors.notion.connector import NotionPage
+from onyx.db.enums import HierarchyNodeType
+
+
+def _make_connector() -> NotionConnector:
+    connector = NotionConnector()
+    connector.load_credentials({"notion_integration_token": "fake-token"})
+    connector.workspace_id = "ws-1"
+    return connector
+
+
+def _make_page(
+    page_id: str,
+    parent: dict,
+    url: str | None = None,
+) -> NotionPage:
+    return NotionPage(
+        id=page_id,
+        created_time="2026-01-01T00:00:00.000Z",
+        last_edited_time="2026-01-01T00:00:00.000Z",
+        in_trash=False,
+        properties={"Name": {"type": "title", "title": [{"plain_text": page_id}]}},
+        url=url or f"https://notion.so/{page_id}",
+        parent=parent,
+    )
+
+
+def _make_db_page(
+    db_id: str,
+    parent: dict,
+    name: str = "Test DB",
+) -> NotionPage:
+    return NotionPage(
+        id=db_id,
+        created_time="2026-01-01T00:00:00.000Z",
+        last_edited_time="2026-01-01T00:00:00.000Z",
+        in_trash=False,
+        properties={},
+        url=f"https://notion.so/{db_id}",
+        parent=parent,
+        database_name=name,
+    )
+
+
+class TestDatabaseParentPageTracking:
+    def test_page_id_parent_is_recorded(self) -> None:
+        """A database whose parent type is page_id is added to _database_parent_page_ids."""
+        connector = _make_connector()
+
+        search_response = MagicMock()
+        search_response.results = [
+            {"id": "ds-1", "parent": {"database_id": "db-1"}},
+        ]
+        search_response.has_more = False
+
+        db_page = _make_db_page("db-1", parent={"type": "page_id", "page_id": "page-P"})
+
+        with (
+            patch.object(connector, "_search_notion", return_value=search_response),
+            patch.object(connector, "_fetch_database_as_page", return_value=db_page),
+        ):
+            list(connector._yield_database_hierarchy_nodes())
+
+        assert "page-P" in connector._database_parent_page_ids
+
+    def test_workspace_parent_not_recorded(self) -> None:
+        """A database whose parent is the workspace root is not tracked."""
+        connector = _make_connector()
+
+        search_response = MagicMock()
+        search_response.results = [
+            {"id": "ds-1", "parent": {"database_id": "db-1"}},
+        ]
+        search_response.has_more = False
+
+        db_page = _make_db_page("db-1", parent={"type": "workspace", "workspace": True})
+
+        with (
+            patch.object(connector, "_search_notion", return_value=search_response),
+            patch.object(connector, "_fetch_database_as_page", return_value=db_page),
+        ):
+            list(connector._yield_database_hierarchy_nodes())
+
+        assert not connector._database_parent_page_ids
+
+    def test_failed_fetch_does_not_record(self) -> None:
+        """A database whose fetch fails (exception path) is not recorded."""
+        import requests
+
+        connector = _make_connector()
+
+        search_response = MagicMock()
+        search_response.results = [
+            {"id": "ds-1", "parent": {"database_id": "db-1"}},
+        ]
+        search_response.has_more = False
+
+        with (
+            patch.object(connector, "_search_notion", return_value=search_response),
+            patch.object(
+                connector,
+                "_fetch_database_as_page",
+                side_effect=requests.exceptions.HTTPError("404"),
+            ),
+        ):
+            list(connector._yield_database_hierarchy_nodes())
+
+        assert not connector._database_parent_page_ids
+
+
+class TestReadPagesEmitsHierarchyNodeForDatabaseParent:
+    def test_database_parent_page_emits_hierarchy_node_without_children(self) -> None:
+        """A page in _database_parent_page_ids emits a hierarchy node from _read_pages
+        even when _read_blocks returns an empty BlockReadOutput."""
+        connector = _make_connector()
+        connector._database_parent_page_ids = {"page-P"}
+
+        page = _make_page("page-P", parent={"type": "workspace", "workspace": True})
+        empty_block_output = BlockReadOutput(
+            blocks=[], child_page_ids=[], hierarchy_nodes=[]
+        )
+
+        with patch.object(connector, "_read_blocks", return_value=empty_block_output):
+            yielded = list(connector._read_pages([page]))
+
+        hierarchy_nodes = [item for item in yielded if isinstance(item, HierarchyNode)]
+        assert any(n.raw_node_id == "page-P" for n in hierarchy_nodes), (
+            "Expected a hierarchy node for the database-parent page, got none. "
+            f"Yielded: {yielded}"
+        )
+        node = next(n for n in hierarchy_nodes if n.raw_node_id == "page-P")
+        assert node.node_type == HierarchyNodeType.PAGE
+
+    def test_non_database_parent_page_does_not_emit_hierarchy_node(self) -> None:
+        """A page NOT in _database_parent_page_ids with no block children emits no
+        hierarchy node (existing behavior preserved)."""
+        connector = _make_connector()
+        # _database_parent_page_ids is empty
+
+        page = _make_page("page-Q", parent={"type": "workspace", "workspace": True})
+        empty_block_output = BlockReadOutput(
+            blocks=[], child_page_ids=[], hierarchy_nodes=[]
+        )
+
+        with patch.object(connector, "_read_blocks", return_value=empty_block_output):
+            yielded = list(connector._read_pages([page]))
+
+        hierarchy_nodes = [item for item in yielded if isinstance(item, HierarchyNode)]
+        assert not any(n.raw_node_id == "page-Q" for n in hierarchy_nodes), (
+            "Expected no hierarchy node for a leaf page, but one was emitted."
+        )


### PR DESCRIPTION
## Description

We weren't creating a hierarchynode for pages without block children; now we still create a node when any db has the page as a parent.

## How Has This Been Tested?

added tests

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing hierarchy nodes for pages that parent standalone Notion databases by emitting a node even when those pages have no block children. This promotes existing STUBs and prevents orphaned databases in the hierarchy.

- **Bug Fixes**
  - Track database parent pages via `_database_parent_page_ids` discovered in `_yield_database_hierarchy_nodes`.
  - Emit a hierarchy node in `_read_pages` for tracked parents even with empty block output to promote STUBs.
  - Skip tracking for workspace parents and on fetch failures; added unit tests for tracking and emission behavior.

<sup>Written for commit 4e58ffa5923ae07c9253c25745c4907958cb7d4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

