### PR TITLE
feat(terraform): make Craft sandbox node group configurable and autoscaling-ready

### DIFF
--- a/deployment/terraform/modules/aws/eks/main.tf
+++ b/deployment/terraform/modules/aws/eks/main.tf
@@ -19,8 +19,8 @@ locals {
 
   # Optional dedicated node group for sandbox pods (nodeSelector/toleration below).
   # IMDSv2 hop-limit 1 blocks sandboxed containers from the node metadata service.
-  craft_sandbox_node_groups = var.enable_craft_sandbox_node_group ? {
-    sandbox = {
+  craft_sandbox_node_groups = var.enable_craft ? {
+    craft_sandbox = {
       name           = "sandbox-node-group"
       instance_types = var.craft_sandbox_node_instance_types
       min_size       = var.craft_sandbox_node_min_size
@@ -47,12 +47,20 @@ locals {
         xvda = {
           device_name = "/dev/xvda"
           ebs = {
-            volume_size           = 50
+            volume_size           = var.craft_sandbox_node_disk_size_gb
             volume_type           = "gp3"
             encrypted             = true
             delete_on_termination = true
           }
         }
+      }
+      # cluster-autoscaler auto-discovery tags (inert unless cluster-autoscaler
+      # runs in the cluster). min_size stays >= 1 so the group never scales to
+      # zero: scaling back up from zero would also require node-template
+      # label/taint tags, which are not set here.
+      tags = {
+        "k8s.io/cluster-autoscaler/enabled"             = "true"
+        "k8s.io/cluster-autoscaler/${var.cluster_name}" = "owned"
       }
     }
   } : {}

--- a/deployment/terraform/modules/aws/eks/variables.tf
+++ b/deployment/terraform/modules/aws/eks/variables.tf
@@ -126,9 +126,9 @@ variable "tags" {
   default     = {}
 }
 
-variable "enable_craft_sandbox_node_group" {
+variable "enable_craft" {
   type        = bool
-  description = "Create a dedicated Craft sandbox node group (labeled onyx.app/workload=sandbox, tainted workload=sandbox:NoSchedule, IMDSv2 hop-limit 1)."
+  description = "Enable Craft infrastructure. Currently provisions a dedicated Craft sandbox node group (labeled onyx.app/workload=sandbox, tainted workload=sandbox:NoSchedule, IMDSv2 hop-limit 1)."
   default     = false
 }
 
@@ -140,8 +140,8 @@ variable "craft_sandbox_node_instance_types" {
 
 variable "craft_sandbox_node_min_size" {
   type        = number
-  description = "Min size of the Craft sandbox node group."
-  default     = 0
+  description = "Min size of the Craft sandbox node group. Keep >= 1: cluster-autoscaler can only scale a group back up from zero with node-template label/taint ASG tags, which are not configured here, so a value of 0 would leave sandbox pods Pending after idle scale-down."
+  default     = 1
 }
 
 variable "craft_sandbox_node_max_size" {
@@ -154,6 +154,17 @@ variable "craft_sandbox_node_desired_size" {
   type        = number
   description = "Desired size of the Craft sandbox node group."
   default     = 1
+}
+
+variable "craft_sandbox_node_disk_size_gb" {
+  type        = number
+  description = "Root EBS volume (GiB) for Craft sandbox nodes. Size this relative to the instance's vCPU and the sandbox pod's ephemeral-storage request (default 5Gi/pod): a node fits min(vCPU/pod-cpu, disk/pod-eph) sandboxes, so a disk too small for the instance makes ephemeral-storage the binding dimension and caps the node far below its CPU capacity. The default suits the default m5.large; raise it if you use larger instances."
+  default     = 50
+
+  validation {
+    condition     = var.craft_sandbox_node_disk_size_gb >= 20
+    error_message = "craft_sandbox_node_disk_size_gb must be at least 20 GiB; the AL2023 AMI and OS overlay consume ~8 GiB, leaving too little ephemeral storage for even one sandbox pod (5Gi request) below that threshold."
+  }
 }
 
 variable "create_gp3_storage_class" {

--- a/deployment/terraform/modules/aws/onyx/main.tf
+++ b/deployment/terraform/modules/aws/onyx/main.tf
@@ -76,11 +76,12 @@ module "eks" {
 
   irsa_additional_service_account_names = var.irsa_additional_service_account_names
 
-  enable_craft_sandbox_node_group   = var.enable_craft_sandbox_node_group
+  enable_craft                      = var.enable_craft
   craft_sandbox_node_instance_types = var.craft_sandbox_node_instance_types
   craft_sandbox_node_min_size       = var.craft_sandbox_node_min_size
   craft_sandbox_node_max_size       = var.craft_sandbox_node_max_size
   craft_sandbox_node_desired_size   = var.craft_sandbox_node_desired_size
+  craft_sandbox_node_disk_size_gb   = var.craft_sandbox_node_disk_size_gb
 
   main_node_subnet_ids = length(var.main_node_subnet_ids) > 0 ? var.main_node_subnet_ids : (
     var.main_node_private_subnets_only ? local.private_subnets : []

--- a/deployment/terraform/modules/aws/onyx/variables.tf
+++ b/deployment/terraform/modules/aws/onyx/variables.tf
@@ -110,10 +110,9 @@ variable "redis_auth_token" {
   sensitive   = true
 }
 
-# Craft sandbox node group knobs, forwarded to the eks module (default off).
-variable "enable_craft_sandbox_node_group" {
+variable "enable_craft" {
   type        = bool
-  description = "Create a dedicated, IMDSv2-hardened Craft sandbox node group (labeled/tainted for sandbox pods)."
+  description = "Enable Craft infrastructure. Currently provisions a dedicated, IMDSv2-hardened Craft sandbox node group (labeled/tainted for sandbox pods)."
   default     = false
 }
 
@@ -125,8 +124,8 @@ variable "craft_sandbox_node_instance_types" {
 
 variable "craft_sandbox_node_min_size" {
   type        = number
-  description = "Min size of the Craft sandbox node group."
-  default     = 0
+  description = "Min size of the Craft sandbox node group. Keep >= 1: cluster-autoscaler can only scale a group back up from zero with node-template label/taint ASG tags, which are not configured here, so a value of 0 would leave sandbox pods Pending after idle scale-down."
+  default     = 1
 }
 
 variable "craft_sandbox_node_max_size" {
@@ -139,6 +138,17 @@ variable "craft_sandbox_node_desired_size" {
   type        = number
   description = "Desired size of the Craft sandbox node group."
   default     = 1
+}
+
+variable "craft_sandbox_node_disk_size_gb" {
+  type        = number
+  description = "Root EBS volume (GiB) for Craft sandbox nodes. Size relative to the instance's vCPU and the sandbox pod's ephemeral-storage request (default 5Gi/pod). The default suits the default m5.large; raise it for larger instances."
+  default     = 50
+
+  validation {
+    condition     = var.craft_sandbox_node_disk_size_gb >= 20
+    error_message = "craft_sandbox_node_disk_size_gb must be at least 20 GiB; the AL2023 AMI and OS overlay consume ~8 GiB, leaving too little ephemeral storage for even one sandbox pod (5Gi request) below that threshold."
+  }
 }
 
 variable "enable_iam_auth" {

--- a/docs/craft/kubernetes/craft-eks-runbook.md
+++ b/docs/craft/kubernetes/craft-eks-runbook.md
@@ -108,7 +108,7 @@ The sandbox node group is an optional EKS managed node group dedicated to Craft
 sandbox pods. It is enabled with:
 
 ```hcl
-enable_craft_sandbox_node_group = true
+enable_craft = true
 ```
 
 Terraform creates a node group with:
@@ -272,7 +272,7 @@ If the existing node group already has:
 - the same security-group shape as regular managed node groups: the shared node
   SG, without also attaching another `kubernetes.io/cluster/<name>`-tagged SG;
 
-then leave `enable_craft_sandbox_node_group=false` and keep using those nodes.
+then leave `enable_craft=false` and keep using those nodes.
 If you want Terraform to own the node group, either import the existing node
 group into Terraform state or create a Terraform-managed node group with a
 non-conflicting name and drain/remove the manual one after sandboxes move.


### PR DESCRIPTION
## Description

Make the optional Craft sandbox node group in `deployment/terraform/modules/aws/eks` (and its `aws/onyx` wrapper) configurable and autoscaling-ready, bringing the OSS-codified module to parity with Onyx's cloud config.

Background: each sandbox pod reserves ~5Gi ephemeral-storage, so a node fits `min(vCPU / pod-cpu, disk / pod-eph)` sandboxes. With the previously hardcoded 50Gi disk, a larger instance on a too-small disk makes ephemeral-storage the binding dimension and caps the node well below its CPU capacity — exactly what bit Onyx cloud (larger instances on the AMI-default ~20Gi disk capped a node at ~3 sandboxes vs ~7 by CPU, so cold provisions failed `Unschedulable: Insufficient ephemeral-storage`).

Changes:

- **`craft_sandbox_node_disk_size_gb`** (default `50`, preserves current behavior) — right-size the root EBS volume for larger instances. Includes a `>= 20` `validation` so a too-small disk is caught at plan time rather than after apply when the first pod fails to schedule. Plumbed through the `onyx` wrapper into the `eks` module.
- **cluster-autoscaler discovery tags** on the node group's ASG so the existing `min/max` actually autoscale (inert unless cluster-autoscaler runs in the cluster).
- **`craft_sandbox_node_min_size` now defaults to `1`** (was `0`) so the group never scales to zero. This keeps a warm sandbox node and avoids needing node-template label/taint ASG tags, which cluster-autoscaler would otherwise require to scale a group back up from zero (and which the v20 managed-node-group module does not place on the ASG anyway).
- **Collision-safe map key** (`craft_sandbox`) when merging into `eks_managed_node_groups`, so the Craft group can't silently overwrite a user-supplied entry. The AWS node group name (`sandbox-node-group`) is unchanged.
- **Renamed the gate variable `enable_craft_sandbox_node_group` → `enable_craft`** as a single master switch for Craft infrastructure in this module.

> [!WARNING]
> **Breaking change:** the `enable_craft_sandbox_node_group` variable is renamed to `enable_craft`. Callers must update the argument name; the old name will produce an "Unsupported argument" error at plan time (fails closed).

## How Has This Been Tested?

- `terraform fmt` clean; change is config-only (new variable + wiring + ASG tags + flag rename).
- The same node-group shape (configurable disk + CA tags) was applied and validated on Onyx's own clusters (craft-dev + st-dev) in cloud-deployment-yamls#529, where it resolved the disk-starvation failure end to end.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Craft sandbox node disk configurable and tag the sandbox node group for cluster-autoscaler discovery. Rename the flag to `enable_craft`, use a collision-safe node group key, and default the sandbox node group min size to 1 to keep a warm node.

- **New Features**
  - Added `craft_sandbox_node_disk_size_gb` (default 50, validation >= 20) for sandbox node root EBS volumes.
  - Tagged the sandbox node group’s ASG for cluster-autoscaler auto-discovery.

- **Migration**
  - Replace `enable_craft_sandbox_node_group` with `enable_craft` in module inputs and docs.
  - Default `craft_sandbox_node_min_size` is now 1 (was 0); autoscaler tags are inert unless cluster-autoscaler runs.

<sup>Written for commit 9bbdb1022a2b347c7aa33ee74470c6b1b650c575. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


