### PR TITLE
chore(nginx): disable server_tokens to hide nginx version

### DIFF
--- a/deployment/data/nginx/app.conf.template
+++ b/deployment/data/nginx/app.conf.template
@@ -1,3 +1,6 @@
+# Don't expose the nginx version in the Server header or on error pages
+server_tokens off;
+
 # Log format to include request latency
 log_format custom_main '$remote_addr - $remote_user [$time_local] "$request" '
                 '$status $body_bytes_sent "$http_referer" '

--- a/deployment/data/nginx/app.conf.template.no-letsencrypt
+++ b/deployment/data/nginx/app.conf.template.no-letsencrypt
@@ -1,3 +1,6 @@
+# Don't expose the nginx version in the Server header or on error pages
+server_tokens off;
+
 # Log format to include request latency
 log_format custom_main '$remote_addr - $remote_user [$time_local] "$request" '
                 '$status $body_bytes_sent "$http_referer" '

--- a/deployment/data/nginx/app.conf.template.prod
+++ b/deployment/data/nginx/app.conf.template.prod
@@ -1,3 +1,6 @@
+# Don't expose the nginx version in the Server header or on error pages
+server_tokens off;
+
 # Log format to include request latency
 log_format custom_main '$remote_addr - $remote_user [$time_local] "$request" '
                 '$status $body_bytes_sent "$http_referer" '

--- a/deployment/helm/charts/onyx/templates/nginx-conf.yaml
+++ b/deployment/helm/charts/onyx/templates/nginx-conf.yaml
@@ -14,6 +14,9 @@ metadata:
   name: onyx-nginx-conf
 data:
   upstreams.conf: |
+    # Don't expose the nginx version in the Server header or on error pages
+    server_tokens off;
+
     upstream api_server {
         server {{ include "onyx.fullname" . }}-api-service:{{ .Values.api.service.servicePort }} fail_timeout=0;
     }

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -297,7 +297,7 @@ nginx:
     # The ingress-nginx subchart doesn't auto-detect our custom ConfigMap changes.
     # Workaround: Helm upgrade will restart if the following annotation value changes.
     podAnnotations:
-      onyx.app/nginx-config-version: "4"
+      onyx.app/nginx-config-version: "5"
 
     # Propagate DOMAIN into nginx so server_name continues to use the same env var
     extraEnvs:


### PR DESCRIPTION
## What

Add `server_tokens off;` to every nginx config so nginx no longer emits its **version** in the `Server` response header or on generated error pages:

- `deployment/data/nginx/app.conf.template`
- `deployment/data/nginx/app.conf.template.prod`
- `deployment/data/nginx/app.conf.template.no-letsencrypt`
- `deployment/helm/charts/onyx/templates/nginx-conf.yaml` (in the `upstreams.conf` http-context fragment, included via the chart's `http-snippet`)

Also bumps `nginx.controller.podAnnotations.onyx.app/nginx-config-version` (`4` → `5`) so a `helm upgrade` restarts the nginx pods and the ConfigMap change actually takes effect.

The AWS ECS template pulls these templates from GitHub at boot, so it picks up the change automatically.

## Why

Defense-in-depth: removes version fingerprinting and quiets the common "web server leaks version information" finding from security scanners / pentests / compliance checks. No functional or performance impact.

## Notes / scope

- This strips the **version** only — the `Server: nginx` token itself remains (fully removing it would require the `headers-more` module).
- Upstream `Server: uvicorn` is already hidden by nginx's default `proxy_hide_header` behavior, so API routes are covered too.
- Out of scope here: the `X-Powered-By: Next.js` header (Next defaults `poweredByHeader` to on and nginx passes it through). `server_tokens` does not affect it — happy to follow up with `poweredByHeader: false` if we want fuller stack-hiding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable nginx version exposure by setting server_tokens off across all configs. Removes the version from the Server header and error pages.

- **Migration**
  - Helm: run an upgrade; the `nginx.controller.podAnnotations.onyx.app/nginx-config-version` bump triggers pod restarts.
  - ECS: instances pull the updated templates on boot. No extra steps.

<sup>Written for commit 3572656ceeb6ad0a2aa19c6d4eea7644c6cf2b58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

