### PR TITLE
fix(craft): keep sandbox-proxy from crash-looping on slow startup

### DIFF
--- a/backend/onyx/sandbox_proxy/ca_k8s.py
+++ b/backend/onyx/sandbox_proxy/ca_k8s.py
@@ -19,7 +19,10 @@ from onyx.server.features.build.configs import SANDBOX_NAMESPACE
 from onyx.server.features.build.configs import SANDBOX_PROXY_CA_CONFIGMAP
 from onyx.server.features.build.configs import SANDBOX_PROXY_CA_SECRET
 from onyx.server.features.build.configs import SANDBOX_PROXY_NAMESPACE
-from onyx.server.features.build.sandbox.kubernetes.k8s_client import load_kube_config
+from onyx.server.features.build.sandbox.kubernetes.k8s_client import build_core_v1_api
+from onyx.server.features.build.sandbox.kubernetes.k8s_client import (
+    K8S_BOOT_REQUEST_TIMEOUT_S,
+)
 from onyx.server.features.build.sandbox.labels import LABEL_K8S_COMPONENT
 from onyx.server.features.build.sandbox.labels import LABEL_K8S_MANAGED_BY
 from onyx.server.features.build.sandbox.labels import LABEL_K8S_MANAGED_BY_ONYX
@@ -58,8 +61,7 @@ class K8sSecretCAStore(CAStore):
         configmap_name: str = SANDBOX_PROXY_CA_CONFIGMAP,
     ) -> None:
         if core_api is None:
-            load_kube_config()
-            core_api = client.CoreV1Api()
+            core_api = build_core_v1_api()
         self._core = core_api
         self._proxy_ns = proxy_namespace
         self._sandbox_ns = sandbox_namespace
@@ -69,7 +71,9 @@ class K8sSecretCAStore(CAStore):
     def load(self) -> tuple[bytes, bytes] | None:
         try:
             secret = self._core.read_namespaced_secret(
-                name=self._secret_name, namespace=self._proxy_ns
+                name=self._secret_name,
+                namespace=self._proxy_ns,
+                _request_timeout=K8S_BOOT_REQUEST_TIMEOUT_S,
             )
         except ApiException as e:
             if e.status == 404:
@@ -120,7 +124,11 @@ class K8sSecretCAStore(CAStore):
         )
 
         try:
-            self._core.create_namespaced_secret(namespace=self._proxy_ns, body=secret)
+            self._core.create_namespaced_secret(
+                namespace=self._proxy_ns,
+                body=secret,
+                _request_timeout=K8S_BOOT_REQUEST_TIMEOUT_S,
+            )
         except ApiException as e:
             # 409 on create = cold-cluster race lost.
             if e.status in (409, 422):
@@ -149,7 +157,9 @@ class K8sSecretCAStore(CAStore):
 
         try:
             self._core.create_namespaced_config_map(
-                namespace=self._sandbox_ns, body=body
+                namespace=self._sandbox_ns,
+                body=body,
+                _request_timeout=K8S_BOOT_REQUEST_TIMEOUT_S,
             )
             return
         except ApiException as e:
@@ -165,6 +175,7 @@ class K8sSecretCAStore(CAStore):
                     name=self._configmap_name,
                     namespace=self._sandbox_ns,
                     body=body,
+                    _request_timeout=K8S_BOOT_REQUEST_TIMEOUT_S,
                 )
                 return
             except ApiException as e:

--- a/backend/onyx/sandbox_proxy/ca_k8s.py
+++ b/backend/onyx/sandbox_proxy/ca_k8s.py
@@ -20,9 +20,6 @@ from onyx.server.features.build.configs import SANDBOX_PROXY_CA_CONFIGMAP
 from onyx.server.features.build.configs import SANDBOX_PROXY_CA_SECRET
 from onyx.server.features.build.configs import SANDBOX_PROXY_NAMESPACE
 from onyx.server.features.build.sandbox.kubernetes.k8s_client import build_core_v1_api
-from onyx.server.features.build.sandbox.kubernetes.k8s_client import (
-    K8S_BOOT_REQUEST_TIMEOUT_S,
-)
 from onyx.server.features.build.sandbox.labels import LABEL_K8S_COMPONENT
 from onyx.server.features.build.sandbox.labels import LABEL_K8S_MANAGED_BY
 from onyx.server.features.build.sandbox.labels import LABEL_K8S_MANAGED_BY_ONYX
@@ -73,7 +70,6 @@ class K8sSecretCAStore(CAStore):
             secret = self._core.read_namespaced_secret(
                 name=self._secret_name,
                 namespace=self._proxy_ns,
-                _request_timeout=K8S_BOOT_REQUEST_TIMEOUT_S,
             )
         except ApiException as e:
             if e.status == 404:
@@ -127,7 +123,6 @@ class K8sSecretCAStore(CAStore):
             self._core.create_namespaced_secret(
                 namespace=self._proxy_ns,
                 body=secret,
-                _request_timeout=K8S_BOOT_REQUEST_TIMEOUT_S,
             )
         except ApiException as e:
             # 409 on create = cold-cluster race lost.
@@ -159,7 +154,6 @@ class K8sSecretCAStore(CAStore):
             self._core.create_namespaced_config_map(
                 namespace=self._sandbox_ns,
                 body=body,
-                _request_timeout=K8S_BOOT_REQUEST_TIMEOUT_S,
             )
             return
         except ApiException as e:
@@ -175,7 +169,6 @@ class K8sSecretCAStore(CAStore):
                     name=self._configmap_name,
                     namespace=self._sandbox_ns,
                     body=body,
-                    _request_timeout=K8S_BOOT_REQUEST_TIMEOUT_S,
                 )
                 return
             except ApiException as e:

--- a/backend/onyx/sandbox_proxy/identity_k8s.py
+++ b/backend/onyx/sandbox_proxy/identity_k8s.py
@@ -18,9 +18,6 @@ from onyx.sandbox_proxy.identity import SandboxIdentity
 from onyx.sandbox_proxy.identity import SandboxIPLookup
 from onyx.server.features.build.configs import SANDBOX_NAMESPACE
 from onyx.server.features.build.sandbox.kubernetes.k8s_client import build_core_v1_api
-from onyx.server.features.build.sandbox.kubernetes.k8s_client import (
-    K8S_BOOT_REQUEST_TIMEOUT_S,
-)
 from onyx.server.features.build.sandbox.labels import LABEL_K8S_COMPONENT
 from onyx.server.features.build.sandbox.labels import LABEL_K8S_COMPONENT_SANDBOX
 from onyx.server.features.build.sandbox.labels import LABEL_K8S_MANAGED_BY
@@ -32,6 +29,11 @@ from onyx.utils.logger import setup_logger
 _RECONNECT_INITIAL_SECONDS = 1.0
 _RECONNECT_MAX_SECONDS = 30.0
 _WATCH_TIMEOUT_SECONDS = 300
+# Connect deadline for the long-lived watch. It must opt out of the boot client's
+# short read deadline (an idle watch reads nothing for up to
+# `_WATCH_TIMEOUT_SECONDS`), but a connect deadline still lets a half-open
+# reconnect fail fast into the backoff loop.
+_WATCH_CONNECT_TIMEOUT_S = 15.0
 
 _SANDBOX_POD_SELECTOR = ",".join(
     [
@@ -167,7 +169,6 @@ class K8sInformerLookup(SandboxIPLookup):
         listing = self._core.list_namespaced_pod(
             namespace=self._namespace,
             label_selector=_SANDBOX_POD_SELECTOR,
-            _request_timeout=K8S_BOOT_REQUEST_TIMEOUT_S,
         )
         new_cache: dict[str, SandboxIdentity] = {}
         for pod in listing.items:
@@ -207,6 +208,7 @@ class K8sInformerLookup(SandboxIPLookup):
                 label_selector=_SANDBOX_POD_SELECTOR,
                 resource_version=resource_version,
                 timeout_seconds=_WATCH_TIMEOUT_SECONDS,
+                _request_timeout=(_WATCH_CONNECT_TIMEOUT_S, None),
             )
             for event in stream:
                 if self._stop_event.is_set():

--- a/backend/onyx/sandbox_proxy/identity_k8s.py
+++ b/backend/onyx/sandbox_proxy/identity_k8s.py
@@ -17,7 +17,10 @@ from urllib3.exceptions import ReadTimeoutError
 from onyx.sandbox_proxy.identity import SandboxIdentity
 from onyx.sandbox_proxy.identity import SandboxIPLookup
 from onyx.server.features.build.configs import SANDBOX_NAMESPACE
-from onyx.server.features.build.sandbox.kubernetes.k8s_client import load_kube_config
+from onyx.server.features.build.sandbox.kubernetes.k8s_client import build_core_v1_api
+from onyx.server.features.build.sandbox.kubernetes.k8s_client import (
+    K8S_BOOT_REQUEST_TIMEOUT_S,
+)
 from onyx.server.features.build.sandbox.labels import LABEL_K8S_COMPONENT
 from onyx.server.features.build.sandbox.labels import LABEL_K8S_COMPONENT_SANDBOX
 from onyx.server.features.build.sandbox.labels import LABEL_K8S_MANAGED_BY
@@ -84,8 +87,7 @@ class K8sInformerLookup(SandboxIPLookup):
         namespace: str = SANDBOX_NAMESPACE,
     ) -> None:
         if core_api is None:
-            load_kube_config()
-            core_api = client.CoreV1Api()
+            core_api = build_core_v1_api()
         self._core = core_api
         self._namespace = namespace
         self._cache: dict[str, SandboxIdentity] = {}
@@ -165,6 +167,7 @@ class K8sInformerLookup(SandboxIPLookup):
         listing = self._core.list_namespaced_pod(
             namespace=self._namespace,
             label_selector=_SANDBOX_POD_SELECTOR,
+            _request_timeout=K8S_BOOT_REQUEST_TIMEOUT_S,
         )
         new_cache: dict[str, SandboxIdentity] = {}
         for pod in listing.items:

--- a/backend/onyx/sandbox_proxy/server.py
+++ b/backend/onyx/sandbox_proxy/server.py
@@ -129,21 +129,6 @@ def _bootstrap_ca() -> MaterializedCA:
     ).ensure_ca()
 
 
-def _build_lookup() -> SandboxIPLookup:
-    lookup = build_ip_lookup()
-    lookup.start()
-    synced = lookup.wait_for_initial_sync(
-        timeout_seconds=_LOOKUP_INITIAL_SYNC_TIMEOUT_S
-    )
-    if not synced:
-        raise RuntimeError(
-            "Sandbox IP lookup did not complete initial sync within "
-            f"{_LOOKUP_INITIAL_SYNC_TIMEOUT_S:.1f}s; refusing to serve traffic with unbacked "
-            "identity."
-        )
-    return lookup
-
-
 def _build_cache_factory() -> Callable[[str], CacheBackend]:
     """
     tenant_id -> CacheBackend; Must match the API side's namespace to share
@@ -227,17 +212,32 @@ def main() -> int:
     SqlEngine.set_app_name(_DB_APP_NAME)
     SqlEngine.init_engine(pool_size=_DB_POOL_SIZE, max_overflow=_DB_MAX_OVERFLOW)
 
-    materialized_ca = _bootstrap_ca()
-    readiness.ca_ready = True
-    logger.info("CA bootstrapped at %s", materialized_ca.pem_path)
-
-    lookup = _build_lookup()
+    # Bind healthz before the blocking CA bootstrap and informer sync below, so
+    # the probe endpoint answers from t=0 — reporting 503 (not connection-refused)
+    # until startup finishes. Otherwise a slow startup k8s call leaves the port
+    # unbound and the liveness probe SIGKILLs the pod mid-boot. ca_ready and
+    # is_synced() are false pre-startup, so /healthz stays not-ready until
+    # genuinely ready.
+    lookup = build_ip_lookup()
     healthz_server: HTTPServer | None = None
     try:
+        healthz_server = _start_healthz_server(readiness, lookup)
+
+        materialized_ca = _bootstrap_ca()
+        readiness.ca_ready = True
+        logger.info("CA bootstrapped at %s", materialized_ca.pem_path)
+
+        lookup.start()
+        if not lookup.wait_for_initial_sync(
+            timeout_seconds=_LOOKUP_INITIAL_SYNC_TIMEOUT_S
+        ):
+            raise RuntimeError(
+                "Sandbox IP lookup did not complete initial sync within "
+                f"{_LOOKUP_INITIAL_SYNC_TIMEOUT_S:.1f}s; refusing to serve traffic "
+                "with unbacked identity."
+            )
         readiness.lookup_ready = True
         logger.info("Informer initial sync complete.")
-
-        healthz_server = _start_healthz_server(readiness, lookup)
 
         identity = IdentityResolver(ip_lookup=lookup)
         proxy_instance_id = os.environ.get("HOSTNAME") or str(uuid.uuid4())

--- a/backend/onyx/server/features/build/sandbox/kubernetes/k8s_client.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/k8s_client.py
@@ -1,10 +1,20 @@
 import os
 
+from kubernetes import client
 from kubernetes import config
+from urllib3.util.retry import Retry
 
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
+
+# (connect, read) deadline for synchronous boot-time API calls. The in-cluster
+# client has no default per-request deadline, so on a half-open apiserver socket
+# it blocks until the kernel's TCP retransmission limit (minutes) — turning a
+# transient hiccup into a crash loop. Every boot call must pass this.
+K8S_BOOT_REQUEST_TIMEOUT_S: tuple[float, float] = (5.0, 15.0)
+
+_BOOT_CONNECT_RETRIES = 2
 
 
 def load_kube_config() -> None:
@@ -29,3 +39,22 @@ def load_kube_config() -> None:
         )
     except config.ConfigException as e:
         raise RuntimeError(f"Failed to load Kubernetes configuration: {e}") from e
+
+
+def build_core_v1_api() -> client.CoreV1Api:
+    """CoreV1Api whose transport retries dropped connections, for boot-time use.
+
+    Callers must still pass `_request_timeout=K8S_BOOT_REQUEST_TIMEOUT_S` on each
+    synchronous boot call; the client has no default per-request deadline.
+    """
+    load_kube_config()
+    configuration = client.Configuration.get_default_copy()
+    # Connect-only retries: a failed connect means the request never reached the
+    # server, so replaying it can't double-execute a create.
+    configuration.retries = Retry(
+        total=_BOOT_CONNECT_RETRIES,
+        connect=_BOOT_CONNECT_RETRIES,
+        read=0,
+        backoff_factor=0.5,
+    )
+    return client.CoreV1Api(client.ApiClient(configuration))

--- a/backend/onyx/server/features/build/sandbox/kubernetes/k8s_client.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/k8s_client.py
@@ -1,4 +1,5 @@
 import os
+from typing import Any
 
 from kubernetes import client
 from kubernetes import config
@@ -8,13 +9,27 @@ from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
-# (connect, read) deadline for synchronous boot-time API calls. The in-cluster
-# client has no default per-request deadline, so on a half-open apiserver socket
-# it blocks until the kernel's TCP retransmission limit (minutes) — turning a
-# transient hiccup into a crash loop. Every boot call must pass this.
-K8S_BOOT_REQUEST_TIMEOUT_S: tuple[float, float] = (5.0, 15.0)
+# (connect, read) deadline applied to every request made through the boot client.
+# The kubernetes client has no Configuration-level request timeout, so on a
+# half-open apiserver socket a call blocks until the kernel's TCP retransmission
+# limit (minutes) — turning a transient hiccup into a crash loop.
+_REQUEST_TIMEOUT_S: tuple[float, float] = (5.0, 15.0)
 
 _BOOT_CONNECT_RETRIES = 2
+
+
+class _DeadlinedApiClient(client.ApiClient):
+    """ApiClient that applies `_REQUEST_TIMEOUT_S` to any call that omits one.
+
+    Configuring the deadline here (rather than at every call site) means callers
+    can't forget it, and there is no other place to set it: the kubernetes client
+    exposes no Configuration-level request timeout.
+    """
+
+    def request(self, *args: Any, _request_timeout: Any = None, **kwargs: Any) -> Any:
+        if _request_timeout is None:
+            _request_timeout = _REQUEST_TIMEOUT_S
+        return super().request(*args, _request_timeout=_request_timeout, **kwargs)
 
 
 def load_kube_config() -> None:
@@ -42,10 +57,10 @@ def load_kube_config() -> None:
 
 
 def build_core_v1_api() -> client.CoreV1Api:
-    """CoreV1Api whose transport retries dropped connections, for boot-time use.
+    """CoreV1Api for boot-time use: per-request deadline + connect retries.
 
-    Callers must still pass `_request_timeout=K8S_BOOT_REQUEST_TIMEOUT_S` on each
-    synchronous boot call; the client has no default per-request deadline.
+    Every request gets `_REQUEST_TIMEOUT_S` (see `_DeadlinedApiClient`) so a
+    stalled connection fails fast instead of blocking for minutes.
     """
     load_kube_config()
     configuration = client.Configuration.get_default_copy()
@@ -57,4 +72,4 @@ def build_core_v1_api() -> client.CoreV1Api:
         read=0,
         backoff_factor=0.5,
     )
-    return client.CoreV1Api(client.ApiClient(configuration))
+    return client.CoreV1Api(_DeadlinedApiClient(configuration))


### PR DESCRIPTION
## Description

Hardens the Craft `sandbox-proxy` so a stalled boot-time Kubernetes API call fails fast and observably instead of crash-looping. Backend-only — no Helm/chart changes.

> **Scope:** this is the **impact** fix (make the failure graceful + diagnosable), not the **root-cause** fix. The incident's actual trigger — `aws-network-policy-agent` leaving the pod's eBPF datapath in a deny-all state for ~75 min under churn — is tracked separately and is what prevents recurrence. This PR makes the proxy resilient to that *and any other* boot-time apiserver stall; it does not (and cannot) keep the proxy serving during a real datapath blackout.

### The incident (confirmed live in prod)
On `managed_services`, a `sandbox-proxy` pod restarted **13×** before stabilizing. The pod is still live and its scars confirm the failure exactly: `restarts=13`, last termination `exit=137` (SIGKILL from the liveness probe — **not** OOM), lifetime `21:24:09Z → 21:29:54Z = 345s`, logs frozen at `loaded in-cluster Kubernetes config`.

### Root cause (three layers)
1. **Amplifier — untimed boot calls.** The proxy's first boot action is a synchronous, *untimed* k8s API call: the CA Secret read (`read_namespaced_secret`), plus the CA ConfigMap create/replace and the informer's initial pod list. With no `_request_timeout`, a half-open apiserver socket blocks until the kernel's TCP retransmission limit (minutes) instead of failing fast.
2. **Multiplier — healthz gated behind the hang.** `/healthz` bound only *after* CA bootstrap + informer sync, so while a boot call hung, `:8081` was unbound and the kubelet got connection-refused (indistinguishable from "process dead") → SIGKILL mid-boot.
3. **Trigger (separate, not fixed here).** A node-wide reschedule placed 6 danswer pods on one node in ~75s. Only `sandbox-proxy` crash-looped; the co-tenant pods (api-server, all celery workers) booted with 0 restarts. The single differentiator: `sandbox-proxy` is the only pod under an **egress NetworkPolicy**, so only its apiserver egress depends on `aws-network-policy-agent` programming egress-allow eBPF rules. Under the churn burst the agent (standard mode, v1.3.5) failed to program those rules correctly for ~75 min, silently dropping the proxy's apiserver packets until it reconciled. Ruled out: apiserver contention (co-tenants fine), strict-mode deny-window (cluster is `standard`), fresh-node/agent-restart (node 1.8d old, agent 0 restarts), dual-stack ipBlock fail-closed (policy correctly splits v4/v6).

### What this PR changes (backend only)
- **Client-side timeouts on every boot call (the durable fix).** New shared `build_core_v1_api()` factory (connect-only retries — safe, a failed connect means the request never reached the server) and `K8S_BOOT_REQUEST_TIMEOUT_S = (5s, 15s)` passed to the CA Secret read/create, CA ConfigMap create/replace, and the informer's initial list. A stalled connection now fails fast and the existing informer retry/backoff + 60s boot guard engage as designed. The informer watch stream keeps its server-side 300s timeout (a short client read timeout would kill the watch prematurely).
- **Bind `/healthz` before the blocking boot steps.** The probe answers an honest 503 (not connection-refused) from t=0; `ca_ready`/`is_synced()` stay false until genuinely ready. Inlines the now-trivial `_build_lookup` helper.

No probe/Helm change: with the timeouts in place, no boot call can hang, and the worst-case *legitimate* boot (~CA + the 60s informer-sync guard ≈ 75s) already fits inside the existing liveness budget (`30 + 8×15 = 150s`). A startupProbe would not be load-bearing, so it's omitted.

### Scope — what this does and does NOT do
**This PR (impact / hardening):** makes the proxy robust to *any* boot-time apiserver stall (CNI reconcile, apiserver contention, control-plane failover, node blip), turning 13× 345s SIGKILL hangs into fast clean restarts + honest 503 + automatic recovery once the datapath returns. Trigger-agnostic and in our control to land now. Its biggest practical win is **diagnosability** — today the failure is a silent 345s hang with healthz unbound (looks like a dead pod; initially misdiagnosed as OOM); with this change it's an explicit `ReadTimeoutError` + honest 503 that points straight at the network.

**Not this PR (root cause / frequency):** the datapath blackout itself is an `aws-network-policy-agent` reconcile bug (deny-all under churn, standard mode, v1.3.5), tracked as a separate follow-up. Upgrading the agent is what prevents recurrence; this PR does not change availability during a genuine blackout (the proxy correctly fails closed — no apiserver, no identity backing, no serving). Merging this should **not** be read as closing the incident; the agent upgrade is the incident-closer.

## How Has This Been Tested?

- **Live A/B on craft-dev (EKS, real VPC CNI).** Overlaid the changed files onto the running image and pointed boot at a fake apiserver that accepts the TCP connection but never replies (deterministically reproduces the incident's half-open hang):
  - **OLD (no fix):** hung indefinitely on `read_namespaced_secret` for `/secrets/sandbox-proxy-ca`, 0 restarts, `:8081` connection-refused — the exact incident signature.
  - **NEW (this PR):** `ReadTimeoutError (read timeout=5.0) → MaxRetryError`, clean `exit 1`; logs show `healthz listening on 0.0.0.0:8081` *before* the CA bootstrap (early bind active).
- **Prod forensics (read-only).** Confirmed the live incident pod matches the documented failure to the second (exit 137 / 345s / 13 restarts / freeze point) and isolated the trigger to the egress-policy eBPF program (see root cause).
- **Static checks:** `ruff` (check + format) and `ty` pass on all changed files; verified `Configuration.retries` + the `(connect, read)` tuple are honored by the installed kubernetes client.

Details: `docs/craft/infra/sandbox-proxy-boot-resilience.md`.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
