### PR TITLE
fix(fe): remove `opal-disabled` layout styling

### DIFF
--- a/web/lib/opal/src/core/disabled/README.md
+++ b/web/lib/opal/src/core/disabled/README.md
@@ -19,7 +19,6 @@ descendants. Works with any children — DOM elements, React components, or frag
 
 | Selector | Effect |
 |----------|--------|
-| `.opal-disabled` | `self-stretch` (wrapper stretches to fill parent cross-axis) |
 | `[data-opal-disabled]` | `cursor-not-allowed`, `select-none`, `pointer-events: none` |
 | `[data-opal-disabled]:not(.interactive)` | `opacity-50` (non-Interactive elements only) |
 | `[data-opal-disabled].interactive` | `pointer-events: auto` (Interactive elements handle their own disabled colors) |

--- a/web/lib/opal/src/core/disabled/components.tsx
+++ b/web/lib/opal/src/core/disabled/components.tsx
@@ -76,7 +76,6 @@ function Disabled({
   const wrapper = (
     <div
       ref={ref}
-      className="opal-disabled"
       {...rest}
       aria-disabled={disabled || undefined}
       data-opal-disabled={disabled || undefined}

--- a/web/lib/opal/src/core/disabled/styles.css
+++ b/web/lib/opal/src/core/disabled/styles.css
@@ -12,10 +12,6 @@
  * re-enabled so the JS layer can suppress onClick.
  */
 
-.opal-disabled {
-  @apply self-stretch;
-}
-
 [data-opal-disabled] {
   @apply cursor-not-allowed select-none;
 }

--- a/web/lib/opal/src/core/disabled/styles.css
+++ b/web/lib/opal/src/core/disabled/styles.css
@@ -2,7 +2,6 @@
 
 /* Disabled — baseline disabled visuals applied via a wrapper <div>.
  *
- * .opal-disabled                         → wrapper stretches to fill parent cross-axis
  * [data-opal-disabled]                   → cursor + pointer-events for all
  * [data-opal-disabled]:not(.interactive) → opacity for non-Interactive elements
  * [data-opal-disabled][data-allow-click] → re-enables clicks

--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -703,7 +703,7 @@ export default function ChatPreferencesPage() {
         <SettingsLayouts.Body>
           {/* Features */}
           <Card border="solid" rounding="lg">
-            <Section>
+            <Section alignItems="stretch">
               <Disabled
                 disabled={!businessTier || uniqueSources.length === 0}
                 allowClick={businessTier}
@@ -921,7 +921,7 @@ export default function ChatPreferencesPage() {
                     description="Tools and capabilities available for chat to use. This does not apply to agents."
                   />
                   <SimpleCollapsible.Content>
-                    <Section gap={0.5}>
+                    <Section gap={0.5} alignItems="stretch">
                       {vectorDbEnabled && searchTool && (
                         <Card border="solid" rounding="lg">
                           <InputHorizontal
@@ -1116,7 +1116,7 @@ export default function ChatPreferencesPage() {
             <SimpleCollapsible.Content>
               <Section gap={1}>
                 <Card border="solid" rounding="lg">
-                  <Section>
+                  <Section alignItems="stretch">
                     <Disabled
                       disabled={!enterpriseTier}
                       tooltip="Chat history retention is an Enterprise Plan feature."


### PR DESCRIPTION
## Description

`Disabled` is semantically not responsible for stretching or causing layout effects. It was previously stretching itself inside of table cells causing the the cell's `items-center` to fail to apply to the button leaving the button at the beginning of the stretched Disabled wrapper.

The only reason I could find for the previous behavior was from the ChatPreferences page where the responsibility for stretching the content has been re-delegated to the parent `Section` components. 

## How Has This Been Tested?

**before**
<img width="1902" height="2085" alt="20260624_15h37m54s_grim" src="https://github.com/user-attachments/assets/6a5f97e3-71c5-4e45-8c3a-a08ba1136505" />

**after**
<img width="1902" height="2085" alt="20260624_15h40m30s_grim" src="https://github.com/user-attachments/assets/8a427988-6d6a-406e-b6ee-49ee64b8787e" />


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `opal-disabled` layout rule and its usage on the wrapper to eliminate layout side effects. Disabled visuals now rely on `[data-opal-disabled]` only, and stale references were removed from comments and the README.

<sup>Written for commit 2672fba89e64f42e3622f1c6406ad2b1681ef828. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



