### PR TITLE
feat(Canvas LTI): UCSD Canvas LTI modifications

### DIFF
--- a/backend/onyx/connectors/canvas/connector.py
+++ b/backend/onyx/connectors/canvas/connector.py
@@ -1708,7 +1708,7 @@ class CanvasConnector(
                 or CanvasCourse(id=course_id, name=f"Course {course_id}")
                 for course_id in self.course_ids
             ]
-            if self.course_ids is not None
+            if self.course_ids
             else self._list_courses()
         )
 

--- a/backend/onyx/connectors/canvas/connector.py
+++ b/backend/onyx/connectors/canvas/connector.py
@@ -1702,7 +1702,15 @@ class CanvasConnector(
         """
         self._release_check_time = datetime.now(timezone.utc)
         batch: list[SlimDocument | HierarchyNode] = []
-        courses = self._list_courses()
+        courses = (
+            [
+                self._get_course(course_id)
+                or CanvasCourse(id=course_id, name=f"Course {course_id}")
+                for course_id in self.course_ids
+            ]
+            if self.course_ids is not None
+            else self._list_courses()
+        )
 
         def _maybe_flush() -> Iterator[list[SlimDocument | HierarchyNode]]:
             nonlocal batch
@@ -1815,4 +1823,5 @@ class CanvasConnector(
 
         if batch:
             yield batch
+            batch = []
         self._release_check_time = None

--- a/backend/tests/unit/onyx/connectors/canvas/test_canvas_connector.py
+++ b/backend/tests/unit/onyx/connectors/canvas/test_canvas_connector.py
@@ -49,11 +49,17 @@ def _mock_course(
 def _build_connector(
     base_url: str = FAKE_BASE_URL,
     credentials: dict[str, Any] | None = None,
+    course_ids: list[int | str] | None = None,
+    batch_size: int = 16,
 ) -> CanvasConnector:
     """Build a connector with mocked credential validation."""
     with patch("onyx.connectors.canvas.client.rl_requests") as mock_req:
         mock_req.get.return_value = _mock_response(json_data=[_mock_course()])
-        connector = CanvasConnector(canvas_base_url=base_url)
+        connector = CanvasConnector(
+            canvas_base_url=base_url,
+            course_ids=course_ids,
+            batch_size=batch_size,
+        )
         connector.load_credentials(
             {"canvas_access_token": FAKE_TOKEN, **(credentials or {})}
         )
@@ -2364,6 +2370,38 @@ class TestReleasedMaterialsFiltering:
 
 class TestSlimDocsNewTypes:
     """Test retrieve_all_slim_docs_perm_sync includes new content types."""
+
+    @patch("onyx.connectors.canvas.connector.get_course_permissions")
+    @patch("onyx.connectors.canvas.client.rl_requests")
+    def test_perm_sync_uses_configured_courses_and_flushes_final_batch(
+        self, mock_requests: MagicMock, mock_perms: MagicMock
+    ) -> None:
+        mock_perms.return_value = ExternalAccess(
+            external_user_emails={"prof@school.edu"},
+            external_user_group_ids=set(),
+            is_public=False,
+        )
+        mock_requests.get.side_effect = _make_url_dispatcher(
+            courses=[_mock_course(2)],
+            pages=[_mock_page(10)],
+            assignments=[],
+            announcements=[],
+            files=[],
+            quizzes=[],
+            discussions=[],
+        )
+        connector = _build_connector(course_ids=[2], batch_size=100)
+
+        batches = list(connector.retrieve_all_slim_docs_perm_sync())
+        all_items = [item for batch in batches for item in batch]
+        slim_ids = {doc.id for doc in all_items if isinstance(doc, SlimDocument)}
+
+        assert "canvas-page-2-10" in slim_ids
+        assert mock_requests.get.call_count > 0
+        assert not any(
+            call.args and call.args[0].rstrip("/").endswith("/courses")
+            for call in mock_requests.get.call_args_list
+        )
 
     @patch("onyx.connectors.canvas.connector.get_course_permissions")
     @patch("onyx.connectors.canvas.client.rl_requests")

--- a/web/src/sections/knowledge/SourceHierarchyBrowser.tsx
+++ b/web/src/sections/knowledge/SourceHierarchyBrowser.tsx
@@ -725,15 +725,12 @@ export default function SourceHierarchyBrowser({
     onToggleDocument(docId);
   };
 
-  // Get the icon for a hierarchy item row
-  const getItemIcon = (item: HierarchyItem, isSelected: boolean) => {
+  // Get the type icon for a hierarchy item row
+  const getItemTypeIcon = (item: HierarchyItem) => {
     if (item.type === "folder") {
-      return <SvgFolder size={16} />;
+      return <SvgFolder className="shrink-0" size={18} />;
     }
-    if (isSelected) {
-      return <Checkbox checked={true} />;
-    }
-    return <SvgFileText size={16} />;
+    return <SvgFileText className="shrink-0" size={18} />;
   };
 
   // Render loading state
@@ -945,17 +942,23 @@ export default function SourceHierarchyBrowser({
                   onClick={() => handleItemClick(item)}
                 >
                   <TableLayouts.CheckboxCell>
-                    {getItemIcon(item, isSelected)}
+                    <Checkbox
+                      checked={isSelected}
+                      aria-label={`Select ${isFolder ? "folder" : "document"} ${
+                        item.data.title
+                      }`}
+                    />
                   </TableLayouts.CheckboxCell>
                   <TableLayouts.TableCell flex>
                     <GeneralLayouts.Section
                       flexDirection="row"
                       justifyContent="start"
                       alignItems="center"
-                      gap={0.25}
+                      gap={0.5}
                       height="auto"
                       width="fit"
                     >
+                      {getItemTypeIcon(item)}
                       <Truncated>{item.data.title}</Truncated>
                       {isFolder && (
                         <Button


### PR DESCRIPTION
## Description

This PR includes two targeted fixes:
1. Fix the knowledge picker row UI so selection is shown with consistent checkboxes for both folders and documents, while keeping the file/folder type icon separate.
2. Fix Canvas permission sync for configured course lists by iterating over `self.course_ids` when present instead of only using `_list_courses()`, which could miss permission updates for explicitly configured courses.

Why:
- The knowledge picker change makes selection behavior clearer and more consistent in the admin UI.
- The Canvas change ensures permission sync works correctly for Canvas setups that limit indexing to specific course IDs, so permissions stay aligned with the configured course scope.

Also included:
- An external dependency unit test covering the Canvas permission sync behavior for configured courses.

## How Has This Been Tested?

UCSD Canvas prod/dev

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [X] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve the knowledge picker UI with consistent selection and better accessibility, and fix Canvas permission sync to use configured course IDs and flush the final batch for complete updates.

- **Bug Fixes**
  - Knowledge picker: always show a checkbox for folders and documents; keep file/folder icons separate; add checkbox aria-labels.
  - Canvas permission sync: when `course_ids` is set, fetch each via `_get_course` (fallback stub if missing) instead of listing all courses; flush the final batch.
  - Unit test covers configured-course sync and final batch flush, and verifies no `/courses` listing call is made.

<sup>Written for commit f4fb9e10b33f7b8691fcb40759f498ba2f3c530f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

