### PR TITLE
fix(github): surface connector validation errors instead of a generic 500

### DIFF
--- a/backend/onyx/connectors/github/connector.py
+++ b/backend/onyx/connectors/github/connector.py
@@ -31,6 +31,7 @@ from onyx.connectors.exceptions import ConnectorValidationError
 from onyx.connectors.exceptions import CredentialExpiredError
 from onyx.connectors.exceptions import InsufficientPermissionsError
 from onyx.connectors.exceptions import UnexpectedValidationError
+from onyx.connectors.exceptions import ValidationError
 from onyx.connectors.github.models import SerializedRepository
 from onyx.connectors.github.rate_limit_utils import sleep_after_rate_limit_exception
 from onyx.connectors.github.utils import deserialize_repository
@@ -1349,8 +1350,13 @@ class GithubConnector(
                     f"Unexpected GitHub error (status={e.status}): {e.data}"
                 )
 
+        except ValidationError:
+            # Let typed validation errors propagate so the API can surface the
+            # real reason instead of collapsing them into a generic 500.
+            raise
+
         except Exception as exc:
-            raise Exception(
+            raise UnexpectedValidationError(
                 f"Unexpected error during GitHub settings validation: {exc}"
             )
 

--- a/backend/tests/unit/onyx/connectors/github/test_github_checkpointing.py
+++ b/backend/tests/unit/onyx/connectors/github/test_github_checkpointing.py
@@ -455,6 +455,29 @@ def test_validate_connector_settings_errors(
     assert expected_message in str(excinfo.value)
 
 
+def test_validate_connector_settings_surfaces_typed_error(
+    build_github_connector: Callable[..., GithubConnector],
+) -> None:
+    """A typed ConnectorValidationError raised mid-validation propagates
+    unchanged, so the connector-setup API surfaces the real reason
+    ("Found no repos...") rather than a generic 500."""
+    github_connector = build_github_connector(repositories="")
+    github_client = cast(Github, github_connector.github_client)
+
+    # No specific repos -> org lookup fails -> fall back to a user that has
+    # zero accessible repos.
+    cast(MagicMock, github_client.get_organization).side_effect = GithubException(
+        status=404, data={}, headers={}
+    )
+    mock_user = MagicMock()
+    mock_user.get_repos.return_value.totalCount = 0
+    cast(MagicMock, github_client.get_user).return_value = mock_user
+
+    with pytest.raises(ConnectorValidationError) as excinfo:
+        github_connector.validate_connector_settings()
+    assert "Found no repos for user" in str(excinfo.value)
+
+
 def test_validate_connector_settings_success(
     build_github_connector: Callable[..., GithubConnector],
     mock_github_client: MagicMock,


### PR DESCRIPTION
## Description

**Bug:** Setting up a GitHub connector whose credential can't see the target owner's repos showed a generic "Unexpected error" toast — the actionable reason was hidden from the admin.

**Cause:** `validate_connector_settings` caught its own typed `ConnectorValidationError` in a final `except Exception` and re-raised a bare `Exception`. That bypassed the associate-credential endpoint's `except ValidationError` (which returns a clean 400 with the message) and fell through to `HTTP 500 detail="Unexpected error"`.

**Fix:** Re-raise typed `ValidationError`s untouched; wrap only genuinely-unexpected errors in `UnexpectedValidationError` (matching the Confluence/Jira validators). Adds a regression test.

The admin now sees e.g. `Found no repos for user: <owner>. Does the credential have the right scopes?` Reported by a cloud Enterprise customer.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check