### PR TITLE
fix(pruning): stop a failed prune from re-firing and flooding the cleanup queue

### DIFF
--- a/backend/onyx/background/celery/tasks/pruning/tasks.py
+++ b/backend/onyx/background/celery/tasks/pruning/tasks.py
@@ -246,6 +246,14 @@ def check_for_pruning(self: Task, *, tenant_id: str) -> bool | None:
                         logger.info("CC pair not due for pruning: %s", cc_pair_id)
                         continue
 
+                    # Skip auto-scheduling during a prune failure backoff; a manual
+                    # prune (API) bypasses this path and can still force a run.
+                    if RedisConnector(tenant_id, cc_pair_id).prune.in_failure_backoff:
+                        logger.info(
+                            "CC pair in pruning failure backoff: %s", cc_pair_id
+                        )
+                        continue
+
                     payload_id = try_creating_prune_generator_task(
                         self.app, cc_pair, db_session, r, tenant_id
                     )
@@ -744,7 +752,16 @@ def connector_pruning_generator_task(
             f"Pruning exceptioned: cc_pair={cc_pair_id} connector={connector_id} payload_id={payload_id}"
         )
 
-        redis_connector.prune.reset()
+        # Back off so a failing prune isn't re-dispatched on the next beat.
+        redis_connector.prune.set_failure_backoff()
+
+        # Only reset (clears the fence + taskset) if cleanup tasks were never
+        # fanned out. If they were, reset would orphan them (it doesn't revoke
+        # them) and the next beat would re-enumerate and re-queue the whole set;
+        # keeping the fence lets the monitor finalize the in-flight taskset.
+        if redis_connector.prune.generator_complete is None:
+            redis_connector.prune.reset()
+
         raise e
     finally:
         if lock.owned():

--- a/backend/onyx/background/celery/tasks/pruning/tasks.py
+++ b/backend/onyx/background/celery/tasks/pruning/tasks.py
@@ -758,9 +758,12 @@ def connector_pruning_generator_task(
         # Only reset (clears the fence + taskset) if cleanup tasks were never
         # fanned out. If they were, reset would orphan them (it doesn't revoke
         # them) and the next beat would re-enumerate and re-queue the whole set;
-        # keeping the fence lets the monitor finalize the in-flight taskset.
+        # keeping the fence lets the monitor finalize the in-flight taskset, and
+        # generator_failed makes it record a FAILED prune instead of a false success.
         if redis_connector.prune.generator_complete is None:
             redis_connector.prune.reset()
+        else:
+            redis_connector.prune.set_generator_failed()
 
         raise e
     finally:
@@ -809,16 +812,25 @@ def monitor_ccpair_pruning_taskset(
         )
         return
 
-    mark_ccpair_as_pruned(int(cc_pair_id), db_session)
-    task_logger.info(
-        f"Connector pruning finished: cc_pair={cc_pair_id} num_pruned={initial}"
-    )
+    # A generator that threw after fan-out still drains its tasks; record FAILED
+    # so the prune retries after the backoff instead of advancing last_pruned.
+    failed = redis_connector.prune.generator_failed
+    if failed:
+        task_logger.warning(
+            f"Connector pruning failed after fan-out: cc_pair={cc_pair_id} num_pruned={initial}"
+        )
+    else:
+        mark_ccpair_as_pruned(int(cc_pair_id), db_session)
+        redis_connector.prune.clear_failure_backoff()
+        task_logger.info(
+            f"Connector pruning finished: cc_pair={cc_pair_id} num_pruned={initial}"
+        )
 
     update_sync_record_status(
         db_session=db_session,
         entity_id=cc_pair_id,
         sync_type=SyncType.PRUNING,
-        sync_status=SyncStatus.SUCCESS,
+        sync_status=SyncStatus.FAILED if failed else SyncStatus.SUCCESS,
         num_docs_synced=initial,
     )
 

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -849,9 +849,8 @@ for _redis_tls_name, _redis_tls_path in (
 
 CELERY_RESULT_EXPIRES = int(os.environ.get("CELERY_RESULT_EXPIRES", 86400))  # seconds
 
-# How long the scheduler skips a connector after its prune fails before it can
-# re-dispatch. Above the prune dispatch cadence (BLOCK_PRUNING, ~8 min in cloud)
-# to break the re-fire loop; well below prune_freq so a failed prune retries soon.
+# 30m default: above the ~8 min cloud prune-dispatch cadence (so a failed prune
+# can't re-fire in a loop), well under prune_freq (so it retries soon, not days later).
 PRUNE_FAILURE_BACKOFF_SECONDS = int(
     os.environ.get("PRUNE_FAILURE_BACKOFF_SECONDS") or 30 * 60
 )

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -849,8 +849,10 @@ for _redis_tls_name, _redis_tls_path in (
 
 CELERY_RESULT_EXPIRES = int(os.environ.get("CELERY_RESULT_EXPIRES", 86400))  # seconds
 
-# 30m default: above the ~8 min cloud prune-dispatch cadence (so a failed prune
-# can't re-fire in a loop), well under prune_freq (so it retries soon, not days later).
+# A failed prune is skipped for this long before the beat re-dispatches it.
+# Floor: the re-dispatch interval (BLOCK_PRUNING = 60s * beat_multiplier, ~8 min
+# in cloud) so a failure can't hot-loop. Ceiling: prune_freq, so it still retries
+# well before the next scheduled prune. 30m is a midpoint with transient slack.
 PRUNE_FAILURE_BACKOFF_SECONDS = int(
     os.environ.get("PRUNE_FAILURE_BACKOFF_SECONDS") or 30 * 60
 )

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -849,6 +849,13 @@ for _redis_tls_name, _redis_tls_path in (
 
 CELERY_RESULT_EXPIRES = int(os.environ.get("CELERY_RESULT_EXPIRES", 86400))  # seconds
 
+# How long the scheduler skips a connector after its prune fails before it can
+# re-dispatch. Above the prune dispatch cadence (BLOCK_PRUNING, ~8 min in cloud)
+# to break the re-fire loop; well below prune_freq so a failed prune retries soon.
+PRUNE_FAILURE_BACKOFF_SECONDS = int(
+    os.environ.get("PRUNE_FAILURE_BACKOFF_SECONDS") or 30 * 60
+)
+
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#broker-pool-limit
 # Setting to None may help when there is a proxy in the way closing idle connections
 _CELERY_BROKER_POOL_LIMIT_DEFAULT = 10

--- a/backend/onyx/redis/redis_connector_prune.py
+++ b/backend/onyx/redis/redis_connector_prune.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 from redis.lock import Lock as RedisLock
 from sqlalchemy.orm import Session
 
+from onyx.configs.app_configs import PRUNE_FAILURE_BACKOFF_SECONDS
 from onyx.configs.constants import CELERY_GENERIC_BEAT_LOCK_TIMEOUT
 from onyx.configs.constants import CELERY_PRUNING_LOCK_TIMEOUT
 from onyx.configs.constants import OnyxCeleryPriority
@@ -57,7 +58,7 @@ class RedisConnectorPrune:
     # Set on prune failure; survives reset(). While present, the scheduled beat
     # skips re-dispatching this cc_pair, so a failing prune can't re-fire and flood.
     FAILURE_BACKOFF_PREFIX = PREFIX + "_failure_backoff"
-    FAILURE_BACKOFF_TTL = 30 * 60  # 30 minutes
+    FAILURE_BACKOFF_TTL = PRUNE_FAILURE_BACKOFF_SECONDS
 
     # Set when the generator throws after fan-out (fence kept); the monitor reads
     # it to record the prune FAILED instead of falsely advancing last_pruned.

--- a/backend/onyx/redis/redis_connector_prune.py
+++ b/backend/onyx/redis/redis_connector_prune.py
@@ -137,8 +137,8 @@ class RedisConnectorPrune:
         return bool(self.redis.exists(self.active_key))
 
     def set_failure_backoff(self) -> None:
-        """Record a prune failure so the scheduled beat skips re-dispatching this
-        cc_pair until the backoff expires. Deliberately survives reset()."""
+        """Record a prune failure so the beat skips re-dispatching this cc_pair
+        until it expires. Survives reset(); cleared by reset_all() on startup."""
         self.redis.set(self.failure_backoff_key, 1, ex=self.FAILURE_BACKOFF_TTL)
 
     @property
@@ -249,4 +249,7 @@ class RedisConnectorPrune:
             r.delete(key)
 
         for key in r.scan_iter(RedisConnectorPrune.FENCE_PREFIX + "*"):
+            r.delete(key)
+
+        for key in r.scan_iter(RedisConnectorPrune.FAILURE_BACKOFF_PREFIX + "*"):
             r.delete(key)

--- a/backend/onyx/redis/redis_connector_prune.py
+++ b/backend/onyx/redis/redis_connector_prune.py
@@ -54,6 +54,11 @@ class RedisConnectorPrune:
     ACTIVE_PREFIX = PREFIX + "_active"
     ACTIVE_TTL = CELERY_PRUNING_LOCK_TIMEOUT * 2
 
+    # Set on prune failure; survives reset(). While present, the scheduled beat
+    # skips re-dispatching this cc_pair, so a failing prune can't re-fire and flood.
+    FAILURE_BACKOFF_PREFIX = PREFIX + "_failure_backoff"
+    FAILURE_BACKOFF_TTL = 30 * 60  # 30 minutes
+
     def __init__(self, tenant_id: str, id: int, redis: TenantRedisClient) -> None:
         self.tenant_id: str = tenant_id
         self.id = id
@@ -68,6 +73,7 @@ class RedisConnectorPrune:
 
         self.subtask_prefix: str = f"{self.SUBTASK_PREFIX}_{id}"
         self.active_key = f"{self.ACTIVE_PREFIX}_{id}"
+        self.failure_backoff_key = f"{self.FAILURE_BACKOFF_PREFIX}_{id}"
 
     def taskset_clear(self) -> None:
         self.redis.delete(self.taskset_key)
@@ -129,6 +135,15 @@ class RedisConnectorPrune:
 
     def active(self) -> bool:
         return bool(self.redis.exists(self.active_key))
+
+    def set_failure_backoff(self) -> None:
+        """Record a prune failure so the scheduled beat skips re-dispatching this
+        cc_pair until the backoff expires. Deliberately survives reset()."""
+        self.redis.set(self.failure_backoff_key, 1, ex=self.FAILURE_BACKOFF_TTL)
+
+    @property
+    def in_failure_backoff(self) -> bool:
+        return bool(self.redis.exists(self.failure_backoff_key))
 
     @property
     def generator_complete(self) -> int | None:

--- a/backend/onyx/redis/redis_connector_prune.py
+++ b/backend/onyx/redis/redis_connector_prune.py
@@ -59,6 +59,10 @@ class RedisConnectorPrune:
     FAILURE_BACKOFF_PREFIX = PREFIX + "_failure_backoff"
     FAILURE_BACKOFF_TTL = 30 * 60  # 30 minutes
 
+    # Set when the generator throws after fan-out (fence kept); the monitor reads
+    # it to record the prune FAILED instead of falsely advancing last_pruned.
+    GENERATOR_FAILED_PREFIX = PREFIX + "_generator_failed"
+
     def __init__(self, tenant_id: str, id: int, redis: TenantRedisClient) -> None:
         self.tenant_id: str = tenant_id
         self.id = id
@@ -74,6 +78,7 @@ class RedisConnectorPrune:
         self.subtask_prefix: str = f"{self.SUBTASK_PREFIX}_{id}"
         self.active_key = f"{self.ACTIVE_PREFIX}_{id}"
         self.failure_backoff_key = f"{self.FAILURE_BACKOFF_PREFIX}_{id}"
+        self.generator_failed_key = f"{self.GENERATOR_FAILED_PREFIX}_{id}"
 
     def taskset_clear(self) -> None:
         self.redis.delete(self.taskset_key)
@@ -81,6 +86,7 @@ class RedisConnectorPrune:
     def generator_clear(self) -> None:
         self.redis.delete(self.generator_progress_key)
         self.redis.delete(self.generator_complete_key)
+        self.redis.delete(self.generator_failed_key)
 
     def get_remaining(self) -> int:
         # todo: move into fence
@@ -144,6 +150,18 @@ class RedisConnectorPrune:
     @property
     def in_failure_backoff(self) -> bool:
         return bool(self.redis.exists(self.failure_backoff_key))
+
+    def clear_failure_backoff(self) -> None:
+        self.redis.delete(self.failure_backoff_key)
+
+    def set_generator_failed(self) -> None:
+        """Mark that the generator threw after fan-out so the monitor records the
+        finalized prune as FAILED instead of advancing last_pruned."""
+        self.redis.set(self.generator_failed_key, 1, ex=self.FENCE_TTL)
+
+    @property
+    def generator_failed(self) -> bool:
+        return bool(self.redis.exists(self.generator_failed_key))
 
     @property
     def generator_complete(self) -> int | None:
@@ -224,6 +242,7 @@ class RedisConnectorPrune:
         self.redis.delete(self.active_key)
         self.redis.delete(self.generator_progress_key)
         self.redis.delete(self.generator_complete_key)
+        self.redis.delete(self.generator_failed_key)
         self.redis.delete(self.taskset_key)
         self.redis.delete(self.fence_key)
 
@@ -252,4 +271,7 @@ class RedisConnectorPrune:
             r.delete(key)
 
         for key in r.scan_iter(RedisConnectorPrune.FAILURE_BACKOFF_PREFIX + "*"):
+            r.delete(key)
+
+        for key in r.scan_iter(RedisConnectorPrune.GENERATOR_FAILED_PREFIX + "*"):
             r.delete(key)


### PR DESCRIPTION
## Description

A connector prune that fails *after* fanning out its per-doc cleanup tasks called `reset()` — which clears the fence/taskset but does **not** revoke the already-queued tasks — and because `last_pruned` only advances on full completion, the scheduled beat re-fired the prune every ~20s. Each re-fire re-enumerated and re-queued the whole set: one stuck prune produced ~1.8M cleanup tasks (~2.4x the doc count) on the `connector_deletion` queue, wedging the light fleet.

Fix:
- Only `reset()` when no cleanup tasks were fanned out (`generator_complete is None`). If they were, keep the fence so the monitor finalizes the in-flight taskset instead of orphaning them and re-queuing.
- Add a 30-min failure backoff (survives `reset()`) that the scheduled beat respects, so a persistently-failing prune can't hot-loop. Manual prunes bypass it.

## How Has This Been Tested?

- `ruff format --check`, `ruff check`, and `ty check` pass on both files.
- No automated test added: the re-fire path is integration-level (generator + monitor + beat); behavior verified by reading those paths.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check