### PR TITLE
feat(search): Skip source filter once no filter settled

### DIFF
--- a/backend/onyx/tools/tool_implementations/search/search_tool.py
+++ b/backend/onyx/tools/tool_implementations/search/search_tool.py
@@ -585,11 +585,13 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
         decide_scope = not self._scope_decision_settled
 
         jobs: list[tuple[Callable, tuple]] = []
+        scope_job_index: int | None = None
         if expand_queries:
             expansion_args = (message_history, self.llm, user_info, memories)
             jobs.append((semantic_query_rephrase, expansion_args))
             jobs.append((keyword_query_expansion, expansion_args))
         if decide_scope:
+            scope_job_index = len(jobs)
             jobs.append((decide_search_scope, decide_args))
 
         results = run_functions_tuples_in_parallel(jobs) if jobs else []
@@ -602,8 +604,8 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
             self._cached_expansion = (semantic_query, keyword_queries)
 
         plan_scope: list[DocumentSource] | None = None
-        if decide_scope:
-            plan_scope = results[-1]
+        if scope_job_index is not None:
+            plan_scope = results[scope_job_index]
             self._scope_decision_settled = plan_scope is None
 
         return semantic_query, keyword_queries, plan_scope

--- a/backend/onyx/tools/tool_implementations/search/search_tool.py
+++ b/backend/onyx/tools/tool_implementations/search/search_tool.py
@@ -98,6 +98,7 @@ from onyx.server.query_and_chat.streaming_models import SearchToolFilterDelta
 from onyx.server.query_and_chat.streaming_models import SearchToolQueriesDelta
 from onyx.server.query_and_chat.streaming_models import SearchToolStart
 from onyx.tools.interface import Tool
+from onyx.tools.models import ChatMinimalTextMessage
 from onyx.tools.models import SearchToolOverrideKwargs
 from onyx.tools.models import ToolCallException
 from onyx.tools.models import ToolResponse
@@ -288,6 +289,7 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
 
         self._search_cycles: list[SearchCycle] = []
         self._cached_expansion: tuple[str | None, list[str]] | None = None
+        self._scope_decision_settled = False
 
         self._id = tool_id
 
@@ -565,6 +567,47 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
             )
         )
 
+    def _expand_queries_and_decide_scope(
+        self,
+        skip_query_expansion: bool,
+        message_history: list[ChatMinimalTextMessage],
+        user_info: str | None,
+        memories: list[str],
+        decide_args: tuple[Any, ...],
+    ) -> tuple[str | None, list[str], list[DocumentSource] | None]:
+        """Expand the query and decide the source scope, in parallel when both apply.
+
+        Repeat calls reuse the cached expansion instead of re-expanding. Once the
+        scope decision finds no source directive it latches off for the rest of the
+        turn, since the conversation cannot introduce one mid-turn.
+        """
+        expand_queries = not skip_query_expansion
+        decide_scope = not self._scope_decision_settled
+
+        jobs: list[tuple[Callable, tuple]] = []
+        if expand_queries:
+            expansion_args = (message_history, self.llm, user_info, memories)
+            jobs.append((semantic_query_rephrase, expansion_args))
+            jobs.append((keyword_query_expansion, expansion_args))
+        if decide_scope:
+            jobs.append((decide_search_scope, decide_args))
+
+        results = run_functions_tuples_in_parallel(jobs) if jobs else []
+
+        semantic_query: str | None = None
+        keyword_queries: list[str] = []
+        if expand_queries:
+            semantic_query = results[0]
+            keyword_queries = results[1] or []
+            self._cached_expansion = (semantic_query, keyword_queries)
+
+        plan_scope: list[DocumentSource] | None = None
+        if decide_scope:
+            plan_scope = results[-1]
+            self._scope_decision_settled = plan_scope is None
+
+        return semantic_query, keyword_queries, plan_scope
+
     @log_function_time(print_only=True)
     def run(
         self,
@@ -710,44 +753,21 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
             list(self._search_cycles),
             llm_queries,
         )
-        plan_scope: list[DocumentSource] | None = None
-
-        # Skip query expansion if this is a repeat search call
-        if override_kwargs.skip_query_expansion:
-            logger.debug("Search tool - Skipping query expansion (repeat search call)")
-            semantic_query = None
-            keyword_queries: list[str] = []
-            plan_scope = decide_search_scope(*decide_args)
-        else:
-            # Start timing for query expansion/rephrase
-            query_expansion_start_time = time.time()
-
-            functions_with_args: list[tuple[Callable, tuple]] = [
-                (
-                    semantic_query_rephrase,
-                    (message_history, self.llm, user_info, memories),
-                ),
-                (
-                    keyword_query_expansion,
-                    (message_history, self.llm, user_info, memories),
-                ),
-                (decide_search_scope, decide_args),
-            ]
-
-            expansion_results = run_functions_tuples_in_parallel(functions_with_args)
-
-            # End timing for query expansion/rephrase
-            query_expansion_elapsed = time.time() - query_expansion_start_time
-            logger.debug(
-                "Search tool - Query expansion/rephrase took %s seconds",
-                format(query_expansion_elapsed, ".3f"),
+        query_expansion_start_time = time.time()
+        semantic_query, keyword_queries, plan_scope = (
+            self._expand_queries_and_decide_scope(
+                skip_query_expansion=override_kwargs.skip_query_expansion,
+                message_history=message_history,
+                user_info=user_info,
+                memories=memories,
+                decide_args=decide_args,
             )
-            semantic_query = expansion_results[0]  # str
-            keyword_queries = (
-                expansion_results[1] if expansion_results[1] is not None else []
-            )  # list[str]
-            plan_scope = expansion_results[2]
-            self._cached_expansion = (semantic_query, keyword_queries)
+        )
+        query_expansion_elapsed = time.time() - query_expansion_start_time
+        logger.debug(
+            "Search tool - Query expansion + scope decision took %s seconds",
+            format(query_expansion_elapsed, ".3f"),
+        )
 
         resolved_scope = (
             plan_scope if plan_scope is not None else user_source_restriction

--- a/backend/onyx/tools/tool_implementations/search/search_tool.py
+++ b/backend/onyx/tools/tool_implementations/search/search_tool.py
@@ -39,6 +39,7 @@ from collections.abc import Callable
 from typing import Any
 from typing import cast
 
+from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from onyx.chat.emitter import Emitter
@@ -130,6 +131,14 @@ from shared_configs.configs import MODEL_SERVER_PORT
 logger = setup_logger()
 
 QUERIES_FIELD = "queries"
+
+
+class QueryExpansionAndScope(BaseModel):
+    """Result of one search cycle's query expansion + source-scope decision."""
+
+    semantic_query: str | None
+    keyword_queries: list[str]
+    plan_scope: list[DocumentSource] | None
 
 
 def _build_scope_note(
@@ -567,6 +576,11 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
             )
         )
 
+    @log_function_time(
+        func_name="Search tool - query expansion + scope decision",
+        print_only=True,
+        debug_only=True,
+    )
     def _expand_queries_and_decide_scope(
         self,
         skip_query_expansion: bool,
@@ -574,7 +588,7 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
         user_info: str | None,
         memories: list[str],
         decide_args: tuple[Any, ...],
-    ) -> tuple[str | None, list[str], list[DocumentSource] | None]:
+    ) -> QueryExpansionAndScope:
         """Expand the query and decide the source scope, in parallel when both apply.
 
         Repeat calls reuse the cached expansion instead of re-expanding. Once the
@@ -608,7 +622,11 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
             plan_scope = results[scope_job_index]
             self._scope_decision_settled = plan_scope is None
 
-        return semantic_query, keyword_queries, plan_scope
+        return QueryExpansionAndScope(
+            semantic_query=semantic_query,
+            keyword_queries=keyword_queries,
+            plan_scope=plan_scope,
+        )
 
     @log_function_time(print_only=True)
     def run(
@@ -621,7 +639,6 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
         overall_start_time = time.time()
 
         # Initialize timing variables (in case of early exceptions)
-        query_expansion_elapsed = 0.0
         document_selection_elapsed = 0.0
         document_expansion_elapsed = 0.0
 
@@ -755,21 +772,16 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
             list(self._search_cycles),
             llm_queries,
         )
-        query_expansion_start_time = time.time()
-        semantic_query, keyword_queries, plan_scope = (
-            self._expand_queries_and_decide_scope(
-                skip_query_expansion=override_kwargs.skip_query_expansion,
-                message_history=message_history,
-                user_info=user_info,
-                memories=memories,
-                decide_args=decide_args,
-            )
+        expansion = self._expand_queries_and_decide_scope(
+            skip_query_expansion=override_kwargs.skip_query_expansion,
+            message_history=message_history,
+            user_info=user_info,
+            memories=memories,
+            decide_args=decide_args,
         )
-        query_expansion_elapsed = time.time() - query_expansion_start_time
-        logger.debug(
-            "Search tool - Query expansion + scope decision took %s seconds",
-            format(query_expansion_elapsed, ".3f"),
-        )
+        semantic_query = expansion.semantic_query
+        keyword_queries = expansion.keyword_queries
+        plan_scope = expansion.plan_scope
 
         resolved_scope = (
             plan_scope if plan_scope is not None else user_source_restriction
@@ -1147,9 +1159,8 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
         # End overall timing
         overall_elapsed = time.time() - overall_start_time
         logger.debug(
-            "Search tool - Total execution time: %s seconds (query expansion: %ss, document selection: %ss, document expansion: %ss)",
+            "Search tool - Total execution time: %s seconds (document selection: %ss, document expansion: %ss)",
             format(overall_elapsed, ".3f"),
-            format(query_expansion_elapsed, ".3f"),
             format(document_selection_elapsed, ".3f"),
             format(document_expansion_elapsed, ".3f"),
         )

--- a/backend/tests/unit/onyx/tools/tool_implementations/search/test_search_tool_run.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/search/test_search_tool_run.py
@@ -249,6 +249,37 @@ def test_cached_expansion_is_reused_on_a_new_filter_not_a_repeat() -> None:
     )
 
 
+def test_no_scope_decision_is_not_repeated_within_a_turn() -> None:
+    """Once a cycle's scope decision comes back unscoped, the conversation has no
+    source directive (which can't change this turn), so later cycles skip the
+    decision instead of burning another LLM call."""
+    tool = _make_tool()
+    connected = [DocumentSource.ZENDESK, DocumentSource.CONFLUENCE]
+    decide_mock = MagicMock(return_value=None)
+
+    _run(tool, decide_mock=decide_mock, connected_sources=connected)
+    _run(tool, decide_mock=decide_mock, connected_sources=connected)
+
+    assert decide_mock.call_count == 1, (
+        "decide_search_scope should run once, then latch off after a no-scope result"
+    )
+
+
+def test_scope_decision_keeps_running_while_a_directive_is_present() -> None:
+    """A routed decision does not latch the skip — the walk must keep deciding on
+    later cycles (e.g. to advance a backoff sequence to the next source)."""
+    tool = _make_tool()
+    connected = [DocumentSource.ZENDESK, DocumentSource.CONFLUENCE]
+    decide_mock = MagicMock(
+        side_effect=[[DocumentSource.ZENDESK], [DocumentSource.CONFLUENCE]]
+    )
+
+    _run(tool, decide_mock=decide_mock, connected_sources=connected)
+    _run(tool, decide_mock=decide_mock, connected_sources=connected)
+
+    assert decide_mock.call_count == 2
+
+
 def test_prior_cycles_accumulate_across_calls_for_the_walk() -> None:
     """A backoff sequence advances: the first call's queries + resolved scope are
     passed back to decide_search_scope as previous_cycles on the second."""


### PR DESCRIPTION
## Description
Currently the source filter is ran on every internal search tool. However, there are many scenarios where a filter is not mentioned in a prompt. As such, in these cases, we do not want to keep running the filter if it has been provided that we should not use a filter.

This PR checks if no filter has been provided, and saves this so that other internal searches in the same iteration don't use a filter.

## How Has This Been Tested?
Tests + Manual 

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip source-scope decision after the first no-scope result within a user turn. Run query expansion and scope decision together (in parallel when both apply) and reuse cached expansions to cut latency and LLM calls.

- **Refactors**
  - Added `_expand_queries_and_decide_scope` and `QueryExpansionAndScope` to coordinate rephrase, keyword expansion, and scope decision; runs conditionally in parallel and logs one combined duration.
  - Cache semantic/keyword expansions across cycles; respect `skip_query_expansion`.
  - Latch scope decision off after an unscoped result; keep deciding while a directive exists. Added unit tests for both behaviors.

<sup>Written for commit 08a3b4a9fc8cd250c7c03c6643c53a3c7c59ef71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



