### PR TITLE
feat(craft): connect external apps on demand — backend request flow

### DIFF
--- a/backend/onyx/auth/permissions.py
+++ b/backend/onyx/auth/permissions.py
@@ -56,7 +56,6 @@ IMPLIED_PERMISSIONS: dict[str, set[str]] = {
     Permission.WRITE_CHAT.value: {Permission.READ_CHAT.value},
     Permission.CRAFT_SANDBOX.value: {
         Permission.READ_SEARCH.value,
-        Permission.CRAFT_REQUEST_APP_SETUP.value,
     },
 }
 
@@ -107,16 +106,11 @@ def require_permission(
     required: Permission,
     *,
     allow_anonymous: bool = False,
-    require_scoped_token: bool = False,
 ) -> Callable[..., Coroutine[Any, Any, User]]:
     """FastAPI dependency factory: require ``required`` of the caller, capped by the
     authenticating token's scopes (unrestricted PAT / session / API key = no cap).
     allow_anonymous admits the anonymous user where the tenant permits it (the
-    anonymous-capable chat surface).
-
-    require_scoped_token makes the route machine-only: the caller must present a
-    scoped token implying ``required``; unscoped principals (session / API key /
-    unrestricted PAT) are denied and the user's own permissions are not consulted."""
+    anonymous-capable chat surface)."""
     base_user = current_chat_accessible_user if allow_anonymous else current_user
 
     async def dependency(request: Request, user: User = Depends(base_user)) -> User:
@@ -126,12 +120,9 @@ def require_permission(
         token_implies = token_scopes is not None and required.value in (
             resolve_effective_permissions({s.value for s in token_scopes})
         )
-        if require_scoped_token:
-            permitted = token_implies
-        else:
-            permitted_by_user = required in get_effective_permissions(user)
-            permitted_by_token = token_scopes is None or token_implies
-            permitted = permitted_by_user and permitted_by_token
+        permitted_by_user = required in get_effective_permissions(user)
+        permitted_by_token = token_scopes is None or token_implies
+        permitted = permitted_by_user and permitted_by_token
         if not permitted:
             raise OnyxError(
                 OnyxErrorCode.INSUFFICIENT_PERMISSIONS,

--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -541,8 +541,6 @@ class Permission(str, PyEnum):
     # identity may use. PAT-only; never granted to a group/user.
     CRAFT_SANDBOX = "craft_sandbox"
 
-    CRAFT_REQUEST_APP_SETUP = "craft:request_app_setup"
-
     # Override — any permission check passes
     FULL_ADMIN_PANEL_ACCESS = "admin"
 
@@ -561,7 +559,6 @@ Permission.IMPLIED = frozenset(
         Permission.READ_CHAT,
         Permission.WRITE_CHAT,
         Permission.READ_ADMIN,
-        Permission.CRAFT_REQUEST_APP_SETUP,
     }
 )
 

--- a/backend/onyx/server/features/build/connect_app.py
+++ b/backend/onyx/server/features/build/connect_app.py
@@ -1,21 +1,12 @@
-"""Connect-app request plumbing.
+"""Connect-app request plumbing — two Redis records, no DB, no turn-side waiting.
 
-When the agent calls the no-op ``connect_app`` tool, opencode emits a permission
-request and pauses the turn. The turn-driving consumer (``serve_client``) does
-two things and then keeps streaming — it never blocks:
-
-* **announces** the request so the live-stream consumer
-  (``merge_events_with_announces``) can emit a ``ConnectAppRequestPacket`` the FE
-  renders as a card, and
-* **stashes** the context needed to answer this exact permission.
-
-The user's decision arrives at the decision endpoint, which loads the stashed
-context and answers opencode directly (an outbound POST to the sandbox) — allow
-(connected) or reject (declined). opencode then resumes the turn and the consumer
-streams the result. No turn-side waiting, no DB row.
-
-Both Redis records are keyed so the producing worker, the live-stream worker, and
-the decision request can be different api-server processes.
+The agent's no-op ``connect_app`` tool makes opencode pause the turn. The turn
+consumer ``announces`` the request (so the live stream can emit a
+``ConnectAppRequestPacket`` card) and ``stashes`` the context to answer it, then
+keeps streaming. The decision endpoint loads that context and answers opencode
+directly on the sandbox — allow (connected) / reject (declined) — and opencode
+resumes. Both records are keyed so the producing, live-stream, and decision
+workers can be different processes.
 """
 
 from enum import Enum

--- a/backend/onyx/server/features/build/connect_app.py
+++ b/backend/onyx/server/features/build/connect_app.py
@@ -1,26 +1,23 @@
-"""Connect-app request rendezvous.
+"""Connect-app request plumbing.
 
 When the agent calls the no-op ``connect_app`` tool, opencode emits a permission
-request. The turn-driving consumer (``serve_client``) announces it here; the
-separate live-stream consumer (``merge_events_with_announces``) picks the
-announce up and emits a ``ConnectAppRequestPacket`` rendered as a card on the
-frontend. The user's connect/reject decision is delivered back and unblocks the
-parked turn.
+request and pauses the turn. The turn-driving consumer (``serve_client``) does
+two things and then keeps streaming — it never blocks:
 
-Two Redis channels, both keyed so the blocked turn and the decision request can
-land on different api-server workers:
+* **announces** the request so the live-stream consumer
+  (``merge_events_with_announces``) can emit a ``ConnectAppRequestPacket`` the FE
+  renders as a card, and
+* **stashes** the context needed to answer this exact permission.
 
-* ``announce`` — carries the request to whichever worker holds the user's live
-  SSE stream (the turn-driving worker does not relay to the browser itself).
-* ``decision`` — a single-shot latch carrying the user's answer back to the
-  parked turn.
+The user's decision arrives at the decision endpoint, which loads the stashed
+context and answers opencode directly (an outbound POST to the sandbox) — allow
+(connected) or reject (declined). opencode then resumes the turn and the consumer
+streams the result. No turn-side waiting, no DB row.
 
-This deliberately avoids the ActionApproval machinery (no DB row, no ``/live``
-poll): the permission already blocks the agent, so all we move is one request up
-and one decision back.
+Both Redis records are keyed so the producing worker, the live-stream worker, and
+the decision request can be different api-server processes.
 """
 
-import time
 from enum import Enum
 
 from pydantic import BaseModel
@@ -31,10 +28,9 @@ from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
-# The decision outlives a brief worker hiccup but not a stale request.
-_DECISION_TTL_S = 60 * 30
-# Only needs to outlive the gap between the announce and the live stream's BLPOP.
+# Each record only needs to outlive the user's connect/decline interaction.
 _ANNOUNCE_TTL_S = 60
+_PENDING_TTL_S = 60 * 30
 
 
 class ConnectAppDecision(str, Enum):
@@ -50,12 +46,22 @@ class ConnectAppRequest(BaseModel):
     reason: str | None = None
 
 
-def _decision_key(request_id: str) -> str:
-    return f"craft:connect_app:decision:{request_id}"
+class ConnectAppPending(BaseModel):
+    """The context the decision endpoint needs to answer one connect_app
+    permission on opencode, keyed by ``request_id``."""
+
+    build_session_id: str
+    opencode_session_id: str
+    perm_id: str
+    directory: str
 
 
 def _announce_key(session_id: str) -> str:
     return f"craft:connect_app:announce:{session_id}"
+
+
+def _pending_key(request_id: str) -> str:
+    return f"craft:connect_app:pending:{request_id}"
 
 
 def announce_request(
@@ -84,38 +90,26 @@ def pop_announcement(
         return None
 
 
-def resolve(request_id: str, decision: ConnectAppDecision, cache: CacheBackend) -> None:
-    """Deliver the user's decision to the parked turn waiting on ``request_id``."""
-    key = _decision_key(request_id)
-    cache.rpush(key, decision.value)
-    cache.expire(key, _DECISION_TTL_S)
+def stash_pending(
+    request_id: str, pending: ConnectAppPending, cache: CacheBackend
+) -> None:
+    """Record how to answer this request's permission, for the decision endpoint."""
+    cache.set(_pending_key(request_id), pending.model_dump_json(), ex=_PENDING_TTL_S)
 
 
-def wait_for_decision(
-    request_id: str, timeout_s: int, cache: CacheBackend
-) -> ConnectAppDecision | None:
-    """Block until the user resolves ``request_id``; ``None`` on timeout.
-
-    Polls in short BLPOP slices so an overall long wait stays responsive to
-    process shutdown. Called from the (synchronous) opencode event consumer.
-    """
-    if timeout_s <= 0:
+def load_pending(request_id: str, cache: CacheBackend) -> ConnectAppPending | None:
+    """Load the answer context; ``None`` if expired/already cleared/unparseable."""
+    raw = cache.get(_pending_key(request_id))
+    if raw is None:
+        return None
+    if isinstance(raw, bytes):
+        raw = raw.decode()
+    try:
+        return ConnectAppPending.model_validate_json(raw)
+    except ValidationError:
+        logger.warning("connect_app: unparseable pending for %s", request_id)
         return None
 
-    key = _decision_key(request_id)
-    deadline = time.monotonic() + timeout_s
-    while time.monotonic() < deadline:
-        result = cache.blpop([key], 1)
-        if result is None:
-            continue
-        _key, value = result
-        if isinstance(value, bytes):
-            value = value.decode()
-        try:
-            return ConnectAppDecision(value)
-        except ValueError:
-            logger.warning(
-                "connect_app: unparseable decision %r for %s", value, request_id
-            )
-            return None
-    return None
+
+def clear_pending(request_id: str, cache: CacheBackend) -> None:
+    cache.delete(_pending_key(request_id))

--- a/backend/onyx/server/features/build/connect_app.py
+++ b/backend/onyx/server/features/build/connect_app.py
@@ -1,0 +1,121 @@
+"""Connect-app request rendezvous.
+
+When the agent calls the no-op ``connect_app`` tool, opencode emits a permission
+request. The turn-driving consumer (``serve_client``) announces it here; the
+separate live-stream consumer (``merge_events_with_announces``) picks the
+announce up and emits a ``ConnectAppRequestPacket`` rendered as a card on the
+frontend. The user's connect/reject decision is delivered back and unblocks the
+parked turn.
+
+Two Redis channels, both keyed so the blocked turn and the decision request can
+land on different api-server workers:
+
+* ``announce`` — carries the request to whichever worker holds the user's live
+  SSE stream (the turn-driving worker does not relay to the browser itself).
+* ``decision`` — a single-shot latch carrying the user's answer back to the
+  parked turn.
+
+This deliberately avoids the ActionApproval machinery (no DB row, no ``/live``
+poll): the permission already blocks the agent, so all we move is one request up
+and one decision back.
+"""
+
+import time
+from enum import Enum
+
+from pydantic import BaseModel
+from pydantic import ValidationError
+
+from onyx.cache.interface import CacheBackend
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+# The decision outlives a brief worker hiccup but not a stale request.
+_DECISION_TTL_S = 60 * 30
+# Only needs to outlive the gap between the announce and the live stream's BLPOP.
+_ANNOUNCE_TTL_S = 60
+
+
+class ConnectAppDecision(str, Enum):
+    CONNECTED = "connected"
+    DECLINED = "declined"
+
+
+class ConnectAppRequest(BaseModel):
+    """The connect prompt carried from the turn consumer to the live stream."""
+
+    request_id: str
+    app_slug: str
+    reason: str | None = None
+
+
+def _decision_key(request_id: str) -> str:
+    return f"craft:connect_app:decision:{request_id}"
+
+
+def _announce_key(session_id: str) -> str:
+    return f"craft:connect_app:announce:{session_id}"
+
+
+def announce_request(
+    session_id: str, request: ConnectAppRequest, cache: CacheBackend
+) -> None:
+    """Hand the request to the worker streaming SSE for ``session_id``."""
+    key = _announce_key(session_id)
+    cache.rpush(key, request.model_dump_json())
+    cache.expire(key, _ANNOUNCE_TTL_S)
+
+
+def pop_announcement(
+    session_id: str, timeout_s: int, cache: CacheBackend
+) -> ConnectAppRequest | None:
+    """BLPOP one announced request; ``None`` on timeout/unparseable payload."""
+    result = cache.blpop([_announce_key(session_id)], timeout_s)
+    if result is None:
+        return None
+    _key, value = result
+    if isinstance(value, bytes):
+        value = value.decode()
+    try:
+        return ConnectAppRequest.model_validate_json(value)
+    except ValidationError:
+        logger.warning("connect_app: unparseable announce %r for %s", value, session_id)
+        return None
+
+
+def resolve(request_id: str, decision: ConnectAppDecision, cache: CacheBackend) -> None:
+    """Deliver the user's decision to the parked turn waiting on ``request_id``."""
+    key = _decision_key(request_id)
+    cache.rpush(key, decision.value)
+    cache.expire(key, _DECISION_TTL_S)
+
+
+def wait_for_decision(
+    request_id: str, timeout_s: int, cache: CacheBackend
+) -> ConnectAppDecision | None:
+    """Block until the user resolves ``request_id``; ``None`` on timeout.
+
+    Polls in short BLPOP slices so an overall long wait stays responsive to
+    process shutdown. Called from the (synchronous) opencode event consumer.
+    """
+    if timeout_s <= 0:
+        return None
+
+    key = _decision_key(request_id)
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        result = cache.blpop([key], 1)
+        if result is None:
+            continue
+        _key, value = result
+        if isinstance(value, bytes):
+            value = value.decode()
+        try:
+            return ConnectAppDecision(value)
+        except ValueError:
+            logger.warning(
+                "connect_app: unparseable decision %r for %s", value, request_id
+            )
+            return None
+    return None

--- a/backend/onyx/server/features/build/external_apps/api.py
+++ b/backend/onyx/server/features/build/external_apps/api.py
@@ -7,6 +7,7 @@ from pydantic import TypeAdapter
 from sqlalchemy.orm import Session
 
 from onyx.auth.permissions import require_permission
+from onyx.cache.factory import get_cache_backend
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import ExternalAppType
 from onyx.db.enums import Permission
@@ -29,12 +30,16 @@ from onyx.db.utils import UNSET
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.external_apps.models import BuiltInExternalAppDescriptor
+from onyx.external_apps.providers.base import OAuthExternalAppProvider
 from onyx.external_apps.providers.registry import action_policy_views
 from onyx.external_apps.providers.registry import fetch_available_built_in_apps
 from onyx.external_apps.providers.registry import get_onyx_managed_provider
+from onyx.external_apps.providers.registry import get_provider_for_app
 from onyx.external_apps.providers.registry import resolve_action_overrides
 from onyx.external_apps.url_glob import UrlGlob
 from onyx.file_store.file_store import get_default_file_store
+from onyx.server.features.build import connect_app
+from onyx.server.features.build.external_apps.models import ConnectAppDecisionRequest
 from onyx.server.features.build.external_apps.models import (
     CreateBuiltInExternalAppRequest,
 )
@@ -50,6 +55,7 @@ from onyx.skills.push import push_skills_for_users
 from onyx.utils.encryption import mask_string
 from onyx.utils.pydantic_util import parse_json_form_field
 from shared_configs.configs import MULTI_TENANT
+from shared_configs.contextvars import get_current_tenant_id
 
 router = APIRouter()
 
@@ -121,6 +127,7 @@ def _to_user_response(
         credential_keys=required_keys,
         credential_values=credential_values,
         authenticated=authenticated,
+        supports_oauth=isinstance(get_provider_for_app(app), OAuthExternalAppProvider),
     )
 
 
@@ -445,3 +452,21 @@ def list_external_apps(
         for app in apps
         if app.skill.enabled
     ]
+
+
+@router.post("/apps/connect/{request_id}/decision")
+def resolve_connect_app_request(
+    request_id: str,
+    body: ConnectAppDecisionRequest,
+    _: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+) -> None:
+    """Record the user's decision on a pending ``connect_app`` request.
+
+    The connect card (rendered from a ``ConnectAppRequestPacket``) POSTs here to
+    unblock the parked agent turn waiting on ``request_id``: "connected" allows
+    its tool call, "declined" hands it a rejection. Idempotent from the caller's
+    view — the waiting consumer reads the first decision; a duplicate lands on an
+    expired/empty key.
+    """
+    cache = get_cache_backend(tenant_id=get_current_tenant_id())
+    connect_app.resolve(request_id, body.decision, cache)

--- a/backend/onyx/server/features/build/external_apps/api.py
+++ b/backend/onyx/server/features/build/external_apps/api.py
@@ -467,13 +467,9 @@ def resolve_connect_app_request(
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> None:
-    """Record the user's decision on a pending ``connect_app`` request.
-
-    The connect card (rendered from a ``ConnectAppRequestPacket``) POSTs here. We
-    load the stashed answer context and answer opencode directly on the user's
-    sandbox — "connected" allows the parked tool call, "declined" hands it a
-    rejection. The turn-driving worker isn't involved. Idempotent: an expired or
-    already-answered request is a no-op.
+    """Answer a pending ``connect_app`` request: load the stashed context and
+    answer opencode on the user's sandbox — connected (allow) / declined
+    (reject). Idempotent; an expired or already-answered request is a no-op.
     """
     cache = get_cache_backend(tenant_id=get_current_tenant_id())
     pending = connect_app.load_pending(request_id, cache)

--- a/backend/onyx/server/features/build/external_apps/api.py
+++ b/backend/onyx/server/features/build/external_apps/api.py
@@ -483,11 +483,17 @@ def resolve_connect_app_request(
     if sandbox is None or sandbox.status != SandboxStatus.RUNNING:
         raise OnyxError(OnyxErrorCode.SERVICE_UNAVAILABLE, "Sandbox is not running.")
 
-    get_sandbox_manager().answer_connect_app_permission(
+    answered = get_sandbox_manager().answer_connect_app_permission(
         sandbox.id,
         opencode_session_id=pending.opencode_session_id,
         perm_id=pending.perm_id,
         directory=pending.directory,
         allow=body.decision == connect_app.ConnectAppDecision.CONNECTED,
     )
+    if not answered:
+        # Leave the pending record intact (TTL) so the user can retry
+        raise OnyxError(
+            OnyxErrorCode.BAD_GATEWAY,
+            "Could not reach the sandbox to apply your choice — please try again.",
+        )
     connect_app.clear_pending(request_id, cache)

--- a/backend/onyx/server/features/build/external_apps/api.py
+++ b/backend/onyx/server/features/build/external_apps/api.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from fastapi import APIRouter
 from fastapi import Depends
 from fastapi import File
@@ -11,6 +13,7 @@ from onyx.cache.factory import get_cache_backend
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import ExternalAppType
 from onyx.db.enums import Permission
+from onyx.db.enums import SandboxStatus
 from onyx.db.external_app import create_external_app
 from onyx.db.external_app import delete_external_app
 from onyx.db.external_app import get_external_app_by_id
@@ -39,6 +42,8 @@ from onyx.external_apps.providers.registry import resolve_action_overrides
 from onyx.external_apps.url_glob import UrlGlob
 from onyx.file_store.file_store import get_default_file_store
 from onyx.server.features.build import connect_app
+from onyx.server.features.build.db.build_session import get_build_session
+from onyx.server.features.build.db.sandbox import get_sandbox_by_user_id
 from onyx.server.features.build.external_apps.models import ConnectAppDecisionRequest
 from onyx.server.features.build.external_apps.models import (
     CreateBuiltInExternalAppRequest,
@@ -47,6 +52,7 @@ from onyx.server.features.build.external_apps.models import ExternalAppAdminResp
 from onyx.server.features.build.external_apps.models import ExternalAppUserResponse
 from onyx.server.features.build.external_apps.models import UpdateExternalAppRequest
 from onyx.server.features.build.external_apps.models import UpsertUserCredentialsRequest
+from onyx.server.features.build.sandbox.factory import get_sandbox_manager
 from onyx.skills.bundle import read_bundle_file
 from onyx.skills.ingest import delete_bundle_blob
 from onyx.skills.ingest import ingest_skill_bundle
@@ -458,15 +464,34 @@ def list_external_apps(
 def resolve_connect_app_request(
     request_id: str,
     body: ConnectAppDecisionRequest,
-    _: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    db_session: Session = Depends(get_session),
 ) -> None:
     """Record the user's decision on a pending ``connect_app`` request.
 
-    The connect card (rendered from a ``ConnectAppRequestPacket``) POSTs here to
-    unblock the parked agent turn waiting on ``request_id``: "connected" allows
-    its tool call, "declined" hands it a rejection. Idempotent from the caller's
-    view — the waiting consumer reads the first decision; a duplicate lands on an
-    expired/empty key.
+    The connect card (rendered from a ``ConnectAppRequestPacket``) POSTs here. We
+    load the stashed answer context and answer opencode directly on the user's
+    sandbox — "connected" allows the parked tool call, "declined" hands it a
+    rejection. The turn-driving worker isn't involved. Idempotent: an expired or
+    already-answered request is a no-op.
     """
     cache = get_cache_backend(tenant_id=get_current_tenant_id())
-    connect_app.resolve(request_id, body.decision, cache)
+    pending = connect_app.load_pending(request_id, cache)
+    if pending is None:
+        return
+
+    # Scope to the caller's own session before touching their sandbox.
+    if get_build_session(UUID(pending.build_session_id), user.id, db_session) is None:
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "Connect request not found.")
+    sandbox = get_sandbox_by_user_id(db_session, user.id)
+    if sandbox is None or sandbox.status != SandboxStatus.RUNNING:
+        raise OnyxError(OnyxErrorCode.SERVICE_UNAVAILABLE, "Sandbox is not running.")
+
+    get_sandbox_manager().answer_connect_app_permission(
+        sandbox.id,
+        opencode_session_id=pending.opencode_session_id,
+        perm_id=pending.perm_id,
+        directory=pending.directory,
+        allow=body.decision == connect_app.ConnectAppDecision.CONNECTED,
+    )
+    connect_app.clear_pending(request_id, cache)

--- a/backend/onyx/server/features/build/external_apps/models.py
+++ b/backend/onyx/server/features/build/external_apps/models.py
@@ -1,10 +1,12 @@
 from typing import Any
 
 from pydantic import BaseModel
+from pydantic import ConfigDict
 
 from onyx.db.enums import EndpointPolicy
 from onyx.db.enums import ExternalAppType
 from onyx.external_apps.models import ActionPolicyView
+from onyx.server.features.build.connect_app import ConnectAppDecision
 
 
 class CreateBuiltInExternalAppRequest(BaseModel):
@@ -107,6 +109,7 @@ class ExternalAppUserResponse(BaseModel):
     credential_keys: list[str]
     credential_values: dict[str, Any]
     authenticated: bool
+    supports_oauth: bool
 
 
 class OAuthStartResponse(BaseModel):
@@ -121,3 +124,8 @@ class OAuthCallbackRequest(BaseModel):
 class OAuthCallbackResponse(BaseModel):
     success: bool
     external_app_id: int
+
+
+class ConnectAppDecisionRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    decision: ConnectAppDecision

--- a/backend/onyx/server/features/build/external_apps/oauth.py
+++ b/backend/onyx/server/features/build/external_apps/oauth.py
@@ -241,9 +241,7 @@ def handle_external_app_oauth_callback(
     )
 
     # Authenticating opens this user's per-user gate; refresh their sandboxes so
-    # the now-usable skill bundle lands (parity with the credentials endpoint).
-    # The connect card's "connected" decision (posted by the FE after this
-    # callback writes the credential) is what resumes a parked connect_app turn.
+    # the now-usable skill bundle lands
     push_skills_for_users({user.id}, db_session)
     db_session.commit()
 

--- a/backend/onyx/server/features/build/external_apps/oauth.py
+++ b/backend/onyx/server/features/build/external_apps/oauth.py
@@ -27,6 +27,7 @@ from onyx.redis.redis_pool import get_redis_client
 from onyx.server.features.build.external_apps.models import OAuthCallbackRequest
 from onyx.server.features.build.external_apps.models import OAuthCallbackResponse
 from onyx.server.features.build.external_apps.models import OAuthStartResponse
+from onyx.skills.push import push_skills_for_users
 from onyx.utils.logger import setup_logger
 from shared_configs.contextvars import get_current_tenant_id
 
@@ -238,6 +239,13 @@ def handle_external_app_oauth_callback(
         user_id=user.id,
         user_credentials=stored_credentials,
     )
+
+    # Authenticating opens this user's per-user gate; refresh their sandboxes so
+    # the now-usable skill bundle lands (parity with the credentials endpoint).
+    # The connect card's "connected" decision (posted by the FE after this
+    # callback writes the credential) is what resumes a parked connect_app turn.
+    push_skills_for_users({user.id}, db_session)
+    db_session.commit()
 
     # One-shot — prevent replay.
     r.delete(redis_key)

--- a/backend/onyx/server/features/build/packets.py
+++ b/backend/onyx/server/features/build/packets.py
@@ -82,7 +82,7 @@ class ConnectAppRequestPacket(BasePacket):
 
     The FE renders the connect card from this packet (resolving the app from the
     registry by ``app_slug``) and POSTs the decision to
-    ``/build/apps/connect/{request_id}/decision`` to unblock the parked turn.
+    ``/build/apps/connect/{request_id}/decision`` to answer the agent's tool call.
     """
 
     type: Literal["connect_app_request"] = "connect_app_request"

--- a/backend/onyx/server/features/build/packets.py
+++ b/backend/onyx/server/features/build/packets.py
@@ -77,8 +77,27 @@ class SubagentStartedPacket(BasePacket):
     parent_session_id: str
 
 
+class ConnectAppRequestPacket(BasePacket):
+    """The agent's ``connect_app`` tool is asking the user to connect an org app.
+
+    The FE renders the connect card from this packet (resolving the app from the
+    registry by ``app_slug``) and POSTs the decision to
+    ``/build/apps/connect/{request_id}/decision`` to unblock the parked turn.
+    """
+
+    type: Literal["connect_app_request"] = "connect_app_request"
+    request_id: str
+    app_slug: str
+    reason: str | None = None
+
+
 # =============================================================================
 # Union Type for Custom Onyx Packets
 # =============================================================================
 
-BuildPacket = ErrorPacket | ApprovalRequestedPacket | SubagentStartedPacket
+BuildPacket = (
+    ErrorPacket
+    | ApprovalRequestedPacket
+    | SubagentStartedPacket
+    | ConnectAppRequestPacket
+)

--- a/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
+++ b/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
@@ -48,6 +48,11 @@ from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
+# opencode permission category emitted by the no-op ``connect_app`` tool (set to
+# "ask" in opencode_config). Intercepted in _handle_permission_ask to drive the
+# connect-app OAuth flow instead of auto-allowing.
+_CONNECT_APP_PERMISSION = "connect_app"
+
 
 # Event union (kept narrow — only the types we actually translate to).
 SandboxEvent = (
@@ -1482,6 +1487,9 @@ class OpencodeServeClient:
                 yield sandbox_event
 
             if raw.get("type") == "permission.asked":
+                # connect_app announces a card to the live stream and blocks for
+                # the user's decision; other permissions auto-allow. Nothing is
+                # yielded here — the card reaches the browser via the announce.
                 self._handle_permission_ask(raw, state.session_id, directory=directory)
 
             if terminated_locally:
@@ -1521,12 +1529,12 @@ class OpencodeServeClient:
     def _handle_permission_ask(
         self, evt: dict[str, Any], session_id: str, *, directory: str
     ) -> None:
-        """Auto-allow + telemetry per §Decisions #1.
+        """Answer opencode's ``permission.asked``.
 
-        Production ``opencode.json`` should already cover every permission
-        category we use. Reaching this path means opencode added a new
-        category we haven't configured — auto-allow keeps the turn moving
-        and the WARN log lets us notice.
+        ``connect_app`` (configured ``"ask"``) announces a connect card to the
+        live stream and blocks for the user's decision; every other category is
+        auto-allowed (production ``opencode.json`` covers the ones we use — an
+        unexpected one means a config gap, so WARN + allow).
         """
         props = evt.get("properties") or {}
         perm_id = props.get("id")
@@ -1537,6 +1545,13 @@ class OpencodeServeClient:
                 "opencode-serve: permission.asked without id; cannot respond"
             )
             return
+
+        if perm_type == _CONNECT_APP_PERMISSION:
+            self._handle_connect_app_permission(
+                evt, session_id, perm_id, directory=directory
+            )
+            return
+
         logger.warning(
             "opencode-serve: auto-allowing unexpected permission.asked "
             "(type=%s patterns=%s session=%s id=%s) — update opencode.json",
@@ -1545,18 +1560,93 @@ class OpencodeServeClient:
             session_id,
             perm_id,
         )
+        self._answer_permission(session_id, perm_id, allow=True, directory=directory)
+
+    def _answer_permission(
+        self, session_id: str, perm_id: str, *, allow: bool, directory: str
+    ) -> None:
+        """Resolve a pending opencode permission: ``allow`` (``once``) runs the
+        tool, deny (``reject``) surfaces the rejection to the agent."""
+        response = "once" if allow else "reject"
         try:
             self._http.post(
                 f"/session/{session_id}/permissions/{perm_id}",
                 params={"directory": directory},
-                json={"response": "once"},
+                json={"response": response},
             )
         except httpx.HTTPError as e:
             logger.warning(
-                "opencode-serve: permission auto-allow failed for %s: %s",
+                "opencode-serve: permission %s (%s) failed for %s: %s",
+                "allow" if allow else "deny",
+                response,
                 perm_id,
                 e,
             )
+
+    def _handle_connect_app_permission(
+        self, evt: dict[str, Any], session_id: str, perm_id: str, *, directory: str
+    ) -> None:
+        """Announce a connect card and block for the user's decision, then answer
+        opencode allow (connected) / reject (declined); a wait timeout declines.
+
+        The turn consumer can't relay to the browser, so it announces (keyed by
+        the build session id in ``directory``) and the live stream emits the
+        card. App slug comes from the tool's ``context.ask`` metadata. See
+        :mod:`onyx.server.features.build.connect_app` for the channels.
+        """
+        from uuid import uuid4
+
+        from onyx.cache.factory import get_cache_backend
+        from onyx.server.features.build import connect_app
+        from onyx.server.features.build.configs import (
+            SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS,
+        )
+        from shared_configs.contextvars import get_current_tenant_id
+
+        props = evt.get("properties") or {}
+        meta_raw = props.get("metadata")
+        meta = meta_raw if isinstance(meta_raw, dict) else {}
+        app_slug = meta.get("app")
+        if not app_slug:
+            logger.warning(
+                "connect_app permission missing app metadata (meta=%s perm_id=%s); "
+                "denying",
+                meta,
+                perm_id,
+            )
+            self._answer_permission(
+                session_id, perm_id, allow=False, directory=directory
+            )
+            return
+
+        build_session_id = directory.rstrip("/").rsplit("/", 1)[-1]
+        request_id = str(uuid4())
+        decision: connect_app.ConnectAppDecision | None = None
+        try:
+            cache = get_cache_backend(tenant_id=get_current_tenant_id())
+            connect_app.announce_request(
+                build_session_id,
+                connect_app.ConnectAppRequest(
+                    request_id=request_id,
+                    app_slug=str(app_slug),
+                    reason=meta.get("reason") or None,
+                ),
+                cache,
+            )
+            decision = connect_app.wait_for_decision(
+                request_id, SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS, cache
+            )
+        except Exception:
+            logger.exception(
+                "connect_app decision wait failed for app=%s; denying", app_slug
+            )
+
+        self._answer_permission(
+            session_id,
+            perm_id,
+            allow=decision == connect_app.ConnectAppDecision.CONNECTED,
+            directory=directory,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
+++ b/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
@@ -53,9 +53,7 @@ from shared_configs.contextvars import get_current_tenant_id
 
 logger = setup_logger()
 
-# opencode permission category emitted by the no-op ``connect_app`` tool (set to
-# "ask" in opencode_config). Intercepted in _handle_permission_ask to drive the
-# connect-app OAuth flow instead of auto-allowing.
+# opencode permission category emitted by the no-op ``connect_app`` tool
 _CONNECT_APP_PERMISSION = "connect_app"
 
 
@@ -1444,7 +1442,9 @@ class OpencodeServeClient:
                     yield PromptResponse.model_validate({"stopReason": "cancelled"})
                     return
 
-            self._reject_expired_connect_app_permissions(state, now, directory=directory)
+            self._reject_expired_connect_app_permissions(
+                state, now, directory=directory
+            )
 
             remaining = timeout - (time.monotonic() - start)
             if remaining <= 0:

--- a/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
+++ b/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
@@ -21,13 +21,17 @@ from dataclasses import dataclass
 from dataclasses import field
 from typing import Any
 from typing import cast
+from uuid import uuid4
 
 import httpx
 
+from onyx.cache.factory import get_cache_backend
+from onyx.server.features.build import connect_app
 from onyx.server.features.build.configs import OPENCODE_SERVE_CONNECT_TIMEOUT
 from onyx.server.features.build.configs import OPENCODE_SERVE_EVENT_READ_TIMEOUT
 from onyx.server.features.build.configs import OPENCODE_SERVE_REQUEST_TIMEOUT
 from onyx.server.features.build.configs import OPENCODE_SERVER_USERNAME
+from onyx.server.features.build.configs import SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS
 from onyx.server.features.build.configs import SANDBOX_TURN_TIMEOUT_SECONDS
 from onyx.server.features.build.configs import SSE_KEEPALIVE_INTERVAL
 from onyx.server.features.build.packets import SubagentStartedPacket
@@ -45,6 +49,7 @@ from onyx.server.features.build.sandbox.opencode.event_bus import BUS_CLOSED_SEN
 from onyx.server.features.build.sandbox.opencode.event_bus import PodEventBus
 from onyx.server.features.build.sandbox.sse import SSEKeepalive
 from onyx.utils.logger import setup_logger
+from shared_configs.contextvars import get_current_tenant_id
 
 logger = setup_logger()
 
@@ -132,6 +137,12 @@ class _TurnState:
     # terminator (fired from session.idle/status) consumes it — message.updated
     # itself is per-step and can't terminate the turn.
     last_finish: str | None = None
+    # connect_app permission id → monotonic deadline. The decision endpoint
+    # answers opencode directly; this is only the timeout fallback — if the user
+    # never decides, reject so the agent gets a clean decline before the turn
+    # times out. A late reject after the user answered is a no-op (opencode
+    # resolves a permission once).
+    pending_connect_app_deadlines: dict[str, float] = field(default_factory=dict)
 
 
 # ---------------------------------------------------------------------------
@@ -1435,6 +1446,8 @@ class OpencodeServeClient:
                     yield PromptResponse.model_validate({"stopReason": "cancelled"})
                     return
 
+            self._reject_expired_connect_app_permissions(state, now, directory=directory)
+
             remaining = timeout - (time.monotonic() - start)
             if remaining <= 0:
                 self.abort(opencode_session_id, directory=directory)
@@ -1487,10 +1500,10 @@ class OpencodeServeClient:
                 yield sandbox_event
 
             if raw.get("type") == "permission.asked":
-                # connect_app announces a card to the live stream and blocks for
-                # the user's decision; other permissions auto-allow. Nothing is
-                # yielded here — the card reaches the browser via the announce.
-                self._handle_permission_ask(raw, state.session_id, directory=directory)
+                # connect_app announces a card to the live stream; the decision
+                # endpoint answers opencode out-of-band. Other permissions
+                # auto-allow. Nothing is yielded here.
+                self._handle_permission_ask(raw, state, directory=directory)
 
             if terminated_locally:
                 return
@@ -1527,14 +1540,15 @@ class OpencodeServeClient:
         _raise_for_status(r, "prompt_async")
 
     def _handle_permission_ask(
-        self, evt: dict[str, Any], session_id: str, *, directory: str
+        self, evt: dict[str, Any], state: _TurnState, *, directory: str
     ) -> None:
         """Answer opencode's ``permission.asked``.
 
-        ``connect_app`` (configured ``"ask"``) announces a connect card to the
-        live stream and blocks for the user's decision; every other category is
-        auto-allowed (production ``opencode.json`` covers the ones we use — an
-        unexpected one means a config gap, so WARN + allow).
+        ``connect_app`` (configured ``"ask"``) announces a connect card and
+        leaves the permission pending for the decision endpoint to answer
+        out-of-band; every other category is auto-allowed (production
+        ``opencode.json`` covers the ones we use — an unexpected one means a
+        config gap, so WARN + allow).
         """
         props = evt.get("properties") or {}
         perm_id = props.get("id")
@@ -1548,7 +1562,7 @@ class OpencodeServeClient:
 
         if perm_type == _CONNECT_APP_PERMISSION:
             self._handle_connect_app_permission(
-                evt, session_id, perm_id, directory=directory
+                evt, state, perm_id, directory=directory
             )
             return
 
@@ -1557,16 +1571,19 @@ class OpencodeServeClient:
             "(type=%s patterns=%s session=%s id=%s) — update opencode.json",
             perm_type,
             patterns,
-            session_id,
+            state.session_id,
             perm_id,
         )
-        self._answer_permission(session_id, perm_id, allow=True, directory=directory)
+        self.answer_permission(
+            state.session_id, perm_id, allow=True, directory=directory
+        )
 
-    def _answer_permission(
+    def answer_permission(
         self, session_id: str, perm_id: str, *, allow: bool, directory: str
     ) -> None:
         """Resolve a pending opencode permission: ``allow`` (``once``) runs the
-        tool, deny (``reject``) surfaces the rejection to the agent."""
+        tool, deny (``reject``) surfaces the rejection to the agent. Answering an
+        already-resolved permission is a no-op on opencode's side."""
         response = "once" if allow else "reject"
         try:
             self._http.post(
@@ -1584,25 +1601,19 @@ class OpencodeServeClient:
             )
 
     def _handle_connect_app_permission(
-        self, evt: dict[str, Any], session_id: str, perm_id: str, *, directory: str
+        self, evt: dict[str, Any], state: _TurnState, perm_id: str, *, directory: str
     ) -> None:
-        """Announce a connect card and block for the user's decision, then answer
-        opencode allow (connected) / reject (declined); a wait timeout declines.
+        """Announce a connect card and leave the permission pending; the decision
+        endpoint answers opencode allow/deny out-of-band (see
+        :mod:`onyx.server.features.build.connect_app`).
 
-        The turn consumer can't relay to the browser, so it announces (keyed by
-        the build session id in ``directory``) and the live stream emits the
-        card. App slug comes from the tool's ``context.ask`` metadata. See
-        :mod:`onyx.server.features.build.connect_app` for the channels.
+        The turn consumer can't relay to the browser, so it announces the card
+        (keyed by the build session id in ``directory``) and stashes the context
+        the decision endpoint needs to answer this exact permission. It does NOT
+        block — the consume loop keeps running while opencode stays paused, and
+        only rejects on the timeout fallback (``pending_connect_app_deadlines``).
+        App slug comes from the tool's ``context.ask`` metadata.
         """
-        from uuid import uuid4
-
-        from onyx.cache.factory import get_cache_backend
-        from onyx.server.features.build import connect_app
-        from onyx.server.features.build.configs import (
-            SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS,
-        )
-        from shared_configs.contextvars import get_current_tenant_id
-
         props = evt.get("properties") or {}
         meta_raw = props.get("metadata")
         meta = meta_raw if isinstance(meta_raw, dict) else {}
@@ -1614,16 +1625,25 @@ class OpencodeServeClient:
                 meta,
                 perm_id,
             )
-            self._answer_permission(
-                session_id, perm_id, allow=False, directory=directory
+            self.answer_permission(
+                state.session_id, perm_id, allow=False, directory=directory
             )
             return
 
         build_session_id = directory.rstrip("/").rsplit("/", 1)[-1]
         request_id = str(uuid4())
-        decision: connect_app.ConnectAppDecision | None = None
         try:
             cache = get_cache_backend(tenant_id=get_current_tenant_id())
+            connect_app.stash_pending(
+                request_id,
+                connect_app.ConnectAppPending(
+                    build_session_id=build_session_id,
+                    opencode_session_id=state.session_id,
+                    perm_id=perm_id,
+                    directory=directory,
+                ),
+                cache,
+            )
             connect_app.announce_request(
                 build_session_id,
                 connect_app.ConnectAppRequest(
@@ -1633,20 +1653,34 @@ class OpencodeServeClient:
                 ),
                 cache,
             )
-            decision = connect_app.wait_for_decision(
-                request_id, SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS, cache
-            )
         except Exception:
             logger.exception(
-                "connect_app decision wait failed for app=%s; denying", app_slug
+                "connect_app announce failed for app=%s; denying", app_slug
             )
+            self.answer_permission(
+                state.session_id, perm_id, allow=False, directory=directory
+            )
+            return
 
-        self._answer_permission(
-            session_id,
-            perm_id,
-            allow=decision == connect_app.ConnectAppDecision.CONNECTED,
-            directory=directory,
+        state.pending_connect_app_deadlines[perm_id] = (
+            time.monotonic() + SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS
         )
+
+    def _reject_expired_connect_app_permissions(
+        self, state: _TurnState, now: float, *, directory: str
+    ) -> None:
+        """Timeout fallback: reject connect_app permissions the user never
+        answered, so the agent gets a clean decline instead of a hung turn."""
+        expired = [
+            perm_id
+            for perm_id, deadline in state.pending_connect_app_deadlines.items()
+            if deadline <= now
+        ]
+        for perm_id in expired:
+            del state.pending_connect_app_deadlines[perm_id]
+            self.answer_permission(
+                state.session_id, perm_id, allow=False, directory=directory
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
+++ b/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
@@ -137,11 +137,9 @@ class _TurnState:
     # terminator (fired from session.idle/status) consumes it — message.updated
     # itself is per-step and can't terminate the turn.
     last_finish: str | None = None
-    # connect_app permission id → monotonic deadline. The decision endpoint
-    # answers opencode directly; this is only the timeout fallback — if the user
-    # never decides, reject so the agent gets a clean decline before the turn
-    # times out. A late reject after the user answered is a no-op (opencode
-    # resolves a permission once).
+    # connect_app permission id → monotonic deadline. Timeout fallback only (the
+    # decision endpoint answers directly); reject an undecided request for a clean
+    # decline. A late reject after the user answered is a harmless no-op.
     pending_connect_app_deadlines: dict[str, float] = field(default_factory=dict)
 
 
@@ -1500,9 +1498,6 @@ class OpencodeServeClient:
                 yield sandbox_event
 
             if raw.get("type") == "permission.asked":
-                # connect_app announces a card to the live stream; the decision
-                # endpoint answers opencode out-of-band. Other permissions
-                # auto-allow. Nothing is yielded here.
                 self._handle_permission_ask(raw, state, directory=directory)
 
             if terminated_locally:
@@ -1542,13 +1537,10 @@ class OpencodeServeClient:
     def _handle_permission_ask(
         self, evt: dict[str, Any], state: _TurnState, *, directory: str
     ) -> None:
-        """Answer opencode's ``permission.asked``.
-
-        ``connect_app`` (configured ``"ask"``) announces a connect card and
-        leaves the permission pending for the decision endpoint to answer
-        out-of-band; every other category is auto-allowed (production
-        ``opencode.json`` covers the ones we use — an unexpected one means a
-        config gap, so WARN + allow).
+        """Answer opencode's ``permission.asked``. ``connect_app`` defers to the
+        connect-card flow; every other category is auto-allowed (production
+        ``opencode.json`` covers them — an unexpected one is a config gap, so
+        WARN + allow).
         """
         props = evt.get("properties") or {}
         perm_id = props.get("id")
@@ -1603,16 +1595,10 @@ class OpencodeServeClient:
     def _handle_connect_app_permission(
         self, evt: dict[str, Any], state: _TurnState, perm_id: str, *, directory: str
     ) -> None:
-        """Announce a connect card and leave the permission pending; the decision
-        endpoint answers opencode allow/deny out-of-band (see
-        :mod:`onyx.server.features.build.connect_app`).
-
-        The turn consumer can't relay to the browser, so it announces the card
-        (keyed by the build session id in ``directory``) and stashes the context
-        the decision endpoint needs to answer this exact permission. It does NOT
-        block — the consume loop keeps running while opencode stays paused, and
-        only rejects on the timeout fallback (``pending_connect_app_deadlines``).
-        App slug comes from the tool's ``context.ask`` metadata.
+        """Announce the card and stash the answer context, then return — the
+        decision endpoint answers opencode out-of-band (see :mod:`connect_app`).
+        Doesn't block; the consume loop's timeout fallback rejects if the user
+        never decides. App slug comes from the tool's ``context.ask`` metadata.
         """
         props = evt.get("properties") or {}
         meta_raw = props.get("metadata")

--- a/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
+++ b/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
@@ -1572,13 +1572,14 @@ class OpencodeServeClient:
 
     def answer_permission(
         self, session_id: str, perm_id: str, *, allow: bool, directory: str
-    ) -> None:
+    ) -> bool:
         """Resolve a pending opencode permission: ``allow`` (``once``) runs the
-        tool, deny (``reject``) surfaces the rejection to the agent. Answering an
-        already-resolved permission is a no-op on opencode's side."""
+        tool, deny (``reject``) surfaces the rejection to the agent. Returns
+        whether opencode accepted the answer; answering an already-resolved
+        permission is a no-op on opencode's side."""
         response = "once" if allow else "reject"
         try:
-            self._http.post(
+            r = self._http.post(
                 f"/session/{session_id}/permissions/{perm_id}",
                 params={"directory": directory},
                 json={"response": response},
@@ -1591,6 +1592,17 @@ class OpencodeServeClient:
                 perm_id,
                 e,
             )
+            return False
+        if not r.is_success:
+            logger.warning(
+                "opencode-serve: permission %s (%s) for %s -> HTTP %s",
+                "allow" if allow else "deny",
+                response,
+                perm_id,
+                r.status_code,
+            )
+            return False
+        return True
 
     def _handle_connect_app_permission(
         self, evt: dict[str, Any], state: _TurnState, perm_id: str, *, directory: str

--- a/backend/onyx/server/features/build/sandbox/serve_transport.py
+++ b/backend/onyx/server/features/build/sandbox/serve_transport.py
@@ -426,11 +426,9 @@ class _ServeMixin:
         directory: str,
         allow: bool,
     ) -> None:
-        """Answer a pending ``connect_app`` permission on ``sandbox_id``.
-
-        The decision endpoint calls this (on whatever worker handled the POST) to
-        answer opencode directly — decoupled from the turn-driving worker. A
-        one-shot unary call, so no event bus."""
+        """Answer a pending ``connect_app`` permission on ``sandbox_id`` — the
+        decision endpoint's path to opencode, on whatever worker handled the POST.
+        One-shot, so no event bus."""
         client = self._build_serve_client(
             sandbox_id, directory, with_event_bus=False
         )

--- a/backend/onyx/server/features/build/sandbox/serve_transport.py
+++ b/backend/onyx/server/features/build/sandbox/serve_transport.py
@@ -425,15 +425,13 @@ class _ServeMixin:
         perm_id: str,
         directory: str,
         allow: bool,
-    ) -> None:
+    ) -> bool:
         """Answer a pending ``connect_app`` permission on ``sandbox_id`` — the
         decision endpoint's path to opencode, on whatever worker handled the POST.
-        One-shot, so no event bus."""
-        client = self._build_serve_client(
-            sandbox_id, directory, with_event_bus=False
-        )
+        Returns whether opencode accepted it. One-shot, so no event bus."""
+        client = self._build_serve_client(sandbox_id, directory, with_event_bus=False)
         try:
-            client.answer_permission(
+            return client.answer_permission(
                 opencode_session_id, perm_id, allow=allow, directory=directory
             )
         finally:

--- a/backend/onyx/server/features/build/sandbox/serve_transport.py
+++ b/backend/onyx/server/features/build/sandbox/serve_transport.py
@@ -417,6 +417,30 @@ class _ServeMixin:
             ).password,
         )
 
+    def answer_connect_app_permission(
+        self,
+        sandbox_id: UUID,
+        *,
+        opencode_session_id: str,
+        perm_id: str,
+        directory: str,
+        allow: bool,
+    ) -> None:
+        """Answer a pending ``connect_app`` permission on ``sandbox_id``.
+
+        The decision endpoint calls this (on whatever worker handled the POST) to
+        answer opencode directly — decoupled from the turn-driving worker. A
+        one-shot unary call, so no event bus."""
+        client = self._build_serve_client(
+            sandbox_id, directory, with_event_bus=False
+        )
+        try:
+            client.answer_permission(
+                opencode_session_id, perm_id, allow=allow, directory=directory
+            )
+        finally:
+            client.close()
+
     def _close_session_buses(self, sandbox_id: UUID, session_id: UUID) -> None:
         """Release the per-(sandbox, session) bus. Call from
         ``cleanup_session_workspace`` — without this the reader thread +

--- a/backend/onyx/server/features/build/session/streaming.py
+++ b/backend/onyx/server/features/build/session/streaming.py
@@ -31,6 +31,7 @@ from onyx.configs.constants import MessageType
 from onyx.db.enums import SandboxStatus
 from onyx.db.models import BuildSession
 from onyx.sandbox_proxy import approval_cache
+from onyx.server.features.build import connect_app
 from onyx.server.features.build.db.build_session import create_message
 from onyx.server.features.build.db.build_session import get_build_session
 from onyx.server.features.build.db.build_session import update_session_activity
@@ -39,6 +40,7 @@ from onyx.server.features.build.db.sandbox import get_sandbox_by_user_id
 from onyx.server.features.build.db.sandbox import update_sandbox_heartbeat
 from onyx.server.features.build.packets import ApprovalRequestedPacket
 from onyx.server.features.build.packets import BuildPacket
+from onyx.server.features.build.packets import ConnectAppRequestPacket
 from onyx.server.features.build.packets import ErrorPacket
 from onyx.server.features.build.packets import SubagentStartedPacket
 from onyx.server.features.build.sandbox.base import SandboxManager
@@ -250,7 +252,15 @@ def event_to_sse(event: Any) -> str:
     """
     if isinstance(event, SSEKeepalive):
         return SSE_KEEPALIVE
-    if isinstance(event, (ApprovalRequestedPacket, ErrorPacket, SubagentStartedPacket)):
+    if isinstance(
+        event,
+        (
+            ApprovalRequestedPacket,
+            ErrorPacket,
+            SubagentStartedPacket,
+            ConnectAppRequestPacket,
+        ),
+    ):
         return _format_packet_event(event)
     return _serialize_sandbox_event(event, _get_event_type(event))
 
@@ -265,11 +275,14 @@ def merge_events_with_announces(
     session_id: UUID,
     tenant_id: str,
 ) -> Generator[Any, None, None]:
-    """Merge sandbox events and approval announces into one stream.
+    """Merge sandbox events and announces into one stream.
 
-    Two producer threads feed a shared queue: the sandbox-event iterator, and a
-    BLPOP poller that emits `ApprovalRequestedPacket` when the proxy
-    signals a new approval. Announce latency is bounded by the 1s BLPOP.
+    Producer threads feed a shared queue: the sandbox-event iterator, a BLPOP
+    poller that emits `ApprovalRequestedPacket` when the proxy signals a new
+    approval, and a BLPOP poller that emits `ConnectAppRequestPacket` when the
+    turn consumer announces a connect-app request (it drives the turn on a
+    possibly-different worker and can't relay to this stream directly). Announce
+    latency is bounded by the 1s BLPOP.
     """
     output: queue_lib.Queue[Any] = queue_lib.Queue()
     stop = threading.Event()
@@ -309,6 +322,29 @@ def merge_events_with_announces(
                 ApprovalRequestedPacket(approval_id=approval_id, session_id=session_id)
             )
 
+    def drive_connect_app_announces() -> None:
+        cache = get_cache_backend(tenant_id=tenant_id)
+        while not stop.is_set():
+            try:
+                request = connect_app.pop_announcement(
+                    str(session_id), timeout_s=1, cache=cache
+                )
+            except Exception:
+                logger.exception(
+                    "connect_app.announce_poll_failed session_id=%s", session_id
+                )
+                time.sleep(1)
+                continue
+            if request is None:
+                continue
+            output.put(
+                ConnectAppRequestPacket(
+                    request_id=request.request_id,
+                    app_slug=request.app_slug,
+                    reason=request.reason,
+                )
+            )
+
     # Spawn via the context-preserving helper so the event iterator's lazy
     # tenant-scoped DB access (e.g. event-bus creation) sees the caller's
     # contextvars instead of raising "Tenant ID is not set".
@@ -323,6 +359,11 @@ def merge_events_with_announces(
     )
     start_thread_with_context(
         drive_announces, name=f"announce-pump-{session_id}", daemon=True
+    )
+    start_thread_with_context(
+        drive_connect_app_announces,
+        name=f"connect-app-pump-{session_id}",
+        daemon=True,
     )
     try:
         while True:

--- a/backend/onyx/server/features/build/session/streaming.py
+++ b/backend/onyx/server/features/build/session/streaming.py
@@ -277,12 +277,10 @@ def merge_events_with_announces(
 ) -> Generator[Any, None, None]:
     """Merge sandbox events and announces into one stream.
 
-    Producer threads feed a shared queue: the sandbox-event iterator, a BLPOP
-    poller that emits `ApprovalRequestedPacket` when the proxy signals a new
-    approval, and a BLPOP poller that emits `ConnectAppRequestPacket` when the
-    turn consumer announces a connect-app request (it drives the turn on a
-    possibly-different worker and can't relay to this stream directly). Announce
-    latency is bounded by the 1s BLPOP.
+    Three producer threads feed a shared queue: the sandbox-event iterator, and
+    two BLPOP pollers that inject an `ApprovalRequestedPacket` / a
+    `ConnectAppRequestPacket` when a request is announced from another worker.
+    Announce latency is bounded by the 1s BLPOP.
     """
     output: queue_lib.Queue[Any] = queue_lib.Queue()
     stop = threading.Event()

--- a/backend/tests/external_dependency_unit/craft/test_connect_app.py
+++ b/backend/tests/external_dependency_unit/craft/test_connect_app.py
@@ -1,8 +1,9 @@
-"""Connect-app rendezvous over Redis: announce up, decision back.
+"""Connect-app plumbing over Redis: announce the card, stash the answer context.
 
-These exercise the two channels the parked turn and the decision request use to
-meet across workers — the announce (request → the live-stream worker) and the
-single-shot decision latch (answer → the parked turn). Real Redis, no DB.
+These exercise the two records the producing worker, the live-stream worker, and
+the decision request use to meet across processes — the announce (request → the
+live-stream worker) and the pending context (request_id → how to answer the
+permission). Real Redis, no DB.
 """
 
 from __future__ import annotations
@@ -17,39 +18,6 @@ from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 
 def _cache() -> CacheBackend:
     return get_cache_backend(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
-
-
-def test_resolve_then_wait_returns_decision() -> None:
-    cache = _cache()
-    request_id = f"connect-app-test-{uuid4()}"
-    cache.delete(connect_app._decision_key(request_id))  # type: ignore[attr-defined]
-
-    connect_app.resolve(request_id, connect_app.ConnectAppDecision.CONNECTED, cache)
-    decision = connect_app.wait_for_decision(request_id, timeout_s=5, cache=cache)
-
-    assert decision is connect_app.ConnectAppDecision.CONNECTED
-
-
-def test_wait_for_decision_times_out_to_none() -> None:
-    cache = _cache()
-    request_id = f"connect-app-test-{uuid4()}"
-    cache.delete(connect_app._decision_key(request_id))  # type: ignore[attr-defined]
-
-    assert connect_app.wait_for_decision(request_id, timeout_s=1, cache=cache) is None
-
-
-def test_decision_is_single_shot() -> None:
-    """The first waiter consumes the decision; a second wait times out."""
-    cache = _cache()
-    request_id = f"connect-app-test-{uuid4()}"
-    cache.delete(connect_app._decision_key(request_id))  # type: ignore[attr-defined]
-
-    connect_app.resolve(request_id, connect_app.ConnectAppDecision.DECLINED, cache)
-    first = connect_app.wait_for_decision(request_id, timeout_s=5, cache=cache)
-    second = connect_app.wait_for_decision(request_id, timeout_s=1, cache=cache)
-
-    assert first is connect_app.ConnectAppDecision.DECLINED
-    assert second is None
 
 
 def test_announce_then_pop_roundtrips_request() -> None:
@@ -72,3 +40,45 @@ def test_pop_announcement_times_out_to_none() -> None:
     cache.delete(connect_app._announce_key(session_id))  # type: ignore[attr-defined]
 
     assert connect_app.pop_announcement(session_id, timeout_s=1, cache=cache) is None
+
+
+def test_stash_then_load_roundtrips_pending() -> None:
+    cache = _cache()
+    request_id = f"connect-app-test-{uuid4()}"
+
+    pending = connect_app.ConnectAppPending(
+        build_session_id="bs-1",
+        opencode_session_id="oc-1",
+        perm_id="perm-1",
+        directory="/workspace/sessions/bs-1",
+    )
+    connect_app.stash_pending(request_id, pending, cache)
+
+    assert connect_app.load_pending(request_id, cache) == pending
+
+
+def test_load_pending_missing_returns_none() -> None:
+    cache = _cache()
+    request_id = f"connect-app-test-{uuid4()}"
+
+    assert connect_app.load_pending(request_id, cache) is None
+
+
+def test_clear_pending_removes_the_context() -> None:
+    """After answering, the context is cleared so a duplicate decision is a no-op."""
+    cache = _cache()
+    request_id = f"connect-app-test-{uuid4()}"
+
+    connect_app.stash_pending(
+        request_id,
+        connect_app.ConnectAppPending(
+            build_session_id="bs-1",
+            opencode_session_id="oc-1",
+            perm_id="perm-1",
+            directory="/workspace/sessions/bs-1",
+        ),
+        cache,
+    )
+    connect_app.clear_pending(request_id, cache)
+
+    assert connect_app.load_pending(request_id, cache) is None

--- a/backend/tests/external_dependency_unit/craft/test_connect_app.py
+++ b/backend/tests/external_dependency_unit/craft/test_connect_app.py
@@ -1,11 +1,3 @@
-"""Connect-app plumbing over Redis: announce the card, stash the answer context.
-
-These exercise the two records the producing worker, the live-stream worker, and
-the decision request use to meet across processes — the announce (request → the
-live-stream worker) and the pending context (request_id → how to answer the
-permission). Real Redis, no DB.
-"""
-
 from __future__ import annotations
 
 from uuid import uuid4

--- a/backend/tests/external_dependency_unit/craft/test_connect_app.py
+++ b/backend/tests/external_dependency_unit/craft/test_connect_app.py
@@ -1,0 +1,74 @@
+"""Connect-app rendezvous over Redis: announce up, decision back.
+
+These exercise the two channels the parked turn and the decision request use to
+meet across workers — the announce (request → the live-stream worker) and the
+single-shot decision latch (answer → the parked turn). Real Redis, no DB.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from onyx.cache.factory import get_cache_backend
+from onyx.cache.interface import CacheBackend
+from onyx.server.features.build import connect_app
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+
+
+def _cache() -> CacheBackend:
+    return get_cache_backend(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
+
+
+def test_resolve_then_wait_returns_decision() -> None:
+    cache = _cache()
+    request_id = f"connect-app-test-{uuid4()}"
+    cache.delete(connect_app._decision_key(request_id))  # type: ignore[attr-defined]
+
+    connect_app.resolve(request_id, connect_app.ConnectAppDecision.CONNECTED, cache)
+    decision = connect_app.wait_for_decision(request_id, timeout_s=5, cache=cache)
+
+    assert decision is connect_app.ConnectAppDecision.CONNECTED
+
+
+def test_wait_for_decision_times_out_to_none() -> None:
+    cache = _cache()
+    request_id = f"connect-app-test-{uuid4()}"
+    cache.delete(connect_app._decision_key(request_id))  # type: ignore[attr-defined]
+
+    assert connect_app.wait_for_decision(request_id, timeout_s=1, cache=cache) is None
+
+
+def test_decision_is_single_shot() -> None:
+    """The first waiter consumes the decision; a second wait times out."""
+    cache = _cache()
+    request_id = f"connect-app-test-{uuid4()}"
+    cache.delete(connect_app._decision_key(request_id))  # type: ignore[attr-defined]
+
+    connect_app.resolve(request_id, connect_app.ConnectAppDecision.DECLINED, cache)
+    first = connect_app.wait_for_decision(request_id, timeout_s=5, cache=cache)
+    second = connect_app.wait_for_decision(request_id, timeout_s=1, cache=cache)
+
+    assert first is connect_app.ConnectAppDecision.DECLINED
+    assert second is None
+
+
+def test_announce_then_pop_roundtrips_request() -> None:
+    cache = _cache()
+    session_id = f"connect-app-test-{uuid4()}"
+    cache.delete(connect_app._announce_key(session_id))  # type: ignore[attr-defined]
+
+    request = connect_app.ConnectAppRequest(
+        request_id="req-1", app_slug="google_calendar", reason="to schedule events"
+    )
+    connect_app.announce_request(session_id, request, cache)
+    popped = connect_app.pop_announcement(session_id, timeout_s=5, cache=cache)
+
+    assert popped == request
+
+
+def test_pop_announcement_times_out_to_none() -> None:
+    cache = _cache()
+    session_id = f"connect-app-test-{uuid4()}"
+    cache.delete(connect_app._announce_key(session_id))  # type: ignore[attr-defined]
+
+    assert connect_app.pop_announcement(session_id, timeout_s=1, cache=cache) is None

--- a/backend/tests/unit/build/test_session_manager_merger.py
+++ b/backend/tests/unit/build/test_session_manager_merger.py
@@ -16,7 +16,9 @@ from uuid import uuid4
 
 import pytest
 
+from onyx.server.features.build.connect_app import ConnectAppRequest
 from onyx.server.features.build.packets import ApprovalRequestedPacket
+from onyx.server.features.build.packets import ConnectAppRequestPacket
 from onyx.server.features.build.session import streaming as streaming_mod
 
 
@@ -126,6 +128,57 @@ def test_announce_emitted_as_approval_requested_packet(
     assert parsed["type"] == "approval_requested"
     assert parsed["approval_id"] == str(approval_id)
     assert parsed["session_id"] == str(session_id)
+
+
+def test_connect_app_announce_emitted_as_packet(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A connect-app announce is injected into the stream as a
+    ConnectAppRequestPacket (the turn-driving worker can't reach the browser, so
+    the card crosses over via this announce)."""
+    session_id = uuid4()
+    request = ConnectAppRequest(
+        request_id="req-9", app_slug="slack", reason="post a message"
+    )
+    announce_enqueued = threading.Event()
+    calls: list[int] = []
+
+    def pop_connect(_sid: str, timeout_s: int, cache: Any) -> ConnectAppRequest | None:  # noqa: ARG001 — kwarg name must match production caller
+        calls.append(1)
+        if len(calls) == 1:
+            return request
+        announce_enqueued.set()
+        time.sleep(min(0.02, float(timeout_s)))
+        return None
+
+    _stub_get_cache_backend(monkeypatch)
+    _stub_pop_announcement(monkeypatch, _always_none)  # approval pump: nothing
+    monkeypatch.setattr(streaming_mod.connect_app, "pop_announcement", pop_connect)
+
+    def events() -> Generator[str, None, None]:
+        assert announce_enqueued.wait(timeout=2.0), "connect-app packet never enqueued"
+        yield "events-end"
+
+    out = _collect_with_timeout(
+        streaming_mod.merge_events_with_announces(
+            events(), session_id=session_id, tenant_id="public"
+        )
+    )
+
+    packets = [item for item in out if isinstance(item, ConnectAppRequestPacket)]
+    assert len(packets) == 1
+    assert packets[0].request_id == "req-9"
+    assert packets[0].app_slug == "slack"
+    assert packets[0].reason == "post a message"
+    assert packets[0].type == "connect_app_request"
+
+    # Verify the SSE-frame shape the attach stream produces from this packet.
+    rendered = streaming_mod.event_to_sse(packets[0])
+    assert rendered.startswith("event: message\n")
+    parsed = json.loads(rendered.split("data: ", 1)[1])
+    assert parsed["type"] == "connect_app_request"
+    assert parsed["request_id"] == "req-9"
+    assert parsed["app_slug"] == "slack"
 
 
 def test_interleaving_events_and_announce(

--- a/backend/tests/unit/onyx/auth/test_permissions.py
+++ b/backend/tests/unit/onyx/auth/test_permissions.py
@@ -130,10 +130,10 @@ class TestResolveEffectivePermissions:
         assert {"read:search", "read:chat", "write:chat", "read:admin"} <= result
 
     def test_craft_sandbox_scope_is_least_privilege(self) -> None:
-        """The Craft sandbox PAT may only company-search and request app setup —
-        it must NOT inherit the chat surfaces (the reason it isn't `basic`)."""
+        """The Craft sandbox PAT may only company-search — it must NOT inherit the
+        chat surfaces (the reason it isn't `basic`)."""
         result = resolve_effective_permissions({"craft_sandbox"})
-        assert result == {"craft_sandbox", "read:search", "craft:request_app_setup"}
+        assert result == {"craft_sandbox", "read:search"}
         assert "read:chat" not in result
         assert "write:chat" not in result
         assert "basic" not in result
@@ -292,50 +292,6 @@ class TestRequirePermission:
             await dep(request=_request([]), user=user)
 
 
-class TestRequireScopedToken:
-    """require_permission(..., require_scoped_token=True) is token-gated: only a
-    scoped PAT carrying the scope passes; unscoped principals (session / API key /
-    unrestricted PAT) are denied even if the user holds the permission."""
-
-    @pytest.mark.asyncio
-    async def test_craft_pat_passes(self) -> None:
-        """The Craft PAT (craft_sandbox implies craft:request_app_setup) is admitted."""
-        user = MagicMock()
-        user.effective_permissions = ["basic"]
-
-        dep = require_permission(
-            Permission.CRAFT_REQUEST_APP_SETUP, require_scoped_token=True
-        )
-        result = await dep(request=_request([Permission.CRAFT_SANDBOX]), user=user)
-        assert result is user
-
-    @pytest.mark.asyncio
-    async def test_session_login_denied(self) -> None:
-        """A logged-in user with no scoped token (token_scopes is None) is denied —
-        the endpoint is machine-only."""
-        user = MagicMock()
-        user.effective_permissions = ["admin"]
-
-        dep = require_permission(
-            Permission.CRAFT_REQUEST_APP_SETUP, require_scoped_token=True
-        )
-        with pytest.raises(OnyxError) as exc_info:
-            await dep(request=_request(None), user=user)
-        assert exc_info.value.error_code == OnyxErrorCode.INSUFFICIENT_PERMISSIONS
-
-    @pytest.mark.asyncio
-    async def test_out_of_scope_pat_denied(self) -> None:
-        """A scoped PAT without the required scope is denied."""
-        user = MagicMock()
-        user.effective_permissions = ["basic"]
-
-        dep = require_permission(
-            Permission.CRAFT_REQUEST_APP_SETUP, require_scoped_token=True
-        )
-        with pytest.raises(OnyxError):
-            await dep(request=_request([Permission.READ_SEARCH]), user=user)
-
-
 class TestAnonymousUserPermissions:
     def test_anonymous_user_resolves_to_basic_scopes(self) -> None:
         assert get_effective_permissions(get_anonymous_user()) == {
@@ -368,7 +324,7 @@ class TestAnonymousUserPermissions:
 
 class TestApiSurfaceScopeRegistration:
     # Hardcoded spec: the complete implied-only set (4 READ_* capability reads
-    # + 5 API-surface scopes). Equality, not subset, so an accidentally
+    # + 4 API-surface scopes). Equality, not subset, so an accidentally
     # over-broad set (a real capability made un-grantable) is also caught.
     EXPECTED_IMPLIED = {
         "read:connectors",
@@ -379,7 +335,6 @@ class TestApiSurfaceScopeRegistration:
         "read:chat",
         "write:chat",
         "read:admin",
-        "craft:request_app_setup",
     }
 
     def test_implied_set_matches_spec(self) -> None:
@@ -397,9 +352,5 @@ class TestApiSurfaceScopeRegistration:
             "write:chat",
         }
         assert IMPLIED_PERMISSIONS["write:chat"] == {"read:chat"}
-        # craft:request_app_setup is reachable ONLY via the craft role scope, never basic.
-        assert IMPLIED_PERMISSIONS["craft_sandbox"] == {
-            "read:search",
-            "craft:request_app_setup",
-        }
-        assert "craft:request_app_setup" not in IMPLIED_PERMISSIONS["basic"]
+        # The craft role scope grants only company-search, never the chat surfaces.
+        assert IMPLIED_PERMISSIONS["craft_sandbox"] == {"read:search"}


### PR DESCRIPTION
## What

Backend for connecting org external apps on demand. When the agent calls the no-op `connect_app` tool, opencode emits a permission request; the api-server turns it into a connect card on the user's screen and resumes the agent once the user connects (or declines).

## How

- **`connect_app`** — a Redis **announce** channel (request → the worker holding the user's live SSE stream) plus a single-shot **decision** latch (answer → the parked turn). No DB row, no `/live` poll.
- **`serve_client`** — intercepts the `connect_app` `permission.asked`, announces the request keyed by the build session, blocks on the decision, then answers opencode allow (connected) / reject (declined). A wait timeout declines.
- **`streaming`** — merges connect-app announces into the live SSE stream as a `ConnectAppRequestPacket`.
- **`external_apps`** — `POST /build/apps/connect/{request_id}/decision` to resolve a request, plus `supports_oauth` on the user app view.
- Drops the now-unused `CRAFT_REQUEST_APP_SETUP` permission and the `require_scoped_token` gate (replaced by this flow).

The agent tool (#12443) and the connect card UI (#12444) stack on this.

- [x] [Optional] Override Linear Check
