### PR TITLE
fix(user-files): drop Vespa-hardcoded chunk-count in delete path

### DIFF
--- a/backend/onyx/background/celery/tasks/user_file_processing/tasks.py
+++ b/backend/onyx/background/celery/tasks/user_file_processing/tasks.py
@@ -682,7 +682,7 @@ def delete_user_file_impl(
         # index resolves itself (Vespa fans out to find chunks, OpenSearch deletes
         # by document id). This keeps the path backend-agnostic.
         if not skip_vespa:
-            chunk_count = (
+            chunk_count: int | None = (
                 chunk_count_from_db
                 if chunk_count_from_db is not None and chunk_count_from_db > 0
                 else None

--- a/backend/onyx/background/celery/tasks/user_file_processing/tasks.py
+++ b/backend/onyx/background/celery/tasks/user_file_processing/tasks.py
@@ -1,9 +1,7 @@
 import datetime
 import time
-from typing import Any
 from uuid import UUID
 
-import httpx
 import sqlalchemy as sa
 from celery import Celery
 from celery import shared_task
@@ -47,7 +45,6 @@ from onyx.db.search_settings import get_active_search_settings_list
 from onyx.db.user_file import fetch_user_files_with_access_relationships
 from onyx.document_index.factory import get_all_document_indices
 from onyx.document_index.interfaces_new import MetadataUpdateRequest
-from onyx.document_index.vespa_constants import DOCUMENT_ID_ENDPOINT
 from onyx.file_store.file_store import get_default_file_store
 from onyx.file_store.utils import store_user_file_plaintext
 from onyx.file_store.utils import user_file_id_to_plaintext_file_name
@@ -57,7 +54,6 @@ from onyx.indexing.embedder import DefaultIndexingEmbedder
 from onyx.indexing.indexing_pipeline import run_indexing_pipeline
 from onyx.redis.redis_pool import get_redis_client
 from onyx.redis.tenant_redis_client import TenantRedisClient
-from onyx.utils.retry_wrapper import retry_builder
 from onyx.utils.variable_functionality import global_version
 
 
@@ -146,52 +142,6 @@ def enqueue_user_file_project_sync_task(
         raise
 
     return True
-
-
-@retry_builder(tries=3, delay=1, backoff=2, jitter=(0.0, 1.0))
-def _visit_chunks(
-    *,
-    http_client: httpx.Client,
-    index_name: str,
-    selection: str,
-    continuation: str | None = None,
-) -> tuple[list[dict[str, Any]], str | None]:
-    task_logger.info(
-        f"Visiting chunks for index={index_name} with selection={selection}"
-    )
-    base_url = DOCUMENT_ID_ENDPOINT.format(index_name=index_name)
-    params: dict[str, str] = {
-        "selection": selection,
-        "wantedDocumentCount": "100",  # Use smaller batch size to avoid timeouts
-    }
-    if continuation:
-        params["continuation"] = continuation
-    resp = http_client.get(base_url, params=params, timeout=None)
-    resp.raise_for_status()
-    payload = resp.json()
-    return payload.get("documents", []), payload.get("continuation")
-
-
-def _get_document_chunk_count(
-    *,
-    index_name: str,
-    selection: str,
-) -> int:
-    chunk_count = 0
-    continuation = None
-    while True:
-        docs, continuation = _visit_chunks(
-            http_client=HttpxPool.get("vespa"),
-            index_name=index_name,
-            selection=selection,
-            continuation=continuation,
-        )
-        if not docs:
-            break
-        chunk_count += len(docs)
-        if not continuation:
-            break
-    return chunk_count
 
 
 @shared_task(
@@ -693,8 +643,6 @@ def delete_user_file_impl(
         skip_vespa = DISABLE_VECTOR_DB
         retry_document_indices: list[RetryDocumentIndex] = []
         chunk_count_from_db: int | None = None
-        index_name: str = ""
-        selection: str = ""
         file_id: str = ""
 
         if not skip_vespa:
@@ -728,18 +676,16 @@ def delete_user_file_impl(
                     RetryDocumentIndex(document_index)
                     for document_index in document_indices
                 ]
-                index_name = active_search_settings.primary.index_name
-                selection = f"{index_name}.document_id=='{user_file_id}'"
 
-        # Phase 2: Vespa deletes + file store deletes (no DB session held)
+        # Phase 2: vector DB deletes + file store deletes (no DB session held).
+        # Pass the DB chunk count when known; otherwise None, which each document
+        # index resolves itself (Vespa fans out to find chunks, OpenSearch deletes
+        # by document id). This keeps the path backend-agnostic.
         if not skip_vespa:
-            chunk_count: int = (
+            chunk_count = (
                 chunk_count_from_db
                 if chunk_count_from_db is not None and chunk_count_from_db > 0
-                else _get_document_chunk_count(
-                    index_name=index_name,
-                    selection=selection,
-                )
+                else None
             )
             for retry_document_index in retry_document_indices:
                 retry_document_index.delete(


### PR DESCRIPTION
## Description

`delete_user_file_impl` computed a user file's chunk count via a **raw Vespa visit** (`HttpxPool.get("vespa")` + Vespa's `DOCUMENT_ID_ENDPOINT`), bypassing the `DocumentIndex` abstraction. On deployments where Vespa has been removed in favor of OpenSearch, the `vespa` host no longer resolves, so user-file deletes crashed with `httpx.ConnectError: [Errno -2] Name or service not known` — but only on the fallback path, when the DB-stored `chunk_count` was missing or zero.

The computed count was purely an optimization passed into `DocumentIndex.delete(doc_id, chunk_count=...)`. Both backends already resolve `chunk_count=None` on their own:

- **Vespa** — `_enrich_basic_chunk_info` → `check_for_final_chunk_existence` fans out (using the index's own pooled client) to find the chunks.
- **OpenSearch** — ignores `chunk_count` entirely and deletes by `document_id`.

This PR removes the redundant `_get_document_chunk_count` / `_visit_chunks` helpers and passes the DB chunk count when known, else `None`, keeping the delete path backend-agnostic. The sibling project-sync path already used the abstraction correctly and is unchanged.

## How Has This Been Tested?

- `python -m py_compile` and `ruff check --select F` (no unused imports/vars) on the edited file.
- Pre-commit (`ty`, `ruff`, `ruff format`) passes.
- Verified both backend `delete` implementations accept and correctly handle `chunk_count=None` by inspection (Vespa `check_for_final_chunk_existence`; OpenSearch deletes by `document_id`).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop hardcoded Vespa chunk-count lookup in user-file delete. Use `DocumentIndex` with DB `chunk_count` or `None` to avoid crashes on `OpenSearch` and keep the delete path backend-agnostic.

- **Bug Fixes**
  - Removed Vespa-only helpers and selection logic; no direct Vespa queries.
  - Pass DB `chunk_count` when >0; else `None` (`int | None`), letting the index resolve it (Vespa fans out; `OpenSearch` ignores).
  - Fixes `httpx.ConnectError` when the `vespa` host is not present.

<sup>Written for commit 89cff75254525617af956537f970f42245dd4bbb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

