### PR TITLE
fix(chat): hide backend stack traces from chat error UI

### DIFF
--- a/web/src/app/app/message/MultiModelPanel.tsx
+++ b/web/src/app/app/message/MultiModelPanel.tsx
@@ -40,8 +40,6 @@ export interface MultiModelPanelProps {
   errorCode?: string | null;
   /** Whether the error is retryable */
   isRetryable?: boolean;
-  /** Stack trace for debugging */
-  errorStackTrace?: string | null;
   /** Additional error details */
   errorDetails?: Record<string, any> | null;
   /** Whether any model is still streaming — disables preferred selection */
@@ -73,7 +71,6 @@ export default function MultiModelPanel({
   errorMessage,
   errorCode,
   isRetryable,
-  errorStackTrace,
   errorDetails,
   isGenerating,
 }: MultiModelPanelProps) {
@@ -156,7 +153,6 @@ export default function MultiModelPanel({
             errorCode={errorCode || undefined}
             isRetryable={isRetryable ?? true}
             details={errorDetails || undefined}
-            stackTrace={errorStackTrace}
           />
         </div>
       ) : (

--- a/web/src/app/app/message/MultiModelResponseView.tsx
+++ b/web/src/app/app/message/MultiModelResponseView.tsx
@@ -437,7 +437,6 @@ export default function MultiModelResponseView({
       errorMessage: response.errorMessage,
       errorCode: response.errorCode,
       isRetryable: response.isRetryable,
-      errorStackTrace: response.errorStackTrace,
       errorDetails: response.errorDetails,
       isGenerating,
     }),

--- a/web/src/app/app/message/Resubmit.tsx
+++ b/web/src/app/app/message/Resubmit.tsx
@@ -1,9 +1,7 @@
-import { useState } from "react";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { SvgChevronDown, SvgChevronRight } from "@opal/icons";
 import { Button } from "@opal/components";
-import { CopyButton } from "@opal/components";
 import { getErrorIcon, getErrorTitle } from "./errorHelpers";
+import { sanitizeChatErrorForDisplay } from "./sanitizeChatError";
 
 interface ResubmitProps {
   resubmit: () => void;
@@ -25,17 +23,15 @@ export const ErrorBanner = ({
   errorCode,
   isRetryable = true,
   details,
-  stackTrace,
   resubmit,
 }: {
   error: string;
   errorCode?: string;
   isRetryable?: boolean;
   details?: Record<string, any>;
-  stackTrace?: string | null;
   resubmit?: () => void;
 }) => {
-  const [isStackTraceExpanded, setIsStackTraceExpanded] = useState(false);
+  const displayError = sanitizeChatErrorForDisplay(error);
 
   return (
     <div className="text-red-700 mt-4 text-sm my-auto">
@@ -43,7 +39,7 @@ export const ErrorBanner = ({
         {getErrorIcon(errorCode)}
         <AlertTitle>{getErrorTitle(errorCode)}</AlertTitle>
         <AlertDescription className="flex flex-col gap-y-1">
-          <span>{error}</span>
+          <span>{displayError}</span>
           {details?.model && (
             <span className="text-xs text-muted-foreground">
               Model: {details.model}
@@ -54,28 +50,6 @@ export const ErrorBanner = ({
             <span className="text-xs text-muted-foreground">
               Tool: {details.tool_name}
             </span>
-          )}
-          {stackTrace && (
-            <div className="mt-2 border-t border-neutral-200 dark:border-neutral-700 pt-2">
-              <div className="flex flex-1 items-center justify-between">
-                <Button
-                  prominence="tertiary"
-                  icon={isStackTraceExpanded ? SvgChevronDown : SvgChevronRight}
-                  onClick={() => setIsStackTraceExpanded(!isStackTraceExpanded)}
-                >
-                  Stack trace
-                </Button>
-                <CopyButton
-                  prominence="tertiary"
-                  getCopyText={() => stackTrace}
-                />
-              </div>
-              {isStackTraceExpanded && (
-                <pre className="mt-2 p-3 bg-neutral-100 dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 rounded-sm text-xs text-neutral-700 dark:text-neutral-300 overflow-auto max-h-48 whitespace-pre-wrap font-mono">
-                  {stackTrace}
-                </pre>
-              )}
-            </div>
           )}
         </AlertDescription>
       </Alert>

--- a/web/src/app/app/message/interfaces.ts
+++ b/web/src/app/app/message/interfaces.ts
@@ -18,6 +18,5 @@ export interface MultiModelResponse {
   errorMessage?: string | null;
   errorCode?: string | null;
   isRetryable?: boolean;
-  errorStackTrace?: string | null;
   errorDetails?: Record<string, any> | null;
 }

--- a/web/src/app/app/message/sanitizeChatError.test.ts
+++ b/web/src/app/app/message/sanitizeChatError.test.ts
@@ -1,0 +1,50 @@
+import {
+  GENERIC_CHAT_ERROR_MESSAGE,
+  sanitizeChatErrorForDisplay,
+} from "./sanitizeChatError";
+
+describe("sanitizeChatErrorForDisplay", () => {
+  it("returns a generic message for empty input", () => {
+    expect(sanitizeChatErrorForDisplay("")).toBe(GENERIC_CHAT_ERROR_MESSAGE);
+    expect(sanitizeChatErrorForDisplay("   ")).toBe(GENERIC_CHAT_ERROR_MESSAGE);
+    expect(sanitizeChatErrorForDisplay(null)).toBe(GENERIC_CHAT_ERROR_MESSAGE);
+  });
+
+  it("preserves user-friendly error messages", () => {
+    expect(sanitizeChatErrorForDisplay("Rate limit exceeded.")).toBe(
+      "Rate limit exceeded."
+    );
+  });
+
+  it("replaces pure stack traces with a generic message", () => {
+    const stackTrace = `Traceback (most recent call last):
+  File "/app/onyx/chat/process_message.py", line 100, in stream_chat
+    raise RuntimeError("boom")
+RuntimeError: boom`;
+
+    expect(sanitizeChatErrorForDisplay(stackTrace)).toBe(
+      GENERIC_CHAT_ERROR_MESSAGE
+    );
+  });
+
+  it("keeps user-facing text before a traceback", () => {
+    const mixed = `The model provider returned an invalid response.
+Traceback (most recent call last):
+  File "/app/onyx/chat/process_message.py", line 100, in stream_chat
+    raise RuntimeError("boom")`;
+
+    expect(sanitizeChatErrorForDisplay(mixed)).toBe(
+      "The model provider returned an invalid response."
+    );
+  });
+
+  it("replaces a headerless multi-frame traceback with a generic message", () => {
+    const headerless = `  File "/app/onyx/chat/process_message.py", line 100, in stream_chat
+  File "/app/onyx/lib/utils.py", line 50, in helper
+RuntimeError: boom`;
+
+    expect(sanitizeChatErrorForDisplay(headerless)).toBe(
+      GENERIC_CHAT_ERROR_MESSAGE
+    );
+  });
+});

--- a/web/src/app/app/message/sanitizeChatError.ts
+++ b/web/src/app/app/message/sanitizeChatError.ts
@@ -1,0 +1,46 @@
+export const GENERIC_CHAT_ERROR_MESSAGE =
+  "Something went wrong while generating a response. Please try again.";
+
+const STACK_TRACE_MARKERS = [
+  "Traceback (most recent call last)",
+  "Exception Group Traceback",
+  "During handling of the above exception",
+];
+
+const STACK_TRACE_FILE_LINE = /^\s*File "/gm;
+
+function looksLikeStackTrace(text: string): boolean {
+  if (STACK_TRACE_MARKERS.some((marker) => text.includes(marker))) {
+    return true;
+  }
+
+  return (text.match(STACK_TRACE_FILE_LINE) || []).length >= 2;
+}
+
+/**
+ * Ensure chat error text shown to users never includes backend stack traces.
+ */
+export function sanitizeChatErrorForDisplay(
+  error: string | null | undefined
+): string {
+  if (!error?.trim()) {
+    return GENERIC_CHAT_ERROR_MESSAGE;
+  }
+
+  const trimmed = error.trim();
+  if (!looksLikeStackTrace(trimmed)) {
+    return trimmed;
+  }
+
+  for (const marker of STACK_TRACE_MARKERS) {
+    const markerIndex = trimmed.indexOf(marker);
+    if (markerIndex > 0) {
+      const beforeTrace = trimmed.slice(0, markerIndex).trim();
+      if (beforeTrace.length > 0 && !looksLikeStackTrace(beforeTrace)) {
+        return beforeTrace;
+      }
+    }
+  }
+
+  return GENERIC_CHAT_ERROR_MESSAGE;
+}

--- a/web/src/hooks/useChatController.ts
+++ b/web/src/hooks/useChatController.ts
@@ -40,6 +40,7 @@ import {
   ToolCallMetadata,
   UserKnowledgeFilePacket,
 } from "@/app/app/interfaces";
+import { sanitizeChatErrorForDisplay } from "@/app/app/message/sanitizeChatError";
 import { StreamStopReason } from "@/lib/search/interfaces";
 import { createChatSession } from "@/app/app/services/lib";
 import {
@@ -682,7 +683,6 @@ export default function useChatController({
       let citations: CitationMap = {};
       let aiMessageImages: FileDescriptor[] | null = null;
       let error: string | null = null;
-      let stackTrace: string | null = null;
       let errorCode: string | null = null;
       let isRetryable: boolean = true;
       let errorDetails: Record<string, any> | null = null;
@@ -824,7 +824,7 @@ export default function useChatController({
               citations: finalMessage?.citations || citations || {},
               files: finalMessage?.files || aiMessageImages || [],
               toolCall: finalMessage?.tool_call || toolCall,
-              stackTrace: stackTrace,
+              stackTrace: null,
               overridden_model: finalMessage?.overridden_model,
               stopReason: stopReason,
               packets: packets,
@@ -1077,9 +1077,11 @@ export default function useChatController({
                         ...errorNode,
                         messageId:
                           assistantMessageIds[errorModelIndex] ?? undefined,
-                        message: streamingError.error,
+                        message: sanitizeChatErrorForDisplay(
+                          streamingError.error
+                        ),
                         type: "error",
-                        stackTrace: streamingError.stack_trace || null,
+                        stackTrace: null,
                         errorCode: streamingError.error_code || null,
                         isRetryable: streamingError.is_retryable ?? true,
                         errorDetails: streamingError.details || null,
@@ -1109,17 +1111,19 @@ export default function useChatController({
                 continue;
               } else {
                 // Single-model: kill the stream
-                error = streamingError.error;
-                stackTrace = streamingError.stack_trace || null;
+                const sanitizedError = sanitizeChatErrorForDisplay(
+                  streamingError.error
+                );
+                error = sanitizedError;
                 errorCode = streamingError.error_code || null;
                 isRetryable = streamingError.is_retryable ?? true;
                 errorDetails = streamingError.details || null;
 
-                setUncaughtError(frozenSessionId, streamingError.error);
+                setUncaughtError(frozenSessionId, sanitizedError);
                 updateChatStateAction(frozenSessionId, "input");
                 updateSubmittedMessage(getCurrentSessionId(), "");
 
-                throw new Error(streamingError.error);
+                throw new Error(sanitizedError);
               }
             } else if (Object.hasOwn(packet, "message_id")) {
               finalMessage = packet as BackendMessage;
@@ -1236,7 +1240,8 @@ export default function useChatController({
         streamSucceeded = true;
       } catch (e: any) {
         console.log("Error:", e);
-        const errorMsg = e.message;
+        // `error` is already sanitized in the single-model streaming error path.
+        const errorMsg = error ?? sanitizeChatErrorForDisplay(e.message);
         const userErrorNode: Message = {
           nodeId: initialUserNode.nodeId,
           message: currMessage,
@@ -1257,7 +1262,7 @@ export default function useChatController({
               type: "error" as const,
               packets: [],
               packetCount: 0,
-              stackTrace,
+              stackTrace: null,
               errorCode,
               isRetryable,
               errorDetails,
@@ -1273,7 +1278,7 @@ export default function useChatController({
                 parentNodeId: initialUserNode.nodeId,
                 packets: [],
                 packetCount: 0,
-                stackTrace: stackTrace,
+                stackTrace: null,
                 errorCode: errorCode,
                 isRetryable: isRetryable,
                 errorDetails: errorDetails,

--- a/web/src/sections/chat/ChatUI.tsx
+++ b/web/src/sections/chat/ChatUI.tsx
@@ -201,7 +201,6 @@ const ChatUI = React.memo(
             errorMessage: isError ? msg.message : null,
             errorCode: isError ? msg.errorCode : null,
             isRetryable: isError ? msg.isRetryable : undefined,
-            errorStackTrace: isError ? msg.stackTrace : null,
             errorDetails: isError ? msg.errorDetails : null,
           };
         });
@@ -288,7 +287,6 @@ const ChatUI = React.memo(
                       errorCode={message.errorCode || undefined}
                       isRetryable={message.isRetryable ?? true}
                       details={message.errorDetails || undefined}
-                      stackTrace={message.stackTrace || undefined}
                     />
                   </div>
                 );
@@ -361,9 +359,6 @@ const ChatUI = React.memo(
                 isRetryable={messages[messages.length - 1]?.isRetryable ?? true}
                 details={
                   messages[messages.length - 1]?.errorDetails || undefined
-                }
-                stackTrace={
-                  messages[messages.length - 1]?.stackTrace || undefined
                 }
               />
             </div>


### PR DESCRIPTION
## Description

Fixes #7699.

Users were seeing backend stack traces in the chat error UI via an expandable "Stack trace" section and, in some cases, traceback text embedded in the error message itself.

This change:
- Sanitizes chat error text before rendering (strips traceback content, falls back to a generic user-friendly message)
- Removes stack trace display from `ErrorBanner`
- Stops persisting stack traces in client-side error message state during streaming

Full stack traces continue to be logged on the server.

## How Has This Been Tested?

- `bun test src/app/app/message/sanitizeChatError.test.ts` (from `web/`)
- `bunx oxlint` on changed files (from `web/`)

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide backend stack traces in the chat error UI by sanitizing error messages and removing the stack trace section. Traces remain server-side only to prevent leaking sensitive info.

- **Bug Fixes**
  - Sanitize chat error text via `sanitizeChatErrorForDisplay` in `useChatController` and `ErrorBanner`; fall back to a generic message.
  - Remove stack trace UI and props across chat views (`ErrorBanner`, `ChatUI`, `MultiModelPanel`, `MultiModelResponseView`); drop `errorStackTrace` types/state.
  - Stop persisting stack traces on the client during streaming; always set `stackTrace` to null and throw/log sanitized errors.
  - Add a headerless-trace heuristic and unit tests for the sanitizer; avoid redundant sanitization in the streaming error catch path.

<sup>Written for commit c768de77443f8cff75a1eb6e2ef707e2dd60e54e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

