### PR TITLE
chore(mobile): trim verbose code comments to lean style

### DIFF
--- a/mobile/__mocks__/expo-secure-store.ts
+++ b/mobile/__mocks__/expo-secure-store.ts
@@ -1,19 +1,9 @@
-// Manual Jest mock for expo-secure-store.
-//
-// expo-secure-store is a node module, so Jest applies this mock AUTOMATICALLY to
-// every test (the file sits adjacent to node_modules) — no `jest.mock(...)` call
-// is needed in individual test files. It mirrors the keychain's get/set/delete
-// semantics with an in-memory Map. (MMKV needs no equivalent: react-native-mmkv
-// v4 self-mocks under Jest via its own `isTest()` check.)
-//
-// `__resetSecureStore()` clears the backing store between tests; it is wired into
-// a global `beforeEach` in jest.setup.ts, so tests start with an empty keychain.
+// Auto-applied to every test (node module manual mock); keychain semantics over an in-memory Map.
 import { jest } from "@jest/globals";
 
 const store = new Map<string, string>();
 
-// Keychain-accessibility constant. The real value is an enum number, but the mock
-// ignores the options arg entirely, so a readable sentinel is all that's needed.
+// Readable sentinel; the mock ignores the options arg.
 export const WHEN_UNLOCKED_THIS_DEVICE_ONLY = "WHEN_UNLOCKED_THIS_DEVICE_ONLY";
 
 export const getItemAsync = jest.fn(
@@ -35,7 +25,7 @@ export const deleteItemAsync = jest.fn(
   },
 );
 
-// Test-only helper (not part of the real module): wipe the in-memory keychain.
+// Test-only helper: wipe the in-memory keychain.
 export function __resetSecureStore(): void {
   store.clear();
 }

--- a/mobile/babel.config.js
+++ b/mobile/babel.config.js
@@ -1,6 +1,4 @@
-// NativeWind enables `className` on RN components: `jsxImportSource: "nativewind"`
-// rewrites JSX, and the "nativewind/babel" preset wires the CSS-interop transform.
-// babel-preset-expo also auto-adds the Reanimated/Worklets plugin when present.
+// `jsxImportSource: "nativewind"` + the nativewind/babel preset enable `className` on RN components.
 module.exports = function (api) {
   api.cache(true);
   return {

--- a/mobile/eslint.config.js
+++ b/mobile/eslint.config.js
@@ -8,6 +8,14 @@ module.exports = defineConfig([
   // Must stay last to override conflicting rules.
   eslintConfigPrettier,
   {
+    // eslint-config-expo's TS override sets a node-only import resolver, which
+    // ignores package.json `exports`, so @onyx-ai/shared subpaths (e.g.
+    // "/native") fail import/no-unresolved. Re-enable the exports-aware resolver.
+    settings: {
+      "import/resolver": { typescript: true, node: true },
+    },
+  },
+  {
     ignores: ["dist/*", ".expo/*", "node_modules/*", "android/*", "ios/*"],
   },
 ]);

--- a/mobile/eslint.config.js
+++ b/mobile/eslint.config.js
@@ -5,7 +5,7 @@ const eslintConfigPrettier = require("eslint-config-prettier");
 
 module.exports = defineConfig([
   expoConfig,
-  // Disable ESLint rules that conflict with Prettier; keep this last so it wins.
+  // Must stay last to override conflicting rules.
   eslintConfigPrettier,
   {
     ignores: ["dist/*", ".expo/*", "node_modules/*", "android/*", "ios/*"],

--- a/mobile/jest.config.js
+++ b/mobile/jest.config.js
@@ -1,21 +1,3 @@
-// Jest config for the mobile app.
-//
-// `jest-expo` provides the Expo/React Native babel transform, module resolution,
-// and native-module shims. We add the `@/` path alias (matching tsconfig) so
-// tests can import + mock app modules by their canonical path.
-//
-// Native-module mocking is centralized, not per-test:
-//   - MMKV: react-native-mmkv v4 self-mocks under Jest (its own `isTest()`), so
-//     `@/state/storage` works against an in-memory store with no setup.
-//   - expo-secure-store: a manual mock at __mocks__/expo-secure-store.ts is
-//     auto-applied to every test (it's a node module).
-//   - jest.setup.ts (setupFilesAfterEnv) resets that keychain + clears mock call
-//     history before each test.
-//
-// Component tests render UI deps that ship untranspiled JSX/ESM (nativewind,
-// @rn-primitives). jest-expo's default transformIgnorePatterns already allow-lists
-// react-native* / expo*; we extend its curated first pattern with those two rather
-// than hand-roll (and lose) the rest.
 const expoPreset = require("jest-expo/jest-preset");
 
 module.exports = {
@@ -25,6 +7,7 @@ module.exports = {
   },
   testMatch: ["<rootDir>/src/**/__tests__/**/*.test.ts?(x)"],
   setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
+  // Extend jest-expo's curated pattern to transpile nativewind/@rn-primitives (untranspiled JSX/ESM).
   transformIgnorePatterns: [
     expoPreset.transformIgnorePatterns[0].replace(
       "standard-navigation",

--- a/mobile/jest.setup.ts
+++ b/mobile/jest.setup.ts
@@ -1,14 +1,6 @@
-// Global test setup, registered via `setupFilesAfterEnv` in jest.config.js so it
-// runs once the test framework is installed (i.e. `beforeEach` is available).
-//
-// Centralizes the cross-cutting reset every test needs: wipe the in-memory
-// expo-secure-store keychain (see __mocks__/expo-secure-store.ts) and clear mock
-// call history. Individual test files no longer repeat this boilerplate.
 import { beforeEach, jest } from "@jest/globals";
 
-// `requireMock` returns the manual mock from __mocks__/expo-secure-store.ts —
-// the same instance the code under test uses — bypassing the real module's types
-// so the test-only reset helper is reachable.
+// requireMock reaches the manual mock's test-only reset helper, bypassing the real module's types.
 const secureStoreMock = jest.requireMock("expo-secure-store") as {
   __resetSecureStore: () => void;
 };

--- a/mobile/metro.config.js
+++ b/mobile/metro.config.js
@@ -1,22 +1,17 @@
-// Default Expo Metro config wrapped with NativeWind so Tailwind classes compile
-// through the bundler. `input` points at the Tailwind entry stylesheet.
 const path = require("path");
 const { getDefaultConfig } = require("expo/metro-config");
 const { withNativeWind } = require("nativewind/metro");
 
 const config = getDefaultConfig(__dirname);
 
-// @onyx-ai/shared is a file: dependency that physically lives under web/lib/shared
-// (outside this project root). Metro only resolves files inside watched folders, so
-// add the package root explicitly. The package ships a self-contained dist/ with
-// zero runtime deps, so we block its dev-only node_modules from Metro's crawl to
-// avoid Haste collisions / duplicate-module resolution.
+// @onyx-ai/shared lives outside this root (web/lib/shared), so add it to watchFolders;
+// block its dev-only node_modules from the crawl to avoid Haste/duplicate-module collisions.
 const sharedRoot = path.resolve(__dirname, "../web/lib/shared");
 config.watchFolders = [...(config.watchFolders ?? []), sharedRoot];
 
 // Resolve shared's subpath exports ("./nativewind-theme", "./native").
 config.resolver.unstable_enablePackageExports = true;
-// Keep module resolution anchored to mobile/node_modules (single React/RN copy).
+// Anchor resolution to mobile/node_modules (single React/RN copy).
 config.resolver.nodeModulesPaths = [path.resolve(__dirname, "node_modules")];
 
 const blockShared = /[/\\]web[/\\]lib[/\\]shared[/\\]node_modules[/\\].*/;

--- a/mobile/src/api/auth/__tests__/browserSso.test.ts
+++ b/mobile/src/api/auth/__tests__/browserSso.test.ts
@@ -1,5 +1,4 @@
-// digestStringAsync delegates to node's real SHA-256 so the S256-match assertion is
-// meaningful; getRandomBytesAsync is deterministic; WebBrowser echoes app_state back.
+// digestStringAsync delegates to node's real SHA-256 so the S256-match assertion is meaningful.
 import { createHash } from "crypto";
 
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
@@ -9,7 +8,7 @@ import { runBrowserSso, BrowserSsoCancelledError } from "@/api/auth/browserSso";
 import type { ProviderDescriptor } from "@/api/auth/providers";
 import { openAuthSessionAsync } from "expo-web-browser";
 
-// `jest.mock` is hoisted above the imports by babel-jest, despite source order.
+// `jest.mock` is hoisted above the imports by babel-jest.
 jest.mock("@/api/config", () => ({ getApiPrefix: () => "/api" }));
 jest.mock("@/state/session", () => ({
   getStoredServerUrl: () => "https://acme.onyx.app",
@@ -24,8 +23,7 @@ jest.mock("expo-crypto", () => ({
       Uint8Array.from({ length: n }, (_, i) => (i * 31 + 7) & 0xff),
     ),
   ),
-  // Real SHA-256 of the verifier string, standard-base64 (what expo returns).
-  // `require` inside the factory: jest forbids referencing out-of-scope imports.
+  // Real SHA-256, standard-base64 (what expo returns); `require` since jest forbids out-of-scope imports here.
   digestStringAsync: jest.fn((_algo: string, data: string) =>
     Promise.resolve(
       // eslint-disable-next-line @typescript-eslint/no-require-imports

--- a/mobile/src/api/auth/__tests__/sessionManager.test.ts
+++ b/mobile/src/api/auth/__tests__/sessionManager.test.ts
@@ -1,12 +1,4 @@
-// SessionManager unit tests — the tricky pure logic that warrants coverage:
-// the single-flight refresh (concurrent callers collapse to one network call),
-// the login/logout cache-purge invariants, and the session-epoch guard that
-// stops a late refresh from resurrecting a logged-out session. Everything
-// touching a native module (HTTP, keychain, MMKV cache, the zustand store) is
-// mocked so the test runs as plain logic with no device dependencies.
-//
-// Globals are imported explicitly from `@jest/globals` so the app's TS config
-// stays free of ambient test types.
+// Globals imported from `@jest/globals` so the app's TS config stays free of ambient test types.
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import type { Mock } from "jest-mock";
 
@@ -27,13 +19,9 @@ import { apiFetch, type ApiFetchInit } from "@/api/client";
 import { ApiError } from "@/api/errors";
 import { persister, queryClient } from "@/query/client";
 
-// `jest.mock` calls are hoisted above the imports by babel-jest, so the mocks
-// are registered before the module under test is loaded (despite the source
-// order here). Mocking the whole `@/state/session` / `@/query/client` modules
-// also keeps their native deps (MMKV) out of the test entirely.
+// `jest.mock` is hoisted above the imports by babel-jest; mocking whole modules also keeps native deps (MMKV) out.
 jest.mock("@/api/client");
 jest.mock("@/api/auth/tokenStore");
-// Mock browserSso to keep expo-web-browser/expo-crypto out of this test.
 jest.mock("@/api/auth/browserSso");
 jest.mock("@/query/client", () => ({
   queryClient: { clear: jest.fn() },
@@ -43,9 +31,7 @@ jest.mock("@/state/session", () => ({
   useSession: { getState: () => ({ setStatus: jest.fn() }) },
 }));
 
-// `apiFetch` is generic (`<T>`), which makes jest.mocked()'s mockResolvedValue /
-// mockImplementation infer `never`. Cast each handle to a concrete, non-generic
-// Mock signature so the matchers and resolved values type cleanly.
+// generic `apiFetch<T>` makes jest.mocked() infer `never`; cast to a concrete Mock signature.
 const mockApiFetch = apiFetch as unknown as Mock<
   (path: string, init?: ApiFetchInit) => Promise<unknown>
 >;
@@ -75,8 +61,7 @@ const token = (access: string): BearerTokenResponse => ({
 
 beforeEach(() => {
   jest.clearAllMocks();
-  // Reset the module-level session epoch + single-flight handle so a test can't
-  // leak state (e.g. a non-null inFlightRefresh) into the next one.
+  // Reset module-level session epoch + single-flight handle so state can't leak across tests.
   __resetSessionStateForTests();
   mockSetToken.mockResolvedValue(undefined);
   mockGetToken.mockResolvedValue(null);
@@ -100,8 +85,7 @@ describe("login", () => {
     expect(body.get("password")).toBe("pw");
 
     expect(mockSetToken).toHaveBeenCalledWith("tok-login");
-    // Token must be installed BEFORE the cache is purged, so a query firing
-    // mid-purge reads the new identity's token, not the prior user's.
+    // Token installed BEFORE cache purge, so a query firing mid-purge reads the new token.
     expect(mockSetToken.mock.invocationCallOrder[0]).toBeLessThan(
       mockClear.mock.invocationCallOrder[0],
     );
@@ -221,9 +205,7 @@ describe("logout", () => {
 
     await logout();
 
-    // The failure is surfaced (traceable) rather than silently swallowed...
     expect(warnSpy).toHaveBeenCalledWith(expect.any(String), revocationError);
-    // ...and the local wipe still runs regardless of the network outcome.
     expect(mockSetToken).toHaveBeenCalledWith(null);
     expect(mockClear).toHaveBeenCalledTimes(1);
     expect(mockRemoveClient).toHaveBeenCalledTimes(1);
@@ -241,7 +223,6 @@ describe("refreshToken (single-flight)", () => {
       }),
     );
 
-    // Three near-simultaneous refresh triggers.
     const p1 = refreshToken();
     const p2 = refreshToken();
     const p3 = refreshToken();
@@ -296,16 +277,16 @@ describe("refreshToken (single-flight)", () => {
           resolveRefresh = resolve;
         });
       }
-      return Promise.resolve(undefined); // logout call
+      return Promise.resolve(undefined);
     });
 
-    const refreshP = refreshToken(); // in flight
-    await logout(); // completes: clears token + bumps the session epoch
+    const refreshP = refreshToken();
+    await logout(); // bumps the session epoch
 
-    resolveRefresh(token("tok-late")); // refresh resolves AFTER logout
+    resolveRefresh(token("tok-late")); // resolves AFTER logout
     await expect(refreshP).resolves.toBeNull();
 
-    // The late token must NOT be written back over the logged-out session.
+    // Late token must NOT be written back over the logged-out session.
     expect(mockSetToken).not.toHaveBeenCalledWith("tok-late");
     expect(mockSetToken).toHaveBeenLastCalledWith(null);
   });
@@ -349,7 +330,7 @@ describe("getValidToken", () => {
     const refreshP = refreshToken();
     const validP = getValidToken();
 
-    rejectFetch(new ApiError({ status: 500 })); // transient
+    rejectFetch(new ApiError({ status: 500 }));
 
     // refresh propagates the transient error; getValidToken must not.
     await expect(refreshP).rejects.toBeInstanceOf(ApiError);

--- a/mobile/src/api/auth/__tests__/tokenStore.test.ts
+++ b/mobile/src/api/auth/__tests__/tokenStore.test.ts
@@ -10,9 +10,7 @@ jest.mock("@/api/config", () => ({
   getBaseUrl: () => mockBaseUrl,
 }));
 
-// expo-secure-store is mocked centrally (__mocks__/expo-secure-store.ts, auto-
-// applied) and reset before each test (jest.setup.ts), so there's no inline mock
-// or store-clearing boilerplate here.
+// expo-secure-store is auto-mocked (__mocks__/expo-secure-store.ts) and reset per test (jest.setup.ts).
 const mockSetItemAsync = SecureStore.setItemAsync as unknown as Mock<
   (
     key: string,

--- a/mobile/src/api/auth/browserSso.ts
+++ b/mobile/src/api/auth/browserSso.ts
@@ -1,7 +1,5 @@
-// System-browser OAuth leg of mobile SSO. Non-obvious invariants:
-//   * authorize URL is OPENED (302), never fetched — else the CSRF cookie sets on the wrong client.
-//   * only `code_challenge` rides the authorize URL; `code_verifier` stays on-device until the exchange.
-//   * `app_state` is verified on return.
+// Authorize URL is OPENED, never fetched — else the CSRF cookie sets on the wrong client.
+// Only `code_challenge` rides the URL; `code_verifier` stays on-device until the exchange.
 import * as Crypto from "expo-crypto";
 import * as Linking from "expo-linking";
 import * as WebBrowser from "expo-web-browser";

--- a/mobile/src/api/auth/instanceUrl.ts
+++ b/mobile/src/api/auth/instanceUrl.ts
@@ -1,5 +1,5 @@
-// `probeAuthType` validates a *candidate* URL via raw `fetch` — `apiFetch` is bound to
-// the already-committed server URL, so it can't reach an unconfirmed instance.
+// Probes a *candidate* URL via raw `fetch`; `apiFetch` is bound to the committed
+// server URL and can't reach an unconfirmed instance.
 import { getApiPrefix } from "@/api/config";
 import type { AuthTypeMetadata } from "@/api/types";
 
@@ -7,8 +7,7 @@ export const ONYX_CLOUD_URL = "https://cloud.onyx.app";
 
 const PROBE_TIMEOUT_MS = 10_000;
 
-// Add https only when no scheme is given (explicit http:// is kept, e.g. localhost);
-// strip query/fragment + trailing slash.
+// Default to https only when no scheme given (keep explicit http:// for localhost).
 export function normalizeServerUrl(input: string): string {
   const trimmed = input.trim();
   if (trimmed.length === 0) {

--- a/mobile/src/api/auth/providers.ts
+++ b/mobile/src/api/auth/providers.ts
@@ -1,4 +1,3 @@
-// Single source of truth for sign-in methods; adding a provider is a one-line addition here.
 import type { AuthType, AuthTypeMetadata } from "@/api/types";
 
 export type ProviderId = "password" | "google" | "oidc" | "saml" | "apple";
@@ -8,7 +7,7 @@ export interface ProviderDescriptor {
   id: ProviderId;
   label: string;
   kind: ProviderKind;
-  // Browser-SSO authorize path, relative to the API prefix; unused for `password`.
+  // Relative to the API prefix; unused for `password`.
   authorizePath?: string;
 }
 
@@ -20,7 +19,7 @@ export const PROVIDER_REGISTRY: Partial<
     id: "google",
     label: "Google",
     kind: "browser",
-    // Dedicated mobile OAuth route; its callback is under /api → returns to the backend, not web.
+    // Mobile-only route; its callback returns to the backend, not the web app.
     authorizePath: "/auth/mobile/oauth/authorize",
   },
 };
@@ -36,7 +35,7 @@ const GOOGLE_AUTH_TYPES: ReadonlySet<AuthType> = new Set<AuthType>([
   "cloud",
 ]);
 
-// Filtered by the backend's reported config; returns [] until config loads.
+// Returns [] until the backend config loads.
 export function visibleProviders(
   config: AuthTypeMetadata | undefined,
 ): ProviderDescriptor[] {

--- a/mobile/src/api/auth/sessionManager.ts
+++ b/mobile/src/api/auth/sessionManager.ts
@@ -1,5 +1,3 @@
-// Single orchestration point for the mobile session lifecycle; all session
-// mutations route through here so the token-and-cache invariants live in one place.
 import { runBrowserSso } from "@/api/auth/browserSso";
 import type { ProviderDescriptor } from "@/api/auth/providers";
 import { apiFetch } from "@/api/client";
@@ -8,7 +6,6 @@ import { isAuthError } from "@/api/errors";
 import { persister, queryClient } from "@/query/client";
 import { useSession } from "@/state/session";
 
-// fastapi-users BearerTransport login/refresh response shape (also the SSO exchange).
 export interface BearerTokenResponse {
   access_token: string;
   token_type: string;
@@ -22,23 +19,20 @@ const LOGIN_PATH = "/auth/mobile/login";
 const REFRESH_PATH = "/auth/mobile/refresh";
 const LOGOUT_PATH = "/auth/mobile/logout";
 const SSO_EXCHANGE_PATH = "/auth/mobile/sso/exchange";
-// Shared (non-mobile) fastapi-users route; only creates the user.
+// Shared (non-mobile) route; only creates the user, mints no token.
 const REGISTER_PATH = "/auth/register";
 
-// Bumped on every identity change; an in-flight refresh applies its result only
-// if this is unchanged, so a refresh resolving after logout/re-login can't
-// resurrect a cleared session or cross-contaminate a new one. (Single-flight
-// dedupes concurrent refreshes; it does nothing to order them against login/logout.)
+// Bumped on every identity change; a late refresh applies its result only if
+// unchanged, so it can't resurrect a logged-out or cross-contaminate a new session.
 let sessionEpoch = 0;
 
-// Drop in-memory + on-disk query cache on both login and logout so a new
-// identity can never read a previous user's cached data.
+// Drop in-memory + on-disk cache so a new identity can't read a prior user's data.
 async function purgeCache(): Promise<void> {
   queryClient.clear();
   await persister.removeClient();
 }
 
-// fastapi-users `/login` expects an OAuth2 password form (`username`/`password`), not JSON.
+// `/login` expects an OAuth2 password form (`username`/`password`), not JSON.
 function passwordForm(email: string, password: string): URLSearchParams {
   const form = new URLSearchParams();
   form.set("username", email);
@@ -48,8 +42,7 @@ function passwordForm(email: string, password: string): URLSearchParams {
 
 async function installSession(accessToken: string): Promise<void> {
   sessionEpoch += 1; // new identity → invalidate any in-flight refresh
-  // Install the new token before purging so a query firing mid-purge reads the
-  // new identity's token, not the prior user's (which would repopulate the cache).
+  // Install the new token before purging, else a query firing mid-purge repopulates the cache with the prior user's data.
   await setToken(accessToken);
   await purgeCache();
   useSession.getState().setStatus("authed");
@@ -58,7 +51,7 @@ async function installSession(accessToken: string): Promise<void> {
 async function passwordLogin(email: string, password: string): Promise<string> {
   const res = await apiFetch<BearerTokenResponse>(LOGIN_PATH, {
     method: "POST",
-    auth: false, // no token yet
+    auth: false,
     body: passwordForm(email, password),
   });
   return res.access_token;
@@ -83,8 +76,8 @@ export async function login(method: LoginMethod): Promise<void> {
   await installSession(accessToken);
 }
 
-// register() succeeded but the follow-up auto-login failed (e.g. the instance requires email
-// verification): the account exists, so the UI must say "sign in", not "signup failed".
+// Register succeeded but auto-login failed (e.g. email verification required):
+// account exists, so the UI must say "sign in", not "signup failed".
 export class PostRegisterLoginError extends Error {
   readonly loginError: unknown;
   constructor(loginError: unknown) {
@@ -115,17 +108,15 @@ export async function register(params: {
   }
 }
 
-// Wipe the session locally; used by logout and on an irrecoverable refresh failure.
 export async function clearLocalSession(): Promise<void> {
-  sessionEpoch += 1; // invalidate any in-flight refresh so it can't resurrect us
+  sessionEpoch += 1; // a late refresh can't resurrect us
   await setToken(null);
   await purgeCache();
   useSession.getState().setStatus("anon");
 }
 
 export async function logout(): Promise<void> {
-  // Best-effort server-side revocation; the local wipe runs regardless so a
-  // network failure can't strand the user half-logged-out.
+  // Best-effort revoke; the local wipe below runs regardless of network failure.
   try {
     await apiFetch<void>(LOGOUT_PATH, { method: "POST" });
   } catch (err) {
@@ -134,8 +125,7 @@ export async function logout(): Promise<void> {
   await clearLocalSession();
 }
 
-// Single-flight refresh: concurrent callers share one in-flight request, so a
-// burst of near-simultaneous triggers can't fan out into N refresh calls.
+// Single-flight: concurrent callers share one in-flight refresh.
 let inFlightRefresh: Promise<string | null> | null = null;
 
 export function refreshToken(): Promise<string | null> {
@@ -146,15 +136,14 @@ export function refreshToken(): Promise<string | null> {
       const res = await apiFetch<BearerTokenResponse>(REFRESH_PATH, {
         method: "POST",
       });
-      // Session logged out/replaced mid-flight: discard rather than mix identities.
+      // Logged out/replaced mid-flight: discard rather than mix identities.
       if (sessionEpoch !== startedEpoch) return null;
       await setToken(res.access_token);
       useSession.getState().setStatus("authed");
       return res.access_token;
     } catch (err) {
-      // Auth error = token already rejected (revoked/expired), unrecoverable: drop
-      // to logged-out, but only if still the same session. Transient errors re-throw
-      // so the caller keeps the existing token and can retry later.
+      // Auth error = token rejected, unrecoverable → wipe (if same session).
+      // Transient errors re-throw so the caller keeps the existing token.
       if (isAuthError(err)) {
         if (sessionEpoch === startedEpoch) await clearLocalSession();
         return null;
@@ -167,23 +156,19 @@ export function refreshToken(): Promise<string | null> {
   return inFlightRefresh;
 }
 
-// Test-only: reset module-level state so a leaked `inFlightRefresh` can't make
-// the next test's `refreshToken()` silently reuse a stale promise.
+// Test-only: clear module state so a leaked `inFlightRefresh` can't bleed into the next test.
 export function __resetSessionStateForTests(): void {
   sessionEpoch = 0;
   inFlightRefresh = null;
 }
 
-// The V1 token is opaque (not a JWT), so expiry can't be read client-side; this
-// returns the stored token as-is without pre-emptive refresh. If a refresh is
-// in flight, callers await it for the freshest token — but a transient failure
-// must not deny them the still-valid stored token, so fall back to it on throw.
+// Token is opaque (not a JWT), so no client-side expiry check; return it as-is.
+// Await an in-flight refresh for freshness, but fall back to the stored token on a transient throw.
 export async function getValidToken(): Promise<string | null> {
   if (inFlightRefresh) {
     try {
       return await inFlightRefresh;
     } catch {
-      // Transient refresh failure (auth failures resolve to null, not throw).
       return getToken();
     }
   }

--- a/mobile/src/api/auth/tokenStore.ts
+++ b/mobile/src/api/auth/tokenStore.ts
@@ -1,17 +1,13 @@
-// Tokens are credentials, so they live in the device keychain via
-// expo-secure-store, NOT in MMKV (non-secret cache only). Scoped by instance
-// URL so user B can't reuse another instance's bearer token. iOS Keychain
-// survives uninstall with no bulk-clear, so logout deletes the entry explicitly.
+// Tokens live in the keychain (expo-secure-store), never MMKV; scoped by instance
+// URL so a bearer can't cross instances. Keychain survives uninstall, so logout deletes explicitly.
 import * as SecureStore from "expo-secure-store";
 
 import { getBaseUrl } from "@/api/config";
 
-// SecureStore keys allow alphanumerics plus ".", "-", "_".
 const ACCESS_TOKEN_KEY_PREFIX = "onyx.auth.access_token";
 const SAFE_KEY_CHAR = /^[A-Za-z0-9.-]$/;
 
-// THIS_DEVICE_ONLY keeps the token out of iCloud/backups; WHEN_UNLOCKED gates
-// reads on an unlocked device.
+// THIS_DEVICE_ONLY keeps the token out of iCloud/backups.
 const TOKEN_KEYCHAIN_OPTIONS: SecureStore.SecureStoreOptions = {
   keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
 };

--- a/mobile/src/api/auth/useAuthConfig.ts
+++ b/mobile/src/api/auth/useAuthConfig.ts
@@ -1,4 +1,3 @@
-// Public endpoint (auth:false) called before the user has a token; keyed by serverUrl so switching instances refetches.
 import { useQuery } from "@tanstack/react-query";
 
 import { apiFetch } from "@/api/client";
@@ -10,7 +9,7 @@ export function useAuthConfig() {
   const serverUrl = useSession((state) => state.serverUrl);
   return useQuery({
     queryKey: QUERY_KEYS.authType(serverUrl),
-    // Idle until connected: without a URL getBaseUrl() throws a plain Error, which TanStack would retry and park in error state.
+    // Without a URL getBaseUrl() throws; staying idle avoids a parked error state.
     enabled: serverUrl !== null,
     queryFn: ({ signal }) =>
       apiFetch<AuthTypeMetadata>("/auth/type", { auth: false, signal }),

--- a/mobile/src/api/auth/useEmailLogin.ts
+++ b/mobile/src/api/auth/useEmailLogin.ts
@@ -1,4 +1,3 @@
-// On success SessionManager has already stored the Bearer token and reset the cache; caller just navigates.
 import { useMutation } from "@tanstack/react-query";
 
 import { login } from "@/api/auth/sessionManager";

--- a/mobile/src/api/auth/useEmailSignup.ts
+++ b/mobile/src/api/auth/useEmailSignup.ts
@@ -1,4 +1,3 @@
-// register() creates the account then logs in; on success the token's already stored, so the caller just navigates.
 import { useMutation } from "@tanstack/react-query";
 
 import { register } from "@/api/auth/sessionManager";

--- a/mobile/src/api/auth/useLogout.ts
+++ b/mobile/src/api/auth/useLogout.ts
@@ -1,4 +1,3 @@
-// Wipes local token + query cache even if the server-side revoke fails.
 import { useMutation } from "@tanstack/react-query";
 
 import { logout } from "@/api/auth/sessionManager";

--- a/mobile/src/api/auth/useSessionRefresh.ts
+++ b/mobile/src/api/auth/useSessionRefresh.ts
@@ -1,4 +1,3 @@
-// Single-flight guard lives in SessionManager.refreshToken, so concurrent triggers collapse to one network call.
 import { useMutation } from "@tanstack/react-query";
 
 import { refreshToken } from "@/api/auth/sessionManager";

--- a/mobile/src/api/client.ts
+++ b/mobile/src/api/client.ts
@@ -1,4 +1,3 @@
-// Single HTTP choke point: base-URL, auth header, JSON, error normalization.
 import { getBaseUrl } from "@/api/config";
 import { getToken } from "@/api/auth/tokenStore";
 import { ApiError } from "@/api/errors";
@@ -6,7 +5,7 @@ import { ApiError } from "@/api/errors";
 export interface ApiFetchInit extends Omit<RequestInit, "body"> {
   // Plain objects are JSON-serialized; pass a string/FormData to send as-is.
   body?: unknown;
-  // Inject `Authorization: Bearer <token>` when present. Set false for public endpoints.
+  // Set false for public endpoints.
   auth?: boolean;
 }
 
@@ -18,7 +17,7 @@ function isBodyInit(body: unknown): body is BodyInit {
     body instanceof Blob ||
     body instanceof ArrayBuffer ||
     // Typed arrays/DataView: without this they'd be JSON.stringified into
-    // `{"0":1,...}`, corrupting binary uploads. ReadableStream omitted: RN
+    // `{"0":1,...}`, corrupting binary uploads. ReadableStream omitted — RN
     // fetch can't stream request bodies.
     ArrayBuffer.isView(body)
   );
@@ -42,25 +41,14 @@ async function buildHeaders(
   return headers;
 }
 
-// Backend error JSON varies by handler (see backend/onyx/main.py +
-// backend/onyx/error_handling); normalize all into ApiError:
-//
-//   OnyxError (global handler):         { error_code: string, detail: string }
-//   HTTPException (4xx/5xx log_http_error): { detail: string }   (detail may be non-string)
-//   RequestValidationError (422):       { status_code, message: string, data: null }
-//   ValueError (400):                   { message: string }
-//   raw FastAPI validation (sub-apps):  { detail: [{ loc, msg, type }, ...] }
-//   non-JSON / empty body:              no parseable body
-//
-// `error_code` comes only from OnyxError; the message lives in `detail`,
-// `message`, or the joined `msg` fields of a raw-validation `detail` array.
+// Backend error JSON shape varies by handler; normalize all into ApiError.
+// `error_code` only comes from OnyxError; message lives in `detail`/`message`.
 function extractErrorCode(record: Record<string, unknown>): string | undefined {
   return typeof record.error_code === "string" ? record.error_code : undefined;
 }
 
 function extractDetail(record: Record<string, unknown>): string | undefined {
   if (typeof record.detail === "string") return record.detail;
-  // Onyx validation (422) / ValueError (400).
   if (typeof record.message === "string") return record.message;
   // Raw FastAPI validation: array of { loc, msg, type }.
   if (Array.isArray(record.detail)) {
@@ -81,7 +69,6 @@ async function toApiError(res: Response): Promise<ApiError> {
   try {
     body = await res.json();
   } catch {
-    // Empty or non-JSON body (proxy 502/504, HTML error page).
     body = undefined;
   }
   const record =
@@ -128,17 +115,17 @@ export async function apiFetch<T>(
   if (text.trim().length === 0) {
     return undefined as T;
   }
-  // A 2xx with non-JSON body (captive portal / proxy / maintenance HTML) would
-  // throw a raw SyntaxError that escapes ApiError normalization and gets retried.
+  // A 2xx with non-JSON body would throw a raw SyntaxError that escapes ApiError
+  // normalization and gets retried.
   try {
     return JSON.parse(text) as T;
   } catch (parseError) {
-    // Preserve the parser error + raw text on `body` for observability.
     throw new ApiError({
       status: res.status,
       detail: `Expected a JSON response but received ${
         res.headers.get("content-type") ?? "an unknown content type"
       }.`,
+      // Preserve the parser error + raw text for observability.
       body: {
         responseText: text,
         parseError:

--- a/mobile/src/api/config.ts
+++ b/mobile/src/api/config.ts
@@ -1,11 +1,9 @@
-// EXPO_PUBLIC_* ships in the client bundle — never put secrets here, base URL only.
-// Resolved lazily per request, not at module load: a module-eval throw crashes the
-// bundle uncatchably, whereas a throw here surfaces as a rejected query the UI can
-// render — and per-request reads make an instance switch take effect on the next call.
+// EXPO_PUBLIC_* ships in the client bundle — base URL only, never secrets.
+// Resolved lazily per request so a config error is a catchable rejected query
+// (not an uncatchable module-eval crash) and instance switches apply next call.
 import { getStoredServerUrl } from "@/state/session";
 
-// `/api` for nginx-fronted deployments (proxy strips it); set EXPO_PUBLIC_API_PREFIX=""
-// for a bare dev backend.
+// `/api` for nginx-fronted deployments (proxy strips it); set "" for a bare dev backend.
 function normalizePrefix(raw: string): string {
   const trimmed = raw.replace(/^\/+|\/+$/g, "");
   return trimmed ? `/${trimmed}` : "";
@@ -27,6 +25,5 @@ export function getBaseUrl(): string {
         "(or set EXPO_PUBLIC_API_URL in mobile/.env.local for development).",
     );
   }
-  // Host + prefix; callers pass bare paths like "/me".
   return `${raw.replace(/\/+$/, "")}${API_PREFIX}`;
 }

--- a/mobile/src/api/errors.ts
+++ b/mobile/src/api/errors.ts
@@ -1,6 +1,3 @@
-// Backend errors arrive as `{ error_code, detail }`, `{ detail }`, or `{ message }`;
-// apiFetch flattens any shape into these typed fields.
-
 interface ApiErrorArgs {
   status: number;
   code?: string;

--- a/mobile/src/api/query-keys.ts
+++ b/mobile/src/api/query-keys.ts
@@ -1,9 +1,6 @@
-// Central TanStack Query key registry (mirrors web's src/lib/swr-keys.ts).
 export const QUERY_KEYS = {
-  // Keyed by serverUrl so switching instances never serves the previous
-  // backend's authenticated identity from cache.
+  // Keyed by serverUrl so switching instances never serves the prior backend's
+  // cached identity/config.
   me: (serverUrl: string | null) => ["me", serverUrl] as const,
-
-  // Keyed by serverUrl so switching instances refetches the new backend's config.
   authType: (serverUrl: string | null) => ["auth-type", serverUrl] as const,
 };

--- a/mobile/src/api/types.ts
+++ b/mobile/src/api/types.ts
@@ -1,6 +1,5 @@
-// Mobile-local, minimal mirror of web's src/lib/types.ts — only fields the app renders.
-// Must list all 7 backend UserRole members: apiFetch casts without runtime validation,
-// so the type can't claim API-returnable values are impossible.
+// Must list all 7 backend UserRole members: apiFetch casts without runtime
+// validation, so the type can't claim API-returnable values are impossible.
 export type UserRole =
   | "limited"
   | "basic"
@@ -20,7 +19,6 @@ export interface CurrentUser {
 // `cloud` = Google OAuth + basic email/password.
 export type AuthType = "basic" | "google_oauth" | "oidc" | "saml" | "cloud";
 
-// Subset of AuthTypeResponse read by the mobile auth flow; from public GET /api/auth/type.
 export interface AuthTypeMetadata {
   auth_type: AuthType;
   requires_verification: boolean;

--- a/mobile/src/app/(auth)/_layout.tsx
+++ b/mobile/src/app/(auth)/_layout.tsx
@@ -1,6 +1,3 @@
-// Layout for the unauthenticated route group: the connect (instance URL) and login
-// screens. Headerless, like the root stack; the AuthGate (root layout) decides when
-// these screens are reachable.
 import { Stack } from "expo-router";
 
 export default function AuthLayout() {

--- a/mobile/src/app/(auth)/connect.tsx
+++ b/mobile/src/app/(auth)/connect.tsx
@@ -1,5 +1,4 @@
-// Connect screen — mobile-only instance picker mirroring the desktop "Root Domain" screen
-// (desktop/src/index.html). Probes the URL via `/auth/type` before committing it.
+// Probes the URL via /auth/type before committing it.
 import { router } from "expo-router";
 import { useState } from "react";
 import { View } from "react-native";
@@ -19,7 +18,7 @@ export default function ConnectScreen() {
   const serverUrl = useSession((state) => state.serverUrl);
   const setServerUrl = useSession((state) => state.setServerUrl);
 
-  // Default to cloud (like desktop): cloud users tap through, self-hosted overwrite.
+  // Default to cloud: cloud users tap through, self-hosted overwrite.
   const [url, setUrl] = useState(serverUrl ?? ONYX_CLOUD_URL);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
@@ -42,7 +41,7 @@ export default function ConnectScreen() {
       setBusy(false);
       return;
     }
-    // `busy` stays true — the screen unmounts on navigation, so there's nothing to reset.
+    // busy stays true: the screen unmounts on navigation, nothing to reset.
     setServerUrl(normalized);
     router.replace("/(auth)/login");
   }

--- a/mobile/src/app/(auth)/login.tsx
+++ b/mobile/src/app/(auth)/login.tsx
@@ -1,4 +1,3 @@
-// Login screen: sign-in methods from the shared AuthMethods, gated on /auth/type.
 import { router } from "expo-router";
 import { ActivityIndicator, View } from "react-native";
 

--- a/mobile/src/app/(auth)/signup.tsx
+++ b/mobile/src/app/(auth)/signup.tsx
@@ -1,4 +1,3 @@
-// Signup screen: shared AuthMethods in signup mode, gated on /auth/type.
 import { router } from "expo-router";
 import { ActivityIndicator } from "react-native";
 

--- a/mobile/src/app/_layout.tsx
+++ b/mobile/src/app/_layout.tsx
@@ -24,14 +24,9 @@ import { bindOnlineManager } from "@/query/online";
 import { SidebarProvider } from "@/components/sidebar";
 import { AuthGate } from "@/components/auth/AuthGate";
 
-// Show the native Onyx splash until the first frame is ready, then reveal the app.
 SplashScreen.preventAutoHideAsync();
 
-// Design tokens flow from @onyx-ai/shared. Web flips CSS variables via the `.dark`
-// class; React Native can't, so we supply the active palette at the app root through
-// NativeWind vars() and swap light/dark with the system color scheme. Semantic
-// classes (e.g. `bg-background-neutral-00`) reference these variables, so they adapt
-// automatically — no `dark:` modifiers at call-sites, exactly like web.
+// RN can't flip CSS vars like web, so the active palette is supplied via NativeWind vars() and swapped on system scheme.
 const lightTheme = vars(varsLight);
 const darkTheme = vars(varsDark);
 
@@ -40,16 +35,10 @@ export default function RootLayout() {
   const themeVars = colorScheme === "dark" ? darkTheme : lightTheme;
 
   useEffect(() => {
-    // Wire React Native connectivity + foreground state into TanStack Query so
-    // queries pause offline and refetch on reconnect / app resume.
     const unbindOnline = bindOnlineManager();
     const unbindFocus = bindAppStateFocus();
 
-    // No async init to await before the first frame. Custom fonts (Hanken Grotesk,
-    // DM Mono, from the @expo-google-fonts/* packages) are embedded into the native
-    // binary at build time via the expo-font config plugin (see app.json), so they're
-    // registered before React mounts — no runtime useFonts / readiness gate is needed
-    // and text never flashes in the system font. Hide the splash on the first render.
+    // Fonts are embedded at build time (no runtime useFonts gate), so nothing to await before the first frame.
     void SplashScreen.hideAsync();
 
     return () => {
@@ -69,10 +58,7 @@ export default function RootLayout() {
             dehydrateOptions,
           }}
         >
-          {/* SidebarProvider owns the shared open/closed (folded) state so any screen
-              can open the sidebar and the portalled overlay can read it. PortalHost is
-              the last child of the themed root, so the overlay renders above all screens
-              while still inheriting the vars() theme + safe-area insets. */}
+          {/* PortalHost is the last child of the themed root so the sidebar overlay renders above all screens while inheriting the vars() theme + insets. */}
           <SidebarProvider>
             <StatusBar style="auto" />
             <AuthGate>

--- a/mobile/src/app/index.tsx
+++ b/mobile/src/app/index.tsx
@@ -15,11 +15,6 @@ import SvgFolder from "@/icons/folder";
 import SvgPlus from "@/icons/plus";
 import SvgSettings from "@/icons/settings";
 
-// Demo of the React Native Sidebar — a port of the web Opal `SidebarLayouts` shell.
-// Tap the menu icon to slide the sidebar in over the screen; tap the backdrop or
-// swipe left to close. Colors resolve from @onyx-ai/shared, identical to web in
-// both light and dark.
-
 function SidebarTrigger() {
   const { setFolded } = useSidebar();
   return (
@@ -41,7 +36,7 @@ export default function Home() {
 
   function choose(key: string) {
     setSelected(key);
-    setFolded(true); // auto-dismiss after selection (demo behavior)
+    setFolded(true);
   }
 
   return (
@@ -61,7 +56,6 @@ export default function Home() {
             Signed in as {user.email}
           </Text>
         ) : null}
-        {/* temporary: log out to test the auth loop */}
         <Button
           width="full"
           prominence="secondary"

--- a/mobile/src/components/auth/AuthGate.tsx
+++ b/mobile/src/components/auth/AuthGate.tsx
@@ -1,9 +1,5 @@
-// AuthGate — wraps the root navigator and steers between the app and the auth screens
-// (decision in `resolveAuthGate`, pure + unit-tested).
-//
-// Navigation is imperative (`router.replace`), not `<Redirect>`: at the root layout
-// <Redirect>'s `useFocusEffect` has no focused route to bind to. `children` (the <Stack>)
-// renders in every branch so the navigator stays mounted; the splash overlays it.
+// Imperative nav, not `<Redirect>`: at the root layout <Redirect>'s `useFocusEffect` has no
+// focused route to bind to. `children` renders in every branch so the navigator stays mounted.
 import { router, useSegments } from "expo-router";
 import * as React from "react";
 import { ActivityIndicator, View } from "react-native";

--- a/mobile/src/components/auth/AuthMethods.tsx
+++ b/mobile/src/components/auth/AuthMethods.tsx
@@ -1,4 +1,3 @@
-// Shared login/signup body: password form + browser-SSO buttons, split by "or".
 import { View } from "react-native";
 
 import type { ProviderDescriptor } from "@/api/auth/providers";

--- a/mobile/src/components/auth/AuthScreenShell.tsx
+++ b/mobile/src/components/auth/AuthScreenShell.tsx
@@ -1,5 +1,3 @@
-// Shared chrome for the connect/login/signup screens (mobile take on web's AuthFlowContainer
-// + LoginText): logo + heading + the caller's form in a card, with `footer` below it.
 import type { ReactNode } from "react";
 import { KeyboardAvoidingView, Platform, ScrollView, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
@@ -27,8 +25,7 @@ export function AuthScreenShell({
         className="flex-1"
         behavior={Platform.OS === "ios" ? "padding" : undefined}
       >
-        {/* No explicit width: `width:"100%"` doesn't resolve inside a ScrollView content view
-            (it overflowed the screen), so the card stretches via the default `align-items: stretch`. */}
+        {/* No explicit width: `width:"100%"` overflows inside a ScrollView; card stretches via default `align-items: stretch`. */}
         <ScrollView
           contentContainerClassName="grow justify-center px-16 py-40"
           keyboardShouldPersistTaps="handled"

--- a/mobile/src/components/auth/AuthSwitchLink.tsx
+++ b/mobile/src/components/auth/AuthSwitchLink.tsx
@@ -1,5 +1,4 @@
-// Login/signup cross-link (web's footer links). The action is an inner <Text onPress> so it
-// reads as one sentence with only the action underlined.
+// Action is an inner <Text onPress> so it reads as one sentence with only the action underlined.
 import { Text } from "@/components/ui/text";
 
 interface AuthSwitchLinkProps {

--- a/mobile/src/components/auth/AuthUnreachable.tsx
+++ b/mobile/src/components/auth/AuthUnreachable.tsx
@@ -1,6 +1,4 @@
-// AuthGate's error overlay when `/api/me` is unreachable: a retry + change-instance escape so
-// a backend blip can't strand the user on a spinner. Self-clears too — the query refetches on
-// app focus / reconnect once the instance is reachable again.
+// Self-clears: the `/api/me` query refetches on app focus / reconnect once the instance is reachable.
 import { router } from "expo-router";
 import { View } from "react-native";
 

--- a/mobile/src/components/auth/EmailPasswordForm.tsx
+++ b/mobile/src/components/auth/EmailPasswordForm.tsx
@@ -1,5 +1,3 @@
-// Shared email/password form for login + signup (web reuses one form via `isSignup`); signup
-// creates the account then logs in (see sessionManager.register).
 import { router } from "expo-router";
 import { useEffect } from "react";
 import { FormProvider, useForm, useWatch } from "react-hook-form";
@@ -34,7 +32,7 @@ function loginErrorMessage(error: unknown): string {
 }
 
 function signupErrorMessage(error: unknown): string {
-  // Account was created; only the auto-login failed — point them at sign-in, not retry-signup.
+  // Account created; only auto-login failed — point at sign-in, not retry-signup.
   if (error instanceof PostRegisterLoginError) {
     return "Account created. Please sign in.";
   }
@@ -45,8 +43,7 @@ function signupErrorMessage(error: unknown): string {
     if (error.status === 429) {
       return "Too many requests. Please try again later.";
     }
-    // fastapi-users rejects a weak password as `{ detail: { reason } }`; apiFetch can't
-    // flatten an object detail, so reach into the raw body for the reason.
+    // Weak-password rejection is `{ detail: { reason } }`; apiFetch can't flatten an object detail, so read the raw body.
     const body = error.body as { detail?: { reason?: string } } | undefined;
     const reason = body?.detail?.reason;
     if (typeof reason === "string" && reason) return reason;
@@ -81,8 +78,7 @@ export function EmailPasswordForm({
   });
   useEffect(() => {
     if (mutation.isError) mutation.reset();
-    // `mutation` is excluded from deps on purpose: it changes when `isError` flips, so
-    // including it would re-run this and reset the error the instant it's set. Edits only.
+    // `mutation` excluded from deps: it changes when `isError` flips, so including it would reset the error the instant it's set.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [email, password]);
 

--- a/mobile/src/components/auth/ProviderSsoButton.tsx
+++ b/mobile/src/components/auth/ProviderSsoButton.tsx
@@ -1,4 +1,4 @@
-// One "Continue with <provider>" button; per-provider so each owns its own mutation.
+// Per-provider component so each owns its own mutation.
 import { router } from "expo-router";
 import { View } from "react-native";
 

--- a/mobile/src/components/auth/__tests__/authRoute.test.ts
+++ b/mobile/src/components/auth/__tests__/authRoute.test.ts
@@ -1,4 +1,3 @@
-// resolveAuthGate decisions as pure logic — every branch + the precedence between them.
 import { describe, expect, it } from "@jest/globals";
 
 import {
@@ -12,7 +11,6 @@ const CONNECT: readonly string[] = ["(auth)", "connect"];
 const LOGIN: readonly string[] = ["(auth)", "login"];
 const SIGNUP: readonly string[] = ["(auth)", "signup"];
 
-// Defaults to the logged-out, unresolved state; each test overrides what it exercises.
 function input(overrides: Partial<AuthGateInput>): AuthGateInput {
   return {
     serverUrl: "https://cloud.onyx.app",

--- a/mobile/src/components/auth/authRoute.ts
+++ b/mobile/src/components/auth/authRoute.ts
@@ -1,5 +1,4 @@
-// AuthGate's routing decision as a pure function, so the branching is unit-tested
-// without rendering RN. `AuthGate.tsx` wires live session + /api/me state in.
+// Pure so the branching is unit-tested without rendering RN; AuthGate.tsx wires live state in.
 import type { SessionStatus } from "@/state/session";
 
 const AUTH_GROUP = "(auth)";
@@ -14,15 +13,13 @@ export type AuthGateResolution =
 
 export interface AuthGateInput {
   serverUrl: string | null;
-  // `"anon"` = explicit logout / rejected token; the gate treats it as a decisive "logged out"
-  // with no `/api/me` round-trip, so logout redirects instantly and works offline.
+  // `"anon"` = explicit logout: decisive "logged out" with no `/api/me` round-trip (instant, offline).
   status: SessionStatus;
   isAuthed: boolean;
   // `/api/me` failed with 401/402/403 — a decisive "logged out".
   isAuthError: boolean;
-  // `/api/me` settled in a non-auth failure (backend unreachable); not "still loading" — retries are done.
+  // `/api/me` settled in a non-auth failure (backend unreachable); not "still loading".
   isUnreachable: boolean;
-  // expo-router route segments, e.g. ["(auth)", "connect"].
   segments: readonly string[];
 }
 
@@ -38,7 +35,6 @@ export function resolveAuthGate(input: AuthGateInput): AuthGateResolution {
       : { kind: "redirect", to: "/(auth)/connect" };
   }
 
-  // Decisive logout → straight to login (see `status` above).
   if (status === "anon") {
     return inAuthGroup
       ? { kind: "render" }
@@ -55,12 +51,11 @@ export function resolveAuthGate(input: AuthGateInput): AuthGateResolution {
       : { kind: "redirect", to: "/(auth)/login" };
   }
 
-  // Won't self-resolve: error+retry screen on protected routes instead of an endless splash.
-  // Auth screens own their errors, so render them as usual.
+  // Won't self-resolve: error+retry on protected routes instead of an endless splash; auth screens own their errors.
   if (isUnreachable) {
     return inAuthGroup ? { kind: "render" } : { kind: "error" };
   }
 
-  // Still resolving: splash on protected routes, render in the auth group (mid-connect/login).
+  // Still resolving: splash on protected routes, render in the auth group.
   return inAuthGroup ? { kind: "render" } : { kind: "splash" };
 }

--- a/mobile/src/components/form/fields.tsx
+++ b/mobile/src/components/form/fields.tsx
@@ -1,6 +1,4 @@
-// Bound field atoms (Layer 2) — the only form files that import react-hook-form. RN
-// counterpart of web's `InputTypeInField` / `PasswordInputTypeInField`. Binds via
-// `useController`, never `register` — RN `TextInput` emits `onChangeText`, not a DOM event.
+// Binds via `useController`, never `register` — RN `TextInput` emits `onChangeText`, not a DOM event.
 import {
   useController,
   type Control,
@@ -20,8 +18,7 @@ import {
   type TextInputVariant,
 } from "@/components/ui/text-input";
 
-// RN TextInput only handles strings, so binding a number/boolean field would coerce +
-// corrupt form state — constrain names to string-valued paths.
+// RN TextInput only handles strings; binding a number/boolean field would corrupt form state.
 type StringFieldPath<TFieldValues extends FieldValues> = {
   [K in FieldPath<TFieldValues>]: FieldPathValue<TFieldValues, K> extends
     | string
@@ -43,15 +40,13 @@ interface FieldBaseProps<
   TName extends StringFieldPath<TFieldValues>,
 > {
   name: TName;
-  /** Optional — falls back to the nearest <FormProvider>. */
   control?: Control<TFieldValues>;
-  /** Inline RHF rules; a `zodResolver` at the form level is preferred. */
   rules?: FieldRules<TFieldValues, TName>;
   title: string;
   description?: string;
   subDescription?: string;
   suffix?: "optional" | (string & {});
-  /** Visually disabled + non-editable. The value stays in form state and submits. */
+  /** Value still submits while disabled. */
   disabled?: boolean;
 }
 
@@ -64,8 +59,7 @@ function resolveVariant(
   return "idle";
 }
 
-// A truthy error with no message (e.g. boolean `required: true`) would flip the field red
-// with no message row or a11y alert — a fallback keeps message + variant in lockstep.
+// Fallback message keeps the error variant and a11y alert in lockstep when an error has no message.
 function errorMessageOf(
   message: string | undefined,
   hasError: boolean,

--- a/mobile/src/components/form/index.ts
+++ b/mobile/src/components/form/index.ts
@@ -1,5 +1,3 @@
-// Public surface. Layer 1 (RHF-free): `InputLayouts` primitives + `TextInput` /
-// `PasswordTextInput` atoms. Layer 2 (RHF-bound): `TextInputField` / `PasswordInputField`.
 import {
   InputDivider,
   InputErrorText,
@@ -26,7 +24,6 @@ export type {
   InputErrorType,
 } from "@/components/form/input-layouts";
 
-/** Namespace for web-parity ergonomics: `<InputLayouts.Vertical .../>`. */
 export const InputLayouts = {
   Vertical,
   Horizontal,

--- a/mobile/src/components/form/input-layouts.tsx
+++ b/mobile/src/components/form/input-layouts.tsx
@@ -1,6 +1,4 @@
-// RN port of web Opal's input-layout primitives (web/lib/opal/src/layouts/inputs/),
-// RHF-free. Spacing uses explicit margins, not `gap` (unreliable in NativeWind on RN
-// — see components/sidebar/SidebarTab.tsx).
+// Spacing uses explicit margins, not `gap` (unreliable in NativeWind on RN).
 import type { ReactNode } from "react";
 import { View } from "react-native";
 
@@ -19,7 +17,7 @@ interface InputLayoutBaseProps {
   description?: string;
   /** "optional" renders "(Optional)"; any other string verbatim. */
   suffix?: "optional" | (string & {});
-  /** Pre-resolved message (Layer 1 never reads RHF); presence renders the error row. */
+  /** Pre-resolved message; these primitives never read RHF. */
   error?: string;
   errorType?: InputErrorType;
   disabled?: boolean;
@@ -119,7 +117,6 @@ function Vertical({
 }
 
 export interface HorizontalProps extends InputLayoutBaseProps {
-  /** Vertically center the input against the label block. */
   center?: boolean;
   icon?: IconFunctionComponent;
 }

--- a/mobile/src/components/form/use-field-controller.ts
+++ b/mobile/src/components/form/use-field-controller.ts
@@ -4,8 +4,7 @@ import {
   type FieldValues,
 } from "react-hook-form";
 
-// Resolves `control`: explicit prop wins, else the nearest <FormProvider> — keeping
-// FormProvider optional. Throws a clear error when neither is present.
+// Explicit `control` prop wins, else the nearest <FormProvider>, keeping the provider optional.
 export function useFieldController<TFieldValues extends FieldValues>(
   explicit?: Control<TFieldValues>,
 ): Control<TFieldValues> {

--- a/mobile/src/components/sidebar/Sidebar.tsx
+++ b/mobile/src/components/sidebar/Sidebar.tsx
@@ -21,18 +21,7 @@ import {
   SIDEBAR_WIDTH_EXPANDED,
 } from "@/components/sidebar/interfaces";
 
-// ---------------------------------------------------------------------------
-// SidebarLayouts — the RN sidebar shell (Root/Header/Body/Footer/Section). A
-// full-height overlay that slides in from the left with a tinted backdrop:
-//   • portalled above all screens via @rn-primitives/portal,
-//   • reanimated translateX slide + backdrop opacity off the `folded` state,
-//   • gesture-handler Pan for swipe-to-close (gated to horizontal so it doesn't
-//     steal the Body ScrollView's vertical scroll),
-//   • colors + typography from the shared design tokens.
-// ---------------------------------------------------------------------------
-
 interface SidebarRootProps {
-  /** Kept for web API parity; the mobile overlay behaves the same regardless. */
   foldable?: boolean;
   children: React.ReactNode;
 }
@@ -41,16 +30,13 @@ function SidebarRoot({ children }: SidebarRootProps) {
   const { folded, setFolded } = useSidebar();
   const insets = useSafeAreaInsets();
 
-  // `progress` is derived (read-only) from the React `folded` state: 1 = open,
-  // 0 = closed (off-screen). Driving it via useDerivedValue keeps the open/close
-  // animation purely state-driven — no manual shared-value mutation in an effect.
+  // Derived from `folded` so the slide stays state-driven (no effect mutation): 1 = open, 0 = closed.
   const progress = useDerivedValue(
     () => withTiming(folded ? 0 : 1, { duration: SIDEBAR_ANIM_MS }),
     [folded],
   );
 
-  // `drag` is a live swipe offset, mutated ONLY inside the Pan worklet and read by
-  // the animated styles — it layers on top of `progress` so a finger drag tracks 1:1.
+  // Live swipe offset, mutated only in the Pan worklet; layers on `progress` for 1:1 finger tracking.
   const drag = useSharedValue(0);
 
   const columnStyle = useAnimatedStyle(() => {
@@ -65,15 +51,11 @@ function SidebarRoot({ children }: SidebarRootProps) {
 
   const close = React.useCallback(() => setFolded(true), [setFolded]);
 
-  // Swipe left on the column to close. `activeOffsetX` gates activation to
-  // horizontal movement, letting vertical scroll fall through to the Body. Built
-  // inline (not via a hook) so `drag` isn't treated as a frozen hook argument —
-  // useSharedValue refs are stable, so re-creating the gesture object is cheap and
-  // the Root only re-renders when `folded` flips.
+  // Swipe-left-to-close; `activeOffsetX` gates to horizontal so vertical scroll falls through to Body.
   const pan = Gesture.Pan()
     .activeOffsetX([-15, 15])
     .onUpdate((e) => {
-      drag.value = Math.min(0, e.translationX); // leftward only
+      drag.value = Math.min(0, e.translationX);
     })
     .onEnd((e) => {
       const shouldClose =
@@ -88,8 +70,7 @@ function SidebarRoot({ children }: SidebarRootProps) {
         pointerEvents={folded ? "none" : "auto"}
         className="absolute inset-0 z-50"
       >
-        {/* Tinted backdrop (web `bg-mask-03`; the ~1px backdrop-blur is dropped — not
-            a mobile token). Tap to close. */}
+        {/* Tap-to-close backdrop. Web's ~1px backdrop-blur is dropped — no mobile token. */}
         <Animated.View style={backdropStyle} className="absolute inset-0">
           <Pressable className="flex-1 bg-mask-03" onPress={close} />
         </Animated.View>
@@ -114,13 +95,8 @@ function SidebarRoot({ children }: SidebarRootProps) {
   );
 }
 
-// ---------------------------------------------------------------------------
-// Header — topbar (logo + close button) with optional pinned content below
-// ---------------------------------------------------------------------------
-
 interface SidebarHeaderProps {
   logo?: (folded: boolean | undefined) => React.ReactNode;
-  /** Kept for web API parity (no hover on touch). */
   showLogoWhenFolded?: boolean;
   children?: React.ReactNode;
 }
@@ -150,12 +126,7 @@ function SidebarHeader({ logo, children }: SidebarHeaderProps) {
   );
 }
 
-// ---------------------------------------------------------------------------
-// Body — scrollable content area
-// ---------------------------------------------------------------------------
-
 interface SidebarBodyProps {
-  /** Accepted for web API parity; scroll-offset persistence is out of scope for the shell. */
   scrollKey?: string;
   children?: React.ReactNode;
 }
@@ -168,10 +139,6 @@ function SidebarBody({ children }: SidebarBodyProps) {
   );
 }
 
-// ---------------------------------------------------------------------------
-// Footer — pinned content below the scroll area
-// ---------------------------------------------------------------------------
-
 interface SidebarFooterProps {
   children?: React.ReactNode;
 }
@@ -180,15 +147,9 @@ function SidebarFooter({ children }: SidebarFooterProps) {
   return <View className="px-2 pt-4">{children}</View>;
 }
 
-// ---------------------------------------------------------------------------
-// Section — titled group within the scrollable body
-// ---------------------------------------------------------------------------
-
 interface SidebarSectionProps {
   title?: string;
-  /** Optional action (e.g. a "+" button); always visible on touch (no hover). */
   action?: React.ReactNode;
-  /** Dims the section header to indicate it is unavailable. */
   disabled?: boolean;
   children?: React.ReactNode;
 }
@@ -222,10 +183,6 @@ function SidebarSection({
     </View>
   );
 }
-
-// ---------------------------------------------------------------------------
-// Exports — mirror the web `SidebarLayouts` namespace
-// ---------------------------------------------------------------------------
 
 export const SidebarLayouts = {
   Root: SidebarRoot,

--- a/mobile/src/components/sidebar/SidebarProvider.tsx
+++ b/mobile/src/components/sidebar/SidebarProvider.tsx
@@ -7,16 +7,7 @@ import {
   type SetStateAction,
 } from "react";
 
-// ---------------------------------------------------------------------------
-// Sidebar state. `folded` is the single source of truth: on a phone the sidebar
-// is an overlay, so `folded === true` means "closed / off-screen" and
-// `folded === false` means "open". Default closed; opened from a trigger.
-//
-// `setFolded` is React's own `useState` setter, so it already accepts either a
-// value (`setFolded(false)`) or an updater (`setFolded((prev) => !prev)` for a
-// toggle) — no wrapper needed.
-// ---------------------------------------------------------------------------
-
+// `folded === true` means closed/off-screen (the overlay's source of truth).
 export interface SidebarStateContextType {
   folded: boolean;
   setFolded: Dispatch<SetStateAction<boolean>>;
@@ -27,7 +18,6 @@ const SidebarStateContext = createContext<SidebarStateContextType | undefined>(
 );
 
 export interface SidebarProviderProps {
-  /** Initial fold state. Defaults to `true` (closed) on mobile. */
   defaultFolded?: boolean;
   children: ReactNode;
 }

--- a/mobile/src/components/sidebar/SidebarTab.tsx
+++ b/mobile/src/components/sidebar/SidebarTab.tsx
@@ -8,22 +8,9 @@ import { Text } from "@/components/ui/text";
 import type { IconFunctionComponent } from "@/icons/types";
 import type { SidebarVariant } from "@/components/sidebar/interfaces";
 
-// ---------------------------------------------------------------------------
-// SidebarTab — React Native port of web's Opal SidebarTab
-// (web/lib/opal/src/components/buttons/sidebar-tab/components.tsx), built on the
-// `Interactive.Stateful` sidebar-heavy / sidebar-light color matrix
-// (web/lib/opal/src/core/interactive/stateful/styles.css:543-662).
-//
-// Web "hover" → RN "pressed" (NativeWind's `active:` modifier on Pressable).
-// All classes resolve to the same Onyx token hex as web.
-// ---------------------------------------------------------------------------
-
 interface SidebarTabColors {
-  /** Selected background; empty/filled is transparent (omitted). */
   bg: string;
-  /** Label foreground color class. */
   label: string;
-  /** Icon foreground. */
   icon: string;
 }
 
@@ -36,7 +23,6 @@ function resolveColors(
     return { bg: "", label: "text-text-03", icon: "text-text-03" };
   }
   if (variant === "sidebar-light") {
-    // All states use text-02 foreground; selected adds the tint-00 background.
     return {
       bg: selected ? "bg-background-tint-00" : "",
       label: "text-text-02",
@@ -55,23 +41,15 @@ function resolveColors(
 }
 
 interface SidebarTabProps {
-  /** Collapses the label, showing only the icon (inert on phone — sidebar is open/closed). */
   folded?: boolean;
-  /** Marks this tab as the currently active item. */
   selected?: boolean;
-  /** Color variant. @default "sidebar-heavy" */
   variant?: SidebarVariant;
-  /** Renders an empty spacer in place of the icon, for nested items. */
   nested?: boolean;
-  /** Disables the tab — muted colors, suppressed press. */
   disabled?: boolean;
   onPress?: () => void;
-  /** Optional route to navigate to on press (expo-router). */
   href?: Href;
   icon?: IconFunctionComponent;
-  /** Content rendered on the right (e.g. a count or action). */
   rightChildren?: React.ReactNode;
-  /** Accepted for web API parity; a no-op on touch. */
   tooltip?: string;
   children?: React.ReactNode;
 }
@@ -107,11 +85,7 @@ function SidebarTab({
         disabled && "opacity-50",
       )}
     >
-      {/* Leading slot — mirrors web's ContentSm (web/lib/opal/.../content/ContentSm.tsx
-          + styles.css): a 16px icon inside a `p-0.5` container (the padding "around"
-          the icon), then a 2px gap (web's `gap: 0.125rem`) before the label, or a
-          matching spacer for nested items so labels align. Explicit margin instead of
-          `gap`, which doesn't render reliably in RN/NativeWind. */}
+      {/* Leading icon/spacer; explicit `mr-0.5` instead of `gap` (unreliable in RN/NativeWind). */}
       {nested ? (
         <View className="mr-0.5 w-5" aria-hidden />
       ) : icon ? (

--- a/mobile/src/components/sidebar/interfaces.ts
+++ b/mobile/src/components/sidebar/interfaces.ts
@@ -1,12 +1,5 @@
-// Shared (non-prop) types for the Sidebar primitive. Mirrors the web Opal
-// `Interactive.Stateful` sidebar variants.
-
 export type SidebarVariant = "sidebar-heavy" | "sidebar-light";
 
-// Sidebar column width, ported from web/lib/opal/src/styles/sizes.css
-// (--sidebar-width-expanded: 15rem). On a phone the folded rail is unused
-// (folded === off-screen), so only the expanded width applies.
 export const SIDEBAR_WIDTH_EXPANDED = 240;
 
-// Slide/backdrop transition duration — matches web's `duration-200`.
 export const SIDEBAR_ANIM_MS = 200;

--- a/mobile/src/components/ui/button.styles.ts
+++ b/mobile/src/components/ui/button.styles.ts
@@ -1,33 +1,23 @@
-// Pure style/state logic for the Button — no RN imports, so it's unit-testable.
-// Ported from web's Opal Button + its color matrix
-// (web/lib/opal/src/core/interactive/stateless/styles.css). Classes are literal
-// token strings (so NativeWind's compiler sees them) resolving to the same Onyx
-// tokens as web. Web `:hover` has no touch equivalent, so the matrix carries only
-// rest / active / disabled.
+// Classes are literal token strings so NativeWind's compiler sees them.
+// No `hover` state: touch has no hover equivalent, so the matrix is rest/active/disabled.
 import type {
   InteractiveProminence,
   InteractiveVariant,
   TextFont,
 } from "@onyx-ai/shared/contracts";
 
-/** Size preset — mirrors web's `ContainerSizeVariants`. */
 export type ButtonSize = "lg" | "md" | "sm" | "xs" | "2xs" | "fit";
 
-/** Width preset. `"fit"` shrink-wraps to content; `"full"` stretches to parent. */
 export type ButtonWidth = "fit" | "full";
 
-/** Touch interaction override (no `hover` — see file header). */
 export type ButtonInteraction = "rest" | "active";
 
-/** Resolved visual state the color matrix is keyed on. */
 export type ButtonColorState = "rest" | "active" | "disabled";
 
 interface ButtonColorCell {
   bg: string;
-  /** Foreground class — label and icon. */
   fg: string;
-  /** Secondary-prominence border (`""` otherwise); tracks `fg` because web's bare
-   *  `@apply border` is `currentColor` in Tailwind v4. */
+  // Tracks `fg`: a bare `@apply border` is `currentColor` in Tailwind v4.
   border: string;
 }
 
@@ -36,8 +26,7 @@ type ButtonColorMatrix = Record<
   Record<InteractiveProminence, Record<ButtonColorState, ButtonColorCell>>
 >;
 
-// Full Record by type, so a new shared variant/prominence won't compile until its
-// cells are added — the cross-platform drift guard.
+// Full Record by type: a new shared variant/prominence won't compile until its cells exist.
 export const BUTTON_COLORS: ButtonColorMatrix = {
   default: {
     primary: {
@@ -200,22 +189,15 @@ export const BUTTON_COLORS: ButtonColorMatrix = {
 };
 
 interface ButtonSizeSpec {
-  /** Height class (`""` = content height, for `fit`). */
-  height: string;
-  /** Min-width class — keeps icon-only buttons square (`""` for `fit`). */
-  minWidth: string;
+  height: string; // `""` = content height, for `fit`
+  minWidth: string; // keeps icon-only buttons square
   padding: string;
   rounding: string;
   font: TextFont;
-  /** Padding around each icon (web's icon-wrapper padding). */
   iconPad: string;
-  /** Icon glyph size, px. */
   iconSize: number;
 }
 
-// Heights are web's line-height tokens → px (lg h1-headline 2.25rem=36 … 2xs
-// secondary 1rem=16); padding web rem×16 (p-2=8 → p-8, p-1=4 → p-4, p-0.5=2 → p-2);
-// rounding from the Button's `isLarge ? "md" : size==="2xs" ? "xs" : "sm"` rule.
 export const BUTTON_SIZES: Record<ButtonSize, ButtonSizeSpec> = {
   lg: {
     height: "h-36",

--- a/mobile/src/components/ui/button.tsx
+++ b/mobile/src/components/ui/button.tsx
@@ -1,8 +1,4 @@
-// React Native port of web's Opal Button
-// (web/lib/opal/src/components/buttons/button/components.tsx); the color matrix
-// and sizing live in button.styles. Web "hover" maps to RN "pressed". Spacing
-// uses margins, not `gap-*` (unreliable in RN/NativeWind — see SidebarTab).
-// `children` is plain string; web's RichStr/markdown is intentionally unsupported.
+// Spacing uses margins, not `gap-*` (unreliable in RN/NativeWind).
 import { ActivityIndicator, Pressable, View } from "react-native";
 import { router, type Href } from "expo-router";
 import { cssInterop } from "nativewind";
@@ -21,39 +17,26 @@ import {
   type ButtonWidth,
 } from "@/components/ui/button.styles";
 
-// ActivityIndicator ignores `style.color`; bridge the text-color class onto its `color` prop so
-// the spinner matches the label (like text-input's placeholder).
+// ActivityIndicator ignores `style.color`; bridge the text-color class onto its `color` prop.
 const Spinner = cssInterop(ActivityIndicator, {
   className: { target: false, nativeStyleToProp: { color: "color" } },
 }) as React.ComponentType<{ className?: string; size?: "small" | "large" }>;
 
 type ButtonBaseProps = InteractiveContract & {
-  /** Size preset. @default "lg" */
   size?: ButtonSize;
-  /** `"fit"` shrink-wraps to content; `"full"` stretches to parent. @default "fit" */
   width?: ButtonWidth;
-  /**
-   * Forces the pressed visual without a touch (e.g. an open popover trigger).
-   * @default "rest"
-   */
   interaction?: ButtonInteraction;
-  /** Shows a spinner, dims to the disabled look, and blocks presses. @default false */
   loading?: boolean;
   rightIcon?: IconFunctionComponent;
   onPress?: () => void;
-  /** Navigates here on press (expo-router). */
   href?: Href;
-  /** Accepted for web API parity; a no-op on touch. */
   tooltip?: string;
-  /** Layout overrides, applied to the outer pressable. */
   className?: string;
-  /** Screen-reader name — required for icon-only buttons (they have no text). */
+  // Required for icon-only buttons — without text a screen reader announces just "button".
   accessibilityLabel?: string;
 };
 
-// Mirrors web's discriminated `ButtonContentProps`: a label or a leading icon,
-// never neither. Icon-only (no children) must supply `accessibilityLabel` —
-// with no text, a screen reader would otherwise announce just "button".
+// A label or a leading icon, never neither; icon-only must supply `accessibilityLabel`.
 type ButtonProps = ButtonBaseProps &
   (
     | { icon?: IconFunctionComponent; children: string }
@@ -96,8 +79,7 @@ function Button({
       accessibilityRole="button"
       accessibilityLabel={accessibilityLabel}
       accessibilityState={{ disabled: disabled || loading, busy: loading }}
-      // RN stretches flex children on the cross axis, so `fit` needs `self-start`
-      // to shrink-wrap like web's `w-fit` (RN has no `fit-content`).
+      // RN stretches flex children cross-axis; `self-start` shrink-wraps `fit` (no `fit-content`).
       className={cn(width === "full" ? "w-full" : "self-start", className)}
     >
       {({ pressed }) => {
@@ -121,7 +103,6 @@ function Button({
             )}
           >
             {loading ? (
-              // Replaces the leading icon while working; rightIcon is suppressed below.
               <View className={cn("items-center justify-center", spec.iconPad)}>
                 <Spinner size="small" className={colors.fg} />
               </View>
@@ -132,9 +113,8 @@ function Button({
             ) : null}
 
             {hasLabel ? (
-              // `mx-4` reproduces web's `gap-1` around the label (RN `gap-*` is
-              // unreliable). `shrink` + `ellipsizeMode="clip"` clip a long label
-              // (matching web) instead of pushing the trailing icon out.
+              // `mx-4` substitutes for `gap-*`; `shrink`+clip trims a long label
+              // instead of pushing the trailing icon out.
               <Text
                 font={spec.font}
                 numberOfLines={1}

--- a/mobile/src/components/ui/icon.tsx
+++ b/mobile/src/components/ui/icon.tsx
@@ -1,11 +1,5 @@
-// Why this exists: React Native has no CSS engine, so a react-native-svg icon can't
-// read a Tailwind class like `text-text-02` (on web the browser does this for free).
-// This wrapper is that missing translator — it turns a color class into a real color
-// and hands it to the icon, so icons use the same design tokens as everything else.
-//
-// How: `cssInterop` compiles the className and maps the resolved text color → the
-// icon's `color` prop, which the SVG's `stroke="currentColor"` reads. Adds a default
-// size (16) + color (`text-text-03`).
+// RN has no CSS engine: `cssInterop` resolves the text-color class to a real color and
+// maps it onto the icon's `color` prop, which the SVG's `stroke="currentColor"` reads.
 import { cssInterop } from "nativewind";
 
 import { cn } from "@/lib/utils";

--- a/mobile/src/components/ui/separator.tsx
+++ b/mobile/src/components/ui/separator.tsx
@@ -1,5 +1,4 @@
-// react-native-reusables `separator` primitive, vendored and reconciled to Onyx tokens
-// (RNR default `bg-border` → `bg-border-01`).
+// Vendored RNR `separator`, reconciled to Onyx tokens (`bg-border` → `bg-border-01`).
 import { cn } from "@/lib/utils";
 import * as SeparatorPrimitive from "@rn-primitives/separator";
 

--- a/mobile/src/components/ui/text-input.tsx
+++ b/mobile/src/components/ui/text-input.tsx
@@ -1,4 +1,3 @@
-// RN port of web Opal's `InputTypeIn` / `PasswordInputTypeIn`.
 import { cva, type VariantProps } from "class-variance-authority";
 import { cssInterop } from "nativewind";
 import { useCallback, useRef, useState, type ReactNode, type Ref } from "react";
@@ -56,12 +55,10 @@ export type TextInputVariant = NonNullable<
 
 export interface TextInputProps extends Omit<RNTextInputProps, "editable"> {
   ref?: Ref<RNTextInput>;
-  /** Border/background tokens + editability. @default "idle" */
   variant?: TextInputVariant;
   leftIcon?: IconFunctionComponent;
   prefixText?: string;
   rightSlot?: ReactNode;
-  /** Clear (×) button while non-empty; suppressed by `rightSlot`. */
   clearButton?: boolean;
   className?: string;
 }
@@ -98,7 +95,7 @@ function TextInput({
   }, [editable]);
 
   const focusBorder = focused && variant === "idle" ? "border-border-05" : "";
-  // Always mounted (stable input width), inert when empty — web's `invisible` reserve-space.
+  // Always mounted (stable input width), inert when empty.
   const hasValue = !!value;
   const showClear = clearButton && !rightSlot && editable;
 
@@ -165,7 +162,6 @@ export interface PasswordTextInputProps extends Omit<
   TextInputProps,
   "rightSlot" | "secureTextEntry" | "leftIcon" | "clearButton"
 > {
-  /** When false (or for a stored backend value) the reveal toggle is disabled. @default true */
   revealable?: boolean;
 }
 

--- a/mobile/src/components/ui/text.tsx
+++ b/mobile/src/components/ui/text.tsx
@@ -1,19 +1,10 @@
-// React Native port of web's Opal `Text` (web/lib/opal/src/components/text/components.tsx),
-// mirrored 1:1: `font` → a `font-*` NativeWind utility (FONT_CONFIG, generated from the
-// shared tokens); `color` → a token class (COLOR_CONFIG; default "text-04", "inherit" →
-// no class). TextFont/TextColor are the shared canonical unions from
-// @onyx-ai/shared/contracts (not the RN-only /native).
-//
-// Omitted vs web (no RN equivalent): the `as` tag and inline-markdown children.
-// `maxLines` → numberOfLines + tail ellipsis; `nowrap` clips one line without one.
 import type { TextColor, TextFont } from "@onyx-ai/shared/contracts";
 import * as React from "react";
 import { Text as RNText } from "react-native";
 
 import { cn } from "@/lib/utils";
 
-// font preset name -> `font-*` utility class (= web's FONT_CONFIG). Literal strings
-// so NativeWind's class scanner picks them up.
+// Literal strings so NativeWind's class scanner picks them up.
 const FONT_CONFIG: Record<TextFont, string> = {
   "heading-h1": "font-heading-h1",
   "heading-h2": "font-heading-h2",
@@ -36,7 +27,6 @@ const FONT_CONFIG: Record<TextFont, string> = {
   "figure-keystroke": "font-figure-keystroke",
 };
 
-// color token -> text color class (= web's COLOR_CONFIG). `inherit` -> no class.
 const COLOR_CONFIG: Record<TextColor, string | null> = {
   inherit: null,
   "text-01": "text-text-01",
@@ -62,13 +52,11 @@ const COLOR_CONFIG: Record<TextColor, string | null> = {
 };
 
 interface TextProps extends React.ComponentProps<typeof RNText> {
-  /** Typography preset (same names as web's Opal Text). @default "main-ui-body" */
   font?: TextFont;
-  /** Color token. @default "text-04" */
   color?: TextColor;
-  /** Keep text on one line, clipped without an ellipsis (web's `nowrap`). */
+  // Clip to one line without an ellipsis.
   nowrap?: boolean;
-  /** Truncate to N lines with a tail ellipsis (web's `maxLines`). */
+  // Truncate to N lines with a tail ellipsis.
   maxLines?: number;
 }
 
@@ -81,8 +69,7 @@ function Text({
   numberOfLines,
   ...props
 }: TextProps) {
-  // maxLines<=0 means "no limit" (web treats it as falsy); fall back to the caller's
-  // own numberOfLines when neither maxLines nor nowrap is set.
+  // maxLines<=0 means "no limit"; fall back to caller's numberOfLines when unset.
   const clamped = maxLines != null && maxLines > 0;
   const clampLines = clamped ? maxLines : nowrap ? 1 : numberOfLines;
   const ellipsizeMode = clamped ? "tail" : nowrap ? "clip" : undefined;
@@ -91,7 +78,6 @@ function Text({
       numberOfLines={clampLines}
       ellipsizeMode={ellipsizeMode}
       // `px-2` = 2px: mobile's spacing scale is pixel-valued, not web Tailwind's 8px.
-      // Matches web Opal Text's `px-[2px]` — on-scale token, not `[2px]`.
       className={cn("px-2", FONT_CONFIG[font], COLOR_CONFIG[color], className)}
       {...props}
     />

--- a/mobile/src/hooks/useCurrentUser.ts
+++ b/mobile/src/hooks/useCurrentUser.ts
@@ -1,4 +1,3 @@
-// Fetches the authenticated user from `/api/me` — the auth gate's identity probe.
 import { useQuery } from "@tanstack/react-query";
 
 import { apiFetch } from "@/api/client";
@@ -10,7 +9,7 @@ export function useCurrentUser() {
   const serverUrl = useSession((state) => state.serverUrl);
   return useQuery({
     queryKey: QUERY_KEYS.me(serverUrl),
-    // Idle until connected: no serverUrl → `getBaseUrl()` throws (not a 401). Like `useAuthConfig`.
+    // No serverUrl → `getBaseUrl()` throws (not a 401), so stay idle until connected.
     enabled: serverUrl !== null,
     queryFn: ({ signal }) => apiFetch<CurrentUser>("/me", { signal }),
   });

--- a/mobile/src/icons/alert-circle.tsx
+++ b/mobile/src/icons/alert-circle.tsx
@@ -2,7 +2,6 @@ import Svg, { Circle, Path } from "react-native-svg";
 
 import type { IconProps } from "@/icons/types";
 
-// RN variant of web Opal `SvgAlertCircle` (web/lib/opal/src/icons/alert-circle.tsx).
 const SvgAlertCircle = ({ size = 16, ...props }: IconProps) => (
   <Svg
     width={size}

--- a/mobile/src/icons/arrow-right-circle.tsx
+++ b/mobile/src/icons/arrow-right-circle.tsx
@@ -2,7 +2,6 @@ import Svg, { Path } from "react-native-svg";
 
 import type { IconProps } from "@/icons/types";
 
-// RN port of web Opal `SvgArrowRightCircle` (web/lib/opal/src/icons/arrow-right-circle.tsx).
 const SvgArrowRightCircle = ({ size = 16, ...props }: IconProps) => (
   <Svg
     width={size}

--- a/mobile/src/icons/bubble-text.tsx
+++ b/mobile/src/icons/bubble-text.tsx
@@ -2,7 +2,6 @@ import Svg, { Path } from "react-native-svg";
 
 import type { IconProps } from "@/icons/types";
 
-// RN variant of web Opal `SvgBubbleText` (web/lib/opal/src/icons/bubble-text.tsx).
 const SvgBubbleText = ({ size = 16, ...props }: IconProps) => (
   <Svg
     width={size}

--- a/mobile/src/icons/eye-closed.tsx
+++ b/mobile/src/icons/eye-closed.tsx
@@ -2,7 +2,6 @@ import Svg, { Path } from "react-native-svg";
 
 import type { IconProps } from "@/icons/types";
 
-// RN variant of web Opal `SvgEyeClosed` (web/lib/opal/src/icons/eye-closed.tsx).
 const SvgEyeClosed = ({ size = 16, ...props }: IconProps) => (
   <Svg
     width={size}

--- a/mobile/src/icons/eye.tsx
+++ b/mobile/src/icons/eye.tsx
@@ -2,7 +2,6 @@ import Svg, { Path } from "react-native-svg";
 
 import type { IconProps } from "@/icons/types";
 
-// RN variant of web Opal `SvgEye` (web/lib/opal/src/icons/eye.tsx).
 const SvgEye = ({ size = 16, ...props }: IconProps) => (
   <Svg
     width={size}

--- a/mobile/src/icons/folder.tsx
+++ b/mobile/src/icons/folder.tsx
@@ -2,7 +2,6 @@ import Svg, { Path } from "react-native-svg";
 
 import type { IconProps } from "@/icons/types";
 
-// RN variant of web Opal `SvgFolder` (web/lib/opal/src/icons/folder.tsx).
 const SvgFolder = ({ size = 16, ...props }: IconProps) => (
   <Svg
     width={size}

--- a/mobile/src/icons/onyx-logo.tsx
+++ b/mobile/src/icons/onyx-logo.tsx
@@ -2,8 +2,7 @@ import Svg, { Path } from "react-native-svg";
 
 import type { IconProps } from "@/icons/types";
 
-// RN port of web Opal `SvgOnyxLogo`. Paths use `currentColor` (RN can't read the CSS var
-// web fills with), tinted via `<Icon as={SvgOnyxLogo} className="text-theme-primary-05" />`.
+// Paths fill with `currentColor` (RN can't read a CSS var), tinted via the `Icon` color class.
 const SvgOnyxLogo = ({ size = 16, ...props }: IconProps) => (
   <Svg
     width={size}

--- a/mobile/src/icons/plus.tsx
+++ b/mobile/src/icons/plus.tsx
@@ -2,7 +2,6 @@ import Svg, { Path } from "react-native-svg";
 
 import type { IconProps } from "@/icons/types";
 
-// RN variant of web Opal `SvgPlus` (web/lib/opal/src/icons/plus.tsx).
 const SvgPlus = ({ size = 16, ...props }: IconProps) => (
   <Svg
     width={size}

--- a/mobile/src/icons/search.tsx
+++ b/mobile/src/icons/search.tsx
@@ -2,7 +2,6 @@ import Svg, { Path } from "react-native-svg";
 
 import type { IconProps } from "@/icons/types";
 
-// RN variant of web Opal `SvgSearch` (web/lib/opal/src/icons/search.tsx).
 const SvgSearch = ({ size = 16, ...props }: IconProps) => (
   <Svg
     width={size}

--- a/mobile/src/icons/settings.tsx
+++ b/mobile/src/icons/settings.tsx
@@ -2,9 +2,7 @@ import Svg, { Path } from "react-native-svg";
 
 import type { IconProps } from "@/icons/types";
 
-// RN variant of web Opal `SvgSettings` (web/lib/opal/src/icons/settings.tsx). The
-// web source wraps the paths in a clipPath bounded to the full 16x16 viewBox (a
-// visual no-op), so it's omitted here.
+// clipPath bounded to the full 16x16 viewBox is a visual no-op, so it's omitted.
 const SvgSettings = ({ size = 16, ...props }: IconProps) => (
   <Svg
     width={size}

--- a/mobile/src/icons/sidebar.tsx
+++ b/mobile/src/icons/sidebar.tsx
@@ -2,7 +2,6 @@ import Svg, { Path } from "react-native-svg";
 
 import type { IconProps } from "@/icons/types";
 
-// RN variant of web Opal `SvgSidebar` (web/lib/opal/src/icons/sidebar.tsx).
 const SvgSidebar = ({ size = 16, ...props }: IconProps) => (
   <Svg
     width={size}

--- a/mobile/src/icons/types.ts
+++ b/mobile/src/icons/types.ts
@@ -1,10 +1,8 @@
 import type * as React from "react";
 import type { SvgProps } from "react-native-svg";
 
-// React Native counterpart of web Opal's icon types (web/lib/opal/src/types.ts).
-// Same shape, retargeted to react-native-svg. Icons render with
-// `stroke="currentColor"`, so color flows from the `color` prop — the `Icon`
-// wrapper (components/ui/icon.tsx) sets it from a `text-*` token class.
+// Icons render with `stroke="currentColor"`; color flows from the `color` prop,
+// which the `Icon` wrapper sets from a `text-*` token class.
 export interface IconProps extends SvgProps {
   className?: string;
   size?: number;

--- a/mobile/src/icons/x-octagon.tsx
+++ b/mobile/src/icons/x-octagon.tsx
@@ -2,7 +2,6 @@ import Svg, { Path } from "react-native-svg";
 
 import type { IconProps } from "@/icons/types";
 
-// RN variant of web Opal `SvgXOctagon` (web/lib/opal/src/icons/x-octagon.tsx).
 const SvgXOctagon = ({ size = 16, ...props }: IconProps) => (
   <Svg
     width={size}

--- a/mobile/src/icons/x.tsx
+++ b/mobile/src/icons/x.tsx
@@ -2,7 +2,6 @@ import Svg, { Path } from "react-native-svg";
 
 import type { IconProps } from "@/icons/types";
 
-// RN variant of web Opal `SvgX` (web/lib/opal/src/icons/x.tsx).
 const SvgX = ({ size = 16, ...props }: IconProps) => (
   <Svg
     width={size}

--- a/mobile/src/lib/utils.ts
+++ b/mobile/src/lib/utils.ts
@@ -1,9 +1,7 @@
 import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 
-// Single class-merge helper for every UI component (mirrors web's @/lib/utils `cn`).
-// clsx flattens conditionals/arrays; twMerge resolves conflicting Tailwind utilities
-// so a later class (e.g. an explicit `text-text-02`) wins over a base default.
+// twMerge resolves conflicting Tailwind utilities so a later class wins over a base default.
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }

--- a/mobile/src/query/client.ts
+++ b/mobile/src/query/client.ts
@@ -5,16 +5,14 @@ import { makeMmkvStorage, queryStorage } from "@/state/storage";
 import { isAuthError } from "@/api/errors";
 import { QUERY_KEYS } from "@/api/query-keys";
 
-// gcTime is pinned to this below; if an inactive query is GC'd before the persist
-// window, the persister rewrites an empty snapshot and the offline cache collapses.
-export const persistMaxAge = 1000 * 60 * 60 * 24; // 24h
+export const persistMaxAge = 1000 * 60 * 60 * 24;
 
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: 30_000,
-      gcTime: persistMaxAge, // must cover the persist window, see persistMaxAge
-      // Don't retry auth/tier errors (401/402/403); they can't succeed without re-auth.
+      gcTime: persistMaxAge, // must cover the persist window or the offline cache collapses
+      // 401/402/403 can't succeed without re-auth.
       retry: (failureCount, error) => !isAuthError(error) && failureCount < 1,
       // Must stay true or the AppState->focusManager bridge in query/focus.ts no-ops.
       refetchOnWindowFocus: true,
@@ -27,10 +25,8 @@ export const persister = createSyncStoragePersister({
   storage: makeMmkvStorage(queryStorage),
 });
 
-// Key prefixes whose data must not hit the unencrypted MMKV snapshot (PII).
-// /api/me (email, role) is the only one today; in-memory cache still holds it,
-// so a relaunch just refetches. Only the leading entity segment forms the prefix
-// since the trailing serverUrl varies per instance.
+// PII prefixes excluded from the unencrypted MMKV snapshot; only the leading entity
+// segment matches since the trailing serverUrl varies per instance.
 const NON_PERSISTED_KEY_PREFIXES: readonly (readonly unknown[])[] = [
   [QUERY_KEYS.me(null)[0]],
 ];
@@ -44,7 +40,6 @@ function isNonPersistedKey(queryKey: readonly unknown[]): boolean {
 export const dehydrateOptions: DehydrateOptions = {
   shouldDehydrateQuery: (query) => {
     if (isNonPersistedKey(query.queryKey)) return false;
-    // Library default: only persist successful queries.
     return query.state.status === "success";
   },
 };

--- a/mobile/src/query/focus.ts
+++ b/mobile/src/query/focus.ts
@@ -1,4 +1,4 @@
-// Bridges RN AppState into TanStack focusManager: the mobile equivalent of browser window-focus refetching.
+// RN AppState -> focusManager: the mobile equivalent of browser window-focus refetching.
 import { AppState, type AppStateStatus } from "react-native";
 import { focusManager } from "@tanstack/react-query";
 

--- a/mobile/src/query/online.ts
+++ b/mobile/src/query/online.ts
@@ -1,11 +1,10 @@
-// Without this, TanStack assumes always-online: offline queries retry-loop and refetchOnReconnect never fires.
+// Without this, TanStack assumes always-online and refetchOnReconnect never fires.
 import NetInfo from "@react-native-community/netinfo";
 import { onlineManager } from "@tanstack/react-query";
 
-// Call once at app startup.
 export function bindOnlineManager(): () => void {
   return NetInfo.addEventListener((state) => {
-    // isInternetReachable is null until NetInfo resolves; treat as online to avoid false offline flashes.
+    // isInternetReachable is null until NetInfo resolves; treat as online.
     onlineManager.setOnline(
       Boolean(state.isConnected) && state.isInternetReachable !== false,
     );

--- a/mobile/src/state/session.ts
+++ b/mobile/src/state/session.ts
@@ -1,10 +1,7 @@
-// Auth-session store: the Onyx instance URL we target + a coarse auth status.
-//
-// `serverUrl` persists straight to MMKV (not via zustand's persist) because the HTTP
-// layer (`config.ts#getBaseUrl`) reads it *synchronously*, once per request, through
-// `getStoredServerUrl`. `status` is in-memory only: `useCurrentUser` (/api/me) is the
-// authoritative identity check, except `"anon"` (explicit logout / rejected token), which
-// the auth gate treats as a decisive logged-out signal.
+// `serverUrl` persists straight to MMKV (not zustand's persist) because the HTTP layer
+// reads it synchronously per request via getStoredServerUrl. `status` is in-memory only;
+// /api/me is the authoritative identity check, except "anon" which the gate treats as a
+// decisive logged-out signal.
 import { create } from "zustand";
 
 import { appStorage } from "@/state/storage";

--- a/mobile/src/state/storage.ts
+++ b/mobile/src/state/storage.ts
@@ -1,8 +1,5 @@
-// MMKV instances + a string storage adapter shared by TanStack Query's persister
-// and (later) zustand's `persist` middleware.
-//
-// react-native-mmkv v4 has NO `new MMKV()` — use the createMMKV factory. Two
-// separate instances so a query-cache clear can't touch other persisted state.
+// react-native-mmkv v4 has no `new MMKV()` — use createMMKV. Two separate instances so a
+// query-cache clear can't touch other persisted state.
 import { createMMKV, type MMKV } from "react-native-mmkv";
 
 export const appStorage: MMKV = createMMKV({ id: "onyx.app" });

--- a/mobile/tailwind.config.js
+++ b/mobile/tailwind.config.js
@@ -1,10 +1,5 @@
-// Design tokens come from @onyx-ai/shared (the same source of truth as web/Opal).
-// `nativewind-theme` is a Tailwind `theme.extend` fragment: semantic colors map to
-// `var(--name)` (resolved at runtime by the vars() provider in src/app/_layout.tsx,
-// so they flip with the system light/dark scheme), and radius/spacing are px numbers.
+// Semantic colors map to `var(--name)`, resolved/flipped at runtime by the vars() provider in _layout.tsx.
 const sharedTheme = require("@onyx-ai/shared/nativewind-theme");
-// `.font-*` → RN-text-style map (RN counterpart of web/Opal's `@utility font-*`
-// blocks), registered below so mobile can use `font-heading-h1` etc. like web.
 const typographyUtilities = require("@onyx-ai/shared/nativewind-typography");
 const plugin = require("tailwindcss/plugin");
 


### PR DESCRIPTION
## Description

- Shorten or remove explanatory comments across the mobile app, keeping only the non-obvious invariants (token-before-purge, session-epoch guard, single-flight refresh, NativeWind `gap`/spacing caveats, keychain accessibility, etc.). Comment/JSDoc-only — no behavior change.
- Fix eslint so value imports of `@onyx-ai/shared` `exports` subpaths (e.g. `/native`) resolve: `eslint-config-expo`'s TS override had replaced `import/resolver` with a node-only resolver that ignores `package.json` `exports`; re-enable the exports-aware TypeScript resolver.

## How Has This Been Tested?

`bunx expo lint` and the mobile type-check pass (0 errors); no runtime behavior changed.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check