### PR TITLE
feat(craft): make sandbox timing knobs configurable

### DIFF
--- a/.github/workflows/pr-craft-compose-integration.yml
+++ b/.github/workflows/pr-craft-compose-integration.yml
@@ -164,6 +164,7 @@ jobs:
             echo 'BUILD_MAX_UPLOAD_FILES_PER_SESSION=5'
             echo 'BUILD_MAX_TOTAL_UPLOAD_SIZE_MB=4'
             echo 'USER_LIBRARY_MAX_FILES_PER_UPLOAD=5'
+            echo 'SANDBOX_IDLE_CLEANUP_INTERVAL_SECONDS=10'
           } > .env
 
       # Raw docker compose (ods compose has no craft overlay yet). Only

--- a/backend/onyx/background/celery/tasks/beat_schedule.py
+++ b/backend/onyx/background/celery/tasks/beat_schedule.py
@@ -16,6 +16,7 @@ from onyx.configs.constants import ONYX_CLOUD_CELERY_TASK_PREFIX
 from onyx.configs.constants import OnyxCeleryPriority
 from onyx.configs.constants import OnyxCeleryQueues
 from onyx.configs.constants import OnyxCeleryTask
+from onyx.server.features.build.configs import SANDBOX_IDLE_CLEANUP_INTERVAL_SECONDS
 from onyx.utils.variable_functionality import _LICENSE_ENFORCEMENT_ENABLED
 from shared_configs.configs import MULTI_TENANT
 
@@ -182,9 +183,10 @@ beat_task_templates: list[dict] = [
         "name": "cleanup-idle-sandboxes",
         "task": OnyxCeleryTask.CLEANUP_IDLE_SANDBOXES,
         # Ticks are cheap (DB-only when nothing is stale); snapshot pacing is
-        # gated inside the task at idle_timeout/4, so cloud's x8 multiplier
-        # (~8 min effective) still lands under the ~15 min data-loss bound.
-        "schedule": timedelta(minutes=1),
+        # gated inside the task at idle_timeout/4. With the cloud x8 multiplier
+        # the effective interval is SANDBOX_IDLE_CLEANUP_INTERVAL_SECONDS * 8;
+        # keep that product under ~15 min to stay within the data-loss bound.
+        "schedule": timedelta(seconds=SANDBOX_IDLE_CLEANUP_INTERVAL_SECONDS),
         "options": {
             "priority": OnyxCeleryPriority.LOW,
             "expires": BEAT_EXPIRES_DEFAULT,

--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -59,6 +59,7 @@ from onyx.sandbox_proxy.logging_utils import sandbox_log_label
 from onyx.sandbox_proxy.logging_utils import short_log_id
 from onyx.sandbox_proxy.request_evaluator import RequestEvaluator
 from onyx.server.features.build.configs import SANDBOX_API_SERVER_URL
+from onyx.server.features.build.configs import SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS
 from onyx.server.features.build.db import action_approval
 from onyx.utils.logger import setup_logger
 
@@ -972,7 +973,7 @@ class GateAddon:
         cache = self._cache_factory(ctx.tenant_id)
         try:
             decision = await approval_cache.wait_for_wake(
-                approval_id, approval_cache.WAIT_TIMEOUT_S, cache
+                approval_id, SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS, cache
             )
             if decision is not None:
                 logger.info(

--- a/backend/onyx/sandbox_proxy/approval_cache.py
+++ b/backend/onyx/sandbox_proxy/approval_cache.py
@@ -7,7 +7,7 @@ here is best-effort over `CacheBackend`. Two lists:
   row; the chat-stream merger BLPOPs to emit the card on the live SSE
   stream. A miss degrades to the FE's next `/live` refetch.
 * `approval:wake:{approval_id}` — api-server RPUSHes when a decision is
-  recorded; the parked proxy BLPOPs to wake before `WAIT_TIMEOUT_S`.
+  recorded; the parked proxy BLPOPs to wake before the wait timeout.
 """
 
 import asyncio
@@ -16,10 +16,6 @@ from uuid import UUID
 
 from onyx.cache.interface import CacheBackend
 from onyx.db.enums import ApprovalDecision
-
-# Max time the proxy parks on one approval; also the `/live` window
-# past which a `decision IS NULL` row is treated as orphaned.
-WAIT_TIMEOUT_S = 180
 
 # Only need to outlive the gap between RPUSH and the consumer's BLPOP.
 ANNOUNCE_TTL_S = 60
@@ -115,7 +111,7 @@ async def wait_for_wake(
 def send_wake(
     approval_id: UUID, decision: ApprovalDecision, cache: CacheBackend
 ) -> None:
-    """Wake the parked proxy. A miss just means it waits out `WAIT_TIMEOUT_S`."""
+    """Wake the parked proxy. A miss just means it waits out the wait timeout."""
     cache.rpush(_wake_key(approval_id), decision.value)
     cache.expire(_wake_key(approval_id), WAKE_TTL_S)
 

--- a/backend/onyx/sandbox_proxy/approval_cache.py
+++ b/backend/onyx/sandbox_proxy/approval_cache.py
@@ -11,6 +11,7 @@ here is best-effort over `CacheBackend`. Two lists:
 """
 
 import asyncio
+import time
 from collections.abc import Iterable
 from uuid import UUID
 
@@ -96,16 +97,28 @@ async def wait_for_wake(
     approval_id: UUID, timeout_s: int, cache: CacheBackend
 ) -> ApprovalDecision | None:
     """Block for a decision. `None` on timeout/unparseable payload (caller re-reads the row)."""
-    result = await asyncio.to_thread(cache.blpop, [_wake_key(approval_id)], timeout_s)
-    if result is None:
+    if timeout_s <= 0:
         return None
-    _key, value = result
-    if isinstance(value, bytes):
-        value = value.decode()
-    try:
-        return ApprovalDecision(value)
-    except ValueError:
-        return None
+
+    deadline = time.monotonic() + timeout_s
+    while True:
+        remaining_s = deadline - time.monotonic()
+        if remaining_s <= 0:
+            return None
+
+        # `asyncio.to_thread` cannot cancel an in-flight BLPOP, so keep each
+        # blocking call short even when the overall wait is configured higher.
+        result = await asyncio.to_thread(cache.blpop, [_wake_key(approval_id)], 1)
+        if result is None:
+            continue
+
+        _key, value = result
+        if isinstance(value, bytes):
+            value = value.decode()
+        try:
+            return ApprovalDecision(value)
+        except ValueError:
+            return None
 
 
 def send_wake(

--- a/backend/onyx/server/features/build/AGENTS.template.md
+++ b/backend/onyx/server/features/build/AGENTS.template.md
@@ -64,9 +64,11 @@ You hold no API keys or tokens, and never need them: the proxy injects the real 
 automatically. Empty or placeholder auth headers are expected.
 
 Actions that change external state (e.g. posting a Slack message, creating a Linear issue, sending
-email) may be gated. The request pauses at the proxy for user approval for up to **3 minutes**.
+email) may be gated. The request pauses at the proxy for user approval for up to
+**{{APPROVAL_WAIT_TIMEOUT_SECONDS}} seconds**.
 
-If you make a network call (e.g. `curl`), set a client timeout of **at least 200 seconds** 
+If you make a network call (e.g. `curl`), set a client timeout of
+**at least {{APPROVAL_CLIENT_TIMEOUT_SECONDS}} seconds**
 so you don't give up before the user decides.
 
 On rejection, timeout, or a disabled action, the call returns HTTP 403 with a JSON

--- a/backend/onyx/server/features/build/approvals/api.py
+++ b/backend/onyx/server/features/build/approvals/api.py
@@ -34,6 +34,7 @@ from onyx.external_apps.matching.engine import actions_requiring_approval
 from onyx.external_apps.matching.engine import MatchedAction
 from onyx.external_apps.presentation.decode import decode_payload
 from onyx.sandbox_proxy import approval_cache
+from onyx.server.features.build.configs import SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS
 from onyx.server.features.build.db import action_approval
 from onyx.server.features.build.db.build_session import get_build_session
 from onyx.utils.logger import setup_logger
@@ -78,7 +79,7 @@ class ApprovalView(BaseModel):
         if self.decision is not None:
             return False
         cutoff = datetime.now(timezone.utc) - timedelta(
-            seconds=approval_cache.WAIT_TIMEOUT_S
+            seconds=SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS
         )
         return self.created_at >= cutoff
 
@@ -133,7 +134,7 @@ def list_live_approvals(
         raise OnyxError(OnyxErrorCode.NOT_FOUND, "session not found")
 
     cutoff = datetime.now(timezone.utc) - timedelta(
-        seconds=approval_cache.WAIT_TIMEOUT_S
+        seconds=SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS
     )
     pending_rows = action_approval.list_session_pending_action_approvals(
         db_session, session_id, created_after=cutoff
@@ -225,7 +226,7 @@ def submit_session_grant(
             "approval request already resolved",
         )
     cutoff = datetime.now(timezone.utc) - timedelta(
-        seconds=approval_cache.WAIT_TIMEOUT_S
+        seconds=SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS
     )
     if current.created_at < cutoff:
         raise OnyxError(

--- a/backend/onyx/server/features/build/configs.py
+++ b/backend/onyx/server/features/build/configs.py
@@ -25,11 +25,18 @@ OPENCODE_DISABLED_TOOLS: list[str] = [
     t.strip() for t in _disabled_tools_str.split(",") if t.strip()
 ]
 
+
 SANDBOX_IDLE_TIMEOUT_SECONDS = int(
     os.environ.get("SANDBOX_IDLE_TIMEOUT_SECONDS", "3600")
 )
 SANDBOX_MAX_CONCURRENT_PER_ORG = int(
     os.environ.get("SANDBOX_MAX_CONCURRENT_PER_ORG", "10")
+)
+SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS = int(
+    os.environ.get("SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS", "180")
+)
+SANDBOX_IDLE_CLEANUP_INTERVAL_SECONDS = int(
+    os.environ.get("SANDBOX_IDLE_CLEANUP_INTERVAL_SECONDS", "60")
 )
 
 SANDBOX_NEXTJS_PORT_START = int(os.environ.get("SANDBOX_NEXTJS_PORT_START", "3010"))

--- a/backend/onyx/server/features/build/sandbox/util/agent_instructions.py
+++ b/backend/onyx/server/features/build/sandbox/util/agent_instructions.py
@@ -4,6 +4,7 @@ from collections.abc import Iterable
 from pathlib import Path
 
 from onyx.db.models import Skill
+from onyx.server.features.build.configs import SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -138,6 +139,14 @@ def generate_agent_instructions(
     content = content.replace("{{LLM_MODEL_NAME}}", model_name or "Unknown")
     content = content.replace(
         "{{NEXTJS_PORT}}", str(nextjs_port) if nextjs_port else "Unknown"
+    )
+    content = content.replace(
+        "{{APPROVAL_WAIT_TIMEOUT_SECONDS}}",
+        str(SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS),
+    )
+    content = content.replace(
+        "{{APPROVAL_CLIENT_TIMEOUT_SECONDS}}",
+        str(SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS + 20),
     )
     content = content.replace("{{DISABLED_TOOLS_SECTION}}", disabled_tools_section)
     content = content.replace("{{AVAILABLE_SKILLS_SECTION}}", skills_section)

--- a/backend/tests/external_dependency_unit/craft/test_approval_gate.py
+++ b/backend/tests/external_dependency_unit/craft/test_approval_gate.py
@@ -52,6 +52,7 @@ from onyx.sandbox_proxy import approval_cache
 from onyx.server.features.build.approvals.api import DecisionBody
 from onyx.server.features.build.approvals.api import list_live_approvals
 from onyx.server.features.build.approvals.api import submit_decision
+from onyx.server.features.build.configs import SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS
 from onyx.server.features.build.configs import SANDBOX_BACKEND
 from onyx.server.features.build.configs import SANDBOX_NAMESPACE
 from onyx.server.features.build.configs import SANDBOX_PROXY_NAMESPACE
@@ -79,9 +80,7 @@ _PROXY_COMPONENT_LABEL = "app.kubernetes.io/component=sandbox-proxy"
 # Matches catalog action ``slack.messages.write``.
 _SLACK_POST_MESSAGE_URL = "https://slack.com/api/chat.postMessage"
 
-# Spec value for approval_cache.WAIT_TIMEOUT_S; pinned by
-# test_wait_timeout_constant_matches_spec.
-_WAIT_TIMEOUT_S_SPEC = 180
+_APPROVAL_WAIT_TIMEOUT_S = SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -385,7 +384,7 @@ def test_expired_on_wait_timeout(
     gated_session: tuple[User, UUID, str],
     db_session: Session,
 ) -> None:
-    """No decision → proxy claims EXPIRED after ``WAIT_TIMEOUT_S``.
+    """No decision → proxy claims EXPIRED after the approval wait timeout.
 
     curl's --max-time must outlive the spec window so we see the proxy's 403
     rather than the client tearing down first.
@@ -398,14 +397,14 @@ def test_expired_on_wait_timeout(
         pod_name,
         output_path,
         text="never decided",
-        max_time_s=_WAIT_TIMEOUT_S_SPEC + 60,
+        max_time_s=_APPROVAL_WAIT_TIMEOUT_S + 60,
         session_id=session_id,
     )
 
     pending = _wait_for_pending_approval(db_session, session_id)
 
     status_code, body = wait_for_pod_exec_output(
-        k8s_client, pod_name, output_path, timeout_s=_WAIT_TIMEOUT_S_SPEC + 30
+        k8s_client, pod_name, output_path, timeout_s=_APPROVAL_WAIT_TIMEOUT_S + 30
     )
     assert status_code == 403, (
         f"sandbox-side curl after timeout should see 403, got {status_code}: {body!r}"
@@ -418,11 +417,6 @@ def test_expired_on_wait_timeout(
     assert refreshed.decision == ApprovalDecision.EXPIRED
 
 
-def test_wait_timeout_constant_matches_spec() -> None:
-    """``approval_cache.WAIT_TIMEOUT_S`` must equal the value tests assume."""
-    assert approval_cache.WAIT_TIMEOUT_S == _WAIT_TIMEOUT_S_SPEC
-
-
 def test_sigterm_drain_unblocks_parked_request(
     k8s_manager: object,  # noqa: ARG001
     k8s_client: client.CoreV1Api,
@@ -431,7 +425,7 @@ def test_sigterm_drain_unblocks_parked_request(
 ) -> None:
     """Deleting the parked proxy pod must drain → wake → EXPIRED.
 
-    Without the drain hook the curl would hang until ``WAIT_TIMEOUT_S``; we
+    Without the drain hook the curl would hang until the wait timeout; we
     assert it unblocks well inside that window.
     """
     _, session_id, pod_name = gated_session
@@ -761,7 +755,7 @@ def test_list_live_excludes_aged_pending_rows(
     gated_session: tuple[User, UUID, str],
     db_session: Session,
 ) -> None:
-    """Pending rows older than ``WAIT_TIMEOUT_S`` are excluded from /live.
+    """Pending rows older than the approval wait timeout are excluded from /live.
 
     Two boundary rows (5s either side of the cutoff) make an off-by-one in the
     ``created_after`` filter (``>=`` vs ``>``) fail this test.
@@ -800,7 +794,7 @@ def test_list_live_excludes_aged_pending_rows(
             actions=slack_actions,
             app_name="Slack",
             payload={"boundary": "just_live"},
-            created_at=now - timedelta(seconds=_WAIT_TIMEOUT_S_SPEC - 5),
+            created_at=now - timedelta(seconds=_APPROVAL_WAIT_TIMEOUT_S - 5),
         )
     )
     db_session.add(
@@ -810,7 +804,7 @@ def test_list_live_excludes_aged_pending_rows(
             actions=slack_actions,
             app_name="Slack",
             payload={"boundary": "just_expired"},
-            created_at=now - timedelta(seconds=_WAIT_TIMEOUT_S_SPEC + 5),
+            created_at=now - timedelta(seconds=_APPROVAL_WAIT_TIMEOUT_S + 5),
         )
     )
     db_session.commit()
@@ -821,16 +815,18 @@ def test_list_live_excludes_aged_pending_rows(
     )
     boundary_ids = {item.approval_id for item in boundary.items}
     assert just_live_id in boundary_ids, (
-        f"Row created {_WAIT_TIMEOUT_S_SPEC - 5}s ago should be live "
+        f"Row created {_APPROVAL_WAIT_TIMEOUT_S - 5}s ago should be live "
         f"(cutoff edge), got: {boundary_ids}"
     )
     assert just_expired_id not in boundary_ids, (
-        f"Row created {_WAIT_TIMEOUT_S_SPEC + 5}s ago should be excluded "
+        f"Row created {_APPROVAL_WAIT_TIMEOUT_S + 5}s ago should be excluded "
         f"(just past cutoff), got: {boundary_ids}"
     )
 
     # Backdate well past the cutoff so the parked row drops out of /live.
-    aged_at = datetime.now(timezone.utc) - timedelta(seconds=_WAIT_TIMEOUT_S_SPEC + 60)
+    aged_at = datetime.now(timezone.utc) - timedelta(
+        seconds=_APPROVAL_WAIT_TIMEOUT_S + 60
+    )
     db_session.execute(
         text("UPDATE action_approval SET created_at = :ts WHERE approval_id = :aid"),
         {"ts": aged_at, "aid": pending.approval_id},
@@ -880,7 +876,7 @@ def test_row_missing_on_claim_returns_expired(
         pod_name,
         output_path,
         text="drop me",
-        max_time_s=_WAIT_TIMEOUT_S_SPEC + 60,
+        max_time_s=_APPROVAL_WAIT_TIMEOUT_S + 60,
         session_id=session_id,
     )
 
@@ -894,7 +890,7 @@ def test_row_missing_on_claim_returns_expired(
     db_session.commit()
 
     status_code, body = wait_for_pod_exec_output(
-        k8s_client, pod_name, output_path, timeout_s=_WAIT_TIMEOUT_S_SPEC + 30
+        k8s_client, pod_name, output_path, timeout_s=_APPROVAL_WAIT_TIMEOUT_S + 30
     )
     assert status_code == 403, (
         f"sandbox-side curl after row-missing claim should see 403, "
@@ -937,7 +933,7 @@ def test_post_decision_after_proxy_claimed_expired_returns_conflict(
         pod_name,
         output_path,
         text="conflict me",
-        max_time_s=_WAIT_TIMEOUT_S_SPEC + 60,
+        max_time_s=_APPROVAL_WAIT_TIMEOUT_S + 60,
         session_id=session_id,
     )
 
@@ -945,7 +941,7 @@ def test_post_decision_after_proxy_claimed_expired_returns_conflict(
 
     # Wait out the park window so the proxy claims EXPIRED.
     status_code, body = wait_for_pod_exec_output(
-        k8s_client, pod_name, output_path, timeout_s=_WAIT_TIMEOUT_S_SPEC + 30
+        k8s_client, pod_name, output_path, timeout_s=_APPROVAL_WAIT_TIMEOUT_S + 30
     )
     assert status_code == 403, (
         f"Expected 403 after wait-timeout, got {status_code}: {body!r}"

--- a/backend/tests/external_dependency_unit/craft/test_approvals_api.py
+++ b/backend/tests/external_dependency_unit/craft/test_approvals_api.py
@@ -27,6 +27,7 @@ from onyx.server.features.build.approvals.api import DecisionBody
 from onyx.server.features.build.approvals.api import list_live_approvals
 from onyx.server.features.build.approvals.api import submit_decision
 from onyx.server.features.build.approvals.api import submit_session_grant
+from onyx.server.features.build.configs import SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS
 from onyx.server.features.build.db import action_approval
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from tests.common.craft.payloads import action_entry
@@ -39,14 +40,6 @@ from tests.external_dependency_unit.craft.db_helpers import make_user
 
 def _stub_send_wake_noop(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(approval_cache, "send_wake", lambda *_args, **_kwargs: None)
-
-
-# Hardcoded spec; the completeness check below pins the source constant to it.
-WAIT_TIMEOUT_S_SPEC = 180
-
-
-def test_wait_timeout_spec() -> None:
-    assert approval_cache.WAIT_TIMEOUT_S == WAIT_TIMEOUT_S_SPEC
 
 
 # --------------------------------------------------------------------------- #
@@ -92,8 +85,9 @@ def test_list_live_approvals_filter_logic(
     assert result is not None
     db_session.commit()
 
-    # Push the stale row just past the 180s spec cutoff (hardcoded, not derived).
-    stale_when = datetime.now(timezone.utc) - timedelta(seconds=190)
+    stale_when = datetime.now(timezone.utc) - timedelta(
+        seconds=SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS + 10
+    )
     force_approval_created_at(db_session, stale.approval_id, stale_when)
 
     response = list_live_approvals(

--- a/backend/tests/external_dependency_unit/sandbox_proxy/test_approval_cache.py
+++ b/backend/tests/external_dependency_unit/sandbox_proxy/test_approval_cache.py
@@ -45,7 +45,6 @@ def test_announce_applies_ttl() -> None:
     announce_approval(uuid4(), session_id, cache)
     remaining = cache.ttl(announce_key(session_id))
 
-    # Hardcoded spec; test_approval_decision_values_complete pins the constant.
     assert 0 < remaining <= 60
 
 
@@ -113,7 +112,6 @@ def test_send_wake_applies_ttl() -> None:
     send_wake(approval_id, ApprovalDecision.APPROVED, cache)
     remaining = cache.ttl(_wake_key(approval_id))
 
-    # Hardcoded spec; the completeness check below pins the constant.
     assert 0 < remaining <= 30
 
 
@@ -170,8 +168,7 @@ def test_cached_session_grants_cover_requires_every_action() -> None:
 
 @pytest.mark.asyncio
 async def test_decision_value_round_trips() -> None:
-    """Pins the enum → bytes → enum encoding; the completeness check below
-    independently pins the full enum value set."""
+    """Pins the enum → bytes → enum encoding."""
     cache = get_cache_backend(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     approval_id = uuid4()
 
@@ -182,10 +179,7 @@ async def test_decision_value_round_trips() -> None:
 
 
 def test_approval_decision_values_complete() -> None:
-    """Pins the full `ApprovalDecision` value set and the cache-layer TTL
-    constants to their spec values (the TTL bound checks elsewhere hardcode
-    the same specs)."""
+    """Pins the full `ApprovalDecision` value set and cache-layer TTL constants."""
     assert {d.value for d in ApprovalDecision} == {"APPROVED", "REJECTED", "EXPIRED"}
     assert approval_cache_module.ANNOUNCE_TTL_S == 60
     assert approval_cache_module.WAKE_TTL_S == 30
-    assert approval_cache_module.WAIT_TIMEOUT_S == 180

--- a/backend/tests/unit/build/test_sandbox_backend_parsing.py
+++ b/backend/tests/unit/build/test_sandbox_backend_parsing.py
@@ -14,7 +14,9 @@ def _restore_configs() -> Iterator[None]:
     # to leave clean module state for other tests.
     yield
     os.environ.pop("SANDBOX_BACKEND", None)
+    os.environ.pop("SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS", None)
     os.environ.pop("SANDBOX_CONTAINER_IMAGE", None)
+    os.environ.pop("SANDBOX_IDLE_CLEANUP_INTERVAL_SECONDS", None)
     os.environ.pop("ONYX_VERSION", None)
     importlib.reload(configs)
 
@@ -95,3 +97,27 @@ def test_blank_sandbox_image_override_does_not_emit_blank_image(
     reloaded = importlib.reload(configs)
 
     assert reloaded.SANDBOX_CONTAINER_IMAGE == "onyxdotapp/sandbox:latest"
+
+
+def test_sandbox_timing_defaults_match_existing_behavior(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS", raising=False)
+    monkeypatch.delenv("SANDBOX_IDLE_CLEANUP_INTERVAL_SECONDS", raising=False)
+
+    reloaded = importlib.reload(configs)
+
+    assert reloaded.SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS == 180
+    assert reloaded.SANDBOX_IDLE_CLEANUP_INTERVAL_SECONDS == 60
+
+
+def test_sandbox_timing_env_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS", "20")
+    monkeypatch.setenv("SANDBOX_IDLE_CLEANUP_INTERVAL_SECONDS", "10")
+
+    reloaded = importlib.reload(configs)
+
+    assert reloaded.SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS == 20
+    assert reloaded.SANDBOX_IDLE_CLEANUP_INTERVAL_SECONDS == 10

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_agent_instructions.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_agent_instructions.py
@@ -1,0 +1,70 @@
+import re
+from pathlib import Path
+
+import pytest
+
+from onyx.server.features.build.sandbox.util import agent_instructions
+
+_TEMPLATE_PLACEHOLDER_RE = re.compile(r"{{[A-Z0-9_]+}}")
+
+
+def _template_path() -> Path:
+    return Path(agent_instructions.__file__).parents[2] / "AGENTS.template.md"
+
+
+def _unresolved_placeholders(content: str) -> set[str]:
+    return set(_TEMPLATE_PLACEHOLDER_RE.findall(content))
+
+
+def test_generate_agent_instructions_uses_configured_approval_timeouts_in_real_template(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        agent_instructions, "SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS", 240
+    )
+
+    content = agent_instructions.generate_agent_instructions(
+        template_path=_template_path(),
+        skills_section="",
+    )
+
+    assert "240 seconds" in content
+    assert "260 seconds" in content
+    assert "3 minutes" not in content
+    assert "200 seconds" not in content
+    assert _unresolved_placeholders(content) == set()
+
+
+def test_generate_agent_instructions_populates_real_template_runtime_values() -> None:
+    skills_section = "- **company-search**: SENTINEL_SKILL_DESCRIPTION"
+
+    content = agent_instructions.generate_agent_instructions(
+        template_path=_template_path(),
+        skills_section=skills_section,
+        provider="openai",
+        model_name="gpt-5-mini",
+        nextjs_port=3210,
+        disabled_tools=["web-search", "shell"],
+        user_name="TEST_USER",
+    )
+
+    assert "TEST_USER" in content
+    assert "3210" in content
+    assert "OpenAI / gpt-5-mini" in content
+    assert "web-search, shell" in content
+    assert skills_section in content
+    assert _unresolved_placeholders(content) == set()
+
+
+def test_generate_agent_instructions_omits_optional_sections_when_values_absent() -> (
+    None
+):
+    content = agent_instructions.generate_agent_instructions(
+        template_path=_template_path(),
+        skills_section="SENTINEL_NO_SKILLS",
+    )
+
+    assert "You are assisting **" not in content
+    assert "**Disabled Tools**" not in content
+    assert "SENTINEL_NO_SKILLS" in content
+    assert _unresolved_placeholders(content) == set()

--- a/backend/tests/unit/sandbox_proxy/test_approval_cache.py
+++ b/backend/tests/unit/sandbox_proxy/test_approval_cache.py
@@ -1,15 +1,22 @@
 from uuid import uuid4
 
+import pytest
+
 from onyx.cache.interface import CacheBackend
 from onyx.cache.interface import CacheLock
+from onyx.db.enums import ApprovalDecision
+from onyx.sandbox_proxy.approval_cache import _wake_key
 from onyx.sandbox_proxy.approval_cache import cache_session_grant_actions
 from onyx.sandbox_proxy.approval_cache import cached_session_grants_cover
+from onyx.sandbox_proxy.approval_cache import wait_for_wake
 
 
 class _MemoryCache(CacheBackend):
     def __init__(self) -> None:
         self.values: dict[str, bytes] = {}
         self.expirations: list[tuple[str, int]] = []
+        self.blpop_result: tuple[bytes, bytes] | None = None
+        self.blpop_calls: list[tuple[list[str], int]] = []
 
     def get(self, key: str) -> bytes | None:
         return self.values.get(key)
@@ -42,8 +49,24 @@ class _MemoryCache(CacheBackend):
     def rpush(self, key: str, value: str | bytes) -> None:  # noqa: ARG002
         raise NotImplementedError
 
-    def blpop(self, keys: list[str], timeout: int = 0) -> tuple[bytes, bytes] | None:  # noqa: ARG002
-        raise NotImplementedError
+    def blpop(self, keys: list[str], timeout: int = 0) -> tuple[bytes, bytes] | None:
+        self.blpop_calls.append((keys, timeout))
+        return self.blpop_result
+
+
+@pytest.mark.asyncio
+async def test_wait_for_wake_uses_short_poll_timeout() -> None:
+    cache = _MemoryCache()
+    approval_id = uuid4()
+    cache.blpop_result = (
+        _wake_key(approval_id).encode(),
+        ApprovalDecision.APPROVED.value.encode(),
+    )
+
+    decision = await wait_for_wake(approval_id, timeout_s=30, cache=cache)
+
+    assert decision == ApprovalDecision.APPROVED
+    assert cache.blpop_calls == [([_wake_key(approval_id)], 1)]
 
 
 def test_cached_session_grants_cover_requires_every_action() -> None:

--- a/backend/tests/unit/sandbox_proxy/test_gate.py
+++ b/backend/tests/unit/sandbox_proxy/test_gate.py
@@ -1599,8 +1599,9 @@ async def test_await_decision_wake_received_returns_decision(
     ctx = _ctx(tenant_id="tenant-1")
 
     async def _fake_wait_for_wake(
-        _approval_id: UUID, _timeout: int, _cache: Any
+        _approval_id: UUID, timeout: int, _cache: Any
     ) -> ApprovalDecision | None:
+        assert timeout == gate.SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS
         return ApprovalDecision.APPROVED
 
     monkeypatch.setattr(gate.approval_cache, "wait_for_wake", _fake_wait_for_wake)

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -37,12 +37,6 @@ IMAGE_TAG=latest
 ## deployments rarely have headroom to over-commit every sandbox.
 # SANDBOX_DOCKER_MEMORY_LIMIT=2g
 # SANDBOX_DOCKER_CPU_LIMIT=1.0
-#
-## Approval wait window and idle cleanup cadence, in seconds.
-## Lower values are useful for CI; production should generally keep defaults.
-# SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS=180
-# SANDBOX_IDLE_CLEANUP_INTERVAL_SECONDS=60
-#
 ## EC2 IMDS note: on EC2 the Docker daemon's default bridge allows traffic to
 ## 169.254.169.254 (Instance Metadata Service), which can hand out IAM role
 ## credentials. The fix is a host-level DOCKER-USER iptables rule that drops

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -38,6 +38,11 @@ IMAGE_TAG=latest
 # SANDBOX_DOCKER_MEMORY_LIMIT=2g
 # SANDBOX_DOCKER_CPU_LIMIT=1.0
 #
+## Approval wait window and idle cleanup cadence, in seconds.
+## Lower values are useful for CI; production should generally keep defaults.
+# SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS=180
+# SANDBOX_IDLE_CLEANUP_INTERVAL_SECONDS=60
+#
 ## EC2 IMDS note: on EC2 the Docker daemon's default bridge allows traffic to
 ## 169.254.169.254 (Instance Metadata Service), which can hand out IAM role
 ## credentials. The fix is a host-level DOCKER-USER iptables rule that drops

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1534,6 +1534,8 @@ configMap:
   SANDBOX_SERVICE_ACCOUNT_NAME: "sandbox"
   SANDBOX_PROXY_CA_SECRET: "sandbox-proxy-ca"
   SANDBOX_PROXY_CA_CONFIGMAP: "sandbox-proxy-ca-bundle"
+  SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS: "180"
+  SANDBOX_IDLE_CLEANUP_INTERVAL_SECONDS: "60"
 
 # -- Craft sandbox RBAC (rendered when configMap.ENABLE_CRAFT=true).
 craft:

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1534,8 +1534,6 @@ configMap:
   SANDBOX_SERVICE_ACCOUNT_NAME: "sandbox"
   SANDBOX_PROXY_CA_SECRET: "sandbox-proxy-ca"
   SANDBOX_PROXY_CA_CONFIGMAP: "sandbox-proxy-ca-bundle"
-  SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS: "180"
-  SANDBOX_IDLE_CLEANUP_INTERVAL_SECONDS: "60"
 
 # -- Craft sandbox RBAC (rendered when configMap.ENABLE_CRAFT=true).
 craft:


### PR DESCRIPTION
## Description

Makes the Craft sandbox approval wait and idle cleanup timings configurable through shared backend config.

- Adds `SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS` and `SANDBOX_IDLE_CLEANUP_INTERVAL_SECONDS`, preserving the existing defaults.
- Wires approval expiry queries, sandbox proxy approval waits, and the idle cleanup beat schedule to those settings.
- Renders sandbox AGENTS approval timeout guidance from config so generated instructions stay accurate when the approval wait changes.
- Keeps cancelled approval waits from pinning proxy threads for the full configured timeout by polling Redis wake waits in short blocking slices.
- Keeps Helm and Docker Compose default env surfaces unchanged while adding focused unit coverage.

## How Has This Been Tested?


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check