### PR TITLE
fix(chat): bound the LLM stream consumer (ENG-4236) to release v4.0

### DIFF
--- a/backend/onyx/chat/llm_step.py
+++ b/backend/onyx/chat/llm_step.py
@@ -19,6 +19,8 @@ from onyx.chat.tool_call_args_streaming import maybe_emit_argument_delta
 from onyx.configs.app_configs import ENABLE_AZURE_IMAGE_CAP
 from onyx.configs.app_configs import LOG_ONYX_MODEL_INTERACTIONS
 from onyx.configs.app_configs import PROMPT_CACHE_CHAT_HISTORY
+from onyx.configs.chat_configs import LLM_STREAM_MAX_CONSECUTIVE_EMPTY_PACKETS
+from onyx.configs.chat_configs import LLM_STREAM_MAX_DURATION_SECONDS
 from onyx.configs.constants import MessageType
 from onyx.context.search.models import SearchDoc
 from onyx.file_store.models import ChatFileType
@@ -40,6 +42,7 @@ from onyx.llm.models import TextContentPart
 from onyx.llm.models import ToolCall
 from onyx.llm.models import ToolMessage
 from onyx.llm.models import UserMessage
+from onyx.llm.multi_llm import LLMStreamError
 from onyx.llm.prompt_cache.processor import process_with_prompt_cache
 from onyx.llm.utils import model_needs_formatting_reenabled
 from onyx.prompts.chat_prompts import CODE_BLOCK_MARKDOWN
@@ -1138,6 +1141,7 @@ def run_llm_step_pkt_generator(
     stream_chunk_count = 0
     actionable_chunk_count = 0
     empty_chunk_count = 0
+    consecutive_empty_count = 0
     finish_reasons: set[str] = set()
     xml_tool_call_content_filter = _XmlToolCallContentFilter()
 
@@ -1273,6 +1277,23 @@ def run_llm_step_pkt_generator(
             timeout_override=timeout_override,
         ):
             stream_chunk_count += 1
+            if (
+                LLM_STREAM_MAX_DURATION_SECONDS > 0
+                and time.monotonic() - stream_start_time
+                > LLM_STREAM_MAX_DURATION_SECONDS
+            ):
+                logger.error(
+                    "LLM stream exceeded max duration of %ss; aborting to free "
+                    "the worker. chunks=%s, provider=%s, model=%s",
+                    LLM_STREAM_MAX_DURATION_SECONDS,
+                    stream_chunk_count,
+                    llm.config.model_provider,
+                    llm.config.model_name,
+                )
+                raise LLMStreamError(
+                    "LLM stream exceeded max duration of "
+                    f"{LLM_STREAM_MAX_DURATION_SECONDS}s"
+                )
             if packet.usage:
                 usage = packet.usage
                 span_generation.span_data.usage = {
@@ -1294,6 +1315,25 @@ def run_llm_step_pkt_generator(
                 and not delta.tool_calls
             ):
                 empty_chunk_count += 1
+                consecutive_empty_count += 1
+                if (
+                    LLM_STREAM_MAX_CONSECUTIVE_EMPTY_PACKETS > 0
+                    and consecutive_empty_count
+                    >= LLM_STREAM_MAX_CONSECUTIVE_EMPTY_PACKETS
+                ):
+                    logger.error(
+                        "LLM stream produced %s consecutive empty packets; "
+                        "aborting to free the worker. "
+                        "finish_reason=%s, provider=%s, model=%s",
+                        consecutive_empty_count,
+                        finish_reason,
+                        llm.config.model_provider,
+                        llm.config.model_name,
+                    )
+                    raise LLMStreamError(
+                        f"LLM stream aborted after {consecutive_empty_count} "
+                        "consecutive empty packets"
+                    )
                 logger.warning(
                     "LLM packet is empty (no content, reasoning, or tool calls). "
                     "finish_reason=%s. Skipping: %s",
@@ -1301,6 +1341,7 @@ def run_llm_step_pkt_generator(
                     packet,
                 )
                 continue
+            consecutive_empty_count = 0
 
             if not first_action_recorded and _delta_has_action(delta):
                 span_generation.span_data.time_to_first_action_seconds = (

--- a/backend/onyx/configs/chat_configs.py
+++ b/backend/onyx/configs/chat_configs.py
@@ -30,6 +30,16 @@ CONTEXT_CHUNKS_BELOW = int(os.environ.get("CONTEXT_CHUNKS_BELOW") or 1)
 LLM_SOCKET_READ_TIMEOUT = int(
     os.environ.get("LLM_SOCKET_READ_TIMEOUT") or "60"
 )  # 60 seconds
+# Abort after this many back-to-back empty packets (resets on any non-empty one);
+# bounds a degenerate stream that would pin a worker thread and wedge the pod.
+# 0 disables.
+LLM_STREAM_MAX_CONSECUTIVE_EMPTY_PACKETS = int(
+    os.environ.get("LLM_STREAM_MAX_CONSECUTIVE_EMPTY_PACKETS") or "1000"
+)
+# Wall-clock backstop for any runaway stream; 0 disables.
+LLM_STREAM_MAX_DURATION_SECONDS = int(
+    os.environ.get("LLM_STREAM_MAX_DURATION_SECONDS") or "900"
+)
 # Timeout for non-streaming secondary LLM flows (e.g. search section-relevance
 # classification and section-expansion selection). These are short, low-effort
 # calls; the bound exists so a stalled provider connection fails fast into the

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -120,6 +120,14 @@ class LLMRateLimitError(Exception):
     """
 
 
+class LLMStreamError(Exception):
+    """
+    Exception raised when an LLM stream is aborted by a safety guard (too many
+    consecutive empty packets, or exceeding the max stream duration) to free the
+    worker thread consuming the stream.
+    """
+
+
 def _prompt_to_dicts(prompt: LanguageModelInput) -> list[dict[str, Any]]:
     """Convert Pydantic message models to dictionaries for LiteLLM.
 

--- a/backend/tests/unit/onyx/chat/test_llm_step_stream_guards.py
+++ b/backend/tests/unit/onyx/chat/test_llm_step_stream_guards.py
@@ -1,0 +1,133 @@
+"""Guards that stop a degenerate LLM stream from wedging an api-server worker.
+
+A stream that emits empty packets (no content, reasoning, or tool calls)
+indefinitely holds a worker thread blocked on the socket. These tests assert the
+consumer aborts such a stream instead of looping forever, while leaving healthy
+streams (including ones that interleave sparse empties with real content) intact.
+"""
+
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from onyx.chat import llm_step as llm_step_module
+from onyx.chat.llm_step import run_llm_step_pkt_generator
+from onyx.llm.interfaces import ToolChoiceOptions
+from onyx.llm.model_response import Delta
+from onyx.llm.model_response import ModelResponseStream
+from onyx.llm.model_response import StreamingChoice
+from onyx.llm.multi_llm import LLMStreamError
+from onyx.server.query_and_chat.placement import Placement
+
+
+def _chunk(delta: Delta) -> ModelResponseStream:
+    return ModelResponseStream(id="c", created="0", choice=StreamingChoice(delta=delta))
+
+
+def _empty_chunk() -> ModelResponseStream:
+    # No content, no reasoning, no tool calls -> hits the empty-packet branch.
+    return _chunk(Delta())
+
+
+def _make_llm(stream: Iterator[ModelResponseStream]) -> MagicMock:
+    llm = MagicMock()
+    llm.config.model_name = "test-model"
+    llm.config.model_provider = "openai"
+    llm.config.api_base = None
+    llm.stream.return_value = stream
+    return llm
+
+
+def _drive(llm: MagicMock) -> tuple[list[Any], Any]:
+    """Run the streaming step to completion; return (emitted_packets, result)."""
+    gen = run_llm_step_pkt_generator(
+        history=[],
+        tool_definitions=[],
+        tool_choice=ToolChoiceOptions.AUTO,
+        llm=llm,
+        placement=Placement(turn_index=1, tab_index=0),
+        state_container=None,
+        citation_processor=None,
+    )
+    packets: list[Any] = []
+    result: Any = None
+    try:
+        while True:
+            packets.append(next(gen))
+    except StopIteration as stop:
+        result, _has_reasoned = stop.value
+    return packets, result
+
+
+@patch("onyx.chat.llm_step.translate_history_to_llm_format", return_value=[])
+def test_unbounded_empty_packets_abort_instead_of_hanging(
+    _translate: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cap = 50
+    monkeypatch.setattr(
+        llm_step_module, "LLM_STREAM_MAX_CONSECUTIVE_EMPTY_PACKETS", cap
+    )
+
+    consumed = 0
+
+    def _runaway_empty_stream() -> Iterator[ModelResponseStream]:
+        nonlocal consumed
+        # Far more than the cap; if the guard fails this would still terminate
+        # (so the test can't hang), but the assertion below pins the cap.
+        for _ in range(cap * 10):
+            consumed += 1
+            yield _empty_chunk()
+
+    with pytest.raises(LLMStreamError):
+        _drive(_make_llm(_runaway_empty_stream()))
+
+    # Aborted promptly at the cap, not after draining the whole stream.
+    assert consumed == cap
+
+
+@patch("onyx.chat.llm_step.translate_history_to_llm_format", return_value=[])
+def test_sparse_empties_interleaved_with_content_do_not_abort(
+    _translate: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cap = 5
+    monkeypatch.setattr(
+        llm_step_module, "LLM_STREAM_MAX_CONSECUTIVE_EMPTY_PACKETS", cap
+    )
+
+    def _bursty_stream() -> Iterator[ModelResponseStream]:
+        # Each burst stays one short of the cap, then a real packet resets it.
+        for _ in range(10):
+            for _ in range(cap - 1):
+                yield _empty_chunk()
+            yield _chunk(Delta(content="hello "))
+
+    # Must complete cleanly; counter resets on every content packet.
+    packets, result = _drive(_make_llm(_bursty_stream()))
+    assert result is not None
+    assert result.answer is not None and "hello" in result.answer
+
+
+@patch("onyx.chat.llm_step.translate_history_to_llm_format", return_value=[])
+def test_duration_backstop_aborts_runaway_stream(
+    _translate: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Disable the empty-packet cap so the duration backstop is what fires.
+    monkeypatch.setattr(llm_step_module, "LLM_STREAM_MAX_CONSECUTIVE_EMPTY_PACKETS", 0)
+    monkeypatch.setattr(llm_step_module, "LLM_STREAM_MAX_DURATION_SECONDS", 10)
+
+    # tick 0 -> stream_start_time; tick 1 trips the cap on the first iteration.
+    ticks = iter([0.0, 1000.0, 1001.0, 1002.0])
+    monkeypatch.setattr(llm_step_module.time, "monotonic", lambda: next(ticks, 2000.0))
+
+    def _slow_stream() -> Iterator[ModelResponseStream]:
+        for _ in range(100):
+            yield _empty_chunk()
+
+    with pytest.raises(LLMStreamError):
+        _drive(_make_llm(_slow_stream()))


### PR DESCRIPTION
Cherry-pick of #12433 to **release/v4.0**.

A degenerate LLM stream that emits empty packets (no content/reasoning/tool
calls) without end holds an anyio worker thread blocked on the socket; enough
concurrent stuck streams saturate the pool, `/health` stops responding, and the
liveness probe SIGKILLs the api-server pod (exit 137) — an api-server restart
loop observed in production. Adds a consecutive-empty-packet cap (resets on any
non-empty packet) plus a generous wall-clock backstop, both raising
`LLMStreamError` so a runaway stream becomes a single failed request instead of
a pod-wide wedge. Limits are env-overridable in `chat_configs.py`.

See #12433 for full context and ENG-4236. Also being cherry-picked to v4.1 and v4.2.

> ⚠️ @yuhongsun96 — touches the body of `run_llm_step_pkt_generator`; additive
> safety guard only, normal streaming path unchanged.

## How Has This Been Tested?

Unit tests in `test_llm_step_stream_guards.py` pass on `main` (the change is
identical). Note: this repo's unit suite currently fails to *collect* on the
v4.0 branch in some local envs due to a pre-existing `UnicodeEncodeError` in
`text_processing.py` import — unrelated to this change; CI runs in the correct
environment.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
