### PR TITLE
fix(scim): accept Entra ID group member removal (path=members + value list)

### DIFF
--- a/backend/ee/onyx/server/scim/patch.py
+++ b/backend/ee/onyx/server/scim/patch.py
@@ -442,19 +442,36 @@ def _apply_group_remove(
     members: list[dict],
     removed_ids: list[str],
 ) -> None:
-    """Remove members from a group."""
+    """Remove members from a group.
+
+    Supports both IdP encodings of a member removal:
+      - Okta:  path = ``members[value eq "user-id"]``
+      - Entra ID (Azure AD): path = ``members`` with the members to remove in a
+        ``value`` list — the same shape Entra uses for ``add``.
+    """
     if not op.path:
         raise ScimPatchError("Remove operation requires a path")
 
     match = _MEMBER_FILTER_RE.match(op.path)
-    if not match:
-        raise ScimPatchError(
-            f"Unsupported remove path '{op.path}'. Expected: members[value eq \"user-id\"]"
-        )
+    if match:
+        _remove_member_ids(members, [match.group(1)], removed_ids)
+        return
 
-    target_id = match.group(1)
-    original_len = len(members)
-    members[:] = [m for m in members if m.get("value") != target_id]
+    if op.path.lower() == "members" and isinstance(op.value, list):
+        _remove_member_ids(members, [m.value for m in op.value], removed_ids)
+        return
 
-    if len(members) < original_len:
-        removed_ids.append(target_id)
+    raise ScimPatchError(
+        f"Unsupported remove path '{op.path}'. Expected: members[value eq \"user-id\"]"
+    )
+
+
+def _remove_member_ids(
+    members: list[dict],
+    target_ids: list[str],
+    removed_ids: list[str],
+) -> None:
+    """Drop the given member IDs from the group, recording those present."""
+    targets = set(target_ids)
+    removed_ids.extend(m["value"] for m in members if m.get("value") in targets)
+    members[:] = [m for m in members if m.get("value") not in targets]

--- a/backend/tests/unit/onyx/server/scim/test_patch.py
+++ b/backend/tests/unit/onyx/server/scim/test_patch.py
@@ -7,6 +7,7 @@ from ee.onyx.server.scim.models import ScimMeta
 from ee.onyx.server.scim.models import ScimName
 from ee.onyx.server.scim.models import ScimPatchOperation
 from ee.onyx.server.scim.models import ScimPatchOperationType
+from ee.onyx.server.scim.models import ScimPatchRequest
 from ee.onyx.server.scim.models import ScimPatchResourceValue
 from ee.onyx.server.scim.models import ScimPatchValue
 from ee.onyx.server.scim.models import ScimUserResource
@@ -395,6 +396,84 @@ class TestApplyGroupPatch:
         )
         assert len(result.members) == 1
         assert removed == []
+
+    def test_remove_member_entra_value_list(self) -> None:
+        """Entra ID removes members via path="members" + a value list rather
+        than Okta's members[value eq "..."] filter."""
+        group = _make_group(
+            members=[
+                ScimGroupMember(value="user-1"),
+                ScimGroupMember(value="user-2"),
+            ]
+        )
+        result, added, removed = apply_group_patch(
+            [
+                ScimPatchOperation(
+                    op=ScimPatchOperationType.REMOVE,
+                    path="members",
+                    value=[ScimGroupMember(value="user-1")],
+                )
+            ],
+            group,
+        )
+        assert [m.value for m in result.members] == ["user-2"]
+        assert removed == ["user-1"]
+        assert added == []
+
+    def test_remove_member_entra_multiple(self) -> None:
+        group = _make_group(
+            members=[
+                ScimGroupMember(value="user-1"),
+                ScimGroupMember(value="user-2"),
+                ScimGroupMember(value="user-3"),
+            ]
+        )
+        result, _, removed = apply_group_patch(
+            [
+                ScimPatchOperation(
+                    op=ScimPatchOperationType.REMOVE,
+                    path="members",
+                    value=[
+                        ScimGroupMember(value="user-1"),
+                        ScimGroupMember(value="user-3"),
+                    ],
+                )
+            ],
+            group,
+        )
+        assert [m.value for m in result.members] == ["user-2"]
+        assert sorted(removed) == ["user-1", "user-3"]
+
+    def test_remove_member_entra_nonexistent(self) -> None:
+        group = _make_group(members=[ScimGroupMember(value="user-1")])
+        result, _, removed = apply_group_patch(
+            [
+                ScimPatchOperation(
+                    op=ScimPatchOperationType.REMOVE,
+                    path="members",
+                    value=[ScimGroupMember(value="user-999")],
+                )
+            ],
+            group,
+        )
+        assert len(result.members) == 1
+        assert removed == []
+
+    def test_remove_member_entra_raw_payload(self) -> None:
+        """The exact body Entra ID sends — capitalized "Remove" op, path
+        "members", value list — must parse and remove the member."""
+        group = _make_group(members=[ScimGroupMember(value="user-1")])
+        request = ScimPatchRequest.model_validate(
+            {
+                "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+                "Operations": [
+                    {"op": "Remove", "path": "members", "value": [{"value": "user-1"}]}
+                ],
+            }
+        )
+        result, _, removed = apply_group_patch(request.Operations, group)
+        assert result.members == []
+        assert removed == ["user-1"]
 
     def test_mixed_operations(self) -> None:
         group = _make_group(members=[ScimGroupMember(value="user-1")])


### PR DESCRIPTION
## Description

Onyx's SCIM group PATCH handler only recognized **Okta's** encoding for removing a group member — the filter path `members[value eq "<id>"]`. **Microsoft Entra ID (Azure AD)** removes members with a different, equally RFC 7644-valid encoding:

```json
{ "op": "remove", "path": "members", "value": [{ "value": "<user-id>" }] }
```

Onyx rejected that form with `HTTP 400 — Unsupported remove path 'members'. Expected: members[value eq "user-id"]`, so **group de-membership never synced for Entra tenants** (the IdP retries the same PATCH on every sync cycle and keeps 400ing).

Note the asymmetry that confirmed the gap: `_apply_group_add` and `_apply_group_replace` already accept `path="members"` + a value list, but `_apply_group_remove` did not. This change teaches `_apply_group_remove` the same encoding (factored into a small `_remove_member_ids` helper), so both Okta and Entra removals work. Path-less removes still error, as before.

## How Has This Been Tested?

- New unit tests in `test_patch.py` covering the Entra encoding: single + multiple member removal, no-op on a non-member, and the exact raw Entra payload (capitalized `"Remove"`, `path:"members"`, value list) parsed through `ScimPatchRequest`.
- Verified against the real parser that the Entra payload previously produced the exact production error and now succeeds, while the Okta filter form and `add` are unchanged.
- Full SCIM unit suite passes (246 tests); pre-commit (ruff, ty type-check, format) clean.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<sub>Needs cherry-pick back to **v4.0** (via the v4.2 / v4.1 chain).</sub>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accept Microsoft Entra ID’s SCIM group member removal format (path="members" + value list) to stop 400 errors and ensure group de-membership sync. Okta’s filter format continues to work.

- **Bug Fixes**
  - Updated `_apply_group_remove` to handle `path="members"` with a `value` list, using a new `_remove_member_ids` helper; Okta and Entra encodings are both supported.
  - Added unit tests for single/multiple removals, non-member no-ops, and the raw Entra payload via `ScimPatchRequest`.

<sup>Written for commit 7759c6da28f8b05c8ac1c52d1793d96355bc2488. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

