### PR TITLE
feat(helm): configurable api-server worker/threadpool concurrency + load-test sweep

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -1488,6 +1488,11 @@ VESPA_MIGRATION_SERVER_SIDE_REQUEST_TIMEOUT = os.environ.get(
 
 SYSTEM_RECURSION_LIMIT = int(os.environ.get("SYSTEM_RECURSION_LIMIT") or "1000")
 
+# Size of the api-server anyio threadpool that runs sync endpoints, including the
+# streaming chat generator (each long request holds one thread for its duration).
+# 0 keeps the anyio default (40). Set via the api.threadpoolSize Helm value.
+API_SERVER_THREADPOOL_SIZE = int(os.environ.get("ONYX_API_THREADPOOL_SIZE") or "0")
+
 PARSE_WITH_TRAFILATURA = os.environ.get("PARSE_WITH_TRAFILATURA", "").lower() == "true"
 
 # allow for custom error messages for different errors returned by litellm

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -8,6 +8,7 @@ from typing import Any
 from typing import cast
 
 import uvicorn
+from anyio import to_thread
 from fastapi import APIRouter
 from fastapi import FastAPI
 from fastapi import HTTPException
@@ -34,6 +35,7 @@ from onyx.auth.users import fastapi_users
 from onyx.auth.users import mobile_auth_backend
 from onyx.auth.users import verify_user_auth_secret
 from onyx.cache.interface import CacheBackendType
+from onyx.configs.app_configs import API_SERVER_THREADPOOL_SIZE
 from onyx.configs.app_configs import APP_API_PREFIX
 from onyx.configs.app_configs import APP_HOST
 from onyx.configs.app_configs import APP_PORT
@@ -325,6 +327,16 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:  # noqa: ARG001
     if SYSTEM_RECURSION_LIMIT is not None:
         sys.setrecursionlimit(SYSTEM_RECURSION_LIMIT)
         logger.notice("System recursion limit set to %s", SYSTEM_RECURSION_LIMIT)
+
+    # Size the anyio threadpool that serves sync endpoints (incl. the streaming
+    # chat generator). Must run inside the event loop, as the limiter is per-loop.
+    if API_SERVER_THREADPOOL_SIZE > 0:
+        to_thread.current_default_thread_limiter().total_tokens = (
+            API_SERVER_THREADPOOL_SIZE
+        )
+        logger.notice(
+            "API server threadpool size set to %s", API_SERVER_THREADPOOL_SIZE
+        )
 
     SqlEngine.set_app_name(POSTGRES_WEB_APP_NAME)
 

--- a/deployment/helm/charts/onyx/templates/api-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/api-deployment.yaml
@@ -74,7 +74,7 @@ spec:
               alembic upgrade head &&
               {{- end }}
               echo "Starting Onyx Api Server" &&
-              uvicorn onyx.main:app --host {{ .Values.global.host }} --port {{ .Values.api.containerPorts.server }}
+              uvicorn onyx.main:app --host {{ .Values.global.host }} --port {{ .Values.api.containerPorts.server }}{{ if gt (int (.Values.api.workers | default 1)) 1 }} --workers {{ .Values.api.workers }}{{ end }}{{ if .Values.api.limitConcurrency }} --limit-concurrency {{ .Values.api.limitConcurrency }}{{ end }}
           ports:
             - name: api-server-port
               containerPort: {{ .Values.api.containerPorts.server }}
@@ -101,6 +101,10 @@ spec:
                 name: {{ . }}
             {{- end }}
           env:
+            {{- if .Values.api.threadpoolSize }}
+            - name: ONYX_API_THREADPOOL_SIZE
+              value: "{{ .Values.api.threadpoolSize }}"
+            {{- end }}
             {{- include "onyx.envSecrets" . | nindent 12}}
             {{- include "onyx.envSecretsRestricted" . | nindent 12}}
             {{- with include "onyx.customCACerts.env" . }}

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -433,6 +433,25 @@ api:
   containerPorts:
     server: 8080
 
+  # Uvicorn worker processes per pod. Each worker is its own process with its own
+  # event loop and threadpool, so >1 adds parallel capacity and keeps a wedged
+  # worker from taking down the pod's /health. The app lifespan runs per worker
+  # (same as adding replicas, which already run it concurrently), so this is
+  # safe; size against pod CPU and per-worker memory. Default 1 = prior behavior.
+  workers: 1
+
+  # Max concurrent connections per uvicorn worker. When set, the worker rejects
+  # new connections past this (503) instead of queueing into a thread-starvation
+  # wedge. Empty = no cap (uvicorn default). Example: 200.
+  limitConcurrency: ""
+
+  # Size of the anyio threadpool serving sync endpoints, including the streaming
+  # chat generator (each long-running request — deep research, code interpreter —
+  # holds one thread for its whole duration). 0 keeps the anyio default (40).
+  # Raise for workloads with many concurrent long agent requests; each thread is
+  # real, so size against CPU/memory.
+  threadpoolSize: 0
+
   podSecurityContext:
     {}
     # fsGroup: 2000

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -150,6 +150,44 @@ ONYX_API_KEY=<key> uv run --group loadtest locust --headless -t 25m -H https://<
 The API key is created by an admin via `POST /api/admin/api-key`
 (`{"name": "loadtest", "role": "basic"}`) or Admin Panel → API Keys.
 
+### Worker concurrency sweep (`ThreadHogUser` + `HealthProbeUser`)
+
+Validates the api-server worker config (`api.workers` / `api.threadpoolSize` /
+CPU in the Helm chart) against the production failure mode: long-running agent
+requests pin the anyio threadpool, the event loop starves, and the liveness
+`httpGet /health` probe (`timeoutSeconds: 10`, `failureThreshold: 3`) starts
+failing → the pod is SIGKILLed.
+
+- **ThreadHogUser** (`hog:*`) — each turn streams a deliberately slow mock
+  response (default `mock-ttft1000-itl200-len600` ≈ 121s), holding one
+  threadpool thread for the whole turn. Concurrency (`-u`) maps directly to
+  pool pressure.
+- **HealthProbeUser** (`HEALTH:probe`) — pins `ONYX_HEALTH_PROBES` (default 1)
+  users that GET `/health` once per `ONYX_HEALTH_INTERVAL` (default 1s),
+  **independent of `-u`**, and fail any probe slower than `ONYX_HEALTH_SLA_MS`
+  (default 10000, the liveness `timeoutSeconds`). The `HEALTH:probe` failure
+  rate is the experiment's primary signal — when it goes non-zero, this config
+  would start getting liveness-killed at that concurrency.
+
+```bash
+# One run: hold ~49 long requests, probe /health throughout.
+ONYX_API_KEY=<key> ONYX_HEALTH_PATH=/health \
+  uv run --group loadtest locust --headless -u 50 -r 5 -t 15m \
+  -H https://<your-onyx-url> ThreadHogUser HealthProbeUser
+```
+
+Sweep `concurrent-long-requests ∈ {10,20,40,80}` (use `ONYX_SHAPE=stepramp`)
+against chart configs `api.workers ∈ {1,2,4}` × `api.threadpoolSize ∈ {40,80}`
+× CPU `∈ {2,4}`. The right config is the smallest one where `HEALTH:probe`
+stays at **0 failures** through your target concurrency.
+
+> **st-dev routing caveats:** the `/loadtest` subpath is shadowed by the
+> catch-all route — point `LOCUST_HOST` at a dedicated host or port-forward.
+> When `LOCUST_HOST` is the web/nginx host, set `ONYX_HEALTH_PATH=/api/health`;
+> when it targets the api Service directly, `/health` is correct. st-dev is
+> direct-RDS, so absolute numbers differ from customer infra — compare configs
+> **relative** to each other, not against an absolute SLA.
+
 ## Configuration (env vars)
 
 | Variable | Default | Purpose |
@@ -160,6 +198,12 @@ The API key is created by an admin via `POST /api/admin/api-key`
 | `ONYX_SEARCH_MODEL` | `mock-tools1` | Model for ChatWithSearchUser |
 | `ONYX_MULTITOOL_MODEL` | `mock-tools3` | Model for MultiToolUser |
 | `ONYX_DR_MODEL` | `mock-agents2` | Model for DeepResearchUser |
+| `ONYX_HOG_MODEL` | `mock-ttft1000-itl200-len600` | Slow model for ThreadHogUser (sets per-turn thread-hold time) |
+| `ONYX_HOG_WAIT_SECONDS` / `ONYX_HOG_STREAM_READ_TIMEOUT` | 1 / 600 | ThreadHogUser think time / max inter-chunk wait |
+| `ONYX_HEALTH_PATH` | `/health` | Health-probe path (`/api/health` via web/nginx host) |
+| `ONYX_HEALTH_PROBES` | 1 | Number of HealthProbeUser instances to pin (independent of `-u`) |
+| `ONYX_HEALTH_INTERVAL` | 1.0 | Seconds between health probes |
+| `ONYX_HEALTH_SLA_MS` | 10000 | Fail a probe slower than this (liveness `timeoutSeconds`) |
 | `ONYX_LONGCONV_MODEL` | unset | Model for LongConversationUser (unset = persona default) |
 | `ONYX_SESSION_TURNS` | 1 | Turns to keep one session alive (LongConversationUser 20, CompressionUser 60) |
 | `ONYX_MSG_CHARS` | 0 | Per-message size in chars (CompressionUser defaults to 8000; 0 = short questions) |

--- a/loadtest/locustfile.py
+++ b/loadtest/locustfile.py
@@ -2,8 +2,10 @@
 
 With no user classes named, the default weighted mix runs (BasicChat 70 /
 ChatWithSearch 20 / MultiTool 8 / DeepResearch 2); name a class to run a
-targeted reproducer (LongConversationUser, DisconnectUser). ONYX_SHAPE=stepramp
-drives a staged ramp. See README.md for usage and env vars.
+targeted reproducer (LongConversationUser, DisconnectUser). For the worker /
+threadpool concurrency sweep, name ThreadHogUser + HealthProbeUser (see
+README "Worker concurrency sweep"). ONYX_SHAPE=stepramp drives a staged ramp.
+See README.md for usage and env vars.
 """
 
 import os
@@ -15,8 +17,10 @@ from scenarios import CompressionUser
 from scenarios import DeepResearchUser
 from scenarios import DisconnectUser
 from scenarios import FileAttachmentUser
+from scenarios import HealthProbeUser
 from scenarios import LongConversationUser
 from scenarios import MultiToolUser
+from scenarios import ThreadHogUser
 
 __all__ = [
     "BasicChatUser",
@@ -27,6 +31,8 @@ __all__ = [
     "DisconnectUser",
     "CompressionUser",
     "FileAttachmentUser",
+    "ThreadHogUser",
+    "HealthProbeUser",
 ]
 
 # Expose the ramp only on request: Locust auto-activates any shape it finds,

--- a/loadtest/scenarios/__init__.py
+++ b/loadtest/scenarios/__init__.py
@@ -3,8 +3,10 @@ from scenarios.compression import CompressionUser
 from scenarios.deep_research import DeepResearchUser
 from scenarios.disconnect import DisconnectUser
 from scenarios.file_attachment import FileAttachmentUser
+from scenarios.health_probe import HealthProbeUser
 from scenarios.long_conversation import LongConversationUser
 from scenarios.multi_tool import MultiToolUser
+from scenarios.thread_hog import ThreadHogUser
 
 __all__ = [
     "CompressionUser",
@@ -12,6 +14,8 @@ __all__ = [
     "DeepResearchUser",
     "DisconnectUser",
     "FileAttachmentUser",
+    "HealthProbeUser",
     "LongConversationUser",
     "MultiToolUser",
+    "ThreadHogUser",
 ]

--- a/loadtest/scenarios/health_probe.py
+++ b/loadtest/scenarios/health_probe.py
@@ -1,0 +1,88 @@
+"""Health-probe user for the worker / threadpool concurrency experiment.
+
+Hits the api-server /health endpoint on a fixed cadence, independent of the
+chat load, and fails any probe slower than the liveness SLA. Run it alongside a
+heavy chat workload (ThreadHogUser or DeepResearchUser) and watch the
+``HEALTH:probe`` failure rate: when it climbs, the threadpool / event loop is
+saturated enough that Kubernetes' liveness probe would start killing the pod.
+
+This is the direct, measurable analogue of the production liveness-kill — the
+liveness probe is ``httpGet /health``, ``timeoutSeconds: 10``,
+``failureThreshold: 3``, so a probe slower than 10s is a failed liveness check
+and three in a row kill the container.
+
+Run (pin probes + drive saturation, then sweep api.workers / threadpoolSize):
+
+    locust ThreadHogUser HealthProbeUser -u 50 -r 5 --host "$LOCUST_HOST"
+
+Env:
+    ONYX_HEALTH_PATH      probe path (default /health; use /api/health when
+                          LOCUST_HOST points at the web/nginx host rather than
+                          the api Service directly)
+    ONYX_HEALTH_PROBES    number of probe users to pin (default 1)
+    ONYX_HEALTH_INTERVAL  seconds between probes (default 1.0)
+    ONYX_HEALTH_SLA_MS    fail a probe slower than this (default 10000, the
+                          liveness timeoutSeconds)
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+from locust import constant_pacing
+from locust import HttpUser
+from locust import task
+from onyx_client.env import env_float
+from onyx_client.env import env_int
+
+
+class HealthProbeUser(HttpUser):
+    # Pin an exact number of probes regardless of -u so the cadence stays stable
+    # as the chat load scales up.
+    fixed_count = env_int("ONYX_HEALTH_PROBES", 1)
+    wait_time = constant_pacing(env_float("ONYX_HEALTH_INTERVAL", 1.0))
+
+    def on_start(self) -> None:
+        # When LOCUST_HOST points at an internal Service (to bypass an external
+        # ALB/WAF), set ONYX_HOST_HEADER so in-cluster nginx routes by Host.
+        host_header = os.environ.get("ONYX_HOST_HEADER")
+        if host_header:
+            self.client.headers["Host"] = host_header
+        self._path = os.environ.get("ONYX_HEALTH_PATH", "/health")
+        self._sla_ms = env_float("ONYX_HEALTH_SLA_MS", 10000.0)
+
+    @task
+    def probe(self) -> None:
+        start = time.perf_counter()
+        try:
+            with self.client.get(
+                self._path,
+                name="HEALTH:probe",
+                catch_response=True,
+                # Cap the wait a bit past the SLA so a wedged /health is recorded
+                # as a (slow) failure instead of blocking the probe forever.
+                timeout=self._sla_ms / 1000.0 + 5.0,
+            ) as response:
+                elapsed_ms = (time.perf_counter() - start) * 1000
+                if response.status_code != 200:
+                    response.failure(f"HTTP {response.status_code}")
+                elif elapsed_ms > self._sla_ms:
+                    # Past the liveness timeout → this probe would have counted
+                    # as a liveness failure (3 in a row kill the pod).
+                    response.failure(
+                        f"slow {elapsed_ms:.0f}ms > {self._sla_ms:.0f}ms SLA"
+                    )
+                else:
+                    response.success()
+        except Exception as exc:
+            # Timeout / connection error: the probe never came back in time,
+            # which is exactly what a liveness failure looks like.
+            self.environment.events.request.fire(
+                request_type="GET",
+                name="HEALTH:probe",
+                response_time=(time.perf_counter() - start) * 1000,
+                response_length=0,
+                exception=exc,
+                context={},
+            )

--- a/loadtest/scenarios/thread_hog.py
+++ b/loadtest/scenarios/thread_hog.py
@@ -1,0 +1,36 @@
+"""Deterministic thread-occupancy driver for the worker / threadpool sweep.
+
+Each turn streams a deliberately slow mock response, so the api-server holds one
+anyio threadpool thread (the chat stream is a sync generator) for the whole
+turn. Pile up enough concurrent ThreadHogUsers and the pool saturates — the
+failure mode that starves /health and triggers liveness kills. Pair with
+HealthProbeUser and sweep api.workers / api.threadpoolSize / CPU to find the
+concurrency a given config survives.
+
+Default model ``mock-ttft1000-itl200-len600`` ≈ 1s + 600 × 0.2s ≈ 121s of
+thread hold per turn. Override with ONYX_HOG_MODEL (mock knobs ride in the
+model name; see mock_llm/app.py).
+"""
+
+from __future__ import annotations
+
+import os
+
+from locust import constant
+from onyx_client.chat_user import OnyxChatUser
+from onyx_client.env import env_float
+
+
+class ThreadHogUser(OnyxChatUser):
+    abstract = False
+    weight = 1
+
+    scenario_prefix: str = "hog"
+    mock_model: str | None = os.environ.get(
+        "ONYX_HOG_MODEL", "mock-ttft1000-itl200-len600"
+    )
+
+    # Each turn already holds a thread for ~2 min; minimal think time keeps the
+    # thread occupied so concurrency maps directly to pool pressure.
+    wait_time = constant(env_float("ONYX_HOG_WAIT_SECONDS", 1.0))
+    stream_read_timeout: float = env_float("ONYX_HOG_STREAM_READ_TIMEOUT", 600.0)


### PR DESCRIPTION
## Description

The api-server runs **one uvicorn worker with the default 40-thread anyio
pool**, both hardcoded in the chart. The chat stream is a sync generator
consumed in that pool, so every long-running agent request (deep research, code
interpreter) holds a thread for its whole duration. Enough concurrent ones
starve the pool and even the async `/health` handler misses its liveness
deadline → the pod is SIGKILLed. Customer clusters that lean on these features
have no supported way to add concurrency headroom short of forking the chart.

This makes the api-server concurrency configurable via three **backward-
compatible** Helm values (mirrors the existing model-server `limitConcurrency`
pattern) so clusters tune it in their values overlay instead of forking:

| Value | Maps to | Default |
|---|---|---|
| `api.workers` | `uvicorn --workers` (only emitted when `>1`) | 1 |
| `api.limitConcurrency` | `uvicorn --limit-concurrency` | unset (no cap) |
| `api.threadpoolSize` | `ONYX_API_THREADPOOL_SIZE` → anyio `to_thread` limiter, set per worker in the api lifespan | 0 (= anyio default 40) |

All defaults preserve current behavior — with no overrides the deployment
renders **byte-identical** to before (`helm template` verified: bare `uvicorn`,
no flags, no env). `api.workers` is safe to raise because the app lifespan
already runs concurrently across replicas today.

### Load-test harness to pick the numbers

The second commit adds the pieces to validate a config on st-dev before rolling
it to a customer, reproducing the exact failure mode:

- **ThreadHogUser** — each turn streams a slow mock response (~121s), holding
  one threadpool thread, so `-u` maps directly to pool pressure.
- **HealthProbeUser** — pins N probes (independent of `-u`) that GET `/health`
  and fail any probe slower than the liveness SLA (10s). The `HEALTH:probe`
  failure rate is the signal: non-zero = this config would get liveness-killed
  at that concurrency.

The README documents the sweep matrix (`workers × threadpoolSize × CPU` vs
concurrent long requests) and the st-dev routing caveats.

## How Has This Been Tested?

- `helm template` / `helm lint`: defaults render byte-identical; overrides
  (`workers=4`, `limitConcurrency=200`, `threadpoolSize=80`) render the expected
  flags + env.
- `onyx.main` imports; anyio limiter setter verified to apply inside the event
  loop (default 40 → override).
- `ty` / `ruff` / `ruff format` pass on backend + loadtest files.
- `locust --list` discovers `ThreadHogUser` / `HealthProbeUser`; mock hold-time
  math confirmed (~121s/turn).
- Full sweep itself runs on st-dev (follow-up; harness is ready).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make api-server concurrency configurable in Helm to prevent threadpool starvation and liveness kills. Adds a Locust harness to validate configs against `/health` SLA under load.

- **New Features**
  - Helm values: `api.workers` → `uvicorn --workers` (emitted only when >1), `api.limitConcurrency` → `uvicorn --limit-concurrency`, `api.threadpoolSize` → `ONYX_API_THREADPOOL_SIZE`.
  - Backend: sets the anyio `to_thread` limiter in app lifespan so the threadpool size applies per worker.
  - Load test: new `ThreadHogUser` (holds a thread ~2 min/turn) and `HealthProbeUser` (fixed-count `/health` probes; fails when >10s). README documents the sweep and routing caveats.
  - Defaults preserve prior behavior; templates render the same with no overrides.

<sup>Written for commit bc0d4e13909df14b3ca61abe56d2ad7ff0487ec4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

