### PR TITLE
fix(craft): return OnyxError when Next.js ports are exhausted

### DIFF
--- a/backend/onyx/server/features/build/db/build_session.py
+++ b/backend/onyx/server/features/build/db/build_session.py
@@ -26,6 +26,8 @@ from onyx.db.models import BuildSession
 from onyx.db.models import LLMProvider as LLMProviderModel
 from onyx.db.models import Sandbox
 from onyx.db.models import User
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.server.features.build.configs import BUILD_MODE_ALLOWED_PROVIDER_TYPES
 from onyx.server.features.build.configs import SANDBOX_NEXTJS_PORT_END
 from onyx.server.features.build.configs import SANDBOX_NEXTJS_PORT_START
@@ -521,7 +523,7 @@ def allocate_nextjs_port(db_session: Session) -> int:
         An available port number
 
     Raises:
-        RuntimeError: If no ports are available in the configured range
+        OnyxError: If no ports are available in the configured range
     """
     from onyx.db.models import BuildSession
 
@@ -538,8 +540,9 @@ def allocate_nextjs_port(db_session: Session) -> int:
         if port not in allocated_ports and _is_port_available(port):
             return port
 
-    raise RuntimeError(
-        f"No available ports in range [{SANDBOX_NEXTJS_PORT_START}, {SANDBOX_NEXTJS_PORT_END})"
+    raise OnyxError(
+        OnyxErrorCode.SERVICE_UNAVAILABLE,
+        f"No available ports in range [{SANDBOX_NEXTJS_PORT_START}, {SANDBOX_NEXTJS_PORT_END})",
     )
 
 

--- a/backend/onyx/server/features/build/session/api.py
+++ b/backend/onyx/server/features/build/session/api.py
@@ -502,6 +502,9 @@ def restore_session(
                 sandbox.status,
             )
 
+    except OnyxError:
+        db_session.rollback()
+        raise
     except Exception as e:
         logger.error("Failed to restore session %s: %s", session_id, e, exc_info=True)
         # Recover so the next attempt isn't blocked by a half-finished state.

--- a/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
@@ -838,11 +838,6 @@ class TestPortAllocator:
         test_user: User,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        # Plan calls for OnyxError here, but the implementation in
-        # ``onyx.server.features.build.db.build_session.allocate_nextjs_port``
-        # raises ``RuntimeError`` with the documented "No available ports"
-        # message. We pin the current behaviour and flag the divergence in
-        # the report. See manager.py / build_session.py for the call sites.
         monkeypatch.setattr(
             "onyx.server.features.build.db.build_session.SANDBOX_NEXTJS_PORT_START",
             50100,
@@ -864,8 +859,9 @@ class TestPortAllocator:
             )
         db_session.commit()
 
-        with pytest.raises(RuntimeError, match="No available ports"):
+        with pytest.raises(OnyxError) as exc_info:
             allocate_nextjs_port(db_session)
+        assert exc_info.value.error_code == OnyxErrorCode.SERVICE_UNAVAILABLE
 
 
 # =============================================================================
@@ -1024,6 +1020,54 @@ class TestRestoreSession:
             stub_sandbox_manager.last_write_files_to_sandbox_payload["mount_path"]
             == USER_LIBRARY_MOUNT_PATH
         )
+
+    def test_restore_preserves_port_exhaustion_onyx_error(
+        self,
+        db_session: Session,
+        test_user: User,
+        sandbox: Callable[..., Sandbox],
+        session_manager_with_stub: SessionManager,  # noqa: ARG002
+        stub_sandbox_manager: StubSandboxManager,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        sandbox(user=test_user, status=SandboxStatus.RUNNING)
+        idle_session = BuildSession(
+            id=uuid4(),
+            user_id=test_user.id,
+            name="restore-port-exhausted",
+            status=BuildSessionStatus.IDLE,
+            nextjs_port=None,
+        )
+        db_session.add(idle_session)
+        db_session.commit()
+
+        stub_sandbox_manager.health_check_returns = True
+        stub_sandbox_manager.session_workspace_exists_returns = False
+
+        monkeypatch.setattr(
+            "onyx.server.features.build.session.api.get_sandbox_manager",
+            lambda: stub_sandbox_manager,
+        )
+
+        def _raise_port_exhausted(_db_session: Session) -> int:
+            raise OnyxError(
+                OnyxErrorCode.SERVICE_UNAVAILABLE,
+                "No available ports in configured range",
+            )
+
+        monkeypatch.setattr(
+            "onyx.server.features.build.session.api.allocate_nextjs_port",
+            _raise_port_exhausted,
+        )
+
+        with pytest.raises(OnyxError) as exc_info:
+            restore_session(
+                session_id=idle_session.id,
+                user=test_user,
+                db_session=db_session,
+            )
+
+        assert exc_info.value.error_code == OnyxErrorCode.SERVICE_UNAVAILABLE
 
 
 # =============================================================================


### PR DESCRIPTION
## Description

When Craft Next.js port allocation exhausts the configured range, return a structured `OnyxError` with `OnyxErrorCode.SERVICE_UNAVAILABLE` instead of raising a raw `RuntimeError`.

Also preserves that `OnyxError` through the session restore path so restore-time port exhaustion is not wrapped as an unstructured 500.

## How Has This Been Tested?


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
