### PR TITLE
test(craft): type shared build integration helpers

### DIFF
--- a/backend/tests/common/craft/users.py
+++ b/backend/tests/common/craft/users.py
@@ -1,0 +1,56 @@
+"""Shared user-seeding helpers for craft integration suites."""
+
+from __future__ import annotations
+
+import httpx
+
+from onyx.auth.schemas import UserRole
+from tests.integration.common_utils.constants import GENERAL_HEADERS
+from tests.integration.common_utils.managers.user import build_email
+from tests.integration.common_utils.managers.user import DEFAULT_PASSWORD
+from tests.integration.common_utils.managers.user import UserManager
+from tests.integration.common_utils.test_models import DATestUser
+
+
+def _is_user_already_exists(response: httpx.Response) -> bool:
+    # Only a 400 with detail REGISTER_USER_ALREADY_EXISTS counts; a malformed
+    # request also 400s but must not be treated as "exists".
+    if response.status_code == 409:
+        return True
+    if response.status_code != 400:
+        return False
+    try:
+        body = response.json()
+    except ValueError:
+        return False
+    return (
+        isinstance(body, dict) and body.get("detail") == "REGISTER_USER_ALREADY_EXISTS"
+    )
+
+
+def create_or_login_admin(name: str) -> DATestUser:
+    """Create the named user (the first registrant becomes admin), or log in if
+    it already exists, asserting it really is an admin.
+
+    On a cluster where the user already exists (no ``reset_all``), this fails
+    loudly rather than silently handing back a lower-privilege user that then
+    403s on admin operations.
+    """
+    try:
+        user = UserManager.create(name=name)
+    except httpx.HTTPStatusError as exc:
+        if not _is_user_already_exists(exc.response):
+            raise
+        user = UserManager.login_as_user(
+            DATestUser(
+                id="",
+                email=build_email(name),
+                password=DEFAULT_PASSWORD,
+                headers=GENERAL_HEADERS.copy(),
+                role=UserRole.ADMIN,
+                is_active=True,
+            )
+        )
+    if user.role != UserRole.ADMIN:
+        raise AssertionError(f"Expected {name} to be an admin, got {user.role.value}")
+    return user

--- a/backend/tests/integration/common_utils/http_client.py
+++ b/backend/tests/integration/common_utils/http_client.py
@@ -15,11 +15,62 @@ reference.
 
 from __future__ import annotations
 
+import time
 from typing import Any
 
 import httpx
 
 from tests.integration.common_utils.constants import API_SERVER_URL
+
+_CONNECT_RETRY_EXCEPTIONS = (
+    httpx.ConnectError,
+    httpx.ConnectTimeout,
+    httpx.PoolTimeout,
+)
+_SAFE_RETRY_EXCEPTIONS = (
+    httpx.ReadTimeout,
+    httpx.RemoteProtocolError,
+)
+_RETRY_STATUSES = {502, 504}
+_SAFE_RETRY_METHODS = {"GET", "HEAD", "OPTIONS"}
+_MAX_ATTEMPTS = 3
+
+
+class RetryingTransport(httpx.HTTPTransport):
+    """httpx transport with bounded retries on transient connect errors / 502 /
+    504, for out-of-process suites whose api_server is reached over a
+    port-forward or proxy. Only retries idempotent (safe) methods on 5xx."""
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        backoff = 0.5
+        for attempt in range(_MAX_ATTEMPTS):
+            last = attempt == _MAX_ATTEMPTS - 1
+            try:
+                response = super().handle_request(request)
+            except _CONNECT_RETRY_EXCEPTIONS:
+                if last:
+                    raise
+                time.sleep(backoff)
+                backoff *= 2
+                continue
+            except _SAFE_RETRY_EXCEPTIONS:
+                if last or request.method.upper() not in _SAFE_RETRY_METHODS:
+                    raise
+                time.sleep(backoff)
+                backoff *= 2
+                continue
+            if (
+                response.status_code in _RETRY_STATUSES
+                and request.method.upper() in _SAFE_RETRY_METHODS
+                and not last
+            ):
+                response.close()
+                time.sleep(backoff)
+                backoff *= 2
+                continue
+            return response
+        raise AssertionError("unreachable")
+
 
 # Typed as ``httpx.Client`` so both FastAPI's ``TestClient`` and a raw
 # ``httpx.Client`` satisfy the signature.

--- a/backend/tests/integration/common_utils/managers/build_session.py
+++ b/backend/tests/integration/common_utils/managers/build_session.py
@@ -9,12 +9,29 @@ Each method calls the API server through the same ``user.headers`` /
 from __future__ import annotations
 
 from typing import Any
+from typing import NamedTuple
 from uuid import UUID
 
+from onyx.db.enums import SandboxStatus
 from onyx.db.enums import SharingScope
+from onyx.server.features.build.interactive_turns.models import InteractiveTurnResponse
+from onyx.server.features.build.models import UploadResponse
+from onyx.server.features.build.sandbox.models import DirectoryListing
+from onyx.server.features.build.session.models import DetailedSessionResponse
+from onyx.server.features.build.session.models import MessageListResponse
+from onyx.server.features.build.session.models import MessageResponse
+from onyx.server.features.build.session.models import OpencodeHistorySnapshotResponse
+from onyx.server.features.build.session.models import SessionListResponse
+from onyx.server.features.build.session.models import SessionResponse
+from onyx.server.features.build.session.models import SnapshotResponse
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.http_client import client
 from tests.integration.common_utils.test_models import DATestUser
+
+
+class SessionWithSandbox(NamedTuple):
+    session_id: UUID
+    sandbox_id: UUID
 
 
 def _sessions_url(*parts: str) -> str:
@@ -37,7 +54,7 @@ class BuildSessionManager:
         *,
         headless: bool = True,
         **kwargs: Any,
-    ) -> dict[str, Any]:
+    ) -> DetailedSessionResponse:
         # The endpoint returns the user's pre-provisioned empty session if
         # one exists. Tests need isolation per call, so delete any existing
         # empty session before creating fresh.
@@ -66,35 +83,73 @@ class BuildSessionManager:
                 f"POST /build/sessions failed: {response.status_code} {response.reason_phrase} "
                 f"— body: {response.text!r} (user_id={user.id}, role={user.role})"
             )
-        return response.json()
+        return DetailedSessionResponse.model_validate(response.json())
 
     @staticmethod
-    def list_sessions(user: DATestUser) -> list[dict[str, Any]]:
+    def create_with_sandbox(
+        user: DATestUser,
+        **kwargs: Any,
+    ) -> SessionWithSandbox:
+        """Create a session and return ``(session_id, sandbox_id)``.
+
+        Asserts the response carries a RUNNING sandbox.
+        """
+        session = BuildSessionManager.create(user, **kwargs)
+        sandbox = session.sandbox
+        assert sandbox is not None, (
+            f"session create did not return a sandbox: {session!r}"
+        )
+        assert sandbox.status == SandboxStatus.RUNNING, (
+            f"session create returned a non-RUNNING sandbox: {sandbox!r}"
+        )
+        return SessionWithSandbox(
+            session_id=UUID(session.id), sandbox_id=UUID(sandbox.id)
+        )
+
+    @staticmethod
+    def list_sessions(user: DATestUser) -> list[SessionResponse]:
         response = client.get(
             _sessions_url(),
             headers=user.headers,
             cookies=user.cookies,
         )
         response.raise_for_status()
-        body = response.json()
-        # Endpoint returns ``SessionListResponse``; sessions live under
-        # the ``sessions`` key.
-        if isinstance(body, dict) and "sessions" in body:
-            sessions = body["sessions"]
-            assert isinstance(sessions, list)
-            return sessions
-        assert isinstance(body, list)
-        return body
+        return SessionListResponse.model_validate(response.json()).sessions
 
     @staticmethod
-    def restore(user: DATestUser, session_id: UUID) -> dict[str, Any]:
+    def restore(user: DATestUser, session_id: UUID) -> DetailedSessionResponse:
         response = client.post(
             _sessions_url(str(session_id), "restore"),
             headers=user.headers,
             cookies=user.cookies,
         )
         response.raise_for_status()
-        return response.json()
+        return DetailedSessionResponse.model_validate(response.json())
+
+    @staticmethod
+    def create_snapshot(user: DATestUser, session_id: UUID) -> SnapshotResponse | None:
+        """POST /snapshot; ``None`` on 204 (session has no outputs to snapshot)."""
+        response = client.post(
+            _sessions_url(str(session_id), "snapshot"),
+            headers=user.headers,
+            cookies=user.cookies,
+        )
+        if response.status_code == 204:
+            return None
+        response.raise_for_status()
+        return SnapshotResponse.model_validate(response.json())
+
+    @staticmethod
+    def create_opencode_history_snapshot(
+        user: DATestUser, session_id: UUID
+    ) -> OpencodeHistorySnapshotResponse:
+        response = client.post(
+            _sessions_url(str(session_id), "opencode-history-snapshot"),
+            headers=user.headers,
+            cookies=user.cookies,
+        )
+        response.raise_for_status()
+        return OpencodeHistorySnapshotResponse.model_validate(response.json())
 
     @staticmethod
     def start_turn(
@@ -103,7 +158,7 @@ class BuildSessionManager:
         content: str,
         *,
         client_request_id: str | None = None,
-    ) -> dict[str, Any]:
+    ) -> InteractiveTurnResponse:
         url = _build_url("sessions", str(session_id), "send-message")
         body: dict[str, Any] = {"content": content}
         if client_request_id is not None:
@@ -115,30 +170,33 @@ class BuildSessionManager:
             cookies=user.cookies,
         )
         response.raise_for_status()
-        return response.json()
+        return InteractiveTurnResponse.model_validate(response.json())
 
     @staticmethod
     def get_active_turn(
         user: DATestUser,
         session_id: UUID,
-    ) -> dict[str, Any] | None:
+    ) -> InteractiveTurnResponse | None:
         response = client.get(
             _build_url("sessions", str(session_id), "turns", "active"),
             headers=user.headers,
             cookies=user.cookies,
         )
         response.raise_for_status()
-        return response.json()
+        body = response.json()
+        return (
+            InteractiveTurnResponse.model_validate(body) if body is not None else None
+        )
 
     @staticmethod
-    def list_messages(user: DATestUser, session_id: UUID) -> list[dict[str, Any]]:
+    def list_messages(user: DATestUser, session_id: UUID) -> list[MessageResponse]:
         response = client.get(
             _build_url("sessions", str(session_id), "messages"),
             headers=user.headers,
             cookies=user.cookies,
         )
         response.raise_for_status()
-        return response.json()["messages"]
+        return MessageListResponse.model_validate(response.json()).messages
 
     @staticmethod
     def upload_file(
@@ -146,7 +204,7 @@ class BuildSessionManager:
         session_id: UUID,
         filename: str,
         content: bytes,
-    ) -> dict[str, Any]:
+    ) -> UploadResponse:
         # File-upload endpoints require multipart; the session cookie still
         # works but Content-Type must be left to ``requests``.
         headers = {k: v for k, v in user.headers.items() if k.lower() != "content-type"}
@@ -157,7 +215,7 @@ class BuildSessionManager:
             cookies=user.cookies,
         )
         response.raise_for_status()
-        return response.json()
+        return UploadResponse.model_validate(response.json())
 
     @staticmethod
     def delete_file(
@@ -177,7 +235,7 @@ class BuildSessionManager:
         user: DATestUser,
         session_id: UUID,
         path: str = "",
-    ) -> dict[str, Any]:
+    ) -> DirectoryListing:
         response = client.get(
             _sessions_url(str(session_id), "files"),
             params={"path": path} if path else None,
@@ -185,7 +243,7 @@ class BuildSessionManager:
             cookies=user.cookies,
         )
         response.raise_for_status()
-        return response.json()
+        return DirectoryListing.model_validate(response.json())
 
     @staticmethod
     def download_artifact(

--- a/backend/tests/integration/common_utils/managers/llm_provider.py
+++ b/backend/tests/integration/common_utils/managers/llm_provider.py
@@ -100,7 +100,7 @@ class LLMProviderManager:
 
     @staticmethod
     def delete(
-        llm_provider: DATestLLMProvider,
+        llm_provider: DATestLLMProvider | LLMProviderView,
         user_performing_action: DATestUser,
     ) -> bool:
         response = client.delete(

--- a/backend/tests/integration/tests/craft/conftest.py
+++ b/backend/tests/integration/tests/craft/conftest.py
@@ -3,15 +3,14 @@
 from __future__ import annotations
 
 import contextlib
-import time
 from collections.abc import Generator
+from typing import NamedTuple
 from uuid import UUID
 from uuid import uuid4
 
 import httpx
 import pytest
 
-from onyx.auth.schemas import UserRole
 from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.engine.sql_engine import SqlEngine
 from onyx.server.features.build.configs import SANDBOX_BACKEND
@@ -19,116 +18,65 @@ from onyx.server.features.build.configs import SandboxBackend
 from onyx.server.features.build.db.sandbox import get_running_sandboxes
 from onyx.server.features.build.sandbox.factory import get_sandbox_manager
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
-from tests.integration.common_utils import http_client
+from tests.common.craft.users import create_or_login_admin
 from tests.integration.common_utils.constants import ADMIN_USER_NAME
-from tests.integration.common_utils.constants import GENERAL_HEADERS
+from tests.integration.common_utils.http_client import RetryingTransport
+from tests.integration.common_utils.http_client import set_test_client
 from tests.integration.common_utils.managers.build_session import BuildSessionManager
 from tests.integration.common_utils.managers.llm_provider import LLMProviderManager
-from tests.integration.common_utils.managers.user import build_email
-from tests.integration.common_utils.managers.user import DEFAULT_PASSWORD
 from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.test_models import DATestLLMProvider
 from tests.integration.common_utils.test_models import DATestUser
 
 
+class SharedSession(NamedTuple):
+    owner: DATestUser
+    session_id: UUID
+
+
 @pytest.fixture(scope="module", autouse=True)
 def _reap_module_sandboxes() -> Generator[None, None, None]:
-    yield
+    """Safety net for leaked suite sandboxes only.
+
+    Snapshots the RUNNING sandbox IDs at setup and reaps only IDs that appeared
+    during the module, so unrelated sandboxes on a shared cluster are untouched.
+    """
     if SANDBOX_BACKEND != SandboxBackend.DOCKER:
+        yield
         return
     SqlEngine.init_engine(pool_size=2, max_overflow=2)
     with get_session_with_tenant(
         tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
     ) as db:
-        running = get_running_sandboxes(db)
+        preexisting = {sandbox.id for sandbox in get_running_sandboxes(db)}
+    yield
+    with get_session_with_tenant(
+        tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+    ) as db:
+        leaked = [
+            sandbox
+            for sandbox in get_running_sandboxes(db)
+            if sandbox.id not in preexisting
+        ]
     manager = get_sandbox_manager()
-    for sandbox in running:
+    for sandbox in leaked:
         with contextlib.suppress(Exception):
             manager.terminate(sandbox.id)
-
-
-_CONNECT_RETRY_EXCEPTIONS = (
-    httpx.ConnectError,
-    httpx.ConnectTimeout,
-    httpx.PoolTimeout,
-)
-_SAFE_RETRY_EXCEPTIONS = (
-    httpx.ReadTimeout,
-    httpx.RemoteProtocolError,
-)
-_RETRY_STATUSES = {502, 504}
-_SAFE_RETRY_METHODS = {"GET", "HEAD", "OPTIONS"}
-_MAX_ATTEMPTS = 3
-
-
-class _RetryingTransport(httpx.HTTPTransport):
-    def handle_request(self, request: httpx.Request) -> httpx.Response:
-        backoff = 0.5
-        for attempt in range(_MAX_ATTEMPTS):
-            last = attempt == _MAX_ATTEMPTS - 1
-            try:
-                response = super().handle_request(request)
-            except _CONNECT_RETRY_EXCEPTIONS:
-                if last:
-                    raise
-                time.sleep(backoff)
-                backoff *= 2
-                continue
-            except _SAFE_RETRY_EXCEPTIONS:
-                if last or request.method.upper() not in _SAFE_RETRY_METHODS:
-                    raise
-                time.sleep(backoff)
-                backoff *= 2
-                continue
-            if (
-                response.status_code in _RETRY_STATUSES
-                and request.method.upper() in _SAFE_RETRY_METHODS
-                and not last
-            ):
-                response.close()
-                time.sleep(backoff)
-                backoff *= 2
-                continue
-            return response
-        raise AssertionError("unreachable")
-
-
-def _create_or_login_user(name: str, expected_role: UserRole) -> DATestUser:
-    try:
-        user = UserManager.create(name=name)
-    except httpx.HTTPStatusError as exc:
-        if exc.response.status_code != 400:
-            raise
-        user = UserManager.login_as_user(
-            DATestUser(
-                id="",
-                email=build_email(name),
-                password=DEFAULT_PASSWORD,
-                headers=GENERAL_HEADERS.copy(),
-                role=expected_role,
-                is_active=True,
-            )
-        )
-    if user.role != expected_role:
-        raise AssertionError(
-            f"Expected {name} to have role {expected_role.value}, got {user.role.value}"
-        )
-    return user
 
 
 @pytest.fixture(scope="session", autouse=True)
 def _test_client() -> Generator[httpx.Client, None, None]:
     """httpx client targeting the real out-of-process api_server."""
     real_client = httpx.Client(
-        transport=_RetryingTransport(),
+        transport=RetryingTransport(),
         timeout=httpx.Timeout(60.0, connect=10.0),
     )
-    http_client.set_test_client(real_client)
+    set_test_client(real_client)
     try:
         yield real_client
     finally:
         real_client.close()
-        http_client.set_test_client(None)
+        set_test_client(None)
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -147,7 +95,7 @@ def _start_celery_workers() -> Generator[None, None, None]:
 def _module_reset_and_seed() -> None:
     """Skip the parent's reset_all() (out-of-process downgrade deadlocks against
     the api_server's pooled connections); seed an admin + LLM provider."""
-    admin = _create_or_login_user(ADMIN_USER_NAME, UserRole.ADMIN)
+    admin = create_or_login_admin(ADMIN_USER_NAME)
     LLMProviderManager.create(user_performing_action=admin, api_key="test-api-key")
 
 
@@ -163,7 +111,7 @@ def llm_provider(admin_user: DATestUser) -> DATestLLMProvider:
 @pytest.fixture(scope="module")
 def shared_session(
     request: pytest.FixtureRequest,
-) -> Generator[tuple[DATestUser, UUID], None, None]:
+) -> Generator[SharedSession, None, None]:
     """One provisioned session + sandbox, shared across a module's tests.
 
     Owned by a per-module user isolated from the function-scoped
@@ -174,12 +122,12 @@ def shared_session(
     slug = request.module.__name__.rsplit(".", 1)[-1].replace("_", "-")
     owner = UserManager.create(name=f"craft-shared-{slug}-{uuid4().hex[:8]}")
     body = BuildSessionManager.create(owner)
-    sandbox = body.get("sandbox")
+    sandbox = body.sandbox
     try:
-        yield owner, UUID(body["id"])
+        yield SharedSession(owner=owner, session_id=UUID(body.id))
     finally:
-        if sandbox and sandbox.get("id"):
+        if sandbox:
             try:
-                get_sandbox_manager().terminate(UUID(sandbox["id"]))
+                get_sandbox_manager().terminate(UUID(sandbox.id))
             except Exception:
                 pass

--- a/backend/tests/integration/tests/craft/docker_e2e/conftest.py
+++ b/backend/tests/integration/tests/craft/docker_e2e/conftest.py
@@ -11,6 +11,7 @@ import pytest
 from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.enums import EndpointPolicy
 from onyx.db.enums import ExternalAppType
+from onyx.db.enums import SandboxStatus
 from onyx.db.external_app import create_external_app
 from onyx.db.external_app import get_built_in_external_app
 from tests.integration.common_utils.managers.build_session import BuildSessionManager
@@ -58,12 +59,12 @@ def _docker_exec(
 
 def _provision_sandbox(user: DATestUser) -> tuple[UUID, str]:
     session = BuildSessionManager.create(user)
-    sandbox = session["sandbox"]
+    sandbox = session.sandbox
     assert sandbox is not None, f"Session response missing sandbox: {session!r}"
-    assert sandbox["status"].upper() == "RUNNING", (
-        f"Sandbox not RUNNING after create: {sandbox['status']!r}"
+    assert sandbox.status == SandboxStatus.RUNNING, (
+        f"Sandbox not RUNNING after create: {sandbox.status!r}"
     )
-    return UUID(session["id"]), _container_name(sandbox["id"])
+    return UUID(session.id), _container_name(sandbox.id)
 
 
 @pytest.fixture(scope="session")

--- a/backend/tests/integration/tests/craft/docker_e2e/test_snapshot_roundtrip_docker.py
+++ b/backend/tests/integration/tests/craft/docker_e2e/test_snapshot_roundtrip_docker.py
@@ -140,8 +140,9 @@ def test_session_and_opencode_history_survive_snapshot_restore(
     # The container name derives from the sandbox id, which restore keeps
     # stable, so `container` still points at the fresh container. Assert it so a
     # future re-key fails here loudly rather than as a cryptic exec error below.
-    assert restored["sandbox"] is not None
-    assert restored["sandbox"]["id"] == str(sandbox_id), (
+    sandbox = restored.sandbox
+    assert sandbox is not None
+    assert sandbox.id == str(sandbox_id), (
         "Restore changed the sandbox id; the container name derived from the "
         "original id is now stale."
     )

--- a/backend/tests/integration/tests/craft/docker_e2e/test_workspace_setup_docker.py
+++ b/backend/tests/integration/tests/craft/docker_e2e/test_workspace_setup_docker.py
@@ -148,7 +148,7 @@ def test_session_setup_creates_user_writable_workspace(
     private_listing = BuildSessionManager.list_files(
         workspace_user, session_id, "outputs/private"
     )
-    private_names = {entry["name"] for entry in private_listing["entries"]}
+    private_names = {entry.name for entry in private_listing.entries}
     assert "private.txt" in private_names
 
     downloaded = BuildSessionManager.download_artifact(
@@ -163,16 +163,16 @@ def test_session_setup_creates_user_writable_workspace(
         filename=upload_name,
         content=b"docker workspace setup check",
     )
-    assert upload["filename"] == upload_name
-    assert upload["path"] == f"attachments/{upload_name}"
+    assert upload.filename == upload_name
+    assert upload.path == f"attachments/{upload_name}"
 
     listing = BuildSessionManager.list_files(workspace_user, session_id, "attachments")
-    attachment_names = {entry["name"] for entry in listing["entries"]}
+    attachment_names = {entry.name for entry in listing.entries}
     assert upload_name in attachment_names
 
-    BuildSessionManager.delete_file(workspace_user, session_id, upload["path"])
+    BuildSessionManager.delete_file(workspace_user, session_id, upload.path)
     post_delete_listing = BuildSessionManager.list_files(
         workspace_user, session_id, "attachments"
     )
-    post_delete_names = {entry["name"] for entry in post_delete_listing["entries"]}
+    post_delete_names = {entry.name for entry in post_delete_listing.entries}
     assert upload_name not in post_delete_names

--- a/backend/tests/integration/tests/craft/test_file_ops_api.py
+++ b/backend/tests/integration/tests/craft/test_file_ops_api.py
@@ -11,19 +11,18 @@ from onyx.server.features.build.sandbox.factory import get_sandbox_manager
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.http_client import client
 from tests.integration.common_utils.managers.build_session import BuildSessionManager
+from tests.integration.common_utils.managers.build_session import SessionWithSandbox
 from tests.integration.common_utils.test_models import DATestUser
+from tests.integration.tests.craft.conftest import SharedSession
 
 
 def _create_session_id(user: DATestUser) -> UUID:
     session = BuildSessionManager.create(user)
-    return UUID(session["id"])
+    return UUID(session.id)
 
 
-def _create_session_with_sandbox(user: DATestUser) -> tuple[UUID, UUID]:
-    session = BuildSessionManager.create(user)
-    sandbox = session["sandbox"]
-    assert sandbox is not None, "session create did not return a sandbox"
-    return UUID(session["id"]), UUID(sandbox["id"])
+def _create_session_with_sandbox(user: DATestUser) -> SessionWithSandbox:
+    return BuildSessionManager.create_with_sandbox(user)
 
 
 def _files_url(session_id: UUID) -> str:
@@ -54,11 +53,11 @@ def _seed_file(user: DATestUser, session_id: UUID, name: str = "seed.txt") -> st
     body = BuildSessionManager.upload_file(
         user, session_id, filename=name, content=b"seed-content"
     )
-    return str(body["path"])
+    return str(body.path)
 
 
 def test_list_directory_rejects_path_traversal(
-    shared_session: tuple[DATestUser, UUID],
+    shared_session: SharedSession,
 ) -> None:
     owner, session_id = shared_session
     response = client.get(
@@ -67,13 +66,14 @@ def test_list_directory_rejects_path_traversal(
         headers=owner.headers,
         cookies=owner.cookies,
     )
-    assert response.status_code in (200, 403)
-    if response.status_code == 200:
-        assert response.json()["entries"] == []
+    # list_directory sanitizes by stripping ".." (never raises traversal), so a
+    # traversal path resolves to a missing dir and returns an empty 200 listing.
+    assert response.status_code == 200
+    assert response.json()["entries"] == []
 
 
 def test_list_directory_returns_200_for_missing_dir(
-    shared_session: tuple[DATestUser, UUID],
+    shared_session: SharedSession,
 ) -> None:
     owner, session_id = shared_session
     response = client.get(
@@ -88,7 +88,7 @@ def test_list_directory_returns_200_for_missing_dir(
 
 
 def test_list_directory_returns_empty_when_workspace_missing(
-    shared_session: tuple[DATestUser, UUID],
+    shared_session: SharedSession,
 ) -> None:
     owner, session_id = shared_session
 
@@ -104,7 +104,7 @@ def test_list_directory_returns_empty_when_workspace_missing(
 
 
 def test_read_file_rejects_path_traversal(
-    shared_session: tuple[DATestUser, UUID],
+    shared_session: SharedSession,
 ) -> None:
     owner, session_id = shared_session
     response = client.get(
@@ -112,11 +112,12 @@ def test_read_file_rejects_path_traversal(
         headers=owner.headers,
         cookies=owner.cookies,
     )
-    assert response.status_code in (400, 403, 404)
+    # read_file strips ".." and resolves to a missing file -> 404.
+    assert response.status_code == 404
 
 
 def test_delete_file_rejects_path_traversal(
-    shared_session: tuple[DATestUser, UUID],
+    shared_session: SharedSession,
 ) -> None:
     owner, session_id = shared_session
     response = client.delete(
@@ -124,11 +125,12 @@ def test_delete_file_rejects_path_traversal(
         headers=owner.headers,
         cookies=owner.cookies,
     )
-    assert response.status_code in (403, 404)
+    # httpx normalizes raw "../" before sending, so the server sees a non-existent path -> 404.
+    assert response.status_code == 404
 
 
 def test_delete_file_rejects_url_encoded_traversal(
-    shared_session: tuple[DATestUser, UUID],
+    shared_session: SharedSession,
 ) -> None:
     owner, session_id = shared_session
     response = client.delete(
@@ -144,7 +146,7 @@ def test_delete_file_rejects_url_encoded_traversal(
     [";", "|", "`", "$()", "&"],
 )
 def test_delete_file_rejects_shell_metachars(
-    shared_session: tuple[DATestUser, UUID], metachar: str
+    shared_session: SharedSession, metachar: str
 ) -> None:
     owner, session_id = shared_session
     encoded = quote(f"attachments/foo{metachar}bar.txt", safe="/")
@@ -157,7 +159,7 @@ def test_delete_file_rejects_shell_metachars(
 
 
 def test_delete_file_rejects_null_byte(
-    shared_session: tuple[DATestUser, UUID],
+    shared_session: SharedSession,
 ) -> None:
     owner, session_id = shared_session
     response = client.delete(
@@ -168,8 +170,20 @@ def test_delete_file_rejects_null_byte(
     assert response.status_code == 403
 
 
+def test_delete_missing_file_returns_404(
+    shared_session: SharedSession,
+) -> None:
+    owner, session_id = shared_session
+    response = client.delete(
+        _delete_file_url(session_id, "attachments/does-not-exist-abc123.txt"),
+        headers=owner.headers,
+        cookies=owner.cookies,
+    )
+    assert response.status_code == 404
+
+
 def test_download_artifact_rejects_path_traversal(
-    shared_session: tuple[DATestUser, UUID],
+    shared_session: SharedSession,
 ) -> None:
     owner, session_id = shared_session
     response = client.get(
@@ -177,7 +191,8 @@ def test_download_artifact_rejects_path_traversal(
         headers=owner.headers,
         cookies=owner.cookies,
     )
-    assert response.status_code in (400, 403, 404)
+    # read_file strips ".." and resolves to a missing file -> 404.
+    assert response.status_code == 404
 
 
 def test_upload_stats_empty_session_has_no_attachments(
@@ -186,7 +201,7 @@ def test_upload_stats_empty_session_has_no_attachments(
     session_id = _create_session_id(admin_user)
 
     listing = BuildSessionManager.list_files(admin_user, session_id, path="attachments")
-    files = [e for e in listing.get("entries", []) if not e["is_directory"]]
+    files = [e for e in listing.entries if not e.is_directory]
     assert files == []
 
 
@@ -203,14 +218,14 @@ def test_upload_stats_reflect_uploaded_files(admin_user: DATestUser) -> None:
     )
 
     listing = BuildSessionManager.list_files(admin_user, session_id, path="attachments")
-    files = [e for e in listing.get("entries", []) if not e["is_directory"]]
-    sizes_by_name = {e["name"]: e["size"] for e in files}
+    files = [e for e in listing.entries if not e.is_directory]
+    sizes_by_name = {e.name: e.size for e in files}
 
     assert sizes_by_name == {"file1.txt": len(first), "file2.txt": len(second)}
 
 
 def test_download_directory_zip_respects_traversal_rules(
-    shared_session: tuple[DATestUser, UUID],
+    shared_session: SharedSession,
 ) -> None:
     owner, session_id = shared_session
     response = client.get(
@@ -222,7 +237,7 @@ def test_download_directory_zip_respects_traversal_rules(
 
 
 def test_pptx_preview_rejects_non_pptx(
-    shared_session: tuple[DATestUser, UUID],
+    shared_session: SharedSession,
 ) -> None:
     owner, session_id = shared_session
     response = client.get(
@@ -234,7 +249,7 @@ def test_pptx_preview_rejects_non_pptx(
 
 
 def test_export_docx_rejects_non_md(
-    shared_session: tuple[DATestUser, UUID],
+    shared_session: SharedSession,
 ) -> None:
     owner, session_id = shared_session
     # Seed a real .txt so the endpoint reaches the extension check, not "not found".
@@ -282,7 +297,7 @@ def test_list_directory_filters_hidden_entries(
         )
 
     listing = BuildSessionManager.list_files(admin_user, session_id)
-    names = {entry["name"] for entry in listing.get("entries", [])}
+    names = {entry.name for entry in listing.entries}
 
     assert ".venv" not in names
     assert "node_modules" not in names
@@ -292,12 +307,12 @@ def test_list_directory_filters_hidden_entries(
 
 
 def test_cross_user_file_access_returns_404(
-    admin_user: DATestUser, basic_user: DATestUser
+    shared_session: SharedSession, admin_user: DATestUser
 ) -> None:
-    foreign_session_id = _create_session_id(basic_user)
+    _owner, session_id = shared_session
 
     response = client.get(
-        _files_url(foreign_session_id),
+        _files_url(session_id),
         headers=admin_user.headers,
         cookies=admin_user.cookies,
     )

--- a/backend/tests/integration/tests/craft/test_messages_api.py
+++ b/backend/tests/integration/tests/craft/test_messages_api.py
@@ -2,22 +2,23 @@
 
 from __future__ import annotations
 
-import uuid
 from uuid import UUID
+from uuid import uuid4
 
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.http_client import client
 from tests.integration.common_utils.managers.build_session import BuildSessionManager
 from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.test_models import DATestUser
+from tests.integration.tests.craft.conftest import SharedSession
 
 
 def test_send_message_starts_background_turn_and_is_idempotent(
     admin_user: DATestUser,
 ) -> None:
     body = BuildSessionManager.create(admin_user)
-    session_id = uuid.UUID(body["id"])
-    request_id = f"req-{uuid.uuid4()}"
+    session_id = UUID(body.id)
+    request_id = f"req-{uuid4()}"
 
     first = BuildSessionManager.start_turn(
         admin_user,
@@ -32,39 +33,39 @@ def test_send_message_starts_background_turn_and_is_idempotent(
         client_request_id=request_id,
     )
 
-    assert first["turn_id"] == same["turn_id"]
-    assert first["session_id"] == str(session_id)
-    assert first["status"] in {"QUEUED", "RUNNING"}
-    assert first["turn_index"] == 0
+    assert first.turn_id == same.turn_id
+    assert first.session_id == str(session_id)
+    assert first.status in {"QUEUED", "RUNNING"}
+    assert first.turn_index == 0
 
     active_turn = BuildSessionManager.get_active_turn(admin_user, session_id)
     if active_turn is not None:
-        assert active_turn["turn_id"] == first["turn_id"]
+        assert active_turn.turn_id == first.turn_id
 
     messages = BuildSessionManager.list_messages(admin_user, session_id)
-    user_messages = [msg for msg in messages if msg["type"] == "user"]
+    user_messages = [msg for msg in messages if msg.type == "user"]
     assert len(user_messages) == 1
-    assert user_messages[0]["turn_index"] == 0
+    assert user_messages[0].turn_index == 0
 
 
 def test_send_message_rejects_concurrent_active_turn(
     admin_user: DATestUser,
 ) -> None:
     body = BuildSessionManager.create(admin_user)
-    session_id = uuid.UUID(body["id"])
+    session_id = UUID(body.id)
 
     BuildSessionManager.start_turn(
         admin_user,
         session_id,
         "hello",
-        client_request_id=f"req-{uuid.uuid4()}",
+        client_request_id=f"req-{uuid4()}",
     )
 
     response = client.post(
         f"{API_SERVER_URL}/build/sessions/{session_id}/send-message",
         json={
             "content": "again",
-            "client_request_id": f"req-{uuid.uuid4()}",
+            "client_request_id": f"req-{uuid4()}",
         },
         headers=admin_user.headers,
         cookies=admin_user.cookies,
@@ -75,10 +76,10 @@ def test_send_message_rejects_concurrent_active_turn(
 
 
 def test_send_message_404_for_other_users_session(
-    shared_session: tuple[DATestUser, UUID],
+    shared_session: SharedSession,
 ) -> None:
     _owner, session_id = shared_session
-    other_user = UserManager.create(name=f"otheruser-{uuid.uuid4().hex[:8]}")
+    other_user = UserManager.create(name=f"otheruser-{uuid4().hex[:8]}")
 
     response = client.post(
         f"{API_SERVER_URL}/build/sessions/{session_id}/send-message",
@@ -91,12 +92,12 @@ def test_send_message_404_for_other_users_session(
 
 
 def test_turn_events_requires_active_turn(
-    shared_session: tuple[DATestUser, UUID],
+    shared_session: SharedSession,
 ) -> None:
     owner, session_id = shared_session
 
     response = client.get(
-        f"{API_SERVER_URL}/build/sessions/{session_id}/turns/{uuid.uuid4()}/events",
+        f"{API_SERVER_URL}/build/sessions/{session_id}/turns/{uuid4()}/events",
         headers=owner.headers,
         cookies=owner.cookies,
     )

--- a/backend/tests/integration/tests/craft/test_sessions_api.py
+++ b/backend/tests/integration/tests/craft/test_sessions_api.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-import uuid
-from typing import Any
 from uuid import UUID
+from uuid import uuid4
 
 from onyx.db.enums import SharingScope
 from onyx.redis.redis_pool import get_redis_client
@@ -18,25 +17,13 @@ from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.test_models import DATestLLMProvider
 from tests.integration.common_utils.test_models import DATestSettings
 from tests.integration.common_utils.test_models import DATestUser
-
-
-def _create_session(user: DATestUser) -> dict[str, Any]:
-    return BuildSessionManager.create(user)
-
-
-def _send_one_message(user: DATestUser, session_id: uuid.UUID) -> None:
-    BuildSessionManager.start_turn(
-        user,
-        session_id,
-        "hello",
-        client_request_id=f"session-list-{uuid.uuid4()}",
-    )
+from tests.integration.tests.craft.conftest import SharedSession
 
 
 def test_create_session_returns_200_with_session_and_sandbox_shape(
     llm_provider: DATestLLMProvider,  # noqa: ARG001 — ensures a default LLM exists
 ) -> None:
-    owner = UserManager.create(name=f"craft-session-shape-{uuid.uuid4().hex[:8]}")
+    owner = UserManager.create(name=f"craft-session-shape-{uuid4().hex[:8]}")
     response = client.post(
         f"{API_SERVER_URL}/build/sessions",
         json={"headless": False},
@@ -54,9 +41,9 @@ def test_set_sharing_scope_changes_webapp_visibility(
     basic_user: DATestUser,
     llm_provider: DATestLLMProvider,  # noqa: ARG001
 ) -> None:
-    body = _create_session(admin_user)
-    session_uuid = uuid.UUID(body["id"])
-    webapp_url = f"{API_SERVER_URL}/build/sessions/{body['id']}/webapp"
+    body = BuildSessionManager.create(admin_user)
+    session_uuid = UUID(body.id)
+    webapp_url = f"{API_SERVER_URL}/build/sessions/{body.id}/webapp"
 
     private_response = client.get(
         webapp_url,
@@ -74,7 +61,9 @@ def test_set_sharing_scope_changes_webapp_visibility(
         cookies=basic_user.cookies,
         follow_redirects=False,
     )
-    assert public_response.status_code in (200, 502, 503, 504)
+    # Session is headless (no Next.js port), so the proxy renders the branded
+    # offline page; the handler remaps any upstream 502/503/504 to a 503.
+    assert public_response.status_code == 503
     assert "text/html" in public_response.headers.get("content-type", "").lower()
 
 
@@ -82,9 +71,10 @@ def test_restore_session_returns_409_when_lock_held(
     admin_user: DATestUser,
     llm_provider: DATestLLMProvider,  # noqa: ARG001
 ) -> None:
-    body = _create_session(admin_user)
-    session_id = body["id"]
-    sandbox_id = body["sandbox"]["id"]
+    body = BuildSessionManager.create(admin_user)
+    session_id = body.id
+    assert body.sandbox is not None
+    sandbox_id = body.sandbox.id
 
     redis_client = get_redis_client(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     lock = redis_client.lock(
@@ -109,15 +99,16 @@ def test_create_session_requires_auth() -> None:
         json={},
         headers={"Content-Type": "application/json"},
     )
+    # current_user rejects with 401; require_permission rejects with 403.
     assert response.status_code in (401, 403)
 
 
 def test_get_session_404_for_other_users_session(
-    shared_session: tuple[DATestUser, UUID],
+    shared_session: SharedSession,
 ) -> None:
     _owner, session_id = shared_session
 
-    other_user = UserManager.create(name=f"other-{uuid.uuid4().hex[:8]}")
+    other_user = UserManager.create(name=f"other-{uuid4().hex[:8]}")
     response = client.get(
         f"{API_SERVER_URL}/build/sessions/{session_id}",
         headers=other_user.headers,
@@ -130,25 +121,35 @@ def test_list_sessions_only_returns_callers_interactive_sessions(
     admin_user: DATestUser,
     llm_provider: DATestLLMProvider,  # noqa: ARG001
 ) -> None:
-    mine = _create_session(admin_user)
-    _send_one_message(admin_user, uuid.UUID(mine["id"]))
+    mine = BuildSessionManager.create(admin_user)
+    BuildSessionManager.start_turn(
+        admin_user,
+        UUID(mine.id),
+        "hello",
+        client_request_id=f"session-list-{uuid4()}",
+    )
 
-    other_user = UserManager.create(name=f"other-{uuid.uuid4().hex[:8]}")
-    theirs = _create_session(other_user)
-    _send_one_message(other_user, uuid.UUID(theirs["id"]))
+    other_user = UserManager.create(name=f"other-{uuid4().hex[:8]}")
+    theirs = BuildSessionManager.create(other_user)
+    BuildSessionManager.start_turn(
+        other_user,
+        UUID(theirs.id),
+        "hello",
+        client_request_id=f"session-list-{uuid4()}",
+    )
 
     sessions = BuildSessionManager.list_sessions(admin_user)
-    ids = {s["id"] for s in sessions}
-    assert mine["id"] in ids
-    assert theirs["id"] not in ids
+    ids = {s.id for s in sessions}
+    assert mine.id in ids
+    assert theirs.id not in ids
 
 
 def test_delete_session_returns_204_and_actually_deletes(
     admin_user: DATestUser,
     llm_provider: DATestLLMProvider,  # noqa: ARG001
 ) -> None:
-    body = _create_session(admin_user)
-    session_id = body["id"]
+    body = BuildSessionManager.create(admin_user)
+    session_id = body.id
 
     response = client.delete(
         f"{API_SERVER_URL}/build/sessions/{session_id}",
@@ -169,8 +170,8 @@ def test_pre_provisioned_check_returns_valid_for_empty_session(
     admin_user: DATestUser,
     llm_provider: DATestLLMProvider,  # noqa: ARG001
 ) -> None:
-    body = _create_session(admin_user)
-    session_id = body["id"]
+    body = BuildSessionManager.create(admin_user)
+    session_id = body.id
 
     response = client.get(
         f"{API_SERVER_URL}/build/sessions/{session_id}/pre-provisioned-check",
@@ -187,10 +188,15 @@ def test_pre_provisioned_check_returns_invalid_after_first_message(
     admin_user: DATestUser,
     llm_provider: DATestLLMProvider,  # noqa: ARG001
 ) -> None:
-    body = _create_session(admin_user)
-    session_id = body["id"]
+    body = BuildSessionManager.create(admin_user)
+    session_id = body.id
 
-    _send_one_message(admin_user, uuid.UUID(session_id))
+    BuildSessionManager.start_turn(
+        admin_user,
+        UUID(session_id),
+        "hello",
+        client_request_id=f"session-list-{uuid4()}",
+    )
 
     response = client.get(
         f"{API_SERVER_URL}/build/sessions/{session_id}/pre-provisioned-check",
@@ -207,8 +213,8 @@ def test_rename_session_with_null_name_no_message_uses_id_fallback(
     admin_user: DATestUser,
     llm_provider: DATestLLMProvider,  # noqa: ARG001
 ) -> None:
-    body = _create_session(admin_user)
-    session_id = body["id"]
+    body = BuildSessionManager.create(admin_user)
+    session_id = body.id
 
     response = client.put(
         f"{API_SERVER_URL}/build/sessions/{session_id}/name",
@@ -225,15 +231,15 @@ def test_rename_session_with_null_name_falls_back_when_llm_call_fails(
     admin_user: DATestUser,
     llm_provider: DATestLLMProvider,  # noqa: ARG001
 ) -> None:
-    body = _create_session(admin_user)
-    session_id = body["id"]
+    body = BuildSessionManager.create(admin_user)
+    session_id = body.id
 
     prompt = "hello"
     BuildSessionManager.start_turn(
         admin_user,
-        uuid.UUID(session_id),
+        UUID(session_id),
         prompt,
-        client_request_id=f"rename-{uuid.uuid4()}",
+        client_request_id=f"rename-{uuid4()}",
     )
 
     response = client.put(
@@ -263,6 +269,7 @@ def test_limited_role_check_uses_account_type_not_permission_flags(
             headers=anon_user.headers,
             cookies=anon_user.cookies,
         )
+        # current_user rejects with 401; require_permission rejects with 403.
         assert response.status_code in (401, 403)
     finally:
         SettingsManager.update_settings(

--- a/backend/tests/integration/tests/craft/test_upload_api.py
+++ b/backend/tests/integration/tests/craft/test_upload_api.py
@@ -8,11 +8,13 @@ from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.http_client import client
 from tests.integration.common_utils.managers.build_session import BuildSessionManager
 from tests.integration.common_utils.test_models import DATestUser
+from tests.integration.tests.craft.conftest import SharedSession
+from tests.integration.tests.craft.user_library_http import multipart_headers
 
 
 def _create_session_id(user: DATestUser) -> UUID:
     session = BuildSessionManager.create(user)
-    return UUID(session["id"])
+    return UUID(session.id)
 
 
 def _upload_url(session_id: UUID) -> str:
@@ -28,19 +30,19 @@ def test_upload_endpoint_returns_file_metadata(admin_user: DATestUser) -> None:
         content=b"hello world",
     )
 
-    assert body["filename"] == "hello.txt"
-    assert isinstance(body["path"], str) and body["path"].endswith("hello.txt")
-    assert body["size_bytes"] == len(b"hello world")
+    assert body.filename == "hello.txt"
+    assert isinstance(body.path, str) and body.path.endswith("hello.txt")
+    assert body.size_bytes == len(b"hello world")
 
 
 def test_upload_over_per_file_cap_returns_400(
-    shared_session: tuple[DATestUser, UUID],
+    shared_session: SharedSession,
 ) -> None:
     owner, session_id = shared_session
 
     # CI lowers BUILD_MAX_UPLOAD_FILE_SIZE_MB to 2; a 3 MiB payload trips it.
     oversized = b"\x00" * (3 * 1024 * 1024)
-    headers = {k: v for k, v in owner.headers.items() if k.lower() != "content-type"}
+    headers = multipart_headers(owner)
     response = client.post(
         _upload_url(session_id),
         files={"file": ("big.txt", oversized, "application/octet-stream")},
@@ -62,9 +64,7 @@ def test_upload_at_count_cap_returns_429(admin_user: DATestUser) -> None:
             content=b"x",
         )
 
-    headers = {
-        k: v for k, v in admin_user.headers.items() if k.lower() != "content-type"
-    }
+    headers = multipart_headers(admin_user)
     response = client.post(
         _upload_url(session_id),
         files={"file": ("file_overflow.txt", b"x", "application/octet-stream")},
@@ -87,9 +87,7 @@ def test_upload_over_cumulative_cap_returns_429(admin_user: DATestUser) -> None:
             content=chunk,
         )
 
-    headers = {
-        k: v for k, v in admin_user.headers.items() if k.lower() != "content-type"
-    }
+    headers = multipart_headers(admin_user)
     response = client.post(
         _upload_url(session_id),
         files={"file": ("chunk_overflow.txt", chunk, "application/octet-stream")},
@@ -103,9 +101,7 @@ def test_upload_accepts_any_extension_via_http(admin_user: DATestUser) -> None:
     """Uploads are not restricted by extension/MIME; a .exe uploads fine."""
     session_id = _create_session_id(admin_user)
 
-    headers = {
-        k: v for k, v in admin_user.headers.items() if k.lower() != "content-type"
-    }
+    headers = multipart_headers(admin_user)
     response = client.post(
         _upload_url(session_id),
         files={"file": ("evil.exe", b"MZ\x90\x00", "application/octet-stream")},
@@ -129,8 +125,8 @@ def test_upload_with_unicode_filename_persists_correctly(
         filename="héllo wörld 你好.txt",
         content=original_bytes,
     )
-    sanitized_name = upload_response["filename"]
-    relative_path = upload_response["path"]
+    sanitized_name = upload_response.filename
+    relative_path = upload_response.path
 
     assert sanitized_name.endswith(".txt")
     assert relative_path.endswith(sanitized_name)
@@ -142,7 +138,7 @@ def test_upload_with_unicode_filename_persists_correctly(
 
 
 def test_upload_endpoint_requires_auth(
-    shared_session: tuple[DATestUser, UUID],
+    shared_session: SharedSession,
 ) -> None:
     """POST with no auth token returns 401 (or 403)."""
     _owner, session_id = shared_session
@@ -157,14 +153,12 @@ def test_upload_endpoint_requires_auth(
 
 
 def test_upload_endpoint_404_for_other_users_session(
-    shared_session: tuple[DATestUser, UUID], basic_user: DATestUser
+    shared_session: SharedSession, basic_user: DATestUser
 ) -> None:
     """Uploading to another user's session returns 404 (existence-hiding)."""
     _owner, foreign_session_id = shared_session
 
-    headers = {
-        k: v for k, v in basic_user.headers.items() if k.lower() != "content-type"
-    }
+    headers = multipart_headers(basic_user)
     response = client.post(
         _upload_url(foreign_session_id),
         files={"file": ("hello.txt", b"hi", "application/octet-stream")},

--- a/backend/tests/integration/tests/craft/test_user_library_api.py
+++ b/backend/tests/integration/tests/craft/test_user_library_api.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Any
 from uuid import uuid4
 
+from onyx.server.features.build.user_library.api import DeleteFileResponse
+from onyx.server.features.build.user_library.api import LibraryEntryResponse
+from onyx.server.features.build.user_library.api import UploadResponse
 from tests.integration.common_utils.test_models import DATestUser
 from tests.integration.tests.craft.user_library_http import delete_user_library_file
 from tests.integration.tests.craft.user_library_http import list_user_library_tree
@@ -14,9 +16,9 @@ from tests.integration.tests.craft.user_library_http import upload_user_library_
 
 
 def _find_doc_by_name(
-    entries: list[dict[str, Any]], name: str
-) -> dict[str, Any] | None:
-    return next((e for e in entries if e.get("name") == name), None)
+    entries: list[LibraryEntryResponse], name: str
+) -> LibraryEntryResponse | None:
+    return next((e for e in entries if e.name == name), None)
 
 
 def test_upload_persists_file_to_s3(admin_user: DATestUser) -> None:
@@ -27,17 +29,17 @@ def test_upload_persists_file_to_s3(admin_user: DATestUser) -> None:
         admin_user, [(filename, payload, "application/octet-stream")]
     )
     response.raise_for_status()
-    body = response.json()
+    body = UploadResponse.model_validate(response.json())
 
-    assert body["total_uploaded"] == 1
-    assert body["total_size_bytes"] == len(payload)
-    [entry] = body["entries"]
-    assert entry["name"] == filename
-    assert entry["file_size"] == len(payload)
-    assert entry["id"].startswith("CRAFT_FILE__")
+    assert body.total_uploaded == 1
+    assert body.total_size_bytes == len(payload)
+    [entry] = body.entries
+    assert entry.name == filename
+    assert entry.file_size == len(payload)
+    assert entry.id.startswith("CRAFT_FILE__")
 
     tree = list_user_library_tree(admin_user)
-    assert any(e["id"] == entry["id"] for e in tree)
+    assert any(e.id == entry.id for e in tree)
 
 
 def test_upload_batch_over_count_cap_rejects(admin_user: DATestUser) -> None:
@@ -56,11 +58,11 @@ def test_upload_zip_extracts_and_applies_caps_recursively(
     small_zip = make_zip_bytes({small_member_name: b"hello"})
     response = upload_user_library_zip(admin_user, small_zip, filename="small.zip")
     response.raise_for_status()
-    body = response.json()
-    assert body["total_uploaded"] == 1
-    [entry] = body["entries"]
+    body = UploadResponse.model_validate(response.json())
+    assert body.total_uploaded == 1
+    [_entry] = body.entries
     tree = list_user_library_tree(admin_user)
-    assert any(small_member_name in e.get("name", "") for e in tree)
+    assert any(small_member_name in e.name for e in tree)
 
     # CI lowers USER_LIBRARY_MAX_FILES_PER_UPLOAD to 5; a 6-member zip trips it.
     over_cap_members = {f"file-{i}-{uuid4().hex[:4]}.txt": b"x" for i in range(6)}
@@ -74,13 +76,15 @@ def test_delete_file_removes_s3_blob(admin_user: DATestUser) -> None:
     filename = f"delete-{uuid4().hex[:6]}.txt"
     response = upload_user_library_files(admin_user, [(filename, b"bye", "text/plain")])
     response.raise_for_status()
-    document_id = response.json()["entries"][0]["id"]
+    upload_body = UploadResponse.model_validate(response.json())
+    document_id = upload_body.entries[0].id
 
     assert _find_doc_by_name(list_user_library_tree(admin_user), filename) is not None
 
     delete_response = delete_user_library_file(admin_user, document_id)
     delete_response.raise_for_status()
-    assert delete_response.json()["deleted"] == document_id
+    delete_body = DeleteFileResponse.model_validate(delete_response.json())
+    assert delete_body.deleted == document_id
 
     assert _find_doc_by_name(list_user_library_tree(admin_user), filename) is None
 
@@ -94,10 +98,11 @@ def test_cross_user_access_returns_404(
         admin_user, [(filename, b"private", "text/plain")]
     )
     response.raise_for_status()
-    document_id = response.json()["entries"][0]["id"]
+    upload_body = UploadResponse.model_validate(response.json())
+    document_id = upload_body.entries[0].id
 
     delete_response = delete_user_library_file(basic_user, document_id)
     assert delete_response.status_code in (403, 404)
 
     basic_tree = list_user_library_tree(basic_user)
-    assert all(e["id"] != document_id for e in basic_tree)
+    assert all(e.id != document_id for e in basic_tree)

--- a/backend/tests/integration/tests/craft/test_webapp_proxy.py
+++ b/backend/tests/integration/tests/craft/test_webapp_proxy.py
@@ -11,6 +11,7 @@ from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.http_client import client
 from tests.integration.common_utils.managers.build_session import BuildSessionManager
 from tests.integration.common_utils.test_models import DATestUser
+from tests.integration.tests.craft.conftest import SharedSession
 
 
 def _webapp_url(session_id: UUID, path: str = "") -> str:
@@ -48,7 +49,7 @@ def _auth_get(
 
 
 def test_proxy_requires_auth_when_private(
-    shared_session: tuple[DATestUser, UUID],
+    shared_session: SharedSession,
 ) -> None:
     """Auth-required surfaces as either 401 or a 302 to /auth/login."""
     owner, session_id = shared_session
@@ -63,7 +64,7 @@ def test_proxy_requires_auth_when_private(
 
 
 def test_proxy_rejects_forged_auth_cookie(
-    shared_session: tuple[DATestUser, UUID],
+    shared_session: SharedSession,
 ) -> None:
     """A forged cookie resolves to no user; public_org still requires auth."""
     owner, session_id = shared_session
@@ -82,14 +83,15 @@ def test_proxy_rejects_forged_auth_cookie(
 
 
 def test_proxy_no_webapp_port_renders_branded_offline_page(
-    shared_session: tuple[DATestUser, UUID],
+    shared_session: SharedSession,
 ) -> None:
     # shared_session is headless, so no Next.js port is allocated.
     owner, session_id = shared_session
 
     response = _auth_get(owner, session_id, follow_redirects=False)
 
-    assert response.status_code in (502, 503, 504)
+    # No Next.js port -> _offline_html_response, which is always 503.
+    assert response.status_code == 503
     assert "text/html" in response.headers.get("content-type", "").lower()
     body = response.text
     assert "Craft" in body
@@ -100,7 +102,7 @@ def test_webapp_download_route_not_shadowed_by_catchall(
     admin_user: DATestUser,
 ) -> None:
     """``/webapp-download`` resolves to the zip endpoint, not the catch-all proxy."""
-    session_id = BuildSessionManager.create(admin_user)["id"]
+    session_id = BuildSessionManager.create(admin_user).id
 
     response = client.get(
         f"{API_SERVER_URL}/build/sessions/{session_id}/webapp-download",

--- a/backend/tests/integration/tests/craft/user_library_http.py
+++ b/backend/tests/integration/tests/craft/user_library_http.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 import io
 import zipfile
 from collections.abc import Iterable
-from typing import Any
 
 import httpx
 
+from onyx.server.features.build.user_library.api import LibraryEntryResponse
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.http_client import client
 from tests.integration.common_utils.test_models import DATestUser
@@ -18,7 +18,7 @@ def _url(*parts: str) -> str:
     return f"{API_SERVER_URL}/build/user-library/" + "/".join(parts)
 
 
-def _multipart_headers(user: DATestUser) -> dict[str, str]:
+def multipart_headers(user: DATestUser) -> dict[str, str]:
     """Drop the JSON Content-Type so the client can set the multipart one."""
     return {k: v for k, v in user.headers.items() if k.lower() != "content-type"}
 
@@ -39,7 +39,7 @@ def upload_user_library_files(
         _url("upload"),
         files=multipart,
         data={"path": path},
-        headers=_multipart_headers(user),
+        headers=multipart_headers(user),
         cookies=user.cookies,
     )
 
@@ -54,21 +54,19 @@ def upload_user_library_zip(
         _url("upload-zip"),
         files={"file": (filename, io.BytesIO(zip_bytes), "application/zip")},
         data={"path": path},
-        headers=_multipart_headers(user),
+        headers=multipart_headers(user),
         cookies=user.cookies,
     )
 
 
-def list_user_library_tree(user: DATestUser) -> list[dict[str, Any]]:
+def list_user_library_tree(user: DATestUser) -> list[LibraryEntryResponse]:
     response = client.get(
         _url("tree"),
         headers=user.headers,
         cookies=user.cookies,
     )
     response.raise_for_status()
-    body = response.json()
-    assert isinstance(body, list)
-    return body
+    return [LibraryEntryResponse.model_validate(entry) for entry in response.json()]
 
 
 def delete_user_library_file(user: DATestUser, document_id: str) -> httpx.Response:


### PR DESCRIPTION
## Description

Types the shared Craft integration test helper foundation and updates existing Craft integration consumers, including Docker callsites, to use validated model attribute access instead of raw response dicts.

Also centralizes the retrying HTTP transport and no-reset admin seeding helpers used by out-of-process Craft integration tests.

## How Has This Been Tested?


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
