### PR TITLE
feat(craft): scope sandbox PAT to least-privilege CRAFT_SANDBOX role

### DIFF
--- a/backend/onyx/auth/permissions.py
+++ b/backend/onyx/auth/permissions.py
@@ -54,6 +54,10 @@ IMPLIED_PERMISSIONS: dict[str, set[str]] = {
         Permission.WRITE_CHAT.value,
     },
     Permission.WRITE_CHAT.value: {Permission.READ_CHAT.value},
+    Permission.CRAFT_SANDBOX.value: {
+        Permission.READ_SEARCH.value,
+        Permission.REQUEST_APP_SETUP.value,
+    },
 }
 
 # Permissions that cannot be toggled via the group-permission API.
@@ -64,6 +68,7 @@ NON_TOGGLEABLE_PERMISSIONS: frozenset[Permission] = frozenset(
     {
         Permission.BASIC_ACCESS,
         Permission.FULL_ADMIN_PANEL_ACCESS,
+        Permission.CRAFT_SANDBOX,
     }
     | Permission.IMPLIED
 )
@@ -102,22 +107,32 @@ def require_permission(
     required: Permission,
     *,
     allow_anonymous: bool = False,
+    require_scoped_token: bool = False,
 ) -> Callable[..., Coroutine[Any, Any, User]]:
     """FastAPI dependency factory: require ``required`` of the caller, capped by the
     authenticating token's scopes (unrestricted PAT / session / API key = no cap).
     allow_anonymous admits the anonymous user where the tenant permits it (the
-    anonymous-capable chat surface)."""
+    anonymous-capable chat surface).
+
+    require_scoped_token makes the route machine-only: the caller must present a
+    scoped token implying ``required``; unscoped principals (session / API key /
+    unrestricted PAT) are denied and the user's own permissions are not consulted."""
     base_user = current_chat_accessible_user if allow_anonymous else current_user
 
     async def dependency(request: Request, user: User = Depends(base_user)) -> User:
         token_scopes: list[Permission] | None = getattr(
             request.state, "token_scopes", None
         )
-        permitted_by_user = required in get_effective_permissions(user)
-        permitted_by_token = token_scopes is None or required.value in (
+        token_implies = token_scopes is not None and required.value in (
             resolve_effective_permissions({s.value for s in token_scopes})
         )
-        if not (permitted_by_user and permitted_by_token):
+        if require_scoped_token:
+            permitted = token_implies
+        else:
+            permitted_by_user = required in get_effective_permissions(user)
+            permitted_by_token = token_scopes is None or token_implies
+            permitted = permitted_by_user and permitted_by_token
+        if not permitted:
             raise OnyxError(
                 OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
                 "You do not have the required permissions for this action.",

--- a/backend/onyx/auth/permissions.py
+++ b/backend/onyx/auth/permissions.py
@@ -56,7 +56,7 @@ IMPLIED_PERMISSIONS: dict[str, set[str]] = {
     Permission.WRITE_CHAT.value: {Permission.READ_CHAT.value},
     Permission.CRAFT_SANDBOX.value: {
         Permission.READ_SEARCH.value,
-        Permission.REQUEST_APP_SETUP.value,
+        Permission.CRAFT_REQUEST_APP_SETUP.value,
     },
 }
 

--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -537,7 +537,7 @@ class Permission(str, PyEnum):
     # identity may use. PAT-only; never granted to a group/user.
     CRAFT_SANDBOX = "craft_sandbox"
 
-    REQUEST_APP_SETUP = "request:app_setup"
+    CRAFT_REQUEST_APP_SETUP = "craft:request_app_setup"
 
     # Override — any permission check passes
     FULL_ADMIN_PANEL_ACCESS = "admin"
@@ -557,7 +557,7 @@ Permission.IMPLIED = frozenset(
         Permission.READ_CHAT,
         Permission.WRITE_CHAT,
         Permission.READ_ADMIN,
-        Permission.REQUEST_APP_SETUP,
+        Permission.CRAFT_REQUEST_APP_SETUP,
     }
 )
 

--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -533,6 +533,12 @@ class Permission(str, PyEnum):
     CREATE_SERVICE_ACCOUNT_API_KEYS = "create:service_account_api_keys"
     CREATE_SLACK_DISCORD_BOTS = "create:slack_discord_bots"
 
+    # Role scopes — a bundle token implying the surfaces a given machine
+    # identity may use. PAT-only; never granted to a group/user.
+    CRAFT_SANDBOX = "craft_sandbox"
+
+    REQUEST_APP_SETUP = "request:app_setup"
+
     # Override — any permission check passes
     FULL_ADMIN_PANEL_ACCESS = "admin"
 
@@ -551,6 +557,7 @@ Permission.IMPLIED = frozenset(
         Permission.READ_CHAT,
         Permission.WRITE_CHAT,
         Permission.READ_ADMIN,
+        Permission.REQUEST_APP_SETUP,
     }
 )
 

--- a/backend/onyx/server/features/build/db/sandbox.py
+++ b/backend/onyx/server/features/build/db/sandbox.py
@@ -45,7 +45,13 @@ def ensure_sandbox_pat(db_session: Session, sandbox: Sandbox, user: User) -> str
 
     if sandbox.encrypted_pat and len(existing_craft_pats) == 1:
         raw_token = sandbox.encrypted_pat.get_value(apply_mask=False)
-        if hash_pat(raw_token) == existing_craft_pats[0].hashed_token:
+        existing = existing_craft_pats[0]
+        # Re-mint if the stored PAT's scopes drifted from the current role scope
+        # (e.g. a PAT issued before CRAFT_SANDBOX) so it isn't served until expiry.
+        if (
+            hash_pat(raw_token) == existing.hashed_token
+            and existing.scopes == [Permission.CRAFT_SANDBOX.value]
+        ):
             return raw_token
 
     for pat in existing_craft_pats:
@@ -57,7 +63,7 @@ def ensure_sandbox_pat(db_session: Session, sandbox: Sandbox, user: User) -> str
         name=f"craft-{user.id}",
         expiration_days=_PAT_EXPIRATION_DAYS,
         pat_type=PatType.CRAFT,
-        scopes=[Permission.READ_SEARCH],
+        scopes=[Permission.CRAFT_SANDBOX],
     )
 
     sandbox.encrypted_pat = raw_token  # ty: ignore[invalid-assignment]

--- a/backend/onyx/server/features/build/db/sandbox.py
+++ b/backend/onyx/server/features/build/db/sandbox.py
@@ -47,11 +47,9 @@ def ensure_sandbox_pat(db_session: Session, sandbox: Sandbox, user: User) -> str
         raw_token = sandbox.encrypted_pat.get_value(apply_mask=False)
         existing = existing_craft_pats[0]
         # Re-mint if the stored PAT's scopes drifted from the current role scope
-        # (e.g. a PAT issued before CRAFT_SANDBOX) so it isn't served until expiry.
-        if (
-            hash_pat(raw_token) == existing.hashed_token
-            and existing.scopes == [Permission.CRAFT_SANDBOX.value]
-        ):
+        if hash_pat(raw_token) == existing.hashed_token and existing.scopes == [
+            Permission.CRAFT_SANDBOX.value
+        ]:
             return raw_token
 
     for pat in existing_craft_pats:

--- a/backend/tests/external_dependency_unit/craft/test_sandbox_pat.py
+++ b/backend/tests/external_dependency_unit/craft/test_sandbox_pat.py
@@ -60,7 +60,7 @@ class TestEnsureSandboxPat:
         pat = db_session.query(PersonalAccessToken).filter_by(hashed_token=hashed).one()
         assert pat.pat_type == PatType.CRAFT
         assert pat.user_id == test_user.id
-        assert pat.scopes == [Permission.READ_SEARCH.value]
+        assert pat.scopes == [Permission.CRAFT_SANDBOX.value]
 
     def test_second_call_reuses_token(
         self,

--- a/backend/tests/unit/onyx/auth/test_permissions.py
+++ b/backend/tests/unit/onyx/auth/test_permissions.py
@@ -133,7 +133,7 @@ class TestResolveEffectivePermissions:
         """The Craft sandbox PAT may only company-search and request app setup —
         it must NOT inherit the chat surfaces (the reason it isn't `basic`)."""
         result = resolve_effective_permissions({"craft_sandbox"})
-        assert result == {"craft_sandbox", "read:search", "request:app_setup"}
+        assert result == {"craft_sandbox", "read:search", "craft:request_app_setup"}
         assert "read:chat" not in result
         assert "write:chat" not in result
         assert "basic" not in result
@@ -299,12 +299,12 @@ class TestRequireScopedToken:
 
     @pytest.mark.asyncio
     async def test_craft_pat_passes(self) -> None:
-        """The Craft PAT (craft_sandbox implies request:app_setup) is admitted."""
+        """The Craft PAT (craft_sandbox implies craft:request_app_setup) is admitted."""
         user = MagicMock()
         user.effective_permissions = ["basic"]
 
         dep = require_permission(
-            Permission.REQUEST_APP_SETUP, require_scoped_token=True
+            Permission.CRAFT_REQUEST_APP_SETUP, require_scoped_token=True
         )
         result = await dep(request=_request([Permission.CRAFT_SANDBOX]), user=user)
         assert result is user
@@ -317,7 +317,7 @@ class TestRequireScopedToken:
         user.effective_permissions = ["admin"]
 
         dep = require_permission(
-            Permission.REQUEST_APP_SETUP, require_scoped_token=True
+            Permission.CRAFT_REQUEST_APP_SETUP, require_scoped_token=True
         )
         with pytest.raises(OnyxError) as exc_info:
             await dep(request=_request(None), user=user)
@@ -330,7 +330,7 @@ class TestRequireScopedToken:
         user.effective_permissions = ["basic"]
 
         dep = require_permission(
-            Permission.REQUEST_APP_SETUP, require_scoped_token=True
+            Permission.CRAFT_REQUEST_APP_SETUP, require_scoped_token=True
         )
         with pytest.raises(OnyxError):
             await dep(request=_request([Permission.READ_SEARCH]), user=user)
@@ -379,7 +379,7 @@ class TestApiSurfaceScopeRegistration:
         "read:chat",
         "write:chat",
         "read:admin",
-        "request:app_setup",
+        "craft:request_app_setup",
     }
 
     def test_implied_set_matches_spec(self) -> None:
@@ -397,9 +397,9 @@ class TestApiSurfaceScopeRegistration:
             "write:chat",
         }
         assert IMPLIED_PERMISSIONS["write:chat"] == {"read:chat"}
-        # request:app_setup is reachable ONLY via the craft role scope, never basic.
+        # craft:request_app_setup is reachable ONLY via the craft role scope, never basic.
         assert IMPLIED_PERMISSIONS["craft_sandbox"] == {
             "read:search",
-            "request:app_setup",
+            "craft:request_app_setup",
         }
-        assert "request:app_setup" not in IMPLIED_PERMISSIONS["basic"]
+        assert "craft:request_app_setup" not in IMPLIED_PERMISSIONS["basic"]

--- a/backend/tests/unit/onyx/auth/test_permissions.py
+++ b/backend/tests/unit/onyx/auth/test_permissions.py
@@ -129,6 +129,15 @@ class TestResolveEffectivePermissions:
         result = resolve_effective_permissions({"admin"})
         assert {"read:search", "read:chat", "write:chat", "read:admin"} <= result
 
+    def test_craft_sandbox_scope_is_least_privilege(self) -> None:
+        """The Craft sandbox PAT may only company-search and request app setup —
+        it must NOT inherit the chat surfaces (the reason it isn't `basic`)."""
+        result = resolve_effective_permissions({"craft_sandbox"})
+        assert result == {"craft_sandbox", "read:search", "request:app_setup"}
+        assert "read:chat" not in result
+        assert "write:chat" not in result
+        assert "basic" not in result
+
 
 # ---------------------------------------------------------------------------
 # get_effective_permissions (expands implied at read time)
@@ -283,6 +292,50 @@ class TestRequirePermission:
             await dep(request=_request([]), user=user)
 
 
+class TestRequireScopedToken:
+    """require_permission(..., require_scoped_token=True) is token-gated: only a
+    scoped PAT carrying the scope passes; unscoped principals (session / API key /
+    unrestricted PAT) are denied even if the user holds the permission."""
+
+    @pytest.mark.asyncio
+    async def test_craft_pat_passes(self) -> None:
+        """The Craft PAT (craft_sandbox implies request:app_setup) is admitted."""
+        user = MagicMock()
+        user.effective_permissions = ["basic"]
+
+        dep = require_permission(
+            Permission.REQUEST_APP_SETUP, require_scoped_token=True
+        )
+        result = await dep(request=_request([Permission.CRAFT_SANDBOX]), user=user)
+        assert result is user
+
+    @pytest.mark.asyncio
+    async def test_session_login_denied(self) -> None:
+        """A logged-in user with no scoped token (token_scopes is None) is denied —
+        the endpoint is machine-only."""
+        user = MagicMock()
+        user.effective_permissions = ["admin"]
+
+        dep = require_permission(
+            Permission.REQUEST_APP_SETUP, require_scoped_token=True
+        )
+        with pytest.raises(OnyxError) as exc_info:
+            await dep(request=_request(None), user=user)
+        assert exc_info.value.error_code == OnyxErrorCode.INSUFFICIENT_PERMISSIONS
+
+    @pytest.mark.asyncio
+    async def test_out_of_scope_pat_denied(self) -> None:
+        """A scoped PAT without the required scope is denied."""
+        user = MagicMock()
+        user.effective_permissions = ["basic"]
+
+        dep = require_permission(
+            Permission.REQUEST_APP_SETUP, require_scoped_token=True
+        )
+        with pytest.raises(OnyxError):
+            await dep(request=_request([Permission.READ_SEARCH]), user=user)
+
+
 class TestAnonymousUserPermissions:
     def test_anonymous_user_resolves_to_basic_scopes(self) -> None:
         assert get_effective_permissions(get_anonymous_user()) == {
@@ -315,7 +368,7 @@ class TestAnonymousUserPermissions:
 
 class TestApiSurfaceScopeRegistration:
     # Hardcoded spec: the complete implied-only set (4 READ_* capability reads
-    # + 4 API-surface scopes). Equality, not subset, so an accidentally
+    # + 5 API-surface scopes). Equality, not subset, so an accidentally
     # over-broad set (a real capability made un-grantable) is also caught.
     EXPECTED_IMPLIED = {
         "read:connectors",
@@ -326,14 +379,15 @@ class TestApiSurfaceScopeRegistration:
         "read:chat",
         "write:chat",
         "read:admin",
+        "request:app_setup",
     }
 
     def test_implied_set_matches_spec(self) -> None:
         assert {p.value for p in Permission.IMPLIED} == self.EXPECTED_IMPLIED
 
-    def test_non_toggleable_is_implied_plus_basic_and_admin(self) -> None:
+    def test_non_toggleable_is_implied_plus_basic_admin_and_craft(self) -> None:
         assert {p.value for p in NON_TOGGLEABLE_PERMISSIONS} == (
-            self.EXPECTED_IMPLIED | {"basic", "admin"}
+            self.EXPECTED_IMPLIED | {"basic", "admin", "craft_sandbox"}
         )
 
     def test_implication_edges_match_spec(self) -> None:
@@ -343,3 +397,9 @@ class TestApiSurfaceScopeRegistration:
             "write:chat",
         }
         assert IMPLIED_PERMISSIONS["write:chat"] == {"read:chat"}
+        # request:app_setup is reachable ONLY via the craft role scope, never basic.
+        assert IMPLIED_PERMISSIONS["craft_sandbox"] == {
+            "read:search",
+            "request:app_setup",
+        }
+        assert "request:app_setup" not in IMPLIED_PERMISSIONS["basic"]


### PR DESCRIPTION
**Stack 1/4** of the split of #12415 (Connect external apps on demand).

Replaces the Craft sandbox PAT's `[READ_SEARCH, BASIC_ACCESS]` grant with a
dedicated `CRAFT_SANDBOX` role scope that implies only `READ_SEARCH` +
`REQUEST_APP_SETUP` — never the chat surfaces. Adds
`require_permission(..., require_scoped_token=True)` for machine-only endpoints
(used by the connect-app endpoints in the next PR). `ensure_sandbox_pat` re-mints
when a stored PAT's scopes have drifted, so pre-existing sandboxes pick up the
new scope rather than serving a stale PAT until expiry.

Pure least-privilege hardening; mergeable on its own.

 -  [x] [Optional] Override Linear Check