### PR TITLE
feat(craft): connect_app sandbox tool + agent instructions

### DIFF
--- a/backend/onyx/db/external_app.py
+++ b/backend/onyx/db/external_app.py
@@ -15,6 +15,7 @@ from onyx.db.enums import ExternalAppType
 from onyx.db.models import ExternalApp
 from onyx.db.models import ExternalAppPolicy
 from onyx.db.models import ExternalAppUserCredential
+from onyx.db.models import User
 from onyx.db.utils import is_set
 from onyx.db.utils import UNSET
 from onyx.db.utils import UnsetType
@@ -149,18 +150,24 @@ def get_external_app_by_skill_id(
 
 def get_connectable_apps_for_user(
     db_session: Session,
-    user_id: UUID,
+    user: User,
 ) -> list[ExternalApp]:
-    """Enabled apps the user could connect but hasn't: those requiring per-user
-    credentials the org hasn't pre-filled, with no complete credential row yet.
+    """Apps the user could connect but hasn't: enabled, visible to them (public /
+    group-granted / personal), requiring per-user credentials the org hasn't
+    pre-filled, with no complete credential row yet.
 
-    Org-credentialed apps (no user-required keys) are usable by everyone and so
-    are excluded — there is nothing for the user to set up."""
-    user_creds_by_app = get_user_credentials_by_app_id(db_session, user_id)
+    Apps whose skill the user can't see are excluded — they'd never be injected
+    even once connected. Org-credentialed apps (no user-required keys) are usable
+    by everyone, so there's nothing to set up."""
+    # Local import breaks the external_app <-> skill module cycle.
+    from onyx.db.skill import visible_skill_ids_for_user
+
+    visible_skill_ids = visible_skill_ids_for_user(user, db_session)
+    user_creds_by_app = get_user_credentials_by_app_id(db_session, user.id)
     return [
         app
         for app in get_external_apps(db_session)
-        if app.skill.enabled
+        if app.skill_id in visible_skill_ids
         and not is_user_authenticated_for_app(app, user_creds_by_app.get(app.id))
     ]
 

--- a/backend/onyx/db/external_app.py
+++ b/backend/onyx/db/external_app.py
@@ -147,6 +147,24 @@ def get_external_app_by_skill_id(
     return db_session.scalar(stmt)
 
 
+def get_connectable_apps_for_user(
+    db_session: Session,
+    user_id: UUID,
+) -> list[ExternalApp]:
+    """Enabled apps the user could connect but hasn't: those requiring per-user
+    credentials the org hasn't pre-filled, with no complete credential row yet.
+
+    Org-credentialed apps (no user-required keys) are usable by everyone and so
+    are excluded — there is nothing for the user to set up."""
+    user_creds_by_app = get_user_credentials_by_app_id(db_session, user_id)
+    return [
+        app
+        for app in get_external_apps(db_session)
+        if app.skill.enabled
+        and not is_user_authenticated_for_app(app, user_creds_by_app.get(app.id))
+    ]
+
+
 def get_external_apps(
     db_session: Session,
 ) -> list[ExternalApp]:

--- a/backend/onyx/db/skill.py
+++ b/backend/onyx/db/skill.py
@@ -114,12 +114,17 @@ def _add_user_visibility_filter(
 
 
 def visible_skill_ids_for_user(user: User, db_session: Session) -> set[UUID]:
-    """Enabled skill ids the user can see (public / group-granted / personal) —
-    the visibility source of truth shared with sandbox injection."""
+    """Enabled skill ids the user can see (public / group-granted / personal).
+
+    A lightweight authorization primitive (ids only, for membership checks such
+    as which external apps a user may connect) — distinct from
+    ``list_skills_for_user``, which is the skills-endpoint listing and excludes
+    external-app-backed skills. The shared visibility predicate is
+    ``_add_user_visibility_filter``."""
     stmt = _add_user_visibility_filter(
         select(Skill).where(Skill.enabled.is_(True)), user
-    )
-    return {skill.id for skill in db_session.scalars(stmt)}
+    ).with_only_columns(Skill.id)
+    return set(db_session.scalars(stmt))
 
 
 def _exclude_unavailable_built_ins(

--- a/backend/onyx/db/skill.py
+++ b/backend/onyx/db/skill.py
@@ -113,6 +113,15 @@ def _add_user_visibility_filter(
     )
 
 
+def visible_skill_ids_for_user(user: User, db_session: Session) -> set[UUID]:
+    """Enabled skill ids the user can see (public / group-granted / personal) —
+    the visibility source of truth shared with sandbox injection."""
+    stmt = _add_user_visibility_filter(
+        select(Skill).where(Skill.enabled.is_(True)), user
+    )
+    return {skill.id for skill in db_session.scalars(stmt)}
+
+
 def _exclude_unavailable_built_ins(
     stmt: Select[tuple[Skill]], db_session: Session
 ) -> Select[tuple[Skill]]:

--- a/backend/onyx/server/features/build/AGENTS.template.md
+++ b/backend/onyx/server/features/build/AGENTS.template.md
@@ -50,6 +50,12 @@ Read a skill's `SKILL.md` (in `.opencode/skills/<name>/`) before doing work it c
 
 {{AVAILABLE_SKILLS_SECTION}}
 
+## Connectable apps
+
+Some org apps aren't set up for this user yet, so you can't call them until they're connected. When the task needs one, call the `connect_app` tool with its slug to prompt the user; once connected, it works like any other app. Never ask for or handle credentials yourself.
+
+{{CONNECTABLE_APPS_LIST}}
+
 ## Credentials & external actions
 
 You have internet access, but every outbound request automatically routes through an egress

--- a/backend/onyx/server/features/build/sandbox/base.py
+++ b/backend/onyx/server/features/build/sandbox/base.py
@@ -166,6 +166,7 @@ class SandboxManager(_ServeMixin, ABC):
         llm_config: LLMProviderConfig,
         nextjs_port: int | None,
         skills_section: str,
+        connectable_apps_section: str,
         user_name: str | None = None,
     ) -> None:
         """Set up a session workspace within an existing sandbox.
@@ -183,6 +184,7 @@ class SandboxManager(_ServeMixin, ABC):
             llm_config: LLM provider configuration (passed to AGENTS.md rendering)
             nextjs_port: Port for the Next.js dev server, or None for headless.
             skills_section: Pre-rendered ``{{AVAILABLE_SKILLS_SECTION}}`` for AGENTS.md.
+            connectable_apps_section: Pre-rendered ``{{CONNECTABLE_APPS_LIST}}`` (may be empty).
             user_name: User's name for personalization in AGENTS.md
 
         Raises:
@@ -246,6 +248,7 @@ class SandboxManager(_ServeMixin, ABC):
         nextjs_port: int | None,
         llm_config: LLMProviderConfig,
         skills_section: str,
+        connectable_apps_section: str,
     ) -> None:
         """Restore a session workspace from a snapshot.
 

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -1105,12 +1105,14 @@ class DockerSandboxManager(SandboxManager):
         llm_config: LLMProviderConfig,
         nextjs_port: int | None,
         skills_section: str,
+        connectable_apps_section: str,
         user_name: str | None = None,
     ) -> str:
         """Shell-escaped AGENTS.md for ``printf '%s' '...'``."""
         agent_instructions = generate_agent_instructions(
             template_path=self._agent_instructions_template_path,
             skills_section=skills_section,
+            connectable_apps_section=connectable_apps_section,
             provider=llm_config.provider,
             model_name=llm_config.model_name,
             nextjs_port=nextjs_port,
@@ -1126,6 +1128,7 @@ class DockerSandboxManager(SandboxManager):
         llm_config: LLMProviderConfig,
         nextjs_port: int | None,
         skills_section: str,
+        connectable_apps_section: str,
         user_name: str | None = None,
     ) -> None:
         container = self._require_container(sandbox_id)
@@ -1134,6 +1137,7 @@ class DockerSandboxManager(SandboxManager):
             llm_config=llm_config,
             nextjs_port=nextjs_port,
             skills_section=skills_section,
+            connectable_apps_section=connectable_apps_section,
             user_name=user_name,
         )
 
@@ -1475,6 +1479,7 @@ echo "Session cleanup complete"
         nextjs_port: int | None,
         llm_config: LLMProviderConfig,
         skills_section: str,
+        connectable_apps_section: str,
     ) -> None:
         container = self._require_container(sandbox_id)
         session_path = f"{SESSIONS_ROOT}/{session_id}"
@@ -1541,6 +1546,7 @@ fi
             llm_config=llm_config,
             nextjs_port=nextjs_port,
             skills_section=skills_section,
+            connectable_apps_section=connectable_apps_section,
         )
 
         if nextjs_port is not None:
@@ -1563,6 +1569,7 @@ fi
         llm_config: LLMProviderConfig,
         nextjs_port: int | None,
         skills_section: str,
+        connectable_apps_section: str,
     ) -> None:
         """
         Rewrite AGENTS.md and the skills symlink post-restore. opencode.json is
@@ -1573,6 +1580,7 @@ fi
             llm_config=llm_config,
             nextjs_port=nextjs_port,
             skills_section=skills_section,
+            connectable_apps_section=connectable_apps_section,
         )
         script = f"""
 set -e

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -184,6 +184,9 @@ _PROXY_CA_BUNDLE_FILE = f"{_PROXY_CA_BUNDLE_DIR}/ca-bundle.crt"
 # Registered in the opencode config only when the proxy is wired up; otherwise
 # it would no-op (no HTTP(S)_PROXY to re-tag).
 _OPENCODE_SESSION_TAG_PLUGIN_PATH = "/workspace/opencode-plugins/session-proxy-tag.ts"
+# Surfaces the no-op `connect_app` tool; always on. Its "ask" permission is what
+# the api-server intercepts to drive the connect-app OAuth flow.
+_OPENCODE_CONNECT_APP_PLUGIN_PATH = "/workspace/opencode-plugins/connect-app.ts"
 _MUTABLE_SANDBOX_IMAGE_TAGS = {"latest", "beta", "edge"}
 
 # In-container opencode-history archive builder: reuses the sandbox_daemon
@@ -893,12 +896,11 @@ class DockerSandboxManager(SandboxManager):
             # opencode-serve reads provider config from env at startup; must be
             # in create_kwargs before the container ever runs.
             opencode_password = secrets.token_urlsafe(32)
-            # Only register the egress-tagging plugin when the proxy is wired
-            # up; otherwise it would no-op (no HTTP(S)_PROXY to re-tag). Mirrors
-            # the K8s manager's gating.
-            session_tag_plugins = (
-                [_OPENCODE_SESSION_TAG_PLUGIN_PATH] if SANDBOX_PROXY_HOST else None
-            )
+            # connect_app is always loaded; the egress-tagging plugin only when
+            # the proxy is wired up (else it no-ops — no HTTP(S)_PROXY to re-tag).
+            plugins = [_OPENCODE_CONNECT_APP_PLUGIN_PATH]
+            if SANDBOX_PROXY_HOST:
+                plugins.append(_OPENCODE_SESSION_TAG_PLUGIN_PATH)
             # Proxy posture: Real PAT + LLM api_key never enter the sandbox. The
             # proxy reads `Sandbox.encrypted_pat` and the per-provider key from
             # Postgres, swaps the placeholder for the real bearer on the wire
@@ -915,7 +917,7 @@ class DockerSandboxManager(SandboxManager):
                     default_provider=llm_config.provider,
                     default_model=llm_config.model_name,
                     disabled_tools=OPENCODE_DISABLED_TOOLS,
-                    plugins=session_tag_plugins,
+                    plugins=plugins,
                 )
             )
             self._ensure_sandbox_image()

--- a/backend/onyx/server/features/build/sandbox/image/opencode-plugins/connect-app.ts
+++ b/backend/onyx/server/features/build/sandbox/image/opencode-plugins/connect-app.ts
@@ -1,0 +1,76 @@
+// A no-op `connect_app` tool the agent calls to ask the user to connect an org
+// app it isn't set up for yet. It does nothing itself: `context.ask` pauses the
+// turn and the api-server drives the connect card, then answers allow/deny (see
+// serve_client._handle_connect_app_permission).
+//
+// Module resolution: this file lives in /workspace/opencode-plugins, which has
+// no node_modules, so a bare runtime `import` of the SDK can't resolve. The type
+// import is erased; the `tool` helper is loaded at runtime by absolute path from
+// opencode's bundled SDK (same approach as the other plugins here).
+
+import type { Plugin } from "@opencode-ai/plugin";
+import type { tool as ToolFactory } from "@opencode-ai/plugin/tool";
+
+const SDK_TOOL_PATHS = [
+  "/home/sandbox/.opencode/node_modules/@opencode-ai/plugin/dist/tool.js",
+  "/home/sandbox/.config/opencode/node_modules/@opencode-ai/plugin/dist/tool.js",
+];
+
+async function loadToolFactory(): Promise<typeof ToolFactory> {
+  for (const path of SDK_TOOL_PATHS) {
+    try {
+      return (await import(path)).tool;
+    } catch {
+      continue;
+    }
+  }
+  throw new Error("could not resolve the @opencode-ai/plugin tool helper");
+}
+
+export const ConnectApp: Plugin = async () => {
+  const tool = await loadToolFactory();
+
+  return {
+    tool: {
+      connect_app: tool({
+        description:
+          "Ask the user to connect an org app you aren't set up to use yet. " +
+          "Pass the app's slug (as listed under 'Connectable apps' in AGENTS.md). " +
+          "This pauses for the user to connect it. If this returns normally the " +
+          "app is connected and you can use it; if it is denied, do not retry — " +
+          "offer an alternative.",
+        args: {
+          app: tool.schema
+            .string()
+            .describe("Slug of the connectable app, e.g. 'google_calendar'"),
+          reason: tool.schema
+            .string()
+            .optional()
+            .describe("One short sentence on why you need it, shown to the user"),
+        },
+        async execute(args, context) {
+          // Blocks until the user answers; resolves on connect, throws on
+          // decline. Requires opencode.json `connect_app: "ask"` to prompt.
+          try {
+            await context.ask({
+              permission: "connect_app",
+              patterns: [args.app],
+              always: [],
+              metadata: { app: args.app, reason: args.reason ?? "" },
+            });
+          } catch {
+            // Return a normal result so the agent keeps control and picks an
+            // alternative, rather than letting the rejection abort the turn.
+            return (
+              `The user declined to connect '${args.app}'. Do not retry connecting ` +
+              `it; offer an alternative or proceed without it.`
+            );
+          }
+          return `'${args.app}' is connected. You can use it now.`;
+        },
+      }),
+    },
+  };
+};
+
+export default ConnectApp;

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -167,6 +167,9 @@ _PODTEMPLATE_NAME = "sandbox-pod"
 # Per-session egress tagging plugin, baked into the sandbox image (see
 # docker/Dockerfile). Path must match the COPY destination there.
 _OPENCODE_SESSION_TAG_PLUGIN_PATH = "/workspace/opencode-plugins/session-proxy-tag.ts"
+# Surfaces the no-op `connect_app` tool; always on. Its "ask" permission is what
+# the api-server intercepts to drive the connect-app OAuth flow.
+_OPENCODE_CONNECT_APP_PLUGIN_PATH = "/workspace/opencode-plugins/connect-app.ts"
 
 
 _PROXY_RESOLVE_RETRY_ATTEMPTS = 5
@@ -1108,7 +1111,10 @@ class KubernetesSandboxManager(SandboxManager):
                     default_provider=llm_config.provider,
                     default_model=llm_config.model_name,
                     disabled_tools=OPENCODE_DISABLED_TOOLS,
-                    plugins=[_OPENCODE_SESSION_TAG_PLUGIN_PATH],
+                    plugins=[
+                        _OPENCODE_CONNECT_APP_PLUGIN_PATH,
+                        _OPENCODE_SESSION_TAG_PLUGIN_PATH,
+                    ],
                 )
             )
             self._provision_opencode_secret(str(sandbox_id), opencode_config_json)

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -462,6 +462,7 @@ class KubernetesSandboxManager(SandboxManager):
     def _load_agent_instructions(
         self,
         skills_section: str,
+        connectable_apps_section: str,
         provider: str | None = None,
         model_name: str | None = None,
         nextjs_port: int | None = None,
@@ -472,6 +473,7 @@ class KubernetesSandboxManager(SandboxManager):
         return generate_agent_instructions(
             template_path=self._agent_instructions_template_path,
             skills_section=skills_section,
+            connectable_apps_section=connectable_apps_section,
             provider=provider,
             model_name=model_name,
             nextjs_port=nextjs_port,
@@ -1370,6 +1372,7 @@ class KubernetesSandboxManager(SandboxManager):
         llm_config: LLMProviderConfig,
         nextjs_port: int | None,
         skills_section: str,
+        connectable_apps_section: str,
         user_name: str | None = None,
     ) -> None:
         """Set up a session workspace within an existing sandbox pod.
@@ -1400,6 +1403,7 @@ class KubernetesSandboxManager(SandboxManager):
         # Attachments section is injected dynamically when first file is uploaded.
         agent_instructions = self._load_agent_instructions(
             skills_section=skills_section,
+            connectable_apps_section=connectable_apps_section,
             provider=llm_config.provider,
             model_name=llm_config.model_name,
             nextjs_port=nextjs_port,
@@ -1826,6 +1830,7 @@ echo "Session cleanup complete"
         nextjs_port: int | None,
         llm_config: LLMProviderConfig,
         skills_section: str,
+        connectable_apps_section: str,
     ) -> None:
         """Restore a FileStore-backed snapshot through the sidecar filesystem API.
 
@@ -1877,6 +1882,7 @@ echo "Session cleanup complete"
                 llm_config=llm_config,
                 nextjs_port=nextjs_port,
                 skills_section=skills_section,
+                connectable_apps_section=connectable_apps_section,
             )
 
             if nextjs_port is not None:
@@ -1904,6 +1910,7 @@ echo "Session cleanup complete"
         llm_config: LLMProviderConfig,
         nextjs_port: int | None,
         skills_section: str,
+        connectable_apps_section: str,
     ) -> None:
         """Regenerate session configuration files after snapshot restore.
 
@@ -1921,6 +1928,7 @@ echo "Session cleanup complete"
         """
         agent_instructions = self._load_agent_instructions(
             skills_section=skills_section,
+            connectable_apps_section=connectable_apps_section,
             provider=llm_config.provider,
             model_name=llm_config.model_name,
             nextjs_port=nextjs_port,

--- a/backend/onyx/server/features/build/sandbox/util/agent_instructions.py
+++ b/backend/onyx/server/features/build/sandbox/util/agent_instructions.py
@@ -91,34 +91,21 @@ def build_skills_section_from_data(skills: Iterable[Skill]) -> str:
     return "\n".join(f"- **{slug}**: {desc}" for slug, desc in entries)
 
 
-def build_connectable_apps_section(apps: Iterable[ExternalApp]) -> str:
-    """Render the "Connectable apps" block: org apps the user hasn't set up yet.
-
-    These aren't usable until connected, so the agent can't call them directly —
-    but knowing they exist lets it plan around them and offer to connect one via
-    the ``connect_app`` tool. Empty input renders nothing (no heading)."""
+def build_connectable_apps_list(apps: Iterable[ExternalApp]) -> str:
+    """Render the connectable-apps bullet list — org apps the user hasn't set up
+    yet. The heading and explanatory prose live in AGENTS.template.md; this only
+    supplies the dynamic ``{{CONNECTABLE_APPS_LIST}}`` value. Mirrors
+    ``build_skills_section_from_data``: a fallback line when there's nothing."""
     entries = sorted((app.skill.slug, _truncate(app.skill.description)) for app in apps)
     if not entries:
-        return ""
-
-    lines = [
-        "",
-        "## Connectable apps",
-        "",
-        "These org apps are available but **not yet set up** for this user, so you "
-        "cannot call them yet. When the task needs one, call the "
-        "`connect_app` tool with its slug to prompt the user to connect it; "
-        "once they do, it works like any connected app. Never ask for or handle "
-        "credentials yourself.",
-        "",
-    ]
-    lines += [f"- **{slug}**: {desc}" for slug, desc in entries]
-    return "\n".join(lines)
+        return "No connectable apps available."
+    return "\n".join(f"- **{slug}**: {desc}" for slug, desc in entries)
 
 
 def generate_agent_instructions(
     template_path: Path,
     skills_section: str,
+    connectable_apps_section: str,
     provider: str | None = None,
     model_name: str | None = None,
     nextjs_port: int | None = None,
@@ -130,6 +117,7 @@ def generate_agent_instructions(
     Args:
         template_path: Path to the AGENTS.template.md file
         skills_section: Pre-rendered skills section
+        connectable_apps_section: Pre-rendered connectable-apps list (may be empty)
         provider: LLM provider type (e.g., "openai", "anthropic")
         model_name: Model name (e.g., "claude-sonnet-4-5", "gpt-4o")
         nextjs_port: Port for Next.js development server
@@ -176,5 +164,6 @@ def generate_agent_instructions(
     )
     content = content.replace("{{DISABLED_TOOLS_SECTION}}", disabled_tools_section)
     content = content.replace("{{AVAILABLE_SKILLS_SECTION}}", skills_section)
+    content = content.replace("{{CONNECTABLE_APPS_LIST}}", connectable_apps_section)
 
     return content

--- a/backend/onyx/server/features/build/sandbox/util/agent_instructions.py
+++ b/backend/onyx/server/features/build/sandbox/util/agent_instructions.py
@@ -3,6 +3,7 @@
 from collections.abc import Iterable
 from pathlib import Path
 
+from onyx.db.models import ExternalApp
 from onyx.db.models import Skill
 from onyx.server.features.build.configs import SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS
 from onyx.utils.logger import setup_logger
@@ -88,6 +89,31 @@ def build_skills_section_from_data(skills: Iterable[Skill]) -> str:
 
     entries.sort(key=lambda e: e[0])
     return "\n".join(f"- **{slug}**: {desc}" for slug, desc in entries)
+
+
+def build_connectable_apps_section(apps: Iterable[ExternalApp]) -> str:
+    """Render the "Connectable apps" block: org apps the user hasn't set up yet.
+
+    These aren't usable until connected, so the agent can't call them directly —
+    but knowing they exist lets it plan around them and offer to connect one via
+    the ``connect_app`` tool. Empty input renders nothing (no heading)."""
+    entries = sorted((app.skill.slug, _truncate(app.skill.description)) for app in apps)
+    if not entries:
+        return ""
+
+    lines = [
+        "",
+        "## Connectable apps",
+        "",
+        "These org apps are available but **not yet set up** for this user, so you "
+        "cannot call them yet. When the task needs one, call the "
+        "`connect_app` tool with its slug to prompt the user to connect it; "
+        "once they do, it works like any connected app. Never ask for or handle "
+        "credentials yourself.",
+        "",
+    ]
+    lines += [f"- **{slug}**: {desc}" for slug, desc in entries]
+    return "\n".join(lines)
 
 
 def generate_agent_instructions(

--- a/backend/onyx/server/features/build/sandbox/util/opencode_config.py
+++ b/backend/onyx/server/features/build/sandbox/util/opencode_config.py
@@ -87,9 +87,7 @@ _PERMISSIONS_TEMPLATE: dict[str, Any] = {
     "question": "allow",
     "webfetch": "allow",
     # Connect-app tool: a no-op tool the agent calls to request connecting an
-    # external app it isn't set up for. "ask" makes opencode pause the turn and
-    # emit permission.asked, which the api-server intercepts to drive the OAuth
-    # card and answer allow/deny (see serve_client._handle_permission_ask).
+    # external app it isn't set up for.
     "connect_app": "ask",
 }
 

--- a/backend/onyx/server/features/build/sandbox/util/opencode_config.py
+++ b/backend/onyx/server/features/build/sandbox/util/opencode_config.py
@@ -86,6 +86,11 @@ _PERMISSIONS_TEMPLATE: dict[str, Any] = {
     "skill": {"*": "allow", "customize-opencode": "deny"},
     "question": "allow",
     "webfetch": "allow",
+    # Connect-app tool: a no-op tool the agent calls to request connecting an
+    # external app it isn't set up for. "ask" makes opencode pause the turn and
+    # emit permission.asked, which the api-server intercepts to drive the OAuth
+    # card and answer allow/deny (see serve_client._handle_permission_ask).
+    "connect_app": "ask",
 }
 
 _TMP_EXTERNAL_DIRECTORY_RULES: dict[str, str] = {

--- a/backend/onyx/server/features/build/session/api.py
+++ b/backend/onyx/server/features/build/session/api.py
@@ -443,8 +443,8 @@ def restore_session(
 
                 snapshot = get_latest_snapshot_for_session(db_session, session_id)
 
-                skills_section, skills_files = build_user_skills_payload(
-                    user, db_session
+                skills_section, connectable_apps_section, skills_files = (
+                    build_user_skills_payload(user, db_session)
                 )
                 if snapshot:
                     try:
@@ -455,6 +455,7 @@ def restore_session(
                             nextjs_port=session.nextjs_port,
                             llm_config=llm_config,
                             skills_section=skills_section,
+                            connectable_apps_section=connectable_apps_section,
                         )
                         session.status = BuildSessionStatus.ACTIVE
                         db_session.commit()
@@ -472,6 +473,7 @@ def restore_session(
                         llm_config=llm_config,
                         nextjs_port=session.nextjs_port,
                         skills_section=skills_section,
+                        connectable_apps_section=connectable_apps_section,
                     )
                     session.status = BuildSessionStatus.ACTIVE
                     db_session.commit()

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -386,7 +386,9 @@ class SessionManager:
         )
         user_name = user.personal_name
 
-        skills_section, skills_files = build_user_skills_payload(user, self._db_session)
+        skills_section, connectable_apps_section, skills_files = (
+            build_user_skills_payload(user, self._db_session)
+        )
 
         self._sandbox_manager.setup_session_workspace(
             sandbox_id=sandbox.id,
@@ -394,6 +396,7 @@ class SessionManager:
             llm_config=llm_config,
             nextjs_port=nextjs_port,
             skills_section=skills_section,
+            connectable_apps_section=connectable_apps_section,
             user_name=user_name,
         )
         self._hydrate_skills(sandbox.id, user, files=skills_files)

--- a/backend/onyx/skills/push.py
+++ b/backend/onyx/skills/push.py
@@ -8,6 +8,7 @@ from uuid import UUID
 
 from sqlalchemy.orm import Session
 
+from onyx.db.external_app import get_connectable_apps_for_user
 from onyx.db.external_app import get_external_app_by_skill_id
 from onyx.db.models import Skill
 from onyx.db.models import User
@@ -19,6 +20,9 @@ from onyx.server.features.build.db.sandbox import get_sandbox_user_map
 from onyx.server.features.build.sandbox.factory import get_sandbox_manager
 from onyx.server.features.build.sandbox.models import FileSet
 from onyx.server.features.build.sandbox.models import PushResult
+from onyx.server.features.build.sandbox.util.agent_instructions import (
+    build_connectable_apps_section,
+)
 from onyx.server.features.build.sandbox.util.agent_instructions import (
     build_skills_section_from_data,
 )
@@ -151,9 +155,17 @@ def build_skills_fileset_for_user(user: User, db_session: Session) -> FileSet:
 
 
 def build_user_skills_payload(user: User, db_session: Session) -> tuple[str, FileSet]:
-    """Return (skills_section, fileset) sharing one set of DB reads."""
+    """Return (skills_section, fileset) sharing one set of DB reads.
+
+    The section also lists org apps the user hasn't connected yet, so the agent
+    knows they exist and can offer to set one up via the connect tool."""
     skills = list_skills_for_sandbox_injection(user=user, db_session=db_session)
     section = build_skills_section_from_data(skills)
+    connectable = build_connectable_apps_section(
+        get_connectable_apps_for_user(db_session, user.id)
+    )
+    if connectable:
+        section = f"{section}\n{connectable}"
     files = _assemble_fileset(skills, user, db_session)
     return section, files
 

--- a/backend/onyx/skills/push.py
+++ b/backend/onyx/skills/push.py
@@ -162,7 +162,7 @@ def build_user_skills_payload(user: User, db_session: Session) -> tuple[str, Fil
     skills = list_skills_for_sandbox_injection(user=user, db_session=db_session)
     section = build_skills_section_from_data(skills)
     connectable = build_connectable_apps_section(
-        get_connectable_apps_for_user(db_session, user.id)
+        get_connectable_apps_for_user(db_session, user)
     )
     if connectable:
         section = f"{section}\n{connectable}"

--- a/backend/onyx/skills/push.py
+++ b/backend/onyx/skills/push.py
@@ -21,7 +21,7 @@ from onyx.server.features.build.sandbox.factory import get_sandbox_manager
 from onyx.server.features.build.sandbox.models import FileSet
 from onyx.server.features.build.sandbox.models import PushResult
 from onyx.server.features.build.sandbox.util.agent_instructions import (
-    build_connectable_apps_section,
+    build_connectable_apps_list,
 )
 from onyx.server.features.build.sandbox.util.agent_instructions import (
     build_skills_section_from_data,
@@ -154,20 +154,20 @@ def build_skills_fileset_for_user(user: User, db_session: Session) -> FileSet:
     return _assemble_fileset(skills, user, db_session)
 
 
-def build_user_skills_payload(user: User, db_session: Session) -> tuple[str, FileSet]:
-    """Return (skills_section, fileset) sharing one set of DB reads.
-
-    The section also lists org apps the user hasn't connected yet, so the agent
-    knows they exist and can offer to set one up via the connect tool."""
+def build_user_skills_payload(
+    user: User, db_session: Session
+) -> tuple[str, str, FileSet]:
+    """Return (skills_section, connectable_apps_section, fileset) sharing one set
+    of DB reads. ``connectable_apps_section`` lists org apps the user hasn't
+    connected yet, so the agent knows they exist and can offer to set one up via
+    the connect tool."""
     skills = list_skills_for_sandbox_injection(user=user, db_session=db_session)
-    section = build_skills_section_from_data(skills)
-    connectable = build_connectable_apps_section(
+    skills_section = build_skills_section_from_data(skills)
+    connectable_apps_section = build_connectable_apps_list(
         get_connectable_apps_for_user(db_session, user)
     )
-    if connectable:
-        section = f"{section}\n{connectable}"
     files = _assemble_fileset(skills, user, db_session)
-    return section, files
+    return skills_section, connectable_apps_section, files
 
 
 def hydrate_sandbox_skills(

--- a/backend/tests/common/craft/stubs.py
+++ b/backend/tests/common/craft/stubs.py
@@ -291,6 +291,7 @@ class StubSandboxManager(SandboxManager):
         llm_config: LLMProviderConfig,
         nextjs_port: int | None,
         skills_section: str,
+        connectable_apps_section: str,
         user_name: str | None = None,
     ) -> None:
         self.setup_session_workspace_count += 1
@@ -300,6 +301,7 @@ class StubSandboxManager(SandboxManager):
             "llm_config": llm_config,
             "nextjs_port": nextjs_port,
             "skills_section": skills_section,
+            "connectable_apps_section": connectable_apps_section,
             "user_name": user_name,
         }
         if not self.setup_session_workspace_silent:
@@ -367,6 +369,7 @@ class StubSandboxManager(SandboxManager):
         nextjs_port: int | None,
         llm_config: LLMProviderConfig,
         skills_section: str,
+        connectable_apps_section: str,
     ) -> None:
         self.restore_snapshot_count += 1
         self.last_restore_snapshot_payload = {
@@ -376,6 +379,7 @@ class StubSandboxManager(SandboxManager):
             "nextjs_port": nextjs_port,
             "llm_config": llm_config,
             "skills_section": skills_section,
+            "connectable_apps_section": connectable_apps_section,
         }
         if not self.restore_snapshot_silent:
             raise _not_configured("restore_snapshot")

--- a/backend/tests/external_dependency_unit/craft/test_connectable_apps.py
+++ b/backend/tests/external_dependency_unit/craft/test_connectable_apps.py
@@ -1,0 +1,72 @@
+"""`get_connectable_apps_for_user`: the org apps a user still needs to connect.
+
+These drive the AGENTS.md "Connectable apps" listing — the agent learns which
+apps exist but aren't usable yet so it can offer to connect one.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from onyx.db.external_app import get_connectable_apps_for_user
+from onyx.server.features.build.sandbox.util.agent_instructions import (
+    build_connectable_apps_section,
+)
+from tests.external_dependency_unit.craft.db_helpers import make_external_app
+from tests.external_dependency_unit.craft.db_helpers import make_skill
+from tests.external_dependency_unit.craft.db_helpers import make_user
+from tests.external_dependency_unit.craft.db_helpers import make_user_credential
+
+# auth_template value carrying a user-supplied placeholder.
+_USER_TOKEN_TEMPLATE = {"Authorization": "Bearer {token}"}
+
+
+def test_lists_only_unconnected_apps_and_renders_them(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    user = make_user(db_session, email_prefix="connectable")
+
+    # Connectable: needs a user-supplied token the org hasn't pre-filled.
+    make_external_app(
+        db_session,
+        skill=make_skill(db_session, slug="needs-setup"),
+        auth_template=_USER_TOKEN_TEMPLATE,
+    )
+    # Connected: the user already stored the token.
+    connected = make_external_app(
+        db_session,
+        skill=make_skill(db_session, slug="already-connected"),
+        auth_template=_USER_TOKEN_TEMPLATE,
+    )
+    make_user_credential(
+        db_session, app=connected, user=user, user_credentials={"token": "secret"}
+    )
+    # Org-credentialed: org pre-fills the token, so there's nothing to set up.
+    make_external_app(
+        db_session,
+        skill=make_skill(db_session, slug="org-filled"),
+        auth_template=_USER_TOKEN_TEMPLATE,
+        organization_credentials={"token": "shared"},
+    )
+    # Disabled: never offered, regardless of credentials.
+    make_external_app(
+        db_session,
+        skill=make_skill(db_session, slug="disabled-app", enabled=False),
+        auth_template=_USER_TOKEN_TEMPLATE,
+    )
+    db_session.commit()
+
+    slugs = {app.skill.slug for app in get_connectable_apps_for_user(db_session, user.id)}
+
+    assert "needs-setup" in slugs
+    assert "already-connected" not in slugs
+    assert "org-filled" not in slugs
+    assert "disabled-app" not in slugs
+
+    section = build_connectable_apps_section(
+        get_connectable_apps_for_user(db_session, user.id)
+    )
+    assert "## Connectable apps" in section
+    assert "needs-setup" in section
+    assert "already-connected" not in section

--- a/backend/tests/external_dependency_unit/craft/test_connectable_apps.py
+++ b/backend/tests/external_dependency_unit/craft/test_connectable_apps.py
@@ -1,9 +1,3 @@
-"""`get_connectable_apps_for_user`: the org apps a user still needs to connect.
-
-These drive the AGENTS.md "Connectable apps" listing — the agent learns which
-apps exist but aren't usable yet so it can offer to connect one.
-"""
-
 from __future__ import annotations
 
 from sqlalchemy.orm import Session
@@ -57,7 +51,9 @@ def test_lists_only_unconnected_apps_and_renders_them(
     )
     db_session.commit()
 
-    slugs = {app.skill.slug for app in get_connectable_apps_for_user(db_session, user.id)}
+    slugs = {
+        app.skill.slug for app in get_connectable_apps_for_user(db_session, user.id)
+    }
 
     assert "needs-setup" in slugs
     assert "already-connected" not in slugs

--- a/backend/tests/external_dependency_unit/craft/test_connectable_apps.py
+++ b/backend/tests/external_dependency_unit/craft/test_connectable_apps.py
@@ -4,7 +4,7 @@ from sqlalchemy.orm import Session
 
 from onyx.db.external_app import get_connectable_apps_for_user
 from onyx.server.features.build.sandbox.util.agent_instructions import (
-    build_connectable_apps_section,
+    build_connectable_apps_list,
 )
 from tests.external_dependency_unit.craft.db_helpers import make_external_app
 from tests.external_dependency_unit.craft.db_helpers import make_skill
@@ -66,9 +66,8 @@ def test_lists_only_unconnected_apps_and_renders_them(
     assert "disabled-app" not in slugs
     assert "hidden-app" not in slugs
 
-    section = build_connectable_apps_section(
+    apps_list = build_connectable_apps_list(
         get_connectable_apps_for_user(db_session, user)
     )
-    assert "## Connectable apps" in section
-    assert "needs-setup" in section
-    assert "hidden-app" not in section
+    assert "- **needs-setup**" in apps_list
+    assert "hidden-app" not in apps_list

--- a/backend/tests/external_dependency_unit/craft/test_connectable_apps.py
+++ b/backend/tests/external_dependency_unit/craft/test_connectable_apps.py
@@ -21,16 +21,16 @@ def test_lists_only_unconnected_apps_and_renders_them(
 ) -> None:
     user = make_user(db_session, email_prefix="connectable")
 
-    # Connectable: needs a user-supplied token the org hasn't pre-filled.
+    # Connectable: public, needs a user token the org hasn't pre-filled.
     make_external_app(
         db_session,
-        skill=make_skill(db_session, slug="needs-setup"),
+        skill=make_skill(db_session, slug="needs-setup", is_public=True),
         auth_template=_USER_TOKEN_TEMPLATE,
     )
     # Connected: the user already stored the token.
     connected = make_external_app(
         db_session,
-        skill=make_skill(db_session, slug="already-connected"),
+        skill=make_skill(db_session, slug="already-connected", is_public=True),
         auth_template=_USER_TOKEN_TEMPLATE,
     )
     make_user_credential(
@@ -39,7 +39,7 @@ def test_lists_only_unconnected_apps_and_renders_them(
     # Org-credentialed: org pre-fills the token, so there's nothing to set up.
     make_external_app(
         db_session,
-        skill=make_skill(db_session, slug="org-filled"),
+        skill=make_skill(db_session, slug="org-filled", is_public=True),
         auth_template=_USER_TOKEN_TEMPLATE,
         organization_credentials={"token": "shared"},
     )
@@ -49,20 +49,26 @@ def test_lists_only_unconnected_apps_and_renders_them(
         skill=make_skill(db_session, slug="disabled-app", enabled=False),
         auth_template=_USER_TOKEN_TEMPLATE,
     )
+    # Not visible: non-public and not granted to this user — must be excluded, or
+    # the user would connect a skill that never injects into their sandbox.
+    make_external_app(
+        db_session,
+        skill=make_skill(db_session, slug="hidden-app", is_public=False),
+        auth_template=_USER_TOKEN_TEMPLATE,
+    )
     db_session.commit()
 
-    slugs = {
-        app.skill.slug for app in get_connectable_apps_for_user(db_session, user.id)
-    }
+    slugs = {app.skill.slug for app in get_connectable_apps_for_user(db_session, user)}
 
     assert "needs-setup" in slugs
     assert "already-connected" not in slugs
     assert "org-filled" not in slugs
     assert "disabled-app" not in slugs
+    assert "hidden-app" not in slugs
 
     section = build_connectable_apps_section(
-        get_connectable_apps_for_user(db_session, user.id)
+        get_connectable_apps_for_user(db_session, user)
     )
     assert "## Connectable apps" in section
     assert "needs-setup" in section
-    assert "already-connected" not in section
+    assert "hidden-app" not in section

--- a/backend/tests/external_dependency_unit/craft/test_scheduled_task_executor.py
+++ b/backend/tests/external_dependency_unit/craft/test_scheduled_task_executor.py
@@ -307,7 +307,7 @@ def test_timeout_error_event_marks_run_failed_with_timeout_class(
     # Bypass skill-payload: encrypted ExternalApp creds break local MIT decryption.
     monkeypatch.setattr(
         "onyx.server.features.build.session.manager.build_user_skills_payload",
-        lambda *_: ("", {}),
+        lambda *_: ("", "", {}),
     )
 
     sandbox(user=test_user, status=SandboxStatus.RUNNING)
@@ -343,7 +343,7 @@ def test_prompt_response_marks_run_succeeded(
     # Bypass skill-payload: encrypted ExternalApp creds break local MIT decryption.
     monkeypatch.setattr(
         "onyx.server.features.build.session.manager.build_user_skills_payload",
-        lambda *_: ("", {}),
+        lambda *_: ("", "", {}),
     )
 
     sandbox(user=test_user, status=SandboxStatus.RUNNING)
@@ -381,7 +381,7 @@ def test_cancelled_prompt_response_marks_run_failed(
     # Bypass skill-payload: encrypted ExternalApp creds break local MIT decryption.
     monkeypatch.setattr(
         "onyx.server.features.build.session.manager.build_user_skills_payload",
-        lambda *_: ("", {}),
+        lambda *_: ("", "", {}),
     )
 
     sandbox(user=test_user, status=SandboxStatus.RUNNING)
@@ -415,7 +415,7 @@ def test_transport_error_event_marks_run_failed_with_agent_exception_class(
     # Bypass skill-payload: encrypted ExternalApp creds break local MIT decryption.
     monkeypatch.setattr(
         "onyx.server.features.build.session.manager.build_user_skills_payload",
-        lambda *_: ("", {}),
+        lambda *_: ("", "", {}),
     )
 
     sandbox(user=test_user, status=SandboxStatus.RUNNING)
@@ -451,7 +451,7 @@ def test_stream_without_prompt_response_marks_run_failed(
     # Bypass skill-payload: encrypted ExternalApp creds break local MIT decryption.
     monkeypatch.setattr(
         "onyx.server.features.build.session.manager.build_user_skills_payload",
-        lambda *_: ("", {}),
+        lambda *_: ("", "", {}),
     )
 
     sandbox(user=test_user, status=SandboxStatus.RUNNING)

--- a/backend/tests/integration/tests/craft/k8s/test_bun_node_modules_dedup.py
+++ b/backend/tests/integration/tests/craft/k8s/test_bun_node_modules_dedup.py
@@ -63,6 +63,7 @@ def _setup_session(
         ),
         nextjs_port=None,
         skills_section="",
+        connectable_apps_section="",
     )
 
 

--- a/backend/tests/integration/tests/craft/k8s/test_snapshot_restore.py
+++ b/backend/tests/integration/tests/craft/k8s/test_snapshot_restore.py
@@ -306,6 +306,7 @@ def test_restore_with_missing_snapshot_creates_fresh_workspace(
         llm_config=default_llm_config(),
         nextjs_port=None,
         skills_section="No skills available.",
+        connectable_apps_section="No connectable apps available.",
     )
 
     listing = pod_exec(

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_agent_instructions.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_agent_instructions.py
@@ -68,3 +68,8 @@ def test_generate_agent_instructions_omits_optional_sections_when_values_absent(
     assert "**Disabled Tools**" not in content
     assert "SENTINEL_NO_SKILLS" in content
     assert _unresolved_placeholders(content) == set()
+
+
+def test_build_connectable_apps_section_empty_renders_nothing() -> None:
+    """No connectable apps → no heading at all (the section is omitted)."""
+    assert agent_instructions.build_connectable_apps_section([]) == ""

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_agent_instructions.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_agent_instructions.py
@@ -26,6 +26,7 @@ def test_generate_agent_instructions_uses_configured_approval_timeouts_in_real_t
     content = agent_instructions.generate_agent_instructions(
         template_path=_template_path(),
         skills_section="",
+        connectable_apps_section="",
     )
 
     assert "240 seconds" in content
@@ -41,6 +42,7 @@ def test_generate_agent_instructions_populates_real_template_runtime_values() ->
     content = agent_instructions.generate_agent_instructions(
         template_path=_template_path(),
         skills_section=skills_section,
+        connectable_apps_section="",
         provider="openai",
         model_name="gpt-5-mini",
         nextjs_port=3210,
@@ -62,6 +64,7 @@ def test_generate_agent_instructions_omits_optional_sections_when_values_absent(
     content = agent_instructions.generate_agent_instructions(
         template_path=_template_path(),
         skills_section="SENTINEL_NO_SKILLS",
+        connectable_apps_section="",
     )
 
     assert "You are assisting **" not in content
@@ -70,6 +73,37 @@ def test_generate_agent_instructions_omits_optional_sections_when_values_absent(
     assert _unresolved_placeholders(content) == set()
 
 
-def test_build_connectable_apps_section_empty_renders_nothing() -> None:
-    """No connectable apps → no heading at all (the section is omitted)."""
-    assert agent_instructions.build_connectable_apps_section([]) == ""
+def test_build_connectable_apps_list_empty_renders_fallback() -> None:
+    """No connectable apps → a fallback line, mirroring ``build_skills_section_
+    from_data``'s "No skills available." (the template blurb stays either way)."""
+    assert (
+        agent_instructions.build_connectable_apps_list([])
+        == "No connectable apps available."
+    )
+
+
+def test_generate_agent_instructions_keeps_connectable_blurb_when_empty() -> None:
+    """No connectable apps → the static blurb still renders, list placeholder
+    resolves to empty, nothing leaks through."""
+    content = agent_instructions.generate_agent_instructions(
+        template_path=_template_path(),
+        skills_section="- **x**: y",
+        connectable_apps_section="",
+    )
+
+    assert "## Connectable apps" in content  # blurb stays regardless of app count
+    assert _unresolved_placeholders(content) == set()
+
+
+def test_generate_agent_instructions_fills_connectable_list_from_template() -> None:
+    """Connectable apps → template-owned blurb renders with the substituted list."""
+    content = agent_instructions.generate_agent_instructions(
+        template_path=_template_path(),
+        skills_section="- **company-search**: SENTINEL_SKILL",
+        connectable_apps_section="- **slack**: SENTINEL_CONNECTABLE",
+    )
+
+    assert "## Connectable apps" in content
+    assert "- **company-search**: SENTINEL_SKILL" in content
+    assert "- **slack**: SENTINEL_CONNECTABLE" in content
+    assert _unresolved_placeholders(content) == set()

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_serve_plumbing.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_serve_plumbing.py
@@ -238,6 +238,7 @@ def test_render_agents_md_returns_escaped_string(
         llm_config=llm_config,
         nextjs_port=None,
         skills_section="",
+        connectable_apps_section="",
     )
     assert isinstance(agents_md, str)
     assert agents_md


### PR DESCRIPTION
## What

The agent-facing half of connect-on-demand: a no-op `connect_app` tool plus the AGENTS.md section that tells the agent which org apps a user can still connect.

## How

- **`connect-app.ts`** — the no-op opencode tool. Its `context.ask` pauses the turn and emits `permission.asked`; the backend (#12415) drives the connect card and answers allow/deny. On decline the tool returns a normal result so the agent keeps control and picks an alternative.
- **`opencode_config`** — `connect_app: "ask"` so the tool prompts rather than auto-allowing.
- **docker / kubernetes sandbox managers** — register the connect-app plugin.
- **`agent_instructions` + `skills/push`** — list the user's connectable apps in AGENTS.md.
- **`db`** — `get_connectable_apps_for_user`.

Stacks on #12415 (backend request flow).

- [x] [Optional] Override Linear Check
