### PR TITLE
fix: persist dark mode toggle across reloads

### DIFF
--- a/web/src/app/components/nrf/SettingsPanel.tsx
+++ b/web/src/app/components/nrf/SettingsPanel.tsx
@@ -13,6 +13,7 @@ import {
   CHAT_BACKGROUND_NONE,
   ChatBackgroundOption,
 } from "@/lib/constants/chatBackgrounds";
+import { ThemePreference } from "@/lib/types";
 
 interface SettingRowProps {
   label: string;
@@ -102,8 +103,10 @@ export const SettingsPanel = ({
   const currentBackgroundId = user?.preferences?.chat_background ?? "none";
   const isDark = theme === "dark";
 
-  const toggleTheme = () => {
-    setTheme(isDark ? "light" : "dark");
+  const toggleTheme = async () => {
+    const nextTheme = isDark ? ThemePreference.LIGHT : ThemePreference.DARK;
+    setTheme(nextTheme);
+    await updateUserThemePreference(nextTheme);
   };
 
   const handleBackgroundChange = async (bg: ChatBackgroundOption) => {

--- a/web/src/app/components/nrf/SettingsPanel.tsx
+++ b/web/src/app/components/nrf/SettingsPanel.tsx
@@ -106,7 +106,12 @@ export const SettingsPanel = ({
   const toggleTheme = async () => {
     const nextTheme = isDark ? ThemePreference.LIGHT : ThemePreference.DARK;
     setTheme(nextTheme);
-    await updateUserThemePreference(nextTheme);
+    try {
+      await updateUserThemePreference(nextTheme);
+    } catch {
+      // errors are already logged and state is rolled back via refreshUser
+      // inside updateUserThemePreference
+    }
   };
 
   const handleBackgroundChange = async (bg: ChatBackgroundOption) => {


### PR DESCRIPTION
## Description

The dark mode toggle in the NRF `SettingsPanel` didn't persist across page reloads.

**Root cause:** `toggleTheme` only called next-themes' `setTheme()`, which updates `localStorage` but not the user's DB `theme_preference`. On reload, `UserProvider` syncs the saved DB `theme_preference` back into next-themes via `setTheme()`, overriding the localStorage value and reverting the toggle to the stale DB preference. Every other theme entry point (`handleBackgroundChange`, the Color Mode selector in `SettingsPage`) already persists to the DB — the toggle was the lone exception.

**Fix:** `toggleTheme` now calls `updateUserThemePreference(nextTheme)` alongside `setTheme`, matching the established pattern, and wraps the call in a `try/catch` (like `handleBackgroundChange`) since `updateUserThemePreference` re-throws on failure. The chosen theme is written to the DB, so the `UserProvider` sync on reload reflects the user's actual choice.

## How Has This Been Tested?

- `oxfmt` / `oxlint` clean; `tsc --noEmit` passes (pre-commit hooks green)
- Manual: toggle dark/light in the settings panel, reload — theme now persists

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
