### PR TITLE
fix(settings): persist only changed personalization fields to stop silent save loss

### DIFF
--- a/web/src/hooks/__tests__/useUserPersonalization.test.tsx
+++ b/web/src/hooks/__tests__/useUserPersonalization.test.tsx
@@ -1,0 +1,73 @@
+import { renderHook, act } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import useUserPersonalization from "@/hooks/useUserPersonalization";
+import { User, UserPersonalization } from "@/lib/types";
+
+function makeUser(personalization: Partial<UserPersonalization>): User {
+  return {
+    personalization: {
+      name: "Bob",
+      role: "Engineer",
+      memories: [],
+      use_memories: false,
+      enable_memory_tool: false,
+      user_preferences: "",
+      ...personalization,
+    },
+  } as unknown as User;
+}
+
+describe("useUserPersonalization", () => {
+  it("persists only the fields the caller changed, not the whole snapshot", async () => {
+    const persist = jest.fn().mockResolvedValue(undefined);
+    const user = makeUser({});
+
+    const { result } = renderHook(() => useUserPersonalization(user, persist));
+
+    await act(async () => {
+      await result.current.handleSavePersonalization({ use_memories: true });
+    });
+
+    expect(persist).toHaveBeenCalledTimes(1);
+    // The payload must contain ONLY the changed field so independent saves
+    // commute on the backend (which leaves omitted fields untouched). Sending
+    // the full snapshot lets a stale save clobber another field's change.
+    expect(persist).toHaveBeenCalledWith({ use_memories: true });
+  });
+
+  it("does not resend unrelated fields when saving name", async () => {
+    const persist = jest.fn().mockResolvedValue(undefined);
+    const user = makeUser({ memories: [{ id: 1, content: "keep me" }] });
+
+    const { result } = renderHook(() => useUserPersonalization(user, persist));
+
+    await act(async () => {
+      await result.current.handleSavePersonalization({ name: "Bobby" });
+    });
+
+    const payload = persist.mock.calls[0]![0] as Partial<UserPersonalization>;
+    expect(payload).toEqual({ name: "Bobby" });
+    expect(payload).not.toHaveProperty("memories");
+    expect(payload).not.toHaveProperty("role");
+  });
+
+  it("trims memories before persisting when memories are the changed field", async () => {
+    const persist = jest.fn().mockResolvedValue(undefined);
+    const user = makeUser({});
+
+    const { result } = renderHook(() => useUserPersonalization(user, persist));
+
+    await act(async () => {
+      await result.current.handleSavePersonalization({
+        memories: [
+          { id: 1, content: "  trimmed  " },
+          { id: 2, content: "   " },
+        ],
+      });
+    });
+
+    expect(persist).toHaveBeenCalledWith({
+      memories: [{ id: 1, content: "trimmed" }],
+    });
+  });
+});

--- a/web/src/hooks/useUserPersonalization.ts
+++ b/web/src/hooks/useUserPersonalization.ts
@@ -95,7 +95,7 @@ interface UseUserPersonalizationOptions {
 export default function useUserPersonalization(
   user: User | null,
   persistPersonalization: (
-    personalization: UserPersonalization
+    personalization: Partial<UserPersonalization>
   ) => Promise<void>,
   options?: UseUserPersonalizationOptions
 ) {
@@ -178,18 +178,33 @@ export default function useUserPersonalization(
     async (overrides?: Partial<UserPersonalization>, silent?: boolean) => {
       setIsSavingPersonalization(true);
 
-      const valuesToSave = { ...personalizationValues, ...overrides };
-      const trimmedMemories = valuesToSave.memories
-        .map((memory) => ({ ...memory, content: memory.content.trim() }))
-        .filter((memory) => memory.content.length > 0);
+      // Persist ONLY the fields the caller intends to change. The backend
+      // leaves omitted fields untouched, so independent field saves commute and
+      // can't clobber one another. Persisting the full local snapshot (the
+      // previous behavior) let a stale save silently revert another field's
+      // change whenever two updates raced.
+      const changes: Partial<UserPersonalization> =
+        overrides ?? personalizationValues;
+      const changesToPersist: Partial<UserPersonalization> =
+        changes.memories === undefined
+          ? changes
+          : {
+              ...changes,
+              memories: changes.memories
+                .map((memory) => ({
+                  ...memory,
+                  content: memory.content.trim(),
+                }))
+                .filter((memory) => memory.content.length > 0),
+            };
 
       const updatedPersonalization: UserPersonalization = {
-        ...valuesToSave,
-        memories: trimmedMemories,
+        ...personalizationValues,
+        ...changesToPersist,
       };
 
       try {
-        await persistPersonalization(updatedPersonalization);
+        await persistPersonalization(changesToPersist);
         setPersonalizationValues(updatedPersonalization);
         if (!silent) {
           onSuccess?.(updatedPersonalization);

--- a/web/src/providers/UserProvider.tsx
+++ b/web/src/providers/UserProvider.tsx
@@ -43,7 +43,7 @@ interface UserContextType {
   ) => Promise<boolean>;
   updateUserTemperatureOverrideEnabled: (enabled: boolean) => Promise<void>;
   updateUserPersonalization: (
-    personalization: UserPersonalization
+    changes: Partial<UserPersonalization>
   ) => Promise<void>;
   updateUserThemePreference: (
     themePreference: ThemePreference
@@ -292,21 +292,26 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
   };
 
   const updateUserPersonalization = async (
-    personalization: UserPersonalization
+    changes: Partial<UserPersonalization>
   ) => {
     try {
       setUpToDateUser((prevUser) => {
-        if (!prevUser) {
+        if (!prevUser?.personalization) {
           return prevUser;
         }
 
+        // Merge only the changed fields so an update to one field never
+        // optimistically wipes the others.
         return {
           ...prevUser,
-          personalization,
+          personalization: {
+            ...prevUser.personalization,
+            ...changes,
+          },
         };
       });
 
-      const response = await persistPersonalization(personalization);
+      const response = await persistPersonalization(changes);
 
       if (!response.ok) {
         await refreshUser();

--- a/web/src/views/SettingsPage.tsx
+++ b/web/src/views/SettingsPage.tsx
@@ -488,7 +488,9 @@ function GeneralSettings() {
                 onBlur={() => {
                   // Only save if the value has changed
                   if (personalizationValues.name !== initialNameRef.current) {
-                    void handleSavePersonalization();
+                    void handleSavePersonalization({
+                      name: personalizationValues.name,
+                    });
                     initialNameRef.current = personalizationValues.name;
                   }
                 }}
@@ -514,7 +516,9 @@ function GeneralSettings() {
                 onBlur={() => {
                   // Only save if the value has changed
                   if (personalizationValues.role !== initialRoleRef.current) {
-                    void handleSavePersonalization();
+                    void handleSavePersonalization({
+                      role: personalizationValues.role,
+                    });
                     initialRoleRef.current = personalizationValues.role;
                   }
                 }}
@@ -1147,7 +1151,11 @@ function ChatPreferencesSettings() {
             placeholder="Describe how you want the system to behave and the tone it should use."
             value={personalizationValues.user_preferences}
             onChange={(e) => updateUserPreferences(e.target.value)}
-            onBlur={() => void handleSavePersonalization()}
+            onBlur={() =>
+              void handleSavePersonalization({
+                user_preferences: personalizationValues.user_preferences,
+              })
+            }
             rows={4}
             maxRows={10}
             autoResize


### PR DESCRIPTION
## Symptom

Clicking Save on the settings page **sometimes silently fails** — a change doesn't persist and no error is shown.

## Root cause

The settings page saves personalization fields independently — name/role/preferences on blur, the memory switches and memories on change — all routed through `useUserPersonalization.handleSavePersonalization`. That function built `{ ...personalizationValues, ...overrides }` and **PATCHed the entire 6-field personalization object** assembled from a client-side snapshot (`web/src/hooks/useUserPersonalization.ts`).

The backend (`backend/onyx/server/manage/users.py:1101`, `PersonalizationUpdateRequest`) is built for *partial* updates — every field is `request.X if request.X is not None else <existing>`, and all request fields are `X | None = None`. But the client never sent `None`; it sent concrete values for all six fields every time. So a save meant to change **one** field also rewrote the other five from a possibly-stale snapshot.

When two updates happened close together (toggling both memory switches, editing a field while a prior save's optimistic update / `refreshUser` was in flight, or PATCH responses arriving out of order), the second save's stale snapshot silently reverted the first. Every PATCH returned `200`, so no error surfaced — hence "silent" and "sometimes" (a timing-dependent last-writer-wins race).

## Fix

Send **only the field(s) the caller actually changed**, leveraging the backend's existing partial-merge semantics. Independent field saves now commute and can't clobber one another.

- `useUserPersonalization.ts` — persist only the changed fields (the `overrides`); keep a full merged object for local/optimistic UI state. Memories are trimmed only when memories are the changed field.
- `UserProvider.tsx` — `updateUserPersonalization` now accepts a `Partial<UserPersonalization>` and **merges** it into the existing personalization optimistically instead of replacing wholesale (the provider method is consumed only by this hook).
- `SettingsPage.tsx` — the three blur callers (name, role, personal preferences) now pass their specific changed field.

The provider method is consumed only by the hook (SettingsPage and MemoriesModal both feed it into `useUserPersonalization`), so the change is contained. `NonAdminStep`/`useShowOnboarding` already call the lib with partial payloads, confirming partial PATCH is an established, backend-supported pattern.

## Verification

- New unit tests in `web/src/hooks/__tests__/useUserPersonalization.test.tsx` assert each save sends **only** the changed field(s) and trims memories — these fail on `main` (full snapshot sent) and pass with the fix.
- `tsc --noEmit`: no new type errors introduced (the repo's 487 pre-existing baseline errors are unchanged; none are in the touched logic).
- Formatter (oxfmt) and linter (oxlint) pass.
- Confirmed `PersonalizationUpdateRequest` fields are all optional, so partial PATCH bodies validate and trigger the none-means-unchanged merge.

> Note: the pre-commit TypeScript hook could not run in this environment (it fetches `tsgo` from npm, which 404s under the network restrictions); type-correctness was verified manually with the installed `tsc`.

## Noticed, out of scope

`useUserPersonalization`'s sync `useEffect` resets local state from `user` on every change, so a `refreshUser()` (or focus revalidation) can still discard a field that's been **typed but not yet blurred**. That's a separate data-loss vector from the reported "save reverts" bug and isn't addressed here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes intermittent settings saves that silently reverted changes by persisting only the fields that actually changed. Partial PATCHes now prevent stale snapshots from overwriting other personalization fields.

- **Bug Fixes**
  - Persist only changed fields in `useUserPersonalization.handleSavePersonalization`; trim memories only when saving memories.
  - `UserProvider.updateUserPersonalization` accepts `Partial<UserPersonalization>` and merges changes optimistically instead of replacing all fields.
  - Settings inputs (name, role, user_preferences) now pass only their field on blur.
  - Added unit tests to ensure partial payloads and memory trimming.

<sup>Written for commit e743048d7ae5b19e1e6458712c7af93b03eeb2b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

