### PR TITLE
fix(chat-search): stable pagination via deterministic id tiebreaker

### DIFF
--- a/backend/onyx/db/chat_search.py
+++ b/backend/onyx/db/chat_search.py
@@ -39,7 +39,9 @@ def search_chat_sessions(
     if not query or not query.strip():
         stmt = (
             select(ChatSession)
-            .order_by(desc(ChatSession.time_created))
+            # `id` breaks ties on the non-unique `time_created` so OFFSET/LIMIT
+            # pages stay disjoint and stable across separate page queries.
+            .order_by(desc(ChatSession.time_created), desc(ChatSession.id))
             .offset(offset_val)
             .limit(page_size + 1)
         )
@@ -95,7 +97,7 @@ def search_chat_sessions(
     final_stmt = (
         select(ChatSession)
         .join(combined_ids, ChatSession.id == combined_ids.c.id)
-        .order_by(desc(ChatSession.time_created))
+        .order_by(desc(ChatSession.time_created), desc(ChatSession.id))
         .distinct()
         .offset(offset_val)
         .limit(page_size + 1)

--- a/backend/tests/external_dependency_unit/db/test_chat_search_pagination.py
+++ b/backend/tests/external_dependency_unit/db/test_chat_search_pagination.py
@@ -1,0 +1,89 @@
+import datetime
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from onyx.db.chat_search import search_chat_sessions
+from onyx.db.models import ChatSession
+from onyx.db.models import User
+from tests.external_dependency_unit.conftest import create_test_user
+
+SHARED_TIME = datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+
+
+def _make_tied_sessions(
+    db_session: Session, user: User, count: int, description: str
+) -> set[UUID]:
+    """Create ``count`` sessions that all share ``SHARED_TIME`` so the only
+    thing keeping OFFSET/LIMIT pages disjoint is a unique ORDER BY tiebreaker."""
+    created_ids: set[UUID] = set()
+    for _ in range(count):
+        chat_session = ChatSession(
+            user_id=user.id,
+            description=description,
+            time_created=SHARED_TIME,
+        )
+        db_session.add(chat_session)
+        db_session.flush()
+        created_ids.add(chat_session.id)
+    return created_ids
+
+
+def _paginate_all(
+    db_session: Session, user_id: UUID, query: str | None, page_size: int
+) -> list[UUID]:
+    """Walk every page via search_chat_sessions, collecting ids in order."""
+    collected: list[UUID] = []
+    page = 1
+    while True:
+        sessions, has_more = search_chat_sessions(
+            user_id=user_id,
+            db_session=db_session,
+            query=query,
+            page=page,
+            page_size=page_size,
+        )
+        collected.extend(s.id for s in sessions)
+        if not has_more:
+            break
+        page += 1
+        # Safety valve so a pagination bug can't loop forever.
+        assert page < 100
+    return collected
+
+
+def test_recent_pagination_stable_with_tied_timestamps(db_session: Session) -> None:
+    """No-query branch: tied ``time_created`` must paginate without cross-page
+    duplicates, without omissions, and in a deterministic order."""
+    user = create_test_user(db_session, "chat-search-recent")
+    created_ids = _make_tied_sessions(db_session, user, count=25, description="recent")
+
+    try:
+        all_ids = _paginate_all(db_session, user.id, query=None, page_size=10)
+
+        # The reported bug: no session repeats across pages.
+        assert len(all_ids) == len(set(all_ids)), "duplicate session(s) across pages"
+        # Flip side of the same defect: nothing silently dropped.
+        assert set(all_ids) == created_ids
+        # Total, deterministic order: time_created DESC, then id DESC.
+        assert all_ids == sorted(created_ids, reverse=True)
+    finally:
+        db_session.rollback()
+
+
+def test_query_pagination_stable_with_tied_timestamps(db_session: Session) -> None:
+    """Search branch: full-text matches with tied ``time_created`` must paginate
+    without cross-page duplicates, without omissions, and in a deterministic order."""
+    user = create_test_user(db_session, "chat-search-query")
+    created_ids = _make_tied_sessions(
+        db_session, user, count=25, description="quarterly alpaca report"
+    )
+
+    try:
+        all_ids = _paginate_all(db_session, user.id, query="alpaca", page_size=10)
+
+        assert len(all_ids) == len(set(all_ids)), "duplicate session(s) across pages"
+        assert set(all_ids) == created_ids
+        assert all_ids == sorted(created_ids, reverse=True)
+    finally:
+        db_session.rollback()


### PR DESCRIPTION
## Root cause

`search_chat_sessions` (`backend/onyx/db/chat_search.py`) paginated with `OFFSET/LIMIT` ordered by `desc(ChatSession.time_created)` **alone**. `time_created` is non-unique, so the sort had no total order: among rows sharing a timestamp, Postgres is free to return them in a different order on each of the *separate* per-page queries. As a result the same chat session could land on more than one page ("page 2 shows duplicates from page 1"), while other sessions were silently dropped.

This affected **both** branches of the function — the no-query "recent sessions" path and the full-text-search path (which additionally uses `.distinct()`).

## Fix

Add `desc(ChatSession.id)` (the primary key — unique, non-null) as a secondary sort key in both `order_by` clauses, giving a strict total order. `OFFSET/LIMIT` pages are now disjoint and stable across queries.

```python
.order_by(desc(ChatSession.time_created), desc(ChatSession.id))
```

`id` is already part of `select(ChatSession)`, so the `SELECT DISTINCT … ORDER BY` query remains valid on Postgres.

## Verification

New external-dependency-unit test `backend/tests/external_dependency_unit/db/test_chat_search_pagination.py` covering **both** branches: it creates 25 sessions sharing one `time_created`, paginates through every page, and asserts no cross-page duplicates, no omissions, and a deterministic `time_created DESC, id DESC` order.

- Reproduced **red** on the unfixed code (duplicates/omissions + non-deterministic order).
- **Green** after the fix, run **20×** consecutively for stability (the original bug was non-deterministic).
- `pre-commit` (ruff, ruff format, `ty` type-check) passes on the changed files.

Verified against a throwaway Postgres migrated to `alembic head` (no shared infra touched).

## Notes / out of scope

- The frontend hook `web/src/lib/sidebar/hooks.ts` (`useChatSearchOptimistic`) already dedups results by session id as a defensive band-aid. It's left in place as defense-in-depth; this PR fixes the actual root cause in the query.
- Known minor test enhancements left for a follow-up (optional): an explicit `has_more` assertion, an exact-multiple-of-`page_size` boundary case, and a variant matching via `message_tsv` rather than `description`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes non-deterministic chat search pagination by adding a deterministic `id` tiebreaker, preventing duplicates and dropped sessions across pages. Applies to both recent sessions and full-text search paths.

- **Bug Fixes**
  - Order results by `time_created DESC, id DESC` in both code paths to make `OFFSET/LIMIT` pages stable and disjoint.
  - Added `backend/tests/external_dependency_unit/db/test_chat_search_pagination.py` to verify no cross-page duplicates, no omissions, and deterministic ordering.

<sup>Written for commit ae11e000ecfa4e73d82fb6483f08855911949497. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---
- [x] Override Linear Check
