### PR TITLE
fix: stop settings page from silently discarding in-progress edits

### DIFF
--- a/web/src/hooks/useUserPersonalization.test.tsx
+++ b/web/src/hooks/useUserPersonalization.test.tsx
@@ -1,0 +1,61 @@
+import { act, renderHook } from "@testing-library/react";
+import useUserPersonalization from "@/hooks/useUserPersonalization";
+import { User, UserPersonalization } from "@/lib/types";
+
+function makeUser(personalization: Partial<UserPersonalization>): User {
+  return {
+    personalization: {
+      name: "",
+      role: "",
+      memories: [],
+      use_memories: true,
+      enable_memory_tool: true,
+      user_preferences: "",
+      ...personalization,
+    },
+  } as unknown as User;
+}
+
+describe("useUserPersonalization", () => {
+  test("does not clobber unsaved local edits when the user object reference changes but its personalization content is unchanged", async () => {
+    const persist = jest.fn().mockResolvedValue(undefined);
+    const user1 = makeUser({ name: "Alice" });
+
+    const { result, rerender } = renderHook(
+      ({ user }) => useUserPersonalization(user, persist),
+      { initialProps: { user: user1 } }
+    );
+
+    // User types a new name but has not yet triggered a save (e.g. has not blurred).
+    act(() => {
+      result.current.updatePersonalizationField("name", "Alice Smith");
+    });
+    expect(result.current.personalizationValues.name).toBe("Alice Smith");
+
+    // An unrelated settings save (theme, auto-scroll, etc.) calls refreshUser(),
+    // which makes SWR hand back a brand-new `user` object reference whose
+    // personalization content is identical to before.
+    const user2 = makeUser({ name: "Alice" });
+    rerender({ user: user2 });
+
+    // The in-progress edit must survive the reference churn.
+    expect(result.current.personalizationValues.name).toBe("Alice Smith");
+  });
+
+  test("adopts genuinely changed server personalization", () => {
+    const persist = jest.fn().mockResolvedValue(undefined);
+    const { result, rerender } = renderHook(
+      ({ user }) => useUserPersonalization(user, persist),
+      { initialProps: { user: makeUser({ name: "Alice" }) } }
+    );
+
+    // No local edit; server pushes a real change (e.g. memory generated elsewhere).
+    rerender({
+      user: makeUser({ name: "Alice", user_preferences: "be terse" }),
+    });
+
+    expect(result.current.personalizationValues.user_preferences).toBe(
+      "be terse"
+    );
+  });
+});

--- a/web/src/hooks/useUserPersonalization.ts
+++ b/web/src/hooks/useUserPersonalization.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { MemoryItem, User, UserPersonalization } from "@/lib/types";
 
 const DEFAULT_PERSONALIZATION: UserPersonalization = {
@@ -111,7 +111,18 @@ export default function useUserPersonalization(
     [user]
   );
 
+  // Resync local form state from the server only when the personalization
+  // *content* actually changes. The `user` object reference churns on every
+  // unrelated settings save (theme, auto-scroll, etc. all call refreshUser()),
+  // and blindly resyncing on that churn would silently clobber a field the
+  // user is still editing but hasn't saved yet.
+  const lastSyncedSignatureRef = useRef<string | null>(null);
   useEffect(() => {
+    const signature = JSON.stringify(basePersonalization);
+    if (signature === lastSyncedSignatureRef.current) {
+      return;
+    }
+    lastSyncedSignatureRef.current = signature;
     setPersonalizationValues(basePersonalization);
   }, [basePersonalization]);
 

--- a/web/src/views/SettingsPage.tsx
+++ b/web/src/views/SettingsPage.tsx
@@ -400,15 +400,18 @@ function GeneralSettings() {
     onError: () => toast.error("Failed to update personalization"),
   });
 
-  // Track initial values to detect changes
-  const initialNameRef = useRef(personalizationValues.name);
-  const initialRoleRef = useRef(personalizationValues.role);
+  // Baseline the blur-save change detection against the *persisted* server
+  // values, not the local (possibly mid-edit) values. Keying off the values
+  // themselves — rather than the `user.personalization` object reference —
+  // means an unrelated settings refresh won't advance the baseline onto an
+  // unsaved edit and cause the next blur to skip the save.
+  const initialNameRef = useRef(user?.personalization?.name ?? "");
+  const initialRoleRef = useRef(user?.personalization?.role ?? "");
 
-  // Update refs when personalization values change from external source
   useEffect(() => {
-    initialNameRef.current = personalizationValues.name;
-    initialRoleRef.current = personalizationValues.role;
-  }, [user?.personalization]);
+    initialNameRef.current = user?.personalization?.name ?? "";
+    initialRoleRef.current = user?.personalization?.role ?? "";
+  }, [user?.personalization?.name, user?.personalization?.role]);
 
   const handleDeleteAllChats = useCallback(async () => {
     setIsDeleting(true);


### PR DESCRIPTION
## Symptom

Users reported that saving on the **settings page** sometimes silently fails — the change they typed (name, work role, or personal preferences) never persists, and no error is shown.

## Root cause

The personalization form on the user settings page keeps optimistic local state in `useUserPersonalization`, which it resynced from the server on **every change of the `user` object reference**:

```ts
const basePersonalization = useMemo(() => derivePersonalizationFromUser(user), [user]);
useEffect(() => { setPersonalizationValues(basePersonalization); }, [basePersonalization]);
```

Every *unrelated* settings save on the same page (theme, chat background, auto‑scroll, default model, …) calls `refreshUser()`, and SWR hands back a brand-new `user` object. That reference churn fired the effect and **overwrote whatever field the user was still editing** back to the server value — before they had a chance to save it (saves happen on blur).

This was compounded in `GeneralSettings`: the name/role change-detection refs were advanced onto the *local, possibly-unsaved* value whenever `user.personalization` changed by reference. So even when the edit survived, the subsequent blur compared the value against itself, saw "no change", and **skipped the save entirely** — silently, with no error.

The intermittency ("sometimes") is exactly the race: it only loses the edit when an unrelated `refreshUser()` lands while a field is mid-edit.

## Fix

- **`useUserPersonalization.ts`** — resync local state only when the server personalization *content* actually changes (value signature), not when the `user` reference merely churns. Genuine server-side changes are still adopted.
- **`SettingsPage.tsx` (`GeneralSettings`)** — baseline the name/role change detection against the *persisted server values* and key the effect on those values, so an unrelated refresh can't move the baseline onto an unsaved edit.

## Verification

Added `web/src/hooks/useUserPersonalization.test.tsx`:
- **red→green** test: edit a field locally, then hand the hook a new `user` object with identical content (simulating `refreshUser()` churn) — the in-progress edit must survive. Fails on `main`, passes with the fix.
- guard test: a genuine server-side personalization change is still adopted (prevents over-correcting into "never sync").

```
Tests: 2 passed
```

## Noticed, out of scope

While mapping settings save flows, a few other pages have separate silent/awkward-failure patterns worth a follow-up (not touched here): the EE Theme/Appearance page early-returns on validation with no toast (and uses `alert()` for logo-upload errors), and some admin numeric-limit blur handlers update their saved-baseline before the save resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the settings page from silently discarding in-progress personalization edits. Edits now persist even when `refreshUser()` returns a new `user` object.

- **Bug Fixes**
  - `useUserPersonalization`: resync local state only when personalization content changes (signature check), not on `user` reference churn.
  - `SettingsPage.tsx` (`GeneralSettings`): compare blur-save against persisted server values; key effects on `name`/`role` values to avoid advancing the baseline onto unsaved edits.
  - Added `useUserPersonalization.test.tsx` to ensure in-progress edits survive `refreshUser()` churn and real server-side changes are still adopted.

<sup>Written for commit 2bab48cbf79398b9c8b3650fa9fa2c885ed2a763. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

