### PR TITLE
fix(reporting): stop usage CSV export dropping rows at the 500-row page boundary (ONX-2293)

### DIFF
--- a/backend/ee/onyx/db/query_history.py
+++ b/backend/ee/onyx/db/query_history.py
@@ -1,11 +1,14 @@
 from collections.abc import Sequence
 from datetime import datetime
+from uuid import UUID
 
+from sqlalchemy import and_
 from sqlalchemy import asc
 from sqlalchemy import BinaryExpression
 from sqlalchemy import ColumnElement
 from sqlalchemy import desc
 from sqlalchemy import distinct
+from sqlalchemy import or_
 from sqlalchemy.orm import contains_eager
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm import Session
@@ -136,10 +139,20 @@ def fetch_chat_sessions_eagerly_by_time(
     db_session: Session,
     limit: int | None = 500,
     initial_time: datetime | None = None,
+    initial_id: UUID | None = None,
 ) -> list[ChatSession]:
-    """Sorted by oldest to newest, then by message id"""
+    """Sorted by oldest to newest, by (time_created, id), then by message id.
+
+    Pagination uses a composite ``(time_created, id)`` keyset cursor. Because
+    ``ChatSession.time_created`` is not unique (it defaults to the transaction
+    clock, so sessions created together share a timestamp), a cursor on
+    ``time_created`` alone would skip every session sharing the previous page's
+    final timestamp. Passing the previous page's last ``(initial_time,
+    initial_id)`` resumes strictly after that row without dropping ties.
+    """
 
     asc_time_order: UnaryExpression = asc(ChatSession.time_created)
+    id_order: UnaryExpression = asc(ChatSession.id)
     message_order: UnaryExpression = asc(ChatMessage.id)
 
     filters: list[ColumnElement | BinaryExpression] = [
@@ -147,12 +160,23 @@ def fetch_chat_sessions_eagerly_by_time(
     ]
 
     if initial_time:
-        filters.append(ChatSession.time_created > initial_time)
+        if initial_id is not None:
+            filters.append(
+                or_(
+                    ChatSession.time_created > initial_time,
+                    and_(
+                        ChatSession.time_created == initial_time,
+                        ChatSession.id > initial_id,
+                    ),
+                )
+            )
+        else:
+            filters.append(ChatSession.time_created > initial_time)
 
     subquery = (
         db_session.query(ChatSession.id, ChatSession.time_created)
         .filter(*filters)
-        .order_by(asc_time_order)
+        .order_by(asc_time_order, id_order)
         .limit(limit)
         .subquery()
     )
@@ -168,7 +192,7 @@ def fetch_chat_sessions_eagerly_by_time(
                 ChatMessage.chat_message_feedbacks
             ),
         )
-        .order_by(asc_time_order, message_order)
+        .order_by(asc_time_order, id_order, message_order)
     )
 
     chat_sessions = query.all()

--- a/backend/ee/onyx/db/query_history.py
+++ b/backend/ee/onyx/db/query_history.py
@@ -159,19 +159,25 @@ def fetch_chat_sessions_eagerly_by_time(
         ChatSession.time_created.between(start, end)
     ]
 
-    if initial_time:
-        if initial_id is not None:
-            filters.append(
-                or_(
-                    ChatSession.time_created > initial_time,
-                    and_(
-                        ChatSession.time_created == initial_time,
-                        ChatSession.id > initial_id,
-                    ),
-                )
+    if initial_time is not None or initial_id is not None:
+        # The two halves form a single composite (time_created, id) keyset
+        # cursor. Accepting only one would silently fall back to a cursor on the
+        # non-unique time_created alone and reintroduce the ONX-2293 row drop, so
+        # require them together.
+        if initial_time is None or initial_id is None:
+            raise ValueError(
+                "initial_time and initial_id are a composite keyset cursor and "
+                "must be provided together"
             )
-        else:
-            filters.append(ChatSession.time_created > initial_time)
+        filters.append(
+            or_(
+                ChatSession.time_created > initial_time,
+                and_(
+                    ChatSession.time_created == initial_time,
+                    ChatSession.id > initial_id,
+                ),
+            )
+        )
 
     subquery = (
         db_session.query(ChatSession.id, ChatSession.time_created)

--- a/backend/ee/onyx/db/usage_export.py
+++ b/backend/ee/onyx/db/usage_export.py
@@ -25,21 +25,24 @@ def get_empty_chat_messages_entries__paginated(
     db_session: Session,
     period: tuple[datetime, datetime],
     limit: int | None = 500,
-    initial_time: datetime | None = None,
-) -> tuple[Optional[datetime], list[ChatMessageSkeleton]]:
+    initial_cursor: tuple[datetime, uuid.UUID] | None = None,
+) -> tuple[Optional[tuple[datetime, uuid.UUID]], list[ChatMessageSkeleton]]:
     """Returns a tuple where:
-    first element is the most recent timestamp out of the sessions iterated
-    - this timestamp can be used to paginate forward in time
+    first element is the ``(time_created, id)`` cursor of the last session
+    iterated, or ``None`` once the final page has been reached - pass it back in
+    as ``initial_cursor`` to fetch the next page
     second element is a list of messages belonging to all the sessions iterated
 
     Only messages of type USER are returned
     """
+    initial_time, initial_id = initial_cursor if initial_cursor else (None, None)
     chat_sessions = fetch_chat_sessions_eagerly_by_time(
         start=period[0],
         end=period[1],
         db_session=db_session,
         limit=limit,
         initial_time=initial_time,
+        initial_id=initial_id,
     )
 
     message_skeletons: list[ChatMessageSkeleton] = []
@@ -107,7 +110,17 @@ def get_empty_chat_messages_entries__paginated(
     if len(chat_sessions) == 0:
         return None, []
 
-    return chat_sessions[-1].time_created, message_skeletons
+    # A short page means there are no more sessions to fetch. Signalling this
+    # via the cursor (rather than the caller stopping on an empty skeleton list)
+    # ensures a full page that happens to contain no USER messages does not end
+    # iteration prematurely.
+    last_session = chat_sessions[-1]
+    next_cursor = (
+        (last_session.time_created, last_session.id)
+        if limit is not None and len(chat_sessions) >= limit
+        else None
+    )
+    return next_cursor, message_skeletons
 
 
 def get_all_empty_chat_message_entries(
@@ -115,22 +128,20 @@ def get_all_empty_chat_message_entries(
     period: tuple[datetime, datetime],
 ) -> Generator[list[ChatMessageSkeleton], None, None]:
     """period is the range of time over which to fetch messages."""
-    initial_time: Optional[datetime] = period[0]
+    cursor: tuple[datetime, uuid.UUID] | None = None
     while True:
         # iterate from oldest to newest
-        time_created, message_skeletons = get_empty_chat_messages_entries__paginated(
+        cursor, message_skeletons = get_empty_chat_messages_entries__paginated(
             db_session,
             period,
-            initial_time=initial_time,
+            initial_cursor=cursor,
         )
 
-        if not message_skeletons:
+        if message_skeletons:
+            yield message_skeletons
+
+        if cursor is None:
             return
-
-        yield message_skeletons
-
-        # Update initial_time for the next iteration
-        initial_time = time_created
 
 
 def get_all_usage_reports(db_session: Session) -> list[UsageReportMetadata]:

--- a/backend/tests/external_dependency_unit/db/test_usage_export_pairing.py
+++ b/backend/tests/external_dependency_unit/db/test_usage_export_pairing.py
@@ -1,15 +1,18 @@
 from datetime import datetime
+from datetime import timedelta
 from datetime import timezone
 from uuid import UUID
 
 from sqlalchemy.orm import Session
 
+from ee.onyx.db.usage_export import get_all_empty_chat_message_entries
 from ee.onyx.db.usage_export import get_empty_chat_messages_entries__paginated
 from onyx.configs.constants import MessageType
 from onyx.db.chat import create_chat_session
 from onyx.db.chat import create_new_chat_message
 from onyx.db.chat import get_or_create_root_message
 from onyx.db.models import ChatMessage
+from onyx.db.models import ChatSession
 from tests.external_dependency_unit.conftest import create_test_user
 
 
@@ -109,6 +112,126 @@ def test_single_assistant_child_emits_single_row(db_session: Session) -> None:
     matching = [s for s in skeletons if s.message_id == user_msg.id]
     assert len(matching) == 1
     assert matching[0].llm_model == "only-model"
+
+
+def test_pagination_does_not_drop_sessions_sharing_boundary_timestamp(
+    db_session: Session,
+) -> None:
+    """Regression for ONX-2293: the usage CSV export drops rows once the data
+    exceeds the 500-session page limit and sessions share the boundary
+    ``time_created``.
+
+    ``fetch_chat_sessions_eagerly_by_time`` paginated with a strict ``>``
+    cursor on the non-unique ``ChatSession.time_created``; every session
+    sharing the last page's timestamp was skipped by the next page. Here all
+    sessions share one timestamp and the count crosses the page boundary, so
+    the buggy implementation emits only the first page worth of rows.
+    """
+    user = create_test_user(db_session, "usage-export-pagination")
+    shared_time = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+    # One past the 500-row page size so the dataset spans more than one page.
+    num_sessions = 501
+    expected_session_ids = set()
+    try:
+        for _ in range(num_sessions):
+            chat_session = create_chat_session(
+                db_session=db_session,
+                description="boundary collision",
+                user_id=user.id,
+                persona_id=None,
+            )
+            db_session.query(ChatSession).filter(
+                ChatSession.id == chat_session.id
+            ).update({ChatSession.time_created: shared_time})
+            root = get_or_create_root_message(chat_session.id, db_session)
+            _make_user_message(db_session, chat_session.id, root)
+            expected_session_ids.add(chat_session.id)
+        db_session.commit()
+
+        seen_session_ids = [
+            skeleton.chat_session_id
+            for batch in get_all_empty_chat_message_entries(db_session, _full_period())
+            for skeleton in batch
+        ]
+        # Other tests share the DB, so scope to the sessions we created.
+        mine_seen = [sid for sid in seen_session_ids if sid in expected_session_ids]
+
+        # No session should be dropped, and none double-counted.
+        assert set(mine_seen) == expected_session_ids
+        assert len(mine_seen) == num_sessions
+    finally:
+        # Keep the shared DB small: sibling tests use the single-page helper and
+        # assume their freshly-created session lands on the first page.
+        if expected_session_ids:
+            db_session.query(ChatMessage).filter(
+                ChatMessage.chat_session_id.in_(expected_session_ids)
+            ).delete(synchronize_session=False)
+            db_session.query(ChatSession).filter(
+                ChatSession.id.in_(expected_session_ids)
+            ).delete(synchronize_session=False)
+            db_session.commit()
+
+
+def test_full_page_with_no_user_messages_keeps_paginating(
+    db_session: Session,
+) -> None:
+    """A full page (``len == limit``) that happens to contain no USER messages
+    must still return a non-None cursor so iteration continues — otherwise
+    later pages (which may hold USER messages) are silently dropped.
+
+    This is the second half of the ONX-2293 fix: pagination now terminates on a
+    short page rather than on an empty skeleton list.
+    """
+    user = create_test_user(db_session, "usage-export-empty-page")
+    shared_time = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    # Tight window so only the sessions created here are in range, independent
+    # of other sessions in the shared DB.
+    window = (
+        shared_time - timedelta(seconds=1),
+        shared_time + timedelta(seconds=1),
+    )
+
+    session_ids = []
+    try:
+        # Two sessions whose only message is an assistant reply (no USER message).
+        for _ in range(2):
+            chat_session = create_chat_session(
+                db_session=db_session,
+                description="no user messages",
+                user_id=user.id,
+                persona_id=None,
+            )
+            db_session.query(ChatSession).filter(
+                ChatSession.id == chat_session.id
+            ).update({ChatSession.time_created: shared_time})
+            root = get_or_create_root_message(chat_session.id, db_session)
+            _make_assistant_message(db_session, chat_session.id, root, "model-x")
+            session_ids.append(chat_session.id)
+        db_session.commit()
+
+        # A full page (limit == number of sessions) with zero USER messages must
+        # advance the cursor rather than signalling end-of-data.
+        full_page_cursor, skeletons = get_empty_chat_messages_entries__paginated(
+            db_session, window, limit=2
+        )
+        assert skeletons == []
+        assert full_page_cursor is not None
+
+        # A short page (fewer sessions than the limit) signals the end.
+        short_page_cursor, _ = get_empty_chat_messages_entries__paginated(
+            db_session, window, limit=10
+        )
+        assert short_page_cursor is None
+    finally:
+        if session_ids:
+            db_session.query(ChatMessage).filter(
+                ChatMessage.chat_session_id.in_(session_ids)
+            ).delete(synchronize_session=False)
+            db_session.query(ChatSession).filter(
+                ChatSession.id.in_(session_ids)
+            ).delete(synchronize_session=False)
+            db_session.commit()
 
 
 def test_orphan_user_message_emits_row_with_null_model(db_session: Session) -> None:


### PR DESCRIPTION
## ONX-2293 — CSV export drops the last row(s) near 500 items

### Root cause
The admin **usage-report CSV export** paginates chat sessions in
`fetch_chat_sessions_eagerly_by_time` (`backend/ee/onyx/db/query_history.py`)
using a keyset cursor that was **`ChatSession.time_created > initial_time`**,
ordered **only** by `time_created`. But `time_created` is **not unique** —
sessions created together (bulk Slack/connector imports, sub-second bursts)
share a timestamp.

Once the dataset exceeds the **500-row page limit**, the next page's strict
`> time_created` filter **skips every session that shares the boundary page's
timestamp**, silently dropping the tail of the export. The sibling
`get_page_of_chat_sessions` already carried an `id` tiebreaker — this function
did not, which is the asymmetry that caused the bug.

A second, latent defect lived in `get_all_empty_chat_message_entries`
(`backend/ee/onyx/db/usage_export.py`): it stopped paginating as soon as a page
produced an empty *skeleton* list, so a full page of 500 sessions that happened
to contain no USER messages would end iteration early and drop everything after.

### Fix
- **Stable composite `(time_created, id)` keyset cursor** — order by
  `(time_created, id)` and resume with `time > t OR (time == t AND id > id)`, so
  ties at the page boundary are no longer skipped.
- **Terminate on a short page** (`len(sessions) < limit`) instead of on an empty
  skeleton list, so a full page with no USER messages keeps paginating.
- The first page now starts with no cursor (inclusive window start), fixing an
  off-by-one that dropped a session created exactly at the window start.

### Verification
- New regression test `test_pagination_does_not_drop_sessions_sharing_boundary_timestamp`:
  501 sessions sharing one `time_created` (one past the page limit) — fails
  before the fix, passes after; asserts no drops and no duplicates.
- New test `test_full_page_with_no_user_messages_keeps_paginating` locks the
  short-page termination contract (red on the old empty-skeleton logic).
- Full `test_usage_export_pairing.py` green (5 passed); `ruff` and `ty` clean.
- Existing integration test `test_usage_reports.py` already exercises 2048
  sessions across 90 days, validating the new keyset path end-to-end.

### Known minor items (not fixed here)
- `query_history.py`: the `initial_id is None` `else` branch is an unreachable
  defensive default in the only call path — harmless, kept for safety.
- `query_history.py:162` gates on `if initial_time:` (truthiness) rather than
  `is not None`; pre-existing and harmless (a set `datetime` is always truthy).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dropped rows in the usage report `chat_messages.csv` when pagination crosses the 500-row boundary by switching to a stable composite cursor, validating it, and correcting the pagination stop condition. Addresses ONX-2293.

- **Bug Fixes**
  - Use a composite `(time_created, id)` keyset cursor and `ORDER BY time_created, id` in `fetch_chat_sessions_eagerly_by_time` to prevent skips on tied timestamps.
  - Require both `initial_time` and `initial_id`; raise if only one is provided to avoid falling back to a time-only cursor.
  - Thread the composite cursor through `get_empty_chat_messages_entries__paginated` and `get_all_empty_chat_message_entries`.
  - Stop paginating on a short page (`len(page) < limit`), not on an empty USER-message batch.
  - Added regression tests: 501 sessions sharing one timestamp (no drops) and a full page with no USER messages (pagination continues).

<sup>Written for commit fc44357172df48a921a9b3116f8601f0bbe068c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

- [x] [Optional] Override Linear Check
