### PR TITLE
fix(craft): open the respective artifact on click in the Artifacts tab

### DIFF
--- a/web/src/app/craft/components/output-panel/ArtifactsTab.tsx
+++ b/web/src/app/craft/components/output-panel/ArtifactsTab.tsx
@@ -25,7 +25,6 @@ import {
 } from "@/app/craft/services/apiServices";
 import { FileSystemEntry } from "@/app/craft/types/streamingTypes";
 import { getFileIcon } from "@/lib/utils";
-import { cn } from "@opal/utils";
 
 interface ArtifactsTabProps {
   artifacts: Artifact[];
@@ -253,9 +252,7 @@ function OutputEntryRow({
   return (
     <>
       <div
-        className={cn(
-          "flex items-center gap-3 p-3 hover:bg-background-tint-01 transition-colors cursor-pointer"
-        )}
+        className="flex items-center gap-3 p-3 hover:bg-background-tint-01 transition-colors cursor-pointer"
         style={{ paddingLeft: 12 + paddingLeft }}
         onClick={
           entry.is_directory

--- a/web/src/app/craft/components/output-panel/ArtifactsTab.tsx
+++ b/web/src/app/craft/components/output-panel/ArtifactsTab.tsx
@@ -14,7 +14,10 @@ import {
 } from "@opal/icons";
 import { Section } from "@/layouts/general-layouts";
 import { Artifact } from "@/app/craft/hooks/useBuildSessionStore";
-import { useFilesNeedsRefresh } from "@/app/craft/hooks/useBuildSessionStore";
+import {
+  useFilesNeedsRefresh,
+  useBuildSessionStore,
+} from "@/app/craft/hooks/useBuildSessionStore";
 import {
   fetchDirectoryListing,
   downloadArtifactFile,
@@ -35,6 +38,24 @@ export default function ArtifactsTab({
 }: ArtifactsTabProps) {
   const webappArtifacts = artifacts.filter(
     (a) => a.type === "nextjs_app" || a.type === "web_app"
+  );
+
+  const setActiveOutputTab = useBuildSessionStore(
+    (state) => state.setActiveOutputTab
+  );
+  const openFilePreview = useBuildSessionStore(
+    (state) => state.openFilePreview
+  );
+
+  const handleWebappOpen = useCallback(() => {
+    if (sessionId) setActiveOutputTab(sessionId, "preview");
+  }, [sessionId, setActiveOutputTab]);
+
+  const handleFileOpen = useCallback(
+    (path: string, fileName: string) => {
+      if (sessionId) openFilePreview(sessionId, path, fileName);
+    },
+    [sessionId, openFilePreview]
   );
 
   const filesNeedsRefresh = useFilesNeedsRefresh();
@@ -144,9 +165,13 @@ export default function ArtifactsTab({
           {webappArtifacts.map((artifact) => (
             <div
               key={artifact.id}
-              className="flex items-center gap-3 p-3 hover:bg-background-tint-01 transition-colors"
+              className="flex items-center gap-3 p-3 hover:bg-background-tint-01 transition-colors cursor-pointer"
+              style={{ paddingLeft: 12 }}
+              onClick={handleWebappOpen}
             >
-              <SvgGlobe size={24} className="stroke-text-02 shrink-0" />
+              <div className="w-4 shrink-0" />
+
+              <SvgGlobe size={20} className="stroke-text-02 shrink-0" />
 
               <div className="flex-1 min-w-0 flex items-center gap-2">
                 <Text font="secondary-body" color="text-04" maxLines={1}>
@@ -162,7 +187,10 @@ export default function ArtifactsTab({
                   variant="action"
                   prominence="tertiary"
                   icon={SvgDownloadCloud}
-                  onClick={handleWebappDownload}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleWebappDownload();
+                  }}
                 >
                   Download
                 </Button>
@@ -178,6 +206,7 @@ export default function ArtifactsTab({
               sessionId={sessionId!}
               depth={0}
               onDownload={handleOutputDownload}
+              onFileOpen={handleFileOpen}
             />
           ))}
         </div>
@@ -191,6 +220,7 @@ interface OutputEntryRowProps {
   sessionId: string;
   depth: number;
   onDownload: (path: string, isDirectory: boolean) => void;
+  onFileOpen: (path: string, fileName: string) => void;
 }
 
 function OutputEntryRow({
@@ -198,6 +228,7 @@ function OutputEntryRow({
   sessionId,
   depth,
   onDownload,
+  onFileOpen,
 }: OutputEntryRowProps) {
   const [expanded, setExpanded] = useState(false);
   const [children, setChildren] = useState<FileSystemEntry[]>([]);
@@ -223,11 +254,14 @@ function OutputEntryRow({
     <>
       <div
         className={cn(
-          "flex items-center gap-3 p-3 hover:bg-background-tint-01 transition-colors",
-          entry.is_directory && "cursor-pointer"
+          "flex items-center gap-3 p-3 hover:bg-background-tint-01 transition-colors cursor-pointer"
         )}
         style={{ paddingLeft: 12 + paddingLeft }}
-        onClick={entry.is_directory ? toggleExpand : undefined}
+        onClick={
+          entry.is_directory
+            ? toggleExpand
+            : () => onFileOpen(entry.path, entry.name)
+        }
       >
         {entry.is_directory ? (
           expanded ? (
@@ -275,6 +309,7 @@ function OutputEntryRow({
             sessionId={sessionId}
             depth={depth + 1}
             onDownload={onDownload}
+            onFileOpen={onFileOpen}
           />
         ))}
     </>


### PR DESCRIPTION
## Description

Clicking an item in the Craft **Artifacts** tab previously did nothing — the rows had hover affordance but no click handlers and were never wired into the output-panel state.

This wires each row into the existing `useBuildSessionStore` actions (the same ones `FilesTab` uses):

- **Web app artifacts** (`nextjs_app` / `web_app`) → `setActiveOutputTab(sessionId, "preview")` switches to the live Preview tab.
- **Output files** (pptx / pdf / image / markdown / etc.) → `openFilePreview(sessionId, path, name)` opens a transient preview tab routed to the correct viewer via `FilePreviewContent`.

It also **unifies row layout** so every artifact type renders identically (shared `w-4` spacer, icon size, and `paddingLeft`) — previously the web app row used a larger globe icon with no spacer, so its icon/name didn't line up with the file rows.

Scope is a single file: `web/src/app/craft/components/output-panel/ArtifactsTab.tsx`.

## How Has This Been Tested?

https://github.com/user-attachments/assets/fdc6b8b3-072c-4265-9534-7555ec5936c2


- Verified end-to-end live in the browser: in a session with `outputs/Presentation.pptx`, clicking the pptx artifact opens the rendered PPTX preview (`sandbox://outputs/Presentation.pptx`); the web app row and file rows are visually aligned.
- Local checks pass: `oxfmt --check`, `oxlint`, `tsgo --noEmit` (and the same via pre-commit hooks on push).
- Multi-agent review (correctness / regressions / tests): no critical or high findings; `OutputEntryRow` is file-private so the new required `onFileOpen` prop has no external callers; Download buttons `stopPropagation` so they don't trigger the row open.
- No automated test added: this is pure UI wiring of already-tested store actions, the analogous `FilesTab` wiring is untested by project convention, and there is no e2e fixture for the craft output panel — so a test here would assert mocks (low signal). Behavior confirmed manually instead.

### Known minor items (for reviewer awareness, not fixed here)
- If a session ever had **multiple** web app artifacts, every web app row opens the same Preview tab. In practice there is exactly one Next.js app per session and the Preview tab shows that single app, so this is moot today.
- `sessionId!` is asserted when passing to `OutputEntryRow`; it's safe (rows only render after a `sessionId`-guarded effect populates entries) but is a mild type smell.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable clicks in the Craft Artifacts tab to open the correct artifact and align row layout for consistency. Web apps now switch to Preview; files open a transient file preview.

- **Bug Fixes**
  - Wired row clicks to `useBuildSessionStore` actions: `setActiveOutputTab("preview")` for web apps, `openFilePreview(path, name)` for files.
  - Stopped Download button clicks from opening the row.
  - Standardized row UI: shared spacer, 20px icons, consistent padding, and pointer cursor.

- **Refactors**
  - Replaced `cn()` with a static class string in `OutputEntryRow` and removed the unused `cn` import.

<sup>Written for commit 126357da431cb5728e1b3cee4a64c9d2909cb2b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

