### PR TITLE
fix(craft): auto-send queued messages on interrupt; fix multi-queue hang

### DIFF
--- a/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
+++ b/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
@@ -827,6 +827,12 @@ def _emit_terminator(
     state.terminator_yielded = True
 
     if error:
+        # An aborted message is a cancellation (the user interrupted), not a
+        # turn failure — emit the normal cancelled terminal so consumers don't
+        # treat an interrupt as an error.
+        if error.get("name") == "MessageAbortedError":
+            yield PromptResponse.model_validate({"stopReason": "cancelled"})
+            return
         msg = ""
         data = error.get("data")
         if isinstance(data, dict):

--- a/backend/onyx/server/features/build/scheduled_tasks/executor.py
+++ b/backend/onyx/server/features/build/scheduled_tasks/executor.py
@@ -381,6 +381,7 @@ def _drive_agent(
         # (terminal Error only) would otherwise be recorded SUCCEEDED (ENG-4234).
         terminal_error: Error | None = None
         got_prompt_response = False
+        cancelled = False
         final_event_count = 0
         # Acquire the per-build_session lock for the duration of the
         # agent loop. __enter__/__exit__ used directly (rather than a
@@ -422,6 +423,11 @@ def _drive_agent(
                 # Break before the budget check: a deadline tripping exactly as
                 # the agent finishes must not mis-mark a success as timed-out.
                 if isinstance(sandbox_event, PromptResponse):
+                    # Scheduled runs have no interrupt mechanism, so a cancelled
+                    # terminal means opencode aborted the agent
+                    # (MessageAbortedError) — record it as a failure, not success.
+                    if getattr(sandbox_event, "stop_reason", None) == "cancelled":
+                        cancelled = True
                     got_prompt_response = True
                     break
 
@@ -480,7 +486,7 @@ def _drive_agent(
                 db_session.commit()
                 return True
 
-            if terminal_error is not None or not got_prompt_response:
+            if terminal_error is not None or cancelled or not got_prompt_response:
                 session_manager.finalize_persist(session_id, state)
                 db_session.commit()
                 if terminal_error is not None:
@@ -492,6 +498,9 @@ def _drive_agent(
                     error_detail = (
                         terminal_error.message or "agent turn ended with an error"
                     )
+                elif cancelled:
+                    error_class = ScheduledTaskErrorClass.AGENT_EXCEPTION
+                    error_detail = "agent turn was aborted before completion"
                 else:
                     error_class = ScheduledTaskErrorClass.AGENT_EXCEPTION
                     error_detail = "agent stream ended without a completion response"

--- a/backend/tests/external_dependency_unit/craft/test_scheduled_task_executor.py
+++ b/backend/tests/external_dependency_unit/craft/test_scheduled_task_executor.py
@@ -409,6 +409,44 @@ def test_prompt_response_marks_run_succeeded(
     assert refreshed.error_class is None
 
 
+def test_cancelled_prompt_response_marks_run_failed(
+    db_session: Session,
+    test_user: User,
+    sandbox: Any,  # noqa: ARG001
+    session_manager_with_stub: SessionManager,  # noqa: ARG001
+    stub_sandbox_manager: StubSandboxManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cancelled terminal (opencode aborted the agent) → FAILED, not SUCCEEDED.
+
+    Scheduled runs have no interrupt mechanism, so a cancelled PromptResponse
+    is an abnormal abort, not a clean completion.
+    """
+    # Bypass skill-payload: encrypted ExternalApp creds break local MIT decryption.
+    monkeypatch.setattr(
+        "onyx.server.features.build.session.manager.build_user_skills_payload",
+        lambda *_: ("", {}),
+    )
+
+    sandbox(user=test_user, status=SandboxStatus.RUNNING)
+    _, run = _seed_task_and_queued_run(db_session, test_user)
+
+    stub_sandbox_manager.health_check_returns = True
+    stub_sandbox_manager.setup_session_workspace_silent = True
+    stub_sandbox_manager.write_files_to_sandbox_silent = True
+    stub_sandbox_manager.send_message_events = [
+        PromptResponse.model_validate({"stopReason": "cancelled"}),
+    ]
+
+    run_scheduled_task_logic(run.id)
+
+    db_session.expire_all()
+    refreshed = db_session.get(ScheduledTaskRun, run.id)
+    assert refreshed is not None
+    assert refreshed.status == ScheduledTaskRunStatus.FAILED
+    assert refreshed.error_class == ScheduledTaskErrorClass.AGENT_EXCEPTION.value
+
+
 def test_transport_error_event_marks_run_failed_with_agent_exception_class(
     db_session: Session,
     test_user: User,

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_translate_opencode_event.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_translate_opencode_event.py
@@ -597,6 +597,32 @@ def test_message_updated_with_error_emits_error_event() -> None:
                         "role": "assistant",
                         "time": {"completed": 1779000000000},
                         "error": {
+                            "name": "UnknownError",
+                            "data": {"message": "Model not found."},
+                        },
+                    }
+                },
+            },
+            s,
+        )
+    )
+    assert len(out) == 1
+    assert isinstance(out[0], Error)
+    assert "Model not found" in out[0].message
+
+
+def test_message_aborted_emits_cancelled_terminal() -> None:
+    s = _state()
+    out = _drain(
+        translate_opencode_event(
+            {
+                "type": "message.updated",
+                "properties": {
+                    "info": {
+                        "sessionID": SESS,
+                        "role": "assistant",
+                        "time": {"completed": 1779000000000},
+                        "error": {
                             "name": "MessageAbortedError",
                             "data": {"message": "Aborted"},
                         },
@@ -607,8 +633,8 @@ def test_message_updated_with_error_emits_error_event() -> None:
         )
     )
     assert len(out) == 1
-    assert isinstance(out[0], Error)
-    assert "Aborted" in out[0].message
+    assert isinstance(out[0], PromptResponse)
+    assert out[0].stop_reason == "cancelled"
 
 
 def test_duplicate_session_error_silenced_after_first() -> None:

--- a/web/src/app/craft/components/ChatPanel.tsx
+++ b/web/src/app/craft/components/ChatPanel.tsx
@@ -9,6 +9,7 @@ import {
   useHasSession,
   useIsRunning,
   useIsInterrupting,
+  useWasInterrupted,
   useOutputPanelOpen,
   useToggleOutputPanel,
   useBuildSessionStore,
@@ -48,7 +49,7 @@ import SubagentView from "@/app/craft/components/SubagentView";
 import SandboxStatusIndicator from "@/app/craft/components/SandboxStatusIndicator";
 import UpgradePlanModal from "@/app/craft/components/UpgradePlanModal";
 import IconButton from "@/refresh-components/buttons/IconButton";
-import { SvgSidebar, SvgChevronDown } from "@opal/icons";
+import { SvgSidebar, SvgChevronDown, SvgStopCircle } from "@opal/icons";
 import { Button as OpalButton, Tooltip } from "@opal/components";
 import { useBuildContext } from "@/app/craft/contexts/BuildContext";
 import useScreenSize from "@/hooks/useScreenSize";
@@ -88,6 +89,7 @@ export default function BuildChatPanel({
   const hasSession = useHasSession();
   const isRunning = useIsRunning();
   const displayIsRunning = isRunning || scheduledRunInFlight;
+  const wasInterrupted = useWasInterrupted();
   const { setLeftSidebarFolded, leftSidebarFolded, videoBackgroundEnabled } =
     useBuildContext();
   const { isMobile } = useScreenSize();
@@ -691,9 +693,17 @@ export default function BuildChatPanel({
                       autoScrollEnabled={isAtBottom}
                       scrollContainerRef={scrollContainerRef}
                       trailingAssistantSlot={
-                        <LiveApprovalsRegion
-                          sessionId={sessionId ?? existingSessionId ?? null}
-                        />
+                        <>
+                          {wasInterrupted && !displayIsRunning && (
+                            <div className="flex items-center gap-2 text-sm text-text-03">
+                              <SvgStopCircle className="size-4 shrink-0 stroke-text-03" />
+                              <span>Response stopped</span>
+                            </div>
+                          )}
+                          <LiveApprovalsRegion
+                            sessionId={sessionId ?? existingSessionId ?? null}
+                          />
+                        </>
                       }
                     />
                   )}

--- a/web/src/app/craft/hooks/useBuildSessionStore.ts
+++ b/web/src/app/craft/hooks/useBuildSessionStore.ts
@@ -591,6 +591,16 @@ export interface BuildSessionData {
    * a fresh turn / aborted fetch).
    */
   isInterrupting: boolean;
+  /**
+   * True from a user interrupt until the next turn starts. Drives the transient
+   * "Response stopped" notice; cleared when a new message is sent.
+   */
+  wasInterrupted: boolean;
+  /**
+   * Bumped per new interactive turn; a pending reconcileInterruptedTurn bails
+   * when it changes, so a stale reconcile can't clobber the superseding turn.
+   */
+  turnGeneration: number;
   error: string | null;
   webappUrl: string | null;
   /** Sandbox info from backend */
@@ -825,6 +835,8 @@ const createInitialSessionData = (
   streamItems: [],
   queuedMessages: [],
   isInterrupting: false,
+  wasInterrupted: false,
+  turnGeneration: 0,
   error: null,
   webappUrl: null,
   sandbox: null,
@@ -2529,6 +2541,13 @@ export const useIsInterrupting = () =>
     const { currentSessionId, sessions } = state;
     if (!currentSessionId) return false;
     return sessions.get(currentSessionId)?.isInterrupting ?? false;
+  });
+
+export const useWasInterrupted = () =>
+  useBuildSessionStore((state) => {
+    const { currentSessionId, sessions } = state;
+    if (!currentSessionId) return false;
+    return sessions.get(currentSessionId)?.wasInterrupted ?? false;
   });
 
 export const useSessionHistory = () =>

--- a/web/src/app/craft/hooks/useBuildStreaming.test.tsx
+++ b/web/src/app/craft/hooks/useBuildStreaming.test.tsx
@@ -1229,6 +1229,43 @@ describe("useBuildStreaming thinking packets", () => {
     );
   });
 
+  it("reloads before flipping to active (avoids the auto-send TOCTOU)", async () => {
+    jest.mocked(interruptMessageStream).mockResolvedValueOnce(undefined);
+    jest.mocked(fetchActiveTurn).mockResolvedValueOnce(null as never);
+    // Capture the session status at the moment loadSession runs. The flip to
+    // "active" triggers the queued auto-send, so the reload must happen while
+    // still "running" — before the flip — or it races the next turn.
+    let statusAtLoad: string | undefined;
+    useBuildSessionStore.setState({
+      loadSession: jest.fn(async () => {
+        statusAtLoad = useBuildSessionStore
+          .getState()
+          .sessions.get(sessionId)?.status;
+      }),
+    } as never);
+    useBuildSessionStore.getState().updateSessionData(sessionId, {
+      status: "running",
+      activeTurnId: "turn-interrupted",
+      activeTurnIndex: 3,
+      activeTurnLocalOwner: true,
+      isInterrupting: false,
+    });
+    const { result } = renderHook(() => useBuildStreaming());
+
+    await act(async () => {
+      await result.current.interruptStreaming(sessionId);
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+      await Promise.resolve();
+    });
+
+    expect(statusAtLoad).toBe("running");
+    expect(
+      useBuildSessionStore.getState().sessions.get(sessionId)?.status
+    ).toBe("active");
+  });
+
   it("bails a stale reconcile once a newer turn supersedes the interrupt", async () => {
     jest.mocked(interruptMessageStream).mockResolvedValueOnce(undefined);
     useBuildSessionStore.getState().updateSessionData(sessionId, {

--- a/web/src/app/craft/hooks/useBuildStreaming.test.tsx
+++ b/web/src/app/craft/hooks/useBuildStreaming.test.tsx
@@ -112,6 +112,28 @@ describe("useBuildStreaming thinking packets", () => {
     });
   });
 
+  it("does not reset the abort controller when a newer turn took ownership mid-stream", async () => {
+    const newerController = new AbortController();
+    jest.mocked(processSSEStream).mockImplementationOnce(async () => {
+      // Simulate a queued message auto-sending mid-stream: the newer turn
+      // installs its own controller while this one is still settling.
+      useBuildSessionStore
+        .getState()
+        .setAbortController(sessionId, newerController);
+    });
+    const { result } = renderHook(() => useBuildStreaming());
+
+    await act(async () => {
+      await result.current.streamMessage(sessionId, "hello");
+    });
+
+    // The completed turn's finally must not clobber the newer turn's controller,
+    // or the newer turn's streamTurnEvents trips the duplicate-watcher guard.
+    expect(
+      useBuildSessionStore.getState().sessions.get(sessionId)?.abortController
+    ).toBe(newerController);
+  });
+
   it("seeds clickable subagent metadata from a task start packet", async () => {
     jest
       .mocked(processSSEStream)
@@ -683,6 +705,38 @@ describe("useBuildStreaming thinking packets", () => {
     ]);
   });
 
+  it("defers to reconcile when an error packet arrives mid-interrupt", async () => {
+    jest
+      .mocked(processSSEStream)
+      .mockImplementationOnce(async (_response, onPacket) => {
+        onPacket({ type: "error", message: "Aborted" } as never);
+      });
+    useBuildSessionStore.getState().updateSessionData(sessionId, {
+      status: "running",
+      activeTurnId: "turn-interrupted",
+      activeTurnLocalOwner: false,
+      isInterrupting: true,
+    });
+    const { result } = renderHook(() => useBuildStreaming());
+
+    await act(async () => {
+      await result.current.streamTurnEvents(
+        sessionId,
+        "turn-interrupted",
+        new AbortController().signal
+      );
+    });
+
+    // An error mid-interrupt (opencode's abort surfaces as one) must not mark the
+    // session failed — that strands the queued auto-send. Settlement defers to
+    // reconcile, so status/error/streamItems are left untouched.
+    const session = useBuildSessionStore.getState().sessions.get(sessionId);
+    expect(session?.status).toBe("running");
+    expect(session?.error).toBeNull();
+    expect(session?.isInterrupting).toBe(true);
+    expect(session?.streamItems).toEqual([]);
+  });
+
   it("clears stale turn metadata when the backend says the turn is not running", async () => {
     jest.mocked(fetchTurnEventStream).mockResolvedValueOnce(null);
     const { result } = renderHook(() => useBuildStreaming());
@@ -707,7 +761,7 @@ describe("useBuildStreaming thinking packets", () => {
     );
   });
 
-  it("clears interrupt state when an attached stream settles", async () => {
+  it("defers settlement to reconcile when a stream settles mid-interrupt", async () => {
     jest.mocked(processSSEStream).mockResolvedValueOnce(undefined);
     useBuildSessionStore.getState().updateSessionData(sessionId, {
       status: "running",
@@ -725,17 +779,14 @@ describe("useBuildStreaming thinking packets", () => {
       );
     });
 
+    // Settlement is deferred to reconcile, so the stream end leaves state untouched.
     const session = useBuildSessionStore.getState().sessions.get(sessionId);
     expect(session).toMatchObject({
-      status: "active",
-      activeTurnId: null,
-      activeTurnLocalOwner: false,
-      isInterrupting: false,
+      status: "running",
+      activeTurnId: "turn-interrupted-settled",
+      isInterrupting: true,
     });
-    expect(useBuildSessionStore.getState().loadSession).toHaveBeenCalledWith(
-      sessionId,
-      { force: true }
-    );
+    expect(useBuildSessionStore.getState().loadSession).not.toHaveBeenCalled();
   });
 
   it("skips duplicate watchers for a locally owned turn", async () => {
@@ -956,7 +1007,53 @@ describe("useBuildStreaming thinking packets", () => {
 
     expect(interruptMessageStream).toHaveBeenCalledWith(sessionId);
     expect(session?.isInterrupting).toBe(true);
+    expect(session?.wasInterrupted).toBe(true);
     expect(toolStatuses).toEqual(["completed", "cancelled"]);
+  });
+
+  it("sets wasInterrupted on interrupt and clears it on the next turn", async () => {
+    useBuildSessionStore.getState().updateSessionData(sessionId, {
+      status: "running",
+      activeTurnId: "turn-x",
+      activeTurnLocalOwner: true,
+    });
+    const { result } = renderHook(() => useBuildStreaming());
+
+    await act(async () => {
+      await result.current.interruptStreaming(sessionId);
+    });
+    expect(
+      useBuildSessionStore.getState().sessions.get(sessionId)?.wasInterrupted
+    ).toBe(true);
+
+    await act(async () => {
+      await result.current.streamMessage(sessionId, "next");
+    });
+    expect(
+      useBuildSessionStore.getState().sessions.get(sessionId)?.wasInterrupted
+    ).toBe(false);
+  });
+
+  it("clears wasInterrupted when the interrupt request fails", async () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    jest
+      .mocked(interruptMessageStream)
+      .mockRejectedValueOnce(new Error("network down"));
+    useBuildSessionStore.getState().updateSessionData(sessionId, {
+      status: "running",
+      activeTurnId: "turn-x",
+      activeTurnLocalOwner: true,
+    });
+    const { result } = renderHook(() => useBuildStreaming());
+
+    await act(async () => {
+      await result.current.interruptStreaming(sessionId);
+    });
+
+    const session = useBuildSessionStore.getState().sessions.get(sessionId);
+    expect(session?.isInterrupting).toBe(false);
+    expect(session?.wasInterrupted).toBe(false);
+    errorSpy.mockRestore();
   });
 
   it("persists an interrupted in-flight tool call as cancelled on prompt_response", async () => {
@@ -1008,7 +1105,8 @@ describe("useBuildStreaming thinking packets", () => {
       | undefined;
 
     expect(session?.streamItems).toEqual([]);
-    expect(session?.isInterrupting).toBe(false);
+    // Settlement is deferred to reconcile, so isInterrupting stays set here.
+    expect(session?.isInterrupting).toBe(true);
     expect(metadata?.streamItems).toEqual([
       expect.objectContaining({
         type: "tool_call",
@@ -1129,6 +1227,47 @@ describe("useBuildStreaming thinking packets", () => {
       sessionId,
       { force: true }
     );
+  });
+
+  it("bails a stale reconcile once a newer turn supersedes the interrupt", async () => {
+    jest.mocked(interruptMessageStream).mockResolvedValueOnce(undefined);
+    useBuildSessionStore.getState().updateSessionData(sessionId, {
+      status: "running",
+      activeTurnId: "turn-interrupted",
+      activeTurnIndex: 3,
+      activeTurnLocalOwner: true,
+      isInterrupting: false,
+      turnGeneration: 5,
+    });
+    const { result } = renderHook(() => useBuildStreaming());
+
+    await act(async () => {
+      await result.current.interruptStreaming(sessionId);
+    });
+
+    // A queued message auto-sends: a new turn starts and bumps turnGeneration.
+    useBuildSessionStore.getState().updateSessionData(sessionId, {
+      status: "running",
+      activeTurnId: "turn-next",
+      activeTurnLocalOwner: true,
+      isInterrupting: false,
+      turnGeneration: 6,
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+      await Promise.resolve();
+    });
+
+    // The stale reconcile must not poll or settle — the live turn is untouched.
+    expect(fetchActiveTurn).not.toHaveBeenCalled();
+    expect(useBuildSessionStore.getState().loadSession).not.toHaveBeenCalled();
+    expect(
+      useBuildSessionStore.getState().sessions.get(sessionId)
+    ).toMatchObject({
+      status: "running",
+      activeTurnId: "turn-next",
+    });
   });
 
   it("does not clear local interrupt state while the backend turn is still active", async () => {

--- a/web/src/app/craft/hooks/useBuildStreaming.test.tsx
+++ b/web/src/app/craft/hooks/useBuildStreaming.test.tsx
@@ -1310,7 +1310,7 @@ describe("useBuildStreaming thinking packets", () => {
     });
   });
 
-  it("clears only interrupt state when interrupted turn reconciliation times out", async () => {
+  it("clears only interrupt state when a timed-out turn is still running", async () => {
     const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
     jest.mocked(interruptMessageStream).mockResolvedValueOnce(undefined);
     const activeTurn = {
@@ -1319,7 +1319,9 @@ describe("useBuildStreaming thinking packets", () => {
       status: "RUNNING",
       turn_index: 3,
     } as never;
-    for (let attempt = 0; attempt < 30; attempt++) {
+    // 30 poll attempts + 1 final post-timeout check, all reporting the turn
+    // still running.
+    for (let attempt = 0; attempt < 31; attempt++) {
       jest.mocked(fetchActiveTurn).mockResolvedValueOnce(activeTurn);
     }
     useBuildSessionStore.getState().updateSessionData(sessionId, {
@@ -1341,7 +1343,7 @@ describe("useBuildStreaming thinking packets", () => {
       });
     }
 
-    expect(fetchActiveTurn).toHaveBeenCalledTimes(30);
+    expect(fetchActiveTurn).toHaveBeenCalledTimes(31);
     expect(
       useBuildSessionStore.getState().sessions.get(sessionId)
     ).toMatchObject({
@@ -1353,6 +1355,55 @@ describe("useBuildStreaming thinking packets", () => {
     expect(useBuildSessionStore.getState().loadSession).not.toHaveBeenCalled();
     expect(warnSpy).toHaveBeenCalledWith(
       "[Streaming] Interrupted turn reconciliation timed out"
+    );
+    warnSpy.mockRestore();
+  });
+
+  it("settles a timed-out turn that the backend reports as gone", async () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    jest.mocked(interruptMessageStream).mockResolvedValueOnce(undefined);
+    const activeTurn = {
+      session_id: sessionId,
+      turn_id: "turn-interrupted",
+      status: "RUNNING",
+      turn_index: 3,
+    } as never;
+    // 30 poll attempts report the turn still running, but the final
+    // post-timeout check finds it gone → settle so the UI unblocks.
+    for (let attempt = 0; attempt < 30; attempt++) {
+      jest.mocked(fetchActiveTurn).mockResolvedValueOnce(activeTurn);
+    }
+    jest.mocked(fetchActiveTurn).mockResolvedValueOnce(null as never);
+    useBuildSessionStore.getState().updateSessionData(sessionId, {
+      status: "running",
+      activeTurnId: "turn-interrupted",
+      activeTurnIndex: 3,
+      activeTurnLocalOwner: true,
+      isInterrupting: false,
+    });
+    const { result } = renderHook(() => useBuildStreaming());
+
+    await act(async () => {
+      await result.current.interruptStreaming(sessionId);
+    });
+    for (let attempt = 0; attempt < 31; attempt++) {
+      await act(async () => {
+        jest.advanceTimersByTime(1000);
+        await Promise.resolve();
+      });
+    }
+
+    expect(
+      useBuildSessionStore.getState().sessions.get(sessionId)
+    ).toMatchObject({
+      status: "active",
+      activeTurnId: null,
+      activeTurnLocalOwner: false,
+      isInterrupting: false,
+    });
+    expect(useBuildSessionStore.getState().loadSession).toHaveBeenCalledWith(
+      sessionId,
+      { force: true }
     );
     warnSpy.mockRestore();
   });

--- a/web/src/app/craft/hooks/useBuildStreaming.ts
+++ b/web/src/app/craft/hooks/useBuildStreaming.ts
@@ -151,28 +151,32 @@ export function useBuildStreaming() {
       interruptedTurnId: string | null,
       generation: number
     ): Promise<void> => {
-      // A newer turn (e.g. a queued message that auto-sent) bumps turnGeneration;
-      // once stale, this reconcile must not settle/reload or it clobbers that turn.
-      const isSuperseded = (): boolean => {
-        const session = useBuildSessionStore.getState().sessions.get(sessionId);
-        return !session || session.turnGeneration !== generation;
+      // May we still act on this interrupt? Only while it's the same turn we
+      // launched for: the generation a queued auto-send would bump is unchanged,
+      // the session is still running, and the backend hasn't moved to a
+      // different turn. Once false, acting would clobber whatever turn is now
+      // live. Pass the turn id to also require it match, or null to skip that.
+      const ownsInterrupt = (turnId: string | null): boolean => {
+        const s = useBuildSessionStore.getState().sessions.get(sessionId);
+        return (
+          !!s &&
+          s.turnGeneration === generation &&
+          s.status === "running" &&
+          (turnId === null || !s.activeTurnId || s.activeTurnId === turnId)
+        );
       };
 
-      // Reload before flipping to "active": the flip triggers the queued
-      // auto-send, so reloading after would race the freshly-started next turn.
-      const settleToActive = async (): Promise<void> => {
+      // Settle the interrupted turn to "active". Reload BEFORE the flip: the
+      // flip triggers the queued auto-send, so reloading after would race the
+      // freshly-started next turn.
+      const settle = async (): Promise<void> => {
         await useBuildSessionStore
           .getState()
           .loadSession(sessionId, { force: true })
           .catch((err) =>
-            console.warn(
-              "[Streaming] Failed to reload reconciled interrupted turn:",
-              err
-            )
+            console.warn("[Streaming] Failed to reload settled turn:", err)
           );
-        if (isSuperseded()) {
-          return;
-        }
+        if (!ownsInterrupt(null)) return;
         updateSessionData(sessionId, {
           status: "active",
           isInterrupting: false,
@@ -182,29 +186,13 @@ export function useBuildStreaming() {
         });
       };
 
-      let reconciledTurnId = interruptedTurnId;
-      for (
-        let attempt = 0;
-        attempt < INTERRUPT_RECONCILE_MAX_ATTEMPTS;
-        attempt++
-      ) {
+      // Poll until the interrupted turn disappears from the backend.
+      let turnId = interruptedTurnId;
+      for (let i = 0; i < INTERRUPT_RECONCILE_MAX_ATTEMPTS; i++) {
         await sleep(INTERRUPT_RECONCILE_INTERVAL_MS);
+        if (!ownsInterrupt(turnId)) return;
 
-        const currentSession = useBuildSessionStore
-          .getState()
-          .sessions.get(sessionId);
-        if (
-          !currentSession ||
-          currentSession.turnGeneration !== generation ||
-          currentSession.status !== "running" ||
-          (reconciledTurnId &&
-            currentSession.activeTurnId &&
-            currentSession.activeTurnId !== reconciledTurnId)
-        ) {
-          return;
-        }
-
-        let activeTurn: Awaited<ReturnType<typeof fetchActiveTurn>> = null;
+        let activeTurn: Awaited<ReturnType<typeof fetchActiveTurn>>;
         try {
           activeTurn = await fetchActiveTurn(sessionId);
         } catch (err) {
@@ -215,52 +203,27 @@ export function useBuildStreaming() {
           continue;
         }
 
-        if (activeTurn) {
-          if (reconciledTurnId === null) {
-            reconciledTurnId = activeTurn.turn_id;
-            continue;
-          }
-          if (activeTurn.turn_id === reconciledTurnId) {
-            continue;
-          }
+        if (!activeTurn) {
+          await settle();
           return;
         }
-
-        if (isSuperseded()) {
-          return;
-        }
-        await settleToActive();
-        return;
+        // Learn the id if the interrupt beat the local activeTurnId; bail if the
+        // backend has moved on to a different turn.
+        if (turnId === null) turnId = activeTurn.turn_id;
+        else if (activeTurn.turn_id !== turnId) return;
       }
 
-      // On timeout, a final check: if the backend turn is actually gone, settle
-      // so the UI doesn't stay stuck on a stale "running"; otherwise leave it.
-      if (
-        isSuperseded() ||
-        useBuildSessionStore.getState().sessions.get(sessionId)?.status !==
-          "running"
-      ) {
-        return;
-      }
-
-      let finalActiveTurn: Awaited<ReturnType<typeof fetchActiveTurn>> = null;
-      let finalFetchSucceeded = true;
-      try {
-        finalActiveTurn = await fetchActiveTurn(sessionId);
-      } catch (err) {
-        finalFetchSucceeded = false;
-        console.warn("[Streaming] Final reconcile check failed:", err);
-      }
-      if (isSuperseded()) {
-        return;
-      }
-
+      // Timed out. One last check: settle if the turn is actually gone now (so
+      // the UI unblocks), otherwise it's genuinely still running — just drop the
+      // "stopping…" affordance and leave it running.
       console.warn("[Streaming] Interrupted turn reconciliation timed out");
-      if (finalFetchSucceeded && finalActiveTurn === null) {
-        await settleToActive();
-      } else {
-        updateSessionData(sessionId, { isInterrupting: false });
-      }
+      if (!ownsInterrupt(turnId)) return;
+      const turnGone = await fetchActiveTurn(sessionId)
+        .then((t) => t === null)
+        .catch(() => false);
+      if (!ownsInterrupt(turnId)) return;
+      if (turnGone) await settle();
+      else updateSessionData(sessionId, { isInterrupting: false });
     },
     [updateSessionData]
   );

--- a/web/src/app/craft/hooks/useBuildStreaming.ts
+++ b/web/src/app/craft/hooks/useBuildStreaming.ts
@@ -158,11 +158,8 @@ export function useBuildStreaming() {
         return !session || session.turnGeneration !== generation;
       };
 
-      // Reload backend state (artifacts, sandbox, ...) while the session is
-      // still "running" — loadSession preserves the live turn in that state —
-      // and only then flip to the terminal status. Reloading before the flip
-      // avoids a TOCTOU: the flip to "active" triggers the queued auto-send, so
-      // a reload after it would race the freshly-started next turn.
+      // Reload before flipping to "active": the flip triggers the queued
+      // auto-send, so reloading after would race the freshly-started next turn.
       const settleToActive = async (): Promise<void> => {
         await useBuildSessionStore
           .getState()
@@ -236,11 +233,8 @@ export function useBuildStreaming() {
         return;
       }
 
-      // Timed out: the interrupt didn't visibly settle within the budget. Do one
-      // final check — if the backend turn is actually gone, settle so the UI
-      // unblocks and any queued message can send (rather than leaving the
-      // session stuck on a stale "running"). If it's still running (or the check
-      // fails), just drop the "stopping" affordance and leave it running.
+      // On timeout, a final check: if the backend turn is actually gone, settle
+      // so the UI doesn't stay stuck on a stale "running"; otherwise leave it.
       if (
         isSuperseded() ||
         useBuildSessionStore.getState().sessions.get(sessionId)?.status !==

--- a/web/src/app/craft/hooks/useBuildStreaming.ts
+++ b/web/src/app/craft/hooks/useBuildStreaming.ts
@@ -158,6 +158,33 @@ export function useBuildStreaming() {
         return !session || session.turnGeneration !== generation;
       };
 
+      // Reload backend state (artifacts, sandbox, ...) while the session is
+      // still "running" — loadSession preserves the live turn in that state —
+      // and only then flip to the terminal status. Reloading before the flip
+      // avoids a TOCTOU: the flip to "active" triggers the queued auto-send, so
+      // a reload after it would race the freshly-started next turn.
+      const settleToActive = async (): Promise<void> => {
+        await useBuildSessionStore
+          .getState()
+          .loadSession(sessionId, { force: true })
+          .catch((err) =>
+            console.warn(
+              "[Streaming] Failed to reload reconciled interrupted turn:",
+              err
+            )
+          );
+        if (isSuperseded()) {
+          return;
+        }
+        updateSessionData(sessionId, {
+          status: "active",
+          isInterrupting: false,
+          activeTurnId: null,
+          activeTurnIndex: null,
+          activeTurnLocalOwner: false,
+        });
+      };
+
       let reconciledTurnId = interruptedTurnId;
       for (
         let attempt = 0;
@@ -202,46 +229,44 @@ export function useBuildStreaming() {
           return;
         }
 
-        // Re-check after the await — a newer turn may have started meanwhile.
         if (isSuperseded()) {
           return;
         }
-
-        updateSessionData(sessionId, {
-          status: "active",
-          isInterrupting: false,
-          activeTurnId: null,
-          activeTurnIndex: null,
-          activeTurnLocalOwner: false,
-        });
-        await useBuildSessionStore
-          .getState()
-          .loadSession(sessionId, { force: true })
-          .catch((err) =>
-            console.warn(
-              "[Streaming] Failed to reload reconciled interrupted turn:",
-              err
-            )
-          );
+        await settleToActive();
         return;
       }
 
-      const currentSession = useBuildSessionStore
-        .getState()
-        .sessions.get(sessionId);
+      // Timed out: the interrupt didn't visibly settle within the budget. Do one
+      // final check — if the backend turn is actually gone, settle so the UI
+      // unblocks and any queued message can send (rather than leaving the
+      // session stuck on a stale "running"). If it's still running (or the check
+      // fails), just drop the "stopping" affordance and leave it running.
       if (
-        !currentSession ||
-        currentSession.turnGeneration !== generation ||
-        currentSession.status !== "running" ||
-        (reconciledTurnId &&
-          currentSession.activeTurnId &&
-          currentSession.activeTurnId !== reconciledTurnId)
+        isSuperseded() ||
+        useBuildSessionStore.getState().sessions.get(sessionId)?.status !==
+          "running"
       ) {
         return;
       }
 
+      let finalActiveTurn: Awaited<ReturnType<typeof fetchActiveTurn>> = null;
+      let finalFetchSucceeded = true;
+      try {
+        finalActiveTurn = await fetchActiveTurn(sessionId);
+      } catch (err) {
+        finalFetchSucceeded = false;
+        console.warn("[Streaming] Final reconcile check failed:", err);
+      }
+      if (isSuperseded()) {
+        return;
+      }
+
       console.warn("[Streaming] Interrupted turn reconciliation timed out");
-      updateSessionData(sessionId, { isInterrupting: false });
+      if (finalFetchSucceeded && finalActiveTurn === null) {
+        await settleToActive();
+      } else {
+        updateSessionData(sessionId, { isInterrupting: false });
+      }
     },
     [updateSessionData]
   );

--- a/web/src/app/craft/hooks/useBuildStreaming.ts
+++ b/web/src/app/craft/hooks/useBuildStreaming.ts
@@ -148,8 +148,16 @@ export function useBuildStreaming() {
   const reconcileInterruptedTurn = useCallback(
     async (
       sessionId: string,
-      interruptedTurnId: string | null
+      interruptedTurnId: string | null,
+      generation: number
     ): Promise<void> => {
+      // A newer turn (e.g. a queued message that auto-sent) bumps turnGeneration;
+      // once stale, this reconcile must not settle/reload or it clobbers that turn.
+      const isSuperseded = (): boolean => {
+        const session = useBuildSessionStore.getState().sessions.get(sessionId);
+        return !session || session.turnGeneration !== generation;
+      };
+
       let reconciledTurnId = interruptedTurnId;
       for (
         let attempt = 0;
@@ -163,6 +171,7 @@ export function useBuildStreaming() {
           .sessions.get(sessionId);
         if (
           !currentSession ||
+          currentSession.turnGeneration !== generation ||
           currentSession.status !== "running" ||
           (reconciledTurnId &&
             currentSession.activeTurnId &&
@@ -193,6 +202,11 @@ export function useBuildStreaming() {
           return;
         }
 
+        // Re-check after the await — a newer turn may have started meanwhile.
+        if (isSuperseded()) {
+          return;
+        }
+
         updateSessionData(sessionId, {
           status: "active",
           isInterrupting: false,
@@ -216,7 +230,9 @@ export function useBuildStreaming() {
         .getState()
         .sessions.get(sessionId);
       if (
-        currentSession?.status !== "running" ||
+        !currentSession ||
+        currentSession.turnGeneration !== generation ||
+        currentSession.status !== "running" ||
         (reconciledTurnId &&
           currentSession.activeTurnId &&
           currentSession.activeTurnId !== reconciledTurnId)
@@ -683,10 +699,10 @@ export function useBuildStreaming() {
 
           case "prompt_response": {
             finalizeStreaming();
-            if (
-              useBuildSessionStore.getState().sessions.get(sessionId)
-                ?.isInterrupting
-            ) {
+            const isInterrupting = useBuildSessionStore
+              .getState()
+              .sessions.get(sessionId)?.isInterrupting;
+            if (isInterrupting) {
               cancelLatestInFlightToolCallStreamItem(sessionId);
             }
 
@@ -718,14 +734,20 @@ export function useBuildStreaming() {
               });
             }
 
-            updateSessionData(sessionId, {
-              status: "active",
-              streamItems: [],
-              isInterrupting: false,
-              activeTurnId: null,
-              activeTurnIndex: null,
-              activeTurnLocalOwner: false,
-            });
+            if (isInterrupting) {
+              // While interrupting, defer settlement to reconcile (settling now races the
+              // in-flight cancel → "Concurrent turn in flight"); just clear persisted streamItems.
+              updateSessionData(sessionId, { streamItems: [] });
+            } else {
+              updateSessionData(sessionId, {
+                status: "active",
+                streamItems: [],
+                isInterrupting: false,
+                activeTurnId: null,
+                activeTurnIndex: null,
+                activeTurnLocalOwner: false,
+              });
+            }
             options?.onPromptResponse?.();
             break;
           }
@@ -736,6 +758,14 @@ export function useBuildStreaming() {
           }
 
           case "error": {
+            // Safety net for an error arriving mid-interrupt: defer to reconcile rather than
+            // marking failed, which strands the queued auto-send and stalls reconcile.
+            if (
+              useBuildSessionStore.getState().sessions.get(sessionId)
+                ?.isInterrupting
+            ) {
+              break;
+            }
             appendErrorItem(parsed.message);
             updateSessionData(sessionId, {
               status: "failed",
@@ -873,26 +903,32 @@ export function useBuildStreaming() {
           const currentSession = useBuildSessionStore
             .getState()
             .sessions.get(sessionId);
-          if (
-            !transportError &&
-            currentSession?.status === "running" &&
-            currentSession?.activeTurnId === turnId
-          ) {
-            clearTurnIfCurrent({
-              status: "active",
-              isInterrupting: false,
-            });
-          }
-          const settledStatus = useBuildSessionStore
-            .getState()
-            .sessions.get(sessionId)?.status;
-          if (settledStatus !== "failed") {
-            await useBuildSessionStore
+          // While interrupting, reconcileInterruptedTurn owns settlement; settling here races it and strands the queued auto-send.
+          if (!currentSession?.isInterrupting) {
+            if (
+              !transportError &&
+              currentSession?.status === "running" &&
+              currentSession?.activeTurnId === turnId
+            ) {
+              clearTurnIfCurrent({
+                status: "active",
+                isInterrupting: false,
+              });
+            }
+            const settledStatus = useBuildSessionStore
               .getState()
-              .loadSession(sessionId, { force: true })
-              .catch((err) =>
-                console.warn("[Streaming] Failed to reload settled turn:", err)
-              );
+              .sessions.get(sessionId)?.status;
+            if (settledStatus !== "failed") {
+              await useBuildSessionStore
+                .getState()
+                .loadSession(sessionId, { force: true })
+                .catch((err) =>
+                  console.warn(
+                    "[Streaming] Failed to reload settled turn:",
+                    err
+                  )
+                );
+            }
           }
           if (!settledFromPromptResponse) {
             onSettled?.();
@@ -926,6 +962,8 @@ export function useBuildStreaming() {
       updateSessionData(sessionId, {
         status: "running",
         isInterrupting: false,
+        wasInterrupted: false,
+        turnGeneration: (existingSession?.turnGeneration ?? 0) + 1,
         activeTurnId: null,
         activeTurnIndex: null,
         activeTurnLocalOwner: true,
@@ -972,7 +1010,13 @@ export function useBuildStreaming() {
           });
         }
       } finally {
-        setAbortController(sessionId, new AbortController());
+        // Only reset if this turn still owns the controller; clobbering a newer
+        // turn's controller trips its streamTurnEvents duplicate-watcher guard
+        // (signal mismatch) and hangs the FE while the backend completes.
+        const session = useBuildSessionStore.getState().sessions.get(sessionId);
+        if (session?.abortController === controller) {
+          setAbortController(sessionId, new AbortController());
+        }
       }
     },
     [setAbortController, updateSessionData, clearStreamItems, streamTurnEvents]
@@ -990,14 +1034,21 @@ export function useBuildStreaming() {
       }
 
       const interruptedTurnId = session.activeTurnId;
-      updateSessionData(sessionId, { isInterrupting: true });
+      const generation = session.turnGeneration;
+      updateSessionData(sessionId, {
+        isInterrupting: true,
+        wasInterrupted: true,
+      });
       cancelLatestInFlightToolCallStreamItem(sessionId);
       try {
         await interruptMessageStream(sessionId);
-        void reconcileInterruptedTurn(sessionId, interruptedTurnId);
+        void reconcileInterruptedTurn(sessionId, interruptedTurnId, generation);
       } catch (err) {
         console.error("[Streaming] Failed to interrupt:", err);
-        updateSessionData(sessionId, { isInterrupting: false });
+        updateSessionData(sessionId, {
+          isInterrupting: false,
+          wasInterrupted: false,
+        });
       }
     },
     [

--- a/web/src/app/craft/hooks/useBuildStreaming.ts
+++ b/web/src/app/craft/hooks/useBuildStreaming.ts
@@ -151,11 +151,8 @@ export function useBuildStreaming() {
       interruptedTurnId: string | null,
       generation: number
     ): Promise<void> => {
-      // May we still act on this interrupt? Only while it's the same turn we
-      // launched for: the generation a queued auto-send would bump is unchanged,
-      // the session is still running, and the backend hasn't moved to a
-      // different turn. Once false, acting would clobber whatever turn is now
-      // live. Pass the turn id to also require it match, or null to skip that.
+      // Only act while this is still the interrupt we launched for; otherwise a
+      // newer turn (a queued auto-send bumps the generation) would be clobbered.
       const ownsInterrupt = (turnId: string | null): boolean => {
         const s = useBuildSessionStore.getState().sessions.get(sessionId);
         return (
@@ -166,9 +163,8 @@ export function useBuildStreaming() {
         );
       };
 
-      // Settle the interrupted turn to "active". Reload BEFORE the flip: the
-      // flip triggers the queued auto-send, so reloading after would race the
-      // freshly-started next turn.
+      // Reload BEFORE the flip to "active": the flip triggers the queued
+      // auto-send, so reloading after would race the freshly-started next turn.
       const settle = async (): Promise<void> => {
         await useBuildSessionStore
           .getState()
@@ -186,7 +182,6 @@ export function useBuildStreaming() {
         });
       };
 
-      // Poll until the interrupted turn disappears from the backend.
       let turnId = interruptedTurnId;
       for (let i = 0; i < INTERRUPT_RECONCILE_MAX_ATTEMPTS; i++) {
         await sleep(INTERRUPT_RECONCILE_INTERVAL_MS);
@@ -207,15 +202,14 @@ export function useBuildStreaming() {
           await settle();
           return;
         }
-        // Learn the id if the interrupt beat the local activeTurnId; bail if the
-        // backend has moved on to a different turn.
+        // turnId is null when the interrupt beat the local activeTurnId — adopt
+        // the backend's; a different id means the backend moved on, so bail.
         if (turnId === null) turnId = activeTurn.turn_id;
         else if (activeTurn.turn_id !== turnId) return;
       }
 
-      // Timed out. One last check: settle if the turn is actually gone now (so
-      // the UI unblocks), otherwise it's genuinely still running — just drop the
-      // "stopping…" affordance and leave it running.
+      // Timed out: settle if the turn is actually gone now (unblock the UI),
+      // otherwise it's genuinely still running — just clear the "stopping" state.
       console.warn("[Streaming] Interrupted turn reconciliation timed out");
       if (!ownsInterrupt(turnId)) return;
       const turnGone = await fetchActiveTurn(sessionId)

--- a/web/src/hooks/useChatController.ts
+++ b/web/src/hooks/useChatController.ts
@@ -363,6 +363,8 @@ export default function useChatController({
     // The stream will close naturally when the backend sends the STOP packet
     setStreamingStartTime(currentSession, null);
     updateChatStateAction(currentSession, "input");
+    // On stop nothing else flips the queue gate, so release it here or queued follow-ups never auto-send.
+    setLatestMessageRenderComplete(currentSession, true);
   }, [currentMessageHistory, currentMessageTree]);
 
   const onSubmit = useCallback(


### PR DESCRIPTION
## Description

Fixes several bugs in Onyx Craft's queued-message auto-send around **interrupting a turn**. Previously, interrupting an agent turn (with messages queued) often stranded the queue, surfaced a spurious red "Aborted" error, or — with multiple queued messages — left a turn hung on the FE while the backend completed it.

_Rebased on latest `main`._

**Backend**
- `_emit_terminator` (`serve_client.py`): opencode reports an interrupt as `MessageAbortedError`, which was translated to a generic `Error("Aborted")` — marking the turn failed. An abort is a *cancellation*, not a failure, so it's now translated to `PromptResponse(stopReason="cancelled")` (the same clean terminal the interactive executor already emits). The interactive executor already maps `cancelled` → `TURN_STATUS_CANCELLED`.
- Scheduled-tasks executor (`scheduled_tasks/executor.py`): scheduled runs have no interrupt mechanism, so a `cancelled` terminal means opencode aborted the agent internally. The executor previously treated any `PromptResponse` as a clean completion → SUCCEEDED, masking the abort. It now records FAILED with `error_class=agent_exception` (the documented bucket for agent-drive failures).

**Frontend (Craft)**
- On interrupt, the terminal packet handlers (`prompt_response`, `error`) and the stream `finally` now **defer settlement to `reconcileInterruptedTurn`** while `isInterrupting`. Settling prematurely either marked the session failed (stranding the queued auto-send) or raced the in-flight cancel (`createTurn` → "Concurrent turn in flight").
- **Multi-queue hang:** `streamMessage`'s `finally` reset the abort controller unconditionally, clobbering a *newer* turn's controller during the auto-send chain — the new turn's `streamTurnEvents` then tripped its duplicate-watcher guard and hung on the FE (BE still completed). It now only resets if this turn still owns the controller.
- Added a per-session `turnGeneration`; a stale `reconcileInterruptedTurn` bails once a newer turn supersedes it (prevents it clobbering the next turn under rapid interrupts).
- `reconcileInterruptedTurn` now reloads backend state **before** flipping to `active` (the flip triggers the queued auto-send, so reloading after raced the freshly-started next turn).
- `reconcileInterruptedTurn` **timeout recovery**: on timeout it does a final `activeTurn` check — if the backend turn is actually gone it settles (UI unblocks, queue can send) instead of leaving the session stuck on a stale "running"; if still running it leaves it running.
- Added a transient **"Response stopped"** indicator (neutral, not a red error), cleared when the next message is sent.

**Standard chat**
- `useChatController.stopGenerating` now releases the queue gate (`setLatestMessageRenderComplete(true)`) so a queued follow-up auto-sends on stop. (A stop with no queued message does nothing.)

## How Has This Been Tested?

- **Unit/component tests:** 113 Craft frontend tests + 87 backend `test_translate_opencode_event` tests + scheduled-task executor tests pass. Added regression tests for: abort → cancelled terminal; controller-ownership (newer turn keeps its controller); stale-reconcile bail on generation bump; reconcile reloads before the active flip (TOCTOU); error-packet-mid-interrupt deferral; `wasInterrupted` set/clear (incl. failed-interrupt reset); timeout-with-turn-gone settles vs timeout-still-running leaves running; cancelled scheduled-task turn → FAILED.
- **Live (claude-in-chrome) end-to-end:** interrupt during a long tool call with a queued message → no "Aborted"/"Concurrent turn" error, queue auto-sends; queue 3 messages + interrupt → all three auto-send and render (previously one hung); "Response stopped" shows on interrupt and clears on next send.
- `tsgo` typecheck, oxlint, oxfmt, ruff all clean.

## Known minor items (for reviewer)

- **`useChatController` change is untested** (no test harness exists for that hook); covered by the live verification above.
- **UX confirmation:** "stop flushes the next queued message" is intentional — flagging in case the desired behavior is for stop to *not* fire the queue.

## CI note

`connectors-check` fails on `TypeError: Got an unexpected keyword argument resourceKey` in `googleapiclient/discovery.py` (Google Drive connector). This is a pre-existing Google API client library incompatibility, unrelated to this PR (no connector code is touched here) and not part of the `required` merge gate.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)