### PR TITLE
test(craft): expand Docker compose integration coverage

### DIFF
--- a/backend/tests/integration/common_utils/managers/build_approvals.py
+++ b/backend/tests/integration/common_utils/managers/build_approvals.py
@@ -1,0 +1,45 @@
+"""HTTP wrapper for build-mode approval endpoints.
+
+Modeled on ``BuildSessionManager``: a thin static façade over the approval
+HTTP API, using the same ``user.headers`` / ``user.cookies`` auth pattern
+used elsewhere in ``common_utils.managers``.
+"""
+
+from __future__ import annotations
+
+import time
+from uuid import UUID
+
+from onyx.server.features.build.approvals.api import ApprovalListResponse
+from onyx.server.features.build.approvals.api import ApprovalView
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.http_client import client
+from tests.integration.common_utils.test_models import DATestUser
+
+
+class BuildApprovalsManager:
+    """Static wrapper around the build-mode approval HTTP API."""
+
+    @staticmethod
+    def list_live(user: DATestUser, session_id: UUID) -> list[ApprovalView]:
+        response = client.get(
+            f"{API_SERVER_URL}/build/approvals/sessions/{session_id}/live",
+            headers=user.headers,
+            cookies=user.cookies,
+        )
+        response.raise_for_status()
+        return ApprovalListResponse.model_validate(response.json()).items
+
+    @staticmethod
+    def wait_for_pending(
+        user: DATestUser, session_id: UUID, timeout_s: float = 30.0
+    ) -> ApprovalView:
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            items = BuildApprovalsManager.list_live(user, session_id)
+            if items:
+                return items[0]
+            time.sleep(0.5)
+        raise AssertionError(
+            f"No pending approval surfaced for session {session_id} within {timeout_s}s."
+        )

--- a/backend/tests/integration/common_utils/managers/llm_provider.py
+++ b/backend/tests/integration/common_utils/managers/llm_provider.py
@@ -102,9 +102,13 @@ class LLMProviderManager:
     def delete(
         llm_provider: DATestLLMProvider | LLMProviderView,
         user_performing_action: DATestUser,
+        force: bool = False,
     ) -> bool:
+        url = f"{API_SERVER_URL}/admin/llm/provider/{llm_provider.id}"
+        if force:
+            url += "?force=true"
         response = client.delete(
-            f"{API_SERVER_URL}/admin/llm/provider/{llm_provider.id}",
+            url,
             headers=user_performing_action.headers,
         )
         response.raise_for_status()

--- a/backend/tests/integration/tests/craft/docker_e2e/conftest.py
+++ b/backend/tests/integration/tests/craft/docker_e2e/conftest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import subprocess
+from typing import NamedTuple
 from typing import Protocol
 from uuid import UUID
 
@@ -18,6 +19,11 @@ from tests.integration.common_utils.managers.build_session import BuildSessionMa
 from tests.integration.common_utils.test_models import DATestUser
 
 
+class DockerSandbox(NamedTuple):
+    session_id: UUID
+    container_name: str
+
+
 class DockerExec(Protocol):
     def __call__(
         self,
@@ -30,7 +36,13 @@ class DockerExec(Protocol):
 
 
 class ProvisionSandbox(Protocol):
-    def __call__(self, user: DATestUser) -> tuple[UUID, str]: ...
+    def __call__(
+        self,
+        user: DATestUser,
+        *,
+        llm_provider_type: str | None = None,
+        llm_model_name: str | None = None,
+    ) -> DockerSandbox: ...
 
 
 def _container_name(sandbox_id: str) -> str:
@@ -57,14 +69,28 @@ def _docker_exec(
     )
 
 
-def _provision_sandbox(user: DATestUser) -> tuple[UUID, str]:
-    session = BuildSessionManager.create(user)
+def _provision_sandbox(
+    user: DATestUser,
+    *,
+    llm_provider_type: str | None = None,
+    llm_model_name: str | None = None,
+) -> DockerSandbox:
+    # Both default to None on the create request, so passing them through
+    # unconditionally is equivalent to omitting them.
+    session = BuildSessionManager.create(
+        user,
+        llm_provider_type=llm_provider_type,
+        llm_model_name=llm_model_name,
+    )
     sandbox = session.sandbox
     assert sandbox is not None, f"Session response missing sandbox: {session!r}"
     assert sandbox.status == SandboxStatus.RUNNING, (
         f"Sandbox not RUNNING after create: {sandbox.status!r}"
     )
-    return UUID(session.id), _container_name(sandbox.id)
+    return DockerSandbox(
+        session_id=UUID(session.id),
+        container_name=_container_name(sandbox.id),
+    )
 
 
 @pytest.fixture(scope="session")

--- a/backend/tests/integration/tests/craft/docker_e2e/test_approval_gate_docker.py
+++ b/backend/tests/integration/tests/craft/docker_e2e/test_approval_gate_docker.py
@@ -25,6 +25,7 @@ from tests.integration.common_utils.managers.build_approvals import (
 from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.test_models import DATestUser
 from tests.integration.tests.craft.docker_e2e.conftest import DockerExec
+from tests.integration.tests.craft.docker_e2e.conftest import DockerSandbox
 from tests.integration.tests.craft.docker_e2e.conftest import ProvisionSandbox
 
 pytestmark = pytest.mark.skipif(
@@ -83,25 +84,25 @@ def gated_user() -> DATestUser:
 def gated_module_sandbox(
     gated_user: DATestUser,
     provision_sandbox: ProvisionSandbox,
-) -> str:
+) -> DockerSandbox:
     # Sandboxes are per-user, so every later ``gated_session`` mint reuses this
     # RUNNING container instead of paying the ~40s provisioning cost again.
-    _session_id, container = provision_sandbox(gated_user)
-    return container
+    return provision_sandbox(gated_user)
 
 
 @pytest.fixture
 def gated_session(
     gated_user: DATestUser,
-    gated_module_sandbox: str,
+    gated_module_sandbox: DockerSandbox,
     provision_sandbox: ProvisionSandbox,
 ) -> DockerGatedSession:
     # Reuses the gated user's already-RUNNING container; only the build-session
     # row -- and thus the proxy tag / approval session id -- is new per test.
     result = provision_sandbox(gated_user)
-    assert result.container_name == gated_module_sandbox, (
+    assert result.container_name == gated_module_sandbox.container_name, (
         "gated_session minted a new container instead of reusing the module "
-        f"sandbox: {result.container_name!r} != {gated_module_sandbox!r}"
+        f"sandbox: {result.container_name!r} != "
+        f"{gated_module_sandbox.container_name!r}"
     )
     return DockerGatedSession(
         user=gated_user,

--- a/backend/tests/integration/tests/craft/docker_e2e/test_approval_gate_docker.py
+++ b/backend/tests/integration/tests/craft/docker_e2e/test_approval_gate_docker.py
@@ -1,37 +1,10 @@
-"""Docker-backend end-to-end approval-gate + posture tests.
-
-Mirrors the K8s ``test_approval_gate.py`` (which lives at
-``external_dependency_unit/craft/``) but runs as an **integration test**: the
-full compose stack with the craft overlay must be up before pytest starts, and
-assertions are made against the real api_server + sandbox-proxy + sandbox
-containers via HTTP and ``docker exec``. The tier-up from external-dep-unit is
-deliberate -- the docker-specific bug classes we catch here (image ENTRYPOINT
-concat, HOME after setpriv, curl httpoxy interactions on the bridge) only
-surface in the integrated provisioning flow.
-
-Bring-up (handled by ``.github/workflows/pr-craft-compose-integration.yml``)::
-
-    docker network create onyx_craft_sandbox
-    docker volume create sandbox_proxy_ca
-    docker compose \\
-        -f docker-compose.yml \\
-        -f docker-compose.dev.yml \\
-        -f docker-compose.craft.yml \\
-        --env-file env.template \\
-        up -d --wait --wait-timeout 600
-
-Skipped automatically when ``SANDBOX_BACKEND != docker`` so the file is a no-op
-on the K8s lane.
-"""
+"""Docker-backend end-to-end approval-gate decision tests."""
 
 from __future__ import annotations
 
 import json
-import re
 import subprocess
-import time
-from collections.abc import Generator
-from typing import Any
+from typing import NamedTuple
 from uuid import UUID
 from uuid import uuid4
 
@@ -43,13 +16,12 @@ from onyx.db.enums import ApprovalDecision
 from onyx.db.enums import ExternalAppType
 from onyx.db.external_app import get_built_in_external_app
 from onyx.server.features.build.configs import SANDBOX_BACKEND
-from onyx.server.features.build.configs import SANDBOX_PROXY_INJECTED_PLACEHOLDER
 from onyx.server.features.build.configs import SandboxBackend
-from onyx.server.features.build.sandbox.docker.docker_sandbox_manager import (
-    SANDBOX_EXEC_USER,
-)
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.http_client import client
+from tests.integration.common_utils.managers.build_approvals import (
+    BuildApprovalsManager,
+)
 from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.test_models import DATestUser
 from tests.integration.tests.craft.docker_e2e.conftest import DockerExec
@@ -60,37 +32,19 @@ pytestmark = pytest.mark.skipif(
     reason="Docker integration tests require SANDBOX_BACKEND=docker.",
 )
 
+
+class DockerGatedSession(NamedTuple):
+    user: DATestUser
+    session_id: UUID
+    container_name: str
+
+
 _SLACK_POST_MESSAGE_URL = "https://slack.com/api/chat.postMessage"
-_PROXY_CA_ISSUER_RE = re.compile(r"CN=Onyx Sandbox Proxy CA")
-_SANDBOX_BRIDGE_NETWORK = "onyx_craft_sandbox"
-
-
-def _opencode_pid(container: str, docker_exec: DockerExec) -> int:
-    """Finds the opencode-serve PID inside the sandbox.
-
-    Returns the integer PID; raises with a diagnostic if not found. We rely on
-    this to assert capability + uid invariants on the actual agent process, not
-    the entrypoint shell.
-    """
-    proc = docker_exec(container, ["pgrep", "-f", "opencode serve"])
-    pids = [int(p) for p in proc.stdout.split() if p.strip()]
-    assert pids, (
-        f"No opencode-serve PID in {container!r}; entrypoint likely crashed. Docker "
-        f"logs:\n{docker_exec(container, ['cat', '/proc/1/status']).stdout}"
-    )
-    return pids[0]
 
 
 def _start_slack_post_via_proxy(
     container: str, session_id: UUID
 ) -> subprocess.Popen[str]:
-    """
-    Starts a sandbox-side curl POST to ``chat.postMessage`` through the proxy
-    and return the Popen. The bearer is intentionally fake; if the request
-    reaches Slack it 401s. Caller drives the gate decision via the API while
-    curl is parked, then ``communicate()``s to collect the result. Output body
-    lands at ``/tmp/slack_out`` inside the sandbox.
-    """
     cmd = (
         f"curl -sS -X POST "
         f"-H 'Authorization: Bearer xoxb-fake' "
@@ -108,28 +62,9 @@ def _start_slack_post_via_proxy(
     )
 
 
-def _wait_for_pending_approval(
-    user: DATestUser, session_id: UUID, timeout_s: float = 30.0
-) -> dict[str, Any]:
-    """Polls the live-approvals HTTP endpoint until a pending row appears."""
-    deadline = time.monotonic() + timeout_s
-    url = f"{API_SERVER_URL}/build/approvals/sessions/{session_id}/live"
-    while time.monotonic() < deadline:
-        resp = client.get(url, headers=user.headers, cookies=user.cookies)
-        resp.raise_for_status()
-        items = resp.json().get("items", [])
-        if items:
-            return items[0]
-        time.sleep(0.5)
-    raise AssertionError(
-        f"No pending approval surfaced for session {session_id} within {timeout_s}s."
-    )
-
-
 def _post_decision(
     user: DATestUser, approval_id: str, decision: ApprovalDecision
 ) -> Response:
-    """POST APPROVE or REJECT via the decision API."""
     url = f"{API_SERVER_URL}/build/approvals/{approval_id}/decision"
     return client.post(
         url,
@@ -139,375 +74,72 @@ def _post_decision(
     )
 
 
-# ------------------------------------------------------------------------------
-# Fixtures
-# ------------------------------------------------------------------------------
-
-
 @pytest.fixture(scope="module")
-def module_user() -> DATestUser:
-    """A user shared across the docker-posture tests (1-5).
-
-    The K8s analogue gives each test its own user + sandbox. We share for the
-    posture tests because they don't mutate any per-sandbox state -- they only
-    read container properties. Tests that drive the gate flow (6-7) take their
-    own fresh user via the ``gated_user`` fixture.
-    """
-    return UserManager.create(name="craft_docker_module")
-
-
-@pytest.fixture(scope="module")
-def module_sandbox(
-    module_user: DATestUser,
-    provision_sandbox: ProvisionSandbox,
-) -> tuple[UUID, str]:
-    """One sandbox provisioned via the real API; reused across posture tests."""
-    return provision_sandbox(module_user)
-
-
-@pytest.fixture
 def gated_user() -> DATestUser:
-    """Function-scoped user for the gate-flow tests -- each test gets its own
-    session + sandbox so approval rows don't leak across tests."""
     return UserManager.create(name=f"craft_docker_gated_{uuid4().hex[:8]}")
+
+
+@pytest.fixture(scope="module")
+def gated_module_sandbox(
+    gated_user: DATestUser,
+    provision_sandbox: ProvisionSandbox,
+) -> str:
+    # Sandboxes are per-user, so every later ``gated_session`` mint reuses this
+    # RUNNING container instead of paying the ~40s provisioning cost again.
+    _session_id, container = provision_sandbox(gated_user)
+    return container
 
 
 @pytest.fixture
 def gated_session(
     gated_user: DATestUser,
+    gated_module_sandbox: str,
     provision_sandbox: ProvisionSandbox,
-) -> Generator[tuple[DATestUser, UUID, str], None, None]:
-    """Provisions a fresh sandbox via the real API for one gate-flow test."""
-    session_id, container = provision_sandbox(gated_user)
-    yield gated_user, session_id, container
-
-
-# ------------------------------------------------------------------------------
-# Tests 1-5: Docker-specific posture invariants
-# ------------------------------------------------------------------------------
-
-
-def test_sandbox_runs_with_zero_caps_at_uid_1000(
-    module_sandbox: tuple[UUID, str],
-    docker_exec: DockerExec,
-) -> None:
-    """
-    The opencode-serve process must run as uid 1000 with an empty bounding set.
-    This is the assertion that catches both the ENTRYPOINT-not-overridden bug
-    (firewall-init.sh skipped -> process stays root) and the HOME-after- setpriv
-    bug (opencode-serve never starts -> no pid to check).
-    """
-    _session_id, container = module_sandbox
-    pid = _opencode_pid(container, docker_exec)
-
-    status = docker_exec(container, ["cat", f"/proc/{pid}/status"]).stdout
-    uid_line = next(line for line in status.splitlines() if line.startswith("Uid:"))
-    cap_lines = {
-        line.split(":")[0]: line
-        for line in status.splitlines()
-        if line.startswith(("CapInh:", "CapPrm:", "CapEff:", "CapBnd:", "CapAmb:"))
-    }
-
-    assert uid_line.split() == ["Uid:", "1000", "1000", "1000", "1000"], uid_line
-    for key, line in cap_lines.items():
-        mask = line.split()[1]
-        assert mask == "0000000000000000", (
-            f"{key} not empty for opencode pid {pid}: {line!r}"
-        )
-
-
-def test_sandbox_https_is_mitmd_by_proxy_ca(
-    module_sandbox: tuple[UUID, str],
-    docker_exec: DockerExec,
-) -> None:
-    """
-    Public HTTPS gets MITM'd: leaf cert issued by the Onyx Sandbox Proxy CA.
-    Proves the firewall-init.sh CA-install step + the iptables proxy-allow rule
-    + the proxy's MITM both work end-to-end.
-    """
-    _session_id, container = module_sandbox
-    proc = docker_exec(
-        container,
-        ["curl", "-sS", "-v", "--max-time", "10", "https://example.com"],
-        timeout=20.0,
+) -> DockerGatedSession:
+    # Reuses the gated user's already-RUNNING container; only the build-session
+    # row -- and thus the proxy tag / approval session id -- is new per test.
+    result = provision_sandbox(gated_user)
+    assert result.container_name == gated_module_sandbox, (
+        "gated_session minted a new container instead of reusing the module "
+        f"sandbox: {result.container_name!r} != {gated_module_sandbox!r}"
     )
-    issuer_line = next(
-        (line for line in proc.stderr.splitlines() if "issuer:" in line),
-        None,
-    )
-    assert issuer_line is not None, (
-        f"No 'issuer:' line in curl -v output: {proc.stderr}"
-    )
-    assert _PROXY_CA_ISSUER_RE.search(issuer_line), (
-        f"Issuer is not the proxy CA: {issuer_line!r}"
+    return DockerGatedSession(
+        user=gated_user,
+        session_id=result.session_id,
+        container_name=result.container_name,
     )
 
 
-def test_credentials_injected_on_wire_returns_real_user(
-    module_user: DATestUser,
-    module_sandbox: tuple[UUID, str],
-    docker_exec: DockerExec,
-) -> None:
-    """
-    Sandbox env carries the placeholder PAT; calling api_server/me via the proxy
-    returns the REAL user record (proves the proxy substituted the bearer header
-    from ``Sandbox.encrypted_pat``).
-    """
-    _session_id, container = module_sandbox
-
-    env_check = docker_exec(container, ["sh", "-c", "echo $ONYX_PAT"])
-    assert env_check.stdout.strip() == SANDBOX_PROXY_INJECTED_PLACEHOLDER, (
-        f"ONYX_PAT in sandbox env was not the placeholder: {env_check.stdout!r}"
-    )
-
-    me_call = docker_exec(
-        container,
-        [
-            "curl",
-            "-sS",
-            "-w",
-            "\nHTTP %{http_code}",
-            "-H",
-            f"Authorization: Bearer {SANDBOX_PROXY_INJECTED_PLACEHOLDER}",
-            "http://api_server:8080/me",
-        ],
-        timeout=15.0,
-    )
-    assert "HTTP 200" in me_call.stdout, f"/me did not return 200: {me_call.stdout!r}"
-    body = me_call.stdout.split("\nHTTP ")[0]
-    payload = json.loads(body)
-    assert payload["id"] == module_user.id, (
-        f"Injected PAT did not resolve to {module_user.id}: {payload!r}"
-    )
+# Gate-flow tests depend on the ``slack_external_app`` fixture.
+#  They also share one module-scoped sandbox (``gated_module_sandbox``),
+# so the credential-mutating ``test_ask_*`` case below is defined LAST
+# and additionally save/restores the Slack row's credentials around its mutation
 
 
-def test_iptables_rejects_bypass_attempts(
-    module_sandbox: tuple[UUID, str],
-    docker_exec: DockerExec,
-) -> None:
-    """
-    All four bypass classes are kernel-level rejected; the loopback embedded
-    resolver stays reachable by design (compose-internal name resolution).
-    """
-    _session_id, container = module_sandbox
-
-    direct_api = docker_exec(
-        container,
-        [
-            "curl",
-            "-sS",
-            "-o",
-            "/dev/null",
-            "--noproxy",
-            "*",
-            "--max-time",
-            "5",
-            "http://api_server:8080/me",
-        ],
-        timeout=10.0,
-    )
-    assert direct_api.returncode == 7, (
-        f"direct api_server bypass not rejected: rc={direct_api.returncode} "
-        f"stderr={direct_api.stderr!r}"
-    )
-
-    direct_internet = docker_exec(
-        container,
-        [
-            "curl",
-            "-sS",
-            "-o",
-            "/dev/null",
-            "--noproxy",
-            "*",
-            "--max-time",
-            "5",
-            "https://1.1.1.1",
-        ],
-        timeout=10.0,
-    )
-    assert direct_internet.returncode == 7, "Direct external IP bypass not rejected."
-
-    udp_dns = docker_exec(
-        container,
-        [
-            "python3",
-            "-c",
-            (
-                "import socket; "
-                "s=socket.socket(socket.AF_INET, socket.SOCK_DGRAM); "
-                "s.settimeout(5); "
-                "s.sendto(b'\\x00\\x01\\x01\\x00\\x00\\x01\\x00\\x00\\x00\\x00\\x00\\x00"
-                "\\x07example\\x03com\\x00\\x00\\x01\\x00\\x01', ('8.8.8.8', 53)); "
-                "s.recvfrom(512)"
-            ),
-        ],
-        timeout=10.0,
-    )
-    assert udp_dns.returncode != 0, (
-        f"External DNS not blocked: stdout={udp_dns.stdout!r} stderr={udp_dns.stderr!r}"
-    )
-    assert (
-        "Operation not permitted" in udp_dns.stderr
-        or "PermissionError" in udp_dns.stderr
-    )
-
-    ipv6_egress = docker_exec(
-        container,
-        [
-            "curl",
-            "-sS",
-            "-o",
-            "/dev/null",
-            "--noproxy",
-            "*",
-            "-6",
-            "--max-time",
-            "5",
-            "https://ipv6.google.com",
-        ],
-        timeout=10.0,
-    )
-    assert ipv6_egress.returncode == 7, "IPv6 egress not blocked"
-
-    # By-design exception: Docker's embedded resolver at 127.0.0.11 is reachable
-    # via the loopback ACCEPT rule. Required so the sandbox can resolve
-    # ``sandbox-proxy``. Asserting positively so a future "close all DNS"
-    # over-correction would fail this test.
-    embedded_dns = docker_exec(
-        container,
-        ["getent", "ahosts", "example.com"],
-        timeout=10.0,
-    )
-    assert embedded_dns.returncode == 0, (
-        f"Docker embedded resolver should resolve example.com: {embedded_dns.stderr!r}"
-    )
-
-
-def test_unlabeled_container_gets_unidentified_sandbox_403() -> None:
-    """
-    A non-sandbox container on the bridge that hits the proxy must get a 403 + a
-    ``identity_unknown_sandbox`` warning in the proxy logs. Proves
-    DockerEventsLookup rejects unknown source IPs and the observability hook we
-    added in branch 6 still fires.
-    """
-    proc = subprocess.run(
-        [
-            "docker",
-            "run",
-            "--rm",
-            "--network",
-            _SANDBOX_BRIDGE_NETWORK,
-            "curlimages/curl:latest",
-            "-sS",
-            "-o",
-            "/dev/null",
-            "-w",
-            "%{http_code}",
-            "--max-time",
-            "10",
-            "-x",
-            "http://sandbox-proxy:8080",
-            "http://api_server:8080/me",
-        ],
-        capture_output=True,
-        text=True,
-        timeout=60,
-        check=False,
-    )
-    assert proc.stdout.strip() == "403", f"Unlabeled bypass not 403: {proc.stdout!r}"
-
-    proxy_logs = subprocess.run(
-        ["docker", "logs", "--tail", "50", "onyx-sandbox-proxy-1"],
-        capture_output=True,
-        text=True,
-        timeout=10,
-        check=False,
-    )
-    assert "identity_unknown_sandbox" in proxy_logs.stderr + proxy_logs.stdout, (
-        f"Proxy did not log identity_unknown_sandbox warning. Recent "
-        f"logs:\n{proxy_logs.stdout[-2000:]}"
-    )
-
-
-def test_sessions_directory_writable_by_sandbox_user(
-    module_sandbox: tuple[UUID, str],
-    docker_exec: DockerExec,
-) -> None:
-    """
-    The /workspace/sessions volume mount must be writable by UID 1000.
-
-    Regression test: Docker volumes are created with root:root ownership.
-    firewall-init.sh must chown the directory before dropping to UID 1000,
-    otherwise session workspace creation fails with EACCES.
-
-    This test verifies that UID 1000 can create a test directory inside
-    /workspace/sessions, proving the permissions fix in firewall-init.sh
-    works correctly.
-    """
-    _session_id, container = module_sandbox
-
-    # Verify /workspace/sessions exists and is owned by 1000:1000
-    stat_result = docker_exec(container, ["stat", "-c", "%u:%g", "/workspace/sessions"])
-    assert stat_result.returncode == 0, (
-        f"/workspace/sessions stat failed: {stat_result.stderr}"
-    )
-    assert stat_result.stdout.strip() == "1000:1000", (
-        f"/workspace/sessions not owned by 1000:1000: {stat_result.stdout.strip()}"
-    )
-
-    # Attempt to create a test directory as UID 1000. Must set the exec user
-    # explicitly because in proxy mode docker exec defaults to the container's
-    # configured root user, not the setpriv-dropped agent user.
-    test_dir = f"/workspace/sessions/test-{uuid4().hex[:8]}"
-    mkdir_result = docker_exec(
-        container,
-        ["mkdir", "-p", test_dir],
-        timeout=10.0,
-        user=SANDBOX_EXEC_USER,
-    )
-    assert mkdir_result.returncode == 0, (
-        f"mkdir failed as UID 1000: rc={mkdir_result.returncode} "
-        f"stderr={mkdir_result.stderr!r}"
-    )
-
-    docker_exec(container, ["rm", "-rf", test_dir], user=SANDBOX_EXEC_USER)
-
-
-# ------------------------------------------------------------------------------
-# Tests 6-7: Gate APPROVE / REJECT flow (analogues of K8s test_approval_gate)
-#
-# Depend on the ``slack_external_app`` fixture so the proxy's
-# ``ExternalAppActionMatcher`` actually claims ``chat.postMessage``. Without
-# that seeding the matcher returns ``None``, the request leaves the proxy with
-# ``policy=off_catalog``, and no approval ever parks. The default deployment has
-# no external apps configured and the K8s lane's ``test_approval_gate.py`` isn't
-# actually run by its CI (verified -- not in the lane's ``paths:`` filter or
-# pytest args), so this fixture is the first place to wire the seeding in.
-# ------------------------------------------------------------------------------
+def _set_slack_org_credentials(value: dict[str, str]) -> None:
+    with get_session_with_tenant(tenant_id="public") as db:
+        app = get_built_in_external_app(db, ExternalAppType.SLACK)
+        assert app is not None, "slack_external_app fixture must seed the row"
+        app.organization_credentials = value  # ty: ignore[invalid-assignment]
+        db.commit()
 
 
 def test_approve_decision_forwards_to_slack(
     slack_external_app: None,  # noqa: ARG001 -- side-effect fixture
-    gated_session: tuple[DATestUser, UUID, str],
+    gated_session: DockerGatedSession,
     docker_exec: DockerExec,
 ) -> None:
-    """
-    A gated Slack request parks at the proxy, becomes a pending ActionApproval,
-    and on APPROVE the proxy forwards upstream. Mirrors K8s
-    ``test_approved_decision_forwards_to_slack``.
-
-    The fake bearer means Slack returns ``invalid_auth`` once the request
-    actually reaches it -- evidence the forward fired (vs. the gate having
-    short-circuited).
-    """
     user, session_id, container = gated_session
 
     curl_proc = _start_slack_post_via_proxy(container, session_id)
 
     try:
-        approval = _wait_for_pending_approval(user, session_id, timeout_s=30.0)
-        resp = _post_decision(user, approval["approval_id"], ApprovalDecision.APPROVED)
+        approval = BuildApprovalsManager.wait_for_pending(
+            user, session_id, timeout_s=30.0
+        )
+        resp = _post_decision(
+            user, str(approval.approval_id), ApprovalDecision.APPROVED
+        )
         assert resp.status_code == 200, (
             f"APPROVE failed: {resp.status_code} {resp.text!r}"
         )
@@ -530,21 +162,20 @@ def test_approve_decision_forwards_to_slack(
 
 def test_reject_decision_returns_403_user_rejected(
     slack_external_app: None,  # noqa: ARG001 -- side-effect fixture
-    gated_session: tuple[DATestUser, UUID, str],
+    gated_session: DockerGatedSession,
     docker_exec: DockerExec,
 ) -> None:
-    """
-    REJECT causes the parked sandbox-side curl to return a 403 carrying the
-    ``USER_REJECTED_ACTION`` error code. Mirrors K8s
-    ``test_rejected_decision_returns_403_user_rejected``.
-    """
     user, session_id, container = gated_session
 
     curl_proc = _start_slack_post_via_proxy(container, session_id)
 
     try:
-        approval = _wait_for_pending_approval(user, session_id, timeout_s=30.0)
-        resp = _post_decision(user, approval["approval_id"], ApprovalDecision.REJECTED)
+        approval = BuildApprovalsManager.wait_for_pending(
+            user, session_id, timeout_s=30.0
+        )
+        resp = _post_decision(
+            user, str(approval.approval_id), ApprovalDecision.REJECTED
+        )
         assert resp.status_code == 200, (
             f"REJECT failed: {resp.status_code} {resp.text!r}"
         )
@@ -565,31 +196,27 @@ def test_reject_decision_returns_403_user_rejected(
 
 def test_ask_with_uninvokable_app_forwards_bare(
     slack_external_app: None,  # noqa: ARG001 -- side-effect fixture
-    gated_session: tuple[DATestUser, UUID, str],
+    gated_session: DockerGatedSession,
     docker_exec: DockerExec,
 ) -> None:
-    """ASKs on an app whose auth template can't be filled forwards bare.
-
-    Documents the credential gate's short-circuit: With no credentials to inject
-    after approval, the gate skips the ASK prompt and forwards the request
-    as-is. Mirrors K8s ``test_ask_with_uninvokable_app_forwards_bare``.
-    """
     user, session_id, container = gated_session
 
-    # Strip Slack's org credential so app_is_available -> False.
+    # Snapshot the row so the strip below is restored exactly, no matter what
+    # the fixture seeded -- the approve/reject siblings share this row.
     with get_session_with_tenant(tenant_id="public") as db:
         app = get_built_in_external_app(db, ExternalAppType.SLACK)
         assert app is not None, "slack_external_app fixture must seed the row"
-        app.organization_credentials = {}  # ty: ignore[invalid-assignment]
-        db.commit()
+        saved_credentials = dict(
+            app.organization_credentials.get_value(apply_mask=False) or {}
+        )
+
+    # Strip Slack's org credential so app_is_available -> False.
+    _set_slack_org_credentials({})
 
     try:
         curl_proc = _start_slack_post_via_proxy(container, session_id)
         try:
             stdout, _stderr = curl_proc.communicate(timeout=60)
-            # Slack returns HTTP 200 with `invalid_auth` in the body for the
-            # fake bearer -- the 200 + body is the proof the request actually
-            # reached slack.com bare (no injection from the gate).
             assert stdout.strip() == "200", (
                 "Uninvokable ASK should forward bare to Slack and Slack should "
                 f"200 with invalid_auth in the body, got {stdout!r}"
@@ -610,11 +237,5 @@ def test_ask_with_uninvokable_app_forwards_bare(
         finally:
             curl_proc.kill()
     finally:
-        # Restore the seeded fake token so sibling tests still gate.
-        with get_session_with_tenant(tenant_id="public") as db:
-            app = get_built_in_external_app(db, ExternalAppType.SLACK)
-            assert app is not None
-            app.organization_credentials = {  # ty: ignore[invalid-assignment]
-                "access_token": "fake-test-token"
-            }
-            db.commit()
+        # Restore the seeded credential so sibling tests still gate.
+        _set_slack_org_credentials(saved_credentials)

--- a/backend/tests/integration/tests/craft/docker_e2e/test_sandbox_network_posture_docker.py
+++ b/backend/tests/integration/tests/craft/docker_e2e/test_sandbox_network_posture_docker.py
@@ -1,0 +1,303 @@
+"""Docker-backend sandbox network/security-posture tests.
+
+Zero-capabilities at UID 1000, proxy-MITM of HTTPS, credential injection on the
+wire, iptables egress lockdown, unidentified-sandbox rejection, and workspace
+ownership — exercised against one module-scoped RUNNING sandbox.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from uuid import uuid4
+
+import pytest
+
+from onyx.server.features.build.configs import SANDBOX_BACKEND
+from onyx.server.features.build.configs import SANDBOX_PROXY_INJECTED_PLACEHOLDER
+from onyx.server.features.build.configs import SandboxBackend
+from onyx.server.features.build.sandbox.docker.docker_sandbox_manager import (
+    SANDBOX_EXEC_USER,
+)
+from tests.integration.common_utils.managers.user import UserManager
+from tests.integration.common_utils.test_models import DATestUser
+from tests.integration.tests.craft.docker_e2e.conftest import DockerExec
+from tests.integration.tests.craft.docker_e2e.conftest import DockerSandbox
+from tests.integration.tests.craft.docker_e2e.conftest import ProvisionSandbox
+
+pytestmark = pytest.mark.skipif(
+    SANDBOX_BACKEND != SandboxBackend.DOCKER,
+    reason="Docker integration tests require SANDBOX_BACKEND=docker.",
+)
+
+_PROXY_CA_ISSUER_RE = re.compile(r"CN=Onyx Sandbox Proxy CA")
+_SANDBOX_BRIDGE_NETWORK = "onyx_craft_sandbox"
+
+
+def _opencode_pid(container: str, docker_exec: DockerExec) -> int:
+    proc = docker_exec(container, ["pgrep", "-f", "opencode serve"])
+    pids = [int(p) for p in proc.stdout.split() if p.strip()]
+    assert pids, (
+        f"No opencode-serve PID in {container!r}; entrypoint likely crashed. Docker "
+        f"logs:\n{docker_exec(container, ['cat', '/proc/1/status']).stdout}"
+    )
+    return pids[0]
+
+
+@pytest.fixture(scope="module")
+def module_user() -> DATestUser:
+    return UserManager.create(name="craft_docker_module")
+
+
+@pytest.fixture(scope="module")
+def module_sandbox(
+    module_user: DATestUser,
+    provision_sandbox: ProvisionSandbox,
+) -> DockerSandbox:
+    return provision_sandbox(module_user)
+
+
+def test_sandbox_runs_with_zero_caps_at_uid_1000(
+    module_sandbox: DockerSandbox,
+    docker_exec: DockerExec,
+) -> None:
+    _session_id, container = module_sandbox
+    pid = _opencode_pid(container, docker_exec)
+
+    status = docker_exec(container, ["cat", f"/proc/{pid}/status"]).stdout
+    uid_line = next(line for line in status.splitlines() if line.startswith("Uid:"))
+    cap_lines = {
+        line.split(":")[0]: line
+        for line in status.splitlines()
+        if line.startswith(("CapInh:", "CapPrm:", "CapEff:", "CapBnd:", "CapAmb:"))
+    }
+
+    assert uid_line.split() == ["Uid:", "1000", "1000", "1000", "1000"], uid_line
+    for key, line in cap_lines.items():
+        mask = line.split()[1]
+        assert mask == "0000000000000000", (
+            f"{key} not empty for opencode pid {pid}: {line!r}"
+        )
+
+
+def test_sandbox_https_is_mitmd_by_proxy_ca(
+    module_sandbox: DockerSandbox,
+    docker_exec: DockerExec,
+) -> None:
+    _session_id, container = module_sandbox
+    proc = docker_exec(
+        container,
+        ["curl", "-sS", "-v", "--max-time", "10", "https://example.com"],
+        timeout=20.0,
+    )
+    issuer_line = next(
+        (line for line in proc.stderr.splitlines() if "issuer:" in line),
+        None,
+    )
+    assert issuer_line is not None, (
+        f"No 'issuer:' line in curl -v output: {proc.stderr}"
+    )
+    assert _PROXY_CA_ISSUER_RE.search(issuer_line), (
+        f"Issuer is not the proxy CA: {issuer_line!r}"
+    )
+
+
+def test_credentials_injected_on_wire_returns_real_user(
+    module_user: DATestUser,
+    module_sandbox: DockerSandbox,
+    docker_exec: DockerExec,
+) -> None:
+    _session_id, container = module_sandbox
+
+    env_check = docker_exec(container, ["sh", "-c", "echo $ONYX_PAT"])
+    assert env_check.stdout.strip() == SANDBOX_PROXY_INJECTED_PLACEHOLDER, (
+        f"ONYX_PAT in sandbox env was not the placeholder: {env_check.stdout!r}"
+    )
+
+    me_call = docker_exec(
+        container,
+        [
+            "curl",
+            "-sS",
+            "-w",
+            "\nHTTP %{http_code}",
+            "-H",
+            f"Authorization: Bearer {SANDBOX_PROXY_INJECTED_PLACEHOLDER}",
+            "http://api_server:8080/me",
+        ],
+        timeout=15.0,
+    )
+    assert "HTTP 200" in me_call.stdout, f"/me did not return 200: {me_call.stdout!r}"
+    body = me_call.stdout.split("\nHTTP ")[0]
+    payload = json.loads(body)
+    assert payload["id"] == module_user.id, (
+        f"Injected PAT did not resolve to {module_user.id}: {payload!r}"
+    )
+
+
+def test_iptables_rejects_bypass_attempts(
+    module_sandbox: DockerSandbox,
+    docker_exec: DockerExec,
+) -> None:
+    _session_id, container = module_sandbox
+
+    direct_api = docker_exec(
+        container,
+        [
+            "curl",
+            "-sS",
+            "-o",
+            "/dev/null",
+            "--noproxy",
+            "*",
+            "--max-time",
+            "5",
+            "http://api_server:8080/me",
+        ],
+        timeout=10.0,
+    )
+    assert direct_api.returncode == 7, (
+        f"direct api_server bypass not rejected: rc={direct_api.returncode} "
+        f"stderr={direct_api.stderr!r}"
+    )
+
+    direct_internet = docker_exec(
+        container,
+        [
+            "curl",
+            "-sS",
+            "-o",
+            "/dev/null",
+            "--noproxy",
+            "*",
+            "--max-time",
+            "5",
+            "https://1.1.1.1",
+        ],
+        timeout=10.0,
+    )
+    assert direct_internet.returncode == 7, "Direct external IP bypass not rejected."
+
+    udp_dns = docker_exec(
+        container,
+        [
+            "python3",
+            "-c",
+            (
+                "import socket; "
+                "s=socket.socket(socket.AF_INET, socket.SOCK_DGRAM); "
+                "s.settimeout(5); "
+                "s.sendto(b'\\x00\\x01\\x01\\x00\\x00\\x01\\x00\\x00\\x00\\x00\\x00\\x00"
+                "\\x07example\\x03com\\x00\\x00\\x01\\x00\\x01', ('8.8.8.8', 53)); "
+                "s.recvfrom(512)"
+            ),
+        ],
+        timeout=10.0,
+    )
+    assert udp_dns.returncode != 0, (
+        f"External DNS not blocked: stdout={udp_dns.stdout!r} stderr={udp_dns.stderr!r}"
+    )
+    assert (
+        "Operation not permitted" in udp_dns.stderr
+        or "PermissionError" in udp_dns.stderr
+    )
+
+    ipv6_egress = docker_exec(
+        container,
+        [
+            "curl",
+            "-sS",
+            "-o",
+            "/dev/null",
+            "--noproxy",
+            "*",
+            "-6",
+            "--max-time",
+            "5",
+            "https://ipv6.google.com",
+        ],
+        timeout=10.0,
+    )
+    assert ipv6_egress.returncode == 7, "IPv6 egress not blocked"
+
+    # Docker's embedded resolver (127.0.0.11) must stay reachable so the sandbox
+    # can resolve ``sandbox-proxy``.
+    embedded_dns = docker_exec(
+        container,
+        ["getent", "ahosts", "example.com"],
+        timeout=10.0,
+    )
+    assert embedded_dns.returncode == 0, (
+        f"Docker embedded resolver should resolve example.com: {embedded_dns.stderr!r}"
+    )
+
+
+def test_unlabeled_container_gets_unidentified_sandbox_403() -> None:
+    proc = subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--network",
+            _SANDBOX_BRIDGE_NETWORK,
+            "curlimages/curl:latest",
+            "-sS",
+            "-o",
+            "/dev/null",
+            "-w",
+            "%{http_code}",
+            "--max-time",
+            "10",
+            "-x",
+            "http://sandbox-proxy:8080",
+            "http://api_server:8080/me",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    assert proc.stdout.strip() == "403", f"Unlabeled bypass not 403: {proc.stdout!r}"
+
+    proxy_logs = subprocess.run(
+        ["docker", "logs", "--tail", "50", "onyx-sandbox-proxy-1"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    assert "identity_unknown_sandbox" in proxy_logs.stderr + proxy_logs.stdout, (
+        f"Proxy did not log identity_unknown_sandbox warning. Recent "
+        f"logs:\n{proxy_logs.stdout[-2000:]}"
+    )
+
+
+def test_sessions_directory_writable_by_sandbox_user(
+    module_sandbox: DockerSandbox,
+    docker_exec: DockerExec,
+) -> None:
+    _session_id, container = module_sandbox
+
+    stat_result = docker_exec(container, ["stat", "-c", "%u:%g", "/workspace/sessions"])
+    assert stat_result.returncode == 0, (
+        f"/workspace/sessions stat failed: {stat_result.stderr}"
+    )
+    assert stat_result.stdout.strip() == "1000:1000", (
+        f"/workspace/sessions not owned by 1000:1000: {stat_result.stdout.strip()}"
+    )
+
+    # docker exec defaults to root, not the setpriv-dropped agent user.
+    test_dir = f"/workspace/sessions/test-{uuid4().hex[:8]}"
+    mkdir_result = docker_exec(
+        container,
+        ["mkdir", "-p", test_dir],
+        timeout=10.0,
+        user=SANDBOX_EXEC_USER,
+    )
+    assert mkdir_result.returncode == 0, (
+        f"mkdir failed as UID 1000: rc={mkdir_result.returncode} "
+        f"stderr={mkdir_result.stderr!r}"
+    )
+
+    docker_exec(container, ["rm", "-rf", test_dir], user=SANDBOX_EXEC_USER)

--- a/backend/tests/integration/tests/craft/docker_e2e/test_serve_streaming_docker.py
+++ b/backend/tests/integration/tests/craft/docker_e2e/test_serve_streaming_docker.py
@@ -27,6 +27,7 @@ from tests.integration.common_utils.managers.llm_provider import LLMProviderMana
 from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.test_models import DATestUser
 from tests.integration.tests.craft.docker_e2e.conftest import DockerExec
+from tests.integration.tests.craft.docker_e2e.conftest import DockerSandbox
 from tests.integration.tests.craft.docker_e2e.conftest import ProvisionSandbox
 
 pytestmark = pytest.mark.skipif(
@@ -151,31 +152,43 @@ def live_session(
     for provider in LLMProviderManager.get_all(admin_user):
         if provider.provider == LlmProviderNames.OPENAI:
             LLMProviderManager.delete(provider, admin_user, force=True)
-    LLMProviderManager.create(
+    created_provider = LLMProviderManager.create(
         user_performing_action=admin_user,
         api_key=real_key,
         default_model_name=_LIVE_MODEL,
     )
-    # Pin the cheap model on the turn; provisioning otherwise selects the
-    # provider's recommended (flagship) model, ignoring default_model_name.
-    result = provision_sandbox(
-        streaming_user,
-        llm_provider_type=LlmProviderNames.OPENAI,
-        llm_model_name=_LIVE_MODEL,
-    )
+    result: DockerSandbox | None = None
     try:
+        # Pin the cheap model on the turn; provisioning otherwise selects the
+        # provider's recommended (flagship) model, ignoring default_model_name.
+        result = provision_sandbox(
+            streaming_user,
+            llm_provider_type=LlmProviderNames.OPENAI,
+            llm_model_name=_LIVE_MODEL,
+        )
         yield DockerLiveSession(user=streaming_user, session_id=result.session_id)
     finally:
         try:
-            subprocess.run(
-                ["docker", "rm", "-f", result.container_name],
-                capture_output=True,
-                text=True,
-                timeout=30.0,
-                check=False,
+            LLMProviderManager.delete(created_provider, admin_user, force=True)
+        except Exception as exc:
+            print(
+                "WARNING: failed to delete live-test LLM provider "
+                f"{created_provider.id!r}: {exc}"
             )
-        except Exception:
-            pass
+        if result is not None:
+            try:
+                subprocess.run(
+                    ["docker", "rm", "-f", result.container_name],
+                    capture_output=True,
+                    text=True,
+                    timeout=30.0,
+                    check=False,
+                )
+            except Exception as exc:
+                print(
+                    "WARNING: failed to remove container "
+                    f"{result.container_name!r}: {exc}"
+                )
 
 
 def test_provision_injects_serve_env_into_real_container(

--- a/backend/tests/integration/tests/craft/docker_e2e/test_serve_streaming_docker.py
+++ b/backend/tests/integration/tests/craft/docker_e2e/test_serve_streaming_docker.py
@@ -1,0 +1,283 @@
+"""Docker-backend opencode-serve streaming end-to-end tests."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+from collections.abc import Generator
+from dataclasses import dataclass
+from dataclasses import field
+from typing import Any
+from typing import NamedTuple
+from uuid import UUID
+from uuid import uuid4
+
+import pytest
+
+from onyx.llm.constants import LlmProviderNames
+from onyx.server.features.build.configs import OPENCODE_SERVER_PASSWORD
+from onyx.server.features.build.configs import SANDBOX_BACKEND
+from onyx.server.features.build.configs import SandboxBackend
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.http_client import client
+from tests.integration.common_utils.managers.build_session import BuildSessionManager
+from tests.integration.common_utils.managers.llm_provider import LLMProviderManager
+from tests.integration.common_utils.managers.user import UserManager
+from tests.integration.common_utils.test_models import DATestUser
+from tests.integration.tests.craft.docker_e2e.conftest import DockerExec
+from tests.integration.tests.craft.docker_e2e.conftest import ProvisionSandbox
+
+pytestmark = pytest.mark.skipif(
+    SANDBOX_BACKEND != SandboxBackend.DOCKER,
+    reason="Docker integration tests require SANDBOX_BACKEND=docker.",
+)
+
+
+class DockerLiveSession(NamedTuple):
+    user: DATestUser
+    session_id: UUID
+
+
+_LIVE_MODEL = "gpt-5-mini"
+
+_SKIP_NO_LLM_KEY = pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY"),
+    reason="docker-serve streaming tests that drive real turns need a real "
+    "OPENAI_API_KEY (the compose lane seeds a fake provider key by default).",
+)
+
+
+@dataclass
+class _Collected:
+    text: str = ""
+    thoughts: list[dict[str, Any]] = field(default_factory=list)
+    tool_starts: list[dict[str, Any]] = field(default_factory=list)
+    tool_progress: list[dict[str, Any]] = field(default_factory=list)
+    terminators: list[dict[str, Any]] = field(default_factory=list)
+    errors: list[dict[str, Any]] = field(default_factory=list)
+
+    @property
+    def term(self) -> dict[str, Any] | None:
+        return self.terminators[0] if self.terminators else None
+
+
+def _iter_sse_events(
+    raw_lines: Generator[str, None, None],
+) -> Generator[dict[str, Any], None, None]:
+    for line in raw_lines:
+        if not line.startswith("data:"):
+            continue
+        raw = line[len("data:") :].strip()
+        if not raw:
+            continue
+        try:
+            yield json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+
+
+def _drive_turn(
+    user: DATestUser,
+    session_id: UUID,
+    prompt: str,
+    *,
+    timeout: float = 180.0,
+) -> _Collected:
+    turn = BuildSessionManager.start_turn(user, session_id, prompt)
+    turn_id = turn.turn_id
+
+    out = _Collected()
+    url = f"{API_SERVER_URL}/build/sessions/{session_id}/turns/{turn_id}/events"
+    with client.stream(
+        "GET",
+        url,
+        headers=user.headers,
+        cookies=user.cookies,
+        timeout=timeout,
+    ) as resp:
+        resp.raise_for_status()
+        for event in _iter_sse_events(resp.iter_lines()):
+            etype = event.get("type")
+            if etype == "agent_message_chunk":
+                out.text += _chunk_text(event)
+            elif etype == "agent_thought_chunk":
+                out.thoughts.append(event)
+            elif etype == "tool_call_start":
+                out.tool_starts.append(event)
+            elif etype == "tool_call_progress":
+                out.tool_progress.append(event)
+            elif etype == "prompt_response":
+                out.terminators.append(event)
+            elif etype == "error":
+                out.errors.append(event)
+
+    # The SSE stream closes slightly before the server releases the turn slot;
+    # wait for it to clear so a follow-up start_turn isn't refused with 409.
+    deadline = time.monotonic() + 30.0
+    while time.monotonic() < deadline:
+        if BuildSessionManager.get_active_turn(user, session_id) is None:
+            break
+        time.sleep(0.5)
+    return out
+
+
+def _chunk_text(event: dict[str, Any]) -> str:
+    content = event.get("content")
+    if isinstance(content, dict) and content.get("type") == "text":
+        return content.get("text") or ""
+    return ""
+
+
+@pytest.fixture
+def streaming_user() -> DATestUser:
+    return UserManager.create(name=f"craft_docker_streaming_{uuid4().hex[:8]}")
+
+
+@pytest.fixture
+def live_session(
+    admin_user: DATestUser,
+    streaming_user: DATestUser,
+    provision_sandbox: ProvisionSandbox,
+) -> Generator[DockerLiveSession, None, None]:
+    real_key = os.environ.get("OPENAI_API_KEY")
+    if not real_key:
+        pytest.skip("OPENAI_API_KEY not set; live-turn streaming tests need it.")
+    # The base craft conftest seeds a fake-keyed openai provider, and both the
+    # session-config and sandbox-proxy key resolvers pick the *first* openai
+    # provider. Delete any existing openai provider so the real key is the only
+    # one in play, then seed it (with gpt-5-mini visible).
+    for provider in LLMProviderManager.get_all(admin_user):
+        if provider.provider == LlmProviderNames.OPENAI:
+            LLMProviderManager.delete(provider, admin_user, force=True)
+    LLMProviderManager.create(
+        user_performing_action=admin_user,
+        api_key=real_key,
+        default_model_name=_LIVE_MODEL,
+    )
+    # Pin the cheap model on the turn; provisioning otherwise selects the
+    # provider's recommended (flagship) model, ignoring default_model_name.
+    result = provision_sandbox(
+        streaming_user,
+        llm_provider_type=LlmProviderNames.OPENAI,
+        llm_model_name=_LIVE_MODEL,
+    )
+    try:
+        yield DockerLiveSession(user=streaming_user, session_id=result.session_id)
+    finally:
+        try:
+            subprocess.run(
+                ["docker", "rm", "-f", result.container_name],
+                capture_output=True,
+                text=True,
+                timeout=30.0,
+                check=False,
+            )
+        except Exception:
+            pass
+
+
+def test_provision_injects_serve_env_into_real_container(
+    provision_sandbox: ProvisionSandbox,
+    docker_exec: DockerExec,
+) -> None:
+    user = UserManager.create(name=f"craft_docker_env_{uuid4().hex[:8]}")
+    _session_id, container = provision_sandbox(user)
+
+    env_dump = docker_exec(container, ["env"])
+    assert env_dump.returncode == 0, f"env failed: {env_dump.stderr!r}"
+    env_keys = {
+        line.split("=", 1)[0] for line in env_dump.stdout.splitlines() if "=" in line
+    }
+    assert OPENCODE_SERVER_PASSWORD in env_keys, (
+        f"{OPENCODE_SERVER_PASSWORD} not injected into container env: {env_keys}"
+    )
+    assert "OPENCODE_CONFIG_CONTENT" in env_keys, (
+        f"OPENCODE_CONFIG_CONTENT not injected into container env: {env_keys}"
+    )
+
+
+def test_concurrent_turn_is_rejected(
+    streaming_user: DATestUser,
+    provision_sandbox: ProvisionSandbox,
+) -> None:
+    session_id, _container = provision_sandbox(streaming_user)
+
+    first = BuildSessionManager.start_turn(
+        streaming_user, session_id, "Say hi briefly."
+    )
+    assert first.turn_id
+
+    second = client.post(
+        f"{API_SERVER_URL}/build/sessions/{session_id}/send-message",
+        json={"content": "and again"},
+        headers=streaming_user.headers,
+        cookies=streaming_user.cookies,
+    )
+    assert second.status_code == 409, (
+        f"Concurrent turn was not rejected with CONFLICT: "
+        f"{second.status_code} {second.text!r}"
+    )
+
+
+@_SKIP_NO_LLM_KEY
+def test_simple_message_streams_text_and_terminates(
+    live_session: DockerLiveSession,
+) -> None:
+    user, session_id = live_session
+    out = _drive_turn(user, session_id, "Say hi briefly.")
+
+    assert out.term is not None, "turn never produced a prompt_response terminator"
+    assert out.term.get("stopReason") == "end_turn", (
+        f"unexpected stop reason: {out.term!r}"
+    )
+    assert out.errors == [], f"unexpected errors: {out.errors}"
+    assert len(out.text) > 0, "expected at least one agent_message_chunk"
+    assert "Say hi briefly" not in out.text, (
+        f"user prompt leaked into assistant text: {out.text!r}"
+    )
+
+
+@_SKIP_NO_LLM_KEY
+def test_bash_tool_call_lifecycle(
+    live_session: DockerLiveSession,
+) -> None:
+    user, session_id = live_session
+    out = _drive_turn(
+        user,
+        session_id,
+        "Run the bash command `echo DOCKER_SERVE_OK` and then say DONE.",
+    )
+
+    assert out.term is not None, "turn never terminated"
+    assert out.errors == [], f"unexpected errors: {out.errors}"
+    assert len(out.tool_starts) >= 1, "expected at least one tool_call_start"
+    bash_starts = [s for s in out.tool_starts if s.get("kind") == "execute"]
+    assert len(bash_starts) >= 1, (
+        f"no bash tool call seen; kinds: {[s.get('kind') for s in out.tool_starts]}"
+    )
+    for cid in {s.get("toolCallId") for s in out.tool_starts}:
+        progress = [p for p in out.tool_progress if p.get("toolCallId") == cid]
+        assert any(p.get("status") == "completed" for p in progress), (
+            f"tool call {cid} never reached status=completed; "
+            f"statuses: {[p.get('status') for p in progress]}"
+        )
+
+
+@_SKIP_NO_LLM_KEY
+def test_multi_turn_session_terminates_each_turn(
+    live_session: DockerLiveSession,
+) -> None:
+    user, session_id = live_session
+    for i, prompt in enumerate(
+        [
+            "Say 'one' and nothing else.",
+            "Say 'two' and nothing else.",
+            "Say 'three' and nothing else.",
+        ]
+    ):
+        out = _drive_turn(user, session_id, prompt)
+        assert out.term is not None, f"turn {i + 1} did not terminate"
+        assert out.errors == [], f"turn {i + 1} had errors: {out.errors}"
+        assert len(out.text) > 0, f"turn {i + 1} produced no text"

--- a/backend/tests/integration/tests/craft/docker_e2e/test_snapshot_roundtrip_docker.py
+++ b/backend/tests/integration/tests/craft/docker_e2e/test_snapshot_roundtrip_docker.py
@@ -140,9 +140,8 @@ def test_session_and_opencode_history_survive_snapshot_restore(
     # The container name derives from the sandbox id, which restore keeps
     # stable, so `container` still points at the fresh container. Assert it so a
     # future re-key fails here loudly rather than as a cryptic exec error below.
-    sandbox = restored.sandbox
-    assert sandbox is not None
-    assert sandbox.id == str(sandbox_id), (
+    assert restored.sandbox is not None
+    assert restored.sandbox.id == str(sandbox_id), (
         "Restore changed the sandbox id; the container name derived from the "
         "original id is now stale."
     )

--- a/backend/tests/integration/tests/craft/docker_e2e/test_workspace_setup_docker.py
+++ b/backend/tests/integration/tests/craft/docker_e2e/test_workspace_setup_docker.py
@@ -9,7 +9,6 @@ hydration, and file API operations backed by docker exec.
 
 from __future__ import annotations
 
-from uuid import UUID
 from uuid import uuid4
 
 import pytest
@@ -23,6 +22,7 @@ from tests.integration.common_utils.managers.build_session import BuildSessionMa
 from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.test_models import DATestUser
 from tests.integration.tests.craft.docker_e2e.conftest import DockerExec
+from tests.integration.tests.craft.docker_e2e.conftest import DockerSandbox
 from tests.integration.tests.craft.docker_e2e.conftest import ProvisionSandbox
 
 pytestmark = pytest.mark.skipif(
@@ -40,13 +40,13 @@ def workspace_user() -> DATestUser:
 def workspace_sandbox(
     workspace_user: DATestUser,
     provision_sandbox: ProvisionSandbox,
-) -> tuple[UUID, str]:
+) -> DockerSandbox:
     return provision_sandbox(workspace_user)
 
 
 def test_session_setup_creates_user_writable_workspace(
     workspace_user: DATestUser,
-    workspace_sandbox: tuple[UUID, str],
+    workspace_sandbox: DockerSandbox,
     docker_exec: DockerExec,
 ) -> None:
     """

--- a/docs/craft/features/approvals/phase-5-docker.md
+++ b/docs/craft/features/approvals/phase-5-docker.md
@@ -602,8 +602,8 @@ poison CI.
   containers via `docker run`, assert `lookup` finds them, evicts on
   removal. Skip if `/var/run/docker.sock` is absent.
 
-**Integration** (CI lane mirroring `pr-craft-k8s-tests.yml`): a new
-`pr-craft-compose-tests.yml` lane stands up the docker-compose stack
+**Integration** (Docker compose CI lane): the
+`pr-craft-compose-integration.yml` lane stands up the docker-compose stack
 with the `--include-craft` overlay, provisions a sandbox, triggers a
 gated Slack request via a stand-in matcher, POSTs APPROVE via the
 decision API, and asserts the upstream forward happened. The whole

--- a/docs/craft/features/streaming/docker-opencode-serve.md
+++ b/docs/craft/features/streaming/docker-opencode-serve.md
@@ -135,9 +135,9 @@ Update `docs/craft/opencode-serve-migration.md` §"Migration phases" to note Doc
 
 ## Tests
 
-**External-dependency-unit** (`backend/tests/external_dependency_unit/craft/`):
-- New file `test_docker_sandbox_serve_streaming.py` — mirror `test_opencode_serve_streaming.py` but against a Docker-provisioned sandbox container. Asserts ordered event sequence from `send_message`. Use a no-tools prompt for determinism.
-- Update `test_kubernetes_sandbox_file_ops.py` if any imports churn from the base.py refactor.
+**Docker compose integration** (`backend/tests/integration/tests/craft/docker_e2e/`):
+- `test_serve_streaming_docker.py` keeps the direct transport/event matrix against a Docker-provisioned sandbox container.
+- Follow-up k8s coverage should validate deployed API/Celery turn handoff once that lane is added.
 
 **Unit** (`backend/tests/unit/onyx/server/features/build/sandbox/`):
 - `test_docker_manager_config.py` — extend the env-allowlist assertion to include the four new serve env vars. Assert the OLD allowlist no longer matches (catches regressions in either direction).


### PR DESCRIPTION
## Description

Extracted from mega branch `whuang/real-craft-integration-tests` to reduce rebase conflicts while landing only the Docker compose integration-test coverage.

This PR adds Docker compose Craft coverage for approval-gate decisions, sandbox network posture, opencode serve streaming, snapshot roundtrip, and workspace setup. It also adds the small integration-test helpers needed by those tests and updates the related Craft docs to point at the Docker compose lane.

It intentionally does not delete external-dependency tests, add k8s integration files, or rewrite compose/k8s CI sharding.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands Docker Compose integration coverage for Craft, with end-to-end tests for approval decisions, sandbox network posture, `opencode serve` streaming, snapshot restore, and workspace setup. Adds small helpers and updates docs to point to the compose lane.

- **New Features**
  - Added compose E2E tests for approvals (APPROVE/REJECT/ASK), posture (zero caps/uid 1000, MITM CA, iptables blocks, unlabeled 403, sessions dir ownership), streaming over `opencode serve` (SSE text, tool lifecycle, multi-turn, concurrent turn rejection), snapshot restore, and workspace setup.
  - Added `BuildApprovalsManager.wait_for_pending` and typed `DockerSandbox`; `ProvisionSandbox` now accepts `llm_provider_type`/`llm_model_name` for model pinning; enabled `force=true` on `LLMProviderManager.delete` for reliable cleanup.
  - Streaming tests inject serve env vars, seed a real `openai` provider using `OPENAI_API_KEY` and pin `gpt-5-mini`, then clean up provider and container.
  - Updated Craft docs to reference the `pr-craft-compose-integration.yml` lane.

- **Refactors**
  - Split posture checks into `test_sandbox_network_posture_docker.py`; narrowed approval tests to decision flow with module-scoped sandbox reuse and typed fixtures.
  - Minor assertion/typing cleanups in snapshot and workspace tests.

<sup>Written for commit 9e149c5cebd14e5eff7992137648ddc81b9ca2fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

