### PR TITLE
fix(jira): Gate permission checking behind perm-sync connector access

### DIFF
--- a/backend/onyx/connectors/jira/connector.py
+++ b/backend/onyx/connectors/jira/connector.py
@@ -910,13 +910,10 @@ class JiraConnector(
         self,
         start: SecondsSinceUnixEpoch | None = None,
         end: SecondsSinceUnixEpoch | None = None,
-        callback: IndexingHeartbeatInterface | None = None,
+        callback: IndexingHeartbeatInterface | None = None,  # noqa: ARG002
         *,
         include_permissions: bool,
     ) -> GenerateSlimDocumentOutput:
-        # callback is accepted to mirror the slim-connector interface; the pruning /
-        # perm-sync extract loops drive heartbeat progress themselves.
-        _ = callback
         one_day = timedelta(hours=24).total_seconds()
 
         start = start or 0

--- a/backend/onyx/connectors/jira/connector.py
+++ b/backend/onyx/connectors/jira/connector.py
@@ -34,6 +34,7 @@ from onyx.connectors.interfaces import CheckpointedConnectorWithPermSync
 from onyx.connectors.interfaces import CheckpointOutput
 from onyx.connectors.interfaces import GenerateSlimDocumentOutput
 from onyx.connectors.interfaces import SecondsSinceUnixEpoch
+from onyx.connectors.interfaces import SlimConnector
 from onyx.connectors.interfaces import SlimConnectorWithPermSync
 from onyx.connectors.jira.access import get_project_permissions
 from onyx.connectors.jira.utils import best_effort_basic_expert_info
@@ -509,6 +510,7 @@ class JiraConnectorCheckpoint(ConnectorCheckpoint):
 
 class JiraConnector(
     CheckpointedConnectorWithPermSync[JiraConnectorCheckpoint],
+    SlimConnector,
     SlimConnectorWithPermSync,
 ):
     def __init__(
@@ -882,12 +884,39 @@ class JiraConnector(
             # if we didn't retrieve a full batch, we're done
             checkpoint.has_more = current_offset - starting_offset == page_size
 
+    def retrieve_all_slim_docs(
+        self,
+        start: SecondsSinceUnixEpoch | None = None,
+        end: SecondsSinceUnixEpoch | None = None,
+        callback: IndexingHeartbeatInterface | None = None,
+    ) -> GenerateSlimDocumentOutput:
+        # ID-only path (e.g. pruning): pruning diffs document IDs and never consumes
+        # permission data, so skip the admin-gated per-project permission resolution.
+        yield from self._retrieve_all_slim_docs(
+            start=start, end=end, callback=callback, include_permissions=False
+        )
+
     def retrieve_all_slim_docs_perm_sync(
         self,
         start: SecondsSinceUnixEpoch | None = None,
         end: SecondsSinceUnixEpoch | None = None,
-        callback: IndexingHeartbeatInterface | None = None,  # noqa: ARG002
+        callback: IndexingHeartbeatInterface | None = None,
     ) -> GenerateSlimDocumentOutput:
+        yield from self._retrieve_all_slim_docs(
+            start=start, end=end, callback=callback, include_permissions=True
+        )
+
+    def _retrieve_all_slim_docs(
+        self,
+        start: SecondsSinceUnixEpoch | None = None,
+        end: SecondsSinceUnixEpoch | None = None,
+        callback: IndexingHeartbeatInterface | None = None,
+        *,
+        include_permissions: bool,
+    ) -> GenerateSlimDocumentOutput:
+        # callback is accepted to mirror the slim-connector interface; the pruning /
+        # perm-sync extract loops drive heartbeat progress themselves.
+        _ = callback
         one_day = timedelta(hours=24).total_seconds()
 
         start = start or 0
@@ -954,8 +983,10 @@ class JiraConnector(
                     SlimDocument(
                         id=doc_id,
                         # Permission sync path - don't prefix, upsert_document_external_perms handles it
-                        external_access=self._get_project_permissions(
-                            project_key, add_prefix=False
+                        external_access=(
+                            self._get_project_permissions(project_key, add_prefix=False)
+                            if include_permissions
+                            else None
                         ),
                         parent_hierarchy_raw_node_id=(
                             self._get_parent_hierarchy_raw_node_id(issue, project_key)

--- a/backend/tests/unit/onyx/connectors/jira/test_jira_slim_retrieval.py
+++ b/backend/tests/unit/onyx/connectors/jira/test_jira_slim_retrieval.py
@@ -1,0 +1,123 @@
+from typing import Any
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from jira.resources import Issue
+
+from onyx.access.models import ExternalAccess
+from onyx.connectors.jira.connector import JiraConnector
+from onyx.connectors.jira.connector import JiraConnectorCheckpoint
+from onyx.connectors.models import SlimDocument
+
+
+def _make_issue(key: str, project_key: str = "TEST") -> MagicMock:
+    issue = MagicMock(spec=Issue)
+    issue.key = key
+    issue.fields = MagicMock()
+    issue.fields.project = MagicMock()
+    issue.fields.project.key = project_key
+    issue.fields.project.name = "Test Project"
+    issue.fields.parent = None
+    return issue
+
+
+def _stop_after_first_page(
+    checkpoint: JiraConnectorCheckpoint, *_args: Any, **_kwargs: Any
+) -> None:
+    checkpoint.has_more = False
+
+
+def _slim_docs(result: Any) -> list[SlimDocument]:
+    docs: list[SlimDocument] = []
+    for batch in result:
+        docs.extend(d for d in batch if isinstance(d, SlimDocument))
+    return docs
+
+
+def test_retrieve_all_slim_docs_skips_permission_resolution(
+    jira_connector: JiraConnector,
+) -> None:
+    """The ID-only path (used by pruning) must not call the admin-gated per-project
+    permission endpoint, and must leave external_access unset."""
+    with (
+        patch(
+            "onyx.connectors.jira.connector._perform_jql_search",
+            return_value=[_make_issue("TEST-1"), _make_issue("TEST-2")],
+        ),
+        patch.object(JiraConnector, "_get_project_permissions") as mock_get_permissions,
+        patch.object(
+            JiraConnector, "_yield_project_hierarchy_node", return_value=iter([])
+        ),
+        patch.object(
+            JiraConnector,
+            "_yield_parent_hierarchy_node_if_epic",
+            return_value=iter([]),
+        ),
+        patch.object(
+            JiraConnector, "_yield_epic_hierarchy_node", return_value=iter([])
+        ),
+        patch.object(JiraConnector, "_is_epic", return_value=False),
+        patch.object(
+            JiraConnector, "_get_parent_hierarchy_raw_node_id", return_value=None
+        ),
+        patch.object(
+            JiraConnector,
+            "update_checkpoint_for_next_run",
+            side_effect=_stop_after_first_page,
+        ),
+    ):
+        docs = _slim_docs(jira_connector.retrieve_all_slim_docs())
+
+    assert [d.id for d in docs] == [
+        "https://jira.example.com/browse/TEST-1",
+        "https://jira.example.com/browse/TEST-2",
+    ]
+    assert all(d.external_access is None for d in docs)
+    mock_get_permissions.assert_not_called()
+
+
+def test_retrieve_all_slim_docs_perm_sync_resolves_permissions(
+    jira_connector: JiraConnector,
+) -> None:
+    """The perm-sync path must still resolve external_access per document."""
+    external_access = ExternalAccess(
+        external_user_emails=set(),
+        external_user_group_ids=set(),
+        is_public=True,
+    )
+    with (
+        patch(
+            "onyx.connectors.jira.connector._perform_jql_search",
+            return_value=[_make_issue("TEST-1")],
+        ),
+        patch.object(
+            JiraConnector,
+            "_get_project_permissions",
+            return_value=external_access,
+        ) as mock_get_permissions,
+        patch.object(
+            JiraConnector, "_yield_project_hierarchy_node", return_value=iter([])
+        ),
+        patch.object(
+            JiraConnector,
+            "_yield_parent_hierarchy_node_if_epic",
+            return_value=iter([]),
+        ),
+        patch.object(
+            JiraConnector, "_yield_epic_hierarchy_node", return_value=iter([])
+        ),
+        patch.object(JiraConnector, "_is_epic", return_value=False),
+        patch.object(
+            JiraConnector, "_get_parent_hierarchy_raw_node_id", return_value=None
+        ),
+        patch.object(
+            JiraConnector,
+            "update_checkpoint_for_next_run",
+            side_effect=_stop_after_first_page,
+        ),
+    ):
+        docs = _slim_docs(jira_connector.retrieve_all_slim_docs_perm_sync())
+
+    assert [d.id for d in docs] == ["https://jira.example.com/browse/TEST-1"]
+    assert all(d.external_access is external_access for d in docs)
+    mock_get_permissions.assert_called_once_with("TEST", add_prefix=False)


### PR DESCRIPTION
## Description
Currently the jira connector only implements the `SlimConnectorWithPermSync`. This means that it only implements `retrieve_all_slim_docs_perm_sync` which does perm-sync logic. When someone creates a public or private jira connector, and supplies credentials that don't have the scope to read the permissions, this causes a 403 which errors that entire indexing / pruning run.

This implements a fix by letting the jira connector also implement the SlimConnector. The perm sync logic is then gated.

When the connector is created w/ perm-sync on, it is created as a `SlimConnectorWithPermSync`, otherwise it is just created as a `SlimConnector`.

## How Has This Been Tested?
Tests

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gated Jira permission checks behind perm-sync to avoid 403s when credentials lack permission scopes. Added an ID-only slim retrieval path for pruning; perm-sync still resolves per-project permissions.

- **Bug Fixes**
  - Made `JiraConnector` implement `SlimConnector` alongside `SlimConnectorWithPermSync`.
  - Added shared `_retrieve_all_slim_docs(..., include_permissions=...)` to toggle permission fetching.
  - `retrieve_all_slim_docs` skips `_get_project_permissions`; `retrieve_all_slim_docs_perm_sync` includes it.
  - Added unit tests ensuring ID-only retrieval leaves `external_access` unset and perm-sync sets it.

<sup>Written for commit e0d160ad2c2784d0fa6e9fdf50ba7fa4b2c7a371. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

