### PR TITLE
fix: drive resourcekey usage when following shortcuts (#12446) to release v4.2

### DIFF
--- a/.secretsignore
+++ b/.secretsignore
@@ -6,3 +6,5 @@ iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAIAAACRXR/mAAAAVElEQVR42u3WwQkAIAwDQOP+O9cN+lJU
 # ripsecrets-detected token within the 1x1 PNG data URL used in the
 # docx-preview sanitizer tests (--strict-ignore needs the exact matched token).
 EAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5Erk
+# public drive file that we're okay with anyone looking at
+0Bw48MNL4gSBwWEt2V3BURXVnRnM

--- a/backend/onyx/connectors/google_drive/doc_conversion.py
+++ b/backend/onyx/connectors/google_drive/doc_conversion.py
@@ -23,6 +23,8 @@ from onyx.connectors.cross_connector_utils.tabular_section_utils import (
 )
 from onyx.connectors.google_drive.constants import DRIVE_FOLDER_TYPE
 from onyx.connectors.google_drive.constants import DRIVE_SHORTCUT_TYPE
+from onyx.connectors.google_drive.file_retrieval import add_drive_resource_key_header
+from onyx.connectors.google_drive.file_retrieval import DRIVE_RESOURCE_KEY_FIELD
 from onyx.connectors.google_drive.models import GDriveMimeType
 from onyx.connectors.google_drive.models import GoogleDriveFileType
 from onyx.connectors.google_drive.section_extraction import get_document_sections
@@ -261,7 +263,10 @@ def onyx_document_id_from_drive_file(file: GoogleDriveFileType) -> str:
 
 
 def download_request(
-    service: GoogleDriveService, file_id: str, size_threshold: int
+    service: GoogleDriveService,
+    file_id: str,
+    size_threshold: int,
+    resource_key: str | None = None,
 ) -> bytes:
     """
     Download the file from Google Drive.
@@ -271,6 +276,7 @@ def download_request(
     request = service.files().get_media(  # ty: ignore[unresolved-attribute]
         fileId=file_id
     )
+    add_drive_resource_key_header(request, file_id, resource_key)
     return _download_request(request, file_id, size_threshold)
 
 
@@ -314,13 +320,14 @@ def _download_and_extract_sections_basic(
     file_id = file["id"]
     file_name = file["name"]
     mime_type = file["mimeType"]
+    resource_key = file.get(DRIVE_RESOURCE_KEY_FIELD)
     link = file.get(WEB_VIEW_LINK_KEY, "")
 
     # For non-Google files, download the file
     # Use the correct API call for downloading files
     # lazy evaluation to only download the file if necessary
     def response_call() -> bytes:
-        return download_request(service, file_id, size_threshold)
+        return download_request(service, file_id, size_threshold, resource_key)
 
     def _extract_tabular(
         raw_bytes: bytes, name: str, content_type: str
@@ -374,6 +381,7 @@ def _download_and_extract_sections_basic(
         request = service.files().export_media(  # ty: ignore[unresolved-attribute]
             fileId=file_id, mimeType=export_mime_type
         )
+        add_drive_resource_key_header(request, file_id, resource_key)
         response = _download_request(request, file_id, size_threshold)
         if not response:
             logger.warning("Failed to export %s as %s", file_name, export_mime_type)

--- a/backend/onyx/connectors/google_drive/file_retrieval.py
+++ b/backend/onyx/connectors/google_drive/file_retrieval.py
@@ -3,6 +3,7 @@ from collections.abc import Iterator
 from datetime import datetime
 from datetime import timezone
 from enum import Enum
+from typing import Any
 from typing import cast
 from urllib.parse import parse_qs
 from urllib.parse import urlparse
@@ -34,6 +35,9 @@ from onyx.utils.variable_functionality import (
 from onyx.utils.variable_functionality import noop_fallback
 
 logger = setup_logger()
+
+DRIVE_RESOURCE_KEY_HEADER = "X-Goog-Drive-Resource-Keys"
+DRIVE_RESOURCE_KEY_FIELD = "resourceKey"
 
 
 class DriveFileFieldType(Enum):
@@ -262,6 +266,14 @@ def _get_single_file_fields(field_type: DriveFileFieldType) -> str:
     return _extract_single_file_fields(_get_fields_for_file_type(field_type))
 
 
+def add_drive_resource_key_header(
+    request: Any, file_id: str, resource_key: str | None
+) -> None:
+    if not resource_key:
+        return
+    request.headers[DRIVE_RESOURCE_KEY_HEADER] = f"{file_id}/{resource_key}"
+
+
 def _get_file_by_id(
     service: Resource,
     file_id: str,
@@ -273,11 +285,14 @@ def _get_file_by_id(
         "fields": fields,
         "supportsAllDrives": True,
     }
-    if resource_key:
-        kwargs["resourceKey"] = resource_key
 
     try:
-        return service.files().get(**kwargs).execute()  # ty: ignore[unresolved-attribute]
+        request = service.files().get(**kwargs)  # ty: ignore[unresolved-attribute]
+        add_drive_resource_key_header(request, file_id, resource_key)
+        file = request.execute()
+        if resource_key:
+            file[DRIVE_RESOURCE_KEY_FIELD] = resource_key
+        return file
     except HttpError as e:
         if e.resp.status in (403, 404):
             logger.debug("Cannot access Drive file %s: %s", file_id, e)

--- a/backend/tests/daily/connectors/google_drive/consts_and_utils.py
+++ b/backend/tests/daily/connectors/google_drive/consts_and_utils.py
@@ -34,6 +34,8 @@ SECTIONS_FILE_IDS = [61]
 FOLDER_3_FILE_IDS = list(range(62, 65))
 
 DONWLOAD_REVOKED_FILE_ID = 21
+RESOURCE_KEY_SHORTCUT_TARGET_DOC_ID = "0Bw48MNL4gSBwWEt2V3BURXVnRnM"
+RESOURCE_KEY_SHORTCUT_TARGET_NAME = "config.yml"
 
 PUBLIC_FOLDER_RANGE = FOLDER_1_2_FILE_IDS
 PUBLIC_FILE_IDS = list(range(55, 57))
@@ -617,6 +619,17 @@ def assert_expected_docs_in_retrieved_docs(
         retrieved=valid_retrieved_texts,
     )
     assert expected_file_texts == valid_retrieved_texts
+
+
+def assert_resource_key_shortcut_target_in_retrieved_docs(
+    retrieved_docs: list[Document],
+) -> None:
+    docs_by_name = {doc.semantic_identifier: doc for doc in retrieved_docs}
+    assert RESOURCE_KEY_SHORTCUT_TARGET_NAME in docs_by_name
+    assert (
+        RESOURCE_KEY_SHORTCUT_TARGET_DOC_ID
+        in docs_by_name[RESOURCE_KEY_SHORTCUT_TARGET_NAME].id
+    )
 
 
 def load_connector_outputs(

--- a/backend/tests/daily/connectors/google_drive/test_admin_oauth.py
+++ b/backend/tests/daily/connectors/google_drive/test_admin_oauth.py
@@ -19,6 +19,9 @@ from tests.daily.connectors.google_drive.consts_and_utils import (
 from tests.daily.connectors.google_drive.consts_and_utils import (
     assert_hierarchy_nodes_match_expected,
 )
+from tests.daily.connectors.google_drive.consts_and_utils import (
+    assert_resource_key_shortcut_target_in_retrieved_docs,
+)
 from tests.daily.connectors.google_drive.consts_and_utils import FOLDER_1_1_FILE_IDS
 from tests.daily.connectors.google_drive.consts_and_utils import FOLDER_1_1_URL
 from tests.daily.connectors.google_drive.consts_and_utils import FOLDER_1_2_FILE_IDS
@@ -104,6 +107,7 @@ def test_include_all(
         retrieved_docs=output.documents,
         expected_file_ids=expected_file_ids,
     )
+    assert_resource_key_shortcut_target_in_retrieved_docs(output.documents)
 
     expected_nodes = get_expected_hierarchy_for_shared_drives(
         include_drive_1=True,
@@ -216,6 +220,7 @@ def test_include_my_drives_only(
         retrieved_docs=output.documents,
         expected_file_ids=expected_file_ids,
     )
+    assert_resource_key_shortcut_target_in_retrieved_docs(output.documents)
 
     expected_nodes = _pick(
         FOLDER_3_ID,

--- a/backend/tests/daily/connectors/google_drive/test_drive_perm_sync.py
+++ b/backend/tests/daily/connectors/google_drive/test_drive_perm_sync.py
@@ -27,6 +27,9 @@ from tests.daily.connectors.google_drive.consts_and_utils import (
     assert_hierarchy_nodes_match_expected,
 )
 from tests.daily.connectors.google_drive.consts_and_utils import (
+    assert_resource_key_shortcut_target_in_retrieved_docs,
+)
+from tests.daily.connectors.google_drive.consts_and_utils import (
     EXTERNAL_SHARED_FOLDER_ID,
 )
 from tests.daily.connectors.google_drive.consts_and_utils import FOLDER_3_ID
@@ -91,7 +94,12 @@ def _build_connector(
 
 
 @pytest.mark.secrets(TestSecret.GOOGLE_DRIVE_SERVICE_ACCOUNT_JSON_STR)
+@patch(
+    "onyx.file_processing.extract_file_text.get_unstructured_api_key",
+    return_value=None,
+)
 def test_gdrive_perm_sync_with_real_data(
+    mock_get_api_key: MagicMock,  # noqa: ARG001
     google_drive_service_acct_connector_factory: Callable[..., GoogleDriveConnector],
     enable_ee: None,  # noqa: ARG001
 ) -> None:
@@ -255,6 +263,7 @@ def test_gdrive_perm_sync_with_real_data(
     # Use include_permissions=True to populate external_access on hierarchy nodes
     hierarchy_connector = _build_connector(google_drive_service_acct_connector_factory)
     output = load_connector_outputs(hierarchy_connector, include_permissions=True)
+    assert_resource_key_shortcut_target_in_retrieved_docs(output.documents)
 
     expected_nodes = get_expected_hierarchy_for_shared_drives(
         include_drive_1=True,

--- a/backend/tests/daily/connectors/google_drive/test_gdrive_shortcuts_daily.py
+++ b/backend/tests/daily/connectors/google_drive/test_gdrive_shortcuts_daily.py
@@ -8,7 +8,16 @@ from onyx.connectors.google_drive.connector import GoogleDriveConnector
 from onyx.connectors.models import Document
 from onyx.connectors.models import TextSection
 from tests.daily.connectors.google_drive.consts_and_utils import ADMIN_EMAIL
+from tests.daily.connectors.google_drive.consts_and_utils import (
+    assert_resource_key_shortcut_target_in_retrieved_docs,
+)
 from tests.daily.connectors.google_drive.consts_and_utils import load_connector_outputs
+from tests.daily.connectors.google_drive.consts_and_utils import (
+    RESOURCE_KEY_SHORTCUT_TARGET_DOC_ID,
+)
+from tests.daily.connectors.google_drive.consts_and_utils import (
+    RESOURCE_KEY_SHORTCUT_TARGET_NAME,
+)
 from tests.daily.connectors.google_drive.consts_and_utils import (
     SHORTCUTS_GALORE_FOLDER_ID,
 )
@@ -25,6 +34,7 @@ SILLY_GUY_DOC_ID = "1l1eAJy9llAQBa3fcOpjLijswXi2fiDJFGst0EmVONk0"
 NUMBER_2_DOC_ID = "1TJN3XJ-rzfnIv0qdyiKdXp__FJt1npRqp3WKLO3R-dM"
 
 EXPECTED_DOC_NAMES = {
+    RESOURCE_KEY_SHORTCUT_TARGET_NAME,
     "just checking",
     "file_0.txt",
     "file_1.txt",
@@ -74,6 +84,8 @@ def test_shared_folder_shortcuts_resolve_files_and_folders(
     assert JUST_CHECKING_DOC_ID in retrieved_ids
     assert SILLY_GUY_DOC_ID in retrieved_ids
     assert NUMBER_2_DOC_ID in retrieved_ids
+    assert RESOURCE_KEY_SHORTCUT_TARGET_DOC_ID in retrieved_ids
+    assert_resource_key_shortcut_target_in_retrieved_docs(output.documents)
 
     assert _doc_text(docs_by_name["file_0.txt"]) == "This is file 0"
     assert _doc_text(docs_by_name["file_1.txt"]) == "This is file 1"

--- a/backend/tests/daily/connectors/google_drive/test_service_acct.py
+++ b/backend/tests/daily/connectors/google_drive/test_service_acct.py
@@ -22,6 +22,9 @@ from tests.daily.connectors.google_drive.consts_and_utils import (
     assert_hierarchy_nodes_match_expected,
 )
 from tests.daily.connectors.google_drive.consts_and_utils import (
+    assert_resource_key_shortcut_target_in_retrieved_docs,
+)
+from tests.daily.connectors.google_drive.consts_and_utils import (
     EXTERNAL_SHARED_DOC_SINGLETON,
 )
 from tests.daily.connectors.google_drive.consts_and_utils import (
@@ -146,6 +149,7 @@ def test_include_all(
         retrieved_docs=output.documents,
         expected_file_ids=expected_file_ids,
     )
+    assert_resource_key_shortcut_target_in_retrieved_docs(output.documents)
 
     expected_nodes = get_expected_hierarchy_for_shared_drives(
         include_drive_1=True,
@@ -338,6 +342,7 @@ def test_include_my_drives_only(
         retrieved_docs=output.documents,
         expected_file_ids=expected_file_ids,
     )
+    assert_resource_key_shortcut_target_in_retrieved_docs(output.documents)
 
     expected_nodes = _pick(
         FOLDER_3_ID,
@@ -528,7 +533,12 @@ def test_shared_folder_owned_by_external_user(
     assert expected_docs[0] in output.documents[0].id
 
 
+@patch(
+    "onyx.file_processing.extract_file_text.get_unstructured_api_key",
+    return_value=None,
+)
 def test_shared_with_me(
+    mock_get_api_key: MagicMock,  # noqa: ARG001
     google_drive_service_acct_connector_factory: Callable[..., GoogleDriveConnector],
 ) -> None:
     print("\n\nRunning test_shared_with_me")
@@ -556,6 +566,7 @@ def test_shared_with_me(
         retrieved_docs=output.documents,
         expected_file_ids=expected_file_ids,
     )
+    assert_resource_key_shortcut_target_in_retrieved_docs(output.documents)
 
     retrieved_ids = {urlparse(doc.id).path.split("/")[-1] for doc in output.documents}
     for id in retrieved_ids:

--- a/backend/tests/unit/onyx/connectors/google_drive/test_drive_shortcut_following.py
+++ b/backend/tests/unit/onyx/connectors/google_drive/test_drive_shortcut_following.py
@@ -10,8 +10,11 @@ from googleapiclient.discovery import Resource
 from onyx.connectors.google_drive.constants import DRIVE_FOLDER_TYPE
 from onyx.connectors.google_drive.constants import DRIVE_SHORTCUT_TYPE
 from onyx.connectors.google_drive.doc_conversion import convert_drive_item_to_document
+from onyx.connectors.google_drive.doc_conversion import download_request
 from onyx.connectors.google_drive.file_retrieval import _get_files_in_parent
 from onyx.connectors.google_drive.file_retrieval import crawl_folders_for_files
+from onyx.connectors.google_drive.file_retrieval import DRIVE_RESOURCE_KEY_FIELD
+from onyx.connectors.google_drive.file_retrieval import DRIVE_RESOURCE_KEY_HEADER
 from onyx.connectors.google_drive.file_retrieval import DriveFileFieldType
 from onyx.connectors.google_drive.models import DriveRetrievalStage
 
@@ -22,6 +25,7 @@ _PDF_MIME_TYPE = "application/pdf"
 class _FakeRequest:
     def __init__(self, response: dict[str, Any]) -> None:
         self._response = response
+        self.headers: dict[str, str] = {}
 
     def execute(self) -> dict[str, Any]:
         return self._response
@@ -31,13 +35,26 @@ class _FakeFilesResource:
     def __init__(self, files_by_id: dict[str, dict[str, Any]]) -> None:
         self.files_by_id = files_by_id
         self.get_calls: list[dict[str, Any]] = []
+        self.get_requests: list[_FakeRequest] = []
 
     def list(self, **_kwargs: object) -> object:
         return object()
 
     def get(self, **kwargs: Any) -> _FakeRequest:
+        if "resourceKey" in kwargs:
+            raise TypeError("Got an unexpected keyword argument resourceKey")
         self.get_calls.append(kwargs)
-        return _FakeRequest(self.files_by_id[kwargs["fileId"]])
+        request = _FakeRequest(self.files_by_id[kwargs["fileId"]])
+        self.get_requests.append(request)
+        return request
+
+    def get_media(self, **kwargs: Any) -> _FakeRequest:
+        if "resourceKey" in kwargs:
+            raise TypeError("Got an unexpected keyword argument resourceKey")
+        self.get_calls.append(kwargs)
+        request = _FakeRequest(self.files_by_id.get(kwargs["fileId"], {}))
+        self.get_requests.append(request)
+        return request
 
 
 class _FakeDriveService:
@@ -52,15 +69,20 @@ def _shortcut(
     shortcut_id: str,
     target_id: str,
     target_mime_type: str,
+    target_resource_key: str | None = None,
 ) -> dict[str, Any]:
+    shortcut_details = {
+        "targetId": target_id,
+        "targetMimeType": target_mime_type,
+    }
+    if target_resource_key:
+        shortcut_details["targetResourceKey"] = target_resource_key
+
     return {
         "id": shortcut_id,
         "name": shortcut_id,
         "mimeType": DRIVE_SHORTCUT_TYPE,
-        "shortcutDetails": {
-            "targetId": target_id,
-            "targetMimeType": target_mime_type,
-        },
+        "shortcutDetails": shortcut_details,
     }
 
 
@@ -120,6 +142,71 @@ def test_shortcut_to_file_yields_target_with_true_parent() -> None:
     assert files == [target]
     assert service.files_resource.get_calls[0]["fileId"] == "target_file"
     assert len(service.files_resource.get_calls) == 1
+
+
+def test_shortcut_to_resource_key_file_uses_header() -> None:
+    target = _target_file("target_file", "true_parent")
+    service = _FakeDriveService(
+        {
+            "shortcut_file": _shortcut(
+                "shortcut_file",
+                "target_file",
+                _PDF_MIME_TYPE,
+                target_resource_key="resource_key",
+            ),
+            "target_file": target,
+        }
+    )
+
+    def _fake_paginated_retrieval(**_kwargs: object) -> Iterator[dict[str, Any]]:
+        yield _shortcut(
+            "shortcut_file",
+            "target_file",
+            _PDF_MIME_TYPE,
+            target_resource_key="resource_key",
+        )
+
+    with patch(
+        f"{_FILE_RETRIEVAL_MODULE}.execute_paginated_retrieval",
+        side_effect=_fake_paginated_retrieval,
+    ):
+        files = list(
+            _get_files_in_parent(
+                service=cast(Resource, service),
+                parent_id="shortcut_parent",
+                field_type=DriveFileFieldType.STANDARD,
+            )
+        )
+
+    assert files == [target]
+    assert service.files_resource.get_calls[0]["fileId"] == "target_file"
+    assert "resourceKey" not in service.files_resource.get_calls[0]
+    assert service.files_resource.get_requests[0].headers == {
+        DRIVE_RESOURCE_KEY_HEADER: "target_file/resource_key"
+    }
+    assert target[DRIVE_RESOURCE_KEY_FIELD] == "resource_key"
+
+
+def test_resource_key_download_uses_header() -> None:
+    service = _FakeDriveService({})
+
+    with patch(
+        "onyx.connectors.google_drive.doc_conversion._download_request",
+        return_value=b"content",
+    ) as mock_download:
+        content = download_request(
+            cast(Any, service),
+            file_id="target_file",
+            size_threshold=1_000,
+            resource_key="resource_key",
+        )
+
+    assert content == b"content"
+    assert service.files_resource.get_calls[0] == {"fileId": "target_file"}
+    assert service.files_resource.get_requests[0].headers == {
+        DRIVE_RESOURCE_KEY_HEADER: "target_file/resource_key"
+    }
+    mock_download.assert_called_once()
 
 
 def test_shortcut_to_folder_crawls_target_folder() -> None:


### PR DESCRIPTION
Cherry-pick of commit 203fc8b5223f73ae24d38de1a24223e15e3606b7 to release/v4.2 branch.

Original PR: #12446

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Google Drive shortcut handling by sending the resource key in headers when resolving and downloading shortcut targets. This prevents 403/404s and ensures files behind resource-keyed links are indexed correctly.

- **Bug Fixes**
  - Add `add_drive_resource_key_header` to set `X-Goog-Drive-Resource-Keys` on `files().get`, `get_media`, and `export_media`.
  - Use header instead of `resourceKey` query param; persist the key on the file as `resourceKey` for downstream downloads.
  - Extend `download_request(...)` to accept `resource_key` and pass it through for both binary downloads and exports.
  - Update tests to assert header usage and presence of resource-key shortcut targets; add a public Drive file ID to `.secretsignore` for test stability.

<sup>Written for commit 1af7c91f7667e50400fe203bec97ded3f7573722. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

