### PR TITLE
chore: llm error message details

### DIFF
--- a/backend/onyx/llm/utils.py
+++ b/backend/onyx/llm/utils.py
@@ -198,7 +198,7 @@ def litellm_exception_to_error_msg(
         error_code = "CONTENT_POLICY"
         is_retryable = False
     elif isinstance(core_exception, BadRequestError):
-        error_msg = "Bad request: The server couldn't process your request. Please check your input."
+        error_msg = f"Bad request: {str(core_exception)}"
         error_code = "BAD_REQUEST"
         is_retryable = True
     elif isinstance(core_exception, AuthenticationError):
@@ -207,13 +207,13 @@ def litellm_exception_to_error_msg(
         is_retryable = False
     elif isinstance(core_exception, PermissionDeniedError):
         error_msg = (
-            "Permission denied: You don't have the necessary permissions for this operation. "
+            f"Permission denied: {str(core_exception)}"
             "Ensure you have access to this model."
         )
         error_code = "PERMISSION_DENIED"
         is_retryable = False
     elif isinstance(core_exception, NotFoundError):
-        error_msg = "Resource not found: The requested resource doesn't exist."
+        error_msg = f"Resource not found: {str(core_exception)}"
         error_code = "NOT_FOUND"
         is_retryable = False
     elif isinstance(core_exception, UnprocessableEntityError):


### PR DESCRIPTION
## Description

our error messages from litellm were dropping some important details, and we already strip out API keys in the caller.

## How Has This Been Tested?

n/a

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include detailed `litellm` exception text in errors for bad requests, permission denied, and not found, so users see why a call failed. API keys remain hidden because redaction happens in the caller.

<sup>Written for commit f88cc06e1abbbb456b58cf6f57299cf9d7eea164. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

