### PR TITLE
fix(web): suppress x-powered-by Next.js header

### DIFF
--- a/web/next.config.js
+++ b/web/next.config.js
@@ -5,6 +5,7 @@ const { PHASE_DEVELOPMENT_SERVER } = require("next/constants");
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   productionBrowserSourceMaps: false,
+  poweredByHeader: false,
   output: "standalone",
   transpilePackages: ["@onyx-ai/opal", "@onyx-ai/shared"],
   typedRoutes: true,


### PR DESCRIPTION
## Problem

Next.js emits `x-powered-by: Next.js` on every response because `web/next.config.js` does not disable it. This is a minor information disclosure issue (framework fingerprinting).

## Fix

Add `poweredByHeader: false` to the `nextConfig` object in `web/next.config.js`. Next.js then omits the `x-powered-by` header from all responses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable the `x-powered-by: Next.js` response header across the web app by setting `poweredByHeader: false` in `web/next.config.js` to reduce framework fingerprinting.

<sup>Written for commit 8a308b3944e4fc0438e13f88179ed94f5eb210f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

