### PR TITLE
feat(fe): Save session drafts in the chat and agent creation text bars

### DIFF
--- a/web/jest.config.js
+++ b/web/jest.config.js
@@ -169,6 +169,7 @@ module.exports = {
         "**/src/refresh-pages/**/*.test.tsx",
         "**/src/hooks/**/*.test.tsx",
         "**/src/sections/**/*.test.tsx",
+        "**/src/views/**/*.test.tsx",
         // Add more patterns here as you add more integration tests
       ],
     },

--- a/web/src/hooks/__tests__/useDraft.test.tsx
+++ b/web/src/hooks/__tests__/useDraft.test.tsx
@@ -1,0 +1,257 @@
+import { renderHook, act } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { useCallback, useEffect, useRef } from "react";
+import { useDraft, draftKey, clearDraft } from "@/hooks/useDraft";
+
+const KEY = draftKey("test", "1");
+
+describe("useDraft", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    sessionStorage.clear();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  it("debounces writes to storage", () => {
+    const { result } = renderHook(() => useDraft<string>({ key: KEY }));
+
+    act(() => {
+      result.current.save("hello");
+    });
+    // Nothing written yet: still inside the debounce window.
+    expect(sessionStorage.getItem(KEY)).toBeNull();
+
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+    expect(JSON.parse(sessionStorage.getItem(KEY)!)).toBe("hello");
+  });
+
+  it("collapses rapid writes into a single trailing write", () => {
+    const { result } = renderHook(() => useDraft<string>({ key: KEY }));
+
+    act(() => {
+      result.current.save("a");
+      result.current.save("ab");
+      result.current.save("abc");
+    });
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+    expect(JSON.parse(sessionStorage.getItem(KEY)!)).toBe("abc");
+  });
+
+  it("restores an existing draft on mount", () => {
+    sessionStorage.setItem(KEY, JSON.stringify("saved"));
+
+    const { result } = renderHook(() => useDraft<string>({ key: KEY }));
+
+    expect(result.current.loaded).toBe(true);
+    expect(result.current.draft).toBe("saved");
+    expect(result.current.hasDraft).toBe(true);
+  });
+
+  it("reports no draft when storage is empty", () => {
+    const { result } = renderHook(() => useDraft<string>({ key: KEY }));
+
+    expect(result.current.loaded).toBe(true);
+    expect(result.current.draft).toBeNull();
+    expect(result.current.hasDraft).toBe(false);
+  });
+
+  it("clear() removes the draft and cancels a pending write", () => {
+    sessionStorage.setItem(KEY, JSON.stringify("saved"));
+    const { result } = renderHook(() => useDraft<string>({ key: KEY }));
+
+    act(() => {
+      result.current.save("new value");
+      result.current.clear();
+    });
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    expect(sessionStorage.getItem(KEY)).toBeNull();
+    expect(result.current.draft).toBeNull();
+  });
+
+  it("skips empty and whitespace-only values, removing any existing key", () => {
+    sessionStorage.setItem(KEY, JSON.stringify("saved"));
+    const { result } = renderHook(() => useDraft<string>({ key: KEY }));
+
+    act(() => {
+      result.current.save("   ");
+    });
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    expect(sessionStorage.getItem(KEY)).toBeNull();
+  });
+
+  it("does not restore a whitespace-only stored value", () => {
+    sessionStorage.setItem(KEY, JSON.stringify("   "));
+    const { result } = renderHook(() => useDraft<string>({ key: KEY }));
+
+    expect(result.current.hasDraft).toBe(false);
+  });
+
+  it("isolates drafts stored under different keys", () => {
+    const keyA = draftKey("test", "a");
+    const keyB = draftKey("test", "b");
+    sessionStorage.setItem(keyA, JSON.stringify("value-a"));
+    sessionStorage.setItem(keyB, JSON.stringify("value-b"));
+
+    const { result: resultA } = renderHook(() =>
+      useDraft<string>({ key: keyA })
+    );
+    const { result: resultB } = renderHook(() =>
+      useDraft<string>({ key: keyB })
+    );
+
+    expect(resultA.current.draft).toBe("value-a");
+    expect(resultB.current.draft).toBe("value-b");
+  });
+
+  it("re-reads when the key changes", () => {
+    const keyA = draftKey("test", "a");
+    const keyB = draftKey("test", "b");
+    sessionStorage.setItem(keyA, JSON.stringify("value-a"));
+    sessionStorage.setItem(keyB, JSON.stringify("value-b"));
+
+    const { result, rerender } = renderHook(
+      ({ key }) => useDraft<string>({ key }),
+      { initialProps: { key: keyA } }
+    );
+    expect(result.current.draft).toBe("value-a");
+
+    rerender({ key: keyB });
+    expect(result.current.draft).toBe("value-b");
+  });
+
+  // Regression: a key change must produce a real false->true `loaded` edge. The
+  // old impl batched setLoaded(false)+setLoaded(true) in one effect, so
+  // `loaded` stayed true across the switch and consumers never re-seeded.
+  it("drops loaded to false on the render right after the key changes", () => {
+    const keyA = draftKey("test", "a");
+    const keyB = draftKey("test", "b");
+
+    const loadedHistory: boolean[] = [];
+    const { rerender } = renderHook(
+      ({ key }) => {
+        const r = useDraft<string>({ key });
+        loadedHistory.push(r.loaded);
+        return r;
+      },
+      { initialProps: { key: keyA } }
+    );
+
+    loadedHistory.length = 0; // ignore mount; focus on the key change
+    rerender({ key: keyB });
+
+    expect(loadedHistory).toContain(false);
+    expect(loadedHistory[loadedHistory.length - 1]).toBe(true);
+  });
+
+  // Regression for the real-world bug: a draft consumer that gates saves on the
+  // loaded edge (re-arm on key change, set seeded once loaded, save only when
+  // seeded) must keep saving after the key flips -- e.g. a new chat session
+  // gaining its real id once the first message is sent. Mirrors AppInputBar.
+  it("still persists after a key change under loaded-edge save gating", () => {
+    const keyA = draftKey("chat", "new");
+    const keyB = draftKey("chat", "123");
+
+    function useGatedDraft(key: string) {
+      const { loaded, draft, save } = useDraft<string>({ key });
+      const seededRef = useRef(false);
+      useEffect(() => {
+        seededRef.current = false;
+      }, [key]);
+      useEffect(() => {
+        if (!loaded || seededRef.current) return;
+        seededRef.current = true;
+      }, [loaded, draft]);
+      const trySave = useCallback(
+        (value: string) => {
+          if (!loaded || !seededRef.current) return;
+          save(value);
+        },
+        [loaded, save]
+      );
+      return { trySave };
+    }
+
+    const { result, rerender } = renderHook(({ key }) => useGatedDraft(key), {
+      initialProps: { key: keyA },
+    });
+
+    rerender({ key: keyB });
+
+    act(() => {
+      result.current.trySave("draft-for-b");
+    });
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    expect(JSON.parse(sessionStorage.getItem(keyB)!)).toBe("draft-for-b");
+  });
+
+  it("uses localStorage when backend is 'local'", () => {
+    const { result } = renderHook(() =>
+      useDraft<string>({ key: KEY, backend: "local" })
+    );
+
+    act(() => {
+      result.current.save("persisted");
+    });
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    expect(JSON.parse(localStorage.getItem(KEY)!)).toBe("persisted");
+    expect(sessionStorage.getItem(KEY)).toBeNull();
+  });
+
+  it("survives storage access throwing (blocked/SSR-like environments)", () => {
+    const getItemSpy = jest
+      .spyOn(Storage.prototype, "getItem")
+      .mockImplementation(() => {
+        throw new Error("blocked");
+      });
+    const setItemSpy = jest
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new Error("blocked");
+      });
+
+    const { result } = renderHook(() => useDraft<string>({ key: KEY }));
+    expect(result.current.draft).toBeNull();
+    expect(result.current.loaded).toBe(true);
+
+    act(() => {
+      result.current.save("hello");
+    });
+    expect(() =>
+      act(() => {
+        jest.advanceTimersByTime(300);
+      })
+    ).not.toThrow();
+
+    getItemSpy.mockRestore();
+    setItemSpy.mockRestore();
+  });
+
+  it("clearDraft helper removes a key directly", () => {
+    sessionStorage.setItem(KEY, JSON.stringify("saved"));
+    clearDraft(KEY);
+    expect(sessionStorage.getItem(KEY)).toBeNull();
+  });
+});

--- a/web/src/hooks/__tests__/useDraft.test.tsx
+++ b/web/src/hooks/__tests__/useDraft.test.tsx
@@ -24,7 +24,6 @@ describe("useDraft", () => {
     act(() => {
       result.current.save("hello");
     });
-    // Nothing written yet: still inside the debounce window.
     expect(sessionStorage.getItem(KEY)).toBeNull();
 
     act(() => {
@@ -130,13 +129,11 @@ describe("useDraft", () => {
     act(() => {
       result.current.save("typed under a");
     });
-    // Switch keys before the debounce fires (e.g. chat:new -> real session id).
     rerender({ key: keyB });
     act(() => {
       jest.advanceTimersByTime(300);
     });
 
-    // The stale timer must not resurrect the old key's value.
     expect(sessionStorage.getItem(keyA)).toBeNull();
     expect(sessionStorage.getItem(keyB)).toBeNull();
   });
@@ -157,9 +154,8 @@ describe("useDraft", () => {
     expect(result.current.draft).toBe("value-b");
   });
 
-  // Regression: a key change must produce a real false->true `loaded` edge. The
-  // old impl batched setLoaded(false)+setLoaded(true) in one effect, so
-  // `loaded` stayed true across the switch and consumers never re-seeded.
+  // Consumers rely on this edge to re-seed; a key change must drop loaded to
+  // false.
   it("drops loaded to false on the render right after the key changes", () => {
     const keyA = draftKey("test", "a");
     const keyB = draftKey("test", "b");
@@ -174,17 +170,14 @@ describe("useDraft", () => {
       { initialProps: { key: keyA } }
     );
 
-    loadedHistory.length = 0; // ignore mount; focus on the key change
+    loadedHistory.length = 0; // ignore mount
     rerender({ key: keyB });
 
     expect(loadedHistory).toContain(false);
     expect(loadedHistory[loadedHistory.length - 1]).toBe(true);
   });
 
-  // Regression for the real-world bug: a draft consumer that gates saves on the
-  // loaded edge (re-arm on key change, set seeded once loaded, save only when
-  // seeded) must keep saving after the key flips -- e.g. a new chat session
-  // gaining its real id once the first message is sent. Mirrors AppInputBar.
+  // Mirrors AppInputBar's loaded-edge save gating across a key flip.
   it("still persists after a key change under loaded-edge save gating", () => {
     const keyA = draftKey("chat", "new");
     const keyB = draftKey("chat", "123");
@@ -225,14 +218,9 @@ describe("useDraft", () => {
     expect(JSON.parse(sessionStorage.getItem(keyB)!)).toBe("draft-for-b");
   });
 
-  // Regression for the enqueue path: when a typed message is committed to the
-  // queue, AppInputBar empties the input (a debounced empty-save) and then
-  // calls clear() explicitly. clear() must remove the draft synchronously so a
-  // reload in the debounce window can't resurrect the already-queued message.
   it("clear() drops a persisted draft immediately, not on the debounce", () => {
     const { result } = renderHook(() => useDraft<string>({ key: KEY }));
 
-    // User typed a message and it reached storage.
     act(() => {
       result.current.save("queued message");
     });
@@ -241,13 +229,11 @@ describe("useDraft", () => {
     });
     expect(sessionStorage.getItem(KEY)).not.toBeNull();
 
-    // Enqueue: empty-save is scheduled (debounced), then clear() fires.
     act(() => {
       result.current.save("");
       result.current.clear();
     });
 
-    // Gone right away, without waiting out the debounce.
     expect(sessionStorage.getItem(KEY)).toBeNull();
   });
 

--- a/web/src/hooks/__tests__/useDraft.test.tsx
+++ b/web/src/hooks/__tests__/useDraft.test.tsx
@@ -225,6 +225,32 @@ describe("useDraft", () => {
     expect(JSON.parse(sessionStorage.getItem(keyB)!)).toBe("draft-for-b");
   });
 
+  // Regression for the enqueue path: when a typed message is committed to the
+  // queue, AppInputBar empties the input (a debounced empty-save) and then
+  // calls clear() explicitly. clear() must remove the draft synchronously so a
+  // reload in the debounce window can't resurrect the already-queued message.
+  it("clear() drops a persisted draft immediately, not on the debounce", () => {
+    const { result } = renderHook(() => useDraft<string>({ key: KEY }));
+
+    // User typed a message and it reached storage.
+    act(() => {
+      result.current.save("queued message");
+    });
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+    expect(sessionStorage.getItem(KEY)).not.toBeNull();
+
+    // Enqueue: empty-save is scheduled (debounced), then clear() fires.
+    act(() => {
+      result.current.save("");
+      result.current.clear();
+    });
+
+    // Gone right away, without waiting out the debounce.
+    expect(sessionStorage.getItem(KEY)).toBeNull();
+  });
+
   it("survives storage access throwing (blocked/SSR-like environments)", () => {
     const getItemSpy = jest
       .spyOn(Storage.prototype, "getItem")

--- a/web/src/hooks/__tests__/useDraft.test.tsx
+++ b/web/src/hooks/__tests__/useDraft.test.tsx
@@ -9,7 +9,6 @@ describe("useDraft", () => {
   beforeEach(() => {
     jest.useFakeTimers();
     sessionStorage.clear();
-    localStorage.clear();
   });
 
   afterEach(() => {
@@ -120,6 +119,28 @@ describe("useDraft", () => {
     expect(resultB.current.draft).toBe("value-b");
   });
 
+  it("cancels a pending write when the key changes, never writing under the old key", () => {
+    const keyA = draftKey("test", "a");
+    const keyB = draftKey("test", "b");
+    const { result, rerender } = renderHook(
+      ({ key }) => useDraft<string>({ key }),
+      { initialProps: { key: keyA } }
+    );
+
+    act(() => {
+      result.current.save("typed under a");
+    });
+    // Switch keys before the debounce fires (e.g. chat:new -> real session id).
+    rerender({ key: keyB });
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    // The stale timer must not resurrect the old key's value.
+    expect(sessionStorage.getItem(keyA)).toBeNull();
+    expect(sessionStorage.getItem(keyB)).toBeNull();
+  });
+
   it("re-reads when the key changes", () => {
     const keyA = draftKey("test", "a");
     const keyB = draftKey("test", "b");
@@ -202,22 +223,6 @@ describe("useDraft", () => {
     });
 
     expect(JSON.parse(sessionStorage.getItem(keyB)!)).toBe("draft-for-b");
-  });
-
-  it("uses localStorage when backend is 'local'", () => {
-    const { result } = renderHook(() =>
-      useDraft<string>({ key: KEY, backend: "local" })
-    );
-
-    act(() => {
-      result.current.save("persisted");
-    });
-    act(() => {
-      jest.advanceTimersByTime(300);
-    });
-
-    expect(JSON.parse(localStorage.getItem(KEY)!)).toBe("persisted");
-    expect(sessionStorage.getItem(KEY)).toBeNull();
   });
 
   it("survives storage access throwing (blocked/SSR-like environments)", () => {

--- a/web/src/hooks/useDraft.ts
+++ b/web/src/hooks/useDraft.ts
@@ -2,32 +2,22 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
-// Persists in-progress input to browser storage so it survives navigation and
-// unexpected logout, then offers it back for restore on return.
-
 const STORAGE_PREFIX = "onyx:draft";
 
-// Namespaced so the flat per-origin store stays collision-free:
-// ``onyx:draft:<scope>:<entityId>``.
 export function draftKey(scope: string, entityId: string): string {
   return `${STORAGE_PREFIX}:${scope}:${entityId}`;
 }
 
-// Drafts live in ``sessionStorage``: per-tab, self-clearing on tab close, and
-// it survives reload and the same-tab login redirect, which is all we need
-// today.
 function getStorage(): Storage | null {
   if (typeof window === "undefined") return null;
   try {
+    // sessionStorage access throws when storage is blocked.
     return window.sessionStorage;
   } catch {
-    // Storage access can throw in private-browsing / blocked-cookie modes.
     return null;
   }
 }
 
-// Direct removal for callers that know the key but don't render the hook (e.g.
-// a save-success path).
 export function clearDraft(key: string) {
   const storage = getStorage();
   if (!storage) return;
@@ -38,8 +28,6 @@ export function clearDraft(key: string) {
   }
 }
 
-// A value is "empty" (and so not worth persisting) when it's nullish or a
-// blank/whitespace-only string. Consumers with richer shapes pass their own.
 function defaultIsEmpty(value: unknown): boolean {
   if (value == null) return true;
   if (typeof value === "string") return value.trim().length === 0;
@@ -54,11 +42,10 @@ export interface UseDraftOptions<T> {
 
 export interface UseDraftReturn<T> {
   draft: T | null;
-  // True once the read for the current key finishes; lets consumers tell "not
-  // read yet" from "read, nothing there" before restoring.
+  // Distinguishes "not read yet" from "read, nothing there".
   loaded: boolean;
   hasDraft: boolean;
-  // Debounced; empty values remove the key instead of writing.
+  // Debounced; empty values remove the key.
   save: (value: T) => void;
   // Removes immediately and cancels any pending write.
   clear: () => void;
@@ -69,9 +56,8 @@ export function useDraft<T>({
   debounceMs = 300,
   isEmpty = defaultIsEmpty,
 }: UseDraftOptions<T>): UseDraftReturn<T> {
-  // Tag the read result with its key so ``loaded`` is derived, not separate
-  // state. This forces a real false->true ``loaded`` edge on every key change,
-  // which consumers rely on to re-seed.
+  // Key-tagged so `loaded` is derived, giving a false->true edge on every key
+  // change that consumers rely on to re-seed.
   const [entry, setEntry] = useState<{ key: string; draft: T | null } | null>(
     null
   );
@@ -79,8 +65,6 @@ export function useDraft<T>({
   const isEmptyRef = useRef(isEmpty);
   isEmptyRef.current = isEmpty;
 
-  // Read the stored draft whenever the key changes. Effects don't run during
-  // SSR, so this never touches storage on the server.
   useEffect(() => {
     const storage = getStorage();
     if (!storage) {
@@ -95,8 +79,8 @@ export function useDraft<T>({
     }
   }, [key]);
 
-  // Cancel a pending write when the key changes (or on unmount) so a debounced
-  // save for the previous key can't land after the consumer has moved on.
+  // Cancel a pending write on key change/unmount so it can't land under the old
+  // key.
   useEffect(() => {
     return () => {
       if (timerRef.current !== null) {
@@ -120,7 +104,7 @@ export function useDraft<T>({
             storage.setItem(key, JSON.stringify(value));
           }
         } catch {
-          // ignore quota / serialization errors
+          // ignore
         }
       }, debounceMs);
     },

--- a/web/src/hooks/useDraft.ts
+++ b/web/src/hooks/useDraft.ts
@@ -1,0 +1,141 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+// Persists in-progress input to browser storage so it survives navigation and
+// unexpected logout, then offers it back for restore on return.
+
+export type DraftBackend = "session" | "local";
+
+const STORAGE_PREFIX = "onyx:draft";
+
+// Namespaced so the flat per-origin store stays collision-free:
+// ``onyx:draft:<scope>:<entityId>``.
+export function draftKey(scope: string, entityId: string): string {
+  return `${STORAGE_PREFIX}:${scope}:${entityId}`;
+}
+
+function getStorage(backend: DraftBackend): Storage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return backend === "local" ? window.localStorage : window.sessionStorage;
+  } catch {
+    // Storage access can throw in private-browsing / blocked-cookie modes.
+    return null;
+  }
+}
+
+// Direct removal for callers that know the key but don't render the hook (e.g.
+// a save-success path).
+export function clearDraft(key: string, backend: DraftBackend = "session") {
+  const storage = getStorage(backend);
+  if (!storage) return;
+  try {
+    storage.removeItem(key);
+  } catch {
+    // ignore
+  }
+}
+
+// A value is "empty" (and so not worth persisting) when it's nullish or a
+// blank/whitespace-only string. Consumers with richer shapes pass their own.
+function defaultIsEmpty(value: unknown): boolean {
+  if (value == null) return true;
+  if (typeof value === "string") return value.trim().length === 0;
+  return false;
+}
+
+export interface UseDraftOptions<T> {
+  key: string;
+  backend?: DraftBackend;
+  debounceMs?: number;
+  isEmpty?: (value: T) => boolean;
+}
+
+export interface UseDraftReturn<T> {
+  draft: T | null;
+  // True once the read for the current key finishes; lets consumers tell "not
+  // read yet" from "read, nothing there" before restoring.
+  loaded: boolean;
+  hasDraft: boolean;
+  // Debounced; empty values remove the key instead of writing.
+  save: (value: T) => void;
+  // Removes immediately and cancels any pending write.
+  clear: () => void;
+}
+
+export function useDraft<T>({
+  key,
+  backend = "session",
+  debounceMs = 300,
+  isEmpty = defaultIsEmpty,
+}: UseDraftOptions<T>): UseDraftReturn<T> {
+  // Tag the read result with its key so ``loaded`` is derived, not separate
+  // state. This forces a real false->true ``loaded`` edge on every key change,
+  // which consumers rely on to re-seed.
+  const [entry, setEntry] = useState<{ key: string; draft: T | null } | null>(
+    null
+  );
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isEmptyRef = useRef(isEmpty);
+  isEmptyRef.current = isEmpty;
+
+  // Read the stored draft whenever the key (or backend) changes. Effects don't
+  // run during SSR, so this never touches storage on the server.
+  useEffect(() => {
+    const storage = getStorage(backend);
+    if (!storage) {
+      setEntry({ key, draft: null });
+      return;
+    }
+    try {
+      const raw = storage.getItem(key);
+      setEntry({ key, draft: raw === null ? null : (JSON.parse(raw) as T) });
+    } catch {
+      setEntry({ key, draft: null });
+    }
+  }, [key, backend]);
+
+  // Cancel any pending write on unmount.
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const save = useCallback(
+    (value: T) => {
+      if (timerRef.current !== null) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null;
+        const storage = getStorage(backend);
+        if (!storage) return;
+        try {
+          if (isEmptyRef.current(value)) {
+            storage.removeItem(key);
+          } else {
+            storage.setItem(key, JSON.stringify(value));
+          }
+        } catch {
+          // ignore quota / serialization errors
+        }
+      }, debounceMs);
+    },
+    [key, backend, debounceMs]
+  );
+
+  const clear = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    clearDraft(key, backend);
+    setEntry({ key, draft: null });
+  }, [key, backend]);
+
+  const loaded = entry !== null && entry.key === key;
+  const draft = loaded ? entry.draft : null;
+  const hasDraft = draft !== null && !isEmptyRef.current(draft);
+
+  return { draft, loaded, hasDraft, save, clear };
+}

--- a/web/src/hooks/useDraft.ts
+++ b/web/src/hooks/useDraft.ts
@@ -5,8 +5,6 @@ import { useCallback, useEffect, useRef, useState } from "react";
 // Persists in-progress input to browser storage so it survives navigation and
 // unexpected logout, then offers it back for restore on return.
 
-export type DraftBackend = "session" | "local";
-
 const STORAGE_PREFIX = "onyx:draft";
 
 // Namespaced so the flat per-origin store stays collision-free:
@@ -15,10 +13,13 @@ export function draftKey(scope: string, entityId: string): string {
   return `${STORAGE_PREFIX}:${scope}:${entityId}`;
 }
 
-function getStorage(backend: DraftBackend): Storage | null {
+// Drafts live in ``sessionStorage``: per-tab, self-clearing on tab close, and
+// it survives reload and the same-tab login redirect, which is all we need
+// today.
+function getStorage(): Storage | null {
   if (typeof window === "undefined") return null;
   try {
-    return backend === "local" ? window.localStorage : window.sessionStorage;
+    return window.sessionStorage;
   } catch {
     // Storage access can throw in private-browsing / blocked-cookie modes.
     return null;
@@ -27,8 +28,8 @@ function getStorage(backend: DraftBackend): Storage | null {
 
 // Direct removal for callers that know the key but don't render the hook (e.g.
 // a save-success path).
-export function clearDraft(key: string, backend: DraftBackend = "session") {
-  const storage = getStorage(backend);
+export function clearDraft(key: string) {
+  const storage = getStorage();
   if (!storage) return;
   try {
     storage.removeItem(key);
@@ -47,7 +48,6 @@ function defaultIsEmpty(value: unknown): boolean {
 
 export interface UseDraftOptions<T> {
   key: string;
-  backend?: DraftBackend;
   debounceMs?: number;
   isEmpty?: (value: T) => boolean;
 }
@@ -66,7 +66,6 @@ export interface UseDraftReturn<T> {
 
 export function useDraft<T>({
   key,
-  backend = "session",
   debounceMs = 300,
   isEmpty = defaultIsEmpty,
 }: UseDraftOptions<T>): UseDraftReturn<T> {
@@ -80,10 +79,10 @@ export function useDraft<T>({
   const isEmptyRef = useRef(isEmpty);
   isEmptyRef.current = isEmpty;
 
-  // Read the stored draft whenever the key (or backend) changes. Effects don't
-  // run during SSR, so this never touches storage on the server.
+  // Read the stored draft whenever the key changes. Effects don't run during
+  // SSR, so this never touches storage on the server.
   useEffect(() => {
-    const storage = getStorage(backend);
+    const storage = getStorage();
     if (!storage) {
       setEntry({ key, draft: null });
       return;
@@ -94,21 +93,25 @@ export function useDraft<T>({
     } catch {
       setEntry({ key, draft: null });
     }
-  }, [key, backend]);
+  }, [key]);
 
-  // Cancel any pending write on unmount.
+  // Cancel a pending write when the key changes (or on unmount) so a debounced
+  // save for the previous key can't land after the consumer has moved on.
   useEffect(() => {
     return () => {
-      if (timerRef.current !== null) clearTimeout(timerRef.current);
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
     };
-  }, []);
+  }, [key]);
 
   const save = useCallback(
     (value: T) => {
       if (timerRef.current !== null) clearTimeout(timerRef.current);
       timerRef.current = setTimeout(() => {
         timerRef.current = null;
-        const storage = getStorage(backend);
+        const storage = getStorage();
         if (!storage) return;
         try {
           if (isEmptyRef.current(value)) {
@@ -121,7 +124,7 @@ export function useDraft<T>({
         }
       }, debounceMs);
     },
-    [key, backend, debounceMs]
+    [key, debounceMs]
   );
 
   const clear = useCallback(() => {
@@ -129,9 +132,9 @@ export function useDraft<T>({
       clearTimeout(timerRef.current);
       timerRef.current = null;
     }
-    clearDraft(key, backend);
+    clearDraft(key);
     setEntry({ key, draft: null });
-  }, [key, backend]);
+  }, [key]);
 
   const loaded = entry !== null && entry.key === key;
   const draft = loaded ? entry.draft : null;

--- a/web/src/sections/input/AppInputBar.tsx
+++ b/web/src/sections/input/AppInputBar.tsx
@@ -217,6 +217,7 @@ const AppInputBar = React.memo(
     } = useDraft<string>({ key: chatDraftStorageKey });
     const draftSeededRef = useRef(false);
     const skipNextDraftSaveRef = useRef(false);
+    const prevDraftKeyRef = useRef(chatDraftStorageKey);
     // Snapshot of message, read non-reactively in the restore effect so seeding
     // doesn't re-run on every keystroke.
     const messageRef = useRef(message);
@@ -224,7 +225,13 @@ const AppInputBar = React.memo(
 
     useEffect(() => {
       draftSeededRef.current = false;
-    }, [chatDraftStorageKey]);
+      // Clear the previous session's leftover text instead of leaking it into
+      // this one.
+      if (prevDraftKeyRef.current !== chatDraftStorageKey) {
+        prevDraftKeyRef.current = chatDraftStorageKey;
+        clearMessage();
+      }
+    }, [chatDraftStorageKey, clearMessage]);
 
     // Restore once read: a URL prompt wins and a non-empty input is never
     // clobbered.

--- a/web/src/sections/input/AppInputBar.tsx
+++ b/web/src/sections/input/AppInputBar.tsx
@@ -20,6 +20,7 @@ import { ChatState, MAX_QUEUED_MESSAGES } from "@/app/app/interfaces";
 import { useQueuedMessageNavigation } from "@/hooks/useQueuedMessageNavigation";
 import { useForcedTools } from "@/lib/hooks/useForcedTools";
 import useAppFocus from "@/hooks/useAppFocus";
+import { useDraft, draftKey } from "@/hooks/useDraft";
 import { getPastedFilesIfNoText } from "@/lib/clipboard";
 import PasteTilePopover from "@/sections/input/PasteTilePopover";
 import { cn } from "@opal/utils";
@@ -205,6 +206,48 @@ const AppInputBar = React.memo(
     const isSearchMode =
       (isNewSession && appMode === "search") || isSearchActive;
 
+    // Draft the message, keyed by chat session id (or "new" before a session
+    // exists; the key flips to the real id once the session is created).
+    const chatSessionId = appFocus.isChat() ? appFocus.getId() : null;
+    const chatDraftStorageKey = draftKey("chat", chatSessionId ?? "new");
+    const {
+      draft: chatDraft,
+      loaded: chatDraftLoaded,
+      save: saveChatDraft,
+      clear: clearChatDraft,
+    } = useDraft<string>({ key: chatDraftStorageKey });
+    const draftSeededRef = useRef(false);
+    const skipNextDraftSaveRef = useRef(false);
+
+    // Re-arm seeding when the active key changes (e.g. switching sessions).
+    useEffect(() => {
+      draftSeededRef.current = false;
+    }, [chatDraftStorageKey]);
+
+    // Restore the draft into the empty input once read. A URL prompt
+    // (initialMessage) wins, and a non-empty input is never clobbered.
+    useEffect(() => {
+      if (!chatDraftLoaded || draftSeededRef.current) return;
+      draftSeededRef.current = true;
+      if (chatDraft && !initialMessage && !message) {
+        // setMessage is async, so the save effect below would fire first with
+        // the stale empty message and wipe what we just seeded; skip that run.
+        skipNextDraftSaveRef.current = true;
+        setMessage(chatDraft);
+      }
+    }, [chatDraftLoaded, chatDraft, initialMessage]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    // Persist message changes (debounced). The hook's empty-skip rule means
+    // clearing the input also removes the stored draft.
+    useEffect(() => {
+      if (!chatDraftLoaded || !draftSeededRef.current) return;
+      if (skipNextDraftSaveRef.current) {
+        skipNextDraftSaveRef.current = false;
+        return;
+      }
+      saveChatDraft(message);
+    }, [message, chatDraftLoaded, saveChatDraft]);
+
     const handleRecordingChange = useCallback((nextIsRecording: boolean) => {
       setIsRecording((prevIsRecording) => {
         if (!prevIsRecording && nextIsRecording) {
@@ -228,8 +271,9 @@ const AppInputBar = React.memo(
           return;
         }
         handleSubmit(text);
+        clearChatDraft();
       },
-      [handleSubmit]
+      [handleSubmit, clearChatDraft]
     );
 
     // Expose reset and focus methods to parent via ref
@@ -237,6 +281,7 @@ const AppInputBar = React.memo(
       reset: () => {
         if (!isAutoSending.current) {
           clearMessage();
+          clearChatDraft();
         }
       },
       focus: () => {

--- a/web/src/sections/input/AppInputBar.tsx
+++ b/web/src/sections/input/AppInputBar.tsx
@@ -206,8 +206,7 @@ const AppInputBar = React.memo(
     const isSearchMode =
       (isNewSession && appMode === "search") || isSearchActive;
 
-    // Draft the message, keyed by chat session id (or "new" before a session
-    // exists; the key flips to the real id once the session is created).
+    // Keyed by chat session id, or "new" until the session is created.
     const chatSessionId = appFocus.isChat() ? appFocus.getId() : null;
     const chatDraftStorageKey = draftKey("chat", chatSessionId ?? "new");
     const {
@@ -218,27 +217,28 @@ const AppInputBar = React.memo(
     } = useDraft<string>({ key: chatDraftStorageKey });
     const draftSeededRef = useRef(false);
     const skipNextDraftSaveRef = useRef(false);
+    // Snapshot of message, read non-reactively in the restore effect so seeding
+    // doesn't re-run on every keystroke.
+    const messageRef = useRef(message);
+    messageRef.current = message;
 
-    // Re-arm seeding when the active key changes (e.g. switching sessions).
     useEffect(() => {
       draftSeededRef.current = false;
     }, [chatDraftStorageKey]);
 
-    // Restore the draft into the empty input once read. A URL prompt
-    // (initialMessage) wins, and a non-empty input is never clobbered.
+    // Restore once read: a URL prompt wins and a non-empty input is never
+    // clobbered.
     useEffect(() => {
       if (!chatDraftLoaded || draftSeededRef.current) return;
       draftSeededRef.current = true;
-      if (chatDraft && !initialMessage && !message) {
-        // setMessage is async, so the save effect below would fire first with
-        // the stale empty message and wipe what we just seeded; skip that run.
+      if (chatDraft && !initialMessage && !messageRef.current) {
+        // Skip the save effect's next run; it would fire with the stale empty
+        // message and wipe what we just seeded.
         skipNextDraftSaveRef.current = true;
         setMessage(chatDraft);
       }
-    }, [chatDraftLoaded, chatDraft, initialMessage]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [chatDraftLoaded, chatDraft, initialMessage, setMessage]);
 
-    // Persist message changes (debounced). The hook's empty-skip rule means
-    // clearing the input also removes the stored draft.
     useEffect(() => {
       if (!chatDraftLoaded || !draftSeededRef.current) return;
       if (skipNextDraftSaveRef.current) {
@@ -784,9 +784,8 @@ const AppInputBar = React.memo(
                 if (queuedMessages.length < MAX_QUEUED_MESSAGES) {
                   enqueueCurrentMessage(message.trim());
                   clearMessage();
-                  // Committed to the queue: drop its draft now rather than via
-                  // the debounced empty-save, so a reload can't briefly
-                  // resurrect it.
+                  // Drop the draft now; a reload could outrace the debounced
+                  // empty-save.
                   clearChatDraft();
                 }
               } else if (chatState == "streaming") {
@@ -935,7 +934,8 @@ const AppInputBar = React.memo(
                         )
                           return;
 
-                        // Enter to submit or queue (Shift+Enter falls through to browser default: inserts <br>)
+                        // Enter to submit or queue (Shift+Enter falls through
+                        // to browser default: inserts <br>).
                         if (
                           event.key === "Enter" &&
                           !showPrompts &&
@@ -964,9 +964,8 @@ const AppInputBar = React.memo(
                           ) {
                             enqueueCurrentMessage(message.trim());
                             clearMessage();
-                            // Committed to the queue: drop its draft now rather
-                            // than via the debounced empty-save, so a reload
-                            // can't briefly resurrect it.
+                            // Drop the draft now; a reload could outrace the
+                            // debounced empty-save.
                             clearChatDraft();
                           }
                         }

--- a/web/src/sections/input/AppInputBar.tsx
+++ b/web/src/sections/input/AppInputBar.tsx
@@ -784,6 +784,10 @@ const AppInputBar = React.memo(
                 if (queuedMessages.length < MAX_QUEUED_MESSAGES) {
                   enqueueCurrentMessage(message.trim());
                   clearMessage();
+                  // Committed to the queue: drop its draft now rather than via
+                  // the debounced empty-save, so a reload can't briefly
+                  // resurrect it.
+                  clearChatDraft();
                 }
               } else if (chatState == "streaming") {
                 stopTTS({ manual: true });
@@ -960,6 +964,10 @@ const AppInputBar = React.memo(
                           ) {
                             enqueueCurrentMessage(message.trim());
                             clearMessage();
+                            // Committed to the queue: drop its draft now rather
+                            // than via the debounced empty-save, so a reload
+                            // can't briefly resurrect it.
+                            clearChatDraft();
                           }
                         }
                       }}

--- a/web/src/views/AgentEditorPage.tsx
+++ b/web/src/views/AgentEditorPage.tsx
@@ -102,7 +102,7 @@ import AgentKnowledgePane from "@/sections/knowledge/AgentKnowledgePane";
 import { ValidSources } from "@/lib/types";
 import { useSettings } from "@/lib/settings/hooks";
 import { useUser } from "@/providers/UserProvider";
-import { useDraft, draftKey, clearDraft } from "@/hooks/useDraft";
+import { useDraft, draftKey } from "@/hooks/useDraft";
 
 interface AgentIconEditorProps {
   existingAgent?: FullAgent | null;
@@ -485,17 +485,31 @@ function AgentStarterMessages() {
 
 interface AgentDraftManagerProps {
   storageKey: string;
+  // Exposes the hook's clear() to the parent's save-success path so it cancels
+  // any pending debounced write before removing the draft (a bare removeItem
+  // would let an in-flight save rewrite the key right after).
+  clearRef: React.RefObject<(() => void) | null>;
 }
 
 // Auto-saves the form to a draft (only while dirty, so a pristine form never
 // prompts) and surfaces a restore banner when one exists.
-export function AgentDraftManager({ storageKey }: AgentDraftManagerProps) {
+export function AgentDraftManager({
+  storageKey,
+  clearRef,
+}: AgentDraftManagerProps) {
   const { values, dirty, setValues } =
     useFormikContext<Record<string, unknown>>();
   const { draft, loaded, hasDraft, save, clear } = useDraft<
     Record<string, unknown>
   >({ key: storageKey });
   const [handled, setHandled] = useState(false);
+
+  useEffect(() => {
+    clearRef.current = clear;
+    return () => {
+      clearRef.current = null;
+    };
+  }, [clear, clearRef]);
 
   useEffect(() => {
     if (loaded && dirty) save(values);
@@ -570,6 +584,9 @@ export default function AgentEditorPage({
     "agent-editor",
     existingAgent?.id != null ? String(existingAgent.id) : "new"
   );
+  // Assigned by AgentDraftManager; lets handleSubmit cancel a pending draft
+  // write before clearing on a successful save.
+  const clearAgentDraftRef = useRef<(() => void) | null>(null);
 
   // Labels are edited in the Share Agent section and saved with the form
   const { labels: allLabels, createLabel } = useLabels();
@@ -997,7 +1014,9 @@ export default function AgentEditorPage({
       const agent = await personaResponse.json();
 
       // Saved: drop the draft so it can't resurface as a stale restore prompt.
-      clearDraft(agentDraftStorageKey);
+      // Via the hook's clear() so a debounced write in flight is cancelled
+      // first.
+      clearAgentDraftRef.current?.();
 
       // Apply the leveled share draft captured in the dialog before the
       // agent existed (the create payload only carries viewer-level ids)
@@ -1342,7 +1361,10 @@ export default function AgentEditorPage({
 
                     {/* Agent Form Content */}
                     <SettingsLayouts.Body>
-                      <AgentDraftManager storageKey={agentDraftStorageKey} />
+                      <AgentDraftManager
+                        storageKey={agentDraftStorageKey}
+                        clearRef={clearAgentDraftRef}
+                      />
 
                       <GeneralLayouts.Section
                         flexDirection="row"

--- a/web/src/views/AgentEditorPage.tsx
+++ b/web/src/views/AgentEditorPage.tsx
@@ -102,6 +102,7 @@ import AgentKnowledgePane from "@/sections/knowledge/AgentKnowledgePane";
 import { ValidSources } from "@/lib/types";
 import { useSettings } from "@/lib/settings/hooks";
 import { useUser } from "@/providers/UserProvider";
+import { useDraft, draftKey, clearDraft } from "@/hooks/useDraft";
 
 interface AgentIconEditorProps {
   existingAgent?: FullAgent | null;
@@ -482,6 +483,60 @@ function AgentStarterMessages() {
   );
 }
 
+interface AgentDraftManagerProps {
+  storageKey: string;
+}
+
+// Auto-saves the form to a draft (only while dirty, so a pristine form never
+// prompts) and surfaces a restore banner when one exists.
+function AgentDraftManager({ storageKey }: AgentDraftManagerProps) {
+  const { values, dirty, setValues } =
+    useFormikContext<Record<string, unknown>>();
+  const { draft, loaded, hasDraft, save, clear } = useDraft<
+    Record<string, unknown>
+  >({ key: storageKey });
+  const [handled, setHandled] = useState(false);
+
+  useEffect(() => {
+    if (loaded && dirty) save(values);
+  }, [values, dirty, loaded, save]);
+
+  if (!loaded || !hasDraft || handled || !draft) return null;
+
+  function handleRestore() {
+    // JSON stores dates as ISO strings; revive the one date field back to a
+    // Date.
+    const cutoff = draft!.knowledge_cutoff_date;
+    setValues({
+      ...draft!,
+      knowledge_cutoff_date:
+        typeof cutoff === "string" ? new Date(cutoff) : (cutoff ?? null),
+    });
+    setHandled(true);
+  }
+
+  function handleDismiss() {
+    clear();
+    setHandled(true);
+  }
+
+  return (
+    <MessageCard
+      variant="info"
+      title="Restore unsaved changes?"
+      description="We saved your in-progress edits from a previous session."
+      rightChildren={
+        <div className="flex gap-2">
+          <Button prominence="secondary" onClick={handleDismiss}>
+            Discard
+          </Button>
+          <Button onClick={handleRestore}>Restore</Button>
+        </div>
+      }
+    />
+  );
+}
+
 export interface AgentEditorPageProps {
   agent?: FullAgent;
   refreshAgent?: () => void;
@@ -502,6 +557,13 @@ export default function AgentEditorPage({
   const canUpdateFeaturedStatus = isAdmin;
   const { vectorDbEnabled } = useSettings();
   const businessTier = useTierAtLeast(Tier.BUSINESS);
+
+  // Separate keys for create vs. edit so a new-agent draft can't bleed into an
+  // existing one.
+  const agentDraftStorageKey = draftKey(
+    "agent-editor",
+    existingAgent?.id != null ? String(existingAgent.id) : "new"
+  );
 
   // Labels are edited in the Share Agent section and saved with the form
   const { labels: allLabels, createLabel } = useLabels();
@@ -928,6 +990,9 @@ export default function AgentEditorPage({
       // Success
       const agent = await personaResponse.json();
 
+      // Saved: drop the draft so it can't resurface as a stale restore prompt.
+      clearDraft(agentDraftStorageKey);
+
       // Apply the leveled share draft captured in the dialog before the
       // agent existed (the create payload only carries viewer-level ids)
       if (!existingAgent && values.shared_draft) {
@@ -1271,6 +1336,8 @@ export default function AgentEditorPage({
 
                     {/* Agent Form Content */}
                     <SettingsLayouts.Body>
+                      <AgentDraftManager storageKey={agentDraftStorageKey} />
+
                       <GeneralLayouts.Section
                         flexDirection="row"
                         gap={2.5}

--- a/web/src/views/AgentEditorPage.tsx
+++ b/web/src/views/AgentEditorPage.tsx
@@ -489,7 +489,7 @@ interface AgentDraftManagerProps {
 
 // Auto-saves the form to a draft (only while dirty, so a pristine form never
 // prompts) and surfaces a restore banner when one exists.
-function AgentDraftManager({ storageKey }: AgentDraftManagerProps) {
+export function AgentDraftManager({ storageKey }: AgentDraftManagerProps) {
   const { values, dirty, setValues } =
     useFormikContext<Record<string, unknown>>();
   const { draft, loaded, hasDraft, save, clear } = useDraft<
@@ -500,6 +500,12 @@ function AgentDraftManager({ storageKey }: AgentDraftManagerProps) {
   useEffect(() => {
     if (loaded && dirty) save(values);
   }, [values, dirty, loaded, save]);
+
+  // Editing the form means the user is working fresh, not restoring; latch the
+  // banner shut so it can't reappear, even if they later revert to pristine.
+  useEffect(() => {
+    if (dirty) setHandled(true);
+  }, [dirty]);
 
   if (!loaded || !hasDraft || handled || !draft) return null;
 

--- a/web/src/views/AgentEditorPage.tsx
+++ b/web/src/views/AgentEditorPage.tsx
@@ -485,16 +485,12 @@ function AgentStarterMessages() {
 
 interface AgentDraftManagerProps {
   storageKey: string;
-  // Exposes the hook's clear() to the parent's save-success path so it cancels
-  // any pending debounced write before removing the draft (a bare removeItem
-  // would let an in-flight save rewrite the key right after).
+  // Lets the parent's save-success path cancel a pending write before clearing.
   clearRef: React.RefObject<(() => void) | null>;
 }
 
-// Headless coordinator for new-agent drafts: auto-saves the form while dirty
-// and auto-restores any stored draft on mount. Only mounted for agent creation;
-// edits to an existing agent are assumed minor and aren't drafted. Renders
-// nothing.
+// Headless: auto-saves the form while dirty and auto-restores the draft on
+// mount. Only mounted for agent creation.
 export function AgentDraftManager({
   storageKey,
   clearRef,
@@ -517,14 +513,13 @@ export function AgentDraftManager({
     if (loaded && dirty) save(values);
   }, [values, dirty, loaded, save]);
 
-  // Restore the draft once the read completes. Safe to apply silently: the
-  // create form starts pristine, so there's nothing to clobber. The !dirty
-  // guard still bails if the user began typing before the read landed.
+  // Restore once read. The !dirty guard avoids clobbering if the user typed
+  // before the read landed.
   useEffect(() => {
     if (!loaded || restoredRef.current) return;
     restoredRef.current = true;
     if (hasDraft && draft && !dirty) {
-      // JSON stores dates as ISO strings; revive the one date field to a Date.
+      // Revive the date field that JSON serialized to an ISO string.
       const cutoff = draft.knowledge_cutoff_date;
       setValues({
         ...draft,
@@ -558,10 +553,7 @@ export default function AgentEditorPage({
   const { vectorDbEnabled } = useSettings();
   const businessTier = useTierAtLeast(Tier.BUSINESS);
 
-  // Drafts are only kept while creating an agent, so a single "new" key.
   const agentDraftStorageKey = draftKey("agent-editor", "new");
-  // Assigned by AgentDraftManager; lets handleSubmit cancel a pending draft
-  // write before clearing on a successful save.
   const clearAgentDraftRef = useRef<(() => void) | null>(null);
 
   // Labels are edited in the Share Agent section and saved with the form
@@ -989,9 +981,7 @@ export default function AgentEditorPage({
       // Success
       const agent = await personaResponse.json();
 
-      // Saved: drop the draft so it can't resurface as a stale restore prompt.
-      // Via the hook's clear() so a debounced write in flight is cancelled
-      // first.
+      // clear() (not clearDraft) so an in-flight debounced write is cancelled too.
       clearAgentDraftRef.current?.();
 
       // Apply the leveled share draft captured in the dialog before the
@@ -1337,8 +1327,7 @@ export default function AgentEditorPage({
 
                     {/* Agent Form Content */}
                     <SettingsLayouts.Body>
-                      {/* Drafts are only kept for new agents; edits to an
-                          existing agent are assumed minor. */}
+                      {/* Drafts only for new agents; edits are assumed minor. */}
                       {!existingAgent && (
                         <AgentDraftManager
                           storageKey={agentDraftStorageKey}

--- a/web/src/views/AgentEditorPage.tsx
+++ b/web/src/views/AgentEditorPage.tsx
@@ -491,8 +491,10 @@ interface AgentDraftManagerProps {
   clearRef: React.RefObject<(() => void) | null>;
 }
 
-// Auto-saves the form to a draft (only while dirty, so a pristine form never
-// prompts) and surfaces a restore banner when one exists.
+// Headless coordinator for new-agent drafts: auto-saves the form while dirty
+// and auto-restores any stored draft on mount. Only mounted for agent creation;
+// edits to an existing agent are assumed minor and aren't drafted. Renders
+// nothing.
 export function AgentDraftManager({
   storageKey,
   clearRef,
@@ -502,7 +504,7 @@ export function AgentDraftManager({
   const { draft, loaded, hasDraft, save, clear } = useDraft<
     Record<string, unknown>
   >({ key: storageKey });
-  const [handled, setHandled] = useState(false);
+  const restoredRef = useRef(false);
 
   useEffect(() => {
     clearRef.current = clear;
@@ -515,46 +517,24 @@ export function AgentDraftManager({
     if (loaded && dirty) save(values);
   }, [values, dirty, loaded, save]);
 
-  // Editing the form means the user is working fresh, not restoring; latch the
-  // banner shut so it can't reappear, even if they later revert to pristine.
+  // Restore the draft once the read completes. Safe to apply silently: the
+  // create form starts pristine, so there's nothing to clobber. The !dirty
+  // guard still bails if the user began typing before the read landed.
   useEffect(() => {
-    if (dirty) setHandled(true);
-  }, [dirty]);
+    if (!loaded || restoredRef.current) return;
+    restoredRef.current = true;
+    if (hasDraft && draft && !dirty) {
+      // JSON stores dates as ISO strings; revive the one date field to a Date.
+      const cutoff = draft.knowledge_cutoff_date;
+      setValues({
+        ...draft,
+        knowledge_cutoff_date:
+          typeof cutoff === "string" ? new Date(cutoff) : (cutoff ?? null),
+      });
+    }
+  }, [loaded, hasDraft, draft, dirty, setValues]);
 
-  if (!loaded || !hasDraft || handled || !draft) return null;
-
-  function handleRestore() {
-    // JSON stores dates as ISO strings; revive the one date field back to a
-    // Date.
-    const cutoff = draft!.knowledge_cutoff_date;
-    setValues({
-      ...draft!,
-      knowledge_cutoff_date:
-        typeof cutoff === "string" ? new Date(cutoff) : (cutoff ?? null),
-    });
-    setHandled(true);
-  }
-
-  function handleDismiss() {
-    clear();
-    setHandled(true);
-  }
-
-  return (
-    <MessageCard
-      variant="info"
-      title="Restore unsaved changes?"
-      description="We saved your in-progress edits from a previous session."
-      rightChildren={
-        <div className="flex gap-2">
-          <Button prominence="secondary" onClick={handleDismiss}>
-            Discard
-          </Button>
-          <Button onClick={handleRestore}>Restore</Button>
-        </div>
-      }
-    />
-  );
+  return null;
 }
 
 export interface AgentEditorPageProps {
@@ -578,12 +558,8 @@ export default function AgentEditorPage({
   const { vectorDbEnabled } = useSettings();
   const businessTier = useTierAtLeast(Tier.BUSINESS);
 
-  // Separate keys for create vs. edit so a new-agent draft can't bleed into an
-  // existing one.
-  const agentDraftStorageKey = draftKey(
-    "agent-editor",
-    existingAgent?.id != null ? String(existingAgent.id) : "new"
-  );
+  // Drafts are only kept while creating an agent, so a single "new" key.
+  const agentDraftStorageKey = draftKey("agent-editor", "new");
   // Assigned by AgentDraftManager; lets handleSubmit cancel a pending draft
   // write before clearing on a successful save.
   const clearAgentDraftRef = useRef<(() => void) | null>(null);
@@ -1361,10 +1337,14 @@ export default function AgentEditorPage({
 
                     {/* Agent Form Content */}
                     <SettingsLayouts.Body>
-                      <AgentDraftManager
-                        storageKey={agentDraftStorageKey}
-                        clearRef={clearAgentDraftRef}
-                      />
+                      {/* Drafts are only kept for new agents; edits to an
+                          existing agent are assumed minor. */}
+                      {!existingAgent && (
+                        <AgentDraftManager
+                          storageKey={agentDraftStorageKey}
+                          clearRef={clearAgentDraftRef}
+                        />
+                      )}
 
                       <GeneralLayouts.Section
                         flexDirection="row"

--- a/web/src/views/__tests__/AgentDraftManager.test.tsx
+++ b/web/src/views/__tests__/AgentDraftManager.test.tsx
@@ -7,7 +7,6 @@ import { draftKey } from "@/hooks/useDraft";
 
 const KEY = draftKey("agent-editor", "new");
 
-// Surfaces the live form value and lets a test dirty the form.
 function FormReadout() {
   const { values, setFieldValue } = useFormikContext<{ name: string }>();
   return (
@@ -61,17 +60,10 @@ describe("AgentDraftManager", () => {
     expect(screen.getByTestId("name").textContent).toBe("");
   });
 
-  // The save-success path calls clearRef (the hook's clear()), which must
-  // cancel a debounced write scheduled by the edit. A bare removeItem would let
-  // the pending timer rewrite the key right after, resurrecting the saved
-  // values.
   it("clearRef cancels a pending debounced write before removing the draft", () => {
     const { clearRef } = renderManager();
 
-    // Editing schedules a debounced save(values).
     fireEvent.click(screen.getByText("edit"));
-
-    // Save succeeds before the debounce fires; the parent clears via the ref.
     act(() => {
       clearRef.current?.();
     });
@@ -79,7 +71,6 @@ describe("AgentDraftManager", () => {
       jest.advanceTimersByTime(300);
     });
 
-    // The cancelled timer must not have rewritten the key.
     expect(sessionStorage.getItem(KEY)).toBeNull();
   });
 });

--- a/web/src/views/__tests__/AgentDraftManager.test.tsx
+++ b/web/src/views/__tests__/AgentDraftManager.test.tsx
@@ -21,7 +21,8 @@ function FormControls() {
 }
 
 function renderManager() {
-  return render(
+  const clearRef = React.createRef<(() => void) | null>();
+  const utils = render(
     <Formik
       initialValues={{ name: "" }}
       onSubmit={() => {}}
@@ -30,11 +31,12 @@ function renderManager() {
       validateOnMount={false}
     >
       <>
-        <AgentDraftManager storageKey={KEY} />
+        <AgentDraftManager storageKey={KEY} clearRef={clearRef} />
         <FormControls />
       </>
     </Formik>
   );
+  return { ...utils, clearRef };
 }
 
 describe("AgentDraftManager banner", () => {
@@ -82,5 +84,27 @@ describe("AgentDraftManager banner", () => {
     // must keep the banner from reappearing.
     fireEvent.click(screen.getByText("revert"));
     expect(screen.queryByText(BANNER)).not.toBeInTheDocument();
+  });
+
+  // The save-success path calls clearRef (the hook's clear()), which must
+  // cancel a debounced write scheduled by the edit. A bare removeItem would let
+  // the pending timer rewrite the key right after, resurrecting the saved
+  // values.
+  it("clearRef cancels a pending debounced write before removing the draft", () => {
+    const { clearRef } = renderManager();
+
+    // Editing schedules a debounced save(values).
+    fireEvent.click(screen.getByText("edit"));
+
+    // Save succeeds before the debounce fires; the parent clears via the ref.
+    act(() => {
+      clearRef.current?.();
+    });
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    // The cancelled timer must not have rewritten the key.
+    expect(sessionStorage.getItem(KEY)).toBeNull();
   });
 });

--- a/web/src/views/__tests__/AgentDraftManager.test.tsx
+++ b/web/src/views/__tests__/AgentDraftManager.test.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { render, screen, act, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { Formik, useFormikContext } from "formik";
+import { AgentDraftManager } from "@/views/AgentEditorPage";
+import { draftKey } from "@/hooks/useDraft";
+
+const KEY = draftKey("agent-editor", "test");
+const BANNER = "Restore unsaved changes?";
+
+// Drives Formik dirtiness from the test: "edit" makes the form dirty, "revert"
+// returns it to initialValues (pristine).
+function FormControls() {
+  const { setFieldValue } = useFormikContext<{ name: string }>();
+  return (
+    <>
+      <button onClick={() => setFieldValue("name", "edited")}>edit</button>
+      <button onClick={() => setFieldValue("name", "")}>revert</button>
+    </>
+  );
+}
+
+function renderManager() {
+  return render(
+    <Formik
+      initialValues={{ name: "" }}
+      onSubmit={() => {}}
+      validateOnChange={false}
+      validateOnBlur={false}
+      validateOnMount={false}
+    >
+      <>
+        <AgentDraftManager storageKey={KEY} />
+        <FormControls />
+      </>
+    </Formik>
+  );
+}
+
+describe("AgentDraftManager banner", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  it("shows the restore banner for a pristine form with a stored draft", () => {
+    sessionStorage.setItem(KEY, JSON.stringify({ name: "draft name" }));
+    renderManager();
+    expect(screen.getByText(BANNER)).toBeInTheDocument();
+  });
+
+  it("does not show the banner when there is no stored draft", () => {
+    renderManager();
+    expect(screen.queryByText(BANNER)).not.toBeInTheDocument();
+  });
+
+  it("hides the banner once the form becomes dirty", () => {
+    sessionStorage.setItem(KEY, JSON.stringify({ name: "draft name" }));
+    renderManager();
+    expect(screen.getByText(BANNER)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("edit"));
+
+    expect(screen.queryByText(BANNER)).not.toBeInTheDocument();
+  });
+
+  it("keeps the banner hidden after the form is reverted to pristine (latch)", () => {
+    sessionStorage.setItem(KEY, JSON.stringify({ name: "draft name" }));
+    renderManager();
+
+    fireEvent.click(screen.getByText("edit"));
+    expect(screen.queryByText(BANNER)).not.toBeInTheDocument();
+
+    // Reverting back to initialValues makes Formik pristine again; the latch
+    // must keep the banner from reappearing.
+    fireEvent.click(screen.getByText("revert"));
+    expect(screen.queryByText(BANNER)).not.toBeInTheDocument();
+  });
+});

--- a/web/src/views/__tests__/AgentDraftManager.test.tsx
+++ b/web/src/views/__tests__/AgentDraftManager.test.tsx
@@ -5,17 +5,15 @@ import { Formik, useFormikContext } from "formik";
 import { AgentDraftManager } from "@/views/AgentEditorPage";
 import { draftKey } from "@/hooks/useDraft";
 
-const KEY = draftKey("agent-editor", "test");
-const BANNER = "Restore unsaved changes?";
+const KEY = draftKey("agent-editor", "new");
 
-// Drives Formik dirtiness from the test: "edit" makes the form dirty, "revert"
-// returns it to initialValues (pristine).
-function FormControls() {
-  const { setFieldValue } = useFormikContext<{ name: string }>();
+// Surfaces the live form value and lets a test dirty the form.
+function FormReadout() {
+  const { values, setFieldValue } = useFormikContext<{ name: string }>();
   return (
     <>
+      <div data-testid="name">{values.name}</div>
       <button onClick={() => setFieldValue("name", "edited")}>edit</button>
-      <button onClick={() => setFieldValue("name", "")}>revert</button>
     </>
   );
 }
@@ -32,14 +30,14 @@ function renderManager() {
     >
       <>
         <AgentDraftManager storageKey={KEY} clearRef={clearRef} />
-        <FormControls />
+        <FormReadout />
       </>
     </Formik>
   );
   return { ...utils, clearRef };
 }
 
-describe("AgentDraftManager banner", () => {
+describe("AgentDraftManager", () => {
   beforeEach(() => {
     jest.useFakeTimers();
     sessionStorage.clear();
@@ -52,38 +50,15 @@ describe("AgentDraftManager banner", () => {
     jest.useRealTimers();
   });
 
-  it("shows the restore banner for a pristine form with a stored draft", () => {
+  it("auto-restores a stored draft into the form on mount", () => {
     sessionStorage.setItem(KEY, JSON.stringify({ name: "draft name" }));
     renderManager();
-    expect(screen.getByText(BANNER)).toBeInTheDocument();
+    expect(screen.getByTestId("name")).toHaveTextContent("draft name");
   });
 
-  it("does not show the banner when there is no stored draft", () => {
+  it("leaves the form untouched when there is no stored draft", () => {
     renderManager();
-    expect(screen.queryByText(BANNER)).not.toBeInTheDocument();
-  });
-
-  it("hides the banner once the form becomes dirty", () => {
-    sessionStorage.setItem(KEY, JSON.stringify({ name: "draft name" }));
-    renderManager();
-    expect(screen.getByText(BANNER)).toBeInTheDocument();
-
-    fireEvent.click(screen.getByText("edit"));
-
-    expect(screen.queryByText(BANNER)).not.toBeInTheDocument();
-  });
-
-  it("keeps the banner hidden after the form is reverted to pristine (latch)", () => {
-    sessionStorage.setItem(KEY, JSON.stringify({ name: "draft name" }));
-    renderManager();
-
-    fireEvent.click(screen.getByText("edit"));
-    expect(screen.queryByText(BANNER)).not.toBeInTheDocument();
-
-    // Reverting back to initialValues makes Formik pristine again; the latch
-    // must keep the banner from reappearing.
-    fireEvent.click(screen.getByText("revert"));
-    expect(screen.queryByText(BANNER)).not.toBeInTheDocument();
+    expect(screen.getByTestId("name").textContent).toBe("");
   });
 
   // The save-success path calls clearRef (the hook's clear()), which must


### PR DESCRIPTION
## Description

Now when users enter text into the chat bar or the agent configuration bar, the text is saved as a draft in session storage and can be reloaded if leaving and coming back to the page.

The draft is overwritten if changes have been made to the text in the relevant fields, with a 300ms debounce.

Drafts are only reloaded in the agent configuration page for new agents, existing agents do not have this draft saving behavior.

NOTE: This PR also fixes a (bug?) where text entered into a chat bar is preserved when switching to another chat. This doesn't seem like correct behavior, and also makes the draft text caching more complicated.

## How Has This Been Tested?

- Went to the agent creation page, entered some text, left, came back, and my draft was still there.
- Entered text in a new chat session, left, came back, and it was still there.
- Entered text in an existing chat session, left, came back, and it was still there.
- Switched between chat sessions with different drafts in each, and drafts were preserved as expected.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Autosaves in-progress text for chat and the agent creation form so users can leave and come back without losing work. Chat drafts restore automatically; the agent form auto-restores only when pristine and clears the draft after create.

- **New Features**
  - Added `useDraft` with debounced writes, per-key session storage, and helpers `draftKey`/`clearDraft`.
  - Chat bar: saves per session (`"new"` flips to real id), restores only into an empty input (URL prompt wins), and clears on send/reset/enqueue.
  - Agent creation: headless auto-save while dirty, auto-restore on pristine load, and clear on successful create; only enabled for new agents.

- **Bug Fixes**
  - Reliable loaded-state flip and canceled pending writes on key changes to prevent stale saves.
  - Skip empty/whitespace values and tolerate blocked storage access.
  - Clear drafts synchronously on send/enqueue and after agent create, canceling debounced writes to prevent reappearing.
  - Avoid wiping a restored draft by skipping the first save after seeding; revive date fields when restoring.

<sup>Written for commit eb6c43cfe1dcc2d1803f4fefd05d8682496758ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
