### PR TITLE
test(craft): make sandbox EDU tests backend-agnostic

### DIFF
--- a/backend/tests/external_dependency_unit/craft/test_ensure_sandbox_running.py
+++ b/backend/tests/external_dependency_unit/craft/test_ensure_sandbox_running.py
@@ -1,22 +1,27 @@
-"""External-dependency unit tests for SessionManager.ensure_sandbox_running.
+"""State-machine coverage for ``SessionManager.ensure_sandbox_running``.
 
-Exercises the headless sandbox state machine: creating a fresh sandbox
-row, waking SLEEPING / TERMINATED / FAILED, recovering a RUNNING-but-
-unhealthy pod, and polling a PROVISIONING sandbox to completion (or
-timeout).
+The headless entry point (``manager.py:ensure_sandbox_running``) delegates to
+``ensure_sandbox_ready`` (``sandbox_lifecycle.py:197``) under the ``POLL``
+provisioning policy. These tests drive the public ``SessionManager`` API
+against the real Postgres DB (via ``db_session``) and the in-memory
+``StubSandboxManager``, exercising every branch of the state machine:
 
-Uses the real Postgres DB (via the ``db_session`` fixture) and the real
-``KubernetesSandboxManager`` against a kind cluster. Each test cleans
-up its sandbox via ``mgr.terminate()`` so consecutive runs stay hermetic.
+* No sandbox row -> create + provision.
+* ``RUNNING`` + pod healthy -> return as-is (hot path; no provision/terminate).
+* ``RUNNING`` + pod unhealthy -> terminate + re-provision.
+* ``SLEEPING`` / ``TERMINATED`` / ``FAILED`` -> re-provision in place.
+* ``PROVISIONING`` that flips RUNNING mid-wait -> return RUNNING, no provision.
+* ``PROVISIONING`` with a 0s wait window -> ``SandboxProvisioningError``.
 
-Gated to the K8s CI lane (``pr-craft-k8s-tests.yml``) since the local
-sandbox backend was removed in
-``docs/craft/2026-05-21-nuke-local-sandbox-manager.md``.
+No real cluster is touched; the stub raises loudly for any unconfigured
+manager method, so each test must declare the slice of the manager it uses.
 """
 
-from collections.abc import Generator
-from unittest.mock import patch
+from __future__ import annotations
+
+from collections.abc import Callable
 from uuid import UUID
+from uuid import uuid4
 
 import pytest
 from sqlalchemy.orm import Session
@@ -24,283 +29,184 @@ from sqlalchemy.orm import Session
 from onyx.db.enums import SandboxStatus
 from onyx.db.models import Sandbox
 from onyx.db.models import User
-from onyx.server.features.build.configs import SANDBOX_BACKEND
-from onyx.server.features.build.configs import SandboxBackend
-from onyx.server.features.build.db.sandbox import create_sandbox__no_commit
-from onyx.server.features.build.db.sandbox import update_sandbox_status__no_commit
-from onyx.server.features.build.sandbox.base import SandboxManager
-from onyx.server.features.build.sandbox.factory import get_sandbox_manager
-from onyx.server.features.build.sandbox.models import LLMProviderConfig
+from onyx.server.features.build.db.sandbox import get_sandbox_by_user_id
+from onyx.server.features.build.sandbox.models import SandboxInfo
 from onyx.server.features.build.session.errors import SandboxProvisioningError
 from onyx.server.features.build.session.manager import SessionManager
-from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
-
-pytestmark = pytest.mark.skipif(
-    SANDBOX_BACKEND != SandboxBackend.KUBERNETES,
-    reason="ensure_sandbox_running tests require SANDBOX_BACKEND=kubernetes; run in the dedicated K8s CI job.",
-)
+from tests.common.craft.stubs import StubSandboxManager
 
 
-def _make_session_manager(db_session: Session) -> SessionManager:
-    """Construct a SessionManager wired to the env's real SandboxManager."""
-    return SessionManager(db_session)
-
-
-@pytest.fixture
-def sandbox_cleanup() -> Generator[list[UUID], None, None]:
-    """Track sandbox IDs created during a test and terminate them after.
-
-    Goes through ``SandboxManager.terminate`` (matching real shutdown
-    behavior) so the test stays valid on both Local and Kubernetes
-    backends. Swallows errors during teardown — the goal is cleanup, not
-    a second assertion surface.
-    """
-    tracked: list[UUID] = []
-    yield tracked
-    mgr = get_sandbox_manager()
-    for sandbox_id in tracked:
-        try:
-            mgr.terminate(sandbox_id)
-        except Exception:
-            # Best-effort: the test may have already terminated it.
-            pass
-
-
-def _provision_real(
-    mgr: SandboxManager,
-    sandbox: Sandbox,
-    user_id: UUID,
-) -> None:
-    """Bring a sandbox to RUNNING on the real backend.
-
-    Used by tests that need the pod/dir to exist before calling
-    ``ensure_sandbox_running`` (e.g. the "RUNNING + healthy" hot path).
-    """
-    mgr.provision(
-        sandbox_id=sandbox.id,
-        user_id=user_id,
-        tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
-        llm_config=LLMProviderConfig(
-            provider="test",
-            model_name="test-model",
-            api_key="test-key",
-            api_base=None,
-        ),
-        onyx_pat="ci-test-pat",
+def _running_info(sandbox_id: UUID) -> SandboxInfo:
+    """A ``provision``-style ``SandboxInfo`` that lands the row at RUNNING."""
+    return SandboxInfo(
+        sandbox_id=sandbox_id,
+        directory_path="/tmp/sandbox",
+        status=SandboxStatus.RUNNING,
+        last_heartbeat=None,
     )
 
 
-def _seed_row(
+def test_creates_sandbox_when_none_exists(
     db_session: Session,
-    user: User,
-    status: SandboxStatus,
-) -> Sandbox:
-    """Create only the DB row — no pod/dir."""
-    sandbox = create_sandbox__no_commit(db_session=db_session, user_id=user.id)
-    update_sandbox_status__no_commit(db_session, sandbox.id, status)
+    test_user: User,
+    stub_sandbox_manager: StubSandboxManager,
+    session_manager_with_stub: SessionManager,
+) -> None:
+    """No sandbox row -> a row is created and provisioned to RUNNING."""
+    stub_sandbox_manager.provision_returns = _running_info(uuid4())
+
+    result = session_manager_with_stub.ensure_sandbox_running(test_user.id)
     db_session.commit()
-    db_session.refresh(sandbox)
-    return sandbox
+
+    assert result.user_id == test_user.id
+    assert result.status == SandboxStatus.RUNNING
+    assert stub_sandbox_manager.provision_count == 1
+    # Exactly one row now exists for the user.
+    rows = db_session.query(Sandbox).filter(Sandbox.user_id == test_user.id).all()
+    assert len(rows) == 1
+    assert rows[0].id == result.id
 
 
-class TestEnsureSandboxRunning:
-    """State-machine coverage for ``SessionManager.ensure_sandbox_running``."""
+def test_running_and_healthy_returns_as_is(
+    test_user: User,
+    sandbox: Callable[..., Sandbox],
+    stub_sandbox_manager: StubSandboxManager,
+    session_manager_with_stub: SessionManager,
+) -> None:
+    """RUNNING + ``health_check`` True -> returned untouched (no provision/terminate)."""
+    existing = sandbox(user=test_user, status=SandboxStatus.RUNNING)
+    stub_sandbox_manager.health_check_returns = True
+    # ``provision_returns``/``terminate_silent`` left unset: the stub raises
+    # if either is invoked, which would fail this test.
 
-    def test_creates_sandbox_when_none_exists(
-        self,
-        db_session: Session,
-        test_user: User,
-        sandbox_cleanup: list[UUID],
-    ) -> None:
-        """No sandbox row → row is created and provisioned for real."""
-        session_manager = _make_session_manager(db_session)
+    result = session_manager_with_stub.ensure_sandbox_running(test_user.id)
 
-        sandbox = session_manager.ensure_sandbox_running(test_user.id)
+    assert result.id == existing.id
+    assert result.status == SandboxStatus.RUNNING
+    assert stub_sandbox_manager.provision_count == 0
+    assert stub_sandbox_manager.terminate_count == 0
+
+
+def test_running_but_unhealthy_recovers_via_terminate_then_provision(
+    db_session: Session,
+    test_user: User,
+    sandbox: Callable[..., Sandbox],
+    stub_sandbox_manager: StubSandboxManager,
+    session_manager_with_stub: SessionManager,
+) -> None:
+    """RUNNING in DB but pod unhealthy -> terminate + re-provision back to RUNNING."""
+    existing = sandbox(user=test_user, status=SandboxStatus.RUNNING)
+    stub_sandbox_manager.health_check_returns = False
+    stub_sandbox_manager.terminate_silent = True
+    stub_sandbox_manager.provision_returns = _running_info(existing.id)
+
+    result = session_manager_with_stub.ensure_sandbox_running(test_user.id)
+    db_session.commit()
+
+    assert result.id == existing.id
+    assert result.status == SandboxStatus.RUNNING
+    assert stub_sandbox_manager.terminate_count == 1
+    assert stub_sandbox_manager.last_terminate_sandbox_id == existing.id
+    assert stub_sandbox_manager.provision_count == 1
+
+
+@pytest.mark.parametrize(
+    "initial_status",
+    [
+        SandboxStatus.SLEEPING,
+        SandboxStatus.TERMINATED,
+        SandboxStatus.FAILED,
+    ],
+)
+def test_wakes_dormant_sandbox(
+    db_session: Session,
+    test_user: User,
+    sandbox: Callable[..., Sandbox],
+    stub_sandbox_manager: StubSandboxManager,
+    session_manager_with_stub: SessionManager,
+    initial_status: SandboxStatus,
+) -> None:
+    """SLEEPING / TERMINATED / FAILED -> re-provision the existing row in place."""
+    existing = sandbox(user=test_user, status=initial_status)
+    stub_sandbox_manager.provision_returns = _running_info(existing.id)
+
+    result = session_manager_with_stub.ensure_sandbox_running(test_user.id)
+    db_session.commit()
+
+    assert result.id == existing.id
+    assert result.status == SandboxStatus.RUNNING
+    assert stub_sandbox_manager.provision_count == 1
+    # No health_check on the wake path: the row was never RUNNING.
+    assert stub_sandbox_manager.health_check_count == 0
+
+
+def test_provisioning_transitions_to_running_during_wait(
+    db_session: Session,
+    test_user: User,
+    sandbox: Callable[..., Sandbox],
+    stub_sandbox_manager: StubSandboxManager,
+    session_manager_with_stub: SessionManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A concurrent provisioner finishes mid-wait: re-enter the state machine on
+    the new RUNNING status and return it without provisioning ourselves."""
+    existing = sandbox(user=test_user, status=SandboxStatus.PROVISIONING)
+
+    # Simulate the "other" provisioner finishing: the poll loop's first
+    # ``time.sleep`` flips the row to RUNNING and commits so the next
+    # ``db_session.refresh`` sees the transition.
+    flipped: list[bool] = [False]
+
+    def _flipping_sleep(_seconds: float) -> None:
+        if flipped[0]:
+            return
+        flipped[0] = True
+        existing.status = SandboxStatus.RUNNING
         db_session.commit()
-        sandbox_cleanup.append(sandbox.id)
 
-        assert sandbox.user_id == test_user.id
-        assert sandbox.status == SandboxStatus.RUNNING
-        # The real provision() left the sandbox in a healthy state.
-        assert session_manager._sandbox_manager.health_check(sandbox.id, timeout=5.0)
-
-    def test_running_and_healthy_returns_as_is(
-        self,
-        db_session: Session,
-        test_user: User,
-        sandbox_cleanup: list[UUID],
-    ) -> None:
-        """RUNNING + health_check=True → no re-provision, no terminate."""
-        session_manager = _make_session_manager(db_session)
-        mgr = session_manager._sandbox_manager
-
-        # Real seeded "healthy RUNNING" state: provision then make sure
-        # the row is RUNNING.
-        existing = create_sandbox__no_commit(
-            db_session=db_session, user_id=test_user.id
-        )
-        _provision_real(mgr, existing, test_user.id)
-        update_sandbox_status__no_commit(db_session, existing.id, SandboxStatus.RUNNING)
-        db_session.commit()
-        sandbox_cleanup.append(existing.id)
-
-        with (
-            patch.object(mgr, "provision", wraps=mgr.provision) as provision_spy,
-            patch.object(mgr, "terminate", wraps=mgr.terminate) as terminate_spy,
-        ):
-            sandbox = session_manager.ensure_sandbox_running(test_user.id)
-
-        assert sandbox.id == existing.id
-        assert sandbox.status == SandboxStatus.RUNNING
-        provision_spy.assert_not_called()
-        terminate_spy.assert_not_called()
-
-    def test_running_but_unhealthy_recovers_via_terminate_then_provision(
-        self,
-        db_session: Session,
-        test_user: User,
-        sandbox_cleanup: list[UUID],
-    ) -> None:
-        """RUNNING in DB but no pod/dir → health_check fails → terminate +
-        re-provision."""
-        # Seed RUNNING in the DB without actually provisioning, so the
-        # real health_check fails (no pod, no directory).
-        existing = _seed_row(db_session, test_user, SandboxStatus.RUNNING)
-        sandbox_cleanup.append(existing.id)
-
-        session_manager = _make_session_manager(db_session)
-        mgr = session_manager._sandbox_manager
-
-        with (
-            patch.object(mgr, "terminate", wraps=mgr.terminate) as terminate_spy,
-            patch.object(mgr, "provision", wraps=mgr.provision) as provision_spy,
-        ):
-            sandbox = session_manager.ensure_sandbox_running(test_user.id)
-            db_session.commit()
-
-        assert sandbox.id == existing.id
-        assert sandbox.status == SandboxStatus.RUNNING
-        terminate_spy.assert_called_once_with(existing.id)
-        provision_spy.assert_called_once()
-        # Real re-provision left the sandbox healthy.
-        assert mgr.health_check(sandbox.id, timeout=5.0)
-
-    @pytest.mark.parametrize(
-        "initial_status",
-        [
-            SandboxStatus.SLEEPING,
-            SandboxStatus.TERMINATED,
-            SandboxStatus.FAILED,
-        ],
+    monkeypatch.setattr(
+        "onyx.server.features.build.session.sandbox_lifecycle.time.sleep",
+        _flipping_sleep,
     )
-    def test_wakes_dormant_sandbox(
-        self,
-        db_session: Session,
-        test_user: User,
-        sandbox_cleanup: list[UUID],
-        initial_status: SandboxStatus,
-    ) -> None:
-        """SLEEPING / TERMINATED / FAILED → re-provision in place."""
-        existing = _seed_row(db_session, test_user, initial_status)
-        sandbox_cleanup.append(existing.id)
 
-        session_manager = _make_session_manager(db_session)
-        mgr = session_manager._sandbox_manager
+    # After the wait, the row is RUNNING and the hot path health-checks it.
+    stub_sandbox_manager.health_check_returns = True
 
-        with patch.object(mgr, "provision", wraps=mgr.provision) as provision_spy:
-            sandbox = session_manager.ensure_sandbox_running(test_user.id)
-            db_session.commit()
+    result = session_manager_with_stub.ensure_sandbox_running(
+        test_user.id,
+        provisioning_wait_seconds=10.0,
+    )
 
-        assert sandbox.id == existing.id
-        assert sandbox.status == SandboxStatus.RUNNING
-        provision_spy.assert_called_once()
-        assert mgr.health_check(sandbox.id, timeout=5.0)
+    assert result.id == existing.id
+    assert result.status == SandboxStatus.RUNNING
+    # We must NOT provision ourselves — the concurrent provisioner owned it.
+    assert stub_sandbox_manager.provision_count == 0
 
-    def test_provisioning_transitions_to_running_during_wait(
-        self,
-        db_session: Session,
-        test_user: User,
-        sandbox_cleanup: list[UUID],
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """A concurrent provisioner finishes mid-wait: we return RUNNING
-        without calling ``provision()`` ourselves."""
-        existing = _seed_row(db_session, test_user, SandboxStatus.PROVISIONING)
-        sandbox_cleanup.append(existing.id)
 
-        session_manager = _make_session_manager(db_session)
-        mgr = session_manager._sandbox_manager
+def test_provisioning_times_out_raises(
+    db_session: Session,
+    test_user: User,
+    sandbox: Callable[..., Sandbox],
+    stub_sandbox_manager: StubSandboxManager,
+    session_manager_with_stub: SessionManager,
+) -> None:
+    """Stuck PROVISIONING + 0s wait -> ``SandboxProvisioningError`` without provisioning.
 
-        # Sleep-hook simulates the "other" provisioner finishing: flip
-        # the DB row to RUNNING AND actually call the real provision so
-        # the subsequent health_check sees a live pod/dir.
-        #
-        # Set the flag *before* calling _provision_real. The k8s manager
-        # polls for pod readiness via ``time.sleep`` inside ``provision``,
-        # and ``monkeypatch.setattr`` on ``time.sleep`` rebinds the
-        # shared module attribute, so the inner sleep calls re-enter
-        # this hook. Without the early flip, those re-entries would
-        # recursively call ``_provision_real`` and blow the stack.
-        flipped: list[bool] = [False]
+    This is the deterministic-timeout contract that
+    ``test_scheduled_task_executor.py::test_run_fails_when_wake_fails`` relies on.
+    """
+    existing = sandbox(user=test_user, status=SandboxStatus.PROVISIONING)
 
-        def _flipping_sleep(_seconds: float) -> None:
-            if not flipped[0]:
-                flipped[0] = True
-                _provision_real(mgr, existing, test_user.id)
-                update_sandbox_status__no_commit(
-                    db_session, existing.id, SandboxStatus.RUNNING
-                )
-                db_session.commit()
-
-        monkeypatch.setattr(
-            "onyx.server.features.build.session.sandbox_lifecycle.time.sleep",
-            _flipping_sleep,
+    with pytest.raises(SandboxProvisioningError):
+        session_manager_with_stub.ensure_sandbox_running(
+            test_user.id,
+            provisioning_wait_seconds=0.0,
         )
 
-        with patch.object(mgr, "provision", wraps=mgr.provision) as provision_spy:
-            sandbox = session_manager.ensure_sandbox_running(
-                test_user.id,
-                provisioning_wait_seconds=10.0,
-            )
-
-        assert sandbox.id == existing.id
-        assert sandbox.status == SandboxStatus.RUNNING
-        # Exactly one provision is expected — the one the sleep hook
-        # makes to simulate the concurrent provisioner finishing. A
-        # second call would mean session_manager re-provisioned after
-        # the wait succeeded, which is what this test exists to prevent.
-        assert provision_spy.call_count == 1
-
-    def test_provisioning_times_out_raises(
-        self,
-        db_session: Session,
-        test_user: User,
-        sandbox_cleanup: list[UUID],
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """Stuck PROVISIONING → SandboxProvisioningError once the deadline
-        elapses (without provisioning ourselves)."""
-        existing = _seed_row(db_session, test_user, SandboxStatus.PROVISIONING)
-        sandbox_cleanup.append(existing.id)
-
-        session_manager = _make_session_manager(db_session)
-        mgr = session_manager._sandbox_manager
-
-        # No-op sleep keeps the test fast; real time.monotonic() still
-        # advances, so the tiny wait deadline elapses on the first check.
-        def _sleep_noop(_seconds: float) -> None:
-            return None
-
-        monkeypatch.setattr(
-            "onyx.server.features.build.session.sandbox_lifecycle.time.sleep",
-            _sleep_noop,
-        )
-
-        with patch.object(mgr, "provision", wraps=mgr.provision) as provision_spy:
-            with pytest.raises(SandboxProvisioningError):
-                session_manager.ensure_sandbox_running(
-                    test_user.id,
-                    provisioning_wait_seconds=0.0,
-                )
-
-        provision_spy.assert_not_called()
+    assert stub_sandbox_manager.provision_count == 0
+    # Row is untouched: still PROVISIONING.
+    db_session.expire_all()
+    refreshed = get_sandbox_by_user_id(db_session, test_user.id)
+    assert refreshed is not None
+    assert refreshed.id == existing.id
+    assert refreshed.status == SandboxStatus.PROVISIONING

--- a/backend/tests/external_dependency_unit/craft/test_scheduled_task_executor.py
+++ b/backend/tests/external_dependency_unit/craft/test_scheduled_task_executor.py
@@ -437,11 +437,13 @@ def test_run_fails_when_wake_fails(
     db_session: Session,
     test_user: User,
     sandbox: Callable[..., Sandbox],
+    session_manager_with_stub: SessionManager,  # noqa: ARG001 — binds the stub backend
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A PROVISIONING sandbox with a 0s wait window makes the wake deterministically
-    raise, which must mark the run FAILED / sandbox_wake_failed. Backend-agnostic:
-    ensure_sandbox_running times out polling the DB row before touching any manager."""
+    """A PROVISIONING sandbox with a 0s wait window makes ensure_sandbox_running time
+    out polling the DB row, marking the run FAILED / sandbox_wake_failed. The stub
+    backend is bound so SessionManager construction can't raise and satisfy the
+    assertion via the same broad handler without exercising the timeout path."""
     monkeypatch.setattr(
         "onyx.server.features.build.scheduled_tasks.executor.PROVISIONING_WAIT_SECONDS",
         0,

--- a/backend/tests/external_dependency_unit/craft/test_scheduled_task_executor.py
+++ b/backend/tests/external_dependency_unit/craft/test_scheduled_task_executor.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import datetime
 import threading
+from collections.abc import Callable
 from typing import Any
 from unittest.mock import patch
 from unittest.mock import PropertyMock
@@ -38,11 +39,10 @@ from onyx.db.enums import ScheduledTaskErrorClass
 from onyx.db.enums import ScheduledTaskRunStatus
 from onyx.db.enums import ScheduledTaskStatus
 from onyx.db.enums import ScheduledTaskTriggerSource
+from onyx.db.models import Sandbox
 from onyx.db.models import ScheduledTask
 from onyx.db.models import ScheduledTaskRun
 from onyx.db.models import User
-from onyx.server.features.build.configs import SANDBOX_BACKEND
-from onyx.server.features.build.configs import SandboxBackend
 from onyx.server.features.build.sandbox.event_schema import Error
 from onyx.server.features.build.sandbox.event_schema import PromptResponse
 from onyx.server.features.build.sandbox.event_schema import TURN_ERROR_CODE_TIMEOUT
@@ -52,7 +52,6 @@ from onyx.server.features.build.session.manager import SessionManager
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 from tests.common.craft.stubs import StubSandboxManager
-from tests.external_dependency_unit.craft.db_helpers import make_sandbox
 from tests.external_dependency_unit.craft.db_helpers import make_user
 
 # ---------------------------------------------------------------------------
@@ -100,49 +99,6 @@ def _seed_task_and_queued_run(
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
-
-
-@pytest.mark.skipif(
-    SANDBOX_BACKEND != SandboxBackend.KUBERNETES,
-    reason="Exercises run_scheduled_task_logic → SessionManager → real "
-    "KubernetesSandboxManager init; requires SANDBOX_BACKEND=kubernetes "
-    "(runs in the dedicated K8s CI job).",
-)
-def test_run_fails_when_wake_fails(
-    db_session: Session,
-    test_user: User,  # noqa: ARG001
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """``ensure_sandbox_running`` raising → run FAILED / ``sandbox_wake_failed``.
-
-    Trigger a deterministic wake failure by seeding the sandbox as
-    ``PROVISIONING`` and dropping the executor's wait window to 0s so
-    ``_wait_for_provisioning_to_complete`` raises ``SandboxProvisioningError``
-    on the first deadline check. That's the executor's Phase-1
-    try/except path, which must translate any exception escaping
-    ``ensure_sandbox_running`` into ``FAILED`` with
-    ``error_class=sandbox_wake_failed``.
-
-    "How we got there" (which specific state triggered the wake, which
-    inner call raised) is intentionally out of scope — this test pins
-    only the executor's contract.
-    """
-    monkeypatch.setattr(
-        "onyx.server.features.build.scheduled_tasks.executor.PROVISIONING_WAIT_SECONDS",
-        0,
-    )
-
-    user = make_user(db_session)
-    make_sandbox(db_session, user, status=SandboxStatus.PROVISIONING)
-    _, run = _seed_task_and_queued_run(db_session, user)
-
-    run_scheduled_task_logic(run.id)
-
-    db_session.expire_all()
-    refreshed = db_session.get(ScheduledTaskRun, run.id)
-    assert refreshed is not None
-    assert refreshed.status == ScheduledTaskRunStatus.FAILED
-    assert refreshed.error_class == ScheduledTaskErrorClass.SANDBOX_WAKE_FAILED.value
 
 
 def test_dispatch_uses_skip_locked_to_avoid_dupes(
@@ -475,3 +431,29 @@ def test_stream_without_prompt_response_marks_run_failed(
     assert refreshed is not None
     assert refreshed.status == ScheduledTaskRunStatus.FAILED
     assert refreshed.error_class == ScheduledTaskErrorClass.AGENT_EXCEPTION.value
+
+
+def test_run_fails_when_wake_fails(
+    db_session: Session,
+    test_user: User,
+    sandbox: Callable[..., Sandbox],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A PROVISIONING sandbox with a 0s wait window makes the wake deterministically
+    raise, which must mark the run FAILED / sandbox_wake_failed. Backend-agnostic:
+    ensure_sandbox_running times out polling the DB row before touching any manager."""
+    monkeypatch.setattr(
+        "onyx.server.features.build.scheduled_tasks.executor.PROVISIONING_WAIT_SECONDS",
+        0,
+    )
+
+    sandbox(user=test_user, status=SandboxStatus.PROVISIONING)
+    _, run = _seed_task_and_queued_run(db_session, test_user)
+
+    run_scheduled_task_logic(run.id)
+
+    db_session.expire_all()
+    refreshed = db_session.get(ScheduledTaskRun, run.id)
+    assert refreshed is not None
+    assert refreshed.status == ScheduledTaskRunStatus.FAILED
+    assert refreshed.error_class == ScheduledTaskErrorClass.SANDBOX_WAKE_FAILED.value

--- a/backend/tests/external_dependency_unit/craft/test_streaming_persistence.py
+++ b/backend/tests/external_dependency_unit/craft/test_streaming_persistence.py
@@ -144,88 +144,41 @@ class TestStreamingPersistence:
     def test_agent_message_chunks_persist_as_single_assistant_row(
         self,
         db_session: Session,
+        test_user: User,
         build_session: BuildSession,
+        sandbox: Callable[..., Sandbox],
+        session_manager_with_stub: SessionManager,
+        stub_sandbox_manager: StubSandboxManager,
         tenant_context: None,  # noqa: ARG002
     ) -> None:
-        """3 chunks → 1 BuildMessage row, concatenated content.
+        """One assistant row per agent_message burst, not one per chunk.
 
-        Simulates:
-        1. Initial user message
-        2. Agent message chunks (3) → 1 assistant row
-        3. Tool call (completed) → 1 assistant row
-        4. Agent message chunks (2) → 1 assistant row
-
-        This verifies that chunk-accumulation finalize writes exactly one row
-        per stream-side burst rather than one row per chunk.
+        Two chunk bursts split by a completed tool call → three assistant rows
+        (first burst, tool row, second burst). Driven through the real
+        ``SessionManager`` stream path so the finalize-on-packet-type-change
+        behaviour is exercised rather than reimplemented in the test body.
         """
-        # 0. Initial user message
-        create_message(
-            session_id=build_session.id,
-            message_type=MessageType.USER,
-            turn_index=0,
-            message_metadata={
-                "type": "user_message",
-                "content": {"type": "text", "text": "Do something"},
-            },
+        sandbox(user=test_user)
+        stub_sandbox_manager.send_message_events = [
+            _text_chunk("Thinking"),
+            _text_chunk(" about it..."),
+            _tool_call_progress("call_1", "Bash", status="completed"),
+            _text_chunk("Done"),
+            _text_chunk(" with tool."),
+            _prompt_response(),
+        ]
+        _drive_persisted_turn(
             db_session=db_session,
+            mgr=session_manager_with_stub,
+            build_session=build_session,
+            user=test_user,
+            content="Do something",
         )
 
-        state = BuildStreamingState(turn_index=0)
-
-        # 1. Stream agent message chunks
-        state.add_message_chunk("Thinking")
-        state.add_message_chunk(" about it...")
-
-        # Simulate switch to tool call (e.g. ToolCallStart event) -> finalize message
-        # In SessionManager, this happens via state.should_finalize_chunks()
-        if state.should_finalize_chunks("tool_call_start"):
-            msg_packet = state.finalize_message_chunks()
-            if msg_packet:
-                create_message(
-                    session_id=build_session.id,
-                    message_type=MessageType.ASSISTANT,
-                    turn_index=0,
-                    message_metadata=msg_packet,
-                    db_session=db_session,
-                )
-        state.clear_last_chunk_type()
-
-        # 2. Handle completed tool call (immediate save)
-        tool_packet = {
-            "type": "tool_call_progress",
-            "toolCallId": "call_1",
-            "status": "completed",
-            "timestamp": "2025-01-01T00:00:00Z",
-        }
-        create_message(
-            session_id=build_session.id,
-            message_type=MessageType.ASSISTANT,
-            turn_index=0,
-            message_metadata=tool_packet,
-            db_session=db_session,
-        )
-
-        # 3. Stream more agent message chunks
-        state.add_message_chunk("Done")
-        state.add_message_chunk(" with tool.")
-
-        # End of stream -> finalize
-        msg_packet = state.finalize_message_chunks()
-        if msg_packet:
-            create_message(
-                session_id=build_session.id,
-                message_type=MessageType.ASSISTANT,
-                turn_index=0,
-                message_metadata=msg_packet,
-                db_session=db_session,
-            )
-
-        # Verify DB state
         messages = get_session_messages(build_session.id, db_session)
-        # 1 user + 3 assistant = 4 total
+        # 1 user + agent_message burst + tool row + agent_message burst.
         assert len(messages) == 4
 
-        # Verify types/order
         assert messages[0].type == MessageType.USER
 
         assert messages[1].type == MessageType.ASSISTANT


### PR DESCRIPTION
## Description

Refocus selected Craft external-dependency-unit tests so they no longer need a live Kubernetes sandbox backend. The sandbox wake state-machine coverage now uses the stub sandbox manager, scheduled task wake-failure coverage uses a deterministic provisioning timeout, and streaming persistence drives the real SessionManager path with stubbed stream events.

## How Has This Been Tested?


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Craft EDU tests backend-agnostic by replacing Kubernetes-only paths with a stubbed sandbox manager and deterministic timeouts. The scheduled-task wake-failure test now binds the stub backend to ensure we exercise the timeout path, not construction errors.

- **Refactors**
  - Rewrote `ensure_sandbox_running` tests to use `StubSandboxManager`; cover healthy RUNNING, unhealthy recovery via terminate+provision, wake from SLEEPING/TERMINATED/FAILED, PROVISIONING flip during wait, and 0s wait raising `SandboxProvisioningError`.
  - Updated scheduled-task wake-failure to bind the stub backend and use a 0s wait window to force a polling timeout; asserts FAILED with `sandbox_wake_failed` and removes `SANDBOX_BACKEND` gating.
  - Drove streaming persistence through real `SessionManager` with stubbed stream events to verify one assistant row per agent_message burst.

<sup>Written for commit 3d96da06e9a084de8e457840cae7dbe75e7d5334. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

