### PR TITLE
fix(fe): model selector items expand after e15dd5903e

### DIFF
--- a/web/src/app/craft/onboarding/components/OnboardingLlmSetup.tsx
+++ b/web/src/app/craft/onboarding/components/OnboardingLlmSetup.tsx
@@ -34,23 +34,25 @@ function SelectableButton({
 }: SelectableButtonProps) {
   const button = (
     <div className="flex flex-col items-center gap-1">
-      <Disabled disabled={disabled} allowClick>
-        <button
-          type="button"
-          onClick={onClick}
-          disabled={disabled}
-          className={cn(
-            "w-full px-6 py-3 rounded-12 border transition-colors",
-            selected
-              ? "border-action-link-05 bg-action-link-01 text-action-text-link-05"
-              : "border-border-01 bg-background-tint-00 text-text-04 hover:bg-background-tint-01"
-          )}
-        >
-          <Text font="main-ui-action" color="text-05">
-            {children}
-          </Text>
-        </button>
-      </Disabled>
+      <div className="w-full">
+        <Disabled disabled={disabled} allowClick>
+          <button
+            type="button"
+            onClick={onClick}
+            disabled={disabled}
+            className={cn(
+              "w-full px-6 py-3 rounded-12 border transition-colors",
+              selected
+                ? "border-action-link-05 bg-action-link-01 text-action-text-link-05"
+                : "border-border-01 bg-background-tint-00 text-text-04 hover:bg-background-tint-01"
+            )}
+          >
+            <Text font="main-ui-action" color="text-05">
+              {children}
+            </Text>
+          </button>
+        </Disabled>
+      </div>
       {subtext && (
         <Text font="figure-small-label" color="text-02">
           {subtext}
@@ -83,23 +85,25 @@ function ModelSelectButton({
 }: ModelSelectButtonProps) {
   return (
     <div className="flex flex-col items-center gap-1 w-full">
-      <Disabled disabled={disabled} allowClick>
-        <button
-          type="button"
-          onClick={onClick}
-          disabled={disabled}
-          className={cn(
-            "w-full px-4 py-2.5 rounded-12 border transition-colors",
-            selected
-              ? "border-action-link-05 bg-action-link-01 text-action-text-link-05"
-              : "border-border-01 bg-background-tint-00 text-text-04 hover:bg-background-tint-01"
-          )}
-        >
-          <Text font="main-ui-action" color="text-05">
-            {label}
-          </Text>
-        </button>
-      </Disabled>
+      <div className="w-full">
+        <Disabled disabled={disabled} allowClick>
+          <button
+            type="button"
+            onClick={onClick}
+            disabled={disabled}
+            className={cn(
+              "w-full px-4 py-2.5 rounded-12 border transition-colors",
+              selected
+                ? "border-action-link-05 bg-action-link-01 text-action-text-link-05"
+                : "border-border-01 bg-background-tint-00 text-text-04 hover:bg-background-tint-01"
+            )}
+          >
+            <Text font="main-ui-action" color="text-05">
+              {label}
+            </Text>
+          </button>
+        </Disabled>
+      </div>
       {recommended && (
         <Text font="figure-small-label" color="text-02">
           Recommended

--- a/web/src/sections/model-selector/ModelSelectorContent.tsx
+++ b/web/src/sections/model-selector/ModelSelectorContent.tsx
@@ -207,7 +207,11 @@ export default function ModelSelectorContent({
                 ]
               : groupedOptions.length === 1
                 ? [
-                    <Section key="single-provider" gap={0.25}>
+                    <Section
+                      key="single-provider"
+                      gap={0.25}
+                      alignItems="stretch"
+                    >
                       {groupedOptions[0]!.options.map(renderModelItem)}
                     </Section>,
                   ]
@@ -261,7 +265,7 @@ export default function ModelSelectorContent({
                         </CollapsibleTrigger>
 
                         <CollapsibleContent>
-                          <Section gap={0.25}>
+                          <Section gap={0.25} alignItems="stretch">
                             {group.options.map(renderModelItem)}
                           </Section>
                         </CollapsibleContent>

--- a/web/src/views/AgentEditorPage.tsx
+++ b/web/src/views/AgentEditorPage.tsx
@@ -338,7 +338,7 @@ function MCPServerCard({
     );
   } else if (hasTools) {
     cardContent = (
-      <GeneralLayouts.Section gap={0.5} padding={0.5}>
+      <GeneralLayouts.Section gap={0.5} padding={0.5} alignItems="stretch">
         {filteredTools.map((tool) => {
           const toolDisabled =
             !tool.isAvailable ||
@@ -1488,7 +1488,7 @@ export default function AgentEditorPage({
                           description="Tools and capabilities available for this agent to use."
                         />
                         <SimpleCollapsible.Content>
-                          <GeneralLayouts.Section gap={0.5}>
+                          <GeneralLayouts.Section gap={0.5} alignItems="stretch">
                             <Disabled
                               disabled={!isImageGenerationAvailable}
                               tooltip={imageGenerationDisabledTooltip}

--- a/web/src/views/AgentEditorPage.tsx
+++ b/web/src/views/AgentEditorPage.tsx
@@ -1488,7 +1488,10 @@ export default function AgentEditorPage({
                           description="Tools and capabilities available for this agent to use."
                         />
                         <SimpleCollapsible.Content>
-                          <GeneralLayouts.Section gap={0.5} alignItems="stretch">
+                          <GeneralLayouts.Section
+                            gap={0.5}
+                            alignItems="stretch"
+                          >
                             <Disabled
                               disabled={!isImageGenerationAvailable}
                               tooltip={imageGenerationDisabledTooltip}

--- a/web/src/views/admin/IndexSettingsPage/index.tsx
+++ b/web/src/views/admin/IndexSettingsPage/index.tsx
@@ -1443,7 +1443,10 @@ export default function IndexSettingsPage() {
                         borderColor={statusVariant}
                         rounding="lg"
                       >
-                        <GeneralLayouts.Section width="full" alignItems="stretch">
+                        <GeneralLayouts.Section
+                          width="full"
+                          alignItems="stretch"
+                        >
                           <InputHorizontal
                             title="Contextual Retrieval"
                             description="Add document-level context to every indexed chunk to improve hybrid search relevance. This can increase embedding cost significantly."
@@ -1508,7 +1511,10 @@ export default function IndexSettingsPage() {
                       }
                     >
                       <Card border="solid" rounding="lg">
-                        <GeneralLayouts.Section width="full" alignItems="stretch">
+                        <GeneralLayouts.Section
+                          width="full"
+                          alignItems="stretch"
+                        >
                           <InputHorizontal
                             title="Extract & Caption Images"
                             description="Extract embedded images from uploaded files (PDFs, DOCX, etc.) and summarize them with a vision-capable LLM so image-only documents become searchable and answerable. Requires a vision-capable default LLM."

--- a/web/src/views/admin/IndexSettingsPage/index.tsx
+++ b/web/src/views/admin/IndexSettingsPage/index.tsx
@@ -1443,7 +1443,7 @@ export default function IndexSettingsPage() {
                         borderColor={statusVariant}
                         rounding="lg"
                       >
-                        <GeneralLayouts.Section width="full">
+                        <GeneralLayouts.Section width="full" alignItems="stretch">
                           <InputHorizontal
                             title="Contextual Retrieval"
                             description="Add document-level context to every indexed chunk to improve hybrid search relevance. This can increase embedding cost significantly."
@@ -1508,7 +1508,7 @@ export default function IndexSettingsPage() {
                       }
                     >
                       <Card border="solid" rounding="lg">
-                        <GeneralLayouts.Section width="full">
+                        <GeneralLayouts.Section width="full" alignItems="stretch">
                           <InputHorizontal
                             title="Extract & Caption Images"
                             description="Extract embedded images from uploaded files (PDFs, DOCX, etc.) and summarize them with a vision-capable LLM so image-only documents become searchable and answerable. Requires a vision-capable default LLM."


### PR DESCRIPTION
## Description

More cases where `Disabled` stretching itself was load-bearing after e15dd5903e.

## How Has This Been Tested?

**multiple providers**
<img width="1902" height="2085" alt="20260626_10h59m21s_grim" src="https://github.com/user-attachments/assets/d00aa0ea-eb77-4693-be51-e4f2187df4de" />

**single provider**
<img width="1902" height="2085" alt="20260626_10h58m55s_grim" src="https://github.com/user-attachments/assets/af6d22fc-a457-426f-87e4-fdca13600129" />

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a regression that stopped `Disabled`-wrapped items from stretching full-width. Restores consistent full-width layouts in model selector, onboarding, agent tools, and index settings.

- **Bug Fixes**
  - Applied alignItems="stretch" to Section containers for single-provider lists, grouped/collapsible model lists, tool cards, and settings rows.
  - Wrapped onboarding provider/model buttons in a full-width container to restore stretched buttons and larger click targets.

<sup>Written for commit 8cc9f3c3973f5c0a62eacb94e1d1d73604a01173. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

