### PR TITLE
fix(deployment): read release id from create response to avoid list race

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -242,12 +242,6 @@ jobs:
 
           release_id=$(get_release_id)
           if [ -z "$release_id" ]; then
-            # Create the draft release via the API and read the id directly from
-            # the creation response. The list endpoint above is eventually
-            # consistent — a freshly created draft can be absent from
-            # get_release_id for several seconds — so re-listing to discover the
-            # new id races and intermittently returns empty. The POST response is
-            # authoritative and always includes the id.
             release_id=$(gh api --method POST "repos/${GITHUB_REPOSITORY}/releases" \
               -f tag_name="$TAG" \
               -f name="$TAG" \

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -242,11 +242,18 @@ jobs:
 
           release_id=$(get_release_id)
           if [ -z "$release_id" ]; then
-            gh release create "$TAG" \
-              --title "$TAG" \
-              --notes "See the assets to download this version and install." \
-              --draft
-            release_id=$(get_release_id)
+            # Create the draft release via the API and read the id directly from
+            # the creation response. The list endpoint above is eventually
+            # consistent — a freshly created draft can be absent from
+            # get_release_id for several seconds — so re-listing to discover the
+            # new id races and intermittently returns empty. The POST response is
+            # authoritative and always includes the id.
+            release_id=$(gh api --method POST "repos/${GITHUB_REPOSITORY}/releases" \
+              -f tag_name="$TAG" \
+              -f name="$TAG" \
+              -f body="See the assets to download this version and install." \
+              -F draft=true \
+              --jq '.id')
           fi
 
           if [ -z "$release_id" ]; then


### PR DESCRIPTION
- [x] [Optional] Please cherry-pick this PR to the latest release version.

## Problem

The `create-release` job intermittently fails with `Failed to resolve release id for tag <tag>`. Example: [run 28249562123, attempt 1](https://github.com/onyx-dot-app/onyx/actions/runs/28249562123/job/83697553505).

The job created a draft release with `gh release create … --draft` (which succeeded), then rediscovered its id by re-listing `GET /releases` and matching on `tag_name`:

```
gh release create … --draft   → succeeded (draft: untagged-e22479c5cd5b44ee1964)
get_release_id (re-list)       → empty   ← GET /releases hadn't caught up yet
→ "Failed to resolve release id for tag v4.2.1" → exit 1
```

`GET /releases` is eventually consistent, so a just-created draft can be absent from the list for several seconds. Re-listing to discover the new id therefore races and intermittently returns empty, failing the job. (Re-runs "succeed" only because the list eventually catches up and finds the orphaned draft left by the failed attempt.)

## Fix

Create the draft via `gh api --method POST /releases` and read `.id` straight from the **creation response**, which is immediately authoritative — eliminating the consistency window entirely. The initial list lookup is retained for idempotency so re-runs reuse an existing/orphaned draft instead of creating duplicates.

This is preferred over retry-with-sleep: a sleep only guesses at the lag window and can still flake, whereas reading the id from the POST response removes the race outright.

## Notes

- Independent of the separate `check-version-tag` topology failure in the same run (`v4.2.0` not an ancestor of `v4.2.1`).
- A leftover orphaned draft (`untagged-e22479c5cd5b44ee1964`) from the failed attempt may exist in the repo's releases and can be cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the create-release job flakiness by reading the release id directly from the POST creation response.
We now create the draft via `gh api --method POST repos/${GITHUB_REPOSITORY}/releases` and parse `.id` with `--jq`, avoiding the eventually consistent `GET /releases` race while keeping the initial list check for idempotent re-runs.

<sup>Written for commit fd6bde6e95830c38f841a261a6b531a7ff3e79f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

