### PR TITLE
feat(web): add strict CSP directives behind WEB_STRICT_CSP_ENABLED

### DIFF
--- a/deployment/docker_compose/env.prod.template
+++ b/deployment/docker_compose/env.prod.template
@@ -10,6 +10,11 @@ WEB_DOMAIN=http://localhost:3000
 # clickjacking protection. Protected by default.
 # WEB_FRAME_PROTECTION_ENABLED=false
 
+# Set to true to add strict Content-Security-Policy directives
+# (default-src/script-src/connect-src/etc.) restricting where scripts load
+# from and where data can be sent. Off by default.
+# WEB_STRICT_CSP_ENABLED=true
+
 # The following are for configuring User Authentication, supported flows are:
 # disabled
 # basic (standard username / password)

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -92,6 +92,11 @@ USER_AUTH_SECRET=""
 ## clickjacking protection. Protected by default.
 # WEB_FRAME_PROTECTION_ENABLED=false
 
+## Set to true to add strict Content-Security-Policy directives
+## (default-src/script-src/connect-src/etc.) restricting where scripts load
+## from and where data can be sent. Off by default.
+# WEB_STRICT_CSP_ENABLED=true
+
 ## Enterprise Features, requires a paid plan and licenses
 ENABLE_PAID_ENTERPRISE_EDITION_FEATURES=false
 

--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -35,6 +35,20 @@ const frameProtectionEnabled =
 const strictCspEnabled =
   process.env.WEB_STRICT_CSP_ENABLED?.toLowerCase() === "true";
 
+// Sentry has no tunnel configured, so the browser SDK POSTs events straight to
+// the host embedded in the DSN. Derive that origin (build-inlined like the SDK
+// itself) so connect-src covers both SaaS (*.ingest.*.sentry.io) and
+// self-hosted instances; empty when Sentry is disabled or the DSN is unparseable.
+const sentryConnectSrc = (() => {
+  const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
+  if (!dsn) return "";
+  try {
+    return new URL(dsn).origin;
+  } catch {
+    return "";
+  }
+})();
+
 // NEXT_PUBLIC_* and NODE_ENV are inlined at build, so this stays build-time —
 // only the frame-ancestors flag above is runtime.
 const upgradeInsecureRequests =
@@ -53,17 +67,26 @@ const CSP_HEADER = [
   upgradeInsecureRequests ? "upgrade-insecure-requests;" : "",
   // 'unsafe-inline' is required: the App Router emits inline scripts for
   // hydration (nonce-based CSP is a deferred follow-up). PostHog is proxied
-  // same-origin via /ph_ingest (next.config.js rewrites), so 'self' covers it;
-  // Sentry events POST to the DSN's ingest host.
+  // same-origin via /ph_ingest (next.config.js rewrites), so 'self' covers it.
+  // googletagmanager.com lets the optional GTM bootstrap (NEXT_PUBLIC_GTM_ENABLED)
+  // load gtm.js; GTM-configured downstream tags may need extra origins added.
   strictCspEnabled ? "default-src 'self';" : "",
-  strictCspEnabled ? "script-src 'self' 'unsafe-inline';" : "",
+  strictCspEnabled
+    ? "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com;"
+    : "",
   // connect-src blob: for the DOCX preview modal, which fetches the document
-  // back out of a blob: URL to render it.
-  strictCspEnabled ? "connect-src 'self' blob: https://*.sentry.io;" : "",
+  // back out of a blob: URL to render it. The Sentry origin (when configured) is
+  // derived from the DSN above.
+  strictCspEnabled
+    ? `connect-src 'self' blob:${
+        sentryConnectSrc ? ` ${sentryConnectSrc}` : ""
+      };`
+    : "",
   // img-src stays broad: chat markdown and connector content render remote
   // images.
   strictCspEnabled ? "img-src 'self' data: blob: https:;" : "",
-  strictCspEnabled ? "media-src 'self' blob: data:;" : "",
+  // cdn.onyx.app serves the Craft page's animated background video.
+  strictCspEnabled ? "media-src 'self' blob: data: https://cdn.onyx.app;" : "",
   // worker-src blob: covers pdf.js-style workers and the PostHog session
   // recorder; frame-src blob: covers in-app PDF preview.
   strictCspEnabled ? "worker-src 'self' blob:;" : "",

--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -29,6 +29,12 @@ const PUBLIC_ROUTES = ["/auth", "/anonymous", "/_next", "/api"];
 const frameProtectionEnabled =
   process.env.WEB_FRAME_PROTECTION_ENABLED?.toLowerCase() !== "false";
 
+// Strict CSP (default-src/script-src/connect-src/etc. directives). Off by
+// default while the allowlist is validated against real deployments; enable
+// with WEB_STRICT_CSP_ENABLED=true (runtime, no rebuild needed).
+const strictCspEnabled =
+  process.env.WEB_STRICT_CSP_ENABLED?.toLowerCase() === "true";
+
 // NEXT_PUBLIC_* and NODE_ENV are inlined at build, so this stays build-time —
 // only the frame-ancestors flag above is runtime.
 const upgradeInsecureRequests =
@@ -45,6 +51,23 @@ const CSP_HEADER = [
     ? "frame-ancestors 'self' chrome-extension: moz-extension:;"
     : "",
   upgradeInsecureRequests ? "upgrade-insecure-requests;" : "",
+  // 'unsafe-inline' is required: the App Router emits inline scripts for
+  // hydration (nonce-based CSP is a deferred follow-up). PostHog is proxied
+  // same-origin via /ph_ingest (next.config.js rewrites), so 'self' covers it;
+  // Sentry events POST to the DSN's ingest host.
+  strictCspEnabled ? "default-src 'self';" : "",
+  strictCspEnabled ? "script-src 'self' 'unsafe-inline';" : "",
+  // connect-src blob: for the DOCX preview modal, which fetches the document
+  // back out of a blob: URL to render it.
+  strictCspEnabled ? "connect-src 'self' blob: https://*.sentry.io;" : "",
+  // img-src stays broad: chat markdown and connector content render remote
+  // images.
+  strictCspEnabled ? "img-src 'self' data: blob: https:;" : "",
+  strictCspEnabled ? "media-src 'self' blob: data:;" : "",
+  // worker-src blob: covers pdf.js-style workers and the PostHog session
+  // recorder; frame-src blob: covers in-app PDF preview.
+  strictCspEnabled ? "worker-src 'self' blob:;" : "",
+  strictCspEnabled ? "frame-src 'self' blob:;" : "",
 ]
   .filter(Boolean)
   .join(" ");


### PR DESCRIPTION
## What

Adds the missing CSP fetch-directives — `default-src`, `script-src`, `connect-src`, plus `img-src`, `media-src`, `worker-src`, and `frame-src` — to the Next.js middleware (`web/src/proxy.ts`), gated behind a new runtime flag **`WEB_STRICT_CSP_ENABLED`** (default **off**).

Today the CSP only sets `style-src`/`font-src`/`object-src`/`base-uri`/`form-action`/`frame-ancestors`. Without `script-src`/`default-src`, there's no policy constraining where scripts load from or where data can be exfiltrated to. These directives add that containment.

## Why off by default

The flag follows the exact runtime pattern of the existing `WEB_FRAME_PROTECTION_ENABLED` (read in middleware, so it applies on restart with **no rebuild**). It ships **off** because a too-narrow `script-src`/`connect-src` allowlist hard-blocks resources rather than degrading gracefully, and parts of the allowlist (Sentry DSN ingest host, PostHog key) can't be exercised from local dev. Default-off lets an operator flip it on, watch their browser console / Sentry for CSP violations against their own origins, and roll back instantly without a redeploy.

**When off, the emitted header is byte-identical to today's** (verified by diff) — zero behavior change for existing deployments.

## The policy (flag on)

```
default-src 'self';
script-src 'self' 'unsafe-inline';
connect-src 'self' blob: https://*.sentry.io;
img-src 'self' data: blob: https:;
media-src 'self' blob: data:;
worker-src 'self' blob:;
frame-src 'self' blob:;
```

Rationale captured inline in `proxy.ts`:
- **`'unsafe-inline'`** on `script-src`: the App Router emits inline hydration scripts (nonce-based CSP is a deferred follow-up).
- **`connect-src blob:`**: the DOCX preview modal fetches the document back out of a `blob:` URL to render it.
- **`frame-src blob:` / `worker-src blob:`**: in-app PDF preview iframe and pdf.js-style / PostHog session-recorder workers.
- **`img-src` broad**: chat markdown and connector content render remote images.
- **PostHog** is proxied same-origin via `/ph_ingest` (covered by `'self'`); **Sentry** events POST to the DSN ingest host (`https://*.sentry.io`).

## Testing

- **Flag off**: emitted header diffed byte-for-byte against the pre-change header — identical.
- **Flag on** (local dev, manual + Playwright): chat streaming, remote chat images, PDF preview (blob iframe), admin pages — all clean, no CSP violations. Surfaced **one** real violation (DOCX preview's `blob:` fetch) which is fixed by the `connect-src blob:` entry above.
- `bunx oxlint` and `bun run types:check` both pass.
- `chat_message_rendering.spec.ts` — 28/28 pass with the flag on.

> [!NOTE]
> The Sentry/PostHog allowlist entries were validated by **code review only** — no `NEXT_PUBLIC_SENTRY_DSN` / PostHog key is set in local dev. A reviewer with a real deployment should confirm their Sentry region host matches `https://*.sentry.io` before flipping the flag on.

## Scope

Code change is `web/src/proxy.ts` only; the two `env*.template` edits are documentation for the new flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds strict CSP directives behind `WEB_STRICT_CSP_ENABLED` to restrict script sources and outbound connections. Off by default; toggle at runtime without rebuild; allows GTM and Craft video, derives Sentry origin from `NEXT_PUBLIC_SENTRY_DSN`, and headers are unchanged when off.

- **New Features**
  - When enabled, middleware adds: default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com; connect-src 'self' blob: [Sentry DSN origin if set]; img-src 'self' data: blob: https:; media-src 'self' blob: data: https://cdn.onyx.app; worker-src 'self' blob:; frame-src 'self' blob:;
  - Covers App Router hydration, DOCX/PDF previews and workers via blob:, PostHog via same-origin proxy, GTM bootstrap, Sentry via DSN-derived origin (supports self-hosted), and the Craft background video.

- **Migration**
  - Set `WEB_STRICT_CSP_ENABLED=true` and restart the web service.
  - If using Sentry, ensure `NEXT_PUBLIC_SENTRY_DSN` is set and monitor for CSP violations.

<sup>Written for commit 63f3646833c92c3c5d59c984651c6c752e9d8de7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

