### PR TITLE
feat(craft): richer create-issue fields for Linear external app (ENG-4257)

### DIFF
--- a/backend/onyx/skills/builtin/linear/SKILL.md.template
+++ b/backend/onyx/skills/builtin/linear/SKILL.md.template
@@ -56,8 +56,15 @@ python linear_api.py projects [--limit N]
 ### Create an issue (write)
 
 ```
-python linear_api.py create-issue <team_id> "Title" [--description D] [--assignee USER_ID]
+python linear_api.py create-issue <team_id> "Title" \
+  [--description D] [--assignee USER_ID] [--project PROJECT_ID] \
+  [--state NAME_OR_ID] [--priority 0-4] [--label LABEL_ID ...] \
+  [--estimate N] [--parent ISSUE_ID]
 ```
+
+`--state` accepts a workflow state name (resolved case-insensitively against
+the team's states) or a state id. `--label` is repeatable. `--priority` is an
+int 0-4 (0 none, 1 urgent, 2 high, 3 normal, 4 low).
 
 ### Comment on an issue (write)
 
@@ -74,6 +81,8 @@ the error rather than retrying blindly.
 
 ## Notes
 
-- `create-issue` needs a team id (from `teams`); `--assignee` takes a user id.
+- `create-issue` needs a team id (from `teams`); `--assignee` takes a user id,
+  `--project` a project id (from `projects`, which now lists each project's
+  linked `teams`), and `--label`/`--parent` take label/issue ids.
 - `call` lets you send any GraphQL — pass user input as variables, not by
   string-formatting into the query.

--- a/backend/onyx/skills/builtin/linear/linear_api.py
+++ b/backend/onyx/skills/builtin/linear/linear_api.py
@@ -139,10 +139,7 @@ def _resolve_state_id(team_id: str, state: str) -> str:
     no matching state is found (or the lookup fails)."""
     if _UUID_RE.match(state):
         return state
-    q = (
-        "query($teamId:String!){ team(id:$teamId)"
-        "{ states { nodes { id name } } } }"
-    )
+    q = "query($teamId:String!){ team(id:$teamId){ states { nodes { id name } } } }"
     resp = _gql(q, {"teamId": team_id})
     if resp.get("errors"):
         raise ValueError(f"could not load workflow states: {resp['errors']}")
@@ -153,8 +150,7 @@ def _resolve_state_id(team_id: str, state: str) -> str:
             return node["id"]
     available = ", ".join(n.get("name", "") for n in nodes) or "(none)"
     raise ValueError(
-        f"no workflow state named {state!r} for team {team_id}; "
-        f"available: {available}"
+        f"no workflow state named {state!r} for team {team_id}; available: {available}"
     )
 
 

--- a/backend/onyx/skills/builtin/linear/linear_api.py
+++ b/backend/onyx/skills/builtin/linear/linear_api.py
@@ -18,6 +18,10 @@ _ENDPOINT = "https://api.linear.app/graphql"
 _PAGE_SIZE = 100
 _DEFAULT_LIMIT = 100
 _IDENT_RE = re.compile(r"^[A-Za-z][A-Za-z0-9]*-\d+$")
+_UUID_RE = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+    r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
 _HTTP_TIMEOUT_SECONDS = 180
 
 _ISSUE_FIELDS = """
@@ -102,6 +106,58 @@ def _issue_filter(a: argparse.Namespace) -> dict[str, Any]:
     return f
 
 
+def _build_issue_create_input(a: argparse.Namespace) -> dict[str, Any]:
+    """Map parsed args onto an IssueCreateInput dict, including only the keys
+    that were actually provided. Pure (no network): callers must resolve any
+    workflow-state *name* to a state id before calling this — pass the id via
+    ``a.state``.
+    """
+    inp: dict[str, Any] = {"teamId": a.team_id, "title": a.title}
+    if getattr(a, "description", None):
+        inp["description"] = a.description
+    if getattr(a, "assignee", None):
+        inp["assigneeId"] = a.assignee
+    if getattr(a, "project", None):
+        inp["projectId"] = a.project
+    if getattr(a, "state", None):
+        inp["stateId"] = a.state
+    if getattr(a, "priority", None) is not None:
+        inp["priority"] = a.priority
+    if getattr(a, "label", None):
+        inp["labelIds"] = list(a.label)
+    if getattr(a, "estimate", None) is not None:
+        inp["estimate"] = a.estimate
+    if getattr(a, "parent", None):
+        inp["parentId"] = a.parent
+    return inp
+
+
+def _resolve_state_id(team_id: str, state: str) -> str:
+    """Resolve a workflow-state reference to a state id. If ``state`` is already
+    a UUID it is returned as-is; otherwise it is treated as a name and matched
+    case-insensitively against the team's workflow states. Raises ValueError if
+    no matching state is found (or the lookup fails)."""
+    if _UUID_RE.match(state):
+        return state
+    q = (
+        "query($teamId:String!){ team(id:$teamId)"
+        "{ states { nodes { id name } } } }"
+    )
+    resp = _gql(q, {"teamId": team_id})
+    if resp.get("errors"):
+        raise ValueError(f"could not load workflow states: {resp['errors']}")
+    team = (resp.get("data") or {}).get("team") or {}
+    nodes = ((team.get("states") or {}).get("nodes")) or []
+    for node in nodes:
+        if (node.get("name") or "").lower() == state.lower():
+            return node["id"]
+    available = ", ".join(n.get("name", "") for n in nodes) or "(none)"
+    raise ValueError(
+        f"no workflow state named {state!r} for team {team_id}; "
+        f"available: {available}"
+    )
+
+
 def _emit(result: dict[str, Any], raw: bool) -> int:
     print(json.dumps(result if raw else _prune(result)))
     return 0 if result.get("ok") else 1
@@ -139,6 +195,16 @@ def _build_parser() -> argparse.ArgumentParser:
     sp.add_argument("title")
     sp.add_argument("--description")
     sp.add_argument("--assignee", help="user id")
+    sp.add_argument("--project", help="project id")
+    sp.add_argument("--state", help="workflow state name or id")
+    sp.add_argument("--priority", type=int, help="priority 0-4")
+    sp.add_argument(
+        "--label",
+        action="append",
+        help="label id (repeatable)",
+    )
+    sp.add_argument("--estimate", type=int, help="point estimate")
+    sp.add_argument("--parent", help="parent issue id")
 
     sp = sub.add_parser("comment", help="comment on an issue (write)")
     sp.add_argument("issue_id")
@@ -196,16 +262,17 @@ def _dispatch(a: argparse.Namespace) -> dict[str, Any]:
     if a.cmd == "projects":
         q = (
             "query($first:Int,$after:String){ projects(first:$first,after:$after)"
-            "{ nodes { id name state url } pageInfo { hasNextPage endCursor } } }"
+            "{ nodes { id name state url teams { nodes { id key name } } }"
+            " pageInfo { hasNextPage endCursor } } }"
         )
         return _paginate(q, {}, "projects", a.limit)
 
     if a.cmd == "create-issue":
-        inp: dict[str, Any] = {"teamId": a.team_id, "title": a.title}
-        if a.description:
-            inp["description"] = a.description
-        if a.assignee:
-            inp["assigneeId"] = a.assignee
+        # Resolve a workflow-state *name* to its id (network) before building the
+        # pure input; `_build_issue_create_input` itself stays network-free.
+        if a.state:
+            a.state = _resolve_state_id(a.team_id, a.state)
+        inp = _build_issue_create_input(a)
         q = (
             "mutation($input:IssueCreateInput!){ issueCreate(input:$input)"
             "{ success issue { id identifier url } } }"
@@ -242,6 +309,9 @@ def main(argv: list[str]) -> int:
     except json.JSONDecodeError as e:
         print(f"invalid variables: {e}", file=sys.stderr)
         return 2
+    except ValueError as e:
+        print(str(e), file=sys.stderr)
+        return 1
     except urllib.error.HTTPError as e:
         detail = e.read().decode("utf-8", errors="replace")
         print(f"HTTP {e.code} calling Linear: {detail}", file=sys.stderr)

--- a/backend/tests/unit/external_apps/test_linear_api_helper.py
+++ b/backend/tests/unit/external_apps/test_linear_api_helper.py
@@ -11,9 +11,7 @@ from pathlib import Path
 from types import ModuleType
 
 _HELPER = (
-    Path(__file__).resolve().parents[3]
-    / "onyx/skills/builtin"
-    / "linear/linear_api.py"
+    Path(__file__).resolve().parents[3] / "onyx/skills/builtin" / "linear/linear_api.py"
 )
 
 

--- a/backend/tests/unit/external_apps/test_linear_api_helper.py
+++ b/backend/tests/unit/external_apps/test_linear_api_helper.py
@@ -1,0 +1,182 @@
+"""The bundled ``linear_api.py`` sandbox helper: the pure ``IssueCreateInput``
+builder used by ``create-issue``. The helper is a standalone script under the
+skills dir (not an importable package), so load it by path. These tests require
+no network and no onyx imports."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+_HELPER = (
+    Path(__file__).resolve().parents[3]
+    / "onyx/skills/builtin"
+    / "linear/linear_api.py"
+)
+
+
+def _load() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("linear_api", _HELPER)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+linear = _load()
+
+
+def _args(**overrides: object) -> argparse.Namespace:
+    """A create-issue namespace with every optional flag unset by default."""
+    base: dict[str, object] = {
+        "team_id": "TEAM1",
+        "title": "Fix the bug",
+        "description": None,
+        "assignee": None,
+        "project": None,
+        "state": None,
+        "priority": None,
+        "label": None,
+        "estimate": None,
+        "parent": None,
+    }
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+def test_build_input_minimal_only_team_and_title() -> None:
+    inp = linear._build_issue_create_input(_args())
+    assert inp == {"teamId": "TEAM1", "title": "Fix the bug"}
+
+
+def test_build_input_maps_all_provided_flags() -> None:
+    inp = linear._build_issue_create_input(
+        _args(
+            description="Steps to repro",
+            assignee="USER1",
+            project="PROJ1",
+            state="STATE1",
+            priority=2,
+            label=["LBL1", "LBL2"],
+            estimate=5,
+            parent="ISSUE1",
+        )
+    )
+    assert inp == {
+        "teamId": "TEAM1",
+        "title": "Fix the bug",
+        "description": "Steps to repro",
+        "assigneeId": "USER1",
+        "projectId": "PROJ1",
+        "stateId": "STATE1",
+        "priority": 2,
+        "labelIds": ["LBL1", "LBL2"],
+        "estimate": 5,
+        "parentId": "ISSUE1",
+    }
+
+
+def test_build_input_omits_unset_keys() -> None:
+    inp = linear._build_issue_create_input(_args(project="PROJ1"))
+    assert inp == {"teamId": "TEAM1", "title": "Fix the bug", "projectId": "PROJ1"}
+    for absent in (
+        "description",
+        "assigneeId",
+        "stateId",
+        "priority",
+        "labelIds",
+        "estimate",
+        "parentId",
+    ):
+        assert absent not in inp
+
+
+def test_build_input_priority_zero_is_kept() -> None:
+    # 0 (no priority) and estimate 0 carry signal and must not be dropped.
+    inp = linear._build_issue_create_input(_args(priority=0, estimate=0))
+    assert inp["priority"] == 0
+    assert inp["estimate"] == 0
+
+
+def test_build_input_single_repeatable_label() -> None:
+    inp = linear._build_issue_create_input(_args(label=["LBL1"]))
+    assert inp["labelIds"] == ["LBL1"]
+
+
+def test_build_input_state_id_passed_through() -> None:
+    # The pure builder treats a.state as an already-resolved id (resolution of a
+    # state *name* happens in the dispatch path, not here).
+    inp = linear._build_issue_create_input(_args(state="resolved-state-id"))
+    assert inp["stateId"] == "resolved-state-id"
+
+
+def test_resolve_state_id_returns_uuid_without_network() -> None:
+    # A UUID is returned as-is, so no GraphQL call is made.
+    uuid = "12345678-1234-1234-1234-1234567890ab"
+    assert linear._resolve_state_id("TEAM1", uuid) == uuid
+
+
+def test_resolve_state_id_matches_name_case_insensitively(monkeypatch) -> None:
+    monkeypatch.setattr(
+        linear,
+        "_gql",
+        lambda _q, _v: {
+            "data": {
+                "team": {
+                    "states": {
+                        "nodes": [
+                            {"id": "s-todo", "name": "Todo"},
+                            {"id": "s-prog", "name": "In Progress"},
+                        ]
+                    }
+                }
+            }
+        },
+    )
+    assert linear._resolve_state_id("TEAM1", "in progress") == "s-prog"
+
+
+def test_resolve_state_id_raises_on_unknown_name(monkeypatch) -> None:
+    monkeypatch.setattr(
+        linear,
+        "_gql",
+        lambda _q, _v: {"data": {"team": {"states": {"nodes": []}}}},
+    )
+    try:
+        linear._resolve_state_id("TEAM1", "Nonexistent")
+    except ValueError as e:
+        assert "Nonexistent" in str(e)
+    else:  # pragma: no cover
+        raise AssertionError("expected ValueError for unknown state name")
+
+
+def test_create_issue_parser_has_new_flags() -> None:
+    args = linear._build_parser().parse_args(
+        [
+            "create-issue",
+            "TEAM1",
+            "Title",
+            "--project",
+            "PROJ1",
+            "--state",
+            "Todo",
+            "--priority",
+            "1",
+            "--label",
+            "LBL1",
+            "--label",
+            "LBL2",
+            "--estimate",
+            "3",
+            "--parent",
+            "ISSUE1",
+        ]
+    )
+    assert args.project == "PROJ1"
+    assert args.state == "Todo"
+    assert args.priority == 1
+    assert args.label == ["LBL1", "LBL2"]
+    assert args.estimate == 3
+    assert args.parent == "ISSUE1"


### PR DESCRIPTION
## Summary

Adds first-class flags to the Linear external-app skill helper's `create-issue`
command so it can set common `IssueCreateInput` fields beyond team/title/
description/assignee.

New `create-issue` flags:

- `--project` — project id
- `--state` — workflow state **name or id** (a name is resolved case-insensitively
  against the team's workflow states; an id passes straight through)
- `--priority` — int 0-4
- `--label` — repeatable label id (`action="append"`)
- `--estimate` — point estimate (int)
- `--parent` — parent issue id

### Implementation notes

- The input-building logic is refactored into a pure, network-free helper
  `_build_issue_create_input(a) -> dict` that maps args to `teamId`, `title`,
  `description`, `assigneeId`, `projectId`, `stateId`, `priority`, `labelIds`,
  `estimate`, and `parentId`, including only keys that were provided (priority/
  estimate `0` are preserved as signal).
- Workflow-state **name** resolution lives in the dispatch path (`_resolve_state_id`),
  not in the pure builder, so the builder is unit-testable without network access.
  Resolution queries `team(id:$teamId){ states{ nodes{ id name } } }` and raises a
  clear error listing available states when no match is found.
- The `projects` query now also returns each project's `teams { nodes { id key name } }`
  so the team↔project linkage is visible (addresses the secondary ask: choosing the
  correct `teamId`).
- `SKILL.md.template` documents the new flags in the existing doc style.

### Testing

- Added `backend/tests/unit/external_apps/test_linear_api_helper.py` (same style as
  `test_gdrive_api_helper.py` — loads the standalone helper by path via `importlib`,
  no network or onyx imports). Covers minimal input, full mapping, omission of unset
  keys, priority/estimate `0` retention, repeatable labels, state-id passthrough,
  state-name resolution (case-insensitive + unknown-name error), and the new parser
  flags.
- `python -m pytest backend/tests/unit/external_apps/test_linear_api_helper.py -q`
  → **10 passed**.
- `python -m py_compile backend/onyx/skills/builtin/linear/linear_api.py` → ok.
- `python backend/onyx/skills/builtin/linear/linear_api.py create-issue -h` → shows
  all new flags.

Closes ENG-4257
https://linear.app/onyx-app/issue/ENG-4257
