### PR TITLE
feat(craft): Google Docs editing in google-drive external app (ENG-4256)

### DIFF
--- a/backend/onyx/skills/builtin/google-drive/SKILL.md.template
+++ b/backend/onyx/skills/builtin/google-drive/SKILL.md.template
@@ -103,9 +103,81 @@ python gdrive_api.py call PATCH "files/<id>" '{"starred": true}'
 Appended to `https://www.googleapis.com/drive/v3/`; pass a JSON object body as the
 last argument for write methods.
 
+## Editing Google Docs (Docs API)
+
+To **surgically edit an existing Google Doc** (insert/delete text, restyle
+paragraphs, add bullets) use the Docs API commands below. These call
+`https://docs.googleapis.com/v1/` — a different host than Drive. `read` still gives
+you the Doc's text, but Docs edits need character **indices**, so fetch the
+structure first with `get-doc`. Note: `<document_id>` is the Drive file id of the
+Doc.
+
+### Get a Doc's structure (indices)
+
+```
+python gdrive_api.py get-doc <document_id> [--fields "documentId,body,title"]
+```
+
+Returns the document's `body.content` with each element's `startIndex` /
+`endIndex`. Use these indices to target edits precisely.
+
+### Insert text at an index (write)
+
+```
+python gdrive_api.py insert-text <document_id> --index N --text "..."
+```
+
+Issues a `batchUpdate` with a single `insertText` request at character index `N`
+(get the index from `get-doc`).
+
+### Append text to the end of a Doc (write)
+
+```
+python gdrive_api.py append-text <document_id> --text "..."
+```
+
+Fetches the Doc, computes the end of the body, and inserts the text there — no
+manual index needed.
+
+### Apply raw batchUpdate requests (write)
+
+```
+python gdrive_api.py batch-update <document_id> '[<request>, ...]'
+python gdrive_api.py batch-update <document_id> --file requests.json
+```
+
+The general escape hatch: pass a JSON **array** of Docs API request objects, sent
+as `{"requests": [...]}` to `documents/<id>:batchUpdate`. Supports the full Docs
+request set, e.g. `insertText`, `deleteContentRange`, `updateParagraphStyle`,
+`createParagraphBullets`, `updateTextStyle`. Example — bold a range then bullet a
+paragraph:
+
+```
+python gdrive_api.py batch-update <document_id> '[
+  {"updateTextStyle": {"range": {"startIndex": 1, "endIndex": 10},
+    "textStyle": {"bold": true}, "fields": "bold"}},
+  {"createParagraphBullets": {"range": {"startIndex": 1, "endIndex": 10},
+    "bulletPreset": "BULLET_DISC_CIRCLE_SQUARE"}}
+]'
+```
+
+### Create a new Google Doc (write)
+
+```
+python gdrive_api.py create-doc --title "My Doc"
+```
+
+Creates a new empty Doc via the Docs API and returns its `documentId` (then use
+`insert-text` / `batch-update` to fill it). To create a Doc from existing
+markdown/HTML content instead, use `upload --convert-to
+application/vnd.google-apps.document`.
+
 ## Output
 
 JSON on stdout. Search/list/drives return `{"ok": true, "items": [...], "count":
 N, "truncated": bool}`. `get` / create / upload / update / replace return `{"ok":
 true, "file": {...}}`. `read` returns `{"ok": true, "id", "name", "mimeType",
-"exportedAs", "truncated", "content"}`. Errors print to stderr and exit non-zero.
+"exportedAs", "truncated", "content"}`. `get-doc` / `create-doc` return `{"ok":
+true, "document": {...}}`; `insert-text` / `append-text` / `batch-update` return
+`{"ok": true, "data": {...}}` (`append-text` also echoes the computed `index`).
+Errors print to stderr and exit non-zero.

--- a/backend/onyx/skills/builtin/google-drive/gdrive_api.py
+++ b/backend/onyx/skills/builtin/google-drive/gdrive_api.py
@@ -19,6 +19,9 @@ from typing import Any
 _BASE = "https://www.googleapis.com/drive/v3/"
 # Content uploads use a separate host path from the metadata/JSON API.
 _UPLOAD_BASE = "https://www.googleapis.com/upload/drive/v3/"
+# The Google Docs API lives on a different host than Drive; surgical edits to an
+# existing Doc (get structure / batchUpdate) go here, not through the Drive base.
+_DOCS_BASE = "https://docs.googleapis.com/v1/"
 _PAGE_SIZE = 100
 _DEFAULT_LIMIT = 100
 _HTTP_TIMEOUT_SECONDS = 180
@@ -104,6 +107,52 @@ def _req_bytes(path: str, params: dict[str, Any], max_bytes: int) -> tuple[bytes
     if len(data) > max_bytes:
         return data[:max_bytes], True
     return data, False
+
+
+def _req_docs(
+    path: str,
+    params: dict[str, Any] | None = None,
+    method: str = "GET",
+    body: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Call a Google Docs API endpoint (docs.googleapis.com, a different host
+    than Drive); return parsed JSON ({} on empty/204)."""
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    headers = {"Content-Type": "application/json; charset=utf-8"} if data else {}
+    req = urllib.request.Request(  # noqa: S310 — fixed https base url
+        _url(_DOCS_BASE, path, params), data=data, method=method, headers=headers
+    )
+    with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT_SECONDS) as resp:  # noqa: S310
+        raw = resp.read().decode("utf-8")
+    return json.loads(raw) if raw.strip() else {}
+
+
+def _doc_end_index(doc: dict[str, Any]) -> int:
+    """The end index of a document's body — the last structural element's
+    `endIndex`. Inserting text must target `endIndex - 1` to stay in range (the
+    final newline is not a valid insertion point past it)."""
+    content = doc.get("body", {}).get("content", []) or []
+    end = 1
+    for element in content:
+        if isinstance(element, dict) and "endIndex" in element:
+            end = element["endIndex"]
+    return end
+
+
+def _get_doc(document_id: str, fields: str | None = None) -> dict[str, Any]:
+    params = {"fields": fields} if fields else None
+    return _req_docs(f"documents/{_seg(document_id)}", params=params)
+
+
+def _batch_update(
+    document_id: str, requests: list[Any]
+) -> dict[str, Any]:
+    """POST a Docs `batchUpdate` with the given list of request objects."""
+    return _req_docs(
+        f"documents/{_seg(document_id)}:batchUpdate",
+        method="POST",
+        body={"requests": requests},
+    )
 
 
 def _upload(
@@ -361,6 +410,52 @@ def _build_parser() -> argparse.ArgumentParser:
     sp.add_argument("method", choices=("GET", "POST", "PATCH", "PUT", "DELETE"))
     sp.add_argument("path", help="appended to drive/v3/")
     sp.add_argument("json_body", nargs="?", help="JSON object for the request body")
+
+    # --- Google Docs API (docs.googleapis.com) ---
+    sp = sub.add_parser(
+        "get-doc", help="get a Google Doc's structure (body content + indices)"
+    )
+    sp.add_argument("document_id")
+    sp.add_argument(
+        "--fields",
+        help="Docs fields selector, e.g. 'documentId,body,title' "
+        "(default: whole document)",
+    )
+
+    sp = sub.add_parser(
+        "batch-update",
+        help="apply raw Docs batchUpdate requests to a Doc (write)",
+    )
+    sp.add_argument("document_id")
+    sp.add_argument(
+        "requests_json",
+        nargs="?",
+        help="JSON array of Docs request objects (e.g. insertText, "
+        "updateParagraphStyle, createParagraphBullets, deleteContentRange)",
+    )
+    sp.add_argument(
+        "--file",
+        dest="requests_file",
+        help="path to a file holding the JSON requests array (instead of inline)",
+    )
+
+    sp = sub.add_parser(
+        "insert-text", help="insert text at an index in a Doc (write)"
+    )
+    sp.add_argument("document_id")
+    sp.add_argument(
+        "--index", type=int, required=True, help="1-based character index to insert at"
+    )
+    sp.add_argument("--text", required=True, help="text to insert")
+
+    sp = sub.add_parser(
+        "append-text", help="append text to the end of a Doc's body (write)"
+    )
+    sp.add_argument("document_id")
+    sp.add_argument("--text", required=True, help="text to append")
+
+    sp = sub.add_parser("create-doc", help="create a new empty Google Doc (write)")
+    sp.add_argument("--title", required=True, help="title of the new document")
     return p
 
 
@@ -433,6 +528,49 @@ def _dispatch(a: argparse.Namespace) -> dict[str, Any]:
             method="DELETE",
         )
         return {"ok": True, "deleted": True}
+
+    # --- Google Docs API ---
+    if a.cmd == "get-doc":
+        doc = _get_doc(a.document_id, fields=getattr(a, "fields", None))
+        return {"ok": True, "document": doc}
+
+    if a.cmd == "batch-update":
+        raw_requests = a.requests_json
+        if getattr(a, "requests_file", None):
+            with open(a.requests_file, encoding="utf-8") as fh:
+                raw_requests = fh.read()
+        if not raw_requests:
+            return {"ok": False, "error": "no requests provided (pass JSON or --file)"}
+        try:
+            requests = json.loads(raw_requests)
+        except json.JSONDecodeError as e:
+            return {"ok": False, "error": f"invalid requests json: {e}"}
+        if not isinstance(requests, list):
+            return {"ok": False, "error": "requests_not_array"}
+        resp = _batch_update(a.document_id, requests)
+        return {"ok": True, "data": resp}
+
+    if a.cmd == "insert-text":
+        requests = [
+            {"insertText": {"location": {"index": a.index}, "text": a.text}}
+        ]
+        resp = _batch_update(a.document_id, requests)
+        return {"ok": True, "data": resp}
+
+    if a.cmd == "append-text":
+        doc = _get_doc(a.document_id, fields="body(content(endIndex))")
+        end = _doc_end_index(doc)
+        # Insert just before the final newline of the body to stay in range.
+        index = max(1, end - 1)
+        requests = [
+            {"insertText": {"location": {"index": index}, "text": a.text}}
+        ]
+        resp = _batch_update(a.document_id, requests)
+        return {"ok": True, "index": index, "data": resp}
+
+    if a.cmd == "create-doc":
+        doc = _req_docs("documents", method="POST", body={"title": a.title})
+        return {"ok": True, "document": doc}
 
     # `call` raw escape hatch
     parsed_body = None

--- a/backend/onyx/skills/builtin/google-drive/gdrive_api.py
+++ b/backend/onyx/skills/builtin/google-drive/gdrive_api.py
@@ -144,9 +144,7 @@ def _get_doc(document_id: str, fields: str | None = None) -> dict[str, Any]:
     return _req_docs(f"documents/{_seg(document_id)}", params=params)
 
 
-def _batch_update(
-    document_id: str, requests: list[Any]
-) -> dict[str, Any]:
+def _batch_update(document_id: str, requests: list[Any]) -> dict[str, Any]:
     """POST a Docs `batchUpdate` with the given list of request objects."""
     return _req_docs(
         f"documents/{_seg(document_id)}:batchUpdate",
@@ -439,9 +437,7 @@ def _build_parser() -> argparse.ArgumentParser:
         help="path to a file holding the JSON requests array (instead of inline)",
     )
 
-    sp = sub.add_parser(
-        "insert-text", help="insert text at an index in a Doc (write)"
-    )
+    sp = sub.add_parser("insert-text", help="insert text at an index in a Doc (write)")
     sp.add_argument("document_id")
     sp.add_argument(
         "--index", type=int, required=True, help="1-based character index to insert at"
@@ -540,20 +536,18 @@ def _dispatch(a: argparse.Namespace) -> dict[str, Any]:
             with open(a.requests_file, encoding="utf-8") as fh:
                 raw_requests = fh.read()
         if not raw_requests:
-            return {"ok": False, "error": "no requests provided (pass JSON or --file)"}
+            raise ValueError("no requests provided (pass JSON or --file)")
         try:
             requests = json.loads(raw_requests)
         except json.JSONDecodeError as e:
-            return {"ok": False, "error": f"invalid requests json: {e}"}
+            raise ValueError(f"invalid requests json: {e}")
         if not isinstance(requests, list):
-            return {"ok": False, "error": "requests_not_array"}
+            raise ValueError("requests must be a JSON array")
         resp = _batch_update(a.document_id, requests)
         return {"ok": True, "data": resp}
 
     if a.cmd == "insert-text":
-        requests = [
-            {"insertText": {"location": {"index": a.index}, "text": a.text}}
-        ]
+        requests = [{"insertText": {"location": {"index": a.index}, "text": a.text}}]
         resp = _batch_update(a.document_id, requests)
         return {"ok": True, "data": resp}
 
@@ -562,9 +556,7 @@ def _dispatch(a: argparse.Namespace) -> dict[str, Any]:
         end = _doc_end_index(doc)
         # Insert just before the final newline of the body to stay in range.
         index = max(1, end - 1)
-        requests = [
-            {"insertText": {"location": {"index": index}, "text": a.text}}
-        ]
+        requests = [{"insertText": {"location": {"index": index}, "text": a.text}}]
         resp = _batch_update(a.document_id, requests)
         return {"ok": True, "index": index, "data": resp}
 
@@ -592,6 +584,9 @@ def main(argv: list[str]) -> int:
     except FileNotFoundError as e:
         print(f"file not found: {e.filename}", file=sys.stderr)
         return 2
+    except ValueError as e:
+        print(str(e), file=sys.stderr)
+        return 1
     except json.JSONDecodeError as e:
         print(f"Google Drive returned a non-JSON response: {e}", file=sys.stderr)
         return 1

--- a/backend/onyx/skills/builtin/google-drive/gdrive_api.py
+++ b/backend/onyx/skills/builtin/google-drive/gdrive_api.py
@@ -536,13 +536,13 @@ def _dispatch(a: argparse.Namespace) -> dict[str, Any]:
             with open(a.requests_file, encoding="utf-8") as fh:
                 raw_requests = fh.read()
         if not raw_requests:
-            raise ValueError("no requests provided (pass JSON or --file)")
+            return {"ok": False, "error": "no_requests"}
         try:
             requests = json.loads(raw_requests)
         except json.JSONDecodeError as e:
-            raise ValueError(f"invalid requests json: {e}")
+            return {"ok": False, "error": f"invalid requests json: {e}"}
         if not isinstance(requests, list):
-            raise ValueError("requests must be a JSON array")
+            return {"ok": False, "error": "requests_not_array"}
         resp = _batch_update(a.document_id, requests)
         return {"ok": True, "data": resp}
 

--- a/backend/tests/unit/external_apps/test_gdrive_api_helper.py
+++ b/backend/tests/unit/external_apps/test_gdrive_api_helper.py
@@ -213,7 +213,7 @@ def test_get_doc_builds_documents_path(monkeypatch: Any) -> None:
         path: str,
         params: dict[str, Any] | None = None,
         method: str = "GET",
-        body: dict[str, Any] | None = None,
+        **_kwargs: Any,
     ) -> dict[str, Any]:
         calls.append((path, params))
         assert method == "GET"
@@ -234,8 +234,7 @@ def test_get_doc_passes_fields(monkeypatch: Any) -> None:
     monkeypatch.setattr(
         gdrive,
         "_req_docs",
-        lambda path, params=None, method="GET", body=None: calls.append((path, params))
-        or {},
+        lambda path, params=None, **_kwargs: calls.append((path, params)) or {},
     )
 
     args = gdrive._build_parser().parse_args(
@@ -251,9 +250,9 @@ def test_insert_text_builds_batch_update_request(monkeypatch: Any) -> None:
 
     def fake_docs(
         path: str,
-        params: dict[str, Any] | None = None,
         method: str = "GET",
         body: dict[str, Any] | None = None,
+        **_kwargs: Any,
     ) -> dict[str, Any]:
         captured.update(path=path, method=method, body=body)
         return {"documentId": "D1"}
@@ -268,9 +267,7 @@ def test_insert_text_builds_batch_update_request(monkeypatch: Any) -> None:
     assert captured["path"] == "documents/D1:batchUpdate"
     assert captured["method"] == "POST"
     assert captured["body"] == {
-        "requests": [
-            {"insertText": {"location": {"index": 5}, "text": "hello"}}
-        ]
+        "requests": [{"insertText": {"location": {"index": 5}, "text": "hello"}}]
     }
     assert result["ok"] is True
 
@@ -280,9 +277,9 @@ def test_append_text_computes_end_index_from_get_doc(monkeypatch: Any) -> None:
 
     def fake_docs(
         path: str,
-        params: dict[str, Any] | None = None,
         method: str = "GET",
         body: dict[str, Any] | None = None,
+        **_kwargs: Any,
     ) -> dict[str, Any]:
         if path.endswith(":batchUpdate"):
             captured.update(path=path, method=method, body=body)
@@ -300,17 +297,13 @@ def test_append_text_computes_end_index_from_get_doc(monkeypatch: Any) -> None:
 
     monkeypatch.setattr(gdrive, "_req_docs", fake_docs)
 
-    args = gdrive._build_parser().parse_args(
-        ["append-text", "D1", "--text", "more"]
-    )
+    args = gdrive._build_parser().parse_args(["append-text", "D1", "--text", "more"])
     result = gdrive._dispatch(args)
 
     # end index 42 -> insert at 41 to stay in range
     assert result["index"] == 41
     assert captured["body"] == {
-        "requests": [
-            {"insertText": {"location": {"index": 41}, "text": "more"}}
-        ]
+        "requests": [{"insertText": {"location": {"index": 41}, "text": "more"}}]
     }
 
 
@@ -324,9 +317,9 @@ def test_batch_update_passes_through_requests_array(monkeypatch: Any) -> None:
 
     def fake_docs(
         path: str,
-        params: dict[str, Any] | None = None,
         method: str = "GET",
         body: dict[str, Any] | None = None,
+        **_kwargs: Any,
     ) -> dict[str, Any]:
         captured.update(path=path, method=method, body=body)
         return {"documentId": "D1", "replies": []}
@@ -336,9 +329,7 @@ def test_batch_update_passes_through_requests_array(monkeypatch: Any) -> None:
     requests_json = (
         '[{"deleteContentRange": {"range": {"startIndex": 1, "endIndex": 5}}}]'
     )
-    args = gdrive._build_parser().parse_args(
-        ["batch-update", "D1", requests_json]
-    )
+    args = gdrive._build_parser().parse_args(["batch-update", "D1", requests_json])
     result = gdrive._dispatch(args)
 
     assert captured["path"] == "documents/D1:batchUpdate"
@@ -352,9 +343,7 @@ def test_batch_update_passes_through_requests_array(monkeypatch: Any) -> None:
 
 
 def test_batch_update_rejects_non_array(monkeypatch: Any) -> None:
-    monkeypatch.setattr(
-        gdrive, "_req_docs", lambda *_a, **_k: pytest_fail_if_called()
-    )
+    monkeypatch.setattr(gdrive, "_req_docs", lambda *_a, **_k: pytest_fail_if_called())
 
     def pytest_fail_if_called() -> dict[str, Any]:
         raise AssertionError("network should not be called for invalid input")
@@ -366,17 +355,12 @@ def test_batch_update_rejects_non_array(monkeypatch: Any) -> None:
     assert result["error"] == "requests_not_array"
 
 
-def test_batch_update_reads_requests_from_file(
-    monkeypatch: Any, tmp_path: Any
-) -> None:
+def test_batch_update_reads_requests_from_file(monkeypatch: Any, tmp_path: Any) -> None:
     captured: dict[str, Any] = {}
     monkeypatch.setattr(
         gdrive,
         "_req_docs",
-        lambda path, params=None, method="GET", body=None: captured.update(
-            path=path, body=body
-        )
-        or {},
+        lambda path, body=None, **_kwargs: captured.update(path=path, body=body) or {},
     )
     reqs = tmp_path / "requests.json"
     reqs.write_text('[{"insertText": {"location": {"index": 1}, "text": "x"}}]')
@@ -396,11 +380,12 @@ def test_create_doc_posts_title(monkeypatch: Any) -> None:
 
     def fake_docs(
         path: str,
-        params: dict[str, Any] | None = None,
         method: str = "GET",
         body: dict[str, Any] | None = None,
+        **_kwargs: Any,
     ) -> dict[str, Any]:
         captured.update(path=path, method=method, body=body)
+        assert body is not None
         return {"documentId": "NEW", "title": body["title"]}
 
     monkeypatch.setattr(gdrive, "_req_docs", fake_docs)

--- a/backend/tests/unit/external_apps/test_gdrive_api_helper.py
+++ b/backend/tests/unit/external_apps/test_gdrive_api_helper.py
@@ -194,3 +194,221 @@ def test_replace_sends_no_metadata_and_targets_file(
     assert captured["file_id"] == "EXISTING"
     assert captured["metadata"] == {}  # replace touches content only
     assert captured["content_type"] == "application/octet-stream"
+
+
+# --- Google Docs API commands ---
+
+
+def test_docs_base_targets_docs_host() -> None:
+    """Docs commands must hit docs.googleapis.com, not the Drive host."""
+    assert gdrive._DOCS_BASE == "https://docs.googleapis.com/v1/"
+    url = gdrive._url(gdrive._DOCS_BASE, "documents/D1:batchUpdate")
+    assert url == "https://docs.googleapis.com/v1/documents/D1:batchUpdate"
+
+
+def test_get_doc_builds_documents_path(monkeypatch: Any) -> None:
+    calls: list[tuple[str, dict[str, Any] | None]] = []
+
+    def fake_docs(
+        path: str,
+        params: dict[str, Any] | None = None,
+        method: str = "GET",
+        body: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        calls.append((path, params))
+        assert method == "GET"
+        return {"documentId": "D1", "title": "Spec"}
+
+    monkeypatch.setattr(gdrive, "_req_docs", fake_docs)
+
+    args = gdrive._build_parser().parse_args(["get-doc", "D1"])
+    result = gdrive._dispatch(args)
+
+    assert calls[0][0] == "documents/D1"
+    assert result["ok"] is True
+    assert result["document"]["documentId"] == "D1"
+
+
+def test_get_doc_passes_fields(monkeypatch: Any) -> None:
+    calls: list[tuple[str, dict[str, Any] | None]] = []
+    monkeypatch.setattr(
+        gdrive,
+        "_req_docs",
+        lambda path, params=None, method="GET", body=None: calls.append((path, params))
+        or {},
+    )
+
+    args = gdrive._build_parser().parse_args(
+        ["get-doc", "D1", "--fields", "documentId,body"]
+    )
+    gdrive._dispatch(args)
+
+    assert calls[0][1] == {"fields": "documentId,body"}
+
+
+def test_insert_text_builds_batch_update_request(monkeypatch: Any) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_docs(
+        path: str,
+        params: dict[str, Any] | None = None,
+        method: str = "GET",
+        body: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        captured.update(path=path, method=method, body=body)
+        return {"documentId": "D1"}
+
+    monkeypatch.setattr(gdrive, "_req_docs", fake_docs)
+
+    args = gdrive._build_parser().parse_args(
+        ["insert-text", "D1", "--index", "5", "--text", "hello"]
+    )
+    result = gdrive._dispatch(args)
+
+    assert captured["path"] == "documents/D1:batchUpdate"
+    assert captured["method"] == "POST"
+    assert captured["body"] == {
+        "requests": [
+            {"insertText": {"location": {"index": 5}, "text": "hello"}}
+        ]
+    }
+    assert result["ok"] is True
+
+
+def test_append_text_computes_end_index_from_get_doc(monkeypatch: Any) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_docs(
+        path: str,
+        params: dict[str, Any] | None = None,
+        method: str = "GET",
+        body: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        if path.endswith(":batchUpdate"):
+            captured.update(path=path, method=method, body=body)
+            return {"documentId": "D1"}
+        # get-doc response: last structural element endIndex is 42
+        return {
+            "body": {
+                "content": [
+                    {"endIndex": 1},
+                    {"endIndex": 25},
+                    {"endIndex": 42},
+                ]
+            }
+        }
+
+    monkeypatch.setattr(gdrive, "_req_docs", fake_docs)
+
+    args = gdrive._build_parser().parse_args(
+        ["append-text", "D1", "--text", "more"]
+    )
+    result = gdrive._dispatch(args)
+
+    # end index 42 -> insert at 41 to stay in range
+    assert result["index"] == 41
+    assert captured["body"] == {
+        "requests": [
+            {"insertText": {"location": {"index": 41}, "text": "more"}}
+        ]
+    }
+
+
+def test_doc_end_index_defaults_to_one_for_empty_body() -> None:
+    assert gdrive._doc_end_index({}) == 1
+    assert gdrive._doc_end_index({"body": {"content": []}}) == 1
+
+
+def test_batch_update_passes_through_requests_array(monkeypatch: Any) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_docs(
+        path: str,
+        params: dict[str, Any] | None = None,
+        method: str = "GET",
+        body: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        captured.update(path=path, method=method, body=body)
+        return {"documentId": "D1", "replies": []}
+
+    monkeypatch.setattr(gdrive, "_req_docs", fake_docs)
+
+    requests_json = (
+        '[{"deleteContentRange": {"range": {"startIndex": 1, "endIndex": 5}}}]'
+    )
+    args = gdrive._build_parser().parse_args(
+        ["batch-update", "D1", requests_json]
+    )
+    result = gdrive._dispatch(args)
+
+    assert captured["path"] == "documents/D1:batchUpdate"
+    assert captured["method"] == "POST"
+    assert captured["body"] == {
+        "requests": [
+            {"deleteContentRange": {"range": {"startIndex": 1, "endIndex": 5}}}
+        ]
+    }
+    assert result["ok"] is True
+
+
+def test_batch_update_rejects_non_array(monkeypatch: Any) -> None:
+    monkeypatch.setattr(
+        gdrive, "_req_docs", lambda *_a, **_k: pytest_fail_if_called()
+    )
+
+    def pytest_fail_if_called() -> dict[str, Any]:
+        raise AssertionError("network should not be called for invalid input")
+
+    args = gdrive._build_parser().parse_args(["batch-update", "D1", '{"a": 1}'])
+    result = gdrive._dispatch(args)
+
+    assert result["ok"] is False
+    assert result["error"] == "requests_not_array"
+
+
+def test_batch_update_reads_requests_from_file(
+    monkeypatch: Any, tmp_path: Any
+) -> None:
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        gdrive,
+        "_req_docs",
+        lambda path, params=None, method="GET", body=None: captured.update(
+            path=path, body=body
+        )
+        or {},
+    )
+    reqs = tmp_path / "requests.json"
+    reqs.write_text('[{"insertText": {"location": {"index": 1}, "text": "x"}}]')
+
+    args = gdrive._build_parser().parse_args(
+        ["batch-update", "D1", "--file", str(reqs)]
+    )
+    gdrive._dispatch(args)
+
+    assert captured["body"]["requests"] == [
+        {"insertText": {"location": {"index": 1}, "text": "x"}}
+    ]
+
+
+def test_create_doc_posts_title(monkeypatch: Any) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_docs(
+        path: str,
+        params: dict[str, Any] | None = None,
+        method: str = "GET",
+        body: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        captured.update(path=path, method=method, body=body)
+        return {"documentId": "NEW", "title": body["title"]}
+
+    monkeypatch.setattr(gdrive, "_req_docs", fake_docs)
+
+    args = gdrive._build_parser().parse_args(["create-doc", "--title", "My Doc"])
+    result = gdrive._dispatch(args)
+
+    assert captured["path"] == "documents"
+    assert captured["method"] == "POST"
+    assert captured["body"] == {"title": "My Doc"}
+    assert result["document"]["documentId"] == "NEW"


### PR DESCRIPTION
## Summary

Adds Google Docs API commands to the `google-drive` external app skill helper so
Craft can **surgically edit an existing Google Doc** (not just read it).

Fixes ENG-4256
https://linear.app/onyx-app/issue/ENG-4256

## Context

The provider (`backend/onyx/external_apps/providers/google_drive.py`) already
supported the Docs API on `main`: `docs.googleapis.com/.*` is in the upstream URL
patterns, the OAuth scope is the full `drive` scope (which grants Docs access),
and the catalog actions `DOCS_READ` / `DOCS_CREATE` / `DOCS_UPDATE` already exist
with correct policies. **No provider/scope/catalog changes were needed.** The
remaining gap was the skill helper, which only exposed Drive API commands.

## Changes

### `gdrive_api.py` — new Google Docs API commands
The Docs API lives on a different host (`https://docs.googleapis.com/v1/`) than
Drive, so a dedicated `_req_docs` request helper targets the correct host. New
subcommands (mutating ones marked `(write)`):

- `get-doc <documentId> [--fields ...]` — GET the document structure (body
  content + indices) to locate edit positions.
- `batch-update <documentId> <requests_json> [--file PATH]` — general escape
  hatch; POSTs `{"requests": [...]}` to `documents/{id}:batchUpdate`. Supports the
  full Docs request set (insertText, deleteContentRange, updateParagraphStyle,
  createParagraphBullets, updateTextStyle, ...).
- `insert-text <documentId> --index N --text TEXT` — convenience batchUpdate with
  a single `insertText` request.
- `append-text <documentId> --text TEXT` — fetches the doc, computes the body end
  index, and inserts at `endIndex - 1` to stay in range.
- `create-doc --title TITLE` — POST `documents` to create a new empty Doc (the
  Docs create endpoint, distinct from Drive upload/convert).

### `SKILL.md.template`
Documents the new commands with usage examples (get-doc, insert-text,
append-text, batch-update, create-doc) and updates the Output section.

### Tests — `test_gdrive_api_helper.py`
Hermetic unit tests (monkeypatch the network layer) verifying the new commands
build the correct URL/host, method, and request body:
- Docs host targeting (`docs.googleapis.com`)
- `get-doc` path + `--fields` passthrough
- `insert-text` builds the right `insertText` batchUpdate request
- `append-text` computes the end index from a mocked `get-doc` (42 -> insert at 41)
- `_doc_end_index` defaults to 1 for an empty body
- `batch-update` passes the requests array through; rejects a non-array; reads
  from `--file`
- `create-doc` posts the title

## Testing

```
cd backend && python -m pytest tests/unit/external_apps/test_gdrive_api_helper.py \
  -q --noconftest -o addopts=""
```

Result: **18 passed**.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Docs API editing commands to the `google-drive` external app so Craft can surgically edit existing Google Docs in place. Implements ENG-4256 by sending edits to `https://docs.googleapis.com/v1/`.

- **New Features**
  - Docs API helper targeting `_DOCS_BASE` (`docs.googleapis.com/v1`).
  - Commands: `get-doc`, `insert-text`, `append-text` (computes end index), `batch-update` (inline JSON or `--file`), `create-doc`.
  - `SKILL.md.template` documents Docs editing and output shapes; write ops return `{"ok": true, "data": {...}}` and `append-text` echoes `index`.
  - CLI prints errors to stderr and exits non-zero.
  - Unit tests cover docs host/paths, `--fields` passthrough, request bodies, end-index logic, array validation, and file-based requests.
  - No provider/scope/catalog changes needed.

<sup>Written for commit 033010d8eba3eeff636e243a5d38b95b2440e98d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

