### PR TITLE
Fix sidebar-tab wrapping issue

### DIFF
--- a/web/lib/opal/src/components/buttons/sidebar-tab/components.tsx
+++ b/web/lib/opal/src/components/buttons/sidebar-tab/components.tsx
@@ -123,6 +123,7 @@ function SidebarTab({
               width="full"
               padding="fit"
               rightChildren={truncationSpacer}
+              titleMaxLines={1}
             />
           ) : (
             <div className="flex flex-row items-center gap-2 w-full">


### PR DESCRIPTION
## Description

Fix sidebar-tab wrapping issue by adding a `titleMaxLines={1}` invocation to the component.

## Screenshots + Videos

<img width="241" height="81" alt="image" src="https://github.com/user-attachments/assets/ecbe5e59-a2d0-4424-ab34-dd04cdf2829a" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix sidebar tab label wrapping by forcing single-line titles with titleMaxLines={1}, preventing layout shifts in the sidebar.

<sup>Written for commit 28ce205bc75597e0b68646aa00740e2ab09b1ad5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

