### PR TITLE
feat(ods): add --no-verify flag to deploy

### DIFF
--- a/tools/ods/cmd/deploy.go
+++ b/tools/ods/cmd/deploy.go
@@ -4,10 +4,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// deployNoVerify, when set, skips git pre-push hooks (passes --no-verify to
-// git push) for deploy subcommands that push to git. It is bound to the
-// persistent --no-verify flag on the parent `deploy` command and inherited by
-// all subcommands; subcommands that don't push to git ignore it.
 var deployNoVerify bool
 
 // NewDeployCommand creates the parent `ods deploy` command. Subcommands hang

--- a/tools/ods/cmd/deploy.go
+++ b/tools/ods/cmd/deploy.go
@@ -4,6 +4,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// deployNoVerify, when set, skips git pre-push hooks (passes --no-verify to
+// git push) for deploy subcommands that push to git. It is bound to the
+// persistent --no-verify flag on the parent `deploy` command and inherited by
+// all subcommands; subcommands that don't push to git ignore it.
+var deployNoVerify bool
+
 // NewDeployCommand creates the parent `ods deploy` command. Subcommands hang
 // off it (e.g. `ods deploy edge`) and represent ad-hoc deployment workflows.
 func NewDeployCommand() *cobra.Command {
@@ -12,6 +18,8 @@ func NewDeployCommand() *cobra.Command {
 		Short: "Trigger ad-hoc deployments",
 		Long:  "Trigger ad-hoc deployments to Onyx-managed environments.",
 	}
+
+	cmd.PersistentFlags().BoolVar(&deployNoVerify, "no-verify", false, "Skip git pre-push hooks (pass --no-verify to git push) when a deploy pushes to git")
 
 	cmd.AddCommand(NewDeployEdgeCommand())
 	cmd.AddCommand(NewDeployWikiCommand())

--- a/tools/ods/cmd/deploy_edge.go
+++ b/tools/ods/cmd/deploy_edge.go
@@ -39,6 +39,7 @@ type DeployEdgeOptions struct {
 	DryRun         bool
 	Yes            bool
 	NoWaitDeploy   bool
+	NoVerify       bool
 }
 
 // NewDeployEdgeCommand creates the `ods deploy edge` command.
@@ -69,6 +70,7 @@ Example usage:
     $ ods deploy edge`,
 		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
+			opts.NoVerify = deployNoVerify
 			deployEdge(opts)
 		},
 	}
@@ -124,8 +126,15 @@ func deployEdge(opts *DeployEdgeOptions) {
 		log.Fatalf("Failed to move local tag: %v", err)
 	}
 
+	pushArgs := []string{"push", "-f"}
+	if opts.NoVerify {
+		log.Info("--no-verify set; skipping git pre-push hooks.")
+		pushArgs = append(pushArgs, "--no-verify")
+	}
+	pushArgs = append(pushArgs, "origin", edgeTagName)
+
 	log.Infof("Force-pushing tag '%s' to origin...", edgeTagName)
-	if err := git.RunCommand("push", "-f", "origin", edgeTagName); err != nil {
+	if err := git.RunCommand(pushArgs...); err != nil {
 		log.Fatalf("Failed to push edge tag: %v", err)
 	}
 


### PR DESCRIPTION
## What

Adds a persistent `--no-verify` flag to the `ods deploy` command.

- Defined on the parent `deploy` command via `PersistentFlags()`, so it's inherited by all subcommands.
- When set, `ods deploy edge` passes `--no-verify` to the edge tag's `git push -f origin edge`, bypassing the configured pre-push hooks (`core.hooksPath`).
- Subcommands that don't push to git (`wiki`) ignore it — the help text notes "when a deploy pushes to git".

## Why

The edge deploy force-pushes the `edge` tag to `origin/main`. Pre-push hooks can be slow or undesirable for this ad-hoc deploy path; `--no-verify` lets you skip them, matching the standard `git push --no-verify` convention.

## Usage

```
ods deploy edge --no-verify
# runs: git push --no-verify -f origin edge
```

## Testing

- `gofmt` clean, `go build ./...` and `go vet ./cmd/` pass.
- Confirmed the flag renders under "Global Flags" in `ods deploy edge --help`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a persistent `--no-verify` flag to `ods deploy` to skip Git pre-push hooks when a deploy pushes to Git. `ods deploy edge` now forwards this flag to the force-push and logs when hooks are skipped.

- **New Features**
  - Adds `--no-verify` as a persistent flag on the parent `deploy` command, inherited by subcommands.
  - `deploy edge` builds `git push -f` args and appends `--no-verify` when set; logs that hooks are skipped.
  - Subcommands that don’t push to Git (e.g., `wiki`) ignore the flag; listed under Global Flags in help.

<sup>Written for commit 4795ffaeb1905e37ac22748cf34cf8bd2d7b8a28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

