### PR TITLE
feat(craft-cli): add 'onyx-cli image' generate/edit command

### DIFF
--- a/cli/cmd/image.go
+++ b/cli/cmd/image.go
@@ -208,7 +208,20 @@ func writeGeneratedImages(images []models.GeneratedImagePayload, output string) 
 		if len(images) > 1 {
 			path = fmt.Sprintf("%s_%d%s", base, i+1, ext)
 		}
-		if err := os.WriteFile(path, data, 0o644); err != nil {
+		// O_EXCL: never overwrite an existing file. Re-running into the same
+		// path (or hitting an existing _N suffix) fails loudly instead of
+		// silently destroying a prior asset — use a fresh -o name to regenerate.
+		f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+		if err != nil {
+			return nil, exitcodes.Newf(exitcodes.General,
+				"failed to write %q: %v", path, err)
+		}
+		if _, err := f.Write(data); err != nil {
+			_ = f.Close()
+			return nil, exitcodes.Newf(exitcodes.General,
+				"failed to write %q: %v", path, err)
+		}
+		if err := f.Close(); err != nil {
 			return nil, exitcodes.Newf(exitcodes.General,
 				"failed to write %q: %v", path, err)
 		}

--- a/cli/cmd/image.go
+++ b/cli/cmd/image.go
@@ -1,0 +1,228 @@
+package cmd
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"github.com/onyx-dot-app/onyx/cli/internal/api"
+	"github.com/onyx-dot-app/onyx/cli/internal/exitcodes"
+	"github.com/onyx-dot-app/onyx/cli/internal/iostreams"
+	"github.com/onyx-dot-app/onyx/cli/internal/models"
+	"github.com/spf13/cobra"
+)
+
+var validImageShapes = map[string]bool{
+	"square":    true,
+	"portrait":  true,
+	"landscape": true,
+}
+
+var imageExtToMime = map[string]string{
+	".png":  "image/png",
+	".jpg":  "image/jpeg",
+	".jpeg": "image/jpeg",
+	".gif":  "image/gif",
+	".webp": "image/webp",
+}
+
+type imageOptions struct {
+	prompt  string
+	output  string
+	shape   string
+	quality string
+	num     int
+	inputs  []string // reference image paths (edit only)
+}
+
+func newImageCmd(ios *iostreams.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "image",
+		Short: "Generate or edit images with the configured image provider",
+		Long: `Generate or edit raster images using the image-generation provider the
+admin configured at /admin/configuration/image-generation (OpenAI, Gemini, or
+Azure). No API key is needed locally — generation runs server-side.
+
+If no provider is configured the command exits with a clear message; ask an
+admin to set one up in the admin panel.`,
+	}
+	cmd.AddCommand(newImageGenerateCmd(ios))
+	cmd.AddCommand(newImageEditCmd(ios))
+	return cmd
+}
+
+func newImageGenerateCmd(ios *iostreams.IOStreams) *cobra.Command {
+	opts := imageOptions{}
+	cmd := &cobra.Command{
+		Use:   "generate",
+		Short: "Generate image(s) from a text prompt",
+		Example: `  onyx-cli image generate -p "a red bicycle on a beach" -o bike.png
+  onyx-cli image generate -p "app icon, flat style" --shape square -n 3 -o icon.png`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runImageGeneration(cmd, ios, opts)
+		},
+	}
+	addCommonImageFlags(cmd, &opts)
+	return cmd
+}
+
+func newImageEditCmd(ios *iostreams.IOStreams) *cobra.Command {
+	opts := imageOptions{}
+	cmd := &cobra.Command{
+		Use:   "edit",
+		Short: "Edit or composite existing image(s) guided by a prompt",
+		Example: `  onyx-cli image edit -i photo.png -p "replace the sky with a sunset" -o out.png
+  onyx-cli image edit -i a.png -i b.png -p "combine these into one scene" -o merged.png`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(opts.inputs) == 0 {
+				return exitcodes.New(exitcodes.BadRequest,
+					"edit requires at least one --input-image")
+			}
+			return runImageGeneration(cmd, ios, opts)
+		},
+	}
+	addCommonImageFlags(cmd, &opts)
+	cmd.Flags().StringArrayVarP(&opts.inputs, "input-image", "i", nil,
+		"Input image path (repeat to composite multiple); first is the primary edit source")
+	return cmd
+}
+
+func addCommonImageFlags(cmd *cobra.Command, opts *imageOptions) {
+	cmd.Flags().StringVarP(&opts.prompt, "prompt", "p", "", "Text prompt (required)")
+	cmd.Flags().StringVarP(&opts.output, "output", "o", "output.png", "Output file path")
+	cmd.Flags().StringVar(&opts.shape, "shape", "square", "Image shape: square, portrait, or landscape")
+	cmd.Flags().StringVarP(&opts.quality, "quality", "q", "", "Render quality (provider-specific, e.g. low/medium/high/auto)")
+	cmd.Flags().IntVarP(&opts.num, "num", "n", 1, "Number of images to generate")
+}
+
+func buildImageRequest(opts imageOptions, references []models.ImageReferencePayload) models.ImageGenerationRequest {
+	return models.ImageGenerationRequest{
+		Prompt:          opts.prompt,
+		Shape:           opts.shape,
+		N:               opts.num,
+		Quality:         opts.quality,
+		ReferenceImages: references,
+	}
+}
+
+func runImageGeneration(cmd *cobra.Command, ios *iostreams.IOStreams, opts imageOptions) error {
+	if strings.TrimSpace(opts.prompt) == "" {
+		return exitcodes.New(exitcodes.BadRequest,
+			"no prompt provided\n  Usage: onyx-cli image generate -p \"your prompt\"")
+	}
+	if !validImageShapes[opts.shape] {
+		return exitcodes.Newf(exitcodes.BadRequest,
+			"invalid --shape %q (expected square, portrait, or landscape)", opts.shape)
+	}
+	if opts.num < 1 {
+		return exitcodes.New(exitcodes.BadRequest, "--num must be at least 1")
+	}
+
+	references, err := loadReferenceImages(opts.inputs)
+	if err != nil {
+		return err
+	}
+
+	_, client, err := requireClient()
+	if err != nil {
+		return err
+	}
+
+	req := buildImageRequest(opts, references)
+
+	ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if ios.IsStdoutTTY {
+		fmt.Fprintf(ios.ErrOut, "\033[2mGenerating...\033[0m\n")
+	}
+
+	resp, err := client.GenerateImage(ctx, req)
+	if err != nil {
+		return imageErrorToExit(err)
+	}
+
+	paths, err := writeGeneratedImages(resp.Images, opts.output)
+	if err != nil {
+		return err
+	}
+	for _, p := range paths {
+		fmt.Fprintln(ios.Out, p)
+	}
+	return nil
+}
+
+func loadReferenceImages(paths []string) ([]models.ImageReferencePayload, error) {
+	if len(paths) == 0 {
+		return nil, nil
+	}
+	references := make([]models.ImageReferencePayload, 0, len(paths))
+	for _, p := range paths {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			return nil, exitcodes.Newf(exitcodes.BadRequest,
+				"could not read input image %q: %v", p, err)
+		}
+		mime := imageExtToMime[strings.ToLower(filepath.Ext(p))]
+		if mime == "" {
+			mime = "image/png"
+		}
+		references = append(references, models.ImageReferencePayload{
+			DataBase64: base64.StdEncoding.EncodeToString(data),
+			MimeType:   mime,
+		})
+	}
+	return references, nil
+}
+
+func writeGeneratedImages(images []models.GeneratedImagePayload, output string) ([]string, error) {
+	if len(images) == 0 {
+		return nil, exitcodes.New(exitcodes.ServerError, "no images returned")
+	}
+	ext := filepath.Ext(output)
+	base := strings.TrimSuffix(output, ext)
+	if ext == "" {
+		ext = ".png"
+	}
+
+	if dir := filepath.Dir(output); dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return nil, exitcodes.Newf(exitcodes.General,
+				"failed to create output directory %q: %v", dir, err)
+		}
+	}
+
+	paths := make([]string, 0, len(images))
+	for i, img := range images {
+		data, err := base64.StdEncoding.DecodeString(img.DataBase64)
+		if err != nil {
+			return nil, exitcodes.Newf(exitcodes.ServerError,
+				"failed to decode returned image: %v", err)
+		}
+		path := output
+		if len(images) > 1 {
+			path = fmt.Sprintf("%s_%d%s", base, i+1, ext)
+		}
+		if err := os.WriteFile(path, data, 0o644); err != nil {
+			return nil, exitcodes.Newf(exitcodes.General,
+				"failed to write %q: %v", path, err)
+		}
+		paths = append(paths, path)
+	}
+	return paths, nil
+}
+
+func imageErrorToExit(err error) error {
+	var apiErr *api.OnyxAPIError
+	if errors.As(err, &apiErr) && apiErr.StatusCode == 404 {
+		return exitcodes.New(exitcodes.NotAvailable,
+			"no image generation provider is configured\n"+
+				"  Ask an admin to configure one at /admin/configuration/image-generation")
+	}
+	return apiErrorToExit(err, "image generation failed")
+}

--- a/cli/cmd/image.go
+++ b/cli/cmd/image.go
@@ -208,9 +208,6 @@ func writeGeneratedImages(images []models.GeneratedImagePayload, output string) 
 		if len(images) > 1 {
 			path = fmt.Sprintf("%s_%d%s", base, i+1, ext)
 		}
-		// O_EXCL: never overwrite an existing file. Re-running into the same
-		// path (or hitting an existing _N suffix) fails loudly instead of
-		// silently destroying a prior asset — use a fresh -o name to regenerate.
 		f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
 		if err != nil {
 			return nil, exitcodes.Newf(exitcodes.General,

--- a/cli/cmd/image_test.go
+++ b/cli/cmd/image_test.go
@@ -135,7 +135,6 @@ func TestWriteGeneratedImages_FailsIfExists(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when output already exists")
 	}
-	// The pre-existing file must be left untouched, not truncated.
 	got, _ := os.ReadFile(out)
 	if string(got) != "existing" {
 		t.Fatalf("existing file was modified: %q", got)

--- a/cli/cmd/image_test.go
+++ b/cli/cmd/image_test.go
@@ -1,0 +1,213 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/base64"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/onyx-dot-app/onyx/cli/internal/api"
+	"github.com/onyx-dot-app/onyx/cli/internal/exitcodes"
+	"github.com/onyx-dot-app/onyx/cli/internal/iostreams"
+	"github.com/onyx-dot-app/onyx/cli/internal/models"
+	"github.com/spf13/cobra"
+)
+
+func testIOStreams() *iostreams.IOStreams {
+	return &iostreams.IOStreams{
+		In:          &bytes.Buffer{},
+		Out:         &bytes.Buffer{},
+		ErrOut:      &bytes.Buffer{},
+		IsStdinTTY:  false,
+		IsStdoutTTY: false,
+	}
+}
+
+func assertExitCode(t *testing.T, err error, want exitcodes.Code) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected error with exit code %d, got nil", want)
+	}
+	var exitErr *exitcodes.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected *exitcodes.ExitError, got %T: %v", err, err)
+	}
+	if exitErr.Code != want {
+		t.Fatalf("expected exit code %d, got %d (%v)", want, exitErr.Code, err)
+	}
+}
+
+func TestBuildImageRequest_ForwardsFields(t *testing.T) {
+	refs := []models.ImageReferencePayload{{DataBase64: "x", MimeType: "image/png"}}
+	req := buildImageRequest(
+		imageOptions{prompt: "a cat", shape: "landscape", quality: "high", num: 3},
+		refs,
+	)
+	if req.Prompt != "a cat" || req.Shape != "landscape" || req.Quality != "high" || req.N != 3 {
+		t.Fatalf("fields not forwarded: %+v", req)
+	}
+	if len(req.ReferenceImages) != 1 || req.ReferenceImages[0].DataBase64 != "x" {
+		t.Fatalf("reference images not forwarded: %+v", req.ReferenceImages)
+	}
+}
+
+func TestRunImageGeneration_EmptyPrompt(t *testing.T) {
+	err := runImageGeneration(&cobra.Command{}, testIOStreams(),
+		imageOptions{prompt: "  ", shape: "square", num: 1, output: "out.png"})
+	assertExitCode(t, err, exitcodes.BadRequest)
+}
+
+func TestRunImageGeneration_InvalidShape(t *testing.T) {
+	err := runImageGeneration(&cobra.Command{}, testIOStreams(),
+		imageOptions{prompt: "a cat", shape: "diagonal", num: 1, output: "out.png"})
+	assertExitCode(t, err, exitcodes.BadRequest)
+}
+
+func TestRunImageGeneration_NumTooLow(t *testing.T) {
+	err := runImageGeneration(&cobra.Command{}, testIOStreams(),
+		imageOptions{prompt: "a cat", shape: "square", num: 0, output: "out.png"})
+	assertExitCode(t, err, exitcodes.BadRequest)
+}
+
+func TestWriteGeneratedImages_Single(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "art.png")
+	raw := []byte("\x89PNG\r\n")
+	images := []models.GeneratedImagePayload{
+		{DataBase64: base64.StdEncoding.EncodeToString(raw), MimeType: "image/png"},
+	}
+
+	paths, err := writeGeneratedImages(images, out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(paths) != 1 || paths[0] != out {
+		t.Fatalf("expected [%s], got %v", out, paths)
+	}
+	got, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("reading output: %v", err)
+	}
+	if !bytes.Equal(got, raw) {
+		t.Fatalf("written bytes mismatch: %q", got)
+	}
+}
+
+func TestWriteGeneratedImages_MultipleSuffixes(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "art.png")
+	b64 := base64.StdEncoding.EncodeToString([]byte("data"))
+	images := []models.GeneratedImagePayload{
+		{DataBase64: b64}, {DataBase64: b64},
+	}
+
+	paths, err := writeGeneratedImages(images, out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{
+		filepath.Join(dir, "art_1.png"),
+		filepath.Join(dir, "art_2.png"),
+	}
+	if len(paths) != 2 || paths[0] != want[0] || paths[1] != want[1] {
+		t.Fatalf("expected %v, got %v", want, paths)
+	}
+	for _, p := range want {
+		if _, err := os.Stat(p); err != nil {
+			t.Fatalf("expected file %s: %v", p, err)
+		}
+	}
+}
+
+func TestWriteGeneratedImages_CreatesParentDirs(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "outputs", "images", "art.png")
+	images := []models.GeneratedImagePayload{
+		{DataBase64: base64.StdEncoding.EncodeToString([]byte("data"))},
+	}
+
+	paths, err := writeGeneratedImages(images, out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(paths) != 1 || paths[0] != out {
+		t.Fatalf("expected [%s], got %v", out, paths)
+	}
+	if _, err := os.Stat(out); err != nil {
+		t.Fatalf("expected file at nested path: %v", err)
+	}
+}
+
+func TestWriteGeneratedImages_Empty(t *testing.T) {
+	_, err := writeGeneratedImages(nil, "out.png")
+	assertExitCode(t, err, exitcodes.ServerError)
+}
+
+func TestWriteGeneratedImages_BadBase64(t *testing.T) {
+	dir := t.TempDir()
+	images := []models.GeneratedImagePayload{{DataBase64: "not!valid!"}}
+	_, err := writeGeneratedImages(images, filepath.Join(dir, "out.png"))
+	assertExitCode(t, err, exitcodes.ServerError)
+}
+
+func TestLoadReferenceImages_ReadsAndEncodes(t *testing.T) {
+	dir := t.TempDir()
+	jpg := filepath.Join(dir, "ref.jpg")
+	raw := []byte("\xff\xd8jpegdata")
+	if err := os.WriteFile(jpg, raw, 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	refs, err := loadReferenceImages([]string{jpg})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("expected 1 reference, got %d", len(refs))
+	}
+	if refs[0].MimeType != "image/jpeg" {
+		t.Fatalf("expected image/jpeg, got %s", refs[0].MimeType)
+	}
+	if refs[0].DataBase64 != base64.StdEncoding.EncodeToString(raw) {
+		t.Fatalf("base64 mismatch")
+	}
+}
+
+func TestLoadReferenceImages_UnknownExtDefaultsPng(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "ref.bin")
+	if err := os.WriteFile(f, []byte("x"), 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	refs, err := loadReferenceImages([]string{f})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if refs[0].MimeType != "image/png" {
+		t.Fatalf("expected image/png default, got %s", refs[0].MimeType)
+	}
+}
+
+func TestLoadReferenceImages_MissingFile(t *testing.T) {
+	_, err := loadReferenceImages([]string{"/does/not/exist.png"})
+	assertExitCode(t, err, exitcodes.BadRequest)
+}
+
+func TestLoadReferenceImages_Empty(t *testing.T) {
+	refs, err := loadReferenceImages(nil)
+	if err != nil || refs != nil {
+		t.Fatalf("expected (nil, nil), got (%v, %v)", refs, err)
+	}
+}
+
+func TestImageErrorToExit_NotConfigured(t *testing.T) {
+	err := imageErrorToExit(&api.OnyxAPIError{StatusCode: 404, Detail: "no config"})
+	assertExitCode(t, err, exitcodes.NotAvailable)
+}
+
+func TestImageErrorToExit_ServerError(t *testing.T) {
+	err := imageErrorToExit(&api.OnyxAPIError{StatusCode: 500, Detail: "boom"})
+	assertExitCode(t, err, exitcodes.ServerError)
+}

--- a/cli/cmd/image_test.go
+++ b/cli/cmd/image_test.go
@@ -121,6 +121,27 @@ func TestWriteGeneratedImages_MultipleSuffixes(t *testing.T) {
 	}
 }
 
+func TestWriteGeneratedImages_FailsIfExists(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "art.png")
+	if err := os.WriteFile(out, []byte("existing"), 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	images := []models.GeneratedImagePayload{
+		{DataBase64: base64.StdEncoding.EncodeToString([]byte("new"))},
+	}
+
+	_, err := writeGeneratedImages(images, out)
+	if err == nil {
+		t.Fatal("expected error when output already exists")
+	}
+	// The pre-existing file must be left untouched, not truncated.
+	got, _ := os.ReadFile(out)
+	if string(got) != "existing" {
+		t.Fatalf("existing file was modified: %q", got)
+	}
+}
+
 func TestWriteGeneratedImages_CreatesParentDirs(t *testing.T) {
 	dir := t.TempDir()
 	out := filepath.Join(dir, "outputs", "images", "art.png")

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -97,6 +97,7 @@ func Execute() error {
 	rootCmd.AddCommand(chatCmd)
 	rootCmd.AddCommand(newAskCmd(ios))
 	rootCmd.AddCommand(newSearchCmd(ios))
+	rootCmd.AddCommand(newImageCmd(ios))
 	rootCmd.AddCommand(newAgentsCmd(ios))
 	rootCmd.AddCommand(newValidateConfigCmd(ios))
 	rootCmd.AddCommand(newServeCmd())

--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -152,6 +152,17 @@ func (c *Client) Search(ctx context.Context, req models.SearchRequest) (*models.
 	return &resp, nil
 }
 
+// GenerateImage calls POST /build/image-generation/generate, which generates
+// image(s) using the workspace's default image-gen provider. Uses the 5min
+// client since high-res generation can be slow.
+func (c *Client) GenerateImage(ctx context.Context, req models.ImageGenerationRequest) (*models.ImageGenerationResponse, error) {
+	var resp models.ImageGenerationResponse
+	if err := c.doJSONWith(ctx, c.streamingHTTPClient, "POST", "/build/image-generation/generate", req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
 // TestConnection checks if the server is reachable and credentials are valid.
 // Returns nil on success, or an error with a descriptive message on failure.
 func (c *Client) TestConnection(ctx context.Context) error {
@@ -355,6 +366,7 @@ type ClientAPI interface {
 	StopChatSession(ctx context.Context, sessionID string)
 	SendMessageStream(ctx context.Context, message string, chatSessionID *string, agentID int, parentMessageID *int, fileDescriptors []models.FileDescriptorPayload) <-chan models.StreamEvent
 	Search(ctx context.Context, req models.SearchRequest) (*models.SearchResponse, error)
+	GenerateImage(ctx context.Context, req models.ImageGenerationRequest) (*models.ImageGenerationResponse, error)
 }
 
 var _ ClientAPI = (*Client)(nil)

--- a/cli/internal/api/image_test.go
+++ b/cli/internal/api/image_test.go
@@ -1,0 +1,59 @@
+package api_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/onyx-dot-app/onyx/cli/internal/api"
+	"github.com/onyx-dot-app/onyx/cli/internal/models"
+	"github.com/onyx-dot-app/onyx/cli/internal/testutil"
+)
+
+func TestGenerateImage_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if !strings.HasSuffix(r.URL.Path, "/build/image-generation/generate") {
+			t.Errorf("path = %s, want .../build/image-generation/generate", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"images": [{"data_base64": "YWJj", "mime_type": "image/png", "revised_prompt": "a cat"}]
+		}`))
+	}))
+	defer srv.Close()
+
+	client := testutil.NewClient(srv.URL)
+	resp, err := client.GenerateImage(t.Context(), models.ImageGenerationRequest{Prompt: "a cat"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Images) != 1 {
+		t.Fatalf("expected 1 image, got %d", len(resp.Images))
+	}
+	if resp.Images[0].DataBase64 != "YWJj" || resp.Images[0].MimeType != "image/png" {
+		t.Errorf("unexpected image payload: %+v", resp.Images[0])
+	}
+}
+
+func TestGenerateImage_404(t *testing.T) {
+	srv := testutil.StatusServer(404)
+	defer srv.Close()
+
+	client := testutil.NewClient(srv.URL)
+	_, err := client.GenerateImage(t.Context(), models.ImageGenerationRequest{Prompt: "a cat"})
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+	var apiErr *api.OnyxAPIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("want *OnyxAPIError, got %T: %v", err, err)
+	}
+	if apiErr.StatusCode != 404 {
+		t.Errorf("status = %d, want 404", apiErr.StatusCode)
+	}
+}

--- a/cli/internal/models/image.go
+++ b/cli/internal/models/image.go
@@ -1,0 +1,25 @@
+package models
+
+type ImageReferencePayload struct {
+	DataBase64 string `json:"data_base64"`
+	MimeType   string `json:"mime_type,omitempty"`
+}
+
+// ImageGenerationRequest is the body for POST /build/image-generation/generate.
+type ImageGenerationRequest struct {
+	Prompt          string                  `json:"prompt"`
+	Shape           string                  `json:"shape,omitempty"`
+	N               int                     `json:"n,omitempty"`
+	Quality         string                  `json:"quality,omitempty"`
+	ReferenceImages []ImageReferencePayload `json:"reference_images,omitempty"`
+}
+
+type GeneratedImagePayload struct {
+	DataBase64    string `json:"data_base64"`
+	MimeType      string `json:"mime_type"`
+	RevisedPrompt string `json:"revised_prompt"`
+}
+
+type ImageGenerationResponse struct {
+	Images []GeneratedImagePayload `json:"images"`
+}


### PR DESCRIPTION
## Description

Adds an `onyx-cli image` command (`generate` + `edit` subcommands) for Onyx Craft. It calls the backend `POST /build/image-generation/generate` endpoint, decodes the returned base64 image(s), and writes them to disk (creating parent directories as needed). Includes `Client.GenerateImage`, request/response models, and `root.go` registration.

This is **1 of 3** PRs splitting the image-generation skill rework:
1. **this PR** — onyx-cli `image` command (client)
2. sandbox image deps (drop `google-genai`, add `requests`)
3. API server — the `/build/image-generation/generate` endpoint + skill rework

The endpoint this command targets ships in PR 3. A new onyx-cli release + sandbox-image pin bump is required before the command is available inside sandboxes (the command path/URL is stable, so no further CLI change is needed).

## How Has This Been Tested?

`go build ./...`, `go vet`, `gofmt -l`, and `go test ./cmd/... ./internal/api/...` all pass. Unit tests cover request assembly, multi-image file writing + parent-dir creation, reference-image loading + mime-by-extension, error→exit-code mapping, and the client call via `httptest`. Also exercised end-to-end against a local kind cluster (generated a real image from inside a provisioned sandbox).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `onyx-cli image` with `generate` and `edit` to create or modify images via the server’s `POST /build/image-generation/generate`. Saves images without overwriting existing files, supports multiple outputs, and optional reference images for edits.

- **New Features**
  - `onyx-cli image generate`: `--prompt`, `--output` (defaults to output.png), `--shape` (square|portrait|landscape), `--num`, `--quality`.
  - `onyx-cli image edit`: adds `-i/--input-image` (repeatable) for reference/composition.
  - Decodes base64 images, creates parent dirs, suffixes `_1`, `_2`, … when `--num > 1`, and fails if the target exists.
  - Adds `Client.GenerateImage` and request/response models; maps 404 to a clear “provider not configured” error; registers the command in the root CLI.

- **Migration**
  - Requires the server endpoint `/build/image-generation/generate` and a configured image provider.
  - For sandboxes, update to an image that includes the new `onyx-cli` release and bump the `sandbox-image` pin once the server ships.

<sup>Written for commit b9b6e42c13d8098012c47fa5e09734ad7796ab61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

