### PR TITLE
chore(craft-sandbox): drop google-genai, add requests to sandbox image deps

### DIFF
--- a/backend/onyx/server/features/build/sandbox/image/initial-requirements.in
+++ b/backend/onyx/server/features/build/sandbox/image/initial-requirements.in
@@ -1,7 +1,6 @@
 cryptography
 defusedxml
 fastapi
-google-genai
 lxml
 matplotlib
 matplotlib-inline
@@ -13,4 +12,5 @@ pdfplumber
 pillow
 pydantic
 python-pptx
+requests
 uvicorn[standard]

--- a/backend/onyx/server/features/build/sandbox/image/initial-requirements.txt
+++ b/backend/onyx/server/features/build/sandbox/image/initial-requirements.txt
@@ -24,7 +24,7 @@ lxml==6.1.1               # via python-pptx, -r initial-requirements.in
 matplotlib==3.11.0        # via -r initial-requirements.in
 matplotlib-inline==0.2.2  # via -r initial-requirements.in
 numpy==2.4.6              # via contourpy, matplotlib, pandas, -r initial-requirements.in
-onyx-cli==1.1.1           # via -r initial-requirements.in
+onyx-cli==1.2.0           # via -r initial-requirements.in
 openpyxl==3.1.5           # via -r initial-requirements.in
 packaging==26.2           # via matplotlib
 pandas==3.0.3             # via -r initial-requirements.in

--- a/backend/onyx/server/features/build/sandbox/image/initial-requirements.txt
+++ b/backend/onyx/server/features/build/sandbox/image/initial-requirements.txt
@@ -24,7 +24,7 @@ lxml==6.1.1               # via python-pptx, -r initial-requirements.in
 matplotlib==3.11.0        # via -r initial-requirements.in
 matplotlib-inline==0.2.2  # via -r initial-requirements.in
 numpy==2.4.6              # via contourpy, matplotlib, pandas, -r initial-requirements.in
-onyx-cli==1.2.0           # via -r initial-requirements.in
+onyx-cli==1.2.1           # via -r initial-requirements.in
 openpyxl==3.1.5           # via -r initial-requirements.in
 packaging==26.2           # via matplotlib
 pandas==3.0.3             # via -r initial-requirements.in

--- a/backend/onyx/server/features/build/sandbox/image/initial-requirements.txt
+++ b/backend/onyx/server/features/build/sandbox/image/initial-requirements.txt
@@ -4,26 +4,21 @@
 # uv pip install --dry-run --refresh --only-binary=:all: --python-version 3.13 --python-platform <platform> -r initial-requirements.txt
 annotated-doc==0.0.4      # via fastapi
 annotated-types==0.7.0    # via pydantic
-anyio==4.13.0             # via google-genai, httpx, starlette, watchfiles
-certifi==2026.5.20        # via httpcore, httpx, requests
+anyio==4.13.0             # via starlette, watchfiles
+certifi==2026.6.17        # via requests
 cffi==2.0.0               # via cryptography
 charset-normalizer==3.4.7  # via pdfminer-six, requests
 click==8.4.1              # via uvicorn
 contourpy==1.3.3          # via matplotlib
-cryptography==49.0.0      # via google-auth, pdfminer-six, --override (workspace), -r initial-requirements.in
+cryptography==49.0.0      # via pdfminer-six, --override (workspace), -r initial-requirements.in
 cycler==0.12.1            # via matplotlib
 defusedxml==0.7.1         # via -r initial-requirements.in
-distro==1.9.0             # via google-genai
 et-xmlfile==2.0.0         # via openpyxl
 fastapi==0.136.3          # via -r initial-requirements.in
 fonttools==4.63.0         # via matplotlib
-google-auth[requests]==2.54.0  # via google-genai
-google-genai==2.8.0       # via -r initial-requirements.in
-h11==0.16.0               # via httpcore, uvicorn, --override (workspace)
-httpcore==1.0.9           # via httpx
+h11==0.16.0               # via uvicorn, --override (workspace)
 httptools==0.8.0          # via uvicorn
-httpx==0.28.1             # via google-genai
-idna==3.18                # via anyio, httpx, requests
+idna==3.18                # via anyio, requests
 kiwisolver==1.5.0         # via matplotlib
 lxml==6.1.1               # via python-pptx, -r initial-requirements.in
 matplotlib==3.11.0        # via -r initial-requirements.in
@@ -36,10 +31,8 @@ pandas==3.0.3             # via -r initial-requirements.in
 pdfminer-six==20251230    # via pdfplumber
 pdfplumber==0.11.9        # via -r initial-requirements.in
 pillow==12.2.0            # via matplotlib, pdfplumber, python-pptx, -r initial-requirements.in
-pyasn1==0.6.3             # via pyasn1-modules
-pyasn1-modules==0.4.2     # via google-auth
 pycparser==3.0            # via cffi
-pydantic==2.13.4          # via fastapi, google-genai, -r initial-requirements.in
+pydantic==2.13.4          # via fastapi, -r initial-requirements.in
 pydantic-core==2.46.4     # via pydantic
 pyparsing==3.3.2          # via matplotlib
 pypdfium2==5.9.0          # via pdfplumber
@@ -47,17 +40,15 @@ python-dateutil==2.9.0.post0  # via matplotlib, pandas
 python-dotenv==1.2.2      # via uvicorn
 python-pptx==1.0.2        # via -r initial-requirements.in
 pyyaml==6.0.3             # via uvicorn
-requests==2.34.2          # via google-auth, google-genai
+requests==2.34.2          # via -r initial-requirements.in
 six==1.17.0               # via python-dateutil
-sniffio==1.3.1            # via google-genai
 starlette==1.3.1          # via fastapi
-tenacity==9.1.4           # via google-genai
 traitlets==5.15.1         # via matplotlib-inline
-typing-extensions==4.15.0  # via fastapi, google-genai, pydantic, pydantic-core, python-pptx, typing-inspection
+typing-extensions==4.15.0  # via fastapi, pydantic, pydantic-core, python-pptx, typing-inspection
 typing-inspection==0.4.2  # via fastapi, pydantic
 urllib3==2.7.0            # via requests
 uvicorn[standard]==0.49.0  # via -r initial-requirements.in
 uvloop==0.22.1            # via uvicorn
 watchfiles==1.2.0         # via uvicorn
-websockets==16.0          # via google-genai, uvicorn
+websockets==16.0          # via uvicorn
 xlsxwriter==3.2.9         # via python-pptx


### PR DESCRIPTION
## Description

Updates the Craft sandbox image's Python dependency closure (`initial-requirements.in`/`.txt`):

- **Removes `google-genai`** (and its now-orphaned transitive deps: `google-auth`, `httpx`, `distro`, `tenacity`, `pyasn1`, …). It was only there for the old Gemini-based image-generation skill, which is being reworked to go through `onyx-cli` + a backend endpoint (PR 3). Nothing else in the sandbox imports it.
- **Adds `requests`** explicitly — previously present only transitively via `google-genai`; kept deliberately as a general convenience for agent-authored Python in the sandbox.

This is **2 of 3** PRs splitting the image-generation skill rework (1 = onyx-cli command #12493, 3 = API server endpoint + skill). Best landed alongside/after PR 3 so the skill stops using `google-genai` before it's removed; the old skill was already effectively inert (its `GEMINI_API_KEY` was never injected), so ordering is low-risk. Requires a sandbox image rebuild to take effect.

## How Has This Been Tested?

Recompiled `initial-requirements.txt` with `uv pip compile` (no `--upgrade`, minimal churn) and verified the wheel-only resolution. Built the sandbox image locally and confirmed `requests` is present and `google-genai` is gone; verified nothing under the sandbox image dir, daemon, or built-in skills imports `genai`.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drop `google-genai`, add `requests`, and pin `onyx-cli==1.2.1` in the Craft sandbox image to support the new image-generation flow via `onyx-cli` and a backend endpoint.

- **Dependencies**
  - Removed: `google-genai` and transitive deps (`google-auth`, `httpx`, `distro`, `tenacity`, `pyasn1`, ...).
  - Added: `requests`.
  - Updated: `onyx-cli` to `1.2.1` (includes the image command at the generic generate path).

- **Migration**
  - Rebuild the sandbox image to apply these changes.

<sup>Written for commit 1523f5bef4a15783e7111b6dba944555bd2a82a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

