### PR TITLE
fix(craft): preserve interrupted turn output when sending a new message

### DIFF
--- a/web/src/app/craft/hooks/loadSessionRestore.test.ts
+++ b/web/src/app/craft/hooks/loadSessionRestore.test.ts
@@ -362,6 +362,102 @@ describe("loadSession restore status", () => {
   });
 });
 
+describe("loadSession preferPersisted (interrupt reconciliation)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useBuildSessionStore.setState({
+      sessions: new Map(),
+      currentSessionId: null,
+    } as never);
+    mockedApi.fetchActiveTurn.mockResolvedValue(null as never);
+    mockedApi.fetchArtifacts.mockResolvedValue([] as never);
+    mockedApi.fetchWebappInfo.mockResolvedValue(
+      webappInfo(true, true) as never
+    );
+    mockedApi.fetchSession.mockResolvedValue(runningSession() as never);
+  });
+
+  // Simulates a lost-to-interrupt prompt_response: local state has only the user
+  // message, while the DB transcript holds the partial agent_thought.
+  function seedInterruptedSession(): void {
+    useBuildSessionStore.getState().createSession(SESSION_ID, {
+      status: "running",
+      messages: [
+        {
+          id: "local-user",
+          type: "user",
+          content: "Write an essay",
+          timestamp: new Date(),
+        },
+      ],
+      activeTurnId: "turn-interrupted",
+      activeTurnIndex: 0,
+      activeTurnLocalOwner: true,
+      isLoaded: false,
+    });
+    mockedApi.fetchMessages.mockResolvedValue([
+      {
+        id: "user-1",
+        type: "user",
+        content: "Write an essay",
+        timestamp: new Date(),
+        message_metadata: {
+          type: "user_message",
+          content: { type: "text", text: "Write an essay" },
+        },
+      },
+      {
+        id: "thought-1",
+        type: "assistant",
+        content: "",
+        timestamp: new Date(),
+        message_metadata: {
+          type: "agent_thought",
+          content: { type: "text", text: "Planning the essay structure." },
+        },
+      },
+    ] as never);
+  }
+
+  it("rehydrates the persisted interrupted transcript while keeping status running", async () => {
+    seedInterruptedSession();
+
+    await useBuildSessionStore
+      .getState()
+      .loadSession(SESSION_ID, { force: true, preferPersisted: true });
+
+    const session = useBuildSessionStore.getState().sessions.get(SESSION_ID);
+    expect(session?.status).toBe("running");
+    const assistant = session?.messages.find((m) => m.type === "assistant");
+    expect(assistant?.message_metadata?.streamItems).toEqual([
+      {
+        type: "thinking",
+        id: "thought-1",
+        content: "Planning the essay structure.",
+        isStreaming: false,
+      },
+    ]);
+    // The DB-sourced path also clears the stale optimistic turn metadata (pre-fix
+    // the isStreaming branch kept activeTurnId="turn-interrupted"/localOwner=true).
+    expect(session?.streamItems).toEqual([]);
+    expect(session?.activeTurnId).toBeNull();
+    expect(session?.activeTurnLocalOwner).toBe(false);
+  });
+
+  it("keeps the stale local transcript without preferPersisted (the bug)", async () => {
+    seedInterruptedSession();
+
+    await useBuildSessionStore
+      .getState()
+      .loadSession(SESSION_ID, { force: true });
+
+    const session = useBuildSessionStore.getState().sessions.get(SESSION_ID);
+    expect(session?.messages).toEqual([
+      expect.objectContaining({ id: "local-user", type: "user" }),
+    ]);
+  });
+});
+
 describe("waitForWebappReady", () => {
   beforeEach(() => jest.clearAllMocks());
   afterEach(() => jest.clearAllMocks());

--- a/web/src/app/craft/hooks/loadSessionRestore.test.ts
+++ b/web/src/app/craft/hooks/loadSessionRestore.test.ts
@@ -377,8 +377,6 @@ describe("loadSession preferPersisted (interrupt reconciliation)", () => {
     mockedApi.fetchSession.mockResolvedValue(runningSession() as never);
   });
 
-  // Simulates a lost-to-interrupt prompt_response: local state has only the user
-  // message, while the DB transcript holds the partial agent_thought.
   function seedInterruptedSession(): void {
     useBuildSessionStore.getState().createSession(SESSION_ID, {
       status: "running",
@@ -437,8 +435,6 @@ describe("loadSession preferPersisted (interrupt reconciliation)", () => {
         isStreaming: false,
       },
     ]);
-    // The DB-sourced path also clears the stale optimistic turn metadata (pre-fix
-    // the isStreaming branch kept activeTurnId="turn-interrupted"/localOwner=true).
     expect(session?.streamItems).toEqual([]);
     expect(session?.activeTurnId).toBeNull();
     expect(session?.activeTurnLocalOwner).toBe(false);

--- a/web/src/app/craft/hooks/useBuildSessionStore.ts
+++ b/web/src/app/craft/hooks/useBuildSessionStore.ts
@@ -1452,10 +1452,9 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
       const hasOptimisticMessages =
         (currentSession?.messages?.length ?? 0) > 0 && currentSessionIsLive;
       const isStreaming = hasOptimisticMessages;
-      // preferPersisted changes only the message source (DB vs local optimistic).
-      // Its sole caller, settle(), runs on a live "running" session, so the
-      // isStreaming status branch below still keeps status live — letting settle
-      // stay the single owner of the flip to "active" (avoiding the auto-send race).
+      // settle() (the only preferPersisted caller) runs on a live "running"
+      // session, so the isStreaming status branch below already keeps status live,
+      // leaving settle the sole owner of the flip to "active" (else auto-send races).
       const useDbMessages = !isStreaming || options?.preferPersisted === true;
 
       // Construct webapp URL

--- a/web/src/app/craft/hooks/useBuildSessionStore.ts
+++ b/web/src/app/craft/hooks/useBuildSessionStore.ts
@@ -1452,8 +1452,10 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
       const hasOptimisticMessages =
         (currentSession?.messages?.length ?? 0) > 0 && currentSessionIsLive;
       const isStreaming = hasOptimisticMessages;
-      // preferPersisted keeps status live (below) so the flip to "active" stays
-      // the caller's and doesn't race the queued auto-send.
+      // preferPersisted changes only the message source (DB vs local optimistic).
+      // Its sole caller, settle(), runs on a live "running" session, so the
+      // isStreaming status branch below still keeps status live — letting settle
+      // stay the single owner of the flip to "active" (avoiding the auto-send race).
       const useDbMessages = !isStreaming || options?.preferPersisted === true;
 
       // Construct webapp URL
@@ -1472,18 +1474,15 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
         activeTurn?.turn_index ??
         (useDbMessages ? null : currentSession!.activeTurnIndex);
 
-      const status =
-        options?.preferPersisted === true && currentSession
-          ? currentSession.status
-          : isStreaming
-            ? currentSession!.status
-            : activeTurn
-              ? "running"
-              : needsRestore
-                ? "creating"
-                : sessionData.status === "active"
-                  ? "active"
-                  : "idle";
+      const status = isStreaming
+        ? currentSession!.status
+        : activeTurn
+          ? "running"
+          : needsRestore
+            ? "creating"
+            : sessionData.status === "active"
+              ? "active"
+              : "idle";
       const persistedMessages = useDbMessages
         ? consolidateMessagesIntoTurns(messages)
         : currentSession!.messages;

--- a/web/src/app/craft/hooks/useBuildSessionStore.ts
+++ b/web/src/app/craft/hooks/useBuildSessionStore.ts
@@ -716,7 +716,7 @@ interface BuildSessionStore {
   // Actions - Session Lifecycle
   loadSession: (
     sessionId: string,
-    options?: { force?: boolean }
+    options?: { force?: boolean; preferPersisted?: boolean }
   ) => Promise<void>;
 
   // Actions - Session History
@@ -1394,7 +1394,10 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
   // Session Lifecycle
   // ===========================================================================
 
-  loadSession: async (sessionId: string, options?: { force?: boolean }) => {
+  loadSession: async (
+    sessionId: string,
+    options?: { force?: boolean; preferPersisted?: boolean }
+  ) => {
     const { setCurrentSession, updateSessionData, sessions } = get();
 
     // Check if already loaded in cache
@@ -1449,6 +1452,9 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
       const hasOptimisticMessages =
         (currentSession?.messages?.length ?? 0) > 0 && currentSessionIsLive;
       const isStreaming = hasOptimisticMessages;
+      // preferPersisted keeps status live (below) so the flip to "active" stays
+      // the caller's and doesn't race the queued auto-send.
+      const useDbMessages = !isStreaming || options?.preferPersisted === true;
 
       // Construct webapp URL
       let webappUrl: string | null = null;
@@ -1461,37 +1467,40 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
 
       const resolvedActiveTurnId =
         activeTurn?.turn_id ??
-        (isStreaming ? currentSession!.activeTurnId : null);
+        (useDbMessages ? null : currentSession!.activeTurnId);
       const resolvedActiveTurnIndex =
         activeTurn?.turn_index ??
-        (isStreaming ? currentSession!.activeTurnIndex : null);
+        (useDbMessages ? null : currentSession!.activeTurnIndex);
 
-      const status = isStreaming
-        ? currentSession!.status
-        : activeTurn
-          ? "running"
-          : needsRestore
-            ? "creating"
-            : sessionData.status === "active"
-              ? "active"
-              : "idle";
-      const persistedMessages = isStreaming
-        ? currentSession!.messages
-        : consolidateMessagesIntoTurns(messages);
-      const restoredActiveTurn = isStreaming
-        ? {
+      const status =
+        options?.preferPersisted === true && currentSession
+          ? currentSession.status
+          : isStreaming
+            ? currentSession!.status
+            : activeTurn
+              ? "running"
+              : needsRestore
+                ? "creating"
+                : sessionData.status === "active"
+                  ? "active"
+                  : "idle";
+      const persistedMessages = useDbMessages
+        ? consolidateMessagesIntoTurns(messages)
+        : currentSession!.messages;
+      const restoredActiveTurn = useDbMessages
+        ? splitActiveTurnTranscript(persistedMessages, resolvedActiveTurnIndex)
+        : {
             messages: persistedMessages,
             streamItems: currentSession!.streamItems,
-          }
-        : splitActiveTurnTranscript(persistedMessages, resolvedActiveTurnIndex);
+          };
       const resolvedMessages = restoredActiveTurn.messages;
       const streamItems = restoredActiveTurn.streamItems;
       // Reconstruct subagents from the raw (un-consolidated) messages — they
       // carry the per-packet _meta needed for classification. Preserve the
       // live map if actively streaming.
-      const subagents = isStreaming
-        ? currentSession!.subagents
-        : buildSubagentsFromMessages(messages);
+      const subagents = useDbMessages
+        ? buildSubagentsFromMessages(messages)
+        : currentSession!.subagents;
       const sandbox =
         needsRestore && sessionData.sandbox
           ? { ...sessionData.sandbox, status: "restoring" as const }
@@ -1510,9 +1519,9 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
         origin: sessionData.origin,
         activeTurnId: resolvedActiveTurnId,
         activeTurnIndex: resolvedActiveTurnIndex,
-        activeTurnLocalOwner: isStreaming
-          ? currentSession!.activeTurnLocalOwner
-          : false,
+        activeTurnLocalOwner: useDbMessages
+          ? false
+          : currentSession!.activeTurnLocalOwner,
         error: null,
         isLoaded: true,
       });

--- a/web/src/app/craft/hooks/useBuildStreaming.test.tsx
+++ b/web/src/app/craft/hooks/useBuildStreaming.test.tsx
@@ -1225,7 +1225,7 @@ describe("useBuildStreaming thinking packets", () => {
     });
     expect(useBuildSessionStore.getState().loadSession).toHaveBeenCalledWith(
       sessionId,
-      { force: true }
+      { force: true, preferPersisted: true }
     );
   });
 
@@ -1440,7 +1440,7 @@ describe("useBuildStreaming thinking packets", () => {
     });
     expect(useBuildSessionStore.getState().loadSession).toHaveBeenCalledWith(
       sessionId,
-      { force: true }
+      { force: true, preferPersisted: true }
     );
     warnSpy.mockRestore();
   });
@@ -1533,7 +1533,7 @@ describe("useBuildStreaming thinking packets", () => {
     });
     expect(useBuildSessionStore.getState().loadSession).toHaveBeenCalledWith(
       sessionId,
-      { force: true }
+      { force: true, preferPersisted: true }
     );
   });
 

--- a/web/src/app/craft/hooks/useBuildStreaming.ts
+++ b/web/src/app/craft/hooks/useBuildStreaming.ts
@@ -168,7 +168,7 @@ export function useBuildStreaming() {
       const settle = async (): Promise<void> => {
         await useBuildSessionStore
           .getState()
-          .loadSession(sessionId, { force: true })
+          .loadSession(sessionId, { force: true, preferPersisted: true })
           .catch((err) =>
             console.warn("[Streaming] Failed to reload settled turn:", err)
           );


### PR DESCRIPTION
## Description

Aborting an in-flight Craft turn and then sending a new message scrapped the interrupted turn's streamed output (thinking, tool calls, partial text) from the conversation.

**Root cause (frontend only):** the interrupted turn's partial output is durably persisted server-side (the executor writes each event to the DB + `finalize_persist` on cancel). But the frontend only committed that partial into the local `messages` array via the live `prompt_response` SSE packet — which on interrupt is racy/lost (the live attach stream `subscribe_to_existing_session_events` translates only opencode bus events; it never injects the synthetic cancelled `prompt_response`). When the partial wasn't committed, `streamMessage` aborted the stream and cleared `streamItems`, dropping it. Recovery never happened because every post-interrupt `loadSession` ran in the `isStreaming` branch, which preserves the stale local messages instead of re-reading the persisted transcript. (A manual page reload always restored it — proving the data was safe in the DB the whole time.)

**The fix:** add a `preferPersisted` option to `loadSession`. When set, messages/streamItems/subagents are sourced from the DB transcript even while the session is live, **but `status` is kept at its live value** so `reconcileInterruptedTurn.settle()` stays the single trigger for the flip to `"active"` — flipping status inside `loadSession` would prematurely fire the queued auto-send and race the next turn. `settle()` now calls `loadSession({ force: true, preferPersisted: true })`.

The refactor (`isStreaming ? A : B` → `useDbMessages ? B : A`, where `useDbMessages = !isStreaming || preferPersisted`) is behavior-preserving for every other caller — with the flag unset, `useDbMessages === !isStreaming`, so each branch reduces exactly to the original.

## How Has This Been Tested?

- **Live, before and after:** reproduced on st-dev (interrupted turn's Thinking block vanished on resend, reappeared only after a manual reload), then confirmed fixed on a local build (the content now survives the resend with no reload; a subsequent hard reload shows an identical, non-duplicated transcript).
- **Unit tests** (`loadSessionRestore.test.ts`): a regression test that `preferPersisted` rehydrates the interrupted transcript from the DB while keeping `status: "running"` and clearing stale turn metadata (`activeTurnId`/`activeTurnLocalOwner`/`streamItems`); plus a control test pinning the old behavior when the flag is unset.
- Updated 3 existing `useBuildStreaming.test.tsx` settle assertions to reflect the new `settle()` call args (deliberate contract change).
- `bun run types:check`, `oxlint`, and the affected jest suites (47 tests) all pass.

## Known minor items (for the reviewer)

- The test reviewer noted the `preferPersisted` *status-preservation* branch is only divergent from the default path when `isStreaming` is false — a state the real `settle()` caller never hits (it's a defensive branch), so it's covered by intent rather than a divergence test.
- No test covers a brand-new queued turn surviving alongside the restored partial (the auto-send race); that coordination lives in `reconcileInterruptedTurn` and is guarded by its generation check.
- A theoretical TOCTOU exists in `settle()` (DB writes land before the guarded status flip re-checks `ownsInterrupt`), but it is unreachable through the UI — new turns only start after the guarded flip.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes loss of partial output when a Craft turn is interrupted and a new message is sent. The UI now restores persisted thinking/tool calls/partial text immediately without a reload.

- **Bug Fixes**
  - Added a `preferPersisted` option to `loadSession` to read messages/subagents/streamItems from the DB transcript while keeping status "running" to avoid auto-send races.
  - Updated `settle()` in `useBuildStreaming` to call `loadSession({ force: true, preferPersisted: true })`.
  - Added a regression test for interrupt reconciliation and updated related assertions.

- **Refactors**
  - Removed a redundant `preferPersisted` status branch; the existing `isStreaming` path already preserves live status.

<sup>Written for commit a2813f7598930d6330f1466cd58bd214dace0d0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- linear override checked -->