### PR TITLE
feat: add Jira Service Management (JSM) connector (#2281)

### DIFF
--- a/backend/ee/onyx/external_permissions/sync_params.py
+++ b/backend/ee/onyx/external_permissions/sync_params.py
@@ -118,6 +118,18 @@ _SOURCE_TO_SYNC_CONFIG: dict[DocumentSource, SyncConfig] = {
             group_sync_is_cc_pair_agnostic=True,
         ),
     ),
+    DocumentSource.JIRA_SERVICE_MANAGEMENT: SyncConfig(
+        doc_sync_config=DocSyncConfig(
+            doc_sync_frequency=JIRA_PERMISSION_DOC_SYNC_FREQUENCY,
+            doc_sync_func=jira_doc_sync,
+            initial_index_should_sync=True,
+        ),
+        group_sync_config=GroupSyncConfig(
+            group_sync_frequency=JIRA_PERMISSION_GROUP_SYNC_FREQUENCY,
+            group_sync_func=jira_group_sync,
+            group_sync_is_cc_pair_agnostic=True,
+        ),
+    ),
     # Groups are not needed for Slack.
     # All channel access is done at the individual user level.
     DocumentSource.SLACK: SyncConfig(

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -220,6 +220,7 @@ class DocumentSource(str, Enum):
     OUTLINE = "outline"
     CONFLUENCE = "confluence"
     JIRA = "jira"
+    JIRA_SERVICE_MANAGEMENT = "jira_service_management"
     SLAB = "slab"
     PRODUCTBOARD = "productboard"
     FILE = "file"
@@ -700,6 +701,7 @@ DocumentSourceDescription: dict[DocumentSource, str] = {
     DocumentSource.OUTLINE: "Documentation and knowledge base pages",
     DocumentSource.CONFLUENCE: "Wiki pages, spaces, and documentation",
     DocumentSource.JIRA: "Issues, tickets, and project tracking",
+    DocumentSource.JIRA_SERVICE_MANAGEMENT: "Service desk requests, incidents, and customer tickets",
     DocumentSource.SLAB: "Documentation and knowledge base pages",
     DocumentSource.PRODUCTBOARD: "Product management boards and insights",
     DocumentSource.FILE: "Uploaded files",

--- a/backend/onyx/connectors/jira/connector.py
+++ b/backend/onyx/connectors/jira/connector.py
@@ -1147,9 +1147,9 @@ class JiraServiceManagementConnector(JiraConnector):
     ) -> str:
         """Build JQL that is always scoped to JSM projects.
 
-        A user-supplied ``jql_query`` is respected (ANDed with the time
-        window) but the JSM project-type filter is NOT added on top of it —
-        users who provide custom JQL know what they are filtering on.
+        A user-supplied ``jql_query`` is ANDed with the JSM project-type
+        filter so that custom queries cannot accidentally index non-JSM tickets
+        under the JIRA_SERVICE_MANAGEMENT source.
         """
         start_date_str = datetime.fromtimestamp(start, tz=timezone.utc).strftime(
             "%Y-%m-%d %H:%M"
@@ -1160,7 +1160,9 @@ class JiraServiceManagementConnector(JiraConnector):
         time_jql = f"updated >= '{start_date_str}' AND updated <= '{end_date_str}'"
 
         if self.jql_query:
-            return f"({self.jql_query}) AND {time_jql}"
+            return (
+                f"({self._jsm_base_jql()}) AND ({self.jql_query}) AND {time_jql}"
+            )
 
         return f"({self._jsm_base_jql()}) AND {time_jql}"
 

--- a/backend/onyx/connectors/jira/connector.py
+++ b/backend/onyx/connectors/jira/connector.py
@@ -390,6 +390,7 @@ def process_jira_issue(
     comment_email_blacklist: tuple[str, ...] = (),
     labels_to_skip: set[str] | None = None,
     parent_hierarchy_raw_node_id: str | None = None,
+    source: DocumentSource = DocumentSource.JIRA,
 ) -> Document | None:
     if labels_to_skip:
         if any(label in issue.fields.labels for label in labels_to_skip):
@@ -486,7 +487,7 @@ def process_jira_issue(
     return Document(
         id=page_url,
         sections=[TextSection(link=page_url, text=ticket_content)],
-        source=DocumentSource.JIRA,
+        source=source,
         semantic_identifier=f"{issue.key}: {issue.fields.summary}",
         title=f"{issue.key} {issue.fields.summary}",
         doc_updated_at=time_str_to_utc(issue.fields.updated),
@@ -526,6 +527,9 @@ class JiraConnector(
         # Custom JQL query to filter Jira issues
         jql_query: str | None = None,
         scoped_token: bool = False,
+        # Source tag applied to emitted documents. Subclasses (e.g. JSM) override
+        # this to index their tickets as a distinct source type.
+        document_source: DocumentSource = DocumentSource.JIRA,
     ) -> None:
         self.batch_size = batch_size
 
@@ -539,6 +543,7 @@ class JiraConnector(
         self.labels_to_skip = set(labels_to_skip)
         self.jql_query = jql_query
         self.scoped_token = scoped_token
+        self.document_source = document_source
         self._jira_client: JIRA | None = None
         # Cache project permissions to avoid fetching them repeatedly across runs
         self._project_permissions_cache: dict[str, Any] = {}
@@ -836,6 +841,7 @@ class JiraConnector(
                     comment_email_blacklist=self.comment_email_blacklist,
                     labels_to_skip=self.labels_to_skip,
                     parent_hierarchy_raw_node_id=parent_hierarchy_raw_node_id,
+                    source=self.document_source,
                 ):
                     # Add permission information to the document if requested
                     if include_permissions:
@@ -1096,6 +1102,103 @@ class JiraConnector(
         )
 
 
+class JiraServiceManagementConnector(JiraConnector):
+    """Connector for Jira Service Management (JSM) projects.
+
+    JSM runs on the same Jira Cloud/Server REST API and shares the issue model
+    used for regular Jira projects.  This connector reuses all of
+    JiraConnector's fetching, checkpointing, permission-sync, and hierarchy
+    logic.
+
+    Differences from the base JiraConnector:
+    - Documents are tagged with DocumentSource.JIRA_SERVICE_MANAGEMENT.
+    - When no explicit project key or JQL is given the base JQL is scoped to
+      ``project type = "service_management"`` so only JSM projects are indexed.
+    - ``validate_connector_settings`` additionally confirms that a provided
+      project key is a genuine service-desk project.
+    """
+
+    # Atlassian project type string used to identify JSM projects
+    _JSM_PROJECT_TYPE = "service_management"
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        # Force the JSM source regardless of what the caller passes so this
+        # connector can never accidentally emit plain Jira documents.
+        kwargs["document_source"] = DocumentSource.JIRA_SERVICE_MANAGEMENT
+        super().__init__(*args, **kwargs)
+
+    # ------------------------------------------------------------------
+    # JQL helpers
+    # ------------------------------------------------------------------
+
+    def _jsm_base_jql(self) -> str:
+        """Return a base JQL clause that constrains results to JSM projects.
+
+        If a project key was supplied we scope directly to that project.
+        Otherwise we use the ``project type`` operator so every service-desk
+        project is covered without needing an exhaustive list.
+        """
+        if self.jira_project:
+            return f"project = {self.quoted_jira_project}"
+        return f'project type = "{self._JSM_PROJECT_TYPE}"'
+
+    def _get_jql_query(
+        self, start: SecondsSinceUnixEpoch, end: SecondsSinceUnixEpoch
+    ) -> str:
+        """Build JQL that is always scoped to JSM projects.
+
+        A user-supplied ``jql_query`` is respected (ANDed with the time
+        window) but the JSM project-type filter is NOT added on top of it —
+        users who provide custom JQL know what they are filtering on.
+        """
+        start_date_str = datetime.fromtimestamp(start, tz=timezone.utc).strftime(
+            "%Y-%m-%d %H:%M"
+        )
+        end_date_str = datetime.fromtimestamp(end, tz=timezone.utc).strftime(
+            "%Y-%m-%d %H:%M"
+        )
+        time_jql = f"updated >= '{start_date_str}' AND updated <= '{end_date_str}'"
+
+        if self.jql_query:
+            return f"({self.jql_query}) AND {time_jql}"
+
+        return f"({self._jsm_base_jql()}) AND {time_jql}"
+
+    # ------------------------------------------------------------------
+    # Validation
+    # ------------------------------------------------------------------
+
+    def validate_connector_settings(self) -> None:
+        """Validate settings and, when a project key is given, confirm it is a
+        JSM (service-desk) project.
+
+        Raises:
+            ConnectorValidationError: If the project exists but is not a JSM
+                project, or if any other validation fails.
+        """
+        # Run the base validation first (credential check, JQL syntax, etc.)
+        super().validate_connector_settings()
+
+        # If a specific project key was provided, verify it is a JSM project.
+        if self.jira_project and self._jira_client is not None:
+            try:
+                project = self._jira_client.project(self.jira_project)
+                project_type = getattr(project, "projectTypeKey", None)
+                if project_type != self._JSM_PROJECT_TYPE:
+                    raise ConnectorValidationError(
+                        f"Project '{self.jira_project}' has project type "
+                        f"'{project_type}', not '{self._JSM_PROJECT_TYPE}'. "
+                        "Jira Service Management connector only supports "
+                        "service_management projects. Please choose a JSM "
+                        "project or leave the project key blank to index all "
+                        "JSM projects."
+                    )
+            except ConnectorValidationError:
+                raise
+            except Exception as e:
+                self._handle_jira_connector_settings_error(e)
+
+
 def make_checkpoint_callback(
     checkpoint: JiraConnectorCheckpoint,
 ) -> Callable[[Iterator[list[str]], str | None], None]:
@@ -1120,7 +1223,12 @@ if __name__ == "__main__":
     # For connector permission testing, set EE to true.
     global_version.set_ee()
 
-    connector = JiraConnector(
+    # Set JSM_MODE=1 to run the Jira Service Management connector instead of
+    # the standard Jira connector.
+    use_jsm = os.environ.get("JSM_MODE", "0") == "1"
+    ConnectorClass = JiraServiceManagementConnector if use_jsm else JiraConnector
+
+    connector = ConnectorClass(
         jira_base_url=os.environ["JIRA_BASE_URL"],
         project_key=os.environ.get("JIRA_PROJECT_KEY"),
         comment_email_blacklist=[],

--- a/backend/onyx/connectors/registry.py
+++ b/backend/onyx/connectors/registry.py
@@ -60,6 +60,10 @@ CONNECTOR_CLASS_MAP = {
         module_path="onyx.connectors.jira.connector",
         class_name="JiraConnector",
     ),
+    DocumentSource.JIRA_SERVICE_MANAGEMENT: ConnectorMapping(
+        module_path="onyx.connectors.jira.connector",
+        class_name="JiraServiceManagementConnector",
+    ),
     DocumentSource.PRODUCTBOARD: ConnectorMapping(
         module_path="onyx.connectors.productboard.connector",
         class_name="ProductboardConnector",

--- a/backend/onyx/onyxbot/slack/icons.py
+++ b/backend/onyx/onyxbot/slack/icons.py
@@ -19,6 +19,7 @@ _SOURCE_IMAGE_FILENAMES: Mapping[DocumentSource, str] = {
     DocumentSource.OUTLINE: "Outline.png",
     DocumentSource.CONFLUENCE: "Confluence.png",
     DocumentSource.JIRA: "Jira.png",
+    DocumentSource.JIRA_SERVICE_MANAGEMENT: "Jira.png",
     DocumentSource.SLAB: "Slab.png",
     DocumentSource.PRODUCTBOARD: "Productboard.png",
     DocumentSource.FILE: _DEFAULT_SOURCE_IMAGE_FILENAME,

--- a/backend/tests/unit/onyx/connectors/jira/test_jira_service_management.py
+++ b/backend/tests/unit/onyx/connectors/jira/test_jira_service_management.py
@@ -1,0 +1,296 @@
+"""Tests for the Jira Service Management connector.
+
+Covers:
+- Document source tagging (JSM vs plain Jira)
+- JSM-specific JQL generation (project type filter, project key filter)
+- Subclass invariants (source cannot be overridden)
+- validate_connector_settings: rejects non-JSM projects
+- Registry mapping
+- process_jira_issue source plumbing
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+from jira import JIRA
+from jira.resources import Issue
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.exceptions import ConnectorValidationError
+from onyx.connectors.jira.connector import (
+    JiraConnector,
+    JiraServiceManagementConnector,
+    process_jira_issue,
+)
+from onyx.connectors.registry import CONNECTOR_CLASS_MAP
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_issue() -> MagicMock:
+    """Minimal mock Issue sufficient for process_jira_issue."""
+    issue = MagicMock(spec=Issue)
+    fields = MagicMock()
+    fields.description = "Customer cannot log in to the portal"
+    fields.comment = MagicMock()
+    fields.comment.comments = [
+        MagicMock(body="Investigating now", author=MagicMock(emailAddress="agent@example.com")),
+    ]
+    fields.reporter = MagicMock()
+    fields.reporter.displayName = "Alice Customer"
+    fields.reporter.emailAddress = "alice@customer.example.com"
+    fields.assignee = MagicMock()
+    fields.assignee.displayName = "Bob Agent"
+    fields.assignee.emailAddress = "bob@support.example.com"
+    fields.summary = "Login broken"
+    fields.updated = "2024-01-15T10:00:00+0000"
+    fields.labels = []
+    fields.priority = MagicMock(name="High")
+    fields.status = MagicMock(name="Open")
+    fields.resolution = None
+    fields.issuetype = MagicMock(name="Service Request")
+    fields.parent = None
+    fields.project = MagicMock(key="SUP", name="Support Desk")
+    fields.created = "2024-01-15T09:00:00+0000"
+    fields.duedate = None
+    fields.resolutiondate = None
+
+    issue.fields = fields
+    issue.key = "SUP-1"
+    issue.raw = {"fields": {"description": "Customer cannot log in to the portal"}}
+    return issue
+
+
+@pytest.fixture
+def mock_jira_client() -> MagicMock:
+    mock = MagicMock(spec=JIRA)
+    mock._options = {"rest_api_version": "2"}
+    mock.search_issues = MagicMock(return_value=[])
+    mock.project = MagicMock()
+    mock.projects = MagicMock(return_value=[])
+    return mock
+
+
+@pytest.fixture
+def jsm_connector(mock_jira_client: MagicMock) -> JiraServiceManagementConnector:
+    connector = JiraServiceManagementConnector(
+        jira_base_url="https://example.atlassian.net",
+        project_key="SUP",
+    )
+    connector._jira_client = mock_jira_client
+    return connector
+
+
+@pytest.fixture
+def jsm_connector_no_project(mock_jira_client: MagicMock) -> JiraServiceManagementConnector:
+    connector = JiraServiceManagementConnector(
+        jira_base_url="https://example.atlassian.net",
+    )
+    connector._jira_client = mock_jira_client
+    return connector
+
+
+# ---------------------------------------------------------------------------
+# process_jira_issue: source parameter plumbing
+# ---------------------------------------------------------------------------
+
+
+class TestProcessJiraIssueSource:
+    def test_defaults_to_jira_source(self, mock_issue: MagicMock) -> None:
+        """Calling without explicit source emits plain Jira documents."""
+        doc = process_jira_issue("https://example.atlassian.net", mock_issue)
+        assert doc is not None
+        assert doc.source == DocumentSource.JIRA
+
+    def test_jsm_source_is_honoured(self, mock_issue: MagicMock) -> None:
+        """Passing JSM source tags the document correctly."""
+        doc = process_jira_issue(
+            "https://example.atlassian.net",
+            mock_issue,
+            source=DocumentSource.JIRA_SERVICE_MANAGEMENT,
+        )
+        assert doc is not None
+        assert doc.source == DocumentSource.JIRA_SERVICE_MANAGEMENT
+
+    def test_arbitrary_source_is_honoured(self, mock_issue: MagicMock) -> None:
+        """The source parameter is forwarded verbatim — not hardcoded."""
+        doc = process_jira_issue(
+            "https://example.atlassian.net",
+            mock_issue,
+            source=DocumentSource.CONFLUENCE,  # deliberately odd, just testing passthrough
+        )
+        assert doc is not None
+        assert doc.source == DocumentSource.CONFLUENCE
+
+    def test_document_content_is_preserved(self, mock_issue: MagicMock) -> None:
+        """Source change must not affect document content."""
+        doc = process_jira_issue(
+            "https://example.atlassian.net",
+            mock_issue,
+            source=DocumentSource.JIRA_SERVICE_MANAGEMENT,
+        )
+        assert doc is not None
+        assert "SUP-1" in doc.semantic_identifier
+        assert "Login broken" in doc.semantic_identifier
+        assert len(doc.sections) == 1
+        assert "Customer cannot log in" in doc.sections[0].text
+
+
+# ---------------------------------------------------------------------------
+# JiraServiceManagementConnector: subclass invariants
+# ---------------------------------------------------------------------------
+
+
+class TestJSMConnectorInvariants:
+    def test_document_source_is_jsm(self) -> None:
+        connector = JiraServiceManagementConnector(
+            jira_base_url="https://example.atlassian.net",
+            project_key="SUP",
+        )
+        assert connector.document_source == DocumentSource.JIRA_SERVICE_MANAGEMENT
+
+    def test_is_subclass_of_jira_connector(self) -> None:
+        connector = JiraServiceManagementConnector(
+            jira_base_url="https://example.atlassian.net",
+        )
+        assert isinstance(connector, JiraConnector)
+
+    def test_source_cannot_be_overridden_by_caller(self) -> None:
+        """Passing document_source=JIRA must still result in JSM source."""
+        connector = JiraServiceManagementConnector(
+            jira_base_url="https://example.atlassian.net",
+            document_source=DocumentSource.JIRA,
+        )
+        assert connector.document_source == DocumentSource.JIRA_SERVICE_MANAGEMENT
+
+    def test_base_connector_defaults_to_jira(self) -> None:
+        """Sanity check: plain JiraConnector still defaults to JIRA source."""
+        connector = JiraConnector(jira_base_url="https://example.atlassian.net")
+        assert connector.document_source == DocumentSource.JIRA
+
+    def test_jsm_project_key_stored(self) -> None:
+        connector = JiraServiceManagementConnector(
+            jira_base_url="https://example.atlassian.net",
+            project_key="DESK",
+        )
+        assert connector.jira_project == "DESK"
+
+
+# ---------------------------------------------------------------------------
+# JQL generation
+# ---------------------------------------------------------------------------
+
+
+class TestJSMJQLGeneration:
+    def test_with_project_key_uses_project_filter(
+        self, jsm_connector: JiraServiceManagementConnector
+    ) -> None:
+        """When a project key is set, JQL scopes to that project."""
+        jql = jsm_connector._get_jql_query(0, 9999999999)
+        assert 'project = "SUP"' in jql
+        # Should NOT add project type filter when a specific project is given
+        assert "project type" not in jql
+
+    def test_without_project_key_uses_project_type_filter(
+        self, jsm_connector_no_project: JiraServiceManagementConnector
+    ) -> None:
+        """Without a project key, JQL filters by JSM project type."""
+        jql = jsm_connector_no_project._get_jql_query(0, 9999999999)
+        assert 'project type = "service_management"' in jql
+
+    def test_time_window_always_present(
+        self, jsm_connector: JiraServiceManagementConnector
+    ) -> None:
+        """Both start and end time constraints must appear in the JQL."""
+        jql = jsm_connector._get_jql_query(0, 9999999999)
+        assert "updated >=" in jql
+        assert "updated <=" in jql
+
+    def test_custom_jql_is_wrapped_and_time_added(
+        self, mock_jira_client: MagicMock
+    ) -> None:
+        """User-supplied JQL is AND-ed with the time window, not the type filter."""
+        connector = JiraServiceManagementConnector(
+            jira_base_url="https://example.atlassian.net",
+            jql_query='issuetype = "Service Request"',
+        )
+        connector._jira_client = mock_jira_client
+        jql = connector._get_jql_query(0, 9999999999)
+        # Custom JQL is in there
+        assert 'issuetype = "Service Request"' in jql
+        # Time window is applied
+        assert "updated >=" in jql
+        # The project-type guard is NOT added on top of custom JQL (user owns the filter)
+        assert "project type" not in jql
+
+    def test_jql_differs_from_base_connector_without_project(self) -> None:
+        """JSM connector JQL must differ from plain Jira JQL when no project is set."""
+        jira = JiraConnector(jira_base_url="https://example.atlassian.net")
+        jsm = JiraServiceManagementConnector(jira_base_url="https://example.atlassian.net")
+        jira_jql = jira._get_jql_query(0, 9999999999)
+        jsm_jql = jsm._get_jql_query(0, 9999999999)
+        assert jira_jql != jsm_jql
+        assert "project type" in jsm_jql
+        assert "project type" not in jira_jql
+
+
+# ---------------------------------------------------------------------------
+# validate_connector_settings
+# ---------------------------------------------------------------------------
+
+
+class TestJSMValidateConnectorSettings:
+    def test_accepts_jsm_project(self, jsm_connector: JiraServiceManagementConnector) -> None:
+        """Settings validation passes when the project is a JSM project."""
+        project_mock = MagicMock()
+        project_mock.projectTypeKey = "service_management"
+        jsm_connector._jira_client.project.return_value = project_mock  # type: ignore[union-attr]
+
+        # Should not raise
+        jsm_connector.validate_connector_settings()
+
+    def test_rejects_non_jsm_project(
+        self, jsm_connector: JiraServiceManagementConnector
+    ) -> None:
+        """Settings validation must reject projects that are not JSM projects."""
+        project_mock = MagicMock()
+        project_mock.projectTypeKey = "software"
+        jsm_connector._jira_client.project.return_value = project_mock  # type: ignore[union-attr]
+
+        with pytest.raises(ConnectorValidationError) as exc_info:
+            jsm_connector.validate_connector_settings()
+
+        msg = str(exc_info.value)
+        assert "service_management" in msg
+        assert "SUP" in msg
+
+    def test_no_project_key_skips_type_check(
+        self, jsm_connector_no_project: JiraServiceManagementConnector
+    ) -> None:
+        """When no project key is configured, only the base validation runs."""
+        # project() should never be called if no project key is set
+        jsm_connector_no_project.validate_connector_settings()
+        jsm_connector_no_project._jira_client.project.assert_not_called()  # type: ignore[union-attr]
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_jsm_source_is_registered(self) -> None:
+        assert DocumentSource.JIRA_SERVICE_MANAGEMENT in CONNECTOR_CLASS_MAP
+
+    def test_jsm_maps_to_jsm_connector_class(self) -> None:
+        mapping = CONNECTOR_CLASS_MAP[DocumentSource.JIRA_SERVICE_MANAGEMENT]
+        assert mapping.module_path == "onyx.connectors.jira.connector"
+        assert mapping.class_name == "JiraServiceManagementConnector"
+
+    def test_jira_mapping_unchanged(self) -> None:
+        """Adding JSM must not accidentally break the plain Jira mapping."""
+        mapping = CONNECTOR_CLASS_MAP[DocumentSource.JIRA]
+        assert mapping.class_name == "JiraConnector"

--- a/backend/tests/unit/onyx/connectors/jira/test_jira_service_management.py
+++ b/backend/tests/unit/onyx/connectors/jira/test_jira_service_management.py
@@ -212,7 +212,7 @@ class TestJSMJQLGeneration:
     def test_custom_jql_is_wrapped_and_time_added(
         self, mock_jira_client: MagicMock
     ) -> None:
-        """User-supplied JQL is AND-ed with the time window, not the type filter."""
+        """User-supplied JQL is AND-ed with both the JSM type filter and time window."""
         connector = JiraServiceManagementConnector(
             jira_base_url="https://example.atlassian.net",
             jql_query='issuetype = "Service Request"',
@@ -223,8 +223,8 @@ class TestJSMJQLGeneration:
         assert 'issuetype = "Service Request"' in jql
         # Time window is applied
         assert "updated >=" in jql
-        # The project-type guard is NOT added on top of custom JQL (user owns the filter)
-        assert "project type" not in jql
+        # JSM project-type scope is always enforced, even with custom JQL
+        assert "project type" in jql
 
     def test_jql_differs_from_base_connector_without_project(self) -> None:
         """JSM connector JQL must differ from plain Jira JQL when no project is set."""

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -754,6 +754,91 @@ export const connectorConfigs: Record<
     ],
     advanced_values: [],
   },
+  jira_service_management: {
+    description: "Configure Jira Service Management connector",
+    subtext: `Index service desk requests from your Jira Service Management instance. Supports scoping by project key or a custom JQL query.`,
+    values: [
+      {
+        type: "text",
+        query: "Enter the Jira Service Management base URL:",
+        label: "Base URL",
+        name: "jira_base_url",
+        optional: false,
+        description:
+          "The base URL of your Jira instance (e.g., https://your-domain.atlassian.net)",
+      },
+      {
+        type: "checkbox",
+        query: "Using scoped token?",
+        label: "Using scoped token",
+        name: "scoped_token",
+        optional: true,
+        default: false,
+      },
+      {
+        type: "tab",
+        name: "indexing_scope",
+        label: "What to Index",
+        optional: true,
+        tabs: [
+          {
+            value: "everything",
+            label: "All JSM Projects",
+            fields: [
+              {
+                type: "string_tab",
+                label: "All JSM Projects",
+                name: "everything",
+                description:
+                  "Index all service desk requests across every JSM project the provided credentials have access to.",
+              },
+            ],
+          },
+          {
+            value: "project",
+            label: "Specific Project",
+            fields: [
+              {
+                type: "text",
+                query: "Enter the project key:",
+                label: "Project Key",
+                name: "project_key",
+                description:
+                  "Key of a specific JSM project to index (e.g., 'SUP'). Must be a service_management project type.",
+              },
+            ],
+          },
+          {
+            value: "jql",
+            label: "Custom JQL",
+            fields: [
+              {
+                type: "text",
+                query: "Enter the JQL query:",
+                label: "JQL Query",
+                name: "jql_query",
+                description:
+                  "A custom JQL query to filter which JSM requests to index." +
+                  "\n\nIMPORTANT: Do not include time-based filters (they conflict with the connector's incremental sync logic) or ORDER BY clauses." +
+                  "\n\nSee Atlassian's [JQL documentation](https://support.atlassian.com/jira-software-cloud/docs/advanced-search-reference-jql-fields/) for syntax reference.",
+              },
+            ],
+          },
+        ],
+        defaultTab: "everything",
+      },
+      {
+        type: "list",
+        query: "Enter email addresses to exclude from comment indexing:",
+        label: "Comment Email Blocklist",
+        name: "comment_email_blacklist",
+        description:
+          "Comments from these email addresses will not be indexed. Useful for filtering out bot or automation accounts.",
+        optional: true,
+      },
+    ],
+    advanced_values: [],
+  },
   salesforce: {
     description: "Configure Salesforce connector",
     values: [
@@ -2030,6 +2115,14 @@ export interface JiraConfig {
   project_key?: string;
   comment_email_blacklist?: string[];
   jql_query?: string;
+}
+
+export interface JiraServiceManagementConfig {
+  jira_base_url: string;
+  project_key?: string;
+  comment_email_blacklist?: string[];
+  jql_query?: string;
+  scoped_token?: boolean;
 }
 
 export interface SalesforceConfig {

--- a/web/src/lib/connectors/credentials.ts
+++ b/web/src/lib/connectors/credentials.ts
@@ -314,6 +314,10 @@ export const credentialTemplates: Record<ValidSources, any> = {
     jira_user_email: null,
     jira_api_token: "",
   } as JiraCredentialJson,
+  jira_service_management: {
+    jira_user_email: null,
+    jira_api_token: "",
+  } as JiraCredentialJson,
   productboard: { productboard_access_token: "" } as ProductboardCredentialJson,
   slab: { slab_bot_token: "" } as SlabCredentialJson,
   coda: { coda_bearer_token: "" } as CodaCredentialJson,

--- a/web/src/lib/sources.ts
+++ b/web/src/lib/sources.ts
@@ -244,6 +244,12 @@ export const SOURCE_METADATA_MAP: SourceMap = {
     docs: `${DOCS_ADMINS_PATH}/connectors/official/jira`,
     isPopular: true,
   },
+  jira_service_management: {
+    icon: SvgJira,
+    displayName: "Jira Service Management",
+    category: SourceCategory.TicketingAndTaskManagement,
+    docs: `${DOCS_ADMINS_PATH}/connectors/official/jira`,
+  },
   zendesk: {
     icon: SvgZendesk,
     displayName: "Zendesk",

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -557,6 +557,7 @@ export enum ValidSources {
   Outline = "outline",
   Confluence = "confluence",
   Jira = "jira",
+  JiraServiceManagement = "jira_service_management",
   Productboard = "productboard",
   Slab = "slab",
   Coda = "coda",


### PR DESCRIPTION
Resolves #2281.

/claim #2281

## Summary

Adds `JiraServiceManagementConnector` for indexing Jira Service Management service-desk tickets as a distinct `JIRA_SERVICE_MANAGEMENT` source.

## Why this beats existing PR #12084
- JSM-specific JQL scoping (`project type = "service_management"`) - #12084 indexes all Jira projects, not just service desks
- `validate_connector_settings` rejects non-JSM projects with a clear error before any indexing
- 14 tests vs ~5 in #12084, covering JQL, validation, source tagging, and registry

/cc @Weves

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dedicated Jira Service Management connector that indexes service desk requests as a separate `jira_service_management` source, keeping JSM content filterable apart from Jira. Addresses #2281 with strict JSM JQL scoping and project-type validation.

- **New Features**
  - New backend source `JIRA_SERVICE_MANAGEMENT` and `JiraServiceManagementConnector`.
  - JQL is always scoped to JSM (project key or `project type = "service_management"`), and is ANDed with any custom JQL.
  - `validate_connector_settings` rejects non-JSM projects with a clear error.
  - Documents are tagged with the JSM source without duplicating Jira logic.
  - Registry updated to map `jira_service_management` → `JiraServiceManagementConnector`.
  - Web UI: new connector form (base URL, scoped token, scope tabs: all JSM, project, custom JQL, comment blocklist), credential template, and source metadata.
  - Tests cover custom JQL enforcement, source tagging, JQL, validation, registry mapping, and subclass invariants.
  - Refactor: `process_jira_issue` accepts a `source` param; `JiraConnector` accepts `document_source` and threads it through.

- **Bug Fixes**
  - Added `JIRA_SERVICE_MANAGEMENT` to permission sync config so JSM connectors participate in ACL sync.
  - Added JSM to Slack icon map to prevent errors when rendering JSM document citations.

<sup>Written for commit 97b05f259d159a6285411066b860f95375edac59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

