### PR TITLE
feat(perms): add is_manager + is_group_manager columns and backfill

### DIFF
--- a/backend/alembic/versions/c71a18ea7d07_add_is_manager_and_is_group_manager.py
+++ b/backend/alembic/versions/c71a18ea7d07_add_is_manager_and_is_group_manager.py
@@ -1,0 +1,92 @@
+"""add is_manager and is_group_manager
+
+Per-(user, group) ``is_manager`` edge + cached ``user.is_group_manager`` boolean
+for the group-manager feature. Additive, ``false`` server default.
+
+Role-gated backfill preserves the curator signal before ``role`` / ``is_curator``
+are dropped later: ``CURATOR`` -> their curated groups; ``GLOBAL_CURATOR`` -> every
+membership. Must run before any release drops ``role`` / ``is_curator``.
+
+Revision ID: c71a18ea7d07
+Revises: c8e316473aaa
+Create Date: 2026-06-29 14:15:32.889597
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "c71a18ea7d07"
+down_revision = "c8e316473aaa"
+branch_labels = None
+depends_on = None
+
+# role compares against the enum NAME (Enum(native_enum=False)) — uppercase.
+user_table = sa.table(
+    "user",
+    sa.column("id", sa.Uuid),
+    sa.column("role", sa.String),
+    sa.column("is_group_manager", sa.Boolean),
+)
+user_user_group = sa.table(
+    "user__user_group",
+    sa.column("user_id", sa.Uuid),
+    sa.column("is_curator", sa.Boolean),
+    sa.column("is_manager", sa.Boolean),
+)
+
+
+def upgrade() -> None:
+    op.add_column(
+        "user__user_group",
+        sa.Column(
+            "is_manager",
+            sa.Boolean(),
+            server_default=sa.text("false"),
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        "user",
+        sa.Column(
+            "is_group_manager",
+            sa.Boolean(),
+            server_default=sa.text("false"),
+            nullable=False,
+        ),
+    )
+
+    op.execute(
+        sa.update(user_user_group)
+        .where(
+            user_user_group.c.user_id == user_table.c.id,
+            user_table.c.role == "CURATOR",
+            user_user_group.c.is_curator == sa.true(),
+        )
+        .values(is_manager=sa.true())
+    )
+    # GLOBAL_CURATOR has no is_curator rows — every membership becomes managed.
+    op.execute(
+        sa.update(user_user_group)
+        .where(
+            user_user_group.c.user_id == user_table.c.id,
+            user_table.c.role == "GLOBAL_CURATOR",
+        )
+        .values(is_manager=sa.true())
+    )
+    managed_user_ids = (
+        sa.select(user_user_group.c.user_id)
+        .where(user_user_group.c.is_manager == sa.true())
+        .distinct()
+    )
+    op.execute(
+        sa.update(user_table)
+        .where(user_table.c.id.in_(managed_user_ids))
+        .values(is_group_manager=sa.true())
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("user", "is_group_manager")
+    op.drop_column("user__user_group", "is_manager")

--- a/backend/alembic/versions/c71a18ea7d07_add_is_manager_and_is_group_manager.py
+++ b/backend/alembic/versions/c71a18ea7d07_add_is_manager_and_is_group_manager.py
@@ -16,7 +16,6 @@ Create Date: 2026-06-29 14:15:32.889597
 from alembic import op
 import sqlalchemy as sa
 
-# revision identifiers, used by Alembic.
 revision = "c71a18ea7d07"
 down_revision = "c8e316473aaa"
 branch_labels = None

--- a/backend/alembic/versions/c8e316473aaa_make_user_role_nullable.py
+++ b/backend/alembic/versions/c8e316473aaa_make_user_role_nullable.py
@@ -9,7 +9,7 @@ safety and will be dropped in a follow-up migration once the new model
 has been in production for a release cycle.
 
 Revision ID: c8e316473aaa
-Revises: 14162713706c
+Revises: 8f2c4a1d9e3b
 Create Date: 2026-04-14 14:57:29.520645
 
 """
@@ -22,7 +22,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "c8e316473aaa"
-down_revision = "14162713706c"
+down_revision = "8f2c4a1d9e3b"
 branch_labels: str | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/alembic/versions/c8e316473aaa_make_user_role_nullable.py
+++ b/backend/alembic/versions/c8e316473aaa_make_user_role_nullable.py
@@ -20,7 +20,6 @@ import sqlalchemy as sa
 from alembic import op
 
 
-# revision identifiers, used by Alembic.
 revision = "c8e316473aaa"
 down_revision = "8f2c4a1d9e3b"
 branch_labels: str | None = None
@@ -37,9 +36,8 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    # Backfill any NULLs written while the column was optional before we
-    # restore the NOT NULL constraint, otherwise the downgrade would fail
-    # against rows inserted after the upgrade.
+    # Backfill NULLs written while the column was optional; otherwise
+    # restoring NOT NULL fails against rows inserted after the upgrade.
     op.execute("UPDATE \"user\" SET role = 'BASIC' WHERE role IS NULL")
     op.alter_column(
         "user",

--- a/backend/ee/onyx/db/analytics.py
+++ b/backend/ee/onyx/db/analytics.py
@@ -11,7 +11,7 @@ from sqlalchemy import or_
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from onyx.auth.permissions import has_permission
+from onyx.auth.permissions import has_global_permission
 from onyx.configs.constants import MessageType
 from onyx.db.enums import Permission
 from onyx.db.models import ChatMessage
@@ -339,7 +339,7 @@ def fetch_assistant_unique_users_total(
 def user_can_view_assistant_stats(
     db_session: Session, user: User, assistant_id: int
 ) -> bool:
-    if has_permission(user, Permission.FULL_ADMIN_PANEL_ACCESS):
+    if has_global_permission(user, Permission.FULL_ADMIN_PANEL_ACCESS):
         return True
 
     # Check if the user created the persona

--- a/backend/ee/onyx/db/persona.py
+++ b/backend/ee/onyx/db/persona.py
@@ -2,12 +2,20 @@ from uuid import UUID
 
 from sqlalchemy.orm import Session
 
+from onyx.auth.permissions import has_permission
+from onyx.auth.scoped_permissions import assert_within_scope
+from onyx.db.enums import Permission
+from onyx.db.enums import PermissionAuthority
 from onyx.db.enums import PersonaSharePermission
 from onyx.db.models import Persona
 from onyx.db.models import Persona__UserGroup
+from onyx.db.models import User
 from onyx.db.persona import apply_persona_user_share_diff
+from onyx.db.persona import can_delete_persona
 from onyx.db.persona import mark_persona_user_files_for_sync
 from onyx.db.persona import resolve_desired_user_shares
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 
 
 def _resolve_desired_group_shares(
@@ -39,8 +47,9 @@ def _apply_persona_group_share_diff(
     desired_shares: dict[int, PersonaSharePermission],
     db_session: Session,
 ) -> None:
-    """Reconcile persona__user_group rows to ``desired_shares`` — delete
-    missing, update changed levels in place, insert new rows."""
+    """Reconcile persona__user_group rows to ``desired_shares`` — delete missing, update
+    changed levels in place, insert new rows. Callers must hold the agent's row lock: this
+    re-reads the rows the scope gate ran on."""
     existing_rows = (
         db_session.query(Persona__UserGroup)
         .filter(Persona__UserGroup.persona_id == persona_id)
@@ -65,10 +74,59 @@ def _apply_persona_group_share_diff(
             )
 
 
+def _assert_group_share_within_scope(
+    acting_user: User,
+    persona_id: int,
+    desired_group_shares: dict[int, PersonaSharePermission],
+    db_session: Session,
+    original_is_public: bool,
+) -> None:
+    """GATE 2: *changing* an agent's group shares is a MANAGE_AGENTS action. Global
+    holders bypass; a scoped manager may only add/remove groups they manage on a PRIVATE
+    agent; anyone else may leave the shares alone but not alter them. Shares are re-read
+    in-txn, never the caller's, so a reassignment can't escape scope — and under the
+    caller's row lock, so the write reconciles this same snapshot. Both the pre-call and
+    current is_public must be private — sharing a public agent in would capture it."""
+    current_shares = {
+        row.user_group_id: row.permission
+        for row in db_session.query(Persona__UserGroup)
+        .filter(Persona__UserGroup.persona_id == persona_id)
+        .all()
+    }
+    # No group either side: a personal agent, nothing to authorize. Keeps groups=[]
+    # creates open to an ADD_AGENTS-only user.
+    if not current_shares and not desired_group_shares:
+        return
+    persona = db_session.query(Persona).filter(Persona.id == persona_id).first()
+    if persona is None:
+        raise OnyxError(
+            OnyxErrorCode.PERSONA_NOT_FOUND, f"Persona {persona_id} does not exist"
+        )
+    # Unchanged shares aren't a mutation either — the editor round-trips current groups on
+    # every save, so otherwise a plain owner couldn't edit an agent someone else
+    # group-shared. Levels count, not just ids. Exempt when there's no scoped authority to
+    # abuse, or when the actor owns the agent — publishing is can_delete_persona's call.
+    if current_shares == desired_group_shares and (
+        has_permission(acting_user, Permission.MANAGE_AGENTS)
+        is not PermissionAuthority.SCOPED
+        or can_delete_persona(acting_user, persona, db_session)
+    ):
+        return
+    assert_within_scope(
+        acting_user,
+        db_session,
+        permission=Permission.MANAGE_AGENTS,
+        current_group_ids=list(current_shares),
+        requested_group_ids=list(desired_group_shares),
+        is_non_public=not original_is_public and not persona.is_public,
+    )
+
+
 def update_persona_access(
     persona_id: int,
     creator_user_id: UUID | None,
     db_session: Session,
+    acting_user: User,
     is_public: bool | None = None,
     user_ids: list[UUID] | None = None,
     group_ids: list[int] | None = None,
@@ -81,9 +139,22 @@ def update_persona_access(
 
     NOTE: Callers are responsible for committing."""
     needs_sync = False
+    # Lock the agent so the gate and _apply_persona_group_share_diff can't be split by a
+    # concurrent save; populate_existing refreshes the caller's already-loaded row, which
+    # would otherwise serve pre-lock is_public out of the identity map.
+    # Read is_public before it's overwritten below, so the gate anchors on the ORIGINAL
+    # state: a public->private convert plus a group-share in one call must not slip through.
+    persona = (
+        db_session.query(Persona)
+        .populate_existing()
+        .filter(Persona.id == persona_id)
+        .with_for_update()
+        .first()
+    )
+    original_is_public = persona.is_public if persona is not None else False
+
     if is_public is not None or public_permission is not None:
         needs_sync = True
-        persona = db_session.query(Persona).filter(Persona.id == persona_id).first()
         if persona:
             if is_public is not None:
                 persona.is_public = is_public
@@ -106,6 +177,13 @@ def update_persona_access(
     )
     if desired_group_shares is not None:
         needs_sync = True
+        _assert_group_share_within_scope(
+            acting_user,
+            persona_id,
+            desired_group_shares,
+            db_session,
+            original_is_public,
+        )
         _apply_persona_group_share_diff(persona_id, desired_group_shares, db_session)
 
     # When sharing changes, user file ACLs need to be updated in the vector DB

--- a/backend/ee/onyx/db/user_group.py
+++ b/backend/ee/onyx/db/user_group.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from collections.abc import Sequence
 from operator import and_
 from uuid import UUID
@@ -12,12 +13,17 @@ from sqlalchemy.orm import Session
 
 from ee.onyx.server.user_group.models import UserGroupCreate
 from ee.onyx.server.user_group.models import UserGroupUpdate
+from onyx.auth.permissions import has_permission
+from onyx.auth.scoped_permissions import assert_manages_group
+from onyx.auth.scoped_permissions import assert_within_scope
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
+from onyx.db.connector_credential_pair import get_cc_pair_groups_for_ids
 from onyx.db.connector_credential_pair import get_connector_credential_pair_from_id
 from onyx.db.enums import AccessType
 from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.enums import GrantSource
 from onyx.db.enums import Permission
+from onyx.db.enums import PermissionAuthority
 from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import Credential
 from onyx.db.models import Credential__UserGroup
@@ -38,6 +44,8 @@ from onyx.db.models import UserGroup__ConnectorCredentialPair
 from onyx.db.permissions import recompute_permissions_for_group__no_commit
 from onyx.db.permissions import recompute_user_permissions__no_commit
 from onyx.db.users import fetch_user_by_id
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -190,6 +198,7 @@ def fetch_user_groups(
     only_up_to_date: bool = True,
     eager_load_for_snapshot: bool = False,
     include_default: bool = True,
+    restrict_to_group_ids: set[int] | None = None,
 ) -> Sequence[UserGroup]:
     """
     Fetches user groups from the database.
@@ -205,6 +214,9 @@ def fetch_user_groups(
         eager_load_for_snapshot: If True, adds eager loading for all relationships
             needed by UserGroup.from_model snapshot creation.
         include_default: If False, excludes system default groups (is_default=True).
+        restrict_to_group_ids: If provided, limits the result to these group ids — the
+            scoped-manager variant passes the groups they manage. An empty set returns
+            nothing (fail-closed); ``None`` returns all groups (admin/global).
 
     Returns:
         Sequence[UserGroup]: A sequence of `UserGroup` objects matching the query criteria.
@@ -214,6 +226,8 @@ def fetch_user_groups(
         stmt = stmt.where(UserGroup.is_up_to_date == True)  # noqa: E712
     if not include_default:
         stmt = stmt.where(UserGroup.is_default == False)  # noqa: E712
+    if restrict_to_group_ids is not None:
+        stmt = stmt.where(UserGroup.id.in_(restrict_to_group_ids))
     if eager_load_for_snapshot:
         stmt = _add_user_group_snapshot_eager_loads(stmt)
     return db_session.scalars(stmt).unique().all()
@@ -459,6 +473,22 @@ def _mark_user_group__cc_pair_relationships_outdated__no_commit(
         user_group__cc_pair_relationship.is_current = False
 
 
+def _current_cc_pair_ids(db_user_group: UserGroup) -> list[int]:
+    """The cc_pairs currently attached to the group — is_current junction rows only.
+
+    A removed cc_pair keeps a stale ``is_current=False`` row until the Vespa sync
+    deletes it, and the plain ``cc_pairs`` relationship has no is_current filter, so
+    it would still surface the removed pair. Reading it as "current" lets a removed
+    (possibly public / out-of-scope) pair be re-attached without re-clearing the
+    scope gate, so always derive the current set from the live relationships.
+    """
+    return [
+        relationship.cc_pair_id
+        for relationship in db_user_group.cc_pair_relationships
+        if relationship.is_current
+    ]
+
+
 def add_users_to_user_group(
     db_session: Session,
     user: User,
@@ -468,6 +498,8 @@ def add_users_to_user_group(
     db_user_group = fetch_user_group(db_session=db_session, user_group_id=user_group_id)
     if db_user_group is None:
         raise ValueError(f"UserGroup with id '{user_group_id}' not found")
+
+    assert_manages_group(user, db_session, group_id=user_group_id)
 
     missing_users = [
         user_id for user_id in user_ids if fetch_user_by_id(db_session, user_id) is None
@@ -490,7 +522,7 @@ def add_users_to_user_group(
 
     user_group_update = UserGroupUpdate(
         user_ids=current_user_ids + new_user_ids,
-        cc_pair_ids=[cc_pair.id for cc_pair in db_user_group.cc_pairs],
+        cc_pair_ids=_current_cc_pair_ids(db_user_group),
     )
 
     return update_user_group(
@@ -501,9 +533,61 @@ def add_users_to_user_group(
     )
 
 
+def _assert_group_update_within_scope(
+    db_session: Session,
+    user: User,
+    user_group_id: int,
+    added_cc_pair_ids: set[int],
+) -> None:
+    """GATE 2 for a scoped manager editing a group: the group must be one they
+    manage, and every newly-attached cc_pair must be a private one within their
+    managed scope — otherwise the junction rewrite could attach a public or
+    out-of-scope connector to the group, granting its members access. Admins /
+    global holders bypass both checks."""
+    assert_manages_group(user, db_session, group_id=user_group_id)
+
+    # The cc_pair re-attach vector only applies to scoped managers; a global
+    # MANAGE_USER_GROUPS holder keeps today's unrestricted attach behavior.
+    if (
+        has_permission(user, Permission.MANAGE_USER_GROUPS)
+        is not PermissionAuthority.SCOPED
+    ):
+        return
+
+    current_groups_by_cc_pair: dict[int, list[int]] = defaultdict(list)
+    for row in get_cc_pair_groups_for_ids(db_session, list(added_cc_pair_ids)):
+        if row.is_current and row.cc_pair_id is not None:
+            current_groups_by_cc_pair[row.cc_pair_id].append(row.user_group_id)
+
+    cc_pairs_by_id = {
+        cc_pair.id: cc_pair
+        for cc_pair in db_session.scalars(
+            select(ConnectorCredentialPair).where(
+                ConnectorCredentialPair.id.in_(added_cc_pair_ids)
+            )
+        )
+    }
+
+    for cc_pair_id in added_cc_pair_ids:
+        cc_pair = cc_pairs_by_id.get(cc_pair_id)
+        if cc_pair is None:
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                f"Connector credential pair '{cc_pair_id}' not found.",
+            )
+        assert_within_scope(
+            user,
+            db_session,
+            permission=Permission.MANAGE_CONNECTORS,
+            current_group_ids=current_groups_by_cc_pair[cc_pair_id],
+            requested_group_ids=[user_group_id],
+            is_non_public=cc_pair.access_type != AccessType.PUBLIC,
+        )
+
+
 def update_user_group(
     db_session: Session,
-    user: User,  # noqa: ARG001
+    user: User,
     user_group_id: int,
     user_group_update: UserGroupUpdate,
 ) -> UserGroup:
@@ -517,6 +601,15 @@ def update_user_group(
         raise ValueError(f"UserGroup with id '{user_group_id}' not found")
 
     _check_user_group_is_modifiable(db_user_group)
+
+    current_cc_pair_ids = set(_current_cc_pair_ids(db_user_group))
+    requested_cc_pair_ids = set(user_group_update.cc_pair_ids)
+    _assert_group_update_within_scope(
+        db_session,
+        user,
+        user_group_id,
+        added_cc_pair_ids=requested_cc_pair_ids - current_cc_pair_ids,
+    )
 
     current_user_ids = set([user.id for user in db_user_group.users])
     updated_user_ids = set(user_group_update.user_ids)
@@ -548,9 +641,7 @@ def update_user_group(
             user_ids=added_user_ids,
         )
 
-    cc_pairs_updated = set([cc_pair.id for cc_pair in db_user_group.cc_pairs]) != set(
-        user_group_update.cc_pair_ids
-    )
+    cc_pairs_updated = current_cc_pair_ids != requested_cc_pair_ids
     if cc_pairs_updated:
         _mark_user_group__cc_pair_relationships_outdated__no_commit(
             db_session=db_session, user_group_id=user_group_id
@@ -573,6 +664,39 @@ def update_user_group(
 
     db_session.commit()
     return db_user_group
+
+
+def _set_group_manager__no_commit(
+    db_session: Session, *, user_id: UUID, group_id: int, is_manager: bool
+) -> None:
+    edge = db_session.scalar(
+        select(User__UserGroup).where(
+            User__UserGroup.user_id == user_id,
+            User__UserGroup.user_group_id == group_id,
+        )
+    )
+    if edge is None:
+        raise ValueError(f"User '{user_id}' is not a member of group '{group_id}'")
+    edge.is_manager = is_manager
+    # Refresh the affected user's cached is_group_manager flag; a pure manager flip
+    # (no membership change) otherwise leaves the route-gate flag stale.
+    recompute_user_permissions__no_commit([user_id], db_session)
+
+
+def make_group_manager(db_session: Session, user_id: UUID, group_id: int) -> None:
+    """Flip is_manager=true on the (user, group) edge. The row must already exist —
+    a manager is always a member — else ValueError. Idempotent. Does NOT commit."""
+    _set_group_manager__no_commit(
+        db_session, user_id=user_id, group_id=group_id, is_manager=True
+    )
+
+
+def revoke_group_manager(db_session: Session, user_id: UUID, group_id: int) -> None:
+    """Flip is_manager=false on the (user, group) edge. The row must exist else
+    ValueError. Idempotent. Does NOT commit."""
+    _set_group_manager__no_commit(
+        db_session, user_id=user_id, group_id=group_id, is_manager=False
+    )
 
 
 def rename_user_group(

--- a/backend/ee/onyx/server/documents/cc_pair.py
+++ b/backend/ee/onyx/server/documents/cc_pair.py
@@ -54,7 +54,9 @@ def get_cc_pair_latest_sync(
 @router.post("/admin/cc-pair/{cc_pair_id}/sync-permissions")
 def sync_cc_pair(
     cc_pair_id: int,
-    user: User = Depends(require_permission(Permission.MANAGE_CONNECTORS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_CONNECTORS, allow_scope=True)
+    ),
     db_session: Session = Depends(get_session),
 ) -> StatusResponse[None]:
     """Triggers permissions sync on a particular cc_pair immediately"""
@@ -64,7 +66,7 @@ def sync_cc_pair(
         cc_pair_id=cc_pair_id,
         db_session=db_session,
         user=user,
-        get_editable=False,
+        get_editable=True,
     )
     if not cc_pair:
         raise OnyxError(
@@ -129,7 +131,9 @@ def get_cc_pair_latest_group_sync(
 @router.post("/admin/cc-pair/{cc_pair_id}/sync-groups")
 def sync_cc_pair_groups(
     cc_pair_id: int,
-    user: User = Depends(require_permission(Permission.MANAGE_CONNECTORS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_CONNECTORS, allow_scope=True)
+    ),
     db_session: Session = Depends(get_session),
 ) -> StatusResponse[None]:
     """Triggers group sync on a particular cc_pair immediately"""
@@ -139,7 +143,7 @@ def sync_cc_pair_groups(
         cc_pair_id=cc_pair_id,
         db_session=db_session,
         user=user,
-        get_editable=False,
+        get_editable=True,
     )
     if not cc_pair:
         raise OnyxError(

--- a/backend/ee/onyx/server/token_rate_limits/api.py
+++ b/backend/ee/onyx/server/token_rate_limits/api.py
@@ -8,12 +8,20 @@ from ee.onyx.db.token_limit import fetch_all_user_group_token_rate_limits_by_gro
 from ee.onyx.db.token_limit import fetch_user_group_token_rate_limits_for_group
 from ee.onyx.db.token_limit import insert_user_group_token_rate_limit
 from onyx.auth.permissions import require_permission
+from onyx.auth.scoped_permissions import assert_manages_group
+from onyx.auth.scoped_permissions import assert_within_scope
 from onyx.configs.constants import PUBLIC_API_TAGS
+from onyx.configs.constants import TokenRateLimitScope
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
 from onyx.db.models import User
+from onyx.db.token_limit import delete_token_rate_limit
 from onyx.db.token_limit import fetch_all_user_token_rate_limits
+from onyx.db.token_limit import get_token_rate_limit_scope_and_group_ids
 from onyx.db.token_limit import insert_user_token_rate_limit
+from onyx.db.token_limit import update_token_rate_limit
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.server.query_and_chat.token_limit import any_rate_limit_exists
 from onyx.server.token_rate_limits.models import TokenRateLimitArgs
 from onyx.server.token_rate_limits.models import TokenRateLimitDisplay
@@ -47,9 +55,14 @@ def get_all_group_token_limit_settings(
 @router.get("/user-group/{group_id}")
 def get_group_token_limit_settings(
     group_id: int,
-    _: User = Depends(require_permission(Permission.MANAGE_USER_GROUPS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_USER_GROUPS, allow_scope=True)
+    ),
     db_session: Session = Depends(get_session),
 ) -> list[TokenRateLimitDisplay]:
+    # GATE 2 (read): a scoped manager may only read limits for a group they manage
+    # (global holders bypass). Single-group path param, so assert_manages_group, not a clause.
+    assert_manages_group(user, db_session, group_id=group_id)
     return [
         TokenRateLimitDisplay.from_db(token_rate_limit)
         for token_rate_limit in fetch_user_group_token_rate_limits_for_group(
@@ -63,9 +76,21 @@ def get_group_token_limit_settings(
 def create_group_token_limit_settings(
     group_id: int,
     token_limit_settings: TokenRateLimitArgs,
-    _: User = Depends(require_permission(Permission.MANAGE_USER_GROUPS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_USER_GROUPS, allow_scope=True)
+    ),
     db_session: Session = Depends(get_session),
 ) -> TokenRateLimitDisplay:
+    # GATE 2: a scoped manager may only set a token limit on a group they manage
+    # (admins bypass). Token limits have no privacy dimension, so is_non_public=True.
+    assert_within_scope(
+        user,
+        db_session,
+        permission=Permission.MANAGE_USER_GROUPS,
+        current_group_ids=[group_id],
+        requested_group_ids=[group_id],
+        is_non_public=True,
+    )
     rate_limit_display = TokenRateLimitDisplay.from_db(
         insert_user_group_token_rate_limit(
             db_session=db_session,
@@ -76,6 +101,86 @@ def create_group_token_limit_settings(
     # clear cache in case this was the first rate limit created
     any_rate_limit_exists.cache_clear()
     return rate_limit_display
+
+
+def _authorize_group_token_rate_limit_write(
+    user: User, db_session: Session, *, group_id: int, rate_limit_id: int
+) -> None:
+    """Manager-scope gate for a group token-limit write: caller must manage group_id AND the
+    limit must belong to it — so a global/per-user id or another group's limit can't be reached
+    through this path. No current path attaches a limit to more than one group, but the schema
+    allows many-to-many; defensively, if a limit ever spans groups (a mutation hits all of them),
+    require the caller to manage every one, not just the group_id in the URL."""
+    assert_within_scope(
+        user,
+        db_session,
+        permission=Permission.MANAGE_USER_GROUPS,
+        current_group_ids=[group_id],
+        requested_group_ids=[group_id],
+        is_non_public=True,
+    )
+    try:
+        scope, group_ids = get_token_rate_limit_scope_and_group_ids(
+            db_session, rate_limit_id
+        )
+    except ValueError:
+        scope, group_ids = None, []
+    if scope != TokenRateLimitScope.USER_GROUP or group_id not in group_ids:
+        raise OnyxError(
+            OnyxErrorCode.NOT_FOUND, "Token rate limit not found for this group."
+        )
+    # Defensive: no current path attaches a limit to >1 group, but the schema allows it. If one
+    # ever did, the mutation would hit all of them, so require the caller to manage every one.
+    assert_within_scope(
+        user,
+        db_session,
+        permission=Permission.MANAGE_USER_GROUPS,
+        current_group_ids=group_ids,
+        requested_group_ids=group_ids,
+        is_non_public=True,
+    )
+
+
+# Separate from the shared by-id routes so this route's require_permission caps a scoped
+# PAT to MANAGE_USER_GROUPS; a shared route would expose FULL_ADMIN global/user limits.
+@router.put("/user-group/{group_id}/rate-limit/{rate_limit_id}")
+def update_group_token_limit_settings(
+    group_id: int,
+    rate_limit_id: int,
+    token_limit_settings: TokenRateLimitArgs,
+    user: User = Depends(
+        require_permission(Permission.MANAGE_USER_GROUPS, allow_scope=True)
+    ),
+    db_session: Session = Depends(get_session),
+) -> TokenRateLimitDisplay:
+    _authorize_group_token_rate_limit_write(
+        user, db_session, group_id=group_id, rate_limit_id=rate_limit_id
+    )
+    rate_limit_display = TokenRateLimitDisplay.from_db(
+        update_token_rate_limit(
+            db_session=db_session,
+            token_rate_limit_id=rate_limit_id,
+            token_rate_limit_settings=token_limit_settings,
+        )
+    )
+    any_rate_limit_exists.cache_clear()
+    return rate_limit_display
+
+
+@router.delete("/user-group/{group_id}/rate-limit/{rate_limit_id}")
+def delete_group_token_limit_settings(
+    group_id: int,
+    rate_limit_id: int,
+    user: User = Depends(
+        require_permission(Permission.MANAGE_USER_GROUPS, allow_scope=True)
+    ),
+    db_session: Session = Depends(get_session),
+) -> None:
+    _authorize_group_token_rate_limit_write(
+        user, db_session, group_id=group_id, rate_limit_id=rate_limit_id
+    )
+    delete_token_rate_limit(db_session=db_session, token_rate_limit_id=rate_limit_id)
+    any_rate_limit_exists.cache_clear()
 
 
 """

--- a/backend/ee/onyx/server/user_group/api.py
+++ b/backend/ee/onyx/server/user_group/api.py
@@ -10,29 +10,39 @@ from ee.onyx.db.user_group import fetch_user_group
 from ee.onyx.db.user_group import fetch_user_groups
 from ee.onyx.db.user_group import fetch_user_groups_for_user
 from ee.onyx.db.user_group import insert_user_group
+from ee.onyx.db.user_group import make_group_manager
 from ee.onyx.db.user_group import prepare_user_group_for_deletion
 from ee.onyx.db.user_group import rename_user_group
+from ee.onyx.db.user_group import revoke_group_manager
 from ee.onyx.db.user_group import set_group_permissions_bulk__no_commit
 from ee.onyx.db.user_group import update_user_group
 from ee.onyx.server.user_group.models import AddUsersToUserGroupRequest
 from ee.onyx.server.user_group.models import BulkSetPermissionsRequest
 from ee.onyx.server.user_group.models import MinimalUserGroupSnapshot
+from ee.onyx.server.user_group.models import SetGroupManagerRequest
 from ee.onyx.server.user_group.models import UpdateGroupAgentsRequest
 from ee.onyx.server.user_group.models import UserGroup
 from ee.onyx.server.user_group.models import UserGroupCreate
 from ee.onyx.server.user_group.models import UserGroupRename
 from ee.onyx.server.user_group.models import UserGroupUpdate
+from onyx.auth.permission_projection import user_group_permissions
 from onyx.auth.permissions import get_effective_permissions
+from onyx.auth.permissions import has_global_permission
+from onyx.auth.permissions import has_permission
 from onyx.auth.permissions import NON_TOGGLEABLE_PERMISSIONS
 from onyx.auth.permissions import PERMISSION_REGISTRY
 from onyx.auth.permissions import PermissionRegistryEntry
 from onyx.auth.permissions import require_permission
+from onyx.auth.scoped_permissions import assert_manages_group
+from onyx.auth.scoped_permissions import get_scoped_groups
+from onyx.auth.scoped_permissions import manages_group
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
 from onyx.configs.constants import PUBLIC_API_TAGS
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
+from onyx.db.enums import PermissionAuthority
 from onyx.db.models import User
-from onyx.db.persona import get_persona_by_id
+from onyx.db.persona import fetch_persona_by_id_for_user
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server.security.store import get_security_settings
@@ -46,18 +56,51 @@ router = APIRouter(prefix="/manage", tags=PUBLIC_API_TAGS)
 @router.get("/admin/user-group")
 def list_user_groups(
     include_default: bool = False,
-    _: User = Depends(require_permission(Permission.READ_USER_GROUPS)),
+    user: User = Depends(
+        require_permission(Permission.READ_USER_GROUPS, allow_scope=True)
+    ),
     db_session: Session = Depends(get_session),
 ) -> list[UserGroup]:
+    # GATE 2 (read): the group list has no membership filter, so a scoped manager must be
+    # restricted here or they'd see the whole org. Only their set is consulted — a global
+    # holder short-circuits in manages_group — but fall back to an empty set, never None,
+    # or manages_group re-queries once per group.
+    managed_group_ids = (
+        get_scoped_groups(user, db_session, Permission.MANAGE_USER_GROUPS)
+        if has_permission(user, Permission.MANAGE_USER_GROUPS)
+        is PermissionAuthority.SCOPED
+        else set[int]()
+    )
+    is_user_groups_admin = has_global_permission(user, Permission.MANAGE_USER_GROUPS)
+    is_full_admin = has_global_permission(user, Permission.FULL_ADMIN_PANEL_ACCESS)
+    restrict_to_group_ids = (
+        None
+        if has_global_permission(user, Permission.READ_USER_GROUPS)
+        else managed_group_ids
+    )
     user_groups = fetch_user_groups(
         db_session,
         only_up_to_date=False,
         eager_load_for_snapshot=True,
         include_default=include_default,
+        restrict_to_group_ids=restrict_to_group_ids,
     )
     mask_credential_prefix = get_security_settings().mask_credential_prefix
     return [
-        UserGroup.from_model(user_group, mask_credential_prefix=mask_credential_prefix)
+        UserGroup.from_model(
+            user_group,
+            mask_credential_prefix=mask_credential_prefix,
+            permissions=user_group_permissions(
+                can_manage=manages_group(
+                    user,
+                    db_session,
+                    group_id=user_group.id,
+                    managed_group_ids=managed_group_ids,
+                ),
+                is_user_groups_admin=is_user_groups_admin,
+                is_full_admin=is_full_admin,
+            ),
+        )
         for user_group in user_groups
     ]
 
@@ -164,9 +207,13 @@ def create_user_group(
 @router.patch("/admin/user-group/rename")
 def rename_user_group_endpoint(
     rename_request: UserGroupRename,
-    _: User = Depends(require_permission(Permission.MANAGE_USER_GROUPS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_USER_GROUPS, allow_scope=True)
+    ),
     db_session: Session = Depends(get_session),
 ) -> UserGroup:
+    # GATE 2: rename's DB fn takes no user and re-reads nothing, so gate here.
+    assert_manages_group(user, db_session, group_id=rename_request.id)
     group = fetch_user_group(db_session, rename_request.id)
     if group and group.is_default:
         raise OnyxError(OnyxErrorCode.CONFLICT, "Cannot rename a default system group.")
@@ -195,7 +242,9 @@ def rename_user_group_endpoint(
 def patch_user_group(
     user_group_id: int,
     user_group_update: UserGroupUpdate,
-    user: User = Depends(require_permission(Permission.MANAGE_USER_GROUPS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_USER_GROUPS, allow_scope=True)
+    ),
     db_session: Session = Depends(get_session),
 ) -> UserGroup:
     try:
@@ -216,7 +265,9 @@ def patch_user_group(
 def add_users(
     user_group_id: int,
     add_users_request: AddUsersToUserGroupRequest,
-    user: User = Depends(require_permission(Permission.MANAGE_USER_GROUPS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_USER_GROUPS, allow_scope=True)
+    ),
     db_session: Session = Depends(get_session),
 ) -> UserGroup:
     try:
@@ -257,12 +308,14 @@ def delete_user_group(
 def update_group_agents(
     user_group_id: int,
     request: UpdateGroupAgentsRequest,
-    user: User = Depends(require_permission(Permission.MANAGE_USER_GROUPS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_USER_GROUPS, allow_scope=True)
+    ),
     db_session: Session = Depends(get_session),
 ) -> None:
     for agent_id in request.added_agent_ids:
-        persona = get_persona_by_id(
-            persona_id=agent_id, user=user, db_session=db_session
+        persona = fetch_persona_by_id_for_user(
+            db_session=db_session, persona_id=agent_id, user=user
         )
         current_group_ids = [g.id for g in persona.groups]
         if user_group_id not in current_group_ids:
@@ -270,19 +323,45 @@ def update_group_agents(
                 persona_id=agent_id,
                 creator_user_id=user.id,
                 db_session=db_session,
+                acting_user=user,
                 group_ids=current_group_ids + [user_group_id],
             )
 
     for agent_id in request.removed_agent_ids:
-        persona = get_persona_by_id(
-            persona_id=agent_id, user=user, db_session=db_session
+        persona = fetch_persona_by_id_for_user(
+            db_session=db_session, persona_id=agent_id, user=user
         )
         current_group_ids = [g.id for g in persona.groups]
         update_persona_access(
             persona_id=agent_id,
             creator_user_id=user.id,
             db_session=db_session,
+            acting_user=user,
             group_ids=[gid for gid in current_group_ids if gid != user_group_id],
         )
 
+    db_session.commit()
+
+
+@router.put("/admin/user-group/{user_group_id}/manager")
+def set_group_manager(
+    user_group_id: int,
+    request: SetGroupManagerRequest,
+    user: User = Depends(
+        require_permission(Permission.MANAGE_USER_GROUPS, allow_scope=True)
+    ),
+    db_session: Session = Depends(get_session),
+) -> None:
+    # GATE 2: an admin / global MANAGE_USER_GROUPS holder may assign in any group;
+    # a scoped manager may only (de)assign managers within a group they manage — so
+    # a manager can delegate within their own group but not beyond it.
+    assert_manages_group(user, db_session, group_id=user_group_id)
+    try:
+        if request.is_manager:
+            make_group_manager(db_session, request.user_id, user_group_id)
+        else:
+            revoke_group_manager(db_session, request.user_id, user_group_id)
+    except ValueError as e:
+        # Target isn't a member of the group (a manager is always a member).
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, str(e))
     db_session.commit()

--- a/backend/ee/onyx/server/user_group/models.py
+++ b/backend/ee/onyx/server/user_group/models.py
@@ -1,6 +1,7 @@
 from uuid import UUID
 
 from pydantic import BaseModel
+from pydantic import Field
 
 from onyx.auth.permissions import Permission
 from onyx.db.models import UserGroup as UserGroupModel
@@ -17,12 +18,17 @@ class UserGroup(BaseModel):
     id: int
     name: str
     users: list[UserInfo]
+    manager_ids: list[str]
     cc_pairs: list[ConnectorCredentialPairDescriptor]
     document_sets: list[DocumentSet]
     personas: list[PersonaSnapshot]
     is_up_to_date: bool
     is_up_for_deletion: bool
     is_default: bool
+    # Per-action affordance map ({"manage": true, ...}) the client reads to show/hide
+    # controls. Empty default = every action denied (missing key is false), so it fails
+    # closed. Only the list-groups endpoint fills it in; the mutation routes leave it empty.
+    permissions: dict[str, bool] = Field(default_factory=dict)
 
     @classmethod
     def from_model(
@@ -30,10 +36,17 @@ class UserGroup(BaseModel):
         user_group_model: UserGroupModel,
         *,
         mask_credential_prefix: bool,
+        permissions: dict[str, bool] | None = None,
     ) -> "UserGroup":
         return cls(
+            permissions=permissions or {},
             id=user_group_model.id,
             name=user_group_model.name,
+            manager_ids=[
+                str(relationship.user_id)
+                for relationship in user_group_model.user_group_relationships
+                if relationship.is_manager and relationship.user_id is not None
+            ],
             users=[
                 UserInfo(
                     id=str(user.id),
@@ -120,6 +133,11 @@ class UserGroupRename(BaseModel):
 class UpdateGroupAgentsRequest(BaseModel):
     added_agent_ids: list[int]
     removed_agent_ids: list[int]
+
+
+class SetGroupManagerRequest(BaseModel):
+    user_id: UUID
+    is_manager: bool
 
 
 class SetPermissionRequest(BaseModel):

--- a/backend/onyx/auth/permission_projection.py
+++ b/backend/onyx/auth/permission_projection.py
@@ -1,0 +1,218 @@
+"""Read-side capability projection.
+
+Stamps a ``permissions`` map on resource DTOs from the same decision the write guards
+enforce, so the client can hide controls the user would be 403'd on.
+
+These maps are affordance hints only, never an authz input: every mutating route keeps
+its own guard as the security boundary. Fail-closed — a key absent from the map reads
+as ``False`` on the client.
+"""
+
+from typing import cast
+from typing import TypedDict
+
+# Each resource's affordance keys are a TypedDict, so a typo or a missing key in the builder
+# below is a type error rather than a silent False on the wire. The ``*_ACTIONS`` vocabulary is
+# derived from the TypedDict (one source of truth), and the builders widen to the generic
+# ``dict[str, bool]`` the DTO fields carry.
+
+
+class CCPairPermissions(TypedDict):
+    edit: bool
+    delete: bool
+    publish: bool
+
+
+CC_PAIR_ACTIONS: frozenset[str] = frozenset(CCPairPermissions.__annotations__)
+
+
+def cc_pair_permissions(
+    *, is_editable: bool, is_connectors_admin: bool
+) -> dict[str, bool]:
+    """``is_editable`` is the managed-scope editable decision the write guard enforces
+    (a scoped manager may edit a managed private connector; it also gates the
+    manage-access control, so there is no separate key). ``delete`` and ``publish``
+    (make org-wide PUBLIC) are global-only: a manager can edit a managed connector but
+    never delete it or make it public."""
+    result: CCPairPermissions = {
+        "edit": is_editable,
+        "delete": is_connectors_admin,
+        "publish": is_connectors_admin,
+    }
+    return cast(dict[str, bool], result)
+
+
+class PersonaPermissions(TypedDict):
+    edit: bool
+    share: bool
+    view_stats: bool
+    delete: bool
+    publish: bool
+    feature: bool
+    list: bool
+    reorder: bool
+
+
+PERSONA_ACTIONS: frozenset[str] = frozenset(PersonaPermissions.__annotations__)
+
+
+def persona_permissions(
+    *,
+    can_edit: bool,
+    can_share: bool,
+    can_view_stats: bool,
+    can_delete: bool,
+    holds_add_agents: bool,
+    is_manage_agents_admin: bool,
+    is_full_admin: bool,
+) -> dict[str, bool]:
+    """Agent (persona) affordance map. ``edit``/``share`` gate on editable alone (their routes are
+    BASIC_ACCESS) — an editor-shared user without ADD_AGENTS may still edit and manage sharing.
+    ``edit`` is the editable-AND-managed-scope decision the update guard enforces; ``share`` is the
+    broader editable decision the share guard enforces (get_editable, no scope AND). ``publish``
+    (make org-wide public, via the share route's is_owner_or_admin gate) is owner-or-admin — no
+    ADD_AGENTS. ``delete`` ANDs ``holds_add_agents``: its route gates on ADD_AGENTS at GATE 1
+    (allow_scope), so an owner lacking it is 403'd there. ``view_stats`` is owner-or-full-admin.
+    ``feature``/``list`` need global MANAGE_AGENTS (which implies ADD_AGENTS) and ``reorder`` full
+    admin."""
+    result: PersonaPermissions = {
+        "edit": can_edit,
+        "share": can_share,
+        "view_stats": can_view_stats,
+        "delete": can_delete and holds_add_agents,
+        "publish": can_delete,
+        "feature": is_manage_agents_admin,
+        "list": is_manage_agents_admin,
+        "reorder": is_full_admin,
+    }
+    return cast(dict[str, bool], result)
+
+
+class DocumentSetPermissions(TypedDict):
+    edit: bool
+    manage_access: bool
+    delete: bool
+    publish: bool
+
+
+DOCUMENT_SET_ACTIONS: frozenset[str] = frozenset(DocumentSetPermissions.__annotations__)
+
+
+def document_set_permissions(
+    *, is_editable: bool, is_document_sets_admin: bool
+) -> dict[str, bool]:
+    """Document set affordance map. ``edit`` and ``manage_access`` are the managed-scope
+    editable decision the write guard enforces (a doc set has no editor-share arm, so
+    editable membership is that decision). ``delete`` and ``publish`` (make org-wide
+    public) are global MANAGE_DOCUMENT_SETS only."""
+    result: DocumentSetPermissions = {
+        "edit": is_editable,
+        "manage_access": is_editable,
+        "delete": is_document_sets_admin,
+        "publish": is_document_sets_admin,
+    }
+    return cast(dict[str, bool], result)
+
+
+class ToolPermissions(TypedDict):
+    edit: bool
+    delete: bool
+    toggle: bool
+    authenticate: bool
+
+
+TOOL_ACTIONS: frozenset[str] = frozenset(ToolPermissions.__annotations__)
+
+
+def tool_permissions(*, can_manage: bool) -> dict[str, bool]:
+    """Custom action (OpenAPI tool) affordance map. Every action — edit, delete, toggle, and
+    authenticate (its OAuth config) — is owner-or-admin (``can_manage``): the creator fully
+    controls the action they made and an admin controls any, while a scoped manager may view
+    and create actions but not edit ones they didn't create."""
+    result: ToolPermissions = {
+        "edit": can_manage,
+        "delete": can_manage,
+        "toggle": can_manage,
+        "authenticate": can_manage,
+    }
+    return cast(dict[str, bool], result)
+
+
+class MCPServerPermissions(TypedDict):
+    edit: bool
+    delete: bool
+    authenticate: bool
+    manage_status: bool
+
+
+MCP_SERVER_ACTIONS: frozenset[str] = frozenset(MCPServerPermissions.__annotations__)
+
+
+def mcp_server_permissions(*, can_manage: bool) -> dict[str, bool]:
+    """MCP server affordance map. Every action — edit, delete, authenticate (connect), and
+    manage_status (disconnect/refresh) — is owner-or-admin (``can_manage``): the owner fully
+    controls their server and an admin controls any, while a scoped manager may view servers
+    connected to their groups and create their own but not manage others'."""
+    result: MCPServerPermissions = {
+        "edit": can_manage,
+        "delete": can_manage,
+        "authenticate": can_manage,
+        "manage_status": can_manage,
+    }
+    return cast(dict[str, bool], result)
+
+
+class CustomSkillPermissions(TypedDict):
+    edit: bool
+    manage_access: bool
+    delete: bool
+    publish: bool
+
+
+CUSTOM_SKILL_ACTIONS: frozenset[str] = frozenset(CustomSkillPermissions.__annotations__)
+
+
+def custom_skill_permissions(
+    *, can_edit: bool, is_full_admin: bool, is_skills_admin: bool
+) -> dict[str, bool]:
+    """Custom skill affordance map. ``edit`` (replace bundle, enable/disable) and
+    ``manage_access`` (group grants) are the managed-scope editable decision the write
+    guard enforces. ``delete`` is FULL_ADMIN only (its route requires
+    FULL_ADMIN_PANEL_ACCESS, no ``allow_scope``); ``publish`` (make org-wide public)
+    needs global MANAGE_SKILLS — a scoped manager fails the guard's non-public check when
+    flipping a skill public."""
+    result: CustomSkillPermissions = {
+        "edit": can_edit,
+        "manage_access": can_edit,
+        "delete": is_full_admin,
+        "publish": is_skills_admin,
+    }
+    return cast(dict[str, bool], result)
+
+
+class UserGroupPermissions(TypedDict):
+    manage: bool
+    delete: bool
+    edit_permissions: bool
+    edit_token_limits: bool
+
+
+USER_GROUP_ACTIONS: frozenset[str] = frozenset(UserGroupPermissions.__annotations__)
+
+
+def user_group_permissions(
+    *, can_manage: bool, is_user_groups_admin: bool, is_full_admin: bool
+) -> dict[str, bool]:
+    """User group affordance map. ``manage`` (rename, membership, assign agents, set
+    manager) and ``edit_token_limits`` are the per-group ``manages_group`` decision — group
+    in the manager's managed set, or global MANAGE_USER_GROUPS. A scoped manager gets full
+    token-limit CRUD for groups they manage: every token route (read/create/update/delete)
+    now admits scope. ``delete`` needs global MANAGE_USER_GROUPS (its route has no
+    ``allow_scope``). ``edit_permissions`` is FULL_ADMIN (the permission-toggle route)."""
+    result: UserGroupPermissions = {
+        "manage": can_manage,
+        "delete": is_user_groups_admin,
+        "edit_permissions": is_full_admin,
+        "edit_token_limits": can_manage,
+    }
+    return cast(dict[str, bool], result)

--- a/backend/onyx/auth/permissions.py
+++ b/backend/onyx/auth/permissions.py
@@ -17,6 +17,7 @@ from pydantic import field_validator
 
 from onyx.db.enums import AccountType
 from onyx.db.enums import Permission
+from onyx.db.enums import PermissionAuthority
 from onyx.db.models import User
 from onyx.db.permissions import parse_permission_values
 from onyx.error_handling.error_codes import OnyxErrorCode
@@ -29,8 +30,10 @@ logger = setup_logger()
 ALL_PERMISSIONS: frozenset[str] = frozenset(p.value for p in Permission)
 
 # Implication map: granted permission -> set of permissions it implies.
+# NOTE: ADD_AGENTS does NOT imply READ_AGENTS — creating your own agents must not grant
+# see-all-agents visibility. READ_AGENTS (browse every agent) comes only from the
+# MANAGE_* admin bundles below.
 IMPLIED_PERMISSIONS: dict[str, set[str]] = {
-    Permission.ADD_AGENTS.value: {Permission.READ_AGENTS.value},
     Permission.MANAGE_AGENTS.value: {
         Permission.ADD_AGENTS.value,
         Permission.READ_AGENTS.value,
@@ -89,6 +92,22 @@ NON_TOGGLEABLE_PERMISSIONS: frozenset[Permission] = frozenset(
 CE_UNGATED_PERMISSIONS: frozenset[Permission] = frozenset(
     {
         Permission.ADD_AGENTS,
+    }
+)
+
+# Abilities a group manager may exercise, scoped to the groups they manage.
+# Never persisted to permission_grant or merged into effective_permissions
+# (which stays global-only); has_permission reads it to classify SCOPED
+# authority, so it lives here, not in scoped_permissions.py (one-way import).
+SCOPED_MANAGER_PERMISSIONS: frozenset[Permission] = frozenset(
+    {
+        Permission.MANAGE_CONNECTORS,
+        Permission.MANAGE_DOCUMENT_SETS,
+        Permission.MANAGE_AGENTS,
+        Permission.ADD_AGENTS,
+        Permission.MANAGE_USER_GROUPS,
+        Permission.MANAGE_ACTIONS,  # scoped via its agents at GATE 2
+        Permission.MANAGE_SKILLS,  # scoped via Skill__UserGroup at GATE 2
     }
 )
 
@@ -186,6 +205,13 @@ PERMISSION_REGISTRY: list[PermissionRegistryEntry] = [
         permissions=[Permission.MANAGE_AGENTS],
         group=2,
     ),
+    PermissionRegistryEntry(
+        id="manage_skills",
+        display_name="Manage Skills",
+        description="Add and update skills that agents can use.",
+        permissions=[Permission.MANAGE_SKILLS],
+        group=2,
+    ),
     # Group 3 — Monitoring & Tokens
     PermissionRegistryEntry(
         id="view_agent_analytics",
@@ -231,6 +257,16 @@ def resolve_effective_permissions(granted: set[str]) -> set[str]:
     return effective
 
 
+# The bundle plus everything it implies. A scoped manager holds the bundle's
+# write tokens AND their implied reads (e.g. MANAGE_USER_GROUPS ⇒ READ_USER_GROUPS)
+# — scoped to their managed groups. has_permission classifies against this so a
+# manager resolves SCOPED for those reads; every READ + allow_scope endpoint must
+# still apply its own GATE 2 scope filter (they'd otherwise return all rows).
+SCOPED_MANAGER_PERMISSIONS_EXPANDED: frozenset[str] = frozenset(
+    resolve_effective_permissions({p.value for p in SCOPED_MANAGER_PERMISSIONS})
+)
+
+
 def get_effective_permissions(user: User) -> set[Permission]:
     """Read granted permissions from the column and expand implied permissions."""
     granted = set(parse_permission_values(user.effective_permissions))
@@ -249,20 +285,44 @@ def get_effective_permissions(user: User) -> set[Permission]:
     return {Permission(p) for p in expanded}
 
 
-def has_permission(user: User, permission: Permission) -> bool:
-    """Check whether *user* holds *permission* (directly or via implication/admin override)."""
-    return permission in get_effective_permissions(user)
+def has_permission(user: User, permission: Permission) -> PermissionAuthority:
+    """Classify *user*'s authority for *permission*: GLOBAL (holds it outright /
+    admin), SCOPED (group manager — only within managed groups), or NONE.
+
+    A scoped grant is group-qualified, so it cannot be a flat bool; callers act
+    on the kind (GLOBAL → unrestricted, SCOPED → check resource scope at GATE 2).
+    """
+    if permission in get_effective_permissions(user):
+        return PermissionAuthority.GLOBAL
+    if (
+        user.is_group_manager
+        and permission.value in SCOPED_MANAGER_PERMISSIONS_EXPANDED
+    ):
+        return PermissionAuthority.SCOPED
+    return PermissionAuthority.NONE
+
+
+def has_global_permission(user: User, permission: Permission) -> bool:
+    """True iff *user* holds *permission* outright (global grant / admin) — the
+    GLOBAL-only convenience over has_permission, for checks that must exclude
+    scoped managers."""
+    return has_permission(user, permission) is PermissionAuthority.GLOBAL
 
 
 def require_permission(
     required: Permission,
     *,
     allow_anonymous: bool = False,
+    allow_scope: bool = False,
 ) -> Callable[..., Coroutine[Any, Any, User]]:
     """FastAPI dependency factory: require ``required`` of the caller, capped by the
     authenticating token's scopes (unrestricted PAT / session / API key = no cap).
-    allow_anonymous admits the anonymous user where the tenant permits it (the
-    anonymous-capable chat surface)."""
+    allow_anonymous admits the anonymous user on the chat surface.
+
+    allow_scope (GATE 1) also lets a SCOPED group manager *reach* the handler — reach
+    only, never authorize. If you set it, the handler MUST scope the manager itself
+    (GATE 2 assert_within_scope for writes, within_managed_scope_clause for reads) or
+    they get every resource. Never on delete / set_group_permissions routes."""
     # Lazy import to break the circular dependency between permissions and users
     # (users.py imports has_permission from this module at top level).
     from onyx.auth.users import current_chat_accessible_user
@@ -274,7 +334,12 @@ def require_permission(
         token_scopes: list[Permission] | None = getattr(
             request.state, "token_scopes", None
         )
-        permitted_by_user = required in get_effective_permissions(user)
+        authority = has_permission(user, required)
+        # allow_scope: GATE 1 lets a SCOPED manager reach the route; default GLOBAL-only.
+        if allow_scope:
+            permitted_by_user = authority is not PermissionAuthority.NONE
+        else:
+            permitted_by_user = authority is PermissionAuthority.GLOBAL
         permitted_by_token = token_scopes is None or required.value in (
             resolve_effective_permissions({s.value for s in token_scopes})
         )

--- a/backend/onyx/auth/scoped_permissions.py
+++ b/backend/onyx/auth/scoped_permissions.py
@@ -1,0 +1,148 @@
+"""
+Scoped-manager authorization primitives.
+
+Separate from the pure ``permissions.py``: the policy for a manager's live group
+scope — the bundle guard and the write-side gate. DB access itself lives in
+``onyx/db/scoped_permissions.py``; this layer only consumes that interface.
+"""
+
+from collections.abc import Collection
+
+from sqlalchemy.orm import Session
+
+from onyx.auth.permissions import has_global_permission
+from onyx.auth.permissions import has_permission
+from onyx.auth.permissions import SCOPED_MANAGER_PERMISSIONS_EXPANDED
+from onyx.db.enums import Permission
+from onyx.db.enums import PermissionAuthority
+from onyx.db.models import User
+from onyx.db.scoped_permissions import fetch_managed_group_ids
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+
+
+def get_scoped_groups(
+    user: User, db_session: Session, permission: Permission | None = None
+) -> set[int]:
+    """Imperative form for the write-side gate. Empty when ``permission`` is
+    given but not scopable, so a non-bundle token never resolves a scope. When
+    ``permission`` is ``None``, skips the bundle check and returns all groups the
+    user manages (scope introspection).
+
+    Gate on the *expanded* bundle to match has_permission: an implied read a
+    manager resolves SCOPED for must resolve a scope here, not an empty set."""
+    if (
+        permission is not None
+        and permission.value not in SCOPED_MANAGER_PERMISSIONS_EXPANDED
+    ):
+        return set()
+    return fetch_managed_group_ids(user, db_session)
+
+
+def within_scope(
+    user: User,
+    db_session: Session,
+    *,
+    permission: Permission,
+    current_group_ids: Collection[int],
+    requested_group_ids: Collection[int],
+    is_non_public: bool,
+    managed_group_ids: set[int] | None = None,
+) -> bool:
+    """Pure GATE-2 (write) decision — no raise. GLOBAL holders always pass. A SCOPED
+    manager passes only for a non-public resource whose every group (current ∪
+    requested) is one they manage, landing in >=1 group. Fail-closed: NONE,
+    out-of-scope, or empty managed scope is ``False``.
+
+    ``managed_group_ids`` lets a caller pass a preloaded managed set so per-row
+    stamping issues no DB query; ``None`` re-queries."""
+    authority = has_permission(user, permission)
+    if authority is PermissionAuthority.GLOBAL:
+        return True
+    if authority is PermissionAuthority.SCOPED:
+        managed = (
+            managed_group_ids
+            if managed_group_ids is not None
+            else get_scoped_groups(user, db_session, permission)
+        )
+        final = set(current_group_ids) | set(requested_group_ids)
+        return bool(managed and final and final.issubset(managed) and is_non_public)
+    return False
+
+
+def assert_within_scope(
+    user: User,
+    db_session: Session,
+    *,
+    permission: Permission,
+    current_group_ids: Collection[int],
+    requested_group_ids: Collection[int],
+    is_non_public: bool,
+) -> None:
+    """GATE 2 (write) — the authorization of record; raises 403 when out of scope.
+
+    ``is_non_public`` is the caller's non-public predicate (PUBLIC excluded; for a
+    cc_pair that admits PRIVATE or SYNC). On update, AND the current and requested
+    states so a currently-PUBLIC resource can't be converted into managed scope.
+
+    Call before any try/except in the endpoint: it raises a 403 OnyxError that a
+    surrounding broad except would otherwise re-wrap as a 500. On create, pass
+    ``current_group_ids=[]``; on update, pass the groups re-read from the DB — never
+    the client's — so a reassignment can't escape scope."""
+    if not within_scope(
+        user,
+        db_session,
+        permission=permission,
+        current_group_ids=current_group_ids,
+        requested_group_ids=requested_group_ids,
+        is_non_public=is_non_public,
+    ):
+        raise OnyxError(
+            OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+            "Group managers can only act on private resources "
+            "within the groups they manage.",
+        )
+
+
+def manages_group(
+    user: User,
+    db_session: Session,
+    *,
+    group_id: int,
+    managed_group_ids: set[int] | None = None,
+) -> bool:
+    """Pure GATE-2 decision for an action scoped to a single user group — no raise. A
+    GLOBAL ``MANAGE_USER_GROUPS`` holder always passes; a scoped manager passes only
+    for a group they manage. Fail-closed: empty managed scope is ``False``.
+    ``managed_group_ids`` lets a caller pass a preloaded set so stamping issues no DB
+    query."""
+    if has_global_permission(user, Permission.MANAGE_USER_GROUPS):
+        return True
+    managed = (
+        managed_group_ids
+        if managed_group_ids is not None
+        else get_scoped_groups(user, db_session, Permission.MANAGE_USER_GROUPS)
+    )
+    return group_id in managed
+
+
+def assert_manages_group(user: User, db_session: Session, *, group_id: int) -> None:
+    """GATE 2 for an action scoped to a single user group (membership edits, manager
+    assignment): a GLOBAL ``MANAGE_USER_GROUPS`` holder bypasses; a scoped manager
+    passes only for a group they manage. NONE, or out-of-scope, rejects."""
+    if not manages_group(user, db_session, group_id=group_id):
+        raise OnyxError(
+            OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+            "Group managers can only act within the groups they manage.",
+        )
+
+
+def assert_global(user: User, *, permission: Permission) -> None:
+    """Admin-only gate for delete and other ops that share a bundle token with
+    scoped create/update: the route admits a SCOPED manager, this rejects them —
+    only GLOBAL authority passes."""
+    if has_permission(user, permission) is not PermissionAuthority.GLOBAL:
+        raise OnyxError(
+            OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+            "This action is restricted to administrators.",
+        )

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -83,7 +83,7 @@ from onyx.auth.invited_users import get_invited_users
 from onyx.auth.invited_users import remove_user_from_invited_users
 from onyx.auth.jwt import verify_jwt_token
 from onyx.auth.pat import get_hashed_pat_from_request
-from onyx.auth.permissions import has_permission
+from onyx.auth.permissions import has_global_permission
 from onyx.auth.schemas import AuthBackend
 from onyx.auth.schemas import UserCreate
 from onyx.auth.signup_rate_limit import enforce_signup_rate_limit
@@ -160,7 +160,7 @@ REGISTER_INVITE_ONLY_CODE = "REGISTER_INVITE_ONLY"
 
 
 def is_user_admin(user: User) -> bool:
-    return has_permission(user, Permission.FULL_ADMIN_PANEL_ACCESS)
+    return has_global_permission(user, Permission.FULL_ADMIN_PANEL_ACCESS)
 
 
 def verify_auth_setting() -> None:

--- a/backend/onyx/db/connector_credential_pair.py
+++ b/backend/onyx/db/connector_credential_pair.py
@@ -5,7 +5,6 @@ from typing import TypeVarTuple
 from fastapi import HTTPException
 from sqlalchemy import delete
 from sqlalchemy import desc
-from sqlalchemy import exists
 from sqlalchemy import Select
 from sqlalchemy import select
 from sqlalchemy import update
@@ -33,6 +32,8 @@ from onyx.db.models import SearchSettings
 from onyx.db.models import User
 from onyx.db.models import User__UserGroup
 from onyx.db.models import UserGroup__ConnectorCredentialPair
+from onyx.db.scoped_permissions import scoped_group_ids_subquery
+from onyx.db.scoped_permissions import within_managed_scope_clause
 from onyx.server.models import StatusResponse
 from onyx.utils.logger import setup_logger
 from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
@@ -70,14 +71,13 @@ def _add_user_filters(
     where_clause = User__UG.user_id == user.id
 
     if get_editable:
-        user_groups = select(User__UG.user_group_id).where(User__UG.user_id == user.id)
-        where_clause &= (
-            ~exists()
-            .where(UG__CCpair.cc_pair_id == ConnectorCredentialPair.id)
-            .where(~UG__CCpair.user_group_id.in_(user_groups))
-            .correlate(ConnectorCredentialPair)
+        where_clause = within_managed_scope_clause(
+            resource_id_col=ConnectorCredentialPair.id,
+            junction_resource_col=UserGroup__ConnectorCredentialPair.cc_pair_id,
+            junction_group_col=UserGroup__ConnectorCredentialPair.user_group_id,
+            non_public_clause=ConnectorCredentialPair.access_type != AccessType.PUBLIC,
+            managed_subq=scoped_group_ids_subquery(user),
         )
-        where_clause |= ConnectorCredentialPair.creator_id == user.id
     else:
         where_clause |= ConnectorCredentialPair.access_type == AccessType.PUBLIC
         where_clause |= ConnectorCredentialPair.access_type == AccessType.SYNC

--- a/backend/onyx/db/document_set.py
+++ b/backend/onyx/db/document_set.py
@@ -4,7 +4,6 @@ from uuid import UUID
 
 from sqlalchemy import and_
 from sqlalchemy import delete
-from sqlalchemy import false as sa_false
 from sqlalchemy import func
 from sqlalchemy import or_
 from sqlalchemy import Select
@@ -13,7 +12,7 @@ from sqlalchemy.orm import aliased
 from sqlalchemy.orm import selectinload
 from sqlalchemy.orm import Session
 
-from onyx.auth.permissions import has_permission
+from onyx.auth.permissions import has_global_permission
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
 from onyx.db.connector_credential_pair import get_cc_pair_groups_for_ids
 from onyx.db.connector_credential_pair import get_connector_credential_pairs
@@ -30,6 +29,8 @@ from onyx.db.models import DocumentSet__UserGroup
 from onyx.db.models import FederatedConnector__DocumentSet
 from onyx.db.models import User
 from onyx.db.models import User__UserGroup
+from onyx.db.scoped_permissions import scoped_group_ids_subquery
+from onyx.db.scoped_permissions import within_managed_scope_clause
 from onyx.server.features.document_set.models import DocumentSetCreationRequest
 from onyx.server.features.document_set.models import DocumentSetUpdateRequest
 from onyx.utils.logger import setup_logger
@@ -40,13 +41,23 @@ logger = setup_logger()
 
 def _add_user_filters(stmt: Select, user: User, get_editable: bool = True) -> Select:
     # MANAGE → always return all
-    if has_permission(user, Permission.MANAGE_DOCUMENT_SETS):
+    if has_global_permission(user, Permission.MANAGE_DOCUMENT_SETS):
         return stmt
-    # Editing requires MANAGE; readers and group-members cannot edit.
+    # Read mirror of GATE 2 for a scoped manager: PRIVATE doc sets whose every
+    # group is managed. Non-managers get an empty subquery, so it fails closed
+    # like the prior sa_false().
     if get_editable:
-        return stmt.where(sa_false())
+        return stmt.where(
+            within_managed_scope_clause(
+                resource_id_col=DocumentSetDBModel.id,
+                junction_resource_col=DocumentSet__UserGroup.document_set_id,
+                junction_group_col=DocumentSet__UserGroup.user_group_id,
+                non_public_clause=DocumentSetDBModel.is_public.is_(False),
+                managed_subq=scoped_group_ids_subquery(user),
+            )
+        )
     # READ → return all when reading, nothing when editing
-    if has_permission(user, Permission.READ_DOCUMENT_SETS):
+    if has_global_permission(user, Permission.READ_DOCUMENT_SETS):
         return stmt
 
     # Otherwise: public document sets, plus those owned by groups the user
@@ -105,6 +116,19 @@ def get_document_set_by_id_for_user(
     stmt = stmt.where(DocumentSetDBModel.id == document_set_id)
     stmt = _add_user_filters(stmt=stmt, user=user, get_editable=get_editable)
     return db_session.scalar(stmt)
+
+
+def get_group_ids_for_document_set(
+    db_session: Session, document_set_id: int
+) -> set[int]:
+    """Current groups on a document set — the ``current_group_ids`` for GATE 2."""
+    return set(
+        db_session.scalars(
+            select(DocumentSet__UserGroup.user_group_id).where(
+                DocumentSet__UserGroup.document_set_id == document_set_id
+            )
+        ).all()
+    )
 
 
 def get_document_set_by_id(

--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -526,6 +526,8 @@ class Permission(str, PyEnum):
     # Toggle tokens
     READ_AGENT_ANALYTICS = "read:agent_analytics"
     MANAGE_ACTIONS = "manage:actions"
+    # In the scoped-manager bundle; registry/enforcement land in a later PR.
+    MANAGE_SKILLS = "manage:skills"
     READ_QUERY_HISTORY = "read:query_history"
     MANAGE_USER_GROUPS = "manage:user_groups"
     CREATE_USER_API_KEYS = "create:user_api_keys"
@@ -553,6 +555,19 @@ Permission.IMPLIED = frozenset(
         Permission.READ_ADMIN,
     }
 )
+
+
+class PermissionAuthority(PyEnum):
+    """The authority a user holds for a permission, returned by has_permission.
+
+    GLOBAL: holds the token outright / admin — unrestricted. SCOPED: group
+    manager — only within managed groups. NONE: not authorized. A scoped grant
+    is group-qualified, so it can't be a flat bool; callers act on the kind.
+    """
+
+    GLOBAL = "global"
+    SCOPED = "scoped"
+    NONE = "none"
 
 
 class PersonaSharePermission(str, PyEnum):

--- a/backend/onyx/db/feedback.py
+++ b/backend/onyx/db/feedback.py
@@ -13,7 +13,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import aliased
 from sqlalchemy.orm import Session
 
-from onyx.auth.permissions import has_permission
+from onyx.auth.permissions import has_global_permission
 from onyx.configs.constants import MessageType
 from onyx.configs.constants import SearchFeedbackType
 from onyx.db.chat import get_chat_message
@@ -44,7 +44,7 @@ def _fetch_db_doc_by_id(doc_id: str, db_session: Session) -> DbDocument:
 
 
 def _add_user_filters(stmt: Select, user: User, get_editable: bool = True) -> Select:
-    if has_permission(user, Permission.FULL_ADMIN_PANEL_ACCESS):
+    if has_global_permission(user, Permission.FULL_ADMIN_PANEL_ACCESS):
         return stmt
 
     stmt = stmt.distinct()

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -378,6 +378,10 @@ class User(SQLAlchemyBaseUserTableUUID, Base):
         default=list,
         server_default=text("'[]'::jsonb"),
     )
+    # Cached for a zero-query route gate; the managed-group list stays live.
+    is_group_manager: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=text("false")
+    )
 
     oidc_expiry: Mapped[datetime.datetime] = mapped_column(
         TIMESTAMPAware(timezone=True), nullable=True
@@ -4359,6 +4363,10 @@ class User__UserGroup(Base):
     __table_args__ = (Index("ix_user__user_group_user_id", "user_id"),)
 
     is_curator: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    # Group-manager role binding for this (user, group) edge.
+    is_manager: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=text("false")
+    )
 
     user_group_id: Mapped[int] = mapped_column(
         ForeignKey("user_group.id"), primary_key=True

--- a/backend/onyx/db/notification.py
+++ b/backend/onyx/db/notification.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy.sql import func
 from sqlalchemy.sql.elements import ColumnElement
 
-from onyx.auth.permissions import has_permission
+from onyx.auth.permissions import has_global_permission
 from onyx.configs.constants import NotificationType
 from onyx.db.enums import Permission
 from onyx.db.models import Notification
@@ -98,7 +98,7 @@ def get_notification_by_id(
     if notif.user_id != user_id and not (
         notif.user_id is None
         and user is not None
-        and has_permission(user, Permission.FULL_ADMIN_PANEL_ACCESS)
+        and has_global_permission(user, Permission.FULL_ADMIN_PANEL_ACCESS)
     ):
         raise PermissionError(
             f"User {user_id} is not authorized to access notification {notification_id}"

--- a/backend/onyx/db/permissions.py
+++ b/backend/onyx/db/permissions.py
@@ -51,6 +51,8 @@ def recompute_user_permissions__no_commit(
     Stores only directly granted permissions — implication expansion
     happens at read time via get_effective_permissions().
 
+    Also refreshes the cached ``is_group_manager`` flag in the same write.
+
     Does NOT commit — caller must commit the session.
     """
     if isinstance(user_ids, (UUID, str)):
@@ -82,11 +84,29 @@ def recompute_user_permissions__no_commit(
     for uid, perm in rows:
         perms_by_user[uid].add(perm.value)
 
+    # Cache only the boolean; the managed-group list stays live. Keyed by str
+    # so the membership check holds whether callers pass UUID or str user ids.
+    manager_uids: set[str] = {
+        str(uid)
+        for uid in db_session.scalars(
+            select(User__UserGroup.user_id)
+            .where(
+                User__UserGroup.user_id.in_(uid_list),
+                User__UserGroup.is_manager.is_(True),
+            )
+            .distinct()
+        )
+        if uid is not None
+    }
+
     for uid, perms in perms_by_user.items():
         db_session.execute(
             update(User)
             .where(User.id == uid)  # ty: ignore[invalid-argument-type]
-            .values(effective_permissions=sorted(perms))
+            .values(
+                effective_permissions=sorted(perms),
+                is_group_manager=str(uid) in manager_uids,
+            )
         )
 
 

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -15,12 +15,17 @@ from sqlalchemy.orm import selectinload
 from sqlalchemy.orm import Session
 
 from onyx.access.hierarchy_access import get_user_external_group_ids
+from onyx.auth.permission_projection import persona_permissions
+from onyx.auth.permissions import has_global_permission
 from onyx.auth.permissions import has_permission
+from onyx.auth.scoped_permissions import assert_within_scope
+from onyx.auth.scoped_permissions import within_scope
 from onyx.configs.constants import DEFAULT_PERSONA_ID
 from onyx.configs.constants import NotificationType
 from onyx.db.constants import SLACK_BOT_PERSONA_PREFIX
 from onyx.db.document_access import get_accessible_documents_by_ids
 from onyx.db.enums import Permission
+from onyx.db.enums import PermissionAuthority
 from onyx.db.enums import PersonaSharePermission
 from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import Document
@@ -40,7 +45,9 @@ from onyx.db.models import UserGroup
 from onyx.db.notification import create_notification
 from onyx.db.persona_sharing import get_persona_access_level
 from onyx.db.persona_sharing import get_user_group_ids_for_user
-from onyx.db.users import user_is_admin
+from onyx.db.scoped_permissions import fetch_managed_group_ids
+from onyx.db.scoped_permissions import scoped_group_ids_subquery
+from onyx.db.scoped_permissions import within_managed_scope_clause
 from onyx.server.features.persona.models import FullPersonaSnapshot
 from onyx.server.features.persona.models import MinimalPersonaSnapshot
 from onyx.server.features.persona.models import PersonaSharedNotificationData
@@ -77,9 +84,9 @@ class PersonaLoadType(Enum):
 def _add_user_filters(
     stmt: Select[tuple[Persona]], user: User, get_editable: bool = True
 ) -> Select[tuple[Persona]]:
-    if has_permission(user, Permission.MANAGE_AGENTS):
+    if has_global_permission(user, Permission.MANAGE_AGENTS):
         return stmt
-    if not get_editable and has_permission(user, Permission.READ_AGENTS):
+    if not get_editable and has_global_permission(user, Permission.READ_AGENTS):
         return stmt
 
     stmt = stmt.distinct()
@@ -130,6 +137,15 @@ def _add_user_filters(
         where_clause |= (Persona.is_public == True) & (  # noqa: E712
             Persona.public_permission == PersonaSharePermission.EDITOR
         )
+        # Scoped group manager: PRIVATE agents whose every group they manage
+        # (empty managed subquery for a non-manager → contributes no rows).
+        where_clause |= within_managed_scope_clause(
+            resource_id_col=Persona.id,
+            junction_resource_col=Persona__UserGroup.persona_id,
+            junction_group_col=Persona__UserGroup.user_group_id,
+            non_public_clause=Persona.is_public.is_(False),
+            managed_subq=scoped_group_ids_subquery(user),
+        )
     else:
         listed = Persona.is_listed == True  # noqa: E712
 
@@ -149,9 +165,19 @@ def _add_user_filters(
 
 
 def fetch_persona_by_id_for_user(
-    db_session: Session, persona_id: int, user: User, get_editable: bool = True
+    db_session: Session,
+    persona_id: int,
+    user: User,
+    get_editable: bool = True,
+    include_deleted: bool = False,
 ) -> Persona:
+    """Load an agent the user may act on. Soft-deleted rows are excluded by default —
+    every caller mutates the agent, and a deleted one shouldn't be reachable. The one
+    opt-in is ``upsert_persona`` *creating* over a deleted same-name row, which it
+    recycles; editing by id never opts in."""
     stmt = select(Persona).where(Persona.id == persona_id).distinct()
+    if not include_deleted:
+        stmt = stmt.where(Persona.deleted.is_(False))
     stmt = _add_user_filters(stmt=stmt, user=user, get_editable=get_editable)
     persona = db_session.scalars(stmt).one_or_none()
     if not persona:
@@ -198,7 +224,7 @@ def _get_persona_by_name(
     - Non-admin users: can only see their own personas
     """
     stmt = select(Persona).where(Persona.name == persona_name)
-    if user and not has_permission(user, Permission.MANAGE_AGENTS):
+    if user and not has_global_permission(user, Permission.MANAGE_AGENTS):
         stmt = stmt.where(Persona.user_id == user.id)
     result = db_session.execute(stmt).scalar_one_or_none()
     return result
@@ -274,6 +300,7 @@ def update_persona_access(
     persona_id: int,
     creator_user_id: UUID | None,
     db_session: Session,
+    acting_user: User,  # noqa: ARG001  (lockstep with EE; MIT has no group sharing)
     is_public: bool | None = None,
     user_ids: list[UUID] | None = None,
     group_ids: list[int] | None = None,
@@ -322,6 +349,224 @@ def update_persona_access(
         mark_persona_user_files_for_sync(persona_id, db_session)
 
 
+def _assert_persona_update_within_managed_scope(
+    persona_id: int | None,
+    request: PersonaUpsertRequest,
+    user: User,
+    db_session: Session,
+) -> None:
+    """GATE 2 for a scoped group manager on the create/update path. Global holders and
+    non-managers are untouched. A SCOPED manager may only act on a currently-private agent
+    whose groups — current and requested — are ones they manage. Groups and privacy are
+    re-read from the DB, not trusted from the request.
+
+    Publishing is NOT gated here: it's owner-or-admin via ``can_delete_persona`` in
+    ``upsert_persona``, so an owner who happens to manage a group keeps that right."""
+    if has_permission(user, Permission.MANAGE_AGENTS) is not PermissionAuthority.SCOPED:
+        return
+    persona = (
+        db_session.query(Persona).filter(Persona.id == persona_id).first()
+        if persona_id is not None
+        else None
+    )
+    current_group_ids: list[int] = []
+    current_is_public = False
+    if persona is not None:
+        current_group_ids = [group.id for group in persona.groups]
+        current_is_public = persona.is_public
+    requested_group_ids = (
+        list(request.groups) if request.groups is not None else current_group_ids
+    )
+    # Personal (no-group) agent: not a group-scoped resource, so nothing to authorize.
+    if not current_group_ids and not requested_group_ids:
+        return
+    # Managing a group never subtracts a right the actor holds as owner, so an edit that
+    # leaves the groups alone is theirs — the editor round-trips them on every save.
+    # Requesting a different set still hits the gate below, and the EE group-share gate
+    # re-checks the diff at the per-group levels this request can't carry.
+    if (
+        persona is not None
+        and set(requested_group_ids) == set(current_group_ids)
+        and can_delete_persona(user, persona, db_session)
+    ):
+        return
+    assert_within_scope(
+        user,
+        db_session,
+        permission=Permission.MANAGE_AGENTS,
+        current_group_ids=current_group_ids,
+        requested_group_ids=requested_group_ids,
+        # Current state only, matching persona_edit_within_scope: an already-public agent
+        # is in nobody's managed scope; publishing a private one is the owner's call.
+        is_non_public=not current_is_public,
+    )
+
+
+def persona_edit_within_scope(
+    user: User,
+    db_session: Session,
+    *,
+    group_ids: list[int],
+    is_public: bool,
+    is_owner: bool = False,
+    managed_group_ids: set[int] | None = None,
+) -> bool:
+    """Read-mode of ``_assert_persona_update_within_managed_scope`` (requested := current).
+    Non-SCOPED holders, personal (no-group) agents, and the owner pass — read-mode never
+    changes the groups, which is the guard's owner exemption. Otherwise a scoped manager
+    passes only when within_scope holds. Pinned to that guard by the contract test."""
+    if has_permission(user, Permission.MANAGE_AGENTS) is not PermissionAuthority.SCOPED:
+        return True
+    if not group_ids:
+        return True
+    if is_owner:
+        return True
+    return within_scope(
+        user,
+        db_session,
+        permission=Permission.MANAGE_AGENTS,
+        current_group_ids=group_ids,
+        requested_group_ids=group_ids,
+        is_non_public=not is_public,
+        managed_group_ids=managed_group_ids,
+    )
+
+
+def can_edit_persona(
+    user: User,
+    persona: Persona,
+    db_session: Session,
+    *,
+    is_editable: bool,
+    managed_group_ids: set[int] | None = None,
+    user_group_ids: set[int] | None = None,
+) -> bool:
+    """The get_editable filter is a superset (owner ∪ EDITOR-share ∪ managed-scope), so a
+    scoped manager EDITOR-shared on an out-of-scope grouped agent qualifies there but is
+    ANDed out by the managed-scope gate — matching the write path. ``is_editable`` is that
+    filter's result; ``user_group_ids`` preloads the owner check's group lookup."""
+    if not is_editable:
+        return False
+    return persona_edit_within_scope(
+        user,
+        db_session,
+        group_ids=[group.id for group in persona.groups],
+        is_public=persona.is_public,
+        is_owner=can_delete_persona(
+            user, persona, db_session, user_group_ids=user_group_ids
+        ),
+        managed_group_ids=managed_group_ids,
+    )
+
+
+def is_persona_editable_by_user(
+    db_session: Session, persona_id: int, user: User
+) -> bool:
+    """Non-raising editability check via the same get_editable filter the edit affordance
+    should reflect (superset: owner ∪ EDITOR-share ∪ managed-scope)."""
+    stmt = select(Persona).where(Persona.id == persona_id).distinct()
+    stmt = _add_user_filters(stmt=stmt, user=user, get_editable=True)
+    return db_session.scalars(stmt).one_or_none() is not None
+
+
+def can_view_persona_stats(user: User, persona: Persona) -> bool:
+    """Owner-or-full-admin — mirrors ee ``user_can_view_assistant_stats`` (pinned by the
+    contract test). Stats are EE-only but the gate itself is trivially MIT-computable."""
+    return has_global_permission(user, Permission.FULL_ADMIN_PANEL_ACCESS) or (
+        persona.user_id == user.id
+    )
+
+
+def can_delete_persona(
+    user: User,
+    persona: Persona,
+    db_session: Session,
+    *,
+    user_group_ids: set[int] | None = None,
+) -> bool:
+    """Owner-or-admin — mirrors the delete/publish handlers' ownership check (via
+    ``get_persona_by_id(is_for_edit=True)``): a global MANAGE_AGENTS holder, the owner,
+    or an owner-group member. A scoped manager is NOT included: deleting or publishing a
+    managed-group agent is owner/admin only, not a manager scope.
+
+    ``user_group_ids`` lets a caller pass a preloaded set so per-row stamping issues no
+    DB query; ``None`` re-queries."""
+    if has_global_permission(user, Permission.MANAGE_AGENTS):
+        return True
+    if persona.user_id == user.id:
+        return True
+    if persona.owner_group_id is not None:
+        group_ids = (
+            user_group_ids
+            if user_group_ids is not None
+            else get_user_group_ids_for_user(db_session, user.id)
+        )
+        return persona.owner_group_id in group_ids
+    return False
+
+
+def _editable_persona_ids_among(
+    db_session: Session, user: User, persona_ids: list[int]
+) -> set[int]:
+    """Subset of ``persona_ids`` the user may edit, via the same get_editable filter the
+    write path enforces — one query for the whole page instead of a per-persona check."""
+    if not persona_ids:
+        return set()
+    stmt = select(Persona).where(Persona.id.in_(persona_ids))
+    stmt = _add_user_filters(stmt=stmt, user=user, get_editable=True)
+    return {persona.id for persona in db_session.scalars(stmt).all()}
+
+
+def stamp_persona_permissions(
+    snapshots: Sequence[MinimalPersonaSnapshot | PersonaSnapshot],
+    personas: Sequence[Persona],
+    user: User,
+    db_session: Session,
+    user_group_ids: set[int],
+) -> None:
+    """Stamp each list snapshot with the same affordance map the single-agent GET does,
+    so cards gate their icons without a per-card refetch. Shared inputs (editable set,
+    managed scope, admin flags) are batched so a page costs a fixed number of queries,
+    not one per persona. ``snapshots`` and ``personas`` must be in the same order."""
+    editable_ids = _editable_persona_ids_among(
+        db_session, user, [persona.id for persona in personas]
+    )
+    # Only scoped managers consult the managed set (GLOBAL/NONE short-circuit earlier);
+    # preload it once so per-row can_edit_persona issues no query.
+    managed_group_ids = (
+        fetch_managed_group_ids(user, db_session)
+        if has_permission(user, Permission.MANAGE_AGENTS) is PermissionAuthority.SCOPED
+        else None
+    )
+    is_manage_agents_admin = has_global_permission(user, Permission.MANAGE_AGENTS)
+    is_full_admin = has_global_permission(user, Permission.FULL_ADMIN_PANEL_ACCESS)
+    # delete/publish also gate on ADD_AGENTS (GATE 1); edit/share don't. Per-user, not per-row.
+    holds_add_agents = (
+        has_permission(user, Permission.ADD_AGENTS) is not PermissionAuthority.NONE
+    )
+    for snapshot, persona in zip(snapshots, personas):
+        is_editable = persona.id in editable_ids
+        snapshot.permissions = persona_permissions(
+            can_edit=can_edit_persona(
+                user,
+                persona,
+                db_session,
+                is_editable=is_editable,
+                managed_group_ids=managed_group_ids,
+                user_group_ids=user_group_ids,
+            ),
+            # share tracks the share guard (get_editable), broader than edit's scope gate
+            can_share=is_editable,
+            can_view_stats=can_view_persona_stats(user, persona),
+            can_delete=can_delete_persona(
+                user, persona, db_session, user_group_ids=user_group_ids
+            ),
+            holds_add_agents=holds_add_agents,
+            is_manage_agents_admin=is_manage_agents_admin,
+            is_full_admin=is_full_admin,
+        )
+
+
 def create_update_persona(
     persona_id: int | None,
     create_persona_request: PersonaUpsertRequest,
@@ -332,9 +577,13 @@ def create_update_persona(
     # Permission to actually use these is checked later
 
     try:
+        _assert_persona_update_within_managed_scope(
+            persona_id, create_persona_request, user, db_session
+        )
+
         # Featured persona validation
         if create_persona_request.is_featured:
-            if not has_permission(user, Permission.MANAGE_AGENTS):
+            if not has_global_permission(user, Permission.MANAGE_AGENTS):
                 raise ValueError(
                     "Only users with agent management permissions can make a featured persona"
                 )
@@ -385,6 +634,7 @@ def create_update_persona(
             persona_id=persona.id,
             creator_user_id=user.id,
             db_session=db_session,
+            acting_user=user,
             user_ids=create_persona_request.users,
             group_ids=create_persona_request.groups,
         )
@@ -435,19 +685,11 @@ def update_persona_shared(
         db_session=db_session, persona_id=persona_id, user=user, get_editable=True
     )
 
-    # Org-wide visibility is an owner/admin decision. EDITOR-level sharees may
-    # edit user/group shares but must not flip is_public / public_permission
-    # (the same guard update_persona_public_status enforces).
-    is_owner_or_admin: bool = (
-        user_is_admin(user)
-        or persona.user_id == user.id
-        or (
-            persona.owner_group_id is not None
-            and persona.owner_group_id
-            in get_user_group_ids_for_user(db_session, user.id)
-        )
-    )
-    if not is_owner_or_admin:
+    # Org-wide visibility is an owner/admin decision. EDITOR-level sharees may edit
+    # user/group shares but must not flip is_public / public_permission. Reuse the
+    # delete/publish predicate so this exactly matches the `publish` projection and the
+    # /public route (global MANAGE_AGENTS, owner, or owner-group) — not just FULL_ADMIN.
+    if not can_delete_persona(user, persona, db_session):
         is_public = None
         public_permission = None
 
@@ -473,6 +715,7 @@ def update_persona_shared(
         persona_id=persona_id,
         creator_user_id=user.id,
         db_session=db_session,
+        acting_user=user,
         is_public=is_public,
         user_ids=user_ids,
         group_ids=group_ids,
@@ -507,7 +750,7 @@ def update_persona_public_status(
         and persona.owner_group_id in get_user_group_ids_for_user(db_session, user.id)
     )
     if (
-        not has_permission(user, Permission.MANAGE_AGENTS)
+        not has_global_permission(user, Permission.MANAGE_AGENTS)
         and persona.user_id != user.id
         and not is_owner_group_member
     ):
@@ -575,19 +818,24 @@ def get_minimal_persona_snapshots_for_user(
             Document.parent_hierarchy_node
         ),
         selectinload(Persona.user),
+        # groups feeds the per-agent edit affordance (persona_edit_within_scope);
+        # eager-load it so stamping the page's permissions isn't an N+1.
+        selectinload(Persona.groups),
         selectinload(Persona.owner_group),
         selectinload(Persona.user_shares),
         selectinload(Persona.group_shares),
     )
     results = db_session.scalars(stmt).all()
     user_group_ids = get_user_group_ids_for_user(db_session, user.id)
-    return [
+    snapshots = [
         MinimalPersonaSnapshot.from_model(
             persona,
             user_permission=get_persona_access_level(persona, user, user_group_ids),
         )
         for persona in results
     ]
+    stamp_persona_permissions(snapshots, results, user, db_session, user_group_ids)
+    return snapshots
 
 
 def get_persona_snapshots_for_user(
@@ -630,7 +878,10 @@ def get_persona_snapshots_for_user(
     )
 
     results = db_session.scalars(stmt).all()
-    return [PersonaSnapshot.from_model(persona) for persona in results]
+    snapshots = [PersonaSnapshot.from_model(persona) for persona in results]
+    user_group_ids = get_user_group_ids_for_user(db_session, user.id)
+    stamp_persona_permissions(snapshots, results, user, db_session, user_group_ids)
+    return snapshots
 
 
 def get_persona_count_for_user(
@@ -730,6 +981,9 @@ def get_minimal_persona_snapshots_paginated(
             ),
         ),
         selectinload(Persona.user),
+        # groups feeds the per-agent edit affordance (persona_edit_within_scope);
+        # eager-load it so stamping the page's permissions isn't an N+1.
+        selectinload(Persona.groups),
         selectinload(Persona.owner_group),
         selectinload(Persona.user_shares),
         selectinload(Persona.group_shares),
@@ -737,13 +991,15 @@ def get_minimal_persona_snapshots_paginated(
 
     results = db_session.scalars(stmt).all()
     user_group_ids = get_user_group_ids_for_user(db_session, user.id)
-    return [
+    snapshots = [
         MinimalPersonaSnapshot.from_model(
             persona,
             user_permission=get_persona_access_level(persona, user, user_group_ids),
         )
         for persona in results
     ]
+    stamp_persona_permissions(snapshots, results, user, db_session, user_group_ids)
+    return snapshots
 
 
 def get_persona_snapshots_paginated(
@@ -817,7 +1073,10 @@ def get_persona_snapshots_paginated(
     )
 
     results = db_session.scalars(stmt).all()
-    return [PersonaSnapshot.from_model(persona) for persona in results]
+    snapshots = [PersonaSnapshot.from_model(persona) for persona in results]
+    user_group_ids = get_user_group_ids_for_user(db_session, user.id)
+    stamp_persona_permissions(snapshots, results, user, db_session, user_group_ids)
+    return snapshots
 
 
 def _get_paginated_persona_query(
@@ -1084,6 +1343,10 @@ def upsert_persona(
     whether or not the assistant is a built-in / default assistant
     """
 
+    # Only a create that lands on a deleted same-name row recycles it; editing by id must
+    # not reach a deleted agent.
+    recycling_deleted = False
+
     if persona_id is not None:
         existing_persona = db_session.query(Persona).filter_by(id=persona_id).first()
     else:
@@ -1097,6 +1360,7 @@ def upsert_persona(
             raise ValueError(
                 f"Assistant with name '{name}' already exists. Please rename your assistant."
             )
+        recycling_deleted = existing_persona is not None
 
     if existing_persona and user:
         # this checks if the user has permission to edit the persona
@@ -1107,6 +1371,7 @@ def upsert_persona(
             persona_id=existing_persona.id,
             user=user,
             get_editable=True,
+            include_deleted=recycling_deleted,
         )
 
     # Fetch and attach tools by IDs
@@ -1189,7 +1454,12 @@ def upsert_persona(
         existing_persona.default_model_configuration_id = default_model_configuration_id
         existing_persona.starter_messages = starter_messages
         existing_persona.deleted = False  # Un-delete if previously deleted
-        if is_public is not None:
+        # Publishing (org-wide public) is owner-or-admin — matches the share route and the
+        # publish projection. An editor-shared user may edit content but not flip an agent
+        # they don't own to public; the change is silently dropped, like is_listed/is_featured.
+        if is_public is not None and (
+            user is None or can_delete_persona(user, existing_persona, db_session)
+        ):
             existing_persona.is_public = is_public
         if remove_image or uploaded_image_id:
             existing_persona.uploaded_image_id = uploaded_image_id
@@ -1201,7 +1471,7 @@ def upsert_persona(
         # Featured/listed changes are curator/admin-only (ENG-4179): shared
         # editors saving the form must never flip them, so non-privileged
         # updates silently preserve the stored values.
-        user_can_set_admin_flags = user is None or has_permission(
+        user_can_set_admin_flags = user is None or has_global_permission(
             user, Permission.MANAGE_AGENTS
         )
         if is_listed is not None and user_can_set_admin_flags:
@@ -1381,8 +1651,8 @@ def get_persona_by_id(
 
     if (
         not user
-        or has_permission(user, Permission.MANAGE_AGENTS)
-        or (not is_for_edit and has_permission(user, Permission.READ_AGENTS))
+        or has_global_permission(user, Permission.MANAGE_AGENTS)
+        or (not is_for_edit and has_global_permission(user, Permission.READ_AGENTS))
     ):
         result = db_session.execute(persona_stmt)
         persona = result.scalar_one_or_none()

--- a/backend/onyx/db/scoped_permissions.py
+++ b/backend/onyx/db/scoped_permissions.py
@@ -1,0 +1,68 @@
+"""DB-layer scope resolution for group-manager scoped permissions.
+
+Raw SQLAlchemy primitives — the managed-group subquery/read plus the read-side
+scope clause. The authorization policy that consumes these (bundle guard + the
+GATE 2 write gate) lives in ``onyx/auth/scoped_permissions.py``.
+"""
+
+from typing import TypeVar
+
+from sqlalchemy import and_
+from sqlalchemy import ColumnElement
+from sqlalchemy import Select
+from sqlalchemy import select
+from sqlalchemy.orm import InstrumentedAttribute
+from sqlalchemy.orm import Session
+
+from onyx.db.models import User
+from onyx.db.models import User__UserGroup
+
+# Resource PK type — int for connectors/doc-sets, UUID for skills. The clause is
+# key-type agnostic; the TypeVar just ties the resource + junction cols together.
+_ResourceId = TypeVar("_ResourceId")
+
+
+def scoped_group_ids_subquery(user: User) -> Select:
+    """Subquery of the groups ``user`` manages; embed in a resource filter to
+    keep the scope predicate in SQL (no extra round-trip)."""
+    return select(User__UserGroup.user_group_id).where(
+        User__UserGroup.user_id == user.id,
+        User__UserGroup.is_manager.is_(True),
+    )
+
+
+def fetch_managed_group_ids(user: User, db_session: Session) -> set[int]:
+    """Execute ``scoped_group_ids_subquery`` — the ids of groups ``user`` manages."""
+    return set(db_session.scalars(scoped_group_ids_subquery(user)).all())
+
+
+def within_managed_scope_clause(
+    *,
+    resource_id_col: InstrumentedAttribute[_ResourceId],
+    junction_resource_col: InstrumentedAttribute[_ResourceId],
+    junction_group_col: InstrumentedAttribute[int],
+    non_public_clause: ColumnElement[bool],
+    managed_subq: Select,
+) -> ColumnElement[bool]:
+    """Read-side mirror of GATE 2: editable-by-manager iff every group is managed,
+    in ≥1 group, and non-public. ``non_public_clause`` is the caller's non-public
+    predicate — resources encode it differently (``DocumentSet.is_public.is_(False)``
+    vs ``ConnectorCredentialPair.access_type != AccessType.PUBLIC``). ``managed_subq``
+    yields no rows for a non-manager, so the clause fails closed."""
+    belongs_to_managed = (
+        select(junction_resource_col)
+        .where(
+            junction_resource_col == resource_id_col,
+            junction_group_col.in_(managed_subq),
+        )
+        .exists()
+    )
+    belongs_to_unmanaged = (
+        select(junction_resource_col)
+        .where(
+            junction_resource_col == resource_id_col,
+            ~junction_group_col.in_(managed_subq),
+        )
+        .exists()
+    )
+    return and_(non_public_clause, belongs_to_managed, ~belongs_to_unmanaged)

--- a/backend/onyx/db/skill.py
+++ b/backend/onyx/db/skill.py
@@ -36,6 +36,8 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import selectinload
 from sqlalchemy.orm import Session
 
+from onyx.auth.permissions import has_global_permission
+from onyx.db.enums import Permission
 from onyx.db.enums import SandboxStatus
 from onyx.db.external_app import is_user_authenticated_for_app
 from onyx.db.models import ExternalApp
@@ -45,6 +47,8 @@ from onyx.db.models import Skill
 from onyx.db.models import Skill__UserGroup
 from onyx.db.models import User
 from onyx.db.models import User__UserGroup
+from onyx.db.scoped_permissions import scoped_group_ids_subquery
+from onyx.db.scoped_permissions import within_managed_scope_clause
 from onyx.db.utils import is_fk_violation
 from onyx.db.utils import is_unique_violation
 from onyx.db.utils import UNSET
@@ -257,8 +261,24 @@ def fetch_skill_by_id(skill_id: UUID, db_session: Session) -> Skill | None:
     return db_session.scalars(stmt).one_or_none()
 
 
-def list_skills_for_admin(db_session: Session) -> Sequence[Skill]:
+def list_skills_for_admin(db_session: Session, user: User) -> Sequence[Skill]:
+    """Admin skill list. A global MANAGE_SKILLS holder (incl. admins) sees every
+    skill; a scoped group manager sees only PRIVATE skills whose every group they
+    manage. Fail-closed: a non-manager's managed subquery is empty → no rows.
+
+    This is the admin/editable path only — NEVER reuse it for runtime visibility
+    (``_add_user_visibility_filter``), which feeds sandbox injection."""
     stmt = select(Skill).options(selectinload(Skill.author)).order_by(Skill.name)
+    if not has_global_permission(user, Permission.MANAGE_SKILLS):
+        stmt = stmt.where(
+            within_managed_scope_clause(
+                resource_id_col=Skill.id,
+                junction_resource_col=Skill__UserGroup.skill_id,
+                junction_group_col=Skill__UserGroup.user_group_id,
+                non_public_clause=Skill.is_public.is_(False),
+                managed_subq=scoped_group_ids_subquery(user),
+            )
+        )
     return list(db_session.scalars(stmt))
 
 

--- a/backend/onyx/db/token_limit.py
+++ b/backend/onyx/db/token_limit.py
@@ -78,6 +78,27 @@ def insert_global_token_rate_limit(
     return token_limit
 
 
+def get_token_rate_limit_scope_and_group_ids(
+    db_session: Session, token_rate_limit_id: int
+) -> tuple[TokenRateLimitScope, list[int]]:
+    """Scope + every group id a rate limit is attached to (empty unless USER_GROUP). Raises
+    ValueError if the id is unknown. The API attaches a limit to one group today, but the schema
+    allows many-to-many, so an authorizing caller must check every group returned, not just one."""
+    token_limit = db_session.get(TokenRateLimit, token_rate_limit_id)
+    if token_limit is None:
+        raise ValueError(f"TokenRateLimit with id '{token_rate_limit_id}' not found")
+    if token_limit.scope != TokenRateLimitScope.USER_GROUP:
+        return token_limit.scope, []
+    group_ids = list(
+        db_session.scalars(
+            select(TokenRateLimit__UserGroup.user_group_id).where(
+                TokenRateLimit__UserGroup.rate_limit_id == token_rate_limit_id
+            )
+        ).all()
+    )
+    return token_limit.scope, group_ids
+
+
 def update_token_rate_limit(
     db_session: Session,
     token_rate_limit_id: int,

--- a/backend/onyx/db/tools.py
+++ b/backend/onyx/db/tools.py
@@ -1,3 +1,4 @@
+from collections.abc import Collection
 from typing import Any
 from typing import cast
 from typing import Type
@@ -9,13 +10,20 @@ from sqlalchemy import or_
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from onyx.auth.permissions import has_permission
 from onyx.db.constants import UNSET
 from onyx.db.constants import UnsetType
 from onyx.db.enums import MCPServerStatus
+from onyx.db.enums import Permission
+from onyx.db.enums import PermissionAuthority
 from onyx.db.models import MCPServer
 from onyx.db.models import OAuthConfig
+from onyx.db.models import Persona
+from onyx.db.models import Persona__Tool
+from onyx.db.models import Persona__UserGroup
 from onyx.db.models import Tool
 from onyx.db.models import ToolCall
+from onyx.db.models import User
 from onyx.server.features.tool.models import Header
 from onyx.tools.built_in_tools import BUILT_IN_TOOL_TYPES
 from onyx.utils.headers import HeaderItemDict
@@ -92,6 +100,87 @@ def get_tool_by_id(tool_id: int, db_session: Session) -> Tool:
     if not tool:
         raise ValueError("Tool by specified id does not exist")
     return tool
+
+
+def can_manage_own_tool(user: User, tool: Tool) -> bool:
+    """Owner-or-admin gate for every action on a custom action (edit, delete, toggle, OAuth
+    config), matching the routes' ``allow_scope`` guard: a global actions-admin manages any
+    action, a scoped manager only one they created. No MANAGE_ACTIONS authority — or a built-in
+    tool (no owner) — never passes."""
+    authority = has_permission(user, Permission.MANAGE_ACTIONS)
+    if authority is PermissionAuthority.GLOBAL:
+        return True
+    if authority is PermissionAuthority.SCOPED:
+        return tool.user_id is not None and tool.user_id == user.id
+    return False
+
+
+def can_manage_mcp_server(user: User, server: MCPServer) -> bool:
+    """Owner-or-admin gate for every action on an MCP server (edit, delete, connect, status).
+    Global MANAGE_ACTIONS manages any server — that permission is full-admin-equivalent for
+    actions, so it isn't narrowed to FULL_ADMIN; a scoped manager only one they own."""
+    authority = has_permission(user, Permission.MANAGE_ACTIONS)
+    if authority is PermissionAuthority.GLOBAL:
+        return True
+    if authority is PermissionAuthority.SCOPED:
+        return server.owner == user.email
+    return False
+
+
+def can_manage_tool(user: User, tool: Tool) -> bool:
+    """The gate for every per-tool action (edit, delete, toggle, OAuth config). An MCP tool
+    is created with ``user_id=None``, so its ownership lives on the server — without routing
+    there, a server's owner could delete it but not disable one of its tools."""
+    if tool.mcp_server is not None:
+        return can_manage_mcp_server(user, tool.mcp_server)
+    return can_manage_own_tool(user, tool)
+
+
+def can_link_oauth_config(
+    user: User, oauth_config_id: int, db_session: Session
+) -> bool:
+    """Whether an action may point at this OAuth config. A global actions-admin links any; a
+    scoped manager only one no other creator's action already uses — the config holds shared
+    client credentials, and ``_assert_can_manage_oauth_config`` derives ownership from exactly
+    these referencing actions, so linking in would grant both."""
+    authority = has_permission(user, Permission.MANAGE_ACTIONS)
+    if authority is PermissionAuthority.GLOBAL:
+        return True
+    if authority is not PermissionAuthority.SCOPED:
+        return False
+    # Vacuously true when nothing references it yet — an unreferenced config has no owner,
+    # and this is the create-config-then-link flow.
+    return all(
+        owner_id == user.id
+        for owner_id in db_session.scalars(
+            select(Tool.user_id).where(Tool.oauth_config_id == oauth_config_id)
+        )
+    )
+
+
+def get_mcp_server_ids_connected_to_groups(
+    group_ids: Collection[int], db_session: Session
+) -> set[int]:
+    """MCP server ids exposed to any of ``group_ids`` via an agent — a persona shared to or
+    owned by the group that uses one of the server's tools. The read-visibility set for a
+    scoped manager, who may view servers connected to their groups without managing them."""
+    if not group_ids:
+        return set()
+    rows = db_session.execute(
+        select(Tool.mcp_server_id)
+        .join(Persona__Tool, Persona__Tool.tool_id == Tool.id)
+        .join(Persona, Persona.id == Persona__Tool.persona_id)
+        .outerjoin(Persona__UserGroup, Persona__UserGroup.persona_id == Persona.id)
+        .where(
+            Tool.mcp_server_id.is_not(None),
+            Persona.deleted.is_(False),
+            or_(
+                Persona__UserGroup.user_group_id.in_(group_ids),
+                Persona.owner_group_id.in_(group_ids),
+            ),
+        )
+    ).all()
+    return {server_id for (server_id,) in rows if server_id is not None}
 
 
 def get_tool_by_name(tool_name: str, db_session: Session) -> Tool:

--- a/backend/onyx/db/users.py
+++ b/backend/onyx/db/users.py
@@ -68,6 +68,23 @@ def user_is_admin(user: User) -> bool:
     )
 
 
+def get_active_admin_users(db_session: Session) -> list[User]:
+    """Active human admins — API-key dummies and system placeholders excluded. Admin is
+    the FULL_ADMIN_PANEL_ACCESS permission now, not a role. Keep in step with
+    ``_add_live_user_count_where_clause(only_admin_users=True)`` in ``db/auth.py``, which
+    can't be reused here: auth -> api_key -> users is an import cycle."""
+    email_col: KeyedColumnElement[Any] = User.__table__.c.email
+    is_active_col: KeyedColumnElement[Any] = User.__table__.c.is_active
+    stmt = select(User).where(
+        is_active_col.is_(True),
+        User.effective_permissions.contains([Permission.FULL_ADMIN_PANEL_ACCESS.value]),
+        expression.not_(email_col.endswith(DANSWER_API_KEY_DUMMY_EMAIL_DOMAIN)),
+        email_col != ANONYMOUS_USER_EMAIL,
+        email_col != NO_AUTH_PLACEHOLDER_USER_EMAIL,
+    )
+    return list(db_session.execute(stmt).unique().scalars().all())
+
+
 def get_all_users(
     db_session: Session,
     email_filter_string: str | None = None,

--- a/backend/onyx/llm/factory.py
+++ b/backend/onyx/llm/factory.py
@@ -2,7 +2,8 @@ from collections.abc import Callable
 from typing import Any
 
 from sqlalchemy.orm import Session
-from onyx.auth.permissions import has_permission
+
+from onyx.auth.permissions import has_global_permission
 from onyx.configs.model_configs import GEN_AI_TEMPERATURE
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import LLMModelFlowType
@@ -174,7 +175,7 @@ def get_llm_for_persona(
             provider_model,
             user_group_ids,
             persona,
-            has_permission(user, Permission.FULL_ADMIN_PANEL_ACCESS),
+            has_global_permission(user, Permission.FULL_ADMIN_PANEL_ACCESS),
         ):
             logger.warning(
                 "User %s with persona %s cannot access provider %s. Falling back to default provider.",

--- a/backend/onyx/server/documents/cc_pair.py
+++ b/backend/onyx/server/documents/cc_pair.py
@@ -9,7 +9,9 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from onyx.auth.permissions import has_global_permission
 from onyx.auth.permissions import require_permission
+from onyx.auth.scoped_permissions import assert_within_scope
 from onyx.background.celery.tasks.pruning.tasks import try_creating_prune_generator_task
 from onyx.background.celery.versioned_apps.client import app as client_app
 from onyx.background.indexing.models import IndexAttemptErrorPydantic
@@ -364,6 +366,7 @@ def get_cc_pair_full_info(
     return CCPairFullInfo.from_models(
         cc_pair_model=cc_pair,
         mask_credential_prefix=get_security_settings().mask_credential_prefix,
+        is_connectors_admin=has_global_permission(user, Permission.MANAGE_CONNECTORS),
         number_of_index_attempts=count_index_attempts_for_cc_pair(
             db_session=db_session,
             cc_pair_id=cc_pair_id,
@@ -424,7 +427,9 @@ def _connector_supports_targeted_reindex(
 def update_cc_pair_status(
     cc_pair_id: int,
     status_update_request: CCStatusUpdateRequest,
-    user: User = Depends(require_permission(Permission.MANAGE_CONNECTORS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_CONNECTORS, allow_scope=True)
+    ),
     db_session: Session = Depends(get_session),
 ) -> JSONResponse:
     """This method returns nearly immediately. It simply sets some signals and
@@ -509,7 +514,9 @@ def update_cc_pair_status(
 def update_cc_pair_name(
     cc_pair_id: int,
     new_name: str,
-    user: User = Depends(require_permission(Permission.MANAGE_CONNECTORS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_CONNECTORS, allow_scope=True)
+    ),
     db_session: Session = Depends(get_session),
 ) -> StatusResponse[int]:
     cc_pair = get_connector_credential_pair_from_id_for_user(
@@ -539,7 +546,9 @@ def update_cc_pair_name(
 def update_cc_pair_property(
     cc_pair_id: int,
     update_request: CCPropertyUpdateRequest,  # in seconds
-    user: User = Depends(require_permission(Permission.MANAGE_CONNECTORS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_CONNECTORS, allow_scope=True)
+    ),
     db_session: Session = Depends(get_session),
 ) -> StatusResponse[int]:
     cc_pair = get_connector_credential_pair_from_id_for_user(
@@ -601,7 +610,9 @@ def get_cc_pair_last_pruned(
 @router.post("/admin/cc-pair/{cc_pair_id}/prune", tags=PUBLIC_API_TAGS)
 def prune_cc_pair(
     cc_pair_id: int,
-    user: User = Depends(require_permission(Permission.MANAGE_CONNECTORS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_CONNECTORS, allow_scope=True)
+    ),
     db_session: Session = Depends(get_session),
 ) -> StatusResponse[list[int]]:
     """Triggers pruning on a particular cc_pair immediately"""
@@ -611,7 +622,7 @@ def prune_cc_pair(
         cc_pair_id=cc_pair_id,
         db_session=db_session,
         user=user,
-        get_editable=False,
+        get_editable=True,
     )
     if not cc_pair:
         raise OnyxError(
@@ -713,7 +724,9 @@ def associate_credential_to_connector(
     connector_id: int,
     credential_id: int,
     metadata: ConnectorCredentialPairMetadata,
-    user: User = Depends(require_permission(Permission.MANAGE_CONNECTORS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_CONNECTORS, allow_scope=True)
+    ),
     db_session: Session = Depends(get_session),
     tenant_id: str = Depends(get_current_tenant_id),
 ) -> StatusResponse[int]:
@@ -722,6 +735,16 @@ def associate_credential_to_connector(
 
     The intent of this endpoint is to handle connectors that actually need credentials.
     """
+
+    # GATE 2 write authorization (see assert_within_scope).
+    assert_within_scope(
+        user,
+        db_session,
+        permission=Permission.MANAGE_CONNECTORS,
+        current_group_ids=[],
+        requested_group_ids=metadata.groups or [],
+        is_non_public=metadata.access_type != AccessType.PUBLIC,
+    )
 
     try:
         validate_ccpair_for_user(

--- a/backend/onyx/server/documents/connector.py
+++ b/backend/onyx/server/documents/connector.py
@@ -22,8 +22,11 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from onyx.auth.email_utils import send_email
+from onyx.auth.permission_projection import cc_pair_permissions
 from onyx.auth.permissions import get_effective_permissions
+from onyx.auth.permissions import has_global_permission
 from onyx.auth.permissions import require_permission
+from onyx.auth.scoped_permissions import assert_within_scope
 from onyx.auth.users import current_chat_accessible_user
 from onyx.background.celery.tasks.pruning.tasks import try_creating_prune_generator_task
 from onyx.background.celery.versioned_apps.client import app as client_app
@@ -1092,7 +1095,9 @@ def get_connector_status(
 @router.post("/admin/connector/indexing-status", tags=PUBLIC_API_TAGS)
 def get_connector_indexing_status(
     request: IndexingStatusRequest,
-    user: User = Depends(require_permission(Permission.MANAGE_CONNECTORS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_CONNECTORS, allow_scope=True)
+    ),
     db_session: Session = Depends(get_session),
 ) -> list[ConnectorIndexingStatusLiteResponse]:
     tenant_id = get_current_tenant_id()
@@ -1113,6 +1118,8 @@ def get_connector_indexing_status(
 
         with open(MOCK_CONNECTOR_FILE_PATH, "r") as f:
             raw_data = json.load(f)
+            for status in raw_data:
+                status.setdefault("permissions", {})  # fail-closed for mock rows
             connector_indexing_statuses = [
                 ConnectorIndexingStatusLite(**status) for status in raw_data
             ]
@@ -1204,6 +1211,14 @@ def get_connector_indexing_status(
         list[IndexAttempt], latest_successful_index_attempts
     )
 
+    # A scoped manager is always a member of the groups they manage, so their editable (managed)
+    # pairs also match the non-editable member query above; drop the overlap so each renders once
+    # (as editable, taking precedence over the read-only row).
+    editable_ids = {cc_pair.id for cc_pair in editable_cc_pairs}
+    non_editable_cc_pairs = [
+        cc_pair for cc_pair in non_editable_cc_pairs if cc_pair.id not in editable_ids
+    ]
+
     document_count_info = get_document_counts_for_all_cc_pairs(db_session)
 
     # Create lookup dictionaries for efficient access
@@ -1224,6 +1239,8 @@ def get_connector_indexing_status(
     cc_pair_to_latest_successful_index_attempt = _attempt_lookup(
         latest_successful_index_attempts
     )
+
+    is_connectors_admin = has_global_permission(user, Permission.MANAGE_CONNECTORS)
 
     def build_connector_indexing_status(
         cc_pair: ConnectorCredentialPair,
@@ -1254,6 +1271,7 @@ def get_connector_indexing_status(
             ),
             is_editable,
             doc_count,
+            is_connectors_admin=is_connectors_admin,
         )
 
     # Process editable cc_pairs
@@ -1270,16 +1288,18 @@ def get_connector_indexing_status(
         if status:
             non_editable_statuses.append(status)
 
-    # Process federated connectors
+    # Admins only — a federated connector has no group linkage to scope by, and its detail
+    # route is global, so a scoped manager would just 403 on click.
     federated_statuses: list[FederatedConnectorStatus] = []
-    for federated_connector in federated_connectors:
-        federated_status = FederatedConnectorStatus(
-            id=federated_connector.id,
-            source=federated_connector.source,
-            name=f"{federated_connector.source.replace('_', ' ').title()}",
-        )
-
-        federated_statuses.append(federated_status)
+    if is_connectors_admin:
+        for federated_connector in federated_connectors:
+            federated_statuses.append(
+                FederatedConnectorStatus(
+                    id=federated_connector.id,
+                    source=federated_connector.source,
+                    name=f"{federated_connector.source.replace('_', ' ').title()}",
+                )
+            )
 
     source_to_summary: dict[DocumentSource, SourceSummary] = {}
 
@@ -1417,6 +1437,8 @@ def _get_connector_indexing_status_lite(
     last_successful_index_time: datetime | None,
     is_editable: bool,
     document_cnt: int,
+    *,
+    is_connectors_admin: bool,
 ) -> ConnectorIndexingStatusLite | None:
     # TODO remove this to enable ingestion API
     if cc_pair.name == "DefaultCCPair":
@@ -1440,6 +1462,9 @@ def _get_connector_indexing_status_lite(
         access_type=cc_pair.access_type,
         cc_pair_status=cc_pair.status,
         is_editable=is_editable,
+        permissions=cc_pair_permissions(
+            is_editable=is_editable, is_connectors_admin=is_connectors_admin
+        ),
         in_progress=in_progress,
         in_repeated_error_state=cc_pair.in_repeated_error_state,
         last_finished_status=(
@@ -1538,9 +1563,13 @@ def _validate_connector_allowed(source: DocumentSource) -> None:
 @router.post("/admin/connector", tags=PUBLIC_API_TAGS)
 def create_connector_from_model(
     connector_data: ConnectorUpdateRequest,
-    user: User = Depends(require_permission(Permission.MANAGE_CONNECTORS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_CONNECTORS, allow_scope=True)
+    ),
     db_session: Session = Depends(get_session),
 ) -> ObjectCreationIdResponse:
+    # No GATE 2: creates only the Connector row (no cc_pair, no group/access
+    # binding yet). Scope is enforced at credential association.
     tenant_id = get_current_tenant_id()
 
     try:
@@ -1567,10 +1596,22 @@ def create_connector_from_model(
 @router.post("/admin/connector-with-mock-credential")
 def create_connector_with_mock_credential(
     connector_data: ConnectorUpdateRequest,
-    user: User = Depends(require_permission(Permission.MANAGE_CONNECTORS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_CONNECTORS, allow_scope=True)
+    ),
     db_session: Session = Depends(get_session),
 ) -> StatusResponse:
     tenant_id = get_current_tenant_id()
+
+    # GATE 2 write authorization (see assert_within_scope).
+    assert_within_scope(
+        user,
+        db_session,
+        permission=Permission.MANAGE_CONNECTORS,
+        current_group_ids=[],
+        requested_group_ids=connector_data.groups or [],
+        is_non_public=connector_data.access_type != AccessType.PUBLIC,
+    )
 
     try:
         _validate_connector_allowed(connector_data.source)

--- a/backend/onyx/server/documents/models.py
+++ b/backend/onyx/server/documents/models.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
 
+from onyx.auth.permission_projection import cc_pair_permissions
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.models import InputType
 from onyx.db.enums import AccessType
@@ -385,6 +386,9 @@ class CCPairFullInfo(BaseModel):
     latest_deletion_attempt: DeletionAttemptSnapshot | None
     access_type: AccessType
     is_editable_for_current_user: bool
+    # per-action affordance map for the requesting user, from the same editable-scope
+    # decision the write guard enforces
+    permissions: dict[str, bool]
     deletion_failure_message: str | None
     indexing: bool
     creator: UUID | None
@@ -458,6 +462,7 @@ class CCPairFullInfo(BaseModel):
         indexing: bool,
         *,
         mask_credential_prefix: bool,
+        is_connectors_admin: bool = False,
         last_successful_index_time: datetime | None = None,
         last_permission_sync_attempt_status: PermissionSyncStatus | None = None,
         permission_syncing: bool = False,
@@ -507,6 +512,10 @@ class CCPairFullInfo(BaseModel):
             latest_deletion_attempt=latest_deletion_attempt,
             access_type=cc_pair_model.access_type,
             is_editable_for_current_user=is_editable_for_current_user,
+            permissions=cc_pair_permissions(
+                is_editable=is_editable_for_current_user,
+                is_connectors_admin=is_connectors_admin,
+            ),
             deletion_failure_message=cc_pair_model.deletion_failure_message,
             indexing=indexing,
             creator=cc_pair_model.creator_id,
@@ -593,6 +602,9 @@ class ConnectorIndexingStatusLite(BaseModel):
     last_status: IndexingStatus | None
     last_success: datetime | None
     is_editable: bool
+    # per-action affordance map for the requesting user, from the same editable-scope
+    # decision the write guard enforces
+    permissions: dict[str, bool]
     docs_indexed: int
     latest_index_attempt_docs_indexed: int | None
 

--- a/backend/onyx/server/documents/targeted_reindex.py
+++ b/backend/onyx/server/documents/targeted_reindex.py
@@ -19,7 +19,8 @@ from fastapi import Depends
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
-from onyx.auth.users import current_curator_or_admin_user
+from onyx.auth.permissions import Permission
+from onyx.auth.permissions import require_permission
 from onyx.background.celery.versioned_apps.client import app as client_app
 from onyx.configs.constants import OnyxCeleryPriority
 from onyx.configs.constants import OnyxCeleryQueues
@@ -77,7 +78,7 @@ class TargetedReindexJobStatusResponse(BaseModel):
 @router.post("/admin/indexing/targeted-reindex")
 def submit_targeted_reindex(
     request: TargetedReindexRequest,
-    user: User = Depends(current_curator_or_admin_user),
+    user: User = Depends(require_permission(Permission.MANAGE_CONNECTORS)),
     db_session: Session = Depends(get_session),
 ) -> TargetedReindexResponse:
     error_ids = request.error_ids or []
@@ -160,7 +161,7 @@ def submit_targeted_reindex(
 @router.get("/admin/indexing/targeted-reindex/{job_id}")
 def get_targeted_reindex_status(
     job_id: int,
-    _: User = Depends(current_curator_or_admin_user),
+    _: User = Depends(require_permission(Permission.MANAGE_CONNECTORS)),
     db_session: Session = Depends(get_session),
 ) -> TargetedReindexJobStatusResponse:
     job = get_targeted_reindex_job(db_session, job_id)

--- a/backend/onyx/server/features/document_set/api.py
+++ b/backend/onyx/server/features/document_set/api.py
@@ -3,7 +3,13 @@ from fastapi import Depends
 from fastapi import Query
 from sqlalchemy.orm import Session
 
+from onyx.auth.permission_projection import document_set_permissions
+from onyx.auth.permissions import has_global_permission
+from onyx.auth.permissions import has_permission
 from onyx.auth.permissions import require_permission
+from onyx.auth.scoped_permissions import assert_within_scope
+from onyx.auth.scoped_permissions import get_scoped_groups
+from onyx.auth.scoped_permissions import within_scope
 from onyx.background.celery.versioned_apps.client import app as client_app
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
 from onyx.configs.constants import OnyxCeleryPriority
@@ -12,11 +18,13 @@ from onyx.db.document_set import check_document_sets_are_public
 from onyx.db.document_set import delete_document_set as db_delete_document_set
 from onyx.db.document_set import fetch_all_document_sets_for_user
 from onyx.db.document_set import get_document_set_by_id
+from onyx.db.document_set import get_group_ids_for_document_set
 from onyx.db.document_set import insert_document_set
 from onyx.db.document_set import mark_document_set_as_to_be_deleted
 from onyx.db.document_set import update_document_set
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
+from onyx.db.enums import PermissionAuthority
 from onyx.db.models import User
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
@@ -33,10 +41,21 @@ router = APIRouter(prefix="/manage")
 @router.post("/admin/document-set")
 def create_document_set(
     document_set_creation_request: DocumentSetCreationRequest,
-    user: User = Depends(require_permission(Permission.MANAGE_DOCUMENT_SETS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_DOCUMENT_SETS, allow_scope=True)
+    ),
     db_session: Session = Depends(get_session),
     tenant_id: str = Depends(get_current_tenant_id),
 ) -> int:
+    # GATE 2 write authorization (see assert_within_scope).
+    assert_within_scope(
+        user,
+        db_session,
+        permission=Permission.MANAGE_DOCUMENT_SETS,
+        current_group_ids=[],
+        requested_group_ids=document_set_creation_request.groups or [],
+        is_non_public=not document_set_creation_request.is_public,
+    )
     try:
         document_set_db_model, _ = insert_document_set(
             document_set_creation_request=document_set_creation_request,
@@ -59,7 +78,9 @@ def create_document_set(
 @router.patch("/admin/document-set")
 def patch_document_set(
     document_set_update_request: DocumentSetUpdateRequest,
-    user: User = Depends(require_permission(Permission.MANAGE_DOCUMENT_SETS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_DOCUMENT_SETS, allow_scope=True)
+    ),
     db_session: Session = Depends(get_session),
     tenant_id: str = Depends(get_current_tenant_id),
 ) -> None:
@@ -69,6 +90,21 @@ def patch_document_set(
             OnyxErrorCode.DOCUMENT_SET_NOT_FOUND,
             f"Document set {document_set_update_request.id} does not exist",
         )
+
+    # GATE 2 write authorization (see assert_within_scope). Current groups AND
+    # current privacy are re-read from the DB, not the client, so a manager can
+    # neither capture-by-reassignment nor convert a currently-PUBLIC set to PRIVATE.
+    assert_within_scope(
+        user,
+        db_session,
+        permission=Permission.MANAGE_DOCUMENT_SETS,
+        current_group_ids=get_group_ids_for_document_set(
+            db_session, document_set_update_request.id
+        ),
+        requested_group_ids=document_set_update_request.groups,
+        is_non_public=not document_set.is_public
+        and not document_set_update_request.is_public,
+    )
 
     try:
         update_document_set(
@@ -135,7 +171,40 @@ def list_document_sets_for_user(
     document_sets = fetch_all_document_sets_for_user(
         db_session=db_session, user=user, get_editable=get_editable
     )
-    return [DocumentSetSummary.from_model(ds) for ds in document_sets]
+    # Stamp editability per row from its already-loaded groups — no second query, no
+    # client-side double-fetch. Only a SCOPED caller reads the managed set (within_scope
+    # short-circuits for GLOBAL/NONE), so skip fetching it otherwise.
+    managed_group_ids = (
+        get_scoped_groups(user, db_session, Permission.MANAGE_DOCUMENT_SETS)
+        if has_permission(user, Permission.MANAGE_DOCUMENT_SETS)
+        is PermissionAuthority.SCOPED
+        else None
+    )
+    is_document_sets_admin = has_global_permission(
+        user, Permission.MANAGE_DOCUMENT_SETS
+    )
+    summaries: list[DocumentSetSummary] = []
+    for ds in document_sets:
+        group_ids = [group.id for group in ds.groups]
+        is_editable = within_scope(
+            user,
+            db_session,
+            permission=Permission.MANAGE_DOCUMENT_SETS,
+            current_group_ids=group_ids,
+            requested_group_ids=group_ids,
+            is_non_public=not ds.is_public,
+            managed_group_ids=managed_group_ids,
+        )
+        summaries.append(
+            DocumentSetSummary.from_model(
+                ds,
+                permissions=document_set_permissions(
+                    is_editable=is_editable,
+                    is_document_sets_admin=is_document_sets_admin,
+                ),
+            )
+        )
+    return summaries
 
 
 @router.get("/document-set-public")

--- a/backend/onyx/server/features/document_set/models.py
+++ b/backend/onyx/server/features/document_set/models.py
@@ -152,14 +152,26 @@ class DocumentSetSummary(BaseModel):
     is_public: bool
     users: list[UUID]
     groups: list[int]
+    # per-action affordance map for the requesting user (mirrors the write-side gate).
+    # Defaults empty (fail-closed); the list endpoint stamps the real map.
+    permissions: dict[str, bool] = Field(default_factory=dict)
     federated_connector_summaries: list[FederatedConnectorSummary] = Field(
         default_factory=list
     )
 
     @classmethod
-    def from_model(cls, document_set: DocumentSetDBModel) -> "DocumentSetSummary":
-        """Create a summary from a DocumentSet database model"""
+    def from_model(
+        cls,
+        document_set: DocumentSetDBModel,
+        *,
+        permissions: dict[str, bool] | None = None,
+    ) -> "DocumentSetSummary":
+        """Create a summary from a DocumentSet database model. ``permissions`` defaults to
+        an empty (fail-closed) map — the document-set list endpoint stamps the real one;
+        summaries embedded in other snapshots (e.g. a persona's attached sets) carry no
+        affordances since there is no per-user edit surface there."""
         return cls(
+            permissions=permissions or {},
             id=document_set.id,
             name=document_set.name,
             description=document_set.description,

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -33,8 +33,12 @@ from onyx.auth.oauth_token_manager import build_oauth_authorization_url
 from onyx.auth.oauth_token_manager import exchange_oauth_code_for_token
 from onyx.auth.oauth_token_manager import OAuthFlowParams
 from onyx.auth.oauth_token_manager import validate_oauth_endpoint_url
+from onyx.auth.permission_projection import mcp_server_permissions
+from onyx.auth.permission_projection import tool_permissions
 from onyx.auth.permissions import get_effective_permissions
+from onyx.auth.permissions import has_permission
 from onyx.auth.permissions import require_permission
+from onyx.auth.scoped_permissions import get_scoped_groups
 from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
@@ -44,6 +48,7 @@ from onyx.db.enums import MCPOAuthProviderMode
 from onyx.db.enums import MCPServerStatus
 from onyx.db.enums import MCPTransport
 from onyx.db.enums import Permission
+from onyx.db.enums import PermissionAuthority
 from onyx.db.mcp import create_connection_config
 from onyx.db.mcp import create_mcp_server__no_commit
 from onyx.db.mcp import delete_all_user_connection_configs_for_server_no_commit
@@ -63,8 +68,11 @@ from onyx.db.models import MCPConnectionConfig
 from onyx.db.models import MCPServer as DbMCPServer
 from onyx.db.models import Tool
 from onyx.db.models import User
+from onyx.db.tools import can_manage_mcp_server
+from onyx.db.tools import can_manage_tool
 from onyx.db.tools import create_tool__no_commit
 from onyx.db.tools import delete_tool__no_commit
+from onyx.db.tools import get_mcp_server_ids_connected_to_groups
 from onyx.db.tools import get_tools_by_mcp_server_id
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
@@ -737,7 +745,9 @@ class MCPOauthState(BaseModel):
 async def connect_admin_oauth(
     request: MCPUserOAuthConnectRequest,
     db: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> MCPUserOAuthConnectResponse:
     """Connect OAuth flow for admin MCP server authentication"""
     return await _connect_oauth(request, db, is_admin=True, user=user)
@@ -1352,21 +1362,43 @@ class ServerToolsResponse(BaseModel):
 
 
 def _ensure_mcp_server_owner_or_admin(server: DbMCPServer, user: User) -> None:
-    logger.info(
-        "Ensuring MCP server owner or admin: %s %s server.owner=%s",
+    """GATE 2 for every MCP server mutation. Delegates to the predicate the projection
+    stamps, so the UI can't offer a control this rejects. A FULL_ADMIN check here would
+    be stricter than the read gate below, which counts global MANAGE_ACTIONS."""
+    if can_manage_mcp_server(user, server):
+        return
+    logger.warning(
+        "Denied MCP server management: user=%s server=%s owner=%s",
+        user.email,
         server.name,
-        user,
         server.owner,
     )
-    if Permission.FULL_ADMIN_PANEL_ACCESS in get_effective_permissions(user):
-        return
+    raise OnyxError(
+        OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+        "Only the server owner can modify MCP servers they have created.",
+    )
 
-    logger.info("User email: %s server.owner=%s", user.email, server.owner)
-    if server.owner != user.email:
-        raise OnyxError(
-            OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
-            "Only the server owner can modify MCP servers they have created.",
-        )
+
+def _ensure_mcp_server_viewable(
+    server: DbMCPServer, user: User, db_session: Session
+) -> None:
+    """Read gate for a single MCP server: a global MANAGE_ACTIONS holder (incl. admins) views
+    any; an owner views their own; a scoped manager views a server connected to their groups
+    via an agent. Managers may view connected servers without managing them; managing is
+    owner-or-admin (``_ensure_mcp_server_owner_or_admin``)."""
+    authority = has_permission(user, Permission.MANAGE_ACTIONS)
+    if authority is PermissionAuthority.GLOBAL:
+        return
+    if server.owner == user.email:
+        return
+    if authority is PermissionAuthority.SCOPED:
+        managed = get_scoped_groups(user, db_session, Permission.MANAGE_ACTIONS)
+        if server.id in get_mcp_server_ids_connected_to_groups(managed, db_session):
+            return
+    raise OnyxError(
+        OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+        "You can only view MCP servers you own or that are connected to your groups.",
+    )
 
 
 def _db_mcp_server_to_api_mcp_server(
@@ -1374,6 +1406,7 @@ def _db_mcp_server_to_api_mcp_server(
     db: Session,
     request_user: User | None,
     include_auth_config: bool = False,
+    permissions: dict[str, bool] | None = None,
 ) -> MCPServer:
     """Convert database MCP server to API model"""
 
@@ -1547,6 +1580,7 @@ def _db_mcp_server_to_api_mcp_server(
         auth_template=auth_template,
         user_credentials=user_credentials,
         admin_credentials=admin_credentials,
+        permissions=permissions or {},
     )
 
 
@@ -1639,7 +1673,9 @@ def _get_connection_config(
 def admin_list_mcp_tools_by_id(
     server_id: int,
     db: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> MCPToolListResponse:
     return _list_mcp_tools_by_id(server_id, db, True, user)
 
@@ -1654,7 +1690,9 @@ def get_mcp_server_tools_snapshots(
     server_id: int,
     source: ToolSnapshotSource = ToolSnapshotSource.DB,
     db: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> list[ToolSnapshot]:
     """
     Get tools for an MCP server as ToolSnapshot objects.
@@ -1672,9 +1710,8 @@ def get_mcp_server_tools_snapshots(
     except ValueError:
         raise HTTPException(status_code=404, detail="MCP server not found")
 
-    _ensure_mcp_server_owner_or_admin(mcp_server, user)
-
     if source == ToolSnapshotSource.MCP:
+        _ensure_mcp_server_owner_or_admin(mcp_server, user)
         try:
             # Discover tools from MCP server and sync to DB
             _list_mcp_tools_by_id(server_id, db, True, user)
@@ -1701,10 +1738,18 @@ def get_mcp_server_tools_snapshots(
 
             logger.error("Failed to discover tools for MCP server: %s", e)
             raise HTTPException(status_code=500, detail="Failed to discover tools")
+    else:
+        _ensure_mcp_server_viewable(mcp_server, user, db)
 
-    # Fetch and return tools from database
+    # Same predicate the status route enforces, so the UI can't offer a toggle that 403s.
     mcp_tools = get_tools_by_mcp_server_id(server_id, db, order_by_id=True)
-    return [ToolSnapshot.from_model(tool) for tool in mcp_tools]
+    return [
+        ToolSnapshot.from_model(
+            tool,
+            permissions=tool_permissions(can_manage=can_manage_tool(user, tool)),
+        )
+        for tool in mcp_tools
+    ]
 
 
 @router.get("/server/{server_id}/tools")
@@ -2254,7 +2299,9 @@ def _sync_tools_for_server(
 def get_mcp_server_detail(
     server_id: int,
     db_session: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> MCPServer:
     """Return details for one MCP server if user has access"""
     try:
@@ -2262,34 +2309,52 @@ def get_mcp_server_detail(
     except ValueError:
         raise HTTPException(status_code=404, detail="MCP server not found")
 
-    _ensure_mcp_server_owner_or_admin(server, user)
-
+    # Read gate: owner, admin, or a manager of a group the server is connected to.
+    _ensure_mcp_server_viewable(server, user, db_session)
     # TODO: user permissions per mcp server not yet implemented, for now
     # permissions are based on access to assistants
     # # Quick permission check – admin or user has access
     # if user and server not in user.accessible_mcp_servers and not user.is_superuser:
     #     raise HTTPException(status_code=403, detail="Forbidden")
-
     return _db_mcp_server_to_api_mcp_server(
         server,
         db_session,
         include_auth_config=True,
         request_user=user,
+        permissions=mcp_server_permissions(
+            can_manage=can_manage_mcp_server(user, server),
+        ),
     )
 
 
 @admin_router.get("/tools")
 def get_all_mcp_tools(
     db: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),  # noqa: ARG001
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> list:
     """Get all tools associated with MCP servers, including both enabled and disabled tools"""
     from sqlalchemy import select
 
-    from onyx.db.models import Tool
-
     # Query MCP tools ordered by ID to maintain consistent ordering
     stmt = select(Tool).where(Tool.mcp_server_id.is_not(None)).order_by(Tool.id)
+
+    # Scope-match the /servers list: a scoped manager only sees tools on servers they own or
+    # that a group they manage is connected to; a global holder sees every server's tools.
+    if (
+        has_permission(user, Permission.MANAGE_ACTIONS)
+        is not PermissionAuthority.GLOBAL
+    ):
+        connected = get_mcp_server_ids_connected_to_groups(
+            get_scoped_groups(user, db, Permission.MANAGE_ACTIONS), db
+        )
+        visible_server_ids = {
+            server.id
+            for server in get_all_mcp_servers(db)
+            if server.owner == user.email or server.id in connected
+        }
+        stmt = stmt.where(Tool.mcp_server_id.in_(visible_server_ids))
 
     mcp_tools = db.scalars(stmt).all()
 
@@ -2302,7 +2367,9 @@ def update_mcp_server_status(
     server_id: int,
     status: MCPServerStatus,
     db: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> dict[str, str]:
     """Update the status of an MCP server"""
     logger.info("Updating MCP server %s status to %s", server_id, status)
@@ -2328,7 +2395,9 @@ def update_mcp_server_status(
 @admin_router.get("/servers", response_model=MCPServersResponse)
 def get_mcp_servers_for_admin(
     db: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> MCPServersResponse:
     """Get all MCP servers for admin display"""
 
@@ -2337,10 +2406,34 @@ def get_mcp_servers_for_admin(
     try:
         db_mcp_servers = get_all_mcp_servers(db)
 
-        # Convert to API model format
+        # A global MANAGE_ACTIONS holder (incl. admins) sees every server; a scoped manager
+        # sees only those they own or that are connected to a group they manage (one query for
+        # the connected set). Managing is owner-or-admin either way (can_manage_mcp_server).
+        if (
+            has_permission(user, Permission.MANAGE_ACTIONS)
+            is PermissionAuthority.GLOBAL
+        ):
+            visible_servers = db_mcp_servers
+        else:
+            connected = get_mcp_server_ids_connected_to_groups(
+                get_scoped_groups(user, db, Permission.MANAGE_ACTIONS), db
+            )
+            visible_servers = [
+                server
+                for server in db_mcp_servers
+                if server.owner == user.email or server.id in connected
+            ]
+
         mcp_servers = [
-            _db_mcp_server_to_api_mcp_server(db_server, db, request_user=user)
-            for db_server in db_mcp_servers
+            _db_mcp_server_to_api_mcp_server(
+                db_server,
+                db,
+                request_user=user,
+                permissions=mcp_server_permissions(
+                    can_manage=can_manage_mcp_server(user, db_server),
+                ),
+            )
+            for db_server in visible_servers
         ]
 
         return MCPServersResponse(mcp_servers=mcp_servers)
@@ -2354,7 +2447,9 @@ def get_mcp_servers_for_admin(
 def get_mcp_server_db_tools(
     server_id: int,
     db: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> ServerToolsResponse:
     """Get existing database tools created for an MCP server"""
     logger.info("Getting database tools for MCP server: %s", server_id)
@@ -2399,7 +2494,9 @@ def get_mcp_server_db_tools(
 def upsert_mcp_server(
     request: MCPToolCreateRequest,
     db_session: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> MCPServerCreateResponse:
     """Create or update an MCP server (no tools yet)"""
 
@@ -2455,6 +2552,11 @@ def upsert_mcp_server(
     except HTTPException:
         # Re-raise HTTP exceptions as-is
         raise
+    except OnyxError:
+        # Preserve authorization/validation errors (e.g. the scope gate's
+        # INSUFFICIENT_PERMISSIONS) so they surface as their real status rather
+        # than a masked 500.
+        raise
     except Exception as e:
         logger.exception("Failed to create/update MCP tool")
         raise HTTPException(
@@ -2466,7 +2568,9 @@ def upsert_mcp_server(
 def update_mcp_server_with_tools(
     request: MCPToolUpdateRequest,
     db_session: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> MCPServerUpdateResponse:
     """Update an MCP server and associated tools"""
 
@@ -2518,7 +2622,9 @@ def update_mcp_server_with_tools(
 def create_mcp_server_simple(
     request: MCPServerSimpleCreateRequest,
     db_session: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> MCPServer:
     """Create MCP server with minimal information - auth to be configured later"""
 
@@ -2565,7 +2671,9 @@ def update_mcp_server_simple(
     server_id: int,
     request: MCPServerSimpleUpdateRequest,
     db_session: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> MCPServer:
     """Update MCP server basic information (name, description, URL)"""
     try:
@@ -2588,9 +2696,13 @@ def update_mcp_server_simple(
 
     db_session.commit()
 
-    # Return the updated server in API format
     return _db_mcp_server_to_api_mcp_server(
-        updated_server, db_session, request_user=user
+        updated_server,
+        db_session,
+        request_user=user,
+        permissions=mcp_server_permissions(
+            can_manage=can_manage_mcp_server(user, updated_server),
+        ),
     )
 
 
@@ -2598,15 +2710,20 @@ def update_mcp_server_simple(
 def delete_mcp_server_admin(
     server_id: int,
     db_session: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> dict:
     """Delete an MCP server and cascading related objects (tools, configs)."""
+    # GATE 2 above the try: the broad `except Exception` below would re-wrap its 403 as a
+    # 500, hiding an authorization failure behind a server error.
     try:
-        # Ensure it exists
         server = get_mcp_server_by_id(server_id, db_session)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="MCP server not found")
+    _ensure_mcp_server_owner_or_admin(server, user)
 
-        _ensure_mcp_server_owner_or_admin(server, user)
-
+    try:
         # Log tools that will be deleted for debugging
         tools_to_delete = get_tools_by_mcp_server_id(server_id, db_session)
         logger.info(

--- a/backend/onyx/server/features/mcp/models.py
+++ b/backend/onyx/server/features/mcp/models.py
@@ -455,6 +455,8 @@ class MCPServer(BaseModel):
         None,
         description="Admin's credential key-value pairs for template substitution and storage",
     )
+    # Server-stamped affordance map; fail-closed empty (only the admin server list stamps it).
+    permissions: dict[str, bool] = Field(default_factory=dict)
 
 
 class MCPServersResponse(BaseModel):

--- a/backend/onyx/server/features/oauth_config/api.py
+++ b/backend/onyx/server/features/oauth_config/api.py
@@ -6,6 +6,7 @@ from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
 from onyx.auth.oauth_token_manager import OAuthTokenManager
+from onyx.auth.permissions import has_global_permission
 from onyx.auth.permissions import require_permission
 from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.db.engine.sql_engine import get_session
@@ -20,6 +21,8 @@ from onyx.db.oauth_config import get_oauth_configs
 from onyx.db.oauth_config import get_tools_by_oauth_config
 from onyx.db.oauth_config import update_oauth_config
 from onyx.db.oauth_config import upsert_user_oauth_token
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.federated_connectors.oauth_utils import generate_oauth_state
 from onyx.federated_connectors.oauth_utils import verify_oauth_state
 from onyx.server.features.oauth_config.models import OAuthCallbackResponse
@@ -59,13 +62,31 @@ def _oauth_config_to_snapshot(
 """Admin endpoints for OAuth configuration management"""
 
 
+def _assert_can_manage_oauth_config(
+    oauth_config: OAuthConfig, user: User, db_session: Session
+) -> None:
+    """Owner-or-admin gate: a global actions-admin manages any OAuth config; a scoped manager
+    manages one only when they own every action referencing it — editing shared credentials
+    would otherwise affect the other creators."""
+    if has_global_permission(user, Permission.MANAGE_ACTIONS):
+        return
+    tools = get_tools_by_oauth_config(oauth_config.id, db_session)
+    if tools and all(tool.user_id == user.id for tool in tools):
+        return
+    raise OnyxError(
+        OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+        "You can only manage OAuth configurations for actions that you created.",
+    )
+
+
 @admin_router.post("/create")
 def create_oauth_config_endpoint(
     oauth_data: OAuthConfigCreate,
     db_session: Session = Depends(get_session),
-    _: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    _: User = Depends(require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)),
 ) -> OAuthConfigSnapshot:
-    """Create a new OAuth configuration (admin only)."""
+    """Create a new OAuth configuration. A scoped manager may create one and link it to an
+    action they created; get/update/delete are then owner-or-admin."""
     try:
         oauth_config = create_oauth_config(
             name=oauth_data.name,
@@ -96,14 +117,18 @@ def list_oauth_configs(
 def get_oauth_config_endpoint(
     oauth_config_id: int,
     db_session: Session = Depends(get_session),
-    _: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> OAuthConfigSnapshot:
-    """Retrieve a single OAuth configuration (admin only)."""
+    """Retrieve a single OAuth configuration (owner or admin)."""
     oauth_config = get_oauth_config(oauth_config_id, db_session)
     if not oauth_config:
-        raise HTTPException(
-            status_code=404, detail=f"OAuth config with id {oauth_config_id} not found"
+        raise OnyxError(
+            OnyxErrorCode.NOT_FOUND,
+            f"OAuth config with id {oauth_config_id} not found",
         )
+    _assert_can_manage_oauth_config(oauth_config, user, db_session)
     return _oauth_config_to_snapshot(oauth_config, db_session)
 
 
@@ -112,9 +137,18 @@ def update_oauth_config_endpoint(
     oauth_config_id: int,
     oauth_data: OAuthConfigUpdate,
     db_session: Session = Depends(get_session),
-    _: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> OAuthConfigSnapshot:
-    """Update an OAuth configuration (admin only)."""
+    """Update an OAuth configuration (owner or admin)."""
+    existing_config = get_oauth_config(oauth_config_id, db_session)
+    if not existing_config:
+        raise OnyxError(
+            OnyxErrorCode.NOT_FOUND,
+            f"OAuth config with id {oauth_config_id} not found",
+        )
+    _assert_can_manage_oauth_config(existing_config, user, db_session)
     try:
         updated_config = update_oauth_config(
             oauth_config_id=oauth_config_id,
@@ -138,9 +172,18 @@ def update_oauth_config_endpoint(
 def delete_oauth_config_endpoint(
     oauth_config_id: int,
     db_session: Session = Depends(get_session),
-    _: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> dict[str, str]:
-    """Delete an OAuth configuration (admin only)."""
+    """Delete an OAuth configuration (owner or admin)."""
+    existing_config = get_oauth_config(oauth_config_id, db_session)
+    if not existing_config:
+        raise OnyxError(
+            OnyxErrorCode.NOT_FOUND,
+            f"OAuth config with id {oauth_config_id} not found",
+        )
+    _assert_can_manage_oauth_config(existing_config, user, db_session)
     try:
         delete_oauth_config(oauth_config_id, db_session)
         return {"message": "OAuth configuration deleted successfully"}

--- a/backend/onyx/server/features/persona/api.py
+++ b/backend/onyx/server/features/persona/api.py
@@ -13,6 +13,9 @@ from pydantic import model_validator
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from onyx.auth.permission_projection import persona_permissions
+from onyx.auth.permissions import has_global_permission
+from onyx.auth.permissions import has_permission
 from onyx.auth.permissions import require_permission
 from onyx.auth.users import current_chat_accessible_user
 from onyx.auth.users import current_limited_user
@@ -22,9 +25,13 @@ from onyx.configs.constants import MilestoneRecordType
 from onyx.configs.constants import PUBLIC_API_TAGS
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
+from onyx.db.enums import PermissionAuthority
 from onyx.db.enums import PersonaSharePermission
 from onyx.db.file_record import get_filerecord_by_file_id_optional
 from onyx.db.models import User
+from onyx.db.persona import can_delete_persona
+from onyx.db.persona import can_edit_persona
+from onyx.db.persona import can_view_persona_stats
 from onyx.db.persona import create_assistant_label
 from onyx.db.persona import create_update_persona
 from onyx.db.persona import delete_persona_label
@@ -35,6 +42,7 @@ from onyx.db.persona import get_persona_by_id
 from onyx.db.persona import get_persona_count_for_user
 from onyx.db.persona import get_persona_snapshots_for_user
 from onyx.db.persona import get_persona_snapshots_paginated
+from onyx.db.persona import is_persona_editable_by_user
 from onyx.db.persona import mark_persona_as_deleted
 from onyx.db.persona import mark_persona_as_not_deleted
 from onyx.db.persona import update_persona_featured
@@ -211,9 +219,18 @@ def patch_agents_display_priorities(
         raise HTTPException(status_code=403, detail=str(e))
 
 
+def _admin_list_get_editable(user: User, get_editable: bool) -> bool:
+    """GATE 2 (read) for the admin agent lists: pin a scoped manager to the editable set.
+    The non-editable branch of ``_add_user_filters`` has no scope restriction, so without
+    this they'd see every listed agent in the org. Global holders keep what they asked for."""
+    if has_permission(user, Permission.READ_AGENTS) is PermissionAuthority.SCOPED:
+        return True
+    return get_editable
+
+
 @admin_router.get("", tags=PUBLIC_API_TAGS)
 def list_personas_admin(
-    user: User = Depends(require_permission(Permission.READ_AGENTS)),
+    user: User = Depends(require_permission(Permission.READ_AGENTS, allow_scope=True)),
     db_session: Session = Depends(get_session),
     include_deleted: bool = False,
     get_editable: bool = Query(False, description="If true, return editable personas"),
@@ -221,7 +238,7 @@ def list_personas_admin(
     return get_persona_snapshots_for_user(
         user=user,
         db_session=db_session,
-        get_editable=get_editable,
+        get_editable=_admin_list_get_editable(user, get_editable),
         include_deleted=include_deleted,
     )
 
@@ -230,7 +247,7 @@ def list_personas_admin(
 def get_agents_admin_paginated(
     page_num: int = Query(0, ge=0, description="Page number (0-indexed)."),
     page_size: int = Query(10, ge=1, le=1000, description="Items per page."),
-    user: User = Depends(require_permission(Permission.READ_AGENTS)),
+    user: User = Depends(require_permission(Permission.READ_AGENTS, allow_scope=True)),
     db_session: Session = Depends(get_session),
     include_deleted: bool = Query(
         False, description="If true, includes deleted personas."
@@ -247,12 +264,14 @@ def get_agents_admin_paginated(
     Returns items for the requested page plus total count.
     Agents are ordered by display_priority (ASC, nulls last) then by ID (ASC).
     """
+    # Resolve once — the page and its total must use the same filter.
+    scoped_get_editable = _admin_list_get_editable(user, get_editable)
     agents = get_persona_snapshots_paginated(
         user=user,
         db_session=db_session,
         page_num=page_num,
         page_size=page_size,
-        get_editable=get_editable,
+        get_editable=scoped_get_editable,
         include_default=include_default,
         include_deleted=include_deleted,
     )
@@ -260,7 +279,7 @@ def get_agents_admin_paginated(
     total_count = get_persona_count_for_user(
         user=user,
         db_session=db_session,
-        get_editable=get_editable,
+        get_editable=scoped_get_editable,
         include_default=include_default,
         include_deleted=include_deleted,
     )
@@ -307,7 +326,7 @@ def upload_file(
 @basic_router.post("", tags=PUBLIC_API_TAGS)
 def create_persona(
     persona_upsert_request: PersonaUpsertRequest,
-    user: User = Depends(require_permission(Permission.ADD_AGENTS)),
+    user: User = Depends(require_permission(Permission.ADD_AGENTS, allow_scope=True)),
     db_session: Session = Depends(get_session),
 ) -> PersonaSnapshot:
     tenant_id = get_current_tenant_id()
@@ -337,7 +356,9 @@ def create_persona(
 def update_persona(
     persona_id: int,
     persona_upsert_request: PersonaUpsertRequest,
-    user: User = Depends(require_permission(Permission.ADD_AGENTS)),
+    # Editable is the gate (get_editable fetch in create_update_persona), not ADD_AGENTS — an
+    # editor-shared user should be able to edit the agent they were granted access to.
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> PersonaSnapshot:
     _validate_user_knowledge_enabled(persona_upsert_request, "update")
@@ -444,7 +465,9 @@ class PersonaShareRequest(BaseModel):
 def share_persona(
     persona_id: int,
     persona_share_request: PersonaShareRequest,
-    user: User = Depends(require_permission(Permission.ADD_AGENTS)),
+    # Editable is the gate (get_editable fetch in update_persona_shared), not ADD_AGENTS — an
+    # editor-shared user should still manage the agent's sharing.
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> None:
     user_shares = (
@@ -487,14 +510,25 @@ def share_persona(
 @basic_router.delete("/{persona_id}", tags=PUBLIC_API_TAGS)
 def delete_persona(
     persona_id: int,
-    user: User = Depends(require_permission(Permission.ADD_AGENTS)),
+    # allow_scope admits an owner who holds ADD_AGENTS only by scope; ownership is enforced
+    # below (mark_persona_as_deleted → get_persona_by_id).
+    user: User = Depends(require_permission(Permission.ADD_AGENTS, allow_scope=True)),
     db_session: Session = Depends(get_session),
 ) -> None:
-    mark_persona_as_deleted(
-        persona_id=persona_id,
-        user=user,
-        db_session=db_session,
-    )
+    try:
+        mark_persona_as_deleted(
+            persona_id=persona_id,
+            user=user,
+            db_session=db_session,
+        )
+    except ValueError as e:
+        logger.exception("Failed to delete persona")
+        # A non-owner failed the ownership check; its ValueError would 400 via the global
+        # handler, so surface the real authorization failure as a 403.
+        raise OnyxError(
+            OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+            "You can only delete agents you created.",
+        ) from e
 
 
 @basic_router.get("")
@@ -596,6 +630,31 @@ def get_persona(
     if user is not None:
         snapshot.user_permission = get_persona_access_level(
             persona, user, user_group_ids
+        )
+        is_editable = is_persona_editable_by_user(db_session, persona.id, user)
+        snapshot.permissions = persona_permissions(
+            can_edit=can_edit_persona(
+                user,
+                persona,
+                db_session,
+                is_editable=is_editable,
+                user_group_ids=user_group_ids,
+            ),
+            # share tracks the share guard (get_editable), broader than edit's scope gate
+            can_share=is_editable,
+            can_view_stats=can_view_persona_stats(user, persona),
+            can_delete=can_delete_persona(
+                user, persona, db_session, user_group_ids=user_group_ids
+            ),
+            # delete/publish also gate on ADD_AGENTS (GATE 1); edit/share don't
+            holds_add_agents=has_permission(user, Permission.ADD_AGENTS)
+            is not PermissionAuthority.NONE,
+            is_manage_agents_admin=has_global_permission(
+                user, Permission.MANAGE_AGENTS
+            ),
+            is_full_admin=has_global_permission(
+                user, Permission.FULL_ADMIN_PANEL_ACCESS
+            ),
         )
     return snapshot
 

--- a/backend/onyx/server/features/persona/models.py
+++ b/backend/onyx/server/features/persona/models.py
@@ -229,6 +229,10 @@ class MinimalPersonaSnapshot(BaseModel):
     owner_group: PersonaOwnerGroupSnapshot | None
     # Computed for the requesting user when the list endpoint provides it
     user_permission: PersonaAccessLevel | None = None
+    # Per-action affordance map for the requesting user; empty on paths that don't
+    # stamp it (fail-closed on the client). List endpoints stamp it so each card
+    # doesn't refetch the full agent just to gate its icons.
+    permissions: dict[str, bool] = Field(default_factory=dict)
 
     @classmethod
     def from_model(
@@ -327,6 +331,9 @@ class PersonaSnapshot(BaseModel):
     hierarchy_nodes: list[HierarchyNodeSnapshot] = Field(default_factory=list)
     # Individual documents attached for scoped search
     attached_documents: list[AttachedDocumentSnapshot] = Field(default_factory=list)
+    # Per-action affordance map for the requesting user, stamped by the endpoint. Empty
+    # where unstamped, so the client fails closed. Inherited by FullPersonaSnapshot.
+    permissions: dict[str, bool] = Field(default_factory=dict)
 
     # Embedded prompt fields (no longer separate prompt_ids)
     system_prompt: str | None = None

--- a/backend/onyx/server/features/skill/api.py
+++ b/backend/onyx/server/features/skill/api.py
@@ -13,7 +13,6 @@ from sqlalchemy.orm import Session
 
 from onyx.auth.permissions import Permission
 from onyx.auth.permissions import require_permission
-from onyx.auth.users import current_curator_or_admin_user
 from onyx.configs.app_configs import MAX_PERSONAL_SKILLS_PER_USER
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import Skill
@@ -170,7 +169,7 @@ def _ensure_owned_personal(skill: Skill, user: User, db_session: Session) -> Non
 
 @admin_router.get("")
 def list_skills_admin(
-    _: User = Depends(current_curator_or_admin_user),
+    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> SkillsList:
     rows = list(list_skills_for_admin(db_session=db_session))
@@ -183,7 +182,7 @@ def create_custom_skill(
     is_public: bool = Form(False),
     group_ids: str = Form("[]"),
     bundle: UploadFile = File(...),
-    user: User = Depends(current_curator_or_admin_user),
+    user: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> CustomSkillResponse:
     parsed_group_ids = _parse_group_ids(group_ids)
@@ -220,7 +219,7 @@ def create_custom_skill(
 def patch_custom_skill(
     skill_id: UUID,
     patch_req: SkillPatchRequest,
-    _: User = Depends(current_curator_or_admin_user),
+    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> CustomSkillResponse:
     """Toggle ``enabled``/``is_public`` on a custom skill. Built-in
@@ -256,7 +255,7 @@ def patch_custom_skill(
 def replace_custom_skill_bundle(
     skill_id: UUID,
     bundle: UploadFile = File(...),
-    _: User = Depends(current_curator_or_admin_user),
+    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> CustomSkillResponse:
     skill = fetch_skill_by_id(skill_id, db_session)
@@ -294,7 +293,7 @@ def replace_custom_skill_bundle(
 def replace_custom_skill_grants(
     skill_id: UUID,
     body: GrantsReplace,
-    _: User = Depends(current_curator_or_admin_user),
+    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> CustomSkillResponse:
     skill = fetch_skill_by_id(skill_id, db_session)
@@ -319,7 +318,7 @@ def replace_custom_skill_grants(
 @admin_router.delete("/custom/{skill_id}")
 def delete_custom_skill(
     skill_id: UUID,
-    _: User = Depends(current_curator_or_admin_user),
+    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> None:
     skill = fetch_skill_by_id(skill_id, db_session)

--- a/backend/onyx/server/features/skill/api.py
+++ b/backend/onyx/server/features/skill/api.py
@@ -11,10 +11,17 @@ from fastapi import UploadFile
 from pydantic import Field
 from sqlalchemy.orm import Session
 
+from onyx.auth.permission_projection import custom_skill_permissions
+from onyx.auth.permissions import has_global_permission
+from onyx.auth.permissions import has_permission
 from onyx.auth.permissions import Permission
 from onyx.auth.permissions import require_permission
+from onyx.auth.scoped_permissions import assert_within_scope
+from onyx.auth.scoped_permissions import get_scoped_groups
+from onyx.auth.scoped_permissions import within_scope
 from onyx.configs.app_configs import MAX_PERSONAL_SKILLS_PER_USER
 from onyx.db.engine.sql_engine import get_session
+from onyx.db.enums import PermissionAuthority
 from onyx.db.models import Skill
 from onyx.db.models import User
 from onyx.db.skill import affected_user_ids_for_skill
@@ -69,6 +76,7 @@ def _split_rows(
     db_session: Session,
     *,
     include_grants: bool,
+    user: User | None = None,
 ) -> tuple[list[BuiltinSkillResponse], list[CustomSkillResponse]]:
     """Partition a flat row list into built-in + custom responses.
 
@@ -76,9 +84,27 @@ def _split_rows(
     in code without cleaning up the seeded row) is logged and dropped —
     we don't surface a half-broken built-in to admins. ``include_grants``
     only applies to custom skills; built-ins are not group-shareable.
+
+    When ``user`` is given (the admin listing), each custom skill is stamped with
+    its per-action affordance map, resolved once from the manager's scope.
     """
     builtins: list[BuiltinSkillResponse] = []
     customs: list[CustomSkillResponse] = []
+
+    # Resolved once so per-skill stamping issues no query. Only a SCOPED caller reads it
+    # (within_scope short-circuits for GLOBAL/NONE), so skip fetching it otherwise.
+    managed_skill_groups: set[int] | None = None
+    is_skills_full_admin = False
+    is_skills_admin = False
+    if user is not None:
+        if has_permission(user, Permission.MANAGE_SKILLS) is PermissionAuthority.SCOPED:
+            managed_skill_groups = get_scoped_groups(
+                user, db_session, Permission.MANAGE_SKILLS
+            )
+        is_skills_full_admin = has_global_permission(
+            user, Permission.FULL_ADMIN_PANEL_ACCESS
+        )
+        is_skills_admin = has_global_permission(user, Permission.MANAGE_SKILLS)
 
     # User paths withhold group ids but still need grant existence so a
     # grants-shared skill isn't reported as personal.
@@ -102,7 +128,27 @@ def _split_rows(
             )
         elif include_grants:
             group_ids = get_group_ids_for_skill(skill.id, db_session)
-            customs.append(CustomSkillResponse.from_model(skill, group_ids=group_ids))
+            skill_perms: dict[str, bool] | None = None
+            if user is not None:
+                # Read-affordance mirroring the patch guard: within_scope on the skill's own groups.
+                skill_perms = custom_skill_permissions(
+                    can_edit=within_scope(
+                        user,
+                        db_session,
+                        permission=Permission.MANAGE_SKILLS,
+                        current_group_ids=group_ids,
+                        requested_group_ids=group_ids,
+                        is_non_public=not skill.is_public,
+                        managed_group_ids=managed_skill_groups,
+                    ),
+                    is_full_admin=is_skills_full_admin,
+                    is_skills_admin=is_skills_admin,
+                )
+            customs.append(
+                CustomSkillResponse.from_model(
+                    skill, group_ids=group_ids, permissions=skill_perms
+                )
+            )
         else:
             customs.append(
                 CustomSkillResponse.from_model(
@@ -169,11 +215,13 @@ def _ensure_owned_personal(skill: Skill, user: User, db_session: Session) -> Non
 
 @admin_router.get("")
 def list_skills_admin(
-    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_SKILLS, allow_scope=True)
+    ),
     db_session: Session = Depends(get_session),
 ) -> SkillsList:
-    rows = list(list_skills_for_admin(db_session=db_session))
-    builtins, customs = _split_rows(rows, db_session, include_grants=True)
+    rows = list(list_skills_for_admin(db_session=db_session, user=user))
+    builtins, customs = _split_rows(rows, db_session, include_grants=True, user=user)
     return SkillsList(builtins=builtins, customs=customs)
 
 
@@ -182,10 +230,22 @@ def create_custom_skill(
     is_public: bool = Form(False),
     group_ids: str = Form("[]"),
     bundle: UploadFile = File(...),
-    user: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_SKILLS, allow_scope=True)
+    ),
     db_session: Session = Depends(get_session),
 ) -> CustomSkillResponse:
     parsed_group_ids = _parse_group_ids(group_ids)
+    # GATE 2: a scoped manager may only create a PRIVATE skill in groups they
+    # manage (admins bypass). No skill exists yet, so current groups are empty.
+    assert_within_scope(
+        user,
+        db_session,
+        permission=Permission.MANAGE_SKILLS,
+        current_group_ids=[],
+        requested_group_ids=parsed_group_ids,
+        is_non_public=not is_public,
+    )
     _reject_reserved_slug(bundle)
 
     file_store = get_default_file_store()
@@ -219,7 +279,9 @@ def create_custom_skill(
 def patch_custom_skill(
     skill_id: UUID,
     patch_req: SkillPatchRequest,
-    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_SKILLS, allow_scope=True)
+    ),
     db_session: Session = Depends(get_session),
 ) -> CustomSkillResponse:
     """Toggle ``enabled``/``is_public`` on a custom skill. Built-in
@@ -230,6 +292,22 @@ def patch_custom_skill(
     if skill is None:
         raise OnyxError(OnyxErrorCode.NOT_FOUND, "Skill not found")
     _ensure_custom(skill)
+
+    # GATE 2: a scoped manager may only patch a skill within managed scope and
+    # never publish it out of scope (admins bypass). Groups are unchanged, so
+    # anchor is_non_public on both current and requested privacy.
+    requested_is_public = (
+        skill.is_public if patch_req.is_public is None else patch_req.is_public
+    )
+    skill_group_ids = get_group_ids_for_skill(skill_id, db_session)
+    assert_within_scope(
+        user,
+        db_session,
+        permission=Permission.MANAGE_SKILLS,
+        current_group_ids=skill_group_ids,
+        requested_group_ids=skill_group_ids,
+        is_non_public=not skill.is_public and not requested_is_public,
+    )
 
     # SQLAlchemy identity map mutates in place; snapshot before patch.
     old_is_public = skill.is_public
@@ -255,13 +333,27 @@ def patch_custom_skill(
 def replace_custom_skill_bundle(
     skill_id: UUID,
     bundle: UploadFile = File(...),
-    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_SKILLS, allow_scope=True)
+    ),
     db_session: Session = Depends(get_session),
 ) -> CustomSkillResponse:
     skill = fetch_skill_by_id(skill_id, db_session)
     if skill is None:
         raise OnyxError(OnyxErrorCode.NOT_FOUND, "Skill not found")
     _ensure_custom(skill)
+
+    # GATE 2: content-only edit; scope a manager to their own PRIVATE skills
+    # (groups unchanged; admins bypass).
+    skill_group_ids = get_group_ids_for_skill(skill_id, db_session)
+    assert_within_scope(
+        user,
+        db_session,
+        permission=Permission.MANAGE_SKILLS,
+        current_group_ids=skill_group_ids,
+        requested_group_ids=skill_group_ids,
+        is_non_public=not skill.is_public,
+    )
 
     file_store = get_default_file_store()
     ingested = ingest_skill_bundle(
@@ -293,13 +385,26 @@ def replace_custom_skill_bundle(
 def replace_custom_skill_grants(
     skill_id: UUID,
     body: GrantsReplace,
-    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_SKILLS, allow_scope=True)
+    ),
     db_session: Session = Depends(get_session),
 ) -> CustomSkillResponse:
     skill = fetch_skill_by_id(skill_id, db_session)
     if skill is None:
         raise OnyxError(OnyxErrorCode.NOT_FOUND, "Skill not found")
     _ensure_custom(skill)
+
+    # GATE 2: current ∪ requested groups ⊆ managed + PRIVATE (admins bypass) —
+    # blocks granting to unmanaged groups and capture-by-reassignment.
+    assert_within_scope(
+        user,
+        db_session,
+        permission=Permission.MANAGE_SKILLS,
+        current_group_ids=get_group_ids_for_skill(skill_id, db_session),
+        requested_group_ids=body.group_ids,
+        is_non_public=not skill.is_public,
+    )
 
     before_affected = affected_user_ids_for_skill(skill, db_session)
 

--- a/backend/onyx/server/features/skill/models.py
+++ b/backend/onyx/server/features/skill/models.py
@@ -6,6 +6,7 @@ from typing import Literal
 from uuid import UUID
 
 from pydantic import BaseModel
+from pydantic import Field
 from pydantic import model_validator
 from sqlalchemy.orm import Session
 
@@ -60,6 +61,8 @@ class CustomSkillResponse(BaseModel):
     updated_at: datetime.datetime | None = None
     granted_group_ids: list[int] = []
     is_personal: bool
+    # Server-stamped affordance map; fail-closed empty (only the admin skills list stamps it).
+    permissions: dict[str, bool] = Field(default_factory=dict)
 
     @classmethod
     def from_model(
@@ -68,6 +71,7 @@ class CustomSkillResponse(BaseModel):
         group_ids: list[int],
         *,
         has_grants: bool | None = None,
+        permissions: dict[str, bool] | None = None,
     ) -> "CustomSkillResponse":
         # Paths that withhold group ids from the response (user-facing) must
         # still pass grant existence so grants-shared skills aren't marked
@@ -77,6 +81,7 @@ class CustomSkillResponse(BaseModel):
             skill.built_in_skill_id is None and not skill.is_public and not grants_exist
         )
         return cls(
+            permissions=permissions or {},
             id=skill.id,
             slug=skill.slug,
             name=skill.name,

--- a/backend/onyx/server/features/tool/api.py
+++ b/backend/onyx/server/features/tool/api.py
@@ -6,13 +6,16 @@ from fastapi import HTTPException
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
-from onyx.auth.permissions import get_effective_permissions
+from onyx.auth.permission_projection import tool_permissions
 from onyx.auth.permissions import require_permission
 from onyx.configs.constants import PUBLIC_API_TAGS
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
 from onyx.db.models import Tool
 from onyx.db.models import User
+from onyx.db.oauth_config import get_oauth_config
+from onyx.db.tools import can_link_oauth_config
+from onyx.db.tools import can_manage_tool
 from onyx.db.tools import create_tool__no_commit
 from onyx.db.tools import delete_tool__no_commit
 from onyx.db.tools import get_tool_by_id
@@ -55,40 +58,64 @@ def _validate_auth_settings(tool_data: CustomToolCreate | CustomToolUpdate) -> N
                 )
 
 
-def _get_editable_custom_tool(tool_id: int, db_session: Session, user: User) -> Tool:
-    """Fetch a custom tool and ensure the caller has permission to edit it."""
+def _get_manageable_custom_tool(tool_id: int, db_session: Session, user: User) -> Tool:
+    """Fetch a custom tool and assert the caller may manage it (owner or admin) — the gate for
+    every action on it: edit, delete, toggle, and OAuth config."""
     try:
         tool = get_tool_by_id(tool_id, db_session)
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
-
     if tool.in_code_tool_id is not None:
         raise HTTPException(
             status_code=400,
             detail="Built-in tools cannot be modified through this endpoint.",
         )
-
-    # Admins can always make changes; non-admins must own the tool.
-    if Permission.FULL_ADMIN_PANEL_ACCESS in get_effective_permissions(user):
-        return tool
-
-    if tool.user_id is None or tool.user_id != user.id:
+    if not can_manage_tool(user, tool):
         raise OnyxError(
             OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
-            "You can only modify actions that you created.",
+            "You can only manage actions you created, or ones belonging to an "
+            "MCP server you own.",
         )
-
     return tool
+
+
+def _assert_can_link_oauth_config(
+    oauth_config_id: int | None,
+    db_session: Session,
+    user: User,
+    current_oauth_config_id: int | None = None,
+) -> None:
+    """GATE 2 for the OAuth config an action points at — the route's own gate only covers
+    the action itself. Authorizes the *change*: re-sending the config the action already
+    uses is no new link, so an admin sharing one across creators can't lock them out of
+    ordinary edits (the editor round-trips the id on every save)."""
+    if oauth_config_id is None or oauth_config_id == current_oauth_config_id:
+        return
+    # Before asking who references it, establish it exists: an unknown id has no referencing
+    # actions, so the gate would pass it through to the FK and surface as a 500.
+    if get_oauth_config(oauth_config_id, db_session) is None:
+        raise OnyxError(
+            OnyxErrorCode.NOT_FOUND,
+            f"OAuth config with id {oauth_config_id} not found",
+        )
+    if not can_link_oauth_config(user, oauth_config_id, db_session):
+        raise OnyxError(
+            OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+            "You can only use OAuth configurations that no other creator's action uses.",
+        )
 
 
 @admin_router.post("/custom", tags=PUBLIC_API_TAGS)
 def create_custom_tool(
     tool_data: CustomToolCreate,
     db_session: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> ToolSnapshot:
     _validate_tool_definition(tool_data.definition)
     _validate_auth_settings(tool_data)
+    _assert_can_link_oauth_config(tool_data.oauth_config_id, db_session, user)
     tool = create_tool__no_commit(
         name=tool_data.name,
         description=tool_data.description,
@@ -109,12 +136,20 @@ def update_custom_tool(
     tool_id: int,
     tool_data: CustomToolUpdate,
     db_session: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> ToolSnapshot:
-    existing_tool = _get_editable_custom_tool(tool_id, db_session, user)
+    existing_tool = _get_manageable_custom_tool(tool_id, db_session, user)
     if tool_data.definition:
         _validate_tool_definition(tool_data.definition)
     _validate_auth_settings(tool_data)
+    _assert_can_link_oauth_config(
+        tool_data.oauth_config_id,
+        db_session,
+        user,
+        current_oauth_config_id=existing_tool.oauth_config_id,
+    )
     updated_tool = update_tool(
         tool_id=tool_id,
         name=tool_data.name,
@@ -133,9 +168,11 @@ def update_custom_tool(
 def delete_custom_tool(
     tool_id: int,
     db_session: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> None:
-    _ = _get_editable_custom_tool(tool_id, db_session, user)
+    _ = _get_manageable_custom_tool(tool_id, db_session, user)
     try:
         delete_tool__no_commit(tool_id, db_session)
     except ValueError as e:
@@ -160,7 +197,9 @@ class ToolStatusUpdateResponse(BaseModel):
 def update_tools_status(
     update_data: ToolStatusUpdateRequest,
     db_session: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),  # noqa: ARG001
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> ToolStatusUpdateResponse:
     """Enable or disable one or more tools.
 
@@ -179,6 +218,12 @@ def update_tools_status(
     for tool_id in update_data.tool_ids:
         tool = tools_by_id.get(tool_id)
         if tool:
+            if not can_manage_tool(user, tool):
+                raise OnyxError(
+                    OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+                    "You can only enable or disable actions you created, or ones "
+                    "belonging to an MCP server you own.",
+                )
             tool.enabled = update_data.enabled
             updated_tools.append(tool_id)
         else:
@@ -208,7 +253,7 @@ class ValidateToolResponse(BaseModel):
 @admin_router.post("/custom/validate", tags=PUBLIC_API_TAGS)
 def validate_tool(
     tool_data: ValidateToolRequest,
-    _: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    _: User = Depends(require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)),
 ) -> ValidateToolResponse:
     _validate_tool_definition(tool_data.definition)
     method_specs = openapi_to_method_specs(tool_data.definition)
@@ -221,16 +266,22 @@ def validate_tool(
 @router.get("/openapi", tags=PUBLIC_API_TAGS)
 def list_openapi_tools(
     db_session: Session = Depends(get_session),
-    _: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
 ) -> list[ToolSnapshot]:
     tools = get_tools(db_session, only_openapi=True)
 
+    # Every action affordance is owner-or-admin, decided per tool with no query.
     openapi_tools: list[ToolSnapshot] = []
     for tool in tools:
         if not should_expose_tool_to_fe(tool):
             continue
 
-        openapi_tools.append(ToolSnapshot.from_model(tool))
+        openapi_tools.append(
+            ToolSnapshot.from_model(
+                tool,
+                permissions=tool_permissions(can_manage=can_manage_tool(user, tool)),
+            )
+        )
 
     return openapi_tools
 

--- a/backend/onyx/server/features/tool/models.py
+++ b/backend/onyx/server/features/tool/models.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from pydantic import BaseModel
+from pydantic import Field
 
 from onyx.db.models import Tool
 from onyx.server.features.tool.tool_visibility import get_tool_visibility_config
@@ -21,17 +22,23 @@ class ToolSnapshot(BaseModel):
     oauth_config_name: str | None = None
     enabled: bool = True
 
+    # Server-stamped affordance map; fail-closed empty (only the admin actions list stamps it).
+    permissions: dict[str, bool] = Field(default_factory=dict)
+
     # Visibility settings computed from TOOL_VISIBILITY_CONFIG
     chat_selectable: bool = True
     agent_creation_selectable: bool = True
     default_enabled: bool = False
 
     @classmethod
-    def from_model(cls, tool: Tool) -> "ToolSnapshot":
+    def from_model(
+        cls, tool: Tool, *, permissions: dict[str, bool] | None = None
+    ) -> "ToolSnapshot":
         # Get visibility config for this tool
         config = get_tool_visibility_config(tool)
 
         return cls(
+            permissions=permissions or {},
             id=tool.id,
             name=tool.name,
             description=tool.description or "",

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -15,7 +15,7 @@ from fastapi import Query
 from pydantic import ValidationError
 from sqlalchemy.orm import Session
 
-from onyx.auth.permissions import has_permission
+from onyx.auth.permissions import has_global_permission
 from onyx.auth.permissions import require_permission
 from onyx.auth.users import current_chat_accessible_user
 from onyx.db.engine.sql_engine import get_session
@@ -761,7 +761,7 @@ def list_llm_provider_basics(
     start_time = datetime.now(timezone.utc)
     logger.debug("Starting to fetch user-accessible LLM providers")
 
-    can_manage_llms = has_permission(user, Permission.MANAGE_LLMS)
+    can_manage_llms = has_global_permission(user, Permission.MANAGE_LLMS)
     user_group_ids = (
         set() if can_manage_llms else fetch_user_group_ids(db_session, user)
     )
@@ -830,7 +830,7 @@ def get_valid_model_names_for_persona(
     if not persona:
         return []
 
-    can_manage_llms = has_permission(user, Permission.MANAGE_LLMS)
+    can_manage_llms = has_global_permission(user, Permission.MANAGE_LLMS)
     all_providers = fetch_existing_llm_providers(
         db_session, [LLMModelFlowType.CHAT, LLMModelFlowType.VISION]
     )
@@ -862,7 +862,7 @@ def get_valid_model_configuration_ids_for_persona(
     Unlike `get_valid_model_names_for_persona`, this check is unambiguous when
     multiple providers expose a model with the same name.
     """
-    can_manage_llms = has_permission(user, Permission.MANAGE_LLMS)
+    can_manage_llms = has_global_permission(user, Permission.MANAGE_LLMS)
     all_providers = fetch_existing_llm_providers(
         db_session, [LLMModelFlowType.CHAT, LLMModelFlowType.VISION]
     )
@@ -910,7 +910,7 @@ def list_llm_providers_for_persona(
             "You don't have access to this assistant",
         )
 
-    can_manage_llms = has_permission(user, Permission.MANAGE_LLMS)
+    can_manage_llms = has_global_permission(user, Permission.MANAGE_LLMS)
     user_group_ids = (
         set() if can_manage_llms else fetch_user_group_ids(db_session, user)
     )

--- a/backend/onyx/server/manage/models.py
+++ b/backend/onyx/server/manage/models.py
@@ -10,6 +10,7 @@ from pydantic import Field
 from pydantic import field_validator
 from pydantic import model_validator
 
+from onyx.auth.permissions import SCOPED_MANAGER_PERMISSIONS_EXPANDED
 from onyx.configs.constants import AuthType
 from onyx.context.search.models import SavedSearchSettings
 from onyx.db.enums import AccountType
@@ -43,6 +44,15 @@ class EmailInviteStatus(str, Enum):
 class BulkInviteResponse(BaseModel):
     invited_count: int
     email_invite_status: EmailInviteStatus
+
+
+class UserPermissionsResponse(BaseModel):
+    # The user's global effective permissions (implication-expanded).
+    permissions: list[str]
+    # Whether the user manages any group, plus the ids of those groups — lets the
+    # frontend reveal manager nav. Not a security boundary (backend GATE 2 enforces).
+    is_manager: bool
+    managed_group_ids: list[int]
 
 
 class VersionResponse(BaseModel):
@@ -119,6 +129,18 @@ class TenantInfo(BaseModel):
     new_tenant: TenantSnapshot | None = None
 
 
+def _admin_capabilities(
+    effective_permissions: list[str], is_group_manager: bool
+) -> list[str]:
+    """Admin-area reach = effective tokens plus the scoped manager bundle when the user
+    manages any group. ``effective_permissions`` itself stays global-only, so org-wide
+    gates that read it still exclude managers. Affordance hint, never an authz input."""
+    caps = set(effective_permissions)
+    if is_group_manager:
+        caps |= SCOPED_MANAGER_PERMISSIONS_EXPANDED
+    return sorted(caps)
+
+
 class UserInfo(BaseModel):
     id: str
     email: str
@@ -137,6 +159,11 @@ class UserInfo(BaseModel):
     password_configured: bool | None = None
     tenant_info: TenantInfo | None = None
     effective_permissions: list[str] = Field(default_factory=list)
+    # True if the user manages any group — lets the client reveal manager nav.
+    # Not a security boundary (backend GATE 2 enforces scope).
+    is_group_manager: bool = False
+    # effective tokens plus the scoped bundle for a manager; drives admin-nav reveal
+    admin_capabilities: list[str] = Field(default_factory=list)
 
     @classmethod
     def from_model(
@@ -194,6 +221,10 @@ class UserInfo(BaseModel):
             is_anonymous_user=is_anonymous_user,
             tenant_info=tenant_info,
             effective_permissions=effective_permissions or [],
+            is_group_manager=user.is_group_manager,
+            admin_capabilities=_admin_capabilities(
+                effective_permissions or [], user.is_group_manager
+            ),
             personalization=UserPersonalization(
                 name=user.personal_name or "",
                 role=user.personal_role or "",

--- a/backend/onyx/server/manage/users.py
+++ b/backend/onyx/server/manage/users.py
@@ -29,6 +29,7 @@ from onyx.auth.invited_users import remove_user_from_invited_users
 from onyx.auth.invited_users import write_invited_users
 from onyx.auth.permissions import get_effective_permissions
 from onyx.auth.permissions import require_permission
+from onyx.auth.scoped_permissions import get_scoped_groups
 from onyx.auth.users import anonymous_user_enabled
 from onyx.auth.users import enforce_seat_limit_locked
 from onyx.auth.users import optional_user
@@ -104,6 +105,7 @@ from onyx.server.manage.models import TenantSnapshot
 from onyx.server.manage.models import ThemePreferenceRequest
 from onyx.server.manage.models import UserByEmail
 from onyx.server.manage.models import UserInfo
+from onyx.server.manage.models import UserPermissionsResponse
 from onyx.server.manage.models import UserPreferences
 from onyx.server.manage.models import UserSpecificAssistantPreference
 from onyx.server.manage.models import UserSpecificAssistantPreferences
@@ -863,8 +865,13 @@ def _get_token_created_at(
 @router.get("/me/permissions", tags=PUBLIC_API_TAGS)
 def get_current_user_permissions(
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
-) -> list[str]:
-    return sorted(p.value for p in get_effective_permissions(user))
+    db_session: Session = Depends(get_session),
+) -> UserPermissionsResponse:
+    return UserPermissionsResponse(
+        permissions=sorted(p.value for p in get_effective_permissions(user)),
+        is_manager=user.is_group_manager,
+        managed_group_ids=sorted(get_scoped_groups(user, db_session)),
+    )
 
 
 @router.get("/me", tags=PUBLIC_API_TAGS, dependencies=[Depends(scope_exempt)])

--- a/backend/onyx/server/token_rate_limits/api.py
+++ b/backend/onyx/server/token_rate_limits/api.py
@@ -60,13 +60,15 @@ def update_token_limit_settings(
     _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> TokenRateLimitDisplay:
-    return TokenRateLimitDisplay.from_db(
+    rate_limit_display = TokenRateLimitDisplay.from_db(
         update_token_rate_limit(
             db_session=db_session,
             token_rate_limit_id=token_rate_limit_id,
             token_rate_limit_settings=token_limit_settings,
         )
     )
+    any_rate_limit_exists.cache_clear()
+    return rate_limit_display
 
 
 @router.delete("/rate-limit/{token_rate_limit_id}")

--- a/backend/tests/external_dependency_unit/auth/test_permission_projection_contract.py
+++ b/backend/tests/external_dependency_unit/auth/test_permission_projection_contract.py
@@ -1,0 +1,1085 @@
+"""The read-side permission projection must equal write-side enforcement.
+
+Each test drives the REAL guard and asserts the extracted boolean the projection
+stamps matches whether the guard raises, across an actor matrix — so the affordance
+the client renders can't silently drift from what the backend enforces.
+"""
+
+import asyncio
+import inspect
+from collections.abc import Callable
+from types import SimpleNamespace
+from uuid import uuid4
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from ee.onyx.db.analytics import user_can_view_assistant_stats
+from ee.onyx.db.token_limit import insert_user_group_token_rate_limit
+from ee.onyx.server.token_rate_limits.api import _authorize_group_token_rate_limit_write
+from ee.onyx.server.token_rate_limits.api import get_group_token_limit_settings
+from ee.onyx.server.user_group.api import delete_user_group
+from ee.onyx.server.user_group.api import set_user_group_permissions
+from onyx.auth.permission_projection import CC_PAIR_ACTIONS
+from onyx.auth.permission_projection import cc_pair_permissions
+from onyx.auth.permission_projection import CUSTOM_SKILL_ACTIONS
+from onyx.auth.permission_projection import custom_skill_permissions
+from onyx.auth.permission_projection import DOCUMENT_SET_ACTIONS
+from onyx.auth.permission_projection import document_set_permissions
+from onyx.auth.permission_projection import MCP_SERVER_ACTIONS
+from onyx.auth.permission_projection import mcp_server_permissions
+from onyx.auth.permission_projection import PERSONA_ACTIONS
+from onyx.auth.permission_projection import persona_permissions
+from onyx.auth.permission_projection import TOOL_ACTIONS
+from onyx.auth.permission_projection import tool_permissions
+from onyx.auth.permission_projection import USER_GROUP_ACTIONS
+from onyx.auth.permission_projection import user_group_permissions
+from onyx.auth.permissions import has_global_permission
+from onyx.auth.permissions import has_permission
+from onyx.auth.scoped_permissions import assert_manages_group
+from onyx.auth.scoped_permissions import assert_within_scope
+from onyx.auth.scoped_permissions import manages_group
+from onyx.auth.scoped_permissions import within_scope
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.models import InputType
+from onyx.db.connector_credential_pair import (
+    get_connector_credential_pair_from_id_for_user,
+)
+from onyx.db.document_set import fetch_all_document_sets_for_user
+from onyx.db.enums import AccessType
+from onyx.db.enums import ConnectorCredentialPairStatus
+from onyx.db.enums import MCPServerStatus
+from onyx.db.enums import Permission
+from onyx.db.enums import PermissionAuthority
+from onyx.db.enums import PersonaSharePermission
+from onyx.db.models import Connector
+from onyx.db.models import ConnectorCredentialPair
+from onyx.db.models import Credential
+from onyx.db.models import DocumentSet
+from onyx.db.models import DocumentSet__UserGroup
+from onyx.db.models import MCPServer
+from onyx.db.models import Persona
+from onyx.db.models import Persona__Tool
+from onyx.db.models import Persona__User
+from onyx.db.models import Persona__UserGroup
+from onyx.db.models import Skill
+from onyx.db.models import Skill__UserGroup
+from onyx.db.models import TokenRateLimit__UserGroup
+from onyx.db.models import Tool
+from onyx.db.models import User
+from onyx.db.models import User__UserGroup
+from onyx.db.models import UserGroup
+from onyx.db.models import UserGroup__ConnectorCredentialPair
+from onyx.db.persona import _assert_persona_update_within_managed_scope
+from onyx.db.persona import can_delete_persona
+from onyx.db.persona import can_edit_persona
+from onyx.db.persona import can_view_persona_stats
+from onyx.db.persona import fetch_persona_by_id_for_user
+from onyx.db.persona import get_persona_by_id
+from onyx.db.persona import is_persona_editable_by_user
+from onyx.db.persona import persona_edit_within_scope
+from onyx.db.skill import get_group_ids_for_skill
+from onyx.db.token_limit import insert_global_token_rate_limit
+from onyx.db.tools import can_manage_mcp_server
+from onyx.db.tools import can_manage_tool
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.features.mcp.api import _ensure_mcp_server_owner_or_admin
+from onyx.server.features.mcp.api import _ensure_mcp_server_viewable
+from onyx.server.features.persona.api import delete_persona
+from onyx.server.features.persona.models import PersonaUpsertRequest
+from onyx.server.features.tool.api import _get_manageable_custom_tool
+from onyx.server.manage.administrative import create_deletion_attempt_for_connector_id
+from onyx.server.token_rate_limits.models import TokenRateLimitArgs
+from tests.external_dependency_unit.conftest import create_test_user
+
+
+def _guard_raises(
+    guard: Callable[..., object], *args: object, **kwargs: object
+) -> bool:
+    try:
+        guard(*args, **kwargs)
+        return False
+    except OnyxError:
+        return True
+
+
+def _route_admits(
+    route_func: Callable[..., object], guard_param: str, actor: User
+) -> bool:
+    """True iff the route's ``require_permission`` admits ``actor`` (unrestricted token).
+    Runs the real dependency, so the assertion tracks the route decorator — not the bool
+    that built the map, which can't catch a FULL_ADMIN vs MANAGE_USER_GROUPS drift."""
+    depends = inspect.signature(route_func).parameters[guard_param].default
+    request = SimpleNamespace(state=SimpleNamespace(token_scopes=None))
+    return not _guard_raises(lambda: asyncio.run(depends.dependency(request, actor)))
+
+
+def _make_group(db_session: Session) -> UserGroup:
+    group = UserGroup(name=f"proj-contract-{uuid4().hex[:12]}")
+    db_session.add(group)
+    db_session.flush()
+    return group
+
+
+def _manage(db_session: Session, user: User, *groups: UserGroup) -> None:
+    for group in groups:
+        db_session.add(
+            User__UserGroup(user_id=user.id, user_group_id=group.id, is_manager=True)
+        )
+    user.is_group_manager = True
+    db_session.commit()
+
+
+def _make_cc_pair(
+    db_session: Session, *, is_public: bool, groups: list[UserGroup]
+) -> ConnectorCredentialPair:
+    connector = Connector(
+        name=f"proj-conn-{uuid4().hex[:12]}",
+        source=DocumentSource.FILE,
+        input_type=InputType.POLL,
+        connector_specific_config={},
+        refresh_freq=None,
+        prune_freq=None,
+        indexing_start=None,
+    )
+    db_session.add(connector)
+    db_session.flush()
+
+    credential = Credential(source=DocumentSource.FILE, credential_json={})
+    db_session.add(credential)
+    db_session.flush()
+
+    cc_pair = ConnectorCredentialPair(
+        connector_id=connector.id,
+        credential_id=credential.id,
+        name=f"proj-ccpair-{uuid4().hex[:12]}",
+        status=ConnectorCredentialPairStatus.ACTIVE,
+        access_type=AccessType.PUBLIC if is_public else AccessType.PRIVATE,
+    )
+    db_session.add(cc_pair)
+    db_session.flush()
+    for group in groups:
+        db_session.add(
+            UserGroup__ConnectorCredentialPair(
+                user_group_id=group.id, cc_pair_id=cc_pair.id, is_current=True
+            )
+        )
+    db_session.commit()
+    return cc_pair
+
+
+def test_cc_pair_projection_matches_gates(db_session: Session) -> None:
+    """Each key is pinned to the real route, not the bool that built it: edit → the editable
+    query (which must agree with the within_scope write decision); delete → the deletion route's
+    GATE 1 (global MANAGE_CONNECTORS, no allow_scope); publish → the associate route's real GATE 2
+    (assert_within_scope for the PUBLIC state). So this fails if either route starts admitting a
+    scoped manager — a scoped manager edits a managed connector but can never delete/publish it."""
+    managed = _make_group(db_session)
+
+    in_scope = create_test_user(db_session, "proj-cc-inscope")
+    _manage(db_session, in_scope, managed)
+    in_scope.effective_permissions = []
+
+    out_scope = create_test_user(db_session, "proj-cc-outscope")
+    _manage(db_session, out_scope, _make_group(db_session))
+    out_scope.effective_permissions = []
+
+    admin = create_test_user(db_session, "proj-cc-admin", is_admin=True)
+    db_session.commit()
+
+    cc_pair = _make_cc_pair(db_session, is_public=False, groups=[managed])
+
+    for actor in (in_scope, out_scope, admin):
+        # edit: the real editable query must agree with the within_scope write decision
+        is_editable = (
+            get_connector_credential_pair_from_id_for_user(
+                cc_pair.id, db_session, actor, get_editable=True
+            )
+            is not None
+        )
+        scope_decision = within_scope(
+            actor,
+            db_session,
+            permission=Permission.MANAGE_CONNECTORS,
+            current_group_ids=[managed.id],
+            requested_group_ids=[managed.id],
+            is_non_public=True,
+        )
+        assert is_editable == scope_decision, actor.email
+
+        # delete: the deletion route's GATE 1 (global only, no allow_scope)
+        delete_admits = _route_admits(
+            create_deletion_attempt_for_connector_id, "user", actor
+        )
+        # publish: the associate route's real GATE 2 for the PUBLIC state (is_non_public=False)
+        publish_enforced = not _guard_raises(
+            assert_within_scope,
+            actor,
+            db_session,
+            permission=Permission.MANAGE_CONNECTORS,
+            current_group_ids=[managed.id],
+            requested_group_ids=[managed.id],
+            is_non_public=False,
+        )
+
+        tags = cc_pair_permissions(
+            is_editable=is_editable,
+            is_connectors_admin=has_global_permission(
+                actor, Permission.MANAGE_CONNECTORS
+            ),
+        )
+        assert tags["edit"] == scope_decision, actor.email
+        assert tags["delete"] == delete_admits, actor.email
+        assert tags["publish"] == publish_enforced, actor.email
+
+    # concrete: an in-scope manager edits but can neither delete nor publish
+    in_scope_editable = (
+        get_connector_credential_pair_from_id_for_user(
+            cc_pair.id, db_session, in_scope, get_editable=True
+        )
+        is not None
+    )
+    assert cc_pair_permissions(
+        is_editable=in_scope_editable,
+        is_connectors_admin=has_global_permission(
+            in_scope, Permission.MANAGE_CONNECTORS
+        ),
+    ) == {"edit": True, "delete": False, "publish": False}
+
+
+def test_cc_pair_projection_key_coverage() -> None:
+    stamped = set(cc_pair_permissions(is_editable=True, is_connectors_admin=True))
+    assert stamped == set(CC_PAIR_ACTIONS), (
+        "cc_pair projection keys drifted from the declared CC_PAIR_ACTIONS vocabulary"
+    )
+
+
+def _make_persona(
+    db_session: Session, *, owner: User, is_public: bool, groups: list[UserGroup]
+) -> Persona:
+    persona = Persona(
+        name=f"proj-persona-{uuid4().hex[:12]}",
+        description="contract",
+        public_permission=PersonaSharePermission.EDITOR,
+        user_id=owner.id,
+        is_public=is_public,
+    )
+    db_session.add(persona)
+    db_session.flush()
+    for group in groups:
+        db_session.add(
+            Persona__UserGroup(persona_id=persona.id, user_group_id=group.id)
+        )
+    db_session.commit()
+    return persona
+
+
+def _make_doc_set(
+    db_session: Session, *, is_public: bool, groups: list[UserGroup]
+) -> DocumentSet:
+    doc_set = DocumentSet(name=f"proj-ds-{uuid4().hex[:12]}", is_public=is_public)
+    db_session.add(doc_set)
+    db_session.flush()
+    for group in groups:
+        db_session.add(
+            DocumentSet__UserGroup(document_set_id=doc_set.id, user_group_id=group.id)
+        )
+    db_session.commit()
+    return doc_set
+
+
+def test_persona_projection_matches_gates(db_session: Session) -> None:
+    """edit tracks the read-editable AND managed-scope decision the write guard enforces;
+    view_stats tracks the real owner-or-admin stats gate; the rest are global-only."""
+    managed = _make_group(db_session)
+    unmanaged = _make_group(db_session)
+
+    in_scope = create_test_user(db_session, "b-persona-in")
+    _manage(db_session, in_scope, managed)
+    in_scope.effective_permissions = []
+
+    out_scope = create_test_user(db_session, "b-persona-out")
+    _manage(db_session, out_scope, unmanaged)
+    out_scope.effective_permissions = []
+
+    owner = create_test_user(db_session, "b-persona-owner")
+    owner.effective_permissions = []
+
+    admin = create_test_user(db_session, "b-persona-admin", is_admin=True)
+    db_session.commit()
+
+    persona = _make_persona(db_session, owner=owner, is_public=False, groups=[managed])
+    group_ids = [group.id for group in persona.groups]
+
+    def edit_guard_raises(
+        actor: User, target: Persona | None = None, groups: list[int] | None = None
+    ) -> bool:
+        target = target or persona
+        request = PersonaUpsertRequest(
+            name=target.name,
+            description=target.description or "",
+            system_prompt="",
+            task_prompt="",
+            datetime_aware=False,
+            document_set_ids=[],
+            tool_ids=[],
+            groups=groups if groups is not None else [g.id for g in target.groups],
+            is_public=target.is_public,
+        )
+        return _guard_raises(
+            _assert_persona_update_within_managed_scope,
+            target.id,
+            request,
+            actor,
+            db_session,
+        )
+
+    for actor in (in_scope, out_scope, owner, admin):
+        # read bool == the real write guard's managed-scope decision
+        assert persona_edit_within_scope(
+            actor,
+            db_session,
+            group_ids=group_ids,
+            is_public=persona.is_public,
+            is_owner=can_delete_persona(actor, persona, db_session),
+        ) == (not edit_guard_raises(actor)), actor.email
+        # view_stats == the real owner-or-admin stats gate
+        assert can_view_persona_stats(actor, persona) == user_can_view_assistant_stats(
+            db_session, actor, persona.id
+        ), actor.email
+        # delete == the real delete handler's ownership gate (get_persona_by_id is_for_edit)
+        try:
+            get_persona_by_id(persona_id=persona.id, user=actor, db_session=db_session)
+            delete_allowed = True
+        except ValueError:
+            delete_allowed = False
+        assert can_delete_persona(actor, persona, db_session) == delete_allowed, (
+            actor.email
+        )
+
+    # A scoped manager who owns the agent keeps the edit right they'd hold as a plain owner,
+    # even though the agent's group is outside their scope — and the read bool agrees.
+    owned_out_of_scope = _make_persona(
+        db_session, owner=out_scope, is_public=False, groups=[managed]
+    )
+    owned_group_ids = [group.id for group in owned_out_of_scope.groups]
+    assert not edit_guard_raises(out_scope, owned_out_of_scope)
+    assert persona_edit_within_scope(
+        out_scope,
+        db_session,
+        group_ids=owned_group_ids,
+        is_public=owned_out_of_scope.is_public,
+        is_owner=can_delete_persona(out_scope, owned_out_of_scope, db_session),
+    )
+    # The exemption covers leaving the groups alone, not widening them.
+    assert edit_guard_raises(
+        out_scope, owned_out_of_scope, owned_group_ids + [unmanaged.id]
+    )
+
+    # concrete: an in-scope manager can edit/share but not view_stats/delete/feature/reorder
+    in_scope_editable = is_persona_editable_by_user(db_session, persona.id, in_scope)
+    mgr_map = persona_permissions(
+        can_edit=can_edit_persona(
+            in_scope, persona, db_session, is_editable=in_scope_editable
+        ),
+        can_share=in_scope_editable,
+        can_view_stats=can_view_persona_stats(in_scope, persona),
+        can_delete=can_delete_persona(in_scope, persona, db_session),
+        holds_add_agents=has_permission(in_scope, Permission.ADD_AGENTS)
+        is not PermissionAuthority.NONE,
+        is_manage_agents_admin=has_global_permission(
+            in_scope, Permission.MANAGE_AGENTS
+        ),
+        is_full_admin=has_global_permission(
+            in_scope, Permission.FULL_ADMIN_PANEL_ACCESS
+        ),
+    )
+    assert mgr_map["edit"] is True and mgr_map["share"] is True
+    assert mgr_map["view_stats"] is False
+    assert not any(mgr_map[a] for a in ("delete", "publish", "feature", "reorder"))
+
+
+def test_delete_persona_route_admits_scoped_owner(
+    enable_ee: None,  # noqa: ARG001 -- side-effect fixture: forces EE for the whole test
+    db_session: Session,
+) -> None:
+    """The delete route must admit a scoped ADD_AGENTS holder (allow_scope=True); otherwise an
+    owner who holds ADD_AGENTS only by scope is 403'd before the GATE-2 ownership check, making
+    the projection's delete=true a lie for them. The gate checks above can't catch a missing
+    allow_scope. enable_ee so ADD_AGENTS is genuinely scoped — CE auto-grants it globally, which
+    would pass the gate regardless and prove nothing."""
+    manager = create_test_user(db_session, "del-route-mgr")
+    _manage(db_session, manager, _make_group(db_session))
+    manager.effective_permissions = []
+    db_session.commit()
+
+    # Premise: if the manager ever holds ADD_AGENTS globally, the route check below tests
+    # nothing — fail loudly here instead of passing vacuously.
+    assert (
+        has_permission(manager, Permission.ADD_AGENTS) is PermissionAuthority.SCOPED
+    ), "manager should hold ADD_AGENTS only by scope"
+    assert _route_admits(delete_persona, "user", manager), (
+        "delete route must admit scoped managers at GATE 1 (allow_scope=True)"
+    )
+
+
+def test_persona_share_projection_tracks_share_guard_not_edit(
+    db_session: Session,
+) -> None:
+    """share follows the share guard (fetch_persona_by_id_for_user / get_editable), which is
+    broader than edit's managed-scope AND gate: an EDITOR-shared manager outside the agent's
+    groups may share it but not update it, so ``share`` must not reuse ``can_edit``."""
+    managed = _make_group(db_session)
+    unmanaged = _make_group(db_session)
+
+    # Manager of `unmanaged`, EDITOR-shared on an agent grouped in `managed` (out of scope).
+    editor = create_test_user(db_session, "share-editor")
+    _manage(db_session, editor, unmanaged)
+    editor.effective_permissions = []
+
+    owner = create_test_user(db_session, "share-owner")
+    owner.effective_permissions = []
+    db_session.commit()
+
+    persona = _make_persona(db_session, owner=owner, is_public=False, groups=[managed])
+    db_session.add(
+        Persona__User(
+            persona_id=persona.id,
+            user_id=editor.id,
+            permission=PersonaSharePermission.EDITOR,
+        )
+    )
+    db_session.commit()
+
+    is_editable = is_persona_editable_by_user(db_session, persona.id, editor)
+    can_edit = can_edit_persona(editor, persona, db_session, is_editable=is_editable)
+
+    # The real share-endpoint gate: does the editable fetch admit them?
+    try:
+        fetch_persona_by_id_for_user(
+            db_session=db_session, persona_id=persona.id, user=editor, get_editable=True
+        )
+        share_allowed = True
+    except HTTPException:
+        share_allowed = False
+
+    assert is_editable is True  # EDITOR-shared → in the editable set
+    assert can_edit is False  # ...but out of managed scope → can't update
+    assert share_allowed is True  # ...yet the share endpoint admits them
+
+    tags = persona_permissions(
+        can_edit=can_edit,
+        can_share=is_editable,
+        can_view_stats=can_view_persona_stats(editor, persona),
+        can_delete=can_delete_persona(editor, persona, db_session),
+        holds_add_agents=has_permission(editor, Permission.ADD_AGENTS)
+        is not PermissionAuthority.NONE,
+        is_manage_agents_admin=has_global_permission(editor, Permission.MANAGE_AGENTS),
+        is_full_admin=has_global_permission(editor, Permission.FULL_ADMIN_PANEL_ACCESS),
+    )
+    assert tags["share"] == share_allowed  # share tracks the share guard...
+    assert tags["edit"] is False  # ...not the stricter edit guard
+
+
+def test_persona_edit_share_editable_without_add_agents(
+    enable_ee: None,  # noqa: ARG001 -- side-effect fixture: forces EE for the whole test
+    db_session: Session,
+) -> None:
+    """edit and share gate on editable alone (their routes are BASIC_ACCESS): an EDITOR-shared
+    user without ADD_AGENTS may still edit and manage sharing, so both are True. enable_ee
+    because CE auto-grants ADD_AGENTS, which would mask that they need no create permission."""
+    owner = create_test_user(db_session, "add-share-owner")
+    owner.effective_permissions = []
+    # EDITOR-shared, but no ADD_AGENTS authority: not a manager, empty permissions.
+    editor = create_test_user(db_session, "add-share-editor")
+    editor.effective_permissions = []
+    db_session.commit()
+
+    persona = _make_persona(db_session, owner=owner, is_public=False, groups=[])
+    db_session.add(
+        Persona__User(
+            persona_id=persona.id,
+            user_id=editor.id,
+            permission=PersonaSharePermission.EDITOR,
+        )
+    )
+    db_session.commit()
+
+    is_editable = is_persona_editable_by_user(db_session, persona.id, editor)
+    holds_add_agents = (
+        has_permission(editor, Permission.ADD_AGENTS) is not PermissionAuthority.NONE
+    )
+    assert is_editable is True  # EDITOR-shared → editable
+    assert holds_add_agents is False  # ...but no ADD_AGENTS authority under EE
+
+    tags = persona_permissions(
+        can_edit=can_edit_persona(editor, persona, db_session, is_editable=is_editable),
+        can_share=is_editable,
+        can_view_stats=can_view_persona_stats(editor, persona),
+        can_delete=can_delete_persona(editor, persona, db_session),
+        holds_add_agents=holds_add_agents,
+        is_manage_agents_admin=has_global_permission(editor, Permission.MANAGE_AGENTS),
+        is_full_admin=has_global_permission(editor, Permission.FULL_ADMIN_PANEL_ACCESS),
+    )
+    assert tags["share"] is True  # editable is enough to share (no ADD_AGENTS needed)
+    assert (
+        tags["edit"] is True
+    )  # ...and to edit — both routes gate on editable, not ADD_AGENTS
+
+
+def test_persona_publish_projection_is_owner_not_add_agents(
+    enable_ee: None,  # noqa: ARG001 -- side-effect fixture: forces EE for the whole test
+    db_session: Session,
+) -> None:
+    """publish (org-wide public, via the share route's is_owner_or_admin gate) is owner-or-admin,
+    NOT ADD_AGENTS-gated. An owner without ADD_AGENTS can publish but cannot delete (delete's
+    route requires ADD_AGENTS). enable_ee because CE auto-grants ADD_AGENTS, masking this."""
+    owner = create_test_user(db_session, "publish-owner")
+    owner.effective_permissions = []
+    db_session.commit()
+
+    persona = _make_persona(db_session, owner=owner, is_public=False, groups=[])
+    is_editable = is_persona_editable_by_user(db_session, persona.id, owner)
+    holds_add_agents = (
+        has_permission(owner, Permission.ADD_AGENTS) is not PermissionAuthority.NONE
+    )
+    assert holds_add_agents is False  # owner holds no ADD_AGENTS authority under EE
+
+    tags = persona_permissions(
+        can_edit=can_edit_persona(owner, persona, db_session, is_editable=is_editable),
+        can_share=is_editable,
+        can_view_stats=can_view_persona_stats(owner, persona),
+        can_delete=can_delete_persona(owner, persona, db_session),
+        holds_add_agents=holds_add_agents,
+        is_manage_agents_admin=has_global_permission(owner, Permission.MANAGE_AGENTS),
+        is_full_admin=has_global_permission(owner, Permission.FULL_ADMIN_PANEL_ACCESS),
+    )
+    assert (
+        tags["publish"] is True
+    )  # owner may publish via the share route (no ADD_AGENTS)
+    assert tags["delete"] is False  # ...but delete's route requires ADD_AGENTS
+
+
+def test_document_set_projection_matches_gates(db_session: Session) -> None:
+    """edit tracks the editable filter, which equals the within_scope decision the write
+    guard enforces; delete/publish track global MANAGE_DOCUMENT_SETS."""
+    managed = _make_group(db_session)
+
+    in_scope = create_test_user(db_session, "b-ds-in")
+    _manage(db_session, in_scope, managed)
+    in_scope.effective_permissions = []
+
+    out_scope = create_test_user(db_session, "b-ds-out")
+    _manage(db_session, out_scope, _make_group(db_session))
+    out_scope.effective_permissions = []
+
+    admin = create_test_user(db_session, "b-ds-admin", is_admin=True)
+    db_session.commit()
+
+    doc_set = _make_doc_set(db_session, is_public=False, groups=[managed])
+
+    for actor in (in_scope, out_scope, admin):
+        editable_ids = {
+            ds.id
+            for ds in fetch_all_document_sets_for_user(
+                db_session=db_session, user=actor, get_editable=True
+            )
+        }
+        is_editable = doc_set.id in editable_ids
+        # the editable filter equals the write guard's scope decision
+        scope_decision = within_scope(
+            actor,
+            db_session,
+            permission=Permission.MANAGE_DOCUMENT_SETS,
+            current_group_ids=[managed.id],
+            requested_group_ids=[managed.id],
+            is_non_public=True,
+        )
+        assert is_editable == scope_decision, actor.email
+
+        is_ds_admin = has_global_permission(actor, Permission.MANAGE_DOCUMENT_SETS)
+        tags = document_set_permissions(
+            is_editable=is_editable, is_document_sets_admin=is_ds_admin
+        )
+        assert tags["edit"] == scope_decision
+        assert tags["manage_access"] == scope_decision
+        assert tags["delete"] == is_ds_admin
+
+
+def test_persona_and_doc_set_key_coverage() -> None:
+    persona_keys = set(
+        persona_permissions(
+            can_edit=True,
+            can_share=True,
+            can_view_stats=True,
+            can_delete=True,
+            holds_add_agents=True,
+            is_manage_agents_admin=True,
+            is_full_admin=True,
+        )
+    )
+    assert persona_keys == set(PERSONA_ACTIONS)
+    ds_keys = set(
+        document_set_permissions(is_editable=True, is_document_sets_admin=True)
+    )
+    assert ds_keys == set(DOCUMENT_SET_ACTIONS)
+
+
+def _make_tool(
+    db_session: Session,
+    *,
+    creator: User | None = None,
+    in_code: str | None = None,
+    mcp_server_id: int | None = None,
+) -> Tool:
+    tool = Tool(
+        name=f"proj-tool-{uuid4().hex[:12]}",
+        description="contract",
+        user_id=creator.id if creator else None,
+        in_code_tool_id=in_code,
+        mcp_server_id=mcp_server_id,
+    )
+    db_session.add(tool)
+    db_session.flush()
+    return tool
+
+
+def _make_mcp_server(db_session: Session, *, owner_email: str) -> MCPServer:
+    server = MCPServer(
+        name=f"proj-mcp-{uuid4().hex[:12]}",
+        owner=owner_email,
+        server_url="https://mcp.example.com",
+        status=MCPServerStatus.CONNECTED,
+    )
+    db_session.add(server)
+    db_session.flush()
+    return server
+
+
+def _link_persona_tool(db_session: Session, persona: Persona, tool: Tool) -> None:
+    db_session.add(Persona__Tool(persona_id=persona.id, tool_id=tool.id))
+    db_session.commit()
+
+
+def _make_skill(
+    db_session: Session, *, is_public: bool, groups: list[UserGroup]
+) -> Skill:
+    skill = Skill(
+        id=uuid4(),
+        slug=f"proj-skill-{uuid4().hex[:12]}",
+        name="contract skill",
+        description="contract",
+        # custom skills need a bundle source (ck_skill_definition_source)
+        bundle_file_id=f"proj-bundle-{uuid4().hex}",
+        bundle_sha256="0" * 64,
+        is_public=is_public,
+    )
+    db_session.add(skill)
+    db_session.flush()
+    for group in groups:
+        db_session.add(Skill__UserGroup(skill_id=skill.id, user_group_id=group.id))
+    db_session.commit()
+    return skill
+
+
+def test_tool_projection_matches_gates(db_session: Session) -> None:
+    """Every action affordance (edit, delete, toggle, authenticate) is owner-or-admin, pinned
+    to _get_manageable_custom_tool. The creator fully controls the action they made; a scoped
+    manager whose group the action is connected to may view/create but not manage it."""
+    managed = _make_group(db_session)
+
+    in_scope = create_test_user(db_session, "proj-tool-in")
+    _manage(db_session, in_scope, managed)
+    in_scope.effective_permissions = []
+
+    # scoped manager who owns the action (via a group unrelated to the action's agents)
+    creator = create_test_user(db_session, "proj-tool-creator")
+    _manage(db_session, creator, _make_group(db_session))
+    creator.effective_permissions = []
+
+    admin = create_test_user(db_session, "proj-tool-admin", is_admin=True)
+    db_session.commit()
+
+    tool = _make_tool(db_session, creator=creator)
+    # a private agent in the managed group references the action -> connected to `managed`
+    persona = _make_persona(
+        db_session, owner=creator, is_public=False, groups=[managed]
+    )
+    _link_persona_tool(db_session, persona, tool)
+
+    for actor in (in_scope, creator, admin):
+        manage_enforced = not _guard_raises(
+            _get_manageable_custom_tool, tool.id, db_session, actor
+        )
+        can_manage = can_manage_tool(actor, tool)
+        assert can_manage == manage_enforced, actor.email
+        assert tool_permissions(can_manage=can_manage) == {
+            "edit": manage_enforced,
+            "delete": manage_enforced,
+            "toggle": manage_enforced,
+            "authenticate": manage_enforced,
+        }
+
+    # a manager of the action's connected group can't manage it (only creator/admin can)
+    assert tool_permissions(can_manage=can_manage_tool(in_scope, tool)) == {
+        "edit": False,
+        "delete": False,
+        "toggle": False,
+        "authenticate": False,
+    }
+    # the creator fully controls the action they made
+    assert tool_permissions(can_manage=can_manage_tool(creator, tool)) == {
+        "edit": True,
+        "delete": True,
+        "toggle": True,
+        "authenticate": True,
+    }
+
+
+def test_mcp_projection_matches_gates(db_session: Session) -> None:
+    """Every MCP action affordance is owner-or-admin, pinned to
+    _ensure_mcp_server_owner_or_admin. A scoped manager whose group the server is connected to
+    may view it (_ensure_mcp_server_viewable) but not manage it."""
+    managed = _make_group(db_session)
+
+    in_scope = create_test_user(db_session, "proj-mcp-in")
+    _manage(db_session, in_scope, managed)
+    in_scope.effective_permissions = []
+
+    owner = create_test_user(db_session, "proj-mcp-owner")
+    _manage(db_session, owner, _make_group(db_session))
+    owner.effective_permissions = []
+
+    admin = create_test_user(db_session, "proj-mcp-admin", is_admin=True)
+    # The only actor the two sides can disagree about: FULL_ADMIN implies every permission,
+    # but not the reverse, so a MANAGE_ACTIONS holder isn't covered by a FULL_ADMIN check.
+    actions_admin = create_test_user(db_session, "proj-mcp-actions")
+    actions_admin.effective_permissions = [Permission.MANAGE_ACTIONS.value]
+    db_session.commit()
+
+    server = _make_mcp_server(db_session, owner_email=owner.email)
+    tool = _make_tool(db_session, mcp_server_id=server.id)
+    persona = _make_persona(db_session, owner=owner, is_public=False, groups=[managed])
+    _link_persona_tool(db_session, persona, tool)
+
+    for actor in (in_scope, owner, admin, actions_admin):
+        manage_enforced = not _guard_raises(
+            _ensure_mcp_server_owner_or_admin, server, actor
+        )
+        can_manage = can_manage_mcp_server(actor, server)
+        assert can_manage == manage_enforced, actor.email
+        assert mcp_server_permissions(can_manage=can_manage) == {
+            "edit": manage_enforced,
+            "delete": manage_enforced,
+            "authenticate": manage_enforced,
+            "manage_status": manage_enforced,
+        }
+
+    # a manager of the server's connected group may VIEW but not manage it
+    assert not _guard_raises(_ensure_mcp_server_viewable, server, in_scope, db_session)
+    assert can_manage_mcp_server(in_scope, server) is False
+    # the owner fully manages their server
+    assert mcp_server_permissions(can_manage=can_manage_mcp_server(owner, server)) == {
+        "edit": True,
+        "delete": True,
+        "authenticate": True,
+        "manage_status": True,
+    }
+
+
+def test_skill_projection_matches_gates(db_session: Session) -> None:
+    """edit/manage_access track the assert_within_scope guard on the skill's groups;
+    delete is FULL_ADMIN; publish (make public) is global MANAGE_SKILLS. A scoped manager
+    edits/re-grants a managed skill but can never delete or publish it."""
+    managed = _make_group(db_session)
+
+    in_scope = create_test_user(db_session, "proj-skill-in")
+    _manage(db_session, in_scope, managed)
+    in_scope.effective_permissions = []
+
+    out_scope = create_test_user(db_session, "proj-skill-out")
+    _manage(db_session, out_scope, _make_group(db_session))
+    out_scope.effective_permissions = []
+
+    admin = create_test_user(db_session, "proj-skill-admin", is_admin=True)
+    db_session.commit()
+
+    skill = _make_skill(db_session, is_public=False, groups=[managed])
+    group_ids = get_group_ids_for_skill(skill.id, db_session)
+
+    for actor in (in_scope, out_scope, admin):
+        edit_enforced = not _guard_raises(
+            assert_within_scope,
+            actor,
+            db_session,
+            permission=Permission.MANAGE_SKILLS,
+            current_group_ids=group_ids,
+            requested_group_ids=group_ids,
+            is_non_public=not skill.is_public,
+        )
+        # publish drives the same guard with the requested public state
+        publish_enforced = not _guard_raises(
+            assert_within_scope,
+            actor,
+            db_session,
+            permission=Permission.MANAGE_SKILLS,
+            current_group_ids=group_ids,
+            requested_group_ids=group_ids,
+            is_non_public=False,
+        )
+        can_edit = within_scope(
+            actor,
+            db_session,
+            permission=Permission.MANAGE_SKILLS,
+            current_group_ids=group_ids,
+            requested_group_ids=group_ids,
+            is_non_public=not skill.is_public,
+        )
+        assert can_edit == edit_enforced, actor.email
+        is_full_admin = has_global_permission(actor, Permission.FULL_ADMIN_PANEL_ACCESS)
+        is_skills_admin = has_global_permission(actor, Permission.MANAGE_SKILLS)
+        tags = custom_skill_permissions(
+            can_edit=can_edit,
+            is_full_admin=is_full_admin,
+            is_skills_admin=is_skills_admin,
+        )
+        assert tags["edit"] == edit_enforced
+        assert tags["manage_access"] == edit_enforced
+        assert tags["delete"] == is_full_admin
+        assert tags["publish"] == publish_enforced  # global MANAGE_SKILLS
+
+    # in-scope manager edits/re-grants but can't delete or publish
+    assert custom_skill_permissions(
+        can_edit=within_scope(
+            in_scope,
+            db_session,
+            permission=Permission.MANAGE_SKILLS,
+            current_group_ids=group_ids,
+            requested_group_ids=group_ids,
+            is_non_public=not skill.is_public,
+        ),
+        is_full_admin=has_global_permission(
+            in_scope, Permission.FULL_ADMIN_PANEL_ACCESS
+        ),
+        is_skills_admin=has_global_permission(in_scope, Permission.MANAGE_SKILLS),
+    ) == {"edit": True, "manage_access": True, "delete": False, "publish": False}
+
+
+def test_actions_and_skill_key_coverage() -> None:
+    assert set(tool_permissions(can_manage=True)) == set(TOOL_ACTIONS)
+    assert set(mcp_server_permissions(can_manage=True)) == set(MCP_SERVER_ACTIONS)
+    assert set(
+        custom_skill_permissions(
+            can_edit=True, is_full_admin=True, is_skills_admin=True
+        )
+    ) == set(CUSTOM_SKILL_ACTIONS)
+
+
+def test_user_group_projection_matches_gates(db_session: Session) -> None:
+    """Each flag is pinned to its real route, not the bool that built it: manage and
+    edit_token_limits → assert_manages_group (per-group scoped — the token read route now
+    admits scope), delete → delete-group (global MANAGE_USER_GROUPS), edit_permissions →
+    permission-toggle (FULL_ADMIN). groups_admin (global MANAGE_USER_GROUPS, not full admin)
+    separates the two levels; out_scope (manages a different group) pins the per-group gate."""
+    managed = _make_group(db_session)
+
+    in_scope = create_test_user(db_session, "proj-ug-in")
+    _manage(db_session, in_scope, managed)
+    in_scope.effective_permissions = []
+
+    out_scope = create_test_user(db_session, "proj-ug-out")
+    _manage(db_session, out_scope, _make_group(db_session))
+    out_scope.effective_permissions = []
+
+    groups_admin = create_test_user(db_session, "proj-ug-groupsadmin")
+    groups_admin.effective_permissions = [Permission.MANAGE_USER_GROUPS.value]
+
+    admin = create_test_user(db_session, "proj-ug-admin", is_admin=True)
+    db_session.commit()
+
+    for actor in (in_scope, out_scope, groups_admin, admin):
+        manage_enforced = not _guard_raises(
+            assert_manages_group, actor, db_session, group_id=managed.id
+        )
+        # the token-limit POST guard (scoped create) is the same managed-scope decision
+        token_create_enforced = not _guard_raises(
+            assert_within_scope,
+            actor,
+            db_session,
+            permission=Permission.MANAGE_USER_GROUPS,
+            current_group_ids=[managed.id],
+            requested_group_ids=[managed.id],
+            is_non_public=True,
+        )
+        can_manage = manages_group(actor, db_session, group_id=managed.id)
+        assert can_manage == manage_enforced, actor.email
+        assert can_manage == token_create_enforced, actor.email
+
+        tags = user_group_permissions(
+            can_manage=can_manage,
+            is_user_groups_admin=has_global_permission(
+                actor, Permission.MANAGE_USER_GROUPS
+            ),
+            is_full_admin=has_global_permission(
+                actor, Permission.FULL_ADMIN_PANEL_ACCESS
+            ),
+        )
+        assert tags["manage"] == manage_enforced, actor.email
+        assert tags["delete"] == _route_admits(delete_user_group, "_", actor), (
+            actor.email
+        )
+        assert tags["edit_permissions"] == _route_admits(
+            set_user_group_permissions, "user", actor
+        ), actor.email
+        # edit_token_limits rides the token read route: GATE 1 admits scope, GATE 2 is
+        # assert_manages_group — net per-group decision, so AND the two.
+        token_read_gate1 = _route_admits(get_group_token_limit_settings, "user", actor)
+        assert tags["edit_token_limits"] == (token_read_gate1 and manage_enforced), (
+            actor.email
+        )
+
+    assert user_group_permissions(
+        can_manage=manages_group(in_scope, db_session, group_id=managed.id),
+        is_user_groups_admin=has_global_permission(
+            in_scope, Permission.MANAGE_USER_GROUPS
+        ),
+        is_full_admin=has_global_permission(
+            in_scope, Permission.FULL_ADMIN_PANEL_ACCESS
+        ),
+    ) == {
+        "manage": True,
+        "delete": False,
+        "edit_permissions": False,
+        # scoped manager now fully manages its group's token limits
+        "edit_token_limits": True,
+    }
+
+    # groups_admin (global MANAGE_USER_GROUPS, not full admin): manages token limits and
+    # deletes the group, but can't edit permissions (FULL_ADMIN).
+    assert user_group_permissions(
+        can_manage=manages_group(groups_admin, db_session, group_id=managed.id),
+        is_user_groups_admin=has_global_permission(
+            groups_admin, Permission.MANAGE_USER_GROUPS
+        ),
+        is_full_admin=has_global_permission(
+            groups_admin, Permission.FULL_ADMIN_PANEL_ACCESS
+        ),
+    ) == {
+        "manage": True,
+        "delete": True,
+        "edit_permissions": False,
+        "edit_token_limits": True,
+    }
+
+
+def test_user_group_key_coverage() -> None:
+    assert set(
+        user_group_permissions(
+            can_manage=True, is_user_groups_admin=True, is_full_admin=True
+        )
+    ) == set(USER_GROUP_ACTIONS)
+
+
+def test_group_token_rate_limit_write_scope(db_session: Session) -> None:
+    """A group token-limit write needs the caller to manage the group AND the limit to
+    belong to it — so a group admin fully manages its limits, but a global/per-user limit or
+    another group's limit can't be reached through the group path."""
+    managed = _make_group(db_session)
+    other = _make_group(db_session)
+
+    args = TokenRateLimitArgs(enabled=True, token_budget=1000, period_hours=24)
+    managed_limit = insert_user_group_token_rate_limit(
+        db_session=db_session, token_rate_limit_settings=args, group_id=managed.id
+    )
+    global_limit = insert_global_token_rate_limit(db_session, args)
+
+    in_scope = create_test_user(db_session, "proj-trl-in")
+    _manage(db_session, in_scope, managed)
+    in_scope.effective_permissions = []
+
+    out_scope = create_test_user(db_session, "proj-trl-out")
+    _manage(db_session, out_scope, other)
+    out_scope.effective_permissions = []
+
+    groups_admin = create_test_user(db_session, "proj-trl-groupsadmin")
+    groups_admin.effective_permissions = [Permission.MANAGE_USER_GROUPS.value]
+
+    admin = create_test_user(db_session, "proj-trl-admin", is_admin=True)
+
+    plain = create_test_user(db_session, "proj-trl-plain")
+    plain.effective_permissions = []
+    db_session.commit()
+
+    def denied(actor: User, group_id: int, rate_limit_id: int) -> bool:
+        return _guard_raises(
+            _authorize_group_token_rate_limit_write,
+            actor,
+            db_session,
+            group_id=group_id,
+            rate_limit_id=rate_limit_id,
+        )
+
+    assert not denied(admin, managed.id, managed_limit.id)
+    assert not denied(groups_admin, managed.id, managed_limit.id)
+    assert not denied(in_scope, managed.id, managed_limit.id)
+    assert denied(out_scope, managed.id, managed_limit.id)
+    assert denied(plain, managed.id, managed_limit.id)
+
+    # a global limit can't be reached through the group path — even for a full admin
+    assert denied(admin, managed.id, global_limit.id)
+
+    # the limit must belong to the claimed group (can't reach managed's limit via other)
+    assert denied(out_scope, other.id, managed_limit.id)
+    assert denied(in_scope, other.id, managed_limit.id)
+
+    # an unknown id folds into the same OnyxError 404, not the helper's raw ValueError
+    nonexistent_limit_id = -1
+    assert denied(in_scope, managed.id, nonexistent_limit_id)
+    assert denied(admin, managed.id, nonexistent_limit_id)
+
+
+def test_group_token_rate_limit_write_multi_group_scope(db_session: Session) -> None:
+    """Defensive: no API path attaches a limit to more than one group, but the schema allows
+    many-to-many. If a limit ever spanned groups, a mutation would hit all of them, so a manager
+    of only one attached group must be denied — the guard checks every attached group, not one
+    arbitrary association; global holders manage all groups so they pass. Builds the multi-group
+    state directly (no API can) to lock in the guard's behavior if that ever changes."""
+    managed = _make_group(db_session)
+    unmanaged = _make_group(db_session)
+
+    args = TokenRateLimitArgs(enabled=True, token_budget=1000, period_hours=24)
+    # limit attached to BOTH a managed and an unmanaged group
+    shared_limit = insert_user_group_token_rate_limit(
+        db_session=db_session, token_rate_limit_settings=args, group_id=managed.id
+    )
+    db_session.add(
+        TokenRateLimit__UserGroup(
+            rate_limit_id=shared_limit.id, user_group_id=unmanaged.id
+        )
+    )
+    db_session.commit()
+
+    in_scope = create_test_user(db_session, "proj-trl-multi-in")
+    _manage(db_session, in_scope, managed)
+    in_scope.effective_permissions = []
+
+    groups_admin = create_test_user(db_session, "proj-trl-multi-groupsadmin")
+    groups_admin.effective_permissions = [Permission.MANAGE_USER_GROUPS.value]
+
+    admin = create_test_user(db_session, "proj-trl-multi-admin", is_admin=True)
+    db_session.commit()
+
+    def denied(actor: User) -> bool:
+        return _guard_raises(
+            _authorize_group_token_rate_limit_write,
+            actor,
+            db_session,
+            group_id=managed.id,
+            rate_limit_id=shared_limit.id,
+        )
+
+    # manager of `managed` only: mutating the shared limit would also hit `unmanaged`, so deny
+    assert denied(in_scope)
+    # global MANAGE_USER_GROUPS holders manage every group, so the shared limit is reachable
+    assert not denied(groups_admin)
+    assert not denied(admin)

--- a/backend/tests/external_dependency_unit/auth/test_scoped_permissions.py
+++ b/backend/tests/external_dependency_unit/auth/test_scoped_permissions.py
@@ -1,0 +1,390 @@
+"""Tests for the scoped-manager authorization primitives — both gates and the
+read-side scope clause, against a real database."""
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from onyx.auth.permissions import SCOPED_MANAGER_PERMISSIONS
+from onyx.auth.scoped_permissions import assert_global
+from onyx.auth.scoped_permissions import assert_within_scope
+from onyx.auth.scoped_permissions import get_scoped_groups
+from onyx.db.enums import AccessType
+from onyx.db.enums import Permission
+from onyx.db.models import ConnectorCredentialPair
+from onyx.db.models import DocumentSet
+from onyx.db.models import DocumentSet__UserGroup
+from onyx.db.models import User
+from onyx.db.models import User__UserGroup
+from onyx.db.models import UserGroup
+from onyx.db.models import UserGroup__ConnectorCredentialPair
+from onyx.db.scoped_permissions import scoped_group_ids_subquery
+from onyx.db.scoped_permissions import within_managed_scope_clause
+from onyx.error_handling.exceptions import OnyxError
+from tests.external_dependency_unit.conftest import create_test_user
+from tests.external_dependency_unit.indexing_helpers import make_cc_pair
+
+
+def _make_group(db_session: Session) -> UserGroup:
+    group = UserGroup(name=f"scope-test-{uuid4().hex[:12]}")
+    db_session.add(group)
+    db_session.flush()
+    return group
+
+
+def _manage(db_session: Session, user: User, *groups: UserGroup) -> None:
+    for group in groups:
+        db_session.add(
+            User__UserGroup(user_id=user.id, user_group_id=group.id, is_manager=True)
+        )
+    user.is_group_manager = True  # recompute sets this cached flag in reality
+    db_session.commit()
+
+
+def _doc_set(db_session: Session, *, is_public: bool, groups: list[UserGroup]) -> int:
+    ds = DocumentSet(name=f"ds-{uuid4().hex[:12]}", is_public=is_public)
+    db_session.add(ds)
+    db_session.flush()
+    for group in groups:
+        db_session.add(
+            DocumentSet__UserGroup(document_set_id=ds.id, user_group_id=group.id)
+        )
+    db_session.commit()
+    return ds.id
+
+
+def test_bundle_is_the_seven_token_set() -> None:
+    assert SCOPED_MANAGER_PERMISSIONS == frozenset(
+        {
+            Permission.MANAGE_CONNECTORS,
+            Permission.MANAGE_DOCUMENT_SETS,
+            Permission.MANAGE_AGENTS,
+            Permission.ADD_AGENTS,
+            Permission.MANAGE_USER_GROUPS,
+            Permission.MANAGE_ACTIONS,
+            Permission.MANAGE_SKILLS,
+        }
+    )
+    # admin-only tokens must never be scopable
+    assert Permission.MANAGE_LLMS not in SCOPED_MANAGER_PERMISSIONS
+
+
+def test_get_scoped_groups_returns_only_managed_edges(db_session: Session) -> None:
+    user = create_test_user(db_session, "scope-mgr")
+    managed_a, managed_b, member_only = (
+        _make_group(db_session),
+        _make_group(db_session),
+        _make_group(db_session),
+    )
+    _manage(db_session, user, managed_a, managed_b)
+    db_session.add(
+        User__UserGroup(user_id=user.id, user_group_id=member_only.id, is_manager=False)
+    )
+    db_session.commit()
+
+    assert get_scoped_groups(user, db_session) == {managed_a.id, managed_b.id}
+    assert get_scoped_groups(user, db_session, Permission.MANAGE_DOCUMENT_SETS) == {
+        managed_a.id,
+        managed_b.id,
+    }
+    # non-bundle token → no scope
+    assert get_scoped_groups(user, db_session, Permission.MANAGE_LLMS) == set()
+
+
+def test_get_scoped_groups_empty_for_non_manager(db_session: Session) -> None:
+    user = create_test_user(db_session, "scope-plain")
+    group = _make_group(db_session)
+    db_session.add(
+        User__UserGroup(user_id=user.id, user_group_id=group.id, is_manager=False)
+    )
+    db_session.commit()
+    assert get_scoped_groups(user, db_session) == set()
+
+
+def test_assert_global_admits_only_global(db_session: Session) -> None:
+    """Admin-only gate (rule A): a SCOPED manager is rejected; GLOBAL passes."""
+    manager = create_test_user(db_session, "global-gate-mgr")
+    _manage(db_session, manager, _make_group(db_session))
+    manager.is_group_manager = True
+    manager.effective_permissions = []  # SCOPED for a bundle token, no global grant
+
+    # SCOPED → rejected even on a bundle token they "reach" at the route.
+    with pytest.raises(OnyxError):
+        assert_global(manager, permission=Permission.MANAGE_DOCUMENT_SETS)
+
+    # NONE → rejected.
+    plain = create_test_user(db_session, "global-gate-plain")
+    plain.effective_permissions = []
+    with pytest.raises(OnyxError):
+        assert_global(plain, permission=Permission.MANAGE_DOCUMENT_SETS)
+
+    # GLOBAL holder → passes.
+    holder = create_test_user(db_session, "global-gate-holder")
+    holder.effective_permissions = [Permission.MANAGE_DOCUMENT_SETS.value]
+    assert_global(holder, permission=Permission.MANAGE_DOCUMENT_SETS)
+
+    # Admin → passes any token.
+    admin = create_test_user(db_session, "global-gate-admin", is_admin=True)
+    assert_global(admin, permission=Permission.MANAGE_DOCUMENT_SETS)
+
+
+def test_assert_within_scope_admin_and_global_bypass(
+    db_session: Session,
+) -> None:
+    admin = create_test_user(db_session, "gate2-admin", is_admin=True)
+    # bypasses every invariant — public + out-of-scope args still pass
+    assert_within_scope(
+        admin,
+        db_session,
+        permission=Permission.MANAGE_DOCUMENT_SETS,
+        current_group_ids=[999_999],
+        requested_group_ids=[],
+        is_non_public=False,
+    )
+
+    holder = create_test_user(db_session, "gate2-holder")
+    holder.effective_permissions = [Permission.MANAGE_DOCUMENT_SETS.value]
+    assert_within_scope(
+        holder,
+        db_session,
+        permission=Permission.MANAGE_DOCUMENT_SETS,
+        current_group_ids=[999_999],
+        requested_group_ids=[],
+        is_non_public=False,
+    )
+
+
+def test_assert_within_scope_manager_invariants(
+    db_session: Session,
+) -> None:
+    manager = create_test_user(db_session, "gate2-mgr")
+    manager.effective_permissions = []  # scoped only, no global token
+    managed = _make_group(db_session)
+    unmanaged = _make_group(db_session)
+    _manage(db_session, manager, managed)
+
+    perm = Permission.MANAGE_DOCUMENT_SETS
+
+    # happy path: private, all groups managed, ≥1 group
+    assert_within_scope(
+        manager,
+        db_session,
+        permission=perm,
+        current_group_ids=[managed.id],
+        requested_group_ids=[],
+        is_non_public=True,
+    )
+
+    # out-of-scope group (capture-by-reassign) → reject
+    with pytest.raises(OnyxError):
+        assert_within_scope(
+            manager,
+            db_session,
+            permission=perm,
+            current_group_ids=[managed.id],
+            requested_group_ids=[unmanaged.id],
+            is_non_public=True,
+        )
+
+    # detach to zero groups → reject
+    with pytest.raises(OnyxError):
+        assert_within_scope(
+            manager,
+            db_session,
+            permission=perm,
+            current_group_ids=[],
+            requested_group_ids=[],
+            is_non_public=True,
+        )
+
+    # non-private resource → reject
+    with pytest.raises(OnyxError):
+        assert_within_scope(
+            manager,
+            db_session,
+            permission=perm,
+            current_group_ids=[managed.id],
+            requested_group_ids=[],
+            is_non_public=False,
+        )
+
+
+def test_assert_within_scope_fails_closed_on_empty_scope(
+    db_session: Session,
+) -> None:
+    # SCOPED but manages nothing → empty scope → reject even a well-formed request
+    user = create_test_user(db_session, "gate2-noscope")
+    user.effective_permissions = []
+    user.is_group_manager = True  # flag set, but no manager edges
+    with pytest.raises(OnyxError):
+        assert_within_scope(
+            user,
+            db_session,
+            permission=Permission.MANAGE_DOCUMENT_SETS,
+            current_group_ids=[1],
+            requested_group_ids=[],
+            is_non_public=True,
+        )
+
+
+def test_assert_within_scope_classifies_each_permission(
+    db_session: Session,
+) -> None:
+    """A user may hold one bundle token globally and another only via manager
+    scope; GATE 2 classifies each permission independently."""
+    user = create_test_user(db_session, "gate2-mixed")
+    user.effective_permissions = [Permission.MANAGE_AGENTS.value]  # global agents only
+    managed = _make_group(db_session)
+    unmanaged = _make_group(db_session)
+    _manage(db_session, user, managed)
+
+    # manage:agents held globally → scope ignored, even an out-of-scope group passes
+    assert_within_scope(
+        user,
+        db_session,
+        permission=Permission.MANAGE_AGENTS,
+        current_group_ids=[unmanaged.id],
+        requested_group_ids=[],
+        is_non_public=True,
+    )
+
+    # manage:connectors only via scope → out-of-scope group rejected
+    with pytest.raises(OnyxError):
+        assert_within_scope(
+            user,
+            db_session,
+            permission=Permission.MANAGE_CONNECTORS,
+            current_group_ids=[unmanaged.id],
+            requested_group_ids=[],
+            is_non_public=True,
+        )
+
+    # manage:connectors within managed scope → allowed
+    assert_within_scope(
+        user,
+        db_session,
+        permission=Permission.MANAGE_CONNECTORS,
+        current_group_ids=[managed.id],
+        requested_group_ids=[],
+        is_non_public=True,
+    )
+
+
+def test_within_managed_scope_clause_selects_right_rows(db_session: Session) -> None:
+    manager = create_test_user(db_session, "clause-mgr")
+    managed_a = _make_group(db_session)
+    managed_b = _make_group(db_session)
+    unmanaged = _make_group(db_session)
+    _manage(db_session, manager, managed_a, managed_b)
+
+    private_one = _doc_set(db_session, is_public=False, groups=[managed_a])
+    private_two = _doc_set(db_session, is_public=False, groups=[managed_a, managed_b])
+    public_in_scope = _doc_set(db_session, is_public=True, groups=[managed_a])
+    private_mixed = _doc_set(db_session, is_public=False, groups=[managed_a, unmanaged])
+    private_no_group = _doc_set(db_session, is_public=False, groups=[])
+
+    clause = within_managed_scope_clause(
+        resource_id_col=DocumentSet.id,
+        junction_resource_col=DocumentSet__UserGroup.document_set_id,
+        junction_group_col=DocumentSet__UserGroup.user_group_id,
+        non_public_clause=DocumentSet.is_public.is_(False),
+        managed_subq=scoped_group_ids_subquery(manager),
+    )
+    editable = set(db_session.scalars(select(DocumentSet.id).where(clause)).all())
+
+    assert private_one in editable
+    assert private_two in editable
+    assert public_in_scope not in editable
+    assert private_mixed not in editable
+    assert private_no_group not in editable
+
+    # non-manager → empty scope → nothing editable
+    plain = create_test_user(db_session, "clause-plain")
+    plain_clause = within_managed_scope_clause(
+        resource_id_col=DocumentSet.id,
+        junction_resource_col=DocumentSet__UserGroup.document_set_id,
+        junction_group_col=DocumentSet__UserGroup.user_group_id,
+        non_public_clause=DocumentSet.is_public.is_(False),
+        managed_subq=scoped_group_ids_subquery(plain),
+    )
+    plain_editable = set(
+        db_session.scalars(select(DocumentSet.id).where(plain_clause)).all()
+    )
+    assert private_one not in plain_editable
+
+
+def test_within_managed_scope_clause_handles_enum_privateness(
+    db_session: Session,
+) -> None:
+    # cc_pair encodes privateness as access_type (enum), not a bool column — the
+    # clause must accept any predicate, which a PR3 caller relies on.
+    manager = create_test_user(db_session, "clause-ccpair-mgr")
+    managed = _make_group(db_session)
+    _manage(db_session, manager, managed)
+
+    private_pair = make_cc_pair(db_session)
+    private_pair.access_type = AccessType.PRIVATE
+    public_pair = make_cc_pair(db_session)
+    public_pair.access_type = AccessType.PUBLIC
+    for pair in (private_pair, public_pair):
+        db_session.add(
+            UserGroup__ConnectorCredentialPair(
+                user_group_id=managed.id, cc_pair_id=pair.id
+            )
+        )
+    db_session.commit()
+
+    clause = within_managed_scope_clause(
+        resource_id_col=ConnectorCredentialPair.id,
+        junction_resource_col=UserGroup__ConnectorCredentialPair.cc_pair_id,
+        junction_group_col=UserGroup__ConnectorCredentialPair.user_group_id,
+        non_public_clause=ConnectorCredentialPair.access_type == AccessType.PRIVATE,
+        managed_subq=scoped_group_ids_subquery(manager),
+    )
+    editable = set(
+        db_session.scalars(select(ConnectorCredentialPair.id).where(clause)).all()
+    )
+
+    assert private_pair.id in editable
+    assert public_pair.id not in editable
+
+
+def test_within_managed_scope_clause_includes_sync_cc_pairs(
+    db_session: Session,
+) -> None:
+    # A manager manages the PRIVATE *and* SYNC cc_pairs in their groups, never
+    # PUBLIC — so the cc_pair caller passes access_type != PUBLIC (not == PRIVATE).
+    manager = create_test_user(db_session, "clause-sync-mgr")
+    managed = _make_group(db_session)
+    _manage(db_session, manager, managed)
+
+    private_pair = make_cc_pair(db_session)
+    private_pair.access_type = AccessType.PRIVATE
+    sync_pair = make_cc_pair(db_session)
+    sync_pair.access_type = AccessType.SYNC
+    public_pair = make_cc_pair(db_session)
+    public_pair.access_type = AccessType.PUBLIC
+    for pair in (private_pair, sync_pair, public_pair):
+        db_session.add(
+            UserGroup__ConnectorCredentialPair(
+                user_group_id=managed.id, cc_pair_id=pair.id
+            )
+        )
+    db_session.commit()
+
+    clause = within_managed_scope_clause(
+        resource_id_col=ConnectorCredentialPair.id,
+        junction_resource_col=UserGroup__ConnectorCredentialPair.cc_pair_id,
+        junction_group_col=UserGroup__ConnectorCredentialPair.user_group_id,
+        non_public_clause=ConnectorCredentialPair.access_type != AccessType.PUBLIC,
+        managed_subq=scoped_group_ids_subquery(manager),
+    )
+    editable = set(
+        db_session.scalars(select(ConnectorCredentialPair.id).where(clause)).all()
+    )
+
+    assert private_pair.id in editable
+    assert sync_pair.id in editable
+    assert public_pair.id not in editable

--- a/backend/tests/external_dependency_unit/craft/test_skill_visibility.py
+++ b/backend/tests/external_dependency_unit/craft/test_skill_visibility.py
@@ -28,7 +28,7 @@ class TestSkillVisibility:
         admin = make_user(db_session, role=UserRole.ADMIN)
         disabled_skill = make_skill(db_session, enabled=False, is_public=True)
 
-        admin_list = list_skills_for_admin(db_session)
+        admin_list = list_skills_for_admin(db_session, admin)
         admin_ids = {s.id for s in admin_list}
 
         assert disabled_skill.id in admin_ids

--- a/backend/tests/external_dependency_unit/db/test_agent_sharing_permissions.py
+++ b/backend/tests/external_dependency_unit/db/test_agent_sharing_permissions.py
@@ -7,16 +7,21 @@ import pytest
 from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
-from onyx.auth.schemas import UserRole
+from onyx.db.enums import Permission
 from onyx.db.enums import PersonaAccessLevel
 from onyx.db.enums import PersonaSharePermission
 from onyx.db.enums import PersonaSharingStatus
 from onyx.db.models import Persona__User
 from onyx.db.models import User
 from onyx.db.persona import fetch_persona_by_id_for_user
+from onyx.db.persona import get_minimal_persona_snapshots_for_user
 from onyx.db.persona import update_persona_access
+from onyx.db.persona import upsert_persona
 from onyx.db.persona_sharing import derive_persona_sharing_status
 from onyx.db.persona_sharing import get_persona_access_level
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.features.persona.api import delete_persona
 from tests.external_dependency_unit.conftest import create_test_user
 from tests.external_dependency_unit.db.agent_sharing_helpers import create_test_persona
 from tests.external_dependency_unit.db.agent_sharing_helpers import (
@@ -37,6 +42,24 @@ def _can_fetch(
         return True
     except HTTPException:
         return False
+
+
+def test_deleted_persona_is_not_fetchable_by_its_owner(db_session: Session) -> None:
+    # Every caller mutates the agent, so a soft-deleted one must not come back — otherwise
+    # it can still be rostered into a group or re-shared while invisible everywhere else.
+    owner = create_test_user(db_session, "deleted-owner")
+    persona = create_test_persona(db_session, owner)
+    persona.deleted = True
+    db_session.commit()
+
+    assert not _can_fetch(db_session, persona.id, owner, editable=True)
+    # upsert_persona's name-reuse path still needs it.
+    assert fetch_persona_by_id_for_user(
+        db_session=db_session,
+        persona_id=persona.id,
+        user=owner,
+        include_deleted=True,
+    )
 
 
 def test_owner_has_edit_access(db_session: Session) -> None:
@@ -77,7 +100,7 @@ def test_unrelated_user_has_no_access_to_private_persona(db_session: Session) ->
 
 def test_admin_always_has_edit_access(db_session: Session) -> None:
     owner = create_test_user(db_session, "owner")
-    admin = create_test_user(db_session, "admin", role=UserRole.ADMIN)
+    admin = create_test_user(db_session, "admin", is_admin=True)
     persona = create_test_persona(db_session, owner)
     assert _can_fetch(db_session, persona.id, admin, editable=True)
 
@@ -126,6 +149,7 @@ def test_legacy_user_ids_path_defaults_to_viewer(db_session: Session) -> None:
         persona_id=persona.id,
         creator_user_id=owner.id,
         db_session=db_session,
+        acting_user=owner,
         user_ids=[shared.id],
     )
     db_session.commit()
@@ -154,6 +178,7 @@ def test_legacy_user_ids_path_preserves_existing_editor_level(
         persona_id=persona.id,
         creator_user_id=owner.id,
         db_session=db_session,
+        acting_user=owner,
         user_ids=[editor.id],
     )
     db_session.commit()
@@ -193,7 +218,7 @@ def test_access_level_for_user_shares(
 
 def test_access_level_admin_and_stranger(db_session: Session) -> None:
     owner = create_test_user(db_session, "owner")
-    admin = create_test_user(db_session, "admin", role=UserRole.ADMIN)
+    admin = create_test_user(db_session, "admin", is_admin=True)
     stranger = create_test_user(db_session, "stranger")
     persona = create_test_persona(db_session, owner)
     db_session.refresh(persona)
@@ -220,3 +245,110 @@ def test_sharing_status_derivation(db_session: Session) -> None:
 
     public_persona = create_test_persona(db_session, owner, is_public=True)
     assert derive_persona_sharing_status(public_persona) == PersonaSharingStatus.PUBLIC
+
+
+def _list_snapshot(db_session: Session, user: User, persona_id: int):
+    snapshots = get_minimal_persona_snapshots_for_user(
+        user=user, db_session=db_session, get_editable=False
+    )
+    return next(s for s in snapshots if s.id == persona_id)
+
+
+def test_list_stamps_affordance_map_for_owner(db_session: Session) -> None:
+    """The list endpoint stamps the per-agent permissions map, so a card gates its icons
+    from list data instead of a per-card full-agent refetch (the flicker Nik flagged)."""
+    owner = create_test_user(db_session, "list-owner")
+    persona = create_test_persona(db_session, owner)
+
+    snap = _list_snapshot(db_session, owner, persona.id)
+    assert snap.permissions.get("edit") is True
+    assert snap.permissions.get("delete") is True
+
+
+def test_list_affordance_map_fail_closed_for_viewer(db_session: Session) -> None:
+    """A viewer-shared user gets the map stamped but every mutating affordance false —
+    the client can't render an edit/delete control the write guard would 403."""
+    owner = create_test_user(db_session, "list-owner2")
+    viewer = create_test_user(db_session, "list-viewer")
+    persona = create_test_persona(db_session, owner)
+    share_persona_with_user(db_session, persona, viewer, PersonaSharePermission.VIEWER)
+
+    snap = _list_snapshot(db_session, viewer, persona.id)
+    assert snap.permissions.get("edit") is False
+    assert snap.permissions.get("delete") is False
+
+
+def test_delete_persona_unowned_raises_403_not_400(db_session: Session) -> None:
+    """A non-owner admitted past GATE 1 (allow_scope) must get a 403 authorization denial, not
+    the generic 400 the global ValueError handler produces for get_persona_by_id's raise."""
+    owner = create_test_user(db_session, "del-owner")
+    stranger = create_test_user(db_session, "del-stranger")
+    persona = create_test_persona(db_session, owner)
+
+    with pytest.raises(OnyxError) as exc_info:
+        delete_persona(persona_id=persona.id, user=stranger, db_session=db_session)
+    assert exc_info.value.error_code == OnyxErrorCode.INSUFFICIENT_PERMISSIONS
+    assert exc_info.value.status_code == 403
+
+
+def test_add_agents_user_does_not_see_others_private_agents(
+    db_session: Session,
+) -> None:
+    """ADD_AGENTS must not imply READ_AGENTS (see-all): the browse list shows own / shared /
+    public, never another user's private agent."""
+    creator = create_test_user(db_session, "add-agents-creator")
+    creator.effective_permissions = [Permission.ADD_AGENTS.value]
+    stranger = create_test_user(db_session, "agent-stranger")
+    db_session.commit()
+
+    own = create_test_persona(db_session, creator)
+    public = create_test_persona(db_session, stranger, is_public=True)
+    shared = create_test_persona(db_session, stranger)
+    share_persona_with_user(db_session, shared, creator, PersonaSharePermission.VIEWER)
+    others_private = create_test_persona(db_session, stranger)
+
+    visible = {
+        snap.id
+        for snap in get_minimal_persona_snapshots_for_user(
+            user=creator, db_session=db_session, get_editable=False
+        )
+    }
+    assert own.id in visible
+    assert public.id in visible
+    assert shared.id in visible
+    assert others_private.id not in visible  # ADD_AGENTS no longer grants see-all
+
+
+def _edit_persona(
+    db_session: Session, persona_id: int, user: User, is_public: bool
+) -> None:
+    """Run the update-path setter as ``user`` requesting ``is_public``."""
+    upsert_persona(
+        user=user,
+        name=f"edit-{is_public}",
+        description="",
+        starter_messages=None,
+        system_prompt="",
+        task_prompt="",
+        datetime_aware=False,
+        is_public=is_public,
+        db_session=db_session,
+        persona_id=persona_id,
+    )
+
+
+def test_editor_cannot_publish_via_update(db_session: Session) -> None:
+    """An EDITOR-shared user may edit the agent but not flip it public via the update path —
+    is_public from a non-owner is dropped (owner-or-admin only, matching the share route)."""
+    owner = create_test_user(db_session, "pub-owner")
+    editor = create_test_user(db_session, "pub-editor")
+    persona = create_test_persona(db_session, owner, is_public=False)
+    share_persona_with_user(db_session, persona, editor, PersonaSharePermission.EDITOR)
+
+    _edit_persona(db_session, persona.id, editor, is_public=True)
+    db_session.refresh(persona)
+    assert persona.is_public is False  # editor's publish attempt is dropped
+
+    _edit_persona(db_session, persona.id, owner, is_public=True)
+    db_session.refresh(persona)
+    assert persona.is_public is True  # owner can publish

--- a/backend/tests/integration/common_utils/managers/user.py
+++ b/backend/tests/integration/common_utils/managers/user.py
@@ -153,7 +153,7 @@ class UserManager:
             headers=user.headers,
         )
         response.raise_for_status()
-        return response.json()
+        return response.json()["permissions"]
 
     @staticmethod
     def is_admin(user_to_verify: DATestUser) -> bool:

--- a/backend/tests/integration/tests/permissions/_access_matrix.py
+++ b/backend/tests/integration/tests/permissions/_access_matrix.py
@@ -20,10 +20,11 @@ the gate.
 
 from typing import Any
 
+import httpx
 import pytest
-import requests
 
 from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.http_client import client
 
 # (method, path, json body or None)
 Endpoint = tuple[str, str, dict[str, Any] | None]
@@ -49,13 +50,16 @@ def call_endpoint(
     body: dict[str, Any] | None,
     headers: dict[str, str] | None,
     cookies: Any = None,
-) -> requests.Response:
+) -> httpx.Response:
+    # Go through the shared client, not `requests` — it resolves to the in-process
+    # TestClient locally and a real httpx.Client in the docker e2e. Raw requests only
+    # ever reaches a live server on :8080, so it can't run in-process.
     kwargs: dict[str, Any] = {"headers": headers or {}, "timeout": 30}
     if cookies is not None:
         kwargs["cookies"] = cookies
     if body is not None:
         kwargs["json"] = body
-    return requests.request(method, f"{API_SERVER_URL}{path}", **kwargs)
+    return client.request(method, f"{API_SERVER_URL}{path}", **kwargs)
 
 
 def resolve_credentials(
@@ -89,7 +93,7 @@ def resolve_credentials(
 _LIMITED_USER_DETAIL = "Access denied. User has limited permissions."
 
 
-def _is_gate_denial(resp: requests.Response) -> bool:
+def _is_gate_denial(resp: httpx.Response) -> bool:
     """True iff the 403 came from an auth-layer gate, not the handler.
 
     Two auth-layer shapes exist:
@@ -119,7 +123,7 @@ def _is_gate_denial(resp: requests.Response) -> bool:
 
 
 def assert_response(
-    resp: requests.Response,
+    resp: httpx.Response,
     method: str,
     path: str,
     user_kind: str,
@@ -142,7 +146,7 @@ def assert_response(
         )
     elif expected == "anon_denied":
         assert resp.status_code in (401, 403), (
-            f"Anonymous should be denied on {method} {path}, " f"got {resp.status_code}"
+            f"Anonymous should be denied on {method} {path}, got {resp.status_code}"
         )
     else:
         raise ValueError(f"Unknown expected value: {expected}")

--- a/backend/tests/integration/tests/permissions/test_group_manager_agents.py
+++ b/backend/tests/integration/tests/permissions/test_group_manager_agents.py
@@ -1,0 +1,623 @@
+"""Escalation suite for scoping agents, skills, actions and token limits to
+group managers.
+
+A scoped group manager may manage these resources only within the groups they
+manage, and never widen beyond their scope:
+
+- **Skills**: create/grant/publish only for PRIVATE skills in managed groups;
+  the admin list is scoped; DELETE is admin-only.
+- **Agents**: may group-share a PRIVATE agent only to managed groups.
+- **Actions/MCP**: owner-or-admin — a manager creates and fully manages (edit/delete)
+  their own actions and servers, but cannot manage ones they didn't create, even those
+  connected to their groups via agents.
+- **Token limits**: settable only on a managed group.
+
+Managers are seeded by flipping ``User__UserGroup.is_manager`` directly (no
+manager-creation helper exists yet). Allowed actions go through Manager classes
+(which assert real success); denied actions go through the shared ``_access_matrix``
+helpers, which verify the 403 is a genuine permission-gate denial.
+
+Not yet covered (needs a live run to verify): PAT scope narrowing.
+"""
+
+import os
+from typing import Any
+from typing import NamedTuple
+from uuid import uuid4
+
+import httpx
+import pytest
+
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.enums import MCPAuthenticationPerformer
+from onyx.db.enums import MCPAuthenticationType
+from onyx.db.enums import Permission
+from onyx.db.models import User__UserGroup
+from onyx.db.permissions import recompute_user_permissions__no_commit
+from tests.integration.common_utils.managers.persona import PersonaManager
+from tests.integration.common_utils.managers.skill import SkillManager
+from tests.integration.common_utils.managers.user import UserManager
+from tests.integration.common_utils.managers.user_group import UserGroupManager
+from tests.integration.common_utils.test_models import DATestUser
+from tests.integration.common_utils.test_models import DATestUserGroup
+from tests.integration.tests.permissions._access_matrix import assert_response
+from tests.integration.tests.permissions._access_matrix import call_endpoint
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="Group manager scoping is an enterprise-only capability",
+)
+
+
+class _ScopedEnv(NamedTuple):
+    admin: DATestUser
+    manager: DATestUser
+    managed_group: DATestUserGroup
+    other_group: DATestUserGroup
+
+
+def _promote_to_manager(user_id: str, group_id: int) -> None:
+    """Flip is_manager on the (user, group) edge and recompute the cached flag."""
+    with get_session_with_current_tenant() as db_session:
+        updated = (
+            db_session.query(User__UserGroup)
+            .filter(
+                User__UserGroup.user_id == user_id,
+                User__UserGroup.user_group_id == group_id,
+            )
+            .update({User__UserGroup.is_manager: True})
+        )
+        # A missing edge updates nothing and every test then runs against a plain member —
+        # the denial cases would still pass, for the wrong reason.
+        assert updated == 1, (
+            f"no User__UserGroup edge for user {user_id} in group {group_id}"
+        )
+        db_session.flush()
+        recompute_user_permissions__no_commit(user_id, db_session)
+        db_session.commit()
+
+
+@pytest.fixture
+def env(reset: None, admin_user: DATestUser) -> _ScopedEnv:  # noqa: ARG001
+    manager = UserManager.create(name="scoped_manager")
+    managed_group = UserGroupManager.create(
+        name="managed", user_ids=[manager.id], user_performing_action=admin_user
+    )
+    other_group = UserGroupManager.create(
+        name="unmanaged", user_performing_action=admin_user
+    )
+    _promote_to_manager(manager.id, managed_group.id)
+    return _ScopedEnv(admin_user, manager, managed_group, other_group)
+
+
+def _tool_body(oauth_config_id: int | None = None) -> dict[str, Any]:
+    return {
+        "name": f"tool-{uuid4()}",
+        "description": "escalation test",
+        # validate_openapi_schema needs info.description, exactly one server URL, and at
+        # least one method — an empty `paths` is rejected.
+        "definition": {
+            "openapi": "3.0.0",
+            "info": {"title": "t", "description": "t", "version": "1.0.0"},
+            "servers": [{"url": "https://example.com"}],
+            "paths": {
+                "/ping": {
+                    "get": {
+                        "summary": "ping",
+                        "operationId": "ping",
+                        "responses": {"200": {"description": "ok"}},
+                    }
+                }
+            },
+        },
+        "custom_headers": [],
+        "passthrough_auth": False,
+        "oauth_config_id": oauth_config_id,
+    }
+
+
+def _create_custom_tool(user: DATestUser, oauth_config_id: int | None = None) -> int:
+    """Create a custom action as ``user`` (must succeed); returns its id."""
+    resp = call_endpoint(
+        "POST",
+        "/admin/tool/custom",
+        _tool_body(oauth_config_id),
+        user.headers,
+        user.cookies,
+    )
+    assert resp.status_code == 200, resp.text
+    return int(resp.json()["id"])
+
+
+def _create_oauth_config(user: DATestUser) -> int:
+    """Create an OAuth config as ``user`` (must succeed); returns its id."""
+    body = {
+        "name": f"oauth-{uuid4()}",
+        "authorization_url": "https://example.com/authorize",
+        "token_url": "https://example.com/token",
+        "client_id": "client-id",
+        "client_secret": "client-secret",
+    }
+    resp = call_endpoint(
+        "POST", "/admin/oauth-config/create", body, user.headers, user.cookies
+    )
+    assert resp.status_code == 200, resp.text
+    return int(resp.json()["id"])
+
+
+def _create_mcp_server(user: DATestUser) -> int:
+    """Create an MCP server as ``user`` (must succeed); returns its id."""
+    body = {
+        "name": f"mcp-{uuid4()}",
+        "description": "escalation test",
+        "server_url": "https://example.com/mcp",
+    }
+    resp = call_endpoint("POST", "/admin/mcp/server", body, user.headers, user.cookies)
+    assert resp.status_code == 200, resp.text
+    return int(resp.json()["id"])
+
+
+def _persona_upsert_body(*, is_public: bool, groups: list[int]) -> dict[str, Any]:
+    return {
+        "name": f"agent-{uuid4()}",
+        "description": "escalation test",
+        "document_set_ids": [],
+        "tool_ids": [],
+        "system_prompt": "",
+        "task_prompt": "",
+        "datetime_aware": False,
+        "is_public": is_public,
+        "groups": groups,
+    }
+
+
+_TOKEN_LIMIT_BODY: dict[str, Any] = {
+    "enabled": True,
+    "token_budget": 1000,
+    "period_hours": 24,
+}
+
+
+def _assert_manager(
+    env: _ScopedEnv,
+    method: str,
+    path: str,
+    expected: str,
+    body: dict[str, Any] | None = None,
+) -> httpx.Response:
+    """Call ``path`` as the scoped manager and assert the permission gate's verdict."""
+    resp = call_endpoint(method, path, body, env.manager.headers, env.manager.cookies)
+    assert_response(resp, method, path, "manager", expected)
+    return resp
+
+
+def test_manager_creates_private_skill_in_managed_group(env: _ScopedEnv) -> None:
+    SkillManager.create_custom(
+        env.manager, is_public=False, group_ids=[env.managed_group.id]
+    )
+
+
+def test_manager_cannot_grant_skill_to_unmanaged_group(env: _ScopedEnv) -> None:
+    skill = SkillManager.create_custom(
+        env.manager, is_public=False, group_ids=[env.managed_group.id]
+    )
+    path = f"/admin/skills/custom/{skill.id}/grants"
+    _assert_manager(
+        env,
+        "PUT",
+        path,
+        "denied",
+        {"group_ids": [env.managed_group.id, env.other_group.id]},
+    )
+
+
+def test_manager_cannot_publish_skill(env: _ScopedEnv) -> None:
+    skill = SkillManager.create_custom(
+        env.manager, is_public=False, group_ids=[env.managed_group.id]
+    )
+    _assert_manager(
+        env, "PATCH", f"/admin/skills/custom/{skill.id}", "denied", {"is_public": True}
+    )
+
+
+def test_manager_cannot_delete_skill(env: _ScopedEnv) -> None:
+    # Owns it, in a managed group — still denied: delete is admin-only.
+    skill = SkillManager.create_custom(
+        env.manager, is_public=False, group_ids=[env.managed_group.id]
+    )
+    _assert_manager(env, "DELETE", f"/admin/skills/custom/{skill.id}", "denied")
+
+
+def test_manager_skill_admin_list_is_scoped(env: _ScopedEnv) -> None:
+    mine = SkillManager.create_custom(
+        env.manager, is_public=False, group_ids=[env.managed_group.id]
+    )
+    theirs = SkillManager.create_custom(
+        env.admin, is_public=False, group_ids=[env.other_group.id]
+    )
+    resp = call_endpoint(
+        "GET", "/admin/skills", None, env.manager.headers, env.manager.cookies
+    )
+    assert resp.status_code == 200, resp.text
+    custom_ids = {c["id"] for c in resp.json()["customs"]}
+    assert str(mine.id) in custom_ids
+    assert str(theirs.id) not in custom_ids
+
+
+def test_manager_shares_agent_to_managed_group(env: _ScopedEnv) -> None:
+    PersonaManager.create(
+        user_performing_action=env.manager,
+        is_public=False,
+        groups=[env.managed_group.id],
+    )
+
+
+def test_manager_cannot_share_agent_to_unmanaged_group(env: _ScopedEnv) -> None:
+    agent = PersonaManager.create(
+        user_performing_action=env.manager,
+        is_public=False,
+        groups=[env.managed_group.id],
+    )
+    _assert_manager(
+        env,
+        "PATCH",
+        f"/persona/{agent.id}/share",
+        "denied",
+        {"group_ids": [env.managed_group.id, env.other_group.id]},
+    )
+
+
+def test_manager_publishes_own_agent(env: _ScopedEnv) -> None:
+    # D9: publishing follows ownership — being a manager must not subtract a right an
+    # ordinary owner holds.
+    agent = PersonaManager.create(
+        user_performing_action=env.manager,
+        is_public=False,
+        groups=[env.managed_group.id],
+    )
+    resp = _assert_manager(
+        env,
+        "PATCH",
+        f"/persona/{agent.id}",
+        "allowed",
+        _persona_upsert_body(is_public=True, groups=[env.managed_group.id]),
+    )
+    # upsert_persona drops an unauthorized is_public silently, so 200 proves nothing.
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["is_public"] is True
+
+
+def test_manager_unpublishes_own_agent(env: _ScopedEnv) -> None:
+    # The direction the group-share gate used to block: the manager pulls their own
+    # published agent back to private, keeping the group share. Ownership authorizes it.
+    agent = PersonaManager.create(
+        user_performing_action=env.manager,
+        is_public=False,
+        groups=[env.managed_group.id],
+    )
+    publish = call_endpoint(
+        "PATCH",
+        f"/persona/{agent.id}",
+        _persona_upsert_body(is_public=True, groups=[env.managed_group.id]),
+        env.admin.headers,
+        env.admin.cookies,
+    )
+    assert publish.status_code == 200, publish.text
+    _assert_manager(
+        env,
+        "PATCH",
+        f"/persona/{agent.id}/share",
+        "allowed",
+        {"is_public": False, "group_ids": [env.managed_group.id]},
+    )
+    read_back = call_endpoint(
+        "GET", f"/persona/{agent.id}", None, env.admin.headers, env.admin.cookies
+    )
+    assert read_back.status_code == 200, read_back.text
+    assert read_back.json()["is_public"] is False
+
+
+def test_manager_cannot_capture_public_agent_via_share(env: _ScopedEnv) -> None:
+    # A PUBLIC agent sits in nobody's managed scope, so sharing it into a managed group
+    # captures it — rejected even for the owner. Ownership buys publishing, not scope.
+    agent = PersonaManager.create(
+        user_performing_action=env.manager, is_public=True, groups=[]
+    )
+    _assert_manager(
+        env,
+        "PATCH",
+        f"/persona/{agent.id}/share",
+        "denied",
+        {"group_ids": [env.managed_group.id]},
+    )
+
+
+def test_manager_creates_personal_agent(env: _ScopedEnv) -> None:
+    # A scoped manager may create a private no-group personal agent like any
+    # ADD_AGENTS user; the managed-group gate applies only once a group is involved.
+    _assert_manager(
+        env,
+        "POST",
+        "/persona",
+        "allowed",
+        _persona_upsert_body(is_public=False, groups=[]),
+    )
+
+
+def _add_agents_only_user(env: _ScopedEnv, name: str) -> DATestUser:
+    """A user whose only admin permission is ADD_AGENTS — no MANAGE_AGENTS authority."""
+    member = UserManager.create(name=name)
+    grant_group = UserGroupManager.create(
+        name=f"{name}-group", user_ids=[member.id], user_performing_action=env.admin
+    )
+    UserGroupManager.set_permissions(
+        user_group=grant_group,
+        permissions=[Permission.ADD_AGENTS.value],
+        user_performing_action=env.admin,
+    ).raise_for_status()
+    return member
+
+
+def test_add_agents_user_creates_personal_agent_with_empty_groups(
+    env: _ScopedEnv,
+) -> None:
+    # An ADD_AGENTS-only user (no MANAGE_AGENTS authority) must still create a
+    # personal agent when the client sends groups=[] (no group share).
+    member = _add_agents_only_user(env, "add_agents_only")
+    path = "/persona"
+    resp = call_endpoint(
+        "POST",
+        path,
+        _persona_upsert_body(is_public=False, groups=[]),
+        member.headers,
+        member.cookies,
+    )
+    assert_response(resp, "POST", path, "member", "allowed")
+
+
+def test_add_agents_owner_saves_agent_group_shared_by_admin(env: _ScopedEnv) -> None:
+    # The editor round-trips current groups on every save, so an unchanged set must not
+    # read as a mutation — else an ADD_AGENTS-only owner loses edit access to their own
+    # agent once an admin group-shares it. Altering the set still needs MANAGE_AGENTS.
+    member = _add_agents_only_user(env, "add_agents_owner")
+    agent = PersonaManager.create(
+        user_performing_action=member, is_public=False, groups=[]
+    )
+    share = call_endpoint(
+        "PATCH",
+        f"/persona/{agent.id}/share",
+        {"group_ids": [env.other_group.id]},
+        env.admin.headers,
+        env.admin.cookies,
+    )
+    assert share.status_code == 200, share.text
+
+    path = f"/persona/{agent.id}"
+    unchanged = call_endpoint(
+        "PATCH",
+        path,
+        _persona_upsert_body(is_public=False, groups=[env.other_group.id]),
+        member.headers,
+        member.cookies,
+    )
+    assert_response(unchanged, "PATCH", path, "member", "allowed")
+
+    widened = call_endpoint(
+        "PATCH",
+        path,
+        _persona_upsert_body(
+            is_public=False, groups=[env.other_group.id, env.managed_group.id]
+        ),
+        member.headers,
+        member.cookies,
+    )
+    assert_response(widened, "PATCH", path, "member", "denied")
+
+
+def test_manager_rosters_agent_shared_to_managed_group(env: _ScopedEnv) -> None:
+    # A private agent shared to the manager's group but owned by the admin can be
+    # rostered out of that group by the manager: the scope-aware lookup admits them
+    # so the MANAGE_AGENTS gate (not an owner-only lookup) authorizes the change.
+    agent = PersonaManager.create(
+        user_performing_action=env.admin,
+        is_public=False,
+        groups=[env.managed_group.id],
+    )
+    path = f"/manage/admin/user-group/{env.managed_group.id}/agents"
+    resp = call_endpoint(
+        "PATCH",
+        path,
+        {"added_agent_ids": [], "removed_agent_ids": [agent.id]},
+        env.manager.headers,
+        env.manager.cookies,
+    )
+    assert resp.status_code == 200, resp.text
+
+
+# Custom actions: owner-or-admin gating (not group-scoped like skills/agents).
+def test_manager_creates_own_action(env: _ScopedEnv) -> None:
+    _create_custom_tool(env.manager)
+
+
+def test_manager_edits_own_action(env: _ScopedEnv) -> None:
+    tool_id = _create_custom_tool(env.manager)
+    _assert_manager(
+        env, "PUT", f"/admin/tool/custom/{tool_id}", "allowed", _tool_body()
+    )
+
+
+def test_manager_deletes_own_action(env: _ScopedEnv) -> None:
+    tool_id = _create_custom_tool(env.manager)
+    _assert_manager(env, "DELETE", f"/admin/tool/custom/{tool_id}", "allowed")
+
+
+def test_manager_cannot_edit_unowned_action(env: _ScopedEnv) -> None:
+    # Owner-or-admin: a manager can't edit an admin-created action, even one used by an agent
+    # in a group they manage (managers get read visibility + their own, not others').
+    tool_id = _create_custom_tool(env.admin)
+    PersonaManager.create(
+        user_performing_action=env.admin,
+        is_public=False,
+        groups=[env.managed_group.id],
+        tool_ids=[tool_id],
+    )
+    _assert_manager(env, "PUT", f"/admin/tool/custom/{tool_id}", "denied", _tool_body())
+
+
+def test_manager_cannot_delete_unowned_action(env: _ScopedEnv) -> None:
+    tool_id = _create_custom_tool(env.admin)
+    _assert_manager(env, "DELETE", f"/admin/tool/custom/{tool_id}", "denied")
+
+
+def test_manager_links_own_oauth_config(env: _ScopedEnv) -> None:
+    # Nothing else references it, so it's theirs to take.
+    oauth_config_id = _create_oauth_config(env.manager)
+    _create_custom_tool(env.manager, oauth_config_id)
+
+
+def test_manager_cannot_link_unowned_oauth_config(env: _ScopedEnv) -> None:
+    # Linking in would authenticate as the admin's OAuth app, using credentials the manager
+    # never sees.
+    oauth_config_id = _create_oauth_config(env.admin)
+    _create_custom_tool(env.admin, oauth_config_id)
+    _assert_manager(
+        env, "POST", "/admin/tool/custom", "denied", _tool_body(oauth_config_id)
+    )
+
+
+def test_unknown_oauth_config_is_rejected_not_a_500(env: _ScopedEnv) -> None:
+    # An unknown id has no referencing actions, so the link gate would wave it through to
+    # the foreign key. Applies to the admin too — the global branch skips the reference read.
+    for actor in (env.manager, env.admin):
+        resp = call_endpoint(
+            "POST",
+            "/admin/tool/custom",
+            _tool_body(2_000_000_000),
+            actor.headers,
+            actor.cookies,
+        )
+        assert resp.status_code == 404, resp.text
+
+
+def test_manager_edits_own_action_keeping_shared_oauth_config(env: _ScopedEnv) -> None:
+    # An admin can link a second action to the manager's config, which makes it shared. The
+    # manager must still be able to edit their own action while re-sending the same id.
+    oauth_config_id = _create_oauth_config(env.manager)
+    tool_id = _create_custom_tool(env.manager, oauth_config_id)
+    _create_custom_tool(env.admin, oauth_config_id)
+    _assert_manager(
+        env,
+        "PUT",
+        f"/admin/tool/custom/{tool_id}",
+        "allowed",
+        _tool_body(oauth_config_id),
+    )
+
+
+def test_manager_cannot_repoint_own_action_at_unowned_oauth_config(
+    env: _ScopedEnv,
+) -> None:
+    # Owning the action doesn't extend to the credentials it points at.
+    oauth_config_id = _create_oauth_config(env.admin)
+    _create_custom_tool(env.admin, oauth_config_id)
+    tool_id = _create_custom_tool(env.manager)
+    _assert_manager(
+        env,
+        "PUT",
+        f"/admin/tool/custom/{tool_id}",
+        "denied",
+        _tool_body(oauth_config_id),
+    )
+
+
+# MCP servers: owner-or-admin gating (not group-scoped like skills/agents).
+def test_manager_creates_mcp_server(env: _ScopedEnv) -> None:
+    _create_mcp_server(env.manager)
+
+
+def test_manager_deletes_own_mcp_server(env: _ScopedEnv) -> None:
+    server_id = _create_mcp_server(env.manager)
+    _assert_manager(env, "DELETE", f"/admin/mcp/server/{server_id}", "allowed")
+
+
+def test_manager_cannot_delete_unowned_mcp_server(env: _ScopedEnv) -> None:
+    server_id = _create_mcp_server(env.admin)
+    _assert_manager(env, "DELETE", f"/admin/mcp/server/{server_id}", "denied")
+
+
+def test_manager_update_via_servers_create_denied_not_masked(
+    env: _ScopedEnv,
+) -> None:
+    # Updating an unowned server through /servers/create must surface the gate's 403, not a
+    # 500 masked by the handler's blanket except.
+    server_id = _create_mcp_server(env.admin)
+    body = {
+        "name": f"mcp-{uuid4()}",
+        "server_url": "https://example.com/mcp",
+        "auth_type": MCPAuthenticationType.NONE.value,
+        "auth_performer": MCPAuthenticationPerformer.ADMIN.value,
+        "existing_server_id": server_id,
+    }
+    _assert_manager(env, "POST", "/admin/mcp/servers/create", "denied", body)
+
+
+def _group_limit_path(group_id: int, limit_id: int | None = None) -> str:
+    base = f"/admin/token-rate-limits/user-group/{group_id}"
+    return base if limit_id is None else f"{base}/rate-limit/{limit_id}"
+
+
+def _create_group_token_limit(user: DATestUser, group_id: int) -> int:
+    """Create a token limit on ``group_id`` as ``user`` (must succeed); returns its id."""
+    resp = call_endpoint(
+        "POST",
+        _group_limit_path(group_id),
+        _TOKEN_LIMIT_BODY,
+        user.headers,
+        user.cookies,
+    )
+    assert resp.status_code == 200, resp.text
+    return int(resp.json()["token_id"])
+
+
+def test_manager_sets_token_limit_on_managed_group(env: _ScopedEnv) -> None:
+    path = _group_limit_path(env.managed_group.id)
+    _assert_manager(env, "POST", path, "allowed", _TOKEN_LIMIT_BODY)
+
+
+def test_manager_cannot_set_token_limit_on_unmanaged_group(env: _ScopedEnv) -> None:
+    path = _group_limit_path(env.other_group.id)
+    _assert_manager(env, "POST", path, "denied", _TOKEN_LIMIT_BODY)
+
+
+def test_manager_reads_token_limits_on_managed_group(env: _ScopedEnv) -> None:
+    _assert_manager(env, "GET", _group_limit_path(env.managed_group.id), "allowed")
+
+
+def test_manager_cannot_read_token_limits_on_unmanaged_group(env: _ScopedEnv) -> None:
+    _assert_manager(env, "GET", _group_limit_path(env.other_group.id), "denied")
+
+
+def test_manager_updates_token_limit_on_managed_group(env: _ScopedEnv) -> None:
+    limit_id = _create_group_token_limit(env.manager, env.managed_group.id)
+    path = _group_limit_path(env.managed_group.id, limit_id)
+    _assert_manager(env, "PUT", path, "allowed", _TOKEN_LIMIT_BODY)
+
+
+def test_manager_cannot_update_token_limit_on_unmanaged_group(env: _ScopedEnv) -> None:
+    limit_id = _create_group_token_limit(env.admin, env.other_group.id)
+    path = _group_limit_path(env.other_group.id, limit_id)
+    _assert_manager(env, "PUT", path, "denied", _TOKEN_LIMIT_BODY)
+
+
+def test_manager_deletes_token_limit_on_managed_group(env: _ScopedEnv) -> None:
+    limit_id = _create_group_token_limit(env.manager, env.managed_group.id)
+    _assert_manager(
+        env, "DELETE", _group_limit_path(env.managed_group.id, limit_id), "allowed"
+    )
+
+
+def test_manager_cannot_delete_token_limit_on_unmanaged_group(env: _ScopedEnv) -> None:
+    limit_id = _create_group_token_limit(env.admin, env.other_group.id)
+    _assert_manager(
+        env, "DELETE", _group_limit_path(env.other_group.id, limit_id), "denied"
+    )

--- a/backend/tests/integration/tests/permissions/test_group_manager_membership.py
+++ b/backend/tests/integration/tests/permissions/test_group_manager_membership.py
@@ -1,0 +1,448 @@
+"""Escalation suite for group-manager assignment + membership scoping.
+
+A scoped group manager may create other managers, edit membership, rename, and
+list groups — but only within the groups they manage. They can never assign a
+manager, add users, rename, or edit a group outside their managed scope; never
+attach a public or out-of-scope connector to their group; and never create,
+delete, or set permissions on a group (all admin-only). The admin-facing group
+list and ``/me/permissions`` return only the manager's own scope. Global holders
+(admins) bypass GATE 2. Managers are seeded by flipping
+``User__UserGroup.is_manager`` directly (no manager-creation helper exists yet).
+
+Allowed actions go through the shared Manager classes (which assert real success);
+denied actions go through the shared ``_access_matrix`` helpers, which verify the
+403 is a genuine permission-gate denial rather than any incidental 403.
+"""
+
+import os
+from typing import Any
+from typing import NamedTuple
+
+import pytest
+
+from onyx.auth.permissions import SCOPED_MANAGER_PERMISSIONS_EXPANDED
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.enums import AccessType
+from onyx.db.models import User__UserGroup
+from onyx.db.models import UserGroup__ConnectorCredentialPair
+from onyx.db.permissions import recompute_user_permissions__no_commit
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.http_client import client
+from tests.integration.common_utils.managers.cc_pair import CCPairManager
+from tests.integration.common_utils.managers.user import UserManager
+from tests.integration.common_utils.managers.user_group import UserGroupManager
+from tests.integration.common_utils.test_models import DATestUser
+from tests.integration.common_utils.test_models import DATestUserGroup
+from tests.integration.tests.permissions._access_matrix import assert_response
+from tests.integration.tests.permissions._access_matrix import call_endpoint
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="Group manager scoping is an enterprise-only capability",
+)
+
+_GROUP_LIST_PATH = "/manage/admin/user-group"
+_RENAME_PATH = "/manage/admin/user-group/rename"
+_ME_PERMISSIONS_PATH = "/me/permissions"
+
+
+class _ScopedEnv(NamedTuple):
+    admin: DATestUser
+    manager: DATestUser
+    member: DATestUser  # plain member of managed_group (assignable target)
+    outsider: DATestUser  # member of other_group only
+    managed_group: DATestUserGroup
+    other_group: DATestUserGroup
+
+
+def _promote_to_manager(user_id: str, group_id: int) -> None:
+    """Flip is_manager on the (user, group) edge and recompute the cached flag."""
+    with get_session_with_current_tenant() as db_session:
+        updated = (
+            db_session.query(User__UserGroup)
+            .filter(
+                User__UserGroup.user_id == user_id,
+                User__UserGroup.user_group_id == group_id,
+            )
+            .update({User__UserGroup.is_manager: True})
+        )
+        # A missing edge updates nothing and every test then runs against a plain member —
+        # the denial cases would still pass, for the wrong reason.
+        assert updated == 1, (
+            f"no User__UserGroup edge for user {user_id} in group {group_id}"
+        )
+        db_session.flush()
+        recompute_user_permissions__no_commit(user_id, db_session)
+        db_session.commit()
+
+
+@pytest.fixture
+def env(reset: None, admin_user: DATestUser) -> _ScopedEnv:  # noqa: ARG001
+    manager = UserManager.create(name="scoped_manager")
+    member = UserManager.create(name="plain_member")
+    outsider = UserManager.create(name="outsider")
+    managed_group = UserGroupManager.create(
+        name="managed",
+        user_ids=[manager.id, member.id],
+        user_performing_action=admin_user,
+    )
+    other_group = UserGroupManager.create(
+        name="unmanaged", user_ids=[outsider.id], user_performing_action=admin_user
+    )
+    # Group creation kicks off a sync, and every edit route 409s/404s while one is in
+    # flight — before GATE 2 runs, so an escalation test would "pass" without reaching it.
+    UserGroupManager.wait_for_sync(
+        user_performing_action=admin_user,
+        user_groups_to_check=[managed_group, other_group],
+    )
+    _promote_to_manager(manager.id, managed_group.id)
+    return _ScopedEnv(admin_user, manager, member, outsider, managed_group, other_group)
+
+
+def _manager_path(group_id: int) -> str:
+    return f"/manage/admin/user-group/{group_id}/manager"
+
+
+def _set_manager_body(user_id: str, is_manager: bool) -> dict[str, Any]:
+    return {"user_id": user_id, "is_manager": is_manager}
+
+
+def _me_permissions(user: DATestUser) -> dict[str, Any]:
+    resp = client.get(
+        url=f"{API_SERVER_URL}{_ME_PERMISSIONS_PATH}", headers=user.headers
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _patch_group_body(user_ids: list[str], cc_pair_ids: list[int]) -> dict[str, Any]:
+    return {"user_ids": user_ids, "cc_pair_ids": cc_pair_ids}
+
+
+def _current_cc_pair_ids(group_id: int) -> set[int]:
+    """The group's live cc_pair junctions, read from the DB. A 403 only proves what came
+    back; this proves the rejected write left no rows behind."""
+    with get_session_with_current_tenant() as db_session:
+        return {
+            row.cc_pair_id
+            for row in db_session.query(UserGroup__ConnectorCredentialPair).filter(
+                UserGroup__ConnectorCredentialPair.user_group_id == group_id,
+                UserGroup__ConnectorCredentialPair.is_current.is_(True),
+            )
+        }
+
+
+def _settled_cc_pair_ids(env: "_ScopedEnv") -> set[int]:
+    """Wait out the sync a cc_pair create kicks off, then snapshot — same reason the
+    ``env`` fixture waits."""
+    UserGroupManager.wait_for_sync(
+        user_performing_action=env.admin,
+        user_groups_to_check=[env.managed_group, env.other_group],
+    )
+    return _current_cc_pair_ids(env.managed_group.id)
+
+
+def _insert_stale_cc_pair_junction(group_id: int, cc_pair_id: int) -> None:
+    """Simulate a removed-but-not-yet-swept cc_pair: an is_current=False junction row
+    (removals mark the row stale rather than delete it, until the Vespa sync runs)."""
+    with get_session_with_current_tenant() as db_session:
+        db_session.add(
+            UserGroup__ConnectorCredentialPair(
+                user_group_id=group_id, cc_pair_id=cc_pair_id, is_current=False
+            )
+        )
+        db_session.commit()
+
+
+# Manager-assignment endpoint — GATE 2 = admin or manager-of-that-group.
+def test_admin_assigns_manager(env: _ScopedEnv) -> None:
+    path = _manager_path(env.managed_group.id)
+    resp = call_endpoint(
+        "PUT",
+        path,
+        _set_manager_body(env.member.id, True),
+        env.admin.headers,
+        env.admin.cookies,
+    )
+    assert resp.status_code == 200, resp.text
+    perms = _me_permissions(env.member)
+    assert perms["is_manager"] is True
+    assert env.managed_group.id in perms["managed_group_ids"]
+
+
+def test_manager_delegates_within_managed_group(env: _ScopedEnv) -> None:
+    # A manager may appoint a co-manager within a group they manage.
+    path = _manager_path(env.managed_group.id)
+    resp = call_endpoint(
+        "PUT",
+        path,
+        _set_manager_body(env.member.id, True),
+        env.manager.headers,
+        env.manager.cookies,
+    )
+    assert resp.status_code == 200, resp.text
+    assert _me_permissions(env.member)["is_manager"] is True
+
+
+def test_manager_cannot_assign_in_unmanaged_group(env: _ScopedEnv) -> None:
+    path = _manager_path(env.other_group.id)
+    resp = call_endpoint(
+        "PUT",
+        path,
+        _set_manager_body(env.outsider.id, True),
+        env.manager.headers,
+        env.manager.cookies,
+    )
+    assert_response(resp, "PUT", path, "manager", "denied")
+
+
+def test_assign_non_member_returns_400(env: _ScopedEnv) -> None:
+    # A manager is always a member — the outsider isn't in managed_group, so even
+    # an admin gets a 400 (not a gate denial).
+    path = _manager_path(env.managed_group.id)
+    resp = call_endpoint(
+        "PUT",
+        path,
+        _set_manager_body(env.outsider.id, True),
+        env.admin.headers,
+        env.admin.cookies,
+    )
+    assert resp.status_code == 400, resp.text
+
+
+def test_revoke_manager_clears_flag(env: _ScopedEnv) -> None:
+    manager_path = _manager_path(env.managed_group.id)
+    call_endpoint(
+        "PUT",
+        manager_path,
+        _set_manager_body(env.member.id, True),
+        env.admin.headers,
+        env.admin.cookies,
+    )
+    resp = call_endpoint(
+        "PUT",
+        manager_path,
+        _set_manager_body(env.member.id, False),
+        env.admin.headers,
+        env.admin.cookies,
+    )
+    assert resp.status_code == 200, resp.text
+    perms = _me_permissions(env.member)
+    assert perms["is_manager"] is False
+    assert env.managed_group.id not in perms["managed_group_ids"]
+
+
+def test_plain_member_cannot_assign(env: _ScopedEnv) -> None:
+    # A member without is_manager holds NONE for MANAGE_USER_GROUPS — GATE 1 rejects.
+    path = _manager_path(env.managed_group.id)
+    resp = call_endpoint(
+        "PUT",
+        path,
+        _set_manager_body(env.member.id, True),
+        env.member.headers,
+        env.member.cookies,
+    )
+    assert_response(resp, "PUT", path, "member", "denied")
+
+
+def test_manager_adds_user_to_managed_group(env: _ScopedEnv) -> None:
+    UserGroupManager.add_users(
+        env.managed_group, [env.outsider.id], user_performing_action=env.manager
+    )
+
+
+def test_manager_cannot_add_user_to_unmanaged_group(env: _ScopedEnv) -> None:
+    path = f"/manage/admin/user-group/{env.other_group.id}/add-users"
+    resp = call_endpoint(
+        "POST",
+        path,
+        {"user_ids": [env.member.id]},
+        env.manager.headers,
+        env.manager.cookies,
+    )
+    assert_response(resp, "POST", path, "manager", "denied")
+
+
+def test_manager_renames_managed_group(env: _ScopedEnv) -> None:
+    resp = call_endpoint(
+        "PATCH",
+        _RENAME_PATH,
+        {"id": env.managed_group.id, "name": "managed-renamed"},
+        env.manager.headers,
+        env.manager.cookies,
+    )
+    assert resp.status_code == 200, resp.text
+
+
+def test_manager_cannot_rename_unmanaged_group(env: _ScopedEnv) -> None:
+    resp = call_endpoint(
+        "PATCH",
+        _RENAME_PATH,
+        {"id": env.other_group.id, "name": "unmanaged-renamed"},
+        env.manager.headers,
+        env.manager.cookies,
+    )
+    assert_response(resp, "PATCH", _RENAME_PATH, "manager", "denied")
+
+
+def test_manager_cannot_patch_unmanaged_group(env: _ScopedEnv) -> None:
+    path = f"/manage/admin/user-group/{env.other_group.id}"
+    resp = call_endpoint(
+        "PATCH",
+        path,
+        _patch_group_body([env.outsider.id], []),
+        env.manager.headers,
+        env.manager.cookies,
+    )
+    assert_response(resp, "PATCH", path, "manager", "denied")
+
+
+# cc_pair re-attach gate — the junction-rewrite escalation vector.
+def test_manager_cannot_attach_public_cc_pair(env: _ScopedEnv) -> None:
+    public_cc_pair = CCPairManager.create_from_scratch(
+        user_performing_action=env.admin, access_type=AccessType.PUBLIC, groups=[]
+    )
+    before = _settled_cc_pair_ids(env)
+    path = f"/manage/admin/user-group/{env.managed_group.id}"
+    resp = call_endpoint(
+        "PATCH",
+        path,
+        _patch_group_body([env.manager.id, env.member.id], [public_cc_pair.id]),
+        env.manager.headers,
+        env.manager.cookies,
+    )
+    assert_response(resp, "PATCH", path, "manager", "denied")
+    assert _current_cc_pair_ids(env.managed_group.id) == before
+    assert public_cc_pair.id not in before
+
+
+def test_manager_cannot_attach_unmanaged_cc_pair(env: _ScopedEnv) -> None:
+    # Admin owns a PRIVATE cc_pair in a group the manager does not manage.
+    unmanaged_cc_pair = CCPairManager.create_from_scratch(
+        user_performing_action=env.admin,
+        access_type=AccessType.PRIVATE,
+        groups=[env.other_group.id],
+    )
+    before = _settled_cc_pair_ids(env)
+    path = f"/manage/admin/user-group/{env.managed_group.id}"
+    resp = call_endpoint(
+        "PATCH",
+        path,
+        _patch_group_body([env.manager.id, env.member.id], [unmanaged_cc_pair.id]),
+        env.manager.headers,
+        env.manager.cookies,
+    )
+    assert_response(resp, "PATCH", path, "manager", "denied")
+    assert _current_cc_pair_ids(env.managed_group.id) == before
+    assert unmanaged_cc_pair.id not in before
+
+
+def test_manager_cannot_reattach_removed_public_cc_pair(env: _ScopedEnv) -> None:
+    # A removed cc_pair leaves a stale is_current=False junction row until the sync
+    # sweeps it; that stale row must not make a public connector look "already
+    # attached" and slip past the re-attach gate.
+    public_cc_pair = CCPairManager.create_from_scratch(
+        user_performing_action=env.admin, access_type=AccessType.PUBLIC, groups=[]
+    )
+    before = _settled_cc_pair_ids(env)
+    _insert_stale_cc_pair_junction(env.managed_group.id, public_cc_pair.id)
+    path = f"/manage/admin/user-group/{env.managed_group.id}"
+    resp = call_endpoint(
+        "PATCH",
+        path,
+        _patch_group_body([env.manager.id, env.member.id], [public_cc_pair.id]),
+        env.manager.headers,
+        env.manager.cookies,
+    )
+    assert_response(resp, "PATCH", path, "manager", "denied")
+    # The stale row must stay stale — revival is the escalation this test guards.
+    assert _current_cc_pair_ids(env.managed_group.id) == before
+    assert public_cc_pair.id not in before
+
+
+def test_manager_attaches_groupless_private_cc_pair(env: _ScopedEnv) -> None:
+    # A private cc_pair in no group lands only in managed scope when attached —
+    # so the manager may pull it into their group.
+    groupless_cc_pair = CCPairManager.create_from_scratch(
+        user_performing_action=env.admin, access_type=AccessType.PRIVATE, groups=[]
+    )
+    _settled_cc_pair_ids(env)
+    path = f"/manage/admin/user-group/{env.managed_group.id}"
+    resp = call_endpoint(
+        "PATCH",
+        path,
+        _patch_group_body([env.manager.id, env.member.id], [groupless_cc_pair.id]),
+        env.manager.headers,
+        env.manager.cookies,
+    )
+    assert resp.status_code == 200, resp.text
+    assert groupless_cc_pair.id in _current_cc_pair_ids(env.managed_group.id)
+
+
+def test_manager_group_list_only_managed(env: _ScopedEnv) -> None:
+    groups = UserGroupManager.get_all(user_performing_action=env.manager)
+    group_ids = {g.id for g in groups}
+    assert env.managed_group.id in group_ids
+    assert env.other_group.id not in group_ids
+
+
+def test_admin_group_list_includes_all(env: _ScopedEnv) -> None:
+    groups = UserGroupManager.get_all(user_performing_action=env.admin)
+    group_ids = {g.id for g in groups}
+    assert {env.managed_group.id, env.other_group.id}.issubset(group_ids)
+
+
+def test_manager_me_permissions_flags(env: _ScopedEnv) -> None:
+    perms = _me_permissions(env.manager)
+    assert perms["is_manager"] is True
+    assert env.managed_group.id in perms["managed_group_ids"]
+    assert env.other_group.id not in perms["managed_group_ids"]
+
+    info = UserManager.get_user_info(env.manager)
+    effective = set(info.effective_permissions)
+    assert info.is_group_manager is True
+    # admin_capabilities unions the scoped bundle so the client can reveal manager nav
+    assert (
+        set(info.admin_capabilities) == effective | SCOPED_MANAGER_PERMISSIONS_EXPANDED
+    )
+    assert set(info.admin_capabilities) > effective
+
+
+def test_member_me_permissions_not_manager(env: _ScopedEnv) -> None:
+    perms = _me_permissions(env.member)
+    assert perms["is_manager"] is False
+    assert perms["managed_group_ids"] == []
+
+    info = UserManager.get_user_info(env.member)
+    assert info.is_group_manager is False
+    assert set(info.admin_capabilities) == set(info.effective_permissions)
+
+
+# Group create/delete/set-permissions stay admin-only.
+def test_manager_cannot_create_group(env: _ScopedEnv) -> None:
+    resp = call_endpoint(
+        "POST",
+        _GROUP_LIST_PATH,
+        {"name": "new-group", "user_ids": [], "cc_pair_ids": []},
+        env.manager.headers,
+        env.manager.cookies,
+    )
+    assert_response(resp, "POST", _GROUP_LIST_PATH, "manager", "denied")
+
+
+def test_manager_cannot_delete_group(env: _ScopedEnv) -> None:
+    path = f"/manage/admin/user-group/{env.managed_group.id}"
+    resp = call_endpoint("DELETE", path, None, env.manager.headers, env.manager.cookies)
+    assert_response(resp, "DELETE", path, "manager", "denied")
+
+
+def test_manager_cannot_set_group_permissions(env: _ScopedEnv) -> None:
+    path = f"/manage/admin/user-group/{env.managed_group.id}/permissions"
+    resp = call_endpoint(
+        "PUT",
+        path,
+        {"permissions": []},
+        env.manager.headers,
+        env.manager.cookies,
+    )
+    assert_response(resp, "PUT", path, "manager", "denied")

--- a/backend/tests/integration/tests/permissions/test_group_manager_resources.py
+++ b/backend/tests/integration/tests/permissions/test_group_manager_resources.py
@@ -1,0 +1,364 @@
+"""Escalation suite for two-gate scoping on connectors + document sets.
+
+A scoped group manager may only create/edit non-PUBLIC resources (PRIVATE or SYNC
+connectors; PRIVATE document sets) whose every group is one they manage; they can
+never widen to PUBLIC, capture another group's resource by reassignment, act
+outside their managed scope, or DELETE (admin-only). Global holders (admins)
+bypass GATE 2. Managers are seeded by flipping ``User__UserGroup.is_manager``
+directly (no manager-creation helper exists yet).
+
+Allowed actions go through the shared Manager classes (which assert real success);
+denied actions go through the shared ``_access_matrix`` helpers, which verify the
+403 is a genuine permission-gate denial rather than any incidental 403.
+"""
+
+import os
+from typing import Any
+from typing import NamedTuple
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import update
+
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.enums import AccessType
+from onyx.db.models import User__UserGroup
+from onyx.db.permissions import recompute_user_permissions__no_commit
+from tests.integration.common_utils.managers.cc_pair import CCPairManager
+from tests.integration.common_utils.managers.connector import ConnectorManager
+from tests.integration.common_utils.managers.credential import CredentialManager
+from tests.integration.common_utils.managers.document_set import DocumentSetManager
+from tests.integration.common_utils.managers.user import UserManager
+from tests.integration.common_utils.managers.user_group import UserGroupManager
+from tests.integration.common_utils.test_models import DATestUser
+from tests.integration.common_utils.test_models import DATestUserGroup
+from tests.integration.tests.permissions._access_matrix import assert_response
+from tests.integration.tests.permissions._access_matrix import call_endpoint
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="Group manager scoping is an enterprise-only capability",
+)
+
+_DOC_SET_PATH = "/manage/admin/document-set"
+
+
+class _ScopedEnv(NamedTuple):
+    admin: DATestUser
+    manager: DATestUser
+    managed_group: DATestUserGroup
+    other_group: DATestUserGroup
+
+
+def _promote_to_manager(user_id: str, group_id: int) -> None:
+    """Flip is_manager on the (user, group) edge and recompute the cached flag."""
+    with get_session_with_current_tenant() as db_session:
+        db_session.execute(
+            update(User__UserGroup)
+            .where(
+                User__UserGroup.user_id == user_id,
+                User__UserGroup.user_group_id == group_id,
+            )
+            .values(is_manager=True)
+        )
+        db_session.flush()
+        recompute_user_permissions__no_commit(user_id, db_session)
+        db_session.commit()
+
+
+@pytest.fixture
+def env(reset: None, admin_user: DATestUser) -> _ScopedEnv:  # noqa: ARG001
+    manager = UserManager.create(name="scoped_manager")
+    managed_group = UserGroupManager.create(
+        name="managed", user_ids=[manager.id], user_performing_action=admin_user
+    )
+    other_group = UserGroupManager.create(
+        name="unmanaged", user_performing_action=admin_user
+    )
+    _promote_to_manager(manager.id, managed_group.id)
+    return _ScopedEnv(admin_user, manager, managed_group, other_group)
+
+
+def _build_connector_and_credential(user: DATestUser) -> tuple[int, int]:
+    connector = ConnectorManager.create(user_performing_action=user)
+    credential = CredentialManager.create(
+        user_performing_action=user, curator_public=False
+    )
+    return connector.id, credential.id
+
+
+def _associate_body(access_type: AccessType, groups: list[int]) -> dict[str, Any]:
+    return {
+        "name": f"cc-{uuid4()}",
+        "access_type": access_type.value,
+        "groups": groups,
+    }
+
+
+def _doc_set_body(
+    *,
+    is_public: bool,
+    groups: list[int],
+    cc_pair_ids: list[int],
+    doc_set_id: int | None = None,
+) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "name": f"ds-{uuid4()}",
+        "description": "escalation test",
+        "cc_pair_ids": cc_pair_ids,
+        "is_public": is_public,
+        "users": [],
+        "groups": groups,
+        "federated_connectors": [],
+    }
+    if doc_set_id is not None:
+        body["id"] = doc_set_id
+    return body
+
+
+def test_admin_creates_public_cc_pair_bypasses_gate(env: _ScopedEnv) -> None:
+    # Control: a global holder is not scope-restricted (PUBLIC, no groups).
+    CCPairManager.create_from_scratch(
+        user_performing_action=env.admin, access_type=AccessType.PUBLIC, groups=[]
+    )
+
+
+def test_manager_creates_private_cc_pair_in_managed_group(env: _ScopedEnv) -> None:
+    CCPairManager.create_from_scratch(
+        user_performing_action=env.manager,
+        access_type=AccessType.PRIVATE,
+        groups=[env.managed_group.id],
+    )
+
+
+def test_manager_cannot_create_cc_pair_in_unmanaged_group(env: _ScopedEnv) -> None:
+    connector_id, credential_id = _build_connector_and_credential(env.manager)
+    path = f"/manage/connector/{connector_id}/credential/{credential_id}"
+    resp = call_endpoint(
+        "PUT",
+        path,
+        _associate_body(AccessType.PRIVATE, [env.other_group.id]),
+        env.manager.headers,
+        env.manager.cookies,
+    )
+    assert_response(resp, "PUT", path, "manager", "denied")
+
+
+def test_manager_cannot_create_public_cc_pair(env: _ScopedEnv) -> None:
+    connector_id, credential_id = _build_connector_and_credential(env.manager)
+    path = f"/manage/connector/{connector_id}/credential/{credential_id}"
+    resp = call_endpoint(
+        "PUT",
+        path,
+        _associate_body(AccessType.PUBLIC, [env.managed_group.id]),
+        env.manager.headers,
+        env.manager.cookies,
+    )
+    assert_response(resp, "PUT", path, "manager", "denied")
+
+
+def test_manager_cannot_create_cc_pair_without_groups(env: _ScopedEnv) -> None:
+    # Fail-closed: a PRIVATE cc_pair in zero groups has no managed scope.
+    connector_id, credential_id = _build_connector_and_credential(env.manager)
+    path = f"/manage/connector/{connector_id}/credential/{credential_id}"
+    resp = call_endpoint(
+        "PUT",
+        path,
+        _associate_body(AccessType.PRIVATE, []),
+        env.manager.headers,
+        env.manager.cookies,
+    )
+    assert_response(resp, "PUT", path, "manager", "denied")
+
+
+def test_manager_creates_private_doc_set_in_managed_group(env: _ScopedEnv) -> None:
+    cc_pair = CCPairManager.create_from_scratch(
+        user_performing_action=env.manager,
+        access_type=AccessType.PRIVATE,
+        groups=[env.managed_group.id],
+    )
+    DocumentSetManager.create(
+        user_performing_action=env.manager,
+        is_public=False,
+        groups=[env.managed_group.id],
+        cc_pair_ids=[cc_pair.id],
+    )
+
+
+def test_manager_cannot_create_public_doc_set(env: _ScopedEnv) -> None:
+    cc_pair = CCPairManager.create_from_scratch(
+        user_performing_action=env.manager,
+        access_type=AccessType.PRIVATE,
+        groups=[env.managed_group.id],
+    )
+    resp = call_endpoint(
+        "POST",
+        _DOC_SET_PATH,
+        _doc_set_body(
+            is_public=True, groups=[env.managed_group.id], cc_pair_ids=[cc_pair.id]
+        ),
+        env.manager.headers,
+        env.manager.cookies,
+    )
+    assert_response(resp, "POST", _DOC_SET_PATH, "manager", "denied")
+
+
+def test_manager_cannot_create_doc_set_in_unmanaged_group(env: _ScopedEnv) -> None:
+    cc_pair = CCPairManager.create_from_scratch(
+        user_performing_action=env.manager,
+        access_type=AccessType.PRIVATE,
+        groups=[env.managed_group.id],
+    )
+    resp = call_endpoint(
+        "POST",
+        _DOC_SET_PATH,
+        _doc_set_body(
+            is_public=False, groups=[env.other_group.id], cc_pair_ids=[cc_pair.id]
+        ),
+        env.manager.headers,
+        env.manager.cookies,
+    )
+    assert_response(resp, "POST", _DOC_SET_PATH, "manager", "denied")
+
+
+def test_manager_cannot_capture_doc_set_by_reassign(env: _ScopedEnv) -> None:
+    cc_pair = CCPairManager.create_from_scratch(
+        user_performing_action=env.manager,
+        access_type=AccessType.PRIVATE,
+        groups=[env.managed_group.id],
+    )
+    doc_set = DocumentSetManager.create(
+        user_performing_action=env.manager,
+        is_public=False,
+        groups=[env.managed_group.id],
+        cc_pair_ids=[cc_pair.id],
+    )
+    # current ∪ requested must be ⊆ managed — adding an unmanaged group is rejected.
+    resp = call_endpoint(
+        "PATCH",
+        _DOC_SET_PATH,
+        _doc_set_body(
+            is_public=False,
+            groups=[env.managed_group.id, env.other_group.id],
+            cc_pair_ids=[cc_pair.id],
+            doc_set_id=doc_set.id,
+        ),
+        env.manager.headers,
+        env.manager.cookies,
+    )
+    assert_response(resp, "PATCH", _DOC_SET_PATH, "manager", "denied")
+
+
+def test_manager_edits_doc_set_within_managed_group(env: _ScopedEnv) -> None:
+    cc_pair = CCPairManager.create_from_scratch(
+        user_performing_action=env.manager,
+        access_type=AccessType.PRIVATE,
+        groups=[env.managed_group.id],
+    )
+    doc_set = DocumentSetManager.create(
+        user_performing_action=env.manager,
+        is_public=False,
+        groups=[env.managed_group.id],
+        cc_pair_ids=[cc_pair.id],
+    )
+    DocumentSetManager.edit(doc_set, user_performing_action=env.manager)
+
+
+def test_manager_cannot_delete_doc_set(env: _ScopedEnv) -> None:
+    cc_pair = CCPairManager.create_from_scratch(
+        user_performing_action=env.manager,
+        access_type=AccessType.PRIVATE,
+        groups=[env.managed_group.id],
+    )
+    doc_set = DocumentSetManager.create(
+        user_performing_action=env.manager,
+        is_public=False,
+        groups=[env.managed_group.id],
+        cc_pair_ids=[cc_pair.id],
+    )
+    # Owns it, in a managed group — still denied: delete is admin-only.
+    path = f"{_DOC_SET_PATH}/{doc_set.id}"
+    resp = call_endpoint("DELETE", path, None, env.manager.headers, env.manager.cookies)
+    assert_response(resp, "DELETE", path, "manager", "denied")
+
+
+def test_manager_cannot_delete_cc_pair(env: _ScopedEnv) -> None:
+    cc_pair = CCPairManager.create_from_scratch(
+        user_performing_action=env.manager,
+        access_type=AccessType.PRIVATE,
+        groups=[env.managed_group.id],
+    )
+    path = "/manage/admin/deletion-attempt"
+    resp = call_endpoint(
+        "POST",
+        path,
+        {"connector_id": cc_pair.connector_id, "credential_id": cc_pair.credential_id},
+        env.manager.headers,
+        env.manager.cookies,
+    )
+    assert_response(resp, "POST", path, "manager", "denied")
+
+
+def test_manager_pauses_own_managed_cc_pair(env: _ScopedEnv) -> None:
+    # Pause/status (mutate routes) authorize via the re-keyed read/editable filter,
+    # not a separate scope check — so managed-scope access gates mutation too.
+    cc_pair = CCPairManager.create_from_scratch(
+        user_performing_action=env.manager,
+        access_type=AccessType.PRIVATE,
+        groups=[env.managed_group.id],
+    )
+    CCPairManager.pause_cc_pair(cc_pair, user_performing_action=env.manager)
+
+
+def test_manager_cannot_pause_unmanaged_cc_pair(env: _ScopedEnv) -> None:
+    # Admin owns a PRIVATE cc_pair in a group the manager does not manage.
+    admin_cc_pair = CCPairManager.create_from_scratch(
+        user_performing_action=env.admin,
+        access_type=AccessType.PRIVATE,
+        groups=[env.other_group.id],
+    )
+    path = f"/manage/admin/cc-pair/{admin_cc_pair.id}/status"
+    resp = call_endpoint(
+        "PUT",
+        path,
+        {"status": "PAUSED"},
+        env.manager.headers,
+        env.manager.cookies,
+    )
+    assert_response(resp, "PUT", path, "manager", "denied")
+
+
+def test_plain_member_cannot_create_doc_set(env: _ScopedEnv) -> None:
+    # A group member without is_manager has NONE authority — rejected at GATE 1.
+    member = UserManager.create(name="plain_member")
+    UserGroupManager.add_users(
+        env.managed_group, [member.id], user_performing_action=env.admin
+    )
+    resp = call_endpoint(
+        "POST",
+        _DOC_SET_PATH,
+        _doc_set_body(is_public=False, groups=[env.managed_group.id], cc_pair_ids=[]),
+        member.headers,
+        member.cookies,
+    )
+    assert_response(resp, "POST", _DOC_SET_PATH, "member", "denied")
+
+
+def test_admin_cc_pair_detail_carries_permissions_map(env: _ScopedEnv) -> None:
+    # The connector read route is GLOBAL-only (no allow_scope), so a scoped manager
+    # can't reach it; this covers the admin wire format (the manager distinction is
+    # proven in the projection contract test).
+    cc_pair = CCPairManager.create_from_scratch(
+        user_performing_action=env.admin,
+        access_type=AccessType.PRIVATE,
+        groups=[env.managed_group.id],
+    )
+    path = f"/manage/admin/cc-pair/{cc_pair.id}"
+    resp = call_endpoint("GET", path, None, env.admin.headers, env.admin.cookies)
+    assert resp.status_code == 200
+
+    body = resp.json()
+    # admin holds global MANAGE_CONNECTORS, so every action is allowed
+    assert body["permissions"] == {"edit": True, "delete": True, "publish": True}
+    # edit is stamped from is_editable_for_current_user, so the two must agree
+    assert body["permissions"]["edit"] == body["is_editable_for_current_user"]

--- a/backend/tests/integration/tests/permissions/test_manage_user_groups.py
+++ b/backend/tests/integration/tests/permissions/test_manage_user_groups.py
@@ -71,10 +71,9 @@ def test_access_matrix(
 
 
 # PUT /manage/admin/user-group/{id}/permissions is admin-only (not
-# MANAGE_USER_GROUPS) to prevent privilege escalation — a group manager
-# could otherwise grant their own group any toggleable permission. The
-# endpoint must remain gated on FULL_ADMIN_PANEL_ACCESS, so holders of
-# MANAGE_USER_GROUPS are expected to be denied here.
+# MANAGE_USER_GROUPS) to prevent privilege escalation: a group manager
+# could otherwise grant their own group any toggleable permission. Gated
+# on FULL_ADMIN_PANEL_ACCESS, so MANAGE_USER_GROUPS holders are denied here.
 _SET_PERMISSIONS_USER_KINDS: list[tuple[str, str]] = [
     ("admin", "allowed"),
     ("holder", "denied"),

--- a/backend/tests/integration/tests/usergroup/test_group_membership_updates_user_permissions.py
+++ b/backend/tests/integration/tests/usergroup/test_group_membership_updates_user_permissions.py
@@ -1,16 +1,50 @@
 import os
 
 import pytest
+from sqlalchemy import select
+from sqlalchemy import update
 
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import Permission
 from onyx.db.models import PermissionGrant
+from onyx.db.models import User
+from onyx.db.models import User__UserGroup
 from onyx.db.models import UserGroup as UserGroupModel
 from onyx.db.permissions import recompute_permissions_for_group__no_commit
 from onyx.db.permissions import recompute_user_permissions__no_commit
 from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.managers.user_group import UserGroupManager
 from tests.integration.common_utils.test_models import DATestUser
+
+
+def _set_membership_is_manager(user_id: str, group_id: int, value: bool) -> None:
+    """Flip is_manager on one (user, group) edge, then recompute.
+
+    make_group_manager lands in a later PR, so promote by writing the edge directly.
+    """
+    with get_session_with_current_tenant() as db_session:
+        db_session.execute(
+            update(User__UserGroup)
+            .where(
+                User__UserGroup.user_id == user_id,
+                User__UserGroup.user_group_id == group_id,
+            )
+            .values(is_manager=value)
+        )
+        db_session.flush()
+        recompute_user_permissions__no_commit(user_id, db_session)
+        db_session.commit()
+
+
+def _is_group_manager(user_id: str) -> bool:
+    with get_session_with_current_tenant() as db_session:
+        value = db_session.scalar(
+            select(User.is_group_manager).where(
+                User.id == user_id  # ty: ignore[invalid-argument-type]
+            )
+        )
+        assert value is not None
+        return value
 
 
 @pytest.mark.skipif(
@@ -112,3 +146,57 @@ def test_group_permission_change_propagates_to_all_members(
     for u in (user_a, user_b):
         perms = UserManager.get_permissions(u)
         assert "add:agents" not in perms, f"{u.id} still has add:agents: {perms}"
+
+
+@pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="User group tests are enterprise only",
+)
+def test_is_group_manager_flag_recomputed_on_manager_change(
+    reset: None,  # noqa: ARG001
+    admin_user: DATestUser,
+) -> None:
+    """is_group_manager is the second column recompute writes (with effective_permissions)."""
+    member: DATestUser = UserManager.create()
+    group = UserGroupManager.create(
+        name="manager-flag-group",
+        user_ids=[admin_user.id, member.id],
+        user_performing_action=admin_user,
+    )
+
+    assert _is_group_manager(member.id) is False
+
+    _set_membership_is_manager(member.id, group.id, True)
+    assert _is_group_manager(member.id) is True
+
+    _set_membership_is_manager(member.id, group.id, False)
+    assert _is_group_manager(member.id) is False
+
+
+@pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="User group tests are enterprise only",
+)
+def test_is_group_manager_true_when_managing_any_group(
+    reset: None,  # noqa: ARG001
+    admin_user: DATestUser,
+) -> None:
+    """Managing one group is enough — even while a plain member of another."""
+    member: DATestUser = UserManager.create()
+    UserGroupManager.create(
+        name="plain-member-group",
+        user_ids=[admin_user.id, member.id],
+        user_performing_action=admin_user,
+    )
+    managed_group = UserGroupManager.create(
+        name="managed-group",
+        user_ids=[admin_user.id, member.id],
+        user_performing_action=admin_user,
+    )
+    assert _is_group_manager(member.id) is False
+
+    _set_membership_is_manager(member.id, managed_group.id, True)
+    assert _is_group_manager(member.id) is True
+
+    _set_membership_is_manager(member.id, managed_group.id, False)
+    assert _is_group_manager(member.id) is False

--- a/backend/tests/unit/onyx/auth/test_permissions.py
+++ b/backend/tests/unit/onyx/auth/test_permissions.py
@@ -12,12 +12,15 @@ from fastapi import Request
 from onyx.auth.permissions import ALL_PERMISSIONS
 from onyx.auth.permissions import CE_UNGATED_PERMISSIONS
 from onyx.auth.permissions import get_effective_permissions
+from onyx.auth.permissions import has_global_permission
+from onyx.auth.permissions import has_permission
 from onyx.auth.permissions import IMPLIED_PERMISSIONS
 from onyx.auth.permissions import NON_TOGGLEABLE_PERMISSIONS
 from onyx.auth.permissions import require_permission
 from onyx.auth.permissions import resolve_effective_permissions
 from onyx.auth.users import get_anonymous_user
 from onyx.db.enums import Permission
+from onyx.db.enums import PermissionAuthority
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.utils.variable_functionality import global_version
@@ -64,9 +67,13 @@ class TestResolveEffectivePermissions:
         """The chat write surface must not leak into the search surface."""
         assert "read:search" not in resolve_effective_permissions({"write:chat"})
 
-    def test_single_implication(self) -> None:
-        result = resolve_effective_permissions({"add:agents"})
-        assert result == {"add:agents", "read:agents"}
+    def test_manage_service_account_api_keys_implies_read_user_groups(self) -> None:
+        result = resolve_effective_permissions({"manage:service_account_api_keys"})
+        assert result == {"manage:service_account_api_keys", "read:user_groups"}
+
+    def test_add_agents_implies_nothing(self) -> None:
+        """ADD_AGENTS must NOT imply READ_AGENTS — creating agents grants no see-all."""
+        assert resolve_effective_permissions({"add:agents"}) == {"add:agents"}
 
     def test_manage_agents_implies_add_and_reads(self) -> None:
         """manage:agents implies add:agents, read:agents, and read:document_sets."""
@@ -129,7 +136,6 @@ class TestResolveEffectivePermissions:
             "read:chat",
             "write:chat",
             "add:agents",
-            "read:agents",
             "manage:connectors",
             "read:connectors",
         }
@@ -161,11 +167,12 @@ class TestGetEffectivePermissions:
         global_version.unset_ee()
 
     def test_expands_implied_permissions(self) -> None:
-        """Column stores only granted; get_effective_permissions expands implied."""
+        """Column stores only granted; get_effective_permissions expands implied. ADD_AGENTS
+        implies nothing — it must not grant READ_AGENTS (see-all-agents)."""
         user = MagicMock()
         user.effective_permissions = ["add:agents"]
         result = get_effective_permissions(user)
-        assert result == {Permission.ADD_AGENTS, Permission.READ_AGENTS}
+        assert result == {Permission.ADD_AGENTS}
 
     def test_admin_expands_to_all(self) -> None:
         user = MagicMock()
@@ -205,7 +212,7 @@ class TestCEUngatedPermissions:
         user.effective_permissions = ["basic"]
         result = get_effective_permissions(user)
         assert Permission.ADD_AGENTS in result
-        assert Permission.READ_AGENTS in result
+        assert Permission.READ_AGENTS not in result  # ADD_AGENTS doesn't grant see-all
         assert Permission.BASIC_ACCESS in result
 
     def test_empty_user_gets_ungated_permissions_in_ce(self) -> None:
@@ -213,7 +220,7 @@ class TestCEUngatedPermissions:
         user.effective_permissions = []
         result = get_effective_permissions(user)
         assert Permission.ADD_AGENTS in result
-        assert Permission.READ_AGENTS in result
+        assert Permission.READ_AGENTS not in result  # ADD_AGENTS doesn't grant see-all
 
     def test_basic_user_does_not_get_ungated_permissions_in_ee(self) -> None:
         global_version.set_ee()
@@ -383,6 +390,125 @@ class TestAnonymousUserPermissions:
         with pytest.raises(OnyxError) as exc_info:
             await dep(request=_request([Permission.READ_SEARCH]), user=user)
         assert exc_info.value.error_code == OnyxErrorCode.INSUFFICIENT_PERMISSIONS
+
+
+class TestRequirePermissionScope:
+    """GATE 1 wiring: allow_scope admits a scoped group manager (cached flag +
+    bundle token, no global grant) while the token cap still applies."""
+
+    def setup_method(self) -> None:
+        global_version.set_ee()
+
+    def teardown_method(self) -> None:
+        global_version.unset_ee()
+
+    def _manager(self) -> MagicMock:
+        user = MagicMock()
+        user.effective_permissions = ["basic"]  # no global manage token
+        user.is_group_manager = True
+        return user
+
+    @pytest.mark.asyncio
+    async def test_allow_scope_admits_scoped_manager(self) -> None:
+        user = self._manager()
+        dep = require_permission(Permission.MANAGE_DOCUMENT_SETS, allow_scope=True)
+        assert await dep(request=_request(None), user=user) is user
+
+    @pytest.mark.asyncio
+    async def test_default_rejects_scoped_manager(self) -> None:
+        # allow_scope off (default) → no behavior change; manager lacks the token.
+        user = self._manager()
+        dep = require_permission(Permission.MANAGE_DOCUMENT_SETS)
+        with pytest.raises(OnyxError):
+            await dep(request=_request(None), user=user)
+
+    @pytest.mark.asyncio
+    async def test_allow_scope_rejects_non_bundle_token(self) -> None:
+        user = self._manager()
+        dep = require_permission(Permission.MANAGE_LLMS, allow_scope=True)
+        with pytest.raises(OnyxError):
+            await dep(request=_request(None), user=user)
+
+    @pytest.mark.asyncio
+    async def test_allow_scope_rejects_non_manager(self) -> None:
+        user = self._manager()
+        user.is_group_manager = False
+        dep = require_permission(Permission.MANAGE_DOCUMENT_SETS, allow_scope=True)
+        with pytest.raises(OnyxError):
+            await dep(request=_request(None), user=user)
+
+    @pytest.mark.asyncio
+    async def test_allow_scope_still_capped_by_token(self) -> None:
+        # Scope would admit, but a read:search-scoped PAT can't reach the token.
+        user = self._manager()
+        dep = require_permission(Permission.MANAGE_DOCUMENT_SETS, allow_scope=True)
+        with pytest.raises(OnyxError):
+            await dep(request=_request([Permission.READ_SEARCH]), user=user)
+
+
+class TestHasPermissionAuthority:
+    """has_permission is the single 3-state classifier: GLOBAL / SCOPED / NONE."""
+
+    def setup_method(self) -> None:
+        global_version.set_ee()
+
+    def teardown_method(self) -> None:
+        global_version.unset_ee()
+
+    def _user(self, perms: list[str], is_manager: bool = False) -> MagicMock:
+        user = MagicMock()
+        user.effective_permissions = perms
+        user.is_group_manager = is_manager
+        return user
+
+    def test_global_when_held_outright(self) -> None:
+        user = self._user(["manage:document_sets"])
+        assert (
+            has_permission(user, Permission.MANAGE_DOCUMENT_SETS)
+            is PermissionAuthority.GLOBAL
+        )
+
+    def test_global_for_admin_on_any_token(self) -> None:
+        user = self._user(["admin"])
+        assert (
+            has_permission(user, Permission.MANAGE_LLMS) is PermissionAuthority.GLOBAL
+        )
+
+    def test_scoped_when_manager_holds_only_via_bundle(self) -> None:
+        user = self._user(["basic"], is_manager=True)
+        assert (
+            has_permission(user, Permission.MANAGE_DOCUMENT_SETS)
+            is PermissionAuthority.SCOPED
+        )
+
+    def test_none_when_manager_but_token_not_in_bundle(self) -> None:
+        user = self._user(["basic"], is_manager=True)
+        assert has_permission(user, Permission.MANAGE_LLMS) is PermissionAuthority.NONE
+
+    def test_none_when_not_manager_and_not_held(self) -> None:
+        user = self._user(["basic"], is_manager=False)
+        assert (
+            has_permission(user, Permission.MANAGE_DOCUMENT_SETS)
+            is PermissionAuthority.NONE
+        )
+
+    def test_global_outranks_scoped(self) -> None:
+        # holds the token globally AND is a manager → GLOBAL wins
+        user = self._user(["manage:document_sets"], is_manager=True)
+        assert (
+            has_permission(user, Permission.MANAGE_DOCUMENT_SETS)
+            is PermissionAuthority.GLOBAL
+        )
+
+    def test_has_global_permission_true_only_for_global(self) -> None:
+        holder = self._user(["manage:document_sets"])
+        assert has_global_permission(holder, Permission.MANAGE_DOCUMENT_SETS) is True
+        # SCOPED manager → not global
+        manager = self._user(["basic"], is_manager=True)
+        assert has_global_permission(manager, Permission.MANAGE_DOCUMENT_SETS) is False
+        # NONE → not global
+        plain = self._user(["basic"])
+        assert has_global_permission(plain, Permission.MANAGE_DOCUMENT_SETS) is False
 
 
 # ---------------------------------------------------------------------------

--- a/docs/group-manager-scoped-permissions/00-index.md
+++ b/docs/group-manager-scoped-permissions/00-index.md
@@ -14,6 +14,7 @@ Source of truth (wiki): `Engineering Projects/Group-Based Permissions System V2/
 | 03 | [03-detailed-design.md](03-detailed-design.md) | DB design (+rationale) · auth primitives · ~4 filter rewrites (+skill, +token-limit; §11) · write-path gate insertions · PAT · API · FE · file tree · pre-impl notes · open decisions | ✅ |
 | 04 | [04-implementation-plan.md](04-implementation-plan.md) | CLAUDE.md-format plan + plan-challenge results (passed all 6) | ✅ |
 | 05 | [05-pr-roadmap.md](05-pr-roadmap.md) | 6 ordered PRs (~2.3k LOC) w/ drift checkpoints + lands-together safety invariant | ✅ |
+| 07 | [07-ui-capability-model-design.md](07-ui-capability-model-design.md) | **UI redesign** (server-driven capability model): kills client-side `visibilityPermissions()`; `/me.admin_capabilities` (coarse) + per-resource `permissions{}` map (per-item) stamped by a shared `can_<action>` helper the write-guard also calls (drift impossible by construction); `<Can>` primitive; 49/109 affordance audit + complete mapping + real contract test + 5-PR roadmap. **v2** — revised after a 34-finding adversarial pressure test | 🆕 design (v2) |
 
 **Decisions locked at GATE 2:** D1 cache `is_group_manager` boolean (route gate zero-query; managed-list stays
 live) · D2 admins-only create groups · D3 admin-or-manager-of-that-group assigns managers.
@@ -27,3 +28,25 @@ everything **except delete** · **D7 attaching an agent to a group is controlled
 chat-runtime, and document/Vespa ACL are untouched, and refuted the backfill data-loss concern. Full
 case-by-case coverage + the boot-bug prerequisite are in **[03 §11](03-detailed-design.md)** — the
 authoritative implementation checklist.
+
+**Decision locked 2026-08-03:** **D8 action + MCP-server _management_ (edit / toggle / OAuth-auth) is
+owner-or-admin, NOT agent-mediated.** D4 still holds for GATE 1 reach + create (a scoped manager reaches
+the action/MCP routes and may create), but the agent-mediated GATE 2 that once let a manager edit any
+action whose referencing agents were all in their managed groups was **dropped** — it was the source of
+most of the review's P1/P2 findings, and the simpler owner-or-creator gate (`can_manage_own_tool` /
+`_ensure_mcp_server_owner_or_admin`, mirrored 1:1 by the UI projection) is the intended final design. Delete
+follows D9 below. This **supersedes** the "agent-mediated GATE 2 replaces owner-or-admin" language
+still in [03 §11](03-detailed-design.md), [05](05-pr-roadmap.md), and [07](07-ui-capability-model-design.md).
+
+**Decision locked 2026-08-04:** **D9 delete/publish follow ownership — D6's "except delete" scopes
+managed-group resources, not ones the manager created.** A scoped manager may delete a custom action or
+MCP server *they created*, and publish an agent *they own*, exactly as any other owner may: the gate is
+owner-or-admin (`can_manage_own_tool`, `_ensure_mcp_server_owner_or_admin`, `can_delete_persona`), and
+being a manager never subtracts a right they'd hold as an ordinary user. D6 still holds where it was
+aimed — a manager may not delete a connector, document set, or agent that merely sits in a group they
+manage. Pinned by `test_permission_projection_contract.py` ("the creator fully controls the action they
+made"); `assert_within_scope` in `_assert_persona_update_within_managed_scope` therefore does **not**
+gate `is_public`, and the EE group-share gate exempts an owner whose group shares are unchanged —
+**shares, not just group ids**: re-leveling a group from VIEWER to EDITOR is a change and gets no
+exemption. What ownership never buys is *widening* — sharing a public agent into a managed group still
+rejects, because that would capture it into scope.

--- a/docs/group-manager-scoped-permissions/01-research.md
+++ b/docs/group-manager-scoped-permissions/01-research.md
@@ -23,8 +23,8 @@ Source of truth: wiki `Engineering Projects/Group-Based Permissions System V2/so
 
 | §8 artifact | Status | Evidence |
 |---|---|---|
-| `is_manager` column on `User__UserGroup` | **ABSENT** | only old `is_curator` present — `backend/onyx/db/models.py:4361` |
-| Alembic migration `4fa09af6ca14` (`is_manager` add/backfill) | **ABSENT — not in tree** | HEAD migration is still `c8e316473aaa` (`make_user_role_nullable`), no child revision |
+| `is_manager` column on `User__UserGroup` | ABSENT at research time → **BUILT (PR1)** | now on `User__UserGroup`; `User.is_group_manager` cached flag added too |
+| Alembic migration (`is_manager` add/backfill) | ABSENT at research time → **BUILT (PR1) as `c71a18ea7d07`** | down_revision `c8e316473aaa`, now head; placeholder `4fa09af6ca14` never used |
 | `SCOPED_MANAGER_PERMISSIONS` bundle | ABSENT | no match in backend |
 | `get_scoped_groups()` resolver | ABSENT | no match |
 | `assert_group_set_within_scope` / `can_act_on_resource` write-side gate | ABSENT | no match |
@@ -34,8 +34,9 @@ Source of truth: wiki `Engineering Projects/Group-Based Permissions System V2/so
 | Group-Manager assignment UI (web) | ABSENT | no manager UI under `web/src/app/(ee/)admin/groups*` |
 | PAT scope-intersection w/ manager scope | ABSENT | `backend/onyx/db/pat.py` scopes are flat permission tokens |
 
-> **⚠ Doc/reality drift:** the wiki §8 text says *"Implemented as revision `4fa09af6ca14`."* That migration
-> **does not exist** in the repo. The doc overstates status — treat all of §8 as not-yet-built.
+> **⚠ Status (updated):** at research time §8 was entirely unbuilt and the wiki's *"Implemented as revision
+> `4fa09af6ca14`"* was wrong. Since then **PR0+PR1 shipped** (migration `c71a18ea7d07`); scoped enforcement
+> (PR2+) is still not-yet-built.
 
 ### Base system (§1–7) — FULLY BUILT (the foundation §8 extends)
 

--- a/docs/group-manager-scoped-permissions/01-research.md
+++ b/docs/group-manager-scoped-permissions/01-research.md
@@ -2,6 +2,11 @@
 
 # §8 Scoped Permissions (Group Manager) — Research
 
+> **Historical research.** Final primitive names/shapes differ — see [03 §2](03-detailed-design.md):
+> `has_permission` returns `PermissionAuthority` (the one classifier; the proposed `has_permission_or_scope`
+> was folded into it), and the write gate is `assert_within_scope` / `assert_global` (not
+> `assert_group_set_within_scope`). The names below reflect the original investigation, not the shipped API.
+
 ## Requirement
 
 Implement **§8 of the Group-Based Permissions System V2** solution design — the **Group Manager**

--- a/docs/group-manager-scoped-permissions/02-high-level-design.md
+++ b/docs/group-manager-scoped-permissions/02-high-level-design.md
@@ -2,9 +2,16 @@
 
 # §8 Scoped Permissions (Group Manager) — High-Level Design
 
+> **Primitives superseded by [03 §2](03-detailed-design.md) (single-classifier model).** `has_permission`
+> now returns `PermissionAuthority` (GLOBAL/SCOPED/NONE) — it is the one classifier; the separate `has_permission_or_scope`
+> is gone. GATE 1 is `require_permission(..., allow_scope=True)` (a threshold on `has_permission`); GATE 2 is
+> `assert_within_scope` / `assert_global`. Names below are updated to match; see 03 §2 for signatures.
+
 > **Revised by the 2026-06-29 regression review.** Bundle/coverage decisions here are updated by
-> **D4** (`manage:actions` stays in the bundle, scoped via agents at GATE 2), **D5** (skills = a 7th scoped resource under a
-> new `manage:skills` token), **D6** (managers do everything **except delete**) and **D7** (attaching an agent
+> **D4** (`manage:actions` stays in the bundle — GATE 1 reach + create; its agent-mediated GATE 2 was later
+> dropped, see **D8**), **D5** (skills = a 7th scoped resource under a
+> new `manage:skills` token), **D6** (managers do everything **except delete a resource that merely sits in a
+> managed group** — deleting something they *created* is ownership, see **D9**) and **D7** (attaching an agent
 > to a group is controlled by `manage:agents`). The authoritative, complete case list lives in
 > [03 §11](03-detailed-design.md). Also a hard prerequisite: the broken `current_curator_or_admin_user`
 > import (03 §11.0) must be fixed or the API server won't boot.
@@ -30,10 +37,15 @@ resolution (never cached, never stale), and a **two-gate** enforcement model who
                                 │
             is_manager=TRUE  ⇒  apply SCOPED_MANAGER_PERMISSIONS (in code)
                                 │   {manage:connectors, manage:document_sets,
-                                ▼    manage:agents, add:agents, manage:user_groups}
-                          but ONLY to    (+ manage:skills + manage:actions; actions
-                          Engineering's   scoped via their agents at GATE 2 — see 03 §11)
+                                ▼    manage:agents, add:agents, manage:user_groups,
+                          but ONLY to     manage:skills, manage:actions}
+                          Engineering's
                           resources — resolved LIVE
+
+   EXCEPT manage:actions — a custom action or MCP server belongs to no group, so there is
+   nothing to scope it by. The bundle grants GATE 1 reach + create only; managing an
+   existing one is plain owner-or-admin (D8). Agent-derived scope survives solely for
+   *viewing* an MCP server connected to a managed group. See 03 §11.1.
 ```
 
 Two things never live in the database as data:
@@ -54,20 +66,20 @@ Every manager action passes **two** independent checks. The first lets them *rea
         │
         ▼
   ┌─────────────────────────── GATE 1: ROUTE GATE ───────────────────────────┐
-  │ require_permission(...) → has_permission_or_scope(MANAGE_DOCUMENT_SETS)   │
+  │ require_permission(...) → has_permission(MANAGE_DOCUMENT_SETS)   │
   │   passes if: holds the token GLOBALLY  OR  manages ANY group.            │
   │   COARSE. Can only reject. Does NOT authorize the action.                │
   └──────────────────────────────────────────────────────────────────────────┘
         │ (reached the handler)
         ▼
   ┌──────────────────── GATE 2: PER-RESOURCE WRITE-SIDE GATE ─────────────────┐
-  │ assert_group_set_within_scope(user, resource, new_groups, access_type)    │
+  │ assert_within_scope(user, resource, new_groups, access_type)    │
   │   runs INSIDE the DB write, in the same transaction. Re-reads the          │
   │   resource's CURRENT groups from the DB (not the client's list). Allows    │
   │   only if the resource ends up:                                            │
   │     • in ≥1 managed group,                                                 │
   │     • with NO group outside the managed set (current ∪ new ⊆ managed),     │
-  │     • PRIVATE (never PUBLIC / SYNC).                                        │
+  │     • non-PUBLIC (PRIVATE or SYNC; never PUBLIC).                           │
   │   Admin override (admin token) skips this entirely.                        │
   └──────────────────────────────────────────────────────────────────────────┘
         │
@@ -109,14 +121,14 @@ The gate therefore loads the resource's **current** groups in the same transacti
    filter."
 
 ### Write path (Alice edits an Engineering connector)
-1. Route gate `has_permission_or_scope(MANAGE_CONNECTORS)` → passes (she manages a group).
+1. Route gate `has_permission(MANAGE_CONNECTORS)` → passes (she manages a group).
 2. Handler calls the connector update DB fn.
-3. **Inside the DB write**, `assert_group_set_within_scope` re-reads the cc_pair's current groups, checks
+3. **Inside the DB write**, `assert_within_scope` re-reads the cc_pair's current groups, checks
    `current ∪ requested ⊆ get_scoped_groups(Alice)`, checks `access_type == PRIVATE`. Pass → write; fail →
    `OnyxError(INSUFFICIENT_PERMISSIONS)`, transaction rolls back.
 
 ### Membership path (Alice adds Bob to Engineering)
-1. Route gate `has_permission_or_scope(MANAGE_USER_GROUPS)` → passes.
+1. Route gate `has_permission(MANAGE_USER_GROUPS)` → passes.
 2. `add_users_to_user_group(... group_id=Engineering ...)`.
 3. Write-side gate: `Engineering ∈ get_scoped_groups(Alice)`? Yes → add. (If Alice targeted Marketing → reject.)
    `set_group_permissions` is **untouched** — it stays `FULL_ADMIN_PANEL_ACCESS`-only, so a manager can never
@@ -128,8 +140,8 @@ The gate therefore loads the resource's **current** groups in the same transacti
         ┌────────────────────────── auth/permissions.py ──────────────────────────┐
         │  SCOPED_MANAGER_PERMISSIONS   (code-defined bundle)                       │
         │  get_scoped_groups(user, perm)         → live indexed read of is_manager  │
-        │  has_permission_or_scope(user, perm)   → GATE 1 (route)                   │
-        │  assert_group_set_within_scope(...)    → GATE 2 (write-side)              │
+        │  has_permission(user, perm)   → GATE 1 (route)                   │
+        │  assert_within_scope(...)    → GATE 2 (write-side)              │
         └───────▲───────────────▲────────────────────────────▲─────────────────────┘
                 │               │                             │
    route deps   │   6× _add_user_filters       group + resource DB write fns
@@ -157,7 +169,7 @@ The gate therefore loads the resource's **current** groups in the same transacti
 - Alice opens the Connectors page → sees only Engineering's connectors (filter re-keyed on managed groups).
 - She creates a connector into Engineering, PRIVATE → GATE 2: `{Engineering} ⊆ {Engineering}` ✓, PRIVATE ✓ →
   created.
-- She tries to set it PUBLIC → GATE 2 rejects (managers are PRIVATE-only).
+- She tries to set it PUBLIC → GATE 2 rejects (managers can't make anything PUBLIC; PRIVATE or SYNC only).
 - She tries `PUT /connector/<Finance id> {groups:[Engineering]}` → GATE 2 re-reads current `{Finance}`,
   `{Finance,Engineering} ⊄ {Engineering}` ✗ → 403.
 - She adds Bob to Engineering → allowed. She tries to add Bob to Marketing → 403.
@@ -176,8 +188,8 @@ The gate therefore loads the resource's **current** groups in the same transacti
    can never go stale.
 
 2. **GATE 2 lives inside each group/resource DB-write function** (re-reading current groups in-txn), exposed as
-   one shared helper `assert_group_set_within_scope`. *Not* a second FastAPI dependency (a dependency can't see
-   the resource's current groups or run in the write transaction). The route dependency `has_permission_or_scope`
+   one shared helper `assert_within_scope`. *Not* a second FastAPI dependency (a dependency can't see
+   the resource's current groups or run in the write transaction). The route dependency `has_permission`
    is only GATE 1.
 
 3. **PAT composition** — a PAT stays a flat permission cap (`request.state.token_scopes`, already implemented). A

--- a/docs/group-manager-scoped-permissions/03-detailed-design.md
+++ b/docs/group-manager-scoped-permissions/03-detailed-design.md
@@ -389,6 +389,10 @@ web/
 9. **Credentials unchanged.** Owner-scoped; deliberately no manager inheritance.
 10. **Tracing / OnyxError / typing conventions** per CLAUDE.md (raise `OnyxError`, strict typing, no
     `response_model`).
+11. **Extend the existing permission tests; don't reflexively add new test files.** The new permission
+    system already has good coverage — verify the relevant suite is sound and add to it when the behavior is
+    one it already drives. New files only for genuinely new homes (e.g. migration backfill). See
+    [04 Tests](04-implementation-plan.md#tests) for the known homes + the PR1 worked example.
 
 ## 10. Decisions resolved at GATE 2
 

--- a/docs/group-manager-scoped-permissions/03-detailed-design.md
+++ b/docs/group-manager-scoped-permissions/03-detailed-design.md
@@ -107,10 +107,12 @@ release — keeps a code rollback possible while §8 is unproven.
 
 ## 2. Code design — new authorization primitives
 
-New module: **`backend/onyx/auth/scoped_permissions.py`** (keeps DB-querying scope logic out of the pure
-`permissions.py`; imports `User`, `Permission`, `User__UserGroup`).
+**One classifier decides authority everywhere — no `allow_scope` fork, no separate `has_permission_or_scope`.**
+`has_permission` itself returns the authority. The classifier + bundle live in the pure `permissions.py`; the
+DB-querying scope logic (scope resolution, write gates, read clause) lives in
+**`backend/onyx/auth/scoped_permissions.py`** (imports `User`, `User__UserGroup`, the bundle — one direction).
 
-### 2.1 The manager ability bundle
+### 2.1 The manager ability bundle (in `permissions.py`)
 
 ```python
 SCOPED_MANAGER_PERMISSIONS: frozenset[Permission] = frozenset({
@@ -120,19 +122,54 @@ SCOPED_MANAGER_PERMISSIONS: frozenset[Permission] = frozenset({
     Permission.ADD_AGENTS,
     Permission.MANAGE_USER_GROUPS,   # membership + resource sharing of the managed group only
     Permission.MANAGE_SKILLS,        # NEW dedicated token (D5) — also grantable globally in the groups UI
-    Permission.MANAGE_ACTIONS,       # tools/MCP — in the bundle for GATE 1 reach; scoped via agents at GATE 2 (D4)
+    Permission.MANAGE_ACTIONS,       # tools/MCP — GATE 1 reach + create only (D4); manage is owner-or-admin (D8)
 })
 ```
-Code-defined, never written to `permission_grant`. Expanded live; never merged into
-`effective_permissions` (which stays global-only).
+Code-defined, never written to `permission_grant`, never merged into `effective_permissions` (which stays
+global-only). Lives in `permissions.py` (not `scoped_permissions.py`) so `has_permission` can read it to
+classify SCOPED authority without an import cycle.
 
-> **`MANAGE_ACTIONS` is in the bundle (D4), scoped via agents.** It must be — GATE 1
-> (`has_permission_or_scope`) would 403 a scoped manager on every action endpoint otherwise. "Agent-mediated"
-> describes GATE 2's scope resolution, not bundle membership: the route gate lets the manager *reach* the
-> tool/MCP endpoints; GATE 2 derives an action's groups from the agents that reference it
-> (`Tool → Persona__Tool → Persona__UserGroup`) and requires them ⊆ managed. See §11.1.
+> **`MANAGE_ACTIONS` is in the bundle (D4).** GATE 1 would 403 a scoped manager on every
+> action endpoint otherwise. The route gate lets the manager *reach* the tool/MCP endpoints and create their
+> own; managing an existing action or server is owner-or-admin — the agent-mediated GATE 2 once planned here
+> was built and then dropped (**D8**). See §11.1.
 
-### 2.2 Live scope resolution (two forms)
+### 2.2 `has_permission` — the single 3-state classifier
+
+A scoped grant is **group-qualified** ("manage:connectors for groups {3,7}") — it has no flat token
+representation, so it can never live in `effective_permissions`, and `has_permission` can never answer a plain
+`True` for a manager: 7 existing call sites treat `True` as global "do anything" (see-all filters, set
+featured/listed/public, fetch-any — call-site audit), so a bool returning `True` for a manager would leak
+org-wide powers. So `has_permission` returns **which** authority the user holds:
+
+```python
+class PermissionAuthority(Enum):
+    GLOBAL   # holds the token outright / admin → unrestricted
+    SCOPED   # group manager → only within managed groups
+    NONE     # not authorized
+
+def has_permission(user: User, permission: Permission) -> PermissionAuthority:
+    if permission in get_effective_permissions(user):        # global token / admin override
+        return PermissionAuthority.GLOBAL
+    if permission in SCOPED_MANAGER_PERMISSIONS and user.is_group_manager:
+        return PermissionAuthority.SCOPED                    # cached flag → zero query
+    return PermissionAuthority.NONE
+
+
+def has_global_permission(user: User, permission: Permission) -> bool:
+    """GLOBAL-only convenience for the many checks that must exclude scoped managers."""
+    return has_permission(user, permission) is PermissionAuthority.GLOBAL
+```
+
+Existing callers migrate by a behavior-preserving rule — a `SCOPED` manager reproduces the old `False` at
+those sites, so nothing leaks and the feature stays inert until each filter opts into `SCOPED` (§3):
+
+```
+has_permission(user, X)        →  has_global_permission(user, X)
+not has_permission(user, X)    →  not has_global_permission(user, X)
+```
+
+### 2.3 Live scope resolution (in `scoped_permissions.py`)
 
 ```python
 def scoped_group_ids_subquery(user: User) -> Select:
@@ -151,59 +188,70 @@ def get_scoped_groups(user: User, db_session: Session,
     return set(db_session.scalars(scoped_group_ids_subquery(user)).all())
 ```
 
-### 2.3 GATE 1 — route gate
+### 2.4 GATE 1 — route gate (one classifier, per-endpoint threshold)
 
-```python
-def has_permission_or_scope(user: User, permission: Permission) -> bool:
-    if has_permission(user, permission):          # global token or admin override
-        return True
-    # D1: cached flag → zero query. scopable + manages something ⇒ reachable.
-    return permission in SCOPED_MANAGER_PERMISSIONS and user.is_group_manager
-```
-
-FastAPI wiring — **extend the existing `require_permission`** with `allow_scope: bool = False` rather than add a
-second factory. Because GATE 1 now reads the cached `user.is_group_manager`, **no DB session dependency is
-needed** at the route:
+`require_permission` keeps the single `has_permission` classifier; `allow_scope` only sets the **acceptance
+threshold** — it is NOT a second resolution path, and `has_permission_or_scope` is gone:
 
 ```python
 # permissions.py — require_permission(required, *, allow_anonymous=False, allow_scope=False)
-# when allow_scope: pass-condition becomes
-#   has_permission_or_scope(user, required) AND permitted_by_token
-# token cap (request.state.token_scopes) is unchanged and still applies.
+permitted_by_user = (has_permission(user, required) is GLOBAL)        if not allow_scope \
+               else (has_permission(user, required) is not NONE)
+# pass:  permitted_by_user AND permitted_by_token     (token cap unchanged)
 ```
-Endpoints a manager must reach (resource + group writes/lists) switch to
-`require_permission(<token>, allow_scope=True)`. `set_group_permissions` stays
-`require_permission(FULL_ADMIN_PANEL_ACCESS)` — **no** `allow_scope`.
 
-### 2.4 GATE 2 — per-resource write-side gate (authorization of record)
+- **default (`allow_scope=False`)**: `is GLOBAL` → identical to today; a manager is rejected. The safe default
+  for every endpoint whose GATE 2 has not landed.
+- **`allow_scope=True`**: `is not NONE` → a manager *reaches* the endpoint. Set this **only when the endpoint's
+  GATE 2 exists** (PR3/PR4). This per-endpoint opt-in **is** the lands-together / no-escalation invariant:
+  ~101 bundle-token endpoints exist today with no GATE 2, and managers already exist (PR1 backfills
+  `is_manager` for ex-curators), so admitting `SCOPED` universally would let an ex-curator create resources in
+  arbitrary groups. No DB session at the route (reads the cached flag).
+
+Admin-only endpoints on a **non-bundle** token (`set_group_permissions` → `FULL_ADMIN_PANEL_ACCESS`) classify a
+manager as NONE regardless of `allow_scope` → reject automatically.
+
+### 2.5 GATE 2 — per-resource write gates (authorization of record)
+
+Two gates, both built on the one classifier:
 
 ```python
-def assert_group_set_within_scope(
-    user: User,
-    db_session: Session,
-    *,
+def assert_within_scope(
+    user: User, db_session: Session, *,
     permission: Permission,                 # the manage:* token this write needs
     current_group_ids: Collection[int],     # re-read from DB, in this txn
     requested_group_ids: Collection[int],   # client-supplied target groups
-    is_private: bool,                        # access_type==PRIVATE / not is_public
+    is_non_public: bool,                     # access_type!=PUBLIC (cc_pair) / not is_public (doc set)
 ) -> None:
-    # Global authority (admin or holds the token globally) → base-system rules already govern.
-    if has_permission(user, permission):
-        return
-    managed = get_scoped_groups(user, db_session, permission)
-    final = set(current_group_ids) | set(requested_group_ids)
-    if not managed or not final or not final.issubset(managed) or not is_private:
-        raise OnyxError(
-            OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
-            "Group managers can only act on private resources within the groups they manage.",
-        )
+    authority = has_permission(user, permission)
+    if authority is PermissionAuthority.GLOBAL:
+        return                                               # base-system rules govern
+    if authority is PermissionAuthority.SCOPED:
+        managed = get_scoped_groups(user, db_session, permission)
+        final = set(current_group_ids) | set(requested_group_ids)
+        if managed and final and final.issubset(managed) and is_non_public:
+            return
+    raise OnyxError(
+        OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+        "Group managers can only act on private resources within the groups they manage.",
+    )                                                        # NONE, or out-of-scope
+
+def assert_global(user: User, *, permission: Permission) -> None:   # delete / admin-only on a bundle token
+    if has_permission(user, permission) is not PermissionAuthority.GLOBAL:
+        raise OnyxError(OnyxErrorCode.INSUFFICIENT_PERMISSIONS, "Admin only.")   # SCOPED manager rejected
 ```
 
-Invariants enforced: `final ⊆ managed` (no group outside scope, closes capture-by-reassign),
-`final` non-empty (resource stays in ≥1 group — covers detach), `is_private` (PRIVATE-only),
-**fail-closed** (empty `managed` ⇒ reject, never "no filter").
+`assert_within_scope` invariants: `final ⊆ managed` (closes capture-by-reassign), `final` non-empty (stays in
+≥1 group — covers detach), `is_non_public` (PRIVATE or SYNC), **fail-closed** (empty `managed` ⇒ reject).
+`assert_global` (D6, **rule A**) keeps delete/admin-only ops admin-only even though they share a bundle token
+with scoped create/update: the route admits the manager (SCOPED ≠ NONE), the handler's `assert_global` rejects
+them.
 
-### 2.5 Manager assignment helpers (EE)
+> **GATE 2 attaches to the group-share / access-change step, not to owner self-edits.** An owner editing their
+> own private persona holds `NONE` for `MANAGE_AGENTS` and must still pass — `assert_within_scope` guards the
+> `update_persona_access` (group_ids / is_public) write specifically, not every mutation (§11.5).
+
+### 2.6 Manager assignment helpers (EE)
 
 ```python
 # backend/ee/onyx/db/user_group.py
@@ -214,7 +262,7 @@ def revoke_group_manager(db_session: Session, user_id: UUID, group_id: int) -> N
     """Flip is_manager=false. Idempotent."""
 ```
 
-### 2.6 Cached-flag recompute (D1 plumbing)
+### 2.7 Cached-flag recompute (D1 plumbing)
 
 `backend/onyx/db/permissions.py:43` `recompute_user_permissions__no_commit` — **extend** to also set
 `user.is_group_manager = EXISTS(is_manager=true for that user)` in the same write. This already fires on
@@ -231,32 +279,59 @@ manager flip (no membership change) refreshes the cached flag. `effective_permis
 > unchanged (no feedback permission in the bundle). The table below still applies row-by-row except the
 > feedback row, which is now NO CHANGE.
 
-Each `get_editable=True` branch gains a scoped-manager case using `scoped_group_ids_subquery(user)`. The
-read-side predicate mirrors GATE 2: a resource is editable-by-manager iff **every** group it belongs to is
-managed, it belongs to **≥1** group, and it is **private**.
+**The scope clause is OR-ed *into* each existing editable predicate — it does NOT replace the filter.** Each
+`_add_user_filters` keeps its full structure; only two things change: (1) the global short-circuit flips to
+`has_permission(user, MANAGE_X) is GLOBAL`; (2) inside the **`get_editable=True`** branch, when
+`has_permission(user, MANAGE_X) is SCOPED`, OR in `within_managed_scope_clause(...)`.
 
-Reusable clause (new helper in `scoped_permissions.py`):
+```python
+def _add_user_filters(stmt, user, get_editable=True):
+    if has_permission(user, MANAGE_X) is GLOBAL:
+        return stmt                                       # global → all
+    if not get_editable and has_permission(user, READ_X) is GLOBAL:
+        return stmt                                       # global read → all (persona/doc-set)
+    ... existing joins ...
+    if get_editable:
+        where_clause = <existing owner/share/member/creator predicate>   # PRESERVED
+        if has_permission(user, MANAGE_X) is SCOPED:                     # NEW, additive
+            where_clause |= within_managed_scope_clause(...)
+    else:
+        where_clause = <existing read predicate>          # PRESERVED — manager reads as a member
+    return stmt.where(where_clause)
+```
+
+Why additive, not replacement — the regressions this prevents:
+- **`get_editable` must be respected.** The read path keeps its own visibility (public/SYNC for cc_pair,
+  public+member for doc-set, owner/share/READ for persona); a manager reads there as a normal member. Only the
+  editable branch gains the scope term.
+- **A `NONE` user keeps their access.** persona owners, cc_pair creators, EDITOR-shares hold no manage token;
+  their existing predicate stays. A blanket `NONE → sa_false()` would strip every normal editor.
+- **A `SCOPED` manager is also a normal user.** They may own a persona / have created a cc_pair *outside* their
+  managed groups; OR-ing (not replacing) preserves that on top of the scoped-editable set.
+
+The editable read-side predicate mirrors GATE 2: editable-by-manager iff every group is managed, in ≥1 group,
+and private — exactly `within_managed_scope_clause` (new helper in `scoped_permissions.py`):
 
 ```python
 def within_managed_scope_clause(
-    resource_id_col, junction_model, junction_resource_col, junction_group_col,
-    is_public_col, managed_subq: Select,
+    resource_id_col, junction_resource_col, junction_group_col,
+    non_public_clause: ColumnElement[bool],  # a predicate, NOT a bool column — cc_pair passes
+    managed_subq: Select,                    #   access_type != AccessType.PUBLIC; doc-set/persona is_public.is_(False)
 ) -> ColumnElement[bool]:
-    """resource is fully inside managed groups, in ≥1 group, and private."""
-    # NOT EXISTS(group not in managed)  AND  EXISTS(group in managed)  AND  is_public = false
+    # NOT EXISTS(group not in managed)  AND  EXISTS(group in managed)  AND  non_public_clause
 ```
 
-| File | Today (`get_editable`) | Change |
+| File | Existing editable fallback | Integration |
 |---|---|---|
-| `backend/onyx/db/document_set.py:41` | returns `sa_false()` (only global MANAGE edits) | add manager branch: editable = `within_managed_scope_clause(...)` over `DocumentSet__UserGroup`. **Biggest build** — currently fully short-circuited. |
-| `backend/onyx/db/connector_credential_pair.py:50` | builds membership/manage join (no short-circuit) | re-key the editable branch onto `scoped_group_ids_subquery` + `within_managed_scope_clause` over `UserGroup__ConnectorCredentialPair`; require PRIVATE. |
-| `backend/onyx/db/persona.py:77` | owner + EDITOR group shares | add manager branch over `Persona__UserGroup`; `add:agents` ownership tier unchanged. |
-| `backend/onyx/db/feedback.py:46` | admin-only (`FULL_ADMIN_PANEL_ACCESS`) | **NO CHANGE** — not in the bundle; admin-only. (§11.7 — the old "mirror connector" label was wrong.) |
-| `backend/onyx/db/credentials.py:41` | owner-keyed (`Credential.user_id==user.id`), no `get_editable` | **NO CHANGE** — credentials stay owner-scoped by design; a manager never inherits others' credentials. Document the deliberate no-op. |
-| `backend/ee/onyx/db/token_limit.py` | no `_add_user_filters`; direct group query | enforce managed-scope in the group-token-limit **write/endpoint** path (manager may set limits only on managed groups). Minor. |
+| `backend/onyx/db/document_set.py:41` | `sa_false()` (no owner/share concept) | `|=` scope clause over `DocumentSet__UserGroup` (`is_public.is_(False)`). The one resource where a standalone scope filter *happens* to match (`false() OR clause == clause`); still expressed as `|=` for uniformity. |
+| `backend/onyx/db/connector_credential_pair.py:50` | member-of-owning-group (all groups ⊆ mine) ∨ creator | `|=` scope clause over `UserGroup__ConnectorCredentialPair` (`access_type == PRIVATE`). |
+| `backend/onyx/db/persona.py:77` | owner ∨ owning-group member ∨ EDITOR direct/group share ∨ org-edit | `|=` scope clause over `Persona__UserGroup` (`is_public.is_(False)`); `add:agents` ownership tier unchanged. |
+| `backend/onyx/db/feedback.py:46` | admin-only (`FULL_ADMIN_PANEL_ACCESS`) | **NO CHANGE** — not in the bundle. (§11.7) |
+| `backend/onyx/db/credentials.py:41` | owner-keyed (`Credential.user_id==user.id`) | **NO CHANGE** — credentials stay owner-scoped; document the deliberate no-op. |
+| `backend/ee/onyx/db/token_limit.py` | no `_add_user_filters`; direct group query | enforce managed-scope in the group-token-limit **write/endpoint** path. Minor. |
 
-**Fail-closed rule for every rewrite:** if `scoped_group_ids_subquery` yields no rows, the manager branch must
-resolve to empty, never to an unfiltered statement.
+**Fail-closed:** `scoped_group_ids_subquery` yields no rows for a non-manager, so `within_managed_scope_clause`
+contributes nothing — never an unfiltered statement.
 
 ---
 
@@ -268,7 +343,8 @@ resolve to empty, never to an unfiltered statement.
 > and cc_pair-reattach fix (§11.6). Use §11.4 as the source of truth.
 
 Each DB-write fn loads the resource's **current** groups in-txn, then calls
-`assert_group_set_within_scope(...)` before mutating. Endpoints switch to `allow_scope=True`.
+`assert_within_scope(...)` before mutating (delete/admin-only ops call `assert_global(...)` instead — rule A).
+Endpoints switch to `allow_scope=True`.
 
 | Resource / action | DB fn (insert gate here) | Endpoint → new dep |
 |---|---|---|
@@ -341,10 +417,11 @@ model `db/pat.py`). A manager's **group** scope is never encoded in the token �
 backend/
   onyx/
     auth/
-      scoped_permissions.py            ← NEW: SCOPED_MANAGER_PERMISSIONS, scoped_group_ids_subquery,
-                                              get_scoped_groups, has_permission_or_scope,
-                                              assert_group_set_within_scope, within_managed_scope_clause
-    auth/permissions.py                ← MOD: require_permission(..., allow_scope=False)
+      scoped_permissions.py            ← NEW: scoped_group_ids_subquery, get_scoped_groups,
+                                              assert_within_scope, assert_global, within_managed_scope_clause
+    db/enums.py                        ← MOD: PermissionAuthority enum (GLOBAL/SCOPED/NONE)
+    auth/permissions.py                ← MOD: SCOPED_MANAGER_PERMISSIONS; has_permission → PermissionAuthority;
+                                              require_permission(..., allow_scope=False) threshold
     db/models.py                       ← MOD: User__UserGroup.is_manager + User.is_group_manager
     db/permissions.py                  ← MOD: recompute_user_permissions__no_commit sets is_group_manager (§11.7)
     db/document_set.py                 ← MOD: _add_user_filters editable manager branch (was sa_false)
@@ -354,9 +431,9 @@ backend/
     db/feedback.py                     ← (no change — admin-only, not in bundle; §11.7)
     db/credentials.py                  ← (no change — documented no-op)
     server/features/skill/api.py       ← MOD: re-point off curator dep; allow_scope by verb (§11.2)
-    server/features/tool/api.py        ← MOD: allow_scope=True; agent-mediated GATE 2 replaces owner-or-admin (§11.1)
-    server/features/mcp/api.py         ← MOD: allow_scope=True; agent-mediated GATE 2 replaces owner-or-admin (§11.1)
-    db/tools.py                        ← MOD: agent-mediated action scope (Tool→Persona__Tool→groups, §11.1)
+    server/features/tool/api.py        ← MOD: allow_scope=True (reach+create); manage stays owner-or-admin — D8 dropped agent-mediated GATE 2 (§11.1)
+    server/features/mcp/api.py         ← MOD: allow_scope=True (reach+create); manage stays owner-or-admin — D8 dropped agent-mediated GATE 2 (§11.1)
+    db/tools.py                        ← MOD: owner-or-admin manage gates (D8); agent-mediated scope kept only for view (§11.1)
     server/.../{document_set,connector,cc_pair,persona}/api.py  ← MOD: allow_scope=True deps
     server/.../permissions api         ← MOD: /users/me/permissions adds is_manager
   ee/onyx/
@@ -377,9 +454,10 @@ web/
 ## 9. Pre-implementation notes (must honor)
 
 1. **GATE 2 is the authorization of record.** Route gate (`allow_scope`) only widens *reachability*; never let
-   it authorize. Every scoped write path must call `assert_group_set_within_scope`.
+   it authorize. Every scoped write path must call `assert_within_scope` (or `assert_global` for admin-only ops).
 2. **Re-read current groups in-txn.** Never trust the client's group list alone (capture-by-reassign).
-3. **PRIVATE-only.** Reject any manager create/edit that sets/keeps PUBLIC or SYNC.
+3. **Non-PUBLIC only.** Reject any manager create/edit that sets/keeps PUBLIC; PRIVATE and SYNC are in scope
+   (a manager manages their group's private *and* auto-sync connectors). Doc sets have no SYNC → PRIVATE only.
 4. **Fail closed.** Empty managed set ⇒ no access; guard every filter against an unfiltered fallback.
 5. **`set_group_permissions` stays admin-only.** Managers manage membership + resource sharing, never the
    group's token grants.
@@ -413,8 +491,8 @@ junction-only · completeness, 18 agents) confirmed the core design is sound —
 runtime untouched, purely junction-based, and the feared backfill data-loss does **not** occur — but found
 that §1–10 under-specify several manager-reachable paths. **This section is the authoritative coverage
 checklist; implement every row.** New decisions locked with the owner: **D4 actions = `manage:actions` in the
-bundle, scoped via agents at GATE 2** · **D5 skills = in scope (7th resource)** · **D6 managers may do
-everything EXCEPT delete**.
+bundle** (its agent-mediated GATE 2 later dropped — **D8**) · **D5 skills = in scope (7th resource)** ·
+**D6 managers may do everything EXCEPT delete** (narrowed by **D9**: a creator may delete what they made).
 
 ### 11.0 PREREQUISITE — independent boot bug (fix before/with PR1)
 `current_curator_or_admin_user` was removed from `onyx/auth/users.py` by §1–7 but is still imported by
@@ -424,13 +502,21 @@ dead dep: skills → see §11.2; `targeted_reindex.py:80/163` → `require_permi
 its connector/indexing peers). This is a merge-integration break, not a §8 feature change, but it blocks
 everything. Add an `import onyx.main` smoke test to CI so a deleted auth dep fails fast.
 
-### 11.1 Actions (D4 — `MANAGE_ACTIONS` in the bundle; scoped via agents at GATE 2)
+### 11.1 Actions (D4 — `MANAGE_ACTIONS` in the bundle; manage is owner-or-admin per D8)
+> **⚠️ SUPERSEDED by D8 (2026-08-03) for the _management_ verbs.** The agent-mediated GATE 2 below
+> (edit/toggle/OAuth-auth resolving an action's groups through its referencing agents) was **built, then
+> dropped** — it caused most of the review's P1/P2 findings. Manage is now plain **owner-or-admin**
+> (`can_manage_own_tool` / `_ensure_mcp_server_owner_or_admin`), mirrored 1:1 by the UI projection; the
+> *view* path keeps agent-mediated scope. GATE 1 reach + create (allow_scope=True) is unchanged; **delete
+> now follows the same owner-or-admin gate (D9), not admin-only.** Read the rest of this section as
+> historical design, not the current gate.
+
 - **`MANAGE_ACTIONS` stays in `SCOPED_MANAGER_PERMISSIONS`** (§2.1). Bundle membership is what GATE 1
-  (`has_permission_or_scope`) checks — drop it and a scoped manager 403s at the route on every action endpoint.
-  "Agent-mediated" is GATE 2's scope resolution, not a reason to omit the token.
+  (`has_permission` → SCOPED, admitted when `allow_scope=True`) checks — drop it and a scoped manager 403s at
+  the route on every action endpoint. "Agent-mediated" is GATE 2's scope resolution, not a reason to omit it.
 - **Reaching the endpoints (GATE 1):** switch the standalone tool/MCP admin endpoints (`tool/api.py`
   POST/PUT/DELETE, `mcp/api.py`) to `require_permission(MANAGE_ACTIONS, allow_scope=True)` so managers can reach
-  them. (Delete stays admin-only per D6.)
+  them, including DELETE — a creator may delete what they made (D9).
 - **Scope check (GATE 2):** actions have no direct group; derive an action's groups from the agents that
   reference it — `Tool → Persona__Tool → Persona__UserGroup` — and require them ⊆ managed (+ PRIVATE). This
   **replaces** the current owner-or-admin per-resource check (`_get_editable_custom_tool` /
@@ -464,7 +550,7 @@ corrections (verified 2026-06-29):
 - **Write side = GATE 2 on the GRANTS seam, not create/update.** `create_skill__no_commit` takes no group_ids
   and `patch_skill` only toggles is_public/enabled; the only group↔skill writer is `replace_skill_grants`
   (`skill.py:430`, reached via PUT `/admin/skills/custom/{id}/grants`, body `GrantsReplace.group_ids`). Put
-  GATE 2 there (current grants via `get_group_ids_for_skill` ∪ requested ⊆ managed, `is_private = not
+  GATE 2 there (current grants via `get_group_ids_for_skill` ∪ requested ⊆ managed, `is_non_public = not
   skill.is_public`, re-read in-txn). Also gate the `is_public` toggle in `patch_custom_skill` so a manager
   can't publish a private skill out of scope.
 - **Endpoint re-point BY VERB.** list/get/create/update/share → `require_permission(MANAGE_SKILLS,
@@ -473,11 +559,17 @@ corrections (verified 2026-06-29):
   re-point on `FULL_ADMIN_PANEL_ACCESS` to unbreak boot; PR4 adds `MANAGE_SKILLS` + `allow_scope` + the GATE 2
   and admin-list together, then narrows the deps.)
 
-### 11.3 Manager power = everything EXCEPT delete (D6)
-Managers may create / edit / attach / detach / pause / rename / share within managed groups (PRIVATE-only,
-GATE 2). **DELETE is admin-only for every resource.** These stay on the plain global dep (no `allow_scope`):
-connector/cc_pair delete (`administrative.py:141`), document-set delete (`document_set/api.py:93`), persona
-delete, skill delete; plus group create (D2) + group delete + `set_group_permissions` (admin-only).
+### 11.3 Manager power = everything EXCEPT deleting a managed-group resource (D6, narrowed by D9)
+Managers may create / edit / attach / detach / pause / rename / share within managed groups (non-PUBLIC only —
+PRIVATE or SYNC; GATE 2). **Delete is admin-only for a resource that merely sits in a managed group.** These
+stay on the plain global dep (no `allow_scope`): connector/cc_pair delete (`administrative.py:141`),
+document-set delete (`document_set/api.py:93`), admin skill delete (`skill/api.py:425`); plus group create
+(D2) + group delete + `set_group_permissions` (admin-only).
+
+**D9 carve-out:** deleting something the manager *created* is ownership, not scope, so it follows the same
+owner-or-admin gate as every other owner: custom actions / MCP servers (`can_manage_own_tool`,
+`_ensure_mcp_server_owner_or_admin`), personas (`can_delete_persona`), personal skills
+(`_ensure_owned_personal`). Being a manager never subtracts a right an ordinary user holds.
 
 ### 11.4 Complete write-path enumeration (supersedes/extends the §4 table — gate EVERY row)
 All `allow_scope=True` + GATE 2 EXCEPT where marked admin-only (D6/D2):
@@ -486,13 +578,13 @@ All `allow_scope=True` + GATE 2 EXCEPT where marked admin-only (D6/D2):
 |---|---|---|
 | cc_pair status `cc_pair.py:427` · name `:512` · property `:542` · prune `:604` | re-keyed editable read-filter authorizes (no group/access change) | allow_scope=True |
 | associate-credential `cc_pair.py:716` · connector create mock-cred `connector.py:1568` · bare create `:1538` | `add_credential_to_connector` (`:496`) | allow_scope=True on **all**; the `connector.py:1603` anchor was imprecise (it's the mock-cred path) |
-| ee `sync_cc_pair_groups` `cc_pair.py:130` | group-attach | allow_scope=True; GATE 2 per cc_pair |
+| ee `sync_cc_pair_groups` (sync-groups) · `sync_cc_pair` (sync-permissions) | re-keyed editable read-filter authorizes — NOTE: these only *enqueue* an external sync task (they do NOT rewrite the group junction; that's PR5's `update_user_group`) | allow_scope=True; load `get_editable=True` (they target SYNC connectors, which a manager manages) |
 | connector/cc_pair **DELETE** `administrative.py:141` | — | **admin-only (D6)** |
 | doc-set create `document_set/api.py:36` · patch `:62` | `insert/update_document_set` (`:220/:296`) | allow_scope=True |
 | doc-set **DELETE** `:93` | — | **admin-only (D6)** |
 | persona create `persona/api.py:310` · update `:181` · **share `:443`** | `update_persona_access` (§11.5) | allow_scope=True; **GATE 2 keyed on `MANAGE_AGENTS` (D7)** — admin/global bypass; scoped managers ⊆ managed; ADD_AGENTS-only can't group-share |
 | skill create/update `skill/api.py:186/...` | skill write fn (§11.2) | allow_scope=True; GATE 2 on `replace_skill_grants` |
-| tool/MCP create/update `tool/api.py` · `mcp/api.py` | GATE 2 via agents (`Tool → Persona__Tool → Persona__UserGroup` ⊆ managed); replaces owner-or-admin check (§11.1) | allow_scope=True; **DELETE admin-only (D6)** |
+| tool/MCP create/update/**delete** `tool/api.py` · `mcp/api.py` | owner-or-admin per resource (`can_manage_own_tool` / `_ensure_mcp_server_owner_or_admin`) — the agent-mediated GATE 2 was dropped (**D8**) | allow_scope=True on every verb; **delete included (D9)** |
 | group update/members `user_group/api.py:194/215` · **rename `:164`** | `update_user_group` / `add_users_to_user_group` | allow_scope=True; GATE 2 = group ∈ managed; **cc_pair_ids per §11.6** |
 | group `/agents` persona attach `user_group/api.py:256` | `update_persona_access` | allow_scope=True; **manager-scope GATE 2 = target group ∈ managed** (the roster surface) |
 | group create `:144` · delete · permissions `:115` | — | **admin-only (D2)** |
@@ -507,6 +599,14 @@ controlled by **`MANAGE_AGENTS`** — not `ADD_AGENTS`, not bare membership. So 
   private. Managers hold `MANAGE_AGENTS` via the bundle.
 - else (`ADD_AGENTS`-only) → reject the group-share. Such a user can still create/edit a private, **no-group**
   personal agent — they just can't attach it to a group.
+
+**The gate authorizes the *diff*, not the state.** Unchanged group shares are not a group-share mutation,
+so they're exempt for a non-SCOPED actor (the editor round-trips the current groups on every save — without
+this a plain owner couldn't edit an agent someone else group-shared) and for an **owner**, who sets their
+own agent's privacy per **D9**. "Unchanged" compares the whole `{group_id: permission}` map — re-leveling
+a group from VIEWER to EDITOR is a change and gets no exemption. A scoped manager who isn't the owner is
+still checked even when nothing changed: holding the share while flipping a public agent private is a
+capture. So is the reverse — sharing a public agent *into* a managed group — which no ownership exempts.
 
 > **Current-code nuance to enforce (PR4):** today the persona create/`/share` route gates on `ADD_AGENTS`
 > (`persona/api.py:310/340/447`) and the share write authorizes via the **editable fetch** (owner/EDITOR/admin,
@@ -569,9 +669,11 @@ either 403s on the Groups page (feature unusable) or sees every org group (leak)
   `db/permissions.py` (recompute) — these are the artifacts implementers slice from.
 - **§11.0 tokens:** `targeted_reindex.py:80/163` → `require_permission(MANAGE_CONNECTORS)` (matches connector
   peers; independent of the skills token). Skills token per §11.2.
-- **D6 delete invariant:** deletes stay admin-only **only** because their route gate keeps `allow_scope=False`
-  — the re-keyed editable filter would otherwise authorize a manager. Never add `allow_scope=True` to a DELETE
-  route; add an escalation test asserting each DELETE 403s a scoped-only manager. (Persona delete is already
-  owner/owner-group gated via `get_persona_by_id`, not `_add_user_filters`, so PR4 doesn't open it.)
+- **D6 delete invariant:** a managed-group resource stays undeletable **only** because its route gate keeps
+  `allow_scope=False` — the re-keyed editable filter would otherwise authorize a manager. Never add
+  `allow_scope=True` to a DELETE route whose only authorization is that filter (connector/cc_pair, doc set,
+  admin skill); add an escalation test asserting each 403s a scoped-only manager. Routes with a per-resource
+  ownership gate are the D9 exception: action/MCP/persona delete run `allow_scope=True` and authorize on
+  owner-or-admin instead, so the filter never decides.
 - Stale prose to fix: "6 filters" → 4 re-keyed + skill (`00:14`, `01:52/64`, `02` ASCII); `§2.6` call →
   `([user_id], db_session)`; `§3` feedback row → NO CHANGE.

--- a/docs/group-manager-scoped-permissions/04-implementation-plan.md
+++ b/docs/group-manager-scoped-permissions/04-implementation-plan.md
@@ -15,9 +15,9 @@ PRIVATE and strictly within their managed groups — enforced authoritatively at
 
 ## Important Notes
 
-- **§8 is fully greenfield; §1–7 is built.** Verified — every §8 artifact is absent; base system complete
-  (`01-research.md`). The wiki's "Implemented as revision `4fa09af6ca14`" is **inaccurate** — that migration is
-  not in the tree (`HEAD = c8e316473aaa`).
+- **§8 is greenfield on §1–7; PR0+PR1 now built.** Base system complete (`01-research.md`). PR1 shipped the
+  schema migration as `c71a18ea7d07` (down_revision `c8e316473aaa`, now head) — the earlier placeholder
+  `4fa09af6ca14` was never used. Scoped artifacts (PR2+) remain absent.
 - **Two-gate model is non-negotiable.** Route gate (`has_permission_or_scope`, cached flag) only grants
   *reachability*; the **authorization of record** is `assert_group_set_within_scope`, run **inside the DB write**,
   re-reading the resource's **current** groups (`02/03`). The route gate must never authorize.
@@ -107,6 +107,22 @@ and can never widen group reach (live `is_manager` bounds groups regardless of t
 Primary type = **integration** (per CLAUDE.md: real deployment, hardest to fake; this is a security boundary).
 Use `UserGroupManager` / resource managers in `tests/integration/common_utils`; prefer fixtures.
 
+> **Find the existing home before writing a new test file.** The new permission system already has
+> strong coverage — don't reflexively `git add` a fresh test file. First locate the suite that already
+> exercises the behavior, read it, confirm it's sound, and **extend it** when the new assertion belongs to
+> a flow it already drives. Only create a new file when no existing suite covers the behavior. Known homes:
+> - recompute / `effective_permissions` → `tests/integration/tests/usergroup/test_group_membership_updates_user_permissions.py`
+> - grant / revoke (bulk) + implied-expansion → `tests/integration/tests/usergroup/test_group_permission_toggle.py`
+> - registration / default-group propagation + fixtures → `tests/integration/tests/permissions/` (`test_auth_permission_propagation.py`, `conftest.py`)
+> - read-time permission expansion (pure logic) → `tests/unit/onyx/auth/test_permissions.py`
+>
+> Worked example (PR1): `is_group_manager` is the *second* column `recompute_user_permissions__no_commit`
+> writes, so its coverage was folded into the existing recompute test above — **not** a standalone file. An
+> earlier standalone `test_is_manager_recompute.py` was deleted because it duplicated that home, flipped the
+> flag on an incidental default-group membership, and re-ran the migration's copied SQL as a self-referential
+> oracle. The migration-backfill case is the one genuinely new home (own file under
+> `tests/integration/tests/migrations/`, running the real alembic migration — never a copied-SQL oracle).
+
 - **Escalation suite (integration)** — for a manager of group X: (a) capture-by-reassign rejected
   (`PUT resource{groups:[X]}` on a resource currently in Y → 403); (b) PUBLIC/SYNC create+edit rejected;
   (c) cross-group membership add rejected (add to Y); (d) **fail-closed** — a user with `is_manager` on zero
@@ -115,9 +131,10 @@ Use `UserGroupManager` / resource managers in `tests/integration/common_utils`; 
   add within X) succeed.
 - **PAT (integration)** — a manager's PAT scoped to `manage:connectors` edits only X's connectors and cannot
   reach Y; a PAT cannot widen group reach.
-- **Migration backfill (external-dependency unit)** — seed CURATOR(+is_curator) and a zero-`is_curator`
-  GLOBAL_CURATOR; assert `is_manager` set correctly (GLOBAL_CURATOR captured on all memberships) and
-  `is_group_manager` mirrors it; fresh-install path leaves all false.
+- **Migration backfill (DEFERRED by owner; revisit before GA) — integration, real alembic** — a new test under
+  `tests/integration/tests/migrations/` that seeds CURATOR(+is_curator) and a zero-`is_curator` GLOBAL_CURATOR,
+  runs the actual migration (down→up), and asserts `is_manager` (GLOBAL_CURATOR captured on all memberships) +
+  `is_group_manager` mirror; fresh-install leaves all false. NOT a copied-SQL oracle.
 - **Filter SQL (external-dependency unit)** — `within_managed_scope_clause` returns exactly the resources whose
   every group ⊆ managed and ≥1 group and private (the `document_set` rebuild especially).
 - **Manager toggle UI (playwright, 1 test)** — admin assigns a manager via the group page; that user then sees

--- a/docs/group-manager-scoped-permissions/04-implementation-plan.md
+++ b/docs/group-manager-scoped-permissions/04-implementation-plan.md
@@ -2,6 +2,11 @@
 
 # §8 Scoped Permissions (Group Manager) — Implementation Plan
 
+> **Primitives per [03 §2](03-detailed-design.md) (single-classifier model).** `has_permission` returns
+> `PermissionAuthority` (one classifier; the separate `has_permission_or_scope` removed) and lives in `permissions.py` with
+> the bundle; `has_global_permission` is the GLOBAL-only bool helper. GATE 1 = `require_permission(...,
+> allow_scope=True)` (threshold); GATE 2 = `assert_within_scope` / `assert_global`. Names below updated to match.
+
 ## Issues to Address
 
 The base group-permission system (§1–7) grants tokens to a whole group — every member gets them everywhere.
@@ -18,8 +23,8 @@ PRIVATE and strictly within their managed groups — enforced authoritatively at
 - **§8 is greenfield on §1–7; PR0+PR1 now built.** Base system complete (`01-research.md`). PR1 shipped the
   schema migration as `c71a18ea7d07` (down_revision `c8e316473aaa`, now head) — the earlier placeholder
   `4fa09af6ca14` was never used. Scoped artifacts (PR2+) remain absent.
-- **Two-gate model is non-negotiable.** Route gate (`has_permission_or_scope`, cached flag) only grants
-  *reachability*; the **authorization of record** is `assert_group_set_within_scope`, run **inside the DB write**,
+- **Two-gate model is non-negotiable.** Route gate (`has_permission`, cached flag) only grants
+  *reachability*; the **authorization of record** is `assert_within_scope`, run **inside the DB write**,
   re-reading the resource's **current** groups (`02/03`). The route gate must never authorize.
 - **D1 (cache the boolean):** new cached `user.is_group_manager` (sibling to `effective_permissions`, which stays
   global-only), recomputed via `recompute_user_permissions__no_commit` (`db/permissions.py:43`) on membership
@@ -40,9 +45,13 @@ PRIVATE and strictly within their managed groups — enforced authoritatively at
 - **Regression-review additions (2026-06-29) — see [03 §11](03-detailed-design.md) for the full checklist:**
   - **PREREQUISITE (boot bug, §11.0):** `current_curator_or_admin_user` is gone but still imported by
     `skill/api.py:16` + `targeted_reindex.py:22` → the API server won't boot. Fix first (Step 0).
-  - **D4 actions (§11.1):** keep `MANAGE_ACTIONS` **in the bundle** (GATE 1 reach); switch the tool/MCP admin
-    endpoints to `allow_scope=True`; GATE 2 scopes via the agents that reference the action
-    (`Tool → Persona__Tool → Persona__UserGroup` ⊆ managed), replacing the owner-or-admin per-resource check.
+  - **D4 actions (§11.1), superseded in part by D8:** keep `MANAGE_ACTIONS` **in the bundle** (GATE 1 reach);
+    switch the tool/MCP admin endpoints to `allow_scope=True`. The agent-mediated GATE 2 was built and then
+    **dropped** — managing an action/server is plain **owner-or-admin** (`can_manage_tool` /
+    `can_manage_mcp_server`), delete included (D9). An MCP-discovered tool has no `user_id`, so
+    `can_manage_tool` routes it to its **server's** owner; global `MANAGE_ACTIONS` is full-admin-equivalent
+    here and is not narrowed to `FULL_ADMIN`. Agent-derived scope survives only for *viewing* an MCP server
+    connected to a managed group.
   - **D5 skills (§11.2):** add a **dedicated `MANAGE_SKILLS` permission** (groups UI + bundle; no migration).
     Skills do NOT mirror personas — add a NEW scoped admin-list path (don't touch the runtime visibility
     filter), GATE 2 on `replace_skill_grants` (the `/grants` seam), re-point `skill/api.py` by verb to
@@ -51,7 +60,9 @@ PRIVATE and strictly within their managed groups — enforced authoritatively at
     `MANAGE_AGENTS` (admin/global bypass; scoped managers ⊆ managed; `ADD_AGENTS`-only can't group-share).
     Today's route is `ADD_AGENTS` + editable-fetch, so PR4 adds the `MANAGE_AGENTS` requirement on the
     group-share write (a small intended tightening).
-  - **D6 delete (§11.3):** managers do everything *except delete* — all DELETE endpoints stay admin-only.
+  - **D6 delete (§11.3), narrowed by D9:** managers do everything *except delete a resource that merely sits
+    in a managed group* (connector/cc_pair, doc set, admin skill). Deleting something they **created** —
+    action, MCP server, agent — is ownership, not scope, and stays owner-or-admin.
   - **Persona GATE 2 (§11.5):** `update_persona_access` lacks the actor `User`+`permission`; thread the
     acting user into it from all 3 callers (create / share / `/agents`) and gate the shared chokepoint.
   - **cc_pair re-attach (§11.6):** `update_user_group` rewrites group↔cc_pair from client `cc_pair_ids` —
@@ -74,15 +85,15 @@ columns, role-gated `is_manager` backfill (CURATOR + GLOBAL_CURATOR), and `is_gr
 result. Extend `recompute_user_permissions__no_commit` (`db/permissions.py:43`) to recompute `is_group_manager`.
 
 **Step 2 — Auth primitives.** New `auth/scoped_permissions.py`: `SCOPED_MANAGER_PERMISSIONS`,
-`scoped_group_ids_subquery`, `get_scoped_groups`, `has_permission_or_scope` (reads cached flag),
-`within_managed_scope_clause`, `assert_group_set_within_scope`. Extend `require_permission` with
+`scoped_group_ids_subquery`, `get_scoped_groups`, `has_permission` (reads cached flag),
+`within_managed_scope_clause`, `assert_within_scope`. Extend `require_permission` with
 `allow_scope: bool` (`auth/permissions.py`). Unit-coverable, no endpoints wired yet.
 
 **Step 3 — Manager assignment.** `make_group_manager` / `revoke_group_manager` (`ee/onyx/db/user_group.py`) with
 a recompute trigger for the affected user. New EE endpoint `PUT …/user-group/{group_id}/manager`
 (`ee/onyx/server/user_group/api.py`) gated `admin ∨ group_id ∈ managed` (D3); reject non-member targets.
 
-**Step 4 — Write-side gates (the security core).** Insert `assert_group_set_within_scope` into each scoped write
+**Step 4 — Write-side gates (the security core).** Insert `assert_within_scope` into each scoped write
 fn, re-reading current groups in-txn: connector create/update (`db/connector_credential_pair.py:496` +
 cc_pair update), document set create/update (`db/document_set.py:220/296`), persona
 (`db/persona.py:325`→`ee/persona.py:68`), group update/add-users (`ee/user_group.py:504/462`). Switch those
@@ -151,7 +162,7 @@ gate in its write fn; the `within_managed_scope_clause` helper is reused, no har
 per-item gate — avoids N indexed reads on batch edits. The route-gate cost is O(1) (cached `is_group_manager`).
 
 ### 2. Fragility: CONCERN → hardened
-The model's load-bearing assumption is *every* scoped write path calls `assert_group_set_within_scope`; a future
+The model's load-bearing assumption is *every* scoped write path calls `assert_within_scope`; a future
 write path that forgets it is an escalation. Hardenings added to the plan:
 - **Minimize insertion sites** — route resource→group attaches through the existing single junction writers
   (e.g. `_relate_groups_to_cc_pair__no_commit`) so the gate has few, obvious homes, not scattered call sites.

--- a/docs/group-manager-scoped-permissions/05-pr-roadmap.md
+++ b/docs/group-manager-scoped-permissions/05-pr-roadmap.md
@@ -72,12 +72,14 @@ highest-value resource types, exercised by the escalation integration suite (man
   | `backend/onyx/db/models.py` | modified | 2 boolean columns (`User__UserGroup`, `User`) |
   | `backend/alembic/versions/c71a18ea7d07_*.py` | new | add columns + role-gated backfill |
   | `backend/onyx/db/permissions.py` | modified | recompute sets `is_group_manager` |
-  | `backend/tests/external_dependency_unit/.../test_is_manager_backfill.py` | new | backfill correctness |
+  | `backend/tests/integration/tests/usergroup/test_group_membership_updates_user_permissions.py` | modified | recompute sets `is_group_manager` (folded into the existing recompute test) |
+  | `tests/integration/tests/migrations/test_is_manager_backfill_migration.py` | new (DEFERRED) | backfill correctness via real alembic |
 - **Est. size:** ~220 LOC
 - **Depends on:** —
 - **Feature-flag state:** N/A — additive, columns unread until PR3+.
-- **Tests on merge:** external-dependency unit — CURATOR(+is_curator)→manager; zero-`is_curator` GLOBAL_CURATOR
-  captured on all memberships; `is_group_manager` mirrors; fresh-install all-false.
+- **Tests on merge:** integration — `is_group_manager` set/cleared by `recompute` on a managed edge (folded
+  into the existing recompute test). Backfill correctness (CURATOR / zero-`is_curator` GLOBAL_CURATOR /
+  fresh-install) is DEFERRED — revisit as a real-alembic migration test before GA.
 - **Drift checkpoint:** confirm `c8e316473aaa` is still head; confirm the pre-GA assumption (curators already
   collapsed to STANDARD) still holds so migrated `is_manager` bits are dormant, not a silent re-grant. If §6.1.1
   snapshot caveat matters operationally, decide whether the zero-managed-group report ships now or later.

--- a/docs/group-manager-scoped-permissions/05-pr-roadmap.md
+++ b/docs/group-manager-scoped-permissions/05-pr-roadmap.md
@@ -2,6 +2,11 @@
 
 # §8 Scoped Permissions (Group Manager) — PR Roadmap
 
+> **Primitives per [03 §2](03-detailed-design.md) (single-classifier model).** `has_permission` →
+> `PermissionAuthority` (one classifier; `has_permission` removed); `has_global_permission` is the
+> GLOBAL-only bool helper. GATE 1 = `require_permission(..., allow_scope=True)` threshold; GATE 2 =
+> `assert_within_scope` / `assert_global`. Names below updated to match.
+
 Six PRs, dependency-ordered. **Safety invariant:** every enforcement PR lands its read-filter + write-side gate
 + endpoint `allow_scope` switch **together** — a manager can never reach an endpoint before its GATE 2 exists, so
 there is no escalation window at any merge boundary. (Pre-GA branch: existing curators were already collapsed to
@@ -9,8 +14,10 @@ STANDARD by the `account_type` backfill, so no live capability is regressed whil
 
 > **Revised by the 2026-06-29 regression review** — see [03 §11](03-detailed-design.md) for the full case
 > checklist. Net changes to this roadmap: a new **PR0** (boot-fix prerequisite); **PR4** adds **skills** (D5)
-> and **actions** scoping (D4 — `manage:actions` stays in the bundle, scoped via agents at GATE 2);
-> **delete stays admin-only** across all PRs (D6); PR3/PR5 enumerate
+> and **actions** scoping (D4 — `manage:actions` stays in the bundle for GATE 1 reach + create; the
+> agent-mediated GATE 2 was later dropped, see **D8**);
+> **delete stays admin-only** across all PRs (D6, narrowed by **D9** — a creator may delete their own
+> action/MCP server); PR3/PR5 enumerate
 > the previously-missed write endpoints (cc_pair status/name/property/prune, persona `/share`, group rename,
 > `/agents`) and the persona-gate signature fix (§11.5) + cc_pair-reattach fix (§11.6).
 
@@ -87,8 +94,8 @@ highest-value resource types, exercised by the escalation integration suite (man
 ## PR 2 — Authorization primitives (inert core)
 - **Goal:** land the reusable scope logic and the route-gate extension with no behavior change.
 - **Scope (in):** new `backend/onyx/auth/scoped_permissions.py` — `SCOPED_MANAGER_PERMISSIONS`,
-  `scoped_group_ids_subquery`, `get_scoped_groups`, `has_permission_or_scope` (reads cached flag),
-  `within_managed_scope_clause`, `assert_group_set_within_scope`; extend `require_permission(allow_scope=False)`.
+  `scoped_group_ids_subquery`, `get_scoped_groups`, `has_permission` (reads cached flag),
+  `within_managed_scope_clause`, `assert_within_scope`; extend `require_permission(allow_scope=False)`.
 - **Out of scope:** wiring any endpoint/filter to them (PR3+).
 - **Files:**
   | File | New/Modified | This PR's slice |
@@ -99,16 +106,16 @@ highest-value resource types, exercised by the escalation integration suite (man
 - **Est. size:** ~330 LOC
 - **Depends on:** PR 1
 - **Feature-flag state:** N/A — nothing calls these yet.
-- **Tests on merge:** unit/external-dependency unit — `assert_group_set_within_scope` invariants (⊆ managed,
+- **Tests on merge:** unit/external-dependency unit — `assert_within_scope` invariants (⊆ managed,
   non-empty, private, fail-closed, admin/global bypass); `within_managed_scope_clause` selects the right rows.
-- **Drift checkpoint:** confirm the bundle is the 7-token set — includes `manage:actions` (D4, scoped via
-  agents at GATE 2) and the new `manage:skills` (D5); confirm `require_permission`'s token-cap branch is
-  unchanged since `03`.
+- **Drift checkpoint:** confirm the bundle is the 7-token set — includes `manage:actions` (D4 keeps it in the
+  bundle for reach + create; manage itself is owner-or-admin per **D8**) and the new `manage:skills` (D5);
+  confirm `require_permission`'s token-cap branch is unchanged since `03`.
 
 ## PR 3 — Enforce scope on connectors & document sets (walking skeleton)
 - **Goal:** prove the full two-gate model end-to-end on the two highest-value resources.
 - **Scope (in):** rewrite editable filters in `connector_credential_pair.py` and `document_set.py` (the latter
-  built from today's `sa_false()`) onto `within_managed_scope_clause`; insert `assert_group_set_within_scope` in
+  built from today's `sa_false()`) onto `within_managed_scope_clause`; insert `assert_within_scope` in
   cc_pair create/update + doc-set create/update DB fns (re-reading current groups in-txn); switch the **full set**
   of manager-reachable endpoints (§11.4) to `require_permission(<token>, allow_scope=True)` — connector create
   (mock-cred `connector.py:1568` **and** bare `:1538`), associate-credential `cc_pair.py:716`, cc_pair status
@@ -142,11 +149,13 @@ highest-value resource types, exercised by the escalation integration suite (man
   bundle; no migration), a NEW scoped admin-list path (do NOT touch the runtime visibility filter), GATE 2 on
   `replace_skill_grants`, re-point `skill/api.py` by verb to `MANAGE_SKILLS, allow_scope=True` (§11.2);
   managed-scope enforcement in EE `token_limit.py` group write path; `credentials.py` **and `feedback.py`** left
-  unchanged (documented no-ops); **persona/skill delete stays admin-only (D6)**; scoped-PAT tests. **Actions
-  (D4):** `MANAGE_ACTIONS` is in the bundle; switch the tool/MCP admin endpoints to `allow_scope=True` and
-  replace their owner-or-admin per-resource check with GATE 2 deriving the action's groups via its agents
-  (`Tool → Persona__Tool → Persona__UserGroup` ⊆ managed); delete stays admin-only; tool used by no agent →
-  owner/admin only.
+  unchanged (documented no-ops); **admin skill delete stays admin-only (D6); persona delete is owner-or-admin
+  (D9)**; scoped-PAT tests. **Actions
+  (D4 + D8):** `MANAGE_ACTIONS` is in the bundle; switch the tool/MCP admin endpoints to `allow_scope=True`
+  so a manager can reach them and create their own. Managing an existing action/server stays
+  **owner-or-admin** (`can_manage_own_tool` / `_ensure_mcp_server_owner_or_admin`) — the agent-mediated GATE 2
+  once planned here was built and then dropped (**D8**); agent-derived scope survives only for *viewing* an
+  MCP server connected to a managed group. A creator may delete what they made (**D9**).
 - **Out of scope:** membership/assignment (PR5); UI (PR6).
 - **Files:**
   | File | New/Modified | This PR's slice |
@@ -155,8 +164,8 @@ highest-value resource types, exercised by the escalation integration suite (man
   | `backend/ee/onyx/db/persona.py` | modified | `update_persona_access` EE gate (lockstep signature) |
   | `backend/onyx/db/skill.py` | modified | scoped admin-list path + `replace_skill_grants` GATE 2 + is_public toggle gate (§11.2) |
   | `backend/onyx/server/features/skill/api.py` | modified | re-point off curator dep; `allow_scope=True` by verb (DELETE stays admin-only) |
-  | `backend/onyx/server/features/{tool,mcp}/api.py` | modified | `allow_scope=True`; agent-mediated GATE 2 replaces owner-or-admin (§11.1) |
-  | `backend/onyx/db/tools.py` | modified | agent-mediated action scope (Tool→Persona__Tool→groups) |
+  | `backend/onyx/server/features/{tool,mcp}/api.py` | modified | `allow_scope=True` (reach + create); manage (edit/toggle/auth) stays **owner-or-admin** — agent-mediated GATE 2 dropped per **D8** |
+  | `backend/onyx/db/tools.py` | modified | `can_manage_own_tool` / `can_manage_mcp_server` owner-or-admin gates (D8); agent-mediated scope kept only for *view* |
   | `backend/ee/onyx/db/token_limit.py` | modified | managed-scope on group token-limit writes |
   | `backend/onyx/server/.../persona api` | modified | `ADD_AGENTS, allow_scope=True` deps |
   | `backend/tests/integration/.../test_group_manager_agents.py` | new | agent + skill + action escalation + ADD_AGENTS-owner no-regression + PAT narrowing |
@@ -166,8 +175,9 @@ highest-value resource types, exercised by the escalation integration suite (man
 - **Feature-flag state:** N/A — lands-together invariant.
 - **Tests on merge:** integration — agent create/share scoped; manager can't widen a PAT's group reach; `add:agents`
   ownership tier still keyed on `Persona.user_id`; credentials remain owner-only for a manager.
-- **Drift checkpoint:** confirm actions-via-agents assumption (no direct tool→group table) still holds; confirm
-  the persona create/update endpoint path + that `manage:agents` is the right scoped token.
+- **Drift checkpoint:** confirm the persona create/update endpoint path + that `manage:agents` is the right
+  scoped token. (The actions-via-agents assumption no longer gates anything — D8 made action/MCP manage
+  owner-or-admin, so there is nothing to derive from the agent join.)
 
 ## PR 5 — Manager assignment & group-membership scoping (backend complete)
 - **Goal:** let admins/in-group managers create managers, and scope membership edits; expose the flag to clients.

--- a/docs/group-manager-scoped-permissions/07-ui-capability-model-design.md
+++ b/docs/group-manager-scoped-permissions/07-ui-capability-model-design.md
@@ -1,0 +1,1251 @@
+# UI Capability Model — Server-Driven Affordance Gating for Scoped Group Permissions
+
+Status: design (v2, revised after adversarial pressure test) · Task: group-manager-scoped-permissions · Supersedes: 06-frontend-affordance-followups.md · Layer: UI/read-projection + a small behavior-preserving backend refactor (PR1-5 enforcement behavior unchanged)
+
+> **⚠️ Read with D8/D9 ([00-index](00-index.md)) in hand.** Every mention below of **agent-mediated** tool/MCP
+> scope — `agent_mediated_scope_allows`, `get_action_agent_scope`, `get_mcp_server_agent_scope`, and the
+> `M|O` classification of action/MCP **edit** — describes a model that was built and then **dropped**.
+> Action and MCP-server management is now plain **owner-or-admin** (`can_manage_own_tool` /
+> `_ensure_mcp_server_owner_or_admin`), and the shipped projection matches: `tool_permissions` /
+> `mcp_server_permissions` take a single `can_manage` bool. Agent-derived scope survives only for *viewing*
+> an MCP server connected to a managed group. Everything else in this document still applies.
+
+## Changelog vs v1
+
+1. **Shared decision helper (by-construction) — D1.** The projection stamps each tag by calling the *same* `can_<action>` boolean the write guard (`assert_*`) calls, so `project == enforce` holds by construction, not by discipline (§2.3, §3.1a).
+2. **Per-action predicates — D2.** Each action's tag is stamped by *its own* real gate (M / A / O / M|O / O|A), replacing the wrong "one filter per resource" that mis-stamped ≥3 actions per resource (§3.3, §5).
+3. **Hot-path / N+1 — D3.** Never stamp the chat/explore list; per-card tags ride the per-card fetch the card already makes; list callers preload the editable + managed sets once via a `ctx` so per-row stamping does no DB (§3.2, §4.4).
+4. **Drop codegen + required field — D4.** Hand-write the 7 per-resource action unions, make `permissions` a *required* (non-optional) field, and add a route-coverage test — no codegen pipeline (§4.5, §6.1).
+5. **Per-page default-deny — D5.** The SSR admin gate default-denies un-enumerated `/admin/*` paths instead of failing open (§3.5, §4.3).
+6. **Federated admin-only — D6.** Federated connectors have no scope model → gate on `isAdmin`, enumerate `/admin/federated` as FULL_ADMIN (§5.6).
+7. **Revert keeps Make-Manager — D7.** The PR6-v1 revert keeps the Make/Revoke Manager toggle — the only UI that reaches PR5's assign-manager route (§6.4).
+8. **Cached-vs-live invalidation — D8.** Every manager-status change — including external group-sync, not just the manual toggle — recomputes perms server-side and busts `['me']` (§3.4, §6.3).
+
+## Table of Contents
+
+- [1. Overview & Motivation](#1-overview--motivation)
+  - [1.1 Evidence](#11-evidence)
+  - [1.2 Three structural root causes](#12-three-structural-root-causes)
+  - [1.3 Goals](#13-goals)
+  - [1.4 Non-Goals](#14-non-goals)
+  - [1.5 Relation to PR1–6 & doc 06](#15-relation-to-pr16--doc-06)
+- [2. Architecture (High-Level Design)](#2-architecture-high-level-design)
+  - [2.1 Two-layer gate model](#21-two-layer-gate-model)
+  - [2.2 The three fields](#22-the-three-fields)
+  - [2.3 Shared-helper invariant (one `can_*`, three callers)](#23-shared-helper-invariant-one-can_-three-callers)
+  - [2.4 Before / after (one affordance)](#24-before--after-one-affordance-edit-this-agent-on-a-chat-card)
+  - [2.5 Why it stays scalable](#25-why-it-stays-scalable)
+  - [2.6 Industry grounding](#26-industry-grounding)
+- [3. Backend Design](#3-backend-design)
+  - [3.1 One shared decision helper (PDP → PEP + projection + test)](#31-one-shared-decision-helper-pdp--pep--projection--test)
+  - [3.1a D1 — One Shared Decision Helper (`can_*`), guard-by-guard](#31a-d1--one-shared-decision-helper-can_-guard-by-guard)
+  - [3.2 Read-side projection: `permissions_for` + ctx (no N+1)](#32-read-side-projection-permissions_for--ctx-no-n1)
+  - [3.3 Per-action predicate table](#33-per-action-predicate-table--each-actions-tag-comes-from-its-own-real-gate)
+  - [3.4 `/me.admin_capabilities` — server-computed Layer-1 set (+ cache coherence)](#34-meadmin_capabilities--server-computed-layer-1-set--cache-coherence)
+  - [3.5 Per-page access gate (AdminSSChrome SEAM) — default-deny](#35-per-page-access-gate-adminsschrome-seam--default-deny)
+  - [3.6 `POST /capabilities` batch endpoint — deferred](#36-post-capabilities-batch-endpoint--deferred)
+  - [3.7 Connectors is the reference implementation](#37-connectors-is-the-reference-implementation--but-does-not-generalize-to-toolmcp)
+- [4. Frontend Design](#4-frontend-design)
+  - [4.1 The `<Can>` primitive (Layer 2)](#41-the-can-primitive-layer-2)
+  - [4.2 `useUser()` new shape](#42-useuser-new-shape)
+  - [4.3 Coarse consumption (Layer 1)](#43-coarse-consumption-layer-1)
+  - [4.4 Per-item consumption — collapse the duplication](#44-per-item-consumption--collapse-the-duplication)
+  - [4.5 Hand-written per-resource action unions (no codegen in v1)](#45-hand-written-per-resource-action-unions-no-codegen-in-v1)
+  - [4.6 Deletions](#46-deletions)
+- [5. Affordance → Action Mapping (complete)](#5-affordance--action-mapping-complete)
+  - [5.1 Agents / Personas — 18](#51-agents--personas--18-dto-map-editm-deleteoa-sharem-featurea-publishoa-lista-reordera-view_statso)
+  - [5.2 Actions / MCP — 9](#52-actions--mcp--9-mcp-mcpserver-editmo-deleteo-authenticateo-manage_statuso-openapi-toolsnapshot-editmo-deletea-togglea)
+  - [5.3 Skills — 8](#53-skills--8-customskillresponse-editm-deletea-manage_accessm-publisha)
+  - [5.4 Groups — 6](#54-groups--6-usergroup-managem-per-group-deletea-edit_permissionsa-edit_token_limitsa)
+  - [5.5 Doc sets — 3](#55-doc-sets--3-documentsetsummary-editm-deletea-manage_accessm-publisha)
+  - [5.6 Connectors (cc_pair) — 3](#56-connectors-cc_pair--3-the-good-domain-is_editable_for_current_user-already-ships--the-template)
+  - [5.7 Nav / page access — 2](#57-nav--page-access--2)
+- [6. Testing, Rollout & PR Roadmap](#6-testing-rollout--pr-roadmap)
+  - [6.1 Contract test — project == enforce](#61-contract-test--project--enforce-the-anti-drift-guarantee)
+  - [6.2 Security note — flags are affordance-only](#62-security-note--flags-are-affordance-only)
+  - [6.3 Cache hygiene (React Query)](#63-cache-hygiene-react-query--incl-cached-vs-live-manager-status-d8)
+  - [6.4 Rollout](#64-rollout)
+  - [6.5 PR roadmap](#65-pr-roadmap-5-review-sized-prs-drift-checkpoint-each)
+  - [6.6 Open decisions](#66-open-decisions)
+
+---
+
+## 1. Overview & Motivation
+
+Onyx's group-manager feature lets a non-admin manage resources *within the groups they manage*. The backend enforcement for this (PR1–PR5) is built, vetted, and fail-closed — it is the real security boundary. The **UI**, however, guesses at that boundary from a second, client-side re-derivation of policy that has already drifted out of agreement with the server. The result is not a security hole; it is an **affordance-correctness** problem: buttons that shouldn't render do, buttons that should render don't, and clicks that pass the client gate 403 at the server. A ground-truth inventory of every permission-gated affordance in the web app quantifies the drift.
+
+### 1.1 Evidence
+
+An 8-agent inventory audited 109 permission-gated UI affordances against the real backend predicate. **49 (45%) are mis-gated.**
+
+| Domain | Mis-gated | Total | Rate | Notes |
+|---|---:|---:|---:|---|
+| Agents / Personas | 18 | 23 | 78% | worst cluster; 4× `canUpdateFeaturedStatus` fork (below) |
+| Actions / MCP / OpenAPI | 9 | 19 | 47% | mixes owner-only + scoped + admin in one surface |
+| Skills | 8 | 11 | 73% | no per-item signal at all |
+| User Groups | 6 | 17 | 35% | missing per-group `manage` signal |
+| Document Sets | 3 | 9 | 33% | page double-fetches + set-diffs to fake editability |
+| Connectors (cc_pair) | 3 | 18 | 17% | **the good domain** — already ships `is_editable_for_current_user` |
+| Navigation | 2 | 12 | 17% | coarse-only |
+| **Total** | **49** | **109** | **45%** | |
+
+Connectors scoring best is the tell: it is the one domain that already stamps a server-computed per-item flag (`backend/onyx/server/documents/connector.py:1231`, `cc_pair.py:323`). Everywhere the client is left to *infer* the boundary, it gets ~half the affordances wrong.
+
+### 1.2 Three structural root causes
+
+```
+                     server truth (PDP: db/scoped_permissions.py)
+                              │
+          ┌───────────────────┴─── enforced correctly (GATE 2, PR1–5)
+          │
+   client RE-DERIVES it ──► drift ──► 49/109 wrong affordances
+```
+
+1. **The client re-derives policy.** `web/src/lib/permissions.ts:33` `visibilityPermissions()` blanket-injects all 6 `SCOPED_MANAGER_PERMISSIONS` into `useUser().permissions` with **zero group scoping** — a manager appears to hold `MANAGE_AGENTS` *everywhere*. This is a second, drifting source of truth for policy the server already owns.
+
+2. **The manual 3-tier gate is un-followable.** To gate one action a dev must choose between injected `permissions`, raw `effective_permissions`, or `isAdmin` — and choose right every time. `canUpdateFeaturedStatus` exists in **four** copies; **three read the wrong tier**:
+
+   | Copy | Reads | Verdict |
+   |---|---|---|
+   | `AgentRowActions.tsx:68` | `user.effective_permissions` | ✅ correct (managers excluded) |
+   | `AgentCard.tsx:57` | injected `permissions` | ❌ manager sees Feature |
+   | `ShareAgentModal.tsx:79` | injected `permissions` | ❌ |
+   | `AgentEditorPage.tsx:492` | injected `permissions` | ❌ |
+
+   Same feature, four sites, 3-of-4 wrong — because the tier choice is manual.
+
+3. **The per-item signal doesn't exist**, so ownership stands in for editability. `checkUserOwnsAgent` (`web/src/lib/agents/utils.ts:10`) gates edit/share/delete on `agent.owner?.id === userId`. It is wrong in **both** directions: managers/editors who *can* edit but don't own → affordance hidden; rows that are readable-not-editable → affordance shown → **403 on click**.
+
+### 1.3 Goals
+
+- Make every permission-gated affordance agree with what the server enforces — **project == enforce by construction**: one shared `can_<action>` helper is called by the write guard, the read projection, and the contract test, so the projected tag and the enforced decision are literally the same boolean (§2.3) — not two implementations kept in sync by discipline.
+- Collapse the 3-tier manual choice into two mechanical primitives: `useCapabilities([...])` (Layer 1) and `<Can resource action>` (Layer 2). No dev tier-picking.
+- Delete the client-side policy re-derivation (`visibilityPermissions`); make the client a pure renderer of server-computed fields.
+- Forward-compatible: server can add an action key to a resource's `permissions` map with **no client deploy** (fail-closed: missing key ⇒ `false`).
+
+### 1.4 Non-Goals
+
+- **Not changing what backend enforcement decides.** GATE 2 / the PR1–5 PEP remain the security boundary; every guard keeps its exact `OnyxErrorCode`, message, and trigger. A small **behavior-preserving** refactor *is* in scope — it lifts each guard's boolean decision into a shared `can_<action>` helper that the guard still calls before raising (§2.3), so the guards enforce identically. The **existing PR1–5 enforcement suite is the proof**: it must stay green with zero edits.
+- **Not a security fix.** Enforcement is already fail-closed; a mis-gated button that 403s is a UX bug, not an escalation. This work is affordance-correctness + maintainability only.
+- **The `can_<action>` helper is required, not deferred.** D1 promotes it from the old "optional `can()` facade" to a v1 core — but as an **internal server function**, not an HTTP endpoint. Only the *batched* `POST /capabilities` endpoint stays deferred (§3.6).
+
+### 1.5 Relation to PR1–6 & doc 06
+
+| PR | Scope | This doc |
+|---|---|---|
+| PR1–5 (`…perms-pr5-manager-assignment-membership`) | backend PDP + PEP, built & vetted | **untouched** — the source of truth we read from |
+| PR6-v1 (on origin) | first UI pass | **reverted**; left on origin as reference |
+| **PR6-v2** (`Subash-Mohan/perms-pr6-manager-ui-v2`, off PR5) | UI/read-projection redesign | **this doc**, ~4 review-sized PRs |
+
+Doc `06-frontend-affordance-followups.md` first named the 3-tier model and the `is_editable` gap for agents. This document **supersedes and generalizes it**: the per-item flag becomes a uniform `resource.permissions: dict[str,bool]` across *all* seven domains, each entry stamped by the guard's own extracted `can_<action>` helper (§2.3), with the 3-tier choice removed rather than documented.
+
+---
+
+## 2. Architecture (High-Level Design)
+
+The client stops deriving policy. The server emits two authoritative signals — a coarse capability set on `/me` and a per-item boolean map on every resource DTO — and the client becomes a pure renderer over them. The per-item map is stamped by a shared `can_<action>` helper that the **write guard also calls** (§2.3), and the coarse set by a server-side capability union — so neither can drift from what the backend enforces. (Backend mechanics are detailed in §3; client mechanics in §4.)
+
+### 2.1 Two-layer gate model
+
+Every affordance resolves to exactly one of two questions. Never a hand-rolled token bundle.
+
+```
+                 ┌──────────────────── SERVER (authoritative) ────────────────────┐
+   GET /me ─────▶│  admin_capabilities = effective_permissions                    │
+                 │                       ∪ (SCOPED_MANAGER_PERMISSIONS if manager) │
+   GET /list ───▶│  DTO.permissions = { edit, delete, share, feature, ... }       │
+   GET /detail ─▶│  (fail-closed boolean map, one per resource row)               │
+                 └───────────────┬───────────────────────────┬────────────────────┘
+                                 │                            │
+                    LAYER 1 — COARSE               LAYER 2 — PER-ITEM
+                 "can manage X somewhere"        "can I do A to THIS x"
+                 nav link · page reach · New X    row button · menu item · modal action
+                 useCapabilities(['agent:create'])  <Can resource={x} action="edit">
+                   reads admin_capabilities           reads x.permissions["edit"]
+```
+
+- **Layer 1 (coarse)** answers *reach*: does a nav link show, does a page SSR-load, does the global "New X" button exist. Capability check — but re-sourced from server-computed `admin_capabilities`, not client-derived tokens. Managers included.
+- **Layer 2 (per-item)** answers *authority on one resource*: read `resource.permissions[action]`. No token can express "…but only for this row"; the boolean map can. Missing key ⇒ `false`.
+
+`is_admin` (`FULL_ADMIN_PANEL_ACCESS`) is retained only for affordances that are genuinely full-admin-only (e.g. reorder agents).
+
+### 2.2 The three fields
+
+The fix is refusing to overload one field. Three fields, three audiences, one of which is new-per-DTO.
+
+| field | shape | who computes | consumed by | managers in it? |
+|---|---|---|---|---|
+| `effective_permissions` | `list[str]` (raw global tokens) | unchanged | backend middleware · org-wide gates (`isAdmin`, feature/publish/delete-global) | **No** — scoped manager power is deliberately absent |
+| `admin_capabilities` | `list[str]` on `/me` (**NEW**) | server: `effective_permissions ∪ (SCOPED_MANAGER_PERMISSIONS if is_group_manager)` | **Layer 1 only** — nav/page/New-X reach; replaces `visibilityPermissions()` | **Yes** |
+| `resource.permissions` | `dict[str,bool]` per DTO (**NEW**) | server: shared `can_<action>` helper, one per action (§2.3) | **Layer 2 only** — `<Can>` on that row | Per-item (a manager is `true` on in-scope rows, `false` elsewhere) |
+
+Why `effective_permissions` and `admin_capabilities` must stay distinct: the union that lets a manager *reach* the Agents page (Layer 1) is exactly the thing that must **not** grant org-wide "feature this agent." Today `visibilityPermissions()` (`web/src/lib/permissions.ts:33`) injects the union into a single `permissions` field consumed by both, forcing devs to remember which of three tiers to read at each call site — and pick wrong (`canUpdateFeaturedStatus` is now copied to **four** sites: `AgentCard.tsx:57`, `ShareAgentModal.tsx:79`, `AgentEditorPage.tsx:492`, `AgentRowActions.tsx:68`). Splitting the field removes the choice.
+
+### 2.3 Shared-helper invariant (one `can_*`, three callers)
+
+Today each tricky guard **decides and raises in one body**; a read projection would have to **re-derive the same decision** separately — two implementations of one policy, guaranteed to drift. The fix makes drift impossible **by construction**: lift the *boolean decision* out of each guard into a shared helper `can_<action>(user, resource, db) -> bool`, then have all three consumers call it.
+
+- **Guard (write, PEP — behavior unchanged):** `assert_<action>` now calls the helper, then raises its exact same `OnyxError` on `False`. Same code, same message, same trigger.
+- **Projection (read, NEW):** stamps `dto.permissions[action] = can_<action>(user, res, db)`.
+- **Contract test:** calls the *same* helper and asserts it equals "the guard did not raise."
+
+```
+              can_<action>(user, resource, db) -> bool      ◀── ONE decision, THREE callers
+                     │
+      ┌───────────────┼─────────────────────────┐
+  assert_<action>   projection stamp          contract test
+  calls helper,     dto.permissions[a] =      assert helper == (assert_ raised?)
+  then RAISES       can_<action>(u,R,db)      across the actor × resource × action matrix
+  (UNCHANGED)             │
+      │             <Can action="edit"> renders ⇔ helper true
+  403 if false
+```
+
+Because `assert_<action>` now *calls* `can_<action>`, "what the projection stamps" and "what the PEP enforces" are the **same boolean** — not a mirror that has to be kept faithful, but literally one function. The safety net proving enforcement is unchanged is the **existing PR1–5 enforcement suite**: it drives the `assert_*` guards and must stay green after the extraction. Green suite ⇒ the decision the PEP makes is provably identical; the only new thing is that the same decision is now also *readable*.
+
+This is a small, behavior-preserving refactor across ~6 guards — `auth/scoped_permissions.py:55` (`assert_within_scope`), `:92` (`assert_manages_group`); persona `db/persona.py:340` + EE `ee/onyx/db/persona.py:73`; tool `tool/api.py:84`; mcp `mcp/api.py:1376`. Two of the underlying gates are **already booleans** (`user_can_view_assistant_stats` `ee/onyx/db/analytics.py:339`, `agent_mediated_scope_allows` `auth/scoped_permissions.py:36`) — the projection just calls them. Full per-guard extraction (Tier-0 scope booleans + Tier-1 read wrappers, and the write-shaped→read-mode adaptation) is specified in §3.1a.
+
+> **Not "one filter per resource."** Each *action* bottoms out on its own real gate with its own shape — owner-bypass, creator-bypass, single-group membership, or a global token. The helper is `can_<action>`, not `can_touch_<resource>`; the editable filter `_add_user_filters(get_editable=True)` is a superset union that mis-stamps most actions if reused alone (over-reports scoped edits → 403; under-reports owner/creator affordances → their own button vanishes). See the per-action table in §3.3.
+
+The connectors domain is the working proof that a server-computed per-item flag is enough for the client: `is_editable` / `is_editable_for_current_user` already ship on the cc_pair DTOs (`server/documents/connector.py:1231`, `cc_pair.py:324-326`) — effectively `can_edit` for a cc_pair. D1 generalizes that one flag into a `permissions` map whose every entry is stamped by the guard's own extracted helper.
+
+### 2.4 Before / after (one affordance: "edit this agent" on a chat card)
+
+Root cause #3 in miniature — ownership standing in for editability, wrong in **both** directions (a scoped manager who can edit but doesn't own → hidden; a readable-not-editable row → shown → 403 on click):
+
+```tsx
+// BEFORE — web/src/lib/agents/utils.ts:10 used as an edit GATE
+{checkUserOwnsAgent(user, agent) && <EditAgentButton agent={agent} />}
+```
+```tsx
+// AFTER — server already answered; client only renders
+<Can resource={agent} action="edit">
+  <EditAgentButton agent={agent} />
+</Can>
+// renders ⇔ agent.permissions.edit === true ; unknown/missing key ⇒ false
+```
+
+Same collapse applies to all tiers — one primitive replaces the three-way choice:
+
+| old tier / signal | old call | new |
+|---|---|---|
+| coarse token | `hasPermission(permissions, MANAGE_AGENTS)` | `useCapabilities(['agent:create'])` (Layer 1) |
+| org-wide token | `hasPermission(effective_permissions, MANAGE_AGENTS)` | `<Can resource={agent} action="feature">` (server returns `false` for managers) |
+| ownership stand-in | `checkUserOwnsAgent(user, agent)` | `<Can resource={agent} action="edit">` |
+
+`checkUserOwnsAgent` survives only as a **label** ("Your Agents"), never as a gate.
+
+### 2.5 Why it stays scalable
+
+| change | cost |
+|---|---|
+| new action on a resource (e.g. `"archive"`) | one server edit — extract/write its `can_archive` helper and add `archive` to that DTO's stamp loop. Clients not yet aware of the key render nothing (fail-closed), so **no client deploy is required** to ship the backend safely. |
+| new resource | wrap its real gate(s) as `can_<action>` and stamp the map. No new policy — the guard already owns the decision. Cost varies by resource (see caveats below); it is **not** a uniform "copy the connectors filter." |
+| policy change (scope rule) | edit the shared helper — `within_scope` / `manages_group`, or the per-resource `can_<action>` — **once**. Guard, projection, and contract test move together, or CI fails. |
+| unknown/forward-compat keys | client `<Can>` treats missing key as `false`; old clients degrade safe, never over-expose. |
+
+**Cost is not uniform — three honest caveats (see §3.2/§3.3):**
+
+- **The hottest path stays untouched.** The chat/explore agent list is `MinimalPersonaSnapshot` fetched `get_editable=False` (`persona/api.py:501-517`) — do **not** stamp `edit`/`share`/`view_stats` onto it. Those per-card tags ride the per-card `GET /persona/{id}` (`FullPersonaSnapshot`) the card already fetches via `useAgent` (`AgentCard.tsx:64`) → **zero net-new query**. Never source them from the existing `user_permission`/`PersonaAccessLevel` field — it does **not** reflect scoped-manager edit rights (silent drift).
+- **Admin lists (low traffic)** preload the editable-id set once and stamp each row from memory (the connectors template); the managed-group set rides on the `ctx` dataclass so per-row stamping does **no** DB.
+- **Tools and MCP have no `get_editable` filter at all** — editability is agent-mediated per resource (`get_action_agent_scope` / `get_mcp_server_agent_scope`, one join each). The preload-once template does **not** transfer; stamp their `edit` tag via a batch resolver (`GROUP BY tool_id`/`server_id`, managed set hoisted once) or only on the detail/edit fetch — never row-by-row on the list.
+
+The failure mode of the current design — *N* affordances × 3 tiers × hand-copied gates drifting independently (49/109 mis-gated) — is structurally removed: there is nothing left to hand-pick.
+
+### 2.6 Industry grounding
+
+The capability-on-the-DTO shape is standard: GitHub returns a `permissions` object per repo and exposes `viewerCanUpdate` / `viewerCanDelete` on GraphQL nodes — the server decides, the client renders. Batch/advisory capability probes (Google IAM `testIamPermissions`, OpenFGA `BatchCheck`, the AuthZEN advisory endpoint) inform UI only and are **never** the enforcement path — matching our split: `resource.permissions` and `admin_capabilities` gate *rendering*; GATE 2 remains the sole security boundary.
+
+---
+
+## 3. Backend Design
+
+The write-side PEP already exists and is vetted (PR1–PR5) and is the security boundary — every mutating endpoint keeps its `require_permission(...)` dependency + its GATE-2 guard, byte-for-byte. What changes is *how the read projection agrees with it.* Rather than have the read side **re-derive** the same policy (a second implementation, guaranteed to drift), this redesign **extracts the boolean decision out of each guard into a shared helper** `can_<action>(user, resource, db) -> bool`. The guard keeps deciding-and-raising (it now calls the helper, then raises — behavior unchanged); the projection stamps the DTO tag by calling the **same** helper; the contract test calls the **same** helper. `project == enforce` becomes true **by construction**, not by discipline.
+
+This promotes the previously-"deferred" `can()` idea (old §1.4 non-goal, old §6.6 open-decision) to a **required, core part of v1** — but as an *internal server function*, not an HTTP endpoint. The `POST /capabilities` HTTP facade stays deferred (§3.6).
+
+### 3.1 One shared decision helper (PDP → PEP + projection + test)
+
+There is no single SQL predicate that decides every action. Each action bottoms out on its **own** real gate — some are scope clauses (`assert_within_scope`), some are single-group membership (`assert_manages_group`), some are agent-mediated (`agent_mediated_scope_allows`), some are owner/creator-or-admin (`user_can_view_assistant_stats`, `_ensure_mcp_server_owner_or_admin`). The invariant is therefore *not* "one predicate, two call sites" — it is **one shared helper per action, called by three consumers**:
+
+```
+                 can_<action>(user, resource, db) -> bool     ◀── ONE decision, THREE callers
+                       │
+     ┌──────────────────┼───────────────────────┐
+ assert_<action>   projection stamp        contract test
+ (calls helper,    dto.permissions[a] =    assert helper == (assert_ raised?)
+  then RAISES —    can_<action>(u,R,db)    over the 5×7 matrix
+  UNCHANGED)              │
+       │            <Can action="edit"> renders ⇔ helper true
+   403 if false
+```
+
+The **safety net** that proves security is unchanged is the *existing* PR1–5 enforcement suite: it drives the `assert_*` guards and must stay green with **zero edits** after the refactor. If it stays green, the decision the PEP makes is provably identical — the only new thing is that the same decision is now *also readable* by the projection. (This replaces the old "read filter is a faithful mirror of GATE 2" framing, which was hand-wavy and — per §3.3 — wrong for most actions: the editable filter alone mis-stamps ≥3 of every resource's actions.)
+
+### 3.1a D1 — One Shared Decision Helper (`can_*`), guard-by-guard
+
+Two-tier helper layout. Tier 0 = generic scope booleans in `auth/scoped_permissions.py`; Tier 1 = per-resource read wrappers that resolve current state, then call Tier 0.
+
+| Tier | Helper | File | Extracted from | Shape |
+|---|---|---|---|---|
+| **0 (generic scope booleans)** | `within_scope(...) -> bool` | `auth/scoped_permissions.py` | `assert_within_scope` (`:55`) | write-shaped (current/requested/non-public) |
+| | `manages_group(...) -> bool` | `auth/scoped_permissions.py` | `assert_manages_group` (`:92`) | single-group |
+| | `agent_mediated_scope_allows(...)` | `auth/scoped_permissions.py:36` | — **already a bool** | reuse as-is |
+| **1 (per-resource read wrappers)** | `can_edit_persona` / `can_share_persona` | `db/persona.py`, `ee/onyx/db/persona.py` | `_assert_persona_update_within_managed_scope` (`:340`), `_assert_group_share_within_scope` (ee `:73`) | resolve current state → call Tier-0 |
+| | `can_view_persona_stats` | `ee/onyx/db/analytics.py:339` | `user_can_view_assistant_stats` — **already a bool** | reuse as-is (O-class) |
+| | `can_edit_custom_tool` | `server/features/tool/api.py` | `_get_editable_custom_tool` (`:84`) + `_assert_action_within_managed_scope` (`:62`) | admin∨creator∨scoped |
+| | `can_edit_mcp_server` | `server/features/mcp/api.py` | `_ensure_mcp_server_editable` (`:1376`) | admin∨owner(email)∨scoped |
+| | `can_manage_group` | `auth/scoped_permissions.py` | thin over `manages_group` | single-group |
+
+Two guards need **no extraction** — they are already booleans (`agent_mediated_scope_allows` `:36`, `user_can_view_assistant_stats` `:339`); the projection just calls them. That is a bonus, not the norm.
+
+#### Tier 0 — generic scope booleans (`auth/scoped_permissions.py`)
+
+`assert_within_scope` (`:55-89`) → `within_scope` + thin raiser. The current guard fuses decide + raise:
+
+```python
+def assert_within_scope(user, db_session, *, permission, current_group_ids,
+                        requested_group_ids, is_non_public) -> None:
+    authority = has_permission(user, permission)
+    if authority is PermissionAuthority.GLOBAL:
+        return
+    if authority is PermissionAuthority.SCOPED:
+        managed = get_scoped_groups(user, db_session, permission)
+        final = set(current_group_ids) | set(requested_group_ids)
+        if managed and final and final.issubset(managed) and is_non_public:
+            return
+    raise OnyxError(OnyxErrorCode.INSUFFICIENT_PERMISSIONS, "Group managers can only ...")
+```
+
+Refactored — the decision is extracted; the raise is unchanged:
+
+```python
+def within_scope(user, db_session, *, permission, current_group_ids,
+                 requested_group_ids, is_non_public,
+                 managed_group_ids: set[int] | None = None) -> bool:
+    """Pure GATE-2 decision. No raise. Called by assert_within_scope (write),
+    the per-row read wrappers (projection), and the contract test.
+    `managed_group_ids` lets a list caller pass a preloaded managed set so
+    per-row stamping issues no DB query (§3.2); None re-queries (single-item/test)."""
+    authority = has_permission(user, permission)
+    if authority is PermissionAuthority.GLOBAL:
+        return True
+    if authority is PermissionAuthority.SCOPED:
+        managed = (managed_group_ids if managed_group_ids is not None
+                   else get_scoped_groups(user, db_session, permission))
+        final = set(current_group_ids) | set(requested_group_ids)
+        return bool(managed and final and final.issubset(managed) and is_non_public)
+    return False
+
+def assert_within_scope(user, db_session, *, permission, current_group_ids,
+                        requested_group_ids, is_non_public) -> None:
+    if not within_scope(user, db_session, permission=permission,
+                        current_group_ids=current_group_ids,
+                        requested_group_ids=requested_group_ids,
+                        is_non_public=is_non_public):
+        raise OnyxError(OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+                        "Group managers can only act on private resources "
+                        "within the groups they manage.")
+```
+
+Same message, same trigger — the PR1–5 suite is unaffected.
+
+`assert_manages_group` (`:92-104`) → `manages_group` + thin raiser:
+
+```python
+def manages_group(user, db_session, *, group_id,
+                  managed_group_ids: set[int] | None = None) -> bool:
+    if has_global_permission(user, Permission.MANAGE_USER_GROUPS):
+        return True
+    managed = (managed_group_ids if managed_group_ids is not None
+               else get_scoped_groups(user, db_session, Permission.MANAGE_USER_GROUPS))
+    return group_id in managed
+
+def assert_manages_group(user, db_session, *, group_id) -> None:
+    if not manages_group(user, db_session, group_id=group_id):
+        raise OnyxError(OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+                        "Group managers can only act within the groups they manage.")
+```
+
+#### The write-shaped → read-mode adaptation (the crux of D1)
+
+`within_scope` is **write-shaped**: it evaluates a *proposed mutation* (`current_group_ids`, `requested_group_ids`, `is_non_public`). A projection asks a different question — *"can this user edit R **as it stands right now**?"* — there is no proposed change. The per-resource read wrapper (Tier 1) is where that adaptation lives: it re-reads R's **current** state and passes **`requested := current`** and **`is_non_public := not R.is_public`**:
+
+```
+WRITE guard  →  within_scope(current=DB groups, requested=REQUEST.groups, non_public=proposed)
+READ wrapper →  within_scope(current=DB groups, requested=DB groups,      non_public=R state)
+                                                 └── same value ──┘
+```
+
+Because both bottom out on `within_scope`, `can_edit_persona(u,R,db)` and "`assert_within_scope` would not raise for R's current state" are the **same boolean by construction** — the contract test only pins the read-mode arg-supply, not the policy.
+
+#### Tier 1 — per-resource read wrappers
+
+**Persona edit / share** (`db/persona.py:340`, `ee/onyx/db/persona.py:73`). Per §3.3 (D2): the projection is **read-editable AND managed-scope** — never `_add_user_filters(get_editable=True)` alone (superset union → over-reports → 403). Extract the scope-boolean from each guard, then compose with editable-membership.
+
+`_assert_persona_update_within_managed_scope` (`:340`) short-circuits non-SCOPED holders and personal (no-group) agents, resolves current groups/privacy in-txn, then delegates the raise to `assert_within_scope`. Extract its body to a bool:
+
+```python
+# db/persona.py
+def persona_update_within_scope(user, db_session, *, persona_id,
+                                requested_group_ids, requested_is_public,
+                                managed_group_ids: set[int] | None = None) -> bool:
+    if has_permission(user, Permission.MANAGE_AGENTS) is not PermissionAuthority.SCOPED:
+        return True                              # not governed by the managed-scope gate
+    current_group_ids, current_is_public = _read_persona_scope(persona_id, db_session)
+    if not current_group_ids and not requested_group_ids:
+        return True                              # personal (no-group) agent
+    return within_scope(user, db_session, permission=Permission.MANAGE_AGENTS,
+                        current_group_ids=current_group_ids,
+                        requested_group_ids=requested_group_ids,
+                        is_non_public=not current_is_public and not requested_is_public,
+                        managed_group_ids=managed_group_ids)
+
+def _assert_persona_update_within_managed_scope(persona_id, request, user, db_session) -> None:
+    # keep the exact `requested_* := request.* if not None else current` resolution
+    # the guard already does (db/persona.py:363-368); abbreviated here.
+    if not persona_update_within_scope(user, db_session, persona_id=persona_id,
+                                       requested_group_ids=_resolved_groups(request, ...),
+                                       requested_is_public=_resolved_public(request, ...)):
+        raise OnyxError(OnyxErrorCode.INSUFFICIENT_PERMISSIONS, "Group managers can only ...")
+```
+
+Read wrapper (projection + contract test call this):
+
+```python
+def can_edit_persona(user, persona: Persona, db_session, *,
+                     editable_ids: set[int], managed_group_ids: set[int] | None = None) -> bool:
+    return persona.id in editable_ids and persona_update_within_scope(   # AND, per §3.3
+        user, db_session, persona_id=persona.id,
+        requested_group_ids=[g.id for g in persona.groups],   # requested := current
+        requested_is_public=persona.is_public,
+        managed_group_ids=managed_group_ids,
+    )
+```
+
+`editable_ids` comes from the existing `_add_user_filters(get_editable=True)` (`db/persona.py:82`), preloaded once per list (§3.2). The **AND** is what keeps a non-manager member out (scope-guard `True` for non-SCOPED, but editable-membership `False`) and keeps an out-of-scope manager out (editable may be `True`, scope-guard `False`).
+
+**Share** has the same shape over `_assert_group_share_within_scope` (ee `:73`, called `:161`, body ends in `assert_within_scope` at ee `:104`): extract `persona_group_share_within_scope(...) -> bool`, then `can_share_persona = editable-membership AND persona_group_share_within_scope(read-mode: requested := current groups, original_is_public := persona.is_public)`.
+
+**Persona view_stats — reclassify M → O (already a bool).** Per §3.3, the real gate is **not** the editable filter — it is `user_can_view_assistant_stats` (`ee/onyx/db/analytics.py:339`), which returns `owner OR FULL_ADMIN`. No extraction:
+
+```python
+def can_view_persona_stats(user, persona, db_session) -> bool:
+    return user_can_view_assistant_stats(db_session, user, persona.id)   # O-class
+```
+
+> **⚠️ SUPERSEDED by D8 (2026-08-03).** Custom-tool and MCP edit are now **owner-or-admin only** — the
+> agent-mediated `scoped` term was dropped. The shipped projection matches: `tool_permissions` /
+> `mcp_server_permissions` (`permission_projection.py`) take a single `can_manage` bool sourced from
+> `can_manage_own_tool` / `can_manage_mcp_server` (owner-or-admin), so the tables below that reference
+> `agent_mediated_scope_allows` / `get_action_agent_scope` describe the old model. Everything else here still applies.
+
+**Custom tool edit — reclassify M → admin ∨ creator ∨ scoped** (`tool/api.py:84`). Stamping only the scoped term hides Edit from a plain **creator** on their own action (`tool.user_id == user.id`, `:100`). `_assert_action_within_managed_scope` (`:62`) just wraps `agent_mediated_scope_allows` — extract its bool, then extract the full disjunction:
+
+```python
+def _action_within_managed_scope(tool_id, db_session, user) -> bool:
+    group_ids, has_public, has_ungrouped = get_action_agent_scope(tool_id, db_session)   # db/tools.py:141
+    return agent_mediated_scope_allows(user, db_session, group_ids=group_ids,
+                                       has_public_agent=has_public,
+                                       has_ungrouped_private_agent=has_ungrouped)
+
+def can_edit_custom_tool(user, tool: Tool, db_session) -> bool:
+    if tool.in_code_tool_id is not None:
+        return False                                                   # built-in
+    if Permission.FULL_ADMIN_PANEL_ACCESS in get_effective_permissions(user):
+        return True                                                    # admin
+    if tool.user_id is not None and tool.user_id == user.id:
+        return True                                                    # creator bypass (:100)
+    if has_permission(user, Permission.MANAGE_ACTIONS) is PermissionAuthority.SCOPED:
+        return _action_within_managed_scope(tool.id, db_session, user) # scoped
+    return False
+```
+
+`_get_editable_custom_tool` keeps its **404** (missing) and **400** (built-in) `HTTPException` raises for precise messaging, then delegates the perms decision to `can_edit_custom_tool` (raising `INSUFFICIENT_PERMISSIONS`, "You can only modify actions that you created."). `ToolSnapshot` already ships `user_id`, so the projection has the creator datum.
+
+**MCP server edit — reclassify M → admin ∨ owner(email) ∨ scoped** (`mcp/api.py:1376`). MCP ownership is **by email** (`server.owner == user.email`, `:1386`); the DTO ships `owner: str`. Stamping only the scoped term hides Edit from the owner:
+
+```python
+def can_edit_mcp_server(user, server: DbMCPServer, db_session) -> bool:
+    if Permission.FULL_ADMIN_PANEL_ACCESS in get_effective_permissions(user):
+        return True                                    # admin
+    if server.owner == user.email:
+        return True                                    # owner-by-EMAIL (:1386)
+    if has_permission(user, Permission.MANAGE_ACTIONS) is PermissionAuthority.SCOPED:
+        group_ids, has_public, has_ungrouped = get_mcp_server_agent_scope(server.id, db_session)  # db/tools.py:153
+        return agent_mediated_scope_allows(user, db_session, group_ids=group_ids,
+                                           has_public_agent=has_public,
+                                           has_ungrouped_private_agent=has_ungrouped)
+    return False
+
+def _ensure_mcp_server_editable(server, user, db_session) -> None:
+    if not can_edit_mcp_server(user, server, db_session):
+        raise OnyxError(OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+                        "Only the server owner or a manager of its groups can modify this MCP server.")
+```
+
+MCP `delete`/`authenticate`/`manage_status` stay **O** via `_ensure_mcp_server_owner_or_admin` (`:1358`) — extract a sibling `can_admin_mcp_server` the same way if those tags are stamped.
+
+**User group manage — distinct single-group shape** (`user_group`):
+
+```python
+def can_manage_group(user, group: UserGroup, db_session, *,
+                     managed_group_ids: set[int] | None = None) -> bool:
+    return manages_group(user, db_session, group_id=group.id,
+                         managed_group_ids=managed_group_ids)   # Tier-0
+```
+
+`assert_manages_group` (`:92`, called at `ee/.../user_group/api.py:191,333`, `ee/.../db/user_group.py:545`) already wraps `manages_group` after the extraction above. The `manager_ids` on the group snapshot is **not** the gate — the gate is managed-set membership OR global `MANAGE_USER_GROUPS`.
+
+#### Guard-by-guard summary
+
+| Guard (file:line) | Current shape | Extracted bool | `assert_*` after | Read wrapper (projection) |
+|---|---|---|---|---|
+| `assert_within_scope` (`auth/scoped_permissions.py:55`) | decide+raise | `within_scope` | calls bool, raises | (used by persona wrappers) |
+| `assert_manages_group` (`:92`) | decide+raise | `manages_group` | calls bool, raises | `can_manage_group` |
+| `_assert_persona_update_within_managed_scope` (`db/persona.py:340`) | resolve+delegate-raise | `persona_update_within_scope` | calls bool, raises | `can_edit_persona` = editable ∧ bool |
+| `_assert_group_share_within_scope` (`ee/…/persona.py:73`) | resolve+delegate-raise | `persona_group_share_within_scope` | calls bool, raises | `can_share_persona` = editable ∧ bool |
+| `_get_editable_custom_tool` + `_assert_action_within_managed_scope` (`tool/api.py:84,62`) | fetch+decide+raise | `can_edit_custom_tool`, `_action_within_managed_scope` | keep 404/400 raises, delegate perms | `can_edit_custom_tool` |
+| `_ensure_mcp_server_editable` (`mcp/api.py:1376`) | decide+raise | `can_edit_mcp_server` | calls bool, raises | `can_edit_mcp_server` |
+| `user_can_view_assistant_stats` (`ee/…/analytics.py:339`) | **already bool** | — | (its own callers) | `can_view_persona_stats` |
+| `agent_mediated_scope_allows` (`auth/scoped_permissions.py:36`) | **already bool** | — | — | (composed by tool/mcp wrappers) |
+
+#### Behavior-preservation invariant (for the reviewer)
+
+- Every `assert_*` keeps its **exact `OnyxErrorCode` + message**; the extraction only relocates the boolean, so the **existing PR1–5 enforcement suite is the proof security is unchanged** — it must stay green with zero edits.
+- If a contract-test cell fails, the bug is in the **read wrapper's composition** (forgot the `editable ∧` for persona; stamped only the scoped term for tool/mcp) — **never** a reason to relax a guard.
+- Fail-closed by shape: every helper's terminal branch returns `False`; unknown authority, empty managed scope, and missing resource state all deny.
+
+### 3.2 Read-side projection: `permissions_for` + ctx (no N+1)
+
+New module `backend/onyx/auth/permission_projection.py`. The projection **never re-derives policy** — it calls the §3.1 `can_<action>` helpers. To keep list paths off the N+1 path, the caller preloads a small `ctx` **once** and threads it through every per-row helper call so per-row stamping issues **no** DB query.
+
+```python
+# auth/permission_projection.py
+@dataclass
+class ScopeCtx:
+    is_admin: bool                    # has_global_permission(user, <resource perm>)
+    editable_ids: set[int]            # 1 scoped query; resources that HAVE _add_user_filters(get_editable=True)
+    managed_group_ids: set[int]       # 1 query: fetch_managed_group_ids(user, db)  ── D3: passed into helpers
+                                      #          so within_scope/manages_group do NOT re-query per row
+
+def build_persona_ctx(user, db_session) -> ScopeCtx:
+    return ScopeCtx(
+        is_admin=has_global_permission(user, Permission.MANAGE_AGENTS),
+        editable_ids=fetch_editable_persona_ids(user, db_session),   # wraps db/persona.py:82
+        managed_group_ids=fetch_managed_group_ids(user, db_session), # db/scoped_permissions.py:34
+    )
+
+def persona_permissions(user, persona, ctx: ScopeCtx) -> dict[str, bool]:
+    return {
+        "edit":       can_edit_persona(user, persona, db=None,        # pure: reads ctx, no DB
+                                       editable_ids=ctx.editable_ids,
+                                       managed_group_ids=ctx.managed_group_ids),
+        "share":      can_share_persona(user, persona, db=None,
+                                        editable_ids=ctx.editable_ids,
+                                        managed_group_ids=ctx.managed_group_ids),
+        "view_stats": ctx.is_admin or persona.user_id == user.id,    # O-class (analytics.py:339 shape)
+        "delete":     ctx.is_admin or _owner_or_owner_group(persona, ctx),  # O|A, §3.3
+        "feature":    ctx.is_admin,   # A
+        "list":       ctx.is_admin,   # A
+        "publish":    ctx.is_admin or _owner_or_owner_group(persona, ctx),  # O|A
+        "reorder":    ctx.is_admin,   # A (FULL_ADMIN)
+    }
+```
+
+> **Adding `managed_group_ids` to the ctx (D3) is the whole point:** without it, each row's `within_scope`/`manages_group` re-runs `get_scoped_groups` → `fetch_managed_group_ids` (one query per row = N+1). With it preloaded, per-row stamping is pure set math. `db=None` is legal in the read wrappers precisely because `managed_group_ids` short-circuits the only DB call `within_scope` makes.
+
+**Where each map is stamped — hot-path honesty (D3).** *Not all lists should carry the map.*
+
+| Surface | Stamp the map? | Why |
+|---|---|---|
+| **Chat/explore agent list** — `list_personas` (`persona/api.py:501-517`, `MinimalPersonaSnapshot`, `get_editable=False`) | **NO** | Hottest read path in the app. Do **not** stamp `edit`/`share`/`view_stats` here. |
+| **Agent card** — `get_persona` (`persona/api.py:568`, `FullPersonaSnapshot`) | **YES** | `AgentCard` already fetches this per card via `useAgent` (`AgentCard.tsx:64`) → **zero net-new query**; stamp the per-card tags here. |
+| **Admin agent list** — `list_personas_admin` (`persona/api.py:215`, low traffic) | **YES** | Preload `ctx` once, stamp each row from memory (connectors template, §3.7). |
+
+**Never** source per-card tags from the existing `FullPersonaSnapshot.user_permission` / `PersonaAccessLevel`: `get_persona_access_level` (`db/persona_sharing.py:40`) is documented (`:48`) as feeding "the sharing UI, not the editable fetch" — it does **not** reflect scoped-manager edit rights, so reusing it silently drifts. Stamp from the `can_*` helper, always.
+
+**Tools & MCP have no editable filter — the connectors template does NOT copy to them (D3).** There is no `_add_user_filters(get_editable=True)` for tools or MCP servers; editability is **agent-mediated per resource** (`get_action_agent_scope` / `get_mcp_server_agent_scope`, one join each). So `ctx.editable_ids` doesn't exist for them, and "preload-once, stamp from memory" does not apply. Two acceptable strategies — pick per surface:
+
+```
+TOOL / MCP list  ── choose one ──
+  (a) BATCH RESOLVER: one GROUP BY tool_id / server_id join resolving all
+      rows' agent-scope up front; hoist managed_group_ids once → stamp from memory.
+  (b) DETAIL-ONLY (v1 lean): do NOT stamp `edit` on the list; stamp it only on
+      the detail/edit fetch (single resource → one join, no N+1).
+```
+
+v1 leans **(b)** for tool/MCP lists (edit is a per-card affordance the detail fetch already loads); add the batch resolver only when a list surface must show the edit tag at scale.
+
+**List path (resources that DO have an editable filter):**
+
+```python
+ctx = build_persona_ctx(user, db_session)          # editable set + managed set resolved ONCE
+for dto in rows:
+    dto.permissions = persona_permissions(user, dto, ctx)   # pure, no DB → no N+1
+```
+
+The DTO field is **required** (D4/§3.3): `permissions: dict[str, bool]`, never optional — a stamp site that forgets to fill it is a type error, not a silently-empty map. Individual *action keys* remain fail-closed (a key absent from the dict ⇒ `false` on the client), which is what preserves forward-compat.
+
+### 3.3 Per-action predicate table — each action's tag comes from ITS OWN real gate
+
+The old "one filter per resource" was wrong: within a single resource, different actions bottom out on **different gate functions with different shapes**. This is an **action-level** table (action → real gate fn → scope class), verified against `HEAD`.
+
+**Scope legend:** `M` = scoped-manager true iff in-scope (admin also true) · `A` = global/admin token only (managers → false) · `O` = owner/creator-or-admin (managers → false unless they own it) · **`M|O`** = scoped **OR** owner/creator **OR** admin (owner-bypass) · **`O|A`** = owner-or-global (owner bypass, but **not** the scoped-manager path).
+
+| Resource | Action | Real gate (fn + file:line) | Scope | Notes |
+|---|---|---|---|---|
+| **Persona** | edit | `_assert_persona_update_within_managed_scope` → `assert_within_scope` `db/persona.py:340` (route `persona/api.py:336`, `ADD_AGENTS` allow_scope) **AND** read-editable `_add_user_filters(get_editable=True)` `db/persona.py:82` | M | Both gates; NOT `get_editable` alone (superset union → over-reports → 403) |
+| | share | `_assert_group_share_within_scope` → `assert_within_scope` **EE** `ee/onyx/db/persona.py:73` (called `:161`; route `persona/api.py:443`) **AND** read-editable | M | EE-only; `_assert_persona_update…` doesn't fire on a groups-unchanged share |
+| | **view_stats** | `user_can_view_assistant_stats` `ee/onyx/db/analytics.py:339` (route `ee/…/analytics/api.py:220`) | **O** | **M→O**: `FULL_ADMIN OR persona.user_id==user.id`. NOT the editable filter |
+| | **delete** | `get_persona_by_id(is_for_edit=True)` `db/persona.py:1426` via `mark_persona_as_deleted` (route `persona/api.py:487`, `ADD_AGENTS` **no** allow_scope) | **O\|A** | `global MANAGE_AGENTS OR owner(user_id) OR owner-group member` — excludes scoped-manager rels, so ≠ edit's `M` |
+| | feature | route `persona/api.py:177` `MANAGE_AGENTS` **no** allow_scope | A | global token |
+| | list (listed) | route `persona/api.py:143` `MANAGE_AGENTS` **no** allow_scope | A | global token |
+| | **publish** (is_public) | `update_persona_public_status` `db/persona.py:560` (route `persona/api.py:158`, `ADD_AGENTS` no allow_scope) | **O\|A** | `global MANAGE_AGENTS OR owner OR owner-group member` — a plain owner CAN org-publish their own agent; not pure A |
+| | reorder | route `persona/api.py:196` `FULL_ADMIN_PANEL_ACCESS` | A | FULL_ADMIN |
+| **DocumentSet** | edit / manage_access | `assert_within_scope` `document_set/api.py:91` (route `:76`, `MANAGE_DOCUMENT_SETS` allow_scope) + read-editable `db/document_set.py:42` | M | |
+| | delete | route `document_set/api.py:123` `MANAGE_DOCUMENT_SETS` **no** allow_scope | A | global token |
+| | publish (make-public) | create/update `is_public` → `assert_within_scope(is_non_public=…)` blocks scoped → global | A | scoped mgr can't publish org-wide |
+| **Skill** | edit | `assert_within_scope` `skill/api.py:258,:304` (routes `:233` patch, `:287` bundle, `MANAGE_SKILLS` allow_scope) | M | **No `get_editable` filter exists** — scope via managed-groups ∩ skill grants |
+| | manage_access (grants) | `assert_within_scope` `skill/api.py:355` (route `:339` `PUT …/grants`) | M | |
+| | delete | route `skill/api.py:378` `FULL_ADMIN_PANEL_ACCESS` | A | FULL_ADMIN |
+| | publish (is_public) | create/patch `is_public` → `assert_within_scope(is_non_public)` blocks scoped → global `MANAGE_SKILLS` | A | |
+| **MCP server** | **edit** | `_ensure_mcp_server_editable` `mcp/api.py:1376` | **M\|O** | `FULL_ADMIN OR server.owner==user.email OR scoped(agent-mediated)`. Owner by **EMAIL**; DTO ships `owner:str` |
+| | delete / authenticate / manage_status | `_ensure_mcp_server_owner_or_admin` `mcp/api.py:1358` | **O** | `FULL_ADMIN OR owner==email` |
+| **OpenAPI action** (Tool) | **edit** | `_get_editable_custom_tool` `tool/api.py:84` (route `:140`, `MANAGE_ACTIONS` allow_scope) | **M\|O** | `FULL_ADMIN OR tool.user_id==user.id (creator) OR scoped(_assert_action_within_managed_scope:62)` |
+| | delete | route `tool/api.py:167` `MANAGE_ACTIONS` **no** allow_scope | A | global route; creator bypass unreachable → A |
+| | toggle (status) | route `tool/api.py:194` `MANAGE_ACTIONS` **no** allow_scope | A | global token |
+| **UserGroup** | **manage** (per-group) | `assert_manages_group` `auth/scoped_permissions.py:92` (patch `:216`→`ee/…/user_group.py:545`, add-users `:239`, rename `:191`, agents `:282`, set-manager `:333`) | **M** (per-group) | `group_id ∈ managed set OR global MANAGE_USER_GROUPS` — single-group, NOT the editable filter |
+| | delete | route `user_group/api.py:262` `MANAGE_USER_GROUPS` **no** allow_scope | A | global token |
+| | edit_permissions | route `user_group/api.py:133` `PUT …/permissions` `FULL_ADMIN` | A | FULL_ADMIN |
+| | edit_token_limits | POST create `assert_within_scope` `token_rate_limits/api.py:74` (allow_scope) = M; per-row PUT/DELETE + `GET /user-groups` `FULL_ADMIN` `:32,:101` = A | M (create) / A (PUT/DELETE) | Split gate |
+| **Connector** (cc_pair) — TEMPLATE | edit / delete / manage_access | `get_connector_credential_pair_from_id_for_user(get_editable=True)` → `is_editable_for_current_user` `cc_pair.py:324-326`; list `is_editable` `connector.py:1231,1443` | M | Already ships the per-item flag |
+| | publish (make-public) | access-controls → global `MANAGE_CONNECTORS` | A | |
+
+**Why "one filter per resource" was wrong (3 lines):**
+1. Within one resource, actions bottom out on **different gate fns with different shapes** — persona alone spans `edit`=editable-filter+scoped-clause (M), `view_stats`=owner-or-admin (O), `feature/list`=global-token (A), `delete/publish`=owner-or-global (O|A). No single filter reproduces all four → a per-resource filter mis-stamps ≥3 of them.
+2. `_add_user_filters(get_editable=True)` is a **superset union** that **over-reports** for scoped actions (shows `edit` where the scoped-clause `+ is_non_public` gate would 403) *and* **under-reports** for owner/creator actions (tool/mcp/persona owners bypass the scoped path by `user_id`/`email` — stamping only the scoped term hides their own button).
+3. Three resources (skill, tool, mcp) have **no `get_editable` filter at all** — editability is `assert_within_scope` (skill) or agent-mediated joins (tool/mcp) — so "reuse the resource's editable filter" doesn't even exist for them.
+
+**Stamp sites (serializers).** Add the **required** `permissions: dict[str, bool]` and stamp via §3.2: `FullPersonaSnapshot.from_model` (per-card `GET /persona/{id}`, **not** the `MinimalPersonaSnapshot` list) · `DocumentSetSummary` · `CustomSkillResponse` · `MCPServer`/`ToolSnapshot` builders (detail/edit fetch, or batch-resolver list) · the EE `UserGroup` snapshot · connectors' `_get_connector_indexing_status_lite` (generalize its lone `is_editable` into the map; keep `is_editable` until the client cuts over).
+
+**Backend coverage test (D4) — closes the "add action, forget to register" hole.** A companion to §3.1's contract test: enumerate every mutating scoped route (`require_permission(..., allow_scope=True)` or a body-level `assert_*` guard) and assert each maps to a stamped action key that is present in the hand-written per-resource action list. A new guarded route with no stamped key fails CI, so the projection can't silently lose an affordance.
+
+```py
+# backend/tests/external_dependency_unit/auth/test_permission_projection_contract.py
+CAN = {("persona","edit"): can_edit_persona, ("persona","share"): can_share_persona,
+       ("persona","view_stats"): can_view_persona_stats, ("tool","edit"): can_edit_custom_tool,
+       ("mcp_server","edit"): can_edit_mcp_server, ("user_group","manage"): can_manage_group, ...}
+
+def test_helper_matches_guard(db_session, actor, resource_kind, action):
+    u, r = make_actor(actor), make_resource(resource_kind)
+    helper_says = CAN[(resource_kind, action)](u, r, db_session)   # projection's boolean
+    raised = guard_raised(resource_kind, action, u, r, db_session) # drive the assert_* guard
+    assert helper_says == (not raised)                             # project == enforce
+
+def test_every_scoped_route_has_a_stamped_key():
+    for route in mutating_scoped_routes():                         # allow_scope / assert_* sites
+        assert route.action_key in HANDWRITTEN_ACTIONS[route.resource]   # no orphan gate
+```
+
+Because `assert_*` now *calls* the helper, `test_helper_matches_guard` is **structural**, not coincidental — a future edit to `within_scope`/`manages_group` moves both sides together or fails CI.
+
+### 3.4 `/me.admin_capabilities` — server-computed Layer-1 set (+ cache coherence)
+
+New field on `UserInfo` (`backend/onyx/server/manage/models.py:131`), derived, never persisted, never consulted by the PEP. `effective_permissions` stays **global-only, unchanged**. `admin_capabilities` is **query-free** — `is_group_manager` is a column and the bundle is a constant:
+
+```python
+# UserInfo.from_model — no DB
+caps = set(effective_permissions or [])
+if user.is_group_manager:                        # cached column
+    caps |= SCOPED_MANAGER_PERMISSIONS_EXPANDED  # auth/permissions.py:263 (implied-expanded)
+admin_capabilities = sorted(caps)
+```
+
+**Cached `is_group_manager` vs live scope — the coherence hazard (D8).** Layer-1 (`admin_capabilities`) reads the **cached** `is_group_manager` bool; Layer-2 (`resource.permissions`) and the PEP resolve **live** scope (`fetch_managed_group_ids`). If the cache drifts *stale-true* — the user was demoted but `is_group_manager` is still `true` — the nav link and page show, but **every** per-item helper resolves `false` (dead buttons). If it drifts *stale-false*, the manager can't even reach the page. Both are avoidable only by recompute-on-change:
+
+> **Requirement:** every mutation that changes a user's manager status MUST `recompute_user_permissions(user)` **and** bust the `['me']` query — **including external group-sync** (a user gains/loses a managed group via IdP/SCIM sync), not just the manual Make/Revoke-Manager toggle. §6.3 currently lists only the manual toggle; the sync path is the one that silently drifts. Document the staleness window: between a sync-driven status change and the next `['me']` refetch, Layer-1 nav can disagree with Layer-2 per-item — the PEP stays correct throughout (it never reads the cache), so the worst case is cosmetic (a shown-but-dead or hidden-but-reachable page), never an escalation.
+
+### 3.5 Per-page access gate (AdminSSChrome SEAM) — default-deny
+
+Today `AdminSSChrome.tsx` calls only `requireAdminAuth()` — coarse "has *some* admin permission" admission (`requireAuth.ts:108`). There is **no per-page check**, so a manager can SSR-load a `FULL_ADMIN_PANEL_ACCESS` page. The naïve fix (look up `ADMIN_ROUTES[path]`, redirect if `requiredPermission ∉ admin_capabilities`) **fails OPEN**: any `/admin/*` path *not in* `ADMIN_ROUTES` (`systeminfo`, `groups2`, `federated/[id]`) matches nothing and admits everyone. The gate must **default-deny**:
+
+```
+match = ADMIN_ROUTES[path]                       (admin-routes.ts:92; entry.requiredPermission single Permission, :86)
+if match is None:                                # UNMATCHED /admin/* — DEFAULT DENY
+    required = FULL_ADMIN_PANEL_ACCESS           # managers redirected off unknown admin pages
+else:
+    required = match.requiredPermission
+if required ∉ me.admin_capabilities → redirect(getFirstPermittedAdminRoute(caps))
+```
+
+Because a manager's bundle never contains `FULL_ADMIN_PANEL_ACCESS`, unknown pages and full-admin pages both redirect managers; manager-reachable pages (`MANAGE_CONNECTORS`, `MANAGE_AGENTS`, …) pass. **Enumerate the currently-missing pages in `ADMIN_ROUTES`** with their real `requiredPermission` so they gate precisely rather than via the default-deny fallback:
+
+| Route | requiredPermission |
+|---|---|
+| `/admin/systeminfo` | `FULL_ADMIN_PANEL_ACCESS` |
+| `/admin/groups2` | `MANAGE_USER_GROUPS` (or `FULL_ADMIN` if it's the settings variant) |
+| `/admin/federated`, `/admin/federated/[id]` | `FULL_ADMIN_PANEL_ACCESS` (federated has no scope model — see §5.6 / D6) |
+
+This SSR gate is **defense-in-depth / least-astonishment, not the security boundary** — the boundary remains each endpoint's `require_permission(...)` + its GATE-2 guard. A manager who somehow reaches a full-admin page still 403s on every mutating call; the gate exists so the client never renders a page whose every action would 403. `requireAdminAuth` is re-sourced from `admin_capabilities` (drop `visibilityPermissions`).
+
+### 3.6 `POST /capabilities` batch endpoint — deferred
+
+For "orphaned" global affordances (a global *New X* button whose token isn't cleanly a single `admin_capabilities` membership, or future batched per-item checks). `testIamPermissions`-shaped, advisory only — **never** an enforcement path:
+
+```
+POST /capabilities  { "permissions": ["connector:create", "agent:feature", ...] }
+  -> { "permissions": ["connector:create"] }        # allowed subset (fail-closed on omission)
+```
+
+**v1 does not need this** — `useCapabilities(['connector:create'])` reads `admin_capabilities` directly. Kept as a deferred appendix; add only when a global affordance can't be expressed as bundle membership. (Note the distinction from §3.1a's `can_*`: those are *required* internal server functions consumed by the projection; this HTTP facade is the *optional* client-facing batch probe.)
+
+### 3.7 Connectors is the reference implementation — but does NOT generalize to tool/MCP
+
+The connectors domain already does the batch pattern: preload the editable set once (`get_connector_credential_pairs_for_user(..., get_editable=True)`), split editable/non-editable, stamp `is_editable` per row (`build_connector_indexing_status(cc_pair, is_editable)`, `connector.py:1229`; detail `is_editable_for_current_user`, `cc_pair.py:326`). This PR generalizes that single boolean into the `permissions` map and copies **preload-once / stamp-each-row** to the resources that **have an editable filter**: persona (admin list), document set, skill, user group.
+
+**It does NOT copy to tools and MCP servers.** Neither has `_add_user_filters(get_editable=True)`; editability is agent-mediated per resource (`get_action_agent_scope` / `get_mcp_server_agent_scope`, `db/tools.py:141,153` — one join each). Copying "preload once" there is impossible; a naïve per-row stamp is N+1. Follow §3.2's D3 fix instead: **batch resolver** (`GROUP BY tool_id`/`server_id`, hoist `managed_group_ids` once) **or** stamp `edit` **only on the detail/edit fetch** (v1 lean). No new policy is written — only the missing per-item signal is surfaced, sourced from the §3.1a helper.
+
+---
+
+_Verified paths (HEAD):_ `backend/onyx/auth/scoped_permissions.py:36,55,92` · `backend/onyx/db/scoped_permissions.py:25,34,39` · `backend/onyx/db/persona.py:82,340,560,1426` · `backend/onyx/db/persona_sharing.py:40,48` · `backend/ee/onyx/db/persona.py:73,104,161` · `backend/onyx/server/features/persona/api.py:143,158,177,196,215,336,443,487,501,568` · `backend/onyx/server/features/tool/api.py:62,84,100,140,167,194` · `backend/onyx/server/features/mcp/api.py:1358,1376,1386` · `backend/onyx/db/tools.py:141,153` · `backend/ee/onyx/db/analytics.py:339` · `backend/onyx/server/features/document_set/api.py:76,91,123` · `backend/onyx/server/features/skill/api.py:233,258,287,304,339,355,378` · `backend/ee/onyx/server/user_group/api.py:133,191,216,239,262,282,333` · `backend/ee/onyx/db/user_group.py:545` · `backend/onyx/server/manage/models.py:131` · `backend/onyx/server/documents/connector.py:1229,1231,1443` · `backend/onyx/server/documents/cc_pair.py:324-326` · `web/src/lib/admin-routes.ts:86,92` · `web/src/lib/auth/requireAuth.ts:108` · `web/src/layouts/chromes/AdminSSChrome.tsx`.
+
+---
+
+## 4. Frontend Design
+
+The client stops computing policy. Every gate resolves to reading a server field: a coarse token in `admin_capabilities` (Layer 1) or a boolean in `resource.permissions[action]` (Layer 2). `visibilityPermissions()` — the client-side re-derivation — is deleted. The complete per-affordance inventory these primitives replace is enumerated in §5.
+
+```
+                     ┌─────────────── /me ───────────────┐
+ Layer 1 (coarse) ── │ admin_capabilities: string[]       │ ── nav / page-reach / "New X"
+                     └────────────────────────────────────┘
+                     ┌──────────── resource DTO ──────────┐
+ Layer 2 (per-item)─ │ permissions: { edit:true, ... }    │ ── <Can> around each affordance
+                     └────────────────────────────────────┘
+```
+
+Two structural rules the rest of this section enforces:
+
+- **The `permissions` field is REQUIRED, not optional** (§4.5). A DTO the server forgot to stamp is a *type error* at the serializer/consumer boundary — never a button that silently vanishes at runtime. Fail-closed (missing *key* ⇒ `false`) stays, but it guards forward-compat drift, not a forgotten stamp.
+- **Layer-2 tags are read from the fetch that already exists** (D3, §4.4). The chat/explore card reads its `permissions` off the per-card `GET /persona/{id}` (`FullPersonaSnapshot`) it *already* fetches via `useAgent` — never off the hot list DTO, never off the legacy `user_permission`/`PersonaAccessLevel` field.
+
+### 4.1 The `<Can>` primitive (Layer 2)
+
+New file `web/src/components/auth/Can.tsx`. Reads the boolean map on the resource DTO; **fail-closed** — a missing key is `false`, so the server can ship a new action key before any client deploy.
+
+```tsx
+// web/src/components/auth/Can.tsx  (NEW)
+import type { ResourceActionOf, WithPermissions } from "@/lib/permissions/resource-actions";
+
+// Bare predicate — for imperative sites (disabled=, onClick guards, useMemo).
+export function can<R extends WithPermissions>(
+  resource: R | null | undefined,
+  action: ResourceActionOf<R>,
+): boolean {
+  return resource?.permissions?.[action] ?? false; // fail-closed on null row / unknown key
+}
+
+// Declarative wrapper — the default for JSX affordances.
+export function Can<R extends WithPermissions>({
+  resource, action, children, fallback = null,
+}: {
+  resource: R;
+  action: ResourceActionOf<R>;   // per-resource union, hand-written — see §4.5
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+}) {
+  return <>{can(resource, action) ? children : fallback}</>;
+}
+```
+
+Because `permissions` is a **required, exhaustive** `Record<Action, boolean>` per resource (§4.5), `resource.permissions[action]` is statically a `boolean` for a well-typed row — the `?? false` only fires for a `null` resource or a runtime key the client's union predates. Usage collapses a 3-tier hand-written decision to one line:
+
+```tsx
+<Can resource={agent} action="feature">
+  <FeatureToggle agentId={agent.id} />
+</Can>
+```
+
+### 4.2 `useUser()` new shape
+
+Drop the injection in `web/src/providers/UserProvider.tsx` (context value, lines 571/576/579). `permissions` was `visibilityPermissions(upToDateUser)` — a client-derived second source of truth. Replace with the server field `admin_capabilities`.
+
+| context field | OLD (`UserProvider.tsx`) | NEW |
+|---|---|---|
+| `isAdmin` (571) | `effective_permissions.includes(FULL_ADMIN_PANEL_ACCESS)` | **unchanged** |
+| `hasAdminAccess` (576) | `hasAnyAdminPermission(visibilityPermissions(user))` | `hasAnyAdminPermission(adminCapabilities)` |
+| `permissions` (579) | `visibilityPermissions(user)` | **removed** |
+| `adminCapabilities` | — (did not exist) | `upToDateUser?.admin_capabilities ?? EMPTY_PERMISSIONS` |
+
+```tsx
+// UserProvider.tsx  value={{ ... }}
+isAdmin: (upToDateUser?.effective_permissions ?? EMPTY_PERMISSIONS)
+  .includes(Permission.FULL_ADMIN_PANEL_ACCESS),                     // unchanged
+adminCapabilities: upToDateUser?.admin_capabilities ?? EMPTY_PERMISSIONS,
+hasAdminAccess: hasAnyAdminPermission(
+  upToDateUser?.admin_capabilities ?? EMPTY_PERMISSIONS,             // was visibilityPermissions(user)
+),
+// permissions: REMOVED
+```
+
+Add `admin_capabilities?: string[]` to `User` in `web/src/lib/types.ts` (beside `effective_permissions?` L131, `is_group_manager?` L134). `is_group_manager` stays for labels but is **no longer read as a gate** — the server already folded it into `admin_capabilities`.
+
+> Staleness (D8): `admin_capabilities` is computed from the **cached** `is_group_manager` column, while Layer-2 `permissions` and the PEP use *live* scope. Any path that flips manager status — the manual toggle **and external group-sync** — must `recompute_user_permissions` and bust `['me']`, or nav shows while every per-item tag is `false` (dead buttons). See §6.3.
+
+### 4.3 Coarse consumption (Layer 1)
+
+All three coarse seams re-source from `admin_capabilities`; none re-derives. The token set is identical to what `visibilityPermissions()` produced, but computed **server-side** by the PDP, so it can't drift from GATE 2.
+
+| seam | file:line | change |
+|---|---|---|
+| nav sidebar | `web/src/lib/admin-sidebar-utils.ts:26` `buildItems(permissions,…)` | callers pass `adminCapabilities`; `hasPermission` body unchanged |
+| SSR admission | `web/src/lib/auth/requireAuth.ts:108` `requireAdminAuth` | `hasAnyAdminPermission(user.admin_capabilities)` — drop `visibilityPermissions(user)` |
+| **per-page guard (NEW, default-deny)** | `web/src/layouts/chromes/AdminSSChrome.tsx:12` | add a per-route check; today this is the **only** gate and it is coarse-only |
+
+**Prerequisite — the frontend token vocabulary must be a superset of what the server can emit** (D4). Nav re-sources from `admin_capabilities`, so every scoped token the server may place in that set must exist as a `Permission` enum member **and** map to an `ADMIN_ROUTES` entry — otherwise the server emits a token the client can't match and a manager's reachable page silently disappears from the nav (and the per-page gate below can't grade it).
+
+The confirmed gap: `Permission.MANAGE_SKILLS` is **absent** from the frontend enum (`web/src/lib/types.ts:65` has no member) and has **no** `ADMIN_ROUTES` entry — this is the same omission the frontend `SCOPED_MANAGER_PERMISSIONS` copy already carries (`web/src/lib/permissions.ts:4` comment admits it drops `MANAGE_SKILLS`). `MANAGE_ACTIONS` exists (`types.ts:78`) with `/admin/actions/{mcp,open-api}` routes, but has no skills sibling. **Before** the nav flips to `admin_capabilities`:
+
+1. Add `MANAGE_SKILLS = "manage:skills"` to the `Permission` enum.
+2. Enumerate the skills-manage route(s) in `ADMIN_ROUTES` with `requiredPermission: MANAGE_SKILLS`.
+3. Audit the enum + `ADMIN_ROUTES` against the backend `SCOPED_MANAGER_PERMISSIONS` bundle so no scoped token is unrepresentable client-side (the `permissions.ts` bundle itself is deleted — §4.6 — but its *members* must survive as enum + route entries).
+
+**The per-page hole (D5).** `AdminSSChrome` admits any user with *any* admin token, so a manager can SSR-load a `FULL_ADMIN`-only page. (`admin-routes.ts` docstring claims a gate "in `ClientLayout.tsx`" — that file doesn't exist; the enforcement is missing.) The naive fix `if (route && !hasPermission(...))` **fails OPEN**: paths not in `ADMIN_ROUTES` make `route` falsy and skip the check entirely. Real `/admin/*` pages that hit this today: `/admin/systeminfo`, `/admin/groups2/**`, `/admin/federated/[id]`. Gate must **default-deny**:
+
+```tsx
+// AdminSSChrome.tsx — after requireAdminAuth() passes
+const caps = authResult.user?.admin_capabilities ?? [];
+const route = matchAdminRoute(pathname);          // exact / longest-prefix, NOT bare startsWith
+// DEFAULT-DENY: an un-enumerated /admin/* path demands the highest token, so a
+// manager is redirected and any newly-added page fails closed until registered.
+const required = route?.requiredPermission ?? Permission.FULL_ADMIN_PANEL_ACCESS;
+if (!hasPermission(caps, required)) {
+  return redirect(getFirstPermittedAdminRoute(caps) as Route);
+}
+```
+
+Enumerate the missing pages in `ADMIN_ROUTES` with their **real** `requiredPermission` (so they resolve by name, not by the fail-closed catch-all):
+
+| path | requiredPermission | why |
+|---|---|---|
+| `/admin/systeminfo` | `FULL_ADMIN_PANEL_ACCESS` | system diagnostics — admin-only |
+| `/admin/federated` (+ `/[id]`) | `FULL_ADMIN_PANEL_ACCESS` | federated connectors have **no scope model**; managers get `403` on every mutation — full-admin only (D6; the "Manage Federated Connector" button is likewise re-gated on `isAdmin`, §5.6) |
+| `/admin/groups2` (+ `/[id]`, `/create`) | `MANAGE_USER_GROUPS` *(verify audience)* | groups-management surface; sibling of `/admin/groups` |
+
+> Matching hazard: the current match is `pathname.startsWith(entry.path)`, so `"/admin/groups2".startsWith("/admin/groups")` is `true` — `groups2` would *accidentally* inherit `/admin/groups`'s `MANAGE_USER_GROUPS` rather than being graded explicitly. `matchAdminRoute` must prefer an **exact / longest-prefix segment** match, and every real page must have its own entry — the default-deny catch-all is the backstop, not the primary mechanism.
+
+Because a manager's `admin_capabilities` never contains `FULL_ADMIN_PANEL_ACCESS`, full-admin pages (and every un-enumerated `/admin/*`) redirect managers automatically; manager-reachable pages (`MANAGE_CONNECTORS`, `MANAGE_AGENTS`, `MANAGE_SKILLS`, …) pass. This SSR gate is **defense-in-depth / least-astonishment, not the security boundary** — a manager who reaches a full-admin page still `403`s on every mutating call.
+
+Global **"New X"** buttons go through a hook, not an inline token check:
+
+```ts
+// web/src/lib/permissions/useCapabilities.ts  (NEW)
+const CAP_TOKEN: Record<string, Permission> = {           // v1 slug → token map
+  "connector:create": Permission.MANAGE_CONNECTORS,
+  "agent:create":     Permission.ADD_AGENTS,
+  "skill:create":     Permission.MANAGE_SKILLS,
+  // …
+};
+export function useCapabilities(required: string[]): boolean {
+  const { adminCapabilities } = useUser();               // v1: read /me
+  return required.every((c) => adminCapabilities.includes(CAP_TOKEN[c]));
+  // later: swap body for POST /capabilities batch (deferred — see §3.6 appendix), same signature
+}
+```
+
+```tsx
+const canCreate = useCapabilities(["connector:create"]);
+{canCreate && <NewConnectorButton />}
+```
+
+### 4.4 Per-item consumption — collapse the duplication
+
+**Where the tags come from (D3).** Per-card Layer-2 tags are **not** stamped onto the hottest path — the chat/explore agent list is a `MinimalPersonaSnapshot` fetched `get_editable=False` (`backend/onyx/server/features/persona/api.py:501-517`); stamping `edit`/`share`/`view_stats` there would add an N+1 scope resolve per card. Instead, `AgentCard` already fetches the per-card `FullPersonaSnapshot` via `useAgent(agent.id)` (`AgentCard.tsx:64`, a `GET /persona/{id}`) — **that** DTO carries `permissions`, so per-card gating is **zero net-new query**. Never source the tag from the existing `user_permission` / `PersonaAccessLevel` field (`ee/onyx/db/persona_sharing.py:48`): it does **not** reflect scoped-manager edit rights → silent drift. Read `fullAgent.permissions`, fall back to hidden while the per-card fetch is in flight.
+
+**Featured status (4 copies today).** The gate is a *global* manage-agents action (managers get `false`), so the server stamps `agent.permissions.feature`. All four sites become `<Can resource={agent} action="feature">`.
+
+| file:line | reads today | verdict |
+|---|---|---|
+| `AgentCard.tsx:57` | `hasPermission(permissions, MANAGE_AGENTS)` (injected) | wrong → managers see it |
+| `ShareAgentModal.tsx:79` | `hasPermission(permissions, …)` (injected) | wrong |
+| `AgentEditorPage.tsx:492` | `hasPermission(permissions, …)` (injected) | wrong |
+| `AgentRowActions.tsx:68` | `hasPermission(user.effective_permissions, …)` (raw) | correct — but the raw/injected fork is exactly what devs get wrong |
+
+→ one server field (`feature`), one primitive; the `MANAGE_AGENTS` token check disappears from all four.
+
+**Ownership-as-gate.** `checkUserOwnsAgent` (`web/src/lib/agents/utils.ts:10`) is wrong in both directions — a manager/editor who can edit but doesn't own is hidden; a readable-not-editable row is shown → 403 on click. Note the tag now carries the **owner bypass** for free: the projection stamps `edit`/`share` true for a plain owner *and* an in-scope manager (§3.3, §5.1), so no client-side owner check is reintroduced.
+
+- `AgentCard.tsx:61` `isOwnedByUser` used to gate edit/share → replace with `can(fullAgent, "edit")` / `can(fullAgent, "share")` (read off the per-card DTO, above).
+- `AgentsNavigationPage.tsx:79` — **keep** `checkUserOwnsAgent`; it only filters the "Your Agents" tab (a label, not a gate).
+
+**Doc-set double-fetch.** `page.tsx Main()` (L353–364) fetches `useDocumentSets()` **and** `useDocumentSets(true)` (`hooks.tsx:10`, two SWR keys), then set-diffs to synthesize editability (`isEditable = editableDocumentSets.some(…)`, L197; union L174–176).
+
+```
+BEFORE:  GET /document-set  +  GET /document-set?editable=true  →  client set-diff  →  isEditable
+AFTER:   GET /document-set  (rows carry permissions.edit)       →  can(ds, "edit")
+```
+
+Delete the second fetch (`SWR_KEYS.documentSetsEditable`), the union, and the `.some()` diff; `useDocumentSets(getEditable)` loses its parameter. Render `<Can resource={ds} action="edit">` / `action="delete"`.
+
+### 4.5 Hand-written per-resource action unions (no codegen in v1)
+
+The action strings must match the server's stamped keys at compile time, so a typo (`action="feaure"`) fails `tsc`, not silently fails-closed at runtime. **There is no codegen pipeline today**, and standing one up is not worth v1 — the vocabulary is 7 small unions. **Hand-write them** (they change about as often as the backend gate set — rarely) and bind each to its DTO type.
+
+```ts
+// web/src/lib/permissions/resource-actions.ts  (HAND-WRITTEN — one small union per resource)
+export type ResourceActionMap = {
+  ConnectorIndexingStatusLite: "edit" | "delete" | "manage_access" | "publish";
+  DocumentSetSummary:          "edit" | "delete" | "manage_access" | "publish";
+  PersonaSnapshot: "edit" | "share" | "view_stats" | "delete" | "feature" | "list" | "reorder" | "publish";
+  CustomSkillResponse:         "edit" | "manage_access" | "delete" | "publish";
+  MCPServer:   "edit" | "delete" | "authenticate" | "manage_status";
+  ToolSnapshot:"edit" | "delete" | "toggle";
+  UserGroup:   "manage" | "delete" | "edit_permissions" | "edit_token_limits";
+};
+
+// REQUIRED + exhaustive per resource. A DTO the server forgot to stamp — or
+// stamped with a missing action — is a *type* error here, not a vanished button.
+export interface WithPermissions<K extends keyof ResourceActionMap = keyof ResourceActionMap> {
+  __resource: K;                                   // phantom tag, set once in the DTO's parser
+  permissions: Record<ResourceActionMap[K], boolean>;
+}
+export type ResourceActionOf<R> =
+  R extends { __resource: infer K extends keyof ResourceActionMap }
+    ? ResourceActionMap[K]
+    : never;
+```
+
+Each DTO type carries a `__resource: "PersonaSnapshot"` phantom tag, so `<Can resource={agent} action="…">` only accepts that resource's actions, and its `permissions` map must be present and complete.
+
+**Required, not optional — the whole point of D4.** With `permissions?: Record<string, boolean>` (optional), a serializer that forgets a resource yields `undefined` → `<Can>` fail-closes → the button *silently disappears* with no error anywhere. Making the field **required** on both ends turns "forgot to stamp" into a hard failure:
+
+- **Backend:** the Pydantic field is `permissions: dict[str, bool]` with **no default** — a `from_model` that doesn't set it raises at construction.
+- **Frontend:** `Record<ResourceActionMap[K], boolean>` is exhaustive — a DTO parser that omits the map, or a stamp loop that drops an action, fails `tsc`.
+
+**Backend coverage test — closes the "add an action, forget to register it" hole.** Type-requiredness catches a *forgotten map*; it does not catch a *new scoped route whose action was never added to the stamp loop / union*. A cheap backend test walks the router and asserts every mutating scoped route has a home:
+
+```py
+# backend/tests/external_dependency_unit/auth/test_scoped_route_coverage.py
+def test_every_scoped_mutation_maps_to_a_stamped_action():
+    # routes carrying require_permission(..., allow_scope=True) OR assert_within_scope in the body
+    for route in scoped_mutating_routes(app):
+        resource, action = ROUTE_TO_ACTION[route.endpoint]      # explicit registry, must be total
+        assert action in STAMPED_ACTIONS[resource], \
+            f"{route.path}: '{action}' not stamped for {resource}"
+```
+
+`STAMPED_ACTIONS[resource]` is the exact key set the projection stamps (§3.3) and mirrors the hand-written frontend unions. Add a scoped route without registering its action → red CI, not a phantom `403`. This pairs with the `project == enforce` contract test (§6.1): that one proves each *stamped* key is correct; this one proves no *gate* is unstamped.
+
+The batch `POST /capabilities` probe stays deferred (§3.6 appendix) — `useCapabilities` reads `admin_capabilities` in v1; nothing here depends on it.
+
+### 4.6 Deletions
+
+| delete | file:line | replaced by |
+|---|---|---|
+| `visibilityPermissions()` + its export | `web/src/lib/permissions.ts:33` | server `admin_capabilities` (§4.2) |
+| `SCOPED_MANAGER_PERMISSIONS` (frontend copy) | `web/src/lib/permissions.ts:7` | server-owned bundle — **but first** ensure every member survives as a `Permission` enum value + `ADMIN_ROUTES` entry (`MANAGE_SKILLS` is the missing one, §4.3); the *bundle constant* goes, the *tokens* must stay |
+| `permissions` context field + all `useUser().permissions` reads | `UserProvider.tsx:579`; `AgentCard.tsx:55`, `ShareAgentModal.tsx`, `AgentEditorPage.tsx:491` | `adminCapabilities` (coarse) / `resource.permissions` (per-item) |
+| `canUpdateFeaturedStatus` (×4) | `AgentCard.tsx:57`, `ShareAgentModal.tsx:79`, `AgentEditorPage.tsx:492`, `AgentRowActions.tsx:68` | `<Can action="feature">` |
+| `checkUserOwnsAgent` **as edit/share gate** | `AgentCard.tsx:61` | `can(fullAgent,"edit"/"share")` — fn kept only for the "Your Agents" label (`AgentsNavigationPage.tsx:79`) |
+| editable doc-set double-fetch + set-diff | `page.tsx:361-364,174-176,197`; `hooks.tsx:10` param; `SWR_KEYS.documentSetsEditable` | single fetch + `can(ds,"edit")` |
+| fail-OPEN per-page gate (naive `if (route && …)`) | proposed `AdminSSChrome.tsx` guard | default-deny gate + enumerated routes (§4.3) |
+
+`hasPermission` / `hasAnyAdminPermission` / `ADMIN_ROUTES` / `buildItems` / `requireAdminAuth` survive unchanged in logic — only their **input** flips from client-derived `visibilityPermissions(user)` to server `admin_capabilities`, and `ADMIN_ROUTES` **gains** the `MANAGE_SKILLS` + `systeminfo`/`groups2`/`federated` entries (§4.3).
+
+---
+
+_Files read to verify:_ `web/src/lib/permissions.ts` (bundle L7, `visibilityPermissions` L33, comment L4 admits `MANAGE_SKILLS` drop), `web/src/lib/types.ts` (Permission enum L65 — **no `MANAGE_SKILLS` member**; `MANAGE_ACTIONS` L78), `web/src/lib/admin-routes.ts` (`requiredPermission` L86; `/admin/actions/*` = `MANAGE_ACTIONS`; **no** skills / `systeminfo` / `groups2` / `federated` entry; match is `startsWith`), `web/src/app/admin/{systeminfo,groups2,federated}` (real un-enumerated `/admin/*` pages), `web/src/lib/auth/requireAuth.ts:108`, `web/src/layouts/chromes/AdminSSChrome.tsx`, `web/src/providers/UserProvider.tsx` (ctx value 571/576/579), `web/src/lib/admin-sidebar-utils.ts` (buildItems L26), `web/src/lib/agents/utils.ts:10`, `web/src/sections/agents/AgentCard.tsx` (55/57/61; `useAgent(agent.id)` L64 — the per-card `FullPersonaSnapshot` fetch the tags ride on), `web/src/sections/modals/ShareAgentModal.tsx:79`, `web/src/refresh-pages/AgentEditorPage.tsx:492`, `web/src/refresh-pages/admin/AgentsPage/AgentRowActions.tsx:68`, `web/src/refresh-pages/AgentsNavigationPage.tsx:79`, `web/src/app/admin/documents/sets/{hooks.tsx,page.tsx}`. Deviations corrected above: (1) `canUpdateFeaturedStatus` is **4** copies (`AgentRowActions.tsx:68` is a fourth, and the only correct one); (2) the per-page gate `admin-routes.ts` attributes to `ClientLayout.tsx` does not exist — per-page enforcement is genuinely absent, and the naive replacement fails OPEN on un-enumerated `/admin/*`; (3) `MANAGE_SKILLS` is absent from the frontend `Permission` enum and `ADMIN_ROUTES`, so the nav re-source silently hides scoped-skills managers until it is added.
+
+---
+
+## 5. Affordance → Action Mapping (complete)
+
+All 49 mis-gated affordances, grouped by domain. **Scope legend** for the `resource.permissions[...]` map — *each action's tag is stamped by **its own** real gate (D2), never one filter per resource*:
+
+- **M** — scoped-manager `true` iff in-scope (admin also `true`).
+- **A** — global/admin token only; managers → `false`.
+- **O** — owner/creator-or-admin; managers → `false` **unless they own it**.
+- **M|O** — union: scoped **OR** owner/creator **OR** admin (owner-bypass — the correction; stamping only the scoped term would hide the button from a plain owner/creator on their own resource).
+- **O|A** — owner-or-global (owner bypass, but **not** the scoped-manager path).
+
+Coarse rows use `hasPermission(adminCapabilities, X)` / `useCapabilities([...])`; truly FULL_ADMIN rows use `isAdmin`. Fail-closed: a missing key ⇒ `false`.
+
+`project == enforce` by construction (§3.1a): the projection stamps each `permissions[action]` by calling the **same** `can_<action>(user, resource, db)` helper the write-side guard (`assert_*`) calls, and the contract test calls it too — no re-derivation. The per-action real-gate → scope-class mapping these rows draw from is the action-level table in §3.3.
+
+### 5.1 Agents / Personas — 18 (DTO map `{edit:M, delete:O|A, share:M, feature:A, publish:O|A, list:A, reorder:A, view_stats:O}`)
+
+| Surface | File:line | Current gate (compressed) | New gate |
+|---|---|---|---|
+| Edit btn (admin list) | `refresh-pages/admin/AgentsPage/AgentRowActions.tsx:159` | none — row shown for every list item | `permissions.edit` (M) |
+| List/Unlist (`toggleAgentListed`) | `AgentRowActions.tsx:176` | none | `permissions.list` (A) |
+| Set/Remove Featured | `AgentRowActions.tsx:195` | `hasPermission(user.effective_permissions, …)` — *the one correct copy* | `permissions.feature` (A) |
+| Share btn (admin list) | `AgentRowActions.tsx:239` | none | `permissions.share` (M) |
+| Stats btn | `AgentRowActions.tsx:251` | none | `permissions.view_stats` (O — owner/admin, `user_can_view_assistant_stats`) |
+| Delete (`deleteAgent`) | `AgentRowActions.tsx:265` | none | `permissions.delete` (O\|A) |
+| Drag-reorder (`handleReorder`) | `refresh-pages/admin/AgentsPage/AgentsTable.tsx:123` | none | `isAdmin` (FULL_ADMIN) / `permissions.reorder` (A) |
+| Edit btn (chat/explore card) | `sections/agents/AgentCard.tsx:161` | `isOwnedByUser` = `checkUserOwnsAgent` | `permissions.edit` (M) |
+| Share btn (chat/explore card) | `AgentCard.tsx:176` | `isOwnedByUser` | `permissions.share` (M) |
+| Quick-feature star | `AgentCard.tsx:149` | `isOwnedByUser && businessTier` | `permissions.feature` (A) |
+| `canUpdateFeaturedStatus` **copy #1 (wrong)** | `AgentCard.tsx:57` | `hasPermission(permissions, …)` — injected tokens | `permissions.feature` (A) |
+| `canUpdateFeaturedStatus` **copy #2 (wrong)** | `sections/modals/ShareAgentModal.tsx:79` | `hasPermission(permissions, …)` — injected tokens | `permissions.feature` (A) |
+| Feature switch (share modal) | `ShareAgentModal.tsx:345` | rendered iff `canUpdateFeaturedStatus` (copy #2) | `permissions.feature` (A) |
+| "Publish This Agent" switch (`isPublic`) | `ShareAgentModal.tsx:340` | none — any sharer can toggle org-public | `permissions.publish` (O\|A) |
+| `canUpdateFeaturedStatus` **copy #3 (wrong)** | `refresh-pages/AgentEditorPage.tsx:492` | `hasPermission(permissions, …)` — injected tokens | `permissions.feature` (A) |
+| Feature control (editor) | `AgentEditorPage.tsx:1545` | rendered iff `canUpdateFeaturedStatus` (copy #3) | `permissions.feature` (A) |
+| Delete agent (`handleDeleteAgent`) | `AgentEditorPage.tsx:889` | none — page-reach only | `permissions.delete` (O\|A) |
+| Share/publish modal open | `AgentEditorPage.tsx:1083` | none — page-reach only | `permissions.share` (M) |
+
+**Note — where the chat-card tags come from (D3).** The chat/explore card's `edit`/`share`/`view_stats` tags are stamped on the per-card **`GET /persona/{id}`** (`FullPersonaSnapshot`) that `AgentCard` **already** fetches via `useAgent` (`AgentCard.tsx:64`) — **zero net-new query**. They are **not** stamped on the `MinimalPersonaSnapshot` chat/explore *list* (fetched `get_editable=False`, `persona/api.py:501-517` — the hottest path; leave it untagged), and are **never** sourced from `user_permission`/`PersonaAccessLevel` (`persona/models.py:398`), which does **not** reflect scoped-manager edit rights (silent drift). Admin-list rows stamp per-row from a preload-once editable-id set (connectors template).
+
+**Note — the gates (D2).** `edit`/`share` = **read-editable AND scoped-assert** — `_add_user_filters(get_editable=True)` (`db/persona.py:82`) **AND** `_assert_persona_update_within_managed_scope`→`assert_within_scope` (share adds EE `_assert_group_share_within_scope`, `ee/onyx/db/persona.py:104,161`); **never** the editable filter alone (superset union → over-reports → 403). `view_stats` = **O** (reclassified M→O): `user_can_view_assistant_stats` (`ee/onyx/db/analytics.py:339`) = owner **OR** FULL_ADMIN — **not** the editable filter. `delete`/`publish` = **O|A** (reclassified A→O|A): `global MANAGE_AGENTS OR owner OR owner-group member` — a plain owner *can* delete/org-publish their own agent, but the filter excludes scoped-manager rels, so ≠ `edit`'s M.
+
+**Note — the featured fork / labels.** `canUpdateFeaturedStatus` exists in **three injected-token copies** (`AgentCard:57`, `ShareAgentModal:79`, `AgentEditorPage:492`) vs the one correct `effective_permissions` copy (`AgentRowActions:68`) — collapse all four to `<Can resource={agent} action="feature">`. `checkUserOwnsAgent` stays only as the **"Your Agents"** label (`AgentsNavigationPage.tsx:79`), never as an edit/share gate. Coarse **"New Agent"** (`AgentsNavigationPage.tsx:105`, currently `hasPermission(permissions, ADD_AGENTS)` off injected tokens) → `useCapabilities(['agent:create'])` off `admin_capabilities`.
+
+### 5.2 Actions / MCP — 9 (MCP `MCPServer {edit:M|O, delete:O, authenticate:O, manage_status:O}`; OpenAPI `ToolSnapshot {edit:M|O, delete:A, toggle:A}`)
+
+| Surface | File:line | Current gate (compressed) | New gate |
+|---|---|---|---|
+| Edit MCP server | `sections/actions/MCPActionCard.tsx:284` | none — page-reach only | `permissions.edit` (M\|O) |
+| Delete MCP server | `MCPActionCard.tsx:213` | none | `permissions.delete` (O) |
+| Authenticate (pending) | `MCPActionCard.tsx:211` | none | `permissions.authenticate` (O) |
+| Disconnect (deauth) | `MCPActionCard.tsx:209` | none | `permissions.authenticate` (O) |
+| Refresh tools / status | `MCPActionCard.tsx:257` | none | `permissions.manage_status` (O) |
+| Edit OpenAPI action | `sections/actions/ActionCard.tsx:131` (via `OpenApiActionCard`) | none | `permissions.edit` (M\|O) |
+| Delete OpenAPI action | `sections/actions/OpenApiActionCard.tsx:130` | none | `permissions.delete` (A) |
+| Toggle tools (enable/disable) | `OpenApiActionCard.tsx:123` | none | `permissions.toggle` (A) |
+| Coarse "Add MCP Server" / "Add OpenAPI Action" | `sections/actions/MCPPageContent.tsx:495`, `OpenApiPageContent.tsx:358` | none | `useCapabilities(['action:create'])` (coarse `MANAGE_ACTIONS`) |
+
+**Note.** **`edit` is `M|O` (owner/creator bypass), not `M` (D2):** MCP edit = `_ensure_mcp_server_editable` (`mcp/api.py:1376`) = `FULL_ADMIN OR server.owner == user.email OR scoped` — MCP ownership is by **EMAIL** (`:1386`; DTO ships `owner:str`); OpenAPI edit = `_get_editable_custom_tool` (`tool/api.py:84`) = `FULL_ADMIN OR tool.user_id == user.id (creator) OR scoped` (`_assert_action_within_managed_scope:62`; `ToolSnapshot` ships `user_id`). Stamping only the scoped term would hide **Edit** from a plain owner/creator on their own resource. MCP delete/authenticate/disconnect/status stay **owner-only** (`_ensure_mcp_server_owner_or_admin`, `:1358`) — the DTO map is the only place that O-vs-M|O distinction survives to the client. OpenAPI `delete`/`toggle` are `MANAGE_ACTIONS` **no `allow_scope`** ⇒ `A`.
+
+### 5.3 Skills — 8 (`CustomSkillResponse {edit:M, delete:A, manage_access:M, publish:A}`)
+
+| Surface | File:line | Current gate (compressed) | New gate |
+|---|---|---|---|
+| Skills-manage **page access** | `layouts/craft/CraftManageLayout.tsx:22` | `hasPermission(effective_permissions, FULL_ADMIN_PANEL_ACCESS)` → redirect | coarse `hasPermission(adminCapabilities, MANAGE_SKILLS)` |
+| "Manage" entry surfacing | `refresh-pages/UserSkillsPage` (routes to manage) | same FULL_ADMIN redirect | coarse `MANAGE_SKILLS` |
+| Edit visibility (grants) | `refresh-pages/admin/SkillsPage/CustomSkillRowActions.tsx:60` | none — no per-row gate at all | `permissions.manage_access` (M) |
+| Replace bundle (edit) | `CustomSkillRowActions.tsx:71` | none | `permissions.edit` (M) |
+| Disable / Re-enable | `CustomSkillRowActions.tsx:81` | none | `permissions.edit` (M) |
+| Delete skill | `CustomSkillRowActions.tsx:92` | none | `permissions.delete` (A) |
+| Share/grant modal (group grants) | `refresh-pages/admin/SkillsPage/ShareSkillModal.tsx` + `SkillSharePicker.tsx` | none | `permissions.manage_access` (M) |
+| Coarse "Upload skill" (create) | `refresh-pages/admin/SkillsPage.tsx` (`UploadSkillModal`) | none | `useCapabilities(['skill:create'])` (coarse `MANAGE_SKILLS`) |
+
+**Note.** The whole page hides behind a **FULL_ADMIN redirect** (`CraftManageLayout`), so a manager holding scoped `MANAGE_SKILLS` (which has **no frontend token today** — see `permissions.ts:5` comment) can't reach it at all → **drop to coarse `admin_capabilities` `MANAGE_SKILLS`**, and add the token. `CustomSkillRowActions` has **zero per-item gating** — every row shows edit/replace/toggle/delete; delete is `FULL_ADMIN` (A), the rest scoped (`MANAGE_SKILLS allow_scope`); `granted_group_ids` already ships on the DTO.
+
+### 5.4 Groups — 6 (`UserGroup {manage:M (per-group), delete:A, edit_permissions:A, edit_token_limits:A}`)
+
+| Surface | File:line | Current gate (compressed) | New gate |
+|---|---|---|---|
+| Open/Manage group (row → edit) | `refresh-pages/admin/GroupsPage/GroupCard.tsx:70` | none — no **per-group** manager signal | `permissions.manage` (M, per-group) |
+| Add members | `refresh-pages/admin/GroupsPage/EditGroupPage.tsx:129` | none — page-reach only | `permissions.manage` (M) |
+| Delete group | `EditGroupPage.tsx:126` | none | `permissions.delete` (A) |
+| Toggle group permissions | `refresh-pages/admin/GroupsPage/GroupPermissionsSection.tsx:74` | data fetch gated on `isAdmin` (`:107`); section still renders | `permissions.edit_permissions` (A) |
+| Add/remove + save token limits | `refresh-pages/admin/GroupsPage/TokenLimitSection.tsx:154/144` | `disabled` from **tier only**, not role | `isAdmin` (PUT/DELETE = FULL_ADMIN); POST scoped |
+| Coarse "New Group" | `refresh-pages/admin/GroupsPage/index.tsx:69` | `actionLabel={isAdmin ? "New Group" : undefined}` — managers hidden | `useCapabilities(['group:create'])` (coarse `MANAGE_USER_GROUPS`) |
+
+**Note.** The **missing signal is per-group `manage`** — `is_group_manager` on `/me` is global; the snapshot already carries `manager_ids`, so `permissions.manage` is `assert_manages_group` (`auth/scoped_permissions.py:92`) for *this* group = `group_id ∈ managed set OR global MANAGE_USER_GROUPS` — a **single-group membership** gate (D2), **not** `within_managed_scope_clause`/the editable filter, and `manager_ids` on the snapshot is *not* itself the gate. Token-limit **PUT/DELETE are FULL_ADMIN** (`ee/.../token_rate_limits/api.py`) → `isAdmin`, not `edit_token_limits`; only POST is scoped.
+
+### 5.5 Doc sets — 3 (`DocumentSetSummary {edit:M, delete:A, manage_access:M, publish:A}`)
+
+| Surface | File:line | Current gate (compressed) | New gate |
+|---|---|---|---|
+| Edit row | `app/admin/documents/sets/page.tsx:204` (`EditRow`, `isEditable`) | client **set-diff** of two fetches (`useDocumentSets()` vs `useDocumentSets(true)`, `page.tsx:359-364`, `:197`) | `permissions.edit` (M) |
+| Delete (`DeleteButton`) | `sets/page.tsx:308` | gated by same client set-diff `isEditable` | `permissions.delete` (A) |
+| Make-public / publish badge | `sets/page.tsx:300` | none — public/private shown, not gated | `permissions.publish` (A) |
+
+**Note.** Kill the **double-fetch + client set-diff** (`hooks.tsx:10-27` + `page.tsx:359-364`) — one list call carrying `permissions.edit` replaces it. DELETE route is `MANAGE_DOCUMENT_SETS` **no `allow_scope`** ⇒ delete `A`; **make-public ⇒ `publish:A`** (managers can edit a scoped set but not publish it org-wide).
+
+### 5.6 Connectors (cc_pair) — 3 (the GOOD domain: `is_editable_for_current_user` already ships — the template)
+
+| Surface | File:line | Current gate (compressed) | New gate |
+|---|---|---|---|
+| Federated connector "Manage" button | `app/admin/indexing/status/CCPairIndexingStatusTable.tsx:308` | ungated — 403s for managers (hard-coded `is_editable: false`; **no scope model** for federated) | **`isAdmin` / coarse `MANAGE_CONNECTORS`** (D6 — decided admin-only); `/admin/federated/[id]` enumerated **FULL_ADMIN** in `ADMIN_ROUTES` |
+| Edit gate (detail page) | `app/admin/connector/[ccPairId]/page.tsx:188-190` | client **re-derives**: `is_editable_for_current_user \|\| (MANAGE_CONNECTORS && !FULL_ADMIN && …)` | pure `permissions.edit` (M) — drop the OR-fallback |
+| Make org-public (publish) | `[ccPairId]/page.tsx` access controls | none | `permissions.publish` (A) |
+
+**Note.** Pause/Delete already gate correctly on `is_editable_for_current_user` (`page.tsx:488`, `:481`) — **this is the template** the other domains copy. **Federated connectors have no `cc_pair` row and no scope model**, so the ungated "Manage Federated Connector" button 403s for managers today. **Decided (D6): gate it on `isAdmin` / global `MANAGE_CONNECTORS` and enumerate `/admin/federated/[id]` as `FULL_ADMIN` in `ADMIN_ROUTES`** — admin-only in v1 (no `permissions.edit` until federated grows a scope source). This resolves former §6.6 open-decision #1 (no longer open). The detail-page edit gate still **re-derives policy client-side** (`MANAGE_CONNECTORS && !FULL_ADMIN`) instead of trusting `permissions.edit` alone — drop the OR-fallback.
+
+### 5.7 Nav / page access — 2
+
+| Surface | File:line | Current gate (compressed) | New gate |
+|---|---|---|---|
+| Admin page SSR access | `layouts/chromes/AdminSSChrome.tsx:13` | coarse admission only — **no per-page `requiredPermission`** ⇒ manager can SSR-load FULL_ADMIN pages | **per-page gate, DEFAULT-DENY**: matched → `hasPermission(adminCapabilities, ADMIN_ROUTES[path].requiredPermission)`; **unmatched `/admin/*` → require `FULL_ADMIN_PANEL_ACCESS`** (redirect managers) |
+| Admin sidebar items | `lib/admin-sidebar-utils.ts:36` `buildItems()` | `hasPermission(permissions, …)` off **injected** `visibilityPermissions()` | re-source `permissions` from `admin_capabilities`; delete `visibilityPermissions` |
+
+**Note.** `AdminSSChrome` is **the only page-access gate** and it's coarse-only — add the per-page check keyed on the matched `ADMIN_ROUTES[path].requiredPermission`, sourced from `admin_capabilities` (so a scoped manager reaches `/admin/agents` but a FULL_ADMIN-only route SSR-redirects). **Default-deny (D5):** a naive matched-only gate **no-ops** on `/admin/*` paths **not** in `ADMIN_ROUTES` (`systeminfo`, `groups2`, `federated/[id]`) → **fails OPEN** (managers reach them). Fix: an **unmatched `/admin/*` requires `FULL_ADMIN_PANEL_ACCESS`** (redirect managers), and the missing pages are **enumerated in `ADMIN_ROUTES`** with their real `requiredPermission` (`/admin/federated/[id]` → `FULL_ADMIN`, per D6). `buildItems()` and `requireAdminAuth` (`lib/auth/requireAuth.ts:108`) both re-source from `admin_capabilities`; **`visibilityPermissions` (`lib/permissions.ts:33`) is deleted**, closing root cause #1 (the drifting second source of truth).
+
+**Roll-up:** 18 + 9 + 8 + 6 + 3 + 3 + 2 = **49**. Every row's **New gate** is server-authoritative — a `permissions[...]` key stamped by the projection via the shared `can_<action>` helper (§3.1a), a coarse `admin_capabilities` check, or `isAdmin` for the genuinely FULL_ADMIN affordances (agent reorder, token-limit PUT/DELETE, **federated "Manage"**). The scope taxonomy is richer than M/A: **O|A** (persona `delete`/`publish` — owner bypass, no scoped path) and **M|O** (tool/MCP `edit` — owner/creator bypass by `user_id`/`email`) carry owner/creator affordances a pure-scoped stamp would wrongly hide, and **O** (`view_stats`, MCP delete/authenticate/status) resolves owner-or-admin. The client is reduced to a pure `<Can>` renderer.
+
+---
+
+_Provenance: every `file:line` in §5 was verified against the repo `HEAD` (branch `perms-pr6-manager-ui-scoped-nav`). Notable confirmations while writing this table: `canUpdateFeaturedStatus` exists in **4** copies (not 3 — `AgentRowActions.tsx:68` is a fourth, and the one correct one); the doc-set double-fetch, the `is_editable_for_current_user` connector template, the `CraftManageLayout` FULL_ADMIN skills redirect, and the `visibilityPermissions` injection point are all present; and the per-page gate that `admin-routes.ts` claims lives in `ClientLayout.tsx` does **not** exist (per-page enforcement is genuinely absent — `AdminSSChrome` is the only gate). Per-gate D2/D5/D6 verifications baked in: persona `view_stats` = `user_can_view_assistant_stats` (owner ∨ FULL_ADMIN, `ee/onyx/db/analytics.py:339`), **not** the editable filter (M→O); persona `edit`/`share` = read-editable **AND** `_assert_persona_update_within_managed_scope`/EE `_assert_group_share_within_scope` (not `get_editable` alone); MCP `edit` owner is by **EMAIL** (`mcp/api.py:1386`) and Tool `edit` has a **creator** bypass (`tool/api.py:100`) — both M→M|O; persona `delete`/`publish` are owner-or-global (A→O|A); federated connectors have no scope model → admin-only (D6); the per-page SSR gate must **default-deny** unmatched `/admin/*` (D5, else it fails open on `systeminfo`/`groups2`/`federated/[id]`)._
+
+---
+
+## 6. Testing, Rollout & PR Roadmap
+
+### 6.1 Contract test — project == enforce (the anti-drift guarantee)
+
+The guarantee is no longer "the read filter is a faithful mirror" — it is **one shared decision helper** (§3.1a). Each tricky guard's boolean is extracted into `can_<action>(user, resource, db) -> bool`; `assert_<action>` calls that helper then raises (behavior byte-for-byte unchanged), the projection stamps `resource.permissions[action]` by calling the **same** helper, and the contract test calls the **same** helper. Because `assert_*` now *calls* `can_*`, `project == enforce` is **structural**, not a coincidence a test has to keep re-checking.
+
+Two tests hold the line.
+
+**(a) Helper-parity contract test.** The centerpiece. It does **not** run a parallel `get_editable=True` read query (v1's drift risk); it drives the **real `assert_*` guard** and asserts the helper the projection stamps equals the guard's decision.
+
+```py
+# backend/tests/external_dependency_unit/auth/test_permission_projection_contract.py
+# extends the scoped-perms fixtures in test_scoped_permissions.py
+
+ACTORS = ["admin", "manager_in_scope", "manager_out_of_scope", "owner", "viewer"]
+
+# (resource, action) -> the SAME can_* helper the projection stamps AND assert_* calls (§3.1a).
+# One entry per per-resource-gated action (M / O / M|O / O|A) in §3.3 + the D2 table.
+CAN = {
+  ("persona","edit"):       can_edit_persona,        # M   editable ∧ within_scope
+  ("persona","share"):      can_share_persona,       # M   editable ∧ group_share_within_scope
+  ("persona","view_stats"): can_view_persona_stats,  # O   owner ∨ FULL_ADMIN (analytics.py:339)
+  ("persona","delete"):     can_delete_persona,      # O|A owner-bypass filter (is_for_edit=True)
+  ("persona","publish"):    can_publish_persona,     # O|A owner ∨ global MANAGE_AGENTS
+  ("tool","edit"):          can_edit_custom_tool,    # M|O admin ∨ creator(user_id) ∨ scoped
+  ("mcp_server","edit"):    can_edit_mcp_server,     # M|O admin ∨ owner(email) ∨ scoped
+  ("user_group","manage"):  can_manage_group,        # M   per-group (managed set ∨ global)
+  ("document_set","edit"):  can_edit_document_set,    # M   editable-id membership
+  ("cc_pair","edit"):       can_edit_cc_pair,         # M   is_editable_for_current_user
+  # …share/manage_access variants stamped by their own can_* helper
+}
+
+@pytest.mark.parametrize("actor", ACTORS)
+@pytest.mark.parametrize(("resource_kind","action"), list(CAN))
+def test_helper_matches_guard(db_session, actor, resource_kind, action):
+    u, r = make_actor(actor), make_resource(resource_kind, actor)
+    helper_says = CAN[(resource_kind, action)](u, r, db_session=db_session)  # projection's boolean
+    raised = guard_raised(resource_kind, action, u, r, db_session)           # drives the real assert_* guard
+    assert helper_says is (not raised), f"DRIFT {resource_kind}.{action} for {actor}"
+```
+
+`guard_raised` invokes the actual `_assert_persona_update_within_managed_scope` / `_ensure_mcp_server_editable` / `assert_manages_group` / … and reports whether it raised `OnyxError`. A policy edit to `within_scope`/`manages_group` (`auth/scoped_permissions.py:55,92`) moves **both** sides at once or fails CI — this is what makes drift structurally impossible. If a cell fails, the bug is the read wrapper's *composition* (forgot the `editable ∧` for persona, or stamped only the scoped term for tool/mcp) — **never** a reason to relax a guard.
+
+**A-class (global-token) actions** — `feature`, `list`, `reorder`, and the pure-global `delete`/`toggle` — have **no per-resource guard**; the gate is the route's `require_permission(perm, allow_scope=False)`. They stamp constant-per-row from `effective_permissions`, so they are asserted against token membership directly (managers → `false`):
+
+```py
+GLOBAL = [("persona","feature",MANAGE_AGENTS), ("persona","list",MANAGE_AGENTS),
+          ("persona","reorder",FULL_ADMIN_PANEL_ACCESS), ("tool","toggle",MANAGE_ACTIONS),
+          ("tool","delete",MANAGE_ACTIONS), ("document_set","delete",MANAGE_DOCUMENT_SETS), …]
+
+@pytest.mark.parametrize("actor", ACTORS)
+@pytest.mark.parametrize(("resource_kind","action","token"), GLOBAL)
+def test_global_token_actions(db_session, actor, resource_kind, action, token):
+    u, r = make_actor(actor), make_resource(resource_kind, actor)
+    dto = to_dto(r, user=u, db=db_session)
+    assert dto.permissions[action] is (token in get_effective_permissions(u))
+```
+
+The matrix is **{admin, manager-in-scope, manager-out-of-scope, owner, viewer} × 7 resources**, so every `M`/`A`/`O`/`M|O`/`O|A` cell in §3.3 is asserted in both directions (granted *and* denied), including the D2 owner/creator bypasses (a plain owner sees `edit` on their own tool/mcp/persona; a manager does **not** see `feature`).
+
+**(b) Route-coverage test (D4).** Closes the "add a scoped route, forget to register its action" hole. Every mutating scoped route must map to an action that is (1) in the hand-written per-resource union (§4.5) and (2) stamped by the projection.
+
+```py
+# backend/tests/external_dependency_unit/auth/test_scoped_route_coverage.py
+def test_every_mutating_scoped_route_is_stamped():
+    # routes whose dep is require_permission(..., allow_scope=True) OR whose body
+    # calls assert_within_scope / assert_manages_group (introspected from the router)
+    for route in discover_scoped_mutations():
+        key = ROUTE_ACTION.get(route.endpoint)                       # (resource, action) — hand-maintained
+        assert key, f"{route.path}: no (resource,action) mapping"
+        resource, action = key
+        assert action in HAND_ACTIONS[resource], f"{action} missing from {resource} action union (§4.5)"
+        assert key in CAN or key in GLOBAL_KEYS, f"{key} not stamped by the projection"
+```
+
+Combined with the **required** (not optional) `permissions` DTO field (§4.5), a forgotten stamp is a compile error on the client and a red test on the server — never a silently-vanishing button.
+
+**E2E (Playwright).** One scenario per resource is overkill; assert the whole-surface invariant once — a scoped manager, in-scope on group G, sees *exactly* the in-scope affordances:
+
+```
+seed: manager M -> scope {G}; agent Ain∈G, Aout∉G; docset Din∈G, Dout∉G
+assert: nav shows Agents+DocSets+Groups (admin_capabilities);  NOT LLMs/Settings (FULL_ADMIN)
+assert: <Can resource=Ain action="edit"> renders;  <Can resource=Aout action="edit"> absent
+assert: Delete on Ain absent (delete=A);  Share on Ain present (share=M)
+assert: direct SSR GET /admin/configuration/llm -> redirect (per-page default-deny, §3.5/D5)
+assert: direct SSR GET /admin/systeminfo (unmapped /admin/* path) -> redirect (fails CLOSED, D5)
+```
+
+### 6.2 Security note — flags are affordance-only
+
+The `permissions{}` map and `admin_capabilities` control **rendering, not authority**. They hide buttons the user would be 403'd on. The real boundary is unchanged — and after D1 the projection is **literally the same code** the PEP's boolean runs, so there is no second decision surface to audit:
+
+| Layer | Artifact | Property |
+|---|---|---|
+| PEP (real gate) | `assert_*` (e.g. `auth/scoped_permissions.py:55`) → now calls `can_*`, then raises | A forged/replayed request with the button "un-hidden" still hits the PEP and 403s. |
+| Decision (truth) | `can_<action>` / `within_scope` / `manages_group` (§3.1a) | Single boolean; guard, projection, and contract test all call it. |
+| Projection (hint) | `resource.permissions[a]`, `admin_capabilities` | Untrusted by the server; never an input to an authz decision. |
+
+Two invariants the review must hold:
+- **Fail-closed by shape:** every helper's terminal branch returns `False` (unknown authority, empty managed scope, missing resource state all deny); on the client a missing action key ⇒ `false`. Forward-compatible — the server ships a new key before any client deploy.
+- **No new decision surface:** the extraction only *relocates* the boolean. The **existing PR1–5 enforcement suite is the proof security is unchanged** — it must stay green with zero edits. If a contract-test cell fails, it is a *projection-composition* bug, never a reason to relax the PEP.
+
+### 6.3 Cache hygiene (React Query) — incl. cached-vs-live manager status (D8)
+
+`permissions{}` rides in the resource DTO, so any mutation that changes who-can-do-what must invalidate the resource query. Additionally, Layer-1 `admin_capabilities` is computed from the **cached** `is_group_manager` column, while Layer-2 `permissions{}` and the PEP use **live** scope. If those drift apart, the failure is silent and ugly: nav shows (cached `is_group_manager=true`) but every per-item `permissions[...]` is `false` → **dead buttons** (or the inverse — hidden nav for a real manager).
+
+**Rule (D8):** *every* manager-status change must `recompute_user_permissions(user)` server-side **and** bust `['me']` client-side — not only the manual toggle, but also external group-sync and any group-membership edit that changes a manager set.
+
+| Mutation | Server | Client invalidate |
+|---|---|---|
+| share / manage_access change | — | `['<resource>', id]` **and** list key `['<resource>s']` |
+| **Make/Revoke Manager** — manual toggle (§5.4 `manage:M`, **KEPT** `3d994d5`) | `recompute_user_permissions(target)` | `['me']` (target) + `['userGroups']` + `['userGroup', gid]` |
+| **External group-sync flips manager status** (SCIM / OIDC / OAuth group sync) | `recompute_user_permissions(affected)` **in the sync task** | no client mutation fires → `['me']` refreshes on next poll (**staleness window**, below) |
+| Group-membership add/remove that changes a manager set | `recompute_user_permissions(affected)` | same as make-manager |
+| ownership transfer | — | `['<resource>', id]` + list key |
+| create / delete | — | list key only |
+
+**Reconciliation with §5.4.** The Make/Revoke Manager toggle is the per-group `manage` affordance (`permissions.manage`, M) and its UI commit `3d994d5` is **KEPT** (§6.4) — it is the only path that reaches PR5's `PUT …/manager` route, so this row is a live mutation, consistent with §5.4.
+
+**Staleness window (documented, accepted).** External group-sync runs in a background worker with no client `onSuccess`, so `['me']` is not busted synchronously — a newly-promoted/demoted manager sees stale nav/buttons until the next `/me` refetch (React Query `staleTime` / refetch-on-focus). This is **least-astonishment, not security**: the PEP still fail-closes, so a stale-*shown* button 403s and a stale-*hidden* button self-heals on refetch. Bound it with a short `staleTime` on `['me']` (or refetch-on-focus); tightening it to push-invalidation is a §6.6 tuning knob.
+
+### 6.4 Rollout
+
+- Fresh branch `Subash-Mohan/perms-pr6-manager-ui-v2` off **PR5** (`perms-pr5-manager-assignment-membership`). Leave PR6-v1 (`perms-pr6-manager-ui-scoped-nav`, **7 commits**) on origin as reference — do not force-push over it.
+- **Revert scope** = only the two commits that reveal nav / hide affordances client-side. The backend `/me` + group-snapshot additions **and the Make/Revoke Manager UI** stay — the new model builds on them.
+
+| PR6-v1 commit | Disposition | Why |
+|---|---|---|
+| `8de63e1` expose manager status on `/me` + group snapshot (`is_group_manager`, `manager_ids`) | **KEEP** | clean — backend models + FE types the v2 Layer-1/per-group signal builds on |
+| `e3532e5` log exception on failed manager assignment | **KEEP** | bundled with `3d994d5` — its log line lives *inside* that function |
+| `3d994d5` Make/Revoke Manager toggle on group edit | **KEEP** | **reverting it deletes the ONLY UI to assign a manager → PR5's `PUT …/manager` route is unreachable → nobody becomes a manager → whole feature inert.** It is an orthogonal member-table UI, independent of the nav/`visibilityPermissions` revert; gated by §5.4 `permissions.manage` (M) |
+| `dc58897` reveal scoped admin nav for managers | **REVERT** | replaced by `admin_capabilities`-sourced nav (§4.3) |
+| `0e3fb24` hide admin-only group affordances | **REVERT** | replaced by per-item `permissions{}` (§5.4) |
+| `8fa5a18` gate org-wide agent actions on global perm | **SUPERSEDE** | correct-tier idea, re-expressed as `feature/list/delete = A` in the map (§3.3) |
+| `0d4aea6` e2e for assignment & scoped nav | **REWRITE** | as the §6.1 E2E whole-surface invariant |
+
+**Roll-up:** KEEP 3 (`8de63e1`, `e3532e5`, `3d994d5` — 2 backend + the make-manager UI); REVERT 2 (`dc58897` nav reveal, `0e3fb24` hide-affordances); SUPERSEDE 1 (`8fa5a18`, folded into the map vocabulary); REWRITE 1 e2e (`0d4aea6`). *(SHAs corrected: `dc59882`→`dc58897`, `0e3f240`→`0e3fb24`.)*
+
+### 6.5 PR roadmap (5 review-sized PRs, drift checkpoint each)
+
+Re-estimated honestly: the D1 shared-helper extraction + the real contract harness + the D4 route-coverage test add scope the v1 sizing understated, so the spine splits into a backend and a frontend PR to stay review-sized. The make-manager toggle is **KEPT** (no rebuild). Per-resource `can_*` wrappers + hand-written action unions + the required `permissions` field land **with the resource that uses them**, not up front.
+
+| PR | Scope | LOC | Drift checkpoint |
+|---|---|---|---|
+| **A1 — Backend spine + shared helper + harness** | `admin_capabilities` on `/me`; **Tier-0 extraction** `within_scope`/`manages_group` from `assert_within_scope`/`assert_manages_group` (behavior-preserving); the **real contract harness** (`test_helper_matches_guard`) + **route-coverage test** (D4); **connectors** `permissions` map as proof (`can_edit_cc_pair` = existing `is_editable_for_current_user`, `cc_pair.py:326`). | ~650 | **PR1–5 enforcement suite green** (proves security byte-for-byte unchanged after extraction); helper-parity green for `cc_pair`; route-coverage green with connectors registered. |
+| **A2 — Frontend spine** | `<Can>` / `can()` + `useCapabilities()`; hand-written per-resource action unions + **required** `permissions` DTO type (D4); **per-page default-deny gate** in `AdminSSChrome` — unmatched `/admin/*` requires `FULL_ADMIN_PANEL_ACCESS` (D5) + enumerate the missing routes (`systeminfo`, `groups2`, `federated/[id]`) in `ADMIN_ROUTES`; add `MANAGE_SKILLS`/`MANAGE_ACTIONS` to the FE `Permission` enum + `ADMIN_ROUTES` (D4); **delete** `visibilityPermissions`/`SCOPED_MANAGER_PERMISSIONS`; connectors client cutover. | ~550 | grep proves **0** `visibilityPermissions`/`SCOPED_MANAGER_PERMISSIONS` sites in web; an unmapped `/admin/*` path redirects (fails closed); nav re-sourced from `admin_capabilities`. |
+| **B — Agents + Doc sets** | extract `can_edit_persona` (editable ∧ scope), `can_share_persona`, `can_view_persona_stats` (O, `analytics.py:339`), `can_delete_persona`/`can_publish_persona` (O\|A); stamp on the **per-card `GET /persona/{id}`** (D3 — never the hot chat/explore list); replace `checkUserOwnsAgent` as a gate → `<Can>` (kept only as the "Your Agents" *label*); dedupe the 3 wrong `canUpdateFeaturedStatus` copies; `DocumentSetSummary.permissions` (kills the double-fetch/set-diff). | ~700 | helper-parity green for `persona`(edit/share/view_stats/delete/publish) + `document_set`; AgentCard renders identically for owner vs in-scope editor; `view_stats` stamps `false` for an out-of-scope manager (O ≠ M). |
+| **C — Skills + Actions/MCP + Tools** | `CustomSkillResponse.permissions`; extract `can_edit_custom_tool` (**M\|O** — admin ∨ creator `user_id` ∨ scoped, `tool/api.py:84,100`) and `can_edit_mcp_server` (**M\|O** — admin ∨ owner-by-**email** ∨ scoped, `mcp/api.py:1376,1386`); tools/MCP have **no `get_editable` list filter** → stamp `edit` only on the **detail/edit fetch** or via a batch resolver, not the list (D3). | ~650 | helper-parity green for `skill`/`mcp_server`/`tool`; **owner/creator sees `edit` on their own resource** (M\|O), manager out-of-scope does not; MCP owner-by-email cell asserted. |
+| **D — Groups + Token limits + Federated + closing gate** | `UserGroup.permissions` incl. **per-group `manage:M`** via `can_manage_group` (`manages_group`, single-group); token-rate-limit map (POST=scoped M, PUT/DELETE/GET=A); **federated connectors** gated on `isAdmin`/global `MANAGE_CONNECTORS`, `/admin/federated` enumerated FULL_ADMIN (D6); land the **full** parametrized matrix + E2E as the closing gate. | ~550 | **full** matrix green (5 actors × 7 resources); per-group `manage` asserted; federated affordance no longer 403s a manager; E2E "manager sees exactly in-scope" passes; route-coverage covers *all* mutating scoped routes. |
+
+Each checkpoint = the contract harness extended to that PR's resources passes before merge; PR-D's is the complete matrix, so drift cannot survive the final merge. Admin-list stamping preloads the editable-id **set** once and stamps each row from memory (connectors template) with `managed_group_ids: set[int]` on the ctx dataclass so per-row stamping does **no** DB (D3).
+
+### 6.6 Open decisions
+
+Federated affordances (D6), the `ResourceAction` codegen (D4), and the `can()` consolidation (D1) are **no longer open** — they moved into the design (see "Resolved," below). What remains genuinely open:
+
+| # | Decision | Options / lean |
+|---|---|---|
+| 1 | **`POST /capabilities` in v1 vs fold into `/me`** | v1: `admin_capabilities` on `/me` covers all Layer-1 needs (small, static per session). A batch endpoint only pays off for large per-item capability fan-out. *Lean: ship on `/me`; add `POST /capabilities` (AuthZEN-style advisory batch) as a deferred appendix only if a screen needs per-item Layer-1 checks at scale.* |
+| 2 | **`['me']` staleness bound on external group-sync** (D8) | The sync task recomputes server-side, but no client mutation busts `['me']`, so a promoted/demoted manager sees stale nav until refetch. *Lean: short `staleTime` + refetch-on-focus on `['me']` (fail-closed already covers correctness); upgrade to push/websocket invalidation only if the window proves annoying.* |
+| 3 | **Stamp O-class MCP admin actions now vs defer** | `delete`/`authenticate`/`manage_status` are owner-or-admin (`_ensure_mcp_server_owner_or_admin`, `mcp/api.py:1358`). *Lean: extract a sibling `can_admin_mcp_server` and stamp them in PR-C alongside `edit`; trivial once the M\|O `edit` helper exists.* |
+
+**Resolved since v1 (folded into the design):**
+- **Federated connectors** (was open #1) → gate on `isAdmin`/global `MANAGE_CONNECTORS`; `/admin/federated` enumerated FULL_ADMIN (§5.6, D6). No scoped model in v1.
+- **`ResourceAction` union** → hand-written per-resource unions + **required** `permissions` field + route-coverage test (§4.5/§6.1, D4). No codegen dependency.
+- **`can()` facade** (was open #3) → **promoted to a required v1 core**: `can_<action>` is the shared decision helper that makes `project == enforce` by construction (§3.1a, D1). It is an internal server function, not an HTTP endpoint.

--- a/web/src/app/admin/connector/[ccPairId]/ConfigDisplay.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/ConfigDisplay.tsx
@@ -148,8 +148,9 @@ export function AdvancedConfigDisplay({
   pruneFreq: number | null;
   refreshFreq: number | null;
   indexingStart: Date | null;
-  onRefreshEdit: () => void;
-  onPruningEdit: () => void;
+  // Omit to hide the pencil for a caller who may not edit.
+  onRefreshEdit?: () => void;
+  onPruningEdit?: () => void;
 }) {
   const formatRefreshFrequency = (seconds: number | null): string => {
     if (seconds === null) return "-";

--- a/web/src/app/admin/connector/[ccPairId]/page.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/page.tsx
@@ -51,7 +51,7 @@ import {
 } from "lucide-react";
 import IndexAttemptErrorsModal from "./IndexAttemptErrorsModal";
 import usePaginatedFetch from "@/hooks/usePaginatedFetch";
-import { IndexAttemptSnapshot, Permission } from "@/lib/types";
+import { IndexAttemptSnapshot } from "@/lib/types";
 import { Spinner } from "@/components/Spinner";
 import { Callout } from "@/components/ui/callout";
 import { Card } from "@/components/ui/card";
@@ -69,7 +69,7 @@ import { SvgSettings } from "@opal/icons";
 import { useUser } from "@/providers/UserProvider";
 import { resolveAllErrorsForCCPair } from "@/lib/targeted_reindex";
 import { SWR_KEYS } from "@/lib/swr-keys";
-import { hasPermission } from "@/lib/permissions";
+import { can } from "@/lib/permissions/resource-actions";
 // synchronize these validations with the SQLAlchemy connector class until we have a
 // centralized schema for both frontend and backend
 const RefreshFrequencySchema = Yup.object().shape({
@@ -95,7 +95,7 @@ const PAGES_PER_BATCH = 8;
 
 function Main({ ccPairId }: { ccPairId: number }) {
   const router = useRouter();
-  const { user, permissions } = useUser();
+  const { user } = useUser();
 
   const {
     data: ccPair,
@@ -184,11 +184,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
 
   const latestIndexAttempt = indexAttempts?.[0];
   const canManageInlineFileConnectorFiles =
-    ccPair?.connector.source === "file" &&
-    (ccPair.is_editable_for_current_user ||
-      (hasPermission(permissions, Permission.MANAGE_CONNECTORS) &&
-        !hasPermission(permissions, Permission.FULL_ADMIN_PANEL_ACCESS) &&
-        ccPair.access_type === "public"));
+    ccPair?.connector.source === "file" && can(ccPair, "edit");
 
   const isResolvingErrors =
     (latestIndexAttempt?.status === "in_progress" ||
@@ -478,14 +474,14 @@ function Main({ ccPairId }: { ccPairId: number }) {
         <div className="ml-2 overflow-hidden text-ellipsis whitespace-nowrap flex-1 mr-4">
           <EditableStringFieldDisplay
             value={ccPair.name}
-            isEditable={ccPair.is_editable_for_current_user}
+            isEditable={can(ccPair, "edit")}
             onUpdate={handleUpdateName}
             scale={2.1}
           />
         </div>
 
         <div className="ml-auto flex gap-x-2">
-          {ccPair.is_editable_for_current_user && (
+          {can(ccPair, "edit") && (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button prominence="secondary" icon={SvgSettings}>
@@ -550,7 +546,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
                     </span>
                   </DropdownMenuItemWithTooltip>
                 )}
-                {!isDeleting && (
+                {!isDeleting && can(ccPair, "delete") && (
                   <DropdownMenuItemWithTooltip
                     onClick={() => {
                       setShowDeleteConnectorConfirmModal(true);
@@ -691,22 +687,21 @@ function Main({ ccPairId }: { ccPairId: number }) {
         </div>
       </Card>
 
-      {credentialTemplates[ccPair.connector.source] &&
-        ccPair.is_editable_for_current_user && (
-          <>
-            <Title size="md" className="mt-10 mb-2">
-              Credential
-            </Title>
+      {credentialTemplates[ccPair.connector.source] && can(ccPair, "edit") && (
+        <>
+          <Title size="md" className="mt-10 mb-2">
+            Credential
+          </Title>
 
-            <div className="mt-2">
-              <CredentialSection
-                ccPair={ccPair}
-                sourceType={ccPair.connector.source}
-                refresh={() => refresh()}
-              />
-            </div>
-          </>
-        )}
+          <div className="mt-2">
+            <CredentialSection
+              ccPair={ccPair}
+              sourceType={ccPair.connector.source}
+              refresh={() => refresh()}
+            />
+          </div>
+        </>
+      )}
 
       {ccPair.connector.connector_specific_config &&
         Object.keys(ccPair.connector.connector_specific_config).length > 0 && (
@@ -757,8 +752,13 @@ function Main({ ccPairId }: { ccPairId: number }) {
                       pruneFreq={pruneFreq}
                       indexingStart={indexingStart}
                       refreshFreq={refreshFreq}
-                      onRefreshEdit={handleRefreshEdit}
-                      onPruningEdit={handlePruningEdit}
+                      // No handler => no pencil, matching the rest of this page's edits.
+                      onRefreshEdit={
+                        can(ccPair, "edit") ? handleRefreshEdit : undefined
+                      }
+                      onPruningEdit={
+                        can(ccPair, "edit") ? handlePruningEdit : undefined
+                      }
                     />
                   </div>
                 </Card>

--- a/web/src/app/admin/connector/[ccPairId]/types.ts
+++ b/web/src/app/admin/connector/[ccPairId]/types.ts
@@ -7,6 +7,7 @@ import {
   AccessType,
 } from "@/lib/types";
 import { UUID } from "crypto";
+import type { PermissionsOf } from "@/lib/permissions/resource-actions";
 
 export enum ConnectorCredentialPairStatus {
   SCHEDULED = "SCHEDULED",
@@ -51,6 +52,8 @@ export interface CCPairFullInfo {
   latest_deletion_attempt: DeletionAttemptSnapshot | null;
   access_type: AccessType;
   is_editable_for_current_user: boolean;
+  // per-action affordance map for the requesting user (mirrors the write-side gate)
+  permissions: PermissionsOf<"CCPair">;
   deletion_failure_message: string | null;
   indexing: boolean;
   creator: UUID | null;

--- a/web/src/app/admin/documents/sets/page.tsx
+++ b/web/src/app/admin/documents/sets/page.tsx
@@ -17,6 +17,7 @@ import Title from "@/components/ui/title";
 import { DocumentSetSummary } from "@/lib/types";
 import { useState } from "react";
 import { useDocumentSets } from "./hooks";
+import { can } from "@/lib/permissions/resource-actions";
 import { ConnectorTitle } from "@/components/admin/connectors/ConnectorTitle";
 import { deleteDocumentSet } from "./lib";
 import { toast } from "@/hooks/useToast";
@@ -147,35 +148,20 @@ const EditRow = ({
 interface DocumentFeedbackTableProps {
   documentSets: DocumentSetSummary[];
   refresh: () => void;
-  refreshEditable: () => void;
-  editableDocumentSets: DocumentSetSummary[];
 }
 
 const DocumentSetTable = ({
   documentSets,
-  editableDocumentSets,
   refresh,
-  refreshEditable,
 }: DocumentFeedbackTableProps) => {
   const [page, setPage] = useState(1);
 
-  // sort by name for consistent ordering
-  documentSets.sort((a, b) => {
-    if (a.name < b.name) {
-      return -1;
-    } else if (a.name > b.name) {
-      return 1;
-    } else {
-      return 0;
-    }
+  // editable rows first, then by name — editability now rides on each row's
+  // permissions map, so no second fetch + set-diff is needed.
+  const sortedDocumentSets = [...documentSets].sort((a, b) => {
+    const editDiff = Number(can(b, "edit")) - Number(can(a, "edit"));
+    return editDiff !== 0 ? editDiff : a.name.localeCompare(b.name);
   });
-
-  const sortedDocumentSets = [
-    ...editableDocumentSets,
-    ...documentSets.filter(
-      (ds) => !editableDocumentSets.some((eds) => eds.id === ds.id)
-    ),
-  ];
 
   return (
     <div>
@@ -194,9 +180,7 @@ const DocumentSetTable = ({
           {sortedDocumentSets
             .slice((page - 1) * numToDisplay, page * numToDisplay)
             .map((documentSet) => {
-              const isEditable = editableDocumentSets.some(
-                (eds) => eds.id === documentSet.id
-              );
+              const isEditable = can(documentSet, "edit");
               return (
                 <TableRow key={documentSet.id}>
                   <TableCell className="whitespace-normal break-all">
@@ -305,7 +289,7 @@ const DocumentSetTable = ({
                     )}
                   </TableCell>
                   <TableCell>
-                    {isEditable ? (
+                    {can(documentSet, "delete") ? (
                       <DeleteButton
                         onClick={async () => {
                           const response = await deleteDocumentSet(
@@ -322,7 +306,6 @@ const DocumentSetTable = ({
                             );
                           }
                           refresh();
-                          refreshEditable();
                         }}
                       />
                     ) : (
@@ -356,14 +339,7 @@ function Main() {
     refreshDocumentSets,
   } = useDocumentSets();
 
-  const {
-    data: editableDocumentSets,
-    isLoading: isEditableDocumentSetsLoading,
-    error: editableDocumentSetsError,
-    refreshDocumentSets: refreshEditableDocumentSets,
-  } = useDocumentSets(true);
-
-  if (isDocumentSetsLoading || isEditableDocumentSetsLoading) {
+  if (isDocumentSetsLoading) {
     return (
       <div className="flex justify-center items-center min-h-[400px]">
         <ThreeDotsLoader />
@@ -373,10 +349,6 @@ function Main() {
 
   if (documentSetsError || !documentSets) {
     return <div>Error: {documentSetsError}</div>;
-  }
-
-  if (editableDocumentSetsError || !editableDocumentSets) {
-    return <div>Error: {editableDocumentSetsError}</div>;
   }
 
   return (
@@ -405,9 +377,7 @@ function Main() {
           <Divider />
           <DocumentSetTable
             documentSets={documentSets}
-            editableDocumentSets={editableDocumentSets}
             refresh={refreshDocumentSets}
-            refreshEditable={refreshEditableDocumentSets}
           />
         </>
       )}

--- a/web/src/app/admin/indexing/status/CCPairIndexingStatusTable.tsx
+++ b/web/src/app/admin/indexing/status/CCPairIndexingStatusTable.tsx
@@ -37,6 +37,7 @@ import { PageSelector } from "@/components/PageSelector";
 import { ConnectorStaggeredSkeleton } from "./ConnectorRowSkeleton";
 import { Button } from "@opal/components";
 import { SvgSettings } from "@opal/icons";
+import { can } from "@/lib/permissions/resource-actions";
 
 // Helper to handle navigation with cmd/ctrl+click support
 // NOTE: using this rather than Next/Link (or similar) since shadcn
@@ -302,6 +303,7 @@ export function CCPairIndexingStatusTable({
             last_status: "success",
             source: ValidSources.File,
             access_type: "public",
+            permissions: {},
             docs_indexed: 1000,
             last_success: "2023-07-01T12:00:00Z",
             last_finished_status: "success",
@@ -364,7 +366,7 @@ export function CCPairIndexingStatusTable({
                           <ConnectorRow
                             key={status.cc_pair_id}
                             ccPairsIndexingStatus={status}
-                            isEditable={status.is_editable}
+                            isEditable={can(status, "edit")}
                           />
                         );
                       }

--- a/web/src/app/craft/v1/apps/manage/layout.tsx
+++ b/web/src/app/craft/v1/apps/manage/layout.tsx
@@ -1,1 +1,4 @@
-export { default } from "@/layouts/craft/CraftManageLayout";
+import { createCraftManageLayout } from "@/layouts/craft/CraftManageLayout";
+import { Permission } from "@/lib/types";
+
+export default createCraftManageLayout(Permission.FULL_ADMIN_PANEL_ACCESS);

--- a/web/src/app/craft/v1/skills/manage/layout.tsx
+++ b/web/src/app/craft/v1/skills/manage/layout.tsx
@@ -1,1 +1,4 @@
-export { default } from "@/layouts/craft/CraftManageLayout";
+import { createCraftManageLayout } from "@/layouts/craft/CraftManageLayout";
+import { Permission } from "@/lib/types";
+
+export default createCraftManageLayout(Permission.MANAGE_SKILLS);

--- a/web/src/hooks/useCapabilities.ts
+++ b/web/src/hooks/useCapabilities.ts
@@ -1,0 +1,11 @@
+import { useUser } from "@/providers/UserProvider";
+import { hasPermission } from "@/lib/permissions";
+import { Permission } from "@/lib/types";
+
+// Coarse "may this user reach X at all" check for affordances not tied to a fetched
+// resource (nav, a global "New X" button). Uses admin_capabilities, so a group manager
+// is included — unlike raw effective_permissions.
+export function useCapabilities(...required: Permission[]): boolean {
+  const { adminCapabilities } = useUser();
+  return hasPermission(adminCapabilities, ...required);
+}

--- a/web/src/hooks/useServerTools.ts
+++ b/web/src/hooks/useServerTools.ts
@@ -98,6 +98,7 @@ export default function useServerTools(
         description: tool.description,
         isAvailable: true,
         isEnabled: tool.enabled,
+        permissions: tool.permissions,
       }))
     : [];
 

--- a/web/src/layouts/chromes/AdminChrome.tsx
+++ b/web/src/layouts/chromes/AdminChrome.tsx
@@ -1,8 +1,11 @@
 "use client";
 
 import AdminSidebar from "@/sections/sidebar/AdminSidebar";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
+import type { Route } from "next";
+import { useEffect } from "react";
 import { useSettingsContext } from "@/providers/SettingsProvider";
+import { useUser } from "@/providers/UserProvider";
 import { ApplicationStatus } from "@/interfaces/settings";
 import { Button, Text } from "@opal/components";
 import { markdown } from "@opal/utils";
@@ -10,18 +13,54 @@ import useScreenSize from "@/hooks/useScreenSize";
 import { SvgSidebar, SvgSimpleLoader } from "@opal/icons";
 import { RootLayout, useSidebarState } from "@opal/layouts";
 import { Section } from "@/layouts/general-layouts";
-import { isVectorDbRequiredRoute } from "@/lib/admin-routes";
+import { isVectorDbRequiredRoute, matchAdminRoute } from "@/lib/admin-routes";
+import {
+  getFirstPermittedAdminRoute,
+  hasAnyAdminPermission,
+  hasPermission,
+} from "@/lib/permissions";
 import LiteModeIndexingNotice from "@/sections/admin/LiteModeIndexingNotice";
 
 export interface AdminChromeProps {
   children: React.ReactNode;
+  // Server-fetched seed (AdminSSChrome) used until /api/me loads client-side.
+  initialAdminCapabilities: string[];
 }
 
-export default function AdminChrome({ children }: AdminChromeProps) {
+export default function AdminChrome({
+  children,
+  initialAdminCapabilities,
+}: AdminChromeProps) {
   const { setFolded } = useSidebarState();
   const { isMobile } = useScreenSize();
   const pathname = usePathname();
   const settings = useSettingsContext();
+  const router = useRouter();
+  const { adminCapabilities: liveAdminCapabilities, isUserLoading } = useUser();
+
+  // Seed only in flight — otherwise logout would leave the page authorized by a stale seed.
+  const adminCapabilities = isUserLoading
+    ? initialAdminCapabilities
+    : liveAdminCapabilities;
+
+  // Match-only per-page gate: if this page is a known admin route the user lacks the
+  // permission for (a group manager landing on a full-admin page), send them to their
+  // first permitted admin page. Unlisted detail sub-pages are left to the backend gate.
+  const matched = matchAdminRoute(pathname);
+  const denied =
+    matched !== undefined &&
+    !hasPermission(adminCapabilities, matched.requiredPermission);
+
+  useEffect(() => {
+    if (!denied) return;
+    // Some reach left → first permitted page; fully revoked → /app (else they'd bounce to an
+    // admin page they still can't open).
+    router.replace(
+      (hasAnyAdminPermission(adminCapabilities)
+        ? getFirstPermittedAdminRoute(adminCapabilities)
+        : "/app") as Route
+    );
+  }, [denied, router, adminCapabilities]);
 
   // Certain admin panels have their own custom sidebar.
   // For those pages, we skip rendering the default `AdminSidebar` and let those individual pages render their own.
@@ -41,6 +80,8 @@ export default function AdminChrome({ children }: AdminChromeProps) {
       content = <LiteModeIndexingNotice />;
     }
   }
+
+  if (denied) return null;
 
   return (
     <RootLayout.Root>

--- a/web/src/layouts/chromes/AdminSSChrome.tsx
+++ b/web/src/layouts/chromes/AdminSSChrome.tsx
@@ -17,8 +17,11 @@ export default async function AdminSSChrome({ children }: AdminSSChromeProps) {
     return redirect(authResult.redirect as Route);
   }
 
+  // Seed the client gate so a cold deep-link doesn't self-redirect before /api/me loads.
   return (
-    <AdminChrome>
+    <AdminChrome
+      initialAdminCapabilities={authResult.user?.admin_capabilities ?? []}
+    >
       <AnnouncementBanner />
       {children}
     </AdminChrome>

--- a/web/src/layouts/craft/CraftManageLayout.tsx
+++ b/web/src/layouts/craft/CraftManageLayout.tsx
@@ -8,22 +8,22 @@ interface CraftManageLayoutProps {
   children: React.ReactNode;
 }
 
-// Server-side admin-only gate (the /api/admin/* endpoints exclude curators,
-// unlike requireAdminAuth which allows them).
-export default async function CraftManageLayout({
-  children,
-}: CraftManageLayoutProps) {
-  const authResult = await requireAuth();
-  if (authResult.redirect) {
-    return redirect(authResult.redirect as Route);
-  }
-  if (
-    !hasPermission(
-      authResult.user?.effective_permissions ?? [],
-      Permission.FULL_ADMIN_PANEL_ACCESS
-    )
-  ) {
-    return redirect("/craft/v1" as Route);
-  }
-  return <>{children}</>;
+// Two routes share this factory but need different gates: /skills/manage passes
+// MANAGE_SKILLS (lets scoped managers in), /apps/manage passes FULL_ADMIN_PANEL_ACCESS
+// (its /admin/apps endpoints are admin-only). Both read admin_capabilities, which adds
+// the scoped-manager perms but never the full-admin token — so the apps gate still
+// rejects scoped managers.
+export function createCraftManageLayout(required: Permission) {
+  return async function CraftManageLayout({
+    children,
+  }: CraftManageLayoutProps) {
+    const authResult = await requireAuth();
+    if (authResult.redirect) {
+      return redirect(authResult.redirect as Route);
+    }
+    if (!hasPermission(authResult.user?.admin_capabilities ?? [], required)) {
+      return redirect("/craft/v1" as Route);
+    }
+    return <>{children}</>;
+  };
 }

--- a/web/src/lib/admin-routes.ts
+++ b/web/src/lib/admin-routes.ts
@@ -487,3 +487,18 @@ export function isVectorDbRequiredRoute(pathname: string): boolean {
     pathname.startsWith(prefix)
   );
 }
+
+/**
+ * The admin route whose path is the longest prefix of `pathname`, or undefined if none
+ * matches. Detail sub-pages covered by no entry return undefined, so the per-page gate
+ * leaves them alone rather than default-denying.
+ */
+export function matchAdminRoute(pathname: string): AdminRouteEntry | undefined {
+  let match: AdminRouteEntry | undefined;
+  for (const route of Object.values(ADMIN_ROUTES) as AdminRouteEntry[]) {
+    if (pathname === route.path || pathname.startsWith(route.path + "/")) {
+      if (!match || route.path.length > match.path.length) match = route;
+    }
+  }
+  return match;
+}

--- a/web/src/lib/admin-sidebar-utils.ts
+++ b/web/src/lib/admin-sidebar-utils.ts
@@ -47,7 +47,7 @@ export function buildItems(
       requiredTier: route.requiredTier,
     };
 
-    // Special case: INDEX_SETTINGS shows reindexing error indicator
+    // INDEX_SETTINGS surfaces a reindexing-needed error indicator
     if (route.path === ADMIN_ROUTES.INDEX_SETTINGS.path) {
       item.error = settings?.settings.needs_reindexing;
     }
@@ -55,7 +55,6 @@ export function buildItems(
     items.push(item);
   }
 
-  // Upgrade Plan — only for full admins without a subscription
   if (
     userCanAccess(Permission.FULL_ADMIN_PANEL_ACCESS) &&
     !flags.hasSubscription

--- a/web/src/lib/agents/types.ts
+++ b/web/src/lib/agents/types.ts
@@ -1,6 +1,7 @@
 import { ValidSources } from "@/lib/types";
 import { ToolSnapshot } from "@/lib/tools/interfaces";
 import { DocumentSetSummary, MinimalUserSnapshot } from "@/lib/types";
+import type { PermissionsOf } from "@/lib/permissions/resource-actions";
 
 // ── Domain / application types ────────────────────────────────────────────────
 
@@ -53,6 +54,8 @@ export interface MinimalAgent {
   builtin_persona: boolean;
   labels?: AgentLabel[];
   owner: MinimalUserSnapshot | null;
+  // per-action affordance map stamped by the list endpoints; empty/absent → fail-closed
+  permissions?: PermissionsOf<"Agent">;
 }
 
 export interface Agent extends MinimalAgent {
@@ -69,6 +72,8 @@ export interface Agent extends MinimalAgent {
 
 export interface FullAgent extends Agent {
   search_start_date: string | null;
+  // per-action affordance map for the requesting user; stamped by GET /persona/{id}
+  permissions: PermissionsOf<"Agent">;
 }
 
 // ── Upsert / API parameter types ──────────────────────────────────────────────

--- a/web/src/lib/auth/requireAuth.ts
+++ b/web/src/lib/auth/requireAuth.ts
@@ -100,8 +100,9 @@ export async function requireAdminAuth(): Promise<AuthCheckResult> {
 
   const { user, authTypeMetadata } = authResult;
 
-  // Check if user has any admin permission
-  if (user && !hasAnyAdminPermission(user.effective_permissions ?? [])) {
+  // Admit anyone who can reach any admin area — a group manager qualifies via the
+  // scoped bundle in admin_capabilities. Per-page and backend gates scope from here.
+  if (user && !hasAnyAdminPermission(user.admin_capabilities ?? [])) {
     return {
       user,
       authTypeMetadata,

--- a/web/src/lib/permissions.test.ts
+++ b/web/src/lib/permissions.test.ts
@@ -67,7 +67,7 @@ describe("hasAnyAdminPermission", () => {
   });
 
   it("returns false when the user only holds non-admin permissions", () => {
-    // BASIC_ACCESS is not gating any admin route — it should not unlock admin.
+    // BASIC_ACCESS gates no admin route, so it must not unlock admin.
     expect(hasAnyAdminPermission([Permission.BASIC_ACCESS])).toBe(false);
   });
 
@@ -86,9 +86,8 @@ describe("hasAnyAdminPermission", () => {
 
 describe("getFirstPermittedAdminRoute", () => {
   it("returns the first sidebar-labelled route for a full admin", () => {
-    // FULL_ADMIN_PANEL_ACCESS unlocks every route — we expect the very first
-    // entry in ADMIN_ROUTES declaration order that has a non-empty
-    // sidebarLabel. Today that is LLM_MODELS.
+    // FULL_ADMIN_PANEL_ACCESS unlocks every route, so the first ADMIN_ROUTES
+    // entry (declaration order) with a non-empty sidebarLabel wins — today LLM_MODELS.
     expect(
       getFirstPermittedAdminRoute([Permission.FULL_ADMIN_PANEL_ACCESS])
     ).toBe(ADMIN_ROUTES.LLM_MODELS.path);

--- a/web/src/lib/permissions/resource-actions.ts
+++ b/web/src/lib/permissions/resource-actions.ts
@@ -1,0 +1,62 @@
+// Per-resource action vocabularies, hand-written to match the keys the server stamps
+// on each resource's `permissions` map. A backend coverage test guards that the server
+// never stamps a key absent here, so this stays in sync without a codegen pipeline.
+
+// `A` is the resource's own action union, which `can()` infers back out of `permissions`
+// at the call site to reject another resource's action.
+export interface WithPermissions<
+  A extends AnyResourceAction = AnyResourceAction,
+> {
+  permissions?: Partial<Record<A, boolean>>;
+}
+
+// One entry per projection in the backend's permission_projection.py. The key names the
+// resource, not the DTO carrying it: CCPair covers both the list row and the detail DTO,
+// and Action covers OpenAPI + MCP tools — each group shares a single backend projection.
+export const RESOURCE_ACTIONS = {
+  CCPair: ["edit", "delete", "publish"],
+  Agent: [
+    "edit",
+    "share",
+    "view_stats",
+    "delete",
+    "publish",
+    "feature",
+    "list",
+    "reorder",
+  ],
+  DocumentSet: ["edit", "manage_access", "delete", "publish"],
+  Action: ["edit", "delete", "toggle", "authenticate"],
+  MCPServer: ["edit", "delete", "authenticate", "manage_status"],
+  CustomSkill: ["edit", "manage_access", "delete", "publish"],
+  UserGroup: ["manage", "delete", "edit_permissions", "edit_token_limits"],
+} as const;
+
+export type ResourceName = keyof typeof RESOURCE_ACTIONS;
+export type ResourceAction<R extends ResourceName> =
+  (typeof RESOURCE_ACTIONS)[R][number];
+
+// Union of all actions — makes a typo a compile error, not a silent false.
+export type AnyResourceAction = ResourceAction<ResourceName>;
+
+// Declare a resource's map as `permissions?: PermissionsOf<"CustomSkill">` to tie it to
+// that vocabulary. Partial because a path that doesn't stamp sends `{}`.
+export type PermissionsOf<R extends ResourceName> = Partial<
+  Record<ResourceAction<R>, boolean>
+>;
+
+// Fail-closed: a missing resource or unstamped key reads as false, so a control the
+// server hasn't authorized (or a new action an older client predates) never renders.
+//
+// `A` comes from the resource's map, so another resource's action doesn't type-check.
+// The `never` branch covers what that misses: every key of `Partial<Record<A, boolean>>`
+// is optional, so an index-signature map satisfies it while naming no resource at all.
+export function can<
+  A extends AnyResourceAction,
+  P extends Partial<Record<A, boolean>>,
+>(
+  resource: (WithPermissions<A> & { permissions?: P }) | null | undefined,
+  action: string extends keyof P ? never : A
+): boolean {
+  return resource?.permissions?.[action] ?? false;
+}

--- a/web/src/lib/tools/interfaces.ts
+++ b/web/src/lib/tools/interfaces.ts
@@ -1,5 +1,6 @@
 import type React from "react";
 import type { IconProps } from "@opal/types";
+import type { PermissionsOf } from "@/lib/permissions/resource-actions";
 
 // Generic action status for UI components
 export enum ActionStatus {
@@ -39,6 +40,8 @@ export interface MCPServer {
   status: MCPServerStatus;
   last_refreshed_at?: string;
   tool_count: number;
+  // Server-stamped affordance map; fail-closed (absent = denied).
+  permissions?: PermissionsOf<"MCPServer">;
 }
 
 export interface MCPServersResponse {
@@ -65,6 +68,7 @@ export interface MCPTool {
   icon?: React.FunctionComponent<IconProps>;
   isAvailable: boolean;
   isEnabled: boolean;
+  permissions?: PermissionsOf<"Action">;
 }
 
 export interface MethodSpec {
@@ -112,6 +116,9 @@ export interface ToolSnapshot {
   chat_selectable: boolean;
   agent_creation_selectable: boolean;
   default_enabled: boolean;
+
+  // Server-stamped affordance map; fail-closed (absent = denied).
+  permissions?: PermissionsOf<"Action">;
 }
 
 export enum MCPAuthenticationType {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -2,6 +2,7 @@ import { Agent } from "@/lib/agents/types";
 import { Credential } from "./connectors/credentials";
 import { Connector } from "./connectors/connectors";
 import { ConnectorCredentialPairStatus } from "@/app/admin/connector/[ccPairId]/types";
+import type { PermissionsOf } from "@/lib/permissions/resource-actions";
 
 export interface UserSpecificAgentPreference {
   disabled_tool_ids?: number[];
@@ -78,6 +79,7 @@ export enum Permission {
   MANAGE_ACTIONS = "manage:actions",
   READ_QUERY_HISTORY = "read:query_history",
   MANAGE_USER_GROUPS = "manage:user_groups",
+  MANAGE_SKILLS = "manage:skills",
   CREATE_USER_API_KEYS = "create:user_api_keys",
   MANAGE_SERVICE_ACCOUNT_API_KEYS = "manage:service_account_api_keys",
   MANAGE_BOTS = "manage:bots",
@@ -130,6 +132,11 @@ export interface User {
   personalization?: UserPersonalization;
   effective_permissions?: string[];
   is_admin?: boolean;
+  // True if the user manages any group (drives manager nav visibility).
+  is_group_manager?: boolean;
+  // effective tokens plus the scoped manager bundle; source for coarse admin-reach
+  // checks (nav, page access). Server-computed so the client never re-derives policy.
+  admin_capabilities?: string[];
 }
 
 export interface TenantInfo {
@@ -298,6 +305,8 @@ export interface ConnectorIndexingStatusLite {
   last_status: ValidStatuses | null;
   last_success: string | null;
   is_editable: boolean;
+  // per-action affordance map for the requesting user (mirrors the write-side gate)
+  permissions: PermissionsOf<"CCPair">;
   docs_indexed: number;
   in_repeated_error_state: boolean;
   latest_index_attempt_docs_indexed: number | null;
@@ -444,6 +453,8 @@ export interface DocumentSetSummary {
   is_public: boolean;
   users: string[];
   groups: number[];
+  // per-action affordance map for the requesting user (mirrors the write-side gate)
+  permissions: PermissionsOf<"DocumentSet">;
   federated_connector_summaries: FederatedConnectorSummary[];
 }
 
@@ -532,6 +543,8 @@ export interface UserGroup {
   id: number;
   name: string;
   users: User[];
+  // ids of members who manage this group (drives the Make/Revoke Manager toggle)
+  manager_ids: string[];
   curator_ids: string[];
   cc_pairs: CCPairDescriptor<any, any>[];
   document_sets: DocumentSetSummary[];
@@ -539,6 +552,8 @@ export interface UserGroup {
   is_up_to_date: boolean;
   is_up_for_deletion: boolean;
   is_default: boolean;
+  // Server-stamped affordance map; fail-closed (absent = denied).
+  permissions?: PermissionsOf<"UserGroup">;
 }
 
 export enum ValidSources {

--- a/web/src/providers/UserProvider.tsx
+++ b/web/src/providers/UserProvider.tsx
@@ -34,6 +34,11 @@ interface UserContextType {
   isAdmin: boolean;
   hasAdminAccess: boolean;
   permissions: string[];
+  // Coarse admin-reach set: effective tokens plus the scoped manager bundle. Feeds
+  // nav/page gates so a group manager is included; org-wide checks still use isAdmin.
+  adminCapabilities: string[];
+  // True only while /api/me is in flight. `user === null` won't do: it also means signed out.
+  isUserLoading: boolean;
   refreshUser: () => Promise<void>;
   isCloudSuperuser: boolean;
   authTypeMetadata: AuthTypeMetadata;
@@ -65,7 +70,12 @@ interface UserContextType {
 const UserContext = createContext<UserContextType | undefined>(undefined);
 
 export function UserProvider({ children }: { children: React.ReactNode }) {
-  const { user: fetchedUser, mutateUser } = useCurrentUser();
+  const { user: fetchedUser, mutateUser, userError } = useCurrentUser();
+  // undefined = in flight. An error counts as resolved, so a failed load fails closed.
+  const isUserLoading = fetchedUser === undefined && userError === undefined;
+  // Permissions read the fetch result, not `upToDateUser`: that copy lands one render late,
+  // so a page gate could see empty permissions after `isUserLoading` went false and redirect.
+  const authUser = fetchedUser ?? null;
   const { authTypeMetadata, isLoading: authTypeMetadataLoading } =
     useAuthTypeMetadata();
   const updatedSettings = useContext(SettingsContext);
@@ -566,13 +576,15 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
         updateUserVoiceSettings,
         toggleAgentPinnedStatus,
         isAdmin: (
-          upToDateUser?.effective_permissions ?? EMPTY_PERMISSIONS
+          authUser?.effective_permissions ?? EMPTY_PERMISSIONS
         ).includes(Permission.FULL_ADMIN_PANEL_ACCESS),
         hasAdminAccess: hasAnyAdminPermission(
-          upToDateUser?.effective_permissions ?? EMPTY_PERMISSIONS
+          authUser?.admin_capabilities ?? EMPTY_PERMISSIONS
         ),
-        permissions: upToDateUser?.effective_permissions ?? EMPTY_PERMISSIONS,
-        isCloudSuperuser: upToDateUser?.is_cloud_superuser ?? false,
+        permissions: authUser?.effective_permissions ?? EMPTY_PERMISSIONS,
+        adminCapabilities: authUser?.admin_capabilities ?? EMPTY_PERMISSIONS,
+        isUserLoading,
+        isCloudSuperuser: authUser?.is_cloud_superuser ?? false,
       }}
     >
       {children}

--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -92,6 +92,7 @@ import { Permission, ValidSources } from "@/lib/types";
 import { useVectorDbEnabled } from "@/providers/SettingsProvider";
 import { useUser } from "@/providers/UserProvider";
 import { hasPermission } from "@/lib/permissions";
+import { can } from "@/lib/permissions/resource-actions";
 import { useTierAtLeast } from "@/hooks/useTierAtLeast";
 import { Tier } from "@/interfaces/settings";
 
@@ -488,11 +489,14 @@ export default function AgentEditorPage({
   const { refresh: refreshAgents } = useAgents();
   const shareAgentModal = useCreateModal();
   const deleteAgentModal = useCreateModal();
-  const { isAdmin, permissions } = useUser();
-  const canUpdateFeaturedStatus = hasPermission(
-    permissions,
-    Permission.MANAGE_AGENTS
-  );
+  const { permissions } = useUser();
+  // Prefer the server's per-agent answer; a new agent has none yet, so fall back to the
+  // global token — which is exactly what the projection stamps for `feature`.
+  const canShare = !existingAgent || can(existingAgent, "share");
+  const canDelete = can(existingAgent, "delete");
+  const canUpdateFeaturedStatus = existingAgent
+    ? can(existingAgent, "feature")
+    : hasPermission(permissions, Permission.MANAGE_AGENTS);
   const vectorDbEnabled = useVectorDbEnabled();
   const businessTier = useTierAtLeast(Tier.BUSINESS);
 
@@ -1529,19 +1533,23 @@ export default function AgentEditorPage({
                           <GeneralLayouts.Section>
                             <Card border="solid" rounding="lg">
                               <GeneralLayouts.Section>
-                                <InputHorizontal
-                                  title="Share This Agent"
-                                  description="with other users, groups, or everyone in your organization."
-                                  center
-                                >
-                                  <Button
-                                    prominence="secondary"
-                                    icon={isShared ? SvgUsers : SvgLock}
-                                    onClick={() => shareAgentModal.toggle(true)}
+                                {canShare && (
+                                  <InputHorizontal
+                                    title="Share This Agent"
+                                    description="with other users, groups, or everyone in your organization."
+                                    center
                                   >
-                                    Share
-                                  </Button>
-                                </InputHorizontal>
+                                    <Button
+                                      prominence="secondary"
+                                      icon={isShared ? SvgUsers : SvgLock}
+                                      onClick={() =>
+                                        shareAgentModal.toggle(true)
+                                      }
+                                    >
+                                      Share
+                                    </Button>
+                                  </InputHorizontal>
+                                )}
                                 {canUpdateFeaturedStatus && (
                                   <>
                                     <InputHorizontal
@@ -1626,7 +1634,7 @@ export default function AgentEditorPage({
                         </SimpleCollapsible.Content>
                       </SimpleCollapsible>
 
-                      {existingAgent && (
+                      {existingAgent && canDelete && (
                         <>
                           <Divider
                             paddingParallel="fit"

--- a/web/src/refresh-pages/UserSkillsPage.tsx
+++ b/web/src/refresh-pages/UserSkillsPage.tsx
@@ -10,6 +10,8 @@ import TextSeparator from "@/refresh-components/TextSeparator";
 import useOnMount from "@/hooks/useOnMount";
 import useUserSkills from "@/hooks/useUserSkills";
 import { useUser } from "@/providers/UserProvider";
+import { useCapabilities } from "@/hooks/useCapabilities";
+import { Permission } from "@/lib/types";
 import SkillCard, {
   type CustomSkillCardItem,
   type SkillCardItem,
@@ -29,7 +31,9 @@ import { toast } from "@/hooks/useToast";
 
 export default function UserSkillsPage() {
   const { data, error, isLoading, refresh } = useUserSkills();
-  const { user, isAdmin } = useUser();
+  const { user } = useUser();
+  // Gate on admin_capabilities/MANAGE_SKILLS so scoped skill managers reach the manage entry, not just admins.
+  const canManageSkills = useCapabilities(Permission.MANAGE_SKILLS);
   const [searchQuery, setSearchQuery] = useState("");
   const [createOpen, setCreateOpen] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<CustomSkillCardItem | null>(
@@ -165,7 +169,7 @@ export default function UserSkillsPage() {
         description="Capability bundles your Craft agent can reach for. This page shows what's currently available to you — skills granted by admins plus your own personal skills."
         rightChildren={
           <div className="flex items-center gap-2">
-            {isAdmin && (
+            {canManageSkills && (
               <Button
                 href="/craft/v1/skills/manage"
                 prominence="secondary"

--- a/web/src/refresh-pages/admin/AgentsPage/AgentRowActions.tsx
+++ b/web/src/refresh-pages/admin/AgentsPage/AgentRowActions.tsx
@@ -37,9 +37,7 @@ import {
 } from "@/lib/agents/svc";
 import { useTierAtLeast } from "@/hooks/useTierAtLeast";
 import { Tier } from "@/interfaces/settings";
-import { useUser } from "@/providers/UserProvider";
-import { hasPermission } from "@/lib/permissions";
-import { Permission } from "@/lib/types";
+import { can } from "@/lib/permissions/resource-actions";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -59,14 +57,20 @@ export default function AgentRowActions({
   onMutate,
 }: AgentRowActionsProps) {
   const router = useRouter();
-  const { isAdmin, permissions } = useUser();
- const businessTier = useTierAtLeast(Tier.BUSINESS);
-  const canUpdateFeaturedStatus = hasPermission(
-    permissions,
-    Permission.MANAGE_AGENTS
-  );
+  const businessTier = useTierAtLeast(Tier.BUSINESS);
   const { agent: fullAgent, refresh: refreshAgent } = useAgent(agent.id);
   const shareModal = useCreateModal();
+
+  // Gate on the list row's stamped permissions so controls render immediately, not after the
+  // per-row fetch; fullAgent is only for the share modal's details below.
+  const canEdit = can(agent, "edit");
+  const canList = can(agent, "list");
+  const canUpdateFeaturedStatus = can(agent, "feature");
+  const canShare = can(agent, "share");
+  const canViewStats = can(agent, "view_stats");
+  const canDeleteRow = !agent.builtin_persona && can(agent, "delete");
+  const hasOverflowItems =
+    canList || canShare || (businessTier && canViewStats) || canDeleteRow;
 
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -148,7 +152,7 @@ export default function AgentRowActions({
             appear-on-hover animation. Making Hoverable more extensible
             (e.g. supporting table row groups) would let us use it here
             instead of raw Tailwind group-hover. */}
-        {!agent.builtin_persona && (
+        {!agent.builtin_persona && canEdit && (
           <div className="opacity-0 group-hover/row:opacity-100 transition-opacity">
             <Button
               prominence="tertiary"
@@ -164,112 +168,119 @@ export default function AgentRowActions({
             />
           </div>
         )}
-        {!agent.is_listed ? (
-          <Button
-            prominence="tertiary"
-            icon={SvgEyeOff}
-            tooltip="Re-list Agent"
-            onClick={() =>
-              handleAction(
-                () => toggleAgentListed(agent.id, agent.is_listed),
-                () => {}
-              )
-            }
-          />
-        ) : (
-          <div
-            className={cn(
-              !agent.is_featured &&
-                "opacity-0 group-hover/row:opacity-100 transition-opacity"
+        {!agent.is_listed
+          ? canList && (
+              <Button
+                prominence="tertiary"
+                icon={SvgEyeOff}
+                tooltip="Re-list Agent"
+                onClick={() =>
+                  handleAction(
+                    () => toggleAgentListed(agent.id, agent.is_listed),
+                    () => {}
+                  )
+                }
+              />
+            )
+          : canUpdateFeaturedStatus && (
+              <div
+                className={cn(
+                  !agent.is_featured &&
+                    "opacity-0 group-hover/row:opacity-100 transition-opacity"
+                )}
+              >
+                <Button
+                  prominence="tertiary"
+                  icon={SvgStar}
+                  interaction={featuredOpen ? "hover" : "rest"}
+                  tooltip={
+                    agent.is_featured ? "Remove Featured" : "Set as Featured"
+                  }
+                  onClick={() => {
+                    setPopoverOpen(false);
+                    setFeaturedOpen(true);
+                  }}
+                />
+              </div>
             )}
-          >
-            <Button
-              prominence="tertiary"
-              icon={SvgStar}
-              interaction={featuredOpen ? "hover" : "rest"}
-              tooltip={
-                agent.is_featured ? "Remove Featured" : "Set as Featured"
-              }
-              onClick={() => {
-                setPopoverOpen(false);
-                setFeaturedOpen(true);
-              }}
-            />
-          </div>
-        )}
 
         {/* Overflow menu */}
-        <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
-          <div
-            className={cn(
-              !popoverOpen &&
-                "opacity-0 group-hover/row:opacity-100 transition-opacity"
-            )}
-          >
-            <Popover.Trigger asChild>
-              <Button prominence="tertiary" icon={SvgMoreHorizontal} />
-            </Popover.Trigger>
-          </div>
-          <Popover.Content align="end" width="sm">
-            <PopoverMenu>
-              {[
-                <LineItem
-                  key="visibility"
-                  icon={agent.is_listed ? SvgEyeOff : SvgEye}
-                  onClick={() => {
-                    setPopoverOpen(false);
-                    if (agent.is_listed) {
-                      setUnlistOpen(true);
-                    } else {
-                      handleAction(
-                        () => toggleAgentListed(agent.id, agent.is_listed),
-                        () => {}
-                      );
-                    }
-                  }}
-                >
-                  {agent.is_listed ? "Unlist Agent" : "List Agent"}
-                </LineItem>,
-                <LineItem
-                  key="share"
-                  icon={SvgShare}
-                  onClick={() => {
-                    setPopoverOpen(false);
-                    shareModal.toggle(true);
-                  }}
-                >
-                  Share
-                </LineItem>,
-                businessTier ? (
-                  <LineItem
-                    key="stats"
-                    icon={SvgBarChart}
-                    onClick={() => {
-                      setPopoverOpen(false);
-                      router.push(`/ee/agents/stats/${agent.id}` as Route);
-                    }}
-                  >
-                    Stats
-                  </LineItem>
-                ) : undefined,
-                !agent.builtin_persona ? null : undefined,
-                !agent.builtin_persona ? (
-                  <LineItem
-                    key="delete"
-                    icon={SvgTrash}
-                    danger
-                    onClick={() => {
-                      setPopoverOpen(false);
-                      setDeleteOpen(true);
-                    }}
-                  >
-                    Delete
-                  </LineItem>
-                ) : undefined,
-              ]}
-            </PopoverMenu>
-          </Popover.Content>
-        </Popover>
+        {hasOverflowItems && (
+          <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
+            <div
+              className={cn(
+                !popoverOpen &&
+                  "opacity-0 group-hover/row:opacity-100 transition-opacity"
+              )}
+            >
+              <Popover.Trigger asChild>
+                <Button prominence="tertiary" icon={SvgMoreHorizontal} />
+              </Popover.Trigger>
+            </div>
+            <Popover.Content align="end" width="sm">
+              <PopoverMenu>
+                {[
+                  canList ? (
+                    <LineItem
+                      key="visibility"
+                      icon={agent.is_listed ? SvgEyeOff : SvgEye}
+                      onClick={() => {
+                        setPopoverOpen(false);
+                        if (agent.is_listed) {
+                          setUnlistOpen(true);
+                        } else {
+                          handleAction(
+                            () => toggleAgentListed(agent.id, agent.is_listed),
+                            () => {}
+                          );
+                        }
+                      }}
+                    >
+                      {agent.is_listed ? "Unlist Agent" : "List Agent"}
+                    </LineItem>
+                  ) : undefined,
+                  canShare ? (
+                    <LineItem
+                      key="share"
+                      icon={SvgShare}
+                      onClick={() => {
+                        setPopoverOpen(false);
+                        shareModal.toggle(true);
+                      }}
+                    >
+                      Share
+                    </LineItem>
+                  ) : undefined,
+                  businessTier && canViewStats ? (
+                    <LineItem
+                      key="stats"
+                      icon={SvgBarChart}
+                      onClick={() => {
+                        setPopoverOpen(false);
+                        router.push(`/ee/agents/stats/${agent.id}` as Route);
+                      }}
+                    >
+                      Stats
+                    </LineItem>
+                  ) : undefined,
+                  canDeleteRow ? (
+                    <LineItem
+                      key="delete"
+                      icon={SvgTrash}
+                      danger
+                      onClick={() => {
+                        setPopoverOpen(false);
+                        setDeleteOpen(true);
+                      }}
+                    >
+                      Delete
+                    </LineItem>
+                  ) : undefined,
+                ]}
+              </PopoverMenu>
+            </Popover.Content>
+          </Popover>
+        )}
       </div>
 
       {deleteOpen && (

--- a/web/src/refresh-pages/admin/AgentsPage/AgentsTable.tsx
+++ b/web/src/refresh-pages/admin/AgentsPage/AgentsTable.tsx
@@ -17,6 +17,7 @@ import { SvgUser, SvgSimpleLoader } from "@opal/icons";
 import { DEFAULT_PAGE_SIZE } from "@/lib/constants";
 import { Section } from "@/layouts/general-layouts";
 import { useAgentsFilters } from "@/sections/agents/AgentsFilters";
+import { can } from "@/lib/permissions/resource-actions";
 
 // ---------------------------------------------------------------------------
 // Column renderers
@@ -120,6 +121,8 @@ export default function AgentsTable() {
   const { filtered: filteredAgents, filterBar } =
     useAgentsFilters(nonBuiltinAgents);
 
+  const canReorder = nonBuiltinAgents.some((agent) => can(agent, "reorder"));
+
   async function handleReorder(
     _orderedIds: string[],
     changedOrders: Record<string, number>
@@ -162,9 +165,7 @@ export default function AgentsTable() {
         getRowId={(row) => String(row.id)}
         pageSize={DEFAULT_PAGE_SIZE}
         searchTerm={searchTerm}
-        draggable={{
-          onReorder: handleReorder,
-        }}
+        draggable={canReorder ? { onReorder: handleReorder } : undefined}
         emptyState={
           <IllustrationContent
             illustration={SvgNoResult}

--- a/web/src/refresh-pages/admin/GroupsPage/EditGroupPage.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/EditGroupPage.tsx
@@ -12,6 +12,7 @@ import {
   SvgMinusCircle,
   SvgPlusCircle,
   SvgSimpleLoader,
+  SvgShield,
 } from "@opal/icons";
 import { markdown } from "@opal/utils";
 import IconButton from "@/refresh-components/buttons/IconButton";
@@ -26,6 +27,7 @@ import { toast } from "@/hooks/useToast";
 import { errorHandlingFetcher, skipRetryOnAuthError } from "@/lib/fetcher";
 import type { UserGroup } from "@/lib/types";
 import { useSettingsContext } from "@/providers/SettingsProvider";
+import { useUser } from "@/providers/UserProvider";
 import { Tier } from "@/interfaces/settings";
 import { tierAtLeast } from "@/lib/tiers";
 import type { MemberRow, TokenRateLimitDisplay } from "./interfaces";
@@ -38,13 +40,14 @@ import {
   updateDocSetGroupSharing,
   saveTokenLimits,
   saveGroupPermissions,
+  setGroupManager,
 } from "./svc";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import SharedGroupResources from "@/refresh-pages/admin/GroupsPage/SharedGroupResources";
 import GroupPermissionsSection from "./GroupPermissionsSection";
 import TokenLimitSection from "./TokenLimitSection";
 import type { TokenLimit } from "./TokenLimitSection";
-import { useUser } from "@/providers/UserProvider";
+import { can } from "@/lib/permissions/resource-actions";
 
 const addModeColumns = memberTableColumns;
 
@@ -60,6 +63,8 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
   const router = useRouter();
   const { mutate } = useSWRConfig();
   const settings = useSettingsContext();
+  const { user } = useUser();
+  const currentUserId = user?.id;
   const isEnterpriseTier = tierAtLeast(
     settings?.settings.tier,
     Tier.ENTERPRISE
@@ -67,7 +72,6 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
   const tokenLimitsDisabledTooltip = markdown(
     "Token rate limits are available on the [Enterprise version of Onyx](/admin/billing) only."
   );
-  const { isAdmin } = useUser();
 
   // Fetch the group data — poll every 5s while syncing so the UI updates
   // automatically when the backend finishes processing the previous edit.
@@ -87,22 +91,28 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
     [groups, groupId]
   );
 
+  const canManage = can(group, "manage");
+  const canDelete = can(group, "delete");
+  const canEditPermissions = can(group, "edit_permissions");
+  const canEditTokenLimits = can(group, "edit_token_limits");
+
   const isSyncing = group != null && !group.is_up_to_date;
 
-  // Fetch token rate limits for this group. Skip retry on tier-gated 402
-  // (BUSINESS-tier tenants don't have access) so SWR doesn't churn the form
-  // by repeatedly flipping its isLoading state.
+  // Gate on edit_token_limits so a non-manager (who'd 403 on the read) skips the fetch.
+  // Skip retry on tier-gated 402 so SWR doesn't churn isLoading.
   const { data: tokenRateLimits, isLoading: tokenLimitsLoading } = useSWR<
     TokenRateLimitDisplay[]
-  >(SWR_KEYS.userGroupTokenRateLimit(groupId), errorHandlingFetcher, {
-    onErrorRetry: skipRetryOnAuthError,
-  });
+  >(
+    canEditTokenLimits ? SWR_KEYS.userGroupTokenRateLimit(groupId) : null,
+    errorHandlingFetcher,
+    { onErrorRetry: skipRetryOnAuthError }
+  );
 
   // Fetch permissions for this group (admin only)
   const { data: groupPermissions, isLoading: permissionsLoading } = useSWR<
     string[]
   >(
-    isAdmin ? SWR_KEYS.userGroupPermissions(groupId) : null,
+    canEditPermissions ? SWR_KEYS.userGroupPermissions(groupId) : null,
     errorHandlingFetcher
   );
 
@@ -192,25 +202,112 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
     setSelectedUserIds((prev) => prev.filter((id) => id !== userId));
   }, []);
 
+  const managerIds = useMemo(() => new Set(group?.manager_ids ?? []), [group]);
+  // Manager must be a saved member (can't assign one that isn't persisted yet).
+  const persistedMemberIds = useMemo(
+    () => new Set(group?.users.map((u) => u.id) ?? []),
+    [group]
+  );
+  const [pendingManagerIds, setPendingManagerIds] = useState<Set<string>>(
+    () => new Set()
+  );
+
+  const isOwnManagerRow = useCallback(
+    (userId: string) =>
+      currentUserId != null &&
+      userId === currentUserId &&
+      (managerIds.has(userId) || pendingManagerIds.has(userId)),
+    [currentUserId, managerIds, pendingManagerIds]
+  );
+
+  // Hits its endpoint immediately (member add/remove defers to Save), then revalidates.
+  const handleToggleManager = useCallback(
+    async (userId: string, makeManager: boolean) => {
+      setPendingManagerIds((prev) => new Set(prev).add(userId));
+      try {
+        await setGroupManager(groupId, userId, makeManager);
+        await mutate(SWR_KEYS.adminUserGroups);
+        toast.success(makeManager ? "Manager assigned" : "Manager revoked");
+      } catch (err) {
+        console.error("Failed to update manager:", err);
+        toast.error(
+          err instanceof Error ? err.message : "Failed to update manager"
+        );
+      } finally {
+        setPendingManagerIds((prev) => {
+          const next = new Set(prev);
+          next.delete(userId);
+          return next;
+        });
+      }
+    },
+    [groupId, mutate]
+  );
+
   const memberColumns = useMemo(
     () => [
       ...baseColumns,
       tc.actions({
         showSorting: false,
         showColumnVisibility: false,
-        cell: (row: MemberRow) => (
-          <IconButton
-            icon={SvgMinusCircle}
-            tertiary
-            onClick={(e) => {
-              e.stopPropagation();
-              handleRemoveMember(row.id ?? row.email);
-            }}
-          />
-        ),
+        cell: (row: MemberRow) => {
+          if (!canManage) return null;
+          const userId = row.id ?? row.email;
+          const isManager = managerIds.has(userId);
+          const isPersisted = persistedMemberIds.has(userId);
+          const isPending = pendingManagerIds.has(userId);
+          const isOwnManager = isOwnManagerRow(userId);
+          return (
+            <div className="flex items-center gap-1">
+              <IconButton
+                icon={isPending ? SvgSimpleLoader : SvgShield}
+                tertiary
+                transient={isManager}
+                disabled={!isPersisted || isPending || isOwnManager}
+                aria-label={isManager ? "Revoke manager" : "Make manager"}
+                tooltip={
+                  !isPersisted
+                    ? "Save the group before assigning a manager"
+                    : isOwnManager
+                      ? "You can't revoke your own manager access"
+                      : isManager
+                        ? "Revoke manager"
+                        : "Make manager"
+                }
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleToggleManager(userId, !isManager);
+                }}
+              />
+              <IconButton
+                icon={SvgMinusCircle}
+                tertiary
+                disabled={isOwnManager}
+                aria-label="Remove member"
+                tooltip={
+                  isOwnManager
+                    ? "You can't remove yourself while managing this group"
+                    : undefined
+                }
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleRemoveMember(userId);
+                }}
+              />
+            </div>
+          );
+        },
       }),
     ],
-    [handleRemoveMember]
+    [
+      handleRemoveMember,
+      handleToggleManager,
+      isOwnManagerRow,
+      managerIds,
+      persistedMemberIds,
+      pendingManagerIds,
+      canManage,
+    ]
   );
 
   // IDs of members not visible in the add-mode table (e.g. inactive users).
@@ -278,13 +375,14 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
         selectedDocSetIds
       );
 
-      // Save token rate limits (create/update/delete) — Enterprise-only
-      if (isEnterpriseTier) {
+      // Group-scoped create/update/delete routes admit a group admin, so their full save
+      // (including PUT/DELETE of existing limits) is authorized.
+      if (isEnterpriseTier && canEditTokenLimits) {
         await saveTokenLimits(groupId, tokenLimits, tokenRateLimits ?? []);
       }
 
-      // Save permissions (bulk desired-state, admin only)
-      if (isAdmin) {
+      // Bulk desired-state replace; FULL_ADMIN only.
+      if (canEditPermissions) {
         await saveGroupPermissions(groupId, enabledPermissions);
       }
 
@@ -294,7 +392,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
 
       mutate(SWR_KEYS.adminUserGroups);
       mutate(SWR_KEYS.userGroupTokenRateLimit(groupId));
-      if (isAdmin) {
+      if (canEditPermissions) {
         mutate(SWR_KEYS.userGroupPermissions(groupId));
       }
       toast.success(`Group "${trimmed}" updated`);
@@ -352,7 +450,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
       </Button>
       <Button
         onClick={handleSave}
-        disabled={!groupName.trim() || isSubmitting || isSyncing}
+        disabled={!groupName.trim() || isSubmitting || isSyncing || !canManage}
         tooltip={
           isSyncing
             ? "Document embeddings are being updated due to recent changes to this group."
@@ -436,13 +534,15 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
                       Done
                     </Button>
                   ) : (
-                    <Button
-                      prominence="tertiary"
-                      icon={SvgPlusCircle}
-                      onClick={() => setIsAddingMembers(true)}
-                    >
-                      Add
-                    </Button>
+                    canManage && (
+                      <Button
+                        prominence="tertiary"
+                        icon={SvgPlusCircle}
+                        onClick={() => setIsAddingMembers(true)}
+                      >
+                        Add
+                      </Button>
+                    )
                   )}
                 </Section>
 
@@ -485,7 +585,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
                 )}
               </Section>
 
-              {isAdmin && (
+              {canEditPermissions && (
                 <GroupPermissionsSection
                   enabledPermissions={enabledPermissions}
                   onPermissionsChange={setEnabledPermissions}
@@ -504,27 +604,28 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
               <TokenLimitSection
                 limits={tokenLimits}
                 onLimitsChange={setTokenLimits}
-                disabled={!isEnterpriseTier}
+                disabled={!isEnterpriseTier || !canEditTokenLimits}
                 disabledTooltip={tokenLimitsDisabledTooltip}
               />
 
-              {/* Delete This Group */}
-              <Card>
-                <InputHorizontal
-                  title="Delete This Group"
-                  description="Members will lose access to any resources shared with this group."
-                  center
-                >
-                  <Button
-                    variant="danger"
-                    prominence="secondary"
-                    icon={SvgTrash}
-                    onClick={() => setShowDeleteModal(true)}
+              {canDelete && (
+                <Card>
+                  <InputHorizontal
+                    title="Delete This Group"
+                    description="Members will lose access to any resources shared with this group."
+                    center
                   >
-                    Delete Group
-                  </Button>
-                </InputHorizontal>
-              </Card>
+                    <Button
+                      variant="danger"
+                      prominence="secondary"
+                      icon={SvgTrash}
+                      onClick={() => setShowDeleteModal(true)}
+                    >
+                      Delete Group
+                    </Button>
+                  </InputHorizontal>
+                </Card>
+              )}
             </>
           )}
         </SettingsLayouts.Body>

--- a/web/src/refresh-pages/admin/GroupsPage/GroupCard.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/GroupCard.tsx
@@ -18,6 +18,7 @@ import { renameGroup } from "./svc";
 import { toast } from "@/hooks/useToast";
 import { useSWRConfig } from "swr";
 import { SWR_KEYS } from "@/lib/swr-keys";
+import { can } from "@/lib/permissions/resource-actions";
 
 interface GroupCardProps {
   group: UserGroup;
@@ -30,6 +31,7 @@ function GroupCard({ group }: GroupCardProps) {
   const isAdmin = group.name === "Admin";
   const isBasic = group.name === "Basic";
   const isSyncing = !group.is_up_to_date;
+  const canManage = can(group, "manage");
 
   async function handleRename(newName: string) {
     try {
@@ -51,8 +53,10 @@ function GroupCard({ group }: GroupCardProps) {
         sizePreset="main-content"
         variant="section"
         tag={isBasic ? { title: "Default" } : undefined}
-        editable={!builtIn && !isSyncing}
-        onTitleChange={!builtIn && !isSyncing ? handleRename : undefined}
+        editable={!builtIn && !isSyncing && canManage}
+        onTitleChange={
+          !builtIn && !isSyncing && canManage ? handleRename : undefined
+        }
         rightChildren={
           <Section flexDirection="row" alignItems="start" gap={0}>
             <div className="py-1">
@@ -62,13 +66,17 @@ function GroupCard({ group }: GroupCardProps) {
                 )}
               </Text>
             </div>
-            <Button
-              icon={SvgChevronRight}
-              prominence="tertiary"
-              tooltip="View group"
-              aria-label="View group"
-              onClick={() => router.push(`/admin/groups/${group.id}` as Route)}
-            />
+            {canManage && (
+              <Button
+                icon={SvgChevronRight}
+                prominence="tertiary"
+                tooltip="View group"
+                aria-label="View group"
+                onClick={() =>
+                  router.push(`/admin/groups/${group.id}` as Route)
+                }
+              />
+            )}
           </Section>
         }
       />

--- a/web/src/refresh-pages/admin/GroupsPage/GroupPermissionsSection.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/GroupPermissionsSection.tsx
@@ -30,11 +30,8 @@ import { errorHandlingFetcher } from "@/lib/fetcher";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import type { PermissionRegistryEntry } from "@/refresh-pages/admin/GroupsPage/interfaces";
 
-// ---------------------------------------------------------------------------
-// Icon mapping — the only permission metadata maintained in the frontend.
-// The `id` keys must match the backend PERMISSION_REGISTRY entries.
-// ---------------------------------------------------------------------------
-
+// Icon mapping — the only permission metadata kept in the frontend.
+// `id` keys must match the backend PERMISSION_REGISTRY entries.
 const ICON_MAP: Record<string, IconFunctionComponent> = {
   manage_llms: SvgCpu,
   manage_connectors_and_document_sets: SvgFiles,
@@ -48,10 +45,6 @@ const ICON_MAP: Record<string, IconFunctionComponent> = {
   view_query_history: SvgHistory,
   create_user_access_token: SvgKey,
 };
-
-// ---------------------------------------------------------------------------
-// Component
-// ---------------------------------------------------------------------------
 
 interface GroupPermissionsSectionProps {
   enabledPermissions: Set<string>;

--- a/web/src/refresh-pages/admin/GroupsPage/index.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { Route } from "next";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import useSWR from "swr";
 import { SvgExternalLink, SvgUsers, SvgSimpleLoader } from "@opal/icons";
@@ -9,7 +9,11 @@ import { Button, MessageCard } from "@opal/components";
 import { SettingsLayouts } from "@opal/layouts";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import type { UserGroup } from "@/lib/types";
+import { Permission } from "@/lib/types";
 import { SWR_KEYS } from "@/lib/swr-keys";
+import { useUser } from "@/providers/UserProvider";
+import { hasPermission } from "@/lib/permissions";
+import { can } from "@/lib/permissions/resource-actions";
 import GroupsList from "./GroupsList";
 import AdminListHeader from "@/sections/admin/AdminListHeader";
 import { IllustrationContent } from "@opal/layouts";
@@ -18,12 +22,27 @@ import SvgNoResult from "@opal/illustrations/no-result";
 function GroupsPage() {
   const router = useRouter();
   const [searchQuery, setSearchQuery] = useState("");
+  const { user } = useUser();
+
+  // Create is global-only (route has no allow_scope); gate on the global token, not
+  // admin_capabilities, which would show it to scoped managers who'd then 403.
+  const canCreateGroup = hasPermission(
+    user?.effective_permissions ?? [],
+    Permission.MANAGE_USER_GROUPS
+  );
 
   const {
     data: groups,
     error,
     isLoading,
   } = useSWR<UserGroup[]>(SWR_KEYS.adminUserGroups, errorHandlingFetcher);
+
+  // The list is READ_USER_GROUPS-scoped (implied by MANAGE_LLMS etc.), so filter to
+  // manageable groups — else a read-only holder sees groups with no open action.
+  const manageableGroups = useMemo(
+    () => (groups ?? []).filter((group) => can(group, "manage")),
+    [groups]
+  );
 
   return (
     <SettingsLayouts.Root>
@@ -53,13 +72,17 @@ function GroupsPage() {
 
       <SettingsLayouts.Body>
         <AdminListHeader
-          hasItems={!isLoading && !error && (groups?.length ?? 0) > 0}
+          hasItems={!isLoading && !error && manageableGroups.length > 0}
           searchQuery={searchQuery}
           onSearchQueryChange={setSearchQuery}
           placeholder="Search groups..."
           emptyStateText="Create groups to organize users and manage access."
-          onAction={() => router.push("/admin/groups/create" as Route)}
-          actionLabel="New Group"
+          onAction={
+            canCreateGroup
+              ? () => router.push("/admin/groups/create" as Route)
+              : undefined
+          }
+          actionLabel={canCreateGroup ? "New Group" : undefined}
         />
 
         {isLoading && <SvgSimpleLoader />}
@@ -73,7 +96,7 @@ function GroupsPage() {
         )}
 
         {!isLoading && !error && groups && (
-          <GroupsList groups={groups} searchQuery={searchQuery} />
+          <GroupsList groups={manageableGroups} searchQuery={searchQuery} />
         )}
       </SettingsLayouts.Body>
     </SettingsLayouts.Root>

--- a/web/src/refresh-pages/admin/GroupsPage/svc.ts
+++ b/web/src/refresh-pages/admin/GroupsPage/svc.ts
@@ -4,6 +4,18 @@ import { SWR_KEYS } from "@/lib/swr-keys";
 
 const USER_GROUP_URL = SWR_KEYS.adminUserGroups;
 
+// Logs an unparseable body — without it a proxy's HTML 502 is indistinguishable from a
+// clean API error at the call site.
+async function responseError(res: Response, action: string): Promise<Error> {
+  try {
+    const detail = (await res.json())?.detail;
+    if (detail) return new Error(detail);
+  } catch (err) {
+    console.error(`${action}: unparseable error body`, res.status, err);
+  }
+  return new Error(`${action}: ${res.statusText}`);
+}
+
 async function renameGroup(groupId: number, newName: string): Promise<void> {
   const res = await fetch(`${USER_GROUP_URL}/rename`, {
     method: "PATCH",
@@ -11,10 +23,7 @@ async function renameGroup(groupId: number, newName: string): Promise<void> {
     body: JSON.stringify({ id: groupId, name: newName }),
   });
   if (!res.ok) {
-    const detail = await res.json().catch(() => null);
-    throw new Error(
-      detail?.detail ?? `Failed to rename group: ${res.statusText}`
-    );
+    throw await responseError(res, "Failed to rename group");
   }
 }
 
@@ -33,10 +42,7 @@ async function createGroup(
     }),
   });
   if (!res.ok) {
-    const detail = await res.json().catch(() => null);
-    throw new Error(
-      detail?.detail ?? `Failed to create group: ${res.statusText}`
-    );
+    throw await responseError(res, "Failed to create group");
   }
   const group = await res.json();
   return group.id;
@@ -56,10 +62,7 @@ async function updateGroup(
     }),
   });
   if (!res.ok) {
-    const detail = await res.json().catch(() => null);
-    throw new Error(
-      detail?.detail ?? `Failed to update group: ${res.statusText}`
-    );
+    throw await responseError(res, "Failed to update group");
   }
 }
 
@@ -68,10 +71,7 @@ async function deleteGroup(groupId: number): Promise<void> {
     method: "DELETE",
   });
   if (!res.ok) {
-    const detail = await res.json().catch(() => null);
-    throw new Error(
-      detail?.detail ?? `Failed to delete group: ${res.statusText}`
-    );
+    throw await responseError(res, "Failed to delete group");
   }
 }
 
@@ -98,10 +98,7 @@ async function updateAgentGroupSharing(
     body: JSON.stringify({ added_agent_ids, removed_agent_ids }),
   });
   if (!res.ok) {
-    const detail = await res.json().catch(() => null);
-    throw new Error(
-      detail?.detail ?? `Failed to update agent sharing: ${res.statusText}`
-    );
+    throw await responseError(res, "Failed to update agent sharing");
   }
 }
 
@@ -228,7 +225,7 @@ async function saveTokenLimits(
     const limit = validLimits[i]!;
     const existingLimit = existing[i]!;
     const updateRes = await fetch(
-      `/api/admin/token-rate-limits/rate-limit/${existingLimit.token_id}`,
+      `/api/admin/token-rate-limits/user-group/${groupId}/rate-limit/${existingLimit.token_id}`,
       {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
@@ -270,7 +267,7 @@ async function saveTokenLimits(
   for (let i = toUpdate; i < existing.length; i++) {
     const existingLimit = existing[i]!;
     const deleteRes = await fetch(
-      `/api/admin/token-rate-limits/rate-limit/${existingLimit.token_id}`,
+      `/api/admin/token-rate-limits/user-group/${groupId}/rate-limit/${existingLimit.token_id}`,
       { method: "DELETE" }
     );
     if (!deleteRes.ok) {
@@ -295,10 +292,22 @@ async function saveGroupPermissions(
     body: JSON.stringify({ permissions: Array.from(enabledPermissions) }),
   });
   if (!res.ok) {
-    const detail = await res.json().catch(() => null);
-    throw new Error(
-      detail?.detail ?? `Failed to update permissions: ${res.statusText}`
-    );
+    throw await responseError(res, "Failed to update permissions");
+  }
+}
+
+async function setGroupManager(
+  groupId: number,
+  userId: string,
+  isManager: boolean
+): Promise<void> {
+  const res = await fetch(`${USER_GROUP_URL}/${groupId}/manager`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ user_id: userId, is_manager: isManager }),
+  });
+  if (!res.ok) {
+    throw await responseError(res, "Failed to update group manager");
   }
 }
 
@@ -311,4 +320,5 @@ export {
   updateDocSetGroupSharing,
   saveTokenLimits,
   saveGroupPermissions,
+  setGroupManager,
 };

--- a/web/src/refresh-pages/admin/SkillsPage/CustomSkillRowActions.tsx
+++ b/web/src/refresh-pages/admin/SkillsPage/CustomSkillRowActions.tsx
@@ -12,6 +12,7 @@ import {
 } from "@opal/icons";
 import LineItem from "@/refresh-components/buttons/LineItem";
 import type { CustomSkill } from "@/refresh-pages/admin/SkillsPage/interfaces";
+import { can } from "@/lib/permissions/resource-actions";
 import { cn } from "@opal/utils";
 
 // ---------------------------------------------------------------------------
@@ -39,6 +40,13 @@ export default function CustomSkillRowActions({
 }: CustomSkillRowActionsProps) {
   const [popoverOpen, setPopoverOpen] = useState(false);
 
+  const canEdit = can(skill, "edit");
+  const canManageAccess = can(skill, "manage_access");
+  const canDelete = can(skill, "delete");
+  const hasItems = canEdit || canManageAccess || canDelete;
+
+  if (!hasItems) return null;
+
   return (
     <div className="flex items-center gap-0.5">
       <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
@@ -55,47 +63,55 @@ export default function CustomSkillRowActions({
         <Popover.Content align="end" width="sm">
           <PopoverMenu>
             {[
-              <LineItem
-                key="share"
-                icon={SvgShare}
-                onClick={() => {
-                  setPopoverOpen(false);
-                  onShare();
-                }}
-              >
-                Edit visibility
-              </LineItem>,
-              <LineItem
-                key="replace"
-                icon={SvgUploadCloud}
-                onClick={() => {
-                  setPopoverOpen(false);
-                  onReplaceBundle();
-                }}
-              >
-                Replace bundle
-              </LineItem>,
-              <LineItem
-                key="enabled"
-                icon={skill.enabled ? SvgEyeOff : SvgEye}
-                onClick={() => {
-                  setPopoverOpen(false);
-                  onToggleEnabled();
-                }}
-              >
-                {skill.enabled ? "Disable" : "Re-enable"}
-              </LineItem>,
-              <LineItem
-                key="delete"
-                icon={SvgTrash}
-                danger
-                onClick={() => {
-                  setPopoverOpen(false);
-                  onDelete();
-                }}
-              >
-                Delete
-              </LineItem>,
+              canManageAccess ? (
+                <LineItem
+                  key="share"
+                  icon={SvgShare}
+                  onClick={() => {
+                    setPopoverOpen(false);
+                    onShare();
+                  }}
+                >
+                  Edit visibility
+                </LineItem>
+              ) : undefined,
+              canEdit ? (
+                <LineItem
+                  key="replace"
+                  icon={SvgUploadCloud}
+                  onClick={() => {
+                    setPopoverOpen(false);
+                    onReplaceBundle();
+                  }}
+                >
+                  Replace bundle
+                </LineItem>
+              ) : undefined,
+              canEdit ? (
+                <LineItem
+                  key="enabled"
+                  icon={skill.enabled ? SvgEyeOff : SvgEye}
+                  onClick={() => {
+                    setPopoverOpen(false);
+                    onToggleEnabled();
+                  }}
+                >
+                  {skill.enabled ? "Disable" : "Re-enable"}
+                </LineItem>
+              ) : undefined,
+              canDelete ? (
+                <LineItem
+                  key="delete"
+                  icon={SvgTrash}
+                  danger
+                  onClick={() => {
+                    setPopoverOpen(false);
+                    onDelete();
+                  }}
+                >
+                  Delete
+                </LineItem>
+              ) : undefined,
             ]}
           </PopoverMenu>
         </Popover.Content>

--- a/web/src/refresh-pages/admin/SkillsPage/ShareSkillModal.tsx
+++ b/web/src/refresh-pages/admin/SkillsPage/ShareSkillModal.tsx
@@ -9,6 +9,7 @@ import SkillSharePicker from "@/refresh-pages/admin/SkillsPage/SkillSharePicker"
 import { patchCustomSkill, replaceCustomSkillGrants } from "@/lib/skills/api";
 import { toast } from "@/hooks/useToast";
 import type { CustomSkill } from "@/refresh-pages/admin/SkillsPage/interfaces";
+import { can } from "@/lib/permissions/resource-actions";
 
 interface ShareSkillModalProps {
   skill: CustomSkill | null;
@@ -104,6 +105,7 @@ export default function ShareSkillModal({
               onIsPublicChange={setIsPublic}
               groupIds={groupIds}
               onGroupIdsChange={setGroupIds}
+              canPublish={can(skill, "publish")}
             />
             {skill.is_personal && (isPublic || groupIds.length > 0) && (
               <MessageCard

--- a/web/src/refresh-pages/admin/SkillsPage/SkillSharePicker.tsx
+++ b/web/src/refresh-pages/admin/SkillsPage/SkillSharePicker.tsx
@@ -17,6 +17,8 @@ interface SkillSharePickerProps {
   onIsPublicChange: (isPublic: boolean) => void;
   groupIds: number[];
   onGroupIdsChange: (groupIds: number[]) => void;
+  // Org-wide publish is admin-only; fail closed so an omitted value disables the switch.
+  canPublish?: boolean;
 }
 
 /**
@@ -32,6 +34,7 @@ export default function SkillSharePicker({
   onIsPublicChange,
   groupIds,
   onGroupIdsChange,
+  canPublish = false,
 }: SkillSharePickerProps) {
   const {
     data: groupsData,
@@ -137,7 +140,11 @@ export default function SkillSharePicker({
               description="Make this skill available to everyone in your organization."
               withLabel
             >
-              <Switch checked={isPublic} onCheckedChange={onIsPublicChange} />
+              <Switch
+                checked={isPublic}
+                onCheckedChange={onIsPublicChange}
+                disabled={!canPublish}
+              />
             </InputHorizontal>
           </Section>
         </Tabs.Content>

--- a/web/src/refresh-pages/admin/SkillsPage/UploadSkillModal.test.tsx
+++ b/web/src/refresh-pages/admin/SkillsPage/UploadSkillModal.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen, waitFor } from "@tests/setup/test-utils";
+import UploadSkillModal from "./UploadSkillModal";
+import { Permission } from "@/lib/types";
+import { useUser } from "@/providers/UserProvider";
+
+jest.mock("@/providers/UserProvider", () => ({
+  useUser: jest.fn(),
+}));
+
+jest.mock("@/hooks/useShareableGroups", () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ data: [] })),
+}));
+
+jest.mock("@/lib/skills/api", () => ({
+  createCustomSkill: jest.fn(),
+}));
+
+const mockUseUser = useUser as jest.Mock;
+
+function noop() {}
+
+describe("UploadSkillModal publish default", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it("opens public-by-default for an admin whose permissions load after mount", async () => {
+    // Mount closed while permissions are still loading (empty set) — the stale-capture case.
+    mockUseUser.mockReturnValue({ permissions: [] });
+    const { rerender } = render(
+      <UploadSkillModal open={false} onClose={noop} onUploaded={noop} />
+    );
+
+    // Permissions resolve (global skill admin) and the dialog opens.
+    mockUseUser.mockReturnValue({ permissions: [Permission.MANAGE_SKILLS] });
+    rerender(<UploadSkillModal open onClose={noop} onUploaded={noop} />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("tab", { name: "Your Organization" })
+      ).toHaveAttribute("data-state", "active")
+    );
+  });
+
+  it("switches to public when permissions resolve after the dialog is already open", async () => {
+    // The Upload button isn't permission-gated, so a click can land while /api/me is
+    // still in flight — canPublish then flips true with no `open` transition to catch it.
+    mockUseUser.mockReturnValue({ permissions: [] });
+    const { rerender } = render(
+      <UploadSkillModal open onClose={noop} onUploaded={noop} />
+    );
+
+    mockUseUser.mockReturnValue({ permissions: [Permission.MANAGE_SKILLS] });
+    rerender(<UploadSkillModal open onClose={noop} onUploaded={noop} />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("tab", { name: "Your Organization" })
+      ).toHaveAttribute("data-state", "active")
+    );
+  });
+
+  it("opens private for a scoped manager without publish permission", async () => {
+    mockUseUser.mockReturnValue({ permissions: [] });
+    render(<UploadSkillModal open onClose={noop} onUploaded={noop} />);
+
+    await waitFor(() =>
+      expect(screen.getByRole("tab", { name: "Groups" })).toHaveAttribute(
+        "data-state",
+        "active"
+      )
+    );
+  });
+});

--- a/web/src/refresh-pages/admin/SkillsPage/UploadSkillModal.tsx
+++ b/web/src/refresh-pages/admin/SkillsPage/UploadSkillModal.tsx
@@ -9,6 +9,9 @@ import { Section } from "@/layouts/general-layouts";
 import SkillSharePicker from "@/refresh-pages/admin/SkillsPage/SkillSharePicker";
 import { createCustomSkill } from "@/lib/skills/api";
 import { toast } from "@/hooks/useToast";
+import { useUser } from "@/providers/UserProvider";
+import { hasPermission } from "@/lib/permissions";
+import { Permission } from "@/lib/types";
 
 interface UploadSkillModalProps {
   open: boolean;
@@ -22,15 +25,32 @@ export default function UploadSkillModal({
   onClose,
   onUploaded,
 }: UploadSkillModalProps) {
+  // Publish is global MANAGE_SKILLS; read effective (global) permissions, not
+  // adminCapabilities — the scoped bundle would over-grant a group manager.
+  const { permissions } = useUser();
+  const canPublish = hasPermission(permissions, Permission.MANAGE_SKILLS);
+
   const [file, setFile] = useState<File | null>(null);
-  const [isPublic, setIsPublic] = useState(true);
+  // Default private for scoped managers; the server 403s their public create.
+  const [isPublic, setIsPublic] = useState(canPublish);
   const [groupIds, setGroupIds] = useState<number[]>([]);
   const [submitting, setSubmitting] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
+  // Opening and /api/me resolving are independent, so the useState above can capture a stale
+  // canPublish and watching only `open` would miss the fix-up. Re-derive on either transition,
+  // during render so the picker's tab mounts from the corrected value.
+  const [synced, setSynced] = useState({ open, canPublish });
+  if (open !== synced.open || canPublish !== synced.canPublish) {
+    setSynced({ open, canPublish });
+    if (open) {
+      setIsPublic(canPublish);
+    }
+  }
+
   function reset() {
     setFile(null);
-    setIsPublic(true);
+    setIsPublic(canPublish);
     setGroupIds([]);
   }
 
@@ -117,6 +137,7 @@ export default function UploadSkillModal({
                 onIsPublicChange={setIsPublic}
                 groupIds={groupIds}
                 onGroupIdsChange={setGroupIds}
+                canPublish={canPublish}
               />
             </Section>
           </Section>

--- a/web/src/refresh-pages/admin/SkillsPage/interfaces.ts
+++ b/web/src/refresh-pages/admin/SkillsPage/interfaces.ts
@@ -1,3 +1,4 @@
+import type { PermissionsOf } from "@/lib/permissions/resource-actions";
 /**
  * Skills API response shapes — mirrors
  * `backend/onyx/server/features/skill/models.py`.
@@ -43,6 +44,8 @@ export interface CustomSkill {
   created_at: string | null;
   updated_at: string | null;
   granted_group_ids: number[];
+  // Server-stamped affordance map; fail-closed (absent = denied).
+  permissions?: PermissionsOf<"CustomSkill">;
 }
 
 export interface SkillsList {

--- a/web/src/sections/actions/MCPActionCard.tsx
+++ b/web/src/sections/actions/MCPActionCard.tsx
@@ -19,6 +19,7 @@ import {
   MCPServer,
 } from "@/lib/tools/interfaces";
 import useServerTools from "@/hooks/useServerTools";
+import { can } from "@/lib/permissions/resource-actions";
 import { KeyedMutator } from "swr";
 import type { IconProps } from "@opal/types";
 import {
@@ -110,6 +111,11 @@ export default function MCPActionCard({
   const [showOnlyEnabled, setShowOnlyEnabled] = useState(false);
   const [isToolsRefreshing, setIsToolsRefreshing] = useState(false);
   const deleteModal = useCreateModal();
+
+  const canEdit = can(server, "edit");
+  const canDelete = can(server, "delete");
+  const canAuthenticate = can(server, "authenticate");
+  const canManageStatus = can(server, "manage_status");
 
   // Update expanded state when initialExpanded changes
   const hasInitializedExpansion = useRef(false);
@@ -206,17 +212,23 @@ export default function MCPActionCard({
       <Actions
         status={status}
         serverName={title}
-        onDisconnect={onDisconnect}
-        onManage={onManage}
-        onAuthenticate={onAuthenticate}
-        onReconnect={onReconnect}
-        onDelete={onDelete ? () => deleteModal.toggle(true) : undefined}
+        onDisconnect={canManageStatus ? onDisconnect : undefined}
+        onManage={canEdit ? onManage : undefined}
+        onAuthenticate={canAuthenticate ? onAuthenticate : undefined}
+        onReconnect={canManageStatus ? onReconnect : undefined}
+        onDelete={
+          canDelete && onDelete ? () => deleteModal.toggle(true) : undefined
+        }
         toolCount={toolCount}
         isToolsExpanded={isToolsExpanded}
         onToggleTools={handleToggleTools}
       />
     ),
     [
+      canAuthenticate,
+      canDelete,
+      canEdit,
+      canManageStatus,
       deleteModal,
       handleToggleTools,
       isToolsExpanded,
@@ -251,13 +263,15 @@ export default function MCPActionCard({
 
     return (
       <div className="flex items-center gap-2">
-        <Button
-          icon={isToolsRefreshing ? SvgSimpleLoader : SvgRefreshCw}
-          prominence="internal"
-          onClick={handleRefreshTools}
-          tooltip="Refresh tools"
-          aria-label="Refresh tools"
-        />
+        {canManageStatus && (
+          <Button
+            icon={isToolsRefreshing ? SvgSimpleLoader : SvgRefreshCw}
+            prominence="internal"
+            onClick={handleRefreshTools}
+            tooltip="Refresh tools"
+            aria-label="Refresh tools"
+          />
+        )}
         {lastRefreshedText && (
           <Text as="p" text03 mainUiBody className="whitespace-nowrap">
             Tools last refreshed {lastRefreshedText}
@@ -266,6 +280,7 @@ export default function MCPActionCard({
       </div>
     );
   }, [
+    canManageStatus,
     server.last_refreshed_at,
     serverId,
     mutate,
@@ -281,8 +296,8 @@ export default function MCPActionCard({
         icon={icon}
         status={status}
         actions={actionsComponent}
-        onEdit={onEdit}
-        onRename={handleRename}
+        onEdit={canEdit ? onEdit : undefined}
+        onRename={canEdit ? handleRename : undefined}
         isExpanded={isToolsExpanded}
         onExpandedChange={setIsToolsExpanded}
         enableSearch={true}
@@ -300,10 +315,16 @@ export default function MCPActionCard({
           enabledCount={tools.filter((tool) => tool.isEnabled).length}
           showOnlyEnabled={showOnlyEnabled}
           onToggleShowOnlyEnabled={handleToggleShowOnlyEnabled}
-          onUpdateToolsStatus={(enabled) => {
-            const toolIds = tools.map((tool) => parseInt(tool.id));
-            onUpdateToolsStatus?.(serverId, toolIds, enabled, mutate);
-          }}
+          onUpdateToolsStatus={
+            // Bulk toggles all tools; the status route 403s the whole batch unless every
+            // tool is manageable, so only offer it when the user can toggle each one.
+            tools.length > 0 && tools.every((tool) => can(tool, "toggle"))
+              ? (enabled) => {
+                  const toolIds = tools.map((tool) => parseInt(tool.id));
+                  onUpdateToolsStatus?.(serverId, toolIds, enabled, mutate);
+                }
+              : undefined
+          }
           isEmpty={filteredTools.length === 0}
           searchQuery={searchQuery}
           emptyMessage="No tools available"
@@ -318,6 +339,7 @@ export default function MCPActionCard({
               icon={tool.icon}
               isAvailable={tool.isAvailable}
               isEnabled={tool.isEnabled}
+              canToggle={can(tool, "toggle")}
               onToggle={(enabled) =>
                 onToolToggle?.(serverId, tool.id, enabled, mutate)
               }

--- a/web/src/sections/actions/OpenApiActionCard.tsx
+++ b/web/src/sections/actions/OpenApiActionCard.tsx
@@ -10,6 +10,7 @@ import { ToolSnapshot, ActionStatus, MethodSpec } from "@/lib/tools/interfaces";
 import ToolItem from "@/sections/actions/ToolItem";
 import { extractMethodSpecsFromDefinition } from "@/lib/tools/openApiService";
 import { updateToolStatus } from "@/lib/tools/mcpService";
+import { can } from "@/lib/permissions/resource-actions";
 import { SvgServer, SvgTrash } from "@opal/icons";
 import Modal from "@/refresh-components/layouts/ConfirmationModalLayout";
 import { Button } from "@opal/components";
@@ -39,6 +40,13 @@ export default function OpenApiActionCard({
   const [searchQuery, setSearchQuery] = useState("");
   const [updatingStatus, setUpdatingStatus] = useState(false);
   const deleteModal = useCreateModal();
+
+  const canEdit = can(tool, "edit");
+  const canDelete = can(tool, "delete");
+  const canToggle = can(tool, "toggle");
+  // Authenticate manages the OAuth config (owner-or-admin) — gate on the server capability,
+  // not canEdit, so a scoped non-owner isn't shown a 403 button.
+  const canAuthenticate = can(tool, "authenticate");
 
   const methodSpecs = useMemo<MethodSpec[]>(() => {
     try {
@@ -121,16 +129,24 @@ export default function OpenApiActionCard({
         toolCount={methodSpecs.length}
         isToolsExpanded={isToolsExpanded}
         onToggleTools={methodSpecs.length ? handleToggleTools : undefined}
-        onDisconnect={() => onOpenDisconnectModal?.(tool)}
-        onManage={onManage ? () => onManage(tool) : undefined}
-        onAuthenticate={() => {
-          onAuthenticate(tool);
-        }}
-        onReconnect={() => handleConnectionUpdate(true)}
-        onDelete={onDelete ? () => deleteModal.toggle(true) : undefined}
+        onDisconnect={
+          canToggle ? () => onOpenDisconnectModal?.(tool) : undefined
+        }
+        onManage={canEdit && onManage ? () => onManage(tool) : undefined}
+        onAuthenticate={
+          canAuthenticate ? () => onAuthenticate(tool) : undefined
+        }
+        onReconnect={canToggle ? () => handleConnectionUpdate(true) : undefined}
+        onDelete={
+          canDelete && onDelete ? () => deleteModal.toggle(true) : undefined
+        }
       />
     ),
     [
+      canAuthenticate,
+      canDelete,
+      canEdit,
+      canToggle,
       deleteModal,
       handleConnectionUpdate,
       handleToggleTools,
@@ -159,7 +175,7 @@ export default function OpenApiActionCard({
         icon={SvgServer}
         status={status}
         actions={actionsComponent}
-        onRename={handleRename}
+        onRename={canEdit ? handleRename : undefined}
         isExpanded={isToolsExpanded}
         onExpandedChange={setIsToolsExpanded}
         enableSearch={true}

--- a/web/src/sections/actions/ToolItem.tsx
+++ b/web/src/sections/actions/ToolItem.tsx
@@ -73,6 +73,7 @@ export interface ToolItemProps {
 
   // Handlers
   onToggle?: (enabled: boolean) => void;
+  canToggle?: boolean;
 
   // Optional styling
   className?: string;
@@ -87,6 +88,7 @@ const ToolItem: React.FC<ToolItemProps> = ({
   variant = "mcp",
   openApiMetadata,
   onToggle,
+  canToggle = true,
   className,
 }) => {
   const isMcpVariant = variant === "mcp";
@@ -226,7 +228,7 @@ const ToolItem: React.FC<ToolItemProps> = ({
             <Switch
               checked={isEnabled}
               onCheckedChange={onToggle}
-              disabled={!isAvailable}
+              disabled={!isAvailable || !canToggle}
               aria-label={`tool-toggle-${name}`}
             />
           </div>

--- a/web/src/sections/actions/modals/AddOpenAPIActionModal.tsx
+++ b/web/src/sections/actions/modals/AddOpenAPIActionModal.tsx
@@ -11,6 +11,7 @@ import { CopyButton } from "@opal/components";
 import { Button, Divider } from "@opal/components";
 import { Hoverable } from "@opal/core";
 import { MethodSpec, ToolSnapshot } from "@/lib/tools/interfaces";
+import { can } from "@/lib/permissions/resource-actions";
 import {
   validateToolDefinition,
   createCustomTool,
@@ -91,6 +92,11 @@ function FormContent({
   const [url, setUrl] = useState<string | undefined>(undefined);
 
   const isEditMode = Boolean(existingTool);
+  // Editing auth manages the action's OAuth config (owner-or-admin); gate on the same
+  // server-stamped capability as the card.
+  const canEditAuthentication = existingTool
+    ? can(existingTool, "authenticate")
+    : false;
 
   const handleFormat = useCallback(() => {
     if (!values.definition.trim()) {
@@ -370,7 +376,12 @@ function FormContent({
                 }}
               />
               <Button
-                disabled={!onEditAuthentication}
+                disabled={!onEditAuthentication || !canEditAuthentication}
+                tooltip={
+                  !canEditAuthentication
+                    ? "Only the action's creator or an admin can manage authentication"
+                    : undefined
+                }
                 prominence="secondary"
                 type="button"
                 onClick={handleEditAuthenticationClick}

--- a/web/src/sections/admin/AdminListHeader.tsx
+++ b/web/src/sections/admin/AdminListHeader.tsx
@@ -16,10 +16,10 @@ interface AdminListHeaderProps {
   placeholder?: string;
   /** Text shown in the empty-state card when no items exist. */
   emptyStateText: string;
-  /** Called when the action button is clicked. */
-  onAction: () => void;
-  /** Label for the action button. */
-  actionLabel: string;
+  /** Action button click handler. Omit (with actionLabel) to hide the button. */
+  onAction?: () => void;
+  /** Label for the action button. Omit (with onAction) to hide it. */
+  actionLabel?: string;
 }
 
 /**
@@ -59,11 +59,12 @@ export default function AdminListHeader({
   onAction,
   actionLabel,
 }: AdminListHeaderProps) {
-  const actionButton = (
-    <Button rightIcon={SvgPlusCircle} onClick={onAction}>
-      {actionLabel}
-    </Button>
-  );
+  const actionButton =
+    onAction && actionLabel ? (
+      <Button rightIcon={SvgPlusCircle} onClick={onAction}>
+        {actionLabel}
+      </Button>
+    ) : null;
 
   if (!hasItems) {
     return (

--- a/web/src/sections/agents/AgentCard.tsx
+++ b/web/src/sections/agents/AgentCard.tsx
@@ -11,16 +11,13 @@ import { noProp } from "@/lib/utils";
 import { cn } from "@opal/utils";
 import { useRouter } from "next/navigation";
 import type { Route } from "next";
-import { checkUserOwnsAgent } from "@/lib/agents/utils";
+import { can } from "@/lib/permissions/resource-actions";
 import { useTierAtLeast } from "@/hooks/useTierAtLeast";
 import { Tier } from "@/interfaces/settings";
 import {
   updateAgentSharedStatus,
   updateAgentFeaturedStatus,
 } from "@/lib/agents/svc";
-import { useUser } from "@/providers/UserProvider";
-import { hasPermission } from "@/lib/permissions";
-import { Permission } from "@/lib/types";
 import {
   SvgActions,
   SvgBarChart,
@@ -52,16 +49,13 @@ export default function AgentCard({ agent }: AgentCardProps) {
     () => pinnedAgents.some((pinnedAgent) => pinnedAgent.id === agent.id),
     [agent.id, pinnedAgents]
   );
-  const { user, isAdmin, permissions } = useUser();
   const businessTier = useTierAtLeast(Tier.BUSINESS);
-  const canUpdateFeaturedStatus = hasPermission(
-    permissions,
-    Permission.MANAGE_AGENTS
-  );
-  const isOwnedByUser = checkUserOwnsAgent(user, agent);
   const shareAgentModal = useCreateModal();
   const agentViewerModal = useCreateModal();
   const { agent: fullAgent, refresh: refreshAgent } = useAgent(agent.id);
+  // Affordances read the map the list endpoint stamped on `agent`, so icons render with
+  // the card instead of popping in after the per-card fullAgent fetch resolves.
+  const canUpdateFeaturedStatus = can(agent, "feature");
 
   // Start chat and auto-pin unpinned agents to the sidebar
   const handleStartChat = useCallback(() => {
@@ -146,7 +140,7 @@ export default function AgentCard({ agent }: AgentCardProps) {
               description={agent.description}
               rightChildren={
                 <>
-                  {isOwnedByUser && businessTier && (
+                  {can(agent, "view_stats") && businessTier && (
                     // TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved
                     <IconButton
                       icon={SvgBarChart}
@@ -158,7 +152,7 @@ export default function AgentCard({ agent }: AgentCardProps) {
                       className="hidden group-hover/AgentCard:flex"
                     />
                   )}
-                  {isOwnedByUser && (
+                  {can(agent, "edit") && (
                     // TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved
                     <IconButton
                       icon={SvgEdit}
@@ -170,7 +164,7 @@ export default function AgentCard({ agent }: AgentCardProps) {
                       className="hidden group-hover/AgentCard:flex"
                     />
                   )}
-                  {isOwnedByUser && (
+                  {can(agent, "share") && (
                     // TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved
                     <IconButton
                       icon={SvgShare}

--- a/web/src/sections/modals/ShareAgentModal.tsx
+++ b/web/src/sections/modals/ShareAgentModal.tsx
@@ -22,6 +22,7 @@ import { useModal } from "@/refresh-components/contexts/ModalContext";
 import { useUser } from "@/providers/UserProvider";
 import { hasPermission } from "@/lib/permissions";
 import { Permission } from "@/lib/types";
+import { can } from "@/lib/permissions/resource-actions";
 import { Formik, useFormikContext } from "formik";
 import { useAgent, useLabels } from "@/lib/agents/hooks";
 import {
@@ -68,7 +69,7 @@ function ShareAgentFormContent({ agentId }: ShareAgentFormContentProps) {
   const { data: groupsData } = useShareableGroups();
   const userDirectoryRestricted =
     usersError instanceof FetchError && usersError.status === 403;
-  const { user: currentUser, isAdmin, permissions } = useUser();
+  const { user: currentUser, permissions, adminCapabilities } = useUser();
   const { agent: fullAgent } = useAgent(agentId ?? null);
   const shareAgentModal = useModal();
   const { labels: allLabels, createLabel } = useLabels();
@@ -76,8 +77,17 @@ function ShareAgentFormContent({ agentId }: ShareAgentFormContentProps) {
 
   const acceptedUsers = usersData ?? [];
   const groups = groupsData ?? [];
-  const canUpdateFeaturedStatus = hasPermission(
-    permissions,
+  // Publish is owner-or-admin per agent, so use the server's answer, not a role check.
+  // A new agent has nothing stamped: publish stays open (its creator owns it), but feature
+  // needs global MANAGE_AGENTS — the create path rejects is_featured without it.
+  const isNewAgent = agentId == null;
+  const canPublish = isNewAgent || can(fullAgent, "publish");
+  const canUpdateFeaturedStatus = isNewAgent
+    ? hasPermission(permissions, Permission.MANAGE_AGENTS)
+    : can(fullAgent, "feature");
+
+  const canGroupShare = hasPermission(
+    adminCapabilities,
     Permission.MANAGE_AGENTS
   );
 
@@ -92,13 +102,21 @@ function ShareAgentFormContent({ agentId }: ShareAgentFormContentProps) {
             label: user.email,
           }));
 
-    const groupOptions = groups.map((group) => ({
-      value: `group-${group.id}`,
-      label: group.name,
-    }));
+    const groupOptions = canGroupShare
+      ? groups.map((group) => ({
+          value: `group-${group.id}`,
+          label: group.name,
+        }))
+      : [];
 
     return [...userOptions, ...groupOptions];
-  }, [acceptedUsers, groups, currentUser?.id, userDirectoryRestricted]);
+  }, [
+    acceptedUsers,
+    groups,
+    currentUser?.id,
+    userDirectoryRestricted,
+    canGroupShare,
+  ]);
 
   const comboBoxDisabled =
     userDirectoryRestricted && comboBoxOptions.length === 0;
@@ -334,13 +352,15 @@ function ShareAgentFormContent({ agentId }: ShareAgentFormContentProps) {
 
             <Tabs.Content value={YOUR_ORGANIZATION_TAB}>
               <Section gap={1} alignItems="stretch" padding={0.5}>
-                <InputHorizontal
-                  title="Publish This Agent"
-                  description="Make this agent available to everyone in your organization."
-                  withLabel
-                >
-                  <SwitchField name="isPublic" />
-                </InputHorizontal>
+                {canPublish && (
+                  <InputHorizontal
+                    title="Publish This Agent"
+                    description="Make this agent available to everyone in your organization."
+                    withLabel
+                  >
+                    <SwitchField name="isPublic" />
+                  </InputHorizontal>
+                )}
 
                 {canUpdateFeaturedStatus && (
                   <>

--- a/web/src/sections/sidebar/AdminSidebar.tsx
+++ b/web/src/sections/sidebar/AdminSidebar.tsx
@@ -41,7 +41,7 @@ export default function AdminSidebar() {
   }, [focusSearch, folded]);
   const pathname = usePathname();
   const { customAnalyticsEnabled } = useCustomAnalyticsEnabled();
-  const { permissions } = useUser();
+  const { adminCapabilities } = useUser();
   const settings = useSettingsContext();
   const tier = settings?.settings.tier;
   const { data: billingData, isLoading: billingLoading } =
@@ -69,7 +69,7 @@ export default function AdminSidebar() {
       !settings?.settings.hide_query_history_from_admin_panel,
   };
 
-  const allItems = buildItems(permissions, flags, settings);
+  const allItems = buildItems(adminCapabilities, flags, settings);
 
   const itemExtractor = useCallback((item: SidebarItemEntry) => item.name, []);
 

--- a/web/src/sections/sidebar/AppSidebar.tsx
+++ b/web/src/sections/sidebar/AppSidebar.tsx
@@ -470,7 +470,7 @@ const AppSidebar = memo(function AppSidebarInner() {
     ]
   );
 
-  const { isAdmin, hasAdminAccess, permissions, user } = useUser();
+  const { isAdmin, hasAdminAccess, adminCapabilities, user } = useUser();
   const activeSidebarTab = useAppFocus();
   const createProjectModal = useCreateModal();
   const showLogoWhenFolded = useShowLogoWhenFolded();
@@ -578,7 +578,7 @@ const AppSidebar = memo(function AppSidebarInner() {
       <div>
         {hasAdminAccess && (
           <SidebarTab
-            href={getFirstPermittedAdminRoute(permissions)}
+            href={getFirstPermittedAdminRoute(adminCapabilities)}
             icon={SvgSettings}
             folded={folded}
           >
@@ -596,7 +596,7 @@ const AppSidebar = memo(function AppSidebarInner() {
     [
       folded,
       hasAdminAccess,
-      permissions,
+      adminCapabilities,
       handleShowBuildIntro,
       isOnyxCraftEnabled,
     ]

--- a/web/tests/e2e/admin/permissions/permission_gating.spec.ts
+++ b/web/tests/e2e/admin/permissions/permission_gating.spec.ts
@@ -73,7 +73,6 @@ test.describe("Permission gating — MANAGE_AGENTS", () => {
 
     const { groupId, email, password } = testUserContext;
 
-    // Admin creates a custom agent
     const agentName = `E2E Manage Agent ${Date.now()}`;
     const agentId = await adminClient.createAgent(agentName, "Test agent");
 
@@ -114,7 +113,6 @@ test.describe("Permission gating — MANAGE_AGENTS", () => {
       await page.waitForLoadState("networkidle");
       expect(page.url()).toContain("/app");
     } finally {
-      // Cleanup: delete the agent
       await page.context().clearCookies();
       await loginAs(page, "admin");
       const cleanupClient = new OnyxApiClient(page.request);
@@ -139,7 +137,6 @@ test.describe("Permission gating — MANAGE_LLMS", () => {
 
     const { groupId, email, password } = testUserContext;
 
-    // Admin creates an LLM provider
     const providerName = `E2E Manage LLM ${Date.now()}`;
     const providerId = await adminClient.createProvider(providerName);
 
@@ -182,7 +179,6 @@ test.describe("Permission gating — MANAGE_LLMS", () => {
       await page.waitForLoadState("networkidle");
       expect(page.url()).toContain("/app");
     } finally {
-      // Cleanup: delete the provider
       await page.context().clearCookies();
       await loginAs(page, "admin");
       const cleanupClient = new OnyxApiClient(page.request);
@@ -207,7 +203,6 @@ test.describe("Permission gating — MANAGE_CONNECTORS", () => {
 
     const { groupId, email, password } = testUserContext;
 
-    // Admin creates a file connector
     const connectorName = `E2E Manage Connector ${Date.now()}`;
     const ccPairId = await adminClient.createFileConnector(connectorName);
 
@@ -261,7 +256,6 @@ test.describe("Permission gating — MANAGE_CONNECTORS", () => {
       await page.waitForLoadState("networkidle");
       expect(page.url()).toContain("/app");
     } finally {
-      // Cleanup: delete the connector
       await page.context().clearCookies();
       await loginAs(page, "admin");
       const cleanupClient = new OnyxApiClient(page.request);
@@ -286,7 +280,6 @@ test.describe("Permission gating — MANAGE_DOCUMENT_SETS", () => {
 
     const { groupId, email, password } = testUserContext;
 
-    // Admin creates a public file connector
     const connectorName = `E2E DocSet Connector ${Date.now()}`;
     const ccPairId = await adminClient.createFileConnector(
       connectorName,
@@ -340,17 +333,17 @@ test.describe("Permission gating — MANAGE_DOCUMENT_SETS", () => {
         page.getByLabel("admin-page-title").getByText("New Document Set")
       ).toBeVisible({ timeout: 10000 });
 
-      // Open the connector dropdown and verify the admin-created connector is listed
+      // Open the connector dropdown
       const connectorSearchInput = page.getByTestId("connector-search-input");
       await expect(connectorSearchInput).toBeVisible({ timeout: 10000 });
       await connectorSearchInput.click();
 
-      // Verify the connector is visible (proves implied READ_CONNECTORS)
+      // Connector visible proves implied READ_CONNECTORS
       await expect(page.getByText(connectorName)).toBeVisible({
         timeout: 10000,
       });
 
-      // Verify group selector loaded successfully (proves implied READ_USER_GROUPS)
+      // Group selector loaded proves implied READ_USER_GROUPS
       await expect(
         page.getByText("Assign group access for this document set")
       ).toBeVisible({ timeout: 10000 });
@@ -381,7 +374,6 @@ test.describe("Permission gating — MANAGE_DOCUMENT_SETS", () => {
       await page.waitForLoadState("networkidle");
       expect(page.url()).toContain("/app");
     } finally {
-      // Cleanup: delete the connector and extra group
       await page.context().clearCookies();
       await loginAs(page, "admin");
       const cleanupClient = new OnyxApiClient(page.request);
@@ -407,7 +399,6 @@ test.describe("Permission gating — MANAGE_ACTIONS", () => {
 
     const { groupId, email, password } = testUserContext;
 
-    // Admin creates an OpenAPI custom tool and an MCP server
     const toolName = `E2E Manage Tool ${Date.now()}`;
     const toolId = await adminClient.createCustomTool(toolName);
 
@@ -473,7 +464,6 @@ test.describe("Permission gating — MANAGE_ACTIONS", () => {
       await page.waitForLoadState("networkidle");
       expect(page.url()).toContain("/app");
     } finally {
-      // Cleanup: delete the tool and MCP server
       await page.context().clearCookies();
       await loginAs(page, "admin");
       const cleanupClient = new OnyxApiClient(page.request);
@@ -499,7 +489,6 @@ test.describe("Permission gating — MANAGE_SERVICE_ACCOUNT_API_KEYS", () => {
 
     const { groupId, email, password } = testUserContext;
 
-    // Admin creates a service account
     const accountName = `E2E Service Account ${Date.now()}`;
     const apiKeyId = await adminClient.createServiceAccount(accountName);
 
@@ -561,7 +550,6 @@ test.describe("Permission gating — MANAGE_SERVICE_ACCOUNT_API_KEYS", () => {
       await page.waitForLoadState("networkidle");
       expect(page.url()).toContain("/app");
     } finally {
-      // Cleanup: delete the service account and extra group
       await page.context().clearCookies();
       await loginAs(page, "admin");
       const cleanupClient = new OnyxApiClient(page.request);
@@ -647,7 +635,6 @@ test.describe("Permission gating — MANAGE_BOTS", () => {
       await page.waitForLoadState("networkidle");
       expect(page.url()).toContain("/app");
     } finally {
-      // Cleanup: delete the Discord guild
       await page.context().clearCookies();
       await loginAs(page, "admin");
       const cleanupClient = new OnyxApiClient(page.request);
@@ -713,7 +700,6 @@ test.describe("Permission gating — READ_QUERY_HISTORY", () => {
       await page.waitForLoadState("networkidle");
       expect(page.url()).toContain("/app");
     } finally {
-      // Cleanup: delete the chat session
       await page.context().clearCookies();
       await loginAs(page, "admin");
       const cleanupClient = new OnyxApiClient(page.request);
@@ -803,7 +789,7 @@ test.describe("Permission gating — CREATE_USER_API_KEYS", () => {
       await expect(newTokenButton).toBeVisible({ timeout: 10000 });
       await expect(newTokenButton).toBeDisabled();
     } finally {
-      // Cleanup: delete the PAT (only requires BASIC_ACCESS)
+      // Delete the PAT (only requires BASIC_ACCESS)
       if (createdPatId !== undefined) {
         await page.context().clearCookies();
         await apiLogin(page, email, password);
@@ -910,7 +896,7 @@ test.describe("Permission gating — MANAGE_USER_GROUPS", () => {
         timeout: 10000,
       });
 
-      // Dismiss the connectors popover by pressing Escape before opening agents
+      // Dismiss the connectors popover before opening agents
       await page.keyboard.press("Escape");
 
       // Open agents popover and verify item (proves READ_AGENTS)
@@ -932,7 +918,7 @@ test.describe("Permission gating — MANAGE_USER_GROUPS", () => {
       await page.waitForLoadState("networkidle");
       expect(page.url()).toContain("/app");
     } finally {
-      // Cleanup: delete resources (doc set before connector since it references it)
+      // Delete doc set before connector since it references it
       await page.context().clearCookies();
       await loginAs(page, "admin");
       const cleanupClient = new OnyxApiClient(page.request);

--- a/web/tests/e2e/admin/permissions/permission_system.spec.ts
+++ b/web/tests/e2e/admin/permissions/permission_system.spec.ts
@@ -50,8 +50,8 @@ test("group permissions apply immediately when a user is added to the group", as
       Permission.MANAGE_LLMS,
     ]);
 
-    // This is intentionally not followed by waitForGroupSync. Auth permission
-    // recomputation is expected to complete before add-users returns.
+    // Intentionally no waitForGroupSync: auth permission recomputation
+    // is expected to complete before add-users returns.
     await adminClient.addUsersToGroup(groupId, [user.id]);
 
     await page.context().clearCookies();

--- a/web/tests/e2e/utils/onyxApiClient.ts
+++ b/web/tests/e2e/utils/onyxApiClient.ts
@@ -776,10 +776,11 @@ export class OnyxApiClient {
 
   async getCurrentUserPermissions(): Promise<string[]> {
     const response = await this.get("/me/permissions");
-    return await this.handleResponse(
+    const body = await this.handleResponse<{ permissions: string[] }>(
       response,
       "Failed to fetch current user permissions"
     );
+    return body.permissions;
   }
 
   async addUserToAdminGroup(email: string): Promise<void> {


### PR DESCRIPTION
## Description

- Add `User__UserGroup.is_manager` (per-(user, group) manager role binding) and a cached `User.is_group_manager` boolean for a zero-query route gate — the schema foundation for scoped group managers.
- Migration `c71a18ea7d07`: additive columns + role-gated backfill of the legacy curator signal (`CURATOR` → curated groups, `GLOBAL_CURATOR` → all memberships) before `role`/`is_curator` are dropped in a later cleanup.
- `recompute_user_permissions__no_commit` now also refreshes the cached `is_group_manager` flag.
- Unblock app boot (PR0): re-point `skill/api.py` and the targeted-reindex endpoints off the removed `current_curator_or_admin_user` dependency.

> The new columns are inert this PR — no readers yet; scoped enforcement, manager assignment, and UI land in later PRs. Re-points `c8e316473aaa` onto the merged-main chain to keep a single alembic head.

## How Has This Been Tested?

- Integration: `is_group_manager` set/clear via the real `recompute` path, folded into the existing membership recompute test (`test_group_membership_updates_user_permissions.py`), incl. a manages-any-of-multiple-groups case. Migration-backfill test deferred. pre-commit (ruff + ty) passes.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-group manager support and a role-gated backfill, plus scoped-manager authorization and server-stamped UI capabilities so managers can act only within their groups.

- **New Features**
  - Schema: add `User__UserGroup.is_manager` and cached `User.is_group_manager` (default `false`), with migration `c71a18ea7d07` backfilling from legacy curator roles; `recompute_user_permissions__no_commit` refreshes `is_group_manager`.
  - Auth: introduce scoped-manager primitives — `require_permission(..., allow_scope=True)`, `assert_within_scope`/`assert_global`, and `has_global_permission`; add `PermissionAuthority` and `Permission.MANAGE_SKILLS`; read filters use `scoped_group_ids_subquery`/`within_managed_scope_clause`.
  - API/DTOs: stamp per-resource `permissions{}` maps via a shared projection (e.g., connectors, document sets, agents, tools, MCP servers, skills); new `/manage/me/permissions` returns effective permissions, `is_manager`, and `managed_group_ids`; group manager assign/revoke APIs (`SetGroupManagerRequest`) added; scope-enforced writes for connectors, document sets, token limits, agents, skills (delete stays admin-only).
  - Frontend: add `can()` resource-action checks and `adminCapabilities`-based nav gates; wire skills/apps manage layouts to `Permission.MANAGE_SKILLS`/`Permission.FULL_ADMIN_PANEL_ACCESS`; update pages to hide edit/share/publish controls based on server-stamped permissions.

- **Bug Fixes**
  - Replace `current_curator_or_admin_user` with `require_permission(...)` to unblock API boot (targeted reindex → `MANAGE_CONNECTORS`, skill admin routes → `FULL_ADMIN_PANEL_ACCESS`); update admin checks to `has_global_permission`.
  - Re-point Alembic head (`c8e316473aaa`) to keep a single migration chain.

<sup>Written for commit 768dcd1fe0ee9b765ad0bce511a1663598a1df12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

