### PR TITLE
fix(auth): validate OAuth next param to prevent open redirect (ENG-4253)

### DIFF
--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -153,6 +153,7 @@ from onyx.utils.telemetry import optional_telemetry
 from onyx.utils.telemetry import RecordType
 from onyx.utils.timing import log_function_time
 from onyx.utils.url import add_url_params
+from onyx.utils.url import sanitize_next_url
 from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
 from shared_configs.configs import async_return_default_schema
 from shared_configs.configs import MULTI_TENANT
@@ -2341,7 +2342,7 @@ def get_oauth_router(
             callback_path = request.app.url_path_for(callback_route_name)
             authorize_redirect_url = f"{WEB_DOMAIN}{callback_path}"
 
-        next_url = request.query_params.get("next", "/")
+        next_url = sanitize_next_url(request.query_params.get("next"))
 
         csrf_token = generate_csrf_token()
         state_data: Dict[str, str] = {
@@ -2614,7 +2615,7 @@ def get_oauth_router(
                     ErrorCode.OAUTH_NOT_AVAILABLE_EMAIL,
                 )
 
-            next_url = state_data.get("next_url", "/")
+            next_url = sanitize_next_url(state_data.get("next_url"))
             referral_source = state_data.get("referral_source", None)
             try:
                 tenant_id = fetch_ee_implementation_or_noop(

--- a/backend/onyx/utils/url.py
+++ b/backend/onyx/utils/url.py
@@ -1,5 +1,6 @@
 import ipaddress
 import socket
+import unicodedata
 from typing import Any
 from urllib.parse import parse_qs
 from urllib.parse import urlencode
@@ -542,3 +543,46 @@ def add_url_params(url: str, params: dict) -> str:
     )
 
     return new_url
+
+
+def sanitize_next_url(next_url: str | None) -> str:
+    """Validate a post-login redirect target, returning a safe value.
+
+    Only same-origin relative paths are permitted. Anything carrying a scheme
+    (e.g. ``javascript:``), a network location (``https://evil.com``), or a
+    protocol-relative form (``//evil.com``, ``/\\evil.com``) falls back to
+    ``"/"``. This prevents open-redirect / post-auth phishing through the OAuth
+    ``next`` parameter.
+    """
+    if not next_url:
+        return "/"
+
+    # Leading/trailing whitespace is ignored by browsers; strip so the checks
+    # below see what the browser will actually navigate to.
+    next_url = next_url.strip()
+    if not next_url:
+        return "/"
+
+    # Some browsers strip a leading control character and then reinterpret the
+    # remainder as scheme-relative (e.g. "\x01//evil.com" -> "//evil.com").
+    if unicodedata.category(next_url[0])[0] == "C":
+        return "/"
+
+    # Browsers treat backslashes as forward slashes, so normalize before the
+    # checks below — otherwise tricks like "/\\evil.com" slip past as a path.
+    normalized = next_url.replace("\\", "/")
+
+    # Reject protocol-relative ("//evil.com") and Chrome's absolute "///" form.
+    if not normalized.startswith("/") or normalized.startswith("//"):
+        return "/"
+
+    try:
+        parsed = urlparse(normalized)
+    except ValueError:
+        # Malformed input (e.g. invalid IPv6 literal) — fall back to safe default.
+        return "/"
+
+    if parsed.scheme or parsed.netloc:
+        return "/"
+
+    return next_url

--- a/backend/tests/unit/onyx/utils/test_sanitize_next_url.py
+++ b/backend/tests/unit/onyx/utils/test_sanitize_next_url.py
@@ -1,0 +1,48 @@
+import pytest
+
+from onyx.utils.url import sanitize_next_url
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        # scheme-bearing payloads
+        "javascript:alert(1)",
+        "https://evil.example.com",
+        "http://evil.example.com/path",
+        "data:text/html,<script>alert(1)</script>",
+        # protocol-relative / netloc forms
+        "//evil.com",
+        "//evil.com/path",
+        # backslash tricks that browsers normalize to "//"
+        "/\\evil.com",
+        "\\\\evil.com",
+        # whitespace + control-char prefixes that browsers strip then reinterpret
+        "  //evil.com",
+        "\t//evil.com",
+        "\x01//evil.com",
+        # malformed authority (urlparse raises / startswith guard catches)
+        "https://[::1",
+        "//[::1",
+        # non-relative / empty
+        "evil.com",
+        "",
+        "   ",
+        None,
+    ],
+)
+def test_sanitize_next_url_rejects_unsafe(value: str | None) -> None:
+    assert sanitize_next_url(value) == "/"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "/",
+        "/chat",
+        "/admin/connectors?foo=bar",
+        "/path/to/page#section",
+    ],
+)
+def test_sanitize_next_url_allows_relative_paths(value: str) -> None:
+    assert sanitize_next_url(value) == value


### PR DESCRIPTION
## Description

Validates the OAuth `next` query parameter to prevent an open redirect.

`GET /auth/login?next=<payload>` embedded `next` into the OAuth state and, after
the OIDC flow completed, used it as the `RedirectResponse` target with no
validation — `javascript:alert(...)`, external `https://...`, protocol-relative
`//evil.com`, and whitespace/control-char-prefixed variants were all accepted,
enabling convincing post-auth phishing from a legitimate login link.

Adds `sanitize_next_url()` in `onyx/utils/url.py`, which permits only
same-origin relative paths (leading `/`, no scheme, no netloc; strips
whitespace, rejects leading control chars, normalizes backslashes) and falls
back to `/` otherwise. Applied at the read site (before the value is signed into
the state) and again on the callback read as defense-in-depth. Legitimate
relative paths pass through unchanged, so there is no behavior change for normal
logins.

## How Has This Been Tested?

- New unit test `backend/tests/unit/onyx/utils/test_sanitize_next_url.py` —
  `javascript:`, external/protocol-relative/backslash/whitespace/control-char
  payloads all normalize to `/`; legitimate relative paths pass through (21
  cases, all passing).
- `ty` type check and `ruff`/`ruff format` pass on the changed files.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an open redirect in the OAuth flow by validating the `next` parameter. Addresses Linear ENG-4253 and blocks external/javascript/protocol-relative redirects; unsafe values now fall back to `/`.

- **Bug Fixes**
  - Added `sanitize_next_url()` in `onyx/utils/url.py` to allow only same-origin relative paths (strips whitespace, normalizes backslashes, rejects scheme/netloc/`//`).
  - Applied sanitization when reading `next` on login and again on callback for defense-in-depth.
  - Added unit tests covering malicious payloads and valid relative paths.

<sup>Written for commit b11c751e259a01ed9347eb5d91d93ec433e8c807. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

