### PR TITLE
fix(web): ignore IME composition Enter in ListFieldInput

### DIFF
--- a/web/src/refresh-components/inputs/ListFieldInput.tsx
+++ b/web/src/refresh-components/inputs/ListFieldInput.tsx
@@ -29,7 +29,7 @@ export function ListFieldInput({
   const [inputValue, setInputValue] = useState("");
 
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter" && inputValue.trim()) {
+    if (e.key === "Enter" && !e.nativeEvent.isComposing && inputValue.trim()) {
       e.preventDefault();
       const trimmedValue = inputValue.trim();
 


### PR DESCRIPTION
## Description

`ListFieldInput` commits the typed text as a chip when Enter is pressed, but it doesn't check whether an IME composition is in progress.

When entering CJK text (Japanese/Chinese/Korean), pressing Enter to confirm a conversion candidate fires `keydown` with `isComposing` set to `true`. The handler treats that as a submit, so the half-converted text is added to the list and the input is cleared, while the candidate the user actually wanted gets discarded. The list ends up with garbled entries.

The fix skips the submit while `e.nativeEvent.isComposing` is `true`. This is the same guard the message input bars already use (`BaseInputBar`, `AppInputBar`), so Enter-to-commit behaves consistently across the inputs.

```diff
-    if (e.key === "Enter" && inputValue.trim()) {
+    if (e.key === "Enter" && !e.nativeEvent.isComposing && inputValue.trim()) {
```

## How Has This Been Tested?

Rendered the component with React Testing Library + jsdom:

- `keydown` Enter with `isComposing: true` no longer adds a value (it did before this change).
- `keydown` Enter with `isComposing: false` still adds the trimmed value as expected.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignore Enter presses during IME composition in `ListFieldInput` to prevent half-composed text from being added as chips. This fixes CJK input issues and aligns Enter-to-commit behavior with `BaseInputBar` and `AppInputBar`.

<sup>Written for commit 450af7305048cc0420dd695305c944e9ce55d085. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

