### PR TITLE
fix(license): persist expiry-banner dismissal for the full license term

### DIFF
--- a/web/src/sections/LicenseExpiryBanner.tsx
+++ b/web/src/sections/LicenseExpiryBanner.tsx
@@ -68,16 +68,10 @@ function computeGraceDaysRemaining(gracePeriodEnd: string | null): number {
   return Math.max(1, Math.ceil(msLeft / 86400000));
 }
 
-function dismissKey(
-  stage: ExpiryWarningStage,
-  expiresAt: string | null
-): string {
-  const base = `${DISMISS_STORAGE_KEY}:${stage}:${expiresAt ?? "unknown"}`;
-  if (stage === "grace") {
-    const today = new Date().toISOString().slice(0, 10);
-    return `${base}:${today}`;
-  }
-  return base;
+// Keyed on expires_at alone so one dismissal persists across stage escalation
+// and grace days; a renewal (new expires_at) surfaces the banner again.
+function dismissKey(expiresAt: string | null): string {
+  return `${DISMISS_STORAGE_KEY}:${expiresAt ?? "unknown"}`;
 }
 
 interface LicenseExpiryBannerViewProps {
@@ -164,7 +158,7 @@ export default function LicenseExpiryBanner() {
   const expiresAt = data?.expires_at ?? null;
   const graceDays = computeGraceDaysRemaining(data?.grace_period_end ?? null);
   const hasLicense = data?.has_license ?? false;
-  const key = dismissKey(stage, expiresAt);
+  const key = dismissKey(expiresAt);
 
   useEffect(() => {
     if (typeof window === "undefined") return;


### PR DESCRIPTION
## Description

The license-expiry banner already had a dismiss "X", but the dismissal didn't persist: the localStorage key included the warning stage and (during grace) the current date, so the banner reappeared on every stage escalation (30d → 14d → 1d → grace) and on each new grace day.

**Fix:** key the dismissal on `expires_at` alone, so one dismissal sticks for the whole license term. A renewal (new `expires_at`) surfaces the banner again for the next term.

Quick fix until the announcement banner is overhauled.

## How Has This Been Tested?

Automated: `bun run types:check` (0 errors), oxlint + oxfmt clean, pre-commit hooks pass. Single file changed (`web/src/sections/LicenseExpiryBanner.tsx`). Live behavior not yet exercised (needs an active license-expiry warning state).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
