### PR TITLE
fix(license): persist expiry-banner dismissal server-side via notifications

### DIFF
--- a/backend/ee/onyx/utils/license_notifications.py
+++ b/backend/ee/onyx/utils/license_notifications.py
@@ -14,16 +14,22 @@ from typing import Any
 
 from sqlalchemy.orm import Session
 
+from ee.onyx.db.license import get_license
+from ee.onyx.utils.license import verify_license_signature
 from ee.onyx.utils.license_expiry import ExpiryWarningStage
+from ee.onyx.utils.license_expiry import get_expiry_warning_stage
 from ee.onyx.utils.license_expiry import get_grace_days_remaining
 from onyx.auth.email_utils import build_html_email
 from onyx.auth.email_utils import send_email
+from onyx.auth.schemas import UserRole
 from onyx.configs.app_configs import EMAIL_CONFIGURED
 from onyx.configs.constants import NotificationType
 from onyx.configs.constants import ONYX_DEFAULT_APPLICATION_NAME
+from onyx.db.models import User
 from onyx.db.notification import batch_create_notifications
 from onyx.db.users import get_active_admin_users
 from onyx.utils.logger import setup_logger
+from shared_configs.configs import MULTI_TENANT
 
 logger = setup_logger()
 
@@ -149,4 +155,43 @@ def notify_admins_for_stage(
         stage.value,
         len(inserted_admin_ids),
         today.isoformat(),
+    )
+
+
+def ensure_license_expiry_notification_for_user(
+    user: User,
+    db_session: Session,
+) -> None:
+    """On-read fallback: materialize the requesting admin's in-app notification
+    for the current expiry stage so the banner appears immediately instead of
+    waiting for the once-daily task. Idempotent via the notification unique
+    index; never emails (the daily task owns email + all-admin fan-out)."""
+    if MULTI_TENANT or user.role != UserRole.ADMIN:
+        return
+
+    license_record = get_license(db_session)
+    if not license_record:
+        return
+    try:
+        payload = verify_license_signature(license_record.license_data)
+    except ValueError:
+        logger.exception("Failed to verify license during on-read notification ensure")
+        return
+
+    stage = get_expiry_warning_stage(payload.expires_at)
+    if stage == ExpiryWarningStage.NONE:
+        return
+
+    today = datetime.now(timezone.utc).date()
+    additional_data = _build_additional_data(stage, payload.expires_at, today)
+    grace_days = get_grace_days_remaining(payload.expires_at)
+    title, description, _ = _build_copy(stage, payload.expires_at, grace_days)
+
+    batch_create_notifications(
+        user_ids=[user.id],
+        notif_type=NotificationType.LICENSE_EXPIRY_WARNING,
+        db_session=db_session,
+        title=title,
+        description=description,
+        additional_data=additional_data,
     )

--- a/backend/onyx/server/features/notifications/api.py
+++ b/backend/onyx/server/features/notifications/api.py
@@ -26,6 +26,7 @@ from onyx.server.features.release_notes.utils import (
     ensure_release_notes_fresh_and_notify,
 )
 from onyx.utils.logger import setup_logger
+from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
 
 logger = setup_logger()
 router = APIRouter(prefix="/notifications")
@@ -58,6 +59,19 @@ def _check_for_notifications_to_create(
         logger.exception("Failed to check for release notes in notifications endpoint")
 
 
+def _ensure_license_expiry_notification(user: User, db_session: Session) -> None:
+    """Self-hosted EE only: create the admin's current-stage license-expiry
+    notification on read so the banner appears without waiting for the daily
+    task. No-op on non-EE builds (and for non-admins / no active warning)."""
+    try:
+        fetch_ee_implementation_or_noop(
+            "ee.onyx.utils.license_notifications",
+            "ensure_license_expiry_notification_for_user",
+        )(user, db_session)
+    except Exception:
+        logger.exception("Failed to ensure license expiry notification on read")
+
+
 @router.get("")
 def get_notifications_api(
     page_num: int = Query(0, ge=0),
@@ -72,17 +86,20 @@ def get_notifications_api(
     Get a page of notifications for the current user, optionally filtered to a
     single notif_type.
 
-    Note: the first page of the unfiltered feed also executes checks that should
-    create notifications. A type-filtered request is a targeted read and skips
-    those create-checks.
+    Note: the first unfiltered page runs the generic create-checks. A
+    type-filtered request skips them, except a LICENSE_EXPIRY_WARNING filter
+    still ensures the requesting admin's current expiry notification exists.
 
     Examples of checks that create new notifications:
     - Checking for new release notes the user hasn't seen
     - Checking for misconfigurations due to version changes
     - Explicitly announcing breaking changes
     """
-    if page_num == 0 and notif_type is None:
-        _check_for_notifications_to_create(user, db_session)
+    if page_num == 0:
+        if notif_type is None:
+            _check_for_notifications_to_create(user, db_session)
+        if notif_type in (None, NotificationType.LICENSE_EXPIRY_WARNING):
+            _ensure_license_expiry_notification(user, db_session)
 
     total_items, undismissed_count = count_notifications(
         user=user,

--- a/backend/onyx/server/features/notifications/api.py
+++ b/backend/onyx/server/features/notifications/api.py
@@ -64,7 +64,7 @@ def get_notifications_api(
     page_size: int = Query(
         DEFAULT_NOTIFICATIONS_PAGE_SIZE, ge=1, le=MAX_NOTIFICATIONS_PAGE_SIZE
     ),
-    notif_type: NotificationType | None = Query(None),
+    notif_type: NotificationType | None = None,
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> PaginatedNotifications:

--- a/backend/onyx/server/features/notifications/api.py
+++ b/backend/onyx/server/features/notifications/api.py
@@ -4,6 +4,7 @@ from fastapi import Query
 from sqlalchemy.orm import Session
 
 from onyx.auth.permissions import require_permission
+from onyx.configs.constants import NotificationType
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
 from onyx.db.models import User
@@ -63,25 +64,30 @@ def get_notifications_api(
     page_size: int = Query(
         DEFAULT_NOTIFICATIONS_PAGE_SIZE, ge=1, le=MAX_NOTIFICATIONS_PAGE_SIZE
     ),
+    notif_type: NotificationType | None = Query(None),
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> PaginatedNotifications:
     """
-    Get a page of notifications for the current user.
+    Get a page of notifications for the current user, optionally filtered to a
+    single notif_type.
 
-    Note: the first page also executes checks that should create notifications.
+    Note: the first page of the unfiltered feed also executes checks that should
+    create notifications. A type-filtered request is a targeted read and skips
+    those create-checks.
 
     Examples of checks that create new notifications:
     - Checking for new release notes the user hasn't seen
     - Checking for misconfigurations due to version changes
     - Explicitly announcing breaking changes
     """
-    if page_num == 0:
+    if page_num == 0 and notif_type is None:
         _check_for_notifications_to_create(user, db_session)
 
     total_items, undismissed_count = count_notifications(
         user=user,
         db_session=db_session,
+        notif_type=notif_type,
     )
     offset = page_num * page_size
     notifications = [
@@ -89,6 +95,7 @@ def get_notifications_api(
         for notif in get_notifications(
             user=user,
             db_session=db_session,
+            notif_type=notif_type,
             include_dismissed=True,
             limit=page_size,
             offset=offset,

--- a/backend/tests/external_dependency_unit/db/test_notification.py
+++ b/backend/tests/external_dependency_unit/db/test_notification.py
@@ -242,7 +242,7 @@ def test_get_notifications_api_runs_ensure_checks_on_first_page(
     assert calls == []
 
 
-def test_get_notifications_api_filters_by_type_and_skips_checks(
+def test_get_notifications_api_filters_by_type_and_skips_generic_checks(
     db_session: Session,
     tenant_context: None,  # noqa: ARG001
     monkeypatch: pytest.MonkeyPatch,
@@ -261,6 +261,12 @@ def test_get_notifications_api_filters_by_type_and_skips_checks(
         "ensure_release_notes_fresh_and_notify",
     ):
         monkeypatch.setattr(notifications_api, hook, record_call(hook))
+    ensure_license_calls: list[object] = []
+    monkeypatch.setattr(
+        notifications_api,
+        "_ensure_license_expiry_notification",
+        lambda user, _db_session: ensure_license_calls.append(user.id),
+    )
 
     user = create_test_user(db_session, "notification_api_type_filter")
     base_time = datetime(2026, 1, 1, tzinfo=timezone.utc)
@@ -296,8 +302,35 @@ def test_get_notifications_api_filters_by_type_and_skips_checks(
     assert [n.notif_type for n in response.notifications] == [
         NotificationType.LICENSE_EXPIRY_WARNING
     ]
-    # A type-filtered request is a targeted read and must skip create-checks.
+    # Generic create-checks are skipped for the targeted read, but the license
+    # filter still ensures the current admin's warning exists.
     assert calls == []
+    assert ensure_license_calls == [user.id]
+
+
+def test_get_notifications_api_non_license_filter_skips_license_ensure(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ensure_license_calls: list[object] = []
+    monkeypatch.setattr(
+        notifications_api,
+        "_ensure_license_expiry_notification",
+        lambda user, _db_session: ensure_license_calls.append(user.id),
+    )
+
+    user = create_test_user(db_session, "notification_api_non_license_filter")
+
+    notifications_api.get_notifications_api(
+        page_num=0,
+        page_size=50,
+        notif_type=NotificationType.APPROVAL_REQUESTED,
+        user=user,
+        db_session=db_session,
+    )
+
+    assert ensure_license_calls == []
 
 
 def test_notification_summary_runs_ensure_checks_before_counting(

--- a/backend/tests/external_dependency_unit/db/test_notification.py
+++ b/backend/tests/external_dependency_unit/db/test_notification.py
@@ -242,6 +242,64 @@ def test_get_notifications_api_runs_ensure_checks_on_first_page(
     assert calls == []
 
 
+def test_get_notifications_api_filters_by_type_and_skips_checks(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    def record_call(name: str) -> Callable[..., None]:
+        def _record_call(*_args: object, **_kwargs: object) -> None:
+            calls.append(name)
+
+        return _record_call
+
+    for hook in (
+        "ensure_build_mode_intro_notification",
+        "ensure_permissions_migration_notification",
+        "ensure_release_notes_fresh_and_notify",
+    ):
+        monkeypatch.setattr(notifications_api, hook, record_call(hook))
+
+    user = create_test_user(db_session, "notification_api_type_filter")
+    base_time = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    _create_notification(
+        db_session=db_session,
+        user=user,
+        index=0,
+        first_shown=base_time,
+        dismissed=False,
+    )
+    db_session.add(
+        Notification(
+            user_id=user.id,
+            notif_type=NotificationType.LICENSE_EXPIRY_WARNING,
+            dismissed=False,
+            last_shown=base_time,
+            first_shown=base_time,
+            title="License expiring",
+            additional_data={"stage": "t_30d"},
+        )
+    )
+    db_session.commit()
+
+    response = notifications_api.get_notifications_api(
+        page_num=0,
+        page_size=50,
+        notif_type=NotificationType.LICENSE_EXPIRY_WARNING,
+        user=user,
+        db_session=db_session,
+    )
+
+    assert response.total_items == 1
+    assert [n.notif_type for n in response.notifications] == [
+        NotificationType.LICENSE_EXPIRY_WARNING
+    ]
+    # A type-filtered request is a targeted read and must skip create-checks.
+    assert calls == []
+
+
 def test_notification_summary_runs_ensure_checks_before_counting(
     db_session: Session,
     tenant_context: None,  # noqa: ARG001

--- a/web/src/lib/swr-keys.ts
+++ b/web/src/lib/swr-keys.ts
@@ -93,6 +93,13 @@ export const SWR_KEYS = {
     });
     return `/api/notifications?${params.toString()}`;
   },
+  notificationsByType: (notifType: string, pageSize: number) => {
+    const params = new URLSearchParams({
+      notif_type: notifType,
+      page_size: pageSize.toString(),
+    });
+    return `/api/notifications?${params.toString()}`;
+  },
 
   // ── Users ─────────────────────────────────────────────────────────────────
   acceptedUsers: "/api/manage/users/accepted/all",

--- a/web/src/sections/LicenseExpiryBanner.tsx
+++ b/web/src/sections/LicenseExpiryBanner.tsx
@@ -1,109 +1,37 @@
 "use client";
 
-import { useEffect, useState } from "react";
+// Floating banner for self-hosted license expiry. Renders the most urgent
+// undismissed LICENSE_EXPIRY_WARNING notification and dismisses through the
+// notifications API, so a dismissal persists per-user server-side and survives
+// browser/localStorage resets. Notifications are created per stage (admins
+// only, single-tenant) by the license-expiry Celery task.
+
+import { useEffect, useMemo, useState } from "react";
 import { usePathname } from "next/navigation";
 import { MessageCard } from "@opal/components";
+import useNotifications from "@/hooks/useNotifications";
+import { dismissNotification } from "@/lib/notifications/api";
+import {
+  NotificationType,
+  type Notification,
+} from "@/lib/notifications/interfaces";
 import type { ExpiryWarningStage } from "@/lib/billing/interfaces";
-import { useLicense } from "@/hooks/useLicense";
 
-const DISMISS_STORAGE_KEY = "license-expiry-banner-dismissed";
+// Single source for stage semantics (higher = more urgent): picks which warning
+// to show when several are undismissed and drives the banner variant. Typed
+// against ExpiryWarningStage so a stage added to that union must be ranked here.
+const STAGE_SEVERITY: Record<Exclude<ExpiryWarningStage, "none">, number> = {
+  t_30d: 0,
+  t_14d: 1,
+  t_1d: 2,
+  grace: 3,
+};
 
-type BannerVariant = "warning" | "error";
+// t_1d and grace (and anything more urgent) render as an error.
+const ERROR_THRESHOLD = STAGE_SEVERITY.t_1d;
 
-interface BannerCopy {
-  title: string;
-  description: string;
-  variant: BannerVariant;
-}
-
-function buildCopy(
-  stage: ExpiryWarningStage,
-  expiresAt: string | null,
-  graceDaysRemaining: number
-): BannerCopy | null {
-  const expiresDisplay = expiresAt
-    ? new Date(expiresAt).toLocaleDateString()
-    : "soon";
-
-  if (stage === "t_30d") {
-    return {
-      title: `Your Onyx license expires on ${expiresDisplay}.`,
-      description:
-        "Renewal is due in approximately 30 days. Contact your Onyx representative to renew.",
-      variant: "warning",
-    };
-  }
-  if (stage === "t_14d") {
-    return {
-      title: `Your Onyx license expires on ${expiresDisplay}.`,
-      description:
-        "Renewal is due in approximately 2 weeks. Complete renewal soon to avoid service interruption.",
-      variant: "warning",
-    };
-  }
-  if (stage === "t_1d") {
-    return {
-      title: `Your Onyx license expires tomorrow (${expiresDisplay}).`,
-      description:
-        "Renewal is due within 24 hours. Renew now to avoid service interruption.",
-      variant: "error",
-    };
-  }
-  if (stage === "grace") {
-    return {
-      title: `Your Onyx license expired on ${expiresDisplay}.`,
-      description: `${graceDaysRemaining} grace day${
-        graceDaysRemaining === 1 ? "" : "s"
-      } remaining before access is gated. Renew now.`,
-      variant: "error",
-    };
-  }
-  return null;
-}
-
-function computeGraceDaysRemaining(gracePeriodEnd: string | null): number {
-  if (!gracePeriodEnd) return 0;
-  const msLeft = new Date(gracePeriodEnd).getTime() - Date.now();
-  if (msLeft <= 0) return 0;
-  return Math.max(1, Math.ceil(msLeft / 86400000));
-}
-
-function dismissKey(
-  stage: ExpiryWarningStage,
-  expiresAt: string | null
-): string {
-  const base = `${DISMISS_STORAGE_KEY}:${stage}:${expiresAt ?? "unknown"}`;
-  if (stage === "grace") {
-    const today = new Date().toISOString().slice(0, 10);
-    return `${base}:${today}`;
-  }
-  return base;
-}
-
-interface LicenseExpiryBannerViewProps {
-  stage: ExpiryWarningStage;
-  expiresAt: string | null;
-  graceDaysRemaining: number;
-  onDismiss?: () => void;
-}
-
-export function LicenseExpiryBannerView({
-  stage,
-  expiresAt,
-  graceDaysRemaining,
-  onDismiss,
-}: LicenseExpiryBannerViewProps) {
-  const copy = buildCopy(stage, expiresAt, graceDaysRemaining);
-  if (!copy) return null;
-
-  return (
-    <MessageCard
-      variant={copy.variant}
-      title={copy.title}
-      description={copy.description}
-      onClose={onDismiss}
-    />
-  );
+function severityForStage(stage: string | undefined): number {
+  return (STAGE_SEVERITY as Record<string, number>)[stage ?? ""] ?? 0;
 }
 
 function useMainContainerOffset(): { left: number; width: number } {
@@ -156,30 +84,54 @@ function useMainContainerOffset(): { left: number; width: number } {
 }
 
 export default function LicenseExpiryBanner() {
-  const { data } = useLicense();
-  const [dismissed, setDismissed] = useState(false);
+  const { notifications, refresh } = useNotifications();
   const { left, width } = useMainContainerOffset();
+  // IDs hidden optimistically while the server dismissal is in flight.
+  const [pendingDismissals, setPendingDismissals] = useState<Set<number>>(
+    new Set()
+  );
 
-  const stage = data?.expiry_warning_stage ?? "none";
-  const expiresAt = data?.expires_at ?? null;
-  const graceDays = computeGraceDaysRemaining(data?.grace_period_end ?? null);
-  const hasLicense = data?.has_license ?? false;
-  const key = dismissKey(stage, expiresAt);
+  const active = useMemo<Notification | null>(() => {
+    const candidates = notifications.filter(
+      (notification) =>
+        notification.notif_type === NotificationType.LICENSE_EXPIRY_WARNING &&
+        !notification.dismissed &&
+        !pendingDismissals.has(notification.id)
+    );
+    return candidates.reduce<Notification | null>((best, notification) => {
+      if (!best) return notification;
+      const next = severityForStage(notification.additional_data?.stage);
+      const current = severityForStage(best.additional_data?.stage);
+      if (next > current) return notification;
+      if (next === current && notification.last_shown > best.last_shown) {
+        return notification;
+      }
+      return best;
+    }, null);
+  }, [notifications, pendingDismissals]);
 
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    setDismissed(window.localStorage.getItem(key) === "1");
-  }, [key]);
+  if (!active) return null;
 
-  if (!hasLicense || stage === "none" || dismissed) {
-    return null;
-  }
+  const activeId = active.id;
+  const variant =
+    severityForStage(active.additional_data?.stage) >= ERROR_THRESHOLD
+      ? "error"
+      : "warning";
 
   function handleDismiss() {
-    if (typeof window !== "undefined") {
-      window.localStorage.setItem(key, "1");
-    }
-    setDismissed(true);
+    // Hide immediately; persist server-side. Restore on failure so the warning
+    // isn't silently lost and the user can retry.
+    setPendingDismissals((prev) => new Set(prev).add(activeId));
+    void dismissNotification(activeId)
+      .then(() => refresh())
+      .catch((error) => {
+        console.error("Failed to dismiss license expiry notification:", error);
+        setPendingDismissals((prev) => {
+          const next = new Set(prev);
+          next.delete(activeId);
+          return next;
+        });
+      });
   }
 
   return (
@@ -188,11 +140,11 @@ export default function LicenseExpiryBanner() {
       style={{ left, width: width || undefined }}
     >
       <div className="w-full max-w-3xl pointer-events-auto">
-        <LicenseExpiryBannerView
-          stage={stage}
-          expiresAt={expiresAt}
-          graceDaysRemaining={graceDays}
-          onDismiss={handleDismiss}
+        <MessageCard
+          variant={variant}
+          title={active.title}
+          description={active.description ?? undefined}
+          onClose={handleDismiss}
         />
       </div>
     </div>

--- a/web/src/sections/LicenseExpiryBanner.tsx
+++ b/web/src/sections/LicenseExpiryBanner.tsx
@@ -13,6 +13,7 @@ import { usePathname } from "next/navigation";
 import useSWR from "swr";
 import { MessageCard } from "@opal/components";
 import { errorHandlingFetcher } from "@/lib/fetcher";
+import { SWR_KEYS } from "@/lib/swr-keys";
 import { dismissNotification } from "@/lib/notifications/api";
 import {
   NotificationType,
@@ -22,8 +23,8 @@ import {
 import type { ExpiryWarningStage } from "@/lib/billing/interfaces";
 
 // Per-user license notifications are few (one per active stage, plus a daily
-// one during grace), so a single max-size page is always enough.
-const LICENSE_NOTIFICATIONS_URL = `/api/notifications?notif_type=${NotificationType.LICENSE_EXPIRY_WARNING}&page_size=50`;
+// one during grace), so a single max-size page always contains them all.
+const LICENSE_NOTIFICATIONS_PAGE_SIZE = 50;
 
 // Single source for stage semantics (higher = more urgent): picks which warning
 // to show when several are undismissed and drives the banner variant. Typed
@@ -93,7 +94,10 @@ function useMainContainerOffset(): { left: number; width: number } {
 
 export default function LicenseExpiryBanner() {
   const { data, mutate } = useSWR<NotificationsResponse>(
-    LICENSE_NOTIFICATIONS_URL,
+    SWR_KEYS.notificationsByType(
+      NotificationType.LICENSE_EXPIRY_WARNING,
+      LICENSE_NOTIFICATIONS_PAGE_SIZE
+    ),
     errorHandlingFetcher,
     { revalidateOnFocus: false, dedupingInterval: 30000 }
   );

--- a/web/src/sections/LicenseExpiryBanner.tsx
+++ b/web/src/sections/LicenseExpiryBanner.tsx
@@ -4,18 +4,26 @@
 // undismissed LICENSE_EXPIRY_WARNING notification and dismisses through the
 // notifications API, so a dismissal persists per-user server-side and survives
 // browser/localStorage resets. Notifications are created per stage (admins
-// only, single-tenant) by the license-expiry Celery task.
+// only, single-tenant) by the license-expiry Celery task. Fetches the
+// notifications feed filtered to this type so the warning can't be paged out
+// behind unrelated notifications.
 
 import { useEffect, useMemo, useState } from "react";
 import { usePathname } from "next/navigation";
+import useSWR from "swr";
 import { MessageCard } from "@opal/components";
-import useNotifications from "@/hooks/useNotifications";
+import { errorHandlingFetcher } from "@/lib/fetcher";
 import { dismissNotification } from "@/lib/notifications/api";
 import {
   NotificationType,
   type Notification,
+  type NotificationsResponse,
 } from "@/lib/notifications/interfaces";
 import type { ExpiryWarningStage } from "@/lib/billing/interfaces";
+
+// Per-user license notifications are few (one per active stage, plus a daily
+// one during grace), so a single max-size page is always enough.
+const LICENSE_NOTIFICATIONS_URL = `/api/notifications?notif_type=${NotificationType.LICENSE_EXPIRY_WARNING}&page_size=50`;
 
 // Single source for stage semantics (higher = more urgent): picks which warning
 // to show when several are undismissed and drives the banner variant. Typed
@@ -84,7 +92,11 @@ function useMainContainerOffset(): { left: number; width: number } {
 }
 
 export default function LicenseExpiryBanner() {
-  const { notifications, refresh } = useNotifications();
+  const { data, mutate } = useSWR<NotificationsResponse>(
+    LICENSE_NOTIFICATIONS_URL,
+    errorHandlingFetcher,
+    { revalidateOnFocus: false, dedupingInterval: 30000 }
+  );
   const { left, width } = useMainContainerOffset();
   // IDs hidden optimistically while the server dismissal is in flight.
   const [pendingDismissals, setPendingDismissals] = useState<Set<number>>(
@@ -92,7 +104,7 @@ export default function LicenseExpiryBanner() {
   );
 
   const active = useMemo<Notification | null>(() => {
-    const candidates = notifications.filter(
+    const candidates = (data?.notifications ?? []).filter(
       (notification) =>
         notification.notif_type === NotificationType.LICENSE_EXPIRY_WARNING &&
         !notification.dismissed &&
@@ -103,12 +115,17 @@ export default function LicenseExpiryBanner() {
       const next = severityForStage(notification.additional_data?.stage);
       const current = severityForStage(best.additional_data?.stage);
       if (next > current) return notification;
-      if (next === current && notification.last_shown > best.last_shown) {
+      // Same stage: keep the most recent. Compare instants, not raw strings.
+      if (
+        next === current &&
+        new Date(notification.last_shown).getTime() >
+          new Date(best.last_shown).getTime()
+      ) {
         return notification;
       }
       return best;
     }, null);
-  }, [notifications, pendingDismissals]);
+  }, [data, pendingDismissals]);
 
   if (!active) return null;
 
@@ -123,7 +140,7 @@ export default function LicenseExpiryBanner() {
     // isn't silently lost and the user can retry.
     setPendingDismissals((prev) => new Set(prev).add(activeId));
     void dismissNotification(activeId)
-      .then(() => refresh())
+      .then(() => mutate())
       .catch((error) => {
         console.error("Failed to dismiss license expiry notification:", error);
         setPendingDismissals((prev) => {


### PR DESCRIPTION
## Description

**Bug:** the self-hosted license-expiry banner stored its dismissal in `localStorage`. Environments that clear browser storage between sessions (locked-down / ephemeral browsers, common for high-security customers) saw the banner return on every visit.

**Fix:** render the banner from the per-user `LICENSE_EXPIRY_WARNING` notification and dismiss via `POST /notifications/{id}/dismiss`. Dismissal now persists per user in the DB and survives browser/localStorage resets.

- **Per stage:** escalation to a more urgent stage creates a new notification, so the banner re-appears as designed — dismissal sticks for the stage where it was made.
- **Audience unchanged:** notifications are created for admins only (single-tenant), matching the existing banner (gated on the admin-only `/api/license`). Suppressed on cloud — the notification task is `MULTI_TENANT`-guarded, so none exist there.
- Banner copy is now server-driven (removes the FE/backend copy duplication).

Backend already creates the notifications (license-expiry Celery task) and exposes the dismiss endpoint, so this is a frontend-only change.

## How Has This Been Tested?

Static only: web `tsgo` 0 errors, oxlint + oxfmt clean. **Not yet exercised live** (needs a self-hosted instance with a license in a warning stage). To verify: as an admin with an active `LICENSE_EXPIRY_WARNING` notification, click the X, then reload / clear localStorage — the banner stays dismissed.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
