### PR TITLE
feat(db): add user language preference column and backend wiring

### DIFF
--- a/backend/alembic/versions/99c855a8f2a1_add_user_language_preference.py
+++ b/backend/alembic/versions/99c855a8f2a1_add_user_language_preference.py
@@ -1,0 +1,33 @@
+"""add user language preference
+
+Revision ID: 99c855a8f2a1
+Revises: f3a9c1d4b7e2
+Create Date: 2026-06-22 15:30:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "99c855a8f2a1"
+down_revision = "f3a9c1d4b7e2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "user",
+        sa.Column(
+            "language",
+            sa.String(),
+            nullable=False,
+            server_default="en",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("user", "language")

--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -239,6 +239,14 @@ class ThemePreference(str, PyEnum):
     SYSTEM = "system"
 
 
+class SupportedLanguage(str, PyEnum):
+    EN = "en"
+    ES = "es"
+    PT = "pt"
+    FR = "fr"
+    DE = "de"
+
+
 class DefaultAppMode(str, PyEnum):
     AUTO = "AUTO"
     CHAT = "CHAT"

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -340,6 +340,12 @@ class User(SQLAlchemyBaseUserTableUUID, Base):
         nullable=True,
         default=None,
     )
+    language: Mapped[str] = mapped_column(
+        String,
+        nullable=False,
+        default="en",
+        server_default="en",
+    )
     chat_background: Mapped[str | None] = mapped_column(String, nullable=True)
     default_app_mode: Mapped[DefaultAppMode] = mapped_column(
         Enum(DefaultAppMode, native_enum=False),

--- a/backend/onyx/db/user_preferences.py
+++ b/backend/onyx/db/user_preferences.py
@@ -214,6 +214,20 @@ def update_user_theme_preference(
     db_session.commit()
 
 
+def update_user_language(
+    user_id: UUID,
+    language: str,
+    db_session: Session,
+) -> None:
+    """Update user's language setting."""
+    db_session.execute(
+        update(User)
+        .where(User.id == user_id)  # ty: ignore[invalid-argument-type]
+        .values(language=language)
+    )
+    db_session.commit()
+
+
 def update_user_chat_background(
     user_id: UUID,
     chat_background: str | None,

--- a/backend/onyx/server/manage/models.py
+++ b/backend/onyx/server/manage/models.py
@@ -14,6 +14,7 @@ from onyx.auth.schemas import UserRole
 from onyx.configs.constants import AuthType
 from onyx.context.search.models import SavedSearchSettings
 from onyx.db.enums import DefaultAppMode
+from onyx.db.enums import SupportedLanguage
 from onyx.db.enums import ThemePreference
 from onyx.db.memory import MAX_MEMORIES_PER_USER
 from onyx.db.models import AllowedAnswerFilters
@@ -80,6 +81,7 @@ class UserPreferences(BaseModel):
     auto_scroll: bool | None = None
     temperature_override_enabled: bool | None = None
     theme_preference: ThemePreference | None = None
+    language: str | None = None
     chat_background: str | None = None
     default_app_mode: DefaultAppMode = DefaultAppMode.CHAT
 
@@ -171,6 +173,7 @@ class UserInfo(BaseModel):
                     auto_scroll=user.auto_scroll,
                     temperature_override_enabled=user.temperature_override_enabled,
                     theme_preference=user.theme_preference,
+                    language=user.language,
                     chat_background=user.chat_background,
                     default_app_mode=user.default_app_mode,
                     paste_as_tile=user.paste_as_tile,
@@ -240,6 +243,10 @@ class AutoScrollRequest(BaseModel):
 
 class ThemePreferenceRequest(BaseModel):
     theme_preference: ThemePreference
+
+
+class LanguageRequest(BaseModel):
+    language: SupportedLanguage
 
 
 class DefaultAppModeRequest(BaseModel):

--- a/backend/onyx/server/manage/users.py
+++ b/backend/onyx/server/manage/users.py
@@ -69,6 +69,7 @@ from onyx.db.user_preferences import update_user_auto_scroll
 from onyx.db.user_preferences import update_user_chat_background
 from onyx.db.user_preferences import update_user_default_app_mode
 from onyx.db.user_preferences import update_user_default_model
+from onyx.db.user_preferences import update_user_language
 from onyx.db.user_preferences import update_user_paste_as_tile
 from onyx.db.user_preferences import update_user_personalization
 from onyx.db.user_preferences import update_user_pinned_assistants
@@ -100,6 +101,7 @@ from onyx.server.manage.models import BulkInviteResponse
 from onyx.server.manage.models import ChatBackgroundRequest
 from onyx.server.manage.models import DefaultAppModeRequest
 from onyx.server.manage.models import EmailInviteStatus
+from onyx.server.manage.models import LanguageRequest
 from onyx.server.manage.models import MemoryItem
 from onyx.server.manage.models import PersonalizationUpdateRequest
 from onyx.server.manage.models import TenantInfo
@@ -1069,6 +1071,15 @@ def update_user_theme_preference_api(
     db_session: Session = Depends(get_session),
 ) -> None:
     update_user_theme_preference(user.id, request.theme_preference, db_session)
+
+
+@router.patch("/user/language")
+def update_user_language_api(
+    request: LanguageRequest,
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> None:
+    update_user_language(user.id, request.language.value, db_session)
 
 
 @router.patch("/user/chat-background")


### PR DESCRIPTION
## Summary

Backend-only slice of #12341 (multi-language translation support). This commits just the **database migration** and the minimal backend wiring to read/update a user's language preference. The frontend i18n pieces (locales, providers, UI) will follow in a separate PR.

Changes:
- **Migration** (`99c855a8f2a1_add_user_language_preference.py`): adds a `language` column to the `user` table — `varchar`, `NOT NULL`, `server_default='en'`. Down-revision is the current head (`f3a9c1d4b7e2`).
- `SupportedLanguage` enum (`en`/`es`/`pt`/`fr`/`de`) in `onyx/db/enums.py`.
- `language` column on the `User` model (kept consistent with the migration).
- `update_user_language` DB helper in `onyx/db/user_preferences.py`.
- `language` field on `UserPreferences` + `LanguageRequest` model in `onyx/server/manage/models.py`.
- `PATCH /user/language` endpoint in `onyx/server/manage/users.py`.

## Testing

- `alembic upgrade head` / `alembic downgrade -1` cycle verified — column is added and dropped cleanly; resulting column is `varchar NOT NULL DEFAULT 'en'`.
- `pre-commit` (ruff, ruff format, ty) passes on all changed files.

Credit to @Yoko-0x0 for the original work in #12341.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a user language preference to the database and a backend endpoint to update it, laying groundwork for multi-language support. Default is 'en' with support for en, es, pt, fr, and de.

- **New Features**
  - Alembic migration: add `language` `varchar NOT NULL DEFAULT 'en'` to `user`.
  - `SupportedLanguage` enum: `en`, `es`, `pt`, `fr`, `de`.
  - `User` model gains `language` with default `'en'`.
  - DB helper: `update_user_language(user_id, language)`.
  - API models: `UserPreferences.language`, `LanguageRequest`.
  - Endpoint: PATCH `/user/language` to set the current user’s language.

<sup>Written for commit 08c0b733ab9fb1760c662f8020402918b135e6dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

