### PR TITLE
feat(celery): add clear_revoked control command to wipe the revoked-task set fleet-wide

### DIFF
--- a/backend/onyx/background/celery/apps/app_base.py
+++ b/backend/onyx/background/celery/apps/app_base.py
@@ -16,6 +16,7 @@ from celery.signals import task_prerun
 from celery.states import READY_STATES
 from celery.utils.log import get_task_logger
 from celery.worker import strategy  # ty: ignore[unresolved-import]
+from celery.worker.control import control_command  # ty: ignore[unresolved-import]
 from redis.lock import Lock as RedisLock
 from sentry_sdk.integrations.celery import CeleryIntegration
 from sqlalchemy import text
@@ -74,6 +75,23 @@ if SENTRY_DSN:
     )
 else:
     logger.debug("Sentry DSN not provided, skipping Sentry initialization")
+
+
+@control_command()
+def clear_revoked(state: Any, **kwargs: Any) -> dict[str, Any]:  # noqa: ARG001
+    """Remote command to wipe this worker's in-memory revoked-task set.
+
+    The set lives only in memory, propagates between workers via mingle, and its
+    cross-node entries don't expire — so after a mass-revoke it can pin at its 50k
+    cap and won't self-heal or clear on a rolling restart. Broadcast this to clear
+    the fleet without restarting. Deliberate use only: revoked state is dropped.
+    """
+    from celery.worker import state as worker_state  # ty: ignore[unresolved-import]
+
+    count = len(worker_state.revoked)
+    worker_state.revoked.clear()
+    task_logger.warning("clear_revoked: cleared %d revoked task ids", count)
+    return {"ok": f"cleared {count} revoked task ids"}
 
 
 class TenantAwareTask(Task):

--- a/backend/onyx/background/celery/apps/app_base.py
+++ b/backend/onyx/background/celery/apps/app_base.py
@@ -85,6 +85,9 @@ def clear_revoked(state: Any, **kwargs: Any) -> dict[str, Any]:  # noqa: ARG001
     cross-node entries don't expire — so after a mass-revoke it can pin at its 50k
     cap and won't self-heal or clear on a rolling restart. Broadcast this to clear
     the fleet without restarting. Deliberate use only: revoked state is dropped.
+
+    Intentionally ungated, like Celery's built-in shutdown/terminate/revoke control
+    commands: the trust boundary is broker access, not a per-command check.
     """
     from celery.worker import state as worker_state  # ty: ignore[unresolved-import]
 


### PR DESCRIPTION
## Description

Adds a `clear_revoked` Celery remote-control command that wipes a worker's in-memory revoked-task set. Broadcasting it clears the whole fleet at once, with **no restart**.

**How we got here:** Celery keeps a per-worker, in-memory set of revoked task IDs, capped at 50k. A runaway connector prune (fixed in #12410) flooded the `connector_deletion` queue and produced a burst of task revocations that pinned this set at its 50k cap on every worker. Two properties make it stick:
- It propagates worker-to-worker via Celery `mingle`, so a rolling restart/redeploy just re-seeds the new pods from the old ones.
- Its entries are timestamped with per-node `time.monotonic()`, which isn't comparable across nodes, so Celery's `purge()` can't expire them — it never self-heals.

Each `mingle` hello-reply carries this ~7 MB set, which OOMs the 4 GiB monitoring worker on every startup → crash loop.

**Why a command:** the set is in memory (no Redis key to delete) and Celery has no built-in clear. Usage, once-off after deploy: `app.control.broadcast("clear_revoked")`. Deliberate op only — revoked state is dropped, so a task revoked just before could still run.

## How Has This Been Tested?

- `ruff format --check`, `ruff check`, `ty check` pass.
- Verified the command registers in Celery's control Panel on import (`clear_revoked in Panel.meta == True`).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check