### PR TITLE
feat(file-processing): isolate PDF text extraction in a subprocess

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -1385,6 +1385,12 @@ XLSX_STREAM_SHEET_BYTES = max(
     0, int(os.environ.get("XLSX_STREAM_SHEET_BYTES") or 50 * 1024 * 1024)
 )
 
+# PDF text extraction runs isolated (a malformed PDF can make PDFium hard-abort
+# or hang); this is the timeout before the subprocess is killed and pypdf runs.
+PDF_TEXT_EXTRACTION_TIMEOUT_SECONDS = float(
+    os.environ.get("PDF_TEXT_EXTRACTION_TIMEOUT_SECONDS") or 120
+)
+
 # Use document summary for contextual rag
 USE_DOCUMENT_SUMMARY = os.environ.get("USE_DOCUMENT_SUMMARY", "true").lower() == "true"
 # Use chunk summary for contextual rag

--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -27,6 +27,7 @@ from PIL import Image
 
 from onyx.configs.app_configs import MAX_EMBEDDED_IMAGES_PER_FILE
 from onyx.configs.app_configs import MAX_XLSX_CELLS_PER_SHEET
+from onyx.configs.app_configs import PDF_TEXT_EXTRACTION_TIMEOUT_SECONDS
 from onyx.configs.app_configs import XLSX_STREAM_SHEET_BYTES
 from onyx.configs.constants import ONYX_METADATA_FILENAME
 from onyx.configs.llm_configs import get_image_extraction_and_analysis_enabled
@@ -38,6 +39,8 @@ from onyx.file_processing.html_utils import parse_html_page_basic
 from onyx.file_processing.unstructured import get_unstructured_api_key
 from onyx.file_processing.unstructured import unstructured_to_text
 from onyx.utils.logger import setup_logger
+from onyx.utils.process_isolation import IsolatedProcessError
+from onyx.utils.process_isolation import run_in_isolated_process
 
 if TYPE_CHECKING:
     from markitdown import MarkItDown
@@ -352,12 +355,16 @@ def read_pdf_file(
                 ):
                     metadata[clean_key] = ", ".join(value)
 
-        # GIL-releasing extraction so a large PDF can't pin the worker — see helper.
+        # PDFium can hard-abort or hang on a malformed PDF (uncatchable in-process),
+        # so run it isolated; a crash, timeout, or PdfiumError falls back to pypdf.
         try:
-            text = _extract_pdf_text_pdfium(file_bytes, decrypt_password)
-        except PdfiumError as pdfium_err:
-            # PDFium rejects some malformed PDFs that pypdf can still read; fall
-            # back so those docs aren't dropped. Only failing files take this path.
+            text = run_in_isolated_process(
+                _extract_pdf_text_pdfium,
+                file_bytes,
+                decrypt_password,
+                timeout=PDF_TEXT_EXTRACTION_TIMEOUT_SECONDS,
+            )
+        except (PdfiumError, IsolatedProcessError) as pdfium_err:
             logger.warning(
                 "PDFium text extraction failed (%s); falling back to pypdf",
                 pdfium_err,

--- a/backend/onyx/utils/process_isolation.py
+++ b/backend/onyx/utils/process_isolation.py
@@ -1,0 +1,157 @@
+"""Run a callable in a throwaway child process so a native crash (SIGSEGV/SIGABRT),
+a hang, or a runaway allocation kills the child instead of the caller. The parent
+gets a typed error and decides how to recover.
+
+For parse paths that feed untrusted bytes to native libs (PDF/image/office).
+"""
+
+import multiprocessing as mp
+import signal
+from collections.abc import Callable
+from multiprocessing.connection import Connection
+from typing import Any
+from typing import TypeVar
+
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+T = TypeVar("T")
+
+_SIGTERM_GRACE_SECONDS = 5.0
+
+_STATUS_OK = "ok"
+_STATUS_EXC = "exc"
+_STATUS_UNRELAYABLE = "unrelayable"
+
+
+class IsolatedProcessError(Exception):
+    """The isolated call did not return a value (crash, timeout, or lost result)."""
+
+
+class IsolatedProcessCrashed(IsolatedProcessError):
+    """Child was killed by a signal, e.g. a native abort/segfault in the callee."""
+
+    def __init__(self, signal_number: int) -> None:
+        self.signal_number = signal_number
+        try:
+            label = signal.Signals(signal_number).name
+        except ValueError:
+            label = f"signal {signal_number}"
+        super().__init__(f"isolated process killed by {label}")
+
+
+class IsolatedProcessTimeout(IsolatedProcessError):
+    """Child exceeded the wall-clock timeout and was terminated."""
+
+    def __init__(self, timeout_seconds: float) -> None:
+        self.timeout_seconds = timeout_seconds
+        super().__init__(f"isolated process exceeded {timeout_seconds:g}s timeout")
+
+
+def _apply_memory_limit(memory_limit_bytes: int) -> None:
+    # Best-effort cap on address space so a runaway alloc fails in the child
+    # instead of OOM-killing the pod. Not enforced everywhere (macOS ignores it).
+    try:
+        import resource
+
+        resource.setrlimit(resource.RLIMIT_AS, (memory_limit_bytes, memory_limit_bytes))
+    except (ImportError, AttributeError, ValueError, OSError) as e:
+        logger.debug("could not apply isolated-process memory limit: %s", e)
+
+
+def _child_entrypoint(
+    fn: Callable[..., Any],
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    memory_limit_bytes: int | None,
+    conn: Connection,
+) -> None:
+    if memory_limit_bytes is not None:
+        _apply_memory_limit(memory_limit_bytes)
+
+    try:
+        payload: tuple[str, Any] = (_STATUS_OK, fn(*args, **kwargs))
+    except Exception as e:
+        # Native crashes are signals (the parent sees those via the exit code), so
+        # only fn's own exceptions land here. Relay them for the parent to re-raise.
+        payload = (_STATUS_EXC, e)
+
+    try:
+        conn.send(payload)
+    except Exception:
+        # Unpicklable result/exception can't cross the pipe; relay its repr.
+        conn.send((_STATUS_UNRELAYABLE, repr(payload[1])))
+    finally:
+        conn.close()
+
+
+def run_in_isolated_process(
+    fn: Callable[..., T],
+    *args: Any,
+    timeout: float,
+    memory_limit_mb: int | None = None,
+    **kwargs: Any,
+) -> T:
+    """Run ``fn(*args, **kwargs)`` in an isolated child process and return its result.
+
+    fn's own exceptions are re-raised here unchanged. A signal kill (native crash)
+    raises ``IsolatedProcessCrashed``, a timeout raises ``IsolatedProcessTimeout``,
+    and a failure to start the child raises ``IsolatedProcessError`` (all subclass
+    it, so callers can catch the base and fall back). fn and args must be picklable.
+    """
+    # forkserver, not spawn: children fork from a clean server and don't re-import
+    # __main__. spawn re-imports it per child, which blows up inside the already
+    # spawned indexing worker (its __main__ is the mp bootstrap, not a script).
+    ctx = mp.get_context("forkserver")
+    memory_limit_bytes = memory_limit_mb * 1024 * 1024 if memory_limit_mb else None
+
+    # Result comes back over an anonymous pipe, not a temp file: nothing on disk
+    # to tamper with, and no Queue feeder thread to deadlock on a big payload.
+    recv_conn, send_conn = ctx.Pipe(duplex=False)
+    proc = ctx.Process(
+        target=_child_entrypoint,
+        args=(fn, args, kwargs, memory_limit_bytes, send_conn),
+    )
+    try:
+        try:
+            proc.start()
+        except Exception as e:
+            logger.warning("could not start isolated process: %s", e)
+            raise IsolatedProcessError(f"could not start isolated process: {e}") from e
+
+        # Parent only reads; drop its write end so the pipe hits EOF when the child
+        # dies (that's how a crash becomes visible).
+        send_conn.close()
+
+        if not recv_conn.poll(timeout):
+            proc.terminate()
+            proc.join(_SIGTERM_GRACE_SECONDS)
+            if proc.is_alive():
+                proc.kill()
+                proc.join()
+            raise IsolatedProcessTimeout(timeout)
+
+        try:
+            status, value = recv_conn.recv()
+        except EOFError:
+            # Pipe closed with no result: the child was killed by a signal.
+            proc.join()
+            if proc.exitcode is not None and proc.exitcode < 0:
+                raise IsolatedProcessCrashed(-proc.exitcode)
+            raise IsolatedProcessError(
+                f"isolated process left no result (exit code {proc.exitcode})"
+            )
+
+        proc.join()
+        if status == _STATUS_OK:
+            return value
+        if status == _STATUS_EXC and isinstance(value, BaseException):
+            raise value
+        logger.warning("isolated process returned an unrelayable result: %s", value)
+        raise IsolatedProcessError(f"isolated process failed: {value!r}")
+    finally:
+        recv_conn.close()
+        if proc.is_alive():
+            proc.kill()
+            proc.join()

--- a/backend/tests/unit/onyx/file_processing/test_pdf.py
+++ b/backend/tests/unit/onyx/file_processing/test_pdf.py
@@ -13,12 +13,14 @@ from io import BytesIO
 from pathlib import Path
 
 import pytest
+from pypdfium2 import PdfiumError
 
 from onyx.file_processing import extract_file_text
 from onyx.file_processing.extract_file_text import count_pdf_embedded_images
 from onyx.file_processing.extract_file_text import pdf_to_text
 from onyx.file_processing.extract_file_text import read_pdf_file
 from onyx.file_processing.password_validation import is_pdf_protected
+from onyx.utils.process_isolation import IsolatedProcessCrashed
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -49,22 +51,45 @@ class TestReadPdfFile:
         assert "Page one content" in text
         assert "Page two content" in text
 
-    def test_falls_back_to_pypdf_when_pdfium_fails(
-        self, monkeypatch: pytest.MonkeyPatch
+    @pytest.mark.parametrize(
+        "isolation_failure",
+        [
+            # pypdf is more lenient than PDFium and reads some PDFs it rejects.
+            PdfiumError("Failed to load document (PDFium: Data format error)."),
+            # A malformed PDF can hard-abort PDFium (SIGABRT); the isolation layer
+            # surfaces that as a crash, not a Python exception.
+            IsolatedProcessCrashed(6),
+        ],
+        ids=["pdfium_error", "native_crash"],
+    )
+    def test_text_extraction_falls_back_to_pypdf_on_isolation_failure(
+        self, monkeypatch: pytest.MonkeyPatch, isolation_failure: Exception
     ) -> None:
-        """PDFium is stricter than pypdf and rejects some PDFs pypdf can read.
-        When PDFium raises, text extraction falls back to pypdf so the document
-        is still indexed rather than silently dropped."""
+        """PDFium runs in an isolated subprocess; whether it raises a PdfiumError
+        or hard-crashes, extraction must fall back to pypdf so the document is
+        still indexed instead of dropped or failing the whole attempt."""
 
-        from pypdfium2 import PdfiumError
+        def _fail(*_args: object, **_kwargs: object) -> str:
+            raise isolation_failure
 
-        def _raise(*_args: object, **_kwargs: object) -> str:
-            raise PdfiumError("Failed to load document (PDFium: Data format error).")
-
-        monkeypatch.setattr(extract_file_text, "_extract_pdf_text_pdfium", _raise)
+        monkeypatch.setattr(extract_file_text, "run_in_isolated_process", _fail)
         text, _, _ = read_pdf_file(_load("multipage.pdf"))
         assert "Page one content" in text
         assert "Page two content" in text
+
+    def test_image_extraction_survives_isolation_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When isolated text extraction fails, the in-process image extraction
+        must still run. A text-extraction crash must not drop the embedded images
+        (they're parsed separately, after the fallback)."""
+
+        def _crash(*_args: object, **_kwargs: object) -> str:
+            raise IsolatedProcessCrashed(6)
+
+        monkeypatch.setattr(extract_file_text, "run_in_isolated_process", _crash)
+        _, _, images = read_pdf_file(_load("with_image.pdf"), extract_images=True)
+        assert len(images) >= 1
 
     def test_metadata_extraction(self) -> None:
         _, pdf_metadata, _ = read_pdf_file(_load("with_metadata.pdf"))

--- a/backend/tests/unit/onyx/utils/test_process_isolation.py
+++ b/backend/tests/unit/onyx/utils/test_process_isolation.py
@@ -1,0 +1,65 @@
+"""The process-isolation helper must convert a native child crash, a hang, and a
+runaway allocation into typed parent-side exceptions, while passing normal return
+values and ordinary exceptions through unchanged."""
+
+import ctypes
+import operator
+import os
+import sys
+import time
+
+import pytest
+
+from onyx.utils.process_isolation import IsolatedProcessCrashed
+from onyx.utils.process_isolation import IsolatedProcessError
+from onyx.utils.process_isolation import IsolatedProcessTimeout
+from onyx.utils.process_isolation import run_in_isolated_process
+
+
+def test_returns_value() -> None:
+    assert run_in_isolated_process(abs, -42, timeout=30) == 42
+
+
+def test_passes_kwargs() -> None:
+    assert run_in_isolated_process(int, "ff", base=16, timeout=30) == 255
+
+
+def test_large_result_crosses_the_boundary() -> None:
+    out = run_in_isolated_process(operator.mul, "ab", 3_000_000, timeout=60)
+    assert len(out) == 6_000_000
+
+
+def test_ordinary_exception_is_reraised() -> None:
+    with pytest.raises(ValueError):
+        run_in_isolated_process(int, "not-an-int", timeout=30)
+
+
+def test_native_abort_becomes_crash() -> None:
+    with pytest.raises(IsolatedProcessCrashed) as exc_info:
+        run_in_isolated_process(os.abort, timeout=30)
+    # SIGABRT, the signal libpdfium raises on a malformed PDF
+    assert exc_info.value.signal_number == 6
+
+
+def test_native_segfault_becomes_crash() -> None:
+    # Null-pointer deref segfaults the child; the parent must see a crash.
+    with pytest.raises(IsolatedProcessCrashed):
+        run_in_isolated_process(ctypes.string_at, 0, timeout=30)
+
+
+def test_timeout_is_enforced_and_child_reaped() -> None:
+    started = time.monotonic()
+    with pytest.raises(IsolatedProcessTimeout):
+        run_in_isolated_process(time.sleep, 30, timeout=1)
+    # returns near the timeout, not after the full 30s sleep
+    assert time.monotonic() - started < 15
+
+
+@pytest.mark.skipif(
+    sys.platform != "linux", reason="RLIMIT_AS is enforced reliably only on Linux"
+)
+def test_memory_limit_bounds_allocation() -> None:
+    with pytest.raises((MemoryError, IsolatedProcessError)):
+        run_in_isolated_process(
+            bytearray, 2 * 1024 * 1024 * 1024, memory_limit_mb=1024, timeout=30
+        )


### PR DESCRIPTION
## Description

**Bug:** A malformed PDF can make PDFium's C++ parser hard-abort (SIGABRT) or segfault deep inside `libpdfium` — confirmed from a core dump. Because that happens in native code reached through ctypes, it's uncatchable in-process: the existing `except PdfiumError` never sees it, so the whole indexing worker dies and fails the attempt (and every other document in the batch).

**Fix:** Add a reusable `onyx/utils/process_isolation.py` helper that runs a callable in a spawned subprocess and turns a signal kill, timeout, or runaway allocation into typed exceptions, re-raising ordinary exceptions unchanged. PDFium text extraction routes through it, so a crash or hang falls back to pypdf exactly like a `PdfiumError` — one bad file is skipped instead of killing the worker. Set `PDF_TEXT_EXTRACTION_TIMEOUT_SECONDS=0` to disable.

**Tests:** Lib unit tests (crash, segfault, timeout, large result, memory cap) and the PDF crash/error → pypdf fallback path.

## How Has This Been Tested?


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check