### PR TITLE
fix(craft-cli): point image command at generic /image-generation/generate

### DIFF
--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -152,12 +152,12 @@ func (c *Client) Search(ctx context.Context, req models.SearchRequest) (*models.
 	return &resp, nil
 }
 
-// GenerateImage calls POST /build/image-generation/generate, which generates
+// GenerateImage calls POST /image-generation/generate, which generates
 // image(s) using the workspace's default image-gen provider. Uses the 5min
 // client since high-res generation can be slow.
 func (c *Client) GenerateImage(ctx context.Context, req models.ImageGenerationRequest) (*models.ImageGenerationResponse, error) {
 	var resp models.ImageGenerationResponse
-	if err := c.doJSONWith(ctx, c.streamingHTTPClient, "POST", "/build/image-generation/generate", req, &resp); err != nil {
+	if err := c.doJSONWith(ctx, c.streamingHTTPClient, "POST", "/image-generation/generate", req, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil

--- a/cli/internal/api/image_test.go
+++ b/cli/internal/api/image_test.go
@@ -17,8 +17,8 @@ func TestGenerateImage_Success(t *testing.T) {
 		if r.Method != "POST" {
 			t.Errorf("method = %s, want POST", r.Method)
 		}
-		if !strings.HasSuffix(r.URL.Path, "/build/image-generation/generate") {
-			t.Errorf("path = %s, want .../build/image-generation/generate", r.URL.Path)
+		if !strings.HasSuffix(r.URL.Path, "/image-generation/generate") {
+			t.Errorf("path = %s, want .../image-generation/generate", r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{


### PR DESCRIPTION
## Description

Follow-up to #12493: the backend image-generation endpoint is being moved out of `/build` to a generic `/image-generation/generate` path (it's not Craft-specific and is now callable by any authenticated onyx-cli user, not just sandboxes — see the API PR). This updates `Client.GenerateImage` to call the new path.

Requires a new onyx-cli release (**v1.2.1**); the sandbox pin (in the sandbox-deps PR) will bump to 1.2.1. v1.2.0 was never deployed, so there's no breakage from the path change.

## How Has This Been Tested?

`go build ./...`, `gofmt`, and `go test ./internal/api/...` pass (the httptest case asserts the new path).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch image generation to POST /image-generation/generate (replacing /build/image-generation/generate) to match the backend change and allow use by all authenticated users. Updated the test to assert the new path.

- **Dependencies**
  - Requires `onyx-cli` v1.2.1.

<sup>Written for commit 9f73ea25765a5680f698cd02dbbd50ebc746045b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

