### PR TITLE
fix(auth): restrict connector read endpoints to curator/admin (ENG-4249)

### DIFF
--- a/backend/onyx/server/documents/connector.py
+++ b/backend/onyx/server/documents/connector.py
@@ -1899,7 +1899,7 @@ def google_drive_callback(
 
 @router.get("/connector", tags=PUBLIC_API_TAGS)
 def get_connectors(
-    _: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    _: User = Depends(current_curator_or_admin_user),
     db_session: Session = Depends(get_session),
 ) -> list[ConnectorSnapshot]:
     connectors = fetch_connectors(db_session)
@@ -1926,7 +1926,7 @@ def get_indexed_sources(
 @router.get("/connector/{connector_id}", tags=PUBLIC_API_TAGS)
 def get_connector_by_id(
     connector_id: int,
-    _: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    _: User = Depends(current_curator_or_admin_user),
     db_session: Session = Depends(get_session),
 ) -> ConnectorSnapshot | StatusResponse[int]:
     connector = fetch_connector_by_id(connector_id, db_session)

--- a/backend/tests/integration/tests/permissions/test_connector_read_access.py
+++ b/backend/tests/integration/tests/permissions/test_connector_read_access.py
@@ -1,10 +1,11 @@
-"""Integration tests for BASIC_ACCESS permission gate.
+"""Integration tests for the curator-or-admin gate on connector read endpoints.
 
-Verifies that endpoints protected by ``require_permission(Permission.BASIC_ACCESS)``
-allow admin and basic users but reject limited service accounts, bot users,
-external-permission users, and anonymous (unauthenticated) client.
-
-Each endpoint is tested with all six user types via parameterization.
+``GET /manage/connector`` (list) and ``GET /manage/connector/{id}`` (by-id) return
+full ``ConnectorSnapshot``s including ``connector_specific_config`` and
+``credential_ids``. They must be restricted to curator/admin users
+(pentest M8 / ENG-4249); basic users, limited service accounts, bot users,
+external-permission users, and anonymous clients must be denied. Curator access
+is covered in ``test_connector_permissions.py``.
 """
 
 import pytest
@@ -14,34 +15,23 @@ from tests.integration.common_utils.http_client import client
 from tests.integration.common_utils.test_models import DATestAPIKey
 from tests.integration.common_utils.test_models import DATestUser
 
-# Representative endpoints that use require_permission(Permission.BASIC_ACCESS).
-# One per major router file to cover breadth without redundancy.
-# Chat endpoints are gated by READ_CHAT/WRITE_CHAT (not BASIC_ACCESS) and are
-# covered by test_chat_scopes.py.
-BASIC_ACCESS_ENDPOINTS: list[tuple[str, str]] = [
-    ("GET", "/manage/credential"),
-    ("GET", "/users"),
-    ("GET", "/settings"),
-    ("GET", "/query/valid-tags"),
-    ("GET", "/input_prompt"),
-    ("GET", "/notifications"),
-    ("GET", "/search-settings/get-all-search-settings"),
-    ("GET", "/user/pats"),
+# Connector read endpoints gated on current_curator_or_admin_user.
+# The by-id path targets a non-existent id on purpose: the auth dependency runs
+# before the handler, so denied users get 403 while an admin gets 404 -- both
+# outcomes confirm the auth gate behaved correctly.
+CONNECTOR_READ_ENDPOINTS: list[tuple[str, str]] = [
+    ("GET", "/manage/connector"),
+    ("GET", "/manage/connector/1"),
 ]
 
 
-# ------------------------------------------------------------------
-# Allowed users: admin and basic
-# ------------------------------------------------------------------
-
-
-@pytest.mark.parametrize("method,path", BASIC_ACCESS_ENDPOINTS)
+@pytest.mark.parametrize("method,path", CONNECTOR_READ_ENDPOINTS)
 def test_admin_user_allowed(
     method: str,
     path: str,
     permission_admin_user: DATestUser,
 ) -> None:
-    """Admin users should be able to access BASIC_ACCESS endpoints."""
+    """Admin users pass the curator-or-admin gate (200 for list, 404 for missing id)."""
     resp = client.request(
         method,
         f"{API_SERVER_URL}{path}",
@@ -49,18 +39,18 @@ def test_admin_user_allowed(
         cookies=permission_admin_user.cookies,
         timeout=30,
     )
-    assert resp.status_code < 400, (
-        f"Admin should access {method} {path}, got {resp.status_code}"
+    assert resp.status_code not in (401, 403), (
+        f"Admin should pass auth on {method} {path}, got {resp.status_code}"
     )
 
 
-@pytest.mark.parametrize("method,path", BASIC_ACCESS_ENDPOINTS)
-def test_basic_user_allowed(
+@pytest.mark.parametrize("method,path", CONNECTOR_READ_ENDPOINTS)
+def test_basic_user_denied(
     method: str,
     path: str,
     permission_basic_user: DATestUser,
 ) -> None:
-    """Basic users should be able to access BASIC_ACCESS endpoints."""
+    """Basic users must NOT read connector config/credential ids."""
     resp = client.request(
         method,
         f"{API_SERVER_URL}{path}",
@@ -68,23 +58,18 @@ def test_basic_user_allowed(
         cookies=permission_basic_user.cookies,
         timeout=30,
     )
-    assert resp.status_code < 400, (
-        f"Basic user should access {method} {path}, got {resp.status_code}"
+    assert resp.status_code == 403, (
+        f"Basic user should be denied on {method} {path}, got {resp.status_code}"
     )
 
 
-# ------------------------------------------------------------------
-# Denied users: limited service account, bot, ext_perm, anonymous
-# ------------------------------------------------------------------
-
-
-@pytest.mark.parametrize("method,path", BASIC_ACCESS_ENDPOINTS)
+@pytest.mark.parametrize("method,path", CONNECTOR_READ_ENDPOINTS)
 def test_limited_service_account_denied(
     method: str,
     path: str,
     limited_service_account: DATestAPIKey,
 ) -> None:
-    """Limited service accounts (no BASIC_ACCESS) should be denied."""
+    """Limited service accounts (no curator/admin role) should be denied."""
     resp = client.request(
         method,
         f"{API_SERVER_URL}{path}",
@@ -97,13 +82,13 @@ def test_limited_service_account_denied(
     )
 
 
-@pytest.mark.parametrize("method,path", BASIC_ACCESS_ENDPOINTS)
+@pytest.mark.parametrize("method,path", CONNECTOR_READ_ENDPOINTS)
 def test_bot_user_denied(
     method: str,
     path: str,
     bot_user_headers: dict[str, str],
 ) -> None:
-    """Bot (SLACK_USER) accounts should be denied from BASIC_ACCESS endpoints."""
+    """Bot (SLACK_USER) accounts should be denied."""
     resp = client.request(
         method,
         f"{API_SERVER_URL}{path}",
@@ -115,13 +100,13 @@ def test_bot_user_denied(
     )
 
 
-@pytest.mark.parametrize("method,path", BASIC_ACCESS_ENDPOINTS)
+@pytest.mark.parametrize("method,path", CONNECTOR_READ_ENDPOINTS)
 def test_ext_perm_user_denied(
     method: str,
     path: str,
     ext_perm_user_headers: dict[str, str],
 ) -> None:
-    """External permission users should be denied from BASIC_ACCESS endpoints."""
+    """External permission users should be denied."""
     resp = client.request(
         method,
         f"{API_SERVER_URL}{path}",
@@ -133,7 +118,7 @@ def test_ext_perm_user_denied(
     )
 
 
-@pytest.mark.parametrize("method,path", BASIC_ACCESS_ENDPOINTS)
+@pytest.mark.parametrize("method,path", CONNECTOR_READ_ENDPOINTS)
 def test_anonymous_denied(
     method: str,
     path: str,


### PR DESCRIPTION
## Description

`GET /manage/connector` (list) and `GET /manage/connector/{connector_id}` (by-id) were gated only on `BASIC_ACCESS`, returning the full `ConnectorSnapshot` — including `connector_specific_config` (internal URLs, JQL queries, paths) and `credential_ids` — to **any** authenticated user. Unlike the credential endpoints (which filter per-user via `fetch_credentials_for_user`), these have no per-object ownership filter, so a basic user could read the entire deployment's connector configuration.

Fix: raise both endpoints to `current_curator_or_admin_user`, matching the already-secured sibling `GET /manage/admin/connector`.

**Blast radius (verified, no real workflow breaks):**
- Curator access is preserved (curator-or-admin gate); covered by `test_connector_permissions.py`.
- The only live frontend consumer is the **admin-only** Document Explorer page, which reads `connector.source` only — admins pass the gate. The other two frontend references are dead/unused.
- No backend internal callers.
- Basic-role API keys lose access to these (`PUBLIC_API_TAGS`) endpoints — the intended security outcome; curator/admin keys still work.

## How Has This Been Tested?

- Added `tests/integration/tests/permissions/test_connector_read_access.py`: admin passes the gate; basic users, limited service accounts, bot users, external-permission users, and anonymous clients are denied (403/401) on both list and by-id.
- Removed `("GET", "/manage/connector")` from the `BASIC_ACCESS_ENDPOINTS` allowlist in `test_basic_access.py` (basic users are no longer permitted).
- `ty`, `ruff`, and `ruff format` pass on all changed files.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts GET /manage/connector and GET /manage/connector/{id} to curator/admin to prevent basic users from seeing full connector configs and credential IDs. Aligns with ENG-4249 (Sportradar M8) and matches the existing /manage/admin/connector gate.

- **Bug Fixes**
  - Gate both endpoints with `current_curator_or_admin_user`.
  - Remove `("GET", "/manage/connector")` from the basic-access allowlist test.
  - Add integration tests: admin allowed; basic users, limited service accounts, bot users, external-permission users, and anonymous clients denied.

- **Migration**
  - If any scripts use basic-role API keys for these endpoints, switch to curator/admin keys.

<sup>Written for commit 74ec3a16b451cbde20096b6b4aff275499ae5a61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

