### PR TITLE
chore(deps): upgrade uv 0.9.9 -> 0.11.25 and digest-pin the image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -54,7 +54,7 @@ RUN ln -sf "$(which fdfind)" /usr/local/bin/fd
 # daily dev uses their own .venv. The apt block above includes the
 # system libraries `uv sync` needs to compile native extensions
 # (cmake, libxmlsec1-dev, pkg-config, postgresql-client).
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.25@sha256:1e3808aa9023d0980e7c15b1fa7c1ac16ff35925780cf5c459858b2d693f01a9 /uv /uvx /usr/local/bin/
 
 # Install prek (https://github.com/j178/prek) — a fast Rust reimplementation of
 # pre-commit and a drop-in replacement for it. Symlinked to `pre-commit` so the

--- a/.github/actions/setup-python-and-install-dependencies/action.yml
+++ b/.github/actions/setup-python-and-install-dependencies/action.yml
@@ -53,7 +53,7 @@ runs:
     - name: Setup uv
       uses: astral-sh/setup-uv@ed21f2f24f8dd64503750218de024bcf64c7250a # ratchet:astral-sh/setup-uv@v7
       with:
-        version: "0.9.9"
+        version: "0.11.25"
       # TODO: Enable caching once there is a uv.lock file checked in.
       # with:
       #   enable-cache: true

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # ratchet:astral-sh/setup-uv@v8.2.0
         with:
-          version: "0.9.9"
+          version: "0.11.25"
           enable-cache: false
 
       - name: Configure AWS credentials

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # ratchet:astral-sh/setup-uv@v8.2.0
         with:
-          version: "0.9.9"
+          version: "0.11.25"
           enable-cache: false
 
       - name: Check which components to build and version info
@@ -171,7 +171,7 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # ratchet:astral-sh/setup-uv@v8.2.0
         with:
-          version: "0.9.9"
+          version: "0.11.25"
           enable-cache: false
 
       - name: Configure AWS credentials
@@ -200,7 +200,7 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # ratchet:astral-sh/setup-uv@v8.2.0
         with:
-          version: "0.9.9"
+          version: "0.11.25"
           # NOTE: This isn't caching much and zizmor suggests this could be poisoned, so disable.
           enable-cache: false
 

--- a/.github/workflows/post-merge-beta-cherry-pick.yml
+++ b/.github/workflows/post-merge-beta-cherry-pick.yml
@@ -158,7 +158,7 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
         with:
           enable-cache: false
-          version: "0.9.9"
+          version: "0.11.25"
 
       - name: Configure git identity as App
         env:

--- a/.github/workflows/pr-helm-chart-testing.yml
+++ b/.github/workflows/pr-helm-chart-testing.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up chart-testing
         uses: helm/chart-testing-action@2e2940618cb426dce2999631d543b53cdcfc8527
         with:
-          uv_version: "0.9.9"
+          uv_version: "0.11.25"
 
       # even though we specify chart-dirs in ct.yaml, it isn't used by ct for the list-changed command...
       - name: Run chart-testing (list-changed)

--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -855,7 +855,7 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # ratchet:astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: false
-          version: "0.9.9"
+          version: "0.11.25"
 
       - name: Determine baseline revision
         id: baseline-rev

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # ratchet:astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: false
-          version: "0.9.9"
+          version: "0.11.25"
       - run: |
           GOOS=linux GOARCH=amd64 CGO_ENABLED=0 uv build --wheel
           GOOS=linux GOARCH=amd64 CGO_ENABLED=0 ONYX_CLI_REUSE_BINARY=1 \

--- a/.github/workflows/release-devtools.yml
+++ b/.github/workflows/release-devtools.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # ratchet:astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: false
-          version: "0.9.9"
+          version: "0.11.25"
       - run: |
           GOOS="${{ matrix.os-arch.goos }}" \
           GOARCH="${{ matrix.os-arch.goarch }}" \

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -28,7 +28,7 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # ratchet:astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: false
-          version: "0.9.9"
+          version: "0.11.25"
 
       - name: Install zizmor from uv.lock
         run: uv sync --frozen --no-install-project --only-group zizmor

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -11,7 +11,7 @@
 ARG BASE_IMAGE_REGISTRY=docker.io
 FROM ${BASE_IMAGE_REGISTRY}/library/python:3.13-slim@sha256:b04b5d7233d2ad9c379e22ea8927cd1378cd15c60d4ef876c065b25ea8fb3bf3 AS builder
 
-COPY --from=ghcr.io/astral-sh/uv:0.9.9 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.25@sha256:1e3808aa9023d0980e7c15b1fa7c1ac16ff35925780cf5c459858b2d693f01a9 /uv /uvx /bin/
 
 # System dependencies for compiling the Python wheels.
 # cmake/libxmlsec1-dev/pkg-config/gcc needed to compile native wheels (e.g. xmlsec)

--- a/backend/Dockerfile.model_server
+++ b/backend/Dockerfile.model_server
@@ -9,7 +9,7 @@ FROM ${BASE_IMAGE_REGISTRY}/library/python:3.13-slim@sha256:b04b5d7233d2ad9c379e
 ENV ONYX_RUNNING_IN_DOCKER="true" \
     HF_HOME=/app/.cache/huggingface
 
-COPY --from=ghcr.io/astral-sh/uv:0.9.9 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.25@sha256:1e3808aa9023d0980e7c15b1fa7c1ac16ff35925780cf5c459858b2d693f01a9 /uv /uvx /bin/
 
 RUN mkdir -p /app/.cache/huggingface
 


### PR DESCRIPTION
## What

Upgrades `uv` from `0.9.9` to `0.11.25` (latest release) everywhere it's pinned, and converts the Docker image references from tag-only to **tag + digest** pins.

## Changes

**Digest-pinned Docker images** (`ghcr.io/astral-sh/uv:0.11.25@sha256:1e3808aa9023d0980e7c15b1fa7c1ac16ff35925780cf5c459858b2d693f01a9`):
- `backend/Dockerfile`
- `backend/Dockerfile.model_server`
- `.devcontainer/Dockerfile` — previously tracked `:latest`, now pinned to the same version + digest

The digest is the multi-arch OCI index for `0.11.25` (linux/amd64 + linux/arm64), so it covers both the arm64 CI runners and x64 dev machines. This matches the digest-pinning convention already used for the other base images in these Dockerfiles.

**CI version bumps** (`setup-uv` takes a plain version string — no digest applicable):
- `.github/actions/setup-python-and-install-dependencies/action.yml`
- `.github/workflows/`: `audit.yml`, `deployment.yml` (×3), `post-merge-beta-cherry-pick.yml`, `pr-helm-chart-testing.yml`, `pr-playwright-tests.yml`, `release-cli.yml`, `release-devtools.yml`, `zizmor.yml`

## Notes

`0.11.25` is a couple of minor lines up from `0.9.9` (across `0.10` and `0.11`). The Docker builds use `uv pip install --require-hashes` against pre-resolved lock exports, which is stable surface area, so behavioral risk is low. If anything surfaces in CI, the likely area would be resolver/lockfile-format changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades `uv` to 0.11.25 and digest-pins the Docker image to ensure reproducible, multi-arch builds. Also replaces the devcontainer `:latest` tag and bumps all CI `setup-uv` usages.

- **Dependencies**
  - Dockerfiles now use `ghcr.io/astral-sh/uv:0.11.25@sha256:1e3808aa9023d0980e7c15b1fa7c1ac16ff35925780cf5c459858b2d693f01a9` in backend, model server, and `.devcontainer` (multi-arch index).
  - GitHub Actions set `astral-sh/setup-uv` version to "0.11.25" in workflows and the composite action.
  - No behavioral changes expected; lockfile-based installs remain the same.

<sup>Written for commit d53410be78d082dad683e531281a5237f02e69b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

