### PR TITLE
chore(deploy): re-enable model-server `sbom` and `provenance`

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1205,8 +1205,6 @@ jobs:
           cache-to: type=inline
           outputs: type=image,name=${{ needs.determine-builds.outputs.is-test-run == 'true' && env.RUNS_ON_ECR_CACHE || env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
           no-cache: ${{ env.EDGE_TAG != 'true' && vars.MODEL_SERVER_NO_CACHE == 'true' }}
-          provenance: false
-          sbom: false
 
   build-model-server-arm64:
     needs:
@@ -1284,8 +1282,6 @@ jobs:
           cache-to: type=inline
           outputs: type=image,name=${{ needs.determine-builds.outputs.is-test-run == 'true' && env.RUNS_ON_ECR_CACHE || env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
           no-cache: ${{ env.EDGE_TAG != 'true' && vars.MODEL_SERVER_NO_CACHE == 'true' }}
-          provenance: false
-          sbom: false
 
   merge-model-server:
     needs:


### PR DESCRIPTION
## Description

We disabled these to try and fix the Dockerhub `400` errors which I'm fairly confident have been resolved by disabling ECR caching during deployments.

## How Has This Been Tested?

Captured by `check-yaml` pre-commit hook?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-enable `sbom` and `provenance` for model-server Docker builds in `.github/workflows/deployment.yml` to restore supply-chain metadata for both amd64 and arm64 images. DockerHub 400 errors were resolved by disabling ECR cache during deploys, so these exports are safe to resume.

<sup>Written for commit 9cbf38cd17fc391f0e051c17ecbe8061209d811e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

