### PR TITLE
fix(ee): scope curator group writes to curated groups

### DIFF
--- a/backend/ee/onyx/db/user_group.py
+++ b/backend/ee/onyx/db/user_group.py
@@ -635,7 +635,7 @@ def _validate_curator_can_modify_group(
     )
     accessible_group_ids = {group.id for group in accessible_groups}
     if user_group_id not in accessible_group_ids:
-        logger.error(
+        logger.warning(
             "User '%s' attempted to modify group '%s' which they do not curate",
             user.email,
             user_group_id,

--- a/backend/ee/onyx/db/user_group.py
+++ b/backend/ee/onyx/db/user_group.py
@@ -607,13 +607,13 @@ def remove_curator_status__no_commit(db_session: Session, user: User) -> None:
 
 def _validate_curator_can_modify_group(
     db_session: Session,
-    user: User | None,
+    user: User,
     user_group_id: int,
 ) -> None:
     """Validates that ``user`` is permitted to modify the given user group
     (its membership, cc_pair assignments, or curator relationships).
 
-    - ADMIN (and internal/system callers with no user) may modify any group.
+    - ADMIN may modify any group.
     - GLOBAL_CURATOR may modify any group they are a member of.
     - CURATOR may only modify groups they actually curate.
 
@@ -622,8 +622,8 @@ def _validate_curator_can_modify_group(
     authorization (403) error rather than a "not found" (404) so callers can
     distinguish "not allowed" from "does not exist".
     """
-    # Admins (and internal/system callers without a user) can modify any group.
-    if user is None or user.role == UserRole.ADMIN:
+    # Admins can modify any group.
+    if user.role == UserRole.ADMIN:
         return
 
     accessible_groups = fetch_user_groups_for_user(

--- a/backend/ee/onyx/db/user_group.py
+++ b/backend/ee/onyx/db/user_group.py
@@ -43,6 +43,8 @@ from onyx.db.models import UserRole
 from onyx.db.permissions import recompute_permissions_for_group__no_commit
 from onyx.db.permissions import recompute_user_permissions__no_commit
 from onyx.db.users import fetch_user_by_id
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.utils.audit import actor_from_user
 from onyx.utils.audit import AuditAction
 from onyx.utils.audit import AuditOutcome
@@ -603,36 +605,44 @@ def remove_curator_status__no_commit(db_session: Session, user: User) -> None:
     _validate_curator_status__no_commit(db_session, [user])
 
 
-def _validate_curator_relationship_update_requester(
+def _validate_curator_can_modify_group(
     db_session: Session,
+    user: User | None,
     user_group_id: int,
-    user_making_change: User,
 ) -> None:
-    """
-    This function validates that the user making the change has the necessary permissions
-    to update the curator relationship for the target user in the given user group.
-    """
+    """Validates that ``user`` is permitted to modify the given user group
+    (its membership, cc_pair assignments, or curator relationships).
 
-    # Admins can update curator relationships for any group
-    if user_making_change.role == UserRole.ADMIN:
+    - ADMIN (and internal/system callers with no user) may modify any group.
+    - GLOBAL_CURATOR may modify any group they are a member of.
+    - CURATOR may only modify groups they actually curate.
+
+    Raises ``OnyxError(UNAUTHORIZED)`` if a curator / global_curator attempts to
+    modify a group that is outside their scope. This is intentionally an
+    authorization (403) error rather than a "not found" (404) so callers can
+    distinguish "not allowed" from "does not exist".
+    """
+    # Admins (and internal/system callers without a user) can modify any group.
+    if user is None or user.role == UserRole.ADMIN:
         return
 
-    # check if the user making the change is a curator in the group they are changing the curator relationship for
-    user_making_change_curator_groups = fetch_user_groups_for_user(
+    accessible_groups = fetch_user_groups_for_user(
         db_session=db_session,
-        user_id=user_making_change.id,
-        # only check if the user making the change is a curator if they are a curator
-        # otherwise, they are a global_curator and can update the curator relationship
-        # for any group they are a member of
-        only_curator_groups=user_making_change.role == UserRole.CURATOR,
+        user_id=user.id,
+        # Curators are scoped to groups they actually curate; global curators
+        # may modify any group they are a member of.
+        only_curator_groups=user.role == UserRole.CURATOR,
     )
-    requestor_curator_group_ids = [
-        group.id for group in user_making_change_curator_groups
-    ]
-    if user_group_id not in requestor_curator_group_ids:
-        raise ValueError(
-            f"user making change {user_making_change.email} is not a curator,"
-            f" admin, or global_curator for group '{user_group_id}'"
+    accessible_group_ids = {group.id for group in accessible_groups}
+    if user_group_id not in accessible_group_ids:
+        logger.error(
+            "User '%s' attempted to modify group '%s' which they do not curate",
+            user.email,
+            user_group_id,
+        )
+        raise OnyxError(
+            OnyxErrorCode.UNAUTHORIZED,
+            "Curators cannot control groups they don't curate",
         )
 
 
@@ -695,10 +705,10 @@ def update_user_curator_relationship(
         target_user=target_user,
     )
 
-    _validate_curator_relationship_update_requester(
+    _validate_curator_can_modify_group(
         db_session=db_session,
+        user=user_making_change,
         user_group_id=user_group_id,
-        user_making_change=user_making_change,
     )
 
     logger.info(
@@ -738,6 +748,15 @@ def add_users_to_user_group(
     user_group_id: int,
     user_ids: list[UUID],
 ) -> UserGroup:
+    # Curators may only modify groups they curate. Validate before any read of
+    # the target group's data so a curator cannot inspect (or mutate) a group
+    # outside their scope, even on the early-return path below.
+    _validate_curator_can_modify_group(
+        db_session=db_session,
+        user=user,
+        user_group_id=user_group_id,
+    )
+
     db_user_group = fetch_user_group(db_session=db_session, user_group_id=user_group_id)
     if db_user_group is None:
         raise ValueError(f"UserGroup with id '{user_group_id}' not found")
@@ -784,6 +803,15 @@ def update_user_group(
     That will be processed by check_for_vespa_user_groups_sync_task and trigger
     a long running background sync to Vespa.
     """
+    # Curators may only modify groups they curate. Validate before any mutation
+    # so a curator cannot rewrite the membership / cc_pair assignments of a
+    # group outside their scope.
+    _validate_curator_can_modify_group(
+        db_session=db_session,
+        user=user,
+        user_group_id=user_group_id,
+    )
+
     stmt = select(UserGroup).where(UserGroup.id == user_group_id)
     db_user_group = db_session.scalar(stmt)
     if db_user_group is None:

--- a/backend/tests/integration/tests/usergroup/test_curator_group_scope.py
+++ b/backend/tests/integration/tests/usergroup/test_curator_group_scope.py
@@ -96,12 +96,16 @@ def test_curator_cannot_modify_unscoped_group(reset: None) -> None:  # noqa: ARG
     assert patch_own_resp.status_code == 200
 
     # --- Positive: curator can still add users to the group they curate ---
-    updated_group_a = UserGroupManager.add_users(
+    UserGroupManager.add_users(
         user_group=group_a,
         user_ids=[other_user.id],
         user_performing_action=curator,
     )
-    assert other_user.id in set(updated_group_a.user_ids)
+    # Re-fetch rather than trust the add-users response body, which does not
+    # reflect the freshly inserted membership.
+    admin_view = UserGroupManager.get_all(user_performing_action=admin_user)
+    group_a_view = next(group for group in admin_view if group.id == group_a.id)
+    assert other_user.id in {str(user.id) for user in group_a_view.users}
 
     # --- Admin is unaffected: can modify any group ---
     admin_add_resp = client.post(
@@ -185,9 +189,13 @@ def test_global_curator_scoped_to_member_groups(reset: None) -> None:  # noqa: A
     )
     assert patch_own_resp.status_code == 200
 
-    updated_group_a = UserGroupManager.add_users(
+    UserGroupManager.add_users(
         user_group=group_a,
         user_ids=[other_user.id],
         user_performing_action=global_curator,
     )
-    assert other_user.id in set(updated_group_a.user_ids)
+    # Re-fetch rather than trust the add-users response body, which does not
+    # reflect the freshly inserted membership.
+    member_view = UserGroupManager.get_all(user_performing_action=admin_user)
+    group_a_view = next(group for group in member_view if group.id == group_a.id)
+    assert other_user.id in {str(user.id) for user in group_a_view.users}

--- a/backend/tests/integration/tests/usergroup/test_curator_group_scope.py
+++ b/backend/tests/integration/tests/usergroup/test_curator_group_scope.py
@@ -12,7 +12,8 @@ caller is a curator/admin *somewhere*) while the underlying DB functions ignored
 the caller entirely. This let a curator of Group A rewrite the membership /
 cc_pair assignments of Group B (e.g. add themselves to a sensitive group).
 
-These tests verify the caller is now scoped to the groups they actually curate.
+These tests verify the caller is now scoped: a CURATOR to the groups they
+actually curate, and a GLOBAL_CURATOR to the groups they are a member of.
 """
 
 import os
@@ -109,3 +110,84 @@ def test_curator_cannot_modify_unscoped_group(reset: None) -> None:  # noqa: ARG
         headers=admin_user.headers,
     )
     assert admin_add_resp.status_code == 200
+
+
+@pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="User group tests are enterprise only",
+)
+def test_global_curator_scoped_to_member_groups(reset: None) -> None:  # noqa: ARG001
+    """A GLOBAL_CURATOR may modify groups they are a member of, but not others.
+
+    This mirrors the documented role semantics (``UserRole``) and the existing
+    ``validate_object_creation_for_user`` scoping: "global curators can curate
+    all groups they are a member of" -- not every group in the deployment.
+    """
+    # First user created is automatically an admin
+    admin_user: DATestUser = UserManager.create(name="admin_user")
+    assert UserManager.is_role(admin_user, UserRole.ADMIN)
+
+    global_curator: DATestUser = UserManager.create(name="global_curator")
+    other_user: DATestUser = UserManager.create(name="other_user")
+
+    UserManager.set_role(
+        user_to_set=global_curator,
+        target_role=UserRole.GLOBAL_CURATOR,
+        user_performing_action=admin_user,
+    )
+    assert UserManager.is_role(global_curator, UserRole.GLOBAL_CURATOR)
+
+    # Group A: the global curator is a member.
+    group_a = UserGroupManager.create(
+        name="group_a",
+        user_ids=[global_curator.id],
+        cc_pair_ids=[],
+        user_performing_action=admin_user,
+    )
+    # Group B: the global curator is not a member.
+    group_b = UserGroupManager.create(
+        name="group_b",
+        user_ids=[],
+        cc_pair_ids=[],
+        user_performing_action=admin_user,
+    )
+    UserGroupManager.wait_for_sync(
+        user_groups_to_check=[group_a, group_b],
+        user_performing_action=admin_user,
+    )
+
+    # --- Negative: cannot PATCH a group they are not a member of ---
+    patch_resp = client.patch(
+        f"{API_SERVER_URL}/manage/admin/user-group/{group_b.id}",
+        json={"user_ids": [global_curator.id], "cc_pair_ids": []},
+        headers=global_curator.headers,
+    )
+    assert patch_resp.status_code == 403
+
+    # --- Negative: cannot add users to a group they are not a member of ---
+    add_resp = client.post(
+        f"{API_SERVER_URL}/manage/admin/user-group/{group_b.id}/add-users",
+        json={"user_ids": [global_curator.id]},
+        headers=global_curator.headers,
+    )
+    assert add_resp.status_code == 403
+
+    # The global curator must not have been added to group B as a side effect.
+    admin_view = UserGroupManager.get_all(user_performing_action=admin_user)
+    group_b_view = next(group for group in admin_view if group.id == group_b.id)
+    assert global_curator.id not in {str(user.id) for user in group_b_view.users}
+
+    # --- Positive: can still modify a group they are a member of ---
+    patch_own_resp = client.patch(
+        f"{API_SERVER_URL}/manage/admin/user-group/{group_a.id}",
+        json={"user_ids": [global_curator.id], "cc_pair_ids": []},
+        headers=global_curator.headers,
+    )
+    assert patch_own_resp.status_code == 200
+
+    updated_group_a = UserGroupManager.add_users(
+        user_group=group_a,
+        user_ids=[other_user.id],
+        user_performing_action=global_curator,
+    )
+    assert other_user.id in set(updated_group_a.user_ids)

--- a/backend/tests/integration/tests/usergroup/test_curator_group_scope.py
+++ b/backend/tests/integration/tests/usergroup/test_curator_group_scope.py
@@ -1,0 +1,111 @@
+"""
+Regression tests for a curator group-scope privilege-escalation bug.
+
+A user with the CURATOR role could modify *any* user group (not just the ones
+they curate) via:
+
+    PATCH /manage/admin/user-group/{user_group_id}
+    POST  /manage/admin/user-group/{user_group_id}/add-users
+
+Both routes guard with ``current_curator_or_admin_user`` (which only proves the
+caller is a curator/admin *somewhere*) while the underlying DB functions ignored
+the caller entirely. This let a curator of Group A rewrite the membership /
+cc_pair assignments of Group B (e.g. add themselves to a sensitive group).
+
+These tests verify the caller is now scoped to the groups they actually curate.
+"""
+
+import os
+
+import pytest
+
+from onyx.db.models import UserRole
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.http_client import client
+from tests.integration.common_utils.managers.user import DATestUser
+from tests.integration.common_utils.managers.user import UserManager
+from tests.integration.common_utils.managers.user_group import UserGroupManager
+
+
+@pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="User group tests are enterprise only",
+)
+def test_curator_cannot_modify_unscoped_group(reset: None) -> None:  # noqa: ARG001
+    # First user created is automatically an admin
+    admin_user: DATestUser = UserManager.create(name="admin_user")
+    assert UserManager.is_role(admin_user, UserRole.ADMIN)
+
+    curator: DATestUser = UserManager.create(name="curator")
+    other_user: DATestUser = UserManager.create(name="other_user")
+
+    # Group A: the curator is a member and will be made its curator.
+    group_a = UserGroupManager.create(
+        name="group_a",
+        user_ids=[curator.id],
+        cc_pair_ids=[],
+        user_performing_action=admin_user,
+    )
+    # Group B: the curator has no relationship to this group.
+    group_b = UserGroupManager.create(
+        name="group_b",
+        user_ids=[],
+        cc_pair_ids=[],
+        user_performing_action=admin_user,
+    )
+    UserGroupManager.wait_for_sync(
+        user_groups_to_check=[group_a, group_b],
+        user_performing_action=admin_user,
+    )
+
+    UserGroupManager.set_curator_status(
+        test_user_group=group_a,
+        user_to_set_as_curator=curator,
+        user_performing_action=admin_user,
+    )
+    assert UserManager.is_role(curator, UserRole.CURATOR)
+
+    # --- Negative: curator cannot PATCH a group they don't curate ---
+    patch_resp = client.patch(
+        f"{API_SERVER_URL}/manage/admin/user-group/{group_b.id}",
+        json={"user_ids": [curator.id], "cc_pair_ids": []},
+        headers=curator.headers,
+    )
+    assert patch_resp.status_code == 403
+
+    # --- Negative: curator cannot add users to a group they don't curate ---
+    add_resp = client.post(
+        f"{API_SERVER_URL}/manage/admin/user-group/{group_b.id}/add-users",
+        json={"user_ids": [curator.id]},
+        headers=curator.headers,
+    )
+    assert add_resp.status_code == 403
+
+    # The curator must not have been added to group B as a side effect.
+    admin_view = UserGroupManager.get_all(user_performing_action=admin_user)
+    group_b_view = next(group for group in admin_view if group.id == group_b.id)
+    assert curator.id not in {str(user.id) for user in group_b_view.users}
+
+    # --- Positive: curator can still PATCH the group they curate ---
+    patch_own_resp = client.patch(
+        f"{API_SERVER_URL}/manage/admin/user-group/{group_a.id}",
+        json={"user_ids": [curator.id], "cc_pair_ids": []},
+        headers=curator.headers,
+    )
+    assert patch_own_resp.status_code == 200
+
+    # --- Positive: curator can still add users to the group they curate ---
+    updated_group_a = UserGroupManager.add_users(
+        user_group=group_a,
+        user_ids=[other_user.id],
+        user_performing_action=curator,
+    )
+    assert other_user.id in set(updated_group_a.user_ids)
+
+    # --- Admin is unaffected: can modify any group ---
+    admin_add_resp = client.post(
+        f"{API_SERVER_URL}/manage/admin/user-group/{group_b.id}/add-users",
+        json={"user_ids": [other_user.id]},
+        headers=admin_user.headers,
+    )
+    assert admin_add_resp.status_code == 200

--- a/backend/tests/unit/ee/onyx/db/test_user_group_audit.py
+++ b/backend/tests/unit/ee/onyx/db/test_user_group_audit.py
@@ -15,6 +15,7 @@ import pytest
 
 from ee.onyx.db.user_group import update_user_group
 from ee.onyx.server.user_group.models import UserGroupUpdate
+from onyx.db.models import UserRole
 
 
 def _audit_events(caplog: pytest.LogCaptureFixture) -> list[dict[str, Any]]:
@@ -52,7 +53,7 @@ def test_update_user_group_emits_on_membership_change(
     existing = uuid4()
     added = uuid4()
     db_session = _make_db_session([existing], [10])
-    admin = MagicMock(id="admin-1", email="admin@example.com")
+    admin = MagicMock(id="admin-1", email="admin@example.com", role=UserRole.ADMIN)
 
     with caplog.at_level(logging.INFO, logger="onyx.audit"):
         update_user_group(
@@ -89,7 +90,7 @@ def test_update_user_group_cc_pair_only_emits_nothing(
 ) -> None:
     existing = uuid4()
     db_session = _make_db_session([existing], [10])
-    admin = MagicMock(id="admin-1", email="admin@example.com")
+    admin = MagicMock(id="admin-1", email="admin@example.com", role=UserRole.ADMIN)
 
     with caplog.at_level(logging.INFO, logger="onyx.audit"):
         update_user_group(


### PR DESCRIPTION
## Summary

`update_user_group` and `add_users_to_user_group` took the requesting `user` but never checked it, so a curator/global_curator could modify any user group's membership and cc_pair assignments — not just the groups in their scope. The `set-curator` path already did this check; this generalizes that helper (`_validate_curator_can_modify_group`) and applies it up front in both functions, before any read or mutation.

- ADMIN (and internal callers with no user): unchanged, may modify any group.
- GLOBAL_CURATOR: scoped to groups they're a member of.
- CURATOR: scoped to groups they actually curate.

Out-of-scope writes now return `OnyxError(UNAUTHORIZED)` → 403, distinct from the existing 404 "not found" mapping. Route dependencies are unchanged.

## Tests

Adds an enterprise-gated integration test (`test_curator_group_scope.py`) covering: a curator gets 403 PATCHing / adding users to a group they don't curate (and isn't added as a side effect), can still modify their own group, and admin is unaffected. Existing user-group audit unit tests updated to give the mocked admin a real role so the admin short-circuit applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lock down curator writes by enforcing scope checks in `update_user_group`, `add_users_to_user_group`, and curator relationship updates before any read or mutation. Out-of-scope requests now return 403 and are logged at WARNING.

- **Bug Fixes**
  - Added `_validate_curator_can_modify_group` (requires a `User`): ADMIN any group; GLOBAL_CURATOR groups they’re a member of; CURATOR groups they curate.
  - Applied the validator early to block reads and writes outside scope.
  - Raise `OnyxError(OnyxErrorCode.UNAUTHORIZED)` and log denials at WARNING.
  - Enterprise integration tests for CURATOR and GLOBAL_CURATOR scoping (403 on unscoped PATCH/add-users; success within scope); audit unit tests use an ADMIN role; add-users tests re-fetch membership to avoid stale response bodies.

<sup>Written for commit 87fef842ba82fc6a3be274bbb5802689c568ec7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

