### PR TITLE
fix(security): redact persona/MCP owner email + internal server_url from basic users (ENG-4251)

### DIFF
--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -754,6 +754,11 @@ def _build_persona_filters(
     return stmt
 
 
+def _user_may_view_persona_owner_email(user: User, persona: Persona) -> bool:
+    """Owner email is PII — only the persona's owner or an admin may see it."""
+    return user.role == UserRole.ADMIN or persona.user_id == user.id
+
+
 def get_minimal_persona_snapshots_for_user(
     user: User,
     db_session: Session,
@@ -795,6 +800,7 @@ def get_minimal_persona_snapshots_for_user(
         MinimalPersonaSnapshot.from_model(
             persona,
             user_permission=get_persona_access_level(persona, user, user_group_ids),
+            include_owner_email=_user_may_view_persona_owner_email(user, persona),
         )
         for persona in results
     ]
@@ -951,6 +957,7 @@ def get_minimal_persona_snapshots_paginated(
         MinimalPersonaSnapshot.from_model(
             persona,
             user_permission=get_persona_access_level(persona, user, user_group_ids),
+            include_owner_email=_user_may_view_persona_owner_email(user, persona),
         )
         for persona in results
     ]

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -1386,13 +1386,15 @@ def _db_mcp_server_to_api_mcp_server(
     user_authenticated: bool | None = None
     user_credentials = None
     admin_credentials = None
-    can_view_admin_credentials = bool(include_auth_config) and (
-        request_user is not None
-        and (
-            request_user.role == UserRole.ADMIN
-            or (request_user.email and request_user.email == db_server.owner)
-        )
+    is_owner_or_admin = request_user is not None and (
+        request_user.role == UserRole.ADMIN
+        or (request_user.email and request_user.email == db_server.owner)
     )
+    can_view_admin_credentials = bool(include_auth_config) and is_owner_or_admin
+    # The internal server_url and the owner email are sensitive: expose them only
+    # to the server's owner or an admin. Basic users attaching MCP actions to an
+    # assistant don't need either (the connect/OAuth flow is brokered server-side).
+    can_view_server_details = is_owner_or_admin
     if db_server.auth_type == MCPAuthenticationType.NONE:
         user_authenticated = True  # No auth required
     elif auth_performer == MCPAuthenticationPerformer.ADMIN:
@@ -1530,8 +1532,8 @@ def _db_mcp_server_to_api_mcp_server(
         id=db_server.id,
         name=db_server.name,
         description=db_server.description,
-        server_url=db_server.server_url,
-        owner=db_server.owner,
+        server_url=db_server.server_url if can_view_server_details else "",
+        owner=db_server.owner if can_view_server_details else "",
         transport=db_server.transport,
         auth_type=db_server.auth_type,
         auth_performer=auth_performer,

--- a/backend/onyx/server/features/persona/models.py
+++ b/backend/onyx/server/features/persona/models.py
@@ -235,6 +235,7 @@ class MinimalPersonaSnapshot(BaseModel):
         cls,
         persona: Persona,
         user_permission: PersonaAccessLevel | None = None,
+        include_owner_email: bool = True,
     ) -> "MinimalPersonaSnapshot":
         # Collect unique sources from document sets, hierarchy nodes, and attached documents
         sources: set[DocumentSource] = set()
@@ -288,7 +289,12 @@ class MinimalPersonaSnapshot(BaseModel):
             builtin_persona=persona.builtin_persona,
             labels=[PersonaLabelSnapshot.from_model(label) for label in persona.labels],
             owner=(
-                MinimalUserSnapshot(id=persona.user.id, email=persona.user.email)
+                # Owner email is PII: keep the id (needed for ownership/creator
+                # filtering) but blank the email for non-owner/non-admin callers.
+                MinimalUserSnapshot(
+                    id=persona.user.id,
+                    email=persona.user.email if include_owner_email else "",
+                )
                 if persona.user
                 else None
             ),

--- a/backend/onyx/server/features/persona/models.py
+++ b/backend/onyx/server/features/persona/models.py
@@ -235,7 +235,9 @@ class MinimalPersonaSnapshot(BaseModel):
         cls,
         persona: Persona,
         user_permission: PersonaAccessLevel | None = None,
-        include_owner_email: bool = True,
+        # Fail closed: the owner email is PII and is only included when a caller
+        # explicitly opts in (owner / admin paths). See the DB-layer callers.
+        include_owner_email: bool = False,
     ) -> "MinimalPersonaSnapshot":
         # Collect unique sources from document sets, hierarchy nodes, and attached documents
         sources: set[DocumentSource] = set()

--- a/backend/tests/integration/tests/permissions/test_owner_pii_redaction.py
+++ b/backend/tests/integration/tests/permissions/test_owner_pii_redaction.py
@@ -1,0 +1,105 @@
+"""Integration tests for owner-email / internal-URL redaction (ENG-4251).
+
+Persona and MCP-server snapshots returned by the basic-access surfaces leaked
+PII (the owner's email) and internal infrastructure detail (the MCP
+`server_url`) to any authenticated user. These tests verify that:
+
+* the owner email is blanked for non-owner / non-admin callers, while
+* the owner (and an admin) still sees the real values.
+"""
+
+from uuid import uuid4
+
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.http_client import client
+from tests.integration.common_utils.managers.persona import PersonaManager
+from tests.integration.common_utils.test_models import DATestUser
+
+
+def _find_persona(entries: list[dict], persona_id: int) -> dict:
+    return next(entry for entry in entries if entry["id"] == persona_id)
+
+
+def _find_mcp_server(payload: dict, server_id: int) -> dict:
+    return next(s for s in payload["mcp_servers"] if s["id"] == server_id)
+
+
+def test_persona_owner_email_redacted_for_non_owner(
+    permission_admin_user: DATestUser,
+    permission_basic_user: DATestUser,
+) -> None:
+    """`GET /api/persona` must not expose the owner email to non-owner users."""
+    persona = PersonaManager.create(
+        name=f"pii-redaction-persona-{uuid4()}",
+        is_public=True,
+        user_performing_action=permission_admin_user,
+    )
+
+    # The owner (admin here) still sees their own email.
+    admin_resp = client.get(
+        f"{API_SERVER_URL}/persona",
+        headers=permission_admin_user.headers,
+        cookies=permission_admin_user.cookies,
+        timeout=30,
+    )
+    admin_resp.raise_for_status()
+    admin_entry = _find_persona(admin_resp.json(), persona.id)
+    assert admin_entry["owner"] is not None
+    assert admin_entry["owner"]["email"] == permission_admin_user.email
+
+    # A basic, non-owner user sees the persona and its owner id (needed for
+    # ownership / creator filtering) but NOT the owner email.
+    basic_resp = client.get(
+        f"{API_SERVER_URL}/persona",
+        headers=permission_basic_user.headers,
+        cookies=permission_basic_user.cookies,
+        timeout=30,
+    )
+    basic_resp.raise_for_status()
+    basic_entry = _find_persona(basic_resp.json(), persona.id)
+    assert basic_entry["owner"] is not None
+    assert basic_entry["owner"]["id"]
+    assert basic_entry["owner"]["email"] == ""
+
+
+def test_mcp_server_details_redacted_for_non_owner(
+    permission_admin_user: DATestUser,
+    permission_basic_user: DATestUser,
+) -> None:
+    """`GET /api/mcp/servers` must not expose server_url / owner to non-owners."""
+    internal_url = f"http://mcp-internal-{uuid4().hex[:8]}.svc.internal/sse"
+    server_name = f"pii-redaction-mcp-{uuid4()}"
+
+    create_resp = client.post(
+        f"{API_SERVER_URL}/admin/mcp/server",
+        json={"name": server_name, "server_url": internal_url},
+        headers=permission_admin_user.headers,
+        cookies=permission_admin_user.cookies,
+        timeout=30,
+    )
+    create_resp.raise_for_status()
+    server_id = create_resp.json()["id"]
+
+    # The owner (admin here) still sees the internal url and owner email.
+    admin_resp = client.get(
+        f"{API_SERVER_URL}/mcp/servers",
+        headers=permission_admin_user.headers,
+        cookies=permission_admin_user.cookies,
+        timeout=30,
+    )
+    admin_resp.raise_for_status()
+    admin_entry = _find_mcp_server(admin_resp.json(), server_id)
+    assert admin_entry["server_url"] == internal_url
+    assert admin_entry["owner"] == permission_admin_user.email
+
+    # A basic, non-owner user sees the server entry but neither sensitive field.
+    basic_resp = client.get(
+        f"{API_SERVER_URL}/mcp/servers",
+        headers=permission_basic_user.headers,
+        cookies=permission_basic_user.cookies,
+        timeout=30,
+    )
+    basic_resp.raise_for_status()
+    basic_entry = _find_mcp_server(basic_resp.json(), server_id)
+    assert basic_entry["server_url"] == ""
+    assert basic_entry["owner"] == ""


### PR DESCRIPTION
## Description

Two basic-access surfaces leaked sensitive data to any authenticated user:

- `GET /api/persona` (`MinimalPersonaSnapshot.owner`) returned every persona owner's **email** to any user who could see the persona.
- `GET /api/mcp/servers/persona/{id}` and `GET /api/mcp/servers` (`MCPServer`) returned the owner **email** and the internal **`server_url`** (e.g. an internal hostname) to basic users.

This restricts those fields to the resource's **owner or an admin**:

- `MinimalPersonaSnapshot.from_model` now takes `include_owner_email`; when the caller isn't the owner/admin, the owner **id is preserved** (still needed for ownership and creator-filtering in the UI) but the **email is blanked**. The decision is made in the two DB-layer callers (`get_minimal_persona_snapshots_for_user` / `_paginated`) via a small `_user_may_view_persona_owner_email` helper.
- The shared MCP converter `_db_mcp_server_to_api_mcp_server` now blanks `server_url` and `owner` unless the caller is the server's owner or an admin. This covers **both** basic MCP endpoints; the admin MCP-management endpoints (which legitimately need these fields) are unaffected since admins/owners still see them.

No frontend changes are required: the basic chat/persona connect flow reads neither field (the OAuth/connect flow is brokered server-side), the agents UI already falls back gracefully (`owner?.email || "Onyx"`, `getActionIcon("")` → default icon), and ownership/creator filtering uses `owner.id`, which is preserved.

Out of scope (per ticket): `GET /api/enterprise-settings` being unauthenticated is by design; the broader `FullPersonaSnapshot`/share-path email exposure is tracked separately.

## How Has This Been Tested?

- Added integration tests (`backend/tests/integration/tests/permissions/test_owner_pii_redaction.py`): a basic non-owner user gets `owner.email == ""` on `/api/persona` and `server_url == "" / owner == ""` on `/api/mcp/servers`, while the owning admin still sees the real values.
- `ruff`, `ruff format`, and `ty` pass on all changed files. (Onyx services were not running locally, so the integration tests will execute in CI.)

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts persona owner emails and internal MCP server `server_url` from basic users. Only the owner or an admin can see them. Resolves ENG-4251.

- **Bug Fixes**
  - Persona list (`GET /api/persona`): keep `owner.id`, blank `owner.email` for non-owner/non-admin. `MinimalPersonaSnapshot.from_model` now defaults `include_owner_email=False` (fail closed); DB callers set it via `_user_may_view_persona_owner_email`.
  - MCP servers (`GET /api/mcp/servers`, `/api/mcp/servers/persona/{id}`): blank `server_url` and `owner` unless owner/admin; admin endpoints unchanged.
  - Added integration tests verifying redaction for basic users and full visibility for owners/admins.

<sup>Written for commit 5bfff2aae17faa0086178377f9b4e6288b6da520. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

