### PR TITLE
chore(config): remove dead AGENT_RERANKING_STATS / AGENT_RETRIEVAL_STATS

### DIFF
--- a/backend/onyx/configs/agent_configs.py
+++ b/backend/onyx/configs/agent_configs.py
@@ -24,10 +24,6 @@ AGENT_ANSWER_GENERATION_BY_FAST_LLM = (
     os.environ.get("AGENT_ANSWER_GENERATION_BY_FAST_LLM", "").lower() == "true"
 )
 
-AGENT_RETRIEVAL_STATS = (
-    not os.environ.get("AGENT_RETRIEVAL_STATS") == "False"
-) or True  # default True
-
 AGENT_MAX_VERIFICATION_HITS = int(
     os.environ.get("AGENT_MAX_VERIFICATION_HITS") or AGENT_DEFAULT_MAX_VERIFIVATION_HITS
 )  # 30
@@ -37,11 +33,6 @@ AGENT_MAX_QUERY_RETRIEVAL_RESULTS = int(
 )  # 15
 
 # Reranking agent configs
-# Reranking stats - no influence on flow outside of stats collection
-AGENT_RERANKING_STATS = (
-    not os.environ.get("AGENT_RERANKING_STATS") == "True"
-) or False  # default False
-
 AGENT_RERANKING_MAX_QUERY_RETRIEVAL_RESULTS = int(
     os.environ.get("AGENT_RERANKING_MAX_QUERY_RETRIEVAL_RESULTS")
     or AGENT_DEFAULT_RERANKING_HITS


### PR DESCRIPTION
## What

Removes two dead agent stats configs from `backend/onyx/configs/agent_configs.py`:

- `AGENT_RERANKING_STATS`
- `AGENT_RETRIEVAL_STATS`

## Why

Both are referenced **nowhere** outside their own definitions (confirmed via repo-wide grep across Python, env templates, docs, and deploy configs), and both used a mangled `(not os.environ.get(...) == "...") or <bool>` pattern whose behavior didn't match its comment:

- `AGENT_RERANKING_STATS` was documented `# default False` but actually resolved to `True` when unset (the `not ... == "True"` inverts the logic and the trailing `or False` is a no-op).
- `AGENT_RETRIEVAL_STATS` had the twin issue — its trailing `or True` forces the value to `True` unconditionally, so its env var was silently ignored.

Since nothing reads either value, removing them is cleaner than fixing logic that has no effect. No runtime impact.

This follows recent precedent (`chore(config): ... remove dead duplicate configs`, #12413).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed two unused agent stats flags from `backend/onyx/configs/agent_configs.py`. This cleans up config and removes misleading default logic; no runtime impact.

- **Refactors**
  - Removed `AGENT_RETRIEVAL_STATS` and `AGENT_RERANKING_STATS` (unused).
  - Dropped confusing `(not env == "...") or <bool>` patterns and mismatched comments to avoid future confusion.

<sup>Written for commit eef066a29cfb0a5fdf21819964718e0fff3331a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

