### PR TITLE
feat(settings): collapse tab nav into a dropdown on narrow screens

### DIFF
--- a/web/src/app/app/settings/layout.tsx
+++ b/web/src/app/app/settings/layout.tsx
@@ -51,21 +51,26 @@ export default function Layout({ children }: LayoutProps) {
           className="md:flex-row md:items-start"
         >
           {/* Narrow screens: dropdown navigation above the tab content */}
-          <InputSelect
-            value={pathname}
-            onValueChange={(href) =>
-              router.push(href as Route, { scroll: false })
-            }
+          <div
+            data-testid="settings-tab-navigation-dropdown"
+            className="md:hidden"
           >
-            <InputSelect.Trigger placeholder="Select a section" />
-            <InputSelect.Content>
-              {tabs.map((tab) => (
-                <InputSelect.Item key={tab.href} value={tab.href}>
-                  {tab.label}
-                </InputSelect.Item>
-              ))}
-            </InputSelect.Content>
-          </InputSelect>
+            <InputSelect
+              value={pathname}
+              onValueChange={(href) =>
+                router.push(href as Route, { scroll: false })
+              }
+            >
+              <InputSelect.Trigger placeholder="Select a section" />
+              <InputSelect.Content>
+                {tabs.map((tab) => (
+                  <InputSelect.Item key={tab.href} value={tab.href}>
+                    {tab.label}
+                  </InputSelect.Item>
+                ))}
+              </InputSelect.Content>
+            </InputSelect>
+          </div>
 
           {/* Wide screens: left tab navigation */}
           <div

--- a/web/src/app/app/settings/layout.tsx
+++ b/web/src/app/app/settings/layout.tsx
@@ -51,26 +51,21 @@ export default function Layout({ children }: LayoutProps) {
           className="md:flex-row md:items-start"
         >
           {/* Narrow screens: dropdown navigation above the tab content */}
-          <div
-            data-testid="settings-tab-navigation-dropdown"
-            className="md:hidden px-2"
+          <InputSelect
+            value={pathname}
+            onValueChange={(href) =>
+              router.push(href as Route, { scroll: false })
+            }
           >
-            <InputSelect
-              value={pathname}
-              onValueChange={(href) =>
-                router.push(href as Route, { scroll: false })
-              }
-            >
-              <InputSelect.Trigger placeholder="Select a section" />
-              <InputSelect.Content>
-                {tabs.map((tab) => (
-                  <InputSelect.Item key={tab.href} value={tab.href}>
-                    {tab.label}
-                  </InputSelect.Item>
-                ))}
-              </InputSelect.Content>
-            </InputSelect>
-          </div>
+            <InputSelect.Trigger placeholder="Select a section" />
+            <InputSelect.Content>
+              {tabs.map((tab) => (
+                <InputSelect.Item key={tab.href} value={tab.href}>
+                  {tab.label}
+                </InputSelect.Item>
+              ))}
+            </InputSelect.Content>
+          </InputSelect>
 
           {/* Wide screens: left tab navigation */}
           <div

--- a/web/src/app/app/settings/layout.tsx
+++ b/web/src/app/app/settings/layout.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
+import type { Route } from "next";
 import { SettingsLayouts } from "@opal/layouts";
 import { SidebarTab } from "@opal/components";
 import { SvgSliders } from "@opal/icons";
+import InputSelect from "@/refresh-components/inputs/InputSelect";
 import { useUser } from "@/providers/UserProvider";
 import { useAuthType } from "@/lib/hooks";
 import { Section } from "@/layouts/general-layouts";
@@ -12,8 +14,14 @@ interface LayoutProps {
   children: React.ReactNode;
 }
 
+interface SettingsTab {
+  href: string;
+  label: string;
+}
+
 export default function Layout({ children }: LayoutProps) {
   const pathname = usePathname();
+  const router = useRouter();
   const { user } = useUser();
   const authType = useAuthType();
 
@@ -21,51 +29,66 @@ export default function Layout({ children }: LayoutProps) {
   const showTokensSection = authType !== null;
   const showAccountsAccessTab = showPasswordSection || showTokensSection;
 
+  const tabs: SettingsTab[] = [
+    { href: "/app/settings/general", label: "General" },
+    { href: "/app/settings/chat-preferences", label: "Chat Preferences" },
+    ...(showAccountsAccessTab
+      ? [{ href: "/app/settings/accounts-access", label: "Accounts & Access" }]
+      : []),
+    { href: "/app/settings/connectors", label: "Connectors" },
+  ];
+
   return (
     <SettingsLayouts.Root width="lg">
       <SettingsLayouts.Header icon={SvgSliders} title="Settings" divider />
 
       <SettingsLayouts.Body>
         <Section
-          flexDirection="row"
+          flexDirection="column"
           justifyContent="start"
-          alignItems="start"
+          alignItems="stretch"
           gap={1.5}
+          className="md:flex-row md:items-start"
         >
-          {/* Left: Tab Navigation */}
+          {/* Narrow screens: dropdown navigation above the tab content */}
           <div
-            data-testid="settings-left-tab-navigation"
-            className="flex flex-col px-2 min-w-50"
+            data-testid="settings-tab-navigation-dropdown"
+            className="md:hidden px-2"
           >
-            <SidebarTab
-              href="/app/settings/general"
-              selected={pathname === "/app/settings/general"}
+            <InputSelect
+              value={pathname}
+              onValueChange={(href) =>
+                router.push(href as Route, { scroll: false })
+              }
             >
-              General
-            </SidebarTab>
-            <SidebarTab
-              href="/app/settings/chat-preferences"
-              selected={pathname === "/app/settings/chat-preferences"}
-            >
-              Chat Preferences
-            </SidebarTab>
-            {showAccountsAccessTab && (
-              <SidebarTab
-                href="/app/settings/accounts-access"
-                selected={pathname === "/app/settings/accounts-access"}
-              >
-                Accounts & Access
-              </SidebarTab>
-            )}
-            <SidebarTab
-              href="/app/settings/connectors"
-              selected={pathname === "/app/settings/connectors"}
-            >
-              Connectors
-            </SidebarTab>
+              <InputSelect.Trigger placeholder="Select a section" />
+              <InputSelect.Content>
+                {tabs.map((tab) => (
+                  <InputSelect.Item key={tab.href} value={tab.href}>
+                    {tab.label}
+                  </InputSelect.Item>
+                ))}
+              </InputSelect.Content>
+            </InputSelect>
           </div>
 
-          {/* Right: Tab Content */}
+          {/* Wide screens: left tab navigation */}
+          <div
+            data-testid="settings-left-tab-navigation"
+            className="hidden md:flex flex-col px-2 min-w-50"
+          >
+            {tabs.map((tab) => (
+              <SidebarTab
+                key={tab.href}
+                href={tab.href}
+                selected={pathname === tab.href}
+              >
+                {tab.label}
+              </SidebarTab>
+            ))}
+          </div>
+
+          {/* Tab Content */}
           {children}
         </Section>
       </SettingsLayouts.Body>

--- a/web/src/app/app/settings/layout.tsx
+++ b/web/src/app/app/settings/layout.tsx
@@ -3,7 +3,7 @@
 import { usePathname, useRouter } from "next/navigation";
 import type { Route } from "next";
 import { SettingsLayouts } from "@opal/layouts";
-import { SidebarTab } from "@opal/components";
+import { SidebarTab, Text } from "@opal/components";
 import { SvgSliders } from "@opal/icons";
 import InputSelect from "@/refresh-components/inputs/InputSelect";
 import { useUser } from "@/providers/UserProvider";
@@ -38,6 +38,12 @@ export default function Layout({ children }: LayoutProps) {
     { href: "/app/settings/connectors", label: "Connectors" },
   ];
 
+  // Derive the trigger label from the pathname directly. InputSelect normally
+  // surfaces the selected label via item registration, but its items are
+  // unmounted while the dropdown is closed, so the label would otherwise be
+  // missing on initial load.
+  const activeTab = tabs.find((tab) => tab.href === pathname);
+
   return (
     <SettingsLayouts.Root width="lg">
       <SettingsLayouts.Header icon={SvgSliders} title="Settings" divider />
@@ -61,7 +67,13 @@ export default function Layout({ children }: LayoutProps) {
                 router.push(href as Route, { scroll: false })
               }
             >
-              <InputSelect.Trigger placeholder="Select a section" />
+              <InputSelect.Trigger placeholder="Select a section">
+                {activeTab && (
+                  <Text font="main-ui-body" color="text-04" nowrap>
+                    {activeTab.label}
+                  </Text>
+                )}
+              </InputSelect.Trigger>
               <InputSelect.Content>
                 {tabs.map((tab) => (
                   <InputSelect.Item key={tab.href} value={tab.href}>


### PR DESCRIPTION
## What

Improves responsiveness of the settings page layout (`web/src/app/app/settings/layout.tsx`).

- **Desktop (`md` and up):** unchanged — the left `SidebarTab` navigation sits beside the tab content, exactly as before (keeps `data-testid="settings-left-tab-navigation"`).
- **Narrow (`< md`):** the left nav collapses into a single `InputSelect` dropdown rendered **above** the tab content. The trigger auto-displays the active tab (driven by `value={pathname}`); selecting an option calls `router.push(href, { scroll: false })`, matching the sidebar's existing `scroll={false}` navigation.

The tab list (including the conditional **Accounts & Access** tab) is now defined once and shared by both renderings. The responsive flip is handled by the existing `Section` (`flexDirection="column"` + `className="md:flex-row md:items-start"`), so source order yields *dropdown-above-content* on mobile and *sidebar-beside-content* on desktop with no extra wrapper.

## Notes

- Dropdown items are text-only, matching the current (icon-less) sidebar tabs.
- Component choices: `InputSelect` (`@/refresh-components/inputs/InputSelect`) for the dropdown; reuses the existing `SidebarTab` for desktop.

## Testing

- `oxlint` clean on the changed file.
- Manual visual check at desktop vs. mobile widths recommended.

<img width="1486" height="2085" alt="20260629_13h39m49s_grim" src="https://github.com/user-attachments/assets/3a60a9c7-1670-43e6-8c3b-3d5377b0ad35" />


<img width="1486" height="2085" alt="20260629_13h35m37s_grim" src="https://github.com/user-attachments/assets/c789c916-5260-471b-9640-7bbff251e372" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapse the settings sidebar into a dropdown on narrow screens while keeping the desktop sidebar unchanged. The dropdown sits above the content on mobile.

- **New Features**
  - Mobile: use `InputSelect` (`@/refresh-components/inputs/InputSelect`) with `value={pathname}` and `router.push(href as Route, { scroll: false })`; adds `data-testid="settings-tab-navigation-dropdown"`.
  - Desktop (`md+`): keep `SidebarTab` (`@opal/components`) with `data-testid="settings-left-tab-navigation"`.
  - One shared tab list for both views, including conditional “Accounts & Access”; responsive flip handled by `Section` with `md` classes.

<sup>Written for commit 2a4d04601f3ed682dadf6414fef72728bc1877f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

