### PR TITLE
feat(skills): add skill preview modal

### DIFF
--- a/backend/onyx/server/features/skill/api.py
+++ b/backend/onyx/server/features/skill/api.py
@@ -42,11 +42,14 @@ from onyx.server.features.skill.models import CustomSkillResponse
 from onyx.server.features.skill.models import GrantsReplace
 from onyx.server.features.skill.models import PersonalSkillPatchRequest
 from onyx.server.features.skill.models import SkillPatchRequest
+from onyx.server.features.skill.models import SkillPreviewResponse
 from onyx.server.features.skill.models import SkillsList
 from onyx.skills.built_in import BUILT_IN_SKILLS
 from onyx.skills.built_in import EXTERNAL_APP_BUILT_IN_SKILL_IDS
 from onyx.skills.bundle import read_bundle_file
 from onyx.skills.bundle import slug_from_filename
+from onyx.skills.content import read_builtin_skill_instructions
+from onyx.skills.content import read_custom_skill_bundle_instructions
 from onyx.skills.ingest import delete_bundle_blob
 from onyx.skills.ingest import ingest_skill_bundle
 from onyx.skills.push import push_skill_to_affected_sandboxes
@@ -156,6 +159,25 @@ def _ensure_owned_personal(skill: Skill, user: User, db_session: Session) -> Non
         )
 
 
+def _preview_response_for_skill(
+    skill: Skill,
+) -> SkillPreviewResponse:
+    if skill.built_in_skill_id is not None:
+        definition = BUILT_IN_SKILLS.get(skill.built_in_skill_id)
+        if definition is None:
+            raise OnyxError(OnyxErrorCode.NOT_FOUND, "Skill not found")
+        return SkillPreviewResponse.from_builtin(
+            skill,
+            instructions_markdown=read_builtin_skill_instructions(definition),
+        )
+
+    instructions_markdown = read_custom_skill_bundle_instructions(skill)
+    return SkillPreviewResponse.from_custom(
+        skill,
+        instructions_markdown=instructions_markdown,
+    )
+
+
 @admin_router.get("")
 def list_skills_admin(
     _: User = Depends(current_curator_or_admin_user),
@@ -164,6 +186,18 @@ def list_skills_admin(
     rows = list(list_skills_for_admin(db_session=db_session))
     builtins, customs = _split_rows(rows, db_session, include_grants=True)
     return SkillsList(builtins=builtins, customs=customs)
+
+
+@admin_router.get("/{skill_id}/preview")
+def preview_skill_admin(
+    skill_id: UUID,
+    _: User = Depends(current_curator_or_admin_user),
+    db_session: Session = Depends(get_session),
+) -> SkillPreviewResponse:
+    skill = fetch_skill_by_id(skill_id, db_session)
+    if skill is None:
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "Skill not found")
+    return _preview_response_for_skill(skill)
 
 
 @admin_router.post("/custom")
@@ -365,6 +399,19 @@ def fetch_skill_for_current_user(
         group_ids=[],
         has_grants=bool(get_group_ids_for_skill(found.id, db_session)),
     )
+
+
+@user_router.get("/{skill_id}/preview")
+def preview_skill_for_current_user(
+    skill_id: UUID,
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> SkillPreviewResponse:
+    found = fetch_skill_for_user(skill_id, user, db_session)
+    if found is None:
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "Skill not found")
+
+    return _preview_response_for_skill(found)
 
 
 @user_router.post("/custom")

--- a/backend/onyx/server/features/skill/models.py
+++ b/backend/onyx/server/features/skill/models.py
@@ -24,6 +24,7 @@ class BuiltinSkillResponse(BaseModel):
     this response — they're row-level implementation detail."""
 
     source: Literal["builtin"] = "builtin"
+    id: UUID
     slug: str
     name: str
     description: str
@@ -38,6 +39,7 @@ class BuiltinSkillResponse(BaseModel):
         db_session: Session,
     ) -> "BuiltinSkillResponse":
         return cls(
+            id=skill.id,
             slug=skill.slug,
             name=skill.name,
             description=skill.description,
@@ -95,6 +97,47 @@ class CustomSkillResponse(BaseModel):
 class SkillsList(BaseModel):
     builtins: list[BuiltinSkillResponse]
     customs: list[CustomSkillResponse]
+
+
+class SkillPreviewResponse(BaseModel):
+    source: Literal["builtin", "custom"]
+    id: UUID
+    name: str
+    description: str
+    author_email: str | None = None
+    instructions_markdown: str
+
+    @classmethod
+    def from_builtin(
+        cls,
+        skill: Skill,
+        *,
+        instructions_markdown: str,
+    ) -> "SkillPreviewResponse":
+        return cls(
+            source="builtin",
+            id=skill.id,
+            name=skill.name,
+            description=skill.description,
+            author_email=None,
+            instructions_markdown=instructions_markdown,
+        )
+
+    @classmethod
+    def from_custom(
+        cls,
+        skill: Skill,
+        *,
+        instructions_markdown: str,
+    ) -> "SkillPreviewResponse":
+        return cls(
+            source="custom",
+            id=skill.id,
+            name=skill.name,
+            description=skill.description,
+            author_email=skill.author.email if skill.author is not None else None,
+            instructions_markdown=instructions_markdown,
+        )
 
 
 class SkillPatchRequest(BaseModel):

--- a/backend/onyx/skills/bundle.py
+++ b/backend/onyx/skills/bundle.py
@@ -138,6 +138,40 @@ def parse_skill_md_metadata(zip_bytes: bytes) -> tuple[str, str]:
     return name.strip(), description.strip()
 
 
+def strip_skill_md_frontmatter(content: str) -> str:
+    match = _FRONTMATTER_REGEX.match(content)
+    if match is None:
+        return content.strip()
+    return content[match.end() :].strip()
+
+
+def read_custom_bundle_instructions(zip_bytes: bytes, slug: str) -> str:
+    validate_custom_bundle(zip_bytes, slug=slug)
+    try:
+        zf = zipfile.ZipFile(io.BytesIO(zip_bytes))
+    except zipfile.BadZipFile:
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, "bundle is not a valid zip")
+
+    with zf:
+        try:
+            raw_skill_md = zf.read(SKILL_MD_NAME)
+        except KeyError:
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                "SKILL.md missing at bundle root",
+            )
+
+    try:
+        skill_md = raw_skill_md.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "SKILL.md must be UTF-8 encoded",
+        ) from exc
+
+    return strip_skill_md_frontmatter(skill_md)
+
+
 def _is_symlink(info: zipfile.ZipInfo) -> bool:
     """True if the zip entry was archived as a Unix symlink.
 

--- a/backend/onyx/skills/bundle.py
+++ b/backend/onyx/skills/bundle.py
@@ -145,28 +145,30 @@ def strip_skill_md_frontmatter(content: str) -> str:
     return content[match.end() :].strip()
 
 
-def read_custom_bundle_instructions(zip_bytes: bytes, slug: str) -> str:
-    validate_custom_bundle(zip_bytes, slug=slug)
+def read_custom_bundle_instructions(zip_bytes: bytes) -> str:
     try:
         zf = zipfile.ZipFile(io.BytesIO(zip_bytes))
-    except zipfile.BadZipFile:
-        raise OnyxError(OnyxErrorCode.INVALID_INPUT, "bundle is not a valid zip")
+    except zipfile.BadZipFile as exc:
+        raise OnyxError(
+            OnyxErrorCode.INTERNAL_ERROR,
+            "Stored skill bundle is not a valid zip.",
+        ) from exc
 
     with zf:
         try:
             raw_skill_md = zf.read(SKILL_MD_NAME)
-        except KeyError:
+        except KeyError as exc:
             raise OnyxError(
-                OnyxErrorCode.INVALID_INPUT,
-                "SKILL.md missing at bundle root",
-            )
+                OnyxErrorCode.INTERNAL_ERROR,
+                "Stored skill bundle is missing SKILL.md.",
+            ) from exc
 
     try:
         skill_md = raw_skill_md.decode("utf-8")
     except UnicodeDecodeError as exc:
         raise OnyxError(
-            OnyxErrorCode.INVALID_INPUT,
-            "SKILL.md must be UTF-8 encoded",
+            OnyxErrorCode.INTERNAL_ERROR,
+            "Stored skill bundle SKILL.md must be UTF-8 encoded.",
         ) from exc
 
     return strip_skill_md_frontmatter(skill_md)

--- a/backend/onyx/skills/content.py
+++ b/backend/onyx/skills/content.py
@@ -1,0 +1,50 @@
+"""Helpers for reading skill source content."""
+
+from onyx.db.models import Skill
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.file_store.file_store import FileStore
+from onyx.file_store.file_store import get_default_file_store
+from onyx.skills.built_in import BuiltInSkillDefinition
+from onyx.skills.bundle import read_custom_bundle_instructions
+from onyx.skills.bundle import SKILL_MD_NAME
+from onyx.skills.bundle import strip_skill_md_frontmatter
+from onyx.skills.bundle import TEMPLATE_SUFFIX
+
+
+def read_builtin_skill_instructions(definition: BuiltInSkillDefinition) -> str:
+    source_path = definition.source_dir / SKILL_MD_NAME
+    if not source_path.is_file():
+        source_path = definition.source_dir / f"{SKILL_MD_NAME}{TEMPLATE_SUFFIX}"
+    if not source_path.is_file():
+        raise OnyxError(
+            OnyxErrorCode.INTERNAL_ERROR,
+            f"Built-in skill '{definition.built_in_skill_id}' has no SKILL.md source.",
+        )
+    try:
+        return strip_skill_md_frontmatter(source_path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise OnyxError(
+            OnyxErrorCode.INTERNAL_ERROR,
+            f"Failed to read built-in skill '{definition.built_in_skill_id}'.",
+        ) from exc
+
+
+def read_custom_skill_bundle_instructions(
+    skill: Skill,
+    file_store: FileStore | None = None,
+) -> str:
+    if skill.bundle_file_id is None:
+        raise OnyxError(
+            OnyxErrorCode.INTERNAL_ERROR,
+            f"Custom skill '{skill.slug}' has no bundle.",
+        )
+    store = file_store or get_default_file_store()
+    try:
+        bundle_bytes = store.read_file(skill.bundle_file_id).read()
+    except Exception as exc:
+        raise OnyxError(
+            OnyxErrorCode.INTERNAL_ERROR,
+            f"Failed to read bundle for skill '{skill.slug}'.",
+        ) from exc
+    return read_custom_bundle_instructions(bundle_bytes, slug=skill.slug)

--- a/backend/onyx/skills/content.py
+++ b/backend/onyx/skills/content.py
@@ -47,4 +47,4 @@ def read_custom_skill_bundle_instructions(
             OnyxErrorCode.INTERNAL_ERROR,
             f"Failed to read bundle for skill '{skill.slug}'.",
         ) from exc
-    return read_custom_bundle_instructions(bundle_bytes, slug=skill.slug)
+    return read_custom_bundle_instructions(bundle_bytes)

--- a/backend/tests/unit/onyx/skills/test_bundle_validation.py
+++ b/backend/tests/unit/onyx/skills/test_bundle_validation.py
@@ -191,9 +191,12 @@ def test_read_custom_bundle_instructions_returns_instruction_body() -> None:
             ("docs/notes.md", b"# Notes\n"),
         ]
     )
-    assert read_custom_bundle_instructions(zip_bytes, slug="hello") == (
-        "# Instructions\n\nDo it."
-    )
+    assert read_custom_bundle_instructions(zip_bytes) == "# Instructions\n\nDo it."
+
+
+def test_read_custom_bundle_instructions_does_not_require_frontmatter() -> None:
+    zip_bytes = _build_zip([("SKILL.md", b"# Instructions\n\nDo it.")])
+    assert read_custom_bundle_instructions(zip_bytes) == "# Instructions\n\nDo it."
 
 
 def _zip_with_patched_compression_method(payload: bytes, method: int) -> bytes:

--- a/backend/tests/unit/onyx/skills/test_bundle_validation.py
+++ b/backend/tests/unit/onyx/skills/test_bundle_validation.py
@@ -17,7 +17,9 @@ from onyx.error_handling.exceptions import OnyxError
 from onyx.skills.bundle import _ZIP_UNIX_CREATE_SYSTEM
 from onyx.skills.bundle import compute_bundle_sha256
 from onyx.skills.bundle import parse_skill_md_metadata
+from onyx.skills.bundle import read_custom_bundle_instructions
 from onyx.skills.bundle import slug_from_filename
+from onyx.skills.bundle import strip_skill_md_frontmatter
 from onyx.skills.bundle import validate_custom_bundle
 
 
@@ -169,6 +171,29 @@ def test_compute_bundle_sha256_differs_for_same_content_different_timestamps() -
     b = _build_zip(entries, fixed_date=(2026, 6, 15, 12, 30, 0))
     assert a != b
     assert compute_bundle_sha256(a) != compute_bundle_sha256(b)
+
+
+def test_strip_skill_md_frontmatter_returns_instruction_body() -> None:
+    content = (
+        "---\nname: Demo\ndescription: Demo skill\n---\n\n# Instructions\n\nDo it."
+    )
+    assert strip_skill_md_frontmatter(content) == "# Instructions\n\nDo it."
+
+
+def test_read_custom_bundle_instructions_returns_instruction_body() -> None:
+    zip_bytes = _build_zip(
+        [
+            (
+                "SKILL.md",
+                b"---\nname: Demo\ndescription: Demo skill\n---\n\n# Instructions\n\nDo it.",
+            ),
+            ("scripts/run.py", b"print('hi')\n"),
+            ("docs/notes.md", b"# Notes\n"),
+        ]
+    )
+    assert read_custom_bundle_instructions(zip_bytes, slug="hello") == (
+        "# Instructions\n\nDo it."
+    )
 
 
 def _zip_with_patched_compression_method(payload: bytes, method: int) -> bytes:

--- a/backend/tests/unit/onyx/skills/test_content.py
+++ b/backend/tests/unit/onyx/skills/test_content.py
@@ -1,0 +1,68 @@
+import io
+import zipfile
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from onyx.db.models import Skill
+from onyx.file_store.file_store import FileStore
+from onyx.skills import built_in as built_in_module
+from onyx.skills.built_in import BuiltInSkillDefinition
+from onyx.skills.content import read_builtin_skill_instructions
+from onyx.skills.content import read_custom_skill_bundle_instructions
+
+
+def _build_zip(entries: list[tuple[str, bytes]]) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, data in entries:
+            zf.writestr(name, data)
+    return buf.getvalue()
+
+
+@pytest.fixture
+def built_in_definition(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> BuiltInSkillDefinition:
+    monkeypatch.setattr(built_in_module, "BUILTIN_SKILLS_PATH", tmp_path)
+    skill_id = "preview-test"
+    source_dir = tmp_path / skill_id
+    source_dir.mkdir()
+    return BuiltInSkillDefinition(built_in_skill_id=skill_id)
+
+
+def test_read_builtin_skill_instructions_strips_frontmatter(
+    built_in_definition: BuiltInSkillDefinition,
+) -> None:
+    (built_in_definition.source_dir / "SKILL.md").write_text(
+        "---\nname: Preview\ndescription: Demo\n---\n\n# Instructions\n\nDo it.",
+        encoding="utf-8",
+    )
+
+    assert (
+        read_builtin_skill_instructions(built_in_definition)
+        == "# Instructions\n\nDo it."
+    )
+
+
+def test_read_custom_skill_bundle_instructions_reads_bundle_from_file_store() -> None:
+    zip_bytes = _build_zip(
+        [
+            (
+                "SKILL.md",
+                b"---\nname: Preview\ndescription: Demo\n---\n\n# Instructions\n\nDo it.",
+            ),
+            ("scripts/run.py", b"print('hi')"),
+        ]
+    )
+    file_store = Mock(spec=FileStore)
+    file_store.read_file.return_value = io.BytesIO(zip_bytes)
+
+    instructions = read_custom_skill_bundle_instructions(
+        Skill(slug="preview-test", bundle_file_id="bundle-file-id"),
+        file_store,
+    )
+
+    file_store.read_file.assert_called_once_with("bundle-file-id")
+    assert instructions == "# Instructions\n\nDo it."

--- a/web/lib/opal/src/components/index.ts
+++ b/web/lib/opal/src/components/index.ts
@@ -55,6 +55,10 @@ export {
   type TextFont,
   type TextColor,
 } from "@opal/components/text/components";
+export {
+  default as CompactMarkdown,
+  type CompactMarkdownProps,
+} from "@opal/components/text/CompactMarkdown";
 
 /* Tag */
 export {

--- a/web/lib/opal/src/components/text/CompactMarkdown.tsx
+++ b/web/lib/opal/src/components/text/CompactMarkdown.tsx
@@ -1,0 +1,206 @@
+import type { ReactNode } from "react";
+import ReactMarkdown, { type Components } from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
+import Link from "next/link";
+import type { Route } from "next";
+
+import { cn } from "@opal/utils";
+
+const sanitizeSchema = {
+  ...defaultSchema,
+  protocols: {
+    ...defaultSchema.protocols,
+    href: [...(defaultSchema.protocols?.href ?? []), "tel"],
+  },
+};
+
+const ALLOWED_ELEMENTS = [
+  "p",
+  "br",
+  "a",
+  "strong",
+  "em",
+  "code",
+  "pre",
+  "del",
+  "blockquote",
+  "ul",
+  "ol",
+  "li",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "table",
+  "thead",
+  "tbody",
+  "tr",
+  "th",
+  "td",
+];
+
+const DEFAULT_COMPONENTS = {
+  h1: ({ node, ...props }) => (
+    <p
+      className="mt-3 first:mt-0 mb-1 text-sm font-semibold text-text-05"
+      {...props}
+    />
+  ),
+  h2: ({ node, ...props }) => (
+    <p
+      className="mt-3 first:mt-0 mb-1 text-sm font-semibold text-text-05"
+      {...props}
+    />
+  ),
+  h3: ({ node, ...props }) => (
+    <p
+      className="mt-2 first:mt-0 mb-1 text-sm font-semibold text-text-05"
+      {...props}
+    />
+  ),
+  h4: ({ node, ...props }) => (
+    <p
+      className="mt-2 first:mt-0 mb-1 text-sm font-medium text-text-05"
+      {...props}
+    />
+  ),
+  h5: ({ node, ...props }) => (
+    <p
+      className="mt-2 first:mt-0 mb-1 text-sm font-medium text-text-05"
+      {...props}
+    />
+  ),
+  h6: ({ node, ...props }) => (
+    <p
+      className="mt-2 first:mt-0 mb-1 text-sm font-medium text-text-05"
+      {...props}
+    />
+  ),
+  p: ({ node, ...props }) => (
+    <p className="my-1 text-sm leading-6 text-text-04" {...props} />
+  ),
+  ul: ({ node, ...props }) => (
+    <ul
+      className="my-1 pl-5 list-disc text-sm leading-6 text-text-04"
+      {...props}
+    />
+  ),
+  ol: ({ node, ...props }) => (
+    <ol
+      className="my-1 pl-5 list-decimal text-sm leading-6 text-text-04"
+      {...props}
+    />
+  ),
+  li: ({ node, ...props }) => <li className="my-0.5 pl-1" {...props} />,
+  strong: ({ node, ...props }) => (
+    <strong className="font-semibold text-text-05" {...props} />
+  ),
+  em: ({ node, ...props }) => <em className="text-text-04" {...props} />,
+  a: ({
+    children,
+    href,
+    ...props
+  }: {
+    children?: ReactNode;
+    href?: string;
+  }) => {
+    if (!href) return <>{children}</>;
+    const isRelative = href.startsWith("/") || href.startsWith("#");
+    if (isRelative) {
+      return (
+        <Link
+          href={href as Route}
+          className="text-link hover:text-link-hover underline underline-offset-2"
+          {...props}
+        >
+          {children}
+        </Link>
+      );
+    }
+    const isHttp = /^https?:/i.test(href);
+    return (
+      <a
+        href={href}
+        className="text-link hover:text-link-hover underline underline-offset-2"
+        {...(isHttp ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+        {...props}
+      >
+        {children}
+      </a>
+    );
+  },
+  blockquote: ({ node, ...props }) => (
+    <blockquote
+      className="my-2 border-l border-border-02 pl-3 text-sm text-text-03"
+      {...props}
+    />
+  ),
+  pre: ({ node, ...props }) => (
+    <pre
+      className="my-2 overflow-x-hidden whitespace-pre-wrap wrap-break-word rounded-08 border border-border-01 bg-background-tint-01 p-2 text-xs leading-5 text-text-04"
+      {...props}
+    />
+  ),
+  code: ({ node, className, ...props }) => (
+    <code
+      className={cn(
+        className,
+        className
+          ? "whitespace-pre-wrap wrap-break-word"
+          : "rounded-04 bg-background-tint-02 px-1 py-0.5 text-xs text-text-05 wrap-break-word"
+      )}
+      {...props}
+    />
+  ),
+  table: ({ node, ...props }) => (
+    <div className="my-2 overflow-hidden rounded-08 border border-border-01">
+      <table
+        className="w-full table-fixed border-collapse text-left text-xs"
+        {...props}
+      />
+    </div>
+  ),
+  th: ({ node, ...props }) => (
+    <th
+      className="border-b border-r border-border-01 bg-background-tint-01 px-2 py-1.5 align-top font-semibold text-text-05 wrap-break-word last:border-r-0"
+      {...props}
+    />
+  ),
+  td: ({ node, ...props }) => (
+    <td
+      className="border-b border-r border-border-01 px-2 py-1.5 align-top text-text-04 wrap-break-word last:border-r-0"
+      {...props}
+    />
+  ),
+} satisfies Components;
+
+export interface CompactMarkdownProps {
+  children: string;
+  className?: string;
+  components?: Partial<Components>;
+}
+
+export default function CompactMarkdown({
+  children,
+  className,
+  components,
+}: CompactMarkdownProps) {
+  return (
+    <ReactMarkdown
+      className={cn(
+        "max-w-full min-w-0 font-main-content-body wrap-break-word",
+        className
+      )}
+      allowedElements={ALLOWED_ELEMENTS}
+      unwrapDisallowed
+      components={{ ...DEFAULT_COMPONENTS, ...components }}
+      remarkPlugins={[remarkGfm]}
+      rehypePlugins={[[rehypeSanitize, sanitizeSchema]]}
+    >
+      {children}
+    </ReactMarkdown>
+  );
+}

--- a/web/lib/opal/src/components/text/CompactMarkdown.tsx
+++ b/web/lib/opal/src/components/text/CompactMarkdown.tsx
@@ -1,4 +1,3 @@
-import type { ReactNode } from "react";
 import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
@@ -99,14 +98,7 @@ const DEFAULT_COMPONENTS = {
     <strong className="font-semibold text-text-05" {...props} />
   ),
   em: ({ node, ...props }) => <em className="text-text-04" {...props} />,
-  a: ({
-    children,
-    href,
-    ...props
-  }: {
-    children?: ReactNode;
-    href?: string;
-  }) => {
+  a: ({ children, href, node: _node, ...props }) => {
     if (!href) return <>{children}</>;
     const isRelative = href.startsWith("/") || href.startsWith("#");
     if (isRelative) {

--- a/web/src/lib/skills/__fixtures__/picker.ts
+++ b/web/src/lib/skills/__fixtures__/picker.ts
@@ -10,6 +10,7 @@ import type {
 export function builtinFixture(over: Partial<BuiltinSkill> = {}): BuiltinSkill {
   return {
     source: "builtin",
+    id: "builtin-1",
     slug: "pptx",
     name: "PPTX",
     description: "Build PowerPoint decks.",

--- a/web/src/lib/swr-keys.ts
+++ b/web/src/lib/swr-keys.ts
@@ -120,6 +120,9 @@ export const SWR_KEYS = {
   // ── Skills ────────────────────────────────────────────────────────────────
   adminSkills: "/api/admin/skills",
   userSkills: "/api/skills",
+  adminSkillPreview: (skillId: string) =>
+    `/api/admin/skills/${skillId}/preview`,
+  userSkillPreview: (skillId: string) => `/api/skills/${skillId}/preview`,
 
   // ── Tools ─────────────────────────────────────────────────────────────────
   tools: "/api/tool",

--- a/web/src/sections/modals/SkillPreviewModal.tsx
+++ b/web/src/sections/modals/SkillPreviewModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import useSWR from "swr";
 import {
   Button,
@@ -9,6 +10,7 @@ import {
   Text,
 } from "@opal/components";
 import { SvgBlocks, SvgSimpleLoader } from "@opal/icons";
+import { cn } from "@opal/utils";
 import Modal from "@/refresh-components/Modal";
 import { Section } from "@/layouts/general-layouts";
 import { errorHandlingFetcher } from "@/lib/fetcher";
@@ -16,6 +18,15 @@ import { SWR_KEYS } from "@/lib/swr-keys";
 import type { SkillPreview } from "@/views/admin/SkillsPage/interfaces";
 
 type SkillPreviewMode = "admin" | "user";
+type InstructionsDisplayMode = "rendered" | "raw";
+
+const INSTRUCTIONS_DISPLAY_OPTIONS: {
+  value: InstructionsDisplayMode;
+  label: string;
+}[] = [
+  { value: "rendered", label: "Rendered" },
+  { value: "raw", label: "Raw" },
+];
 
 interface SkillPreviewModalProps {
   open: boolean;
@@ -51,6 +62,8 @@ export default function SkillPreviewModal({
   fallbackTitle = "Skill preview",
   onClose,
 }: SkillPreviewModalProps) {
+  const [instructionsDisplayMode, setInstructionsDisplayMode] =
+    useState<InstructionsDisplayMode>("rendered");
   const swrKey =
     open && skillId
       ? mode === "admin"
@@ -62,6 +75,14 @@ export default function SkillPreviewModal({
     error,
     isLoading,
   } = useSWR<SkillPreview>(swrKey, errorHandlingFetcher);
+  const instructionsMarkdown =
+    preview?.instructions_markdown || "No instructions found.";
+
+  useEffect(() => {
+    if (open) {
+      setInstructionsDisplayMode("rendered");
+    }
+  }, [open, skillId]);
 
   return (
     <Modal open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
@@ -111,13 +132,47 @@ export default function SkillPreviewModal({
               </div>
 
               <Section gap={0.25} alignItems="stretch">
-                <Text font="main-ui-action" color="text-05">
-                  Instructions
-                </Text>
-                <div className="rounded-lg border border-border p-3 overflow-y-auto overflow-x-hidden bg-background-50 max-h-[48dvh]">
-                  <CompactMarkdown>
-                    {preview.instructions_markdown || "No instructions found."}
-                  </CompactMarkdown>
+                <div className="flex items-center justify-between gap-2">
+                  <Text font="main-ui-action" color="text-05">
+                    Instructions
+                  </Text>
+                  <div
+                    role="group"
+                    className="inline-flex shrink-0 rounded-08 border border-border-01 bg-background-tint-01 p-0.5"
+                    aria-label="Instruction display mode"
+                  >
+                    {INSTRUCTIONS_DISPLAY_OPTIONS.map((option) => {
+                      const isSelected =
+                        option.value === instructionsDisplayMode;
+                      return (
+                        <button
+                          key={option.value}
+                          type="button"
+                          aria-pressed={isSelected}
+                          className={cn(
+                            "h-6 rounded-04 px-2 text-xs font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-border-04",
+                            isSelected
+                              ? "bg-background-neutral-00 text-text-05 shadow-sm"
+                              : "text-text-03 hover:text-text-05"
+                          )}
+                          onClick={() =>
+                            setInstructionsDisplayMode(option.value)
+                          }
+                        >
+                          {option.label}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+                <div className="rounded-lg border border-border p-3 overflow-y-auto overflow-x-hidden bg-background-neutral-00 max-h-[48dvh]">
+                  {instructionsDisplayMode === "rendered" ? (
+                    <CompactMarkdown>{instructionsMarkdown}</CompactMarkdown>
+                  ) : (
+                    <pre className="m-0 whitespace-pre-wrap wrap-break-word font-mono text-xs leading-5 text-text-04">
+                      {instructionsMarkdown}
+                    </pre>
+                  )}
                 </div>
               </Section>
             </Section>

--- a/web/src/sections/modals/SkillPreviewModal.tsx
+++ b/web/src/sections/modals/SkillPreviewModal.tsx
@@ -6,7 +6,6 @@ import {
   Button,
   CompactMarkdown,
   MessageCard,
-  Tag,
   Text,
   Tooltip,
 } from "@opal/components";
@@ -37,13 +36,6 @@ interface SkillPreviewModalProps {
   skillId: string | null;
   fallbackTitle?: string;
   onClose: () => void;
-}
-
-function statusTag(preview: SkillPreview) {
-  if (preview.source === "builtin") {
-    return <Tag title="Built-in" color="blue" />;
-  }
-  return <Tag title="Custom" color="gray" />;
 }
 
 function metadataRows(
@@ -114,14 +106,6 @@ export default function SkillPreviewModal({
           {preview && !isLoading && !error && (
             <Section gap={1} alignItems="stretch">
               <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
-                <div className="flex flex-col gap-1">
-                  <Text font="main-ui-action" color="text-05">
-                    Source
-                  </Text>
-                  <div className="flex flex-wrap items-center gap-1">
-                    {statusTag(preview)}
-                  </div>
-                </div>
                 {metadataRows(preview).map((row) => (
                   <div key={row.label} className="flex flex-col gap-1">
                     <Text font="main-ui-action" color="text-05">

--- a/web/src/sections/modals/SkillPreviewModal.tsx
+++ b/web/src/sections/modals/SkillPreviewModal.tsx
@@ -8,9 +8,11 @@ import {
   MessageCard,
   Tag,
   Text,
+  Tooltip,
 } from "@opal/components";
-import { SvgBlocks, SvgSimpleLoader } from "@opal/icons";
+import { SvgBlocks, SvgCode, SvgEye, SvgSimpleLoader } from "@opal/icons";
 import { cn } from "@opal/utils";
+import type { IconFunctionComponent } from "@opal/types";
 import Modal from "@/refresh-components/Modal";
 import { Section } from "@/layouts/general-layouts";
 import { errorHandlingFetcher } from "@/lib/fetcher";
@@ -23,9 +25,10 @@ type InstructionsDisplayMode = "rendered" | "raw";
 const INSTRUCTIONS_DISPLAY_OPTIONS: {
   value: InstructionsDisplayMode;
   label: string;
+  icon: IconFunctionComponent;
 }[] = [
-  { value: "rendered", label: "Rendered" },
-  { value: "raw", label: "Raw" },
+  { value: "rendered", label: "Rendered markdown", icon: SvgEye },
+  { value: "raw", label: "Raw markdown", icon: SvgCode },
 ];
 
 interface SkillPreviewModalProps {
@@ -144,23 +147,30 @@ export default function SkillPreviewModal({
                     {INSTRUCTIONS_DISPLAY_OPTIONS.map((option) => {
                       const isSelected =
                         option.value === instructionsDisplayMode;
+                      const Icon = option.icon;
                       return (
-                        <button
+                        <Tooltip
                           key={option.value}
-                          type="button"
-                          aria-pressed={isSelected}
-                          className={cn(
-                            "h-6 rounded-04 px-2 text-xs font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-border-04",
-                            isSelected
-                              ? "bg-background-neutral-00 text-text-05 shadow-sm"
-                              : "text-text-03 hover:text-text-05"
-                          )}
-                          onClick={() =>
-                            setInstructionsDisplayMode(option.value)
-                          }
+                          tooltip={option.label}
+                          side="top"
                         >
-                          {option.label}
-                        </button>
+                          <button
+                            type="button"
+                            aria-label={option.label}
+                            aria-pressed={isSelected}
+                            className={cn(
+                              "flex h-6 w-6 items-center justify-center rounded-04 transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-border-04",
+                              isSelected
+                                ? "bg-background-neutral-00 text-text-05 shadow-sm"
+                                : "text-text-03 hover:text-text-05"
+                            )}
+                            onClick={() =>
+                              setInstructionsDisplayMode(option.value)
+                            }
+                          >
+                            <Icon size={14} aria-hidden="true" />
+                          </button>
+                        </Tooltip>
                       );
                     })}
                   </div>

--- a/web/src/sections/modals/SkillPreviewModal.tsx
+++ b/web/src/sections/modals/SkillPreviewModal.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import useSWR from "swr";
+import {
+  Button,
+  CompactMarkdown,
+  MessageCard,
+  Tag,
+  Text,
+} from "@opal/components";
+import { SvgBlocks, SvgSimpleLoader } from "@opal/icons";
+import Modal from "@/refresh-components/Modal";
+import { Section } from "@/layouts/general-layouts";
+import { errorHandlingFetcher } from "@/lib/fetcher";
+import { SWR_KEYS } from "@/lib/swr-keys";
+import type { SkillPreview } from "@/views/admin/SkillsPage/interfaces";
+
+type SkillPreviewMode = "admin" | "user";
+
+interface SkillPreviewModalProps {
+  open: boolean;
+  mode: SkillPreviewMode;
+  skillId: string | null;
+  fallbackTitle?: string;
+  onClose: () => void;
+}
+
+function statusTag(preview: SkillPreview) {
+  if (preview.source === "builtin") {
+    return <Tag title="Built-in" color="blue" />;
+  }
+  return <Tag title="Custom" color="gray" />;
+}
+
+function metadataRows(
+  preview: SkillPreview
+): { label: string; value: string }[] {
+  const rows: { label: string; value: string }[] = [];
+  if (preview.source === "builtin") {
+    rows.push({ label: "Created by", value: "Onyx" });
+  } else if (preview.author_email) {
+    rows.push({ label: "Created by", value: preview.author_email });
+  }
+  return rows;
+}
+
+export default function SkillPreviewModal({
+  open,
+  mode,
+  skillId,
+  fallbackTitle = "Skill preview",
+  onClose,
+}: SkillPreviewModalProps) {
+  const swrKey =
+    open && skillId
+      ? mode === "admin"
+        ? SWR_KEYS.adminSkillPreview(skillId)
+        : SWR_KEYS.userSkillPreview(skillId)
+      : null;
+  const {
+    data: preview,
+    error,
+    isLoading,
+  } = useSWR<SkillPreview>(swrKey, errorHandlingFetcher);
+
+  return (
+    <Modal open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
+      <Modal.Content width="lg" height="lg">
+        <Modal.Header
+          icon={SvgBlocks}
+          title={preview?.name ?? fallbackTitle}
+          description={preview?.description}
+          onClose={onClose}
+        />
+        <Modal.Body>
+          {isLoading && (
+            <div className="flex items-center justify-center min-h-40">
+              <SvgSimpleLoader />
+            </div>
+          )}
+
+          {error && !isLoading && (
+            <MessageCard
+              variant="error"
+              title="Failed to load skill"
+              description="Try closing and opening the preview again."
+            />
+          )}
+
+          {preview && !isLoading && !error && (
+            <Section gap={1} alignItems="stretch">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+                <div className="flex flex-col gap-1">
+                  <Text font="main-ui-action" color="text-05">
+                    Source
+                  </Text>
+                  <div className="flex flex-wrap items-center gap-1">
+                    {statusTag(preview)}
+                  </div>
+                </div>
+                {metadataRows(preview).map((row) => (
+                  <div key={row.label} className="flex flex-col gap-1">
+                    <Text font="main-ui-action" color="text-05">
+                      {row.label}
+                    </Text>
+                    <Text font="main-ui-body" color="text-04">
+                      {row.value}
+                    </Text>
+                  </div>
+                ))}
+              </div>
+
+              <Section gap={0.25} alignItems="stretch">
+                <Text font="main-ui-action" color="text-05">
+                  Instructions
+                </Text>
+                <div className="rounded-lg border border-border p-3 overflow-y-auto overflow-x-hidden bg-background-50 max-h-[48dvh]">
+                  <CompactMarkdown>
+                    {preview.instructions_markdown || "No instructions found."}
+                  </CompactMarkdown>
+                </div>
+              </Section>
+            </Section>
+          )}
+        </Modal.Body>
+        <Modal.Footer>
+          <Button onClick={onClose}>Close</Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal>
+  );
+}

--- a/web/src/views/UserSkillsPage.tsx
+++ b/web/src/views/UserSkillsPage.tsx
@@ -16,6 +16,7 @@ import SkillCard, {
 } from "@/sections/cards/SkillCard";
 import CreatePersonalSkillModal from "@/views/UserSkillsPage/CreatePersonalSkillModal";
 import { ConfirmEntityModal } from "@/sections/modals/ConfirmEntityModal";
+import SkillPreviewModal from "@/sections/modals/SkillPreviewModal";
 import {
   deleteUserSkill,
   patchUserSkill,
@@ -33,6 +34,9 @@ export default function UserSkillsPage() {
   const [searchQuery, setSearchQuery] = useState("");
   const [createOpen, setCreateOpen] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<CustomSkillCardItem | null>(
+    null
+  );
+  const [previewTarget, setPreviewTarget] = useState<SkillCardItem | null>(
     null
   );
   const searchInputRef = useRef<HTMLInputElement>(null);
@@ -114,7 +118,7 @@ export default function UserSkillsPage() {
   const items = useMemo<SkillCardItem[]>(() => {
     if (!data) return [];
     const builtinItems: SkillCardItem[] = data.builtins.map((b) => ({
-      id: `builtin:${b.slug}`,
+      id: b.id,
       name: b.name,
       description: b.description,
       source: "builtin",
@@ -231,6 +235,7 @@ export default function UserSkillsPage() {
                         onReplaceBundle={handleReplaceBundleClick}
                         onDelete={setDeleteTarget}
                         onToggleEnabled={handleToggleEnabled}
+                        onClick={setPreviewTarget}
                       />
                     ))}
                   </div>
@@ -278,6 +283,14 @@ export default function UserSkillsPage() {
           onSubmit={handleDeleteConfirmed}
         />
       )}
+
+      <SkillPreviewModal
+        open={previewTarget !== null}
+        mode="user"
+        skillId={previewTarget?.id ?? null}
+        fallbackTitle={previewTarget?.name}
+        onClose={() => setPreviewTarget(null)}
+      />
     </SettingsLayouts.Root>
   );
 }

--- a/web/src/views/admin/SkillsPage.tsx
+++ b/web/src/views/admin/SkillsPage.tsx
@@ -14,12 +14,16 @@ import BuiltinSkillsTable from "@/views/admin/SkillsPage/BuiltinSkillsTable";
 import CustomSkillsTable from "@/views/admin/SkillsPage/CustomSkillsTable";
 import UploadSkillModal from "@/views/admin/SkillsPage/UploadSkillModal";
 import ShareSkillModal from "@/views/admin/SkillsPage/ShareSkillModal";
+import SkillPreviewModal from "@/sections/modals/SkillPreviewModal";
 import {
   deleteCustomSkill,
   patchCustomSkill,
   replaceCustomSkillBundle,
 } from "@/lib/skills/api";
-import type { CustomSkill } from "@/views/admin/SkillsPage/interfaces";
+import type {
+  BuiltinSkill,
+  CustomSkill,
+} from "@/views/admin/SkillsPage/interfaces";
 
 // ---------------------------------------------------------------------------
 // Page
@@ -34,6 +38,9 @@ export default function SkillsPage({ onBack }: SkillsPageProps = {}) {
 
   const [uploadOpen, setUploadOpen] = useState(false);
   const [shareTarget, setShareTarget] = useState<CustomSkill | null>(null);
+  const [previewTarget, setPreviewTarget] = useState<
+    BuiltinSkill | CustomSkill | null
+  >(null);
   const replaceBundleTarget = useRef<CustomSkill | null>(null);
   const replaceFileRef = useRef<HTMLInputElement>(null);
 
@@ -134,7 +141,10 @@ export default function SkillsPage({ onBack }: SkillsPageProps = {}) {
                   description="Built-ins ship with the deploy."
                 />
               ) : (
-                <BuiltinSkillsTable skills={data.builtins} />
+                <BuiltinSkillsTable
+                  skills={data.builtins}
+                  onPreviewSkill={setPreviewTarget}
+                />
               )}
             </Section>
 
@@ -154,6 +164,7 @@ export default function SkillsPage({ onBack }: SkillsPageProps = {}) {
                 onReplaceBundle={handleReplaceBundleClick}
                 onToggleEnabled={handleToggleEnabled}
                 onDeleteSkill={handleDelete}
+                onPreviewSkill={setPreviewTarget}
               />
             </Section>
           </Section>
@@ -181,6 +192,14 @@ export default function SkillsPage({ onBack }: SkillsPageProps = {}) {
         open={shareTarget !== null}
         onClose={() => setShareTarget(null)}
         onSaved={refresh}
+      />
+
+      <SkillPreviewModal
+        open={previewTarget !== null}
+        mode="admin"
+        skillId={previewTarget?.id ?? null}
+        fallbackTitle={previewTarget?.name}
+        onClose={() => setPreviewTarget(null)}
       />
     </SettingsLayouts.Root>
   );

--- a/web/src/views/admin/SkillsPage/BuiltinSkillsTable.tsx
+++ b/web/src/views/admin/SkillsPage/BuiltinSkillsTable.tsx
@@ -15,6 +15,7 @@ import { DEFAULT_PAGE_SIZE } from "@/lib/constants";
 
 interface BuiltinSkillsTableProps {
   skills: BuiltinSkill[];
+  onPreviewSkill: (skill: BuiltinSkill) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -75,6 +76,7 @@ const COLUMNS = [
 
 export default function BuiltinSkillsTable({
   skills,
+  onPreviewSkill,
 }: BuiltinSkillsTableProps) {
   const columns = useMemo(() => COLUMNS, []);
 
@@ -82,8 +84,9 @@ export default function BuiltinSkillsTable({
     <Table
       data={skills}
       columns={columns}
-      getRowId={(row) => row.slug}
+      getRowId={(row) => row.id}
       pageSize={DEFAULT_PAGE_SIZE}
+      onRowClick={onPreviewSkill}
     />
   );
 }

--- a/web/src/views/admin/SkillsPage/CustomSkillsTable.tsx
+++ b/web/src/views/admin/SkillsPage/CustomSkillsTable.tsx
@@ -24,6 +24,7 @@ interface CustomSkillsTableProps {
   onReplaceBundle: (skill: CustomSkill) => void;
   onToggleEnabled: (skill: CustomSkill) => void;
   onDeleteSkill: (skill: CustomSkill) => void;
+  onPreviewSkill: (skill: CustomSkill) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -63,6 +64,7 @@ export default function CustomSkillsTable({
   onReplaceBundle,
   onToggleEnabled,
   onDeleteSkill,
+  onPreviewSkill,
 }: CustomSkillsTableProps) {
   const [searchTerm, setSearchTerm] = useState("");
 
@@ -146,6 +148,7 @@ export default function CustomSkillsTable({
         getRowId={(row) => row.id}
         pageSize={DEFAULT_PAGE_SIZE}
         searchTerm={searchTerm}
+        onRowClick={onPreviewSkill}
         emptyState={
           <IllustrationContent
             illustration={SvgNoResult}

--- a/web/src/views/admin/SkillsPage/interfaces.ts
+++ b/web/src/views/admin/SkillsPage/interfaces.ts
@@ -21,6 +21,7 @@ export type SkillVisibility = "private" | "groups" | "org_wide";
 
 export interface BuiltinSkill {
   source: "builtin";
+  id: string;
   slug: string;
   name: string;
   description: string;
@@ -48,4 +49,13 @@ export interface CustomSkill {
 export interface SkillsList {
   builtins: BuiltinSkill[];
   customs: CustomSkill[];
+}
+
+export interface SkillPreview {
+  source: SkillSource;
+  id: string;
+  name: string;
+  description: string;
+  author_email: string | null;
+  instructions_markdown: string;
 }


### PR DESCRIPTION
## Description
<img width="840" height="865" alt="image" src="https://github.com/user-attachments/assets/f725873a-be3a-48bb-9231-7c86c9529d76" />

- Adds skill preview endpoints and a unified preview response for built-in and custom skills.
- Adds a reusable Opal CompactMarkdown renderer for compact block markdown in preview surfaces.
- Wires skill preview modals into the user skills page and admin skills tables.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a skill preview modal across admin and user flows. Renders sanitized, compact markdown from SKILL.md with a toggle to view raw instructions.

- **New Features**
  - Endpoints: `GET /api/admin/skills/{id}/preview` and `GET /api/skills/{id}/preview`.
  - Unified `SkillPreviewResponse` with `source`, `id`, `name`, `description`, `author_email`, `instructions_markdown`.
  - Instruction sources: built-ins read `SKILL.md` or `SKILL.md.template`; customs read from bundle; both strip frontmatter.
  - UI: `CompactMarkdown` in `@opal/components` (GFM + sanitize) and `SkillPreviewModal` with Rendered/Raw toggle; wired to User Skills and Admin Skills (row click).
  - SWR keys: `adminSkillPreview(id)`, `userSkillPreview(id)`; built-in skills API now returns `id` and the frontend uses it for row keys and clicks.

- **Refactors**
  - Preview mode toggle uses icon buttons with tooltips (eye/code).
  - Preview metadata simplified to show only creator (Onyx or author email).

<sup>Written for commit ca491433bb2267e2cb1f60778a5b5a8c8884435f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



