### PR TITLE
refactor(web): replace @phosphor-icons/react with Opal icons

### DIFF
--- a/web/bun.lock
+++ b/web/bun.lock
@@ -15,7 +15,6 @@
         "@headlessui/tailwindcss": "^0.2.1",
         "@onyx-ai/opal": "file:./lib/opal",
         "@onyx-ai/shared": "file:./lib/shared",
-        "@phosphor-icons/react": "^2.0.8",
         "@radix-ui/react-accordion": "^1.2.2",
         "@radix-ui/react-avatar": "^1.1.10",
         "@radix-ui/react-collapsible": "^1.1.2",
@@ -637,8 +636,6 @@
     "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.71.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-W4HvOHGzVLHcrmFu+bMrJlho+/yrlX5ZNdJZqGe8MEldkQG+RHYhxxad9P4jvWAYFmIqUA5i9DQ8QsJqSU9GIw=="],
 
     "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.71.0", "", { "os": "win32", "cpu": "x64" }, "sha512-D2kyEIPHk/G/wiZLnwTVC/sVst+T/lKldVOjAFpgTIBUAOlry72e5OiapDbDBF4LfJLkN5ypJb/8Eu6yJzkveQ=="],
-
-    "@phosphor-icons/react": ["@phosphor-icons/react@2.1.10", "", { "peerDependencies": { "react": ">= 16.8", "react-dom": ">= 16.8" } }, "sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 

--- a/web/jest.config.js
+++ b/web/jest.config.js
@@ -19,7 +19,6 @@ const esmPackages = [
   "@radix-ui",
   "@floating-ui",
   "@headlessui",
-  "@phosphor-icons",
   // Testing & Mocking
   "msw",
   "until-async",

--- a/web/package.json
+++ b/web/package.json
@@ -41,7 +41,6 @@
     "@headlessui/tailwindcss": "^0.2.1",
     "@onyx-ai/opal": "file:./lib/opal",
     "@onyx-ai/shared": "file:./lib/shared",
-    "@phosphor-icons/react": "^2.0.8",
     "@radix-ui/react-accordion": "^1.2.2",
     "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-collapsible": "^1.1.2",

--- a/web/src/app/admin/documents/explorer/Explorer.tsx
+++ b/web/src/app/admin/documents/explorer/Explorer.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { adminSearch } from "./lib";
-import { MagnifyingGlass } from "@phosphor-icons/react";
 import { useState, useEffect, useCallback } from "react";
 import { OnyxDocument } from "@/lib/search/interfaces";
 import { buildDocumentSummaryDisplay } from "@/components/search/DocumentDisplay";

--- a/web/src/app/ee/admin/standard-answer/page.tsx
+++ b/web/src/app/ee/admin/standard-answer/page.tsx
@@ -17,7 +17,7 @@ import {
 import Link from "next/link";
 import type { Route } from "next";
 import { StandardAnswer, StandardAnswerCategory } from "@/lib/types";
-import { MagnifyingGlass } from "@phosphor-icons/react";
+import { SvgSearch } from "@opal/icons";
 import { useState, JSX } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -237,7 +237,7 @@ const StandardAnswersTable = ({
   return (
     <div className="justify-center py-2">
       <div className="flex items-center w-full border-2 border-border rounded-lg px-4 py-2 focus-within:border-accent">
-        <MagnifyingGlass />
+        <SvgSearch className="w-4 h-4" />
         <textarea
           autoFocus
           className="grow ml-2 h-6 bg-transparent outline-hidden placeholder-subtle overflow-hidden whitespace-normal resize-none"


### PR DESCRIPTION
## Summary

Removes the `@phosphor-icons/react` dependency and replaces its only usages with Opal icons, continuing the migration to the Opal design system.

The library was used in just two places, both for `MagnifyingGlass`:
- **`standard-answer/page.tsx`** — replaced with Opal's `SvgSearch` (sized `w-4 h-4` to match Phosphor's default 1em). `SvgSearch` already uses `stroke="currentColor"`, so it inherits text color like the old icon.
- **`Explorer.tsx`** — the import was dead (never rendered), so it's simply removed.

The dependency is also dropped from `package.json`, the bun lockfile (`bun install` removed 1 package), and the Jest ESM-transform list in `jest.config.js`.

## Testing
- `bunx oxlint` passes on both changed files.
- No remaining `@phosphor-icons` references anywhere in source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced `@phosphor-icons/react` with Opal icons to continue the move to the Opal design system. Swapped the only usage to `@opal/icons` and removed the dependency.

- **Refactors**
  - `ee/admin/standard-answer/page.tsx`: Replace `MagnifyingGlass` with `SvgSearch` (`className="w-4 h-4"`).
  - `admin/documents/explorer/Explorer.tsx`: Remove unused `MagnifyingGlass` import.

- **Dependencies**
  - Remove `@phosphor-icons/react` from `package.json`, `bun.lock`, and the ESM transform list in `jest.config.js`.

<sup>Written for commit a1cc1998d1fa19e46f880cd19804de567af6d55b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12532?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

