### PR TITLE
fix(desktop): keep app content below the macOS native title bar after login

### DIFF
--- a/desktop/src/titlebar.js
+++ b/desktop/src/titlebar.js
@@ -60,39 +60,51 @@
         }
       }
 
-      html,
-      body {
-        height: var(--onyx-desktop-viewport-height);
-        min-height: var(--onyx-desktop-viewport-height);
-        margin: 0;
-        padding: 0;
-        overflow: hidden;
-      }
-
-      body {
-        padding-top: var(--onyx-desktop-titlebar-height) !important;
+      /* Reserve the native overlay-titlebar strip on the ROOT element. Doing
+         this on <html> (rather than <body>) keeps the reservation working no
+         matter how the embedded web app structures or restyles <body>, and
+         shifts every normal-flow descendant below the titlebar. box-sizing +
+         padding-top carves out the strip; the fixed titlebar element is drawn
+         on top of it. */
+      html {
         box-sizing: border-box;
+        height: var(--onyx-desktop-viewport-height) !important;
+        padding-top: var(--onyx-desktop-titlebar-height) !important;
+        overflow: hidden !important;
       }
 
-      body > div#__next,
-      body > div#root,
-      body > main {
-        height: var(--onyx-desktop-safe-height);
-        min-height: var(--onyx-desktop-safe-height);
-        overflow: auto;
-      }
-
-      /* Override common Tailwind viewport helpers so content fits under the titlebar */
-      .h-screen {
+      body {
         height: var(--onyx-desktop-safe-height) !important;
+        min-height: 0 !important;
+        margin: 0 !important;
+        overflow: hidden !important;
+      }
+
+      /* Clamp full-viewport-height containers to the area BELOW the titlebar so
+         their bottom edge doesn't overflow past the window. Covers raw Tailwind
+         utilities AND the Opal layout classes that bake height:100vh into a
+         compiled class name via @apply (which the utility overrides miss). */
+      .h-screen,
+      .max-h-screen,
+      .opal-sidebar-root__column,
+      .opal-sidebar-root__overlay[data-variant="mobile"],
+      .opal-sidebar-root__overlay[data-variant="medium"] {
+        height: var(--onyx-desktop-safe-height) !important;
+        max-height: var(--onyx-desktop-safe-height) !important;
       }
 
       .min-h-screen {
         min-height: var(--onyx-desktop-safe-height) !important;
       }
 
-      .max-h-screen {
-        max-height: var(--onyx-desktop-safe-height) !important;
+      /* Fixed sidebar overlays / backdrops are positioned against the viewport,
+         so inset-y-0 pins them to y=0 (under the traffic lights). Re-anchor them
+         below the titlebar. */
+      .opal-sidebar-root__overlay[data-variant="mobile"],
+      .opal-sidebar-root__overlay[data-variant="medium"],
+      .opal-sidebar-root__backdrop {
+        top: var(--onyx-desktop-titlebar-height) !important;
+        bottom: 0 !important;
       }
 
       #${TITLEBAR_ID} {

--- a/web/src/app/css/desktop-titlebar.css
+++ b/web/src/app/css/desktop-titlebar.css
@@ -1,0 +1,73 @@
+/*
+  Desktop (Tauri) native title-bar reservation.
+
+  The Onyx desktop app is a Tauri wrapper that loads this web app remotely and
+  uses macOS `titleBarStyle: "Overlay"` — the traffic lights float over the web
+  content, so the app must keep the top strip clear. The desktop wrapper injects
+  a `titlebar.js` shim to do this, but that shim ships frozen inside installed
+  binaries: when the web layout changes, already-installed apps don't get the
+  update. These rules let the web app reserve the strip itself, so the fix
+  reaches every existing install via the remote bundle without a desktop release.
+
+  Activated by the `onyx-desktop` class added to <html> (see the inline detector
+  in app/layout.tsx). All rules are gated on `html.onyx-desktop`, so browser
+  users are completely unaffected. The selectors are deliberately more specific
+  than the shim's (`.onyx-desktop` + element/id), and this sheet is imported
+  unlayered, so it deterministically wins over every shim version — producing a
+  single inset (never a doubled 72px gap) regardless of which shim is present.
+
+  Window dragging is still provided by the shim's fixed drag strip, which sits on
+  top of the reserved zone.
+*/
+
+html.onyx-desktop {
+  --onyx-titlebar-height: 36px;
+
+  box-sizing: border-box;
+  height: 100dvh !important;
+  /* Carve out the title-bar strip at the root so every normal-flow descendant
+     is pushed below it, no matter how the app structures <body>. */
+  padding-top: var(--onyx-titlebar-height) !important;
+  overflow: hidden !important;
+}
+
+html.onyx-desktop > body {
+  height: calc(100dvh - var(--onyx-titlebar-height)) !important;
+  min-height: 0 !important;
+  /* Cancel any title-bar padding a shim may have put on <body> so it doesn't
+     stack with the root padding above. */
+  padding-top: 0 !important;
+  margin: 0 !important;
+  overflow: hidden !important;
+}
+
+/*
+  Clamp full-viewport-height containers to the area below the title bar so their
+  bottom edge doesn't overflow past the window. Covers raw Tailwind utilities AND
+  the Opal layout classes that compile `height: 100vh` into a class name via
+  @apply (which utility-class overrides can't reach).
+*/
+html.onyx-desktop .h-screen,
+html.onyx-desktop .max-h-screen,
+html.onyx-desktop .opal-sidebar-root__column,
+html.onyx-desktop .opal-sidebar-root__overlay[data-variant="mobile"],
+html.onyx-desktop .opal-sidebar-root__overlay[data-variant="medium"] {
+  height: calc(100dvh - var(--onyx-titlebar-height)) !important;
+  max-height: calc(100dvh - var(--onyx-titlebar-height)) !important;
+}
+
+html.onyx-desktop .min-h-screen {
+  min-height: calc(100dvh - var(--onyx-titlebar-height)) !important;
+}
+
+/*
+  Fixed sidebar overlays / backdrops are positioned against the viewport, so
+  `inset-y-0` pins them to y=0 (under the traffic lights). Re-anchor them below
+  the title bar.
+*/
+html.onyx-desktop .opal-sidebar-root__overlay[data-variant="mobile"],
+html.onyx-desktop .opal-sidebar-root__overlay[data-variant="medium"],
+html.onyx-desktop .opal-sidebar-root__backdrop {
+  top: var(--onyx-titlebar-height) !important;
+  bottom: 0 !important;
+}

--- a/web/src/app/css/desktop-titlebar.css
+++ b/web/src/app/css/desktop-titlebar.css
@@ -21,7 +21,10 @@
 */
 
 html.onyx-desktop {
-  --onyx-titlebar-height: 36px;
+  /* Inherit the desktop shim's titlebar height when it is present, so the two
+     layers can't silently diverge. The 36px literal is the single fallback
+     source of truth for when no shim has set the variable. */
+  --onyx-titlebar-height: var(--onyx-desktop-titlebar-height, 36px);
 
   box-sizing: border-box;
   height: 100dvh !important;

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -12,6 +12,9 @@
 @import "./css/line-item.css" layer(base);
 @import "./css/square-button.css" layer(base);
 @import "./css/z-index.css" layer(base);
+/* Imported unlayered (and gated on html.onyx-desktop) so it overrides the
+   frozen desktop-wrapper shim regardless of source order. */
+@import "./css/desktop-titlebar.css";
 @config '../../tailwind.config.js';
 
 /*

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -76,6 +76,34 @@ export default function Layout({ children }: LayoutProps) {
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0, interactive-widget=resizes-content"
         />
 
+        {/* Tag <html> as desktop before paint when running inside the Tauri
+            wrapper, so the native title-bar reservation in
+            css/desktop-titlebar.css engages. Retries briefly in case the Tauri
+            globals aren't injected yet at parse time. No-op in a browser. */}
+        <Script
+          id="onyx-desktop-detector"
+          strategy="beforeInteractive"
+          dangerouslySetInnerHTML={{
+            __html: `
+              (function () {
+                function mark() {
+                  if ('__TAURI_INTERNALS__' in window || '__TAURI__' in window) {
+                    document.documentElement.classList.add('onyx-desktop');
+                    return true;
+                  }
+                  return false;
+                }
+                if (!mark()) {
+                  var tries = 0;
+                  var timer = setInterval(function () {
+                    if (mark() || ++tries > 20) clearInterval(timer);
+                  }, 50);
+                }
+              })();
+            `,
+          }}
+        />
+
         {GTM_ENABLED && (
           <Script
             id="google-tag-manager"
@@ -94,16 +122,6 @@ export default function Layout({ children }: LayoutProps) {
       </head>
 
       <body className={`relative font-hanken`}>
-        {/* Tag <html> as desktop ASAP (before paint) when running inside the
-            Tauri wrapper, so the native title-bar reservation in
-            css/desktop-titlebar.css engages. Retries briefly in case the Tauri
-            globals aren't injected yet at parse time. No-op in a browser. */}
-        <script
-          dangerouslySetInnerHTML={{
-            __html:
-              "(function(){function m(){if('__TAURI_INTERNALS__' in window||'__TAURI__' in window){document.documentElement.classList.add('onyx-desktop');return true}return false}if(!m()){var n=0,t=setInterval(function(){if(m()||++n>20)clearInterval(t)},50)}})();",
-          }}
-        />
         <ThemeProvider
           attribute="class"
           defaultTheme="system"

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -94,6 +94,16 @@ export default function Layout({ children }: LayoutProps) {
       </head>
 
       <body className={`relative font-hanken`}>
+        {/* Tag <html> as desktop ASAP (before paint) when running inside the
+            Tauri wrapper, so the native title-bar reservation in
+            css/desktop-titlebar.css engages. Retries briefly in case the Tauri
+            globals aren't injected yet at parse time. No-op in a browser. */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html:
+              "(function(){function m(){if('__TAURI_INTERNALS__' in window||'__TAURI__' in window){document.documentElement.classList.add('onyx-desktop');return true}return false}if(!m()){var n=0,t=setInterval(function(){if(m()||++n>20)clearInterval(t)},50)}})();",
+          }}
+        />
         <ThemeProvider
           attribute="class"
           defaultTheme="system"

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -76,30 +76,20 @@ export default function Layout({ children }: LayoutProps) {
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0, interactive-widget=resizes-content"
         />
 
-        {/* Tag <html> as desktop before paint when running inside the Tauri
-            wrapper, so the native title-bar reservation in
-            css/desktop-titlebar.css engages. Retries briefly in case the Tauri
-            globals aren't injected yet at parse time. No-op in a browser. */}
+        {/* When running inside the Tauri desktop wrapper, tag <html> as desktop
+            so the native title-bar reservation in css/desktop-titlebar.css
+            engages before paint. Tauri injects its IPC globals via an init
+            script that runs before page scripts, so this synchronous check sees
+            them; the class then persists across client-side navigations. No-op
+            in a browser. */}
         <Script
           id="onyx-desktop-detector"
           strategy="beforeInteractive"
           dangerouslySetInnerHTML={{
             __html: `
-              (function () {
-                function mark() {
-                  if ('__TAURI_INTERNALS__' in window || '__TAURI__' in window) {
-                    document.documentElement.classList.add('onyx-desktop');
-                    return true;
-                  }
-                  return false;
-                }
-                if (!mark()) {
-                  var tries = 0;
-                  var timer = setInterval(function () {
-                    if (mark() || ++tries > 20) clearInterval(timer);
-                  }, 50);
-                }
-              })();
+              if ('__TAURI_INTERNALS__' in window || '__TAURI__' in window) {
+                document.documentElement.classList.add('onyx-desktop');
+              }
             `,
           }}
         />


### PR DESCRIPTION
## Description

Fixes #12158.

Fixes the macOS desktop app window freezing / UI clipping into the title bar after login (reported in #12158).

**Root cause.** The desktop app is a Tauri wrapper that loads the web app remotely and uses macOS `titleBarStyle: "Overlay"`, so the web UI must keep the top strip clear of the traffic lights. The wrapper's injected `titlebar.js` shim reserved that space via `body { padding-top }` and by overriding the literal `.h-screen` utility. The Opal layout migration broke **both** hooks: it restructured `<body>` and baked `height: 100vh` into compiled class names (e.g. `.opal-sidebar-root__column`) via `@apply`, which a `.h-screen` utility override can no longer reach. So after login the authenticated shell painted flush to `y=0` — clipping the sidebar under the traffic lights and stealing window-drag — while the login page (normal flow) stayed fine.

**Fix (two layers):**

- **Desktop shim** (`desktop/src/titlebar.js`): reserve the strip on `<html>` instead of `<body>` so the offset survives however the app structures `<body>`, cap the Opal full-viewport classes, and re-anchor the fixed sidebar overlays below the strip.
- **Web app** (`web/`): the same reservation, gated on `html.onyx-desktop` (added by an early Tauri detector in `layout.tsx`), in a new `css/desktop-titlebar.css` imported **unlayered** with higher specificity than any shim selector. This reaches existing installs through the remote bundle **without a desktop release**, and is idempotent with the shim (single 36px inset, never doubled). Every rule is a no-op outside the desktop app.

## How Has This Been Tested?

- Desktop shim verified locally via `cd desktop && bun run debug` against cloud: after login the sidebar logo sits below the traffic lights (no clip) and the window drags again.
- Web layer is gated entirely behind `html.onyx-desktop`, so browser users are unaffected; selectors/specificity were chosen so it deterministically overrides any shim version without doubling the inset. To preview before deploy: point the desktop app's Settings → Root Domain at a local web build.

<img width="1478" height="631" alt="Screenshot 2026-06-29 at 3 50 54 PM" src="https://github.com/user-attachments/assets/eb6a43e9-76ef-481f-9fdc-10b11207015d" />

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes macOS desktop UI clipping into the native overlay title bar after login. Reserves the title bar strip at the root and clamps full-height layouts so content sits below the traffic lights; window drag works again.

- **Bug Fixes**
  - Desktop shim (`desktop/src/titlebar.js`): reserve space on `<html>` (not `<body>`), cap `.h-screen`/Opal full-viewport classes, and re-anchor sidebar overlays/backdrop below the strip.
  - Web app: add `web/src/app/css/desktop-titlebar.css` gated by `html.onyx-desktop`, imported unlayered in `globals.css`; source the height from `--onyx-desktop-titlebar-height` with a 36px fallback; early detector in `layout.tsx` uses `next/script` with `beforeInteractive` (retry loop removed to avoid layout jumps). Ships to existing installs and remains idempotent with the shim (single inset).

<sup>Written for commit 4e1a67466424f18d52ef1609abf759ec94b0440b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



