### PR TITLE
feat(tracing): admin API for tracing providers (PR 2/3, stacked on #12529)

### DIFF
--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -133,6 +133,7 @@ from onyx.server.manage.opensearch_migration.api import (
 )
 from onyx.server.manage.search_settings import router as search_settings_router
 from onyx.server.manage.slack_bot import router as slack_bot_management_router
+from onyx.server.manage.tracing.api import admin_router as tracing_admin_router
 from onyx.server.manage.users import router as user_router
 from onyx.server.manage.voice.api import admin_router as voice_admin_router
 from onyx.server.manage.voice.user_api import router as voice_router
@@ -560,6 +561,7 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
     include_router_with_global_prefix_prepended(application, embedding_router)
     include_router_with_global_prefix_prepended(application, web_search_router)
     include_router_with_global_prefix_prepended(application, web_search_admin_router)
+    include_router_with_global_prefix_prepended(application, tracing_admin_router)
     include_router_with_global_prefix_prepended(application, voice_admin_router)
     include_router_with_global_prefix_prepended(application, voice_router)
     include_router_with_global_prefix_prepended(application, voice_websocket_router)

--- a/backend/onyx/server/manage/tracing/api.py
+++ b/backend/onyx/server/manage/tracing/api.py
@@ -61,11 +61,12 @@ def _build_view(
     row: TracingProviderConfig | None,
     effective: EffectiveTracingConfig,
 ) -> TracingProviderView:
-    is_connected = (
-        effective.braintrust is not None
-        if provider_type == TracingProviderType.BRAINTRUST
-        else effective.langfuse is not None
-    )
+    if provider_type == TracingProviderType.BRAINTRUST:
+        is_connected = effective.braintrust is not None
+    elif provider_type == TracingProviderType.LANGFUSE:
+        is_connected = effective.langfuse is not None
+    else:
+        is_connected = False
     if row is not None:
         return TracingProviderView(
             provider_type=provider_type,

--- a/backend/onyx/server/manage/tracing/api.py
+++ b/backend/onyx/server/manage/tracing/api.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+from fastapi import Depends
+from sqlalchemy.orm import Session
+
+from onyx.auth.permissions import require_permission
+from onyx.db.engine.sql_engine import get_session
+from onyx.db.enums import Permission
+from onyx.db.models import TracingProviderConfig
+from onyx.db.models import User
+from onyx.db.tracing import delete_tracing_provider
+from onyx.db.tracing import fetch_tracing_provider
+from onyx.db.tracing import upsert_tracing_provider
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.manage.tracing.models import TracingProviderTestRequest
+from onyx.server.manage.tracing.models import TracingProviderUpsertRequest
+from onyx.server.manage.tracing.models import TracingProviderView
+from onyx.tracing.provider_config import BraintrustConfig
+from onyx.tracing.provider_config import EffectiveTracingConfig
+from onyx.tracing.provider_config import LangfuseConfig
+from onyx.tracing.provider_config import resolve_effective_tracing_config
+from onyx.tracing.validation import validate_tracing_credentials
+from onyx.utils.logger import setup_logger
+from shared_configs.configs import MULTI_TENANT
+from shared_configs.enums import TracingProviderType
+
+logger = setup_logger()
+
+
+def _reject_if_multi_tenant() -> None:
+    if MULTI_TENANT:
+        raise OnyxError(
+            OnyxErrorCode.SINGLE_TENANT_ONLY,
+            "Tracing provider configuration is not available on this deployment.",
+        )
+
+
+admin_router = APIRouter(
+    prefix="/admin/tracing", dependencies=[Depends(_reject_if_multi_tenant)]
+)
+
+
+def _env_config_for(
+    provider_type: TracingProviderType, effective: EffectiveTracingConfig
+) -> dict[str, str]:
+    """Non-secret settings to surface for an env-sourced provider (for the UI/adopt)."""
+    if provider_type == TracingProviderType.BRAINTRUST and effective.braintrust:
+        return {"project": effective.braintrust.project}
+    if provider_type == TracingProviderType.LANGFUSE and effective.langfuse:
+        config = {"public_key": effective.langfuse.public_key}
+        if effective.langfuse.host:
+            config["host"] = effective.langfuse.host
+        return config
+    return {}
+
+
+def _build_view(
+    provider_type: TracingProviderType,
+    row: TracingProviderConfig | None,
+    effective: EffectiveTracingConfig,
+) -> TracingProviderView:
+    is_connected = (
+        effective.braintrust is not None
+        if provider_type == TracingProviderType.BRAINTRUST
+        else effective.langfuse is not None
+    )
+    if row is not None:
+        return TracingProviderView(
+            provider_type=provider_type,
+            connected=is_connected,
+            source="db",
+            enabled=row.enabled,
+            config=row.config or {},
+            masked_api_key=(
+                row.api_key.get_value(apply_mask=True) if row.api_key else None
+            ),
+        )
+    if is_connected:
+        return TracingProviderView(
+            provider_type=provider_type,
+            connected=True,
+            source="env",
+            enabled=True,
+            config=_env_config_for(provider_type, effective),
+        )
+    return TracingProviderView(
+        provider_type=provider_type,
+        connected=False,
+        source="none",
+        enabled=False,
+    )
+
+
+@admin_router.get("/providers")
+def list_tracing_providers(
+    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> list[TracingProviderView]:
+    effective = resolve_effective_tracing_config()
+    return [
+        _build_view(
+            provider_type, fetch_tracing_provider(provider_type, db_session), effective
+        )
+        for provider_type in TracingProviderType
+    ]
+
+
+@admin_router.post("/providers")
+def upsert_tracing_provider_endpoint(
+    request: TracingProviderUpsertRequest,
+    user: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> TracingProviderView:
+    upsert_tracing_provider(
+        provider_type=request.provider_type,
+        api_key=request.api_key,
+        api_key_changed=request.api_key_changed,
+        config=request.config,
+        enabled=request.enabled,
+        updated_by_user_id=user.id if user else None,
+        db_session=db_session,
+    )
+    db_session.commit()
+
+    effective = resolve_effective_tracing_config()
+    row = fetch_tracing_provider(request.provider_type, db_session)
+    return _build_view(request.provider_type, row, effective)
+
+
+@admin_router.delete("/providers/{provider_type}")
+def disconnect_tracing_provider(
+    provider_type: TracingProviderType,
+    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> TracingProviderView:
+    delete_tracing_provider(provider_type, db_session)
+    db_session.commit()
+
+    effective = resolve_effective_tracing_config()
+    return _build_view(provider_type, None, effective)
+
+
+@admin_router.post("/providers/test")
+def test_tracing_provider(
+    request: TracingProviderTestRequest,
+    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> dict[str, str]:
+    config = request.config or {}
+    api_key = request.api_key
+    if request.use_stored_key:
+        row = fetch_tracing_provider(request.provider_type, db_session)
+        if row is None or not row.api_key:
+            raise OnyxError(
+                OnyxErrorCode.NOT_FOUND,
+                "No stored key found for this provider.",
+            )
+        api_key = row.api_key.get_value(apply_mask=False)
+        config = {**(row.config or {}), **config}
+
+    try:
+        validate_tracing_credentials(
+            provider_type=request.provider_type, api_key=api_key, config=config
+        )
+    except ValueError as e:
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, str(e)) from e
+
+    return {"status": "ok"}
+
+
+@admin_router.post("/providers/{provider_type}/adopt-env")
+def adopt_env_tracing_provider(
+    provider_type: TracingProviderType,
+    user: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> TracingProviderView:
+    """Copy an env-var-configured provider into a DB row so it can be managed in the UI."""
+    if fetch_tracing_provider(provider_type, db_session) is not None:
+        raise OnyxError(
+            OnyxErrorCode.CONFLICT,
+            "Provider is already configured in the UI.",
+        )
+
+    effective = resolve_effective_tracing_config()
+    api_key, config = _env_credentials(provider_type, effective)
+    if api_key is None:
+        raise OnyxError(
+            OnyxErrorCode.NOT_FOUND,
+            "No environment-configured credentials found for this provider.",
+        )
+
+    upsert_tracing_provider(
+        provider_type=provider_type,
+        api_key=api_key,
+        api_key_changed=True,
+        config=config,
+        enabled=True,
+        updated_by_user_id=user.id if user else None,
+        db_session=db_session,
+    )
+    db_session.commit()
+
+    effective = resolve_effective_tracing_config()
+    row = fetch_tracing_provider(provider_type, db_session)
+    return _build_view(provider_type, row, effective)
+
+
+def _env_credentials(
+    provider_type: TracingProviderType, effective: EffectiveTracingConfig
+) -> tuple[str | None, dict[str, str]]:
+    if provider_type == TracingProviderType.BRAINTRUST and isinstance(
+        effective.braintrust, BraintrustConfig
+    ):
+        return effective.braintrust.api_key, {"project": effective.braintrust.project}
+    if provider_type == TracingProviderType.LANGFUSE and isinstance(
+        effective.langfuse, LangfuseConfig
+    ):
+        config = {"public_key": effective.langfuse.public_key}
+        if effective.langfuse.host:
+            config["host"] = effective.langfuse.host
+        return effective.langfuse.secret_key, config
+    return None, {}

--- a/backend/onyx/server/manage/tracing/models.py
+++ b/backend/onyx/server/manage/tracing/models.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from pydantic import BaseModel
 from pydantic import Field
 
@@ -8,7 +10,7 @@ class TracingProviderView(BaseModel):
     provider_type: TracingProviderType
     connected: bool
     # "db" (configured in the UI), "env" (legacy env vars), or "none".
-    source: str
+    source: Literal["db", "env", "none"]
     enabled: bool
     config: dict[str, str] = Field(default_factory=dict)
     masked_api_key: str | None = None

--- a/backend/onyx/server/manage/tracing/models.py
+++ b/backend/onyx/server/manage/tracing/models.py
@@ -1,0 +1,35 @@
+from pydantic import BaseModel
+from pydantic import Field
+
+from shared_configs.enums import TracingProviderType
+
+
+class TracingProviderView(BaseModel):
+    provider_type: TracingProviderType
+    connected: bool
+    # "db" (configured in the UI), "env" (legacy env vars), or "none".
+    source: str
+    enabled: bool
+    config: dict[str, str] = Field(default_factory=dict)
+    masked_api_key: str | None = None
+
+
+class TracingProviderUpsertRequest(BaseModel):
+    provider_type: TracingProviderType
+    config: dict[str, str] | None = None
+    api_key: str | None = None
+    api_key_changed: bool = Field(
+        default=False,
+        description="Set to true when providing a new key for an existing provider.",
+    )
+    enabled: bool = True
+
+
+class TracingProviderTestRequest(BaseModel):
+    provider_type: TracingProviderType
+    api_key: str | None = None
+    use_stored_key: bool = Field(
+        default=False,
+        description="If true, validate the stored key instead of `api_key`.",
+    )
+    config: dict[str, str] | None = None

--- a/backend/onyx/tracing/validation.py
+++ b/backend/onyx/tracing/validation.py
@@ -1,0 +1,54 @@
+"""Best-effort credential validation for tracing providers (used by /test)."""
+
+from __future__ import annotations
+
+from onyx.utils.logger import setup_logger
+from shared_configs.enums import TracingProviderType
+
+logger = setup_logger()
+
+
+def validate_tracing_credentials(
+    *,
+    provider_type: TracingProviderType,
+    api_key: str | None,
+    config: dict[str, str],
+) -> None:
+    """Raise ValueError if the credentials are missing or rejected by the provider."""
+    if not api_key:
+        raise ValueError("API key is required.")
+
+    if provider_type == TracingProviderType.BRAINTRUST:
+        _validate_braintrust(api_key)
+    elif provider_type == TracingProviderType.LANGFUSE:
+        _validate_langfuse(api_key, config)
+
+
+def _validate_braintrust(api_key: str) -> None:
+    import braintrust
+
+    try:
+        braintrust.login(api_key=api_key)
+    except Exception as e:
+        raise ValueError(f"Braintrust credential check failed: {e}") from e
+
+
+def _validate_langfuse(secret_key: str, config: dict[str, str]) -> None:
+    public_key = config.get("public_key")
+    if not public_key:
+        raise ValueError("Langfuse requires both a secret key and a public key.")
+
+    from langfuse import Langfuse
+
+    try:
+        client = Langfuse(
+            public_key=public_key,
+            secret_key=secret_key,
+            host=config.get("host") or None,
+        )
+        if not client.auth_check():
+            raise ValueError("Langfuse rejected the provided credentials.")
+    except ValueError:
+        raise
+    except Exception as e:
+        raise ValueError(f"Langfuse credential check failed: {e}") from e

--- a/backend/onyx/tracing/validation.py
+++ b/backend/onyx/tracing/validation.py
@@ -1,11 +1,23 @@
-"""Best-effort credential validation for tracing providers (used by /test)."""
+"""Best-effort credential validation for tracing providers (used by /test).
+
+Validation hits each provider's REST API directly with the supplied credentials
+rather than the provider SDKs. The SDK entry points (e.g. ``braintrust.login``)
+mutate process-global state, so calling them here would let a test key clobber the
+live tracing client; a plain authenticated request has no such side effect.
+"""
 
 from __future__ import annotations
+
+import requests
 
 from onyx.utils.logger import setup_logger
 from shared_configs.enums import TracingProviderType
 
 logger = setup_logger()
+
+_VALIDATION_TIMEOUT_S = 10
+_BRAINTRUST_API_URL = "https://api.braintrust.dev"
+_LANGFUSE_DEFAULT_HOST = "https://cloud.langfuse.com"
 
 
 def validate_tracing_credentials(
@@ -25,12 +37,22 @@ def validate_tracing_credentials(
 
 
 def _validate_braintrust(api_key: str) -> None:
-    import braintrust
-
     try:
-        braintrust.login(api_key=api_key)
-    except Exception as e:
-        raise ValueError(f"Braintrust credential check failed: {e}") from e
+        resp = requests.get(
+            f"{_BRAINTRUST_API_URL}/v1/project",
+            headers={"Authorization": f"Bearer {api_key}"},
+            params={"limit": 1},
+            timeout=_VALIDATION_TIMEOUT_S,
+        )
+    except requests.RequestException as e:
+        raise ValueError(f"Could not reach Braintrust: {e}") from e
+
+    if resp.status_code in (401, 403):
+        raise ValueError("Braintrust rejected the provided API key.")
+    if not resp.ok:
+        raise ValueError(
+            f"Braintrust credential check failed (HTTP {resp.status_code})."
+        )
 
 
 def _validate_langfuse(secret_key: str, config: dict[str, str]) -> None:
@@ -38,17 +60,18 @@ def _validate_langfuse(secret_key: str, config: dict[str, str]) -> None:
     if not public_key:
         raise ValueError("Langfuse requires both a secret key and a public key.")
 
-    from langfuse import Langfuse
-
+    host = (config.get("host") or _LANGFUSE_DEFAULT_HOST).rstrip("/")
     try:
-        client = Langfuse(
-            public_key=public_key,
-            secret_key=secret_key,
-            host=config.get("host") or None,
+        # Langfuse's public API uses Basic auth (public key + secret key).
+        resp = requests.get(
+            f"{host}/api/public/projects",
+            auth=(public_key, secret_key),
+            timeout=_VALIDATION_TIMEOUT_S,
         )
-        if not client.auth_check():
-            raise ValueError("Langfuse rejected the provided credentials.")
-    except ValueError:
-        raise
-    except Exception as e:
-        raise ValueError(f"Langfuse credential check failed: {e}") from e
+    except requests.RequestException as e:
+        raise ValueError(f"Could not reach Langfuse: {e}") from e
+
+    if resp.status_code in (401, 403):
+        raise ValueError("Langfuse rejected the provided credentials.")
+    if not resp.ok:
+        raise ValueError(f"Langfuse credential check failed (HTTP {resp.status_code}).")

--- a/backend/onyx/tracing/validation.py
+++ b/backend/onyx/tracing/validation.py
@@ -31,15 +31,16 @@ def validate_tracing_credentials(
         raise ValueError("API key is required.")
 
     if provider_type == TracingProviderType.BRAINTRUST:
-        _validate_braintrust(api_key)
+        _validate_braintrust(api_key, config)
     elif provider_type == TracingProviderType.LANGFUSE:
         _validate_langfuse(api_key, config)
 
 
-def _validate_braintrust(api_key: str) -> None:
+def _validate_braintrust(api_key: str, config: dict[str, str]) -> None:
+    base_url = (config.get("api_url") or _BRAINTRUST_API_URL).rstrip("/")
     try:
         resp = requests.get(
-            f"{_BRAINTRUST_API_URL}/v1/project",
+            f"{base_url}/v1/project",
             headers={"Authorization": f"Bearer {api_key}"},
             params={"limit": 1},
             timeout=_VALIDATION_TIMEOUT_S,

--- a/backend/tests/external_dependency_unit/tracing/test_tracing_admin_api.py
+++ b/backend/tests/external_dependency_unit/tracing/test_tracing_admin_api.py
@@ -1,0 +1,119 @@
+"""Drives the /admin/tracing endpoint handlers in-process against the real DB.
+
+The handlers are invoked directly (passing a real session); auth is enforced by
+FastAPI dependencies at the HTTP layer and is out of scope here.
+"""
+
+from collections.abc import Generator
+from typing import cast
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.db.models import User
+from onyx.db.tracing import delete_tracing_provider
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.manage.tracing import api as tracing_api
+from onyx.server.manage.tracing.api import adopt_env_tracing_provider
+from onyx.server.manage.tracing.api import disconnect_tracing_provider
+from onyx.server.manage.tracing.api import list_tracing_providers
+from onyx.server.manage.tracing.api import upsert_tracing_provider_endpoint
+from onyx.server.manage.tracing.models import TracingProviderTestRequest
+from onyx.server.manage.tracing.models import TracingProviderUpsertRequest
+from onyx.tracing import provider_config
+from shared_configs.enums import TracingProviderType
+
+# Handlers tolerate a None user (updated_by becomes null); cast to satisfy typing.
+_NO_USER = cast(User, None)
+
+
+@pytest.fixture(autouse=True)
+def clean_tracing_table(db_session: Session) -> Generator[None, None, None]:
+    for provider in TracingProviderType:
+        delete_tracing_provider(provider, db_session)
+    db_session.commit()
+    yield
+    for provider in TracingProviderType:
+        delete_tracing_provider(provider, db_session)
+    db_session.commit()
+
+
+def _view(views: list, provider_type: TracingProviderType):
+    return next(v for v in views if v.provider_type == provider_type)
+
+
+def test_connect_then_list_shows_db_masked(db_session: Session) -> None:
+    upsert_tracing_provider_endpoint(
+        TracingProviderUpsertRequest(
+            provider_type=TracingProviderType.BRAINTRUST,
+            api_key="bt-secret",
+            api_key_changed=True,
+            config={"project": "MyProject"},
+        ),
+        _NO_USER,
+        db_session,
+    )
+
+    views = list_tracing_providers(_NO_USER, db_session)
+    braintrust = _view(views, TracingProviderType.BRAINTRUST)
+    assert braintrust.connected is True
+    assert braintrust.source == "db"
+    assert braintrust.config == {"project": "MyProject"}
+    assert braintrust.masked_api_key and "bt-secret" not in braintrust.masked_api_key
+
+    langfuse = _view(views, TracingProviderType.LANGFUSE)
+    assert langfuse.connected is False
+    assert langfuse.source == "none"
+
+
+def test_disconnect_removes_db_row(db_session: Session) -> None:
+    upsert_tracing_provider_endpoint(
+        TracingProviderUpsertRequest(
+            provider_type=TracingProviderType.BRAINTRUST,
+            api_key="bt-secret",
+            api_key_changed=True,
+            config={"project": "P"},
+        ),
+        _NO_USER,
+        db_session,
+    )
+
+    view = disconnect_tracing_provider(
+        TracingProviderType.BRAINTRUST, _NO_USER, db_session
+    )
+    assert view.source == "none"
+    assert view.connected is False
+
+
+def test_validate_endpoint_rejects_missing_key(db_session: Session) -> None:
+    with pytest.raises(OnyxError):
+        tracing_api.test_tracing_provider(
+            TracingProviderTestRequest(provider_type=TracingProviderType.BRAINTRUST),
+            _NO_USER,
+            db_session,
+        )
+
+
+def test_adopt_env_without_env_raises(db_session: Session) -> None:
+    with pytest.raises(OnyxError):
+        adopt_env_tracing_provider(TracingProviderType.BRAINTRUST, _NO_USER, db_session)
+
+
+def test_adopt_env_copies_into_db_row(
+    db_session: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(provider_config, "BRAINTRUST_API_KEY", "env-key")
+    monkeypatch.setattr(provider_config, "BRAINTRUST_PROJECT", "EnvProject")
+
+    view = adopt_env_tracing_provider(
+        TracingProviderType.BRAINTRUST, _NO_USER, db_session
+    )
+    assert view.source == "db"
+    assert view.connected is True
+    assert view.config == {"project": "EnvProject"}
+
+
+def test_multi_tenant_gate_rejects(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(tracing_api, "MULTI_TENANT", True)
+    with pytest.raises(OnyxError):
+        tracing_api._reject_if_multi_tenant()


### PR DESCRIPTION
## Description

**PR 2 of 3** for UI-configurable tracing providers. **Stacked on #12529** (base branch is `jtahara/tracing-ui-config-backend`) — review that first; this PR's diff shows only the API layer.

Adds the admin API at **`/admin/tracing`** that drives the PR 1 data model. Admin-gated (`FULL_ADMIN_PANEL_ACCESS`) and rejected under `MULTI_TENANT` (single-tenant only), per the agreed scope:

- `GET /providers` — per-provider status: `connected`, `source` (`db` | `env` | `none`), `enabled`, non-secret `config`, and `masked_api_key` (plaintext key never returned).
- `POST /providers` — connect/update; honors `api_key_changed` so the stored key isn't overwritten on edit.
- `DELETE /providers/{provider_type}` — disconnect (reverts to env fallback if one exists).
- `POST /providers/test` — validates credentials against the provider (Braintrust login / Langfuse `auth_check`) before the admin commits.
- `POST /providers/{provider_type}/adopt-env` — the migration action: copies env-var config into a DB row so it can be managed in the UI.

Uses `OnyxError` + typed returns (no `HTTPException` / `response_model`) per repo conventions. Router registered in `main.py`.

## How Has This Been Tested?

External-dependency-unit tests driving the handlers in-process against real Postgres (`tests/external_dependency_unit/tracing/test_tracing_admin_api.py`): connect → list shows `db`/masked, disconnect removes the row, `/test` rejects a missing key, `adopt-env` copies env→DB (and errors when no env config exists), and the `MULTI_TENANT` gate raises. Full suite (PR 1 resolution + PR 2 API) = 27 tests green; `ruff`/`ruff format`/`ty` clean.

Note: a full HTTP/auth integration test will run in CI once this branch is deployed — it can't be exercised against the shared local api_server, which doesn't run this branch's code. The handler logic, DB round-trip, masking, and gating are covered in-process.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an admin-only API at `/admin/tracing` to manage tracing providers (Braintrust, Langfuse): list status, connect/update, disconnect, test credentials, and adopt env-based configs. Requires `FULL_ADMIN_PANEL_ACCESS`; blocked in `MULTI_TENANT`.

- **New Features**
  - `GET /admin/tracing/providers` — returns per-provider status: `connected`, `source` (`db` | `env` | `none`), `enabled`, non-secret `config`, `masked_api_key`.
  - `POST /admin/tracing/providers` — upserts provider; honors `api_key_changed` so stored keys aren’t overwritten on edit.
  - `DELETE /admin/tracing/providers/{provider_type}` — disconnects; falls back to env config if present.
  - `POST /admin/tracing/providers/test` — validates credentials via direct HTTP calls; Braintrust validation honors `api_url` in `config`.
  - `POST /admin/tracing/providers/{provider_type}/adopt-env` — copies env var config into a DB row for UI management.
  - Admin-gated and single-tenant only; uses `OnyxError` with typed returns; router registered in `main.py`.

- **Migration**
  - For env-based configs, call `POST /admin/tracing/providers/{provider_type}/adopt-env` to migrate into the DB.
  - No migration on multi-tenant deployments (request is rejected).

<sup>Written for commit 663c601c809be5f9a82768864779c0d84c546e2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

