### PR TITLE
fix(code-interpreter): Too many files accumulating in code interpreter

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -1430,6 +1430,27 @@ CODE_INTERPRETER_MAX_OUTPUT_LENGTH = int(
     os.environ.get("CODE_INTERPRETER_MAX_OUTPUT_LENGTH") or 50_000
 )
 
+# Backstop on per-execution file staging. Session files accumulate over a chat
+# (generated artifacts get carried forward), and staging each one is a blocking
+# object-store read + upload in the request worker; an unbounded set can block
+# longer than the api-server liveness window. Cap by count and cumulative bytes
+# and drop the overflow (oldest first).
+CODE_INTERPRETER_MAX_STAGED_FILES = int(
+    os.environ.get("CODE_INTERPRETER_MAX_STAGED_FILES") or 25
+)
+
+CODE_INTERPRETER_MAX_STAGED_BYTES = int(
+    os.environ.get("CODE_INTERPRETER_MAX_STAGED_BYTES") or 100 * 1024 * 1024
+)
+
+# Cache-miss file uploads run concurrently to keep staging within the liveness
+# window. Bounded fan-out: the sandbox can be overwhelmed by a large upload
+# burst, so keep this modest. Each upload is individually bounded by the
+# client's per-request timeout.
+CODE_INTERPRETER_MAX_PARALLEL_UPLOADS = int(
+    os.environ.get("CODE_INTERPRETER_MAX_PARALLEL_UPLOADS") or 8
+)
+
 # Per-call MCP read timeout; configurable since some tools (e.g. data-agent
 # servers) run longer than the default.
 MCP_TOOL_CALL_TIMEOUT_SECONDS = int(

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -1443,12 +1443,12 @@ CODE_INTERPRETER_MAX_STAGED_BYTES = int(
     os.environ.get("CODE_INTERPRETER_MAX_STAGED_BYTES") or 100 * 1024 * 1024
 )
 
-# Cache-miss file uploads run concurrently to keep staging within the liveness
-# window. Bounded fan-out: the sandbox can be overwhelmed by a large upload
-# burst, so keep this modest. Each upload is individually bounded by the
-# client's per-request timeout.
-CODE_INTERPRETER_MAX_PARALLEL_UPLOADS = int(
-    os.environ.get("CODE_INTERPRETER_MAX_PARALLEL_UPLOADS") or 8
+# Bounds the fan-out of both staging phases — reading files from the object
+# store and uploading cache misses to the sandbox — so neither blocks the
+# request worker serially nor overwhelms a backend with a burst. Each I/O call
+# is individually bounded by its own per-request timeout.
+CODE_INTERPRETER_STAGING_CONCURRENCY = int(
+    os.environ.get("CODE_INTERPRETER_STAGING_CONCURRENCY") or 8
 )
 
 # Per-call MCP read timeout; configurable since some tools (e.g. data-agent

--- a/backend/onyx/tools/models.py
+++ b/backend/onyx/tools/models.py
@@ -335,3 +335,6 @@ class LlmPythonExecutionResult(BaseModel):
     timed_out: bool
     generated_files: list[PythonExecutionFile]
     error: str | None = None
+    # Set when some session files are absent — dropped by the staging caps or
+    # failed to upload — so the LLM doesn't assume they're available.
+    staging_notice: str | None = None

--- a/backend/onyx/tools/models.py
+++ b/backend/onyx/tools/models.py
@@ -335,6 +335,5 @@ class LlmPythonExecutionResult(BaseModel):
     timed_out: bool
     generated_files: list[PythonExecutionFile]
     error: str | None = None
-    # Set when some session files are absent — dropped by the staging caps or
-    # failed to upload — so the LLM doesn't assume they're available.
+    # Set when some session files are absent
     staging_notice: str | None = None

--- a/backend/onyx/tools/tool_implementations/python/python_tool.py
+++ b/backend/onyx/tools/tool_implementations/python/python_tool.py
@@ -15,9 +15,9 @@ from onyx.chat.emitter import Emitter
 from onyx.configs.app_configs import CODE_INTERPRETER_BASE_URL
 from onyx.configs.app_configs import CODE_INTERPRETER_DEFAULT_TIMEOUT_MS
 from onyx.configs.app_configs import CODE_INTERPRETER_MAX_OUTPUT_LENGTH
-from onyx.configs.app_configs import CODE_INTERPRETER_MAX_PARALLEL_UPLOADS
 from onyx.configs.app_configs import CODE_INTERPRETER_MAX_STAGED_BYTES
 from onyx.configs.app_configs import CODE_INTERPRETER_MAX_STAGED_FILES
+from onyx.configs.app_configs import CODE_INTERPRETER_STAGING_CONCURRENCY
 from onyx.configs.constants import FileOrigin
 from onyx.db.code_interpreter import fetch_code_interpreter_server
 from onyx.file_store.utils import build_full_frontend_file_url
@@ -106,20 +106,15 @@ def _code_references_file(filename: str, code: str) -> bool:
     return filename in code or _safe_code_interpreter_filename(filename) in code
 
 
-def _select_files_for_staging(
-    chat_files: list[ChatFile],
-    code: str,
-    *,
-    max_files: int,
-    max_bytes: int,
-) -> tuple[list[tuple[ChatFile, bytes]], int]:
-    """Choose which session files to stage, reading bytes only for the chosen.
+def _read_chat_file_content(chat_file: ChatFile) -> bytes:
+    """Materialize a (possibly lazy) chat file's bytes; the object-store read
+    happens here. Extracted so reads can be batched in parallel."""
+    return chat_file.content
 
-    Files the ``code`` names explicitly are staged first; the remaining
-    count/byte budget is backfilled with the most recent of the rest. Returns
-    the selected ``(file, content)`` pairs in chronological order and the number
-    of files the caps dropped.
-    """
+
+def _staging_priority(chat_files: list[ChatFile], code: str) -> list[int]:
+    """``chat_files`` indices in staging-priority order: files the code names
+    first, then the rest, newest-first within each group."""
     referenced: list[int] = []
     unreferenced: list[int] = []
     for idx, chat_file in enumerate(chat_files):
@@ -129,38 +124,72 @@ def _select_files_for_staging(
             else unreferenced
         )
         bucket.append(idx)
+    return list(reversed(referenced)) + list(reversed(unreferenced))
 
-    # Newest-first within each group so the caps keep the most recent files.
-    priority = list(reversed(referenced)) + list(reversed(unreferenced))
+
+def _select_files_for_staging(
+    chat_files: list[ChatFile],
+    code: str,
+    *,
+    max_files: int,
+    max_bytes: int,
+    read_concurrency: int,
+) -> tuple[list[tuple[ChatFile, bytes]], int, list[str]]:
+    """Choose which session files to stage, reading bytes only for the chosen.
+
+    Files the ``code`` names explicitly are staged first; the remaining
+    count/byte budget is backfilled with the most recent of the rest. Candidates
+    are read in bounded parallel batches — concurrency hides read latency while
+    only one batch is held in memory at a time. Returns the selected
+    ``(file, content)`` pairs in chronological order, the number of files the
+    caps dropped (excluding read failures), and the filenames that failed to
+    read.
+    """
+    # Count cap: only the top candidates can ever be staged, so never read more.
+    candidates = _staging_priority(chat_files, code)[:max_files]
 
     selected: dict[int, bytes] = {}
+    read_failures: list[str] = []
     staged_bytes = 0
-    for idx in priority:
-        if len(selected) >= max_files:
+    for start in range(0, len(candidates), read_concurrency):
+        batch = candidates[start : start + read_concurrency]
+        contents = run_functions_tuples_in_parallel(
+            [(_read_chat_file_content, (chat_files[idx],)) for idx in batch],
+            allow_failures=True,
+            max_workers=read_concurrency,
+        )
+
+        over_budget = False
+        for idx, content in zip(batch, contents):
+            if content is None:
+                logger.warning(
+                    "Failed to read file for Python execution: %s",
+                    chat_files[idx].filename,
+                )
+                read_failures.append(chat_files[idx].filename)
+                continue
+            # Always stage at least one file; otherwise stop at the byte budget.
+            if selected and staged_bytes + len(content) > max_bytes:
+                over_budget = True
+                break
+            selected[idx] = content
+            staged_bytes += len(content)
+        if over_budget:
             break
-        try:
-            content = chat_files[idx].content
-        except Exception as e:
-            logger.warning("Failed to read file for Python execution: %s", e)
-            continue
-        # Always stage at least one file; otherwise stop at the byte budget.
-        if selected and staged_bytes + len(content) > max_bytes:
-            break
-        selected[idx] = content
-        staged_bytes += len(content)
 
     chronological = [(chat_files[idx], selected[idx]) for idx in sorted(selected)]
-    return chronological, len(chat_files) - len(selected)
+    dropped_by_caps = len(chat_files) - len(selected) - len(read_failures)
+    return chronological, dropped_by_caps, read_failures
 
 
 def _build_staging_notice(
     dropped_count: int,
     total_files: int,
-    failed_uploads: list[str],
+    failed_files: list[str],
 ) -> str | None:
     """LLM-facing note when some session files are absent — dropped by the caps
-    or failed to upload — so the model doesn't assume they're available.
-    ``None`` when everything staged."""
+    or failed to stage (read/upload error) — so the model doesn't assume they're
+    available. ``None`` when everything staged."""
     parts: list[str] = []
     if dropped_count > 0:
         parts.append(
@@ -169,10 +198,9 @@ def _build_staging_notice(
             f"{CODE_INTERPRETER_MAX_STAGED_BYTES} bytes); files referenced in the "
             f"code were prioritized."
         )
-    if failed_uploads:
+    if failed_files:
         parts.append(
-            f"Failed to stage {len(failed_uploads)} file(s): "
-            f"{', '.join(failed_uploads)}."
+            f"Failed to stage {len(failed_files)} file(s): {', '.join(failed_files)}."
         )
     return " ".join(parts) if parts else None
 
@@ -288,7 +316,7 @@ class PythonTool(Tool[PythonToolOverrideKwargs]):
             upload_results = run_functions_tuples_in_parallel(
                 [(client.upload_file, (p.content, p.file_name)) for p in misses],
                 allow_failures=True,
-                max_workers=CODE_INTERPRETER_MAX_PARALLEL_UPLOADS,
+                max_workers=CODE_INTERPRETER_STAGING_CONCURRENCY,
             )
             for plan, ci_file_id in zip(misses, upload_results):
                 if ci_file_id is None:
@@ -351,16 +379,17 @@ class PythonTool(Tool[PythonToolOverrideKwargs]):
         with CodeInterpreterClient() as client:
             # Select the files to stage (referenced-first, recent backfill,
             # bounded by the caps), upload them, and note any drops to the LLM.
-            selected, dropped_count = _select_files_for_staging(
+            selected, dropped_count, read_failures = _select_files_for_staging(
                 chat_files,
                 code,
                 max_files=CODE_INTERPRETER_MAX_STAGED_FILES,
                 max_bytes=CODE_INTERPRETER_MAX_STAGED_BYTES,
+                read_concurrency=CODE_INTERPRETER_STAGING_CONCURRENCY,
             )
-            files_to_stage, failed_uploads = self._upload_and_stage(client, selected)
+            files_to_stage, upload_failures = self._upload_and_stage(client, selected)
 
             staging_notice = _build_staging_notice(
-                dropped_count, len(chat_files), failed_uploads
+                dropped_count, len(chat_files), read_failures + upload_failures
             )
             if staging_notice:
                 logger.warning(staging_notice)

--- a/backend/onyx/tools/tool_implementations/python/python_tool.py
+++ b/backend/onyx/tools/tool_implementations/python/python_tool.py
@@ -6,6 +6,7 @@ from io import BytesIO
 from typing import Any
 from typing import cast
 
+from pydantic import BaseModel
 from pydantic import TypeAdapter
 from sqlalchemy.orm import Session
 from typing_extensions import override
@@ -14,6 +15,9 @@ from onyx.chat.emitter import Emitter
 from onyx.configs.app_configs import CODE_INTERPRETER_BASE_URL
 from onyx.configs.app_configs import CODE_INTERPRETER_DEFAULT_TIMEOUT_MS
 from onyx.configs.app_configs import CODE_INTERPRETER_MAX_OUTPUT_LENGTH
+from onyx.configs.app_configs import CODE_INTERPRETER_MAX_PARALLEL_UPLOADS
+from onyx.configs.app_configs import CODE_INTERPRETER_MAX_STAGED_BYTES
+from onyx.configs.app_configs import CODE_INTERPRETER_MAX_STAGED_FILES
 from onyx.configs.constants import FileOrigin
 from onyx.db.code_interpreter import fetch_code_interpreter_server
 from onyx.file_store.utils import build_full_frontend_file_url
@@ -23,6 +27,7 @@ from onyx.server.query_and_chat.streaming_models import Packet
 from onyx.server.query_and_chat.streaming_models import PythonToolDelta
 from onyx.server.query_and_chat.streaming_models import PythonToolStart
 from onyx.tools.interface import Tool
+from onyx.tools.models import ChatFile
 from onyx.tools.models import LlmPythonExecutionResult
 from onyx.tools.models import PythonExecutionFile
 from onyx.tools.models import PythonToolOverrideKwargs
@@ -44,6 +49,7 @@ from onyx.tools.tool_implementations.python.code_interpreter_client import (
 )
 from onyx.tools.tool_implementations.utils import truncate_output as _truncate_output
 from onyx.utils.logger import setup_logger
+from onyx.utils.threadpool_concurrency import run_functions_tuples_in_parallel
 
 logger = setup_logger()
 
@@ -83,6 +89,92 @@ def _dedupe_code_interpreter_filename(
     deduped_filename = f"{base[:max_base_len]}{suffix}"
     seen_filenames.add(deduped_filename)
     return deduped_filename
+
+
+class _StagePlan(BaseModel):
+    file_name: str
+    content: bytes
+    cache_key: tuple[str, str]  # (file_name, content_hash)
+
+
+def _code_references_file(filename: str, code: str) -> bool:
+    """Heuristic: the code wants a file if its name appears literally in the
+    code. Checked on the raw filename and its sanitized (sandbox) form, since
+    the model may write either. Filename-only — no object-store read."""
+    if not filename:
+        return False
+    return filename in code or _safe_code_interpreter_filename(filename) in code
+
+
+def _select_files_for_staging(
+    chat_files: list[ChatFile],
+    code: str,
+    *,
+    max_files: int,
+    max_bytes: int,
+) -> tuple[list[tuple[ChatFile, bytes]], int]:
+    """Choose which session files to stage, reading bytes only for the chosen.
+
+    Files the ``code`` names explicitly are staged first; the remaining
+    count/byte budget is backfilled with the most recent of the rest. Returns
+    the selected ``(file, content)`` pairs in chronological order and the number
+    of files the caps dropped.
+    """
+    referenced: list[int] = []
+    unreferenced: list[int] = []
+    for idx, chat_file in enumerate(chat_files):
+        bucket = (
+            referenced
+            if _code_references_file(chat_file.filename, code)
+            else unreferenced
+        )
+        bucket.append(idx)
+
+    # Newest-first within each group so the caps keep the most recent files.
+    priority = list(reversed(referenced)) + list(reversed(unreferenced))
+
+    selected: dict[int, bytes] = {}
+    staged_bytes = 0
+    for idx in priority:
+        if len(selected) >= max_files:
+            break
+        try:
+            content = chat_files[idx].content
+        except Exception as e:
+            logger.warning("Failed to read file for Python execution: %s", e)
+            continue
+        # Always stage at least one file; otherwise stop at the byte budget.
+        if selected and staged_bytes + len(content) > max_bytes:
+            break
+        selected[idx] = content
+        staged_bytes += len(content)
+
+    chronological = [(chat_files[idx], selected[idx]) for idx in sorted(selected)]
+    return chronological, len(chat_files) - len(selected)
+
+
+def _build_staging_notice(
+    dropped_count: int,
+    total_files: int,
+    failed_uploads: list[str],
+) -> str | None:
+    """LLM-facing note when some session files are absent — dropped by the caps
+    or failed to upload — so the model doesn't assume they're available.
+    ``None`` when everything staged."""
+    parts: list[str] = []
+    if dropped_count > 0:
+        parts.append(
+            f"{dropped_count} of {total_files} session files were not staged due "
+            f"to per-execution limits ({CODE_INTERPRETER_MAX_STAGED_FILES} files / "
+            f"{CODE_INTERPRETER_MAX_STAGED_BYTES} bytes); files referenced in the "
+            f"code were prioritized."
+        )
+    if failed_uploads:
+        parts.append(
+            f"Failed to stage {len(failed_uploads)} file(s): "
+            f"{', '.join(failed_uploads)}."
+        )
+    return " ".join(parts) if parts else None
 
 
 class PythonTool(Tool[PythonToolOverrideKwargs]):
@@ -162,6 +254,61 @@ class PythonTool(Tool[PythonToolOverrideKwargs]):
         # The code is available in run() method via llm_kwargs
         # We'll emit the start packet in run() instead
 
+    def _upload_and_stage(
+        self,
+        client: CodeInterpreterClient,
+        selected: list[tuple[ChatFile, bytes]],
+    ) -> tuple[list[FileInput], list[str]]:
+        """Upload the selected files, returning stage specs and the names of any
+        that failed to upload.
+
+        Cache misses upload concurrently (bounded); the cache is written
+        single-threaded afterward so it is never mutated from worker threads.
+        Files are staged in chronological order for deterministic dedup naming.
+        """
+        seen_filenames: set[str] = set()
+        plans: list[_StagePlan] = []
+        for ind, (chat_file, content) in enumerate(selected):
+            file_name = _dedupe_code_interpreter_filename(
+                chat_file.filename, seen_filenames, str(ind)
+            )
+            content_hash = hashlib.sha256(content).hexdigest()
+            plans.append(
+                _StagePlan(
+                    file_name=file_name,
+                    content=content,
+                    cache_key=(file_name, content_hash),
+                )
+            )
+
+        # allow_failures keeps one bad upload from sinking the batch; each upload
+        # is individually bounded by the client's per-request timeout.
+        misses = [p for p in plans if p.cache_key not in self._uploaded_file_cache]
+        if misses:
+            upload_results = run_functions_tuples_in_parallel(
+                [(client.upload_file, (p.content, p.file_name)) for p in misses],
+                allow_failures=True,
+                max_workers=CODE_INTERPRETER_MAX_PARALLEL_UPLOADS,
+            )
+            for plan, ci_file_id in zip(misses, upload_results):
+                if ci_file_id is None:
+                    logger.warning(
+                        "Failed to upload file for Python execution: %s", plan.file_name
+                    )
+                    continue
+                self._uploaded_file_cache[plan.cache_key] = ci_file_id
+
+        files_to_stage: list[FileInput] = []
+        failed_uploads: list[str] = []
+        for plan in plans:
+            ci_file_id = self._uploaded_file_cache.get(plan.cache_key)
+            if ci_file_id is None:
+                failed_uploads.append(plan.file_name)
+                continue
+            files_to_stage.append({"path": plan.file_name, "file_id": ci_file_id})
+            logger.info("Staged file for Python execution: %s", plan.file_name)
+        return files_to_stage, failed_uploads
+
     def run(
         self,
         placement: Placement,
@@ -202,31 +349,21 @@ class PythonTool(Tool[PythonToolOverrideKwargs]):
         # Create Code Interpreter client — context manager ensures
         # session.close() is called on every exit path.
         with CodeInterpreterClient() as client:
-            # Stage chat files for execution
-            files_to_stage: list[FileInput] = []
-            seen_filenames: set[str] = set()
-            for ind, chat_file in enumerate(chat_files):
-                file_name = _dedupe_code_interpreter_filename(
-                    chat_file.filename,
-                    seen_filenames,
-                    str(ind),
-                )
-                try:
-                    content_hash = hashlib.sha256(chat_file.content).hexdigest()
-                    cache_key = (file_name, content_hash)
-                    ci_file_id = self._uploaded_file_cache.get(cache_key)
-                    if ci_file_id is None:
-                        # Upload to Code Interpreter
-                        ci_file_id = client.upload_file(chat_file.content, file_name)
-                        self._uploaded_file_cache[cache_key] = ci_file_id
+            # Select the files to stage (referenced-first, recent backfill,
+            # bounded by the caps), upload them, and note any drops to the LLM.
+            selected, dropped_count = _select_files_for_staging(
+                chat_files,
+                code,
+                max_files=CODE_INTERPRETER_MAX_STAGED_FILES,
+                max_bytes=CODE_INTERPRETER_MAX_STAGED_BYTES,
+            )
+            files_to_stage, failed_uploads = self._upload_and_stage(client, selected)
 
-                    # Stage for execution
-                    files_to_stage.append({"path": file_name, "file_id": ci_file_id})
-
-                    logger.info("Staged file for Python execution: %s", file_name)
-
-                except Exception as e:
-                    logger.warning("Failed to stage file %s: %s", file_name, e)
+            staging_notice = _build_staging_notice(
+                dropped_count, len(chat_files), failed_uploads
+            )
+            if staging_notice:
+                logger.warning(staging_notice)
 
             try:
                 logger.debug("Executing code: %s", code)
@@ -360,6 +497,7 @@ class PythonTool(Tool[PythonToolOverrideKwargs]):
                     timed_out=result_event.timed_out,
                     generated_files=generated_files,
                     error=(None if result_event.exit_code == 0 else truncated_stderr),
+                    staging_notice=staging_notice,
                 )
 
                 # Serialize result for LLM
@@ -397,6 +535,7 @@ class PythonTool(Tool[PythonToolOverrideKwargs]):
                     timed_out=False,
                     generated_files=[],
                     error=error_msg,
+                    staging_notice=staging_notice,
                 )
 
                 adapter = TypeAdapter(LlmPythonExecutionResult)

--- a/backend/onyx/tools/tool_implementations/python/python_tool.py
+++ b/backend/onyx/tools/tool_implementations/python/python_tool.py
@@ -127,6 +127,15 @@ def _staging_priority(chat_files: list[ChatFile], code: str) -> list[int]:
     return list(reversed(referenced)) + list(reversed(unreferenced))
 
 
+class _StagingSelection(BaseModel):
+    # Selected (file, content) pairs in chronological order.
+    files: list[tuple[ChatFile, bytes]]
+    # Files excluded by the count/byte caps (not counting read failures).
+    dropped_by_caps: int
+    # Filenames whose bytes could not be read from the object store.
+    read_failures: list[str]
+
+
 def _select_files_for_staging(
     chat_files: list[ChatFile],
     code: str,
@@ -134,16 +143,13 @@ def _select_files_for_staging(
     max_files: int,
     max_bytes: int,
     read_concurrency: int,
-) -> tuple[list[tuple[ChatFile, bytes]], int, list[str]]:
+) -> _StagingSelection:
     """Choose which session files to stage, reading bytes only for the chosen.
 
     Files the ``code`` names explicitly are staged first; the remaining
     count/byte budget is backfilled with the most recent of the rest. Candidates
     are read in bounded parallel batches — concurrency hides read latency while
-    only one batch is held in memory at a time. Returns the selected
-    ``(file, content)`` pairs in chronological order, the number of files the
-    caps dropped (excluding read failures), and the filenames that failed to
-    read.
+    only one batch is held in memory at a time.
     """
     # Count cap: only the top candidates can ever be staged, so never read more.
     candidates = _staging_priority(chat_files, code)[:max_files]
@@ -178,8 +184,11 @@ def _select_files_for_staging(
             break
 
     chronological = [(chat_files[idx], selected[idx]) for idx in sorted(selected)]
-    dropped_by_caps = len(chat_files) - len(selected) - len(read_failures)
-    return chronological, dropped_by_caps, read_failures
+    return _StagingSelection(
+        files=chronological,
+        dropped_by_caps=len(chat_files) - len(selected) - len(read_failures),
+        read_failures=read_failures,
+    )
 
 
 def _build_staging_notice(
@@ -379,17 +388,21 @@ class PythonTool(Tool[PythonToolOverrideKwargs]):
         with CodeInterpreterClient() as client:
             # Select the files to stage (referenced-first, recent backfill,
             # bounded by the caps), upload them, and note any drops to the LLM.
-            selected, dropped_count, read_failures = _select_files_for_staging(
+            selection = _select_files_for_staging(
                 chat_files,
                 code,
                 max_files=CODE_INTERPRETER_MAX_STAGED_FILES,
                 max_bytes=CODE_INTERPRETER_MAX_STAGED_BYTES,
                 read_concurrency=CODE_INTERPRETER_STAGING_CONCURRENCY,
             )
-            files_to_stage, upload_failures = self._upload_and_stage(client, selected)
+            files_to_stage, upload_failures = self._upload_and_stage(
+                client, selection.files
+            )
 
             staging_notice = _build_staging_notice(
-                dropped_count, len(chat_files), read_failures + upload_failures
+                selection.dropped_by_caps,
+                len(chat_files),
+                selection.read_failures + upload_failures,
             )
             if staging_notice:
                 logger.warning(staging_notice)

--- a/backend/tests/unit/onyx/tools/tool_implementations/python/test_python_tool_upload_cache.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/python/test_python_tool_upload_cache.py
@@ -474,18 +474,18 @@ def test_select_returns_chronological_order_and_no_drops() -> None:
     files = [ChatFile(filename=f"f{i}.csv", content=b"x") for i in range(4)]
     code = "open('f0.csv'); open('f3.csv')"  # mix of referenced and not
 
-    selected, dropped, read_failures = _select_files_for_staging(
+    selection = _select_files_for_staging(
         files, code, max_files=10, max_bytes=1000, read_concurrency=4
     )
 
-    assert [cf.filename for cf, _ in selected] == [
+    assert [cf.filename for cf, _ in selection.files] == [
         "f0.csv",
         "f1.csv",
         "f2.csv",
         "f3.csv",
     ]
-    assert dropped == 0
-    assert read_failures == []
+    assert selection.dropped_by_caps == 0
+    assert selection.read_failures == []
 
 
 def test_select_always_keeps_one_file_over_byte_budget() -> None:
@@ -493,12 +493,12 @@ def test_select_always_keeps_one_file_over_byte_budget() -> None:
     # the tool could never run against a big-but-required input.
     files = [ChatFile(filename="big.csv", content=b"x" * 100)]
 
-    selected, dropped, _ = _select_files_for_staging(
+    selection = _select_files_for_staging(
         files, "big.csv", max_files=10, max_bytes=10, read_concurrency=4
     )
 
-    assert [cf.filename for cf, _ in selected] == ["big.csv"]
-    assert dropped == 0
+    assert [cf.filename for cf, _ in selection.files] == ["big.csv"]
+    assert selection.dropped_by_caps == 0
 
 
 def test_select_skips_unreadable_files() -> None:
@@ -512,7 +512,7 @@ def test_select_skips_unreadable_files() -> None:
         ChatFile(filename="good.csv", content=b"ok"),
     ]
 
-    selected, dropped, read_failures = _select_files_for_staging(
+    selection = _select_files_for_staging(
         files,
         "open('bad.csv'); open('good.csv')",
         max_files=10,
@@ -520,9 +520,9 @@ def test_select_skips_unreadable_files() -> None:
         read_concurrency=4,
     )
 
-    assert [cf.filename for cf, _ in selected] == ["good.csv"]
-    assert dropped == 0
-    assert read_failures == ["bad.csv"]
+    assert [cf.filename for cf, _ in selection.files] == ["good.csv"]
+    assert selection.dropped_by_caps == 0
+    assert selection.read_failures == ["bad.csv"]
 
 
 def test_code_references_file_matches_raw_and_sanitized_names() -> None:

--- a/backend/tests/unit/onyx/tools/tool_implementations/python/test_python_tool_upload_cache.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/python/test_python_tool_upload_cache.py
@@ -5,14 +5,19 @@ run() calls within the same session instead of re-uploading identical content
 on every agent loop iteration.
 """
 
+import json
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
 from onyx.tools.models import ChatFile
 from onyx.tools.models import PythonToolOverrideKwargs
+from onyx.tools.models import ToolResponse
 from onyx.tools.tool_implementations.python.code_interpreter_client import (
     StreamResultEvent,
 )
+from onyx.tools.tool_implementations.python.python_tool import _build_staging_notice
+from onyx.tools.tool_implementations.python.python_tool import _code_references_file
+from onyx.tools.tool_implementations.python.python_tool import _select_files_for_staging
 from onyx.tools.tool_implementations.python.python_tool import PythonTool
 
 TOOL_MODULE = "onyx.tools.tool_implementations.python.python_tool"
@@ -36,7 +41,12 @@ def _make_override(files: list[ChatFile]) -> PythonToolOverrideKwargs:
     return PythonToolOverrideKwargs(chat_files=files)
 
 
-def _run_tool(tool: PythonTool, mock_client: MagicMock, files: list[ChatFile]) -> None:
+def _run_tool(
+    tool: PythonTool,
+    mock_client: MagicMock,
+    files: list[ChatFile],
+    code: str = "print('hi')",
+) -> ToolResponse:
     """Call tool.run() with a mocked CodeInterpreterClient context manager."""
     from onyx.server.query_and_chat.placement import Placement
 
@@ -50,7 +60,7 @@ def _run_tool(tool: PythonTool, mock_client: MagicMock, files: list[ChatFile]) -
     override = _make_override(files)
 
     with patch(f"{TOOL_MODULE}.CodeInterpreterClient", return_value=ctx):
-        tool.run(placement=placement, override_kwargs=override, code="print('hi')")
+        return tool.run(placement=placement, override_kwargs=override, code=code)
 
 
 # ---------------------------------------------------------------------------
@@ -182,7 +192,9 @@ def test_unsafe_filename_sanitized_before_upload_and_stage() -> None:
 def test_sanitized_filename_collisions_get_deduped() -> None:
     tool = _make_tool()
     client = MagicMock()
-    client.upload_file.side_effect = ["id-a", "id-b"]
+    # Return an id derived from the name so assertions don't depend on the
+    # (now concurrent, non-deterministic) order uploads complete in.
+    client.upload_file.side_effect = lambda _content, name: f"id::{name}"
 
     files = [
         ChatFile(filename="a/b.csv", content=b"first"),
@@ -191,14 +203,12 @@ def test_sanitized_filename_collisions_get_deduped() -> None:
 
     _run_tool(tool, client, files)
 
-    assert [call.args[1] for call in client.upload_file.call_args_list] == [
-        "a_b.csv",
-        "a_b_1.csv",
-    ]
+    uploaded_names = {call.args[1] for call in client.upload_file.call_args_list}
+    assert uploaded_names == {"a_b.csv", "a_b_1.csv"}
     _, kwargs = client.execute_streaming.call_args
     assert kwargs["files"] == [
-        {"path": "a_b.csv", "file_id": "id-a"},
-        {"path": "a_b_1.csv", "file_id": "id-b"},
+        {"path": "a_b.csv", "file_id": "id::a_b.csv"},
+        {"path": "a_b_1.csv", "file_id": "id::a_b_1.csv"},
     ]
 
 
@@ -245,3 +255,284 @@ def test_upload_failure_not_cached() -> None:
     _run_tool(tool, client, files)
 
     assert client.upload_file.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# S1 backstop: per-execution staging cap by file count and total bytes
+# ---------------------------------------------------------------------------
+
+
+def _result_of(resp: ToolResponse) -> dict:
+    return json.loads(resp.llm_facing_response)
+
+
+@patch(f"{TOOL_MODULE}.CODE_INTERPRETER_MAX_STAGED_FILES", 2)
+@patch(f"{TOOL_MODULE}.CODE_INTERPRETER_BASE_URL", "http://fake:8000")
+def test_staging_caps_file_count_and_keeps_most_recent() -> None:
+    tool = _make_tool()
+    client = MagicMock()
+    client.upload_file.side_effect = [f"id-{i}" for i in range(10)]
+
+    # Files accumulate oldest-first; the two most recent should survive the cap.
+    files = [ChatFile(filename=f"f{i}.csv", content=f"c{i}".encode()) for i in range(5)]
+
+    resp = _run_tool(tool, client, files)
+
+    _, kwargs = client.execute_streaming.call_args
+    assert [f["path"] for f in kwargs["files"]] == ["f3.csv", "f4.csv"]
+    assert client.upload_file.call_count == 2
+
+    notice = _result_of(resp)["staging_notice"]
+    assert notice is not None and "3 of 5" in notice
+
+
+@patch(f"{TOOL_MODULE}.CODE_INTERPRETER_MAX_STAGED_FILES", 2)
+@patch(f"{TOOL_MODULE}.CODE_INTERPRETER_BASE_URL", "http://fake:8000")
+def test_count_overflow_files_are_not_downloaded() -> None:
+    # The dropped (oldest) files must never have their bytes read from the
+    # object store — that blocking read is exactly what the cap avoids.
+    tool = _make_tool()
+    client = MagicMock()
+    client.upload_file.side_effect = [f"id-{i}" for i in range(10)]
+
+    download_counts = {f"f{i}.csv": 0 for i in range(5)}
+
+    def _make_loader(name: str):  # type: ignore[no-untyped-def]
+        def _load() -> bytes:
+            download_counts[name] += 1
+            return b"data"
+
+        return _load
+
+    files = [
+        ChatFile.lazy_from_filename(
+            filename=f"f{i}.csv", loader=_make_loader(f"f{i}.csv")
+        )
+        for i in range(5)
+    ]
+
+    _run_tool(tool, client, files)
+
+    # Only the two most recent files were read; the three oldest were skipped.
+    assert download_counts == {
+        "f0.csv": 0,
+        "f1.csv": 0,
+        "f2.csv": 0,
+        "f3.csv": 1,
+        "f4.csv": 1,
+    }
+
+
+@patch(f"{TOOL_MODULE}.CODE_INTERPRETER_MAX_STAGED_FILES", 10)
+@patch(f"{TOOL_MODULE}.CODE_INTERPRETER_MAX_STAGED_BYTES", 10)
+@patch(f"{TOOL_MODULE}.CODE_INTERPRETER_BASE_URL", "http://fake:8000")
+def test_staging_caps_total_bytes_and_keeps_most_recent() -> None:
+    tool = _make_tool()
+    client = MagicMock()
+    client.upload_file.side_effect = [f"id-{i}" for i in range(10)]
+
+    # Three 6-byte files, 10-byte budget: only the most recent fits.
+    files = [ChatFile(filename=f"f{i}.csv", content=b"123456") for i in range(3)]
+
+    resp = _run_tool(tool, client, files)
+
+    _, kwargs = client.execute_streaming.call_args
+    assert [f["path"] for f in kwargs["files"]] == ["f2.csv"]
+    assert client.upload_file.call_count == 1
+
+    notice = _result_of(resp)["staging_notice"]
+    assert notice is not None and "2 of 3" in notice
+
+
+@patch(f"{TOOL_MODULE}.CODE_INTERPRETER_BASE_URL", "http://fake:8000")
+def test_no_staging_notice_when_under_caps() -> None:
+    tool = _make_tool()
+    client = MagicMock()
+    client.upload_file.side_effect = ["id-a", "id-b"]
+
+    files = [
+        ChatFile(filename="a.csv", content=b"aaa"),
+        ChatFile(filename="b.xlsx", content=b"bbb"),
+    ]
+
+    resp = _run_tool(tool, client, files)
+
+    assert _result_of(resp)["staging_notice"] is None
+
+
+@patch(f"{TOOL_MODULE}.CODE_INTERPRETER_BASE_URL", "http://fake:8000")
+def test_upload_failure_is_surfaced_and_other_files_still_staged() -> None:
+    tool = _make_tool()
+    client = MagicMock()
+
+    def _upload(_content: bytes, name: str) -> str:
+        if name == "bad.csv":
+            raise RuntimeError("boom")
+        return f"id::{name}"
+
+    client.upload_file.side_effect = _upload
+
+    files = [
+        ChatFile(filename="good.csv", content=b"g"),
+        ChatFile(filename="bad.csv", content=b"b"),
+    ]
+
+    resp = _run_tool(tool, client, files, code="open('good.csv'); open('bad.csv')")
+
+    # The failed file is reported to the LLM; the other file still staged.
+    notice = _result_of(resp)["staging_notice"]
+    assert notice is not None and "bad.csv" in notice
+    _, kwargs = client.execute_streaming.call_args
+    assert [f["path"] for f in kwargs["files"]] == ["good.csv"]
+
+
+# ---------------------------------------------------------------------------
+# Reference filter: code that names a file prioritizes staging it, then the
+# remaining budget is backfilled with the most recent files.
+# ---------------------------------------------------------------------------
+
+
+@patch(f"{TOOL_MODULE}.CODE_INTERPRETER_MAX_STAGED_FILES", 2)
+@patch(f"{TOOL_MODULE}.CODE_INTERPRETER_BASE_URL", "http://fake:8000")
+def test_referenced_file_prioritized_then_recency_backfill() -> None:
+    tool = _make_tool()
+    client = MagicMock()
+    client.upload_file.side_effect = [f"id-{i}" for i in range(10)]
+
+    # a.csv is the OLDEST file but the code names it; b/c/d are unreferenced.
+    files = [ChatFile(filename=f"{n}.csv", content=n.encode()) for n in "abcd"]
+
+    resp = _run_tool(
+        tool, client, files, code="import pandas as pd\ndf = pd.read_csv('a.csv')"
+    )
+
+    _, kwargs = client.execute_streaming.call_args
+    staged = {f["path"] for f in kwargs["files"]}
+    # Referenced oldest file kept despite recency, plus the newest backfill.
+    assert staged == {"a.csv", "d.csv"}
+    assert _result_of(resp)["staging_notice"] is not None
+
+
+@patch(f"{TOOL_MODULE}.CODE_INTERPRETER_MAX_STAGED_FILES", 1)
+@patch(f"{TOOL_MODULE}.CODE_INTERPRETER_BASE_URL", "http://fake:8000")
+def test_referenced_old_file_read_unreferenced_recent_not() -> None:
+    # With no budget to backfill, only the referenced (old) file is read; the
+    # more recent unreferenced file is never pulled from the object store.
+    tool = _make_tool()
+    client = MagicMock()
+    client.upload_file.side_effect = ["id-old"]
+
+    download_counts = {"old.csv": 0, "new.csv": 0}
+
+    def _make_loader(name: str):  # type: ignore[no-untyped-def]
+        def _load() -> bytes:
+            download_counts[name] += 1
+            return b"data"
+
+        return _load
+
+    files = [
+        ChatFile.lazy_from_filename(filename="old.csv", loader=_make_loader("old.csv")),
+        ChatFile.lazy_from_filename(filename="new.csv", loader=_make_loader("new.csv")),
+    ]
+
+    _run_tool(tool, client, files, code="open('old.csv').read()")
+
+    _, kwargs = client.execute_streaming.call_args
+    assert [f["path"] for f in kwargs["files"]] == ["old.csv"]
+    assert download_counts == {"old.csv": 1, "new.csv": 0}
+
+
+@patch(f"{TOOL_MODULE}.CODE_INTERPRETER_MAX_STAGED_FILES", 2)
+@patch(f"{TOOL_MODULE}.CODE_INTERPRETER_BASE_URL", "http://fake:8000")
+def test_dynamic_reference_falls_back_to_recent() -> None:
+    # A glob/dynamic reference names no file literally, so the filter matches
+    # nothing and we fall back to staging the most recent files (capped).
+    tool = _make_tool()
+    client = MagicMock()
+    client.upload_file.side_effect = [f"id-{i}" for i in range(10)]
+
+    files = [ChatFile(filename=f"f{i}.csv", content=f"c{i}".encode()) for i in range(4)]
+
+    _run_tool(
+        tool,
+        client,
+        files,
+        code="import glob\nfor p in glob.glob('*.csv'):\n    print(p)",
+    )
+
+    _, kwargs = client.execute_streaming.call_args
+    assert [f["path"] for f in kwargs["files"]] == ["f2.csv", "f3.csv"]
+
+
+# ---------------------------------------------------------------------------
+# Direct coverage of the pure selection helper
+# ---------------------------------------------------------------------------
+
+
+def test_select_returns_chronological_order_and_no_drops() -> None:
+    files = [ChatFile(filename=f"f{i}.csv", content=b"x") for i in range(4)]
+    code = "open('f0.csv'); open('f3.csv')"  # mix of referenced and not
+
+    selected, dropped = _select_files_for_staging(
+        files, code, max_files=10, max_bytes=1000
+    )
+
+    assert [cf.filename for cf, _ in selected] == [
+        "f0.csv",
+        "f1.csv",
+        "f2.csv",
+        "f3.csv",
+    ]
+    assert dropped == 0
+
+
+def test_select_always_keeps_one_file_over_byte_budget() -> None:
+    # A single file larger than the entire budget is still staged, otherwise
+    # the tool could never run against a big-but-required input.
+    files = [ChatFile(filename="big.csv", content=b"x" * 100)]
+
+    selected, dropped = _select_files_for_staging(
+        files, "big.csv", max_files=10, max_bytes=10
+    )
+
+    assert [cf.filename for cf, _ in selected] == ["big.csv"]
+    assert dropped == 0
+
+
+def test_select_skips_unreadable_files() -> None:
+    # A file whose bytes can't be read from the object store is skipped rather
+    # than aborting staging, and counts as dropped.
+    def _bad_loader() -> bytes:
+        raise RuntimeError("object store unavailable")
+
+    files = [
+        ChatFile.lazy_from_filename(filename="bad.csv", loader=_bad_loader),
+        ChatFile(filename="good.csv", content=b"ok"),
+    ]
+
+    selected, dropped = _select_files_for_staging(
+        files, "open('bad.csv'); open('good.csv')", max_files=10, max_bytes=1000
+    )
+
+    assert [cf.filename for cf, _ in selected] == ["good.csv"]
+    assert dropped == 1
+
+
+def test_code_references_file_matches_raw_and_sanitized_names() -> None:
+    # Raw filename appears in the code.
+    assert _code_references_file("report.csv", "pd.read_csv('report.csv')")
+    # Only the sanitized sandbox form ("a:b.csv" -> "a_b.csv") appears.
+    assert _code_references_file("a:b.csv", "open('a_b.csv')")
+    # Neither form present, and the empty-name guard.
+    assert not _code_references_file("report.csv", "print('hello')")
+    assert not _code_references_file("", "anything")
+
+
+def test_staging_notice_combines_drops_and_upload_failures() -> None:
+    notice = _build_staging_notice(2, 5, ["x.csv"])
+    assert notice is not None
+    assert "2 of 5" in notice
+    assert "x.csv" in notice
+
+    assert _build_staging_notice(0, 5, []) is None

--- a/backend/tests/unit/onyx/tools/tool_implementations/python/test_python_tool_upload_cache.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/python/test_python_tool_upload_cache.py
@@ -474,8 +474,8 @@ def test_select_returns_chronological_order_and_no_drops() -> None:
     files = [ChatFile(filename=f"f{i}.csv", content=b"x") for i in range(4)]
     code = "open('f0.csv'); open('f3.csv')"  # mix of referenced and not
 
-    selected, dropped = _select_files_for_staging(
-        files, code, max_files=10, max_bytes=1000
+    selected, dropped, read_failures = _select_files_for_staging(
+        files, code, max_files=10, max_bytes=1000, read_concurrency=4
     )
 
     assert [cf.filename for cf, _ in selected] == [
@@ -485,6 +485,7 @@ def test_select_returns_chronological_order_and_no_drops() -> None:
         "f3.csv",
     ]
     assert dropped == 0
+    assert read_failures == []
 
 
 def test_select_always_keeps_one_file_over_byte_budget() -> None:
@@ -492,8 +493,8 @@ def test_select_always_keeps_one_file_over_byte_budget() -> None:
     # the tool could never run against a big-but-required input.
     files = [ChatFile(filename="big.csv", content=b"x" * 100)]
 
-    selected, dropped = _select_files_for_staging(
-        files, "big.csv", max_files=10, max_bytes=10
+    selected, dropped, _ = _select_files_for_staging(
+        files, "big.csv", max_files=10, max_bytes=10, read_concurrency=4
     )
 
     assert [cf.filename for cf, _ in selected] == ["big.csv"]
@@ -502,7 +503,7 @@ def test_select_always_keeps_one_file_over_byte_budget() -> None:
 
 def test_select_skips_unreadable_files() -> None:
     # A file whose bytes can't be read from the object store is skipped rather
-    # than aborting staging, and counts as dropped.
+    # than aborting staging, and is reported as a read failure (NOT a cap-drop).
     def _bad_loader() -> bytes:
         raise RuntimeError("object store unavailable")
 
@@ -511,12 +512,17 @@ def test_select_skips_unreadable_files() -> None:
         ChatFile(filename="good.csv", content=b"ok"),
     ]
 
-    selected, dropped = _select_files_for_staging(
-        files, "open('bad.csv'); open('good.csv')", max_files=10, max_bytes=1000
+    selected, dropped, read_failures = _select_files_for_staging(
+        files,
+        "open('bad.csv'); open('good.csv')",
+        max_files=10,
+        max_bytes=1000,
+        read_concurrency=4,
     )
 
     assert [cf.filename for cf, _ in selected] == ["good.csv"]
-    assert dropped == 1
+    assert dropped == 0
+    assert read_failures == ["bad.csv"]
 
 
 def test_code_references_file_matches_raw_and_sanitized_names() -> None:


### PR DESCRIPTION
## Description
There is an issue where the python tool accumulates many files and then pods crash as too many files are being sent to the code interpreter service. This aims to fix that by introducing the following restrictions:
 - Cap files being uploaded by a max num files and max bytes
 - Select files that have been explicitly mentioned in the provided code
 - Introduce parallel uploading

## How Has This Been Tested?
Manual + Tests

closes https://linear.app/onyx-app/issue/ENG-4258/api-server-liveness-kills-exit-137-python-tool-re-stages-all

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check
