### PR TITLE
chore(opensearch): Do not raise if chunk not found for update

### DIFF
--- a/backend/onyx/document_index/opensearch/client.py
+++ b/backend/onyx/document_index/opensearch/client.py
@@ -49,6 +49,9 @@ _RETRYABLE_UPDATE_ERROR_TYPES = (
 )
 
 
+_DOCUMENT_MISSING_ERROR_TYPE = "document_missing_exception"
+
+
 logger = setup_logger(__name__)
 # Set the logging level to WARNING to ignore INFO and DEBUG logs from
 # opensearch. By default it emits INFO-level logs for every request.
@@ -1074,7 +1077,10 @@ class OpenSearchIndexClient(OpenSearchClient):
         },
     )
     def update_document(
-        self, document_chunk_id: str, properties_to_update: dict[str, Any]
+        self,
+        document_chunk_id: str,
+        properties_to_update: dict[str, Any],
+        ignore_missing: bool = False,
     ) -> None:
         """Updates an OpenSearch document chunk's properties.
 
@@ -1083,6 +1089,9 @@ class OpenSearchIndexClient(OpenSearchClient):
                 update.
             properties_to_update: The properties of the document to update. Each
                 property should exist in the schema.
+            ignore_missing: If True, silently return instead of raising when the
+                document chunk does not exist (OpenSearch responds with a 404).
+                Defaults to False.
 
         Raises:
             Exception: There was an error updating the document.
@@ -1093,12 +1102,22 @@ class OpenSearchIndexClient(OpenSearchClient):
             self._index_name,
         )
         update_body: dict[str, Any] = {"doc": properties_to_update}
-        result = self._client.update(
-            index=self._index_name,
-            id=document_chunk_id,
-            body=update_body,
-            _source=False,
-        )
+        try:
+            result = self._client.update(
+                index=self._index_name,
+                id=document_chunk_id,
+                body=update_body,
+                _source=False,
+            )
+        except TransportError as e:
+            if ignore_missing and e.status_code == 404:
+                logger.debug(
+                    "Document chunk %s not found in index %s; ignoring as requested.",
+                    document_chunk_id,
+                    self._index_name,
+                )
+                return
+            raise
         result_id = result.get("_id", "")
         # Sanity check.
         if result_id != document_chunk_id:
@@ -1137,7 +1156,10 @@ class OpenSearchIndexClient(OpenSearchClient):
         },
     )
     def bulk_update_documents(
-        self, document_chunk_ids: list[str], properties_to_update: dict[str, Any]
+        self,
+        document_chunk_ids: list[str],
+        properties_to_update: dict[str, Any],
+        ignore_missing: bool = False,
     ) -> None:
         """Bulk updates OpenSearch document chunks' properties.
 
@@ -1149,6 +1171,10 @@ class OpenSearchIndexClient(OpenSearchClient):
                 update.
             properties_to_update: The properties of the document to update. Each
                 property should exist in the schema.
+            ignore_missing: If True, document chunks that do not exist
+                (OpenSearch reports a 404 ``document_missing_exception``) are
+                skipped instead of being treated as fatal errors. Defaults to
+                False.
 
         Raises:
             Exception: There was an error during the bulk update.
@@ -1191,6 +1217,7 @@ class OpenSearchIndexClient(OpenSearchClient):
             raise_on_exception=True,
         )
 
+        ignored_missing_count = 0
         if errors:
             retryable_ids = []
             fatal_errors = []
@@ -1206,7 +1233,19 @@ class OpenSearchIndexClient(OpenSearchClient):
                 err_obj = info.get("error", {})
                 err_type = err_obj.get("type", "") if isinstance(err_obj, dict) else ""
 
-                if status >= 500 and err_type in _RETRYABLE_UPDATE_ERROR_TYPES:
+                if (
+                    ignore_missing
+                    and status == 404
+                    and err_type == _DOCUMENT_MISSING_ERROR_TYPE
+                ):
+                    logger.debug(
+                        "Document chunk %s not found in index %s during bulk update; "
+                        "ignoring as requested.",
+                        info.get("_id", ""),
+                        self._index_name,
+                    )
+                    ignored_missing_count += 1
+                elif status >= 500 and err_type in _RETRYABLE_UPDATE_ERROR_TYPES:
                     # We have seen a bug in OpenSearch version 3.4.0 when using
                     # the knn plugin and when derived_source is enabled (the
                     # default), when OpenSearch is under load sometimes updates
@@ -1266,11 +1305,12 @@ class OpenSearchIndexClient(OpenSearchClient):
                 )
             successes += new_successes
 
-        if successes != len(document_chunk_ids):
+        expected_successes = len(document_chunk_ids) - ignored_missing_count
+        if successes != expected_successes:
             raise OpenSearchUpdateError(
                 f"OpenSearch reported no errors during bulk update but the number of successful "
                 f"operations ({successes}) does not match the number of document chunks "
-                f"({len(document_chunk_ids)})."
+                f"({expected_successes})."
             )
         logger.debug(
             "Successfully bulk updated %s document chunks.", len(document_chunk_ids)

--- a/backend/onyx/document_index/opensearch/opensearch_document_index.py
+++ b/backend/onyx/document_index/opensearch/opensearch_document_index.py
@@ -644,6 +644,7 @@ class OpenSearchDocumentIndex(DocumentIndex):
             self._client.bulk_update_documents(
                 document_chunk_ids=doc_chunk_ids_to_update,
                 properties_to_update=properties_to_update,
+                ignore_missing=True,
             )
 
     def id_based_retrieval(

--- a/backend/tests/external_dependency_unit/opensearch/test_opensearch_client.py
+++ b/backend/tests/external_dependency_unit/opensearch/test_opensearch_client.py
@@ -1005,6 +1005,31 @@ class TestOpenSearchClient:
                 properties_to_update={"hidden": True},
             )
 
+    def test_update_nonexistent_document_ignore_missing(
+        self, test_client: OpenSearchIndexClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Tests updating a nonexistent document with ignore_missing does not
+        raise.
+        """
+        # Precondition.
+        _patch_global_tenant_state(monkeypatch, False)
+        tenant_state = TenantState(tenant_id=POSTGRES_DEFAULT_SCHEMA, multitenant=False)
+        mappings = DocumentSchema.get_document_schema(
+            vector_dimension=128, multitenant=tenant_state.multitenant
+        )
+        settings = DocumentSchema.get_index_settings_based_on_environment()
+        test_client.create_index(mappings=mappings, settings=settings)
+
+        # Under test and postcondition.
+        # Updating a document that doesn't exist is a no-op when ignore_missing
+        # is set.
+        test_client.update_document(
+            document_chunk_id="test_source__nonexistent__512__0",
+            properties_to_update={"hidden": True},
+            ignore_missing=True,
+        )
+
     def test_bulk_update_documents(
         self, test_client: OpenSearchIndexClient, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -1110,6 +1135,65 @@ class TestOpenSearchClient:
                 ],
                 properties_to_update={"hidden": True},
             )
+
+    def test_bulk_update_nonexistent_documents_ignore_missing(
+        self, test_client: OpenSearchIndexClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Tests bulk updating with ignore_missing skips nonexistent chunks while
+        still applying updates to the chunks that do exist.
+        """
+        # Precondition.
+        _patch_global_tenant_state(monkeypatch, False)
+        tenant_state = TenantState(tenant_id=POSTGRES_DEFAULT_SCHEMA, multitenant=False)
+        mappings = DocumentSchema.get_document_schema(
+            vector_dimension=128, multitenant=tenant_state.multitenant
+        )
+        settings = DocumentSchema.get_index_settings_based_on_environment()
+        test_client.create_index(mappings=mappings, settings=settings)
+
+        # Create a single document; the rest of the update targets won't exist.
+        doc = _create_test_document_chunk(
+            document_id="test-doc-bulk-update-ignore-missing",
+            chunk_index=0,
+            content="Original content",
+            tenant_state=tenant_state,
+        )
+        test_client.index_document(document=doc, tenant_state=tenant_state)
+        existing_id = get_opensearch_doc_chunk_id(
+            tenant_state=tenant_state,
+            document_id=doc.document_id,
+            chunk_index=doc.chunk_index,
+            max_chunk_size=doc.max_chunk_size,
+        )
+
+        # Under test.
+        # Mix of one existing chunk and two nonexistent ones.
+        test_client.bulk_update_documents(
+            document_chunk_ids=[
+                existing_id,
+                "test_source__nonexistent-1__512__0",
+                "test_source__nonexistent-2__512__0",
+            ],
+            properties_to_update={"hidden": True, "global_boost": 9},
+            ignore_missing=True,
+        )
+
+        # Postcondition.
+        # The existing chunk is updated; the missing ones are silently skipped.
+        updated_doc = test_client.get_document(document_chunk_id=existing_id)
+        assert updated_doc.hidden is True
+        assert updated_doc.global_boost == 9
+
+        # All-missing is also a no-op when ignore_missing is set.
+        test_client.bulk_update_documents(
+            document_chunk_ids=[
+                "test_source__nonexistent-3__512__0",
+                "test_source__nonexistent-4__512__0",
+            ],
+            properties_to_update={"hidden": True},
+            ignore_missing=True,
+        )
 
     def test_bulk_update_documents_retries_retryable_errors(
         self, test_client: OpenSearchIndexClient, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Description

This exception throwing was not present in the old Vespa codepath, and I can only enumerate 3 scenarios where we might see this exception being raised:

- There was a chunk deleted in the middle of an update call. Nothing to update.
- There are supposed to be chunks indexed for a doc but they haven't been indexed yet, when they are indexed they will already have the most up-to-date metadata.
- There is some artifact in a document that results in no chunks being made but chunk count still being incremented, leading to callers of the update method trying to update ghost chunks which don't exist and never will.

## How Has This Been Tested?

Added automated tests.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip errors when updating non-existent chunks in `OpenSearch`. Adds an `ignore_missing` option to single and bulk update APIs and uses it in the document index update path to avoid spurious 404s.

- **Bug Fixes**
  - Added `ignore_missing` to `update_document` and `bulk_update_documents` to skip 404 `document_missing_exception` cases.
  - Bulk updates now count skipped items and validate successes accordingly; retry logic for transient 5xx errors is unchanged.
  - `update()` in the document index now calls bulk update with `ignore_missing=True` to match the old Vespa behavior, with tests covering both single and bulk paths.

<sup>Written for commit 556b3557c5ab60fc26fd0429a3222231c3b96e81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

