### PR TITLE
feat(skills): create skills from a git repo (backend)

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -70,6 +70,18 @@ GENERATIVE_MODEL_ACCESS_CHECK_FREQ = int(
     os.environ.get("GENERATIVE_MODEL_ACCESS_CHECK_FREQ") or 86400
 )  # 1 day
 
+# Skills marketplace: max compressed archive size fetched from GitHub/GitLab.
+# The whole archive is buffered in memory during fetch + extract, so this also
+# bounds per-request memory. A skill repo is small, so the default stays well
+# below the uncompressed bundle caps; raise via env if you host larger repos.
+SKILL_MARKETPLACE_ARCHIVE_MAX_BYTES = _non_negative_int_env(
+    "SKILL_MARKETPLACE_ARCHIVE_MAX_BYTES", 25 * 1024 * 1024
+)
+# Skills marketplace: HTTP fetch timeout in seconds for repo archive downloads.
+SKILL_MARKETPLACE_FETCH_TIMEOUT_SECONDS = _non_negative_int_env(
+    "SKILL_MARKETPLACE_FETCH_TIMEOUT_SECONDS", 30
+)
+
 # Controls whether users can use User Knowledge (personal documents) in assistants
 DISABLE_USER_KNOWLEDGE = os.environ.get("DISABLE_USER_KNOWLEDGE", "").lower() == "true"
 

--- a/backend/onyx/server/features/skill/api.py
+++ b/backend/onyx/server/features/skill/api.py
@@ -28,6 +28,12 @@ from onyx.db.users import fetch_user_by_id
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.file_store.file_store import get_default_file_store
+from onyx.server.features.skill.models import RepoSkillInstallFailure
+from onyx.server.features.skill.models import RepoSkillPreviewItem
+from onyx.server.features.skill.models import RepoSkillsInstallRequest
+from onyx.server.features.skill.models import RepoSkillsInstallResult
+from onyx.server.features.skill.models import RepoSkillsPreview
+from onyx.server.features.skill.models import RepoSkillsPreviewRequest
 from onyx.server.features.skill.models import SkillEditableDetailResponse
 from onyx.server.features.skill.models import SkillPatchRequest
 from onyx.server.features.skill.models import SkillPreviewResponse
@@ -50,8 +56,15 @@ from onyx.skills.content import read_custom_skill_bundle_instructions
 from onyx.skills.ingest import delete_bundle_blob
 from onyx.skills.ingest import ingested_skill_bundle
 from onyx.skills.ingest import save_skill_bundle_bytes
+from onyx.skills.marketplace import build_bundle_for_skill
+from onyx.skills.marketplace import extracted_skills
+from onyx.skills.marketplace import fetch_repo_archive
+from onyx.skills.marketplace import parse_skill_source
 from onyx.skills.push import push_skill_to_affected_sandboxes
 from onyx.skills.push import push_skills_for_users
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
 
 user_router = APIRouter(prefix="/skills")
 
@@ -512,3 +525,153 @@ def delete_current_user_skill(
     push_skills_for_users(affected, db_session)
     if old_file_id is not None:
         delete_bundle_blob(get_default_file_store(), old_file_id)
+
+
+def _reserved_skill_slugs() -> frozenset[str]:
+    return frozenset(BUILT_IN_SKILLS) | frozenset(
+        EXTERNAL_APP_BUILT_IN_SKILL_IDS.values()
+    )
+
+
+def _preview_repo_skills(source: str) -> RepoSkillsPreview:
+    parsed = parse_skill_source(source)
+    archive = fetch_repo_archive(parsed)
+    source_label = f"{parsed.host}/{parsed.owner}/{parsed.repo}"
+    with extracted_skills(archive, parsed.subpath) as discovered:
+        items: list[RepoSkillPreviewItem] = []
+        for skill in discovered:
+            if parsed.skill_filters:
+                last_segment = skill.rel_path.split("/")[-1]
+                pre_selected = any(
+                    f.lower() in (skill.slug, skill.name.lower(), last_segment.lower())
+                    for f in parsed.skill_filters
+                )
+            else:
+                pre_selected = True
+            items.append(
+                RepoSkillPreviewItem(
+                    slug=skill.slug,
+                    name=skill.name,
+                    description=skill.description,
+                    rel_path=skill.rel_path,
+                    pre_selected=pre_selected,
+                )
+            )
+        return RepoSkillsPreview(
+            source_label=source_label,
+            ref=parsed.ref,
+            skills=items,
+        )
+
+
+def _install_repo_skills(
+    source: str,
+    slugs: list[str],
+    user: User,
+    db_session: Session,
+) -> RepoSkillsInstallResult:
+    """Fetch + discover the repo, then install each requested skill as a personal
+    skill owned by ``user``.
+
+    Each skill is ingested and committed on its own (mirroring the single-skill
+    create endpoint), so one failure (validation, slug collision, reserved slug,
+    file-store error) becomes a per-skill failure entry rather than aborting the
+    batch. ``ingested_skill_bundle`` deletes the stored blob if the commit raises;
+    the session is rolled back so the next iteration stays usable. Visibility
+    follows the create-custom default (personal/private) — sharing is a separate
+    step via the existing share endpoints. The sandbox push is best-effort.
+    """
+    parsed = parse_skill_source(source)
+    archive = fetch_repo_archive(parsed)
+    file_store = get_default_file_store()
+    reserved = _reserved_skill_slugs()
+
+    # Dedupe preserving order.
+    seen_slugs: set[str] = set()
+    unique_slugs: list[str] = []
+    for s in slugs:
+        if s not in seen_slugs:
+            seen_slugs.add(s)
+            unique_slugs.append(s)
+
+    if not unique_slugs:
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, "no skills selected")
+
+    failures: list[RepoSkillInstallFailure] = []
+    created_rows: list[Skill] = []
+
+    with extracted_skills(archive, parsed.subpath) as discovered:
+        by_slug = {s.slug: s for s in discovered}
+
+        to_install = []
+        for slug in unique_slugs:
+            if slug not in by_slug:
+                failures.append(
+                    RepoSkillInstallFailure(slug=slug, error="not found in repository")
+                )
+            else:
+                to_install.append(by_slug[slug])
+
+        for skill in to_install:
+            try:
+                if skill.slug in reserved:
+                    raise OnyxError(
+                        OnyxErrorCode.INVALID_INPUT,
+                        f"slug '{skill.slug}' is reserved",
+                    )
+                bundle = build_bundle_for_skill(skill)
+                with ingested_skill_bundle(
+                    bundle, None, file_store, slug=skill.slug
+                ) as ingested:
+                    row = create_skill__no_commit(
+                        slug=ingested.slug,
+                        name=ingested.name,
+                        description=ingested.description,
+                        bundle_file_id=ingested.bundle_file_id,
+                        bundle_sha256=ingested.bundle_sha256,
+                        is_public=False,
+                        author_user_id=user.id,
+                        db_session=db_session,
+                    )
+                    db_session.commit()
+                created_rows.append(row)
+            except Exception as e:
+                # Roll back the failed flush so the session stays usable; the
+                # ingested_skill_bundle context already cleaned up the blob.
+                db_session.rollback()
+                if not isinstance(e, OnyxError):
+                    logger.exception("Unexpected error installing skill %s", skill.slug)
+                error = e.detail if isinstance(e, OnyxError) else "internal error"
+                failures.append(RepoSkillInstallFailure(slug=skill.slug, error=error))
+
+    # Rows are already committed; the sandbox push is best-effort and must never
+    # turn a successful install into a 500 (which would hide the committed rows
+    # and trigger slug-collision failures on retry).
+    try:
+        for row in created_rows:
+            push_skill_to_affected_sandboxes(row, db_session)
+    except Exception:
+        logger.exception("Post-commit skill push failed after repo install")
+
+    created = [
+        skill_response_for_user(row, user, db_session, include_share_details=True)
+        for row in created_rows
+    ]
+    return RepoSkillsInstallResult(created=created, failures=failures)
+
+
+@user_router.post("/from-repo/preview")
+def preview_repo_skills(
+    body: RepoSkillsPreviewRequest,
+    _: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+) -> RepoSkillsPreview:
+    return _preview_repo_skills(body.source)
+
+
+@user_router.post("/from-repo/install")
+def install_repo_skills(
+    body: RepoSkillsInstallRequest,
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> RepoSkillsInstallResult:
+    return _install_repo_skills(body.source, body.slugs, user, db_session)

--- a/backend/onyx/server/features/skill/models.py
+++ b/backend/onyx/server/features/skill/models.py
@@ -244,3 +244,36 @@ class SkillShareRequest(BaseModel):
 
 class TransferSkillOwnershipRequest(BaseModel):
     new_owner_user_id: UUID
+
+
+class RepoSkillsPreviewRequest(BaseModel):
+    source: str
+
+
+class RepoSkillPreviewItem(BaseModel):
+    slug: str
+    name: str
+    description: str
+    rel_path: str
+    pre_selected: bool
+
+
+class RepoSkillsPreview(BaseModel):
+    source_label: str
+    ref: str | None
+    skills: list[RepoSkillPreviewItem]
+
+
+class RepoSkillsInstallRequest(BaseModel):
+    source: str
+    slugs: list[str]
+
+
+class RepoSkillInstallFailure(BaseModel):
+    slug: str
+    error: str
+
+
+class RepoSkillsInstallResult(BaseModel):
+    created: list[SkillResponse]
+    failures: list[RepoSkillInstallFailure]

--- a/backend/onyx/skills/bundle.py
+++ b/backend/onyx/skills/bundle.py
@@ -73,36 +73,8 @@ def read_bundle_file(bundle_file: BinaryIO) -> bytes:
     return data
 
 
-def parse_skill_md_metadata(zip_bytes: bytes) -> tuple[str, str]:
-    """Extract ``(name, description)`` from the bundle's SKILL.md frontmatter.
-
-    The bundle is the source of truth for skill metadata. ``validate_custom_bundle``
-    has already confirmed structural shape; here we re-open the zip just for the
-    SKILL.md payload because parsing frontmatter requires the contents, not the
-    archive layout.
-    """
-    try:
-        zf = zipfile.ZipFile(io.BytesIO(zip_bytes))
-    except zipfile.BadZipFile:
-        raise OnyxError(OnyxErrorCode.INVALID_INPUT, "bundle is not a valid zip")
-
-    with zf:
-        try:
-            raw = zf.read(SKILL_MD_NAME)
-        except KeyError:
-            raise OnyxError(
-                OnyxErrorCode.INVALID_INPUT,
-                "SKILL.md missing at bundle root",
-            )
-
-    try:
-        content = raw.decode("utf-8")
-    except UnicodeDecodeError as exc:
-        raise OnyxError(
-            OnyxErrorCode.INVALID_INPUT,
-            "SKILL.md must be UTF-8 encoded",
-        ) from exc
-
+def parse_skill_md_text(content: str) -> tuple[str, str]:
+    """Parse ``(name, description)`` from the raw text of a SKILL.md file."""
     match = _FRONTMATTER_REGEX.match(content)
     if match is None:
         raise OnyxError(
@@ -136,6 +108,39 @@ def parse_skill_md_metadata(zip_bytes: bytes) -> tuple[str, str]:
             "SKILL.md frontmatter must include a non-empty 'description'",
         )
     return name.strip(), description.strip()
+
+
+def parse_skill_md_metadata(zip_bytes: bytes) -> tuple[str, str]:
+    """Extract ``(name, description)`` from the bundle's SKILL.md frontmatter.
+
+    The bundle is the source of truth for skill metadata. ``validate_custom_bundle``
+    has already confirmed structural shape; here we re-open the zip just for the
+    SKILL.md payload because parsing frontmatter requires the contents, not the
+    archive layout.
+    """
+    try:
+        zf = zipfile.ZipFile(io.BytesIO(zip_bytes))
+    except zipfile.BadZipFile:
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, "bundle is not a valid zip")
+
+    with zf:
+        try:
+            raw = zf.read(SKILL_MD_NAME)
+        except KeyError:
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                "SKILL.md missing at bundle root",
+            )
+
+    try:
+        content = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "SKILL.md must be UTF-8 encoded",
+        ) from exc
+
+    return parse_skill_md_text(content)
 
 
 def strip_skill_md_frontmatter(content: str) -> str:

--- a/backend/onyx/skills/marketplace.py
+++ b/backend/onyx/skills/marketplace.py
@@ -1,0 +1,670 @@
+"""Skills marketplace: fetch and unpack skill bundles from git hosting providers."""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import re
+import shutil
+import tarfile
+import tempfile
+import zipfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from urllib.parse import quote
+from urllib.parse import urlparse
+
+import requests
+from pydantic import BaseModel
+from pydantic import ConfigDict
+from pydantic import Field
+
+from onyx.configs.app_configs import SKILL_MARKETPLACE_ARCHIVE_MAX_BYTES
+from onyx.configs.app_configs import SKILL_MARKETPLACE_FETCH_TIMEOUT_SECONDS
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.skills.built_in import SLUG_REGEX
+from onyx.skills.bundle import DEFAULT_PER_FILE_MAX_BYTES
+from onyx.skills.bundle import DEFAULT_TOTAL_MAX_BYTES
+from onyx.skills.bundle import parse_skill_md_text
+from onyx.skills.bundle import SKILL_MD_NAME
+from onyx.skills.bundle import TEMPLATE_SUFFIX
+from onyx.utils.url import ssrf_safe_get
+from onyx.utils.url import SSRFException
+
+_SUPPORTED_HOSTS = ("github.com", "gitlab.com")
+# Maximum number of tar members to extract (zip-bomb / runaway archive guard).
+_TAR_MAX_MEMBERS = 10_000
+
+
+class ParsedSource(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    host: str
+    owner: str
+    repo: str
+    ref: str | None
+    subpath: str | None
+    skill_filters: list[str] = Field(default_factory=list)
+
+
+class DiscoveredSkill(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    slug: str
+    name: str
+    description: str
+    rel_path: str
+    abs_dir: Path
+
+
+def _strip_skills_command(raw: str) -> tuple[str, list[str]]:
+    """Strip leading npx/skills/add tokens; collect --skill/-s values.
+
+    Returns (source_token, skill_filters).
+    """
+    tokens = raw.split()
+    # Drop npx variants and the skills binary name
+    while tokens and tokens[0] in ("npx", "-y", "npx-y"):
+        tokens.pop(0)
+    # Drop package name variants: skills, skills@latest, skills@X.Y.Z
+    if tokens and (tokens[0] == "skills" or tokens[0].startswith("skills@")):
+        tokens.pop(0)
+    if tokens and tokens[0] == "add":
+        tokens.pop(0)
+
+    # Flags that consume a following value (besides --skill/-s which we collect).
+    _VALUE_FLAGS = {"--agent", "-a"}
+    # Boolean flags to skip (no following value).
+    _BOOL_FLAGS = {"--global", "-g", "--yes", "-y", "--copy", "--all", "--list", "-l"}
+
+    skill_filters: list[str] = []
+    source: str | None = None
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok in ("--skill", "-s"):
+            i += 1
+            if i < len(tokens):
+                skill_filters.append(tokens[i])
+        elif tok in _VALUE_FLAGS:
+            i += 1  # skip value
+        elif tok in _BOOL_FLAGS:
+            pass
+        elif tok.startswith("-"):
+            # Unknown flag; if it contains '=' it's self-contained, else skip next.
+            if "=" not in tok:
+                i += 1
+        else:
+            if source is None:
+                source = tok
+        i += 1
+
+    return source or "", skill_filters
+
+
+def parse_skill_source(raw: str) -> ParsedSource:
+    """Parse a skills.sh command, bare owner/repo, or full URL into ParsedSource."""
+    stripped = raw.strip()
+
+    # Detect skills.sh command by presence of 'add' keyword before non-flag token,
+    # or by leading npx/skills prefix.
+    looks_like_command = (
+        any(stripped.startswith(prefix) for prefix in ("npx ", "skills ", "skills@"))
+        or " add " in stripped
+    )
+
+    if looks_like_command:
+        source_token, skill_filters = _strip_skills_command(stripped)
+    else:
+        source_token = stripped
+        skill_filters = []
+
+    if not source_token:
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, "no source found in input")
+
+    if source_token.startswith("https://") or source_token.startswith("http://"):
+        return _parse_url_source(source_token, skill_filters)
+
+    # Bare owner/repo (may contain a host prefix like github.com/owner/repo)
+    if "/" in source_token:
+        parts = source_token.split("/")
+        if "." in parts[0]:
+            host = parts[0].lower()
+            if host not in _SUPPORTED_HOSTS:
+                raise OnyxError(
+                    OnyxErrorCode.INVALID_INPUT,
+                    f"unsupported host '{host}'; supported: {', '.join(_SUPPORTED_HOSTS)}",
+                )
+            if len(parts) < 3:
+                raise OnyxError(
+                    OnyxErrorCode.INVALID_INPUT,
+                    f"cannot extract owner and repo from '{source_token}'",
+                )
+            owner = parts[1]
+            repo = parts[2].removesuffix(".git")
+            return ParsedSource(
+                host=host,
+                owner=owner,
+                repo=repo,
+                ref=None,
+                subpath=None,
+                skill_filters=skill_filters,
+            )
+        if len(parts) < 2:
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                f"cannot extract owner and repo from '{source_token}'",
+            )
+        owner = parts[0]
+        repo = parts[1].removesuffix(".git")
+        return ParsedSource(
+            host="github.com",
+            owner=owner,
+            repo=repo,
+            ref=None,
+            subpath=None,
+            skill_filters=skill_filters,
+        )
+
+    raise OnyxError(
+        OnyxErrorCode.INVALID_INPUT,
+        f"cannot extract owner and repo from '{source_token}'",
+    )
+
+
+def _parse_url_source(url: str, skill_filters: list[str]) -> ParsedSource:
+    """Parse a full https:// URL into ParsedSource."""
+    parsed = urlparse(url)
+    host = (parsed.hostname or "").lower()
+    if host not in _SUPPORTED_HOSTS:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            f"unsupported host '{host}'; supported: {', '.join(_SUPPORTED_HOSTS)}",
+        )
+
+    # path looks like /owner/repo[.git][/tree/<ref>[/subpath...]]
+    path_parts = [p for p in parsed.path.split("/") if p]
+    if len(path_parts) < 2:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            f"cannot extract owner and repo from URL '{url}'",
+        )
+
+    ref: str | None = None
+    subpath: str | None = None
+
+    # GitLab inserts a "-" separator between the project path and tree/blob/...
+    # The project path may be nested through subgroups
+    # (group/subgroup/.../repo), so everything before "-" is the project path:
+    # all but the last segment is the owner namespace, the last is the repo.
+    if host == "gitlab.com" and "-" in path_parts:
+        sep = path_parts.index("-")
+        project_parts = path_parts[:sep]
+        if len(project_parts) < 2:
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                f"cannot extract owner and repo from URL '{url}'",
+            )
+        owner = "/".join(project_parts[:-1])
+        repo = project_parts[-1].removesuffix(".git")
+        rest = path_parts[sep + 1 :]
+    else:
+        owner = path_parts[0]
+        repo = path_parts[1].removesuffix(".git")
+        rest = path_parts[2:]
+
+    # Tree/ref form: /tree/<ref>[/<subpath>...] (after the host-specific prefix
+    # handling above). A slash-containing ref is not disambiguated from the
+    # subpath — the first segment after tree is taken as the ref.
+    if rest and rest[0] == "tree":
+        if len(rest) < 2:
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                f"malformed tree URL '{url}': missing ref after /tree/",
+            )
+        ref = rest[1]
+        if len(rest) > 2:
+            subpath = "/".join(rest[2:])
+
+    return ParsedSource(
+        host=host,
+        owner=owner,
+        repo=repo,
+        ref=ref,
+        subpath=subpath,
+        skill_filters=skill_filters,
+    )
+
+
+def fetch_repo_archive(source: ParsedSource) -> bytes:
+    """Download the repository tar.gz archive for the given ParsedSource."""
+    ref = source.ref or "HEAD"
+
+    # owner/repo/ref come from URL path segments that urlparse already decoded,
+    # so re-encode before interpolating — an unescaped '#'/'?' would otherwise
+    # truncate the path as a fragment/query and fetch a different resource.
+    # safe="/" keeps subgroup and slashed-ref separators intact.
+    owner = quote(source.owner, safe="/")
+    repo = quote(source.repo, safe="")
+    ref_enc = quote(ref, safe="/")
+
+    if source.host == "github.com":
+        url = f"https://codeload.github.com/{owner}/{repo}/tar.gz/{ref_enc}"
+    else:
+        # gitlab.com
+        url = (
+            f"https://gitlab.com/{owner}/{repo}"
+            f"/-/archive/{ref_enc}/{repo}-{ref_enc}.tar.gz"
+        )
+
+    try:
+        response = ssrf_safe_get(
+            url,
+            timeout=SKILL_MARKETPLACE_FETCH_TIMEOUT_SECONDS,
+            stream=True,
+        )
+    except SSRFException as exc:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            f"SSRF check failed for '{url}': {exc}",
+        ) from exc
+    except requests.RequestException as exc:
+        raise OnyxError(
+            OnyxErrorCode.BAD_GATEWAY,
+            f"failed to reach '{url}': {exc}",
+        ) from exc
+
+    # Context-manage the streamed response so the connection is released on
+    # every exit path (status raises, size-cap, stream error, or success)
+    # rather than leaking until GC.
+    with response:
+        if response.status_code == 404:
+            raise OnyxError(
+                OnyxErrorCode.NOT_FOUND,
+                f"Repository or ref not found: {source.owner}/{source.repo}@{ref}",
+            )
+        if response.status_code != 200:
+            raise OnyxError(
+                OnyxErrorCode.BAD_GATEWAY,
+                f"unexpected status {response.status_code} fetching '{url}'",
+            )
+
+        chunks: list[bytes] = []
+        total = 0
+        try:
+            for chunk in response.iter_content(chunk_size=64 * 1024):
+                if not chunk:
+                    continue
+                total += len(chunk)
+                if total > SKILL_MARKETPLACE_ARCHIVE_MAX_BYTES:
+                    raise OnyxError(
+                        OnyxErrorCode.PAYLOAD_TOO_LARGE,
+                        f"archive exceeds {SKILL_MARKETPLACE_ARCHIVE_MAX_BYTES // (1024 * 1024)} MiB",
+                    )
+                chunks.append(chunk)
+        except requests.RequestException as exc:
+            raise OnyxError(
+                OnyxErrorCode.BAD_GATEWAY,
+                f"error streaming archive from '{url}': {exc}",
+            ) from exc
+
+        return b"".join(chunks)
+
+
+def _safe_extract_tar(
+    archive_bytes: bytes,
+    dest: Path,
+) -> None:
+    """Extract a tar.gz archive into dest with path-traversal and size guards."""
+    buf = io.BytesIO(archive_bytes)
+    try:
+        tf = tarfile.open(fileobj=buf, mode="r:gz")
+    except tarfile.TarError as exc:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            f"archive is not a valid tar.gz: {exc}",
+        ) from exc
+
+    dest_resolved = dest.resolve()
+    member_count = 0
+    total_bytes = 0
+
+    with tf:
+        for member in tf:
+            member_count += 1
+            if member_count > _TAR_MAX_MEMBERS:
+                raise OnyxError(
+                    OnyxErrorCode.INVALID_INPUT,
+                    f"archive exceeds {_TAR_MAX_MEMBERS} members",
+                )
+
+            # Reject symlinks, hardlinks, and device files — only regular files and dirs.
+            if member.issym() or member.islnk():
+                raise OnyxError(
+                    OnyxErrorCode.INVALID_INPUT,
+                    f"archive contains a symlink/hardlink: '{member.name}'",
+                )
+            if not (member.isreg() or member.isdir()):
+                raise OnyxError(
+                    OnyxErrorCode.INVALID_INPUT,
+                    f"archive contains unsupported entry type: '{member.name}'",
+                )
+
+            # Resolve target and check it stays inside dest.
+            target = (dest / member.name).resolve()
+            try:
+                target.relative_to(dest_resolved)
+            except ValueError:
+                raise OnyxError(
+                    OnyxErrorCode.INVALID_INPUT,
+                    f"archive entry escapes root: '{member.name}'",
+                )
+
+            if member.isdir():
+                target.mkdir(parents=True, exist_ok=True)
+                continue
+
+            if member.size > DEFAULT_PER_FILE_MAX_BYTES:
+                raise OnyxError(
+                    OnyxErrorCode.PAYLOAD_TOO_LARGE,
+                    f"file '{member.name}' exceeds "
+                    f"{DEFAULT_PER_FILE_MAX_BYTES // (1024 * 1024)} MiB",
+                )
+            total_bytes += member.size
+            if total_bytes > DEFAULT_TOTAL_MAX_BYTES:
+                raise OnyxError(
+                    OnyxErrorCode.PAYLOAD_TOO_LARGE,
+                    f"archive exceeds {DEFAULT_TOTAL_MAX_BYTES // (1024 * 1024)} MiB uncompressed",
+                )
+
+            target.parent.mkdir(parents=True, exist_ok=True)
+            fobj = tf.extractfile(member)
+            if fobj is None:
+                continue
+            with fobj, open(target, "wb") as out:
+                written = 0
+                while True:
+                    chunk = fobj.read(64 * 1024)
+                    if not chunk:
+                        break
+                    written += len(chunk)
+                    if written > DEFAULT_PER_FILE_MAX_BYTES:
+                        raise OnyxError(
+                            OnyxErrorCode.PAYLOAD_TOO_LARGE,
+                            f"file '{member.name}' exceeds "
+                            f"{DEFAULT_PER_FILE_MAX_BYTES // (1024 * 1024)} MiB",
+                        )
+                    out.write(chunk)
+
+
+def _strip_top_level_dir(root: Path) -> Path:
+    """If root contains exactly one child directory, return it (GitHub/GitLab wrap)."""
+    children = list(root.iterdir())
+    if len(children) == 1 and children[0].is_dir():
+        return children[0]
+    return root
+
+
+def _parse_manifest_skill_dirs(search_root: Path) -> list[Path]:
+    """Read .claude-plugin/marketplace.json or plugin.json for declared skill dirs.
+
+    Manifest content is untrusted (it ships inside the fetched archive), so every
+    declared path is confined to ``search_root`` — absolute paths, ``..`` escapes,
+    and anything resolving outside the repo root are skipped.
+    """
+    root_resolved = search_root.resolve()
+
+    def _confined(base: Path, rel: str) -> Path | None:
+        if rel.startswith("/") or ".." in Path(rel).parts:
+            return None
+        candidate = (base / rel).resolve()
+        try:
+            candidate.relative_to(root_resolved)
+        except ValueError:
+            return None
+        return candidate if candidate.is_dir() else None
+
+    dirs: list[Path] = []
+    for name in ("marketplace.json", "plugin.json"):
+        manifest_path = search_root / ".claude-plugin" / name
+        if not manifest_path.is_file():
+            continue
+        try:
+            data = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        if not isinstance(data, dict):
+            continue
+
+        # Format 1: top-level "skills" array of relative paths
+        skills_list = data.get("skills")
+        if isinstance(skills_list, list):
+            for entry in skills_list:
+                if not isinstance(entry, str):
+                    continue
+                confined = _confined(search_root, entry)
+                if confined is not None:
+                    dirs.append(confined)
+
+        # Format 2: "plugins" list with metadata.pluginRoot and skills
+        plugins = data.get("plugins")
+        if isinstance(plugins, list):
+            for plugin in plugins:
+                if not isinstance(plugin, dict):
+                    continue
+                meta = plugin.get("metadata", {})
+                plugin_root_rel = (
+                    meta.get("pluginRoot", "") if isinstance(meta, dict) else ""
+                )
+                plugin_root = search_root
+                if plugin_root_rel:
+                    confined_root = _confined(search_root, plugin_root_rel)
+                    if confined_root is None:
+                        continue
+                    plugin_root = confined_root
+                skill_entries = plugin.get("skills", [])
+                if isinstance(skill_entries, list):
+                    for entry in skill_entries:
+                        if not isinstance(entry, str):
+                            continue
+                        confined = _confined(plugin_root, entry)
+                        if confined is not None:
+                            dirs.append(confined)
+    return dirs
+
+
+def _discover_skills_in_dir(
+    archive_bytes: bytes,
+    tmp: Path,
+    subpath: str | None = None,
+) -> list[DiscoveredSkill]:
+    """Core discovery logic operating on an already-created tmp directory."""
+    _safe_extract_tar(archive_bytes, tmp)
+    repo_root = _strip_top_level_dir(tmp)
+
+    # Determine search root, guarding against traversal.
+    if subpath:
+        search_root = (repo_root / subpath).resolve()
+        try:
+            search_root.relative_to(repo_root.resolve())
+        except ValueError:
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                f"subpath '{subpath}' escapes repository root",
+            )
+        if not search_root.is_dir():
+            raise OnyxError(
+                OnyxErrorCode.NOT_FOUND,
+                f"subpath '{subpath}' not found in archive",
+            )
+    else:
+        search_root = repo_root
+
+    seen: set[Path] = set()
+    skill_dirs: list[Path] = []
+
+    def _add(d: Path) -> None:
+        resolved = d.resolve()
+        if (
+            resolved not in seen
+            and resolved.is_dir()
+            and (resolved / SKILL_MD_NAME).is_file()
+        ):
+            seen.add(resolved)
+            skill_dirs.append(d)
+
+    # Root-level SKILL.md
+    _add(search_root)
+
+    # Flat: skills/*/SKILL.md
+    skills_base = search_root / "skills"
+    if skills_base.is_dir():
+        skills_children = sorted(skills_base.iterdir())
+        for d in skills_children:
+            if d.is_dir() and not d.name.startswith("."):
+                _add(d)
+        # Catalog: skills/*/*/SKILL.md
+        for d in skills_children:
+            if d.is_dir() and not d.name.startswith("."):
+                for sub in sorted(d.iterdir()):
+                    if sub.is_dir():
+                        _add(sub)
+        # Hidden curated containers
+        for hidden in (".curated", ".experimental"):
+            container = skills_base / hidden
+            if container.is_dir():
+                for d in sorted(container.iterdir()):
+                    if d.is_dir():
+                        _add(d)
+
+    # .claude/skills/*/SKILL.md
+    claude_skills = search_root / ".claude" / "skills"
+    if claude_skills.is_dir():
+        for d in sorted(claude_skills.iterdir()):
+            if d.is_dir():
+                _add(d)
+
+    # .agents/skills/*/SKILL.md
+    agents_skills = search_root / ".agents" / "skills"
+    if agents_skills.is_dir():
+        for d in sorted(agents_skills.iterdir()):
+            if d.is_dir():
+                _add(d)
+
+    # Manifest-declared dirs
+    for d in _parse_manifest_skill_dirs(search_root):
+        _add(d)
+
+    results: list[DiscoveredSkill] = []
+    repo_root_resolved = repo_root.resolve()
+    for skill_dir in skill_dirs:
+        try:
+            skill_md_text = (skill_dir / SKILL_MD_NAME).read_text(encoding="utf-8")
+            name, description = parse_skill_md_text(skill_md_text)
+        except OnyxError:
+            continue
+        except Exception:
+            continue
+
+        # slug: dir basename. Only a true repo-root SKILL.md (no subpath) falls
+        # back to the repo wrapper dir name; a subpath leaf (e.g. a tree URL
+        # pointing at skills/docx) keeps its own dir name.
+        if skill_dir.resolve() == repo_root_resolved:
+            slug_candidate = repo_root.name.lower()
+            # Strip common suffixes like -main, -master
+            for suffix in ("-main", "-master"):
+                if slug_candidate.endswith(suffix):
+                    slug_candidate = slug_candidate[: -len(suffix)]
+                    break
+        else:
+            slug_candidate = skill_dir.name.lower()
+
+        # Slugify: replace non-alnum with '-', strip leading/trailing '-'
+        slug = re.sub(r"[^a-z0-9]+", "-", slug_candidate).strip("-")
+        if not SLUG_REGEX.match(slug):
+            continue
+
+        try:
+            rel_path = str(skill_dir.resolve().relative_to(repo_root_resolved))
+        except ValueError:
+            rel_path = skill_dir.name
+
+        results.append(
+            DiscoveredSkill(
+                slug=slug,
+                name=name,
+                description=description,
+                rel_path=rel_path,
+                abs_dir=skill_dir.resolve(),
+            )
+        )
+
+    return sorted(results, key=lambda s: s.slug)
+
+
+def build_bundle_for_skill(skill: DiscoveredSkill) -> bytes:
+    """Produce an in-memory zip of a discovered skill's contents.
+
+    The zip root contains the skill dir's contents (SKILL.md at root, all
+    sibling files/subdirs). Excludes symlinks, .template files, and __pycache__.
+    """
+    buf = io.BytesIO()
+    total = 0
+
+    with zipfile.ZipFile(buf, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
+        skill_root = skill.abs_dir
+        for dirpath, dirnames, filenames in os.walk(skill_root):
+            # Prune __pycache__ in-place so os.walk skips them.
+            dirnames[:] = [d for d in dirnames if d != "__pycache__"]
+
+            dir_path = Path(dirpath)
+            for filename in filenames:
+                file_path = dir_path / filename
+
+                # Skip symlinks and .template files.
+                if file_path.is_symlink():
+                    continue
+                if filename.endswith(TEMPLATE_SUFFIX):
+                    continue
+
+                rel = file_path.relative_to(skill_root)
+                arc_name = str(rel)
+
+                file_size = file_path.stat().st_size
+                if file_size > DEFAULT_PER_FILE_MAX_BYTES:
+                    raise OnyxError(
+                        OnyxErrorCode.PAYLOAD_TOO_LARGE,
+                        f"file '{arc_name}' exceeds "
+                        f"{DEFAULT_PER_FILE_MAX_BYTES // (1024 * 1024)} MiB",
+                    )
+                total += file_size
+                if total > DEFAULT_TOTAL_MAX_BYTES:
+                    raise OnyxError(
+                        OnyxErrorCode.PAYLOAD_TOO_LARGE,
+                        f"skill bundle exceeds "
+                        f"{DEFAULT_TOTAL_MAX_BYTES // (1024 * 1024)} MiB uncompressed",
+                    )
+
+                zf.write(file_path, arcname=arc_name)
+
+    return buf.getvalue()
+
+
+@contextmanager
+def extracted_skills(
+    archive_bytes: bytes,
+    subpath: str | None = None,
+) -> Iterator[list[DiscoveredSkill]]:
+    """Context manager: extract archive, yield discovered skills, then clean up.
+
+    abs_dir on each DiscoveredSkill is only valid inside this with-block.
+    """
+    tmp = Path(tempfile.mkdtemp())
+    try:
+        skills = _discover_skills_in_dir(archive_bytes, tmp, subpath)
+        yield skills
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)

--- a/backend/tests/external_dependency_unit/skills/test_marketplace_install.py
+++ b/backend/tests/external_dependency_unit/skills/test_marketplace_install.py
@@ -1,0 +1,422 @@
+"""External-dependency tests for _install_repo_skills.
+
+Requires: Postgres, Redis, MinIO/S3 (real db_session + file store).
+Run via: uv run python -m dotenv -f .vscode/.env run -- pytest backend/tests/external_dependency_unit/skills/test_marketplace_install.py -x -q
+"""
+
+from __future__ import annotations
+
+import io
+import tarfile
+from collections.abc import Generator
+from uuid import uuid4
+
+import pytest
+from fastapi_users.password import PasswordHelper
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import SqlEngine
+from onyx.db.enums import AccountType
+from onyx.db.models import Skill
+from onyx.db.models import User
+from onyx.db.models import UserRole
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.file_store.file_store import FileStore
+from onyx.file_store.file_store import get_default_file_store
+from onyx.server.features.skill.api import _install_repo_skills
+from onyx.skills.built_in import BUILT_IN_SKILLS
+from onyx.skills.bundle import validate_custom_bundle
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
+
+
+def _make_tar(files: dict[str, str]) -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        for name, data in files.items():
+            b = data.encode()
+            ti = tarfile.TarInfo(name)
+            ti.size = len(b)
+            ti.mtime = 0
+            tf.addfile(ti, io.BytesIO(b))
+    return buf.getvalue()
+
+
+def _skill_md(name: str = "My Skill", description: str = "does things") -> str:
+    return f"---\nname: {name}\ndescription: {description}\n---\n# body\n"
+
+
+def _init_engine() -> None:
+    SqlEngine.init_engine(pool_size=10, max_overflow=5)
+
+
+def _make_user(db_session: Session) -> User:
+    helper = PasswordHelper()
+    user = User(
+        id=uuid4(),
+        email=f"marketplace_test_{uuid4().hex[:8]}@example.com",
+        hashed_password=helper.hash(helper.generate()),
+        is_active=True,
+        is_superuser=False,
+        is_verified=True,
+        role=UserRole.BASIC,
+        account_type=AccountType.STANDARD,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+def _delete_user(user_id: object) -> None:
+    try:
+        token = CURRENT_TENANT_ID_CONTEXTVAR.set(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
+        try:
+            with get_session_with_current_tenant() as session:
+                row = session.get(User, user_id)
+                if row is not None:
+                    session.delete(row)
+                    session.commit()
+        finally:
+            CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+    except Exception:
+        pass
+
+
+def _delete_skills_by_slugs(slugs: list[str]) -> None:
+    if not slugs:
+        return
+    try:
+        token = CURRENT_TENANT_ID_CONTEXTVAR.set(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
+        try:
+            with get_session_with_current_tenant() as session:
+                rows = (
+                    session.execute(select(Skill).where(Skill.slug.in_(slugs)))
+                    .scalars()
+                    .all()
+                )
+                file_store = get_default_file_store()
+                for row in rows:
+                    if row.bundle_file_id:
+                        try:
+                            file_store.delete_file(
+                                row.bundle_file_id, error_on_missing=False
+                            )
+                        except Exception:
+                            pass
+                    session.delete(row)
+                session.commit()
+        finally:
+            CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+    except Exception:
+        pass
+
+
+@pytest.fixture(scope="function")
+def db_session() -> Generator[Session, None, None]:
+    _init_engine()
+    with get_session_with_current_tenant() as session:
+        yield session
+
+
+@pytest.fixture(scope="function")
+def tenant_context() -> Generator[None, None, None]:
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
+    try:
+        yield
+    finally:
+        CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+
+
+@pytest.fixture(scope="function")
+def test_user(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> Generator[User, None, None]:
+    user = _make_user(db_session)
+    yield user
+    db_session.rollback()
+    _delete_user(user.id)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def initialize_file_store() -> Generator[None, None, None]:
+    _init_engine()
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
+    try:
+        get_default_file_store().initialize()
+        yield
+    finally:
+        CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+
+
+class TestInstallRepoSkills:
+    def test_happy_path_two_skills(
+        self,
+        db_session: Session,
+        test_user: User,
+        monkeypatch: pytest.MonkeyPatch,
+        request: pytest.FixtureRequest,
+        tenant_context: None,  # noqa: ARG002
+    ) -> None:
+        slug_a = f"skill-alpha-{uuid4().hex[:6]}"
+        slug_b = f"skill-beta-{uuid4().hex[:6]}"
+        archive = _make_tar(
+            {
+                f"repo-main/skills/{slug_a}/SKILL.md": _skill_md("Alpha", "alpha desc"),
+                f"repo-main/skills/{slug_b}/SKILL.md": _skill_md("Beta", "beta desc"),
+            }
+        )
+        monkeypatch.setattr(
+            "onyx.server.features.skill.api.fetch_repo_archive",
+            lambda _source: archive,
+        )
+        request.addfinalizer(lambda: _delete_skills_by_slugs([slug_a, slug_b]))
+
+        result = _install_repo_skills(
+            "owner/repo", [slug_a, slug_b], test_user, db_session
+        )
+
+        assert len(result.created) == 2
+        assert result.failures == []
+        created_slugs = {r.slug for r in result.created}
+        assert slug_a in created_slugs
+        assert slug_b in created_slugs
+
+        rows = (
+            db_session.execute(select(Skill).where(Skill.slug.in_([slug_a, slug_b])))
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 2
+        for row in rows:
+            assert row.bundle_file_id is not None
+            # Installed skills are personal to the author by default.
+            assert row.author_user_id == test_user.id
+
+    def test_happy_path_bundle_passes_validate(
+        self,
+        db_session: Session,
+        test_user: User,
+        monkeypatch: pytest.MonkeyPatch,
+        request: pytest.FixtureRequest,
+        tenant_context: None,  # noqa: ARG002
+    ) -> None:
+        slug = f"validate-skill-{uuid4().hex[:6]}"
+        archive = _make_tar(
+            {f"repo-main/skills/{slug}/SKILL.md": _skill_md("Validate", "desc")}
+        )
+        monkeypatch.setattr(
+            "onyx.server.features.skill.api.fetch_repo_archive",
+            lambda _source: archive,
+        )
+        request.addfinalizer(lambda: _delete_skills_by_slugs([slug]))
+
+        result = _install_repo_skills("owner/repo", [slug], test_user, db_session)
+        assert len(result.created) == 1
+
+        row = db_session.execute(select(Skill).where(Skill.slug == slug)).scalar_one()
+        assert row.bundle_file_id is not None
+
+        file_store = get_default_file_store()
+        blob = b"".join(file_store.read_file(row.bundle_file_id, use_tempfile=False))
+        validate_custom_bundle(blob, slug=slug)
+
+    def test_slug_collision_is_per_skill_failure(
+        self,
+        db_session: Session,
+        test_user: User,
+        monkeypatch: pytest.MonkeyPatch,
+        request: pytest.FixtureRequest,
+        tenant_context: None,  # noqa: ARG002
+    ) -> None:
+        existing_slug = f"existing-{uuid4().hex[:6]}"
+        new_slug = f"newskill-{uuid4().hex[:6]}"
+        archive = _make_tar(
+            {
+                f"repo-main/skills/{existing_slug}/SKILL.md": _skill_md(
+                    "Existing", "e"
+                ),
+                f"repo-main/skills/{new_slug}/SKILL.md": _skill_md("New", "n"),
+            }
+        )
+        monkeypatch.setattr(
+            "onyx.server.features.skill.api.fetch_repo_archive",
+            lambda _source: archive,
+        )
+        request.addfinalizer(lambda: _delete_skills_by_slugs([existing_slug, new_slug]))
+
+        result1 = _install_repo_skills(
+            "owner/repo", [existing_slug], test_user, db_session
+        )
+        assert len(result1.created) == 1
+        assert result1.failures == []
+
+        # Second install: same slug (collision) + new slug.
+        result2 = _install_repo_skills(
+            "owner/repo", [existing_slug, new_slug], test_user, db_session
+        )
+        assert len(result2.created) == 1
+        assert result2.created[0].slug == new_slug
+        assert len(result2.failures) == 1
+        assert result2.failures[0].slug == existing_slug
+
+    def test_slug_not_in_repo_is_failure_entry(
+        self,
+        db_session: Session,
+        test_user: User,
+        monkeypatch: pytest.MonkeyPatch,
+        request: pytest.FixtureRequest,
+        tenant_context: None,  # noqa: ARG002
+    ) -> None:
+        real_slug = f"real-skill-{uuid4().hex[:6]}"
+        archive = _make_tar(
+            {f"repo-main/skills/{real_slug}/SKILL.md": _skill_md("Real", "r")}
+        )
+        monkeypatch.setattr(
+            "onyx.server.features.skill.api.fetch_repo_archive",
+            lambda _source: archive,
+        )
+        request.addfinalizer(lambda: _delete_skills_by_slugs([real_slug]))
+
+        missing_slug = f"does-not-exist-{uuid4().hex[:6]}"
+        result = _install_repo_skills(
+            "owner/repo", [missing_slug], test_user, db_session
+        )
+
+        assert result.created == []
+        assert len(result.failures) == 1
+        assert result.failures[0].slug == missing_slug
+        assert "not found" in result.failures[0].error.lower()
+
+
+class TestReservedSlugRejection:
+    def test_reserved_slug_is_failure_normal_slug_is_created(
+        self,
+        db_session: Session,
+        test_user: User,
+        monkeypatch: pytest.MonkeyPatch,
+        request: pytest.FixtureRequest,
+        tenant_context: None,  # noqa: ARG002
+    ) -> None:
+        """A skill whose slug matches a built-in ends up in failures; others created."""
+        reserved_slug = next(iter(BUILT_IN_SKILLS))
+        normal_slug = f"normal-skill-{uuid4().hex[:6]}"
+
+        archive = _make_tar(
+            {
+                f"repo-main/skills/{reserved_slug}/SKILL.md": _skill_md(
+                    "Reserved", "reserved"
+                ),
+                f"repo-main/skills/{normal_slug}/SKILL.md": _skill_md("Normal", "n"),
+            }
+        )
+        monkeypatch.setattr(
+            "onyx.server.features.skill.api.fetch_repo_archive",
+            lambda _source: archive,
+        )
+        request.addfinalizer(lambda: _delete_skills_by_slugs([normal_slug]))
+
+        result = _install_repo_skills(
+            "owner/repo",
+            [reserved_slug, normal_slug],
+            test_user,
+            db_session,
+        )
+
+        assert len(result.created) == 1
+        assert result.created[0].slug == normal_slug
+
+        assert len(result.failures) == 1
+        assert result.failures[0].slug == reserved_slug
+        assert "reserved" in result.failures[0].error.lower()
+
+
+class TestBlobCleanupOnFailure:
+    def test_create_skill_failure_cleans_blob(
+        self,
+        db_session: Session,
+        test_user: User,
+        monkeypatch: pytest.MonkeyPatch,
+        request: pytest.FixtureRequest,
+        tenant_context: None,  # noqa: ARG002
+    ) -> None:
+        """When create_skill__no_commit raises, ingested_skill_bundle deletes the blob."""
+        slug = f"fail-skill-{uuid4().hex[:6]}"
+        archive = _make_tar(
+            {f"repo-main/skills/{slug}/SKILL.md": _skill_md("Fail", "f")}
+        )
+        monkeypatch.setattr(
+            "onyx.server.features.skill.api.fetch_repo_archive",
+            lambda _source: archive,
+        )
+
+        # ingested_skill_bundle cleans up via onyx.skills.ingest.delete_bundle_blob;
+        # spy there to confirm the blob is removed on the create failure.
+        deleted_blob_ids: list[str] = []
+        import onyx.skills.ingest as ingest_mod
+
+        real_delete = ingest_mod.delete_bundle_blob
+
+        def _spy_delete(file_store: FileStore, file_id: str) -> None:
+            deleted_blob_ids.append(file_id)
+            real_delete(file_store, file_id)
+
+        monkeypatch.setattr(ingest_mod, "delete_bundle_blob", _spy_delete)
+
+        def _raising_create(**_kwargs: object) -> None:
+            raise OnyxError(OnyxErrorCode.INVALID_INPUT, "boom")
+
+        monkeypatch.setattr(
+            "onyx.server.features.skill.api.create_skill__no_commit",
+            _raising_create,
+        )
+        request.addfinalizer(lambda: _delete_skills_by_slugs([slug]))
+
+        result = _install_repo_skills("owner/repo", [slug], test_user, db_session)
+
+        assert result.created == []
+        assert len(result.failures) == 1
+        assert result.failures[0].slug == slug
+        assert len(deleted_blob_ids) == 1
+
+        row = db_session.execute(
+            select(Skill).where(Skill.slug == slug)
+        ).scalar_one_or_none()
+        assert row is None
+
+    def test_non_onyx_error_records_internal_error(
+        self,
+        db_session: Session,
+        test_user: User,
+        monkeypatch: pytest.MonkeyPatch,
+        request: pytest.FixtureRequest,
+        tenant_context: None,  # noqa: ARG002
+    ) -> None:
+        """Non-OnyxError from create_skill__no_commit → failure with 'internal error'."""
+        slug = f"internal-err-{uuid4().hex[:6]}"
+        archive = _make_tar(
+            {f"repo-main/skills/{slug}/SKILL.md": _skill_md("Internal", "i")}
+        )
+        monkeypatch.setattr(
+            "onyx.server.features.skill.api.fetch_repo_archive",
+            lambda _source: archive,
+        )
+
+        def _runtime_raise(**_kwargs: object) -> None:
+            raise RuntimeError("unexpected")
+
+        monkeypatch.setattr(
+            "onyx.server.features.skill.api.create_skill__no_commit",
+            _runtime_raise,
+        )
+        request.addfinalizer(lambda: _delete_skills_by_slugs([slug]))
+
+        result = _install_repo_skills("owner/repo", [slug], test_user, db_session)
+
+        assert result.created == []
+        assert len(result.failures) == 1
+        assert result.failures[0].error == "internal error"

--- a/backend/tests/unit/skills/test_marketplace_discover.py
+++ b/backend/tests/unit/skills/test_marketplace_discover.py
@@ -1,0 +1,407 @@
+"""Unit tests for extracted_skills and build_bundle_for_skill — no services required."""
+
+from __future__ import annotations
+
+import io
+import tarfile
+import zipfile
+
+import pytest
+
+from onyx.error_handling.exceptions import OnyxError
+from onyx.skills.bundle import validate_custom_bundle
+from onyx.skills.marketplace import build_bundle_for_skill
+from onyx.skills.marketplace import extracted_skills
+
+_VALID_SKILL_MD = "---\nname: My Skill\ndescription: does things\n---\n# body\n"
+
+
+def make_tar(files: dict[str, str]) -> bytes:
+    """Build a GitHub-style tar.gz with a single top-level wrapper dir."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        for name, data in files.items():
+            b = data.encode()
+            ti = tarfile.TarInfo(name)
+            ti.size = len(b)
+            ti.mtime = 0
+            tf.addfile(ti, io.BytesIO(b))
+    return buf.getvalue()
+
+
+def make_tar_bytes(files: dict[str, bytes]) -> bytes:
+    """Like make_tar but accepts raw bytes values."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        for name, data in files.items():
+            ti = tarfile.TarInfo(name)
+            ti.size = len(data)
+            ti.mtime = 0
+            tf.addfile(ti, io.BytesIO(data))
+    return buf.getvalue()
+
+
+def test_flat_skill_discovered() -> None:
+    archive = make_tar({"repo-main/skills/my-tool/SKILL.md": _VALID_SKILL_MD})
+    with extracted_skills(archive) as skills:
+        slugs = [s.slug for s in skills]
+    assert "my-tool" in slugs
+
+
+def test_subpath_pointing_at_skill_dir_uses_dir_slug() -> None:
+    # A tree/subpath URL pointing directly at a skill dir must derive the slug
+    # from that dir (e.g. "docx"), not the repo wrapper name.
+    archive = make_tar({"repo-main/skills/docx/SKILL.md": _VALID_SKILL_MD})
+    with extracted_skills(archive, subpath="skills/docx") as skills:
+        slugs = [s.slug for s in skills]
+    assert slugs == ["docx"]
+
+
+def test_catalog_skill_discovered() -> None:
+    # skills/cat/deep/SKILL.md  — two levels under skills/
+    archive = make_tar({"repo-main/skills/cat/deep/SKILL.md": _VALID_SKILL_MD})
+    with extracted_skills(archive) as skills:
+        slugs = [s.slug for s in skills]
+    assert "deep" in slugs
+
+
+def test_claude_skills_discovered() -> None:
+    archive = make_tar({"repo-main/.claude/skills/cl/SKILL.md": _VALID_SKILL_MD})
+    with extracted_skills(archive) as skills:
+        slugs = [s.slug for s in skills]
+    assert "cl" in slugs
+
+
+def test_root_level_skill_discovered() -> None:
+    archive = make_tar({"repo-main/SKILL.md": _VALID_SKILL_MD})
+    with extracted_skills(archive) as skills:
+        assert len(skills) == 1
+        # slug comes from repo dir name "repo-main" → strips "-main" → "repo"
+        assert skills[0].slug == "repo"
+
+
+def test_multiple_layout_archive() -> None:
+    archive = make_tar(
+        {
+            "repo-main/skills/flat/SKILL.md": _VALID_SKILL_MD,
+            "repo-main/skills/cat/deep/SKILL.md": _VALID_SKILL_MD,
+            "repo-main/.claude/skills/cl/SKILL.md": _VALID_SKILL_MD,
+        }
+    )
+    with extracted_skills(archive) as skills:
+        slugs = {s.slug for s in skills}
+    assert "flat" in slugs
+    assert "deep" in slugs
+    assert "cl" in slugs
+
+
+def test_name_and_description_from_frontmatter() -> None:
+    skill_md = "---\nname: Fancy Tool\ndescription: Does fancy things\n---\n"
+    archive = make_tar({"repo-main/skills/fancy-tool/SKILL.md": skill_md})
+    with extracted_skills(archive) as skills:
+        assert len(skills) == 1
+        assert skills[0].name == "Fancy Tool"
+        assert skills[0].description == "Does fancy things"
+
+
+def test_build_bundle_passes_validate() -> None:
+    archive = make_tar(
+        {
+            "repo-main/skills/my-tool/SKILL.md": _VALID_SKILL_MD,
+            "repo-main/skills/my-tool/helper.py": "print('hi')\n",
+        }
+    )
+    with extracted_skills(archive) as skills:
+        assert len(skills) == 1
+        bundle = build_bundle_for_skill(skills[0])
+    validate_custom_bundle(bundle, slug=skills[0].slug)
+
+
+def test_build_bundle_includes_sibling_file() -> None:
+    archive = make_tar(
+        {
+            "repo-main/skills/my-tool/SKILL.md": _VALID_SKILL_MD,
+            "repo-main/skills/my-tool/helper.py": "print('hi')\n",
+        }
+    )
+    with extracted_skills(archive) as skills:
+        assert len(skills) == 1
+        bundle = build_bundle_for_skill(skills[0])
+
+    zf = zipfile.ZipFile(io.BytesIO(bundle))
+    names = zf.namelist()
+    assert "SKILL.md" in names
+    assert "helper.py" in names
+
+
+def test_subpath_filters_skills() -> None:
+    # With subpath="skills/inner", search_root = repo-main/skills/inner.
+    # The flat pattern skills/*/SKILL.md becomes skills/inner/skills/tool/SKILL.md
+    # which is deep. Easier: put a skill directly at root of the subpath tree.
+    # subpath="skills/in-scope" → search_root = repo-main/skills/in-scope
+    # → _add(search_root) picks up SKILL.md there; slug = dir name with -main stripped.
+    archive = make_tar(
+        {
+            "repo-main/skills/in-scope/SKILL.md": _VALID_SKILL_MD,
+            # This skill is outside the subpath — should NOT appear
+            "repo-main/.claude/skills/outside/SKILL.md": _VALID_SKILL_MD,
+        }
+    )
+    with extracted_skills(archive, subpath="skills/in-scope") as skills:
+        slugs = {s.slug for s in skills}
+    # Exactly one skill found — the one inside the subpath. A subpath leaf keeps
+    # its own dir name as the slug (only a true repo-root SKILL.md falls back to
+    # the repo wrapper name), so the slug is "in-scope", not "repo".
+    assert slugs == {"in-scope"}
+    assert "outside" not in slugs
+
+
+def test_subpath_not_found_raises() -> None:
+    archive = make_tar({"repo-main/skills/tool/SKILL.md": _VALID_SKILL_MD})
+    with pytest.raises(OnyxError):
+        with extracted_skills(archive, subpath="nonexistent") as _:
+            pass
+
+
+def test_tar_traversal_raises() -> None:
+    # "../../evil.txt" resolves to a path above dest, triggering the OnyxError.
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        evil_data = b"evil"
+        ti = tarfile.TarInfo("../../evil.txt")
+        ti.size = len(evil_data)
+        ti.mtime = 0
+        tf.addfile(ti, io.BytesIO(evil_data))
+    archive = buf.getvalue()
+
+    with pytest.raises(OnyxError):
+        with extracted_skills(archive) as _:
+            pass
+
+
+def test_invalid_skill_md_skipped() -> None:
+    # SKILL.md with no frontmatter — parser raises OnyxError → skill is skipped.
+    bad_skill_md = "# No frontmatter here\nJust body text.\n"
+    good_skill_md = _VALID_SKILL_MD
+    archive = make_tar(
+        {
+            "repo-main/skills/bad-skill/SKILL.md": bad_skill_md,
+            "repo-main/skills/good-skill/SKILL.md": good_skill_md,
+        }
+    )
+    with extracted_skills(archive) as skills:
+        slugs = {s.slug for s in skills}
+    assert "bad-skill" not in slugs
+    assert "good-skill" in slugs
+
+
+def test_invalid_skill_md_only_no_crash() -> None:
+    bad_skill_md = "# No frontmatter\n"
+    archive = make_tar({"repo-main/skills/bad/SKILL.md": bad_skill_md})
+    with extracted_skills(archive) as skills:
+        assert skills == []
+
+
+def _tar_with_special_member(member_type: bytes, name: str = "repo-main/evil") -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        ti = tarfile.TarInfo(name)
+        ti.type = member_type
+        if member_type in (tarfile.SYMTYPE, tarfile.LNKTYPE):
+            ti.linkname = "/etc/passwd"
+        ti.size = 0
+        ti.mtime = 0
+        tf.addfile(ti)
+    return buf.getvalue()
+
+
+def test_tar_symlink_rejected() -> None:
+    # A symlink member could point anywhere on the host — extraction must refuse.
+    archive = _tar_with_special_member(tarfile.SYMTYPE)
+    with pytest.raises(OnyxError):
+        with extracted_skills(archive) as _:
+            pass
+
+
+def test_tar_hardlink_rejected() -> None:
+    archive = _tar_with_special_member(tarfile.LNKTYPE)
+    with pytest.raises(OnyxError):
+        with extracted_skills(archive) as _:
+            pass
+
+
+def test_tar_non_regular_member_rejected() -> None:
+    # Device/FIFO members are neither file nor dir — must be refused.
+    archive = _tar_with_special_member(tarfile.FIFOTYPE)
+    with pytest.raises(OnyxError):
+        with extracted_skills(archive) as _:
+            pass
+
+
+def test_per_file_size_cap_enforced(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("onyx.skills.marketplace.DEFAULT_PER_FILE_MAX_BYTES", 8)
+    archive = make_tar_bytes({"repo-main/skills/big/SKILL.md": b"x" * 64})
+    with pytest.raises(OnyxError):
+        with extracted_skills(archive) as _:
+            pass
+
+
+def test_total_size_cap_enforced(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("onyx.skills.marketplace.DEFAULT_PER_FILE_MAX_BYTES", 1024)
+    monkeypatch.setattr("onyx.skills.marketplace.DEFAULT_TOTAL_MAX_BYTES", 16)
+    archive = make_tar_bytes(
+        {
+            "repo-main/skills/a/SKILL.md": b"x" * 12,
+            "repo-main/skills/b/SKILL.md": b"y" * 12,
+        }
+    )
+    with pytest.raises(OnyxError):
+        with extracted_skills(archive) as _:
+            pass
+
+
+def test_member_count_cap_enforced(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("onyx.skills.marketplace._TAR_MAX_MEMBERS", 2)
+    archive = make_tar(
+        {
+            "repo-main/a.txt": "a",
+            "repo-main/b.txt": "b",
+            "repo-main/c.txt": "c",
+        }
+    )
+    with pytest.raises(OnyxError):
+        with extracted_skills(archive) as _:
+            pass
+
+
+def test_manifest_declared_skill_discovered() -> None:
+    # .claude-plugin/marketplace.json "skills" array points at a dir whose name
+    # need not match any of the auto-scanned layouts.
+    archive = make_tar(
+        {
+            "repo-main/.claude-plugin/marketplace.json": '{"skills": ["tools/widget"]}',
+            "repo-main/tools/widget/SKILL.md": _VALID_SKILL_MD,
+        }
+    )
+    with extracted_skills(archive) as skills:
+        slugs = {s.slug for s in skills}
+    assert "widget" in slugs
+
+
+def test_manifest_path_confinement() -> None:
+    # An escaping manifest entry is ignored (untrusted archive content); the
+    # confined sibling entry is still discovered.
+    archive = make_tar(
+        {
+            "repo-main/.claude-plugin/marketplace.json": (
+                '{"skills": ["nested/ok", "../escape", "/etc"]}'
+            ),
+            "repo-main/nested/ok/SKILL.md": _VALID_SKILL_MD,
+        }
+    )
+    with extracted_skills(archive) as skills:
+        slugs = {s.slug for s in skills}
+    assert "ok" in slugs
+    assert "escape" not in slugs
+
+
+def test_subpath_traversal_escape_raises() -> None:
+    archive = make_tar({"repo-main/skills/tool/SKILL.md": _VALID_SKILL_MD})
+    with pytest.raises(OnyxError, match="escapes repository root"):
+        with extracted_skills(archive, subpath="../../etc") as _:
+            pass
+
+
+def test_manifest_plugins_format_discovered() -> None:
+    archive = make_tar(
+        {
+            "repo-main/.claude-plugin/plugin.json": (
+                '{"plugins": [{"metadata": {"pluginRoot": "pkg"}, '
+                '"skills": ["widget"]}]}'
+            ),
+            "repo-main/pkg/widget/SKILL.md": _VALID_SKILL_MD,
+        }
+    )
+    with extracted_skills(archive) as skills:
+        slugs = {s.slug for s in skills}
+    assert "widget" in slugs
+
+
+def test_manifest_plugins_escaping_plugin_root_skipped() -> None:
+    archive = make_tar(
+        {
+            "repo-main/.claude-plugin/marketplace.json": (
+                '{"plugins": ['
+                '{"metadata": {"pluginRoot": "../evil"}, "skills": ["x"]}, '
+                '{"metadata": {"pluginRoot": "pkg"}, "skills": ["widget"]}'
+                "]}"
+            ),
+            "repo-main/pkg/widget/SKILL.md": _VALID_SKILL_MD,
+        }
+    )
+    with extracted_skills(archive) as skills:
+        slugs = {s.slug for s in skills}
+    assert "widget" in slugs
+    assert "x" not in slugs
+
+
+def test_build_bundle_per_file_cap_enforced(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Extract at the real cap, then lower it for the build — moving the
+    # monkeypatch before extraction would trip the extraction-time cap instead.
+    archive = make_tar(
+        {
+            "repo-main/skills/my-tool/SKILL.md": _VALID_SKILL_MD,
+            "repo-main/skills/my-tool/big.bin": "x" * 256,
+        }
+    )
+    with extracted_skills(archive) as skills:
+        assert len(skills) == 1
+        monkeypatch.setattr("onyx.skills.marketplace.DEFAULT_PER_FILE_MAX_BYTES", 16)
+        with pytest.raises(OnyxError):
+            build_bundle_for_skill(skills[0])
+
+
+def test_agents_skills_layout_discovered() -> None:
+    archive = make_tar({"repo-main/.agents/skills/ag/SKILL.md": _VALID_SKILL_MD})
+    with extracted_skills(archive) as skills:
+        slugs = {s.slug for s in skills}
+    assert "ag" in slugs
+
+
+def test_curated_container_discovered() -> None:
+    archive = make_tar({"repo-main/skills/.curated/cur/SKILL.md": _VALID_SKILL_MD})
+    with extracted_skills(archive) as skills:
+        slugs = {s.slug for s in skills}
+    assert "cur" in slugs
+
+
+def test_non_sluggable_dir_name_skipped() -> None:
+    archive = make_tar(
+        {
+            "repo-main/skills/!!!/SKILL.md": _VALID_SKILL_MD,
+            "repo-main/skills/good/SKILL.md": _VALID_SKILL_MD,
+        }
+    )
+    with extracted_skills(archive) as skills:
+        slugs = {s.slug for s in skills}
+    assert slugs == {"good"}
+
+
+def test_build_bundle_excludes_template_and_pycache() -> None:
+    archive = make_tar(
+        {
+            "repo-main/skills/my-tool/SKILL.md": _VALID_SKILL_MD,
+            "repo-main/skills/my-tool/keep.py": "print('hi')\n",
+            "repo-main/skills/my-tool/SKILL.md.template": "ignored\n",
+            "repo-main/skills/my-tool/__pycache__/x.pyc": "bytecode\n",
+        }
+    )
+    with extracted_skills(archive) as skills:
+        assert len(skills) == 1
+        bundle = build_bundle_for_skill(skills[0])
+
+    names = zipfile.ZipFile(io.BytesIO(bundle)).namelist()
+    assert "SKILL.md" in names
+    assert "keep.py" in names
+    assert "SKILL.md.template" not in names
+    assert not any("__pycache__" in n for n in names)

--- a/backend/tests/unit/skills/test_marketplace_fetch.py
+++ b/backend/tests/unit/skills/test_marketplace_fetch.py
@@ -1,0 +1,140 @@
+"""Unit tests for fetch_repo_archive URL construction + error mapping.
+
+ssrf_safe_get is monkeypatched so no real network calls are made.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+import requests
+
+from onyx.error_handling.exceptions import OnyxError
+from onyx.skills.marketplace import fetch_repo_archive
+from onyx.skills.marketplace import ParsedSource
+from onyx.utils.url import SSRFException
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, chunks: list[bytes]) -> None:
+        self.status_code = status_code
+        self._chunks = chunks
+        self.url = "fake"
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, *exc: Any) -> bool:
+        return False
+
+    def iter_content(self, chunk_size: int = 0) -> Iterator[bytes]:  # noqa: ARG002
+        yield from self._chunks
+
+
+def _source(host: str, owner: str, repo: str, ref: str | None = None) -> ParsedSource:
+    return ParsedSource(
+        host=host, owner=owner, repo=repo, ref=ref, subpath=None, skill_filters=[]
+    )
+
+
+def test_github_url_constructed(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, str] = {}
+
+    def fake_get(url: str, **_kwargs: Any) -> _FakeResponse:
+        seen["url"] = url
+        return _FakeResponse(200, [b"tar", b"ball"])
+
+    monkeypatch.setattr("onyx.skills.marketplace.ssrf_safe_get", fake_get)
+    out = fetch_repo_archive(_source("github.com", "o", "r", "main"))
+    assert out == b"tarball"
+    assert seen["url"] == "https://codeload.github.com/o/r/tar.gz/main"
+
+
+def test_github_default_ref_is_head(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, str] = {}
+
+    def fake_get(url: str, **_kwargs: Any) -> _FakeResponse:
+        seen["url"] = url
+        return _FakeResponse(200, [b"x"])
+
+    monkeypatch.setattr("onyx.skills.marketplace.ssrf_safe_get", fake_get)
+    fetch_repo_archive(_source("github.com", "o", "r"))
+    assert seen["url"].endswith("/tar.gz/HEAD")
+
+
+def test_gitlab_subgroup_url_constructed(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, str] = {}
+
+    def fake_get(url: str, **_kwargs: Any) -> _FakeResponse:
+        seen["url"] = url
+        return _FakeResponse(200, [b"x"])
+
+    monkeypatch.setattr("onyx.skills.marketplace.ssrf_safe_get", fake_get)
+    fetch_repo_archive(_source("gitlab.com", "group/subgroup", "r", "dev"))
+    assert seen["url"] == (
+        "https://gitlab.com/group/subgroup/r/-/archive/dev/r-dev.tar.gz"
+    )
+
+
+def test_url_components_are_percent_encoded(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A ref carrying URL-structural chars must be encoded so it can't truncate
+    # the path as a fragment/query; slashed refs keep their '/'.
+    seen: dict[str, str] = {}
+
+    def fake_get(url: str, **_kwargs: Any) -> _FakeResponse:
+        seen["url"] = url
+        return _FakeResponse(200, [b"x"])
+
+    monkeypatch.setattr("onyx.skills.marketplace.ssrf_safe_get", fake_get)
+    fetch_repo_archive(_source("github.com", "o", "r", "feature/x#frag"))
+    assert seen["url"] == "https://codeload.github.com/o/r/tar.gz/feature/x%23frag"
+
+
+def test_404_maps_to_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "onyx.skills.marketplace.ssrf_safe_get",
+        lambda _url, **_kw: _FakeResponse(404, []),
+    )
+    with pytest.raises(OnyxError):
+        fetch_repo_archive(_source("github.com", "o", "r"))
+
+
+def test_non_200_maps_to_bad_gateway(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "onyx.skills.marketplace.ssrf_safe_get",
+        lambda _url, **_kw: _FakeResponse(503, []),
+    )
+    with pytest.raises(OnyxError):
+        fetch_repo_archive(_source("github.com", "o", "r"))
+
+
+def test_ssrf_exception_maps_to_invalid_input(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_get(_url: str, **_kwargs: Any) -> _FakeResponse:
+        raise SSRFException("blocked")
+
+    monkeypatch.setattr("onyx.skills.marketplace.ssrf_safe_get", fake_get)
+    with pytest.raises(OnyxError):
+        fetch_repo_archive(_source("github.com", "o", "r"))
+
+
+def test_network_error_maps_to_bad_gateway(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_get(_url: str, **_kwargs: Any) -> _FakeResponse:
+        raise requests.ConnectionError("boom")
+
+    monkeypatch.setattr("onyx.skills.marketplace.ssrf_safe_get", fake_get)
+    with pytest.raises(OnyxError):
+        fetch_repo_archive(_source("github.com", "o", "r"))
+
+
+def test_streamed_size_cap_enforced(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "onyx.skills.marketplace.SKILL_MARKETPLACE_ARCHIVE_MAX_BYTES", 4
+    )
+    monkeypatch.setattr(
+        "onyx.skills.marketplace.ssrf_safe_get",
+        lambda _url, **_kw: _FakeResponse(200, [b"aa", b"bb", b"cc"]),
+    )
+    with pytest.raises(OnyxError):
+        fetch_repo_archive(_source("github.com", "o", "r"))

--- a/backend/tests/unit/skills/test_marketplace_parse.py
+++ b/backend/tests/unit/skills/test_marketplace_parse.py
@@ -1,0 +1,165 @@
+"""Unit tests for parse_skill_source — no services required."""
+
+from __future__ import annotations
+
+import pytest
+
+from onyx.error_handling.exceptions import OnyxError
+from onyx.skills.marketplace import parse_skill_source
+from onyx.skills.marketplace import ParsedSource
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        # Full npx skills add command with --skill filter
+        (
+            "npx skills add https://github.com/vercel-labs/skills --skill find-skills",
+            ParsedSource(
+                host="github.com",
+                owner="vercel-labs",
+                repo="skills",
+                ref=None,
+                subpath=None,
+                skill_filters=["find-skills"],
+            ),
+        ),
+        # skills add with two --skill flags
+        (
+            "skills add owner/repo --skill a --skill b",
+            ParsedSource(
+                host="github.com",
+                owner="owner",
+                repo="repo",
+                ref=None,
+                subpath=None,
+                skill_filters=["a", "b"],
+            ),
+        ),
+        # Bare owner/repo — defaults to github.com, no ref/subpath
+        (
+            "owner/repo",
+            ParsedSource(
+                host="github.com",
+                owner="owner",
+                repo="repo",
+                ref=None,
+                subpath=None,
+                skill_filters=[],
+            ),
+        ),
+        # .git suffix stripped
+        (
+            "https://github.com/o/r.git",
+            ParsedSource(
+                host="github.com",
+                owner="o",
+                repo="r",
+                ref=None,
+                subpath=None,
+                skill_filters=[],
+            ),
+        ),
+        # /tree/<ref>/<subpath> parsed
+        (
+            "https://github.com/o/r/tree/main/skills/x",
+            ParsedSource(
+                host="github.com",
+                owner="o",
+                repo="r",
+                ref="main",
+                subpath="skills/x",
+                skill_filters=[],
+            ),
+        ),
+        # gitlab.com host accepted
+        (
+            "https://gitlab.com/o/r",
+            ParsedSource(
+                host="gitlab.com",
+                owner="o",
+                repo="r",
+                ref=None,
+                subpath=None,
+                skill_filters=[],
+            ),
+        ),
+        # GitLab /-/tree/<ref>/<subpath> — the "-" separator is handled
+        (
+            "https://gitlab.com/o/r/-/tree/main/skills/foo",
+            ParsedSource(
+                host="gitlab.com",
+                owner="o",
+                repo="r",
+                ref="main",
+                subpath="skills/foo",
+                skill_filters=[],
+            ),
+        ),
+        # GitLab subgroups: the project path before "-" may be nested, so the
+        # owner namespace keeps every segment except the final repo name.
+        (
+            "https://gitlab.com/group/subgroup/r/-/tree/main/skills/foo",
+            ParsedSource(
+                host="gitlab.com",
+                owner="group/subgroup",
+                repo="r",
+                ref="main",
+                subpath="skills/foo",
+                skill_filters=[],
+            ),
+        ),
+        (
+            "https://gitlab.com/group/sub1/sub2/r/-/tree/dev",
+            ParsedSource(
+                host="gitlab.com",
+                owner="group/sub1/sub2",
+                repo="r",
+                ref="dev",
+                subpath=None,
+                skill_filters=[],
+            ),
+        ),
+    ],
+)
+def test_parse_skill_source_ok(raw: str, expected: ParsedSource) -> None:
+    assert parse_skill_source(raw) == expected
+
+
+def test_unsupported_host_raises() -> None:
+    with pytest.raises(OnyxError):
+        parse_skill_source("https://evil.com/o/r")
+
+
+def test_garbage_string_raises() -> None:
+    with pytest.raises(OnyxError):
+        parse_skill_source("notavalidsource")
+
+
+def test_bare_hostname_only_raises() -> None:
+    # e.g. "github.com/owner" — only one path segment after host
+    with pytest.raises(OnyxError):
+        parse_skill_source("github.com/onlyowner")
+
+
+def test_tree_url_without_ref_raises() -> None:
+    # /owner/repo/tree/ with nothing after
+    with pytest.raises(OnyxError):
+        parse_skill_source("https://github.com/o/r/tree/")
+
+
+def test_ref_only_no_subpath() -> None:
+    result = parse_skill_source("https://github.com/o/r/tree/main")
+    assert result.ref == "main"
+    assert result.subpath is None
+
+
+def test_skill_filters_deduplication_not_done_by_parser() -> None:
+    # Parser does NOT deduplicate — it just collects all --skill values.
+    result = parse_skill_source("skills add owner/repo --skill a --skill a")
+    assert result.skill_filters == ["a", "a"]
+
+
+def test_git_suffix_stripped_in_bare_form() -> None:
+    result = parse_skill_source("owner/repo.git")
+    assert result.repo == "repo"

--- a/backend/tests/unit/skills/test_marketplace_preview.py
+++ b/backend/tests/unit/skills/test_marketplace_preview.py
@@ -1,0 +1,67 @@
+"""Unit tests for _preview_repo_skills — no services required."""
+
+from __future__ import annotations
+
+import io
+import tarfile
+
+import pytest
+
+from onyx.server.features.skill.api import _preview_repo_skills
+
+
+def _make_tar(files: dict[str, str]) -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        for name, data in files.items():
+            b = data.encode()
+            ti = tarfile.TarInfo(name)
+            ti.size = len(b)
+            ti.mtime = 0
+            tf.addfile(ti, io.BytesIO(b))
+    return buf.getvalue()
+
+
+def _skill_md(name: str, description: str = "does things") -> str:
+    return f"---\nname: {name}\ndescription: {description}\n---\n# body\n"
+
+
+class TestPreviewRepoSkills:
+    def test_skill_filter_marks_matching_slug_preselected(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A source with --skill <slug> → only that skill has pre_selected=True."""
+        archive = _make_tar(
+            {
+                "repo-main/skills/alpha/SKILL.md": _skill_md("Alpha"),
+                "repo-main/skills/beta/SKILL.md": _skill_md("Beta"),
+            }
+        )
+        monkeypatch.setattr(
+            "onyx.server.features.skill.api.fetch_repo_archive",
+            lambda _parsed: archive,
+        )
+
+        preview = _preview_repo_skills("skills add owner/repo --skill alpha")
+
+        slugs = {item.slug: item.pre_selected for item in preview.skills}
+        assert slugs.get("alpha") is True
+        assert slugs.get("beta") is False
+
+    def test_no_filter_all_preselected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No --skill filter → all preview items have pre_selected=True."""
+        archive = _make_tar(
+            {
+                "repo-main/skills/alpha/SKILL.md": _skill_md("Alpha"),
+                "repo-main/skills/beta/SKILL.md": _skill_md("Beta"),
+            }
+        )
+        monkeypatch.setattr(
+            "onyx.server.features.skill.api.fetch_repo_archive",
+            lambda _parsed: archive,
+        )
+
+        preview = _preview_repo_skills("owner/repo")
+
+        assert all(item.pre_selected for item in preview.skills)
+        assert len(preview.skills) == 2

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -80,6 +80,12 @@ USER_AUTH_SECRET=""
 # Automatically clamped to MAX_ALLOWED_UPLOAD_SIZE_MB at runtime.
 # DEFAULT_USER_FILE_MAX_UPLOAD_SIZE_MB=100
 
+# Skills marketplace: max compressed repo archive fetched from GitHub/GitLab when
+# installing skills from a repo. Buffered in memory, so this also bounds
+# per-request memory. Defaults (bytes / seconds) suit small skill repos.
+# SKILL_MARKETPLACE_ARCHIVE_MAX_BYTES=26214400
+# SKILL_MARKETPLACE_FETCH_TIMEOUT_SECONDS=30
+
 ## Base URL for redirects
 # WEB_DOMAIN=
 

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1569,6 +1569,9 @@ configMap:
   HARD_DELETE_CHATS: ""
   MAX_ALLOWED_UPLOAD_SIZE_MB: ""
   DEFAULT_USER_FILE_MAX_UPLOAD_SIZE_MB: ""
+  # Skills marketplace (install skills from a git repo)
+  SKILL_MARKETPLACE_ARCHIVE_MAX_BYTES: ""
+  SKILL_MARKETPLACE_FETCH_TIMEOUT_SECONDS: ""
   # Sandbox config — always "kubernetes" for Helm deployments
   SANDBOX_BACKEND: "kubernetes"
   SANDBOX_NAMESPACE: "onyx-sandboxes"


### PR DESCRIPTION
## Description

Backend-only slice of the larger skills-marketplace work: install skills directly from a GitHub/GitLab repository. Split out from the bigger branch to keep this reviewable.

- **`onyx/skills/marketplace.py`** (new): parse a `skills.sh` command / bare `owner/repo` / full URL into a source; SSRF-safe fetch of the repo `tar.gz`; path-traversal- and size-guarded extraction; skill discovery across the common layouts (root `SKILL.md`, `skills/*`, catalog `skills/*/*`, `.claude/skills`, `.agents/skills`, and `.claude-plugin` manifest-declared dirs); and per-skill in-memory zip bundle building.
- **`skill/api.py`**: user + admin `/from-repo/preview` and `/from-repo/install` endpoints. The install loop creates each skill inside its own savepoint so one failure (validation, slug collision, file-store error) becomes a per-skill failure entry instead of aborting the batch. The personal path enforces the per-user skill cap under an advisory lock; the sandbox push is best-effort post-commit.
- **`bundle.py`**: extract `parse_skill_md_text` so SKILL.md frontmatter parsing is reusable for on-disk discovery (not just zip bundles). `parse_skill_md_metadata` now delegates to it.
- **`app_configs.py`**: `SKILL_MARKETPLACE_ARCHIVE_MAX_BYTES` and `SKILL_MARKETPLACE_FETCH_TIMEOUT_SECONDS`.

Frontend and custom-app-from-repo support land in follow-up PRs.

## How Has This Been Tested?

- `pytest backend/tests/unit/skills/` — unit tests covering source parsing, repo discovery, and preview logic, including the security guards: tar traversal/symlink/hardlink/size/member caps, subpath traversal-escape rejection, manifest path confinement (both `skills` and `plugins`/`pluginRoot` formats), and the bundle-build per-file cap. All pass.
- `backend/tests/external_dependency_unit/skills/test_marketplace_install.py` — covers the install loop (happy path, slug collisions, cap enforcement, reserved slugs, blob cleanup on failure). Runs in CI against the file store.

## Known minor items (for the reviewer — surfaced by a multi-lens review, intentionally not fixed here)

- **(design) Transaction held across uploads** — the install loop holds the DB transaction + per-user advisory lock across N file-store uploads. Functionally correct (savepoint isolation + blob cleanup verified) but deviates from "don't hold a session across external calls." Fix would be a restructure (upload all bundles, then lock + insert in a short txn); left for a follow-up decision. Blast radius is bounded (per-user lock).
- **(deployment) No per-endpoint rate limit** on the BASIC_ACCESS `/from-repo/*` endpoints, which trigger user-supplied outbound fetches + extraction. Confirm a gateway-level throttle exists or add one.
- **(low) Install returns 200 even when every selected skill fails** (`{created: [], failures: [...]}`). Coherent batch contract; flagging to confirm it's intentional vs. signalling at the status layer.
- **(low) Source-parse edge cases**: an unknown flag immediately before the source yields a clean "no source found" error (fails safe, not a misparse); `--skill=value` (=-joined) form is dropped; a bare `host/owner/repo/tree/ref` token ignores the ref; GitLab archive filename for slashed refs is fragile.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
