### PR TITLE
chore: replace remaining Danswer branding mentions with Onyx

### DIFF
--- a/.vscode/env.web_template.txt
+++ b/.vscode/env.web_template.txt
@@ -7,7 +7,7 @@
 AUTH_TYPE=basic
 DEV_MODE=true
 
-# Enable the full set of Danswer Enterprise Edition features.
+# Enable the full set of Onyx Enterprise Edition features.
 # NOTE: DO NOT ENABLE THIS UNLESS YOU HAVE A PAID ENTERPRISE LICENSE (or if you
 # are using this for local testing/development).
 ENABLE_PAID_ENTERPRISE_EDITION_FEATURES=false

--- a/.vscode/env_template.txt
+++ b/.vscode/env_template.txt
@@ -46,7 +46,7 @@ PYTHONPATH=../backend
 PYTHONUNBUFFERED=1
 
 
-# Enable the full set of Danswer Enterprise Edition features.
+# Enable the full set of Onyx Enterprise Edition features.
 # NOTE: DO NOT ENABLE THIS UNLESS YOU HAVE A PAID ENTERPRISE LICENSE (or if you
 # are using this for local testing/development).
 ENABLE_PAID_ENTERPRISE_EDITION_FEATURES=False

--- a/backend/ee/onyx/server/oauth/google_drive.py
+++ b/backend/ee/onyx/server/oauth/google_drive.py
@@ -54,7 +54,7 @@ class GoogleDriveOAuth:
 
     TOKEN_URL = "https://oauth2.googleapis.com/token"
 
-    # SCOPE is per https://docs.danswer.dev/connectors/google-drive
+    # SCOPE is per https://docs.onyx.app/admins/connectors/official/google_drive/overview
     # TODO: Merge with or use google_utils.GOOGLE_SCOPES
     SCOPE = (
         "https://www.googleapis.com/auth/drive.readonly%20"

--- a/backend/ee/onyx/server/oauth/slack.py
+++ b/backend/ee/onyx/server/oauth/slack.py
@@ -40,7 +40,7 @@ class SlackOAuth:
 
     TOKEN_URL = "https://slack.com/api/oauth.v2.access"
 
-    # SCOPE is per https://docs.danswer.dev/connectors/slack
+    # SCOPE is per https://docs.onyx.app/admins/connectors/official/slack/slack_indexed
     BOT_SCOPE = (
         "channels:history,"
         "channels:read,"

--- a/deployment/docker_compose/docker-compose.resources.yml
+++ b/deployment/docker_compose/docker-compose.resources.yml
@@ -1,7 +1,7 @@
 # Docker service resource limits. Most are commented out by default.
 # 'background' service has preset (override-able) limits due to variable resource needs.
 # Uncomment and set env vars for specific service limits.
-# See: https://docs.danswer.dev/deployment/resource-sizing for details.
+# See: https://docs.onyx.app/deployment/getting_started/resourcing for details.
 
 services:
   background:

--- a/web/src/app/admin/bots/SlackBotTable.tsx
+++ b/web/src/app/admin/bots/SlackBotTable.tsx
@@ -111,7 +111,7 @@ export const SlackBotTable = ({ slackBots }: { slackBots: SlackBot[] }) => {
                 colSpan={5}
                 className="text-center text-muted-foreground"
               >
-                Please add a New Slack Bot to begin chatting with Danswer!
+                Please add a New Slack Bot to begin chatting with Onyx!
               </TableCell>
             </TableRow>
           )}


### PR DESCRIPTION
## What

Sweeps the repo for leftover **Danswer** product-branding references and updates them to **Onyx**. The repo was already ~95% migrated, so this is a small, targeted cleanup of the few remaining pure-branding mentions.

### Changes (6 files)

| File | Change |
|---|---|
| `web/src/app/admin/bots/SlackBotTable.tsx` | UI empty-state copy: "chatting with Danswer!" → "Onyx!" |
| `.vscode/env.web_template.txt` | comment: "Danswer Enterprise Edition" → "Onyx" |
| `.vscode/env_template.txt` | comment: "Danswer Enterprise Edition" → "Onyx" |
| `backend/ee/onyx/server/oauth/slack.py` | stale link `docs.danswer.dev` → `docs.onyx.app` |
| `backend/ee/onyx/server/oauth/google_drive.py` | stale link `docs.danswer.dev` → `docs.onyx.app` |
| `deployment/docker_compose/docker-compose.resources.yml` | stale link `docs.danswer.dev` → `docs.onyx.app` |

## Scope / what was intentionally left alone

A blanket find-and-replace would break things, so the following were **deliberately preserved**:

- **External test fixtures** — `danswerai.atlassian.net`, Salesforce/SharePoint URLs, `@danswer.ai` emails, real group IDs
- **Vespa index/schema names** — `danswer_chunk`, `danswer_index`, `__danswer_alt_index` (live data contract; renaming needs a reindex)
- **Env-var contracts** — `NEXT_PUBLIC_DO_NOT_USE_TOGGLE_OFF_DANSWER_POWERED`, `DANSWER_*`
- **HuggingFace model** — `Danswer/filter-extraction-model`
- **Legal/copyright** — `DanswerAI, Inc.` and the intentional "Onyx (formerly Danswer)" note in `AGENTS.md`

> Note: a case-insensitive search for "danswer" also matches the unrelated `StandardAnswer` feature (`Standar`+`dAnswer`); those were excluded.

## Test plan

Text/branding-only change — no behavioral impact. No tests added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced remaining Danswer branding with Onyx in UI copy and comments, and updated stale docs links to `docs.onyx.app`. No behavior changes; kept external fixtures, `DANSWER_*` env vars, Vespa index names, the `Danswer/filter-extraction-model`, and legal references as-is.

<sup>Written for commit f4e99db652370a0207e3df8e2c0af72edd94579c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

