### PR TITLE
feat: per-user usage + cost tracking — schema + models (1/4) [modifying #11766]

### DIFF
--- a/backend/alembic/versions/8c1d4f6a2e9b_add_usage_cost_tracking.py
+++ b/backend/alembic/versions/8c1d4f6a2e9b_add_usage_cost_tracking.py
@@ -29,10 +29,16 @@ def upgrade() -> None:
         # Empty string (not NULL) for a provider-agnostic override, so the unique
         # key works on every Postgres version (NULLS NOT DISTINCT is PG15+ only).
         sa.Column("provider", sa.String(), nullable=False, server_default=""),
-        sa.Column("input_cost_per_mtok", sa.Float(), nullable=False),
-        sa.Column("output_cost_per_mtok", sa.Float(), nullable=False),
+        sa.Column("input_cost_per_mtok", sa.Numeric(18, 6), nullable=False),
+        sa.Column("output_cost_per_mtok", sa.Numeric(18, 6), nullable=False),
         # null cache rate bills cache reads at the input rate (litellm default).
-        sa.Column("cache_read_cost_per_mtok", sa.Float(), nullable=True),
+        sa.Column("cache_read_cost_per_mtok", sa.Numeric(18, 6), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
         # The model's onupdate=func.now() is ORM-side only (not DDL), so
         # updated_at auto-bumps on ORM writes but not on raw-SQL UPDATEs.
         sa.Column(
@@ -69,7 +75,7 @@ def upgrade() -> None:
         sa.Column(
             "cache_read_tokens", sa.BigInteger(), nullable=False, server_default="0"
         ),
-        sa.Column("cost_cents", sa.Float(), nullable=False, server_default="0.0"),
+        sa.Column("cost_cents", sa.Numeric(18, 6), nullable=False, server_default="0"),
         sa.Column(
             "created_at",
             sa.DateTime(timezone=True),
@@ -98,7 +104,7 @@ def upgrade() -> None:
 
     op.add_column(
         "token_rate_limit",
-        sa.Column("cost_budget_cents", sa.Float(), nullable=True),
+        sa.Column("cost_budget_cents", sa.Numeric(18, 6), nullable=True),
     )
     op.alter_column("token_rate_limit", "token_budget", nullable=True)
     # A limit must carry a token budget, a cost budget, or both — never neither.

--- a/backend/alembic/versions/8c1d4f6a2e9b_add_usage_cost_tracking.py
+++ b/backend/alembic/versions/8c1d4f6a2e9b_add_usage_cost_tracking.py
@@ -64,10 +64,10 @@ def upgrade() -> None:
         # Empty string (not NULL) for "no provider" so the dedup unique index
         # works on every Postgres version (NULLS NOT DISTINCT is PG15+ only).
         sa.Column("provider", sa.String(), nullable=False, server_default=""),
-        sa.Column("input_tokens", sa.Integer(), nullable=False),
-        sa.Column("output_tokens", sa.Integer(), nullable=False),
+        sa.Column("input_tokens", sa.BigInteger(), nullable=False),
+        sa.Column("output_tokens", sa.BigInteger(), nullable=False),
         sa.Column(
-            "cache_read_tokens", sa.Integer(), nullable=False, server_default="0"
+            "cache_read_tokens", sa.BigInteger(), nullable=False, server_default="0"
         ),
         sa.Column("cost_cents", sa.Float(), nullable=False, server_default="0.0"),
         sa.Column(
@@ -107,11 +107,11 @@ def downgrade() -> None:
     op.drop_constraint(
         "ck_token_rate_limit_budget_set", "token_rate_limit", type_="check"
     )
-    # token_budget goes back to NOT NULL; back-fill any cost-only rows first so
-    # the alter can't fail on NULLs.
-    op.execute(
-        "UPDATE token_rate_limit SET token_budget = 0 WHERE token_budget IS NULL"
-    )
+    # Delete cost-only rows before restoring NOT NULL. Zero-filling them would
+    # leave token_budget=0 rows that older enforcement reads as "block at 0
+    # tokens" (rejecting every request); a cost-only limit can't function once
+    # cost_budget_cents is dropped below anyway.
+    op.execute("DELETE FROM token_rate_limit WHERE token_budget IS NULL")
     op.alter_column("token_rate_limit", "token_budget", nullable=False)
     op.drop_column("token_rate_limit", "cost_budget_cents")
     op.drop_index("uq_user_usage_dims", table_name="user_usage")

--- a/backend/alembic/versions/8c1d4f6a2e9b_add_usage_cost_tracking.py
+++ b/backend/alembic/versions/8c1d4f6a2e9b_add_usage_cost_tracking.py
@@ -1,0 +1,114 @@
+"""add usage + cost tracking schema
+
+Creates the per-user usage rollup table and the per-model cost-override table,
+and adds a cost budget to token rate limits (token budget becomes nullable so a
+limit can be token-only, cost-only, or both).
+
+Revision ID: 8c1d4f6a2e9b
+Revises: f3a9c1d4b7e2
+Create Date: 2026-06-05 00:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+import fastapi_users_db_sqlalchemy
+
+# revision identifiers, used by Alembic.
+revision = "8c1d4f6a2e9b"
+down_revision = "f3a9c1d4b7e2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "model_cost_override",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("model", sa.String(), nullable=False),
+        sa.Column("input_cost_per_mtok", sa.Float(), nullable=False),
+        sa.Column("output_cost_per_mtok", sa.Float(), nullable=False),
+        # null cache rate bills cache reads at the input rate (litellm default).
+        sa.Column("cache_read_cost_per_mtok", sa.Float(), nullable=True),
+        # The model's onupdate=func.now() is ORM-side only (not DDL), so
+        # updated_at auto-bumps on ORM writes but not on raw-SQL UPDATEs.
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("model", name="uq_model_cost_override_model"),
+    )
+
+    op.create_table(
+        "user_usage",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column(
+            "user_id",
+            fastapi_users_db_sqlalchemy.generics.GUID(),
+            nullable=False,
+        ),
+        sa.Column(
+            "window_start", sa.DateTime(timezone=True), nullable=False, index=True
+        ),
+        sa.Column("model", sa.String(), nullable=False),
+        sa.Column("flow", sa.String(), nullable=False),
+        # Empty string (not NULL) for "no provider" so the dedup unique index
+        # works on every Postgres version (NULLS NOT DISTINCT is PG15+ only).
+        sa.Column("provider", sa.String(), nullable=False, server_default=""),
+        sa.Column("input_tokens", sa.Integer(), nullable=False),
+        sa.Column("output_tokens", sa.Integer(), nullable=False),
+        sa.Column(
+            "cache_read_tokens", sa.Integer(), nullable=False, server_default="0"
+        ),
+        sa.Column("cost_cents", sa.Float(), nullable=False, server_default="0.0"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_user_usage_user_id", "user_usage", ["user_id"], unique=False)
+    # Upsert key. provider is non-null ('' when absent), so a plain unique index
+    # dedups correctly on every Postgres version (no PG15-only NULLS NOT DISTINCT).
+    op.create_index(
+        "uq_user_usage_dims",
+        "user_usage",
+        ["user_id", "window_start", "model", "flow", "provider"],
+        unique=True,
+    )
+
+    op.add_column(
+        "token_rate_limit",
+        sa.Column("cost_budget_cents", sa.Float(), nullable=True),
+    )
+    op.alter_column("token_rate_limit", "token_budget", nullable=True)
+    # A limit must carry a token budget, a cost budget, or both — never neither.
+    op.create_check_constraint(
+        "ck_token_rate_limit_budget_set",
+        "token_rate_limit",
+        "token_budget IS NOT NULL OR cost_budget_cents IS NOT NULL",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "ck_token_rate_limit_budget_set", "token_rate_limit", type_="check"
+    )
+    # token_budget goes back to NOT NULL; back-fill any cost-only rows first so
+    # the alter can't fail on NULLs.
+    op.execute(
+        "UPDATE token_rate_limit SET token_budget = 0 WHERE token_budget IS NULL"
+    )
+    op.alter_column("token_rate_limit", "token_budget", nullable=False)
+    op.drop_column("token_rate_limit", "cost_budget_cents")
+    op.drop_index("uq_user_usage_dims", table_name="user_usage")
+    op.drop_index("ix_user_usage_user_id", table_name="user_usage")
+    op.drop_index("ix_user_usage_window_start", table_name="user_usage")
+    op.drop_table("user_usage")
+    op.drop_table("model_cost_override")

--- a/backend/alembic/versions/8c1d4f6a2e9b_add_usage_cost_tracking.py
+++ b/backend/alembic/versions/8c1d4f6a2e9b_add_usage_cost_tracking.py
@@ -76,6 +76,12 @@ def upgrade() -> None:
             server_default=sa.func.now(),
             nullable=False,
         ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
         sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
         sa.PrimaryKeyConstraint("id"),
     )

--- a/backend/alembic/versions/8c1d4f6a2e9b_add_usage_cost_tracking.py
+++ b/backend/alembic/versions/8c1d4f6a2e9b_add_usage_cost_tracking.py
@@ -26,6 +26,9 @@ def upgrade() -> None:
         "model_cost_override",
         sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("model", sa.String(), nullable=False),
+        # Empty string (not NULL) for a provider-agnostic override, so the unique
+        # key works on every Postgres version (NULLS NOT DISTINCT is PG15+ only).
+        sa.Column("provider", sa.String(), nullable=False, server_default=""),
         sa.Column("input_cost_per_mtok", sa.Float(), nullable=False),
         sa.Column("output_cost_per_mtok", sa.Float(), nullable=False),
         # null cache rate bills cache reads at the input rate (litellm default).
@@ -39,7 +42,10 @@ def upgrade() -> None:
             nullable=False,
         ),
         sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint("model", name="uq_model_cost_override_model"),
+        # provider+model so the same model can be priced per provider.
+        sa.UniqueConstraint(
+            "provider", "model", name="uq_model_cost_override_provider_model"
+        ),
     )
 
     op.create_table(
@@ -73,7 +79,8 @@ def upgrade() -> None:
         sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
         sa.PrimaryKeyConstraint("id"),
     )
-    op.create_index("ix_user_usage_user_id", "user_usage", ["user_id"], unique=False)
+    # No standalone user_id index: uq_user_usage_dims leads with user_id, so
+    # Postgres uses it for user-only lookups.
     # Upsert key. provider is non-null ('' when absent), so a plain unique index
     # dedups correctly on every Postgres version (no PG15-only NULLS NOT DISTINCT).
     op.create_index(
@@ -108,7 +115,6 @@ def downgrade() -> None:
     op.alter_column("token_rate_limit", "token_budget", nullable=False)
     op.drop_column("token_rate_limit", "cost_budget_cents")
     op.drop_index("uq_user_usage_dims", table_name="user_usage")
-    op.drop_index("ix_user_usage_user_id", table_name="user_usage")
     op.drop_index("ix_user_usage_window_start", table_name="user_usage")
     op.drop_table("user_usage")
     op.drop_table("model_cost_override")

--- a/backend/alembic/versions/8c1d4f6a2e9b_add_usage_cost_tracking.py
+++ b/backend/alembic/versions/8c1d4f6a2e9b_add_usage_cost_tracking.py
@@ -5,7 +5,7 @@ and adds a cost budget to token rate limits (token budget becomes nullable so a
 limit can be token-only, cost-only, or both).
 
 Revision ID: 8c1d4f6a2e9b
-Revises: f3a9c1d4b7e2
+Revises: 99c855a8f2a1
 Create Date: 2026-06-05 00:00:00.000000
 
 """
@@ -16,7 +16,7 @@ import fastapi_users_db_sqlalchemy
 
 # revision identifiers, used by Alembic.
 revision = "8c1d4f6a2e9b"
-down_revision = "f3a9c1d4b7e2"
+down_revision = "99c855a8f2a1"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/8c1d4f6a2e9b_add_usage_cost_tracking.py
+++ b/backend/alembic/versions/8c1d4f6a2e9b_add_usage_cost_tracking.py
@@ -26,8 +26,7 @@ def upgrade() -> None:
         "model_cost_override",
         sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("model", sa.String(), nullable=False),
-        # Empty string (not NULL) for a provider-agnostic override, so the unique
-        # key works on every Postgres version (NULLS NOT DISTINCT is PG15+ only).
+        # '' not NULL: unique key works pre-PG15 without NULLS NOT DISTINCT.
         sa.Column("provider", sa.String(), nullable=False, server_default=""),
         sa.Column("input_cost_per_mtok", sa.Numeric(18, 6), nullable=False),
         sa.Column("output_cost_per_mtok", sa.Numeric(18, 6), nullable=False),
@@ -39,8 +38,7 @@ def upgrade() -> None:
             server_default=sa.func.now(),
             nullable=False,
         ),
-        # The model's onupdate=func.now() is ORM-side only (not DDL), so
-        # updated_at auto-bumps on ORM writes but not on raw-SQL UPDATEs.
+        # onupdate=func.now() is ORM-only; raw-SQL UPDATEs won't bump updated_at.
         sa.Column(
             "updated_at",
             sa.DateTime(timezone=True),
@@ -67,8 +65,7 @@ def upgrade() -> None:
         ),
         sa.Column("model", sa.String(), nullable=False),
         sa.Column("flow", sa.String(), nullable=False),
-        # Empty string (not NULL) for "no provider" so the dedup unique index
-        # works on every Postgres version (NULLS NOT DISTINCT is PG15+ only).
+        # '' not NULL: unique index dedups pre-PG15 without NULLS NOT DISTINCT.
         sa.Column("provider", sa.String(), nullable=False, server_default=""),
         sa.Column("input_tokens", sa.BigInteger(), nullable=False),
         sa.Column("output_tokens", sa.BigInteger(), nullable=False),
@@ -91,10 +88,7 @@ def upgrade() -> None:
         sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
         sa.PrimaryKeyConstraint("id"),
     )
-    # No standalone user_id index: uq_user_usage_dims leads with user_id, so
-    # Postgres uses it for user-only lookups.
-    # Upsert key. provider is non-null ('' when absent), so a plain unique index
-    # dedups correctly on every Postgres version (no PG15-only NULLS NOT DISTINCT).
+    # uq_user_usage_dims (user_id-first) serves user-only lookups; no separate index needed.
     op.create_index(
         "uq_user_usage_dims",
         "user_usage",
@@ -119,10 +113,7 @@ def downgrade() -> None:
     op.drop_constraint(
         "ck_token_rate_limit_budget_set", "token_rate_limit", type_="check"
     )
-    # Delete cost-only rows before restoring NOT NULL. Zero-filling them would
-    # leave token_budget=0 rows that older enforcement reads as "block at 0
-    # tokens" (rejecting every request); a cost-only limit can't function once
-    # cost_budget_cents is dropped below anyway.
+    # Zero-filling would set token_budget=0, which older enforcement treats as "block all".
     op.execute("DELETE FROM token_rate_limit WHERE token_budget IS NULL")
     op.alter_column("token_rate_limit", "token_budget", nullable=False)
     op.drop_column("token_rate_limit", "cost_budget_cents")

--- a/backend/alembic/versions/8c1d4f6a2e9b_add_usage_cost_tracking.py
+++ b/backend/alembic/versions/8c1d4f6a2e9b_add_usage_cost_tracking.py
@@ -5,7 +5,7 @@ and adds a cost budget to token rate limits (token budget becomes nullable so a
 limit can be token-only, cost-only, or both).
 
 Revision ID: 8c1d4f6a2e9b
-Revises: a4c9d2e7f1b8
+Revises: 582269841f06
 Create Date: 2026-06-05 00:00:00.000000
 
 """
@@ -16,7 +16,7 @@ import fastapi_users_db_sqlalchemy
 
 # revision identifiers, used by Alembic.
 revision = "8c1d4f6a2e9b"
-down_revision = "a4c9d2e7f1b8"
+down_revision = "582269841f06"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/8c1d4f6a2e9b_add_usage_cost_tracking.py
+++ b/backend/alembic/versions/8c1d4f6a2e9b_add_usage_cost_tracking.py
@@ -5,7 +5,7 @@ and adds a cost budget to token rate limits (token budget becomes nullable so a
 limit can be token-only, cost-only, or both).
 
 Revision ID: 8c1d4f6a2e9b
-Revises: 99c855a8f2a1
+Revises: a4c9d2e7f1b8
 Create Date: 2026-06-05 00:00:00.000000
 
 """
@@ -16,7 +16,7 @@ import fastapi_users_db_sqlalchemy
 
 # revision identifiers, used by Alembic.
 revision = "8c1d4f6a2e9b"
-down_revision = "99c855a8f2a1"
+down_revision = "a4c9d2e7f1b8"
 branch_labels = None
 depends_on = None
 

--- a/backend/ee/onyx/db/token_limit.py
+++ b/backend/ee/onyx/db/token_limit.py
@@ -89,6 +89,7 @@ def insert_user_group_token_rate_limit(
     token_limit = TokenRateLimit(
         enabled=token_rate_limit_settings.enabled,
         token_budget=token_rate_limit_settings.token_budget,
+        cost_budget_cents=token_rate_limit_settings.cost_budget_cents,
         period_hours=token_rate_limit_settings.period_hours,
         scope=TokenRateLimitScope.USER_GROUP,
     )

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5477,6 +5477,12 @@ class UserUsage(Base):
     created_at: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
+    updated_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
 
     __table_args__ = (
         # Upsert key: accumulate into one row per dimension tuple per window.

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -25,6 +25,7 @@ from sqlalchemy import ForeignKeyConstraint
 from sqlalchemy import func
 from sqlalchemy import Index
 from sqlalchemy import Integer
+from sqlalchemy import Numeric
 from sqlalchemy import PrimaryKeyConstraint
 from sqlalchemy import Sequence
 from sqlalchemy import String
@@ -4672,7 +4673,9 @@ class TokenRateLimit(Base):
     # from that gate. At least one must be set — enforced by the check constraint
     # below, so a backfill / direct write can't create an unenforceable row.
     token_budget: Mapped[int | None] = mapped_column(Integer, nullable=True)
-    cost_budget_cents: Mapped[float | None] = mapped_column(Float, nullable=True)
+    cost_budget_cents: Mapped[float | None] = mapped_column(
+        Numeric(18, 6, asdecimal=False), nullable=True
+    )
     period_hours: Mapped[int] = mapped_column(Integer, nullable=False)
     scope: Mapped[TokenRateLimitScope] = mapped_column(
         Enum(TokenRateLimitScope, native_enum=False)
@@ -5472,7 +5475,9 @@ class UserUsage(Base):
     cache_read_tokens: Mapped[int] = mapped_column(
         BigInteger, nullable=False, default=0
     )
-    cost_cents: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    cost_cents: Mapped[float] = mapped_column(
+        Numeric(18, 6, asdecimal=False), nullable=False, default=0.0
+    )
 
     created_at: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
@@ -5520,13 +5525,25 @@ class ModelCostOverride(Base):
     )
 
     # Rates in USD per million tokens.
-    input_cost_per_mtok: Mapped[float] = mapped_column(Float, nullable=False)
-    output_cost_per_mtok: Mapped[float] = mapped_column(Float, nullable=False)
+    input_cost_per_mtok: Mapped[float] = mapped_column(
+        Numeric(18, 6, asdecimal=False), nullable=False
+    )
+    output_cost_per_mtok: Mapped[float] = mapped_column(
+        Numeric(18, 6, asdecimal=False), nullable=False
+    )
     # Cache-read rate; null bills cache reads at the input rate (litellm default).
-    cache_read_cost_per_mtok: Mapped[float | None] = mapped_column(Float, nullable=True)
+    cache_read_cost_per_mtok: Mapped[float | None] = mapped_column(
+        Numeric(18, 6, asdecimal=False), nullable=True
+    )
 
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
     updated_at: Mapped[datetime.datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
     )
 
     __table_args__ = (

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -4669,12 +4669,9 @@ class TokenRateLimit(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
-    # A row carries a token budget, a cost budget, or both; a null side is exempt
-    # from that gate. At least one must be set — enforced by the check constraint
-    # below, so a backfill / direct write can't create an unenforceable row.
+    # Null side skips its gate; at least one must be set (check constraint below).
     token_budget: Mapped[int | None] = mapped_column(Integer, nullable=True)
-    # USD cents; Numeric(18,6) avoids binary-float rounding on accumulation.
-    # Sub-cent precision (6 dp) keeps fractional per-token deltas exact.
+    # USD cents; Numeric(18,6) exact accumulation, 6dp for sub-cent per-token deltas.
     cost_budget_cents: Mapped[float | None] = mapped_column(
         Numeric(18, 6, asdecimal=False), nullable=True
     )
@@ -5454,8 +5451,7 @@ class UserUsage(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
 
-    # No index=True: uq_user_usage_dims leads with user_id, so Postgres uses it
-    # for user-only lookups.
+    # No index=True: uq_user_usage_dims (user_id-first) covers user-only lookups.
     user_id: Mapped[UUID] = mapped_column(
         ForeignKey("user.id", ondelete="CASCADE"), nullable=False
     )
@@ -5466,8 +5462,7 @@ class UserUsage(Base):
 
     model: Mapped[str] = mapped_column(String, nullable=False)
     flow: Mapped[str] = mapped_column(String, nullable=False)
-    # Empty string (not NULL) for "no provider" so the dedup unique index below
-    # works on every Postgres version without NULLS NOT DISTINCT (PG15+).
+    # '' not NULL: unique index dedups pre-PG15 without NULLS NOT DISTINCT.
     provider: Mapped[str] = mapped_column(
         String, nullable=False, default="", server_default=""
     )

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -4673,6 +4673,8 @@ class TokenRateLimit(Base):
     # from that gate. At least one must be set — enforced by the check constraint
     # below, so a backfill / direct write can't create an unenforceable row.
     token_budget: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    # USD cents; Numeric(18,6) avoids binary-float rounding on accumulation.
+    # Sub-cent precision (6 dp) keeps fractional per-token deltas exact.
     cost_budget_cents: Mapped[float | None] = mapped_column(
         Numeric(18, 6, asdecimal=False), nullable=True
     )

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5449,8 +5449,10 @@ class UserUsage(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
 
+    # No index=True: uq_user_usage_dims leads with user_id, so Postgres uses it
+    # for user-only lookups.
     user_id: Mapped[UUID] = mapped_column(
-        ForeignKey("user.id", ondelete="CASCADE"), nullable=False, index=True
+        ForeignKey("user.id", ondelete="CASCADE"), nullable=False
     )
 
     window_start: Mapped[datetime.datetime] = mapped_column(
@@ -5501,8 +5503,13 @@ class ModelCostOverride(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
 
-    # litellm-style model name (e.g. "gpt-4o"); one override per model.
-    model: Mapped[str] = mapped_column(String, nullable=False, unique=True)
+    # litellm-style model name (e.g. "gpt-4o").
+    model: Mapped[str] = mapped_column(String, nullable=False)
+    # Empty string (not NULL) for a provider-agnostic override, so the unique key
+    # below works on every Postgres version without NULLS NOT DISTINCT (PG15+).
+    provider: Mapped[str] = mapped_column(
+        String, nullable=False, default="", server_default=""
+    )
 
     # Rates in USD per million tokens.
     input_cost_per_mtok: Mapped[float] = mapped_column(Float, nullable=False)
@@ -5512,6 +5519,13 @@ class ModelCostOverride(Base):
 
     updated_at: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    __table_args__ = (
+        # provider+model so the same model can be priced per provider.
+        UniqueConstraint(
+            "provider", "model", name="uq_model_cost_override_provider_model"
+        ),
     )
 
 

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5467,9 +5467,11 @@ class UserUsage(Base):
         String, nullable=False, default="", server_default=""
     )
 
-    input_tokens: Mapped[int] = mapped_column(Integer, nullable=False)
-    output_tokens: Mapped[int] = mapped_column(Integer, nullable=False)
-    cache_read_tokens: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    input_tokens: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    output_tokens: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    cache_read_tokens: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, default=0
+    )
     cost_cents: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
 
     created_at: Mapped[datetime.datetime] = mapped_column(

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -4668,13 +4668,24 @@ class TokenRateLimit(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
-    token_budget: Mapped[int] = mapped_column(Integer, nullable=False)
+    # A row carries a token budget, a cost budget, or both; a null side is exempt
+    # from that gate. At least one must be set — enforced by the check constraint
+    # below, so a backfill / direct write can't create an unenforceable row.
+    token_budget: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    cost_budget_cents: Mapped[float | None] = mapped_column(Float, nullable=True)
     period_hours: Mapped[int] = mapped_column(Integer, nullable=False)
     scope: Mapped[TokenRateLimitScope] = mapped_column(
         Enum(TokenRateLimitScope, native_enum=False)
     )
     created_at: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "token_budget IS NOT NULL OR cost_budget_cents IS NOT NULL",
+            name="ck_token_rate_limit_budget_set",
+        ),
     )
 
 
@@ -5419,6 +5430,88 @@ class TenantUsage(Base):
     __table_args__ = (
         # Ensure only one row per window start (tenant_id is in the schema name)
         UniqueConstraint("window_start", name="uq_tenant_usage_window"),
+    )
+
+
+class UserUsage(Base):
+    """
+    Per-user LLM usage rollup within a time window — the source of truth for
+    per-user cost/token attribution and budget checks. Mirrors TenantUsage's
+    window-rollup model (one accumulating row per window+dims, not a per-call
+    ledger).
+
+    One row per (user, window, model, flow, provider), accumulated in place;
+    windows match the tenant-usage alignment so per-user and per-tenant totals
+    reconcile.
+    """
+
+    __tablename__ = "user_usage"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+
+    user_id: Mapped[UUID] = mapped_column(
+        ForeignKey("user.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+
+    window_start: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, index=True
+    )
+
+    model: Mapped[str] = mapped_column(String, nullable=False)
+    flow: Mapped[str] = mapped_column(String, nullable=False)
+    # Empty string (not NULL) for "no provider" so the dedup unique index below
+    # works on every Postgres version without NULLS NOT DISTINCT (PG15+).
+    provider: Mapped[str] = mapped_column(
+        String, nullable=False, default="", server_default=""
+    )
+
+    input_tokens: Mapped[int] = mapped_column(Integer, nullable=False)
+    output_tokens: Mapped[int] = mapped_column(Integer, nullable=False)
+    cache_read_tokens: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    cost_cents: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    __table_args__ = (
+        # Upsert key: accumulate into one row per dimension tuple per window.
+        # provider is non-null ('' when absent), so a plain unique index dedups
+        # correctly on every Postgres version (no NULLS NOT DISTINCT needed).
+        Index(
+            "uq_user_usage_dims",
+            "user_id",
+            "window_start",
+            "model",
+            "flow",
+            "provider",
+            unique=True,
+        ),
+    )
+
+
+class ModelCostOverride(Base):
+    """Admin-set per-model rates that supersede litellm pricing.
+
+    Negotiated enterprise rates win over litellm's published numbers, so cost
+    computation consults this table before falling back to litellm.
+    """
+
+    __tablename__ = "model_cost_override"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+
+    # litellm-style model name (e.g. "gpt-4o"); one override per model.
+    model: Mapped[str] = mapped_column(String, nullable=False, unique=True)
+
+    # Rates in USD per million tokens.
+    input_cost_per_mtok: Mapped[float] = mapped_column(Float, nullable=False)
+    output_cost_per_mtok: Mapped[float] = mapped_column(Float, nullable=False)
+    # Cache-read rate; null bills cache reads at the input rate (litellm default).
+    cache_read_cost_per_mtok: Mapped[float | None] = mapped_column(Float, nullable=True)
+
+    updated_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
     )
 
 

--- a/backend/onyx/db/token_limit.py
+++ b/backend/onyx/db/token_limit.py
@@ -53,6 +53,7 @@ def insert_user_token_rate_limit(
     token_limit = TokenRateLimit(
         enabled=token_rate_limit_settings.enabled,
         token_budget=token_rate_limit_settings.token_budget,
+        cost_budget_cents=token_rate_limit_settings.cost_budget_cents,
         period_hours=token_rate_limit_settings.period_hours,
         scope=TokenRateLimitScope.USER,
     )
@@ -69,6 +70,7 @@ def insert_global_token_rate_limit(
     token_limit = TokenRateLimit(
         enabled=token_rate_limit_settings.enabled,
         token_budget=token_rate_limit_settings.token_budget,
+        cost_budget_cents=token_rate_limit_settings.cost_budget_cents,
         period_hours=token_rate_limit_settings.period_hours,
         scope=TokenRateLimitScope.GLOBAL,
     )
@@ -89,6 +91,7 @@ def update_token_rate_limit(
 
     token_limit.enabled = token_rate_limit_settings.enabled
     token_limit.token_budget = token_rate_limit_settings.token_budget
+    token_limit.cost_budget_cents = token_rate_limit_settings.cost_budget_cents
     token_limit.period_hours = token_rate_limit_settings.period_hours
     db_session.commit()
 

--- a/backend/onyx/server/query_and_chat/token_limit.py
+++ b/backend/onyx/server/query_and_chat/token_limit.py
@@ -105,6 +105,9 @@ def _is_rate_limited(
     If at least one rate limit is exceeded, return True
     """
     for rate_limit in rate_limits:
+        if rate_limit.token_budget is None:
+            continue
+
         tokens_used = sum(
             u_token_count
             for u_date, u_token_count in usage

--- a/backend/onyx/server/token_rate_limits/models.py
+++ b/backend/onyx/server/token_rate_limits/models.py
@@ -1,18 +1,27 @@
 from pydantic import BaseModel
+from pydantic import model_validator
 
 from onyx.db.models import TokenRateLimit
 
 
 class TokenRateLimitArgs(BaseModel):
     enabled: bool
-    token_budget: int
+    token_budget: int | None = None
+    cost_budget_cents: float | None = None
     period_hours: int
+
+    @model_validator(mode="after")
+    def validate_budget_set(self) -> "TokenRateLimitArgs":
+        if self.token_budget is None and self.cost_budget_cents is None:
+            raise ValueError("Either token_budget or cost_budget_cents must be set")
+        return self
 
 
 class TokenRateLimitDisplay(BaseModel):
     token_id: int
     enabled: bool
-    token_budget: int
+    token_budget: int | None
+    cost_budget_cents: float | None
     period_hours: int
 
     @classmethod
@@ -21,5 +30,6 @@ class TokenRateLimitDisplay(BaseModel):
             token_id=token_rate_limit.id,
             enabled=token_rate_limit.enabled,
             token_budget=token_rate_limit.token_budget,
+            cost_budget_cents=token_rate_limit.cost_budget_cents,
             period_hours=token_rate_limit.period_hours,
         )

--- a/backend/tests/unit/onyx/server/test_token_rate_limit_budget_models.py
+++ b/backend/tests/unit/onyx/server/test_token_rate_limit_budget_models.py
@@ -1,0 +1,49 @@
+import datetime
+
+import pytest
+from pydantic import ValidationError
+
+from onyx.configs.constants import TokenRateLimitScope
+from onyx.db.models import TokenRateLimit
+from onyx.server.query_and_chat.token_limit import _is_rate_limited
+from onyx.server.token_rate_limits.models import TokenRateLimitArgs
+from onyx.server.token_rate_limits.models import TokenRateLimitDisplay
+
+
+def _rate_limit(
+    token_budget: int | None, cost_budget_cents: float | None = None
+) -> TokenRateLimit:
+    return TokenRateLimit(
+        id=1,
+        enabled=True,
+        token_budget=token_budget,
+        cost_budget_cents=cost_budget_cents,
+        period_hours=1,
+        scope=TokenRateLimitScope.GLOBAL,
+    )
+
+
+def test_cost_only_rate_limit_skips_token_enforcement() -> None:
+    usage = [(datetime.datetime.now(datetime.UTC), 1_000_000)]
+
+    assert not _is_rate_limited([_rate_limit(None, cost_budget_cents=1.0)], usage)
+
+
+def test_token_budget_still_enforces_tokens() -> None:
+    usage = [(datetime.datetime.now(datetime.UTC), 1_000)]
+
+    assert _is_rate_limited([_rate_limit(1)], usage)
+
+
+def test_token_rate_limit_args_requires_a_budget() -> None:
+    with pytest.raises(
+        ValidationError, match="Either token_budget or cost_budget_cents"
+    ):
+        TokenRateLimitArgs(enabled=True, period_hours=1)
+
+
+def test_token_rate_limit_display_allows_cost_only_limit() -> None:
+    display = TokenRateLimitDisplay.from_db(_rate_limit(None, cost_budget_cents=2.5))
+
+    assert display.token_budget is None
+    assert display.cost_budget_cents == 2.5


### PR DESCRIPTION
mirror of PR #11766 so I can make edits

- [ ] [Optional] Please cherry-pick this PR to the latest release version. 
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-user LLM usage and cost tracking with cost-aware rate limits. Adds `user_usage` and `model_cost_override`, and supports token-only, cost-only, or combined budgets on `token_rate_limit`.

- **New Features**
  - `user_usage`: per-user rollup by window/model/flow/provider with tokens and `cost_cents` (unique on `(user_id, window_start, model, flow, provider)`; `provider` stored as `""` for reliable uniqueness).
  - `model_cost_override`: per-model rates with provider-specific pricing (unique on `(provider, model)`; `provider` uses `""` when unset), optional `cache_read_cost_per_mtok`.
  - Rate limits: `token_rate_limit` adds `cost_budget_cents`; `token_budget` is nullable; DB check requires at least one budget. Pydantic models enforce this, API display includes both budgets, and token enforcement skips when `token_budget` is null.

- **Migration**
  - Single Alembic migration creates `user_usage` and `model_cost_override`, adds `cost_budget_cents`, makes `token_budget` nullable, and adds the budget check. Money values use `Numeric(18,6)` with `asdecimal=False`. Adds `created_at` to `model_cost_override`.
  - Downgrade deletes cost-only limits before restoring non-null `token_budget` to avoid blocking after rollback.

<sup>Written for commit 4163d9c97697501556e0122c90e73dd4ad13d693. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



