### PR TITLE
fix(indexing): dedupe documents by id within an indexing batch

### DIFF
--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -1214,6 +1214,20 @@ def _maybe_push_documents(
             )
 
 
+def _dedupe_documents_by_id(documents: list[Document]) -> list[Document]:
+    seen_doc_ids: set[str] = set()
+    deduped: list[Document] = []
+    for document in documents:
+        if document.id in seen_doc_ids:
+            logger.warning(
+                "Dropping duplicate document %s within indexing batch", document.id
+            )
+            continue
+        seen_doc_ids.add(document.id)
+        deduped.append(document)
+    return deduped
+
+
 @log_function_time(debug_only=True)
 def index_doc_batch(
     *,
@@ -1260,6 +1274,8 @@ def index_doc_batch(
     attempt_id: int | None = (
         _attempt_metadata.attempt_id if _attempt_metadata is not None else None
     )
+
+    document_batch = _dedupe_documents_by_id(document_batch)
 
     filtered_documents, filter_failures = filter_fnc(document_batch)
     filtered_documents = _apply_document_ingestion_hook(filtered_documents)

--- a/backend/tests/unit/onyx/indexing/test_indexing_pipeline.py
+++ b/backend/tests/unit/onyx/indexing/test_indexing_pipeline.py
@@ -24,6 +24,7 @@ from onyx.hooks.points.document_ingestion import DocumentIngestionSection
 from onyx.indexing.chunker import Chunker
 from onyx.indexing.embedder import DefaultIndexingEmbedder
 from onyx.indexing.indexing_pipeline import _apply_document_ingestion_hook
+from onyx.indexing.indexing_pipeline import _dedupe_documents_by_id
 from onyx.indexing.indexing_pipeline import add_contextual_summaries
 from onyx.indexing.indexing_pipeline import filter_documents
 from onyx.indexing.indexing_pipeline import get_docs_to_update
@@ -51,6 +52,27 @@ def create_test_document(
         source=DocumentSource.FILE,
         metadata={},
     )
+
+
+def test_dedupe_documents_by_id_drops_non_contiguous_duplicate() -> None:
+    docs = [
+        create_test_document(doc_id="a"),
+        create_test_document(doc_id="b"),
+        create_test_document(doc_id="a"),
+    ]
+
+    result = _dedupe_documents_by_id(docs)
+
+    assert [doc.id for doc in result] == ["a", "b"]
+    assert result[0] is docs[0]
+
+
+def test_dedupe_documents_by_id_no_duplicates() -> None:
+    docs = [create_test_document(doc_id="a"), create_test_document(doc_id="b")]
+
+    result = _dedupe_documents_by_id(docs)
+
+    assert [doc.id for doc in result] == ["a", "b"]
 
 
 def test_filter_documents_empty_title_and_content() -> None:


### PR DESCRIPTION
## Summary

Closes #12420.

If a connector emits the same `document.id` more than once within a single indexing batch (e.g. a Confluence attachment linked from multiple pages, yielded once per referencing page), the index attempt fails. `write_chunks_to_vector_db_with_backoff` assumes each document appears once with contiguous chunks; a non-contiguous reappearance (`docA … docB … docA`) breaks the per-doc fallback's `itertools.groupby(make_chunks(), key=doc_id)` and raises `RuntimeError("Doc chunks are not arriving in order...")`, failing the whole batch (the OpenSearch backend also 409s on the colliding chunk ids; the previous Vespa path hid this because its put was idempotent).

This dedupes the batch by `document.id` at the point every connector funnels through (`index_doc_batch`), keeping the first occurrence and logging the drop, so the rest of the pipeline gets the unique-id invariant it already assumes.

## Test plan

`backend/tests/unit/onyx/indexing/test_indexing_pipeline.py`:

- `test_dedupe_documents_by_id_drops_non_contiguous_duplicate` — `docA, docB, docA` keeps the first `docA` and drops the later one.
- `test_dedupe_documents_by_id_no_duplicates` — passthrough when ids are unique.

```
pytest backend/tests/unit/onyx/indexing/test_indexing_pipeline.py
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicate documents by `document.id` within each indexing batch to prevent failures when the same id appears multiple times. Closes #12420; keeps the first occurrence and logs drops to maintain the unique-id invariant and avoid OpenSearch 409s.

- **Bug Fixes**
  - Dedupes in `index_doc_batch` via `_dedupe_documents_by_id`; later duplicates are dropped with a warning.
  - Prevents non-contiguous duplicate failures (previous `groupby` RuntimeError) and OpenSearch 409s; adds unit tests for duplicate-drop and passthrough cases.

<sup>Written for commit 01b7c3ff353ea904145c79d9c2a7ca57e9b5f3c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12555?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

