### PR TITLE
fix: retry empty/non-JSON Graph responses in SharePoint connector

### DIFF
--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -1902,24 +1902,17 @@ class SharepointConnector(
                 )
                 if response.status_code in GRAPH_API_RETRYABLE_STATUSES:
                     if attempt < GRAPH_API_MAX_RETRIES:
-                        parsed_retry_after = parse_retry_after_seconds(
-                            response.headers.get("Retry-After")
+                        wait = _backoff_seconds(
+                            attempt, response.headers.get("Retry-After")
                         )
-                        retry_after = (
-                            parsed_retry_after
-                            if parsed_retry_after is not None
-                            else float(2**attempt)
-                        )
-                        wait = min(retry_after, 60)
                         logger.warning(
-                            "Graph API %s on attempt %s, retrying in %ss: %s",
+                            "Graph API %s on attempt %s, retrying in %.1fs: %s",
                             response.status_code,
                             attempt + 1,
                             wait,
                             url,
                         )
                         time.sleep(wait)
-                        # Re-acquire token in case it expired during a long traversal
                         access_token = self._get_graph_access_token()
                         headers = {"Authorization": f"Bearer {access_token}"}
                         continue
@@ -1927,14 +1920,20 @@ class SharepointConnector(
                 try:
                     return response.json()
                 except (ValueError, requests.exceptions.JSONDecodeError):
-                    # Graph intermittently returns an empty/non-JSON 2xx body under load; treat it as transient and retry.
+                    # Graph intermittently returns an empty/non-JSON 2xx body
+                    # under load; treat it as transient and retry.
                     if attempt < GRAPH_API_MAX_RETRIES:
-                        wait = _backoff_seconds(attempt, response.headers.get("Retry-After"))
+                        wait = _backoff_seconds(
+                            attempt, response.headers.get("Retry-After")
+                        )
                         logger.warning(
                             "Graph API non-JSON/empty body (status %s, len=%s) on "
                             "attempt %s, retrying in %.1fs: %s",
-                            response.status_code, len(response.content),
-                            attempt + 1, wait, url,
+                            response.status_code,
+                            len(response.content),
+                            attempt + 1,
+                            wait,
+                            url,
                         )
                         time.sleep(wait)
                         access_token = self._get_graph_access_token()
@@ -1944,7 +1943,13 @@ class SharepointConnector(
             except TRANSIENT_TRANSPORT_EXCEPTIONS:
                 if attempt < GRAPH_API_MAX_RETRIES:
                     wait = _backoff_seconds(attempt, retry_after=None)
-                    ...
+                    logger.warning(
+                        "Graph API transport error on attempt %s, retrying in %.1fs: %s",
+                        attempt + 1,
+                        wait,
+                        url,
+                    )
+                    time.sleep(wait)
                     continue
                 raise
 

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -1924,17 +1924,27 @@ class SharepointConnector(
                         headers = {"Authorization": f"Bearer {access_token}"}
                         continue
                 _log_and_raise_for_status(response)
-                return response.json()
-            except (requests.ConnectionError, requests.Timeout):
+                try:
+                    return response.json()
+                except (ValueError, requests.exceptions.JSONDecodeError):
+                    # Graph intermittently returns an empty/non-JSON 2xx body under load; treat it as transient and retry.
+                    if attempt < GRAPH_API_MAX_RETRIES:
+                        wait = _backoff_seconds(attempt, response.headers.get("Retry-After"))
+                        logger.warning(
+                            "Graph API non-JSON/empty body (status %s, len=%s) on "
+                            "attempt %s, retrying in %.1fs: %s",
+                            response.status_code, len(response.content),
+                            attempt + 1, wait, url,
+                        )
+                        time.sleep(wait)
+                        access_token = self._get_graph_access_token()
+                        headers = {"Authorization": f"Bearer {access_token}"}
+                        continue
+                    raise
+            except TRANSIENT_TRANSPORT_EXCEPTIONS:
                 if attempt < GRAPH_API_MAX_RETRIES:
-                    wait = min(2**attempt, 60)
-                    logger.warning(
-                        "Graph API connection error on attempt %s, retrying in %ss: %s",
-                        attempt + 1,
-                        wait,
-                        url,
-                    )
-                    time.sleep(wait)
+                    wait = _backoff_seconds(attempt, retry_after=None)
+                    ...
                     continue
                 raise
 

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_graph_api_get_json_retry.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_graph_api_get_json_retry.py
@@ -1,0 +1,97 @@
+"""Unit tests for SharepointConnector._graph_api_get_json retry behavior.
+
+Covers the empty/non-JSON 2xx body case: Microsoft Graph intermittently returns
+a body-less response under load (gateway-shed throttling, backend list-view
+timeouts on large libraries, mid-response connection drops). The bare
+response.json() used to raise an unretried JSONDecodeError that aborted indexing
+of large (>2K file) libraries; it must now be retried like any transient error.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+import requests
+from requests import Response
+
+from onyx.connectors.sharepoint import connector as sp_connector
+from onyx.connectors.sharepoint.connector import GRAPH_API_MAX_RETRIES
+from onyx.connectors.sharepoint.connector import SharepointConnector
+
+SITE_URL = "https://tenant.sharepoint.com/sites/Big"
+PAGE_URL = "https://graph.microsoft.com/v1.0/drives/abc/root/children"
+
+
+def _response(status: int = 200, body: Any = None, raw: bytes | None = None) -> Response:
+    """Build a fake requests.Response. body=None + raw=None => empty body."""
+    resp = Response()
+    resp.status_code = status
+    if raw is not None:
+        resp._content = raw
+    elif body is not None:
+        resp._content = json.dumps(body).encode()
+    else:
+        resp._content = b""  # empty 2xx body -> JSONDecodeError on .json()
+    resp.headers["Content-Type"] = "application/json"
+    return resp
+
+
+def _connector(monkeypatch: pytest.MonkeyPatch) -> SharepointConnector:
+    connector = SharepointConnector(sites=[SITE_URL])
+    connector.graph_api_base = "https://graph.microsoft.com/v1.0"
+    # Avoid real MSAL token acquisition.
+    monkeypatch.setattr(connector, "_get_graph_access_token", lambda: "fake-token")
+    # Never actually sleep between retries.
+    monkeypatch.setattr(sp_connector.time, "sleep", lambda *_a, **_k: None)
+    return connector
+
+
+def test_retries_empty_body_then_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty 2xx body is retried; the next good page is returned."""
+    connector = _connector(monkeypatch)
+    payload = {"value": [{"id": "1", "name": "f.docx"}]}
+    responses = iter([_response(200, body=None), _response(200, body=payload)])
+    monkeypatch.setattr(sp_connector.requests, "get", lambda *_a, **_k: next(responses))
+
+    result = connector._graph_api_get_json(PAGE_URL, {"$top": "200"})
+
+    assert result == payload
+
+
+def test_raises_after_exhausting_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A persistently empty body re-raises JSONDecodeError after all retries."""
+    connector = _connector(monkeypatch)
+    calls = {"n": 0}
+
+    def _always_empty(*_a: Any, **_k: Any) -> Response:
+        calls["n"] += 1
+        return _response(200, body=None)
+
+    monkeypatch.setattr(sp_connector.requests, "get", _always_empty)
+
+    with pytest.raises(requests.exceptions.JSONDecodeError):
+        connector._graph_api_get_json(PAGE_URL)
+
+    assert calls["n"] == GRAPH_API_MAX_RETRIES + 1
+
+
+def test_retries_chunked_encoding_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A mid-stream drop (ChunkedEncodingError) is retried, not fatal."""
+    connector = _connector(monkeypatch)
+    payload = {"value": []}
+    state = {"n": 0}
+
+    def _flaky(*_a: Any, **_k: Any) -> Response:
+        state["n"] += 1
+        if state["n"] == 1:
+            raise requests.exceptions.ChunkedEncodingError("connection dropped")
+        return _response(200, body=payload)
+
+    monkeypatch.setattr(sp_connector.requests, "get", _flaky)
+
+    result = connector._graph_api_get_json(PAGE_URL)
+
+    assert result == payload
+    assert state["n"] == 2


### PR DESCRIPTION
Description
-----------

Fixes an unhandled `JSONDecodeError` in the SharePoint connector that aborts indexing of large libraries (>2K files).

`_graph_api_get_json` called `response.json()` without guarding against an empty or non-JSON response body. Under sustained load --- throttling shed at the gateway as a body-less 2xx, backend [list-view-threshold](https://learn.microsoft.com/troubleshoot/sharepoint/lists-and-libraries/items-exceeds-list-view-threshold) timeouts on large libraries, or connections dropped mid-response --- Microsoft Graph intermittently returns a 2xx with an empty body. `_log_and_raise_for_status` passes (status is OK), then `response.json()` raises `JSONDecodeError`, which escaped the retry loop uncaught and failed the entire run.

It scales with file count: each `$top=200` page is one Graph call with some small probability of a bad response, so a 2K+ file library means hundreds of calls and a near-certain hit --- and a single one killed the whole job, since there was no per-call recovery for a non-JSON body.

Changes:

-   Guard `response.json()` --- treat an empty/non-JSON body as transient and retry (re-acquiring the token) instead of crashing; re-raise only after retries are exhausted.
-   Widen the transport `except` to include `ChunkedEncodingError` / `ContentDecodingError` (siblings of `ConnectionError`, not subclasses), so mid-stream connection drops are retried here too.

Affected file: `backend/onyx/connectors/sharepoint/connector.py` --- `_graph_api_get_json`.

How Has This Been Tested?
-------------------------

Added `backend/tests/unit/onyx/connectors/sharepoint/test_graph_api_get_json_retry.py` with three unit tests (mocking `requests.get` and `time.sleep`):

-   `test_retries_empty_body_then_succeeds` --- an empty 2xx body is retried and the next good page is returned.
-   `test_raises_after_exhausting_retries` --- a persistently empty body re-raises `JSONDecodeError` after `GRAPH_API_MAX_RETRIES + 1` attempts.
-   `test_retries_chunked_encoding_error` --- a mid-stream `ChunkedEncodingError` is retried, not fatal (regression guard for the widened `except`).

Run:

```
cd backend && python -m pytest tests/unit/onyx/connectors/sharepoint/test_graph_api_get_json_retry.py -v

```

This PR Fixes #12554 

Additional Options
------------------

-   [ ]  [Optional] Please cherry-pick this PR to the latest release version.
-   [ ]  [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries empty/non-JSON 2xx Microsoft Graph responses in the SharePoint connector to avoid JSONDecodeError on large libraries. Also unifies exponential backoff (respecting Retry-After) and restores sleep for transport retries to keep pagination stable under load.

- **Bug Fixes**
  - Guard `_graph_api_get_json` to treat empty/invalid JSON bodies as transient; retry with token refresh, fail only after retries are exhausted.
  - Unify retry backoff via `_backoff_seconds` for 429/503 and transport errors; honor `Retry-After`; restore `time.sleep` in the transport retry path.
  - Expand retryable transport errors to include `ChunkedEncodingError` and `ContentDecodingError`; add unit tests for retry-then-succeed, retry exhaustion, and mid-stream drop.

<sup>Written for commit 78bf39e669bc4dd8209a4e5da73ee701e9395c33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

