### PR TITLE
fix(confluence): pass scoped_token to group sync client

### DIFF
--- a/backend/ee/onyx/external_permissions/confluence/group_sync.py
+++ b/backend/ee/onyx/external_permissions/confluence/group_sync.py
@@ -163,6 +163,9 @@ def confluence_group_sync(
 ) -> Generator[ExternalUserGroup, None, None]:
     provider = OnyxDBCredentialsProvider(tenant_id, "confluence", cc_pair.credential_id)
     is_cloud = cc_pair.connector.connector_specific_config.get("is_cloud", False)
+    scoped_token = cc_pair.connector.connector_specific_config.get(
+        "scoped_token", False
+    )
     wiki_base: str = cc_pair.connector.connector_specific_config["wiki_base"]
     url = wiki_base.rstrip("/")
 
@@ -176,7 +179,9 @@ def confluence_group_sync(
         "max_backoff_seconds": 60,
     }
 
-    confluence_client = OnyxConfluence(is_cloud, url, provider)
+    confluence_client = OnyxConfluence(
+        is_cloud, url, provider, scoped_token=scoped_token
+    )
     confluence_client._probe_connection(**probe_kwargs)
     confluence_client._initialize_connection(**final_kwargs)
 


### PR DESCRIPTION
## Description

`confluence_group_sync` built the `OnyxConfluence` client without the `scoped_token` flag, so it defaulted to `False`. For Confluence **Cloud** instances authenticating with a **scoped API token**, this left the base URL as the wiki host (e.g. `https://<org>.atlassian.net/wiki`) instead of being rewritten to `https://api.atlassian.com/ex/confluence/<cloud_id>/...` via `scoped_url()`.

A scoped token only authenticates against `api.atlassian.com`, so the spaces probe hit the wrong host, received a non-JSON (HTML) response, and failed with:

```
requests.exceptions.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

This explains why indexing and **document** permission sync worked (those go through the connector, which already passes the flag) while only **group membership sync** failed.

The fix reads `scoped_token` from `connector_specific_config` and threads it through, mirroring the existing Jira group sync (`ee/onyx/external_permissions/jira/group_sync.py`).

Reported by a customer running 4.0.5; the bug is still present on `main`.

## How Has This Been Tested?

- Verified the call path: `OnyxConfluence.__init__` defaults `scoped_token=False`, which skips `scoped_url()` and selects the v2 spaces API against the wiki host — matching the customer's traceback through `retrieve_confluence_spaces` -> `_paginate_spaces_for_endpoint` -> `response.json()`.
- Confirmed the connector itself (`connector.py`) and Jira group sync already pass `scoped_token`; only Confluence group sync omitted it.
- `ty` and `ruff` pre-commit hooks pass.

No automated test added — this path requires a live Confluence Cloud instance with a scoped token, which CI can't exercise. Happy to add an external-dependency unit test asserting the client is constructed with the scoped URL if reviewers prefer.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pass scoped_token from the connector config to the Confluence group sync `OnyxConfluence` client so Cloud instances with scoped API tokens use the `api.atlassian.com` base URL. Fixes group membership sync failures (HTML response -> JSONDecodeError) and matches the Jira group sync behavior.

<sup>Written for commit d9d72efa71a26553e66910be63dcc85baad2ce36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

