### PR TITLE
fix(google-drive): retry connection drops during retrieval

### DIFF
--- a/backend/onyx/connectors/google_utils/google_utils.py
+++ b/backend/onyx/connectors/google_utils/google_utils.py
@@ -174,10 +174,11 @@ def _execute_single_retrieval(
         else:
             logger.exception("Error executing request:")
             raise e
-    except (TimeoutError, socket.timeout, ConnectionError, ssl.SSLError) as error:
-        # Connection-level drops (broken pipe, reset, SSL teardown) hit mid-crawl
-        # on long parallel Drive paginations; retry the page rather than failing
-        # the whole attempt.
+    except (TimeoutError, socket.timeout, ConnectionError, ssl.SSLEOFError) as error:
+        # Connection-level drops (broken pipe, reset, TLS EOF) hit mid-crawl on
+        # long parallel Drive paginations. Retry the page instead of failing the
+        # whole attempt. Narrow SSL to SSLEOFError so permanent SSL errors
+        # (cert/version) still fail fast.
         logger.warning(
             "Transient network error executing Google API request; retrying with backoff. Details: %s",
             error,

--- a/backend/onyx/connectors/google_utils/google_utils.py
+++ b/backend/onyx/connectors/google_utils/google_utils.py
@@ -1,5 +1,6 @@
 import re
 import socket
+import ssl
 import time
 from collections.abc import Callable
 from collections.abc import Iterator
@@ -173,9 +174,12 @@ def _execute_single_retrieval(
         else:
             logger.exception("Error executing request:")
             raise e
-    except (TimeoutError, socket.timeout) as error:
+    except (TimeoutError, socket.timeout, ConnectionError, ssl.SSLError) as error:
+        # Connection-level drops (broken pipe, reset, SSL teardown) hit mid-crawl
+        # on long parallel Drive paginations; retry the page rather than failing
+        # the whole attempt.
         logger.warning(
-            "Timed out executing Google API request; retrying with backoff. Details: %s",
+            "Transient network error executing Google API request; retrying with backoff. Details: %s",
             error,
         )
         results = add_retries(lambda: retrieval_function(**request_kwargs).execute())()

--- a/backend/tests/unit/onyx/connectors/google_utils/test_google_retrieval_retry.py
+++ b/backend/tests/unit/onyx/connectors/google_utils/test_google_retrieval_retry.py
@@ -1,0 +1,48 @@
+"""Drive/Gmail paginated retrieval must retry transient connection drops
+(broken pipe, reset, SSL teardown, timeout) instead of letting one dropped
+socket fail the whole crawl."""
+
+import socket
+import ssl
+from collections.abc import Callable
+
+import pytest
+
+from onyx.connectors.google_utils.google_utils import _execute_single_retrieval
+
+
+class _Request:
+    def __init__(self, execute_fn: Callable[[], dict]) -> None:
+        self._execute_fn = execute_fn
+
+    def execute(self) -> dict:
+        return self._execute_fn()
+
+
+@pytest.mark.parametrize(
+    "transient_error",
+    [
+        BrokenPipeError(32, "Broken pipe"),
+        ConnectionResetError("connection reset by peer"),
+        ssl.SSLError("decryption failed or bad record mac"),
+        socket.timeout("timed out"),
+    ],
+)
+def test_retrieval_retries_transient_connection_errors(
+    transient_error: Exception,
+) -> None:
+    attempts = {"count": 0}
+
+    def execute() -> dict:
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise transient_error
+        return {"files": [{"id": "ok"}]}
+
+    def retrieval_function(**_kwargs: object) -> _Request:
+        return _Request(execute)
+
+    result = _execute_single_retrieval(retrieval_function)
+
+    assert result == {"files": [{"id": "ok"}]}
+    assert attempts["count"] == 2  # failed once, retried, succeeded

--- a/backend/tests/unit/onyx/connectors/google_utils/test_google_retrieval_retry.py
+++ b/backend/tests/unit/onyx/connectors/google_utils/test_google_retrieval_retry.py
@@ -1,6 +1,6 @@
 """Drive/Gmail paginated retrieval must retry transient connection drops
-(broken pipe, reset, SSL teardown, timeout) instead of letting one dropped
-socket fail the whole crawl."""
+(broken pipe, reset, TLS EOF, timeout) instead of letting one dropped socket
+fail the whole crawl, and must re-raise when the drop persists."""
 
 import socket
 import ssl
@@ -8,7 +8,7 @@ from collections.abc import Callable
 
 import pytest
 
-from onyx.connectors.google_utils.google_utils import _execute_single_retrieval
+from onyx.connectors.google_utils import google_utils
 
 
 class _Request:
@@ -19,15 +19,15 @@ class _Request:
         return self._execute_fn()
 
 
-@pytest.mark.parametrize(
-    "transient_error",
-    [
-        BrokenPipeError(32, "Broken pipe"),
-        ConnectionResetError("connection reset by peer"),
-        ssl.SSLError("decryption failed or bad record mac"),
-        socket.timeout("timed out"),
-    ],
-)
+_TRANSIENT_ERRORS = [
+    BrokenPipeError(32, "Broken pipe"),
+    ConnectionResetError("connection reset by peer"),
+    ssl.SSLEOFError("EOF occurred in violation of protocol"),
+    socket.timeout("timed out"),
+]
+
+
+@pytest.mark.parametrize("transient_error", _TRANSIENT_ERRORS)
 def test_retrieval_retries_transient_connection_errors(
     transient_error: Exception,
 ) -> None:
@@ -42,7 +42,41 @@ def test_retrieval_retries_transient_connection_errors(
     def retrieval_function(**_kwargs: object) -> _Request:
         return _Request(execute)
 
-    result = _execute_single_retrieval(retrieval_function)
+    result = google_utils._execute_single_retrieval(retrieval_function)
 
     assert result == {"files": [{"id": "ok"}]}
     assert attempts["count"] == 2  # failed once, retried, succeeded
+
+
+@pytest.mark.parametrize("transient_error", _TRANSIENT_ERRORS)
+def test_retrieval_reraises_when_retries_exhausted(
+    transient_error: Exception,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the drop persists across retries the error propagates, not swallowed."""
+
+    # Stand in for add_retries with an instant (no-backoff) retry that re-raises,
+    # matching tenacity's reraise=True without the real delay.
+    def instant_retries(fn: Callable[[], dict]) -> Callable[[], dict]:
+        def wrapper() -> dict:
+            error: Exception | None = None
+            for _ in range(3):
+                try:
+                    return fn()
+                except Exception as exc:
+                    error = exc
+            assert error is not None
+            raise error
+
+        return wrapper
+
+    monkeypatch.setattr(google_utils, "add_retries", instant_retries)
+
+    def execute() -> dict:
+        raise transient_error
+
+    def retrieval_function(**_kwargs: object) -> _Request:
+        return _Request(execute)
+
+    with pytest.raises(type(transient_error)):
+        google_utils._execute_single_retrieval(retrieval_function)


### PR DESCRIPTION
## Description

Google Drive crawls fail the whole index attempt on a transient connection drop. `_execute_single_retrieval` retries `HttpError` 5xx and timeouts but not connection-level errors, so a single `BrokenPipeError` (connection reset / SSL teardown) mid-pagination propagates up through the parallel per-user retrieval and kills the attempt.

**Fix:** add `ConnectionError` (covers `BrokenPipeError` / reset / abort) and `ssl.SSLError` to the transient-retry branch in `google_utils._execute_single_retrieval`, reusing the existing `add_retries` backoff so a dropped socket retries the page instead of failing the crawl.

Test: parametrized unit test asserting broken pipe / reset / SSL / timeout are retried, not raised.

## How Has This Been Tested?

## Additional Options
- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
