### PR TITLE
fix(telemetry): emit broker-global queue metrics once per window

### DIFF
--- a/backend/onyx/background/celery/tasks/monitoring/tasks.py
+++ b/backend/onyx/background/celery/tasks/monitoring/tasks.py
@@ -42,6 +42,7 @@ from onyx.db.models import SyncRecord
 from onyx.db.models import UserGroup
 from onyx.db.search_settings import get_active_search_settings_list
 from onyx.redis.redis_pool import get_redis_client
+from onyx.redis.redis_pool import get_shared_redis_client
 from onyx.redis.redis_pool import redis_lock_dump
 from onyx.redis.tenant_redis_client import TenantRedisClient
 from onyx.utils.platform_utils import is_running_in_container
@@ -53,6 +54,12 @@ from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 
 _MONITORING_SOFT_TIME_LIMIT = 60 * 5  # 5 minutes
 _MONITORING_TIME_LIMIT = _MONITORING_SOFT_TIME_LIMIT + 60  # 6 minutes
+
+# Queue lengths are broker-global, so they are emitted by at most one tenant per
+# window rather than once per tenant every cycle. Keep the lease shorter than the
+# 5-minute monitor beat so it expires before the next cycle and never blocks it.
+_GLOBAL_QUEUE_METRICS_LEASE = "monitoring_global_queue_metrics_lease"
+_GLOBAL_QUEUE_METRICS_LEASE_TTL = 60 * 4  # 4 minutes
 
 _CONNECTOR_INDEX_ATTEMPT_START_LATENCY_KEY_FMT = (
     "monitoring_connector_index_attempt_start_latency:{cc_pair_id}:{index_attempt_id}"
@@ -710,7 +717,17 @@ def monitor_background_processes(self: Task, *, tenant_id: str) -> None:
 
         # Collect queue metrics with broker connection
         r_celery = celery_get_broker_client(self.app)
-        queue_metrics = _collect_queue_metrics(r_celery)
+
+        # Queue lengths are broker-global. Emit them from only one tenant per
+        # short window by taking a cross-tenant lease, so the same values are not
+        # re-sent once per tenant. The lease is intentionally left to expire on
+        # its own so the next window re-acquires it.
+        queue_metrics: list[Metric] = []
+        queue_lease = get_shared_redis_client().lock(
+            _GLOBAL_QUEUE_METRICS_LEASE, timeout=_GLOBAL_QUEUE_METRICS_LEASE_TTL
+        )
+        if queue_lease.acquire(blocking=False):
+            queue_metrics = _collect_queue_metrics(r_celery)
 
         # Collect remaining metrics (no broker connection needed)
         with get_session_with_current_tenant() as db_session:

--- a/backend/onyx/utils/telemetry.py
+++ b/backend/onyx/utils/telemetry.py
@@ -32,6 +32,10 @@ _DANSWER_TELEMETRY_ENDPOINT = "https://telemetry.onyx.app/anonymous_telemetry"
 _CACHED_UUID: str | None = None
 _CACHED_INSTANCE_DOMAIN: str | None = None
 
+# Cap each telemetry POST so a slow or unreachable endpoint cannot pin a sender
+# thread indefinitely and let threads accumulate.
+_TELEMETRY_POST_TIMEOUT_SECONDS = 5
+
 
 class RecordType(str, Enum):
     VERSION = "version"
@@ -132,6 +136,7 @@ def optional_telemetry(
                     _DANSWER_TELEMETRY_ENDPOINT,
                     headers={"Content-Type": "application/json"},
                     json=payload,
+                    timeout=_TELEMETRY_POST_TIMEOUT_SECONDS,
                 )
 
             except Exception:


### PR DESCRIPTION
## Description

**Bug:** the cloud monitoring workers OOM-crash-loop. Root cause, confirmed against a week of telemetry data: `monitor_background_processes` runs once per tenant, and `_collect_queue_metrics` measures ~20 broker-global Celery queue depths and emits them with `key=None` (every run). The queues are shared across all tenants, so every tenant re-emits the same global values. With hundreds of tenants that is about 1.8 million telemetry events per day in ~300/sec bursts. Each `optional_telemetry` call spawns a thread doing a timeout-less POST, so the threads pile up (measured 2,038 on the worker) and OOM the 4 GiB pod.

**Fix:**
1. Emit the global queue metrics from at most one tenant per 5-minute window. The queue block is gated behind a cross-tenant lease in the shared redis namespace, so the first tenant of a window emits and the rest skip. This removes the per-tenant redundancy (the bulk of the volume) at the source and matches the original 5-minute monitor cadence. The metrics keep their real per-tenant context, so the EE instance_domain lookup is unaffected.
2. Add a timeout to the telemetry POST, so a slow or unreachable endpoint cannot pin a sender thread and let threads accumulate.

Connector and sync metrics are genuinely per-tenant and keyed/deduped, so they are unchanged.

Note: while tracing this I found a separate pre-existing bug where four sync metrics share one dedup key, so only `sync_run_succeeded` ever emits (duration, doc count, speed are dropped). Out of scope here, flagging for a follow-up.

## How Has This Been Tested?

## Additional Options

- [ ] This PR should be considered for cherry-pick if the release branch has been cut
- [x] Override Linear Check