### PR TITLE
feat: per-user usage + cost tracking — enforcement (3/4)

### DIFF
--- a/backend/ee/onyx/server/query_and_chat/token_limit.py
+++ b/backend/ee/onyx/server/query_and_chat/token_limit.py
@@ -5,7 +5,6 @@ from itertools import groupby
 from typing import Dict, List, Tuple
 from uuid import UUID
 
-from fastapi import HTTPException
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
@@ -21,10 +20,18 @@ from onyx.db.models import (
     UserGroup,
 )
 from onyx.db.token_limit import fetch_all_user_token_rate_limits
+from onyx.db.user_usage import (
+    get_group_cost_cents_buckets_since,
+    get_user_cost_cents_buckets_since,
+)
 from onyx.server.query_and_chat.token_limit import (
     _get_cutoff_time,
-    _is_rate_limited,
+    _has_token_budget,
+    _LEDGER_GRID,
+    _raise_for_longest_window,
     _user_is_rate_limited_by_global,
+    _worst_triggered_cost_limit,
+    _worst_triggered_limit,
 )
 from onyx.utils.threadpool_concurrency import run_functions_tuples_in_parallel
 
@@ -58,16 +65,35 @@ def _user_is_rate_limited(user_id: UUID) -> None:
         user_rate_limits = fetch_all_user_token_rate_limits(
             db_session=db_session, enabled_only=True, ordered=False
         )
+        if not user_rate_limits:
+            return
 
-        if user_rate_limits:
-            user_cutoff_time = _get_cutoff_time(user_rate_limits)
+        # Token side — skip the usage scan entirely when every limit is cost-only.
+        token_triggered = None
+        if _has_token_budget(user_rate_limits):
+            token_limits = [
+                rl
+                for rl in user_rate_limits
+                if rl.token_budget is not None and rl.token_budget > 0
+            ]
+            user_cutoff_time = _get_cutoff_time(token_limits)
             user_usage = _fetch_user_usage(user_id, user_cutoff_time, db_session)
+            token_triggered = _worst_triggered_limit(user_rate_limits, user_usage)
 
-            if _is_rate_limited(user_rate_limits, user_usage):
-                raise HTTPException(
-                    status_code=429,
-                    detail="Token budget exceeded for user. Try again later.",
-                )
+        # Cost side — same UserUsage-ledger bucket approach as the global gate.
+        cost_buckets: list[tuple[datetime, float]] = []
+        if any(rl.cost_budget_cents is not None for rl in user_rate_limits):
+            cost_cutoff = _get_cutoff_time(user_rate_limits) - _LEDGER_GRID
+            cost_buckets = get_user_cost_cents_buckets_since(
+                db_session, str(user_id), cost_cutoff
+            )
+        cost_triggered = _worst_triggered_cost_limit(user_rate_limits, cost_buckets)
+
+        _raise_for_longest_window(
+            "your account",
+            token_triggered.period_hours if token_triggered else None,
+            cost_triggered.period_hours if cost_triggered else None,
+        )
 
 
 def _fetch_user_usage(
@@ -97,33 +123,54 @@ User Group rate limits
 def _user_is_rate_limited_by_group(user_id: UUID) -> None:
     with get_session_with_current_tenant() as db_session:
         group_rate_limits = _fetch_all_user_group_rate_limits(user_id, db_session)
+        if not group_rate_limits:
+            return
 
-        if group_rate_limits:
-            # Group cutoff time is the same for all groups.
-            # This could be optimized to only fetch the maximum cutoff time for
-            # a specific group, but seems unnecessary for now.
-            group_cutoff_time = _get_cutoff_time(
-                [e for sublist in group_rate_limits.values() for e in sublist]
-            )
+        all_limits = [e for sublist in group_rate_limits.values() for e in sublist]
+        user_group_ids = list(group_rate_limits.keys())
 
-            user_group_ids = list(group_rate_limits.keys())
+        # Token usage per group — skip the scan when every group limit is cost-only.
+        group_usage: dict[int, list[tuple[datetime, int]]] = {}
+        if _has_token_budget(all_limits):
+            token_limits = [
+                rl for rl in all_limits if rl.token_budget is not None and rl.token_budget > 0
+            ]
+            group_cutoff_time = _get_cutoff_time(token_limits)
             group_usage = _fetch_user_group_usage(
                 user_group_ids, group_cutoff_time, db_session
             )
 
-            has_at_least_one_untriggered_limit = False
-            for user_group_id, rate_limits in group_rate_limits.items():
-                usage = group_usage.get(user_group_id, [])
+        # Cost buckets per group — one query for the widest window.
+        group_cost_buckets: dict[int, list[tuple[datetime, float]]] = {}
+        if any(rl.cost_budget_cents is not None for rl in all_limits):
+            cost_cutoff = _get_cutoff_time(all_limits) - _LEDGER_GRID
+            group_cost_buckets = get_group_cost_cents_buckets_since(
+                db_session, user_group_ids, cost_cutoff
+            )
 
-                if not _is_rate_limited(rate_limits, usage):
-                    has_at_least_one_untriggered_limit = True
-                    break
-
-            if not has_at_least_one_untriggered_limit:
-                raise HTTPException(
-                    status_code=429,
-                    detail="Token budget exceeded for user's groups. Try again later.",
+        # A user passes if ANY of their groups is fully under budget (token AND
+        # cost). Only when EVERY group has an exceeded limit do we block, then
+        # report the longest offending window across all groups.
+        worst_token_period: int | None = None
+        worst_cost_period: int | None = None
+        for user_group_id, rate_limits in group_rate_limits.items():
+            usage = group_usage.get(user_group_id, [])
+            token_trig = _worst_triggered_limit(rate_limits, usage)
+            cost_trig = _worst_triggered_cost_limit(
+                rate_limits, group_cost_buckets.get(user_group_id, [])
+            )
+            if token_trig is None and cost_trig is None:
+                return  # this group is under budget -> user is allowed
+            if token_trig is not None:
+                worst_token_period = max(
+                    worst_token_period or 0, token_trig.period_hours
                 )
+            if cost_trig is not None:
+                worst_cost_period = max(worst_cost_period or 0, cost_trig.period_hours)
+
+        _raise_for_longest_window(
+            "your group", worst_token_period, worst_cost_period
+        )
 
 
 def _fetch_all_user_group_rate_limits(

--- a/backend/onyx/error_handling/exceptions.py
+++ b/backend/onyx/error_handling/exceptions.py
@@ -46,6 +46,7 @@ class OnyxError(Exception):
         detail: str | None = None,
         *,
         status_code_override: int | None = None,
+        extra: dict[str, object] | None = None,
         headers: dict[str, str] | None = None,
     ) -> None:
         resolved_detail = detail or error_code.code
@@ -53,6 +54,9 @@ class OnyxError(Exception):
         self.error_code = error_code
         self.detail = resolved_detail
         self._status_code_override = status_code_override
+        # extra: machine-readable fields merged into the JSON body (e.g. reset_at).
+        # headers: response headers the FE/clients need (e.g. Retry-After).
+        self.extra = extra
         self.headers = headers
 
     @property
@@ -70,9 +74,13 @@ def log_onyx_error(exc: OnyxError) -> None:
 
 
 def onyx_error_to_json_response(exc: OnyxError) -> JSONResponse:
+    content = exc.error_code.detail(exc.detail)
+    if exc.extra:
+        # extra first so the canonical error_code/detail can't be overwritten.
+        content = {**exc.extra, **content}
     return JSONResponse(
         status_code=exc.status_code,
-        content=exc.error_code.detail(exc.detail),
+        content=content,
         headers=exc.headers,
     )
 

--- a/backend/onyx/server/features/build/session/messages.py
+++ b/backend/onyx/server/features/build/session/messages.py
@@ -46,6 +46,7 @@ from onyx.server.features.build.session.models import (
     MessageRequest,
     MessageResponse,
 )
+from onyx.server.query_and_chat.token_limit import check_token_rate_limits
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -140,6 +141,9 @@ def send_message(
             SessionManager(db_session).reload_session_skills(session_id, user)
 
         check_build_rate_limits(user=user, db_session=db_session)
+        # Craft turns also respect the org/user token + cost budgets. No-op when
+        # none are configured; raises the structured 429 when over budget.
+        check_token_rate_limits(user)
 
         turn_index = count_user_messages(session_id, db_session)
         if request.provider and request.model:
@@ -203,6 +207,8 @@ def send_subagent_message(
     request: MessageRequest,
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     _rate_limit_check: None = Depends(check_build_rate_limits),
+    # Craft turns also respect the org/user token + cost budgets (no-op when none).
+    _token_rate_limit_check: None = Depends(check_token_rate_limits),
 ) -> StreamingResponse:
     """
     Send a follow-up message to a subagent's child opencode session and

--- a/backend/onyx/server/query_and_chat/token_limit.py
+++ b/backend/onyx/server/query_and_chat/token_limit.py
@@ -67,7 +67,14 @@ def _user_is_rate_limited_by_global() -> None:
             # Skip the token-usage aggregation when every limit is cost-only.
             triggered = None
             if _has_token_budget(global_rate_limits):
-                global_cutoff_time = _get_cutoff_time(global_rate_limits)
+                # Scan the token table only as far back as the widest *token*
+                # window — a longer cost-only window must not widen the scan.
+                token_limits = [
+                    rl
+                    for rl in global_rate_limits
+                    if rl.token_budget is not None and rl.token_budget > 0
+                ]
+                global_cutoff_time = _get_cutoff_time(token_limits)
                 global_usage = _fetch_global_usage(global_cutoff_time, db_session)
                 triggered = _worst_triggered_limit(global_rate_limits, global_usage)
 
@@ -157,6 +164,17 @@ def _worst_triggered_limit(
                 worst = rate_limit
 
     return worst
+
+
+def _is_rate_limited(
+    rate_limits: Sequence[TokenRateLimit],
+    usage: Sequence[tuple[datetime, int]],
+) -> bool:
+    """Whether any token budget in ``rate_limits`` is exceeded by ``usage``.
+
+    Thin bool wrapper over ``_worst_triggered_limit`` for the EE user/group
+    token gates, which enforce token budgets only (cost gating is global-only)."""
+    return _worst_triggered_limit(rate_limits, usage) is not None
 
 
 def _worst_triggered_cost_limit(

--- a/backend/onyx/server/query_and_chat/token_limit.py
+++ b/backend/onyx/server/query_and_chat/token_limit.py
@@ -17,11 +17,8 @@ from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.utils.logger import setup_logger
 from onyx.utils.variable_functionality import fetch_versioned_implementation
-<<<<<<< HEAD
 from shared_configs.contextvars import get_current_tenant_id
-=======
 from shared_configs.configs import USAGE_LIMIT_WINDOW_SECONDS
->>>>>>> bb95655549 (feat(usage): cost budgets on token rate limits (CE enforcement))
 
 logger = setup_logger()
 

--- a/backend/onyx/server/query_and_chat/token_limit.py
+++ b/backend/onyx/server/query_and_chat/token_limit.py
@@ -172,8 +172,9 @@ def _is_rate_limited(
 ) -> bool:
     """Whether any token budget in ``rate_limits`` is exceeded by ``usage``.
 
-    Thin bool wrapper over ``_worst_triggered_limit`` for the EE user/group
-    token gates, which enforce token budgets only (cost gating is global-only)."""
+    Thin bool wrapper over ``_worst_triggered_limit``. Token-only — the cost side
+    of every scope (global/user/group) is enforced separately via
+    ``_worst_triggered_cost_limit`` over the UserUsage cost ledger."""
     return _worst_triggered_limit(rate_limits, usage) is not None
 
 

--- a/backend/onyx/server/query_and_chat/token_limit.py
+++ b/backend/onyx/server/query_and_chat/token_limit.py
@@ -1,10 +1,11 @@
+from collections.abc import Callable
 from collections.abc import Sequence
 from datetime import datetime, timedelta, timezone
 from threading import RLock
 
 from cachetools import TTLCache
 from dateutil import tz
-from fastapi import Depends, HTTPException
+from fastapi import Depends
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
@@ -12,14 +13,26 @@ from onyx.auth.users import current_chat_accessible_user
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.models import ChatMessage, ChatSession, TokenRateLimit, User
 from onyx.db.token_limit import fetch_all_global_token_rate_limits
+from onyx.db.user_usage import get_total_cost_cents_since
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.utils.logger import setup_logger
 from onyx.utils.variable_functionality import fetch_versioned_implementation
+<<<<<<< HEAD
 from shared_configs.contextvars import get_current_tenant_id
+=======
+from shared_configs.configs import USAGE_LIMIT_WINDOW_SECONDS
+>>>>>>> bb95655549 (feat(usage): cost budgets on token rate limits (CE enforcement))
 
 logger = setup_logger()
 
+# Admin token budgets are entered in thousands of tokens; the stored value is
+# multiplied by this to get the real token count enforced.
+TOKEN_BUDGET_UNIT = 1000
 
-TOKEN_BUDGET_UNIT = 1_000
+# The cost ledger buckets at this fixed grid; the cost cutoff is relaxed by one
+# grid to capture partially-overlapping buckets (see _worst_triggered_cost_limit).
+_LEDGER_GRID = timedelta(seconds=USAGE_LIMIT_WINDOW_SECONDS)
 
 
 def check_token_rate_limits(
@@ -52,14 +65,22 @@ def _user_is_rate_limited_by_global() -> None:
         )
 
         if global_rate_limits:
-            global_cutoff_time = _get_cutoff_time(global_rate_limits)
-            global_usage = _fetch_global_usage(global_cutoff_time, db_session)
+            # Skip the token-usage aggregation when every limit is cost-only.
+            triggered = None
+            if _has_token_budget(global_rate_limits):
+                global_cutoff_time = _get_cutoff_time(global_rate_limits)
+                global_usage = _fetch_global_usage(global_cutoff_time, db_session)
+                triggered = _worst_triggered_limit(global_rate_limits, global_usage)
 
-            if _is_rate_limited(global_rate_limits, global_usage):
-                raise HTTPException(
-                    status_code=429,
-                    detail="Token budget exceeded for organization. Try again later.",
-                )
+            cost_triggered = _worst_triggered_cost_limit(
+                global_rate_limits,
+                lambda cutoff: get_total_cost_cents_since(db_session, cutoff),
+            )
+            _raise_for_longest_window(
+                "organization",
+                triggered.period_hours if triggered else None,
+                cost_triggered.period_hours if cost_triggered else None,
+            )
 
 
 def _fetch_global_usage(
@@ -93,14 +114,27 @@ def _get_cutoff_time(rate_limits: Sequence[TokenRateLimit]) -> datetime:
     return datetime.now(tz=timezone.utc) - timedelta(hours=max_period_hours)
 
 
-def _is_rate_limited(
+def _has_token_budget(rate_limits: Sequence[TokenRateLimit]) -> bool:
+    """Whether any limit sets a positive token budget. If not (cost-only limits),
+    the caller skips the token-usage aggregation query entirely."""
+    return any(
+        rl.token_budget is not None and rl.token_budget > 0 for rl in rate_limits
+    )
+
+
+def _worst_triggered_limit(
     rate_limits: Sequence[TokenRateLimit], usage: Sequence[tuple[datetime, int]]
-) -> bool:
-    """
-    If at least one rate limit is exceeded, return True
-    """
+) -> TokenRateLimit | None:
+    """Among the exceeded token limits, return the one with the longest window
+    (or None). Picking the longest period_hours makes the reported reset
+    deterministic and conservative: a client that waits it out won't immediately
+    re-trip a still-exceeded longer limit. Carries period_hours for the reset."""
+    worst: TokenRateLimit | None = None
     for rate_limit in rate_limits:
-        if rate_limit.token_budget is None:
+        # A null (cost-only) or non-positive token_budget is token-exempt — skip
+        # the token check. Guarding <= 0 means a 0 (new cost-only rows store null,
+        # but legacy/edge rows may hold 0) can never block every request.
+        if rate_limit.token_budget is None or rate_limit.token_budget <= 0:
             continue
 
         tokens_used = sum(
@@ -110,10 +144,77 @@ def _is_rate_limited(
             >= datetime.now(tz=tz.UTC) - timedelta(hours=rate_limit.period_hours)
         )
 
+        # The admin enters the budget in THOUSANDS of tokens (Onyx convention),
+        # so the stored value is scaled up to the real token count here.
         if tokens_used >= rate_limit.token_budget * TOKEN_BUDGET_UNIT:
-            return True
+            if worst is None or rate_limit.period_hours > worst.period_hours:
+                worst = rate_limit
 
-    return False
+    return worst
+
+
+def _worst_triggered_cost_limit(
+    rate_limits: Sequence[TokenRateLimit],
+    cost_since: Callable[[datetime], float],
+) -> TokenRateLimit | None:
+    """Among rows whose cost_budget_cents is set and exceeded, return the one
+    with the longest window (or None) — longest period_hours so the reset is
+    deterministic and conservative, matching _worst_triggered_limit.
+
+    Cost comes from the UserUsage ledger (not ChatMessage.token_count), which
+    buckets spend at a coarse fixed grid (_LEDGER_GRID). A bucket has no sub-grid
+    timing, so to mirror the token sliding window over [now - period_hours, now]
+    we count every bucket that *overlaps* it: window_start >= now - period_hours
+    - grid. This is conservative (a budget period finer than the grid can pull in
+    one adjacent bucket) — fail-CLOSED, the safe direction for a budget gate.
+    Rows without a cost_budget_cents are cost-exempt (token-only).
+    """
+    now = datetime.now(tz=timezone.utc)
+    worst: TokenRateLimit | None = None
+    for rate_limit in rate_limits:
+        budget = rate_limit.cost_budget_cents
+        if budget is None:
+            continue
+
+        cutoff = now - timedelta(hours=rate_limit.period_hours) - _LEDGER_GRID
+        if cost_since(cutoff) >= budget:
+            if worst is None or rate_limit.period_hours > worst.period_hours:
+                worst = rate_limit
+
+    return worst
+
+
+def raise_rate_limited(scope: str, period_hours: int) -> None:
+    """Raise a structured 429 carrying the offending scope + when its window rolls over.
+
+    Sliding-window enforcement has no single fixed reset instant; we report a full
+    period from now as the conservative "try again after" so the FE banner can count down.
+    """
+    retry_after_seconds = period_hours * 3600
+    reset_at = datetime.now(tz=timezone.utc) + timedelta(seconds=retry_after_seconds)
+    reset_at_iso = reset_at.isoformat()
+    raise OnyxError(
+        OnyxErrorCode.RATE_LIMITED,
+        # Neutral wording, no raw timestamp — the FE renders a friendly reset
+        # time from reset_at / retry_after_seconds below.
+        f"You've reached the usage budget for {scope}.",
+        extra={
+            "scope": scope,
+            "reset_at": reset_at_iso,
+            "retry_after_seconds": retry_after_seconds,
+        },
+        headers={"Retry-After": str(retry_after_seconds)},
+    )
+
+
+def _raise_for_longest_window(scope: str, *period_hours: int | None) -> None:
+    """Raise once for the longest of the given reset windows (Nones skipped).
+    The token and cost gates are independent; evaluating both before raising
+    avoids reporting a too-early reset when a short token window and a long cost
+    window are both exceeded."""
+    periods = [p for p in period_hours if p is not None]
+    if periods:
+        raise_rate_limited(scope, max(periods))
 
 
 _ANY_RATE_LIMIT_EXISTS_CACHE_TTL_SECONDS = 60

--- a/backend/onyx/server/query_and_chat/token_limit.py
+++ b/backend/onyx/server/query_and_chat/token_limit.py
@@ -1,4 +1,3 @@
-from collections.abc import Callable
 from collections.abc import Sequence
 from datetime import datetime, timedelta, timezone
 from threading import RLock
@@ -13,7 +12,7 @@ from onyx.auth.users import current_chat_accessible_user
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.models import ChatMessage, ChatSession, TokenRateLimit, User
 from onyx.db.token_limit import fetch_all_global_token_rate_limits
-from onyx.db.user_usage import get_total_cost_cents_since
+from onyx.db.user_usage import get_total_cost_cents_buckets_since
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.utils.logger import setup_logger
@@ -72,9 +71,16 @@ def _user_is_rate_limited_by_global() -> None:
                 global_usage = _fetch_global_usage(global_cutoff_time, db_session)
                 triggered = _worst_triggered_limit(global_rate_limits, global_usage)
 
+            cost_buckets: list[tuple[datetime, float]] = []
+            if any(rl.cost_budget_cents is not None for rl in global_rate_limits):
+                # One bucket fetch for the widest window; _worst_triggered_cost_limit
+                # sums per-limit in Python (no query per cost limit).
+                cost_cutoff = _get_cutoff_time(global_rate_limits) - _LEDGER_GRID
+                cost_buckets = get_total_cost_cents_buckets_since(
+                    db_session, cost_cutoff
+                )
             cost_triggered = _worst_triggered_cost_limit(
-                global_rate_limits,
-                lambda cutoff: get_total_cost_cents_since(db_session, cutoff),
+                global_rate_limits, cost_buckets
             )
             _raise_for_longest_window(
                 "organization",
@@ -155,14 +161,15 @@ def _worst_triggered_limit(
 
 def _worst_triggered_cost_limit(
     rate_limits: Sequence[TokenRateLimit],
-    cost_since: Callable[[datetime], float],
+    cost_buckets: Sequence[tuple[datetime, float]],
 ) -> TokenRateLimit | None:
     """Among rows whose cost_budget_cents is set and exceeded, return the one
     with the longest window (or None) — longest period_hours so the reset is
     deterministic and conservative, matching _worst_triggered_limit.
 
-    Cost comes from the UserUsage ledger (not ChatMessage.token_count), which
-    buckets spend at a coarse fixed grid (_LEDGER_GRID). A bucket has no sub-grid
+    Cost comes from the UserUsage ledger (not ChatMessage.token_count), bucketed
+    at a coarse fixed grid (_LEDGER_GRID) and fetched once upstream; we sum the
+    buckets per window in Python (no query per limit). A bucket has no sub-grid
     timing, so to mirror the token sliding window over [now - period_hours, now]
     we count every bucket that *overlaps* it: window_start >= now - period_hours
     - grid. This is conservative (a budget period finer than the grid can pull in
@@ -177,7 +184,10 @@ def _worst_triggered_cost_limit(
             continue
 
         cutoff = now - timedelta(hours=rate_limit.period_hours) - _LEDGER_GRID
-        if cost_since(cutoff) >= budget:
+        cost = sum(
+            cents for window_start, cents in cost_buckets if window_start >= cutoff
+        )
+        if cost >= budget:
             if worst is None or rate_limit.period_hours > worst.period_hours:
                 worst = rate_limit
 

--- a/backend/tests/unit/onyx/server/features/build/session/test_messages_background_turn.py
+++ b/backend/tests/unit/onyx/server/features/build/session/test_messages_background_turn.py
@@ -9,6 +9,7 @@ import pytest
 from sqlalchemy.orm import Session
 
 from onyx.db.models import User
+from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server.features.build.session import messages as messages_api
 from onyx.server.features.build.session.models import MessageRequest
@@ -82,6 +83,7 @@ def test_send_message_starts_background_turn(monkeypatch: pytest.MonkeyPatch) ->
     _patch_skill_state(monkeypatch)
     monkeypatch.setattr(messages_api, "get_build_session", get_session_stub)
     monkeypatch.setattr(messages_api, "check_build_rate_limits", lambda **_: None)
+    monkeypatch.setattr(messages_api, "check_token_rate_limits", lambda *_: None)
     monkeypatch.setattr(
         messages_api,
         "create_message",
@@ -131,6 +133,7 @@ def test_send_message_rejects_second_active_turn(
     _patch_skill_state(monkeypatch)
     monkeypatch.setattr(messages_api, "get_build_session", get_session_stub)
     monkeypatch.setattr(messages_api, "check_build_rate_limits", lambda **_: None)
+    monkeypatch.setattr(messages_api, "check_token_rate_limits", lambda *_: None)
     monkeypatch.setattr(messages_api, "create_message", _create_message_noop)
     monkeypatch.setattr(messages_api, "start_interactive_turn_runner", MagicMock())
 
@@ -206,6 +209,7 @@ def test_send_message_is_idempotent_for_same_client_request(
     _patch_skill_state(monkeypatch)
     monkeypatch.setattr(messages_api, "get_build_session", get_session_stub)
     monkeypatch.setattr(messages_api, "check_build_rate_limits", rate_limit_check)
+    monkeypatch.setattr(messages_api, "check_token_rate_limits", lambda *_: None)
     monkeypatch.setattr(
         messages_api,
         "create_message",
@@ -254,6 +258,7 @@ def test_send_message_leaves_turn_active_if_runner_cannot_start(
     _patch_skill_state(monkeypatch)
     monkeypatch.setattr(messages_api, "get_build_session", get_session_stub)
     monkeypatch.setattr(messages_api, "check_build_rate_limits", lambda **_: None)
+    monkeypatch.setattr(messages_api, "check_token_rate_limits", lambda *_: None)
     monkeypatch.setattr(messages_api, "create_message", _create_message_noop)
     monkeypatch.setattr(
         messages_api,
@@ -276,3 +281,38 @@ def test_send_message_leaves_turn_active_if_runner_cannot_start(
     assert response.status == "QUEUED"
     assert active is not None
     assert active.turn_id == UUID(response.turn_id)
+
+
+def test_send_message_blocked_when_over_token_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A user over their token/cost budget can't start a Craft turn: the gate
+    raises a structured 429 before any turn is created or scheduled."""
+    cache = FakeCache()
+    session_id = uuid4()
+    user_id = uuid4()
+    session = SimpleNamespace(id=session_id)
+    start_runner = MagicMock()
+
+    monkeypatch.setattr(messages_api, "get_cache_backend", lambda: cache)
+    monkeypatch.setattr(messages_api, "get_build_session", lambda *_, **__: session)
+    monkeypatch.setattr(messages_api, "check_build_rate_limits", lambda **_: None)
+    monkeypatch.setattr(messages_api, "check_token_rate_limits", lambda *_: None)
+    monkeypatch.setattr(messages_api, "create_message", _create_message_noop)
+    monkeypatch.setattr(messages_api, "start_interactive_turn_runner", start_runner)
+
+    def _over_budget(_user: object) -> None:
+        raise OnyxError(OnyxErrorCode.RATE_LIMITED, "You've reached the usage budget.")
+
+    monkeypatch.setattr(messages_api, "check_token_rate_limits", _over_budget)
+
+    with pytest.raises(OnyxError) as ei:
+        messages_api.send_message(
+            session_id=session_id,
+            request=MessageRequest(content="hello", client_request_id="req-1"),
+            user=cast(User, SimpleNamespace(id=user_id)),
+            db_session=cast(Session, _FakeDbSession(user_message_count=0)),
+        )
+
+    assert ei.value.error_code is OnyxErrorCode.RATE_LIMITED
+    start_runner.assert_not_called()  # no turn scheduled when over budget

--- a/backend/tests/unit/onyx/server/query_and_chat/test_token_limit.py
+++ b/backend/tests/unit/onyx/server/query_and_chat/test_token_limit.py
@@ -18,6 +18,7 @@ from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.orm import Session
 from sqlalchemy.orm import sessionmaker
 
+import ee.onyx.server.query_and_chat.token_limit as ee_token_limit
 import onyx.server.query_and_chat.token_limit as token_limit
 from onyx.db.models import TokenRateLimit
 from onyx.db.models import TokenRateLimitScope
@@ -235,7 +236,7 @@ def _cost_limit(
     cost_budget_cents: float | None,
     scope: TokenRateLimitScope,
     period_hours: int = 1,
-    token_budget: int = 10**12,  # effectively unbounded so only cost can trigger
+    token_budget: int | None = 10**12,  # default unbounded; None = cost-only
 ) -> TokenRateLimit:
     limit = TokenRateLimit(
         enabled=True,
@@ -456,6 +457,233 @@ class TestCostEnforcementRealLedgerPath:
         monkeypatch.setattr(token_limit, "_fetch_global_usage", lambda *_: _usage(1))
 
         token_limit._user_is_rate_limited_by_global()  # no raise
+
+
+# ---------------------------------------------------------------------------
+# EE per-user and per-group gates. These are the scopes the original code never
+# enforced cost on (a User/Group cost budget was silently a no-op). Data sources
+# are stubbed; the real gate logic runs.
+# ---------------------------------------------------------------------------
+
+
+def _stub_user_sources(
+    monkeypatch: pytest.MonkeyPatch,
+    limits: list[TokenRateLimit],
+    token_usage: list[tuple[datetime.datetime, int]],
+    cost_buckets: list[tuple[datetime.datetime, float]],
+) -> None:
+    monkeypatch.setattr(
+        ee_token_limit, "get_session_with_current_tenant", lambda: _SessionCtx()
+    )
+    monkeypatch.setattr(
+        ee_token_limit, "fetch_all_user_token_rate_limits", lambda **_: limits
+    )
+    monkeypatch.setattr(ee_token_limit, "_fetch_user_usage", lambda *_: token_usage)
+    monkeypatch.setattr(
+        ee_token_limit, "get_user_cost_cents_buckets_since", lambda *_: cost_buckets
+    )
+
+
+class TestUserGateEE:
+    """The per-user gate must enforce BOTH token and cost budgets. The cost half
+    was previously unenforced, so a per-user cost budget did nothing."""
+
+    def test_user_over_cost_budget_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import uuid
+
+        limit = _cost_limit(500.0, TokenRateLimitScope.USER, period_hours=2)
+        _stub_user_sources(monkeypatch, [limit], _usage(1), _recent_cost_buckets(600.0))
+        with pytest.raises(OnyxError) as ei:
+            ee_token_limit._user_is_rate_limited(uuid.uuid4())
+        _assert_structured_429(ei.value, "your account", 2)
+
+    def test_user_under_cost_budget_does_not_raise(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import uuid
+
+        limit = _cost_limit(500.0, TokenRateLimitScope.USER)
+        _stub_user_sources(monkeypatch, [limit], _usage(1), _recent_cost_buckets(100.0))
+        ee_token_limit._user_is_rate_limited(uuid.uuid4())  # no raise
+
+    def test_user_over_token_budget_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import uuid
+
+        limit = _make_limit(token_budget=1)  # 1,000 tokens
+        limit.scope = TokenRateLimitScope.USER
+        limit.period_hours = 5
+        _stub_user_sources(monkeypatch, [limit], _usage(2_000), [])
+        with pytest.raises(OnyxError) as ei:
+            ee_token_limit._user_is_rate_limited(uuid.uuid4())
+        _assert_structured_429(ei.value, "your account", 5)
+
+    def test_cost_only_user_limit_skips_token_query(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import uuid
+
+        cost_only = TokenRateLimit(
+            enabled=True,
+            token_budget=None,
+            cost_budget_cents=500.0,
+            period_hours=1,
+            scope=TokenRateLimitScope.USER,
+        )
+        monkeypatch.setattr(
+            ee_token_limit, "get_session_with_current_tenant", lambda: _SessionCtx()
+        )
+        monkeypatch.setattr(
+            ee_token_limit, "fetch_all_user_token_rate_limits", lambda **_: [cost_only]
+        )
+
+        def _boom(*_a: object) -> object:
+            raise AssertionError("token aggregation ran for a cost-only user limit")
+
+        monkeypatch.setattr(ee_token_limit, "_fetch_user_usage", _boom)
+        monkeypatch.setattr(
+            ee_token_limit,
+            "get_user_cost_cents_buckets_since",
+            lambda *_: _recent_cost_buckets(100.0),
+        )
+        ee_token_limit._user_is_rate_limited(uuid.uuid4())  # no raise, no token query
+
+
+def _stub_group_sources(
+    monkeypatch: pytest.MonkeyPatch,
+    group_limits: dict[int, list[TokenRateLimit]],
+    group_token_usage: dict[int, list[tuple[datetime.datetime, int]]],
+    group_cost_buckets: dict[int, list[tuple[datetime.datetime, float]]],
+) -> None:
+    monkeypatch.setattr(
+        ee_token_limit, "get_session_with_current_tenant", lambda: _SessionCtx()
+    )
+    monkeypatch.setattr(
+        ee_token_limit, "_fetch_all_user_group_rate_limits", lambda *_: group_limits
+    )
+    monkeypatch.setattr(
+        ee_token_limit, "_fetch_user_group_usage", lambda *_: group_token_usage
+    )
+    monkeypatch.setattr(
+        ee_token_limit,
+        "get_group_cost_cents_buckets_since",
+        lambda *_: group_cost_buckets,
+    )
+
+
+class TestGroupGateEE:
+    """The per-group gate must enforce cost too, while keeping the 'allowed if
+    ANY of the user's groups is under budget' semantics."""
+
+    def test_group_over_cost_budget_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import uuid
+
+        limit = _cost_limit(500.0, TokenRateLimitScope.USER_GROUP, period_hours=4)
+        _stub_group_sources(
+            monkeypatch, {1: [limit]}, {1: _usage(1)}, {1: _recent_cost_buckets(600.0)}
+        )
+        with pytest.raises(OnyxError) as ei:
+            ee_token_limit._user_is_rate_limited_by_group(uuid.uuid4())
+        _assert_structured_429(ei.value, "your group", 4)
+
+    def test_user_allowed_when_one_group_under_budget(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import uuid
+
+        over = _cost_limit(100.0, TokenRateLimitScope.USER_GROUP)
+        under = _cost_limit(100.0, TokenRateLimitScope.USER_GROUP)
+        _stub_group_sources(
+            monkeypatch,
+            {1: [over], 2: [under]},
+            {1: _usage(1), 2: _usage(1)},
+            {1: _recent_cost_buckets(600.0), 2: _recent_cost_buckets(10.0)},
+        )
+        # group 2 is under budget -> user allowed despite group 1 being over
+        ee_token_limit._user_is_rate_limited_by_group(uuid.uuid4())  # no raise
+
+    def test_all_groups_over_budget_raises_longest_window(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import uuid
+
+        g1 = _cost_limit(100.0, TokenRateLimitScope.USER_GROUP, period_hours=1)
+        g2 = _cost_limit(100.0, TokenRateLimitScope.USER_GROUP, period_hours=6)
+        _stub_group_sources(
+            monkeypatch,
+            {1: [g1], 2: [g2]},
+            {1: _usage(1), 2: _usage(1)},
+            {1: _recent_cost_buckets(600.0), 2: _recent_cost_buckets(600.0)},
+        )
+        with pytest.raises(OnyxError) as ei:
+            ee_token_limit._user_is_rate_limited_by_group(uuid.uuid4())
+        _assert_structured_429(ei.value, "your group", 6)
+
+
+class TestUserCostEnforcementRealLedgerPath:
+    """The per-user cost gate end-to-end through the real UserUsage ledger —
+    guards get_user_cost_cents_buckets_since and the wiring that was missing
+    (a per-user cost budget previously did nothing)."""
+
+    def test_user_over_cost_blocks_against_real_ledger(
+        self, monkeypatch: pytest.MonkeyPatch, ledger_session: Session
+    ) -> None:
+        import uuid
+
+        uid = uuid.uuid4()
+        now = datetime.datetime.now(tz=datetime.timezone.utc)
+        ledger_window = get_window_start(now, period_hours=168)
+        record_user_usage(
+            ledger_session, str(uid), "m", "CHAT", None, 1, 1, 0, 500.0, ledger_window
+        )
+
+        limit = _cost_limit(
+            100.0, TokenRateLimitScope.USER, period_hours=24, token_budget=None
+        )
+        monkeypatch.setattr(
+            ee_token_limit,
+            "get_session_with_current_tenant",
+            lambda: _RealLedgerSessionCtx(ledger_session),
+        )
+        monkeypatch.setattr(
+            ee_token_limit, "fetch_all_user_token_rate_limits", lambda **_: [limit]
+        )
+        # cost-only path: the token scan must be skipped, so no ChatMessage query.
+        with pytest.raises(OnyxError) as ei:
+            ee_token_limit._user_is_rate_limited(uid)
+        _assert_structured_429(ei.value, "your account", 24)
+
+    def test_other_users_spend_not_counted(
+        self, monkeypatch: pytest.MonkeyPatch, ledger_session: Session
+    ) -> None:
+        # A different user's spend must NOT count against this user's budget —
+        # the new bucket helper filters by user_id.
+        import uuid
+
+        me, other = uuid.uuid4(), uuid.uuid4()
+        now = datetime.datetime.now(tz=datetime.timezone.utc)
+        win = get_window_start(now, period_hours=168)
+        record_user_usage(
+            ledger_session, str(other), "m", "CHAT", None, 1, 1, 0, 9999.0, win
+        )
+
+        limit = _cost_limit(
+            100.0, TokenRateLimitScope.USER, period_hours=24, token_budget=None
+        )
+        monkeypatch.setattr(
+            ee_token_limit,
+            "get_session_with_current_tenant",
+            lambda: _RealLedgerSessionCtx(ledger_session),
+        )
+        monkeypatch.setattr(
+            ee_token_limit, "fetch_all_user_token_rate_limits", lambda **_: [limit]
+        )
+        ee_token_limit._user_is_rate_limited(me)  # no raise — other user's spend
 
 
 class TestTokenRateLimitArgsValidation:

--- a/backend/tests/unit/onyx/server/query_and_chat/test_token_limit.py
+++ b/backend/tests/unit/onyx/server/query_and_chat/test_token_limit.py
@@ -247,13 +247,18 @@ def _cost_limit(
     return limit
 
 
+def _recent_cost_buckets(total: float) -> list[tuple[datetime.datetime, float]]:
+    """A single just-now cost bucket, so it lands inside any limit's window."""
+    return [(datetime.datetime.now(datetime.timezone.utc), total)]
+
+
 class TestWorstTriggeredCostLimit:
-    """Unit of the shared cost evaluator (no DB; cost is injected)."""
+    """Unit of the shared cost evaluator (no DB; cost buckets are injected)."""
 
     def test_over_cost_budget_returns_row(self) -> None:
         limit = _cost_limit(100.0, TokenRateLimitScope.USER)
         triggered = token_limit._worst_triggered_cost_limit(
-            [limit], cost_since=lambda _cutoff: 150.0
+            [limit], _recent_cost_buckets(150.0)
         )
         assert triggered is limit
 
@@ -261,7 +266,7 @@ class TestWorstTriggeredCostLimit:
         limit = _cost_limit(100.0, TokenRateLimitScope.USER)
         assert (
             token_limit._worst_triggered_cost_limit(
-                [limit], cost_since=lambda _cutoff: 99.99
+                [limit], _recent_cost_buckets(99.99)
             )
             is None
         )
@@ -270,7 +275,7 @@ class TestWorstTriggeredCostLimit:
         limit = _cost_limit(100.0, TokenRateLimitScope.USER)
         assert (
             token_limit._worst_triggered_cost_limit(
-                [limit], cost_since=lambda _cutoff: 100.0
+                [limit], _recent_cost_buckets(100.0)
             )
             is limit
         )
@@ -280,7 +285,7 @@ class TestWorstTriggeredCostLimit:
         limit = _cost_limit(None, TokenRateLimitScope.USER)
         assert (
             token_limit._worst_triggered_cost_limit(
-                [limit], cost_since=lambda _cutoff: 10**9
+                [limit], _recent_cost_buckets(10**9)
             )
             is None
         )
@@ -299,7 +304,11 @@ class TestGlobalCostRejectionPath:
         )
         # under token budget so only cost can trigger
         monkeypatch.setattr(token_limit, "_fetch_global_usage", lambda *_: _usage(1))
-        monkeypatch.setattr(token_limit, "get_total_cost_cents_since", lambda *_: 600.0)
+        monkeypatch.setattr(
+            token_limit,
+            "get_total_cost_cents_buckets_since",
+            lambda *_: _recent_cost_buckets(600.0),
+        )
 
         with pytest.raises(OnyxError) as ei:
             token_limit._user_is_rate_limited_by_global()
@@ -316,7 +325,11 @@ class TestGlobalCostRejectionPath:
             token_limit, "fetch_all_global_token_rate_limits", lambda **_: [limit]
         )
         monkeypatch.setattr(token_limit, "_fetch_global_usage", lambda *_: _usage(1))
-        monkeypatch.setattr(token_limit, "get_total_cost_cents_since", lambda *_: 100.0)
+        monkeypatch.setattr(
+            token_limit,
+            "get_total_cost_cents_buckets_since",
+            lambda *_: _recent_cost_buckets(100.0),
+        )
 
         token_limit._user_is_rate_limited_by_global()  # no raise
 
@@ -342,7 +355,11 @@ class TestGlobalCostRejectionPath:
             raise AssertionError("token aggregation ran for a cost-only limit")
 
         monkeypatch.setattr(token_limit, "_fetch_global_usage", _boom)
-        monkeypatch.setattr(token_limit, "get_total_cost_cents_since", lambda *_: 100.0)
+        monkeypatch.setattr(
+            token_limit,
+            "get_total_cost_cents_buckets_since",
+            lambda *_: _recent_cost_buckets(100.0),
+        )
 
         token_limit._user_is_rate_limited_by_global()  # no raise, no token query
 

--- a/backend/tests/unit/onyx/server/query_and_chat/test_token_limit.py
+++ b/backend/tests/unit/onyx/server/query_and_chat/test_token_limit.py
@@ -1,0 +1,465 @@
+"""Unit tests for token-rate-limit enforcement (in-memory SQLite).
+
+Guards the admin-facing unit: a stored ``token_budget`` of N is in thousands,
+so it enforces at N * 1000 tokens (the Onyx convention).
+"""
+
+import datetime
+from collections.abc import Generator
+from typing import cast
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy import Table
+from sqlalchemy.dialects.postgresql import JSONB as PGJSONB
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.orm import Session
+from sqlalchemy.orm import sessionmaker
+
+import onyx.server.query_and_chat.token_limit as token_limit
+from onyx.db.models import TokenRateLimit
+from onyx.db.models import TokenRateLimitScope
+from onyx.db.models import UserUsage
+from onyx.db.user_usage import get_window_start
+from onyx.db.user_usage import record_user_usage
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.query_and_chat.token_limit import _worst_triggered_limit
+
+
+def _is_rate_limited(
+    rate_limits: list[TokenRateLimit],
+    usage: list[tuple[datetime.datetime, int]],
+) -> bool:
+    return _worst_triggered_limit(rate_limits, usage) is not None
+
+
+# Postgres-only column types -> SQLite equivalents so the real UserUsage table
+# can back the real cost-source query path.
+@compiles(PGUUID, "sqlite")
+def _compile_pguuid_sqlite(_e: object, _c: object, **_kw: object) -> str:
+    return "CHAR(36)"
+
+
+@compiles(PGJSONB, "sqlite")
+def _compile_jsonb_sqlite(_e: object, _c: object, **_kw: object) -> str:
+    return "JSON"
+
+
+@pytest.fixture
+def db_session() -> Generator[Session, None, None]:
+    engine: Engine = create_engine("sqlite://")
+    # Only the table under test; user-group FK is not exercised here.
+    cast(Table, TokenRateLimit.__table__).create(bind=engine)
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def _make_limit(token_budget: int) -> TokenRateLimit:
+    return TokenRateLimit(
+        enabled=True,
+        token_budget=token_budget,
+        period_hours=1,
+        scope=TokenRateLimitScope.GLOBAL,
+    )
+
+
+def _usage(token_count: int) -> list[tuple[datetime.datetime, int]]:
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    return [(now, token_count)]
+
+
+class TestIsRateLimitedUnit:
+    def test_budget_is_in_thousands(self) -> None:
+        # token_budget=12 means 12,000 tokens (the Onyx thousands convention).
+        limit = _make_limit(token_budget=12)
+        assert _is_rate_limited([limit], _usage(11_999)) is False
+        assert _is_rate_limited([limit], _usage(12_000)) is True
+        assert _is_rate_limited([limit], _usage(12_001)) is True
+
+    def test_below_budget_not_limited(self) -> None:
+        limit = _make_limit(token_budget=1000)  # 1,000,000 tokens
+        assert _is_rate_limited([limit], _usage(999_999)) is False
+
+    def test_at_budget_is_limited(self) -> None:
+        limit = _make_limit(token_budget=1000)  # 1,000,000 tokens
+        assert _is_rate_limited([limit], _usage(1_000_000)) is True
+
+    def test_cost_only_limit_is_token_exempt(self) -> None:
+        # A cost-only limit (token_budget=None) must NOT block on tokens — a 0
+        # would make tokens_used >= 0 always true and block every request.
+        cost_only = TokenRateLimit(
+            enabled=True,
+            token_budget=None,
+            cost_budget_cents=500.0,
+            period_hours=1,
+            scope=TokenRateLimitScope.GLOBAL,
+        )
+        assert _is_rate_limited([cost_only], _usage(10_000_000)) is False
+
+    def test_zero_token_budget_does_not_block(self) -> None:
+        # A legacy/edge token_budget of 0 must be treated as no token limit, not
+        # "block at 0 tokens" (which would reject every request).
+        zero = TokenRateLimit(
+            enabled=True,
+            token_budget=0,
+            cost_budget_cents=500.0,
+            period_hours=1,
+            scope=TokenRateLimitScope.GLOBAL,
+        )
+        assert _is_rate_limited([zero], _usage(10_000_000)) is False
+
+    def test_longest_window_among_exceeded_wins(self) -> None:
+        # When several limits are exceeded the reset must be deterministic and
+        # conservative: report the longest window so a retry can't immediately
+        # re-trip a still-exceeded longer limit. Order must not matter.
+        short = TokenRateLimit(
+            enabled=True,
+            token_budget=1,
+            period_hours=1,
+            scope=TokenRateLimitScope.GLOBAL,
+        )
+        long_ = TokenRateLimit(
+            enabled=True,
+            token_budget=1,
+            period_hours=24,
+            scope=TokenRateLimitScope.GLOBAL,
+        )
+        for order in ([short, long_], [long_, short]):
+            worst = _worst_triggered_limit(order, _usage(10_000))
+            assert worst is not None and worst.period_hours == 24
+
+
+def _assert_structured_429(exc: OnyxError, scope: str, period_hours: int) -> None:
+    """The 429 the FE banner binds to: RATE_LIMITED + scope + reset fields + header."""
+    assert exc.error_code is OnyxErrorCode.RATE_LIMITED
+    assert exc.status_code == 429
+    assert scope in exc.detail
+
+    extra = exc.extra or {}
+    assert extra["scope"] == scope
+    assert extra["retry_after_seconds"] == period_hours * 3600
+
+    reset_at = datetime.datetime.fromisoformat(cast(str, extra["reset_at"]))
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    expected = now + datetime.timedelta(hours=period_hours)
+    # Allow a few seconds of execution slop.
+    assert abs((reset_at - expected).total_seconds()) < 60
+
+    assert exc.headers == {"Retry-After": str(period_hours * 3600)}
+
+
+class TestRaiseRateLimited:
+    def test_global_scope_shape(self) -> None:
+        with pytest.raises(OnyxError) as ei:
+            token_limit.raise_rate_limited("organization", period_hours=2)
+        _assert_structured_429(ei.value, "organization", 2)
+
+
+class TestRaiseForLongestWindow:
+    """Token + cost gates are evaluated together; the reported reset is the
+    longest window, so a short token limit can't mask a longer cost reset."""
+
+    def test_longest_of_token_and_cost_wins(self) -> None:
+        with pytest.raises(OnyxError) as ei:
+            token_limit._raise_for_longest_window("user", 1, 24)
+        _assert_structured_429(ei.value, "user", 24)
+
+    def test_skips_none_windows(self) -> None:
+        with pytest.raises(OnyxError) as ei:
+            token_limit._raise_for_longest_window("user", None, 5)
+        _assert_structured_429(ei.value, "user", 5)
+
+    def test_no_trigger_does_not_raise(self) -> None:
+        token_limit._raise_for_longest_window("user", None, None)  # no raise
+
+
+class _SessionCtx:
+    """Minimal stand-in for get_session_with_current_tenant (only the limit fetch is patched)."""
+
+    def __enter__(self) -> object:
+        return object()
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+
+class TestGlobalRejectionPath:
+    """CE path: a global limit over budget raises the structured 429."""
+
+    def test_over_global_budget_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        limit = _make_limit(token_budget=1000)
+        limit.period_hours = 3
+
+        monkeypatch.setattr(
+            token_limit, "get_session_with_current_tenant", lambda: _SessionCtx()
+        )
+        monkeypatch.setattr(
+            token_limit,
+            "fetch_all_global_token_rate_limits",
+            lambda **_: [limit],
+        )
+        # date_trunc isn't valid on SQLite; stub usage directly.
+        monkeypatch.setattr(
+            token_limit, "_fetch_global_usage", lambda *_: _usage(1_500_000)
+        )
+
+        with pytest.raises(OnyxError) as ei:
+            token_limit._user_is_rate_limited_by_global()
+        _assert_structured_429(ei.value, "organization", 3)
+
+    def test_under_global_budget_does_not_raise(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        limit = _make_limit(token_budget=1000)
+        monkeypatch.setattr(
+            token_limit, "get_session_with_current_tenant", lambda: _SessionCtx()
+        )
+        monkeypatch.setattr(
+            token_limit,
+            "fetch_all_global_token_rate_limits",
+            lambda **_: [limit],
+        )
+        monkeypatch.setattr(token_limit, "_fetch_global_usage", lambda *_: _usage(10))
+
+        token_limit._user_is_rate_limited_by_global()  # no raise
+
+
+def _cost_limit(
+    cost_budget_cents: float | None,
+    scope: TokenRateLimitScope,
+    period_hours: int = 1,
+    token_budget: int = 10**12,  # effectively unbounded so only cost can trigger
+) -> TokenRateLimit:
+    limit = TokenRateLimit(
+        enabled=True,
+        token_budget=token_budget,
+        period_hours=period_hours,
+        scope=scope,
+    )
+    limit.cost_budget_cents = cost_budget_cents
+    return limit
+
+
+class TestWorstTriggeredCostLimit:
+    """Unit of the shared cost evaluator (no DB; cost is injected)."""
+
+    def test_over_cost_budget_returns_row(self) -> None:
+        limit = _cost_limit(100.0, TokenRateLimitScope.USER)
+        triggered = token_limit._worst_triggered_cost_limit(
+            [limit], cost_since=lambda _cutoff: 150.0
+        )
+        assert triggered is limit
+
+    def test_under_cost_budget_returns_none(self) -> None:
+        limit = _cost_limit(100.0, TokenRateLimitScope.USER)
+        assert (
+            token_limit._worst_triggered_cost_limit(
+                [limit], cost_since=lambda _cutoff: 99.99
+            )
+            is None
+        )
+
+    def test_at_cost_budget_triggers(self) -> None:
+        limit = _cost_limit(100.0, TokenRateLimitScope.USER)
+        assert (
+            token_limit._worst_triggered_cost_limit(
+                [limit], cost_since=lambda _cutoff: 100.0
+            )
+            is limit
+        )
+
+    def test_row_without_cost_budget_is_exempt(self) -> None:
+        # token-only row (cost_budget_cents is None) is never cost-limited
+        limit = _cost_limit(None, TokenRateLimitScope.USER)
+        assert (
+            token_limit._worst_triggered_cost_limit(
+                [limit], cost_since=lambda _cutoff: 10**9
+            )
+            is None
+        )
+
+
+class TestGlobalCostRejectionPath:
+    """CE global path: a global cost budget summed across the tenant raises."""
+
+    def test_over_global_cost_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        limit = _cost_limit(500.0, TokenRateLimitScope.GLOBAL, period_hours=3)
+        monkeypatch.setattr(
+            token_limit, "get_session_with_current_tenant", lambda: _SessionCtx()
+        )
+        monkeypatch.setattr(
+            token_limit, "fetch_all_global_token_rate_limits", lambda **_: [limit]
+        )
+        # under token budget so only cost can trigger
+        monkeypatch.setattr(token_limit, "_fetch_global_usage", lambda *_: _usage(1))
+        monkeypatch.setattr(token_limit, "get_total_cost_cents_since", lambda *_: 600.0)
+
+        with pytest.raises(OnyxError) as ei:
+            token_limit._user_is_rate_limited_by_global()
+        _assert_structured_429(ei.value, "organization", 3)
+
+    def test_under_global_cost_does_not_raise(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        limit = _cost_limit(500.0, TokenRateLimitScope.GLOBAL)
+        monkeypatch.setattr(
+            token_limit, "get_session_with_current_tenant", lambda: _SessionCtx()
+        )
+        monkeypatch.setattr(
+            token_limit, "fetch_all_global_token_rate_limits", lambda **_: [limit]
+        )
+        monkeypatch.setattr(token_limit, "_fetch_global_usage", lambda *_: _usage(1))
+        monkeypatch.setattr(token_limit, "get_total_cost_cents_since", lambda *_: 100.0)
+
+        token_limit._user_is_rate_limited_by_global()  # no raise
+
+    def test_cost_only_skips_token_aggregation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A cost-only limit (token_budget=None) must not run the token-usage query.
+        limit = TokenRateLimit(
+            enabled=True,
+            token_budget=None,
+            cost_budget_cents=500.0,
+            period_hours=1,
+            scope=TokenRateLimitScope.GLOBAL,
+        )
+        monkeypatch.setattr(
+            token_limit, "get_session_with_current_tenant", lambda: _SessionCtx()
+        )
+        monkeypatch.setattr(
+            token_limit, "fetch_all_global_token_rate_limits", lambda **_: [limit]
+        )
+
+        def _boom(*_a: object) -> object:
+            raise AssertionError("token aggregation ran for a cost-only limit")
+
+        monkeypatch.setattr(token_limit, "_fetch_global_usage", _boom)
+        monkeypatch.setattr(token_limit, "get_total_cost_cents_since", lambda *_: 100.0)
+
+        token_limit._user_is_rate_limited_by_global()  # no raise, no token query
+
+
+class _RealLedgerSessionCtx:
+    """Yields a real SQLite session backing the actual UserUsage cost query."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def __enter__(self) -> Session:
+        return self._session
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+
+@pytest.fixture
+def ledger_session() -> Generator[Session, None, None]:
+    engine: Engine = create_engine("sqlite://")
+    cast(Table, UserUsage.__table__).create(bind=engine)
+    session = sessionmaker(bind=engine)()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+class TestCostEnforcementRealLedgerPath:
+    """The global cost gate, end-to-end through the real cost source — the
+    regression that the prior exact-window read fail-opened on a sub-grid
+    budget period."""
+
+    def test_sub_grid_period_blocks_against_real_ledger(
+        self, monkeypatch: pytest.MonkeyPatch, ledger_session: Session
+    ) -> None:
+        # Ledger row written at the weekly grid (as the real processor does),
+        # but the admin's budget period is 24h. The sliding cutoff still reads it.
+        import uuid
+
+        now = datetime.datetime.now(tz=datetime.timezone.utc)
+        ledger_window = get_window_start(now, period_hours=168)
+        record_user_usage(
+            ledger_session,
+            str(uuid.uuid4()),
+            "m",
+            "CHAT",
+            None,
+            1,
+            1,
+            0,
+            500.0,
+            ledger_window,
+        )
+
+        limit = _cost_limit(100.0, TokenRateLimitScope.GLOBAL, period_hours=24)
+        monkeypatch.setattr(
+            token_limit,
+            "get_session_with_current_tenant",
+            lambda: _RealLedgerSessionCtx(ledger_session),
+        )
+        monkeypatch.setattr(
+            token_limit, "fetch_all_global_token_rate_limits", lambda **_: [limit]
+        )
+        monkeypatch.setattr(token_limit, "_fetch_global_usage", lambda *_: _usage(1))
+
+        with pytest.raises(OnyxError) as ei:
+            token_limit._user_is_rate_limited_by_global()
+        _assert_structured_429(ei.value, "organization", 24)
+
+    def test_window_rollover_does_not_count(
+        self, monkeypatch: pytest.MonkeyPatch, ledger_session: Session
+    ) -> None:
+        import uuid
+
+        now = datetime.datetime.now(tz=datetime.timezone.utc)
+        current = get_window_start(now, period_hours=168)
+        # Two grids back: always before the (period + one-grid) relaxed cutoff,
+        # regardless of weekday. A 24h budget must not see last-period spend.
+        prior = current - datetime.timedelta(days=14)
+        record_user_usage(
+            ledger_session, str(uuid.uuid4()), "m", "CHAT", None, 1, 1, 0, 9999.0, prior
+        )
+
+        limit = _cost_limit(100.0, TokenRateLimitScope.GLOBAL, period_hours=24)
+        monkeypatch.setattr(
+            token_limit,
+            "get_session_with_current_tenant",
+            lambda: _RealLedgerSessionCtx(ledger_session),
+        )
+        monkeypatch.setattr(
+            token_limit, "fetch_all_global_token_rate_limits", lambda **_: [limit]
+        )
+        monkeypatch.setattr(token_limit, "_fetch_global_usage", lambda *_: _usage(1))
+
+        token_limit._user_is_rate_limited_by_global()  # no raise
+
+
+class TestTokenRateLimitArgsValidation:
+    """A limit must carry a token budget, a cost budget, or both — never neither."""
+
+    def test_neither_budget_rejected(self) -> None:
+        from onyx.server.token_rate_limits.models import TokenRateLimitArgs
+
+        with pytest.raises(ValueError):
+            TokenRateLimitArgs(enabled=True, token_budget=None, period_hours=24)
+
+    def test_cost_only_accepted(self) -> None:
+        from onyx.server.token_rate_limits.models import TokenRateLimitArgs
+
+        args = TokenRateLimitArgs(
+            enabled=True, token_budget=None, period_hours=24, cost_budget_cents=500.0
+        )
+        assert args.token_budget is None and args.cost_budget_cents == 500.0
+
+    def test_token_only_accepted(self) -> None:
+        from onyx.server.token_rate_limits.models import TokenRateLimitArgs
+
+        args = TokenRateLimitArgs(enabled=True, token_budget=1000, period_hours=24)
+        assert args.token_budget == 1000 and args.cost_budget_cents is None

--- a/backend/tests/unit/onyx/server/token_rate_limits/test_cost_budget_api.py
+++ b/backend/tests/unit/onyx/server/token_rate_limits/test_cost_budget_api.py
@@ -1,0 +1,89 @@
+"""Global token-rate-limit create/read round-trips cost_budget_cents (cents at
+the API boundary), and a limit may carry only a cost budget (no token budget)."""
+
+from collections.abc import Generator
+from typing import cast
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy import Table
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from onyx.auth.users import current_user
+from onyx.db.engine.sql_engine import get_session
+from onyx.db.enums import Permission
+from onyx.db.models import TokenRateLimit
+from onyx.error_handling.exceptions import register_onyx_exception_handlers
+from onyx.server.token_rate_limits.api import router as token_rate_limit_router
+
+
+class _StubUser:
+    def __init__(self, permissions: list[str]) -> None:
+        self.id = "00000000-0000-0000-0000-000000000001"
+        self.effective_permissions = permissions
+
+
+_ADMIN = _StubUser([Permission.FULL_ADMIN_PANEL_ACCESS.value])
+
+
+@pytest.fixture
+def db_session() -> Generator[Session, None, None]:
+    # StaticPool keeps the table alive across the endpoint's commit().
+    engine: Engine = create_engine(
+        "sqlite://", poolclass=StaticPool, connect_args={"check_same_thread": False}
+    )
+    cast(Table, TokenRateLimit.__table__).create(bind=engine)
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def _make_app(db_session: Session) -> FastAPI:
+    app = FastAPI()
+    register_onyx_exception_handlers(app)
+    app.include_router(token_rate_limit_router)
+    app.dependency_overrides[get_session] = lambda: db_session
+    app.dependency_overrides[current_user] = lambda: _ADMIN
+    return app
+
+
+def test_create_persists_cost_budget_and_get_returns_it(db_session: Session) -> None:
+    client = TestClient(_make_app(db_session))
+
+    created = client.post(
+        "/admin/token-rate-limits/global",
+        json={
+            "enabled": True,
+            "token_budget": 1000,
+            "period_hours": 24,
+            "cost_budget_cents": 500.0,
+        },
+    )
+    assert created.status_code == 200
+    assert created.json()["cost_budget_cents"] == 500.0
+
+    listing = client.get("/admin/token-rate-limits/global")
+    assert listing.status_code == 200
+    rows = listing.json()
+    assert len(rows) == 1
+    assert rows[0]["cost_budget_cents"] == 500.0
+    assert rows[0]["token_budget"] == 1000
+
+
+def test_cost_budget_optional_defaults_null(db_session: Session) -> None:
+    client = TestClient(_make_app(db_session))
+
+    created = client.post(
+        "/admin/token-rate-limits/global",
+        json={"enabled": True, "token_budget": 1000, "period_hours": 24},
+    )
+    assert created.status_code == 200
+    assert created.json()["cost_budget_cents"] is None


### PR DESCRIPTION
## Description

Part **3 of 4** of the per-user usage + cost tracking stack. Mirror of #11888 by @beraterkanelcelik, cherry-picked onto our stack base.

> **Stacked PR.** Targets `feat/usage-2-accounting2` (mirror of #12551). Review the enforcement layer only.

### Net-new in this PR — CE/global enforcement + structured 429
- `server/query_and_chat/token_limit.py` — extends the existing token-rate-limit gate to also enforce **cost** budgets (global + per-user/group CE). Token aggregation skipped for cost-only limits; the 429 reports the **longest** exceeded window across token + cost.
- `error_handling/exceptions.py` — additive `OnyxError.extra` / `headers` so the 429 carries `Retry-After` + structured detail.
- `server/token_rate_limits/models.py` — `cost_budget_cents` on the rate-limit API model.
- Unit tests for the gate (token/cost/longest-window) + the cost-budget API.
- Craft (Build Mode) send-message and subagent turns now respect token/cost budgets.

Depends on feat/usage-2-accounting2. Frontend (4/4) follows.

### Stack
1. Schema + models → #12550 (merged to `temp/pr-11766`)
2. Accounting → #12551 (`feat/usage-2-accounting2`)
3. **Enforcement ← this PR** (`feat/usage-3-enforcement`)
4. Frontend → TBD (`feat/usage-4-frontend`)

## How Has This Been Tested?

Unit tests for the enforcement gate and cost-budget API (cherry-picked from #11888).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces token and cost budgets at organization, user, and group scopes, returning a structured 429 with Retry-After and applying the limits to Craft turns. Adds cost budgets to the token-rate-limit API (token-only, cost-only, or both) and improves accuracy and performance of checks.

- New Features
  - Enforce token and cost budgets for org/user/group; raise one 429 for the longest exceeded window.
  - Structured 429 via `OnyxError` with `extra` (scope, reset_at, retry_after_seconds) and `Retry-After`.
  - `cost_budget_cents` on the rate-limit API; `token_budget` can be null (cost-only). Craft send-message and subagent turns now respect these budgets.

- Bug Fixes
  - Per-user and per-group cost budgets now enforced; group gate still allows if any group is under budget.
  - Removed N+1 in the global cost gate by fetching cost buckets once and summing per limit in code.
  - Token scan uses only token-window limits; cost-only limits skip token aggregation and don’t widen the scan.
  - Cost ledger cutoff relaxed by one bucket to handle overlap; deterministic resets by reporting the longest exceeded window.

<sup>Written for commit db7188d4a48fd2da60a8fda1f16f5889b7268bbc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

