### PR TITLE
feat: per-user usage + cost tracking — frontend (4/4)

### DIFF
--- a/web/src/app/admin/token-rate-limits/CreateRateLimitModal.test.tsx
+++ b/web/src/app/admin/token-rate-limits/CreateRateLimitModal.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen, setupUser } from "@tests/setup/test-utils";
+import CreateRateLimitModal from "@/app/admin/token-rate-limits/CreateRateLimitModal";
+
+test("requires at least one enforcement budget", async () => {
+  const user = setupUser();
+  const onSubmit = jest.fn().mockResolvedValue(undefined);
+
+  render(
+    <CreateRateLimitModal isOpen setIsOpen={jest.fn()} onSubmit={onSubmit} />
+  );
+
+  await user.type(screen.getByLabelText("Time Window (UTC Days)"), "1");
+  await user.click(screen.getByRole("button", { name: "Create" }));
+
+  expect(
+    await screen.findByText("Set a token budget and/or a cost budget")
+  ).toBeInTheDocument();
+  expect(onSubmit).not.toHaveBeenCalled();
+});

--- a/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
+++ b/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
@@ -19,7 +19,8 @@ interface CreateRateLimitModalProps {
   onSubmit: (
     target_scope: Scope,
     period_hours: number,
-    token_budget: number,
+    token_budget: number | null,
+    cost_budget_cents: number | null,
     group_id: number
   ) => void;
   forSpecificScope?: Scope;
@@ -72,6 +73,7 @@ export default function CreateRateLimitModal({
             enabled: true,
             period_days: "",
             token_budget: "",
+            cost_budget_dollars: "",
             target_scope: forSpecificScope || Scope.GLOBAL,
             user_group_id: forSpecificUserGroup,
           }}
@@ -81,8 +83,17 @@ export default function CreateRateLimitModal({
               .integer("Time Window must be a whole number of days")
               .min(1, "Time Window must be at least 1 day"),
             token_budget: Yup.number()
-              .required("Token Budget is a required field")
-              .min(1, "Token Budget must be at least 1"),
+              .min(1, "Token Budget must be at least 1")
+              .test(
+                "budget-required",
+                "Set a token budget and/or a cost budget",
+                (value, context) =>
+                  value != null || context.parent.cost_budget_dollars !== ""
+              ),
+            cost_budget_dollars: Yup.number().min(
+              0,
+              "Cost Budget cannot be negative"
+            ),
             target_scope: Yup.string().required(
               "Target Scope is a required field"
             ),
@@ -100,10 +111,19 @@ export default function CreateRateLimitModal({
           })}
           onSubmit={async (values, formikHelpers) => {
             formikHelpers.setSubmitting(true);
+            // Empty token field → null (cost-only); the gate skips a null budget.
+            // Sending 0 would mean "0-token limit" and block every request.
+            const tokenBudget =
+              values.token_budget === "" ? null : Number(values.token_budget);
+            const costBudgetCents =
+              values.cost_budget_dollars === ""
+                ? null
+                : Math.round(Number(values.cost_budget_dollars) * 100);
             onSubmit(
               values.target_scope,
               Number(values.period_days) * HOURS_PER_DAY,
-              Number(values.token_budget),
+              tokenBudget,
+              costBudgetCents,
               Number(values.user_group_id)
             );
             return formikHelpers.setSubmitting(false);
@@ -147,7 +167,13 @@ export default function CreateRateLimitModal({
                 />
                 <TextFormField
                   name="token_budget"
-                  label="Token Budget (Thousands)"
+                  label="Token Budget (Thousands, optional)"
+                  type="number"
+                  placeholder=""
+                />
+                <TextFormField
+                  name="cost_budget_dollars"
+                  label="Cost Budget (USD per period, optional)"
                   type="number"
                   placeholder=""
                 />

--- a/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
+++ b/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
@@ -21,7 +21,7 @@ interface CreateRateLimitModalProps {
     period_hours: number,
     token_budget: number | null,
     cost_budget_cents: number | null,
-    group_id: number,
+    group_id: number
   ) => void;
   forSpecificScope?: Scope;
   forSpecificUserGroup?: number;
@@ -36,7 +36,7 @@ export default function CreateRateLimitModal({
 }: CreateRateLimitModalProps) {
   const [modalUserGroups, setModalUserGroups] = useState([]);
   const [shouldFetchUserGroups, setShouldFetchUserGroups] = useState(
-    forSpecificScope === Scope.USER_GROUP,
+    forSpecificScope === Scope.USER_GROUP
   );
 
   useEffect(() => {
@@ -87,24 +87,24 @@ export default function CreateRateLimitModal({
               // this, "" coerces to NaN and trips .min(1) even when only a cost
               // budget is set. Mirrors the cost_budget_dollars transform below.
               .transform((value, original) =>
-                original === "" ? undefined : value,
+                original === "" ? undefined : value
               )
               .min(1, "Token Budget must be at least 1")
               .test(
                 "budget-required",
                 "Set a token budget and/or a cost budget",
                 (value, context) =>
-                  value != null || context.parent.cost_budget_dollars !== "",
+                  value != null || context.parent.cost_budget_dollars !== ""
               ),
             cost_budget_dollars: Yup.number()
               // Empty (no cost budget) is allowed; a 0 would make the gate fire
               // on the first request (cost_since >= 0 is always true).
               .transform((value, original) =>
-                original === "" ? undefined : value,
+                original === "" ? undefined : value
               )
               .moreThan(0, "Cost Budget must be greater than 0"),
             target_scope: Yup.string().required(
-              "Target Scope is a required field",
+              "Target Scope is a required field"
             ),
             user_group_id: Yup.string().test(
               "user_group_id",
@@ -115,7 +115,7 @@ export default function CreateRateLimitModal({
                   (context.parent.target_scope === "user_group" &&
                     value !== undefined)
                 );
-              },
+              }
             ),
           })}
           onSubmit={async (values, formikHelpers) => {
@@ -133,7 +133,7 @@ export default function CreateRateLimitModal({
               Number(values.period_days) * HOURS_PER_DAY,
               tokenBudget,
               costBudgetCents,
-              Number(values.user_group_id),
+              Number(values.user_group_id)
             );
             return formikHelpers.setSubmitting(false);
           }}

--- a/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
+++ b/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
@@ -83,6 +83,12 @@ export default function CreateRateLimitModal({
               .integer("Time Window must be a whole number of days")
               .min(1, "Time Window must be at least 1 day"),
             token_budget: Yup.number()
+              // Empty (no token budget) is allowed — a cost-only limit. Without
+              // this, "" coerces to NaN and trips .min(1) even when only a cost
+              // budget is set. Mirrors the cost_budget_dollars transform below.
+              .transform((value, original) =>
+                original === "" ? undefined : value,
+              )
               .min(1, "Token Budget must be at least 1")
               .test(
                 "budget-required",

--- a/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
+++ b/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
@@ -21,7 +21,7 @@ interface CreateRateLimitModalProps {
     period_hours: number,
     token_budget: number | null,
     cost_budget_cents: number | null,
-    group_id: number
+    group_id: number,
   ) => void;
   forSpecificScope?: Scope;
   forSpecificUserGroup?: number;
@@ -36,7 +36,7 @@ export default function CreateRateLimitModal({
 }: CreateRateLimitModalProps) {
   const [modalUserGroups, setModalUserGroups] = useState([]);
   const [shouldFetchUserGroups, setShouldFetchUserGroups] = useState(
-    forSpecificScope === Scope.USER_GROUP
+    forSpecificScope === Scope.USER_GROUP,
   );
 
   useEffect(() => {
@@ -88,14 +88,17 @@ export default function CreateRateLimitModal({
                 "budget-required",
                 "Set a token budget and/or a cost budget",
                 (value, context) =>
-                  value != null || context.parent.cost_budget_dollars !== ""
+                  value != null || context.parent.cost_budget_dollars !== "",
               ),
-            cost_budget_dollars: Yup.number().min(
-              0,
-              "Cost Budget cannot be negative"
-            ),
+            cost_budget_dollars: Yup.number()
+              // Empty (no cost budget) is allowed; a 0 would make the gate fire
+              // on the first request (cost_since >= 0 is always true).
+              .transform((value, original) =>
+                original === "" ? undefined : value,
+              )
+              .moreThan(0, "Cost Budget must be greater than 0"),
             target_scope: Yup.string().required(
-              "Target Scope is a required field"
+              "Target Scope is a required field",
             ),
             user_group_id: Yup.string().test(
               "user_group_id",
@@ -106,7 +109,7 @@ export default function CreateRateLimitModal({
                   (context.parent.target_scope === "user_group" &&
                     value !== undefined)
                 );
-              }
+              },
             ),
           })}
           onSubmit={async (values, formikHelpers) => {
@@ -124,7 +127,7 @@ export default function CreateRateLimitModal({
               Number(values.period_days) * HOURS_PER_DAY,
               tokenBudget,
               costBudgetCents,
-              Number(values.user_group_id)
+              Number(values.user_group_id),
             );
             return formikHelpers.setSubmitting(false);
           }}

--- a/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
+++ b/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
@@ -22,7 +22,7 @@ interface CreateRateLimitModalProps {
     token_budget: number | null,
     cost_budget_cents: number | null,
     group_id: number
-  ) => void;
+  ) => Promise<void>;
   forSpecificScope?: Scope;
   forSpecificUserGroup?: number;
 }
@@ -118,8 +118,7 @@ export default function CreateRateLimitModal({
               }
             ),
           })}
-          onSubmit={async (values, formikHelpers) => {
-            formikHelpers.setSubmitting(true);
+          onSubmit={async (values) => {
             // Empty token field → null (cost-only); the gate skips a null budget.
             // Sending 0 would mean "0-token limit" and block every request.
             const tokenBudget =
@@ -128,14 +127,13 @@ export default function CreateRateLimitModal({
               values.cost_budget_dollars === ""
                 ? null
                 : Math.round(Number(values.cost_budget_dollars) * 100);
-            onSubmit(
+            await onSubmit(
               values.target_scope,
               Number(values.period_days) * HOURS_PER_DAY,
               tokenBudget,
               costBudgetCents,
               Number(values.user_group_id)
             );
-            return formikHelpers.setSubmitting(false);
           }}
         >
           {({ isSubmitting, values, setFieldValue }) => (

--- a/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
+++ b/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
@@ -94,7 +94,7 @@ export default function CreateRateLimitModal({
                 "budget-required",
                 "Set a token budget and/or a cost budget",
                 (value, context) =>
-                  value != null || context.parent.cost_budget_dollars !== ""
+                  value != null || context.parent.cost_budget_dollars != null
               ),
             cost_budget_dollars: Yup.number()
               // Empty (no cost budget) is allowed; a 0 would make the gate fire

--- a/web/src/app/admin/token-rate-limits/TokenRateLimitTables.test.tsx
+++ b/web/src/app/admin/token-rate-limits/TokenRateLimitTables.test.tsx
@@ -1,0 +1,24 @@
+import { formatPeriod } from "@/app/admin/token-rate-limits/TokenRateLimitTables";
+import type { TokenRateLimitDisplay } from "@/app/admin/token-rate-limits/types";
+
+function tokenRateLimit(
+  periodHours: number,
+  tokenBudget: number | null,
+  costBudgetCents: number | null
+): TokenRateLimitDisplay {
+  return {
+    token_id: 1,
+    enabled: true,
+    token_budget: tokenBudget,
+    period_hours: periodHours,
+    cost_budget_cents: costBudgetCents,
+  };
+}
+
+test.each([
+  ["token-only", tokenRateLimit(24, 1, null), "1 UTC day"],
+  ["cost-only", tokenRateLimit(24, null, 100), "1 UTC day"],
+  ["dual", tokenRateLimit(48, 1, 100), "2 UTC days"],
+])("%s limits display UTC-day windows", (_name, limit, expected) => {
+  expect(formatPeriod(limit)).toBe(expected);
+});

--- a/web/src/app/admin/token-rate-limits/TokenRateLimitTables.test.tsx
+++ b/web/src/app/admin/token-rate-limits/TokenRateLimitTables.test.tsx
@@ -1,5 +1,29 @@
+import { render, screen, setupUser, waitFor } from "@tests/setup/test-utils";
 import { formatPeriod } from "@/app/admin/token-rate-limits/TokenRateLimitTables";
+import { TokenRateLimitTable } from "@/app/admin/token-rate-limits/TokenRateLimitTables";
 import type { TokenRateLimitDisplay } from "@/app/admin/token-rate-limits/types";
+
+const mockDelete = jest.fn();
+const mockMutate = jest.fn();
+const mockToastError = jest.fn();
+const mockUpdate = jest.fn();
+
+jest.mock("@/app/admin/token-rate-limits/lib", () => ({
+  deleteTokenRateLimit: (...args: unknown[]) => mockDelete(...args),
+  updateTokenRateLimit: (...args: unknown[]) => mockUpdate(...args),
+}));
+
+jest.mock("@opal/layouts/toast/store", () => ({
+  toast: {
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+jest.mock("swr", () => ({
+  __esModule: true,
+  ...jest.requireActual("swr"),
+  mutate: (...args: unknown[]) => mockMutate(...args),
+}));
 
 function tokenRateLimit(
   periodHours: number,
@@ -21,4 +45,48 @@ test.each([
   ["dual", tokenRateLimit(48, 1, 100), "2 UTC days"],
 ])("%s limits display UTC-day windows", (_name, limit, expected) => {
   expect(formatPeriod(limit)).toBe(expected);
+});
+
+describe("token rate limit mutation failures", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("shows an update error instead of rejecting the click handler", async () => {
+    const user = setupUser();
+    mockUpdate.mockRejectedValue(new Error("Update failed"));
+    render(
+      <TokenRateLimitTable
+        tokenRateLimits={[tokenRateLimit(24, 1, null)]}
+        fetchUrl="/api/test-limits"
+        isAdmin
+      />
+    );
+
+    await user.click(screen.getByRole("checkbox"));
+
+    await waitFor(() =>
+      expect(mockToastError).toHaveBeenCalledWith("Update failed")
+    );
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  test("shows a delete error instead of rejecting the click handler", async () => {
+    const user = setupUser();
+    mockDelete.mockRejectedValue(new Error("Delete failed"));
+    render(
+      <TokenRateLimitTable
+        tokenRateLimits={[tokenRateLimit(24, 1, null)]}
+        fetchUrl="/api/test-limits"
+        isAdmin
+      />
+    );
+
+    await user.click(screen.getByRole("button"));
+
+    await waitFor(() =>
+      expect(mockToastError).toHaveBeenCalledWith("Delete failed")
+    );
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
 });

--- a/web/src/app/admin/token-rate-limits/TokenRateLimitTables.tsx
+++ b/web/src/app/admin/token-rate-limits/TokenRateLimitTables.tsx
@@ -55,7 +55,7 @@ export const TokenRateLimitTable = ({
 
   const handleEnabledChange = (id: number) => {
     const tokenRateLimit = tokenRateLimits.find(
-      (tokenRateLimit) => tokenRateLimit.token_id === id,
+      (tokenRateLimit) => tokenRateLimit.token_id === id
     );
 
     if (!tokenRateLimit) {
@@ -207,7 +207,7 @@ export const GenericTokenRateLimitTable = ({
 }) => {
   const { data, isLoading, error } = useSWR<TokenRateLimitDisplay[]>(
     fetchUrl,
-    errorHandlingFetcher,
+    errorHandlingFetcher
   );
 
   if (isLoading) {

--- a/web/src/app/admin/token-rate-limits/TokenRateLimitTables.tsx
+++ b/web/src/app/admin/token-rate-limits/TokenRateLimitTables.tsx
@@ -22,8 +22,6 @@ import { Spacer } from "@opal/components";
 const HOURS_PER_DAY = 24;
 const UTC_DAY_LABEL = "UTC day";
 const HOUR_LABEL = "hour";
-const COST_ONLY_LABEL = "Cost only";
-
 function formatPeriod(tokenRateLimit: TokenRateLimitDisplay): string {
   const isTokenBudget = tokenRateLimit.token_budget !== null;
   const value = isTokenBudget
@@ -67,6 +65,7 @@ export const TokenRateLimitTable = ({
     updateTokenRateLimit(id, {
       token_budget: tokenRateLimit.token_budget,
       period_hours: tokenRateLimit.period_hours,
+      cost_budget_cents: tokenRateLimit.cost_budget_cents,
       enabled: !tokenRateLimit.enabled,
     }).then(() => {
       mutate(fetchUrl);
@@ -117,6 +116,7 @@ export const TokenRateLimitTable = ({
             {shouldRenderGroupName() && <TableHead>Group Name</TableHead>}
             <TableHead>Time Window</TableHead>
             <TableHead>Token Budget (Thousands)</TableHead>
+            <TableHead>Cost Budget (USD)</TableHead>
             {isAdmin && <TableHead>Delete</TableHead>}
           </TableRow>
         </TableHeader>
@@ -162,9 +162,15 @@ export const TokenRateLimitTable = ({
                 )}
                 <TableCell>{formatPeriod(tokenRateLimit)}</TableCell>
                 <TableCell>
-                  {tokenRateLimit.token_budget === null
-                    ? COST_ONLY_LABEL
-                    : `${tokenRateLimit.token_budget} thousand tokens`}
+                  {tokenRateLimit.token_budget != null
+                    ? (tokenRateLimit.token_budget * 1000).toLocaleString() +
+                      " tokens"
+                    : "—"}
+                </TableCell>
+                <TableCell>
+                  {tokenRateLimit.cost_budget_cents != null
+                    ? "$" + (tokenRateLimit.cost_budget_cents / 100).toFixed(2)
+                    : "—"}
                 </TableCell>
                 {isAdmin && (
                   <TableCell>

--- a/web/src/app/admin/token-rate-limits/TokenRateLimitTables.tsx
+++ b/web/src/app/admin/token-rate-limits/TokenRateLimitTables.tsx
@@ -55,7 +55,7 @@ export const TokenRateLimitTable = ({
 
   const handleEnabledChange = (id: number) => {
     const tokenRateLimit = tokenRateLimits.find(
-      (tokenRateLimit) => tokenRateLimit.token_id === id
+      (tokenRateLimit) => tokenRateLimit.token_id === id,
     );
 
     if (!tokenRateLimit) {
@@ -115,7 +115,7 @@ export const TokenRateLimitTable = ({
             <TableHead>Enabled</TableHead>
             {shouldRenderGroupName() && <TableHead>Group Name</TableHead>}
             <TableHead>Time Window</TableHead>
-            <TableHead>Token Budget (Thousands)</TableHead>
+            <TableHead>Token Budget</TableHead>
             <TableHead>Cost Budget (USD)</TableHead>
             {isAdmin && <TableHead>Delete</TableHead>}
           </TableRow>
@@ -207,7 +207,7 @@ export const GenericTokenRateLimitTable = ({
 }) => {
   const { data, isLoading, error } = useSWR<TokenRateLimitDisplay[]>(
     fetchUrl,
-    errorHandlingFetcher
+    errorHandlingFetcher,
   );
 
   if (isLoading) {

--- a/web/src/app/admin/token-rate-limits/TokenRateLimitTables.tsx
+++ b/web/src/app/admin/token-rate-limits/TokenRateLimitTables.tsx
@@ -21,14 +21,9 @@ import { Spacer } from "@opal/components";
 
 const HOURS_PER_DAY = 24;
 const UTC_DAY_LABEL = "UTC day";
-const HOUR_LABEL = "hour";
-function formatPeriod(tokenRateLimit: TokenRateLimitDisplay): string {
-  const isTokenBudget = tokenRateLimit.token_budget !== null;
-  const value = isTokenBudget
-    ? tokenRateLimit.period_hours / HOURS_PER_DAY
-    : tokenRateLimit.period_hours;
-  const unit = isTokenBudget ? UTC_DAY_LABEL : HOUR_LABEL;
-  return `${value} ${unit}${value === 1 ? "" : "s"}`;
+export function formatPeriod(tokenRateLimit: TokenRateLimitDisplay): string {
+  const days = tokenRateLimit.period_hours / HOURS_PER_DAY;
+  return `${days} ${UTC_DAY_LABEL}${days === 1 ? "" : "s"}`;
 }
 
 type TokenRateLimitTableArgs = {

--- a/web/src/app/admin/token-rate-limits/TokenRateLimitTables.tsx
+++ b/web/src/app/admin/token-rate-limits/TokenRateLimitTables.tsx
@@ -10,7 +10,7 @@ import {
 import Title from "@/components/ui/title";
 import { DeleteButton } from "@/components/DeleteButton";
 import { deleteTokenRateLimit, updateTokenRateLimit } from "./lib";
-import { PageLoader } from "@opal/layouts";
+import { PageLoader, toast } from "@opal/layouts";
 import { TokenRateLimitDisplay } from "./types";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import useSWR, { mutate } from "swr";
@@ -21,6 +21,9 @@ import { Spacer } from "@opal/components";
 
 const HOURS_PER_DAY = 24;
 const UTC_DAY_LABEL = "UTC day";
+const UPDATE_ERROR_MESSAGE = "Failed to update token rate limit";
+const DELETE_ERROR_MESSAGE = "Failed to delete token rate limit";
+
 export function formatPeriod(tokenRateLimit: TokenRateLimitDisplay): string {
   const days = tokenRateLimit.period_hours / HOURS_PER_DAY;
   return `${days} ${UTC_DAY_LABEL}${days === 1 ? "" : "s"}`;
@@ -48,7 +51,7 @@ export const TokenRateLimitTable = ({
     tokenRateLimits[0] !== undefined &&
     tokenRateLimits[0].group_name !== undefined;
 
-  const handleEnabledChange = (id: number) => {
+  const handleEnabledChange = async (id: number) => {
     const tokenRateLimit = tokenRateLimits.find(
       (tokenRateLimit) => tokenRateLimit.token_id === id
     );
@@ -57,20 +60,31 @@ export const TokenRateLimitTable = ({
       return;
     }
 
-    updateTokenRateLimit(id, {
-      token_budget: tokenRateLimit.token_budget,
-      period_hours: tokenRateLimit.period_hours,
-      cost_budget_cents: tokenRateLimit.cost_budget_cents,
-      enabled: !tokenRateLimit.enabled,
-    }).then(() => {
-      mutate(fetchUrl);
-    });
+    try {
+      await updateTokenRateLimit(id, {
+        token_budget: tokenRateLimit.token_budget,
+        period_hours: tokenRateLimit.period_hours,
+        cost_budget_cents: tokenRateLimit.cost_budget_cents,
+        enabled: !tokenRateLimit.enabled,
+      });
+      await mutate(fetchUrl);
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : UPDATE_ERROR_MESSAGE
+      );
+    }
   };
 
-  const handleDelete = (id: number) =>
-    deleteTokenRateLimit(id).then(() => {
-      mutate(fetchUrl);
-    });
+  const handleDelete = async (id: number) => {
+    try {
+      await deleteTokenRateLimit(id);
+      await mutate(fetchUrl);
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : DELETE_ERROR_MESSAGE
+      );
+    }
+  };
 
   if (tokenRateLimits.length === 0) {
     return (

--- a/web/src/app/admin/token-rate-limits/lib.test.tsx
+++ b/web/src/app/admin/token-rate-limits/lib.test.tsx
@@ -1,0 +1,61 @@
+import {
+  deleteTokenRateLimit,
+  insertGlobalTokenRateLimit,
+  insertGroupTokenRateLimit,
+  insertUserTokenRateLimit,
+  updateTokenRateLimit,
+} from "@/app/admin/token-rate-limits/lib";
+import type { TokenRateLimitArgs } from "@/app/admin/token-rate-limits/types";
+
+const tokenRateLimit: TokenRateLimitArgs = {
+  enabled: true,
+  token_budget: 1,
+  period_hours: 24,
+  cost_budget_cents: null,
+};
+const ERROR_DETAIL = "Database unavailable";
+
+const mutationCases: [string, () => Promise<void>][] = [
+  ["global create", () => insertGlobalTokenRateLimit(tokenRateLimit)],
+  ["user create", () => insertUserTokenRateLimit(tokenRateLimit)],
+  ["group create", () => insertGroupTokenRateLimit(tokenRateLimit, 1)],
+  ["update", () => updateTokenRateLimit(1, tokenRateLimit)],
+  ["delete", () => deleteTokenRateLimit(1)],
+];
+
+describe("token rate limit mutations", () => {
+  const originalFetch = global.fetch;
+  const fetchMock = jest.fn();
+
+  beforeAll(() => {
+    global.fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    fetchMock.mockReset();
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  test.each(mutationCases)(
+    "%s throws the backend detail",
+    async (_, mutate) => {
+      fetchMock.mockResolvedValue({
+        ok: false,
+        json: jest.fn().mockResolvedValue({ detail: ERROR_DETAIL }),
+      } as unknown as Response);
+
+      await expect(mutate()).rejects.toThrow(ERROR_DETAIL);
+    }
+  );
+
+  test("resolves after a successful response", async () => {
+    fetchMock.mockResolvedValue({ ok: true } as Response);
+
+    await expect(
+      insertGlobalTokenRateLimit(tokenRateLimit)
+    ).resolves.toBeUndefined();
+  });
+});

--- a/web/src/app/admin/token-rate-limits/lib.ts
+++ b/web/src/app/admin/token-rate-limits/lib.ts
@@ -1,64 +1,89 @@
+import { parseErrorDetail } from "@/lib/fetcher";
 import { TokenRateLimitArgs } from "./types";
 
 const API_PREFIX = "/api/admin/token-rate-limits";
+const CREATE_ERROR_MESSAGE = "Failed to create token rate limit";
+const UPDATE_ERROR_MESSAGE = "Failed to update token rate limit";
+const DELETE_ERROR_MESSAGE = "Failed to delete token rate limit";
 
 // Global Token Limits
 export const insertGlobalTokenRateLimit = async (
   tokenRateLimit: TokenRateLimitArgs
-) => {
-  return await fetch(`${API_PREFIX}/global`, {
+): Promise<void> => {
+  const response = await fetch(`${API_PREFIX}/global`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
     body: JSON.stringify(tokenRateLimit),
   });
+  if (!response.ok) {
+    throw new Error(await parseErrorDetail(response, CREATE_ERROR_MESSAGE));
+  }
 };
 
 // User Token Limits
 export const insertUserTokenRateLimit = async (
   tokenRateLimit: TokenRateLimitArgs
-) => {
-  return await fetch(`${API_PREFIX}/users`, {
+): Promise<void> => {
+  const response = await fetch(`${API_PREFIX}/users`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
     body: JSON.stringify(tokenRateLimit),
   });
+  if (!response.ok) {
+    throw new Error(await parseErrorDetail(response, CREATE_ERROR_MESSAGE));
+  }
 };
 
 // User Group Token Limits (EE Only)
 export const insertGroupTokenRateLimit = async (
   tokenRateLimit: TokenRateLimitArgs,
   group_id: number
-) => {
-  return await fetch(`${API_PREFIX}/user-group/${group_id}`, {
+): Promise<void> => {
+  const response = await fetch(`${API_PREFIX}/user-group/${group_id}`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
     body: JSON.stringify(tokenRateLimit),
   });
+  if (!response.ok) {
+    throw new Error(await parseErrorDetail(response, CREATE_ERROR_MESSAGE));
+  }
 };
 
 // Common Endpoints
 
-export const deleteTokenRateLimit = async (token_rate_limit_id: number) => {
-  return await fetch(`${API_PREFIX}/rate-limit/${token_rate_limit_id}`, {
-    method: "DELETE",
-  });
+export const deleteTokenRateLimit = async (
+  token_rate_limit_id: number
+): Promise<void> => {
+  const response = await fetch(
+    `${API_PREFIX}/rate-limit/${token_rate_limit_id}`,
+    { method: "DELETE" }
+  );
+  if (!response.ok) {
+    throw new Error(await parseErrorDetail(response, DELETE_ERROR_MESSAGE));
+  }
 };
 
 export const updateTokenRateLimit = async (
   token_rate_limit_id: number,
   tokenRateLimit: TokenRateLimitArgs
-) => {
-  return await fetch(`${API_PREFIX}/rate-limit/${token_rate_limit_id}`, {
-    method: "PUT",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(tokenRateLimit),
-  });
+): Promise<void> => {
+  const response = await fetch(
+    `${API_PREFIX}/rate-limit/${token_rate_limit_id}`,
+    {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(tokenRateLimit),
+    }
+  );
+  if (!response.ok) {
+    throw new Error(await parseErrorDetail(response, UPDATE_ERROR_MESSAGE));
+  }
 };

--- a/web/src/app/admin/token-rate-limits/page.tsx
+++ b/web/src/app/admin/token-rate-limits/page.tsx
@@ -40,13 +40,15 @@ const USER_GROUP_DESCRIPTION =
 const handleCreateTokenRateLimit = async (
   target_scope: Scope,
   period_hours: number,
-  token_budget: number,
+  token_budget: number | null,
+  cost_budget_cents: number | null,
   group_id: number = -1
 ) => {
   const tokenRateLimitArgs = {
     enabled: true,
     token_budget: token_budget,
     period_hours: period_hours,
+    cost_budget_cents: cost_budget_cents,
   };
 
   if (target_scope === Scope.GLOBAL) {
@@ -82,13 +84,15 @@ function Main() {
   const handleSubmit = (
     target_scope: Scope,
     period_hours: number,
-    token_budget: number,
+    token_budget: number | null,
+    cost_budget_cents: number | null,
     group_id: number = -1
   ) => {
     handleCreateTokenRateLimit(
       target_scope,
       period_hours,
       token_budget,
+      cost_budget_cents,
       group_id
     )
       .then(() => {

--- a/web/src/app/admin/token-rate-limits/page.tsx
+++ b/web/src/app/admin/token-rate-limits/page.tsx
@@ -36,6 +36,7 @@ const USER_GROUP_DESCRIPTION =
   all users in the group will be temporarily blocked from spending tokens, regardless \
   of their individual limits. If a user is in multiple groups, the most lenient limit \
   will apply.";
+const CREATE_ERROR_MESSAGE = "Failed to create token rate limit";
 
 const handleCreateTokenRateLimit = async (
   target_scope: Scope,
@@ -43,7 +44,7 @@ const handleCreateTokenRateLimit = async (
   token_budget: number | null,
   cost_budget_cents: number | null,
   group_id: number = -1
-) => {
+): Promise<void> => {
   const tokenRateLimitArgs = {
     enabled: true,
     token_budget: token_budget,
@@ -52,14 +53,21 @@ const handleCreateTokenRateLimit = async (
   };
 
   if (target_scope === Scope.GLOBAL) {
-    return await insertGlobalTokenRateLimit(tokenRateLimitArgs);
-  } else if (target_scope === Scope.USER) {
-    return await insertUserTokenRateLimit(tokenRateLimitArgs);
-  } else if (target_scope === Scope.USER_GROUP) {
-    return await insertGroupTokenRateLimit(tokenRateLimitArgs, group_id);
-  } else {
-    throw new Error(`Invalid target_scope: ${target_scope}`);
+    await insertGlobalTokenRateLimit(tokenRateLimitArgs);
+    return;
   }
+
+  if (target_scope === Scope.USER) {
+    await insertUserTokenRateLimit(tokenRateLimitArgs);
+    return;
+  }
+
+  if (target_scope === Scope.USER_GROUP) {
+    await insertGroupTokenRateLimit(tokenRateLimitArgs, group_id);
+    return;
+  }
+
+  throw new Error(`Invalid target_scope: ${target_scope}`);
 };
 
 function Main() {
@@ -81,28 +89,29 @@ function Main() {
     }
   };
 
-  const handleSubmit = (
+  const handleSubmit = async (
     target_scope: Scope,
     period_hours: number,
     token_budget: number | null,
     cost_budget_cents: number | null,
     group_id: number = -1
-  ) => {
-    handleCreateTokenRateLimit(
-      target_scope,
-      period_hours,
-      token_budget,
-      cost_budget_cents,
-      group_id
-    )
-      .then(() => {
-        setModalIsOpen(false);
-        toast.success("Token rate limit created!");
-        updateTable(target_scope);
-      })
-      .catch((error) => {
-        toast.error(error.message);
-      });
+  ): Promise<void> => {
+    try {
+      await handleCreateTokenRateLimit(
+        target_scope,
+        period_hours,
+        token_budget,
+        cost_budget_cents,
+        group_id
+      );
+      setModalIsOpen(false);
+      toast.success("Token rate limit created!");
+      updateTable(target_scope);
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : CREATE_ERROR_MESSAGE
+      );
+    }
   };
 
   return (

--- a/web/src/app/admin/token-rate-limits/types.ts
+++ b/web/src/app/admin/token-rate-limits/types.ts
@@ -8,6 +8,8 @@ export interface TokenRateLimitArgs {
   enabled: boolean;
   token_budget: number | null;
   period_hours: number;
+  // Cents at the API boundary; the UI collects dollars and converts.
+  cost_budget_cents?: number | null;
 }
 
 export interface TokenRateLimit {
@@ -15,6 +17,7 @@ export interface TokenRateLimit {
   enabled: boolean;
   token_budget: number | null;
   period_hours: number;
+  cost_budget_cents: number | null;
 }
 
 export interface TokenRateLimitDisplay extends TokenRateLimit {

--- a/web/src/app/app/interfaces.ts
+++ b/web/src/app/app/interfaces.ts
@@ -305,6 +305,18 @@ export interface StreamingError {
   details?: Record<string, any>;
 }
 
+// error_code emitted by the backend usage rate-limiter (429). Branch on this to
+// show the dedicated usage-limit banner instead of the generic chat error.
+export const RATE_LIMITED_ERROR_CODE = "RATE_LIMITED";
+
+// Shape of StreamingError.details for a RATE_LIMITED error — mirrors the 429
+// JSON body so the banner can compute a human-friendly reset time.
+export interface RateLimitDetails {
+  scope?: string;
+  reset_at?: string; // ISO timestamp
+  retry_after_seconds?: number;
+}
+
 export interface InputPrompt {
   id: number;
   prompt: string;

--- a/web/src/app/app/message/Resubmit.test.tsx
+++ b/web/src/app/app/message/Resubmit.test.tsx
@@ -1,0 +1,32 @@
+import { act, render, screen } from "@tests/setup/test-utils";
+import { ErrorBanner } from "@/app/app/message/Resubmit";
+import { RATE_LIMITED_ERROR_CODE } from "@/app/app/interfaces";
+
+describe("rate-limit error banner", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-07-28T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test("updates when the reset time is reached", () => {
+    render(
+      <ErrorBanner
+        error="You've reached the usage budget for your account."
+        errorCode={RATE_LIMITED_ERROR_CODE}
+        details={{ reset_at: "2026-07-28T12:00:30Z" }}
+      />
+    );
+
+    expect(screen.getByText(/Resets in 1 minute/)).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(30_000);
+    });
+
+    expect(screen.getByText("You can try again now.")).toBeInTheDocument();
+  });
+});

--- a/web/src/app/app/message/Resubmit.tsx
+++ b/web/src/app/app/message/Resubmit.tsx
@@ -4,6 +4,52 @@ import { SvgChevronDown, SvgChevronRight } from "@opal/icons";
 import { Button } from "@opal/components";
 import { CopyButton } from "@opal/components";
 import { getErrorIcon, getErrorTitle } from "./errorHelpers";
+import {
+  RateLimitDetails,
+  RATE_LIMITED_ERROR_CODE,
+} from "@/app/app/interfaces";
+
+// Turn a 429's reset_at / retry_after_seconds into a human-friendly sentence.
+// Returns null if neither field is present (banner falls back to the detail).
+function formatRateLimitReset(details: RateLimitDetails): string | null {
+  const resetMs = resolveResetMs(details);
+  if (resetMs === null) return null;
+
+  const remainingMs = resetMs - Date.now();
+  if (remainingMs <= 0) return "You can try again now.";
+
+  const plural = (n: number, unit: string) => `${n} ${unit}${n === 1 ? "" : "s"}`;
+  const minutes = Math.ceil(remainingMs / 60_000);
+  const hours = Math.ceil(remainingMs / 3_600_000);
+  const days = Math.ceil(remainingMs / 86_400_000);
+  const relative =
+    minutes < 60
+      ? plural(minutes, "minute")
+      : hours < 48
+        ? plural(hours, "hour")
+        : plural(days, "day");
+  const resetDate = new Date(resetMs);
+  // For multi-day resets a date is clearer than just a clock time.
+  const at =
+    days >= 2
+      ? resetDate.toLocaleDateString(undefined, { month: "short", day: "numeric" })
+      : resetDate.toLocaleTimeString(undefined, {
+          hour: "numeric",
+          minute: "2-digit",
+        });
+  return `Resets in ${relative} (${at}).`;
+}
+
+function resolveResetMs(details: RateLimitDetails): number | null {
+  if (details.reset_at) {
+    const parsed = Date.parse(details.reset_at);
+    if (!Number.isNaN(parsed)) return parsed;
+  }
+  if (typeof details.retry_after_seconds === "number") {
+    return Date.now() + details.retry_after_seconds * 1000;
+  }
+  return null;
+}
 
 interface ResubmitProps {
   resubmit: () => void;
@@ -36,6 +82,26 @@ export const ErrorBanner = ({
   resubmit?: () => void;
 }) => {
   const [isStackTraceExpanded, setIsStackTraceExpanded] = useState(false);
+
+  // Usage rate-limit (429): a focused banner with a reset time and no
+  // Regenerate affordance — retrying would just re-trip the same limit.
+  if (errorCode === RATE_LIMITED_ERROR_CODE) {
+    const resetLine = formatRateLimitReset((details as RateLimitDetails) ?? {});
+    return (
+      <div className="text-red-700 mt-4 text-sm my-auto">
+        <Alert variant="broken">
+          {getErrorIcon(errorCode)}
+          <AlertTitle>{getErrorTitle(errorCode)}</AlertTitle>
+          <AlertDescription className="flex flex-col gap-y-1">
+            <span>{error || "You've reached your usage limit."}</span>
+            {resetLine && (
+              <span className="text-xs text-muted-foreground">{resetLine}</span>
+            )}
+          </AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
 
   return (
     <div className="text-red-700 mt-4 text-sm my-auto">

--- a/web/src/app/app/message/Resubmit.tsx
+++ b/web/src/app/app/message/Resubmit.tsx
@@ -18,7 +18,8 @@ function formatRateLimitReset(details: RateLimitDetails): string | null {
   const remainingMs = resetMs - Date.now();
   if (remainingMs <= 0) return "You can try again now.";
 
-  const plural = (n: number, unit: string) => `${n} ${unit}${n === 1 ? "" : "s"}`;
+  const plural = (n: number, unit: string) =>
+    `${n} ${unit}${n === 1 ? "" : "s"}`;
   const minutes = Math.ceil(remainingMs / 60_000);
   const hours = Math.ceil(remainingMs / 3_600_000);
   const days = Math.ceil(remainingMs / 86_400_000);
@@ -32,7 +33,10 @@ function formatRateLimitReset(details: RateLimitDetails): string | null {
   // For multi-day resets a date is clearer than just a clock time.
   const at =
     days >= 2
-      ? resetDate.toLocaleDateString(undefined, { month: "short", day: "numeric" })
+      ? resetDate.toLocaleDateString(undefined, {
+          month: "short",
+          day: "numeric",
+        })
       : resetDate.toLocaleTimeString(undefined, {
           hour: "numeric",
           minute: "2-digit",

--- a/web/src/app/app/message/Resubmit.tsx
+++ b/web/src/app/app/message/Resubmit.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { SvgChevronDown, SvgChevronRight } from "@opal/icons";
 import { Button } from "@opal/components";
@@ -9,13 +9,10 @@ import {
   RATE_LIMITED_ERROR_CODE,
 } from "@/app/app/interfaces";
 
-// Turn a 429's reset_at / retry_after_seconds into a human-friendly sentence.
-// Returns null if neither field is present (banner falls back to the detail).
-function formatRateLimitReset(details: RateLimitDetails): string | null {
-  const resetMs = resolveResetMs(details);
-  if (resetMs === null) return null;
+const COUNTDOWN_TICK_MS = 1_000;
 
-  const remainingMs = resetMs - Date.now();
+function formatRateLimitReset(resetMs: number, nowMs: number): string {
+  const remainingMs = resetMs - nowMs;
   if (remainingMs <= 0) return "You can try again now.";
 
   const plural = (n: number, unit: string) =>
@@ -44,15 +41,60 @@ function formatRateLimitReset(details: RateLimitDetails): string | null {
   return `Resets in ${relative} (${at}).`;
 }
 
-function resolveResetMs(details: RateLimitDetails): number | null {
-  if (details.reset_at) {
-    const parsed = Date.parse(details.reset_at);
+function resolveResetMs(
+  resetAt?: string,
+  retryAfterSeconds?: number
+): number | null {
+  if (resetAt) {
+    const parsed = Date.parse(resetAt);
     if (!Number.isNaN(parsed)) return parsed;
   }
-  if (typeof details.retry_after_seconds === "number") {
-    return Date.now() + details.retry_after_seconds * 1000;
+  if (typeof retryAfterSeconds === "number") {
+    return Date.now() + retryAfterSeconds * 1_000;
   }
   return null;
+}
+
+interface RateLimitBannerProps {
+  error: string;
+  errorCode: string;
+  details: RateLimitDetails;
+}
+
+function RateLimitBanner({ error, errorCode, details }: RateLimitBannerProps) {
+  const [nowMs, setNowMs] = useState(Date.now());
+  const resetMs = useMemo(
+    () => resolveResetMs(details.reset_at, details.retry_after_seconds),
+    [details.reset_at, details.retry_after_seconds]
+  );
+
+  useEffect(() => {
+    if (resetMs === null) return;
+
+    setNowMs(Date.now());
+    const interval = window.setInterval(
+      () => setNowMs(Date.now()),
+      COUNTDOWN_TICK_MS
+    );
+    return () => window.clearInterval(interval);
+  }, [resetMs]);
+
+  const resetLine =
+    resetMs === null ? null : formatRateLimitReset(resetMs, nowMs);
+  return (
+    <div className="text-red-700 mt-4 text-sm my-auto">
+      <Alert variant="broken">
+        {getErrorIcon(errorCode)}
+        <AlertTitle>{getErrorTitle(errorCode)}</AlertTitle>
+        <AlertDescription className="flex flex-col gap-y-1">
+          <span>{error || "You've reached your usage limit."}</span>
+          {resetLine && (
+            <span className="text-xs text-muted-foreground">{resetLine}</span>
+          )}
+        </AlertDescription>
+      </Alert>
+    </div>
+  );
 }
 
 interface ResubmitProps {
@@ -87,23 +129,13 @@ export const ErrorBanner = ({
 }) => {
   const [isStackTraceExpanded, setIsStackTraceExpanded] = useState(false);
 
-  // Usage rate-limit (429): a focused banner with a reset time and no
-  // Regenerate affordance — retrying would just re-trip the same limit.
   if (errorCode === RATE_LIMITED_ERROR_CODE) {
-    const resetLine = formatRateLimitReset((details as RateLimitDetails) ?? {});
     return (
-      <div className="text-red-700 mt-4 text-sm my-auto">
-        <Alert variant="broken">
-          {getErrorIcon(errorCode)}
-          <AlertTitle>{getErrorTitle(errorCode)}</AlertTitle>
-          <AlertDescription className="flex flex-col gap-y-1">
-            <span>{error || "You've reached your usage limit."}</span>
-            {resetLine && (
-              <span className="text-xs text-muted-foreground">{resetLine}</span>
-            )}
-          </AlertDescription>
-        </Alert>
-      </div>
+      <RateLimitBanner
+        error={error}
+        errorCode={errorCode}
+        details={(details as RateLimitDetails) ?? {}}
+      />
     );
   }
 

--- a/web/src/app/app/message/errorHelpers.tsx
+++ b/web/src/app/app/message/errorHelpers.tsx
@@ -6,6 +6,7 @@ import { AlertCircle, Clock, Lock, Wifi, Server } from "lucide-react";
 export const getErrorIcon = (errorCode?: string) => {
   switch (errorCode) {
     case "RATE_LIMIT":
+    case "RATE_LIMITED":
       return <Clock className="h-4 w-4" />;
     case "AUTH_ERROR":
     case "PERMISSION_DENIED":
@@ -28,6 +29,8 @@ export const getErrorTitle = (errorCode?: string) => {
   switch (errorCode) {
     case "RATE_LIMIT":
       return "Rate Limit Exceeded";
+    case "RATE_LIMITED":
+      return "Usage limit reached";
     case "AUTH_ERROR":
       return "Authentication Error";
     case "PERMISSION_DENIED":

--- a/web/src/app/app/services/lib.tsx
+++ b/web/src/app/app/services/lib.tsx
@@ -14,6 +14,8 @@ import {
   Message,
   MessageResponseIDInfo,
   MultiModelMessageResponseIDInfo,
+  RateLimitDetails,
+  RATE_LIMITED_ERROR_CODE,
   ResearchType,
   RetrievalType,
   StreamingError,
@@ -215,6 +217,31 @@ export async function* sendMessage({
 
   if (!response.ok) {
     const data = await response.json().catch(() => ({}));
+
+    // Surface the usage rate-limit (429) as a structured StreamingError packet
+    // so the chat UI can render the dedicated usage-limit banner. Throwing a
+    // bare Error here would flatten error_code/reset_at into an opaque string.
+    if (
+      response.status === 429 &&
+      data.error_code === RATE_LIMITED_ERROR_CODE
+    ) {
+      const rateLimitDetails: RateLimitDetails = {
+        scope: data.scope,
+        reset_at: data.reset_at,
+        retry_after_seconds: data.retry_after_seconds,
+      };
+      const streamingError: StreamingError = {
+        error: data.detail ?? "You've reached your usage limit.",
+        stack_trace: "",
+        error_code: RATE_LIMITED_ERROR_CODE,
+        // Regenerate would just re-trip the limit, so this is not retryable.
+        is_retryable: false,
+        details: rateLimitDetails,
+      };
+      yield streamingError;
+      return;
+    }
+
     throw new Error(data.detail ?? `HTTP error! status: ${response.status}`);
   }
 

--- a/web/src/app/app/settings/layout.tsx
+++ b/web/src/app/app/settings/layout.tsx
@@ -36,6 +36,7 @@ export default function Layout({ children }: LayoutProps) {
       ? [{ href: "/app/settings/accounts-access", label: "Accounts & Access" }]
       : []),
     { href: "/app/settings/connectors", label: "Connectors" },
+    { href: "/app/settings/usage", label: "Usage" },
   ];
 
   // Derive the trigger label from the pathname directly. InputSelect normally

--- a/web/src/app/app/settings/usage/UsageSettings.tsx
+++ b/web/src/app/app/settings/usage/UsageSettings.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Section } from "@/layouts/general-layouts";
 import { Content } from "@opal/layouts";
 import { Text, EmptyMessageCard, Divider } from "@opal/components";
@@ -9,14 +9,20 @@ import {
   SvgWallet,
   SvgCreditCard,
   SvgSimpleLoader,
+  SvgChevronRight,
 } from "@opal/icons";
 import InputSelect from "@/refresh-components/inputs/InputSelect";
 import Card from "@/refresh-components/cards/Card";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/refresh-components/Collapsible";
 import { cn } from "@opal/utils";
 import {
   useUserUsage,
   type UsagePerDayByModel,
-  type SelectedModelPrice,
+  type ModelPrice,
 } from "@/app/app/settings/usage/lib";
 
 const DAYS_OPTIONS = ["7", "30"] as const;
@@ -118,41 +124,119 @@ function WindowCostSection({ windowCostCents, rows }: WindowCostSectionProps) {
 }
 
 interface ModelPriceSectionProps {
-  price: SelectedModelPrice | null;
+  prices: ModelPrice[];
+  defaultModel: string | null;
 }
 
-function ModelPriceSection({ price }: ModelPriceSectionProps) {
+function formatMtok(value: number | null): string {
+  return value !== null ? `$${value.toFixed(2)}` : "—";
+}
+
+// Every available model's price (USD/1M, input · output · cache), grouped into a
+// collapsible menu per provider — click a provider to expand its models. Mirrors
+// the chat model selector so users can compare costs, not just the default.
+function ModelPriceSection({ prices, defaultModel }: ModelPriceSectionProps) {
+  const groups = useMemo(() => {
+    const byProvider = new Map<string, ModelPrice[]>();
+    for (const price of prices) {
+      const key = price.provider ?? "Other";
+      const list = byProvider.get(key) ?? [];
+      list.push(price);
+      byProvider.set(key, list);
+    }
+    return Array.from(byProvider.entries())
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([provider, models]) => ({ provider, models }));
+  }, [prices]);
+
+  // Expand the provider that holds the default model (else the first).
+  const defaultProvider = useMemo(
+    () =>
+      prices.find((p) => p.model === defaultModel)?.provider ??
+      groups[0]?.provider ??
+      null,
+    [prices, defaultModel, groups],
+  );
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  useEffect(() => {
+    if (defaultProvider) setExpanded(new Set([defaultProvider]));
+  }, [defaultProvider]);
+
+  function toggle(provider: string) {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(provider)) next.delete(provider);
+      else next.add(provider);
+      return next;
+    });
+  }
+
   return (
     <Section gap={0.75} justifyContent="start">
       <Content
         icon={SvgCreditCard}
-        title="Your model's price"
+        title="Model prices"
+        description="USD per 1M tokens (input · output · cache) for every available model"
         sizePreset="main-content"
         variant="section"
         width="full"
       />
       <Card>
-        {price &&
-        price.input_per_mtok !== null &&
-        price.output_per_mtok !== null ? (
-          <Section
-            flexDirection="row"
-            justifyContent="between"
-            alignItems="center"
-            width="full"
-            gap={1}
-          >
-            <Text font="main-ui-body" color="text-03">
-              {`$${price.input_per_mtok.toFixed(2)} / 1M input`}
-            </Text>
-            <Text font="main-ui-body" color="text-03">
-              {`$${price.output_per_mtok.toFixed(2)} / 1M output`}
-            </Text>
-          </Section>
-        ) : (
+        {groups.length === 0 ? (
           <Text font="main-ui-body" color="text-01">
-            Price unavailable
+            Prices unavailable
           </Text>
+        ) : (
+          <Section gap={0.25} alignItems="stretch" justifyContent="start">
+            {groups.map(({ provider, models }) => {
+              const open = expanded.has(provider);
+              return (
+                <Collapsible
+                  key={provider}
+                  open={open}
+                  onOpenChange={() => toggle(provider)}
+                  className="flex flex-col"
+                >
+                  <CollapsibleTrigger asChild>
+                    <div className="flex flex-row items-center justify-between cursor-pointer select-none py-1.5">
+                      <Text font="main-ui-action" color="text-03">
+                        {provider}
+                      </Text>
+                      <SvgChevronRight
+                        className={cn(
+                          "w-4 h-4 text-text-03 transition-transform",
+                          open && "rotate-90",
+                        )}
+                      />
+                    </div>
+                  </CollapsibleTrigger>
+                  <CollapsibleContent>
+                    <Section gap={0} alignItems="stretch" justifyContent="start">
+                      {models.map((price) => (
+                        <div
+                          key={`${provider}-${price.model}`}
+                          className="flex flex-row items-center justify-between gap-2 py-1 pl-3"
+                        >
+                          <Text font="secondary-body" color="text-03" nowrap>
+                            {price.model === defaultModel
+                              ? `${price.model} · default`
+                              : price.model}
+                          </Text>
+                          <Text font="secondary-body" color="text-01" nowrap>
+                            {`${formatMtok(price.input_per_mtok)} in · ${formatMtok(
+                              price.output_per_mtok,
+                            )} out · ${formatMtok(
+                              price.cache_per_mtok ?? price.input_per_mtok,
+                            )} cache`}
+                          </Text>
+                        </div>
+                      ))}
+                    </Section>
+                  </CollapsibleContent>
+                </Collapsible>
+              );
+            })}
+          </Section>
         )}
       </Card>
     </Section>
@@ -299,11 +383,14 @@ export default function UsageSettings() {
               windowCostCents={data.window_cost_cents}
               rows={data.per_day_by_model}
             />
-            <ModelPriceSection price={data.selected_model_price} />
             <BudgetSection
               budgetCents={data.budget_cents}
               budgetRemainingCents={data.budget_remaining_cents}
               budgetPeriodHours={data.budget_period_hours}
+            />
+            <ModelPriceSection
+              prices={data.available_model_prices ?? []}
+              defaultModel={data.selected_model_price?.model ?? null}
             />
           </Section>
         )}

--- a/web/src/app/app/settings/usage/UsageSettings.tsx
+++ b/web/src/app/app/settings/usage/UsageSettings.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Section } from "@/layouts/general-layouts";
 import { Content } from "@opal/layouts";
 import { Text, EmptyMessageCard, Divider } from "@opal/components";
@@ -39,7 +39,7 @@ function WindowCostSection({ windowCostCents, rows }: WindowCostSectionProps) {
   // Drives the relative bar widths in the breakdown.
   const maxRowCost = rows.reduce(
     (max, row) => Math.max(max, row.cost_cents),
-    0
+    0,
   );
   const hasCache = rows.some((row) => row.cache_read_tokens > 0);
 
@@ -101,7 +101,7 @@ function WindowCostSection({ windowCostCents, rows }: WindowCostSectionProps) {
 
                 <Text font="secondary-body" color="text-01">
                   {`${formatTokens(row.input_tokens)} in · ${formatTokens(
-                    row.output_tokens
+                    row.output_tokens,
                   )} out${
                     hasCache
                       ? ` · ${formatTokens(row.cache_read_tokens)} cache`
@@ -184,7 +184,7 @@ function BudgetSection({
   budgetRemainingCents,
   budgetPeriodHours,
 }: BudgetSectionProps) {
-  // budget_* are null until P5 enforcement ships; show a graceful empty state.
+  // budget_* are null when the user has no cost limit; show a graceful empty state.
   const hasBudget = budgetCents !== null;
   const remaining = budgetRemainingCents ?? 0;
   const spent = hasBudget ? Math.max(0, budgetCents - remaining) : 0;
@@ -215,7 +215,9 @@ function BudgetSection({
               </Text>
               <Text font="secondary-body" color="text-01">
                 {`of ${formatDollars(budgetCents)}${
-                  budgetPeriodHours ? ` per ${formatPeriod(budgetPeriodHours)}` : ""
+                  budgetPeriodHours
+                    ? ` per ${formatPeriod(budgetPeriodHours)}`
+                    : ""
                 }`}
               </Text>
             </Section>
@@ -225,7 +227,7 @@ function BudgetSection({
                   "h-full rounded-full",
                   usedFraction >= 1
                     ? "bg-status-error-05"
-                    : "bg-theme-primary-05"
+                    : "bg-theme-primary-05",
                 )}
                 style={{ width: `${usedFraction * 100}%` }}
               />
@@ -244,6 +246,10 @@ function BudgetSection({
 export default function UsageSettings() {
   const [days, setDays] = useState<string>(String(DEFAULT_DAYS));
   const { data, error, isLoading } = useUserUsage(Number(days));
+
+  useEffect(() => {
+    if (error) console.error("Failed to load usage", error);
+  }, [error]);
 
   return (
     <Section gap={2}>

--- a/web/src/app/app/settings/usage/UsageSettings.tsx
+++ b/web/src/app/app/settings/usage/UsageSettings.tsx
@@ -1,0 +1,307 @@
+"use client";
+
+import { useState } from "react";
+import { Section } from "@/layouts/general-layouts";
+import { Content } from "@opal/layouts";
+import { Text, EmptyMessageCard, Divider } from "@opal/components";
+import {
+  SvgBarChart,
+  SvgWallet,
+  SvgCreditCard,
+  SvgSimpleLoader,
+} from "@opal/icons";
+import InputSelect from "@/refresh-components/inputs/InputSelect";
+import Card from "@/refresh-components/cards/Card";
+import { cn } from "@opal/utils";
+import {
+  useUserUsage,
+  type UsagePerDayByModel,
+  type SelectedModelPrice,
+} from "@/app/app/settings/usage/lib";
+
+const DAYS_OPTIONS = ["7", "30"] as const;
+const DEFAULT_DAYS = 30;
+
+function formatDollars(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+function formatTokens(tokens: number): string {
+  return tokens.toLocaleString();
+}
+
+interface WindowCostSectionProps {
+  windowCostCents: number;
+  rows: UsagePerDayByModel[];
+}
+
+function WindowCostSection({ windowCostCents, rows }: WindowCostSectionProps) {
+  // Drives the relative bar widths in the breakdown.
+  const maxRowCost = rows.reduce(
+    (max, row) => Math.max(max, row.cost_cents),
+    0
+  );
+  const hasCache = rows.some((row) => row.cache_read_tokens > 0);
+
+  return (
+    <Section gap={0.75} justifyContent="start">
+      <Content
+        icon={SvgBarChart}
+        title="Usage this period"
+        description={`${formatDollars(windowCostCents)} spent`}
+        sizePreset="main-content"
+        variant="section"
+        width="full"
+      />
+
+      {rows.length === 0 ? (
+        <EmptyMessageCard
+          sizePreset="main-ui"
+          title="No usage recorded yet"
+          description="Your model usage and costs will show up here once you start chatting."
+        />
+      ) : (
+        <Card>
+          {rows.map((row, index) => (
+            <div key={`${row.day}-${row.model}`}>
+              {index > 0 && <Divider />}
+              <Section gap={0.5} alignItems="start" justifyContent="start">
+                <Section
+                  flexDirection="row"
+                  justifyContent="between"
+                  alignItems="center"
+                  width="full"
+                  gap={1}
+                >
+                  <Section gap={0} alignItems="start" justifyContent="start">
+                    <Text font="main-ui-action" color="text-03">
+                      {row.model}
+                    </Text>
+                    <Text font="secondary-body" color="text-01">
+                      {row.day}
+                    </Text>
+                  </Section>
+                  <Text font="main-ui-action" color="text-03" nowrap>
+                    {formatDollars(row.cost_cents)}
+                  </Text>
+                </Section>
+
+                {/* Cost bar — proportional to the priciest row in the window. */}
+                <div className="w-full h-1.5 rounded-full bg-background-neutral-03 overflow-hidden">
+                  <div
+                    className="h-full rounded-full bg-theme-primary-05"
+                    style={{
+                      width:
+                        maxRowCost > 0
+                          ? `${Math.max(2, (row.cost_cents / maxRowCost) * 100)}%`
+                          : "0%",
+                    }}
+                  />
+                </div>
+
+                <Text font="secondary-body" color="text-01">
+                  {`${formatTokens(row.input_tokens)} in · ${formatTokens(
+                    row.output_tokens
+                  )} out${
+                    hasCache
+                      ? ` · ${formatTokens(row.cache_read_tokens)} cache`
+                      : ""
+                  }`}
+                </Text>
+              </Section>
+            </div>
+          ))}
+        </Card>
+      )}
+    </Section>
+  );
+}
+
+interface ModelPriceSectionProps {
+  price: SelectedModelPrice | null;
+}
+
+function ModelPriceSection({ price }: ModelPriceSectionProps) {
+  return (
+    <Section gap={0.75} justifyContent="start">
+      <Content
+        icon={SvgCreditCard}
+        title="Your model's price"
+        sizePreset="main-content"
+        variant="section"
+        width="full"
+      />
+      <Card>
+        {price &&
+        price.input_per_mtok !== null &&
+        price.output_per_mtok !== null ? (
+          <Section
+            flexDirection="row"
+            justifyContent="between"
+            alignItems="center"
+            width="full"
+            gap={1}
+          >
+            <Text font="main-ui-body" color="text-03">
+              {`$${price.input_per_mtok.toFixed(2)} / 1M input`}
+            </Text>
+            <Text font="main-ui-body" color="text-03">
+              {`$${price.output_per_mtok.toFixed(2)} / 1M output`}
+            </Text>
+          </Section>
+        ) : (
+          <Text font="main-ui-body" color="text-01">
+            Price unavailable
+          </Text>
+        )}
+      </Card>
+    </Section>
+  );
+}
+
+interface BudgetSectionProps {
+  budgetCents: number | null;
+  budgetRemainingCents: number | null;
+  budgetPeriodHours: number | null;
+}
+
+// Hours -> a friendly window label so the budget reads "per week", not "per 168h".
+function formatPeriod(hours: number | null): string {
+  if (hours == null) return "";
+  if (hours % 168 === 0) {
+    const w = hours / 168;
+    return w === 1 ? "week" : `${w} weeks`;
+  }
+  if (hours % 24 === 0) {
+    const d = hours / 24;
+    return d === 1 ? "day" : `${d} days`;
+  }
+  return hours === 1 ? "hour" : `${hours} hours`;
+}
+
+function BudgetSection({
+  budgetCents,
+  budgetRemainingCents,
+  budgetPeriodHours,
+}: BudgetSectionProps) {
+  // budget_* are null until P5 enforcement ships; show a graceful empty state.
+  const hasBudget = budgetCents !== null;
+  const remaining = budgetRemainingCents ?? 0;
+  const spent = hasBudget ? Math.max(0, budgetCents - remaining) : 0;
+  const usedFraction =
+    hasBudget && budgetCents > 0 ? Math.min(1, spent / budgetCents) : 0;
+
+  return (
+    <Section gap={0.75} justifyContent="start">
+      <Content
+        icon={SvgWallet}
+        title="Budget"
+        sizePreset="main-content"
+        variant="section"
+        width="full"
+      />
+      <Card>
+        {hasBudget ? (
+          <Section gap={0.5} alignItems="start" justifyContent="start">
+            <Section
+              flexDirection="row"
+              justifyContent="between"
+              alignItems="center"
+              width="full"
+              gap={1}
+            >
+              <Text font="main-ui-body" color="text-03">
+                {`${formatDollars(remaining)} remaining`}
+              </Text>
+              <Text font="secondary-body" color="text-01">
+                {`of ${formatDollars(budgetCents)}${
+                  budgetPeriodHours ? ` per ${formatPeriod(budgetPeriodHours)}` : ""
+                }`}
+              </Text>
+            </Section>
+            <div className="w-full h-1.5 rounded-full bg-background-neutral-03 overflow-hidden">
+              <div
+                className={cn(
+                  "h-full rounded-full",
+                  usedFraction >= 1
+                    ? "bg-status-error-05"
+                    : "bg-theme-primary-05"
+                )}
+                style={{ width: `${usedFraction * 100}%` }}
+              />
+            </div>
+          </Section>
+        ) : (
+          <Text font="main-ui-body" color="text-01">
+            No budget set
+          </Text>
+        )}
+      </Card>
+    </Section>
+  );
+}
+
+export default function UsageSettings() {
+  const [days, setDays] = useState<string>(String(DEFAULT_DAYS));
+  const { data, error, isLoading } = useUserUsage(Number(days));
+
+  return (
+    <Section gap={2}>
+      <Section gap={0.75} justifyContent="start">
+        <Section
+          flexDirection="row"
+          justifyContent="between"
+          alignItems="center"
+          width="full"
+          gap={1}
+        >
+          <Content title="Usage" sizePreset="main-content" variant="section" />
+          <div className="min-w-32">
+            <InputSelect value={days} onValueChange={setDays}>
+              <InputSelect.Trigger placeholder="Period" />
+              <InputSelect.Content>
+                {DAYS_OPTIONS.map((option) => (
+                  <InputSelect.Item key={option} value={option}>
+                    {`Last ${option} days`}
+                  </InputSelect.Item>
+                ))}
+              </InputSelect.Content>
+            </InputSelect>
+          </div>
+        </Section>
+
+        {isLoading ? (
+          <Card>
+            <Section
+              flexDirection="row"
+              justifyContent="center"
+              alignItems="center"
+              width="full"
+            >
+              <SvgSimpleLoader />
+            </Section>
+          </Card>
+        ) : error || !data ? (
+          <EmptyMessageCard
+            sizePreset="main-ui"
+            title="Couldn't load usage"
+            description="Something went wrong fetching your usage. Try again in a moment."
+          />
+        ) : (
+          <Section gap={2}>
+            <WindowCostSection
+              windowCostCents={data.window_cost_cents}
+              rows={data.per_day_by_model}
+            />
+            <ModelPriceSection price={data.selected_model_price} />
+            <BudgetSection
+              budgetCents={data.budget_cents}
+              budgetRemainingCents={data.budget_remaining_cents}
+              budgetPeriodHours={data.budget_period_hours}
+            />
+          </Section>
+        )}
+      </Section>
+    </Section>
+  );
+}

--- a/web/src/app/app/settings/usage/UsageSettings.tsx
+++ b/web/src/app/app/settings/usage/UsageSettings.tsx
@@ -45,7 +45,7 @@ function WindowCostSection({ windowCostCents, rows }: WindowCostSectionProps) {
   // Drives the relative bar widths in the breakdown.
   const maxRowCost = rows.reduce(
     (max, row) => Math.max(max, row.cost_cents),
-    0,
+    0
   );
   const hasCache = rows.some((row) => row.cache_read_tokens > 0);
 
@@ -107,7 +107,7 @@ function WindowCostSection({ windowCostCents, rows }: WindowCostSectionProps) {
 
                 <Text font="secondary-body" color="text-01">
                   {`${formatTokens(row.input_tokens)} in · ${formatTokens(
-                    row.output_tokens,
+                    row.output_tokens
                   )} out${
                     hasCache
                       ? ` · ${formatTokens(row.cache_read_tokens)} cache`
@@ -155,7 +155,7 @@ function ModelPriceSection({ prices, defaultModel }: ModelPriceSectionProps) {
       prices.find((p) => p.model === defaultModel)?.provider ??
       groups[0]?.provider ??
       null,
-    [prices, defaultModel, groups],
+    [prices, defaultModel, groups]
   );
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   useEffect(() => {
@@ -205,13 +205,17 @@ function ModelPriceSection({ prices, defaultModel }: ModelPriceSectionProps) {
                       <SvgChevronRight
                         className={cn(
                           "w-4 h-4 text-text-03 transition-transform",
-                          open && "rotate-90",
+                          open && "rotate-90"
                         )}
                       />
                     </div>
                   </CollapsibleTrigger>
                   <CollapsibleContent>
-                    <Section gap={0} alignItems="stretch" justifyContent="start">
+                    <Section
+                      gap={0}
+                      alignItems="stretch"
+                      justifyContent="start"
+                    >
                       {models.map((price) => (
                         <div
                           key={`${provider}-${price.model}`}
@@ -224,9 +228,9 @@ function ModelPriceSection({ prices, defaultModel }: ModelPriceSectionProps) {
                           </Text>
                           <Text font="secondary-body" color="text-01" nowrap>
                             {`${formatMtok(price.input_per_mtok)} in · ${formatMtok(
-                              price.output_per_mtok,
+                              price.output_per_mtok
                             )} out · ${formatMtok(
-                              price.cache_per_mtok ?? price.input_per_mtok,
+                              price.cache_per_mtok ?? price.input_per_mtok
                             )} cache`}
                           </Text>
                         </div>
@@ -311,7 +315,7 @@ function BudgetSection({
                   "h-full rounded-full",
                   usedFraction >= 1
                     ? "bg-status-error-05"
-                    : "bg-theme-primary-05",
+                    : "bg-theme-primary-05"
                 )}
                 style={{ width: `${usedFraction * 100}%` }}
               />

--- a/web/src/app/app/settings/usage/UsageSettings.tsx
+++ b/web/src/app/app/settings/usage/UsageSettings.tsx
@@ -197,18 +197,16 @@ function ModelPriceSection({ prices, defaultModel }: ModelPriceSectionProps) {
                   onOpenChange={() => toggle(provider)}
                   className="flex flex-col"
                 >
-                  <CollapsibleTrigger asChild>
-                    <div className="flex flex-row items-center justify-between cursor-pointer select-none py-1.5">
-                      <Text font="main-ui-action" color="text-03">
-                        {provider}
-                      </Text>
-                      <SvgChevronRight
-                        className={cn(
-                          "w-4 h-4 text-text-03 transition-transform",
-                          open && "rotate-90"
-                        )}
-                      />
-                    </div>
+                  <CollapsibleTrigger className="flex flex-row items-center justify-between cursor-pointer select-none py-1.5">
+                    <Text font="main-ui-action" color="text-03">
+                      {provider}
+                    </Text>
+                    <SvgChevronRight
+                      className={cn(
+                        "w-4 h-4 text-text-03 transition-transform",
+                        open && "rotate-90"
+                      )}
+                    />
                   </CollapsibleTrigger>
                   <CollapsibleContent>
                     <Section

--- a/web/src/app/app/settings/usage/lib.ts
+++ b/web/src/app/app/settings/usage/lib.ts
@@ -11,9 +11,12 @@ export interface UsagePerDayByModel {
   cost_cents: number;
 }
 
-export interface SelectedModelPrice {
+export interface ModelPrice {
+  model: string;
+  provider: string | null;
   input_per_mtok: number | null; // $/1M tokens; null if the model is unpriced
   output_per_mtok: number | null;
+  cache_per_mtok: number | null; // null => cache reads bill at the input rate
 }
 
 export interface UserUsageResponse {
@@ -24,7 +27,8 @@ export interface UserUsageResponse {
   budget_cents: number | null;
   budget_remaining_cents: number | null;
   budget_period_hours: number | null;
-  selected_model_price: SelectedModelPrice | null;
+  selected_model_price: ModelPrice | null;
+  available_model_prices: ModelPrice[];
 }
 
 export function useUserUsage(days: number) {

--- a/web/src/app/app/settings/usage/lib.ts
+++ b/web/src/app/app/settings/usage/lib.ts
@@ -1,0 +1,35 @@
+import useSWR from "swr";
+import { errorHandlingFetcher, skipRetryOnAuthError } from "@/lib/fetcher";
+import { SWR_KEYS } from "@/lib/swr-keys";
+
+export interface UsagePerDayByModel {
+  day: string; // "YYYY-MM-DD"
+  model: string;
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+  cost_cents: number;
+}
+
+export interface SelectedModelPrice {
+  input_per_mtok: number | null; // $/1M tokens; null if the model is unpriced
+  output_per_mtok: number | null;
+}
+
+export interface UserUsageResponse {
+  per_day_by_model: UsagePerDayByModel[];
+  window_cost_cents: number;
+  // The user's cost budget, what's left, and its window in hours (for the
+  // "per week/day/hour" label). All null when no cost limit applies.
+  budget_cents: number | null;
+  budget_remaining_cents: number | null;
+  budget_period_hours: number | null;
+  selected_model_price: SelectedModelPrice | null;
+}
+
+export function useUserUsage(days: number) {
+  return useSWR<UserUsageResponse>(SWR_KEYS.userUsage(days), errorHandlingFetcher, {
+    revalidateOnFocus: false,
+    onErrorRetry: skipRetryOnAuthError,
+  });
+}

--- a/web/src/app/app/settings/usage/lib.ts
+++ b/web/src/app/app/settings/usage/lib.ts
@@ -32,8 +32,12 @@ export interface UserUsageResponse {
 }
 
 export function useUserUsage(days: number) {
-  return useSWR<UserUsageResponse>(SWR_KEYS.userUsage(days), errorHandlingFetcher, {
-    revalidateOnFocus: false,
-    onErrorRetry: skipRetryOnAuthError,
-  });
+  return useSWR<UserUsageResponse>(
+    SWR_KEYS.userUsage(days),
+    errorHandlingFetcher,
+    {
+      revalidateOnFocus: false,
+      onErrorRetry: skipRetryOnAuthError,
+    }
+  );
 }

--- a/web/src/app/app/settings/usage/lib.ts
+++ b/web/src/app/app/settings/usage/lib.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import useSWR from "swr";
 import { errorHandlingFetcher, skipRetryOnAuthError } from "@/lib/fetcher";
 import { SWR_KEYS } from "@/lib/swr-keys";

--- a/web/src/app/app/settings/usage/page.tsx
+++ b/web/src/app/app/settings/usage/page.tsx
@@ -1,0 +1,5 @@
+import UsageSettings from "@/app/app/settings/usage/UsageSettings";
+
+export default function UsagePage() {
+  return <UsageSettings />;
+}

--- a/web/src/app/ee/admin/performance/usage/page.tsx
+++ b/web/src/app/ee/admin/performance/usage/page.tsx
@@ -7,6 +7,7 @@ import { QueryPerformanceChart } from "@/app/ee/admin/performance/usage/QueryPer
 import { PersonaMessagesChart } from "@/app/ee/admin/performance/usage/PersonaMessagesChart";
 import { useTimeRange } from "@/app/ee/admin/performance/lib";
 import UsageReports from "@/app/ee/admin/performance/usage/UsageReports";
+import PerUserUsagePanel from "@/views/admin/PerUserUsagePanel";
 import { Divider } from "@opal/components";
 import { useAdminAgents } from "@/lib/agents/hooks";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
@@ -33,6 +34,8 @@ export default function AnalyticsPage() {
           availablePersonas={agents}
           timeRange={timeRange}
         />
+        <Divider />
+        <PerUserUsagePanel />
         <Divider />
         <UsageReports />
       </SettingsLayouts.Body>

--- a/web/src/lib/languageModels/costOverrides.ts
+++ b/web/src/lib/languageModels/costOverrides.ts
@@ -7,20 +7,22 @@ import { SWR_KEYS } from "@/lib/swr-keys";
 
 /**
  * Admin-set negotiated per-model rate, overriding the built-in price book.
- * Rates are USD per MILLION tokens. There is no provider field — overrides
- * key solely on `model`.
+ * Rates are USD per MILLION tokens. Keyed on (provider, model); provider is ""
+ * for a provider-agnostic override.
  */
 export interface CostOverride {
   model: string;
+  provider: string;
   input_cost_per_mtok: number;
   output_cost_per_mtok: number;
   cache_read_cost_per_mtok: number | null; // null = bill cache at the input rate
   updated_at: string | null;
 }
 
-/** PUT body — an idempotent upsert keyed on `model`. */
+/** PUT body — an idempotent upsert keyed on (provider, model). */
 export interface CostOverrideUpsert {
   model: string;
+  provider?: string; // "" / omitted = provider-agnostic
   input_cost_per_mtok: number;
   output_cost_per_mtok: number;
   cache_read_cost_per_mtok: number | null;
@@ -34,7 +36,7 @@ export function useCostOverrides() {
   const { data, error, isLoading, mutate } = useSWR<CostOverride[]>(
     SWR_KEYS.costOverrides,
     errorHandlingFetcher,
-    { revalidateOnFocus: false }
+    { revalidateOnFocus: false },
   );
 
   return {
@@ -51,7 +53,7 @@ export function useCostOverrides() {
  * @throws Error with the API detail message on failure.
  */
 export async function upsertCostOverride(
-  body: CostOverrideUpsert
+  body: CostOverrideUpsert,
 ): Promise<CostOverride> {
   const response = await fetch(SWR_KEYS.costOverrides, {
     method: "PUT",
@@ -71,16 +73,21 @@ export async function upsertCostOverride(
  * the caller's intent (override absent) is satisfied either way.
  * @throws Error with the API detail message on non-404 failures.
  */
-export async function deleteCostOverride(model: string): Promise<void> {
+export async function deleteCostOverride(
+  model: string,
+  provider: string = "",
+): Promise<void> {
   // Keep "/" as real path separators (backend route is {model:path}) but encode
   // each segment, so slash-containing model ids (e.g. "bedrock/...") delete.
   const encodedModel = model
     .split("/")
     .map((segment) => encodeURIComponent(segment))
     .join("/");
-  const response = await fetch(`${SWR_KEYS.costOverrides}/${encodedModel}`, {
-    method: "DELETE",
-  });
+  const query = provider ? `?provider=${encodeURIComponent(provider)}` : "";
+  const response = await fetch(
+    `${SWR_KEYS.costOverrides}/${encodedModel}${query}`,
+    { method: "DELETE" },
+  );
 
   if (response.ok || response.status === 404) {
     return;
@@ -91,7 +98,7 @@ export async function deleteCostOverride(model: string): Promise<void> {
 
 /** Revalidate the overrides list after a mutation. */
 export async function refreshCostOverrides(
-  mutate: ScopedMutator
+  mutate: ScopedMutator,
 ): Promise<void> {
   await mutate(SWR_KEYS.costOverrides);
 }

--- a/web/src/lib/languageModels/costOverrides.ts
+++ b/web/src/lib/languageModels/costOverrides.ts
@@ -1,0 +1,107 @@
+"use client";
+
+import useSWR from "swr";
+import type { ScopedMutator } from "swr";
+import { errorHandlingFetcher } from "@/lib/fetcher";
+import { SWR_KEYS } from "@/lib/swr-keys";
+
+/**
+ * Admin-set negotiated per-model rate, overriding the built-in price book.
+ * Rates are USD per MILLION tokens. There is no provider field — overrides
+ * key solely on `model`.
+ */
+export interface CostOverride {
+  model: string;
+  input_cost_per_mtok: number;
+  output_cost_per_mtok: number;
+  cache_read_cost_per_mtok: number | null; // null = bill cache at the input rate
+  updated_at: string | null;
+}
+
+/** PUT body — an idempotent upsert keyed on `model`. */
+export interface CostOverrideUpsert {
+  model: string;
+  input_cost_per_mtok: number;
+  output_cost_per_mtok: number;
+  cache_read_cost_per_mtok: number | null;
+}
+
+/**
+ * Lists existing cost overrides via `GET /api/admin/cost-overrides` (admin).
+ * Mutate `SWR_KEYS.costOverrides` after a write to revalidate.
+ */
+export function useCostOverrides() {
+  const { data, error, isLoading, mutate } = useSWR<CostOverride[]>(
+    SWR_KEYS.costOverrides,
+    errorHandlingFetcher,
+    { revalidateOnFocus: false }
+  );
+
+  return {
+    costOverrides: data,
+    isLoading,
+    error,
+    refetch: mutate,
+  };
+}
+
+/**
+ * Upserts a cost override. PUT is idempotent — re-sending an existing model
+ * updates its rates rather than erroring.
+ * @throws Error with the API detail message on failure.
+ */
+export async function upsertCostOverride(
+  body: CostOverrideUpsert
+): Promise<CostOverride> {
+  const response = await fetch(SWR_KEYS.costOverrides, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    throw new Error(await extractError(response));
+  }
+
+  return response.json();
+}
+
+/**
+ * Deletes a cost override by model name. A 404 (already gone) is swallowed —
+ * the caller's intent (override absent) is satisfied either way.
+ * @throws Error with the API detail message on non-404 failures.
+ */
+export async function deleteCostOverride(model: string): Promise<void> {
+  // Keep "/" as real path separators (backend route is {model:path}) but encode
+  // each segment, so slash-containing model ids (e.g. "bedrock/...") delete.
+  const encodedModel = model
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+  const response = await fetch(`${SWR_KEYS.costOverrides}/${encodedModel}`, {
+    method: "DELETE",
+  });
+
+  if (response.ok || response.status === 404) {
+    return;
+  }
+
+  throw new Error(await extractError(response));
+}
+
+/** Revalidate the overrides list after a mutation. */
+export async function refreshCostOverrides(
+  mutate: ScopedMutator
+): Promise<void> {
+  await mutate(SWR_KEYS.costOverrides);
+}
+
+/** Pull the backend's `detail`/`error_code`, falling back to the status text. */
+async function extractError(response: Response): Promise<string> {
+  try {
+    const data = await response.json();
+    return data.detail || data.error_code || response.statusText;
+  } catch {
+    return response.statusText;
+  }
+}

--- a/web/src/lib/languageModels/costOverrides.ts
+++ b/web/src/lib/languageModels/costOverrides.ts
@@ -36,7 +36,7 @@ export function useCostOverrides() {
   const { data, error, isLoading, mutate } = useSWR<CostOverride[]>(
     SWR_KEYS.costOverrides,
     errorHandlingFetcher,
-    { revalidateOnFocus: false },
+    { revalidateOnFocus: false }
   );
 
   return {
@@ -53,7 +53,7 @@ export function useCostOverrides() {
  * @throws Error with the API detail message on failure.
  */
 export async function upsertCostOverride(
-  body: CostOverrideUpsert,
+  body: CostOverrideUpsert
 ): Promise<CostOverride> {
   const response = await fetch(SWR_KEYS.costOverrides, {
     method: "PUT",
@@ -75,7 +75,7 @@ export async function upsertCostOverride(
  */
 export async function deleteCostOverride(
   model: string,
-  provider: string = "",
+  provider: string = ""
 ): Promise<void> {
   // Keep "/" as real path separators (backend route is {model:path}) but encode
   // each segment, so slash-containing model ids (e.g. "bedrock/...") delete.
@@ -86,7 +86,7 @@ export async function deleteCostOverride(
   const query = provider ? `?provider=${encodeURIComponent(provider)}` : "";
   const response = await fetch(
     `${SWR_KEYS.costOverrides}/${encodedModel}${query}`,
-    { method: "DELETE" },
+    { method: "DELETE" }
   );
 
   if (response.ok || response.status === 404) {
@@ -98,7 +98,7 @@ export async function deleteCostOverride(
 
 /** Revalidate the overrides list after a mutation. */
 export async function refreshCostOverrides(
-  mutate: ScopedMutator,
+  mutate: ScopedMutator
 ): Promise<void> {
   await mutate(SWR_KEYS.costOverrides);
 }

--- a/web/src/lib/swr-keys.ts
+++ b/web/src/lib/swr-keys.ts
@@ -43,6 +43,8 @@ export const SWR_KEYS = {
     `/api/admin/llm/built-in/options/${providerEndpoint}`,
   llmContextualCost: "/api/admin/llm/provider-contextual-cost",
   costOverrides: "/api/admin/cost-overrides",
+  adminUsageExport: "/api/admin/usage/export",
+  adminUsageReset: "/api/admin/usage/reset",
   userUsage: (days: number) => `/api/user/usage?days=${days}`,
 
   // ── Image Generation ──────────────────────────────────────────────────────

--- a/web/src/lib/swr-keys.ts
+++ b/web/src/lib/swr-keys.ts
@@ -42,6 +42,8 @@ export const SWR_KEYS = {
   wellKnownLlmProvider: (providerEndpoint: string) =>
     `/api/admin/llm/built-in/options/${providerEndpoint}`,
   llmContextualCost: "/api/admin/llm/provider-contextual-cost",
+  costOverrides: "/api/admin/cost-overrides",
+  userUsage: (days: number) => `/api/user/usage?days=${days}`,
 
   // ── Image Generation ──────────────────────────────────────────────────────
   imageGenConfig: "/api/admin/image-generation/config",

--- a/web/src/lib/usage/userUsage.ts
+++ b/web/src/lib/usage/userUsage.ts
@@ -27,7 +27,7 @@ export function useUsageExport() {
   const { data, error, isLoading, mutate } = useSWR<UsageExportResponse>(
     SWR_KEYS.adminUsageExport,
     errorHandlingFetcher,
-    { revalidateOnFocus: false },
+    { revalidateOnFocus: false }
   );
 
   return { usage: data, isLoading, error, refetch: mutate };

--- a/web/src/lib/usage/userUsage.ts
+++ b/web/src/lib/usage/userUsage.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import useSWR from "swr";
+import { errorHandlingFetcher } from "@/lib/fetcher";
+import { SWR_KEYS } from "@/lib/swr-keys";
+
+export interface UsageExportTotals {
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+  cost_cents: number;
+}
+
+export interface UsageExportUser {
+  email: string;
+  totals: UsageExportTotals;
+}
+
+export interface UsageExportResponse {
+  start: string;
+  end: string;
+  users: UsageExportUser[];
+}
+
+/** Company-wide per-user usage with a revalidation callback. */
+export function useUsageExport() {
+  const { data, error, isLoading, mutate } = useSWR<UsageExportResponse>(
+    SWR_KEYS.adminUsageExport,
+    errorHandlingFetcher,
+    { revalidateOnFocus: false },
+  );
+
+  return { usage: data, isLoading, error, refetch: mutate };
+}
+
+/** Clears a user's current UTC-day usage bucket. */
+export async function resetUserUsage(userEmail: string): Promise<void> {
+  const response = await fetch(SWR_KEYS.adminUsageReset, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ user_email: userEmail }),
+  });
+
+  if (!response.ok) {
+    const data = await response.json().catch(() => null);
+    throw new Error(data?.detail || data?.error_code || response.statusText);
+  }
+}

--- a/web/src/refresh-components/inputs/InputNumber.tsx
+++ b/web/src/refresh-components/inputs/InputNumber.tsx
@@ -48,6 +48,7 @@ export interface InputNumberProps {
   min?: number;
   max?: number;
   step?: number;
+  decimalPlaces?: number;
   defaultValue?: number;
   showReset?: boolean;
   variant?: Variants;
@@ -62,6 +63,7 @@ export default function InputNumber({
   min,
   max,
   step = 1,
+  decimalPlaces = 0,
   defaultValue,
   showReset = false,
   variant = "primary",
@@ -74,6 +76,8 @@ export default function InputNumber({
     value === null ? "" : String(value)
   );
   const isDisabled = disabled || variant === "disabled";
+  const inputPattern =
+    decimalPlaces === 0 ? "[0-9]*" : `[0-9]*[.]?[0-9]{0,${decimalPlaces}}`;
 
   // Sync input value when external value changes (e.g., from stepper buttons or reset)
   React.useEffect(() => {
@@ -86,17 +90,19 @@ export default function InputNumber({
     value !== null && (min === undefined || effectiveValue > min);
   const canReset =
     showReset && defaultValue !== undefined && value !== defaultValue;
+  const normalizePrecision = (newValue: number) =>
+    Number(newValue.toFixed(decimalPlaces));
 
   const handleIncrement = () => {
     if (canIncrement) {
-      const newValue = effectiveValue + step;
+      const newValue = normalizePrecision(effectiveValue + step);
       onChange(max !== undefined ? Math.min(newValue, max) : newValue);
     }
   };
 
   const handleDecrement = () => {
     if (canDecrement) {
-      const newValue = effectiveValue - step;
+      const newValue = normalizePrecision(effectiveValue - step);
       onChange(min !== undefined ? Math.max(newValue, min) : newValue);
     }
   };
@@ -119,8 +125,7 @@ export default function InputNumber({
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const rawValue = e.target.value;
 
-    // Only allow digits (and empty string)
-    if (rawValue !== "" && !/^\d+$/.test(rawValue)) {
+    if (rawValue !== "" && !new RegExp(`^${inputPattern}$`).test(rawValue)) {
       return;
     }
 
@@ -131,7 +136,10 @@ export default function InputNumber({
       return;
     }
 
-    const val = parseInt(rawValue, 10);
+    const val = Number(rawValue);
+    if (!Number.isFinite(val)) {
+      return;
+    }
     let newValue = val;
     if (min !== undefined) newValue = Math.max(newValue, min);
     if (max !== undefined) newValue = Math.min(newValue, max);
@@ -150,8 +158,8 @@ export default function InputNumber({
       <input
         ref={inputRef}
         type="text"
-        inputMode="numeric"
-        pattern="[0-9]*"
+        inputMode={decimalPlaces === 0 ? "numeric" : "decimal"}
+        pattern={inputPattern}
         disabled={isDisabled}
         value={inputValue}
         placeholder={placeholder}

--- a/web/src/views/admin/CostOverridesPanel.test.tsx
+++ b/web/src/views/admin/CostOverridesPanel.test.tsx
@@ -1,0 +1,147 @@
+import type { ReactNode } from "react";
+import { render, screen, setupUser, waitFor } from "@tests/setup/test-utils";
+import CostOverridesPanel from "@/views/admin/CostOverridesPanel";
+import type { CostOverride } from "@/lib/languageModels/costOverrides";
+
+const mockMutate = jest.fn();
+const mockRefreshCostOverrides = jest.fn();
+const mockUpsertCostOverride = jest.fn();
+
+const costOverrides: CostOverride[] = [
+  {
+    model: "shared-model",
+    provider: "openai",
+    input_cost_per_mtok: 1,
+    output_cost_per_mtok: 2,
+    cache_read_cost_per_mtok: null,
+    updated_at: null,
+  },
+  {
+    model: "shared-model",
+    provider: "anthropic",
+    input_cost_per_mtok: 3,
+    output_cost_per_mtok: 4,
+    cache_read_cost_per_mtok: null,
+    updated_at: null,
+  },
+];
+
+jest.mock("swr", () => ({
+  __esModule: true,
+  ...jest.requireActual("swr"),
+  useSWRConfig: () => ({ mutate: mockMutate }),
+}));
+
+jest.mock("@/lib/languageModels/costOverrides", () => ({
+  useCostOverrides: () => ({
+    costOverrides,
+    isLoading: false,
+    error: undefined,
+  }),
+  deleteCostOverride: jest.fn(),
+  refreshCostOverrides: (...args: unknown[]) =>
+    mockRefreshCostOverrides(...args),
+  upsertCostOverride: (...args: unknown[]) => mockUpsertCostOverride(...args),
+}));
+
+jest.mock("@/sections/model-selector/ModelSelector", () => ({
+  __esModule: true,
+  default: ({
+    onChange,
+    renderTrigger,
+  }: {
+    onChange: (option: {
+      modelName: string;
+      provider: string;
+      modelConfigurationId: number;
+    }) => void;
+    renderTrigger: () => ReactNode;
+  }) => (
+    <>
+      {renderTrigger()}
+      <button
+        onClick={() =>
+          onChange({
+            modelName: "shared-model",
+            provider: "anthropic",
+            modelConfigurationId: 1,
+          })
+        }
+      >
+        Choose Anthropic model
+      </button>
+    </>
+  ),
+}));
+
+describe("CostOverridesPanel", () => {
+  beforeEach(() => {
+    mockRefreshCostOverrides.mockResolvedValue(undefined);
+    mockUpsertCostOverride.mockResolvedValue(costOverrides[1]);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("distinguishes the same model under different providers", () => {
+    render(<CostOverridesPanel />);
+
+    expect(screen.getByText(/OpenAI · In \$1.00/)).toBeInTheDocument();
+    expect(screen.getByText(/Anthropic · In \$3.00/)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: "Edit Anthropic override for shared-model",
+      })
+    ).toBeInTheDocument();
+  });
+
+  test("preserves the provider when editing an override", async () => {
+    const user = setupUser();
+    render(<CostOverridesPanel />);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Edit Anthropic override for shared-model",
+      })
+    );
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(mockUpsertCostOverride).toHaveBeenCalledWith({
+        model: "shared-model",
+        provider: "anthropic",
+        input_cost_per_mtok: 3,
+        output_cost_per_mtok: 4,
+        cache_read_cost_per_mtok: null,
+      });
+    });
+  });
+
+  test("saves the selected provider when adding an override", async () => {
+    const user = setupUser();
+    render(<CostOverridesPanel />);
+
+    await user.click(screen.getByRole("button", { name: "Add override" }));
+    await user.click(
+      screen.getByRole("button", { name: "Choose Anthropic model" })
+    );
+
+    await user.type(screen.getByPlaceholderText("3.00"), "3");
+    await user.type(screen.getByPlaceholderText("15.00"), "4");
+    const submitButton = screen.getAllByRole("button", {
+      name: "Add override",
+    })[1] as HTMLElement;
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(mockUpsertCostOverride).toHaveBeenCalledWith({
+        model: "shared-model",
+        provider: "anthropic",
+        input_cost_per_mtok: 3,
+        output_cost_per_mtok: 4,
+        cache_read_cost_per_mtok: null,
+      });
+    });
+  });
+});

--- a/web/src/views/admin/CostOverridesPanel.test.tsx
+++ b/web/src/views/admin/CostOverridesPanel.test.tsx
@@ -11,7 +11,7 @@ const costOverrides: CostOverride[] = [
   {
     model: "shared-model",
     provider: "openai",
-    input_cost_per_mtok: 1,
+    input_cost_per_mtok: 0.001,
     output_cost_per_mtok: 2,
     cache_read_cost_per_mtok: null,
     updated_at: null,
@@ -87,7 +87,7 @@ describe("CostOverridesPanel", () => {
   test("distinguishes the same model under different providers", () => {
     render(<CostOverridesPanel />);
 
-    expect(screen.getByText(/OpenAI · In \$1.00/)).toBeInTheDocument();
+    expect(screen.getByText(/OpenAI · In \$0.001/)).toBeInTheDocument();
     expect(screen.getByText(/Anthropic · In \$3.00/)).toBeInTheDocument();
     expect(
       screen.getByRole("button", {

--- a/web/src/views/admin/CostOverridesPanel.tsx
+++ b/web/src/views/admin/CostOverridesPanel.tsx
@@ -48,15 +48,15 @@ function OverrideForm({ existing, onDone }: OverrideFormProps) {
   const { mutate } = useSWRConfig();
   const [model, setModel] = useState(existing?.model ?? "");
   const [inputRate, setInputRate] = useState(
-    existing ? String(existing.input_cost_per_mtok) : ""
+    existing ? String(existing.input_cost_per_mtok) : "",
   );
   const [outputRate, setOutputRate] = useState(
-    existing ? String(existing.output_cost_per_mtok) : ""
+    existing ? String(existing.output_cost_per_mtok) : "",
   );
   const [cacheRate, setCacheRate] = useState(
     existing?.cache_read_cost_per_mtok != null
       ? String(existing.cache_read_cost_per_mtok)
-      : ""
+      : "",
   );
   const [submitting, setSubmitting] = useState(false);
 
@@ -79,8 +79,15 @@ function OverrideForm({ existing, onDone }: OverrideFormProps) {
   const isEdit = existing !== undefined;
   const parsedInput = parseRate(inputRate);
   const parsedOutput = parseRate(outputRate);
+  // Empty cache rate is valid (bill cache reads at the input rate); a non-empty
+  // but unparseable value must block submit, not silently drop to null.
+  const parsedCache = parseRate(cacheRate);
+  const cacheValid = cacheRate.trim() === "" || parsedCache !== null;
   const canSubmit =
-    model.trim() !== "" && parsedInput !== null && parsedOutput !== null;
+    model.trim() !== "" &&
+    parsedInput !== null &&
+    parsedOutput !== null &&
+    cacheValid;
 
   async function handleSubmit() {
     if (!canSubmit || parsedInput === null || parsedOutput === null) return;
@@ -91,7 +98,7 @@ function OverrideForm({ existing, onDone }: OverrideFormProps) {
         input_cost_per_mtok: parsedInput,
         output_cost_per_mtok: parsedOutput,
         // Empty cache rate => null (cache reads bill at the input rate).
-        cache_read_cost_per_mtok: parseRate(cacheRate),
+        cache_read_cost_per_mtok: parsedCache,
       });
       await refreshCostOverrides(mutate);
       toast.success(`Saved rate for ${model.trim()}.`);
@@ -237,7 +244,7 @@ function OverrideRow({ override }: OverrideRowProps) {
             </Text>
             <Text font="secondary-body" color="text-03">
               {`In ${formatRate(override.input_cost_per_mtok)} · Out ${formatRate(
-                override.output_cost_per_mtok
+                override.output_cost_per_mtok,
               )}${
                 override.cache_read_cost_per_mtok != null
                   ? ` · Cache ${formatRate(override.cache_read_cost_per_mtok)}`
@@ -293,7 +300,7 @@ export default function CostOverridesPanel() {
       <ContentAction
         title="Cost Overrides"
         description={markdown(
-          `Set negotiated per-model rates in **${RATE_UNIT_LABEL}**. These override the built-in price book for usage cost calculations.`
+          `Set negotiated per-model rates in **${RATE_UNIT_LABEL}**. These override the built-in price book for usage cost calculations.`,
         )}
         sizePreset="main-content"
         variant="section"

--- a/web/src/views/admin/CostOverridesPanel.tsx
+++ b/web/src/views/admin/CostOverridesPanel.tsx
@@ -1,0 +1,339 @@
+"use client";
+
+import { ChangeEvent, useMemo, useState } from "react";
+import { useSWRConfig } from "swr";
+import { toast } from "@/hooks/useToast";
+import { ThreeDotsLoader } from "@/components/Loading";
+import { ContentAction } from "@opal/layouts";
+import { Button, Card, InputTypeIn, MessageCard, Text } from "@opal/components";
+import { Hoverable } from "@opal/core";
+import { SvgCheck, SvgEdit, SvgPlus, SvgTrash, SvgX } from "@opal/icons";
+import { markdown } from "@opal/utils";
+import InputComboBox from "@/refresh-components/inputs/InputComboBox";
+import { useAdminLLMProviders } from "@/hooks/useLanguageModels";
+import * as GeneralLayouts from "@/layouts/general-layouts";
+import {
+  CostOverride,
+  deleteCostOverride,
+  refreshCostOverrides,
+  upsertCostOverride,
+  useCostOverrides,
+} from "@/lib/languageModels/costOverrides";
+
+const RATE_UNIT_LABEL = "USD per 1M tokens";
+
+// Accepts integers/decimals only; "" is allowed mid-edit, validated on submit.
+function parseRate(raw: string): number | null {
+  if (raw.trim() === "") return null;
+  if (!/^\d*\.?\d+$/.test(raw.trim())) return null;
+  const value = Number(raw);
+  return Number.isFinite(value) && value >= 0 ? value : null;
+}
+
+function formatRate(value: number): string {
+  return `$${value.toFixed(2)}`;
+}
+
+// ============================================================================
+// OverrideForm — shared add/edit form (PUT upsert)
+// ============================================================================
+
+interface OverrideFormProps {
+  // Editing an existing row locks the model name (it's the upsert key).
+  existing?: CostOverride;
+  onDone: () => void;
+}
+
+function OverrideForm({ existing, onDone }: OverrideFormProps) {
+  const { mutate } = useSWRConfig();
+  const [model, setModel] = useState(existing?.model ?? "");
+  const [inputRate, setInputRate] = useState(
+    existing ? String(existing.input_cost_per_mtok) : ""
+  );
+  const [outputRate, setOutputRate] = useState(
+    existing ? String(existing.output_cost_per_mtok) : ""
+  );
+  const [cacheRate, setCacheRate] = useState(
+    existing?.cache_read_cost_per_mtok != null
+      ? String(existing.cache_read_cost_per_mtok)
+      : ""
+  );
+  const [submitting, setSubmitting] = useState(false);
+
+  // Offer the org's configured models as options so the override key matches the
+  // model id actually recorded in usage (free-text still allowed for a model not
+  // yet configured, e.g. an embedding/rerank id).
+  const { llmProviders } = useAdminLLMProviders();
+  const modelOptions = useMemo(() => {
+    const names = new Set<string>();
+    for (const provider of llmProviders ?? []) {
+      for (const mc of provider.model_configurations) {
+        names.add(mc.name);
+      }
+    }
+    return Array.from(names)
+      .sort()
+      .map((name) => ({ value: name, label: name }));
+  }, [llmProviders]);
+
+  const isEdit = existing !== undefined;
+  const parsedInput = parseRate(inputRate);
+  const parsedOutput = parseRate(outputRate);
+  const canSubmit =
+    model.trim() !== "" && parsedInput !== null && parsedOutput !== null;
+
+  async function handleSubmit() {
+    if (!canSubmit || parsedInput === null || parsedOutput === null) return;
+    setSubmitting(true);
+    try {
+      await upsertCostOverride({
+        model: model.trim(),
+        input_cost_per_mtok: parsedInput,
+        output_cost_per_mtok: parsedOutput,
+        // Empty cache rate => null (cache reads bill at the input rate).
+        cache_read_cost_per_mtok: parseRate(cacheRate),
+      });
+      await refreshCostOverrides(mutate);
+      toast.success(`Saved rate for ${model.trim()}.`);
+      onDone();
+    } catch (e) {
+      const message = e instanceof Error ? e.message : "Unknown error";
+      toast.error(`Failed to save override: ${message}`);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Card border="solid" rounding="lg">
+      <GeneralLayouts.Section
+        gap={0.75}
+        height="fit"
+        alignItems="stretch"
+        justifyContent="start"
+      >
+        <div className="flex flex-col gap-1">
+          <Text font="secondary-action" color="text-03">
+            Model
+          </Text>
+          {isEdit ? (
+            <InputTypeIn value={model} variant="readOnly" />
+          ) : (
+            <InputComboBox
+              value={model}
+              options={modelOptions}
+              strict={false}
+              placeholder="Select a configured model, or type a model id"
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                setModel(e.target.value)
+              }
+              onValueChange={(value: string) => setModel(value)}
+            />
+          )}
+        </div>
+
+        <div className="grid grid-cols-2 gap-2">
+          <div className="flex flex-col gap-1">
+            <Text font="secondary-action" color="text-03">
+              {`Input rate (${RATE_UNIT_LABEL})`}
+            </Text>
+            <InputTypeIn
+              value={inputRate}
+              prefixText="$"
+              inputMode="decimal"
+              placeholder="3.00"
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                setInputRate(e.target.value)
+              }
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <Text font="secondary-action" color="text-03">
+              {`Output rate (${RATE_UNIT_LABEL})`}
+            </Text>
+            <InputTypeIn
+              value={outputRate}
+              prefixText="$"
+              inputMode="decimal"
+              placeholder="15.00"
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                setOutputRate(e.target.value)
+              }
+            />
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <Text font="secondary-action" color="text-03">
+            {`Cache-read rate (${RATE_UNIT_LABEL}, optional)`}
+          </Text>
+          <InputTypeIn
+            value={cacheRate}
+            prefixText="$"
+            inputMode="decimal"
+            placeholder="defaults to input rate"
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              setCacheRate(e.target.value)
+            }
+          />
+        </div>
+
+        <div className="flex flex-row gap-2 justify-end">
+          <Button prominence="tertiary" onClick={onDone} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button
+            icon={SvgCheck}
+            onClick={handleSubmit}
+            disabled={!canSubmit || submitting}
+          >
+            {isEdit ? "Save" : "Add override"}
+          </Button>
+        </div>
+      </GeneralLayouts.Section>
+    </Card>
+  );
+}
+
+// ============================================================================
+// OverrideRow — one configured override with edit + delete
+// ============================================================================
+
+interface OverrideRowProps {
+  override: CostOverride;
+}
+
+function OverrideRow({ override }: OverrideRowProps) {
+  const { mutate } = useSWRConfig();
+  const [editing, setEditing] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  async function handleDelete() {
+    setDeleting(true);
+    try {
+      await deleteCostOverride(override.model);
+      await refreshCostOverrides(mutate);
+      toast.success(`Removed override for ${override.model}.`);
+    } catch (e) {
+      const message = e instanceof Error ? e.message : "Unknown error";
+      toast.error(`Failed to remove override: ${message}`);
+      setDeleting(false);
+    }
+  }
+
+  if (editing) {
+    return (
+      <OverrideForm existing={override} onDone={() => setEditing(false)} />
+    );
+  }
+
+  return (
+    <Hoverable.Root group="OverrideRow">
+      <Card border="solid" rounding="lg" padding="sm">
+        <div className="flex flex-row items-center justify-between gap-2 p-2">
+          <div className="flex flex-col gap-0.5 min-w-0">
+            <Text font="main-ui-action" color="text-04" nowrap>
+              {override.model}
+            </Text>
+            <Text font="secondary-body" color="text-03">
+              {`In ${formatRate(override.input_cost_per_mtok)} · Out ${formatRate(
+                override.output_cost_per_mtok
+              )}${
+                override.cache_read_cost_per_mtok != null
+                  ? ` · Cache ${formatRate(override.cache_read_cost_per_mtok)}`
+                  : ""
+              } · ${RATE_UNIT_LABEL}`}
+            </Text>
+            {override.updated_at && (
+              <Text font="secondary-body" color="text-02">
+                {`Updated ${new Date(override.updated_at).toLocaleString()}`}
+              </Text>
+            )}
+          </div>
+
+          <div className="flex flex-row">
+            <Button
+              icon={SvgEdit}
+              prominence="tertiary"
+              aria-label={`Edit override for ${override.model}`}
+              disabled={deleting}
+              onClick={() => setEditing(true)}
+            />
+            <Hoverable.Item group="OverrideRow" variant="appear-on-hover">
+              <Button
+                icon={SvgTrash}
+                prominence="tertiary"
+                aria-label={`Delete override for ${override.model}`}
+                disabled={deleting}
+                onClick={handleDelete}
+              />
+            </Hoverable.Item>
+          </div>
+        </div>
+      </Card>
+    </Hoverable.Root>
+  );
+}
+
+// ============================================================================
+// CostOverridesPanel — section embedded on the Language Models page
+// ============================================================================
+
+export default function CostOverridesPanel() {
+  const { costOverrides, isLoading, error } = useCostOverrides();
+  const [adding, setAdding] = useState(false);
+
+  return (
+    <GeneralLayouts.Section
+      gap={0.75}
+      height="fit"
+      alignItems="stretch"
+      justifyContent="start"
+    >
+      <ContentAction
+        title="Cost Overrides"
+        description={markdown(
+          `Set negotiated per-model rates in **${RATE_UNIT_LABEL}**. These override the built-in price book for usage cost calculations.`
+        )}
+        sizePreset="main-content"
+        variant="section"
+        rightChildren={
+          <Button
+            icon={SvgPlus}
+            prominence="secondary"
+            disabled={adding}
+            onClick={() => setAdding(true)}
+          >
+            Add override
+          </Button>
+        }
+      />
+
+      {adding && <OverrideForm onDone={() => setAdding(false)} />}
+
+      {error ? (
+        <MessageCard
+          variant="error"
+          icon={SvgX}
+          title="Failed to load cost overrides."
+        />
+      ) : isLoading ? (
+        <ThreeDotsLoader />
+      ) : costOverrides && costOverrides.length > 0 ? (
+        <div className="flex flex-col gap-2">
+          {costOverrides.map((override) => (
+            <OverrideRow key={override.model} override={override} />
+          ))}
+        </div>
+      ) : (
+        !adding && (
+          <MessageCard
+            variant="info"
+            title="No cost overrides set."
+            description={`Add one to apply a negotiated rate (${RATE_UNIT_LABEL}) for a model.`}
+          />
+        )
+      )}
+    </GeneralLayouts.Section>
+  );
+}

--- a/web/src/views/admin/CostOverridesPanel.tsx
+++ b/web/src/views/admin/CostOverridesPanel.tsx
@@ -1,16 +1,23 @@
 "use client";
 
-import { ChangeEvent, useMemo, useState } from "react";
+import { ChangeEvent, useState } from "react";
 import { useSWRConfig } from "swr";
 import { toast } from "@/hooks/useToast";
 import { PageLoader } from "@/refresh-components/PageLoader";
 import { ContentAction } from "@opal/layouts";
-import { Button, Card, InputTypeIn, MessageCard, Text } from "@opal/components";
+import {
+  Button,
+  Card,
+  InputTypeIn,
+  MessageCard,
+  OpenButton,
+  Text,
+} from "@opal/components";
 import { Hoverable } from "@opal/core";
 import { SvgCheck, SvgEdit, SvgPlus, SvgTrash, SvgX } from "@opal/icons";
 import { markdown } from "@opal/utils";
-import InputComboBox from "@/refresh-components/inputs/InputComboBox";
-import { useAdminLLMProviders } from "@/lib/languageModels/hooks";
+import ModelSelector from "@/sections/model-selector/ModelSelector";
+import { LLMOption } from "@/lib/languageModels/options";
 import * as GeneralLayouts from "@/layouts/general-layouts";
 import {
   CostOverride,
@@ -60,21 +67,9 @@ function OverrideForm({ existing, onDone }: OverrideFormProps) {
   );
   const [submitting, setSubmitting] = useState(false);
 
-  // Offer the org's configured models as options so the override key matches the
-  // model id actually recorded in usage (free-text still allowed for a model not
-  // yet configured, e.g. an embedding/rerank id).
-  const { llmProviders } = useAdminLLMProviders();
-  const modelOptions = useMemo(() => {
-    const names = new Set<string>();
-    for (const provider of llmProviders ?? []) {
-      for (const mc of provider.model_configurations) {
-        names.add(mc.name);
-      }
-    }
-    return Array.from(names)
-      .sort()
-      .map((name) => ({ value: name, label: name }));
-  }, [llmProviders]);
+  // The override keys on the model name; track the picked config id too so the
+  // selector can highlight the current choice.
+  const [modelConfigId, setModelConfigId] = useState<number | null>(null);
 
   const isEdit = existing !== undefined;
   const parsedInput = parseRate(inputRate);
@@ -127,15 +122,16 @@ function OverrideForm({ existing, onDone }: OverrideFormProps) {
           {isEdit ? (
             <InputTypeIn value={model} variant="readOnly" />
           ) : (
-            <InputComboBox
-              value={model}
-              options={modelOptions}
-              strict={false}
-              placeholder="Select a configured model, or type a model id"
-              onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                setModel(e.target.value)
-              }
-              onValueChange={(value: string) => setModel(value)}
+            <ModelSelector
+              value={modelConfigId}
+              onChange={(opt: LLMOption) => {
+                setModel(opt.modelName);
+                setModelConfigId(opt.modelConfigurationId ?? null);
+              }}
+              renderTrigger={() => (
+                <OpenButton>{model || "Select a model"}</OpenButton>
+              )}
+              side="bottom"
             />
           )}
         </div>

--- a/web/src/views/admin/CostOverridesPanel.tsx
+++ b/web/src/views/admin/CostOverridesPanel.tsx
@@ -10,7 +10,7 @@ import { Hoverable } from "@opal/core";
 import { SvgCheck, SvgEdit, SvgPlus, SvgTrash, SvgX } from "@opal/icons";
 import { markdown } from "@opal/utils";
 import InputComboBox from "@/refresh-components/inputs/InputComboBox";
-import { useAdminLLMProviders } from "@/hooks/useLanguageModels";
+import { useAdminLLMProviders } from "@/lib/languageModels/hooks";
 import * as GeneralLayouts from "@/layouts/general-layouts";
 import {
   CostOverride,
@@ -104,6 +104,7 @@ function OverrideForm({ existing, onDone }: OverrideFormProps) {
       toast.success(`Saved rate for ${model.trim()}.`);
       onDone();
     } catch (e) {
+      console.error("Failed to save cost override", e);
       const message = e instanceof Error ? e.message : "Unknown error";
       toast.error(`Failed to save override: ${message}`);
     } finally {
@@ -218,10 +219,11 @@ function OverrideRow({ override }: OverrideRowProps) {
   async function handleDelete() {
     setDeleting(true);
     try {
-      await deleteCostOverride(override.model);
+      await deleteCostOverride(override.model, override.provider);
       await refreshCostOverrides(mutate);
       toast.success(`Removed override for ${override.model}.`);
     } catch (e) {
+      console.error("Failed to remove cost override", e);
       const message = e instanceof Error ? e.message : "Unknown error";
       toast.error(`Failed to remove override: ${message}`);
       setDeleting(false);
@@ -329,7 +331,10 @@ export default function CostOverridesPanel() {
       ) : costOverrides && costOverrides.length > 0 ? (
         <div className="flex flex-col gap-2">
           {costOverrides.map((override) => (
-            <OverrideRow key={override.model} override={override} />
+            <OverrideRow
+              key={`${override.provider}:${override.model}`}
+              override={override}
+            />
           ))}
         </div>
       ) : (

--- a/web/src/views/admin/CostOverridesPanel.tsx
+++ b/web/src/views/admin/CostOverridesPanel.tsx
@@ -3,7 +3,7 @@
 import { ChangeEvent, useMemo, useState } from "react";
 import { useSWRConfig } from "swr";
 import { toast } from "@/hooks/useToast";
-import { ThreeDotsLoader } from "@/components/Loading";
+import { PageLoader } from "@/refresh-components/PageLoader";
 import { ContentAction } from "@opal/layouts";
 import { Button, Card, InputTypeIn, MessageCard, Text } from "@opal/components";
 import { Hoverable } from "@opal/core";
@@ -327,7 +327,7 @@ export default function CostOverridesPanel() {
           title="Failed to load cost overrides."
         />
       ) : isLoading ? (
-        <ThreeDotsLoader />
+        <PageLoader />
       ) : costOverrides && costOverrides.length > 0 ? (
         <div className="flex flex-col gap-2">
           {costOverrides.map((override) => (

--- a/web/src/views/admin/CostOverridesPanel.tsx
+++ b/web/src/views/admin/CostOverridesPanel.tsx
@@ -2,9 +2,7 @@
 
 import { ChangeEvent, useState } from "react";
 import { useSWRConfig } from "swr";
-import { toast } from "@/hooks/useToast";
-import { PageLoader } from "@/refresh-components/PageLoader";
-import { ContentAction } from "@opal/layouts";
+import { ContentAction, PageLoader, toast } from "@opal/layouts";
 import {
   Button,
   Card,
@@ -55,15 +53,15 @@ function OverrideForm({ existing, onDone }: OverrideFormProps) {
   const { mutate } = useSWRConfig();
   const [model, setModel] = useState(existing?.model ?? "");
   const [inputRate, setInputRate] = useState(
-    existing ? String(existing.input_cost_per_mtok) : "",
+    existing ? String(existing.input_cost_per_mtok) : ""
   );
   const [outputRate, setOutputRate] = useState(
-    existing ? String(existing.output_cost_per_mtok) : "",
+    existing ? String(existing.output_cost_per_mtok) : ""
   );
   const [cacheRate, setCacheRate] = useState(
     existing?.cache_read_cost_per_mtok != null
       ? String(existing.cache_read_cost_per_mtok)
-      : "",
+      : ""
   );
   const [submitting, setSubmitting] = useState(false);
 
@@ -242,7 +240,7 @@ function OverrideRow({ override }: OverrideRowProps) {
             </Text>
             <Text font="secondary-body" color="text-03">
               {`In ${formatRate(override.input_cost_per_mtok)} · Out ${formatRate(
-                override.output_cost_per_mtok,
+                override.output_cost_per_mtok
               )}${
                 override.cache_read_cost_per_mtok != null
                   ? ` · Cache ${formatRate(override.cache_read_cost_per_mtok)}`
@@ -298,7 +296,7 @@ export default function CostOverridesPanel() {
       <ContentAction
         title="Cost Overrides"
         description={markdown(
-          `Set negotiated per-model rates in **${RATE_UNIT_LABEL}**. These override the built-in price book for usage cost calculations.`,
+          `Set negotiated per-model rates in **${RATE_UNIT_LABEL}**. These override the built-in price book for usage cost calculations.`
         )}
         sizePreset="main-content"
         variant="section"

--- a/web/src/views/admin/CostOverridesPanel.tsx
+++ b/web/src/views/admin/CostOverridesPanel.tsx
@@ -15,6 +15,7 @@ import { Hoverable } from "@opal/core";
 import { SvgCheck, SvgEdit, SvgPlus, SvgTrash, SvgX } from "@opal/icons";
 import { markdown } from "@opal/utils";
 import ModelSelector from "@/sections/model-selector/ModelSelector";
+import { getProvider } from "@/lib/languageModels";
 import { LLMOption } from "@/lib/languageModels/options";
 import * as GeneralLayouts from "@/layouts/general-layouts";
 import {
@@ -26,6 +27,11 @@ import {
 } from "@/lib/languageModels/costOverrides";
 
 const RATE_UNIT_LABEL = "USD per 1M tokens";
+const ALL_PROVIDERS_LABEL = "All providers";
+
+function getProviderDisplayName(provider: string): string {
+  return provider ? getProvider(provider).companyName : ALL_PROVIDERS_LABEL;
+}
 
 // Accepts integers/decimals only; "" is allowed mid-edit, validated on submit.
 function parseRate(raw: string): number | null {
@@ -39,9 +45,7 @@ function formatRate(value: number): string {
   return `$${value.toFixed(2)}`;
 }
 
-// ============================================================================
-// OverrideForm — shared add/edit form (PUT upsert)
-// ============================================================================
+// Shared add/edit form for the idempotent upsert.
 
 interface OverrideFormProps {
   // Editing an existing row locks the model name (it's the upsert key).
@@ -52,6 +56,7 @@ interface OverrideFormProps {
 function OverrideForm({ existing, onDone }: OverrideFormProps) {
   const { mutate } = useSWRConfig();
   const [model, setModel] = useState(existing?.model ?? "");
+  const [provider, setProvider] = useState(existing?.provider ?? "");
   const [inputRate, setInputRate] = useState(
     existing ? String(existing.input_cost_per_mtok) : ""
   );
@@ -76,6 +81,9 @@ function OverrideForm({ existing, onDone }: OverrideFormProps) {
   // but unparseable value must block submit, not silently drop to null.
   const parsedCache = parseRate(cacheRate);
   const cacheValid = cacheRate.trim() === "" || parsedCache !== null;
+  const modelLabel = model
+    ? `${getProviderDisplayName(provider)} · ${model}`
+    : "";
   const canSubmit =
     model.trim() !== "" &&
     parsedInput !== null &&
@@ -88,6 +96,7 @@ function OverrideForm({ existing, onDone }: OverrideFormProps) {
     try {
       await upsertCostOverride({
         model: model.trim(),
+        provider,
         input_cost_per_mtok: parsedInput,
         output_cost_per_mtok: parsedOutput,
         // Empty cache rate => null (cache reads bill at the input rate).
@@ -118,16 +127,17 @@ function OverrideForm({ existing, onDone }: OverrideFormProps) {
             Model
           </Text>
           {isEdit ? (
-            <InputTypeIn value={model} variant="readOnly" />
+            <InputTypeIn value={modelLabel} variant="readOnly" />
           ) : (
             <ModelSelector
               value={modelConfigId}
               onChange={(opt: LLMOption) => {
                 setModel(opt.modelName);
+                setProvider(opt.provider);
                 setModelConfigId(opt.modelConfigurationId ?? null);
               }}
               renderTrigger={() => (
-                <OpenButton>{model || "Select a model"}</OpenButton>
+                <OpenButton>{modelLabel || "Select a model"}</OpenButton>
               )}
               side="bottom"
             />
@@ -197,9 +207,7 @@ function OverrideForm({ existing, onDone }: OverrideFormProps) {
   );
 }
 
-// ============================================================================
-// OverrideRow — one configured override with edit + delete
-// ============================================================================
+// One configured override with edit and delete actions.
 
 interface OverrideRowProps {
   override: CostOverride;
@@ -209,6 +217,7 @@ function OverrideRow({ override }: OverrideRowProps) {
   const { mutate } = useSWRConfig();
   const [editing, setEditing] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const providerDisplayName = getProviderDisplayName(override.provider);
 
   async function handleDelete() {
     setDeleting(true);
@@ -239,9 +248,9 @@ function OverrideRow({ override }: OverrideRowProps) {
               {override.model}
             </Text>
             <Text font="secondary-body" color="text-03">
-              {`In ${formatRate(override.input_cost_per_mtok)} · Out ${formatRate(
-                override.output_cost_per_mtok
-              )}${
+              {`${providerDisplayName} · In ${formatRate(
+                override.input_cost_per_mtok
+              )} · Out ${formatRate(override.output_cost_per_mtok)}${
                 override.cache_read_cost_per_mtok != null
                   ? ` · Cache ${formatRate(override.cache_read_cost_per_mtok)}`
                   : ""
@@ -258,7 +267,7 @@ function OverrideRow({ override }: OverrideRowProps) {
             <Button
               icon={SvgEdit}
               prominence="tertiary"
-              aria-label={`Edit override for ${override.model}`}
+              aria-label={`Edit ${providerDisplayName} override for ${override.model}`}
               disabled={deleting}
               onClick={() => setEditing(true)}
             />
@@ -266,7 +275,7 @@ function OverrideRow({ override }: OverrideRowProps) {
               <Button
                 icon={SvgTrash}
                 prominence="tertiary"
-                aria-label={`Delete override for ${override.model}`}
+                aria-label={`Delete ${providerDisplayName} override for ${override.model}`}
                 disabled={deleting}
                 onClick={handleDelete}
               />
@@ -278,9 +287,7 @@ function OverrideRow({ override }: OverrideRowProps) {
   );
 }
 
-// ============================================================================
-// CostOverridesPanel — section embedded on the Language Models page
-// ============================================================================
+// Section embedded on the Language Models page.
 
 export default function CostOverridesPanel() {
   const { costOverrides, isLoading, error } = useCostOverrides();

--- a/web/src/views/admin/CostOverridesPanel.tsx
+++ b/web/src/views/admin/CostOverridesPanel.tsx
@@ -42,7 +42,10 @@ function parseRate(raw: string): number | null {
 }
 
 function formatRate(value: number): string {
-  return `$${value.toFixed(2)}`;
+  return `$${value.toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 20,
+  })}`;
 }
 
 // Shared add/edit form for the idempotent upsert.

--- a/web/src/views/admin/GroupsPage/CreateGroupPage.tsx
+++ b/web/src/views/admin/GroupsPage/CreateGroupPage.tsx
@@ -32,7 +32,7 @@ function CreateGroupPage() {
   const [selectedDocSetIds, setSelectedDocSetIds] = useState<number[]>([]);
   const [selectedAgentIds, setSelectedAgentIds] = useState<number[]>([]);
   const [tokenLimits, setTokenLimits] = useState<TokenLimit[]>([
-    { tokenBudget: null, periodDays: null },
+    { tokenBudget: null, periodDays: null, costBudgetDollars: null },
   ]);
 
   const { rows: allRows, isLoading, error } = useGroupMemberCandidates();

--- a/web/src/views/admin/GroupsPage/EditGroupPage.tsx
+++ b/web/src/views/admin/GroupsPage/EditGroupPage.tsx
@@ -101,7 +101,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
   const [selectedDocSetIds, setSelectedDocSetIds] = useState<number[]>([]);
   const [selectedAgentIds, setSelectedAgentIds] = useState<number[]>([]);
   const [tokenLimits, setTokenLimits] = useState<TokenLimit[]>([
-    { tokenBudget: null, periodDays: null },
+    { tokenBudget: null, periodDays: null, costBudgetDollars: null },
   ]);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -143,6 +143,8 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
         tokenRateLimits.map((trl) => ({
           tokenBudget: trl.token_budget,
           periodDays: trl.period_hours / HOURS_PER_DAY,
+          costBudgetDollars:
+            trl.cost_budget_cents != null ? trl.cost_budget_cents / 100 : null,
         }))
       );
     }

--- a/web/src/views/admin/GroupsPage/TokenLimitSection.test.tsx
+++ b/web/src/views/admin/GroupsPage/TokenLimitSection.test.tsx
@@ -1,0 +1,24 @@
+import { useState } from "react";
+import { render, screen, setupUser } from "@tests/setup/test-utils";
+import TokenLimitSection from "@/views/admin/GroupsPage/TokenLimitSection";
+import type { TokenLimit } from "@/views/admin/GroupsPage/TokenLimitSection";
+
+function TokenLimitSectionHarness() {
+  const [limits, setLimits] = useState<TokenLimit[]>([
+    { tokenBudget: null, periodDays: null, costBudgetDollars: null },
+  ]);
+
+  return <TokenLimitSection limits={limits} onLimitsChange={setLimits} />;
+}
+
+test("accepts a cost limit with cents", async () => {
+  const user = setupUser();
+  render(<TokenLimitSectionHarness />);
+
+  const costLimit = screen.getByPlaceholderText("Cost limit");
+  await user.type(costLimit, "1.23");
+  await user.click(screen.getByRole("button", { name: "Add Limit" }));
+
+  expect(costLimit).toHaveValue("1.23");
+  expect(screen.getAllByPlaceholderText("Cost limit")).toHaveLength(2);
+});

--- a/web/src/views/admin/GroupsPage/TokenLimitSection.tsx
+++ b/web/src/views/admin/GroupsPage/TokenLimitSection.tsx
@@ -20,6 +20,7 @@ import SimpleCollapsible from "@/refresh-components/SimpleCollapsible";
 export interface TokenLimit {
   tokenBudget: number | null;
   periodDays: number | null;
+  costBudgetDollars: number | null;
 }
 
 interface TokenLimitSectionProps {
@@ -54,12 +55,18 @@ function TokenLimitSection({
 
   function addLimit() {
     const emptyIndex = limits.findIndex(
-      (l) => l.tokenBudget === null && l.periodDays === null
+      (l) =>
+        l.tokenBudget === null &&
+        l.periodDays === null &&
+        l.costBudgetDollars === null
     );
     if (emptyIndex !== -1) return;
     const key = nextKeyRef.current++;
     keysRef.current = [...keysRef.current, key];
-    onLimitsChange([...limits, { tokenBudget: null, periodDays: null }]);
+    onLimitsChange([
+      ...limits,
+      { tokenBudget: null, periodDays: null, costBudgetDollars: null },
+    ]);
   }
 
   function removeLimit(index: number) {
@@ -103,7 +110,15 @@ function TokenLimitSection({
                     Token Limit
                   </Text>
                   <Text mainUiMuted text03 className="ml-0.5">
-                    (thousand tokens)
+                    (thousands)
+                  </Text>
+                </div>
+                <div className="flex-1 flex items-center min-w-[160px]">
+                  <Text mainUiAction text04>
+                    Cost Limit
+                  </Text>
+                  <Text mainUiMuted text03 className="ml-0.5">
+                    (USD)
                   </Text>
                 </div>
                 <div className="flex-1 flex items-center min-w-[160px]">
@@ -127,7 +142,15 @@ function TokenLimitSection({
                       value={limit.tokenBudget}
                       onChange={(v) => updateLimit(i, "tokenBudget", v)}
                       min={0}
-                      placeholder="Token limit in thousands"
+                      placeholder="Token limit (thousands)"
+                    />
+                  </div>
+                  <div className="flex-1">
+                    <InputNumber
+                      value={limit.costBudgetDollars}
+                      onChange={(v) => updateLimit(i, "costBudgetDollars", v)}
+                      min={0}
+                      placeholder="Cost limit"
                     />
                   </div>
                   <div className="flex-1">

--- a/web/src/views/admin/GroupsPage/TokenLimitSection.tsx
+++ b/web/src/views/admin/GroupsPage/TokenLimitSection.tsx
@@ -150,6 +150,8 @@ function TokenLimitSection({
                       value={limit.costBudgetDollars}
                       onChange={(v) => updateLimit(i, "costBudgetDollars", v)}
                       min={0}
+                      step={0.01}
+                      decimalPlaces={2}
                       placeholder="Cost limit"
                     />
                   </div>

--- a/web/src/views/admin/GroupsPage/groupTokenLimitsSvc.test.tsx
+++ b/web/src/views/admin/GroupsPage/groupTokenLimitsSvc.test.tsx
@@ -1,0 +1,46 @@
+import { saveTokenLimits } from "@/views/admin/GroupsPage/svc";
+
+describe("group token-limit persistence", () => {
+  const originalFetch = global.fetch;
+  const fetchMock = jest.fn();
+
+  beforeAll(() => {
+    global.fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    fetchMock.mockReset();
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  test.each([
+    [
+      "token",
+      { tokenBudget: 0, periodDays: 1, costBudgetDollars: null },
+      { token_budget: 0, cost_budget_cents: null },
+    ],
+    [
+      "cost",
+      { tokenBudget: null, periodDays: 1, costBudgetDollars: 0 },
+      { token_budget: null, cost_budget_cents: 0 },
+    ],
+  ])(
+    "preserves an invalid zero %s budget for API validation",
+    async (_, limit, expected) => {
+      fetchMock.mockResolvedValue({ ok: true } as Response);
+
+      await saveTokenLimits(7, [limit], []);
+
+      const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe("/api/admin/token-rate-limits/user-group/7");
+      expect(JSON.parse(String(options.body))).toEqual({
+        enabled: true,
+        ...expected,
+        period_hours: 24,
+      });
+    }
+  );
+});

--- a/web/src/views/admin/GroupsPage/interfaces.ts
+++ b/web/src/views/admin/GroupsPage/interfaces.ts
@@ -17,6 +17,8 @@ export interface MemberRow extends UserRow {
 export interface TokenRateLimitDisplay {
   token_id: number;
   enabled: boolean;
-  token_budget: number;
+  // null for a cost-only limit (matches the backend's nullable column).
+  token_budget: number | null;
   period_hours: number;
+  cost_budget_cents: number | null;
 }

--- a/web/src/views/admin/GroupsPage/svc.ts
+++ b/web/src/views/admin/GroupsPage/svc.ts
@@ -204,13 +204,21 @@ const HOURS_PER_DAY = 24;
 interface TokenLimitPayload {
   tokenBudget: number | null;
   periodDays: number | null;
+  costBudgetDollars: number | null;
 }
 
 interface ExistingTokenLimit {
   token_id: number;
   enabled: boolean;
-  token_budget: number;
+  token_budget: number | null;
   period_hours: number;
+  cost_budget_cents: number | null;
+}
+
+interface ValidTokenLimit {
+  tokenBudget: number | null;
+  periodDays: number;
+  costBudgetCents: number | null;
 }
 
 async function saveTokenLimits(
@@ -218,11 +226,22 @@ async function saveTokenLimits(
   limits: TokenLimitPayload[],
   existing: ExistingTokenLimit[]
 ): Promise<void> {
-  // Filter to only valid (non-null) limits
-  const validLimits = limits.filter(
-    (l): l is { tokenBudget: number; periodDays: number } =>
-      l.tokenBudget != null && l.periodDays != null
-  );
+  const validLimits: ValidTokenLimit[] = limits
+    .map((l) => {
+      const tokenBudget =
+        l.tokenBudget != null && l.tokenBudget > 0 ? l.tokenBudget : null;
+      const cents =
+        l.costBudgetDollars != null
+          ? Math.round(l.costBudgetDollars * 100)
+          : null;
+      const costBudgetCents = cents != null && cents > 0 ? cents : null;
+      return { tokenBudget, periodDays: l.periodDays, costBudgetCents };
+    })
+    .filter(
+      (l): l is ValidTokenLimit =>
+        l.periodDays != null &&
+        (l.tokenBudget != null || l.costBudgetCents != null)
+    );
 
   // Update existing limits (match by index position)
   const toUpdate = Math.min(validLimits.length, existing.length);
@@ -238,6 +257,7 @@ async function saveTokenLimits(
           enabled: existingLimit.enabled,
           token_budget: limit.tokenBudget,
           period_hours: limit.periodDays * HOURS_PER_DAY,
+          cost_budget_cents: limit.costBudgetCents,
         }),
       }
     );
@@ -260,6 +280,7 @@ async function saveTokenLimits(
           enabled: true,
           token_budget: limit.tokenBudget,
           period_hours: limit.periodDays * HOURS_PER_DAY,
+          cost_budget_cents: limit.costBudgetCents,
         }),
       }
     );

--- a/web/src/views/admin/GroupsPage/svc.ts
+++ b/web/src/views/admin/GroupsPage/svc.ts
@@ -228,14 +228,15 @@ async function saveTokenLimits(
 ): Promise<void> {
   const validLimits: ValidTokenLimit[] = limits
     .map((l) => {
-      const tokenBudget =
-        l.tokenBudget != null && l.tokenBudget > 0 ? l.tokenBudget : null;
-      const cents =
+      const costBudgetCents =
         l.costBudgetDollars != null
           ? Math.round(l.costBudgetDollars * 100)
           : null;
-      const costBudgetCents = cents != null && cents > 0 ? cents : null;
-      return { tokenBudget, periodDays: l.periodDays, costBudgetCents };
+      return {
+        tokenBudget: l.tokenBudget,
+        periodDays: l.periodDays,
+        costBudgetCents,
+      };
     })
     .filter(
       (l): l is ValidTokenLimit =>

--- a/web/src/views/admin/LanguageModelsPage.tsx
+++ b/web/src/views/admin/LanguageModelsPage.tsx
@@ -31,6 +31,7 @@ import { LLMProviderName, LLMProviderView } from "@/lib/languageModels/types";
 import { Section } from "@/layouts/general-layouts";
 import { markdown } from "@opal/utils";
 import { usePHFeatureFlag, PHFeatureFlag } from "@/lib/analytics/hooks";
+import CostOverridesPanel from "@/views/admin/CostOverridesPanel";
 
 const route = ADMIN_ROUTES.LLM_MODELS;
 
@@ -509,6 +510,11 @@ export default function LanguageModelsPage() {
             ))}
           </div>
         </Disabled>
+
+        <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+
+        {/* ── Cost Overrides — negotiated per-model rates for usage costing ── */}
+        <CostOverridesPanel />
       </SettingsLayouts.Body>
     </SettingsLayouts.Root>
   );

--- a/web/src/views/admin/PerUserUsagePanel.tsx
+++ b/web/src/views/admin/PerUserUsagePanel.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "@/hooks/useToast";
+import { PageLoader } from "@/refresh-components/PageLoader";
+import { Button, Card, MessageCard, Text } from "@opal/components";
+import { SvgX } from "@opal/icons";
+import {
+  resetUserUsage,
+  useUsageExport,
+  UsageExportUser,
+} from "@/lib/usage/userUsage";
+
+function formatTokens(n: number): string {
+  return n.toLocaleString();
+}
+
+function formatCost(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+interface UsageRowProps {
+  user: UsageExportUser;
+  onReset: () => void;
+}
+
+function UsageRow({ user, onReset }: UsageRowProps) {
+  const [resetting, setResetting] = useState(false);
+  const totals = user.totals;
+
+  async function handleReset() {
+    setResetting(true);
+    try {
+      await resetUserUsage(user.email);
+      toast.success(`Reset usage for ${user.email}.`);
+      onReset();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "unknown error";
+      toast.error(`Failed to reset usage: ${message}`);
+    } finally {
+      setResetting(false);
+    }
+  }
+
+  return (
+    <div
+      className="flex flex-row items-center gap-4 py-2"
+      data-testid={`usage-row-${user.email}`}
+    >
+      <div className="flex-1 truncate">
+        <Text font="main-ui-body">{user.email}</Text>
+      </div>
+      <div className="w-28 text-right">
+        <Text font="main-ui-body" color="text-03">
+          {formatTokens(totals.input_tokens)}
+        </Text>
+      </div>
+      <div className="w-28 text-right">
+        <Text font="main-ui-body" color="text-03">
+          {formatTokens(totals.output_tokens)}
+        </Text>
+      </div>
+      <div className="w-24 text-right">
+        <Text font="main-ui-body">{formatCost(totals.cost_cents)}</Text>
+      </div>
+      <Button
+        variant="default"
+        prominence="tertiary"
+        size="sm"
+        disabled={resetting}
+        onClick={handleReset}
+      >
+        Reset
+      </Button>
+    </div>
+  );
+}
+
+/** Admin per-user token and cost totals for the report window. */
+export default function PerUserUsagePanel() {
+  const { usage, isLoading, error, refetch } = useUsageExport();
+
+  if (isLoading) return <PageLoader />;
+  if (error) {
+    return (
+      <MessageCard
+        variant="error"
+        icon={SvgX}
+        title="Failed to load per-user usage."
+      />
+    );
+  }
+
+  const users = usage?.users ?? [];
+
+  return (
+    <Card border="solid" rounding="lg" padding="sm">
+      <div className="flex flex-col gap-2">
+        <Text font="heading-h3">Per-user usage</Text>
+        <Text font="secondary-body" color="text-03">
+          Tokens and cost per user over the report window. Reset clears the
+          user&apos;s current UTC-day usage; prior days are kept.
+        </Text>
+
+        {users.length === 0 ? (
+          <Text font="main-ui-body" color="text-03">
+            No usage recorded yet.
+          </Text>
+        ) : (
+          <div className="flex flex-col divide-y divide-border-01">
+            <div className="flex flex-row items-center gap-4 py-2">
+              <div className="flex-1">
+                <Text font="main-ui-action">User</Text>
+              </div>
+              <div className="w-28 text-right">
+                <Text font="main-ui-action">Input</Text>
+              </div>
+              <div className="w-28 text-right">
+                <Text font="main-ui-action">Output</Text>
+              </div>
+              <div className="w-24 text-right">
+                <Text font="main-ui-action">Cost</Text>
+              </div>
+              <div className="w-[68px]" />
+            </div>
+            {users.map((user) => (
+              <UsageRow key={user.email} user={user} onReset={refetch} />
+            ))}
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/web/src/views/admin/PerUserUsagePanel.tsx
+++ b/web/src/views/admin/PerUserUsagePanel.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { toast } from "@/hooks/useToast";
 import { PageLoader } from "@/refresh-components/PageLoader";
-import { Button, Card, MessageCard, Text } from "@opal/components";
+import { Button, Card, InputTypeIn, MessageCard, Text } from "@opal/components";
 import { SvgChevronLeft, SvgChevronRight, SvgX } from "@opal/icons";
 import {
   resetUserUsage,
@@ -13,12 +13,25 @@ import {
 
 const PAGE_SIZE = 10;
 
+type SortKey =
+  | "email"
+  | "input_tokens"
+  | "output_tokens"
+  | "cache_read_tokens"
+  | "cost_cents";
+type SortDir = "asc" | "desc";
+
 function formatTokens(n: number): string {
   return n.toLocaleString();
 }
 
 function formatCost(cents: number): string {
   return `$${(cents / 100).toFixed(2)}`;
+}
+
+function sortValue(user: UsageExportUser, key: SortKey): number | string {
+  if (key === "email") return user.email.toLowerCase();
+  return user.totals[key];
 }
 
 interface UsageRowProps {
@@ -83,26 +96,94 @@ function UsageRow({ user, onReset }: UsageRowProps) {
   );
 }
 
-function HeaderCell({ label }: { label: string }) {
+interface SortHeaderProps {
+  label: string;
+  sortKey: SortKey;
+  activeKey: SortKey;
+  dir: SortDir;
+  onSort: (key: SortKey) => void;
+  align: "left" | "right";
+}
+
+function SortHeader({
+  label,
+  sortKey,
+  activeKey,
+  dir,
+  onSort,
+  align,
+}: SortHeaderProps) {
+  const active = activeKey === sortKey;
+  const indicator = active ? (dir === "desc" ? " ↓" : " ↑") : "";
   return (
-    <div className="w-24 text-right">
-      <Text font="main-ui-action">{label}</Text>
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={() => onSort(sortKey)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onSort(sortKey);
+        }
+      }}
+      className={`cursor-pointer select-none ${
+        align === "right" ? "w-24 text-right" : "flex-1"
+      }`}
+    >
+      <Text font="main-ui-action" color={active ? "text-05" : "text-03"}>
+        {`${label}${indicator}`}
+      </Text>
     </div>
   );
 }
 
-/** Paginated admin per-user token and cost totals. */
+/** Searchable, sortable admin per-user usage totals. */
 export default function PerUserUsagePanel() {
   const { usage, isLoading, error, refetch } = useUsageExport();
   const [page, setPage] = useState(0);
+  const [query, setQuery] = useState("");
+  const [sortKey, setSortKey] = useState<SortKey>("cost_cents");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
 
   const users = usage?.users ?? [];
-  const pageCount = Math.max(1, Math.ceil(users.length / PAGE_SIZE));
+
+  const visible = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    const filtered = q
+      ? users.filter((u) => u.email.toLowerCase().includes(q))
+      : users;
+    return [...filtered].sort((a, b) => {
+      const av = sortValue(a, sortKey);
+      const bv = sortValue(b, sortKey);
+      const cmp =
+        typeof av === "string" && typeof bv === "string"
+          ? av.localeCompare(bv)
+          : (av as number) - (bv as number);
+      return sortDir === "asc" ? cmp : -cmp;
+    });
+  }, [users, query, sortKey, sortDir]);
+
+  const pageCount = Math.max(1, Math.ceil(visible.length / PAGE_SIZE));
+
+  // Jump back to the first page whenever the filter or sort reshapes the list.
+  useEffect(() => {
+    setPage(0);
+  }, [query, sortKey, sortDir]);
 
   // Clamp the page when the list shrinks (e.g. a reset drops a user off).
   useEffect(() => {
     if (page > pageCount - 1) setPage(pageCount - 1);
   }, [page, pageCount]);
+
+  function handleSort(key: SortKey) {
+    if (key === sortKey) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      // Numeric columns lead high→low (leaderboard); email reads A→Z.
+      setSortDir(key === "email" ? "asc" : "desc");
+    }
+  }
 
   if (isLoading) return <PageLoader />;
   if (error) {
@@ -115,7 +196,7 @@ export default function PerUserUsagePanel() {
     );
   }
 
-  const pageUsers = users.slice(page * PAGE_SIZE, page * PAGE_SIZE + PAGE_SIZE);
+  const pageUsers = visible.slice(page * PAGE_SIZE, page * PAGE_SIZE + PAGE_SIZE);
 
   return (
     <Card border="solid" rounding="lg" padding="sm">
@@ -123,25 +204,68 @@ export default function PerUserUsagePanel() {
         <Text font="heading-h3">Per-user usage</Text>
         <Text font="secondary-body" color="text-03">
           Tokens (input, output, cache reads) and cost per user over the report
-          window. Reset clears the user&apos;s current UTC-day usage; prior days
-          are kept.
+          window. Click a column to rank by it, or search by email. Reset clears
+          the user&apos;s current UTC-day usage; prior days are kept.
         </Text>
+
+        <InputTypeIn
+          value={query}
+          placeholder="Search users by email…"
+          onChange={(e) => setQuery(e.target.value)}
+        />
 
         {users.length === 0 ? (
           <Text font="main-ui-body" color="text-03">
             No usage recorded yet.
           </Text>
+        ) : visible.length === 0 ? (
+          <Text font="main-ui-body" color="text-03">
+            {`No users match "${query}".`}
+          </Text>
         ) : (
           <>
             <div className="flex flex-col divide-y divide-border-01">
               <div className="flex flex-row items-center gap-4 py-2">
-                <div className="flex-1">
-                  <Text font="main-ui-action">User</Text>
-                </div>
-                <HeaderCell label="Input" />
-                <HeaderCell label="Output" />
-                <HeaderCell label="Cache" />
-                <HeaderCell label="Cost" />
+                <SortHeader
+                  label="User"
+                  sortKey="email"
+                  activeKey={sortKey}
+                  dir={sortDir}
+                  onSort={handleSort}
+                  align="left"
+                />
+                <SortHeader
+                  label="Input"
+                  sortKey="input_tokens"
+                  activeKey={sortKey}
+                  dir={sortDir}
+                  onSort={handleSort}
+                  align="right"
+                />
+                <SortHeader
+                  label="Output"
+                  sortKey="output_tokens"
+                  activeKey={sortKey}
+                  dir={sortDir}
+                  onSort={handleSort}
+                  align="right"
+                />
+                <SortHeader
+                  label="Cache"
+                  sortKey="cache_read_tokens"
+                  activeKey={sortKey}
+                  dir={sortDir}
+                  onSort={handleSort}
+                  align="right"
+                />
+                <SortHeader
+                  label="Cost"
+                  sortKey="cost_cents"
+                  activeKey={sortKey}
+                  dir={sortDir}
+                  onSort={handleSort}
+                  align="right"
+                />
                 <div className="w-[68px]" />
               </div>
               {pageUsers.map((user) => (
@@ -160,7 +284,7 @@ export default function PerUserUsagePanel() {
                   onClick={() => setPage((p) => Math.max(0, p - 1))}
                 />
                 <Text font="main-ui-body" color="text-03">
-                  {`Page ${page + 1} of ${pageCount}`}
+                  {`Page ${page + 1} of ${pageCount} · ${visible.length} users`}
                 </Text>
                 <Button
                   variant="default"

--- a/web/src/views/admin/PerUserUsagePanel.tsx
+++ b/web/src/views/admin/PerUserUsagePanel.tsx
@@ -1,10 +1,9 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { toast } from "@/hooks/useToast";
-import { PageLoader } from "@/refresh-components/PageLoader";
 import { Button, Card, InputTypeIn, MessageCard, Text } from "@opal/components";
 import { SvgChevronLeft, SvgChevronRight, SvgX } from "@opal/icons";
+import { PageLoader, toast } from "@opal/layouts";
 import {
   resetUserUsage,
   useUsageExport,
@@ -196,7 +195,10 @@ export default function PerUserUsagePanel() {
     );
   }
 
-  const pageUsers = visible.slice(page * PAGE_SIZE, page * PAGE_SIZE + PAGE_SIZE);
+  const pageUsers = visible.slice(
+    page * PAGE_SIZE,
+    page * PAGE_SIZE + PAGE_SIZE
+  );
 
   return (
     <Card border="solid" rounding="lg" padding="sm">

--- a/web/src/views/admin/PerUserUsagePanel.tsx
+++ b/web/src/views/admin/PerUserUsagePanel.tsx
@@ -1,15 +1,17 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "@/hooks/useToast";
 import { PageLoader } from "@/refresh-components/PageLoader";
 import { Button, Card, MessageCard, Text } from "@opal/components";
-import { SvgX } from "@opal/icons";
+import { SvgChevronLeft, SvgChevronRight, SvgX } from "@opal/icons";
 import {
   resetUserUsage,
   useUsageExport,
   UsageExportUser,
 } from "@/lib/usage/userUsage";
+
+const PAGE_SIZE = 10;
 
 function formatTokens(n: number): string {
   return n.toLocaleString();
@@ -50,14 +52,19 @@ function UsageRow({ user, onReset }: UsageRowProps) {
       <div className="flex-1 truncate">
         <Text font="main-ui-body">{user.email}</Text>
       </div>
-      <div className="w-28 text-right">
+      <div className="w-24 text-right">
         <Text font="main-ui-body" color="text-03">
           {formatTokens(totals.input_tokens)}
         </Text>
       </div>
-      <div className="w-28 text-right">
+      <div className="w-24 text-right">
         <Text font="main-ui-body" color="text-03">
           {formatTokens(totals.output_tokens)}
+        </Text>
+      </div>
+      <div className="w-24 text-right">
+        <Text font="main-ui-body" color="text-03">
+          {formatTokens(totals.cache_read_tokens)}
         </Text>
       </div>
       <div className="w-24 text-right">
@@ -76,9 +83,26 @@ function UsageRow({ user, onReset }: UsageRowProps) {
   );
 }
 
-/** Admin per-user token and cost totals for the report window. */
+function HeaderCell({ label }: { label: string }) {
+  return (
+    <div className="w-24 text-right">
+      <Text font="main-ui-action">{label}</Text>
+    </div>
+  );
+}
+
+/** Paginated admin per-user token and cost totals. */
 export default function PerUserUsagePanel() {
   const { usage, isLoading, error, refetch } = useUsageExport();
+  const [page, setPage] = useState(0);
+
+  const users = usage?.users ?? [];
+  const pageCount = Math.max(1, Math.ceil(users.length / PAGE_SIZE));
+
+  // Clamp the page when the list shrinks (e.g. a reset drops a user off).
+  useEffect(() => {
+    if (page > pageCount - 1) setPage(pageCount - 1);
+  }, [page, pageCount]);
 
   if (isLoading) return <PageLoader />;
   if (error) {
@@ -91,15 +115,16 @@ export default function PerUserUsagePanel() {
     );
   }
 
-  const users = usage?.users ?? [];
+  const pageUsers = users.slice(page * PAGE_SIZE, page * PAGE_SIZE + PAGE_SIZE);
 
   return (
     <Card border="solid" rounding="lg" padding="sm">
       <div className="flex flex-col gap-2">
         <Text font="heading-h3">Per-user usage</Text>
         <Text font="secondary-body" color="text-03">
-          Tokens and cost per user over the report window. Reset clears the
-          user&apos;s current UTC-day usage; prior days are kept.
+          Tokens (input, output, cache reads) and cost per user over the report
+          window. Reset clears the user&apos;s current UTC-day usage; prior days
+          are kept.
         </Text>
 
         {users.length === 0 ? (
@@ -107,26 +132,47 @@ export default function PerUserUsagePanel() {
             No usage recorded yet.
           </Text>
         ) : (
-          <div className="flex flex-col divide-y divide-border-01">
-            <div className="flex flex-row items-center gap-4 py-2">
-              <div className="flex-1">
-                <Text font="main-ui-action">User</Text>
+          <>
+            <div className="flex flex-col divide-y divide-border-01">
+              <div className="flex flex-row items-center gap-4 py-2">
+                <div className="flex-1">
+                  <Text font="main-ui-action">User</Text>
+                </div>
+                <HeaderCell label="Input" />
+                <HeaderCell label="Output" />
+                <HeaderCell label="Cache" />
+                <HeaderCell label="Cost" />
+                <div className="w-[68px]" />
               </div>
-              <div className="w-28 text-right">
-                <Text font="main-ui-action">Input</Text>
-              </div>
-              <div className="w-28 text-right">
-                <Text font="main-ui-action">Output</Text>
-              </div>
-              <div className="w-24 text-right">
-                <Text font="main-ui-action">Cost</Text>
-              </div>
-              <div className="w-[68px]" />
+              {pageUsers.map((user) => (
+                <UsageRow key={user.email} user={user} onReset={refetch} />
+              ))}
             </div>
-            {users.map((user) => (
-              <UsageRow key={user.email} user={user} onReset={refetch} />
-            ))}
-          </div>
+
+            {pageCount > 1 && (
+              <div className="flex flex-row items-center justify-end gap-3 pt-2">
+                <Button
+                  variant="default"
+                  prominence="tertiary"
+                  size="sm"
+                  icon={SvgChevronLeft}
+                  disabled={page === 0}
+                  onClick={() => setPage((p) => Math.max(0, p - 1))}
+                />
+                <Text font="main-ui-body" color="text-03">
+                  {`Page ${page + 1} of ${pageCount}`}
+                </Text>
+                <Button
+                  variant="default"
+                  prominence="tertiary"
+                  size="sm"
+                  icon={SvgChevronRight}
+                  disabled={page >= pageCount - 1}
+                  onClick={() => setPage((p) => Math.min(pageCount - 1, p + 1))}
+                />
+              </div>
+            )}
+          </>
         )}
       </div>
     </Card>

--- a/web/src/views/admin/PerUserUsagePanel.tsx
+++ b/web/src/views/admin/PerUserUsagePanel.tsx
@@ -226,53 +226,55 @@ export default function PerUserUsagePanel() {
           </Text>
         ) : (
           <>
-            <div className="flex flex-col divide-y divide-border-01">
-              <div className="flex flex-row items-center gap-4 py-2">
-                <SortHeader
-                  label="User"
-                  sortKey="email"
-                  activeKey={sortKey}
-                  dir={sortDir}
-                  onSort={handleSort}
-                  align="left"
-                />
-                <SortHeader
-                  label="Input"
-                  sortKey="input_tokens"
-                  activeKey={sortKey}
-                  dir={sortDir}
-                  onSort={handleSort}
-                  align="right"
-                />
-                <SortHeader
-                  label="Output"
-                  sortKey="output_tokens"
-                  activeKey={sortKey}
-                  dir={sortDir}
-                  onSort={handleSort}
-                  align="right"
-                />
-                <SortHeader
-                  label="Cache"
-                  sortKey="cache_read_tokens"
-                  activeKey={sortKey}
-                  dir={sortDir}
-                  onSort={handleSort}
-                  align="right"
-                />
-                <SortHeader
-                  label="Cost"
-                  sortKey="cost_cents"
-                  activeKey={sortKey}
-                  dir={sortDir}
-                  onSort={handleSort}
-                  align="right"
-                />
-                <div className="w-[68px]" />
+            <div className="overflow-x-auto">
+              <div className="min-w-[740px] flex flex-col divide-y divide-border-01">
+                <div className="flex flex-row items-center gap-4 py-2">
+                  <SortHeader
+                    label="User"
+                    sortKey="email"
+                    activeKey={sortKey}
+                    dir={sortDir}
+                    onSort={handleSort}
+                    align="left"
+                  />
+                  <SortHeader
+                    label="Input"
+                    sortKey="input_tokens"
+                    activeKey={sortKey}
+                    dir={sortDir}
+                    onSort={handleSort}
+                    align="right"
+                  />
+                  <SortHeader
+                    label="Output"
+                    sortKey="output_tokens"
+                    activeKey={sortKey}
+                    dir={sortDir}
+                    onSort={handleSort}
+                    align="right"
+                  />
+                  <SortHeader
+                    label="Cache"
+                    sortKey="cache_read_tokens"
+                    activeKey={sortKey}
+                    dir={sortDir}
+                    onSort={handleSort}
+                    align="right"
+                  />
+                  <SortHeader
+                    label="Cost"
+                    sortKey="cost_cents"
+                    activeKey={sortKey}
+                    dir={sortDir}
+                    onSort={handleSort}
+                    align="right"
+                  />
+                  <div className="w-[68px]" />
+                </div>
+                {pageUsers.map((user) => (
+                  <UsageRow key={user.email} user={user} onReset={refetch} />
+                ))}
               </div>
-              {pageUsers.map((user) => (
-                <UsageRow key={user.email} user={user} onReset={refetch} />
-              ))}
             </div>
 
             {pageCount > 1 && (
@@ -282,6 +284,8 @@ export default function PerUserUsagePanel() {
                   prominence="tertiary"
                   size="sm"
                   icon={SvgChevronLeft}
+                  tooltip="Previous page"
+                  aria-label="Previous page"
                   disabled={page === 0}
                   onClick={() => setPage((p) => Math.max(0, p - 1))}
                 />
@@ -293,6 +297,8 @@ export default function PerUserUsagePanel() {
                   prominence="tertiary"
                   size="sm"
                   icon={SvgChevronRight}
+                  tooltip="Next page"
+                  aria-label="Next page"
                   disabled={page >= pageCount - 1}
                   onClick={() => setPage((p) => Math.min(pageCount - 1, p + 1))}
                 />

--- a/web/tests/e2e/admin/per_user_usage.spec.ts
+++ b/web/tests/e2e/admin/per_user_usage.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from "@playwright/test";
+import { ChatPage } from "@tests/e2e/chat/ChatPage";
+
+/**
+ * Admin per-user usage table + Reset. Real e2e (no mocking): the admin sends a
+ * chat to accrue usage, then the Usage Statistics page must list that usage per
+ * user, and the Reset action must clear it. Requires a working LLM provider in
+ * the e2e environment so the chat records token usage.
+ */
+test.use({ storageState: "admin_auth.json" });
+
+test.describe("admin per-user usage table + reset", () => {
+  test("usage shows per user and Reset clears it", async ({ page }) => {
+    // 1) Accrue usage by sending a chat as the admin.
+    const chat = new ChatPage(page);
+    await chat.goto();
+    await chat.inputBar.fill("hello there");
+    await chat.inputBar.send();
+    await chat.aiMessage(0).waitFor({ state: "visible", timeout: 60_000 });
+
+    // 2) The admin's usage now appears in the per-user table.
+    await page.goto("/admin/performance/usage");
+    const row = page.locator('[data-testid^="usage-row-"]').first();
+    await expect(row).toBeVisible({ timeout: 15_000 });
+
+    // 3) Reset clears the user's current-window usage (toast confirms).
+    await row.getByRole("button", { name: "Reset" }).click();
+    await expect(page.getByText(/reset usage for/i)).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+});

--- a/web/tests/e2e/admin/per_user_usage.spec.ts
+++ b/web/tests/e2e/admin/per_user_usage.spec.ts
@@ -1,5 +1,6 @@
-import { test, expect } from "@playwright/test";
+import { test } from "@playwright/test";
 import { ChatPage } from "@tests/e2e/chat/ChatPage";
+import { AdminUsagePage } from "@tests/e2e/pages/AdminUsagePage";
 
 /**
  * Admin per-user usage table + Reset. Real e2e (no mocking): the admin sends a
@@ -18,15 +19,8 @@ test.describe("admin per-user usage table + reset", () => {
     await chat.inputBar.send();
     await chat.aiMessage(0).waitFor({ state: "visible", timeout: 60_000 });
 
-    // 2) The admin's usage now appears in the per-user table.
-    await page.goto("/admin/performance/usage");
-    const row = page.locator('[data-testid^="usage-row-"]').first();
-    await expect(row).toBeVisible({ timeout: 15_000 });
-
-    // 3) Reset clears the user's current-window usage (toast confirms).
-    await row.getByRole("button", { name: "Reset" }).click();
-    await expect(page.getByText(/reset usage for/i)).toBeVisible({
-      timeout: 10_000,
-    });
+    const usage = new AdminUsagePage(page);
+    await usage.goto();
+    await usage.resetFirstUser();
   });
 });

--- a/web/tests/e2e/admin/token_rate_limit.spec.ts
+++ b/web/tests/e2e/admin/token_rate_limit.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from "@playwright/test";
+import { ChatPage } from "@tests/e2e/chat/ChatPage";
+
+/**
+ * Rate-limit enforcement is a server-side gate, so this is a REAL e2e: it does
+ * NOT mock the chat endpoint (mocking would bypass the gate). It creates a tiny
+ * per-user token budget, sends real chats until usage accrues past it, and
+ * asserts the structured 429 renders as the "usage limit reached" banner.
+ *
+ * Requires a working LLM provider in the e2e environment (chats must actually
+ * produce token usage). The same admin user creates the limit and sends the
+ * chats, so the USER scope applies to them.
+ */
+test.use({ storageState: "admin_auth.json" });
+
+const RATE_LIMIT_API = "/api/admin/token-rate-limits";
+
+test.describe("usage budget blocks chat", () => {
+  let limitId: number | undefined;
+
+  test.afterEach(async ({ page }) => {
+    if (limitId != null) {
+      await page.request.delete(`${RATE_LIMIT_API}/rate-limit/${limitId}`);
+      limitId = undefined;
+    }
+  });
+
+  test("a per-user token budget surfaces the usage-limit banner", async ({
+    page,
+  }) => {
+    // 1) Tiny per-user token budget (1 => 1,000 tokens enforced).
+    const res = await page.request.post(`${RATE_LIMIT_API}/users`, {
+      data: {
+        enabled: true,
+        token_budget: 1,
+        period_hours: 168,
+        cost_budget_cents: null,
+      },
+    });
+    expect(res.ok()).toBeTruthy();
+    const body = await res.json();
+    limitId = body.token_id ?? body.id;
+
+    const chat = new ChatPage(page);
+    await chat.goto();
+
+    // 2) Usage accrues server-side and the gate reads the recorded total before
+    //    each request, so the first turn starts at 0 and it takes a few turns to
+    //    cross the budget. Stop as soon as the banner appears.
+    const banner = page.getByText(/you've reached the usage budget/i);
+    for (let turn = 0; turn < 8 && !(await banner.isVisible()); turn++) {
+      await chat.inputBar.fill(`write a few sentences about topic ${turn}`);
+      await chat.inputBar.send();
+      await Promise.race([
+        banner.waitFor({ state: "visible", timeout: 45_000 }).catch(() => {}),
+        chat
+          .aiMessage(turn)
+          .waitFor({ state: "visible", timeout: 45_000 })
+          .catch(() => {}),
+      ]);
+    }
+
+    // 3) The structured 429 renders as a friendly, scope-aware banner.
+    await expect(banner).toBeVisible();
+    await expect(page.getByText(/your account/i)).toBeVisible();
+  });
+});

--- a/web/tests/e2e/admin/token_rate_limit.spec.ts
+++ b/web/tests/e2e/admin/token_rate_limit.spec.ts
@@ -43,25 +43,7 @@ test.describe("usage budget blocks chat", () => {
 
     const chat = new ChatPage(page);
     await chat.goto();
-
-    // 2) Usage accrues server-side and the gate reads the recorded total before
-    //    each request, so the first turn starts at 0 and it takes a few turns to
-    //    cross the budget. Stop as soon as the banner appears.
-    const banner = page.getByText(/you've reached the usage budget/i);
-    for (let turn = 0; turn < 8 && !(await banner.isVisible()); turn++) {
-      await chat.inputBar.fill(`write a few sentences about topic ${turn}`);
-      await chat.inputBar.send();
-      await Promise.race([
-        banner.waitFor({ state: "visible", timeout: 45_000 }).catch(() => {}),
-        chat
-          .aiMessage(turn)
-          .waitFor({ state: "visible", timeout: 45_000 })
-          .catch(() => {}),
-      ]);
-    }
-
-    // 3) The structured 429 renders as a friendly, scope-aware banner.
-    await expect(banner).toBeVisible();
-    await expect(page.getByText(/your account/i)).toBeVisible();
+    await chat.sendUntilUsageLimit(8);
+    await chat.expectAccountUsageLimit();
   });
 });

--- a/web/tests/e2e/chat/ChatPage.ts
+++ b/web/tests/e2e/chat/ChatPage.ts
@@ -20,6 +20,7 @@ export class ChatPage {
   // Message collections
   readonly humanMessages: Locator;
   readonly aiMessages: Locator;
+  readonly usageLimitBanner: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -28,6 +29,7 @@ export class ChatPage {
     this.scrollContainer = page.getByTestId("chat-scroll-container");
     this.humanMessages = page.locator("#onyx-human-message");
     this.aiMessages = page.getByTestId("onyx-ai-message");
+    this.usageLimitBanner = page.getByText(/you've reached the usage budget/i);
   }
 
   humanMessage(index = 0): Locator {
@@ -85,5 +87,29 @@ export class ChatPage {
 
   async expectNoHumanMessages(): Promise<void> {
     await expect(this.humanMessages).toHaveCount(0);
+  }
+
+  async sendUntilUsageLimit(maxTurns: number): Promise<void> {
+    for (
+      let turn = 0;
+      turn < maxTurns && !(await this.usageLimitBanner.isVisible());
+      turn++
+    ) {
+      await this.inputBar.fill(`write a few sentences about topic ${turn}`);
+      await this.inputBar.send();
+      await Promise.race([
+        this.usageLimitBanner
+          .waitFor({ state: "visible", timeout: 45_000 })
+          .catch(() => {}),
+        this.aiMessage(turn)
+          .waitFor({ state: "visible", timeout: 45_000 })
+          .catch(() => {}),
+      ]);
+    }
+  }
+
+  async expectAccountUsageLimit(): Promise<void> {
+    await expect(this.usageLimitBanner).toBeVisible();
+    await expect(this.page.getByText(/your account/i)).toBeVisible();
   }
 }

--- a/web/tests/e2e/pages/AdminUsagePage.ts
+++ b/web/tests/e2e/pages/AdminUsagePage.ts
@@ -1,0 +1,33 @@
+import { expect, type Locator, type Page } from "@playwright/test";
+
+const RESET_ENDPOINT = "/api/admin/usage/reset";
+
+export class AdminUsagePage {
+  readonly page: Page;
+  readonly usageRows: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.usageRows = page.locator('[data-testid^="usage-row-"]');
+  }
+
+  async goto(): Promise<void> {
+    await this.page.goto("/admin/performance/usage");
+    await expect(this.usageRows.first()).toBeVisible({ timeout: 15_000 });
+  }
+
+  async resetFirstUser(): Promise<void> {
+    const row = this.usageRows.first();
+    const responsePromise = this.page.waitForResponse(
+      (response) =>
+        response.url().includes(RESET_ENDPOINT) &&
+        response.request().method() === "POST"
+    );
+
+    await row.getByRole("button", { name: "Reset" }).click();
+    expect((await responsePromise).ok()).toBeTruthy();
+    await expect(this.page.getByText(/reset usage for/i)).toBeVisible({
+      timeout: 10_000,
+    });
+  }
+}


### PR DESCRIPTION
## Description

Part **4 of 4** of the per-user usage + cost tracking stack. Mirror of #11889 by @beraterkanelcelik, cherry-picked onto our stack base.

> **Stacked PR.** Targets `feat/usage-3-enforcement` (mirror of #12567). Review the frontend layer only.

### Net-new in this PR — frontend
- `app/app/settings/usage/` — per-user **Usage tab** (token + cost totals, per-model/day breakdown) fed by `GET /user/usage`. Shows all configured model prices (input/output/cache) grouped by provider, collapsible.
- `views/admin/CostOverridesPanel.tsx` + `lib/languageModels/costOverrides.ts` — admin **cost-override** editor (model dropdown via `ModelSelector`, collapsible by provider).
- `views/admin/PerUserUsagePanel.tsx` — admin per-user usage table with search, sortable columns, pagination (10/page), and a "Reset" action that clears a user's current window via `POST /admin/usage/reset`.
- `app/app/message/errorHelpers.tsx` + `Resubmit.tsx` — **429 budget banner** with `Retry-After` countdown.
- `admin/token-rate-limits/` + group editor — cost-budget fields (token-only / cost-only / both, hour/day/week selector).
- E2E specs: budget banner (real gate), per-user usage view + reset.

Depends on feat/usage-3-enforcement.

### Stack
1. Schema + models → #12550 (merged to `temp/pr-11766`)
2. Accounting → #12551 (`feat/usage-2-accounting2`)
3. Enforcement → #12567 (`feat/usage-3-enforcement`)
4. **Frontend ← this PR** (`feat/usage-4-frontend`)

## How Has This Been Tested?

E2E specs (budget banner, per-user usage panel) and tsc/oxlint clean (cherry-picked from #11889).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a self‑service Usage tab and admin tools for per‑user token/cost tracking, per‑model cost overrides, and cost‑aware token limits. Also adds a dedicated 429 “usage limit reached” banner with a live countdown, plus an admin per‑user usage table with Reset.

- **New Features**
  - Usage tab: 7/30‑day window; per‑day/per‑model tokens, cache reads, and cost; budget bar; default model price and all model prices (input/output/cache) grouped by provider with collapsible menus.
  - Chat: structured 429 `RATE_LIMITED` handling with a live reset countdown.
  - Admin: Cost Overrides panel on the Language Models page; override rates per (provider, model); add/edit/delete.
  - Admin: Per‑user usage table with email search, sortable columns (incl. cache), pagination (10/page), and Reset via `POST /admin/usage/reset`.
  - Admin token limits: add cost budget (USD) alongside token budget; create token‑only, cost‑only, or both; tables show UTC‑day windows with token count and cost columns.
  - API: `/user/usage` returns `selected_model_price` and `available_model_prices` (incl. cache rates).

- **Bug Fixes**
  - Persist `cost_budget_cents` on group limit create; allow cost‑only limits; reject $0 cost budgets; support decimal cost inputs; validate cache‑read rate input.
  - Token rate limits UI: drop misleading “(Thousands)” header, show full token count and USD cost, and surface update/delete errors.
  - Cost overrides FE: include provider in keys/requests and log save/delete failures; log user‑usage fetch failures.

<sup>Written for commit aef30f6eff6726cbbe2568633c4775b1635c7f16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

