### PR TITLE
feat(craft): HubSpot optional_scope for write scopes (ENG-4260)

### DIFF
--- a/backend/onyx/external_apps/providers/base.py
+++ b/backend/onyx/external_apps/providers/base.py
@@ -80,6 +80,12 @@ class OAuthFlowSpec(BaseModel):
     # The query param the `scope` value rides under. Slack uses `user_scope`
     # to request user-acting tokens; without it Slack assumes bot scopes.
     scope_param: str
+    # Scopes to request as *optional* (space-joined), ridden under the
+    # `optional_scope` auth-URL param. Providers that support it (e.g. HubSpot)
+    # silently drop any optional scope the account can't grant instead of
+    # failing the whole authorize page, so write scopes that read-only/free
+    # tiers lack don't break OAuth for everyone. Empty means "don't send it".
+    optional_scope: str = ""
     extra_authorize_params: dict[str, str] = {}
 
 

--- a/backend/onyx/external_apps/providers/base.py
+++ b/backend/onyx/external_apps/providers/base.py
@@ -80,12 +80,13 @@ class OAuthFlowSpec(BaseModel):
     # The query param the `scope` value rides under. Slack uses `user_scope`
     # to request user-acting tokens; without it Slack assumes bot scopes.
     scope_param: str
-    # Scopes to request as *optional* (space-joined), ridden under the
-    # `optional_scope` auth-URL param. Providers that support it (e.g. HubSpot)
-    # silently drop any optional scope the account can't grant instead of
-    # failing the whole authorize page, so write scopes that read-only/free
-    # tiers lack don't break OAuth for everyone. Empty means "don't send it".
+    # Space-joined scopes requested as optional. Providers that honor them
+    # (e.g. HubSpot) drop any the account can't grant rather than failing the
+    # whole authorize page, so writes don't lock out read-only tiers. Empty
+    # means the param is omitted.
     optional_scope: str = ""
+    # The query param `optional_scope` rides under, mirroring `scope_param`.
+    optional_scope_param: str = "optional_scope"
     extra_authorize_params: dict[str, str] = {}
 
 

--- a/backend/onyx/external_apps/providers/hubspot.py
+++ b/backend/onyx/external_apps/providers/hubspot.py
@@ -131,7 +131,7 @@ _REQUIRED_SCOPES = [
     "crm.objects.deals.read",
 ]
 
-# Optional, not required: read-only/free tiers can't grant writes, and HubSpot
+# Optional, read-only/free tiers can't grant writes, and HubSpot
 # fails the whole authorize page on any ungrantable required scope. As optional
 # scopes it drops what the account lacks, so everyone can still connect.
 _OPTIONAL_WRITE_SCOPES = [

--- a/backend/onyx/external_apps/providers/hubspot.py
+++ b/backend/onyx/external_apps/providers/hubspot.py
@@ -121,9 +121,8 @@ _ENDPOINTS: list[EndpointSpec] = [
 ]
 
 
-# Required scopes: `oauth` is mandatory for the auth-code flow, plus read on the
-# CRM objects this provider catalogs. Every HubSpot account — including read-only
-# and free tiers — can grant these, so requesting them as required is always safe.
+# `oauth` is mandatory for the auth-code flow; the reads cover the CRM objects
+# this provider catalogs. Every HubSpot tier can grant these.
 _REQUIRED_SCOPES = [
     "oauth",
     "crm.objects.owners.read",
@@ -132,12 +131,9 @@ _REQUIRED_SCOPES = [
     "crm.objects.deals.read",
 ]
 
-# Write scopes go in `optional_scope`, not the required `scope`. Read-only/free
-# HubSpot accounts can't grant writer scopes, and HubSpot fails the *entire*
-# authorize page if the account lacks any required scope — so requesting writes
-# as required would lock those users out of OAuth altogether. As optional scopes
-# HubSpot silently drops the ones an account can't grant: everyone connects (read
-# always succeeds) and write lights up only where the account supports it.
+# Optional, not required: read-only/free tiers can't grant writes, and HubSpot
+# fails the whole authorize page on any ungrantable required scope. As optional
+# scopes it drops what the account lacks, so everyone can still connect.
 _OPTIONAL_WRITE_SCOPES = [
     "crm.objects.contacts.write",
     "crm.objects.companies.write",

--- a/backend/onyx/external_apps/providers/hubspot.py
+++ b/backend/onyx/external_apps/providers/hubspot.py
@@ -121,16 +121,26 @@ _ENDPOINTS: list[EndpointSpec] = [
 ]
 
 
-# Scopes requested from HubSpot. `oauth` is mandatory for the auth-code flow;
-# the rest grant read/write on the CRM objects this provider catalogs.
-_SCOPES = [
+# Required scopes: `oauth` is mandatory for the auth-code flow, plus read on the
+# CRM objects this provider catalogs. Every HubSpot account — including read-only
+# and free tiers — can grant these, so requesting them as required is always safe.
+_REQUIRED_SCOPES = [
     "oauth",
     "crm.objects.owners.read",
     "crm.objects.contacts.read",
-    "crm.objects.contacts.write",
     "crm.objects.companies.read",
-    "crm.objects.companies.write",
     "crm.objects.deals.read",
+]
+
+# Write scopes go in `optional_scope`, not the required `scope`. Read-only/free
+# HubSpot accounts can't grant writer scopes, and HubSpot fails the *entire*
+# authorize page if the account lacks any required scope — so requesting writes
+# as required would lock those users out of OAuth altogether. As optional scopes
+# HubSpot silently drops the ones an account can't grant: everyone connects (read
+# always succeeds) and write lights up only where the account supports it.
+_OPTIONAL_WRITE_SCOPES = [
+    "crm.objects.contacts.write",
+    "crm.objects.companies.write",
     "crm.objects.deals.write",
 ]
 
@@ -142,8 +152,9 @@ class HubspotProvider(OAuthExternalAppProvider, OnyxManagedExtApp):
         oauth=OAuthFlowSpec(
             authorize_url="https://app.hubspot.com/oauth/authorize",
             token_url="https://api.hubapi.com/oauth/v1/token",
-            scope=" ".join(_SCOPES),
+            scope=" ".join(_REQUIRED_SCOPES),
             scope_param="scope",
+            optional_scope=" ".join(_OPTIONAL_WRITE_SCOPES),
         ),
         descriptor=AdminDescriptorSpec(
             description=(

--- a/backend/onyx/server/features/build/external_apps/oauth.py
+++ b/backend/onyx/server/features/build/external_apps/oauth.py
@@ -121,11 +121,9 @@ def start_external_app_oauth(
         "state": state,
         **oauth.extra_authorize_params,
     }
-    # Optional scopes (HubSpot) ride under their own param: the provider drops
-    # any the account can't grant rather than failing the whole authorize page.
-    # Set after extra_authorize_params so a provider can't accidentally clobber it.
+    # Set after extra_authorize_params so a provider can't clobber it.
     if oauth.optional_scope:
-        params["optional_scope"] = oauth.optional_scope
+        params[oauth.optional_scope_param] = oauth.optional_scope
     # urlencode so URI-shaped scopes (Google) get `:` and `/`
     # percent-encoded.
     authorize_url = f"{oauth.authorize_url}?{urlencode(params)}"

--- a/backend/onyx/server/features/build/external_apps/oauth.py
+++ b/backend/onyx/server/features/build/external_apps/oauth.py
@@ -121,6 +121,11 @@ def start_external_app_oauth(
         "state": state,
         **oauth.extra_authorize_params,
     }
+    # Optional scopes (HubSpot) ride under their own param: the provider drops
+    # any the account can't grant rather than failing the whole authorize page.
+    # Set after extra_authorize_params so a provider can't accidentally clobber it.
+    if oauth.optional_scope:
+        params["optional_scope"] = oauth.optional_scope
     # urlencode so URI-shaped scopes (Google) get `:` and `/`
     # percent-encoded.
     authorize_url = f"{oauth.authorize_url}?{urlencode(params)}"

--- a/backend/tests/unit/external_apps/test_hubspot_provider.py
+++ b/backend/tests/unit/external_apps/test_hubspot_provider.py
@@ -5,10 +5,18 @@ scopes — can still complete OAuth. See ENG-4260."""
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+from urllib.parse import parse_qs
+from urllib.parse import urlparse
+
+import pytest
+
 from onyx.db.enums import ExternalAppType
 from onyx.external_apps.providers.base import OAuthFlowSpec
 from onyx.external_apps.providers.hubspot import HubspotProvider
 from onyx.external_apps.providers.registry import PROVIDERS
+from onyx.server.features.build.external_apps import oauth as oauth_route
 
 
 def _provider() -> HubspotProvider:
@@ -65,3 +73,34 @@ def test_optional_scope_is_carried_on_the_spec() -> None:
         optional_scope="write extra.write",
     )
     assert spec.optional_scope == "write extra.write"
+
+
+def test_authorize_url_carries_optional_scope(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The bug this fixes lives in the authorize URL, so exercise the route end
+    to end: `start_external_app_oauth` must emit the writes under HubSpot's
+    `optional_scope` param and keep them out of required `scope`."""
+    oauth = _provider().spec.oauth
+    app = SimpleNamespace(
+        id=1,
+        app_type=ExternalAppType.HUBSPOT,
+        skill=SimpleNamespace(name="HubSpot", enabled=True),
+        organization_credentials=SimpleNamespace(
+            get_value=lambda apply_mask: {
+                "client_id": "client-id",
+                "client_secret": "client-secret",
+            }
+        ),
+    )
+    monkeypatch.setattr(oauth_route, "get_external_app_by_id", lambda *_: app)
+    monkeypatch.setattr(oauth_route, "get_current_tenant_id", lambda: "tenant")
+    monkeypatch.setattr(oauth_route, "get_redis_client", lambda tenant_id: MagicMock())
+
+    response = oauth_route.start_external_app_oauth(
+        external_app_id=app.id,
+        user=SimpleNamespace(id="user-1"),
+        db_session=MagicMock(),
+    )
+
+    query = parse_qs(urlparse(response.authorize_url).query)
+    assert set(query["optional_scope"][0].split()) == set(oauth.optional_scope.split())
+    assert not any(s.endswith(".write") for s in query["scope"][0].split())

--- a/backend/tests/unit/external_apps/test_hubspot_provider.py
+++ b/backend/tests/unit/external_apps/test_hubspot_provider.py
@@ -1,0 +1,67 @@
+"""The HubSpot provider's OAuth scopes: read scopes (+ the mandatory `oauth`
+scope) are requested as required, while write scopes ride under HubSpot's
+`optional_scope` param so read-only/free accounts — which can't grant writer
+scopes — can still complete OAuth. See ENG-4260."""
+
+from __future__ import annotations
+
+from onyx.db.enums import ExternalAppType
+from onyx.external_apps.providers.base import OAuthFlowSpec
+from onyx.external_apps.providers.hubspot import HubspotProvider
+from onyx.external_apps.providers.registry import PROVIDERS
+
+
+def _provider() -> HubspotProvider:
+    provider = PROVIDERS[ExternalAppType.HUBSPOT]
+    assert isinstance(provider, HubspotProvider)
+    return provider
+
+
+def test_required_scope_is_read_only_plus_oauth() -> None:
+    """The required `scope` carries `oauth` + every read scope and no writes —
+    so an account that lacks write access never fails the authorize page."""
+    scope = _provider().spec.oauth.scope
+    required = set(scope.split())
+    assert required == {
+        "oauth",
+        "crm.objects.owners.read",
+        "crm.objects.contacts.read",
+        "crm.objects.companies.read",
+        "crm.objects.deals.read",
+    }
+    assert not any(s.endswith(".write") for s in required)
+
+
+def test_optional_scope_is_exactly_the_writes() -> None:
+    """Writer scopes ride under `optional_scope`; HubSpot drops the ones an
+    account can't grant rather than failing OAuth for everyone."""
+    optional = set(_provider().spec.oauth.optional_scope.split())
+    assert optional == {
+        "crm.objects.contacts.write",
+        "crm.objects.companies.write",
+        "crm.objects.deals.write",
+    }
+
+
+def test_optional_scope_defaults_empty() -> None:
+    """`optional_scope` is opt-in: a spec that doesn't set it sends nothing."""
+    spec = OAuthFlowSpec(
+        authorize_url="https://example.com/authorize",
+        token_url="https://example.com/token",
+        scope="read",
+        scope_param="scope",
+    )
+    assert spec.optional_scope == ""
+
+
+def test_optional_scope_is_carried_on_the_spec() -> None:
+    """When set, the value round-trips onto the (frozen) spec unchanged so the
+    authorize-URL builder can emit it under the `optional_scope` param."""
+    spec = OAuthFlowSpec(
+        authorize_url="https://example.com/authorize",
+        token_url="https://example.com/token",
+        scope="read",
+        scope_param="scope",
+        optional_scope="write extra.write",
+    )
+    assert spec.optional_scope == "write extra.write"

--- a/backend/tests/unit/external_apps/test_hubspot_provider.py
+++ b/backend/tests/unit/external_apps/test_hubspot_provider.py
@@ -6,6 +6,7 @@ scopes — can still complete OAuth. See ENG-4260."""
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import MagicMock
 from urllib.parse import parse_qs
 from urllib.parse import urlparse
@@ -13,6 +14,7 @@ from urllib.parse import urlparse
 import pytest
 
 from onyx.db.enums import ExternalAppType
+from onyx.db.models import User
 from onyx.external_apps.providers.base import OAuthFlowSpec
 from onyx.external_apps.providers.hubspot import HubspotProvider
 from onyx.external_apps.providers.registry import PROVIDERS
@@ -85,7 +87,7 @@ def test_authorize_url_carries_optional_scope(monkeypatch: pytest.MonkeyPatch) -
         app_type=ExternalAppType.HUBSPOT,
         skill=SimpleNamespace(name="HubSpot", enabled=True),
         organization_credentials=SimpleNamespace(
-            get_value=lambda apply_mask: {
+            get_value=lambda **_: {
                 "client_id": "client-id",
                 "client_secret": "client-secret",
             }
@@ -93,11 +95,11 @@ def test_authorize_url_carries_optional_scope(monkeypatch: pytest.MonkeyPatch) -
     )
     monkeypatch.setattr(oauth_route, "get_external_app_by_id", lambda *_: app)
     monkeypatch.setattr(oauth_route, "get_current_tenant_id", lambda: "tenant")
-    monkeypatch.setattr(oauth_route, "get_redis_client", lambda tenant_id: MagicMock())
+    monkeypatch.setattr(oauth_route, "get_redis_client", lambda **_: MagicMock())
 
     response = oauth_route.start_external_app_oauth(
         external_app_id=app.id,
-        user=SimpleNamespace(id="user-1"),
+        user=cast(User, SimpleNamespace(id="user-1")),
         db_session=MagicMock(),
     )
 


### PR DESCRIPTION
## Summary

The HubSpot external app requested write-heavy scopes (`crm.objects.contacts.write`, `crm.objects.companies.write`, `crm.objects.deals.write`) as **required**. HubSpot fails the *entire* authorize page if the account lacks access to **any** required scope, so users on read-only/free HubSpot tiers couldn't complete OAuth at all.

This moves all writer scopes to HubSpot's `optional_scope` auth-URL param while keeping only the read scopes (plus the mandatory `oauth` scope) as required `scope`. HubSpot silently drops optional scopes the account can't grant, so everyone can connect (read always succeeds) and write lights up only where the account supports it.

## Changes

- **`base.py`**: Added a generic, provider-agnostic `optional_scope: str = ""` field to `OAuthFlowSpec`, documented as riding under the `optional_scope` auth-URL param.
- **`oauth.py`**: `start_external_app_oauth` now emits `optional_scope` in the authorize-URL params when set, placed after `extra_authorize_params` so it can't be unintentionally clobbered.
- **`hubspot.py`**: Split `_SCOPES` into `_REQUIRED_SCOPES` (`oauth` + four `.read` scopes) and `_OPTIONAL_WRITE_SCOPES` (the three `.write` scopes), wired into `OAuthFlowSpec(scope=..., optional_scope=...)`, with a comment explaining why writes are optional.
- **Tests**: Added `tests/unit/external_apps/test_hubspot_provider.py` asserting required `scope` contains reads + `oauth` and no `.write`, that `optional_scope` is exactly the three writes, and that `OAuthFlowSpec.optional_scope` defaults empty and round-trips when set.

## Testing

`python -m pytest tests/unit/external_apps/ -q` → 226 passed. `ruff check` clean on all changed files.

This is part of a series of HubSpot read/write-gap fixes (related: ENG-4261, ENG-4262, ENG-4263).

Fixes ENG-4260
https://linear.app/onyx-app/issue/ENG-4260/use-hubspot-optional-scope-for-write-scopes-so-read-onlyfree-accounts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow read-only/free HubSpot accounts to complete OAuth by moving write scopes to HubSpot’s optional_scope while keeping reads + oauth required. Adds provider-agnostic optional_scope and a configurable optional_scope_param to the OAuth spec and authorize URL builder. Fixes ENG-4260.

- **New Features**
  - Added optional_scope and optional_scope_param (default "optional_scope") to OAuthFlowSpec; start_external_app_oauth emits it under the configured param after extra_authorize_params.

- **Bug Fixes**
  - HubSpot: required scopes are oauth + reads; write scopes moved to optional_scope so all accounts can connect.

<sup>Written for commit 0dea8acc628c91549008c05b8b259a90309b7b10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

