### PR TITLE
feat(craft): persist per-user granted HubSpot scopes (ENG-4261)

### DIFF
--- a/backend/onyx/external_apps/providers/hubspot.py
+++ b/backend/onyx/external_apps/providers/hubspot.py
@@ -18,6 +18,18 @@ from onyx.external_apps.providers.base import OAuthProviderSpec
 from onyx.external_apps.providers.base import OnyxManagedExtApp
 from onyx.external_apps.providers.base import OrgCredentialField
 from onyx.external_apps.providers.base import token_response_error
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+# HubSpot's token endpoint omits the granted scopes, so to discover what a user
+# actually consented to we read the token-info endpoint, which returns a
+# `scopes` array. With `optional_scope` (ENG-4260) different users grant
+# different scope sets, so we must record the per-user grant.
+_TOKEN_INFO_URL = "https://api.hubapi.com/oauth/v1/access-tokens/{access_token}"
+
+# Bounded so a slow/hung token-info call can't pin the OAuth connect flow.
+_TOKEN_INFO_TIMEOUT_SECONDS = 15.0
 
 
 class HubspotAction(ExternalAppAction):
@@ -224,4 +236,44 @@ class HubspotProvider(OAuthExternalAppProvider, OnyxManagedExtApp):
             creds["refresh_token"] = response_data["refresh_token"]
         if response_data.get("expires_in"):
             creds["expires_in"] = response_data["expires_in"]
+
+        # Record the scopes actually granted for this user. The token response
+        # itself omits granted scopes, so we hit HubSpot's token-info endpoint
+        # to read them. Downstream features consume `granted_scopes`: skill
+        # action gating (ENG-4262) and write-denied messaging (ENG-4263).
+        granted_scopes = self._fetch_granted_scopes(access_token)
+        if granted_scopes is not None:
+            creds["granted_scopes"] = granted_scopes
         return creds
+
+    def _fetch_granted_scopes(self, access_token: str) -> list[str] | None:
+        """Best-effort lookup of the scopes HubSpot actually granted for this
+        token, via the token-info endpoint (the token response omits them).
+
+        Returns the list of scope strings, or ``None`` if the lookup fails.
+        Strictly non-fatal: any network/HTTP/JSON error is swallowed and logged
+        as a warning so a hiccup here can never break the OAuth connect flow (or
+        the refresh path, which also calls ``extract_credentials``)."""
+        try:
+            response = requests.get(
+                _TOKEN_INFO_URL.format(access_token=access_token),
+                timeout=_TOKEN_INFO_TIMEOUT_SECONDS,
+            )
+            response.raise_for_status()
+            body = response.json()
+        except (requests.RequestException, ValueError) as exc:
+            logger.warning(
+                "Could not fetch HubSpot granted scopes from the token-info "
+                "endpoint; persisting credential without `granted_scopes`: %s",
+                exc,
+            )
+            return None
+
+        scopes = body.get("scopes") if isinstance(body, dict) else None
+        if not isinstance(scopes, list):
+            logger.warning(
+                "HubSpot token-info response had no `scopes` list; persisting "
+                "credential without `granted_scopes`."
+            )
+            return None
+        return [str(scope) for scope in scopes]

--- a/backend/tests/unit/external_apps/test_hubspot_provider.py
+++ b/backend/tests/unit/external_apps/test_hubspot_provider.py
@@ -1,0 +1,130 @@
+"""The HubSpot provider's credential extraction, focused on persisting the
+per-user granted scopes (ENG-4261).
+
+With `optional_scope` (ENG-4260) different users grant different scope sets, so
+on the OAuth callback we read HubSpot's token-info endpoint and persist the
+actually-granted scopes under `granted_scopes` alongside the credential. The
+lookup is strictly best-effort: a failure must never break the connect flow."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+import requests
+
+from onyx.error_handling.exceptions import OnyxError
+from onyx.external_apps.providers import hubspot as hubspot_module
+from onyx.external_apps.providers.hubspot import HubspotProvider
+
+_TOKEN_RESPONSE: dict[str, Any] = {
+    "access_token": "at-123",
+    "token_type": "bearer",
+    "refresh_token": "rt-456",
+    "expires_in": 1800,
+}
+
+_GRANTED_SCOPES = [
+    "crm.objects.contacts.read",
+    "crm.objects.contacts.write",
+]
+
+
+def _token_info_response(status_code: int, body: Any) -> requests.Response:
+    """A real `requests.Response` whose `.json()` returns `body`, mimicking the
+    HubSpot token-info endpoint."""
+    response = requests.Response()
+    response.status_code = status_code
+    response._content = json.dumps(body).encode()
+    return response
+
+
+def _patch_token_info(
+    monkeypatch: pytest.MonkeyPatch, response_or_exc: object
+) -> dict[str, Any]:
+    """Patch the token-info GET. If `response_or_exc` is an Exception, raising it;
+    otherwise returning it. Captures the URL the provider requested."""
+    captured: dict[str, Any] = {}
+
+    def _get(url: str, **kwargs: Any) -> object:
+        captured["url"] = url
+        captured["timeout"] = kwargs.get("timeout")
+        if isinstance(response_or_exc, Exception):
+            raise response_or_exc
+        return response_or_exc
+
+    monkeypatch.setattr(hubspot_module.requests, "get", _get)
+    return captured
+
+
+def test_extract_credentials_persists_granted_scopes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """On a successful token-info lookup the granted scopes are persisted
+    alongside the access token (and the other credential fields)."""
+    captured = _patch_token_info(
+        monkeypatch, _token_info_response(200, {"scopes": _GRANTED_SCOPES})
+    )
+
+    creds = HubspotProvider().extract_credentials(_TOKEN_RESPONSE)
+
+    assert creds["access_token"] == "at-123"
+    assert creds["refresh_token"] == "rt-456"
+    assert creds["expires_in"] == 1800
+    assert creds["granted_scopes"] == _GRANTED_SCOPES
+    # The token-info endpoint is addressed by the access token in the path.
+    assert captured["url"].endswith("/oauth/v1/access-tokens/at-123")
+
+
+def test_extract_credentials_no_token_info_call_failure_is_non_fatal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A network error talking to the token-info endpoint must NOT break connect:
+    the access token is still returned and `granted_scopes` is simply absent."""
+    _patch_token_info(monkeypatch, requests.ConnectionError("connection reset"))
+
+    creds = HubspotProvider().extract_credentials(_TOKEN_RESPONSE)
+
+    assert creds["access_token"] == "at-123"
+    assert "granted_scopes" not in creds
+
+
+def test_extract_credentials_http_error_is_non_fatal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-2xx from the token-info endpoint (raise_for_status) is swallowed."""
+    _patch_token_info(monkeypatch, _token_info_response(401, {"message": "expired"}))
+
+    creds = HubspotProvider().extract_credentials(_TOKEN_RESPONSE)
+
+    assert creds["access_token"] == "at-123"
+    assert "granted_scopes" not in creds
+
+
+def test_extract_credentials_missing_scopes_field_is_non_fatal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 200 token-info body without a `scopes` list yields no granted scopes,
+    but still does not raise."""
+    _patch_token_info(monkeypatch, _token_info_response(200, {"hub_id": 42}))
+
+    creds = HubspotProvider().extract_credentials(_TOKEN_RESPONSE)
+
+    assert creds["access_token"] == "at-123"
+    assert "granted_scopes" not in creds
+
+
+def test_extract_credentials_missing_access_token_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An absent access token is a hard error — and we never attempt the
+    token-info lookup."""
+
+    def _boom(*_a: Any, **_k: Any) -> object:
+        raise AssertionError("token-info must not be called without an access token")
+
+    monkeypatch.setattr(hubspot_module.requests, "get", _boom)
+
+    with pytest.raises(OnyxError):
+        HubspotProvider().extract_credentials({"token_type": "bearer"})


### PR DESCRIPTION
## Summary

Persist the HubSpot scopes a user actually granted, per user, on the OAuth callback.

With `optional_scope` (ENG-4260) different users consent to different scope sets, but we
did not record what was actually granted. HubSpot's token endpoint response omits the
granted scopes, so this change reads HubSpot's token-info endpoint
(`GET https://api.hubapi.com/oauth/v1/access-tokens/{access_token}`) inside
`HubspotProvider.extract_credentials` and stores the returned `scopes` array under a new
`granted_scopes` key in the credentials dict. The existing
`upsert_external_app_user_credential` flow then persists it onto
`ExternalAppUserCredential.user_credentials` with no DB/schema changes.

## Behavior / robustness

- The token-info lookup is strictly **best-effort and non-fatal**: any network, HTTP, or
  JSON error is caught and logged as a warning, and `granted_scopes` is simply omitted —
  it can never break the OAuth connect flow (or the refresh path, which also calls
  `extract_credentials`).
- Bounded 15s timeout so a slow/hung token-info call can't pin the connect flow.
- A 200 body lacking a `scopes` list is also handled gracefully (no `granted_scopes`).

## Tests

Added `backend/tests/unit/external_apps/test_hubspot_provider.py` covering:
- success: `granted_scopes` persisted alongside `access_token`/`refresh_token`/`expires_in`,
  and the token-info URL is addressed by the access token in the path
- network error → still returns the access token, no `granted_scopes`, no raise
- HTTP error (non-2xx) → swallowed, no `granted_scopes`
- 200 body missing `scopes` → no `granted_scopes`
- missing access token → raises and never calls token-info

`python -m pytest tests/unit/external_apps/ -q` → **227 passed**. `ruff check`/`ruff format`
clean on the changed files.

## Relationships

- Depends on ENG-4260 (`optional_scope`).
- Unblocks ENG-4262 (skill action gating) and ENG-4263 (write-denied messaging), which
  consume `granted_scopes`.

Fixes ENG-4261
https://linear.app/onyx-app/issue/ENG-4261/persist-per-user-granted-hubspot-scopes-after-oauth-callback


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist the HubSpot scopes each user actually granted on OAuth callback, stored per user. Addresses ENG-4261 and supports `optional_scope` for downstream gating and messaging.

- New Features
  - Fetch granted scopes from HubSpot token-info (`GET https://api.hubapi.com/oauth/v1/access-tokens/{access_token}`) inside `HubspotProvider.extract_credentials`.
  - Store as `granted_scopes` in the persisted credential; no DB/schema changes.
  - Best-effort with a 15s timeout; errors are logged and do not break connect/refresh.
  - Unit tests cover success and failure paths. Unblocks ENG-4262 and ENG-4263.

<sup>Written for commit a5ff64ba453cf2c1c1e88f2e8f6be7ce4e6ec080. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

