### PR TITLE
feat(craft): graceful paid-seat messaging on denied HubSpot writes (ENG-4263)

### DIFF
--- a/backend/onyx/skills/builtin/hubspot/hubspot_api.py
+++ b/backend/onyx/skills/builtin/hubspot/hubspot_api.py
@@ -26,6 +26,13 @@ _METHODS = ("GET", "POST", "PATCH", "PUT", "DELETE")
 # CRM object types this helper supports (path segment under /crm/v3/objects).
 _OBJECTS = ("contacts", "companies", "deals")
 
+# Write subcommands. A write that lacks the HubSpot write scope comes back as a
+# 401 (sometimes 403). The raw auth error confuses the Craft agent (it reads
+# like a credential-injection failure), so we translate it into actionable text
+# explaining a paid write seat is required — see ENG-4263.
+_WRITE_CMDS = ("create", "update")
+_WRITE_DENIED_STATUSES = (401, 403)
+
 # Sensible default properties to fetch per object so output is useful without
 # the caller having to enumerate every property name.
 _DEFAULT_PROPERTIES: dict[str, list[str]] = {
@@ -82,6 +89,28 @@ def _properties_from_pairs(pairs: list[str]) -> dict[str, str]:
         key, value = pair.split("=", 1)
         props[key.strip()] = value
     return props
+
+
+def _write_denied_message(obj: str | None) -> str:
+    """Friendly text for a write rejected for lack of the HubSpot write scope.
+
+    A raw 401/403 here reads like a credential-injection failure and confuses
+    the agent, so we explain the real cause: the connected HubSpot account
+    lacks a paid write seat / write scope for this object (ENG-4263)."""
+    target = f"to {obj}" if obj else "to this object"
+    return (
+        f"This action requires a paid HubSpot seat with write access {target}. "
+        "Your connected HubSpot account doesn't have the write scope for this "
+        "object, so create/update isn't available. Ask a HubSpot admin to grant "
+        "write access (a paid write seat), then reconnect HubSpot in Onyx."
+    )
+
+
+def _is_write_scope_denial(cmd: str | None, status: int) -> bool:
+    """True when a write (create/update) was rejected with a 401/403, i.e. the
+    connected account lacks the write scope. Reads and other statuses keep the
+    raw upstream error unchanged (ENG-4263)."""
+    return cmd in _WRITE_CMDS and status in _WRITE_DENIED_STATUSES
 
 
 def _emit(result: dict[str, Any], raw: bool) -> int:
@@ -262,7 +291,20 @@ def main(argv: list[str]) -> int:
             )
         except ValueError:
             message = detail
-        print(json.dumps({"ok": False, "status": e.code, "error": message}))
+        # A denied write (missing scope) returns a raw 401/403 that looks like a
+        # credential failure and confuses the agent; surface actionable text
+        # instead while preserving the upstream message under `detail` for
+        # debugging (ENG-4263).
+        if _is_write_scope_denial(getattr(a, "cmd", None), e.code):
+            out: dict[str, Any] = {
+                "ok": False,
+                "status": e.code,
+                "error": _write_denied_message(getattr(a, "object", None)),
+                "detail": message,
+            }
+        else:
+            out = {"ok": False, "status": e.code, "error": message}
+        print(json.dumps(out))
         return 1
     except urllib.error.URLError as e:
         print(f"network error calling HubSpot: {e.reason}", file=sys.stderr)

--- a/backend/tests/unit/external_apps/test_hubspot_api_helper.py
+++ b/backend/tests/unit/external_apps/test_hubspot_api_helper.py
@@ -1,0 +1,167 @@
+"""The bundled ``hubspot_api.py`` sandbox helper: the friendly "paid write
+seat" translation applied to denied HubSpot writes (ENG-4263). The helper is a
+standalone script under the skills dir (not an importable package), so load it
+by path. A denied write (missing scope) comes back as a raw 401/403 that reads
+like a credential-injection failure and confuses the agent; these tests assert
+we replace it with actionable text for writes while leaving reads / other
+statuses untouched."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import urllib.error
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+_HELPER = (
+    Path(__file__).resolve().parents[3]
+    / "onyx/skills/builtin"
+    / "hubspot/hubspot_api.py"
+)
+
+
+def _load() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("hubspot_api", _HELPER)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+hubspot = _load()
+
+
+def _http_error(status: int, message: str = "permission denied") -> urllib.error.HTTPError:
+    body = json.dumps({"message": message}).encode("utf-8")
+    return urllib.error.HTTPError(
+        url="https://api.hubapi.com/crm/v3/objects/contacts",
+        code=status,
+        msg="error",
+        hdrs=None,  # type: ignore[arg-type]
+        fp=io.BytesIO(body),
+    )
+
+
+def _run(monkeypatch: Any, capsys: Any, argv: list[str], error: Exception) -> tuple[int, dict[str, Any]]:
+    """Invoke main with `_dispatch` raising `error`, returning (exit_code, parsed_json)."""
+
+    def _boom(_a: Any) -> Any:
+        raise error
+
+    monkeypatch.setattr(hubspot, "_dispatch", _boom)
+    code = hubspot.main(["hubspot_api.py", *argv])
+    out = capsys.readouterr().out.strip()
+    return code, json.loads(out)
+
+
+# --- pure helpers ---
+
+
+def test_write_denied_message_includes_object() -> None:
+    msg = hubspot._write_denied_message("contacts")
+    assert "paid HubSpot seat" in msg
+    assert "write access" in msg
+    assert "contacts" in msg
+
+
+def test_write_denied_message_without_object_is_generic() -> None:
+    msg = hubspot._write_denied_message(None)
+    assert "paid HubSpot seat" in msg
+    assert "this object" in msg
+
+
+def test_is_write_scope_denial_matrix() -> None:
+    assert hubspot._is_write_scope_denial("create", 401) is True
+    assert hubspot._is_write_scope_denial("update", 403) is True
+    # reads keep the raw error
+    assert hubspot._is_write_scope_denial("list", 401) is False
+    assert hubspot._is_write_scope_denial("get", 403) is False
+    # non-auth statuses keep the raw error even on a write
+    assert hubspot._is_write_scope_denial("create", 400) is False
+
+
+# --- main() HTTPError translation ---
+
+
+def test_create_401_returns_friendly_paid_seat_message(monkeypatch: Any, capsys: Any) -> None:
+    code, out = _run(
+        monkeypatch,
+        capsys,
+        ["create", "contacts", "--set", "email=a@b.co"],
+        _http_error(401, "missing scopes"),
+    )
+    assert code == 1
+    assert out["ok"] is False
+    assert out["status"] == 401
+    assert "paid HubSpot seat" in out["error"]
+    assert "write access" in out["error"]
+    assert "contacts" in out["error"]
+    # original upstream message preserved for debugging
+    assert out["detail"] == "missing scopes"
+
+
+def test_update_403_returns_friendly_paid_seat_message(monkeypatch: Any, capsys: Any) -> None:
+    code, out = _run(
+        monkeypatch,
+        capsys,
+        ["update", "deals", "ID1", "--set", "amount=10"],
+        _http_error(403, "forbidden"),
+    )
+    assert code == 1
+    assert out["ok"] is False
+    assert out["status"] == 403
+    assert "paid HubSpot seat" in out["error"]
+    assert "deals" in out["error"]
+    assert out["detail"] == "forbidden"
+
+
+def test_read_401_keeps_raw_error(monkeypatch: Any, capsys: Any) -> None:
+    code, out = _run(
+        monkeypatch,
+        capsys,
+        ["list", "contacts"],
+        _http_error(401, "token expired"),
+    )
+    assert code == 1
+    assert out["ok"] is False
+    assert out["status"] == 401
+    assert out["error"] == "token expired"
+    assert "paid HubSpot seat" not in out["error"]
+    assert "detail" not in out
+
+
+def test_get_403_keeps_raw_error(monkeypatch: Any, capsys: Any) -> None:
+    code, out = _run(
+        monkeypatch,
+        capsys,
+        ["get", "companies", "ID1"],
+        _http_error(403, "no access"),
+    )
+    assert code == 1
+    assert out["error"] == "no access"
+    assert "paid HubSpot seat" not in out["error"]
+
+
+def test_write_400_keeps_raw_error(monkeypatch: Any, capsys: Any) -> None:
+    # A non-auth failure on a write (e.g. validation) is a different problem and
+    # must keep its original message.
+    code, out = _run(
+        monkeypatch,
+        capsys,
+        ["create", "contacts", "--set", "email=bad"],
+        _http_error(400, "invalid email"),
+    )
+    assert code == 1
+    assert out["status"] == 400
+    assert out["error"] == "invalid email"
+    assert "paid HubSpot seat" not in out["error"]
+    assert "detail" not in out
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## Summary

When a HubSpot **write** (`create` / `update`) is attempted without the required
write scope, the HubSpot API returns a raw 401 (sometimes 403). That raw auth
error reads like a credential-injection failure and confuses the Craft agent.

This change translates those denied writes into a clear, actionable message in
`backend/onyx/skills/builtin/hubspot/hubspot_api.py`:

> This action requires a paid HubSpot seat with write access to `<object>`. Your
> connected HubSpot account doesn't have the write scope for this object, so
> create/update isn't available. Ask a HubSpot admin to grant write access (a
> paid write seat), then reconnect HubSpot in Onyx.

Details:
- Only applies to write commands (`create`/`update`) failing with **401/403**.
  Reads (`list`/`get`/`search`/`owners`) and non-auth statuses (e.g. 400) keep
  their original upstream error unchanged.
- Includes the object type (`contacts`/`companies`/`deals`) so the message is
  specific.
- Output keeps the same JSON shape — `{"ok": false, "status": <code>, "error":
  "<friendly message>"}` with exit code 1 — and preserves the original upstream
  message under a new `detail` key for debugging.
- Logic factored into small, testable helpers (`_write_denied_message`,
  `_is_write_scope_denial`).

## Tests

Added `backend/tests/unit/external_apps/test_hubspot_api_helper.py` (loads the
helper by path, monkeypatches `_dispatch` to raise `HTTPError`) covering:
- `create`/`update` → 401 and 403 produce the friendly paid-seat message with
  the right object name, exit code 1, original message under `detail`.
- reads (`list`/`get`) → 401/403 keep the raw error.
- a write → 400 keeps the raw error.

`python -m pytest tests/unit/external_apps/ -q` → **230 passed**. `ruff check`
clean on changed files.

## Related

Fixes ENG-4263 — https://linear.app/onyx-app/issue/ENG-4263/graceful-paid-write-seat-required-messaging-on-denied-hubspot-writes

Part of the HubSpot read/write-gap series (relates to ENG-4260, ENG-4261, ENG-4262).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Translates 401/403 errors on HubSpot writes into a clear “paid write seat required” message, so users get actionable guidance instead of a confusing auth failure. Only affects `create`/`update`; reads and non-auth errors are unchanged. Addresses ENG-4263.

- **Bug Fixes**
  - Map denied writes (`create`/`update`) to a friendly message that includes the object type.
  - Preserve response shape and exit code; keep the upstream error in `detail` for debugging.
  - Add small helpers for detection/message generation with unit tests covering write/read and status cases.

<sup>Written for commit 3345e4c1f324f5b2e800555310ec625399e7a3db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

