### PR TITLE
feat(search): support time_cutoff_upper for bounded time filtering

### DIFF
--- a/backend/onyx/context/search/models.py
+++ b/backend/onyx/context/search/models.py
@@ -65,6 +65,7 @@ class BaseFilters(BaseModel):
     source_type: list[DocumentSource] | None = None
     document_set: list[str] | None = None
     time_cutoff: datetime | None = None
+    time_cutoff_upper: datetime | None = None
     tags: list[Tag] | None = None
 
 

--- a/backend/onyx/context/search/pipeline.py
+++ b/backend/onyx/context/search/pipeline.py
@@ -99,6 +99,7 @@ def _build_index_filters(
         source_type=source_filter,
         document_set=document_set_filter,
         time_cutoff=time_filter,
+        time_cutoff_upper=base_filters.time_cutoff_upper,
         tags=base_filters.tags,
         access_control_list=user_acl_filters,
         tenant_id=get_current_tenant_id() if MULTI_TENANT else None,

--- a/backend/onyx/document_index/FILTER_SEMANTICS.md
+++ b/backend/onyx/document_index/FILTER_SEMANTICS.md
@@ -115,5 +115,5 @@ AND (user_project contains 7)
 | `source_type` | `source_type` | `string` | Connector source type (e.g. `web`, `jira`) |
 | `tags` | `metadata_list` | `array<string>` | Document metadata tags |
 | `time_cutoff` | `doc_updated_at` | `long` | Minimum document update timestamp |
-| `time_cutoff_upper` | `doc_updated_at` | `long` | Maximum document update timestamp (pairs with `time_cutoff` for a range; excludes undated docs) |
+| `time_cutoff_upper` | `doc_updated_at` | `long` | Maximum document update timestamp; usable alone or together with `time_cutoff` for a closed range; excludes undated docs in all cases |
 | `tenant_id` | `tenant_id` | `string` | Tenant isolation (multi-tenant) |

--- a/backend/onyx/document_index/FILTER_SEMANTICS.md
+++ b/backend/onyx/document_index/FILTER_SEMANTICS.md
@@ -11,7 +11,7 @@ How `IndexFilters` fields combine into the final query filter. Describes the act
 | **Visibility** | `hidden` | Always applied (unless `include_hidden`) |
 | **Tenant** | `tenant_id` | AND (multi-tenant only) |
 | **ACL** | `access_control_list` | OR within, AND with rest |
-| **Narrowing** | `source_type`, `tags`, `time_cutoff` | Each OR within, AND with rest |
+| **Narrowing** | `source_type`, `tags`, `time_cutoff`, `time_cutoff_upper` | Each OR within, AND with rest |
 | **Knowledge scope** | `document_set`, `attached_document_ids`, `hierarchy_node_ids`, `persona_id_filter`, `project_id_filter` | OR within group, AND with rest |
 
 ## How filters combine
@@ -115,4 +115,5 @@ AND (user_project contains 7)
 | `source_type` | `source_type` | `string` | Connector source type (e.g. `web`, `jira`) |
 | `tags` | `metadata_list` | `array<string>` | Document metadata tags |
 | `time_cutoff` | `doc_updated_at` | `long` | Minimum document update timestamp |
+| `time_cutoff_upper` | `doc_updated_at` | `long` | Maximum document update timestamp (pairs with `time_cutoff` for a range; excludes undated docs) |
 | `tenant_id` | `tenant_id` | `string` | Tenant isolation (multi-tenant) |

--- a/backend/onyx/document_index/opensearch/search.py
+++ b/backend/onyx/document_index/opensearch/search.py
@@ -895,12 +895,16 @@ class DocumentQuery:
             persona_id_filter: If not None, only documents whose personas array
                 contains this persona ID will be retrieved. Primary — creates
                 a knowledge scope on its own.
-            time_cutoff: Time cutoff for the documents to retrieve. If not None,
-                Documents which were last updated before this date will not be
-                returned. For documents which do not have a value for their last
-                updated time, we assume some default age of
-                ASSUMED_DOCUMENT_AGE_DAYS for when the document was last
-                updated.
+            time_cutoff: Inclusive lower bound on a document's last updated time.
+                If not None, documents last updated before this time will not be
+                returned. Documents which have no last updated time are included
+                only when this bound is open-ended (time_cutoff_upper is None)
+                and older than ASSUMED_DOCUMENT_AGE_DAYS — a closed range cannot
+                vouch for an undated document.
+            time_cutoff_upper: Inclusive upper bound on a document's last updated
+                time. If not None, documents last updated after this time will
+                not be returned. May be set with or without time_cutoff. When
+                set, undated documents are always excluded.
             min_chunk_index: The minimum chunk index to retrieve, inclusive. If
                 None, no minimum chunk index will be applied.
             max_chunk_index: The maximum chunk index to retrieve, inclusive. If

--- a/backend/onyx/document_index/opensearch/search.py
+++ b/backend/onyx/document_index/opensearch/search.py
@@ -231,6 +231,7 @@ class DocumentQuery:
             project_id_filter=index_filters.project_id_filter,
             persona_id_filter=index_filters.persona_id_filter,
             time_cutoff=index_filters.time_cutoff,
+            time_cutoff_upper=index_filters.time_cutoff_upper,
             min_chunk_index=min_chunk_index,
             max_chunk_index=max_chunk_index,
             max_chunk_size=max_chunk_size,
@@ -297,6 +298,7 @@ class DocumentQuery:
             project_id_filter=None,
             persona_id_filter=None,
             time_cutoff=None,
+            time_cutoff_upper=None,
             min_chunk_index=None,
             max_chunk_index=None,
             max_chunk_size=None,
@@ -369,6 +371,7 @@ class DocumentQuery:
             project_id_filter=index_filters.project_id_filter,
             persona_id_filter=index_filters.persona_id_filter,
             time_cutoff=index_filters.time_cutoff,
+            time_cutoff_upper=index_filters.time_cutoff_upper,
             min_chunk_index=None,
             max_chunk_index=None,
             attached_document_ids=index_filters.attached_document_ids,
@@ -464,6 +467,7 @@ class DocumentQuery:
             project_id_filter=index_filters.project_id_filter,
             persona_id_filter=index_filters.persona_id_filter,
             time_cutoff=index_filters.time_cutoff,
+            time_cutoff_upper=index_filters.time_cutoff_upper,
             min_chunk_index=None,
             max_chunk_index=None,
             attached_document_ids=index_filters.attached_document_ids,
@@ -546,6 +550,7 @@ class DocumentQuery:
             project_id_filter=index_filters.project_id_filter,
             persona_id_filter=index_filters.persona_id_filter,
             time_cutoff=index_filters.time_cutoff,
+            time_cutoff_upper=index_filters.time_cutoff_upper,
             min_chunk_index=None,
             max_chunk_index=None,
             attached_document_ids=index_filters.attached_document_ids,
@@ -607,6 +612,7 @@ class DocumentQuery:
             project_id_filter=index_filters.project_id_filter,
             persona_id_filter=index_filters.persona_id_filter,
             time_cutoff=index_filters.time_cutoff,
+            time_cutoff_upper=index_filters.time_cutoff_upper,
             min_chunk_index=None,
             max_chunk_index=None,
             attached_document_ids=index_filters.attached_document_ids,
@@ -846,6 +852,7 @@ class DocumentQuery:
         project_id_filter: int | None,
         persona_id_filter: int | None,
         time_cutoff: datetime | None,
+        time_cutoff_upper: datetime | None,
         min_chunk_index: int | None,
         max_chunk_index: int | None,
         max_chunk_size: int | None = None,
@@ -1080,27 +1087,37 @@ class DocumentQuery:
         def _get_persona_filter(persona_id: int) -> TermQuery[int]:
             return {"term": {PERSONAS_FIELD_NAME: {"value": persona_id}}}
 
-        def _get_time_cutoff_filter(time_cutoff: datetime) -> dict[str, Any]:
-            # Convert to UTC if not already so the cutoff is comparable to the
+        def _get_time_cutoff_filter(
+            time_cutoff: datetime | None,
+            time_cutoff_upper: datetime | None,
+        ) -> dict[str, Any]:
+            # Convert to UTC if not already so the bounds are comparable to the
             # document data.
-            time_cutoff = set_or_convert_timezone_to_utc(time_cutoff)
+            range_bounds: dict[str, int] = {}
+            if time_cutoff is not None:
+                time_cutoff = set_or_convert_timezone_to_utc(time_cutoff)
+                range_bounds["gte"] = int(time_cutoff.timestamp())
+            if time_cutoff_upper is not None:
+                time_cutoff_upper = set_or_convert_timezone_to_utc(time_cutoff_upper)
+                range_bounds["lte"] = int(time_cutoff_upper.timestamp())
+
             # Logical OR operator on its elements.
             time_cutoff_filter: dict[str, Any] = {
                 "bool": {"should": [], "minimum_should_match": 1}
             }
             time_cutoff_filter["bool"]["should"].append(
-                {
-                    "range": {
-                        LAST_UPDATED_FIELD_NAME: {"gte": int(time_cutoff.timestamp())}
-                    }
-                }
+                {"range": {LAST_UPDATED_FIELD_NAME: range_bounds}}
             )
-            if time_cutoff < datetime.now(timezone.utc) - timedelta(
-                days=ASSUMED_DOCUMENT_AGE_DAYS
+            if (
+                time_cutoff is not None
+                and time_cutoff_upper is None
+                and time_cutoff
+                < datetime.now(timezone.utc) - timedelta(days=ASSUMED_DOCUMENT_AGE_DAYS)
             ):
-                # Since the time cutoff is older than ASSUMED_DOCUMENT_AGE_DAYS
-                # ago, we include documents which have no
-                # LAST_UPDATED_FIELD_NAME value.
+                # The lower bound is older than ASSUMED_DOCUMENT_AGE_DAYS ago and
+                # open-ended, so include documents which have no
+                # LAST_UPDATED_FIELD_NAME value. A bounded range excludes them —
+                # an undated doc cannot be shown to fall within the range.
                 time_cutoff_filter["bool"]["should"].append(
                     {
                         "bool": {
@@ -1267,13 +1284,14 @@ class DocumentQuery:
                 )
             filter_clauses.append(knowledge_filter)
 
-        if time_cutoff is not None:
-            # If a time cutoff is provided, the caller will only retrieve
-            # documents where the document was last updated at or after the time
-            # cutoff. For documents which do not have a value for
-            # LAST_UPDATED_FIELD_NAME, we assume some default age for the
-            # purposes of time cutoff.
-            filter_clauses.append(_get_time_cutoff_filter(time_cutoff))
+        if time_cutoff is not None or time_cutoff_upper is not None:
+            # When a time bound is provided, only retrieve documents whose last
+            # updated time falls within [time_cutoff, time_cutoff_upper] (either
+            # bound may be open). For documents with no LAST_UPDATED_FIELD_NAME
+            # value, see _get_time_cutoff_filter for the inclusion rule.
+            filter_clauses.append(
+                _get_time_cutoff_filter(time_cutoff, time_cutoff_upper)
+            )
 
         if min_chunk_index is not None or max_chunk_index is not None:
             filter_clauses.append(

--- a/backend/onyx/document_index/vespa/shared_utils/vespa_request_builders.py
+++ b/backend/onyx/document_index/vespa/shared_utils/vespa_request_builders.py
@@ -125,16 +125,30 @@ def build_vespa_filters(
 
     def _build_time_filter(
         cutoff: datetime | None,
+        cutoff_upper: datetime | None = None,
         untimed_doc_cutoff: timedelta = timedelta(days=92),
     ) -> str:
-        if not cutoff:
+        if not cutoff and not cutoff_upper:
             return ""
-        include_untimed = datetime.now(timezone.utc) - untimed_doc_cutoff > cutoff
-        cutoff_secs = int(cutoff.timestamp())
 
-        if include_untimed:
-            return f"!({DOC_UPDATED_AT} < {cutoff_secs})"
-        return f"({DOC_UPDATED_AT} >= {cutoff_secs})"
+        clauses: list[str] = []
+        if cutoff:
+            # Untimed docs (no doc_updated_at) are only included for an old, open-
+            # ended lower bound. A bounded range excludes them — an undated doc
+            # cannot be shown to fall within [cutoff, cutoff_upper].
+            include_untimed = (
+                cutoff_upper is None
+                and datetime.now(timezone.utc) - untimed_doc_cutoff > cutoff
+            )
+            cutoff_secs = int(cutoff.timestamp())
+            if include_untimed:
+                clauses.append(f"!({DOC_UPDATED_AT} < {cutoff_secs})")
+            else:
+                clauses.append(f"({DOC_UPDATED_AT} >= {cutoff_secs})")
+        if cutoff_upper:
+            clauses.append(f"({DOC_UPDATED_AT} <= {int(cutoff_upper.timestamp())})")
+
+        return " and ".join(clauses)
 
     def _build_user_project_filter(
         project_id: int | None,
@@ -229,7 +243,10 @@ def build_vespa_filters(
         filter_parts.append(knowledge_scope_parts[0])
 
     # Time filter
-    _append(filter_parts, _build_time_filter(filters.time_cutoff))
+    _append(
+        filter_parts,
+        _build_time_filter(filters.time_cutoff, filters.time_cutoff_upper),
+    )
 
     # # Knowledge Graph Filters
     # _append(filter_parts, _build_kg_filter(

--- a/backend/tests/external_dependency_unit/opensearch/test_assistant_knowledge_filter.py
+++ b/backend/tests/external_dependency_unit/opensearch/test_assistant_knowledge_filter.py
@@ -49,6 +49,7 @@ def _get_search_filters(
         project_id_filter=project_id_filter,
         persona_id_filter=persona_id_filter,
         time_cutoff=None,
+        time_cutoff_upper=None,
         min_chunk_index=None,
         max_chunk_index=None,
         max_chunk_size=None,

--- a/backend/tests/unit/onyx/document_index/opensearch/test_time_cutoff_filter.py
+++ b/backend/tests/unit/onyx/document_index/opensearch/test_time_cutoff_filter.py
@@ -1,0 +1,124 @@
+"""Unit tests for the OpenSearch time-cutoff filter construction.
+
+These exercise `DocumentQuery._get_search_filters` directly (a pure DSL builder,
+no live OpenSearch) to pin how `time_cutoff` / `time_cutoff_upper` turn into the
+`last_updated` range clause, and when undated documents are included. Mirrors the
+Vespa coverage in `tests/unit/onyx/utils/test_vespa_query.py`.
+"""
+
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from typing import Any
+
+from onyx.document_index.interfaces_new import TenantState
+from onyx.document_index.opensearch.constants import ASSUMED_DOCUMENT_AGE_DAYS
+from onyx.document_index.opensearch.schema import LAST_UPDATED_FIELD_NAME
+from onyx.document_index.opensearch.search import DocumentQuery
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
+
+
+def _build_time_filters(
+    time_cutoff: datetime | None,
+    time_cutoff_upper: datetime | None,
+) -> list[dict[str, Any]]:
+    """Build the filter clauses with only the time bounds set. ACL and the
+    hidden clause are suppressed so the time clause (if any) is the sole result."""
+    return DocumentQuery._get_search_filters(
+        tenant_state=TenantState(tenant_id=POSTGRES_DEFAULT_SCHEMA, multitenant=False),
+        include_hidden=True,
+        access_control_list=None,
+        source_types=[],
+        tags=[],
+        document_sets=[],
+        project_id_filter=None,
+        persona_id_filter=None,
+        time_cutoff=time_cutoff,
+        time_cutoff_upper=time_cutoff_upper,
+        min_chunk_index=None,
+        max_chunk_index=None,
+        max_chunk_size=None,
+        document_id=None,
+        attached_document_ids=None,
+        hierarchy_node_ids=None,
+    )
+
+
+def _time_clause(filter_clauses: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Locate the time-cutoff clause: a bool/should whose first element is a
+    `range` on the last-updated field."""
+    for clause in filter_clauses:
+        should = clause.get("bool", {}).get("should")
+        if (
+            should
+            and "range" in should[0]
+            and LAST_UPDATED_FIELD_NAME in should[0]["range"]
+        ):
+            return clause
+    return None
+
+
+def _range_bounds(clause: dict[str, Any]) -> dict[str, int]:
+    return clause["bool"]["should"][0]["range"][LAST_UPDATED_FIELD_NAME]
+
+
+def _includes_undated(clause: dict[str, Any]) -> bool:
+    """Whether the clause ORs in documents that have no last-updated value."""
+    return any(
+        isinstance(sub.get("bool"), dict) and "must_not" in sub["bool"]
+        for sub in clause["bool"]["should"]
+    )
+
+
+def _old() -> datetime:
+    """A lower bound older than the undated-inclusion threshold."""
+    return datetime.now(timezone.utc) - timedelta(days=ASSUMED_DOCUMENT_AGE_DAYS + 10)
+
+
+def test_no_time_filter_produces_no_clause() -> None:
+    assert _time_clause(_build_time_filters(None, None)) is None
+
+
+def test_recent_lower_bound_excludes_undated() -> None:
+    """A recent lower bound is a strict `gte`; undated docs are not assumed
+    recent, so they are excluded."""
+    start = datetime.now(timezone.utc) - timedelta(days=1)
+    clause = _time_clause(_build_time_filters(start, None))
+    assert clause is not None
+    assert _range_bounds(clause) == {"gte": int(start.timestamp())}
+    assert not _includes_undated(clause)
+
+
+def test_old_open_ended_lower_bound_includes_undated() -> None:
+    """An old, open-ended lower bound assumes undated docs may be that old, so
+    they are OR'd in via a `must_not exists` should-element."""
+    start = _old()
+    clause = _time_clause(_build_time_filters(start, None))
+    assert clause is not None
+    assert _range_bounds(clause) == {"gte": int(start.timestamp())}
+    assert _includes_undated(clause)
+
+
+def test_upper_bound_only() -> None:
+    """An upper bound alone is a strict `lte`; undated docs are excluded (there
+    is no lower bound that could vouch for them)."""
+    end = datetime(2023, 6, 1, tzinfo=timezone.utc)
+    clause = _time_clause(_build_time_filters(None, end))
+    assert clause is not None
+    assert _range_bounds(clause) == {"lte": int(end.timestamp())}
+    assert not _includes_undated(clause)
+
+
+def test_bounded_range_excludes_undated_even_when_lower_bound_is_old() -> None:
+    """A bounded range emits both `gte` and `lte`. Undated docs are excluded even
+    though the lower bound is old — an undated doc cannot be shown to fall within
+    a closed range."""
+    start = _old()
+    end = datetime.now(timezone.utc) - timedelta(days=1)
+    clause = _time_clause(_build_time_filters(start, end))
+    assert clause is not None
+    assert _range_bounds(clause) == {
+        "gte": int(start.timestamp()),
+        "lte": int(end.timestamp()),
+    }
+    assert not _includes_undated(clause)

--- a/backend/tests/unit/onyx/utils/test_vespa_query.py
+++ b/backend/tests/unit/onyx/utils/test_vespa_query.py
@@ -203,6 +203,30 @@ class TestBuildVespaFilters:
             == result
         )
 
+    def test_time_range_filter(self) -> None:
+        """A bounded range emits strict >= and <= clauses and excludes untimed
+        docs (no `!(... < ...)` form), even when the lower bound is old."""
+        start = datetime(2020, 1, 1, tzinfo=timezone.utc)
+        end = datetime(2020, 1, 31, 23, 59, 59, tzinfo=timezone.utc)
+        filters = IndexFilters(
+            access_control_list=[], time_cutoff=start, time_cutoff_upper=end
+        )
+        result = build_vespa_filters(filters)
+        start_secs = int(start.timestamp())
+        end_secs = int(end.timestamp())
+        assert (
+            f"!({HIDDEN}=true) and ({DOC_UPDATED_AT} >= {start_secs}) and "
+            f"({DOC_UPDATED_AT} <= {end_secs}) and " == result
+        )
+
+    def test_time_upper_bound_only(self) -> None:
+        """An upper bound alone emits just a <= clause."""
+        end = datetime(2023, 6, 1, tzinfo=timezone.utc)
+        filters = IndexFilters(access_control_list=[], time_cutoff_upper=end)
+        result = build_vespa_filters(filters)
+        end_secs = int(end.timestamp())
+        assert f"!({HIDDEN}=true) and ({DOC_UPDATED_AT} <= {end_secs}) and " == result
+
     def test_combined_filters(self) -> None:
         """Test combining multiple filter types.
 


### PR DESCRIPTION
## Summary

Extends the document index filters with an **upper** bound on a document's last-updated time (`time_cutoff_upper`), so an internal search can scope to a closed `[time_cutoff, time_cutoff_upper]` range instead of only a lower cutoff. This is the index-layer plumbing only; the secondary-LLM time-filter flow that decides the window lives in a separate branch/PR.

## Changes

- **Interfaces** (`models.py`, `pipeline.py`): add `time_cutoff_upper: datetime | None` to `BaseFilters` (inherited by `IndexFilters`) and pass it through `_build_index_filters` into the final `IndexFilters`.
- **OpenSearch** (`opensearch/search.py`): thread `time_cutoff_upper` through the query builders; emit a single `range` clause with `gte` / `lte` as available. Undated documents (no `LAST_UPDATED_FIELD_NAME`) are only included for an **old, open-ended lower bound** — a bounded range excludes them, since an undated doc can't be shown to fall inside the range.
- **Vespa** (`vespa_request_builders.py`): `_build_time_filter` now builds `>=` and/or `<=` clauses joined with `and`, applying the same undated-doc rule.
- **Docs** (`FILTER_SEMANTICS.md`): document the new field and its range/undated semantics.

## Testing

- `test_vespa_query.py`: new cases for a bounded range (strict `>=` and `<=`, untimed docs excluded even when the lower bound is old) and an upper-bound-only filter.
- `test_assistant_knowledge_filter.py`: pass the new required arg.

Existing vespa unit tests pass (`pytest backend/tests/unit/onyx/utils/test_vespa_query.py`); `ty`, ruff, and ruff-format pass via pre-commit.

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an upper time bound (`time_cutoff_upper`) to the last-updated filter so searches can use a bounded [time_cutoff, time_cutoff_upper] range or an upper-only cutoff. Undated docs are only included for an old, open-ended lower bound; bounded and upper-only ranges exclude them.

- New Features
  - Added `time_cutoff_upper` to `BaseFilters`/`IndexFilters` and threaded it through the pipeline and all OpenSearch query builders.
  - OpenSearch: emit one `range` on `last_updated` with `gte`/`lte` as provided; OR-in undated docs only for an old, open-ended lower bound; documented the new arg in `_get_search_filters` docstring.
  - Vespa: build `>=`/`<=` clauses joined with `and`, with the same undated-doc rule.
  - Docs/tests: updated `FILTER_SEMANTICS.md` to note standalone `time_cutoff_upper`; added OpenSearch and Vespa unit tests for lower-only, upper-only, and bounded ranges; updated affected tests.

<sup>Written for commit 5dd2cb3a8891034c9f17f57a647ff4a194c8b2a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



