### PR TITLE
fix(indexing): deliver repeated-error connector notifications to admins

### DIFF
--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -94,11 +94,12 @@ from onyx.db.indexing_coordination import CoordinationStatus
 from onyx.db.indexing_coordination import IndexingCoordination
 from onyx.db.models import IndexAttempt
 from onyx.db.models import SearchSettings
-from onyx.db.notification import create_notification
-from onyx.db.notification import get_notifications
+from onyx.db.notification import batch_create_notifications
+from onyx.db.notification import delete_notifications_by_additional_data
 from onyx.db.search_settings import get_current_search_settings
 from onyx.db.search_settings import get_secondary_search_settings
 from onyx.db.swap_index import check_and_perform_index_swap
+from onyx.db.users import get_active_admin_users
 from onyx.document_index.factory import get_all_document_indices
 from onyx.error_handling.exceptions import OnyxError
 from onyx.file_store.document_batch_storage import DocumentBatchStorage
@@ -622,19 +623,13 @@ def check_indexing_completion(
             if cc_pair.in_repeated_error_state:
                 cc_pair.in_repeated_error_state = False
 
-                # Delete any existing error notification for this CC pair so a
-                # fresh one is created if the connector fails again later.
-                for notif in get_notifications(
-                    user=None,
-                    db_session=db_session,
+                # Clear every admin's error notification for this connector so a
+                # fresh one is created if it fails again later.
+                delete_notifications_by_additional_data(
                     notif_type=NotificationType.CONNECTOR_REPEATED_ERRORS,
-                    include_dismissed=True,
-                ):
-                    if (
-                        notif.additional_data
-                        and notif.additional_data.get("cc_pair_id") == cc_pair.id
-                    ):
-                        db_session.delete(notif)
+                    db_session=db_session,
+                    additional_data={"cc_pair_id": cc_pair.id},
+                )
 
                 db_session.commit()
                 on_connector_error_state_change(
@@ -1002,8 +997,11 @@ def check_for_indexing(self: Task, *, tenant_id: str) -> int | None:
                     )
                     source = cc_pair.connector.source.value
                     connector_url = f"/admin/connector/{cc_pair.id}"
-                    create_notification(
-                        user_id=None,
+                    admin_ids = [
+                        admin.id for admin in get_active_admin_users(db_session)
+                    ]
+                    batch_create_notifications(
+                        user_ids=admin_ids,
                         notif_type=NotificationType.CONNECTOR_REPEATED_ERRORS,
                         db_session=db_session,
                         title=f"Connector '{connector_name}' has entered repeated error state",

--- a/backend/onyx/db/notification.py
+++ b/backend/onyx/db/notification.py
@@ -97,17 +97,11 @@ def delete_notifications_by_additional_data(
     used at creation, so it clears exactly the rows create_notification /
     batch_create_notifications would have written for the same key."""
     additional_data_normalized = additional_data if additional_data is not None else {}
-    notifications = (
-        db_session.query(Notification)
-        .filter_by(notif_type=notif_type)
-        .filter(
-            func.coalesce(Notification.additional_data, cast({}, postgresql.JSONB))
-            == additional_data_normalized
-        )
-        .all()
-    )
-    for notification in notifications:
-        db_session.delete(notification)
+    db_session.query(Notification).filter(
+        Notification.notif_type == notif_type,
+        func.coalesce(Notification.additional_data, cast({}, postgresql.JSONB))
+        == additional_data_normalized,
+    ).delete(synchronize_session=False)
 
 
 def get_notification_by_id(

--- a/backend/onyx/db/notification.py
+++ b/backend/onyx/db/notification.py
@@ -87,6 +87,29 @@ def create_notification(
     return notification
 
 
+def delete_notifications_by_additional_data(
+    notif_type: NotificationType,
+    db_session: Session,
+    additional_data: dict | None = None,
+) -> None:
+    """Delete every notification of this type whose additional_data matches,
+    regardless of user. Matches the COALESCE(additional_data, '{}') equality
+    used at creation, so it clears exactly the rows create_notification /
+    batch_create_notifications would have written for the same key."""
+    additional_data_normalized = additional_data if additional_data is not None else {}
+    notifications = (
+        db_session.query(Notification)
+        .filter_by(notif_type=notif_type)
+        .filter(
+            func.coalesce(Notification.additional_data, cast({}, postgresql.JSONB))
+            == additional_data_normalized
+        )
+        .all()
+    )
+    for notification in notifications:
+        db_session.delete(notification)
+
+
 def get_notification_by_id(
     notification_id: int, user: User, db_session: Session
 ) -> Notification:

--- a/backend/tests/external_dependency_unit/db/test_notification.py
+++ b/backend/tests/external_dependency_unit/db/test_notification.py
@@ -489,6 +489,16 @@ def test_delete_notifications_by_additional_data_clears_all_admins_for_cc_pair(
         == 2
     )
 
+    # Dismissal must not shield a row from recovery cleanup — otherwise a
+    # dismissed-then-recovered connector would never alert again.
+    dismissed_row = next(
+        n
+        for n in rows_for(NotificationType.CONNECTOR_REPEATED_ERRORS)
+        if n.user_id == admin_one.id and n.additional_data == {"cc_pair_id": 1}
+    )
+    dismissed_row.dismissed = True
+    db_session.commit()
+
     delete_notifications_by_additional_data(
         notif_type=NotificationType.CONNECTOR_REPEATED_ERRORS,
         db_session=db_session,

--- a/backend/tests/external_dependency_unit/db/test_notification.py
+++ b/backend/tests/external_dependency_unit/db/test_notification.py
@@ -10,8 +10,10 @@ from sqlalchemy.orm import Session
 from onyx.configs.constants import NotificationType
 from onyx.db.models import Notification
 from onyx.db.models import User
+from onyx.db.notification import batch_create_notifications
 from onyx.db.notification import count_notifications
 from onyx.db.notification import create_notification
+from onyx.db.notification import delete_notifications_by_additional_data
 from onyx.db.notification import dismiss_user_notifications
 from onyx.db.notification import get_notifications
 from onyx.server.features.notifications import api as notifications_api
@@ -427,6 +429,79 @@ def test_notification_summary_and_dismiss_all_api(
         select(Notification).where(Notification.id == other_user_notification.id)
     ).one()
     assert other_user_row.dismissed is False
+
+
+def test_delete_notifications_by_additional_data_clears_all_admins_for_cc_pair(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    # Mirrors the connector-error flow: an alert is fanned out to every admin
+    # on error, then cleared for all of them when the connector recovers.
+    admin_one = create_test_user(db_session, "notif_delete_admin_one")
+    admin_two = create_test_user(db_session, "notif_delete_admin_two")
+
+    batch_create_notifications(
+        user_ids=[admin_one.id, admin_two.id],
+        notif_type=NotificationType.CONNECTOR_REPEATED_ERRORS,
+        db_session=db_session,
+        title="Connector in repeated error state",
+        additional_data={"cc_pair_id": 1},
+    )
+    # A different connector and a different type must survive the targeted clear.
+    create_notification(
+        user_id=admin_one.id,
+        notif_type=NotificationType.CONNECTOR_REPEATED_ERRORS,
+        db_session=db_session,
+        title="Other connector in repeated error state",
+        additional_data={"cc_pair_id": 2},
+    )
+    create_notification(
+        user_id=admin_one.id,
+        notif_type=NotificationType.APPROVAL_REQUESTED,
+        db_session=db_session,
+        title="Approval for cc_pair 1",
+        additional_data={"cc_pair_id": 1},
+    )
+
+    admin_ids = [admin_one.id, admin_two.id]
+
+    def rows_for(notif_type: NotificationType) -> list[Notification]:
+        # Scope to the users this test created — the shared DB carries committed
+        # rows from other tests, so a global query by type is not isolated.
+        return list(
+            db_session.scalars(
+                select(Notification).where(
+                    Notification.user_id.in_(admin_ids),
+                    Notification.notif_type == notif_type,
+                )
+            ).all()
+        )
+
+    # Both admins start with a cc_pair_id=1 error notification.
+    assert (
+        len(
+            [
+                n
+                for n in rows_for(NotificationType.CONNECTOR_REPEATED_ERRORS)
+                if n.additional_data == {"cc_pair_id": 1}
+            ]
+        )
+        == 2
+    )
+
+    delete_notifications_by_additional_data(
+        notif_type=NotificationType.CONNECTOR_REPEATED_ERRORS,
+        db_session=db_session,
+        additional_data={"cc_pair_id": 1},
+    )
+    db_session.commit()
+
+    # Every admin's cc_pair_id=1 row is gone; the cc_pair_id=2 row is untouched.
+    assert [
+        n.additional_data for n in rows_for(NotificationType.CONNECTOR_REPEATED_ERRORS)
+    ] == [{"cc_pair_id": 2}]
+    # A different notif_type with the same cc_pair_id is not affected.
+    assert len(rows_for(NotificationType.APPROVAL_REQUESTED)) == 1
 
 
 def _disable_notification_ensure_checks(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Description

#10207 added an admin notification when a connector enters repeated-error state, but no admin ever saw it.

**Bug:** the notification was written with `user_id=None`. `GET /notifications` only returns rows where `user_id == <requesting user>.id` (`_notification_filters`), and nothing merges global `user_id IS NULL` rows into that list — so the row was written but never read.

**Fix:**
- Fan the alert out to every active admin via `get_active_admin_users` + `batch_create_notifications` (same delivery pattern as release notes / license-expiry warnings).
- On recovery, clear all admins' rows for the connector via a new `delete_notifications_by_additional_data` helper, so a fresh alert fires if it fails again. Deletes regardless of `dismissed`, also closing the prior "re-entry after dismissal" gap.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check