### PR TITLE
fix(web): show "Indexing" not "Error" during an in-progress index attempt

### DIFF
--- a/web/src/components/Status.tsx
+++ b/web/src/components/Status.tsx
@@ -171,7 +171,9 @@ export function CCPairStatus({
         Paused
       </Badge>
     );
-  } else if (inRepeatedErrorState) {
+  } else if (inRepeatedErrorState && lastIndexAttemptStatus !== "in_progress") {
+    // A live attempt reads as "Indexing". The sticky error state only shows
+    // once that attempt is no longer running.
     badge = (
       <Badge variant="destructive" icon={FiAlertTriangle}>
         Error


### PR DESCRIPTION
## Description

The connector **Status** badge read **Error** even while an index attempt was actively running (docs flowing, attempt shown "In Progress" in the table below).

**Cause:** `CCPairStatus` checks the sticky `in_repeated_error_state` flag before the in-progress check, so the error branch short-circuits and the "Indexing" branch is never reached. The backend only clears that flag on a successful attempt, so it stays set throughout a retry.

**Fix:** Skip the error branch while the latest attempt is `in_progress`, letting it fall through to the existing "Indexing" badge. The backend flag is untouched. It intentionally persists so a just-unpaused connector is not immediately re-paused.

Shared component, so this also corrects the connector list at `/admin/indexing/status`.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check