### PR TITLE
feat(skills): add share permission schema

### DIFF
--- a/backend/alembic/versions/a4c9d2e7f1b8_skill_sharing_permissions.py
+++ b/backend/alembic/versions/a4c9d2e7f1b8_skill_sharing_permissions.py
@@ -1,0 +1,62 @@
+"""skill sharing permissions
+
+Revision ID: a4c9d2e7f1b8
+Revises: 99c855a8f2a1
+Create Date: 2026-06-30
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "a4c9d2e7f1b8"
+down_revision = "99c855a8f2a1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "skill",
+        sa.Column(
+            "public_permission",
+            sa.String(),
+            nullable=True,
+        ),
+    )
+    op.drop_column("skill", "is_public")
+    op.add_column(
+        "skill__user_group",
+        sa.Column("permission", sa.String(), nullable=False, server_default="VIEWER"),
+    )
+    op.create_table(
+        "skill__user",
+        sa.Column("skill_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("permission", sa.String(), nullable=False, server_default="VIEWER"),
+        sa.ForeignKeyConstraint(
+            ["skill_id"],
+            ["skill.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["user.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("skill_id", "user_id"),
+    )
+    op.create_index("ix_skill__user_user_id", "skill__user", ["user_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_skill__user_user_id", table_name="skill__user")
+    op.drop_table("skill__user")
+    op.drop_column("skill__user_group", "permission")
+    op.add_column(
+        "skill",
+        sa.Column("is_public", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    op.drop_column("skill", "public_permission")

--- a/backend/alembic/versions/a4c9d2e7f1b8_skill_sharing_permissions.py
+++ b/backend/alembic/versions/a4c9d2e7f1b8_skill_sharing_permissions.py
@@ -26,6 +26,7 @@ def upgrade() -> None:
             nullable=True,
         ),
     )
+    op.execute("UPDATE skill SET public_permission = 'VIEWER' WHERE is_public = true")
     op.drop_column("skill", "is_public")
     op.add_column(
         "skill__user_group",
@@ -59,4 +60,6 @@ def downgrade() -> None:
         "skill",
         sa.Column("is_public", sa.Boolean(), nullable=False, server_default=sa.false()),
     )
+    op.execute("UPDATE skill SET is_public = true WHERE public_permission IS NOT NULL")
+    op.alter_column("skill", "is_public", server_default=None)
     op.drop_column("skill", "public_permission")

--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -581,6 +581,14 @@ class PersonaSharePermission(str, PyEnum):
     VIEWER = "VIEWER"
 
 
+class SkillSharePermission(str, PyEnum):
+    """Level granted by a skill share row (user or group), or to the whole org
+    via `Skill.public_permission`."""
+
+    EDITOR = "EDITOR"
+    VIEWER = "VIEWER"
+
+
 class PersonaAccessLevel(str, PyEnum):
     """Computed access the requesting user holds on a persona.
 

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -36,12 +36,14 @@ from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql import JSONB as PGJSONB
 from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlalchemy.engine.interfaces import Dialect
+from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import DeclarativeBase
 from sqlalchemy.orm import Mapped
 from sqlalchemy.orm import mapped_column
 from sqlalchemy.orm import Mapper
 from sqlalchemy.orm import relationship
 from sqlalchemy.orm import validates
+from sqlalchemy.sql.elements import ColumnElement
 from sqlalchemy.types import LargeBinary
 from sqlalchemy.types import TypeDecorator
 from typing_extensions import TypedDict  # noreorder
@@ -96,6 +98,7 @@ from onyx.db.enums import ScheduledTaskStatus
 from onyx.db.enums import ScheduledTaskTriggerSource
 from onyx.db.enums import SessionOrigin
 from onyx.db.enums import SharingScope
+from onyx.db.enums import SkillSharePermission
 from onyx.db.enums import SwitchoverType
 from onyx.db.enums import SyncStatus
 from onyx.db.enums import SyncType
@@ -633,6 +636,30 @@ class Persona__User(Base):
     )
 
     user: Mapped["User | None"] = relationship("User")
+
+
+class Skill__User(Base):
+    __tablename__ = "skill__user"
+
+    skill_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("skill.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    user_id: Mapped[UUID] = mapped_column(
+        ForeignKey("user.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    permission: Mapped[SkillSharePermission] = mapped_column(
+        Enum(SkillSharePermission, native_enum=False),
+        nullable=False,
+        default=SkillSharePermission.VIEWER,
+        server_default=SkillSharePermission.VIEWER.value,
+    )
+
+    user: Mapped["User"] = relationship("User")
+
+    __table_args__ = (Index("ix_skill__user_user_id", "user_id"),)
 
 
 class DocumentSet__User(Base):
@@ -4294,8 +4321,24 @@ class Skill(Base):
         ForeignKey("user.id", ondelete="SET NULL"),
         nullable=True,
     )
-    is_public: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    public_permission: Mapped[SkillSharePermission | None] = mapped_column(
+        Enum(SkillSharePermission, native_enum=False),
+        nullable=True,
+    )
     enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+
+    @hybrid_property
+    def is_public(self) -> bool:
+        return self.public_permission is not None
+
+    @is_public.inplace.setter
+    def _is_public_setter(self, value: bool) -> None:
+        self.public_permission = SkillSharePermission.VIEWER if value else None
+
+    @is_public.inplace.expression
+    @classmethod
+    def _is_public_expression(cls) -> ColumnElement[bool]:
+        return cls.public_permission.isnot(None)
 
     created_at: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
@@ -4312,10 +4355,27 @@ class Skill(Base):
         foreign_keys=[author_user_id],
     )
 
+    users: Mapped[list[User]] = relationship(
+        "User",
+        secondary=Skill__User.__table__,
+        viewonly=True,
+        overlaps="user_shares",
+    )
+    user_shares: Mapped[list[Skill__User]] = relationship(
+        "Skill__User",
+        viewonly=True,
+        overlaps="users",
+    )
+    group_shares: Mapped[list["Skill__UserGroup"]] = relationship(
+        "Skill__UserGroup",
+        viewonly=True,
+        overlaps="groups",
+    )
     groups: Mapped[list["UserGroup"]] = relationship(
         "UserGroup",
         secondary="skill__user_group",
         viewonly=True,
+        overlaps="group_shares",
     )
 
     __table_args__ = (
@@ -4473,6 +4533,14 @@ class Skill__UserGroup(Base):
         ForeignKey("user_group.id", ondelete="CASCADE"),
         primary_key=True,
     )
+    permission: Mapped[SkillSharePermission] = mapped_column(
+        Enum(SkillSharePermission, native_enum=False),
+        nullable=False,
+        default=SkillSharePermission.VIEWER,
+        server_default=SkillSharePermission.VIEWER.value,
+    )
+
+    user_group: Mapped["UserGroup"] = relationship("UserGroup")
 
 
 class LLMProvider__Persona(Base):

--- a/backend/tests/external_dependency_unit/craft/conftest.py
+++ b/backend/tests/external_dependency_unit/craft/conftest.py
@@ -23,6 +23,7 @@ from onyx.db.engine.sql_engine import SqlEngine
 from onyx.db.enums import AccountType
 from onyx.db.enums import BuildSessionStatus
 from onyx.db.enums import SandboxStatus
+from onyx.db.enums import SkillSharePermission
 from onyx.db.llm import fetch_default_llm_model
 from onyx.db.llm import fetch_existing_llm_provider
 from onyx.db.llm import remove_llm_provider
@@ -298,7 +299,7 @@ def seeded_skill(
             description=f"Seeded skill {slug}",
             bundle_file_id=bundle_file_id,
             bundle_sha256=bundle_sha256,
-            is_public=public,
+            public_permission=SkillSharePermission.VIEWER if public else None,
             enabled=True,
             author_user_id=author_user_id,
         )

--- a/backend/tests/external_dependency_unit/craft/db_helpers.py
+++ b/backend/tests/external_dependency_unit/craft/db_helpers.py
@@ -33,6 +33,7 @@ from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.enums import EndpointPolicy
 from onyx.db.enums import ExternalAppType
 from onyx.db.enums import SandboxStatus
+from onyx.db.enums import SkillSharePermission
 from onyx.db.models import ActionApproval
 from onyx.db.models import Connector
 from onyx.db.models import ConnectorCredentialPair
@@ -42,6 +43,7 @@ from onyx.db.models import ExternalAppPolicy
 from onyx.db.models import ExternalAppUserCredential
 from onyx.db.models import Sandbox
 from onyx.db.models import Skill
+from onyx.db.models import Skill__User
 from onyx.db.models import Skill__UserGroup
 from onyx.db.models import User
 from onyx.db.models import User__UserGroup
@@ -127,6 +129,7 @@ def make_skill(
     *,
     slug: str | None = None,
     is_public: bool = False,
+    public_permission: SkillSharePermission = SkillSharePermission.VIEWER,
     enabled: bool = True,
 ) -> Skill:
     """Create a single custom ``Skill`` row.
@@ -142,7 +145,7 @@ def make_skill(
         description="d",
         bundle_file_id=f"bundle-{uuid4().hex[:8]}",
         bundle_sha256="0" * 64,
-        is_public=is_public,
+        public_permission=public_permission if is_public else None,
         enabled=enabled,
     )
     db_session.add(skill)
@@ -173,7 +176,7 @@ def make_built_in_skill_row(
         built_in_skill_id=built_in_skill_id,
         bundle_file_id=None,
         bundle_sha256=None,
-        is_public=is_public,
+        public_permission=SkillSharePermission.VIEWER if is_public else None,
         enabled=enabled,
     )
     db_session.add(skill)
@@ -262,14 +265,48 @@ def make_user_credential(
     return cred
 
 
-def grant_skill_to_group(
-    db_session: Session, skill: Skill, group: UserGroup
-) -> Skill__UserGroup:
-    """Insert a ``Skill__UserGroup`` grant row."""
-    grant = Skill__UserGroup(skill_id=skill.id, user_group_id=group.id)
-    db_session.add(grant)
+def share_skill_with_user(
+    db_session: Session,
+    skill: Skill,
+    user: User,
+    permission: SkillSharePermission = SkillSharePermission.VIEWER,
+) -> Skill__User:
+    """Insert a ``Skill__User`` share row."""
+    share = Skill__User(
+        skill_id=skill.id,
+        user_id=user.id,
+        permission=permission,
+    )
+    db_session.add(share)
     db_session.flush()
-    return grant
+    return share
+
+
+def share_skill_with_group(
+    db_session: Session,
+    skill: Skill,
+    group: UserGroup,
+    permission: SkillSharePermission = SkillSharePermission.VIEWER,
+) -> Skill__UserGroup:
+    """Insert a ``Skill__UserGroup`` share row."""
+    share = Skill__UserGroup(
+        skill_id=skill.id,
+        user_group_id=group.id,
+        permission=permission,
+    )
+    db_session.add(share)
+    db_session.flush()
+    return share
+
+
+def grant_skill_to_group(
+    db_session: Session,
+    skill: Skill,
+    group: UserGroup,
+    permission: SkillSharePermission = SkillSharePermission.VIEWER,
+) -> Skill__UserGroup:
+    """Backward-compatible alias for group skill shares."""
+    return share_skill_with_group(db_session, skill, group, permission)
 
 
 def make_cc_pair(


### PR DESCRIPTION
## Description

Add the schema foundation for skill sharing permissions. This introduces explicit share permissions for public, group, and direct user sharing, adds the direct user share table and ORM relationships, and includes the Alembic migration/downgrade path.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
