### PR TITLE
fix: scope cross-tenant permission caches per tenant/instance

### DIFF
--- a/backend/ee/onyx/external_permissions/salesforce/utils.py
+++ b/backend/ee/onyx/external_permissions/salesforce/utils.py
@@ -2,33 +2,32 @@ from simple_salesforce import Salesforce
 from simple_salesforce.format import format_soql
 from sqlalchemy.orm import Session
 
-from onyx.db.connector_credential_pair import get_connector_credential_pair_from_id
 from onyx.db.document import get_cc_pairs_for_document
 from onyx.utils.logger import setup_logger
+from shared_configs.contextvars import get_current_tenant_id
 
 logger = setup_logger()
 
-_ANY_SALESFORCE_CLIENT: Salesforce | None = None
+# Salesforce client per tenant, built from the first cc_pair of the first censored
+# doc. Keyed by tenant_id so one tenant's org + credentials are never reused to
+# resolve another tenant's access.
+_TENANT_SALESFORCE_CLIENT: dict[str, Salesforce] = {}
 
 
 def get_any_salesforce_client_for_doc_id(
     db_session: Session, doc_id: str
 ) -> Salesforce:
     """
-    We create a salesforce client for the first cc_pair for the first doc_id where
-    salesforce censoring is enabled. After that we just cache and reuse the same
-    client for all queries.
+    Return a cached Salesforce client for the current tenant, building it from the
+    first cc_pair of the given doc on first use. Cached to avoid a Postgres lookup
+    and a fresh client per query.
 
-    We do this to reduce the number of postgres queries we make at query time.
-
-    This may be problematic if they are using multiple cc_pairs for salesforce.
-    E.g. there are 2 different credential sets for 2 different salesforce cc_pairs
-    but only one has the permissions to access the permissions needed for the query.
+    Still imperfect when a tenant has multiple Salesforce cc_pairs with different
+    credentials: we use the first, which may lack the permissions the query needs.
     """
-
-    # NOTE: this global seems very very bad
-    global _ANY_SALESFORCE_CLIENT
-    if _ANY_SALESFORCE_CLIENT is None:
+    tenant_id = get_current_tenant_id()
+    client = _TENANT_SALESFORCE_CLIENT.get(tenant_id)
+    if client is None:
         cc_pairs = get_cc_pairs_for_document(db_session, doc_id)
         first_cc_pair = cc_pairs[0]
         credential_json = (
@@ -36,12 +35,13 @@ def get_any_salesforce_client_for_doc_id(
             if first_cc_pair.credential.credential_json
             else {}
         )
-        _ANY_SALESFORCE_CLIENT = Salesforce(
+        client = Salesforce(
             username=credential_json["sf_username"],
             password=credential_json["sf_password"],
             security_token=credential_json["sf_security_token"],
         )
-    return _ANY_SALESFORCE_CLIENT
+        _TENANT_SALESFORCE_CLIENT[tenant_id] = client
+    return client
 
 
 def _query_salesforce_user_id(sf_client: Salesforce, user_email: str) -> str | None:
@@ -65,9 +65,10 @@ def _query_salesforce_user_id(sf_client: Salesforce, user_email: str) -> str | N
     return None
 
 
-# This contains only the user_ids that we have found in Salesforce.
-# If we don't know their user_id, we don't store anything in the cache.
-_CACHED_SF_EMAIL_TO_ID_MAP: dict[str, str] = {}
+# (tenant_id, user_email) -> Salesforce user_id. Keyed by tenant so a shared email
+# never resolves to another tenant's Salesforce user. Only real (non-None) ids are
+# stored; unknown emails are re-queried each call.
+_CACHED_SF_EMAIL_TO_ID_MAP: dict[tuple[str, str], str] = {}
 
 
 def get_salesforce_user_id_from_email(
@@ -75,41 +76,19 @@ def get_salesforce_user_id_from_email(
     user_email: str,
 ) -> str | None:
     """
-    We cache this so we don't have to query Salesforce for every query and salesforce
-    user IDs never change.
-    Memory usage is fine because we just store 2 small strings per user.
-
-    If the email is not in the cache, we check the local salesforce database for the info.
-    If the user is not found in the local salesforce database, we query Salesforce.
-    Whatever we get back from Salesforce is added to the database.
-    If no user_id is found, we add a NULL_ID_STRING to the database for that email so
-    we don't query Salesforce again (which is slow) but we still check the local salesforce
-    database every query until a user id is found. This is acceptable because the query time
-    is quite fast.
-    If a user_id is created in Salesforce, it will be added to the local salesforce database
-    next time the connector is run. Then that value will be found in this function and cached.
-
-    NOTE: First time this runs, it may be slow if it hasn't already been updated in the local
-    salesforce database. (Around 0.1-0.3 seconds)
-    If it's cached or stored in the local salesforce database, it's fast (<0.001 seconds).
+    Resolve a Salesforce user_id for an email, cached per tenant since Salesforce
+    user ids are stable. A miss queries Salesforce (~0.1-0.3s); a hit is ~instant.
     """
+    cache_key = (get_current_tenant_id(), user_email)
+    cached_user_id = _CACHED_SF_EMAIL_TO_ID_MAP.get(cache_key)
+    if cached_user_id is not None:
+        return cached_user_id
 
-    # NOTE: this global seems bad
-    global _CACHED_SF_EMAIL_TO_ID_MAP
-    if user_email in _CACHED_SF_EMAIL_TO_ID_MAP:
-        if _CACHED_SF_EMAIL_TO_ID_MAP[user_email] is not None:
-            return _CACHED_SF_EMAIL_TO_ID_MAP[user_email]
-
-    # some caching via sqlite existed here before ... check history if interested
-
-    # ...query Salesforce and store the result in the database
     user_id = _query_salesforce_user_id(sf_client, user_email)
-
     if user_id is None:
         return None
 
-    # If the found user_id is real, cache it
-    _CACHED_SF_EMAIL_TO_ID_MAP[user_email] = user_id
+    _CACHED_SF_EMAIL_TO_ID_MAP[cache_key] = user_id
     return user_id
 
 
@@ -145,45 +124,3 @@ def get_objects_access_for_user_id(
     )
     result = salesforce_client.query_all(access_query)
     return {record["RecordId"]: record["HasReadAccess"] for record in result["records"]}
-
-
-_CC_PAIR_ID_SALESFORCE_CLIENT_MAP: dict[int, Salesforce] = {}
-_DOC_ID_TO_CC_PAIR_ID_MAP: dict[str, int] = {}
-
-
-# NOTE: This is not used anywhere.
-def _get_salesforce_client_for_doc_id(db_session: Session, doc_id: str) -> Salesforce:
-    """
-    Uses a document id to get the cc_pair that indexed that document and uses the credentials
-    for that cc_pair to create a Salesforce client.
-    Problems:
-    - There may be multiple cc_pairs for a document, and we don't know which one to use.
-        - right now we just use the first one
-    - Building a new Salesforce client for each document is slow.
-    - Memory usage could be an issue as we build these dictionaries.
-    """
-    if doc_id not in _DOC_ID_TO_CC_PAIR_ID_MAP:
-        cc_pairs = get_cc_pairs_for_document(db_session, doc_id)
-        first_cc_pair = cc_pairs[0]
-        _DOC_ID_TO_CC_PAIR_ID_MAP[doc_id] = first_cc_pair.id
-
-    cc_pair_id = _DOC_ID_TO_CC_PAIR_ID_MAP[doc_id]
-    if cc_pair_id not in _CC_PAIR_ID_SALESFORCE_CLIENT_MAP:
-        cc_pair = get_connector_credential_pair_from_id(
-            db_session=db_session,
-            cc_pair_id=cc_pair_id,
-        )
-        if cc_pair is None:
-            raise ValueError(f"CC pair {cc_pair_id} not found")
-        credential_json = (
-            cc_pair.credential.credential_json.get_value(apply_mask=False)
-            if cc_pair.credential.credential_json
-            else {}
-        )
-        _CC_PAIR_ID_SALESFORCE_CLIENT_MAP[cc_pair_id] = Salesforce(
-            username=credential_json["sf_username"],
-            password=credential_json["sf_password"],
-            security_token=credential_json["sf_security_token"],
-        )
-
-    return _CC_PAIR_ID_SALESFORCE_CLIENT_MAP[cc_pair_id]

--- a/backend/onyx/connectors/confluence/onyx_confluence.py
+++ b/backend/onyx/connectors/confluence/onyx_confluence.py
@@ -70,12 +70,16 @@ _CONFCLOUD_77618_404_BODY_SIGNATURES = (
 )
 
 _USER_NOT_FOUND = "Unknown Confluence User"
-_USER_ID_TO_DISPLAY_NAME_CACHE: dict[str, str | None] = {}
-_USER_EMAIL_CACHE: dict[str, str | None] = {}
+# All three caches are keyed by (confluence instance base url, identifier). The
+# Confluence Server/DC username and userKey namespaces are per-instance, so a bare
+# identifier key would let one instance's user resolve to another instance's email
+# when several Confluence connectors run in the same multi-tenant worker process.
+_USER_ID_TO_DISPLAY_NAME_CACHE: dict[tuple[str, str], str | None] = {}
+_USER_EMAIL_CACHE: dict[tuple[str, str], str | None] = {}
 # Separate cache from _USER_EMAIL_CACHE: the DC 9.1+ REST space-permissions
 # response only includes a user's userKey (CONFSERVER-100505), not their
 # username, so we have to resolve email by a different identifier.
-_USER_KEY_TO_EMAIL_CACHE: dict[str, str | None] = {}
+_USER_KEY_TO_EMAIL_CACHE: dict[tuple[str, str], str | None] = {}
 _DEFAULT_PAGINATION_LIMIT = 1000
 _MINIMUM_PAGINATION_LIMIT = 5
 
@@ -1298,7 +1302,8 @@ def get_user_email_from_username__server(
     confluence_client: OnyxConfluence, user_name: str
 ) -> str | None:
     global _USER_EMAIL_CACHE
-    if _USER_EMAIL_CACHE.get(user_name) is None:
+    cache_key = (confluence_client._url, user_name)
+    if _USER_EMAIL_CACHE.get(cache_key) is None:
         try:
             response = confluence_client.get_mobile_parameters(user_name)
             email = response.get("email")
@@ -1321,8 +1326,8 @@ def get_user_email_from_username__server(
                 e,
             )
             email = None
-        _USER_EMAIL_CACHE[user_name] = email
-    return _USER_EMAIL_CACHE[user_name]
+        _USER_EMAIL_CACHE[cache_key] = email
+    return _USER_EMAIL_CACHE[cache_key]
 
 
 def get_user_email_from_userkey__server(
@@ -1339,7 +1344,8 @@ def get_user_email_from_userkey__server(
     different (userKey is opaque hex, username is human-readable).
     """
     global _USER_KEY_TO_EMAIL_CACHE
-    if user_key not in _USER_KEY_TO_EMAIL_CACHE:
+    cache_key = (confluence_client._url, user_key)
+    if cache_key not in _USER_KEY_TO_EMAIL_CACHE:
         try:
             response = confluence_client.get_user_details_by_userkey(user_key)
             email = response.get("email") if isinstance(response, dict) else None
@@ -1360,8 +1366,8 @@ def get_user_email_from_userkey__server(
                 e,
             )
             email = None
-        _USER_KEY_TO_EMAIL_CACHE[user_key] = email
-    return _USER_KEY_TO_EMAIL_CACHE[user_key]
+        _USER_KEY_TO_EMAIL_CACHE[cache_key] = email
+    return _USER_KEY_TO_EMAIL_CACHE[cache_key]
 
 
 def _parse_dc_version(version_str: str) -> tuple[int, int] | None:
@@ -1388,7 +1394,8 @@ def _get_user(confluence_client: OnyxConfluence, user_id: str) -> str:
         str: The User Display Name. 'Unknown User' if the user is deactivated or not found
     """
     global _USER_ID_TO_DISPLAY_NAME_CACHE
-    if _USER_ID_TO_DISPLAY_NAME_CACHE.get(user_id) is None:
+    cache_key = (confluence_client._url, user_id)
+    if _USER_ID_TO_DISPLAY_NAME_CACHE.get(cache_key) is None:
         try:
             result = confluence_client.get_user_details_by_userkey(user_id)
             found_display_name = result.get("displayName")
@@ -1402,9 +1409,9 @@ def _get_user(confluence_client: OnyxConfluence, user_id: str) -> str:
             except Exception:
                 found_display_name = None
 
-        _USER_ID_TO_DISPLAY_NAME_CACHE[user_id] = found_display_name
+        _USER_ID_TO_DISPLAY_NAME_CACHE[cache_key] = found_display_name
 
-    return _USER_ID_TO_DISPLAY_NAME_CACHE.get(user_id) or _USER_NOT_FOUND
+    return _USER_ID_TO_DISPLAY_NAME_CACHE.get(cache_key) or _USER_NOT_FOUND
 
 
 def sanitize_attachment_title(title: str) -> str:

--- a/backend/tests/unit/ee/onyx/external_permissions/salesforce/test_salesforce_perm_cache_tenant_isolation.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/salesforce/test_salesforce_perm_cache_tenant_isolation.py
@@ -1,0 +1,77 @@
+"""Regression coverage for tenant isolation of the Salesforce permission-censoring
+caches: the per-tenant Salesforce client and the email->user_id map must never let
+one tenant's org, credentials, or resolved user id serve another tenant's access check."""
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import ee.onyx.external_permissions.salesforce.utils as sf_utils
+from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
+
+
+def test_email_to_id_cache_is_tenant_isolated() -> None:
+    sf_utils._CACHED_SF_EMAIL_TO_ID_MAP.clear()
+    email = "shared@example.com"
+    client = MagicMock()
+
+    with patch.object(sf_utils, "_query_salesforce_user_id") as mock_query:
+        mock_query.return_value = "id_a"
+        token = CURRENT_TENANT_ID_CONTEXTVAR.set("tenant_a")
+        try:
+            assert sf_utils.get_salesforce_user_id_from_email(client, email) == "id_a"
+            # second call for the same tenant is served from cache (no extra query)
+            assert sf_utils.get_salesforce_user_id_from_email(client, email) == "id_a"
+        finally:
+            CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+        assert mock_query.call_count == 1
+
+        # same email under a different tenant must not see tenant_a's cached id
+        mock_query.return_value = "id_b"
+        token = CURRENT_TENANT_ID_CONTEXTVAR.set("tenant_b")
+        try:
+            assert sf_utils.get_salesforce_user_id_from_email(client, email) == "id_b"
+        finally:
+            CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+        assert mock_query.call_count == 2
+
+
+def test_salesforce_client_cache_is_tenant_isolated() -> None:
+    sf_utils._TENANT_SALESFORCE_CLIENT.clear()
+    doc_id = "doc-1"
+
+    cc_pair = MagicMock()
+    cc_pair.credential.credential_json.get_value.return_value = {
+        "sf_username": "u",
+        "sf_password": "p",
+        "sf_security_token": "t",
+    }
+    client_a = object()
+    client_b = object()
+
+    with (
+        patch.object(sf_utils, "get_cc_pairs_for_document", return_value=[cc_pair]),
+        patch.object(
+            sf_utils, "Salesforce", side_effect=[client_a, client_b]
+        ) as mock_salesforce,
+    ):
+        db_session = MagicMock()
+
+        token = CURRENT_TENANT_ID_CONTEXTVAR.set("tenant_a")
+        try:
+            first = sf_utils.get_any_salesforce_client_for_doc_id(db_session, doc_id)
+            # repeat call reuses the same client for the tenant
+            second = sf_utils.get_any_salesforce_client_for_doc_id(db_session, doc_id)
+        finally:
+            CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+        assert first is client_a
+        assert second is client_a
+
+        token = CURRENT_TENANT_ID_CONTEXTVAR.set("tenant_b")
+        try:
+            other = sf_utils.get_any_salesforce_client_for_doc_id(db_session, doc_id)
+        finally:
+            CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+        # tenant_b gets its own client, never tenant_a's
+        assert other is client_b
+        # one client built per tenant, not per call
+        assert mock_salesforce.call_count == 2

--- a/backend/tests/unit/onyx/connectors/confluence/test_confluence_user_cache_instance_isolation.py
+++ b/backend/tests/unit/onyx/connectors/confluence/test_confluence_user_cache_instance_isolation.py
@@ -1,0 +1,76 @@
+"""Regression coverage for instance isolation of the Confluence user-resolution
+caches. Confluence Server/DC usernames and userKeys are unique only within one
+instance, so the username->email, userKey->email, and userid->display-name caches
+must key on the instance base url. Otherwise one instance's user can resolve to
+another instance's email (an ACL-affecting leak) when several Confluence connectors
+run in the same multi-tenant worker process."""
+
+from unittest.mock import MagicMock
+
+import onyx.connectors.confluence.onyx_confluence as onyx_confluence
+
+
+def _client(url: str) -> MagicMock:
+    client = MagicMock()
+    client._url = url
+    return client
+
+
+def test_username_email_cache_is_instance_isolated() -> None:
+    onyx_confluence._USER_EMAIL_CACHE.clear()
+    username = "jsmith"
+    client_a = _client("https://a.example.com")
+    client_a.get_mobile_parameters.return_value = {"email": "a@example.com"}
+    client_b = _client("https://b.example.com")
+    client_b.get_mobile_parameters.return_value = {"email": "b@example.com"}
+
+    assert (
+        onyx_confluence.get_user_email_from_username__server(client_a, username)
+        == "a@example.com"
+    )
+    # repeat call for the same instance is served from cache
+    assert (
+        onyx_confluence.get_user_email_from_username__server(client_a, username)
+        == "a@example.com"
+    )
+    assert client_a.get_mobile_parameters.call_count == 1
+
+    # same username on a different instance must not see instance A's email
+    assert (
+        onyx_confluence.get_user_email_from_username__server(client_b, username)
+        == "b@example.com"
+    )
+    assert client_b.get_mobile_parameters.call_count == 1
+
+
+def test_userkey_email_cache_is_instance_isolated() -> None:
+    onyx_confluence._USER_KEY_TO_EMAIL_CACHE.clear()
+    user_key = "ff8080816f"
+    client_a = _client("https://a.example.com")
+    client_a.get_user_details_by_userkey.return_value = {"email": "a@example.com"}
+    client_b = _client("https://b.example.com")
+    client_b.get_user_details_by_userkey.return_value = {"email": "b@example.com"}
+
+    assert (
+        onyx_confluence.get_user_email_from_userkey__server(client_a, user_key)
+        == "a@example.com"
+    )
+    assert (
+        onyx_confluence.get_user_email_from_userkey__server(client_b, user_key)
+        == "b@example.com"
+    )
+    assert client_a.get_user_details_by_userkey.call_count == 1
+    assert client_b.get_user_details_by_userkey.call_count == 1
+
+
+def test_display_name_cache_is_instance_isolated() -> None:
+    onyx_confluence._USER_ID_TO_DISPLAY_NAME_CACHE.clear()
+    user_id = "user-1"
+    client_a = _client("https://a.example.com")
+    client_a.get_user_details_by_userkey.return_value = {"displayName": "Alice A"}
+    client_b = _client("https://b.example.com")
+    client_b.get_user_details_by_userkey.return_value = {"displayName": "Bob B"}
+
+    assert onyx_confluence._get_user(client_a, user_id) == "Alice A"
+    # same id on a different instance must not see instance A's display name
+    assert onyx_confluence._get_user(client_b, user_id) == "Bob B"

--- a/backend/tests/unit/onyx/connectors/confluence/test_onyx_confluence.py
+++ b/backend/tests/unit/onyx/connectors/confluence/test_onyx_confluence.py
@@ -1440,7 +1440,7 @@ def test_get_user_email_from_userkey_caches_lookups(
     cache.
     """
     user_key = "test_userkey_unique_to_this_case"
-    onyx_confluence_module._USER_KEY_TO_EMAIL_CACHE.pop(user_key, None)
+    onyx_confluence_module._USER_KEY_TO_EMAIL_CACHE.clear()
 
     user_details_mock = mock.Mock(
         return_value={
@@ -1474,7 +1474,7 @@ def test_get_user_email_from_userkey_caches_negative_result(
     HTTP load and keeps the warning log from spamming.
     """
     user_key = "missing_userkey_unique_to_this_case"
-    onyx_confluence_module._USER_KEY_TO_EMAIL_CACHE.pop(user_key, None)
+    onyx_confluence_module._USER_KEY_TO_EMAIL_CACHE.clear()
 
     user_details_mock = mock.Mock(
         side_effect=HTTPError(response=_create_mock_response(404, {}, "x"))


### PR DESCRIPTION
## Description

Security fix found during a caching audit. Permission-resolution code cached results in process-global module state with no tenant/instance in the key, so in a shared multi-tenant worker one tenant's or instance's data served another's access check.

- **Salesforce** (`ee/onyx/external_permissions/salesforce/utils.py`): the query-time censoring client and email->user_id map are now keyed by `tenant_id`. Also deletes the unused `_get_salesforce_client_for_doc_id` and its globals (same latent defect).
- **Confluence** (`onyx/connectors/confluence/onyx_confluence.py`): the username->email, userKey->email, and userid->display-name caches are now keyed by `(instance base url, identifier)`. Server/DC usernames and userKeys are unique only within one instance.

Single-tenant and lite deployments are unaffected (default-schema / single-instance key, plain in-process dicts).

## How Has This Been Tested?

New unit tests assert the Salesforce (tenant) and Confluence (instance) caches are isolated. ruff + project-wide ty + pytest green locally.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check