### PR TITLE
fix(ci): gate cloud merge jobs on image-audit so they don't skip

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -625,6 +625,7 @@ jobs:
       - build-web-amd64
       - build-web-arm64
       - image-audit
+    if: always() && needs.build-web-amd64.result == 'success' && needs.build-web-arm64.result == 'success' && needs.image-audit.result == 'success'
     runs-on:
       - runs-on
       - runner=2cpu-linux-x64
@@ -862,6 +863,7 @@ jobs:
       - build-web-cloud-amd64
       - build-web-cloud-arm64
       - image-audit
+    if: always() && needs.build-web-cloud-amd64.result == 'success' && needs.build-web-cloud-arm64.result == 'success' && needs.image-audit.result == 'success'
     runs-on:
       - runs-on
       - runner=2cpu-linux-x64
@@ -1069,6 +1071,7 @@ jobs:
       - build-backend-amd64
       - build-backend-arm64
       - image-audit
+    if: always() && needs.build-backend-amd64.result == 'success' && needs.build-backend-arm64.result == 'success' && needs.image-audit.result == 'success'
     runs-on:
       - runs-on
       - runner=2cpu-linux-x64
@@ -1292,6 +1295,7 @@ jobs:
       - build-model-server-amd64
       - build-model-server-arm64
       - image-audit
+    if: always() && needs.build-model-server-amd64.result == 'success' && needs.build-model-server-arm64.result == 'success' && needs.image-audit.result == 'success'
     runs-on:
       - runs-on
       - runner=2cpu-linux-x64


### PR DESCRIPTION
## Description

**Bug:** PR #12547 added `image-audit` to the `needs:` of `merge-web`, `merge-web-cloud`, `merge-backend`, and `merge-model-server`, but only `merge-sandbox` got its `if:` updated to handle that dependency with `always()` + an explicit result check. The other four still use the implicit `success()` gate, which skips the job when a needed matrix job (`image-audit`) has skipped legs.

**Effect:** On the `v4.2.0-cloud.3` build ([run 28483934400](https://github.com/onyx-dot-app/onyx/actions/runs/28483934400)) all four merges skipped despite the cloud images building fine. The `build-*-amd64/arm64` jobs only push by digest, so the merge jobs are what create the `:<tag>` manifest and gate `dispatch-cloud-deployment`. Net result: the `onyxdotapp/onyx-*-cloud:v4.2.0-cloud.3` tags were never pushed and the cloud deploy never dispatched, while the run still showed green.

**Fix:** Give the four merge jobs the same `always()` + result-check gate `merge-sandbox` already has.

## How Has This Been Tested?

<!-- leave for reviewer -->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check