### PR TITLE
fix(mobile): sidebar chat titles, instant switch, live stream errors

### DIFF
--- a/mobile/src/api/chat/sessions.ts
+++ b/mobile/src/api/chat/sessions.ts
@@ -31,6 +31,18 @@ export async function getChatSession(
   return apiFetch<BackendChatSession>(`/chat/get-chat-session/${sessionId}`);
 }
 
+// name=null → backend LLM-generates the name. Callers refetch the list to show it.
+export async function nameChatSession(sessionId: string): Promise<string> {
+  const { new_name } = await apiFetch<{ new_name: string }>(
+    "/chat/rename-chat-session",
+    {
+      method: "PUT",
+      body: { chat_session_id: sessionId, name: null },
+    },
+  );
+  return new_name;
+}
+
 // client abort alone leaves the backend generating
 export async function stopChatSession(sessionId: string): Promise<void> {
   await apiFetch<void>(`/chat/stop-chat-session/${sessionId}`, {

--- a/mobile/src/api/chat/stream.ts
+++ b/mobile/src/api/chat/stream.ts
@@ -6,7 +6,11 @@ import { getBaseUrl } from "@/api/config";
 import { getToken } from "@/api/auth/tokenStore";
 import { createNdjsonBuffer } from "@/chat/ndjson";
 import { FileDescriptor } from "@/chat/interfaces";
-import { MessageResponseIDInfo, Packet } from "@/chat/streamingModels";
+import {
+  MessageResponseIDInfo,
+  Packet,
+  StreamingError,
+} from "@/chat/streamingModels";
 
 export interface SendMessageBody {
   message: string;
@@ -19,7 +23,7 @@ export interface SendMessageBody {
 }
 
 // The wire mixes wrapped packets ({placement, obj}) with root control objects; discriminate by field, not `type`.
-export type StreamEvent = Packet | MessageResponseIDInfo;
+export type StreamEvent = Packet | MessageResponseIDInfo | StreamingError;
 
 export function isPacket(event: StreamEvent): event is Packet {
   return "obj" in event && "placement" in event;
@@ -29,6 +33,10 @@ export function isMessageIdInfo(
   event: StreamEvent,
 ): event is MessageResponseIDInfo {
   return "user_message_id" in event;
+}
+
+export function isStreamingError(event: StreamEvent): event is StreamingError {
+  return "error" in event;
 }
 
 // Heartbeats come wrapped or at root; drop both.

--- a/mobile/src/app/(app)/_layout.tsx
+++ b/mobile/src/app/(app)/_layout.tsx
@@ -3,10 +3,11 @@ import { Stack } from "expo-router";
 import { AppSidebar } from "@/components/chat/AppSidebar";
 
 // Sidebar mounted here (not per-screen) so its overlay spans every (app) screen.
+// animation "none": no slide between chats — the sidebar folds away to reveal the new one.
 export default function AppLayout() {
   return (
     <>
-      <Stack screenOptions={{ headerShown: false }} />
+      <Stack screenOptions={{ headerShown: false, animation: "none" }} />
       <AppSidebar />
     </>
   );

--- a/mobile/src/chat/streamingModels.ts
+++ b/mobile/src/chat/streamingModels.ts
@@ -84,3 +84,13 @@ export interface MessageResponseIDInfo {
   user_message_id: number | null;
   reserved_assistant_message_id: number;
 }
+
+// Root object (not wrapped in Packet), streamed over a 200 when generation fails.
+// Discriminate by "error" presence. Mirrors backend `StreamingError`.
+export interface StreamingError {
+  error: string;
+  stack_trace?: string;
+  error_code?: string;
+  is_retryable?: boolean;
+  details?: Record<string, unknown>;
+}

--- a/mobile/src/hooks/__tests__/useChatController.test.tsx
+++ b/mobile/src/hooks/__tests__/useChatController.test.tsx
@@ -1,4 +1,11 @@
-import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
 import type { Mock } from "jest-mock";
 import * as React from "react";
 import { act, renderHook, waitFor } from "@testing-library/react-native";
@@ -7,9 +14,16 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   createChatSession,
   getChatSession,
+  nameChatSession,
   stopChatSession,
 } from "@/api/chat/sessions";
 import { streamChatMessage, type StreamEvent } from "@/api/chat/stream";
+import { QUERY_KEYS } from "@/api/query-keys";
+import {
+  buildImmediateMessages,
+  SYSTEM_NODE_ID,
+  upsertMessages,
+} from "@/chat/messageTree";
 import { PacketType } from "@/chat/streamingModels";
 import { useChatController } from "@/hooks/useChatController";
 import { useChatSessionStore } from "@/state/chatSessionStore";
@@ -27,10 +41,12 @@ jest.mock("@/api/chat/stream", () => ({
     "obj" in event && "placement" in event,
   isMessageIdInfo: (event: { user_message_id?: unknown }) =>
     "user_message_id" in event,
+  isStreamingError: (event: { error?: unknown }) => "error" in event,
 }));
 jest.mock("@/api/chat/sessions", () => ({
   createChatSession: jest.fn(),
   getChatSession: jest.fn(),
+  nameChatSession: jest.fn(),
   stopChatSession: jest.fn(),
 }));
 
@@ -45,6 +61,9 @@ const getSessionMock = getChatSession as unknown as Mock<
 >;
 const stopSessionMock = stopChatSession as unknown as Mock<
   (id: string) => Promise<void>
+>;
+const nameSessionMock = nameChatSession as unknown as Mock<
+  (id: string) => Promise<string>
 >;
 
 function startPacket(content: string): StreamEvent {
@@ -95,9 +114,18 @@ function accumulated(packets: { obj: { type: string; content?: string } }[]) {
 describe("useChatController", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    nameSessionMock.mockResolvedValue("Generated Name");
     useChatSessionStore.setState({
       currentSessionId: null,
       sessions: new Map(),
+    });
+  });
+
+  // Drain the ~200ms auto-naming timer (wrapped in act so late store updates don't warn)
+  // so a stray nameChatSession call can't bleed into the next test.
+  afterEach(async () => {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 220));
     });
   });
 
@@ -152,6 +180,105 @@ describe("useChatController", () => {
         true,
       ),
     );
+    // drain the naming timer so it doesn't bleed into later tests
+    await waitFor(() =>
+      expect(nameSessionMock).toHaveBeenCalledWith("new-session"),
+    );
+  });
+
+  it("names the new chat and refreshes the sidebar after the first response", async () => {
+    createSessionMock.mockResolvedValue("new-session");
+    streamMock.mockReturnValue(scripted([startPacket("Hi"), endPacket()]));
+
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    const invalidateSpy = jest.spyOn(client, "invalidateQueries");
+    function localWrapper({ children }: { children: React.ReactNode }) {
+      return (
+        <QueryClientProvider client={client}>{children}</QueryClientProvider>
+      );
+    }
+
+    const { result } = renderHook(() => useChatController(null), {
+      wrapper: localWrapper,
+    });
+    act(() => result.current.setInput("hello"));
+    await act(async () => {
+      await result.current.submit();
+    });
+
+    await waitFor(() =>
+      expect(nameSessionMock).toHaveBeenCalledWith("new-session"),
+    );
+    await waitFor(() =>
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: QUERY_KEYS.chatSessions("https://example.test"),
+      }),
+    );
+  });
+
+  it("does not auto-name a session that already has prior messages", async () => {
+    // seed s1 with a prior exchange → a real ongoing chat
+    const { initialUserNode, initialAgentNode } = buildImmediateMessages(
+      SYSTEM_NODE_ID,
+      "earlier message",
+      [],
+    );
+    useChatSessionStore
+      .getState()
+      .hydrateSession(
+        "s1",
+        upsertMessages(new Map(), [initialUserNode, initialAgentNode], true),
+      );
+    streamMock.mockReturnValue(scripted([startPacket("Hi"), endPacket()]));
+
+    const { result } = renderHook(() => useChatController("s1"), { wrapper });
+    act(() => result.current.setInput("follow up"));
+    await act(async () => {
+      await result.current.submit();
+    });
+
+    await waitFor(() => expect(result.current.chatState).toBe("input"));
+    expect(nameSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("auto-names an opened-but-empty session on its first message", async () => {
+    // reopened, unnamed, no user messages yet — must still name on the first message
+    useChatSessionStore.getState().ensureSession("s1");
+    streamMock.mockReturnValue(scripted([startPacket("Hi"), endPacket()]));
+
+    const { result } = renderHook(() => useChatController("s1"), { wrapper });
+    act(() => result.current.setInput("hi"));
+    await act(async () => {
+      await result.current.submit();
+    });
+
+    await waitFor(() => expect(nameSessionMock).toHaveBeenCalledWith("s1"));
+  });
+
+  it("renders a backend streaming error on the assistant node (live)", async () => {
+    useChatSessionStore.getState().ensureSession("s1");
+    // root-level StreamingError over a 200, not a wrapped packet
+    streamMock.mockReturnValue(
+      scripted([
+        { error: "Error from gpt-4o-mini: empty response" } as StreamEvent,
+      ]),
+    );
+
+    const { result } = renderHook(() => useChatController("s1"), { wrapper });
+    act(() => result.current.setInput("hi"));
+    await act(async () => {
+      await result.current.submit();
+    });
+
+    await waitFor(() => {
+      const last = result.current.messages[result.current.messages.length - 1];
+      expect(last?.type).toBe("error");
+    });
+    const errorNode = result.current.messages.find((m) => m.type === "error");
+    expect(errorNode?.message).toBe("Error from gpt-4o-mini: empty response");
+    await waitFor(() => expect(result.current.chatState).toBe("input"));
   });
 
   it("stop aborts the stream and stops the backend run", async () => {

--- a/mobile/src/hooks/useChatController.ts
+++ b/mobile/src/hooks/useChatController.ts
@@ -2,17 +2,20 @@
 // keeps writing by sessionId after the landing screen unmounts navigating into /chat/[id].
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { router } from "expo-router";
-import { useQuery } from "@tanstack/react-query";
+import { QueryClient, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { QUERY_KEYS } from "@/api/query-keys";
 import {
+  ChatSessionSummary,
   createChatSession,
   getChatSession,
+  nameChatSession,
   stopChatSession,
 } from "@/api/chat/sessions";
 import {
   isMessageIdInfo,
   isPacket,
+  isStreamingError,
   SendMessageBody,
   streamChatMessage,
 } from "@/api/chat/stream";
@@ -31,6 +34,40 @@ import { useChatSessionStore } from "@/state/chatSessionStore";
 import { useSession } from "@/state/session";
 
 const FLUSH_INTERVAL_MS = 50;
+// stream "finished" can beat the session's DB commit; wait before naming (web does too).
+const NAMING_DELAY_MS = 200;
+
+// Name from the cached sidebar list, to avoid re-naming an already-named chat.
+function getCachedSessionName(
+  queryClient: QueryClient,
+  serverUrl: string | null,
+  sessionId: string,
+): string | null {
+  const data = queryClient.getQueryData<{
+    pages: { sessions: ChatSessionSummary[] }[];
+  }>(QUERY_KEYS.chatSessions(serverUrl));
+  const session = data?.pages
+    .flatMap((page) => page.sessions)
+    .find((item) => item.id === sessionId);
+  return session?.name ?? null;
+}
+
+// After the first response: name the chat, then refetch the sidebar so the name shows.
+async function finalizeNewChatSession(
+  sessionId: string,
+  serverUrl: string | null,
+  queryClient: QueryClient,
+): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, NAMING_DELAY_MS));
+  try {
+    await nameChatSession(sessionId);
+  } catch {
+    // best-effort; still refetch so the chat shows (unnamed)
+  }
+  await queryClient.invalidateQueries({
+    queryKey: QUERY_KEYS.chatSessions(serverUrl),
+  });
+}
 
 async function runChatStream(
   sessionId: string,
@@ -84,6 +121,16 @@ async function runChatStream(
         });
         continue;
       }
+      // root error object → mark the node errored; else it's dropped and stuck on "…"
+      // until a reload hydrates the persisted error (web parity).
+      if (isStreamingError(event)) {
+        pending = [];
+        store.getState().patchNode(sessionId, agentNodeId, {
+          type: "error",
+          message: event.error,
+        });
+        break;
+      }
       if (isPacket(event)) {
         if (!sawStreaming) {
           sawStreaming = true;
@@ -124,6 +171,7 @@ export interface ChatController {
 export function useChatController(sessionId: string | null): ChatController {
   const [input, setInput] = useState("");
   const serverUrl = useSession((state) => state.serverUrl);
+  const queryClient = useQueryClient();
   const sessionData = useChatSessionStore((state) =>
     sessionId ? state.sessions.get(sessionId) : undefined,
   );
@@ -165,12 +213,17 @@ export function useChatController(sessionId: string | null): ChatController {
     // (the input is empty → canSend is false).
     setInput("");
 
+    const isNewSession = sessionId == null;
     let activeId = sessionId;
     if (activeId != null) {
       const current = useChatSessionStore.getState().sessions.get(activeId);
       if (current && current.chatState !== "input") return; // a run is already active
     } else {
       activeId = await createChatSession();
+      // show the new chat immediately (unnamed); finalize refetches once it's named
+      void queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS.chatSessions(serverUrl),
+      });
     }
 
     const store = useChatSessionStore.getState();
@@ -180,6 +233,11 @@ export function useChatController(sessionId: string | null): ChatController {
       useChatSessionStore.getState().sessions.get(activeId)?.messageTree ??
       new Map();
     const chain = getLatestMessageChain(tree);
+    // name on the first user message of an unnamed session — keyed on history, not
+    // `sessionId == null`, so a reopened empty session still gets named (web parity).
+    const shouldAutoName =
+      !chain.some((node) => node.type === "user") &&
+      !getCachedSessionName(queryClient, serverUrl, activeId)?.trim();
     const lastNode = chain[chain.length - 1];
     const parentNodeId = lastNode ? lastNode.nodeId : SYSTEM_NODE_ID;
     // -3 (synthetic root) → null; null = first message.
@@ -212,18 +270,23 @@ export function useChatController(sessionId: string | null): ChatController {
     };
 
     // replace so Back doesn't return to the empty landing
-    if (sessionId == null) {
+    if (isNewSession) {
       router.replace({ pathname: "/chat/[id]", params: { id: activeId } });
     }
 
-    void runChatStream(
+    const streamDone = runChatStream(
       activeId,
       initialUserNode.nodeId,
       initialAgentNode.nodeId,
       body,
       controller.signal,
     );
-  }, [input, sessionId]);
+    if (shouldAutoName) {
+      void streamDone
+        .then(() => finalizeNewChatSession(activeId, serverUrl, queryClient))
+        .catch(() => {});
+    }
+  }, [input, sessionId, serverUrl, queryClient]);
 
   const stop = useCallback(() => {
     if (sessionId == null) return;


### PR DESCRIPTION
## Description

- New chats now show their backend-generated title in the sidebar and header after the first response (previously it never appeared), matching web.
- Switching or starting a chat swaps content instantly instead of sliding the whole screen, so the sidebar overlay stays stable.
- Backend streaming errors (e.g. an empty LLM response) now render live on the assistant message instead of hanging on a "…" placeholder until the app is reopened.

## How Has This Been Tested?

- Added/updated jest unit tests (full mobile suite: 133 passing); `bun run typecheck` and `bun run lint` clean.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check