### PR TITLE
feat(mobile): add settings layout primitives + tab nav

### DIFF
--- a/mobile/src/components/settings/SettingsLayout.tsx
+++ b/mobile/src/components/settings/SettingsLayout.tsx
@@ -1,0 +1,105 @@
+import type { ReactNode } from "react";
+import { ScrollView, View } from "react-native";
+
+import { cn } from "@/lib/utils";
+import { Icon } from "@/components/ui/icon";
+import { Separator } from "@/components/ui/separator";
+import { Text } from "@/components/ui/text";
+import type { IconFunctionComponent } from "@/icons/types";
+
+// RN port of Opal `SettingsLayouts`. Sticky + scroll-shadow (web: only when Header has
+// `rightChildren`) is intentionally omitted. Web's `width` variants are dropped — a phone
+// is always narrower than the smallest cap; back-nav is the screen's chrome / OS gesture.
+
+interface SettingsRootProps {
+  children: ReactNode;
+  className?: string;
+}
+
+function SettingsRoot({ children, className }: SettingsRootProps) {
+  return (
+    <ScrollView
+      className={cn("flex-1", className)}
+      showsVerticalScrollIndicator={false}
+    >
+      {children}
+    </ScrollView>
+  );
+}
+
+interface SettingsHeaderProps {
+  icon: IconFunctionComponent;
+  title: string;
+  description?: string;
+  children?: ReactNode;
+  rightChildren?: ReactNode;
+  divider?: boolean;
+}
+
+function SettingsHeader({
+  icon,
+  title,
+  description,
+  children,
+  rightChildren,
+  divider,
+}: SettingsHeaderProps) {
+  return (
+    <View className="w-full">
+      <View className="h-16" />
+
+      <View className="gap-24 px-16">
+        <View className="w-full flex-row items-start justify-between">
+          <View className="flex-1 flex-col items-start">
+            <View className="items-center justify-center p-2">
+              <Icon as={icon} size={32} className="text-text-05" />
+            </View>
+            <Text font="heading-h2" color="text-05">
+              {title}
+            </Text>
+            {description ? (
+              <Text font="secondary-body" color="text-03" className="pt-2">
+                {description}
+              </Text>
+            ) : null}
+          </View>
+          {rightChildren ? <View>{rightChildren}</View> : null}
+        </View>
+
+        {children}
+      </View>
+
+      {divider ? (
+        <>
+          <View className="h-24" />
+          <View className="px-16">
+            <Separator />
+          </View>
+        </>
+      ) : (
+        <View className="h-8" />
+      )}
+    </View>
+  );
+}
+
+interface SettingsBodyProps {
+  children: ReactNode;
+  className?: string;
+}
+
+function SettingsBody({ children, className }: SettingsBodyProps) {
+  return (
+    <View className={cn("w-full flex-col gap-32 px-16 pb-72 pt-24", className)}>
+      {children}
+    </View>
+  );
+}
+
+export const SettingsLayout = {
+  Root: SettingsRoot,
+  Header: SettingsHeader,
+  Body: SettingsBody,
+};
+
+export type { SettingsRootProps, SettingsHeaderProps, SettingsBodyProps };

--- a/mobile/src/components/settings/SettingsTabNav.tsx
+++ b/mobile/src/components/settings/SettingsTabNav.tsx
@@ -16,15 +16,17 @@ interface SettingsTabNavProps {
 function SettingsTabNav({ tabs, activeHref, className }: SettingsTabNavProps) {
   return (
     <View className={cn("flex-col px-8", className)}>
-      {tabs.map((tab) => (
-        <SidebarTab
-          key={String(tab.href)}
-          href={tab.href}
-          selected={tab.href === activeHref}
-        >
-          {tab.label}
-        </SidebarTab>
-      ))}
+      {tabs.map((tab) => {
+        // Reduce a bare-path or object-form href to its pathname to match
+        // `activeHref` (a `usePathname()` string) and to key the list.
+        const path =
+          typeof tab.href === "string" ? tab.href : tab.href.pathname;
+        return (
+          <SidebarTab key={path} href={tab.href} selected={path === activeHref}>
+            {tab.label}
+          </SidebarTab>
+        );
+      })}
     </View>
   );
 }

--- a/mobile/src/components/settings/SettingsTabNav.tsx
+++ b/mobile/src/components/settings/SettingsTabNav.tsx
@@ -1,0 +1,32 @@
+import { View } from "react-native";
+
+import { cn } from "@/lib/utils";
+// Leaf import (not the barrel) keeps this reanimated-free / unit-testable.
+import { SidebarTab } from "@/components/sidebar/SidebarTab";
+import type { SettingsTab } from "@/components/settings/interfaces";
+
+// A phone renders the vertical `SidebarTab` column (web's `md:` layout), not the
+// narrow-screen dropdown.
+interface SettingsTabNavProps {
+  tabs: SettingsTab[];
+  activeHref: string;
+  className?: string;
+}
+
+function SettingsTabNav({ tabs, activeHref, className }: SettingsTabNavProps) {
+  return (
+    <View className={cn("flex-col px-8", className)}>
+      {tabs.map((tab) => (
+        <SidebarTab
+          key={String(tab.href)}
+          href={tab.href}
+          selected={tab.href === activeHref}
+        >
+          {tab.label}
+        </SidebarTab>
+      ))}
+    </View>
+  );
+}
+
+export { SettingsTabNav, type SettingsTabNavProps };

--- a/mobile/src/components/settings/interfaces.ts
+++ b/mobile/src/components/settings/interfaces.ts
@@ -1,0 +1,6 @@
+import type { Href } from "expo-router";
+
+export interface SettingsTab {
+  href: Href;
+  label: string;
+}

--- a/mobile/src/icons/sliders.tsx
+++ b/mobile/src/icons/sliders.tsx
@@ -1,0 +1,24 @@
+import Svg, { Path } from "react-native-svg";
+
+import type { IconProps } from "@/icons/types";
+
+// clipPath bounded to the full 16x16 viewBox is a visual no-op, so it's omitted.
+const SvgSliders = ({ size = 16, ...props }: IconProps) => (
+  <Svg
+    width={size}
+    height={size}
+    viewBox="0 0 16 16"
+    fill="none"
+    stroke="currentColor"
+    {...props}
+  >
+    <Path
+      d="M2.66666 14V9.33333M2.66666 6.66667V2M7.99999 14V8M7.99999 5.33333V2M13.3333 14V10.6667M13.3333 8V2M0.666656 9.33333H4.66666M5.99999 5.33333H9.99999M11.3333 10.6667H15.3333"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </Svg>
+);
+
+export default SvgSliders;


### PR DESCRIPTION
## Description

- Port web's Opal `SettingsLayouts` to the mobile app as reusable primitives: `SettingsLayout` (Root / Header / Body) plus `SettingsTabNav` (vertical section nav) and a `sliders` header icon.
- Phone-first and web-faithful: drops web's responsive width variants, the `InputSelect` dropdown, the sticky scroll-shadow, and the in-content back button (mobile back is the OS gesture / screen chrome); screen wiring is intentionally left to the consuming screens.

## How Has This Been Tested?

- Mobile typecheck, lint, and format pass; the primitives are presentational and not yet mounted in a screen.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
