### PR TITLE
fix(ci): gate dispatch-cloud-deployment with always() so it doesn't skip

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1684,7 +1684,14 @@ jobs:
       - merge-backend
       - merge-model-server
       - merge-sandbox
-    if: needs.determine-builds.outputs.is-cloud-tag == 'true' && needs.determine-builds.outputs.is-test-run != 'true'
+    if: >-
+      always()
+      && needs.merge-web-cloud.result == 'success'
+      && needs.merge-backend.result == 'success'
+      && needs.merge-model-server.result == 'success'
+      && needs.merge-sandbox.result == 'success'
+      && needs.determine-builds.outputs.is-cloud-tag == 'true'
+      && needs.determine-builds.outputs.is-test-run != 'true'
     # NOTE: Github-hosted runners have about 20s faster queue times and are preferred here.
     runs-on: ubuntu-slim
     timeout-minutes: 10


### PR DESCRIPTION
## Description

**Bug:** `dispatch-cloud-deployment` uses a plain `if:` with no `always()`. When the sandbox context image is already cached, `build-sandbox-amd64/arm64` are skipped and `merge-sandbox` only runs via its own `always()`. That skipped `build-sandbox` then propagates through the chain into `dispatch`'s implicit `success()` gate, so it skips even though all four cloud merges succeed.

Pre-existing (not from the recent image-audit change). Across cloud tags, `dispatch` ran iff `build-sandbox` was not skipped — it skipped on `cloud.0/3/4` and `4.1-cloud.8/9/10` (sandbox cached) and ran on `cloud.1/2` (sandbox built).

**Effect:** On `v4.2.0-cloud.4` ([run 28529602414](https://github.com/onyx-dot-app/onyx/actions/runs/28529602414)) the `:v4.2.0-cloud.4` images were pushed but the deploy dispatch never fired.

**Fix:** Give `dispatch-cloud-deployment` the same `always()` + explicit `.result == 'success'` gate `merge-sandbox` already uses, so it fires whenever the four cloud merges succeed on a non-test cloud tag, and still blocks if any merge fails.

## How Has This Been Tested?

<!-- leave for reviewer -->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check