### PR TITLE
chore(web): build frontend on a Docker Hardened Image

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -528,6 +528,15 @@ jobs:
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ env.DOCKER_TOKEN }}
 
+      # web/Dockerfile pulls its hardened Node base from dhi.io, authenticated with the same
+      # Docker account credentials (the account must have access to the DHI catalog).
+      - name: Login to Docker Hardened Images (dhi.io)
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        with:
+          registry: dhi.io
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ env.DOCKER_TOKEN }}
+
       - name: Build and push AMD64
         id: build
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
@@ -598,6 +607,15 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         with:
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ env.DOCKER_TOKEN }}
+
+      # web/Dockerfile pulls its hardened Node base from dhi.io, authenticated with the same
+      # Docker account credentials (the account must have access to the DHI catalog).
+      - name: Login to Docker Hardened Images (dhi.io)
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        with:
+          registry: dhi.io
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ env.DOCKER_TOKEN }}
 
@@ -743,6 +761,15 @@ jobs:
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ env.DOCKER_TOKEN }}
 
+      # web/Dockerfile pulls its hardened Node base from dhi.io, authenticated with the same
+      # Docker account credentials (the account must have access to the DHI catalog).
+      - name: Login to Docker Hardened Images (dhi.io)
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        with:
+          registry: dhi.io
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ env.DOCKER_TOKEN }}
+
       - name: Build and push AMD64
         id: build
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
@@ -824,6 +851,15 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         with:
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ env.DOCKER_TOKEN }}
+
+      # web/Dockerfile pulls its hardened Node base from dhi.io, authenticated with the same
+      # Docker account credentials (the account must have access to the DHI catalog).
+      - name: Login to Docker Hardened Images (dhi.io)
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        with:
+          registry: dhi.io
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ env.DOCKER_TOKEN }}
 

--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -168,6 +168,15 @@ jobs:
         with:
           ecr-registry: ${{ vars.ECR_REGISTRY }}
 
+      # web/Dockerfile pulls its hardened Node base from dhi.io, authenticated with the same
+      # Docker account credentials (the account must have access to the DHI catalog).
+      - name: Login to Docker Hardened Images (dhi.io)
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        with:
+          registry: dhi.io
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
       - name: Build and push Web Docker image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -306,6 +306,17 @@ If you want to make changes to Onyx and run those changes in Docker, you can als
 docker compose up -d --build
 ```
 
+> **Note:** Building the web image (`web/Dockerfile`) pulls its base from Docker Hardened
+> Images (`dhi.io`), so you must authenticate first with a Docker account that has access to
+> the DHI catalog:
+>
+> ```bash
+> docker login dhi.io
+> ```
+>
+> Pulling the pre-built `onyxdotapp/onyx-web-server` image (the default `docker compose up -d`
+> without `--build`) does not require this.
+
 ---
 
 ## macOS-Specific Notes

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -99,7 +99,7 @@ RUN --mount=type=secret,id=sentry_auth_token \
     NODE_OPTIONS="${NODE_OPTIONS}" npx next build
 
 # Runtime stage. The DHI runtime variant is near-distroless: no shell or package manager, runs
-# as the non-root `node` user (uid 1000), WORKDIR /app and ENTRYPOINT ["node"] pre-set.
+# as the non-root `node` user (uid 1000) with WORKDIR /app pre-set.
 # TODO(pin): pin by digest -- `docker login dhi.io` then
 # `docker buildx imagetools inspect dhi.io/node:24-debian13`.
 FROM dhi.io/node:24-debian13 AS runner
@@ -192,5 +192,5 @@ ENV ONYX_VERSION=${ONYX_VERSION}
 # name only — breaking loopback healthchecks. Force 0.0.0.0 instead.
 ENV HOSTNAME="0.0.0.0"
 
-# DHI presets ENTRYPOINT ["node"], so CMD is just the script path.
-CMD ["server.js"]
+# The DHI runtime image sets no default ENTRYPOINT, so invoke node explicitly.
+CMD ["node", "server.js"]

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -8,9 +8,8 @@ ARG BASE_IMAGE_REGISTRY=docker.io
 FROM ${BASE_IMAGE_REGISTRY}/oven/bun:1@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4 AS bun_source
 
 # Build stage. The DHI "-dev" variant runs as root and ships a shell, apt, and npm/npx.
-# TODO(pin): pin by digest -- `docker login dhi.io` then
-# `docker buildx imagetools inspect dhi.io/node:24-debian13-dev`.
-FROM dhi.io/node:24-debian13-dev AS builder
+# Refresh the digest with: docker buildx imagetools inspect dhi.io/node:24-debian13-dev
+FROM dhi.io/node:24-debian13-dev@sha256:25a83f18150669e9ce3c9437327add4d75ae4ea26cbdb5e8747b66d3b74a567a AS builder
 COPY --from=bun_source /usr/local/bin/bun /usr/local/bin/bun
 COPY --from=bun_source /usr/local/bin/bunx /usr/local/bin/bunx
 WORKDIR /app
@@ -100,9 +99,8 @@ RUN --mount=type=secret,id=sentry_auth_token \
 
 # Runtime stage. The DHI runtime variant is near-distroless: no shell or package manager, runs
 # as the non-root `node` user (uid 1000) with WORKDIR /app pre-set.
-# TODO(pin): pin by digest -- `docker login dhi.io` then
-# `docker buildx imagetools inspect dhi.io/node:24-debian13`.
-FROM dhi.io/node:24-debian13 AS runner
+# Refresh the digest with: docker buildx imagetools inspect dhi.io/node:24-debian13
+FROM dhi.io/node:24-debian13@sha256:805278f24c1146c6d3c96577b6256f8f97c43196fff88315fe3291a1ce118ddd AS runner
 
 LABEL com.onyx.maintainer="founders@onyx.app"
 LABEL com.onyx.description="This image is the web/frontend container of Onyx which \

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,18 +1,14 @@
-# Registry prefix for the bun binary source below. Defaults to Docker Hub; CI overrides this to
-# the ECR pull-through cache (<account>.dkr.ecr.us-east-2.amazonaws.com/docker-hub) to avoid
-# Docker Hub rate limits. NOTE: this applies only to `bun_source` -- the hardened Node base
-# images come from Docker Hardened Images (dhi.io), a separate registry that is NOT served by
-# the pull-through cache and requires `docker login dhi.io`.
+# Registry prefix for the bun binary source below. Defaults to Docker Hub; CI overrides it to
+# the ECR pull-through cache to dodge rate limits. Applies only to `bun_source` -- the DHI Node
+# bases come from dhi.io, a separate registry not served by the cache (see the FROM lines below).
 ARG BASE_IMAGE_REGISTRY=docker.io
 
-# bun binary source. Pinned via the registry prefix in its own stage because buildx
-# rejects variable expansion directly in `COPY --from=` -- the ARG is only expandable in a FROM.
-# Use the glibc (Debian) build so the binary runs on the glibc-based DHI node images below.
+# bun binary source, in its own stage because buildx only expands the registry ARG in a FROM,
+# not in `COPY --from=`. Use the glibc (Debian) build so it runs on the glibc DHI node images.
 FROM ${BASE_IMAGE_REGISTRY}/oven/bun:1@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4 AS bun_source
 
-# Step 1. Install dependencies + rebuild the source code only when needed.
-# The DHI "-dev" variant runs as root and ships a shell, apt, npm/npx, and git for the build.
-# TODO(pin): pin by digest once resolvable -- `docker login dhi.io` then
+# Build stage. The DHI "-dev" variant runs as root and ships a shell, apt, and npm/npx.
+# TODO(pin): pin by digest -- `docker login dhi.io` then
 # `docker buildx imagetools inspect dhi.io/node:24-debian13-dev`.
 FROM dhi.io/node:24-debian13-dev AS builder
 COPY --from=bun_source /usr/local/bin/bun /usr/local/bin/bun
@@ -102,10 +98,9 @@ RUN --mount=type=secret,id=sentry_auth_token \
     fi && \
     NODE_OPTIONS="${NODE_OPTIONS}" npx next build
 
-# Step 2. Production image, copy all the files and run next.
-# The DHI runtime variant is near-distroless: no shell, no package manager, and it already
-# runs as the non-root `node` user (uid 1000) with WORKDIR /app and ENTRYPOINT ["node"].
-# TODO(pin): pin by digest once resolvable -- `docker login dhi.io` then
+# Runtime stage. The DHI runtime variant is near-distroless: no shell or package manager, runs
+# as the non-root `node` user (uid 1000), WORKDIR /app and ENTRYPOINT ["node"] pre-set.
+# TODO(pin): pin by digest -- `docker login dhi.io` then
 # `docker buildx imagetools inspect dhi.io/node:24-debian13`.
 FROM dhi.io/node:24-debian13 AS runner
 
@@ -124,11 +119,7 @@ WORKDIR /app
 # Disable automatic telemetry collection
 ENV NEXT_TELEMETRY_DISABLED=1
 
-# The DHI runtime image already runs as the non-root `node` user (uid 1000); there is no
-# global node_modules to remove and no shell to run a cleanup step, so both are dropped.
-
-# The `/app` directory is root-owned, so build artifacts are re-owned to `node` on copy.
-# Add back in if we add anything to `public`
+# `/app` is root-owned, so re-own build artifacts to `node` on copy.
 COPY --from=builder --chown=node:node /app/public ./public
 
 # Automatically leverage output traces to reduce image size
@@ -201,5 +192,5 @@ ENV ONYX_VERSION=${ONYX_VERSION}
 # name only — breaking loopback healthchecks. Force 0.0.0.0 instead.
 ENV HOSTNAME="0.0.0.0"
 
-# The DHI runtime image sets ENTRYPOINT ["node"], so the command is just the script path.
+# DHI presets ENTRYPOINT ["node"], so CMD is just the script path.
 CMD ["server.js"]

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,24 +1,20 @@
-# Registry prefix for base images. Defaults to Docker Hub; CI overrides this to the ECR
-# pull-through cache (<account>.dkr.ecr.us-east-2.amazonaws.com/docker-hub) to avoid Docker
-# Hub rate limits.
+# Registry prefix for the bun binary source below. Defaults to Docker Hub; CI overrides this to
+# the ECR pull-through cache (<account>.dkr.ecr.us-east-2.amazonaws.com/docker-hub) to avoid
+# Docker Hub rate limits. NOTE: this applies only to `bun_source` -- the hardened Node base
+# images come from Docker Hardened Images (dhi.io), a separate registry that is NOT served by
+# the pull-through cache and requires `docker login dhi.io`.
 ARG BASE_IMAGE_REGISTRY=docker.io
-FROM ${BASE_IMAGE_REGISTRY}/library/node:24-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f AS base
-
-LABEL com.onyx.maintainer="founders@onyx.app"
-LABEL com.onyx.description="This image is the web/frontend container of Onyx which \
-contains code for both the Community and Enterprise editions of Onyx. If you do not \
-have a contract or agreement with DanswerAI, you are not permitted to use the Enterprise \
-Edition features outside of personal development or testing purposes. Please reach out to \
-founders@onyx.app for more information. Please visit https://github.com/onyx-dot-app/onyx"
 
 # bun binary source. Pinned via the registry prefix in its own stage because buildx
 # rejects variable expansion directly in `COPY --from=` -- the ARG is only expandable in a FROM.
-FROM ${BASE_IMAGE_REGISTRY}/oven/bun:1-alpine@sha256:5acc90a93e91ff07bf72aa90a7c9f0fa189765aec90b47bdbf2152d2196383c0 AS bun_source
+# Use the glibc (Debian) build so the binary runs on the glibc-based DHI node images below.
+FROM ${BASE_IMAGE_REGISTRY}/oven/bun:1@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4 AS bun_source
 
-# Step 1. Install dependencies + rebuild the source code only when needed
-FROM base AS builder
-# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
-RUN apk add --no-cache libc6-compat
+# Step 1. Install dependencies + rebuild the source code only when needed.
+# The DHI "-dev" variant runs as root and ships a shell, apt, npm/npx, and git for the build.
+# TODO(pin): pin by digest once resolvable -- `docker login dhi.io` then
+# `docker buildx imagetools inspect dhi.io/node:24-debian13-dev`.
+FROM dhi.io/node:24-debian13-dev AS builder
 COPY --from=bun_source /usr/local/bin/bun /usr/local/bin/bun
 COPY --from=bun_source /usr/local/bin/bunx /usr/local/bin/bunx
 WORKDIR /app
@@ -106,14 +102,21 @@ RUN --mount=type=secret,id=sentry_auth_token \
     fi && \
     NODE_OPTIONS="${NODE_OPTIONS}" npx next build
 
-# Step 2. Production image, copy all the files and run next
-FROM base AS runner
-WORKDIR /app
+# Step 2. Production image, copy all the files and run next.
+# The DHI runtime variant is near-distroless: no shell, no package manager, and it already
+# runs as the non-root `node` user (uid 1000) with WORKDIR /app and ENTRYPOINT ["node"].
+# TODO(pin): pin by digest once resolvable -- `docker login dhi.io` then
+# `docker buildx imagetools inspect dhi.io/node:24-debian13`.
+FROM dhi.io/node:24-debian13 AS runner
 
-# Remove global node modules, since they are not needed by the actual app
-# (all dependencies are copied over into the `/app` dir itself). These
-# global modules may be outdated and trigger security scans.
-RUN rm -rf /usr/local/lib/node_modules
+LABEL com.onyx.maintainer="founders@onyx.app"
+LABEL com.onyx.description="This image is the web/frontend container of Onyx which \
+contains code for both the Community and Enterprise editions of Onyx. If you do not \
+have a contract or agreement with DanswerAI, you are not permitted to use the Enterprise \
+Edition features outside of personal development or testing purposes. Please reach out to \
+founders@onyx.app for more information. Please visit https://github.com/onyx-dot-app/onyx"
+
+WORKDIR /app
 
 # Not needed, set by compose
 # ENV NODE_ENV production
@@ -121,18 +124,17 @@ RUN rm -rf /usr/local/lib/node_modules
 # Disable automatic telemetry collection
 ENV NEXT_TELEMETRY_DISABLED=1
 
-# Don't run production as root
-RUN addgroup --system --gid 1001 nodejs
-RUN adduser --system --uid 1001 nextjs
-USER nextjs
+# The DHI runtime image already runs as the non-root `node` user (uid 1000); there is no
+# global node_modules to remove and no shell to run a cleanup step, so both are dropped.
 
+# The `/app` directory is root-owned, so build artifacts are re-owned to `node` on copy.
 # Add back in if we add anything to `public`
-COPY --from=builder /app/public ./public
+COPY --from=builder --chown=node:node /app/public ./public
 
 # Automatically leverage output traces to reduce image size
 # https://nextjs.org/docs/advanced-features/output-file-tracing
-COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
-COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=builder --chown=node:node /app/.next/standalone ./
+COPY --from=builder --chown=node:node /app/.next/static ./.next/static
 
 # Environment variables must be redefined at run time
 # NOTE: if you add something here, make sure to add it to the builder as well
@@ -199,4 +201,5 @@ ENV ONYX_VERSION=${ONYX_VERSION}
 # name only — breaking loopback healthchecks. Force 0.0.0.0 instead.
 ENV HOSTNAME="0.0.0.0"
 
-CMD ["node", "server.js"]
+# The DHI runtime image sets ENTRYPOINT ["node"], so the command is just the script path.
+CMD ["server.js"]


### PR DESCRIPTION
## Summary

Converts `web/Dockerfile` from `node:24-alpine` to a **Docker Hardened Image** (DHI), shipping the frontend on a near-distroless, non-root runtime with no shell or package manager — dramatically shrinking the CVE surface of the production image while keeping build behavior identical.

Two design decisions:
- **Distribution channel:** the free **`dhi.io` community catalog** (`dhi.io/node:<tag>`).
- **OS base:** **Debian (glibc)** — `24-debian13-dev` for the build stage, `24-debian13` for the runtime stage.

## Changes

**`web/Dockerfile`** — restructured into the canonical DHI two-tier pattern:
- **builder** → `dhi.io/node:24-debian13-dev` (root; ships shell/`apt`/`npm` for `bun install` + `npx next build`)
- **runner** → `dhi.io/node:24-debian13` (near-distroless; non-root `node`, uid 1000; no shell/package manager)
- `bun_source` switched from `oven/bun:1-alpine` (musl) → `oven/bun:1` (glibc) so the binary runs on the Debian base (digest reused from `.devcontainer/Dockerfile`)
- dropped `apk add libc6-compat` (Alpine-only), the `rm -rf .../node_modules` cleanup, and the `addgroup`/`adduser`/`USER nextjs` (uid 1001) block — the runtime image is already non-root
- artifacts copied with `--chown=node:node` (`/app` is root-owned in DHI); `CMD ["server.js"]` since the DHI `ENTRYPOINT` is already `node`
- descriptive `LABEL`s moved onto the shipped runner stage

**CI** — `dhi.io` is a separate registry not served by the ECR pull-through cache, so added a `docker login dhi.io` step to:
- the 4 web build jobs in `deployment.yml`
- `build-web-image` in `pr-playwright-tests.yml`

reusing the existing Docker account credentials (`dhi.io` authenticates with the Docker Hub account).

**`CONTRIBUTING.md`** — documents the new `docker login dhi.io` prerequisite for local `--build`.

## Follow-ups before merge

- [x] **Pin the DHI digests.** Done in this PR — both `dhi.io/node:...` FROM lines are pinned to the digests CI resolved on a green build (`docker buildx imagetools inspect` to refresh).
- [x] **Confirm DHI catalog access.** The CI login reuses `DOCKER_USERNAME`/`DOCKER_TOKEN`; that account must have accepted the DHI community terms, otherwise a dedicated credential pair is needed. Confirmed working: the `build-web-image` job pulled both DHI images successfully with the existing `DOCKER_USERNAME`/`DOCKER_TOKEN`.

## Testing

Build + run verification requires a Docker daemon (not available in the devcontainer). The **`pr-playwright-tests.yml` pipeline is the primary gate** — it builds the hardened web image and runs the full Playwright E2E suite against it. The compose healthcheck (`node -e "..."`) still works because the `node` binary is present in the DHI runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build the web frontend on Docker Hardened Images from `dhi.io` (Debian/glibc) with a non‑root, near‑distroless runtime to reduce the CVE surface without changing behavior. Start the app with `node server.js` since the DHI runtime has no default ENTRYPOINT.

- **Refactors**
  - Switched `web/Dockerfile` to `dhi.io/node:24-debian13-dev` (builder) and `dhi.io/node:24-debian13` (runtime); runs as non‑root `node`.
  - Pinned both DHI base images by digest to avoid tag drift.
  - Set `CMD ["node", "server.js"]`; copied artifacts with `--chown=node:node`; moved bun source to glibc `oven/bun:1`; removed Alpine/user setup.
  - Trimmed Dockerfile comments.

- **Migration**
  - CI: added `docker login dhi.io` to web image build jobs in `deployment.yml` and the PR Playwright workflow.
  - Local: run `docker login dhi.io` before building `web/Dockerfile` (documented in `CONTRIBUTING.md`).

<sup>Written for commit b3e50b3b789520250905b7e2a6b93d7f017f52f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

