### PR TITLE
chore: ee codeowners (#12236) to release v4.1

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,3 +7,8 @@
 
 # Beta cherry-pick workflow owners
 /.github/workflows/post-merge-beta-cherry-pick.yml @justin-tahara @jmelahman
+
+# Enterprise Edition code owners
+/backend/ee/ @evan-onyx @Weves
+/web/src/ee/ @evan-onyx @Weves
+/web/src/app/ee/ @evan-onyx @Weves


### PR DESCRIPTION
Cherry-pick of commit 72b285b0c6d801acb1ada3884544a1c8b8e3cbf9 to release/v4.1 branch.

Original PR: #12236

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Enterprise Edition CODEOWNERS so PRs touching EE code auto-request reviews from `@evan-onyx` and `@Weves`.
Covered paths: `/backend/ee/`, `/web/src/ee/`, `/web/src/app/ee/`.

<sup>Written for commit 9bafd87f8574510eb73fb78a2c6a7dda81c9f730. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

