### PR TITLE
chore: more ee codeowners (#12386) to release v4.2

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,6 @@
 /.github/workflows/post-merge-beta-cherry-pick.yml @justin-tahara @jmelahman
 
 # Enterprise Edition code owners
-/backend/ee/ @evan-onyx @Weves
-/web/src/ee/ @evan-onyx @Weves
-/web/src/app/ee/ @evan-onyx @Weves
+/backend/ee/ @evan-onyx @Weves @jmelahman @justin-tahara
+/web/src/ee/ @evan-onyx @Weves @jmelahman @justin-tahara
+/web/src/app/ee/ @evan-onyx @Weves @jmelahman @justin-tahara


### PR DESCRIPTION
Cherry-pick of commit a6c3d86f8147fa8fcefff4026d486e5032bb56fc to release/v4.2 branch.

Original PR: #12386

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `@jmelahman` and `@justin-tahara` as code owners for Enterprise Edition directories (`/backend/ee/`, `/web/src/ee/`, `/web/src/app/ee/`) to improve review coverage in v4.2.

<sup>Written for commit b53901dd67e8d7bf5df763452d0f913733448bf0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

