### PR TITLE
fix: don't render missing middle initial as 'None' in expert name

### DIFF
--- a/backend/onyx/connectors/cross_connector_utils/miscellaneous_utils.py
+++ b/backend/onyx/connectors/cross_connector_utils/miscellaneous_utils.py
@@ -77,7 +77,9 @@ def datetime_from_utc_timestamp(timestamp: int) -> datetime:
 
 def basic_expert_info_representation(info: BasicExpertInfo) -> str | None:
     if info.first_name and info.last_name:
-        return f"{info.first_name} {info.middle_initial} {info.last_name}"
+        if info.middle_initial:
+            return f"{info.first_name} {info.middle_initial} {info.last_name}"
+        return f"{info.first_name} {info.last_name}"
 
     if info.display_name:
         return info.display_name

--- a/backend/tests/unit/onyx/connectors/cross_connector_utils/test_miscellaneous_utils.py
+++ b/backend/tests/unit/onyx/connectors/cross_connector_utils/test_miscellaneous_utils.py
@@ -2,7 +2,11 @@ import datetime
 
 import pytest
 
-from onyx.connectors.cross_connector_utils.miscellaneous_utils import time_str_to_utc
+from onyx.connectors.cross_connector_utils.miscellaneous_utils import (
+    basic_expert_info_representation,
+    time_str_to_utc,
+)
+from onyx.connectors.models import BasicExpertInfo
 
 
 def test_time_str_to_utc() -> None:
@@ -51,3 +55,30 @@ def test_time_str_to_utc_raises_on_impossible_dates() -> None:
     ):
         with pytest.raises(ValueError):
             time_str_to_utc(bad)
+
+
+def test_basic_expert_info_representation() -> None:
+    # first + last with no middle initial must not interpolate a literal "None"
+    assert (
+        basic_expert_info_representation(
+            BasicExpertInfo(first_name="John", last_name="Doe")
+        )
+        == "John Doe"
+    )
+    # the middle initial is included when present
+    assert (
+        basic_expert_info_representation(
+            BasicExpertInfo(first_name="John", middle_initial="Q", last_name="Doe")
+        )
+        == "John Q Doe"
+    )
+    # display_name fallback when the name is incomplete
+    assert (
+        basic_expert_info_representation(BasicExpertInfo(display_name="Team Inbox"))
+        == "Team Inbox"
+    )
+    # email fallback
+    assert (
+        basic_expert_info_representation(BasicExpertInfo(email="owner@example.com"))
+        == "owner@example.com"
+    )


### PR DESCRIPTION
### Problem

`basic_expert_info_representation` (in `backend/onyx/connectors/cross_connector_utils/miscellaneous_utils.py`) builds a document owner's display name with an unconditional f-string:

```python
if info.first_name and info.last_name:
    return f"{info.first_name} {info.middle_initial} {info.last_name}"
```

`middle_initial` is optional (the `BasicExpertInfo` docstring: *"first_name + (optional middle_initial) + last_name"*). When an owner has a first and last name but **no** middle initial — the common case — Python interpolates `None` as the literal text `"None"`, producing e.g. `"John None Doe"`.

This isn't cosmetic: `basic_expert_info_representation` → `get_experts_stores_representations` feeds document `primary_owners` / `secondary_owners`, which are indexed into Vespa and OpenSearch. So any owner without a middle initial gets a searchable/displayed owner value corrupted with an embedded `"None"`.

The sibling method `BasicExpertInfo.get_semantic_name` already guards this correctly (`if self.middle_initial:`); this path simply missed the same guard.

### Reproduction

```python
basic_expert_info_representation(BasicExpertInfo(first_name="John", last_name="Doe"))
# before: "John None Doe"
# after:  "John Doe"
```

### Fix

```python
if info.first_name and info.last_name:
    if info.middle_initial:
        return f"{info.first_name} {info.middle_initial} {info.last_name}"
    return f"{info.first_name} {info.last_name}"
```

The with-middle-initial case is unchanged (`"John Q Doe"`); the other fallbacks (display_name, email, first_name) are untouched.

### Tests

Added `test_basic_expert_info_representation` to `backend/tests/unit/onyx/connectors/cross_connector_utils/test_miscellaneous_utils.py` covering the no-middle-initial case (regression), the with-middle-initial case, and the display_name/email fallbacks. Verified RED→GREEN against the real function (`"John None Doe"` → `"John Doe"`).

Happy to open a tracking issue first if the maintainers prefer — this is a small, self-contained bug fix in the MIT core (not `ee/`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes expert name formatting to avoid "None" when `middle_initial` is missing. Ensures owners are indexed and displayed as "first last" in Vespa/OpenSearch.

- **Bug Fixes**
  - Guard `middle_initial` in `basic_expert_info_representation`; use "first last" when absent, keep "first M last" when present.
  - Added unit tests for no-middle-initial, with-middle-initial, and display_name/email fallbacks.

<sup>Written for commit 020901347f3c0a21546a4d5d2cf850c84a447fa5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

