### PR TITLE
chore: [Running GitHub actions for #12595]

### DIFF
--- a/backend/onyx/connectors/cross_connector_utils/miscellaneous_utils.py
+++ b/backend/onyx/connectors/cross_connector_utils/miscellaneous_utils.py
@@ -77,7 +77,9 @@ def datetime_from_utc_timestamp(timestamp: int) -> datetime:
 
 def basic_expert_info_representation(info: BasicExpertInfo) -> str | None:
     if info.first_name and info.last_name:
-        return f"{info.first_name} {info.middle_initial} {info.last_name}"
+        if info.middle_initial:
+            return f"{info.first_name} {info.middle_initial} {info.last_name}"
+        return f"{info.first_name} {info.last_name}"
 
     if info.display_name:
         return info.display_name

--- a/backend/tests/unit/onyx/connectors/cross_connector_utils/test_miscellaneous_utils.py
+++ b/backend/tests/unit/onyx/connectors/cross_connector_utils/test_miscellaneous_utils.py
@@ -2,7 +2,11 @@ import datetime
 
 import pytest
 
+from onyx.connectors.cross_connector_utils.miscellaneous_utils import (
+    basic_expert_info_representation,
+)
 from onyx.connectors.cross_connector_utils.miscellaneous_utils import time_str_to_utc
+from onyx.connectors.models import BasicExpertInfo
 
 
 def test_time_str_to_utc() -> None:
@@ -51,3 +55,30 @@ def test_time_str_to_utc_raises_on_impossible_dates() -> None:
     ):
         with pytest.raises(ValueError):
             time_str_to_utc(bad)
+
+
+def test_basic_expert_info_representation() -> None:
+    # first + last with no middle initial must not interpolate a literal "None"
+    assert (
+        basic_expert_info_representation(
+            BasicExpertInfo(first_name="John", last_name="Doe")
+        )
+        == "John Doe"
+    )
+    # the middle initial is included when present
+    assert (
+        basic_expert_info_representation(
+            BasicExpertInfo(first_name="John", middle_initial="Q", last_name="Doe")
+        )
+        == "John Q Doe"
+    )
+    # display_name fallback when the name is incomplete
+    assert (
+        basic_expert_info_representation(BasicExpertInfo(display_name="Team Inbox"))
+        == "Team Inbox"
+    )
+    # email fallback
+    assert (
+        basic_expert_info_representation(BasicExpertInfo(email="owner@example.com"))
+        == "owner@example.com"
+    )


### PR DESCRIPTION
This PR runs GitHub Actions CI for #12595.

- [x] Override Linear Check

**This PR should be closed (not merged) after CI completes.**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes expert name rendering so a missing middle initial no longer shows as "None", and adds tests for name formatting and fallbacks.

- **Bug Fixes**
  - Update `basic_expert_info_representation` to include the middle initial only when present; otherwise render "First Last".
  - Keep fallbacks to `display_name` and `email` when first/last are missing.
  - Add unit tests covering no-middle-initial, with-middle-initial, `display_name`, and `email` cases.

<sup>Written for commit 56ff32270f7062f3843463c2ab04ab24006e06a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

