### PR TITLE
chore: more ee codeowners (#12386) to release v4.1

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,6 @@
 /.github/workflows/post-merge-beta-cherry-pick.yml @justin-tahara @jmelahman
 
 # Enterprise Edition code owners
-/backend/ee/ @evan-onyx @Weves
-/web/src/ee/ @evan-onyx @Weves
-/web/src/app/ee/ @evan-onyx @Weves
+/backend/ee/ @evan-onyx @Weves @jmelahman @justin-tahara
+/web/src/ee/ @evan-onyx @Weves @jmelahman @justin-tahara
+/web/src/app/ee/ @evan-onyx @Weves @jmelahman @justin-tahara


### PR DESCRIPTION
Cherry-pick of commit a6c3d86f8147fa8fcefff4026d486e5032bb56fc to release/v4.1 branch.

Original PR: #12386

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@jmelahman` and `@justin-tahara` as code owners for `/backend/ee/`, `/web/src/ee/`, and `/web/src/app/ee/` to ensure EE changes in v4.1 automatically request the right reviewers and improve coverage.

<sup>Written for commit 4d8569ab6c3050956ab421572e61402101317349. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

