### PR TITLE
fix(web): guard useNotifications against non-array API responses

### DIFF
--- a/web/src/hooks/useNotifications.test.tsx
+++ b/web/src/hooks/useNotifications.test.tsx
@@ -1,0 +1,99 @@
+import { renderHook } from "@testing-library/react";
+import type { NotificationsResponse } from "@/lib/notifications/interfaces";
+import { NotificationType } from "@/lib/notifications/interfaces";
+import useNotifications from "./useNotifications";
+
+const mockUseSWRInfinite = jest.fn();
+
+jest.mock("swr/infinite", () => ({
+  __esModule: true,
+  default: (...args: unknown[]) => mockUseSWRInfinite(...args),
+}));
+
+jest.mock("swr", () => ({
+  __esModule: true,
+  ...jest.requireActual("swr"),
+  useSWRConfig: () => ({ mutate: jest.fn() }),
+}));
+
+function makePage(
+  overrides: Partial<NotificationsResponse>
+): NotificationsResponse {
+  return {
+    notifications: [],
+    total_items: 0,
+    undismissed_count: 0,
+    page_num: 0,
+    page_size: 25,
+    has_more: false,
+    ...overrides,
+  };
+}
+
+function notification(id: number) {
+  return {
+    id,
+    notif_type: NotificationType.REINDEX,
+    title: `notification ${id}`,
+    description: null,
+    dismissed: false,
+    first_shown: "2026-01-01T00:00:00Z",
+    last_shown: "2026-01-01T00:00:00Z",
+  };
+}
+
+function mockInfinite(data: unknown) {
+  mockUseSWRInfinite.mockReturnValue({
+    data,
+    error: undefined,
+    mutate: jest.fn(),
+    size: Array.isArray(data) ? data.length : 0,
+    setSize: jest.fn(),
+  });
+}
+
+describe("useNotifications", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // Regression for #12591: the notifications API returning a page whose
+  // `notifications` field is not an array must not throw. This hook feeds
+  // always-mounted UI (sidebar, notifications popover), so a throw here
+  // black-screens the app instead of degrading gracefully.
+  it.each<[string, unknown]>([
+    ["an object", {}],
+    ["a string", "unexpected"],
+    ["null", null],
+    ["undefined", undefined],
+  ])("returns [] without throwing when a page's notifications is %s", (_, value) => {
+    mockInfinite([makePage({ notifications: value as never })]);
+
+    const { result } = renderHook(() => useNotifications());
+
+    expect(result.current.notifications).toEqual([]);
+  });
+
+  it("skips a malformed page but still returns notifications from valid pages", () => {
+    mockInfinite([
+      makePage({ notifications: [notification(1)] }),
+      makePage({ notifications: {} as never }),
+      makePage({ notifications: [notification(2)] }),
+    ]);
+
+    const { result } = renderHook(() => useNotifications());
+
+    expect(result.current.notifications.map((n) => n.id)).toEqual([1, 2]);
+  });
+
+  it("de-duplicates notifications across pages for a valid response", () => {
+    mockInfinite([
+      makePage({ notifications: [notification(1), notification(2)] }),
+      makePage({ notifications: [notification(2), notification(3)] }),
+    ]);
+
+    const { result } = renderHook(() => useNotifications());
+
+    expect(result.current.notifications.map((n) => n.id)).toEqual([1, 2, 3]);
+  });
+});

--- a/web/src/hooks/useNotifications.ts
+++ b/web/src/hooks/useNotifications.ts
@@ -83,15 +83,21 @@ export default function useNotifications({
     if (!data) return [];
 
     const seenNotificationIds = new Set<number>();
-    return data.flatMap((page) =>
-      page.notifications.filter((notification) => {
+    return data.flatMap((page) => {
+      // Guard against a malformed page (`notifications` not an array): this hook
+      // feeds always-mounted UI (sidebar, notifications popover), so throwing
+      // here would crash the app rather than degrade gracefully.
+      const pageNotifications = Array.isArray(page?.notifications)
+        ? page.notifications
+        : [];
+      return pageNotifications.filter((notification) => {
         if (seenNotificationIds.has(notification.id)) {
           return false;
         }
         seenNotificationIds.add(notification.id);
         return true;
-      })
-    );
+      });
+    });
   }, [data]);
   const firstPage = data?.[0];
   const lastPage = data?.[data.length - 1];


### PR DESCRIPTION
## Problem

Fixes #12591 — an uncaught, minified `TypeError: P.filter is not a function` crashes the entire React app to a black screen ("Application error: a client-side exception has occurred") on self-hosted deployments.

## Root cause

`useNotifications` built its list with an unguarded filter:

```ts
return data.flatMap((page) =>
  page.notifications.filter(...)   // throws if page.notifications isn't an array
);
```

`page` comes from the `/api/notifications` fetch. If a page's `notifications` field is anything other than an array (an unexpected/malformed response shape), `.filter` throws during render. The hook feeds **always-mounted** UI — the sidebar and the notifications popover — so the throw propagates to the root and takes down the whole app instead of degrading gracefully.

This unguarded `.filter` is present **unchanged in v4.2.2** (`release/v4.2`), which matches the reporter's environment. (Note: the `LicenseExpiryBanner` was *not* involved — its notification-fetching rewrite lives only on `main` and was never backported to `release/v4.2`, so it doesn't exist in v4.2.2.)

## Why the type-checker doesn't catch it

The fetch boundary is an unchecked assertion:

```ts
export const errorHandlingFetcher = async <T>(url): Promise<T> => {
  ...
  return res.json();   // Response.json() is Promise<any>
};
```

`<T>` is a promise to the compiler, not a runtime check. Once data is declared `NotificationsResponse`, `notifications` is typed non-optional `Notification[]`, so `.filter` type-checks and TS sees nothing to guard. Only a runtime validator (zod/valibot) or a defensive `Array.isArray` (this PR) can catch a response that violates the declared contract — version skew, a proxy error body, an empty list serialized as `{}`/`null`, etc.

## Fix

Coerce each page's `notifications` to an array with `Array.isArray` before filtering.

## Tests

`useNotifications.test.tsx` (jsdom): asserts the hook returns `[]` (skipping only the malformed page) instead of throwing for object/string/null/undefined payloads, plus valid-response and cross-page de-dup cases. Verified the guard-less hook fails these (the exact `TypeError`) and passes with the guard.

## Follow-ups (not in this PR)

- **Backport to `release/v4.2`** — a `main` merge won't reach v4.2.2 users; the guard needs cherry-picking to the release branch to actually fix the reported deployment.
- The `LicenseExpiryBanner` on `main` has the same latent class of bug (`(data?.notifications ?? []).filter` — `?? []` doesn't cover a truthy non-array). Worth hardening separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)