### PR TITLE
feat(search): Surface time filter on FE

### DIFF
--- a/backend/onyx/server/query_and_chat/streaming_models.py
+++ b/backend/onyx/server/query_and_chat/streaming_models.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from enum import Enum
 from typing import Annotated
 from typing import Any
@@ -179,14 +180,16 @@ class SearchToolQueriesDelta(BaseObj):
     queries: list[str]
 
 
-# The connector/source filter applied to this internal search (which sources are
-# being searched). Absent == no filter applied (searched everything).
+# Filters applied to this internal search. Empty `sources` == scope not narrowed
+# (searched everything); either time bound may be absent (open-ended).
 class SearchToolFilterDelta(BaseObj):
     type: Literal["search_tool_filter_delta"] = (
         StreamingType.SEARCH_TOOL_FILTER_DELTA.value
     )
 
-    sources: list[str]
+    sources: list[str] = []
+    time_filter_start: datetime | None = None
+    time_filter_end: datetime | None = None
 
 
 # Documents coming through as the system knows what to add to the context

--- a/backend/onyx/tools/tool_implementations/search/search_tool.py
+++ b/backend/onyx/tools/tool_implementations/search/search_tool.py
@@ -841,18 +841,26 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
             )
         )
 
-        # Surface the scope to the UI only when it narrows to a strict subset of
-        # the connected sources — scoping to all of them is equivalent to an
-        # unscoped search, so the UI keeps its default "internal documents" label.
+        # Surface the applied filters (source scope + time window) to the UI. Scope
+        # is reported only when it narrows to a strict subset — scoping to all
+        # connected sources is equivalent to an unscoped search.
         scopes_all_sources = bool(connected_sources) and set(
             connected_sources
         ).issubset(resolved_scope or [])
-        if resolved_scope and not scopes_all_sources:
+        emitted_sources = (
+            [source.value for source in resolved_scope]
+            if resolved_scope and not scopes_all_sources
+            else []
+        )
+        time_filter = expansion.time_filter
+        if emitted_sources or time_filter is not None:
             self.emitter.emit(
                 Packet(
                     placement=placement,
                     obj=SearchToolFilterDelta(
-                        sources=[source.value for source in resolved_scope]
+                        sources=emitted_sources,
+                        time_filter_start=time_filter.start if time_filter else None,
+                        time_filter_end=time_filter.end if time_filter else None,
                     ),
                 )
             )
@@ -881,7 +889,6 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
                 slack_access_token = None
 
         # The pipeline composes the lower bound with any persona time floor.
-        time_filter = expansion.time_filter
         if time_filter is not None:
             effective_filters = time_filter.apply_to(effective_filters or BaseFilters())
             logger.info(

--- a/web/src/app/app/message/messageComponents/timeline/hooks/useTimelineHeader.ts
+++ b/web/src/app/app/message/messageComponents/timeline/hooks/useTimelineHeader.ts
@@ -68,8 +68,10 @@ export function useTimelineHeader(
       } else if (searchState.isInternetSearch) {
         headerText = "Searching the web";
       } else {
-        // A source filter overrides the header with the connector(s).
-        headerText = formatSearchHeader(searchState.sourceFilters);
+        headerText = formatSearchHeader(
+          searchState.sourceFilters,
+          searchState.timeFilter
+        );
       }
       return { headerText, hasPackets, userStopped };
     }

--- a/web/src/app/app/message/messageComponents/timeline/renderers/search/InternalSearchToolRenderer.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/renderers/search/InternalSearchToolRenderer.tsx
@@ -62,7 +62,8 @@ export const InternalSearchToolRenderer: MessageRenderer<
   children,
 }) => {
   const searchState = constructCurrentSearchState(packets);
-  const { queries, results, sourceFilters, isComplete } = searchState;
+  const { queries, results, sourceFilters, timeFilter, isComplete } =
+    searchState;
 
   const isCompact = renderType === RenderType.COMPACT;
   const isHighlight = renderType === RenderType.HIGHLIGHT;
@@ -70,8 +71,7 @@ export const InternalSearchToolRenderer: MessageRenderer<
 
   const hasResults = results.length > 0;
 
-  // A source filter overrides the header with the connector(s) it scoped to.
-  const queriesHeader = formatSearchHeader(sourceFilters);
+  const queriesHeader = formatSearchHeader(sourceFilters, timeFilter);
 
   if (queries.length === 0) {
     return children([

--- a/web/src/app/app/message/messageComponents/timeline/renderers/search/__tests__/searchStateUtils.test.ts
+++ b/web/src/app/app/message/messageComponents/timeline/renderers/search/__tests__/searchStateUtils.test.ts
@@ -1,0 +1,93 @@
+import {
+  constructCurrentSearchState,
+  formatSearchHeader,
+  formatTimeWindow,
+} from "../searchStateUtils";
+import {
+  SearchToolFilterDelta,
+  SearchToolPacket,
+} from "@/app/app/services/streamingModels";
+
+function filterPacket(obj: Partial<SearchToolFilterDelta>): SearchToolPacket {
+  return {
+    placement: { turn_index: 0 },
+    obj: { type: "search_tool_filter_delta", sources: [], ...obj },
+  };
+}
+
+describe("formatTimeWindow", () => {
+  it("returns null when there is no time filter", () => {
+    expect(formatTimeWindow(null)).toBeNull();
+    expect(formatTimeWindow({ start: null, end: null })).toBeNull();
+  });
+
+  it("phrases a lower-bound-only window as 'since'", () => {
+    expect(formatTimeWindow({ start: "2024-01-05T12:00:00Z", end: null })).toBe(
+      "since Jan 5, 2024"
+    );
+  });
+
+  it("phrases an upper-bound-only window as 'before'", () => {
+    expect(formatTimeWindow({ start: null, end: "2024-03-10T12:00:00Z" })).toBe(
+      "before Mar 10, 2024"
+    );
+  });
+
+  it("formats day boundaries as their UTC date regardless of local timezone", () => {
+    // A single-day window as the backend emits it: midnight to end-of-day UTC.
+    expect(
+      formatTimeWindow({
+        start: "2026-07-15T00:00:00+00:00",
+        end: "2026-07-15T23:59:59.999999+00:00",
+      })
+    ).toBe("from Jul 15, 2026 to Jul 15, 2026");
+  });
+
+  it("phrases a bounded window as 'from ... to ...'", () => {
+    expect(
+      formatTimeWindow({
+        start: "2024-01-05T12:00:00Z",
+        end: "2024-03-10T12:00:00Z",
+      })
+    ).toBe("from Jan 5, 2024 to Mar 10, 2024");
+  });
+});
+
+describe("formatSearchHeader", () => {
+  it("appends the time window to the default header", () => {
+    expect(
+      formatSearchHeader([], { start: "2024-01-05T12:00:00Z", end: null })
+    ).toBe("Searching internal documents (since Jan 5, 2024)");
+  });
+
+  it("leaves the header untouched when no time window applies", () => {
+    expect(formatSearchHeader([])).toBe("Searching internal documents");
+    expect(formatSearchHeader([], null)).toBe("Searching internal documents");
+  });
+});
+
+describe("constructCurrentSearchState filter extraction", () => {
+  it("unions sources and takes the latest time window from filter deltas", () => {
+    const state = constructCurrentSearchState([
+      filterPacket({ sources: ["slack"] }),
+      filterPacket({
+        sources: [],
+        time_filter_start: "2024-01-05T12:00:00Z",
+        time_filter_end: null,
+      }),
+    ]);
+    expect(state.sourceFilters).toEqual(["slack"]);
+    expect(state.timeFilter).toEqual({
+      start: "2024-01-05T12:00:00Z",
+      end: null,
+    });
+  });
+
+  it("leaves timeFilter null when no delta carries a time bound", () => {
+    const state = constructCurrentSearchState([
+      filterPacket({ sources: ["slack", "notion"] }),
+    ]);
+    expect(state.sourceFilters).toEqual(["slack", "notion"]);
+    expect(state.timeFilter).toBeNull();
+  });
+});

--- a/web/src/app/app/message/messageComponents/timeline/renderers/search/searchStateUtils.ts
+++ b/web/src/app/app/message/messageComponents/timeline/renderers/search/searchStateUtils.ts
@@ -29,34 +29,71 @@ export const QUERIES_PER_EXPANSION = 5;
 export const INITIAL_RESULTS_TO_SHOW = 3;
 export const RESULTS_PER_EXPANSION = 10;
 
+// Applied time window; null == no time filter, either bound may be open-ended.
+export interface TimeFilter {
+  start: string | null;
+  end: string | null;
+}
+
 export interface SearchState {
   queries: string[];
   results: OnyxDocument[];
   sourceFilters: string[];
+  timeFilter: TimeFilter | null;
   isSearching: boolean;
   hasResults: boolean;
   isComplete: boolean;
   isInternetSearch: boolean;
 }
 
-/**
- * Header text for an internal search step. When a source filter was applied,
- * overrides the default "Searching internal documents" with the connector(s).
- */
 const MAX_HEADER_SOURCES = 3;
 
-export const formatSearchHeader = (sourceFilters: string[]): string => {
-  if (sourceFilters.length === 0) return "Searching internal documents";
-  const names = sourceFilters.map((source) =>
-    isValidSource(source)
-      ? getSourceDisplayName(source as ValidSources)
-      : source
-  );
-  const shown = names.slice(0, MAX_HEADER_SOURCES);
-  const overflow = names.length - shown.length;
-  const label =
-    overflow > 0 ? `${shown.join(", ")} +${overflow} more` : shown.join(", ");
-  return `Searching ${label}`;
+// The bounds are day-granularity UTC dates; format in UTC so a midnight start
+// doesn't render as the previous day in western timezones. Locale is pinned to
+// match the surrounding hardcoded-English header copy.
+const formatFilterDate = (iso: string): string =>
+  new Date(iso).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+
+// Phrases a window as "since <date>", "before <date>", or "from <date> to <date>".
+export const formatTimeWindow = (
+  timeFilter: TimeFilter | null
+): string | null => {
+  if (!timeFilter) return null;
+  const { start, end } = timeFilter;
+  if (start && end) {
+    return `from ${formatFilterDate(start)} to ${formatFilterDate(end)}`;
+  }
+  if (start) return `since ${formatFilterDate(start)}`;
+  if (end) return `before ${formatFilterDate(end)}`;
+  return null;
+};
+
+export const formatSearchHeader = (
+  sourceFilters: string[],
+  timeFilter: TimeFilter | null = null
+): string => {
+  let base: string;
+  if (sourceFilters.length === 0) {
+    base = "Searching internal documents";
+  } else {
+    const names = sourceFilters.map((source) =>
+      isValidSource(source)
+        ? getSourceDisplayName(source as ValidSources)
+        : source
+    );
+    const shown = names.slice(0, MAX_HEADER_SOURCES);
+    const overflow = names.length - shown.length;
+    const label =
+      overflow > 0 ? `${shown.join(", ")} +${overflow} more` : shown.join(", ");
+    base = `Searching ${label}`;
+  }
+  const timeWindowText = formatTimeWindow(timeFilter);
+  return timeWindowText ? `${base} (${timeWindowText})` : base;
 };
 
 /** Constructs the current search state from search tool packets. */
@@ -76,6 +113,20 @@ export const constructCurrentSearchState = (
   const filterDeltas = packets
     .filter((packet) => packet.obj.type === PacketType.SEARCH_TOOL_FILTER_DELTA)
     .map((packet) => packet.obj as SearchToolFilterDelta);
+
+  // Time rides on the same filter delta; take the latest one carrying a bound.
+  const timeDelta = filterDeltas
+    .filter(
+      (delta) =>
+        delta.time_filter_start != null || delta.time_filter_end != null
+    )
+    .at(-1);
+  const timeFilter: TimeFilter | null = timeDelta
+    ? {
+        start: timeDelta.time_filter_start ?? null,
+        end: timeDelta.time_filter_end ?? null,
+      }
+    : null;
 
   const documentDeltas = packets
     .filter(
@@ -128,6 +179,7 @@ export const constructCurrentSearchState = (
     queries,
     results,
     sourceFilters,
+    timeFilter,
     isSearching,
     hasResults,
     isComplete,

--- a/web/src/app/app/services/streamingModels.ts
+++ b/web/src/app/app/services/streamingModels.ts
@@ -136,6 +136,9 @@ export interface SearchToolFilterDelta extends BaseObj {
   type: "search_tool_filter_delta";
   // Connector/source values this search is scoped to (empty == all)
   sources: string[];
+  // Applied time window as ISO datetime strings; either bound may be open-ended
+  time_filter_start?: string | null;
+  time_filter_end?: string | null;
 }
 
 export interface SearchToolDocumentsDelta extends BaseObj {


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
<img width="925" height="585" alt="Screenshot 2026-07-01 at 11 40 57 AM" src="https://github.com/user-attachments/assets/0a76c3dc-2a3c-482e-99ee-157137388d5b" />


## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface the applied time window in internal search. Backend now emits time bounds, and the UI appends them to the search header in UTC (e.g., “Searching internal documents (since Jan 5, 2024)”).

- **New Features**
  - Backend: extended `SearchToolFilterDelta` with `time_filter_start`/`time_filter_end`; `sources` defaults to `[]` and only populates when the scope narrows; emit a filter packet when sources or a time filter are present.
  - FE: extract the latest `timeFilter` from filter deltas; added `formatTimeWindow` (UTC day-based, supports “since/before/from…to”) and updated `formatSearchHeader` usage in `useTimelineHeader` and `InternalSearchToolRenderer`; updated `SearchToolFilterDelta` type in `streamingModels.ts`.
  - Tests: added unit tests for time window formatting, header text, and filter extraction.

<sup>Written for commit 2bca731fb35036031efd7c1e8769943694c422be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

