### PR TITLE
feat(ods): add `ods audit --actions` to scan pinned GitHub Actions

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -14,7 +14,10 @@ on:
       - "pyproject.toml"
       - "uv.lock"
       - ".github/dependabot.yml"
-      - ".github/workflows/audit.yml"
+      # Any workflow or composite-action change can bump a pinned action to a
+      # vulnerable version, so gate the PR that makes the change (not just nightly).
+      - ".github/workflows/**"
+      - ".github/actions/**"
       - "tools/ods/**"
   schedule:
     # Nightly at 09:00 UTC.

--- a/tools/ods/cmd/audit.go
+++ b/tools/ods/cmd/audit.go
@@ -14,6 +14,7 @@ type AuditOptions struct {
 	Web        bool
 	Python     bool
 	Dependabot bool
+	Actions    bool
 	Format     string
 	FailOn     string
 	IgnoreURL  string
@@ -28,10 +29,11 @@ func NewAuditCommand() *cobra.Command {
 		Short: "Audit dependencies for known vulnerabilities",
 		Long: `Audit dependencies for known vulnerabilities.
 
-Scans the JavaScript (bun.lock) and Python (uv.lock) lockfiles via osv-scanner
-and open GitHub Dependabot security alerts. With no selector flags, all sources
-are audited. Accepted advisories are suppressed via an allowlist fetched from S3
-at runtime, so releases can be unblocked without a code change.
+Scans the JavaScript (bun.lock) and Python (uv.lock) lockfiles via osv-scanner,
+open GitHub Dependabot security alerts, and the GitHub Actions pinned in
+.github/workflows against OSV.dev. With no selector flags, all sources are
+audited. Accepted advisories are suppressed via an allowlist fetched from S3 at
+runtime, so releases can be unblocked without a code change.
 
 Exits non-zero when an unignored finding at or above --fail-on remains, which is
 how it gates deploys.`,
@@ -44,6 +46,7 @@ how it gates deploys.`,
 	cmd.Flags().BoolVar(&opts.Web, "web", false, "Audit web/JS dependencies (bun.lock)")
 	cmd.Flags().BoolVar(&opts.Python, "python", false, "Audit Python dependencies (uv.lock)")
 	cmd.Flags().BoolVar(&opts.Dependabot, "dependabot", false, "Audit open Dependabot security alerts")
+	cmd.Flags().BoolVar(&opts.Actions, "actions", false, "Audit GitHub Actions pinned in .github/workflows")
 	cmd.Flags().StringVar(&opts.Format, "format", "text", "Output format: text, json, or sarif")
 	cmd.Flags().StringVar(&opts.FailOn, "fail-on", "critical", "Minimum severity that fails the audit: critical, high, moderate, or low")
 	cmd.Flags().StringVar(&opts.IgnoreURL, "ignore-url", audit.DefaultIgnoreURL, "S3 URL of the advisory allowlist")
@@ -63,6 +66,7 @@ func runAudit(opts *AuditOptions) {
 		Web:        opts.Web,
 		Python:     opts.Python,
 		Dependabot: opts.Dependabot,
+		Actions:    opts.Actions,
 		Format:     opts.Format,
 		FailOn:     failOn,
 		IgnoreURL:  opts.IgnoreURL,

--- a/tools/ods/cmd/audit.go
+++ b/tools/ods/cmd/audit.go
@@ -31,9 +31,9 @@ func NewAuditCommand() *cobra.Command {
 
 Scans the JavaScript (bun.lock) and Python (uv.lock) lockfiles via osv-scanner,
 open GitHub Dependabot security alerts, and the GitHub Actions pinned in
-.github/workflows against OSV.dev. With no selector flags, all sources are
-audited. Accepted advisories are suppressed via an allowlist fetched from S3 at
-runtime, so releases can be unblocked without a code change.
+.github/workflows and .github/actions against OSV.dev. With no selector flags,
+all sources are audited. Accepted advisories are suppressed via an allowlist
+fetched from S3 at runtime, so releases can be unblocked without a code change.
 
 Exits non-zero when an unignored finding at or above --fail-on remains, which is
 how it gates deploys.`,
@@ -46,7 +46,7 @@ how it gates deploys.`,
 	cmd.Flags().BoolVar(&opts.Web, "web", false, "Audit web/JS dependencies (bun.lock)")
 	cmd.Flags().BoolVar(&opts.Python, "python", false, "Audit Python dependencies (uv.lock)")
 	cmd.Flags().BoolVar(&opts.Dependabot, "dependabot", false, "Audit open Dependabot security alerts")
-	cmd.Flags().BoolVar(&opts.Actions, "actions", false, "Audit GitHub Actions pinned in .github/workflows")
+	cmd.Flags().BoolVar(&opts.Actions, "actions", false, "Audit GitHub Actions in .github/workflows and .github/actions")
 	cmd.Flags().StringVar(&opts.Format, "format", "text", "Output format: text, json, or sarif")
 	cmd.Flags().StringVar(&opts.FailOn, "fail-on", "critical", "Minimum severity that fails the audit: critical, high, moderate, or low")
 	cmd.Flags().StringVar(&opts.IgnoreURL, "ignore-url", audit.DefaultIgnoreURL, "S3 URL of the advisory allowlist")

--- a/tools/ods/go.mod
+++ b/tools/ods/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	google.golang.org/protobuf v1.36.11
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -162,7 +163,6 @@ require (
 	google.golang.org/grpc v1.81.1 // indirect
 	gopkg.in/ini.v1 v1.67.2 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/libc v1.72.3 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/tools/ods/go.mod
+++ b/tools/ods/go.mod
@@ -4,6 +4,7 @@ go 1.26.4
 
 require (
 	github.com/gdamore/tcell/v2 v2.13.8
+	github.com/google/osv-scalibr v0.4.6-0.20260612031204-164402d9140e
 	github.com/google/osv-scanner/v2 v2.4.0
 	github.com/jmelahman/tag v0.5.2
 	github.com/ossf/osv-schema/bindings/go v0.0.0-20260424063704-83285ce2a866
@@ -77,7 +78,6 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/google/go-containerregistry v0.20.7 // indirect
-	github.com/google/osv-scalibr v0.4.6-0.20260612031204-164402d9140e // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/ianlancetaylor/demangle v0.0.0-20260505044615-1ff4bf46051f // indirect
 	github.com/icholy/digest v1.1.0 // indirect

--- a/tools/ods/internal/audit/actions.go
+++ b/tools/ods/internal/audit/actions.go
@@ -37,11 +37,11 @@ import (
 	"github.com/google/osv-scalibr/extractor/filesystem"
 	"github.com/google/osv-scalibr/extractor/filesystem/misc/githubactions"
 	"github.com/google/osv-scalibr/purl"
-	"github.com/google/osv-scalibr/semantic"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/version"
 )
 
 const (
@@ -321,8 +321,8 @@ func uniqueActionNames(refs []actionRef) []string {
 // The bool is false when no comparable version could be determined.
 func actionVersion(ref actionRef, cache map[string][]ghTag) (string, bool) {
 	if !ref.IsSHA {
-		if isSemverish(ref.Ref) {
-			return normalizeVersion(ref.Ref), true
+		if version.IsSemverish(ref.Ref) {
+			return version.Normalize(ref.Ref), true
 		}
 		return "", false
 	}
@@ -463,11 +463,11 @@ func versionForSHA(tags []ghTag, sha string) (string, bool) {
 		if !strings.EqualFold(t.Commit.SHA, sha) {
 			continue
 		}
-		v := normalizeVersion(t.Name)
-		if !isSemverish(v) {
+		v := version.Normalize(t.Name)
+		if !version.IsSemverish(v) {
 			continue
 		}
-		if best == "" || semverCompare(v, best) > 0 {
+		if best == "" || version.Compare(v, best) > 0 {
 			best = v
 		}
 	}
@@ -478,13 +478,13 @@ func versionForSHA(tags []ghTag, sha string) (string, bool) {
 
 // affectedByAdvisory reports whether a resolved version falls within any of the
 // advisory's GitHub Actions affected ranges.
-func affectedByAdvisory(version string, v osvVuln) bool {
+func affectedByAdvisory(ver string, v osvVuln) bool {
 	for _, aff := range v.Affected {
 		if !strings.EqualFold(aff.Package.Ecosystem, actionsEcosystem) {
 			continue
 		}
-		for _, ev := range aff.Versions {
-			if normalizeVersion(ev) == version {
+		for _, e := range aff.Versions {
+			if version.Normalize(e) == ver {
 				return true
 			}
 		}
@@ -494,7 +494,7 @@ func affectedByAdvisory(version string, v osvVuln) bool {
 			if r.Type != "ECOSYSTEM" && r.Type != "SEMVER" {
 				continue
 			}
-			if inRange(version, r.Events) {
+			if inRange(ver, r.Events) {
 				return true
 			}
 		}
@@ -510,9 +510,9 @@ type rangeEvent struct {
 
 // inRange applies OSV range semantics: walking events in ascending version order,
 // an "introduced" opens the affected interval and a "fixed"/"last_affected" closes
-// it. version is affected if the interval is open once all events at or below it
+// it. target is affected if the interval is open once all events at or below it
 // have been applied.
-func inRange(version string, events []map[string]string) bool {
+func inRange(target string, events []map[string]string) bool {
 	var evs []rangeEvent
 	for _, e := range events {
 		for kind, ver := range e {
@@ -530,22 +530,22 @@ func inRange(version string, events []map[string]string) bool {
 		if evs[j].ver == "0" {
 			return false
 		}
-		return semverCompare(evs[i].ver, evs[j].ver) < 0
+		return version.Compare(evs[i].ver, evs[j].ver) < 0
 	})
 
 	affected := false
 	for _, e := range evs {
 		switch e.kind {
 		case "introduced":
-			if e.ver == "0" || semverCompare(version, e.ver) >= 0 {
+			if e.ver == "0" || version.Compare(target, e.ver) >= 0 {
 				affected = true
 			}
 		case "fixed":
-			if semverCompare(version, e.ver) >= 0 {
+			if version.Compare(target, e.ver) >= 0 {
 				affected = false
 			}
 		case "last_affected":
-			if semverCompare(version, e.ver) > 0 {
+			if version.Compare(target, e.ver) > 0 {
 				affected = false
 			}
 		}
@@ -564,7 +564,7 @@ func firstFixed(v osvVuln) string {
 		for _, r := range aff.Ranges {
 			for _, e := range r.Events {
 				if f, ok := e["fixed"]; ok && f != "" {
-					if fixed == "" || semverCompare(f, fixed) < 0 {
+					if fixed == "" || version.Compare(f, fixed) < 0 {
 						fixed = f
 					}
 				}
@@ -623,30 +623,4 @@ func actionTitle(v osvVuln) string {
 		return strings.TrimSpace(line)
 	}
 	return details
-}
-
-// --- version helpers ---
-
-// normalizeVersion strips a leading "v" so tag names (v6.0.2) and advisory bounds
-// (6.0.2) compare on equal footing.
-func normalizeVersion(s string) string {
-	s = strings.TrimSpace(s)
-	if len(s) > 1 && (s[0] == 'v' || s[0] == 'V') {
-		s = s[1:]
-	}
-	return s
-}
-
-// isSemverish reports whether s looks like a numeric version once normalized,
-// filtering out branch names and floating tags we can't order.
-func isSemverish(s string) bool {
-	s = normalizeVersion(s)
-	return s != "" && s[0] >= '0' && s[0] <= '9'
-}
-
-// semverCompare orders two semver-ish strings via osv-scalibr's comparator (the
-// same one used for npm/Go/crates OSV matching). Inputs are normalized first.
-func semverCompare(a, b string) int {
-	c, _ := semantic.ParseSemverVersion(normalizeVersion(a)).CompareStr(normalizeVersion(b))
-	return c
 }

--- a/tools/ods/internal/audit/actions.go
+++ b/tools/ods/internal/audit/actions.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -79,17 +80,25 @@ func scanActions() ([]Finding, error) {
 
 	// Query advisories once per unique action name.
 	advisories := make(map[string][]osvVuln)
-	for _, name := range uniqueActionNames(refs) {
+	names := uniqueActionNames(refs)
+	failed := 0
+	for _, name := range names {
 		vulns, err := queryActionAdvisories(client, name)
 		if err != nil {
 			// A single flaky query shouldn't sink the whole audit; the lockfile
 			// scan is the primary gate. Warn and treat the action as clean.
 			log.Warnf("OSV query failed for action %s: %v", name, err)
+			failed++
 			continue
 		}
 		if len(vulns) > 0 {
 			advisories[name] = vulns
 		}
+	}
+	// If every query failed, OSV.dev is effectively unavailable; surface that as a
+	// scan error rather than reporting a clean, no-findings result.
+	if failed > 0 && failed == len(names) {
+		return nil, fmt.Errorf("all %d OSV.dev advisory queries failed", failed)
 	}
 	if len(advisories) == 0 {
 		return nil, nil
@@ -414,9 +423,28 @@ func resolveActionTags(name string) ([]ghTag, error) {
 		}
 		return nil, err
 	}
-	var tags []ghTag
-	if err := json.Unmarshal(out, &tags); err != nil {
+	tags, err := parseTagPages(out)
+	if err != nil {
 		return nil, fmt.Errorf("failed to parse tags for %s: %w", name, err)
+	}
+	return tags, nil
+}
+
+// parseTagPages flattens the output of `gh api --paginate`. Depending on the gh
+// version it emits either a single merged JSON array or one array per page
+// (concatenated without a wrapper); decoding the stream of arrays handles both.
+func parseTagPages(data []byte) ([]ghTag, error) {
+	var tags []ghTag
+	dec := json.NewDecoder(bytes.NewReader(data))
+	for {
+		var page []ghTag
+		if err := dec.Decode(&page); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, err
+		}
+		tags = append(tags, page...)
 	}
 	return tags, nil
 }
@@ -487,6 +515,9 @@ func inRange(version string, events []map[string]string) bool {
 		}
 	}
 	sort.SliceStable(evs, func(i, j int) bool {
+		if evs[i].ver == evs[j].ver {
+			return false
+		}
 		// "introduced: 0" is the lower bound and always sorts first.
 		if evs[i].ver == "0" {
 			return true

--- a/tools/ods/internal/audit/actions.go
+++ b/tools/ods/internal/audit/actions.go
@@ -1,0 +1,512 @@
+package audit
+
+// GitHub Actions dependency audit.
+//
+// osv-scalibr's github/actions extractor can *discover* the actions referenced by
+// .github/workflows/*.{yml,yaml}, but as of osv-scanner v2.4.0 the scanner cannot
+// *match* them against advisories: semantic.Parse has no comparator for the
+// "GitHub Actions" ecosystem, so IsAffected returns false for every action (in
+// both online and offline modes). GitHub Actions advisories also carry only
+// ECOSYSTEM version ranges (no enumerated versions, no affected commits), which
+// OSV.dev's version-query endpoint cannot evaluate.
+//
+// We therefore use the extractor purely for discovery and do our own matching:
+// query OSV.dev for advisories by action name, resolve each SHA-pinned ref to its
+// release tag via the GitHub CLI (the security-recommended pinning style leaves us
+// only a commit to work with), and evaluate the advisory's ECOSYSTEM ranges with a
+// semver comparator. A pin we can't resolve to a comparable version is surfaced as
+// an unverified (non-blocking) finding rather than silently dropped.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	cpb "github.com/google/osv-scalibr/binary/proto/config_go_proto"
+	"github.com/google/osv-scalibr/extractor/filesystem"
+	"github.com/google/osv-scalibr/extractor/filesystem/misc/githubactions"
+	"github.com/google/osv-scalibr/purl"
+	"github.com/google/osv-scalibr/semantic"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
+)
+
+const (
+	// actionsEcosystem is the OSV ecosystem name for GitHub Actions advisories.
+	actionsEcosystem = "GitHub Actions"
+	// osvQueryURL is the OSV.dev single-package query endpoint.
+	osvQueryURL = "https://api.osv.dev/v1/query"
+)
+
+// actionRef is a single `uses:` reference discovered in a workflow file.
+type actionRef struct {
+	Name     string // owner/repo
+	Ref      string // git tag or 40-char commit SHA
+	IsSHA    bool   // Ref is a full commit SHA (needs tag resolution to compare)
+	Manifest string // repo-relative workflow path the ref came from
+}
+
+// scanActions discovers the actions used across the repo's workflows and matches
+// them against OSV.dev advisories. Returns nil when there are no workflows or no
+// advisories affect any used action.
+func scanActions() ([]Finding, error) {
+	root, err := paths.GitRoot()
+	if err != nil {
+		return nil, err
+	}
+	refs, err := extractActions(root)
+	if err != nil {
+		return nil, err
+	}
+	refs = dedupeRefs(refs)
+	if len(refs) == 0 {
+		return nil, nil
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+
+	// Query advisories once per unique action name.
+	advisories := make(map[string][]osvVuln)
+	for _, name := range uniqueActionNames(refs) {
+		vulns, err := queryActionAdvisories(client, name)
+		if err != nil {
+			// A single flaky query shouldn't sink the whole audit; the lockfile
+			// scan is the primary gate. Warn and treat the action as clean.
+			log.Warnf("OSV query failed for action %s: %v", name, err)
+			continue
+		}
+		if len(vulns) > 0 {
+			advisories[name] = vulns
+		}
+	}
+	if len(advisories) == 0 {
+		return nil, nil
+	}
+
+	// Only actions with advisories need version resolution, so tag lookups (the
+	// expensive part) run for a handful of actions at most.
+	tagCache := make(map[string][]ghTag)
+	var findings []Finding
+	for _, ref := range refs {
+		vulns := advisories[ref.Name]
+		if len(vulns) == 0 {
+			continue
+		}
+		version, resolved := actionVersion(ref, tagCache)
+		for _, v := range vulns {
+			if !resolved {
+				findings = append(findings, actionFinding(ref, v, false))
+				continue
+			}
+			if affectedByAdvisory(version, v) {
+				findings = append(findings, actionFinding(ref, v, true))
+			}
+		}
+	}
+	return findings, nil
+}
+
+// extractActions runs osv-scalibr's github/actions extractor over each workflow
+// file and returns the referenced actions. Returns nil when there is no
+// .github/workflows directory.
+func extractActions(root string) ([]actionRef, error) {
+	dir := filepath.Join(root, ".github", "workflows")
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	ext, err := githubactions.New(&cpb.PluginConfig{})
+	if err != nil {
+		return nil, err
+	}
+
+	var refs []actionRef
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if suffix := filepath.Ext(e.Name()); suffix != ".yml" && suffix != ".yaml" {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		f, err := os.Open(path)
+		if err != nil {
+			return nil, err
+		}
+		inv, err := ext.Extract(context.Background(), &filesystem.ScanInput{Path: path, Reader: f})
+		_ = f.Close()
+		if err != nil {
+			log.Warnf("Skipping workflow %s: %v", e.Name(), err)
+			continue
+		}
+		manifest := filepath.ToSlash(filepath.Join(".github", "workflows", e.Name()))
+		for _, pkg := range inv.Packages {
+			if pkg.PURLType != purl.TypeGithub {
+				continue
+			}
+			ref := actionRef{Name: pkg.Name, Ref: pkg.Version, Manifest: manifest}
+			// The extractor records the ref as a source-code commit only when it
+			// is a full 40-char SHA, which is exactly when we need tag resolution.
+			if pkg.SourceCode != nil && pkg.SourceCode.Commit != "" {
+				ref.IsSHA = true
+			}
+			refs = append(refs, ref)
+		}
+	}
+	return refs, nil
+}
+
+// dedupeRefs collapses identical name@ref pairs, keeping the first manifest seen.
+func dedupeRefs(refs []actionRef) []actionRef {
+	seen := make(map[string]bool, len(refs))
+	out := refs[:0]
+	for _, r := range refs {
+		key := r.Name + "@" + r.Ref
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, r)
+	}
+	return out
+}
+
+// uniqueActionNames returns the distinct owner/repo names across refs.
+func uniqueActionNames(refs []actionRef) []string {
+	seen := make(map[string]bool, len(refs))
+	var names []string
+	for _, r := range refs {
+		if seen[r.Name] {
+			continue
+		}
+		seen[r.Name] = true
+		names = append(names, r.Name)
+	}
+	return names
+}
+
+// actionVersion resolves a ref to a semver-comparable version. Tag refs are used
+// directly; SHA pins are resolved to their highest release tag via the GitHub CLI.
+// The bool is false when no comparable version could be determined.
+func actionVersion(ref actionRef, cache map[string][]ghTag) (string, bool) {
+	if !ref.IsSHA {
+		if isSemverish(ref.Ref) {
+			return normalizeVersion(ref.Ref), true
+		}
+		return "", false
+	}
+	tags, ok := cache[ref.Name]
+	if !ok {
+		t, err := resolveActionTags(ref.Name)
+		if err != nil {
+			log.Warnf("Could not resolve tags for %s: %v", ref.Name, err)
+		}
+		tags = t
+		cache[ref.Name] = tags
+	}
+	return versionForSHA(tags, ref.Ref)
+}
+
+// --- OSV.dev query ---
+
+// osvVuln is the subset of an OSV.dev vulnerability record we consume.
+type osvVuln struct {
+	ID               string         `json:"id"`
+	Aliases          []string       `json:"aliases"`
+	Summary          string         `json:"summary"`
+	Details          string         `json:"details"`
+	Affected         []osvAffected  `json:"affected"`
+	DatabaseSpecific map[string]any `json:"database_specific"`
+}
+
+type osvAffected struct {
+	Package  osvPackage `json:"package"`
+	Ranges   []osvRange `json:"ranges"`
+	Versions []string   `json:"versions"`
+}
+
+type osvPackage struct {
+	Ecosystem string `json:"ecosystem"`
+	Name      string `json:"name"`
+}
+
+type osvRange struct {
+	Type   string              `json:"type"`
+	Events []map[string]string `json:"events"`
+}
+
+// queryActionAdvisories asks OSV.dev for advisories affecting an action, querying
+// by name only. GitHub Actions advisories use ECOSYSTEM ranges OSV cannot match
+// against a supplied version, so we fetch all of them and evaluate ranges locally.
+func queryActionAdvisories(client *http.Client, name string) ([]osvVuln, error) {
+	payload, err := json.Marshal(map[string]any{
+		"package": osvPackage{Ecosystem: actionsEcosystem, Name: name},
+	})
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest(http.MethodPost, osvQueryURL, bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("osv.dev returned status %d", resp.StatusCode)
+	}
+
+	var out struct {
+		Vulns []osvVuln `json:"vulns"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+	return out.Vulns, nil
+}
+
+// --- GitHub tag resolution ---
+
+// ghTag is a single entry from the GitHub list-tags API.
+type ghTag struct {
+	Name   string `json:"name"`
+	Commit struct {
+		SHA string `json:"sha"`
+	} `json:"commit"`
+}
+
+// resolveActionTags lists the tags of an action's repo via the GitHub CLI, reusing
+// the same authenticated `gh` the Dependabot audit relies on. Public-repo reads
+// work with any token.
+func resolveActionTags(name string) ([]ghTag, error) {
+	// per_page goes in the query string, not as a -f field: gh switches to POST
+	// when any -f/-F field is set without an explicit method, which 404s on this
+	// GET-only endpoint.
+	cmd := exec.Command("gh", "api",
+		"repos/"+name+"/tags?per_page=100",
+		"--paginate",
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("%w: %s", err, strings.TrimSpace(string(exitErr.Stderr)))
+		}
+		return nil, err
+	}
+	var tags []ghTag
+	if err := json.Unmarshal(out, &tags); err != nil {
+		return nil, fmt.Errorf("failed to parse tags for %s: %w", name, err)
+	}
+	return tags, nil
+}
+
+// versionForSHA returns the highest semver tag whose commit matches sha. The bool
+// is false when no semver tag points at the commit (e.g. a pin to an untagged
+// commit), leaving the ref unresolvable.
+func versionForSHA(tags []ghTag, sha string) (string, bool) {
+	best := ""
+	for _, t := range tags {
+		if !strings.EqualFold(t.Commit.SHA, sha) {
+			continue
+		}
+		v := normalizeVersion(t.Name)
+		if !isSemverish(v) {
+			continue
+		}
+		if best == "" || semverCompare(v, best) > 0 {
+			best = v
+		}
+	}
+	return best, best != ""
+}
+
+// --- Advisory range evaluation ---
+
+// affectedByAdvisory reports whether a resolved version falls within any of the
+// advisory's GitHub Actions affected ranges.
+func affectedByAdvisory(version string, v osvVuln) bool {
+	for _, aff := range v.Affected {
+		if !strings.EqualFold(aff.Package.Ecosystem, actionsEcosystem) {
+			continue
+		}
+		for _, ev := range aff.Versions {
+			if normalizeVersion(ev) == version {
+				return true
+			}
+		}
+		for _, r := range aff.Ranges {
+			// GitHub advisories use ECOSYSTEM ranges; accept SEMVER too since both
+			// carry semver-ordered bounds for this ecosystem.
+			if r.Type != "ECOSYSTEM" && r.Type != "SEMVER" {
+				continue
+			}
+			if inRange(version, r.Events) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// rangeEvent is a flattened OSV range event.
+type rangeEvent struct {
+	kind string // introduced | fixed | last_affected
+	ver  string
+}
+
+// inRange applies OSV range semantics: walking events in ascending version order,
+// an "introduced" opens the affected interval and a "fixed"/"last_affected" closes
+// it. version is affected if the interval is open once all events at or below it
+// have been applied.
+func inRange(version string, events []map[string]string) bool {
+	var evs []rangeEvent
+	for _, e := range events {
+		for kind, ver := range e {
+			evs = append(evs, rangeEvent{kind: kind, ver: ver})
+		}
+	}
+	sort.SliceStable(evs, func(i, j int) bool {
+		// "introduced: 0" is the lower bound and always sorts first.
+		if evs[i].ver == "0" {
+			return true
+		}
+		if evs[j].ver == "0" {
+			return false
+		}
+		return semverCompare(evs[i].ver, evs[j].ver) < 0
+	})
+
+	affected := false
+	for _, e := range evs {
+		switch e.kind {
+		case "introduced":
+			if e.ver == "0" || semverCompare(version, e.ver) >= 0 {
+				affected = true
+			}
+		case "fixed":
+			if semverCompare(version, e.ver) >= 0 {
+				affected = false
+			}
+		case "last_affected":
+			if semverCompare(version, e.ver) > 0 {
+				affected = false
+			}
+		}
+	}
+	return affected
+}
+
+// firstFixed returns the earliest "fixed" version across the advisory's GitHub
+// Actions ranges, for display as the remediation target.
+func firstFixed(v osvVuln) string {
+	fixed := ""
+	for _, aff := range v.Affected {
+		if !strings.EqualFold(aff.Package.Ecosystem, actionsEcosystem) {
+			continue
+		}
+		for _, r := range aff.Ranges {
+			for _, e := range r.Events {
+				if f, ok := e["fixed"]; ok && f != "" {
+					if fixed == "" || semverCompare(f, fixed) < 0 {
+						fixed = f
+					}
+				}
+			}
+		}
+	}
+	return fixed
+}
+
+// --- Finding construction ---
+
+// actionFinding builds a Finding for an advisory affecting an action. When
+// confirmed is false the pin could not be resolved to a comparable version, so the
+// finding is demoted to unknown severity (non-blocking) and flagged as unverified.
+func actionFinding(ref actionRef, v osvVuln, confirmed bool) Finding {
+	f := Finding{
+		ID:        v.ID,
+		Aliases:   v.Aliases,
+		Ecosystem: actionsEcosystem,
+		Package:   ref.Name,
+		Version:   ref.Ref,
+		Severity:  actionSeverity(v),
+		Title:     actionTitle(v),
+		URL:       osvBaseURL + v.ID,
+		Source:    SourceActions,
+		FixedIn:   firstFixed(v),
+		Manifest:  ref.Manifest,
+	}
+	if !confirmed {
+		f.Severity = SeverityUnknown
+		f.Title = "unverified pin — " + f.Title
+	}
+	return f
+}
+
+// actionSeverity reads the GHSA severity label from the advisory's
+// database_specific block, mirroring the lockfile scanner's fallback path.
+func actionSeverity(v osvVuln) Severity {
+	if v.DatabaseSpecific != nil {
+		if label, ok := v.DatabaseSpecific["severity"].(string); ok {
+			if s := ParseSeverity(label); s != SeverityUnknown {
+				return s
+			}
+		}
+	}
+	return SeverityUnknown
+}
+
+// actionTitle returns a one-line advisory title, preferring the summary.
+func actionTitle(v osvVuln) string {
+	if s := strings.TrimSpace(v.Summary); s != "" {
+		return s
+	}
+	details := strings.TrimSpace(v.Details)
+	if line, _, found := strings.Cut(details, "\n"); found {
+		return strings.TrimSpace(line)
+	}
+	return details
+}
+
+// --- version helpers ---
+
+// normalizeVersion strips a leading "v" so tag names (v6.0.2) and advisory bounds
+// (6.0.2) compare on equal footing.
+func normalizeVersion(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) > 1 && (s[0] == 'v' || s[0] == 'V') {
+		s = s[1:]
+	}
+	return s
+}
+
+// isSemverish reports whether s looks like a numeric version once normalized,
+// filtering out branch names and floating tags we can't order.
+func isSemverish(s string) bool {
+	s = normalizeVersion(s)
+	return s != "" && s[0] >= '0' && s[0] <= '9'
+}
+
+// semverCompare orders two semver-ish strings via osv-scalibr's comparator (the
+// same one used for npm/Go/crates OSV matching). Inputs are normalized first.
+func semverCompare(a, b string) int {
+	c, _ := semantic.ParseSemverVersion(normalizeVersion(a)).CompareStr(normalizeVersion(b))
+	return c
+}

--- a/tools/ods/internal/audit/actions.go
+++ b/tools/ods/internal/audit/actions.go
@@ -208,8 +208,19 @@ func extractCompositeActions(ext filesystem.Extractor, root string) ([]actionRef
 		if err != nil {
 			return err
 		}
-		steps, ok := compositeSteps(data)
-		if !ok {
+		manifest := path
+		if rel, err := filepath.Rel(root, path); err == nil {
+			manifest = rel
+		}
+		manifest = filepath.ToSlash(manifest)
+		steps, err := compositeSteps(data)
+		if err != nil {
+			// A broken action.yml would otherwise drop its nested uses from the
+			// audit silently; warn so the skipped coverage is visible.
+			log.Warnf("Skipping unparseable composite action %s: %v", manifest, err)
+			return nil
+		}
+		if len(steps) == 0 {
 			return nil
 		}
 		wrapped, err := yaml.Marshal(map[string]any{
@@ -218,11 +229,6 @@ func extractCompositeActions(ext filesystem.Extractor, root string) ([]actionRef
 		if err != nil {
 			return err
 		}
-		manifest := path
-		if rel, err := filepath.Rel(root, path); err == nil {
-			manifest = rel
-		}
-		manifest = filepath.ToSlash(manifest)
 		rs, err := usesFromReader(ext, path, bytes.NewReader(wrapped), manifest)
 		if err != nil {
 			log.Warnf("Skipping composite action %s: %v", manifest, err)
@@ -237,26 +243,25 @@ func extractCompositeActions(ext filesystem.Extractor, root string) ([]actionRef
 	return refs, nil
 }
 
-// compositeSteps returns the runs.steps of a composite action.yml, or ok=false
-// when the file is not a composite action (Docker and JavaScript actions
-// reference no other actions).
-func compositeSteps(data []byte) ([]any, bool) {
+// compositeSteps returns the runs.steps of a composite action.yml. It returns a
+// nil slice and nil error for a valid but non-composite action (Docker and
+// JavaScript actions reference no other actions), and a non-nil error only when
+// the file can't be parsed as YAML — so callers can distinguish a clean skip from
+// a broken file whose dependencies would otherwise vanish from the audit.
+func compositeSteps(data []byte) ([]any, error) {
 	var doc map[string]any
 	if err := yaml.Unmarshal(data, &doc); err != nil {
-		return nil, false
+		return nil, err
 	}
 	runs, ok := doc["runs"].(map[string]any)
 	if !ok {
-		return nil, false
+		return nil, nil
 	}
 	if using, _ := runs["using"].(string); !strings.EqualFold(using, "composite") {
-		return nil, false
+		return nil, nil
 	}
-	steps, ok := runs["steps"].([]any)
-	if !ok {
-		return nil, false
-	}
-	return steps, true
+	steps, _ := runs["steps"].([]any)
+	return steps, nil
 }
 
 // usesFromReader runs the extractor over a workflow document and maps the

--- a/tools/ods/internal/audit/actions.go
+++ b/tools/ods/internal/audit/actions.go
@@ -22,6 +22,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"io/fs"
 	"net/http"
 	"os"
 	"os/exec"
@@ -36,6 +38,7 @@ import (
 	"github.com/google/osv-scalibr/purl"
 	"github.com/google/osv-scalibr/semantic"
 	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
 
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
 )
@@ -55,9 +58,9 @@ type actionRef struct {
 	Manifest string // repo-relative workflow path the ref came from
 }
 
-// scanActions discovers the actions used across the repo's workflows and matches
-// them against OSV.dev advisories. Returns nil when there are no workflows or no
-// advisories affect any used action.
+// scanActions discovers the actions used across the repo's workflows and
+// composite actions and matches them against OSV.dev advisories. Returns nil when
+// nothing is referenced or no advisories affect any used action.
 func scanActions() ([]Finding, error) {
 	root, err := paths.GitRoot()
 	if err != nil {
@@ -115,20 +118,34 @@ func scanActions() ([]Finding, error) {
 	return findings, nil
 }
 
-// extractActions runs osv-scalibr's github/actions extractor over each workflow
-// file and returns the referenced actions. Returns nil when there is no
-// .github/workflows directory.
+// extractActions discovers the actions referenced across the repo's reusable
+// workflows (.github/workflows) and composite actions (.github/actions). Returns
+// nil when neither exists.
 func extractActions(root string) ([]actionRef, error) {
+	ext, err := githubactions.New(&cpb.PluginConfig{})
+	if err != nil {
+		return nil, err
+	}
+
+	workflowRefs, err := extractWorkflowActions(ext, root)
+	if err != nil {
+		return nil, err
+	}
+	compositeRefs, err := extractCompositeActions(ext, root)
+	if err != nil {
+		return nil, err
+	}
+	return append(workflowRefs, compositeRefs...), nil
+}
+
+// extractWorkflowActions runs the github/actions extractor over each
+// .github/workflows/*.{yml,yaml} file.
+func extractWorkflowActions(ext filesystem.Extractor, root string) ([]actionRef, error) {
 	dir := filepath.Join(root, ".github", "workflows")
 	entries, err := os.ReadDir(dir)
 	if os.IsNotExist(err) {
 		return nil, nil
 	}
-	if err != nil {
-		return nil, err
-	}
-
-	ext, err := githubactions.New(&cpb.PluginConfig{})
 	if err != nil {
 		return nil, err
 	}
@@ -146,25 +163,112 @@ func extractActions(root string) ([]actionRef, error) {
 		if err != nil {
 			return nil, err
 		}
-		inv, err := ext.Extract(context.Background(), &filesystem.ScanInput{Path: path, Reader: f})
+		manifest := filepath.ToSlash(filepath.Join(".github", "workflows", e.Name()))
+		rs, err := usesFromReader(ext, path, f, manifest)
 		_ = f.Close()
 		if err != nil {
 			log.Warnf("Skipping workflow %s: %v", e.Name(), err)
 			continue
 		}
-		manifest := filepath.ToSlash(filepath.Join(".github", "workflows", e.Name()))
-		for _, pkg := range inv.Packages {
-			if pkg.PURLType != purl.TypeGithub {
-				continue
-			}
-			ref := actionRef{Name: pkg.Name, Ref: pkg.Version, Manifest: manifest}
-			// The extractor records the ref as a source-code commit only when it
-			// is a full 40-char SHA, which is exactly when we need tag resolution.
-			if pkg.SourceCode != nil && pkg.SourceCode.Commit != "" {
-				ref.IsSHA = true
-			}
-			refs = append(refs, ref)
+		refs = append(refs, rs...)
+	}
+	return refs, nil
+}
+
+// extractCompositeActions discovers the actions referenced by composite actions
+// under .github/actions. The github/actions extractor only understands workflow
+// files (jobs.<id>.steps[].uses), so each composite action's runs.steps is
+// reshaped into a synthetic single-job workflow before extraction — reusing the
+// extractor's uses parsing (subpaths, docker/local skips, SHA detection) rather
+// than reimplementing it.
+func extractCompositeActions(ext filesystem.Extractor, root string) ([]actionRef, error) {
+	dir := filepath.Join(root, ".github", "actions")
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return nil, nil
+	}
+
+	var refs []actionRef
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
 		}
+		if d.IsDir() || (d.Name() != "action.yml" && d.Name() != "action.yaml") {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		steps, ok := compositeSteps(data)
+		if !ok {
+			return nil
+		}
+		wrapped, err := yaml.Marshal(map[string]any{
+			"jobs": map[string]any{"composite": map[string]any{"steps": steps}},
+		})
+		if err != nil {
+			return err
+		}
+		manifest := path
+		if rel, err := filepath.Rel(root, path); err == nil {
+			manifest = rel
+		}
+		manifest = filepath.ToSlash(manifest)
+		rs, err := usesFromReader(ext, path, bytes.NewReader(wrapped), manifest)
+		if err != nil {
+			log.Warnf("Skipping composite action %s: %v", manifest, err)
+			return nil
+		}
+		refs = append(refs, rs...)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return refs, nil
+}
+
+// compositeSteps returns the runs.steps of a composite action.yml, or ok=false
+// when the file is not a composite action (Docker and JavaScript actions
+// reference no other actions).
+func compositeSteps(data []byte) ([]any, bool) {
+	var doc map[string]any
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, false
+	}
+	runs, ok := doc["runs"].(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	if using, _ := runs["using"].(string); !strings.EqualFold(using, "composite") {
+		return nil, false
+	}
+	steps, ok := runs["steps"].([]any)
+	if !ok {
+		return nil, false
+	}
+	return steps, true
+}
+
+// usesFromReader runs the extractor over a workflow document and maps the
+// referenced GitHub actions into actionRefs tagged with the given manifest path.
+func usesFromReader(ext filesystem.Extractor, path string, r io.Reader, manifest string) ([]actionRef, error) {
+	inv, err := ext.Extract(context.Background(), &filesystem.ScanInput{Path: path, Reader: r})
+	if err != nil {
+		return nil, err
+	}
+	var refs []actionRef
+	for _, pkg := range inv.Packages {
+		if pkg.PURLType != purl.TypeGithub {
+			continue
+		}
+		ref := actionRef{Name: pkg.Name, Ref: pkg.Version, Manifest: manifest}
+		// The extractor records the ref as a source-code commit only when it is a
+		// full 40-char SHA, which is exactly when we need tag resolution.
+		if pkg.SourceCode != nil && pkg.SourceCode.Commit != "" {
+			ref.IsSHA = true
+		}
+		refs = append(refs, ref)
 	}
 	return refs, nil
 }

--- a/tools/ods/internal/audit/actions_test.go
+++ b/tools/ods/internal/audit/actions_test.go
@@ -215,6 +215,34 @@ func TestNormalizeVersionAndSemverish(t *testing.T) {
 	}
 }
 
+func TestCompositeSteps(t *testing.T) {
+	composite := []byte(`
+name: x
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v4
+      shell: bash
+    - run: echo hi
+      shell: bash
+`)
+	steps, ok := compositeSteps(composite)
+	if !ok || len(steps) != 2 {
+		t.Fatalf("compositeSteps = (%d steps, %v), want (2, true)", len(steps), ok)
+	}
+
+	// Docker/JavaScript actions reference no other actions.
+	docker := []byte("name: x\nruns:\n  using: docker\n  image: Dockerfile\n")
+	if _, ok := compositeSteps(docker); ok {
+		t.Error("docker action should not be treated as composite")
+	}
+
+	// Malformed YAML must be skipped, not fail the scan.
+	if _, ok := compositeSteps([]byte("runs: [unclosed")); ok {
+		t.Error("malformed yaml should return ok=false")
+	}
+}
+
 func mkTag(name, sha string) ghTag {
 	t := ghTag{Name: name}
 	t.Commit.SHA = sha

--- a/tools/ods/internal/audit/actions_test.go
+++ b/tools/ods/internal/audit/actions_test.go
@@ -1,0 +1,222 @@
+package audit
+
+import "testing"
+
+// ecoVuln builds a GitHub Actions advisory with a single ECOSYSTEM range.
+func ecoVuln(id string, events ...map[string]string) osvVuln {
+	return osvVuln{
+		ID: id,
+		Affected: []osvAffected{{
+			Package: osvPackage{Ecosystem: actionsEcosystem, Name: "tj-actions/changed-files"},
+			Ranges:  []osvRange{{Type: "ECOSYSTEM", Events: events}},
+		}},
+	}
+}
+
+func TestAffectedByAdvisoryFixedRange(t *testing.T) {
+	// introduced: 0, fixed: 46.0.1  (mirrors GHSA-mrrh-fwg8-r2c3)
+	v := ecoVuln("GHSA-x", map[string]string{"introduced": "0"}, map[string]string{"fixed": "46.0.1"})
+	cases := []struct {
+		version string
+		want    bool
+	}{
+		{"45.0.7", true},  // below fix
+		{"46.0.0", true},  // still below fix
+		{"46.0.1", false}, // exactly the fix -> patched
+		{"46.0.2", false}, // above fix
+		{"41", true},      // major-only tag below fix
+	}
+	for _, tc := range cases {
+		if got := affectedByAdvisory(tc.version, v); got != tc.want {
+			t.Errorf("affectedByAdvisory(%q) = %v, want %v", tc.version, got, tc.want)
+		}
+	}
+}
+
+func TestAffectedByAdvisoryLastAffected(t *testing.T) {
+	v := ecoVuln("GHSA-y", map[string]string{"introduced": "0"}, map[string]string{"last_affected": "45.0.7"})
+	if !affectedByAdvisory("45.0.7", v) {
+		t.Error("45.0.7 should be affected (== last_affected)")
+	}
+	if affectedByAdvisory("45.0.8", v) {
+		t.Error("45.0.8 should not be affected (> last_affected)")
+	}
+}
+
+func TestAffectedByAdvisoryEnumeratedVersions(t *testing.T) {
+	v := osvVuln{
+		ID: "GHSA-z",
+		Affected: []osvAffected{{
+			Package:  osvPackage{Ecosystem: actionsEcosystem, Name: "a/b"},
+			Versions: []string{"v44.0.0", "44.1.0"},
+		}},
+	}
+	if !affectedByAdvisory("44.0.0", v) {
+		t.Error("44.0.0 should match enumerated version (v-prefix normalized)")
+	}
+	if affectedByAdvisory("44.2.0", v) {
+		t.Error("44.2.0 should not match")
+	}
+}
+
+func TestAffectedByAdvisoryIgnoresOtherEcosystems(t *testing.T) {
+	v := osvVuln{
+		ID: "GHSA-npm",
+		Affected: []osvAffected{{
+			Package: osvPackage{Ecosystem: "npm", Name: "lodash"},
+			Ranges:  []osvRange{{Type: "SEMVER", Events: []map[string]string{{"introduced": "0"}, {"fixed": "99.0.0"}}}},
+		}},
+	}
+	if affectedByAdvisory("1.0.0", v) {
+		t.Error("non-GitHub-Actions affected entries must be ignored")
+	}
+}
+
+func TestFirstFixed(t *testing.T) {
+	v := ecoVuln("GHSA-x", map[string]string{"introduced": "0"}, map[string]string{"fixed": "46.0.1"})
+	if got := firstFixed(v); got != "46.0.1" {
+		t.Errorf("firstFixed = %q, want 46.0.1", got)
+	}
+	// No fixed event -> empty.
+	v2 := ecoVuln("GHSA-y", map[string]string{"introduced": "0"}, map[string]string{"last_affected": "45.0.7"})
+	if got := firstFixed(v2); got != "" {
+		t.Errorf("firstFixed = %q, want empty", got)
+	}
+}
+
+func TestVersionForSHA(t *testing.T) {
+	const sha = "de0fac2e4500dabe0009e67214ff5f5447ce83dd"
+	tags := []ghTag{
+		mkTag("v6", sha),
+		mkTag("v6.0.2", sha),    // more specific tag on the same commit
+		mkTag("v5.9.9", "othr"), // different commit
+		mkTag("nightly", sha),   // non-semver, must be ignored
+	}
+	got, ok := versionForSHA(tags, sha)
+	if !ok || got != "6.0.2" {
+		t.Errorf("versionForSHA = (%q, %v), want (6.0.2, true)", got, ok)
+	}
+
+	if _, ok := versionForSHA(tags, "0000000000000000000000000000000000000000"); ok {
+		t.Error("unknown sha should not resolve")
+	}
+}
+
+func TestActionVersionTagPin(t *testing.T) {
+	cache := map[string][]ghTag{}
+	// A semver tag pin resolves directly without touching the cache/network.
+	got, ok := actionVersion(actionRef{Name: "a/b", Ref: "v4.2.1", IsSHA: false}, cache)
+	if !ok || got != "4.2.1" {
+		t.Errorf("actionVersion(tag) = (%q, %v), want (4.2.1, true)", got, ok)
+	}
+	// A branch/floating ref is not comparable.
+	if _, ok := actionVersion(actionRef{Name: "a/b", Ref: "main", IsSHA: false}, cache); ok {
+		t.Error("branch ref should be unresolvable")
+	}
+}
+
+func TestActionSeverity(t *testing.T) {
+	v := osvVuln{DatabaseSpecific: map[string]any{"severity": "HIGH"}}
+	if got := actionSeverity(v); got != SeverityHigh {
+		t.Errorf("actionSeverity = %q, want high", got)
+	}
+	if got := actionSeverity(osvVuln{}); got != SeverityUnknown {
+		t.Errorf("actionSeverity(empty) = %q, want unknown", got)
+	}
+}
+
+func TestActionFindingConfirmed(t *testing.T) {
+	ref := actionRef{Name: "tj-actions/changed-files", Ref: "45.0.7", Manifest: ".github/workflows/ci.yml"}
+	v := ecoVuln("GHSA-mrrh-fwg8-r2c3", map[string]string{"introduced": "0"}, map[string]string{"fixed": "46.0.1"})
+	v.Summary = "changed-files leaks secrets"
+	v.DatabaseSpecific = map[string]any{"severity": "HIGH"}
+
+	f := actionFinding(ref, v, true)
+	if f.Source != SourceActions {
+		t.Errorf("source = %q, want %q", f.Source, SourceActions)
+	}
+	if f.Severity != SeverityHigh {
+		t.Errorf("severity = %q, want high", f.Severity)
+	}
+	if f.Package != "tj-actions/changed-files" || f.Version != "45.0.7" {
+		t.Errorf("package/version wrong: %+v", f)
+	}
+	if f.Ecosystem != actionsEcosystem {
+		t.Errorf("ecosystem = %q", f.Ecosystem)
+	}
+	if f.Title != "changed-files leaks secrets" {
+		t.Errorf("title = %q", f.Title)
+	}
+	if f.FixedIn != "46.0.1" {
+		t.Errorf("fixedIn = %q, want 46.0.1", f.FixedIn)
+	}
+	if f.URL != osvBaseURL+"GHSA-mrrh-fwg8-r2c3" {
+		t.Errorf("url = %q", f.URL)
+	}
+	if f.Manifest != ".github/workflows/ci.yml" {
+		t.Errorf("manifest = %q", f.Manifest)
+	}
+}
+
+func TestActionFindingIndeterminate(t *testing.T) {
+	ref := actionRef{Name: "tj-actions/changed-files", Ref: "0e58ed8671d6b60d0890c21b07f8835ace038e67"}
+	v := ecoVuln("GHSA-mrrh-fwg8-r2c3")
+	v.Summary = "changed-files leaks secrets"
+	v.DatabaseSpecific = map[string]any{"severity": "HIGH"}
+
+	f := actionFinding(ref, v, false)
+	// Unresolved pins must not block the gate, so severity is demoted...
+	if f.Severity != SeverityUnknown {
+		t.Errorf("severity = %q, want unknown for unverified pin", f.Severity)
+	}
+	// ...and the title flags why.
+	if f.Title != "unverified pin — changed-files leaks secrets" {
+		t.Errorf("title = %q", f.Title)
+	}
+}
+
+func TestDedupeRefs(t *testing.T) {
+	refs := []actionRef{
+		{Name: "a/b", Ref: "v1", Manifest: "w1.yml"},
+		{Name: "a/b", Ref: "v1", Manifest: "w2.yml"}, // dup, dropped
+		{Name: "a/b", Ref: "v2", Manifest: "w1.yml"},
+		{Name: "c/d", Ref: "v1", Manifest: "w1.yml"},
+	}
+	got := dedupeRefs(refs)
+	if len(got) != 3 {
+		t.Fatalf("dedupeRefs len = %d, want 3", len(got))
+	}
+	if got[0].Manifest != "w1.yml" {
+		t.Errorf("first manifest = %q, want w1.yml (first seen kept)", got[0].Manifest)
+	}
+}
+
+func TestUniqueActionNames(t *testing.T) {
+	refs := []actionRef{
+		{Name: "a/b", Ref: "v1"},
+		{Name: "a/b", Ref: "v2"},
+		{Name: "c/d", Ref: "v1"},
+	}
+	got := uniqueActionNames(refs)
+	if len(got) != 2 || got[0] != "a/b" || got[1] != "c/d" {
+		t.Errorf("uniqueActionNames = %v, want [a/b c/d]", got)
+	}
+}
+
+func TestNormalizeVersionAndSemverish(t *testing.T) {
+	if got := normalizeVersion("v6.0.2"); got != "6.0.2" {
+		t.Errorf("normalizeVersion = %q", got)
+	}
+	if !isSemverish("v45.0.7") || !isSemverish("41") {
+		t.Error("v45.0.7 and 41 should be semverish")
+	}
+	if isSemverish("main") || isSemverish("") {
+		t.Error("branch names and empty strings are not semverish")
+	}
+}
+
+func mkTag(name, sha string) ghTag {
+	t := ghTag{Name: name}
+	t.Commit.SHA = sha
+	return t
+}

--- a/tools/ods/internal/audit/actions_test.go
+++ b/tools/ods/internal/audit/actions_test.go
@@ -226,20 +226,20 @@ runs:
     - run: echo hi
       shell: bash
 `)
-	steps, ok := compositeSteps(composite)
-	if !ok || len(steps) != 2 {
-		t.Fatalf("compositeSteps = (%d steps, %v), want (2, true)", len(steps), ok)
+	steps, err := compositeSteps(composite)
+	if err != nil || len(steps) != 2 {
+		t.Fatalf("compositeSteps = (%d steps, %v), want (2, nil)", len(steps), err)
 	}
 
-	// Docker/JavaScript actions reference no other actions.
+	// Docker/JavaScript actions reference no other actions: a clean skip.
 	docker := []byte("name: x\nruns:\n  using: docker\n  image: Dockerfile\n")
-	if _, ok := compositeSteps(docker); ok {
-		t.Error("docker action should not be treated as composite")
+	if steps, err := compositeSteps(docker); err != nil || steps != nil {
+		t.Errorf("docker action = (%v, %v), want (nil, nil)", steps, err)
 	}
 
-	// Malformed YAML must be skipped, not fail the scan.
-	if _, ok := compositeSteps([]byte("runs: [unclosed")); ok {
-		t.Error("malformed yaml should return ok=false")
+	// Malformed YAML must surface an error so the skipped file is visible.
+	if _, err := compositeSteps([]byte("runs: [unclosed")); err == nil {
+		t.Error("malformed yaml should return an error")
 	}
 }
 

--- a/tools/ods/internal/audit/actions_test.go
+++ b/tools/ods/internal/audit/actions_test.go
@@ -203,18 +203,6 @@ func TestUniqueActionNames(t *testing.T) {
 	}
 }
 
-func TestNormalizeVersionAndSemverish(t *testing.T) {
-	if got := normalizeVersion("v6.0.2"); got != "6.0.2" {
-		t.Errorf("normalizeVersion = %q", got)
-	}
-	if !isSemverish("v45.0.7") || !isSemverish("41") {
-		t.Error("v45.0.7 and 41 should be semverish")
-	}
-	if isSemverish("main") || isSemverish("") {
-		t.Error("branch names and empty strings are not semverish")
-	}
-}
-
 func TestCompositeSteps(t *testing.T) {
 	composite := []byte(`
 name: x

--- a/tools/ods/internal/audit/actions_test.go
+++ b/tools/ods/internal/audit/actions_test.go
@@ -243,6 +243,41 @@ runs:
 	}
 }
 
+func TestParseTagPages(t *testing.T) {
+	// Modern gh --paginate merges pages into one array.
+	single := []byte(`[{"name":"v1","commit":{"sha":"aaa"}},{"name":"v2","commit":{"sha":"bbb"}}]`)
+	tags, err := parseTagPages(single)
+	if err != nil || len(tags) != 2 {
+		t.Fatalf("single: (%d tags, %v), want 2 tags", len(tags), err)
+	}
+
+	// Older gh --paginate concatenates one array per page without a wrapper.
+	concat := []byte(`[{"name":"v1","commit":{"sha":"aaa"}}][{"name":"v2","commit":{"sha":"bbb"}}]`)
+	tags, err = parseTagPages(concat)
+	if err != nil || len(tags) != 2 {
+		t.Fatalf("concatenated: (%d tags, %v), want 2 tags", len(tags), err)
+	}
+	if tags[1].Name != "v2" || tags[1].Commit.SHA != "bbb" {
+		t.Errorf("second tag wrong: %+v", tags[1])
+	}
+
+	if tags, err := parseTagPages([]byte(`[]`)); err != nil || len(tags) != 0 {
+		t.Errorf("empty page: (%d, %v), want 0 tags", len(tags), err)
+	}
+}
+
+func TestInRangeToleratesDuplicateZeroEvents(t *testing.T) {
+	// Malformed advisory with two introduced:0 events must not violate the sort's
+	// ordering contract (panic) and should still evaluate correctly.
+	events := []map[string]string{{"introduced": "0"}, {"introduced": "0"}, {"fixed": "2.0.0"}}
+	if !inRange("1.0.0", events) {
+		t.Error("1.0.0 should be affected (< fixed 2.0.0)")
+	}
+	if inRange("2.0.0", events) {
+		t.Error("2.0.0 should be patched (== fixed)")
+	}
+}
+
 func mkTag(name, sha string) ghTag {
 	t := ghTag{Name: name}
 	t.Commit.SHA = sha

--- a/tools/ods/internal/audit/audit.go
+++ b/tools/ods/internal/audit/audit.go
@@ -137,6 +137,12 @@ func Run(opts Options) (*Result, error) {
 	scanDependabot := runAll || opts.Dependabot
 	scanActionsSrc := runAll || opts.Actions
 
+	// A lockfile scan (web/python) is the primary deploy gate. While one is
+	// running, a flaky Dependabot/Actions backend is downgraded to a warning;
+	// otherwise a failure of an explicitly requested backend is fatal, so the
+	// audit can't report success without having actually checked anything.
+	lockfileGate := scanWeb || scanPython
+
 	var findings []Finding
 
 	if scanWeb || scanPython {
@@ -154,10 +160,7 @@ func Run(opts Options) (*Result, error) {
 	if scanDependabot {
 		fs, err := auditDependabot()
 		if err != nil {
-			// When this is the only requested source, surface the error. Otherwise
-			// the lockfile scan is the primary gate, so warn and continue rather
-			// than fail the whole audit on an API hiccup.
-			if isOnlySource(opts, opts.Dependabot) {
+			if !lockfileGate {
 				return nil, fmt.Errorf("dependabot audit failed: %w", err)
 			}
 			log.Warnf("Dependabot audit skipped: %v", err)
@@ -169,7 +172,7 @@ func Run(opts Options) (*Result, error) {
 	if scanActionsSrc {
 		fs, err := scanActions()
 		if err != nil {
-			if isOnlySource(opts, opts.Actions) {
+			if !lockfileGate {
 				return nil, fmt.Errorf("github actions audit failed: %w", err)
 			}
 			log.Warnf("GitHub Actions audit skipped: %v", err)
@@ -209,22 +212,6 @@ func Run(opts Options) (*Result, error) {
 		return nil, err
 	}
 	return result, nil
-}
-
-// isOnlySource reports whether sel is the single explicitly requested source, so
-// a backend failure should fail the whole audit instead of being downgraded to a
-// warning. It is false during an all-sources run (no selector flags set).
-func isOnlySource(opts Options, sel bool) bool {
-	if !sel {
-		return false
-	}
-	n := 0
-	for _, s := range []bool{opts.Web, opts.Python, opts.Dependabot, opts.Actions} {
-		if s {
-			n++
-		}
-	}
-	return n == 1
 }
 
 // lockfilePaths returns the lockfiles to scan based on the selectors, skipping

--- a/tools/ods/internal/audit/audit.go
+++ b/tools/ods/internal/audit/audit.go
@@ -33,6 +33,7 @@ const (
 	SourceOSV        = "osv-scanner"
 	SourceDependabot = "dependabot"
 	SourceImage      = "osv-scanner-image"
+	SourceActions    = "github-actions"
 )
 
 // rank gives an orderable weight to a severity; higher is more severe.
@@ -112,6 +113,7 @@ type Options struct {
 	Web        bool
 	Python     bool
 	Dependabot bool
+	Actions    bool
 	Format     string // text|json|sarif
 	FailOn     Severity
 	IgnoreURL  string
@@ -129,10 +131,11 @@ type Result struct {
 // report to opts.Writer, and returns the result. With no selector flags set,
 // all backends are run.
 func Run(opts Options) (*Result, error) {
-	runAll := !opts.Web && !opts.Python && !opts.Dependabot
+	runAll := !opts.Web && !opts.Python && !opts.Dependabot && !opts.Actions
 	scanWeb := runAll || opts.Web
 	scanPython := runAll || opts.Python
 	scanDependabot := runAll || opts.Dependabot
+	scanActionsSrc := runAll || opts.Actions
 
 	var findings []Finding
 
@@ -151,13 +154,25 @@ func Run(opts Options) (*Result, error) {
 	if scanDependabot {
 		fs, err := auditDependabot()
 		if err != nil {
-			// When Dependabot is the only requested source, surface the error.
-			// Otherwise the lockfile scan is the primary gate, so warn and
-			// continue rather than fail the whole audit on an API hiccup.
-			if opts.Dependabot && !opts.Web && !opts.Python {
+			// When this is the only requested source, surface the error. Otherwise
+			// the lockfile scan is the primary gate, so warn and continue rather
+			// than fail the whole audit on an API hiccup.
+			if isOnlySource(opts, opts.Dependabot) {
 				return nil, fmt.Errorf("dependabot audit failed: %w", err)
 			}
 			log.Warnf("Dependabot audit skipped: %v", err)
+		} else {
+			findings = append(findings, fs...)
+		}
+	}
+
+	if scanActionsSrc {
+		fs, err := scanActions()
+		if err != nil {
+			if isOnlySource(opts, opts.Actions) {
+				return nil, fmt.Errorf("github actions audit failed: %w", err)
+			}
+			log.Warnf("GitHub Actions audit skipped: %v", err)
 		} else {
 			findings = append(findings, fs...)
 		}
@@ -194,6 +209,22 @@ func Run(opts Options) (*Result, error) {
 		return nil, err
 	}
 	return result, nil
+}
+
+// isOnlySource reports whether sel is the single explicitly requested source, so
+// a backend failure should fail the whole audit instead of being downgraded to a
+// warning. It is false during an all-sources run (no selector flags set).
+func isOnlySource(opts Options, sel bool) bool {
+	if !sel {
+		return false
+	}
+	n := 0
+	for _, s := range []bool{opts.Web, opts.Python, opts.Dependabot, opts.Actions} {
+		if s {
+			n++
+		}
+	}
+	return n == 1
 }
 
 // lockfilePaths returns the lockfiles to scan based on the selectors, skipping

--- a/tools/ods/internal/version/version.go
+++ b/tools/ods/internal/version/version.go
@@ -1,0 +1,34 @@
+// Package version provides small helpers for normalizing and comparing
+// semver-ish version strings (release tags, advisory bounds, etc.).
+package version
+
+import (
+	"strings"
+
+	"github.com/google/osv-scalibr/semantic"
+)
+
+// Normalize strips a leading "v" so tag names (v6.0.2) and bare versions (6.0.2)
+// compare on equal footing, and trims surrounding whitespace.
+func Normalize(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) > 1 && (s[0] == 'v' || s[0] == 'V') {
+		s = s[1:]
+	}
+	return s
+}
+
+// IsSemverish reports whether s looks like a numeric version once normalized,
+// filtering out branch names and floating tags that can't be ordered.
+func IsSemverish(s string) bool {
+	s = Normalize(s)
+	return s != "" && s[0] >= '0' && s[0] <= '9'
+}
+
+// Compare orders two semver-ish strings via osv-scalibr's comparator (the same
+// one used for npm/Go/crates OSV matching). Inputs are normalized first. It
+// returns -1, 0, or 1 for a < b, a == b, a > b.
+func Compare(a, b string) int {
+	c, _ := semantic.ParseSemverVersion(Normalize(a)).CompareStr(Normalize(b))
+	return c
+}

--- a/tools/ods/internal/version/version_test.go
+++ b/tools/ods/internal/version/version_test.go
@@ -1,0 +1,46 @@
+package version
+
+import "testing"
+
+func TestNormalize(t *testing.T) {
+	cases := map[string]string{
+		"v6.0.2":  "6.0.2",
+		"V6.0.2":  "6.0.2",
+		"6.0.2":   "6.0.2",
+		"  v41  ": "41",
+		"main":    "main",
+		"":        "",
+		"v":       "v", // too short to strip
+	}
+	for in, want := range cases {
+		if got := Normalize(in); got != want {
+			t.Errorf("Normalize(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestIsSemverish(t *testing.T) {
+	if !IsSemverish("v45.0.7") || !IsSemverish("41") {
+		t.Error("v45.0.7 and 41 should be semverish")
+	}
+	if IsSemverish("main") || IsSemverish("") {
+		t.Error("branch names and empty strings are not semverish")
+	}
+}
+
+func TestCompare(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"46.0.1", "46.0.0", 1},
+		{"46.0.0", "46.0.1", -1},
+		{"v46.0.1", "46.0.1", 0}, // v-prefix normalized before compare
+		{"41", "40.9.9", 1},
+	}
+	for _, tc := range cases {
+		if got := Compare(tc.a, tc.b); got != tc.want {
+			t.Errorf("Compare(%q, %q) = %d, want %d", tc.a, tc.b, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## What

Adds `ods audit --actions`, auditing the GitHub Actions pinned in `.github/workflows` **and** the composite actions in `.github/actions` against OSV.dev, gating deploys on known-vulnerable actions the same way the lockfile and Dependabot sources already do. It joins the default all-sources run, so bare `ods audit` (and the CI gate + nightly SARIF) now covers actions too.

```
$ ods audit --actions
Dependency vulnerabilities:
  HIGH      GitHub Actions GHSA-mrrh-fwg8-r2c3    tj-actions/changed-files@40…  tj-actions changed-files through 45.0.7 …
  UNKNOWN   GitHub Actions GHSA-vqf5-2xx6-9wfm    github/codeql-action@ba454b…  unverified pin — GitHub PAT written to …
```

## Why a custom matcher

osv-scalibr (PR google/osv-scalibr#2032) can *extract* workflow action refs, but osv-scanner v2.4.0 **cannot match** them:

- `semantic.Parse` has no comparator for the `GitHub Actions` ecosystem, so `IsAffected` returns `false` for every action — in both online and offline modes (the code even comments this).
- GitHub Actions advisories carry only `ECOSYSTEM` version ranges (no enumerated versions, no affected commits), which OSV.dev's version-query endpoint can't evaluate. Verified against the live API: a versioned GitHub Actions query returns nothing even for a version an advisory explicitly lists as affected.

So a naive `--actions` on `DoScan` would run, extract everything, and detect nothing — a silent no-op gate. Instead this uses the extractor only for **discovery** and matches ourselves.

## How it works

1. **Extract** actions via scalibr's `github/actions` extractor (`owner/repo@ref`), across both `.github/workflows/*.yml` and the composite `.github/actions/*/action.yml` (each composite's `runs.steps` is reshaped into a synthetic one-job workflow so the same extractor parses it).
2. **Query OSV.dev** by action name only (no version), fetching all advisories + their ECOSYSTEM ranges.
3. **Resolve** each SHA pin → release tag via `gh api repos/{action}/tags` (reusing the same authed `gh` the Dependabot path uses; only for actions that *have* advisories, so a handful of calls at most). This repo pins actions by commit SHA — the recommended style — so tag comparison alone finds nothing without this step.
4. **Compare** the resolved version against the advisory ranges with scalibr's semver comparator (the same one OSV uses for npm/Go/crates), wrapped behind a small shared `internal/version` helper.

**Policy:** confirmed-affected pins report at the advisory severity and gate per `--fail-on`. A pin that can't be resolved to a comparable version (untagged commit, floating branch) is surfaced as an `unverified pin` at unknown severity — visible but non-blocking — rather than dropped or guessed. Findings flow through the existing allowlist, dedupe, and text/json/sarif reporting unchanged. Backend failures warn-and-continue during an all-sources run, so an OSV/`gh` hiccup won't break the gate.

## Testing

- 15 unit tests over the pure matcher logic (range evaluation incl. `fixed`/`last_affected`/enumerated versions, SHA→tag selection, severity, finding construction), plus 3 covering the extracted `internal/version` helpers.
- Live end-to-end:
  - Synthetic `tj-actions/changed-files@<v45.0.0 SHA>` → resolved to 45.0.0 → **HIGH `GHSA-mrrh-fwg8-r2c3`**, `fixed_in: 46.0.1`, `--fail-on high` exits 1 (gate works).
  - `actions/download-artifact` and `j178/prek-action` pins resolved and correctly dropped as patched (true negatives).
  - `github/codeql-action` correctly surfaced as `unverified` (its pin maps only to a `codeql-bundle-*` tag, a different version namespace than the advisory's `3.x`).
- `go build` / `go vet` / `gofmt` clean.

## CI gating

The audit workflow's PR `paths:` filter now includes `.github/workflows/**` and `.github/actions/**`, so a PR that bumps a pinned action to a vulnerable version trips the gate on that PR — not just the nightly run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `ods audit --actions` to scan pinned GitHub Actions in `.github/workflows` and composite actions in `.github/actions` against OSV.dev, failing on known‑vulnerable pins. The audit workflow now gates PRs that change workflows or composite actions, and `--actions` runs by default with `ods audit`.

- **New Features**
  - New `--actions` selector; included in the default all-sources run.
  - Scans workflows and composite actions, extracts `owner/repo@ref`, queries OSV by action, resolves SHA pins to tags via `gh`, and matches ECOSYSTEM ranges locally with `osv-scalibr`.
  - Fails on confirmed vulnerable pins per `--fail-on`; unresolvable pins are reported as “unverified” (unknown severity, non-blocking).
  - CI: PR paths now include `.github/workflows/**` and `.github/actions/**` so action bumps are gated on the PR.

- **Bug Fixes**
  - Parses `gh api --paginate` output in both merged and concatenated JSON modes to keep tag resolution reliable.
  - Range evaluation tolerates duplicate/equal-version events and evaluates correctly.
  - Returns an error when all OSV.dev advisory queries fail, preventing false “clean” results on outages.
  - Backend failures are fatal only when no lockfile scan is running; otherwise they warn-and-continue.
  - Warns on unparseable `.github/actions/*/action.yml` instead of silently skipping composite action dependencies.

<sup>Written for commit e5bdb1dea1365bfa97dc23b8113dd933e27b690e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


