### PR TITLE
feat(skills): add unified backend skill management

### DIFF
--- a/.github/workflows/pr-craft-k8s-tests.yml
+++ b/.github/workflows/pr-craft-k8s-tests.yml
@@ -103,6 +103,7 @@ jobs:
               - 'backend/Dockerfile'
               - 'backend/onyx/sandbox_proxy/**'
               - 'backend/onyx/server/features/build/**'
+              - 'backend/onyx/server/features/skill/**'
               - 'backend/onyx/skills/**'
               - 'backend/shared_configs/**'
               - 'deployment/helm/**'

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -2074,11 +2074,19 @@ async def current_user(
     return user
 
 
+_CURATOR_OR_ADMIN_ROLES = frozenset(
+    {UserRole.GLOBAL_CURATOR, UserRole.CURATOR, UserRole.ADMIN}
+)
+
+
+def is_user_curator_or_admin(user: User) -> bool:
+    return user.role in _CURATOR_OR_ADMIN_ROLES
+
+
 async def current_curator_or_admin_user(
     user: User = Depends(current_user),
 ) -> User:
-    allowed_roles = {UserRole.GLOBAL_CURATOR, UserRole.CURATOR, UserRole.ADMIN}
-    if user.role not in allowed_roles:
+    if not is_user_curator_or_admin(user):
         raise BasicAuthenticationError(
             detail="Access denied. User is not a curator or admin.",
         )

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -70,10 +70,6 @@ GENERATIVE_MODEL_ACCESS_CHECK_FREQ = int(
     os.environ.get("GENERATIVE_MODEL_ACCESS_CHECK_FREQ") or 86400
 )  # 1 day
 
-# Per-user cap on self-managed personal skills. Env-overridable so CI can lower
-# it without uploading the full quota of real bundles to exercise the limit.
-MAX_PERSONAL_SKILLS_PER_USER = _non_negative_int_env("MAX_PERSONAL_SKILLS_PER_USER", 50)
-
 # Controls whether users can use User Knowledge (personal documents) in assistants
 DISABLE_USER_KNOWLEDGE = os.environ.get("DISABLE_USER_KNOWLEDGE", "").lower() == "true"
 

--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -589,6 +589,14 @@ class SkillSharePermission(str, PyEnum):
     VIEWER = "VIEWER"
 
 
+class SkillAccessLevel(str, PyEnum):
+    """Computed access the requesting user holds on a skill."""
+
+    OWNER = "OWNER"
+    EDITOR = "EDITOR"
+    VIEWER = "VIEWER"
+
+
 class PersonaAccessLevel(str, PyEnum):
     """Computed access the requesting user holds on a persona.
 

--- a/backend/onyx/db/external_app.py
+++ b/backend/onyx/db/external_app.py
@@ -300,7 +300,6 @@ def create_external_app(
             author_user_id=author_user_id,
             db_session=db_session,
         )
-        # `create_skill` hardcodes enabled=True; honour the caller's intent.
         if not enabled:
             skill.enabled = False
 

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -36,14 +36,12 @@ from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql import JSONB as PGJSONB
 from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlalchemy.engine.interfaces import Dialect
-from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import DeclarativeBase
 from sqlalchemy.orm import Mapped
 from sqlalchemy.orm import mapped_column
 from sqlalchemy.orm import Mapper
 from sqlalchemy.orm import relationship
 from sqlalchemy.orm import validates
-from sqlalchemy.sql.elements import ColumnElement
 from sqlalchemy.types import LargeBinary
 from sqlalchemy.types import TypeDecorator
 from typing_extensions import TypedDict  # noreorder
@@ -4326,19 +4324,6 @@ class Skill(Base):
         nullable=True,
     )
     enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
-
-    @hybrid_property
-    def is_public(self) -> bool:
-        return self.public_permission is not None
-
-    @is_public.inplace.setter
-    def _is_public_setter(self, value: bool) -> None:
-        self.public_permission = SkillSharePermission.VIEWER if value else None
-
-    @is_public.inplace.expression
-    @classmethod
-    def _is_public_expression(cls) -> ColumnElement[bool]:
-        return cls.public_permission.isnot(None)
 
     created_at: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False

--- a/backend/onyx/db/persona_sharing.py
+++ b/backend/onyx/db/persona_sharing.py
@@ -25,6 +25,16 @@ def get_user_group_ids_for_user(db_session: Session, user_id: UUID) -> set[int]:
     )
 
 
+def get_curated_user_group_ids_for_user(db_session: Session, user_id: UUID) -> set[int]:
+    return set(
+        db_session.scalars(
+            select(User__UserGroup.user_group_id)
+            .where(User__UserGroup.user_id == user_id)
+            .where(User__UserGroup.is_curator.is_(True))
+        ).all()
+    )
+
+
 def persona_ownership_is_vacant(persona: Persona) -> bool:
     """True when no live owner holds the persona: both owner refs are NULL on
     a non-builtin persona, or the owning user is deactivated or gone. Vacant

--- a/backend/onyx/db/skill.py
+++ b/backend/onyx/db/skill.py
@@ -15,13 +15,11 @@ immediately (skills sync via S3-backed bundles, so blob retention isn't
 needed).
 
 These helpers never commit — callers control the transaction boundary so a
-multi-step admin flow (e.g. create row + replace grants) can roll back atomically.
+multi-step admin flow (e.g. create row + replace shares) can roll back atomically.
 """
 
-import hashlib
-import struct
+from collections.abc import Mapping
 from collections.abc import Sequence
-from dataclasses import dataclass
 from enum import Enum
 from uuid import UUID
 
@@ -29,11 +27,9 @@ from sqlalchemy import and_
 from sqlalchemy import ColumnElement
 from sqlalchemy import delete
 from sqlalchemy import exists
-from sqlalchemy import func
 from sqlalchemy import or_
 from sqlalchemy import Select
 from sqlalchemy import select
-from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import selectinload
 from sqlalchemy.orm import Session
@@ -52,14 +48,9 @@ from onyx.db.models import User
 from onyx.db.models import User__UserGroup
 from onyx.db.utils import is_fk_violation
 from onyx.db.utils import is_unique_violation
-from onyx.db.utils import UNSET
-from onyx.db.utils import UnsetType
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.skills.built_in import BUILT_IN_SKILLS
-from onyx.utils.logger import setup_logger
-
-logger = setup_logger()
 
 SKILL_SLUG_UNIQUE_CONSTRAINT = "uq_skill_slug"
 
@@ -68,12 +59,6 @@ class SkillAccessPolicy(str, Enum):
     VIEW = "view"
     EDIT = "edit"
     USE = "use"
-
-
-@dataclass(frozen=True, kw_only=True)
-class SkillPatch:
-    is_public: bool | UnsetType = UNSET
-    enabled: bool | UnsetType = UNSET
 
 
 def _is_shared_with_user(
@@ -108,30 +93,6 @@ def _is_shared_with_user_group(
     return stmt.exists()
 
 
-def _any_share_exists() -> ColumnElement[bool]:
-    user_share_exists = (
-        select(Skill__User.skill_id).where(Skill__User.skill_id == Skill.id).exists()
-    )
-    group_share_exists = (
-        select(Skill__UserGroup.skill_id)
-        .where(Skill__UserGroup.skill_id == Skill.id)
-        .exists()
-    )
-    return or_(user_share_exists, group_share_exists)
-
-
-def _personal_skill_clause(user_id: UUID) -> ColumnElement[bool]:
-    """Predicate matching *user_id*'s personal skills: custom, non-public,
-    zero direct/group shares, authored by the user."""
-    no_shares = ~_any_share_exists()
-    return and_(
-        Skill.author_user_id == user_id,
-        Skill.built_in_skill_id.is_(None),
-        Skill.public_permission.is_(None),
-        no_shares,
-    )
-
-
 def _is_group_shared_only_with_curator_scope(user: User) -> ColumnElement[bool]:
     """Curators can manage skills only when all group shares are in their scope."""
     curator_scope_group_ids = select(User__UserGroup.user_group_id).where(
@@ -163,37 +124,11 @@ def _is_group_shared_only_with_curator_scope(user: User) -> ColumnElement[bool]:
     return and_(share_in_curator_scope_exists.exists(), no_group_share_outside_scope)
 
 
-def all_skills_for_user_incl_external_apps(
-    user: User, db_session: Session
-) -> set[UUID]:
-    """Enabled skill ids the user can see, including external-app-backed rows.
-
-    Used by the external-app API to decide which apps a user may connect. This
-    deliberately does not apply the per-user external-app credential gate.
-    """
-    stmt = (
-        select(Skill.id)
-        .where(Skill.enabled.is_(True))
-        .where(
-            or_(
-                Skill.public_permission.isnot(None),
-                _is_shared_with_user(user),
-                _is_shared_with_user_group(user),
-                and_(
-                    Skill.author_user_id == user.id,
-                    Skill.built_in_skill_id.is_(None),
-                ),
-            )
-        )
-    )
-    return set(db_session.scalars(stmt))
-
-
 def _exclude_unavailable_built_in_skills(
     stmt: Select[tuple[Skill]], db_session: Session
 ) -> Select[tuple[Skill]]:
     """Hide built-ins whose codified ``is_available(db)`` returns False.
-    User reads use this; admin reads don't (admins see all rows)."""
+    User-facing reads use this; admin VIEW reads don't (admins see all rows)."""
     unavailable = [
         d.built_in_skill_id
         for d in BUILT_IN_SKILLS.values()
@@ -321,6 +256,8 @@ def _skill_select_for_access_policy(
         available_external_app_skill_ids = _external_app_skill_ids_available_to_user(
             user, db_session
         )
+        # Non-external-app skills are always available; external-app skills
+        # need credentials from the user to be available
         available_in_sandbox = or_(
             ExternalApp.id.is_(None),
             Skill.id.in_(available_external_app_skill_ids),
@@ -335,346 +272,37 @@ def _skill_select_for_access_policy(
     raise ValueError(f"Unknown skill access policy: {policy}")
 
 
-def list_skills(
-    *,
-    policy: SkillAccessPolicy,
-    db_session: Session,
-    user: User,
-) -> Sequence[Skill]:
-    stmt = _skill_select_for_access_policy(
-        policy=policy,
-        db_session=db_session,
-        user=user,
-        order_by_name=True,
-    )
-    return list(db_session.scalars(stmt))
-
-
-def fetch_skill(
-    skill_id: UUID,
-    *,
-    policy: SkillAccessPolicy,
-    db_session: Session,
-    user: User,
-) -> Skill | None:
-    stmt = _skill_select_for_access_policy(
-        policy=policy,
-        db_session=db_session,
-        user=user,
-        order_by_name=False,
-    ).where(Skill.id == skill_id)
-    return db_session.scalars(stmt).one_or_none()
-
-
-def list_skills_for_user(user: User, db_session: Session) -> Sequence[Skill]:
-    """Skills the user sees in the skills endpoint.
-
-    External-app-backed skills are excluded unconditionally — they're
-    surfaced (and mutated) via the external-apps API only. Use
-    ``list_skills_for_sandbox_injection`` to get the wider set the
-    sandbox actually receives (which includes authenticated external
-    apps).
-
-    Disabled skills are hidden EXCEPT the user's own personal skills,
-    which stay listed (greyed out in the UI) so the owner can re-enable
-    them. Sandbox injection never includes disabled skills.
-    """
-    return list_skills(
-        policy=SkillAccessPolicy.VIEW,
-        user=user,
-        db_session=db_session,
-    )
-
-
-def fetch_skill_for_user(
-    skill_id: UUID, user: User, db_session: Session
-) -> Skill | None:
-    """Skill the user can read via the skills endpoint. Returns ``None``
-    for external-app-backed rows even when the id matches — the skills
-    endpoint must not be a mutation seam for external apps. Disabled
-    skills resolve only for their owner (own-personal rows)."""
-    return fetch_skill(
-        skill_id,
-        policy=SkillAccessPolicy.VIEW,
-        user=user,
-        db_session=db_session,
-    )
-
-
-def fetch_skill_for_user_by_slug(
-    slug: str, user: User, db_session: Session
-) -> Skill | None:
-    """Slug variant of ``fetch_skill_for_user``. Same exclusion: never
-    returns external-app-backed skills."""
-    stmt = _skill_select_for_access_policy(
-        policy=SkillAccessPolicy.VIEW,
-        db_session=db_session,
-        user=user,
-        order_by_name=False,
-    ).where(Skill.slug == slug)
-    return db_session.scalars(stmt).one_or_none()
-
-
-def fetch_skill_for_edit(
-    skill_id: UUID, user: User, db_session: Session
-) -> Skill | None:
-    return fetch_skill(
-        skill_id,
-        policy=SkillAccessPolicy.EDIT,
-        user=user,
-        db_session=db_session,
-    )
-
-
-def list_skills_for_sandbox_injection(
+def all_skills_for_user_incl_external_apps(
     user: User, db_session: Session
-) -> Sequence[Skill]:
-    """Skills delivered into *user*'s sandbox: every regular skill they
-    can see, plus the external-app-backed skills they've authenticated
-    for. Used by the sandbox skill-push path, NOT by the skills
-    endpoint (which excludes external apps entirely)."""
-    return list_skills(
-        policy=SkillAccessPolicy.USE,
-        user=user,
-        db_session=db_session,
-    )
+) -> set[UUID]:
+    """Enabled skill ids the user can see, including external-app-backed rows.
 
-
-def fetch_skill_by_id(skill_id: UUID, db_session: Session) -> Skill | None:
-    stmt = _skill_select_with_eager_load(order_by_name=False).where(
-        Skill.id == skill_id
-    )
-    return db_session.scalars(stmt).one_or_none()
-
-
-def list_skills_for_admin(db_session: Session) -> Sequence[Skill]:
-    stmt = _skill_select_with_eager_load(order_by_name=True)
-    return list(db_session.scalars(stmt))
-
-
-def create_skill__no_commit(
-    *,
-    slug: str,
-    name: str,
-    description: str,
-    bundle_file_id: str,
-    bundle_sha256: str,
-    is_public: bool,
-    public_permission: SkillSharePermission | None = None,
-    author_user_id: UUID | None,
-    db_session: Session,
-) -> Skill:
-    existing = db_session.scalars(select(Skill.id).where(Skill.slug == slug)).first()
-    if existing is not None:
-        raise OnyxError(
-            OnyxErrorCode.DUPLICATE_RESOURCE,
-            f"A skill with slug '{slug}' already exists.",
-        )
-
-    skill = Skill(
-        slug=slug,
-        name=name,
-        description=description,
-        bundle_file_id=bundle_file_id,
-        bundle_sha256=bundle_sha256,
-        public_permission=_public_permission_for_update(
-            current_permission=None,
-            is_public=is_public,
-            public_permission=public_permission,
-        ),
-        author_user_id=author_user_id,
-        enabled=True,
-    )
-    db_session.add(skill)
-    try:
-        db_session.flush()
-    except IntegrityError as e:
-        if is_unique_violation(e, SKILL_SLUG_UNIQUE_CONSTRAINT):
-            raise OnyxError(
-                OnyxErrorCode.DUPLICATE_RESOURCE,
-                f"A skill with slug '{slug}' already exists.",
-            ) from e
-        raise
-    return skill
-
-
-def create_built_in_skill_row__no_commit(
-    *,
-    built_in_skill_id: str,
-    name: str,
-    description: str,
-    is_public: bool,
-    enabled: bool,
-    author_user_id: UUID | None = None,
-    public_permission: SkillSharePermission | None = None,
-    db_session: Session,
-) -> Skill:
-    """Create a built-in-style ``Skill`` row: ``built_in_skill_id`` set,
-    ``slug == built_in_skill_id`` (the stable on-disk dir name), bundle fields
-    NULL (per the XOR check constraint). Used for external-app providers, whose
-    rows are created on demand rather than seeded.
-
-    Because the slug is the (globally unique) built-in id, a tenant can hold at
-    most one row per provider — a second attempt raises
-    ``OnyxError(DUPLICATE_RESOURCE)``, which is the desired "connect Slack once"
-    behaviour.
+    Used by the external-app API to decide which apps a user may connect. This
+    deliberately does not apply the per-user external-app credential gate.
     """
-    existing = db_session.scalars(
-        select(Skill.id).where(Skill.slug == built_in_skill_id)
-    ).first()
-    if existing is not None:
-        raise OnyxError(
-            OnyxErrorCode.DUPLICATE_RESOURCE,
-            f"A skill with slug '{built_in_skill_id}' already exists.",
+    stmt = (
+        select(Skill.id)
+        .where(Skill.enabled.is_(True))
+        .where(
+            or_(
+                Skill.public_permission.isnot(None),
+                _is_shared_with_user(user),
+                _is_shared_with_user_group(user),
+                and_(
+                    Skill.author_user_id == user.id,
+                    Skill.built_in_skill_id.is_(None),
+                ),
+            )
         )
-
-    skill = Skill(
-        slug=built_in_skill_id,
-        name=name,
-        description=description,
-        built_in_skill_id=built_in_skill_id,
-        bundle_file_id=None,
-        bundle_sha256=None,
-        public_permission=_public_permission_for_update(
-            current_permission=None,
-            is_public=is_public,
-            public_permission=public_permission,
-        ),
-        author_user_id=author_user_id,
-        enabled=enabled,
     )
-    db_session.add(skill)
-    try:
-        db_session.flush()
-    except IntegrityError as e:
-        if is_unique_violation(e, SKILL_SLUG_UNIQUE_CONSTRAINT):
-            raise OnyxError(
-                OnyxErrorCode.DUPLICATE_RESOURCE,
-                f"A skill with slug '{built_in_skill_id}' already exists.",
-            ) from e
-        raise
-    return skill
-
-
-def replace_skill_bundle(
-    *,
-    skill_id: UUID,
-    new_bundle_file_id: str,
-    new_bundle_sha256: str,
-    new_name: str,
-    new_description: str,
-    db_session: Session,
-) -> tuple[Skill, str]:
-    """Swap a skill's bundle blob and refresh its display metadata.
-
-    Returns ``(skill, old_bundle_file_id)`` so the caller can delete the
-    old blob from FileStore AFTER the transaction commits — never
-    inline.
-
-    Name and description come from the new bundle's SKILL.md frontmatter so
-    the DB row stays in lockstep with what's actually pushed to sandboxes.
-
-    Rejects built-in rows — they have no bundle.
-    """
-    skill = fetch_skill_by_id(skill_id, db_session)
-    if skill is None:
-        raise OnyxError(
-            OnyxErrorCode.NOT_FOUND,
-            f"Skill {skill_id} not found.",
-        )
-    if skill.built_in_skill_id is not None:
-        raise OnyxError(
-            OnyxErrorCode.INVALID_INPUT,
-            f"Skill '{skill.slug}' is a built-in and has no bundle.",
-        )
-
-    # Custom rows always have a bundle (XOR check constraint), but guard
-    # explicitly rather than assert so a corrupt row fails loud, not silent.
-    if skill.bundle_file_id is None:
-        raise OnyxError(
-            OnyxErrorCode.INVALID_INPUT,
-            f"Skill '{skill.slug}' has no bundle to replace.",
-        )
-
-    old_bundle_file_id = skill.bundle_file_id
-    skill.bundle_file_id = new_bundle_file_id
-    skill.bundle_sha256 = new_bundle_sha256
-    skill.name = new_name
-    skill.description = new_description
-    db_session.flush()
-    return skill, old_bundle_file_id
-
-
-def patch_skill(
-    *,
-    skill_id: UUID,
-    patch: SkillPatch,
-    db_session: Session,
-) -> Skill:
-    skill = fetch_skill_by_id(skill_id, db_session)
-    if skill is None:
-        raise OnyxError(
-            OnyxErrorCode.NOT_FOUND,
-            f"Skill {skill_id} not found.",
-        )
-
-    if not isinstance(patch.is_public, UnsetType):
-        skill.public_permission = _public_permission_for_update(
-            current_permission=skill.public_permission,
-            is_public=patch.is_public,
-            public_permission=None,
-        )
-    if not isinstance(patch.enabled, UnsetType):
-        skill.enabled = patch.enabled
-
-    db_session.flush()
-    return skill
-
-
-def replace_skill_grants(
-    skill_id: UUID, group_ids: Sequence[int], db_session: Session
-) -> None:
-    if fetch_skill_by_id(skill_id, db_session) is None:
-        raise OnyxError(
-            OnyxErrorCode.NOT_FOUND,
-            f"Skill {skill_id} not found.",
-        )
-    db_session.execute(
-        delete(Skill__UserGroup).where(Skill__UserGroup.skill_id == skill_id)
-    )
-    seen: set[int] = set()
-    for group_id in group_ids:
-        if group_id in seen:
-            continue
-        seen.add(group_id)
-        db_session.add(Skill__UserGroup(skill_id=skill_id, user_group_id=group_id))
-    try:
-        db_session.flush()
-    except IntegrityError as e:
-        if is_fk_violation(e):
-            raise OnyxError(
-                OnyxErrorCode.INVALID_INPUT,
-                "One or more group IDs do not exist.",
-            ) from e
-        raise
-
-
-def delete_skill(skill_id: UUID, db_session: Session) -> str | None:
-    """Hard-delete a skill and return its `bundle_file_id` for caller cleanup."""
-    skill = fetch_skill_by_id(skill_id, db_session)
-    if skill is None:
-        return None
-    bundle_file_id = skill.bundle_file_id
-    db_session.delete(skill)
-    db_session.flush()
-    return bundle_file_id
+    return set(db_session.scalars(stmt))
 
 
 def affected_user_ids_for_skill(skill: Skill, db_session: Session) -> set[UUID]:
-    """Return user IDs with an active sandbox who should have this skill.
+    """Return user IDs with a running sandbox that should contain this skill.
 
-    Does not filter by ``enabled`` — callers use this for both enable and
-    disable transitions (the pushed fileset handles the actual filtering).
+    Deliberately does not filter by ``enabled``: disable/delete flows still need
+    the previous recipients so the push pipeline can remove the skill files.
     """
     if skill.public_permission is not None:
         stmt = select(Sandbox.user_id).where(Sandbox.status == SandboxStatus.RUNNING)
@@ -717,64 +345,294 @@ def affected_user_ids_for_skill(skill: Skill, db_session: Session) -> set[UUID]:
     return user_ids
 
 
-def count_personal_skills_for_user(user_id: UUID, db_session: Session) -> int:
-    stmt = select(func.count(Skill.id)).where(_personal_skill_clause(user_id))
-    return db_session.scalar(stmt) or 0
-
-
-# Namespaced + user-hashed so unrelated users don't block each other and the
-# lock id can't collide with other advisory locks in the codebase.
-_PERSONAL_SKILL_LOCK_NAMESPACE = "onyx_personal_skill_lock"
-
-
-def _personal_skill_lock_id(user_id: UUID) -> int:
-    digest = hashlib.sha256(
-        f"{_PERSONAL_SKILL_LOCK_NAMESPACE}:{user_id}".encode()
-    ).digest()
-    # Full 64-bit key (not 32-bit hashtext) so distinct users don't collide;
-    # explicit big-endian so the id is stable across platforms.
-    # pg_advisory_xact_lock takes a signed 8-byte int.
-    return struct.unpack(">q", digest[:8])[0]
-
-
-def lock_personal_skills_for_user(user_id: UUID, db_session: Session) -> None:
-    """Serialize a user's concurrent personal-skill creates so the
-    count-then-insert cap check is race-free; released at transaction end."""
-    lock_id = _personal_skill_lock_id(user_id)
-    logger.debug(
-        "Acquiring personal-skill advisory lock for user %s (lock_id=%d)",
-        user_id,
-        lock_id,
-    )
-    db_session.execute(
-        text("SELECT pg_advisory_xact_lock(:lock_id)"),
-        {"lock_id": lock_id},
-    )
-    logger.debug("Acquired personal-skill advisory lock for user %s", user_id)
-
-
-def skill_ids_with_grants(skill_ids: Sequence[UUID], db_session: Session) -> set[UUID]:
-    """Subset of *skill_ids* that have at least one direct or group share row."""
-    if not skill_ids:
-        return set()
-
-    group_share_stmt = (
-        select(Skill__UserGroup.skill_id)
-        .where(Skill__UserGroup.skill_id.in_(skill_ids))
-        .distinct()
-    )
-    user_share_stmt = (
-        select(Skill__User.skill_id)
-        .where(Skill__User.skill_id.in_(skill_ids))
-        .distinct()
-    )
-    return set(db_session.scalars(group_share_stmt)) | set(
-        db_session.scalars(user_share_stmt)
-    )
-
-
-def get_group_ids_for_skill(skill_id: UUID, db_session: Session) -> list[int]:
-    stmt = select(Skill__UserGroup.user_group_id).where(
-        Skill__UserGroup.skill_id == skill_id
+def list_skills(
+    *,
+    policy: SkillAccessPolicy,
+    db_session: Session,
+    user: User,
+) -> Sequence[Skill]:
+    stmt = _skill_select_for_access_policy(
+        policy=policy,
+        db_session=db_session,
+        user=user,
+        order_by_name=True,
     )
     return list(db_session.scalars(stmt))
+
+
+def fetch_skill(
+    skill_id: UUID,
+    *,
+    policy: SkillAccessPolicy,
+    db_session: Session,
+    user: User,
+) -> Skill | None:
+    stmt = _skill_select_for_access_policy(
+        policy=policy,
+        db_session=db_session,
+        user=user,
+        order_by_name=False,
+    ).where(Skill.id == skill_id)
+    return db_session.scalars(stmt).one_or_none()
+
+
+def fetch_skill_by_id_for_system(skill_id: UUID, db_session: Session) -> Skill | None:
+    """Fetch a skill by id without applying user access policy.
+
+    Only use this for system flows that have already made an authorization
+    decision, such as post-commit reloads or sandbox invalidation.
+    """
+    stmt = _skill_select_with_eager_load(order_by_name=False).where(
+        Skill.id == skill_id
+    )
+    return db_session.scalars(stmt).one_or_none()
+
+
+def _add_skill_with_unique_slug__no_commit(
+    skill: Skill,
+    *,
+    slug: str,
+    db_session: Session,
+) -> Skill:
+    existing = db_session.scalars(select(Skill.id).where(Skill.slug == slug)).first()
+    if existing is not None:
+        raise OnyxError(
+            OnyxErrorCode.DUPLICATE_RESOURCE,
+            f"A skill with slug '{slug}' already exists.",
+        )
+
+    db_session.add(skill)
+    try:
+        db_session.flush()
+    except IntegrityError as e:
+        if is_unique_violation(e, SKILL_SLUG_UNIQUE_CONSTRAINT):
+            raise OnyxError(
+                OnyxErrorCode.DUPLICATE_RESOURCE,
+                f"A skill with slug '{slug}' already exists.",
+            ) from e
+        raise
+    return skill
+
+
+def create_skill__no_commit(
+    *,
+    slug: str,
+    name: str,
+    description: str,
+    bundle_file_id: str,
+    bundle_sha256: str,
+    is_public: bool,
+    public_permission: SkillSharePermission | None = None,
+    author_user_id: UUID | None,
+    db_session: Session,
+) -> Skill:
+    skill = Skill(
+        slug=slug,
+        name=name,
+        description=description,
+        bundle_file_id=bundle_file_id,
+        bundle_sha256=bundle_sha256,
+        public_permission=_public_permission_for_update(
+            current_permission=None,
+            is_public=is_public,
+            public_permission=public_permission,
+        ),
+        author_user_id=author_user_id,
+        enabled=True,
+    )
+    return _add_skill_with_unique_slug__no_commit(
+        skill,
+        slug=slug,
+        db_session=db_session,
+    )
+
+
+def create_built_in_skill_row__no_commit(
+    *,
+    built_in_skill_id: str,
+    name: str,
+    description: str,
+    is_public: bool,
+    enabled: bool,
+    author_user_id: UUID | None = None,
+    public_permission: SkillSharePermission | None = None,
+    db_session: Session,
+) -> Skill:
+    """Create a built-in-style ``Skill`` row: ``built_in_skill_id`` set,
+    ``slug == built_in_skill_id`` (the stable on-disk dir name), bundle fields
+    NULL (per the XOR check constraint). Used for external-app providers, whose
+    rows are created on demand rather than seeded.
+
+    Because the slug is the (globally unique) built-in id, a tenant can hold at
+    most one row per provider — a second attempt raises
+    ``OnyxError(DUPLICATE_RESOURCE)``, which is the desired "connect Slack once"
+    behaviour.
+    """
+    skill = Skill(
+        slug=built_in_skill_id,
+        name=name,
+        description=description,
+        built_in_skill_id=built_in_skill_id,
+        bundle_file_id=None,
+        bundle_sha256=None,
+        public_permission=_public_permission_for_update(
+            current_permission=None,
+            is_public=is_public,
+            public_permission=public_permission,
+        ),
+        author_user_id=author_user_id,
+        enabled=enabled,
+    )
+    return _add_skill_with_unique_slug__no_commit(
+        skill,
+        slug=built_in_skill_id,
+        db_session=db_session,
+    )
+
+
+def replace_skill_bundle(
+    *,
+    skill: Skill,
+    new_bundle_file_id: str,
+    new_bundle_sha256: str,
+    new_name: str,
+    new_description: str,
+    db_session: Session,
+) -> str:
+    """Swap a skill's bundle blob and refresh its display metadata.
+
+    Returns the old bundle file id so the caller can delete the old blob from
+    FileStore after the transaction commits.
+
+    Name and description come from the new bundle's SKILL.md frontmatter so
+    the DB row stays in lockstep with what's actually pushed to sandboxes.
+
+    Rejects built-in rows — they have no bundle.
+    """
+    if skill.built_in_skill_id is not None:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            f"Skill '{skill.slug}' is a built-in and has no bundle.",
+        )
+
+    # Custom rows always have a bundle (XOR check constraint), but guard
+    # explicitly rather than assert so a corrupt row fails loud, not silent.
+    if skill.bundle_file_id is None:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            f"Skill '{skill.slug}' has no bundle to replace.",
+        )
+
+    old_bundle_file_id = skill.bundle_file_id
+    skill.bundle_file_id = new_bundle_file_id
+    skill.bundle_sha256 = new_bundle_sha256
+    skill.name = new_name
+    skill.description = new_description
+    db_session.flush()
+    return old_bundle_file_id
+
+
+def update_skill_fields(
+    *,
+    skill: Skill,
+    db_session: Session,
+    is_public: bool | None = None,
+    public_permission: SkillSharePermission | None = None,
+    enabled: bool | None = None,
+) -> Skill:
+    if is_public is not None or public_permission is not None:
+        skill.public_permission = _public_permission_for_update(
+            current_permission=skill.public_permission,
+            is_public=is_public,
+            public_permission=public_permission,
+        )
+    if enabled is not None:
+        skill.enabled = enabled
+    db_session.flush()
+    return skill
+
+
+def replace_skill_shares(
+    *,
+    skill: Skill,
+    db_session: Session,
+    user_shares: Mapping[UUID, SkillSharePermission] | None = None,
+    group_shares: Mapping[int, SkillSharePermission] | None = None,
+) -> None:
+    if user_shares is not None:
+        db_session.execute(delete(Skill__User).where(Skill__User.skill_id == skill.id))
+        for user_id, permission in user_shares.items():
+            db_session.add(
+                Skill__User(skill_id=skill.id, user_id=user_id, permission=permission)
+            )
+
+    if group_shares is not None:
+        db_session.execute(
+            delete(Skill__UserGroup).where(Skill__UserGroup.skill_id == skill.id)
+        )
+        for group_id, permission in group_shares.items():
+            db_session.add(
+                Skill__UserGroup(
+                    skill_id=skill.id,
+                    user_group_id=group_id,
+                    permission=permission,
+                )
+            )
+
+    try:
+        db_session.flush()
+    except IntegrityError as e:
+        if is_fk_violation(e):
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                "One or more share targets do not exist.",
+            ) from e
+        raise
+
+
+def transfer_skill_ownership(
+    *,
+    skill: Skill,
+    new_owner_user_id: UUID,
+    db_session: Session,
+) -> None:
+    previous_owner_user_id = skill.author_user_id
+    skill.author_user_id = new_owner_user_id
+
+    db_session.execute(
+        delete(Skill__User).where(
+            Skill__User.skill_id == skill.id,
+            Skill__User.user_id == new_owner_user_id,
+        )
+    )
+
+    if (
+        previous_owner_user_id is not None
+        and previous_owner_user_id != new_owner_user_id
+    ):
+        existing_share = db_session.scalar(
+            select(Skill__User).where(
+                Skill__User.skill_id == skill.id,
+                Skill__User.user_id == previous_owner_user_id,
+            )
+        )
+        if existing_share is not None:
+            existing_share.permission = SkillSharePermission.EDITOR
+        else:
+            db_session.add(
+                Skill__User(
+                    skill_id=skill.id,
+                    user_id=previous_owner_user_id,
+                    permission=SkillSharePermission.EDITOR,
+                )
+            )
+
+    db_session.flush()
+
+
+def delete_skill(skill: Skill, db_session: Session) -> str | None:
+    """Hard-delete a skill and return its `bundle_file_id` for caller cleanup."""
+    bundle_file_id = skill.bundle_file_id
+    db_session.delete(skill)
+    db_session.flush()
+    return bundle_file_id

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -107,7 +107,6 @@ from onyx.server.features.persona.api import agents_router
 from onyx.server.features.persona.api import basic_router as persona_router
 from onyx.server.features.projects.api import router as projects_router
 from onyx.server.features.search.api import router as search_api_router
-from onyx.server.features.skill.api import admin_router as skill_admin_router
 from onyx.server.features.skill.api import user_router as skill_router
 from onyx.server.features.tool.api import admin_router as admin_tool_router
 from onyx.server.features.tool.api import router as tool_router
@@ -575,7 +574,6 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
     include_router_with_global_prefix_prepended(application, mcp_router)
     include_router_with_global_prefix_prepended(application, mcp_admin_router)
     include_router_with_global_prefix_prepended(application, skill_router)
-    include_router_with_global_prefix_prepended(application, skill_admin_router)
 
     include_router_with_global_prefix_prepended(application, pat_router)
     include_router_with_global_prefix_prepended(application, captcha_router)

--- a/backend/onyx/server/features/skill/api.py
+++ b/backend/onyx/server/features/skill/api.py
@@ -1,226 +1,48 @@
-import json
-from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter
 from fastapi import Depends
 from fastapi import File
-from fastapi import Form
 from fastapi import UploadFile
-from pydantic import Field
 from sqlalchemy.orm import Session
 
-from onyx.auth.permissions import Permission
 from onyx.auth.permissions import require_permission
-from onyx.auth.users import current_curator_or_admin_user
-from onyx.configs.app_configs import MAX_PERSONAL_SKILLS_PER_USER
+from onyx.auth.users import is_user_curator_or_admin
 from onyx.db.engine.sql_engine import get_session
-from onyx.db.models import Skill
+from onyx.db.enums import Permission
 from onyx.db.models import User
-from onyx.db.skill import affected_user_ids_for_skill
-from onyx.db.skill import count_personal_skills_for_user
-from onyx.db.skill import create_skill__no_commit
-from onyx.db.skill import delete_skill
-from onyx.db.skill import fetch_skill_by_id
-from onyx.db.skill import fetch_skill_for_edit
-from onyx.db.skill import fetch_skill_for_user
-from onyx.db.skill import fetch_skill_for_user_by_slug
-from onyx.db.skill import get_group_ids_for_skill
+from onyx.db.skill import fetch_skill
 from onyx.db.skill import list_skills
-from onyx.db.skill import list_skills_for_user
-from onyx.db.skill import lock_personal_skills_for_user
-from onyx.db.skill import patch_skill
-from onyx.db.skill import replace_skill_grants
-from onyx.db.skill import skill_ids_with_grants
 from onyx.db.skill import SkillAccessPolicy
-from onyx.db.skill import SkillPatch
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
-from onyx.file_store.file_store import get_default_file_store
-from onyx.server.features.skill.models import BuiltinSkillResponse
-from onyx.server.features.skill.models import CustomSkillResponse
-from onyx.server.features.skill.models import GrantsReplace
-from onyx.server.features.skill.models import PersonalSkillPatchRequest
+from onyx.server.features.skill.models import SkillEditableDetailResponse
 from onyx.server.features.skill.models import SkillPatchRequest
 from onyx.server.features.skill.models import SkillPreviewResponse
+from onyx.server.features.skill.models import SkillResponse
+from onyx.server.features.skill.models import SkillShareRequest
 from onyx.server.features.skill.models import SkillsList
-from onyx.server.features.skill.mutation_helpers import ensure_custom_skill
-from onyx.server.features.skill.mutation_helpers import ensure_owned_personal_skill
-from onyx.server.features.skill.mutation_helpers import ingested_skill_bundle
-from onyx.server.features.skill.mutation_helpers import reject_reserved_skill_slug
+from onyx.server.features.skill.models import TransferSkillOwnershipRequest
+from onyx.server.features.skill.mutation_helpers import create_custom_skill_for_user
+from onyx.server.features.skill.mutation_helpers import delete_custom_skill_for_user
+from onyx.server.features.skill.mutation_helpers import get_editable_custom_skill
+from onyx.server.features.skill.mutation_helpers import patch_custom_skill_for_user
 from onyx.server.features.skill.mutation_helpers import (
-    replace_custom_skill_bundle_contents,
+    replace_custom_skill_bundle_for_user,
 )
-from onyx.server.features.skill.response_helpers import preview_response_for_skill
-from onyx.server.features.skill.response_helpers import split_skill_rows
-from onyx.skills.built_in import BUILT_IN_SKILLS
-from onyx.skills.ingest import delete_bundle_blob
-from onyx.skills.push import push_skill_to_affected_sandboxes
-from onyx.skills.push import push_skills_for_users
+from onyx.server.features.skill.mutation_helpers import (
+    transfer_custom_skill_ownership_for_user,
+)
+from onyx.server.features.skill.mutation_helpers import (
+    update_custom_skill_shares_for_user,
+)
+from onyx.server.features.skill.response_helpers import custom_skill_response_for_user
+from onyx.server.features.skill.response_helpers import skill_preview_response
+from onyx.server.features.skill.response_helpers import skill_response_for_user
+from onyx.server.features.skill.response_helpers import skills_list_response_for_user
+from onyx.skills.content import read_custom_skill_bundle_instructions
 
-admin_router = APIRouter(prefix="/admin/skills")
 user_router = APIRouter(prefix="/skills")
-
-
-@admin_router.get("")
-def list_skills_admin(
-    user: User = Depends(current_curator_or_admin_user),
-    db_session: Session = Depends(get_session),
-) -> SkillsList:
-    rows = list(
-        list_skills(
-            policy=SkillAccessPolicy.VIEW,
-            user=user,
-            db_session=db_session,
-        )
-    )
-    builtins, customs = split_skill_rows(rows, db_session, include_grants=True)
-    return SkillsList(builtins=builtins, customs=customs)
-
-
-@admin_router.get("/{skill_id}/preview")
-def preview_skill_admin(
-    skill_id: UUID,
-    _: User = Depends(current_curator_or_admin_user),
-    db_session: Session = Depends(get_session),
-) -> SkillPreviewResponse:
-    skill = fetch_skill_by_id(skill_id, db_session)
-    if skill is None:
-        raise OnyxError(OnyxErrorCode.NOT_FOUND, "Skill not found")
-    return preview_response_for_skill(skill)
-
-
-@admin_router.post("/custom")
-def create_custom_skill(
-    is_public: bool = Form(False),
-    group_ids: str = Form("[]"),
-    bundle: UploadFile = File(...),
-    user: User = Depends(current_curator_or_admin_user),
-    db_session: Session = Depends(get_session),
-) -> CustomSkillResponse:
-    parsed_group_ids = _parse_group_ids(group_ids)
-    reject_reserved_skill_slug(bundle.filename)
-
-    with ingested_skill_bundle(
-        bundle_file=bundle.file,
-        filename=bundle.filename,
-    ) as ingested:
-        skill = create_skill__no_commit(
-            slug=ingested.slug,
-            name=ingested.name,
-            description=ingested.description,
-            bundle_file_id=ingested.bundle_file_id,
-            bundle_sha256=ingested.bundle_sha256,
-            is_public=is_public,
-            author_user_id=user.id,
-            db_session=db_session,
-        )
-        if parsed_group_ids:
-            replace_skill_grants(skill.id, parsed_group_ids, db_session=db_session)
-        db_session.commit()
-
-    push_skill_to_affected_sandboxes(skill, db_session)
-    return CustomSkillResponse.from_model(skill, group_ids=parsed_group_ids)
-
-
-@admin_router.patch("/custom/{skill_id}")
-def patch_custom_skill(
-    skill_id: UUID,
-    patch_req: SkillPatchRequest,
-    user: User = Depends(current_curator_or_admin_user),
-    db_session: Session = Depends(get_session),
-) -> CustomSkillResponse:
-    """Toggle ``enabled``/``is_public`` on a custom skill."""
-    skill = fetch_skill_for_edit(skill_id, user, db_session)
-    if skill is None:
-        raise OnyxError(OnyxErrorCode.NOT_FOUND, "Skill not found")
-    ensure_custom_skill(skill)
-
-    old_visibility = (skill.public_permission, skill.enabled)
-    before_affected = affected_user_ids_for_skill(skill, db_session)
-
-    updated = patch_skill(
-        skill_id=skill_id, patch=patch_req.to_domain(), db_session=db_session
-    )
-    db_session.commit()
-
-    visibility_changed = old_visibility != (updated.public_permission, updated.enabled)
-    if visibility_changed:
-        after_affected = affected_user_ids_for_skill(updated, db_session)
-        push_skills_for_users(before_affected | after_affected, db_session)
-
-    return CustomSkillResponse.from_model(
-        updated, group_ids=get_group_ids_for_skill(skill_id, db_session)
-    )
-
-
-@admin_router.put("/custom/{skill_id}/bundle")
-def replace_custom_skill_bundle(
-    skill_id: UUID,
-    bundle: UploadFile = File(...),
-    user: User = Depends(current_curator_or_admin_user),
-    db_session: Session = Depends(get_session),
-) -> CustomSkillResponse:
-    skill = fetch_skill_for_edit(skill_id, user, db_session)
-    if skill is None:
-        raise OnyxError(OnyxErrorCode.NOT_FOUND, "Skill not found")
-    ensure_custom_skill(skill)
-
-    updated = replace_custom_skill_bundle_contents(
-        skill=skill,
-        bundle_file=bundle.file,
-        filename=bundle.filename,
-        db_session=db_session,
-    )
-    return CustomSkillResponse.from_model(
-        updated, group_ids=get_group_ids_for_skill(skill_id, db_session)
-    )
-
-
-@admin_router.put("/custom/{skill_id}/grants")
-def replace_custom_skill_grants(
-    skill_id: UUID,
-    body: GrantsReplace,
-    user: User = Depends(current_curator_or_admin_user),
-    db_session: Session = Depends(get_session),
-) -> CustomSkillResponse:
-    skill = fetch_skill_for_edit(skill_id, user, db_session)
-    if skill is None:
-        raise OnyxError(OnyxErrorCode.NOT_FOUND, "Skill not found")
-    ensure_custom_skill(skill)
-
-    before_affected = affected_user_ids_for_skill(skill, db_session)
-
-    replace_skill_grants(skill_id, body.group_ids, db_session=db_session)
-    db_session.commit()
-
-    updated = fetch_skill_by_id(skill_id, db_session)
-    if updated is None:
-        raise OnyxError(OnyxErrorCode.NOT_FOUND, "Skill not found")
-    after_affected = affected_user_ids_for_skill(updated, db_session)
-    push_skills_for_users(before_affected | after_affected, db_session)
-
-    return CustomSkillResponse.from_model(updated, group_ids=body.group_ids)
-
-
-@admin_router.delete("/custom/{skill_id}")
-def delete_custom_skill(
-    skill_id: UUID,
-    user: User = Depends(current_curator_or_admin_user),
-    db_session: Session = Depends(get_session),
-) -> None:
-    skill = fetch_skill_for_edit(skill_id, user, db_session)
-    if skill is None:
-        raise OnyxError(OnyxErrorCode.NOT_FOUND, "Skill not found")
-    ensure_custom_skill(skill)
-
-    affected = affected_user_ids_for_skill(skill, db_session)
-    old_file_id = delete_skill(skill_id, db_session)
-    db_session.commit()
-
-    push_skills_for_users(affected, db_session)
-    if old_file_id is not None:
-        delete_bundle_blob(get_default_file_store(), old_file_id)
 
 
 @user_router.get("")
@@ -228,41 +50,33 @@ def list_skills_for_current_user(
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> SkillsList:
-    rows = list(list_skills_for_user(user=user, db_session=db_session))
-    builtins, customs = split_skill_rows(rows, db_session, include_grants=False)
-    return SkillsList(builtins=builtins, customs=customs)
+    rows = list_skills(
+        policy=SkillAccessPolicy.VIEW,
+        user=user,
+        db_session=db_session,
+    )
+    return skills_list_response_for_user(list(rows), user, db_session)
 
 
-@user_router.get("/{slug_or_id}")
+@user_router.get("/{skill_id}")
 def fetch_skill_for_current_user(
-    slug_or_id: str,
+    skill_id: UUID,
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
-) -> Annotated[
-    BuiltinSkillResponse | CustomSkillResponse, Field(discriminator="source")
-]:
-    try:
-        skill_id: UUID | None = UUID(slug_or_id)
-    except ValueError:
-        skill_id = None
-
-    found: Skill | None = None
-    if skill_id is not None:
-        found = fetch_skill_for_user(skill_id, user, db_session)
-    if found is None:
-        found = fetch_skill_for_user_by_slug(slug_or_id, user, db_session)
-    if found is None:
+) -> SkillResponse:
+    skill = fetch_skill(
+        skill_id,
+        policy=SkillAccessPolicy.VIEW,
+        user=user,
+        db_session=db_session,
+    )
+    if skill is None:
         raise OnyxError(OnyxErrorCode.NOT_FOUND, "Skill not found")
-
-    if found.built_in_skill_id is not None:
-        definition = BUILT_IN_SKILLS.get(found.built_in_skill_id)
-        if definition is None:
-            raise OnyxError(OnyxErrorCode.NOT_FOUND, "Skill not found")
-        return BuiltinSkillResponse.from_row(found, definition, db_session)
-    return CustomSkillResponse.from_model(
-        found,
-        group_ids=[],
-        has_grants=found.id in skill_ids_with_grants([found.id], db_session),
+    return skill_response_for_user(
+        skill,
+        user,
+        db_session,
+        include_share_details=is_user_curator_or_admin(user),
     )
 
 
@@ -272,137 +86,145 @@ def preview_skill_for_current_user(
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> SkillPreviewResponse:
-    found = fetch_skill_for_user(skill_id, user, db_session)
-    if found is None:
+    skill = fetch_skill(
+        skill_id,
+        policy=SkillAccessPolicy.VIEW,
+        user=user,
+        db_session=db_session,
+    )
+    if skill is None:
         raise OnyxError(OnyxErrorCode.NOT_FOUND, "Skill not found")
-
-    return preview_response_for_skill(found)
+    return skill_preview_response(skill)
 
 
 @user_router.post("/custom")
-def create_personal_skill(
+def create_custom_skill(
     bundle: UploadFile = File(...),
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
-) -> CustomSkillResponse:
-    lock_personal_skills_for_user(user.id, db_session)
-    if (
-        count_personal_skills_for_user(user.id, db_session)
-        >= MAX_PERSONAL_SKILLS_PER_USER
-    ):
-        raise OnyxError(
-            OnyxErrorCode.INVALID_INPUT,
-            f"You have reached the limit of {MAX_PERSONAL_SKILLS_PER_USER} "
-            "personal skills. Delete one before creating another.",
-        )
-
-    reject_reserved_skill_slug(bundle.filename)
-
-    with ingested_skill_bundle(
+) -> SkillResponse:
+    skill = create_custom_skill_for_user(
         bundle_file=bundle.file,
         filename=bundle.filename,
-    ) as ingested:
-        skill = create_skill__no_commit(
-            slug=ingested.slug,
-            name=ingested.name,
-            description=ingested.description,
-            bundle_file_id=ingested.bundle_file_id,
-            bundle_sha256=ingested.bundle_sha256,
-            is_public=False,
-            author_user_id=user.id,
-            db_session=db_session,
-        )
-        db_session.commit()
+        user=user,
+        db_session=db_session,
+    )
+    return custom_skill_response_for_user(
+        skill,
+        user,
+        db_session,
+        include_share_details=True,
+    )
 
-    push_skill_to_affected_sandboxes(skill, db_session)
-    return CustomSkillResponse.from_model(skill, group_ids=[])
+
+@user_router.get("/custom/{skill_id}/edit")
+def fetch_custom_skill_for_edit(
+    skill_id: UUID,
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> SkillEditableDetailResponse:
+    skill = get_editable_custom_skill(skill_id, user, db_session)
+    response = custom_skill_response_for_user(
+        skill,
+        user,
+        db_session,
+        include_share_details=True,
+    )
+    return SkillEditableDetailResponse(
+        **response.model_dump(),
+        instructions_markdown=read_custom_skill_bundle_instructions(skill),
+    )
 
 
 @user_router.put("/custom/{skill_id}/bundle")
-def replace_personal_skill_bundle(
+def replace_current_user_skill_bundle(
     skill_id: UUID,
     bundle: UploadFile = File(...),
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
-) -> CustomSkillResponse:
-    # fetch_skill_by_id bypasses the enabled filter on purpose: an
-    # admin-disabled personal skill must stay mutable by its owner.
-    skill = fetch_skill_by_id(skill_id, db_session)
-    if skill is None:
-        raise OnyxError(OnyxErrorCode.NOT_FOUND, "Skill not found")
-    ensure_owned_personal_skill(skill, user, db_session)
-
-    updated = replace_custom_skill_bundle_contents(
-        skill=skill,
+) -> SkillResponse:
+    skill = replace_custom_skill_bundle_for_user(
+        skill_id=skill_id,
         bundle_file=bundle.file,
         filename=bundle.filename,
+        user=user,
         db_session=db_session,
     )
-    return CustomSkillResponse.from_model(updated, group_ids=[])
+    return custom_skill_response_for_user(
+        skill,
+        user,
+        db_session,
+        include_share_details=True,
+    )
 
 
 @user_router.patch("/custom/{skill_id}")
-def patch_personal_skill(
+def patch_current_user_skill(
     skill_id: UUID,
-    patch_req: PersonalSkillPatchRequest,
+    patch_req: SkillPatchRequest,
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
-) -> CustomSkillResponse:
-    """Owner toggle for ``enabled``. The skill stays listed for the owner
-    while disabled (greyed out) but drops out of their sandbox fileset."""
-    skill = fetch_skill_by_id(skill_id, db_session)
-    if skill is None:
-        raise OnyxError(OnyxErrorCode.NOT_FOUND, "Skill not found")
-    ensure_owned_personal_skill(skill, user, db_session)
-
-    enabled_changed = skill.enabled != patch_req.enabled
-    before_affected = affected_user_ids_for_skill(skill, db_session)
-    updated = patch_skill(
+) -> SkillResponse:
+    skill = patch_custom_skill_for_user(
         skill_id=skill_id,
-        patch=SkillPatch(enabled=patch_req.enabled),
+        patch=patch_req,
+        user=user,
         db_session=db_session,
     )
-    db_session.commit()
+    return custom_skill_response_for_user(
+        skill,
+        user,
+        db_session,
+        include_share_details=True,
+    )
 
-    if enabled_changed:
-        after_affected = affected_user_ids_for_skill(updated, db_session)
-        push_skills_for_users(before_affected | after_affected, db_session)
-    return CustomSkillResponse.from_model(updated, group_ids=[])
+
+@user_router.patch("/custom/{skill_id}/share")
+def share_current_user_skill(
+    skill_id: UUID,
+    share_req: SkillShareRequest,
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> SkillResponse:
+    skill = update_custom_skill_shares_for_user(
+        skill_id=skill_id,
+        share=share_req,
+        user=user,
+        db_session=db_session,
+    )
+    return custom_skill_response_for_user(
+        skill,
+        user,
+        db_session,
+        include_share_details=True,
+    )
+
+
+@user_router.post("/custom/{skill_id}/transfer-ownership")
+def transfer_current_user_skill_ownership(
+    skill_id: UUID,
+    transfer_req: TransferSkillOwnershipRequest,
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> SkillResponse:
+    skill = transfer_custom_skill_ownership_for_user(
+        skill_id=skill_id,
+        transfer=transfer_req,
+        user=user,
+        db_session=db_session,
+    )
+    return custom_skill_response_for_user(
+        skill,
+        user,
+        db_session,
+        include_share_details=True,
+    )
 
 
 @user_router.delete("/custom/{skill_id}")
-def delete_personal_skill(
+def delete_current_user_skill(
     skill_id: UUID,
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> None:
-    skill = fetch_skill_by_id(skill_id, db_session)
-    if skill is None:
-        raise OnyxError(OnyxErrorCode.NOT_FOUND, "Skill not found")
-    ensure_owned_personal_skill(skill, user, db_session)
-
-    affected = affected_user_ids_for_skill(skill, db_session)
-    old_file_id = delete_skill(skill_id, db_session)
-    db_session.commit()
-
-    push_skills_for_users(affected, db_session)
-    if old_file_id is not None:
-        delete_bundle_blob(get_default_file_store(), old_file_id)
-
-
-def _parse_group_ids(raw: str) -> list[int]:
-    try:
-        parsed = json.loads(raw)
-    except (json.JSONDecodeError, TypeError):
-        raise OnyxError(
-            OnyxErrorCode.INVALID_INPUT,
-            "group_ids must be a JSON array of integers",
-        )
-    if not isinstance(parsed, list) or not all(
-        isinstance(g, int) and not isinstance(g, bool) for g in parsed
-    ):
-        raise OnyxError(
-            OnyxErrorCode.INVALID_INPUT,
-            "group_ids must be a JSON array of integers",
-        )
-    return parsed
+    delete_custom_skill_for_user(skill_id=skill_id, user=user, db_session=db_session)

--- a/backend/onyx/server/features/skill/models.py
+++ b/backend/onyx/server/features/skill/models.py
@@ -6,39 +6,62 @@ from typing import Literal
 from uuid import UUID
 
 from pydantic import BaseModel
+from pydantic import ConfigDict
+from pydantic import Field
 from pydantic import model_validator
 from sqlalchemy.orm import Session
 
+from onyx.db.enums import SkillAccessLevel
+from onyx.db.enums import SkillSharePermission
 from onyx.db.models import Skill
-from onyx.db.skill import SkillPatch
+from onyx.server.models import MinimalUserSnapshot
 from onyx.skills.built_in import BuiltInSkillDefinition
 
 
-class BuiltinSkillResponse(BaseModel):
-    """A built-in skill — backed by a ``skill`` row whose
-    ``built_in_skill_id`` references a definition in
-    ``onyx.skills.built_in.BUILT_IN_SKILLS``. Display fields come from
-    the row; ``is_available`` / ``unavailable_reason`` come from the
-    codified definition. Built-ins are not admin-mutable, so lifecycle
-    fields (``enabled``, ``is_public``, group grants) are not part of
-    this response — they're row-level implementation detail."""
+class SkillUserShare(BaseModel):
+    user: MinimalUserSnapshot
+    permission: SkillSharePermission
 
-    source: Literal["builtin"] = "builtin"
+
+class SkillGroupShare(BaseModel):
+    group_id: int
+    group_name: str
+    permission: SkillSharePermission
+
+
+class SkillResponse(BaseModel):
+    source: Literal["builtin", "custom"]
     id: UUID
     slug: str
     name: str
     description: str
-    is_available: bool
+
+    is_available: bool | None = None
     unavailable_reason: str | None = None
 
+    is_public: bool | None = None
+    enabled: bool | None = None
+    author_user_id: UUID | None = None
+    author_email: str | None = None
+    owner: MinimalUserSnapshot | None = None
+    ownership_vacant: bool = False
+    created_at: datetime.datetime | None = None
+    updated_at: datetime.datetime | None = None
+    user_shares: list[SkillUserShare] = Field(default_factory=list)
+    group_shares: list[SkillGroupShare] = Field(default_factory=list)
+    public_permission: SkillSharePermission | None = None
+    is_personal: bool = False
+    user_permission: SkillAccessLevel | None = None
+
     @classmethod
-    def from_row(
+    def from_builtin(
         cls,
         skill: Skill,
         definition: BuiltInSkillDefinition,
         db_session: Session,
-    ) -> "BuiltinSkillResponse":
+    ) -> "SkillResponse":
         return cls(
+            source="builtin",
             id=skill.id,
             slug=skill.slug,
             name=skill.name,
@@ -47,39 +70,36 @@ class BuiltinSkillResponse(BaseModel):
             unavailable_reason=definition.unavailable_reason,
         )
 
-
-class CustomSkillResponse(BaseModel):
-    source: Literal["custom"] = "custom"
-    id: UUID
-    slug: str
-    name: str
-    description: str
-    is_public: bool
-    enabled: bool
-    author_user_id: UUID | None = None
-    author_email: str | None = None
-    created_at: datetime.datetime | None = None
-    updated_at: datetime.datetime | None = None
-    granted_group_ids: list[int] = []
-    is_personal: bool
-
     @classmethod
-    def from_model(
+    def from_custom(
         cls,
         skill: Skill,
-        group_ids: list[int],
         *,
-        has_grants: bool | None = None,
-    ) -> "CustomSkillResponse":
-        # Paths that withhold group ids from the response (user-facing) must
-        # still pass grant existence so grants-shared skills aren't marked
-        # personal.
-        grants_exist = bool(group_ids) if has_grants is None else has_grants
+        user_permission: SkillAccessLevel | None = None,
+        include_share_details: bool = False,
+    ) -> "SkillResponse":
+        user_shares = [
+            SkillUserShare(
+                user=MinimalUserSnapshot(id=share.user.id, email=share.user.email),
+                permission=share.permission,
+            )
+            for share in skill.user_shares
+            if share.user is not None
+        ]
+        group_shares = [
+            SkillGroupShare(
+                group_id=share.user_group_id,
+                group_name=share.user_group.name,
+                permission=share.permission,
+            )
+            for share in skill.group_shares
+            if share.user_group is not None
+        ]
+        visible_user_shares = user_shares if include_share_details else []
+        visible_group_shares = group_shares if include_share_details else []
         is_org_shared = skill.public_permission is not None
-        is_personal = (
-            skill.built_in_skill_id is None and not is_org_shared and not grants_exist
-        )
         return cls(
+            source="custom",
             id=skill.id,
             slug=skill.slug,
             name=skill.name,
@@ -88,16 +108,27 @@ class CustomSkillResponse(BaseModel):
             enabled=skill.enabled,
             author_user_id=skill.author_user_id,
             author_email=skill.author.email if skill.author is not None else None,
+            owner=(
+                MinimalUserSnapshot(id=skill.author.id, email=skill.author.email)
+                if skill.author is not None
+                else None
+            ),
+            ownership_vacant=skill.author_user_id is None
+            or skill.author is None
+            or not skill.author.is_active,
             created_at=skill.created_at,
             updated_at=skill.updated_at,
-            granted_group_ids=group_ids,
-            is_personal=is_personal,
+            user_shares=visible_user_shares,
+            group_shares=visible_group_shares,
+            public_permission=skill.public_permission,
+            is_personal=not is_org_shared and not user_shares and not group_shares,
+            user_permission=user_permission,
         )
 
 
 class SkillsList(BaseModel):
-    builtins: list[BuiltinSkillResponse]
-    customs: list[CustomSkillResponse]
+    builtins: list[SkillResponse]
+    customs: list[SkillResponse]
 
 
 class SkillPreviewResponse(BaseModel):
@@ -141,8 +172,18 @@ class SkillPreviewResponse(BaseModel):
         )
 
 
+class SkillEditableDetailResponse(SkillResponse):
+    instructions_markdown: str
+
+
 class SkillPatchRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str | None = None
+    description: str | None = None
+    instructions_markdown: str | None = None
     is_public: bool | None = None
+    public_permission: SkillSharePermission | None = None
     enabled: bool | None = None
 
     @model_validator(mode="before")
@@ -150,21 +191,59 @@ class SkillPatchRequest(BaseModel):
     def _reject_explicit_nulls(cls, data: Any) -> Any:
         """Omitting a field = 'leave unchanged'. Sending null = invalid."""
         if isinstance(data, dict):
-            for field in ("is_public", "enabled"):
+            for field in (
+                "name",
+                "description",
+                "instructions_markdown",
+                "is_public",
+                "public_permission",
+                "enabled",
+            ):
                 if field in data and data[field] is None:
                     raise ValueError(f"{field} cannot be null")
         return data
 
-    def to_domain(self) -> SkillPatch:
-        return SkillPatch(**{f: getattr(self, f) for f in self.model_fields_set})
+    @model_validator(mode="after")
+    def _strip_values(self) -> "SkillPatchRequest":
+        for field in ("name", "description", "instructions_markdown"):
+            value = getattr(self, field)
+            if value is None:
+                continue
+            stripped = value.strip()
+            if not stripped:
+                raise ValueError(f"{field} cannot be empty")
+            setattr(self, field, stripped)
+        return self
+
+    @property
+    def has_details_update(self) -> bool:
+        return bool(
+            self.model_fields_set & {"name", "description", "instructions_markdown"}
+        )
+
+    @property
+    def has_db_field_update(self) -> bool:
+        return bool(
+            self.model_fields_set & {"is_public", "public_permission", "enabled"}
+        )
 
 
-class PersonalSkillPatchRequest(BaseModel):
-    """User-endpoint patch: ``enabled`` only. ``is_public`` is the promotion
-    seam and stays admin-only."""
-
-    enabled: bool
+class SkillUserShareRequest(BaseModel):
+    user_id: UUID
+    permission: SkillSharePermission
 
 
-class GrantsReplace(BaseModel):
-    group_ids: list[int]
+class SkillGroupShareRequest(BaseModel):
+    group_id: int
+    permission: SkillSharePermission
+
+
+class SkillShareRequest(BaseModel):
+    user_shares: list[SkillUserShareRequest] | None = None
+    group_shares: list[SkillGroupShareRequest] | None = None
+    is_public: bool | None = None
+    public_permission: SkillSharePermission | None = None
+
+
+class TransferSkillOwnershipRequest(BaseModel):
+    new_owner_user_id: UUID

--- a/backend/onyx/server/features/skill/mutation_helpers.py
+++ b/backend/onyx/server/features/skill/mutation_helpers.py
@@ -2,65 +2,56 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import BinaryIO
 from typing import Final
+from uuid import UUID
 
 from sqlalchemy.orm import Session
 
+from onyx.auth.schemas import UserRole
+from onyx.db.enums import AccountType
+from onyx.db.enums import SkillSharePermission
 from onyx.db.models import Skill
 from onyx.db.models import User
+from onyx.db.skill import affected_user_ids_for_skill
+from onyx.db.skill import create_skill__no_commit
+from onyx.db.skill import delete_skill
+from onyx.db.skill import fetch_skill
+from onyx.db.skill import fetch_skill_by_id_for_system
 from onyx.db.skill import replace_skill_bundle
-from onyx.db.skill import skill_ids_with_grants
+from onyx.db.skill import replace_skill_shares
+from onyx.db.skill import SkillAccessPolicy
+from onyx.db.skill import transfer_skill_ownership
+from onyx.db.skill import update_skill_fields
+from onyx.db.users import fetch_user_by_id
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.file_store.file_store import get_default_file_store
+from onyx.server.features.skill.models import SkillPatchRequest
+from onyx.server.features.skill.models import SkillShareRequest
+from onyx.server.features.skill.models import TransferSkillOwnershipRequest
 from onyx.skills.built_in import BUILT_IN_SKILLS
 from onyx.skills.built_in import EXTERNAL_APP_BUILT_IN_SKILL_IDS
+from onyx.skills.bundle import compute_bundle_sha256
 from onyx.skills.bundle import read_bundle_file
+from onyx.skills.bundle import read_custom_bundle_instructions
+from onyx.skills.bundle import rewrite_custom_bundle_skill_md
 from onyx.skills.bundle import slug_from_filename
+from onyx.skills.content import read_custom_skill_bundle_bytes
 from onyx.skills.ingest import delete_bundle_blob
 from onyx.skills.ingest import ingest_skill_bundle
 from onyx.skills.ingest import IngestedBundle
+from onyx.skills.ingest import save_skill_bundle_bytes
 from onyx.skills.push import push_skill_to_affected_sandboxes
+from onyx.skills.push import push_skills_for_users
 
-# Built-in slugs plus external-app provider slugs (rows created on demand by
-# slug — a user-claimed slug would block the org from connecting that app).
 _RESERVED_SKILL_SLUGS: Final[frozenset[str]] = frozenset(BUILT_IN_SKILLS) | frozenset(
     EXTERNAL_APP_BUILT_IN_SKILL_IDS.values()
 )
 
 
-def ensure_custom_skill(skill: Skill) -> None:
-    """Block any mutation on a built-in skill row."""
-    if skill.built_in_skill_id is not None:
-        raise OnyxError(
-            OnyxErrorCode.INVALID_INPUT,
-            f"Skill '{skill.slug}' is a built-in and cannot be modified.",
-        )
-
-
 def reject_reserved_skill_slug(filename: str | None) -> None:
-    """Reject a bundle whose slug collides with codified skill identifiers."""
     slug = slug_from_filename(filename)
     if slug in _RESERVED_SKILL_SLUGS:
         raise OnyxError(OnyxErrorCode.INVALID_INPUT, f"slug '{slug}' is reserved")
-
-
-def ensure_owned_personal_skill(
-    skill: Skill,
-    user: User,
-    db_session: Session,
-) -> None:
-    """Gate user-endpoint mutations to the caller's own personal skills."""
-    ensure_custom_skill(skill)
-    if skill.author_user_id != user.id:
-        raise OnyxError(OnyxErrorCode.NOT_FOUND, "Skill not found")
-    if skill.public_permission is not None or skill_ids_with_grants(
-        [skill.id], db_session
-    ):
-        raise OnyxError(
-            OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
-            "This skill is managed by your organization and can no longer "
-            "be modified through personal skill endpoints.",
-        )
 
 
 @contextmanager
@@ -85,20 +76,308 @@ def ingested_skill_bundle(
         raise
 
 
-def replace_custom_skill_bundle_contents(
-    *,
-    skill: Skill,
-    bundle_file: BinaryIO,
-    filename: str | None,
+def _refetch_skill_or_404(skill_id: UUID, db_session: Session) -> Skill:
+    skill = fetch_skill_by_id_for_system(skill_id, db_session)
+    if skill is None:
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "Skill not found")
+    return skill
+
+
+def _ensure_can_edit_org_visibility(skill: Skill, user: User) -> None:
+    if skill.author_user_id == user.id:
+        return
+    if user.role == UserRole.ADMIN:
+        return
+    raise OnyxError(
+        OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+        "You do not have permission to change organization-wide skill access.",
+    )
+
+
+def get_editable_custom_skill(
+    skill_id: UUID,
+    user: User,
     db_session: Session,
 ) -> Skill:
+    skill = fetch_skill(
+        skill_id,
+        policy=SkillAccessPolicy.EDIT,
+        user=user,
+        db_session=db_session,
+    )
+    if skill is None:
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "Skill not found")
+    return skill
+
+
+def create_custom_skill_for_user(
+    *,
+    bundle_file: BinaryIO,
+    filename: str | None,
+    user: User,
+    db_session: Session,
+) -> Skill:
+    reject_reserved_skill_slug(filename)
+    with ingested_skill_bundle(bundle_file=bundle_file, filename=filename) as ingested:
+        skill = create_skill__no_commit(
+            slug=ingested.slug,
+            name=ingested.name,
+            description=ingested.description,
+            bundle_file_id=ingested.bundle_file_id,
+            bundle_sha256=ingested.bundle_sha256,
+            is_public=False,
+            author_user_id=user.id,
+            db_session=db_session,
+        )
+        db_session.commit()
+
+    push_skill_to_affected_sandboxes(skill, db_session)
+    return skill
+
+
+def patch_custom_skill_for_user(
+    *,
+    skill_id: UUID,
+    patch: SkillPatchRequest,
+    user: User,
+    db_session: Session,
+) -> Skill:
+    skill = get_editable_custom_skill(skill_id, user, db_session)
+    if {"is_public", "public_permission"} & patch.model_fields_set:
+        _ensure_can_edit_org_visibility(skill, user)
+
+    if not (patch.has_details_update or patch.has_db_field_update):
+        return skill
+
+    old_visibility = (skill.public_permission, skill.enabled)
+    before_affected = affected_user_ids_for_skill(skill, db_session)
+
+    file_store = get_default_file_store() if patch.has_details_update else None
+    new_bundle_file_id: str | None = None
+    old_bundle_file_id: str | None = None
+
+    try:
+        if file_store is not None:
+            old_bundle_bytes = read_custom_skill_bundle_bytes(skill, file_store)
+            name = patch.name if patch.name is not None else skill.name
+            description = (
+                patch.description
+                if patch.description is not None
+                else skill.description
+            )
+            instructions_markdown = patch.instructions_markdown
+            if instructions_markdown is None:
+                instructions_markdown = read_custom_bundle_instructions(
+                    old_bundle_bytes
+                )
+            new_bundle_bytes = rewrite_custom_bundle_skill_md(
+                old_bundle_bytes,
+                slug=skill.slug,
+                name=name,
+                description=description,
+                instructions_markdown=instructions_markdown,
+            )
+            new_bundle_file_id = save_skill_bundle_bytes(
+                new_bundle_bytes,
+                display_name=f"{skill.slug}.zip",
+                file_store=file_store,
+            )
+            old_bundle_file_id = replace_skill_bundle(
+                skill=skill,
+                new_bundle_file_id=new_bundle_file_id,
+                new_bundle_sha256=compute_bundle_sha256(new_bundle_bytes),
+                new_name=name,
+                new_description=description,
+                db_session=db_session,
+            )
+
+        if patch.has_db_field_update:
+            is_public = (
+                patch.is_public if "is_public" in patch.model_fields_set else None
+            )
+            public_permission = (
+                patch.public_permission
+                if "public_permission" in patch.model_fields_set
+                else None
+            )
+            enabled = patch.enabled if "enabled" in patch.model_fields_set else None
+            update_skill_fields(
+                skill=skill,
+                is_public=is_public,
+                public_permission=public_permission,
+                enabled=enabled,
+                db_session=db_session,
+            )
+
+        db_session.commit()
+    except Exception:
+        if file_store is not None and new_bundle_file_id is not None:
+            delete_bundle_blob(file_store, new_bundle_file_id)
+        raise
+
+    updated = _refetch_skill_or_404(skill_id, db_session)
+    visibility_changed = old_visibility != (
+        updated.public_permission,
+        updated.enabled,
+    )
+    if patch.has_details_update or visibility_changed:
+        after_affected = affected_user_ids_for_skill(updated, db_session)
+        push_skills_for_users(before_affected | after_affected, db_session)
+
+    if file_store is not None and old_bundle_file_id is not None:
+        delete_bundle_blob(file_store, old_bundle_file_id)
+    return updated
+
+
+def update_custom_skill_shares_for_user(
+    *,
+    skill_id: UUID,
+    share: SkillShareRequest,
+    user: User,
+    db_session: Session,
+) -> Skill:
+    skill = get_editable_custom_skill(skill_id, user, db_session)
+    if (
+        share.user_shares is None
+        and share.group_shares is None
+        and share.is_public is None
+        and share.public_permission is None
+    ):
+        return skill
+
+    touches_org_visibility = (
+        share.is_public is not None or share.public_permission is not None
+    )
+    if touches_org_visibility:
+        _ensure_can_edit_org_visibility(skill, user)
+
+    before_affected = affected_user_ids_for_skill(skill, db_session)
+    if touches_org_visibility:
+        update_skill_fields(
+            skill=skill,
+            is_public=share.is_public,
+            public_permission=share.public_permission,
+            db_session=db_session,
+        )
+
+    user_shares: dict[UUID, SkillSharePermission] | None = None
+    if share.user_shares is not None:
+        user_shares = {
+            user_share.user_id: user_share.permission
+            for user_share in share.user_shares
+            if user_share.user_id != skill.author_user_id
+        }
+
+    group_shares: dict[int, SkillSharePermission] | None = None
+    if share.group_shares is not None:
+        group_shares = {
+            group_share.group_id: group_share.permission
+            for group_share in share.group_shares
+        }
+
+    replace_skill_shares(
+        skill=skill,
+        user_shares=user_shares,
+        group_shares=group_shares,
+        db_session=db_session,
+    )
+
+    db_session.commit()
+    updated = _refetch_skill_or_404(skill.id, db_session)
+    after_affected = affected_user_ids_for_skill(updated, db_session)
+    push_skills_for_users(before_affected | after_affected, db_session)
+    return updated
+
+
+def transfer_custom_skill_ownership_for_user(
+    *,
+    skill_id: UUID,
+    transfer: TransferSkillOwnershipRequest,
+    user: User,
+    db_session: Session,
+) -> Skill:
+    skill = fetch_skill(
+        skill_id,
+        policy=SkillAccessPolicy.VIEW,
+        user=user,
+        db_session=db_session,
+    )
+    if skill is None:
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "Skill not found")
+    if skill.built_in_skill_id is not None:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            f"Skill '{skill.slug}' is a built-in and cannot change ownership.",
+        )
+
+    ownership_vacant = (
+        skill.author_user_id is None
+        or skill.author is None
+        or not skill.author.is_active
+    )
+    if skill.author_user_id != user.id and not (
+        user.role == UserRole.ADMIN and ownership_vacant
+    ):
+        raise OnyxError(
+            OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+            "Only the owner can transfer ownership of this skill.",
+        )
+
+    target = fetch_user_by_id(db_session, transfer.new_owner_user_id)
+    if target is None:
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "New owner not found.")
+    if not target.is_active:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "Ownership can only be transferred to an active user.",
+        )
+    if target.role in [UserRole.SLACK_USER, UserRole.EXT_PERM_USER, UserRole.LIMITED]:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "Ownership cannot be transferred to this account type.",
+        )
+    if target.account_type is not None and target.account_type != AccountType.STANDARD:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "Ownership cannot be transferred to bots or service accounts.",
+        )
+    if target.id == skill.author_user_id:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "This user already owns the skill.",
+        )
+
+    before_affected = affected_user_ids_for_skill(skill, db_session)
+    transfer_skill_ownership(
+        skill=skill,
+        new_owner_user_id=target.id,
+        db_session=db_session,
+    )
+
+    db_session.commit()
+    updated = _refetch_skill_or_404(skill.id, db_session)
+    after_affected = affected_user_ids_for_skill(updated, db_session)
+    push_skills_for_users(before_affected | after_affected, db_session)
+    return updated
+
+
+def replace_custom_skill_bundle_for_user(
+    *,
+    skill_id: UUID,
+    bundle_file: BinaryIO,
+    filename: str | None,
+    user: User,
+    db_session: Session,
+) -> Skill:
+    skill = get_editable_custom_skill(skill_id, user, db_session)
+
     with ingested_skill_bundle(
         bundle_file=bundle_file,
         filename=filename,
         slug=skill.slug,
     ) as ingested:
-        updated, old_file_id = replace_skill_bundle(
-            skill_id=skill.id,
+        old_file_id = replace_skill_bundle(
+            skill=skill,
             new_bundle_file_id=ingested.bundle_file_id,
             new_bundle_sha256=ingested.bundle_sha256,
             new_name=ingested.name,
@@ -107,6 +386,24 @@ def replace_custom_skill_bundle_contents(
         )
         db_session.commit()
 
+    updated = _refetch_skill_or_404(skill_id, db_session)
     push_skill_to_affected_sandboxes(updated, db_session)
     delete_bundle_blob(get_default_file_store(), old_file_id)
     return updated
+
+
+def delete_custom_skill_for_user(
+    *,
+    skill_id: UUID,
+    user: User,
+    db_session: Session,
+) -> None:
+    skill = get_editable_custom_skill(skill_id, user, db_session)
+
+    affected = affected_user_ids_for_skill(skill, db_session)
+    old_file_id = delete_skill(skill, db_session)
+    db_session.commit()
+
+    push_skills_for_users(affected, db_session)
+    if old_file_id is not None:
+        delete_bundle_blob(get_default_file_store(), old_file_id)

--- a/backend/onyx/server/features/skill/response_helpers.py
+++ b/backend/onyx/server/features/skill/response_helpers.py
@@ -1,15 +1,18 @@
-from uuid import UUID
-
 from sqlalchemy.orm import Session
 
+from onyx.auth.schemas import UserRole
+from onyx.auth.users import is_user_curator_or_admin
+from onyx.db.enums import SkillAccessLevel
+from onyx.db.enums import SkillSharePermission
 from onyx.db.models import Skill
-from onyx.db.skill import get_group_ids_for_skill
-from onyx.db.skill import skill_ids_with_grants
+from onyx.db.models import User
+from onyx.db.persona_sharing import get_curated_user_group_ids_for_user
+from onyx.db.persona_sharing import get_user_group_ids_for_user
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
-from onyx.server.features.skill.models import BuiltinSkillResponse
-from onyx.server.features.skill.models import CustomSkillResponse
 from onyx.server.features.skill.models import SkillPreviewResponse
+from onyx.server.features.skill.models import SkillResponse
+from onyx.server.features.skill.models import SkillsList
 from onyx.skills.built_in import BUILT_IN_SKILLS
 from onyx.skills.content import read_builtin_skill_instructions
 from onyx.skills.content import read_custom_skill_bundle_instructions
@@ -18,28 +21,124 @@ from onyx.utils.logger import setup_logger
 logger = setup_logger()
 
 
-def split_skill_rows(
-    rows: list[Skill],
+def user_permission_for_skill(
+    skill: Skill,
+    user: User,
+    user_group_ids: set[int],
+    curated_user_group_ids: set[int] | None = None,
+) -> SkillAccessLevel | None:
+    if skill.built_in_skill_id is not None:
+        return SkillAccessLevel.VIEWER
+
+    if skill.author_user_id == user.id:
+        return SkillAccessLevel.OWNER
+
+    if user.role == UserRole.ADMIN:
+        return SkillAccessLevel.EDITOR
+
+    direct_permissions = {
+        share.permission for share in skill.user_shares if share.user_id == user.id
+    }
+    group_permissions = {
+        share.permission
+        for share in skill.group_shares
+        if share.user_group_id in user_group_ids
+    }
+    share_permissions = direct_permissions | group_permissions
+
+    is_org_shared = skill.public_permission is not None
+    is_shared_with_user = bool(share_permissions)
+    group_share_ids = {share.user_group_id for share in skill.group_shares}
+    curator_managed_group_ids = set[int]()
+    if user.role == UserRole.GLOBAL_CURATOR:
+        curator_managed_group_ids = user_group_ids
+    elif user.role == UserRole.CURATOR:
+        curator_managed_group_ids = curated_user_group_ids or set()
+    is_curator_managed = (
+        bool(group_share_ids)
+        and bool(curator_managed_group_ids)
+        and group_share_ids <= curator_managed_group_ids
+    )
+    has_explicit_edit = (
+        SkillSharePermission.EDITOR in share_permissions
+        or is_org_shared
+        and skill.public_permission == SkillSharePermission.EDITOR
+    )
+
+    if has_explicit_edit:
+        return SkillAccessLevel.EDITOR
+
+    if is_curator_managed:
+        return SkillAccessLevel.EDITOR
+
+    if is_org_shared or is_shared_with_user:
+        return SkillAccessLevel.VIEWER
+
+    return None
+
+
+def custom_skill_response_for_user(
+    skill: Skill,
+    user: User,
     db_session: Session,
     *,
-    include_grants: bool,
-) -> tuple[list[BuiltinSkillResponse], list[CustomSkillResponse]]:
-    """Partition a flat row list into built-in + custom responses.
+    user_group_ids: set[int] | None = None,
+    curated_user_group_ids: set[int] | None = None,
+    include_share_details: bool = False,
+) -> SkillResponse:
+    if user_group_ids is None:
+        user_group_ids = get_user_group_ids_for_user(db_session, user.id)
+    if curated_user_group_ids is None and user.role == UserRole.CURATOR:
+        curated_user_group_ids = get_curated_user_group_ids_for_user(
+            db_session, user.id
+        )
+    return SkillResponse.from_custom(
+        skill,
+        user_permission=user_permission_for_skill(
+            skill,
+            user,
+            user_group_ids,
+            curated_user_group_ids,
+        ),
+        include_share_details=include_share_details,
+    )
 
-    A row with an unknown ``built_in_skill_id`` (definition was removed
-    in code without cleaning up the seeded row) is logged and dropped -
-    we don't surface a half-broken built-in to admins. ``include_grants``
-    only applies to custom skills; built-ins are not group-shareable.
-    """
-    builtins: list[BuiltinSkillResponse] = []
-    customs: list[CustomSkillResponse] = []
 
-    # User paths withhold group ids but still need grant existence so a
-    # grants-shared skill isn't reported as personal.
-    custom_ids = [s.id for s in rows if s.built_in_skill_id is None]
-    granted_skill_ids: set[UUID] = set()
-    if custom_ids:
-        granted_skill_ids = skill_ids_with_grants(custom_ids, db_session)
+def skill_response_for_user(
+    skill: Skill,
+    user: User,
+    db_session: Session,
+    *,
+    include_share_details: bool = False,
+) -> SkillResponse:
+    if skill.built_in_skill_id is not None:
+        definition = BUILT_IN_SKILLS.get(skill.built_in_skill_id)
+        if definition is None:
+            raise OnyxError(OnyxErrorCode.NOT_FOUND, "Skill not found")
+        return SkillResponse.from_builtin(skill, definition, db_session)
+
+    return custom_skill_response_for_user(
+        skill,
+        user,
+        db_session,
+        include_share_details=include_share_details,
+    )
+
+
+def skills_list_response_for_user(
+    rows: list[Skill],
+    user: User,
+    db_session: Session,
+) -> SkillsList:
+    builtins: list[SkillResponse] = []
+    customs: list[SkillResponse] = []
+    include_share_details = is_user_curator_or_admin(user)
+    user_group_ids = get_user_group_ids_for_user(db_session, user.id)
+    curated_user_group_ids = (
+        get_curated_user_group_ids_for_user(db_session, user.id)
+        if user.role == UserRole.CURATOR
+        else set()
+    )
 
     for skill in rows:
         if skill.built_in_skill_id is not None:
@@ -51,33 +150,24 @@ def split_skill_rows(
                     skill.built_in_skill_id,
                 )
                 continue
-            builtins.append(
-                BuiltinSkillResponse.from_row(skill, definition, db_session)
-            )
-        elif include_grants:
-            group_ids = get_group_ids_for_skill(skill.id, db_session)
-            customs.append(
-                CustomSkillResponse.from_model(
-                    skill,
-                    group_ids=group_ids,
-                    has_grants=skill.id in granted_skill_ids,
-                )
-            )
-        else:
-            customs.append(
-                CustomSkillResponse.from_model(
-                    skill,
-                    group_ids=[],
-                    has_grants=skill.id in granted_skill_ids,
-                )
-            )
+            builtins.append(SkillResponse.from_builtin(skill, definition, db_session))
+            continue
 
-    return builtins, customs
+        customs.append(
+            custom_skill_response_for_user(
+                skill,
+                user,
+                db_session,
+                user_group_ids=user_group_ids,
+                curated_user_group_ids=curated_user_group_ids,
+                include_share_details=include_share_details,
+            )
+        )
+
+    return SkillsList(builtins=builtins, customs=customs)
 
 
-def preview_response_for_skill(
-    skill: Skill,
-) -> SkillPreviewResponse:
+def skill_preview_response(skill: Skill) -> SkillPreviewResponse:
     if skill.built_in_skill_id is not None:
         definition = BUILT_IN_SKILLS.get(skill.built_in_skill_id)
         if definition is None:
@@ -87,8 +177,7 @@ def preview_response_for_skill(
             instructions_markdown=read_builtin_skill_instructions(definition),
         )
 
-    instructions_markdown = read_custom_skill_bundle_instructions(skill)
     return SkillPreviewResponse.from_custom(
         skill,
-        instructions_markdown=instructions_markdown,
+        instructions_markdown=read_custom_skill_bundle_instructions(skill),
     )

--- a/backend/onyx/skills/bundle.py
+++ b/backend/onyx/skills/bundle.py
@@ -174,6 +174,115 @@ def read_custom_bundle_instructions(zip_bytes: bytes) -> str:
     return strip_skill_md_frontmatter(skill_md)
 
 
+def build_skill_md(
+    *,
+    name: str,
+    description: str,
+    instructions_markdown: str,
+) -> str:
+    name = name.strip()
+    description = description.strip()
+    instructions_markdown = instructions_markdown.strip()
+    if not name:
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, "Skill name cannot be empty.")
+    if not description:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "Skill description cannot be empty.",
+        )
+    if not instructions_markdown:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "Skill instructions cannot be empty.",
+        )
+
+    frontmatter = yaml.safe_dump(
+        {"name": name, "description": description},
+        sort_keys=False,
+        allow_unicode=True,
+    ).strip()
+    return f"---\n{frontmatter}\n---\n\n{instructions_markdown}\n"
+
+
+def rewrite_custom_bundle_skill_md(
+    zip_bytes: bytes,
+    *,
+    slug: str,
+    name: str,
+    description: str,
+    instructions_markdown: str,
+) -> bytes:
+    """Return a new custom bundle with root SKILL.md replaced.
+
+    Existing supporting files are copied through unchanged. The resulting
+    archive is validated with the normal custom-bundle validator before it is
+    returned to callers for storage.
+    """
+    new_skill_md = build_skill_md(
+        name=name,
+        description=description,
+        instructions_markdown=instructions_markdown,
+    ).encode("utf-8")
+
+    try:
+        source_zip = zipfile.ZipFile(io.BytesIO(zip_bytes))
+    except zipfile.BadZipFile as exc:
+        raise OnyxError(
+            OnyxErrorCode.INTERNAL_ERROR,
+            "Stored skill bundle is not a valid zip.",
+        ) from exc
+
+    output = io.BytesIO()
+    saw_skill_md = False
+    with (
+        source_zip,
+        zipfile.ZipFile(
+            output, mode="w", compression=zipfile.ZIP_DEFLATED
+        ) as target_zip,
+    ):
+        for info in source_zip.infolist():
+            try:
+                normalized = _check_zip_entry_path(info.filename)
+            except OnyxError as exc:
+                raise OnyxError(
+                    OnyxErrorCode.INTERNAL_ERROR,
+                    "Stored skill bundle contains an unsafe path.",
+                ) from exc
+            if _is_symlink(info):
+                raise OnyxError(
+                    OnyxErrorCode.INTERNAL_ERROR,
+                    "Stored skill bundle contains a symlink.",
+                )
+
+            if normalized == SKILL_MD_NAME:
+                if saw_skill_md:
+                    continue
+                target_zip.writestr(info, new_skill_md)
+                saw_skill_md = True
+                continue
+
+            if info.is_dir():
+                target_zip.writestr(info, b"")
+            else:
+                try:
+                    target_zip.writestr(info, source_zip.read(info))
+                except Exception as exc:
+                    raise OnyxError(
+                        OnyxErrorCode.INTERNAL_ERROR,
+                        "Failed to read stored skill bundle entry.",
+                    ) from exc
+
+    if not saw_skill_md:
+        raise OnyxError(
+            OnyxErrorCode.INTERNAL_ERROR,
+            "Stored skill bundle is missing SKILL.md.",
+        )
+
+    rewritten = output.getvalue()
+    validate_custom_bundle(rewritten, slug=slug)
+    return rewritten
+
+
 def _is_symlink(info: zipfile.ZipInfo) -> bool:
     """True if the zip entry was archived as a Unix symlink.
 

--- a/backend/onyx/skills/content.py
+++ b/backend/onyx/skills/content.py
@@ -34,6 +34,14 @@ def read_custom_skill_bundle_instructions(
     skill: Skill,
     file_store: FileStore | None = None,
 ) -> str:
+    bundle_bytes = read_custom_skill_bundle_bytes(skill, file_store)
+    return read_custom_bundle_instructions(bundle_bytes)
+
+
+def read_custom_skill_bundle_bytes(
+    skill: Skill,
+    file_store: FileStore | None = None,
+) -> bytes:
     if skill.bundle_file_id is None:
         raise OnyxError(
             OnyxErrorCode.INTERNAL_ERROR,
@@ -47,4 +55,4 @@ def read_custom_skill_bundle_instructions(
             OnyxErrorCode.INTERNAL_ERROR,
             f"Failed to read bundle for skill '{skill.slug}'.",
         ) from exc
-    return read_custom_bundle_instructions(bundle_bytes)
+    return bundle_bytes

--- a/backend/onyx/skills/ingest.py
+++ b/backend/onyx/skills/ingest.py
@@ -20,6 +20,20 @@ class IngestedBundle(NamedTuple):
     description: str
 
 
+def save_skill_bundle_bytes(
+    bundle_bytes: bytes,
+    *,
+    display_name: str,
+    file_store: FileStore,
+) -> str:
+    return file_store.save_file(
+        content=io.BytesIO(bundle_bytes),
+        display_name=display_name,
+        file_origin=FileOrigin.SKILL_BUNDLE,
+        file_type="application/zip",
+    )
+
+
 def ingest_skill_bundle(
     bundle_bytes: bytes,
     filename: str | None,
@@ -44,11 +58,10 @@ def ingest_skill_bundle(
     name, description = parse_skill_md_metadata(bundle_bytes)
     sha = compute_bundle_sha256(bundle_bytes)
 
-    bundle_file_id = file_store.save_file(
-        content=io.BytesIO(bundle_bytes),
+    bundle_file_id = save_skill_bundle_bytes(
+        bundle_bytes,
         display_name=f"{slug}.zip",
-        file_origin=FileOrigin.SKILL_BUNDLE,
-        file_type="application/zip",
+        file_store=file_store,
     )
     return IngestedBundle(
         slug=slug,

--- a/backend/tests/external_dependency_unit/craft/db_helpers.py
+++ b/backend/tests/external_dependency_unit/craft/db_helpers.py
@@ -301,16 +301,6 @@ def share_skill_with_group(
     return share
 
 
-def grant_skill_to_group(
-    db_session: Session,
-    skill: Skill,
-    group: UserGroup,
-    permission: SkillSharePermission = SkillSharePermission.VIEWER,
-) -> Skill__UserGroup:
-    """Backward-compatible alias for group skill shares."""
-    return share_skill_with_group(db_session, skill, group, permission)
-
-
 def make_cc_pair(
     db_session: Session,
     source: DocumentSource,

--- a/backend/tests/external_dependency_unit/craft/test_built_in_skill_seeding.py
+++ b/backend/tests/external_dependency_unit/craft/test_built_in_skill_seeding.py
@@ -22,11 +22,11 @@ from sqlalchemy.orm import Session
 
 from onyx.db.models import Skill
 from onyx.db.models import User
-from onyx.db.skill import fetch_skill_for_user
-from onyx.db.skill import list_skills_for_sandbox_injection
-from onyx.db.skill import list_skills_for_user
+from onyx.db.skill import fetch_skill
+from onyx.db.skill import list_skills
+from onyx.db.skill import SkillAccessPolicy
 from onyx.error_handling.exceptions import OnyxError
-from onyx.server.features.skill.mutation_helpers import ensure_custom_skill
+from onyx.server.features.skill.mutation_helpers import get_editable_custom_skill
 from onyx.skills import built_in as built_in_module
 from onyx.skills.built_in import BUILT_IN_SKILLS
 from onyx.skills.built_in import BuiltInSkillDefinition
@@ -84,7 +84,12 @@ class TestAvailabilityGate:
         )
 
         visible = {
-            s.built_in_skill_id for s in list_skills_for_user(test_user, db_session)
+            s.built_in_skill_id
+            for s in list_skills(
+                policy=SkillAccessPolicy.VIEW,
+                user=test_user,
+                db_session=db_session,
+            )
         }
         assert gated_id not in visible
 
@@ -97,7 +102,11 @@ class TestAvailabilityGate:
 
         visible_built_ins = {
             s.built_in_skill_id
-            for s in list_skills_for_user(test_user, db_session)
+            for s in list_skills(
+                policy=SkillAccessPolicy.VIEW,
+                user=test_user,
+                db_session=db_session,
+            )
             if s.built_in_skill_id is not None
         }
         # Some built-ins gate on environment availability (e.g. image-generation
@@ -120,14 +129,22 @@ class TestAvailabilityGate:
         monkeypatch.setattr(built_in_module, "ENABLE_BROWSER", False)
         off = {
             s.built_in_skill_id
-            for s in list_skills_for_sandbox_injection(test_user, db_session)
+            for s in list_skills(
+                policy=SkillAccessPolicy.USE,
+                user=test_user,
+                db_session=db_session,
+            )
         }
         assert "browser" not in off
 
         monkeypatch.setattr(built_in_module, "ENABLE_BROWSER", True)
         on = {
             s.built_in_skill_id
-            for s in list_skills_for_sandbox_injection(test_user, db_session)
+            for s in list_skills(
+                policy=SkillAccessPolicy.USE,
+                user=test_user,
+                db_session=db_session,
+            )
         }
         assert "browser" in on
 
@@ -151,27 +168,42 @@ class TestAvailabilityGate:
             ),
         )
 
-        assert fetch_skill_for_user(row.id, test_user, db_session) is None
+        assert (
+            fetch_skill(
+                row.id,
+                policy=SkillAccessPolicy.VIEW,
+                user=test_user,
+                db_session=db_session,
+            )
+            is None
+        )
 
 
 class TestBuiltInIsImmutable:
-    """Built-in skill rows reject every admin mutation path: PATCH,
-    bundle-replace, grants-replace, delete. Enforcement lives at the
-    service layer via ``ensure_custom_skill`` and the discriminator is
-    ``built_in_skill_id IS NOT NULL``."""
+    """Built-in skill rows are not editable custom skills."""
 
-    def test_ensure_custom_rejects_built_in_rows(self, db_session: Session) -> None:
+    def test_edit_fetch_rejects_built_in_rows(
+        self,
+        db_session: Session,
+        test_user: User,
+    ) -> None:
         row = make_built_in_skill_row(db_session, built_in_skill_id="pptx")
         db_session.commit()
 
-        with pytest.raises(OnyxError, match="cannot be modified"):
-            ensure_custom_skill(row)
+        with pytest.raises(OnyxError, match="Skill not found"):
+            get_editable_custom_skill(row.id, test_user, db_session)
 
-    def test_ensure_custom_accepts_custom_rows(self, db_session: Session) -> None:
+    def test_edit_fetch_accepts_owned_custom_rows(
+        self,
+        db_session: Session,
+        test_user: User,
+    ) -> None:
         custom = make_skill(db_session, slug=f"custom-{uuid4().hex[:8]}")
+        custom.author_user_id = test_user.id
         db_session.commit()
 
-        ensure_custom_skill(custom)  # no raise
+        skill = get_editable_custom_skill(custom.id, test_user, db_session)
+        assert skill.id == custom.id
 
 
 class TestNonUniqueBuiltInId:

--- a/backend/tests/external_dependency_unit/craft/test_external_app_fileset.py
+++ b/backend/tests/external_dependency_unit/craft/test_external_app_fileset.py
@@ -5,9 +5,9 @@ External-app providers are *built-in skills* created on demand: their ``Skill``
 row carries a ``built_in_skill_id`` (e.g. ``slack``) so it renders through the
 exact same disk-backed path as a seeded built-in — there is no external-app
 special case in the push pipeline. These tests verify that an authenticated,
-enabled provider delivers its on-disk content under its stable directory, and
-that the gate (``list_skills_for_sandbox_injection``: enabled + per-user
-credential completeness) keeps content out otherwise.
+    enabled provider delivers its on-disk content under its stable directory, and
+    that the USE access policy (enabled + per-user credential completeness) keeps
+    content out otherwise.
 
 Uses the real Slack provider directory on disk so the wiring
 (``built_in_skill_id -> source dir``) is exercised end to end. The DB-layer

--- a/backend/tests/external_dependency_unit/craft/test_external_app_skill_visibility.py
+++ b/backend/tests/external_dependency_unit/craft/test_external_app_skill_visibility.py
@@ -1,18 +1,16 @@
 """External-app vs skill-endpoint boundary.
 
 External-app-backed skills are managed via the external-apps API; the
-skills API never lists or mutates them. The sandbox-injection path is
+skills API never lists or mutates them. The USE policy is
 *different* — it includes the authenticated external-app skills the
 user has connected, so the agent's workspace gets the right files.
 
 Two contracts under test:
 
-1. The skills endpoint (``list_skills_for_user`` / ``fetch_skill_for_user``
-   / ``fetch_skill_for_user_by_slug``) **never** returns an external-app
-   skill, regardless of whether the user has authenticated for it.
-2. The sandbox-injection path (``list_skills_for_sandbox_injection``)
-   includes external-app skills the user has authenticated for and
-   excludes the ones they haven't.
+1. Regular skills-page reads never return an external-app skill, regardless of
+   whether the user has authenticated for it.
+2. The USE policy includes external-app skills the user has
+   authenticated for and excludes the ones they haven't.
 
 Regular skills (no backing ``ExternalApp`` row) are unaffected by
 either filter and remain subject only to the existing ``enabled`` +
@@ -21,15 +19,15 @@ sharing-scope rules.
 
 from __future__ import annotations
 
+from uuid import UUID
+
 from sqlalchemy.orm import Session
 
 from onyx.db.models import User
 from onyx.db.models import UserRole
-from onyx.db.skill import fetch_skill_for_user
-from onyx.db.skill import fetch_skill_for_user_by_slug
-from onyx.db.skill import list_skills_for_sandbox_injection
-from onyx.db.skill import list_skills_for_user
-from onyx.server.features.skill.api import list_skills_admin
+from onyx.db.skill import fetch_skill
+from onyx.db.skill import list_skills
+from onyx.db.skill import SkillAccessPolicy
 from tests.external_dependency_unit.craft.db_helpers import make_external_app
 from tests.external_dependency_unit.craft.db_helpers import make_skill
 from tests.external_dependency_unit.craft.db_helpers import make_user
@@ -41,12 +39,50 @@ _AUTH_TEMPLATE = {"token": "{token}", "account": "{account}"}
 _FULL_CREDS = {"token": "t", "account": "a"}
 
 
-def _endpoint_ids(user: User, db_session: Session) -> set:
-    return {s.id for s in list_skills_for_user(user, db_session)}
+def _endpoint_ids(user: User, db_session: Session) -> set[UUID]:
+    return {
+        s.id
+        for s in list_skills(
+            policy=SkillAccessPolicy.VIEW,
+            user=user,
+            db_session=db_session,
+        )
+    }
 
 
-def _injectable_ids(user: User, db_session: Session) -> set:
-    return {s.id for s in list_skills_for_sandbox_injection(user, db_session)}
+def _admin_endpoint_ids(db_session: Session) -> set[UUID]:
+    admin = make_user(db_session, role=UserRole.ADMIN)
+    return {
+        s.id
+        for s in list_skills(
+            policy=SkillAccessPolicy.VIEW,
+            user=admin,
+            db_session=db_session,
+        )
+    }
+
+
+def _usable_ids(user: User, db_session: Session) -> set[UUID]:
+    return {
+        s.id
+        for s in list_skills(
+            policy=SkillAccessPolicy.USE,
+            user=user,
+            db_session=db_session,
+        )
+    }
+
+
+def _endpoint_fetches_none(skill_id: UUID, user: User, db_session: Session) -> bool:
+    return (
+        fetch_skill(
+            skill_id,
+            policy=SkillAccessPolicy.VIEW,
+            user=user,
+            db_session=db_session,
+        )
+        is None
+    )
 
 
 # ── skills endpoint NEVER shows external-app skills ────────────────
@@ -61,8 +97,7 @@ def test_skills_endpoint_hides_external_app_when_unauthenticated(
     make_external_app(db_session, skill=skill, auth_template=_AUTH_TEMPLATE)
 
     assert skill.id not in _endpoint_ids(user, db_session)
-    assert fetch_skill_for_user(skill.id, user, db_session) is None
-    assert fetch_skill_for_user_by_slug(skill.slug, user, db_session) is None
+    assert _endpoint_fetches_none(skill.id, user, db_session)
 
 
 def test_skills_endpoint_hides_external_app_even_when_authenticated(
@@ -81,8 +116,7 @@ def test_skills_endpoint_hides_external_app_even_when_authenticated(
     make_user_credential(db_session, app=app, user=user, user_credentials=_FULL_CREDS)
 
     assert skill.id not in _endpoint_ids(user, db_session)
-    assert fetch_skill_for_user(skill.id, user, db_session) is None
-    assert fetch_skill_for_user_by_slug(skill.slug, user, db_session) is None
+    assert _endpoint_fetches_none(skill.id, user, db_session)
 
 
 def test_skills_endpoint_hides_external_app_with_no_required_keys(
@@ -102,12 +136,11 @@ def test_admin_skills_endpoint_hides_external_app(
     db_session: Session,
     test_user: User,  # noqa: ARG001
 ) -> None:
-    admin = make_user(db_session, role=UserRole.ADMIN)
     regular = make_skill(db_session, is_public=True, slug="plain-admin-skill")
     external = make_skill(db_session, is_public=True, slug="ext-admin-hidden")
     make_external_app(db_session, skill=external, auth_template={})
 
-    visible = {s.id for s in list_skills_admin(admin, db_session).customs}
+    visible = _admin_endpoint_ids(db_session)
     assert regular.id in visible
     assert external.id not in visible
 
@@ -127,10 +160,10 @@ def test_regular_skill_still_visible_in_skills_endpoint(
     assert gated.id not in visible
 
 
-# ── sandbox injection respects per-user authentication ─────────────
+# ── USE respects per-user authentication ───────────────────────────
 
 
-def test_sandbox_injection_includes_authenticated_external_app(
+def test_use_includes_authenticated_external_app(
     db_session: Session,
     test_user: User,  # noqa: ARG001
 ) -> None:
@@ -142,10 +175,10 @@ def test_sandbox_injection_includes_authenticated_external_app(
     app = make_external_app(db_session, skill=skill, auth_template=_AUTH_TEMPLATE)
     make_user_credential(db_session, app=app, user=user, user_credentials=_FULL_CREDS)
 
-    assert skill.id in _injectable_ids(user, db_session)
+    assert skill.id in _usable_ids(user, db_session)
 
 
-def test_sandbox_injection_excludes_unauthenticated_external_app(
+def test_use_excludes_unauthenticated_external_app(
     db_session: Session,
     test_user: User,  # noqa: ARG001
 ) -> None:
@@ -153,10 +186,10 @@ def test_sandbox_injection_excludes_unauthenticated_external_app(
     skill = make_skill(db_session, is_public=True)
     make_external_app(db_session, skill=skill, auth_template=_AUTH_TEMPLATE)
 
-    assert skill.id not in _injectable_ids(user, db_session)
+    assert skill.id not in _usable_ids(user, db_session)
 
 
-def test_sandbox_injection_excludes_partial_credentials(
+def test_use_excludes_partial_credentials(
     db_session: Session,
     test_user: User,  # noqa: ARG001
 ) -> None:
@@ -167,10 +200,10 @@ def test_sandbox_injection_excludes_partial_credentials(
         db_session, app=app, user=user, user_credentials={"token": "t"}
     )  # missing "account"
 
-    assert skill.id not in _injectable_ids(user, db_session)
+    assert skill.id not in _usable_ids(user, db_session)
 
 
-def test_sandbox_injection_includes_external_app_with_no_required_keys(
+def test_use_includes_external_app_with_no_required_keys(
     db_session: Session,
     test_user: User,  # noqa: ARG001
 ) -> None:
@@ -190,12 +223,12 @@ def test_sandbox_injection_includes_external_app_with_no_required_keys(
         organization_credentials={"token": "from-org"},
     )
 
-    injectable = _injectable_ids(user, db_session)
-    assert s_empty.id in injectable
-    assert s_org_filled.id in injectable
+    usable = _usable_ids(user, db_session)
+    assert s_empty.id in usable
+    assert s_org_filled.id in usable
 
 
-def test_sandbox_injection_includes_regular_skills(
+def test_use_includes_regular_skills(
     db_session: Session,
     test_user: User,  # noqa: ARG001
 ) -> None:
@@ -204,4 +237,4 @@ def test_sandbox_injection_includes_regular_skills(
     user = make_user(db_session)
     regular = make_skill(db_session, is_public=True, slug="plain-included")
 
-    assert regular.id in _injectable_ids(user, db_session)
+    assert regular.id in _usable_ids(user, db_session)

--- a/backend/tests/external_dependency_unit/craft/test_skill_affected_users.py
+++ b/backend/tests/external_dependency_unit/craft/test_skill_affected_users.py
@@ -98,27 +98,6 @@ class TestAffectedUserIdsForSkill:
         assert shared_user.id in result
         assert unshared_user.id not in result
 
-    def test_shared_private_skill_still_returns_author(
-        self,
-        db_session: Session,
-        test_user: User,  # noqa: ARG002
-    ) -> None:
-        author = make_user(db_session)
-        shared_user = make_user(db_session)
-        shared_group = make_group(db_session)
-        add_user_to_group(db_session, shared_user, shared_group)
-        make_sandbox(db_session, author)
-        make_sandbox(db_session, shared_user)
-        skill = make_skill(db_session, is_public=False)
-        skill.author_user_id = author.id
-        share_skill_with_group(db_session, skill, shared_group)
-        db_session.flush()
-
-        result = affected_user_ids_for_skill(skill, db_session)
-
-        assert author.id in result
-        assert shared_user.id in result
-
     def test_disabled_skill_still_returns_affected_users(
         self,
         db_session: Session,

--- a/backend/tests/external_dependency_unit/craft/test_skill_api_access.py
+++ b/backend/tests/external_dependency_unit/craft/test_skill_api_access.py
@@ -2,18 +2,22 @@
 
 from __future__ import annotations
 
+import io
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import MagicMock
+
 import pytest
+from fastapi import UploadFile
 from sqlalchemy.orm import Session
 
+from onyx.db.enums import SkillAccessLevel
+from onyx.db.enums import SkillSharePermission
 from onyx.db.models import User
 from onyx.db.models import UserRole
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
-from onyx.server.features.skill.api import fetch_skill_for_current_user
-from onyx.server.features.skill.api import patch_custom_skill
-from onyx.server.features.skill.api import patch_personal_skill
-from onyx.server.features.skill.models import CustomSkillResponse
-from onyx.server.features.skill.models import PersonalSkillPatchRequest
+from onyx.server.features.skill import api as skill_api
 from onyx.server.features.skill.models import SkillPatchRequest
 from tests.external_dependency_unit.craft.db_helpers import add_user_to_group
 from tests.external_dependency_unit.craft.db_helpers import make_group
@@ -23,23 +27,25 @@ from tests.external_dependency_unit.craft.db_helpers import share_skill_with_gro
 from tests.external_dependency_unit.craft.db_helpers import share_skill_with_user
 
 
-def test_admin_mutation_uses_edit_policy_for_curator_scope(
+def _upload(filename: str) -> UploadFile:
+    return cast(
+        UploadFile,
+        SimpleNamespace(file=io.BytesIO(b"bundle"), filename=filename),
+    )
+
+
+def test_curator_without_group_scope_cannot_patch_shared_skill(
     db_session: Session,
     test_user: User,  # noqa: ARG001
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     curator = make_user(db_session, role=UserRole.CURATOR)
     group = make_group(db_session)
     add_user_to_group(db_session, curator, group)
     private_skill = make_skill(db_session, is_public=False, enabled=True)
     share_skill_with_group(db_session, private_skill, group)
-    monkeypatch.setattr(
-        "onyx.server.features.skill.api.push_skills_for_users",
-        lambda *_args: None,
-    )
 
     with pytest.raises(OnyxError) as exc_info:
-        patch_custom_skill(
+        skill_api.patch_current_user_skill(
             private_skill.id,
             SkillPatchRequest(enabled=False),
             user=curator,
@@ -59,17 +65,73 @@ def test_fetch_direct_shared_skill_is_not_personal(
     private_skill = make_skill(db_session, is_public=False, enabled=True)
     share_skill_with_user(db_session, private_skill, user)
 
-    response = fetch_skill_for_current_user(
-        str(private_skill.id),
+    response = skill_api.fetch_skill_for_current_user(
+        private_skill.id,
         user=user,
         db_session=db_session,
     )
 
-    assert isinstance(response, CustomSkillResponse)
+    assert response.source == "custom"
     assert response.is_personal is False
+    assert response.user_permission == SkillAccessLevel.VIEWER
 
 
-def test_personal_mutation_rejects_direct_shared_skill(
+def test_viewer_share_cannot_patch_skill(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+) -> None:
+    owner = make_user(db_session, role=UserRole.BASIC)
+    shared_user = make_user(db_session, role=UserRole.BASIC)
+    private_skill = make_skill(
+        db_session,
+        is_public=False,
+        enabled=True,
+        author_user_id=owner.id,
+    )
+    share_skill_with_user(
+        db_session,
+        private_skill,
+        shared_user,
+        SkillSharePermission.VIEWER,
+    )
+
+    with pytest.raises(OnyxError) as exc_info:
+        skill_api.patch_current_user_skill(
+            private_skill.id,
+            SkillPatchRequest(enabled=False),
+            user=shared_user,
+            db_session=db_session,
+        )
+
+    assert exc_info.value.error_code == OnyxErrorCode.NOT_FOUND
+    db_session.refresh(private_skill)
+    assert private_skill.enabled is True
+
+
+def test_create_reserved_slug_rejects_before_reading_bundle(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = make_user(db_session, role=UserRole.BASIC)
+    read_bundle_file = MagicMock()
+    monkeypatch.setattr(
+        "onyx.server.features.skill.mutation_helpers.read_bundle_file",
+        read_bundle_file,
+    )
+
+    with pytest.raises(OnyxError) as exc_info:
+        skill_api.create_custom_skill(
+            bundle=_upload("pptx.zip"),
+            user=user,
+            db_session=db_session,
+        )
+
+    assert exc_info.value.error_code == OnyxErrorCode.INVALID_INPUT
+    read_bundle_file.assert_not_called()
+
+
+def test_replace_bundle_authorizes_before_reading_bundle(
     db_session: Session,
     test_user: User,  # noqa: ARG001
     monkeypatch: pytest.MonkeyPatch,
@@ -82,20 +144,25 @@ def test_personal_mutation_rejects_direct_shared_skill(
         enabled=True,
         author_user_id=owner.id,
     )
-    share_skill_with_user(db_session, private_skill, shared_user)
+    share_skill_with_user(
+        db_session,
+        private_skill,
+        shared_user,
+        SkillSharePermission.VIEWER,
+    )
+    read_bundle_file = MagicMock()
     monkeypatch.setattr(
-        "onyx.server.features.skill.api.push_skills_for_users",
-        lambda *_args: None,
+        "onyx.server.features.skill.mutation_helpers.read_bundle_file",
+        read_bundle_file,
     )
 
     with pytest.raises(OnyxError) as exc_info:
-        patch_personal_skill(
+        skill_api.replace_current_user_skill_bundle(
             private_skill.id,
-            PersonalSkillPatchRequest(enabled=False),
-            user=owner,
+            bundle=_upload("replace-test.zip"),
+            user=shared_user,
             db_session=db_session,
         )
 
-    assert exc_info.value.error_code == OnyxErrorCode.INSUFFICIENT_PERMISSIONS
-    db_session.refresh(private_skill)
-    assert private_skill.enabled is True
+    assert exc_info.value.error_code == OnyxErrorCode.NOT_FOUND
+    read_bundle_file.assert_not_called()

--- a/backend/tests/external_dependency_unit/craft/test_skill_ownership_transfer.py
+++ b/backend/tests/external_dependency_unit/craft/test_skill_ownership_transfer.py
@@ -1,0 +1,249 @@
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from onyx.db.enums import AccountType
+from onyx.db.enums import SkillSharePermission
+from onyx.db.models import Skill
+from onyx.db.models import Skill__User
+from onyx.db.models import User
+from onyx.db.models import UserRole
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.features.skill.models import TransferSkillOwnershipRequest
+from onyx.server.features.skill.mutation_helpers import (
+    transfer_custom_skill_ownership_for_user,
+)
+from tests.external_dependency_unit.craft.db_helpers import make_sandbox
+from tests.external_dependency_unit.craft.db_helpers import make_skill
+from tests.external_dependency_unit.craft.db_helpers import make_user
+from tests.external_dependency_unit.craft.db_helpers import share_skill_with_user
+
+
+def _owned_skill(db_session: Session, owner: User) -> Skill:
+    skill = make_skill(db_session)
+    skill.author_user_id = owner.id
+    db_session.flush()
+    return skill
+
+
+def _share_row(
+    db_session: Session,
+    skill: Skill,
+    user: User,
+) -> Skill__User | None:
+    return db_session.scalar(
+        select(Skill__User).where(
+            Skill__User.skill_id == skill.id,
+            Skill__User.user_id == user.id,
+        )
+    )
+
+
+@pytest.fixture(autouse=True)
+def push_calls(monkeypatch: pytest.MonkeyPatch) -> list[set[object]]:
+    calls: list[set[object]] = []
+    monkeypatch.setattr(
+        "onyx.server.features.skill.mutation_helpers.push_skills_for_users",
+        lambda user_ids, _db_session: calls.append(set(user_ids)),
+    )
+    return calls
+
+
+def test_owner_transfers_to_active_user(
+    db_session: Session,
+    push_calls: list[set[object]],
+) -> None:
+    owner = make_user(db_session, role=UserRole.BASIC)
+    new_owner = make_user(db_session, role=UserRole.BASIC)
+    skill = _owned_skill(db_session, owner)
+    share_skill_with_user(
+        db_session,
+        skill,
+        new_owner,
+        SkillSharePermission.VIEWER,
+    )
+
+    transferred = transfer_custom_skill_ownership_for_user(
+        skill_id=skill.id,
+        transfer=TransferSkillOwnershipRequest(new_owner_user_id=new_owner.id),
+        user=owner,
+        db_session=db_session,
+    )
+
+    assert transferred.author_user_id == new_owner.id
+    assert _share_row(db_session, transferred, new_owner) is None
+    previous_owner_share = _share_row(db_session, transferred, owner)
+    assert previous_owner_share is not None
+    assert previous_owner_share.permission == SkillSharePermission.EDITOR
+    assert push_calls == [set()]
+
+
+def test_transfer_pushes_previous_and_new_owner_sandboxes(
+    db_session: Session,
+    push_calls: list[set[object]],
+) -> None:
+    owner = make_user(db_session, role=UserRole.BASIC)
+    new_owner = make_user(db_session, role=UserRole.BASIC)
+    make_sandbox(db_session, owner)
+    make_sandbox(db_session, new_owner)
+    skill = _owned_skill(db_session, owner)
+
+    transfer_custom_skill_ownership_for_user(
+        skill_id=skill.id,
+        transfer=TransferSkillOwnershipRequest(new_owner_user_id=new_owner.id),
+        user=owner,
+        db_session=db_session,
+    )
+
+    assert push_calls == [{owner.id, new_owner.id}]
+
+
+@pytest.mark.parametrize(
+    "permission",
+    [SkillSharePermission.VIEWER, SkillSharePermission.EDITOR],
+)
+def test_non_owner_sharee_cannot_transfer(
+    db_session: Session,
+    permission: SkillSharePermission,
+    push_calls: list[set[object]],
+) -> None:
+    owner = make_user(db_session, role=UserRole.BASIC)
+    sharee = make_user(db_session, role=UserRole.BASIC)
+    target = make_user(db_session, role=UserRole.BASIC)
+    skill = _owned_skill(db_session, owner)
+    share_skill_with_user(db_session, skill, sharee, permission)
+
+    with pytest.raises(OnyxError) as exc_info:
+        transfer_custom_skill_ownership_for_user(
+            skill_id=skill.id,
+            transfer=TransferSkillOwnershipRequest(new_owner_user_id=target.id),
+            user=sharee,
+            db_session=db_session,
+        )
+
+    assert exc_info.value.error_code == OnyxErrorCode.INSUFFICIENT_PERMISSIONS
+    db_session.refresh(skill)
+    assert skill.author_user_id == owner.id
+    assert _share_row(db_session, skill, sharee) is not None
+    assert push_calls == []
+
+
+def test_transfer_rejects_inactive_target(
+    db_session: Session,
+    push_calls: list[set[object]],
+) -> None:
+    owner = make_user(db_session, role=UserRole.BASIC)
+    target = make_user(db_session, role=UserRole.BASIC)
+    target.is_active = False
+    skill = _owned_skill(db_session, owner)
+    db_session.flush()
+
+    with pytest.raises(OnyxError) as exc_info:
+        transfer_custom_skill_ownership_for_user(
+            skill_id=skill.id,
+            transfer=TransferSkillOwnershipRequest(new_owner_user_id=target.id),
+            user=owner,
+            db_session=db_session,
+        )
+
+    assert exc_info.value.error_code == OnyxErrorCode.INVALID_INPUT
+    db_session.refresh(skill)
+    assert skill.author_user_id == owner.id
+    assert _share_row(db_session, skill, target) is None
+    assert push_calls == []
+
+
+def test_transfer_rejects_unsupported_target_account_type(
+    db_session: Session,
+    push_calls: list[set[object]],
+) -> None:
+    owner = make_user(db_session, role=UserRole.BASIC)
+    target = make_user(
+        db_session,
+        role=UserRole.BASIC,
+    )
+    target.account_type = AccountType.BOT
+    skill = _owned_skill(db_session, owner)
+    db_session.flush()
+
+    with pytest.raises(OnyxError) as exc_info:
+        transfer_custom_skill_ownership_for_user(
+            skill_id=skill.id,
+            transfer=TransferSkillOwnershipRequest(new_owner_user_id=target.id),
+            user=owner,
+            db_session=db_session,
+        )
+
+    assert exc_info.value.error_code == OnyxErrorCode.INVALID_INPUT
+    db_session.refresh(skill)
+    assert skill.author_user_id == owner.id
+    assert _share_row(db_session, skill, target) is None
+    assert push_calls == []
+
+
+def test_admin_transfers_vacant_skill(
+    db_session: Session,
+    push_calls: list[set[object]],
+) -> None:
+    admin = make_user(db_session, role=UserRole.ADMIN)
+    target = make_user(db_session, role=UserRole.BASIC)
+    skill = make_skill(db_session)
+
+    transferred = transfer_custom_skill_ownership_for_user(
+        skill_id=skill.id,
+        transfer=TransferSkillOwnershipRequest(new_owner_user_id=target.id),
+        user=admin,
+        db_session=db_session,
+    )
+
+    assert transferred.author_user_id == target.id
+    assert _share_row(db_session, transferred, admin) is None
+    assert push_calls == [set()]
+
+
+def test_admin_cannot_transfer_owned_skill(
+    db_session: Session,
+    push_calls: list[set[object]],
+) -> None:
+    owner = make_user(db_session, role=UserRole.BASIC)
+    admin = make_user(db_session, role=UserRole.ADMIN)
+    target = make_user(db_session, role=UserRole.BASIC)
+    skill = _owned_skill(db_session, owner)
+
+    with pytest.raises(OnyxError) as exc_info:
+        transfer_custom_skill_ownership_for_user(
+            skill_id=skill.id,
+            transfer=TransferSkillOwnershipRequest(new_owner_user_id=target.id),
+            user=admin,
+            db_session=db_session,
+        )
+
+    assert exc_info.value.error_code == OnyxErrorCode.INSUFFICIENT_PERMISSIONS
+    db_session.refresh(skill)
+    assert skill.author_user_id == owner.id
+    assert _share_row(db_session, skill, target) is None
+    assert push_calls == []
+
+
+def test_transfer_rejects_missing_target(
+    db_session: Session,
+    push_calls: list[set[object]],
+) -> None:
+    owner = make_user(db_session, role=UserRole.BASIC)
+    skill = _owned_skill(db_session, owner)
+
+    with pytest.raises(OnyxError) as exc_info:
+        transfer_custom_skill_ownership_for_user(
+            skill_id=skill.id,
+            transfer=TransferSkillOwnershipRequest(new_owner_user_id=uuid4()),
+            user=owner,
+            db_session=db_session,
+        )
+
+    assert exc_info.value.error_code == OnyxErrorCode.NOT_FOUND
+    db_session.refresh(skill)
+    assert skill.author_user_id == owner.id
+    assert push_calls == []

--- a/backend/tests/external_dependency_unit/craft/test_skill_visibility.py
+++ b/backend/tests/external_dependency_unit/craft/test_skill_visibility.py
@@ -2,29 +2,37 @@
 
 from __future__ import annotations
 
-from uuid import uuid4
-
 from sqlalchemy.orm import Session
 
 from onyx.db.enums import SkillSharePermission
 from onyx.db.models import User
 from onyx.db.models import UserRole
 from onyx.db.skill import fetch_skill
-from onyx.db.skill import fetch_skill_for_user
-from onyx.db.skill import fetch_skill_for_user_by_slug
-from onyx.db.skill import list_skills_for_admin
-from onyx.db.skill import list_skills_for_sandbox_injection
-from onyx.db.skill import list_skills_for_user
-from onyx.db.skill import patch_skill
+from onyx.db.skill import list_skills
 from onyx.db.skill import SkillAccessPolicy
-from onyx.db.skill import SkillPatch
+from onyx.db.skill import update_skill_fields
 from tests.external_dependency_unit.craft.db_helpers import add_user_to_group
-from tests.external_dependency_unit.craft.db_helpers import grant_skill_to_group
 from tests.external_dependency_unit.craft.db_helpers import make_group
 from tests.external_dependency_unit.craft.db_helpers import make_skill
 from tests.external_dependency_unit.craft.db_helpers import make_user
 from tests.external_dependency_unit.craft.db_helpers import share_skill_with_group
 from tests.external_dependency_unit.craft.db_helpers import share_skill_with_user
+
+
+def _admin_skills(admin: User, db_session: Session):
+    return list_skills(
+        policy=SkillAccessPolicy.VIEW,
+        user=admin,
+        db_session=db_session,
+    )
+
+
+def _user_skills(user: User, db_session: Session):
+    return list_skills(
+        policy=SkillAccessPolicy.VIEW,
+        user=user,
+        db_session=db_session,
+    )
 
 
 class TestSkillVisibility:
@@ -36,7 +44,7 @@ class TestSkillVisibility:
         admin = make_user(db_session, role=UserRole.ADMIN)
         disabled_skill = make_skill(db_session, enabled=False, is_public=True)
 
-        admin_list = list_skills_for_admin(db_session)
+        admin_list = _admin_skills(admin, db_session)
         admin_ids = {s.id for s in admin_list}
 
         assert disabled_skill.id in admin_ids
@@ -44,7 +52,7 @@ class TestSkillVisibility:
         admin_seen = next(s for s in admin_list if s.id == disabled_skill.id)
         assert admin_seen.enabled is False
         # And the admin path *also* bypasses the user filter — this user
-        # exists but does not change what list_skills_for_admin returns.
+        # exists but does not change what the admin skill listing returns.
         assert admin is not None
 
     def test_user_does_not_see_disabled_skill(
@@ -55,7 +63,7 @@ class TestSkillVisibility:
         user = make_user(db_session, role=UserRole.BASIC)
         disabled_skill = make_skill(db_session, enabled=False, is_public=True)
 
-        user_list = list_skills_for_user(user, db_session)
+        user_list = _user_skills(user, db_session)
         user_ids = {s.id for s in user_list}
 
         assert disabled_skill.id not in user_ids
@@ -68,28 +76,28 @@ class TestSkillVisibility:
         user = make_user(db_session, role=UserRole.BASIC)
         public_skill = make_skill(db_session, is_public=True, enabled=True)
 
-        user_list = list_skills_for_user(user, db_session)
+        user_list = _user_skills(user, db_session)
         user_ids = {s.id for s in user_list}
 
         assert public_skill.id in user_ids
 
-    def test_user_does_not_see_private_skill_without_grant(
+    def test_user_does_not_see_private_skill_without_share(
         self,
         db_session: Session,
         test_user: User,  # noqa: ARG002
     ) -> None:
         user = make_user(db_session, role=UserRole.BASIC)
-        # Another group exists with the grant; this user is not in it.
+        # Another group has a share; this user is not in it.
         other_group = make_group(db_session)
         private_skill = make_skill(db_session, is_public=False, enabled=True)
-        grant_skill_to_group(db_session, private_skill, other_group)
+        share_skill_with_group(db_session, private_skill, other_group)
 
-        user_list = list_skills_for_user(user, db_session)
+        user_list = _user_skills(user, db_session)
         user_ids = {s.id for s in user_list}
 
         assert private_skill.id not in user_ids
 
-    def test_user_sees_private_skill_via_group_grant(
+    def test_user_sees_private_skill_via_group_share(
         self,
         db_session: Session,
         test_user: User,  # noqa: ARG002
@@ -98,9 +106,9 @@ class TestSkillVisibility:
         group = make_group(db_session)
         add_user_to_group(db_session, user, group)
         private_skill = make_skill(db_session, is_public=False, enabled=True)
-        grant_skill_to_group(db_session, private_skill, group)
+        share_skill_with_group(db_session, private_skill, group)
 
-        user_list = list_skills_for_user(user, db_session)
+        user_list = _user_skills(user, db_session)
         user_ids = {s.id for s in user_list}
 
         assert private_skill.id in user_ids
@@ -114,25 +122,15 @@ class TestSkillVisibility:
         private_skill = make_skill(db_session, is_public=False, enabled=True)
         share_skill_with_user(db_session, private_skill, user)
 
-        user_list = list_skills_for_user(user, db_session)
-        user_ids = {s.id for s in user_list}
+        result = fetch_skill(
+            private_skill.id,
+            policy=SkillAccessPolicy.VIEW,
+            user=user,
+            db_session=db_session,
+        )
 
-        assert private_skill.id in user_ids
-
-    def test_sandbox_injection_uses_direct_user_share(
-        self,
-        db_session: Session,
-        test_user: User,  # noqa: ARG002
-    ) -> None:
-        user = make_user(db_session, role=UserRole.BASIC)
-        private_skill = make_skill(db_session, is_public=False, enabled=True)
-        share_skill_with_user(db_session, private_skill, user)
-
-        injected_ids = {
-            s.id for s in list_skills_for_sandbox_injection(user, db_session)
-        }
-
-        assert private_skill.id in injected_ids
+        assert result is not None
+        assert result.id == private_skill.id
 
     def test_direct_viewer_share_does_not_grant_edit(
         self,
@@ -190,7 +188,7 @@ class TestSkillVisibility:
         group = make_group(db_session)
         add_user_to_group(db_session, user, group)
         private_skill = make_skill(db_session, is_public=False, enabled=True)
-        grant_skill_to_group(
+        share_skill_with_group(
             db_session,
             private_skill,
             group,
@@ -215,7 +213,7 @@ class TestSkillVisibility:
         group = make_group(db_session)
         add_user_to_group(db_session, user, group)
         private_skill = make_skill(db_session, is_public=False, enabled=True)
-        grant_skill_to_group(
+        share_skill_with_group(
             db_session,
             private_skill,
             group,
@@ -254,7 +252,7 @@ class TestSkillVisibility:
 
         assert result is None
 
-    def test_public_editor_permission_grants_edit(
+    def test_org_editor_permission_grants_edit(
         self,
         db_session: Session,
         test_user: User,  # noqa: ARG002
@@ -276,6 +274,28 @@ class TestSkillVisibility:
 
         assert result is not None
         assert result.id == public_skill.id
+
+    def test_admin_edit_fetch_allows_personal_disabled_skill(
+        self,
+        db_session: Session,
+        test_user: User,  # noqa: ARG002
+    ) -> None:
+        admin = make_user(db_session, role=UserRole.ADMIN)
+        private_disabled_skill = make_skill(
+            db_session,
+            is_public=False,
+            enabled=False,
+        )
+
+        result = fetch_skill(
+            private_disabled_skill.id,
+            policy=SkillAccessPolicy.EDIT,
+            user=admin,
+            db_session=db_session,
+        )
+
+        assert result is not None
+        assert result.id == private_disabled_skill.id
 
     def test_disabled_skill_visible_to_editor_share_but_not_viewer_share(
         self,
@@ -332,8 +352,11 @@ class TestSkillVisibility:
             is None
         )
 
-        skill.public_permission = SkillSharePermission.EDITOR
-        db_session.flush()
+        update_skill_fields(
+            skill=skill,
+            public_permission=SkillSharePermission.EDITOR,
+            db_session=db_session,
+        )
         editor_result = fetch_skill(
             skill.id,
             policy=SkillAccessPolicy.EDIT,
@@ -343,11 +366,7 @@ class TestSkillVisibility:
         assert editor_result is not None
         assert editor_result.id == skill.id
 
-        patch_skill(
-            skill_id=skill.id,
-            patch=SkillPatch(is_public=False),
-            db_session=db_session,
-        )
+        update_skill_fields(skill=skill, is_public=False, db_session=db_session)
         assert (
             fetch_skill(
                 skill.id,
@@ -367,16 +386,16 @@ class TestSkillVisibility:
         group = make_group(db_session)
         membership = add_user_to_group(db_session, user, group)
         private_skill = make_skill(db_session, is_public=False, enabled=True)
-        grant_skill_to_group(db_session, private_skill, group)
+        share_skill_with_group(db_session, private_skill, group)
 
-        before_ids = {s.id for s in list_skills_for_user(user, db_session)}
+        before_ids = {s.id for s in _user_skills(user, db_session)}
         assert private_skill.id in before_ids
 
-        # Yank the user out of the granted group.
+        # Yank the user out of the shared group.
         db_session.delete(membership)
         db_session.flush()
 
-        after_ids = {s.id for s in list_skills_for_user(user, db_session)}
+        after_ids = {s.id for s in _user_skills(user, db_session)}
         assert private_skill.id not in after_ids
 
     def test_curator_user_visibility_matches_regular_user(
@@ -390,16 +409,16 @@ class TestSkillVisibility:
         curator = make_user(db_session, role=UserRole.CURATOR)
         basic = make_user(db_session, role=UserRole.BASIC)
 
-        # A private skill granted to a group the curator is NOT in.
+        # A private skill shared with a group the curator is NOT in.
         other_group = make_group(db_session)
         private_skill = make_skill(db_session, is_public=False, enabled=True)
-        grant_skill_to_group(db_session, private_skill, other_group)
+        share_skill_with_group(db_session, private_skill, other_group)
 
         # A public skill — both should see it.
         public_skill = make_skill(db_session, is_public=True, enabled=True)
 
-        curator_ids = {s.id for s in list_skills_for_user(curator, db_session)}
-        basic_ids = {s.id for s in list_skills_for_user(basic, db_session)}
+        curator_ids = {s.id for s in _user_skills(curator, db_session)}
+        basic_ids = {s.id for s in _user_skills(basic, db_session)}
 
         # Curator does NOT get admin bypass: invisible private skill is
         # invisible for both.
@@ -409,7 +428,7 @@ class TestSkillVisibility:
         assert public_skill.id in curator_ids
         assert public_skill.id in basic_ids
 
-    def test_fetch_skill_for_user_returns_none_when_not_granted(
+    def test_view_fetch_returns_none_when_not_shared(
         self,
         db_session: Session,
         test_user: User,  # noqa: ARG002
@@ -417,35 +436,16 @@ class TestSkillVisibility:
         user = make_user(db_session, role=UserRole.BASIC)
         other_group = make_group(db_session)
         private_skill = make_skill(db_session, is_public=False, enabled=True)
-        grant_skill_to_group(db_session, private_skill, other_group)
+        share_skill_with_group(db_session, private_skill, other_group)
 
-        result = fetch_skill_for_user(private_skill.id, user, db_session)
+        result = fetch_skill(
+            private_skill.id,
+            policy=SkillAccessPolicy.VIEW,
+            user=user,
+            db_session=db_session,
+        )
 
         assert result is None
-
-    def test_fetch_skill_by_slug_obeys_visibility(
-        self,
-        db_session: Session,
-        test_user: User,  # noqa: ARG002
-    ) -> None:
-        user = make_user(db_session, role=UserRole.BASIC)
-        group = make_group(db_session)
-        other_group = make_group(db_session)
-        add_user_to_group(db_session, user, group)
-
-        granted_slug = f"granted-{uuid4().hex[:8]}"
-        ungranted_slug = f"ungranted-{uuid4().hex[:8]}"
-        granted_skill = make_skill(db_session, slug=granted_slug, is_public=False)
-        ungranted_skill = make_skill(db_session, slug=ungranted_slug, is_public=False)
-        grant_skill_to_group(db_session, granted_skill, group)
-        grant_skill_to_group(db_session, ungranted_skill, other_group)
-
-        seen = fetch_skill_for_user_by_slug(granted_slug, user, db_session)
-        unseen = fetch_skill_for_user_by_slug(ungranted_slug, user, db_session)
-
-        assert seen is not None
-        assert seen.id == granted_skill.id
-        assert unseen is None
 
     def test_edit_fetch_allows_curator_for_curated_group_skill(
         self,

--- a/backend/tests/integration/common_utils/managers/skill.py
+++ b/backend/tests/integration/common_utils/managers/skill.py
@@ -1,12 +1,35 @@
 import io
-import json
 import zipfile
+from collections.abc import Sequence
+from typing import TypeVar
+from uuid import UUID
 from uuid import uuid4
 
+import httpx
+from pydantic import BaseModel
+
+from onyx.db.enums import SkillSharePermission
+from onyx.server.features.skill.models import SkillEditableDetailResponse
+from onyx.server.features.skill.models import SkillGroupShareRequest
+from onyx.server.features.skill.models import SkillPatchRequest
+from onyx.server.features.skill.models import SkillPreviewResponse
+from onyx.server.features.skill.models import SkillResponse
+from onyx.server.features.skill.models import SkillShareRequest
+from onyx.server.features.skill.models import SkillsList
+from onyx.server.features.skill.models import SkillUserShareRequest
+from onyx.server.features.skill.models import TransferSkillOwnershipRequest
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.http_client import client
-from tests.integration.common_utils.test_models import DATestSkill
 from tests.integration.common_utils.test_models import DATestUser
+
+_ResponseModel = TypeVar("_ResponseModel", bound=BaseModel)
+
+
+def _response_model(
+    response: httpx.Response,
+    model: type[_ResponseModel],
+) -> _ResponseModel:
+    return model.model_validate(response.json())
 
 
 def build_minimal_bundle(
@@ -44,7 +67,7 @@ class SkillManager:
         group_ids: list[int] | None = None,
         bundle_bytes: bytes | None = None,
         filename: str | None = None,
-    ) -> DATestSkill:
+    ) -> SkillResponse:
         slug = slug or f"test-skill-{uuid4().hex[:8]}"
         if bundle_bytes is None:
             bundle_bytes = build_minimal_bundle(
@@ -55,11 +78,7 @@ class SkillManager:
         headers.pop("Content-Type", None)
 
         response = client.post(
-            f"{API_SERVER_URL}/admin/skills/custom",
-            data={
-                "is_public": str(is_public).lower(),
-                "group_ids": json.dumps(group_ids or []),
-            },
+            f"{API_SERVER_URL}/skills/custom",
             files={
                 "bundle": (
                     filename or f"{slug}.zip",
@@ -70,53 +89,57 @@ class SkillManager:
             headers=headers,
         )
         response.raise_for_status()
-        data = response.json()
-        return DATestSkill(
-            id=data["id"],
-            slug=data["slug"],
-            name=data["name"],
-            description=data["description"],
-            is_public=data["is_public"],
-            enabled=data["enabled"],
-            granted_group_ids=data.get("granted_group_ids", []),
-            is_personal=data.get("is_personal", False),
-        )
+        skill = _response_model(response, SkillResponse)
+
+        if is_public or group_ids:
+            share_req = SkillShareRequest(
+                is_public=is_public,
+                group_shares=[
+                    SkillGroupShareRequest(
+                        group_id=group_id,
+                        permission=SkillSharePermission.VIEWER,
+                    )
+                    for group_id in group_ids or []
+                ],
+            )
+            share_response = client.patch(
+                f"{API_SERVER_URL}/skills/custom/{skill.id}/share",
+                json=share_req.model_dump(mode="json", exclude_none=True),
+                headers=user_performing_action.headers,
+            )
+            share_response.raise_for_status()
+            return _response_model(share_response, SkillResponse)
+
+        return skill
 
     @staticmethod
     def patch_custom(
-        skill: DATestSkill,
+        skill: SkillResponse,
         user_performing_action: DATestUser,
-        **fields: object,
-    ) -> DATestSkill:
+        patch_req: SkillPatchRequest,
+    ) -> SkillResponse:
         response = client.patch(
-            f"{API_SERVER_URL}/admin/skills/custom/{skill.id}",
-            json=fields,
+            f"{API_SERVER_URL}/skills/custom/{skill.id}",
+            json=patch_req.model_dump(
+                mode="json",
+                exclude_unset=True,
+            ),
             headers=user_performing_action.headers,
         )
         response.raise_for_status()
-        data = response.json()
-        return DATestSkill(
-            id=data["id"],
-            slug=data["slug"],
-            name=data["name"],
-            description=data["description"],
-            is_public=data["is_public"],
-            enabled=data["enabled"],
-            granted_group_ids=data.get("granted_group_ids", []),
-            is_personal=data.get("is_personal", False),
-        )
+        return _response_model(response, SkillResponse)
 
     @staticmethod
     def replace_bundle(
-        skill: DATestSkill,
+        skill: SkillResponse,
         bundle_bytes: bytes,
         user_performing_action: DATestUser,
-    ) -> DATestSkill:
+    ) -> SkillResponse:
         headers = dict(user_performing_action.headers)
         headers.pop("Content-Type", None)
 
         response = client.put(
-            f"{API_SERVER_URL}/admin/skills/custom/{skill.id}/bundle",
+            f"{API_SERVER_URL}/skills/custom/{skill.id}/bundle",
             files={
                 "bundle": (
                     f"{skill.slug}.zip",
@@ -127,49 +150,38 @@ class SkillManager:
             headers=headers,
         )
         response.raise_for_status()
-        data = response.json()
-        return DATestSkill(
-            id=data["id"],
-            slug=data["slug"],
-            name=data["name"],
-            description=data["description"],
-            is_public=data["is_public"],
-            enabled=data["enabled"],
-            granted_group_ids=data.get("granted_group_ids", []),
-            is_personal=data.get("is_personal", False),
-        )
+        return _response_model(response, SkillResponse)
 
     @staticmethod
-    def replace_grants(
-        skill: DATestSkill,
+    def replace_group_shares(
+        skill: SkillResponse,
         group_ids: list[int],
         user_performing_action: DATestUser,
-    ) -> DATestSkill:
-        response = client.put(
-            f"{API_SERVER_URL}/admin/skills/custom/{skill.id}/grants",
-            json={"group_ids": group_ids},
+    ) -> SkillResponse:
+        share_req = SkillShareRequest(
+            group_shares=[
+                SkillGroupShareRequest(
+                    group_id=group_id,
+                    permission=SkillSharePermission.VIEWER,
+                )
+                for group_id in group_ids
+            ],
+        )
+        response = client.patch(
+            f"{API_SERVER_URL}/skills/custom/{skill.id}/share",
+            json=share_req.model_dump(mode="json", exclude_none=True),
             headers=user_performing_action.headers,
         )
         response.raise_for_status()
-        data = response.json()
-        return DATestSkill(
-            id=data["id"],
-            slug=data["slug"],
-            name=data["name"],
-            description=data["description"],
-            is_public=data["is_public"],
-            enabled=data["enabled"],
-            granted_group_ids=data.get("granted_group_ids", []),
-            is_personal=data.get("is_personal", False),
-        )
+        return _response_model(response, SkillResponse)
 
     @staticmethod
     def delete_custom(
-        skill: DATestSkill,
+        skill: SkillResponse,
         user_performing_action: DATestUser,
     ) -> None:
         response = client.delete(
-            f"{API_SERVER_URL}/admin/skills/custom/{skill.id}",
+            f"{API_SERVER_URL}/skills/custom/{skill.id}",
             headers=user_performing_action.headers,
         )
         response.raise_for_status()
@@ -177,36 +189,102 @@ class SkillManager:
     @staticmethod
     def list_all(
         user_performing_action: DATestUser,
-    ) -> dict:
-        response = client.get(
-            f"{API_SERVER_URL}/admin/skills",
-            headers=user_performing_action.headers,
-        )
-        response.raise_for_status()
-        return response.json()
-
-    @staticmethod
-    def list_for_user(
-        user_performing_action: DATestUser,
-    ) -> dict:
+    ) -> SkillsList:
         response = client.get(
             f"{API_SERVER_URL}/skills",
             headers=user_performing_action.headers,
         )
         response.raise_for_status()
-        return response.json()
+        return _response_model(response, SkillsList)
 
     @staticmethod
-    def get_for_user(
-        slug_or_id: str,
+    def list_for_user(
         user_performing_action: DATestUser,
-    ) -> dict:
+    ) -> SkillsList:
         response = client.get(
-            f"{API_SERVER_URL}/skills/{slug_or_id}",
+            f"{API_SERVER_URL}/skills",
             headers=user_performing_action.headers,
         )
         response.raise_for_status()
-        return response.json()
+        return _response_model(response, SkillsList)
+
+    @staticmethod
+    def get_for_user(
+        skill_id: str | UUID,
+        user_performing_action: DATestUser,
+    ) -> SkillResponse:
+        response = client.get(
+            f"{API_SERVER_URL}/skills/{skill_id}",
+            headers=user_performing_action.headers,
+        )
+        response.raise_for_status()
+        return _response_model(response, SkillResponse)
+
+    @staticmethod
+    def preview(
+        skill_id: str | UUID,
+        user_performing_action: DATestUser,
+    ) -> SkillPreviewResponse:
+        response = client.get(
+            f"{API_SERVER_URL}/skills/{skill_id}/preview",
+            headers=user_performing_action.headers,
+        )
+        response.raise_for_status()
+        return _response_model(response, SkillPreviewResponse)
+
+    @staticmethod
+    def get_editable(
+        skill_id: str | UUID,
+        user_performing_action: DATestUser,
+    ) -> SkillEditableDetailResponse:
+        response = client.get(
+            f"{API_SERVER_URL}/skills/custom/{skill_id}/edit",
+            headers=user_performing_action.headers,
+        )
+        response.raise_for_status()
+        return _response_model(response, SkillEditableDetailResponse)
+
+    @staticmethod
+    def share(
+        skill: SkillResponse,
+        user_performing_action: DATestUser,
+        *,
+        is_public: bool | None = None,
+        public_permission: SkillSharePermission | None = None,
+        user_shares: Sequence[SkillUserShareRequest] | None = None,
+        group_shares: Sequence[SkillGroupShareRequest] | None = None,
+    ) -> SkillResponse:
+        share_req = SkillShareRequest(
+            user_shares=list(user_shares) if user_shares is not None else None,
+            group_shares=list(group_shares) if group_shares is not None else None,
+            is_public=is_public,
+            public_permission=public_permission,
+        )
+
+        response = client.patch(
+            f"{API_SERVER_URL}/skills/custom/{skill.id}/share",
+            json=share_req.model_dump(mode="json", exclude_none=True),
+            headers=user_performing_action.headers,
+        )
+        response.raise_for_status()
+        return _response_model(response, SkillResponse)
+
+    @staticmethod
+    def transfer_ownership(
+        skill: SkillResponse,
+        new_owner_user_id: UUID | str,
+        user_performing_action: DATestUser,
+    ) -> SkillResponse:
+        transfer_req = TransferSkillOwnershipRequest(
+            new_owner_user_id=UUID(str(new_owner_user_id))
+        )
+        response = client.post(
+            f"{API_SERVER_URL}/skills/custom/{skill.id}/transfer-ownership",
+            json=transfer_req.model_dump(mode="json"),
+            headers=user_performing_action.headers,
+        )
+        response.raise_for_status()
+        return _response_model(response, SkillResponse)
 
     @staticmethod
     def create_personal(
@@ -217,7 +295,7 @@ class SkillManager:
         description: str | None = None,
         bundle_bytes: bytes | None = None,
         filename: str | None = None,
-    ) -> DATestSkill:
+    ) -> SkillResponse:
         slug = slug or f"personal-skill-{uuid4().hex[:8]}"
         if bundle_bytes is None:
             bundle_bytes = build_minimal_bundle(
@@ -239,24 +317,14 @@ class SkillManager:
             headers=headers,
         )
         response.raise_for_status()
-        data = response.json()
-        return DATestSkill(
-            id=data["id"],
-            slug=data["slug"],
-            name=data["name"],
-            description=data["description"],
-            is_public=data["is_public"],
-            enabled=data["enabled"],
-            granted_group_ids=data.get("granted_group_ids", []),
-            is_personal=data.get("is_personal", False),
-        )
+        return _response_model(response, SkillResponse)
 
     @staticmethod
     def replace_personal_bundle(
-        skill: DATestSkill,
+        skill: SkillResponse,
         bundle_bytes: bytes,
         user_performing_action: DATestUser,
-    ) -> DATestSkill:
+    ) -> SkillResponse:
         headers = dict(user_performing_action.headers)
         headers.pop("Content-Type", None)
 
@@ -272,46 +340,28 @@ class SkillManager:
             headers=headers,
         )
         response.raise_for_status()
-        data = response.json()
-        return DATestSkill(
-            id=data["id"],
-            slug=data["slug"],
-            name=data["name"],
-            description=data["description"],
-            is_public=data["is_public"],
-            enabled=data["enabled"],
-            granted_group_ids=data.get("granted_group_ids", []),
-            is_personal=data.get("is_personal", False),
-        )
+        return _response_model(response, SkillResponse)
 
     @staticmethod
     def patch_personal(
-        skill: DATestSkill,
+        skill: SkillResponse,
         user_performing_action: DATestUser,
-        *,
-        enabled: bool,
-    ) -> DATestSkill:
+        patch_req: SkillPatchRequest,
+    ) -> SkillResponse:
         response = client.patch(
             f"{API_SERVER_URL}/skills/custom/{skill.id}",
-            json={"enabled": enabled},
+            json=patch_req.model_dump(
+                mode="json",
+                exclude_unset=True,
+            ),
             headers=user_performing_action.headers,
         )
         response.raise_for_status()
-        data = response.json()
-        return DATestSkill(
-            id=data["id"],
-            slug=data["slug"],
-            name=data["name"],
-            description=data["description"],
-            is_public=data["is_public"],
-            enabled=data["enabled"],
-            granted_group_ids=data.get("granted_group_ids", []),
-            is_personal=data.get("is_personal", False),
-        )
+        return _response_model(response, SkillResponse)
 
     @staticmethod
     def delete_personal(
-        skill: DATestSkill,
+        skill: SkillResponse,
         user_performing_action: DATestUser,
     ) -> None:
         response = client.delete(

--- a/backend/tests/integration/common_utils/test_models.py
+++ b/backend/tests/integration/common_utils/test_models.py
@@ -317,14 +317,3 @@ class DATestDiscordChannelConfig(BaseModel):
     thread_only_mode: bool = False
     require_bot_invocation: bool = True
     persona_override_id: int | None = None
-
-
-class DATestSkill(BaseModel):
-    id: UUID | None = None
-    slug: str
-    name: str
-    description: str
-    is_public: bool = False
-    enabled: bool = True
-    granted_group_ids: list[int] = Field(default_factory=list)
-    is_personal: bool = False

--- a/backend/tests/integration/tests/craft/k8s/test_skill_push.py
+++ b/backend/tests/integration/tests/craft/k8s/test_skill_push.py
@@ -18,6 +18,7 @@ from onyx.configs.constants import DocumentSource
 from onyx.db.enums import AccessType
 from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.enums import SandboxStatus
+from onyx.db.enums import SkillSharePermission
 from onyx.db.models import Connector
 from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import Credential
@@ -29,6 +30,9 @@ from onyx.db.models import UserGroup
 from onyx.db.models import UserGroup__ConnectorCredentialPair
 from onyx.server.features.build.configs import SANDBOX_BACKEND
 from onyx.server.features.build.configs import SandboxBackend
+from onyx.server.features.skill.models import SkillPatchRequest
+from onyx.server.features.skill.models import SkillResponse
+from onyx.server.features.skill.models import SkillUserShareRequest
 from onyx.skills import built_in as built_in_module
 from onyx.skills.built_in import BuiltInSkillDefinition
 from onyx.skills.push import build_skills_fileset_for_user
@@ -36,7 +40,6 @@ from onyx.skills.push import push_skill_to_affected_sandboxes
 from tests.integration.common_utils.managers.skill import SkillManager
 from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.managers.user_group import UserGroupManager
-from tests.integration.common_utils.test_models import DATestSkill
 from tests.integration.common_utils.test_models import DATestUser
 from tests.integration.common_utils.test_models import DATestUserGroup
 from tests.integration.tests.craft.k8s.k8s_fixtures import SandboxHandle
@@ -85,7 +88,7 @@ def _create_skill(
     body: bytes | str,
     is_public: bool = False,
     group_ids: list[int] | None = None,
-) -> DATestSkill:
+) -> SkillResponse:
     return SkillManager.create_custom(
         admin,
         slug=slug,
@@ -98,10 +101,10 @@ def _create_skill(
 
 def _replace_bundle(
     admin: DATestUser,
-    skill: DATestSkill,
+    skill: SkillResponse,
     *,
     body: bytes | str,
-) -> DATestSkill:
+) -> SkillResponse:
     return SkillManager.replace_bundle(
         skill,
         _bundle(skill.slug, body),
@@ -197,7 +200,7 @@ def _make_built_in_skill_row(db_session: Session, *, built_in_skill_id: str) -> 
         built_in_skill_id=built_in_skill_id,
         bundle_file_id=None,
         bundle_sha256=None,
-        is_public=True,
+        public_permission=SkillSharePermission.VIEWER,
         enabled=True,
     )
     db_session.add(skill)
@@ -242,7 +245,7 @@ def _seed_custom_skill(
         description=f"Seeded skill {slug}",
         bundle_file_id=bundle_file_id,
         bundle_sha256=hashlib.sha256(bundle_bytes).hexdigest(),
-        is_public=public,
+        public_permission=SkillSharePermission.VIEWER if public else None,
         enabled=True,
     )
     db_session.add(skill)
@@ -338,7 +341,7 @@ class TestSkillPush:
                 b"public skill body\n",
             )
 
-    def test_private_skill_only_lands_in_granted_users_sandboxes(
+    def test_private_skill_only_lands_in_shared_users_sandboxes(
         self,
         k8s_admin_user: DATestUser,
         running_sandbox: Callable[..., SandboxHandle],
@@ -389,11 +392,13 @@ class TestSkillPush:
         )
         _skill_file_path(workspace, skill.slug).wait_for_bytes(b"to be disabled\n")
 
-        SkillManager.patch_custom(skill, k8s_admin_user, enabled=False)
+        SkillManager.patch_custom(
+            skill, k8s_admin_user, SkillPatchRequest(enabled=False)
+        )
 
         (_skills_dir(workspace) / skill.slug).wait_for_absent()
 
-    def test_grants_change_adds_to_newly_granted_and_removes_from_revoked(
+    def test_share_change_adds_to_newly_shared_and_removes_from_revoked(
         self,
         k8s_admin_user: DATestUser,
         running_sandbox: Callable[..., SandboxHandle],
@@ -411,21 +416,69 @@ class TestSkillPush:
             [user_b.id],
         )
 
-        slug = f"grants-flip-{uuid4().hex[:6]}"
+        slug = f"shares-flip-{uuid4().hex[:6]}"
         skill = _create_skill(
             k8s_admin_user,
             slug,
             is_public=False,
             group_ids=[group_x.id],
-            body="shifting grants\n",
+            body="shifting shares\n",
         )
-        _skill_file_path(ws_a, skill.slug).wait_for_bytes(b"shifting grants\n")
+        _skill_file_path(ws_a, skill.slug).wait_for_bytes(b"shifting shares\n")
         _skill_file_path(ws_b, skill.slug).wait_for_absent()
 
-        SkillManager.replace_grants(skill, [group_y.id], k8s_admin_user)
+        SkillManager.replace_group_shares(skill, [group_y.id], k8s_admin_user)
 
         _skill_file_path(ws_a, skill.slug).wait_for_absent()
-        _skill_file_path(ws_b, skill.slug).wait_for_bytes(b"shifting grants\n")
+        _skill_file_path(ws_b, skill.slug).wait_for_bytes(b"shifting shares\n")
+
+    def test_direct_user_share_change_adds_to_newly_shared_and_removes_from_revoked(
+        self,
+        k8s_admin_user: DATestUser,
+        running_sandbox: Callable[..., SandboxHandle],
+    ) -> None:
+        handle = running_sandbox()
+        user_a, user_b = _create_users(2)
+        [ws_a, ws_b] = handle.provision_api_users([user_a, user_b])
+
+        slug = f"direct-shares-flip-{uuid4().hex[:6]}"
+        skill = _create_skill(
+            k8s_admin_user,
+            slug,
+            is_public=False,
+            body="direct shifting shares\n",
+        )
+        _skill_file_path(ws_a, skill.slug).wait_for_absent()
+        _skill_file_path(ws_b, skill.slug).wait_for_absent()
+
+        skill = SkillManager.share(
+            skill,
+            k8s_admin_user,
+            user_shares=[
+                SkillUserShareRequest(
+                    user_id=UUID(user_a.id),
+                    permission=SkillSharePermission.VIEWER,
+                )
+            ],
+        )
+        assert [str(share.user.id) for share in skill.user_shares] == [user_a.id]
+        _skill_file_path(ws_a, skill.slug).wait_for_bytes(b"direct shifting shares\n")
+        _skill_file_path(ws_b, skill.slug).wait_for_absent()
+
+        skill = SkillManager.share(
+            skill,
+            k8s_admin_user,
+            user_shares=[
+                SkillUserShareRequest(
+                    user_id=UUID(user_b.id),
+                    permission=SkillSharePermission.VIEWER,
+                )
+            ],
+        )
+        assert [str(share.user.id) for share in skill.user_shares] == [user_b.id]
+
+        _skill_file_path(ws_a, skill.slug).wait_for_absent()
+        _skill_file_path(ws_b, skill.slug).wait_for_bytes(b"direct shifting shares\n")
 
     def test_replace_bundle_propagates_new_content(
         self,
@@ -473,7 +526,7 @@ class TestSkillPush:
         (_skills_dir(ws_a) / skill.slug).wait_for_absent()
         (_skills_dir(ws_b) / skill.slug).wait_for_absent()
 
-    def test_user_with_overlapping_grants_receives_skill_once(
+    def test_user_with_overlapping_shares_receives_skill_once(
         self,
         k8s_admin_user: DATestUser,
         running_sandbox: Callable[..., SandboxHandle],
@@ -491,7 +544,7 @@ class TestSkillPush:
             [user.id],
         )
 
-        slug = f"dup-grants-{uuid4().hex[:6]}"
+        slug = f"dup-shares-{uuid4().hex[:6]}"
         skill = _create_skill(
             k8s_admin_user,
             slug,

--- a/backend/tests/integration/tests/skills/test_skills_admin.py
+++ b/backend/tests/integration/tests/skills/test_skills_admin.py
@@ -15,6 +15,7 @@ from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.models import FileRecord
 from onyx.db.models import Skill
 from onyx.file_store.file_store import get_default_file_store
+from onyx.server.features.skill.models import SkillPatchRequest
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.http_client import client
 from tests.integration.common_utils.managers.skill import build_minimal_bundle
@@ -66,22 +67,25 @@ def _skill_bundle_blob_ids() -> set[str]:
 def test_create_and_list_skill(admin_user: DATestUser) -> None:
     slug = f"test-create-{uuid4().hex[:6]}"
     skill = SkillManager.create_custom(admin_user, slug=slug)
-    assert skill.id is not None
     assert skill.slug == slug
     assert skill.enabled is True
 
     skills_list = SkillManager.list_all(admin_user)
-    custom_slugs = [c["slug"] for c in skills_list["customs"]]
+    custom_slugs = [skill.slug for skill in skills_list.customs]
     assert slug in custom_slugs
 
 
 def test_patch_skill_metadata(admin_user: DATestUser) -> None:
     skill = SkillManager.create_custom(admin_user, slug=f"patch-test-{uuid4().hex[:6]}")
 
-    public = SkillManager.patch_custom(skill, admin_user, is_public=True)
+    public = SkillManager.patch_custom(
+        skill, admin_user, SkillPatchRequest(is_public=True)
+    )
     assert public.is_public is True
 
-    disabled = SkillManager.patch_custom(skill, admin_user, enabled=False)
+    disabled = SkillManager.patch_custom(
+        skill, admin_user, SkillPatchRequest(enabled=False)
+    )
     assert disabled.enabled is False
 
 
@@ -108,7 +112,7 @@ def test_delete_skill(admin_user: DATestUser) -> None:
     SkillManager.delete_custom(skill, admin_user)
 
     skills_list = SkillManager.list_all(admin_user)
-    custom_slugs = [c["slug"] for c in skills_list["customs"]]
+    custom_slugs = [skill.slug for skill in skills_list.customs]
     assert slug not in custom_slugs
 
 
@@ -141,12 +145,12 @@ def test_bundle_with_template_rejected(admin_user: DATestUser) -> None:
     assert exc_info.value.response.status_code == 400
 
 
-def test_grants_replace(admin_user: DATestUser) -> None:
+def test_group_shares_replace(admin_user: DATestUser) -> None:
     skill = SkillManager.create_custom(
-        admin_user, slug=f"grants-test-{uuid4().hex[:6]}", is_public=False
+        admin_user, slug=f"group-shares-test-{uuid4().hex[:6]}", is_public=False
     )
-    updated = SkillManager.replace_grants(skill, [], admin_user)
-    assert updated.granted_group_ids == []
+    updated = SkillManager.replace_group_shares(skill, [], admin_user)
+    assert updated.group_shares == []
 
 
 def test_metadata_from_bundle_frontmatter(admin_user: DATestUser) -> None:
@@ -188,11 +192,11 @@ def test_bad_filename_rejected(admin_user: DATestUser) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_create_skill_201_persists_row_grants_bundle(
+def test_create_skill_201_persists_row_group_shares_bundle(
     admin_user: DATestUser,
 ) -> None:
-    """POST → row persisted with bundle blob and grants visible in DB."""
-    group = UserGroupManager.create(admin_user, name="create-grants-group")
+    """POST -> row persisted with bundle blob and group shares visible in DB."""
+    group = UserGroupManager.create(admin_user, name="create-shares-group")
 
     slug = f"persist-{uuid4().hex[:8]}"
     skill = SkillManager.create_custom(
@@ -202,13 +206,12 @@ def test_create_skill_201_persists_row_grants_bundle(
         group_ids=[group.id],
     )
 
-    assert skill.id is not None
-    assert skill.granted_group_ids == [group.id]
+    assert [share.group_id for share in skill.group_shares] == [group.id]
 
     row = _fetch_skill_row(skill.id)
     assert row is not None, "skill row missing after create"
     assert row.slug == slug
-    assert row.is_public is False
+    assert row.public_permission is None
     assert row.enabled is True
     assert row.bundle_file_id, "skill row has no bundle_file_id"
     assert _bundle_blob_exists(row.bundle_file_id), (
@@ -302,7 +305,7 @@ def test_create_skill_failure_cleans_up_orphan_blob(
 
     # First create — succeeds and saves blob #1.
     first = SkillManager.create_custom(admin_user, slug=slug)
-    first_row = _fetch_skill_row(first.id) if first.id is not None else None
+    first_row = _fetch_skill_row(first.id)
     assert first_row is not None
     first_blob_id = first_row.bundle_file_id
     assert first_blob_id is not None  # custom skills always have a bundle
@@ -344,11 +347,13 @@ def test_create_skill_failure_cleans_up_orphan_blob(
 
 
 # ---------------------------------------------------------------------------
-# Grants
+# Sharing
 # ---------------------------------------------------------------------------
 
 
-def test_replace_grants_400_on_unknown_group_id(admin_user: DATestUser) -> None:
+def test_replace_group_shares_400_on_unknown_group_id(
+    admin_user: DATestUser,
+) -> None:
     """Unknown group id → 400 with a message that names the failure mode.
 
     Regression for SHA `c5e427ceab`: FK violations must surface as a 400
@@ -359,7 +364,7 @@ def test_replace_grants_400_on_unknown_group_id(admin_user: DATestUser) -> None:
     )
 
     with pytest.raises(httpx.HTTPStatusError) as exc_info:
-        SkillManager.replace_grants(skill, [10_000_000], admin_user)
+        SkillManager.replace_group_shares(skill, [10_000_000], admin_user)
 
     response = exc_info.value.response
     assert response.status_code == 400
@@ -378,7 +383,7 @@ def test_replace_grants_400_on_unknown_group_id(admin_user: DATestUser) -> None:
 def test_delete_skill_404_for_nonexistent(admin_user: DATestUser) -> None:
     bogus_id = uuid4()
     response = client.delete(
-        f"{API_SERVER_URL}/admin/skills/custom/{bogus_id}",
+        f"{API_SERVER_URL}/skills/custom/{bogus_id}",
         headers=admin_user.headers,
     )
     assert response.status_code == 404
@@ -389,28 +394,19 @@ def test_delete_skill_404_for_nonexistent(admin_user: DATestUser) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_non_admin_returns_403_on_post(basic_user: DATestUser) -> None:
-    with pytest.raises(httpx.HTTPStatusError) as exc_info:
-        SkillManager.create_custom(basic_user, slug=f"forbid-{uuid4().hex[:6]}")
-    assert exc_info.value.response.status_code == 403
-
-
-def test_non_admin_returns_403_on_admin_list(basic_user: DATestUser) -> None:
-    response = client.get(
-        f"{API_SERVER_URL}/admin/skills",
-        headers=basic_user.headers,
+def test_basic_user_can_create_private_skill(basic_user: DATestUser) -> None:
+    skill = SkillManager.create_custom(
+        basic_user, slug=f"basic-create-{uuid4().hex[:6]}"
     )
-    assert response.status_code == 403
+    assert skill.is_public is False
+    assert skill.user_permission == "OWNER"
 
 
 def test_curator_can_post_skill(
     admin_user: DATestUser,
     basic_user: DATestUser,
 ) -> None:
-    """Curators are accepted by the admin-skills endpoints.
-
-    Pins current behavior — see `craft-risks.md` §2.4.
-    """
+    """Curators can create through the same user-facing endpoint."""
     curator = UserManager.set_role(
         user_to_set=basic_user,
         target_role=UserRole.CURATOR,
@@ -421,7 +417,6 @@ def test_curator_can_post_skill(
         skill = SkillManager.create_custom(
             curator, slug=f"curator-create-{uuid4().hex[:6]}"
         )
-        assert skill.id is not None
         assert skill.enabled is True
     finally:
         # restore so module-shared basic_user fixture stays BASIC

--- a/backend/tests/integration/tests/skills/test_skills_management.py
+++ b/backend/tests/integration/tests/skills/test_skills_management.py
@@ -1,0 +1,428 @@
+from __future__ import annotations
+
+from uuid import UUID
+from uuid import uuid4
+
+import httpx
+import pytest
+
+from onyx.db.enums import SkillAccessLevel
+from onyx.db.enums import SkillSharePermission
+from onyx.server.features.skill.models import SkillPatchRequest
+from onyx.server.features.skill.models import SkillResponse
+from onyx.server.features.skill.models import SkillUserShareRequest
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.http_client import client
+from tests.integration.common_utils.managers.skill import SkillManager
+from tests.integration.common_utils.managers.user import UserManager
+from tests.integration.common_utils.test_models import DATestUser
+
+
+def _assert_skill_hidden(skill_id: object, user: DATestUser) -> None:
+    response = client.get(
+        f"{API_SERVER_URL}/skills/{skill_id}",
+        headers=user.headers,
+    )
+    assert response.status_code == 404
+
+
+def _assert_edit_hidden(skill_id: object, user: DATestUser) -> None:
+    response = client.get(
+        f"{API_SERVER_URL}/skills/custom/{skill_id}/edit",
+        headers=user.headers,
+    )
+    assert response.status_code == 404
+
+
+def _skill_id(skill: SkillResponse) -> UUID:
+    return skill.id
+
+
+def test_edit_fetch_returns_instructions_and_share_details(
+    basic_user: DATestUser,
+    admin_user: DATestUser,  # noqa: ARG001
+) -> None:
+    editor = UserManager.create(name=f"skill_editor_{uuid4().hex[:8]}")
+    viewer = UserManager.create(name=f"skill_viewer_{uuid4().hex[:8]}")
+    stranger = UserManager.create(name=f"skill_stranger_{uuid4().hex[:8]}")
+    skill = SkillManager.create_custom(
+        basic_user,
+        slug=f"edit-fetch-{uuid4().hex[:6]}",
+    )
+    skill_id = _skill_id(skill)
+
+    shared = SkillManager.share(
+        skill,
+        basic_user,
+        user_shares=[
+            SkillUserShareRequest(
+                user_id=UUID(editor.id),
+                permission=SkillSharePermission.EDITOR,
+            ),
+            SkillUserShareRequest(
+                user_id=UUID(viewer.id),
+                permission=SkillSharePermission.VIEWER,
+            ),
+        ],
+    )
+    assert len(shared.user_shares) == 2
+
+    owner_editable = SkillManager.get_editable(skill_id, basic_user)
+    assert owner_editable.user_permission == SkillAccessLevel.OWNER
+    assert owner_editable.instructions_markdown == "Skill instructions."
+
+    editable = SkillManager.get_editable(skill_id, editor)
+    assert editable.id == skill_id
+    assert editable.user_permission == SkillAccessLevel.EDITOR
+    assert editable.instructions_markdown == "Skill instructions."
+    assert {share.permission for share in editable.user_shares} == {
+        SkillSharePermission.EDITOR,
+        SkillSharePermission.VIEWER,
+    }
+
+    _assert_edit_hidden(skill_id, viewer)
+    _assert_edit_hidden(skill_id, stranger)
+
+
+def test_preview_returns_instructions_without_share_details(
+    basic_user: DATestUser,
+    admin_user: DATestUser,  # noqa: ARG001
+) -> None:
+    viewer = UserManager.create(name=f"skill_preview_viewer_{uuid4().hex[:8]}")
+    skill = SkillManager.create_custom(
+        basic_user,
+        slug=f"preview-custom-{uuid4().hex[:6]}",
+        name="Preview Skill",
+        description="Preview description",
+    )
+    skill_id = _skill_id(skill)
+    SkillManager.share(
+        skill,
+        basic_user,
+        user_shares=[
+            SkillUserShareRequest(
+                user_id=UUID(viewer.id),
+                permission=SkillSharePermission.VIEWER,
+            )
+        ],
+    )
+
+    preview = SkillManager.preview(skill_id, viewer)
+
+    assert preview.source == "custom"
+    assert preview.id == skill_id
+    assert preview.name == "Preview Skill"
+    assert preview.description == "Preview description"
+    assert preview.instructions_markdown == "Skill instructions."
+    assert not hasattr(preview, "user_shares")
+    assert not hasattr(preview, "group_shares")
+    assert not hasattr(preview, "user_permission")
+
+
+def test_builtin_preview_returns_instructions(basic_user: DATestUser) -> None:
+    builtins = SkillManager.list_for_user(basic_user).builtins
+    assert builtins
+
+    preview = SkillManager.preview(builtins[0].id, basic_user)
+
+    assert preview.source == "builtin"
+    assert preview.id == builtins[0].id
+    assert preview.instructions_markdown.strip()
+
+
+def test_patch_details_rewrites_bundle_without_changing_slug(
+    basic_user: DATestUser,
+) -> None:
+    slug = f"patch-details-{uuid4().hex[:6]}"
+    skill = SkillManager.create_custom(
+        basic_user,
+        slug=slug,
+        name="Original Name",
+        description="Original description",
+    )
+    skill_id = _skill_id(skill)
+
+    updated = SkillManager.patch_custom(
+        skill,
+        basic_user,
+        SkillPatchRequest(
+            name="Updated Name",
+            description="Updated description",
+            instructions_markdown="# Updated instructions\n\nUse the revised workflow.",
+        ),
+    )
+
+    assert updated.slug == slug
+    assert updated.name == "Updated Name"
+    assert updated.description == "Updated description"
+
+    editable = SkillManager.get_editable(skill_id, basic_user)
+    assert editable.name == "Updated Name"
+    assert editable.description == "Updated description"
+    assert editable.instructions_markdown == (
+        "# Updated instructions\n\nUse the revised workflow."
+    )
+
+    preview = SkillManager.preview(skill_id, basic_user)
+    assert preview.name == "Updated Name"
+    assert preview.description == "Updated description"
+    assert preview.instructions_markdown == (
+        "# Updated instructions\n\nUse the revised workflow."
+    )
+
+
+def test_direct_viewer_share_grants_view_not_edit(
+    basic_user: DATestUser,
+    admin_user: DATestUser,  # noqa: ARG001
+) -> None:
+    viewer = UserManager.create(name=f"skill_direct_viewer_{uuid4().hex[:8]}")
+    skill = SkillManager.create_custom(
+        basic_user,
+        slug=f"direct-viewer-{uuid4().hex[:6]}",
+    )
+    skill_id = _skill_id(skill)
+
+    shared = SkillManager.share(
+        skill,
+        basic_user,
+        user_shares=[
+            SkillUserShareRequest(
+                user_id=UUID(viewer.id),
+                permission=SkillSharePermission.VIEWER,
+            )
+        ],
+    )
+
+    assert len(shared.user_shares) == 1
+    assert str(shared.user_shares[0].user.id) == viewer.id
+    assert shared.user_shares[0].user.email == viewer.email
+    assert shared.user_shares[0].permission == SkillSharePermission.VIEWER
+    visible = SkillManager.get_for_user(str(skill_id), viewer)
+    assert visible.user_permission == SkillAccessLevel.VIEWER
+    assert visible.is_personal is False
+    _assert_edit_hidden(skill_id, viewer)
+
+
+def test_direct_editor_share_grants_edit(
+    basic_user: DATestUser,
+    admin_user: DATestUser,  # noqa: ARG001
+) -> None:
+    editor = UserManager.create(name=f"skill_direct_editor_{uuid4().hex[:8]}")
+    skill = SkillManager.create_custom(
+        basic_user,
+        slug=f"direct-editor-{uuid4().hex[:6]}",
+    )
+    skill_id = _skill_id(skill)
+
+    SkillManager.share(
+        skill,
+        basic_user,
+        user_shares=[
+            SkillUserShareRequest(
+                user_id=UUID(editor.id),
+                permission=SkillSharePermission.EDITOR,
+            )
+        ],
+    )
+
+    editable = SkillManager.get_editable(skill_id, editor)
+    assert editable.user_permission == SkillAccessLevel.EDITOR
+    assert editable.instructions_markdown == "Skill instructions."
+
+
+def test_org_wide_editor_permission_grants_edit(
+    basic_user: DATestUser,
+    admin_user: DATestUser,  # noqa: ARG001
+) -> None:
+    other_user = UserManager.create(name=f"skill_org_editor_{uuid4().hex[:8]}")
+    skill = SkillManager.create_custom(
+        basic_user,
+        slug=f"org-editor-{uuid4().hex[:6]}",
+    )
+    skill_id = _skill_id(skill)
+
+    public_viewer = SkillManager.share(
+        skill,
+        basic_user,
+        is_public=True,
+        public_permission=SkillSharePermission.VIEWER,
+    )
+    assert public_viewer.is_public is True
+    assert public_viewer.public_permission == SkillSharePermission.VIEWER
+    _assert_edit_hidden(skill_id, other_user)
+
+    public_editor = SkillManager.share(
+        skill,
+        basic_user,
+        is_public=True,
+        public_permission=SkillSharePermission.EDITOR,
+    )
+
+    assert public_editor.is_public is True
+    assert public_editor.public_permission == SkillSharePermission.EDITOR
+    editable = SkillManager.get_editable(skill_id, other_user)
+    assert editable.user_permission == SkillAccessLevel.EDITOR
+
+
+def test_switching_from_org_wide_to_scoped_share_removes_org_visibility(
+    basic_user: DATestUser,
+    admin_user: DATestUser,  # noqa: ARG001
+) -> None:
+    shared_user = UserManager.create(name=f"skill_scoped_user_{uuid4().hex[:8]}")
+    unshared_user = UserManager.create(name=f"skill_unscoped_user_{uuid4().hex[:8]}")
+    skill = SkillManager.create_custom(
+        basic_user,
+        slug=f"scoped-share-{uuid4().hex[:6]}",
+    )
+    skill_id = _skill_id(skill)
+
+    SkillManager.share(skill, basic_user, is_public=True)
+    assert SkillManager.get_for_user(str(skill_id), unshared_user).id == skill_id
+
+    scoped = SkillManager.share(
+        skill,
+        basic_user,
+        is_public=False,
+        user_shares=[
+            SkillUserShareRequest(
+                user_id=UUID(shared_user.id),
+                permission=SkillSharePermission.VIEWER,
+            )
+        ],
+    )
+
+    assert scoped.is_public is False
+    assert [str(share.user.id) for share in scoped.user_shares] == [shared_user.id]
+    assert SkillManager.get_for_user(str(skill_id), shared_user).id == skill_id
+    _assert_skill_hidden(skill_id, unshared_user)
+
+
+def test_owner_transfer_demotes_previous_owner_and_promotes_new_owner(
+    basic_user: DATestUser,
+    admin_user: DATestUser,  # noqa: ARG001
+) -> None:
+    new_owner = UserManager.create(name=f"skill_new_owner_{uuid4().hex[:8]}")
+    skill = SkillManager.create_custom(
+        basic_user,
+        slug=f"transfer-owner-{uuid4().hex[:6]}",
+    )
+    skill_id = _skill_id(skill)
+    SkillManager.share(
+        skill,
+        basic_user,
+        user_shares=[
+            SkillUserShareRequest(
+                user_id=UUID(new_owner.id),
+                permission=SkillSharePermission.VIEWER,
+            )
+        ],
+    )
+
+    old_owner_response = SkillManager.transfer_ownership(
+        skill,
+        new_owner.id,
+        basic_user,
+    )
+
+    assert old_owner_response.author_user_id is not None
+    assert str(old_owner_response.author_user_id) == new_owner.id
+    assert old_owner_response.user_permission == SkillAccessLevel.EDITOR
+    assert len(old_owner_response.user_shares) == 1
+    assert str(old_owner_response.user_shares[0].user.id) == basic_user.id
+    assert old_owner_response.user_shares[0].user.email == basic_user.email
+    assert old_owner_response.user_shares[0].permission == SkillSharePermission.EDITOR
+
+    new_owner_response = SkillManager.get_for_user(str(skill_id), new_owner)
+    assert new_owner_response.author_user_id == UUID(new_owner.id)
+    assert new_owner_response.user_permission == SkillAccessLevel.OWNER
+
+
+@pytest.mark.parametrize(
+    "permission",
+    [SkillSharePermission.VIEWER, SkillSharePermission.EDITOR],
+)
+def test_sharee_cannot_transfer_ownership(
+    basic_user: DATestUser,
+    admin_user: DATestUser,  # noqa: ARG001
+    permission: SkillSharePermission,
+) -> None:
+    sharee = UserManager.create(name=f"skill_transfer_sharee_{uuid4().hex[:8]}")
+    target = UserManager.create(name=f"skill_transfer_target_{uuid4().hex[:8]}")
+    skill = SkillManager.create_custom(
+        basic_user,
+        slug=f"transfer-deny-{permission.lower()}-{uuid4().hex[:6]}",
+    )
+    SkillManager.share(
+        skill,
+        basic_user,
+        user_shares=[
+            SkillUserShareRequest(user_id=UUID(sharee.id), permission=permission)
+        ],
+    )
+
+    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+        SkillManager.transfer_ownership(skill, target.id, sharee)
+
+    assert exc_info.value.response.status_code == 403
+
+
+def test_transfer_rejects_missing_and_inactive_targets(
+    basic_user: DATestUser,
+    admin_user: DATestUser,
+) -> None:
+    inactive_target = UserManager.create(
+        name=f"skill_inactive_target_{uuid4().hex[:8]}"
+    )
+    inactive_target = UserManager.set_status(
+        inactive_target,
+        False,
+        admin_user,
+    )
+    skill = SkillManager.create_custom(
+        basic_user,
+        slug=f"transfer-target-{uuid4().hex[:6]}",
+    )
+    skill_id = _skill_id(skill)
+
+    missing_response = client.post(
+        f"{API_SERVER_URL}/skills/custom/{skill_id}/transfer-ownership",
+        json={"new_owner_user_id": str(uuid4())},
+        headers=basic_user.headers,
+    )
+    assert missing_response.status_code == 404
+
+    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+        SkillManager.transfer_ownership(skill, inactive_target.id, basic_user)
+
+    assert exc_info.value.response.status_code == 400
+
+
+def test_admin_transfers_vacant_skill_but_not_owned_skill(
+    admin_user: DATestUser,
+) -> None:
+    owner = UserManager.create(name=f"skill_transfer_owner_{uuid4().hex[:8]}")
+    target = UserManager.create(name=f"skill_admin_target_{uuid4().hex[:8]}")
+    owned_skill = SkillManager.create_custom(
+        owner,
+        slug=f"admin-owned-transfer-{uuid4().hex[:6]}",
+    )
+    owned_skill_id = _skill_id(owned_skill)
+
+    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+        SkillManager.transfer_ownership(owned_skill, target.id, admin_user)
+    assert exc_info.value.response.status_code == 403
+
+    inactive_owner = UserManager.set_status(owner, False, admin_user)
+    try:
+        vacant_response = SkillManager.transfer_ownership(
+            owned_skill,
+            target.id,
+            admin_user,
+        )
+    finally:
+        UserManager.set_status(inactive_owner, True, admin_user)
+
+    assert vacant_response.author_user_id is not None
+    assert str(vacant_response.author_user_id) == target.id
+    new_owner_response = SkillManager.get_for_user(str(owned_skill_id), target)
+    assert new_owner_response.user_permission == SkillAccessLevel.OWNER

--- a/backend/tests/integration/tests/skills/test_skills_personal.py
+++ b/backend/tests/integration/tests/skills/test_skills_personal.py
@@ -3,8 +3,7 @@
 Covers the user-facing ``POST /skills/custom``,
 ``PUT /skills/custom/{id}/bundle``, and ``DELETE /skills/custom/{id}``
 endpoints: ownership/visibility rules, reserved slugs, duplicate slugs,
-promotion to org-wide, admin disable as a reversible mute, and the
-per-user cap.
+promotion to org-wide, and admin disable as a reversible mute.
 """
 
 from __future__ import annotations
@@ -14,7 +13,7 @@ from uuid import uuid4
 import httpx
 import pytest
 
-from onyx.configs.app_configs import MAX_PERSONAL_SKILLS_PER_USER
+from onyx.server.features.skill.models import SkillPatchRequest
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.http_client import client
 from tests.integration.common_utils.managers.skill import build_minimal_bundle
@@ -30,7 +29,7 @@ def other_basic_user(admin_user: DATestUser) -> DATestUser:  # noqa: ARG001
 
 
 def _user_custom_slugs(user: DATestUser) -> list[str]:
-    return [c["slug"] for c in SkillManager.list_for_user(user)["customs"]]
+    return [skill.slug for skill in SkillManager.list_for_user(user).customs]
 
 
 def test_create_personal_skill_visibility(
@@ -43,18 +42,12 @@ def test_create_personal_skill_visibility(
     assert skill.is_personal is True
     assert skill.is_public is False
 
-    own_list = SkillManager.list_for_user(basic_user)["customs"]
-    mine = [c for c in own_list if c["slug"] == slug]
+    own_list = SkillManager.list_for_user(basic_user).customs
+    mine = [skill for skill in own_list if skill.slug == slug]
     assert len(mine) == 1
-    assert mine[0]["is_personal"] is True
+    assert mine[0].is_personal is True
 
     assert slug not in _user_custom_slugs(other_basic_user)
-
-    response = client.get(
-        f"{API_SERVER_URL}/skills/{slug}",
-        headers=other_basic_user.headers,
-    )
-    assert response.status_code == 404
 
     response = client.get(
         f"{API_SERVER_URL}/skills/{skill.id}",
@@ -62,19 +55,19 @@ def test_create_personal_skill_visibility(
     )
     assert response.status_code == 404
 
-    admin_customs = SkillManager.list_all(admin_user)["customs"]
-    admin_match = [c for c in admin_customs if c["slug"] == slug]
+    admin_customs = SkillManager.list_all(admin_user).customs
+    admin_match = [skill for skill in admin_customs if skill.slug == slug]
     assert len(admin_match) == 1
-    assert admin_match[0]["is_personal"] is True
+    assert admin_match[0].is_personal is True
 
 
 def test_owner_can_fetch_own_personal_skill(basic_user: DATestUser) -> None:
     slug = f"personal-fetch-{uuid4().hex[:6]}"
-    SkillManager.create_personal(basic_user, slug=slug)
+    skill = SkillManager.create_personal(basic_user, slug=slug)
 
-    fetched = SkillManager.get_for_user(slug, basic_user)
-    assert fetched["slug"] == slug
-    assert fetched["is_personal"] is True
+    fetched = SkillManager.get_for_user(str(skill.id), basic_user)
+    assert fetched.slug == slug
+    assert fetched.is_personal is True
 
 
 def test_owner_can_replace_bundle_and_delete(basic_user: DATestUser) -> None:
@@ -154,47 +147,50 @@ def test_personal_slug_collides_with_admin_skill_both_directions(
     assert exc_info.value.response.status_code == 409
 
 
-def test_admin_can_hard_delete_personal_skill(
+def test_admin_cannot_hard_delete_personal_skill(
     admin_user: DATestUser,
     basic_user: DATestUser,
 ) -> None:
-    slug = f"personal-admin-kill-{uuid4().hex[:6]}"
+    slug = f"personal-admin-delete-{uuid4().hex[:6]}"
     skill = SkillManager.create_personal(basic_user, slug=slug)
 
-    # admin's hard kill switch (the admin DELETE route) wipes another user's
-    # personal skill outright
-    SkillManager.delete_custom(skill, admin_user)
+    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+        SkillManager.delete_custom(skill, admin_user)
+    assert exc_info.value.response.status_code == 403
 
-    assert slug not in _user_custom_slugs(basic_user)
-    admin_slugs = [c["slug"] for c in SkillManager.list_all(admin_user)["customs"]]
-    assert slug not in admin_slugs
+    assert slug in _user_custom_slugs(basic_user)
+    admin_slugs = [skill.slug for skill in SkillManager.list_all(admin_user).customs]
+    assert slug in admin_slugs
 
 
-def test_promotion_makes_skill_org_wide_and_locks_owner_out(
-    admin_user: DATestUser,
+def test_owner_can_share_org_wide_and_retain_edit_permissions(
     basic_user: DATestUser,
     other_basic_user: DATestUser,
 ) -> None:
     slug = f"personal-promote-{uuid4().hex[:6]}"
     skill = SkillManager.create_personal(basic_user, slug=slug)
 
-    promoted = SkillManager.patch_custom(skill, admin_user, is_public=True)
+    promoted = SkillManager.patch_personal(
+        skill, basic_user, SkillPatchRequest(is_public=True)
+    )
     assert promoted.is_public is True
     assert promoted.is_personal is False
 
-    other_list = SkillManager.list_for_user(other_basic_user)["customs"]
-    visible = [c for c in other_list if c["slug"] == slug]
+    other_list = SkillManager.list_for_user(other_basic_user).customs
+    visible = [skill for skill in other_list if skill.slug == slug]
     assert len(visible) == 1
-    assert visible[0]["is_personal"] is False
+    assert visible[0].is_personal is False
 
-    new_bundle = build_minimal_bundle(slug)
-    with pytest.raises(httpx.HTTPStatusError) as exc_info:
-        SkillManager.replace_personal_bundle(skill, new_bundle, basic_user)
-    assert exc_info.value.response.status_code == 403
+    new_bundle = build_minimal_bundle(
+        slug, name="Retained Owner Edit", description="Owner can still edit"
+    )
+    updated = SkillManager.replace_personal_bundle(skill, new_bundle, basic_user)
+    assert updated.name == "Retained Owner Edit"
 
-    with pytest.raises(httpx.HTTPStatusError) as exc_info:
-        SkillManager.delete_personal(skill, basic_user)
-    assert exc_info.value.response.status_code == 403
+    disabled = SkillManager.patch_personal(
+        skill, basic_user, SkillPatchRequest(enabled=False)
+    )
+    assert disabled.enabled is False
 
 
 def test_owner_can_toggle_personal_skill(
@@ -204,40 +200,46 @@ def test_owner_can_toggle_personal_skill(
     slug = f"personal-toggle-{uuid4().hex[:6]}"
     skill = SkillManager.create_personal(basic_user, slug=slug)
 
-    toggled = SkillManager.patch_personal(skill, basic_user, enabled=False)
+    toggled = SkillManager.patch_personal(
+        skill, basic_user, SkillPatchRequest(enabled=False)
+    )
     assert toggled.enabled is False
     assert toggled.is_personal is True
 
     # still listed for the owner (greyed out in the UI), enabled=False
     own = [
-        c
-        for c in SkillManager.list_for_user(basic_user)["customs"]
-        if c["slug"] == slug
+        skill
+        for skill in SkillManager.list_for_user(basic_user).customs
+        if skill.slug == slug
     ]
     assert len(own) == 1
-    assert own[0]["enabled"] is False
+    assert own[0].enabled is False
 
     # still invisible to everyone else
     assert slug not in _user_custom_slugs(other_basic_user)
     with pytest.raises(httpx.HTTPStatusError) as exc_info:
-        SkillManager.patch_personal(skill, other_basic_user, enabled=True)
+        SkillManager.patch_personal(
+            skill, other_basic_user, SkillPatchRequest(enabled=True)
+        )
     assert exc_info.value.response.status_code == 404
 
-    reenabled = SkillManager.patch_personal(skill, basic_user, enabled=True)
+    reenabled = SkillManager.patch_personal(
+        skill, basic_user, SkillPatchRequest(enabled=True)
+    )
     assert reenabled.enabled is True
 
 
-def test_owner_cannot_toggle_after_promotion(
-    admin_user: DATestUser,
+def test_owner_can_toggle_after_sharing_org_wide(
     basic_user: DATestUser,
 ) -> None:
     slug = f"personal-toggle-promo-{uuid4().hex[:6]}"
     skill = SkillManager.create_personal(basic_user, slug=slug)
-    SkillManager.patch_custom(skill, admin_user, is_public=True)
+    SkillManager.patch_personal(skill, basic_user, SkillPatchRequest(is_public=True))
 
-    with pytest.raises(httpx.HTTPStatusError) as exc_info:
-        SkillManager.patch_personal(skill, basic_user, enabled=False)
-    assert exc_info.value.response.status_code == 403
+    disabled = SkillManager.patch_personal(
+        skill, basic_user, SkillPatchRequest(enabled=False)
+    )
+    assert disabled.enabled is False
 
 
 def test_admin_disable_then_owner_reenable(
@@ -245,35 +247,22 @@ def test_admin_disable_then_owner_reenable(
     basic_user: DATestUser,
 ) -> None:
     """Admin disable is a reversible mute, not a sticky lock: the skill stays
-    listed (greyed) for the owner and the owner can re-enable it. The admin's
-    irreversible override is delete (see test_admin_can_hard_delete_personal_skill)."""
+    listed (greyed) for the owner and the owner can re-enable it."""
     slug = f"personal-admin-toggle-{uuid4().hex[:6]}"
     skill = SkillManager.create_personal(basic_user, slug=slug)
+    SkillManager.patch_personal(skill, basic_user, SkillPatchRequest(is_public=True))
 
-    SkillManager.patch_custom(skill, admin_user, enabled=False)
+    SkillManager.patch_custom(skill, admin_user, SkillPatchRequest(enabled=False))
     own = [
-        c
-        for c in SkillManager.list_for_user(basic_user)["customs"]
-        if c["slug"] == slug
+        skill
+        for skill in SkillManager.list_for_user(basic_user).customs
+        if skill.slug == slug
     ]
-    assert len(own) == 1 and own[0]["enabled"] is False
+    assert len(own) == 1 and own[0].enabled is False
 
     # enabled is a shared flag with no who-disabled tracking, so the owner can
     # turn it back on.
-    reenabled = SkillManager.patch_personal(skill, basic_user, enabled=True)
+    reenabled = SkillManager.patch_personal(
+        skill, basic_user, SkillPatchRequest(enabled=True)
+    )
     assert reenabled.enabled is True
-
-
-def test_per_user_personal_skill_cap(admin_user: DATestUser) -> None:  # noqa: ARG001
-    # dedicated user so personal skills from other tests don't skew the count
-    capped_user = UserManager.create(name=f"capped_{uuid4().hex[:8]}")
-    for i in range(MAX_PERSONAL_SKILLS_PER_USER):
-        SkillManager.create_personal(capped_user, slug=f"cap-{i}-{uuid4().hex[:6]}")
-
-    with pytest.raises(httpx.HTTPStatusError) as exc_info:
-        SkillManager.create_personal(capped_user, slug=f"cap-over-{uuid4().hex[:6]}")
-    response = exc_info.value.response
-    assert response.status_code == 400
-    body = response.json()
-    detail = str(body.get("detail") or body)
-    assert "limit" in detail.lower()

--- a/backend/tests/integration/tests/skills/test_skills_user.py
+++ b/backend/tests/integration/tests/skills/test_skills_user.py
@@ -1,11 +1,11 @@
 """User skill API tests (HTTP boundary).
 
 These tests live at the user-facing HTTP boundary for ``/skills`` and
-``/skills/{slug_or_id}``. They verify visibility rules (public, private,
-grants, disabled), the slug + id lookup contract, and the admin-only
-delete guard.
+``/skills/{id}``. They verify visibility rules (public, private,
+group shares, disabled), the id lookup contract, and the admin-only delete
+guard.
 
-Admin-route auth (POST, list, etc.) is covered exhaustively in
+Admin-route mutation auth is covered exhaustively in
 ``test_skills_admin.py``; here we only assert the user-side surface.
 """
 
@@ -16,6 +16,7 @@ from uuid import uuid4
 
 import pytest
 
+from onyx.server.features.skill.models import SkillPatchRequest
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.http_client import client
 from tests.integration.common_utils.managers.skill import SkillManager
@@ -35,10 +36,8 @@ def test_get_skills_returns_builtins_plus_accessible_customs(
     user_skills = SkillManager.list_for_user(basic_user)
     # Built-ins ship with the deployment; the registry always returns at
     # least one entry for an out-of-the-box install.
-    assert isinstance(user_skills.get("builtins"), list)
-    assert isinstance(user_skills.get("customs"), list)
-    assert len(user_skills["builtins"]) >= 1
-    assert len(user_skills["customs"]) >= 1
+    assert len(user_skills.builtins) >= 1
+    assert len(user_skills.customs) >= 1
 
 
 def test_user_does_not_see_disabled_skill(
@@ -47,22 +46,22 @@ def test_user_does_not_see_disabled_skill(
 ) -> None:
     slug = f"disabled-{uuid4().hex[:6]}"
     skill = SkillManager.create_custom(admin_user, slug=slug, is_public=True)
-    SkillManager.patch_custom(skill, admin_user, enabled=False)
+    SkillManager.patch_custom(skill, admin_user, SkillPatchRequest(enabled=False))
 
     user_skills = SkillManager.list_for_user(basic_user)
-    custom_slugs = [c["slug"] for c in user_skills["customs"]]
+    custom_slugs = [skill.slug for skill in user_skills.customs]
     assert slug not in custom_slugs
 
 
-def test_user_does_not_see_private_skill_without_grant(
+def test_user_does_not_see_private_skill_without_share(
     admin_user: DATestUser,
     basic_user: DATestUser,
 ) -> None:
-    slug = f"private-nogrant-{uuid4().hex[:6]}"
+    slug = f"private-unshared-{uuid4().hex[:6]}"
     SkillManager.create_custom(admin_user, slug=slug, is_public=False)
 
     user_skills = SkillManager.list_for_user(basic_user)
-    custom_slugs = [c["slug"] for c in user_skills["customs"]]
+    custom_slugs = [skill.slug for skill in user_skills.customs]
     assert slug not in custom_slugs
 
 
@@ -74,7 +73,7 @@ def test_user_sees_public_skill(
     SkillManager.create_custom(admin_user, slug=slug, is_public=True)
 
     user_skills = SkillManager.list_for_user(basic_user)
-    custom_slugs = [c["slug"] for c in user_skills["customs"]]
+    custom_slugs = [skill.slug for skill in user_skills.customs]
     assert slug in custom_slugs
 
 
@@ -82,14 +81,14 @@ def test_user_sees_public_skill(
     os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
     reason="User-group management requires EE features enabled.",
 )
-def test_user_sees_private_skill_with_grant(
+def test_user_sees_private_skill_with_group_share(
     admin_user: DATestUser,
     basic_user: DATestUser,
 ) -> None:
-    """Adding ``basic_user`` to a granted group surfaces a private skill."""
+    """Adding ``basic_user`` to a shared group surfaces a private skill."""
     group = UserGroupManager.create(
         admin_user,
-        name=f"grant-r-{uuid4().hex[:6]}",
+        name=f"share-r-{uuid4().hex[:6]}",
         user_ids=[admin_user.id],
     )
     UserGroupManager.wait_for_sync(
@@ -98,7 +97,7 @@ def test_user_sees_private_skill_with_grant(
     )
     UserGroupManager.add_users(group, [basic_user.id], admin_user)
 
-    slug = f"private-granted-{uuid4().hex[:6]}"
+    slug = f"private-shared-{uuid4().hex[:6]}"
     SkillManager.create_custom(
         admin_user,
         slug=slug,
@@ -107,23 +106,8 @@ def test_user_sees_private_skill_with_grant(
     )
 
     user_skills = SkillManager.list_for_user(basic_user)
-    custom_slugs = [c["slug"] for c in user_skills["customs"]]
+    custom_slugs = [skill.slug for skill in user_skills.customs]
     assert slug in custom_slugs
-
-
-def test_get_skill_by_slug_404_when_not_visible(
-    admin_user: DATestUser,
-    basic_user: DATestUser,
-) -> None:
-    """A private skill the user has no grant for → 404 on direct slug lookup."""
-    slug = f"hidden-slug-{uuid4().hex[:6]}"
-    SkillManager.create_custom(admin_user, slug=slug, is_public=False)
-
-    response = client.get(
-        f"{API_SERVER_URL}/skills/{slug}",
-        headers=basic_user.headers,
-    )
-    assert response.status_code == 404
 
 
 def test_get_skill_by_id_404_when_not_visible(
@@ -133,7 +117,6 @@ def test_get_skill_by_id_404_when_not_visible(
     """Direct lookup by UUID obeys the same visibility filter as listing."""
     slug = f"hidden-id-{uuid4().hex[:6]}"
     skill = SkillManager.create_custom(admin_user, slug=slug, is_public=False)
-    assert skill.id is not None
 
     response = client.get(
         f"{API_SERVER_URL}/skills/{skill.id}",
@@ -142,25 +125,23 @@ def test_get_skill_by_id_404_when_not_visible(
     assert response.status_code == 404
 
 
-def test_non_admin_cannot_delete_skill(
+def test_non_owner_cannot_delete_skill(
     admin_user: DATestUser,
     basic_user: DATestUser,
 ) -> None:
-    """Regular users get 403 when deleting via the admin route."""
+    """Users without edit permissions cannot delete another user's skill."""
     skill = SkillManager.create_custom(admin_user, slug=f"no-del-{uuid4().hex[:6]}")
     response = client.delete(
-        f"{API_SERVER_URL}/admin/skills/custom/{skill.id}",
+        f"{API_SERVER_URL}/skills/custom/{skill.id}",
         headers=basic_user.headers,
     )
-    assert response.status_code == 403
+    assert response.status_code == 404
 
 
 # ---------------------------------------------------------------------------
 # Notes on coverage shifted to ``test_skills_admin.py``
 # ---------------------------------------------------------------------------
-# - ``test_non_admin_cannot_create`` → covered by
-#   ``test_skills_admin.py::test_non_admin_returns_403_on_post``.
-# - ``test_disabled_skill_in_admin_list`` → admin-side behaviour, covered
-#   by the admin patch/list flow in ``test_skills_admin.py``.
-# - ``test_non_admin_cannot_list_admin`` → covered by
-#   ``test_skills_admin.py::test_non_admin_returns_403_on_admin_list``.
+# - Create behavior is covered by the single user-facing ``POST /skills/custom``
+#   path in ``test_skills_personal.py`` and ``test_skills_admin.py``.
+# - Disabled skill admin-side behaviour is covered by the admin patch and
+#   unified list flow in ``test_skills_admin.py``.

--- a/backend/tests/unit/onyx/skills/test_bundle_validation.py
+++ b/backend/tests/unit/onyx/skills/test_bundle_validation.py
@@ -18,6 +18,7 @@ from onyx.skills.bundle import _ZIP_UNIX_CREATE_SYSTEM
 from onyx.skills.bundle import compute_bundle_sha256
 from onyx.skills.bundle import parse_skill_md_metadata
 from onyx.skills.bundle import read_custom_bundle_instructions
+from onyx.skills.bundle import rewrite_custom_bundle_skill_md
 from onyx.skills.bundle import slug_from_filename
 from onyx.skills.bundle import strip_skill_md_frontmatter
 from onyx.skills.bundle import validate_custom_bundle
@@ -197,6 +198,34 @@ def test_read_custom_bundle_instructions_returns_instruction_body() -> None:
 def test_read_custom_bundle_instructions_does_not_require_frontmatter() -> None:
     zip_bytes = _build_zip([("SKILL.md", b"# Instructions\n\nDo it.")])
     assert read_custom_bundle_instructions(zip_bytes) == "# Instructions\n\nDo it."
+
+
+def test_rewrite_custom_bundle_skill_md_preserves_supporting_files() -> None:
+    original = _build_zip(
+        [
+            (
+                "SKILL.md",
+                b"---\nname: Old\ndescription: Old desc\n---\n\nOld instructions.",
+            ),
+            ("scripts/run.py", b"print('hi')\n"),
+            ("docs/notes.md", b"# Notes\n"),
+        ]
+    )
+
+    rewritten = rewrite_custom_bundle_skill_md(
+        original,
+        slug="hello",
+        name="New",
+        description="New desc",
+        instructions_markdown="# New instructions\n\nDo it.",
+    )
+
+    assert validate_custom_bundle(rewritten, slug="hello") is None
+    assert parse_skill_md_metadata(rewritten) == ("New", "New desc")
+    assert read_custom_bundle_instructions(rewritten) == "# New instructions\n\nDo it."
+    with zipfile.ZipFile(io.BytesIO(rewritten)) as zf:
+        assert zf.read("scripts/run.py") == b"print('hi')\n"
+        assert zf.read("docs/notes.md") == b"# Notes\n"
 
 
 def _zip_with_patched_compression_method(payload: bytes, method: int) -> bytes:

--- a/backend/tests/unit/onyx/skills/test_skill_access.py
+++ b/backend/tests/unit/onyx/skills/test_skill_access.py
@@ -1,0 +1,324 @@
+from uuid import uuid4
+
+import pytest
+
+from onyx.auth.schemas import UserRole
+from onyx.db.enums import SkillAccessLevel
+from onyx.db.enums import SkillSharePermission
+from onyx.db.models import Skill
+from onyx.db.models import Skill__User
+from onyx.db.models import Skill__UserGroup
+from onyx.db.models import User
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.features.skill.mutation_helpers import _ensure_can_edit_org_visibility
+from onyx.server.features.skill.response_helpers import user_permission_for_skill
+
+
+def _user(role: UserRole = UserRole.BASIC) -> User:
+    return User(id=uuid4(), email=f"{uuid4().hex}@example.com", role=role)
+
+
+def _skill(
+    author: User,
+    *,
+    is_public: bool = False,
+    public_permission: SkillSharePermission = SkillSharePermission.VIEWER,
+) -> Skill:
+    return Skill(
+        id=uuid4(),
+        slug=f"skill-{uuid4().hex}",
+        name="Skill",
+        description="Description",
+        author_user_id=author.id,
+        public_permission=public_permission if is_public else None,
+        enabled=True,
+    )
+
+
+def _share_with_user(
+    skill: Skill,
+    user_id: object | None = None,
+    permission: SkillSharePermission = SkillSharePermission.VIEWER,
+) -> None:
+    skill.user_shares = [
+        Skill__User(
+            skill_id=skill.id,
+            user_id=user_id or uuid4(),
+            permission=permission,
+        )
+    ]
+
+
+def _share_with_groups(
+    skill: Skill,
+    group_ids: list[int],
+    permission: SkillSharePermission = SkillSharePermission.VIEWER,
+) -> None:
+    skill.group_shares = [
+        Skill__UserGroup(
+            skill_id=skill.id,
+            user_group_id=group_id,
+            permission=permission,
+        )
+        for group_id in group_ids
+    ]
+
+
+def test_author_retains_owner_permission_after_sharing() -> None:
+    author = _user()
+    private_shared = _skill(author)
+    _share_with_user(private_shared)
+
+    assert (
+        user_permission_for_skill(private_shared, author, set())
+        == SkillAccessLevel.OWNER
+    )
+    assert (
+        user_permission_for_skill(_skill(author, is_public=True), author, set())
+        == SkillAccessLevel.OWNER
+    )
+
+
+def test_admin_can_edit_custom_skill_regardless_of_share_state() -> None:
+    author = _user()
+    admin = _user(UserRole.ADMIN)
+
+    assert (
+        user_permission_for_skill(_skill(author), admin, set())
+        == SkillAccessLevel.EDITOR
+    )
+
+    shared = _skill(author)
+    _share_with_user(shared)
+    assert user_permission_for_skill(shared, admin, set()) == SkillAccessLevel.EDITOR
+    assert (
+        user_permission_for_skill(_skill(author, is_public=True), admin, set())
+        == SkillAccessLevel.EDITOR
+    )
+
+
+def test_viewer_grants_do_not_grant_editor() -> None:
+    author = _user()
+    basic = _user()
+
+    direct_viewer = _skill(author)
+    _share_with_user(direct_viewer, basic.id, SkillSharePermission.VIEWER)
+    assert (
+        user_permission_for_skill(direct_viewer, basic, set())
+        == SkillAccessLevel.VIEWER
+    )
+
+    group_viewer = _skill(author)
+    _share_with_groups(group_viewer, [1], SkillSharePermission.VIEWER)
+    assert (
+        user_permission_for_skill(group_viewer, basic, {1}) == SkillAccessLevel.VIEWER
+    )
+
+    org_viewer = _skill(
+        author,
+        is_public=True,
+        public_permission=SkillSharePermission.VIEWER,
+    )
+    assert (
+        user_permission_for_skill(org_viewer, basic, set()) == SkillAccessLevel.VIEWER
+    )
+
+
+def test_public_editor_permission_grants_editor() -> None:
+    author = _user()
+    basic = _user()
+
+    assert (
+        user_permission_for_skill(
+            _skill(
+                author,
+                is_public=True,
+                public_permission=SkillSharePermission.EDITOR,
+            ),
+            basic,
+            set(),
+        )
+        == SkillAccessLevel.EDITOR
+    )
+
+
+def test_editor_grants_from_direct_group_or_org_share_grant_editor() -> None:
+    author = _user()
+    basic = _user()
+
+    direct_editor = _skill(author)
+    _share_with_user(direct_editor, basic.id, SkillSharePermission.EDITOR)
+    assert (
+        user_permission_for_skill(direct_editor, basic, set())
+        == SkillAccessLevel.EDITOR
+    )
+
+    group_editor = _skill(author)
+    _share_with_groups(group_editor, [1], SkillSharePermission.EDITOR)
+    assert (
+        user_permission_for_skill(group_editor, basic, {1}) == SkillAccessLevel.EDITOR
+    )
+
+    org_editor = _skill(
+        author,
+        is_public=True,
+        public_permission=SkillSharePermission.EDITOR,
+    )
+    assert (
+        user_permission_for_skill(org_editor, basic, set()) == SkillAccessLevel.EDITOR
+    )
+
+
+def test_any_editor_grant_wins_over_viewer_grants() -> None:
+    author = _user()
+    basic = _user()
+
+    direct_editor_group_viewer = _skill(author)
+    _share_with_user(
+        direct_editor_group_viewer,
+        basic.id,
+        SkillSharePermission.EDITOR,
+    )
+    _share_with_groups(
+        direct_editor_group_viewer,
+        [1],
+        SkillSharePermission.VIEWER,
+    )
+    assert (
+        user_permission_for_skill(direct_editor_group_viewer, basic, {1})
+        == SkillAccessLevel.EDITOR
+    )
+
+    direct_viewer_group_editor = _skill(author)
+    _share_with_user(
+        direct_viewer_group_editor,
+        basic.id,
+        SkillSharePermission.VIEWER,
+    )
+    _share_with_groups(
+        direct_viewer_group_editor,
+        [1],
+        SkillSharePermission.EDITOR,
+    )
+    assert (
+        user_permission_for_skill(direct_viewer_group_editor, basic, {1})
+        == SkillAccessLevel.EDITOR
+    )
+
+    public_viewer_direct_editor = _skill(
+        author,
+        is_public=True,
+        public_permission=SkillSharePermission.VIEWER,
+    )
+    _share_with_user(
+        public_viewer_direct_editor,
+        basic.id,
+        SkillSharePermission.EDITOR,
+    )
+    assert (
+        user_permission_for_skill(public_viewer_direct_editor, basic, set())
+        == SkillAccessLevel.EDITOR
+    )
+
+
+def test_curator_viewer_access_does_not_grant_editor() -> None:
+    author = _user()
+    curator = _user(UserRole.CURATOR)
+
+    public_skill = _skill(author, is_public=True)
+    assert (
+        user_permission_for_skill(
+            public_skill,
+            curator,
+            user_group_ids=set(),
+            curated_user_group_ids=set(),
+        )
+        == SkillAccessLevel.VIEWER
+    )
+
+    direct_shared = _skill(author)
+    _share_with_user(direct_shared, curator.id)
+    assert (
+        user_permission_for_skill(
+            direct_shared,
+            curator,
+            user_group_ids=set(),
+            curated_user_group_ids=set(),
+        )
+        == SkillAccessLevel.VIEWER
+    )
+
+
+def test_curator_can_edit_skill_shared_with_curated_groups() -> None:
+    author = _user()
+    curator = _user(UserRole.CURATOR)
+    skill = _skill(author)
+    _share_with_groups(skill, [1])
+
+    assert (
+        user_permission_for_skill(
+            skill,
+            curator,
+            user_group_ids={1},
+            curated_user_group_ids={1},
+        )
+        == SkillAccessLevel.EDITOR
+    )
+
+
+def test_curator_cannot_edit_skill_shared_outside_curated_groups() -> None:
+    author = _user()
+    curator = _user(UserRole.CURATOR)
+    skill = _skill(author)
+    _share_with_groups(skill, [1, 2])
+
+    assert (
+        user_permission_for_skill(
+            skill,
+            curator,
+            user_group_ids={1},
+            curated_user_group_ids={1},
+        )
+        == SkillAccessLevel.VIEWER
+    )
+
+
+def test_global_curator_can_edit_skill_shared_with_member_groups() -> None:
+    author = _user()
+    global_curator = _user(UserRole.GLOBAL_CURATOR)
+    skill = _skill(author)
+    _share_with_groups(skill, [1, 2])
+
+    assert (
+        user_permission_for_skill(
+            skill,
+            global_curator,
+            user_group_ids={1, 2},
+        )
+        == SkillAccessLevel.EDITOR
+    )
+
+
+def test_curator_editor_cannot_edit_org_visibility() -> None:
+    author = _user()
+    curator = _user(UserRole.CURATOR)
+    skill = _skill(author)
+    _share_with_groups(skill, [1])
+
+    with pytest.raises(OnyxError):
+        _ensure_can_edit_org_visibility(skill, curator)
+
+
+def test_admin_editor_can_edit_org_visibility() -> None:
+    author = _user()
+    admin = _user(UserRole.ADMIN)
+    skill = _skill(author, is_public=True)
+
+    _ensure_can_edit_org_visibility(skill, admin)
+
+
+def test_admin_can_edit_personal_skill_org_visibility() -> None:
+    author = _user()
+    admin = _user(UserRole.ADMIN)
+
+    _ensure_can_edit_org_visibility(_skill(author), admin)

--- a/backend/tests/unit/onyx/skills/test_skill_mutation_helpers.py
+++ b/backend/tests/unit/onyx/skills/test_skill_mutation_helpers.py
@@ -1,183 +1,55 @@
 import io
-from types import SimpleNamespace
-from typing import cast
 from unittest.mock import MagicMock
-from uuid import UUID
-from uuid import uuid4
 
 import pytest
-from fastapi import UploadFile
-from sqlalchemy.orm import Session
 
-from onyx.configs.app_configs import MAX_PERSONAL_SKILLS_PER_USER
-from onyx.db.enums import SkillSharePermission
-from onyx.db.models import Skill
-from onyx.db.models import User
+from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
-from onyx.server.features.skill.api import create_personal_skill
-from onyx.server.features.skill.api import patch_personal_skill
-from onyx.server.features.skill.api import replace_personal_skill_bundle
-from onyx.server.features.skill.models import CustomSkillResponse
-from onyx.server.features.skill.models import PersonalSkillPatchRequest
-from onyx.server.features.skill.mutation_helpers import ensure_owned_personal_skill
+from onyx.server.features.skill.mutation_helpers import ingested_skill_bundle
+from onyx.server.features.skill.mutation_helpers import reject_reserved_skill_slug
+from onyx.skills.ingest import IngestedBundle
 
 
-def _custom_skill(
-    *,
-    author_user_id: UUID | None = None,
-    public_permission: SkillSharePermission | None = None,
-) -> Skill:
-    return Skill(
-        id=uuid4(),
-        slug=f"skill-{uuid4().hex[:8]}",
-        name="Skill",
-        description="Description",
-        bundle_file_id=f"bundle-{uuid4().hex[:8]}",
-        bundle_sha256="0" * 64,
-        built_in_skill_id=None,
-        author_user_id=author_user_id,
-        public_permission=public_permission,
-        enabled=True,
-    )
+def test_reject_reserved_skill_slug_blocks_built_in_slug() -> None:
+    with pytest.raises(OnyxError) as exc_info:
+        reject_reserved_skill_slug("pptx.zip")
+
+    assert exc_info.value.error_code == OnyxErrorCode.INVALID_INPUT
 
 
-def _upload(filename: str) -> UploadFile:
-    return cast(
-        UploadFile,
-        SimpleNamespace(file=io.BytesIO(b"bundle"), filename=filename),
-    )
-
-
-def test_custom_skill_response_public_state_comes_from_public_permission() -> None:
-    private_skill = _custom_skill(public_permission=None)
-    org_skill = _custom_skill(public_permission=SkillSharePermission.VIEWER)
-
-    assert (
-        CustomSkillResponse.from_model(private_skill, group_ids=[]).is_public is False
-    )
-    assert CustomSkillResponse.from_model(org_skill, group_ids=[]).is_public is True
-
-
-def test_custom_skill_response_uses_direct_grants_for_personal_state() -> None:
-    skill = _custom_skill(public_permission=None)
-
-    response = CustomSkillResponse.from_model(
-        skill,
-        group_ids=[],
-        has_grants=True,
-    )
-
-    assert response.is_personal is False
-
-
-def test_directly_shared_skill_cannot_use_personal_mutation_path(
+def test_ingested_skill_bundle_deletes_new_blob_on_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    author_user_id = uuid4()
-    skill = _custom_skill(author_user_id=author_user_id)
-    user = cast(User, SimpleNamespace(id=author_user_id))
-    db_session = cast(Session, MagicMock())
+    file_store = object()
+    delete_bundle_blob = MagicMock()
     monkeypatch.setattr(
-        "onyx.server.features.skill.mutation_helpers.skill_ids_with_grants",
-        lambda _skill_ids, _db_session: {skill.id},
-    )
-
-    with pytest.raises(OnyxError):
-        ensure_owned_personal_skill(skill, user, db_session)
-
-
-def test_create_personal_skill_rejects_quota_before_reading_bundle(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    user = cast(User, SimpleNamespace(id=uuid4()))
-    db_session = cast(Session, MagicMock())
-    read_bundle_file = MagicMock()
-
-    monkeypatch.setattr(
-        "onyx.server.features.skill.api.lock_personal_skills_for_user",
-        lambda _user_id, _db_session: None,
+        "onyx.server.features.skill.mutation_helpers.get_default_file_store",
+        lambda: file_store,
     )
     monkeypatch.setattr(
-        "onyx.server.features.skill.api.count_personal_skills_for_user",
-        lambda _user_id, _db_session: MAX_PERSONAL_SKILLS_PER_USER,
+        "onyx.server.features.skill.mutation_helpers.read_bundle_file",
+        lambda bundle_file: bundle_file.read(),
     )
     monkeypatch.setattr(
-        "onyx.server.features.skill.mutation_helpers.read_bundle_file", read_bundle_file
-    )
-
-    with pytest.raises(OnyxError):
-        create_personal_skill(
-            bundle=_upload("quota-test.zip"),
-            user=user,
-            db_session=db_session,
-        )
-
-    read_bundle_file.assert_not_called()
-
-
-def test_replace_personal_skill_bundle_authorizes_before_reading_bundle(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    skill = _custom_skill(author_user_id=uuid4())
-    user = cast(User, SimpleNamespace(id=uuid4()))
-    db_session = cast(Session, MagicMock())
-    read_bundle_file = MagicMock()
-
-    monkeypatch.setattr(
-        "onyx.server.features.skill.api.fetch_skill_by_id",
-        lambda _skill_id, _db_session: skill,
+        "onyx.server.features.skill.mutation_helpers.ingest_skill_bundle",
+        lambda *_args, **_kwargs: IngestedBundle(
+            slug="helper-skill",
+            bundle_file_id="new-bundle",
+            bundle_sha256="0" * 64,
+            name="Helper Skill",
+            description="Description",
+        ),
     )
     monkeypatch.setattr(
-        "onyx.server.features.skill.mutation_helpers.read_bundle_file", read_bundle_file
+        "onyx.server.features.skill.mutation_helpers.delete_bundle_blob",
+        delete_bundle_blob,
     )
 
-    with pytest.raises(OnyxError):
-        replace_personal_skill_bundle(
-            skill_id=skill.id,
-            bundle=_upload("replace-test.zip"),
-            user=user,
-            db_session=db_session,
-        )
+    with pytest.raises(RuntimeError):
+        with ingested_skill_bundle(
+            bundle_file=io.BytesIO(b"bundle"),
+            filename="helper-skill.zip",
+        ):
+            raise RuntimeError("db write failed")
 
-    read_bundle_file.assert_not_called()
-
-
-def test_noop_personal_patch_does_not_push_sandboxes(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    user_id = uuid4()
-    skill = _custom_skill(author_user_id=user_id)
-    user = cast(User, SimpleNamespace(id=user_id))
-    db_session = cast(Session, MagicMock())
-    push_skills_for_users = MagicMock()
-
-    monkeypatch.setattr(
-        "onyx.server.features.skill.api.fetch_skill_by_id",
-        lambda _skill_id, _db_session: skill,
-    )
-    monkeypatch.setattr(
-        "onyx.server.features.skill.mutation_helpers.skill_ids_with_grants",
-        lambda _skill_ids, _db_session: set(),
-    )
-    monkeypatch.setattr(
-        "onyx.server.features.skill.api.affected_user_ids_for_skill",
-        lambda _skill, _db_session: {user_id},
-    )
-    monkeypatch.setattr(
-        "onyx.server.features.skill.api.patch_skill",
-        lambda **_kwargs: skill,
-    )
-    monkeypatch.setattr(
-        "onyx.server.features.skill.api.push_skills_for_users",
-        push_skills_for_users,
-    )
-
-    response = patch_personal_skill(
-        skill_id=skill.id,
-        patch_req=PersonalSkillPatchRequest(enabled=True),
-        user=user,
-        db_session=db_session,
-    )
-
-    assert response.id == skill.id
-    push_skills_for_users.assert_not_called()
+    delete_bundle_blob.assert_called_once_with(file_store, "new-bundle")

--- a/backend/tests/unit/onyx/skills/test_skill_patch_unset_sentinel.py
+++ b/backend/tests/unit/onyx/skills/test_skill_patch_unset_sentinel.py
@@ -1,50 +1,87 @@
-"""Unit tests for SkillPatchRequest — sentinel mapping and null rejection."""
+"""Unit tests for SkillPatchRequest intent tracking."""
 
 import pytest
 from pydantic import ValidationError
 
-from onyx.db.utils import UnsetType
+from onyx.db.enums import SkillSharePermission
 from onyx.server.features.skill.models import SkillPatchRequest
 
 
-def test_omitted_fields_produce_unset() -> None:
-    """Fields not included in the request should produce UNSET in the domain object."""
+def test_omitted_fields_do_not_count_as_updates() -> None:
     req = SkillPatchRequest(is_public=True)
-    patch = req.to_domain()
 
-    assert patch.is_public is True
-    assert isinstance(patch.enabled, UnsetType)
+    assert req.model_fields_set == {"is_public"}
+    assert req.has_db_field_update is True
+    assert req.has_details_update is False
 
 
 def test_all_fields_sent() -> None:
-    """All fields explicitly sent should appear in the domain object."""
-    req = SkillPatchRequest(is_public=True, enabled=False)
-    patch = req.to_domain()
+    req = SkillPatchRequest(
+        is_public=True,
+        public_permission=SkillSharePermission.EDITOR,
+        enabled=False,
+    )
 
-    assert patch.is_public is True
-    assert patch.enabled is False
+    assert req.model_fields_set == {"is_public", "public_permission", "enabled"}
+    assert req.is_public is True
+    assert req.public_permission == SkillSharePermission.EDITOR
+    assert req.enabled is False
 
 
-def test_false_values_not_treated_as_unset() -> None:
-    """Explicitly sending False should NOT produce UNSET."""
+def test_false_values_count_as_updates() -> None:
     req = SkillPatchRequest(is_public=False, enabled=False)
-    patch = req.to_domain()
 
-    assert patch.is_public is False
-    assert patch.enabled is False
+    assert req.model_fields_set == {"is_public", "enabled"}
+    assert req.has_db_field_update is True
+    assert req.is_public is False
+    assert req.enabled is False
 
 
-def test_empty_request_all_unset() -> None:
-    """An empty request should have all fields as UNSET."""
+def test_empty_request_has_no_update_intent() -> None:
     req = SkillPatchRequest()
-    patch = req.to_domain()
 
-    assert isinstance(patch.is_public, UnsetType)
-    assert isinstance(patch.enabled, UnsetType)
+    assert req.model_fields_set == set()
+    assert req.has_db_field_update is False
+    assert req.has_details_update is False
 
 
-@pytest.mark.parametrize("field", ["is_public", "enabled"])
+def test_detail_fields_track_intent() -> None:
+    req = SkillPatchRequest(
+        name=" Updated name ",
+        description=" Updated description ",
+        instructions_markdown=" Updated instructions ",
+    )
+
+    assert req.name == "Updated name"
+    assert req.description == "Updated description"
+    assert req.instructions_markdown == "Updated instructions"
+    assert req.has_details_update is True
+    assert req.has_db_field_update is False
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "name",
+        "description",
+        "instructions_markdown",
+        "is_public",
+        "public_permission",
+        "enabled",
+    ],
+)
 def test_explicit_null_rejected(field: str) -> None:
     """Sending field=null (not omitting it) should raise ValidationError."""
     with pytest.raises(ValidationError, match=f"{field} cannot be null"):
         SkillPatchRequest.model_validate({field: None})
+
+
+@pytest.mark.parametrize("field", ["name", "description", "instructions_markdown"])
+def test_empty_strings_rejected(field: str) -> None:
+    with pytest.raises(ValidationError, match=f"{field} cannot be empty"):
+        SkillPatchRequest.model_validate({field: "  "})
+
+
+def test_extra_fields_rejected() -> None:
+    with pytest.raises(ValidationError):
+        SkillPatchRequest.model_validate({"slug": "new-slug"})


### PR DESCRIPTION
## Description

Adds the backend portion of the remaining skills management work in one PR:

- unifies custom skill management under `/skills/custom/*`
- adds editable skill detail, bundle rewrite, sharing, permission, ownership transfer, and delete flows
- expands skill response/access modeling for owner/editor/viewer behavior
- updates backend tests and integration helpers for the new backend API contract
- adds skill backend paths to the craft k8s test trigger

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies backend skill management behind `/skills/custom/*`, adds share-based permissions with computed access levels, and consolidates read responses. External‑app skills are excluded from regular reads and included only under the USE policy.

- **New Features**
  - Unified endpoints under `/skills/custom/*` for create, patch, bundle replace, share replace, transfer ownership, and delete.
  - Computed access via `SkillAccessLevel` and share model using `SkillSharePermission` for users, curated groups, and public; curator/admin rules gate org visibility and group sharing.
  - Editable details with SKILL.md rebuild; helpers to read/save bundle bytes.
  - List/get return `SkillsList`, `SkillResponse`, and `SkillPreviewResponse`; external‑app skills filtered from regular reads and included only by the USE policy.

- **Migration**
  - Admin router removed; use `/skills/custom/*` for all management.
  - Fetch by id only at `/skills/{id}`; update clients to use ids and the new response models, and respect `access_level` for edits.
  - Replace legacy “grants” with “shares”; remove `MAX_PERSONAL_SKILLS_PER_USER`.

<sup>Written for commit d651844f81fa8326cb9aeed9abe7ea9b32bfa5aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

