### PR TITLE
chore: litellm bump v1.89.4

### DIFF
--- a/backend/onyx/llm/litellm_singleton/monkey_patches.py
+++ b/backend/onyx/llm/litellm_singleton/monkey_patches.py
@@ -315,7 +315,6 @@ def _patch_openai_responses_transform_response() -> None:
     Patches LiteLLMResponsesTransformationHandler.transform_response to properly
     concatenate multiple reasoning summary parts with newlines in non-streaming responses.
     """
-    # Store the original method
     original_transform_response = (
         LiteLLMResponsesTransformationHandler.transform_response
     )
@@ -344,34 +343,9 @@ def _patch_openai_responses_transform_response() -> None:
         api_key: Optional[str] = None,
         json_mode: Optional[bool] = None,
     ) -> Any:
-        """
-        Patched transform_response that properly concatenates reasoning summary parts
-        with newlines.
-        """
-        from openai.types.responses.response import Response as ResponsesAPIResponse
+        from litellm.types.llms.openai import ResponsesAPIResponse
         from openai.types.responses.response_reasoning_item import ResponseReasoningItem
 
-        # Check if raw_response has reasoning items that need concatenation
-        if isinstance(raw_response, ResponsesAPIResponse) and raw_response.output:
-            for item in raw_response.output:
-                if isinstance(item, ResponseReasoningItem) and item.summary:
-                    # Concatenate summary texts with double newlines
-                    summary_texts = []
-                    for summary_item in item.summary:
-                        text = getattr(summary_item, "text", "")
-                        if text:
-                            summary_texts.append(text)
-
-                    if len(summary_texts) > 1:
-                        # Modify the first summary item to contain all concatenated text
-                        combined_text = "\n\n".join(summary_texts)
-                        if hasattr(item.summary[0], "text"):
-                            # Create a modified copy of the response with concatenated text
-                            # Since OpenAI types are typically frozen, we need to work around this
-                            # by modifying the object after the fact or using the result
-                            pass  # The fix is applied in the result processing below
-
-        # Call the original method
         result = original_transform_response(
             self,
             model,
@@ -387,28 +361,26 @@ def _patch_openai_responses_transform_response() -> None:
             json_mode,
         )
 
-        # Post-process: If there are multiple summary items, fix the reasoning_content
+        combined_text: str | None = None
         if isinstance(raw_response, ResponsesAPIResponse) and raw_response.output:
             for item in raw_response.output:
-                if isinstance(item, ResponseReasoningItem) and item.summary:
-                    if len(item.summary) > 1:
-                        # Concatenate all summary texts with double newlines
-                        summary_texts = []
-                        for summary_item in item.summary:
-                            text = getattr(summary_item, "text", "")
-                            if text:
-                                summary_texts.append(text)
+                if not isinstance(item, ResponseReasoningItem) or not item.summary:
+                    continue
 
-                        if summary_texts:
-                            combined_text = "\n\n".join(summary_texts)
-                            # Update the reasoning_content in the result choices
-                            if hasattr(result, "choices"):
-                                for choice in result.choices:
-                                    if hasattr(choice, "message") and hasattr(
-                                        choice.message, "reasoning_content"
-                                    ):
-                                        choice.message.reasoning_content = combined_text
-                    break  # Only process the first reasoning item
+                summary_texts = [
+                    text
+                    for summary_item in item.summary
+                    if (text := getattr(summary_item, "text", ""))
+                ]
+                if len(summary_texts) > 1:
+                    combined_text = "\n\n".join(summary_texts)
+                break
+
+        if combined_text and hasattr(result, "choices"):
+            for choice in result.choices:
+                message = getattr(choice, "message", None)
+                if message is not None and getattr(message, "reasoning_content", None):
+                    message.reasoning_content = combined_text
 
         return result
 

--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -1358,9 +1358,9 @@ ldap3==2.9.1 \
 libpass==1.9.3 \
     --hash=sha256:3cbeb14d22086660e92c30d787ea981973d67394e81c8c870e1a83cfe1c84353 \
     --hash=sha256:7830b9323d9ba96a841ad698a8dec1d43a2b0b7f1c855c76772e7972c1c6d959
-litellm==1.85.1 \
-    --hash=sha256:3b8ef0c89ff2736cbd27109f17ff31f1bd0ab59dee9be8cadb28ec3cb167ce0d \
-    --hash=sha256:c89eb5dfd18cce3d40b59e79c74f7f645bc7814a417c6ab25e53c786f0a6ab7b
+litellm==1.89.4 \
+    --hash=sha256:ab551a8d52cb703c738b4db7cb6f350c4bb2ff146f0d3cc3986fd879a1eecac5 \
+    --hash=sha256:c3a19961b9e3576d4aafb6d27a0a8e1d06c370784b2d88631a9ba0d027cfd757
     # via onyx
 locket==1.0.0 \
     --hash=sha256:5c0d4c052a8bbbf750e056a8e65ccd309086f4f0f18a2eac306a8dfa4112a632 \

--- a/backend/requirements/dev.txt
+++ b/backend/requirements/dev.txt
@@ -949,9 +949,9 @@ kiwisolver==1.4.9 \
     --hash=sha256:efb3a45b35622bb6c16dbfab491a8f5a391fe0e9d45ef32f4df85658232ca0e2 \
     --hash=sha256:f68e4f3eeca8fb22cc3d731f9715a13b652795ef657a13df1ad0c7dc0e9731df
     # via matplotlib
-litellm==1.85.1 \
-    --hash=sha256:3b8ef0c89ff2736cbd27109f17ff31f1bd0ab59dee9be8cadb28ec3cb167ce0d \
-    --hash=sha256:c89eb5dfd18cce3d40b59e79c74f7f645bc7814a417c6ab25e53c786f0a6ab7b
+litellm==1.89.4 \
+    --hash=sha256:ab551a8d52cb703c738b4db7cb6f350c4bb2ff146f0d3cc3986fd879a1eecac5 \
+    --hash=sha256:c3a19961b9e3576d4aafb6d27a0a8e1d06c370784b2d88631a9ba0d027cfd757
     # via onyx
 mako==1.3.12 \
     --hash=sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9 \

--- a/backend/requirements/ee.txt
+++ b/backend/requirements/ee.txt
@@ -688,9 +688,9 @@ jsonschema-specifications==2025.9.1 \
     --hash=sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe \
     --hash=sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d
     # via jsonschema
-litellm==1.85.1 \
-    --hash=sha256:3b8ef0c89ff2736cbd27109f17ff31f1bd0ab59dee9be8cadb28ec3cb167ce0d \
-    --hash=sha256:c89eb5dfd18cce3d40b59e79c74f7f645bc7814a417c6ab25e53c786f0a6ab7b
+litellm==1.89.4 \
+    --hash=sha256:ab551a8d52cb703c738b4db7cb6f350c4bb2ff146f0d3cc3986fd879a1eecac5 \
+    --hash=sha256:c3a19961b9e3576d4aafb6d27a0a8e1d06c370784b2d88631a9ba0d027cfd757
     # via onyx
 markupsafe==3.0.3 \
     --hash=sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf \

--- a/backend/requirements/model_server.txt
+++ b/backend/requirements/model_server.txt
@@ -739,9 +739,9 @@ kombu==5.5.4 \
     --hash=sha256:886600168275ebeada93b888e831352fe578168342f0d1d5833d88ba0d847363 \
     --hash=sha256:a12ed0557c238897d8e518f1d1fdf84bd1516c5e305af2dacd85c2015115feb8
     # via celery
-litellm==1.85.1 \
-    --hash=sha256:3b8ef0c89ff2736cbd27109f17ff31f1bd0ab59dee9be8cadb28ec3cb167ce0d \
-    --hash=sha256:c89eb5dfd18cce3d40b59e79c74f7f645bc7814a417c6ab25e53c786f0a6ab7b
+litellm==1.89.4 \
+    --hash=sha256:ab551a8d52cb703c738b4db7cb6f350c4bb2ff146f0d3cc3986fd879a1eecac5 \
+    --hash=sha256:c3a19961b9e3576d4aafb6d27a0a8e1d06c370784b2d88631a9ba0d027cfd757
     # via onyx
 markupsafe==3.0.3 \
     --hash=sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf \

--- a/backend/tests/unit/onyx/llm/test_litellm_monkey_patches.py
+++ b/backend/tests/unit/onyx/llm/test_litellm_monkey_patches.py
@@ -1,6 +1,18 @@
+from datetime import datetime
 from typing import Any
 
+from litellm.completion_extras.litellm_responses_transformation.transformation import (
+    LiteLLMResponsesTransformationHandler,
+)
+from litellm.litellm_core_utils.litellm_logging import Logging
 from litellm.llms.ollama.chat.transformation import OllamaChatCompletionResponseIterator
+from litellm.types.llms.openai import ResponseAPIUsage
+from litellm.types.llms.openai import ResponsesAPIResponse
+from litellm.types.utils import ModelResponse
+from openai.types.responses.response_output_message import ResponseOutputMessage
+from openai.types.responses.response_output_text import ResponseOutputText
+from openai.types.responses.response_reasoning_item import ResponseReasoningItem
+from openai.types.responses.response_reasoning_item import Summary
 
 from onyx.llm.litellm_singleton.monkey_patches import apply_monkey_patches
 
@@ -101,3 +113,78 @@ def test_ollama_chunk_parser_preserves_content_when_thinking_and_content_coexist
 
     assert response.choices[0].delta.reasoning_content == "Need one thought"
     assert response.choices[0].delta.content == "Visible answer token"
+
+
+def test_responses_transform_response_preserves_reasoning_summary_sections() -> None:
+    apply_monkey_patches()
+    raw_response = ResponsesAPIResponse(
+        id="resp_1",
+        created_at=0,
+        error=None,
+        incomplete_details=None,
+        instructions=None,
+        metadata={},
+        model="m",
+        object="response",
+        output=[
+            ResponseReasoningItem(
+                id="rs_1",
+                type="reasoning",
+                summary=[
+                    Summary(text="first section", type="summary_text"),
+                    Summary(text="second section", type="summary_text"),
+                ],
+            ),
+            ResponseOutputMessage(
+                id="msg_1",
+                type="message",
+                role="assistant",
+                status="completed",
+                content=[
+                    ResponseOutputText(
+                        type="output_text",
+                        text="answer",
+                        annotations=[],
+                    )
+                ],
+            ),
+        ],
+        parallel_tool_calls=False,
+        temperature=None,
+        tool_choice="auto",
+        tools=[],
+        top_p=None,
+        max_output_tokens=None,
+        previous_response_id=None,
+        reasoning=None,
+        status="completed",
+        text=None,
+        truncation=None,
+        usage=ResponseAPIUsage(input_tokens=2, output_tokens=3, total_tokens=5),
+        user=None,
+        store=False,
+    )
+
+    result = LiteLLMResponsesTransformationHandler().transform_response(
+        model="m",
+        raw_response=raw_response,
+        model_response=ModelResponse(),
+        logging_obj=Logging(
+            model="m",
+            messages=[],
+            stream=False,
+            call_type="responses",
+            start_time=datetime.now(),
+            litellm_call_id="test-call-id",
+            function_id="test-function-id",
+        ),
+        request_data={},
+        messages=[],
+        optional_params={},
+        litellm_params={},
+        encoding=None,
+    )
+
+    assert (
+        result.choices[0].message.reasoning_content == "first section\n\nsecond section"
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "cohere==5.6.1",
     "fastapi==0.133.1",
     "google-genai==1.52.0",
-    "litellm[google]==1.85.1",
+    "litellm[google]==1.89.4",
     "openai==2.38.0",
     "pydantic==2.11.7",
     # Shared so structured JSON logging (LOG_FORMAT=json) works in the

--- a/uv.lock
+++ b/uv.lock
@@ -3184,7 +3184,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.85.1"
+version = "1.89.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -3200,9 +3200,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/da/55/aebffceaa08688a989e9c68b3edc3a520a1f8338eb0346668774bd66ad88/litellm-1.85.1.tar.gz", hash = "sha256:3b8ef0c89ff2736cbd27109f17ff31f1bd0ab59dee9be8cadb28ec3cb167ce0d", size = 15346324, upload-time = "2026-05-21T02:30:38.185Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/e1/ce008da0be1515b025f1b008d0664e3d2b2ffdbece2913d71baefc9887f4/litellm-1.89.4.tar.gz", hash = "sha256:ab551a8d52cb703c738b4db7cb6f350c4bb2ff146f0d3cc3986fd879a1eecac5", size = 14061816, upload-time = "2026-06-25T02:35:40.674Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/a0/263a13c2253201aa11563a69d9a87f3510030aa765a16f57fc40ceefcdf5/litellm-1.85.1-py3-none-any.whl", hash = "sha256:c89eb5dfd18cce3d40b59e79c74f7f645bc7814a417c6ab25e53c786f0a6ab7b", size = 16980080, upload-time = "2026-05-21T02:30:35.096Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/cc/6fc72581a3ad22b7a53e8dddcc4ccc3ac679795d2200629f0fab35cb6d34/litellm-1.89.4-py3-none-any.whl", hash = "sha256:c3a19961b9e3576d4aafb6d27a0a8e1d06c370784b2d88631a9ba0d027cfd757", size = 15472272, upload-time = "2026-06-25T02:35:37.523Z" },
 ]
 
 [package.optional-dependencies]
@@ -4026,7 +4026,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -4037,7 +4037,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -4064,9 +4064,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -4077,7 +4077,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -4358,7 +4358,7 @@ requires-dist = [
     { name = "cohere", specifier = "==5.6.1" },
     { name = "fastapi", specifier = "==0.133.1" },
     { name = "google-genai", specifier = "==1.52.0" },
-    { name = "litellm", extras = ["google"], specifier = "==1.85.1" },
+    { name = "litellm", extras = ["google"], specifier = "==1.89.4" },
     { name = "openai", specifier = "==2.38.0" },
     { name = "prometheus-client", specifier = ">=0.21.1" },
     { name = "prometheus-fastapi-instrumentator", specifier = "==8.0.0" },
@@ -4886,7 +4886,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -6479,8 +6479,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
## Description

bumps litellm to v1.89.4, a version where https://github.com/BerriAI/litellm/issues/28132 is fixed and several CVEs are patched.

## How Has This Been Tested?

n/a

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `litellm` to v1.89.4 for upstream bug fix and CVE patches, and update our monkey patch to preserve reasoning summaries in non-streaming responses. Adds a unit test for this behavior.

- **Bug Fixes**
  - Updated `LiteLLMResponsesTransformationHandler.transform_response` monkey patch to use `litellm`’s new OpenAI types and join multiple reasoning summary parts with double newlines.
  - Added unit test to ensure `reasoning_content` preserves multi-section summaries.

- **Dependencies**
  - Bumped `litellm` 1.85.1 → 1.89.4 in `pyproject.toml` and `backend/requirements/{default,dev,ee,model_server}.txt`.
  - Regenerated `uv.lock` (new `litellm` refs; normalized platform markers for some CUDA, `pexpect`, `secretstorage`).

<sup>Written for commit cabb33085f3552ca380a121d09afbfe6cd11020c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

