### PR TITLE
feat(external apps): Add granted scopes db col

### DIFF
--- a/backend/alembic/versions/582269841f06_add_granted_scopes_to_external_app_user_.py
+++ b/backend/alembic/versions/582269841f06_add_granted_scopes_to_external_app_user_.py
@@ -1,0 +1,41 @@
+"""add granted_scopes to external_app_user_credential
+
+Adds a queryable, unencrypted column for the OAuth scopes a user actually
+granted for an external app. Authorization metadata (not a secret), so it lives
+alongside — not inside — the encrypted ``user_credentials`` blob.
+
+Nullable: NULL distinguishes "no authoritative grant recorded" (provider
+doesn't report scopes, or the best-effort lookup failed) from a known granted
+set. Existing rows backfill to NULL, which is the correct "unknown" state.
+
+Revision ID: 582269841f06
+Revises: 989bc57562e4
+Create Date: 2026-07-01 12:09:19.735991
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = "582269841f06"
+down_revision = "989bc57562e4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "external_app_user_credential",
+        sa.Column(
+            "granted_scopes",
+            postgresql.ARRAY(sa.String()),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("external_app_user_credential", "granted_scopes")

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -6217,6 +6217,14 @@ class ExternalAppUserCredential(Base):
     user_credentials: Mapped[SensitiveValue[dict[str, Any]]] = mapped_column(
         EncryptedJson(), nullable=False, default=dict
     )
+    # OAuth scopes the user actually granted for this app. NULL means
+    # we have no authoritative record of the grant (provider doesn't report
+    # scopes, or the best-effort lookup failed); a non-null list is the exact
+    # set the user granted. Consumers must distinguish the two.
+    granted_scopes: Mapped[list[str] | None] = mapped_column(
+        postgresql.ARRAY(String),
+        nullable=True,
+    )
     created_at: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True),
         server_default=func.now(),


### PR DESCRIPTION
## Description
Although we request N scopes, we might only get a subset of these back. We want to actively know which scopes we have actually been granted. This persists that data as a DB row.

## How Has This Been Tested?
N/a

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a nullable `granted_scopes` array to track the OAuth scopes a user actually approved for each external app. This is stored outside the encrypted `user_credentials` to make permission checks and auditing queryable.

- **Migration**
  - Adds an Alembic migration creating `granted_scopes` (text array) on `external_app_user_credential`.
  - Existing rows default to NULL = “unknown”; treat NULL differently from an empty list.
  - Run the DB migration; no other changes required.

<sup>Written for commit 76c434675067fd28e9eee0bcb6670a2f5ba2597c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

