### PR TITLE
test(web): hide flaky access-tokens status in settings visual regression

### DIFF
--- a/web/src/views/SettingsPage.tsx
+++ b/web/src/views/SettingsPage.tsx
@@ -1691,7 +1691,11 @@ function AccountsAccessSettings() {
                 <Section gap={0}>
                   <Section flexDirection="row" padding={0.25} gap={0.5}>
                     {pats.length === 0 ? (
-                      <Section padding={0.5} alignItems="start">
+                      <Section
+                        padding={0.5}
+                        alignItems="start"
+                        data-testid="access-token-list-status"
+                      >
                         <Text font="secondary-body" color="text-03">
                           {isLoading
                             ? "Loading tokens..."

--- a/web/tests/e2e/settings/settings_pages.spec.ts
+++ b/web/tests/e2e/settings/settings_pages.spec.ts
@@ -51,10 +51,18 @@ for (const theme of THEMES) {
         // Scope the screenshot to the settings container (rendered by
         // `SettingsLayouts.Root`) so dynamic app chrome (sidebar, greeting
         // text, etc.) doesn't cause spurious diffs.
+        //
+        // The access-tokens list loads via SWR, so it flakily flips between
+        // "Loading tokens..." and "No access tokens created." depending on
+        // whether the fetch has settled — hide it to keep the diff stable.
         await expectElementScreenshot(
           page.locator("#page-wrapper-scroll-container"),
           {
             name: `settings-${theme}-${slug}`,
+            hide:
+              slug === "accounts-access"
+                ? ['[data-testid="access-token-list-status"]']
+                : [],
           }
         );
       }


### PR DESCRIPTION
## Problem

The `settings-*-accounts-access` Playwright visual regression screenshots (from `web/tests/e2e/settings/settings_pages.spec.ts`) flakily fail. The access-tokens list is fetched client-side via SWR, so the status text raced between **"Loading tokens..."** (fetch in flight) and **"No access tokens created."** (fetch settled, empty) depending on whether the request had resolved when the screenshot was captured.

## Fix

Hide the status element from the screenshot for the `accounts-access` tab only, matching the existing `DEFAULT_HIDE_SELECTORS` convention in `visualRegression.ts` (e.g. the `actions-container` "TODO: Remove once it loads consistently" entry).

- **`web/src/views/SettingsPage.tsx`** — add a stable `data-testid="access-token-list-status"` to the `Section` wrapping the loading/empty status text.
- **`web/tests/e2e/settings/settings_pages.spec.ts`** — pass `hide: ['[data-testid="access-token-list-status"]']` to `expectElementScreenshot` for the `accounts-access` slug only (other tabs unchanged).

**Why the layout stays stable:** the status `Section` is `w-full` (fills the row) and the "New Access Token" button is pinned right via `shrink-0`, so `visibility: hidden` blanks only the text pixels — the button position and surrounding layout are unaffected.

## Note

Because the status text is now hidden, the `settings-*-accounts-access` baselines will differ from the previous ones and must be re-accepted on the next `VISUAL_REGRESSION=true` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes flaky visual regression on Settings › Accounts → Access by hiding the status text that flips between “Loading tokens...” and “No access tokens created.” Adds a stable `data-testid` and hides that node only for this tab, keeping layout unchanged.

- Bug Fixes
  - In web/src/views/SettingsPage.tsx, add `data-testid="access-token-list-status"` to the status Section.
  - In web/tests/e2e/settings/settings_pages.spec.ts, hide `[data-testid="access-token-list-status"]` in `expectElementScreenshot` when `slug === 'accounts-access'`.

- Migration
  - Re-accept `settings-*-accounts-access` baselines on the next `VISUAL_REGRESSION=true` run.

<sup>Written for commit cbdb58fadc61c57c3f94d0d4b146b0b1ec29cea4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

