### PR TITLE
fix: tenant-scope and invalidate the token-rate-limit existence cache

### DIFF
--- a/backend/ee/onyx/server/token_rate_limits/api.py
+++ b/backend/ee/onyx/server/token_rate_limits/api.py
@@ -15,7 +15,9 @@ from onyx.db.enums import Permission
 from onyx.db.models import User
 from onyx.db.token_limit import fetch_all_user_token_rate_limits
 from onyx.db.token_limit import insert_user_token_rate_limit
-from onyx.server.query_and_chat.token_limit import any_rate_limit_exists
+from onyx.server.query_and_chat.token_limit import (
+    invalidate_any_rate_limit_exists_cache,
+)
 from onyx.server.token_rate_limits.models import TokenRateLimitArgs
 from onyx.server.token_rate_limits.models import TokenRateLimitDisplay
 
@@ -76,7 +78,7 @@ def create_group_token_limit_settings(
         )
     )
     # clear cache in case this was the first rate limit created
-    any_rate_limit_exists.cache_clear()
+    invalidate_any_rate_limit_exists_cache()
     return rate_limit_display
 
 
@@ -106,5 +108,5 @@ def create_user_token_limit_settings(
         insert_user_token_rate_limit(db_session, token_limit_settings)
     )
     # clear cache in case this was the first rate limit created
-    any_rate_limit_exists.cache_clear()
+    invalidate_any_rate_limit_exists_cache()
     return rate_limit_display

--- a/backend/onyx/server/query_and_chat/token_limit.py
+++ b/backend/onyx/server/query_and_chat/token_limit.py
@@ -2,8 +2,9 @@ from collections.abc import Sequence
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
-from functools import lru_cache
+from threading import RLock
 
+from cachetools import TTLCache
 from dateutil import tz
 from fastapi import Depends
 from fastapi import HTTPException
@@ -20,6 +21,7 @@ from onyx.db.models import User
 from onyx.db.token_limit import fetch_all_global_token_rate_limits
 from onyx.utils.logger import setup_logger
 from onyx.utils.variable_functionality import fetch_versioned_implementation
+from shared_configs.contextvars import get_current_tenant_id
 
 logger = setup_logger()
 
@@ -118,13 +120,29 @@ def _is_rate_limited(
     return False
 
 
-@lru_cache()
+_ANY_RATE_LIMIT_EXISTS_CACHE_TTL_SECONDS = 60
+_any_rate_limit_exists_lock = RLock()
+# tenant_id -> whether that tenant has any enabled token rate limit. Keyed by tenant so
+# one tenant's answer never suppresses another's enforcement in a shared worker. The
+# short TTL bounds staleness across processes without an explicit cross-process bust.
+_any_rate_limit_exists_cache: TTLCache[str, bool] = TTLCache(
+    maxsize=10_000, ttl=_ANY_RATE_LIMIT_EXISTS_CACHE_TTL_SECONDS
+)
+
+
 def any_rate_limit_exists() -> bool:
-    """Checks if any rate limit exists in the database. Is cached, so that if no rate limits
-    are setup, we don't have any effect on average query latency."""
+    """Whether the current tenant has any enabled token rate limit. Cached per tenant so
+    the common no-limits case stays a cheap fast-path on the chat dependency without a DB
+    query per message."""
+    tenant_id = get_current_tenant_id()
+    with _any_rate_limit_exists_lock:
+        cached = _any_rate_limit_exists_cache.get(tenant_id)
+    if cached is not None:
+        return cached
+
     logger.debug("Checking for any rate limits...")
     with get_session_with_current_tenant() as db_session:
-        return (
+        exists = (
             db_session.scalar(
                 select(TokenRateLimit.id).where(
                     TokenRateLimit.enabled == True  # noqa: E712
@@ -132,3 +150,14 @@ def any_rate_limit_exists() -> bool:
             )
             is not None
         )
+
+    with _any_rate_limit_exists_lock:
+        _any_rate_limit_exists_cache[tenant_id] = exists
+    return exists
+
+
+def invalidate_any_rate_limit_exists_cache() -> None:
+    """Drop the current tenant's cached flag after a rate-limit write so the change is
+    picked up on this process without waiting for the TTL."""
+    with _any_rate_limit_exists_lock:
+        _any_rate_limit_exists_cache.pop(get_current_tenant_id(), None)

--- a/backend/onyx/server/token_rate_limits/api.py
+++ b/backend/onyx/server/token_rate_limits/api.py
@@ -11,7 +11,9 @@ from onyx.db.token_limit import delete_token_rate_limit
 from onyx.db.token_limit import fetch_all_global_token_rate_limits
 from onyx.db.token_limit import insert_global_token_rate_limit
 from onyx.db.token_limit import update_token_rate_limit
-from onyx.server.query_and_chat.token_limit import any_rate_limit_exists
+from onyx.server.query_and_chat.token_limit import (
+    invalidate_any_rate_limit_exists_cache,
+)
 from onyx.server.token_rate_limits.models import TokenRateLimitArgs
 from onyx.server.token_rate_limits.models import TokenRateLimitDisplay
 
@@ -44,7 +46,7 @@ def create_global_token_limit_settings(
         insert_global_token_rate_limit(db_session, token_limit_settings)
     )
     # clear cache in case this was the first rate limit created
-    any_rate_limit_exists.cache_clear()
+    invalidate_any_rate_limit_exists_cache()
     return rate_limit_display
 
 

--- a/backend/onyx/server/token_rate_limits/api.py
+++ b/backend/onyx/server/token_rate_limits/api.py
@@ -62,13 +62,16 @@ def update_token_limit_settings(
     _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> TokenRateLimitDisplay:
-    return TokenRateLimitDisplay.from_db(
+    rate_limit_display = TokenRateLimitDisplay.from_db(
         update_token_rate_limit(
             db_session=db_session,
             token_rate_limit_id=token_rate_limit_id,
             token_rate_limit_settings=token_limit_settings,
         )
     )
+    # enabling/disabling a limit changes whether any rate limit exists
+    invalidate_any_rate_limit_exists_cache()
+    return rate_limit_display
 
 
 @router.delete("/rate-limit/{token_rate_limit_id}")
@@ -77,7 +80,9 @@ def delete_token_limit_settings(
     _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> None:
-    return delete_token_rate_limit(
+    delete_token_rate_limit(
         db_session=db_session,
         token_rate_limit_id=token_rate_limit_id,
     )
+    # removing a limit can change whether any rate limit exists
+    invalidate_any_rate_limit_exists_cache()

--- a/backend/tests/unit/onyx/server/query_and_chat/test_any_rate_limit_exists_tenant_scope.py
+++ b/backend/tests/unit/onyx/server/query_and_chat/test_any_rate_limit_exists_tenant_scope.py
@@ -1,0 +1,80 @@
+"""Regression coverage for tenant scoping of the token-rate-limit existence cache.
+
+`any_rate_limit_exists()` gates all token-rate-limit enforcement, so its per-process
+cache must be keyed by tenant. Otherwise the first tenant to warm it fixes the answer
+for every tenant on that worker, and a tenant that configured limits gets them silently
+bypassed."""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import onyx.server.query_and_chat.token_limit as token_limit
+from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
+
+
+@contextmanager
+def _tenant(tenant_id: str) -> Iterator[None]:
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set(tenant_id)
+    try:
+        yield
+    finally:
+        CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+
+
+def _session_for(tenant_id: str | None) -> MagicMock:
+    """Fake `get_session_with_current_tenant()` result: tenant_a has an enabled rate
+    limit (scalar returns an id), every other tenant has none (scalar returns None)."""
+    session = MagicMock()
+    session.scalar.return_value = 1 if tenant_id == "tenant_a" else None
+    ctx = MagicMock()
+    ctx.__enter__.return_value = session
+    ctx.__exit__.return_value = False
+    return ctx
+
+
+def test_any_rate_limit_exists_is_tenant_scoped_and_cached() -> None:
+    token_limit._any_rate_limit_exists_cache.clear()
+
+    def fake_get_session() -> MagicMock:
+        return _session_for(CURRENT_TENANT_ID_CONTEXTVAR.get())
+
+    with patch.object(
+        token_limit, "get_session_with_current_tenant", side_effect=fake_get_session
+    ) as mock_get_session:
+        with _tenant("tenant_a"):
+            assert token_limit.any_rate_limit_exists() is True
+            # second call for the same tenant is served from cache
+            assert token_limit.any_rate_limit_exists() is True
+
+        # a different tenant must not inherit tenant_a's cached answer
+        with _tenant("tenant_b"):
+            assert token_limit.any_rate_limit_exists() is False
+
+    # one DB check per tenant (2), not 3 — tenant_a's second call hit the cache
+    assert mock_get_session.call_count == 2
+
+
+def test_invalidate_clears_only_current_tenant() -> None:
+    token_limit._any_rate_limit_exists_cache.clear()
+
+    def fake_get_session() -> MagicMock:
+        return _session_for(CURRENT_TENANT_ID_CONTEXTVAR.get())
+
+    with patch.object(
+        token_limit, "get_session_with_current_tenant", side_effect=fake_get_session
+    ) as mock_get_session:
+        with _tenant("tenant_a"):
+            assert token_limit.any_rate_limit_exists() is True
+        with _tenant("tenant_b"):
+            assert token_limit.any_rate_limit_exists() is False
+            token_limit.invalidate_any_rate_limit_exists_cache()  # clears tenant_b only
+        # tenant_a stays cached; tenant_b was invalidated so it re-checks
+        with _tenant("tenant_a"):
+            assert token_limit.any_rate_limit_exists() is True
+        with _tenant("tenant_b"):
+            assert token_limit.any_rate_limit_exists() is False
+
+    # tenant_a checked once, tenant_b checked twice (invalidated) => 3
+    assert mock_get_session.call_count == 3


### PR DESCRIPTION
## Description

Correctness fix found during a caching audit.

- **Bug:** `any_rate_limit_exists()` gates all token-rate-limit enforcement but cached its result in a process-global zero-arg `@lru_cache`.
- **Cause:** in a shared multi-tenant worker the first tenant to warm it fixes the True/False for every tenant on that process. Most tenants have no limits, so the cached `False` makes the chat dependency short-circuit, and a tenant that configured token rate limits gets them silently not enforced. `cache_clear()` only wiped the one global entry, re-poisoned by the next caller of any tenant.
- **Fix:** key the cache by `tenant_id` (per-tenant `TTLCache`, mirrors the security-settings cache), and clear only the current tenant's entry on a rate-limit write. The short TTL also lets other processes converge without a cross-process bust.
- Also closes a pre-existing gap: the `PUT` and `DELETE` rate-limit endpoints never invalidated the cache (only `POST` did), so an enable/disable toggle or a delete previously took effect only via restart. All three write paths now invalidate.

Covers the EE user/group limits too (same gate). Single-tenant unaffected (default-schema key).

## How Has This Been Tested?

New unit test asserts the cache is tenant-scoped and that invalidation targets only the current tenant.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check