### PR TITLE
refactor(skills): simplify db mutation helpers

### DIFF
--- a/backend/onyx/db/skill.py
+++ b/backend/onyx/db/skill.py
@@ -20,6 +20,7 @@ multi-step admin flow (e.g. create row + replace grants) can roll back atomicall
 
 import hashlib
 import struct
+from collections.abc import Mapping
 from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import Enum
@@ -464,13 +465,6 @@ def create_skill__no_commit(
     author_user_id: UUID | None,
     db_session: Session,
 ) -> Skill:
-    existing = db_session.scalars(select(Skill.id).where(Skill.slug == slug)).first()
-    if existing is not None:
-        raise OnyxError(
-            OnyxErrorCode.DUPLICATE_RESOURCE,
-            f"A skill with slug '{slug}' already exists.",
-        )
-
     skill = Skill(
         slug=slug,
         name=name,
@@ -519,15 +513,6 @@ def create_built_in_skill_row__no_commit(
     ``OnyxError(DUPLICATE_RESOURCE)``, which is the desired "connect Slack once"
     behaviour.
     """
-    existing = db_session.scalars(
-        select(Skill.id).where(Skill.slug == built_in_skill_id)
-    ).first()
-    if existing is not None:
-        raise OnyxError(
-            OnyxErrorCode.DUPLICATE_RESOURCE,
-            f"A skill with slug '{built_in_skill_id}' already exists.",
-        )
-
     skill = Skill(
         slug=built_in_skill_id,
         name=name,
@@ -605,6 +590,27 @@ def replace_skill_bundle(
     return skill, old_bundle_file_id
 
 
+def update_skill_fields(
+    *,
+    skill: Skill,
+    db_session: Session,
+    is_public: bool | None = None,
+    public_permission: SkillSharePermission | None = None,
+    enabled: bool | None = None,
+) -> Skill:
+    if is_public is not None or public_permission is not None:
+        skill.public_permission = _public_permission_for_update(
+            current_permission=skill.public_permission,
+            is_public=is_public,
+            public_permission=public_permission,
+        )
+    if enabled is not None:
+        skill.enabled = enabled
+
+    db_session.flush()
+    return skill
+
+
 def patch_skill(
     *,
     skill_id: UUID,
@@ -618,36 +624,131 @@ def patch_skill(
             f"Skill {skill_id} not found.",
         )
 
-    if not isinstance(patch.is_public, UnsetType):
-        skill.public_permission = _public_permission_for_update(
-            current_permission=skill.public_permission,
-            is_public=patch.is_public,
-            public_permission=None,
-        )
-    if not isinstance(patch.enabled, UnsetType):
-        skill.enabled = patch.enabled
+    return update_skill_fields(
+        skill=skill,
+        db_session=db_session,
+        is_public=None if isinstance(patch.is_public, UnsetType) else patch.is_public,
+        enabled=None if isinstance(patch.enabled, UnsetType) else patch.enabled,
+    )
 
-    db_session.flush()
-    return skill
+
+def replace_skill_shares(
+    *,
+    skill: Skill,
+    db_session: Session,
+    user_shares: Mapping[UUID, SkillSharePermission] | None = None,
+    group_shares: Mapping[int, SkillSharePermission] | None = None,
+) -> None:
+    if user_shares is not None:
+        db_session.execute(delete(Skill__User).where(Skill__User.skill_id == skill.id))
+        for user_id, permission in user_shares.items():
+            db_session.add(
+                Skill__User(skill_id=skill.id, user_id=user_id, permission=permission)
+            )
+
+    if group_shares is not None:
+        db_session.execute(
+            delete(Skill__UserGroup).where(Skill__UserGroup.skill_id == skill.id)
+        )
+        for group_id, permission in group_shares.items():
+            db_session.add(
+                Skill__UserGroup(
+                    skill_id=skill.id,
+                    user_group_id=group_id,
+                    permission=permission,
+                )
+            )
+
+    try:
+        db_session.flush()
+    except IntegrityError as e:
+        if is_fk_violation(e):
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                "One or more share targets do not exist.",
+            ) from e
+        raise
+
+
+def transfer_skill_ownership(
+    *,
+    skill: Skill,
+    new_owner_user_id: UUID,
+    db_session: Session,
+) -> None:
+    if skill.built_in_skill_id is not None:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            f"Skill '{skill.slug}' is a built-in and cannot have its ownership transferred.",
+        )
+
+    previous_owner_user_id = skill.author_user_id
+    if new_owner_user_id == previous_owner_user_id:
+        return
+
+    try:
+        with db_session.no_autoflush:
+            skill.author_user_id = new_owner_user_id
+
+            db_session.execute(
+                delete(Skill__User).where(
+                    Skill__User.skill_id == skill.id,
+                    Skill__User.user_id == new_owner_user_id,
+                )
+            )
+
+            if previous_owner_user_id is not None:
+                existing_share = db_session.scalar(
+                    select(Skill__User).where(
+                        Skill__User.skill_id == skill.id,
+                        Skill__User.user_id == previous_owner_user_id,
+                    )
+                )
+                if existing_share is not None:
+                    existing_share.permission = SkillSharePermission.EDITOR
+                else:
+                    db_session.add(
+                        Skill__User(
+                            skill_id=skill.id,
+                            user_id=previous_owner_user_id,
+                            permission=SkillSharePermission.EDITOR,
+                        )
+                    )
+
+        db_session.flush()
+    except IntegrityError as e:
+        if is_fk_violation(e):
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                "New owner user does not exist.",
+            ) from e
+        raise
 
 
 def replace_skill_grants(
     skill_id: UUID, group_ids: Sequence[int], db_session: Session
 ) -> None:
-    if fetch_skill_by_id(skill_id, db_session) is None:
+    skill = fetch_skill_by_id(skill_id, db_session)
+    if skill is None:
         raise OnyxError(
             OnyxErrorCode.NOT_FOUND,
             f"Skill {skill_id} not found.",
         )
-    db_session.execute(
-        delete(Skill__UserGroup).where(Skill__UserGroup.skill_id == skill_id)
-    )
-    seen: set[int] = set()
+    group_shares: dict[int, SkillSharePermission] = {}
     for group_id in group_ids:
-        if group_id in seen:
-            continue
-        seen.add(group_id)
-        db_session.add(Skill__UserGroup(skill_id=skill_id, user_group_id=group_id))
+        group_shares.setdefault(group_id, SkillSharePermission.VIEWER)
+
+    db_session.execute(
+        delete(Skill__UserGroup).where(Skill__UserGroup.skill_id == skill.id)
+    )
+    for group_id, permission in group_shares.items():
+        db_session.add(
+            Skill__UserGroup(
+                skill_id=skill.id,
+                user_group_id=group_id,
+                permission=permission,
+            )
+        )
     try:
         db_session.flush()
     except IntegrityError as e:

--- a/backend/tests/external_dependency_unit/craft/test_skill_db_mutations.py
+++ b/backend/tests/external_dependency_unit/craft/test_skill_db_mutations.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+from uuid import UUID
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from onyx.db.enums import SkillSharePermission
+from onyx.db.models import Skill__User
+from onyx.db.models import Skill__UserGroup
+from onyx.db.skill import patch_skill
+from onyx.db.skill import replace_skill_grants
+from onyx.db.skill import replace_skill_shares
+from onyx.db.skill import SkillPatch
+from onyx.db.skill import transfer_skill_ownership
+from onyx.db.skill import update_skill_fields
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from tests.external_dependency_unit.craft.db_helpers import make_built_in_skill_row
+from tests.external_dependency_unit.craft.db_helpers import make_group
+from tests.external_dependency_unit.craft.db_helpers import make_skill
+from tests.external_dependency_unit.craft.db_helpers import make_user
+from tests.external_dependency_unit.craft.db_helpers import share_skill_with_group
+from tests.external_dependency_unit.craft.db_helpers import share_skill_with_user
+
+
+def _direct_share_permissions(
+    db_session: Session, skill_id: UUID
+) -> dict[UUID, SkillSharePermission]:
+    rows = db_session.scalars(
+        select(Skill__User).where(Skill__User.skill_id == skill_id)
+    ).all()
+    return {row.user_id: row.permission for row in rows}
+
+
+def _group_share_permissions(
+    db_session: Session, skill_id: UUID
+) -> dict[int, SkillSharePermission]:
+    rows = db_session.scalars(
+        select(Skill__UserGroup).where(Skill__UserGroup.skill_id == skill_id)
+    ).all()
+    return {row.user_group_id: row.permission for row in rows}
+
+
+def test_update_skill_fields_supports_permission_and_enabled_updates(
+    db_session: Session,
+) -> None:
+    skill = make_skill(db_session, is_public=False, enabled=True)
+
+    update_skill_fields(
+        skill=skill,
+        public_permission=SkillSharePermission.EDITOR,
+        enabled=False,
+        db_session=db_session,
+    )
+
+    assert skill.public_permission == SkillSharePermission.EDITOR
+    assert skill.enabled is False
+
+    update_skill_fields(
+        skill=skill,
+        is_public=False,
+        db_session=db_session,
+    )
+
+    assert skill.public_permission is None
+    assert skill.enabled is False
+
+
+def test_patch_skill_preserves_unset_fields(db_session: Session) -> None:
+    skill = make_skill(db_session, is_public=True, enabled=True)
+
+    updated = patch_skill(
+        skill_id=skill.id,
+        patch=SkillPatch(enabled=False),
+        db_session=db_session,
+    )
+
+    assert updated.enabled is False
+    assert updated.public_permission == SkillSharePermission.VIEWER
+
+    updated = patch_skill(
+        skill_id=skill.id,
+        patch=SkillPatch(is_public=False),
+        db_session=db_session,
+    )
+
+    assert updated.enabled is False
+    assert updated.public_permission is None
+
+
+def test_replace_skill_shares_replaces_requested_share_types(
+    db_session: Session,
+) -> None:
+    old_user = make_user(db_session)
+    new_user = make_user(db_session)
+    old_group = make_group(db_session)
+    new_group = make_group(db_session)
+    skill = make_skill(db_session)
+    share_skill_with_user(
+        db_session,
+        skill,
+        old_user,
+        SkillSharePermission.EDITOR,
+    )
+    share_skill_with_group(
+        db_session,
+        skill,
+        old_group,
+        SkillSharePermission.EDITOR,
+    )
+
+    replace_skill_shares(
+        skill=skill,
+        user_shares={new_user.id: SkillSharePermission.VIEWER},
+        group_shares={new_group.id: SkillSharePermission.EDITOR},
+        db_session=db_session,
+    )
+
+    assert _direct_share_permissions(db_session, skill.id) == {
+        new_user.id: SkillSharePermission.VIEWER
+    }
+    assert _group_share_permissions(db_session, skill.id) == {
+        new_group.id: SkillSharePermission.EDITOR
+    }
+
+
+def test_replace_skill_shares_leaves_omitted_share_types_unchanged(
+    db_session: Session,
+) -> None:
+    user = make_user(db_session)
+    group = make_group(db_session)
+    skill = make_skill(db_session)
+    share_skill_with_user(db_session, skill, user, SkillSharePermission.VIEWER)
+    share_skill_with_group(db_session, skill, group, SkillSharePermission.EDITOR)
+
+    replace_skill_shares(
+        skill=skill,
+        user_shares={},
+        db_session=db_session,
+    )
+
+    assert _direct_share_permissions(db_session, skill.id) == {}
+    assert _group_share_permissions(db_session, skill.id) == {
+        group.id: SkillSharePermission.EDITOR
+    }
+
+
+def test_replace_skill_grants_deduplicates_group_ids_as_viewer(
+    db_session: Session,
+) -> None:
+    first_group = make_group(db_session)
+    second_group = make_group(db_session)
+    skill = make_skill(db_session)
+
+    replace_skill_grants(
+        skill.id,
+        [first_group.id, first_group.id, second_group.id],
+        db_session,
+    )
+
+    assert _group_share_permissions(db_session, skill.id) == {
+        first_group.id: SkillSharePermission.VIEWER,
+        second_group.id: SkillSharePermission.VIEWER,
+    }
+
+
+def test_replace_skill_grants_preserves_invalid_group_message(
+    db_session: Session,
+) -> None:
+    skill = make_skill(db_session)
+
+    with pytest.raises(OnyxError) as exc_info:
+        replace_skill_grants(skill.id, [-1], db_session)
+
+    assert exc_info.value.error_code == OnyxErrorCode.INVALID_INPUT
+    assert exc_info.value.detail == "One or more group IDs do not exist."
+
+
+def test_transfer_skill_ownership_removes_new_owner_direct_share_and_upgrades_previous_owner(
+    db_session: Session,
+) -> None:
+    previous_owner = make_user(db_session)
+    new_owner = make_user(db_session)
+    skill = make_skill(db_session, author_user_id=previous_owner.id)
+    share_skill_with_user(
+        db_session,
+        skill,
+        previous_owner,
+        SkillSharePermission.VIEWER,
+    )
+    share_skill_with_user(
+        db_session,
+        skill,
+        new_owner,
+        SkillSharePermission.EDITOR,
+    )
+
+    transfer_skill_ownership(
+        skill=skill,
+        new_owner_user_id=new_owner.id,
+        db_session=db_session,
+    )
+
+    assert skill.author_user_id == new_owner.id
+    direct_shares = _direct_share_permissions(db_session, skill.id)
+    assert direct_shares == {previous_owner.id: SkillSharePermission.EDITOR}
+
+
+def test_transfer_skill_ownership_adds_previous_owner_editor_share(
+    db_session: Session,
+) -> None:
+    previous_owner = make_user(db_session)
+    new_owner = make_user(db_session)
+    skill = make_skill(db_session, author_user_id=previous_owner.id)
+
+    transfer_skill_ownership(
+        skill=skill,
+        new_owner_user_id=new_owner.id,
+        db_session=db_session,
+    )
+
+    assert skill.author_user_id == new_owner.id
+    direct_shares = _direct_share_permissions(db_session, skill.id)
+    assert direct_shares == {previous_owner.id: SkillSharePermission.EDITOR}
+
+
+def test_transfer_skill_ownership_self_transfer_preserves_direct_share(
+    db_session: Session,
+) -> None:
+    owner = make_user(db_session)
+    skill = make_skill(db_session, author_user_id=owner.id)
+    share_skill_with_user(
+        db_session,
+        skill,
+        owner,
+        SkillSharePermission.VIEWER,
+    )
+
+    transfer_skill_ownership(
+        skill=skill,
+        new_owner_user_id=owner.id,
+        db_session=db_session,
+    )
+
+    assert skill.author_user_id == owner.id
+    direct_shares = _direct_share_permissions(db_session, skill.id)
+    assert direct_shares == {owner.id: SkillSharePermission.VIEWER}
+
+
+def test_transfer_skill_ownership_rejects_built_in_skill(
+    db_session: Session,
+) -> None:
+    new_owner = make_user(db_session)
+    skill = make_built_in_skill_row(
+        db_session,
+        built_in_skill_id=f"built-in-{new_owner.id.hex[:8]}",
+    )
+
+    with pytest.raises(OnyxError) as exc_info:
+        transfer_skill_ownership(
+            skill=skill,
+            new_owner_user_id=new_owner.id,
+            db_session=db_session,
+        )
+
+    assert exc_info.value.error_code == OnyxErrorCode.INVALID_INPUT
+    assert skill.author_user_id is None
+
+
+def test_transfer_skill_ownership_rejects_missing_new_owner(
+    db_session: Session,
+) -> None:
+    previous_owner = make_user(db_session)
+    skill = make_skill(db_session, author_user_id=previous_owner.id)
+
+    with pytest.raises(OnyxError) as exc_info:
+        transfer_skill_ownership(
+            skill=skill,
+            new_owner_user_id=uuid4(),
+            db_session=db_session,
+        )
+
+    assert exc_info.value.error_code == OnyxErrorCode.INVALID_INPUT
+    assert exc_info.value.detail == "New owner user does not exist."


### PR DESCRIPTION
## Description

Adds DB mutation helper foundations for upcoming skill management changes while preserving current call-site compatibility.

- Adds object-oriented helpers for field updates, share replacement, and ownership transfer.
- Keeps existing ID-based wrappers for current API routes.
- Mirrors the mega-branch inline slug insert/flush handling and avoids a shared `_add_skill_with_unique_slug__no_commit` helper.
- Adds focused DB-helper coverage for share and ownership semantics.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies skill DB mutation helpers into small, composable functions for field updates, share/grant replacement, and ownership transfer. Keeps behavior the same and adds focused tests.

- **Refactors**
  - `patch_skill` now delegates to `update_skill_fields` to preserve unset fields and update public permission and `enabled`.
  - Share helpers: `replace_skill_shares` replaces only provided user/group shares, leaves omitted share types unchanged, and raises `INVALID_INPUT` for nonexistent targets.
  - `replace_skill_grants` deduplicates groups with default `VIEWER` and keeps the existing "One or more group IDs do not exist." message.
  - `transfer_skill_ownership` rejects built-ins, removes the new owner’s direct share, upgrades the previous owner to `EDITOR`, no-ops on self-transfer, and raises "New owner user does not exist." if the user is missing.
  - Removed pre-insert duplicate slug checks in creation helpers; added tests covering all behaviors.

<sup>Written for commit ed992b656a7cdce430b95633e2eb30e424517661. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

