### PR TITLE
feat(skills): add skill access helpers

### DIFF
--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -2074,11 +2074,19 @@ async def current_user(
     return user
 
 
+_CURATOR_OR_ADMIN_ROLES = frozenset(
+    {UserRole.GLOBAL_CURATOR, UserRole.CURATOR, UserRole.ADMIN}
+)
+
+
+def is_user_curator_or_admin(user: User) -> bool:
+    return user.role in _CURATOR_OR_ADMIN_ROLES
+
+
 async def current_curator_or_admin_user(
     user: User = Depends(current_user),
 ) -> User:
-    allowed_roles = {UserRole.GLOBAL_CURATOR, UserRole.CURATOR, UserRole.ADMIN}
-    if user.role not in allowed_roles:
+    if not is_user_curator_or_admin(user):
         raise BasicAuthenticationError(
             detail="Access denied. User is not a curator or admin.",
         )

--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -589,6 +589,14 @@ class SkillSharePermission(str, PyEnum):
     VIEWER = "VIEWER"
 
 
+class SkillAccessLevel(str, PyEnum):
+    """Computed access the requesting user holds on a skill."""
+
+    OWNER = "OWNER"
+    EDITOR = "EDITOR"
+    VIEWER = "VIEWER"
+
+
 class PersonaAccessLevel(str, PyEnum):
     """Computed access the requesting user holds on a persona.
 

--- a/backend/onyx/db/persona_sharing.py
+++ b/backend/onyx/db/persona_sharing.py
@@ -25,6 +25,16 @@ def get_user_group_ids_for_user(db_session: Session, user_id: UUID) -> set[int]:
     )
 
 
+def get_curated_user_group_ids_for_user(db_session: Session, user_id: UUID) -> set[int]:
+    return set(
+        db_session.scalars(
+            select(User__UserGroup.user_group_id)
+            .where(User__UserGroup.user_id == user_id)
+            .where(User__UserGroup.is_curator.is_(True))
+        ).all()
+    )
+
+
 def persona_ownership_is_vacant(persona: Persona) -> bool:
     """True when no live owner holds the persona: both owner refs are NULL on
     a non-builtin persona, or the owning user is deactivated or gone. Vacant

--- a/backend/onyx/server/features/skill/response_helpers.py
+++ b/backend/onyx/server/features/skill/response_helpers.py
@@ -2,7 +2,11 @@ from uuid import UUID
 
 from sqlalchemy.orm import Session
 
+from onyx.auth.schemas import UserRole
+from onyx.db.enums import SkillAccessLevel
+from onyx.db.enums import SkillSharePermission
 from onyx.db.models import Skill
+from onyx.db.models import User
 from onyx.db.skill import get_group_ids_for_skill
 from onyx.db.skill import skill_ids_with_grants
 from onyx.error_handling.error_codes import OnyxErrorCode
@@ -16,6 +20,60 @@ from onyx.skills.content import read_custom_skill_bundle_instructions
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
+
+
+def user_permission_for_skill(
+    skill: Skill,
+    user: User,
+    user_group_ids: set[int],
+    curated_user_group_ids: set[int] | None = None,
+) -> SkillAccessLevel | None:
+    if skill.built_in_skill_id is not None:
+        return SkillAccessLevel.VIEWER
+
+    if skill.author_user_id == user.id:
+        return SkillAccessLevel.OWNER
+
+    if user.role == UserRole.ADMIN:
+        return SkillAccessLevel.EDITOR
+
+    direct_permissions = {
+        share.permission for share in skill.user_shares if share.user_id == user.id
+    }
+    group_permissions = {
+        share.permission
+        for share in skill.group_shares
+        if share.user_group_id in user_group_ids
+    }
+    share_permissions = direct_permissions | group_permissions
+
+    is_org_shared = skill.public_permission is not None
+    is_shared_with_user = bool(share_permissions)
+    group_share_ids = {share.user_group_id for share in skill.group_shares}
+    curator_managed_group_ids = set[int]()
+    if user.role == UserRole.GLOBAL_CURATOR:
+        curator_managed_group_ids = user_group_ids
+    elif user.role == UserRole.CURATOR:
+        curator_managed_group_ids = curated_user_group_ids or set()
+    is_curator_managed = (
+        bool(group_share_ids)
+        and bool(curator_managed_group_ids)
+        and group_share_ids <= curator_managed_group_ids
+    )
+    has_explicit_edit = SkillSharePermission.EDITOR in share_permissions or (
+        is_org_shared and skill.public_permission == SkillSharePermission.EDITOR
+    )
+
+    if has_explicit_edit:
+        return SkillAccessLevel.EDITOR
+
+    if is_curator_managed:
+        return SkillAccessLevel.EDITOR
+
+    if is_org_shared or is_shared_with_user:
+        return SkillAccessLevel.VIEWER
+
+    return None
 
 
 def split_skill_rows(

--- a/backend/onyx/server/features/skill/response_helpers.py
+++ b/backend/onyx/server/features/skill/response_helpers.py
@@ -64,10 +64,7 @@ def user_permission_for_skill(
         is_org_shared and skill.public_permission == SkillSharePermission.EDITOR
     )
 
-    if has_explicit_edit:
-        return SkillAccessLevel.EDITOR
-
-    if is_curator_managed:
+    if has_explicit_edit or is_curator_managed:
         return SkillAccessLevel.EDITOR
 
     if is_org_shared or is_shared_with_user:

--- a/backend/tests/unit/onyx/skills/test_skill_access.py
+++ b/backend/tests/unit/onyx/skills/test_skill_access.py
@@ -1,0 +1,203 @@
+from uuid import UUID
+from uuid import uuid4
+
+from onyx.auth.schemas import UserRole
+from onyx.db.enums import SkillAccessLevel
+from onyx.db.enums import SkillSharePermission
+from onyx.db.models import Skill
+from onyx.db.models import Skill__User
+from onyx.db.models import Skill__UserGroup
+from onyx.db.models import User
+from onyx.server.features.skill.response_helpers import user_permission_for_skill
+
+
+def _user(role: UserRole = UserRole.BASIC) -> User:
+    return User(id=uuid4(), email=f"{uuid4().hex}@example.com", role=role)
+
+
+def _skill(
+    author: User,
+    *,
+    built_in_skill_id: str | None = None,
+    public_permission: SkillSharePermission | None = None,
+) -> Skill:
+    return Skill(
+        id=uuid4(),
+        slug=f"skill-{uuid4().hex}",
+        name="Skill",
+        description="Description",
+        built_in_skill_id=built_in_skill_id,
+        bundle_file_id=None if built_in_skill_id else f"bundle-{uuid4().hex}",
+        author_user_id=author.id,
+        public_permission=public_permission,
+        enabled=True,
+    )
+
+
+def _share_with_user(
+    skill: Skill,
+    user_id: UUID | None = None,
+    permission: SkillSharePermission = SkillSharePermission.VIEWER,
+) -> None:
+    skill.user_shares = [
+        Skill__User(
+            skill_id=skill.id,
+            user_id=user_id or uuid4(),
+            permission=permission,
+        )
+    ]
+
+
+def _share_with_groups(
+    skill: Skill,
+    group_ids: list[int],
+    permission: SkillSharePermission = SkillSharePermission.VIEWER,
+) -> None:
+    skill.group_shares = [
+        Skill__UserGroup(
+            skill_id=skill.id,
+            user_group_id=group_id,
+            permission=permission,
+        )
+        for group_id in group_ids
+    ]
+
+
+def test_built_in_skills_are_viewer_for_all_users() -> None:
+    user = _user()
+    skill = _skill(_user(), built_in_skill_id="built-in")
+
+    assert user_permission_for_skill(skill, user, set()) == SkillAccessLevel.VIEWER
+
+
+def test_author_retains_owner_permission_after_sharing() -> None:
+    author = _user()
+    skill = _skill(author, public_permission=SkillSharePermission.VIEWER)
+    _share_with_user(skill)
+
+    assert user_permission_for_skill(skill, author, set()) == SkillAccessLevel.OWNER
+
+
+def test_admin_can_edit_custom_skill_regardless_of_share_state() -> None:
+    admin = _user(UserRole.ADMIN)
+    skill = _skill(_user())
+
+    assert user_permission_for_skill(skill, admin, set()) == SkillAccessLevel.EDITOR
+
+
+def test_editor_grants_from_direct_group_or_org_share_grant_editor() -> None:
+    direct_user = _user()
+    direct_editor = _skill(_user())
+    _share_with_user(direct_editor, direct_user.id, SkillSharePermission.EDITOR)
+    assert (
+        user_permission_for_skill(direct_editor, direct_user, set())
+        == SkillAccessLevel.EDITOR
+    )
+
+    group_user = _user()
+    group_editor = _skill(_user())
+    _share_with_groups(group_editor, [1], SkillSharePermission.EDITOR)
+    assert (
+        user_permission_for_skill(group_editor, group_user, {1})
+        == SkillAccessLevel.EDITOR
+    )
+
+    org_user = _user()
+    org_editor = _skill(_user(), public_permission=SkillSharePermission.EDITOR)
+    assert (
+        user_permission_for_skill(org_editor, org_user, set())
+        == SkillAccessLevel.EDITOR
+    )
+
+
+def test_viewer_grants_from_direct_group_or_org_share_grant_viewer() -> None:
+    direct_user = _user()
+    direct_viewer = _skill(_user())
+    _share_with_user(direct_viewer, direct_user.id)
+    assert (
+        user_permission_for_skill(direct_viewer, direct_user, set())
+        == SkillAccessLevel.VIEWER
+    )
+
+    group_user = _user()
+    group_viewer = _skill(_user())
+    _share_with_groups(group_viewer, [1])
+    assert (
+        user_permission_for_skill(group_viewer, group_user, {1})
+        == SkillAccessLevel.VIEWER
+    )
+
+    org_user = _user()
+    org_viewer = _skill(_user(), public_permission=SkillSharePermission.VIEWER)
+    assert (
+        user_permission_for_skill(org_viewer, org_user, set())
+        == SkillAccessLevel.VIEWER
+    )
+
+
+def test_any_editor_grant_wins_over_viewer_grants() -> None:
+    user = _user()
+    skill = _skill(_user(), public_permission=SkillSharePermission.VIEWER)
+    _share_with_groups(skill, [1], SkillSharePermission.EDITOR)
+
+    assert user_permission_for_skill(skill, user, {1}) == SkillAccessLevel.EDITOR
+
+
+def test_curator_can_edit_skill_only_when_all_group_shares_are_curated() -> None:
+    curator = _user(UserRole.CURATOR)
+    managed_skill = _skill(_user())
+    _share_with_groups(managed_skill, [1, 2])
+
+    assert (
+        user_permission_for_skill(
+            managed_skill,
+            curator,
+            user_group_ids={1, 2},
+            curated_user_group_ids={1, 2},
+        )
+        == SkillAccessLevel.EDITOR
+    )
+
+    partially_managed_skill = _skill(_user())
+    _share_with_groups(partially_managed_skill, [1, 2])
+    assert (
+        user_permission_for_skill(
+            partially_managed_skill,
+            curator,
+            user_group_ids={1, 2},
+            curated_user_group_ids={1},
+        )
+        == SkillAccessLevel.VIEWER
+    )
+
+
+def test_global_curator_can_edit_skill_only_when_all_group_shares_are_member_groups() -> (
+    None
+):
+    global_curator = _user(UserRole.GLOBAL_CURATOR)
+    managed_skill = _skill(_user())
+    _share_with_groups(managed_skill, [1, 2])
+
+    assert (
+        user_permission_for_skill(
+            managed_skill,
+            global_curator,
+            user_group_ids={1, 2},
+        )
+        == SkillAccessLevel.EDITOR
+    )
+
+    partially_managed_skill = _skill(_user())
+    _share_with_groups(partially_managed_skill, [1, 2])
+    assert (
+        user_permission_for_skill(
+            partially_managed_skill,
+            global_curator,
+            user_group_ids={1},
+        )
+        == SkillAccessLevel.VIEWER
+    )
+
+
+def test_unshared_custom_skill_has_no_access_for_non_author() -> None:
+    assert user_permission_for_skill(_skill(_user()), _user(), set()) is None


### PR DESCRIPTION
## Description

Adds reusable skill access helper foundations without changing the current skills API response shape.

- Adds a shared curator/admin role helper.
- Adds curated group lookup support.
- Adds computed skill access levels and helper coverage for owner, editor, viewer, curator, and admin cases.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds helpers to compute per-user skill access (OWNER/EDITOR/VIEWER) without changing the skills API. Includes curated-group edit rules and unified editor checks across shares and curator roles.

- **New Features**
  - `user_permission_for_skill` computes access from author/admin, direct/group/org shares, and curator scope; built-ins are always VIEWER; curators/global curators can edit only when all group shares are curated/member groups.
  - Added `SkillAccessLevel` enum; `is_user_curator_or_admin` (used in `current_curator_or_admin_user`); `get_curated_user_group_ids_for_user`; unit tests for access and precedence.

- **Bug Fixes**
  - Combined editor access checks so explicit editor shares or curator-managed group shares both grant EDITOR consistently.

<sup>Written for commit 5ca378b401a899ca53596d042348766458b62492. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

