### PR TITLE
refactor(skills): centralize bundle ingestion cleanup

### DIFF
--- a/backend/onyx/server/features/build/external_apps/api.py
+++ b/backend/onyx/server/features/build/external_apps/api.py
@@ -55,7 +55,7 @@ from onyx.server.features.build.external_apps.models import UpsertUserCredential
 from onyx.server.features.build.sandbox.factory import get_sandbox_manager
 from onyx.skills.bundle import read_bundle_file
 from onyx.skills.ingest import delete_bundle_blob
-from onyx.skills.ingest import ingest_skill_bundle
+from onyx.skills.ingest import ingested_skill_bundle
 from onyx.skills.push import push_skill_to_affected_sandboxes
 from onyx.skills.push import push_skills_for_users
 from onyx.utils.encryption import mask_string
@@ -296,10 +296,11 @@ def create_custom_external_app(
         )
 
     file_store = get_default_file_store()
-    ingested = ingest_skill_bundle(
-        read_bundle_file(bundle.file), bundle.filename, file_store
-    )
-    try:
+    with ingested_skill_bundle(
+        read_bundle_file(bundle.file),
+        bundle.filename,
+        file_store,
+    ) as ingested:
         app = create_external_app(
             db_session=db_session,
             name=name.strip(),
@@ -317,9 +318,6 @@ def create_custom_external_app(
         # Push before commit so a failure rolls back the create + orphaned blob.
         push_skill_to_affected_sandboxes(app.skill, db_session)
         db_session.commit()
-    except Exception:
-        delete_bundle_blob(file_store, ingested.bundle_file_id)
-        raise
 
     return _to_admin_response(app)
 
@@ -343,10 +341,12 @@ def replace_custom_app_bundle(
         )
 
     file_store = get_default_file_store()
-    ingested = ingest_skill_bundle(
-        read_bundle_file(bundle.file), bundle.filename, file_store, slug=app.skill.slug
-    )
-    try:
+    with ingested_skill_bundle(
+        read_bundle_file(bundle.file),
+        bundle.filename,
+        file_store,
+        slug=app.skill.slug,
+    ) as ingested:
         app, old_bundle_file_id = update_external_app(
             db_session=db_session,
             external_app_id=external_app_id,
@@ -357,9 +357,6 @@ def replace_custom_app_bundle(
         # Push before commit so a failure rolls back the swap + orphaned blob.
         push_skill_to_affected_sandboxes(app.skill, db_session)
         db_session.commit()
-    except Exception:
-        delete_bundle_blob(file_store, ingested.bundle_file_id)
-        raise
 
     # Drop the superseded blob only after the swap committed.
     if old_bundle_file_id:

--- a/backend/onyx/server/features/skill/mutation_helpers.py
+++ b/backend/onyx/server/features/skill/mutation_helpers.py
@@ -17,7 +17,7 @@ from onyx.skills.built_in import EXTERNAL_APP_BUILT_IN_SKILL_IDS
 from onyx.skills.bundle import read_bundle_file
 from onyx.skills.bundle import slug_from_filename
 from onyx.skills.ingest import delete_bundle_blob
-from onyx.skills.ingest import ingest_skill_bundle
+from onyx.skills.ingest import ingested_skill_bundle as ingest_bundle_with_cleanup
 from onyx.skills.ingest import IngestedBundle
 from onyx.skills.push import push_skill_to_affected_sandboxes
 
@@ -71,18 +71,10 @@ def ingested_skill_bundle(
     slug: str | None = None,
 ) -> Iterator[IngestedBundle]:
     file_store = get_default_file_store()
-    ingested = ingest_skill_bundle(
-        read_bundle_file(bundle_file),
-        filename,
-        file_store,
-        slug=slug,
-    )
-
-    try:
+    with ingest_bundle_with_cleanup(
+        read_bundle_file(bundle_file), filename, file_store, slug=slug
+    ) as ingested:
         yield ingested
-    except Exception:
-        delete_bundle_blob(file_store, ingested.bundle_file_id)
-        raise
 
 
 def replace_custom_skill_bundle_contents(

--- a/backend/onyx/skills/ingest.py
+++ b/backend/onyx/skills/ingest.py
@@ -1,4 +1,6 @@
 import io
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import NamedTuple
 
 from onyx.configs.constants import FileOrigin
@@ -20,6 +22,20 @@ class IngestedBundle(NamedTuple):
     description: str
 
 
+def save_skill_bundle_bytes(
+    bundle_bytes: bytes,
+    *,
+    display_name: str,
+    file_store: FileStore,
+) -> str:
+    return file_store.save_file(
+        content=io.BytesIO(bundle_bytes),
+        display_name=display_name,
+        file_origin=FileOrigin.SKILL_BUNDLE,
+        file_type="application/zip",
+    )
+
+
 def ingest_skill_bundle(
     bundle_bytes: bytes,
     filename: str | None,
@@ -35,8 +51,8 @@ def ingest_skill_bundle(
     Pass ``slug`` to keep an existing row's slug when replacing a bundle on
     update; when omitted the slug is derived from ``filename`` (create path).
 
-    The caller owns DB row creation and must delete ``bundle_file_id`` if its
-    transaction fails.
+    Prefer ``ingested_skill_bundle`` when the stored blob should be cleaned up
+    automatically if the caller's transaction fails.
     """
     if slug is None:
         slug = slug_from_filename(filename)
@@ -44,11 +60,10 @@ def ingest_skill_bundle(
     name, description = parse_skill_md_metadata(bundle_bytes)
     sha = compute_bundle_sha256(bundle_bytes)
 
-    bundle_file_id = file_store.save_file(
-        content=io.BytesIO(bundle_bytes),
+    bundle_file_id = save_skill_bundle_bytes(
+        bundle_bytes,
         display_name=f"{slug}.zip",
-        file_origin=FileOrigin.SKILL_BUNDLE,
-        file_type="application/zip",
+        file_store=file_store,
     )
     return IngestedBundle(
         slug=slug,
@@ -57,6 +72,27 @@ def ingest_skill_bundle(
         name=name,
         description=description,
     )
+
+
+@contextmanager
+def ingested_skill_bundle(
+    bundle_bytes: bytes,
+    filename: str | None,
+    file_store: FileStore,
+    *,
+    slug: str | None = None,
+) -> Iterator[IngestedBundle]:
+    ingested = ingest_skill_bundle(
+        bundle_bytes,
+        filename,
+        file_store,
+        slug=slug,
+    )
+    try:
+        yield ingested
+    except Exception:
+        delete_bundle_blob(file_store, ingested.bundle_file_id)
+        raise
 
 
 def delete_bundle_blob(file_store: FileStore, file_id: str) -> None:

--- a/backend/tests/external_dependency_unit/craft/test_custom_external_app_create.py
+++ b/backend/tests/external_dependency_unit/craft/test_custom_external_app_create.py
@@ -407,7 +407,8 @@ def test_create_cleans_up_blob_on_failure(
 
     deleted: list[str] = []
     monkeypatch.setattr(
-        api, "delete_bundle_blob", lambda _fs, file_id: deleted.append(file_id)
+        "onyx.skills.ingest.delete_bundle_blob",
+        lambda _fs, file_id: deleted.append(file_id),
     )
 
     slug = f"custom-test-{uuid4().hex[:8]}"

--- a/backend/tests/unit/onyx/server/features/build/external_apps/test_api_bundle_cleanup.py
+++ b/backend/tests/unit/onyx/server/features/build/external_apps/test_api_bundle_cleanup.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import io
+from types import SimpleNamespace
+from typing import Any
+from typing import cast
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import UploadFile
+from sqlalchemy.orm import Session
+
+from onyx.db.enums import ExternalAppType
+from onyx.db.models import ExternalApp
+from onyx.file_store.file_store import FileStore
+from onyx.server.features.build.external_apps import api as external_apps_api
+from onyx.skills.ingest import IngestedBundle
+
+
+def test_create_custom_external_app_cleans_new_bundle_on_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    file_store = cast(FileStore, object())
+    delete_bundle_blob = MagicMock()
+    monkeypatch.setattr(external_apps_api, "get_default_file_store", lambda: file_store)
+    monkeypatch.setattr(
+        "onyx.skills.ingest.ingest_skill_bundle",
+        lambda *_args, **_kwargs: IngestedBundle(
+            slug="helper-skill",
+            bundle_file_id="new-bundle",
+            bundle_sha256="0" * 64,
+            name="Helper Skill",
+            description="Bundle description",
+        ),
+    )
+    monkeypatch.setattr("onyx.skills.ingest.delete_bundle_blob", delete_bundle_blob)
+
+    def raise_db_error(**_kwargs: Any) -> None:
+        raise RuntimeError("db write failed")
+
+    monkeypatch.setattr(external_apps_api, "create_external_app", raise_db_error)
+
+    with pytest.raises(RuntimeError):
+        external_apps_api.create_custom_external_app(
+            name="Helper Skill",
+            description="",
+            upstream_url_patterns='["https://api.example.com/*"]',
+            auth_template='{"Authorization": "Bearer {token}"}',
+            organization_credentials='{"token": "secret"}',
+            bundle=cast(
+                UploadFile,
+                SimpleNamespace(
+                    file=io.BytesIO(b"bundle"),
+                    filename="helper-skill.zip",
+                ),
+            ),
+            db_session=cast(Session, object()),
+        )
+
+    delete_bundle_blob.assert_called_once_with(file_store, "new-bundle")
+
+
+def test_replace_custom_app_bundle_cleans_new_bundle_on_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    file_store = cast(FileStore, object())
+    delete_bundle_blob = MagicMock()
+    app = cast(
+        ExternalApp,
+        SimpleNamespace(
+            app_type=ExternalAppType.CUSTOM,
+            skill=SimpleNamespace(slug="helper-skill"),
+        ),
+    )
+    monkeypatch.setattr(external_apps_api, "get_default_file_store", lambda: file_store)
+    monkeypatch.setattr(external_apps_api, "_get_app_or_404", lambda *_args: app)
+    monkeypatch.setattr(
+        "onyx.skills.ingest.ingest_skill_bundle",
+        lambda *_args, **_kwargs: IngestedBundle(
+            slug="helper-skill",
+            bundle_file_id="replacement-bundle",
+            bundle_sha256="1" * 64,
+            name="Helper Skill",
+            description="Bundle description",
+        ),
+    )
+    monkeypatch.setattr("onyx.skills.ingest.delete_bundle_blob", delete_bundle_blob)
+
+    def raise_db_error(**_kwargs: Any) -> None:
+        raise RuntimeError("db write failed")
+
+    monkeypatch.setattr(external_apps_api, "update_external_app", raise_db_error)
+
+    with pytest.raises(RuntimeError):
+        external_apps_api.replace_custom_app_bundle(
+            external_app_id=1,
+            bundle=cast(
+                UploadFile,
+                SimpleNamespace(
+                    file=io.BytesIO(b"bundle"),
+                    filename="helper-skill.zip",
+                ),
+            ),
+            db_session=cast(Session, object()),
+        )
+
+    delete_bundle_blob.assert_called_once_with(file_store, "replacement-bundle")

--- a/backend/tests/unit/onyx/skills/test_ingest.py
+++ b/backend/tests/unit/onyx/skills/test_ingest.py
@@ -1,0 +1,39 @@
+from typing import cast
+from unittest.mock import MagicMock
+
+import pytest
+
+from onyx.file_store.file_store import FileStore
+from onyx.skills.ingest import ingested_skill_bundle
+from onyx.skills.ingest import IngestedBundle
+
+
+def test_ingested_skill_bundle_deletes_new_blob_on_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    file_store = cast(FileStore, object())
+    delete_bundle_blob = MagicMock()
+    monkeypatch.setattr(
+        "onyx.skills.ingest.ingest_skill_bundle",
+        lambda *_args, **_kwargs: IngestedBundle(
+            slug="helper-skill",
+            bundle_file_id="new-bundle",
+            bundle_sha256="0" * 64,
+            name="Helper Skill",
+            description="Description",
+        ),
+    )
+    monkeypatch.setattr(
+        "onyx.skills.ingest.delete_bundle_blob",
+        delete_bundle_blob,
+    )
+
+    with pytest.raises(RuntimeError):
+        with ingested_skill_bundle(
+            b"bundle",
+            "helper-skill.zip",
+            file_store,
+        ):
+            raise RuntimeError("db write failed")
+
+    delete_bundle_blob.assert_called_once_with(file_store, "new-bundle")


### PR DESCRIPTION
## Description

Centralizes custom skill bundle ingestion cleanup behind shared helpers in `onyx.skills.ingest`.

- Adds a reusable bundle save helper and cleanup context manager.
- Updates skill and custom external app mutation paths to use the shared cleanup path.
- Adds focused unit coverage for bundle cleanup on failure.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes skill bundle ingestion and cleanup in `onyx.skills.ingest` to prevent orphaned blobs and remove duplicated try/except logic.

- **Refactors**
  - Added `ingested_skill_bundle` context manager for automatic blob cleanup on failures and `save_skill_bundle_bytes`; `ingest_skill_bundle` now uses the save helper.
  - Updated `external_apps` create/replace and skill mutation helpers to use the shared context manager; removed local try/except and `delete_bundle_blob` calls.
  - Added unit tests verifying cleanup on failure in `external_apps` API and the ingest context manager.

<sup>Written for commit 24d46e623901bc55bde85d9d4609c80db5c41032. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

