### PR TITLE
chore(fmt): apply oxfmt after upgrade

### DIFF
--- a/web/src/refresh-components/popovers/ActionsPopover/ActionLineItem.tsx
+++ b/web/src/refresh-components/popovers/ActionsPopover/ActionLineItem.tsx
@@ -129,21 +129,22 @@ export default function ActionLineItem({
               />
             )}
 
-            {!isSearchToolWithNoConnectors && !isUnavailable && (
-              // TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved
-              <IconButton
-                icon={SvgSlash}
-                onClick={noProp(onToggle)}
-                internal
-                aria-label={disabled ? "Enable" : "Disable"}
-                className={cn(
-                  !disabled && "invisible group-hover/LineItem:visible",
-                  // Hide when showing source count (it has its own hover behavior)
-                  shouldShowSourceCount && "hidden!"
-                )}
-                tooltip={disabled ? "Enable" : "Disable"}
-              />
-            )}
+            {!isSearchToolWithNoConnectors &&
+              !isUnavailable && (
+                // TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved
+                <IconButton
+                  icon={SvgSlash}
+                  onClick={noProp(onToggle)}
+                  internal
+                  aria-label={disabled ? "Enable" : "Disable"}
+                  className={cn(
+                    !disabled && "invisible group-hover/LineItem:visible",
+                    // Hide when showing source count (it has its own hover behavior)
+                    shouldShowSourceCount && "hidden!"
+                  )}
+                  tooltip={disabled ? "Enable" : "Disable"}
+                />
+              )}
 
             {isUnavailable && showAdminConfigure && adminConfigureHref && (
               <Button

--- a/web/src/sections/agents/AgentCard.tsx
+++ b/web/src/sections/agents/AgentCard.tsx
@@ -89,18 +89,19 @@ export default function AgentCard({ agent }: AgentCardProps) {
               description={agent.description}
               rightChildren={
                 <>
-                  {isOwnedByUser && businessTier && (
-                    // TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved
-                    <IconButton
-                      icon={SvgBarChart}
-                      tertiary
-                      onClick={noProp(() =>
-                        router.push(`/ee/agents/stats/${agent.id}` as Route)
-                      )}
-                      tooltip="View Agent Stats"
-                      className="hidden group-hover/AgentCard:flex"
-                    />
-                  )}
+                  {isOwnedByUser &&
+                    businessTier && (
+                      // TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved
+                      <IconButton
+                        icon={SvgBarChart}
+                        tertiary
+                        onClick={noProp(() =>
+                          router.push(`/ee/agents/stats/${agent.id}` as Route)
+                        )}
+                        tooltip="View Agent Stats"
+                        className="hidden group-hover/AgentCard:flex"
+                      />
+                    )}
                   {canEditAgent && (
                     // TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved
                     <IconButton


### PR DESCRIPTION
## Description

I recently upgraded oxfmt in https://github.com/onyx-dot-app/onyx/pull/12606. I ran the command below on that branch, but it seems you need to run `bun install` first or the pre-commit hook will use the stale version.

Fixes: https://github.com/onyx-dot-app/onyx/actions/runs/28545287213/job/84628931202

## How Has This Been Tested?

`prek run --all-files oxfmt`

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applied upgraded `oxfmt` formatting to `ActionLineItem.tsx` and `AgentCard.tsx` to match new style rules. No behavior changes.

<sup>Written for commit db12b9e8f0cd5a7146c7018d9eea0b7b92ded7ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

