### PR TITLE
feat(external apps): Apply granted scopes to external apps

### DIFF
--- a/backend/onyx/db/external_app.py
+++ b/backend/onyx/db/external_app.py
@@ -5,6 +5,7 @@ from uuid import UUID
 from uuid import uuid4
 
 from sqlalchemy import delete
+from sqlalchemy import func
 from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import selectinload
@@ -469,6 +470,7 @@ def upsert_external_app_user_credential(
     external_app_id: int,
     user_id: UUID,
     user_credentials: dict[str, Any],
+    granted_scopes: list[str] | None = None,
     resolve_masked_values: bool = False,
 ) -> ExternalAppUserCredential:
     """Create or replace the calling user's credentials for the app, and commit.
@@ -476,6 +478,11 @@ def upsert_external_app_user_credential(
     ``OnyxError(NOT_FOUND)`` if the app doesn't exist. ``resolve_masked_values``
     is for user form submissions that may echo masked display values; internal
     OAuth writers should store provider-returned values as-is.
+
+    ``granted_scopes`` is the authoritative OAuth grant, captured at connect
+    time. ``None`` means "don't touch it": an existing grant is preserved, so
+    the refresh and credential-form paths (which don't re-derive scopes) can't
+    clobber it. Pass a list only from the connect flow.
     """
     app = get_external_app_by_id(db_session, external_app_id)
     if app is None:
@@ -501,13 +508,24 @@ def upsert_external_app_user_credential(
         external_app_id=external_app_id,
         user_id=user_id,
         user_credentials=user_credentials,
+        granted_scopes=granted_scopes,
     )
+    # A hand-built ON CONFLICT DO UPDATE doesn't fire the column's `onupdate`,
+    # so bump `updated_at` explicitly to keep it truthful on reconnect.
+    update_set: dict[str, Any] = {
+        "user_credentials": stmt.excluded.user_credentials,
+        "updated_at": func.now(),
+    }
+    # Only overwrite granted_scopes when the caller supplied a fresh grant;
+    # otherwise leave the stored value untouched.
+    if granted_scopes is not None:
+        update_set["granted_scopes"] = stmt.excluded.granted_scopes
     stmt = stmt.on_conflict_do_update(
         index_elements=[
             ExternalAppUserCredential.external_app_id,
             ExternalAppUserCredential.user_id,
         ],
-        set_={"user_credentials": stmt.excluded.user_credentials},
+        set_=update_set,
     ).returning(ExternalAppUserCredential)
 
     cred = db_session.scalars(stmt).one()

--- a/backend/onyx/db/external_app.py
+++ b/backend/onyx/db/external_app.py
@@ -479,10 +479,9 @@ def upsert_external_app_user_credential(
     is for user form submissions that may echo masked display values; internal
     OAuth writers should store provider-returned values as-is.
 
-    ``granted_scopes`` is the authoritative OAuth grant, captured at connect
-    time. ``None`` means "don't touch it": an existing grant is preserved, so
-    the refresh and credential-form paths (which don't re-derive scopes) can't
-    clobber it. Pass a list only from the connect flow.
+    ``granted_scopes=None`` preserves any existing grant, so the refresh and
+    credential-form paths (which don't re-derive scopes) can't clobber it. Pass
+    a list only from the connect flow.
     """
     app = get_external_app_by_id(db_session, external_app_id)
     if app is None:
@@ -510,14 +509,12 @@ def upsert_external_app_user_credential(
         user_credentials=user_credentials,
         granted_scopes=granted_scopes,
     )
-    # A hand-built ON CONFLICT DO UPDATE doesn't fire the column's `onupdate`,
-    # so bump `updated_at` explicitly to keep it truthful on reconnect.
+    # ON CONFLICT DO UPDATE doesn't fire the column's `onupdate`, so bump
+    # `updated_at` explicitly.
     update_set: dict[str, Any] = {
         "user_credentials": stmt.excluded.user_credentials,
         "updated_at": func.now(),
     }
-    # Only overwrite granted_scopes when the caller supplied a fresh grant;
-    # otherwise leave the stored value untouched.
     if granted_scopes is not None:
         update_set["granted_scopes"] = stmt.excluded.granted_scopes
     stmt = stmt.on_conflict_do_update(

--- a/backend/onyx/db/external_app.py
+++ b/backend/onyx/db/external_app.py
@@ -480,10 +480,9 @@ def upsert_external_app_user_credential(
     OAuth writers should store provider-returned values as-is.
 
     ``granted_scopes`` is the connect-time OAuth grant: a list, or ``None`` when
-    a fresh authorize couldn't determine it — either value overwrites the stored
-    grant (``None`` clears a now-stale prior grant to "unknown"). Leave it
-    ``UNSET`` on the refresh and credential-form paths, which don't re-derive
-    scopes, to keep the stored grant untouched.
+    a fresh authorize couldn't determine it — both overwrite the stored value
+    (``None`` clears a now-stale grant to "unknown"). The refresh and form paths
+    leave it ``UNSET`` to keep the stored grant untouched.
     """
     app = get_external_app_by_id(db_session, external_app_id)
     if app is None:

--- a/backend/onyx/db/external_app.py
+++ b/backend/onyx/db/external_app.py
@@ -470,7 +470,7 @@ def upsert_external_app_user_credential(
     external_app_id: int,
     user_id: UUID,
     user_credentials: dict[str, Any],
-    granted_scopes: list[str] | None = None,
+    granted_scopes: list[str] | None | UnsetType = UNSET,
     resolve_masked_values: bool = False,
 ) -> ExternalAppUserCredential:
     """Create or replace the calling user's credentials for the app, and commit.
@@ -479,9 +479,11 @@ def upsert_external_app_user_credential(
     is for user form submissions that may echo masked display values; internal
     OAuth writers should store provider-returned values as-is.
 
-    ``granted_scopes=None`` preserves any existing grant, so the refresh and
-    credential-form paths (which don't re-derive scopes) can't clobber it. Pass
-    a list only from the connect flow.
+    ``granted_scopes`` is the connect-time OAuth grant: a list, or ``None`` when
+    a fresh authorize couldn't determine it — either value overwrites the stored
+    grant (``None`` clears a now-stale prior grant to "unknown"). Leave it
+    ``UNSET`` on the refresh and credential-form paths, which don't re-derive
+    scopes, to keep the stored grant untouched.
     """
     app = get_external_app_by_id(db_session, external_app_id)
     if app is None:
@@ -507,7 +509,7 @@ def upsert_external_app_user_credential(
         external_app_id=external_app_id,
         user_id=user_id,
         user_credentials=user_credentials,
-        granted_scopes=granted_scopes,
+        granted_scopes=granted_scopes if is_set(granted_scopes) else None,
     )
     # ON CONFLICT DO UPDATE doesn't fire the column's `onupdate`, so bump
     # `updated_at` explicitly.
@@ -515,7 +517,7 @@ def upsert_external_app_user_credential(
         "user_credentials": stmt.excluded.user_credentials,
         "updated_at": func.now(),
     }
-    if granted_scopes is not None:
+    if is_set(granted_scopes):
         update_set["granted_scopes"] = stmt.excluded.granted_scopes
     stmt = stmt.on_conflict_do_update(
         index_elements=[

--- a/backend/onyx/external_apps/providers/base.py
+++ b/backend/onyx/external_apps/providers/base.py
@@ -266,15 +266,11 @@ class OAuthExternalAppProvider(ExternalAppProvider, abstract=True):
         token is absent."""
 
     def extract_granted_scopes(self, response_data: dict[str, Any]) -> list[str] | None:
-        """The OAuth scopes the user actually granted, from the initial-grant
-        token response — or ``None`` when the provider gives no authoritative
-        signal (so the caller records the grant as unknown rather than empty).
+        """The scopes the user granted, from the connect-time token response, or
+        ``None`` when the provider gives no authoritative signal.
 
-        Default: the RFC 6749 §3.3 space-delimited ``scope`` field, which most
-        providers echo with the *granted* (post-downscope) scopes. Override for
-        providers that nest it (Slack's ``authed_user.scope``) or omit it from
-        the token response and require a separate lookup (HubSpot). Read only at
-        connect time: a refresh cannot change what a grant authorised.
+        Default reads the RFC 6749 §3.3 ``scope`` field. Override for providers
+        that nest it (Slack) or require a separate lookup (HubSpot).
         """
         return parse_granted_scopes(response_data.get("scope"))
 

--- a/backend/onyx/external_apps/providers/base.py
+++ b/backend/onyx/external_apps/providers/base.py
@@ -1,4 +1,3 @@
-import re
 from abc import ABC
 from abc import abstractmethod
 from collections.abc import Mapping
@@ -56,23 +55,20 @@ def token_response_error(http_response: requests.Response, body: Any) -> str | N
     return None
 
 
-# Handles space-delimited (RFC 6749 §3.3) and comma-delimited (GitHub, Slack)
-# scope strings with one rule; scope tokens contain neither whitespace nor commas.
-_SCOPE_DELIMITERS = re.compile(r"[,\s]+")
-
-
-def parse_granted_scopes(raw: Any) -> list[str] | None:
+def parse_granted_scopes(raw: object) -> list[str] | None:
     """Normalise a granted-scope signal (delimited string or list) into a scope
     list. Returns ``None`` — never ``[]`` — for an absent/empty signal, so
     callers record "grant unknown" rather than an (impossible) empty grant.
     """
     if isinstance(raw, str):
-        scopes = _SCOPE_DELIMITERS.split(raw.strip())
+        # Space- or comma-delimited (RFC 6749 §3.3; GitHub/Slack), incl. mixed
+        # forms like "repo, gist" — normalise to spaces so split() handles all.
+        parts: list[str] = raw.replace(",", " ").split()
     elif isinstance(raw, list):
-        scopes = [str(scope).strip() for scope in raw]
+        parts = [str(scope) for scope in raw]
     else:
         return None
-    scopes = [scope for scope in scopes if scope]
+    scopes = [stripped for part in parts if (stripped := part.strip())]
     return scopes or None
 
 

--- a/backend/onyx/external_apps/providers/base.py
+++ b/backend/onyx/external_apps/providers/base.py
@@ -56,20 +56,15 @@ def token_response_error(http_response: requests.Response, body: Any) -> str | N
     return None
 
 
-# OAuth scope tokens never contain whitespace or commas, so splitting on either
-# unambiguously handles the space-delimited (RFC 6749 §3.3), comma-delimited
-# (GitHub, Slack), and already-tokenised forms with one rule.
+# Handles space-delimited (RFC 6749 §3.3) and comma-delimited (GitHub, Slack)
+# scope strings with one rule; scope tokens contain neither whitespace nor commas.
 _SCOPE_DELIMITERS = re.compile(r"[,\s]+")
 
 
 def parse_granted_scopes(raw: Any) -> list[str] | None:
-    """Normalise a provider's granted-scope signal into a scope list, or
-    ``None`` when the provider gave us nothing authoritative.
-
-    Accepts a delimited string (space or comma) or an already-split list.
-    Returns ``None`` — never ``[]`` — for an absent/empty signal, so callers
-    record "grant unknown" rather than fabricating an empty grant (an empty
-    grant is meaningless for OAuth: a token always carries its base scopes).
+    """Normalise a granted-scope signal (delimited string or list) into a scope
+    list. Returns ``None`` — never ``[]`` — for an absent/empty signal, so
+    callers record "grant unknown" rather than an (impossible) empty grant.
     """
     if isinstance(raw, str):
         scopes = _SCOPE_DELIMITERS.split(raw.strip())

--- a/backend/onyx/external_apps/providers/base.py
+++ b/backend/onyx/external_apps/providers/base.py
@@ -1,3 +1,4 @@
+import re
 from abc import ABC
 from abc import abstractmethod
 from collections.abc import Mapping
@@ -53,6 +54,31 @@ def token_response_error(http_response: requests.Response, body: Any) -> str | N
     if body.get("ok") is False:
         return body.get("error") or "unknown"
     return None
+
+
+# OAuth scope tokens never contain whitespace or commas, so splitting on either
+# unambiguously handles the space-delimited (RFC 6749 §3.3), comma-delimited
+# (GitHub, Slack), and already-tokenised forms with one rule.
+_SCOPE_DELIMITERS = re.compile(r"[,\s]+")
+
+
+def parse_granted_scopes(raw: Any) -> list[str] | None:
+    """Normalise a provider's granted-scope signal into a scope list, or
+    ``None`` when the provider gave us nothing authoritative.
+
+    Accepts a delimited string (space or comma) or an already-split list.
+    Returns ``None`` — never ``[]`` — for an absent/empty signal, so callers
+    record "grant unknown" rather than fabricating an empty grant (an empty
+    grant is meaningless for OAuth: a token always carries its base scopes).
+    """
+    if isinstance(raw, str):
+        scopes = _SCOPE_DELIMITERS.split(raw.strip())
+    elif isinstance(raw, list):
+        scopes = [str(scope).strip() for scope in raw]
+    else:
+        return None
+    scopes = [scope for scope in scopes if scope]
+    return scopes or None
 
 
 class OrgCredentialField(BaseModel):
@@ -243,6 +269,19 @@ class OAuthExternalAppProvider(ExternalAppProvider, abstract=True):
         credentials to persist for the user (e.g. pull the user access token out
         of Slack's nested ``authed_user``). Raise ``OnyxError`` if the expected
         token is absent."""
+
+    def extract_granted_scopes(self, response_data: dict[str, Any]) -> list[str] | None:
+        """The OAuth scopes the user actually granted, from the initial-grant
+        token response — or ``None`` when the provider gives no authoritative
+        signal (so the caller records the grant as unknown rather than empty).
+
+        Default: the RFC 6749 §3.3 space-delimited ``scope`` field, which most
+        providers echo with the *granted* (post-downscope) scopes. Override for
+        providers that nest it (Slack's ``authed_user.scope``) or omit it from
+        the token response and require a separate lookup (HubSpot). Read only at
+        connect time: a refresh cannot change what a grant authorised.
+        """
+        return parse_granted_scopes(response_data.get("scope"))
 
     # --- Refresh template method (override a hook below, not this) ---
 

--- a/backend/onyx/external_apps/providers/hubspot.py
+++ b/backend/onyx/external_apps/providers/hubspot.py
@@ -1,4 +1,5 @@
 from typing import Any
+from urllib.parse import quote
 
 import requests
 
@@ -256,7 +257,7 @@ class HubspotProvider(OAuthExternalAppProvider, OnyxManagedExtApp):
             return None
         try:
             response = requests.get(
-                _TOKEN_INFO_URL.format(access_token=access_token),
+                _TOKEN_INFO_URL.format(access_token=quote(access_token, safe="")),
                 timeout=_TOKEN_INFO_TIMEOUT_SECONDS,
             )
             response.raise_for_status()

--- a/backend/onyx/external_apps/providers/hubspot.py
+++ b/backend/onyx/external_apps/providers/hubspot.py
@@ -17,7 +17,19 @@ from onyx.external_apps.providers.base import OAuthFlowSpec
 from onyx.external_apps.providers.base import OAuthProviderSpec
 from onyx.external_apps.providers.base import OnyxManagedExtApp
 from onyx.external_apps.providers.base import OrgCredentialField
+from onyx.external_apps.providers.base import parse_granted_scopes
 from onyx.external_apps.providers.base import token_response_error
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+# HubSpot's token response omits the granted scopes, so the actual per-user
+# grant (which diverges under `optional_scope`, ENG-4260) is read from the
+# token-info endpoint, which returns a `scopes` array.
+_TOKEN_INFO_URL = "https://api.hubapi.com/oauth/v1/access-tokens/{access_token}"
+
+# Bounded so a slow/hung token-info call can't pin the OAuth connect flow.
+_TOKEN_INFO_TIMEOUT_SECONDS = 15.0
 
 
 class HubspotAction(ExternalAppAction):
@@ -232,3 +244,30 @@ class HubspotProvider(OAuthExternalAppProvider, OnyxManagedExtApp):
         if response_data.get("expires_in"):
             creds["expires_in"] = response_data["expires_in"]
         return creds
+
+    def extract_granted_scopes(self, response_data: dict[str, Any]) -> list[str] | None:
+        """HubSpot omits the granted scopes from the token response, so read
+        them from the token-info endpoint. Strictly best-effort: any
+        network/HTTP/JSON error returns ``None`` (grant unknown) rather than
+        breaking connect — the caller persists the credential regardless.
+        """
+        access_token = response_data.get("access_token")
+        if not access_token:
+            return None
+        try:
+            response = requests.get(
+                _TOKEN_INFO_URL.format(access_token=access_token),
+                timeout=_TOKEN_INFO_TIMEOUT_SECONDS,
+            )
+            response.raise_for_status()
+            body = response.json()
+        except (requests.RequestException, ValueError) as exc:
+            logger.warning(
+                "Could not fetch HubSpot granted scopes from the token-info "
+                "endpoint; recording the grant as unknown: %s",
+                exc,
+            )
+            return None
+        return parse_granted_scopes(
+            body.get("scopes") if isinstance(body, dict) else None
+        )

--- a/backend/onyx/external_apps/providers/hubspot.py
+++ b/backend/onyx/external_apps/providers/hubspot.py
@@ -25,8 +25,8 @@ from onyx.utils.logger import setup_logger
 logger = setup_logger()
 
 # HubSpot's token response omits the granted scopes, so the actual per-user
-# grant (which diverges under `optional_scope`, ENG-4260) is read from the
-# token-info endpoint, which returns a `scopes` array.
+# grant (which diverges under `optional_scope`) is read from the token-info
+# endpoint, which returns a `scopes` array.
 _TOKEN_INFO_URL = "https://api.hubapi.com/oauth/v1/access-tokens/{access_token}"
 
 # Bounded so a slow/hung token-info call can't pin the OAuth connect flow.

--- a/backend/onyx/external_apps/providers/hubspot.py
+++ b/backend/onyx/external_apps/providers/hubspot.py
@@ -247,10 +247,9 @@ class HubspotProvider(OAuthExternalAppProvider, OnyxManagedExtApp):
         return creds
 
     def extract_granted_scopes(self, response_data: dict[str, Any]) -> list[str] | None:
-        """HubSpot omits the granted scopes from the token response, so read
-        them from the token-info endpoint. Strictly best-effort: any
+        """Reads the grant from the token-info endpoint. Best-effort: any
         network/HTTP/JSON error returns ``None`` (grant unknown) rather than
-        breaking connect — the caller persists the credential regardless.
+        breaking connect.
         """
         access_token = response_data.get("access_token")
         if not access_token:

--- a/backend/onyx/external_apps/providers/slack.py
+++ b/backend/onyx/external_apps/providers/slack.py
@@ -15,6 +15,7 @@ from onyx.external_apps.providers.base import OAuthFlowSpec
 from onyx.external_apps.providers.base import OAuthProviderSpec
 from onyx.external_apps.providers.base import OnyxManagedExtApp
 from onyx.external_apps.providers.base import OrgCredentialField
+from onyx.external_apps.providers.base import parse_granted_scopes
 
 
 class SlackAction(ExternalAppAction):
@@ -180,3 +181,9 @@ class SlackProvider(OAuthExternalAppProvider, OnyxManagedExtApp):
         if authed_user.get("expires_in"):
             creds["expires_in"] = authed_user["expires_in"]
         return creds
+
+    def extract_granted_scopes(self, response_data: dict[str, Any]) -> list[str] | None:
+        # The user token's granted scopes live under `authed_user.scope` (the
+        # top-level `scope` would be the bot's), comma-delimited.
+        authed_user = response_data.get("authed_user") or {}
+        return parse_granted_scopes(authed_user.get("scope"))

--- a/backend/onyx/server/features/build/external_apps/oauth.py
+++ b/backend/onyx/server/features/build/external_apps/oauth.py
@@ -236,9 +236,8 @@ def handle_external_app_oauth_callback(
         provider.extract_credentials(response_data), datetime.now(timezone.utc)
     )
 
-    # The authorize-time grant is authoritative and captured only here (a
-    # refresh can't change it). None when the provider gives no signal, which
-    # the upsert records as "unknown" without disturbing a prior grant.
+    # The grant is authoritative and captured only here (a refresh can't change
+    # it); None when the provider gives no signal.
     granted_scopes = provider.extract_granted_scopes(response_data)
 
     upsert_external_app_user_credential(

--- a/backend/onyx/server/features/build/external_apps/oauth.py
+++ b/backend/onyx/server/features/build/external_apps/oauth.py
@@ -236,11 +236,17 @@ def handle_external_app_oauth_callback(
         provider.extract_credentials(response_data), datetime.now(timezone.utc)
     )
 
+    # The authorize-time grant is authoritative and captured only here (a
+    # refresh can't change it). None when the provider gives no signal, which
+    # the upsert records as "unknown" without disturbing a prior grant.
+    granted_scopes = provider.extract_granted_scopes(response_data)
+
     upsert_external_app_user_credential(
         db_session,
         external_app_id=app.id,
         user_id=user.id,
         user_credentials=stored_credentials,
+        granted_scopes=granted_scopes,
     )
 
     # Authenticating opens this user's per-user gate; refresh their sandboxes so

--- a/backend/tests/external_dependency_unit/craft/test_granted_scopes_persistence.py
+++ b/backend/tests/external_dependency_unit/craft/test_granted_scopes_persistence.py
@@ -1,0 +1,174 @@
+"""Persisting the OAuth grant onto ``ExternalAppUserCredential.granted_scopes``
+via ``upsert_external_app_user_credential`` (ENG-4261).
+
+The connect flow records the authoritative grant; refresh and credential-form
+saves pass ``granted_scopes=None`` and must leave a prior grant untouched."""
+
+from __future__ import annotations
+
+import time
+
+from sqlalchemy.orm import Session
+
+from onyx.db.enums import ExternalAppType
+from onyx.db.external_app import get_external_app_user_credential
+from onyx.db.external_app import upsert_external_app_user_credential
+from onyx.db.models import ExternalApp
+from tests.external_dependency_unit.craft.db_helpers import make_external_app
+from tests.external_dependency_unit.craft.db_helpers import make_skill
+from tests.external_dependency_unit.craft.db_helpers import make_user
+
+_BEARER = {"Authorization": "Bearer {access_token}"}
+
+
+def _hubspot_app(db_session: Session) -> ExternalApp:
+    return make_external_app(
+        db_session,
+        skill=make_skill(db_session),
+        auth_template=_BEARER,
+        app_type=ExternalAppType.HUBSPOT,
+    )
+
+
+def test_connect_records_granted_scopes(
+    db_session: Session,
+    test_user: object,  # noqa: ARG001
+) -> None:
+    user = make_user(db_session)
+    app = _hubspot_app(db_session)
+
+    upsert_external_app_user_credential(
+        db_session,
+        external_app_id=app.id,
+        user_id=user.id,
+        user_credentials={"access_token": "t"},
+        granted_scopes=["crm.read", "crm.write"],
+    )
+
+    cred = get_external_app_user_credential(
+        db_session, external_app_id=app.id, user_id=user.id
+    )
+    assert cred is not None
+    assert cred.granted_scopes == ["crm.read", "crm.write"]
+
+
+def test_missing_scopes_leaves_grant_unknown(
+    db_session: Session,
+    test_user: object,  # noqa: ARG001
+) -> None:
+    """A new row written without a grant (provider gave no signal) is NULL —
+    not an empty list — so downstream can tell "unknown" from "granted none"."""
+    user = make_user(db_session)
+    app = _hubspot_app(db_session)
+
+    upsert_external_app_user_credential(
+        db_session,
+        external_app_id=app.id,
+        user_id=user.id,
+        user_credentials={"access_token": "t"},
+    )
+
+    cred = get_external_app_user_credential(
+        db_session, external_app_id=app.id, user_id=user.id
+    )
+    assert cred is not None
+    assert cred.granted_scopes is None
+
+
+def test_refresh_preserves_existing_grant(
+    db_session: Session,
+    test_user: object,  # noqa: ARG001
+) -> None:
+    """A later upsert with ``granted_scopes=None`` (the refresh / form path)
+    rotates the credential but must not wipe the stored grant."""
+    user = make_user(db_session)
+    app = _hubspot_app(db_session)
+
+    upsert_external_app_user_credential(
+        db_session,
+        external_app_id=app.id,
+        user_id=user.id,
+        user_credentials={"access_token": "t1"},
+        granted_scopes=["crm.read", "crm.write"],
+    )
+    upsert_external_app_user_credential(
+        db_session,
+        external_app_id=app.id,
+        user_id=user.id,
+        user_credentials={"access_token": "t2"},
+    )
+
+    cred = get_external_app_user_credential(
+        db_session, external_app_id=app.id, user_id=user.id
+    )
+    assert cred is not None
+    assert cred.user_credentials.get_value(apply_mask=False)["access_token"] == "t2"
+    assert cred.granted_scopes == ["crm.read", "crm.write"]
+
+
+def test_reconnect_bumps_updated_at(
+    db_session: Session,
+    test_user: object,  # noqa: ARG001
+) -> None:
+    """A conflict-update refreshes `updated_at` (the hand-built ON CONFLICT
+    clause sets it explicitly, since the column `onupdate` doesn't fire)."""
+    user = make_user(db_session)
+    app = _hubspot_app(db_session)
+
+    first = upsert_external_app_user_credential(
+        db_session,
+        external_app_id=app.id,
+        user_id=user.id,
+        user_credentials={"access_token": "t1"},
+    )
+    # The conflict path returns the identity-mapped instance without
+    # repopulating it from RETURNING, so reload to read the DB's real values.
+    db_session.refresh(first)
+    original_created_at = first.created_at
+    original_updated_at = first.updated_at
+
+    # `now()` is transaction-start time; a brief gap guarantees the second
+    # transaction's timestamp is strictly later, so the assertion isn't flaky.
+    time.sleep(0.05)
+
+    second = upsert_external_app_user_credential(
+        db_session,
+        external_app_id=app.id,
+        user_id=user.id,
+        user_credentials={"access_token": "t2"},
+    )
+    db_session.refresh(second)
+
+    assert second.updated_at > original_updated_at
+    # created_at is untouched — this is an update, not a re-insert.
+    assert second.created_at == original_created_at
+
+
+def test_reconnect_overwrites_grant(
+    db_session: Session,
+    test_user: object,  # noqa: ARG001
+) -> None:
+    """Reconnecting (a fresh grant) replaces the stored scopes wholesale."""
+    user = make_user(db_session)
+    app = _hubspot_app(db_session)
+
+    upsert_external_app_user_credential(
+        db_session,
+        external_app_id=app.id,
+        user_id=user.id,
+        user_credentials={"access_token": "t"},
+        granted_scopes=["crm.read"],
+    )
+    upsert_external_app_user_credential(
+        db_session,
+        external_app_id=app.id,
+        user_id=user.id,
+        user_credentials={"access_token": "t"},
+        granted_scopes=["crm.read", "crm.write", "crm.delete"],
+    )
+
+    cred = get_external_app_user_credential(
+        db_session, external_app_id=app.id, user_id=user.id
+    )
+    assert cred is not None
+    assert cred.granted_scopes == ["crm.read", "crm.write", "crm.delete"]

--- a/backend/tests/external_dependency_unit/craft/test_granted_scopes_persistence.py
+++ b/backend/tests/external_dependency_unit/craft/test_granted_scopes_persistence.py
@@ -1,8 +1,9 @@
 """Persisting the OAuth grant onto ``ExternalAppUserCredential.granted_scopes``
 via ``upsert_external_app_user_credential`` (ENG-4261).
 
-The connect flow records the authoritative grant; refresh and credential-form
-saves pass ``granted_scopes=None`` and must leave a prior grant untouched."""
+The connect flow records the authoritative grant (a list, or ``None`` for
+"unknown" — both overwrite); refresh and credential-form saves omit the
+argument (``UNSET``) and must leave a prior grant untouched."""
 
 from __future__ import annotations
 
@@ -56,8 +57,8 @@ def test_missing_scopes_leaves_grant_unknown(
     db_session: Session,
     test_user: object,  # noqa: ARG001
 ) -> None:
-    """A new row written without a grant (provider gave no signal) is NULL —
-    not an empty list — so downstream can tell "unknown" from "granted none"."""
+    """A new row written without a grant argument is NULL — not an empty list —
+    so downstream can tell "unknown" from "granted none"."""
     user = make_user(db_session)
     app = _hubspot_app(db_session)
 
@@ -79,7 +80,7 @@ def test_refresh_preserves_existing_grant(
     db_session: Session,
     test_user: object,  # noqa: ARG001
 ) -> None:
-    """A later upsert with ``granted_scopes=None`` (the refresh / form path)
+    """A later upsert that omits ``granted_scopes`` (the refresh / form path)
     rotates the credential but must not wipe the stored grant."""
     user = make_user(db_session)
     app = _hubspot_app(db_session)
@@ -104,6 +105,38 @@ def test_refresh_preserves_existing_grant(
     assert cred is not None
     assert cred.user_credentials.get_value(apply_mask=False)["access_token"] == "t2"
     assert cred.granted_scopes == ["crm.read", "crm.write"]
+
+
+def test_reconnect_with_unknown_grant_clears_stale_scopes(
+    db_session: Session,
+    test_user: object,  # noqa: ARG001
+) -> None:
+    """A reconnect whose scope extraction failed passes ``granted_scopes=None``
+    and must clear the prior grant to NULL — a fresh authorize can change the
+    grant, so keeping the old scopes would be stale."""
+    user = make_user(db_session)
+    app = _hubspot_app(db_session)
+
+    upsert_external_app_user_credential(
+        db_session,
+        external_app_id=app.id,
+        user_id=user.id,
+        user_credentials={"access_token": "t1"},
+        granted_scopes=["crm.read", "crm.write"],
+    )
+    upsert_external_app_user_credential(
+        db_session,
+        external_app_id=app.id,
+        user_id=user.id,
+        user_credentials={"access_token": "t2"},
+        granted_scopes=None,
+    )
+
+    cred = get_external_app_user_credential(
+        db_session, external_app_id=app.id, user_id=user.id
+    )
+    assert cred is not None
+    assert cred.granted_scopes is None
 
 
 def test_reconnect_bumps_updated_at(

--- a/backend/tests/unit/external_apps/test_provider_granted_scopes.py
+++ b/backend/tests/unit/external_apps/test_provider_granted_scopes.py
@@ -1,0 +1,157 @@
+"""Per-provider granted-scope extraction (ENG-4261).
+
+On the OAuth callback each provider derives the scopes the user actually
+granted, persisted onto ``ExternalAppUserCredential.granted_scopes`` for
+downstream action gating. Most providers echo the RFC 6749 ``scope`` field and
+inherit the base default; only Slack (nested) and HubSpot (out-of-band lookup)
+override. A signal we can't read is recorded as ``None`` — never an empty
+grant."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+import requests
+
+from onyx.db.enums import ExternalAppType
+from onyx.external_apps.providers import hubspot as hubspot_module
+from onyx.external_apps.providers.base import OAuthExternalAppProvider
+from onyx.external_apps.providers.base import parse_granted_scopes
+from onyx.external_apps.providers.hubspot import HubspotProvider
+from onyx.external_apps.providers.registry import PROVIDERS
+
+
+def _oauth_provider(app_type: ExternalAppType) -> OAuthExternalAppProvider:
+    provider = PROVIDERS[app_type]
+    assert isinstance(provider, OAuthExternalAppProvider)
+    return provider
+
+
+# --- parse_granted_scopes: the shared, delimiter-tolerant normaliser ---------
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("a b c", ["a", "b", "c"]),  # RFC 6749 space-delimited
+        ("a,b,c", ["a", "b", "c"]),  # comma-delimited (GitHub, Slack)
+        ("  a   b,c ,, ", ["a", "b", "c"]),  # mixed delimiters + empties dropped
+        (["a", " b ", "c"], ["a", "b", "c"]),  # already tokenised
+        ("single", ["single"]),
+    ],
+)
+def test_parse_granted_scopes_parses(raw: Any, expected: list[str]) -> None:
+    assert parse_granted_scopes(raw) == expected
+
+
+@pytest.mark.parametrize("raw", [None, "", "   ", ",, ", [], ["", "  "], 42, {}])
+def test_parse_granted_scopes_absent_is_none(raw: Any) -> None:
+    """An absent/empty signal is None (grant unknown), never an empty list."""
+    assert parse_granted_scopes(raw) is None
+
+
+# --- Default: providers that echo the top-level `scope` field ----------------
+
+
+def test_github_default_reads_comma_delimited_scope() -> None:
+    granted = _oauth_provider(ExternalAppType.GITHUB).extract_granted_scopes(
+        {"access_token": "at", "scope": "repo,read:org,read:user"}
+    )
+    assert granted == ["repo", "read:org", "read:user"]
+
+
+def test_google_default_reads_space_delimited_scope() -> None:
+    granted = _oauth_provider(ExternalAppType.GMAIL).extract_granted_scopes(
+        {"access_token": "at", "scope": "openid https://mail.google.com/"}
+    )
+    assert granted == ["openid", "https://mail.google.com/"]
+
+
+def test_default_missing_scope_is_none() -> None:
+    provider = _oauth_provider(ExternalAppType.LINEAR)
+    assert provider.extract_granted_scopes({"access_token": "at"}) is None
+
+
+# --- Slack: scope is nested under `authed_user` ------------------------------
+
+
+def test_slack_reads_nested_authed_user_scope() -> None:
+    granted = _oauth_provider(ExternalAppType.SLACK).extract_granted_scopes(
+        {
+            "access_token": "bot-token",
+            "authed_user": {"scope": "channels:read,chat:write"},
+        }
+    )
+    assert granted == ["channels:read", "chat:write"]
+
+
+def test_slack_missing_authed_user_is_none() -> None:
+    provider = _oauth_provider(ExternalAppType.SLACK)
+    assert provider.extract_granted_scopes({"access_token": "bot-token"}) is None
+
+
+# --- HubSpot: out-of-band token-info lookup, strictly best-effort ------------
+
+
+def _token_info_response(status_code: int, body: Any) -> requests.Response:
+    response = requests.Response()
+    response.status_code = status_code
+    response._content = json.dumps(body).encode()
+    return response
+
+
+def _patch_token_info(
+    monkeypatch: pytest.MonkeyPatch, response_or_exc: object
+) -> dict[str, Any]:
+    captured: dict[str, Any] = {}
+
+    def _get(url: str, **kwargs: Any) -> object:
+        captured["url"] = url
+        captured["timeout"] = kwargs.get("timeout")
+        if isinstance(response_or_exc, Exception):
+            raise response_or_exc
+        return response_or_exc
+
+    monkeypatch.setattr(hubspot_module.requests, "get", _get)
+    return captured
+
+
+def test_hubspot_fetches_granted_scopes(monkeypatch: pytest.MonkeyPatch) -> None:
+    scopes = ["crm.objects.contacts.read", "crm.objects.contacts.write"]
+    captured = _patch_token_info(
+        monkeypatch, _token_info_response(200, {"scopes": scopes})
+    )
+
+    granted = HubspotProvider().extract_granted_scopes({"access_token": "at-123"})
+
+    assert granted == scopes
+    assert captured["url"].endswith("/oauth/v1/access-tokens/at-123")
+
+
+def test_hubspot_network_error_is_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_token_info(monkeypatch, requests.ConnectionError("connection reset"))
+    assert HubspotProvider().extract_granted_scopes({"access_token": "at"}) is None
+
+
+def test_hubspot_http_error_is_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_token_info(monkeypatch, _token_info_response(401, {"message": "expired"}))
+    assert HubspotProvider().extract_granted_scopes({"access_token": "at"}) is None
+
+
+def test_hubspot_missing_scopes_field_is_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_token_info(monkeypatch, _token_info_response(200, {"hub_id": 42}))
+    assert HubspotProvider().extract_granted_scopes({"access_token": "at"}) is None
+
+
+def test_hubspot_missing_access_token_skips_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _boom(*_a: Any, **_k: Any) -> object:
+        raise AssertionError("token-info must not be called without an access token")
+
+    monkeypatch.setattr(hubspot_module.requests, "get", _boom)
+    assert HubspotProvider().extract_granted_scopes({}) is None


### PR DESCRIPTION
## Description
Persist the scopes a user actually granted, per user, on the OAuth callback.



## How Has This Been Tested?
Manual + Tests

## Additional Options

Fixes ENG-4261
https://linear.app/onyx-app/issue/ENG-4261/persist-per-user-granted-hubspot-scopes-after-oauth-callback

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply per-user OAuth scope grants to external apps and persist them as `granted_scopes` on each credential for accurate permission checks. Implements ENG-4261 with HubSpot support, Slack nesting, and a shared parser for consistent scope extraction; also ensures `updated_at` is bumped on credential updates.

- **New Features**
  - On OAuth callback, extract and save the user’s granted scopes; refresh/credential-form saves omit this to preserve existing grants.
  - `upsert_external_app_user_credential` accepts `granted_scopes`: provided list overwrites; `None` clears; `UNSET` leaves unchanged; `updated_at` is explicitly set on conflict.
  - Provider extraction: default reads space/comma-delimited `scope`; Slack reads `authed_user.scope`; HubSpot fetches via the token-info endpoint (best-effort, 15s timeout). Shared parser accepts strings/lists and returns `None` when absent.

- **Migration**
  - Run Alembic migration `582269841f06`. Existing rows remain `NULL` (grant unknown).

<sup>Written for commit 9ff83a3e5635a8218176f7fdef153510245f8b76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

