### PR TITLE
chore(deps): upgrade litellm: `1.83.0`->`1.85.1` to release v3.3

### DIFF
--- a/.github/actions/setup-python-and-install-dependencies/action.yml
+++ b/.github/actions/setup-python-and-install-dependencies/action.yml
@@ -64,8 +64,18 @@ runs:
       env:
         REQUIREMENTS: ${{ inputs.requirements }}
       run: |
-        # Build the uv pip install command with each requirement file as array elements
-        cmd=("uv" "pip" "install")
+        # NOTE: --require-hashes is intentionally omitted on this branch. The
+        # requirements files here are version-pinned but not hash-pinned, so
+        # --require-hashes would reject them (e.g. agent-client-protocol==0.7.1
+        # has no hash). We rely on the exact version pins instead.
+        # TODO: drop --no-config and --no-deps once litellm no longer requires
+        # [tool.uv].override-dependencies in pyproject.toml. The overrides
+        # exist to relax litellm's exact transitive pins (e.g. jsonschema,
+        # aiohttp); they're unpinned ranges. --no-config keeps uv from picking
+        # up the root pyproject.toml; --no-deps keeps uv from re-resolving
+        # transitive deps from package metadata (the requirements file is
+        # already a complete, pinned export of uv.lock).
+        cmd=("uv" "pip" "install" "--no-config" "--no-deps")
         while IFS= read -r req; do
           # Skip empty lines
           if [ -n "$req" ]; then

--- a/.github/actions/setup-python-and-install-dependencies/action.yml
+++ b/.github/actions/setup-python-and-install-dependencies/action.yml
@@ -64,18 +64,8 @@ runs:
       env:
         REQUIREMENTS: ${{ inputs.requirements }}
       run: |
-        # NOTE: --require-hashes is intentionally omitted on this branch. The
-        # requirements files here are version-pinned but not hash-pinned, so
-        # --require-hashes would reject them (e.g. agent-client-protocol==0.7.1
-        # has no hash). We rely on the exact version pins instead.
-        # TODO: drop --no-config and --no-deps once litellm no longer requires
-        # [tool.uv].override-dependencies in pyproject.toml. The overrides
-        # exist to relax litellm's exact transitive pins (e.g. jsonschema,
-        # aiohttp); they're unpinned ranges. --no-config keeps uv from picking
-        # up the root pyproject.toml; --no-deps keeps uv from re-resolving
-        # transitive deps from package metadata (the requirements file is
-        # already a complete, pinned export of uv.lock).
-        cmd=("uv" "pip" "install" "--no-config" "--no-deps")
+        # Build the uv pip install command with each requirement file as array elements
+        cmd=("uv" "pip" "install")
         while IFS= read -r req; do
           # Skip empty lines
           if [ -n "$req" ]; then

--- a/.github/workflows/pr-external-dependency-unit-tests.yml
+++ b/.github/workflows/pr-external-dependency-unit-tests.yml
@@ -161,6 +161,7 @@ jobs:
             -o junit_family=xunit2 \
             -xv \
             --ff \
+            -m "not nightly" \
             backend/tests/external_dependency_unit/${TEST_DIR}
 
       - name: Collect Docker logs on failure

--- a/backend/onyx/llm/litellm_singleton/monkey_patches.py
+++ b/backend/onyx/llm/litellm_singleton/monkey_patches.py
@@ -3,7 +3,7 @@ LiteLLM Monkey Patches
 
 This module addresses the following issues in LiteLLM:
 
-Status checked against LiteLLM v1.83.0 (2026-03-31):
+Status checked against LiteLLM v1.83.14 (2026-05-04):
 
 1. Ollama Streaming Reasoning Content (_patch_ollama_chunk_parser):
    - LiteLLM's chunk_parser doesn't properly handle reasoning content in streaming
@@ -187,7 +187,12 @@ def _patch_ollama_chunk_parser() -> None:
                 tool_calls=tool_calls,
             )
             if chunk["done"] is True:
-                finish_reason = chunk.get("done_reason", "stop")
+                finish_reason = chunk.get("done_reason") or "stop"
+                # Mirror upstream's fix for BerriAI/litellm#18922: when tool
+                # calls are present, override done_reason to "tool_calls" so
+                # downstream consumers branch correctly.
+                if tool_calls:
+                    finish_reason = "tool_calls"
                 choices = [
                     StreamingChoices(
                         delta=delta,
@@ -499,11 +504,17 @@ def _patch_responses_api_usage_format() -> None:
                             total_tokens=usage.get("total_tokens", 0),
                         )
                     elif "input_tokens" in usage or "output_tokens" in usage:
-                        # Already in Responses API format, just convert to proper type
+                        # Already in Responses API format, just convert to proper type.
+                        # List every field explicitly so a new field added upstream
+                        # surfaces here (and in the audit header) instead of being
+                        # silently dropped or silently absorbed.
                         values["usage"] = ResponseAPIUsage(
                             input_tokens=usage.get("input_tokens", 0),
+                            input_tokens_details=usage.get("input_tokens_details"),
                             output_tokens=usage.get("output_tokens", 0),
+                            output_tokens_details=usage.get("output_tokens_details"),
                             total_tokens=usage.get("total_tokens", 0),
+                            cost=usage.get("cost"),
                         )
 
         # Call original model_construct (need to call it as unbound method)
@@ -544,7 +555,7 @@ def _patch_logging_assembled_streaming_response() -> None:
         return
 
     def _patched_get_assembled_streaming_response(
-        self: Any,  # noqa: ARG001
+        self: Any,
         result: Any,
         start_time: Any,  # noqa: ARG001
         end_time: Any,  # noqa: ARG001
@@ -559,6 +570,8 @@ def _patch_logging_assembled_streaming_response() -> None:
         This patch uses model_construct to rebuild the response with the transformed
         usage, ensuring proper typing.
         """
+        if self.stream is not True:
+            return None
         if isinstance(result, ModelResponse):
             return result
         elif isinstance(result, TextCompletionResponse):

--- a/backend/onyx/llm/litellm_singleton/monkey_patches.py
+++ b/backend/onyx/llm/litellm_singleton/monkey_patches.py
@@ -3,7 +3,7 @@ LiteLLM Monkey Patches
 
 This module addresses the following issues in LiteLLM:
 
-Status checked against LiteLLM v1.83.14 (2026-05-04):
+Status checked against LiteLLM v1.85.1 (2026-05-26):
 
 1. Ollama Streaming Reasoning Content (_patch_ollama_chunk_parser):
    - LiteLLM's chunk_parser doesn't properly handle reasoning content in streaming
@@ -11,9 +11,10 @@ Status checked against LiteLLM v1.83.14 (2026-05-04):
    - Processes native "thinking" field from Ollama responses
    - Also handles <think>...</think> tags in content for models that use that format
    - Tracks reasoning state to properly separate thinking from regular content
-   STATUS: STILL NEEDED - Upstream uses `is not None` for thinking field checks, but
-           Ollama sends thinking="" (empty string) as a transition signal. Our truthy
-           check correctly treats empty string as end-of-reasoning.
+   STATUS: STILL NEEDED - Upstream v1.85.1 adopted the truthy check on thinking and the
+           elif→if fix for simultaneous thinking+content chunks, but still does not track
+           <think>...</think> tag boundaries within content. Our `_in_think_tag_block`
+           state is required to correctly classify content that crosses a </think> boundary.
 
 2. Reasoning Summary Newlines (_patch_responses_reasoning_summary_newlines):
    - LiteLLM passes through reasoning_summary_text.delta content as-is without
@@ -52,9 +53,10 @@ Status checked against LiteLLM v1.83.14 (2026-05-04):
      completion format and sets it as a dict on ResponsesAPIResponse.usage
    - This replaces the proper ResponseAPIUsage object with a dict, causing Pydantic
      serialization warnings
-   STATUS: STILL NEEDED - Our patch creates a deep copy before modification.
-         Handles ResponseCompletedEvent, ResponseIncompleteEvent, and
-         ResponseFailedEvent (matching upstream behavior in v1.83.0).
+   STATUS: STILL NEEDED - Upstream still mutates result.response.usage in place via
+         setattr in v1.85.1. Our patch rebuilds the response via model_construct so the
+         original ResponseAPIUsage object is preserved. Handles ResponseCompletedEvent,
+         ResponseIncompleteEvent, and ResponseFailedEvent (matching upstream).
 """
 
 import time
@@ -465,11 +467,11 @@ def _patch_responses_api_usage_format() -> None:
     This patch wraps model_construct to transform usage before construction, ensuring
     the correct type regardless of which code path calls model_construct.
 
-    Affected locations in LiteLLM:
-    - litellm/llms/openai/responses/transformation.py (lines 183, 563)
-    - litellm/llms/chatgpt/responses/transformation.py (line 153)
-    - litellm/llms/manus/responses/transformation.py (lines 243, 334)
-    - litellm/llms/volcengine/responses/transformation.py (line 280)
+    Affected locations in LiteLLM v1.85.1:
+    - litellm/llms/openai/responses/transformation.py (lines 215, 574)
+    - litellm/llms/chatgpt/responses/transformation.py (line 147)
+    - litellm/llms/manus/responses/transformation.py (lines 157, 224)
+    - litellm/llms/volcengine/responses/transformation.py (lines 225, 277)
     - litellm/completion_extras/litellm_responses_transformation/handler.py (line 51)
     """
     from litellm.types.llms.openai import ResponseAPIUsage

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -6,6 +6,7 @@ asyncio_default_fixture_loop_scope = function
 markers =
     slow: marks tests as slow
     alembic: marks tests for alembic migration testing
+    nightly: marks tests that should only run on the nightly schedule (skipped on PRs)
 filterwarnings =
     ignore::DeprecationWarning
     ignore::cryptography.utils.CryptographyDeprecationWarning

--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -220,7 +220,9 @@ dropbox==12.0.2
 durationpy==0.10
     # via kubernetes
 email-validator==2.2.0
-    # via fastapi-users
+    # via
+    #   fastapi-users
+    #   pydantic
 emoji==2.15.0
     # via unstructured
 et-xmlfile==2.0.0
@@ -391,15 +393,9 @@ idna==3.11
 importlib-metadata==8.7.0
     # via
     #   dask
-    #   google-api-core
-    #   hubspot-api-client
     #   keyring
     #   litellm
     #   opentelemetry-api
-    #   pywikibot
-    #   redis
-    #   sqlalchemy
-    #   trafilatura
 inflection==0.5.1
     # via pyairtable
 iniconfig==2.3.0
@@ -439,11 +435,10 @@ jsonpointer==3.0.0
     # via jsonpatch
 jsonref==1.1.0
     # via fastmcp
-jsonschema==4.23.0
+jsonschema==4.25.1
     # via
     #   litellm
     #   mcp
-    #   onyx
 jsonschema-path==0.4.6
     # via fastmcp
 jsonschema-specifications==2025.9.1
@@ -463,7 +458,7 @@ langfuse==3.10.0
 langsmith==0.7.32
     # via langchain-core
 lazy-imports==1.0.1
-litellm==1.83.14
+litellm==1.85.1
     # via onyx
 locket==1.0.0
     # via
@@ -559,7 +554,7 @@ olefile==0.47
     #   python-oxmsg
 onnxruntime==1.20.1
     # via magika
-openai==2.14.0
+openai==2.38.0
     # via
     #   exa-py
     #   langfuse
@@ -958,7 +953,7 @@ tenacity==9.1.2
     #   voyageai
 text-unidecode==1.3
     # via python-slugify
-tiktoken==0.7.0
+tiktoken==0.8.0
     # via litellm
 timeago==1.0.16
 tld==0.13.1

--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -220,9 +220,7 @@ dropbox==12.0.2
 durationpy==0.10
     # via kubernetes
 email-validator==2.2.0
-    # via
-    #   fastapi-users
-    #   pydantic
+    # via fastapi-users
 emoji==2.15.0
     # via unstructured
 et-xmlfile==2.0.0
@@ -393,9 +391,15 @@ idna==3.11
 importlib-metadata==8.7.0
     # via
     #   dask
+    #   google-api-core
+    #   hubspot-api-client
     #   keyring
     #   litellm
     #   opentelemetry-api
+    #   pywikibot
+    #   redis
+    #   sqlalchemy
+    #   trafilatura
 inflection==0.5.1
     # via pyairtable
 iniconfig==2.3.0
@@ -435,10 +439,11 @@ jsonpointer==3.0.0
     # via jsonpatch
 jsonref==1.1.0
     # via fastmcp
-jsonschema==4.25.1
+jsonschema==4.23.0
     # via
     #   litellm
     #   mcp
+    #   onyx
 jsonschema-path==0.4.6
     # via fastmcp
 jsonschema-specifications==2025.9.1
@@ -458,7 +463,7 @@ langfuse==3.10.0
 langsmith==0.7.32
     # via langchain-core
 lazy-imports==1.0.1
-litellm==1.83.0
+litellm==1.83.14
     # via onyx
 locket==1.0.0
     # via

--- a/backend/requirements/dev.txt
+++ b/backend/requirements/dev.txt
@@ -205,13 +205,9 @@ h11==0.16.0
     # via
     #   httpcore
     #   uvicorn
-h2==4.3.0
-    # via httpx
 hatchling==1.28.0
 hf-xet==1.4.3 ; platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'
     # via huggingface-hub
-hpack==4.1.0
-    # via h2
 httpcore==1.0.9
     # via httpx
 httpx==0.28.1
@@ -227,8 +223,6 @@ httpx-sse==0.4.3
     #   mcp
 huggingface-hub==0.36.2
     # via tokenizers
-hyperframe==6.1.0
-    # via h2
 identify==2.6.15
     # via pre-commit
 idna==3.11
@@ -238,12 +232,7 @@ idna==3.11
     #   requests
     #   yarl
 importlib-metadata==8.7.0
-    # via
-    #   google-api-core
-    #   jupyter-client
-    #   litellm
-    #   sqlalchemy
-    #   virtualenv
+    # via litellm
 iniconfig==2.3.0
     # via pytest
 ipykernel==6.29.5
@@ -262,11 +251,10 @@ jmespath==1.0.1
     #   aiobotocore
     #   boto3
     #   botocore
-jsonschema==4.23.0
+jsonschema==4.25.1
     # via
     #   litellm
     #   mcp
-    #   onyx
 jsonschema-specifications==2025.9.1
     # via jsonschema
 jupyter-client==8.6.3
@@ -279,7 +267,7 @@ kiwisolver==1.4.9
     # via matplotlib
 kubernetes==31.0.0
     # via onyx
-litellm==1.83.14
+litellm==1.85.1
     # via onyx
 mako==1.3.11
     # via alembic
@@ -317,7 +305,7 @@ oauthlib==3.2.2
     #   kubernetes
     #   requests-oauthlib
 onyx-devtools==0.7.6
-openai==2.14.0
+openai==2.38.0
     # via
     #   litellm
     #   onyx
@@ -523,7 +511,7 @@ tenacity==9.1.2
     # via
     #   google-genai
     #   voyageai
-tiktoken==0.7.0
+tiktoken==0.8.0
     # via litellm
 tokenizers==0.22.2
     # via

--- a/backend/requirements/dev.txt
+++ b/backend/requirements/dev.txt
@@ -205,9 +205,13 @@ h11==0.16.0
     # via
     #   httpcore
     #   uvicorn
+h2==4.3.0
+    # via httpx
 hatchling==1.28.0
 hf-xet==1.4.3 ; platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'
     # via huggingface-hub
+hpack==4.1.0
+    # via h2
 httpcore==1.0.9
     # via httpx
 httpx==0.28.1
@@ -223,6 +227,8 @@ httpx-sse==0.4.3
     #   mcp
 huggingface-hub==0.36.2
     # via tokenizers
+hyperframe==6.1.0
+    # via h2
 identify==2.6.15
     # via pre-commit
 idna==3.11
@@ -232,7 +238,12 @@ idna==3.11
     #   requests
     #   yarl
 importlib-metadata==8.7.0
-    # via litellm
+    # via
+    #   google-api-core
+    #   jupyter-client
+    #   litellm
+    #   sqlalchemy
+    #   virtualenv
 iniconfig==2.3.0
     # via pytest
 ipykernel==6.29.5
@@ -251,10 +262,11 @@ jmespath==1.0.1
     #   aiobotocore
     #   boto3
     #   botocore
-jsonschema==4.25.1
+jsonschema==4.23.0
     # via
     #   litellm
     #   mcp
+    #   onyx
 jsonschema-specifications==2025.9.1
     # via jsonschema
 jupyter-client==8.6.3
@@ -267,7 +279,7 @@ kiwisolver==1.4.9
     # via matplotlib
 kubernetes==31.0.0
     # via onyx
-litellm==1.83.0
+litellm==1.83.14
     # via onyx
 mako==1.3.11
     # via alembic

--- a/backend/requirements/ee.txt
+++ b/backend/requirements/ee.txt
@@ -165,12 +165,8 @@ h11==0.16.0
     # via
     #   httpcore
     #   uvicorn
-h2==4.3.0
-    # via httpx
 hf-xet==1.4.3 ; platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'
     # via huggingface-hub
-hpack==4.1.0
-    # via h2
 httpcore==1.0.9
     # via httpx
 httpx==0.28.1
@@ -186,8 +182,6 @@ httpx-sse==0.4.3
     #   mcp
 huggingface-hub==0.36.2
     # via tokenizers
-hyperframe==6.1.0
-    # via h2
 idna==3.11
     # via
     #   anyio
@@ -195,9 +189,7 @@ idna==3.11
     #   requests
     #   yarl
 importlib-metadata==8.7.0
-    # via
-    #   google-api-core
-    #   litellm
+    # via litellm
 jinja2==3.1.6
     # via litellm
 jiter==0.12.0
@@ -207,16 +199,15 @@ jmespath==1.0.1
     #   aiobotocore
     #   boto3
     #   botocore
-jsonschema==4.23.0
+jsonschema==4.25.1
     # via
     #   litellm
     #   mcp
-    #   onyx
 jsonschema-specifications==2025.9.1
     # via jsonschema
 kubernetes==31.0.0
     # via onyx
-litellm==1.83.14
+litellm==1.85.1
     # via onyx
 markupsafe==3.0.3
     # via jinja2
@@ -235,7 +226,7 @@ oauthlib==3.2.2
     # via
     #   kubernetes
     #   requests-oauthlib
-openai==2.14.0
+openai==2.38.0
     # via
     #   litellm
     #   onyx
@@ -371,7 +362,7 @@ tenacity==9.1.2
     # via
     #   google-genai
     #   voyageai
-tiktoken==0.7.0
+tiktoken==0.8.0
     # via litellm
 tokenizers==0.22.2
     # via

--- a/backend/requirements/ee.txt
+++ b/backend/requirements/ee.txt
@@ -165,8 +165,12 @@ h11==0.16.0
     # via
     #   httpcore
     #   uvicorn
+h2==4.3.0
+    # via httpx
 hf-xet==1.4.3 ; platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'
     # via huggingface-hub
+hpack==4.1.0
+    # via h2
 httpcore==1.0.9
     # via httpx
 httpx==0.28.1
@@ -182,6 +186,8 @@ httpx-sse==0.4.3
     #   mcp
 huggingface-hub==0.36.2
     # via tokenizers
+hyperframe==6.1.0
+    # via h2
 idna==3.11
     # via
     #   anyio
@@ -189,7 +195,9 @@ idna==3.11
     #   requests
     #   yarl
 importlib-metadata==8.7.0
-    # via litellm
+    # via
+    #   google-api-core
+    #   litellm
 jinja2==3.1.6
     # via litellm
 jiter==0.12.0
@@ -199,15 +207,16 @@ jmespath==1.0.1
     #   aiobotocore
     #   boto3
     #   botocore
-jsonschema==4.25.1
+jsonschema==4.23.0
     # via
     #   litellm
     #   mcp
+    #   onyx
 jsonschema-specifications==2025.9.1
     # via jsonschema
 kubernetes==31.0.0
     # via onyx
-litellm==1.83.0
+litellm==1.83.14
     # via onyx
 markupsafe==3.0.3
     # via jinja2

--- a/backend/requirements/model_server.txt
+++ b/backend/requirements/model_server.txt
@@ -188,8 +188,12 @@ h11==0.16.0
     # via
     #   httpcore
     #   uvicorn
+h2==4.3.0
+    # via httpx
 hf-xet==1.4.3 ; platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'
     # via huggingface-hub
+hpack==4.1.0
+    # via h2
 httpcore==1.0.9
     # via httpx
 httpx==0.28.1
@@ -209,6 +213,8 @@ huggingface-hub==0.36.2
     #   sentence-transformers
     #   tokenizers
     #   transformers
+hyperframe==6.1.0
+    # via h2
 idna==3.11
     # via
     #   anyio
@@ -216,7 +222,10 @@ idna==3.11
     #   requests
     #   yarl
 importlib-metadata==8.7.0
-    # via litellm
+    # via
+    #   google-api-core
+    #   litellm
+    #   triton
 jinja2==3.1.6
     # via
     #   litellm
@@ -230,17 +239,18 @@ jmespath==1.0.1
     #   botocore
 joblib==1.5.2
     # via scikit-learn
-jsonschema==4.25.1
+jsonschema==4.23.0
     # via
     #   litellm
     #   mcp
+    #   onyx
 jsonschema-specifications==2025.9.1
     # via jsonschema
 kombu==5.5.4
     # via celery
 kubernetes==31.0.0
     # via onyx
-litellm==1.83.0
+litellm==1.83.14
     # via onyx
 markupsafe==3.0.3
     # via jinja2

--- a/backend/requirements/model_server.txt
+++ b/backend/requirements/model_server.txt
@@ -188,12 +188,8 @@ h11==0.16.0
     # via
     #   httpcore
     #   uvicorn
-h2==4.3.0
-    # via httpx
 hf-xet==1.4.3 ; platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'
     # via huggingface-hub
-hpack==4.1.0
-    # via h2
 httpcore==1.0.9
     # via httpx
 httpx==0.28.1
@@ -213,8 +209,6 @@ huggingface-hub==0.36.2
     #   sentence-transformers
     #   tokenizers
     #   transformers
-hyperframe==6.1.0
-    # via h2
 idna==3.11
     # via
     #   anyio
@@ -222,10 +216,7 @@ idna==3.11
     #   requests
     #   yarl
 importlib-metadata==8.7.0
-    # via
-    #   google-api-core
-    #   litellm
-    #   triton
+    # via litellm
 jinja2==3.1.6
     # via
     #   litellm
@@ -239,18 +230,17 @@ jmespath==1.0.1
     #   botocore
 joblib==1.5.2
     # via scikit-learn
-jsonschema==4.23.0
+jsonschema==4.25.1
     # via
     #   litellm
     #   mcp
-    #   onyx
 jsonschema-specifications==2025.9.1
     # via jsonschema
 kombu==5.5.4
     # via celery
 kubernetes==31.0.0
     # via onyx
-litellm==1.83.14
+litellm==1.85.1
     # via onyx
 markupsafe==3.0.3
     # via jinja2
@@ -316,7 +306,7 @@ oauthlib==3.2.2
     # via
     #   kubernetes
     #   requests-oauthlib
-openai==2.14.0
+openai==2.38.0
     # via
     #   litellm
     #   onyx
@@ -479,7 +469,7 @@ tenacity==9.1.2
     #   voyageai
 threadpoolctl==3.6.0
     # via scikit-learn
-tiktoken==0.7.0
+tiktoken==0.8.0
     # via litellm
 tokenizers==0.22.2
     # via

--- a/backend/tests/external_dependency_unit/conftest.py
+++ b/backend/tests/external_dependency_unit/conftest.py
@@ -15,6 +15,13 @@ from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 from tests.external_dependency_unit.constants import TEST_TENANT_ID
 from tests.external_dependency_unit.full_setup import ensure_full_deployment_setup
 
+# Opt into the shared @pytest.mark.secrets / test_secrets infrastructure.
+from tests.utils.pytest_secrets import (
+    pytest_collection_modifyitems as pytest_collection_modifyitems,
+)
+from tests.utils.pytest_secrets import pytest_configure as pytest_configure
+from tests.utils.pytest_secrets import test_secrets as test_secrets
+
 
 @pytest.fixture(scope="function")
 def db_session() -> Generator[Session, None, None]:

--- a/backend/tests/external_dependency_unit/llm/test_ollama_streaming.py
+++ b/backend/tests/external_dependency_unit/llm/test_ollama_streaming.py
@@ -1,0 +1,96 @@
+"""Live behavior test for Ollama streaming through LiteLLM.
+
+`_patch_ollama_chunk_parser` (in `monkey_patches.py`) ensures reasoning
+tokens are routed to `Delta.reasoning_content` and visible answer tokens
+land on `Delta.content`, for both native `thinking` field chunks and
+legacy `<think>...</think>`-tagged content chunks. Unit tests in
+`backend/tests/unit/onyx/llm/test_litellm_monkey_patches.py` cover the
+state machine against crafted chunk dicts; this test exercises the same
+path against Ollama Cloud's live wire format so we catch upstream
+protocol drift.
+"""
+
+import pytest
+
+from onyx.llm.constants import LlmProviderNames
+from onyx.llm.models import ChatCompletionMessage
+from onyx.llm.models import UserMessage
+from onyx.llm.multi_llm import LitellmLLM
+from tests.utils.secret_names import TestSecret
+
+pytestmark = pytest.mark.nightly
+
+# gpt-oss:120b-cloud emits native `thinking` tokens and is included in the
+# nightly Ollama Cloud matrix, so the credential already has access.
+_THINKING_MODEL = "gpt-oss:120b-cloud"
+
+
+@pytest.mark.secrets(TestSecret.OLLAMA_API_KEY)
+def test_streaming_separates_reasoning_content_from_visible_content(
+    test_secrets: dict[TestSecret, str],
+) -> None:
+    """A thinking-capable Ollama model must stream its chain-of-thought on
+    `Delta.reasoning_content` and its final answer on `Delta.content`, and
+    every thinking chunk must surface (not just the first two). A single
+    chunk may legitimately carry both fields — Ollama emits transition
+    chunks with both `thinking` and `content` populated, and the patch
+    routes them to their respective Delta fields rather than dropping
+    either.
+
+    Without `_patch_ollama_chunk_parser`, LiteLLM's Ollama transformer
+    silently drops reasoning_content from the third chunk onwards
+    (transformation.py:504-510 only branches for the first two thinking
+    chunks). This test guards against regression in either the patch or
+    upstream Ollama chunk shape.
+    """
+    llm = LitellmLLM(
+        api_key=test_secrets[TestSecret.OLLAMA_API_KEY],
+        model_provider=LlmProviderNames.OLLAMA_CHAT,
+        model_name=_THINKING_MODEL,
+        api_base="https://ollama.com",
+        max_input_tokens=8192,
+        timeout=120,
+    )
+
+    prompt: list[ChatCompletionMessage] = [
+        UserMessage(
+            role="user",
+            content=(
+                "Think briefly about what 12 * 7 is, then respond with just "
+                "the number."
+            ),
+        )
+    ]
+
+    reasoning_parts: list[str] = []
+    content_parts: list[str] = []
+    for chunk in llm.stream(prompt=prompt):
+        delta = chunk.choice.delta
+        rc = delta.reasoning_content
+        content = delta.content
+        if rc:
+            reasoning_parts.append(rc)
+        if content:
+            content_parts.append(content)
+
+    full_reasoning = "".join(reasoning_parts)
+    full_content = "".join(content_parts)
+
+    assert full_content.strip(), (
+        f"Model produced reasoning but no visible answer tokens. "
+        f"reasoning={full_reasoning!r}"
+    )
+    # Upstream LiteLLM only emits reasoning on the first two thinking chunks
+    # then silently drops the rest. A thinking model on a non-trivial prompt
+    # should always stream more than two reasoning chunks, so anything <= 2
+    # means the patch is missing or upstream regressed.
+    assert len(reasoning_parts) > 2, (
+        f"Expected more than 2 reasoning chunks (upstream bug drops chunks "
+        f"3+), got {len(reasoning_parts)}. reasoning_parts={reasoning_parts!r}"
+    )
+    assert (
+        "<think>" not in full_content and "</think>" not in full_content
+    ), f"Raw <think> tags leaked into visible content: {full_content!r}"
+    assert (
+        "<think>" not in full_reasoning and "</think>" not in full_reasoning
+    ), f"Raw <think> tags leaked into reasoning_content: {full_reasoning!r}"

--- a/backend/tests/external_dependency_unit/llm/test_openai_responses_api.py
+++ b/backend/tests/external_dependency_unit/llm/test_openai_responses_api.py
@@ -1,0 +1,306 @@
+"""Live behavior tests for the OpenAI Responses API path through LiteLLM.
+
+`LitellmLLM` routes true OpenAI models through LiteLLM's Responses API
+bridge (model name prefixed with `openai/responses/`). These tests exercise
+behavior of that bridge that cannot be reached with mocks:
+
+- Parallel tool calls land in distinct streaming slots with intact arguments.
+- Streaming errors surface as the appropriate exception type rather than
+  being masked by an internal `TypeError`.
+- Reasoning summary sections are separated by a blank line in the streamed
+  `reasoning_content` (covered by `_patch_responses_reasoning_summary_newlines`
+  in `monkey_patches.py`).
+- Non-streaming reasoning summary parts are joined with blank lines
+  (covered by `_patch_openai_responses_transform_response`).
+- No Pydantic serializer warnings escape during a Responses API stream
+  (covered by `_patch_responses_api_usage_format` and
+  `_patch_logging_assembled_streaming_response`).
+"""
+
+import json
+import warnings
+
+import pytest
+
+from onyx.llm.constants import LlmProviderNames
+from onyx.llm.litellm_singleton import litellm
+from onyx.llm.models import ChatCompletionMessage
+from onyx.llm.models import UserMessage
+from onyx.llm.multi_llm import LitellmLLM
+from tests.utils.secret_names import TestSecret
+
+pytestmark = pytest.mark.nightly
+
+
+def _build_openai_llm(model: str, api_key: str) -> LitellmLLM:
+    return LitellmLLM(
+        api_key=api_key,
+        model_provider=LlmProviderNames.OPENAI,
+        model_name=model,
+        max_input_tokens=128_000,
+        timeout=60,
+    )
+
+
+@pytest.mark.secrets(TestSecret.OPENAI_API_KEY)
+def test_streaming_parallel_tool_calls_land_in_distinct_slots(
+    test_secrets: dict[TestSecret, str],
+) -> None:
+    """Concurrent tool calls in a single streaming response must arrive on
+    distinct `index` values with intact, parseable arguments.
+
+    Pre-litellm-1.83.0 the responses bridge hardcoded `index=0` for every
+    tool call, causing argument deltas from the second call to overwrite the
+    first; it also set `finish_reason="tool_calls"` on the first
+    `output_item.done`, terminating the stream before the second call
+    arrived. Onyx's responses-streaming patch was removed once upstream
+    fixed both. This test is the regression guard against either failure
+    re-emerging.
+    """
+    llm = _build_openai_llm("gpt-4o-mini", test_secrets[TestSecret.OPENAI_API_KEY])
+
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get the current weather for a city.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "get_population",
+                "description": "Get the population of a city.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            },
+        },
+    ]
+
+    prompt: list[ChatCompletionMessage] = [
+        UserMessage(
+            role="user",
+            content=(
+                "For Paris, France: call get_weather AND get_population. "
+                "Issue both tool calls in a single response."
+            ),
+        )
+    ]
+
+    accumulated: dict[int, dict[str, str]] = {}
+    for chunk in llm.stream(prompt=prompt, tools=tools):
+        for tc in chunk.choice.delta.tool_calls:
+            slot = accumulated.setdefault(
+                tc.index, {"id": "", "name": "", "arguments": ""}
+            )
+            if tc.id:
+                slot["id"] = tc.id
+            if tc.function:
+                if tc.function.name:
+                    slot["name"] = tc.function.name
+                if tc.function.arguments:
+                    slot["arguments"] += tc.function.arguments
+
+    indices = sorted(accumulated.keys())
+    assert indices == list(
+        range(len(indices))
+    ), f"Tool call indices should be 0..N-1, got {indices}"
+
+    names = {slot["name"] for slot in accumulated.values()}
+    assert names == {
+        "get_weather",
+        "get_population",
+    }, f"Expected both tool names to land in distinct slots, got {names}"
+
+    for slot in accumulated.values():
+        assert slot["id"], f"Tool call slot missing id: {slot}"
+        try:
+            parsed = json.loads(slot["arguments"])
+        except json.JSONDecodeError as e:
+            pytest.fail(
+                f"Tool call arguments not valid JSON for {slot['name']!r}: "
+                f"{slot['arguments']!r} ({e})"
+            )
+        assert "city" in parsed, f"Expected 'city' in arguments, got {parsed}"
+
+
+def test_responses_call_with_invalid_key_raises_authentication_error() -> None:
+    """An invalid API key must surface as `AuthenticationError`.
+
+    Specifically, passing `metadata=None` together with a bad key must NOT
+    surface as `TypeError: argument of type 'NoneType' is not iterable`.
+    Pre-1.83.0 LiteLLM's `@client` wrapper did `kwargs.get("metadata", {})`
+    which returned `None` when the key existed with value `None`, masking
+    the real auth failure. Upstream now uses `kwargs.get("metadata") or {}`.
+    Onyx's `_patch_responses_metadata_none` was removed once that fix
+    landed; this test guards against regression.
+    """
+    with pytest.raises(Exception) as exc_info:
+        litellm.responses(
+            model="openai/gpt-5.4-nano",
+            input="hi",
+            api_key="sk-onyx-contract-test-deliberately-invalid",
+            metadata=None,
+            max_output_tokens=8,
+        )
+
+    err = exc_info.value
+    err_str = str(err)
+    assert (
+        "NoneType" not in err_str
+    ), f"metadata=None TypeError leaked into the surfaced exception: {err_str!r}"
+    assert (
+        isinstance(err, litellm.exceptions.AuthenticationError)
+        or "auth" in err_str.lower()
+        or "401" in err_str
+    ), (
+        f"Expected AuthenticationError-shaped exception, got "
+        f"{type(err).__name__}: {err_str!r}"
+    )
+
+
+@pytest.mark.secrets(TestSecret.OPENAI_API_KEY)
+def test_responses_call_tolerates_explicit_metadata_none(
+    test_secrets: dict[TestSecret, str],
+) -> None:
+    """Passing `metadata=None` on the happy path must not raise.
+
+    Sister test to `test_responses_call_with_invalid_key_raises_authentication_error`:
+    confirms `metadata=None` is tolerated for *successful* calls, not just
+    error paths.
+    """
+    response = litellm.responses(
+        model="openai/gpt-5.4-nano",
+        input="Reply with exactly the word: ok",
+        api_key=test_secrets[TestSecret.OPENAI_API_KEY],
+        metadata=None,
+        max_output_tokens=16,
+    )
+    assert response is not None
+
+
+@pytest.mark.secrets(TestSecret.OPENAI_API_KEY)
+def test_streaming_reasoning_summary_sections_are_separated_by_blank_line(
+    test_secrets: dict[TestSecret, str],
+) -> None:
+    """Streamed `reasoning_content` must contain a `\\n\\n` separator
+    between distinct summary sections.
+
+    LiteLLM passes through `response.reasoning_summary_text.delta` events
+    as-is, with no separator when `summary_index` changes. Without the
+    separator, multiple sections render as a single concatenated wall of
+    text. `_patch_responses_reasoning_summary_newlines` (in
+    `monkey_patches.py`) inserts the blank line. This test guards that the
+    patch is still firing for current LiteLLM and OpenAI behavior.
+    """
+    llm = _build_openai_llm("gpt-5.4-nano", test_secrets[TestSecret.OPENAI_API_KEY])
+
+    prompt: list[ChatCompletionMessage] = [
+        UserMessage(
+            role="user",
+            content=(
+                "Plan a 3-day trip to Tokyo for someone with a peanut allergy on a $2000 budget. "
+                "First plan the itinerary, then verify each restaurant choice is safe, then check "
+                "the budget math."
+            ),
+        )
+    ]
+
+    reasoning_parts: list[str] = []
+    for chunk in llm.stream(prompt=prompt):
+        rc = chunk.choice.delta.reasoning_content
+        if rc:
+            reasoning_parts.append(rc)
+
+    full_reasoning = "".join(reasoning_parts)
+
+    assert (
+        "\n\n" in full_reasoning
+    ), f"Expected double-newline separator between summary sections: {full_reasoning!r}"
+
+
+@pytest.mark.secrets(TestSecret.OPENAI_API_KEY)
+def test_non_streaming_reasoning_summary_sections_are_separated_by_blank_line(
+    test_secrets: dict[TestSecret, str],
+) -> None:
+    """Non-streaming `reasoning_content` must contain a `\\n\\n` separator
+    between distinct reasoning summary sections.
+
+    Sister test to
+    `test_streaming_reasoning_summary_sections_are_separated_by_blank_line`.
+    LiteLLM's `LiteLLMResponsesTransformationHandler.transform_response`
+    joins multiple reasoning summary parts with a single space, which renders
+    as a wall of text. `_patch_openai_responses_transform_response` (in
+    `monkey_patches.py`) post-processes the result to join with `\\n\\n`. This
+    test guards that the patch fires on the non-stream path.
+    """
+    llm = _build_openai_llm("gpt-5.4-nano", test_secrets[TestSecret.OPENAI_API_KEY])
+
+    prompt: list[ChatCompletionMessage] = [
+        UserMessage(
+            role="user",
+            content=(
+                "Plan a 3-day trip to Tokyo for someone with a peanut allergy on a $2000 budget. "
+                "First plan the itinerary, then verify each restaurant choice is safe, then check "
+                "the budget math."
+            ),
+        )
+    ]
+
+    response = llm.invoke(prompt=prompt)
+    reasoning = response.choice.message.reasoning_content or ""
+
+    assert (
+        "\n\n" in reasoning
+    ), f"Expected double-newline separator between summary sections: {reasoning!r}"
+
+
+@pytest.mark.secrets(TestSecret.OPENAI_API_KEY)
+def test_streaming_emits_no_pydantic_serializer_warnings(
+    test_secrets: dict[TestSecret, str],
+) -> None:
+    """Streaming a Responses API call must not emit Pydantic serializer
+    warnings.
+
+    LiteLLM's logging path calls `model_dump()` on a
+    `ResponsesAPIResponse` whose `usage` field has been mutated to a chat-
+    completion-shaped dict, which triggers a `Pydantic serializer warnings:
+    PydanticSerializationUnexpectedValue` `UserWarning`. Two patches
+    cooperate to silence it: `_patch_responses_api_usage_format` ensures
+    `model_construct` rebuilds usage as a typed `ResponseAPIUsage`, and
+    `_patch_logging_assembled_streaming_response` deep-copies the response
+    before mutation so the original keeps its proper type. This test
+    captures the symptom rather than either patch's internals — if the
+    warning escapes, at least one patch is broken or upstream regressed.
+    """
+    llm = _build_openai_llm("gpt-5.4-nano", test_secrets[TestSecret.OPENAI_API_KEY])
+
+    prompt: list[ChatCompletionMessage] = [
+        UserMessage(role="user", content="Reply with exactly the word: ok")
+    ]
+
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        for _ in llm.stream(prompt=prompt):
+            pass
+
+    serializer_warnings = [
+        w
+        for w in captured
+        if "Pydantic serializer warnings" in str(w.message)
+        or "PydanticSerializationUnexpectedValue" in str(w.message)
+    ]
+    assert not serializer_warnings, (
+        "Pydantic serializer warning(s) escaped during Responses API stream; "
+        "monkey patches for usage format / assembled streaming response are "
+        f"not silencing them: {[str(w.message) for w in serializer_warnings]!r}"
+    )

--- a/backend/tests/utils/secret_names.py
+++ b/backend/tests/utils/secret_names.py
@@ -26,6 +26,7 @@ class TestSecret(StrEnum):
     AZURE_API_URL = "AZURE_API_URL"
     LITELLM_API_KEY = "LITELLM_API_KEY"
     LITELLM_API_URL = "LITELLM_API_URL"
+    OLLAMA_API_KEY = "OLLAMA_API_KEY"
 
     @classmethod
     def aws_prefix(cls) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ dependencies = [
     "cohere==5.6.1",
     "fastapi==0.133.1",
     "google-genai==1.52.0",
-    "litellm[google]==1.83.0",
+    "litellm[google]==1.83.14",
+    "jsonschema==4.23.0",
     "openai==2.14.0",
     "pydantic==2.11.7",
     "prometheus_client>=0.21.1",
@@ -200,6 +201,27 @@ model_server = [
 
 [tool.uv]
 default-groups = ["backend", "dev", "ee", "model_server"]
+
+# litellm >=1.83.x switched from loose ranges to exact `==` pins on its
+# transitive dependencies (see https://github.com/BerriAI/litellm/issues/25280),
+# which forces downgrades of packages we already pin to newer versions and
+# regressions on transitively resolved packages. Replace those exact pins with
+# the loose ranges litellm declared prior to 1.83.1 so that uv's resolver is
+# free to pick versions consistent with our top-level pins (or newer).
+override-dependencies = [
+    "aiohttp>=3.10",
+    "click",
+    "fastuuid>=0.13.0",
+    "httpx[http2]>=0.23.0",
+    "importlib-metadata>=6.8.0",
+    "jinja2>=3.1.2,<4.0.0",
+    "openai",
+    "pydantic",
+    "python-dotenv",
+    "tiktoken",
+    "tokenizers",
+    "google-cloud-aiplatform>=1.38.0",
+]
 
 [tool.ty.environment]
 python-version = "3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,8 @@ dependencies = [
     "cohere==5.6.1",
     "fastapi==0.133.1",
     "google-genai==1.52.0",
-    "litellm[google]==1.83.14",
-    "jsonschema==4.23.0",
-    "openai==2.14.0",
+    "litellm[google]==1.85.1",
+    "openai==2.38.0",
     "pydantic==2.11.7",
     "prometheus_client>=0.21.1",
     "prometheus_fastapi_instrumentator==7.1.0",
@@ -112,7 +111,7 @@ backend = [
     "starlette==0.49.3",
     "supervisor==4.3.0",
     "RapidFuzz==3.13.0",
-    "tiktoken==0.7.0",
+    "tiktoken==0.8.0",
     "timeago==1.0.16",
     "types-openpyxl==3.0.4.7",
     "unstructured==0.18.27",
@@ -201,27 +200,6 @@ model_server = [
 
 [tool.uv]
 default-groups = ["backend", "dev", "ee", "model_server"]
-
-# litellm >=1.83.x switched from loose ranges to exact `==` pins on its
-# transitive dependencies (see https://github.com/BerriAI/litellm/issues/25280),
-# which forces downgrades of packages we already pin to newer versions and
-# regressions on transitively resolved packages. Replace those exact pins with
-# the loose ranges litellm declared prior to 1.83.1 so that uv's resolver is
-# free to pick versions consistent with our top-level pins (or newer).
-override-dependencies = [
-    "aiohttp>=3.10",
-    "click",
-    "fastuuid>=0.13.0",
-    "httpx[http2]>=0.23.0",
-    "importlib-metadata>=6.8.0",
-    "jinja2>=3.1.2,<4.0.0",
-    "openai",
-    "pydantic",
-    "python-dotenv",
-    "tiktoken",
-    "tokenizers",
-    "google-cloud-aiplatform>=1.38.0",
-]
 
 [tool.ty.environment]
 python-version = "3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -14,6 +14,22 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'win32'",
 ]
 
+[manifest]
+overrides = [
+    { name = "aiohttp", specifier = ">=3.10" },
+    { name = "click" },
+    { name = "fastuuid", specifier = ">=0.13.0" },
+    { name = "google-cloud-aiplatform", specifier = ">=1.38.0" },
+    { name = "httpx", extras = ["http2"], specifier = ">=0.23.0" },
+    { name = "importlib-metadata", specifier = ">=6.8.0" },
+    { name = "jinja2", specifier = ">=3.1.2,<4.0.0" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "tiktoken" },
+    { name = "tokenizers" },
+]
+
 [[package]]
 name = "accelerate"
 version = "1.6.0"
@@ -1107,7 +1123,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boto3" },
     { name = "fastavro" },
-    { name = "httpx" },
+    { name = "httpx", extra = ["http2"] },
     { name = "httpx-sse" },
     { name = "parameterized" },
     { name = "pydantic" },
@@ -1338,7 +1354,7 @@ dependencies = [
     { name = "click" },
     { name = "cloudpickle" },
     { name = "fsspec" },
-    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
+    { name = "importlib-metadata" },
     { name = "packaging" },
     { name = "partd" },
     { name = "pyyaml" },
@@ -1591,7 +1607,7 @@ name = "exa-py"
 version = "1.15.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx" },
+    { name = "httpx", extra = ["http2"] },
     { name = "openai" },
     { name = "pydantic" },
     { name = "requests" },
@@ -1752,7 +1768,7 @@ dependencies = [
     { name = "authlib" },
     { name = "cyclopts" },
     { name = "exceptiongroup" },
-    { name = "httpx" },
+    { name = "httpx", extra = ["http2"] },
     { name = "jsonref" },
     { name = "jsonschema-path" },
     { name = "mcp" },
@@ -1761,7 +1777,7 @@ dependencies = [
     { name = "packaging" },
     { name = "platformdirs" },
     { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
-    { name = "pydantic", extra = ["email"] },
+    { name = "pydantic" },
     { name = "pyperclip" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
@@ -2049,6 +2065,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-auth" },
     { name = "googleapis-common-protos" },
+    { name = "importlib-metadata" },
     { name = "proto-plus" },
     { name = "protobuf" },
     { name = "requests" },
@@ -2246,7 +2263,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "google-auth" },
-    { name = "httpx" },
+    { name = "httpx", extra = ["http2"] },
     { name = "pydantic" },
     { name = "requests" },
     { name = "tenacity" },
@@ -2573,7 +2590,7 @@ name = "httpx-oauth"
 version = "0.15.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx" },
+    { name = "httpx", extra = ["http2"] },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6d/08/b2e0f360e84994ec5c67473cef7198d22ccb2215e5068c0a21182d22baaa/httpx_oauth-0.15.1.tar.gz", hash = "sha256:4094cf0938fc7252b5f5dfd62cd1ab5aee2fcb6734e621942ee17d1af4806b74", size = 41302, upload-time = "2024-08-22T13:01:20.328Z" }
 wheels = [
@@ -2595,6 +2612,7 @@ version = "11.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
+    { name = "importlib-metadata" },
     { name = "python-dateutil" },
     { name = "requests" },
     { name = "six" },
@@ -2981,7 +2999,7 @@ wheels = [
 
 [[package]]
 name = "jsonschema"
-version = "4.25.1"
+version = "4.23.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -2989,9 +3007,9 @@ dependencies = [
     { name = "referencing" },
     { name = "rpds-py" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/69/f7185de793a29082a9f3c7728268ffb31cb5095131a9c139a74078e27336/jsonschema-4.25.1.tar.gz", hash = "sha256:e4a9655ce0da0c0b67a085847e00a3a51449e1157f4f75e9fb5aa545e122eb85", size = 357342, upload-time = "2025-08-18T17:03:50.038Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/2e/03362ee4034a4c917f697890ccd4aec0800ccf9ded7f511971c75451deec/jsonschema-4.23.0.tar.gz", hash = "sha256:d71497fef26351a33265337fa77ffeb82423f3ea21283cd9467bb03999266bc4", size = 325778, upload-time = "2024-07-08T18:40:05.546Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl", hash = "sha256:3fba0169e345c7175110351d456342c364814cfcf3b964ba4587f22915230a63", size = 90040, upload-time = "2025-08-18T17:03:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/69/4a/4f9dbeb84e8850557c02365a0eee0649abe5eb1d84af92a25731c6c0f922/jsonschema-4.23.0-py3-none-any.whl", hash = "sha256:fbadb6f8b144a8f8cf9f0b89ba94501d143e50411a1278633f56a7acf7fd5566", size = 88462, upload-time = "2024-07-08T18:40:00.165Z" },
 ]
 
 [[package]]
@@ -3025,6 +3043,7 @@ name = "jupyter-client"
 version = "8.6.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "importlib-metadata" },
     { name = "jupyter-core" },
     { name = "python-dateutil" },
     { name = "pyzmq" },
@@ -3066,7 +3085,7 @@ name = "keyring"
 version = "25.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
+    { name = "importlib-metadata" },
     { name = "jaraco-classes" },
     { name = "jaraco-context" },
     { name = "jaraco-functools" },
@@ -3240,7 +3259,7 @@ version = "3.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "backoff" },
-    { name = "httpx" },
+    { name = "httpx", extra = ["http2"] },
     { name = "openai" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
@@ -3260,7 +3279,7 @@ name = "langsmith"
 version = "0.7.32"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx" },
+    { name = "httpx", extra = ["http2"] },
     { name = "orjson", marker = "platform_python_implementation != 'PyPy'" },
     { name = "packaging" },
     { name = "pydantic" },
@@ -3286,13 +3305,13 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.83.0"
+version = "1.83.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "click" },
     { name = "fastuuid" },
-    { name = "httpx" },
+    { name = "httpx", extra = ["http2"] },
     { name = "importlib-metadata" },
     { name = "jinja2" },
     { name = "jsonschema" },
@@ -3302,9 +3321,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/92/6ce9737554994ca8e536e5f4f6a87cc7c4774b656c9eb9add071caf7d54b/litellm-1.83.0.tar.gz", hash = "sha256:860bebc76c4bb27b4cf90b4a77acd66dba25aced37e3db98750de8a1766bfb7a", size = 17333062, upload-time = "2026-03-31T05:08:25.331Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/7c/c095649380adc96c8630273c1768c2ad1e74aa2ee1dd8dd05d218a60569f/litellm-1.83.14.tar.gz", hash = "sha256:24aef9b47cdc424c833e32f3727f411741c690832cd1fe4405e0077144fe09c9", size = 14836599, upload-time = "2026-04-26T03:16:10.176Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/2c/a670cc050fcd6f45c6199eb99e259c73aea92edba8d5c2fc1b3686d36217/litellm-1.83.0-py3-none-any.whl", hash = "sha256:88c536d339248f3987571493015784671ba3f193a328e1ea6780dbebaa2094a8", size = 15610306, upload-time = "2026-03-31T05:08:21.987Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/5c/1b5691575420135e90578543b2bf219497caa33cfd0af64cb38f30288450/litellm-1.83.14-py3-none-any.whl", hash = "sha256:92b11ba2a32cf80707ddf388d18526696c7999a21b418c5e3b6eda1243d2cfdb", size = 16457054, upload-time = "2026-04-26T03:16:05.72Z" },
 ]
 
 [package.optional-dependencies]
@@ -3699,7 +3718,7 @@ version = "1.27.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
+    { name = "httpx", extra = ["http2"] },
     { name = "httpx-sse" },
     { name = "jsonschema" },
     { name = "pydantic" },
@@ -4351,6 +4370,7 @@ dependencies = [
     { name = "discord-py" },
     { name = "fastapi" },
     { name = "google-genai" },
+    { name = "jsonschema" },
     { name = "kubernetes" },
     { name = "litellm", extra = ["google"] },
     { name = "openai" },
@@ -4522,8 +4542,9 @@ requires-dist = [
     { name = "discord-py", specifier = "==2.4.0" },
     { name = "fastapi", specifier = "==0.133.1" },
     { name = "google-genai", specifier = "==1.52.0" },
+    { name = "jsonschema", specifier = "==4.23.0" },
     { name = "kubernetes", specifier = ">=31.0.0" },
-    { name = "litellm", extras = ["google"], specifier = "==1.83.0" },
+    { name = "litellm", extras = ["google"], specifier = "==1.83.14" },
     { name = "openai", specifier = "==2.14.0" },
     { name = "prometheus-client", specifier = ">=0.21.1" },
     { name = "prometheus-fastapi-instrumentator", specifier = "==7.1.0" },
@@ -4705,7 +4726,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "distro" },
-    { name = "httpx" },
+    { name = "httpx", extra = ["http2"] },
     { name = "jiter" },
     { name = "pydantic" },
     { name = "sniffio" },
@@ -5639,11 +5660,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/c0/ec2b1c8712ca690e5d61979dee872603e92b8a32f94cc1b72d53beab008a/pydantic-2.11.7-py3-none-any.whl", hash = "sha256:dde5df002701f6de26248661f6835bbe296a47bf73990135c7d07ce741b9623b", size = 444782, upload-time = "2025-06-14T08:33:14.905Z" },
 ]
 
-[package.optional-dependencies]
-email = [
-    { name = "email-validator" },
-]
-
 [[package]]
 name = "pydantic-core"
 version = "2.33.2"
@@ -6178,6 +6194,7 @@ name = "pywikibot"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "importlib-metadata" },
     { name = "mwparserfromhell" },
     { name = "packaging" },
     { name = "requests" },
@@ -6393,6 +6410,7 @@ version = "5.0.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
+    { name = "importlib-metadata" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/10/defc227d65ea9c2ff5244645870859865cba34da7373477c8376629746ec/redis-5.0.8.tar.gz", hash = "sha256:0c5b10d387568dfe0698c6fad6615750c24170e548ca2deac10c649d463e9870", size = 4595651, upload-time = "2024-07-30T14:11:52.137Z" }
 wheels = [
@@ -7113,6 +7131,7 @@ version = "2.0.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "importlib-metadata" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c0/b1/127b7612dc8625dd34eb202efc594dac86f5208aef4ff467dfd630e76f9d/SQLAlchemy-2.0.15.tar.gz", hash = "sha256:2e940a8659ef870ae10e0d9e2a6d5aaddf0ff6e91f7d0d7732afc9e8c4be9bbc", size = 9296612, upload-time = "2023-05-20T01:00:13.011Z" }
@@ -7436,6 +7455,7 @@ dependencies = [
     { name = "charset-normalizer" },
     { name = "courlan" },
     { name = "htmldate" },
+    { name = "importlib-metadata" },
     { name = "justext" },
     { name = "lxml" },
     { name = "urllib3" },
@@ -7479,6 +7499,9 @@ wheels = [
 name = "triton"
 version = "3.5.1"
 source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata", marker = "sys_platform != 'win32'" },
+]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/72/ec90c3519eaf168f22cb1757ad412f3a2add4782ad3a92861c9ad135d886/triton-3.5.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:61413522a48add32302353fdbaaf92daaaab06f6b5e3229940d21b5207f47579", size = 170425802, upload-time = "2025-11-11T17:40:53.209Z" },
     { url = "https://files.pythonhosted.org/packages/f2/50/9a8358d3ef58162c0a415d173cfb45b67de60176e1024f71fbc4d24c0b6d/triton-3.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d2c6b915a03888ab931a9fd3e55ba36785e1fe70cbea0b40c6ef93b20fc85232", size = 170470207, upload-time = "2025-11-11T17:41:00.253Z" },
@@ -7799,7 +7822,7 @@ dependencies = [
     { name = "aiofiles" },
     { name = "cryptography" },
     { name = "httpcore" },
-    { name = "httpx" },
+    { name = "httpx", extra = ["http2"] },
     { name = "pydantic" },
     { name = "pypdf" },
     { name = "requests-toolbelt" },
@@ -7885,6 +7908,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
     { name = "filelock" },
+    { name = "importlib-metadata" },
     { name = "platformdirs" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/aa/a3/4d310fa5f00863544e1d0f4de93bddec248499ccf97d4791bc3122c9d4f3/virtualenv-20.36.1.tar.gz", hash = "sha256:8befb5c81842c641f8ee658481e42641c68b5eab3521d8e092d18320902466ba", size = 6032239, upload-time = "2026-01-09T18:21:01.296Z" }

--- a/uv.lock
+++ b/uv.lock
@@ -14,22 +14,6 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'win32'",
 ]
 
-[manifest]
-overrides = [
-    { name = "aiohttp", specifier = ">=3.10" },
-    { name = "click" },
-    { name = "fastuuid", specifier = ">=0.13.0" },
-    { name = "google-cloud-aiplatform", specifier = ">=1.38.0" },
-    { name = "httpx", extras = ["http2"], specifier = ">=0.23.0" },
-    { name = "importlib-metadata", specifier = ">=6.8.0" },
-    { name = "jinja2", specifier = ">=3.1.2,<4.0.0" },
-    { name = "openai" },
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "tiktoken" },
-    { name = "tokenizers" },
-]
-
 [[package]]
 name = "accelerate"
 version = "1.6.0"
@@ -1123,7 +1107,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boto3" },
     { name = "fastavro" },
-    { name = "httpx", extra = ["http2"] },
+    { name = "httpx" },
     { name = "httpx-sse" },
     { name = "parameterized" },
     { name = "pydantic" },
@@ -1354,7 +1338,7 @@ dependencies = [
     { name = "click" },
     { name = "cloudpickle" },
     { name = "fsspec" },
-    { name = "importlib-metadata" },
+    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
     { name = "packaging" },
     { name = "partd" },
     { name = "pyyaml" },
@@ -1607,7 +1591,7 @@ name = "exa-py"
 version = "1.15.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx", extra = ["http2"] },
+    { name = "httpx" },
     { name = "openai" },
     { name = "pydantic" },
     { name = "requests" },
@@ -1768,7 +1752,7 @@ dependencies = [
     { name = "authlib" },
     { name = "cyclopts" },
     { name = "exceptiongroup" },
-    { name = "httpx", extra = ["http2"] },
+    { name = "httpx" },
     { name = "jsonref" },
     { name = "jsonschema-path" },
     { name = "mcp" },
@@ -1777,7 +1761,7 @@ dependencies = [
     { name = "packaging" },
     { name = "platformdirs" },
     { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
-    { name = "pydantic" },
+    { name = "pydantic", extra = ["email"] },
     { name = "pyperclip" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
@@ -2065,7 +2049,6 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-auth" },
     { name = "googleapis-common-protos" },
-    { name = "importlib-metadata" },
     { name = "proto-plus" },
     { name = "protobuf" },
     { name = "requests" },
@@ -2263,7 +2246,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "google-auth" },
-    { name = "httpx", extra = ["http2"] },
+    { name = "httpx" },
     { name = "pydantic" },
     { name = "requests" },
     { name = "tenacity" },
@@ -2590,7 +2573,7 @@ name = "httpx-oauth"
 version = "0.15.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx", extra = ["http2"] },
+    { name = "httpx" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6d/08/b2e0f360e84994ec5c67473cef7198d22ccb2215e5068c0a21182d22baaa/httpx_oauth-0.15.1.tar.gz", hash = "sha256:4094cf0938fc7252b5f5dfd62cd1ab5aee2fcb6734e621942ee17d1af4806b74", size = 41302, upload-time = "2024-08-22T13:01:20.328Z" }
 wheels = [
@@ -2612,7 +2595,6 @@ version = "11.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
-    { name = "importlib-metadata" },
     { name = "python-dateutil" },
     { name = "requests" },
     { name = "six" },
@@ -2999,7 +2981,7 @@ wheels = [
 
 [[package]]
 name = "jsonschema"
-version = "4.23.0"
+version = "4.25.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -3007,9 +2989,9 @@ dependencies = [
     { name = "referencing" },
     { name = "rpds-py" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/2e/03362ee4034a4c917f697890ccd4aec0800ccf9ded7f511971c75451deec/jsonschema-4.23.0.tar.gz", hash = "sha256:d71497fef26351a33265337fa77ffeb82423f3ea21283cd9467bb03999266bc4", size = 325778, upload-time = "2024-07-08T18:40:05.546Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/69/f7185de793a29082a9f3c7728268ffb31cb5095131a9c139a74078e27336/jsonschema-4.25.1.tar.gz", hash = "sha256:e4a9655ce0da0c0b67a085847e00a3a51449e1157f4f75e9fb5aa545e122eb85", size = 357342, upload-time = "2025-08-18T17:03:50.038Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/4a/4f9dbeb84e8850557c02365a0eee0649abe5eb1d84af92a25731c6c0f922/jsonschema-4.23.0-py3-none-any.whl", hash = "sha256:fbadb6f8b144a8f8cf9f0b89ba94501d143e50411a1278633f56a7acf7fd5566", size = 88462, upload-time = "2024-07-08T18:40:00.165Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl", hash = "sha256:3fba0169e345c7175110351d456342c364814cfcf3b964ba4587f22915230a63", size = 90040, upload-time = "2025-08-18T17:03:48.373Z" },
 ]
 
 [[package]]
@@ -3043,7 +3025,6 @@ name = "jupyter-client"
 version = "8.6.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "importlib-metadata" },
     { name = "jupyter-core" },
     { name = "python-dateutil" },
     { name = "pyzmq" },
@@ -3085,7 +3066,7 @@ name = "keyring"
 version = "25.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "importlib-metadata" },
+    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
     { name = "jaraco-classes" },
     { name = "jaraco-context" },
     { name = "jaraco-functools" },
@@ -3259,7 +3240,7 @@ version = "3.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "backoff" },
-    { name = "httpx", extra = ["http2"] },
+    { name = "httpx" },
     { name = "openai" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
@@ -3279,7 +3260,7 @@ name = "langsmith"
 version = "0.7.32"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx", extra = ["http2"] },
+    { name = "httpx" },
     { name = "orjson", marker = "platform_python_implementation != 'PyPy'" },
     { name = "packaging" },
     { name = "pydantic" },
@@ -3305,13 +3286,13 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.83.14"
+version = "1.85.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "click" },
     { name = "fastuuid" },
-    { name = "httpx", extra = ["http2"] },
+    { name = "httpx" },
     { name = "importlib-metadata" },
     { name = "jinja2" },
     { name = "jsonschema" },
@@ -3321,9 +3302,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8d/7c/c095649380adc96c8630273c1768c2ad1e74aa2ee1dd8dd05d218a60569f/litellm-1.83.14.tar.gz", hash = "sha256:24aef9b47cdc424c833e32f3727f411741c690832cd1fe4405e0077144fe09c9", size = 14836599, upload-time = "2026-04-26T03:16:10.176Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/55/aebffceaa08688a989e9c68b3edc3a520a1f8338eb0346668774bd66ad88/litellm-1.85.1.tar.gz", hash = "sha256:3b8ef0c89ff2736cbd27109f17ff31f1bd0ab59dee9be8cadb28ec3cb167ce0d", size = 15346324, upload-time = "2026-05-21T02:30:38.185Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/5c/1b5691575420135e90578543b2bf219497caa33cfd0af64cb38f30288450/litellm-1.83.14-py3-none-any.whl", hash = "sha256:92b11ba2a32cf80707ddf388d18526696c7999a21b418c5e3b6eda1243d2cfdb", size = 16457054, upload-time = "2026-04-26T03:16:05.72Z" },
+    { url = "https://files.pythonhosted.org/packages/17/a0/263a13c2253201aa11563a69d9a87f3510030aa765a16f57fc40ceefcdf5/litellm-1.85.1-py3-none-any.whl", hash = "sha256:c89eb5dfd18cce3d40b59e79c74f7f645bc7814a417c6ab25e53c786f0a6ab7b", size = 16980080, upload-time = "2026-05-21T02:30:35.096Z" },
 ]
 
 [package.optional-dependencies]
@@ -3718,7 +3699,7 @@ version = "1.27.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx", extra = ["http2"] },
+    { name = "httpx" },
     { name = "httpx-sse" },
     { name = "jsonschema" },
     { name = "pydantic" },
@@ -4370,7 +4351,6 @@ dependencies = [
     { name = "discord-py" },
     { name = "fastapi" },
     { name = "google-genai" },
-    { name = "jsonschema" },
     { name = "kubernetes" },
     { name = "litellm", extra = ["google"] },
     { name = "openai" },
@@ -4542,10 +4522,9 @@ requires-dist = [
     { name = "discord-py", specifier = "==2.4.0" },
     { name = "fastapi", specifier = "==0.133.1" },
     { name = "google-genai", specifier = "==1.52.0" },
-    { name = "jsonschema", specifier = "==4.23.0" },
     { name = "kubernetes", specifier = ">=31.0.0" },
-    { name = "litellm", extras = ["google"], specifier = "==1.83.14" },
-    { name = "openai", specifier = "==2.14.0" },
+    { name = "litellm", extras = ["google"], specifier = "==1.85.1" },
+    { name = "openai", specifier = "==2.38.0" },
     { name = "prometheus-client", specifier = ">=0.21.1" },
     { name = "prometheus-fastapi-instrumentator", specifier = "==7.1.0" },
     { name = "pydantic", specifier = "==2.11.7" },
@@ -4642,7 +4621,7 @@ backend = [
     { name = "starlette", specifier = "==0.49.3" },
     { name = "stripe", specifier = "==10.12.0" },
     { name = "supervisor", specifier = "==4.3.0" },
-    { name = "tiktoken", specifier = "==0.7.0" },
+    { name = "tiktoken", specifier = "==0.8.0" },
     { name = "timeago", specifier = "==1.0.16" },
     { name = "trafilatura", specifier = "==1.12.2" },
     { name = "types-openpyxl", specifier = "==3.0.4.7" },
@@ -4721,21 +4700,21 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.14.0"
+version = "2.38.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "distro" },
-    { name = "httpx", extra = ["http2"] },
+    { name = "httpx" },
     { name = "jiter" },
     { name = "pydantic" },
     { name = "sniffio" },
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d8/b1/12fe1c196bea326261718eb037307c1c1fe1dedc2d2d4de777df822e6238/openai-2.14.0.tar.gz", hash = "sha256:419357bedde9402d23bf8f2ee372fca1985a73348debba94bddff06f19459952", size = 626938, upload-time = "2025-12-19T03:28:45.742Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8f/12/cfa322c5f5dd8fa21aab9a7a8e979e7a11123800f86ca8d82eb68a83d213/openai-2.38.0.tar.gz", hash = "sha256:798694c6cf74145541fda94325b6f8f72d8e1fd0262cc137c8d728177a6a4ce3", size = 772764, upload-time = "2026-05-21T21:23:42.105Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/4b/7c1a00c2c3fbd004253937f7520f692a9650767aa73894d7a34f0d65d3f4/openai-2.14.0-py3-none-any.whl", hash = "sha256:7ea40aca4ffc4c4a776e77679021b47eec1160e341f42ae086ba949c9dcc9183", size = 1067558, upload-time = "2025-12-19T03:28:43.727Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/bf/ccff9be562e24207716d04ef9dc931c76aff0c89a7265da43e2104d7fe06/openai-2.38.0-py3-none-any.whl", hash = "sha256:ec6661c57b2dcc47414a767e6e3335c7ed3d19c9696999283a3c82e95c756a3c", size = 1344910, upload-time = "2026-05-21T21:23:39.636Z" },
 ]
 
 [[package]]
@@ -5660,6 +5639,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/c0/ec2b1c8712ca690e5d61979dee872603e92b8a32f94cc1b72d53beab008a/pydantic-2.11.7-py3-none-any.whl", hash = "sha256:dde5df002701f6de26248661f6835bbe296a47bf73990135c7d07ce741b9623b", size = 444782, upload-time = "2025-06-14T08:33:14.905Z" },
 ]
 
+[package.optional-dependencies]
+email = [
+    { name = "email-validator" },
+]
+
 [[package]]
 name = "pydantic-core"
 version = "2.33.2"
@@ -6194,7 +6178,6 @@ name = "pywikibot"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "importlib-metadata" },
     { name = "mwparserfromhell" },
     { name = "packaging" },
     { name = "requests" },
@@ -6410,7 +6393,6 @@ version = "5.0.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
-    { name = "importlib-metadata" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/10/defc227d65ea9c2ff5244645870859865cba34da7373477c8376629746ec/redis-5.0.8.tar.gz", hash = "sha256:0c5b10d387568dfe0698c6fad6615750c24170e548ca2deac10c649d463e9870", size = 4595651, upload-time = "2024-07-30T14:11:52.137Z" }
 wheels = [
@@ -7131,7 +7113,6 @@ version = "2.0.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
-    { name = "importlib-metadata" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c0/b1/127b7612dc8625dd34eb202efc594dac86f5208aef4ff467dfd630e76f9d/SQLAlchemy-2.0.15.tar.gz", hash = "sha256:2e940a8659ef870ae10e0d9e2a6d5aaddf0ff6e91f7d0d7732afc9e8c4be9bbc", size = 9296612, upload-time = "2023-05-20T01:00:13.011Z" }
@@ -7285,28 +7266,32 @@ wheels = [
 
 [[package]]
 name = "tiktoken"
-version = "0.7.0"
+version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "regex" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/4a/abaec53e93e3ef37224a4dd9e2fc6bb871e7a538c2b6b9d2a6397271daf4/tiktoken-0.7.0.tar.gz", hash = "sha256:1077266e949c24e0291f6c350433c6f0971365ece2b173a23bc3b9f9defef6b6", size = 33437, upload-time = "2024-05-13T18:03:28.793Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/02/576ff3a6639e755c4f70997b2d315f56d6d71e0d046f4fb64cb81a3fb099/tiktoken-0.8.0.tar.gz", hash = "sha256:9ccbb2740f24542534369c5635cfd9b2b3c2490754a78ac8831d99f89f94eeb2", size = 35107, upload-time = "2024-10-03T22:44:04.196Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/eb/57492b2568eea1d546da5cc1ae7559d924275280db80ba07e6f9b89a914b/tiktoken-0.7.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:10c7674f81e6e350fcbed7c09a65bca9356eaab27fb2dac65a1e440f2bcfe30f", size = 961468, upload-time = "2024-05-13T18:02:43.788Z" },
-    { url = "https://files.pythonhosted.org/packages/30/ef/e07dbfcb2f85c84abaa1b035a9279575a8da0236305491dc22ae099327f7/tiktoken-0.7.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:084cec29713bc9d4189a937f8a35dbdfa785bd1235a34c1124fe2323821ee93f", size = 907005, upload-time = "2024-05-13T18:02:45.327Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/9b/f36db825b1e9904c3a2646439cb9923fc1e09208e2e071c6d9dd64ead131/tiktoken-0.7.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:811229fde1652fedcca7c6dfe76724d0908775b353556d8a71ed74d866f73f7b", size = 1049183, upload-time = "2024-05-13T18:02:46.574Z" },
-    { url = "https://files.pythonhosted.org/packages/61/b4/b80d1fe33015e782074e96bbbf4108ccd283b8deea86fb43c15d18b7c351/tiktoken-0.7.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:86b6e7dc2e7ad1b3757e8a24597415bafcfb454cebf9a33a01f2e6ba2e663992", size = 1080830, upload-time = "2024-05-13T18:02:48.444Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/40/c66ff3a21af6d62a7e0ff428d12002c4e0389f776d3ff96dcaa0bb354eee/tiktoken-0.7.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1063c5748be36344c7e18c7913c53e2cca116764c2080177e57d62c7ad4576d1", size = 1092967, upload-time = "2024-05-13T18:02:50.006Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/80/f4c9e255ff236e6a69ce44b927629cefc1b63d3a00e2d1c9ed540c9492d2/tiktoken-0.7.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:20295d21419bfcca092644f7e2f2138ff947a6eb8cfc732c09cc7d76988d4a89", size = 1142682, upload-time = "2024-05-13T18:02:51.814Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/10/c04b4ff592a5f46b28ebf4c2353f735c02ae7f0ce1b165d00748ced6467e/tiktoken-0.7.0-cp311-cp311-win_amd64.whl", hash = "sha256:959d993749b083acc57a317cbc643fb85c014d055b2119b739487288f4e5d1cb", size = 799009, upload-time = "2024-05-13T18:02:53.057Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/46/4cdda4186ce900608f522da34acf442363346688c71b938a90a52d7b84cc/tiktoken-0.7.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:71c55d066388c55a9c00f61d2c456a6086673ab7dec22dd739c23f77195b1908", size = 960446, upload-time = "2024-05-13T18:02:54.409Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/30/09ced367d280072d7a3e21f34263dfbbf6378661e7a0f6414e7c18971083/tiktoken-0.7.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:09ed925bccaa8043e34c519fbb2f99110bd07c6fd67714793c21ac298e449410", size = 906652, upload-time = "2024-05-13T18:02:56.25Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/7b/c949e4954441a879a67626963dff69096e3c774758b9f2bb0853f7b4e1e7/tiktoken-0.7.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:03c6c40ff1db0f48a7b4d2dafeae73a5607aacb472fa11f125e7baf9dce73704", size = 1047904, upload-time = "2024-05-13T18:02:57.707Z" },
-    { url = "https://files.pythonhosted.org/packages/50/81/1842a22f15586072280364c2ab1e40835adaf64e42fe80e52aff921ee021/tiktoken-0.7.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d20b5c6af30e621b4aca094ee61777a44118f52d886dbe4f02b70dfe05c15350", size = 1079836, upload-time = "2024-05-13T18:02:59.009Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/87/51a133a3d5307cf7ae3754249b0faaa91d3414b85c3d36f80b54d6817aa6/tiktoken-0.7.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d427614c3e074004efa2f2411e16c826f9df427d3c70a54725cae860f09e4bf4", size = 1092472, upload-time = "2024-05-13T18:03:00.597Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/1f/c93517dc6d3b2c9e988b8e24f87a8b2d4a4ab28920a3a3f3ea338397ae0c/tiktoken-0.7.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8c46d7af7b8c6987fac9b9f61041b452afe92eb087d29c9ce54951280f899a97", size = 1141881, upload-time = "2024-05-13T18:03:02.743Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/4b/48ca098cb580c099b5058bf62c4cb5e90ca6130fa43ef4df27088536245b/tiktoken-0.7.0-cp312-cp312-win_amd64.whl", hash = "sha256:0bc603c30b9e371e7c4c7935aba02af5994a909fc3c0fe66e7004070858d3f8f", size = 799281, upload-time = "2024-05-13T18:03:04.036Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/1e/ca48e7bfeeccaf76f3a501bd84db1fa28b3c22c9d1a1f41af9fb7579c5f6/tiktoken-0.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d622d8011e6d6f239297efa42a2657043aaed06c4f68833550cac9e9bc723ef1", size = 1039700, upload-time = "2024-10-03T22:43:28.315Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/f8/f0101d98d661b34534769c3818f5af631e59c36ac6d07268fbfc89e539ce/tiktoken-0.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2efaf6199717b4485031b4d6edb94075e4d79177a172f38dd934d911b588d54a", size = 982413, upload-time = "2024-10-03T22:43:29.807Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/3c/2b95391d9bd520a73830469f80a96e3790e6c0a5ac2444f80f20b4b31051/tiktoken-0.8.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5637e425ce1fc49cf716d88df3092048359a4b3bbb7da762840426e937ada06d", size = 1144242, upload-time = "2024-10-04T04:42:53.66Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c4/c4a4360de845217b6aa9709c15773484b50479f36bb50419c443204e5de9/tiktoken-0.8.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9fb0e352d1dbe15aba082883058b3cce9e48d33101bdaac1eccf66424feb5b47", size = 1176588, upload-time = "2024-10-03T22:43:31.136Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/a3/ef984e976822cd6c2227c854f74d2e60cf4cd6fbfca46251199914746f78/tiktoken-0.8.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:56edfefe896c8f10aba372ab5706b9e3558e78db39dd497c940b47bf228bc419", size = 1237261, upload-time = "2024-10-03T22:43:32.75Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/86/eea2309dc258fb86c7d9b10db536434fc16420feaa3b6113df18b23db7c2/tiktoken-0.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:326624128590def898775b722ccc327e90b073714227175ea8febbc920ac0a99", size = 884537, upload-time = "2024-10-03T22:43:34.592Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/22/34b2e136a6f4af186b6640cbfd6f93400783c9ef6cd550d9eab80628d9de/tiktoken-0.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:881839cfeae051b3628d9823b2e56b5cc93a9e2efb435f4cf15f17dc45f21586", size = 1039357, upload-time = "2024-10-03T22:43:36.362Z" },
+    { url = "https://files.pythonhosted.org/packages/04/d2/c793cf49c20f5855fd6ce05d080c0537d7418f22c58e71f392d5e8c8dbf7/tiktoken-0.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fe9399bdc3f29d428f16a2f86c3c8ec20be3eac5f53693ce4980371c3245729b", size = 982616, upload-time = "2024-10-03T22:43:37.658Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/a1/79846e5ef911cd5d75c844de3fa496a10c91b4b5f550aad695c5df153d72/tiktoken-0.8.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9a58deb7075d5b69237a3ff4bb51a726670419db6ea62bdcd8bd80c78497d7ab", size = 1144011, upload-time = "2024-10-03T22:43:39.092Z" },
+    { url = "https://files.pythonhosted.org/packages/26/32/e0e3a859136e95c85a572e4806dc58bf1ddf651108ae8b97d5f3ebe1a244/tiktoken-0.8.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2908c0d043a7d03ebd80347266b0e58440bdef5564f84f4d29fb235b5df3b04", size = 1175432, upload-time = "2024-10-03T22:43:40.323Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/89/926b66e9025b97e9fbabeaa59048a736fe3c3e4530a204109571104f921c/tiktoken-0.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:294440d21a2a51e12d4238e68a5972095534fe9878be57d905c476017bff99fc", size = 1236576, upload-time = "2024-10-03T22:43:41.516Z" },
+    { url = "https://files.pythonhosted.org/packages/45/e2/39d4aa02a52bba73b2cd21ba4533c84425ff8786cc63c511d68c8897376e/tiktoken-0.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:d8f3192733ac4d77977432947d563d7e1b310b96497acd3c196c9bddb36ed9db", size = 883824, upload-time = "2024-10-03T22:43:43.33Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/38/802e79ba0ee5fcbf240cd624143f57744e5d411d2e9d9ad2db70d8395986/tiktoken-0.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:02be1666096aff7da6cbd7cdaa8e7917bfed3467cd64b38b1f112e96d3b06a24", size = 1039648, upload-time = "2024-10-03T22:43:45.22Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/da/24cdbfc302c98663fbea66f5866f7fa1048405c7564ab88483aea97c3b1a/tiktoken-0.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94ff53c5c74b535b2cbf431d907fc13c678bbd009ee633a2aca269a04389f9a", size = 982763, upload-time = "2024-10-03T22:43:46.571Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/f0/0ecf79a279dfa41fc97d00adccf976ecc2556d3c08ef3e25e45eb31f665b/tiktoken-0.8.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b231f5e8982c245ee3065cd84a4712d64692348bc609d84467c57b4b72dcbc5", size = 1144417, upload-time = "2024-10-03T22:43:48.633Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/d3/155d2d4514f3471a25dc1d6d20549ef254e2aa9bb5b1060809b1d3b03d3a/tiktoken-0.8.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4177faa809bd55f699e88c96d9bb4635d22e3f59d635ba6fd9ffedf7150b9953", size = 1175108, upload-time = "2024-10-03T22:43:50.568Z" },
+    { url = "https://files.pythonhosted.org/packages/19/eb/5989e16821ee8300ef8ee13c16effc20dfc26c777d05fbb6825e3c037b81/tiktoken-0.8.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5376b6f8dc4753cd81ead935c5f518fa0fbe7e133d9e25f648d8c4dabdd4bad7", size = 1236520, upload-time = "2024-10-03T22:43:51.759Z" },
+    { url = "https://files.pythonhosted.org/packages/40/59/14b20465f1d1cb89cfbc96ec27e5617b2d41c79da12b5e04e96d689be2a7/tiktoken-0.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:18228d624807d66c87acd8f25fc135665617cab220671eb65b50f5d70fa51f69", size = 883849, upload-time = "2024-10-03T22:43:53.999Z" },
 ]
 
 [[package]]
@@ -7455,7 +7440,6 @@ dependencies = [
     { name = "charset-normalizer" },
     { name = "courlan" },
     { name = "htmldate" },
-    { name = "importlib-metadata" },
     { name = "justext" },
     { name = "lxml" },
     { name = "urllib3" },
@@ -7499,9 +7483,6 @@ wheels = [
 name = "triton"
 version = "3.5.1"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "importlib-metadata", marker = "sys_platform != 'win32'" },
-]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/72/ec90c3519eaf168f22cb1757ad412f3a2add4782ad3a92861c9ad135d886/triton-3.5.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:61413522a48add32302353fdbaaf92daaaab06f6b5e3229940d21b5207f47579", size = 170425802, upload-time = "2025-11-11T17:40:53.209Z" },
     { url = "https://files.pythonhosted.org/packages/f2/50/9a8358d3ef58162c0a415d173cfb45b67de60176e1024f71fbc4d24c0b6d/triton-3.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d2c6b915a03888ab931a9fd3e55ba36785e1fe70cbea0b40c6ef93b20fc85232", size = 170470207, upload-time = "2025-11-11T17:41:00.253Z" },
@@ -7822,7 +7803,7 @@ dependencies = [
     { name = "aiofiles" },
     { name = "cryptography" },
     { name = "httpcore" },
-    { name = "httpx", extra = ["http2"] },
+    { name = "httpx" },
     { name = "pydantic" },
     { name = "pypdf" },
     { name = "requests-toolbelt" },
@@ -7908,7 +7889,6 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
     { name = "filelock" },
-    { name = "importlib-metadata" },
     { name = "platformdirs" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/aa/a3/4d310fa5f00863544e1d0f4de93bddec248499ccf97d4791bc3122c9d4f3/virtualenv-20.36.1.tar.gz", hash = "sha256:8befb5c81842c641f8ee658481e42641c68b5eab3521d8e092d18320902466ba", size = 6032239, upload-time = "2026-01-09T18:21:01.296Z" }


### PR DESCRIPTION
## Description

Cherry-pick of https://github.com/onyx-dot-app/onyx/pull/10807 & https://github.com/onyx-dot-app/onyx/pull/11385 (and https://github.com/onyx-dot-app/onyx/pull/10462 but that's purely testing infra) back to the `v3` branch to pick up security fixes namely addressing https://nvd.nist.gov/vuln/detail/CVE-2026-42271.

## How Has This Been Tested?

Captured by existing.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `litellm` to 1.85.1 and relax its transitive pins via `uv` overrides to pick up security fixes (CVE-2026-42271). Patches and nightly live tests align with OpenAI Responses API and Ollama streaming; CI installs from pinned requirements and skips nightly-only tests on PRs.

- **Dependencies**
  - Bump `litellm` to `1.85.1`; update `openai` to `2.38.0` and `tiktoken` to `0.8.0` across `pyproject`, requirements, and `uv.lock` (keep `[tool.uv].override-dependencies` to relax exact transitive pins).
  - CI: use `uv pip install --no-config --no-deps` with pinned files (no `--require-hashes`); skip tests marked `nightly` in PR runs.

- **Bug Fixes**
  - Responses API patches: set `done_reason="tool_calls"` when tool calls exist; rebuild `usage` as typed `ResponseAPIUsage` via `model_construct` (preserves new details fields); skip assembled streaming response when not streaming; join reasoning summaries with blank lines (streaming and non-streaming).
  - Ollama streaming reasoning: track `<think>...</think>` boundaries so reasoning and content are classified correctly.
  - Nightly live tests: parallel tool calls keep distinct indices/arguments; `metadata=None` is tolerated and invalid keys raise auth errors; reasoning summaries include blank-line separators; no Pydantic serializer warnings during streams.

<sup>Written for commit 7c917f497757336526d78ad9d26056ff4c0c4c26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





