### PR TITLE
fix: do not mirror encrypted KV secrets to Redis in plaintext

### DIFF
--- a/backend/onyx/key_value_store/store.py
+++ b/backend/onyx/key_value_store/store.py
@@ -28,16 +28,19 @@ class PgRedisKVStore(KeyValueStore):
         return self._cache
 
     def store(self, key: str, val: JSON_ro, encrypt: bool = False) -> None:
-        # Not encrypted in Cache backend (typically Redis), but encrypted in Postgres
+        # Encrypted values are protected at rest in Postgres; never mirror them to the
+        # cache backend (typically Redis) in plaintext. Cache only non-encrypted values,
+        # and drop any stale plaintext entry a prior write may have left for this key.
         try:
-            self._get_cache().set(
-                REDIS_KEY_PREFIX + key, json.dumps(val), ex=KV_REDIS_KEY_EXPIRATION
-            )
+            if encrypt:
+                self._get_cache().delete(REDIS_KEY_PREFIX + key)
+            else:
+                self._get_cache().set(
+                    REDIS_KEY_PREFIX + key, json.dumps(val), ex=KV_REDIS_KEY_EXPIRATION
+                )
         except Exception as e:
             # Fallback gracefully to Postgres if Cache backend fails
-            logger.error(
-                "Failed to set value in Cache backend for key '%s': %s", key, str(e)
-            )
+            logger.error("Failed to update Cache backend for key '%s': %s", key, str(e))
 
         encrypted_val = val if encrypt else None
         plain_val = val if not encrypt else None
@@ -70,22 +73,27 @@ class PgRedisKVStore(KeyValueStore):
 
             if obj.value is not None:
                 value = obj.value
+                cacheable = True
             elif obj.encrypted_value is not None:
                 # Unwrap SensitiveValue - this is internal backend use
                 value = obj.encrypted_value.get_value(apply_mask=False)
+                # Encrypted-at-rest secret: never repopulate the plaintext cache
+                cacheable = False
             else:
                 value = None
+                cacheable = True
 
-            try:
-                self._get_cache().set(
-                    REDIS_KEY_PREFIX + key,
-                    json.dumps(value),
-                    ex=KV_REDIS_KEY_EXPIRATION,
-                )
-            except Exception as e:
-                logger.error(
-                    "Failed to set value in cache for key '%s': %s", key, str(e)
-                )
+            if cacheable:
+                try:
+                    self._get_cache().set(
+                        REDIS_KEY_PREFIX + key,
+                        json.dumps(value),
+                        ex=KV_REDIS_KEY_EXPIRATION,
+                    )
+                except Exception as e:
+                    logger.error(
+                        "Failed to set value in cache for key '%s': %s", key, str(e)
+                    )
 
             return cast(JSON_ro, value)
 

--- a/backend/onyx/key_value_store/store.py
+++ b/backend/onyx/key_value_store/store.py
@@ -12,9 +12,7 @@ from onyx.utils.special_types import JSON_ro
 logger = setup_logger()
 
 
-# v2: encrypted values are no longer mirrored to the cache. The version bump abandons
-# any plaintext-secret entries written by the pre-v2 code (they expire from the old
-# prefix by TTL) instead of serving them on a cache hit.
+# Bumping this version abandons all entries cached under the prior prefix.
 REDIS_KEY_PREFIX = "onyx_kv_store_v2:"
 KV_REDIS_KEY_EXPIRATION = 60 * 60 * 24  # 1 Day
 
@@ -31,9 +29,8 @@ class PgRedisKVStore(KeyValueStore):
         return self._cache
 
     def store(self, key: str, val: JSON_ro, encrypt: bool = False) -> None:
-        # Encrypted values are protected at rest in Postgres; never mirror them to the
-        # cache backend (typically Redis) in plaintext. Cache only non-encrypted values,
-        # and drop any stale plaintext entry a prior write may have left for this key.
+        # Never mirror encrypted values to the cache in plaintext. Cache only
+        # non-encrypted values, and evict any stale entry for an encrypted key.
         try:
             if encrypt:
                 self._get_cache().delete(REDIS_KEY_PREFIX + key)
@@ -98,8 +95,7 @@ class PgRedisKVStore(KeyValueStore):
                         "Failed to set value in cache for key '%s': %s", key, str(e)
                     )
             else:
-                # Evict any cache entry for a key that turns out to be encrypted (e.g.
-                # cached while plaintext, then re-stored as a secret) so it is not served.
+                # Evict a stale plaintext entry for a key that is now encrypted.
                 try:
                     self._get_cache().delete(REDIS_KEY_PREFIX + key)
                 except Exception as e:

--- a/backend/onyx/key_value_store/store.py
+++ b/backend/onyx/key_value_store/store.py
@@ -12,7 +12,10 @@ from onyx.utils.special_types import JSON_ro
 logger = setup_logger()
 
 
-REDIS_KEY_PREFIX = "onyx_kv_store:"
+# v2: encrypted values are no longer mirrored to the cache. The version bump abandons
+# any plaintext-secret entries written by the pre-v2 code (they expire from the old
+# prefix by TTL) instead of serving them on a cache hit.
+REDIS_KEY_PREFIX = "onyx_kv_store_v2:"
 KV_REDIS_KEY_EXPIRATION = 60 * 60 * 24  # 1 Day
 
 
@@ -93,6 +96,15 @@ class PgRedisKVStore(KeyValueStore):
                 except Exception as e:
                     logger.error(
                         "Failed to set value in cache for key '%s': %s", key, str(e)
+                    )
+            else:
+                # Evict any cache entry for a key that turns out to be encrypted (e.g.
+                # cached while plaintext, then re-stored as a secret) so it is not served.
+                try:
+                    self._get_cache().delete(REDIS_KEY_PREFIX + key)
+                except Exception as e:
+                    logger.error(
+                        "Failed to evict cache entry for key '%s': %s", key, str(e)
                     )
 
             return cast(JSON_ro, value)

--- a/backend/tests/external_dependency_unit/cache/test_kv_store_cache_layer.py
+++ b/backend/tests/external_dependency_unit/cache/test_kv_store_cache_layer.py
@@ -164,3 +164,15 @@ class TestEncryptedValuesNotCached:
         kv_store.store("secret_c", {"token": "new"}, encrypt=True)
 
         assert pg_cache.get(REDIS_KEY_PREFIX + "secret_c") is None
+
+    def test_load_ignores_pre_v2_plaintext_entry(
+        self, kv_store: PgRedisKVStore, pg_cache: PostgresCacheBackend
+    ) -> None:
+        kv_store.store("secret_d", {"token": "real"}, encrypt=True)
+
+        # a plaintext secret left in the cache by the pre-v2 code, under the OLD prefix
+        pg_cache.set("onyx_kv_store:secret_d", json.dumps({"leaked": "old"}))
+
+        # load reads the current (v2) prefix, so the stale old-prefix entry is never
+        # served. It returns the value from Postgres
+        assert kv_store.load("secret_d") == {"token": "real"}

--- a/backend/tests/external_dependency_unit/cache/test_kv_store_cache_layer.py
+++ b/backend/tests/external_dependency_unit/cache/test_kv_store_cache_layer.py
@@ -140,9 +140,7 @@ class TestEncryptedValuesNotCached:
     ) -> None:
         kv_store.store("secret_a", {"token": "s3cr3t"}, encrypt=True)
 
-        # the secret is never written to the cache backend...
         assert pg_cache.get(REDIS_KEY_PREFIX + "secret_a") is None
-        # ...but still loads correctly from Postgres
         assert kv_store.load("secret_a") == {"token": "s3cr3t"}
 
     def test_encrypted_load_does_not_repopulate_cache(
@@ -150,15 +148,13 @@ class TestEncryptedValuesNotCached:
     ) -> None:
         kv_store.store("secret_b", {"token": "abc"}, encrypt=True)
 
-        # a load is a cache miss that falls through to Postgres. It must not
-        # repopulate the cache with the decrypted secret
         assert kv_store.load("secret_b") == {"token": "abc"}
         assert pg_cache.get(REDIS_KEY_PREFIX + "secret_b") is None
 
     def test_store_with_encrypt_drops_stale_plaintext_entry(
         self, kv_store: PgRedisKVStore, pg_cache: PostgresCacheBackend
     ) -> None:
-        # a plaintext entry left by an earlier (pre-fix) write
+        # a stale plaintext entry already in the cache
         pg_cache.set(REDIS_KEY_PREFIX + "secret_c", json.dumps({"old": "plain"}))
 
         kv_store.store("secret_c", {"token": "new"}, encrypt=True)
@@ -170,9 +166,8 @@ class TestEncryptedValuesNotCached:
     ) -> None:
         kv_store.store("secret_d", {"token": "real"}, encrypt=True)
 
-        # a plaintext secret left in the cache by the pre-v2 code, under the OLD prefix
+        # a stale plaintext entry under the previous cache prefix
         pg_cache.set("onyx_kv_store:secret_d", json.dumps({"leaked": "old"}))
 
-        # load reads the current (v2) prefix, so the stale old-prefix entry is never
-        # served. It returns the value from Postgres
+        # load uses the current prefix, so the old-prefix entry is never served
         assert kv_store.load("secret_d") == {"token": "real"}

--- a/backend/tests/external_dependency_unit/cache/test_kv_store_cache_layer.py
+++ b/backend/tests/external_dependency_unit/cache/test_kv_store_cache_layer.py
@@ -129,3 +129,38 @@ class TestCacheFailureGracefulDegradation:
         kv.store("survive", 42)
         loaded = kv.load("survive")
         assert loaded == 42
+
+
+class TestEncryptedValuesNotCached:
+    """Encrypted-at-rest KV values (connector secrets, OAuth tokens) must never be
+    mirrored to the cache backend in plaintext."""
+
+    def test_store_with_encrypt_does_not_cache_plaintext(
+        self, kv_store: PgRedisKVStore, pg_cache: PostgresCacheBackend
+    ) -> None:
+        kv_store.store("secret_a", {"token": "s3cr3t"}, encrypt=True)
+
+        # the secret is never written to the cache backend...
+        assert pg_cache.get(REDIS_KEY_PREFIX + "secret_a") is None
+        # ...but still loads correctly from Postgres
+        assert kv_store.load("secret_a") == {"token": "s3cr3t"}
+
+    def test_encrypted_load_does_not_repopulate_cache(
+        self, kv_store: PgRedisKVStore, pg_cache: PostgresCacheBackend
+    ) -> None:
+        kv_store.store("secret_b", {"token": "abc"}, encrypt=True)
+
+        # a load is a cache miss that falls through to Postgres. It must not
+        # repopulate the cache with the decrypted secret
+        assert kv_store.load("secret_b") == {"token": "abc"}
+        assert pg_cache.get(REDIS_KEY_PREFIX + "secret_b") is None
+
+    def test_store_with_encrypt_drops_stale_plaintext_entry(
+        self, kv_store: PgRedisKVStore, pg_cache: PostgresCacheBackend
+    ) -> None:
+        # a plaintext entry left by an earlier (pre-fix) write
+        pg_cache.set(REDIS_KEY_PREFIX + "secret_c", json.dumps({"old": "plain"}))
+
+        kv_store.store("secret_c", {"token": "new"}, encrypt=True)
+
+        assert pg_cache.get(REDIS_KEY_PREFIX + "secret_c") is None


### PR DESCRIPTION
## Description

Security fix found during a caching audit.

- **Bug:** `PgRedisKVStore.store()` wrote `json.dumps(val)` to the cache backend (Redis) regardless of the `encrypt` flag, and `load()` re-populated it with the decrypted value. Secrets encrypted at rest in Postgres sat in Redis as plaintext for up to 24h.
- **Exposure:** Google OAuth app credentials, service-account private keys, and per-credential OAuth tokens (`google_kv.py`), plus the customer UUID.
- **Fix:** cache only non-encrypted values. Skip the cache write when `encrypt=True` (and drop any stale plaintext entry), and never repopulate the cache from the encrypted column on load. Encrypted keys now always read from Postgres, which is fine since they are read during connector sync, not a per-request hot path.

## How Has This Been Tested?

Added external-dependency-unit tests asserting encrypted values are never written to the cache backend and that a load does not repopulate it. All 11 KV cache-layer tests pass against a local Postgres, ruff and project-wide ty clean.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check