### PR TITLE
fix(craft): clean up scheduled task run summary display

### DIFF
--- a/backend/onyx/server/features/build/scheduled_tasks/executor.py
+++ b/backend/onyx/server/features/build/scheduled_tasks/executor.py
@@ -76,6 +76,22 @@ SUMMARY_MAX_CHARS = 120
 PROVISIONING_WAIT_SECONDS = 120
 
 
+def _clip_summary(text: str) -> str:
+    """Clip to ~SUMMARY_MAX_CHARS at a word boundary, with an ellipsis.
+
+    Only backtracks to the last space when it sits past the halfway point,
+    so a long unbroken token (e.g. a URL) degrades to a mid-token cut
+    instead of discarding most of the snippet.
+    """
+    if len(text) <= SUMMARY_MAX_CHARS:
+        return text
+    clipped = text[:SUMMARY_MAX_CHARS]
+    last_space = clipped.rfind(" ")
+    if last_space > SUMMARY_MAX_CHARS // 2:
+        clipped = clipped[:last_space]
+    return clipped.rstrip() + "…"
+
+
 def _summary_from_state(state: BuildStreamingState, fallback: str = "") -> str:
     """Build a ~120-char summary from accumulated agent message text.
 
@@ -85,8 +101,8 @@ def _summary_from_state(state: BuildStreamingState, fallback: str = "") -> str:
     if state.message_chunks:
         full = "".join(state.message_chunks).strip()
         if full:
-            return full[:SUMMARY_MAX_CHARS]
-    return fallback[:SUMMARY_MAX_CHARS] if fallback else ""
+            return _clip_summary(full)
+    return _clip_summary(fallback) if fallback else ""
 
 
 def _summary_from_session_messages(session_id: UUID, db_session: Any) -> str:
@@ -108,7 +124,7 @@ def _summary_from_session_messages(session_id: UUID, db_session: Any) -> str:
         if isinstance(content, dict):
             text = content.get("text") or ""
             if isinstance(text, str) and text.strip():
-                return text.strip()[:SUMMARY_MAX_CHARS]
+                return _clip_summary(text.strip())
     return ""
 
 

--- a/backend/onyx/server/features/build/scheduled_tasks/executor.py
+++ b/backend/onyx/server/features/build/scheduled_tasks/executor.py
@@ -77,8 +77,6 @@ PROVISIONING_WAIT_SECONDS = 120
 
 
 def _clip_summary(text: str) -> str:
-    """Only backtracks to a space past the halfway point so one long token
-    (e.g. a URL) can't discard most of the snippet."""
     if len(text) <= SUMMARY_MAX_CHARS:
         return text
     clipped = text[:SUMMARY_MAX_CHARS]

--- a/backend/onyx/server/features/build/scheduled_tasks/executor.py
+++ b/backend/onyx/server/features/build/scheduled_tasks/executor.py
@@ -77,12 +77,8 @@ PROVISIONING_WAIT_SECONDS = 120
 
 
 def _clip_summary(text: str) -> str:
-    """Clip to ~SUMMARY_MAX_CHARS at a word boundary, with an ellipsis.
-
-    Only backtracks to the last space when it sits past the halfway point,
-    so a long unbroken token (e.g. a URL) degrades to a mid-token cut
-    instead of discarding most of the snippet.
-    """
+    """Only backtracks to a space past the halfway point so one long token
+    (e.g. a URL) can't discard most of the snippet."""
     if len(text) <= SUMMARY_MAX_CHARS:
         return text
     clipped = text[:SUMMARY_MAX_CHARS]

--- a/backend/tests/unit/onyx/server/features/build/scheduled_tasks/test_executor.py
+++ b/backend/tests/unit/onyx/server/features/build/scheduled_tasks/test_executor.py
@@ -14,7 +14,8 @@ def test_clip_summary_exactly_max_passthrough() -> None:
 def test_clip_summary_clips_at_word_boundary_with_ellipsis() -> None:
     text = ("word " * 40).strip()
     clipped = _clip_summary(text)
-    assert clipped == "word " * 23 + "word…"
+    words_kept = SUMMARY_MAX_CHARS // len("word ") - 1
+    assert clipped == "word " * words_kept + "word…"
     assert len(clipped) <= SUMMARY_MAX_CHARS + 1
 
 

--- a/backend/tests/unit/onyx/server/features/build/scheduled_tasks/test_executor.py
+++ b/backend/tests/unit/onyx/server/features/build/scheduled_tasks/test_executor.py
@@ -1,0 +1,36 @@
+from onyx.server.features.build.scheduled_tasks.executor import _clip_summary
+from onyx.server.features.build.scheduled_tasks.executor import SUMMARY_MAX_CHARS
+
+
+def test_clip_summary_short_text_passthrough() -> None:
+    assert _clip_summary("All done.") == "All done."
+
+
+def test_clip_summary_exactly_max_passthrough() -> None:
+    text = "x" * SUMMARY_MAX_CHARS
+    assert _clip_summary(text) == text
+
+
+def test_clip_summary_clips_at_word_boundary_with_ellipsis() -> None:
+    text = ("word " * 40).strip()
+    clipped = _clip_summary(text)
+    assert clipped == "word " * 23 + "word…"
+    assert len(clipped) <= SUMMARY_MAX_CHARS + 1
+
+
+def test_clip_summary_no_space_falls_back_to_hard_cut() -> None:
+    text = "x" * 200
+    assert _clip_summary(text) == "x" * SUMMARY_MAX_CHARS + "…"
+
+
+def test_clip_summary_early_space_does_not_discard_snippet() -> None:
+    text = "Done: " + "a" * 200
+    clipped = _clip_summary(text)
+    assert clipped == text[:SUMMARY_MAX_CHARS] + "…"
+
+
+def test_clip_summary_strips_trailing_space_before_ellipsis() -> None:
+    text = "word " * 40
+    clipped = _clip_summary(text)
+    assert not clipped[:-1].endswith(" ")
+    assert clipped.endswith("…")

--- a/web/src/app/craft/v1/tasks/components/RunHistoryTable.tsx
+++ b/web/src/app/craft/v1/tasks/components/RunHistoryTable.tsx
@@ -84,17 +84,12 @@ interface SummaryCellProps {
   row: ScheduledRunSummary;
 }
 
-// Run summaries are LLM-generated markdown of arbitrary length; the table
-// cell has a fixed height, so render them as plain text clamped to two lines
-// (exactly the cell's height) with a hover tooltip carrying the longer text.
 function SummaryCell({ row }: SummaryCellProps) {
   const reason = getNonClickableReason(row);
   const raw = row.summary ?? row.skip_reason ?? row.error_class;
-  // Heading markers are stripped from the raw text (line-anchored, before
-  // toPlainString collapses newlines) so mid-sentence "# " survives.
-  // toPlainString only strips paired inline markers; server-side truncation
-  // can leave unpaired ones behind, which the last two passes sweep up —
-  // `__` only at marker positions so word-internal `foo__bar` is preserved.
+  // Headings must be stripped before toPlainString collapses newlines (else
+  // mid-sentence "# " gets eaten); the trailing passes sweep unpaired markers
+  // left by server truncation — `__` only at marker edges so `foo__bar` survives.
   const stripped = raw
     ? toPlainString(markdown(raw.replace(/^#{1,6}\s+/gm, "")))
         .replace(/\*\*|~~|`/g, "")
@@ -107,6 +102,7 @@ function SummaryCell({ row }: SummaryCellProps) {
   const tooltip = showTooltip ? clipAtWordBoundary(plain) : undefined;
 
   const text = (
+    // Two 20px lines exactly fill the table's fixed 40px cell; three would clip.
     <Text font="main-ui-body" color="text-03" maxLines={2}>
       {plain ?? "—"}
     </Text>

--- a/web/src/app/craft/v1/tasks/components/RunHistoryTable.tsx
+++ b/web/src/app/craft/v1/tasks/components/RunHistoryTable.tsx
@@ -18,6 +18,8 @@ import {
 } from "@opal/components";
 import SvgLock from "@opal/icons/lock";
 import { SvgSimpleLoader } from "@opal/icons";
+import { markdown } from "@opal/utils";
+import { toPlainString } from "@opal/components/text/InlineMarkdown";
 import { Section } from "@/layouts/general-layouts";
 import { listScheduledTaskRuns } from "@/app/craft/v1/tasks/api";
 import { RunStatusBadge } from "@/app/craft/v1/tasks/components/StatusBadge";
@@ -44,6 +46,8 @@ interface RunHistoryTableProps {
 
 const tc = createTableColumns<ScheduledRunSummary>();
 const RUN_HISTORY_REFRESH_INTERVAL_MS = 5000;
+const SUMMARY_TOOLTIP_THRESHOLD_CHARS = 80;
+const SUMMARY_TOOLTIP_MAX_CHARS = 400;
 
 interface NonClickableCellProps {
   reason: string | null;
@@ -64,6 +68,60 @@ function NonClickableCell({ reason, children }: NonClickableCellProps) {
         {children}
       </div>
     </Tooltip>
+  );
+}
+
+function clipAtWordBoundary(text: string): string {
+  // Slice by code points so an astral char at the boundary isn't split.
+  const chars = Array.from(text);
+  if (chars.length <= SUMMARY_TOOLTIP_MAX_CHARS) return text;
+  const head = chars.slice(0, SUMMARY_TOOLTIP_MAX_CHARS).join("");
+  const lastSpace = head.lastIndexOf(" ");
+  return `${(lastSpace > 0 ? head.slice(0, lastSpace) : head).trimEnd()}…`;
+}
+
+interface SummaryCellProps {
+  row: ScheduledRunSummary;
+}
+
+// Run summaries are LLM-generated markdown of arbitrary length; the table
+// cell has a fixed height, so render them as plain text clamped to two lines
+// (exactly the cell's height) with a hover tooltip carrying the longer text.
+function SummaryCell({ row }: SummaryCellProps) {
+  const reason = getNonClickableReason(row);
+  const raw = row.summary ?? row.skip_reason ?? row.error_class;
+  // Heading markers are stripped from the raw text (line-anchored, before
+  // toPlainString collapses newlines) so mid-sentence "# " survives.
+  // toPlainString only strips paired inline markers; server-side truncation
+  // can leave unpaired ones behind, which the last two passes sweep up —
+  // `__` only at marker positions so word-internal `foo__bar` is preserved.
+  const stripped = raw
+    ? toPlainString(markdown(raw.replace(/^#{1,6}\s+/gm, "")))
+        .replace(/\*\*|~~|`/g, "")
+        .replace(/(?<!\w)__|__(?!\w)/g, "")
+    : null;
+  const plain = stripped?.trim() ? stripped : null;
+
+  const showTooltip =
+    !reason && plain != null && plain.length > SUMMARY_TOOLTIP_THRESHOLD_CHARS;
+  const tooltip = showTooltip ? clipAtWordBoundary(plain) : undefined;
+
+  const text = (
+    <Text font="main-ui-body" color="text-03" maxLines={2}>
+      {plain ?? "—"}
+    </Text>
+  );
+
+  return (
+    <NonClickableCell reason={reason}>
+      {tooltip ? (
+        <Tooltip tooltip={tooltip} side="top" delayDuration={300}>
+          <div className="min-w-0">{text}</div>
+        </Tooltip>
+      ) : (
+        text
+      )}
+    </NonClickableCell>
   );
 }
 
@@ -129,13 +187,7 @@ function buildColumns() {
       id: "summary",
       header: "Summary",
       width: { weight: 38 },
-      cell: (row) => (
-        <NonClickableCell reason={getNonClickableReason(row)}>
-          <Text font="main-ui-body" color="text-03">
-            {row.summary ?? row.skip_reason ?? row.error_class ?? "—"}
-          </Text>
-        </NonClickableCell>
-      ),
+      cell: (row) => <SummaryCell row={row} />,
     }),
     tc.column("trigger_source", {
       header: "Trigger",

--- a/web/src/app/craft/v1/tasks/components/RunHistoryTable.tsx
+++ b/web/src/app/craft/v1/tasks/components/RunHistoryTable.tsx
@@ -72,7 +72,6 @@ function NonClickableCell({ reason, children }: NonClickableCellProps) {
 }
 
 function clipAtWordBoundary(text: string): string {
-  // Slice by code points so an astral char at the boundary isn't split.
   const chars = Array.from(text);
   if (chars.length <= SUMMARY_TOOLTIP_MAX_CHARS) return text;
   const head = chars.slice(0, SUMMARY_TOOLTIP_MAX_CHARS).join("");
@@ -87,9 +86,7 @@ interface SummaryCellProps {
 function SummaryCell({ row }: SummaryCellProps) {
   const reason = getNonClickableReason(row);
   const raw = row.summary ?? row.skip_reason ?? row.error_class;
-  // Headings must be stripped before toPlainString collapses newlines (else
-  // mid-sentence "# " gets eaten); the trailing passes sweep unpaired markers
-  // left by server truncation — `__` only at marker edges so `foo__bar` survives.
+  // Heading strip must run before toPlainString collapses newlines.
   const stripped = raw
     ? toPlainString(markdown(raw.replace(/^#{1,6}\s+/gm, "")))
         .replace(/\*\*|~~|`/g, "")


### PR DESCRIPTION
## Description

The Summary column on the Craft scheduled-tasks run-history table (`/craft/v1/tasks/[id]`) rendered raw LLM markdown (literal `**bold**` markers) into a fixed-height cell, cropping the text mid-line at the top and bottom. This PR makes the summary presentable end to end:

**Frontend (`RunHistoryTable.tsx`)**
- New `SummaryCell`: strips markdown to plain text (line-anchored heading strip before newline collapse, `toPlainString` for paired inline markers, then a sweep for unpaired markers left behind by server-side truncation — word-internal `__` like `foo__bar` is preserved).
- Clamps to two lines (`maxLines={2}`), which exactly fits the table's fixed 40px cell — no more mid-line cropping.
- Long summaries (> 80 chars) on clickable rows get a hover tooltip with the stored summary, clipped at a word boundary (code-point-safe). Non-clickable rows keep their existing "why can't I open this" tooltip untouched.
- Empty-after-strip summaries fall back to the "—" placeholder.

**Backend (`executor.py`)**
- `_clip_summary` truncates stored summaries at a word boundary with an ellipsis instead of a hard `[:120]` mid-word slice. Backtracking is floored at the halfway point so URL/token-heavy text degrades to a mid-token cut rather than discarding most of the snippet.

The full agent message remains available by clicking the run row (opens the session); the table summary is intentionally a snippet (`SUMMARY_MAX_CHARS = 120`).

### Known minor items (intentionally not addressed)
- Historical rows written by the old hard slice can still show a stray unpaired `[` from a link cut mid-label, or a lone `*`/`_`; the marker sweep covers the common cases (`**`, `__`, `~~`, backticks) only. Cosmetic, self-heals as new runs are written.
- Frontend `clipAtWordBoundary` and backend `_clip_summary` implement the same idea independently (different constants/languages); a drift would only affect tooltip clipping, not stored data.

## How Has This Been Tested?

- New unit tests for `_clip_summary` (`backend/tests/unit/.../scheduled_tasks/test_executor.py`, 6 cases: passthrough, exact-boundary, word-boundary clip, no-space fallback, early-space floor, trailing-space strip) — all pass.
- Verified live in the browser against seeded run data (long multi-paragraph markdown summary, ~120-char truncated summaries with unclosed `**`, failed run with `error_class`, skipped run with `skip_reason`, short summary): two-line clamp, markdown stripping, tooltip, non-clickable reason tooltip, and row-click navigation all behave as expected. Verified `#support`-style channel names and `foo__bar` identifiers are not corrupted.
- `bun run types:check`, `oxfmt`, `oxlint`, and pre-commit all green.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the run summary column in `/craft/v1/tasks/[id]` by stripping markdown, clamping to two lines, and adding a hover tooltip for long text. Backend now stores ~120‑char summaries clipped at word boundaries with an ellipsis.

- **Bug Fixes**
  - Render summaries as plain text; no raw markdown or mid-line cropping.
  - Clamp to two lines to fit the 40px cell.
  - Keep the existing non-clickable row tooltip; show "—" when empty.

- **New Features**
  - Hover tooltip on clickable rows for long summaries (>80 chars), clipped at a word boundary with an ellipsis.
  - `_clip_summary` persists ~120‑char snippets at a word boundary.
  - Unit tests cover boundary cases with expectations derived from `SUMMARY_MAX_CHARS`.

<sup>Written for commit c1715f5a2abfdaf03c9e2d62b73917f2ea05069d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

