### PR TITLE
chore(model-server): build on a Docker Hardened Image (full distroless)

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1229,6 +1229,15 @@ jobs:
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ env.DOCKER_TOKEN }}
 
+      # Dockerfile.model_server pulls its hardened Python base from dhi.io, authenticated
+      # with the same Docker account credentials (the account must have DHI catalog access).
+      - name: Login to Docker Hardened Images (dhi.io)
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        with:
+          registry: dhi.io
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ env.DOCKER_TOKEN }}
+
       - name: Build and push AMD64
         id: build
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
@@ -1303,6 +1312,15 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
         with:
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ env.DOCKER_TOKEN }}
+
+      # Dockerfile.model_server pulls its hardened Python base from dhi.io, authenticated
+      # with the same Docker account credentials (the account must have DHI catalog access).
+      - name: Login to Docker Hardened Images (dhi.io)
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        with:
+          registry: dhi.io
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ env.DOCKER_TOKEN }}
 

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -169,6 +169,15 @@ jobs:
         with:
           ecr-registry: ${{ vars.ECR_REGISTRY }}
 
+      # Dockerfile.model_server pulls its hardened Python base from dhi.io, authenticated
+      # with the same Docker account credentials (the account must have DHI catalog access).
+      - name: Login to Docker Hardened Images (dhi.io)
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        with:
+          registry: dhi.io
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
       - name: Build and push Model Server Docker image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
         with:

--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -301,6 +301,16 @@ jobs:
         with:
           ecr-registry: ${{ vars.ECR_REGISTRY }}
 
+      # backend/Dockerfile.model_server pulls its hardened Python base from dhi.io,
+      # authenticated with the same Docker account credentials (the account must
+      # have access to the DHI catalog).
+      - name: Login to Docker Hardened Images (dhi.io)
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        with:
+          registry: dhi.io
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
       - name: Build and push Model Server Docker image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
         with:

--- a/.github/workflows/pr-python-model-tests.yml
+++ b/.github/workflows/pr-python-model-tests.yml
@@ -67,6 +67,15 @@ jobs:
         with:
           ecr-registry: ${{ vars.ECR_REGISTRY }}
 
+      # Dockerfile.model_server pulls its hardened Python base from dhi.io, authenticated
+      # with the same Docker account credentials (the account must have DHI catalog access).
+      - name: Login to Docker Hardened Images (dhi.io)
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        with:
+          registry: dhi.io
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # ratchet:docker/setup-buildx-action@v4
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -306,16 +306,16 @@ If you want to make changes to Onyx and run those changes in Docker, you can als
 docker compose up -d --build
 ```
 
-> **Note:** Building the web image (`web/Dockerfile`) pulls its base from Docker Hardened
-> Images (`dhi.io`), so you must authenticate first with a Docker account that has access to
-> the DHI catalog:
+> **Note:** Building the web image (`web/Dockerfile`) and the model-server image
+> (`backend/Dockerfile.model_server`) pulls their bases from Docker Hardened Images (`dhi.io`),
+> so you must authenticate first with a Docker account that has access to the DHI catalog:
 >
 > ```bash
 > docker login dhi.io
 > ```
 >
-> Pulling the pre-built `onyxdotapp/onyx-web-server` image (the default `docker compose up -d`
-> without `--build`) does not require this.
+> Pulling the pre-built `onyxdotapp/onyx-web-server` / `onyxdotapp/onyx-model-server` images
+> (the default `docker compose up -d` without `--build`) does not require this.
 
 ---
 

--- a/backend/Dockerfile.model_server
+++ b/backend/Dockerfile.model_server
@@ -1,17 +1,36 @@
-# Registry prefix for base images. Defaults to Docker Hub; CI overrides this to the ECR
-# pull-through cache (<account>.dkr.ecr.us-east-2.amazonaws.com/docker-hub) to avoid Docker
-# Hub rate limits.
+# Registry prefix retained for parity with the other Dockerfiles and so the
+# BASE_IMAGE_REGISTRY build-arg (passed by docker-bake.hcl / CI) stays valid.
+# The hardened Python bases below come from dhi.io -- a separate registry not
+# served by the ECR pull-through cache -- so they intentionally bypass this ARG.
 ARG BASE_IMAGE_REGISTRY=docker.io
 
-# Base stage with dependencies
-FROM ${BASE_IMAGE_REGISTRY}/library/python:3.13-slim@sha256:b04b5d7233d2ad9c379e22ea8927cd1378cd15c60d4ef876c065b25ea8fb3bf3 AS base
+# Build stage. The DHI "-dev" variant runs as root and ships a shell, apt, and
+# build tooling -- everything needed to install the wheels.
+# Refresh the digest with: docker buildx imagetools inspect dhi.io/python:3.13-debian13-dev
+FROM dhi.io/python:3.13-debian13-dev@sha256:7933d16e50454c39bca6e935027166d5e5b05c6c03383dc2f58e8fe6e2440b7d AS builder
 
 ENV ONYX_RUNNING_IN_DOCKER="true" \
-    HF_HOME=/app/.cache/huggingface
+    HF_HOME=/app/.cache/huggingface \
+    VIRTUAL_ENV=/app/.venv \
+    PATH="/app/.venv/bin:$PATH" \
+    UV_PYTHON_DOWNLOADS=never \
+    UV_PYTHON_PREFERENCE=only-system
 
 COPY --from=ghcr.io/astral-sh/uv:0.11.25@sha256:1e3808aa9023d0980e7c15b1fa7c1ac16ff35925780cf5c459858b2d693f01a9 /uv /uvx /bin/
 
-RUN mkdir -p /app/.cache/huggingface
+# Install into a self-contained venv rather than the system site-packages. The
+# venv lives at a fixed path we control (/app/.venv), so the distroless runtime
+# stage can copy it wholesale without depending on the base image's Python layout.
+RUN uv venv /app/.venv --python 3.13
+
+# Pre-create the runtime writable dirs here (the distroless runtime has no shell
+# to mkdir). Left empty in this stage; the model download happens downstream.
+RUN mkdir -p /app/.cache/huggingface /var/log/onyx
+
+# Recreate the `onyx` user (UID 1001) from the previous image so deployments that
+# pin `-u onyx` / `user: onyx` keep resolving and their 1001-owned volumes stay
+# writable. Its passwd/group entries are copied into the distroless runtime below.
+RUN groupadd -g 1001 onyx && useradd -u 1001 -g onyx -M -s /usr/sbin/nologin onyx
 
 COPY ./requirements/model_server.txt /tmp/requirements.txt
 
@@ -20,22 +39,25 @@ COPY ./requirements/model_server.txt /tmp/requirements.txt
 # awk extracts each matching package block in full — the package line plus its
 # `--hash=...` continuation lines — so --require-hashes can verify them.
 RUN awk '/^[[:alnum:]]/ { keep = ($0 ~ /^(torch|nvidia-[a-z0-9-]+|triton)==/) } keep' /tmp/requirements.txt \
-        | uv pip install --system --no-cache-dir --no-deps --require-hashes -r /dev/stdin && \
+        | uv pip install --python /app/.venv/bin/python --no-cache-dir --no-deps --require-hashes -r /dev/stdin && \
     rm -rf ~/.cache/uv
 
 # TODO: drop --no-deps once we upgrade to a litellm version with looser dependencies.
-RUN uv pip install --system --no-cache-dir --no-deps --require-hashes \
+RUN uv pip install --python /app/.venv/bin/python --no-cache-dir --no-deps --require-hashes \
         -r /tmp/requirements.txt && \
     rm -rf ~/.cache/uv /tmp/*.txt
 
 # Stage for downloading embedding models. Instantiating SentenceTransformer
 # pulls down both the weights and the custom architecture code.
-FROM base AS embedding-models
+FROM builder AS embedding-models
 RUN python -c "from sentence_transformers import SentenceTransformer; \
 SentenceTransformer(model_name_or_path='nomic-ai/nomic-embed-text-v1', trust_remote_code=True);"
 
-# Final stage - combine all downloads
-FROM base AS final
+# Runtime stage. The DHI runtime variant is near-distroless: no shell or package
+# manager, runs non-root. We run as the `onyx` user (UID 1001, carried over from
+# the previous image; see USER below) and chown everything the runtime writes to it.
+# Refresh the digest with: docker buildx imagetools inspect dhi.io/python:3.13-debian13
+FROM dhi.io/python:3.13-debian13@sha256:05827957dafc7b83633d56f24d9281525d3546a1d600eef90385c7212d3def5e AS final
 
 LABEL com.danswer.maintainer="founders@onyx.app"
 LABEL com.danswer.description="This image is for the Onyx model server which runs all of the \
@@ -43,43 +65,57 @@ AI models for Onyx. This container and all the code is MIT Licensed and free for
 You can find it at https://hub.docker.com/r/onyx/onyx-model-server. For more details, \
 visit https://github.com/onyx-dot-app/onyx."
 
-# Create non-root user for security best practices
-RUN groupadd -g 1001 onyx && \
-    useradd -u 1001 -g onyx -m -s /bin/bash onyx && \
-    mkdir -p /var/log/onyx && \
-    chmod 755 /var/log/onyx && \
-    chown onyx:onyx /var/log/onyx
+WORKDIR /app
+
+ENV ONYX_RUNNING_IN_DOCKER="true" \
+    HF_HOME=/app/.cache/huggingface \
+    HOME=/app/.cache/huggingface \
+    PYTHONPATH=/app \
+    VIRTUAL_ENV=/app/.venv \
+    PATH="/app/.venv/bin:$PATH"
+
+# Bring the `onyx` user (1001) into the distroless runtime. The -dev builder's
+# passwd/group are a superset of the runtime's, so copying them preserves the
+# base's own entries while adding `onyx`, letting `USER onyx` and any runtime
+# `-u onyx` override resolve the name.
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /etc/group /etc/group
+
+# Installed dependencies (the venv) plus the writable runtime dirs, owned by the
+# onyx UID (1001) so the process can write the HF cache and logs. When users mount
+# named volumes over these paths, the volume seeds with the same ownership.
+COPY --from=builder --chown=1001:1001 /app/.venv /app/.venv
+COPY --from=builder --chown=1001:1001 /app/.cache/huggingface /app/.cache/huggingface
+COPY --from=builder --chown=1001:1001 /var/log/onyx /var/log/onyx
 
 # In case the user has volumes mounted to /app/.cache/huggingface that they've downloaded while
 # running Onyx, move the current contents of the cache folder to a temporary location to ensure
 # it's preserved in order to combine with the user's cache contents
-COPY --chown=onyx:onyx --from=embedding-models /app/.cache/huggingface /app/.cache/temp_huggingface
-
-WORKDIR /app
+COPY --chown=1001:1001 --from=embedding-models /app/.cache/huggingface /app/.cache/temp_huggingface
 
 # Utils used by model server
-COPY ./onyx/utils/logger.py /app/onyx/utils/logger.py
-COPY ./onyx/utils/platform_utils.py /app/onyx/utils/platform_utils.py
-COPY ./onyx/utils/middleware.py /app/onyx/utils/middleware.py
-COPY ./onyx/utils/tenant.py /app/onyx/utils/tenant.py
+COPY --chown=1001:1001 ./onyx/utils/logger.py /app/onyx/utils/logger.py
+COPY --chown=1001:1001 ./onyx/utils/platform_utils.py /app/onyx/utils/platform_utils.py
+COPY --chown=1001:1001 ./onyx/utils/middleware.py /app/onyx/utils/middleware.py
+COPY --chown=1001:1001 ./onyx/utils/tenant.py /app/onyx/utils/tenant.py
 
 # Sentry configuration (used when SENTRY_DSN is set)
-COPY ./onyx/configs/__init__.py /app/onyx/configs/__init__.py
-COPY ./onyx/configs/sentry.py /app/onyx/configs/sentry.py
+COPY --chown=1001:1001 ./onyx/configs/__init__.py /app/onyx/configs/__init__.py
+COPY --chown=1001:1001 ./onyx/configs/sentry.py /app/onyx/configs/sentry.py
 
 # Place to fetch version information
-COPY ./onyx/__init__.py /app/onyx/__init__.py
+COPY --chown=1001:1001 ./onyx/__init__.py /app/onyx/__init__.py
 
 # Shared between Onyx Backend and Model Server
-COPY ./shared_configs /app/shared_configs
+COPY --chown=1001:1001 ./shared_configs /app/shared_configs
 
 # Model Server main code
-COPY ./model_server /app/model_server
-
-ENV PYTHONPATH=/app
+COPY --chown=1001:1001 ./model_server /app/model_server
 
 # Default ONYX_VERSION, typically overriden during builds by GitHub Actions.
 ARG ONYX_VERSION=0.0.0-dev
 ENV ONYX_VERSION=${ONYX_VERSION}
+
+USER onyx
 
 CMD ["python", "-m", "model_server"]

--- a/backend/Dockerfile.model_server
+++ b/backend/Dockerfile.model_server
@@ -29,8 +29,11 @@ RUN mkdir -p /app/.cache/huggingface /var/log/onyx
 
 # Recreate the `onyx` user (UID 1001) from the previous image so deployments that
 # pin `-u onyx` / `user: onyx` keep resolving and their 1001-owned volumes stay
-# writable. Its passwd/group entries are copied into the distroless runtime below.
-RUN groupadd -g 1001 onyx && useradd -u 1001 -g onyx -M -s /usr/sbin/nologin onyx
+# writable. The DHI "-dev" image ships a shell but not the `shadow` tools
+# (groupadd/useradd), so write the passwd/group entries directly; they're copied
+# into the distroless runtime below.
+RUN printf 'onyx:x:1001:\n' >> /etc/group && \
+    printf 'onyx:x:1001:1001::/home/onyx:/usr/sbin/nologin\n' >> /etc/passwd
 
 COPY ./requirements/model_server.txt /tmp/requirements.txt
 

--- a/backend/model_server/__main__.py
+++ b/backend/model_server/__main__.py
@@ -24,6 +24,12 @@ def main() -> None:
 
     run_server()
 
+    # uvicorn.run() only returns once the server has stopped serving, so treat any
+    # return here as a failure: exit non-zero so `restart: on-failure` (compose) and
+    # `restartPolicy: OnFailure` (k8s) bring the container back. A bare return would
+    # exit 0 and silently suppress the restart.
+    sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/backend/onyx/utils/logger.py
+++ b/backend/onyx/utils/logger.py
@@ -272,23 +272,34 @@ def _add_file_handlers(logger: logging.Logger, formatter: logging.Formatter) -> 
             if is_containerized
             else f"./log/{LOG_FILE_NAME}_{level}.log"
         )
-        # Ensure the log directory exists
-        log_dir = os.path.dirname(file_name)
-        if not os.path.exists(log_dir):
-            os.makedirs(log_dir, exist_ok=True)
+        try:
+            # Ensure the log directory exists
+            log_dir = os.path.dirname(file_name)
+            if not os.path.exists(log_dir):
+                os.makedirs(log_dir, exist_ok=True)
 
-        # Truncate log file if DEV_LOGGING_ENABLED (for clean dev experience)
-        if DEV_LOGGING_ENABLED and os.path.exists(file_name):
-            try:
-                open(file_name, "w").close()  # Truncate the file
-            except Exception:
-                pass  # Ignore errors, just proceed with normal logging
+            # Truncate log file if DEV_LOGGING_ENABLED (for clean dev experience)
+            if DEV_LOGGING_ENABLED and os.path.exists(file_name):
+                try:
+                    open(file_name, "w").close()  # Truncate the file
+                except Exception:
+                    pass  # Ignore errors, just proceed with normal logging
 
-        file_handler = RotatingFileHandler(
-            file_name,
-            maxBytes=25 * 1024 * 1024,  # 25 MB
-            backupCount=5,  # Keep 5 backup files
-        )
+            file_handler = RotatingFileHandler(
+                file_name,
+                maxBytes=25 * 1024 * 1024,  # 25 MB
+                backupCount=5,  # Keep 5 backup files
+            )
+        except OSError:
+            # The log location isn't writable by this process — e.g. a nonroot
+            # container whose mounted /var/log/onyx volume is owned by another UID.
+            # Fall back to the stdout handler instead of crashing at import time.
+            logger.warning(
+                "Cannot write log files under %s; falling back to stdout logging.",
+                os.path.dirname(file_name),
+            )
+            return
+
         file_handler.setLevel(get_log_level_from_str(level))
         file_handler.setFormatter(formatter)
         logger.addHandler(file_handler)


### PR DESCRIPTION
## What

Migrates the model-server image (`onyxdotapp/onyx-model-server` / `-cloud`) from `python:3.13-slim` to a **Docker Hardened Image** running a **full distroless runtime** — no shell, no package manager, nonroot (the `onyx` user, UID 1001) — to shrink its attack surface / CVE count without changing behavior (FastAPI/uvicorn on `:9000`, CPU + GPU, amd64 + arm64).

Follows the DHI pattern established for the web frontend (#12592): bases come from `dhi.io`, authenticated with the same Docker account credentials.

> **This is the image half of a two-PR split.** The companion Helm chart change (run the model servers nonroot + `Chart` 0.7.0) is **#12788**, which must merge **only after** this image publishes as `:latest`. See *Merge order* below.

## Changes

- **`backend/Dockerfile.model_server`** — multi-stage build on `dhi.io/python:3.13-debian13-dev` (build) → `dhi.io/python:3.13-debian13` (runtime), both **digest-pinned** (multi-arch index digests). Dependencies install into a **self-contained venv at `/app/.venv`**, independent of the base image's Python layout. Runtime writable dirs (`HF_HOME`, `/var/log/onyx`) are pre-created and `--chown`'d to `1001`. Keeps the torch/CUDA layer split and the `embedding-models` (nomic) pre-bake. Image default: `USER onyx`, `CMD ["python", "-m", "model_server"]`.
  - **Keeps the `onyx` user at UID 1001** (the previous image's user), recreated in the `-dev` builder and carried into the distroless runtime via its `passwd`/`group` — so setups that pin `-u onyx` / `user: onyx` keep resolving, and volumes written by the old image (owned by 0/1001) stay usable. (Chose 1001 over the DHI-default 65532 for this backward compat; it's still nonroot.)
- **`backend/onyx/utils/logger.py`** — the file logger now falls back to stdout (instead of crashing at import) when `/var/log/onyx` isn't writable — e.g. a nonroot container whose mounted log volume is owned by another UID. Makes the root→nonroot move non-breaking for existing deployments with a persistent, root-owned logs volume.
- **CI** — add `dhi.io` login to the model-server build/test jobs (`deployment.yml` amd64 + arm64, `pr-integration-tests.yml`, `pr-python-model-tests.yml`); extend the `CONTRIBUTING.md` DHI note.

The startup entrypoint (`model_server/__main__.py`, `DISABLE_MODEL_SERVER` gate) and the Python CA-merge (`model_server/ca_certs.py`, `ONYX_CUSTOM_CA_CERTS_DIR`) already landed on `main` (#12754, #12761), as did the compose `command` removal and the Helm deployment-template changes — so this PR is the base-image swap, the logger stdout fallback, and the CI login.

## Compatibility

Safe to merge and publish on its own — it needs **no** chart change:

- `main`'s chart runs the model servers as **root** (`runAsUser: 0`); the distroless image runs fine as root (it can write its `1001`-owned dirs).
- `main`'s chart already uses the shell-free CA path (`ONYX_CUSTOM_CA_CERTS_DIR`, plain `uvicorn`), which the distroless image's `ca_certs.py` handles in Python — no shell needed.

The nonroot security posture is realized only once **#12788** lands (hence the ordering).

**Caveat (inherent to going shell-less):** a chart *older* than the current `main` — one that still wraps the command in `/bin/sh -c "update-ca-certificates && …"` — with `customCACerts` enabled will crash on this image (no `/bin/sh`). Those operators must move to a chart that uses the `ONYX_CUSTOM_CA_CERTS_DIR` path.

## Merge order

1. **This PR (image)** → wait for the distroless image to build & publish as `:latest`.
2. Then **#12788 (chart)** — flips the deployments to nonroot `1001` + `Chart` 0.7.0.

This avoids releasing a chart that requires an image version that isn't `:latest` yet.

## Remaining / follow-ups

- [x] **Pin the DHI base digests** — `-dev` `@sha256:7933d16e…40b7d`, runtime `@sha256:05827957…ef5e` (confirmed multi-arch index digests: `index.v1+json` with `linux/amd64` + `linux/arm64`).
- [ ] **Build + boot smoke** (amd64 + arm64): server comes up on `:9000`, `/api/health` OK; `DISABLE_MODEL_SERVER=true` exits cleanly. Validates torch/CUDA `libstdc++`/`libgomp` on the new base.
- [ ] **GPU smoke** if a GPU runner is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

