### PR TITLE
fix(chat): base chat retention on last message time

### DIFF
--- a/backend/onyx/db/chat.py
+++ b/backend/onyx/db/chat.py
@@ -373,7 +373,11 @@ def get_chat_sessions_older_than(
     days_old: int, db_session: Session
 ) -> list[tuple[UUID | None, UUID]]:
     """
-    Retrieves chat sessions older than a specified number of days.
+    Retrieves chat sessions whose last activity is older than a specified number of days.
+
+    "Last activity" is the time of the most recent message in the session, so an
+    old session that is still being used is retained. Sessions without any messages
+    fall back to their creation time.
 
     Args:
         days_old: The number of days to consider as "old".
@@ -384,10 +388,14 @@ def get_chat_sessions_older_than(
     """
 
     cutoff_time = datetime.now(tz=timezone.utc) - timedelta(days=days_old)
+    last_activity = func.coalesce(
+        func.max(ChatMessage.time_sent), ChatSession.time_created
+    )
     old_sessions: Sequence[Row[Tuple[UUID | None, UUID]]] = db_session.execute(
-        select(ChatSession.user_id, ChatSession.id).where(
-            ChatSession.time_created < cutoff_time
-        )
+        select(ChatSession.user_id, ChatSession.id)
+        .outerjoin(ChatMessage, ChatMessage.chat_session_id == ChatSession.id)
+        .group_by(ChatSession.id, ChatSession.user_id)
+        .having(last_activity < cutoff_time)
     ).fetchall()
 
     # convert old_sessions to a conventional list of tuples

--- a/backend/tests/integration/tests/chat_retention/test_chat_retention.py
+++ b/backend/tests/integration/tests/chat_retention/test_chat_retention.py
@@ -1,14 +1,22 @@
 import os
 import time
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from uuid import UUID
 
 import httpx
 import pytest
+from sqlalchemy import update
 
 from onyx.db.chat import delete_chat_session
 from onyx.db.chat import get_chat_sessions_older_than
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.models import ChatMessage
+from onyx.db.models import ChatSession
 from tests.integration.common_utils.managers.chat import ChatSessionManager
 from tests.integration.common_utils.managers.settings import SettingsManager
+from tests.integration.common_utils.test_models import DATestChatSession
 from tests.integration.common_utils.test_models import DATestLLMProvider
 from tests.integration.common_utils.test_models import DATestSettings
 from tests.integration.common_utils.test_models import DATestUser
@@ -30,6 +38,39 @@ def _run_ttl_cleanup(retention_days: int) -> None:
                 include_deleted=True,
                 hard_delete=True,
             )
+
+
+def _backdate_session(
+    session_id: UUID, created_days_ago: int, last_message_days_ago: int
+) -> None:
+    """Rewrite a session's creation time and its messages' sent time so retention
+    behavior can be tested deterministically without sleeping."""
+    now = datetime.now(tz=timezone.utc)
+    with get_session_with_current_tenant() as db_session:
+        db_session.execute(
+            update(ChatSession)
+            .where(ChatSession.id == session_id)
+            .values(time_created=now - timedelta(days=created_days_ago))
+        )
+        db_session.execute(
+            update(ChatMessage)
+            .where(ChatMessage.chat_session_id == session_id)
+            .values(time_sent=now - timedelta(days=last_message_days_ago))
+        )
+        db_session.commit()
+
+
+def _is_session_deleted(chat_session: DATestChatSession, user: DATestUser) -> bool:
+    try:
+        history = ChatSessionManager.get_chat_history(
+            chat_session=chat_session,
+            user_performing_action=user,
+        )
+        return len(history) == 0
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code in (404, 400):
+            return True
+        raise
 
 
 @pytest.mark.skipif(
@@ -73,17 +114,67 @@ def test_chat_retention(
     _run_ttl_cleanup(retention_days)
 
     # Verify the chat session was deleted
-    session_deleted = False
-    try:
-        chat_history = ChatSessionManager.get_chat_history(
-            chat_session=chat_session,
-            user_performing_action=admin_user,
-        )
-        session_deleted = len(chat_history) == 0
-    except httpx.HTTPStatusError as e:
-        if e.response.status_code in (404, 400):
-            session_deleted = True
-        else:
-            raise
+    assert _is_session_deleted(chat_session, admin_user), (
+        "Chat session was not deleted after retention period"
+    )
 
-    assert session_deleted, "Chat session was not deleted after retention period"
+
+@pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="Chat retention tests are enterprise only",
+)
+def test_chat_retention_uses_last_message_time(
+    reset: None,  # noqa: ARG001
+    admin_user: DATestUser,
+    llm_provider: DATestLLMProvider,  # noqa: ARG001
+) -> None:
+    """Retention is based on last message time, not session creation time.
+
+    An old session that received a recent message should be retained, while an
+    old session with no recent activity should be deleted.
+    """
+
+    retention_days = 30
+    settings = DATestSettings(maximum_chat_retention_days=retention_days)
+    SettingsManager.update_settings(settings, user_performing_action=admin_user)
+
+    # Created long ago but recently used -> should be RETAINED
+    active_session = ChatSessionManager.create(
+        persona_id=0,
+        description="Old session, recent activity",
+        user_performing_action=admin_user,
+    )
+    active_response = ChatSessionManager.send_message(
+        chat_session_id=active_session.id,
+        message="Recent message keeps this session alive",
+        user_performing_action=admin_user,
+    )
+    assert active_response.error is None, (
+        f"Chat response should not have an error: {active_response.error}"
+    )
+    _backdate_session(active_session.id, created_days_ago=60, last_message_days_ago=1)
+
+    # Created long ago and inactive -> should be DELETED
+    stale_session = ChatSessionManager.create(
+        persona_id=0,
+        description="Old session, no recent activity",
+        user_performing_action=admin_user,
+    )
+    stale_response = ChatSessionManager.send_message(
+        chat_session_id=stale_session.id,
+        message="This session has gone stale",
+        user_performing_action=admin_user,
+    )
+    assert stale_response.error is None, (
+        f"Chat response should not have an error: {stale_response.error}"
+    )
+    _backdate_session(stale_session.id, created_days_ago=60, last_message_days_ago=60)
+
+    _run_ttl_cleanup(retention_days)
+
+    assert not _is_session_deleted(active_session, admin_user), (
+        "Session with a recent message should be retained"
+    )
+    assert _is_session_deleted(stale_session, admin_user), (
+        "Session with no recent activity should be deleted"
+    )


### PR DESCRIPTION
## Description

Chat retention (the enterprise TTL job that auto-deletes old chat sessions) selected sessions purely by `ChatSession.time_created`. As a result, an actively-used session that was *created* before the retention window was deleted even if it had recent messages.

This changes `get_chat_sessions_older_than` to compare against the **last message time** — `MAX(ChatMessage.time_sent)` per session — falling back to `time_created` for sessions that have no messages. Now only genuinely inactive chats are auto-deleted.

The change is isolated to the single query in `backend/onyx/db/chat.py`. No schema migration or backfill is required, and the Celery TTL task / scheduling / settings chain is untouched.

## How Has This Been Tested?

- Compiled and executed the new query against a live dev Postgres, and ran `get_chat_sessions_older_than` end-to-end through SQLAlchemy against real data.
- Extended the enterprise integration test suite (`test_chat_retention.py`) with `test_chat_retention_uses_last_message_time`, which backdates timestamps to assert that an old session with a *recent* message is retained while an old session with no recent activity is deleted.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix chat retention to use the last message time for TTL, so active sessions aren’t deleted. Inactive sessions with no recent messages are still cleaned up.

- **Bug Fixes**
  - Updated `get_chat_sessions_older_than` to use `COALESCE(MAX(ChatMessage.time_sent), ChatSession.time_created)` with `OUTER JOIN`, `GROUP BY`, and `HAVING` for cutoff filtering.
  - No schema or task changes; only the query is updated.
  - Added integration test `test_chat_retention_uses_last_message_time` with helpers to backdate timestamps for deterministic validation.

<sup>Written for commit fe72d49715c811aedc8c0b0bb802a7827b1efabd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

