### PR TITLE
refactor(skills): add bundle rewrite utilities

### DIFF
--- a/backend/onyx/skills/bundle.py
+++ b/backend/onyx/skills/bundle.py
@@ -174,6 +174,127 @@ def read_custom_bundle_instructions(zip_bytes: bytes) -> str:
     return strip_skill_md_frontmatter(skill_md)
 
 
+def build_skill_md(
+    *,
+    name: str,
+    description: str,
+    instructions_markdown: str,
+) -> str:
+    name = name.strip()
+    description = description.strip()
+    instructions_markdown = instructions_markdown.strip()
+    if not name:
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, "Skill name cannot be empty.")
+    if not description:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "Skill description cannot be empty.",
+        )
+    if not instructions_markdown:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "Skill instructions cannot be empty.",
+        )
+
+    frontmatter = yaml.safe_dump(
+        {"name": name, "description": description},
+        sort_keys=False,
+        allow_unicode=True,
+    ).strip()
+    return f"---\n{frontmatter}\n---\n\n{instructions_markdown}\n"
+
+
+def rewrite_custom_bundle_skill_md(
+    zip_bytes: bytes,
+    *,
+    slug: str,
+    name: str,
+    description: str,
+    instructions_markdown: str,
+) -> bytes:
+    """Return a new custom bundle with root SKILL.md replaced.
+
+    Existing supporting files are copied through unchanged. The resulting
+    archive is validated with the normal custom-bundle validator before it is
+    returned to callers for storage.
+    """
+    check_slug(slug)
+    if slug in BUILT_IN_SKILLS:
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, f"slug '{slug}' is reserved")
+
+    new_skill_md = build_skill_md(
+        name=name,
+        description=description,
+        instructions_markdown=instructions_markdown,
+    ).encode("utf-8")
+    if len(new_skill_md) > DEFAULT_PER_FILE_MAX_BYTES:
+        raise OnyxError(
+            OnyxErrorCode.PAYLOAD_TOO_LARGE,
+            f"file '{SKILL_MD_NAME}' exceeds "
+            f"{DEFAULT_PER_FILE_MAX_BYTES // (1024 * 1024)} MiB",
+        )
+
+    try:
+        source_zip = zipfile.ZipFile(io.BytesIO(zip_bytes))
+    except zipfile.BadZipFile as exc:
+        raise OnyxError(
+            OnyxErrorCode.INTERNAL_ERROR,
+            "Stored skill bundle is not a valid zip.",
+        ) from exc
+
+    output = io.BytesIO()
+    saw_skill_md = False
+    with (
+        source_zip,
+        zipfile.ZipFile(
+            output, mode="w", compression=zipfile.ZIP_DEFLATED
+        ) as target_zip,
+    ):
+        for info in source_zip.infolist():
+            try:
+                normalized = _check_zip_entry_path(info.filename)
+            except OnyxError as exc:
+                raise OnyxError(
+                    OnyxErrorCode.INTERNAL_ERROR,
+                    "Stored skill bundle contains an unsafe path.",
+                ) from exc
+            if _is_symlink(info):
+                raise OnyxError(
+                    OnyxErrorCode.INTERNAL_ERROR,
+                    "Stored skill bundle contains a symlink.",
+                )
+
+            if normalized == SKILL_MD_NAME:
+                if saw_skill_md:
+                    continue
+                fresh_info = zipfile.ZipInfo(filename=SKILL_MD_NAME)
+                fresh_info.compress_type = zipfile.ZIP_DEFLATED
+                target_zip.writestr(fresh_info, new_skill_md)
+                saw_skill_md = True
+                continue
+
+            if info.is_dir():
+                target_zip.writestr(info, b"")
+            else:
+                try:
+                    target_zip.writestr(info, source_zip.read(info))
+                except Exception as exc:
+                    raise OnyxError(
+                        OnyxErrorCode.INTERNAL_ERROR,
+                        "Failed to read stored skill bundle entry.",
+                    ) from exc
+
+    if not saw_skill_md:
+        raise OnyxError(
+            OnyxErrorCode.INTERNAL_ERROR,
+            "Stored skill bundle is missing SKILL.md.",
+        )
+
+    rewritten = output.getvalue()
+    validate_custom_bundle(rewritten, slug=slug)
+    return rewritten
+
+
 def _is_symlink(info: zipfile.ZipInfo) -> bool:
     """True if the zip entry was archived as a Unix symlink.
 

--- a/backend/onyx/skills/content.py
+++ b/backend/onyx/skills/content.py
@@ -34,6 +34,14 @@ def read_custom_skill_bundle_instructions(
     skill: Skill,
     file_store: FileStore | None = None,
 ) -> str:
+    bundle_bytes = read_custom_skill_bundle_bytes(skill, file_store)
+    return read_custom_bundle_instructions(bundle_bytes)
+
+
+def read_custom_skill_bundle_bytes(
+    skill: Skill,
+    file_store: FileStore | None = None,
+) -> bytes:
     if skill.bundle_file_id is None:
         raise OnyxError(
             OnyxErrorCode.INTERNAL_ERROR,
@@ -47,4 +55,4 @@ def read_custom_skill_bundle_instructions(
             OnyxErrorCode.INTERNAL_ERROR,
             f"Failed to read bundle for skill '{skill.slug}'.",
         ) from exc
-    return read_custom_bundle_instructions(bundle_bytes)
+    return bundle_bytes

--- a/backend/tests/unit/onyx/skills/test_bundle_validation.py
+++ b/backend/tests/unit/onyx/skills/test_bundle_validation.py
@@ -13,11 +13,13 @@ import zipfile
 
 import pytest
 
+from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.skills.bundle import _ZIP_UNIX_CREATE_SYSTEM
 from onyx.skills.bundle import compute_bundle_sha256
 from onyx.skills.bundle import parse_skill_md_metadata
 from onyx.skills.bundle import read_custom_bundle_instructions
+from onyx.skills.bundle import rewrite_custom_bundle_skill_md
 from onyx.skills.bundle import slug_from_filename
 from onyx.skills.bundle import strip_skill_md_frontmatter
 from onyx.skills.bundle import validate_custom_bundle
@@ -197,6 +199,67 @@ def test_read_custom_bundle_instructions_returns_instruction_body() -> None:
 def test_read_custom_bundle_instructions_does_not_require_frontmatter() -> None:
     zip_bytes = _build_zip([("SKILL.md", b"# Instructions\n\nDo it.")])
     assert read_custom_bundle_instructions(zip_bytes) == "# Instructions\n\nDo it."
+
+
+def test_rewrite_custom_bundle_skill_md_preserves_supporting_files() -> None:
+    original = _build_zip(
+        [
+            (
+                "SKILL.md",
+                b"---\nname: Old\ndescription: Old desc\n---\n\nOld instructions.",
+            ),
+            ("scripts/run.py", b"print('hi')\n"),
+            ("docs/notes.md", b"# Notes\n"),
+        ]
+    )
+
+    rewritten = rewrite_custom_bundle_skill_md(
+        original,
+        slug="hello",
+        name="New",
+        description="New desc",
+        instructions_markdown="# New instructions\n\nDo it.",
+    )
+
+    assert validate_custom_bundle(rewritten, slug="hello") is None
+    assert parse_skill_md_metadata(rewritten) == ("New", "New desc")
+    assert read_custom_bundle_instructions(rewritten) == "# New instructions\n\nDo it."
+    with zipfile.ZipFile(io.BytesIO(rewritten)) as zf:
+        assert zf.read("scripts/run.py") == b"print('hi')\n"
+        assert zf.read("docs/notes.md") == b"# Notes\n"
+
+
+def test_rewrite_custom_bundle_skill_md_rejects_oversized_skill_md_before_zip_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("onyx.skills.bundle.DEFAULT_PER_FILE_MAX_BYTES", 128)
+
+    with pytest.raises(OnyxError) as exc_info:
+        rewrite_custom_bundle_skill_md(
+            b"not a zip",
+            slug="hello",
+            name="New",
+            description="New desc",
+            instructions_markdown="x" * 256,
+        )
+
+    assert exc_info.value.error_code == OnyxErrorCode.PAYLOAD_TOO_LARGE
+
+
+def test_rewrite_custom_bundle_skill_md_rejects_missing_skill_md() -> None:
+    original = _build_zip([("scripts/run.py", b"print('hi')\n")])
+
+    with pytest.raises(OnyxError) as exc_info:
+        rewrite_custom_bundle_skill_md(
+            original,
+            slug="hello",
+            name="New",
+            description="New desc",
+            instructions_markdown="# New instructions\n\nDo it.",
+        )
+
+    assert exc_info.value.error_code == OnyxErrorCode.INTERNAL_ERROR
+    assert exc_info.value.detail == "Stored skill bundle is missing SKILL.md."
 
 
 def _zip_with_patched_compression_method(payload: bytes, method: int) -> bytes:


### PR DESCRIPTION
## Description

Adds reusable skill bundle rewrite helpers for replacing the root `SKILL.md` while preserving supporting files and revalidating the resulting bundle. Also exposes a helper for reading stored custom skill bundle bytes so later skill editor work can update metadata and instructions without duplicating file-store reads.

## How Has This Been Tested?


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds utilities to rewrite the root `SKILL.md` in custom skill bundles while keeping supporting files intact and validating the result. Also exposes a helper to read stored bundle bytes to reduce duplicate file-store reads.

- **New Features**
  - `rewrite_custom_bundle_skill_md(...)` replaces `SKILL.md`, preserves other entries, rejects unsafe paths/symlinks, checks size before reading the zip, enforces slug rules (non-built-in), revalidates the bundle, and errors if `SKILL.md` is missing.
  - `build_skill_md(...)` builds a normalized `SKILL.md` with validated name, description, and instructions.
  - `read_custom_skill_bundle_bytes(...)` returns raw bundle bytes for reuse (used by `read_custom_skill_bundle_instructions`).

<sup>Written for commit a0f49a6809d6895e6462bb1a7e7da3c403bcef86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

