### PR TITLE
refactor(agents): extract share modal utilities

### DIFF
--- a/web/src/sections/modals/AddPeoplePicker.tsx
+++ b/web/src/sections/modals/AddPeoplePicker.tsx
@@ -5,11 +5,13 @@ import { Button, LineItemButton, Tag, Text } from "@opal/components";
 import { SvgUser, SvgUsers, SvgX } from "@opal/icons";
 import { cn } from "@opal/utils";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
-import { PersonaSharePermission } from "@/lib/agents/types";
-import { MinimalUserSnapshot } from "@/lib/types";
-import { MinimalUserGroupSnapshot } from "@/hooks/useShareableGroups";
+import type { MinimalUserSnapshot } from "@/lib/types";
+import type { MinimalUserGroupSnapshot } from "@/hooks/useShareableGroups";
 import { SharePermissionMenu } from "@/sections/modals/SharePermissionMenu";
-import { PERMISSION_OPTIONS } from "@/sections/modals/shareAccessConstants";
+import {
+  PERMISSION_OPTIONS,
+  type ShareAccessPermission,
+} from "@/sections/modals/shareAccessConstants";
 
 interface Suggestion {
   id: string;
@@ -27,9 +29,9 @@ export interface AddPeoplePickerProps {
   onAddUser: (user: MinimalUserSnapshot) => void;
   onRemoveGroup: (groupId: number) => void;
   onRemoveUser: (userId: string) => void;
-  onStagedPermissionChange: (permission: PersonaSharePermission) => void;
+  onStagedPermissionChange: (permission: ShareAccessPermission) => void;
   stagedGroups: MinimalUserGroupSnapshot[];
-  stagedPermission: PersonaSharePermission;
+  stagedPermission: ShareAccessPermission;
   stagedUsers: MinimalUserSnapshot[];
   users: MinimalUserSnapshot[];
 }

--- a/web/src/sections/modals/ShareAgentModal.tsx
+++ b/web/src/sections/modals/ShareAgentModal.tsx
@@ -3,24 +3,19 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { mutate } from "swr";
 import useShareableGroups, {
-  MinimalUserGroupSnapshot,
+  type MinimalUserGroupSnapshot,
 } from "@/hooks/useShareableGroups";
 import useShareableUsers from "@/hooks/useShareableUsers";
 import { toast } from "@/hooks/useToast";
 import { useAgent } from "@/lib/agents/hooks";
-import {
-  PersonaGroupShare,
-  PersonaSharePermission,
-  PersonaUserShare,
-  type FullAgent,
-} from "@/lib/agents/types";
+import type { FullAgent, PersonaSharePermission } from "@/lib/agents/types";
 import {
   removeSelfFromAgentShares,
   transferAgentOwnership,
   updateAgentShares,
 } from "@/lib/agents/svc";
 import { SWR_KEYS } from "@/lib/swr-keys";
-import { MinimalUserSnapshot } from "@/lib/types";
+import type { MinimalUserSnapshot } from "@/lib/types";
 import { useUser } from "@/providers/UserProvider";
 import { useSettings } from "@/lib/settings/hooks";
 import Modal from "@/refresh-components/Modal";
@@ -37,17 +32,24 @@ import {
   SvgUserManage,
   SvgUsers,
 } from "@opal/icons";
-import type { IconFunctionComponent } from "@opal/types";
-import { Content } from "@opal/layouts";
 import { copyText, markdown } from "@opal/utils";
 import { useModal } from "@/refresh-components/contexts/ModalContext";
 import { AddPeoplePicker } from "@/sections/modals/AddPeoplePicker";
 import { ShareAccessRow } from "@/sections/modals/ShareAccessRow";
+import {
+  StaticPermissionLabel,
+  TransferTrailingButton,
+} from "@/sections/modals/ShareModalPermissionControls";
 import { SharePermissionMenu } from "@/sections/modals/SharePermissionMenu";
 import {
   PERMISSION_OPTIONS,
   SCOPE_OPTIONS,
 } from "@/sections/modals/shareAccessConstants";
+import {
+  applyStagedShares,
+  serializeDraftState,
+  type ShareDraftState as BaseShareDraftState,
+} from "@/sections/modals/shareDraftState";
 import {
   TransferOwnershipTarget,
   TransferOwnershipView,
@@ -55,12 +57,7 @@ import {
 
 type ShareModalView = "share" | "transfer";
 
-export interface ShareDraftState {
-  groupShares: PersonaGroupShare[];
-  isPublic: boolean;
-  publicPermission: PersonaSharePermission;
-  userShares: PersonaUserShare[];
-}
+export type ShareDraftState = BaseShareDraftState<PersonaSharePermission>;
 
 export interface ShareAgentModalProps {
   agentId?: number;
@@ -111,57 +108,6 @@ function buildInitialDraftState(
   };
 }
 
-function serializeDraftState(state: ShareDraftState): string {
-  const normalizedUsers = [...state.userShares]
-    .map((share) => ({ id: share.user.id, permission: share.permission }))
-    .sort((first, second) => first.id.localeCompare(second.id));
-  const normalizedGroups = [...state.groupShares]
-    .map((share) => ({ id: share.group_id, permission: share.permission }))
-    .sort((first, second) => first.id - second.id);
-
-  return JSON.stringify({
-    groupShares: normalizedGroups,
-    isPublic: state.isPublic,
-    publicPermission: state.publicPermission,
-    userShares: normalizedUsers,
-  });
-}
-
-function applyStagedShares(
-  draftState: ShareDraftState,
-  stagedUsers: MinimalUserSnapshot[],
-  stagedGroups: MinimalUserGroupSnapshot[],
-  stagedPermission: PersonaSharePermission
-): ShareDraftState {
-  const userShareMap = new Map(
-    draftState.userShares.map((share) => [share.user.id, share])
-  );
-  const groupShareMap = new Map(
-    draftState.groupShares.map((share) => [share.group_id, share])
-  );
-
-  stagedUsers.forEach((user) => {
-    userShareMap.set(user.id, {
-      permission: stagedPermission,
-      user,
-    });
-  });
-
-  stagedGroups.forEach((group) => {
-    groupShareMap.set(group.id, {
-      group_id: group.id,
-      group_name: group.name,
-      permission: stagedPermission,
-    });
-  });
-
-  return {
-    ...draftState,
-    groupShares: Array.from(groupShareMap.values()),
-    userShares: Array.from(userShareMap.values()),
-  };
-}
-
 async function refreshAgentShareCaches(agentId: number) {
   await Promise.all([
     mutate(SWR_KEYS.personas),
@@ -171,45 +117,6 @@ async function refreshAgentShareCaches(agentId: number) {
       (key) => typeof key === "string" && key.startsWith(SWR_KEYS.adminAgents)
     ),
   ]);
-}
-
-interface StaticPermissionLabelProps {
-  icon: IconFunctionComponent;
-  label: string;
-  muted?: boolean;
-}
-
-// Non-interactive permission display sitting in the row's permission column
-function StaticPermissionLabel({
-  icon,
-  label,
-  muted = false,
-}: StaticPermissionLabelProps) {
-  return (
-    <Content
-      color={muted ? "muted" : undefined}
-      icon={icon}
-      sizePreset="main-ui"
-      title={label}
-      variant="section"
-    />
-  );
-}
-
-interface TransferTrailingButtonProps {
-  onTransfer: () => void;
-}
-
-function TransferTrailingButton({ onTransfer }: TransferTrailingButtonProps) {
-  return (
-    <Button
-      icon={SvgArrowExchange}
-      onClick={onTransfer}
-      prominence="tertiary"
-      size="sm"
-      tooltip="Transfer Ownership"
-    />
-  );
 }
 
 export default function ShareAgentModal({

--- a/web/src/sections/modals/ShareModalPermissionControls.tsx
+++ b/web/src/sections/modals/ShareModalPermissionControls.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { Button } from "@opal/components";
+import { SvgArrowExchange } from "@opal/icons";
+import { Content } from "@opal/layouts";
+import type { IconFunctionComponent } from "@opal/types";
+
+export interface StaticPermissionLabelProps {
+  icon: IconFunctionComponent;
+  label: string;
+  muted?: boolean;
+}
+
+// Non-interactive permission display sitting in the row's permission column.
+export function StaticPermissionLabel({
+  icon,
+  label,
+  muted = false,
+}: StaticPermissionLabelProps) {
+  return (
+    <Content
+      color={muted ? "muted" : undefined}
+      icon={icon}
+      sizePreset="main-ui"
+      title={label}
+      variant="section"
+    />
+  );
+}
+
+export interface TransferTrailingButtonProps {
+  onTransfer: () => void;
+}
+
+export function TransferTrailingButton({
+  onTransfer,
+}: TransferTrailingButtonProps) {
+  return (
+    <Button
+      icon={SvgArrowExchange}
+      onClick={onTransfer}
+      prominence="tertiary"
+      size="sm"
+      tooltip="Transfer Ownership"
+    />
+  );
+}

--- a/web/src/sections/modals/shareAccessConstants.ts
+++ b/web/src/sections/modals/shareAccessConstants.ts
@@ -1,10 +1,10 @@
-import { PersonaSharePermission } from "@/lib/agents/types";
 import { SvgBubbleText, SvgEdit, SvgLock, SvgOrganization } from "@opal/icons";
 import { SharePermissionMenuOption } from "@/sections/modals/SharePermissionMenu";
 
 export type ShareScope = "PRIVATE" | "PUBLIC";
+export type ShareAccessPermission = "EDITOR" | "VIEWER";
 
-export const PERMISSION_OPTIONS: SharePermissionMenuOption<PersonaSharePermission>[] =
+export const PERMISSION_OPTIONS: SharePermissionMenuOption<ShareAccessPermission>[] =
   [
     {
       icon: SvgBubbleText,

--- a/web/src/sections/modals/shareDraftState.ts
+++ b/web/src/sections/modals/shareDraftState.ts
@@ -1,0 +1,77 @@
+import type { MinimalUserGroupSnapshot } from "@/hooks/useShareableGroups";
+import type { MinimalUserSnapshot } from "@/lib/types";
+import type { ShareAccessPermission } from "@/sections/modals/shareAccessConstants";
+
+export interface ShareDraftUserShare<
+  Permission extends ShareAccessPermission = ShareAccessPermission,
+> {
+  user: MinimalUserSnapshot;
+  permission: Permission;
+}
+
+export interface ShareDraftGroupShare<
+  Permission extends ShareAccessPermission = ShareAccessPermission,
+> {
+  group_id: number;
+  group_name: string;
+  permission: Permission;
+}
+
+export interface ShareDraftState<
+  Permission extends ShareAccessPermission = ShareAccessPermission,
+> {
+  groupShares: ShareDraftGroupShare<Permission>[];
+  isPublic: boolean;
+  publicPermission: Permission;
+  userShares: ShareDraftUserShare<Permission>[];
+}
+
+export function serializeDraftState<Permission extends ShareAccessPermission>(
+  state: ShareDraftState<Permission>
+): string {
+  const normalizedUsers = [...state.userShares]
+    .map((share) => ({ id: share.user.id, permission: share.permission }))
+    .sort((first, second) => first.id.localeCompare(second.id));
+  const normalizedGroups = [...state.groupShares]
+    .map((share) => ({ id: share.group_id, permission: share.permission }))
+    .sort((first, second) => first.id - second.id);
+
+  return JSON.stringify({
+    groupShares: normalizedGroups,
+    isPublic: state.isPublic,
+    publicPermission: state.publicPermission,
+    userShares: normalizedUsers,
+  });
+}
+
+export function applyStagedShares<Permission extends ShareAccessPermission>(
+  draftState: ShareDraftState<Permission>,
+  stagedUsers: MinimalUserSnapshot[],
+  stagedGroups: MinimalUserGroupSnapshot[],
+  stagedPermission: Permission
+): ShareDraftState<Permission> {
+  const userShareMap = new Map(
+    draftState.userShares.map((share) => [share.user.id, share])
+  );
+  const groupShareMap = new Map(
+    draftState.groupShares.map((share) => [share.group_id, share])
+  );
+
+  stagedUsers.forEach((user) => {
+    userShareMap.set(user.id, { permission: stagedPermission, user });
+  });
+
+  stagedGroups.forEach((group) => {
+    groupShareMap.set(group.id, {
+      group_id: group.id,
+      group_name: group.name,
+      permission: stagedPermission,
+    });
+  });
+
+  return {
+    ...draftState,
+    groupShares: Array.from(groupShareMap.values()),
+    userShares: Array.from(userShareMap.values()),
+  };
+}


### PR DESCRIPTION
## Description

Extracts reusable share-modal draft state helpers and permission display controls from the agent sharing modal. The agent modal behavior stays the same, while the shared utilities can be reused by later Craft skill sharing UI work without carrying agent-specific types.

## How Has This Been Tested?


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted reusable share-modal utilities for draft state and permission UI, keeping the agent share modal behavior unchanged and enabling reuse in upcoming Craft skill sharing.

- **Refactors**
  - Added `shareDraftState.ts` with generic `ShareDraftState`, `serializeDraftState`, and `applyStagedShares`.
  - Added `ShareModalPermissionControls.tsx` with `StaticPermissionLabel` and `TransferTrailingButton`.
  - Updated `ShareAgentModal.tsx` to use shared utilities and remove inline helpers.
  - Introduced `ShareAccessPermission` and updated `PERMISSION_OPTIONS`; adjusted `AddPeoplePicker` props to use it.

- **Migration**
  - Import utilities from `shareDraftState` and UI controls from `ShareModalPermissionControls` for new sharing UIs.
  - Use `ShareAccessPermission` with `PERMISSION_OPTIONS` in UI; convert to domain types (e.g., `PersonaSharePermission`) at service boundaries if needed.

<sup>Written for commit 6cb3624685fe39263f53b74f83a30dd6e8f02a2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

