### PR TITLE
ci(skills): trigger craft k8s tests for skill api changes

### DIFF
--- a/.github/workflows/pr-craft-k8s-tests.yml
+++ b/.github/workflows/pr-craft-k8s-tests.yml
@@ -103,6 +103,7 @@ jobs:
               - 'backend/Dockerfile'
               - 'backend/onyx/sandbox_proxy/**'
               - 'backend/onyx/server/features/build/**'
+              - 'backend/onyx/server/features/skill/**'
               - 'backend/onyx/skills/**'
               - 'backend/shared_configs/**'
               - 'deployment/helm/**'


### PR DESCRIPTION
## Description

Adds `backend/onyx/server/features/skill/**` to the Craft k8s test path filter so changes to the skills API trigger the same workflow as other Craft backend feature changes.

## How Has This Been Tested?


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update CI to trigger Craft k8s tests when files under `backend/onyx/server/features/skill/**` change. Ensures Skill API changes run the same workflow as other Craft backend features.

<sup>Written for commit 96002c2896b5e5bff8bb6e61a694cf38d47eea83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

