### PR TITLE
feat(craft): grant Slack external app files:write to upload files

### DIFF
--- a/backend/onyx/external_apps/providers/slack.py
+++ b/backend/onyx/external_apps/providers/slack.py
@@ -97,6 +97,9 @@ _ENDPOINTS: list[EndpointSpec] = [
             RestRoute(method="GET", path="/api/files.getUploadURLExternal"),
             RestRoute(method="POST", path="/api/files.getUploadURLExternal"),
             RestRoute(method="POST", path="/api/files.completeUploadExternal"),
+            # The raw bytes POST to a pre-signed /upload/v1/<token> URL on
+            # files.slack.com — route it to FILES_WRITE, not the domain fallback.
+            RestRoute(method="POST", path="/upload/v1/{token...}"),
         ),
     ),
 ]
@@ -134,7 +137,7 @@ class SlackProvider(OAuthExternalAppProvider, OnyxManagedExtApp):
                 "https://slack\\.com/api/.*",
                 # files.getUploadURLExternal hands back a pre-signed upload URL
                 # on the files.slack.com host that the raw bytes are POSTed to.
-                "https://files\\.slack\\.com/.*",
+                "https://files\\.slack\\.com/upload/v1/.*",
             ],
             auth_template={"Authorization": "Bearer {access_token}"},
             required_org_credential_fields=[

--- a/backend/onyx/external_apps/providers/slack.py
+++ b/backend/onyx/external_apps/providers/slack.py
@@ -26,6 +26,7 @@ class SlackAction(ExternalAppAction):
     SEARCH_READ = "slack.search.read"
     MESSAGES_WRITE = "slack.messages.write"
     DM_OPEN = "slack.dm.open"
+    FILES_WRITE = "slack.files.write"
 
 
 # Slack Web API calls are POST to https://slack.com/api/<method>; the action is
@@ -85,6 +86,19 @@ _ENDPOINTS: list[EndpointSpec] = [
         description="Open (or resume) a direct message conversation with a user.",
         matches=(RestRoute(method="POST", path="/api/conversations.open"),),
     ),
+    EndpointSpec(
+        id=SlackAction.FILES_WRITE,
+        normalised_name="Upload files",
+        description=(
+            "Upload a file and share it to a channel, direct message, or "
+            "thread using Slack's external upload flow."
+        ),
+        matches=(
+            RestRoute(method="GET", path="/api/files.getUploadURLExternal"),
+            RestRoute(method="POST", path="/api/files.getUploadURLExternal"),
+            RestRoute(method="POST", path="/api/files.completeUploadExternal"),
+        ),
+    ),
 ]
 
 
@@ -100,6 +114,7 @@ class SlackProvider(OAuthExternalAppProvider, OnyxManagedExtApp):
                     "channels:history",
                     "channels:read",
                     "chat:write",
+                    "files:write",
                     "groups:history",
                     "groups:read",
                     "im:history",
@@ -115,7 +130,12 @@ class SlackProvider(OAuthExternalAppProvider, OnyxManagedExtApp):
             description=(
                 "Read your Slack messages and channels as context inside Onyx Craft."
             ),
-            upstream_url_patterns=["https://slack\\.com/api/.*"],
+            upstream_url_patterns=[
+                "https://slack\\.com/api/.*",
+                # files.getUploadURLExternal hands back a pre-signed upload URL
+                # on the files.slack.com host that the raw bytes are POSTed to.
+                "https://files\\.slack\\.com/.*",
+            ],
             auth_template={"Authorization": "Bearer {access_token}"},
             required_org_credential_fields=[
                 OrgCredentialField(
@@ -141,8 +161,9 @@ class SlackProvider(OAuthExternalAppProvider, OnyxManagedExtApp):
                 "Permissions, add this Onyx instance's callback URL "
                 "(/craft/v1/apps/oauth/callback) to Redirect URLs, and add the "
                 "User Token Scopes you want the agent to use (channels:history, "
-                "channels:read, chat:write, groups:history, groups:read, "
-                "im:history, im:read, im:write, search:read, users:read). No "
+                "channels:read, chat:write, files:write, groups:history, "
+                "groups:read, im:history, im:read, im:write, search:read, "
+                "users:read). No "
                 "bot user is required. Then paste the app's Client ID and "
                 "Client Secret below."
             ),

--- a/backend/onyx/skills/builtin/slack/SKILL.md.template
+++ b/backend/onyx/skills/builtin/slack/SKILL.md.template
@@ -1,6 +1,6 @@
 ---
 name: slack
-description: Read, search, and post Slack messages on the connected user's behalf via the Slack Web API.
+description: Read, search, post, and upload files to Slack on the connected user's behalf via the Slack Web API.
 ---
 
 # Slack
@@ -58,6 +58,16 @@ python slack_api.py search "deploy failed" [--count N]
 ```
 python slack_api.py post C0123456789 "Hello from Onyx"
 ```
+
+### Upload a file (write)
+
+```
+python slack_api.py upload C0123456789 ./chart.png --comment "Latest chart" --title "Chart"
+```
+
+Shares a local file into the channel/DM (add `--thread-ts` to reply in a
+thread) via Slack's external upload flow (`files.getUploadURLExternal` ->
+upload -> `files.completeUploadExternal`).
 
 ## Output
 

--- a/backend/onyx/skills/builtin/slack/slack_api.py
+++ b/backend/onyx/skills/builtin/slack/slack_api.py
@@ -20,6 +20,7 @@ _METHOD_RE = re.compile(r"^[a-z][a-zA-Z0-9._]*$")
 _PAGE_SIZE = 200
 _DEFAULT_LIMIT = 200
 _HTTP_TIMEOUT_SECONDS = 180
+_MAX_UPLOAD_BYTES = 500 * 1024 * 1024  # Slack's own upload limit
 
 
 def _prune(value: Any) -> Any:
@@ -180,6 +181,8 @@ def _upload_file(
         return {"ok": False, "error": "file_not_found"}
     filename = os.path.basename(file_path)
     length = os.path.getsize(file_path)
+    if length > _MAX_UPLOAD_BYTES:
+        return {"ok": False, "error": "file_too_large"}
     reserved = _call(
         "files.getUploadURLExternal", {"filename": filename, "length": length}
     )
@@ -189,6 +192,9 @@ def _upload_file(
     file_id = reserved.get("file_id")
     if not upload_url or not file_id:
         return {"ok": False, "error": "missing_upload_url"}
+    parsed_url = urllib.parse.urlparse(upload_url)
+    if parsed_url.scheme != "https" or parsed_url.hostname != "files.slack.com":
+        return {"ok": False, "error": "untrusted_upload_url"}
     with open(file_path, "rb") as fh:
         content = fh.read()
     put = urllib.request.Request(  # noqa: S310 — Slack-issued upload URL
@@ -245,9 +251,7 @@ def _dispatch(a: argparse.Namespace) -> dict[str, Any]:
         return _call("chat.postMessage", {"channel": a.channel, "text": a.text})
 
     if a.cmd == "upload":
-        return _upload_file(
-            a.channel, a.file_path, a.title, a.comment, a.thread_ts
-        )
+        return _upload_file(a.channel, a.file_path, a.title, a.comment, a.thread_ts)
 
     # `call` is the only remaining subcommand (subparser is required).
     return _raw_call(a.method, a.json_args, a.as_json)

--- a/backend/onyx/skills/builtin/slack/slack_api.py
+++ b/backend/onyx/skills/builtin/slack/slack_api.py
@@ -7,6 +7,7 @@ Slack signals failure with {"ok": false, "error": "..."} (still HTTP 200).
 
 import argparse
 import json
+import os
 import re
 import sys
 import urllib.error
@@ -132,6 +133,13 @@ def _build_parser() -> argparse.ArgumentParser:
     sp.add_argument("channel")
     sp.add_argument("text")
 
+    sp = sub.add_parser("upload", help="upload a file and share it (write)")
+    sp.add_argument("channel")
+    sp.add_argument("file_path")
+    sp.add_argument("--title", help="file title shown in Slack")
+    sp.add_argument("--comment", help="message text posted with the file")
+    sp.add_argument("--thread-ts", dest="thread_ts", help="reply in this thread")
+
     sp = sub.add_parser("call", help="raw Slack method")
     sp.add_argument("method")
     sp.add_argument("json_args", nargs="?")
@@ -156,6 +164,50 @@ def _raw_call(method: str, json_args: str | None, as_json: bool) -> dict[str, An
             return {"ok": False, "error": "json_args_not_object"}
         args = parsed
     return _call(method, args, as_json=as_json)
+
+
+def _upload_file(
+    channel: str,
+    file_path: str,
+    title: str | None,
+    comment: str | None,
+    thread_ts: str | None,
+) -> dict[str, Any]:
+    """Share a local file using Slack's external upload flow:
+    files.getUploadURLExternal -> POST bytes to the returned URL ->
+    files.completeUploadExternal (which posts it to the channel/thread)."""
+    if not os.path.isfile(file_path):
+        return {"ok": False, "error": "file_not_found"}
+    filename = os.path.basename(file_path)
+    length = os.path.getsize(file_path)
+    reserved = _call(
+        "files.getUploadURLExternal", {"filename": filename, "length": length}
+    )
+    if not reserved.get("ok"):
+        return reserved
+    upload_url = reserved.get("upload_url")
+    file_id = reserved.get("file_id")
+    if not upload_url or not file_id:
+        return {"ok": False, "error": "missing_upload_url"}
+    with open(file_path, "rb") as fh:
+        content = fh.read()
+    put = urllib.request.Request(  # noqa: S310 — Slack-issued upload URL
+        upload_url,
+        data=content,
+        method="POST",
+        headers={"Content-Type": "application/octet-stream"},
+    )
+    with urllib.request.urlopen(put, timeout=_HTTP_TIMEOUT_SECONDS):  # noqa: S310
+        pass
+    file_entry: dict[str, Any] = {"id": file_id}
+    if title:
+        file_entry["title"] = title
+    complete: dict[str, Any] = {"files": [file_entry], "channel_id": channel}
+    if comment:
+        complete["initial_comment"] = comment
+    if thread_ts:
+        complete["thread_ts"] = thread_ts
+    return _call("files.completeUploadExternal", complete)
 
 
 def _dispatch(a: argparse.Namespace) -> dict[str, Any]:
@@ -191,6 +243,11 @@ def _dispatch(a: argparse.Namespace) -> dict[str, Any]:
 
     if a.cmd == "post":
         return _call("chat.postMessage", {"channel": a.channel, "text": a.text})
+
+    if a.cmd == "upload":
+        return _upload_file(
+            a.channel, a.file_path, a.title, a.comment, a.thread_ts
+        )
 
     # `call` is the only remaining subcommand (subparser is required).
     return _raw_call(a.method, a.json_args, a.as_json)

--- a/backend/tests/unit/external_apps/test_slack_catalog.py
+++ b/backend/tests/unit/external_apps/test_slack_catalog.py
@@ -44,6 +44,9 @@ def _matching_actions(method: str, path: str) -> set[str]:
         ("GET", "/api/files.getUploadURLExternal", {SlackAction.FILES_WRITE}),
         ("POST", "/api/files.getUploadURLExternal", {SlackAction.FILES_WRITE}),
         ("POST", "/api/files.completeUploadExternal", {SlackAction.FILES_WRITE}),
+        # The raw-bytes POST to the pre-signed files.slack.com upload URL must
+        # fall under FILES_WRITE, not the whole-domain "Perform action" fallback.
+        ("POST", "/upload/v1/CwABgAB123", {SlackAction.FILES_WRITE}),
     ],
 )
 def test_rest_route_resolves_to_exactly_one_action(
@@ -64,9 +67,7 @@ def test_rest_route_resolves_to_exactly_one_action(
         (SlackAction.FILES_WRITE, EndpointPolicy.ASK),
     ],
 )
-def test_default_policies(
-    action: SlackAction, expected_policy: EndpointPolicy
-) -> None:
+def test_default_policies(action: SlackAction, expected_policy: EndpointPolicy) -> None:
     by_id = {endpoint.id: endpoint for endpoint in _CATALOG}
     assert by_id[action].default_policy == expected_policy
 
@@ -75,5 +76,6 @@ def test_files_write_scope_and_upstream_pattern() -> None:
     spec = SlackProvider.spec
     assert "files:write" in spec.oauth.scope.split(",")
     assert (
-        "https://files\\.slack\\.com/.*" in spec.descriptor.upstream_url_patterns
+        "https://files\\.slack\\.com/upload/v1/.*"
+        in spec.descriptor.upstream_url_patterns
     )

--- a/backend/tests/unit/external_apps/test_slack_catalog.py
+++ b/backend/tests/unit/external_apps/test_slack_catalog.py
@@ -1,0 +1,79 @@
+"""The Slack provider catalog: REST routes resolve to exactly the intended
+action, and default policies match the design (reads auto-approve; message and
+file writes require approval).
+
+Exercises the pure rule layer directly, mirroring ``test_github_catalog``."""
+
+from __future__ import annotations
+
+import pytest
+
+from onyx.db.enums import EndpointPolicy
+from onyx.db.enums import ExternalAppType
+from onyx.external_apps.matching.request import MatchContext
+from onyx.external_apps.matching.request import ProxiedRequest
+from onyx.external_apps.matching.rules import rule_matches
+from onyx.external_apps.providers.registry import get_endpoint_catalog
+from onyx.external_apps.providers.slack import SlackAction
+from onyx.external_apps.providers.slack import SlackProvider
+
+_CATALOG = get_endpoint_catalog(ExternalAppType.SLACK)
+
+
+def _matching_actions(method: str, path: str) -> set[str]:
+    context = MatchContext(ProxiedRequest(method=method, path=path, body=None))
+    return {
+        endpoint.id
+        for endpoint in _CATALOG
+        if any(rule_matches(rule, context) for rule in endpoint.matches)
+    }
+
+
+@pytest.mark.parametrize(
+    "method, path, expected",
+    [
+        ("POST", "/api/conversations.list", {SlackAction.CHANNELS_READ}),
+        ("POST", "/api/conversations.info", {SlackAction.CHANNELS_READ}),
+        ("POST", "/api/conversations.history", {SlackAction.MESSAGES_READ}),
+        ("POST", "/api/conversations.replies", {SlackAction.MESSAGES_READ}),
+        ("POST", "/api/users.list", {SlackAction.USERS_READ}),
+        ("POST", "/api/users.info", {SlackAction.USERS_READ}),
+        ("POST", "/api/search.messages", {SlackAction.SEARCH_READ}),
+        ("POST", "/api/chat.postMessage", {SlackAction.MESSAGES_WRITE}),
+        ("POST", "/api/conversations.open", {SlackAction.DM_OPEN}),
+        ("GET", "/api/files.getUploadURLExternal", {SlackAction.FILES_WRITE}),
+        ("POST", "/api/files.getUploadURLExternal", {SlackAction.FILES_WRITE}),
+        ("POST", "/api/files.completeUploadExternal", {SlackAction.FILES_WRITE}),
+    ],
+)
+def test_rest_route_resolves_to_exactly_one_action(
+    method: str, path: str, expected: set[str]
+) -> None:
+    assert _matching_actions(method, path) == expected
+
+
+@pytest.mark.parametrize(
+    "action, expected_policy",
+    [
+        (SlackAction.CHANNELS_READ, EndpointPolicy.ALWAYS),
+        (SlackAction.MESSAGES_READ, EndpointPolicy.ALWAYS),
+        (SlackAction.USERS_READ, EndpointPolicy.ALWAYS),
+        (SlackAction.SEARCH_READ, EndpointPolicy.ALWAYS),
+        (SlackAction.MESSAGES_WRITE, EndpointPolicy.ASK),
+        (SlackAction.DM_OPEN, EndpointPolicy.ASK),
+        (SlackAction.FILES_WRITE, EndpointPolicy.ASK),
+    ],
+)
+def test_default_policies(
+    action: SlackAction, expected_policy: EndpointPolicy
+) -> None:
+    by_id = {endpoint.id: endpoint for endpoint in _CATALOG}
+    assert by_id[action].default_policy == expected_policy
+
+
+def test_files_write_scope_and_upstream_pattern() -> None:
+    spec = SlackProvider.spec
+    assert "files:write" in spec.oauth.scope.split(",")
+    assert (
+        "https://files\\.slack\\.com/.*" in spec.descriptor.upstream_url_patterns
+    )


### PR DESCRIPTION
## Summary

Grants the Craft Slack external app the `files:write` scope so agents can upload and share generated files (images, PDFs, charts) directly into Slack messages/threads, instead of degrading to text-only.

## Changes
- Add `files:write` to the Slack provider's requested user scopes and to the admin setup instructions.
- Add a `FILES_WRITE` catalog action covering `files.getUploadURLExternal` (GET/POST) and `files.completeUploadExternal` (defaults to ASK, like other writes).
- Allow the `files.slack.com` upload host in the egress upstream URL patterns (the external upload flow POSTs the raw bytes to a pre-signed URL on that host).
- Add an `upload` command to the bundled Slack helper (`slack_api.py`) implementing `files.getUploadURLExternal` -> upload -> `files.completeUploadExternal`, and document it in the skill template.
- Add `test_slack_catalog.py` covering route resolution and default policies.

## Testing
- `py_compile` on all changed Python files.
- Verified the new `files.*` REST routes resolve to `FILES_WRITE` (and unrelated routes do not) via the pure matcher, and that its default policy is ASK.
- Exercised the `slack_api.py upload` flow end-to-end with mocked Slack calls.

Fixes ENG-4267

Linear: https://linear.app/onyx-app/issue/ENG-4267/slack-external-app-grant-fileswrite-so-it-can-upload-files-to-its

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Slack file uploads by granting the Craft Slack external app the `files:write` scope and implementing Slack’s external upload flow. Agents can share images, PDFs, and charts in messages and threads. Addresses Linear ENG-4267.

- New Features
  - Added `files:write` to requested user scopes and setup docs.
  - Introduced `FILES_WRITE` action for `files.getUploadURLExternal` (GET/POST), `files.completeUploadExternal` (POST), and presigned uploads at `/upload/v1/...` (default policy ASK).
  - Allowed `https://files.slack.com/upload/v1/.*` in upstream URL patterns for presigned uploads.
  - Added an `upload` command to the Slack helper to run the external upload flow; documented in the skill template.
  - Added unit tests for route resolution (incl. `/upload/v1`), default policies, and scope/pattern checks.

- Migration
  - Slack admins: add `files:write` to the app’s User Token Scopes.

<sup>Written for commit acb2d7af3aef5de17fd4c0e38b229ecf0ee37593. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

