### PR TITLE
Openrouter as an image generation provider

### DIFF
--- a/backend/onyx/image_gen/factory.py
+++ b/backend/onyx/image_gen/factory.py
@@ -4,18 +4,21 @@ from onyx.image_gen.interfaces import ImageGenerationProvider
 from onyx.image_gen.interfaces import ImageGenerationProviderCredentials
 from onyx.image_gen.providers.azure_img_gen import AzureImageGenerationProvider
 from onyx.image_gen.providers.openai_img_gen import OpenAIImageGenerationProvider
+from onyx.image_gen.providers.openrouter_img_gen import OpenRouterImageGenerationProvider
 from onyx.image_gen.providers.vertex_img_gen import VertexImageGenerationProvider
 
 
 class ImageGenerationProviderName(str, Enum):
     AZURE = "azure"
     OPENAI = "openai"
+    OPENROUTER = "openrouter"
     VERTEX_AI = "vertex_ai"
 
 
 PROVIDERS: dict[ImageGenerationProviderName, type[ImageGenerationProvider]] = {
     ImageGenerationProviderName.AZURE: AzureImageGenerationProvider,
     ImageGenerationProviderName.OPENAI: OpenAIImageGenerationProvider,
+    ImageGenerationProviderName.OPENROUTER: OpenRouterImageGenerationProvider,
     ImageGenerationProviderName.VERTEX_AI: VertexImageGenerationProvider,
 }
 

--- a/backend/onyx/image_gen/providers/openrouter_img_gen.py
+++ b/backend/onyx/image_gen/providers/openrouter_img_gen.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import base64
+from datetime import datetime
+from typing import Any
+from typing import TYPE_CHECKING
+
+import requests
+
+from onyx.image_gen.interfaces import ImageGenerationProvider
+from onyx.image_gen.interfaces import ImageGenerationProviderCredentials
+from onyx.image_gen.interfaces import ReferenceImage
+from onyx.tracing.flows import LLMFlow
+from onyx.tracing.llm_utils import traced_llm_call
+
+if TYPE_CHECKING:
+    from onyx.image_gen.interfaces import ImageGenerationResponse
+
+
+OPENROUTER_DEFAULT_API_BASE = "https://openrouter.ai/api/v1"
+
+
+class OpenRouterImageGenerationProvider(ImageGenerationProvider):
+    def __init__(
+        self,
+        api_key: str,
+        api_base: str | None = None,
+    ) -> None:
+        self._api_key = api_key
+        self._api_base = (api_base or OPENROUTER_DEFAULT_API_BASE).rstrip("/")
+
+    @classmethod
+    def validate_credentials(
+        cls,
+        credentials: ImageGenerationProviderCredentials,
+    ) -> bool:
+        return bool(credentials.api_key)
+
+    @classmethod
+    def _build_from_credentials(
+        cls,
+        credentials: ImageGenerationProviderCredentials,
+    ) -> OpenRouterImageGenerationProvider:
+        assert credentials.api_key
+        return cls(api_key=credentials.api_key, api_base=credentials.api_base)
+
+    @property
+    def supports_reference_images(self) -> bool:
+        return True
+
+    @property
+    def max_reference_images(self) -> int:
+        return 10
+
+    def generate_image(
+        self,
+        prompt: str,
+        model: str,
+        size: str,
+        n: int,
+        quality: str | None = None,
+        reference_images: list[ReferenceImage] | None = None,
+        **kwargs: Any,
+    ) -> ImageGenerationResponse:
+        from litellm.types.utils import ImageObject
+        from litellm.types.utils import ImageResponse
+
+        payload: dict[str, Any] = {
+            "model": model,
+            "prompt": prompt,
+            "size": size,
+            "n": n,
+        }
+        if quality:
+            payload["quality"] = quality
+        if reference_images:
+            payload["input_references"] = [
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": _reference_image_to_data_url(reference_image),
+                    },
+                }
+                for reference_image in reference_images
+            ]
+
+        for key, value in kwargs.items():
+            if value is not None and key != "response_format":
+                payload[key] = value
+
+        with traced_llm_call(
+            flow=LLMFlow.IMAGE_EDIT if reference_images else LLMFlow.IMAGE_GENERATION,
+            model=model,
+            provider="openrouter",
+            input_messages=[{"role": "user", "content": prompt}],
+        ):
+            response = requests.post(
+                f"{self._api_base}/images",
+                headers={
+                    "Authorization": f"Bearer {self._api_key}",
+                    "Content-Type": "application/json",
+                },
+                json=payload,
+                timeout=300,
+            )
+            response.raise_for_status()
+
+        result = response.json()
+        generated_data = [
+            ImageObject(
+                b64_json=item["b64_json"],
+                revised_prompt=item.get("revised_prompt") or prompt,
+            )
+            for item in result.get("data", [])
+            if item.get("b64_json")
+        ]
+        if not generated_data:
+            raise RuntimeError("No image data returned from OpenRouter.")
+
+        return ImageResponse(
+            created=result.get("created") or int(datetime.now().timestamp()),
+            data=generated_data,
+        )
+
+
+def _reference_image_to_data_url(reference_image: ReferenceImage) -> str:
+    encoded = base64.b64encode(reference_image.data).decode("utf-8")
+    return f"data:{reference_image.mime_type};base64,{encoded}"

--- a/backend/tests/unit/onyx/image_gen/test_provider_building.py
+++ b/backend/tests/unit/onyx/image_gen/test_provider_building.py
@@ -1,4 +1,5 @@
 import json
+from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pytest
@@ -305,3 +306,62 @@ def test_azure_provider_rejects_reference_images_for_unsupported_model() -> None
             n=1,
             reference_images=[ReferenceImage(data=b"image-1", mime_type="image/png")],
         )
+
+
+def test_build_openrouter_provider_from_api_key_and_base() -> None:
+    from onyx.image_gen.providers.openrouter_img_gen import (
+        OpenRouterImageGenerationProvider,
+    )
+
+    credentials = _get_default_image_gen_creds()
+    credentials.api_key = "test-key"
+    credentials.api_base = "https://example.openrouter.ai/api/v1"
+
+    image_gen_provider = get_image_generation_provider("openrouter", credentials)
+
+    assert isinstance(image_gen_provider, OpenRouterImageGenerationProvider)
+    assert image_gen_provider._api_key == "test-key"
+    assert image_gen_provider._api_base == "https://example.openrouter.ai/api/v1"
+    assert image_gen_provider.supports_reference_images is True
+    assert image_gen_provider.max_reference_images == 10
+
+
+def test_build_openrouter_provider_fails_no_api_key() -> None:
+    credentials = _get_default_image_gen_creds()
+
+    with pytest.raises(ImageProviderCredentialsError):
+        get_image_generation_provider("openrouter", credentials)
+
+
+def test_openrouter_provider_posts_image_generation_request() -> None:
+    from onyx.image_gen.providers.openrouter_img_gen import (
+        OpenRouterImageGenerationProvider,
+    )
+
+    provider = OpenRouterImageGenerationProvider(api_key="test-key")
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "created": 123,
+        "data": [{"b64_json": "aGVsbG8="}],
+    }
+
+    with patch("requests.post", return_value=mock_response) as mock_post:
+        response = provider.generate_image(
+            prompt="draw a mountain",
+            model="bytedance-seed/seedream-4.5",
+            size="1024x1024",
+            n=1,
+            quality="high",
+        )
+
+    assert response.data[0].b64_json == "aGVsbG8="
+    mock_response.raise_for_status.assert_called_once()
+    mock_post.assert_called_once()
+    assert mock_post.call_args.args[0] == "https://openrouter.ai/api/v1/images"
+    assert mock_post.call_args.kwargs["json"] == {
+        "model": "bytedance-seed/seedream-4.5",
+        "prompt": "draw a mountain",
+        "size": "1024x1024",
+        "n": 1,
+        "quality": "high",
+    }

--- a/web/src/views/admin/ImageGenerationPage/ImageGenerationContent.tsx
+++ b/web/src/views/admin/ImageGenerationPage/ImageGenerationContent.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useMemo, useEffect } from "react";
-import useSWR from "swr";
+import useSWR, { useSWRConfig } from "swr";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import { useCreateModal } from "@/refresh-components/contexts/ModalContext";
 import { toast } from "@/hooks/useToast";
@@ -34,6 +34,7 @@ import { getModelIcon } from "@/lib/languageModels";
 const NO_DEFAULT_VALUE = "__none__";
 
 export default function ImageGenerationContent() {
+  const { mutate } = useSWRConfig();
   const {
     data: llmProviderResponse,
     error: llmError,
@@ -98,6 +99,7 @@ export default function ImageGenerationContent() {
         await setDefaultImageGenerationConfig(config.image_provider_id);
         toast.success(`${provider.title} set as default`);
         refetchConfigs();
+        mutate(SWR_KEYS.tools);
       } catch (error) {
         toast.error(
           error instanceof Error ? error.message : "Failed to set default"
@@ -115,6 +117,7 @@ export default function ImageGenerationContent() {
         await unsetDefaultImageGenerationConfig(config.image_provider_id);
         toast.success(`${provider.title} deselected`);
         refetchConfigs();
+        mutate(SWR_KEYS.tools);
       } catch (error) {
         toast.error(
           error instanceof Error ? error.message : "Failed to deselect"
@@ -144,6 +147,7 @@ export default function ImageGenerationContent() {
       toast.success(`${disconnectProvider.title} disconnected`);
       refetchConfigs();
       refetchProviders();
+      mutate(SWR_KEYS.tools);
     } catch (error) {
       console.error("Failed to disconnect image generation provider:", error);
       toast.error(
@@ -160,6 +164,7 @@ export default function ImageGenerationContent() {
     setEditConfig(null);
     refetchConfigs();
     refetchProviders();
+    mutate(SWR_KEYS.tools);
   };
 
   if (llmError || configError) {

--- a/web/src/views/admin/ImageGenerationPage/constants.ts
+++ b/web/src/views/admin/ImageGenerationPage/constants.ts
@@ -70,6 +70,19 @@ export const IMAGE_PROVIDER_GROUPS: ProviderGroup[] = [
     ],
   },
   {
+    name: "OpenRouter",
+    providers: [
+      {
+        image_provider_id: "openrouter_image",
+        model_name: "google/gemini-3.1-flash-image",
+        provider_name: "openrouter",
+        title: "OpenRouter Image Model",
+        description:
+          "Generate images through OpenRouter using any supported image model slug.",
+      },
+    ],
+  },
+  {
     name: "Google Cloud Vertex AI",
     providers: [
       {

--- a/web/src/views/admin/ImageGenerationPage/forms/OpenRouterImageGenForm.tsx
+++ b/web/src/views/admin/ImageGenerationPage/forms/OpenRouterImageGenForm.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import * as Yup from "yup";
+import { FormikField } from "@/refresh-components/form/FormikField";
+import { FormField } from "@/refresh-components/form/FormField";
+import { InputTypeIn } from "@opal/components";
+import InputComboBox from "@/refresh-components/inputs/InputComboBox";
+import PasswordInputTypeIn from "@/refresh-components/inputs/PasswordInputTypeIn";
+import { ImageGenFormWrapper } from "@/views/admin/ImageGenerationPage/forms/ImageGenFormWrapper";
+import {
+  ImageGenFormBaseProps,
+  ImageGenFormChildProps,
+  ImageGenSubmitPayload,
+} from "@/views/admin/ImageGenerationPage/forms/types";
+import { ImageGenerationCredentials } from "@/views/admin/ImageGenerationPage/svc";
+import { ImageProvider } from "@/views/admin/ImageGenerationPage/constants";
+
+const OPENROUTER_PROVIDER_NAME = "openrouter";
+const DEFAULT_OPENROUTER_MODEL = "bytedance-seed/seedream-4.5";
+
+interface OpenRouterFormValues {
+  model_name: string;
+  api_key: string;
+}
+
+const initialValues: OpenRouterFormValues = {
+  model_name: DEFAULT_OPENROUTER_MODEL,
+  api_key: "",
+};
+
+const validationSchema = Yup.object().shape({
+  model_name: Yup.string().required("Model slug is required"),
+  api_key: Yup.string().required("API Key is required"),
+});
+
+function getInitialValuesFromCredentials(
+  credentials: ImageGenerationCredentials,
+  _imageProvider: ImageProvider
+): Partial<OpenRouterFormValues> {
+  return {
+    api_key: credentials.api_key || "",
+  };
+}
+
+function transformValues(
+  values: OpenRouterFormValues,
+  imageProvider: ImageProvider
+): ImageGenSubmitPayload {
+  return {
+    modelName: values.model_name.trim(),
+    imageProviderId: imageProvider.image_provider_id,
+    provider: OPENROUTER_PROVIDER_NAME,
+    apiKey: values.api_key,
+  };
+}
+
+function OpenRouterFormFields(
+  props: ImageGenFormChildProps<OpenRouterFormValues>
+) {
+  const {
+    apiStatus,
+    showApiMessage,
+    errorMessage,
+    disabled,
+    isLoadingCredentials,
+    apiKeyOptions,
+    resetApiState,
+    imageProvider,
+  } = props;
+
+  return (
+    <>
+      <FormikField<string>
+        name="model_name"
+        render={(field, helper, meta, state) => (
+          <FormField name="model_name" state={state} className="w-full">
+            <FormField.Label>Model Slug</FormField.Label>
+            <FormField.Control>
+              <InputTypeIn
+                value={field.value}
+                onChange={(e) => {
+                  helper.setValue(e.target.value);
+                  resetApiState();
+                }}
+                onBlur={field.onBlur}
+                placeholder="bytedance-seed/seedream-4.5"
+                variant={disabled ? "disabled" : undefined}
+              />
+            </FormField.Control>
+            <FormField.Message
+              messages={{
+                idle: "Enter any OpenRouter image model slug from the image models page.",
+                error: meta.error,
+              }}
+            />
+          </FormField>
+        )}
+      />
+      <FormikField<string>
+        name="api_key"
+        render={(field, helper, meta, state) => (
+          <FormField
+            name="api_key"
+            state={apiStatus === "error" ? "error" : state}
+            className="w-full"
+          >
+            <FormField.Label>API Key</FormField.Label>
+            <FormField.Control>
+              {apiKeyOptions.length > 0 ? (
+                <InputComboBox
+                  value={field.value}
+                  onChange={(e) => {
+                    helper.setValue(e.target.value);
+                    resetApiState();
+                  }}
+                  onValueChange={(value) => {
+                    helper.setValue(value);
+                    resetApiState();
+                  }}
+                  onBlur={field.onBlur}
+                  options={apiKeyOptions}
+                  placeholder={
+                    isLoadingCredentials
+                      ? "Loading..."
+                      : "Enter new API key or select existing provider"
+                  }
+                  disabled={disabled}
+                  isError={apiStatus === "error"}
+                />
+              ) : (
+                <PasswordInputTypeIn
+                  {...field}
+                  onChange={(e) => {
+                    field.onChange(e);
+                    resetApiState();
+                  }}
+                  placeholder={
+                    isLoadingCredentials ? "Loading..." : "Enter your API key"
+                  }
+                  disabled={disabled}
+                  error={apiStatus === "error"}
+                />
+              )}
+            </FormField.Control>
+            {showApiMessage ? (
+              <FormField.APIMessage
+                state={apiStatus}
+                messages={{
+                  loading: `Testing API key with ${imageProvider.title}...`,
+                  success: "API key is valid. Configuration saved.",
+                  error: errorMessage || "Invalid API key",
+                }}
+              />
+            ) : (
+              <FormField.Message
+                messages={{
+                  idle: "Enter a new API key or select an existing OpenRouter provider.",
+                  error: meta.error,
+                }}
+              />
+            )}
+          </FormField>
+        )}
+      />
+    </>
+  );
+}
+
+export function OpenRouterImageGenForm(props: ImageGenFormBaseProps) {
+  const { imageProvider, existingConfig } = props;
+  const modelName =
+    existingConfig?.model_name || imageProvider.model_name || DEFAULT_OPENROUTER_MODEL;
+
+  return (
+    <ImageGenFormWrapper<OpenRouterFormValues>
+      {...props}
+      title={
+        existingConfig
+          ? `Edit ${imageProvider.title}`
+          : `Connect ${imageProvider.title}`
+      }
+      description={imageProvider.description}
+      initialValues={{
+        ...initialValues,
+        model_name: modelName,
+      }}
+      validationSchema={validationSchema}
+      getInitialValuesFromCredentials={getInitialValuesFromCredentials}
+      transformValues={(values) => transformValues(values, imageProvider)}
+    >
+      {(childProps) => <OpenRouterFormFields {...childProps} />}
+    </ImageGenFormWrapper>
+  );
+}

--- a/web/src/views/admin/ImageGenerationPage/forms/getImageGenForm.tsx
+++ b/web/src/views/admin/ImageGenerationPage/forms/getImageGenForm.tsx
@@ -3,6 +3,7 @@ import { ImageGenFormBaseProps } from "@/views/admin/ImageGenerationPage/forms/t
 import { OpenAIImageGenForm } from "@/views/admin/ImageGenerationPage/forms/OpenAIImageGenForm";
 import { AzureImageGenForm } from "@/views/admin/ImageGenerationPage/forms/AzureImageGenForm";
 import { VertexImageGenForm } from "@/views/admin/ImageGenerationPage/forms/VertexImageGenForm";
+import { OpenRouterImageGenForm } from "@/views/admin/ImageGenerationPage/forms/OpenRouterImageGenForm";
 
 /**
  * Factory function that routes to the correct provider-specific form
@@ -18,6 +19,8 @@ export function getImageGenForm(props: ImageGenFormBaseProps): React.ReactNode {
       return <AzureImageGenForm {...props} />;
     case "vertex_ai":
       return <VertexImageGenForm {...props} />;
+    case "openrouter":
+      return <OpenRouterImageGenForm {...props} />;
     default:
       // Fallback to OpenAI form for unknown providers
       console.warn(

--- a/web/src/views/admin/ImageGenerationPage/forms/index.ts
+++ b/web/src/views/admin/ImageGenerationPage/forms/index.ts
@@ -3,3 +3,4 @@ export { ImageGenFormWrapper } from "@/views/admin/ImageGenerationPage/forms/Ima
 export { OpenAIImageGenForm } from "@/views/admin/ImageGenerationPage/forms/OpenAIImageGenForm";
 export { AzureImageGenForm } from "@/views/admin/ImageGenerationPage/forms/AzureImageGenForm";
 export { getImageGenForm } from "@/views/admin/ImageGenerationPage/forms/getImageGenForm";
+export { OpenRouterImageGenForm } from "@/views/admin/ImageGenerationPage/forms/OpenRouterImageGenForm";


### PR DESCRIPTION
## Description

Adds OpenRouter support as an image generation provider.

This PR includes:
- Backend provider implementation for OpenRouter image generation via `/images`
- Registration of `openrouter` in the image generation provider factory
- Support for OpenRouter API key validation, custom API base, model slug configuration, and reference images
- Admin UI option for configuring OpenRouter image models
- OpenRouter-specific image generation form with model slug and API key fields
- SWR cache invalidation for tools after image generation provider changes, so default/disconnect/config updates are reflected correctly

## How Has This Been Tested?

Added unit coverage for:
- Building the OpenRouter provider from credentials
- Rejecting OpenRouter configuration without an API key
- Posting an OpenRouter image generation request with the expected payload

Tests were added in `backend/tests/unit/onyx/image_gen/test_provider_building.py`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add OpenRouter as an image generation provider with admin UI support and reference images. Also refresh the tools cache after provider changes so the UI stays in sync.

- **New Features**
  - Backend: added `openrouter` provider (`OpenRouterImageGenerationProvider`) using `/images`, API key validation, optional `api_base`, and up to 10 reference images.
  - Admin: new OpenRouter option and form (model slug + API key), integrated into the form factory; default model `bytedance-seed/seedream-4.5`.
  - Tests: covered provider build from credentials, rejection without API key, and request payload.

- **Bug Fixes**
  - Invalidate `SWR_KEYS.tools` after setting/unsetting default, disconnecting, or updating image provider config to prevent stale tool state.

<sup>Written for commit f903031b7658708ab6cbb24f94c0a61e4dc4093c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

