### PR TITLE
feat(reindex): run port jobs on the docprocessing worker

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -357,7 +357,7 @@
         "--loglevel=INFO",
         "--hostname=light@%n",
         "-Q",
-        "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration,port"
+        "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration"
       ],
       "presentation": {
         "group": "2",
@@ -552,7 +552,7 @@
         "--loglevel=INFO",
         "--hostname=docprocessing@%n",
         "-Q",
-        "docprocessing"
+        "docprocessing,port"
       ],
       "presentation": {
         "group": "2",
@@ -645,7 +645,7 @@
         "--loglevel=INFO",
         "--hostname=light@%n",
         "-Q",
-        "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration,port"
+        "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration"
       ],
       "presentation": {
         "group": "2",
@@ -846,7 +846,7 @@
         "--loglevel=INFO",
         "--hostname=docprocessing@%n",
         "-Q",
-        "docprocessing"
+        "docprocessing,port"
       ],
       "presentation": {
         "group": "2",

--- a/backend/onyx/background/README.md
+++ b/backend/onyx/background/README.md
@@ -13,7 +13,7 @@ The background jobs take care of:
 | Worker                    | File                           | Queues                                                                                                               |
 | ------------------------- | ------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
 | Primary                   | `apps/primary.py`              | `celery`                                                                                                             |
-| Light                     | `apps/light.py`                | `vespa_metadata_sync`, `connector_deletion`, `doc_permissions_upsert`, `checkpoint_cleanup`, `index_attempt_cleanup`, `opensearch_migration` |
+| Light                     | `apps/light.py`                | `vespa_metadata_sync`, `connector_deletion`, `doc_permissions_upsert`, `checkpoint_cleanup`, `index_attempt_cleanup` |
 | Heavy                     | `apps/heavy.py`                | `connector_pruning`, `connector_doc_permissions_sync`, `connector_external_group_sync`, `csv_generation`, `sandbox`  |
 | Docprocessing             | `apps/docprocessing.py`        | `docprocessing`, `port`                                                                                              |
 | Docfetching               | `apps/docfetching.py`          | `connector_doc_fetching`                                                                                             |

--- a/backend/onyx/background/README.md
+++ b/backend/onyx/background/README.md
@@ -13,9 +13,9 @@ The background jobs take care of:
 | Worker                    | File                           | Queues                                                                                                               |
 | ------------------------- | ------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
 | Primary                   | `apps/primary.py`              | `celery`                                                                                                             |
-| Light                     | `apps/light.py`                | `vespa_metadata_sync`, `connector_deletion`, `doc_permissions_upsert`, `checkpoint_cleanup`, `index_attempt_cleanup` |
+| Light                     | `apps/light.py`                | `vespa_metadata_sync`, `connector_deletion`, `doc_permissions_upsert`, `checkpoint_cleanup`, `index_attempt_cleanup`, `opensearch_migration` |
 | Heavy                     | `apps/heavy.py`                | `connector_pruning`, `connector_doc_permissions_sync`, `connector_external_group_sync`, `csv_generation`, `sandbox`  |
-| Docprocessing             | `apps/docprocessing.py`        | `docprocessing`                                                                                                      |
+| Docprocessing             | `apps/docprocessing.py`        | `docprocessing`, `port`                                                                                              |
 | Docfetching               | `apps/docfetching.py`          | `connector_doc_fetching`                                                                                             |
 | User File Processing      | `apps/user_file_processing.py` | `user_file_processing`, `user_file_project_sync`, `user_file_delete`                                                 |
 | Monitoring                | `apps/monitoring.py`           | `monitoring`                                                                                                         |

--- a/backend/onyx/background/celery/apps/docprocessing.py
+++ b/backend/onyx/background/celery/apps/docprocessing.py
@@ -164,6 +164,7 @@ celery_app.autodiscover_tasks(
     app_base.filter_task_modules(
         [
             "onyx.background.celery.tasks.docprocessing",
+            "onyx.background.celery.tasks.port",
         ]
     )
 )

--- a/backend/onyx/background/celery/apps/light.py
+++ b/backend/onyx/background/celery/apps/light.py
@@ -159,7 +159,6 @@ celery_app.autodiscover_tasks(
             "onyx.background.celery.tasks.connector_deletion",
             "onyx.background.celery.tasks.doc_permission_syncing",
             "onyx.background.celery.tasks.docprocessing",
-            "onyx.background.celery.tasks.port",
             "onyx.background.celery.tasks.opensearch_migration",
             # Sandbox cleanup tasks (build feature)
             "onyx.background.celery.tasks.build",

--- a/backend/onyx/background/celery/tasks/port/tasks.py
+++ b/backend/onyx/background/celery/tasks/port/tasks.py
@@ -427,12 +427,13 @@ def _resolve_port_target_settings(db_session: Session) -> SearchSettings | None:
     if future is not None and future.use_port_flow:
         return future
     present = get_current_search_settings(db_session)
-    if (
-        present.use_port_flow
-        and present.port_backfill_source_id is not None
-        and port_backfill_has_pending_work(db_session, present.id)
-    ):
-        return present
+    if present.use_port_flow and present.port_backfill_source_id is not None:
+        if port_backfill_has_pending_work(db_session, present.id):
+            return present
+        # Backfill drained: unpin the source so we stop re-checking a done job, the
+        # source index can be reclaimed, and the reindex/vespa guards read "not backfilling".
+        present.port_backfill_source_id = None
+        db_session.commit()
     return None
 
 

--- a/backend/onyx/background/celery/tasks/port/tasks.py
+++ b/backend/onyx/background/celery/tasks/port/tasks.py
@@ -28,6 +28,7 @@ from sqlalchemy.orm import Session
 from onyx.background.celery.apps.app_base import task_logger
 from onyx.background.celery.tasks.beat_schedule import BEAT_EXPIRES_DEFAULT
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
+from onyx.configs.app_configs import MAX_CONCURRENT_PORT_ATTEMPTS
 from onyx.configs.constants import CELERY_GENERIC_BEAT_LOCK_TIMEOUT
 from onyx.configs.constants import OnyxCeleryPriority
 from onyx.configs.constants import OnyxCeleryQueues
@@ -47,6 +48,7 @@ from onyx.db.enums import SwitchoverType
 from onyx.db.models import PortAttempt
 from onyx.db.models import SearchSettings
 from onyx.db.port_attempt import commit_port_cursor
+from onyx.db.port_attempt import count_active_port_attempts
 from onyx.db.port_attempt import count_consecutive_failed_port_attempts_no_progress
 from onyx.db.port_attempt import create_port_attempt
 from onyx.db.port_attempt import get_active_port_attempt
@@ -472,6 +474,11 @@ def run_check_for_port(tenant_id: str, celery_app: Celery) -> int | None:
                 seconds=BEAT_EXPIRES_DEFAULT
             )
 
+            # Cap concurrent attempts so the port doesn't fill every docprocessing slot
+            # and starve live indexing. Gates only NEW creation; recovery re-enqueues of
+            # already-active attempts below still run (they don't add load).
+            active_attempts = count_active_port_attempts(db_session, search_settings_id)
+
             for cc_pair_id in cc_pair_ids:
                 lock_beat.reacquire()
                 active = get_active_port_attempt(
@@ -500,6 +507,10 @@ def run_check_for_port(tenant_id: str, celery_app: Celery) -> int | None:
                                 "NOT_STARTED PortAttempt %s",
                                 active.id,
                             )
+                    continue
+                # At the concurrency cap: don't start new attempts this tick (the
+                # remaining cc_pairs still get recovery re-enqueues above next pass).
+                if active_attempts >= MAX_CONCURRENT_PORT_ATTEMPTS:
                     continue
                 latest = get_latest_port_attempt(
                     db_session, cc_pair_id, search_settings_id
@@ -552,6 +563,7 @@ def run_check_for_port(tenant_id: str, celery_app: Celery) -> int | None:
                     mark_port_failed(db_session, attempt.id, error_msg="enqueue failed")
                     continue
                 tasks_created += 1
+                active_attempts += 1
     finally:
         if lock_beat.owned():
             lock_beat.release()

--- a/backend/onyx/background/celery/tasks/port/tasks.py
+++ b/backend/onyx/background/celery/tasks/port/tasks.py
@@ -508,7 +508,7 @@ def run_check_for_port(tenant_id: str, celery_app: Celery) -> int | None:
                                 active.id,
                             )
                     continue
-                # At the concurrency cap: don't start new attempts this tick (the
+                # At the concurrency cap: don't start new attempts(the
                 # remaining cc_pairs still get recovery re-enqueues above next pass).
                 if active_attempts >= MAX_CONCURRENT_PORT_ATTEMPTS:
                     continue

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -945,7 +945,10 @@ except ValueError:
 
 # Reindex-port runs on the docprocessing worker; cap concurrent port attempts well
 # below its concurrency so a large reindex leaves slots for live indexing.
-MAX_CONCURRENT_PORT_ATTEMPTS = int(os.environ.get("MAX_CONCURRENT_PORT_ATTEMPTS") or 2)
+# Floor at 1: 0 (or negative) would gate off every new port attempt.
+MAX_CONCURRENT_PORT_ATTEMPTS = max(
+    1, _non_negative_int_env("MAX_CONCURRENT_PORT_ATTEMPTS", 2)
+)
 
 _CELERY_WORKER_DOCFETCHING_CONCURRENCY_DEFAULT = 1
 try:

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -943,6 +943,10 @@ except ValueError:
         _CELERY_WORKER_DOCPROCESSING_CONCURRENCY_DEFAULT
     )
 
+# Reindex-port runs on the docprocessing worker; cap concurrent port attempts well
+# below its concurrency so a large reindex leaves slots for live indexing.
+MAX_CONCURRENT_PORT_ATTEMPTS = int(os.environ.get("MAX_CONCURRENT_PORT_ATTEMPTS") or 2)
+
 _CELERY_WORKER_DOCFETCHING_CONCURRENCY_DEFAULT = 1
 try:
     env_value = os.environ.get("CELERY_WORKER_DOCFETCHING_CONCURRENCY")

--- a/backend/onyx/db/port_attempt.py
+++ b/backend/onyx/db/port_attempt.py
@@ -16,8 +16,12 @@ from sqlalchemy import select
 from sqlalchemy import update
 from sqlalchemy.orm import Session
 
+from onyx.db.connector_credential_pair import (
+    fetch_indexable_standard_connector_credential_pair_ids,
+)
 from onyx.db.enums import IndexModelStatus
 from onyx.db.enums import PortAttemptStatus
+from onyx.db.enums import SwitchoverType
 from onyx.db.models import PortAttempt
 from onyx.db.models import SearchSettings
 from onyx.utils.logger import setup_logger
@@ -25,6 +29,10 @@ from onyx.utils.logger import setup_logger
 logger = setup_logger()
 
 _ACTIVE_STATUSES = [PortAttemptStatus.NOT_STARTED, PortAttemptStatus.IN_PROGRESS]
+
+# States check_for_port won't create a further attempt for; anything else
+# (none / active / FAILED) is still pending work.
+_SETTLED_STATUSES = frozenset({PortAttemptStatus.SUCCESS, PortAttemptStatus.CANCELED})
 
 # Reads enough recent attempts to reach the streak where retry backoff caps (9 at
 # the current 30s base / 1h cap); 10 = small margin. Raise if that cap is raised.
@@ -112,30 +120,44 @@ def count_active_port_attempts(db_session: Session, search_settings_id: int) -> 
 def port_backfill_has_pending_work(
     db_session: Session, search_settings_id: int
 ) -> bool:
-    """True while a post-swap (INSTANT) backfill still has work for this settings:
-    no attempts yet (just promoted) or at least one not yet SUCCESS/CANCELED. Lets
-    check_for_port stop targeting a promoted PRESENT once every cc_pair is ported."""
-    any_attempt = db_session.execute(
-        select(exists().where(PortAttempt.search_settings_id == search_settings_id))
-    ).scalar()
-    if not any_attempt:
-        return True
-    return bool(
-        db_session.execute(
-            select(
-                exists().where(
-                    PortAttempt.search_settings_id == search_settings_id,
-                    PortAttempt.status.in_(
-                        [
-                            PortAttemptStatus.NOT_STARTED,
-                            PortAttemptStatus.IN_PROGRESS,
-                            PortAttemptStatus.FAILED,
-                        ]
-                    ),
-                )
-            )
-        ).scalar()
+    """True while some in-scope cc_pair lacks a settled port attempt, so check_for_port
+    keeps targeting a promoted (INSTANT) PRESENT until every cc_pair is ported.
+
+    Cc_pair-aware, not existing-row-aware: MAX_CONCURRENT_PORT_ATTEMPTS defers cc_pairs to
+    later ticks, so all-terminal *existing* rows != done — un-attempted cc_pairs still
+    need one. Checking only existing rows let the first fast batch's SUCCESS strand the
+    rest, leaving the live index incomplete. Scope + _SETTLED_STATUSES match check_for_port
+    so this never reports pending for a cc_pair it won't act on.
+    """
+    settings = db_session.get(SearchSettings, search_settings_id)
+    active_only = (
+        settings is not None and settings.switchover_type == SwitchoverType.ACTIVE_ONLY
     )
+    in_scope_cc_pair_ids = fetch_indexable_standard_connector_credential_pair_ids(
+        db_session, active_cc_pairs_only=active_only
+    )
+    if not in_scope_cc_pair_ids:
+        return False
+    # Latest attempt per cc_pair in one DISTINCT ON pass (avoids an N+1 over cc_pairs).
+    settled_cc_pairs = {
+        cc_pair_id
+        for cc_pair_id, status in db_session.execute(
+            select(PortAttempt.cc_pair_id, PortAttempt.status)
+            .where(
+                PortAttempt.search_settings_id == search_settings_id,
+                PortAttempt.cc_pair_id.in_(in_scope_cc_pair_ids),
+            )
+            .distinct(PortAttempt.cc_pair_id)
+            .order_by(
+                PortAttempt.cc_pair_id,
+                PortAttempt.time_created.desc(),
+                PortAttempt.id.desc(),
+            )
+        )
+        if status in _SETTLED_STATUSES
+    }
+    # Pending if any in-scope cc_pair has no settled latest attempt (incl. none at all).
+    return bool(set(in_scope_cc_pair_ids) - settled_cc_pairs)
 
 
 def is_active_port_backfill_source(

--- a/backend/onyx/db/port_attempt.py
+++ b/backend/onyx/db/port_attempt.py
@@ -95,6 +95,20 @@ def get_active_port_attempt(
     ).scalar_one_or_none()
 
 
+def count_active_port_attempts(db_session: Session, search_settings_id: int) -> int:
+    """Active (NOT_STARTED / IN_PROGRESS) attempts across all cc_pairs for a settings.
+    check_for_port caps new attempt creation on this so the port doesn't fill every
+    docprocessing slot and starve live indexing."""
+    return db_session.execute(
+        select(func.count())
+        .select_from(PortAttempt)
+        .where(
+            PortAttempt.search_settings_id == search_settings_id,
+            PortAttempt.status.in_(_ACTIVE_STATUSES),
+        )
+    ).scalar_one()
+
+
 def port_backfill_has_pending_work(
     db_session: Session, search_settings_id: int
 ) -> bool:

--- a/backend/scripts/dev_run_background_jobs.py
+++ b/backend/scripts/dev_run_background_jobs.py
@@ -41,7 +41,7 @@ def run_jobs() -> None:
         "--loglevel=INFO",
         "--hostname=light@%n",
         "-Q",
-        "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration,port",
+        "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration",
     ]
 
     cmd_worker_docprocessing = [
@@ -54,7 +54,7 @@ def run_jobs() -> None:
         "--prefetch-multiplier=1",
         "--loglevel=INFO",
         "--hostname=docprocessing@%n",
-        "--queues=docprocessing",
+        "--queues=docprocessing,port",
     ]
 
     cmd_worker_docfetching = [

--- a/backend/supervisord.conf
+++ b/backend/supervisord.conf
@@ -44,7 +44,7 @@ stopasgroup=true
 [program:celery_worker_light]
 command=celery -A onyx.background.celery.versioned_apps.light worker
     --hostname=light@%%n
-    -Q vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration,port
+    -Q vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration
 stdout_logfile=/var/log/celery_worker_light.log
 stdout_logfile_maxbytes=16MB
 redirect_stderr=true
@@ -66,7 +66,7 @@ stopasgroup=true
 [program:celery_worker_docprocessing]
 command=celery -A onyx.background.celery.versioned_apps.docprocessing worker
     --hostname=docprocessing@%%n
-    -Q docprocessing
+    -Q docprocessing,port
 stdout_logfile=/var/log/celery_worker_docprocessing.log
 stdout_logfile_maxbytes=16MB
 redirect_stderr=true

--- a/backend/tests/external_dependency_unit/db/test_reindex_port.py
+++ b/backend/tests/external_dependency_unit/db/test_reindex_port.py
@@ -39,6 +39,7 @@ from onyx.configs.app_configs import MAX_CONCURRENT_PORT_ATTEMPTS
 from onyx.configs.constants import OnyxCeleryQueues
 from onyx.configs.constants import OnyxCeleryTask
 from onyx.context.search.models import SavedSearchSettings
+from onyx.db import port_attempt as port_attempt_db
 from onyx.db.connector_credential_pair import get_last_successful_attempt_poll_range_end
 from onyx.db.document import document_has_indexable_cc_pair
 from onyx.db.document import filter_existing_cc_pair_document_ids
@@ -75,6 +76,7 @@ from onyx.db.port_attempt import mark_port_canceled
 from onyx.db.port_attempt import mark_port_failed
 from onyx.db.port_attempt import mark_port_in_progress
 from onyx.db.port_attempt import mark_port_succeeded
+from onyx.db.port_attempt import port_backfill_has_pending_work
 from onyx.db.port_attempt import request_port_cancel
 from onyx.db.search_settings import create_search_settings
 from onyx.db.search_settings import get_current_search_settings
@@ -993,6 +995,152 @@ def test_check_for_port_caps_concurrent_attempts(
             )
             db_session.commit()
             cleanup_cc_pair(db_session, p)
+
+
+def test_port_backfill_pending_work_is_cc_pair_aware(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    """Regression: a promoted-PRESENT backfill stays pending until EVERY in-scope cc_pair
+    is ported, not just until the attempts created so far are terminal. The concurrency
+    cap defers cc_pairs across ticks, so all-SUCCESS existing rows with un-attempted
+    cc_pairs remaining must still read pending (else the live index is left incomplete)."""
+    ss = get_current_search_settings(db_session)
+    pairs = [make_cc_pair(db_session) for _ in range(3)]
+    ids = [p.id for p in pairs]
+
+    def _succeed(cc_pair_id: int) -> None:
+        db_session.add(
+            PortAttempt(
+                cc_pair_id=cc_pair_id,
+                search_settings_id=ss.id,
+                status=PortAttemptStatus.SUCCESS,
+            )
+        )
+        db_session.commit()
+
+    try:
+        with patch.object(
+            port_attempt_db,
+            "fetch_indexable_standard_connector_credential_pair_ids",
+            lambda *_, **__: ids,
+        ):
+            _succeed(pairs[0].id)
+            # old code returned False here (all existing rows terminal); fixed -> pending
+            assert port_backfill_has_pending_work(db_session, ss.id) is True
+
+            _succeed(pairs[1].id)
+            assert port_backfill_has_pending_work(db_session, ss.id) is True
+
+            _succeed(pairs[2].id)
+            assert port_backfill_has_pending_work(db_session, ss.id) is False
+    finally:
+        db_session.rollback()
+        for p in pairs:
+            db_session.query(PortAttempt).filter(PortAttempt.cc_pair_id == p.id).delete(
+                synchronize_session="fetch"
+            )
+            db_session.commit()
+            cleanup_cc_pair(db_session, p)
+
+
+def test_port_backfill_pending_work_settled_statuses(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    """Per-cc_pair 'settled' mirrors check_for_port's no-retry set: SUCCESS and CANCELED
+    are done; no-attempt or FAILED is still pending (check_for_port (re)creates/retries
+    it). CANCELED must NOT read pending -- else the guard deadlocks on a cc_pair the
+    scheduler refuses to retry."""
+    ss = get_current_search_settings(db_session)
+
+    def _pending_for(status: PortAttemptStatus | None) -> bool:
+        pair = make_cc_pair(db_session)
+        try:
+            with patch.object(
+                port_attempt_db,
+                "fetch_indexable_standard_connector_credential_pair_ids",
+                lambda *_, **__: [pair.id],
+            ):
+                if status is not None:
+                    db_session.add(
+                        PortAttempt(
+                            cc_pair_id=pair.id,
+                            search_settings_id=ss.id,
+                            status=status,
+                        )
+                    )
+                    db_session.commit()
+                return port_backfill_has_pending_work(db_session, ss.id)
+        finally:
+            db_session.rollback()
+            db_session.query(PortAttempt).filter(
+                PortAttempt.cc_pair_id == pair.id
+            ).delete(synchronize_session="fetch")
+            db_session.commit()
+            cleanup_cc_pair(db_session, pair)
+
+    assert _pending_for(None) is True  # just promoted, no attempt yet
+    assert _pending_for(PortAttemptStatus.FAILED) is True  # retryable
+    assert _pending_for(PortAttemptStatus.SUCCESS) is False
+    assert _pending_for(PortAttemptStatus.CANCELED) is False  # settled -> no deadlock
+
+
+def test_resolve_clears_backfill_source_when_drained(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """Once every in-scope cc_pair of a promoted-PRESENT (INSTANT) backfill is ported,
+    _resolve unpins port_backfill_source_id so the done job stops being re-checked and
+    the source index becomes reclaimable (set at swap, otherwise never cleared)."""
+    cc_pair, present_id = cc_pair_and_future
+    present = db_session.get(SearchSettings, present_id)
+    assert present is not None
+    source = (
+        db_session.query(SearchSettings.id)
+        .filter(SearchSettings.id != present_id)
+        .first()
+    )
+    assert source is not None
+    present.use_port_flow = True
+    present.port_backfill_source_id = source[0]
+    db_session.add(
+        PortAttempt(
+            cc_pair_id=cc_pair.id,
+            search_settings_id=present_id,
+            status=PortAttemptStatus.SUCCESS,
+        )
+    )
+    db_session.commit()
+
+    try:
+        with (
+            patch.object(
+                port_task, "get_secondary_search_settings", lambda *_, **__: None
+            ),
+            patch.object(
+                port_task,
+                "get_current_search_settings",
+                lambda *_, **__: db_session.get(SearchSettings, present_id),
+            ),
+            patch.object(
+                port_attempt_db,
+                "fetch_indexable_standard_connector_credential_pair_ids",
+                lambda *_, **__: [cc_pair.id],
+            ),
+        ):
+            target = port_task._resolve_port_target_settings(db_session)
+
+        assert target is None  # drained -> not a target
+        db_session.expire_all()
+        refreshed = db_session.get(SearchSettings, present_id)
+        assert refreshed is not None
+        assert refreshed.port_backfill_source_id is None
+    finally:
+        db_session.rollback()
+        db_session.query(PortAttempt).filter(
+            PortAttempt.cc_pair_id == cc_pair.id
+        ).delete(synchronize_session="fetch")
+        db_session.commit()
 
 
 def test_check_for_port_gated_off_when_not_port_flow(

--- a/backend/tests/external_dependency_unit/db/test_reindex_port.py
+++ b/backend/tests/external_dependency_unit/db/test_reindex_port.py
@@ -35,6 +35,7 @@ from onyx.background.celery.tasks.port import tasks as port_task
 from onyx.background.celery.tasks.port.tasks import run_check_for_port
 from onyx.background.celery.tasks.port.tasks import run_port_attempt
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
+from onyx.configs.app_configs import MAX_CONCURRENT_PORT_ATTEMPTS
 from onyx.configs.constants import OnyxCeleryQueues
 from onyx.configs.constants import OnyxCeleryTask
 from onyx.context.search.models import SavedSearchSettings
@@ -937,6 +938,61 @@ def test_check_for_port_creates_and_enqueues(
     }
     assert call.kwargs["queue"] == OnyxCeleryQueues.PORT
     assert call.kwargs["expires"] == BEAT_EXPIRES_DEFAULT
+
+
+def test_check_for_port_caps_concurrent_attempts(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """More in-scope cc_pairs than MAX_CONCURRENT_PORT_ATTEMPTS -> only the cap's worth
+    of attempts are created/enqueued per tick, so the port can't fill every
+    docprocessing slot and starve live indexing."""
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    future_ss.use_port_flow = True
+    db_session.commit()
+
+    # cap + 2 in-scope cc_pairs so the cap genuinely bites this tick.
+    extra_pairs = [
+        make_cc_pair(db_session) for _ in range(MAX_CONCURRENT_PORT_ATTEMPTS + 1)
+    ]
+    all_ids = [cc_pair.id] + [p.id for p in extra_pairs]
+    celery_app = MagicMock()
+    try:
+        with (
+            patch.object(
+                port_task,
+                "get_secondary_search_settings",
+                lambda db, *_, **__: db.get(SearchSettings, future_id),
+            ),
+            patch.object(
+                port_task,
+                "fetch_indexable_standard_connector_credential_pair_ids",
+                lambda *_, **__: all_ids,
+            ),
+        ):
+            result = run_check_for_port(get_current_tenant_id(), celery_app)
+
+        assert result == MAX_CONCURRENT_PORT_ATTEMPTS
+        assert celery_app.send_task.call_count == MAX_CONCURRENT_PORT_ATTEMPTS
+        db_session.expire_all()
+        created = (
+            db_session.query(PortAttempt)
+            .filter(
+                PortAttempt.search_settings_id == future_id,
+                PortAttempt.cc_pair_id.in_(all_ids),
+            )
+            .count()
+        )
+        assert created == MAX_CONCURRENT_PORT_ATTEMPTS
+    finally:
+        db_session.rollback()
+        for p in extra_pairs:
+            db_session.query(PortAttempt).filter(PortAttempt.cc_pair_id == p.id).delete(
+                synchronize_session="fetch"
+            )
+            db_session.commit()
+            cleanup_cc_pair(db_session, p)
 
 
 def test_check_for_port_gated_off_when_not_port_flow(

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -159,7 +159,7 @@ _CELERY_WORKER_PROGRAMS: list[tuple[str, str]] = [
         "connector_pruning,connector_doc_permissions_sync,"
         "connector_external_group_sync,csv_generation,sandbox",
     ),
-    ("docprocessing", "docprocessing"),
+    ("docprocessing", "docprocessing,port"),
     (
         "user_file_processing",
         "user_file_processing,user_file_project_sync,user_file_delete",

--- a/backend/tests/unit/onyx/background/celery/tasks/test_port_wiring.py
+++ b/backend/tests/unit/onyx/background/celery/tasks/test_port_wiring.py
@@ -8,9 +8,6 @@ or `-Q` entry would silently break with every other test still green:
 
   beat schedules check_for_port  ->  docprocessing worker consumes the `port` queue
   ->  docprocessing worker has run_port_attempt registered to execute it.
-
-The port task runs on docprocessing (not light) so its long re-embed can't starve
-the light worker's security-sensitive vespa_metadata_sync (ACL revocation) queue.
 """
 
 import re

--- a/backend/tests/unit/onyx/background/celery/tasks/test_port_wiring.py
+++ b/backend/tests/unit/onyx/background/celery/tasks/test_port_wiring.py
@@ -6,8 +6,11 @@ nothing there proves a beat-enqueued port task actually reaches a worker. These
 unit tests guard exactly that transport seam — the part a dropped autodiscover line
 or `-Q` entry would silently break with every other test still green:
 
-  beat schedules check_for_port  ->  light worker consumes the `port` queue
-  ->  light worker has run_port_attempt registered to execute it.
+  beat schedules check_for_port  ->  docprocessing worker consumes the `port` queue
+  ->  docprocessing worker has run_port_attempt registered to execute it.
+
+The port task runs on docprocessing (not light) so its long re-embed can't starve
+the light worker's security-sensitive vespa_metadata_sync (ACL revocation) queue.
 """
 
 import re
@@ -58,19 +61,18 @@ def test_check_for_port_scheduled_in_beat() -> None:
         assert OnyxCeleryTask.CHECK_FOR_PORT in scheduled
 
 
-def test_light_worker_consumes_port_queue() -> None:
-    # run_port_attempt is enqueued to the PORT queue; the light worker is its only
-    # consumer. Dropping `port` from this `-Q` list strands every port task.
-    assert OnyxCeleryQueues.PORT in _worker_queues("celery_worker_light")
+def test_docprocessing_worker_consumes_port_queue() -> None:
+    # run_port_attempt is enqueued to the PORT queue; the docprocessing worker is its
+    # only consumer. Dropping `port` from this `-Q` list strands every port task.
+    assert OnyxCeleryQueues.PORT in _worker_queues("celery_worker_docprocessing")
 
 
-def test_light_worker_registers_port_tasks() -> None:
+def test_docprocessing_worker_registers_port_tasks() -> None:
     # Consuming the queue is moot if autodiscovery doesn't register the task body:
-    # the worker would reject it as unknown. Importing + loading the light app
-    # mirrors worker bootstrap, so both port tasks must resolve by name.
-    from onyx.background.celery.apps.light import celery_app
+    # the worker would reject it as unknown. Importing + loading the docprocessing app
+    # mirrors worker bootstrap, so run_port_attempt must resolve by name.
+    from onyx.background.celery.apps.docprocessing import celery_app
 
     celery_app.loader.import_default_modules()
     registered = set(celery_app.tasks.keys())
     assert OnyxCeleryTask.RUN_PORT_ATTEMPT in registered
-    assert OnyxCeleryTask.CHECK_FOR_PORT in registered

--- a/deployment/helm/charts/onyx/templates/celery-worker-docprocessing.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docprocessing.yaml
@@ -76,7 +76,7 @@ spec:
               {{- end }}
               "--hostname=docprocessing@%n",
               "-Q",
-              "docprocessing",
+              "docprocessing,port",
             ]
           ports:
             - name: metrics

--- a/deployment/helm/charts/onyx/templates/celery-worker-light.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-light.yaml
@@ -73,7 +73,7 @@ spec:
               {{- end }}
               "--hostname=light@%n",
               "-Q",
-              "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration,port",
+              "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration",
             ]
           ports:
             - name: metrics


### PR DESCRIPTION
## Description

- The light worker is for fast, short-lived jobs (including permission/ACL sync). The reindex `port` job is heavy and long-running, so it doesn't belong there — move it to the docprocessing worker, which handles the heavy, time-consuming indexing work.
- Cap concurrent port attempts per tenant (`MAX_CONCURRENT_PORT_ATTEMPTS`, default 2) so a large reindex leaves docprocessing slots free for live indexing.
- Make the post-swap (INSTANT) backfill's completion check cc_pair-aware. Because the cap above defers some cc_pairs to later ticks, the old check (which only inspected existing attempt rows) could report the backfill "done" the moment the first batch's attempts all succeeded — stranding the deferred cc_pairs and leaving the live index permanently incomplete with no self-heal. `port_backfill_has_pending_work` now reports pending until every in-scope cc_pair has a settled (SUCCESS/CANCELED) latest attempt, and `_resolve_port_target_settings` clears `port_backfill_source_id` once the backfill drains so the source index can be reclaimed and the reindex/Vespa guards read "not backfilling".

## How Has This Been Tested?

- Updated the worker/queue wiring unit tests and added a concurrency-cap test.
- Added unit tests covering the cc_pair-aware backfill drain (deferred cc_pairs keep the backfill pending; the source is unpinned once every cc_pair settles).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
