### PR TITLE
feat: add external group sync error tracking

### DIFF
--- a/backend/alembic/versions/8a4f1c2d3e5b_add_external_group_sync_errors.py
+++ b/backend/alembic/versions/8a4f1c2d3e5b_add_external_group_sync_errors.py
@@ -22,7 +22,7 @@ def upgrade() -> None:
         "external_group_sync_errors",
         sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("external_group_sync_attempt_id", sa.Integer(), nullable=False),
-        sa.Column("connector_credential_pair_id", sa.Integer(), nullable=False),
+        sa.Column("connector_credential_pair_id", sa.Integer(), nullable=True),
         sa.Column("external_group_id", sa.String(), nullable=True),
         sa.Column("external_group_name", sa.String(), nullable=True),
         sa.Column("failure_message", sa.Text(), nullable=False),

--- a/backend/alembic/versions/8a4f1c2d3e5b_add_external_group_sync_errors.py
+++ b/backend/alembic/versions/8a4f1c2d3e5b_add_external_group_sync_errors.py
@@ -1,0 +1,70 @@
+"""add external group sync errors
+
+Revision ID: 8a4f1c2d3e5b
+Revises: 7f2a3b9c1d4e
+Create Date: 2026-07-02 10:45:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "8a4f1c2d3e5b"
+down_revision = "7f2a3b9c1d4e"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "external_group_sync_errors",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("external_group_sync_attempt_id", sa.Integer(), nullable=False),
+        sa.Column("connector_credential_pair_id", sa.Integer(), nullable=False),
+        sa.Column("external_group_id", sa.String(), nullable=True),
+        sa.Column("external_group_name", sa.String(), nullable=True),
+        sa.Column("failure_message", sa.Text(), nullable=False),
+        sa.Column("full_exception_trace", sa.Text(), nullable=True),
+        sa.Column("error_type", sa.String(), nullable=True),
+        sa.Column(
+            "time_created",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["connector_credential_pair_id"],
+            ["connector_credential_pair.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["external_group_sync_attempt_id"],
+            ["external_group_permission_sync_attempt.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_external_group_sync_errors_connector_credential_pair_id",
+        "external_group_sync_errors",
+        ["connector_credential_pair_id"],
+    )
+    op.create_index(
+        "ix_external_group_sync_errors_external_group_sync_attempt_id",
+        "external_group_sync_errors",
+        ["external_group_sync_attempt_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_external_group_sync_errors_external_group_sync_attempt_id",
+        table_name="external_group_sync_errors",
+    )
+    op.drop_index(
+        "ix_external_group_sync_errors_connector_credential_pair_id",
+        table_name="external_group_sync_errors",
+    )
+    op.drop_table("external_group_sync_errors")

--- a/backend/ee/onyx/background/celery/tasks/external_group_syncing/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/external_group_syncing/tasks.py
@@ -598,7 +598,33 @@ def _timed_perform_external_group_sync(
         cumulative_upsert_time = 0.0
         start_time = time.monotonic()
         try:
-            external_user_group_generator = ext_group_sync_func(tenant_id, cc_pair)
+
+            def record_group_sync_failure(failure: ExternalGroupSyncFailure) -> None:
+                nonlocal total_group_errors
+                total_group_errors += 1
+                create_external_group_sync_error(
+                    external_group_sync_attempt_id=attempt_id,
+                    connector_credential_pair_id=cc_pair_id,
+                    db_session=db_session,
+                    external_group_id=failure.external_group_id,
+                    external_group_name=failure.external_group_name,
+                    failure_message=failure.failure_message,
+                    full_exception_trace=failure.full_exception_trace,
+                    error_type=(
+                        type(failure.exception).__name__ if failure.exception else None
+                    ),
+                )
+                _check_external_group_failure_threshold(
+                    total_failures=total_group_errors,
+                    total_groups_seen=total_groups_processed + total_group_errors,
+                    last_failure=failure,
+                )
+
+            external_user_group_generator = ext_group_sync_func(
+                tenant_id,
+                cc_pair,
+                record_group_sync_failure,
+            )
             for external_group_sync_result in external_user_group_generator:
                 # Check if the task has exceeded its timeout
                 # NOTE: Celery's soft_time_limit does not work with thread pools,
@@ -612,29 +638,6 @@ def _timed_perform_external_group_sync(
                         f"timeout={timeout_seconds}s "
                         f"groups_processed={total_groups_processed}"
                     )
-
-                if isinstance(external_group_sync_result, ExternalGroupSyncFailure):
-                    total_group_errors += 1
-                    create_external_group_sync_error(
-                        external_group_sync_attempt_id=attempt_id,
-                        connector_credential_pair_id=cc_pair_id,
-                        db_session=db_session,
-                        external_group_id=external_group_sync_result.external_group_id,
-                        external_group_name=external_group_sync_result.external_group_name,
-                        failure_message=external_group_sync_result.failure_message,
-                        full_exception_trace=external_group_sync_result.full_exception_trace,
-                        error_type=(
-                            type(external_group_sync_result.exception).__name__
-                            if external_group_sync_result.exception
-                            else None
-                        ),
-                    )
-                    _check_external_group_failure_threshold(
-                        total_failures=total_group_errors,
-                        total_groups_seen=total_groups_processed + total_group_errors,
-                        last_failure=external_group_sync_result,
-                    )
-                    continue
 
                 external_user_group = external_group_sync_result
                 external_user_group_batch.append(external_user_group)

--- a/backend/ee/onyx/background/celery/tasks/external_group_syncing/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/external_group_syncing/tasks.py
@@ -109,9 +109,10 @@ def _check_external_group_failure_threshold(
     last_failure: ExternalGroupSyncFailure,
 ) -> None:
     failure_ratio = total_failures / (total_groups_seen or 1)
+    # Continue only while both the absolute and relative failure limits are safe.
     if (
         total_failures <= _EXTERNAL_GROUP_FAILURE_THRESHOLD
-        or failure_ratio <= _EXTERNAL_GROUP_FAILURE_RATIO_THRESHOLD
+        and failure_ratio <= _EXTERNAL_GROUP_FAILURE_RATIO_THRESHOLD
     ):
         return
 

--- a/backend/ee/onyx/background/celery/tasks/external_group_syncing/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/external_group_syncing/tasks.py
@@ -20,6 +20,7 @@ from ee.onyx.background.celery.tasks.external_group_syncing.group_sync_utils imp
 )
 from ee.onyx.db.connector_credential_pair import get_all_auto_sync_cc_pairs
 from ee.onyx.db.connector_credential_pair import get_cc_pairs_by_source
+from ee.onyx.db.external_perm import ExternalGroupSyncFailure
 from ee.onyx.db.external_perm import ExternalUserGroup
 from ee.onyx.db.external_perm import mark_old_external_groups_as_stale
 from ee.onyx.db.external_perm import remove_stale_external_groups
@@ -53,6 +54,7 @@ from onyx.db.enums import SyncType
 from onyx.db.models import ConnectorCredentialPair
 from onyx.db.permission_sync_attempt import complete_external_group_sync_attempt
 from onyx.db.permission_sync_attempt import create_external_group_sync_attempt
+from onyx.db.permission_sync_attempt import create_external_group_sync_error
 from onyx.db.permission_sync_attempt import mark_external_group_sync_attempt_failed
 from onyx.db.permission_sync_attempt import mark_external_group_sync_attempt_in_progress
 from onyx.db.sync_record import insert_sync_record
@@ -81,6 +83,8 @@ logger = setup_logger()
 
 
 _EXTERNAL_GROUP_BATCH_SIZE = 100
+_EXTERNAL_GROUP_FAILURE_THRESHOLD = 3
+_EXTERNAL_GROUP_FAILURE_RATIO_THRESHOLD = 0.1
 
 
 def _fail_external_group_sync_attempt(attempt_id: int, error_msg: str) -> None:
@@ -89,6 +93,34 @@ def _fail_external_group_sync_attempt(attempt_id: int, error_msg: str) -> None:
         mark_external_group_sync_attempt_failed(
             attempt_id, db_session, error_message=error_msg
         )
+
+
+def _external_group_failure_label(failure: ExternalGroupSyncFailure) -> str:
+    return (
+        failure.external_group_name
+        or failure.external_group_id
+        or "unknown external group"
+    )
+
+
+def _check_external_group_failure_threshold(
+    total_failures: int,
+    total_groups_seen: int,
+    last_failure: ExternalGroupSyncFailure,
+) -> None:
+    failure_ratio = total_failures / (total_groups_seen or 1)
+    if (
+        total_failures <= _EXTERNAL_GROUP_FAILURE_THRESHOLD
+        or failure_ratio <= _EXTERNAL_GROUP_FAILURE_RATIO_THRESHOLD
+    ):
+        return
+
+    raise RuntimeError(
+        "External group sync encountered too many group-level errors, aborting. "
+        f"failures={total_failures} groups_seen={total_groups_seen} "
+        f"last_failed_group={_external_group_failure_label(last_failure)!r} "
+        f"last_error={last_failure.failure_message}"
+    )
 
 
 def _get_fence_validation_block_expiration() -> int:
@@ -561,11 +593,12 @@ def _timed_perform_external_group_sync(
         seen_users: set[str] = set()  # Track unique users across all groups
         total_groups_processed = 0
         total_group_memberships_synced = 0
+        total_group_errors = 0
         cumulative_upsert_time = 0.0
         start_time = time.monotonic()
         try:
             external_user_group_generator = ext_group_sync_func(tenant_id, cc_pair)
-            for external_user_group in external_user_group_generator:
+            for external_group_sync_result in external_user_group_generator:
                 # Check if the task has exceeded its timeout
                 # NOTE: Celery's soft_time_limit does not work with thread pools,
                 # so we must enforce timeouts internally.
@@ -579,6 +612,30 @@ def _timed_perform_external_group_sync(
                         f"groups_processed={total_groups_processed}"
                     )
 
+                if isinstance(external_group_sync_result, ExternalGroupSyncFailure):
+                    total_group_errors += 1
+                    create_external_group_sync_error(
+                        external_group_sync_attempt_id=attempt_id,
+                        connector_credential_pair_id=cc_pair_id,
+                        db_session=db_session,
+                        external_group_id=external_group_sync_result.external_group_id,
+                        external_group_name=external_group_sync_result.external_group_name,
+                        failure_message=external_group_sync_result.failure_message,
+                        full_exception_trace=external_group_sync_result.full_exception_trace,
+                        error_type=(
+                            type(external_group_sync_result.exception).__name__
+                            if external_group_sync_result.exception
+                            else None
+                        ),
+                    )
+                    _check_external_group_failure_threshold(
+                        total_failures=total_group_errors,
+                        total_groups_seen=total_groups_processed + total_group_errors,
+                        last_failure=external_group_sync_result,
+                    )
+                    continue
+
+                external_user_group = external_group_sync_result
                 external_user_group_batch.append(external_user_group)
 
                 # Track progress
@@ -650,14 +707,15 @@ def _timed_perform_external_group_sync(
             total_users_processed=total_users_processed,
             total_groups_processed=total_groups_processed,
             total_group_memberships_synced=total_group_memberships_synced,
-            errors_encountered=0,
+            errors_encountered=total_group_errors,
         )
         logger.info(
-            "Completed external group sync attempt %s: %s groups, %s users, %s memberships",
+            "Completed external group sync attempt %s: %s groups, %s users, %s memberships, %s errors",
             attempt_id,
             total_groups_processed,
             total_users_processed,
             total_group_memberships_synced,
+            total_group_errors,
         )
 
         inc_group_sync_groups_processed(connector_type, total_groups_processed)

--- a/backend/ee/onyx/background/celery/tasks/external_group_syncing/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/external_group_syncing/tasks.py
@@ -87,6 +87,16 @@ _EXTERNAL_GROUP_FAILURE_THRESHOLD = 3
 _EXTERNAL_GROUP_FAILURE_RATIO_THRESHOLD = 0.1
 
 
+class ExternalGroupSyncFailureThresholdError(RuntimeError):
+    def __init__(
+        self,
+        message: str,
+        full_exception_trace: str | None,
+    ) -> None:
+        super().__init__(message)
+        self.full_exception_trace = full_exception_trace
+
+
 def _fail_external_group_sync_attempt(attempt_id: int, error_msg: str) -> None:
     """Helper to mark an external group sync attempt as failed with an error message."""
     with get_session_with_current_tenant() as db_session:
@@ -116,12 +126,18 @@ def _check_external_group_failure_threshold(
     ):
         return
 
-    raise RuntimeError(
-        "External group sync encountered too many group-level errors, aborting. "
-        f"failures={total_failures} groups_seen={total_groups_seen} "
-        f"last_failed_group={_external_group_failure_label(last_failure)!r} "
-        f"last_error={last_failure.failure_message}"
+    error = ExternalGroupSyncFailureThresholdError(
+        (
+            "External group sync encountered too many group-level errors, aborting. "
+            f"failures={total_failures} groups_seen={total_groups_seen} "
+            f"last_failed_group={_external_group_failure_label(last_failure)!r} "
+            f"last_error={last_failure.failure_message}"
+        ),
+        full_exception_trace=last_failure.full_exception_trace,
     )
+    if last_failure.exception:
+        raise error from last_failure.exception
+    raise error
 
 
 def _get_fence_validation_block_expiration() -> int:
@@ -673,13 +689,19 @@ def _timed_perform_external_group_sync(
                 cumulative_upsert_time += time.monotonic() - upsert_start
         except Exception as e:
             format_error_for_logging(e)
+            full_exception_trace = (
+                e.full_exception_trace
+                if isinstance(e, ExternalGroupSyncFailureThresholdError)
+                and e.full_exception_trace
+                else traceback.format_exc()
+            )
 
             # Mark as failed (this also updates progress to show partial progress)
             mark_external_group_sync_attempt_failed(
                 attempt_id,
                 db_session,
                 error_message=str(e),
-                full_exception_trace=traceback.format_exc(),
+                full_exception_trace=full_exception_trace,
             )
 
             # TODO: add some notification to the admins here

--- a/backend/ee/onyx/db/external_perm.py
+++ b/backend/ee/onyx/db/external_perm.py
@@ -2,6 +2,7 @@ from collections.abc import Sequence
 from uuid import UUID
 
 from pydantic import BaseModel
+from pydantic import Field
 from sqlalchemy import delete
 from sqlalchemy import select
 from sqlalchemy import update
@@ -29,6 +30,16 @@ class ExternalUserGroup(BaseModel):
     # When this is `True`, this `ExternalUserGroup` object doesn't really represent
     # an actual "group" in the source.
     gives_anyone_access: bool = False
+
+
+class ExternalGroupSyncFailure(BaseModel):
+    external_group_id: str | None = None
+    external_group_name: str | None = None
+    failure_message: str
+    full_exception_trace: str | None = None
+    exception: Exception | None = Field(default=None, exclude=True)
+
+    model_config = {"arbitrary_types_allowed": True}
 
 
 def delete_user__ext_group_for_user__no_commit(

--- a/backend/ee/onyx/external_permissions/confluence/group_sync.py
+++ b/backend/ee/onyx/external_permissions/confluence/group_sync.py
@@ -1,5 +1,7 @@
+from collections.abc import Callable
 from collections.abc import Generator
 
+from ee.onyx.db.external_perm import ExternalGroupSyncFailure
 from ee.onyx.db.external_perm import ExternalUserGroup
 from ee.onyx.external_permissions.confluence.constants import ALL_CONF_EMAILS_GROUP_NAME
 from onyx.background.error_logging import emit_background_error
@@ -160,6 +162,7 @@ def _build_final_group_to_member_email_map(
 def confluence_group_sync(
     tenant_id: str,
     cc_pair: ConnectorCredentialPair,
+    record_group_sync_failure: Callable[[ExternalGroupSyncFailure], None],  # noqa: ARG001
 ) -> Generator[ExternalUserGroup, None, None]:
     provider = OnyxDBCredentialsProvider(tenant_id, "confluence", cc_pair.credential_id)
     is_cloud = cc_pair.connector.connector_specific_config.get("is_cloud", False)

--- a/backend/ee/onyx/external_permissions/github/group_sync.py
+++ b/backend/ee/onyx/external_permissions/github/group_sync.py
@@ -1,4 +1,3 @@
-import traceback
 from collections.abc import Callable
 from collections.abc import Generator
 
@@ -17,7 +16,7 @@ logger = setup_logger()
 def github_group_sync(
     tenant_id: str,  # noqa: ARG001
     cc_pair: ConnectorCredentialPair,
-    record_group_sync_failure: Callable[[ExternalGroupSyncFailure], None],
+    record_group_sync_failure: Callable[[ExternalGroupSyncFailure], None],  # noqa: ARG001
 ) -> Generator[ExternalUserGroup, None, None]:
     github_connector: GithubConnector = GithubConnector(
         **cc_pair.connector.connector_specific_config
@@ -45,22 +44,8 @@ def github_group_sync(
         repos = github_connector.get_all_repos(github_connector.github_client)
 
     for repo in repos:
-        try:
-            for external_group in get_external_user_group(
-                repo, github_connector.github_client
-            ):
-                logger.info("External group: %s", external_group)
-                yield external_group
-        except Exception as e:
-            logger.warning(
-                "Error processing repository %s (%s): %s", repo.id, repo.name, e
-            )
-            record_group_sync_failure(
-                ExternalGroupSyncFailure(
-                    external_group_id=str(repo.id),
-                    external_group_name=repo.name,
-                    failure_message=str(e),
-                    full_exception_trace=traceback.format_exc(),
-                    exception=e,
-                )
-            )
+        for external_group in get_external_user_group(
+            repo, github_connector.github_client
+        ):
+            logger.info("External group: %s", external_group)
+            yield external_group

--- a/backend/ee/onyx/external_permissions/github/group_sync.py
+++ b/backend/ee/onyx/external_permissions/github/group_sync.py
@@ -1,7 +1,9 @@
+import traceback
 from collections.abc import Generator
 
 from github import Repository
 
+from ee.onyx.db.external_perm import ExternalGroupSyncFailure
 from ee.onyx.db.external_perm import ExternalUserGroup
 from ee.onyx.external_permissions.github.utils import get_external_user_group
 from onyx.connectors.github.connector import GithubConnector
@@ -14,7 +16,7 @@ logger = setup_logger()
 def github_group_sync(
     tenant_id: str,  # noqa: ARG001
     cc_pair: ConnectorCredentialPair,
-) -> Generator[ExternalUserGroup, None, None]:
+) -> Generator[ExternalUserGroup | ExternalGroupSyncFailure, None, None]:
     github_connector: GithubConnector = GithubConnector(
         **cc_pair.connector.connector_specific_config
     )
@@ -48,6 +50,13 @@ def github_group_sync(
                 logger.info("External group: %s", external_group)
                 yield external_group
         except Exception as e:
-            logger.error(
+            logger.warning(
                 "Error processing repository %s (%s): %s", repo.id, repo.name, e
+            )
+            yield ExternalGroupSyncFailure(
+                external_group_id=str(repo.id),
+                external_group_name=repo.name,
+                failure_message=str(e),
+                full_exception_trace=traceback.format_exc(),
+                exception=e,
             )

--- a/backend/ee/onyx/external_permissions/github/group_sync.py
+++ b/backend/ee/onyx/external_permissions/github/group_sync.py
@@ -1,4 +1,5 @@
 import traceback
+from collections.abc import Callable
 from collections.abc import Generator
 
 from github import Repository
@@ -16,7 +17,8 @@ logger = setup_logger()
 def github_group_sync(
     tenant_id: str,  # noqa: ARG001
     cc_pair: ConnectorCredentialPair,
-) -> Generator[ExternalUserGroup | ExternalGroupSyncFailure, None, None]:
+    record_group_sync_failure: Callable[[ExternalGroupSyncFailure], None],
+) -> Generator[ExternalUserGroup, None, None]:
     github_connector: GithubConnector = GithubConnector(
         **cc_pair.connector.connector_specific_config
     )
@@ -53,10 +55,12 @@ def github_group_sync(
             logger.warning(
                 "Error processing repository %s (%s): %s", repo.id, repo.name, e
             )
-            yield ExternalGroupSyncFailure(
-                external_group_id=str(repo.id),
-                external_group_name=repo.name,
-                failure_message=str(e),
-                full_exception_trace=traceback.format_exc(),
-                exception=e,
+            record_group_sync_failure(
+                ExternalGroupSyncFailure(
+                    external_group_id=str(repo.id),
+                    external_group_name=repo.name,
+                    failure_message=str(e),
+                    full_exception_trace=traceback.format_exc(),
+                    exception=e,
+                )
             )

--- a/backend/ee/onyx/external_permissions/google_drive/group_sync.py
+++ b/backend/ee/onyx/external_permissions/google_drive/group_sync.py
@@ -1,4 +1,5 @@
 import traceback
+from collections.abc import Callable
 from collections.abc import Generator
 
 from googleapiclient.errors import HttpError
@@ -422,7 +423,8 @@ def _build_onyx_groups(
 def gdrive_group_sync(
     tenant_id: str,  # noqa: ARG001
     cc_pair: ConnectorCredentialPair,
-) -> Generator[ExternalUserGroup | ExternalGroupSyncFailure, None, None]:
+    record_group_sync_failure: Callable[[ExternalGroupSyncFailure], None],
+) -> Generator[ExternalUserGroup, None, None]:
     # Initialize connector and build credential/service objects
     google_drive_connector = GoogleDriveConnector(
         **cc_pair.connector.connector_specific_config
@@ -456,12 +458,14 @@ def gdrive_group_sync(
                 group_email,
                 e,
             )
-            yield ExternalGroupSyncFailure(
-                external_group_id=group_email,
-                external_group_name=group_email,
-                failure_message=str(e),
-                full_exception_trace=traceback.format_exc(),
-                exception=e,
+            record_group_sync_failure(
+                ExternalGroupSyncFailure(
+                    external_group_id=group_email,
+                    external_group_name=group_email,
+                    failure_message=str(e),
+                    full_exception_trace=traceback.format_exc(),
+                    exception=e,
+                )
             )
             continue
 

--- a/backend/ee/onyx/external_permissions/google_drive/group_sync.py
+++ b/backend/ee/onyx/external_permissions/google_drive/group_sync.py
@@ -1,8 +1,10 @@
+import traceback
 from collections.abc import Generator
 
 from googleapiclient.errors import HttpError
 from pydantic import BaseModel
 
+from ee.onyx.db.external_perm import ExternalGroupSyncFailure
 from ee.onyx.db.external_perm import ExternalUserGroup
 from ee.onyx.external_permissions.google_drive.folder_retrieval import (
     get_folder_permissions_by_ids,
@@ -420,7 +422,7 @@ def _build_onyx_groups(
 def gdrive_group_sync(
     tenant_id: str,  # noqa: ARG001
     cc_pair: ConnectorCredentialPair,
-) -> Generator[ExternalUserGroup, None, None]:
+) -> Generator[ExternalUserGroup | ExternalGroupSyncFailure, None, None]:
     # Initialize connector and build credential/service objects
     google_drive_connector = GoogleDriveConnector(
         **cc_pair.connector.connector_specific_config
@@ -446,7 +448,23 @@ def gdrive_group_sync(
     # Each google group is an Onyx group, yield those
     group_email_to_member_emails_map: dict[str, list[str]] = {}
     for group_email in all_group_emails:
-        onyx_group = _google_group_to_onyx_group(admin_service, group_email)
+        try:
+            onyx_group = _google_group_to_onyx_group(admin_service, group_email)
+        except Exception as e:
+            logger.warning(
+                "Skipping Google group %s after member sync failure: %s",
+                group_email,
+                e,
+            )
+            yield ExternalGroupSyncFailure(
+                external_group_id=group_email,
+                external_group_name=group_email,
+                failure_message=str(e),
+                full_exception_trace=traceback.format_exc(),
+                exception=e,
+            )
+            continue
+
         group_email_to_member_emails_map[group_email] = onyx_group.user_emails
         yield onyx_group
 

--- a/backend/ee/onyx/external_permissions/jira/group_sync.py
+++ b/backend/ee/onyx/external_permissions/jira/group_sync.py
@@ -1,9 +1,11 @@
+import traceback
 from collections.abc import Generator
 from typing import Any
 
 from jira import JIRA
 from jira.exceptions import JIRAError
 
+from ee.onyx.db.external_perm import ExternalGroupSyncFailure
 from ee.onyx.db.external_perm import ExternalUserGroup
 from onyx.connectors.jira.utils import build_jira_client
 from onyx.db.models import ConnectorCredentialPair
@@ -13,10 +15,6 @@ logger = setup_logger()
 
 _ATLASSIAN_ACCOUNT_TYPE = "atlassian"
 _GROUP_MEMBER_PAGE_SIZE = 50
-
-# The GET /group/member endpoint was introduced in Jira 6.0.
-# Jira versions older than 6.0 do not have group management REST APIs at all.
-_MIN_JIRA_VERSION_FOR_GROUP_MEMBER = "6.0"
 
 
 def _fetch_group_member_page(
@@ -48,10 +46,9 @@ def _fetch_group_member_page(
     except JIRAError as e:
         if e.status_code == 404:
             raise RuntimeError(
-                f"GET /group/member returned 404 for group '{group_name}'. "
-                f"This endpoint requires Jira {_MIN_JIRA_VERSION_FOR_GROUP_MEMBER}+. "
-                f"If you are running a self-hosted Jira instance, please upgrade "
-                f"to at least Jira {_MIN_JIRA_VERSION_FOR_GROUP_MEMBER}."
+                f"Jira listed group '{group_name}', but GET /group/member could "
+                "not find it. The group may have been renamed, deleted, or "
+                "returned with a non-canonical name."
             ) from e
         raise
 
@@ -70,11 +67,7 @@ def _get_group_member_emails(
     start_at = 0
 
     while True:
-        try:
-            page = _fetch_group_member_page(jira_client, group_name, start_at)
-        except Exception as e:
-            logger.error("Error fetching members for group %s: %s", group_name, e)
-            raise
+        page = _fetch_group_member_page(jira_client, group_name, start_at)
 
         members: list[dict[str, Any]] = page.get("values", [])
         for member in members:
@@ -104,7 +97,7 @@ def _get_group_member_emails(
 def jira_group_sync(
     tenant_id: str,  # noqa: ARG001
     cc_pair: ConnectorCredentialPair,
-) -> Generator[ExternalUserGroup, None, None]:
+) -> Generator[ExternalUserGroup | ExternalGroupSyncFailure, None, None]:
     """Sync Jira groups and their members, yielding one group at a time.
 
     Streams group-by-group rather than accumulating all groups in memory.
@@ -138,10 +131,26 @@ def jira_group_sync(
         if not group_name:
             continue
 
-        member_emails = _get_group_member_emails(
-            jira_client=jira_client,
-            group_name=group_name,
-        )
+        try:
+            member_emails = _get_group_member_emails(
+                jira_client=jira_client,
+                group_name=group_name,
+            )
+        except Exception as e:
+            logger.warning(
+                "Skipping Jira group %s after member sync failure: %s",
+                group_name,
+                e,
+            )
+            yield ExternalGroupSyncFailure(
+                external_group_id=group_name,
+                external_group_name=group_name,
+                failure_message=str(e),
+                full_exception_trace=traceback.format_exc(),
+                exception=e,
+            )
+            continue
+
         if not member_emails:
             logger.debug("No members found for group %s", group_name)
             continue

--- a/backend/ee/onyx/external_permissions/jira/group_sync.py
+++ b/backend/ee/onyx/external_permissions/jira/group_sync.py
@@ -1,4 +1,5 @@
 import traceback
+from collections.abc import Callable
 from collections.abc import Generator
 from typing import Any
 
@@ -97,7 +98,8 @@ def _get_group_member_emails(
 def jira_group_sync(
     tenant_id: str,  # noqa: ARG001
     cc_pair: ConnectorCredentialPair,
-) -> Generator[ExternalUserGroup | ExternalGroupSyncFailure, None, None]:
+    record_group_sync_failure: Callable[[ExternalGroupSyncFailure], None],
+) -> Generator[ExternalUserGroup, None, None]:
     """Sync Jira groups and their members, yielding one group at a time.
 
     Streams group-by-group rather than accumulating all groups in memory.
@@ -142,12 +144,14 @@ def jira_group_sync(
                 group_name,
                 e,
             )
-            yield ExternalGroupSyncFailure(
-                external_group_id=group_name,
-                external_group_name=group_name,
-                failure_message=str(e),
-                full_exception_trace=traceback.format_exc(),
-                exception=e,
+            record_group_sync_failure(
+                ExternalGroupSyncFailure(
+                    external_group_id=group_name,
+                    external_group_name=group_name,
+                    failure_message=str(e),
+                    full_exception_trace=traceback.format_exc(),
+                    exception=e,
+                )
             )
             continue
 

--- a/backend/ee/onyx/external_permissions/jira/group_sync.py
+++ b/backend/ee/onyx/external_permissions/jira/group_sync.py
@@ -17,6 +17,10 @@ logger = setup_logger()
 _ATLASSIAN_ACCOUNT_TYPE = "atlassian"
 _GROUP_MEMBER_PAGE_SIZE = 50
 
+# The GET /group/member endpoint was introduced in Jira 6.0.
+# Jira versions older than 6.0 do not have group management REST APIs at all.
+_MIN_JIRA_VERSION_FOR_GROUP_MEMBER = "6.0"
+
 
 def _fetch_group_member_page(
     jira_client: JIRA,
@@ -47,9 +51,10 @@ def _fetch_group_member_page(
     except JIRAError as e:
         if e.status_code == 404:
             raise RuntimeError(
-                f"Jira listed group '{group_name}', but GET /group/member could "
-                "not find it. The group may have been renamed, deleted, or "
-                "returned with a non-canonical name."
+                f"GET /group/member returned 404 for group '{group_name}'. "
+                f"This endpoint requires Jira {_MIN_JIRA_VERSION_FOR_GROUP_MEMBER}+. "
+                "If you are running a self-hosted Jira instance, please upgrade "
+                f"to at least Jira {_MIN_JIRA_VERSION_FOR_GROUP_MEMBER}."
             ) from e
         raise
 

--- a/backend/ee/onyx/external_permissions/perm_sync_types.py
+++ b/backend/ee/onyx/external_permissions/perm_sync_types.py
@@ -59,12 +59,15 @@ DocSyncFuncType = Callable[
     Generator[ElementExternalAccess, None, None],
 ]
 
+ExternalGroupFailureCallback = Callable[[ExternalGroupSyncFailure], None]
+
 GroupSyncFuncType = Callable[
     [
         str,  # tenant_id
         ConnectorCredentialPair,  # cc_pair
+        ExternalGroupFailureCallback,  # record_group_sync_failure
     ],
-    Generator[ExternalUserGroup | ExternalGroupSyncFailure, None, None],
+    Generator[ExternalUserGroup, None, None],
 ]
 
 # list of chunks to be censored and the user email. returns censored chunks

--- a/backend/ee/onyx/external_permissions/perm_sync_types.py
+++ b/backend/ee/onyx/external_permissions/perm_sync_types.py
@@ -3,6 +3,7 @@ from collections.abc import Generator
 from typing import Optional
 from typing import Protocol
 
+from ee.onyx.db.external_perm import ExternalGroupSyncFailure  # noqa
 from ee.onyx.db.external_perm import ExternalUserGroup  # noqa
 from onyx.access.models import DocExternalAccess  # noqa
 from onyx.access.models import ElementExternalAccess  # noqa
@@ -63,7 +64,7 @@ GroupSyncFuncType = Callable[
         str,  # tenant_id
         ConnectorCredentialPair,  # cc_pair
     ],
-    Generator[ExternalUserGroup, None, None],
+    Generator[ExternalUserGroup | ExternalGroupSyncFailure, None, None],
 ]
 
 # list of chunks to be censored and the user email. returns censored chunks

--- a/backend/ee/onyx/external_permissions/sharepoint/group_sync.py
+++ b/backend/ee/onyx/external_permissions/sharepoint/group_sync.py
@@ -1,4 +1,3 @@
-import traceback
 from collections.abc import Callable
 from collections.abc import Generator
 
@@ -61,37 +60,18 @@ def sharepoint_group_sync(
     for site_descriptor in site_descriptors:
         logger.debug("Processing site: %s", site_descriptor.url)
 
-        try:
-            ctx = ClientContext(site_descriptor.url).with_access_token(
-                lambda: acquire_token_for_rest(
-                    msal_app, sp_tenant_domain, sp_domain_suffix
-                )
-            )
+        ctx = ClientContext(site_descriptor.url).with_access_token(
+            lambda: acquire_token_for_rest(msal_app, sp_tenant_domain, sp_domain_suffix)
+        )
 
-            external_groups = get_sharepoint_external_groups(
-                ctx,
-                connector.graph_client,
-                graph_api_base=connector.graph_api_base,
-                record_group_sync_failure=record_group_sync_failure,
-                get_access_token=connector._get_graph_access_token,
-                enumerate_all_ad_groups=enumerate_all,
-            )
-        except Exception as e:
-            logger.warning(
-                "Skipping SharePoint site %s after group sync failure: %s",
-                site_descriptor.url,
-                e,
-            )
-            record_group_sync_failure(
-                ExternalGroupSyncFailure(
-                    external_group_id=site_descriptor.url,
-                    external_group_name=site_descriptor.url,
-                    failure_message=str(e),
-                    full_exception_trace=traceback.format_exc(),
-                    exception=e,
-                )
-            )
-            continue
+        external_groups = get_sharepoint_external_groups(
+            ctx,
+            connector.graph_client,
+            graph_api_base=connector.graph_api_base,
+            record_group_sync_failure=record_group_sync_failure,
+            get_access_token=connector._get_graph_access_token,
+            enumerate_all_ad_groups=enumerate_all,
+        )
 
         # Yield each group
         for group in external_groups:

--- a/backend/ee/onyx/external_permissions/sharepoint/group_sync.py
+++ b/backend/ee/onyx/external_permissions/sharepoint/group_sync.py
@@ -1,4 +1,5 @@
 import traceback
+from collections.abc import Callable
 from collections.abc import Generator
 
 from office365.sharepoint.client_context import ClientContext
@@ -20,7 +21,8 @@ logger = setup_logger()
 def sharepoint_group_sync(
     tenant_id: str,  # noqa: ARG001
     cc_pair: ConnectorCredentialPair,
-) -> Generator[ExternalUserGroup | ExternalGroupSyncFailure, None, None]:
+    record_group_sync_failure: Callable[[ExternalGroupSyncFailure], None],
+) -> Generator[ExternalUserGroup, None, None]:
     """Sync SharePoint groups and their members"""
 
     # Get site URLs from connector config
@@ -70,6 +72,7 @@ def sharepoint_group_sync(
                 ctx,
                 connector.graph_client,
                 graph_api_base=connector.graph_api_base,
+                record_group_sync_failure=record_group_sync_failure,
                 get_access_token=connector._get_graph_access_token,
                 enumerate_all_ad_groups=enumerate_all,
             )
@@ -79,21 +82,19 @@ def sharepoint_group_sync(
                 site_descriptor.url,
                 e,
             )
-            yield ExternalGroupSyncFailure(
-                external_group_id=site_descriptor.url,
-                external_group_name=site_descriptor.url,
-                failure_message=str(e),
-                full_exception_trace=traceback.format_exc(),
-                exception=e,
+            record_group_sync_failure(
+                ExternalGroupSyncFailure(
+                    external_group_id=site_descriptor.url,
+                    external_group_name=site_descriptor.url,
+                    failure_message=str(e),
+                    full_exception_trace=traceback.format_exc(),
+                    exception=e,
+                )
             )
             continue
 
         # Yield each group
         for group in external_groups:
-            if isinstance(group, ExternalGroupSyncFailure):
-                yield group
-                continue
-
             logger.debug(
                 "Found group: %s with %s members", group.id, len(group.user_emails)
             )

--- a/backend/ee/onyx/external_permissions/sharepoint/group_sync.py
+++ b/backend/ee/onyx/external_permissions/sharepoint/group_sync.py
@@ -1,7 +1,9 @@
+import traceback
 from collections.abc import Generator
 
 from office365.sharepoint.client_context import ClientContext
 
+from ee.onyx.db.external_perm import ExternalGroupSyncFailure
 from ee.onyx.db.external_perm import ExternalUserGroup
 from ee.onyx.external_permissions.sharepoint.permission_utils import (
     get_sharepoint_external_groups,
@@ -18,7 +20,7 @@ logger = setup_logger()
 def sharepoint_group_sync(
     tenant_id: str,  # noqa: ARG001
     cc_pair: ConnectorCredentialPair,
-) -> Generator[ExternalUserGroup, None, None]:
+) -> Generator[ExternalUserGroup | ExternalGroupSyncFailure, None, None]:
     """Sync SharePoint groups and their members"""
 
     # Get site URLs from connector config
@@ -57,20 +59,41 @@ def sharepoint_group_sync(
     for site_descriptor in site_descriptors:
         logger.debug("Processing site: %s", site_descriptor.url)
 
-        ctx = ClientContext(site_descriptor.url).with_access_token(
-            lambda: acquire_token_for_rest(msal_app, sp_tenant_domain, sp_domain_suffix)
-        )
+        try:
+            ctx = ClientContext(site_descriptor.url).with_access_token(
+                lambda: acquire_token_for_rest(
+                    msal_app, sp_tenant_domain, sp_domain_suffix
+                )
+            )
 
-        external_groups = get_sharepoint_external_groups(
-            ctx,
-            connector.graph_client,
-            graph_api_base=connector.graph_api_base,
-            get_access_token=connector._get_graph_access_token,
-            enumerate_all_ad_groups=enumerate_all,
-        )
+            external_groups = get_sharepoint_external_groups(
+                ctx,
+                connector.graph_client,
+                graph_api_base=connector.graph_api_base,
+                get_access_token=connector._get_graph_access_token,
+                enumerate_all_ad_groups=enumerate_all,
+            )
+        except Exception as e:
+            logger.warning(
+                "Skipping SharePoint site %s after group sync failure: %s",
+                site_descriptor.url,
+                e,
+            )
+            yield ExternalGroupSyncFailure(
+                external_group_id=site_descriptor.url,
+                external_group_name=site_descriptor.url,
+                failure_message=str(e),
+                full_exception_trace=traceback.format_exc(),
+                exception=e,
+            )
+            continue
 
         # Yield each group
         for group in external_groups:
+            if isinstance(group, ExternalGroupSyncFailure):
+                yield group
+                continue
+
             logger.debug(
                 "Found group: %s with %s members", group.id, len(group.user_emails)
             )

--- a/backend/ee/onyx/external_permissions/sharepoint/permission_utils.py
+++ b/backend/ee/onyx/external_permissions/sharepoint/permission_utils.py
@@ -1,5 +1,6 @@
 import re
 import time
+import traceback
 from collections import deque
 from collections.abc import Callable
 from collections.abc import Generator
@@ -16,6 +17,7 @@ from office365.sharepoint.permissions.securable_object import RoleAssignmentColl
 from office365.sharepoint.principal.users.collection import UserCollection
 from pydantic import BaseModel
 
+from ee.onyx.db.external_perm import ExternalGroupSyncFailure
 from ee.onyx.db.external_perm import ExternalUserGroup
 from onyx.access.models import ExternalAccess
 from onyx.access.utils import build_ext_group_name_for_onyx
@@ -692,7 +694,7 @@ def _enumerate_ad_groups_paginated(
     get_access_token: Callable[[], str],
     already_resolved: set[str],
     graph_api_base: str,
-) -> Generator[ExternalUserGroup, None, None]:
+) -> Generator[ExternalUserGroup | ExternalGroupSyncFailure, None, None]:
     """Paginate through all Azure AD groups and yield ExternalUserGroup for each.
 
     Skips groups whose suffixed name is already in *already_resolved*.
@@ -728,12 +730,27 @@ def _enumerate_ad_groups_paginated(
             "$select": "userPrincipalName,mail",
             "$top": "999",
         }
-        for member_json in _iter_graph_collection(
-            members_url, get_access_token, members_params
-        ):
-            email = member_json.get("userPrincipalName") or member_json.get("mail")
-            if email:
-                member_emails.append(_normalize_email(email))
+        try:
+            for member_json in _iter_graph_collection(
+                members_url, get_access_token, members_params
+            ):
+                email = member_json.get("userPrincipalName") or member_json.get("mail")
+                if email:
+                    member_emails.append(_normalize_email(email))
+        except Exception as e:
+            logger.warning(
+                "Skipping Azure AD group %s after member sync failure: %s",
+                name,
+                e,
+            )
+            yield ExternalGroupSyncFailure(
+                external_group_id=group_id,
+                external_group_name=name,
+                failure_message=str(e),
+                full_exception_trace=traceback.format_exc(),
+                exception=e,
+            )
+            continue
 
         yield ExternalUserGroup(id=name, user_emails=member_emails)
 
@@ -746,7 +763,7 @@ def get_sharepoint_external_groups(
     graph_api_base: str,
     get_access_token: Callable[[], str] | None = None,
     enumerate_all_ad_groups: bool = False,
-) -> list[ExternalUserGroup]:
+) -> list[ExternalUserGroup | ExternalGroupSyncFailure]:
     groups: set[SharepointGroup] = set()
 
     def add_group_to_sets(role_assignments: RoleAssignmentCollection) -> None:
@@ -804,7 +821,7 @@ def get_sharepoint_external_groups(
         client_context, graph_client, groups, is_group_sync=True
     )
 
-    external_user_groups: list[ExternalUserGroup] = [
+    external_user_groups: list[ExternalUserGroup | ExternalGroupSyncFailure] = [
         ExternalUserGroup(id=group_name, user_emails=list(emails))
         for group_name, emails in groups_and_members.groups_to_emails.items()
     ]

--- a/backend/ee/onyx/external_permissions/sharepoint/permission_utils.py
+++ b/backend/ee/onyx/external_permissions/sharepoint/permission_utils.py
@@ -694,7 +694,8 @@ def _enumerate_ad_groups_paginated(
     get_access_token: Callable[[], str],
     already_resolved: set[str],
     graph_api_base: str,
-) -> Generator[ExternalUserGroup | ExternalGroupSyncFailure, None, None]:
+    record_group_sync_failure: Callable[[ExternalGroupSyncFailure], None],
+) -> Generator[ExternalUserGroup, None, None]:
     """Paginate through all Azure AD groups and yield ExternalUserGroup for each.
 
     Skips groups whose suffixed name is already in *already_resolved*.
@@ -743,12 +744,14 @@ def _enumerate_ad_groups_paginated(
                 name,
                 e,
             )
-            yield ExternalGroupSyncFailure(
-                external_group_id=group_id,
-                external_group_name=name,
-                failure_message=str(e),
-                full_exception_trace=traceback.format_exc(),
-                exception=e,
+            record_group_sync_failure(
+                ExternalGroupSyncFailure(
+                    external_group_id=group_id,
+                    external_group_name=name,
+                    failure_message=str(e),
+                    full_exception_trace=traceback.format_exc(),
+                    exception=e,
+                )
             )
             continue
 
@@ -761,9 +764,10 @@ def get_sharepoint_external_groups(
     client_context: ClientContext,
     graph_client: GraphClient,
     graph_api_base: str,
+    record_group_sync_failure: Callable[[ExternalGroupSyncFailure], None],
     get_access_token: Callable[[], str] | None = None,
     enumerate_all_ad_groups: bool = False,
-) -> list[ExternalUserGroup | ExternalGroupSyncFailure]:
+) -> list[ExternalUserGroup]:
     groups: set[SharepointGroup] = set()
 
     def add_group_to_sets(role_assignments: RoleAssignmentCollection) -> None:
@@ -821,7 +825,7 @@ def get_sharepoint_external_groups(
         client_context, graph_client, groups, is_group_sync=True
     )
 
-    external_user_groups: list[ExternalUserGroup | ExternalGroupSyncFailure] = [
+    external_user_groups: list[ExternalUserGroup] = [
         ExternalUserGroup(id=group_name, user_emails=list(emails))
         for group_name, emails in groups_and_members.groups_to_emails.items()
     ]
@@ -834,7 +838,10 @@ def get_sharepoint_external_groups(
 
     already_resolved = set(groups_and_members.groups_to_emails.keys())
     for group in _enumerate_ad_groups_paginated(
-        get_access_token, already_resolved, graph_api_base
+        get_access_token,
+        already_resolved,
+        graph_api_base,
+        record_group_sync_failure,
     ):
         external_user_groups.append(group)
 

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5389,6 +5389,12 @@ class ExternalGroupPermissionSyncAttempt(Base):
         "ConnectorCredentialPair"
     )
 
+    error_rows: Mapped[list["ExternalGroupSyncError"]] = relationship(
+        "ExternalGroupSyncError",
+        back_populates="external_group_sync_attempt",
+        cascade="all, delete-orphan",
+    )
+
     __table_args__ = (
         Index(
             "ix_group_sync_attempt_cc_pair_time",
@@ -5407,6 +5413,45 @@ class ExternalGroupPermissionSyncAttempt(Base):
 
     def is_finished(self) -> bool:
         return self.status.is_terminal()
+
+
+class ExternalGroupSyncError(Base):
+    __tablename__ = "external_group_sync_errors"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+
+    external_group_sync_attempt_id: Mapped[int] = mapped_column(
+        ForeignKey("external_group_permission_sync_attempt.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    connector_credential_pair_id: Mapped[int] = mapped_column(
+        ForeignKey("connector_credential_pair.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    external_group_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    external_group_name: Mapped[str | None] = mapped_column(String, nullable=True)
+
+    failure_message: Mapped[str] = mapped_column(Text)
+    full_exception_trace: Mapped[str | None] = mapped_column(Text, default=None)
+    error_type: Mapped[str | None] = mapped_column(String, nullable=True)
+
+    time_created: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+    )
+
+    external_group_sync_attempt: Mapped[ExternalGroupPermissionSyncAttempt] = (
+        relationship(
+            "ExternalGroupPermissionSyncAttempt",
+            back_populates="error_rows",
+        )
+    )
+    connector_credential_pair: Mapped[ConnectorCredentialPair] = relationship(
+        "ConnectorCredentialPair"
+    )
 
 
 class License(Base):

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5425,9 +5425,9 @@ class ExternalGroupSyncError(Base):
         nullable=False,
         index=True,
     )
-    connector_credential_pair_id: Mapped[int] = mapped_column(
+    connector_credential_pair_id: Mapped[int | None] = mapped_column(
         ForeignKey("connector_credential_pair.id", ondelete="CASCADE"),
-        nullable=False,
+        nullable=True,
         index=True,
     )
 
@@ -5449,7 +5449,7 @@ class ExternalGroupSyncError(Base):
             back_populates="error_rows",
         )
     )
-    connector_credential_pair: Mapped[ConnectorCredentialPair] = relationship(
+    connector_credential_pair: Mapped[ConnectorCredentialPair | None] = relationship(
         "ConnectorCredentialPair"
     )
 

--- a/backend/onyx/db/permission_sync_attempt.py
+++ b/backend/onyx/db/permission_sync_attempt.py
@@ -20,6 +20,7 @@ from onyx.db.models import Connector
 from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import DocPermissionSyncAttempt
 from onyx.db.models import ExternalGroupPermissionSyncAttempt
+from onyx.db.models import ExternalGroupSyncError
 from onyx.utils.logger import setup_logger
 from onyx.utils.telemetry import optional_telemetry
 from onyx.utils.telemetry import RecordType
@@ -464,6 +465,67 @@ def mark_external_group_sync_attempt_failed(
     except Exception:
         db_session.rollback()
         raise
+
+
+def create_external_group_sync_error(
+    external_group_sync_attempt_id: int,
+    connector_credential_pair_id: int,
+    db_session: Session,
+    failure_message: str,
+    external_group_id: str | None = None,
+    external_group_name: str | None = None,
+    full_exception_trace: str | None = None,
+    error_type: str | None = None,
+) -> int:
+    error = ExternalGroupSyncError(
+        external_group_sync_attempt_id=external_group_sync_attempt_id,
+        connector_credential_pair_id=connector_credential_pair_id,
+        external_group_id=external_group_id,
+        external_group_name=external_group_name,
+        failure_message=failure_message,
+        full_exception_trace=full_exception_trace,
+        error_type=error_type,
+    )
+    db_session.add(error)
+    db_session.commit()
+
+    return error.id
+
+
+def count_external_group_sync_errors_for_attempt(
+    external_group_sync_attempt_id: int,
+    db_session: Session,
+) -> int:
+    result = db_session.scalar(
+        select(func.count())
+        .select_from(ExternalGroupSyncError)
+        .where(
+            ExternalGroupSyncError.external_group_sync_attempt_id
+            == external_group_sync_attempt_id
+        )
+    )
+    return 0 if result is None else result
+
+
+def get_external_group_sync_errors_for_attempt(
+    external_group_sync_attempt_id: int,
+    db_session: Session,
+    page: int | None = None,
+    page_size: int | None = None,
+) -> list[ExternalGroupSyncError]:
+    stmt = (
+        select(ExternalGroupSyncError)
+        .where(
+            ExternalGroupSyncError.external_group_sync_attempt_id
+            == external_group_sync_attempt_id
+        )
+        .order_by(ExternalGroupSyncError.time_created.desc())
+    )
+
+    if page is not None and page_size is not None:
+        stmt = stmt.offset(page * page_size).limit(page_size)
+
+    return list(db_session.scalars(stmt).all())
 
 
 def complete_external_group_sync_attempt(

--- a/backend/onyx/db/permission_sync_attempt.py
+++ b/backend/onyx/db/permission_sync_attempt.py
@@ -507,6 +507,25 @@ def count_external_group_sync_errors_for_attempt(
     return 0 if result is None else result
 
 
+def get_error_counts_for_external_group_sync_attempts(
+    external_group_sync_attempt_ids: list[int],
+    db_session: Session,
+) -> dict[int, int]:
+    if not external_group_sync_attempt_ids:
+        return {}
+
+    stmt = (
+        select(ExternalGroupSyncError.external_group_sync_attempt_id, func.count())
+        .where(
+            ExternalGroupSyncError.external_group_sync_attempt_id.in_(
+                external_group_sync_attempt_ids
+            )
+        )
+        .group_by(ExternalGroupSyncError.external_group_sync_attempt_id)
+    )
+    return {attempt_id: count for attempt_id, count in db_session.execute(stmt).all()}
+
+
 def get_external_group_sync_errors_for_attempt(
     external_group_sync_attempt_id: int,
     db_session: Session,

--- a/backend/onyx/db/permission_sync_attempt.py
+++ b/backend/onyx/db/permission_sync_attempt.py
@@ -469,7 +469,7 @@ def mark_external_group_sync_attempt_failed(
 
 def create_external_group_sync_error(
     external_group_sync_attempt_id: int,
-    connector_credential_pair_id: int,
+    connector_credential_pair_id: int | None,
     db_session: Session,
     failure_message: str,
     external_group_id: str | None = None,

--- a/backend/onyx/server/documents/cc_pair.py
+++ b/backend/onyx/server/documents/cc_pair.py
@@ -358,6 +358,7 @@ def get_cc_pair_external_group_sync_attempts(
     start_idx = page_num * page_size
     end_idx = start_idx + page_size
     attempts = all_attempts[start_idx:end_idx]
+    # Count in SQL so listing attempts does not materialize every error row.
     error_counts = get_error_counts_for_external_group_sync_attempts(
         external_group_sync_attempt_ids=[attempt.id for attempt in attempts],
         db_session=db_session,

--- a/backend/onyx/server/documents/cc_pair.py
+++ b/backend/onyx/server/documents/cc_pair.py
@@ -53,6 +53,9 @@ from onyx.db.index_attempt_metrics import get_stage_metrics_for_attempt
 from onyx.db.indexing_coordination import IndexingCoordination
 from onyx.db.models import IndexAttempt
 from onyx.db.models import User
+from onyx.db.permission_sync_attempt import count_external_group_sync_errors_for_attempt
+from onyx.db.permission_sync_attempt import get_external_group_sync_attempt
+from onyx.db.permission_sync_attempt import get_external_group_sync_errors_for_attempt
 from onyx.db.permission_sync_attempt import (
     get_latest_doc_permission_sync_attempt_for_cc_pair,
 )
@@ -77,6 +80,7 @@ from onyx.server.documents.models import ConnectorCredentialPairMetadata
 from onyx.server.documents.models import DocPermissionSyncAttemptSnapshot
 from onyx.server.documents.models import DocumentSyncStatus
 from onyx.server.documents.models import ExternalGroupSyncAttemptSnapshot
+from onyx.server.documents.models import ExternalGroupSyncErrorSnapshot
 from onyx.server.documents.models import IndexAttemptSnapshot
 from onyx.server.documents.models import IndexAttemptStageMetricSnapshot
 from onyx.server.documents.models import IndexAttemptStageMetricsResponse
@@ -225,6 +229,34 @@ def _get_cc_pair_source_or_raise(
     return cc_pair.connector.source
 
 
+def _external_group_sync_attempt_is_relevant_to_cc_pair(
+    attempt_id: int,
+    cc_pair_id: int,
+    source: DocumentSource,
+    db_session: Session,
+) -> bool:
+    attempt = get_external_group_sync_attempt(
+        db_session=db_session,
+        attempt_id=attempt_id,
+        eager_load_connector=True,
+    )
+    if attempt is None or attempt.connector_credential_pair is None:
+        return False
+
+    if attempt.connector_credential_pair_id == cc_pair_id:
+        return True
+
+    source_group_sync_is_cc_pair_agnostic = fetch_ee_implementation_or_noop(
+        "onyx.external_permissions.sync_params",
+        "source_group_sync_is_cc_pair_agnostic",
+        noop_return_value=False,
+    )
+    if not source_group_sync_is_cc_pair_agnostic(source):
+        return False
+
+    return attempt.connector_credential_pair.connector.source == source
+
+
 @router.get("/admin/cc-pair/{cc_pair_id}/permission-sync-attempts")
 def get_cc_pair_permission_sync_attempts(
     cc_pair_id: int,
@@ -321,6 +353,51 @@ def get_cc_pair_external_group_sync_attempts(
             for attempt in all_attempts[start_idx:end_idx]
         ],
         total_items=len(all_attempts),
+    )
+
+
+@router.get(
+    "/admin/cc-pair/{cc_pair_id}/external-group-sync-attempts/{attempt_id}/errors"
+)
+def get_cc_pair_external_group_sync_attempt_errors(
+    cc_pair_id: int,
+    attempt_id: int,
+    page_num: int = Query(0, ge=0),
+    page_size: int = Query(10, ge=1, le=100),
+    user: User = Depends(current_curator_or_admin_user),
+    db_session: Session = Depends(get_session),
+) -> PaginatedReturn[ExternalGroupSyncErrorSnapshot]:
+    source = _get_cc_pair_source_or_raise(cc_pair_id, user, db_session)
+    if not _external_group_sync_attempt_is_relevant_to_cc_pair(
+        attempt_id=attempt_id,
+        cc_pair_id=cc_pair_id,
+        source=source,
+        db_session=db_session,
+    ):
+        raise OnyxError(
+            OnyxErrorCode.NOT_FOUND,
+            "External group sync attempt not found for current user permissions",
+        )
+
+    total_count = count_external_group_sync_errors_for_attempt(
+        external_group_sync_attempt_id=attempt_id,
+        db_session=db_session,
+    )
+    errors = get_external_group_sync_errors_for_attempt(
+        external_group_sync_attempt_id=attempt_id,
+        db_session=db_session,
+        page=page_num,
+        page_size=page_size,
+    )
+
+    return PaginatedReturn(
+        items=[
+            ExternalGroupSyncErrorSnapshot.from_external_group_sync_error_db_model(
+                error
+            )
+            for error in errors
+        ],
+        total_items=total_count,
     )
 
 

--- a/backend/onyx/server/documents/cc_pair.py
+++ b/backend/onyx/server/documents/cc_pair.py
@@ -54,6 +54,9 @@ from onyx.db.indexing_coordination import IndexingCoordination
 from onyx.db.models import IndexAttempt
 from onyx.db.models import User
 from onyx.db.permission_sync_attempt import count_external_group_sync_errors_for_attempt
+from onyx.db.permission_sync_attempt import (
+    get_error_counts_for_external_group_sync_attempts,
+)
 from onyx.db.permission_sync_attempt import get_external_group_sync_attempt
 from onyx.db.permission_sync_attempt import get_external_group_sync_errors_for_attempt
 from onyx.db.permission_sync_attempt import (
@@ -354,13 +357,19 @@ def get_cc_pair_external_group_sync_attempts(
     )
     start_idx = page_num * page_size
     end_idx = start_idx + page_size
+    attempts = all_attempts[start_idx:end_idx]
+    error_counts = get_error_counts_for_external_group_sync_attempts(
+        external_group_sync_attempt_ids=[attempt.id for attempt in attempts],
+        db_session=db_session,
+    )
     return CCPairSyncAttemptsResponse[ExternalGroupSyncAttemptSnapshot](
         applicable=True,
         items=[
             ExternalGroupSyncAttemptSnapshot.from_external_group_sync_attempt_db_model(
-                attempt
+                attempt,
+                error_count=error_counts.get(attempt.id, 0),
             )
-            for attempt in all_attempts[start_idx:end_idx]
+            for attempt in attempts
         ],
         total_items=len(all_attempts),
     )

--- a/backend/onyx/server/documents/cc_pair.py
+++ b/backend/onyx/server/documents/cc_pair.py
@@ -229,32 +229,42 @@ def _get_cc_pair_source_or_raise(
     return cc_pair.connector.source
 
 
-def _external_group_sync_attempt_is_relevant_to_cc_pair(
-    attempt_id: int,
+def _check_user_has_access_to_external_group_sync_attempt_errors(
+    user: User,
     cc_pair_id: int,
-    source: DocumentSource,
+    attempt_id: int,
     db_session: Session,
-) -> bool:
+) -> None:
+    source = _get_cc_pair_source_or_raise(cc_pair_id, user, db_session)
     attempt = get_external_group_sync_attempt(
         db_session=db_session,
         attempt_id=attempt_id,
         eager_load_connector=True,
     )
     if attempt is None or attempt.connector_credential_pair is None:
-        return False
+        raise OnyxError(
+            OnyxErrorCode.NOT_FOUND,
+            "External group sync attempt not found for current user permissions",
+        )
 
     if attempt.connector_credential_pair_id == cc_pair_id:
-        return True
+        return
 
     source_group_sync_is_cc_pair_agnostic = fetch_ee_implementation_or_noop(
         "onyx.external_permissions.sync_params",
         "source_group_sync_is_cc_pair_agnostic",
         noop_return_value=False,
     )
-    if not source_group_sync_is_cc_pair_agnostic(source):
-        return False
+    if (
+        source_group_sync_is_cc_pair_agnostic(source)
+        and attempt.connector_credential_pair.connector.source == source
+    ):
+        return
 
-    return attempt.connector_credential_pair.connector.source == source
+    raise OnyxError(
+        OnyxErrorCode.NOT_FOUND,
+        "External group sync attempt not found for current user permissions",
+    )
 
 
 @router.get("/admin/cc-pair/{cc_pair_id}/permission-sync-attempts")
@@ -367,17 +377,12 @@ def get_cc_pair_external_group_sync_attempt_errors(
     user: User = Depends(current_curator_or_admin_user),
     db_session: Session = Depends(get_session),
 ) -> PaginatedReturn[ExternalGroupSyncErrorSnapshot]:
-    source = _get_cc_pair_source_or_raise(cc_pair_id, user, db_session)
-    if not _external_group_sync_attempt_is_relevant_to_cc_pair(
-        attempt_id=attempt_id,
+    _check_user_has_access_to_external_group_sync_attempt_errors(
+        user=user,
         cc_pair_id=cc_pair_id,
-        source=source,
+        attempt_id=attempt_id,
         db_session=db_session,
-    ):
-        raise OnyxError(
-            OnyxErrorCode.NOT_FOUND,
-            "External group sync attempt not found for current user permissions",
-        )
+    )
 
     total_count = count_external_group_sync_errors_for_attempt(
         external_group_sync_attempt_id=attempt_id,

--- a/backend/onyx/server/documents/models.py
+++ b/backend/onyx/server/documents/models.py
@@ -422,7 +422,7 @@ class ExternalGroupSyncAttemptSnapshot(BaseModel):
 class ExternalGroupSyncErrorSnapshot(BaseModel):
     id: int
     external_group_sync_attempt_id: int
-    connector_credential_pair_id: int
+    connector_credential_pair_id: int | None
     external_group_id: str | None
     external_group_name: str | None
     failure_message: str

--- a/backend/onyx/server/documents/models.py
+++ b/backend/onyx/server/documents/models.py
@@ -27,6 +27,7 @@ from onyx.db.models import Credential
 from onyx.db.models import DocPermissionSyncAttempt
 from onyx.db.models import Document as DbDocument
 from onyx.db.models import ExternalGroupPermissionSyncAttempt
+from onyx.db.models import ExternalGroupSyncError
 from onyx.db.models import IndexAttempt
 from onyx.db.models import IndexAttemptStageMetric
 from onyx.db.models import IndexingStatus
@@ -388,6 +389,7 @@ class ExternalGroupSyncAttemptSnapshot(BaseModel):
     total_users_processed: int
     total_groups_processed: int
     total_group_memberships_synced: int
+    error_count: int
     time_created: str
     time_started: str | None
     time_finished: str | None
@@ -404,6 +406,7 @@ class ExternalGroupSyncAttemptSnapshot(BaseModel):
             total_users_processed=attempt.total_users_processed or 0,
             total_groups_processed=attempt.total_groups_processed or 0,
             total_group_memberships_synced=attempt.total_group_memberships_synced or 0,
+            error_count=len(attempt.error_rows),
             time_created=attempt.time_created.isoformat(),
             time_started=(
                 attempt.time_started.isoformat() if attempt.time_started else None
@@ -411,6 +414,34 @@ class ExternalGroupSyncAttemptSnapshot(BaseModel):
             time_finished=(
                 attempt.time_finished.isoformat() if attempt.time_finished else None
             ),
+        )
+
+
+class ExternalGroupSyncErrorSnapshot(BaseModel):
+    id: int
+    external_group_sync_attempt_id: int
+    connector_credential_pair_id: int
+    external_group_id: str | None
+    external_group_name: str | None
+    failure_message: str
+    full_exception_trace: str | None
+    error_type: str | None
+    time_created: str
+
+    @classmethod
+    def from_external_group_sync_error_db_model(
+        cls, error: ExternalGroupSyncError
+    ) -> "ExternalGroupSyncErrorSnapshot":
+        return ExternalGroupSyncErrorSnapshot(
+            id=error.id,
+            external_group_sync_attempt_id=error.external_group_sync_attempt_id,
+            connector_credential_pair_id=error.connector_credential_pair_id,
+            external_group_id=error.external_group_id,
+            external_group_name=error.external_group_name,
+            failure_message=error.failure_message,
+            full_exception_trace=error.full_exception_trace,
+            error_type=error.error_type,
+            time_created=error.time_created.isoformat(),
         )
 
 

--- a/backend/onyx/server/documents/models.py
+++ b/backend/onyx/server/documents/models.py
@@ -396,7 +396,9 @@ class ExternalGroupSyncAttemptSnapshot(BaseModel):
 
     @classmethod
     def from_external_group_sync_attempt_db_model(
-        cls, attempt: ExternalGroupPermissionSyncAttempt
+        cls,
+        attempt: ExternalGroupPermissionSyncAttempt,
+        error_count: int,
     ) -> "ExternalGroupSyncAttemptSnapshot":
         return ExternalGroupSyncAttemptSnapshot(
             id=attempt.id,
@@ -406,7 +408,7 @@ class ExternalGroupSyncAttemptSnapshot(BaseModel):
             total_users_processed=attempt.total_users_processed or 0,
             total_groups_processed=attempt.total_groups_processed or 0,
             total_group_memberships_synced=attempt.total_group_memberships_synced or 0,
-            error_count=len(attempt.error_rows),
+            error_count=error_count,
             time_created=attempt.time_created.isoformat(),
             time_started=(
                 attempt.time_started.isoformat() if attempt.time_started else None

--- a/backend/tests/daily/connectors/google_drive/test_drive_perm_sync.py
+++ b/backend/tests/daily/connectors/google_drive/test_drive_perm_sync.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 import pytest
 
+from ee.onyx.db.external_perm import ExternalUserGroup
 from ee.onyx.external_permissions.google_drive.doc_sync import gdrive_doc_sync
 from ee.onyx.external_permissions.google_drive.group_sync import gdrive_group_sync
 from onyx.access.models import DocExternalAccess
@@ -172,6 +173,7 @@ def test_gdrive_perm_sync_with_real_data(
     group_id_to_email_mapping: dict[str, set[str]] = defaultdict(set)
     groups_with_anyone_access: set[str] = set()
     for group in external_user_groups:
+        assert isinstance(group, ExternalUserGroup)
         for email in group.user_emails:
             group_id_to_email_mapping[group.id].add(email)
 

--- a/backend/tests/daily/connectors/google_drive/test_drive_perm_sync.py
+++ b/backend/tests/daily/connectors/google_drive/test_drive_perm_sync.py
@@ -166,7 +166,13 @@ def test_gdrive_perm_sync_with_real_data(
         "ee.onyx.external_permissions.google_drive.group_sync.GoogleDriveConnector",
         return_value=_build_connector(google_drive_service_acct_connector_factory),
     ):
-        external_user_group_generator = gdrive_group_sync("test_tenant", mock_cc_pair)
+        external_user_group_generator = gdrive_group_sync(
+            "test_tenant",
+            mock_cc_pair,
+            record_group_sync_failure=lambda failure: pytest.fail(
+                f"Unexpected group sync failure: {failure}"
+            ),
+        )
         external_user_groups = list(external_user_group_generator)
 
     # map group ids to emails

--- a/backend/tests/daily/connectors/google_drive/test_drive_perm_sync.py
+++ b/backend/tests/daily/connectors/google_drive/test_drive_perm_sync.py
@@ -8,7 +8,6 @@ from unittest.mock import patch
 
 import pytest
 
-from ee.onyx.db.external_perm import ExternalUserGroup
 from ee.onyx.external_permissions.google_drive.doc_sync import gdrive_doc_sync
 from ee.onyx.external_permissions.google_drive.group_sync import gdrive_group_sync
 from onyx.access.models import DocExternalAccess
@@ -179,7 +178,6 @@ def test_gdrive_perm_sync_with_real_data(
     group_id_to_email_mapping: dict[str, set[str]] = defaultdict(set)
     groups_with_anyone_access: set[str] = set()
     for group in external_user_groups:
-        assert isinstance(group, ExternalUserGroup)
         for email in group.user_emails:
             group_id_to_email_mapping[group.id].add(email)
 

--- a/backend/tests/external_dependency_unit/connectors/confluence/test_confluence_group_sync.py
+++ b/backend/tests/external_dependency_unit/connectors/confluence/test_confluence_group_sync.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+import pytest
 from sqlalchemy.orm import Session
 
 from ee.onyx.db.external_perm import ExternalGroupSyncFailure
@@ -112,7 +113,7 @@ _EXPECTED_CONFLUENCE_GROUPS = [
 
 
 def _fail_on_group_sync_failure(failure: ExternalGroupSyncFailure) -> None:
-    raise AssertionError(f"Unexpected group sync failure: {failure}")
+    pytest.fail(f"Unexpected group sync failure: {failure}")
 
 
 def test_confluence_group_sync(

--- a/backend/tests/external_dependency_unit/connectors/confluence/test_confluence_group_sync.py
+++ b/backend/tests/external_dependency_unit/connectors/confluence/test_confluence_group_sync.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from sqlalchemy.orm import Session
 
+from ee.onyx.db.external_perm import ExternalGroupSyncFailure
 from ee.onyx.external_permissions.confluence.group_sync import confluence_group_sync
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.models import InputType
@@ -110,6 +111,10 @@ _EXPECTED_CONFLUENCE_GROUPS = [
 ]
 
 
+def _fail_on_group_sync_failure(failure: ExternalGroupSyncFailure) -> None:
+    raise AssertionError(f"Unexpected group sync failure: {failure}")
+
+
 def test_confluence_group_sync(
     db_session: Session,
     confluence_connector_config: dict[str, Any],
@@ -152,6 +157,7 @@ def test_confluence_group_sync(
     group_sync_iter = confluence_group_sync(
         tenant_id=tenant_id,
         cc_pair=cc_pair,
+        record_group_sync_failure=_fail_on_group_sync_failure,
     )
 
     expected_groups = {group.id: group for group in _EXPECTED_CONFLUENCE_GROUPS}

--- a/backend/tests/external_dependency_unit/connectors/google_drive/test_google_drive_group_sync.py
+++ b/backend/tests/external_dependency_unit/connectors/google_drive/test_google_drive_group_sync.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from collections.abc import Generator
 from unittest.mock import Mock
 from unittest.mock import patch
@@ -8,6 +9,7 @@ from sqlalchemy.orm import Session
 from ee.onyx.background.celery.tasks.external_group_syncing.tasks import (
     _perform_external_group_sync,
 )
+from ee.onyx.db.external_perm import ExternalGroupSyncFailure
 from ee.onyx.db.external_perm import ExternalUserGroup
 from onyx.access.utils import build_ext_group_name_for_onyx
 from onyx.configs.constants import DocumentSource
@@ -130,6 +132,7 @@ class TestPerformExternalGroupSync:
         def mock_group_sync_func(
             tenant_id: str,  # noqa: ARG001
             cc_pair: ConnectorCredentialPair,  # noqa: ARG001
+            record_group_sync_failure: Callable[[ExternalGroupSyncFailure], None],  # noqa: ARG001
         ) -> Generator[ExternalUserGroup, None, None]:
             for group in mock_groups:
                 yield group
@@ -199,6 +202,7 @@ class TestPerformExternalGroupSync:
         def initial_group_sync_func(
             tenant_id: str,  # noqa: ARG001
             cc_pair: ConnectorCredentialPair,  # noqa: ARG001
+            record_group_sync_failure: Callable[[ExternalGroupSyncFailure], None],  # noqa: ARG001
         ) -> Generator[ExternalUserGroup, None, None]:
             yield ExternalUserGroup(id="group1", user_emails=[user1.email, user2.email])
             yield ExternalUserGroup(id="group2", user_emails=[user2.email])
@@ -233,6 +237,7 @@ class TestPerformExternalGroupSync:
             def updated_group_sync_func(
                 tenant_id: str,  # noqa: ARG001
                 cc_pair: ConnectorCredentialPair,  # noqa: ARG001
+                record_group_sync_failure: Callable[[ExternalGroupSyncFailure], None],  # noqa: ARG001
             ) -> Generator[ExternalUserGroup, None, None]:
                 # group1 now has user1 and user3 (user2 removed, user3 added)
                 yield ExternalUserGroup(
@@ -299,6 +304,7 @@ class TestPerformExternalGroupSync:
         def initial_group_sync_func(
             tenant_id: str,  # noqa: ARG001
             cc_pair: ConnectorCredentialPair,  # noqa: ARG001
+            record_group_sync_failure: Callable[[ExternalGroupSyncFailure], None],  # noqa: ARG001
         ) -> Generator[ExternalUserGroup, None, None]:
             yield ExternalUserGroup(id="group1", user_emails=[user1.email, user2.email])
             yield ExternalUserGroup(id="group2", user_emails=[user1.email])
@@ -338,6 +344,7 @@ class TestPerformExternalGroupSync:
             def updated_group_sync_func(
                 tenant_id: str,  # noqa: ARG001
                 cc_pair: ConnectorCredentialPair,  # noqa: ARG001
+                record_group_sync_failure: Callable[[ExternalGroupSyncFailure], None],  # noqa: ARG001
             ) -> Generator[ExternalUserGroup, None, None]:
                 # Only group1 remains, group2 and public_group are removed
                 yield ExternalUserGroup(
@@ -387,6 +394,7 @@ class TestPerformExternalGroupSync:
         def initial_group_sync_func(
             tenant_id: str,  # noqa: ARG001
             cc_pair: ConnectorCredentialPair,  # noqa: ARG001
+            record_group_sync_failure: Callable[[ExternalGroupSyncFailure], None],  # noqa: ARG001
         ) -> Generator[ExternalUserGroup, None, None]:
             yield ExternalUserGroup(id="group1", user_emails=[user1.email])
 
@@ -415,6 +423,7 @@ class TestPerformExternalGroupSync:
             def empty_group_sync_func(
                 tenant_id: str,  # noqa: ARG001
                 cc_pair: ConnectorCredentialPair,  # noqa: ARG001
+                record_group_sync_failure: Callable[[ExternalGroupSyncFailure], None],  # noqa: ARG001
             ) -> Generator[ExternalUserGroup, None, None]:
                 # No groups yielded
                 return
@@ -448,6 +457,7 @@ class TestPerformExternalGroupSync:
         def large_group_sync_func(
             tenant_id: str,  # noqa: ARG001
             cc_pair: ConnectorCredentialPair,  # noqa: ARG001
+            record_group_sync_failure: Callable[[ExternalGroupSyncFailure], None],  # noqa: ARG001
         ) -> Generator[ExternalUserGroup, None, None]:
             yield ExternalUserGroup(
                 id="large_group", user_emails=[user.email for user in users]
@@ -488,6 +498,7 @@ class TestPerformExternalGroupSync:
         def mixed_group_sync_func(
             tenant_id: str,  # noqa: ARG001
             cc_pair: ConnectorCredentialPair,  # noqa: ARG001
+            record_group_sync_failure: Callable[[ExternalGroupSyncFailure], None],  # noqa: ARG001
         ) -> Generator[ExternalUserGroup, None, None]:
             yield ExternalUserGroup(
                 id="regular_group", user_emails=[user1.email, user2.email]

--- a/backend/tests/external_dependency_unit/connectors/jira/test_jira_group_sync.py
+++ b/backend/tests/external_dependency_unit/connectors/jira/test_jira_group_sync.py
@@ -3,6 +3,7 @@ from typing import Any
 import pytest
 from sqlalchemy.orm import Session
 
+from ee.onyx.db.external_perm import ExternalUserGroup
 from ee.onyx.external_permissions.jira.group_sync import jira_group_sync
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.models import InputType
@@ -146,10 +147,12 @@ def test_jira_group_sync(
         )
 
         expected_groups = {group.id: group for group in _EXPECTED_JIRA_GROUPS}
-        actual_groups = {
-            group.id: ExternalUserGroupSet.from_model(external_user_group=group)
-            for group in group_sync_iter
-        }
+        actual_groups: dict[str, ExternalUserGroupSet] = {}
+        for group in group_sync_iter:
+            assert isinstance(group, ExternalUserGroup)
+            actual_groups[group.id] = ExternalUserGroupSet.from_model(
+                external_user_group=group
+            )
         assert expected_groups == actual_groups
     finally:
         db_session.rollback()

--- a/backend/tests/external_dependency_unit/connectors/jira/test_jira_group_sync.py
+++ b/backend/tests/external_dependency_unit/connectors/jira/test_jira_group_sync.py
@@ -144,6 +144,9 @@ def test_jira_group_sync(
         group_sync_iter = jira_group_sync(
             tenant_id=tenant_id,
             cc_pair=cc_pair,
+            record_group_sync_failure=lambda failure: pytest.fail(
+                f"Unexpected group sync failure: {failure}"
+            ),
         )
 
         expected_groups = {group.id: group for group in _EXPECTED_JIRA_GROUPS}

--- a/backend/tests/external_dependency_unit/connectors/jira/test_jira_group_sync.py
+++ b/backend/tests/external_dependency_unit/connectors/jira/test_jira_group_sync.py
@@ -3,7 +3,6 @@ from typing import Any
 import pytest
 from sqlalchemy.orm import Session
 
-from ee.onyx.db.external_perm import ExternalUserGroup
 from ee.onyx.external_permissions.jira.group_sync import jira_group_sync
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.models import InputType
@@ -152,7 +151,6 @@ def test_jira_group_sync(
         expected_groups = {group.id: group for group in _EXPECTED_JIRA_GROUPS}
         actual_groups: dict[str, ExternalUserGroupSet] = {}
         for group in group_sync_iter:
-            assert isinstance(group, ExternalUserGroup)
             actual_groups[group.id] = ExternalUserGroupSet.from_model(
                 external_user_group=group
             )

--- a/backend/tests/external_dependency_unit/permission_sync/test_external_group_permission_sync_attempt.py
+++ b/backend/tests/external_dependency_unit/permission_sync/test_external_group_permission_sync_attempt.py
@@ -22,8 +22,11 @@ from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import Credential
 from onyx.db.models import ExternalGroupPermissionSyncAttempt
 from onyx.db.permission_sync_attempt import complete_external_group_sync_attempt
+from onyx.db.permission_sync_attempt import count_external_group_sync_errors_for_attempt
 from onyx.db.permission_sync_attempt import create_external_group_sync_attempt
+from onyx.db.permission_sync_attempt import create_external_group_sync_error
 from onyx.db.permission_sync_attempt import get_external_group_sync_attempt
+from onyx.db.permission_sync_attempt import get_external_group_sync_errors_for_attempt
 from onyx.db.permission_sync_attempt import (
     get_recent_external_group_sync_attempts_for_cc_pair,
 )
@@ -234,6 +237,47 @@ class TestExternalGroupPermissionSyncAttempt:
         assert attempt.status == PermissionSyncStatus.FAILED
         assert attempt.error_message == error_msg
         assert attempt.full_exception_trace == full_trace
+
+    def test_external_group_sync_error_crud(self, db_session: Session) -> None:
+        """Individual group failures are persisted separately from the
+        aggregate sync attempt so a run can complete with errors."""
+        cc_pair = _create_test_connector_credential_pair(db_session)
+        attempt_id = create_external_group_sync_attempt(cc_pair.id, db_session)
+
+        error_id = create_external_group_sync_error(
+            external_group_sync_attempt_id=attempt_id,
+            connector_credential_pair_id=cc_pair.id,
+            db_session=db_session,
+            external_group_id="jira-group-id",
+            external_group_name="Jira Admins",
+            failure_message="Jira returned 404 for this group",
+            full_exception_trace="Traceback...",
+            error_type="JIRAError",
+        )
+
+        assert error_id is not None
+        assert (
+            count_external_group_sync_errors_for_attempt(
+                external_group_sync_attempt_id=attempt_id,
+                db_session=db_session,
+            )
+            == 1
+        )
+
+        errors = get_external_group_sync_errors_for_attempt(
+            external_group_sync_attempt_id=attempt_id,
+            db_session=db_session,
+            page=0,
+            page_size=10,
+        )
+
+        assert len(errors) == 1
+        assert errors[0].id == error_id
+        assert errors[0].external_group_id == "jira-group-id"
+        assert errors[0].external_group_name == "Jira Admins"
+        assert errors[0].failure_message == "Jira returned 404 for this group"
+        assert errors[0].full_exception_trace == "Traceback..."
+        assert errors[0].error_type == "JIRAError"
 
     def test_get_recent_external_group_sync_attempts_for_cc_pair(
         self, db_session: Session

--- a/backend/tests/external_dependency_unit/permission_sync/test_external_group_permission_sync_attempt.py
+++ b/backend/tests/external_dependency_unit/permission_sync/test_external_group_permission_sync_attempt.py
@@ -289,6 +289,24 @@ class TestExternalGroupPermissionSyncAttempt:
         assert errors[0].full_exception_trace == "Traceback..."
         assert errors[0].error_type == "JIRAError"
 
+        global_attempt_id = create_external_group_sync_attempt(None, db_session)
+        global_error_id = create_external_group_sync_error(
+            external_group_sync_attempt_id=global_attempt_id,
+            connector_credential_pair_id=None,
+            db_session=db_session,
+            external_group_id="global-group-id",
+            external_group_name="Global Group",
+            failure_message="Global group sync failed",
+        )
+
+        global_errors = get_external_group_sync_errors_for_attempt(
+            external_group_sync_attempt_id=global_attempt_id,
+            db_session=db_session,
+        )
+        assert len(global_errors) == 1
+        assert global_errors[0].id == global_error_id
+        assert global_errors[0].connector_credential_pair_id is None
+
     def test_get_recent_external_group_sync_attempts_for_cc_pair(
         self, db_session: Session
     ) -> None:

--- a/backend/tests/external_dependency_unit/permission_sync/test_external_group_permission_sync_attempt.py
+++ b/backend/tests/external_dependency_unit/permission_sync/test_external_group_permission_sync_attempt.py
@@ -25,6 +25,9 @@ from onyx.db.permission_sync_attempt import complete_external_group_sync_attempt
 from onyx.db.permission_sync_attempt import count_external_group_sync_errors_for_attempt
 from onyx.db.permission_sync_attempt import create_external_group_sync_attempt
 from onyx.db.permission_sync_attempt import create_external_group_sync_error
+from onyx.db.permission_sync_attempt import (
+    get_error_counts_for_external_group_sync_attempts,
+)
 from onyx.db.permission_sync_attempt import get_external_group_sync_attempt
 from onyx.db.permission_sync_attempt import get_external_group_sync_errors_for_attempt
 from onyx.db.permission_sync_attempt import (
@@ -243,6 +246,9 @@ class TestExternalGroupPermissionSyncAttempt:
         aggregate sync attempt so a run can complete with errors."""
         cc_pair = _create_test_connector_credential_pair(db_session)
         attempt_id = create_external_group_sync_attempt(cc_pair.id, db_session)
+        attempt_id_without_errors = create_external_group_sync_attempt(
+            cc_pair.id, db_session
+        )
 
         error_id = create_external_group_sync_error(
             external_group_sync_attempt_id=attempt_id,
@@ -263,6 +269,10 @@ class TestExternalGroupPermissionSyncAttempt:
             )
             == 1
         )
+        assert get_error_counts_for_external_group_sync_attempts(
+            external_group_sync_attempt_ids=[attempt_id, attempt_id_without_errors],
+            db_session=db_session,
+        ) == {attempt_id: 1}
 
         errors = get_external_group_sync_errors_for_attempt(
             external_group_sync_attempt_id=attempt_id,

--- a/backend/tests/unit/ee/onyx/external_permissions/github/test_github_group_sync.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/github/test_github_group_sync.py
@@ -1,0 +1,49 @@
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from ee.onyx.external_permissions.github.group_sync import github_group_sync
+from onyx.db.models import ConnectorCredentialPair
+
+
+def _cc_pair() -> ConnectorCredentialPair:
+    credential_json = MagicMock()
+    credential_json.get_value.return_value = {}
+    return cast(
+        ConnectorCredentialPair,
+        SimpleNamespace(
+            connector=SimpleNamespace(connector_specific_config={}),
+            credential=SimpleNamespace(credential_json=credential_json),
+        ),
+    )
+
+
+def test_github_repo_group_sync_failure_is_fatal() -> None:
+    connector = MagicMock()
+    connector.github_client = object()
+    connector.repositories = None
+    connector.get_all_repos.return_value = [SimpleNamespace(id=123, name="repo")]
+
+    with (
+        patch(
+            "ee.onyx.external_permissions.github.group_sync.GithubConnector",
+            return_value=connector,
+        ),
+        patch(
+            "ee.onyx.external_permissions.github.group_sync.get_external_user_group",
+            side_effect=RuntimeError("repo failed"),
+        ),
+        pytest.raises(RuntimeError, match="repo failed"),
+    ):
+        list(
+            github_group_sync(
+                "tenant",
+                _cc_pair(),
+                lambda failure: pytest.fail(
+                    f"Unexpected group sync failure callback: {failure}"
+                ),
+            )
+        )

--- a/backend/tests/unit/ee/onyx/external_permissions/jira/test_jira_group_sync.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/jira/test_jira_group_sync.py
@@ -63,7 +63,8 @@ def test_jira_group_sync_yields_group_level_failure_for_member_fetch_error() -> 
     assert len(failures) == 1
     assert failures[0].external_group_id == "stale-group"
     assert failures[0].external_group_name == "stale-group"
-    assert "GET /group/member could not find it" in failures[0].failure_message
+    assert "GET /group/member returned 404" in failures[0].failure_message
+    assert "This endpoint requires Jira 6.0+" in failures[0].failure_message
     assert failures[0].full_exception_trace is not None
 
 

--- a/backend/tests/unit/ee/onyx/external_permissions/jira/test_jira_group_sync.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/jira/test_jira_group_sync.py
@@ -7,7 +7,6 @@ import pytest
 from jira.exceptions import JIRAError
 
 from ee.onyx.db.external_perm import ExternalGroupSyncFailure
-from ee.onyx.db.external_perm import ExternalUserGroup
 from ee.onyx.external_permissions.jira.group_sync import jira_group_sync
 from onyx.db.models import ConnectorCredentialPair
 
@@ -58,7 +57,6 @@ def test_jira_group_sync_yields_group_level_failure_for_member_fetch_error() -> 
         results = list(jira_group_sync("tenant", _cc_pair(), failures.append))
 
     assert len(results) == 1
-    assert isinstance(results[0], ExternalUserGroup)
     assert results[0].id == "jira-users"
     assert results[0].user_emails == ["user@example.com"]
 

--- a/backend/tests/unit/ee/onyx/external_permissions/jira/test_jira_group_sync.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/jira/test_jira_group_sync.py
@@ -50,22 +50,23 @@ def test_jira_group_sync_yields_group_level_failure_for_member_fetch_error() -> 
 
     jira_client._get_json.side_effect = get_json
 
+    failures: list[ExternalGroupSyncFailure] = []
     with patch(
         "ee.onyx.external_permissions.jira.group_sync.build_jira_client",
         return_value=jira_client,
     ):
-        results = list(jira_group_sync("tenant", _cc_pair()))
+        results = list(jira_group_sync("tenant", _cc_pair(), failures.append))
 
-    assert len(results) == 2
+    assert len(results) == 1
     assert isinstance(results[0], ExternalUserGroup)
     assert results[0].id == "jira-users"
     assert results[0].user_emails == ["user@example.com"]
 
-    assert isinstance(results[1], ExternalGroupSyncFailure)
-    assert results[1].external_group_id == "stale-group"
-    assert results[1].external_group_name == "stale-group"
-    assert "GET /group/member could not find it" in results[1].failure_message
-    assert results[1].full_exception_trace is not None
+    assert len(failures) == 1
+    assert failures[0].external_group_id == "stale-group"
+    assert failures[0].external_group_name == "stale-group"
+    assert "GET /group/member could not find it" in failures[0].failure_message
+    assert failures[0].full_exception_trace is not None
 
 
 def test_jira_group_sync_keeps_group_listing_failure_fatal() -> None:
@@ -77,4 +78,4 @@ def test_jira_group_sync_keeps_group_listing_failure_fatal() -> None:
         return_value=jira_client,
     ):
         with pytest.raises(RuntimeError, match="group listing failed"):
-            list(jira_group_sync("tenant", _cc_pair()))
+            list(jira_group_sync("tenant", _cc_pair(), lambda _failure: None))

--- a/backend/tests/unit/ee/onyx/external_permissions/jira/test_jira_group_sync.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/jira/test_jira_group_sync.py
@@ -1,0 +1,80 @@
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from jira.exceptions import JIRAError
+
+from ee.onyx.db.external_perm import ExternalGroupSyncFailure
+from ee.onyx.db.external_perm import ExternalUserGroup
+from ee.onyx.external_permissions.jira.group_sync import jira_group_sync
+from onyx.db.models import ConnectorCredentialPair
+
+
+def _cc_pair() -> ConnectorCredentialPair:
+    credential_json = MagicMock()
+    credential_json.get_value.return_value = {"jira_api_token": "token"}
+    return cast(
+        ConnectorCredentialPair,
+        SimpleNamespace(
+            id=1,
+            connector=SimpleNamespace(
+                connector_specific_config={
+                    "jira_base_url": "https://example.atlassian.net",
+                    "scoped_token": False,
+                }
+            ),
+            credential=SimpleNamespace(credential_json=credential_json),
+        ),
+    )
+
+
+def test_jira_group_sync_yields_group_level_failure_for_member_fetch_error() -> None:
+    jira_client = MagicMock()
+    jira_client.groups.return_value = ["jira-users", "stale-group"]
+
+    def get_json(path: str, params: dict[str, object]) -> dict[str, object]:
+        assert path == "group/member"
+        if params["groupname"] == "stale-group":
+            raise JIRAError("group missing", status_code=404)
+        return {
+            "values": [
+                {
+                    "accountType": "atlassian",
+                    "emailAddress": "user@example.com",
+                }
+            ],
+            "isLast": True,
+        }
+
+    jira_client._get_json.side_effect = get_json
+
+    with patch(
+        "ee.onyx.external_permissions.jira.group_sync.build_jira_client",
+        return_value=jira_client,
+    ):
+        results = list(jira_group_sync("tenant", _cc_pair()))
+
+    assert len(results) == 2
+    assert isinstance(results[0], ExternalUserGroup)
+    assert results[0].id == "jira-users"
+    assert results[0].user_emails == ["user@example.com"]
+
+    assert isinstance(results[1], ExternalGroupSyncFailure)
+    assert results[1].external_group_id == "stale-group"
+    assert results[1].external_group_name == "stale-group"
+    assert "GET /group/member could not find it" in results[1].failure_message
+    assert results[1].full_exception_trace is not None
+
+
+def test_jira_group_sync_keeps_group_listing_failure_fatal() -> None:
+    jira_client = MagicMock()
+    jira_client.groups.side_effect = RuntimeError("group listing failed")
+
+    with patch(
+        "ee.onyx.external_permissions.jira.group_sync.build_jira_client",
+        return_value=jira_client,
+    ):
+        with pytest.raises(RuntimeError, match="group listing failed"):
+            list(jira_group_sync("tenant", _cc_pair()))

--- a/backend/tests/unit/ee/onyx/external_permissions/sharepoint/test_group_sync.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/sharepoint/test_group_sync.py
@@ -1,0 +1,59 @@
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from ee.onyx.external_permissions.sharepoint.group_sync import sharepoint_group_sync
+from onyx.db.models import ConnectorCredentialPair
+
+
+def _cc_pair() -> ConnectorCredentialPair:
+    credential_json = MagicMock()
+    credential_json.get_value.return_value = {}
+    return cast(
+        ConnectorCredentialPair,
+        SimpleNamespace(
+            connector=SimpleNamespace(connector_specific_config={}),
+            credential=SimpleNamespace(credential_json=credential_json),
+        ),
+    )
+
+
+def test_sharepoint_site_group_sync_failure_is_fatal() -> None:
+    connector = MagicMock()
+    connector.msal_app = object()
+    connector.sp_tenant_domain = "contoso"
+    connector.sharepoint_domain_suffix = "sharepoint.com"
+    connector.site_descriptors = [
+        SimpleNamespace(url="https://contoso.sharepoint.com/sites/team")
+    ]
+    connector.graph_client = object()
+    connector.graph_api_base = "https://graph.microsoft.com/v1.0"
+    connector._get_graph_access_token.return_value = "token"
+
+    with (
+        patch(
+            "ee.onyx.external_permissions.sharepoint.group_sync.SharepointConnector",
+            return_value=connector,
+        ),
+        patch(
+            "ee.onyx.external_permissions.sharepoint.group_sync.ClientContext"
+        ) as mock_client_context,
+        patch(
+            "ee.onyx.external_permissions.sharepoint.group_sync.get_sharepoint_external_groups",
+            side_effect=RuntimeError("site failed"),
+        ),
+        pytest.raises(RuntimeError, match="site failed"),
+    ):
+        mock_client_context.return_value.with_access_token.return_value = MagicMock()
+        list(
+            sharepoint_group_sync(
+                "tenant",
+                _cc_pair(),
+                lambda failure: pytest.fail(
+                    f"Unexpected group sync failure callback: {failure}"
+                ),
+            )
+        )

--- a/backend/tests/unit/ee/onyx/external_permissions/sharepoint/test_permission_utils.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/sharepoint/test_permission_utils.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
+from ee.onyx.db.external_perm import ExternalUserGroup
 from ee.onyx.external_permissions.sharepoint.permission_utils import (
     _enumerate_ad_groups_paginated,
 )
@@ -136,9 +137,13 @@ def test_enumerate_ad_groups_yields_groups(mock_get: MagicMock) -> None:
     )
 
     assert len(results) == 2
-    eng = next(r for r in results if r.id == "Engineering_g1")
+    assert all(isinstance(result, ExternalUserGroup) for result in results)
+    external_user_groups = [
+        result for result in results if isinstance(result, ExternalUserGroup)
+    ]
+    eng = next(r for r in external_user_groups if r.id == "Engineering_g1")
     assert eng.user_emails == ["alice@contoso.com"]
-    mkt = next(r for r in results if r.id == "Marketing_g2")
+    mkt = next(r for r in external_user_groups if r.id == "Marketing_g2")
     assert mkt.user_emails == ["bob@contoso.com"]
 
 
@@ -210,6 +215,7 @@ def test_default_skips_ad_enumeration(
     )
 
     assert len(results) == 1
+    assert isinstance(results[0], ExternalUserGroup)
     assert results[0].id == "SiteGroup_abc"
     assert results[0].user_emails == ["alice@contoso.com"]
 
@@ -241,7 +247,11 @@ def test_enumerate_all_includes_ad_groups(
     )
 
     assert len(results) == 2
-    ids = {r.id for r in results}
+    external_user_groups = [
+        result for result in results if isinstance(result, ExternalUserGroup)
+    ]
+    assert len(external_user_groups) == len(results)
+    ids = {r.id for r in external_user_groups}
     assert ids == {"SiteGroup_abc", "ADGroup_xyz"}
     mock_enum.assert_called_once()
 

--- a/backend/tests/unit/ee/onyx/external_permissions/sharepoint/test_permission_utils.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/sharepoint/test_permission_utils.py
@@ -40,7 +40,7 @@ def _fake_token() -> str:
 
 
 def _fail_on_group_sync_failure(failure: ExternalGroupSyncFailure) -> None:
-    raise AssertionError(f"Unexpected group sync failure: {failure}")
+    pytest.fail(f"Unexpected group sync failure: {failure}")
 
 
 def _make_graph_page(

--- a/backend/tests/unit/ee/onyx/external_permissions/sharepoint/test_permission_utils.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/sharepoint/test_permission_utils.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
+from ee.onyx.db.external_perm import ExternalGroupSyncFailure
 from ee.onyx.db.external_perm import ExternalUserGroup
 from ee.onyx.external_permissions.sharepoint.permission_utils import (
     _enumerate_ad_groups_paginated,
@@ -36,6 +37,10 @@ GRAPH_API_BASE = "https://graph.microsoft.com/v1.0"
 
 def _fake_token() -> str:
     return "fake-token"
+
+
+def _fail_on_group_sync_failure(failure: ExternalGroupSyncFailure) -> None:
+    raise AssertionError(f"Unexpected group sync failure: {failure}")
 
 
 def _make_graph_page(
@@ -132,18 +137,17 @@ def test_enumerate_ad_groups_yields_groups(mock_get: MagicMock) -> None:
 
     results = list(
         _enumerate_ad_groups_paginated(
-            _fake_token, already_resolved=set(), graph_api_base=GRAPH_API_BASE
+            _fake_token,
+            already_resolved=set(),
+            graph_api_base=GRAPH_API_BASE,
+            record_group_sync_failure=_fail_on_group_sync_failure,
         )
     )
 
     assert len(results) == 2
-    assert all(isinstance(result, ExternalUserGroup) for result in results)
-    external_user_groups = [
-        result for result in results if isinstance(result, ExternalUserGroup)
-    ]
-    eng = next(r for r in external_user_groups if r.id == "Engineering_g1")
+    eng = next(r for r in results if r.id == "Engineering_g1")
     assert eng.user_emails == ["alice@contoso.com"]
-    mkt = next(r for r in external_user_groups if r.id == "Marketing_g2")
+    mkt = next(r for r in results if r.id == "Marketing_g2")
     assert mkt.user_emails == ["bob@contoso.com"]
 
 
@@ -157,6 +161,7 @@ def test_enumerate_ad_groups_skips_already_resolved(mock_get: MagicMock) -> None
             _fake_token,
             already_resolved={"Engineering_g1"},
             graph_api_base=GRAPH_API_BASE,
+            record_group_sync_failure=_fail_on_group_sync_failure,
         )
     )
     assert results == []
@@ -171,7 +176,10 @@ def test_enumerate_ad_groups_circuit_breaker(mock_get: MagicMock) -> None:
 
     results = list(
         _enumerate_ad_groups_paginated(
-            _fake_token, already_resolved=set(), graph_api_base=GRAPH_API_BASE
+            _fake_token,
+            already_resolved=set(),
+            graph_api_base=GRAPH_API_BASE,
+            record_group_sync_failure=_fail_on_group_sync_failure,
         )
     )
     assert len(results) <= AD_GROUP_ENUMERATION_THRESHOLD
@@ -212,10 +220,10 @@ def test_default_skips_ad_enumeration(
         client_context=MagicMock(),
         graph_client=MagicMock(),
         graph_api_base=GRAPH_API_BASE,
+        record_group_sync_failure=_fail_on_group_sync_failure,
     )
 
     assert len(results) == 1
-    assert isinstance(results[0], ExternalUserGroup)
     assert results[0].id == "SiteGroup_abc"
     assert results[0].user_emails == ["alice@contoso.com"]
 
@@ -228,8 +236,6 @@ def test_enumerate_all_includes_ad_groups(
     mock_recursive: MagicMock,
     mock_enum: MagicMock,
 ) -> None:
-    from ee.onyx.db.external_perm import ExternalUserGroup
-
     mock_recursive.return_value = GroupsResult(
         groups_to_emails={"SiteGroup_abc": {"alice@contoso.com"}},
         found_public_group=False,
@@ -244,14 +250,11 @@ def test_enumerate_all_includes_ad_groups(
         get_access_token=_fake_token,
         enumerate_all_ad_groups=True,
         graph_api_base=GRAPH_API_BASE,
+        record_group_sync_failure=_fail_on_group_sync_failure,
     )
 
     assert len(results) == 2
-    external_user_groups = [
-        result for result in results if isinstance(result, ExternalUserGroup)
-    ]
-    assert len(external_user_groups) == len(results)
-    ids = {r.id for r in external_user_groups}
+    ids = {r.id for r in results}
     assert ids == {"SiteGroup_abc", "ADGroup_xyz"}
     mock_enum.assert_called_once()
 
@@ -276,6 +279,7 @@ def test_enumerate_all_without_token_skips(
         get_access_token=None,
         enumerate_all_ad_groups=True,
         graph_api_base=GRAPH_API_BASE,
+        record_group_sync_failure=_fail_on_group_sync_failure,
     )
 
     assert results == []

--- a/backend/tests/unit/ee/onyx/external_permissions/test_external_group_syncing_tasks.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/test_external_group_syncing_tasks.py
@@ -3,14 +3,18 @@ import pytest
 from ee.onyx.background.celery.tasks.external_group_syncing.tasks import (
     _check_external_group_failure_threshold,
 )
+from ee.onyx.background.celery.tasks.external_group_syncing.tasks import (
+    ExternalGroupSyncFailureThresholdError,
+)
 from ee.onyx.db.external_perm import ExternalGroupSyncFailure
 
 
-def _failure() -> ExternalGroupSyncFailure:
+def _failure(full_exception_trace: str | None = None) -> ExternalGroupSyncFailure:
     return ExternalGroupSyncFailure(
         external_group_id="group-id",
         external_group_name="group-name",
         failure_message="group sync failed",
+        full_exception_trace=full_exception_trace,
     )
 
 
@@ -38,3 +42,16 @@ def test_external_group_failure_threshold_aborts_when_ratio_exceeded() -> None:
             total_groups_seen=5,
             last_failure=_failure(),
         )
+
+
+def test_external_group_failure_threshold_preserves_last_failure_trace() -> None:
+    full_exception_trace = "Traceback...\noriginal group sync failure"
+
+    with pytest.raises(ExternalGroupSyncFailureThresholdError) as exc_info:
+        _check_external_group_failure_threshold(
+            total_failures=4,
+            total_groups_seen=10,
+            last_failure=_failure(full_exception_trace=full_exception_trace),
+        )
+
+    assert exc_info.value.full_exception_trace == full_exception_trace

--- a/backend/tests/unit/ee/onyx/external_permissions/test_external_group_syncing_tasks.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/test_external_group_syncing_tasks.py
@@ -1,0 +1,40 @@
+import pytest
+
+from ee.onyx.background.celery.tasks.external_group_syncing.tasks import (
+    _check_external_group_failure_threshold,
+)
+from ee.onyx.db.external_perm import ExternalGroupSyncFailure
+
+
+def _failure() -> ExternalGroupSyncFailure:
+    return ExternalGroupSyncFailure(
+        external_group_id="group-id",
+        external_group_name="group-name",
+        failure_message="group sync failed",
+    )
+
+
+def test_external_group_failure_threshold_allows_safe_failure_count() -> None:
+    _check_external_group_failure_threshold(
+        total_failures=1,
+        total_groups_seen=20,
+        last_failure=_failure(),
+    )
+
+
+def test_external_group_failure_threshold_aborts_when_count_exceeded() -> None:
+    with pytest.raises(RuntimeError, match="too many group-level errors"):
+        _check_external_group_failure_threshold(
+            total_failures=4,
+            total_groups_seen=100,
+            last_failure=_failure(),
+        )
+
+
+def test_external_group_failure_threshold_aborts_when_ratio_exceeded() -> None:
+    with pytest.raises(RuntimeError, match="too many group-level errors"):
+        _check_external_group_failure_threshold(
+            total_failures=1,
+            total_groups_seen=5,
+            last_failure=_failure(),
+        )

--- a/web/src/app/admin/connector/[ccPairId]/ExternalGroupSyncAttemptsTable.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/ExternalGroupSyncAttemptsTable.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useMemo, useState } from "react";
 import {
+  Button,
   createTableColumns,
   EmptyMessageCard,
   Pagination,
@@ -11,6 +12,7 @@ import {
 import { Section } from "@/layouts/general-layouts";
 import { localizeAndPrettify } from "@opal/time";
 import ExceptionTraceModal from "@/sections/modals/PreviewModal/ExceptionTraceModal";
+import ExternalGroupSyncErrorsModal from "./ExternalGroupSyncErrorsModal";
 import { PermissionSyncStatusBadge } from "./PermissionSyncStatusBadge";
 import type { ExternalGroupSyncAttemptSnapshot } from "./types";
 
@@ -55,7 +57,10 @@ const tc = createTableColumns<ExternalGroupSyncAttemptSnapshot>();
 //
 // `Time Started` is bumped to 26 so `localizeAndPrettify` (e.g.
 // "5/3/2026, 12:00:00 PM") stays on a single line.
-function buildColumns(onErrorClick: (errorMessage: string) => void) {
+function buildColumns(
+  onErrorClick: (errorMessage: string) => void,
+  onGroupErrorsClick: (attemptId: number) => void
+) {
   return [
     tc.column("time_started", {
       header: "Time Started",
@@ -108,9 +113,28 @@ function buildColumns(onErrorClick: (errorMessage: string) => void) {
         </Text>
       ),
     }),
+    tc.column("error_count", {
+      header: "Errors",
+      weight: 10,
+      enableSorting: false,
+      cell: (value, row) =>
+        value > 0 ? (
+          <Button
+            size="sm"
+            prominence="tertiary"
+            onClick={() => onGroupErrorsClick(row.id)}
+          >
+            {`View ${value}`}
+          </Button>
+        ) : (
+          <Text as="span" font="secondary-body" color="text-03">
+            -
+          </Text>
+        ),
+    }),
     tc.column("error_message", {
       header: "Error Message",
-      weight: 28,
+      weight: 22,
       enableSorting: false,
       cell: (value, row) => (
         <ErrorMessageCell
@@ -170,6 +194,7 @@ function ErrorMessageCell({
 }
 
 export interface ExternalGroupSyncAttemptsTableProps {
+  ccPairId: number;
   attempts: ExternalGroupSyncAttemptSnapshot[];
   /** 1-based page index, matching `IndexAttemptsTable`. */
   currentPage: number;
@@ -178,19 +203,27 @@ export interface ExternalGroupSyncAttemptsTableProps {
 }
 
 export function ExternalGroupSyncAttemptsTable({
+  ccPairId,
   attempts,
   currentPage,
   totalPages,
   onPageChange,
 }: ExternalGroupSyncAttemptsTableProps) {
   const [openErrorMessage, setOpenErrorMessage] = useState<string | null>(null);
+  const [openErrorsAttemptId, setOpenErrorsAttemptId] = useState<number | null>(
+    null
+  );
   const handleErrorClick = useCallback(
     (errorMessage: string) => setOpenErrorMessage(errorMessage),
     []
   );
+  const handleGroupErrorsClick = useCallback(
+    (attemptId: number) => setOpenErrorsAttemptId(attemptId),
+    []
+  );
   const columns = useMemo(
-    () => buildColumns(handleErrorClick),
-    [handleErrorClick]
+    () => buildColumns(handleErrorClick, handleGroupErrorsClick),
+    [handleErrorClick, handleGroupErrorsClick]
   );
 
   if (!attempts.length) {
@@ -210,6 +243,13 @@ export function ExternalGroupSyncAttemptsTable({
           onOutsideClick={() => setOpenErrorMessage(null)}
           exceptionTrace={openErrorMessage}
           title={ERROR_MODAL_TITLE}
+        />
+      )}
+      {openErrorsAttemptId !== null && (
+        <ExternalGroupSyncErrorsModal
+          ccPairId={ccPairId}
+          attemptId={openErrorsAttemptId}
+          onClose={() => setOpenErrorsAttemptId(null)}
         />
       )}
 

--- a/web/src/app/admin/connector/[ccPairId]/ExternalGroupSyncErrorsModal.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/ExternalGroupSyncErrorsModal.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import {
+  Button,
+  createTableColumns,
+  EmptyMessageCard,
+  Pagination,
+  Table,
+  Text,
+} from "@opal/components";
+import { localizeAndPrettify } from "@opal/time";
+import Modal from "@/refresh-components/Modal";
+import { Section } from "@/layouts/general-layouts";
+import usePaginatedFetch from "@/hooks/usePaginatedFetch";
+import { SWR_KEYS } from "@/lib/swr-keys";
+import ExceptionTraceModal from "@/sections/modals/PreviewModal/ExceptionTraceModal";
+import type { ExternalGroupSyncError } from "./types";
+
+const ITEMS_PER_PAGE = 10;
+const PAGES_PER_BATCH = 1;
+
+const tc = createTableColumns<ExternalGroupSyncError>();
+
+function buildColumns(onTraceClick: (trace: string) => void) {
+  return [
+    tc.column("time_created", {
+      header: "Time",
+      weight: 18,
+      enableSorting: false,
+      cell: (value) => (
+        <Text as="span" font="main-ui-body" color="text-04">
+          {localizeAndPrettify(value)}
+        </Text>
+      ),
+    }),
+    tc.column("external_group_name", {
+      header: "Group",
+      weight: 24,
+      enableSorting: false,
+      cell: (value, row) => (
+        <Text as="span" font="main-ui-body" color="text-04" maxLines={2}>
+          {value ?? row.external_group_id ?? "Unknown"}
+        </Text>
+      ),
+    }),
+    tc.column("error_type", {
+      header: "Type",
+      weight: 14,
+      enableSorting: false,
+      cell: (value) => (
+        <Text as="span" font="secondary-body" color="text-03">
+          {value ?? "-"}
+        </Text>
+      ),
+    }),
+    tc.column("failure_message", {
+      header: "Error Message",
+      weight: 34,
+      enableSorting: false,
+      cell: (value) => (
+        <Text as="span" font="secondary-body" color="text-03" maxLines={3}>
+          {value}
+        </Text>
+      ),
+    }),
+    tc.column("full_exception_trace", {
+      header: "Trace",
+      weight: 10,
+      enableSorting: false,
+      cell: (value, row) =>
+        value ? (
+          <Button
+            size="sm"
+            prominence="tertiary"
+            onClick={() => onTraceClick(value)}
+          >
+            View
+          </Button>
+        ) : (
+          <Text as="span" font="secondary-body" color="text-03">
+            -
+          </Text>
+        ),
+    }),
+  ];
+}
+
+export interface ExternalGroupSyncErrorsModalProps {
+  ccPairId: number;
+  attemptId: number;
+  onClose: () => void;
+}
+
+export default function ExternalGroupSyncErrorsModal({
+  ccPairId,
+  attemptId,
+  onClose,
+}: ExternalGroupSyncErrorsModalProps) {
+  const [openTrace, setOpenTrace] = useState<string | null>(null);
+  const handleTraceClick = useCallback(
+    (trace: string) => setOpenTrace(trace),
+    []
+  );
+  const columns = useMemo(
+    () => buildColumns(handleTraceClick),
+    [handleTraceClick]
+  );
+
+  const {
+    currentPageData,
+    isLoading,
+    error,
+    currentPage,
+    totalPages,
+    goToPage,
+  } = usePaginatedFetch<ExternalGroupSyncError>({
+    itemsPerPage: ITEMS_PER_PAGE,
+    pagesPerBatch: PAGES_PER_BATCH,
+    endpoint: SWR_KEYS.ccPairExternalGroupSyncAttemptErrors(
+      ccPairId,
+      attemptId
+    ),
+    disableUrlSync: true,
+  });
+
+  const errors = currentPageData ?? [];
+
+  return (
+    <>
+      {openTrace !== null && (
+        <ExceptionTraceModal
+          onOutsideClick={() => setOpenTrace(null)}
+          exceptionTrace={openTrace}
+          title="Group Membership Sync Error Trace"
+        />
+      )}
+      <Modal open onOpenChange={onClose}>
+        <Modal.Content width="full" height="full">
+          <Modal.Header
+            title="Group Membership Sync Errors"
+            onClose={onClose}
+            height="fit"
+          />
+          <Modal.Body height="full">
+            <Section gap={1} alignItems="stretch" height="full">
+              <Text as="p" font="main-ui-body" color="text-03">
+                These errors were recorded while syncing individual external
+                groups for this run.
+              </Text>
+
+              {error ? (
+                <EmptyMessageCard
+                  sizePreset="main-ui"
+                  title="Failed to load group sync errors"
+                  description={error.message}
+                />
+              ) : isLoading && currentPageData === null ? (
+                <EmptyMessageCard
+                  sizePreset="main-ui"
+                  title="Loading group sync errors"
+                />
+              ) : errors.length === 0 ? (
+                <EmptyMessageCard
+                  sizePreset="main-ui"
+                  title="No group sync errors found"
+                />
+              ) : (
+                <Section gap={0.75} alignItems="stretch" height="auto">
+                  <Table
+                    data={errors}
+                    columns={columns}
+                    getRowId={(row) => String(row.id)}
+                  />
+                  {totalPages > 1 && (
+                    <Section
+                      flexDirection="row"
+                      justifyContent="center"
+                      height="auto"
+                      className="pt-1"
+                    >
+                      <Pagination
+                        variant="list"
+                        currentPage={currentPage}
+                        totalPages={totalPages}
+                        onChange={goToPage}
+                      />
+                    </Section>
+                  )}
+                </Section>
+              )}
+            </Section>
+          </Modal.Body>
+        </Modal.Content>
+      </Modal>
+    </>
+  );
+}

--- a/web/src/app/admin/connector/[ccPairId]/SyncAttemptsTabs.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/SyncAttemptsTabs.tsx
@@ -151,6 +151,7 @@ function GroupMembershipTabBody({ ccPairId }: { ccPairId: number }) {
 
   return (
     <ExternalGroupSyncAttemptsTable
+      ccPairId={ccPairId}
       attempts={result.currentPageData ?? []}
       currentPage={result.currentPage}
       totalPages={result.totalPages}

--- a/web/src/app/admin/connector/[ccPairId]/types.ts
+++ b/web/src/app/admin/connector/[ccPairId]/types.ts
@@ -115,9 +115,22 @@ export interface ExternalGroupSyncAttemptSnapshot {
   total_users_processed: number;
   total_groups_processed: number;
   total_group_memberships_synced: number;
+  error_count: number;
   time_created: string;
   time_started: string | null;
   time_finished: string | null;
+}
+
+export interface ExternalGroupSyncError {
+  id: number;
+  external_group_sync_attempt_id: number;
+  connector_credential_pair_id: number;
+  external_group_id: string | null;
+  external_group_name: string | null;
+  failure_message: string;
+  full_exception_trace: string | null;
+  error_type: string | null;
+  time_created: string;
 }
 
 /**

--- a/web/src/app/admin/connector/[ccPairId]/types.ts
+++ b/web/src/app/admin/connector/[ccPairId]/types.ts
@@ -124,7 +124,7 @@ export interface ExternalGroupSyncAttemptSnapshot {
 export interface ExternalGroupSyncError {
   id: number;
   external_group_sync_attempt_id: number;
-  connector_credential_pair_id: number;
+  connector_credential_pair_id: number | null;
   external_group_id: string | null;
   external_group_name: string | null;
   failure_message: string;

--- a/web/src/lib/swr-keys.ts
+++ b/web/src/lib/swr-keys.ts
@@ -229,6 +229,8 @@ export const SWR_KEYS = {
     `/api/manage/admin/cc-pair/${ccPairId}/external-group-sync-attempts`,
   ccPairExternalGroupSyncAttemptsProbe: (ccPairId: number) =>
     `/api/manage/admin/cc-pair/${ccPairId}/external-group-sync-attempts?page_num=0&page_size=1`,
+  ccPairExternalGroupSyncAttemptErrors: (ccPairId: number, attemptId: number) =>
+    `/api/manage/admin/cc-pair/${ccPairId}/external-group-sync-attempts/${attemptId}/errors`,
 
   // ── Indexing Errors ───────────────────────────────────────────────────────
   // Base key for the per-cc-pair errors endpoint. The page also reads


### PR DESCRIPTION
## Description

- Add `ExternalGroupSyncError` persistence for recoverable group-level sync failures.
- Record per-group/repository/site failures during external group sync and keep unrecoverable listing/discovery failures as run-level failures.
- Mark group sync attempts as completed with errors when recoverable failures occur, and fail the run once the group-level failure threshold is exceeded.
- Surface group sync error counts and a paginated error-detail modal in the admin Group Membership Sync table.

## How Has This Been Tested?

- `.venv/bin/ruff check ...` on touched backend files.
- `.venv/bin/pytest -q backend/tests/unit/ee/onyx/external_permissions/jira/test_jira_group_sync.py`
- `.venv/bin/pytest -q backend/tests/external_dependency_unit/permission_sync/test_external_group_permission_sync_attempt.py`
- `../.venv/bin/alembic heads`
- `git diff --check`
- Pre-commit: `ty`, `ruff`, `ruff format`, ripsecrets, and TypeScript type check passed. `oxfmt` and `oxlint` were skipped at commit time because the local Node launcher fails on extensionless package bins; direct frontend formatter/linter checks passed before commit.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
