### PR TITLE
ci(pre-commit): run ruff in isolated overlay instead of syncing project

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,13 +80,21 @@ repos:
       - id: uv-run
         alias: ruff
         name: ruff
-        args: ["ruff", "check", "--fix"]
+        # Run ruff from an isolated overlay (`--no-project --with`) so the hook
+        # never syncs the dev `.venv` or pulls in the backend toolchain (torch,
+        # nvidia-*, etc.) — a full project sync on a cold CI runner installs
+        # 450+ packages just to lint. Same isolation goal as the zizmor hook
+        # below. ruff discovers `[tool.ruff]` from pyproject.toml independently
+        # of uv's project handling, so config still applies. Keep the pinned
+        # version in sync with `ruff` in the dev dependency group in
+        # pyproject.toml.
+        args: ["--no-project", "--with=ruff==0.12.0", "ruff", "check", "--fix"]
         pass_filenames: true
         types_or: [python]
       - id: uv-run
         alias: ruff-format
         name: ruff format
-        args: ["ruff", "format"]
+        args: ["--no-project", "--with=ruff==0.12.0", "ruff", "format"]
         pass_filenames: true
         types_or: [python]
       - id: uv-run

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,6 +151,8 @@ dev = [
     "pytest-xdist==3.8.0",
     "pytest==9.0.3",
     "release-tag==0.5.2",
+    # Keep in sync with the pinned `ruff==` in the ruff / ruff-format hooks in
+    # .pre-commit-config.yaml, which install ruff into an isolated overlay.
     "ruff==0.12.0",
     "types-docker==7.1.0.20260518",
     "types-beautifulsoup4==4.12.0.3",


### PR DESCRIPTION
## Problem

The `ruff` and `ruff-format` pre-commit hooks run via the `uv-run` hook, i.e. `uv run ruff ...`. `uv run` syncs the full project `.venv` before executing, so on a cold CI runner (no existing `.venv`) it installs 450+ packages — the `onyx` build, `torch`, `nvidia-nccl-cu12`, etc. — just to run a linter that needs none of them:

```
ruff.....................................................................Failed
- hook id: uv-run
  Creating virtual environment at: .venv
  ⠋ Preparing packages... (0/452)
  nvidia-nccl-cu12     ------------------------------     0 B/307.42 MiB
```

## Fix

Switch both hooks to an isolated overlay, matching the existing `zizmor` hook right below them in the same file:

```yaml
args: ["--no-project", "--with=ruff==0.12.0", "ruff", "check", "--fix"]
args: ["--no-project", "--with=ruff==0.12.0", "ruff", "format"]
```

`--no-project` skips project discovery/sync entirely; `--with=ruff==0.12.0` provides a tiny cached env containing only ruff. This is the same dependency-isolation approach the repo already uses in CI (`uv run --no-sync --with ...`).

## Notes

- Ruff discovers `[tool.ruff]` from `pyproject.toml` independently of uv's project handling, so lint/format config is unchanged (verified: `--show-settings` still resolves `target_version = 3.13`).
- Version pinned to `ruff==0.12.0` to stay in sync with the `dev` dependency group in `pyproject.toml`.
- `ty` is intentionally left on the plain `uv-run` hook — it needs the synced venv to type-check against installed dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run `ruff` pre-commit hooks in an isolated `uv` overlay to skip syncing the project `.venv` on CI, reducing cold runs from 450+ packages to just `ruff`. This speeds up linting and avoids GPU/toolchain downloads.

- **Refactors**
  - Update `ruff` and `ruff-format` hooks to `uv-run --no-project --with=ruff==0.12.0 ruff ...`, matching the existing `zizmor` overlay.
  - Config from `[tool.ruff]` is unchanged; pin `ruff==0.12.0` and add cross-reference comments in `.pre-commit-config.yaml` and `pyproject.toml` to keep versions aligned.

<sup>Written for commit 8285b2749d6e00c8397c63e890e3eb1a9689b6e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12657?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

