### PR TITLE
Add WEB_CONNECTOR_PLAYWRIGHT_BROWSER_TYPE / _EXECUTABLE_PATH config

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -686,6 +686,16 @@ WEB_CONNECTOR_VALIDATE_URLS = os.environ.get("WEB_CONNECTOR_VALIDATE_URLS")
 # fall back to a one-shot Playwright (Chromium) render to bypass JS-based
 # bot detection. Disable to skip the fallback (e.g. on hosts that don't have
 # the Chromium binary installed).
+# Browser engine and binary used by start_playwright() (WebConnector crawl and
+# the OnyxWebCrawler fallback). Defaults match existing behavior; set these to
+# point at a different Playwright-managed browser build.
+WEB_CONNECTOR_PLAYWRIGHT_BROWSER_TYPE = os.environ.get(
+    "WEB_CONNECTOR_PLAYWRIGHT_BROWSER_TYPE", "chromium"
+)
+WEB_CONNECTOR_PLAYWRIGHT_EXECUTABLE_PATH = os.environ.get(
+    "WEB_CONNECTOR_PLAYWRIGHT_EXECUTABLE_PATH"
+)
+
 OPEN_URL_PLAYWRIGHT_FALLBACK_ENABLED = (
     os.environ.get("OPEN_URL_PLAYWRIGHT_FALLBACK_ENABLED", "true").lower() == "true"
 )

--- a/backend/onyx/utils/playwright_fetch.py
+++ b/backend/onyx/utils/playwright_fetch.py
@@ -23,6 +23,8 @@ from pydantic import BaseModel
 from onyx.configs.app_configs import WEB_CONNECTOR_OAUTH_CLIENT_ID
 from onyx.configs.app_configs import WEB_CONNECTOR_OAUTH_CLIENT_SECRET
 from onyx.configs.app_configs import WEB_CONNECTOR_OAUTH_TOKEN_URL
+from onyx.configs.app_configs import WEB_CONNECTOR_PLAYWRIGHT_BROWSER_TYPE
+from onyx.configs.app_configs import WEB_CONNECTOR_PLAYWRIGHT_EXECUTABLE_PATH
 from onyx.utils.logger import setup_logger
 from onyx.utils.url import SSRFException
 from onyx.utils.url import validate_outbound_http_url
@@ -83,14 +85,18 @@ def start_playwright() -> tuple[Playwright, BrowserContext]:
     """
     playwright = sync_playwright().start()
 
-    browser = playwright.chromium.launch(
-        headless=True,
-        args=[
+    engine = getattr(playwright, WEB_CONNECTOR_PLAYWRIGHT_BROWSER_TYPE)
+    launch_kwargs: dict = {"headless": True}
+    if WEB_CONNECTOR_PLAYWRIGHT_BROWSER_TYPE == "chromium":
+        launch_kwargs["args"] = [
             "--disable-blink-features=AutomationControlled",
             "--disable-features=IsolateOrigins,site-per-process",
             "--disable-site-isolation-trials",
-        ],
-    )
+        ]
+    if WEB_CONNECTOR_PLAYWRIGHT_EXECUTABLE_PATH:
+        launch_kwargs["executable_path"] = WEB_CONNECTOR_PLAYWRIGHT_EXECUTABLE_PATH
+
+    browser = engine.launch(**launch_kwargs)
 
     context = browser.new_context(
         user_agent=DEFAULT_USER_AGENT,


### PR DESCRIPTION
start_playwright() was hardcoded to chromium.launch() with no way to point it at a different browser engine or binary. This adds WEB_CONNECTOR_PLAYWRIGHT_BROWSER_TYPE and WEB_CONNECTOR_PLAYWRIGHT_EXECUTABLE_PATH env vars, following the same pattern as the existing OPEN_URL_PLAYWRIGHT_FALLBACK_ENABLED setting. Defaults keep current behavior unchanged, and the Chromium-specific args are guarded behind the default case. Motivated by invisible_playwright, a Playwright wrapper around a Firefox build patched at the source level for a realistic fingerprint - this connector already hand-rolls Chromium automation-flag spoofing, so a real Firefox binary removes that whole cat-and-mouse problem for one config change. Opened as draft, happy to adjust naming or scope.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Playwright browser engine and binary configurable for WebConnector and the fallback renderer, enabling Firefox or custom builds without code changes. Defaults remain Chromium; Chromium-specific launch args only apply when using Chromium.

- **New Features**
  - `WEB_CONNECTOR_PLAYWRIGHT_BROWSER_TYPE` ("chromium" default) to select `chromium`, `firefox`, or `webkit`.
  - `WEB_CONNECTOR_PLAYWRIGHT_EXECUTABLE_PATH` to point to a specific browser binary.
  - `start_playwright()` now launches the chosen engine with the optional executable path.

- **Migration**
  - No changes needed by default.
  - To switch, set `WEB_CONNECTOR_PLAYWRIGHT_BROWSER_TYPE=firefox` and optionally `WEB_CONNECTOR_PLAYWRIGHT_EXECUTABLE_PATH=/path/to/firefox`.

<sup>Written for commit 76349499ff16cc8046145fe4608abd7f8a03bae5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

