### PR TITLE
feat(craft): default ENABLE_BROWSER on to match the sandbox image

### DIFF
--- a/backend/onyx/server/features/build/configs.py
+++ b/backend/onyx/server/features/build/configs.py
@@ -69,9 +69,10 @@ SANDBOX_SERVICE_ACCOUNT_NAME = os.environ.get("SANDBOX_SERVICE_ACCOUNT_NAME", "s
 
 ENABLE_CRAFT = os.environ.get("ENABLE_CRAFT", "false").lower() == "true"
 
-# Gates the built-in `browser` skill. Distinct from the sandbox image's
-# build-time ENABLE_BROWSER ARG — set this runtime env to match it.
-ENABLE_BROWSER = os.environ.get("ENABLE_BROWSER", "false").lower() == "true"
+# Gates the built-in `browser` skill. Defaults on to match the sandbox image's
+# build-time ENABLE_BROWSER ARG (also on); a browserless sandbox build must set
+# this false too, else the skill is advertised without its runtime.
+ENABLE_BROWSER = os.environ.get("ENABLE_BROWSER", "true").lower() == "true"
 
 SANDBOX_PUSH_PRIVATE_KEY = os.environ.get("ONYX_SANDBOX_PUSH_PRIVATE_KEY", "")
 

--- a/docs/craft/specs/browser-use.md
+++ b/docs/craft/specs/browser-use.md
@@ -68,10 +68,13 @@ No dedicated AGENTS.md section is needed.
 ## Gating
 
 `ENABLE_BROWSER` (`onyx/server/features/build/configs.py`, api-server runtime
-env, default OFF): set it to match the sandbox image's build-time
-`ENABLE_BROWSER` ARG. It's the single signal of "does this deployment's image
+env, default ON): must match the sandbox image's build-time `ENABLE_BROWSER` ARG
+(also default ON). It's the single signal of "does this deployment's image
 include the browser runtime," and gates the built-in `browser` skill via the
-registry. There is no per-user feature flag.
+registry. There is no per-user feature flag. Both defaults are on, so the
+standard released image surfaces the skill; a deployment that builds a
+browserless sandbox (`--build-arg ENABLE_BROWSER=false`) must also set this
+runtime env `false`, or the skill is advertised without its runtime.
 
 ## Image
 
@@ -81,7 +84,7 @@ at it via `AGENT_BROWSER_EXECUTABLE_PATH` rather than `agent-browser install`,
 which fetches a no-arm64 Chrome-for-Testing) + `libnss3-tools` (certutil) +
 `agent-browser` (npm global). The `browser` wrapper is always copied; it's inert
 when `ENABLE_BROWSER=false` (agent-browser absent) and only advertised via the
-per-user-gated skill.
+deployment-gated skill.
 
 ## Browser state is ephemeral
 


### PR DESCRIPTION
## Description

Flip the `ENABLE_BROWSER` **runtime** default from off → on in `configs.py`, so the built-in `browser` skill is available wherever Craft runs without a per-deployment configmap flag.

Context: the sandbox image already bakes the browser runtime by default (Dockerfile `ARG ENABLE_BROWSER=true`), so the runtime gate defaulting off was hiding an already-shipped capability and forcing an `ENABLE_BROWSER=true` env on every environment (managed_services, st-dev, …). The two switches now default the same way (both on).

Coupling to be aware of (documented in `docs/craft/specs/browser-use.md`): a deployment that deliberately builds a **browserless** sandbox (`--build-arg ENABLE_BROWSER=false`, to drop ~290 MB) must now **also** set the runtime env `ENABLE_BROWSER=false`, otherwise the skill is advertised without its runtime (`browser` → command not found). Failure mode is a clear error, not a hazard.

Files: `backend/onyx/server/features/build/configs.py` (default), `docs/craft/specs/browser-use.md` (gating section + a stale "per-user-gated" → "deployment-gated" fix).

## How Has This Been Tested?

- Pre-commit green (`ty`, `ruff`, `ruff format`).
- Gating is covered by `test_browser_built_in_gated_on_enable_browser`, which monkeypatches `ENABLE_BROWSER` False/True directly, so it's independent of the default and still asserts the skill drops out when off / appears when on.
- No test relied on the default being off (verified).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default `ENABLE_BROWSER` runtime flag to on to match the sandbox image. The built-in browser skill is now available by default without per-env flags.

- **Migration**
  - If you build a browserless sandbox (`--build-arg ENABLE_BROWSER=false`), also set `ENABLE_BROWSER=false` at runtime to avoid advertising the skill without its runtime.

<sup>Written for commit 38952afe789010d9ce6eb501642ba2ed23b71537. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

