### PR TITLE
feat(skills): add share, transfer, and edit endpoints

### DIFF
--- a/backend/onyx/db/skill.py
+++ b/backend/onyx/db/skill.py
@@ -525,6 +525,15 @@ def update_skill_fields(
     return skill
 
 
+def _flush_shares(db_session: Session, fk_violation_detail: str) -> None:
+    try:
+        db_session.flush()
+    except IntegrityError as e:
+        if is_fk_violation(e):
+            raise OnyxError(OnyxErrorCode.INVALID_INPUT, fk_violation_detail) from e
+        raise
+
+
 def replace_skill_shares(
     *,
     skill: Skill,
@@ -538,6 +547,7 @@ def replace_skill_shares(
             db_session.add(
                 Skill__User(skill_id=skill.id, user_id=user_id, permission=permission)
             )
+        _flush_shares(db_session, "One or more user share targets do not exist.")
 
     if group_shares is not None:
         db_session.execute(
@@ -551,16 +561,7 @@ def replace_skill_shares(
                     permission=permission,
                 )
             )
-
-    try:
-        db_session.flush()
-    except IntegrityError as e:
-        if is_fk_violation(e):
-            raise OnyxError(
-                OnyxErrorCode.INVALID_INPUT,
-                "One or more share targets do not exist.",
-            ) from e
-        raise
+        _flush_shares(db_session, "One or more group share targets do not exist.")
 
 
 def transfer_skill_ownership(

--- a/backend/onyx/server/features/skill/api.py
+++ b/backend/onyx/server/features/skill/api.py
@@ -9,7 +9,9 @@ from sqlalchemy.orm import Session
 from onyx.auth.permissions import require_permission
 from onyx.auth.schemas import UserRole
 from onyx.db.engine.sql_engine import get_session
+from onyx.db.enums import AccountType
 from onyx.db.enums import Permission
+from onyx.db.enums import SkillSharePermission
 from onyx.db.models import Skill
 from onyx.db.models import User
 from onyx.db.skill import affected_user_ids_for_skill
@@ -18,24 +20,36 @@ from onyx.db.skill import delete_skill
 from onyx.db.skill import fetch_skill
 from onyx.db.skill import list_skills
 from onyx.db.skill import replace_skill_bundle
+from onyx.db.skill import replace_skill_shares
 from onyx.db.skill import SkillAccessPolicy
+from onyx.db.skill import transfer_skill_ownership
 from onyx.db.skill import update_skill_fields
+from onyx.db.users import fetch_user_by_id
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.file_store.file_store import get_default_file_store
+from onyx.server.features.skill.models import SkillEditableDetailResponse
 from onyx.server.features.skill.models import SkillPatchRequest
 from onyx.server.features.skill.models import SkillPreviewResponse
 from onyx.server.features.skill.models import SkillResponse
+from onyx.server.features.skill.models import SkillShareRequest
 from onyx.server.features.skill.models import SkillsList
+from onyx.server.features.skill.models import TransferSkillOwnershipRequest
 from onyx.server.features.skill.response_helpers import skill_preview_response
 from onyx.server.features.skill.response_helpers import skill_response_for_user
 from onyx.server.features.skill.response_helpers import skills_list_response_for_user
 from onyx.skills.built_in import BUILT_IN_SKILLS
 from onyx.skills.built_in import EXTERNAL_APP_BUILT_IN_SKILL_IDS
+from onyx.skills.bundle import compute_bundle_sha256
 from onyx.skills.bundle import read_bundle_file
+from onyx.skills.bundle import read_custom_bundle_instructions
+from onyx.skills.bundle import rewrite_custom_bundle_skill_md
 from onyx.skills.bundle import slug_from_filename
+from onyx.skills.content import read_custom_skill_bundle_bytes
+from onyx.skills.content import read_custom_skill_bundle_instructions
 from onyx.skills.ingest import delete_bundle_blob
 from onyx.skills.ingest import ingested_skill_bundle
+from onyx.skills.ingest import save_skill_bundle_bytes
 from onyx.skills.push import push_skill_to_affected_sandboxes
 from onyx.skills.push import push_skills_for_users
 
@@ -140,6 +154,33 @@ def create_custom_skill(
     )
 
 
+@user_router.get("/custom/{skill_id}/edit")
+def fetch_custom_skill_for_edit(
+    skill_id: UUID,
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> SkillEditableDetailResponse:
+    skill = fetch_skill(
+        skill_id,
+        policy=SkillAccessPolicy.EDIT,
+        user=user,
+        db_session=db_session,
+    )
+    if skill is None:
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "Skill not found")
+
+    response = skill_response_for_user(
+        skill,
+        user,
+        db_session,
+        include_share_details=True,
+    )
+    return SkillEditableDetailResponse(
+        **response.model_dump(),
+        instructions_markdown=read_custom_skill_bundle_instructions(skill),
+    )
+
+
 @user_router.put("/custom/{skill_id}/bundle")
 def replace_current_user_skill_bundle(
     skill_id: UUID,
@@ -202,7 +243,7 @@ def patch_current_user_skill(
     if "public_permission" in patch_req.model_fields_set:
         _ensure_can_edit_org_visibility(skill, user)
 
-    if not patch_req.has_db_field_update:
+    if not (patch_req.has_details_update or patch_req.has_db_field_update):
         return skill_response_for_user(
             skill,
             user,
@@ -212,36 +253,235 @@ def patch_current_user_skill(
 
     old_visibility = (skill.public_permission, skill.enabled)
     before_affected = affected_user_ids_for_skill(skill, db_session)
+    file_store = get_default_file_store() if patch_req.has_details_update else None
+    new_bundle_file_id: str | None = None
+    old_bundle_file_id: str | None = None
 
-    public_permission = (
-        patch_req.public_permission
-        if "public_permission" in patch_req.model_fields_set
-        else None
-    )
-    is_public = (
-        public_permission is not None
-        if "public_permission" in patch_req.model_fields_set
-        else None
-    )
-    enabled = patch_req.enabled if "enabled" in patch_req.model_fields_set else None
-    update_skill_fields(
-        skill=skill,
-        is_public=is_public,
-        public_permission=public_permission,
-        enabled=enabled,
-        db_session=db_session,
-    )
+    try:
+        if file_store is not None:
+            old_bundle_bytes = read_custom_skill_bundle_bytes(skill, file_store)
+            name = patch_req.name if patch_req.name is not None else skill.name
+            description = (
+                patch_req.description
+                if patch_req.description is not None
+                else skill.description
+            )
+            instructions_markdown = patch_req.instructions_markdown
+            if instructions_markdown is None:
+                instructions_markdown = read_custom_bundle_instructions(
+                    old_bundle_bytes
+                )
+            new_bundle_bytes = rewrite_custom_bundle_skill_md(
+                old_bundle_bytes,
+                slug=skill.slug,
+                name=name,
+                description=description,
+                instructions_markdown=instructions_markdown,
+            )
+            new_bundle_file_id = save_skill_bundle_bytes(
+                new_bundle_bytes,
+                display_name=f"{skill.slug}.zip",
+                file_store=file_store,
+            )
+            old_bundle_file_id = replace_skill_bundle(
+                skill=skill,
+                new_bundle_file_id=new_bundle_file_id,
+                new_bundle_sha256=compute_bundle_sha256(new_bundle_bytes),
+                new_name=name,
+                new_description=description,
+                db_session=db_session,
+            )
 
-    db_session.commit()
+        if patch_req.has_db_field_update:
+            public_permission = (
+                patch_req.public_permission
+                if "public_permission" in patch_req.model_fields_set
+                else None
+            )
+            is_public = (
+                public_permission is not None
+                if "public_permission" in patch_req.model_fields_set
+                else None
+            )
+            enabled = (
+                patch_req.enabled if "enabled" in patch_req.model_fields_set else None
+            )
+            update_skill_fields(
+                skill=skill,
+                is_public=is_public,
+                public_permission=public_permission,
+                enabled=enabled,
+                db_session=db_session,
+            )
+
+        db_session.commit()
+    except Exception:
+        if file_store is not None and new_bundle_file_id is not None:
+            delete_bundle_blob(file_store, new_bundle_file_id)
+        raise
+
     db_session.expire(skill)
     visibility_changed = old_visibility != (
         skill.public_permission,
         skill.enabled,
     )
-    if visibility_changed:
+    if patch_req.has_details_update or visibility_changed:
         after_affected = affected_user_ids_for_skill(skill, db_session)
         push_skills_for_users(before_affected | after_affected, db_session)
 
+    if file_store is not None and old_bundle_file_id is not None:
+        delete_bundle_blob(file_store, old_bundle_file_id)
+    return skill_response_for_user(
+        skill,
+        user,
+        db_session,
+        include_share_details=True,
+    )
+
+
+@user_router.patch("/custom/{skill_id}/share")
+def share_current_user_skill(
+    skill_id: UUID,
+    share_req: SkillShareRequest,
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> SkillResponse:
+    skill = fetch_skill(
+        skill_id,
+        policy=SkillAccessPolicy.EDIT,
+        user=user,
+        db_session=db_session,
+    )
+    if skill is None:
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "Skill not found")
+    if (
+        share_req.user_shares is None
+        and share_req.group_shares is None
+        and "public_permission" not in share_req.model_fields_set
+    ):
+        return skill_response_for_user(
+            skill,
+            user,
+            db_session,
+            include_share_details=True,
+        )
+
+    touches_org_visibility = "public_permission" in share_req.model_fields_set
+    if touches_org_visibility:
+        _ensure_can_edit_org_visibility(skill, user)
+
+    before_affected = affected_user_ids_for_skill(skill, db_session)
+    if touches_org_visibility:
+        update_skill_fields(
+            skill=skill,
+            is_public=share_req.public_permission is not None,
+            public_permission=share_req.public_permission,
+            db_session=db_session,
+        )
+
+    user_shares: dict[UUID, SkillSharePermission] | None = None
+    if share_req.user_shares is not None:
+        user_shares = {
+            user_share.user_id: user_share.permission
+            for user_share in share_req.user_shares
+            if user_share.user_id != skill.author_user_id
+        }
+
+    group_shares: dict[int, SkillSharePermission] | None = None
+    if share_req.group_shares is not None:
+        group_shares = {
+            group_share.group_id: group_share.permission
+            for group_share in share_req.group_shares
+        }
+
+    replace_skill_shares(
+        skill=skill,
+        user_shares=user_shares,
+        group_shares=group_shares,
+        db_session=db_session,
+    )
+
+    db_session.commit()
+    db_session.expire(skill)
+    after_affected = affected_user_ids_for_skill(skill, db_session)
+    push_skills_for_users(before_affected | after_affected, db_session)
+    return skill_response_for_user(
+        skill,
+        user,
+        db_session,
+        include_share_details=True,
+    )
+
+
+@user_router.post("/custom/{skill_id}/transfer-ownership")
+def transfer_current_user_skill_ownership(
+    skill_id: UUID,
+    transfer_req: TransferSkillOwnershipRequest,
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> SkillResponse:
+    skill = fetch_skill(
+        skill_id,
+        policy=SkillAccessPolicy.VIEW,
+        user=user,
+        db_session=db_session,
+    )
+    if skill is None:
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "Skill not found")
+    if skill.built_in_skill_id is not None:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            f"Skill '{skill.slug}' is a built-in and cannot change ownership.",
+        )
+
+    ownership_vacant = (
+        skill.author_user_id is None
+        or skill.author is None
+        or not skill.author.is_active
+    )
+    if skill.author_user_id != user.id and not (
+        user.role == UserRole.ADMIN and ownership_vacant
+    ):
+        raise OnyxError(
+            OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+            "Only the owner can transfer ownership of this skill.",
+        )
+
+    target = fetch_user_by_id(db_session, transfer_req.new_owner_user_id)
+    if target is None:
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "New owner not found.")
+    if not target.is_active:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "Ownership can only be transferred to an active user.",
+        )
+    if target.role in [UserRole.SLACK_USER, UserRole.EXT_PERM_USER, UserRole.LIMITED]:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "Ownership cannot be transferred to this account type.",
+        )
+    if target.account_type is not None and target.account_type != AccountType.STANDARD:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "Ownership cannot be transferred to bots or service accounts.",
+        )
+    if target.id == skill.author_user_id:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "This user already owns the skill.",
+        )
+
+    before_affected = affected_user_ids_for_skill(skill, db_session)
+    transfer_skill_ownership(
+        skill=skill,
+        new_owner_user_id=target.id,
+        db_session=db_session,
+    )
+
+    db_session.commit()
+    db_session.expire(skill)
+    after_affected = affected_user_ids_for_skill(skill, db_session)
+    push_skills_for_users(before_affected | after_affected, db_session)
     return skill_response_for_user(
         skill,
         user,

--- a/backend/onyx/server/features/skill/models.py
+++ b/backend/onyx/server/features/skill/models.py
@@ -172,9 +172,16 @@ class SkillPreviewResponse(BaseModel):
         )
 
 
+class SkillEditableDetailResponse(SkillResponse):
+    instructions_markdown: str
+
+
 class SkillPatchRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    name: str | None = None
+    description: str | None = None
+    instructions_markdown: str | None = None
     public_permission: SkillSharePermission | None = None
     enabled: bool | None = None
 
@@ -184,10 +191,56 @@ class SkillPatchRequest(BaseModel):
         """Omitting a field = 'leave unchanged'. Null ``enabled`` is invalid;
         null ``public_permission`` is valid and revokes org-wide access."""
         if isinstance(data, dict):
-            if "enabled" in data and data["enabled"] is None:
-                raise ValueError("enabled cannot be null")
+            for field in (
+                "name",
+                "description",
+                "instructions_markdown",
+                "enabled",
+            ):
+                if field in data and data[field] is None:
+                    raise ValueError(f"{field} cannot be null")
         return data
+
+    @model_validator(mode="after")
+    def _strip_values(self) -> "SkillPatchRequest":
+        for field in ("name", "description", "instructions_markdown"):
+            value = getattr(self, field)
+            if value is None:
+                continue
+            stripped = value.strip()
+            if not stripped:
+                raise ValueError(f"{field} cannot be empty")
+            setattr(self, field, stripped)
+        return self
+
+    @property
+    def has_details_update(self) -> bool:
+        return bool(
+            self.model_fields_set & {"name", "description", "instructions_markdown"}
+        )
 
     @property
     def has_db_field_update(self) -> bool:
         return bool(self.model_fields_set & {"public_permission", "enabled"})
+
+
+class SkillUserShareRequest(BaseModel):
+    user_id: UUID
+    permission: SkillSharePermission
+
+
+class SkillGroupShareRequest(BaseModel):
+    group_id: int
+    permission: SkillSharePermission
+
+
+class SkillShareRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    user_shares: list[SkillUserShareRequest] | None = None
+    group_shares: list[SkillGroupShareRequest] | None = None
+    public_permission: SkillSharePermission | None = None
+
+
+class TransferSkillOwnershipRequest(BaseModel):
+    new_owner_user_id: UUID

--- a/backend/onyx/server/features/skill/models.py
+++ b/backend/onyx/server/features/skill/models.py
@@ -188,8 +188,8 @@ class SkillPatchRequest(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def _reject_explicit_nulls(cls, data: Any) -> Any:
-        """Omitting a field = 'leave unchanged'. Null ``enabled`` is invalid;
-        null ``public_permission`` is valid and revokes org-wide access."""
+        """Omitting a field = 'leave unchanged'. Null is invalid for these
+        fields; null ``public_permission`` is valid and revokes org access."""
         if isinstance(data, dict):
             for field in (
                 "name",

--- a/backend/tests/external_dependency_unit/craft/test_skill_db_mutations.py
+++ b/backend/tests/external_dependency_unit/craft/test_skill_db_mutations.py
@@ -145,7 +145,7 @@ def test_replace_skill_shares_leaves_omitted_share_types_unchanged(
     }
 
 
-def test_replace_skill_shares_preserves_invalid_target_message(
+def test_replace_skill_shares_names_invalid_group_target(
     db_session: Session,
 ) -> None:
     skill = make_skill(db_session)
@@ -158,7 +158,23 @@ def test_replace_skill_shares_preserves_invalid_target_message(
         )
 
     assert exc_info.value.error_code == OnyxErrorCode.INVALID_INPUT
-    assert exc_info.value.detail == "One or more share targets do not exist."
+    assert exc_info.value.detail == "One or more group share targets do not exist."
+
+
+def test_replace_skill_shares_names_invalid_user_target(
+    db_session: Session,
+) -> None:
+    skill = make_skill(db_session)
+
+    with pytest.raises(OnyxError) as exc_info:
+        replace_skill_shares(
+            skill=skill,
+            user_shares={uuid4(): SkillSharePermission.VIEWER},
+            db_session=db_session,
+        )
+
+    assert exc_info.value.error_code == OnyxErrorCode.INVALID_INPUT
+    assert exc_info.value.detail == "One or more user share targets do not exist."
 
 
 def test_transfer_skill_ownership_removes_new_owner_direct_share_and_upgrades_previous_owner(

--- a/backend/tests/external_dependency_unit/craft/test_skill_ownership_transfer.py
+++ b/backend/tests/external_dependency_unit/craft/test_skill_ownership_transfer.py
@@ -1,0 +1,318 @@
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from onyx.db.enums import AccountType
+from onyx.db.enums import SkillSharePermission
+from onyx.db.models import Skill
+from onyx.db.models import Skill__User
+from onyx.db.models import User
+from onyx.db.models import UserRole
+from onyx.db.skill import transfer_skill_ownership
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.features.skill.api import transfer_current_user_skill_ownership
+from onyx.server.features.skill.models import TransferSkillOwnershipRequest
+from tests.external_dependency_unit.craft.db_helpers import make_built_in_skill_row
+from tests.external_dependency_unit.craft.db_helpers import make_sandbox
+from tests.external_dependency_unit.craft.db_helpers import make_skill
+from tests.external_dependency_unit.craft.db_helpers import make_user
+from tests.external_dependency_unit.craft.db_helpers import share_skill_with_user
+
+
+def _owned_skill(db_session: Session, owner: User) -> Skill:
+    skill = make_skill(db_session)
+    skill.author_user_id = owner.id
+    db_session.flush()
+    return skill
+
+
+def _share_row(
+    db_session: Session,
+    skill: Skill,
+    user: User,
+) -> Skill__User | None:
+    return db_session.scalar(
+        select(Skill__User).where(
+            Skill__User.skill_id == skill.id,
+            Skill__User.user_id == user.id,
+        )
+    )
+
+
+@pytest.fixture(autouse=True)
+def push_calls(monkeypatch: pytest.MonkeyPatch) -> list[set[object]]:
+    calls: list[set[object]] = []
+    monkeypatch.setattr(
+        "onyx.server.features.skill.api.push_skills_for_users",
+        lambda user_ids, _db_session: calls.append(set(user_ids)),
+    )
+    return calls
+
+
+def test_owner_transfers_to_active_user(
+    db_session: Session,
+    push_calls: list[set[object]],
+) -> None:
+    owner = make_user(db_session, role=UserRole.BASIC)
+    new_owner = make_user(db_session, role=UserRole.BASIC)
+    skill = _owned_skill(db_session, owner)
+    share_skill_with_user(
+        db_session,
+        skill,
+        new_owner,
+        SkillSharePermission.VIEWER,
+    )
+
+    response = transfer_current_user_skill_ownership(
+        skill.id,
+        TransferSkillOwnershipRequest(new_owner_user_id=new_owner.id),
+        user=owner,
+        db_session=db_session,
+    )
+    db_session.refresh(skill)
+
+    assert response.author_user_id == new_owner.id
+    assert skill.author_user_id == new_owner.id
+    assert _share_row(db_session, skill, new_owner) is None
+    previous_owner_share = _share_row(db_session, skill, owner)
+    assert previous_owner_share is not None
+    assert previous_owner_share.permission == SkillSharePermission.EDITOR
+    assert push_calls == [set()]
+
+
+def test_transfer_pushes_previous_and_new_owner_sandboxes(
+    db_session: Session,
+    push_calls: list[set[object]],
+) -> None:
+    owner = make_user(db_session, role=UserRole.BASIC)
+    new_owner = make_user(db_session, role=UserRole.BASIC)
+    make_sandbox(db_session, owner)
+    make_sandbox(db_session, new_owner)
+    skill = _owned_skill(db_session, owner)
+
+    transfer_current_user_skill_ownership(
+        skill.id,
+        TransferSkillOwnershipRequest(new_owner_user_id=new_owner.id),
+        user=owner,
+        db_session=db_session,
+    )
+
+    assert push_calls == [{owner.id, new_owner.id}]
+
+
+def test_transfer_to_current_owner_is_noop(
+    db_session: Session,
+    push_calls: list[set[object]],
+) -> None:
+    owner = make_user(db_session, role=UserRole.BASIC)
+    skill = _owned_skill(db_session, owner)
+    share_skill_with_user(db_session, skill, owner, SkillSharePermission.VIEWER)
+
+    transfer_skill_ownership(
+        skill=skill,
+        new_owner_user_id=owner.id,
+        db_session=db_session,
+    )
+
+    db_session.refresh(skill)
+    assert skill.author_user_id == owner.id
+    owner_share = _share_row(db_session, skill, owner)
+    assert owner_share is not None
+    assert owner_share.permission == SkillSharePermission.VIEWER
+    assert push_calls == []
+
+
+def test_transfer_rejects_built_in_skill(
+    db_session: Session,
+    push_calls: list[set[object]],
+) -> None:
+    target = make_user(db_session, role=UserRole.BASIC)
+    skill = make_built_in_skill_row(
+        db_session,
+        built_in_skill_id=f"builtin-transfer-{uuid4().hex[:8]}",
+        is_public=True,
+    )
+
+    with pytest.raises(OnyxError) as exc_info:
+        transfer_skill_ownership(
+            skill=skill,
+            new_owner_user_id=target.id,
+            db_session=db_session,
+        )
+
+    assert exc_info.value.error_code == OnyxErrorCode.INVALID_INPUT
+    db_session.refresh(skill)
+    assert skill.author_user_id is None
+    assert push_calls == []
+
+
+def test_transfer_rejects_missing_target_helper(
+    db_session: Session,
+    push_calls: list[set[object]],
+) -> None:
+    owner = make_user(db_session, role=UserRole.BASIC)
+    skill = _owned_skill(db_session, owner)
+
+    with pytest.raises(OnyxError) as exc_info:
+        transfer_skill_ownership(
+            skill=skill,
+            new_owner_user_id=uuid4(),
+            db_session=db_session,
+        )
+
+    assert exc_info.value.error_code == OnyxErrorCode.INVALID_INPUT
+    assert exc_info.value.detail == "New owner user does not exist."
+    assert push_calls == []
+
+
+@pytest.mark.parametrize(
+    "permission",
+    [SkillSharePermission.VIEWER, SkillSharePermission.EDITOR],
+)
+def test_non_owner_sharee_cannot_transfer(
+    db_session: Session,
+    permission: SkillSharePermission,
+    push_calls: list[set[object]],
+) -> None:
+    owner = make_user(db_session, role=UserRole.BASIC)
+    sharee = make_user(db_session, role=UserRole.BASIC)
+    target = make_user(db_session, role=UserRole.BASIC)
+    skill = _owned_skill(db_session, owner)
+    share_skill_with_user(db_session, skill, sharee, permission)
+
+    with pytest.raises(OnyxError) as exc_info:
+        transfer_current_user_skill_ownership(
+            skill.id,
+            TransferSkillOwnershipRequest(new_owner_user_id=target.id),
+            user=sharee,
+            db_session=db_session,
+        )
+
+    assert exc_info.value.error_code == OnyxErrorCode.INSUFFICIENT_PERMISSIONS
+    db_session.refresh(skill)
+    assert skill.author_user_id == owner.id
+    assert _share_row(db_session, skill, sharee) is not None
+    assert push_calls == []
+
+
+def test_transfer_rejects_inactive_target(
+    db_session: Session,
+    push_calls: list[set[object]],
+) -> None:
+    owner = make_user(db_session, role=UserRole.BASIC)
+    target = make_user(db_session, role=UserRole.BASIC)
+    target.is_active = False
+    skill = _owned_skill(db_session, owner)
+    db_session.flush()
+
+    with pytest.raises(OnyxError) as exc_info:
+        transfer_current_user_skill_ownership(
+            skill.id,
+            TransferSkillOwnershipRequest(new_owner_user_id=target.id),
+            user=owner,
+            db_session=db_session,
+        )
+
+    assert exc_info.value.error_code == OnyxErrorCode.INVALID_INPUT
+    db_session.refresh(skill)
+    assert skill.author_user_id == owner.id
+    assert _share_row(db_session, skill, target) is None
+    assert push_calls == []
+
+
+def test_transfer_rejects_unsupported_target_account_type(
+    db_session: Session,
+    push_calls: list[set[object]],
+) -> None:
+    owner = make_user(db_session, role=UserRole.BASIC)
+    target = make_user(
+        db_session,
+        role=UserRole.BASIC,
+    )
+    target.account_type = AccountType.BOT
+    skill = _owned_skill(db_session, owner)
+    db_session.flush()
+
+    with pytest.raises(OnyxError) as exc_info:
+        transfer_current_user_skill_ownership(
+            skill.id,
+            TransferSkillOwnershipRequest(new_owner_user_id=target.id),
+            user=owner,
+            db_session=db_session,
+        )
+
+    assert exc_info.value.error_code == OnyxErrorCode.INVALID_INPUT
+    db_session.refresh(skill)
+    assert skill.author_user_id == owner.id
+    assert _share_row(db_session, skill, target) is None
+    assert push_calls == []
+
+
+def test_admin_transfers_vacant_skill(
+    db_session: Session,
+    push_calls: list[set[object]],
+) -> None:
+    admin = make_user(db_session, role=UserRole.ADMIN)
+    target = make_user(db_session, role=UserRole.BASIC)
+    skill = make_skill(db_session)
+
+    response = transfer_current_user_skill_ownership(
+        skill.id,
+        TransferSkillOwnershipRequest(new_owner_user_id=target.id),
+        user=admin,
+        db_session=db_session,
+    )
+    db_session.refresh(skill)
+
+    assert response.author_user_id == target.id
+    assert skill.author_user_id == target.id
+    assert _share_row(db_session, skill, admin) is None
+    assert push_calls == [set()]
+
+
+def test_admin_cannot_transfer_owned_skill(
+    db_session: Session,
+    push_calls: list[set[object]],
+) -> None:
+    owner = make_user(db_session, role=UserRole.BASIC)
+    admin = make_user(db_session, role=UserRole.ADMIN)
+    target = make_user(db_session, role=UserRole.BASIC)
+    skill = _owned_skill(db_session, owner)
+
+    with pytest.raises(OnyxError) as exc_info:
+        transfer_current_user_skill_ownership(
+            skill.id,
+            TransferSkillOwnershipRequest(new_owner_user_id=target.id),
+            user=admin,
+            db_session=db_session,
+        )
+
+    assert exc_info.value.error_code == OnyxErrorCode.INSUFFICIENT_PERMISSIONS
+    db_session.refresh(skill)
+    assert skill.author_user_id == owner.id
+    assert _share_row(db_session, skill, target) is None
+    assert push_calls == []
+
+
+def test_transfer_rejects_missing_target(
+    db_session: Session,
+    push_calls: list[set[object]],
+) -> None:
+    owner = make_user(db_session, role=UserRole.BASIC)
+    skill = _owned_skill(db_session, owner)
+
+    with pytest.raises(OnyxError) as exc_info:
+        transfer_current_user_skill_ownership(
+            skill.id,
+            TransferSkillOwnershipRequest(new_owner_user_id=uuid4()),
+            user=owner,
+            db_session=db_session,
+        )
+
+    assert exc_info.value.error_code == OnyxErrorCode.NOT_FOUND
+    db_session.refresh(skill)
+    assert skill.author_user_id == owner.id
+    assert push_calls == []

--- a/backend/tests/integration/common_utils/managers/skill.py
+++ b/backend/tests/integration/common_utils/managers/skill.py
@@ -261,13 +261,17 @@ class SkillManager:
         elif is_public is True:
             org_public_permission = SkillSharePermission.VIEWER
 
-        share_req = SkillShareRequest(
-            user_shares=list(user_shares) if user_shares is not None else None,
-            group_shares=list(group_shares) if group_shares is not None else None,
-            public_permission=org_public_permission,
-        )
+        # Constructor kwargs land in model_fields_set even when None, so only
+        # pass fields the caller actually set — an explicit null
+        # public_permission would revoke org-wide access.
+        share_fields: dict[str, object] = {}
+        if user_shares is not None:
+            share_fields["user_shares"] = list(user_shares)
+        if group_shares is not None:
+            share_fields["group_shares"] = list(group_shares)
         if include_org_visibility:
-            share_req.model_fields_set.add("public_permission")
+            share_fields["public_permission"] = org_public_permission
+        share_req = SkillShareRequest.model_validate(share_fields)
 
         response = client.patch(
             f"{API_SERVER_URL}/skills/custom/{skill.id}/share",

--- a/backend/tests/integration/common_utils/managers/skill.py
+++ b/backend/tests/integration/common_utils/managers/skill.py
@@ -1,5 +1,6 @@
 import io
 import zipfile
+from collections.abc import Sequence
 from typing import TypeVar
 from uuid import UUID
 from uuid import uuid4
@@ -8,10 +9,15 @@ import httpx
 from pydantic import BaseModel
 
 from onyx.db.enums import SkillSharePermission
+from onyx.server.features.skill.models import SkillEditableDetailResponse
+from onyx.server.features.skill.models import SkillGroupShareRequest
 from onyx.server.features.skill.models import SkillPatchRequest
 from onyx.server.features.skill.models import SkillPreviewResponse
 from onyx.server.features.skill.models import SkillResponse
+from onyx.server.features.skill.models import SkillShareRequest
 from onyx.server.features.skill.models import SkillsList
+from onyx.server.features.skill.models import SkillUserShareRequest
+from onyx.server.features.skill.models import TransferSkillOwnershipRequest
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.http_client import client
 from tests.integration.common_utils.test_models import DATestUser
@@ -58,6 +64,7 @@ class SkillManager:
         name: str | None = None,
         description: str | None = None,
         is_public: bool = False,
+        group_ids: list[int] | None = None,
         bundle_bytes: bytes | None = None,
         filename: str | None = None,
     ) -> SkillResponse:
@@ -84,14 +91,24 @@ class SkillManager:
         response.raise_for_status()
         skill = _response_model(response, SkillResponse)
 
-        if is_public:
-            patch_response = client.patch(
-                f"{API_SERVER_URL}/skills/custom/{skill.id}",
-                json={"public_permission": SkillSharePermission.VIEWER.value},
+        if is_public or group_ids:
+            share_req = SkillShareRequest(
+                public_permission=SkillSharePermission.VIEWER if is_public else None,
+                group_shares=[
+                    SkillGroupShareRequest(
+                        group_id=group_id,
+                        permission=SkillSharePermission.VIEWER,
+                    )
+                    for group_id in group_ids or []
+                ],
+            )
+            share_response = client.patch(
+                f"{API_SERVER_URL}/skills/custom/{skill.id}/share",
+                json=share_req.model_dump(mode="json", exclude_unset=True),
                 headers=user_performing_action.headers,
             )
-            patch_response.raise_for_status()
-            return _response_model(patch_response, SkillResponse)
+            share_response.raise_for_status()
+            return _response_model(share_response, SkillResponse)
 
         return skill
 
@@ -131,6 +148,29 @@ class SkillManager:
                 )
             },
             headers=headers,
+        )
+        response.raise_for_status()
+        return _response_model(response, SkillResponse)
+
+    @staticmethod
+    def replace_group_shares(
+        skill: SkillResponse,
+        group_ids: list[int],
+        user_performing_action: DATestUser,
+    ) -> SkillResponse:
+        share_req = SkillShareRequest(
+            group_shares=[
+                SkillGroupShareRequest(
+                    group_id=group_id,
+                    permission=SkillSharePermission.VIEWER,
+                )
+                for group_id in group_ids
+            ],
+        )
+        response = client.patch(
+            f"{API_SERVER_URL}/skills/custom/{skill.id}/share",
+            json=share_req.model_dump(mode="json", exclude_none=True),
+            headers=user_performing_action.headers,
         )
         response.raise_for_status()
         return _response_model(response, SkillResponse)
@@ -191,6 +231,68 @@ class SkillManager:
         )
         response.raise_for_status()
         return _response_model(response, SkillPreviewResponse)
+
+    @staticmethod
+    def get_editable(
+        skill_id: str | UUID,
+        user_performing_action: DATestUser,
+    ) -> SkillEditableDetailResponse:
+        response = client.get(
+            f"{API_SERVER_URL}/skills/custom/{skill_id}/edit",
+            headers=user_performing_action.headers,
+        )
+        response.raise_for_status()
+        return _response_model(response, SkillEditableDetailResponse)
+
+    @staticmethod
+    def share(
+        skill: SkillResponse,
+        user_performing_action: DATestUser,
+        *,
+        is_public: bool | None = None,
+        public_permission: SkillSharePermission | None = None,
+        user_shares: Sequence[SkillUserShareRequest] | None = None,
+        group_shares: Sequence[SkillGroupShareRequest] | None = None,
+    ) -> SkillResponse:
+        org_public_permission: SkillSharePermission | None = None
+        include_org_visibility = is_public is not None or public_permission is not None
+        if public_permission is not None:
+            org_public_permission = public_permission
+        elif is_public is True:
+            org_public_permission = SkillSharePermission.VIEWER
+
+        share_req = SkillShareRequest(
+            user_shares=list(user_shares) if user_shares is not None else None,
+            group_shares=list(group_shares) if group_shares is not None else None,
+            public_permission=org_public_permission,
+        )
+        if include_org_visibility:
+            share_req.model_fields_set.add("public_permission")
+
+        response = client.patch(
+            f"{API_SERVER_URL}/skills/custom/{skill.id}/share",
+            json=share_req.model_dump(mode="json", exclude_unset=True),
+            headers=user_performing_action.headers,
+        )
+        response.raise_for_status()
+        return _response_model(response, SkillResponse)
+
+    @staticmethod
+    def transfer_ownership(
+        skill: SkillResponse,
+        new_owner_user_id: UUID | str,
+        user_performing_action: DATestUser,
+    ) -> SkillResponse:
+        transfer_req = TransferSkillOwnershipRequest(
+            new_owner_user_id=UUID(str(new_owner_user_id))
+        )
+        response = client.post(
+            f"{API_SERVER_URL}/skills/custom/{skill.id}/transfer-ownership",
+            json=transfer_req.model_dump(mode="json"),
+            headers=user_performing_action.headers,
+        )
+        response.raise_for_status()
+        return _response_model(response, SkillResponse)
 
     @staticmethod
     def create_personal(

--- a/backend/tests/integration/tests/craft/k8s/test_skill_push.py
+++ b/backend/tests/integration/tests/craft/k8s/test_skill_push.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from uuid import UUID
 from uuid import uuid4
 
+import httpx
 import pytest
 from sqlalchemy.orm import Session
 
@@ -31,13 +32,16 @@ from onyx.server.features.build.configs import SANDBOX_BACKEND
 from onyx.server.features.build.configs import SandboxBackend
 from onyx.server.features.skill.models import SkillPatchRequest
 from onyx.server.features.skill.models import SkillResponse
+from onyx.server.features.skill.models import SkillUserShareRequest
 from onyx.skills.built_in import BUILT_IN_SKILLS
 from onyx.skills.built_in import BuiltInSkillDefinition
 from onyx.skills.push import build_skills_fileset_for_user
 from onyx.skills.push import push_skill_to_affected_sandboxes
 from tests.integration.common_utils.managers.skill import SkillManager
 from tests.integration.common_utils.managers.user import UserManager
+from tests.integration.common_utils.managers.user_group import UserGroupManager
 from tests.integration.common_utils.test_models import DATestUser
+from tests.integration.common_utils.test_models import DATestUserGroup
 from tests.integration.tests.craft.k8s.k8s_fixtures import SandboxHandle
 from tests.integration.tests.craft.k8s.k8s_fixtures import WorkspaceProxy
 
@@ -83,11 +87,13 @@ def _create_skill(
     *,
     body: bytes | str,
     is_public: bool = False,
+    group_ids: list[int] | None = None,
 ) -> SkillResponse:
     return SkillManager.create_custom(
         admin,
         slug=slug,
         is_public=is_public,
+        group_ids=group_ids or [],
         bundle_bytes=_bundle(slug, body),
         filename=f"{slug}.zip",
     )
@@ -109,6 +115,32 @@ def _replace_bundle(
 def _create_users(count: int) -> list[DATestUser]:
     prefix = f"craft-k8s-skill-{uuid4().hex[:8]}"
     return [UserManager.create(name=f"{prefix}-{idx}") for idx in range(count)]
+
+
+@pytest.fixture
+def user_group_factory(
+    k8s_admin_user: DATestUser,
+) -> Generator[Callable[[str, list[str]], DATestUserGroup], None, None]:
+    groups: list[DATestUserGroup] = []
+
+    def _create(name: str, user_ids: list[str]) -> DATestUserGroup:
+        group = UserGroupManager.create(
+            k8s_admin_user,
+            name=name,
+            user_ids=user_ids,
+        )
+        groups.append(group)
+        return group
+
+    try:
+        yield _create
+    finally:
+        for group in reversed(groups):
+            try:
+                UserGroupManager.delete(group, k8s_admin_user)
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code != 404:
+                    raise
 
 
 def _make_db_group(db_session: Session, name: str) -> UserGroup:
@@ -309,20 +341,53 @@ class TestSkillPush:
                 b"public skill body\n",
             )
 
+    def test_private_skill_only_lands_in_shared_users_sandboxes(
+        self,
+        k8s_admin_user: DATestUser,
+        running_sandbox: Callable[..., SandboxHandle],
+        user_group_factory: Callable[[str, list[str]], DATestUserGroup],
+    ) -> None:
+        handle = running_sandbox()
+        user_a, user_b, user_c = _create_users(3)
+        [ws_a, ws_b, ws_c] = handle.provision_api_users([user_a, user_b, user_c])
+        group = user_group_factory(
+            f"engineering-{uuid4().hex[:6]}",
+            [user_a.id],
+        )
+
+        slug = f"eng-only-{uuid4().hex[:6]}"
+        skill = _create_skill(
+            k8s_admin_user,
+            slug,
+            is_public=False,
+            group_ids=[group.id],
+            body="engineering only\n",
+        )
+
+        _skill_file_path(ws_a, skill.slug).wait_for_bytes(b"engineering only\n")
+        _skill_file_path(ws_b, skill.slug).wait_for_absent()
+        _skill_file_path(ws_c, skill.slug).wait_for_absent()
+
     def test_disable_skill_removes_files_from_affected_sandboxes(
         self,
         k8s_admin_user: DATestUser,
         running_sandbox: Callable[..., SandboxHandle],
+        user_group_factory: Callable[[str, list[str]], DATestUserGroup],
     ) -> None:
         handle = running_sandbox()
         [user] = _create_users(1)
         [workspace] = handle.provision_api_users([user])
+        group = user_group_factory(
+            f"disable-grp-{uuid4().hex[:6]}",
+            [user.id],
+        )
 
         slug = f"disable-me-{uuid4().hex[:6]}"
         skill = _create_skill(
             k8s_admin_user,
             slug,
-            is_public=True,
+            is_public=False,
+            group_ids=[group.id],
             body="to be disabled\n",
         )
         _skill_file_path(workspace, skill.slug).wait_for_bytes(b"to be disabled\n")
@@ -332,6 +397,88 @@ class TestSkillPush:
         )
 
         (_skills_dir(workspace) / skill.slug).wait_for_absent()
+
+    def test_share_change_adds_to_newly_shared_and_removes_from_revoked(
+        self,
+        k8s_admin_user: DATestUser,
+        running_sandbox: Callable[..., SandboxHandle],
+        user_group_factory: Callable[[str, list[str]], DATestUserGroup],
+    ) -> None:
+        handle = running_sandbox()
+        user_a, user_b = _create_users(2)
+        [ws_a, ws_b] = handle.provision_api_users([user_a, user_b])
+        group_x = user_group_factory(
+            f"grp-x-{uuid4().hex[:6]}",
+            [user_a.id],
+        )
+        group_y = user_group_factory(
+            f"grp-y-{uuid4().hex[:6]}",
+            [user_b.id],
+        )
+
+        slug = f"shares-flip-{uuid4().hex[:6]}"
+        skill = _create_skill(
+            k8s_admin_user,
+            slug,
+            is_public=False,
+            group_ids=[group_x.id],
+            body="shifting shares\n",
+        )
+        _skill_file_path(ws_a, skill.slug).wait_for_bytes(b"shifting shares\n")
+        _skill_file_path(ws_b, skill.slug).wait_for_absent()
+
+        SkillManager.replace_group_shares(skill, [group_y.id], k8s_admin_user)
+
+        _skill_file_path(ws_a, skill.slug).wait_for_absent()
+        _skill_file_path(ws_b, skill.slug).wait_for_bytes(b"shifting shares\n")
+
+    def test_direct_user_share_change_adds_to_newly_shared_and_removes_from_revoked(
+        self,
+        k8s_admin_user: DATestUser,
+        running_sandbox: Callable[..., SandboxHandle],
+    ) -> None:
+        handle = running_sandbox()
+        user_a, user_b = _create_users(2)
+        [ws_a, ws_b] = handle.provision_api_users([user_a, user_b])
+
+        slug = f"direct-shares-flip-{uuid4().hex[:6]}"
+        skill = _create_skill(
+            k8s_admin_user,
+            slug,
+            is_public=False,
+            body="direct shifting shares\n",
+        )
+        _skill_file_path(ws_a, skill.slug).wait_for_absent()
+        _skill_file_path(ws_b, skill.slug).wait_for_absent()
+
+        skill = SkillManager.share(
+            skill,
+            k8s_admin_user,
+            user_shares=[
+                SkillUserShareRequest(
+                    user_id=UUID(user_a.id),
+                    permission=SkillSharePermission.VIEWER,
+                )
+            ],
+        )
+        assert [str(share.user.id) for share in skill.user_shares] == [user_a.id]
+        _skill_file_path(ws_a, skill.slug).wait_for_bytes(b"direct shifting shares\n")
+        _skill_file_path(ws_b, skill.slug).wait_for_absent()
+
+        skill = SkillManager.share(
+            skill,
+            k8s_admin_user,
+            user_shares=[
+                SkillUserShareRequest(
+                    user_id=UUID(user_b.id),
+                    permission=SkillSharePermission.VIEWER,
+                )
+            ],
+        )
+        assert [str(share.user.id) for share in skill.user_shares] == [user_b.id]
+
+        _skill_file_path(ws_a, skill.slug).wait_for_absent()
+        _skill_file_path(ws_b, skill.slug).wait_for_bytes(b"direct shifting shares\n")
 
     def test_replace_bundle_propagates_new_content(
         self,
@@ -378,6 +525,39 @@ class TestSkillPush:
 
         (_skills_dir(ws_a) / skill.slug).wait_for_absent()
         (_skills_dir(ws_b) / skill.slug).wait_for_absent()
+
+    def test_user_with_overlapping_shares_receives_skill_once(
+        self,
+        k8s_admin_user: DATestUser,
+        running_sandbox: Callable[..., SandboxHandle],
+        user_group_factory: Callable[[str, list[str]], DATestUserGroup],
+    ) -> None:
+        handle = running_sandbox()
+        [user] = _create_users(1)
+        [workspace] = handle.provision_api_users([user])
+        group_x = user_group_factory(
+            f"dup-x-{uuid4().hex[:6]}",
+            [user.id],
+        )
+        group_y = user_group_factory(
+            f"dup-y-{uuid4().hex[:6]}",
+            [user.id],
+        )
+
+        slug = f"dup-shares-{uuid4().hex[:6]}"
+        skill = _create_skill(
+            k8s_admin_user,
+            slug,
+            is_public=False,
+            group_ids=[group_x.id, group_y.id],
+            body="dedup\n",
+        )
+
+        _skill_file_path(workspace, skill.slug).wait_for_bytes(b"dedup\n")
+        skill_dir = _skills_dir(workspace) / skill.slug
+        skill_files = [p for p in skill_dir.rglob("*") if p.is_file()]
+        assert len(skill_files) == 1
+        assert skill_files[0].name == "SKILL.md"
 
 
 class TestSkillPushLowLevel:

--- a/backend/tests/integration/tests/skills/test_skills_admin.py
+++ b/backend/tests/integration/tests/skills/test_skills_admin.py
@@ -22,6 +22,7 @@ from tests.integration.common_utils.http_client import client
 from tests.integration.common_utils.managers.skill import build_minimal_bundle
 from tests.integration.common_utils.managers.skill import SkillManager
 from tests.integration.common_utils.managers.user import UserManager
+from tests.integration.common_utils.managers.user_group import UserGroupManager
 from tests.integration.common_utils.test_models import DATestUser
 
 # ---------------------------------------------------------------------------
@@ -147,6 +148,14 @@ def test_bundle_with_template_rejected(admin_user: DATestUser) -> None:
     assert exc_info.value.response.status_code == 400
 
 
+def test_group_shares_replace(admin_user: DATestUser) -> None:
+    skill = SkillManager.create_custom(
+        admin_user, slug=f"group-shares-test-{uuid4().hex[:6]}", is_public=False
+    )
+    updated = SkillManager.replace_group_shares(skill, [], admin_user)
+    assert updated.group_shares == []
+
+
 def test_metadata_from_bundle_frontmatter(admin_user: DATestUser) -> None:
     bundle = build_minimal_bundle(
         "from-frontmatter", name="From Bundle", description="From bundle desc"
@@ -186,16 +195,21 @@ def test_bad_filename_rejected(admin_user: DATestUser) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_create_skill_201_persists_row_and_bundle(
+def test_create_skill_201_persists_row_group_shares_bundle(
     admin_user: DATestUser,
 ) -> None:
-    """POST -> row persisted with bundle blob visible in DB."""
+    """POST -> row persisted with bundle blob and group shares visible in DB."""
+    group = UserGroupManager.create(admin_user, name="create-shares-group")
+
     slug = f"persist-{uuid4().hex[:8]}"
     skill = SkillManager.create_custom(
         admin_user,
         slug=slug,
         is_public=False,
+        group_ids=[group.id],
     )
+
+    assert [share.group_id for share in skill.group_shares] == [group.id]
 
     row = _fetch_skill_row(skill.id)
     assert row is not None, "skill row missing after create"
@@ -333,6 +347,35 @@ def test_create_skill_failure_cleans_up_orphan_blob(
         f"expected exactly one skill row with slug {slug}; got {len(rows)}"
     )
     assert rows[0].bundle_file_id == first_blob_id
+
+
+# ---------------------------------------------------------------------------
+# Sharing
+# ---------------------------------------------------------------------------
+
+
+def test_replace_group_shares_400_on_unknown_group_id(
+    admin_user: DATestUser,
+) -> None:
+    """Unknown group id → 400 with a message that names the failure mode.
+
+    Regression for SHA `c5e427ceab`: FK violations must surface as a 400
+    INVALID_INPUT, not a 500.
+    """
+    skill = SkillManager.create_custom(
+        admin_user, slug=f"unknown-grp-{uuid4().hex[:8]}", is_public=False
+    )
+
+    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+        SkillManager.replace_group_shares(skill, [10_000_000], admin_user)
+
+    response = exc_info.value.response
+    assert response.status_code == 400
+    body = response.json()
+    detail = str(body.get("detail") or body)
+    assert "group" in detail.lower(), (
+        f"error detail must mention groups; got {detail!r}"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/integration/tests/skills/test_skills_management.py
+++ b/backend/tests/integration/tests/skills/test_skills_management.py
@@ -1,0 +1,428 @@
+from __future__ import annotations
+
+from uuid import UUID
+from uuid import uuid4
+
+import httpx
+import pytest
+
+from onyx.db.enums import SkillAccessLevel
+from onyx.db.enums import SkillSharePermission
+from onyx.server.features.skill.models import SkillPatchRequest
+from onyx.server.features.skill.models import SkillResponse
+from onyx.server.features.skill.models import SkillUserShareRequest
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.http_client import client
+from tests.integration.common_utils.managers.skill import SkillManager
+from tests.integration.common_utils.managers.user import UserManager
+from tests.integration.common_utils.test_models import DATestUser
+
+
+def _assert_skill_hidden(skill_id: object, user: DATestUser) -> None:
+    response = client.get(
+        f"{API_SERVER_URL}/skills/{skill_id}",
+        headers=user.headers,
+    )
+    assert response.status_code == 404
+
+
+def _assert_edit_hidden(skill_id: object, user: DATestUser) -> None:
+    response = client.get(
+        f"{API_SERVER_URL}/skills/custom/{skill_id}/edit",
+        headers=user.headers,
+    )
+    assert response.status_code == 404
+
+
+def _skill_id(skill: SkillResponse) -> UUID:
+    return skill.id
+
+
+def test_edit_fetch_returns_instructions_and_share_details(
+    basic_user: DATestUser,
+    admin_user: DATestUser,  # noqa: ARG001
+) -> None:
+    editor = UserManager.create(name=f"skill_editor_{uuid4().hex[:8]}")
+    viewer = UserManager.create(name=f"skill_viewer_{uuid4().hex[:8]}")
+    stranger = UserManager.create(name=f"skill_stranger_{uuid4().hex[:8]}")
+    skill = SkillManager.create_custom(
+        basic_user,
+        slug=f"edit-fetch-{uuid4().hex[:6]}",
+    )
+    skill_id = _skill_id(skill)
+
+    shared = SkillManager.share(
+        skill,
+        basic_user,
+        user_shares=[
+            SkillUserShareRequest(
+                user_id=UUID(editor.id),
+                permission=SkillSharePermission.EDITOR,
+            ),
+            SkillUserShareRequest(
+                user_id=UUID(viewer.id),
+                permission=SkillSharePermission.VIEWER,
+            ),
+        ],
+    )
+    assert len(shared.user_shares) == 2
+
+    owner_editable = SkillManager.get_editable(skill_id, basic_user)
+    assert owner_editable.user_permission == SkillAccessLevel.OWNER
+    assert owner_editable.instructions_markdown == "Skill instructions."
+
+    editable = SkillManager.get_editable(skill_id, editor)
+    assert editable.id == skill_id
+    assert editable.user_permission == SkillAccessLevel.EDITOR
+    assert editable.instructions_markdown == "Skill instructions."
+    assert {share.permission for share in editable.user_shares} == {
+        SkillSharePermission.EDITOR,
+        SkillSharePermission.VIEWER,
+    }
+
+    _assert_edit_hidden(skill_id, viewer)
+    _assert_edit_hidden(skill_id, stranger)
+
+
+def test_preview_returns_instructions_without_share_details(
+    basic_user: DATestUser,
+    admin_user: DATestUser,  # noqa: ARG001
+) -> None:
+    viewer = UserManager.create(name=f"skill_preview_viewer_{uuid4().hex[:8]}")
+    skill = SkillManager.create_custom(
+        basic_user,
+        slug=f"preview-custom-{uuid4().hex[:6]}",
+        name="Preview Skill",
+        description="Preview description",
+    )
+    skill_id = _skill_id(skill)
+    SkillManager.share(
+        skill,
+        basic_user,
+        user_shares=[
+            SkillUserShareRequest(
+                user_id=UUID(viewer.id),
+                permission=SkillSharePermission.VIEWER,
+            )
+        ],
+    )
+
+    preview = SkillManager.preview(skill_id, viewer)
+
+    assert preview.source == "custom"
+    assert preview.id == skill_id
+    assert preview.name == "Preview Skill"
+    assert preview.description == "Preview description"
+    assert preview.instructions_markdown == "Skill instructions."
+    assert not hasattr(preview, "user_shares")
+    assert not hasattr(preview, "group_shares")
+    assert not hasattr(preview, "user_permission")
+
+
+def test_builtin_preview_returns_instructions(basic_user: DATestUser) -> None:
+    builtins = SkillManager.list_for_user(basic_user).builtins
+    assert builtins
+
+    preview = SkillManager.preview(builtins[0].id, basic_user)
+
+    assert preview.source == "builtin"
+    assert preview.id == builtins[0].id
+    assert preview.instructions_markdown.strip()
+
+
+def test_patch_details_rewrites_bundle_without_changing_slug(
+    basic_user: DATestUser,
+) -> None:
+    slug = f"patch-details-{uuid4().hex[:6]}"
+    skill = SkillManager.create_custom(
+        basic_user,
+        slug=slug,
+        name="Original Name",
+        description="Original description",
+    )
+    skill_id = _skill_id(skill)
+
+    updated = SkillManager.patch_custom(
+        skill,
+        basic_user,
+        SkillPatchRequest(
+            name="Updated Name",
+            description="Updated description",
+            instructions_markdown="# Updated instructions\n\nUse the revised workflow.",
+        ),
+    )
+
+    assert updated.slug == slug
+    assert updated.name == "Updated Name"
+    assert updated.description == "Updated description"
+
+    editable = SkillManager.get_editable(skill_id, basic_user)
+    assert editable.name == "Updated Name"
+    assert editable.description == "Updated description"
+    assert editable.instructions_markdown == (
+        "# Updated instructions\n\nUse the revised workflow."
+    )
+
+    preview = SkillManager.preview(skill_id, basic_user)
+    assert preview.name == "Updated Name"
+    assert preview.description == "Updated description"
+    assert preview.instructions_markdown == (
+        "# Updated instructions\n\nUse the revised workflow."
+    )
+
+
+def test_direct_viewer_share_grants_view_not_edit(
+    basic_user: DATestUser,
+    admin_user: DATestUser,  # noqa: ARG001
+) -> None:
+    viewer = UserManager.create(name=f"skill_direct_viewer_{uuid4().hex[:8]}")
+    skill = SkillManager.create_custom(
+        basic_user,
+        slug=f"direct-viewer-{uuid4().hex[:6]}",
+    )
+    skill_id = _skill_id(skill)
+
+    shared = SkillManager.share(
+        skill,
+        basic_user,
+        user_shares=[
+            SkillUserShareRequest(
+                user_id=UUID(viewer.id),
+                permission=SkillSharePermission.VIEWER,
+            )
+        ],
+    )
+
+    assert len(shared.user_shares) == 1
+    assert str(shared.user_shares[0].user.id) == viewer.id
+    assert shared.user_shares[0].user.email == viewer.email
+    assert shared.user_shares[0].permission == SkillSharePermission.VIEWER
+    visible = SkillManager.get_for_user(str(skill_id), viewer)
+    assert visible.user_permission == SkillAccessLevel.VIEWER
+    assert visible.is_personal is False
+    _assert_edit_hidden(skill_id, viewer)
+
+
+def test_direct_editor_share_grants_edit(
+    basic_user: DATestUser,
+    admin_user: DATestUser,  # noqa: ARG001
+) -> None:
+    editor = UserManager.create(name=f"skill_direct_editor_{uuid4().hex[:8]}")
+    skill = SkillManager.create_custom(
+        basic_user,
+        slug=f"direct-editor-{uuid4().hex[:6]}",
+    )
+    skill_id = _skill_id(skill)
+
+    SkillManager.share(
+        skill,
+        basic_user,
+        user_shares=[
+            SkillUserShareRequest(
+                user_id=UUID(editor.id),
+                permission=SkillSharePermission.EDITOR,
+            )
+        ],
+    )
+
+    editable = SkillManager.get_editable(skill_id, editor)
+    assert editable.user_permission == SkillAccessLevel.EDITOR
+    assert editable.instructions_markdown == "Skill instructions."
+
+
+def test_org_wide_editor_permission_grants_edit(
+    basic_user: DATestUser,
+    admin_user: DATestUser,  # noqa: ARG001
+) -> None:
+    other_user = UserManager.create(name=f"skill_org_editor_{uuid4().hex[:8]}")
+    skill = SkillManager.create_custom(
+        basic_user,
+        slug=f"org-editor-{uuid4().hex[:6]}",
+    )
+    skill_id = _skill_id(skill)
+
+    public_viewer = SkillManager.share(
+        skill,
+        basic_user,
+        is_public=True,
+        public_permission=SkillSharePermission.VIEWER,
+    )
+    assert public_viewer.public_permission is not None
+    assert public_viewer.public_permission == SkillSharePermission.VIEWER
+    _assert_edit_hidden(skill_id, other_user)
+
+    public_editor = SkillManager.share(
+        skill,
+        basic_user,
+        is_public=True,
+        public_permission=SkillSharePermission.EDITOR,
+    )
+
+    assert public_editor.public_permission is not None
+    assert public_editor.public_permission == SkillSharePermission.EDITOR
+    editable = SkillManager.get_editable(skill_id, other_user)
+    assert editable.user_permission == SkillAccessLevel.EDITOR
+
+
+def test_switching_from_org_wide_to_scoped_share_removes_org_visibility(
+    basic_user: DATestUser,
+    admin_user: DATestUser,  # noqa: ARG001
+) -> None:
+    shared_user = UserManager.create(name=f"skill_scoped_user_{uuid4().hex[:8]}")
+    unshared_user = UserManager.create(name=f"skill_unscoped_user_{uuid4().hex[:8]}")
+    skill = SkillManager.create_custom(
+        basic_user,
+        slug=f"scoped-share-{uuid4().hex[:6]}",
+    )
+    skill_id = _skill_id(skill)
+
+    SkillManager.share(skill, basic_user, is_public=True)
+    assert SkillManager.get_for_user(str(skill_id), unshared_user).id == skill_id
+
+    scoped = SkillManager.share(
+        skill,
+        basic_user,
+        is_public=False,
+        user_shares=[
+            SkillUserShareRequest(
+                user_id=UUID(shared_user.id),
+                permission=SkillSharePermission.VIEWER,
+            )
+        ],
+    )
+
+    assert scoped.public_permission is None
+    assert [str(share.user.id) for share in scoped.user_shares] == [shared_user.id]
+    assert SkillManager.get_for_user(str(skill_id), shared_user).id == skill_id
+    _assert_skill_hidden(skill_id, unshared_user)
+
+
+def test_owner_transfer_demotes_previous_owner_and_promotes_new_owner(
+    basic_user: DATestUser,
+    admin_user: DATestUser,  # noqa: ARG001
+) -> None:
+    new_owner = UserManager.create(name=f"skill_new_owner_{uuid4().hex[:8]}")
+    skill = SkillManager.create_custom(
+        basic_user,
+        slug=f"transfer-owner-{uuid4().hex[:6]}",
+    )
+    skill_id = _skill_id(skill)
+    SkillManager.share(
+        skill,
+        basic_user,
+        user_shares=[
+            SkillUserShareRequest(
+                user_id=UUID(new_owner.id),
+                permission=SkillSharePermission.VIEWER,
+            )
+        ],
+    )
+
+    old_owner_response = SkillManager.transfer_ownership(
+        skill,
+        new_owner.id,
+        basic_user,
+    )
+
+    assert old_owner_response.author_user_id is not None
+    assert str(old_owner_response.author_user_id) == new_owner.id
+    assert old_owner_response.user_permission == SkillAccessLevel.EDITOR
+    assert len(old_owner_response.user_shares) == 1
+    assert str(old_owner_response.user_shares[0].user.id) == basic_user.id
+    assert old_owner_response.user_shares[0].user.email == basic_user.email
+    assert old_owner_response.user_shares[0].permission == SkillSharePermission.EDITOR
+
+    new_owner_response = SkillManager.get_for_user(str(skill_id), new_owner)
+    assert new_owner_response.author_user_id == UUID(new_owner.id)
+    assert new_owner_response.user_permission == SkillAccessLevel.OWNER
+
+
+@pytest.mark.parametrize(
+    "permission",
+    [SkillSharePermission.VIEWER, SkillSharePermission.EDITOR],
+)
+def test_sharee_cannot_transfer_ownership(
+    basic_user: DATestUser,
+    admin_user: DATestUser,  # noqa: ARG001
+    permission: SkillSharePermission,
+) -> None:
+    sharee = UserManager.create(name=f"skill_transfer_sharee_{uuid4().hex[:8]}")
+    target = UserManager.create(name=f"skill_transfer_target_{uuid4().hex[:8]}")
+    skill = SkillManager.create_custom(
+        basic_user,
+        slug=f"transfer-deny-{permission.lower()}-{uuid4().hex[:6]}",
+    )
+    SkillManager.share(
+        skill,
+        basic_user,
+        user_shares=[
+            SkillUserShareRequest(user_id=UUID(sharee.id), permission=permission)
+        ],
+    )
+
+    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+        SkillManager.transfer_ownership(skill, target.id, sharee)
+
+    assert exc_info.value.response.status_code == 403
+
+
+def test_transfer_rejects_missing_and_inactive_targets(
+    basic_user: DATestUser,
+    admin_user: DATestUser,
+) -> None:
+    inactive_target = UserManager.create(
+        name=f"skill_inactive_target_{uuid4().hex[:8]}"
+    )
+    inactive_target = UserManager.set_status(
+        inactive_target,
+        False,
+        admin_user,
+    )
+    skill = SkillManager.create_custom(
+        basic_user,
+        slug=f"transfer-target-{uuid4().hex[:6]}",
+    )
+    skill_id = _skill_id(skill)
+
+    missing_response = client.post(
+        f"{API_SERVER_URL}/skills/custom/{skill_id}/transfer-ownership",
+        json={"new_owner_user_id": str(uuid4())},
+        headers=basic_user.headers,
+    )
+    assert missing_response.status_code == 404
+
+    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+        SkillManager.transfer_ownership(skill, inactive_target.id, basic_user)
+
+    assert exc_info.value.response.status_code == 400
+
+
+def test_admin_transfers_vacant_skill_but_not_owned_skill(
+    admin_user: DATestUser,
+) -> None:
+    owner = UserManager.create(name=f"skill_transfer_owner_{uuid4().hex[:8]}")
+    target = UserManager.create(name=f"skill_admin_target_{uuid4().hex[:8]}")
+    owned_skill = SkillManager.create_custom(
+        owner,
+        slug=f"admin-owned-transfer-{uuid4().hex[:6]}",
+    )
+    owned_skill_id = _skill_id(owned_skill)
+
+    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+        SkillManager.transfer_ownership(owned_skill, target.id, admin_user)
+    assert exc_info.value.response.status_code == 403
+
+    inactive_owner = UserManager.set_status(owner, False, admin_user)
+    try:
+        vacant_response = SkillManager.transfer_ownership(
+            owned_skill,
+            target.id,
+            admin_user,
+        )
+    finally:
+        UserManager.set_status(inactive_owner, True, admin_user)
+
+    assert vacant_response.author_user_id is not None
+    assert str(vacant_response.author_user_id) == target.id
+    new_owner_response = SkillManager.get_for_user(str(owned_skill_id), target)
+    assert new_owner_response.user_permission == SkillAccessLevel.OWNER

--- a/backend/tests/integration/tests/skills/test_skills_user.py
+++ b/backend/tests/integration/tests/skills/test_skills_user.py
@@ -11,12 +11,16 @@ Admin-route mutation auth is covered exhaustively in
 
 from __future__ import annotations
 
+import os
 from uuid import uuid4
+
+import pytest
 
 from onyx.server.features.skill.models import SkillPatchRequest
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.http_client import client
 from tests.integration.common_utils.managers.skill import SkillManager
+from tests.integration.common_utils.managers.user_group import UserGroupManager
 from tests.integration.common_utils.test_models import DATestUser
 
 
@@ -67,6 +71,39 @@ def test_user_sees_public_skill(
 ) -> None:
     slug = f"public-{uuid4().hex[:6]}"
     SkillManager.create_custom(admin_user, slug=slug, is_public=True)
+
+    user_skills = SkillManager.list_for_user(basic_user)
+    custom_slugs = [skill.slug for skill in user_skills.customs]
+    assert slug in custom_slugs
+
+
+@pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="User-group management requires EE features enabled.",
+)
+def test_user_sees_private_skill_with_group_share(
+    admin_user: DATestUser,
+    basic_user: DATestUser,
+) -> None:
+    """Adding ``basic_user`` to a shared group surfaces a private skill."""
+    group = UserGroupManager.create(
+        admin_user,
+        name=f"share-r-{uuid4().hex[:6]}",
+        user_ids=[admin_user.id],
+    )
+    UserGroupManager.wait_for_sync(
+        user_performing_action=admin_user,
+        user_groups_to_check=[group],
+    )
+    UserGroupManager.add_users(group, [basic_user.id], admin_user)
+
+    slug = f"private-shared-{uuid4().hex[:6]}"
+    SkillManager.create_custom(
+        admin_user,
+        slug=slug,
+        is_public=False,
+        group_ids=[group.id],
+    )
 
     user_skills = SkillManager.list_for_user(basic_user)
     custom_slugs = [skill.slug for skill in user_skills.customs]

--- a/backend/tests/unit/onyx/skills/test_skill_patch_unset_sentinel.py
+++ b/backend/tests/unit/onyx/skills/test_skill_patch_unset_sentinel.py
@@ -12,6 +12,7 @@ def test_omitted_fields_do_not_count_as_updates() -> None:
 
     assert req.model_fields_set == {"public_permission"}
     assert req.has_db_field_update is True
+    assert req.has_details_update is False
 
 
 def test_all_fields_sent() -> None:
@@ -39,12 +40,36 @@ def test_empty_request_has_no_update_intent() -> None:
 
     assert req.model_fields_set == set()
     assert req.has_db_field_update is False
+    assert req.has_details_update is False
 
 
-def test_explicit_enabled_null_rejected() -> None:
-    """Sending enabled=null (not omitting it) should raise ValidationError."""
-    with pytest.raises(ValidationError, match="enabled cannot be null"):
-        SkillPatchRequest.model_validate({"enabled": None})
+def test_detail_fields_track_intent() -> None:
+    req = SkillPatchRequest(
+        name=" Updated name ",
+        description=" Updated description ",
+        instructions_markdown=" Updated instructions ",
+    )
+
+    assert req.name == "Updated name"
+    assert req.description == "Updated description"
+    assert req.instructions_markdown == "Updated instructions"
+    assert req.has_details_update is True
+    assert req.has_db_field_update is False
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "name",
+        "description",
+        "instructions_markdown",
+        "enabled",
+    ],
+)
+def test_explicit_null_rejected(field: str) -> None:
+    """Sending field=null (not omitting it) should raise ValidationError."""
+    with pytest.raises(ValidationError, match=f"{field} cannot be null"):
+        SkillPatchRequest.model_validate({field: None})
 
 
 def test_public_permission_null_allowed() -> None:
@@ -53,6 +78,12 @@ def test_public_permission_null_allowed() -> None:
     assert req.public_permission is None
     assert req.model_fields_set == {"public_permission"}
     assert req.has_db_field_update is True
+
+
+@pytest.mark.parametrize("field", ["name", "description", "instructions_markdown"])
+def test_empty_strings_rejected(field: str) -> None:
+    with pytest.raises(ValidationError, match=f"{field} cannot be empty"):
+        SkillPatchRequest.model_validate({field: "  "})
 
 
 def test_extra_fields_rejected() -> None:


### PR DESCRIPTION
## Description

Adds the skill management endpoints deferred from #12662 (stacked on it; split out of #12637):

- `PATCH /skills/custom/{id}/share` — replace user/group shares and set org-wide `public_permission` in one call. Org-visibility changes are gated by the same curator/admin check as before; the author is excluded from user shares.
- `POST /skills/custom/{id}/transfer-ownership` — owner can transfer to any active standard-account user; an admin can claim ownership only when it is vacant (no author, or author deactivated). The prior owner keeps an EDITOR share.
- `GET /skills/custom/{id}/edit` — full editable detail for anyone with EDIT access, including `instructions_markdown` extracted from the bundle.
- `PATCH /skills/custom/{id}` expanded to accept `name`, `description`, and `instructions_markdown`: the stored bundle's SKILL.md is rewritten in place, the new bundle blob is swapped atomically (orphan cleanup on failure), and the change is pushed to affected sandboxes.

Also restores the share-dependent test coverage deferred in #12662 (test manager `share`/`transfer_ownership`/`get_editable`/`replace_group_shares` helpers, `group_ids` on `create_custom`, share cases in `test_skills_admin.py`, `test_skills_user.py`, `test_skill_push.py`, `test_skill_patch_unset_sentinel.py`) and adds two new suites: `tests/integration/tests/skills/test_skills_management.py` and `tests/external_dependency_unit/craft/test_skill_ownership_transfer.py`.

## How Has This Been Tested?

- `python -c "import onyx.main"` — clean import
- `pytest tests/unit` — 1763 passed; one pre-existing Confluence/Redis environment failure that reproduces identically on the megabranch and passes in isolation (unrelated to this change)
- `python -m ty check onyx/server/features/skill onyx/db/skill.py` — all checks passed
- `python -m compileall tests/integration tests/external_dependency_unit` — clean
- Integration and external-dependency-unit suites (including the new management and ownership-transfer tests) run in CI

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds endpoints to share custom skills, transfer ownership, and fetch editable details. Edits can now update name, description, and `instructions_markdown` with an atomic bundle swap; changes push to affected sandboxes.

- **New Features**
  - GET `/skills/custom/{id}/edit` — returns full editable detail (share info + `instructions_markdown`) for users with EDIT access.
  - PATCH `/skills/custom/{id}/share` — replace user/group shares and optionally org-wide `public_permission` in one call; org-visibility changes require curator/admin; author excluded from user shares; pushes to affected sandboxes.
  - POST `/skills/custom/{id}/transfer-ownership` — owner can transfer to any active standard user; bots/service/limited/Slack/ext-perm accounts rejected; admins can claim only if ownership is vacant; previous owner becomes EDITOR; built-ins rejected; pushes to affected sandboxes.
  - PATCH `/skills/custom/{id}` — accepts `name`, `description`, and `instructions_markdown`; rewrites SKILL.md and swaps bundle atomically with cleanup on failure; pushes on details or visibility change.
  - Models/validation — added `SkillEditableDetailResponse`, `SkillShareRequest`, and `TransferSkillOwnershipRequest`; trims detail fields and rejects null/empty strings (`public_permission: null` revokes org access); intent flags for detail vs DB updates.

- **Bug Fixes**
  - Share FK violations now return 400 and name the target type (“user” vs “group”); tests pin these messages.
  - Share helper only sends org visibility when explicitly set to avoid unintended org access changes.

<sup>Written for commit fa828095f653b56287cade8b69eeb5b3872e4280. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12663?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

