### PR TITLE
feat: allow multiple Google Drive and Gmail connectors

### DIFF
--- a/backend/onyx/server/documents/credential.py
+++ b/backend/onyx/server/documents/credential.py
@@ -14,7 +14,6 @@ from onyx.auth.users import current_curator_or_admin_user
 from onyx.configs.constants import PUBLIC_API_TAGS
 from onyx.connectors.factory import validate_ccpair_for_user
 from onyx.db.credentials import alter_credential
-from onyx.db.credentials import cleanup_gmail_credentials
 from onyx.db.credentials import create_credential
 from onyx.db.credentials import CREDENTIAL_PERMISSIONS_TO_IGNORE
 from onyx.db.credentials import delete_credential
@@ -166,10 +165,6 @@ def create_credential_from_model(
             object_is_public=credential_info.curator_public,
         )
 
-    # Temporary fix for empty Google App credentials
-    if credential_info.source == DocumentSource.GMAIL:
-        cleanup_gmail_credentials(db_session=db_session)
-
     credential = create_credential(credential_info, user, db_session)
     emit_audit_event(
         AuditAction.CREDENTIAL_CREATE,
@@ -240,10 +235,6 @@ def create_credential_with_private_key(
             target_group_ids=groups,
             object_is_public=curator_public,
         )
-
-    # Temporary fix for empty Google App credentials
-    if DocumentSource(source) == DocumentSource.GMAIL:
-        cleanup_gmail_credentials(db_session=db_session)
 
     credential = create_credential(credential_info, user, db_session)
     emit_audit_event(

--- a/backend/tests/external_dependency_unit/connectors/test_gmail_multi_credential.py
+++ b/backend/tests/external_dependency_unit/connectors/test_gmail_multi_credential.py
@@ -1,0 +1,117 @@
+"""Creating a Gmail credential preserves existing Gmail credential rows."""
+
+from collections.abc import Generator
+from dataclasses import dataclass
+from dataclasses import field
+from uuid import UUID
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from onyx.auth.schemas import UserRole
+from onyx.configs.constants import DocumentSource
+from onyx.db.models import Credential
+from onyx.db.models import User
+from onyx.server.documents.credential import create_credential_from_model
+from onyx.server.documents.models import CredentialBase
+from tests.external_dependency_unit.conftest import create_test_user
+
+
+@dataclass
+class CreatedGmailCredentialState:
+    credential_ids: list[int] = field(default_factory=list)
+    user_id: UUID | None = None
+
+
+def _current_gmail_credential_ids(db_session: Session) -> set[int]:
+    credential_ids = db_session.scalars(
+        select(Credential.id).where(Credential.source == DocumentSource.GMAIL)
+    ).all()
+    return set(credential_ids)
+
+
+def _gmail_credential_request(*, name: str, suffix: str) -> CredentialBase:
+    return CredentialBase(
+        source=DocumentSource.GMAIL,
+        credential_json={
+            "client_id": f"gmail-client-{suffix}.apps.googleusercontent.com",
+            "client_secret": f"gmail-secret-{suffix}",
+            "project_id": f"gmail-project-{suffix}",
+        },
+        admin_public=True,
+        name=name,
+    )
+
+
+@pytest.fixture
+def created_gmail_credentials_cleanup(
+    db_session: Session,
+) -> Generator[CreatedGmailCredentialState, None, None]:
+    state = CreatedGmailCredentialState()
+    yield state
+
+    db_session.rollback()
+
+    for credential_id in state.credential_ids:
+        credential = db_session.get(Credential, credential_id)
+        if credential is not None:
+            db_session.delete(credential)
+
+    if state.user_id is not None:
+        user = db_session.get(User, state.user_id)
+        if user is not None:
+            db_session.delete(user)
+
+    db_session.commit()
+
+
+def test_second_gmail_credential_preserves_first(
+    db_session: Session,
+    created_gmail_credentials_cleanup: CreatedGmailCredentialState,
+) -> None:
+    # Gmail creation enforces the EE creation hook unless the user is ADMIN.
+    admin = create_test_user(
+        db_session,
+        "gmail_multi_credential_admin",
+        role=UserRole.ADMIN,
+    )
+    created_gmail_credentials_cleanup.user_id = admin.id
+
+    baseline_gmail_credential_ids = _current_gmail_credential_ids(db_session)
+    unique_suffix = uuid4().hex[:8]
+
+    # Exercise the endpoint handler directly to cover the real creation path.
+    first_response = create_credential_from_model(
+        _gmail_credential_request(
+            name=f"gmail-multi-first-{unique_suffix}",
+            suffix=f"{unique_suffix}-first",
+        ),
+        admin,
+        db_session,
+    )
+    created_gmail_credentials_cleanup.credential_ids.append(first_response.id)
+
+    gmail_credential_ids_after_first = _current_gmail_credential_ids(db_session)
+    assert first_response.id in gmail_credential_ids_after_first
+    assert (
+        len(gmail_credential_ids_after_first) == len(baseline_gmail_credential_ids) + 1
+    )
+
+    second_response = create_credential_from_model(
+        _gmail_credential_request(
+            name=f"gmail-multi-second-{unique_suffix}",
+            suffix=f"{unique_suffix}-second",
+        ),
+        admin,
+        db_session,
+    )
+    created_gmail_credentials_cleanup.credential_ids.append(second_response.id)
+
+    gmail_credential_ids_after_second = _current_gmail_credential_ids(db_session)
+    assert first_response.id in gmail_credential_ids_after_second
+    assert second_response.id in gmail_credential_ids_after_second
+    assert (
+        len(gmail_credential_ids_after_second) == len(baseline_gmail_credential_ids) + 2
+    )

--- a/web/src/app/admin/connectors/[connector]/AddConnectorPage.tsx
+++ b/web/src/app/admin/connectors/[connector]/AddConnectorPage.tsx
@@ -34,7 +34,6 @@ import {
 } from "@/lib/connectors/connectors";
 import { useSettings } from "@/lib/settings/hooks";
 import Modal from "@/refresh-components/Modal";
-import { GmailMain } from "@/app/admin/connectors/[connector]/pages/gmail/GmailPage";
 import {
   useGmailCredentials,
   useGoogleDriveCredentials,
@@ -56,6 +55,7 @@ import {
 import { CreateStdOAuthCredential } from "@/components/credentials/actions/CreateStdOAuthCredential";
 import { Spinner } from "@/components/Spinner";
 import { Button } from "@opal/components";
+import { Section } from "@opal/layouts";
 import { deleteConnector } from "@/lib/connector";
 import ConnectorDocsLink from "@/components/admin/connectors/ConnectorDocsLink";
 import Text from "@/refresh-components/texts/Text";
@@ -534,116 +534,114 @@ export default function AddConnector({
                 Select a credential
               </Text>
 
-              {connector == ValidSources.Gmail ? (
-                <GmailMain />
-              ) : (
-                <>
-                  <ModifyCredential
-                    showIfEmpty
-                    accessType={formikProps.values.access_type}
-                    defaultedCredential={currentCredential!}
-                    credentials={credentials}
-                    editableCredentials={editableCredentials}
-                    onDeleteCredential={onDeleteCredential}
-                    onSwitch={onSwap}
-                  />
-                  {!createCredentialFormToggle && (
-                    <div className="mt-6 flex gap-4">
-                      {/* Button to pop up a form to manually enter credentials */}
-                      <Button
-                        onClick={async () => {
-                          if (oauthDetails && oauthDetails.oauth_enabled) {
-                            if (oauthDetails.additional_kwargs.length > 0) {
-                              setCreateCredentialFormToggle(true);
-                            } else {
-                              const redirectUrl =
-                                await getConnectorOauthRedirectUrl(
-                                  connector,
-                                  {}
-                                );
-                              // if redirect is supported, just use it
-                              if (redirectUrl) {
-                                window.location.href = redirectUrl;
-                              } else {
-                                setCreateCredentialFormToggle(
-                                  (createConnectorToggle) =>
-                                    !createConnectorToggle
-                                );
-                              }
-                            }
+              <>
+                <ModifyCredential
+                  showIfEmpty
+                  accessType={formikProps.values.access_type}
+                  defaultedCredential={currentCredential!}
+                  credentials={credentials}
+                  editableCredentials={editableCredentials}
+                  onDeleteCredential={onDeleteCredential}
+                  onSwitch={onSwap}
+                />
+                {!createCredentialFormToggle && (
+                  <Section
+                    flexDirection="row"
+                    justifyContent="start"
+                    gap={1}
+                    className="mt-6"
+                  >
+                    {/* Button to pop up a form to manually enter credentials */}
+                    <Button
+                      onClick={async () => {
+                        if (oauthDetails && oauthDetails.oauth_enabled) {
+                          if (oauthDetails.additional_kwargs.length > 0) {
+                            setCreateCredentialFormToggle(true);
                           } else {
-                            setCreateCredentialFormToggle(
-                              (createConnectorToggle) => !createConnectorToggle
-                            );
+                            const redirectUrl =
+                              await getConnectorOauthRedirectUrl(connector, {});
+                            // if redirect is supported, just use it
+                            if (redirectUrl) {
+                              window.location.href = redirectUrl;
+                            } else {
+                              setCreateCredentialFormToggle(
+                                (createConnectorToggle) =>
+                                  !createConnectorToggle
+                              );
+                            }
                           }
-                        }}
-                      >
-                        Create New
-                      </Button>
-                      {/* Button to sign in via OAuth */}
-                      {oauthSupportedSources.includes(connector) &&
-                        (NEXT_PUBLIC_CLOUD_ENABLED || NEXT_PUBLIC_TEST_ENV) && (
-                          <Button
-                            disabled={isAuthorizing}
-                            variant="action"
-                            onClick={handleAuthorize}
-                            hidden={!isAuthorizeVisible}
-                          >
-                            {isAuthorizing
-                              ? "Authorizing..."
-                              : `Authorize with ${getSourceDisplayName(
-                                  connector
-                                )}`}
-                          </Button>
-                        )}
-                    </div>
-                  )}
-
-                  {createCredentialFormToggle && (
-                    <Modal
-                      open
-                      onOpenChange={() => setCreateCredentialFormToggle(false)}
+                        } else {
+                          setCreateCredentialFormToggle(
+                            (createConnectorToggle) => !createConnectorToggle
+                          );
+                        }
+                      }}
                     >
-                      <Modal.Content>
-                        <Modal.Header
-                          icon={SvgKey}
-                          title={`Create a ${getSourceDisplayName(
-                            connector
-                          )} credential`}
-                          onClose={() => setCreateCredentialFormToggle(false)}
-                        />
-                        <Modal.Body>
-                          {oauthDetailsLoading ? (
-                            <Spinner />
-                          ) : (
-                            <>
-                              {oauthDetails && oauthDetails.oauth_enabled ? (
-                                <CreateStdOAuthCredential
-                                  sourceType={connector}
-                                  additionalFields={
-                                    oauthDetails.additional_kwargs
-                                  }
-                                />
-                              ) : (
-                                <CreateCredential
-                                  close
-                                  refresh={refresh}
-                                  sourceType={connector}
-                                  accessType={formikProps.values.access_type}
-                                  onSwitch={onSwap}
-                                  onClose={() =>
-                                    setCreateCredentialFormToggle(false)
-                                  }
-                                />
-                              )}
-                            </>
-                          )}
-                        </Modal.Body>
-                      </Modal.Content>
-                    </Modal>
-                  )}
-                </>
-              )}
+                      Create New
+                    </Button>
+                    {/* Button to sign in via OAuth */}
+                    {oauthSupportedSources.includes(connector) &&
+                      (NEXT_PUBLIC_CLOUD_ENABLED || NEXT_PUBLIC_TEST_ENV) && (
+                        <Button
+                          disabled={isAuthorizing}
+                          variant="action"
+                          onClick={handleAuthorize}
+                          hidden={!isAuthorizeVisible}
+                        >
+                          {isAuthorizing
+                            ? "Authorizing..."
+                            : `Authorize with ${getSourceDisplayName(
+                                connector
+                              )}`}
+                        </Button>
+                      )}
+                  </Section>
+                )}
+
+                {createCredentialFormToggle && (
+                  <Modal
+                    open
+                    onOpenChange={() => setCreateCredentialFormToggle(false)}
+                  >
+                    <Modal.Content>
+                      <Modal.Header
+                        icon={SvgKey}
+                        title={`Create a ${getSourceDisplayName(
+                          connector
+                        )} credential`}
+                        onClose={() => setCreateCredentialFormToggle(false)}
+                      />
+                      <Modal.Body>
+                        {oauthDetailsLoading ? (
+                          <Spinner />
+                        ) : (
+                          <>
+                            {oauthDetails && oauthDetails.oauth_enabled ? (
+                              <CreateStdOAuthCredential
+                                sourceType={connector}
+                                additionalFields={
+                                  oauthDetails.additional_kwargs
+                                }
+                              />
+                            ) : (
+                              <CreateCredential
+                                close
+                                refresh={refresh}
+                                sourceType={connector}
+                                accessType={formikProps.values.access_type}
+                                onSwitch={onSwap}
+                                onClose={() =>
+                                  setCreateCredentialFormToggle(false)
+                                }
+                              />
+                            )}
+                          </>
+                        )}
+                      </Modal.Body>
+                    </Modal.Content>
+                  </Modal>
+                )}
+              </>
             </CardSection>
           )}
 

--- a/web/src/app/admin/connectors/[connector]/pages/gdrive/Credential.tsx
+++ b/web/src/app/admin/connectors/[connector]/pages/gdrive/Credential.tsx
@@ -3,67 +3,33 @@ import React, { useState, useEffect } from "react";
 import * as Yup from "yup";
 import { useRouter } from "next/navigation";
 import type { Route } from "next";
-import { adminDeleteCredential } from "@/lib/credential";
 import { setupGoogleDriveOAuth } from "@/lib/googleDrive";
 import { DOCS_ADMINS_PATH } from "@/lib/constants";
 import { Form, Formik } from "formik";
 import { User } from "@/lib/types";
 import { Button, Text } from "@opal/components";
+import { Section } from "@opal/layouts";
 import InputFile from "@/refresh-components/inputs/InputFile";
 import InputTypeInField from "@/refresh-components/form/InputTypeInField";
-import {
-  Credential,
-  GoogleDriveCredentialJson,
-  GoogleDriveServiceAccountCredentialJson,
-} from "@/lib/connectors/credentials";
 import {
   parseOauthAppCredentialJson,
   refreshAllGoogleData,
 } from "@/lib/googleConnector";
 import { ValidSources } from "@/lib/types";
-import { FiCheck } from "react-icons/fi";
 import { markdown } from "@opal/utils";
 
 interface DriveCredentialSectionProps {
-  googleDrivePublicUploadedCredential?: Credential<GoogleDriveCredentialJson>;
-  googleDriveServiceAccountCredential?: Credential<GoogleDriveServiceAccountCredentialJson>;
-  appCredentialData?: { client_id: string };
   refreshCredentials: () => void;
-  connectorAssociated: boolean;
   user: User | null;
 }
 
-async function handleRevokeAccess(
-  connectorAssociated: boolean,
-  existingCredential:
-    | Credential<GoogleDriveCredentialJson>
-    | Credential<GoogleDriveServiceAccountCredentialJson>,
-  refreshCredentials: () => void
-) {
-  if (connectorAssociated) {
-    const message =
-      "Cannot revoke the Google Drive credential while any connector is still associated with the credential. " +
-      "Please delete all associated connectors, then try again.";
-    toast.error(message);
-    return;
-  }
-
-  await adminDeleteCredential(existingCredential.id);
-  toast.success("Successfully revoked the Google Drive credential!");
-
-  refreshCredentials();
-}
-
 export const DriveAuthSection = ({
-  googleDrivePublicUploadedCredential,
-  googleDriveServiceAccountCredential,
-  appCredentialData,
   refreshCredentials,
-  connectorAssociated,
   user,
 }: DriveCredentialSectionProps) => {
   const router = useRouter();
   const [isAuthenticating, setIsAuthenticating] = useState(false);
+  const [justCreated, setJustCreated] = useState(false);
   const [serviceAccountKey, setServiceAccountKey] = useState<Record<
     string,
     unknown
@@ -72,66 +38,33 @@ export const DriveAuthSection = ({
     string,
     unknown
   > | null>(null);
-  const [
-    localGoogleDrivePublicCredential,
-    setLocalGoogleDrivePublicCredential,
-  ] = useState(googleDrivePublicUploadedCredential);
-  const [
-    localGoogleDriveServiceAccountCredential,
-    setLocalGoogleDriveServiceAccountCredential,
-  ] = useState(googleDriveServiceAccountCredential);
-
-  // Update local state when props change
-  useEffect(() => {
-    setLocalGoogleDrivePublicCredential(googleDrivePublicUploadedCredential);
-    setLocalGoogleDriveServiceAccountCredential(
-      googleDriveServiceAccountCredential
-    );
-  }, [
-    googleDrivePublicUploadedCredential,
-    googleDriveServiceAccountCredential,
-  ]);
-
-  const existingCredential =
-    localGoogleDrivePublicCredential ||
-    localGoogleDriveServiceAccountCredential;
-  if (existingCredential) {
+  // Confirm only a credential created in this session. A pre-existing one must
+  // not gate the form, or a second could never be created. Revoke is in the list.
+  if (justCreated) {
     return (
-      <div className="w-full">
-        <div className="mt-4">
-          <div className="py-3 px-4 bg-blue-50/30 dark:bg-blue-900/5 rounded-sm mb-4 flex items-start">
-            <FiCheck className="text-blue-500 h-5 w-5 mr-2 mt-0.5 shrink-0" />
-            <div className="flex-1">
-              <span className="font-medium block">Authentication Complete</span>
-              <p className="text-sm mt-1 text-text-500 dark:text-text-400 wrap-break-word">
-                Your Google Drive credentials have been successfully uploaded
-                and authenticated.
-              </p>
-            </div>
-          </div>
-          <Button
-            variant="danger"
-            onClick={async () => {
-              handleRevokeAccess(
-                connectorAssociated,
-                existingCredential,
-                refreshCredentials
-              );
-            }}
-          >
-            Revoke Access
-          </Button>
-        </div>
-      </div>
+      <Section
+        alignItems="start"
+        justifyContent="start"
+        gap={0.25}
+        className="mt-4 rounded-sm border border-border-02 bg-background-tint-02 px-4 py-3"
+      >
+        <Text as="p" font="main-ui-action">
+          Authentication Complete
+        </Text>
+        <Text as="p" font="secondary-body" color="text-03">
+          Your Google Drive credential was created. Manage or revoke it from the
+          credential list.
+        </Text>
+      </Section>
     );
   }
 
   return (
-    <div className="w-full">
+    <Section alignItems="start" justifyContent="start" gap={1}>
       <Text as="h3" font="heading-h2">
         Google Drive Authentication
       </Text>
-      <div className="mt-4 w-full space-y-4">
+      <Section alignItems="start" justifyContent="start" gap={1}>
         <Text as="p" font="main-ui-action">
           Option 1: OAuth app
         </Text>
@@ -149,7 +82,7 @@ export const DriveAuthSection = ({
             );
           }}
         />
-        <div className="flex w-full justify-end">
+        <Section flexDirection="row" justifyContent="end">
           <Button
             disabled={!oauthAppCredential || isAuthenticating}
             onClick={async () => {
@@ -181,7 +114,7 @@ export const DriveAuthSection = ({
               ? "Authenticating..."
               : "Authenticate with Google Drive"}
           </Button>
-        </div>
+        </Section>
         <Text as="p" font="main-ui-action">
           Option 2: Service account
         </Text>
@@ -249,6 +182,7 @@ export const DriveAuthSection = ({
                 toast.success(
                   "Successfully created service account credential"
                 );
+                setJustCreated(true);
                 refreshCredentials();
               } else {
                 const errorMsg = await response.text();
@@ -266,8 +200,8 @@ export const DriveAuthSection = ({
           }}
         >
           {({ isSubmitting }) => (
-            <Form>
-              <div className="w-full space-y-1">
+            <Form className="w-full">
+              <Section alignItems="start" justifyContent="start" gap={0.25}>
                 <Text font="main-ui-body" color="text-03">
                   Primary Admin Email
                 </Text>
@@ -279,16 +213,20 @@ export const DriveAuthSection = ({
                   Enter the email of an admin or owner of the Google
                   Organization that owns the Google Drive(s) you want to index.
                 </Text>
-              </div>
-              <div className="flex w-full justify-end pt-2">
+              </Section>
+              <Section
+                flexDirection="row"
+                justifyContent="end"
+                className="pt-2"
+              >
                 <Button disabled={isSubmitting} type="submit">
                   {isSubmitting ? "Creating..." : "Create Credential"}
                 </Button>
-              </div>
+              </Section>
             </Form>
           )}
         </Formik>
-      </div>
-    </div>
+      </Section>
+    </Section>
   );
 };

--- a/web/src/app/admin/connectors/[connector]/pages/gdrive/GoogleDrivePage.tsx
+++ b/web/src/app/admin/connectors/[connector]/pages/gdrive/GoogleDrivePage.tsx
@@ -6,17 +6,9 @@ import { LoadingAnimation } from "@/components/Loading";
 import { ValidSources } from "@/lib/types";
 import { usePublicCredentials } from "@/lib/hooks";
 import { DriveAuthSection } from "./Credential";
-import {
-  Credential,
-  GoogleDriveCredentialJson,
-  GoogleDriveServiceAccountCredentialJson,
-} from "@/lib/connectors/credentials";
 import { useUser } from "@/providers/UserProvider";
 import {
   useGoogleCredentials,
-  useConnectorsByCredentialId,
-  filterUploadedCredentials,
-  checkConnectorsExist,
   refreshAllGoogleData,
 } from "@/lib/googleConnector";
 
@@ -38,29 +30,16 @@ const GDriveMain = () => {
     error: googleDriveCredentialsError,
   } = useGoogleCredentials(ValidSources.GoogleDrive);
 
-  // Filter uploaded credentials and get credential ID
-  const { credential_id } = filterUploadedCredentials(googleDriveCredentials);
-
-  // Get connectors for the credential ID
-  const {
-    data: googleDriveConnectors,
-    isLoading: isGoogleDriveConnectorsLoading,
-    error: googleDriveConnectorsError,
-    refreshConnectorsByCredentialId,
-  } = useConnectorsByCredentialId(credential_id);
-
   // Handle refresh of all data
   const handleRefresh = () => {
     refreshCredentials();
-    refreshConnectorsByCredentialId();
     refreshAllGoogleData(ValidSources.GoogleDrive);
   };
 
   // Loading state
   if (
     (!credentialsData && isCredentialsLoading) ||
-    (!googleDriveCredentials && isGoogleDriveCredentialsLoading) ||
-    (!googleDriveConnectors && isGoogleDriveConnectorsLoading)
+    (!googleDriveCredentials && isGoogleDriveCredentialsLoading)
   ) {
     return (
       <div className="mx-auto">
@@ -80,50 +59,11 @@ const GDriveMain = () => {
     );
   }
 
-  if (googleDriveConnectorsError) {
-    return (
-      <ErrorCallout errorTitle="Failed to load Google Drive associated connectors." />
-    );
-  }
-
-  // Check if connectors exist
-  const connectorAssociated = checkConnectorsExist(googleDriveConnectors);
-
-  // Get the uploaded OAuth credential
-  const googleDrivePublicUploadedCredential:
-    | Credential<GoogleDriveCredentialJson>
-    | undefined = credentialsData.find(
-    (credential) =>
-      credential.credential_json?.google_tokens &&
-      credential.admin_public &&
-      credential.source === "google_drive" &&
-      credential.credential_json.authentication_method !== "oauth_interactive"
-  );
-
-  // Get the service account credential
-  const googleDriveServiceAccountCredential:
-    | Credential<GoogleDriveServiceAccountCredentialJson>
-    | undefined = credentialsData.find(
-    (credential) =>
-      credential.credential_json?.google_service_account_key &&
-      credential.source === "google_drive"
-  );
-
   return (
     <>
       {isAdmin && (
         <>
-          <DriveAuthSection
-            refreshCredentials={handleRefresh}
-            googleDrivePublicUploadedCredential={
-              googleDrivePublicUploadedCredential
-            }
-            googleDriveServiceAccountCredential={
-              googleDriveServiceAccountCredential
-            }
-            connectorAssociated={connectorAssociated}
-            user={user}
-          />
+          <DriveAuthSection refreshCredentials={handleRefresh} user={user} />
         </>
       )}
     </>

--- a/web/src/app/admin/connectors/[connector]/pages/gmail/Credential.tsx
+++ b/web/src/app/admin/connectors/[connector]/pages/gmail/Credential.tsx
@@ -1,4 +1,5 @@
 import { Button, Text } from "@opal/components";
+import { Section } from "@opal/layouts";
 import InputFile from "@/refresh-components/inputs/InputFile";
 import InputTypeInField from "@/refresh-components/form/InputTypeInField";
 import { toast } from "@/hooks/useToast";
@@ -6,7 +7,6 @@ import React, { useState, useEffect } from "react";
 import * as Yup from "yup";
 import { useRouter } from "next/navigation";
 import type { Route } from "next";
-import { adminDeleteCredential } from "@/lib/credential";
 import { setupGmailOAuth } from "@/lib/gmail";
 import { DOCS_ADMINS_PATH } from "@/lib/constants";
 import { CRAFT_OAUTH_COOKIE_NAME } from "@/app/craft/v1/constants";
@@ -14,67 +14,28 @@ import Cookies from "js-cookie";
 import { Form, Formik } from "formik";
 import { User } from "@/lib/types";
 import {
-  Credential,
-  GmailCredentialJson,
-  GmailServiceAccountCredentialJson,
-} from "@/lib/connectors/credentials";
-import {
   parseOauthAppCredentialJson,
   refreshAllGoogleData,
 } from "@/lib/googleConnector";
 import { ValidSources } from "@/lib/types";
-import { FiCheck } from "react-icons/fi";
 import { markdown } from "@opal/utils";
-import { Section } from "@/layouts/general-layouts";
 
 interface GmailCredentialSectionProps {
-  gmailPublicCredential?: Credential<GmailCredentialJson>;
-  gmailServiceAccountCredential?: Credential<GmailServiceAccountCredentialJson>;
   refreshCredentials: () => void;
-  connectorExists: boolean;
   user: User | null;
   buildMode?: boolean;
   onOAuthRedirect?: () => void;
-  onCredentialCreated?: (
-    credential: Credential<
-      GmailCredentialJson | GmailServiceAccountCredentialJson
-    >
-  ) => void;
-}
-
-async function handleRevokeAccess(
-  connectorExists: boolean,
-  existingCredential:
-    | Credential<GmailCredentialJson>
-    | Credential<GmailServiceAccountCredentialJson>,
-  refreshCredentials: () => void
-) {
-  if (connectorExists) {
-    const message =
-      "Cannot revoke the Gmail credential while any connector is still associated with the credential. " +
-      "Please delete all associated connectors, then try again.";
-    toast.error(message);
-    return;
-  }
-
-  await adminDeleteCredential(existingCredential.id);
-  toast.success("Successfully revoked the Gmail credential!");
-
-  refreshCredentials();
 }
 
 export const GmailAuthSection = ({
-  gmailPublicCredential,
-  gmailServiceAccountCredential,
   refreshCredentials,
-  connectorExists,
   user,
   buildMode = false,
   onOAuthRedirect,
-  onCredentialCreated,
 }: GmailCredentialSectionProps) => {
   const router = useRouter();
   const [isAuthenticating, setIsAuthenticating] = useState(false);
+  const [justCreated, setJustCreated] = useState(false);
   const [serviceAccountKey, setServiceAccountKey] = useState<Record<
     string,
     unknown
@@ -83,66 +44,33 @@ export const GmailAuthSection = ({
     string,
     unknown
   > | null>(null);
-  const [localGmailPublicCredential, setLocalGmailPublicCredential] = useState(
-    gmailPublicCredential
-  );
-  const [
-    localGmailServiceAccountCredential,
-    setLocalGmailServiceAccountCredential,
-  ] = useState(gmailServiceAccountCredential);
-
-  // Update local state when props change
-  useEffect(() => {
-    setLocalGmailPublicCredential(gmailPublicCredential);
-    setLocalGmailServiceAccountCredential(gmailServiceAccountCredential);
-  }, [gmailPublicCredential, gmailServiceAccountCredential]);
-
-  const existingCredential =
-    localGmailPublicCredential || localGmailServiceAccountCredential;
-  if (existingCredential) {
+  // Confirm only a credential created in this session. A pre-existing one must
+  // not gate the form, or a second could never be created. Revoke is in the list.
+  if (justCreated) {
     return (
-      <div className="w-full">
-        <div className="mt-4">
-          <div className="py-3 px-4 bg-blue-50/30 dark:bg-blue-900/5 rounded-sm mb-4 flex items-start">
-            <FiCheck className="text-blue-500 h-5 w-5 mr-2 mt-0.5 shrink-0" />
-            <div className="flex-1">
-              <span className="font-medium block">Authentication Complete</span>
-              <p className="text-sm mt-1 text-text-500 dark:text-text-400 wrap-break-word">
-                Your Gmail credentials have been successfully uploaded and
-                authenticated.
-              </p>
-            </div>
-          </div>
-          <Section flexDirection="row" justifyContent="between" height="fit">
-            <Button
-              variant="danger"
-              onClick={async () => {
-                handleRevokeAccess(
-                  connectorExists,
-                  existingCredential,
-                  refreshCredentials
-                );
-              }}
-            >
-              Revoke Access
-            </Button>
-            {buildMode && onCredentialCreated && (
-              <Button onClick={() => onCredentialCreated(existingCredential)}>
-                Continue
-              </Button>
-            )}
-          </Section>
-        </div>
-      </div>
+      <Section
+        alignItems="start"
+        justifyContent="start"
+        gap={0.25}
+        className="mt-4 rounded-sm border border-border-02 bg-background-tint-02 px-4 py-3"
+      >
+        <Text as="p" font="main-ui-action">
+          Authentication Complete
+        </Text>
+        <Text as="p" font="secondary-body" color="text-03">
+          Your Gmail credential was created. Manage or revoke it from the
+          credential list.
+        </Text>
+      </Section>
     );
   }
 
   return (
-    <div className="w-full">
+    <Section alignItems="start" justifyContent="start" gap={1}>
       <Text as="h3" font="heading-h2">
         Gmail Authentication
       </Text>
-      <div className="mt-4 w-full space-y-4">
+      <Section alignItems="start" justifyContent="start" gap={1}>
         <Text as="p" font="main-ui-action">
           Option 1: OAuth app
         </Text>
@@ -160,7 +88,7 @@ export const GmailAuthSection = ({
             );
           }}
         />
-        <div className="flex w-full justify-end">
+        <Section flexDirection="row" justifyContent="end">
           <Button
             disabled={!oauthAppCredential || isAuthenticating}
             onClick={async () => {
@@ -193,7 +121,7 @@ export const GmailAuthSection = ({
           >
             {isAuthenticating ? "Authenticating..." : "Authenticate with Gmail"}
           </Button>
-        </div>
+        </Section>
         <Text as="p" font="main-ui-action">
           Option 2: Service account
         </Text>
@@ -261,6 +189,7 @@ export const GmailAuthSection = ({
                 toast.success(
                   "Successfully created service account credential"
                 );
+                setJustCreated(true);
                 refreshCredentials();
               } else {
                 const errorMsg = await response.text();
@@ -278,8 +207,8 @@ export const GmailAuthSection = ({
           }}
         >
           {({ isSubmitting }) => (
-            <Form>
-              <div className="w-full space-y-1">
+            <Form className="w-full">
+              <Section alignItems="start" justifyContent="start" gap={0.25}>
                 <Text font="main-ui-body" color="text-03">
                   Primary Admin Email
                 </Text>
@@ -291,16 +220,20 @@ export const GmailAuthSection = ({
                   Enter the email of an admin or owner of the Google
                   Organization that owns the Gmail account(s) you want to index.
                 </Text>
-              </div>
-              <div className="flex w-full justify-end pt-2">
+              </Section>
+              <Section
+                flexDirection="row"
+                justifyContent="end"
+                className="pt-2"
+              >
                 <Button disabled={isSubmitting} type="submit">
                   {isSubmitting ? "Creating..." : "Create Credential"}
                 </Button>
-              </div>
+              </Section>
             </Form>
           )}
         </Formik>
-      </div>
-    </div>
+      </Section>
+    </Section>
   );
 };

--- a/web/src/app/admin/connectors/[connector]/pages/gmail/GmailPage.tsx
+++ b/web/src/app/admin/connectors/[connector]/pages/gmail/GmailPage.tsx
@@ -4,45 +4,30 @@ import React from "react";
 import { ErrorCallout } from "@/components/ErrorCallout";
 import { LoadingAnimation } from "@/components/Loading";
 import { toast } from "@/hooks/useToast";
-import { CCPairBasicInfo, ValidSources } from "@/lib/types";
+import { ValidSources } from "@/lib/types";
 import {
   Credential,
   GmailCredentialJson,
   GmailServiceAccountCredentialJson,
 } from "@/lib/connectors/credentials";
 import { GmailAuthSection } from "./Credential";
-import { usePublicCredentials, useBasicConnectorStatus } from "@/lib/hooks";
+import { usePublicCredentials } from "@/lib/hooks";
 import { useUser } from "@/providers/UserProvider";
 import {
   useGoogleCredentials,
-  useConnectorsByCredentialId,
-  filterUploadedCredentials,
-  checkConnectorsExist,
   refreshAllGoogleData,
 } from "@/lib/googleConnector";
 
 interface GmailMainProps {
   buildMode?: boolean;
   onOAuthRedirect?: () => void;
-  onCredentialCreated?: (
-    credential: Credential<
-      GmailCredentialJson | GmailServiceAccountCredentialJson
-    >
-  ) => void;
 }
 
 export const GmailMain = ({
   buildMode = false,
   onOAuthRedirect,
-  onCredentialCreated,
 }: GmailMainProps) => {
   const { isAdmin, user } = useUser();
-
-  const {
-    data: connectorIndexingStatuses,
-    isLoading: isConnectorIndexingStatusesLoading,
-    error: connectorIndexingStatusesError,
-  } = useBasicConnectorStatus();
 
   const {
     data: credentialsData,
@@ -57,26 +42,14 @@ export const GmailMain = ({
     error: gmailCredentialsError,
   } = useGoogleCredentials(ValidSources.Gmail);
 
-  const { credential_id } = filterUploadedCredentials(gmailCredentials);
-
-  const {
-    data: gmailConnectors,
-    isLoading: isGmailConnectorsLoading,
-    error: gmailConnectorsError,
-    refreshConnectorsByCredentialId,
-  } = useConnectorsByCredentialId(credential_id);
-
   const handleRefresh = () => {
     refreshCredentials();
-    refreshConnectorsByCredentialId();
     refreshAllGoogleData(ValidSources.Gmail);
   };
 
   if (
-    (!connectorIndexingStatuses && isConnectorIndexingStatusesLoading) ||
     (!credentialsData && isCredentialsLoading) ||
-    (!gmailCredentials && isGmailCredentialsLoading) ||
-    (!gmailConnectors && isGmailConnectorsLoading)
+    (!gmailCredentials && isGmailCredentialsLoading)
   ) {
     return (
       <div className="mx-auto">
@@ -93,60 +66,15 @@ export const GmailMain = ({
     return <ErrorCallout errorTitle="Failed to load Gmail credentials." />;
   }
 
-  if (connectorIndexingStatusesError || !connectorIndexingStatuses) {
-    return <ErrorCallout errorTitle="Failed to load connectors." />;
-  }
-
-  if (gmailConnectorsError) {
-    return (
-      <ErrorCallout errorTitle="Failed to load Gmail associated connectors." />
-    );
-  }
-
-  const connectorExistsFromCredential = checkConnectorsExist(gmailConnectors);
-
-  const gmailPublicUploadedCredential:
-    | Credential<GmailCredentialJson>
-    | undefined = credentialsData.find(
-    (credential) =>
-      credential.credential_json?.google_tokens &&
-      credential.admin_public &&
-      credential.source === "gmail" &&
-      credential.credential_json.authentication_method !== "oauth_interactive"
-  );
-
-  const gmailServiceAccountCredential:
-    | Credential<GmailServiceAccountCredentialJson>
-    | undefined = credentialsData.find(
-    (credential) =>
-      credential.credential_json?.google_service_account_key &&
-      credential.source === "gmail"
-  );
-
-  const gmailConnectorIndexingStatuses: CCPairBasicInfo[] =
-    connectorIndexingStatuses.filter(
-      (connectorIndexingStatus) => connectorIndexingStatus.source === "gmail"
-    );
-
-  const connectorExists =
-    connectorExistsFromCredential || gmailConnectorIndexingStatuses.length > 0;
-
   return (
     <>
       {isAdmin && (
         <>
           <GmailAuthSection
             refreshCredentials={handleRefresh}
-            gmailPublicCredential={gmailPublicUploadedCredential}
-            gmailServiceAccountCredential={gmailServiceAccountCredential}
-            connectorExists={connectorExists}
             user={user}
             buildMode={buildMode}
             onOAuthRedirect={onOAuthRedirect}
-            // Necessary prop drilling for build mode v1.
-            // TODO: either integrate gmail into normal flow
-            // or create a build-mode specific Gmail flow
-            onCredentialCreated={onCredentialCreated}
           />
         </>
       )}


### PR DESCRIPTION
## Description

Lets an admin create and run multiple Google Drive and Gmail connectors on one instance. **Stacked on #12666.** [Design doc](https://dev-wiki.onyx.app/app/wiki/Engineering%20Projects/Onyx%20Projects/Google%20Credential%20Model%20Refactor/Design.md).

The credential-setup UI blocked a second Google credential: the auth section short-circuited to "Authentication Complete" as soon as any credential for the source existed. It now confirms only a credential created in the current session, so more can be added. Gmail is routed through the same credential-list + "Create New" modal Drive already uses, instead of a single inline flow.

Backend: drop the `cleanup_gmail_credentials` wipe from the credential-create paths (it deleted every Gmail credential on create). The helper stays for the Gmail app-credential DELETE route.

The run path, indexing, and permission sync are already per-cc_pair, so multiple connectors index independently.

## How Has This Been Tested?

Full E2E on a dev instance against the real onyx-test.com Workspace, via the admin UI end to end. Final state: five Google Drive connectors across four credential rows, all indexing independently.

- Multi-credential UX: the old any-credential-exists short-circuit is gone. Credentials created repeatedly through the modal (per-session `justCreated` panel, list reopens cleanly). Four credential rows coexisted: two rows from one service-account key, one row from a second key of the same SA, one OAuth credential.
- Two connectors on one credential, scoped to different folders: both indexed, 15 docs each, fully disjoint document sets (verified in `document_by_connector_credential_pair`, zero overlap).
- Separate credential rows (same SA, different keys) each drove their own connector to successful indexing (5 docs each from distinct fixture folders).
- OAuth path: app cred stored on the credential (no global slot) went through authorize -> Google consent -> callback; tokens landed next to the app cred and the connector indexes the consenting user's Drive (55+ docs).
- Deletion independence: deleting connectors sharing a credential left the credential and sibling connectors untouched (guards the `cleanup_gmail_credentials`-style wipe removal).
- Negative paths: a structurally-valid-but-fake SA key is rejected at connector validation (PEM parse), and a real SA without domain-wide delegation is rejected with the typed missing-scopes error. Clear toasts, not 500s.

Automated: external-dependency test confirms a second Gmail credential does not delete the first; unit suite, ruff, project-wide ty, FE types/lint all pass.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


