### PR TITLE
fix(jira): skip deleted groups during group sync

### DIFF
--- a/backend/ee/onyx/external_permissions/jira/group_sync.py
+++ b/backend/ee/onyx/external_permissions/jira/group_sync.py
@@ -1,3 +1,4 @@
+import json
 from collections.abc import Generator
 from typing import Any
 
@@ -17,6 +18,37 @@ _GROUP_MEMBER_PAGE_SIZE = 50
 # The GET /group/member endpoint was introduced in Jira 6.0.
 # Jira versions older than 6.0 do not have group management REST APIs at all.
 _MIN_JIRA_VERSION_FOR_GROUP_MEMBER = "6.0"
+
+
+class _JiraGroupNotFoundError(RuntimeError):
+    pass
+
+
+def _get_jira_error_text(error: JIRAError) -> str:
+    raw_text = getattr(error, "text", "")
+    if not isinstance(raw_text, str):
+        return str(raw_text)
+
+    try:
+        payload = json.loads(raw_text)
+    except json.JSONDecodeError:
+        return raw_text
+
+    if not isinstance(payload, dict):
+        return raw_text
+
+    error_messages = payload.get("errorMessages")
+    if isinstance(error_messages, list):
+        return "; ".join(str(message) for message in error_messages)
+    if error_messages:
+        return str(error_messages)
+
+    return raw_text
+
+
+def _is_group_not_found_error(error: JIRAError) -> bool:
+    error_text = _get_jira_error_text(error).lower()
+    return "the group named" in error_text and "does not exist" in error_text
 
 
 def _fetch_group_member_page(
@@ -47,6 +79,11 @@ def _fetch_group_member_page(
         )
     except JIRAError as e:
         if e.status_code == 404:
+            if _is_group_not_found_error(e):
+                raise _JiraGroupNotFoundError(
+                    f"Jira group '{group_name}' no longer exists"
+                ) from e
+
             raise RuntimeError(
                 f"GET /group/member returned 404 for group '{group_name}'. "
                 f"This endpoint requires Jira {_MIN_JIRA_VERSION_FOR_GROUP_MEMBER}+. "
@@ -72,6 +109,13 @@ def _get_group_member_emails(
     while True:
         try:
             page = _fetch_group_member_page(jira_client, group_name, start_at)
+        except _JiraGroupNotFoundError:
+            logger.warning(
+                "Jira returned group %s from groups() but /group/member says it no "
+                "longer exists. Skipping.",
+                group_name,
+            )
+            return set()
         except Exception as e:
             logger.error("Error fetching members for group %s: %s", group_name, e)
             raise

--- a/backend/tests/unit/ee/onyx/external_permissions/jira/test_jira_group_sync.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/jira/test_jira_group_sync.py
@@ -1,0 +1,39 @@
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+from jira import JIRA
+from jira.exceptions import JIRAError
+
+from ee.onyx.external_permissions.jira.group_sync import _fetch_group_member_page
+from ee.onyx.external_permissions.jira.group_sync import _get_group_member_emails
+
+
+def test_get_group_member_emails_skips_deleted_group(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    jira_client = MagicMock(spec=JIRA)
+    jira_client._get_json.side_effect = JIRAError(
+        status_code=404,
+        text=(
+            '{"errorMessages":["The group named \'stale group \' does not '
+            'exist"],"errors":{}}'
+        ),
+    )
+
+    with caplog.at_level(logging.WARNING):
+        member_emails = _get_group_member_emails(jira_client, "stale group ")
+
+    assert member_emails == set()
+    assert "no longer exists" in caplog.text
+
+
+def test_fetch_group_member_page_keeps_unrecognized_404_error() -> None:
+    jira_client = MagicMock(spec=JIRA)
+    jira_client._get_json.side_effect = JIRAError(
+        status_code=404,
+        text="Not Found",
+    )
+
+    with pytest.raises(RuntimeError, match="requires Jira 6.0"):
+        _fetch_group_member_page(jira_client, "jira-users", 0)


### PR DESCRIPTION
## Description

Skips stale Jira groups during external group sync when Jira's group listing includes a group that `/group/member` then reports as deleted or missing.

This keeps the sync moving for Jira Cloud responses like `The group named ... does not exist`, while preserving the existing Jira-version error for unrecognized `404` responses from the same endpoint.

## How Has This Been Tested?

- `pytest -q backend/tests/unit/ee/onyx/external_permissions/jira/test_jira_group_sync.py`
- `ruff check backend/ee/onyx/external_permissions/jira/group_sync.py backend/tests/unit/ee/onyx/external_permissions/jira/test_jira_group_sync.py`
- `ruff format --check backend/ee/onyx/external_permissions/jira/group_sync.py backend/tests/unit/ee/onyx/external_permissions/jira/test_jira_group_sync.py`
- `ty check backend/ee/onyx/external_permissions/jira/group_sync.py backend/tests/unit/ee/onyx/external_permissions/jira/test_jira_group_sync.py`
- Pre-commit hooks from `git commit`

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skips deleted Jira groups during external group sync so a stale group doesn’t stop the sync. Continues syncing other groups while keeping the existing error behavior for unrecognized 404s and outdated Jira versions.

- **Bug Fixes**
  - Detects “group does not exist” 404s from /group/member and skips that group with a warning.
  - Preserves the existing RuntimeError for other 404s (e.g., Jira < 6.0).
  - Adds unit tests covering both cases.

<sup>Written for commit 03f176cf986149f87a2eb0511939a738ae09cc38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

