### PR TITLE
feat: reuse an existing credential's Google OAuth app

### DIFF
--- a/backend/onyx/connectors/google_utils/google_kv.py
+++ b/backend/onyx/connectors/google_utils/google_kv.py
@@ -175,6 +175,32 @@ def build_service_account_creds(
     )
 
 
+def app_cred_from_credential_json(
+    credential_json: dict[str, Any],
+) -> dict[str, Any] | None:
+    """App cred derivable from a credential's json: the stored value, else one
+    rebuilt from the token blob (which embeds the client id/secret), else None."""
+    existing = credential_json.get(DB_CREDENTIALS_DICT_APP_CREDENTIAL_KEY)
+    if existing is not None:
+        return _load_google_json(existing)
+    token_raw = credential_json.get(DB_CREDENTIALS_DICT_TOKEN_KEY)
+    if token_raw is None:
+        return None
+    token_dict = _load_google_json(token_raw)
+    if "client_id" not in token_dict or "client_secret" not in token_dict:
+        return None
+    return {
+        "web": {
+            "client_id": token_dict["client_id"],
+            "client_secret": token_dict["client_secret"],
+            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+            "token_uri": token_dict.get(
+                "token_uri", "https://oauth2.googleapis.com/token"
+            ),
+        }
+    }
+
+
 def _app_cred_on_row(
     credential_id: int,
     user: User,
@@ -194,28 +220,12 @@ def _app_cred_on_row(
     if existing is not None:
         return _load_google_json(existing)
 
-    token_raw = existing_json.get(DB_CREDENTIALS_DICT_TOKEN_KEY)
-    if token_raw is None:
+    reconstructed = app_cred_from_credential_json(existing_json)
+    if reconstructed is None:
         raise ValueError(
             f"Credential {credential_id} has no OAuth app credential. "
             "Provide one when creating the credential."
         )
-    token_dict = _load_google_json(token_raw)
-    if "client_id" not in token_dict or "client_secret" not in token_dict:
-        raise ValueError(
-            f"Credential {credential_id} has no OAuth app credential and its "
-            "token does not embed one."
-        )
-    reconstructed = {
-        "web": {
-            "client_id": token_dict["client_id"],
-            "client_secret": token_dict["client_secret"],
-            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-            "token_uri": token_dict.get(
-                "token_uri", "https://oauth2.googleapis.com/token"
-            ),
-        }
-    }
     # get_value returns SensitiveValue's cached dict, so build a new one rather
     # than mutating it in place.
     updated_json = {

--- a/backend/onyx/server/documents/credential.py
+++ b/backend/onyx/server/documents/credential.py
@@ -13,6 +13,10 @@ from onyx.auth.permissions import require_permission
 from onyx.auth.users import current_curator_or_admin_user
 from onyx.configs.constants import PUBLIC_API_TAGS
 from onyx.connectors.factory import validate_ccpair_for_user
+from onyx.connectors.google_utils.google_kv import app_cred_from_credential_json
+from onyx.connectors.google_utils.shared_constants import (
+    DB_CREDENTIALS_DICT_APP_CREDENTIAL_KEY,
+)
 from onyx.db.credentials import alter_credential
 from onyx.db.credentials import create_credential
 from onyx.db.credentials import CREDENTIAL_PERMISSIONS_TO_IGNORE
@@ -27,6 +31,8 @@ from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
 from onyx.db.models import DocumentSource
 from onyx.db.models import User
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.server.documents.models import CredentialBase
 from onyx.server.documents.models import CredentialDataUpdateRequest
 from onyx.server.documents.models import CredentialSnapshot
@@ -163,6 +169,30 @@ def create_credential_from_model(
             user=user,
             target_group_ids=credential_info.groups,
             object_is_public=credential_info.curator_public,
+        )
+
+    if credential_info.source_credential_id is not None:
+        source_credential = fetch_credential_by_id_for_user(
+            credential_info.source_credential_id, user, db_session
+        )
+        if source_credential is None:
+            raise OnyxError(
+                OnyxErrorCode.CREDENTIAL_NOT_FOUND,
+                f"Source credential {credential_info.source_credential_id} not found",
+            )
+        source_json = (
+            source_credential.credential_json.get_value(apply_mask=False)
+            if source_credential.credential_json
+            else {}
+        )
+        app_cred = app_cred_from_credential_json(source_json)
+        if app_cred is None:
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                "Source credential has no OAuth app credential to reuse",
+            )
+        credential_info.credential_json.setdefault(
+            DB_CREDENTIALS_DICT_APP_CREDENTIAL_KEY, app_cred
         )
 
     credential = create_credential(credential_info, user, db_session)

--- a/backend/onyx/server/documents/models.py
+++ b/backend/onyx/server/documents/models.py
@@ -134,6 +134,8 @@ class CredentialDataUpdateRequest(BaseModel):
 
 class CredentialBase(BaseModel):
     credential_json: dict[str, Any]
+    # Copy the OAuth app credential from this credential at create time
+    source_credential_id: int | None = None
     # if `true`, then all Admins will have access to the credential
     admin_public: bool
     source: DocumentSource

--- a/web/src/app/admin/connectors/[connector]/pages/gdrive/Credential.tsx
+++ b/web/src/app/admin/connectors/[connector]/pages/gdrive/Credential.tsx
@@ -7,8 +7,10 @@ import { setupGoogleDriveOAuth } from "@/lib/googleDrive";
 import { DOCS_ADMINS_PATH } from "@/lib/constants";
 import { Form, Formik } from "formik";
 import { User } from "@/lib/types";
+import { Credential } from "@/lib/connectors/credentials";
 import { Button, Text } from "@opal/components";
 import InputFile from "@/refresh-components/inputs/InputFile";
+import InputSelect from "@/refresh-components/inputs/InputSelect";
 import InputTypeInField from "@/refresh-components/form/InputTypeInField";
 import {
   parseOauthAppCredentialJson,
@@ -20,15 +22,21 @@ import { markdown } from "@opal/utils";
 interface DriveCredentialSectionProps {
   refreshCredentials: () => void;
   user: User | null;
+  // OAuth credentials whose app can be reused for a new credential
+  existingOauthCredentials?: Credential<Record<string, unknown>>[];
 }
 
 export const DriveAuthSection = ({
   refreshCredentials,
   user,
+  existingOauthCredentials = [],
 }: DriveCredentialSectionProps) => {
   const router = useRouter();
   const [isAuthenticating, setIsAuthenticating] = useState(false);
   const [justCreated, setJustCreated] = useState(false);
+  const [sourceCredentialId, setSourceCredentialId] = useState<number | null>(
+    null
+  );
   const [serviceAccountKey, setServiceAccountKey] = useState<Record<
     string,
     unknown
@@ -67,20 +75,52 @@ export const DriveAuthSection = ({
             `Upload the OAuth app JSON from Google Cloud Console ([setup instructions](${DOCS_ADMINS_PATH}/connectors/official/google_drive/overview)), then authenticate with the Google account whose Drive you want to index.`
           )}
         </Text>
-        <InputFile
-          accept="application/json"
-          placeholder="Upload or paste your OAuth app JSON"
-          setValue={(value) => {
-            setOauthAppCredential(
-              value ? parseOauthAppCredentialJson(value) : null
-            );
-          }}
-        />
+        {existingOauthCredentials.length > 0 && (
+          <InputSelect
+            value={
+              sourceCredentialId === null ? "new" : String(sourceCredentialId)
+            }
+            onValueChange={(value) =>
+              setSourceCredentialId(value === "new" ? null : Number(value))
+            }
+          >
+            <InputSelect.Trigger placeholder="Upload a new OAuth app" />
+            <InputSelect.Content>
+              <InputSelect.Item value="new">
+                Upload a new OAuth app
+              </InputSelect.Item>
+              {existingOauthCredentials.map((credential) => (
+                <InputSelect.Item
+                  key={credential.id}
+                  value={String(credential.id)}
+                >
+                  {`Use the app from credential #${credential.id}${
+                    credential.name ? ` (${credential.name})` : ""
+                  }`}
+                </InputSelect.Item>
+              ))}
+            </InputSelect.Content>
+          </InputSelect>
+        )}
+        {sourceCredentialId === null && (
+          <InputFile
+            accept="application/json"
+            placeholder="Upload or paste your OAuth app JSON"
+            setValue={(value) => {
+              setOauthAppCredential(
+                value ? parseOauthAppCredentialJson(value) : null
+              );
+            }}
+          />
+        )}
         <div className="flex w-full justify-end">
           <Button
-            disabled={!oauthAppCredential || isAuthenticating}
+            disabled={
+              (sourceCredentialId === null && !oauthAppCredential) ||
+              isAuthenticating
+            }
             onClick={async () => {
-              if (!oauthAppCredential) {
+              if (sourceCredentialId === null && !oauthAppCredential) {
                 return;
               }
               setIsAuthenticating(true);
@@ -88,7 +128,8 @@ export const DriveAuthSection = ({
                 const [authUrl, errorMsg] = await setupGoogleDriveOAuth({
                   isAdmin: true,
                   name: "OAuth (uploaded)",
-                  appCredential: oauthAppCredential,
+                  appCredential: oauthAppCredential ?? undefined,
+                  sourceCredentialId: sourceCredentialId ?? undefined,
                 });
                 if (authUrl) {
                   router.push(authUrl as Route);

--- a/web/src/app/admin/connectors/[connector]/pages/gdrive/GoogleDrivePage.tsx
+++ b/web/src/app/admin/connectors/[connector]/pages/gdrive/GoogleDrivePage.tsx
@@ -63,7 +63,16 @@ const GDriveMain = () => {
     <>
       {isAdmin && (
         <>
-          <DriveAuthSection refreshCredentials={handleRefresh} user={user} />
+          <DriveAuthSection
+            refreshCredentials={handleRefresh}
+            user={user}
+            existingOauthCredentials={credentialsData.filter(
+              (credential) =>
+                credential.source === "google_drive" &&
+                (credential.credential_json?.google_app_credential ||
+                  credential.credential_json?.google_tokens)
+            )}
+          />
         </>
       )}
     </>

--- a/web/src/app/admin/connectors/[connector]/pages/gmail/Credential.tsx
+++ b/web/src/app/admin/connectors/[connector]/pages/gmail/Credential.tsx
@@ -1,5 +1,6 @@
 import { Button, Text } from "@opal/components";
 import InputFile from "@/refresh-components/inputs/InputFile";
+import InputSelect from "@/refresh-components/inputs/InputSelect";
 import InputTypeInField from "@/refresh-components/form/InputTypeInField";
 import { toast } from "@/hooks/useToast";
 import React, { useState, useEffect } from "react";
@@ -12,6 +13,7 @@ import { CRAFT_OAUTH_COOKIE_NAME } from "@/app/craft/v1/constants";
 import Cookies from "js-cookie";
 import { Form, Formik } from "formik";
 import { User } from "@/lib/types";
+import { Credential } from "@/lib/connectors/credentials";
 import {
   parseOauthAppCredentialJson,
   refreshAllGoogleData,
@@ -22,6 +24,8 @@ import { markdown } from "@opal/utils";
 interface GmailCredentialSectionProps {
   refreshCredentials: () => void;
   user: User | null;
+  // OAuth credentials whose app can be reused for a new credential
+  existingOauthCredentials?: Credential<Record<string, unknown>>[];
   buildMode?: boolean;
   onOAuthRedirect?: () => void;
 }
@@ -29,12 +33,16 @@ interface GmailCredentialSectionProps {
 export const GmailAuthSection = ({
   refreshCredentials,
   user,
+  existingOauthCredentials = [],
   buildMode = false,
   onOAuthRedirect,
 }: GmailCredentialSectionProps) => {
   const router = useRouter();
   const [isAuthenticating, setIsAuthenticating] = useState(false);
   const [justCreated, setJustCreated] = useState(false);
+  const [sourceCredentialId, setSourceCredentialId] = useState<number | null>(
+    null
+  );
   const [serviceAccountKey, setServiceAccountKey] = useState<Record<
     string,
     unknown
@@ -73,20 +81,52 @@ export const GmailAuthSection = ({
             `Upload the OAuth app JSON from Google Cloud Console ([setup instructions](${DOCS_ADMINS_PATH}/connectors/official/gmail/overview)), then authenticate with the Google account whose Gmail you want to index.`
           )}
         </Text>
-        <InputFile
-          accept="application/json"
-          placeholder="Upload or paste your OAuth app JSON"
-          setValue={(value) => {
-            setOauthAppCredential(
-              value ? parseOauthAppCredentialJson(value) : null
-            );
-          }}
-        />
+        {existingOauthCredentials.length > 0 && (
+          <InputSelect
+            value={
+              sourceCredentialId === null ? "new" : String(sourceCredentialId)
+            }
+            onValueChange={(value) =>
+              setSourceCredentialId(value === "new" ? null : Number(value))
+            }
+          >
+            <InputSelect.Trigger placeholder="Upload a new OAuth app" />
+            <InputSelect.Content>
+              <InputSelect.Item value="new">
+                Upload a new OAuth app
+              </InputSelect.Item>
+              {existingOauthCredentials.map((credential) => (
+                <InputSelect.Item
+                  key={credential.id}
+                  value={String(credential.id)}
+                >
+                  {`Use the app from credential #${credential.id}${
+                    credential.name ? ` (${credential.name})` : ""
+                  }`}
+                </InputSelect.Item>
+              ))}
+            </InputSelect.Content>
+          </InputSelect>
+        )}
+        {sourceCredentialId === null && (
+          <InputFile
+            accept="application/json"
+            placeholder="Upload or paste your OAuth app JSON"
+            setValue={(value) => {
+              setOauthAppCredential(
+                value ? parseOauthAppCredentialJson(value) : null
+              );
+            }}
+          />
+        )}
         <div className="flex w-full justify-end">
           <Button
-            disabled={!oauthAppCredential || isAuthenticating}
+            disabled={
+              (sourceCredentialId === null && !oauthAppCredential) ||
+              isAuthenticating
+            }
             onClick={async () => {
-              if (!oauthAppCredential) {
+              if (sourceCredentialId === null && !oauthAppCredential) {
                 return;
               }
               setIsAuthenticating(true);
@@ -98,7 +138,8 @@ export const GmailAuthSection = ({
                 }
                 const [authUrl, errorMsg] = await setupGmailOAuth({
                   isAdmin: true,
-                  appCredential: oauthAppCredential,
+                  appCredential: oauthAppCredential ?? undefined,
+                  sourceCredentialId: sourceCredentialId ?? undefined,
                 });
                 if (authUrl) {
                   onOAuthRedirect?.();

--- a/web/src/app/admin/connectors/[connector]/pages/gmail/GmailPage.tsx
+++ b/web/src/app/admin/connectors/[connector]/pages/gmail/GmailPage.tsx
@@ -75,6 +75,12 @@ export const GmailMain = ({
             user={user}
             buildMode={buildMode}
             onOAuthRedirect={onOAuthRedirect}
+            existingOauthCredentials={credentialsData.filter(
+              (credential) =>
+                credential.source === "gmail" &&
+                (credential.credential_json?.google_app_credential ||
+                  credential.credential_json?.google_tokens)
+            )}
           />
         </>
       )}

--- a/web/src/lib/gmail.ts
+++ b/web/src/lib/gmail.ts
@@ -3,10 +3,14 @@ import { Credential } from "./connectors/credentials";
 export const setupGmailOAuth = async ({
   isAdmin,
   appCredential,
+  sourceCredentialId,
 }: {
   isAdmin: boolean;
-  // OAuth app ({"web": {...}}) to store on the credential.
-  appCredential: Record<string, unknown>;
+  // OAuth app ({"web": {...}}) to store on the credential. Exactly one of
+  // appCredential or sourceCredentialId must be provided.
+  appCredential?: Record<string, unknown>;
+  // Copy the OAuth app from this existing credential instead.
+  sourceCredentialId?: number;
 }): Promise<[string | null, string]> => {
   const credentialCreationResponse = await fetch("/api/manage/credential", {
     method: "POST",
@@ -15,7 +19,10 @@ export const setupGmailOAuth = async ({
     },
     body: JSON.stringify({
       admin_public: isAdmin,
-      credential_json: { google_app_credential: appCredential },
+      credential_json: appCredential
+        ? { google_app_credential: appCredential }
+        : {},
+      source_credential_id: sourceCredentialId,
       source: "gmail",
     }),
   });

--- a/web/src/lib/googleDrive.ts
+++ b/web/src/lib/googleDrive.ts
@@ -4,11 +4,15 @@ export const setupGoogleDriveOAuth = async ({
   isAdmin,
   name,
   appCredential,
+  sourceCredentialId,
 }: {
   isAdmin: boolean;
   name: string;
-  // OAuth app ({"web": {...}}) to store on the credential.
-  appCredential: Record<string, unknown>;
+  // OAuth app ({"web": {...}}) to store on the credential. Exactly one of
+  // appCredential or sourceCredentialId must be provided.
+  appCredential?: Record<string, unknown>;
+  // Copy the OAuth app from this existing credential instead.
+  sourceCredentialId?: number;
 }): Promise<[string | null, string]> => {
   const credentialCreationResponse = await fetch("/api/manage/credential", {
     method: "POST",
@@ -17,7 +21,10 @@ export const setupGoogleDriveOAuth = async ({
     },
     body: JSON.stringify({
       admin_public: isAdmin,
-      credential_json: { google_app_credential: appCredential },
+      credential_json: appCredential
+        ? { google_app_credential: appCredential }
+        : {},
+      source_credential_id: sourceCredentialId,
       source: "google_drive",
       name: name,
     }),


### PR DESCRIPTION
## Description

A new OAuth credential can copy its app credential from an existing credential instead of a fresh upload. **Stacked on #12668.** [Design doc](https://dev-wiki.onyx.app/app/wiki/Engineering%20Projects/Onyx%20Projects/Google%20Credential%20Model%20Refactor/Design.md).

- The create endpoint accepts `source_credential_id`, enforces the caller can read that credential, and copies its app cred (or one rebuilt from its token blob) onto the new credential. Server side only, since `client_secret` is masked in snapshots.
- The authenticate step shows a picker of reusable credentials next to the upload. Nothing is ever chosen implicitly: a credential is created with an uploaded app, a copied app, or it errors at authorize.

## How Has This Been Tested?

Unit tests cover the extractor (stored value, token-blob rebuild, None). ruff + project-wide ty + FE types/lint/format clean.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check