### PR TITLE
Support connecting the GitLab connector to a specific branch

### DIFF
--- a/backend/onyx/connectors/gitlab/connector.py
+++ b/backend/onyx/connectors/gitlab/connector.py
@@ -10,6 +10,7 @@ from typing import TypeVar
 
 import gitlab
 import pytz
+from gitlab.exceptions import GitlabGetError
 from gitlab.v4.objects import Project
 
 from onyx.configs.app_configs import GITLAB_CONNECTOR_INCLUDE_CODE_FILES
@@ -94,24 +95,39 @@ def _convert_issue_to_document(issue: Any) -> Document:
 
 
 def _convert_code_to_document(
-    project: Project, file: Any, url: str, projectName: str, projectOwner: str
+    project: Project,
+    file: Any,
+    url: str,
+    projectName: str,
+    projectOwner: str,
+    branch: str | None = None,
 ) -> Document:
-    # Dynamically get the default branch from the project object
-    default_branch = project.default_branch
+    # Use the explicitly configured branch if provided, otherwise fall back
+    # to the project's default branch (preserves prior behavior).
+    target_branch = branch or project.default_branch
 
-    # Fetch the file content using the correct branch
-    file_content_obj = project.files.get(
-        file_path=file["path"],
-        ref=default_branch,  # Use the default branch
-    )
+    # Fetch the file content using the resolved branch
+    try:
+        file_content_obj = project.files.get(
+            file_path=file["path"],
+            ref=target_branch,
+        )
+    except GitlabGetError as e:
+        if e.response_code == 404:
+            raise ValueError(
+                f"Could not fetch '{file['path']}' from branch '{target_branch}' in "
+                f"project '{projectOwner}/{projectName}'. Check that the branch exists "
+                "and that the configured access token has permission to read it."
+            ) from e
+        raise
     try:
         file_content = file_content_obj.decode().decode("utf-8")
     except UnicodeDecodeError:
         file_content = file_content_obj.decode().decode("latin-1")
 
-    # Construct the file URL dynamically using the default branch
+    # Construct the file URL dynamically using the resolved branch
     file_url = (
-        f"{url}/{projectOwner}/{projectName}/-/blob/{default_branch}/{file['path']}"
+        f"{url}/{projectOwner}/{projectName}/-/blob/{target_branch}/{file['path']}"
     )
 
     # Create and return a Document object
@@ -142,6 +158,7 @@ class GitlabConnector(LoadConnector, PollConnector):
         include_mrs: bool = True,
         include_issues: bool = True,
         include_code_files: bool = GITLAB_CONNECTOR_INCLUDE_CODE_FILES,
+        branch: str | None = None,
     ) -> None:
         self.project_owner = project_owner
         self.project_name = project_name
@@ -150,6 +167,9 @@ class GitlabConnector(LoadConnector, PollConnector):
         self.include_mrs = include_mrs
         self.include_issues = include_issues
         self.include_code_files = include_code_files
+        # Normalize "" (e.g. from an empty form field) to None so it falls
+        # back cleanly to the project's default branch.
+        self.branch = branch or None
         self.gitlab_client: gitlab.Gitlab | None = None
 
     def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
@@ -173,7 +193,19 @@ class GitlabConnector(LoadConnector, PollConnector):
             queue = deque([""])  # Start with the root directory
             while queue:
                 current_path = queue.popleft()
-                files = project.repository_tree(path=current_path, all=True)
+                try:
+                    files = project.repository_tree(
+                        path=current_path, ref=self.branch, all=True
+                    )
+                except GitlabGetError as e:
+                    if e.response_code == 404 and self.branch:
+                        raise ValueError(
+                            f"Could not list files from branch '{self.branch}' in "
+                            f"project '{self.project_owner}/{self.project_name}'. "
+                            "Check that the branch exists and that the configured "
+                            "access token has permission to read it."
+                        ) from e
+                    raise
                 for file_batch in _batch_gitlab_objects(files, self.batch_size):
                     code_doc_batch: list[Document | HierarchyNode] = []
                     for file in file_batch:
@@ -188,6 +220,7 @@ class GitlabConnector(LoadConnector, PollConnector):
                                     self.gitlab_client.url,
                                     self.project_name,
                                     self.project_owner,
+                                    self.branch,
                                 )
                             )
                         elif file["type"] == "tree":
@@ -264,6 +297,7 @@ if __name__ == "__main__":
         include_mrs=True,
         include_issues=True,
         include_code_files=GITLAB_CONNECTOR_INCLUDE_CODE_FILES,
+        branch=os.environ.get("BRANCH"),  # optional, defaults to the default branch
     )
 
     connector.load_credentials(

--- a/backend/tests/daily/connectors/gitlab/test_gitlab_basic.py
+++ b/backend/tests/daily/connectors/gitlab/test_gitlab_basic.py
@@ -35,6 +35,57 @@ def gitlab_connector(
     return connector
 
 
+@pytest.fixture
+def gitlab_connector_with_branch(
+    test_secrets: dict[TestSecret, str],
+) -> GitlabConnector:
+    """Same test project, but pinned to a non-default branch to verify the
+    `branch` config option is respected end-to-end."""
+    connector = GitlabConnector(
+        project_owner="onyx2895818",
+        project_name="onyx",
+        include_mrs=False,
+        include_issues=False,
+        include_code_files=True,
+        branch="test-branch",  # must exist in the test fixture repo
+    )
+    gitlab_url = os.environ.get("GITLAB_URL", "https://gitlab.com")
+    gitlab_token = test_secrets[TestSecret.GITLAB_ACCESS_TOKEN]
+
+    connector.load_credentials(
+        {
+            "gitlab_access_token": gitlab_token,
+            "gitlab_url": gitlab_url,
+        }
+    )
+    return connector
+
+
+def test_gitlab_connector_branch_override(
+    gitlab_connector_with_branch: GitlabConnector,
+) -> None:
+    doc_batches = gitlab_connector_with_branch.load_from_state()
+    docs = [
+        doc
+        for doc in itertools.chain(*doc_batches)
+        if not isinstance(doc, HierarchyNode)
+    ]
+
+    assert len(docs) > 0
+    for doc in docs:
+        assert doc.metadata["type"] == "CodeFile"
+        # Blob URLs should reference the configured branch, not the
+        # repository's default branch.
+        assert "/-/blob/test-branch/" in doc.sections[0].link
+
+
+def test_gitlab_connector_no_branch_uses_default(
+    gitlab_connector: GitlabConnector,
+) -> None:
+    """Regression check: omitting `branch` must keep using the default branch."""
+    assert gitlab_connector.branch is None
+
+
 def test_gitlab_connector_basic(gitlab_connector: GitlabConnector) -> None:
     doc_batches = gitlab_connector.load_from_state()
     docs = list(itertools.chain(*doc_batches))

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -314,6 +314,15 @@ export const connectorConfigs: Record<
     ],
     advanced_values: [
       {
+        type: "text",
+        query: "Enter a branch (optional):",
+        label: "Branch",
+        name: "branch",
+        description:
+          "Branch to index code files from. Leave blank to use the repository's default branch.",
+        optional: true,
+      },
+      {
         type: "checkbox",
         query: "Include merge requests?",
         label: "Include MRs",
@@ -1992,6 +2001,7 @@ export interface GithubConfig {
 export interface GitlabConfig {
   project_owner: string;
   project_name: string;
+  branch?: string;
   include_mrs: boolean;
   include_issues: boolean;
 }


### PR DESCRIPTION
Closes #12649

## What this does

Right now the GitLab connector always pulls code files from the repo's default branch (usually `main`). This adds an optional `branch` setting so you can point it at a different branch instead (like `dev` or `staging`), while leaving everything working exactly as before if you don't set one.

## What changed

- You can now enter a branch name in the GitLab connector's advanced settings. Leave it blank and nothing changes.
- The connector now uses that branch when listing and fetching code files.
- If you type a branch that doesn't exist (or the token can't access it), you now get a clear error message instead of a confusing crash.
- Added tests for both cases: a branch is set, and no branch is set.

## What this doesn't change

This only affects code files. Merge requests and issues aren't tied to a specific branch in GitLab, so they're indexed the same way as before either way.

## How I tested it

I don't have access to Onyx's internal test project or CI secrets, so I couldn't run the official test suite myself. Instead, I created my own small GitLab repo with two branches (`main` and `dev`) that had different file content, and ran the connector directly against it:

- Set to `dev` → correctly pulled the `dev` version of the file
- Left blank → correctly fell back to `main`, same as before
- Set to a branch that doesn't exist → got a clean error message instead of a crash

I've added a test (`test_gitlab_connector_branch_override`) for this in the repo, but it needs a `test-branch` branch to exist in Onyx's internal test project to actually run , happy to adjust if maintainers want a different setup.

## Technical details

**`backend/onyx/connectors/gitlab/connector.py`**
- `GitlabConnector.__init__` now accepts an optional `branch: str | None = None`. An empty string is normalized to `None` so a blank form field behaves identically to omitting the setting.
- `_convert_code_to_document` now accepts a `branch` parameter and resolves it as `target_branch = branch or project.default_branch` — explicit branch wins, otherwise falls back to the repo's default, exactly matching prior behavior.
- Two separate GitLab API calls needed the branch threaded through, not just one:
  - `project.repository_tree(path=..., ref=self.branch, all=True)` : controls which branch's file *listing* is returned.
  - `project.files.get(file_path=..., ref=target_branch)` : controls which branch's file *content* is fetched.
  
  Both had to be updated together, fixing only the content fetch would leave you listing files from the wrong branch while fetching their content from the right one, which could easily 404 or silently mismatch for files that don't exist on both branches.
- Verified against the exact `python-gitlab` version pinned in this repo (`5.6.0`) that `ref=None` is safe: the library only adds `ref` to the outgoing API query if it's truthy, so passing `None` behaves identically to omitting the parameter.
- Added `except GitlabGetError` around both API calls above. A 404 on either one now raises a `ValueError` with a message identifying the branch and project, instead of letting the raw `GitlabGetError`/`GitlabHttpError` traceback propagate up uncaught.
- The blob URL construction (used as the document's link back to GitLab) now uses `target_branch` instead of the hardcoded `project.default_branch`, so links shown in Onyx correctly point at whichever branch content was actually indexed from.

**`web/src/lib/connectors/connectors.tsx`**
- Added a `branch` text field (optional) to the GitLab connector's `advanced_values` form config, and `branch?: string` to the `GitlabConfig` TypeScript interface.
- Traced the full data path to confirm this reaches the backend correctly: form submissions serialize into `connector_specific_config: dict[str, Any]` (untyped, no schema filtering), which `onyx/connectors/factory.py` unpacks directly as `connector_class(**connector_specific_config)` , so the `branch` key flows straight into `GitlabConnector.__init__` with no extra wiring needed.

**`backend/tests/daily/connectors/gitlab/test_gitlab_basic.py`**
- Added `gitlab_connector_with_branch` fixture, pinned to a `test-branch` branch on the existing test project.
- Added `test_gitlab_connector_branch_override`, asserting all returned code-file documents' links contain `/-/blob/test-branch/`.
- Added `test_gitlab_connector_no_branch_uses_default`, a lightweight regression check that `connector.branch is None` when unset.

## Known limitations (not caused by this change, just worth knowing)

- Switching branches doesn't clean up previously-indexed content from the old branch, this connector doesn't implement pruning, which is a pre-existing limitation unrelated to this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an optional branch setting to the GitLab connector so you can index code from a specific branch instead of the repo's default. Keeps existing behavior when left blank and shows clear errors if the branch can't be read.

- **New Features**
  - Added `branch` field in the GitLab connector's advanced settings; blank uses the default branch.
  - Backend lists and fetches files from the chosen branch, and blob URLs point to it.
  - Returns a clear error if the branch doesn't exist or the token lacks access.
  - Added tests for branch override and default-branch behavior.

<sup>Written for commit b78111f9db942b3b0f60e068cb23b38039695d81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

