### PR TITLE
fix(web): chain session-expiry timeout to avoid setTimeout 32-bit overflow

### DIFF
--- a/web/src/lib/auth/hooks.ts
+++ b/web/src/lib/auth/hooks.ts
@@ -38,6 +38,10 @@ export function useAuthTypeMetadata(): {
   return { authTypeMetadata: data, isLoading, error };
 }
 
+// setTimeout stores its delay as a 32-bit signed int; anything above this
+// overflows and fires immediately.
+const MAX_TIMEOUT_DELAY_MS = 2 ** 31 - 1;
+
 function computeSecondsUntilExpiration(user: User): number | null {
   if (!user.token_expires_at) return null;
   return getSecondsUntilExpiration(new Date(user.token_expires_at));
@@ -113,10 +117,18 @@ export function useSessionWatcher(): SessionWatcherResult {
     // a 200 with deep-equal data, which never re-runs this effect — the
     // one-shot timer disarms and the session dies unwatched. A 200 after the
     // wall means the session moved, and its new expiry re-arms us.
-    expiryTimeoutRef.current = setTimeout(
-      () => mutateUser(),
-      (seconds + 2) * 1000
-    );
+    // Sessions longer than ~24.8 days also exceed setTimeout's max delay, so
+    // chain intermediate timeouts until the remaining delay fits.
+    const scheduleExpiryCheck = (delayMs: number) => {
+      if (delayMs > MAX_TIMEOUT_DELAY_MS) {
+        expiryTimeoutRef.current = setTimeout(() => {
+          scheduleExpiryCheck(delayMs - MAX_TIMEOUT_DELAY_MS);
+        }, MAX_TIMEOUT_DELAY_MS);
+      } else {
+        expiryTimeoutRef.current = setTimeout(() => mutateUser(), delayMs);
+      }
+    };
+    scheduleExpiryCheck((seconds + 2) * 1000);
   }, [inAuthFlow, user, mutateUser]);
 
   useEffect(() => {


### PR DESCRIPTION
## Problem

For any deployment with `SESSION_EXPIRE_TIME_SECONDS` above ~24.8 days (e.g. 30-day sessions, `2592000`), the "You Have Been Logged Out" modal appears **immediately on every page load** even though the session is valid (`/me` returns 200).

## Root cause

As diagnosed in #12645: `setupExpirationTimeout` passes `(secondsUntilExpiration + 10) * 1000` directly to `setTimeout`. Delays above `2**31 - 1` ms (~24.85 days) overflow the 32-bit signed int that `setTimeout` uses internally and fire on the next tick — so `setExpired(true)` runs instantly.

## Fix

Chain intermediate timeouts of at most `2**31 - 1` ms until the remaining delay fits, then schedule the real expiration. The existing `expirationTimeoutRef` is reassigned at each hop, so the unmount/re-run cleanup (`clearTimeout(expirationTimeoutRef.current)`) still cancels the whole chain — no lifecycle changes needed.

- ≤ 24.8-day sessions: behavior byte-for-byte identical (single timeout, same delay).
- \> 24.8-day sessions: modal fires at the actual expiry instead of immediately.

## Verification

- Reproduced the overflow: `setTimeout(fn, 2592010000)` fires immediately with the Node/Chromium timer warning `TimeoutOverflowWarning: 2592010000 does not fit into a 32-bit signed integer`.
- Verified the chaining logic with a scaled-down harness (max-delay stand-in of 50 ms, 230 ms total → 4 hops + final timer, fired at the correct time, single ref always cancelable).

Fixes #12645

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #12645 by chaining session-expiry `setTimeout`s to avoid 32-bit overflow that caused the logout modal to fire immediately on very long sessions. Sessions > ~24.8 days now check at the correct time; shorter sessions are unchanged.

- **Bug Fixes**
  - Add `MAX_TIMEOUT_DELAY_MS = 2 ** 31 - 1` and chain timers until the remaining delay fits, then schedule the final `mutateUser()` check.
  - Keep cleanup intact: `expiryTimeoutRef` always points to the active timer, so `clearTimeout` cancels the whole chain.
  - Implemented in `useSessionWatcher` (`web/src/lib/auth/hooks.ts`).

<sup>Written for commit 63865197d97002b1f086cc91a003327ae028e911. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

