### PR TITLE
fix(llm): stop 400s on Claude Sonnet 5 reasoning requests

### DIFF
--- a/backend/onyx/llm/anthropic_capabilities.py
+++ b/backend/onyx/llm/anthropic_capabilities.py
@@ -1,0 +1,142 @@
+"""Resolution of Anthropic thinking/sampling API contracts.
+
+Newer Anthropic models (Opus 4.7+, Sonnet 5, Fable 5 / Mythos 5) removed the
+legacy manual thinking API (thinking.type=enabled + budget_tokens) and reject
+non-default sampling params (temperature / top_p / top_k) with a 400.
+
+Resolution order for every helper in this module:
+
+1. Capability flags from litellm's model registry (``litellm.model_cost``).
+   The registry updates day-0 for new Anthropic releases, so future models
+   resolve correctly without an Onyx code change.
+2. Hardcoded fallback tuples for models the registry can't positively
+   identify — proxy aliases (e.g. ``litellm_proxy/...`` deployments where the
+   admin named the model something custom), dated/regional variants absent
+   from the map, and airgapped deployments running a stale bundled map.
+3. Anything still unknown defaults to the legacy behavior, so existing
+   deployments see no silent behavior shift.
+
+An explicit registry answer (True or False) is definitive in both directions;
+the fallback tuples only fill silence — a flag that is absent (None) never
+downgrades a model that the tuples match, and an explicit flag is never
+overridden by a colliding tuple substring.
+"""
+
+from typing import Any
+
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+# Fallback: models that require adaptive thinking AND reject sampling params
+# (both removals shipped together from Opus 4.7 onward). Substring match to
+# cover proxy/Vertex naming variants (e.g. "claude-4.7-opus" via
+# litellm_proxy). LiteLLM's drop_params can't handle the sampling-param
+# rejection because AnthropicConfig still lists temperature as supported.
+_ANTHROPIC_NEW_CONTRACT_MODELS = (
+    "claude-opus-4-7",
+    "claude-opus-4.7",
+    "claude-4-7-opus",
+    "claude-4.7-opus",
+    "claude-opus-4-8",
+    "claude-opus-4.8",
+    "claude-4-8-opus",
+    "claude-4.8-opus",
+    "claude-fable-5",
+    "claude-5-fable",
+    "claude-mythos-5",
+    "claude-5-mythos",
+    "claude-sonnet-5",
+    "claude-5-sonnet",
+)
+
+# Fallback: Anthropic models that ACCEPT the adaptive thinking API. Superset
+# of the new-contract list — Sonnet 4.6 supports adaptive but still accepts
+# the legacy thinking API and sampling params, so it belongs here only.
+_ANTHROPIC_SUPPORTS_ADAPTIVE_THINKING_MODELS = (
+    *_ANTHROPIC_NEW_CONTRACT_MODELS,
+    "claude-sonnet-4-6",
+    "claude-4-6-sonnet",
+)
+
+
+def _matches_fallback(model_name: str, fallback_models: tuple[str, ...]) -> bool:
+    normalized_model_name = model_name.lower()
+    return any(
+        fallback_model in normalized_model_name for fallback_model in fallback_models
+    )
+
+
+def _litellm_capability_flags(model_name: str) -> tuple[bool | None, bool | None]:
+    """Look up (supports_adaptive_thinking, supports_sampling_params) in
+    litellm's model registry. Returns (None, None) when the model isn't in
+    the registry or the lookup fails — callers then use the fallback tuples.
+
+    Deliberately uncached: litellm can refresh its model map at runtime, and
+    the lookup is a handful of dict reads.
+    """
+    try:
+        from onyx.llm.litellm_singleton import litellm
+
+        model_cost: dict[str, dict[str, Any]] = litellm.model_cost
+        entry = model_cost.get(model_name) or model_cost.get(model_name.lower())
+        if entry is None and "/" in model_name:
+            # Strip the provider prefix, e.g.
+            # "litellm_proxy/claude-sonnet-5" -> "claude-sonnet-5".
+            stripped = model_name.split("/", 1)[-1]
+            entry = model_cost.get(stripped) or model_cost.get(stripped.lower())
+        if entry is None:
+            return (None, None)
+
+        adaptive = entry.get("supports_adaptive_thinking")
+        sampling = entry.get("supports_sampling_params")
+        return (
+            adaptive if isinstance(adaptive, bool) else None,
+            sampling if isinstance(sampling, bool) else None,
+        )
+    except Exception:
+        logger.warning(
+            "litellm capability lookup failed for model %r; "
+            "falling back to the hardcoded model lists",
+            model_name,
+            exc_info=True,
+        )
+        return (None, None)
+
+
+def anthropic_requires_adaptive_thinking(model_name: str) -> bool:
+    """True when the model rejects the legacy thinking.type=enabled API and
+    must be sent thinking.type=adaptive + output_config.effort.
+    """
+    adaptive, sampling = _litellm_capability_flags(model_name)
+    # The registry has no direct "rejects legacy thinking" flag. The models
+    # that removed legacy thinking are exactly those that also removed
+    # sampling params (Opus 4.7+, Sonnet 5, Fable 5) — requiring both signals
+    # excludes Sonnet 4.6, which supports adaptive but still accepts legacy.
+    if adaptive is True and sampling is False:
+        return True
+    # An explicit contradiction of the new contract is definitive — don't let
+    # a colliding fallback substring override it.
+    if adaptive is False or sampling is True:
+        return False
+    return _matches_fallback(model_name, _ANTHROPIC_NEW_CONTRACT_MODELS)
+
+
+def anthropic_supports_adaptive_thinking(model_name: str) -> bool:
+    """True when the model accepts the adaptive thinking API (superset of
+    :func:`anthropic_requires_adaptive_thinking` — includes Sonnet 4.6).
+    """
+    adaptive, _ = _litellm_capability_flags(model_name)
+    if adaptive is not None:
+        return adaptive
+    return _matches_fallback(model_name, _ANTHROPIC_SUPPORTS_ADAPTIVE_THINKING_MODELS)
+
+
+def anthropic_omits_sampling_params(model_name: str) -> bool:
+    """True when the model rejects non-default temperature/top_p/top_k and
+    the params must be omitted from the request entirely.
+    """
+    _, sampling = _litellm_capability_flags(model_name)
+    if sampling is not None:
+        return sampling is False
+    return _matches_fallback(model_name, _ANTHROPIC_NEW_CONTRACT_MODELS)

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -14,6 +14,8 @@ from onyx.configs.chat_configs import LLM_FIRST_CHUNK_MAX_RETRIES
 from onyx.configs.chat_configs import LLM_SOCKET_READ_TIMEOUT
 from onyx.configs.model_configs import GEN_AI_TEMPERATURE
 from onyx.configs.model_configs import LITELLM_EXTRA_BODY
+from onyx.llm.anthropic_capabilities import anthropic_omits_sampling_params
+from onyx.llm.anthropic_capabilities import anthropic_requires_adaptive_thinking
 from onyx.llm.constants import LlmProviderNames
 from onyx.llm.cost import calculate_llm_cost_cents
 from onyx.llm.interfaces import LanguageModelInput
@@ -77,38 +79,6 @@ _VERTEX_ANTHROPIC_MODELS_REJECTING_OUTPUT_CONFIG = (
     "claude-opus-4-6",
     "claude-opus-4-7",
     "claude-opus-4-8",
-)
-
-# Anthropic models that require the adaptive thinking API (thinking.type.adaptive
-# + output_config.effort) instead of the legacy thinking.type.enabled + budget_tokens.
-_ANTHROPIC_ADAPTIVE_THINKING_MODELS = (
-    "claude-opus-4-7",
-    "claude-opus-4-8",
-    "claude-fable-5",
-    "claude-5-fable",
-    "claude-mythos-5",
-    "claude-5-mythos",
-)
-
-# Anthropic models that reject any non-default sampling parameter (temperature,
-# top_p, top_k). For these models we must omit these params entirely from the
-# request payload — passing them returns a 400 invalid_request_error. LiteLLM's
-# drop_params is unreliable here because AnthropicConfig still lists temperature
-# as supported. Match on substring to cover proxy/Vertex naming variants (e.g.
-# "claude-4.7-opus" via litellm_proxy).
-_ANTHROPIC_NO_SAMPLING_PARAMS_MODELS = (
-    "claude-opus-4-7",
-    "claude-opus-4.7",
-    "claude-4-7-opus",
-    "claude-4.7-opus",
-    "claude-opus-4-8",
-    "claude-opus-4.8",
-    "claude-4-8-opus",
-    "claude-4.8-opus",
-    "claude-fable-5",
-    "claude-5-fable",
-    "claude-mythos-5",
-    "claude-5-mythos",
 )
 
 
@@ -269,22 +239,6 @@ def _is_vertex_model_rejecting_output_config(model_name: str) -> bool:
     return any(
         blocked_model in normalized_model_name
         for blocked_model in _VERTEX_ANTHROPIC_MODELS_REJECTING_OUTPUT_CONFIG
-    )
-
-
-def _anthropic_uses_adaptive_thinking(model_name: str) -> bool:
-    normalized_model_name = model_name.lower()
-    return any(
-        adaptive_model in normalized_model_name
-        for adaptive_model in _ANTHROPIC_ADAPTIVE_THINKING_MODELS
-    )
-
-
-def _anthropic_omits_sampling_params(model_name: str) -> bool:
-    normalized_model_name = model_name.lower()
-    return any(
-        no_sampling_model in normalized_model_name
-        for no_sampling_model in _ANTHROPIC_NO_SAMPLING_PARAMS_MODELS
     )
 
 
@@ -570,7 +524,7 @@ class LitellmLLM(LLM):
         # https://github.com/BerriAI/litellm/issues/26444
         # TODO(litellm): Consider removing this once the above is resolved,
         # although this assumes users have upgraded their litellm if relevant.
-        omits_sampling_params = _anthropic_omits_sampling_params(self.config.model_name)
+        omits_sampling_params = anthropic_omits_sampling_params(self.config.model_name)
         if not omits_sampling_params:
             optional_kwargs["temperature"] = 1 if is_reasoning else self._temperature
 
@@ -605,7 +559,7 @@ class LitellmLLM(LLM):
                 # (notably Bedrock).
                 has_tool_call_history = _prompt_contains_tool_call_history(prompt)
 
-                if _anthropic_uses_adaptive_thinking(self.config.model_name):
+                if anthropic_requires_adaptive_thinking(self.config.model_name):
                     # Newer Anthropic models (Claude Opus 4.7+) reject
                     # thinking.type.enabled — they require the adaptive
                     # thinking config with output_config.effort.

--- a/backend/onyx/llm/well_known_providers/recommended-models.json
+++ b/backend/onyx/llm/well_known_providers/recommended-models.json
@@ -1,13 +1,19 @@
 {
-  "version": "1.4",
-  "updated_at": "2026-06-04T00:00:00Z",
+  "version": "1.5",
+  "updated_at": "2026-07-03T00:00:00Z",
   "providers": {
     "openai": {
       "default_model": "gpt-5.5",
       "additional_visible_models": [
-        { "name": "gpt-5.5" },
-        { "name": "gpt-5.4" },
-        { "name": "gpt-5.2" }
+        {
+          "name": "gpt-5.5"
+        },
+        {
+          "name": "gpt-5.4"
+        },
+        {
+          "name": "gpt-5.2"
+        }
       ]
     },
     "anthropic": {
@@ -24,6 +30,10 @@
         {
           "name": "claude-opus-4-6",
           "display_name": "Claude Opus 4.6"
+        },
+        {
+          "name": "claude-sonnet-5",
+          "display_name": "Claude Sonnet 5"
         },
         {
           "name": "claude-sonnet-4-6",

--- a/backend/onyx/server/features/build/sandbox/util/opencode_config.py
+++ b/backend/onyx/server/features/build/sandbox/util/opencode_config.py
@@ -9,21 +9,16 @@ restart.
 
 from typing import Any
 
+from onyx.llm.anthropic_capabilities import anthropic_supports_adaptive_thinking
 from onyx.server.features.build.sandbox.models import LLMProviderConfig
-
-# 4.6+ supports adaptive thinking; older needs enabled+budgetTokens.
-_ADAPTIVE_THINKING_MODELS = frozenset(
-    {"claude-opus-4-7", "claude-opus-4-8", "claude-sonnet-4-6"}
-)
 
 
 def _model_options(provider: str, model_name: str) -> dict[str, Any]:
     if provider == "openai":
         return {"reasoningEffort": "high"}
     if provider in ("anthropic", "bedrock"):
-        if model_name in _ADAPTIVE_THINKING_MODELS or model_name.startswith(
-            tuple(f"{m}-" for m in _ADAPTIVE_THINKING_MODELS)
-        ):
+        # 4.6+ supports adaptive thinking; older needs enabled+budgetTokens.
+        if anthropic_supports_adaptive_thinking(model_name):
             return {"thinking": {"type": "adaptive", "display": "summarized"}}
         return {"thinking": {"type": "enabled", "budgetTokens": 16000}}
     if provider == "google":

--- a/backend/tests/external_dependency_unit/llm/test_anthropic_thinking_contract.py
+++ b/backend/tests/external_dependency_unit/llm/test_anthropic_thinking_contract.py
@@ -1,0 +1,90 @@
+"""External dependency unit tests for the Anthropic thinking/sampling
+contract resolution.
+
+Newer Anthropic models (Opus 4.7+, Sonnet 5, Fable 5) reject the legacy
+thinking API (thinking.type=enabled + budget_tokens) and non-default sampling
+params with a 400. These tests make real API calls to verify Onyx sends the
+adaptive-thinking payload these models require — the exact failure the
+capability resolution in onyx/llm/anthropic_capabilities.py prevents.
+
+Real-call tests use claude-haiku-4-5 for the legacy path (cheap tier per
+testing guidelines) and claude-sonnet-5 for the new-contract path (the
+contract under test has no cheaper representative).
+"""
+
+import os
+
+import pytest
+
+from onyx.llm.models import ChatCompletionMessage
+from onyx.llm.models import ReasoningEffort
+from onyx.llm.models import UserMessage
+from onyx.llm.multi_llm import LitellmLLM
+
+_ANTHROPIC_KEY_MISSING = not os.environ.get("ANTHROPIC_API_KEY")
+
+
+def _make_llm(model_name: str) -> LitellmLLM:
+    return LitellmLLM(
+        api_key=os.environ["ANTHROPIC_API_KEY"],
+        model_provider="anthropic",
+        model_name=model_name,
+        max_input_tokens=200000,
+    )
+
+
+@pytest.mark.skipif(_ANTHROPIC_KEY_MISSING, reason="Anthropic API key not available")
+def test_sonnet_5_reasoning_stream_does_not_400() -> None:
+    """Regression: claude-sonnet-5 with reasoning enabled 400'd with
+    'thinking.type.enabled is not supported for this model' before the
+    capability resolution routed it to the adaptive thinking API.
+    """
+    llm = _make_llm("claude-sonnet-5")
+    messages: list[ChatCompletionMessage] = [
+        UserMessage(role="user", content="Reply with exactly one word: ok")
+    ]
+
+    chunks = list(
+        llm.stream(
+            messages,
+            reasoning_effort=ReasoningEffort.HIGH,
+            max_tokens=2048,
+        )
+    )
+
+    assert chunks, "Expected at least one streamed chunk"
+
+
+@pytest.mark.skipif(_ANTHROPIC_KEY_MISSING, reason="Anthropic API key not available")
+def test_sonnet_5_reasoning_invoke_does_not_400() -> None:
+    llm = _make_llm("claude-sonnet-5")
+    messages: list[ChatCompletionMessage] = [
+        UserMessage(role="user", content="Reply with exactly one word: ok")
+    ]
+
+    response = llm.invoke(
+        messages,
+        reasoning_effort=ReasoningEffort.HIGH,
+        max_tokens=2048,
+    )
+
+    assert response.choice.message.content, "Expected a non-empty response"
+
+
+@pytest.mark.skipif(_ANTHROPIC_KEY_MISSING, reason="Anthropic API key not available")
+def test_legacy_model_keeps_working_with_reasoning() -> None:
+    """Older models must stay on their existing (legacy) thinking path."""
+    llm = _make_llm("claude-haiku-4-5")
+    messages: list[ChatCompletionMessage] = [
+        UserMessage(role="user", content="Reply with exactly one word: ok")
+    ]
+
+    chunks = list(
+        llm.stream(
+            messages,
+            reasoning_effort=ReasoningEffort.HIGH,
+            max_tokens=2048,
+        )
+    )
+
+    assert chunks, "Expected at least one streamed chunk"

--- a/backend/tests/unit/onyx/llm/test_anthropic_capabilities.py
+++ b/backend/tests/unit/onyx/llm/test_anthropic_capabilities.py
@@ -1,0 +1,159 @@
+"""Tests for capability-driven resolution of Anthropic thinking/sampling
+contracts.
+
+Both resolution branches are covered: the litellm-registry branch (flags
+present in litellm.model_cost) and the hardcoded-tuple fallback branch
+(model absent from the registry, e.g. proxy aliases or stale bundled maps).
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from onyx.llm.anthropic_capabilities import anthropic_omits_sampling_params
+from onyx.llm.anthropic_capabilities import anthropic_requires_adaptive_thinking
+from onyx.llm.anthropic_capabilities import anthropic_supports_adaptive_thinking
+
+# ---------------------------------------------------------------------------
+# Registry branch — real litellm bundled map
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "claude-sonnet-5",
+        "claude-opus-4-7",
+        "claude-opus-4-8",
+        "claude-fable-5",
+        # Provider-prefixed and regional variants present in the registry
+        "anthropic/claude-sonnet-5",
+        "us.anthropic.claude-sonnet-5",
+        "vertex_ai/claude-sonnet-5",
+    ],
+)
+def test_new_contract_models_resolve_via_registry(model_name: str) -> None:
+    # Disable the fallback so a pass proves the registry branch fired.
+    with patch("onyx.llm.anthropic_capabilities._matches_fallback", return_value=False):
+        assert anthropic_requires_adaptive_thinking(model_name)
+        assert anthropic_supports_adaptive_thinking(model_name)
+        assert anthropic_omits_sampling_params(model_name)
+
+
+def test_sonnet_4_6_supports_adaptive_but_keeps_legacy_paths() -> None:
+    # Sonnet 4.6 accepts adaptive thinking but still accepts the legacy
+    # thinking API and sampling params — it must not be treated as a
+    # new-contract model.
+    assert anthropic_supports_adaptive_thinking("claude-sonnet-4-6")
+    assert not anthropic_requires_adaptive_thinking("claude-sonnet-4-6")
+    assert not anthropic_omits_sampling_params("claude-sonnet-4-6")
+
+
+@pytest.mark.parametrize("model_name", ["claude-3-5-sonnet", "claude-sonnet-4-5"])
+def test_older_sonnet_models_are_unaffected(model_name: str) -> None:
+    assert not anthropic_requires_adaptive_thinking(model_name)
+    assert not anthropic_supports_adaptive_thinking(model_name)
+    assert not anthropic_omits_sampling_params(model_name)
+
+
+def test_future_model_with_registry_flags_needs_no_code_change() -> None:
+    # A hypothetical future Anthropic model that ships with correct flags in
+    # the litellm registry must resolve without touching Onyx code.
+    synthetic_entry = {
+        "claude-saga-6": {
+            "litellm_provider": "anthropic",
+            "supports_adaptive_thinking": True,
+            "supports_sampling_params": False,
+        }
+    }
+    from onyx.llm.litellm_singleton import litellm
+
+    with patch.dict(litellm.model_cost, synthetic_entry):
+        assert anthropic_requires_adaptive_thinking("claude-saga-6")
+        assert anthropic_supports_adaptive_thinking("claude-saga-6")
+        assert anthropic_omits_sampling_params("claude-saga-6")
+
+
+# ---------------------------------------------------------------------------
+# Fallback branch — model absent from the registry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        # Aliases a litellm_proxy admin might configure — absent from the
+        # registry, resolved by tuple substring match.
+        "litellm_proxy/my-claude-sonnet-5-alias",
+        "claude-sonnet-5@20260101",
+        "claude-5-sonnet",
+        "claude-4.8-opus",
+    ],
+)
+def test_unmapped_new_contract_variants_resolve_via_fallback(
+    model_name: str,
+) -> None:
+    with patch(
+        "onyx.llm.anthropic_capabilities._litellm_capability_flags",
+        return_value=(None, None),
+    ):
+        assert anthropic_requires_adaptive_thinking(model_name)
+        assert anthropic_omits_sampling_params(model_name)
+
+
+class _RaisingDict(dict):
+    def get(self, *_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("registry unavailable")
+
+
+def test_registry_lookup_failure_falls_back_to_tuples() -> None:
+    # A broken/unavailable registry must degrade to the fallback tuples, not
+    # raise or change behavior for known models.
+    from onyx.llm.litellm_singleton import litellm
+
+    with patch.object(litellm, "model_cost", _RaisingDict()):
+        assert anthropic_requires_adaptive_thinking("claude-sonnet-5")
+        assert anthropic_omits_sampling_params("claude-sonnet-5")
+        assert not anthropic_requires_adaptive_thinking("claude-sonnet-4-5")
+
+
+def test_explicit_registry_answer_beats_colliding_fallback_substring() -> None:
+    # A future model whose name contains a new-contract substring but whose
+    # registry entry explicitly supports sampling / rejects adaptive must
+    # follow the registry, not the substring match.
+    entry = {
+        "claude-opus-4-7-pro": {
+            "supports_adaptive_thinking": False,
+            "supports_sampling_params": True,
+        }
+    }
+    from onyx.llm.litellm_singleton import litellm
+
+    with patch.dict(litellm.model_cost, entry):
+        assert not anthropic_requires_adaptive_thinking("claude-opus-4-7-pro")
+        assert not anthropic_supports_adaptive_thinking("claude-opus-4-7-pro")
+        assert not anthropic_omits_sampling_params("claude-opus-4-7-pro")
+
+
+def test_runtime_map_refresh_is_picked_up() -> None:
+    # litellm can refresh its model map at runtime; a model that was missing
+    # must resolve via the registry once the refreshed map contains it.
+    from onyx.llm.litellm_singleton import litellm
+
+    with patch.object(litellm, "model_cost", {}):
+        assert not anthropic_requires_adaptive_thinking("claude-saga-6")
+
+    refreshed = {
+        "claude-saga-6": {
+            "supports_adaptive_thinking": True,
+            "supports_sampling_params": False,
+        }
+    }
+    with patch.object(litellm, "model_cost", refreshed):
+        assert anthropic_requires_adaptive_thinking("claude-saga-6")
+
+
+def test_unknown_model_defaults_to_legacy_behavior() -> None:
+    assert not anthropic_requires_adaptive_thinking("some-unrelated-model")
+    assert not anthropic_supports_adaptive_thinking("some-unrelated-model")
+    assert not anthropic_omits_sampling_params("some-unrelated-model")

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -442,6 +442,9 @@ ANTHROPIC_MODELS_OMITTING_SAMPLING_PARAMS = [
     "claude-5-fable",
     "claude-mythos-5",
     "claude-5-mythos",
+    "claude-sonnet-5",
+    "claude-sonnet-5@20260101",
+    "claude-5-sonnet",
 ]
 
 
@@ -477,6 +480,8 @@ def test_omits_temperature_for_no_sampling_params_models(model_name: str) -> Non
         "claude-5-fable",
         "claude-mythos-5",
         "claude-5-mythos",
+        "claude-sonnet-5",
+        "claude-5-sonnet",
     ],
 )
 @pytest.mark.parametrize(

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_config.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_config.py
@@ -45,14 +45,26 @@ def test_single_provider_renders_all_required_fields() -> None:
     ] == {"type": "adaptive", "display": "summarized"}
 
 
-def test_adaptive_anthropic_models_request_readable_thinking_summaries() -> None:
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "claude-opus-4-8",
+        "claude-sonnet-4-6",
+        "claude-sonnet-5",
+        "claude-fable-5",
+        "claude-mythos-5",
+    ],
+)
+def test_adaptive_anthropic_models_request_readable_thinking_summaries(
+    model_name: str,
+) -> None:
     config = build_multi_provider_opencode_config(
-        providers=[_cfg("anthropic", "claude-opus-4-8")],
+        providers=[_cfg("anthropic", model_name)],
         default_provider="anthropic",
-        default_model="claude-opus-4-8",
+        default_model=model_name,
     )
 
-    assert config["provider"]["anthropic"]["models"]["claude-opus-4-8"]["options"][
+    assert config["provider"]["anthropic"]["models"][model_name]["options"][
         "thinking"
     ] == {"type": "adaptive", "display": "summarized"}
 


### PR DESCRIPTION
## Description

Fixes #12680


Claude Sonnet 5 requests with reasoning enabled fail with a 400:

```
AnthropicException: "thinking.type.enabled" is not supported for this model.
Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.
```

Root cause: the adaptive-thinking / no-sampling-params model lists in `multi_llm.py` are hardcoded substring tuples that don't include `claude-sonnet-5`. This is the fourth time this bug class has come up (Opus 4.7, Opus 4.8 and Fable 5 each needed the same patch), and the lists are duplicated - the opencode sandbox config carries its own copy, which was silently missing Fable 5 / Mythos 5 entirely.

This PR consolidates resolution into a new `onyx/llm/anthropic_capabilities.py`, resolved in order:

1. **litellm registry first** - reads `supports_adaptive_thinking` / `supports_sampling_params` from `litellm.model_cost`. The currently pinned litellm (1.89.4) already bundles accurate flags for all affected models, so no litellm bump is needed, and litellm refreshes its map remotely at startup - future Anthropic models resolve with zero code change. `get_model_info()` can't be used here since its `ModelInfo` schema drops these keys.
2. **Fallback to the previous substring tuples** for models the registry can't positively identify: proxy aliases (`litellm_proxy/...`), dated/regional variants, airgapped deployments with a stale bundled map.
3. **Unknown models keep the legacy default** - no silent behavior shifts.

One subtlety: the registry has no direct "rejects legacy thinking" flag, and `supports_adaptive_thinking` alone also matches Sonnet 4.6 (which still accepts the legacy path). Requiring `adaptive=True AND sampling=False` identifies exactly the new-contract generation without changing Sonnet 4.6 behavior.

Two related fixes that fell out of the consolidation:
- Dotted proxy variants (e.g. `claude-4.8-opus`) were in the sampling tuple but missing from the thinking tuple, so those aliases still sent legacy thinking and 400'd.
- The opencode sandbox path now resolves Opus 4.6 to adaptive via the registry, matching that module's stated "4.6+ supports adaptive" intent (it was missing from the old frozenset).


Also adds `claude-sonnet-5` to `recommended-models.json` (version 1.5): Auto mode providers sync their model list from this GitHub-hosted file, and the current version (1.4, dated 2026-06-04) predates the Sonnet 5 release — so the model never appears in the admin picker even with auto-update enabled. Ordering matters here: exposing the model in Auto mode without the resolution fix above would push a 400-broken model to every reasoning-enabled deployment on the next 30-minute sync, so both changes ship together.


Prior art: this is the same failure class previously patched per-model in #10878 (Opus 4.7 rejecting `temperature`), #11524 (Opus 4.8 sampling params + adaptive thinking), and #11992 (Fable 5 / Mythos 5 adaptive thinking, fixing #11991) — each needing release backports. The capability-driven resolution here is intended to end that cycle: the next Anthropic model resolves from litellm's registry without a code change, with the substring tuples retained as fallback for proxy aliases and airgapped deployments.

## How Has This Been Tested?

- Unit tests (`test_anthropic_capabilities.py`, updated `test_multi_llm.py` / `test_opencode_config.py`): both resolution branches (registry hit / tuple fallback), the Sonnet 4.6 boundary, registry-failure degradation, runtime map refresh pickup, negative matches (`claude-3-5-sonnet`, `claude-sonnet-4-5` unaffected), and a synthetic future-model registry entry resolving with zero code change. 299 passing.
- Verified the actual request body sent to `api.anthropic.com/v1/messages` for `claude-sonnet-5`: `thinking: {"type": "adaptive"}` + `output_config.effort`, no `temperature` / `budget_tokens`.
- Live API tests (`backend/tests/external_dependency_unit/llm/test_anthropic_thinking_contract.py`): real calls passing for Sonnet 5 stream + invoke with reasoning (the previously-failing scenario), plus a `claude-haiku-4-5` control confirming legacy models stay on their existing path. Tests skip when `ANTHROPIC_API_KEY` is absent, same pattern as `test_prompt_caching.py`.
- `ty check` and `ruff` clean on changed files.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops 400 errors on Anthropic reasoning requests (e.g., `claude-sonnet-5`) by detecting model capabilities, switching to adaptive thinking, and omitting sampling params. Also surfaces `claude-sonnet-5` in Auto mode via `recommended-models.json` v1.5.

- **Bug Fixes**
  - Use `litellm` capability flags (`supports_adaptive_thinking`, `supports_sampling_params`) to send `thinking: { type: "adaptive" }` and drop `temperature/top_p/top_k` where required.
  - Gate the “new contract” on `adaptive=True` and `sampling=False` to avoid changing `claude-sonnet-4-6`.
  - Normalize aliases/variants (including `litellm_proxy/...`, dotted/regional names) across stream/invoke and sandbox.

- **Refactors**
  - Centralize Anthropic capability logic in `onyx/llm/anthropic_capabilities.py`; remove duplicated tuples in `multi_llm.py` and sandbox; sandbox now uses `anthropic_supports_adaptive_thinking`.
  - Add tests for registry/fallback paths, Sonnet 4.6 boundary, runtime refresh, and live Anthropic calls; no `litellm` bump required.

<sup>Written for commit e53ffd04c9dc7a55e808dbd1497bdd0650522e24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

