### PR TITLE
fix(llm): keep admin model choices when auto-update is enabled

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -181,6 +181,14 @@ repos:
             |deployment/docker_compose/env\.(template|prod\.template)
             |deployment/helm/charts/onyx/(values\.yaml|templates/configmap\.yaml)
           )$
+      - id: recommended-models-updated-at
+        name: recommended-models updated_at bump
+        description: "Fail when recommended-models.json changes without a newer updated_at (the config resolver picks the newest copy by timestamp)"
+        language: system
+        entry: python3 backend/scripts/check_recommended_models_bump.py
+        pass_filenames: false
+        stages: [pre-commit]
+        files: ^backend/onyx/llm/well_known_providers/recommended-models\.json$
       - id: bun-install
         name: bun install
         description: "Automatically run 'bun install' after a checkout, pull or rebase"

--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -903,7 +903,14 @@ def sync_auto_mode_models(
     # Mark models that are no longer in GitHub config as not visible
     for model_name, model in existing_models.items():
         if model_name not in recommended_visible_model_names:
-            if model.is_visible and model.id not in default_flow_model_ids:
+            if model.is_visible and model.id in default_flow_model_ids:
+                logger.info(
+                    "Auto mode sync keeping default model '%s' visible on "
+                    "provider '%s' even though it is not in the config",
+                    model_name,
+                    provider.name or provider.provider,
+                )
+            elif model.is_visible:
                 model.is_visible = False
                 changes += 1
 

--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -843,7 +843,10 @@ def sync_auto_mode_models(
 ) -> int:
     """Sync models from GitHub config to a provider in Auto mode.
 
-    In Auto mode, the model list and default are controlled by GitHub config.
+    In Auto mode, the model list and visibility are controlled by GitHub
+    config. The global default model is left alone unless the currently
+    selected default was removed from the config (and thus hidden), in which
+    case it is moved to the recommended default.
     The schema has:
     - default_model: The default model config (always visible)
     - additional_visible_models: List of additional visible models
@@ -915,7 +918,11 @@ def sync_auto_mode_models(
             )
             changes += 1
 
-    # Update the default if this provider currently holds the global CHAT default.
+    # If this provider holds the global CHAT default and the sync just hid that
+    # model (it dropped out of the GitHub config), move the default to the
+    # recommended one. An admin-chosen default that is still in the recommended
+    # visible list is preserved — Auto mode manages the model list, not the
+    # admin's default selection.
     # We flush (but don't commit) so that _update_default_model can see the new
     # model rows, then commit everything atomically to avoid a window where the
     # old default is invisible but still pointed-to.
@@ -929,6 +936,7 @@ def sync_auto_mode_models(
             current_default
             and current_default.llm_provider_id == provider.id
             and current_default.name != recommended_default.name
+            and current_default.name not in recommended_visible_model_names
         ):
             _update_default_model__no_commit(
                 db_session=db_session,

--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -843,12 +843,14 @@ def sync_auto_mode_models(
 ) -> int:
     """Sync models from GitHub config to a provider in Auto mode.
 
-    In Auto mode, the model list and visibility are controlled by GitHub
-    config, with one exception: a model that is currently a default for some
-    flow (global chat default, vision default, ...) is never hidden and the
-    default is never reassigned, even when that model is not in the config.
-    Auto mode curates the available list — it must not change what the org's
-    chats actually run on.
+    In Auto mode, the GitHub config decides which models are *offered*:
+    newly recommended models are added (visible), and models dropped from
+    the config are hidden. Admin choices win within that list:
+    - A model the admin deselected (hid) stays hidden even though the config
+      lists it.
+    - A model that is currently a default for some flow (global chat default,
+      vision default, ...) is never hidden and the default is never
+      reassigned, even when that model is not in the config.
     The schema has:
     - default_model: The default model config (always visible)
     - additional_visible_models: List of additional visible models
@@ -908,18 +910,12 @@ def sync_auto_mode_models(
     # Add or update models from GitHub config
     for model_config in recommended_visible_models:
         if model_config.name in existing_models:
-            # Update existing model
+            # Update existing model. Visibility is deliberately left alone:
+            # a model the admin deselected stays hidden even though the
+            # config lists it.
             existing = existing_models[model_config.name]
-            # Check each field for changes
-            updated = False
             if existing.display_name != model_config.display_name:
                 existing.display_name = model_config.display_name
-                updated = True
-            # All models in the config are visible
-            if not existing.is_visible:
-                existing.is_visible = True
-                updated = True
-            if updated:
                 changes += 1
         else:
             # Add new model - all models from GitHub config are visible
@@ -953,6 +949,17 @@ def sync_auto_mode_models(
             and current_default.name != recommended_default.name
             and not current_default.is_visible
         ):
+            # The recommended default may itself have been deselected by the
+            # admin — it must be visible to serve as the default.
+            recommended_row = db_session.scalar(
+                select(ModelConfiguration).where(
+                    ModelConfiguration.llm_provider_id == provider.id,
+                    ModelConfiguration.name == recommended_default.name,
+                )
+            )
+            if recommended_row and not recommended_row.is_visible:
+                recommended_row.is_visible = True
+                changes += 1
             _update_default_model__no_commit(
                 db_session=db_session,
                 provider_id=provider.id,

--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -844,9 +844,11 @@ def sync_auto_mode_models(
     """Sync models from GitHub config to a provider in Auto mode.
 
     In Auto mode, the model list and visibility are controlled by GitHub
-    config. The global default model is left alone unless the currently
-    selected default was removed from the config (and thus hidden), in which
-    case it is moved to the recommended default.
+    config, with one exception: a model that is currently a default for some
+    flow (global chat default, vision default, ...) is never hidden and the
+    default is never reassigned, even when that model is not in the config.
+    Auto mode curates the available list — it must not change what the org's
+    chats actually run on.
     The schema has:
     - default_model: The default model config (always visible)
     - additional_visible_models: List of additional visible models
@@ -882,10 +884,24 @@ def sync_auto_mode_models(
         ).all()
     }
 
+    # Models that are a default for some flow must survive the sync visible,
+    # even when the GitHub config drops them (e.g. an admin-chosen default
+    # that the curated list doesn't carry).
+    default_flow_model_ids = set(
+        db_session.scalars(
+            select(LLMModelFlow.model_configuration_id)
+            .join(ModelConfiguration)
+            .where(
+                LLMModelFlow.is_default.is_(True),
+                ModelConfiguration.llm_provider_id == provider.id,
+            )
+        ).all()
+    )
+
     # Mark models that are no longer in GitHub config as not visible
     for model_name, model in existing_models.items():
         if model_name not in recommended_visible_model_names:
-            if model.is_visible:
+            if model.is_visible and model.id not in default_flow_model_ids:
                 model.is_visible = False
                 changes += 1
 
@@ -918,11 +934,10 @@ def sync_auto_mode_models(
             )
             changes += 1
 
-    # If this provider holds the global CHAT default and the sync just hid that
-    # model (it dropped out of the GitHub config), move the default to the
-    # recommended one. An admin-chosen default that is still in the recommended
-    # visible list is preserved — Auto mode manages the model list, not the
-    # admin's default selection.
+    # Safety net: the sync never hides the CHAT default (see above), so this
+    # only fires if some other path left the global default pointing at a
+    # hidden model — repair it to the recommended default rather than letting
+    # chat run on an invisible model.
     # We flush (but don't commit) so that _update_default_model can see the new
     # model rows, then commit everything atomically to avoid a window where the
     # old default is invisible but still pointed-to.
@@ -936,7 +951,7 @@ def sync_auto_mode_models(
             current_default
             and current_default.llm_provider_id == provider.id
             and current_default.name != recommended_default.name
-            and current_default.name not in recommended_visible_model_names
+            and not current_default.is_visible
         ):
             _update_default_model__no_commit(
                 db_session=db_session,

--- a/backend/onyx/llm/well_known_providers/auto_update_service.py
+++ b/backend/onyx/llm/well_known_providers/auto_update_service.py
@@ -3,10 +3,9 @@
 This service manages Auto mode LLM providers, where models and configuration
 are managed centrally via a GitHub-hosted JSON file. In Auto mode:
 - Model list is controlled by GitHub config
-- Model visibility is controlled by GitHub config
-- Default model follows the GitHub config only when the current default is
-  removed from the config; an admin-chosen default that is still in the
-  config is preserved
+- Model visibility is controlled by GitHub config, except that models
+  currently set as a default (chat, vision, ...) always stay visible
+- The admin-chosen default model is never changed by a sync
 - Admin only needs to provide API credentials
 """
 
@@ -84,9 +83,9 @@ def sync_llm_models_from_github(
 
     In Auto mode, GitHub config controls:
     - Model list
-    - Model visibility (is_visible)
-    - Default model, but only when the current default was removed from the
-      config (an admin-chosen default that remains in the config is kept)
+    - Model visibility (is_visible), except models currently set as a
+      default for some flow — those always stay visible and the admin-chosen
+      default model is never changed
 
     Args:
         db_session: Database session

--- a/backend/onyx/llm/well_known_providers/auto_update_service.py
+++ b/backend/onyx/llm/well_known_providers/auto_update_service.py
@@ -2,9 +2,10 @@
 
 This service manages Auto mode LLM providers, where models and configuration
 are managed centrally via a GitHub-hosted JSON file. In Auto mode:
-- Model list is controlled by GitHub config
-- Model visibility is controlled by GitHub config, except that models
-  currently set as a default (chat, vision, ...) always stay visible
+- The GitHub config decides which models are offered: new recommendations
+  are added visible, models dropped from the config are hidden
+- Admin choices win within that list: deselected models stay hidden, and
+  models currently set as a default (chat, vision, ...) always stay visible
 - The admin-chosen default model is never changed by a sync
 - Admin only needs to provide API credentials
 """
@@ -81,11 +82,11 @@ def sync_llm_models_from_github(
 ) -> dict[str, int]:
     """Sync models from GitHub config to database for all Auto mode providers.
 
-    In Auto mode, GitHub config controls:
-    - Model list
-    - Model visibility (is_visible), except models currently set as a
-      default for some flow — those always stay visible and the admin-chosen
-      default model is never changed
+    In Auto mode, GitHub config controls which models are offered (new
+    recommendations added visible, dropped models hidden), while admin
+    choices win within that list: deselected models stay hidden, models set
+    as a default for some flow always stay visible, and the admin-chosen
+    default model is never changed.
 
     Args:
         db_session: Database session

--- a/backend/onyx/llm/well_known_providers/auto_update_service.py
+++ b/backend/onyx/llm/well_known_providers/auto_update_service.py
@@ -10,7 +10,10 @@ are managed centrally via a GitHub-hosted JSON file. In Auto mode:
 - Admin only needs to provide API credentials
 """
 
+import json
+import pathlib
 from datetime import datetime
+from datetime import timezone
 
 import httpx
 from sqlalchemy.orm import Session
@@ -76,6 +79,44 @@ def fetch_llm_recommendations_from_github(
         return None
 
 
+def load_bundled_recommendations() -> LLMRecommendations | None:
+    """Load the recommended-models.json copy shipped with this release."""
+    json_path = pathlib.Path(__file__).parent / "recommended-models.json"
+    try:
+        with open(json_path, "r") as f:
+            return LLMRecommendations.model_validate(json.load(f))
+    except Exception as e:
+        logger.error("Failed to load bundled LLM recommendations: %s", e)
+        return None
+
+
+def _as_utc(dt: datetime) -> datetime:
+    return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt
+
+
+def fetch_llm_recommendations(
+    timeout: float = 30.0,
+) -> LLMRecommendations | None:
+    """Resolve the LLM recommendations config.
+
+    Uses whichever of the GitHub-hosted config and the bundled copy has the
+    newer `updated_at`: GitHub can push recommendations to running
+    deployments without a release, while a fresh release isn't held back by
+    a stale (or unreachable) remote file — e.g. air-gapped deployments still
+    get the recommendations shipped with their version.
+    """
+    remote = fetch_llm_recommendations_from_github(timeout=timeout)
+    bundled = load_bundled_recommendations()
+
+    if remote and bundled:
+        return (
+            remote
+            if _as_utc(remote.updated_at) >= _as_utc(bundled.updated_at)
+            else bundled
+        )
+    return remote or bundled
+
+
 def sync_llm_models_from_github(
     db_session: Session,
     force: bool = False,
@@ -104,10 +145,10 @@ def sync_llm_models_from_github(
         logger.debug("No providers in Auto mode found")
         return {}
 
-    # Fetch config from GitHub
-    config = fetch_llm_recommendations_from_github()
+    # Resolve config (GitHub-hosted or the newer bundled copy)
+    config = fetch_llm_recommendations()
     if not config:
-        logger.warning("Failed to fetch GitHub config")
+        logger.warning("Failed to resolve LLM recommendations config")
         return {}
 
     # Skip if we've already processed this version (unless forced)

--- a/backend/onyx/llm/well_known_providers/auto_update_service.py
+++ b/backend/onyx/llm/well_known_providers/auto_update_service.py
@@ -4,7 +4,9 @@ This service manages Auto mode LLM providers, where models and configuration
 are managed centrally via a GitHub-hosted JSON file. In Auto mode:
 - Model list is controlled by GitHub config
 - Model visibility is controlled by GitHub config
-- Default model is controlled by GitHub config
+- Default model follows the GitHub config only when the current default is
+  removed from the config; an admin-chosen default that is still in the
+  config is preserved
 - Admin only needs to provide API credentials
 """
 
@@ -80,11 +82,11 @@ def sync_llm_models_from_github(
 ) -> dict[str, int]:
     """Sync models from GitHub config to database for all Auto mode providers.
 
-    In Auto mode, EVERYTHING is controlled by GitHub config:
+    In Auto mode, GitHub config controls:
     - Model list
     - Model visibility (is_visible)
-    - Default model
-    - Fast default model
+    - Default model, but only when the current default was removed from the
+      config (an admin-chosen default that remains in the config is kept)
 
     Args:
         db_session: Database session

--- a/backend/onyx/llm/well_known_providers/llm_provider_options.py
+++ b/backend/onyx/llm/well_known_providers/llm_provider_options.py
@@ -8,9 +8,6 @@ from onyx.llm.utils import get_max_input_tokens
 from onyx.llm.utils import model_supports_image_input
 from onyx.llm.well_known_providers.auto_update_models import LLMRecommendations
 from onyx.llm.well_known_providers.auto_update_service import fetch_llm_recommendations
-from onyx.llm.well_known_providers.auto_update_service import (
-    load_bundled_recommendations,
-)
 from onyx.llm.well_known_providers.constants import ANTHROPIC_PROVIDER_NAME
 from onyx.llm.well_known_providers.constants import AZURE_PROVIDER_NAME
 from onyx.llm.well_known_providers.constants import BEDROCK_PROVIDER_NAME
@@ -78,7 +75,7 @@ def get_recommendations() -> LLMRecommendations:
         ):
             return _cached_recommendations
 
-        result = fetch_llm_recommendations() or load_bundled_recommendations()
+        result = fetch_llm_recommendations()
         if result is None:
             raise RuntimeError(
                 "Failed to load LLM recommendations (remote and bundled)"

--- a/backend/onyx/llm/well_known_providers/llm_provider_options.py
+++ b/backend/onyx/llm/well_known_providers/llm_provider_options.py
@@ -1,5 +1,3 @@
-import json
-import pathlib
 import threading
 import time
 
@@ -9,8 +7,9 @@ from onyx.llm.constants import WELL_KNOWN_PROVIDER_NAMES
 from onyx.llm.utils import get_max_input_tokens
 from onyx.llm.utils import model_supports_image_input
 from onyx.llm.well_known_providers.auto_update_models import LLMRecommendations
+from onyx.llm.well_known_providers.auto_update_service import fetch_llm_recommendations
 from onyx.llm.well_known_providers.auto_update_service import (
-    fetch_llm_recommendations_from_github,
+    load_bundled_recommendations,
 )
 from onyx.llm.well_known_providers.constants import ANTHROPIC_PROVIDER_NAME
 from onyx.llm.well_known_providers.constants import AZURE_PROVIDER_NAME
@@ -58,13 +57,6 @@ def _get_provider_to_models_map() -> dict[str, list[str]]:
     }
 
 
-def _load_bundled_recommendations() -> LLMRecommendations:
-    json_path = pathlib.Path(__file__).parent / "recommended-models.json"
-    with open(json_path, "r") as f:
-        json_config = json.load(f)
-    return LLMRecommendations.model_validate(json_config)
-
-
 def get_recommendations() -> LLMRecommendations:
     """Get the recommendations, with an in-memory cache to avoid
     hitting GitHub on every API request."""
@@ -86,8 +78,11 @@ def get_recommendations() -> LLMRecommendations:
         ):
             return _cached_recommendations
 
-        recommendations_from_github = fetch_llm_recommendations_from_github()
-        result = recommendations_from_github or _load_bundled_recommendations()
+        result = fetch_llm_recommendations() or load_bundled_recommendations()
+        if result is None:
+            raise RuntimeError(
+                "Failed to load LLM recommendations (remote and bundled)"
+            )
 
         _cached_recommendations = result
         _cached_recommendations_time = time.monotonic()

--- a/backend/onyx/llm/well_known_providers/recommended-models.json
+++ b/backend/onyx/llm/well_known_providers/recommended-models.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.4",
-  "updated_at": "2026-06-04T00:00:00Z",
+  "version": "1.5",
+  "updated_at": "2026-07-05T00:00:00Z",
   "providers": {
     "openai": {
       "default_model": "gpt-5.5",
@@ -14,6 +14,10 @@
       "default_model": "claude-opus-4-8",
       "additional_visible_models": [
         {
+          "name": "claude-fable-5",
+          "display_name": "Claude Fable 5"
+        },
+        {
           "name": "claude-opus-4-8",
           "display_name": "Claude Opus 4.8"
         },
@@ -24,6 +28,10 @@
         {
           "name": "claude-opus-4-6",
           "display_name": "Claude Opus 4.6"
+        },
+        {
+          "name": "claude-sonnet-5",
+          "display_name": "Claude Sonnet 5"
         },
         {
           "name": "claude-sonnet-4-6",

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -55,9 +55,7 @@ from onyx.llm.utils import get_llm_contextual_cost
 from onyx.llm.utils import is_sensitive_custom_config_key
 from onyx.llm.utils import litellm_thinks_model_supports_image_input
 from onyx.llm.utils import test_llm
-from onyx.llm.well_known_providers.auto_update_service import (
-    fetch_llm_recommendations_from_github,
-)
+from onyx.llm.well_known_providers.auto_update_service import fetch_llm_recommendations
 from onyx.llm.well_known_providers.constants import LM_STUDIO_API_KEY_CONFIG_KEY
 from onyx.llm.well_known_providers.constants import VERTEX_AUTH_METHOD_KWARG
 from onyx.llm.well_known_providers.constants import VERTEX_AUTH_METHOD_SERVICE_ACCOUNT
@@ -641,7 +639,7 @@ def put_llm_provider(
         if transitioning_to_auto_mode:
             from onyx.db.llm import sync_auto_mode_models
 
-            config = fetch_llm_recommendations_from_github()
+            config = fetch_llm_recommendations()
             if config and llm_provider_upsert_request.provider in config.providers:
                 updated_provider = fetch_existing_llm_provider_by_id(
                     id=result.id, db_session=db_session
@@ -739,16 +737,17 @@ def set_provider_as_default_vision(
 def get_auto_config(
     _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
 ) -> dict:
-    """Get the current Auto mode configuration from GitHub.
+    """Get the current Auto mode configuration.
 
     Returns the available models and default configurations for each
-    supported provider type when using Auto mode.
+    supported provider type when using Auto mode (from the GitHub-hosted
+    config or the newer bundled copy).
     """
-    config = fetch_llm_recommendations_from_github()
+    config = fetch_llm_recommendations()
     if not config:
         raise OnyxError(
             OnyxErrorCode.BAD_GATEWAY,
-            "Failed to fetch configuration from GitHub",
+            "Failed to resolve Auto mode configuration",
         )
     return config.model_dump()
 

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -621,9 +621,10 @@ def put_llm_provider(
     # When transitioning to auto mode, preserve existing model configurations
     # so the upsert doesn't try to delete them (which would trip the default
     # model protection guard). sync_auto_mode_models will handle the model
-    # lifecycle afterward — adding new models, hiding removed ones, and
-    # updating the default. This is safe even if sync fails: the provider
-    # keeps its old models and default rather than losing them.
+    # lifecycle afterward — adding new models and hiding removed ones, while
+    # keeping default models visible and untouched. This is safe even if sync
+    # fails: the provider keeps its old models and default rather than losing
+    # them.
     if transitioning_to_auto_mode and existing_provider:
         llm_provider_upsert_request.model_configurations = [
             ModelConfigurationUpsertRequest.from_model(mc)

--- a/backend/scripts/check_recommended_models_bump.py
+++ b/backend/scripts/check_recommended_models_bump.py
@@ -1,0 +1,59 @@
+"""Pre-commit guard for recommended-models.json.
+
+The auto-mode config resolver picks the newer of the GitHub-hosted config and
+the bundled copy by `updated_at`, so an edit that forgets to bump the
+timestamp would silently never win against the remote file. Fail the commit
+when the file's content changes without a strictly newer `updated_at`.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime
+from datetime import timezone
+
+CONFIG_PATH = "backend/onyx/llm/well_known_providers/recommended-models.json"
+
+
+def _parse_updated_at(raw_config: str) -> datetime:
+    dt = datetime.fromisoformat(
+        json.loads(raw_config)["updated_at"].replace("Z", "+00:00")
+    )
+    return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt
+
+
+def main() -> int:
+    # pre-commit sets PRE_COMMIT_FROM_REF for from-ref runs (e.g. CI over a
+    # commit range); plain commits compare against HEAD.
+    base_ref = os.environ.get("PRE_COMMIT_FROM_REF") or "HEAD"
+    result = subprocess.run(
+        ["git", "show", f"{base_ref}:{CONFIG_PATH}"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        # File doesn't exist at the base ref (newly added) — nothing to check.
+        return 0
+
+    with open(CONFIG_PATH, "r") as f:
+        new_raw = f.read()
+
+    if json.loads(result.stdout) == json.loads(new_raw):
+        return 0
+
+    old_ts = _parse_updated_at(result.stdout)
+    new_ts = _parse_updated_at(new_raw)
+    if new_ts <= old_ts:
+        print(
+            f"{CONFIG_PATH} changed but updated_at was not bumped "
+            f"(still {new_ts.isoformat()}, base has {old_ts.isoformat()}).\n"
+            "Deployments resolve the newest config by updated_at, so this "
+            "edit would never take effect. Bump updated_at (and version)."
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/external_dependency_unit/llm/test_llm_provider_auto_mode.py
+++ b/backend/tests/external_dependency_unit/llm/test_llm_provider_auto_mode.py
@@ -100,11 +100,11 @@ class TestAutoModeSyncFeature:
     ) -> None:
         """
         Test that when a provider is uploaded with auto mode enabled and no model
-        configurations, the models from fetch_llm_recommendations_from_github()
+        configurations, the models from fetch_llm_recommendations()
         are synced to the provider.
 
         Steps:
-        1. Mock fetch_llm_recommendations_from_github to return a known config
+        1. Mock fetch_llm_recommendations to return a known config
         2. Upload provider with is_auto_mode=True and no model_configurations
         3. Fetch the provider and verify all recommended models are present
         4. Set the provider as default
@@ -124,7 +124,7 @@ class TestAutoModeSyncFeature:
 
         try:
             with patch(
-                "onyx.server.manage.llm.api.fetch_llm_recommendations_from_github",
+                "onyx.server.manage.llm.api.fetch_llm_recommendations",
                 return_value=mock_recommendations,
             ):
                 # Step 1-2: Upload provider with auto mode on and no model configs
@@ -221,7 +221,7 @@ class TestAutoModeSyncFeature:
 
         try:
             with patch(
-                "onyx.server.manage.llm.api.fetch_llm_recommendations_from_github",
+                "onyx.server.manage.llm.api.fetch_llm_recommendations",
                 return_value=mock_recommendations,
             ):
                 # Upload an OpenAI provider with auto mode
@@ -331,7 +331,7 @@ class TestAutoModeSyncFeature:
 
             # Step 2: Update provider to enable auto mode
             with patch(
-                "onyx.server.manage.llm.api.fetch_llm_recommendations_from_github",
+                "onyx.server.manage.llm.api.fetch_llm_recommendations",
                 return_value=mock_recommendations,
             ):
                 put_llm_provider(
@@ -410,7 +410,7 @@ class TestAutoModeSyncFeature:
 
         try:
             with patch(
-                "onyx.server.manage.llm.api.fetch_llm_recommendations_from_github",
+                "onyx.server.manage.llm.api.fetch_llm_recommendations",
                 return_value=mock_recommendations,
             ):
                 # Upload an OpenAI provider (not in config)
@@ -517,7 +517,7 @@ class TestAutoModeSyncFeature:
 
         try:
             with patch(
-                "onyx.server.manage.llm.api.fetch_llm_recommendations_from_github",
+                "onyx.server.manage.llm.api.fetch_llm_recommendations",
                 return_value=mock_recommendations,
             ):
                 # Step 1: Create provider 1 (OpenAI) with auto mode
@@ -544,7 +544,7 @@ class TestAutoModeSyncFeature:
             update_default_provider(provider_1.id, provider_1_default_model, db_session)
 
             with patch(
-                "onyx.server.manage.llm.api.fetch_llm_recommendations_from_github",
+                "onyx.server.manage.llm.api.fetch_llm_recommendations",
                 return_value=mock_recommendations,
             ):
                 # Step 2: Create provider 2 (Anthropic) with auto mode
@@ -753,7 +753,7 @@ class TestAutoModeTransitionsAndResync:
 
             # Step 2: Transition to auto mode
             with patch(
-                "onyx.server.manage.llm.api.fetch_llm_recommendations_from_github",
+                "onyx.server.manage.llm.api.fetch_llm_recommendations",
                 return_value=auto_config,
             ):
                 put_llm_provider(
@@ -815,7 +815,7 @@ class TestAutoModeTransitionsAndResync:
         try:
             # Step 1: Create in auto mode
             with patch(
-                "onyx.server.manage.llm.api.fetch_llm_recommendations_from_github",
+                "onyx.server.manage.llm.api.fetch_llm_recommendations",
                 return_value=initial_config,
             ):
                 put_llm_provider(
@@ -913,7 +913,7 @@ class TestAutoModeTransitionsAndResync:
         try:
             # Step 1: Create with config v1
             with patch(
-                "onyx.server.manage.llm.api.fetch_llm_recommendations_from_github",
+                "onyx.server.manage.llm.api.fetch_llm_recommendations",
                 return_value=config_v1,
             ):
                 put_llm_provider(
@@ -982,7 +982,7 @@ class TestAutoModeTransitionsAndResync:
 
         try:
             with patch(
-                "onyx.server.manage.llm.api.fetch_llm_recommendations_from_github",
+                "onyx.server.manage.llm.api.fetch_llm_recommendations",
                 return_value=config,
             ):
                 put_llm_provider(
@@ -1098,7 +1098,7 @@ class TestAutoModeTransitionsAndResync:
 
             # Enable auto mode via the API, like the admin modal does
             with patch(
-                "onyx.server.manage.llm.api.fetch_llm_recommendations_from_github",
+                "onyx.server.manage.llm.api.fetch_llm_recommendations",
                 return_value=mock_recommendations,
             ):
                 put_llm_provider(
@@ -1172,7 +1172,7 @@ class TestAutoModeTransitionsAndResync:
 
         try:
             with patch(
-                "onyx.server.manage.llm.api.fetch_llm_recommendations_from_github",
+                "onyx.server.manage.llm.api.fetch_llm_recommendations",
                 return_value=config_v1,
             ):
                 put_llm_provider(
@@ -1273,7 +1273,7 @@ class TestAutoModeTransitionsAndResync:
 
         try:
             with patch(
-                "onyx.server.manage.llm.api.fetch_llm_recommendations_from_github",
+                "onyx.server.manage.llm.api.fetch_llm_recommendations",
                 return_value=config_v1,
             ):
                 put_llm_provider(
@@ -1359,7 +1359,7 @@ class TestAutoModeTransitionsAndResync:
 
         try:
             with patch(
-                "onyx.server.manage.llm.api.fetch_llm_recommendations_from_github",
+                "onyx.server.manage.llm.api.fetch_llm_recommendations",
                 return_value=config,
             ):
                 put_llm_provider(
@@ -1459,7 +1459,7 @@ class TestAutoModeTransitionsAndResync:
 
         try:
             with patch(
-                "onyx.server.manage.llm.api.fetch_llm_recommendations_from_github",
+                "onyx.server.manage.llm.api.fetch_llm_recommendations",
                 return_value=config,
             ):
                 put_llm_provider(
@@ -1533,7 +1533,7 @@ class TestAutoModeTransitionsAndResync:
 
         try:
             with patch(
-                "onyx.server.manage.llm.api.fetch_llm_recommendations_from_github",
+                "onyx.server.manage.llm.api.fetch_llm_recommendations",
                 return_value=config,
             ):
                 put_llm_provider(

--- a/backend/tests/external_dependency_unit/llm/test_llm_provider_auto_mode.py
+++ b/backend/tests/external_dependency_unit/llm/test_llm_provider_auto_mode.py
@@ -703,14 +703,16 @@ class TestAutoModeTransitionsAndResync:
         provider_name: str,
     ) -> None:
         """When the default provider transitions from manual to auto mode,
-        the global default should be preserved (set to the recommended model).
+        the admin-chosen global default must be preserved as long as that
+        model is still present in the GitHub config — even when it differs
+        from the config's recommended default.
 
         Steps:
         1. Create a manual-mode provider with models, set it as global default.
         2. Transition to auto mode (model_configurations=[] triggers cascade
            delete of old ModelConfigurations and their LLMModelFlow rows).
-        3. Verify the provider is still the global default, now using the
-           recommended default model from the GitHub config.
+        3. Verify the provider is still the global default, still using the
+           admin-chosen model (not the config's recommended default).
         """
         initial_models = [
             ModelConfigurationUpsertRequest(name="gpt-4o", is_visible=True),
@@ -781,8 +783,9 @@ class TestAutoModeTransitionsAndResync:
             assert default_after.llm_provider_id == provider.id, (
                 "Default should still belong to the same provider after transition"
             )
-            assert default_after.name == "gpt-4o-mini", (
-                f"Default should be updated to the recommended model 'gpt-4o-mini', got '{default_after.name}'"
+            assert default_after.name == "gpt-4o", (
+                "Default should remain the admin-chosen 'gpt-4o' since it is "
+                f"still in the GitHub config, got '{default_after.name}'"
             )
 
         finally:
@@ -1149,21 +1152,22 @@ class TestAutoModeTransitionsAndResync:
             db_session.rollback()
             _cleanup_provider(db_session, provider_name)
 
-    def test_sync_updates_default_when_recommended_default_changes(
+    def test_sync_preserves_default_when_recommended_default_changes(
         self,
         db_session: Session,
         provider_name: str,
     ) -> None:
         """When the provider owns the CHAT default and a sync arrives with a
-        different recommended default model (both models still in config),
-        the global default should be updated to the new recommendation.
+        different recommended default model, the current default must be kept
+        as long as it is still in the config — the recommendation only applies
+        when the current default is removed.
 
         Steps:
         1. Create auto-mode provider with config v1: default=gpt-4o.
         2. Set gpt-4o as the global CHAT default.
         3. Re-sync with config v2: default=gpt-4o-mini (gpt-4o still present).
-        4. Verify the CHAT default switched to gpt-4o-mini and both models
-           remain visible.
+        4. Verify the CHAT default is still gpt-4o and both models remain
+           visible.
         """
         config_v1 = _create_mock_llm_recommendations(
             provider=LlmProviderNames.OPENAI,
@@ -1219,7 +1223,10 @@ class TestAutoModeTransitionsAndResync:
                 provider=provider,
                 llm_recommendations=config_v2,
             )
-            assert changes > 0, "Sync should report changes when default switches"
+            assert changes == 0, (
+                "Sync should be a no-op when the current default is still in "
+                f"the config, got {changes} changes"
+            )
 
             # Both models should remain visible
             db_session.expire_all()
@@ -1233,11 +1240,11 @@ class TestAutoModeTransitionsAndResync:
             assert visibility["gpt-4o"] is True
             assert visibility["gpt-4o-mini"] is True
 
-            # The CHAT default should now be gpt-4o-mini
+            # The CHAT default should still be the admin-chosen gpt-4o
             default_after = fetch_default_llm_model(db_session)
             assert default_after is not None
-            assert default_after.name == "gpt-4o-mini", (
-                f"Default should be updated to 'gpt-4o-mini', got '{default_after.name}'"
+            assert default_after.name == "gpt-4o", (
+                f"Default should remain 'gpt-4o', got '{default_after.name}'"
             )
 
         finally:

--- a/backend/tests/external_dependency_unit/llm/test_llm_provider_auto_mode.py
+++ b/backend/tests/external_dependency_unit/llm/test_llm_provider_auto_mode.py
@@ -1051,21 +1051,115 @@ class TestAutoModeTransitionsAndResync:
             db_session.rollback()
             _cleanup_provider(db_session, provider_name)
 
-    def test_default_model_hidden_when_removed_from_config(
+    def test_transition_to_auto_mode_preserves_default_not_in_config(
+        self,
+        db_session: Session,
+        provider_name: str,
+    ) -> None:
+        """Enabling auto mode must preserve the admin-chosen default model
+        even when that model does not appear in the GitHub config at all
+        (e.g. the curated list lags behind newly released models).
+
+        Regression test: an Anthropic provider with claude-sonnet-5 as the
+        global default flipped to the config's recommended claude-opus-4-8 on
+        save, because the sync hid the default and reassigned it.
+        """
+        admin_default = "claude-sonnet-5"
+
+        # Config recommends opus and does NOT contain sonnet-5
+        mock_recommendations = _create_mock_llm_recommendations(
+            provider=LlmProviderNames.ANTHROPIC,
+            default_model_name="claude-opus-4-8",
+            additional_models=["claude-haiku-4-5"],
+        )
+
+        try:
+            put_llm_provider(
+                llm_provider_upsert_request=LLMProviderUpsertRequest(
+                    name=provider_name,
+                    provider=LlmProviderNames.ANTHROPIC,
+                    api_key="sk-test-key-00000000000000000000000000000000000",
+                    api_key_changed=True,
+                    is_auto_mode=False,
+                    model_configurations=[
+                        ModelConfigurationUpsertRequest(
+                            name=admin_default, is_visible=True
+                        ),
+                    ],
+                ),
+                is_creation=True,
+                user=_create_mock_admin(),
+                db_session=db_session,
+            )
+
+            provider = fetch_existing_llm_provider(
+                name=provider_name, db_session=db_session
+            )
+            assert provider is not None
+            update_default_provider(provider.id, admin_default, db_session)
+
+            # Enable auto mode via the API, like the admin modal does
+            with patch(
+                "onyx.server.manage.llm.api.fetch_llm_recommendations_from_github",
+                return_value=mock_recommendations,
+            ):
+                put_llm_provider(
+                    llm_provider_upsert_request=LLMProviderUpsertRequest(
+                        id=provider.id,
+                        name=provider_name,
+                        provider=LlmProviderNames.ANTHROPIC,
+                        api_key=None,
+                        api_key_changed=False,
+                        is_auto_mode=True,
+                        model_configurations=[],
+                    ),
+                    is_creation=False,
+                    user=_create_mock_admin(),
+                    db_session=db_session,
+                )
+
+            db_session.expire_all()
+            default_after = fetch_default_llm_model(db_session)
+            assert default_after is not None
+            assert default_after.name == admin_default, (
+                f"Default must remain '{admin_default}' after enabling auto "
+                f"mode, got '{default_after.name}'"
+            )
+            assert default_after.is_visible is True, (
+                "The default model must stay visible even though it is not "
+                "in the GitHub config"
+            )
+
+            # Config models were still added and made visible
+            provider_after = fetch_existing_llm_provider(
+                name=provider_name, db_session=db_session
+            )
+            assert provider_after is not None
+            visibility = {
+                mc.name: mc.is_visible for mc in provider_after.model_configurations
+            }
+            assert visibility.get("claude-opus-4-8") is True
+            assert visibility.get("claude-haiku-4-5") is True
+
+        finally:
+            db_session.rollback()
+            _cleanup_provider(db_session, provider_name)
+
+    def test_default_model_kept_when_removed_from_config(
         self,
         db_session: Session,
         provider_name: str,
     ) -> None:
         """When the current default model is removed from the config, sync
-        should hide it. The default model flow row should still exist (it
-        points at the ModelConfiguration), but the model is no longer visible.
+        must keep it visible and keep it as the default — Auto mode curates
+        the model list but never pulls the admin-chosen default out from
+        under the org.
 
         Steps:
         1. Create provider with config: default=gpt-4o, additional=[gpt-4o-mini].
         2. Set gpt-4o as the global default.
         3. Re-sync with config: default=gpt-4o-mini (gpt-4o removed entirely).
-        4. Verify gpt-4o is hidden, gpt-4o-mini is visible, and
-           fetch_default_llm_model still returns a result (the flow row persists).
+        4. Verify gpt-4o stays visible and remains the global default.
         """
         config_v1 = _create_mock_llm_recommendations(
             provider=LlmProviderNames.OPENAI,
@@ -1116,12 +1210,11 @@ class TestAutoModeTransitionsAndResync:
             )
             assert provider is not None
 
-            changes = sync_auto_mode_models(
+            sync_auto_mode_models(
                 db_session=db_session,
                 provider=provider,
                 llm_recommendations=config_v2,
             )
-            assert changes > 0
 
             # Step 4: Verify visibility
             db_session.expire_all()
@@ -1133,19 +1226,19 @@ class TestAutoModeTransitionsAndResync:
             visibility = {
                 mc.name: mc.is_visible for mc in provider.model_configurations
             }
-            assert visibility["gpt-4o"] is False, "Removed default should be hidden"
-            assert visibility["gpt-4o-mini"] is True, "New default should be visible"
+            assert visibility["gpt-4o"] is True, (
+                "The default model must stay visible even when removed from the config"
+            )
+            assert visibility["gpt-4o-mini"] is True, (
+                "Recommended default should be visible"
+            )
 
-            # The old default (gpt-4o) is now hidden. sync_auto_mode_models
-            # should update the global default to the new recommended default
-            # (gpt-4o-mini) so that it is not silently lost.
             db_session.expire_all()
             default_after = fetch_default_llm_model(db_session)
-            assert default_after is not None, (
-                "Default model should not be None — sync should set the new recommended default when the old one is hidden"
-            )
-            assert default_after.name == "gpt-4o-mini", (
-                f"Default should be updated to the new recommended model 'gpt-4o-mini', but got '{default_after.name}'"
+            assert default_after is not None
+            assert default_after.name == "gpt-4o", (
+                "The admin-chosen default must survive the sync even when "
+                f"removed from the config, got '{default_after.name}'"
             )
 
         finally:

--- a/backend/tests/external_dependency_unit/llm/test_llm_provider_auto_mode.py
+++ b/backend/tests/external_dependency_unit/llm/test_llm_provider_auto_mode.py
@@ -128,8 +128,6 @@ class TestAutoModeSyncFeature:
                 return_value=mock_recommendations,
             ):
                 # Step 1-2: Upload provider with auto mode on and no model configs
-                # NOTE: We need to provide a default_model_name for the initial upsert,
-                # but auto mode will override it with the GitHub config's default
                 put_llm_provider(
                     llm_provider_upsert_request=LLMProviderUpsertRequest(
                         name=provider_name,
@@ -1338,6 +1336,178 @@ class TestAutoModeTransitionsAndResync:
             assert default_after is not None
             assert default_after.name == "gpt-4o", (
                 f"Default should remain 'gpt-4o', got '{default_after.name}'"
+            )
+
+        finally:
+            db_session.rollback()
+            _cleanup_provider(db_session, provider_name)
+
+    def test_sync_preserves_admin_hidden_config_model(
+        self,
+        db_session: Session,
+        provider_name: str,
+    ) -> None:
+        """A model the admin deselected stays hidden across syncs even though
+        the GitHub config lists it — auto mode decides what is offered, the
+        admin decides what is enabled.
+        """
+        config = _create_mock_llm_recommendations(
+            provider=LlmProviderNames.OPENAI,
+            default_model_name="gpt-4o",
+            additional_models=["gpt-4o-mini"],
+        )
+
+        try:
+            with patch(
+                "onyx.server.manage.llm.api.fetch_llm_recommendations_from_github",
+                return_value=config,
+            ):
+                put_llm_provider(
+                    llm_provider_upsert_request=LLMProviderUpsertRequest(
+                        name=provider_name,
+                        provider=LlmProviderNames.OPENAI,
+                        api_key="sk-test-key-00000000000000000000000000000000000",
+                        api_key_changed=True,
+                        is_auto_mode=True,
+                        model_configurations=[],
+                    ),
+                    is_creation=True,
+                    user=_create_mock_admin(),
+                    db_session=db_session,
+                )
+
+            db_session.expire_all()
+            provider = fetch_existing_llm_provider(
+                name=provider_name, db_session=db_session
+            )
+            assert provider is not None
+            update_default_provider(provider.id, "gpt-4o", db_session)
+
+            # Admin deselects gpt-4o-mini while staying in auto mode (a
+            # regular save, not a transition, so no sync runs here)
+            put_llm_provider(
+                llm_provider_upsert_request=LLMProviderUpsertRequest(
+                    id=provider.id,
+                    name=provider_name,
+                    provider=LlmProviderNames.OPENAI,
+                    api_key=None,
+                    api_key_changed=False,
+                    is_auto_mode=True,
+                    model_configurations=[
+                        ModelConfigurationUpsertRequest(
+                            name="gpt-4o", is_visible=True, display_name="GPT-4O"
+                        ),
+                        ModelConfigurationUpsertRequest(
+                            name="gpt-4o-mini",
+                            is_visible=False,
+                            display_name="GPT-4O-MINI",
+                        ),
+                    ],
+                ),
+                is_creation=False,
+                user=_create_mock_admin(),
+                db_session=db_session,
+            )
+
+            # A background sync with the unchanged config must not re-enable it
+            db_session.expire_all()
+            provider = fetch_existing_llm_provider(
+                name=provider_name, db_session=db_session
+            )
+            assert provider is not None
+            sync_auto_mode_models(
+                db_session=db_session,
+                provider=provider,
+                llm_recommendations=config,
+            )
+
+            db_session.expire_all()
+            provider = fetch_existing_llm_provider(
+                name=provider_name, db_session=db_session
+            )
+            assert provider is not None
+            visibility = {
+                mc.name: mc.is_visible for mc in provider.model_configurations
+            }
+            assert visibility["gpt-4o-mini"] is False, (
+                "Sync must not re-enable a model the admin deselected"
+            )
+            assert visibility["gpt-4o"] is True
+
+            default_model = fetch_default_llm_model(db_session)
+            assert default_model is not None
+            assert default_model.name == "gpt-4o"
+
+        finally:
+            db_session.rollback()
+            _cleanup_provider(db_session, provider_name)
+
+    def test_sync_repairs_default_pointing_at_hidden_model(
+        self,
+        db_session: Session,
+        provider_name: str,
+    ) -> None:
+        """Safety net: if the global CHAT default somehow points at a hidden
+        model (state no normal path produces), the sync moves it to the
+        recommended default and makes that model visible.
+        """
+        config = _create_mock_llm_recommendations(
+            provider=LlmProviderNames.OPENAI,
+            default_model_name="gpt-4o",
+            additional_models=["gpt-4o-mini"],
+        )
+
+        try:
+            with patch(
+                "onyx.server.manage.llm.api.fetch_llm_recommendations_from_github",
+                return_value=config,
+            ):
+                put_llm_provider(
+                    llm_provider_upsert_request=LLMProviderUpsertRequest(
+                        name=provider_name,
+                        provider=LlmProviderNames.OPENAI,
+                        api_key="sk-test-key-00000000000000000000000000000000000",
+                        api_key_changed=True,
+                        is_auto_mode=True,
+                        model_configurations=[],
+                    ),
+                    is_creation=True,
+                    user=_create_mock_admin(),
+                    db_session=db_session,
+                )
+
+            db_session.expire_all()
+            provider = fetch_existing_llm_provider(
+                name=provider_name, db_session=db_session
+            )
+            assert provider is not None
+            update_default_provider(provider.id, "gpt-4o-mini", db_session)
+
+            # Manufacture the broken state directly: hide every model,
+            # including the current default
+            for mc in provider.model_configurations:
+                mc.is_visible = False
+            db_session.commit()
+
+            db_session.expire_all()
+            provider = fetch_existing_llm_provider(
+                name=provider_name, db_session=db_session
+            )
+            assert provider is not None
+            sync_auto_mode_models(
+                db_session=db_session,
+                provider=provider,
+                llm_recommendations=config,
+            )
+
+            db_session.expire_all()
+            default_model = fetch_default_llm_model(db_session)
+            assert default_model is not None
+            assert default_model.name == "gpt-4o", (
+                "Safety net should move a hidden default to the recommended model"
+            )
+            assert default_model.is_visible is True, (
+                "The repaired default must be made visible"
             )
 
         finally:

--- a/backend/tests/unit/onyx/llm/test_auto_update_service.py
+++ b/backend/tests/unit/onyx/llm/test_auto_update_service.py
@@ -1,0 +1,83 @@
+"""Tests for LLM recommendations config resolution (remote vs bundled)."""
+
+from datetime import datetime
+from datetime import timezone
+from unittest.mock import patch
+
+from onyx.llm.well_known_providers.auto_update_models import LLMRecommendations
+from onyx.llm.well_known_providers.auto_update_service import fetch_llm_recommendations
+from onyx.llm.well_known_providers.auto_update_service import (
+    load_bundled_recommendations,
+)
+
+
+def _make_config(updated_at: datetime) -> LLMRecommendations:
+    return LLMRecommendations(
+        version="test",
+        updated_at=updated_at,
+        providers={},
+    )
+
+
+_MODULE = "onyx.llm.well_known_providers.auto_update_service"
+
+
+def test_remote_wins_when_newer() -> None:
+    remote = _make_config(datetime(2026, 7, 1, tzinfo=timezone.utc))
+    bundled = _make_config(datetime(2026, 6, 1, tzinfo=timezone.utc))
+    with (
+        patch(f"{_MODULE}.fetch_llm_recommendations_from_github", return_value=remote),
+        patch(f"{_MODULE}.load_bundled_recommendations", return_value=bundled),
+    ):
+        assert fetch_llm_recommendations() is remote
+
+
+def test_bundled_wins_when_newer() -> None:
+    """A fresh release must not be held back by a stale remote config."""
+    remote = _make_config(datetime(2026, 6, 1, tzinfo=timezone.utc))
+    bundled = _make_config(datetime(2026, 7, 1, tzinfo=timezone.utc))
+    with (
+        patch(f"{_MODULE}.fetch_llm_recommendations_from_github", return_value=remote),
+        patch(f"{_MODULE}.load_bundled_recommendations", return_value=bundled),
+    ):
+        assert fetch_llm_recommendations() is bundled
+
+
+def test_bundled_used_when_remote_unavailable() -> None:
+    bundled = _make_config(datetime(2026, 7, 1, tzinfo=timezone.utc))
+    with (
+        patch(f"{_MODULE}.fetch_llm_recommendations_from_github", return_value=None),
+        patch(f"{_MODULE}.load_bundled_recommendations", return_value=bundled),
+    ):
+        assert fetch_llm_recommendations() is bundled
+
+
+def test_none_when_both_unavailable() -> None:
+    with (
+        patch(f"{_MODULE}.fetch_llm_recommendations_from_github", return_value=None),
+        patch(f"{_MODULE}.load_bundled_recommendations", return_value=None),
+    ):
+        assert fetch_llm_recommendations() is None
+
+
+def test_naive_timestamps_compare_safely() -> None:
+    """A config authored without an explicit timezone must not crash the
+    comparison against a tz-aware one."""
+    remote = _make_config(datetime(2026, 6, 1, tzinfo=timezone.utc))
+    bundled = _make_config(datetime(2026, 7, 1))  # naive
+    with (
+        patch(f"{_MODULE}.fetch_llm_recommendations_from_github", return_value=remote),
+        patch(f"{_MODULE}.load_bundled_recommendations", return_value=bundled),
+    ):
+        assert fetch_llm_recommendations() is bundled
+
+
+def test_bundled_file_parses_and_includes_current_anthropic_models() -> None:
+    """The shipped recommended-models.json must be valid and carry the
+    current Anthropic generation (regression: Fable 5 / Sonnet 5 were
+    missing, so auto-mode providers never offered them)."""
+    bundled = load_bundled_recommendations()
+    assert bundled is not None
+    anthropic_models = {m.name for m in bundled.get_visible_models("anthropic")}
+    assert "claude-fable-5" in anthropic_models
+    assert "claude-sonnet-5" in anthropic_models

--- a/backend/tests/unit/onyx/server/features/build/test_build_mode_provider_types_sync.py
+++ b/backend/tests/unit/onyx/server/features/build/test_build_mode_provider_types_sync.py
@@ -9,8 +9,8 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from onyx.llm.well_known_providers.llm_provider_options import (
-    _load_bundled_recommendations,
+from onyx.llm.well_known_providers.auto_update_service import (
+    load_bundled_recommendations,
 )
 from onyx.server.features.build.configs import BUILD_MODE_ALLOWED_PROVIDER_TYPES
 
@@ -32,7 +32,8 @@ def test_frontend_and_backend_craft_provider_types_match() -> None:
 
 
 def test_recommended_config_covers_allowed_provider_types() -> None:
-    recommendations = _load_bundled_recommendations()
+    recommendations = load_bundled_recommendations()
+    assert recommendations is not None
     for provider_type in BUILD_MODE_ALLOWED_PROVIDER_TYPES:
         assert recommendations.get_default_model(provider_type) is not None, (
             f"recommended-models.json has no default_model for Craft provider "

--- a/web/src/lib/languageModels/hooks.ts
+++ b/web/src/lib/languageModels/hooks.ts
@@ -252,6 +252,62 @@ export function useWellKnownLLMProvider(providerName: LLMProviderName) {
   };
 }
 
+// Raw shape of GET /api/admin/llm/auto-config (LLMRecommendations.model_dump()).
+interface AutoModeModelRef {
+  name: string;
+  display_name?: string | null;
+}
+
+interface AutoModeProviderRecommendation {
+  default_model: AutoModeModelRef;
+  additional_visible_models: AutoModeModelRef[];
+}
+
+interface AutoModeRecommendations {
+  version: string;
+  updated_at: string;
+  providers: Record<string, AutoModeProviderRecommendation>;
+}
+
+/**
+ * Fetches the Auto mode model recommendations (the GitHub-hosted config that
+ * drives auto-updating providers) and exposes the model names offered for a
+ * given provider type.
+ *
+ * Hits `GET /api/admin/llm/auto-config`.
+ *
+ * @param providerName - The provider type (e.g. "anthropic"). Pass `null`
+ *   to suppress the request (e.g. when the auto-update toggle is hidden).
+ *
+ * @returns
+ * - `autoModelNames` — Set of model names the config offers for this
+ *    provider, or `null` while loading / on error / when the provider has
+ *    no auto config.
+ */
+export function useAutoModeConfig(providerName: string | null | undefined) {
+  const { data, error, isLoading } = useSWR<AutoModeRecommendations>(
+    providerName ? SWR_KEYS.llmAutoConfig : null,
+    errorHandlingFetcher,
+    {
+      revalidateOnFocus: false,
+      revalidateIfStale: false,
+      dedupingInterval: 60000,
+    }
+  );
+
+  const autoModelNames = useMemo(() => {
+    if (!data || !providerName) return null;
+    const recommendation = data.providers[providerName];
+    if (!recommendation) return null;
+    return new Set([
+      recommendation.default_model.name,
+      ...recommendation.additional_visible_models.map((m) => m.name),
+    ]);
+  }, [data, providerName]);
+
+  return { autoModelNames, isLoading, error };
+}
+
 export interface CustomProviderOption {
   value: string;
   label: string;

--- a/web/src/lib/swr-keys.ts
+++ b/web/src/lib/swr-keys.ts
@@ -41,6 +41,7 @@ export const SWR_KEYS = {
   wellKnownLlmProvider: (providerEndpoint: string) =>
     `/api/admin/llm/built-in/options/${providerEndpoint}`,
   llmContextualCost: "/api/admin/llm/provider-contextual-cost",
+  llmAutoConfig: "/api/admin/llm/auto-config",
 
   // ── Image Generation ──────────────────────────────────────────────────────
   imageGenConfig: "/api/admin/image-generation/config",

--- a/web/src/sections/modals/languageModels/ModelSelectionField.test.tsx
+++ b/web/src/sections/modals/languageModels/ModelSelectionField.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * Component test: ModelSelectionField in auto-update mode.
+ *
+ * Regression coverage for the auto-mode model list:
+ * - rows stay toggleable (admins can deselect models the config offers)
+ * - a deselected row stays in the list so it can be re-selected before saving
+ * - models the config offers but the admin hid are listed unchecked
+ * - hidden models outside the offered set are not listed at all
+ */
+
+import { render, screen, setupUser } from "@tests/setup/test-utils";
+import { PointerEventsCheckLevel } from "@testing-library/user-event";
+import { Formik, Form } from "formik";
+import { ModelSelectionField } from "@/sections/modals/languageModels/shared";
+import { BaseLLMFormValues } from "@/sections/modals/languageModels/utils";
+import { ModelConfiguration } from "@/lib/languageModels/types";
+import { SWR_KEYS } from "@/lib/swr-keys";
+
+const AUTO_CONFIG = {
+  version: "1.5",
+  updated_at: "2026-07-05T00:00:00Z",
+  providers: {
+    anthropic: {
+      default_model: { name: "claude-opus-4-8" },
+      additional_visible_models: [
+        { name: "claude-opus-4-8", display_name: "Claude Opus 4.8" },
+        { name: "claude-sonnet-4-6", display_name: "Claude Sonnet 4.6" },
+        { name: "claude-haiku-4-5", display_name: "Claude Haiku 4.5" },
+      ],
+    },
+  },
+};
+
+jest.mock("swr", () => {
+  const actual = jest.requireActual("swr");
+  return {
+    ...actual,
+    __esModule: true,
+    useSWRConfig: () => ({ mutate: jest.fn() }),
+    default: (key: string | null) => ({
+      data: key === SWR_KEYS.llmAutoConfig ? AUTO_CONFIG : undefined,
+      error: undefined,
+      isLoading: false,
+    }),
+  };
+});
+
+function makeModel(name: string, isVisible: boolean): ModelConfiguration {
+  return {
+    name,
+    is_visible: isVisible,
+    max_input_tokens: null,
+    supports_image_input: false,
+    supports_reasoning: false,
+    display_name: name,
+    effectiveDisplayName: name,
+  } as ModelConfiguration;
+}
+
+function renderField(models: ModelConfiguration[]) {
+  const initialValues: BaseLLMFormValues = {
+    provider: "anthropic",
+    is_public: true,
+    is_auto_mode: true,
+    groups: [],
+    personas: [],
+    model_configurations: models,
+  };
+
+  let latestValues = initialValues;
+  render(
+    <Formik initialValues={initialValues} onSubmit={jest.fn()}>
+      {(formik) => {
+        latestValues = formik.values;
+        return (
+          <Form>
+            <ModelSelectionField shouldShowAutoUpdateToggle={true} />
+          </Form>
+        );
+      }}
+    </Formik>
+  );
+  return () => latestValues;
+}
+
+function row(name: string): HTMLElement | null {
+  return document.querySelector(`[data-model-name="${name}"]`);
+}
+
+describe("ModelSelectionField in auto mode", () => {
+  test("lists offered models plus the visible off-config default, hides the rest", () => {
+    renderField([
+      // admin default, visible but NOT in the auto config
+      makeModel("claude-sonnet-5", true),
+      makeModel("claude-opus-4-8", true),
+      // offered by the config but deselected by the admin earlier
+      makeModel("claude-haiku-4-5", false),
+      // hidden and outside the offered set — must not be listed
+      makeModel("claude-3-opus", false),
+    ]);
+
+    expect(row("claude-sonnet-5")).not.toBeNull();
+    expect(row("claude-opus-4-8")).not.toBeNull();
+    expect(row("claude-haiku-4-5")).not.toBeNull();
+    expect(row("claude-3-opus")).toBeNull();
+  });
+
+  test("deselecting an offered model updates form state and keeps the row listed", async () => {
+    const user = setupUser({
+      pointerEventsCheck: PointerEventsCheckLevel.Never,
+    });
+    const getValues = renderField([
+      makeModel("claude-sonnet-5", true),
+      makeModel("claude-opus-4-8", true),
+    ]);
+
+    const opusRow = row("claude-opus-4-8");
+    expect(opusRow).not.toBeNull();
+    await user.click(opusRow!.querySelector('[role="button"]')!);
+
+    const opus = getValues().model_configurations.find(
+      (m) => m.name === "claude-opus-4-8"
+    );
+    expect(opus?.is_visible).toBe(false);
+    // still listed (it's in the offered set) so it can be re-selected
+    expect(row("claude-opus-4-8")).not.toBeNull();
+    // the other model is untouched
+    expect(
+      getValues().model_configurations.find((m) => m.name === "claude-sonnet-5")
+        ?.is_visible
+    ).toBe(true);
+  });
+
+  test("select all / deselect all operates on the offered set only", async () => {
+    const user = setupUser({
+      pointerEventsCheck: PointerEventsCheckLevel.Never,
+    });
+    const getValues = renderField([
+      makeModel("claude-sonnet-5", true),
+      makeModel("claude-opus-4-8", true),
+      makeModel("claude-3-opus", false), // outside the offered set
+    ]);
+
+    await user.click(screen.getByRole("button", { name: "Deselect All" }));
+
+    const values = getValues().model_configurations;
+    expect(values.find((m) => m.name === "claude-opus-4-8")?.is_visible).toBe(
+      false
+    );
+    expect(values.find((m) => m.name === "claude-sonnet-5")?.is_visible).toBe(
+      false
+    );
+    // not offered, not shown — must not be flipped on by select-all cycles
+    await user.click(screen.getByRole("button", { name: "Select All" }));
+    expect(
+      getValues().model_configurations.find((m) => m.name === "claude-3-opus")
+        ?.is_visible
+    ).toBe(false);
+  });
+});

--- a/web/src/sections/modals/languageModels/shared.tsx
+++ b/web/src/sections/modals/languageModels/shared.tsx
@@ -9,6 +9,7 @@ import { Interactive } from "@opal/core";
 import { useTierAtLeast } from "@/hooks/useTierAtLeast";
 import { Tier } from "@/lib/settings/types";
 import { useAgents } from "@/lib/agents/hooks";
+import { useAutoModeConfig } from "@/lib/languageModels/hooks";
 import { useUserGroups } from "@/lib/hooks";
 import type {
   LLMProviderView,
@@ -492,7 +493,6 @@ function modelRightChildren(model: ModelConfiguration): React.ReactNode {
 
 interface ModelRowProps {
   model: ModelConfiguration;
-  isAutoMode: boolean;
   onToggleVisibility: (visible: boolean) => void;
   onRename: (value: string | undefined) => void;
 }
@@ -510,20 +510,11 @@ interface ModelRowProps {
  * ContentAction) but with a typeless `Interactive.Container`, which renders a
  * `<div>` instead of a `<button>`.
  */
-function ModelRow({
-  model,
-  isAutoMode,
-  onToggleVisibility,
-  onRename,
-}: ModelRowProps) {
+function ModelRow({ model, onToggleVisibility, onRename }: ModelRowProps) {
   const displayName =
     model.custom_display_name || model.display_name || model.name;
-  // In auto mode every model is shown, so the row is always "selected" and the
-  // visibility toggle is disabled.
-  const isSelected = isAutoMode || model.is_visible;
-  const toggleVisibility = isAutoMode
-    ? undefined
-    : () => onToggleVisibility(!model.is_visible);
+  const isSelected = model.is_visible;
+  const toggleVisibility = () => onToggleVisibility(!model.is_visible);
 
   return (
     <div data-model-name={model.name}>
@@ -531,18 +522,14 @@ function ModelRow({
         variant="select-heavy"
         state={isSelected ? "selected" : "empty"}
         onClick={toggleVisibility}
-        role={toggleVisibility ? "button" : undefined}
-        tabIndex={toggleVisibility ? 0 : undefined}
-        onKeyDown={
-          toggleVisibility
-            ? (e: React.KeyboardEvent) => {
-                if (e.key === "Enter" || e.key === " ") {
-                  e.preventDefault();
-                  toggleVisibility();
-                }
-              }
-            : undefined
-        }
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e: React.KeyboardEvent) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            toggleVisibility();
+          }
+        }}
       >
         <Interactive.Container width="full" size="fit" rounding="md">
           <div className="w-full p-2">
@@ -585,8 +572,14 @@ export function ModelSelectionField({
     shouldShowAutoUpdateToggle && formikProps.values.is_auto_mode;
   const models = formikProps.values.model_configurations;
 
-  // Snapshot the original model visibility so we can restore it when
-  // toggling auto mode back on.
+  // The auto-update config decides which models auto mode *offers*; the admin
+  // still chooses which offered models are enabled.
+  const { autoModelNames } = useAutoModeConfig(
+    shouldShowAutoUpdateToggle ? formikProps.values.provider : null
+  );
+
+  // Snapshot the models first present in the form, so rows deselected while
+  // auto mode is on don't vanish from the list (they must stay re-selectable).
   const originalModelsRef = useRef(models);
   useEffect(() => {
     if (originalModelsRef.current.length === 0 && models.length > 0) {
@@ -621,26 +614,36 @@ export function ModelSelectionField({
 
   function handleToggleAutoMode(nextIsAutoMode: boolean) {
     formikProps.setFieldValue("is_auto_mode", nextIsAutoMode);
-    if (nextIsAutoMode) {
-      formikProps.setFieldValue(
-        "model_configurations",
-        originalModelsRef.current
-      );
-    }
   }
 
-  const allSelected = models.length > 0 && models.every((m) => m.is_visible);
+  // In auto mode, list the models the config offers plus anything currently
+  // or originally visible (e.g. an admin-chosen default the config doesn't
+  // carry). Hidden models outside that set stay out of the list — enabling
+  // them would just be reverted by the next background sync.
+  const originallyVisibleNames = new Set(
+    originalModelsRef.current.filter((m) => m.is_visible).map((m) => m.name)
+  );
+  const autoOfferedModels = models.filter(
+    (m) =>
+      m.is_visible ||
+      autoModelNames?.has(m.name) ||
+      originallyVisibleNames.has(m.name)
+  );
+
+  // "Select All" only operates on the models shown in the list, which in
+  // auto mode is the offered subset rather than every known model.
+  const selectionScope = isAutoMode ? autoOfferedModels : models;
+  const allSelected =
+    selectionScope.length > 0 && selectionScope.every((m) => m.is_visible);
 
   function handleToggleSelectAll() {
     const nextVisible = !allSelected;
-    const updated = models.map((m) => ({
-      ...m,
-      is_visible: nextVisible,
-    }));
+    const scopeNames = new Set(selectionScope.map((m) => m.name));
+    const updated = models.map((m) =>
+      scopeNames.has(m.name) ? { ...m, is_visible: nextVisible } : m
+    );
     formikProps.setFieldValue("model_configurations", updated);
   }
-
-  const visibleModels = models.filter((m) => m.is_visible);
 
   return (
     <Card background="light" border="none" padding="sm">
@@ -652,7 +655,7 @@ export function ModelSelectionField({
         >
           <Section flexDirection="row" gap={0}>
             <Button
-              disabled={isAutoMode || models.length === 0}
+              disabled={selectionScope.length === 0}
               prominence="tertiary"
               size="md"
               onClick={handleToggleSelectAll}
@@ -668,7 +671,7 @@ export function ModelSelectionField({
         ) : (
           <Section gap={0.25} alignItems="stretch">
             {(() => {
-              const baseModels = isAutoMode ? visibleModels : models;
+              const baseModels = isAutoMode ? autoOfferedModels : models;
               // Sort alphabetically by id for providers that ship rich model
               // metadata (Nebius TokenFactory) so the order is stable across
               // refetches; otherwise keep the given order.
@@ -687,7 +690,6 @@ export function ModelSelectionField({
                     <ModelRow
                       key={model.name}
                       model={model}
-                      isAutoMode={isAutoMode}
                       onToggleVisibility={(visible) =>
                         setVisibility(model.name, visible)
                       }
@@ -768,7 +770,7 @@ export function ModelSelectionField({
         {shouldShowAutoUpdateToggle && (
           <InputHorizontal
             title="Auto Update"
-            description="Update the available models when new models are released."
+            description="Add newly released models automatically. You still choose which models are enabled."
             withLabel
           >
             <Switch

--- a/web/src/sections/modals/languageModels/shared.tsx
+++ b/web/src/sections/modals/languageModels/shared.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Formik, Form, useFormikContext } from "formik";
 import type { FormikConfig } from "formik";
 import { cn } from "@opal/utils";
@@ -620,15 +620,19 @@ export function ModelSelectionField({
   // or originally visible (e.g. an admin-chosen default the config doesn't
   // carry). Hidden models outside that set stay out of the list — enabling
   // them would just be reverted by the next background sync.
-  const originallyVisibleNames = new Set(
-    originalModelsRef.current.filter((m) => m.is_visible).map((m) => m.name)
-  );
-  const autoOfferedModels = models.filter(
-    (m) =>
-      m.is_visible ||
-      autoModelNames?.has(m.name) ||
-      originallyVisibleNames.has(m.name)
-  );
+  // The ref snapshot only diverges from `models` after a user edit, which
+  // changes `models` identity, so it doesn't need to be a dependency itself.
+  const autoOfferedModels = useMemo(() => {
+    const originallyVisibleNames = new Set(
+      originalModelsRef.current.filter((m) => m.is_visible).map((m) => m.name)
+    );
+    return models.filter(
+      (m) =>
+        m.is_visible ||
+        autoModelNames?.has(m.name) ||
+        originallyVisibleNames.has(m.name)
+    );
+  }, [models, autoModelNames]);
 
   // "Select All" only operates on the models shown in the list, which in
   // auto mode is the offered subset rather than every known model.

--- a/web/src/sections/modals/languageModels/utils.ts
+++ b/web/src/sections/modals/languageModels/utils.ts
@@ -111,6 +111,8 @@ export function buildValidationSchema(
 
 /** Base form values that all provider forms share. */
 export interface BaseLLMFormValues {
+  /** Provider type (e.g. "anthropic") — set by every form's initial values. */
+  provider?: string;
   name?: string;
   api_key?: string;
   api_base?: string;


### PR DESCRIPTION
## Description

Fixes #12681.

Enabling auto-update on an LLM provider (or the periodic sync afterwards) moved the global default model to the config's recommended default and hid anything not in the config, throwing away the admin's choices. Four commits, meant to be reviewable one at a time:

- `sync_auto_mode_models` no longer hides or reassigns a model that is currently a default for any flow (chat, vision, ...). This matches the invariant the manual upsert path already enforces ("cannot hide the default model"). The old reassignment block survives only as a repair path for a default that already points at a hidden model, and it now also un-hides the model it repairs to.
- Admins can deselect models while auto-update stays on. The sync stops force-re-showing config models the admin hid (new config models are still added visible, dropped ones still hidden), and the modal keeps checkboxes active in auto mode. The list shown in auto mode is the offered set — models from `/admin/llm/auto-config` plus anything currently or originally visible — so a deselected row doesn't vanish before saving, and models outside the managed set can't be enabled only to get reverted by the next sync.
- Recommendations now resolve through a single `fetch_llm_recommendations()` that takes the newer of the GitHub-hosted config and the bundled `recommended-models.json` (by `updated_at`). GitHub can still push recommendation updates to running deployments without a release, but a new release isn't held back by a stale remote file, and air-gapped deployments work from the bundle instead of getting a 502.
- Bundled config bumped to 1.5 with `claude-fable-5` and `claude-sonnet-5` added to the Anthropic list. I left `claude-opus-4-8` as the recommended default — say the word if you'd rather move that too, but it felt like a product decision.

There's also a small pre-commit hook now that fails any edit to `recommended-models.json` that doesn't bump `updated_at` — with newest-wins resolution, a forgotten bump would silently never take effect.

## How Has This Been Tested?

- `backend/tests/external_dependency_unit/llm/test_llm_provider_auto_mode.py`: 16 tests pass. New coverage: admin default preserved on transition even when the model isn't in the config at all, deselected config model stays hidden across syncs, and the hidden-default repair path. The two tests that asserted the old "config always wins" behavior were rewritten to assert the new semantics.
- New unit tests for config resolution (`backend/tests/unit/onyx/llm/test_auto_update_service.py`): remote-newer wins, bundled-newer wins, fallback when remote is unreachable, naive/aware timestamp comparison doesn't crash, and a guard that the bundled file parses and carries the current Anthropic generation.
- New component tests for `ModelSelectionField` in auto mode (`ModelSelectionField.test.tsx`): rows stay toggleable, a deselected row stays listed so it can be re-selected, hidden models outside the offered set don't render, and select-all only touches the offered set.
- Frontend: `tsc --noEmit`, oxlint, and oxfmt clean; full jest suite for the provider modals passes (10/10).
- Manually verified the resolver against the live GitHub config: it returns the newer bundled 1.5 with fable/sonnet-5 in the Anthropic list, and the modal shows them as deselectable rows.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
