### PR TITLE
fix(chat): stop citation processor from corrupting code fences

### DIFF
--- a/backend/onyx/chat/citation_processor.py
+++ b/backend/onyx/chat/citation_processor.py
@@ -317,8 +317,14 @@ class DynamicCitationProcessor:
                 if len(parts) > 1 and len(parts[1]) > 0:
                     piece_that_comes_after = parts[1][0]
                     if piece_that_comes_after == "\n" and in_code_block(self.llm_out):
-                        self.curr_segment = self.curr_segment.replace(
-                            "```", "```plaintext"
+                        # Only label the specific bare fence we just detected (the
+                        # first ``` in the segment). Using replace() here rewrote
+                        # *every* ``` in the buffer, so any other fence in the same
+                        # segment was corrupted -- e.g. a following ```bash became
+                        # ```plaintextbash, and a closing ``` became ```plaintext
+                        # (which starts a spurious code block).
+                        self.curr_segment = (
+                            parts[0] + "```plaintext" + "```".join(parts[1:])
                         )
 
         # Look for citations in current segment


### PR DESCRIPTION
## Fix: citation processor corrupts code fences by rewriting every `\`\`\`` in the buffer

### Problem
`DynamicCitationProcessor` labels unlabeled code fences with `plaintext` while
streaming, but does it with a replace-all:

```python
self.curr_segment = self.curr_segment.replace("```", "```plaintext")
```

`str.replace` rewrites **every** fence in `curr_segment`, so other fences in the
same buffer get corrupted:

- ` ```bash ` → ` ```plaintextbash `
- closing ` ``` ` → ` ```plaintext ` (starts a spurious code block)

This is streamed to the client **and** persisted to `chat_message.message`, so it
shows up in the UI and survives reloads. Common for command/how-to answers that
contain more than one fence.

### Fix
Only rewrite the specific bare fence that was detected — the first ``` ``` ``` in the
segment, whose following character the code already inspected via `parts[1][0]`:

```python
self.curr_segment = parts[0] + "```plaintext" + "```".join(parts[1:])
```

Intent is preserved (a bare opening fence still gets a `plaintext` language), but
labeled fences and closing fences are left intact. The change is idempotent for
the detected fence and touches nothing else.

### Testing
- Verified on a live v4.0.9 deployment: answers containing a ` ```bash ` block plus
  a bare output block now render cleanly; no ` ```plaintextbash ` / stray
  ` ```plaintext ` in the stored message.
- Happy to add a unit test for `DynamicCitationProcessor` asserting that a
  `bash`-labeled fence adjacent to a bare fence is left unchanged, if maintainers
  want it in this PR.

Fixes #12684


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed a bug where the streaming citation processor relabeled every three‑backtick code fence, corrupting code blocks in the UI and stored messages. It now labels only the detected bare opening fence as plaintext and leaves labeled (e.g., bash) and closing fences unchanged.

<sup>Written for commit e9763688a936cd08b62b5dcaf48a9d2d0b47bc49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

