### PR TITLE
chore(craft): backfill Notion built-in external app

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -32,6 +32,11 @@ from celery.backends.database.session import (  # ty: ignore[unresolved-import]
     ResultModelBase,
 )
 from onyx.db.engine.sql_engine import SqlEngine
+from onyx.utils.variable_functionality import set_is_ee_based_on_env_variable
+
+# Match the app processes' edition so migrations that use versioned
+# implementations (e.g. encrypt_string_to_bytes) resolve the EE variants.
+set_is_ee_based_on_env_variable()
 
 # Make sure in alembic.ini [logger_root] level=INFO is set or most logging will be
 # hidden! (defaults to level=WARN)

--- a/backend/alembic/versions/2e0b2b146de1_backfill_notion_external_app.py
+++ b/backend/alembic/versions/2e0b2b146de1_backfill_notion_external_app.py
@@ -1,0 +1,120 @@
+"""Backfill the Notion built-in external app for existing tenants (cloud only)
+
+Seeds Notion (disabled) per tenant schema with credentials from the
+``EXT_APP_NOTION_*`` env vars, following ``f3a9c1d4b7e2``: frozen snapshot
+of ``onyx/external_apps/providers/notion.py``, no-op when not multi-tenant.
+
+Revision ID: 2e0b2b146de1
+Revises: 7f2a3b9c1d4e
+Create Date: 2026-07-02 16:32:58.801196
+
+"""
+
+import json
+import os
+import uuid
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+from onyx.utils.encryption import encrypt_string_to_bytes
+
+# revision identifiers, used by Alembic.
+revision = "2e0b2b146de1"
+down_revision = "7f2a3b9c1d4e"
+branch_labels = None
+depends_on = None
+
+_APP_TYPE = "NOTION"
+_SLUG = "notion"
+_NAME = "Notion"
+_DESCRIPTION = (
+    "Search, read, and write Notion pages, databases, blocks, and "
+    "comments on the user's behalf."
+)
+_UPSTREAM_URL_PATTERNS = ["https://api\\.notion\\.com/.*"]
+_AUTH_TEMPLATE = {"Authorization": "Bearer {access_token}"}
+_CRED_FIELDS = ("client_id", "client_secret")
+
+
+def _org_credentials() -> dict[str, str]:
+    creds = {
+        field: os.environ.get(f"EXT_APP_{_APP_TYPE}_{field.upper()}", "").strip()
+        for field in _CRED_FIELDS
+    }
+    return creds if all(creds.values()) else {}
+
+
+def _is_cloud() -> bool:
+    """External apps are seeded only in the managed cloud (multi-tenant)
+    deployment; self-hosted installs manage their own apps."""
+    return os.environ.get("MULTI_TENANT", "").lower() == "true"
+
+
+def upgrade() -> None:
+    if not _is_cloud():
+        return
+
+    bind = op.get_bind()
+
+    # Deleting the skill cascades to its external_app + policies/credentials.
+    bind.execute(
+        sa.text(
+            "DELETE FROM skill WHERE slug = :slug OR id IN "
+            "(SELECT skill_id FROM external_app WHERE app_type = :app_type)"
+        ),
+        {"slug": _SLUG, "app_type": _APP_TYPE},
+    )
+
+    skill_id = uuid.uuid4()
+    bind.execute(
+        sa.text(
+            "INSERT INTO skill "
+            "(id, slug, name, description, built_in_skill_id, "
+            " bundle_file_id, bundle_sha256, author_user_id, "
+            " public_permission, enabled) "
+            "VALUES (:id, :slug, :name, :description, :slug, "
+            " NULL, NULL, NULL, 'VIEWER', FALSE)"
+        ).bindparams(sa.bindparam("id", type_=postgresql.UUID(as_uuid=True))),
+        {
+            "id": skill_id,
+            "slug": _SLUG,
+            "name": _NAME,
+            "description": _DESCRIPTION,
+        },
+    )
+
+    bind.execute(
+        sa.text(
+            "INSERT INTO external_app "
+            "(skill_id, app_type, upstream_url_patterns, auth_template, "
+            " organization_credentials) "
+            "VALUES (:skill_id, :app_type, :patterns, :auth, :creds)"
+        ).bindparams(
+            sa.bindparam("skill_id", type_=postgresql.UUID(as_uuid=True)),
+            sa.bindparam("patterns", type_=postgresql.ARRAY(sa.String())),
+            sa.bindparam("auth", type_=postgresql.JSONB()),
+            sa.bindparam("creds", type_=sa.LargeBinary()),
+        ),
+        {
+            "skill_id": skill_id,
+            "app_type": _APP_TYPE,
+            "patterns": _UPSTREAM_URL_PATTERNS,
+            "auth": _AUTH_TEMPLATE,
+            "creds": encrypt_string_to_bytes(json.dumps(_org_credentials())),
+        },
+    )
+
+
+def downgrade() -> None:
+    if not _is_cloud():
+        return
+
+    op.get_bind().execute(
+        sa.text(
+            "DELETE FROM skill WHERE id IN "
+            "(SELECT skill_id FROM external_app WHERE app_type = :app_type)"
+        ),
+        {"app_type": _APP_TYPE},
+    )

--- a/backend/alembic/versions/2e0b2b146de1_backfill_notion_external_app.py
+++ b/backend/alembic/versions/2e0b2b146de1_backfill_notion_external_app.py
@@ -5,7 +5,7 @@ Seeds Notion (disabled) per tenant schema with credentials from the
 of ``onyx/external_apps/providers/notion.py``, no-op when not multi-tenant.
 
 Revision ID: 2e0b2b146de1
-Revises: 7f2a3b9c1d4e
+Revises: d49e41659191
 Create Date: 2026-07-02 16:32:58.801196
 
 """
@@ -22,7 +22,7 @@ from onyx.utils.encryption import encrypt_string_to_bytes
 
 # revision identifiers, used by Alembic.
 revision = "2e0b2b146de1"
-down_revision = "7f2a3b9c1d4e"
+down_revision = "d49e41659191"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/f3a9c1d4b7e2_provision_built_in_external_apps.py
+++ b/backend/alembic/versions/f3a9c1d4b7e2_provision_built_in_external_apps.py
@@ -11,11 +11,10 @@ catalog is re-created (disabled) with credentials sourced from the populated
 ``EXT_APP_<APP_TYPE>_<FIELD>`` env vars. Re-seeding this way also clears any
 admin enabled-state and per-action policy overrides on the built-in apps.
 
-Self-contained by design: the app catalog, env parsing, and credential
-encryption are inlined rather than imported from application code, so the
-migration stays reproducible and independent of code that may change later. The
-catalog below is a frozen 2026-06 snapshot of ``onyx/external_apps/providers/*``;
-the encryption mirrors ``onyx.utils.encryption._encrypt_string``.
+The app catalog and env parsing are inlined rather than imported from
+application code, so the migration stays reproducible and independent of code
+that may change later. The catalog below is a frozen 2026-06 snapshot of
+``onyx/external_apps/providers/*``.
 
 Revision ID: f3a9c1d4b7e2
 Revises: 8f2c4a1d9e3b
@@ -27,15 +26,12 @@ import json
 import logging
 import os
 import uuid
-from os import urandom
 
 import sqlalchemy as sa
 from alembic import op
-from cryptography.hazmat.primitives import padding
-from cryptography.hazmat.primitives.ciphers import algorithms
-from cryptography.hazmat.primitives.ciphers import Cipher
-from cryptography.hazmat.primitives.ciphers import modes
 from sqlalchemy.dialects import postgresql
+
+from onyx.utils.encryption import encrypt_string_to_bytes
 
 # revision identifiers, used by Alembic.
 revision = "f3a9c1d4b7e2"
@@ -126,29 +122,6 @@ _BUILT_IN_APPS: list[dict] = [
 ]
 
 
-def _trimmed_key(key: str) -> bytes:
-    encoded = key.encode()
-    for size in (32, 24, 16):
-        if len(encoded) >= size:
-            return encoded[:size]
-    raise RuntimeError("Invalid ENCRYPTION_KEY_SECRET - too short")
-
-
-def _encrypt(raw: str) -> bytes:
-    """AES-CBC (PKCS7, random IV prepended), matching the EE encryption used by
-    the EncryptedJson column. Falls back to plaintext bytes when no key is set,
-    matching the MIT path — though in practice this only runs in the cloud."""
-    key = os.environ.get("ENCRYPTION_KEY_SECRET") or ""
-    if not key:
-        return raw.encode()
-    iv = urandom(16)
-    padder = padding.PKCS7(algorithms.AES.block_size).padder()
-    padded = padder.update(raw.encode()) + padder.finalize()
-    cipher = Cipher(algorithms.AES(_trimmed_key(key)), modes.CBC(iv))
-    encryptor = cipher.encryptor()
-    return iv + encryptor.update(padded) + encryptor.finalize()
-
-
 def _org_credentials(app_type: str) -> dict[str, str]:
     """Credentials from EXT_APP_<APP_TYPE>_<FIELD> env vars. All-or-nothing:
     partial config is treated as unconfigured (stored as an empty mapping)."""
@@ -231,7 +204,9 @@ def upgrade() -> None:
                 "app_type": app_type,
                 "patterns": app["upstream_url_patterns"],
                 "auth": _AUTH_TEMPLATE,
-                "creds": _encrypt(json.dumps(_org_credentials(app_type))),
+                "creds": encrypt_string_to_bytes(
+                    json.dumps(_org_credentials(app_type))
+                ),
             },
         )
         created += 1


### PR DESCRIPTION
## Description

Backfills the Notion built-in external app for existing managed-cloud tenant schemas.

This seeds the built-in Notion skill and external app as disabled, uses `EXT_APP_NOTION_*` organization credentials when present, and no-ops outside multi-tenant deployments.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backfills the built-in Notion external app for managed-cloud tenants and standardizes credential encryption. Also sets the EE flag in Alembic so versioned implementations (e.g., `encrypt_string_to_bytes`) resolve correctly.

- **Migration**
  - Runs only when `MULTI_TENANT=true`; self-hosted is unaffected.
  - Deletes any existing Notion skill/app, then seeds a disabled `notion` skill and external app with Notion API URL pattern and Bearer auth; uses `EXT_APP_NOTION_CLIENT_ID`/`EXT_APP_NOTION_CLIENT_SECRET` when provided.
  - Replaces inline AES code in the built-in apps seed migration with `encrypt_string_to_bytes`, and uses the same in this Notion backfill.
  - Sets EE mode in `alembic/env.py` to match the app’s edition so versioned encryption resolves.

<sup>Written for commit ab2f2704196ac3ea05286644ce298a43cfddf6e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

