### PR TITLE
chore: agents md vespa

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ Onyx uses Celery for asynchronous task processing with multiple specialized work
    - Coordinates core background tasks and system-wide operations
    - Handles connector management, document sync, pruning, and periodic checks
    - Runs with 4 threads concurrency
-   - Tasks: connector deletion, vespa sync, pruning, LLM model updates, user file sync
+   - Tasks: connector deletion, document-index sync, pruning, LLM model updates, user file sync
 
 2. **Docfetching Worker** (`docfetching`)
 
@@ -46,14 +46,14 @@ Onyx uses Celery for asynchronous task processing with multiple specialized work
      - Upserts documents to PostgreSQL
      - Chunks documents and adds contextual information
      - Embeds chunks via model server
-     - Writes chunks to Vespa vector database
+     - Writes chunks to the OpenSearch-backed document index
      - Updates document metadata
    - Configurable concurrency (default from env)
 
 4. **Light Worker** (`light`)
 
    - Handles lightweight, fast operations
-   - Tasks: vespa metadata sync, connector deletion, doc permissions upsert, checkpoint cleanup, index attempt cleanup
+   - Tasks: document-index metadata sync, connector deletion, doc permissions upsert, checkpoint cleanup, index attempt cleanup
    - Higher concurrency for quick tasks
 
 5. **Heavy Worker** (`heavy`)
@@ -81,7 +81,7 @@ Onyx uses Celery for asynchronous task processing with multiple specialized work
    - Schedules tasks like:
      - Indexing checks (every 15 seconds)
      - Connector deletion checks (every 20 seconds)
-     - Vespa sync checks (every 20 seconds)
+     - Document-index metadata sync checks (every 20 seconds)
      - Pruning checks (every 20 seconds)
      - Monitoring tasks (every 5 minutes)
      - Cleanup tasks (hourly)
@@ -141,9 +141,14 @@ comments that only describe the instantaneous change (e.g. what was just added/r
 - **Backend**: Python 3.13, FastAPI, SQLAlchemy, Alembic, Celery
 - **Frontend**: Next.js 15+, React 18, TypeScript, Tailwind CSS
 - **Database**: PostgreSQL with Redis caching
-- **Search**: Vespa vector database
+- **Search**: OpenSearch-backed keyword and vector document index
 - **Auth**: OAuth2, SAML, multi-provider support
 - **AI/ML**: LangChain, LiteLLM, multiple embedding models
+
+OpenSearch is the current document index backend for search and indexing. Some
+legacy modules, Celery task names, and migration helpers still mention Vespa; treat
+those as compatibility or migration artifacts unless the active `DocumentIndex`
+factory/config path explicitly uses them.
 
 ### Directory Structure
 
@@ -154,7 +159,7 @@ backend/
 │   ├── chat/                    # Chat functionality & LLM interactions
 │   ├── connectors/              # Data source connectors
 │   ├── db/                      # Database models & operations
-│   ├── document_index/          # Vespa integration
+│   ├── document_index/          # OpenSearch-backed DocumentIndex integration
 │   ├── federated_connectors/    # External search connectors
 │   ├── llm/                     # LLM provider integrations
 │   └── server/                  # API endpoints & routers
@@ -230,7 +235,7 @@ pytest -xv backend/tests/unit
 ### External Dependency Unit Tests
 
 These tests assume that all external dependencies of Onyx are available and callable (e.g. Postgres, Redis,
-MinIO/S3, Vespa are running + OpenAI can be called + any request to the internet is fine + etc.).
+MinIO/S3, OpenSearch are running + OpenAI can be called + any request to the internet is fine + etc.).
 
 However, the actual Onyx containers are not running and with these tests we call the function to test directly.
 We can also mock components/calls at will.


### PR DESCRIPTION
## Description

remove reference to vespa from agents.md

## How Has This Been Tested?

n/a

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced Vespa references in `AGENTS.md` with the current `OpenSearch`-backed document index to reflect the active search backend and clarify worker task names and scheduler checks.

Also updates directory descriptions and external test dependencies to match `OpenSearch`; no code behavior changes.

<sup>Written for commit f2e9789407a9d54660fa4750ff9c06c16933f635. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

