### PR TITLE
chore(helm): bump chart version to 0.6.8

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.6.7
+version: 0.6.8
 appVersion: latest
 annotations:
   category: Productivity


### PR DESCRIPTION
## Description

- Bump the Onyx Helm chart version `0.6.7 → 0.6.8`

## How Has This Been Tested?

Chart-only version bump; no functional change — the `port` queue wiring already exists in the Helm template and `supervisord.conf`.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

