### PR TITLE
feat(settings): convert Custom Retention to an inline days input

### DIFF
--- a/web/src/views/admin/ChatPreferencesPage.tsx
+++ b/web/src/views/admin/ChatPreferencesPage.tsx
@@ -22,6 +22,8 @@ import {
   SvgExternalLink,
   SvgOrganization,
   SvgRefreshCw,
+  SvgRevert,
+  SvgChevronDown,
 } from "@opal/icons";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 import {
@@ -55,6 +57,7 @@ import {
   Tooltip,
 } from "@opal/components";
 import Modal from "@/refresh-components/Modal";
+import GenericConfirmModal from "@/sections/modals/GenericConfirmModal";
 import { Switch } from "@opal/components";
 import { useMcpServersForAgentEditor } from "@/lib/agents/hooks";
 import useOpenApiTools from "@/hooks/useOpenApiTools";
@@ -370,10 +373,20 @@ function FileSizeLimitFields({
   );
 }
 
-// Retention presets offered directly in the dropdown. Any other (positive)
-// value is surfaced via the "Custom…" option. The backend stores
-// maximum_chat_retention_days as a free-form number, so these are purely UI.
-const RETENTION_PRESETS: number[] = [7, 30, 60, 90, 365];
+// Retention presets offered directly in the dropdown, matching the Figma
+// design. Any other (positive) value is surfaced via "Custom Retention". The
+// backend stores maximum_chat_retention_days as a free-form number of days, so
+// these are purely UI ("1 year" is just a label for 365).
+interface RetentionPreset {
+  days: number;
+  label: string;
+}
+const RETENTION_PRESETS: RetentionPreset[] = [
+  { days: 365, label: "1 year" },
+  { days: 30, label: "30 days" },
+  { days: 60, label: "60 days" },
+  { days: 90, label: "90 days" },
+];
 // FE-only guard: the backend imposes no upper bound, so cap absurd input.
 const MAX_RETENTION_DAYS = 36500; // ~100 years
 const CUSTOM_RETENTION_VALUE = "custom";
@@ -382,7 +395,7 @@ const FOREVER_RETENTION_VALUE = "forever";
 // Pure predicate — lives at module scope so it can be referenced inside
 // useEffect without an exhaustive-deps suppression.
 const valueIsCustomRetention = (v: number | null): v is number =>
-  v !== null && !RETENTION_PRESETS.includes(v);
+  v !== null && !RETENTION_PRESETS.some((preset) => preset.days === v);
 
 // True only when the string is one or more digits within the allowed range.
 // parseInt alone would silently accept "1.5" → 1 or "7abc" → 7, so guard with
@@ -392,21 +405,48 @@ const isValidCustomRetention = (raw: string): boolean =>
   parseInt(raw, 10) > 0 &&
   parseInt(raw, 10) <= MAX_RETENTION_DAYS;
 
+// A "reduction" shortens the retention window, making more chats eligible for
+// permanent deletion — so it warrants a confirmation. null = Forever (∞).
+const isRetentionReduction = (
+  current: number | null,
+  next: number | null
+): boolean => {
+  if (next === null) return false; // Forever is never a reduction
+  if (current === null) return true; // Forever → finite shortens retention
+  return next < current;
+};
+
 interface RetentionFieldProps {
   value: number | null;
   disabled: boolean;
   onSave: (value: number | null) => void;
 }
 
-// Chat-retention control: a preset dropdown plus a "Custom…" option that
-// reveals a numeric "days" input. Drop-in replacement for the bare
-// <InputSelect>; the persisted shape (number | null) is unchanged, so any
+// Chat-retention control: a preset dropdown where "Custom Retention" converts
+// the dropdown in place into a numeric "days" input (with revert + reopen
+// affordances). The persisted shape (number | null) is unchanged, so any
 // existing value — preset or not — round-trips correctly.
 function RetentionField({ value, disabled, onSave }: RetentionFieldProps) {
   const [showCustom, setShowCustom] = useState(valueIsCustomRetention(value));
   const [customDays, setCustomDays] = useState(
     valueIsCustomRetention(value) ? String(value) : ""
   );
+  // Controlled so the "More" chevron can reopen the presets from custom mode.
+  const [selectOpen, setSelectOpen] = useState(false);
+  // A pending reduction awaiting confirmation (always a positive number; null
+  // means nothing is pending).
+  const [pendingValue, setPendingValue] = useState<number | null>(null);
+
+  const customInputRef = useRef<HTMLInputElement>(null);
+  const focusCustomOnShowRef = useRef(false);
+  // Set when a preset is chosen from the dropdown, so closing the dropdown
+  // doesn't bounce a still-custom value back into the input (see onOpenChange).
+  const pickedPresetRef = useRef(false);
+
+  const syncToValue = (v: number | null) => {
+    setShowCustom(valueIsCustomRetention(v));
+    setCustomDays(valueIsCustomRetention(v) ? String(v) : "");
+  };
 
   // Re-sync when the stored value changes externally (e.g. another admin),
   // but only when our local state matches the last value we persisted.
@@ -414,78 +454,124 @@ function RetentionField({ value, disabled, onSave }: RetentionFieldProps) {
   useEffect(() => {
     if (value === lastSavedRef.current) return;
     lastSavedRef.current = value;
-    setShowCustom(valueIsCustomRetention(value));
-    setCustomDays(valueIsCustomRetention(value) ? String(value) : "");
+    syncToValue(value);
   }, [value]);
 
-  const selectValue = showCustom
-    ? CUSTOM_RETENTION_VALUE
-    : value === null
-      ? FOREVER_RETENTION_VALUE
-      : String(value);
+  // Focus the custom input only when the user explicitly picks "Custom
+  // Retention" (never on initial mount for an already-custom value).
+  useEffect(() => {
+    if (showCustom && focusCustomOnShowRef.current) {
+      customInputRef.current?.focus();
+      focusCustomOnShowRef.current = false;
+    }
+  }, [showCustom]);
+
+  // Only read while in select mode. A stored custom value (transiently visible
+  // here after "More") maps to no item, so the trigger shows the placeholder
+  // until the user picks — at which point onValueChange fires reliably.
+  const selectValue = value === null ? FOREVER_RETENTION_VALUE : String(value);
 
   const persist = (next: number | null) => {
     lastSavedRef.current = next;
     onSave(next);
   };
 
+  // Route every save through here so reductions (preset or custom) are
+  // confirmed before touching the persisted value.
+  const requestPersist = (next: number | null) => {
+    if (next === value) return;
+    if (isRetentionReduction(value, next)) {
+      setPendingValue(next);
+      return;
+    }
+    persist(next);
+  };
+
   const handleSelectChange = (next: string) => {
     if (next === CUSTOM_RETENTION_VALUE) {
-      // Reveal the input; don't persist until a valid number is entered.
+      focusCustomOnShowRef.current = true;
       setShowCustom(true);
       return;
     }
+    pickedPresetRef.current = true;
     setShowCustom(false);
-    setCustomDays("");
-    persist(next === FOREVER_RETENTION_VALUE ? null : parseInt(next, 10));
+    requestPersist(
+      next === FOREVER_RETENTION_VALUE ? null : parseInt(next, 10)
+    );
+  };
+
+  // Closing the reopened dropdown without picking a preset returns to the
+  // custom input (the stored value is still custom).
+  const handleOpenChange = (open: boolean) => {
+    setSelectOpen(open);
+    if (open) return;
+    if (!pickedPresetRef.current && valueIsCustomRetention(value)) {
+      setShowCustom(true);
+    }
+    pickedPresetRef.current = false;
   };
 
   const handleCustomBlur = () => {
-    // Empty/invalid input reverts to the last persisted selection.
+    // Empty input reverts the field to Forever.
+    if (customDays.trim() === "") {
+      setShowCustom(false);
+      requestPersist(null);
+      return;
+    }
+    // Invalid input reverts to the last persisted selection.
     if (!isValidCustomRetention(customDays)) {
-      setShowCustom(valueIsCustomRetention(value));
-      setCustomDays(valueIsCustomRetention(value) ? String(value) : "");
+      syncToValue(value);
       return;
     }
 
     const parsed = parseInt(customDays, 10);
     const normalized = String(parsed);
     if (normalized !== customDays) setCustomDays(normalized);
-    if (parsed !== value) persist(parsed);
+    requestPersist(parsed);
+  };
+
+  // Restore Default → back to Forever.
+  const handleRestoreDefault = () => {
+    setShowCustom(false);
+    requestPersist(null);
+  };
+
+  // More → leave custom mode and reopen the preset dropdown.
+  const handleReopenPresets = () => {
+    setShowCustom(false);
+    setSelectOpen(true);
+  };
+
+  const handleConfirmReduction = () => {
+    if (pendingValue !== null) persist(pendingValue);
+    setPendingValue(null);
+  };
+
+  const handleCancelReduction = () => {
+    // Discard the pending change and restore the UI to the persisted value.
+    setPendingValue(null);
+    syncToValue(value);
   };
 
   const customInvalid =
     customDays !== "" && !isValidCustomRetention(customDays);
 
+  const iconButtonProps = {
+    prominence: "tertiary",
+    size: "xs",
+    type: "button",
+    disabled,
+  } as const;
+
   return (
     <div className="flex flex-col gap-2 w-full">
-      <InputSelect
-        value={selectValue}
-        onValueChange={handleSelectChange}
-        disabled={disabled}
-      >
-        <InputSelect.Trigger />
-        <InputSelect.Content>
-          <InputSelect.Item value={FOREVER_RETENTION_VALUE}>
-            Forever
-          </InputSelect.Item>
-          {RETENTION_PRESETS.map((d) => (
-            <InputSelect.Item key={d} value={String(d)}>
-              {d} days
-            </InputSelect.Item>
-          ))}
-          <InputSelect.Item value={CUSTOM_RETENTION_VALUE}>
-            Custom…
-          </InputSelect.Item>
-        </InputSelect.Content>
-      </InputSelect>
-
-      {showCustom && (
+      {showCustom ? (
         <div className="flex flex-col gap-1 w-full">
           <InputTypeIn
+            ref={customInputRef}
             inputMode="numeric"
             pattern="[0-9]*"
-            placeholder="Enter number of days"
+            placeholder="In days"
             value={customDays}
             onChange={(e) => setCustomDays(e.target.value)}
             onBlur={handleCustomBlur}
@@ -493,9 +579,20 @@ function RetentionField({ value, disabled, onSave }: RetentionFieldProps) {
               disabled ? "disabled" : customInvalid ? "error" : undefined
             }
             rightChildren={
-              <Text font="secondary-body" color="text-03">
-                days
-              </Text>
+              <div className="flex flex-row items-center gap-0.5">
+                <Button
+                  icon={SvgRevert}
+                  tooltip="Restore Default"
+                  onClick={handleRestoreDefault}
+                  {...iconButtonProps}
+                />
+                <Button
+                  icon={SvgChevronDown}
+                  tooltip="More"
+                  onClick={handleReopenPresets}
+                  {...iconButtonProps}
+                />
+              </div>
             }
           />
           {customInvalid && (
@@ -504,6 +601,41 @@ function RetentionField({ value, disabled, onSave }: RetentionFieldProps) {
             </Text>
           )}
         </div>
+      ) : (
+        <InputSelect
+          value={selectValue}
+          onValueChange={handleSelectChange}
+          open={selectOpen}
+          onOpenChange={handleOpenChange}
+          disabled={disabled}
+        >
+          <InputSelect.Trigger />
+          <InputSelect.Content>
+            <InputSelect.Item value={FOREVER_RETENTION_VALUE}>
+              Forever
+            </InputSelect.Item>
+            {RETENTION_PRESETS.map((preset) => (
+              <InputSelect.Item key={preset.days} value={String(preset.days)}>
+                {preset.label}
+              </InputSelect.Item>
+            ))}
+            <InputSelect.Item value={CUSTOM_RETENTION_VALUE}>
+              Custom Retention
+            </InputSelect.Item>
+          </InputSelect.Content>
+        </InputSelect>
+      )}
+
+      {pendingValue !== null && (
+        <GenericConfirmModal
+          title="Reduce chat retention?"
+          message={`Chats with no activity for longer than ${pendingValue} ${
+            pendingValue === 1 ? "day" : "days"
+          } will be permanently deleted. This cannot be undone.`}
+          confirmText="Reduce retention"
+          onClose={handleCancelReduction}
+          onConfirm={handleConfirmReduction}
+        />
       )}
     </div>
   );

--- a/web/src/views/admin/ChatPreferencesPage.tsx
+++ b/web/src/views/admin/ChatPreferencesPage.tsx
@@ -579,7 +579,7 @@ function RetentionField({ value, disabled, onSave }: RetentionFieldProps) {
               disabled ? "disabled" : customInvalid ? "error" : undefined
             }
             rightChildren={
-              <div className="flex flex-row items-center gap-0.5">
+              <Section flexDirection="row" gap={0.125} width="fit" height="fit">
                 <Button
                   icon={SvgRevert}
                   tooltip="Restore Default"
@@ -592,7 +592,7 @@ function RetentionField({ value, disabled, onSave }: RetentionFieldProps) {
                   onClick={handleReopenPresets}
                   {...iconButtonProps}
                 />
-              </div>
+              </Section>
             }
           />
           {customInvalid && (

--- a/web/src/views/admin/ChatPreferencesPage.tsx
+++ b/web/src/views/admin/ChatPreferencesPage.tsx
@@ -382,10 +382,11 @@ interface RetentionPreset {
   label: string;
 }
 const RETENTION_PRESETS: RetentionPreset[] = [
-  { days: 365, label: "1 year" },
+  { days: 7, label: "7 days" },
   { days: 30, label: "30 days" },
   { days: 60, label: "60 days" },
   { days: 90, label: "90 days" },
+  { days: 365, label: "1 year" },
 ];
 // FE-only guard: the backend imposes no upper bound, so cap absurd input.
 const MAX_RETENTION_DAYS = 36500; // ~100 years

--- a/web/src/views/admin/ChatPreferencesPage.tsx
+++ b/web/src/views/admin/ChatPreferencesPage.tsx
@@ -619,6 +619,7 @@ function RetentionField({ value, disabled, onSave }: RetentionFieldProps) {
                 {preset.label}
               </InputSelect.Item>
             ))}
+            <InputSelect.Separator />
             <InputSelect.Item value={CUSTOM_RETENTION_VALUE}>
               Custom Retention
             </InputSelect.Item>

--- a/web/tests/e2e/admin/chat_retention_control.spec.ts
+++ b/web/tests/e2e/admin/chat_retention_control.spec.ts
@@ -1,0 +1,200 @@
+import { Page } from "@playwright/test";
+import { test, expect } from "@tests/e2e/fixtures/eeFeatures";
+import { loginAs } from "@tests/e2e/utils/auth";
+
+const CHAT_PREFS_URL = "/admin/configuration/chat-preferences";
+
+function retentionField(page: Page) {
+  return page.locator("label").filter({ hasText: "Keep Chat History" });
+}
+
+function retentionTrigger(page: Page) {
+  return retentionField(page).locator('[role="combobox"]');
+}
+
+function customInput(page: Page) {
+  return retentionField(page).getByPlaceholder("In days");
+}
+
+// First icon button inside the custom input is "Restore Default" (the second
+// is "More"). Tooltips don't set an accessible name, so target positionally.
+function restoreDefaultButton(page: Page) {
+  return retentionField(page)
+    .locator(".opal-input")
+    .getByRole("button")
+    .first();
+}
+
+async function expandAdvancedOptions(page: Page): Promise<void> {
+  await expect(page.locator('[aria-label="admin-page-title"]')).toBeVisible({
+    timeout: 10000,
+  });
+
+  const header = page.getByText("Advanced Options", { exact: true });
+  await expect(header).toBeVisible({ timeout: 10000 });
+
+  const label = retentionField(page).first();
+  if (await label.isVisible().catch(() => false)) return;
+
+  await header.scrollIntoViewIfNeeded();
+  await header.click();
+  await expect(label).toBeVisible({ timeout: 5000 });
+}
+
+async function gotoChatPreferences(page: Page): Promise<void> {
+  await page.goto(CHAT_PREFS_URL);
+  await page.waitForLoadState("networkidle");
+  await expandAdvancedOptions(page);
+}
+
+// Confirm a reduction (Forever -> finite value) and wait for the save toast.
+async function confirmReduction(page: Page): Promise<void> {
+  await expect(page.getByText("Reduce chat retention?")).toBeVisible({
+    timeout: 5000,
+  });
+  await page.getByRole("button", { name: "Reduce retention" }).click();
+  await expect(page.getByText("Settings updated")).toBeVisible({
+    timeout: 5000,
+  });
+}
+
+// Enter a custom retention of `days` starting from a Forever/larger value.
+async function setCustomRetention(page: Page, days: string): Promise<void> {
+  await retentionTrigger(page).click();
+  await page
+    .getByRole("option", { name: "Custom Retention", exact: true })
+    .click();
+  await expect(customInput(page)).toBeVisible();
+  await customInput(page).fill(days);
+  await customInput(page).blur();
+  await confirmReduction(page);
+}
+
+async function resetToForever(page: Page): Promise<void> {
+  await gotoChatPreferences(page);
+
+  // Custom-input mode: Restore Default returns to Forever (an increase, so no
+  // confirmation modal).
+  if (
+    await customInput(page)
+      .isVisible()
+      .catch(() => false)
+  ) {
+    await restoreDefaultButton(page).click();
+    await expect(page.getByText("Settings updated"))
+      .toBeVisible({ timeout: 5000 })
+      .catch(() => {});
+    return;
+  }
+
+  const trigger = retentionTrigger(page);
+  if (((await trigger.textContent()) ?? "").includes("Forever")) return;
+  await trigger.click();
+  await page.getByRole("option", { name: "Forever", exact: true }).click();
+  await expect(page.getByText("Settings updated")).toBeVisible({
+    timeout: 5000,
+  });
+}
+
+test.describe("Chat retention control @exclusive", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.context().clearCookies();
+    await loginAs(page, "admin");
+  });
+
+  test.afterEach(async ({ page, eeEnabled }) => {
+    if (!eeEnabled) return;
+    await resetToForever(page).catch(() => {});
+  });
+
+  test("dropdown lists the configured retention presets", async ({
+    page,
+    eeEnabled,
+  }) => {
+    test.skip(!eeEnabled, "Chat retention requires an Enterprise license");
+    await gotoChatPreferences(page);
+
+    await retentionTrigger(page).click();
+
+    for (const label of [
+      "Forever",
+      "1 year",
+      "30 days",
+      "60 days",
+      "90 days",
+      "Custom Retention",
+    ]) {
+      await expect(
+        page.getByRole("option", { name: label, exact: true })
+      ).toBeVisible();
+    }
+    // The legacy "7 days" preset was intentionally removed.
+    await expect(
+      page.getByRole("option", { name: "7 days", exact: true })
+    ).toHaveCount(0);
+
+    await page.keyboard.press("Escape");
+  });
+
+  test("Custom Retention converts the dropdown into a days input that persists", async ({
+    page,
+    eeEnabled,
+  }) => {
+    test.skip(!eeEnabled, "Chat retention requires an Enterprise license");
+    await resetToForever(page);
+    await gotoChatPreferences(page);
+
+    await setCustomRetention(page, "45");
+
+    // In-place conversion: the dropdown is gone, replaced by the input.
+    await expect(customInput(page)).toBeVisible();
+    await expect(retentionTrigger(page)).toHaveCount(0);
+
+    // 45 is not a preset, so it round-trips back into the custom input.
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+    await expandAdvancedOptions(page);
+    await expect(customInput(page)).toHaveValue("45");
+  });
+
+  test("Restore Default returns retention to Forever", async ({
+    page,
+    eeEnabled,
+  }) => {
+    test.skip(!eeEnabled, "Chat retention requires an Enterprise license");
+    await resetToForever(page);
+    await gotoChatPreferences(page);
+
+    await setCustomRetention(page, "45");
+
+    await restoreDefaultButton(page).click();
+    await expect(page.getByText("Settings updated")).toBeVisible({
+      timeout: 5000,
+    });
+
+    await expect(retentionTrigger(page)).toContainText("Forever");
+  });
+
+  test("reducing retention prompts confirmation; cancel keeps the current value", async ({
+    page,
+    eeEnabled,
+  }) => {
+    test.skip(!eeEnabled, "Chat retention requires an Enterprise license");
+    await resetToForever(page);
+    await gotoChatPreferences(page);
+
+    await retentionTrigger(page).click();
+    await page.getByRole("option", { name: "30 days", exact: true }).click();
+
+    await expect(page.getByText("Reduce chat retention?")).toBeVisible({
+      timeout: 5000,
+    });
+
+    // Cancel by dismissing the modal (no inputs inside, so Escape closes it).
+    await page.keyboard.press("Escape");
+    await expect(page.getByText("Reduce chat retention?")).toHaveCount(0);
+
+    // The value was not changed.
+    await expect(retentionTrigger(page)).toContainText("Forever");
+  });
+});

--- a/web/tests/e2e/admin/chat_retention_control.spec.ts
+++ b/web/tests/e2e/admin/chat_retention_control.spec.ts
@@ -1,100 +1,6 @@
-import { Page } from "@playwright/test";
 import { test, expect } from "@tests/e2e/fixtures/eeFeatures";
 import { loginAs } from "@tests/e2e/utils/auth";
-
-const CHAT_PREFS_URL = "/admin/configuration/chat-preferences";
-
-function retentionField(page: Page) {
-  return page.locator("label").filter({ hasText: "Keep Chat History" });
-}
-
-function retentionTrigger(page: Page) {
-  return retentionField(page).locator('[role="combobox"]');
-}
-
-function customInput(page: Page) {
-  return retentionField(page).getByPlaceholder("In days");
-}
-
-// First icon button inside the custom input is "Restore Default" (the second
-// is "More"). Tooltips don't set an accessible name, so target positionally.
-function restoreDefaultButton(page: Page) {
-  return retentionField(page)
-    .locator(".opal-input")
-    .getByRole("button")
-    .first();
-}
-
-async function expandAdvancedOptions(page: Page): Promise<void> {
-  await expect(page.locator('[aria-label="admin-page-title"]')).toBeVisible({
-    timeout: 10000,
-  });
-
-  const header = page.getByText("Advanced Options", { exact: true });
-  await expect(header).toBeVisible({ timeout: 10000 });
-
-  const label = retentionField(page).first();
-  if (await label.isVisible().catch(() => false)) return;
-
-  await header.scrollIntoViewIfNeeded();
-  await header.click();
-  await expect(label).toBeVisible({ timeout: 5000 });
-}
-
-async function gotoChatPreferences(page: Page): Promise<void> {
-  await page.goto(CHAT_PREFS_URL);
-  await page.waitForLoadState("networkidle");
-  await expandAdvancedOptions(page);
-}
-
-// Confirm a reduction (Forever -> finite value) and wait for the save toast.
-async function confirmReduction(page: Page): Promise<void> {
-  await expect(page.getByText("Reduce chat retention?")).toBeVisible({
-    timeout: 5000,
-  });
-  await page.getByRole("button", { name: "Reduce retention" }).click();
-  await expect(page.getByText("Settings updated")).toBeVisible({
-    timeout: 5000,
-  });
-}
-
-// Enter a custom retention of `days` starting from a Forever/larger value.
-async function setCustomRetention(page: Page, days: string): Promise<void> {
-  await retentionTrigger(page).click();
-  await page
-    .getByRole("option", { name: "Custom Retention", exact: true })
-    .click();
-  await expect(customInput(page)).toBeVisible();
-  await customInput(page).fill(days);
-  await customInput(page).blur();
-  await confirmReduction(page);
-}
-
-async function resetToForever(page: Page): Promise<void> {
-  await gotoChatPreferences(page);
-
-  // Custom-input mode: Restore Default returns to Forever (an increase, so no
-  // confirmation modal).
-  if (
-    await customInput(page)
-      .isVisible()
-      .catch(() => false)
-  ) {
-    await restoreDefaultButton(page).click();
-    await expect(page.getByText("Settings updated"))
-      .toBeVisible({ timeout: 5000 })
-      .catch(() => {});
-    return;
-  }
-
-  const trigger = retentionTrigger(page);
-  if (((await trigger.textContent()) ?? "").includes("Forever")) return;
-  await trigger.click();
-  await page.getByRole("option", { name: "Forever", exact: true }).click();
-  await expect(page.getByText("Settings updated")).toBeVisible({
-    timeout: 5000,
-  });
-}
+import { ChatPreferencesPage } from "@tests/e2e/pages/ChatPreferencesPage";
 
 test.describe("Chat retention control @exclusive", () => {
   test.beforeEach(async ({ page }) => {
@@ -104,7 +10,9 @@ test.describe("Chat retention control @exclusive", () => {
 
   test.afterEach(async ({ page, eeEnabled }) => {
     if (!eeEnabled) return;
-    await resetToForever(page).catch(() => {});
+    await new ChatPreferencesPage(page)
+      .resetRetentionToForever()
+      .catch(() => {});
   });
 
   test("dropdown lists the configured retention presets", async ({
@@ -112,10 +20,10 @@ test.describe("Chat retention control @exclusive", () => {
     eeEnabled,
   }) => {
     test.skip(!eeEnabled, "Chat retention requires an Enterprise license");
-    await gotoChatPreferences(page);
+    const chatPrefs = new ChatPreferencesPage(page);
+    await chatPrefs.gotoAdvancedOptions();
 
-    await retentionTrigger(page).click();
-
+    await chatPrefs.openRetentionDropdown();
     for (const label of [
       "Forever",
       "7 days",
@@ -125,9 +33,7 @@ test.describe("Chat retention control @exclusive", () => {
       "1 year",
       "Custom Retention",
     ]) {
-      await expect(
-        page.getByRole("option", { name: label, exact: true })
-      ).toBeVisible();
+      await expect(chatPrefs.retentionOption(label)).toBeVisible();
     }
 
     await page.keyboard.press("Escape");
@@ -138,20 +44,19 @@ test.describe("Chat retention control @exclusive", () => {
     eeEnabled,
   }) => {
     test.skip(!eeEnabled, "Chat retention requires an Enterprise license");
-    await resetToForever(page);
-    await gotoChatPreferences(page);
+    const chatPrefs = new ChatPreferencesPage(page);
+    await chatPrefs.resetRetentionToForever();
+    await chatPrefs.gotoAdvancedOptions();
 
-    await setCustomRetention(page, "45");
+    await chatPrefs.setCustomRetention("45");
 
     // In-place conversion: the dropdown is gone, replaced by the input.
-    await expect(customInput(page)).toBeVisible();
-    await expect(retentionTrigger(page)).toHaveCount(0);
+    await expect(chatPrefs.retentionCustomInput).toBeVisible();
+    await expect(chatPrefs.retentionTrigger).toHaveCount(0);
 
     // 45 is not a preset, so it round-trips back into the custom input.
-    await page.reload();
-    await page.waitForLoadState("networkidle");
-    await expandAdvancedOptions(page);
-    await expect(customInput(page)).toHaveValue("45");
+    await chatPrefs.reloadAdvancedOptions();
+    await expect(chatPrefs.retentionCustomInput).toHaveValue("45");
   });
 
   test("Restore Default returns retention to Forever", async ({
@@ -159,17 +64,14 @@ test.describe("Chat retention control @exclusive", () => {
     eeEnabled,
   }) => {
     test.skip(!eeEnabled, "Chat retention requires an Enterprise license");
-    await resetToForever(page);
-    await gotoChatPreferences(page);
+    const chatPrefs = new ChatPreferencesPage(page);
+    await chatPrefs.resetRetentionToForever();
+    await chatPrefs.gotoAdvancedOptions();
 
-    await setCustomRetention(page, "45");
+    await chatPrefs.setCustomRetention("45");
+    await chatPrefs.restoreRetentionDefault();
 
-    await restoreDefaultButton(page).click();
-    await expect(page.getByText("Settings updated")).toBeVisible({
-      timeout: 5000,
-    });
-
-    await expect(retentionTrigger(page)).toContainText("Forever");
+    await expect(chatPrefs.retentionTrigger).toContainText("Forever");
   });
 
   test("reducing retention prompts confirmation; cancel keeps the current value", async ({
@@ -177,21 +79,16 @@ test.describe("Chat retention control @exclusive", () => {
     eeEnabled,
   }) => {
     test.skip(!eeEnabled, "Chat retention requires an Enterprise license");
-    await resetToForever(page);
-    await gotoChatPreferences(page);
+    const chatPrefs = new ChatPreferencesPage(page);
+    await chatPrefs.resetRetentionToForever();
+    await chatPrefs.gotoAdvancedOptions();
 
-    await retentionTrigger(page).click();
-    await page.getByRole("option", { name: "30 days", exact: true }).click();
+    await chatPrefs.selectRetentionPreset("30 days");
+    await expect(chatPrefs.reduceRetentionModal).toBeVisible();
 
-    await expect(page.getByText("Reduce chat retention?")).toBeVisible({
-      timeout: 5000,
-    });
-
-    // Cancel by dismissing the modal (no inputs inside, so Escape closes it).
-    await page.keyboard.press("Escape");
-    await expect(page.getByText("Reduce chat retention?")).toHaveCount(0);
+    await chatPrefs.cancelRetentionReduction();
 
     // The value was not changed.
-    await expect(retentionTrigger(page)).toContainText("Forever");
+    await expect(chatPrefs.retentionTrigger).toContainText("Forever");
   });
 });

--- a/web/tests/e2e/admin/chat_retention_control.spec.ts
+++ b/web/tests/e2e/admin/chat_retention_control.spec.ts
@@ -118,20 +118,17 @@ test.describe("Chat retention control @exclusive", () => {
 
     for (const label of [
       "Forever",
-      "1 year",
+      "7 days",
       "30 days",
       "60 days",
       "90 days",
+      "1 year",
       "Custom Retention",
     ]) {
       await expect(
         page.getByRole("option", { name: label, exact: true })
       ).toBeVisible();
     }
-    // The legacy "7 days" preset was intentionally removed.
-    await expect(
-      page.getByRole("option", { name: "7 days", exact: true })
-    ).toHaveCount(0);
 
     await page.keyboard.press("Escape");
   });

--- a/web/tests/e2e/pages/ChatPreferencesPage.ts
+++ b/web/tests/e2e/pages/ChatPreferencesPage.ts
@@ -3,7 +3,8 @@
  * (/admin/configuration/chat-preferences).
  *
  * Covers attaching an MCP server's tools to the default agent, toggling
- * individual tools (with persistence), and editing the default system prompt.
+ * individual tools (with persistence), editing the default system prompt, and
+ * the "Keep Chat History" retention control.
  */
 
 import { type Page, type Locator, expect } from "@playwright/test";
@@ -12,11 +13,15 @@ export class ChatPreferencesPage {
   readonly page: Page;
   readonly title: Locator;
   readonly modifyPromptButton: Locator;
+  readonly retentionField: Locator;
 
   constructor(page: Page) {
     this.page = page;
     this.title = page.locator('[aria-label="admin-page-title"]');
     this.modifyPromptButton = page.getByText("Modify Prompt");
+    this.retentionField = page
+      .locator("label")
+      .filter({ hasText: "Keep Chat History" });
   }
 
   // ---------------------------------------------------------------------------
@@ -134,6 +139,136 @@ export class ChatPreferencesPage {
 
   async expectSystemPromptValue(text: string): Promise<void> {
     await expect(this.promptTextarea).toHaveValue(text);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Chat retention ("Keep Chat History")
+  // ---------------------------------------------------------------------------
+
+  get retentionTrigger(): Locator {
+    return this.retentionField.locator('[role="combobox"]');
+  }
+
+  /** The "In days" input shown once "Custom Retention" is selected. */
+  get retentionCustomInput(): Locator {
+    return this.retentionField.getByPlaceholder("In days");
+  }
+
+  /** First icon button in the custom input restores the default (Forever). */
+  get retentionRestoreDefaultButton(): Locator {
+    return this.retentionField
+      .locator(".opal-input")
+      .getByRole("button")
+      .first();
+  }
+
+  /** Second icon button in the custom input reopens the preset dropdown. */
+  get retentionMoreButton(): Locator {
+    return this.retentionField
+      .locator(".opal-input")
+      .getByRole("button")
+      .nth(1);
+  }
+
+  get reduceRetentionModal(): Locator {
+    return this.page.getByText("Reduce chat retention?");
+  }
+
+  retentionOption(label: string): Locator {
+    return this.page.getByRole("option", { name: label, exact: true });
+  }
+
+  /** Expand the "Advanced Options" collapsible so the retention control shows. */
+  async expandAdvancedOptions(): Promise<void> {
+    const header = this.page.getByText("Advanced Options", { exact: true });
+    await expect(header).toBeVisible();
+    if (
+      await this.retentionField
+        .first()
+        .isVisible()
+        .catch(() => false)
+    ) {
+      return;
+    }
+    await header.scrollIntoViewIfNeeded();
+    await header.click();
+    await expect(this.retentionField.first()).toBeVisible();
+  }
+
+  /** Navigate to the page and reveal the retention control. */
+  async gotoAdvancedOptions(): Promise<void> {
+    await this.goto();
+    await this.page.waitForLoadState("networkidle");
+    await this.expandAdvancedOptions();
+  }
+
+  /** Reload and re-reveal the retention control (Advanced Options recollapses). */
+  async reloadAdvancedOptions(): Promise<void> {
+    await this.page.reload();
+    await this.page.waitForLoadState("networkidle");
+    await this.expandAdvancedOptions();
+  }
+
+  async openRetentionDropdown(): Promise<void> {
+    await this.retentionTrigger.click();
+  }
+
+  async selectRetentionPreset(label: string): Promise<void> {
+    await this.openRetentionDropdown();
+    await this.retentionOption(label).click();
+  }
+
+  /** Choose "Custom Retention" and wait for the days input to appear. */
+  async chooseCustomRetention(): Promise<void> {
+    await this.openRetentionDropdown();
+    await this.retentionOption("Custom Retention").click();
+    await expect(this.retentionCustomInput).toBeVisible();
+  }
+
+  async confirmRetentionReduction(): Promise<void> {
+    await expect(this.reduceRetentionModal).toBeVisible();
+    await this.page.getByRole("button", { name: "Reduce retention" }).click();
+    await this.expectToast("Settings updated");
+  }
+
+  async cancelRetentionReduction(): Promise<void> {
+    // No inputs live inside the modal, so Escape dismisses it immediately.
+    await this.page.keyboard.press("Escape");
+    await expect(this.reduceRetentionModal).toHaveCount(0);
+  }
+
+  /**
+   * Enter a custom retention value coming from Forever/a larger value. This
+   * shortens the retention window, so it triggers (and confirms) the reduction
+   * prompt.
+   */
+  async setCustomRetention(days: string): Promise<void> {
+    await this.chooseCustomRetention();
+    await this.retentionCustomInput.fill(days);
+    await this.retentionCustomInput.blur();
+    await this.confirmRetentionReduction();
+  }
+
+  async restoreRetentionDefault(): Promise<void> {
+    await this.retentionRestoreDefaultButton.click();
+    await this.expectToast("Settings updated");
+  }
+
+  /** Best-effort reset so shared state is left at the safe "Forever" default. */
+  async resetRetentionToForever(): Promise<void> {
+    await this.gotoAdvancedOptions();
+    if (await this.retentionCustomInput.isVisible().catch(() => false)) {
+      await this.retentionRestoreDefaultButton.click();
+      await this.expectToast("Settings updated").catch(() => {});
+      return;
+    }
+    if (
+      ((await this.retentionTrigger.textContent()) ?? "").includes("Forever")
+    ) {
+      return;
+    }
+    await this.selectRetentionPreset("Forever");
+    await this.expectToast("Settings updated");
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Reshapes the admin **Chat Preferences → Advanced Options → "Keep Chat History"** control to match the finalized Figma design ([dropdown](https://www.figma.com/design/sNcHyrXBLtTFDK0ijjMnSk/Admin-Panel?node-id=2270-16456&m=dev), [custom input](https://www.figma.com/design/sNcHyrXBLtTFDK0ijjMnSk/Admin-Panel?node-id=2270-38277&m=dev)).

Previously, choosing "Custom…" left the dropdown in place and revealed a **separate** number input below it. Now selecting **"Custom Retention"** converts the dropdown **in place** into a days input.

## What changed

- **Presets**: `Forever · 7 days · 30 days · 60 days · 90 days · 1 year · Custom Retention` (ascending; "1 year" is the label for `365`). A divider separates the presets from **Custom Retention**.
- **In-place conversion**: selecting "Custom Retention" replaces the dropdown with an **"In days"** input.
- **Input affordances**: a **Restore Default** button (→ Forever) and a **More** chevron that reopens the presets.
- **Behaviors**: save-on-blur, **empty → Forever**, and a **confirmation modal** whenever the retention window is *shortened* (more chats become eligible for permanent deletion) — applied to both preset and custom changes.

Backend is unchanged: `maximum_chat_retention_days` is still stored as a free-form number of days.

### Implementation note
Radix `Select.Item` (v2) has no public `onSelect` prop, so the mode logic relies solely on `onValueChange` + a controlled `open` state rather than an item click handler, which keeps re-entry into the custom input reliable.

## Test plan

- `tsgo` typecheck, `oxlint`, and `oxfmt` all clean.
- New Playwright E2E spec `web/tests/e2e/admin/chat_retention_control.spec.ts` (Enterprise-gated) — **all 4 tests pass** against a live enterprise-tier deployment:
  - dropdown lists the configured presets
  - Custom Retention converts the dropdown into the days input and persists across reload
  - Restore Default returns to Forever
  - reducing retention prompts confirmation; cancel keeps the current value

🤖 Generated with [Claude Code](https://claude.com/claude-code)