### PR TITLE
fix: disambiguate mcp tools (#12548) to release v4.3

### DIFF
--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -66,6 +66,7 @@ from onyx.tools.tool_implementations.search.search_tool import SearchTool
 from onyx.tools.tool_implementations.web_search.utils import extract_url_snippet_map
 from onyx.tools.tool_implementations.web_search.web_search_tool import WebSearchTool
 from onyx.tools.tool_runner import run_tool_calls
+from onyx.tools.utils import compute_all_tool_tokens
 from onyx.tracing.framework.create import trace
 from onyx.utils.logger import setup_logger
 from shared_configs.contextvars import get_current_tenant_id
@@ -838,13 +839,14 @@ def run_llm_loop(
                 else None
             )
 
+            tool_token_budget = compute_all_tool_tokens(final_tools, token_counter)
             truncated_message_history = construct_message_history(
                 system_prompt=system_prompt,
                 custom_agent_prompt=custom_agent_prompt_msg,
                 simple_chat_history=simple_chat_history,
                 reminder_message=reminder_msg,
                 context_files=context_files,
-                available_tokens=available_tokens,
+                available_tokens=max(0, available_tokens - tool_token_budget),
                 token_counter=token_counter,
                 all_injected_file_metadata=all_injected_file_metadata,
             )
@@ -976,7 +978,6 @@ def run_llm_loop(
                     except (json.JSONDecodeError, AttributeError):
                         pass
 
-                # Build a mapping of tool names to tool objects for getting tool_id
                 tools_by_name = {tool.name: tool for tool in final_tools}
 
                 # Add the results to the chat history. Even though tools may run in parallel,

--- a/backend/onyx/tools/fake_tools/research_agent.py
+++ b/backend/onyx/tools/fake_tools/research_agent.py
@@ -68,6 +68,8 @@ from onyx.tools.tool_implementations.search.search_tool import SearchTool
 from onyx.tools.tool_implementations.web_search.utils import extract_url_snippet_map
 from onyx.tools.tool_implementations.web_search.web_search_tool import WebSearchTool
 from onyx.tools.tool_runner import run_tool_calls
+from onyx.tools.utils import compute_all_tool_tokens
+from onyx.tools.utils import compute_tool_definition_tokens
 from onyx.tools.utils import generate_tools_description
 from onyx.tracing.framework.create import function_span
 from onyx.utils.logger import setup_logger
@@ -323,18 +325,24 @@ def run_research_agent_call(
                 else:
                     reminder_message = None
 
+                research_agent_tools = get_research_agent_additional_tool_definitions(
+                    include_think_tool=not is_reasoning_model
+                )
+                tool_token_budget = compute_all_tool_tokens(
+                    current_tools, token_counter
+                ) + compute_tool_definition_tokens(research_agent_tools, token_counter)
+
                 constructed_history = construct_message_history(
                     system_prompt=system_prompt,
                     custom_agent_prompt=None,
                     simple_chat_history=msg_history,
                     reminder_message=reminder_message,
                     context_files=None,
-                    available_tokens=llm.config.max_input_tokens,
+                    available_tokens=max(
+                        0, llm.config.max_input_tokens - tool_token_budget
+                    ),
                 )
 
-                research_agent_tools = get_research_agent_additional_tool_definitions(
-                    include_think_tool=not is_reasoning_model
-                )
                 # Use think tool processor for non-reasoning models to convert
                 # think_tool calls to reasoning content (same as dr_loop.py)
                 custom_processor = (

--- a/backend/onyx/tools/tool_constructor.py
+++ b/backend/onyx/tools/tool_constructor.py
@@ -1,3 +1,4 @@
+from collections import Counter
 from typing import cast
 from uuid import UUID
 
@@ -50,6 +51,13 @@ from onyx.utils.headers import header_dict_to_header_list
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
+
+
+def _disambiguate_mcp_tool_names(tools: list[Tool]) -> None:
+    tool_name_counts = Counter(tool.name for tool in tools)
+    for tool in tools:
+        if isinstance(tool, MCPTool) and tool_name_counts[tool.name] > 1:
+            tool.use_disambiguated_name()
 
 
 class SearchToolConfig(BaseModel):
@@ -509,5 +517,6 @@ def _construct_tools_impl(
     tools: list[Tool] = []
     for tool_list in tool_dict.values():
         tools.extend(tool_list)
+    _disambiguate_mcp_tool_names(tools)
 
     return tool_dict

--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -16,6 +16,7 @@ from onyx.tools.interface import Tool
 from onyx.tools.models import CustomToolCallSummary
 from onyx.tools.models import ToolResponse
 from onyx.tools.tool_implementations.mcp.mcp_client import call_mcp_tool
+from onyx.tools.tool_name import sanitize_tool_name
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -75,11 +76,12 @@ class MCPTool(Tool[None]):
         self._user_oauth_token = user_oauth_token
         self._additional_headers = additional_headers or {}
 
-        self._name = tool_name
+        self._mcp_tool_name = tool_name
+        self._name = tool_name  # NOTE: this may change in _disambiguate_mcp_tool_names
         self._tool_definition = tool_definition
         self._description = tool_description
         self._display_name = tool_definition.get("displayName", tool_name)
-        self._llm_name = f"mcp:{mcp_server.name}:{tool_name}"
+        self._llm_name = sanitize_tool_name(f"mcp_{mcp_server.name}_{tool_name}")
 
     @property
     def id(self) -> int:
@@ -97,9 +99,8 @@ class MCPTool(Tool[None]):
     def display_name(self) -> str:
         return self._display_name
 
-    @property
-    def llm_name(self) -> str:
-        return self._llm_name
+    def use_disambiguated_name(self) -> None:
+        self._name = self._llm_name
 
     def tool_definition(self) -> dict:
         """Return the tool definition from the MCP server"""
@@ -247,7 +248,7 @@ class MCPTool(Tool[None]):
 
             tool_result = call_mcp_tool(
                 self.mcp_server.server_url,
-                self._name,
+                self._mcp_tool_name,
                 llm_kwargs,
                 connection_headers=headers,
                 transport=self.mcp_server.transport or MCPTransport.STREAMABLE_HTTP,

--- a/backend/onyx/tools/utils.py
+++ b/backend/onyx/tools/utils.py
@@ -1,4 +1,6 @@
 import json
+from collections.abc import Callable
+from typing import Any
 
 from sqlalchemy.orm import Session
 
@@ -9,7 +11,6 @@ from onyx.db.models import LLMProvider
 from onyx.llm.constants import LlmProviderNames
 from onyx.llm.utils import find_model_obj
 from onyx.llm.utils import get_model_map
-from onyx.natural_language_processing.utils import BaseTokenizer
 from onyx.tools.interface import Tool
 
 
@@ -26,12 +27,23 @@ def explicit_tool_calling_supported(model_provider: str, model_name: str) -> boo
     return bool(model_obj.get("supports_function_calling"))
 
 
-def compute_tool_tokens(tool: Tool, llm_tokenizer: BaseTokenizer) -> int:
-    return len(llm_tokenizer.encode(json.dumps(tool.tool_definition())))
+def compute_tool_tokens(tool: Tool, token_counter: Callable[[str], int]) -> int:
+    return token_counter(json.dumps(tool.tool_definition()))
 
 
-def compute_all_tool_tokens(tools: list[Tool], llm_tokenizer: BaseTokenizer) -> int:
-    return sum(compute_tool_tokens(tool, llm_tokenizer) for tool in tools)
+def compute_all_tool_tokens(
+    tools: list[Tool], token_counter: Callable[[str], int]
+) -> int:
+    return sum(compute_tool_tokens(tool, token_counter) for tool in tools)
+
+
+def compute_tool_definition_tokens(
+    tool_definitions: list[dict[str, Any]], token_counter: Callable[[str], int]
+) -> int:
+    return sum(
+        token_counter(json.dumps(tool_definition))
+        for tool_definition in tool_definitions
+    )
 
 
 def is_image_generation_available(db_session: Session) -> bool:

--- a/backend/tests/unit/onyx/tools/test_mcp_tool_schema.py
+++ b/backend/tests/unit/onyx/tools/test_mcp_tool_schema.py
@@ -10,10 +10,17 @@ These tests pin the contract that MCPTool.tool_definition() always returns
 a JSON-Schema-valid `parameters` dict with a `properties` key.
 """
 
+from typing import Any
 from unittest.mock import MagicMock
+from unittest.mock import patch
 
 import pytest
 
+from onyx.db.enums import MCPAuthenticationType
+from onyx.server.query_and_chat.placement import Placement
+from onyx.tools.interface import Tool
+from onyx.tools.models import ToolResponse
+from onyx.tools.tool_constructor import _disambiguate_mcp_tool_names
 from onyx.tools.tool_implementations.mcp.mcp_tool import _normalize_parameters_schema
 from onyx.tools.tool_implementations.mcp.mcp_tool import MCPTool
 
@@ -67,14 +74,64 @@ class TestNormalizeParametersSchema:
         assert _normalize_parameters_schema(schema) == schema
 
 
-def _make_tool(input_schema: dict) -> MCPTool:
+class _StaticTool(Tool[None]):
+    def __init__(self, name: str) -> None:
+        super().__init__(emitter=MagicMock())
+        self._name = name
+
+    @property
+    def id(self) -> int:
+        return 2
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str:
+        return "Static tool"
+
+    @property
+    def display_name(self) -> str:
+        return self._name
+
+    def tool_definition(self) -> dict[str, Any]:
+        return {
+            "type": "function",
+            "function": {
+                "name": self._name,
+                "description": self.description,
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+
+    def emit_start(self, placement: Placement) -> None:
+        pass
+
+    def run(
+        self,
+        placement: Placement,
+        override_kwargs: None = None,
+        **llm_kwargs: Any,
+    ) -> ToolResponse:
+        raise NotImplementedError
+
+
+def _make_tool(
+    input_schema: dict,
+    tool_name: str = "aws___list_regions",
+    server_name: str = "aws-knowledge",
+) -> MCPTool:
     mcp_server = MagicMock()
-    mcp_server.name = "aws-knowledge"
+    mcp_server.name = server_name
+    mcp_server.server_url = "http://mcp.example"
+    mcp_server.auth_type = MCPAuthenticationType.NONE
+    mcp_server.transport = None
     return MCPTool(
         tool_id=1,
         emitter=MagicMock(),
         mcp_server=mcp_server,
-        tool_name="aws___list_regions",
+        tool_name=tool_name,
         tool_description="List AWS regions",
         tool_definition=input_schema,
     )
@@ -119,6 +176,60 @@ class TestMCPToolDefinition:
         tool.tool_definition()
 
         assert stored == {"type": "object"}
+
+
+class TestMCPToolLLMNames:
+    def test_mcp_tool_keeps_original_name_without_conflicts(self) -> None:
+        tool = _make_tool({"type": "object"})
+
+        _disambiguate_mcp_tool_names([tool])
+
+        assert tool.name == "aws___list_regions"
+        assert tool.tool_definition()["function"]["name"] == "aws___list_regions"
+
+    def test_mcp_tool_disambiguates_at_construction_when_names_conflict(self) -> None:
+        mcp_tool = _make_tool(
+            {"type": "object"}, tool_name="shared", server_name="server name"
+        )
+        static_tool = _StaticTool("shared")
+
+        _disambiguate_mcp_tool_names([mcp_tool, static_tool])
+
+        assert mcp_tool.name == "mcp_server_name_shared"
+        assert (
+            mcp_tool.tool_definition()["function"]["name"] == "mcp_server_name_shared"
+        )
+        assert static_tool.name == "shared"
+
+    def test_second_order_disambiguated_name_conflicts_are_allowed(self) -> None:
+        mcp_tool = _make_tool(
+            {"type": "object"}, tool_name="shared", server_name="server"
+        )
+        conflicting_tool = _StaticTool("shared")
+        second_order_conflicting_tool = _StaticTool("mcp_server_shared")
+
+        tools: list[Tool] = [mcp_tool, conflicting_tool, second_order_conflicting_tool]
+        _disambiguate_mcp_tool_names(tools)
+
+        assert [tool.name for tool in tools] == [
+            "mcp_server_shared",
+            "shared",
+            "mcp_server_shared",
+        ]
+
+    def test_disambiguated_mcp_tool_calls_server_with_original_name(self) -> None:
+        mcp_tool = _make_tool({"type": "object"}, tool_name="shared")
+        conflicting_tool = _StaticTool("shared")
+        _disambiguate_mcp_tool_names([mcp_tool, conflicting_tool])
+
+        with patch(
+            "onyx.tools.tool_implementations.mcp.mcp_tool.call_mcp_tool",
+            return_value={"ok": True},
+        ) as mock_call_mcp_tool:
+            mcp_tool.run(Placement(turn_index=0))
+
+        mock_call_mcp_tool.assert_called_once()
+        assert mock_call_mcp_tool.call_args.args[1] == "shared"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Cherry-pick of commit 74629824bc84ae00170f4e4a4a76d85c509d3b8f to release/v4.3 branch.

Original PR: #12548

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents MCP tool name collisions by disambiguating their LLM-facing names and fixes context budgeting by subtracting tool schema tokens before message construction. Ensures correct server calls while avoiding overflows.

- **Bug Fixes**
  - Disambiguate conflicting MCP tool names; LLM-facing name becomes `mcp_<server>_<tool>` (sanitized) only when collisions exist.
  - Keep original MCP tool name for server execution; added `use_disambiguated_name()` and sanitized `llm_name`.
  - Apply disambiguation during tool construction so names are unique across all tools.
  - Subtract tokens for all tool definitions from available tokens in the chat loop and research agent.
  - Introduced `compute_all_tool_tokens` and `compute_tool_definition_tokens`; token utils now use a `token_counter` callable.
  - Added tests covering schema normalization, disambiguation, and correct server invocation.

<sup>Written for commit 2d45c1ba8f2b0eb12b3b4a96f901a932e769a73d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

