### PR TITLE
Combined cherry-pick of #12526, #12559, #12534, #12639 to release v4.3

### DIFF
--- a/backend/ee/onyx/external_permissions/confluence/group_sync.py
+++ b/backend/ee/onyx/external_permissions/confluence/group_sync.py
@@ -163,6 +163,9 @@ def confluence_group_sync(
 ) -> Generator[ExternalUserGroup, None, None]:
     provider = OnyxDBCredentialsProvider(tenant_id, "confluence", cc_pair.credential_id)
     is_cloud = cc_pair.connector.connector_specific_config.get("is_cloud", False)
+    scoped_token = cc_pair.connector.connector_specific_config.get(
+        "scoped_token", False
+    )
     wiki_base: str = cc_pair.connector.connector_specific_config["wiki_base"]
     url = wiki_base.rstrip("/")
 
@@ -176,7 +179,9 @@ def confluence_group_sync(
         "max_backoff_seconds": 60,
     }
 
-    confluence_client = OnyxConfluence(is_cloud, url, provider)
+    confluence_client = OnyxConfluence(
+        is_cloud, url, provider, scoped_token=scoped_token
+    )
     confluence_client._probe_connection(**probe_kwargs)
     confluence_client._initialize_connection(**final_kwargs)
 

--- a/backend/onyx/db/chat.py
+++ b/backend/onyx/db/chat.py
@@ -373,7 +373,11 @@ def get_chat_sessions_older_than(
     days_old: int, db_session: Session
 ) -> list[tuple[UUID | None, UUID]]:
     """
-    Retrieves chat sessions older than a specified number of days.
+    Retrieves chat sessions whose last activity is older than a specified number of days.
+
+    "Last activity" is the time of the most recent message in the session, so an
+    old session that is still being used is retained. Sessions without any messages
+    fall back to their creation time.
 
     Args:
         days_old: The number of days to consider as "old".
@@ -384,10 +388,14 @@ def get_chat_sessions_older_than(
     """
 
     cutoff_time = datetime.now(tz=timezone.utc) - timedelta(days=days_old)
+    last_activity = func.coalesce(
+        func.max(ChatMessage.time_sent), ChatSession.time_created
+    )
     old_sessions: Sequence[Row[Tuple[UUID | None, UUID]]] = db_session.execute(
-        select(ChatSession.user_id, ChatSession.id).where(
-            ChatSession.time_created < cutoff_time
-        )
+        select(ChatSession.user_id, ChatSession.id)
+        .outerjoin(ChatMessage, ChatMessage.chat_session_id == ChatSession.id)
+        .group_by(ChatSession.id, ChatSession.user_id)
+        .having(last_activity < cutoff_time)
     ).fetchall()
 
     # convert old_sessions to a conventional list of tuples

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -754,6 +754,11 @@ def _build_persona_filters(
     return stmt
 
 
+def _user_may_view_persona_owner_email(user: User, persona: Persona) -> bool:
+    """Owner email is PII — only the persona's owner or an admin may see it."""
+    return user.role == UserRole.ADMIN or persona.user_id == user.id
+
+
 def get_minimal_persona_snapshots_for_user(
     user: User,
     db_session: Session,
@@ -795,6 +800,7 @@ def get_minimal_persona_snapshots_for_user(
         MinimalPersonaSnapshot.from_model(
             persona,
             user_permission=get_persona_access_level(persona, user, user_group_ids),
+            include_owner_email=_user_may_view_persona_owner_email(user, persona),
         )
         for persona in results
     ]
@@ -951,6 +957,7 @@ def get_minimal_persona_snapshots_paginated(
         MinimalPersonaSnapshot.from_model(
             persona,
             user_permission=get_persona_access_level(persona, user, user_group_ids),
+            include_owner_email=_user_may_view_persona_owner_email(user, persona),
         )
         for persona in results
     ]

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -1386,13 +1386,15 @@ def _db_mcp_server_to_api_mcp_server(
     user_authenticated: bool | None = None
     user_credentials = None
     admin_credentials = None
-    can_view_admin_credentials = bool(include_auth_config) and (
-        request_user is not None
-        and (
-            request_user.role == UserRole.ADMIN
-            or (request_user.email and request_user.email == db_server.owner)
-        )
+    is_owner_or_admin = request_user is not None and (
+        request_user.role == UserRole.ADMIN
+        or (request_user.email and request_user.email == db_server.owner)
     )
+    can_view_admin_credentials = bool(include_auth_config) and is_owner_or_admin
+    # The internal server_url and the owner email are sensitive: expose them only
+    # to the server's owner or an admin. Basic users attaching MCP actions to an
+    # assistant don't need either (the connect/OAuth flow is brokered server-side).
+    can_view_server_details = is_owner_or_admin
     if db_server.auth_type == MCPAuthenticationType.NONE:
         user_authenticated = True  # No auth required
     elif auth_performer == MCPAuthenticationPerformer.ADMIN:
@@ -1530,8 +1532,8 @@ def _db_mcp_server_to_api_mcp_server(
         id=db_server.id,
         name=db_server.name,
         description=db_server.description,
-        server_url=db_server.server_url,
-        owner=db_server.owner,
+        server_url=db_server.server_url if can_view_server_details else "",
+        owner=db_server.owner if can_view_server_details else "",
         transport=db_server.transport,
         auth_type=db_server.auth_type,
         auth_performer=auth_performer,

--- a/backend/onyx/server/features/persona/models.py
+++ b/backend/onyx/server/features/persona/models.py
@@ -235,6 +235,9 @@ class MinimalPersonaSnapshot(BaseModel):
         cls,
         persona: Persona,
         user_permission: PersonaAccessLevel | None = None,
+        # Fail closed: the owner email is PII and is only included when a caller
+        # explicitly opts in (owner / admin paths). See the DB-layer callers.
+        include_owner_email: bool = False,
     ) -> "MinimalPersonaSnapshot":
         # Collect unique sources from document sets, hierarchy nodes, and attached documents
         sources: set[DocumentSource] = set()
@@ -288,7 +291,12 @@ class MinimalPersonaSnapshot(BaseModel):
             builtin_persona=persona.builtin_persona,
             labels=[PersonaLabelSnapshot.from_model(label) for label in persona.labels],
             owner=(
-                MinimalUserSnapshot(id=persona.user.id, email=persona.user.email)
+                # Owner email is PII: keep the id (needed for ownership/creator
+                # filtering) but blank the email for non-owner/non-admin callers.
+                MinimalUserSnapshot(
+                    id=persona.user.id,
+                    email=persona.user.email if include_owner_email else "",
+                )
                 if persona.user
                 else None
             ),

--- a/backend/tests/integration/tests/chat_retention/test_chat_retention.py
+++ b/backend/tests/integration/tests/chat_retention/test_chat_retention.py
@@ -1,14 +1,22 @@
 import os
 import time
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from uuid import UUID
 
 import httpx
 import pytest
+from sqlalchemy import update
 
 from onyx.db.chat import delete_chat_session
 from onyx.db.chat import get_chat_sessions_older_than
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.models import ChatMessage
+from onyx.db.models import ChatSession
 from tests.integration.common_utils.managers.chat import ChatSessionManager
 from tests.integration.common_utils.managers.settings import SettingsManager
+from tests.integration.common_utils.test_models import DATestChatSession
 from tests.integration.common_utils.test_models import DATestLLMProvider
 from tests.integration.common_utils.test_models import DATestSettings
 from tests.integration.common_utils.test_models import DATestUser
@@ -30,6 +38,39 @@ def _run_ttl_cleanup(retention_days: int) -> None:
                 include_deleted=True,
                 hard_delete=True,
             )
+
+
+def _backdate_session(
+    session_id: UUID, created_days_ago: int, last_message_days_ago: int
+) -> None:
+    """Rewrite a session's creation time and its messages' sent time so retention
+    behavior can be tested deterministically without sleeping."""
+    now = datetime.now(tz=timezone.utc)
+    with get_session_with_current_tenant() as db_session:
+        db_session.execute(
+            update(ChatSession)
+            .where(ChatSession.id == session_id)
+            .values(time_created=now - timedelta(days=created_days_ago))
+        )
+        db_session.execute(
+            update(ChatMessage)
+            .where(ChatMessage.chat_session_id == session_id)
+            .values(time_sent=now - timedelta(days=last_message_days_ago))
+        )
+        db_session.commit()
+
+
+def _is_session_deleted(chat_session: DATestChatSession, user: DATestUser) -> bool:
+    try:
+        history = ChatSessionManager.get_chat_history(
+            chat_session=chat_session,
+            user_performing_action=user,
+        )
+        return len(history) == 0
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code in (404, 400):
+            return True
+        raise
 
 
 @pytest.mark.skipif(
@@ -73,17 +114,67 @@ def test_chat_retention(
     _run_ttl_cleanup(retention_days)
 
     # Verify the chat session was deleted
-    session_deleted = False
-    try:
-        chat_history = ChatSessionManager.get_chat_history(
-            chat_session=chat_session,
-            user_performing_action=admin_user,
-        )
-        session_deleted = len(chat_history) == 0
-    except httpx.HTTPStatusError as e:
-        if e.response.status_code in (404, 400):
-            session_deleted = True
-        else:
-            raise
+    assert _is_session_deleted(chat_session, admin_user), (
+        "Chat session was not deleted after retention period"
+    )
 
-    assert session_deleted, "Chat session was not deleted after retention period"
+
+@pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="Chat retention tests are enterprise only",
+)
+def test_chat_retention_uses_last_message_time(
+    reset: None,  # noqa: ARG001
+    admin_user: DATestUser,
+    llm_provider: DATestLLMProvider,  # noqa: ARG001
+) -> None:
+    """Retention is based on last message time, not session creation time.
+
+    An old session that received a recent message should be retained, while an
+    old session with no recent activity should be deleted.
+    """
+
+    retention_days = 30
+    settings = DATestSettings(maximum_chat_retention_days=retention_days)
+    SettingsManager.update_settings(settings, user_performing_action=admin_user)
+
+    # Created long ago but recently used -> should be RETAINED
+    active_session = ChatSessionManager.create(
+        persona_id=0,
+        description="Old session, recent activity",
+        user_performing_action=admin_user,
+    )
+    active_response = ChatSessionManager.send_message(
+        chat_session_id=active_session.id,
+        message="Recent message keeps this session alive",
+        user_performing_action=admin_user,
+    )
+    assert active_response.error is None, (
+        f"Chat response should not have an error: {active_response.error}"
+    )
+    _backdate_session(active_session.id, created_days_ago=60, last_message_days_ago=1)
+
+    # Created long ago and inactive -> should be DELETED
+    stale_session = ChatSessionManager.create(
+        persona_id=0,
+        description="Old session, no recent activity",
+        user_performing_action=admin_user,
+    )
+    stale_response = ChatSessionManager.send_message(
+        chat_session_id=stale_session.id,
+        message="This session has gone stale",
+        user_performing_action=admin_user,
+    )
+    assert stale_response.error is None, (
+        f"Chat response should not have an error: {stale_response.error}"
+    )
+    _backdate_session(stale_session.id, created_days_ago=60, last_message_days_ago=60)
+
+    _run_ttl_cleanup(retention_days)
+
+    assert not _is_session_deleted(active_session, admin_user), (
+        "Session with a recent message should be retained"
+    )
+    assert _is_session_deleted(stale_session, admin_user), (
+        "Session with no recent activity should be deleted"
+    )

--- a/backend/tests/integration/tests/permissions/test_owner_pii_redaction.py
+++ b/backend/tests/integration/tests/permissions/test_owner_pii_redaction.py
@@ -1,0 +1,105 @@
+"""Integration tests for owner-email / internal-URL redaction (ENG-4251).
+
+Persona and MCP-server snapshots returned by the basic-access surfaces leaked
+PII (the owner's email) and internal infrastructure detail (the MCP
+`server_url`) to any authenticated user. These tests verify that:
+
+* the owner email is blanked for non-owner / non-admin callers, while
+* the owner (and an admin) still sees the real values.
+"""
+
+from uuid import uuid4
+
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.http_client import client
+from tests.integration.common_utils.managers.persona import PersonaManager
+from tests.integration.common_utils.test_models import DATestUser
+
+
+def _find_persona(entries: list[dict], persona_id: int) -> dict:
+    return next(entry for entry in entries if entry["id"] == persona_id)
+
+
+def _find_mcp_server(payload: dict, server_id: int) -> dict:
+    return next(s for s in payload["mcp_servers"] if s["id"] == server_id)
+
+
+def test_persona_owner_email_redacted_for_non_owner(
+    permission_admin_user: DATestUser,
+    permission_basic_user: DATestUser,
+) -> None:
+    """`GET /api/persona` must not expose the owner email to non-owner users."""
+    persona = PersonaManager.create(
+        name=f"pii-redaction-persona-{uuid4()}",
+        is_public=True,
+        user_performing_action=permission_admin_user,
+    )
+
+    # The owner (admin here) still sees their own email.
+    admin_resp = client.get(
+        f"{API_SERVER_URL}/persona",
+        headers=permission_admin_user.headers,
+        cookies=permission_admin_user.cookies,
+        timeout=30,
+    )
+    admin_resp.raise_for_status()
+    admin_entry = _find_persona(admin_resp.json(), persona.id)
+    assert admin_entry["owner"] is not None
+    assert admin_entry["owner"]["email"] == permission_admin_user.email
+
+    # A basic, non-owner user sees the persona and its owner id (needed for
+    # ownership / creator filtering) but NOT the owner email.
+    basic_resp = client.get(
+        f"{API_SERVER_URL}/persona",
+        headers=permission_basic_user.headers,
+        cookies=permission_basic_user.cookies,
+        timeout=30,
+    )
+    basic_resp.raise_for_status()
+    basic_entry = _find_persona(basic_resp.json(), persona.id)
+    assert basic_entry["owner"] is not None
+    assert basic_entry["owner"]["id"]
+    assert basic_entry["owner"]["email"] == ""
+
+
+def test_mcp_server_details_redacted_for_non_owner(
+    permission_admin_user: DATestUser,
+    permission_basic_user: DATestUser,
+) -> None:
+    """`GET /api/mcp/servers` must not expose server_url / owner to non-owners."""
+    internal_url = f"http://mcp-internal-{uuid4().hex[:8]}.svc.internal/sse"
+    server_name = f"pii-redaction-mcp-{uuid4()}"
+
+    create_resp = client.post(
+        f"{API_SERVER_URL}/admin/mcp/server",
+        json={"name": server_name, "server_url": internal_url},
+        headers=permission_admin_user.headers,
+        cookies=permission_admin_user.cookies,
+        timeout=30,
+    )
+    create_resp.raise_for_status()
+    server_id = create_resp.json()["id"]
+
+    # The owner (admin here) still sees the internal url and owner email.
+    admin_resp = client.get(
+        f"{API_SERVER_URL}/mcp/servers",
+        headers=permission_admin_user.headers,
+        cookies=permission_admin_user.cookies,
+        timeout=30,
+    )
+    admin_resp.raise_for_status()
+    admin_entry = _find_mcp_server(admin_resp.json(), server_id)
+    assert admin_entry["server_url"] == internal_url
+    assert admin_entry["owner"] == permission_admin_user.email
+
+    # A basic, non-owner user sees the server entry but neither sensitive field.
+    basic_resp = client.get(
+        f"{API_SERVER_URL}/mcp/servers",
+        headers=permission_basic_user.headers,
+        cookies=permission_basic_user.cookies,
+        timeout=30,
+    )
+    basic_resp.raise_for_status()
+    basic_entry = _find_mcp_server(basic_resp.json(), server_id)
+    assert basic_entry["server_url"] == ""
+    assert basic_entry["owner"] == ""

--- a/desktop/src/titlebar.js
+++ b/desktop/src/titlebar.js
@@ -60,39 +60,51 @@
         }
       }
 
-      html,
-      body {
-        height: var(--onyx-desktop-viewport-height);
-        min-height: var(--onyx-desktop-viewport-height);
-        margin: 0;
-        padding: 0;
-        overflow: hidden;
-      }
-
-      body {
-        padding-top: var(--onyx-desktop-titlebar-height) !important;
+      /* Reserve the native overlay-titlebar strip on the ROOT element. Doing
+         this on <html> (rather than <body>) keeps the reservation working no
+         matter how the embedded web app structures or restyles <body>, and
+         shifts every normal-flow descendant below the titlebar. box-sizing +
+         padding-top carves out the strip; the fixed titlebar element is drawn
+         on top of it. */
+      html {
         box-sizing: border-box;
+        height: var(--onyx-desktop-viewport-height) !important;
+        padding-top: var(--onyx-desktop-titlebar-height) !important;
+        overflow: hidden !important;
       }
 
-      body > div#__next,
-      body > div#root,
-      body > main {
-        height: var(--onyx-desktop-safe-height);
-        min-height: var(--onyx-desktop-safe-height);
-        overflow: auto;
-      }
-
-      /* Override common Tailwind viewport helpers so content fits under the titlebar */
-      .h-screen {
+      body {
         height: var(--onyx-desktop-safe-height) !important;
+        min-height: 0 !important;
+        margin: 0 !important;
+        overflow: hidden !important;
+      }
+
+      /* Clamp full-viewport-height containers to the area BELOW the titlebar so
+         their bottom edge doesn't overflow past the window. Covers raw Tailwind
+         utilities AND the Opal layout classes that bake height:100vh into a
+         compiled class name via @apply (which the utility overrides miss). */
+      .h-screen,
+      .max-h-screen,
+      .opal-sidebar-root__column,
+      .opal-sidebar-root__overlay[data-variant="mobile"],
+      .opal-sidebar-root__overlay[data-variant="medium"] {
+        height: var(--onyx-desktop-safe-height) !important;
+        max-height: var(--onyx-desktop-safe-height) !important;
       }
 
       .min-h-screen {
         min-height: var(--onyx-desktop-safe-height) !important;
       }
 
-      .max-h-screen {
-        max-height: var(--onyx-desktop-safe-height) !important;
+      /* Fixed sidebar overlays / backdrops are positioned against the viewport,
+         so inset-y-0 pins them to y=0 (under the traffic lights). Re-anchor them
+         below the titlebar. */
+      .opal-sidebar-root__overlay[data-variant="mobile"],
+      .opal-sidebar-root__overlay[data-variant="medium"],
+      .opal-sidebar-root__backdrop {
+        top: var(--onyx-desktop-titlebar-height) !important;
+        bottom: 0 !important;
       }
 
       #${TITLEBAR_ID} {

--- a/web/src/app/css/desktop-titlebar.css
+++ b/web/src/app/css/desktop-titlebar.css
@@ -1,0 +1,76 @@
+/*
+  Desktop (Tauri) native title-bar reservation.
+
+  The Onyx desktop app is a Tauri wrapper that loads this web app remotely and
+  uses macOS `titleBarStyle: "Overlay"` — the traffic lights float over the web
+  content, so the app must keep the top strip clear. The desktop wrapper injects
+  a `titlebar.js` shim to do this, but that shim ships frozen inside installed
+  binaries: when the web layout changes, already-installed apps don't get the
+  update. These rules let the web app reserve the strip itself, so the fix
+  reaches every existing install via the remote bundle without a desktop release.
+
+  Activated by the `onyx-desktop` class added to <html> (see the inline detector
+  in app/layout.tsx). All rules are gated on `html.onyx-desktop`, so browser
+  users are completely unaffected. The selectors are deliberately more specific
+  than the shim's (`.onyx-desktop` + element/id), and this sheet is imported
+  unlayered, so it deterministically wins over every shim version — producing a
+  single inset (never a doubled 72px gap) regardless of which shim is present.
+
+  Window dragging is still provided by the shim's fixed drag strip, which sits on
+  top of the reserved zone.
+*/
+
+html.onyx-desktop {
+  /* Inherit the desktop shim's titlebar height when it is present, so the two
+     layers can't silently diverge. The 36px literal is the single fallback
+     source of truth for when no shim has set the variable. */
+  --onyx-titlebar-height: var(--onyx-desktop-titlebar-height, 36px);
+
+  box-sizing: border-box;
+  height: 100dvh !important;
+  /* Carve out the title-bar strip at the root so every normal-flow descendant
+     is pushed below it, no matter how the app structures <body>. */
+  padding-top: var(--onyx-titlebar-height) !important;
+  overflow: hidden !important;
+}
+
+html.onyx-desktop > body {
+  height: calc(100dvh - var(--onyx-titlebar-height)) !important;
+  min-height: 0 !important;
+  /* Cancel any title-bar padding a shim may have put on <body> so it doesn't
+     stack with the root padding above. */
+  padding-top: 0 !important;
+  margin: 0 !important;
+  overflow: hidden !important;
+}
+
+/*
+  Clamp full-viewport-height containers to the area below the title bar so their
+  bottom edge doesn't overflow past the window. Covers raw Tailwind utilities AND
+  the Opal layout classes that compile `height: 100vh` into a class name via
+  @apply (which utility-class overrides can't reach).
+*/
+html.onyx-desktop .h-screen,
+html.onyx-desktop .max-h-screen,
+html.onyx-desktop .opal-sidebar-root__column,
+html.onyx-desktop .opal-sidebar-root__overlay[data-variant="mobile"],
+html.onyx-desktop .opal-sidebar-root__overlay[data-variant="medium"] {
+  height: calc(100dvh - var(--onyx-titlebar-height)) !important;
+  max-height: calc(100dvh - var(--onyx-titlebar-height)) !important;
+}
+
+html.onyx-desktop .min-h-screen {
+  min-height: calc(100dvh - var(--onyx-titlebar-height)) !important;
+}
+
+/*
+  Fixed sidebar overlays / backdrops are positioned against the viewport, so
+  `inset-y-0` pins them to y=0 (under the traffic lights). Re-anchor them below
+  the title bar.
+*/
+html.onyx-desktop .opal-sidebar-root__overlay[data-variant="mobile"],
+html.onyx-desktop .opal-sidebar-root__overlay[data-variant="medium"],
+html.onyx-desktop .opal-sidebar-root__backdrop {
+  top: var(--onyx-titlebar-height) !important;
+  bottom: 0 !important;
+}

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -12,6 +12,9 @@
 @import "./css/line-item.css" layer(base);
 @import "./css/square-button.css" layer(base);
 @import "./css/z-index.css" layer(base);
+/* Imported unlayered (and gated on html.onyx-desktop) so it overrides the
+   frozen desktop-wrapper shim regardless of source order. */
+@import "./css/desktop-titlebar.css";
 @config '../../tailwind.config.js';
 
 /*

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -76,6 +76,24 @@ export default function Layout({ children }: LayoutProps) {
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0, interactive-widget=resizes-content"
         />
 
+        {/* When running inside the Tauri desktop wrapper, tag <html> as desktop
+            so the native title-bar reservation in css/desktop-titlebar.css
+            engages before paint. Tauri injects its IPC globals via an init
+            script that runs before page scripts, so this synchronous check sees
+            them; the class then persists across client-side navigations. No-op
+            in a browser. */}
+        <Script
+          id="onyx-desktop-detector"
+          strategy="beforeInteractive"
+          dangerouslySetInnerHTML={{
+            __html: `
+              if ('__TAURI_INTERNALS__' in window || '__TAURI__' in window) {
+                document.documentElement.classList.add('onyx-desktop');
+              }
+            `,
+          }}
+        />
+
         {GTM_ENABLED && (
           <Script
             id="google-tag-manager"


### PR DESCRIPTION
## Description

Combined cherry-pick of the following merged PRs to `release/v4.3` (clean picks, no conflicts):

- #12526 — fix(security): redact persona/MCP owner email + internal server_url from basic users (ENG-4251)
- #12559 — fix(confluence): pass scoped_token to group sync client
- #12534 — fix(desktop): keep app content below the macOS native title bar after login
- #12639 — fix(chat): base chat retention on last message time

## How Has This Been Tested?

Each change was tested in its original PR on `main`. All four commits cherry-picked cleanly with `-x` in merge order.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cherry-picks four fixes into v4.3: tighten PII redaction, fix Confluence group sync auth, keep desktop content below the macOS overlay title bar, and base chat retention on last message time.

- **Bug Fixes**
  - Security (ENG-4251): Redact persona owner email and MCP `server_url` for non-owner/non-admin users; only owners/admins see them. Added integration tests.
  - Confluence: Pass `scoped_token` to the group sync client to scope permissions correctly.
  - Desktop: Reserve native title-bar space on macOS/Tauri so content sits below it after login. Added `desktop-titlebar.css` and a runtime detector in layout.
  - Chat retention: Determine “old” sessions by the last message time (fallback to creation time if no messages). Added deterministic retention tests.

<sup>Written for commit e4ce19ca70f385d3b5e3469d2adb117e2e3b3b46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

