### PR TITLE
feat(chat): per-chat export as text and markdown in project menu

### DIFF
--- a/web/src/layouts/chromes/AppChrome.tsx
+++ b/web/src/layouts/chromes/AppChrome.tsx
@@ -25,6 +25,11 @@ import {
 import { handleMoveOperation } from "@/lib/sidebar/svc";
 import { LOCAL_STORAGE_KEYS } from "@/lib/sidebar/constants";
 import { deleteChatSession } from "@/app/app/services/lib";
+import {
+  exportChatSession,
+  ChatExportFormat,
+} from "@/lib/chat/exportChatSession";
+import { UNNAMED_CHAT } from "@/lib/constants";
 import { useRouter } from "next/navigation";
 import MoveCustomAgentChatModal from "@/sections/modals/MoveCustomAgentChatModal";
 import ConfirmationModalLayout from "@/refresh-components/layouts/ConfirmationModalLayout";
@@ -43,9 +48,11 @@ import { useSidebarState } from "@opal/layouts";
 import useScreenSize from "@/hooks/useScreenSize";
 import {
   SvgBubbleText,
+  SvgFileText,
   SvgFitWidth,
   SvgFolderIn,
   SvgFullWidth,
+  SvgHash,
   SvgMoreHorizontal,
   SvgSearchMenu,
   SvgShare,
@@ -194,6 +201,24 @@ function Header() {
     }
   }, []);
 
+  const handleExport = useCallback(
+    async (format: ChatExportFormat) => {
+      if (!currentChatSession) return;
+      setPopoverOpen(false);
+      try {
+        await exportChatSession(
+          currentChatSession.id,
+          currentChatSession.name || UNNAMED_CHAT,
+          format
+        );
+      } catch (error) {
+        console.error("Failed to export chat:", error);
+        showErrorNotification("Failed to export chat. Please try again.");
+      }
+    },
+    [currentChatSession]
+  );
+
   useEffect(() => {
     const items = showMoveOptions
       ? [
@@ -222,6 +247,24 @@ function Header() {
             title="Move to Project"
             onClick={noProp(() => setShowMoveOptions(true))}
           />,
+          null,
+          <LineItemButton
+            key="export-text"
+            sizePreset="main-ui"
+            rounding="sm"
+            icon={SvgFileText}
+            title="Export as Text"
+            onClick={noProp(() => handleExport("text"))}
+          />,
+          <LineItemButton
+            key="export-markdown"
+            sizePreset="main-ui"
+            rounding="sm"
+            icon={SvgHash}
+            title="Export as Markdown"
+            onClick={noProp(() => handleExport("markdown"))}
+          />,
+          null,
           <LineItemButton
             key="delete"
             sizePreset="main-ui"
@@ -240,6 +283,7 @@ function Header() {
     currentChatSession,
     setDeleteConfirmationModalOpen,
     handleMoveClick,
+    handleExport,
   ]);
 
   return (

--- a/web/src/layouts/chromes/AppChrome.tsx
+++ b/web/src/layouts/chromes/AppChrome.tsx
@@ -48,6 +48,8 @@ import { useSidebarState } from "@opal/layouts";
 import useScreenSize from "@/hooks/useScreenSize";
 import {
   SvgBubbleText,
+  SvgChevronLeft,
+  SvgDownload,
   SvgFileText,
   SvgFitWidth,
   SvgFolderIn,
@@ -89,6 +91,7 @@ function Header() {
     number | null
   >(null);
   const [showMoveOptions, setShowMoveOptions] = useState(false);
+  const [showExportOptions, setShowExportOptions] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [popoverItems, setPopoverItems] = useState<React.ReactNode[]>([]);
@@ -204,7 +207,6 @@ function Header() {
   const handleExport = useCallback(
     async (format: ChatExportFormat) => {
       if (!currentChatSession) return;
-      setPopoverOpen(false);
       try {
         await exportChatSession(
           currentChatSession.id,
@@ -220,65 +222,89 @@ function Header() {
   );
 
   useEffect(() => {
-    const items = showMoveOptions
-      ? [
-          <PopoverSearchInput
-            key="search"
-            setShowMoveOptions={setShowMoveOptions}
-            onSearch={setSearchTerm}
-          />,
-          ...filteredProjects.map((project) => (
-            <LineItemButton
-              key={project.id}
-              sizePreset="main-ui"
-              rounding="sm"
-              icon={SvgFolderIn}
-              title={project.name}
-              onClick={noProp(() => handleMoveClick(project.id))}
-            />
-          )),
-        ]
-      : [
+    let items: ReactNode[];
+    if (showMoveOptions) {
+      items = [
+        <PopoverSearchInput
+          key="search"
+          setShowMoveOptions={setShowMoveOptions}
+          onSearch={setSearchTerm}
+        />,
+        ...filteredProjects.map((project) => (
           <LineItemButton
-            key="move"
+            key={project.id}
             sizePreset="main-ui"
             rounding="sm"
             icon={SvgFolderIn}
-            title="Move to Project"
-            onClick={noProp(() => setShowMoveOptions(true))}
-          />,
-          null,
+            title={project.name}
+            onClick={noProp(() => handleMoveClick(project.id))}
+          />
+        )),
+      ];
+    } else if (showExportOptions) {
+      items = [
+        <LineItemButton
+          key="export-back"
+          sizePreset="main-ui"
+          rounding="sm"
+          icon={SvgChevronLeft}
+          title="Export As…"
+          onClick={noProp(() => setShowExportOptions(false))}
+        />,
+        <Popover.Close asChild key="export-plaintext">
           <LineItemButton
-            key="export-text"
             sizePreset="main-ui"
             rounding="sm"
             icon={SvgFileText}
-            title="Export as Text"
+            title="Plaintext"
             onClick={noProp(() => handleExport("text"))}
-          />,
+          />
+        </Popover.Close>,
+        <Popover.Close asChild key="export-markdown">
           <LineItemButton
-            key="export-markdown"
             sizePreset="main-ui"
             rounding="sm"
             icon={SvgHash}
-            title="Export as Markdown"
+            title="Markdown"
             onClick={noProp(() => handleExport("markdown"))}
-          />,
-          null,
-          <LineItemButton
-            key="delete"
-            sizePreset="main-ui"
-            rounding="sm"
-            color="danger"
-            icon={SvgTrash}
-            title="Delete"
-            onClick={noProp(() => setDeleteConfirmationModalOpen(true))}
-          />,
-        ];
+          />
+        </Popover.Close>,
+      ];
+    } else {
+      items = [
+        <LineItemButton
+          key="move"
+          sizePreset="main-ui"
+          rounding="sm"
+          icon={SvgFolderIn}
+          title="Move to Project"
+          onClick={noProp(() => setShowMoveOptions(true))}
+        />,
+        <LineItemButton
+          key="export"
+          sizePreset="main-ui"
+          rounding="sm"
+          icon={SvgDownload}
+          title="Export As…"
+          onClick={noProp(() => setShowExportOptions(true))}
+        />,
+        null,
+        <LineItemButton
+          key="delete"
+          sizePreset="main-ui"
+          rounding="sm"
+          color="danger"
+          icon={SvgTrash}
+          title="Delete"
+          onClick={noProp(() => setDeleteConfirmationModalOpen(true))}
+        />,
+      ];
+    }
 
     setPopoverItems(items);
   }, [
     showMoveOptions,
+    showExportOptions,
     filteredProjects,
     currentChatSession,
     setDeleteConfirmationModalOpen,
@@ -463,6 +489,7 @@ function Header() {
                         setPopoverOpen(state);
                         if (!state) {
                           setShowMoveOptions(false);
+                          setShowExportOptions(false);
                           setSearchTerm("");
                         }
                       }}

--- a/web/src/lib/chat/exportChatSession.test.ts
+++ b/web/src/lib/chat/exportChatSession.test.ts
@@ -78,7 +78,11 @@ function lastDownload(): {
   mimeType?: string;
 } {
   expect(mockedDownloadFile).toHaveBeenCalledTimes(1);
-  const [filename, opts] = mockedDownloadFile.mock.calls[0];
+  const call = mockedDownloadFile.mock.calls[0];
+  if (!call) {
+    throw new Error("downloadFile was not called");
+  }
+  const [filename, opts] = call;
   if (!("content" in opts)) {
     throw new Error("expected content-based download");
   }

--- a/web/src/lib/chat/exportChatSession.test.ts
+++ b/web/src/lib/chat/exportChatSession.test.ts
@@ -1,0 +1,171 @@
+import {
+  BackendChatSession,
+  BackendMessage,
+  ChatSessionSharedStatus,
+} from "@/app/app/interfaces";
+import { downloadFile } from "@/lib/download";
+import { exportChatSession } from "./exportChatSession";
+
+jest.mock("@/lib/download", () => ({
+  downloadFile: jest.fn(),
+}));
+
+const mockedDownloadFile = downloadFile as jest.MockedFunction<
+  typeof downloadFile
+>;
+
+function makeMessage(
+  message_type: string,
+  message: string,
+  overrides: Partial<BackendMessage> = {}
+): BackendMessage {
+  return {
+    message_id: 0,
+    message_type,
+    research_type: null,
+    parent_message: null,
+    latest_child_message: null,
+    message,
+    rephrased_query: null,
+    context_docs: null,
+    time_sent: "2026-01-01T00:00:00Z",
+    overridden_model: "",
+    alternate_assistant_id: null,
+    chat_session_id: "session-1",
+    citations: null,
+    files: [],
+    tool_call: null,
+    current_feedback: null,
+    sub_questions: [],
+    comments: null,
+    parentMessageId: null,
+    refined_answer_improvement: null,
+    is_agentic: null,
+    preferred_response_id: null,
+    model_display_name: null,
+    error: null,
+    ...overrides,
+  };
+}
+
+function makeSession(messages: BackendMessage[]): BackendChatSession {
+  return {
+    chat_session_id: "session-1",
+    description: "",
+    persona_id: 0,
+    persona_name: "",
+    messages,
+    time_created: "2026-01-01T00:00:00Z",
+    time_updated: "2026-01-01T00:00:00Z",
+    shared_status: ChatSessionSharedStatus.Private,
+    current_temperature_override: null,
+    owner_name: null,
+    packets: [],
+  };
+}
+
+function mockFetchOk(session: BackendChatSession): void {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => session,
+  }) as unknown as typeof fetch;
+}
+
+/** Grab the `{ filename, content, mimeType }` of the single download call. */
+function lastDownload(): {
+  filename: string;
+  content: string;
+  mimeType?: string;
+} {
+  expect(mockedDownloadFile).toHaveBeenCalledTimes(1);
+  const [filename, opts] = mockedDownloadFile.mock.calls[0];
+  if (!("content" in opts)) {
+    throw new Error("expected content-based download");
+  }
+  return { filename, content: opts.content, mimeType: opts.mimeType };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("exportChatSession", () => {
+  const conversation = [
+    makeMessage("user", "Hello there"),
+    makeMessage("assistant", "Hi! How can I help?"),
+  ];
+
+  it("exports a plain-text transcript with a .txt filename", async () => {
+    mockFetchOk(makeSession(conversation));
+
+    await exportChatSession("session-1", "My Chat", "text");
+
+    const { filename, content, mimeType } = lastDownload();
+    expect(filename).toBe("My_Chat.txt");
+    expect(mimeType).toBe("text/plain");
+    expect(content).toBe(
+      "My Chat\n\nUser:\nHello there\n\nAssistant:\nHi! How can I help?\n"
+    );
+  });
+
+  it("exports a markdown transcript with a .md filename and headings", async () => {
+    mockFetchOk(makeSession(conversation));
+
+    await exportChatSession("session-1", "My Chat", "markdown");
+
+    const { filename, content, mimeType } = lastDownload();
+    expect(filename).toBe("My_Chat.md");
+    expect(mimeType).toBe("text/markdown");
+    expect(content).toBe(
+      "# My Chat\n\n## User\n\nHello there\n\n## Assistant\n\nHi! How can I help?\n"
+    );
+  });
+
+  it("omits system, tool-call, reminder, and empty messages", async () => {
+    mockFetchOk(
+      makeSession([
+        makeMessage("system", "you are a helpful assistant"),
+        makeMessage("user", "Question?"),
+        makeMessage("tool_call_response", "{...}"),
+        makeMessage("assistant", "Answer."),
+        makeMessage("user_reminder", "reminder"),
+        makeMessage("assistant", "   "),
+      ])
+    );
+
+    await exportChatSession("session-1", "Chat", "text");
+
+    const { content } = lastDownload();
+    expect(content).toBe("Chat\n\nUser:\nQuestion?\n\nAssistant:\nAnswer.\n");
+  });
+
+  it("sanitizes unsafe characters in the filename", async () => {
+    mockFetchOk(makeSession(conversation));
+
+    await exportChatSession("session-1", "a/b: report? <v2>", "text");
+
+    expect(lastDownload().filename).toBe("a_b__report___v2_.txt");
+  });
+
+  it("falls back to the default chat name when the name is blank", async () => {
+    mockFetchOk(makeSession(conversation));
+
+    await exportChatSession("session-1", "   ", "markdown");
+
+    const { filename, content } = lastDownload();
+    expect(filename).toBe("New_Chat.md");
+    expect(content.startsWith("# New Chat\n")).toBe(true);
+  });
+
+  it("throws and does not download when the fetch fails", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+    }) as unknown as typeof fetch;
+
+    await expect(exportChatSession("missing", "Chat", "text")).rejects.toThrow(
+      "Failed to fetch chat session: 404"
+    );
+    expect(mockedDownloadFile).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/lib/chat/exportChatSession.ts
+++ b/web/src/lib/chat/exportChatSession.ts
@@ -1,0 +1,85 @@
+import { BackendChatSession, BackendMessage } from "@/app/app/interfaces";
+import { UNNAMED_CHAT } from "@/lib/constants";
+import { downloadFile } from "@/lib/download";
+
+export type ChatExportFormat = "text" | "markdown";
+
+// Only user/assistant turns carry conversational content worth exporting;
+// system, tool-call, and reminder messages are internal plumbing.
+const EXPORTABLE_MESSAGE_TYPES = new Set(["user", "assistant"]);
+
+function roleLabel(messageType: string): string {
+  if (messageType === "user") return "User";
+  if (messageType === "assistant") return "Assistant";
+  return messageType;
+}
+
+function exportableMessages(session: BackendChatSession): BackendMessage[] {
+  return session.messages.filter(
+    (message) =>
+      EXPORTABLE_MESSAGE_TYPES.has(message.message_type) &&
+      message.message.trim().length > 0
+  );
+}
+
+function chatSessionToText(session: BackendChatSession, title: string): string {
+  const blocks = exportableMessages(session).map(
+    (message) =>
+      `${roleLabel(message.message_type)}:\n${message.message.trim()}`
+  );
+  return [title, ...blocks].join("\n\n") + "\n";
+}
+
+function chatSessionToMarkdown(
+  session: BackendChatSession,
+  title: string
+): string {
+  const blocks = exportableMessages(session).map(
+    (message) =>
+      `## ${roleLabel(message.message_type)}\n\n${message.message.trim()}`
+  );
+  return [`# ${title}`, ...blocks].join("\n\n") + "\n";
+}
+
+// Collapse anything that isn't filename-safe so the download lands cleanly
+// across operating systems.
+function sanitizeFilename(name: string): string {
+  const trimmed = name.trim() || UNNAMED_CHAT;
+  return (
+    trimmed
+      .replace(/[^a-z0-9-_ ]/gi, "_")
+      .replace(/\s+/g, "_")
+      .slice(0, 100) || UNNAMED_CHAT
+  );
+}
+
+/**
+ * Fetch a chat session's full message history and trigger a browser download
+ * of its transcript as either plain text or markdown.
+ */
+export async function exportChatSession(
+  chatSessionId: string,
+  chatName: string,
+  format: ChatExportFormat
+): Promise<void> {
+  const response = await fetch(`/api/chat/get-chat-session/${chatSessionId}`);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch chat session: ${response.status}`);
+  }
+  const session = (await response.json()) as BackendChatSession;
+
+  const title = chatName.trim() || UNNAMED_CHAT;
+  const base = sanitizeFilename(chatName);
+
+  if (format === "markdown") {
+    downloadFile(`${base}.md`, {
+      content: chatSessionToMarkdown(session, title),
+      mimeType: "text/markdown",
+    });
+  } else {
+    downloadFile(`${base}.txt`, {
+      content: chatSessionToText(session, title),
+      mimeType: "text/plain",
+    });
+  }
+}

--- a/web/src/lib/chat/exportChatSession.ts
+++ b/web/src/lib/chat/exportChatSession.ts
@@ -45,12 +45,10 @@ function chatSessionToMarkdown(
 // across operating systems.
 function sanitizeFilename(name: string): string {
   const trimmed = name.trim() || UNNAMED_CHAT;
-  return (
-    trimmed
-      .replace(/[^a-z0-9-_ ]/gi, "_")
-      .replace(/\s+/g, "_")
-      .slice(0, 100) || UNNAMED_CHAT
-  );
+  return trimmed
+    .replace(/[^a-z0-9-_ ]/gi, "_")
+    .replace(/\s+/g, "_")
+    .slice(0, 100);
 }
 
 /**

--- a/web/src/sections/projects/ProjectChatSessionList.tsx
+++ b/web/src/sections/projects/ProjectChatSessionList.tsx
@@ -34,6 +34,7 @@ import {
 import { timeAgo } from "@opal/time";
 import type { IconFunctionComponent } from "@opal/types";
 import { noProp } from "@/lib/utils";
+import { showErrorNotification } from "@/lib/sidebar/utils";
 import MoveCustomAgentChatModal from "@/sections/modals/MoveCustomAgentChatModal";
 import ConfirmationModalLayout from "@/refresh-components/layouts/ConfirmationModalLayout";
 import { PopoverSearchInput } from "@/sections/sidebar/ChatButton";
@@ -135,7 +136,12 @@ function ProjectChatItem({
   const handleExport = useCallback(
     async (format: ChatExportFormat) => {
       setPopoverOpen(false);
-      await exportChatSession(chat.id, chat.name || UNNAMED_CHAT, format);
+      try {
+        await exportChatSession(chat.id, chat.name || UNNAMED_CHAT, format);
+      } catch (error) {
+        console.error("Failed to export chat:", error);
+        showErrorNotification("Failed to export chat. Please try again.");
+      }
     },
     [chat.id, chat.name]
   );

--- a/web/src/sections/projects/ProjectChatSessionList.tsx
+++ b/web/src/sections/projects/ProjectChatSessionList.tsx
@@ -23,8 +23,10 @@ import { Hoverable } from "@opal/core";
 import { DEFAULT_AGENT_ID, UNNAMED_CHAT } from "@/lib/constants";
 import {
   SvgBubbleText,
+  SvgFileText,
   SvgFolder,
   SvgFolderIn,
+  SvgHash,
   SvgMoreHorizontal,
   SvgSimpleLoader,
   SvgTrash,
@@ -35,6 +37,10 @@ import { noProp } from "@/lib/utils";
 import MoveCustomAgentChatModal from "@/sections/modals/MoveCustomAgentChatModal";
 import ConfirmationModalLayout from "@/refresh-components/layouts/ConfirmationModalLayout";
 import { PopoverSearchInput } from "@/sections/sidebar/ChatButton";
+import {
+  exportChatSession,
+  ChatExportFormat,
+} from "@/lib/chat/exportChatSession";
 
 const LS_HIDE_MOVE_CUSTOM_AGENT_MODAL_KEY = "onyx:hideMoveCustomAgentModal";
 
@@ -126,6 +132,14 @@ function ProjectChatItem({
     setPopoverOpen(false);
   }, [chat.id, fetchProjects, refreshChatSessions, afterRefresh]);
 
+  const handleExport = useCallback(
+    async (format: ChatExportFormat) => {
+      setPopoverOpen(false);
+      await exportChatSession(chat.id, chat.name || UNNAMED_CHAT, format);
+    },
+    [chat.id, chat.name]
+  );
+
   const popoverItems = useMemo(() => {
     if (!showMoveOptions) {
       return [
@@ -144,6 +158,23 @@ function ProjectChatItem({
           icon={SvgFolder}
           title={`Remove from ${projects.find((p) => p.id === projectId)?.name ?? "Project"}`}
           onClick={noProp(handleRemoveFromProject)}
+        />,
+        null,
+        <LineItemButton
+          key="export-text"
+          sizePreset="main-ui"
+          rounding="sm"
+          icon={SvgFileText}
+          title="Export as Text"
+          onClick={noProp(() => handleExport("text"))}
+        />,
+        <LineItemButton
+          key="export-markdown"
+          sizePreset="main-ui"
+          rounding="sm"
+          icon={SvgHash}
+          title="Export as Markdown"
+          onClick={noProp(() => handleExport("markdown"))}
         />,
         null,
         <LineItemButton
@@ -185,6 +216,7 @@ function ProjectChatItem({
     filteredProjects,
     handleMoveChatSession,
     handleRemoveFromProject,
+    handleExport,
   ]);
 
   return (

--- a/web/src/sections/projects/ProjectChatSessionList.tsx
+++ b/web/src/sections/projects/ProjectChatSessionList.tsx
@@ -23,10 +23,8 @@ import { Hoverable } from "@opal/core";
 import { DEFAULT_AGENT_ID, UNNAMED_CHAT } from "@/lib/constants";
 import {
   SvgBubbleText,
-  SvgFileText,
   SvgFolder,
   SvgFolderIn,
-  SvgHash,
   SvgMoreHorizontal,
   SvgSimpleLoader,
   SvgTrash,
@@ -34,14 +32,9 @@ import {
 import { timeAgo } from "@opal/time";
 import type { IconFunctionComponent } from "@opal/types";
 import { noProp } from "@/lib/utils";
-import { showErrorNotification } from "@/lib/sidebar/utils";
 import MoveCustomAgentChatModal from "@/sections/modals/MoveCustomAgentChatModal";
 import ConfirmationModalLayout from "@/refresh-components/layouts/ConfirmationModalLayout";
 import { PopoverSearchInput } from "@/sections/sidebar/ChatButton";
-import {
-  exportChatSession,
-  ChatExportFormat,
-} from "@/lib/chat/exportChatSession";
 
 const LS_HIDE_MOVE_CUSTOM_AGENT_MODAL_KEY = "onyx:hideMoveCustomAgentModal";
 
@@ -133,19 +126,6 @@ function ProjectChatItem({
     setPopoverOpen(false);
   }, [chat.id, fetchProjects, refreshChatSessions, afterRefresh]);
 
-  const handleExport = useCallback(
-    async (format: ChatExportFormat) => {
-      setPopoverOpen(false);
-      try {
-        await exportChatSession(chat.id, chat.name || UNNAMED_CHAT, format);
-      } catch (error) {
-        console.error("Failed to export chat:", error);
-        showErrorNotification("Failed to export chat. Please try again.");
-      }
-    },
-    [chat.id, chat.name]
-  );
-
   const popoverItems = useMemo(() => {
     if (!showMoveOptions) {
       return [
@@ -164,23 +144,6 @@ function ProjectChatItem({
           icon={SvgFolder}
           title={`Remove from ${projects.find((p) => p.id === projectId)?.name ?? "Project"}`}
           onClick={noProp(handleRemoveFromProject)}
-        />,
-        null,
-        <LineItemButton
-          key="export-text"
-          sizePreset="main-ui"
-          rounding="sm"
-          icon={SvgFileText}
-          title="Export as Text"
-          onClick={noProp(() => handleExport("text"))}
-        />,
-        <LineItemButton
-          key="export-markdown"
-          sizePreset="main-ui"
-          rounding="sm"
-          icon={SvgHash}
-          title="Export as Markdown"
-          onClick={noProp(() => handleExport("markdown"))}
         />,
         null,
         <LineItemButton
@@ -222,7 +185,6 @@ function ProjectChatItem({
     filteredProjects,
     handleMoveChatSession,
     handleRemoveFromProject,
-    handleExport,
   ]);
 
   return (


### PR DESCRIPTION
## What

Adds a per-chat **Export** action to the chat header's more-options (`•••`) menu in `AppChrome`, following the Figma design: a single **"Export As…"** entry that opens a submenu with **Plaintext** and **Markdown** options.

## How

- New utility `web/src/lib/chat/exportChatSession.ts`:
  - `exportChatSession(chatSessionId, chatName, format)` fetches the full session via `GET /api/chat/get-chat-session/{id}` and triggers a browser download using the existing `downloadFile` helper.
  - Only `user`/`assistant` turns with non-empty content are included (skips `system`, `tool_call_response`, `user_reminder`).
  - **Plaintext** → `.txt` (`text/plain`), `User:` / `Assistant:` labeled blocks.
  - **Markdown** → `.md` (`text/markdown`), `#` title + `##` role headings.
  - Filenames are sanitized (OS-safe chars, whitespace → `_`, 100-char cap) with an `UNNAMED_CHAT` fallback.
- `AppChrome.tsx` header menu: a `showExportOptions` state drives a three-branch popover (main / move sub-list / **export sub-list**). The main menu shows **Export As…** (opens the submenu); the submenu shows a back row + **Plaintext** + **Markdown**, mirroring the existing Move-to-Project sub-list pattern. Format items are wrapped in `Popover.Close` so selecting one closes the menu. Errors surface via `showErrorNotification`.

## Notes

- Export uses the **raw stored message text**. Assistant messages are already markdown source, so the markdown export renders cleanly and the plaintext export preserves the same raw content.
- Icons: **Plaintext** uses `SvgFileText` (matches the design). The design's **Markdown** glyph ("M↓") has no equivalent in the Opal icon set, so `SvgHash` is used as a stand-in — a dedicated markdown icon can be imported from Figma if exact parity is wanted.

## Testing

Jest unit test at `web/src/lib/chat/exportChatSession.test.ts` (6 cases, all passing) covering text + markdown output shape, filenames/mime types, message filtering, filename sanitization, blank-name fallback, and fetch-failure behavior.

Playwright was considered but skipped: the logic risk is entirely in the pure string transformation (well-covered by the unit test), and E2E would require a full stack plus seeded project/chat/messages — poor cost/coverage tradeoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)