### PR TITLE
fix(admin): grow form-input rows to the Figma input-column width

### DIFF
--- a/web/lib/opal/src/layouts/content-action/README.md
+++ b/web/lib/opal/src/layouts/content-action/README.md
@@ -16,6 +16,7 @@ Inherits **all** props from [`Content`](../content/README.md) (same discriminate
 |---|---|---|---|
 | `rightChildren` | `ReactNode` | `undefined` | Content rendered on the right side. Wrapper stretches to the full height of the row. |
 | `padding` | `SizeVariant` | `"lg"` | Padding preset applied around the `Content` area. Uses the shared size scale from `@opal/shared`. |
+| `fillRight` | `boolean` | `false` | When `true`, the `rightChildren` column grows to fill the row (capped at `--block-width-form-input-column-max`, 240px) instead of hugging its content. Use for full-width form inputs; leave off for compact controls like toggles/buttons. Ignored in the `responsive` branch. |
 
 ### `padding` reference
 
@@ -39,6 +40,10 @@ These values are identical to the padding applied by `Interactive.Container` at 
 - The outer wrapper is `flex flex-row items-stretch w-full`.
 - `Content` sits inside a `flex-1 min-w-0` div with padding from `padding`.
 - `rightChildren` is wrapped in `flex items-stretch shrink-0` so it stretches vertically.
+- With `fillRight`, the `rightChildren` wrapper instead becomes `flex-1 min-w-0` with a
+  `max-width: var(--block-width-form-input-column-max)` (240px) cap, so the input grows to fill
+  the row up to the Figma input-column width. The child input keeps its own `w-full` +
+  `min-width` floor.
 
 ## Usage Examples
 
@@ -84,6 +89,25 @@ import { SvgArrowExchange, SvgCloud } from "@opal/icons";
   }
 />
 ```
+
+### Full-width form input (`fillRight`)
+
+```tsx
+import { ContentAction } from "@opal/layouts";
+import { InputSelect } from "@/refresh-components/inputs/InputSelect";
+
+<ContentAction
+  title="Query History Visibility"
+  description="Control what is shown in query history"
+  sizePreset="main-ui"
+  variant="section"
+  fillRight
+  rightChildren={<InputSelect ... />}
+/>
+```
+
+The select grows to fill the row (up to 240px) instead of sitting at its content width. Compact
+controls like `Switch`/`Button` should omit `fillRight` so they keep hugging the right edge.
 
 ### No right children (padding-only wrapper)
 

--- a/web/lib/opal/src/layouts/content-action/components.tsx
+++ b/web/lib/opal/src/layouts/content-action/components.tsx
@@ -42,6 +42,16 @@ type ContentActionProps = ContentProps & {
    * @default false
    */
   responsive?: boolean;
+
+  /**
+   * When true, the `rightChildren` column grows to fill the row (capped at
+   * `--block-width-form-input-column-max`) instead of hugging its content.
+   * Intended for full-width form inputs; leave off for compact controls like
+   * toggles/buttons. Ignored in the `responsive` branch.
+   *
+   * @default false
+   */
+  fillRight?: boolean;
 };
 
 // ---------------------------------------------------------------------------
@@ -91,6 +101,7 @@ function ContentAction({
   padding = "lg",
   center = false,
   responsive = false,
+  fillRight = false,
   ...contentProps
 }: ContentActionProps) {
   const { padding: paddingClass } = containerSizeVariants[padding];
@@ -114,7 +125,9 @@ function ContentAction({
         <Content {...contentProps} />
       </div>
       {rightChildren && (
-        <div className="opal-content-action-right">{rightChildren}</div>
+        <div className="opal-content-action-right" data-fill={fillRight || undefined}>
+          {rightChildren}
+        </div>
       )}
     </div>
   );

--- a/web/lib/opal/src/layouts/content-action/components.tsx
+++ b/web/lib/opal/src/layouts/content-action/components.tsx
@@ -125,7 +125,10 @@ function ContentAction({
         <Content {...contentProps} />
       </div>
       {rightChildren && (
-        <div className="opal-content-action-right" data-fill={fillRight || undefined}>
+        <div
+          className="opal-content-action-right"
+          data-fill={fillRight || undefined}
+        >
           {rightChildren}
         </div>
       )}

--- a/web/lib/opal/src/layouts/content-action/styles.css
+++ b/web/lib/opal/src/layouts/content-action/styles.css
@@ -20,6 +20,13 @@
   @apply flex shrink-0 items-stretch;
 }
 
+/* Form-input rows: the control grows to fill the row, capped at the input
+   column max. The child input keeps its own min-width floor. */
+.opal-content-action-right[data-fill] {
+  @apply flex-1 min-w-0;
+  max-width: var(--block-width-form-input-column-max);
+}
+
 .opal-content-action[data-centered="true"] .opal-content-action-right {
   @apply items-center;
 }

--- a/web/lib/opal/src/layouts/inputs/README.md
+++ b/web/lib/opal/src/layouts/inputs/README.md
@@ -41,6 +41,9 @@ Places title/description on the left, input control on the right.
 | `withLabel` | `boolean \| string` | `false` | Same as Vertical |
 | `disabled` | `boolean` | `false` | Passes through to the label wrapper |
 | `center` | `boolean` | `false` | Vertically center the input with the label |
+| `icon` | `IconFunctionComponent` | — | Optional icon rendered beside the title |
+| `responsive` | `boolean` | `false` | Stack the control between title and description on narrow viewports (floats back to the right at `sm`). Best for text inputs; avoid for compact controls like toggles. |
+| `fillInput` | `boolean` | `false` | Grow the control to fill the row (capped at the form input-column max, 240px) instead of hugging its content. Use for full-width inputs like selects/text fields; avoid for compact controls like toggles/switches. Forwarded to `ContentAction` as `fillRight`. |
 | `title` | `string \| RichStr` | — | Section title |
 | `tag` | `TagProps` | — | Tag rendered beside the title |
 | `description` | `string \| RichStr` | — | Section description |
@@ -81,5 +84,15 @@ import { InputVertical, InputHorizontal } from "@opal/layouts";
 // No label (default) — for non-form children like buttons
 <InputHorizontal title="Delete" description="Remove this item">
   <Button variant="danger">Delete</Button>
+</InputHorizontal>
+
+// Full-width input — the select grows to fill the row (capped at 240px)
+<InputHorizontal
+  withLabel="visibility"
+  title="Query History Visibility"
+  description="Control what is shown in query history"
+  fillInput
+>
+  <InputSelect ... />
 </InputHorizontal>
 ```

--- a/web/lib/opal/src/layouts/inputs/components.tsx
+++ b/web/lib/opal/src/layouts/inputs/components.tsx
@@ -132,6 +132,12 @@ interface HorizontalProps extends InputLayoutProps {
    * compact controls like toggles/switches.
    */
   responsive?: boolean;
+  /**
+   * When true, the control grows to fill the row (capped at the form input
+   * column max) instead of hugging its content. Use for full-width inputs like
+   * selects/text fields; avoid for compact controls like toggles/switches.
+   */
+  fillInput?: boolean;
 }
 
 function Horizontal({
@@ -146,6 +152,7 @@ function Horizontal({
   description,
   suffix,
   responsive,
+  fillInput,
 }: HorizontalProps) {
   const fieldName =
     typeof withLabelProp === "string" ? withLabelProp : undefined;
@@ -164,6 +171,7 @@ function Horizontal({
         padding="fit"
         center={center}
         responsive={responsive}
+        fillRight={fillInput}
         rightChildren={children}
       />
       {fieldName && <FormikInputError name={fieldName} />}

--- a/web/src/views/admin/ChatPreferencesPage.tsx
+++ b/web/src/views/admin/ChatPreferencesPage.tsx
@@ -1135,6 +1135,7 @@ export default function ChatPreferencesPage() {
                         }
                         disabled={!enterpriseTier}
                         withLabel
+                        fillInput
                       >
                         <RetentionField
                           value={s.maximum_chat_retention_days ?? null}
@@ -1150,6 +1151,7 @@ export default function ChatPreferencesPage() {
                       title="Query History Visibility"
                       description="Control how your organization's full chat history appears in the Admin Panel."
                       withLabel
+                      fillInput
                     >
                       <InputSelect
                         value={s.query_history_type ?? QueryHistoryType.NORMAL}


### PR DESCRIPTION
## Problem

On the admin **Chat Preferences** page, the **Query History Visibility** dropdown (value "Show with User Info") and the **Keep Chat History** select rendered at their 160px min-width instead of expanding to the [Figma spec](https://www.figma.com/design/sNcHyrXBLtTFDK0ijjMnSk/Admin-Panel?node-id=2264-145369&m=dev).

The dropdown already carried the correct `min-width`; the real gap was **flex-grow**. In Figma the input's column is `flex-[1_0_0] max-w-[240px]` with a `min-w-[160px]` control, but `InputHorizontal`'s right column is `.opal-content-action-right { flex shrink-0 }` — so the control never grew.

## Change

Add an **opt-in** grow variant so this only affects full-width inputs, not the compact Switch/toggle rows that share `InputHorizontal`:

- `content-action/styles.css` — new `.opal-content-action-right[data-fill]` variant: `flex-1 min-w-0; max-width: var(--block-width-form-input-column-max)` (the existing but previously-unused 240px token).
- `ContentAction` — new `fillRight?: boolean` prop that sets `data-fill`.
- `InputHorizontal` (`Horizontal`) — new `fillInput?: boolean` prop, forwarded as `fillRight`.
- `ChatPreferencesPage` — `fillInput` on the two `InputSelect` rows. Switch rows untouched.

The control keeps its own `min-w-(--block-width-form-input-min)` (160px) floor, reproducing Figma's `[160px, 240px]` band.

## Verification

Measured against the live compiled stylesheet:

- Tokens resolve to the Figma values — input-column-max = 240px, input-min = 160px.
- `[data-fill]` → `flex-grow: 1`, `max-width: 240px`. Wide/medium rows grow the select to **240px**; a narrow row floors it at **160px**.
- A row **without** `data-fill` (a Switch) stays at **36px / `flex-grow: 0`** — compact-control rows are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**before**
<img width="2473" height="2085" alt="20260706_11h22m18s_grim" src="https://github.com/user-attachments/assets/b0b2cdef-81fe-4566-8d0e-431123020fd5" />

**after**
<img width="2473" height="2085" alt="20260706_11h22m23s_grim" src="https://github.com/user-attachments/assets/b25c83c1-78fc-4214-9b47-12fe3a6a9415" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Grow form-input rows to the Figma input-column width so the two selects on the Admin Chat Preferences page expand up to 240px instead of sticking at 160px. Compact controls (switches) are unchanged.

- **Bug Fixes**
  - Added `fillRight` to `ContentAction` and a `[data-fill]` CSS variant (`flex-1 min-w-0; max-width: var(--block-width-form-input-column-max)` = 240px).
  - Added `fillInput` to `InputHorizontal` and enabled it for the two `InputSelect` rows in `ChatPreferencesPage`.
  - Kept the input’s 160px min-width token, matching the 160–240px band from Figma.
  - Documented `fillRight`/`fillInput` in `@opal/layouts` READMEs with examples for full-width inputs.

<sup>Written for commit 00e918b6ee205ec1a562bb9448af9aa275f59630. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



