### PR TITLE
fix(helm): v4.3 chart deploy blockers — sandbox-proxy IPv6 netpol fail-closed + duplicate server_tokens nginx crash-loop

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.6.7
+version: 0.6.8
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/templates/nginx-conf.yaml
+++ b/deployment/helm/charts/onyx/templates/nginx-conf.yaml
@@ -14,9 +14,6 @@ metadata:
   name: onyx-nginx-conf
 data:
   upstreams.conf: |
-    # Don't expose the nginx version in the Server header or on error pages
-    server_tokens off;
-
     upstream api_server {
         server {{ include "onyx.fullname" . }}-api-service:{{ .Values.api.service.servicePort }} fail_timeout=0;
     }

--- a/deployment/helm/charts/onyx/templates/sandbox-proxy/networkpolicy-egress.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-proxy/networkpolicy-egress.yaml
@@ -24,22 +24,25 @@ spec:
       {{- include "onyx.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: sandbox-proxy
   policyTypes: [Egress]
-  # IPv4 and IPv6 are kept in SEPARATE egress rules on purpose. AWS VPC CNI fails the
-  # whole policy closed (drops ALL egress) when both an IPv4 and an IPv6 ipBlock share a
-  # single `to:` peer list; splitting them into distinct rules programs correctly.
-  # Verified on the craft-dev EKS cluster (VPC CNI enforcing).
+  # The IPv6 rule is opt-in (sandboxProxy.egressAllowIPv6) and OFF by default. Even as a
+  # separate egress rule, the AWS VPC CNI network-policy agent intermittently fails to
+  # program an IPv6 ipBlock into the egress eBPF map (EINVAL), which leaves the map empty
+  # and FAIL-CLOSED — new sandbox-proxy pods crash-loop unable to reach the api-server.
+  # Single-stack IPv4 clusters (the common case) have no IPv6 egress to gate anyway.
+  # Dual-stack clusters must enable it: once an Egress policy selects the pod, unmatched
+  # IPv6 is denied, so an IPv4-only allow silently drops all IPv6 egress there.
   egress:
     - to:
         - ipBlock:
             cidr: 0.0.0.0/0
             except:
               - 169.254.0.0/16 # link-local incl. cloud metadata (IMDS) — SSRF block
-    # IPv6: once an Egress policy selects the pod, unmatched IPv6 is denied, so an
-    # IPv4-only allow would silently drop all IPv6 egress on dual-stack clusters.
+    {{- if .Values.sandboxProxy.egressAllowIPv6 }}
     - to:
         - ipBlock:
             cidr: ::/0
             except:
               - fe80::/10         # link-local
               - fd00:ec2::254/128 # IPv6 cloud metadata (IMDS) — SSRF block
+    {{- end }}
 {{- end }}

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1591,6 +1591,12 @@ sandboxPod:
 
 # -- Sandbox egress proxy.
 sandboxProxy:
+  # Allow IPv6 (::/0 minus link-local/IMDS) egress from the proxy. OFF by default: the AWS
+  # VPC CNI network-policy agent intermittently fails to program IPv6 ipBlocks into the
+  # egress eBPF map (EINVAL), leaving it empty and fail-closed (proxy pods crash-loop), and
+  # single-stack IPv4 clusters have no IPv6 egress to gate. Enable ONLY on dual-stack
+  # clusters, where an Egress policy without an IPv6 allow silently drops all IPv6 egress.
+  egressAllowIPv6: false
   replicaCount: 2
   terminationGracePeriodSeconds: 200
   progressDeadlineSeconds: 300

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -297,7 +297,7 @@ nginx:
     # The ingress-nginx subchart doesn't auto-detect our custom ConfigMap changes.
     # Workaround: Helm upgrade will restart if the following annotation value changes.
     podAnnotations:
-      onyx.app/nginx-config-version: "5"
+      onyx.app/nginx-config-version: "6"
 
     # Propagate DOMAIN into nginx so server_name continues to use the same env var
     extraEnvs:
@@ -305,6 +305,11 @@ nginx:
         value: localhost
 
     config:
+      # Hide the nginx version in Server headers/error pages. Set via the
+      # controller's supported knob — do NOT put `server_tokens` in the
+      # http-snippet files: ingress-nginx already emits the directive in the
+      # http{} block, and a duplicate fails `nginx -t` (config reload/startup).
+      server-tokens: "false"
       # Expose DOMAIN to the nginx config and pull in our custom snippets
       main-snippet: |
         env DOMAIN;


### PR DESCRIPTION
## Description

Two independent chart bugs that both crash-loop pods on a fresh v4.3.0 (chart 0.6.7) single-tenant deployment; bundled per cherry-pick convention.

**1. sandbox-proxy egress NetworkPolicy IPv6 rule fails closed (Craft + VPC CNI enforcement)**
The AWS network-policy agent intermittently fails to program the IPv6 `::/0` ipBlock into the egress eBPF map (EINVAL) — even as a separate egress rule — leaving the map empty and fail-closed; affected sandbox-proxy pods crash-loop unable to reach the api-server for the proxy CA secret. Same failure mode was previously fixed on the managed-cloud raw manifests but the chart template still shipped the rule. Fix: IPv6 rule now gated behind `sandboxProxy.egressAllowIPv6` (default `false`; single-stack IPv4 clusters have no IPv6 egress to gate). Dual-stack clusters must opt in — documented in the values comment.

**2. Duplicate `server_tokens` directive crash-loops the bundled nginx controller**

Fixes #12675.
#12401 added `server_tokens off;` to the chart's custom `upstreams.conf` http-snippet, but ingress-nginx always emits `server_tokens` in the `http{}` block itself, so `nginx -t` fails ("directive is duplicate") and new controller pods crash-loop, wedging the rollout. Untested until now because internal deployments run a hardened standalone nginx instead of the subchart path. Fix: drop the directive from the snippet and set the controller's supported `server-tokens: "false"` config knob instead (same hardening, exactly one directive); bump `onyx.app/nginx-config-version` 5→6 so nginx pods restart on upgrade. Chart bumped to 0.6.8.

## How Has This Been Tested?

- `helm template` (Craft-enabled values, kube 1.33): default render has no `::/0` rule and zero `server_tokens` occurrences in the custom snippet; the controller ConfigMap carries `server-tokens: "false"`; `--set sandboxProxy.egressAllowIPv6=true` restores the full IPv6 rule.
- Both fixes validated live on an affected NP-enforcing EKS deployment: the equivalent netpol patch recovered the crash-looping sandbox-proxy replica (2/2 Ready); the nginx crash-loop reproduces the exact `server_tokens directive is duplicate` error this removes.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

