### PR TITLE
feat(ods): add `audit ignore` TUI for the advisory allowlist

### DIFF
--- a/tools/ods/cmd/audit.go
+++ b/tools/ods/cmd/audit.go
@@ -49,7 +49,7 @@ how it gates deploys.`,
 	cmd.Flags().StringVar(&opts.IgnoreURL, "ignore-url", audit.DefaultIgnoreURL, "S3 URL of the advisory allowlist")
 
 	cmd.AddCommand(newAuditImageCommand())
-	cmd.AddCommand(newAuditEditCommand())
+	cmd.AddCommand(newAuditIgnoreCommand())
 
 	return cmd
 }

--- a/tools/ods/cmd/audit.go
+++ b/tools/ods/cmd/audit.go
@@ -49,6 +49,7 @@ how it gates deploys.`,
 	cmd.Flags().StringVar(&opts.IgnoreURL, "ignore-url", audit.DefaultIgnoreURL, "S3 URL of the advisory allowlist")
 
 	cmd.AddCommand(newAuditImageCommand())
+	cmd.AddCommand(newAuditEditCommand())
 
 	return cmd
 }

--- a/tools/ods/cmd/audit_edit.go
+++ b/tools/ods/cmd/audit_edit.go
@@ -1,0 +1,183 @@
+package cmd
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/audit"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/prompt"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/tui"
+)
+
+// AuditEditOptions holds options for the `ods audit edit` command.
+type AuditEditOptions struct {
+	IgnoreURL string
+}
+
+// newAuditEditCommand creates the `ods audit edit` subcommand.
+func newAuditEditCommand() *cobra.Command {
+	opts := &AuditEditOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "edit",
+		Short: "Edit the audit advisory allowlist in a TUI",
+		Long: `Edit the audit advisory allowlist.
+
+Fetches the allowlist (from S3 by default), opens a terminal table where you can
+add, edit, and delete suppressions, then uploads the result back after a
+confirmation prompt. Pass a local file path to --ignore-url to edit a file on
+disk instead of S3.`,
+		Args: cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			runAuditEdit(opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.IgnoreURL, "ignore-url", audit.DefaultIgnoreURL, "S3 URL or local path of the advisory allowlist")
+
+	return cmd
+}
+
+func runAuditEdit(opts *AuditEditOptions) {
+	url := opts.IgnoreURL
+
+	orig, err := audit.FetchIgnores(url)
+	if err != nil {
+		log.Fatalf("Failed to fetch allowlist from %s: %v", url, err)
+	}
+
+	rows := make([]map[string]string, len(orig))
+	for i, e := range orig {
+		rows[i] = entryToRow(e)
+	}
+
+	cols := ignoreColumns(gitUserEmail())
+
+	editedRows, saved, err := tui.EditRows("Audit allowlist — "+url, cols, rows)
+	if err != nil {
+		// No usable terminal (e.g. piped input): show a read-only dump instead of
+		// crashing, and leave the allowlist untouched.
+		log.Debugf("TUI editor unavailable: %v", err)
+		printIgnores(orig)
+		log.Warnf("An interactive terminal is required to edit; edit %s manually.", url)
+		return
+	}
+	if !saved {
+		fmt.Println("No changes made.")
+		return
+	}
+
+	edited := make([]audit.IgnoreEntry, len(editedRows))
+	for i, r := range editedRows {
+		e := rowToEntry(r)
+		if err := audit.ValidateEntry(e); err != nil {
+			log.Fatalf("Invalid allowlist entry %q: %v", e.ID, err)
+		}
+		edited[i] = e
+	}
+	audit.SortIgnores(edited)
+
+	added, removed, changed := audit.DiffIgnores(orig, edited)
+	if len(added) == 0 && len(removed) == 0 && len(changed) == 0 {
+		fmt.Println("No changes to save.")
+		return
+	}
+
+	printDiff(added, removed, changed)
+
+	if !prompt.Confirm(fmt.Sprintf("Upload updated allowlist (%d entries) to %s? [Y/n] ", len(edited), url)) {
+		fmt.Println("Aborted; nothing uploaded.")
+		return
+	}
+
+	if err := audit.SaveIgnores(url, edited); err != nil {
+		log.Fatalf("Failed to save allowlist: %v", err)
+	}
+	fmt.Printf("Uploaded %d entries to %s\n", len(edited), url)
+}
+
+// ignoreColumns is the table/form schema for an IgnoreEntry. defaultAddedBy
+// prefills the "Added By" field of newly added entries.
+func ignoreColumns(defaultAddedBy string) []tui.Column {
+	return []tui.Column{
+		{Key: "id", Title: "ID", Required: true},
+		{Key: "ecosystem", Title: "Ecosystem"},
+		{Key: "reason", Title: "Reason"},
+		{Key: "added_by", Title: "Added By", Default: defaultAddedBy},
+		{Key: "expires", Title: "Expires", Validate: audit.ValidateExpires},
+	}
+}
+
+func entryToRow(e audit.IgnoreEntry) map[string]string {
+	return map[string]string{
+		"id":        e.ID,
+		"ecosystem": e.Ecosystem,
+		"reason":    e.Reason,
+		"added_by":  e.AddedBy,
+		"expires":   e.Expires,
+	}
+}
+
+func rowToEntry(r map[string]string) audit.IgnoreEntry {
+	return audit.IgnoreEntry{
+		ID:        r["id"],
+		Ecosystem: r["ecosystem"],
+		Reason:    r["reason"],
+		AddedBy:   r["added_by"],
+		Expires:   r["expires"],
+	}
+}
+
+func printIgnores(entries []audit.IgnoreEntry) {
+	if len(entries) == 0 {
+		fmt.Println("Allowlist is empty.")
+		return
+	}
+	fmt.Printf("Allowlist (%d entries):\n", len(entries))
+	for _, e := range entries {
+		fmt.Printf("  - %s\n", formatEntry(e))
+	}
+}
+
+func printDiff(added, removed, changed []audit.IgnoreEntry) {
+	fmt.Println("Changes:")
+	for _, e := range added {
+		fmt.Printf("  + %s\n", formatEntry(e))
+	}
+	for _, e := range removed {
+		fmt.Printf("  - %s\n", formatEntry(e))
+	}
+	for _, e := range changed {
+		fmt.Printf("  ~ %s\n", formatEntry(e))
+	}
+}
+
+func formatEntry(e audit.IgnoreEntry) string {
+	parts := []string{e.ID}
+	if e.Ecosystem != "" {
+		parts = append(parts, "eco="+e.Ecosystem)
+	}
+	if e.Expires != "" {
+		parts = append(parts, "expires="+e.Expires)
+	}
+	if e.AddedBy != "" {
+		parts = append(parts, "by="+e.AddedBy)
+	}
+	if e.Reason != "" {
+		parts = append(parts, "reason="+e.Reason)
+	}
+	return strings.Join(parts, "  ")
+}
+
+// gitUserEmail returns the configured git user email, or "" if unavailable.
+func gitUserEmail() string {
+	out, err := exec.Command("git", "config", "user.email").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/tools/ods/cmd/audit_ignore.go
+++ b/tools/ods/cmd/audit_ignore.go
@@ -13,38 +13,57 @@ import (
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/tui"
 )
 
-// AuditEditOptions holds options for the `ods audit edit` command.
-type AuditEditOptions struct {
+// AuditIgnoreOptions holds options shared by the `ods audit ignore` commands.
+type AuditIgnoreOptions struct {
 	IgnoreURL string
 }
 
-// newAuditEditCommand creates the `ods audit edit` subcommand.
-func newAuditEditCommand() *cobra.Command {
-	opts := &AuditEditOptions{}
+// newAuditIgnoreCommand creates the `ods audit ignore` command group. Running it
+// bare opens the allowlist editor, the same as `ods audit ignore edit`.
+func newAuditIgnoreCommand() *cobra.Command {
+	opts := &AuditIgnoreOptions{}
 
 	cmd := &cobra.Command{
+		Use:   "ignore",
+		Short: "Manage the audit advisory allowlist",
+		Long: `Manage the audit advisory allowlist (the suppressions applied by "ods audit").
+
+Run bare to open the interactive editor, or use a subcommand. The allowlist is
+fetched from S3 by default; pass a local file path to --ignore-url to edit a file
+on disk instead.`,
+		Args: cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			runAuditEdit(opts.IgnoreURL)
+		},
+	}
+
+	// A persistent flag so both the bare command and its subcommands share it.
+	cmd.PersistentFlags().StringVar(&opts.IgnoreURL, "ignore-url", audit.DefaultIgnoreURL, "S3 URL or local path of the advisory allowlist")
+
+	cmd.AddCommand(newAuditIgnoreEditCommand(opts))
+
+	return cmd
+}
+
+// newAuditIgnoreEditCommand creates the `ods audit ignore edit` subcommand. It
+// shares the parent's --ignore-url via the passed options.
+func newAuditIgnoreEditCommand(opts *AuditIgnoreOptions) *cobra.Command {
+	return &cobra.Command{
 		Use:   "edit",
 		Short: "Edit the audit advisory allowlist in a TUI",
 		Long: `Edit the audit advisory allowlist.
 
 Fetches the allowlist (from S3 by default), opens a terminal table where you can
 add, edit, and delete suppressions, then uploads the result back after a
-confirmation prompt. Pass a local file path to --ignore-url to edit a file on
-disk instead of S3.`,
+confirmation prompt.`,
 		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			runAuditEdit(opts)
+			runAuditEdit(opts.IgnoreURL)
 		},
 	}
-
-	cmd.Flags().StringVar(&opts.IgnoreURL, "ignore-url", audit.DefaultIgnoreURL, "S3 URL or local path of the advisory allowlist")
-
-	return cmd
 }
 
-func runAuditEdit(opts *AuditEditOptions) {
-	url := opts.IgnoreURL
-
+func runAuditEdit(url string) {
 	orig, err := audit.FetchIgnores(url)
 	if err != nil {
 		log.Fatalf("Failed to fetch allowlist from %s: %v", url, err)

--- a/tools/ods/cmd/audit_ignore.go
+++ b/tools/ods/cmd/audit_ignore.go
@@ -64,7 +64,7 @@ confirmation prompt.`,
 }
 
 func runAuditEdit(url string) {
-	orig, err := audit.FetchIgnores(url)
+	orig, err := audit.LoadIgnoresForEdit(url)
 	if err != nil {
 		log.Fatalf("Failed to fetch allowlist from %s: %v", url, err)
 	}
@@ -99,6 +99,12 @@ func runAuditEdit(url string) {
 		edited[i] = e
 	}
 	audit.SortIgnores(edited)
+
+	if dups := audit.DuplicateKeys(edited); len(dups) > 0 {
+		log.Errorf("Duplicate entries (id + ecosystem): %s", strings.Join(dups, ", "))
+		fmt.Println("Nothing uploaded; remove the duplicates and try again.")
+		return
+	}
 
 	added, removed, changed := audit.DiffIgnores(orig, edited)
 	if len(added) == 0 && len(removed) == 0 && len(changed) == 0 {

--- a/tools/ods/internal/audit/audit.go
+++ b/tools/ods/internal/audit/audit.go
@@ -170,7 +170,7 @@ func Run(opts Options) (*Result, error) {
 		}
 	}
 
-	ignores, err := fetchIgnores(opts.IgnoreURL)
+	ignores, err := FetchIgnores(opts.IgnoreURL)
 	if err != nil {
 		// Err toward blocking: proceed with an empty allowlist so unignored
 		// criticals still fail the gate rather than slipping through.

--- a/tools/ods/internal/audit/ignore.go
+++ b/tools/ods/internal/audit/ignore.go
@@ -36,8 +36,9 @@ type ignoreFile struct {
 }
 
 // FetchIgnores downloads and parses the allowlist from an s3:// URL. A plain
-// local path (no s3:// prefix) is read directly from disk. An empty URL yields
-// an empty list.
+// local path (no s3:// prefix) is read directly from disk; a missing file is an
+// error, so a typo'd --ignore-url surfaces rather than silently yielding no
+// suppressions. An empty URL yields an empty list.
 func FetchIgnores(url string) ([]IgnoreEntry, error) {
 	if url == "" {
 		return nil, nil
@@ -62,13 +63,11 @@ func FetchIgnores(url string) ([]IgnoreEntry, error) {
 }
 
 // readIgnoresFile reads and parses an allowlist from a local file. A missing
-// file yields an empty list so a first edit can start from scratch.
+// file returns an os.ErrNotExist error; callers that want to bootstrap an empty
+// allowlist (e.g. the editor) should use LoadIgnoresForEdit.
 func readIgnoresFile(path string) ([]IgnoreEntry, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
 		return nil, err
 	}
 	var f ignoreFile

--- a/tools/ods/internal/audit/ignore.go
+++ b/tools/ods/internal/audit/ignore.go
@@ -35,11 +35,16 @@ type ignoreFile struct {
 	Ignores []IgnoreEntry `json:"ignores"`
 }
 
-// fetchIgnores downloads and parses the allowlist from an s3:// URL. An empty
-// URL yields an empty list.
-func fetchIgnores(url string) ([]IgnoreEntry, error) {
+// FetchIgnores downloads and parses the allowlist from an s3:// URL. A plain
+// local path (no s3:// prefix) is read directly from disk. An empty URL yields
+// an empty list.
+func FetchIgnores(url string) ([]IgnoreEntry, error) {
 	if url == "" {
 		return nil, nil
+	}
+
+	if !strings.HasPrefix(url, "s3://") {
+		return readIgnoresFile(url)
 	}
 
 	tmp, err := os.CreateTemp("", "ods-audit-ignores-*.json")
@@ -53,15 +58,22 @@ func fetchIgnores(url string) ([]IgnoreEntry, error) {
 	if err := s3.FetchToFile(url, tmpPath); err != nil {
 		return nil, err
 	}
+	return readIgnoresFile(tmpPath)
+}
 
-	data, err := os.ReadFile(tmpPath)
+// readIgnoresFile reads and parses an allowlist from a local file. A missing
+// file yields an empty list so a first edit can start from scratch.
+func readIgnoresFile(path string) ([]IgnoreEntry, error) {
+	data, err := os.ReadFile(path)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
 		return nil, err
 	}
-
 	var f ignoreFile
 	if err := json.Unmarshal(data, &f); err != nil {
-		return nil, fmt.Errorf("failed to parse allowlist %s: %w", url, err)
+		return nil, fmt.Errorf("failed to parse allowlist %s: %w", path, err)
 	}
 	return f.Ignores, nil
 }

--- a/tools/ods/internal/audit/ignore_edit.go
+++ b/tools/ods/internal/audit/ignore_edit.go
@@ -2,6 +2,7 @@ package audit
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -14,6 +15,45 @@ import (
 // MarshalIgnores serializes entries as the on-disk allowlist JSON document.
 func MarshalIgnores(entries []IgnoreEntry) ([]byte, error) {
 	return json.MarshalIndent(ignoreFile{Ignores: entries}, "", "  ")
+}
+
+// LoadIgnoresForEdit fetches the allowlist for interactive editing. Unlike
+// FetchIgnores, a missing local file yields an empty list so the editor can
+// bootstrap a fresh allowlist. A missing S3 object is still an error, so the
+// editor never overwrites the real list after a transient fetch failure.
+func LoadIgnoresForEdit(url string) ([]IgnoreEntry, error) {
+	entries, err := FetchIgnores(url)
+	if err != nil && !strings.HasPrefix(url, "s3://") && errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	return entries, err
+}
+
+// DuplicateKeys returns the id+ecosystem keys that appear more than once,
+// formatted for display. Two entries with the same id and ecosystem are
+// redundant suppressions and would collapse in DiffIgnores.
+func DuplicateKeys(entries []IgnoreEntry) []string {
+	counts := make(map[string]int, len(entries))
+	order := make([]string, 0, len(entries))
+	for _, e := range entries {
+		k := ignoreKey(e)
+		if counts[k] == 0 {
+			order = append(order, k)
+		}
+		counts[k]++
+	}
+	var dups []string
+	for _, k := range order {
+		if counts[k] > 1 {
+			id, eco, _ := strings.Cut(k, "\x00")
+			label := id
+			if eco != "" {
+				label += " (" + eco + ")"
+			}
+			dups = append(dups, label)
+		}
+	}
+	return dups
 }
 
 // ValidateEntry checks a single allowlist entry: id is required and expires,
@@ -89,6 +129,9 @@ func SaveIgnores(url string, entries []IgnoreEntry) error {
 		if err := ValidateEntry(e); err != nil {
 			return fmt.Errorf("invalid allowlist entry %q: %w", e.ID, err)
 		}
+	}
+	if dups := DuplicateKeys(entries); len(dups) > 0 {
+		return fmt.Errorf("duplicate allowlist entries (id + ecosystem): %s", strings.Join(dups, ", "))
 	}
 	SortIgnores(entries)
 

--- a/tools/ods/internal/audit/ignore_edit.go
+++ b/tools/ods/internal/audit/ignore_edit.go
@@ -1,0 +1,122 @@
+package audit
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/s3"
+)
+
+// MarshalIgnores serializes entries as the on-disk allowlist JSON document.
+func MarshalIgnores(entries []IgnoreEntry) ([]byte, error) {
+	return json.MarshalIndent(ignoreFile{Ignores: entries}, "", "  ")
+}
+
+// ValidateEntry checks a single allowlist entry: id is required and expires,
+// when set, must be a YYYY-MM-DD date.
+func ValidateEntry(e IgnoreEntry) error {
+	if strings.TrimSpace(e.ID) == "" {
+		return fmt.Errorf("id is required")
+	}
+	if err := ValidateExpires(e.Expires); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ValidateExpires reports whether a non-empty expires value is a YYYY-MM-DD
+// date. An empty value (never expires) is valid.
+func ValidateExpires(s string) error {
+	if s == "" {
+		return nil
+	}
+	if _, err := time.Parse(expiresLayout, s); err != nil {
+		return fmt.Errorf("must be YYYY-MM-DD")
+	}
+	return nil
+}
+
+// SortIgnores orders entries by id then ecosystem (case-insensitive) for stable,
+// diff-friendly output.
+func SortIgnores(entries []IgnoreEntry) {
+	sort.SliceStable(entries, func(i, j int) bool {
+		a, b := entries[i], entries[j]
+		if !strings.EqualFold(a.ID, b.ID) {
+			return strings.ToLower(a.ID) < strings.ToLower(b.ID)
+		}
+		return strings.ToLower(a.Ecosystem) < strings.ToLower(b.Ecosystem)
+	})
+}
+
+// DiffIgnores compares two allowlists keyed by id+ecosystem and returns the
+// entries added, removed, and changed (same key, other fields differ).
+func DiffIgnores(oldEntries, newEntries []IgnoreEntry) (added, removed, changed []IgnoreEntry) {
+	oldByKey := make(map[string]IgnoreEntry, len(oldEntries))
+	for _, e := range oldEntries {
+		oldByKey[ignoreKey(e)] = e
+	}
+	newByKey := make(map[string]IgnoreEntry, len(newEntries))
+	for _, e := range newEntries {
+		newByKey[ignoreKey(e)] = e
+	}
+	for _, e := range newEntries {
+		if prev, ok := oldByKey[ignoreKey(e)]; !ok {
+			added = append(added, e)
+		} else if prev != e {
+			changed = append(changed, e)
+		}
+	}
+	for _, e := range oldEntries {
+		if _, ok := newByKey[ignoreKey(e)]; !ok {
+			removed = append(removed, e)
+		}
+	}
+	return added, removed, changed
+}
+
+func ignoreKey(e IgnoreEntry) string {
+	return strings.ToLower(e.ID) + "\x00" + strings.ToLower(e.Ecosystem)
+}
+
+// SaveIgnores validates, sorts, and writes the allowlist. An s3:// URL is
+// uploaded via the AWS CLI; a plain local path is written directly to disk.
+func SaveIgnores(url string, entries []IgnoreEntry) error {
+	for _, e := range entries {
+		if err := ValidateEntry(e); err != nil {
+			return fmt.Errorf("invalid allowlist entry %q: %w", e.ID, err)
+		}
+	}
+	SortIgnores(entries)
+
+	data, err := MarshalIgnores(entries)
+	if err != nil {
+		return fmt.Errorf("failed to marshal allowlist: %w", err)
+	}
+
+	if !strings.HasPrefix(url, "s3://") {
+		if err := os.WriteFile(url, data, 0644); err != nil {
+			return fmt.Errorf("failed to write allowlist %s: %w", url, err)
+		}
+		return nil
+	}
+
+	tmp, err := os.CreateTemp("", "ods-audit-ignores-*.json")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+
+	return s3.PutFile(tmpPath, url)
+}

--- a/tools/ods/internal/audit/ignore_edit_test.go
+++ b/tools/ods/internal/audit/ignore_edit_test.go
@@ -2,6 +2,8 @@ package audit
 
 import (
 	"encoding/json"
+	"errors"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -148,11 +150,43 @@ func TestSaveIgnoresRejectsInvalid(t *testing.T) {
 	}
 }
 
-func TestFetchIgnoresMissingLocalFile(t *testing.T) {
+func TestSaveIgnoresRejectsDuplicates(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "ignores.json")
+	err := SaveIgnores(path, []IgnoreEntry{
+		{ID: "GHSA-x", Ecosystem: "npm"},
+		{ID: "ghsa-x", Ecosystem: "NPM", Reason: "dup, case-insensitive"},
+	})
+	if err == nil {
+		t.Fatal("expected SaveIgnores to reject duplicate id+ecosystem entries")
+	}
+}
+
+func TestDuplicateKeys(t *testing.T) {
+	dups := DuplicateKeys([]IgnoreEntry{
+		{ID: "GHSA-a", Ecosystem: "npm"},
+		{ID: "GHSA-a", Ecosystem: "pypi"}, // distinct ecosystem, not a dup
+		{ID: "GHSA-a", Ecosystem: "npm"},  // dup of the first
+		{ID: "GHSA-b"},
+	})
+	if len(dups) != 1 {
+		t.Fatalf("expected 1 duplicate key, got %v", dups)
+	}
+}
+
+func TestFetchIgnoresMissingLocalFileErrors(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "does-not-exist.json")
-	got, err := FetchIgnores(path)
+	if _, err := FetchIgnores(path); err == nil {
+		t.Fatal("expected FetchIgnores to error on a missing local file")
+	} else if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected os.ErrNotExist, got %v", err)
+	}
+}
+
+func TestLoadIgnoresForEditMissingLocalFileBootstraps(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "does-not-exist.json")
+	got, err := LoadIgnoresForEdit(path)
 	if err != nil {
-		t.Fatalf("FetchIgnores on missing file should not error, got %v", err)
+		t.Fatalf("LoadIgnoresForEdit on missing local file should not error, got %v", err)
 	}
 	if got != nil {
 		t.Fatalf("expected nil entries for missing file, got %#v", got)

--- a/tools/ods/internal/audit/ignore_edit_test.go
+++ b/tools/ods/internal/audit/ignore_edit_test.go
@@ -1,0 +1,160 @@
+package audit
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestMarshalIgnoresRoundTrip(t *testing.T) {
+	entries := []IgnoreEntry{
+		{ID: "GHSA-aaaa", Ecosystem: "npm", Reason: "not reachable", AddedBy: "you@onyx.app", Expires: "2026-09-01"},
+		{ID: "GHSA-bbbb"},
+	}
+
+	data, err := MarshalIgnores(entries)
+	if err != nil {
+		t.Fatalf("MarshalIgnores: %v", err)
+	}
+
+	var f ignoreFile
+	if err := json.Unmarshal(data, &f); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(f.Ignores, entries) {
+		t.Fatalf("round trip mismatch:\n got %#v\nwant %#v", f.Ignores, entries)
+	}
+}
+
+func TestMarshalIgnoresOmitsEmptyFields(t *testing.T) {
+	data, err := MarshalIgnores([]IgnoreEntry{{ID: "GHSA-only"}})
+	if err != nil {
+		t.Fatalf("MarshalIgnores: %v", err)
+	}
+	for _, field := range []string{"ecosystem", "reason", "added_by", "expires"} {
+		if strings.Contains(string(data), field) {
+			t.Errorf("expected %q to be omitted, got:\n%s", field, data)
+		}
+	}
+}
+
+func TestValidateEntry(t *testing.T) {
+	tests := []struct {
+		name    string
+		entry   IgnoreEntry
+		wantErr bool
+	}{
+		{"ok minimal", IgnoreEntry{ID: "GHSA-x"}, false},
+		{"ok full", IgnoreEntry{ID: "GHSA-x", Expires: "2026-01-02"}, false},
+		{"empty id", IgnoreEntry{ID: "   "}, true},
+		{"bad expires", IgnoreEntry{ID: "GHSA-x", Expires: "09/01/2026"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateEntry(tt.entry)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ValidateEntry(%+v) err = %v, wantErr = %v", tt.entry, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateExpires(t *testing.T) {
+	if err := ValidateExpires(""); err != nil {
+		t.Errorf("empty expires should be valid, got %v", err)
+	}
+	if err := ValidateExpires("2026-09-01"); err != nil {
+		t.Errorf("valid expires rejected: %v", err)
+	}
+	if err := ValidateExpires("not-a-date"); err == nil {
+		t.Errorf("invalid expires accepted")
+	}
+}
+
+func TestSortIgnores(t *testing.T) {
+	entries := []IgnoreEntry{
+		{ID: "GHSA-b", Ecosystem: "pypi"},
+		{ID: "GHSA-a", Ecosystem: "npm"},
+		{ID: "GHSA-a", Ecosystem: "go"},
+	}
+	SortIgnores(entries)
+	got := []string{}
+	for _, e := range entries {
+		got = append(got, e.ID+"/"+e.Ecosystem)
+	}
+	want := []string{"GHSA-a/go", "GHSA-a/npm", "GHSA-b/pypi"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("SortIgnores order = %v, want %v", got, want)
+	}
+}
+
+func TestDiffIgnores(t *testing.T) {
+	oldEntries := []IgnoreEntry{
+		{ID: "A"},
+		{ID: "B", Reason: "old"},
+		{ID: "C"},
+	}
+	newEntries := []IgnoreEntry{
+		{ID: "A"},
+		{ID: "B", Reason: "new"},
+		{ID: "D"},
+	}
+	added, removed, changed := DiffIgnores(oldEntries, newEntries)
+
+	if len(added) != 1 || added[0].ID != "D" {
+		t.Errorf("added = %+v, want [D]", added)
+	}
+	if len(removed) != 1 || removed[0].ID != "C" {
+		t.Errorf("removed = %+v, want [C]", removed)
+	}
+	if len(changed) != 1 || changed[0].ID != "B" || changed[0].Reason != "new" {
+		t.Errorf("changed = %+v, want [B reason=new]", changed)
+	}
+}
+
+func TestSaveIgnoresLocalRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "ignores.json")
+	entries := []IgnoreEntry{
+		{ID: "GHSA-bbbb", Ecosystem: "pypi"},
+		{ID: "GHSA-aaaa", Ecosystem: "npm", Reason: "accepted"},
+	}
+
+	if err := SaveIgnores(path, entries); err != nil {
+		t.Fatalf("SaveIgnores: %v", err)
+	}
+
+	got, err := FetchIgnores(path)
+	if err != nil {
+		t.Fatalf("FetchIgnores: %v", err)
+	}
+
+	// SaveIgnores sorts before writing, so the read-back order is deterministic.
+	want := []IgnoreEntry{
+		{ID: "GHSA-aaaa", Ecosystem: "npm", Reason: "accepted"},
+		{ID: "GHSA-bbbb", Ecosystem: "pypi"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("read back = %#v, want %#v", got, want)
+	}
+}
+
+func TestSaveIgnoresRejectsInvalid(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "ignores.json")
+	err := SaveIgnores(path, []IgnoreEntry{{ID: ""}})
+	if err == nil {
+		t.Fatal("expected SaveIgnores to reject an entry with empty id")
+	}
+}
+
+func TestFetchIgnoresMissingLocalFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "does-not-exist.json")
+	got, err := FetchIgnores(path)
+	if err != nil {
+		t.Fatalf("FetchIgnores on missing file should not error, got %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil entries for missing file, got %#v", got)
+	}
+}

--- a/tools/ods/internal/audit/image.go
+++ b/tools/ods/internal/audit/image.go
@@ -31,7 +31,7 @@ func RunImage(opts ImageOptions) (*Result, error) {
 		return nil, fmt.Errorf("image scan failed: %w", err)
 	}
 
-	ignores, err := fetchIgnores(opts.IgnoreURL)
+	ignores, err := FetchIgnores(opts.IgnoreURL)
 	if err != nil {
 		// Err toward blocking: proceed with an empty allowlist so unignored
 		// criticals still fail the gate rather than slipping through.

--- a/tools/ods/internal/s3/put.go
+++ b/tools/ods/internal/s3/put.go
@@ -1,0 +1,33 @@
+package s3
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// PutFile uploads a single local file to an S3 object using the AWS CLI.
+// This is equivalent to: aws s3 cp <srcPath> <s3url>
+//
+// Unlike downloads, uploads have no unsigned fallback and always require AWS
+// credentials.
+func PutFile(srcPath string, s3url string) error {
+	if _, err := ParseS3URL(s3url); err != nil {
+		return err
+	}
+
+	log.Infof("Uploading %s to %s ...", srcPath, s3url)
+	cmd := exec.Command("aws", "s3", "cp", srcPath, s3url)
+	// Keep transfer progress off stdout so it can't corrupt a report a caller is
+	// capturing from our stdout (see fetch.go).
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("aws s3 cp failed: %w\n\nTo authenticate, run:\n  aws sso login\n\nOr configure AWS credentials with:\n  aws configure sso", err)
+	}
+
+	return nil
+}

--- a/tools/ods/internal/tui/editor.go
+++ b/tools/ods/internal/tui/editor.go
@@ -1,0 +1,490 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+// Column describes one editable field, rendered both as a table column and as a
+// form field.
+type Column struct {
+	Key      string
+	Title    string
+	Required bool
+	// Default prefills the field when adding a new row (ignored when editing).
+	Default string
+	// Validate is an optional per-field check applied to non-empty values when a
+	// form is submitted. Return a non-nil error to reject the value.
+	Validate func(string) error
+}
+
+// EditRows shows a full-screen table of rows with add/edit/delete and
+// save/cancel. Each row maps a column key to its value. It returns the edited
+// rows and whether the user chose to save (false = cancelled). A non-nil error
+// means the terminal could not be initialized, in which case the caller should
+// fall back to a non-TUI path.
+func EditRows(title string, cols []Column, rows []map[string]string) ([]map[string]string, bool, error) {
+	screen, err := tcell.NewScreen()
+	if err != nil {
+		return nil, false, err
+	}
+	if err := screen.Init(); err != nil {
+		return nil, false, err
+	}
+	defer screen.Fini()
+
+	rows, saved := runEditor(screen, title, cols, rows)
+	return rows, saved, nil
+}
+
+// runEditor drives the editor on an already-initialized screen. Split out from
+// EditRows so it can be exercised with a tcell SimulationScreen in tests.
+func runEditor(screen tcell.Screen, title string, cols []Column, rows []map[string]string) ([]map[string]string, bool) {
+	ed := &rowEditor{
+		screen: screen,
+		title:  title,
+		cols:   cols,
+		rows:   cloneRows(rows),
+	}
+	saved := ed.run()
+	return ed.rows, saved
+}
+
+type rowEditor struct {
+	screen tcell.Screen
+	title  string
+	cols   []Column
+	rows   []map[string]string
+	cursor int
+}
+
+const (
+	tableHeaderLines = 4 // title, blank, column header, blank
+	tableFooterLines = 2 // blank + keybinds
+)
+
+var (
+	styleTableTitle   = tcell.StyleDefault.Bold(true)
+	styleTableHeader  = tcell.StyleDefault.Bold(true).Foreground(tcell.ColorTeal)
+	styleRow          = tcell.StyleDefault
+	styleRowCursor    = tcell.StyleDefault.Reverse(true)
+	styleFormLabel    = tcell.StyleDefault
+	styleFormLabelAct = tcell.StyleDefault.Bold(true).Foreground(tcell.ColorTeal)
+	styleFormValue    = tcell.StyleDefault
+	styleError        = tcell.StyleDefault.Foreground(tcell.ColorRed).Bold(true)
+	styleHint         = tcell.StyleDefault.Dim(true)
+)
+
+// --- table loop --------------------------------------------------------------
+
+func (ed *rowEditor) run() bool {
+	offset := 0
+	for {
+		_, h := ed.screen.Size()
+		ed.drawTable(offset)
+		ed.screen.Show()
+
+		switch ev := ed.screen.PollEvent().(type) {
+		case *tcell.EventResize:
+			ed.screen.Sync()
+		case *tcell.EventKey:
+			switch ev.Key() {
+			case tcell.KeyEscape, tcell.KeyCtrlC:
+				return false
+			case tcell.KeyUp:
+				ed.moveCursor(-1)
+			case tcell.KeyDown:
+				ed.moveCursor(1)
+			case tcell.KeyHome:
+				ed.cursor = 0
+			case tcell.KeyEnd:
+				ed.cursor = ed.lastIndex()
+			case tcell.KeyPgUp:
+				ed.moveCursor(-(h - tableHeaderLines - tableFooterLines))
+			case tcell.KeyPgDn:
+				ed.moveCursor(h - tableHeaderLines - tableFooterLines)
+			case tcell.KeyEnter:
+				ed.doEdit()
+			case tcell.KeyRune:
+				switch ev.Rune() {
+				case 'q':
+					return false
+				case 'j':
+					ed.moveCursor(1)
+				case 'k':
+					ed.moveCursor(-1)
+				case 'g':
+					ed.cursor = 0
+				case 'G':
+					ed.cursor = ed.lastIndex()
+				case 'a':
+					ed.doAdd()
+				case 'e':
+					ed.doEdit()
+				case 'd':
+					ed.doDelete()
+				case 's':
+					return true
+				}
+			}
+		}
+
+		listHeight := h - tableHeaderLines - tableFooterLines
+		if listHeight < 1 {
+			listHeight = 1
+		}
+		if ed.cursor < offset {
+			offset = ed.cursor
+		}
+		if ed.cursor >= offset+listHeight {
+			offset = ed.cursor - listHeight + 1
+		}
+		if offset < 0 {
+			offset = 0
+		}
+	}
+}
+
+func (ed *rowEditor) lastIndex() int {
+	if len(ed.rows) == 0 {
+		return 0
+	}
+	return len(ed.rows) - 1
+}
+
+func (ed *rowEditor) moveCursor(delta int) {
+	ed.cursor += delta
+	if ed.cursor < 0 {
+		ed.cursor = 0
+	}
+	if ed.cursor > ed.lastIndex() {
+		ed.cursor = ed.lastIndex()
+	}
+}
+
+func (ed *rowEditor) doAdd() {
+	empty := make(map[string]string, len(ed.cols))
+	for _, c := range ed.cols {
+		empty[c.Key] = c.Default
+	}
+	if row, ok := ed.editForm("Add entry", empty); ok {
+		ed.rows = append(ed.rows, row)
+		ed.cursor = len(ed.rows) - 1
+	}
+}
+
+func (ed *rowEditor) doEdit() {
+	if len(ed.rows) == 0 {
+		return
+	}
+	if row, ok := ed.editForm("Edit entry", ed.rows[ed.cursor]); ok {
+		ed.rows[ed.cursor] = row
+	}
+}
+
+func (ed *rowEditor) doDelete() {
+	if len(ed.rows) == 0 {
+		return
+	}
+	if !ed.confirm(fmt.Sprintf("Delete entry %q?  (y/N)", ed.rowLabel(ed.cursor))) {
+		return
+	}
+	ed.rows = append(ed.rows[:ed.cursor], ed.rows[ed.cursor+1:]...)
+	if ed.cursor > ed.lastIndex() {
+		ed.cursor = ed.lastIndex()
+	}
+}
+
+func (ed *rowEditor) rowLabel(i int) string {
+	if len(ed.cols) == 0 {
+		return ""
+	}
+	return ed.rows[i][ed.cols[0].Key]
+}
+
+// --- form loop ---------------------------------------------------------------
+
+// editForm shows a modal form for a single row and returns the edited row plus
+// whether it was confirmed. Values are trimmed and validated on submit.
+func (ed *rowEditor) editForm(title string, initial map[string]string) (map[string]string, bool) {
+	values := make([][]rune, len(ed.cols))
+	for i, c := range ed.cols {
+		values[i] = []rune(initial[c.Key])
+	}
+	active := 0
+	caret := len(values[active])
+	errMsg := ""
+
+	labelWidth := 0
+	for _, c := range ed.cols {
+		if l := len([]rune(c.Title)); l > labelWidth {
+			labelWidth = l
+		}
+	}
+
+	for {
+		ed.drawForm(title, values, active, caret, labelWidth, errMsg)
+		ed.screen.Show()
+
+		switch ev := ed.screen.PollEvent().(type) {
+		case *tcell.EventResize:
+			ed.screen.Sync()
+		case *tcell.EventKey:
+			switch ev.Key() {
+			case tcell.KeyEscape, tcell.KeyCtrlC:
+				return nil, false
+			case tcell.KeyEnter:
+				row := make(map[string]string, len(ed.cols))
+				for i, c := range ed.cols {
+					row[c.Key] = strings.TrimSpace(string(values[i]))
+				}
+				if err := validateRow(ed.cols, row); err != nil {
+					errMsg = err.Error()
+					continue
+				}
+				return row, true
+			case tcell.KeyTab, tcell.KeyDown:
+				active = (active + 1) % len(ed.cols)
+				caret = len(values[active])
+				errMsg = ""
+			case tcell.KeyBacktab, tcell.KeyUp:
+				active = (active - 1 + len(ed.cols)) % len(ed.cols)
+				caret = len(values[active])
+				errMsg = ""
+			case tcell.KeyLeft:
+				if caret > 0 {
+					caret--
+				}
+			case tcell.KeyRight:
+				if caret < len(values[active]) {
+					caret++
+				}
+			case tcell.KeyHome:
+				caret = 0
+			case tcell.KeyEnd:
+				caret = len(values[active])
+			case tcell.KeyBackspace, tcell.KeyBackspace2:
+				if caret > 0 {
+					values[active] = append(values[active][:caret-1], values[active][caret:]...)
+					caret--
+				}
+			case tcell.KeyDelete:
+				if caret < len(values[active]) {
+					values[active] = append(values[active][:caret], values[active][caret+1:]...)
+				}
+			case tcell.KeyRune:
+				v := values[active]
+				nv := make([]rune, 0, len(v)+1)
+				nv = append(nv, v[:caret]...)
+				nv = append(nv, ev.Rune())
+				nv = append(nv, v[caret:]...)
+				values[active] = nv
+				caret++
+			}
+		}
+	}
+}
+
+func validateRow(cols []Column, row map[string]string) error {
+	for _, c := range cols {
+		v := row[c.Key]
+		if c.Required && strings.TrimSpace(v) == "" {
+			return fmt.Errorf("%s is required", c.Title)
+		}
+		if c.Validate != nil && v != "" {
+			if err := c.Validate(v); err != nil {
+				return fmt.Errorf("%s: %v", c.Title, err)
+			}
+		}
+	}
+	return nil
+}
+
+// confirm draws a single-line yes/no prompt over the current screen (default No)
+// and returns the answer.
+func (ed *rowEditor) confirm(msg string) bool {
+	for {
+		w, h := ed.screen.Size()
+		drawLine(ed.screen, 0, h-1, w, " "+msg, styleError)
+		ed.screen.Show()
+		switch ev := ed.screen.PollEvent().(type) {
+		case *tcell.EventResize:
+			ed.screen.Sync()
+		case *tcell.EventKey:
+			switch ev.Key() {
+			case tcell.KeyEscape, tcell.KeyCtrlC, tcell.KeyEnter:
+				return false
+			case tcell.KeyRune:
+				switch ev.Rune() {
+				case 'y', 'Y':
+					return true
+				case 'n', 'N':
+					return false
+				}
+			}
+		}
+	}
+}
+
+// --- drawing -----------------------------------------------------------------
+
+func (ed *rowEditor) drawTable(offset int) {
+	s := ed.screen
+	s.Clear()
+	s.HideCursor()
+	w, h := s.Size()
+
+	widths := ed.columnWidths()
+
+	title := fmt.Sprintf(" %s  (%d %s)", ed.title, len(ed.rows), entryWord(len(ed.rows)))
+	drawLine(s, 0, 0, w, title, styleTableTitle)
+
+	headerCells := make([]string, len(ed.cols))
+	for i, c := range ed.cols {
+		headerCells[i] = c.Title
+	}
+	drawLine(s, 0, 2, w, "  "+renderCells(widths, headerCells), styleTableHeader)
+
+	listTop := tableHeaderLines
+	listHeight := h - tableHeaderLines - tableFooterLines
+	if listHeight < 1 {
+		listHeight = 1
+	}
+
+	if len(ed.rows) == 0 {
+		drawLine(s, 0, listTop, w, "  (no entries — press 'a' to add)", styleHint)
+	}
+
+	for i := 0; i < listHeight; i++ {
+		ri := offset + i
+		if ri >= len(ed.rows) {
+			break
+		}
+		y := listTop + i
+		cells := make([]string, len(ed.cols))
+		for j, c := range ed.cols {
+			cells[j] = ed.rows[ri][c.Key]
+		}
+		prefix := "  "
+		style := styleRow
+		if ri == ed.cursor {
+			prefix = "> "
+			style = styleRowCursor
+		}
+		drawLine(s, 0, y, w, prefix+renderCells(widths, cells), style)
+	}
+
+	if len(ed.rows) > listHeight {
+		drawScrollbar(s, w-1, listTop, listHeight, offset, len(ed.rows))
+	}
+
+	footer := " ↑/↓ move  a add  e/enter edit  d delete  s save  q/esc cancel"
+	drawLine(s, 0, h-1, w, footer, styleFooter)
+}
+
+func (ed *rowEditor) drawForm(title string, values [][]rune, active, caret, labelWidth int, errMsg string) {
+	s := ed.screen
+	s.Clear()
+	s.HideCursor()
+	w, h := s.Size()
+
+	drawLine(s, 0, 0, w, " "+title, styleTableTitle)
+
+	startY := 2
+	for i, c := range ed.cols {
+		y := startY + i
+		labelStyle := styleFormLabel
+		if i == active {
+			labelStyle = styleFormLabelAct
+		}
+		req := " "
+		if c.Required {
+			req = "*"
+		}
+		x := drawStr(s, 0, y, w, "  ", labelStyle)
+		x = drawStr(s, x, y, w, padRunes(c.Title, labelWidth), labelStyle)
+		x = drawStr(s, x, y, w, " "+req+" : ", labelStyle)
+		valX := x
+		drawLine(s, valX, y, w, string(values[i]), styleFormValue)
+		if i == active {
+			if cx := valX + caret; cx < w {
+				s.ShowCursor(cx, y)
+			}
+		}
+	}
+
+	if errMsg != "" {
+		drawLine(s, 0, startY+len(ed.cols)+1, w, "  "+errMsg, styleError)
+	}
+
+	footer := " Tab/↑↓ field  ←/→ move  Enter save  Esc cancel   (* required)"
+	drawLine(s, 0, h-1, w, footer, styleFooter)
+}
+
+func (ed *rowEditor) columnWidths() []int {
+	const maxCol = 48
+	widths := make([]int, len(ed.cols))
+	for i, c := range ed.cols {
+		widths[i] = len([]rune(c.Title))
+	}
+	for _, row := range ed.rows {
+		for i, c := range ed.cols {
+			if l := len([]rune(row[c.Key])); l > widths[i] {
+				widths[i] = l
+			}
+		}
+	}
+	for i := range widths {
+		if widths[i] > maxCol {
+			widths[i] = maxCol
+		}
+	}
+	return widths
+}
+
+// --- small helpers -----------------------------------------------------------
+
+func renderCells(widths []int, cells []string) string {
+	var b strings.Builder
+	for i, cell := range cells {
+		if i > 0 {
+			b.WriteString("  ")
+		}
+		b.WriteString(padRunes(cell, widths[i]))
+	}
+	return b.String()
+}
+
+// padRunes pads s with spaces to width, or truncates with an ellipsis when
+// longer.
+func padRunes(s string, width int) string {
+	r := []rune(s)
+	if len(r) > width {
+		if width <= 1 {
+			return string(r[:width])
+		}
+		return string(r[:width-1]) + "…"
+	}
+	return s + strings.Repeat(" ", width-len(r))
+}
+
+func entryWord(n int) string {
+	if n == 1 {
+		return "entry"
+	}
+	return "entries"
+}
+
+func cloneRows(rows []map[string]string) []map[string]string {
+	out := make([]map[string]string, len(rows))
+	for i, r := range rows {
+		m := make(map[string]string, len(r))
+		for k, v := range r {
+			m[k] = v
+		}
+		out[i] = m
+	}
+	return out
+}

--- a/tools/ods/internal/tui/editor.go
+++ b/tools/ods/internal/tui/editor.go
@@ -102,9 +102,9 @@ func (ed *rowEditor) run() bool {
 			case tcell.KeyEnd:
 				ed.cursor = ed.lastIndex()
 			case tcell.KeyPgUp:
-				ed.moveCursor(-(h - tableHeaderLines - tableFooterLines))
+				ed.moveCursor(-visibleRows(h))
 			case tcell.KeyPgDn:
-				ed.moveCursor(h - tableHeaderLines - tableFooterLines)
+				ed.moveCursor(visibleRows(h))
 			case tcell.KeyEnter:
 				ed.doEdit()
 			case tcell.KeyRune:
@@ -131,10 +131,7 @@ func (ed *rowEditor) run() bool {
 			}
 		}
 
-		listHeight := h - tableHeaderLines - tableFooterLines
-		if listHeight < 1 {
-			listHeight = 1
-		}
+		listHeight := visibleRows(h)
 		if ed.cursor < offset {
 			offset = ed.cursor
 		}
@@ -162,6 +159,15 @@ func (ed *rowEditor) moveCursor(delta int) {
 	if ed.cursor > ed.lastIndex() {
 		ed.cursor = ed.lastIndex()
 	}
+}
+
+// visibleRows is the number of table rows that fit on a screen of height h,
+// always at least 1 so paging stays directionally correct on tiny terminals.
+func visibleRows(h int) int {
+	if n := h - tableHeaderLines - tableFooterLines; n > 1 {
+		return n
+	}
+	return 1
 }
 
 func (ed *rowEditor) doAdd() {
@@ -348,10 +354,7 @@ func (ed *rowEditor) drawTable(offset int) {
 	drawLine(s, 0, 2, w, "  "+renderCells(widths, headerCells), styleTableHeader)
 
 	listTop := tableHeaderLines
-	listHeight := h - tableHeaderLines - tableFooterLines
-	if listHeight < 1 {
-		listHeight = 1
-	}
+	listHeight := visibleRows(h)
 
 	if len(ed.rows) == 0 {
 		drawLine(s, 0, listTop, w, "  (no entries — press 'a' to add)", styleHint)

--- a/tools/ods/internal/tui/editor_test.go
+++ b/tools/ods/internal/tui/editor_test.go
@@ -1,0 +1,138 @@
+package tui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+var testCols = []Column{
+	{Key: "id", Title: "ID", Required: true},
+	{Key: "note", Title: "Note"},
+}
+
+// runSim drives the editor on a simulation screen. InjectKey blocks until the
+// event is consumed, so inject runs in its own goroutine concurrently with the
+// editor loop; each key is paced by the loop's next PollEvent. The sequence must
+// reach save or cancel so the loop terminates.
+func runSim(t *testing.T, cols []Column, rows []map[string]string, inject func(s tcell.SimulationScreen)) ([]map[string]string, bool) {
+	t.Helper()
+	s := tcell.NewSimulationScreen("")
+	if err := s.Init(); err != nil {
+		t.Fatalf("SimulationScreen Init: %v", err)
+	}
+	defer s.Fini()
+	s.SetSize(100, 30)
+
+	type outcome struct {
+		rows  []map[string]string
+		saved bool
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		r, sv := runEditor(s, "test", cols, rows)
+		done <- outcome{r, sv}
+	}()
+	go inject(s)
+
+	select {
+	case o := <-done:
+		return o.rows, o.saved
+	case <-time.After(5 * time.Second):
+		t.Fatal("editor did not terminate; injected sequence never reached save/cancel")
+		return nil, false
+	}
+}
+
+func typeRunes(s tcell.SimulationScreen, text string) {
+	for _, r := range text {
+		s.InjectKey(tcell.KeyRune, r, tcell.ModNone)
+	}
+}
+
+func key(s tcell.SimulationScreen, k tcell.Key) {
+	s.InjectKey(k, 0, tcell.ModNone)
+}
+
+func TestEditRowsAddAndSave(t *testing.T) {
+	rows, saved := runSim(t, testCols, nil, func(s tcell.SimulationScreen) {
+		typeRunes(s, "a") // add
+		typeRunes(s, "GHSA-1")
+		key(s, tcell.KeyTab)
+		typeRunes(s, "hello")
+		key(s, tcell.KeyEnter) // submit form
+		typeRunes(s, "s")      // save
+	})
+
+	if !saved {
+		t.Fatal("expected saved = true")
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d: %#v", len(rows), rows)
+	}
+	if rows[0]["id"] != "GHSA-1" || rows[0]["note"] != "hello" {
+		t.Fatalf("unexpected row: %#v", rows[0])
+	}
+}
+
+func TestEditRowsCancelKeepsNothing(t *testing.T) {
+	initial := []map[string]string{{"id": "KEEP", "note": ""}}
+	rows, saved := runSim(t, testCols, initial, func(s tcell.SimulationScreen) {
+		typeRunes(s, "q") // quit without saving
+	})
+	if saved {
+		t.Fatal("expected saved = false on quit")
+	}
+	if len(rows) != 1 || rows[0]["id"] != "KEEP" {
+		t.Fatalf("rows should be returned unchanged, got %#v", rows)
+	}
+}
+
+func TestEditRowsValidationBlocksEmptyID(t *testing.T) {
+	rows, saved := runSim(t, testCols, nil, func(s tcell.SimulationScreen) {
+		typeRunes(s, "a")
+		key(s, tcell.KeyEnter) // empty id -> rejected, stays in form
+		typeRunes(s, "OK")
+		key(s, tcell.KeyEnter) // now valid -> submits
+		typeRunes(s, "s")
+	})
+	if !saved {
+		t.Fatal("expected saved = true")
+	}
+	if len(rows) != 1 || rows[0]["id"] != "OK" {
+		t.Fatalf("expected single row id=OK, got %#v", rows)
+	}
+}
+
+func TestEditRowsTextEditingBackspace(t *testing.T) {
+	rows, _ := runSim(t, testCols, nil, func(s tcell.SimulationScreen) {
+		typeRunes(s, "a")
+		typeRunes(s, "ABX")
+		key(s, tcell.KeyBackspace2) // delete X -> AB
+		typeRunes(s, "C")           // -> ABC
+		key(s, tcell.KeyEnter)
+		typeRunes(s, "s")
+	})
+	if len(rows) != 1 || rows[0]["id"] != "ABC" {
+		t.Fatalf("expected id=ABC, got %#v", rows)
+	}
+}
+
+func TestEditRowsDelete(t *testing.T) {
+	initial := []map[string]string{
+		{"id": "A", "note": ""},
+		{"id": "B", "note": ""},
+	}
+	rows, saved := runSim(t, testCols, initial, func(s tcell.SimulationScreen) {
+		typeRunes(s, "d") // delete row under cursor (A)
+		typeRunes(s, "y") // confirm
+		typeRunes(s, "s") // save
+	})
+	if !saved {
+		t.Fatal("expected saved = true")
+	}
+	if len(rows) != 1 || rows[0]["id"] != "B" {
+		t.Fatalf("expected single row id=B after deleting A, got %#v", rows)
+	}
+}


### PR DESCRIPTION
## What

Adds `ods audit ignore`: a full-screen terminal UI for managing the audit **advisory allowlist** (the S3-hosted `ignores.json` that `ods audit` uses to suppress accepted vulnerabilities).

<img width="1660" height="1036" alt="20260706_12h39m58s_grim" src="https://github.com/user-attachments/assets/a6c0ae38-1671-4cbb-825c-474236ca39e5" />
<img width="1660" height="1036" alt="20260706_12h40m05s_grim" src="https://github.com/user-attachments/assets/bee7fdff-e83e-4a71-83fc-fc59b756be65" />

Today the only way to add/remove a suppression is to hand-edit that JSON and `aws s3 cp` it back up — there was no read path in the CLI and no write path at all. This command:

- Fetches the current allowlist (from S3 by default).
- Presents it in a **table** with the `id`, `ecosystem`, `reason`, `added_by`, `expires` columns.
- Supports **add / edit / delete** entries via a small form (with `id` required and `expires` validated as `YYYY-MM-DD`; `added_by` prefilled from `git config user.email`).
- On save, shows a **diff summary** and **uploads back to S3 after a confirmation prompt**.

Pass a local file path to `--ignore-url` to edit a file on disk instead of S3 (handy for dev/testing without touching shared infra).

```
ods audit ignore                                  # open the editor on the live S3 allowlist
ods audit ignore edit                             # same thing, explicit verb
ods audit ignore --ignore-url /tmp/ignores.json   # edit a local file
```

`ignore` is a command group: running it bare opens the editor, and `edit` is an explicit subcommand — both share `--ignore-url` (a persistent flag). This uses the codebase's own vocabulary (`ignores.json` / `IgnoreEntry` / `--ignore-url`) and leaves room for future `ignore add/list/rm` subcommands.

## How

Built on raw `tcell` (already a dependency), matching the existing `internal/tui/picker.go` convention rather than pulling in a new TUI library:

- **`internal/audit`** — exported `FetchIgnores` (+ a local-path read branch), and added `MarshalIgnores`, `ValidateEntry`, `ValidateExpires`, `SortIgnores`, `DiffIgnores`, and `SaveIgnores` (S3 upload or local write).
- **`internal/s3`** — added `PutFile` for single-file `aws s3 cp` uploads, mirroring the existing download error hints.
- **`internal/tui`** — added a generic `EditRows(title, cols, rows)` table+form editor, including a minimal single-line text-input widget (the one primitive `picker.go` lacked). Reuses the existing draw helpers and styles.
- **`cmd`** — added the `audit ignore` command group with an `edit` child. Falls back to a read-only text dump when no interactive terminal is available.

## Testing

- `go build ./...`, `go vet ./...`, `gofmt` — all clean.
- **Unit tests** (`internal/audit`): marshal round-trip + `omitempty`, entry/expires validation, sort determinism, diff classification, and a `SaveIgnores` ↔ `FetchIgnores` local-file round-trip (no S3 needed).
- **Event-loop tests** (`internal/tui`): drive the real editor loop via a tcell `SimulationScreen` — add+save, cancel, empty-ID validation blocking, backspace text-editing, and delete.
- **Manual**: verified `--help` wiring for `audit ignore` / `audit ignore edit`, the shared `--ignore-url`, and the no-TTY fallback (leaves the file untouched).

The interactive TUI and the live S3 upload leg can't run in CI (no terminal / no AWS creds), but the loop is covered by simulation tests and the write path by the local round-trip test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)