### PR TITLE
fix(craft): update sandbox heartbeat on message send

### DIFF
--- a/backend/onyx/server/features/build/db/build_session.py
+++ b/backend/onyx/server/features/build/db/build_session.py
@@ -15,7 +15,6 @@ from sqlalchemy.orm import Session
 from onyx.auth.schemas import UserRole
 from onyx.configs.constants import MessageType
 from onyx.db.enums import BuildSessionStatus
-from onyx.db.enums import SandboxStatus
 from onyx.db.enums import SessionOrigin
 from onyx.db.enums import SharingScope
 from onyx.db.llm import can_user_access_llm_provider
@@ -220,39 +219,6 @@ def delete_build_session__no_commit(
     db_session.flush()
     logger.info("Deleted build session %s", session_id)
     return True
-
-
-# Sandbox operations
-# NOTE: Most sandbox operations have moved to sandbox.py
-# These remain here for convenience in session-related workflows
-
-
-def update_sandbox_status(
-    sandbox_id: UUID,
-    status: SandboxStatus,
-    db_session: Session,
-    container_id: str | None = None,
-) -> None:
-    """Update the status of a sandbox."""
-    sandbox = db_session.query(Sandbox).filter(Sandbox.id == sandbox_id).one_or_none()
-    if sandbox:
-        sandbox.status = status
-        if container_id is not None:
-            sandbox.container_id = container_id
-        sandbox.last_heartbeat = datetime.now(tz=timezone.utc)
-        db_session.commit()
-        logger.info("Updated sandbox %s status to %s", sandbox_id, status)
-
-
-def update_sandbox_heartbeat(
-    sandbox_id: UUID,
-    db_session: Session,
-) -> None:
-    """Update the heartbeat timestamp for a sandbox."""
-    sandbox = db_session.query(Sandbox).filter(Sandbox.id == sandbox_id).one_or_none()
-    if sandbox:
-        sandbox.last_heartbeat = datetime.now(tz=timezone.utc)
-        db_session.commit()
 
 
 # Artifact operations

--- a/backend/onyx/server/features/build/db/sandbox.py
+++ b/backend/onyx/server/features/build/db/sandbox.py
@@ -133,15 +133,14 @@ def update_sandbox_status__no_commit(
     return sandbox
 
 
-def update_sandbox_heartbeat(db_session: Session, sandbox_id: UUID) -> Sandbox:
-    """Update sandbox last_heartbeat to now."""
+def update_sandbox_heartbeat(db_session: Session, sandbox_id: UUID) -> None:
+    """Update sandbox last_heartbeat to now. No-op if the sandbox row is gone."""
     sandbox = get_sandbox_by_id(db_session, sandbox_id)
-    if not sandbox:
-        raise ValueError(f"Sandbox {sandbox_id} not found")
+    if sandbox is None:
+        return
 
     sandbox.last_heartbeat = datetime.datetime.now(datetime.timezone.utc)
     db_session.commit()
-    return sandbox
 
 
 def get_running_sandboxes(db_session: Session) -> list[Sandbox]:

--- a/backend/onyx/server/features/build/interactive_turns/executor.py
+++ b/backend/onyx/server/features/build/interactive_turns/executor.py
@@ -11,6 +11,7 @@ from onyx.cache.interface import CACHE_TRANSIENT_ERRORS
 from onyx.cache.interface import CacheBackend
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.server.features.build.db.build_session import update_session_activity
+from onyx.server.features.build.db.sandbox import update_sandbox_heartbeat
 from onyx.server.features.build.interactive_turns.state import claim_turn_for_runner
 from onyx.server.features.build.interactive_turns.state import finish_turn
 from onyx.server.features.build.interactive_turns.state import get_active_turn
@@ -176,6 +177,7 @@ def _drive_interactive_turn(
 
         try:
             update_session_activity(session_id, db_session)
+            update_sandbox_heartbeat(db_session, sandbox.id)
 
             if interrupt_requested():
                 session_manager.finalize_persist(session_id, state)

--- a/backend/tests/unit/onyx/server/features/build/interactive_turns/test_executor.py
+++ b/backend/tests/unit/onyx/server/features/build/interactive_turns/test_executor.py
@@ -75,6 +75,7 @@ def _run_turn_with_events(
     prompt_slot = _FakePromptSlot()
     persisted: list[object] = []
     finalized: list[UUID] = []
+    heartbeat_calls: list[UUID] = []
 
     turn = create_interactive_turn(
         cache=cache,
@@ -145,6 +146,11 @@ def _run_turn_with_events(
     )
     monkeypatch.setattr(executor, "SessionManager", FakeSessionManager)
     monkeypatch.setattr(executor, "update_session_activity", lambda *_: None)
+    monkeypatch.setattr(
+        executor,
+        "update_sandbox_heartbeat",
+        lambda _db, sandbox_id_arg: heartbeat_calls.append(sandbox_id_arg),
+    )
     monkeypatch.setattr(executor, "is_interrupt_requested", lambda *_: False)
     monkeypatch.setattr(executor, "clear_interrupt", lambda *_: None)
 
@@ -156,8 +162,10 @@ def _run_turn_with_events(
         cache=cache,
         db_session=db_session,
         finalized=finalized,
+        heartbeat_calls=heartbeat_calls,
         persisted=persisted,
         prompt_slot=prompt_slot,
+        sandbox_id=sandbox_id,
         session_id=session_id,
         turn=turn,
         user_id=user_id,
@@ -182,6 +190,7 @@ def test_runner_succeeds_on_prompt_response(monkeypatch: pytest.MonkeyPatch) -> 
     )
     assert result.persisted == [prompt_response]
     assert result.finalized == [result.session_id]
+    assert result.heartbeat_calls == [result.sandbox_id]
     assert result.prompt_slot.exited
     assert result.db_session.rollbacks == 0
 
@@ -399,6 +408,7 @@ def test_lost_runner_does_not_clear_reclaimed_turn_interrupt(
     )
     monkeypatch.setattr(executor, "SessionManager", FakeSessionManager)
     monkeypatch.setattr(executor, "update_session_activity", lambda *_: None)
+    monkeypatch.setattr(executor, "update_sandbox_heartbeat", lambda *_: None)
     monkeypatch.setattr(executor, "is_interrupt_requested", lambda *_: False)
     monkeypatch.setattr(
         executor,


### PR DESCRIPTION
## Description

The Craft send-message path (interactive turn via opencode-serve) never refreshed `sandbox.last_heartbeat` — the only signal `cleanup_idle_sandboxes_task` uses to decide idleness. The heartbeat was last set at session restore/provision, so a user chatting continuously for longer than `SANDBOX_IDLE_TIMEOUT_SECONDS` (1h) had their sandbox snapshotted and put to sleep mid-conversation, potentially mid-turn.

Fix: the interactive turn runner now bumps the sandbox heartbeat at turn start, next to the existing `update_session_activity` call. This covers every turn entry point (interactive send-message and headless/scheduled turns). Since turns are budgeted at 30 minutes and the idle timeout is 1 hour, a per-turn bump is sufficient — an active turn can never coexist with an idle-eligible heartbeat.

## How Has This Been Tested?

- Unit: `test_executor.py` now asserts the runner refreshes the heartbeat for the correct sandbox; full suite passes.

## Additional Options
fixes https://linear.app/onyx-app/issue/ENG-4272/message-turns-through-opencode-serve-seem-to-not-refresh-heartbeat
- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refresh the sandbox heartbeat at the start of each turn so active chats aren’t snapshotted for idleness mid-conversation. Also tolerate missing sandbox rows and remove a duplicate helper. Addresses ENG-4272.

- **Bug Fixes**
  - Call `update_sandbox_heartbeat` alongside `update_session_activity` at turn start for interactive and headless turns.
  - Make heartbeat update a no-op if the sandbox is missing and delete the duplicate helper from `build_session.py`; add tests to assert the correct sandbox is updated.

<sup>Written for commit 2216461667c9ffcb3554a339f4ac9b1ff3d7a6eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



