### PR TITLE
fix(craft): require hover dwell before swapping open plus-menu flyout

### DIFF
--- a/web/src/sections/input/PlusMenuButton.tsx
+++ b/web/src/sections/input/PlusMenuButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, type ReactNode } from "react";
+import { useState, useCallback, useRef, type ReactNode } from "react";
 import { Button, Popover } from "@opal/components";
 import { SvgChevronRight, SvgPlus } from "@opal/icons";
 import type { IconFunctionComponent } from "@opal/types";
@@ -32,12 +32,17 @@ export interface PlusMenuButtonProps {
   ariaLabel?: string;
 }
 
+// Dwell time before hovering a row swaps away an already-open flyout, so a
+// pointer passing over sibling rows en route to the flyout doesn't collapse it.
+const FLYOUT_SWAP_DELAY_MS = 150;
+
 interface FlyoutRowProps {
   icon: IconFunctionComponent;
   label: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onHoverOpen: () => void;
+  onHoverLeave: () => void;
   children: ReactNode[];
 }
 
@@ -48,6 +53,7 @@ function FlyoutRow({
   open,
   onOpenChange,
   onHoverOpen,
+  onHoverLeave,
   children,
 }: FlyoutRowProps) {
   return (
@@ -57,6 +63,7 @@ function FlyoutRow({
           icon={icon}
           selected={open}
           onPointerEnter={onHoverOpen}
+          onPointerLeave={onHoverLeave}
           rightChildren={<SvgChevronRight className="h-4 w-4 text-text-03" />}
         >
           {label}
@@ -87,16 +94,43 @@ export function PlusMenuButton({
 }: PlusMenuButtonProps) {
   const [open, setOpen] = useState(false);
   const [openKey, setOpenKey] = useState<string | null>(null);
+  const pendingSwapRef = useRef<number | null>(null);
+
+  const cancelPendingSwap = useCallback(() => {
+    if (pendingSwapRef.current !== null) {
+      window.clearTimeout(pendingSwapRef.current);
+      pendingSwapRef.current = null;
+    }
+  }, []);
 
   const close = useCallback(() => {
+    cancelPendingSwap();
     setOpen(false);
     setOpenKey(null);
-  }, []);
+  }, [cancelPendingSwap]);
 
   // Functional update keeps sibling open/close events from racing.
   const flyoutOpenChange = useCallback((key: string, next: boolean) => {
     setOpenKey((prev) => (next ? key : prev === key ? null : prev));
   }, []);
+
+  // Opens instantly when no flyout is open; otherwise requires a short dwell
+  // (cancelled on pointer-leave) before swapping or collapsing, so incidental
+  // pass-overs of sibling rows don't yank the open flyout away.
+  const hoverRow = useCallback(
+    (key: string | null) => {
+      cancelPendingSwap();
+      if (openKey === null || openKey === key) {
+        if (key !== null) setOpenKey(key);
+        return;
+      }
+      pendingSwapRef.current = window.setTimeout(() => {
+        pendingSwapRef.current = null;
+        setOpenKey(key);
+      }, FLYOUT_SWAP_DELAY_MS);
+    },
+    [openKey, cancelPendingSwap]
+  );
 
   const menuChildren: ReactNode[] = items.map((item) => {
     if (item === null) return null;
@@ -109,7 +143,8 @@ export function PlusMenuButton({
           label={item.label}
           open={openKey === item.key}
           onOpenChange={(next) => flyoutOpenChange(item.key, next)}
-          onHoverOpen={() => setOpenKey(item.key)}
+          onHoverOpen={() => hoverRow(item.key)}
+          onHoverLeave={cancelPendingSwap}
         >
           {item.flyoutItems.map((sub) => (
             <LineItem
@@ -137,8 +172,9 @@ export function PlusMenuButton({
           item.onSelect?.();
           close();
         }}
-        // Hovering a non-flyout row collapses any open flyout.
-        onPointerEnter={() => setOpenKey(null)}
+        // Hovering a non-flyout row collapses any open flyout (after a dwell).
+        onPointerEnter={() => hoverRow(null)}
+        onPointerLeave={cancelPendingSwap}
       >
         {item.label}
       </LineItem>


### PR DESCRIPTION
## Description

After/before video demonstrating fixed version vs. existing

https://github.com/user-attachments/assets/c71c1903-7bf7-42af-85b4-12afa3e3575c


In the Craft plus-menu popover, hovering a flyout row (e.g. "Apps") opens its submenu, but moving the pointer diagonally toward that submenu often passes over a sibling row (e.g. "Library"), which instantly swapped or collapsed the open flyout.

This adds hover intent to `PlusMenuButton`: opening a flyout from a closed state is still instant, but once a flyout is open, hovering a different row only swaps/collapses it after a 150ms dwell. The pending swap is cancelled on `pointerleave`, so a pointer merely passing over a sibling row never fires it — only deliberately resting on the row does.

## How Has This Been Tested?

- `tsc --noEmit`, oxfmt, oxlint pass.
- Manual check: open the Craft plus-menu, hover "Apps", sweep diagonally across "Library" into the flyout panel — the flyout should stay on Apps; resting on "Library" for ~150ms should swap it.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add hover intent to the plus-menu flyouts so accidental diagonal passes don’t instantly swap or collapse the open submenu. Swapping/collapsing now requires a brief dwell, improving navigation.

- **Bug Fixes**
  - Require a 150ms dwell before swapping/collapsing an already-open flyout; opening from a closed state remains instant.
  - Cancel pending swaps on pointer leave to ignore incidental pass-overs.
  - Implemented in `PlusMenuButton.tsx` with `FLYOUT_SWAP_DELAY_MS` and a `pendingSwapRef`-backed timeout.

<sup>Written for commit b2ef71805b4a7b133b7dee9685e5e617769b0ece. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

