### PR TITLE
fix(opal): render LineItemButton as div to fix nested-button hydration error

### DIFF
--- a/web/lib/opal/src/components/buttons/line-item-button/README.md
+++ b/web/lib/opal/src/components/buttons/line-item-button/README.md
@@ -8,11 +8,15 @@ A composite component that wraps `Interactive.Stateful > Interactive.Container >
 
 ```
 Interactive.Stateful         <- selectVariant, state, interaction, onClick, href, ref
-  └─ Interactive.Container   <- type, width, rounding
+  └─ Interactive.Container   <- width, rounding
        └─ ContentAction      <- withInteractive, padding="lg"
             ├─ Content       <- icon, title, description, sizePreset, variant, ...
             └─ rightChildren
 ```
+
+The row renders as a focusable `<div role="button">` (with Enter/Space activation) rather than a
+native `<button>`, so interactive `rightChildren` such as action buttons don't produce invalid
+button-in-button nesting. With `href` it renders an anchor instead.
 
 `padding` is hardcoded to `"lg"` and `withInteractive` is always `true`. These are not exposed as props.
 
@@ -37,7 +41,6 @@ Interactive.Stateful         <- selectVariant, state, interaction, onClick, href
 |------|------|---------|-------------|
 | `rounding` | `InteractiveContainerRoundingVariant` | `"md"` | Corner rounding preset (height is content-driven) |
 | `width` | `WidthVariant` | `"full"` | Container width |
-| `type` | `"submit" \| "button" \| "reset"` | `"button"` | HTML button type |
 | `tooltip` | `string` | — | Tooltip text shown on hover |
 | `tooltipSide` | `TooltipSide` | `"top"` | Tooltip side |
 

--- a/web/lib/opal/src/components/buttons/line-item-button/components.tsx
+++ b/web/lib/opal/src/components/buttons/line-item-button/components.tsx
@@ -64,6 +64,21 @@ function handleRowKeyUp(e: React.KeyboardEvent<HTMLDivElement>) {
   }
 }
 
+// Ignore clicks originating from nested interactive children (e.g.
+// `rightChildren` action buttons) so they don't also activate the row.
+function guardNestedInteractiveClick(
+  onClick: React.MouseEventHandler<HTMLElement> | undefined
+): React.MouseEventHandler<HTMLElement> | undefined {
+  if (!onClick) return undefined;
+  return (e) => {
+    const nested = (e.target as HTMLElement).closest(
+      'button, a, [role="button"]'
+    );
+    if (nested && nested !== e.currentTarget) return;
+    onClick(e);
+  };
+}
+
 function LineItemButton({
   // Interactive surface
   selectVariant = "select-light",
@@ -101,7 +116,7 @@ function LineItemButton({
       variant={selectVariant}
       state={state}
       interaction={interaction}
-      onClick={onClick}
+      onClick={guardNestedInteractiveClick(onClick)}
       href={href}
       target={target}
       group={group}

--- a/web/lib/opal/src/components/buttons/line-item-button/components.tsx
+++ b/web/lib/opal/src/components/buttons/line-item-button/components.tsx
@@ -1,3 +1,4 @@
+import type React from "react";
 import {
   Interactive,
   type InteractiveStatefulProps,
@@ -18,14 +19,7 @@ type ContentPassthroughProps = DistributiveOmit<
 
 type LineItemButtonOwnProps = Pick<
   InteractiveStatefulProps,
-  | "state"
-  | "interaction"
-  | "onClick"
-  | "href"
-  | "target"
-  | "group"
-  | "ref"
-  | "type"
+  "state" | "interaction" | "onClick" | "href" | "target" | "group" | "ref"
 > & {
   /** Interactive select variant. @default "select-light" */
   selectVariant?: "select-light" | "select-heavy";
@@ -49,6 +43,27 @@ type LineItemButtonProps = ContentPassthroughProps & LineItemButtonOwnProps;
 // LineItemButton
 // ---------------------------------------------------------------------------
 
+// Mirrors native <button> activation (Enter fires on keydown, Space on keyup).
+// Guarded so keystrokes on nested interactive children (e.g. `rightChildren`
+// action buttons) don't also activate the row.
+function handleRowKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+  if (e.target !== e.currentTarget) return;
+  if (e.key === "Enter") {
+    e.preventDefault();
+    e.currentTarget.click();
+  } else if (e.key === " ") {
+    e.preventDefault();
+  }
+}
+
+function handleRowKeyUp(e: React.KeyboardEvent<HTMLDivElement>) {
+  if (e.target !== e.currentTarget) return;
+  if (e.key === " ") {
+    e.preventDefault();
+    e.currentTarget.click();
+  }
+}
+
 function LineItemButton({
   // Interactive surface
   selectVariant = "select-light",
@@ -59,7 +74,6 @@ function LineItemButton({
   target,
   group,
   ref,
-  type = "button",
 
   // Sizing
   rounding = "md",
@@ -70,6 +84,18 @@ function LineItemButton({
   // ContentAction pass-through
   ...contentActionProps
 }: LineItemButtonProps) {
+  // The row renders as a focusable div (role="button") instead of a native
+  // <button> so interactive `rightChildren` (e.g. action buttons) don't nest
+  // a <button> inside a <button> — invalid HTML that breaks hydration.
+  const rowButtonProps = href
+    ? undefined
+    : ({
+        role: "button",
+        tabIndex: 0,
+        onKeyDown: handleRowKeyDown,
+        onKeyUp: handleRowKeyUp,
+      } as const);
+
   const item = (
     <Interactive.Stateful
       variant={selectVariant}
@@ -82,10 +108,10 @@ function LineItemButton({
       ref={ref}
     >
       <Interactive.Container
-        type={type}
         width={width}
         size="fit"
         rounding={rounding}
+        {...rowButtonProps}
       >
         <div className="w-full p-2">
           <ContentAction


### PR DESCRIPTION
## Summary

Opening the notifications popover logged a React hydration error: `In HTML, <button> cannot be a descendant of <button>`. `NotificationItem` places a dismiss `Button` inside `LineItemButton`'s `rightChildren`, and both rendered native `<button>` elements (`LineItemButton` passed `type="button"` down to `Interactive.Container`).

## Fix

Render the `LineItemButton` row as a focusable `<div role="button" tabIndex={0}>` instead of a native `<button>`, so interactive `rightChildren` no longer produce invalid button-in-button nesting. This mirrors the earlier fix for the legacy `LineItem` (#8599) and the existing `SidebarTab` pattern (its `Interactive.Container` already renders a div).

- Enter/Space activation is reproduced per the native button contract (Enter fires on keydown, Space on keyup, Space keydown suppresses page scroll), guarded with `e.target !== e.currentTarget` so keystrokes on nested action buttons don't also activate the row.
- The `href` variant still renders an anchor via `Interactive.Container`.
- The unused `type` prop is removed — no caller passed it, and none relied on `type="submit"`.

## Compatibility notes

- No `LineItemButton` call site passes interactive-element-dependent selectors: e2e tests use `getByRole("button")` (still matches `role="button"` divs) or `[data-interactive-state]` attribute selectors (element-agnostic).
- `Content` explicitly sets `text-left`, so losing the UA `text-align: center` button default has no visual effect.
- `web` `types:check` error set is byte-identical before/after the change (the existing failures are a pre-existing missing-build issue with `@onyx-ai/shared`).

## Test plan

- `bun run types:check` — no new errors vs baseline.
- oxlint + oxfmt clean on the changed files.
- Manual validation of the notifications popover to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a nested-button React hydration error by rendering `LineItemButton` rows as focusable divs and guarding row activation to ignore clicks from nested actions. Prevents invalid button-in-button and accidental row triggers in the notifications popover and similar UIs.

- **Bug Fixes**
  - Render row as `<div role="button" tabIndex={0}>` with Enter (keydown) and Space (keyup) activation; ignore keystrokes and clicks from nested interactive children; prevent Space scroll.
  - Keep the `href` variant rendering an anchor via `Interactive.Container`.
  - Remove the unused `type` prop and update the `README.md`.

<sup>Written for commit 34742885c80b3ecba6d5daa7e7711771dabc5159. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

