### PR TITLE
fix(voice): gate silent audio out of chunked STT to stop hallucinated transcripts

### DIFF
--- a/backend/onyx/server/manage/voice/websocket_api.py
+++ b/backend/onyx/server/manage/voice/websocket_api.py
@@ -48,6 +48,15 @@ PCM_TRANSCRIBE_WINDOW_BYTES = PCM_BYTES_PER_SECOND * 3
 # an order of magnitude above; quiet-room mic noise well below.
 SILENCE_RMS_THRESHOLD = 150.0
 
+# Absolute floor (~-61 dBFS) for the low-gain fallback in
+# _speech_rms_threshold — audio quieter than this everywhere is silence.
+MIN_SPEECH_RMS = 30.0
+
+# Low-gain fallback: quiet audio counts as speech only when its loudest
+# frames stand at least this far above the recording's own noise floor.
+# Speech has strong dynamics (pauses between words); steady mic noise doesn't.
+SPEECH_DYNAMICS_RATIO = 4.0
+
 # Audio kept around detected speech when trimming silence off a full recording
 SILENCE_TRIM_PADDING_SECONDS = 0.5
 
@@ -61,21 +70,52 @@ def pcm16_rms(audio: bytes) -> float:
     return float(np.sqrt(np.mean(samples * samples)))
 
 
+def _speech_rms_threshold(frame_rms_values: list[float]) -> float | None:
+    """RMS threshold separating speech frames from silence for a recording.
+
+    Uses SILENCE_RMS_THRESHOLD when the recording reaches it. Otherwise falls
+    back to a relative test so quiet input from a low-gain microphone still
+    counts as speech when it stands well out of the recording's own noise
+    floor. Returns None when the recording contains no speech-like content.
+    """
+    if not frame_rms_values:
+        return None
+    peak = max(frame_rms_values)
+    if peak >= SILENCE_RMS_THRESHOLD:
+        return SILENCE_RMS_THRESHOLD
+    if peak < MIN_SPEECH_RMS:
+        return None
+    noise_floor = max(
+        sorted(frame_rms_values)[len(frame_rms_values) // 10], 1.0
+    )  # 10th percentile
+    if peak >= SPEECH_DYNAMICS_RATIO * noise_floor:
+        return max(MIN_SPEECH_RMS, peak / SPEECH_DYNAMICS_RATIO)
+    return None
+
+
 def trim_pcm16_silence(audio: bytes) -> bytes:
     """Trim leading/trailing silence from raw PCM16 audio.
 
     Analyzes the audio in 100ms frames and keeps everything from the first to
-    the last frame whose RMS reaches SILENCE_RMS_THRESHOLD, plus padding.
-    Returns b"" if no frame contains speech.
+    the last speech frame (per _speech_rms_threshold), plus padding. Returns
+    b"" if no frame contains speech.
     """
     frame_bytes = PCM_BYTES_PER_SECOND // 10
     if frame_bytes == 0 or not audio:
         return audio
 
+    frame_offsets = range(0, len(audio), frame_bytes)
+    frame_rms_values = [
+        pcm16_rms(audio[idx : idx + frame_bytes]) for idx in frame_offsets
+    ]
+    threshold = _speech_rms_threshold(frame_rms_values)
+    if threshold is None:
+        return b""
+
     speech_frame_indices = [
         idx
-        for idx in range(0, len(audio), frame_bytes)
-        if pcm16_rms(audio[idx : idx + frame_bytes]) >= SILENCE_RMS_THRESHOLD
+        for idx, frame_rms in zip(frame_offsets, frame_rms_values)
+        if frame_rms >= threshold
     ]
     if not speech_frame_indices:
         return b""
@@ -179,8 +219,9 @@ class ChunkedTranscriber:
         if self.is_pcm:
             full_audio_data = trim_pcm16_silence(full_audio_data)
             if not full_audio_data:
-                # Nothing but silence was recorded
-                return ""
+                # No speech detected in the recording; empty unless earlier
+                # windows produced transcripts
+                return " ".join(self.transcripts)
         if full_audio_data:
             try:
                 transcript = await self.provider.transcribe(

--- a/backend/onyx/server/manage/voice/websocket_api.py
+++ b/backend/onyx/server/manage/voice/websocket_api.py
@@ -7,6 +7,7 @@ import os
 from collections.abc import MutableMapping
 from typing import Any
 
+import numpy as np
 from fastapi import APIRouter
 from fastapi import Depends
 from fastapi import WebSocket
@@ -30,8 +31,63 @@ logger = setup_logger()
 router = APIRouter(prefix="/voice")
 
 
-# Transcribe every ~0.5 seconds of audio (webm/opus is ~2-4KB/s, so ~1-2KB per 0.5s)
+# Byte threshold for non-PCM formats, where the audio can't be analyzed server-side
 MIN_CHUNK_BYTES = 1500
+
+# The browser recorder sends raw PCM16 mono at 24kHz
+PCM_SAMPLE_RATE = 24000
+PCM_BYTES_PER_SECOND = PCM_SAMPLE_RATE * 2
+
+# Whisper-style models pad short inputs to a 30s window and hallucinate
+# training-data boilerplate (e.g. broadcast sign-offs) on silence/padding, so
+# PCM audio is transcribed in multi-second windows and windows without speech
+# are dropped without calling the provider.
+PCM_TRANSCRIBE_WINDOW_BYTES = PCM_BYTES_PER_SECOND * 3
+
+# int16 RMS below this (~-46 dBFS) is treated as silence. Speech is typically
+# an order of magnitude above; quiet-room mic noise well below.
+SILENCE_RMS_THRESHOLD = 150.0
+
+# Audio kept around detected speech when trimming silence off a full recording
+SILENCE_TRIM_PADDING_SECONDS = 0.5
+
+
+def pcm16_rms(audio: bytes) -> float:
+    """RMS amplitude of raw little-endian PCM16 audio (0.0 for empty input)."""
+    usable = len(audio) - (len(audio) % 2)
+    if usable == 0:
+        return 0.0
+    samples = np.frombuffer(audio[:usable], dtype=np.int16).astype(np.float64)
+    return float(np.sqrt(np.mean(samples * samples)))
+
+
+def trim_pcm16_silence(audio: bytes) -> bytes:
+    """Trim leading/trailing silence from raw PCM16 audio.
+
+    Analyzes the audio in 100ms frames and keeps everything from the first to
+    the last frame whose RMS reaches SILENCE_RMS_THRESHOLD, plus padding.
+    Returns b"" if no frame contains speech.
+    """
+    frame_bytes = PCM_BYTES_PER_SECOND // 10
+    if frame_bytes == 0 or not audio:
+        return audio
+
+    speech_frame_indices = [
+        idx
+        for idx in range(0, len(audio), frame_bytes)
+        if pcm16_rms(audio[idx : idx + frame_bytes]) >= SILENCE_RMS_THRESHOLD
+    ]
+    if not speech_frame_indices:
+        return b""
+
+    padding_bytes = int(PCM_BYTES_PER_SECOND * SILENCE_TRIM_PADDING_SECONDS)
+    start = max(0, speech_frame_indices[0] - padding_bytes)
+    end = min(len(audio), speech_frame_indices[-1] + frame_bytes + padding_bytes)
+    # Keep sample alignment
+    start -= start % 2
+    return audio[start:end]
+
+
 VOICE_DISABLE_STREAMING_FALLBACK = (
     os.environ.get("VOICE_DISABLE_STREAMING_FALLBACK", "").lower() == "true"
 )
@@ -49,14 +105,24 @@ WS_MAX_TTS_TEXT_LENGTH = 4096  # Max text length per synthesize call (matches RE
 
 
 class ChunkedTranscriber:
-    """Fallback transcriber for providers without streaming support."""
+    """Fallback transcriber for providers without streaming support.
+
+    For raw PCM16 input, audio is transcribed in multi-second windows and
+    silence is never sent to the provider — STT models hallucinate on
+    silent/near-silent audio instead of returning an empty transcript.
+    """
 
     def __init__(self, provider: Any, audio_format: str = "webm"):
         self.provider = provider
         self.audio_format = audio_format
+        self.is_pcm = audio_format == "pcm16"
+        self.window_bytes = (
+            PCM_TRANSCRIBE_WINDOW_BYTES if self.is_pcm else MIN_CHUNK_BYTES
+        )
         self.chunk_buffer = io.BytesIO()
         self.full_audio = io.BytesIO()
         self.chunk_bytes = 0
+        self.window_has_speech = False
         self.transcripts: list[str] = []
 
     async def add_chunk(self, chunk: bytes) -> str | None:
@@ -65,9 +131,28 @@ class ChunkedTranscriber:
         self.full_audio.write(chunk)
         self.chunk_bytes += len(chunk)
 
-        if self.chunk_bytes >= MIN_CHUNK_BYTES:
+        if (
+            self.is_pcm
+            and not self.window_has_speech
+            and pcm16_rms(chunk) >= SILENCE_RMS_THRESHOLD
+        ):
+            self.window_has_speech = True
+
+        if self.chunk_bytes >= self.window_bytes:
+            if self.is_pcm and not self.window_has_speech:
+                logger.debug(
+                    "Chunked transcription: dropping silent window (%s bytes)",
+                    self.chunk_bytes,
+                )
+                self._reset_window()
+                return None
             return await self._transcribe_chunk()
         return None
+
+    def _reset_window(self) -> None:
+        self.chunk_buffer = io.BytesIO()
+        self.chunk_bytes = 0
+        self.window_has_speech = False
 
     async def _transcribe_chunk(self) -> str | None:
         """Transcribe current chunk and append to running transcript."""
@@ -77,8 +162,7 @@ class ChunkedTranscriber:
 
         try:
             transcript = await self.provider.transcribe(audio_data, self.audio_format)
-            self.chunk_buffer = io.BytesIO()
-            self.chunk_bytes = 0
+            self._reset_window()
 
             if transcript and transcript.strip():
                 self.transcripts.append(transcript.strip())
@@ -86,13 +170,17 @@ class ChunkedTranscriber:
             return None
         except Exception as e:
             logger.error("Transcription error: %s", e)
-            self.chunk_buffer = io.BytesIO()
-            self.chunk_bytes = 0
+            self._reset_window()
             return None
 
     async def flush(self) -> str:
         """Get final transcript from full audio for best accuracy."""
         full_audio_data = self.full_audio.getvalue()
+        if self.is_pcm:
+            full_audio_data = trim_pcm16_silence(full_audio_data)
+            if not full_audio_data:
+                # Nothing but silence was recorded
+                return ""
         if full_audio_data:
             try:
                 transcript = await self.provider.transcribe(

--- a/backend/onyx/server/manage/voice/websocket_api.py
+++ b/backend/onyx/server/manage/voice/websocket_api.py
@@ -53,9 +53,11 @@ SILENCE_RMS_THRESHOLD = 150.0
 MIN_SPEECH_RMS = 30.0
 
 # Low-gain fallback: quiet audio counts as speech only when its loudest
-# frames stand at least this far above the recording's own noise floor.
-# Speech has strong dynamics (pauses between words); steady mic noise doesn't.
-SPEECH_DYNAMICS_RATIO = 4.0
+# frames stand at least this far (~8dB) above the recording's own noise
+# floor. Speech has strong dynamics (pauses between words); steady mic noise
+# stays near 1x. Below this, an empty transcript (visible, recoverable) is
+# deliberately preferred over risking hallucinated text.
+SPEECH_DYNAMICS_RATIO = 2.5
 
 # Audio kept around detected speech when trimming silence off a full recording
 SILENCE_TRIM_PADDING_SECONDS = 0.5

--- a/backend/tests/unit/onyx/server/manage/voice/test_chunked_transcriber.py
+++ b/backend/tests/unit/onyx/server/manage/voice/test_chunked_transcriber.py
@@ -1,0 +1,132 @@
+"""Tests for ChunkedTranscriber silence gating and PCM windowing.
+
+STT models hallucinate training-data boilerplate on silent audio instead of
+returning an empty transcript, so silent audio must never reach the provider.
+"""
+
+import math
+from unittest.mock import AsyncMock
+
+import pytest
+
+from onyx.server.manage.voice.websocket_api import ChunkedTranscriber
+from onyx.server.manage.voice.websocket_api import pcm16_rms
+from onyx.server.manage.voice.websocket_api import PCM_BYTES_PER_SECOND
+from onyx.server.manage.voice.websocket_api import PCM_SAMPLE_RATE
+from onyx.server.manage.voice.websocket_api import SILENCE_RMS_THRESHOLD
+from onyx.server.manage.voice.websocket_api import trim_pcm16_silence
+
+
+def _silence(seconds: float) -> bytes:
+    return b"\x00\x00" * int(PCM_SAMPLE_RATE * seconds)
+
+
+def _tone(seconds: float, amplitude: int = 8000, freq_hz: float = 440.0) -> bytes:
+    n_samples = int(PCM_SAMPLE_RATE * seconds)
+    samples = bytearray()
+    for i in range(n_samples):
+        value = int(amplitude * math.sin(2 * math.pi * freq_hz * i / PCM_SAMPLE_RATE))
+        samples += value.to_bytes(2, "little", signed=True)
+    return bytes(samples)
+
+
+def _chunks(audio: bytes, chunk_seconds: float = 0.25) -> list[bytes]:
+    chunk_bytes = int(PCM_BYTES_PER_SECOND * chunk_seconds)
+    return [audio[i : i + chunk_bytes] for i in range(0, len(audio), chunk_bytes)]
+
+
+def _make_transcriber(transcript: str = "hello world") -> ChunkedTranscriber:
+    provider = AsyncMock()
+    provider.transcribe = AsyncMock(return_value=transcript)
+    return ChunkedTranscriber(provider, audio_format="pcm16")
+
+
+def test_pcm16_rms() -> None:
+    assert pcm16_rms(b"") == 0.0
+    assert pcm16_rms(_silence(1.0)) == 0.0
+    tone_rms = pcm16_rms(_tone(1.0))
+    # RMS of a sine wave is amplitude / sqrt(2)
+    assert tone_rms == pytest.approx(8000 / math.sqrt(2), rel=0.01)
+    assert tone_rms > SILENCE_RMS_THRESHOLD
+
+
+@pytest.mark.asyncio
+async def test_silent_audio_never_reaches_provider() -> None:
+    transcriber = _make_transcriber()
+
+    for chunk in _chunks(_silence(10.0)):
+        result = await transcriber.add_chunk(chunk)
+        assert result is None
+
+    transcriber.provider.transcribe.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_flush_of_silent_recording_returns_empty() -> None:
+    transcriber = _make_transcriber()
+
+    for chunk in _chunks(_silence(2.0)):
+        await transcriber.add_chunk(chunk)
+
+    assert await transcriber.flush() == ""
+    transcriber.provider.transcribe.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_speech_is_transcribed_in_multi_second_windows() -> None:
+    transcriber = _make_transcriber()
+
+    results = [await transcriber.add_chunk(chunk) for chunk in _chunks(_tone(6.0))]
+
+    transcripts = [r for r in results if r is not None]
+    # 6s of speech at a 3s window = exactly 2 provider calls
+    assert transcriber.provider.transcribe.await_count == 2
+    assert transcripts[-1] == "hello world hello world"
+
+
+@pytest.mark.asyncio
+async def test_window_with_brief_speech_is_transcribed() -> None:
+    transcriber = _make_transcriber()
+
+    audio = _silence(1.0) + _tone(0.5) + _silence(1.5)
+    results = [await transcriber.add_chunk(chunk) for chunk in _chunks(audio)]
+
+    assert transcriber.provider.transcribe.await_count == 1
+    assert [r for r in results if r is not None] == ["hello world"]
+
+
+@pytest.mark.asyncio
+async def test_flush_trims_leading_and_trailing_silence() -> None:
+    transcriber = _make_transcriber()
+
+    for chunk in _chunks(_silence(2.0) + _tone(1.0) + _silence(4.0)):
+        await transcriber.add_chunk(chunk)
+
+    assert await transcriber.flush() == "hello world"
+
+    sent_audio = transcriber.provider.transcribe.await_args.args[0]
+    # 1s of tone + at most 0.5s padding on each side
+    assert PCM_BYTES_PER_SECOND * 1.0 <= len(sent_audio) <= PCM_BYTES_PER_SECOND * 2.0
+
+
+@pytest.mark.asyncio
+async def test_non_pcm_format_keeps_legacy_byte_threshold() -> None:
+    provider = AsyncMock()
+    provider.transcribe = AsyncMock(return_value="hi")
+    transcriber = ChunkedTranscriber(provider, audio_format="webm")
+
+    result = await transcriber.add_chunk(b"\x00" * 1500)
+
+    provider.transcribe.assert_awaited_once()
+    assert result == "hi"
+
+
+def test_trim_pcm16_silence() -> None:
+    assert trim_pcm16_silence(b"") == b""
+    assert trim_pcm16_silence(_silence(5.0)) == b""
+
+    tone = _tone(1.0)
+    trimmed = trim_pcm16_silence(_silence(3.0) + tone + _silence(3.0))
+    assert len(tone) <= len(trimmed) <= len(tone) + PCM_BYTES_PER_SECOND
+    # Trimmed audio still contains the speech energy
+    assert pcm16_rms(trimmed) >= SILENCE_RMS_THRESHOLD

--- a/backend/tests/unit/onyx/server/manage/voice/test_chunked_transcriber.py
+++ b/backend/tests/unit/onyx/server/manage/voice/test_chunked_transcriber.py
@@ -151,6 +151,24 @@ async def test_flush_recovers_quiet_speech_below_absolute_threshold() -> None:
 
 
 @pytest.mark.asyncio
+async def test_flush_recovers_quiet_speech_over_steady_noise_floor() -> None:
+    """Quiet speech over a constant noise floor: speech peaks stand ~3x above
+    the floor, which must count as speech-like dynamics."""
+    transcriber = _make_transcriber()
+
+    floor = _tone(2.0, amplitude=45)  # RMS ~32 noise floor
+    speech = _tone(1.0, amplitude=130)  # RMS ~92, still below the 150 threshold
+    assert pcm16_rms(speech) < SILENCE_RMS_THRESHOLD
+
+    for chunk in _chunks(floor + speech + floor):
+        await transcriber.add_chunk(chunk)
+    transcriber.provider.transcribe.assert_not_awaited()
+
+    assert await transcriber.flush() == "hello world"
+    transcriber.provider.transcribe.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_flush_of_uniform_low_noise_returns_empty() -> None:
     """Steady low-level noise has no speech-like dynamics and must not be
     transcribed even though it is above the low-gain speech floor."""

--- a/backend/tests/unit/onyx/server/manage/voice/test_chunked_transcriber.py
+++ b/backend/tests/unit/onyx/server/manage/voice/test_chunked_transcriber.py
@@ -130,3 +130,49 @@ def test_trim_pcm16_silence() -> None:
     assert len(tone) <= len(trimmed) <= len(tone) + PCM_BYTES_PER_SECOND
     # Trimmed audio still contains the speech energy
     assert pcm16_rms(trimmed) >= SILENCE_RMS_THRESHOLD
+
+
+@pytest.mark.asyncio
+async def test_flush_recovers_quiet_speech_below_absolute_threshold() -> None:
+    """Low-gain mic: speech never crosses the absolute RMS threshold, but it
+    stands well out of the noise floor, so flush must still transcribe it."""
+    transcriber = _make_transcriber()
+
+    quiet_tone = _tone(1.0, amplitude=100)  # RMS ~71, below the 150 threshold
+    assert pcm16_rms(quiet_tone) < SILENCE_RMS_THRESHOLD
+
+    for chunk in _chunks(_silence(2.0) + quiet_tone + _silence(2.0)):
+        await transcriber.add_chunk(chunk)
+    # Live windows are gated by the conservative absolute threshold
+    transcriber.provider.transcribe.assert_not_awaited()
+
+    assert await transcriber.flush() == "hello world"
+    transcriber.provider.transcribe.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_flush_of_uniform_low_noise_returns_empty() -> None:
+    """Steady low-level noise has no speech-like dynamics and must not be
+    transcribed even though it is above the low-gain speech floor."""
+    transcriber = _make_transcriber()
+
+    noise = _tone(6.0, amplitude=50)  # RMS ~35, uniform across the recording
+    for chunk in _chunks(noise):
+        await transcriber.add_chunk(chunk)
+
+    assert await transcriber.flush() == ""
+    transcriber.provider.transcribe.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_flush_falls_back_to_window_transcripts() -> None:
+    """If silence trimming leaves nothing, earlier window transcripts must
+    not be discarded."""
+    transcriber = _make_transcriber()
+    transcriber.transcripts = ["hello", "world"]
+
+    for chunk in _chunks(_silence(1.0)):
+        await transcriber.add_chunk(chunk)
+
+    assert await transcriber.flush() == "hello world"
+    transcriber.provider.transcribe.assert_not_awaited()


### PR DESCRIPTION
## Description

Voice recordings with an open-but-silent microphone produce transcripts full of hallucinated text — most notoriously Korean broadcast sign-offs (`MBC 뉴스 이덕영입니다`), YouTube caption disclaimers, and repeated `you` tokens. Confirmed hitting many users across multiple deployments; users end up sending these hallucinations as chat messages.

Root cause: Whisper-style STT models hallucinate training-data boilerplate on silent/near-silent audio instead of returning an empty transcript, and the chunked STT fallback path amplifies this maximally:

- The browser recorder streams raw PCM16 in ~250ms slices with no VAD gating.
- `ChunkedTranscriber` fired an independent transcription API call for every slice (`MIN_CHUNK_BYTES = 1500` ≈ 31ms of PCM), each padded to a 30s window by the model — i.e. ~99-100% silence per call, ~4 API calls per second.
- Language auto-detection re-rolls on every call, so hallucinations flip languages chunk to chunk, and the fragments are string-joined into the live transcript.
- The final full-audio pass transcribes long silent tails, which also hallucinate.

Fix (chunked PCM path only; non-PCM formats keep legacy behavior):

- Transcribe in 3-second windows instead of per-slice (also cuts STT API volume ~12x)
- Drop windows containing no chunk above a speech RMS threshold (~-46 dBFS) without calling the provider — silence can no longer reach the STT model
- Trim leading/trailing silence before the final full-audio transcription; a recording containing only silence now returns an empty transcript

## How Has This Been Tested?

- New unit tests (`test_chunked_transcriber.py`, 8 tests) covering: silent audio never reaches the provider, silent-recording flush returns empty without a provider call, 3s windowing call counts, brief-speech-in-window still transcribes, flush silence trimming bounds, non-PCM legacy threshold, and RMS/trim helpers on synthetic PCM (silence + sine tones)
- Full voice unit suite passes (71 tests)
- Verified the commit cherry-picks cleanly onto `release/v4.0` and the changed file compiles under Python 3.11

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop hallucinated transcripts from silent microphones by gating silence in chunked STT for `pcm16` and trimming silence in the final pass. This removes bogus text, recovers quiet speech from low‑gain mics via a 2.5x dynamics test, and reduces STT provider calls by ~12x.

- **Bug Fixes**
  - For raw `pcm16`, transcribe in 3s windows and drop windows with no speech (RMS below threshold) without calling the provider.
  - Trim leading/trailing silence before the final pass; keep low‑gain speech when peaks are ≥2.5x above the noise floor; all‑silence returns empty; if trimming removes everything, return prior window transcripts.
  - Keep legacy byte-based chunking for non-PCM formats (e.g., `webm`); behavior unchanged.

<sup>Written for commit bb9e0a66ecbd22b620bf9a08774dc8d23ecba63f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

