### PR TITLE
test(e2e): de-race scroll-bottom assertions in scroll_behavior spec

### DIFF
--- a/web/tests/e2e/chat/scroll_behavior.spec.ts
+++ b/web/tests/e2e/chat/scroll_behavior.spec.ts
@@ -47,8 +47,7 @@ async function setAutoScroll(page: Page, enabled: boolean) {
  * Helper to get the scroll container element
  */
 function getScrollContainer(page: Page) {
-  // The scroll container is the div with overflow-y-auto inside ChatUI
-  return page.locator(".overflow-y-auto").first();
+  return page.getByTestId("chat-scroll-container");
 }
 
 test.describe("Chat Scroll Behavior", () => {
@@ -124,13 +123,19 @@ test.describe("Chat Scroll Behavior", () => {
     // Send another message to create some content
     await sendMessage(page, "Another message to test scrolling behavior");
 
-    // The scroll container should be scrolled to bottom
+    // The scroll container should settle at the bottom. Poll because the
+    // DynamicBottomSpacer's ~600ms smooth scroll and streaming-driven spacer
+    // resizes are still in flight when sendMessage resolves.
     const scrollContainer = getScrollContainer(page);
-    const isAtBottom = await scrollContainer.evaluate((el: HTMLElement) => {
-      return Math.abs(el.scrollHeight - el.scrollTop - el.clientHeight) < 10;
-    });
-
-    expect(isAtBottom).toBe(true);
+    await expect
+      .poll(
+        () =>
+          scrollContainer.evaluate((el: HTMLElement) =>
+            Math.abs(el.scrollHeight - el.scrollTop - el.clientHeight)
+          ),
+        { timeout: 10_000 }
+      )
+      .toBeLessThan(10);
   });
 });
 
@@ -264,13 +269,18 @@ test.describe("Dynamic Bottom Spacer - Fresh Chat Effect", () => {
     // Send a message
     await sendMessage(page, "Please respond with a short message");
 
-    // After AI response completes, verify we're still at the bottom
+    // After AI response completes, verify we settle at the bottom (poll: the
+    // smooth scroll / spacer resize may still be in flight when sendMessage
+    // resolves). Allow a small tolerance (10px) for rounding.
     const scrollContainer = getScrollContainer(page);
-    const isAtBottom = await scrollContainer.evaluate((el: HTMLElement) => {
-      // Allow a small tolerance (10px) for rounding
-      return Math.abs(el.scrollHeight - el.scrollTop - el.clientHeight) < 10;
-    });
-
-    expect(isAtBottom).toBe(true);
+    await expect
+      .poll(
+        () =>
+          scrollContainer.evaluate((el: HTMLElement) =>
+            Math.abs(el.scrollHeight - el.scrollTop - el.clientHeight)
+          ),
+        { timeout: 10_000 }
+      )
+      .toBeLessThan(10);
   });
 });


### PR DESCRIPTION
## Description

The merge-queue Playwright run [28391044237](https://github.com/onyx-dot-app/onyx/actions/runs/28391044237) failed all 3 retries on `Chat Scroll Behavior › Auto-scroll ON: scrolls to bottom on new message`.

Root cause: `sendMessage()` resolves as soon as the AI message element *appears*, but at that moment the DynamicBottomSpacer is still mid-flight — it kicks off a ~600ms smooth scroll, suppresses the container's instant auto-scroll while `data-smooth-scroll-active` is set, and keeps resizing the spacer as content streams. The test then did a **one-shot** `scrollHeight - scrollTop - clientHeight < 10` check, measuring mid-animation.

Changes:
- Replace the one-shot at-bottom checks (in both `Auto-scroll ON` and `Scroll container remains at bottom after AI response completes`) with `expect.poll` on the bottom distance — the pattern the sibling tests in this file already use.
- Target `getByTestId("chat-scroll-container")` instead of first-match `.overflow-y-auto`, which is fragile against DOM-order changes.

## How Has This Been Tested?

Pre-commit hooks (oxfmt, oxlint, TypeScript type check) pass. Test-only change; the merge-queue Playwright run on this PR exercises it directly.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes chat scroll e2e tests by polling until the container settles at the bottom and using a stable test-id selector, removing flaky failures caused by mid-animation reads.

- **Bug Fixes**
  - Replace one-shot at-bottom checks with `expect.poll` on bottom distance (<10px, 10s timeout) in the two affected tests.
  - Select the scroll container via `getByTestId("chat-scroll-container")` instead of the first `.overflow-y-auto` to avoid DOM-order fragility.

<sup>Written for commit 3c1daddfc83aaa3fee78c12b2f350ee6553c44ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

