### PR TITLE
chore(deps): cherry-pick paths-filter 3.0.2→4.0.1 bump to release/v4.0

### DIFF
--- a/.github/workflows/pr-database-tests.yml
+++ b/.github/workflows/pr-database-tests.yml
@@ -28,7 +28,7 @@ jobs:
         if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         with:
           persist-credentials: false
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # ratchet:dorny/paths-filter@v3
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter
         if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         with:

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # ratchet:dorny/paths-filter@v3
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter
         if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         with:

--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -88,7 +88,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # ratchet:dorny/paths-filter@v3
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter
         if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         with:

--- a/.github/workflows/pr-python-checks.yml
+++ b/.github/workflows/pr-python-checks.yml
@@ -28,7 +28,7 @@ jobs:
         if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         with:
           persist-credentials: false
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # ratchet:dorny/paths-filter@v3
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter
         if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         with:

--- a/.github/workflows/pr-python-connector-tests.yml
+++ b/.github/workflows/pr-python-connector-tests.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Detect Connector changes
         id: changes
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # ratchet:dorny/paths-filter@v3
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         with:
           filters: |
             hubspot:

--- a/.github/workflows/pr-python-tests.yml
+++ b/.github/workflows/pr-python-tests.yml
@@ -28,7 +28,7 @@ jobs:
         if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         with:
           persist-credentials: false
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # ratchet:dorny/paths-filter@v3
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter
         if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         with:


### PR DESCRIPTION
## Description

Cherry-pick of a5f0c7d143 (#11718) onto `release/v4.0`.

The `changes` (paths-filter) job has repeatedly killed `release/v4.0` merge-queue runs of Run Playwright Tests with `fatal: shallow file has changed since we read it` (runs [27656893245](https://github.com/onyx-dot-app/onyx/actions/runs/27656893245), [27773217585](https://github.com/onyx-dot-app/onyx/actions/runs/27773217585), [28809367064](https://github.com/onyx-dot-app/onyx/actions/runs/28809367064)), ejecting PRs from the queue.

Root cause: paths-filter v3.0.2 has no `merge_group` support, so on release-queue branches it falls back to diffing against the repo default branch — `git merge-base origin/main gh-readonly-queue/release/v4.0/...` — deepening the shallow clone in `--deepen=200` loops until it hits the git shallow-file race. v4.0.1 diffs against `merge_group.base_sha` directly, so there is no merge-base loop. `main` and `release/v4.1` already carry this pin; `release/v4.0` is the only branch left on v3.0.2.

## How Has This Been Tested?

Clean cherry-pick (`git cherry-pick -x`), 6 files, one pin line each — identical to what has been running on `main` since June 4. The failure mode is exercised by this branch's own merge-queue run.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cherry-picks an upgrade to `dorny/paths-filter` in `release/v4.0` PR workflows to stop merge-queue failures. v4.0.1 uses `merge_group` data and avoids the shallow-clone race causing “fatal: shallow file has changed since we read it”.

- **Dependencies**
  - Bump `dorny/paths-filter` from 3.0.2 to 4.0.1 (`fbd0ab8…`) across PR test workflows (database, integration, Playwright, Python checks/tests, Python connector tests).

<sup>Written for commit 097f5b0805328d6f87be09ace0f23df1fa47edcf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

