### PR TITLE
fix(sandbox): pin chromium to 149 — trixie-security 150 SIGTRAPs at launch, breaking craft browser CI

### DIFF
--- a/backend/onyx/server/features/build/sandbox/image/Dockerfile
+++ b/backend/onyx/server/features/build/sandbox/image/Dockerfile
@@ -50,6 +50,13 @@ ARG ENABLE_SKILLS=true
 ARG ENABLE_BROWSER=true
 ARG OPENCODE_VERSION=1.15.7
 ARG AGENT_BROWSER_VERSION=0.31.1
+# trixie-security's chromium 150.0.7871.46-1~deb13u1 SIGTRAPs at launch
+# (https://bugs.debian.org/chromium — also broke grafana-image-renderer and
+# linuxserver/docker-chromium), which kills the Craft `browser` command and the
+# craft-k8s browser CI lane. Pin the last known-good build (from
+# trixie-proposed-updates) until a fixed security build lands, then drop the
+# pin and the proposed-updates apt source below.
+ARG CHROMIUM_VERSION=149.0.7827.196-1~deb13u1
 
 # firewall-init.sh needs: iptables (egress lockdown), ca-certificates (trust
 # store), gosu (legacy, not currently invoked). setpriv ships with util-linux in
@@ -96,9 +103,13 @@ RUN if [ "$ENABLE_SKILLS" = "true" ]; then \
 # Chromium's NSS db). Its own layer: big and rarely-changing, so an
 # AGENT_BROWSER_VERSION bump below re-pulls only the small CLI layer, not this.
 RUN if [ "$ENABLE_BROWSER" = "true" ]; then \
+    echo "deb http://deb.debian.org/debian trixie-proposed-updates main" \
+    > /etc/apt/sources.list.d/trixie-proposed-updates.list && \
     apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    chromium \
+    chromium="${CHROMIUM_VERSION}" \
+    chromium-common="${CHROMIUM_VERSION}" \
     libnss3-tools \
+    && rm /etc/apt/sources.list.d/trixie-proposed-updates.list \
     && rm -rf /var/lib/apt/lists/*; \
     fi
 


### PR DESCRIPTION
## Description

Every `craft-k8s (browser)` job on main-bound PRs and merge-queue runs has been failing since ~18:00 UTC 2026-07-06 with:

```
AssertionError: ✗ Chrome exited early (exit code: unknown) without writing DevToolsActivePort
```

`exit code: unknown` = Chrome was signal-killed. Root cause: the sandbox image installs `chromium` **unpinned** from apt, and Debian pushed `150.0.7871.46-1~deb13u1` to trixie-security, which crashes at startup with SIGTRAP — a known-broken build ([Debian forum](https://debianforum.de/forum/viewtopic.php?p=1412586), [grafana-image-renderer](https://community.grafana.com/t/grafana-image-renderer-stopped-working-after-chromium-upgrade/163566), [linuxserver/docker-chromium#60](https://github.com/linuxserver/docker-chromium/issues/60)).

Timeline evidence:
- Last green browser run ([28804255692](https://github.com/onyx-dot-app/onyx/actions/runs/28804255692), 15:47 UTC): sandbox image build fully **CACHED** (old chromium 149).
- First red run ([28816057825](https://github.com/onyx-dot-app/onyx/actions/runs/28816057825), 19:01 UTC): cache miss rebuilt the layer and installed **chromium 150.0.7871.46-1~deb13u1**; every browser job since fails.
- Green nightly builds installed **149.0.7827.196-1~deb13u1**.

Fix: pin `chromium`/`chromium-common` to the last known-good `149.0.7827.196-1~deb13u1`, still published in `trixie-proposed-updates` (amd64 + arm64). The apt source line is added and removed within the same layer. Drop the pin once Debian ships a fixed security build (>150.0.7871.46).

## How Has This Been Tested?

- Dry-run of the pinned install against the exact `python:3.13-slim` base digest resolves cleanly from proposed-updates.
- This PR's own `craft-k8s (browser)` job rebuilds the chromium layer (Dockerfile changed → cache bust) and runs `test_browser_fetches_https_through_egress_proxy` end to end — the direct regression check.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins `chromium` in the sandbox image to 149.0.7827.196-1~deb13u1 to stop the v150 startup crash and restore passing `craft-k8s (browser)` CI.

- **Bug Fixes**
  - Installs `chromium` and `chromium-common` at 149.0.7827.196-1~deb13u1 from trixie-proposed-updates, then removes the apt source in the same layer.
  - Prevents Chrome from exiting early (SIGTRAP / missing DevToolsActivePort) so browser tests run reliably.

<sup>Written for commit cf1cb329729cd349fb228895baa180c6c87c37f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12717?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

