### PR TITLE
feat(web): always log toast messages to the console

### DIFF
--- a/web/src/hooks/useToast.ts
+++ b/web/src/hooks/useToast.ts
@@ -65,13 +65,11 @@ function addToast(options: ToastOptions): string {
     createdAt: Date.now(),
   };
 
-  if (process.env.NODE_ENV === "development") {
-    const method = TOAST_CONSOLE_METHOD[level];
-    if (entry.description) {
-      console[method](`[Toast] ${entry.message}`, entry.description);
-    } else {
-      console[method](`[Toast] ${entry.message}`);
-    }
+  const method = TOAST_CONSOLE_METHOD[level];
+  if (entry.description) {
+    console[method](`[Toast] ${entry.message}`, entry.description);
+  } else {
+    console[method](`[Toast] ${entry.message}`);
   }
 
   toasts = [...toasts, entry];


### PR DESCRIPTION
## What

Removes the `process.env.NODE_ENV === "development"` guard in `useToast.ts` so toast messages are mirrored to the browser console in **all** environments, not just dev.

## Why

- Toasts auto-dismiss after 4s and are ephemeral, so the console gives a **persistent, debuggable record** of what the user saw.
- The text is **already rendered on screen** for the user, so logging the same string to the console exposes nothing the DOM doesn't already show.
- **No error-tracking noise:** the frontend Sentry client (`instrumentation-client.ts`) does not enable the `CaptureConsole` integration, so these console calls do **not** become Sentry error events. They are picked up as **breadcrumbs** by the default integration, which only attach to real error events — a mild plus for debugging context.

## Change

```diff
-  if (process.env.NODE_ENV === "development") {
-    const method = TOAST_CONSOLE_METHOD[level];
-    if (entry.description) {
-      console[method](`[Toast] ${entry.message}`, entry.description);
-    } else {
-      console[method](`[Toast] ${entry.message}`);
-    }
+  const method = TOAST_CONSOLE_METHOD[level];
+  if (entry.description) {
+    console[method](`[Toast] ${entry.message}`, entry.description);
+  } else {
+    console[method](`[Toast] ${entry.message}`);
   }
```

The `[Toast]` prefix and level→method mapping (`error`→`console.error`, `warning`→`console.warn`, etc.) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always mirror toast messages to the browser console in all environments to give a persistent record for debugging. Keeps the `[Toast]` prefix and level-to-console mapping; Sentry only records these as breadcrumbs, not events.

<sup>Written for commit 00fc9be7cf20d0c14ec8889cd46117524987d559. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

