### PR TITLE
fix(desktop): grant webview ACL permissions for shell-open and titlebar drag

### DIFF
--- a/desktop/src-tauri/capabilities/main.json
+++ b/desktop/src-tauri/capabilities/main.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "main",
+  "description": "Grants the webview pages the plugin commands they invoke: shell open for target=_blank links (the shell plugin's injected click handler) and window dragging / double-click maximize for the injected titlebar drag region. The server URL is user-configurable (self-hosted deployments), so the remote grant must cover any origin the webview may load.",
+  "windows": ["*"],
+  "local": true,
+  "remote": {
+    "urls": ["http://*:*", "https://*:*"]
+  },
+  "permissions": [
+    "core:window:allow-start-dragging",
+    "core:window:allow-internal-toggle-maximize",
+    "shell:default"
+  ]
+}


### PR DESCRIPTION
## Description

The desktop app ships with **no Tauri capability files**, so Tauri v2's ACL denies every plugin command invoked from the webview. Two things are actually broken in production:

- **External links do nothing.** `tauri-plugin-shell` unconditionally injects a click handler that `preventDefault()`s every `<a target="_blank">` click and calls `invoke("plugin:shell|open")` — which the empty ACL denies. The link never opens, and the uncaught rejection is reported to Sentry ([ONYX-WEB-8M](https://onyx-vl.sentry.io/issues/7168640788), 195 events).
- **Double-click-to-maximize on the injected titlebar is broken.** The titlebar's `data-tauri-drag-region` makes Tauri's core script invoke `plugin:window|start_dragging` ([ONYX-WEB-82](https://onyx-vl.sentry.io/issues/7105588669), 173 events) and `plugin:window|internal_toggle_maximize` ([ONYX-WEB-AB](https://onyx-vl.sentry.io/issues/7264268310), 42 events), both denied. Dragging still works only because `titlebar.js` falls back to the custom `start_drag_window` app command, which bypasses the ACL.

The v1-style `"plugins": { "shell": { "open": true } }` in `tauri.conf.json` only configures the open command's URL scope — it does not grant the ACL permission.

This adds `src-tauri/capabilities/main.json` (auto-enabled by Tauri at build time) granting exactly the three commands the injected scripts invoke:

- `shell:default` — `allow-open` with the plugin's pre-configured scope (http/https/mailto/tel)
- `core:window:allow-start-dragging`
- `core:window:allow-internal-toggle-maximize`

The grant covers local pages and any remote origin (`http://*:*`, `https://*:*`) because the server URL is user-configurable for self-hosted deployments, so the remote origin can't be pinned at compile time. App-defined commands (`open_in_browser`, `toggle_menu_bar`, …) are unaffected — they bypass the ACL since no app manifest is generated.

Fixes ONYX-WEB-8M
Fixes ONYX-WEB-82
Fixes ONYX-WEB-AB

## How Has This Been Tested?

- Validated the capability file against the generated `gen/schemas/desktop-schema.json` (passes) and confirmed all three permission identifiers exist in the generated ACL manifests.
- Verified the `remote.urls` URLPattern semantics (`https://*` misses non-default ports; `*:*` matches all hosts/ports) against the same spec implementation Tauri's matcher uses.
- No Rust toolchain in the dev container, so no local build — the `Build Desktop App` CI workflow triggers on `desktop/**` and `tauri build` resolves capabilities at compile time, so an invalid capability would fail CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Tauri v2 capability file to grant webview ACL permissions for `shell` open and window drag/maximize. This restores external link opening and titlebar double‑click maximize in the desktop app.

- **Bug Fixes**
  - External links open again by allowing `shell:default` (`allow-open`) via `tauri-plugin-shell` with the plugin’s scope.
  - Titlebar interactions work by allowing `core:window:allow-start-dragging` and `core:window:allow-internal-toggle-maximize` for local pages and remote `http://*:*` / `https://*:*` (server URL is user-configurable).

<sup>Written for commit a0083e40c8d0cb029e95f53d14dd3a4fcfe8ee45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

