### PR TITLE
feat(chat): add per-chat "Keep Chat" retention exemption (EE)

### DIFF
--- a/backend/alembic/versions/da41c7ca5933_add_retention_exempt_to_chat_session.py
+++ b/backend/alembic/versions/da41c7ca5933_add_retention_exempt_to_chat_session.py
@@ -1,0 +1,33 @@
+"""add retention_exempt to chat_session
+
+Revision ID: da41c7ca5933
+Revises: 2e0b2b146de1
+Create Date: 2026-07-06 23:09:25.146385
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "da41c7ca5933"
+down_revision = "2e0b2b146de1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "chat_session",
+        sa.Column(
+            "retention_exempt",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("chat_session", "retention_exempt")

--- a/backend/onyx/db/chat.py
+++ b/backend/onyx/db/chat.py
@@ -293,6 +293,7 @@ def update_chat_session(
     chat_session_id: UUID,
     description: str | None = None,
     sharing_status: ChatSessionSharedStatus | None = None,
+    retention_exempt: bool | None = None,
 ) -> ChatSession:
     chat_session = get_chat_session_by_id(
         chat_session_id=chat_session_id, user_id=user_id, db_session=db_session
@@ -305,6 +306,8 @@ def update_chat_session(
         chat_session.description = description
     if sharing_status is not None:
         chat_session.shared_status = sharing_status
+    if retention_exempt is not None:
+        chat_session.retention_exempt = retention_exempt
 
     db_session.commit()
 
@@ -379,6 +382,9 @@ def get_chat_sessions_older_than(
     old session that is still being used is retained. Sessions without any messages
     fall back to their creation time.
 
+    Sessions the user marked as retention-exempt ("Keep Chat") are never returned,
+    so the retention/TTL job leaves them untouched.
+
     Args:
         days_old: The number of days to consider as "old".
         db_session: The database session.
@@ -394,6 +400,7 @@ def get_chat_sessions_older_than(
     old_sessions: Sequence[Row[Tuple[UUID | None, UUID]]] = db_session.execute(
         select(ChatSession.user_id, ChatSession.id)
         .outerjoin(ChatMessage, ChatMessage.chat_session_id == ChatSession.id)
+        .where(ChatSession.retention_exempt.is_(False))
         .group_by(ChatSession.id, ChatSession.user_id)
         .having(last_activity < cutoff_time)
     ).fetchall()

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -2891,6 +2891,11 @@ class ChatSession(Base):
     onyxbot_flow: Mapped[bool] = mapped_column(Boolean, default=False)
     # Only ever set to True if system is set to not hard-delete chats
     deleted: Mapped[bool] = mapped_column(Boolean, default=False)
+    # When True, this session is exempt from the org's chat retention policy
+    # (the EE TTL job will never auto-delete it). Set per-chat by the user.
+    retention_exempt: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=text("false")
+    )
     # controls whether or not this conversation is viewable by others
     shared_status: Mapped[ChatSessionSharedStatus] = mapped_column(
         Enum(ChatSessionSharedStatus, native_enum=False),

--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -207,6 +207,7 @@ def get_user_chat_sessions(
                 shared_status=chat.shared_status,
                 current_alternate_model=chat.current_alternate_model,
                 current_temperature_override=chat.temperature_override,
+                retention_exempt=chat.retention_exempt,
             )
             for chat in chat_sessions
         ],
@@ -379,6 +380,7 @@ def get_chat_session(
         shared_status=chat_session.shared_status,
         current_temperature_override=chat_session.temperature_override,
         deleted=chat_session.deleted,
+        retention_exempt=chat_session.retention_exempt,
         owner_name=chat_session.user.personal_name if chat_session.user else None,
         # Packets are now directly serialized as Packet Pydantic models
         packets=replay_packet_lists,
@@ -498,6 +500,7 @@ def patch_chat_session(
         user_id=user_id,
         chat_session_id=session_id,
         sharing_status=chat_session_update_req.sharing_status,
+        retention_exempt=chat_session_update_req.retention_exempt,
     )
     return None
 

--- a/backend/onyx/server/query_and_chat/models.py
+++ b/backend/onyx/server/query_and_chat/models.py
@@ -173,7 +173,10 @@ class ChatRenameRequest(BaseModel):
 
 
 class ChatSessionUpdateRequest(BaseModel):
-    sharing_status: ChatSessionSharedStatus
+    sharing_status: ChatSessionSharedStatus | None = None
+    # When set, marks/unmarks this chat as exempt from the org's retention
+    # policy ("Keep Chat"). None leaves the current value unchanged.
+    retention_exempt: bool | None = None
 
 
 class DeleteAllSessionsRequest(BaseModel):
@@ -193,6 +196,7 @@ class ChatSessionDetails(BaseModel):
     shared_status: ChatSessionSharedStatus
     current_alternate_model: str | None = None
     current_temperature_override: float | None = None
+    retention_exempt: bool = False
 
     @classmethod
     def from_model(cls, model: ChatSession) -> "ChatSessionDetails":
@@ -205,6 +209,7 @@ class ChatSessionDetails(BaseModel):
             shared_status=model.shared_status,
             current_alternate_model=model.current_alternate_model,
             current_temperature_override=model.temperature_override,
+            retention_exempt=model.retention_exempt,
         )
 
 
@@ -267,6 +272,7 @@ class ChatSessionDetailResponse(BaseModel):
     current_alternate_model: str | None
     current_temperature_override: float | None
     deleted: bool = False
+    retention_exempt: bool = False
     owner_name: str | None = None
     packets: list[list[Packet]]
     # Set while a run is in flight and resumable: cursor-0 replay+tail is

--- a/backend/tests/integration/common_utils/managers/chat.py
+++ b/backend/tests/integration/common_utils/managers/chat.py
@@ -392,6 +392,23 @@ class ChatSessionManager:
         response.raise_for_status()
 
     @staticmethod
+    def set_retention_exempt(
+        chat_session: DATestChatSession,
+        retention_exempt: bool,
+        user_performing_action: DATestUser,
+    ) -> bool:
+        """
+        Mark (or unmark) a chat session as exempt from the org's retention policy
+        ("Keep Chat"). Returns True if the update succeeded, False otherwise.
+        """
+        response = client.patch(
+            f"{API_SERVER_URL}/chat/chat-session/{chat_session.id}",
+            json={"retention_exempt": retention_exempt},
+            headers=user_performing_action.headers,
+        )
+        return not response.is_error
+
+    @staticmethod
     def delete(
         chat_session: DATestChatSession,
         user_performing_action: DATestUser,

--- a/backend/tests/integration/tests/chat_retention/test_chat_retention.py
+++ b/backend/tests/integration/tests/chat_retention/test_chat_retention.py
@@ -123,6 +123,69 @@ def test_chat_retention(
     os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
     reason="Chat retention tests are enterprise only",
 )
+def test_chat_retention_respects_keep_chat(
+    reset: None,  # noqa: ARG001
+    admin_user: DATestUser,
+    llm_provider: DATestLLMProvider,  # noqa: ARG001
+) -> None:
+    """A session the user marked "Keep Chat" (retention_exempt) is never deleted
+    by the TTL job, while an equally-old non-exempt session still is."""
+
+    retention_days = 30
+    settings = DATestSettings(maximum_chat_retention_days=retention_days)
+    SettingsManager.update_settings(settings, user_performing_action=admin_user)
+
+    # Old + inactive, but marked "Keep Chat" -> should be RETAINED
+    kept_session = ChatSessionManager.create(
+        persona_id=0,
+        description="Old session the user chose to keep",
+        user_performing_action=admin_user,
+    )
+    kept_response = ChatSessionManager.send_message(
+        chat_session_id=kept_session.id,
+        message="This session is kept",
+        user_performing_action=admin_user,
+    )
+    assert kept_response.error is None, (
+        f"Chat response should not have an error: {kept_response.error}"
+    )
+    _backdate_session(kept_session.id, created_days_ago=60, last_message_days_ago=60)
+    assert ChatSessionManager.set_retention_exempt(
+        chat_session=kept_session,
+        retention_exempt=True,
+        user_performing_action=admin_user,
+    ), "Failed to mark chat session as retention-exempt"
+
+    # Old + inactive, not kept -> should be DELETED
+    stale_session = ChatSessionManager.create(
+        persona_id=0,
+        description="Old session, not kept",
+        user_performing_action=admin_user,
+    )
+    stale_response = ChatSessionManager.send_message(
+        chat_session_id=stale_session.id,
+        message="This session is not kept",
+        user_performing_action=admin_user,
+    )
+    assert stale_response.error is None, (
+        f"Chat response should not have an error: {stale_response.error}"
+    )
+    _backdate_session(stale_session.id, created_days_ago=60, last_message_days_ago=60)
+
+    _run_ttl_cleanup(retention_days)
+
+    assert not _is_session_deleted(kept_session, admin_user), (
+        "A retention-exempt (Keep Chat) session should never be auto-deleted"
+    )
+    assert _is_session_deleted(stale_session, admin_user), (
+        "A non-exempt stale session should be deleted"
+    )
+
+
+@pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="Chat retention tests are enterprise only",
+)
 def test_chat_retention_uses_last_message_time(
     reset: None,  # noqa: ARG001
     admin_user: DATestUser,

--- a/web/lib/opal/src/icons/archive.tsx
+++ b/web/lib/opal/src/icons/archive.tsx
@@ -1,0 +1,36 @@
+import type { IconProps } from "@opal/types";
+const SvgArchive = ({ size, ...props }: IconProps) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 16 16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    stroke="currentColor"
+    {...props}
+  >
+    <rect
+      x="2"
+      y="2.5"
+      width="12"
+      height="3.5"
+      rx="0.75"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M3 6V13.5H13V6"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M6.5 9H9.5"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+export default SvgArchive;

--- a/web/lib/opal/src/icons/index.ts
+++ b/web/lib/opal/src/icons/index.ts
@@ -10,6 +10,7 @@ export { default as SvgActivitySmall } from "@opal/icons/activity-small";
 export { default as SvgAddLines } from "@opal/icons/add-lines";
 export { default as SvgAlertCircle } from "@opal/icons/alert-circle";
 export { default as SvgAlertTriangle } from "@opal/icons/alert-triangle";
+export { default as SvgArchive } from "@opal/icons/archive";
 export { default as SvgArrowDownDot } from "@opal/icons/arrow-down-dot";
 export { default as SvgArrowExchange } from "@opal/icons/arrow-exchange";
 export { default as SvgArrowLeft } from "@opal/icons/arrow-left";

--- a/web/src/app/app/interfaces.ts
+++ b/web/src/app/app/interfaces.ts
@@ -142,6 +142,7 @@ export interface ChatSession {
   project_id: number | null;
   current_alternate_model: string;
   current_temperature_override: number | null;
+  retention_exempt: boolean;
 }
 
 export interface SearchSession {
@@ -204,6 +205,7 @@ export interface BackendChatSession {
   shared_status: ChatSessionSharedStatus;
   current_temperature_override: number | null;
   current_alternate_model?: string;
+  retention_exempt: boolean;
 
   owner_name: string | null;
   packets: Packet[][];
@@ -222,6 +224,7 @@ export function toChatSession(backend: BackendChatSession): ChatSession {
     project_id: null,
     current_alternate_model: backend.current_alternate_model ?? "",
     current_temperature_override: backend.current_temperature_override,
+    retention_exempt: backend.retention_exempt,
   };
 }
 

--- a/web/src/app/app/services/lib.tsx
+++ b/web/src/app/app/services/lib.tsx
@@ -329,6 +329,22 @@ export async function renameChatSession(
   return response;
 }
 
+export async function setChatSessionRetentionExempt(
+  chatSessionId: string,
+  retentionExempt: boolean
+) {
+  const response = await fetch(`/api/chat/chat-session/${chatSessionId}`, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      retention_exempt: retentionExempt,
+    }),
+  });
+  return response;
+}
+
 export async function deleteChatSession(chatSessionId: string) {
   const response = await fetch(
     `/api/chat/delete-chat-session/${chatSessionId}`,

--- a/web/src/hooks/useChatSessions.ts
+++ b/web/src/hooks/useChatSessions.ts
@@ -270,6 +270,7 @@ export default function useChatSessions(): UseChatSessionsOutput {
         project_id: projectId ?? null,
         current_alternate_model: "",
         current_temperature_override: null,
+        retention_exempt: false,
       });
     },
     []

--- a/web/src/layouts/chromes/AppChrome.tsx
+++ b/web/src/layouts/chromes/AppChrome.tsx
@@ -24,7 +24,10 @@ import {
 } from "@/lib/sidebar/utils";
 import { handleMoveOperation } from "@/lib/sidebar/svc";
 import { LOCAL_STORAGE_KEYS } from "@/lib/sidebar/constants";
-import { deleteChatSession } from "@/app/app/services/lib";
+import {
+  deleteChatSession,
+  setChatSessionRetentionExempt,
+} from "@/app/app/services/lib";
 import {
   exportChatSession,
   ChatExportFormat,
@@ -47,6 +50,7 @@ import SimplePopover from "@/refresh-components/SimplePopover";
 import { useSidebarState } from "@opal/layouts";
 import useScreenSize from "@/hooks/useScreenSize";
 import {
+  SvgArchive,
   SvgBubbleText,
   SvgChevronLeft,
   SvgDownload,
@@ -77,6 +81,7 @@ import { useFullWidthChat } from "@/providers/FullWidthChatProvider";
 function Header() {
   const appFocus = useAppFocus();
   const businessTier = useTierAtLeast(Tier.BUSINESS);
+  const enterpriseTier = useTierAtLeast(Tier.ENTERPRISE);
   const { state, setAppMode } = useQueryController();
   const isSearchModeAvailable = useIsSearchModeAvailable();
   const settings = useSettings();
@@ -221,6 +226,31 @@ function Header() {
     [currentChatSession]
   );
 
+  const handleToggleKeepChat = useCallback(async () => {
+    if (!currentChatSession) return;
+    const nextValue = !currentChatSession.retention_exempt;
+    try {
+      const response = await setChatSessionRetentionExempt(
+        currentChatSession.id,
+        nextValue
+      );
+      if (!response.ok) {
+        throw new Error("Failed to update chat retention setting");
+      }
+      await refreshChatSessions();
+      setPopoverOpen(false);
+    } catch (error) {
+      console.error("Failed to update keep-chat setting:", error);
+      showErrorNotification("Failed to update chat. Please try again.");
+    }
+  }, [currentChatSession, refreshChatSessions]);
+
+  // "Keep Chat" only makes sense when the org enforces a finite retention
+  // policy (a value, not "forever"), and it is an Enterprise-only feature.
+  const retentionDays = settings.maximum_chat_retention_days;
+  const canKeepChat =
+    enterpriseTier && retentionDays != null && retentionDays > 0;
+
   useEffect(() => {
     let items: ReactNode[];
     if (showMoveOptions) {
@@ -288,6 +318,20 @@ function Header() {
           title="Export As…"
           onClick={noProp(() => setShowExportOptions(true))}
         />,
+        canKeepChat && (
+          <LineItemButton
+            key="keep-chat"
+            sizePreset="main-ui"
+            rounding="sm"
+            icon={SvgArchive}
+            title="Keep Chat"
+            description="Exempt from Auto-Deletion"
+            state={
+              currentChatSession?.retention_exempt ? "selected" : undefined
+            }
+            onClick={noProp(handleToggleKeepChat)}
+          />
+        ),
         null,
         <LineItemButton
           key="delete"
@@ -307,6 +351,8 @@ function Header() {
     showExportOptions,
     filteredProjects,
     currentChatSession,
+    canKeepChat,
+    handleToggleKeepChat,
     setDeleteConfirmationModalOpen,
     handleMoveClick,
     handleExport,

--- a/web/src/lib/chat/exportChatSession.test.ts
+++ b/web/src/lib/chat/exportChatSession.test.ts
@@ -59,6 +59,7 @@ function makeSession(messages: BackendMessage[]): BackendChatSession {
     time_updated: "2026-01-01T00:00:00Z",
     shared_status: ChatSessionSharedStatus.Private,
     current_temperature_override: null,
+    retention_exempt: false,
     owner_name: null,
     packets: [],
   };


### PR DESCRIPTION
## What

Lets users mark an individual chat as **exempt from the org's chat retention policy** so it is never auto-deleted, via a new **Keep Chat** item in the in-chat "…" (dots) menu.

This is an Enterprise feature and the option only appears when the org actually has a finite retention policy set (i.e. not "forever").

![menu design](https://www.figma.com/design/BV9tfqwS0GjTIJP7ki6Qux/Search---Chat---Tools?node-id=2204-4068)

> Design: `Keep Chat` / `Exempt from Auto-Deletion`, gated to Enterprise + a non-"forever" retention policy.

## How

**Backend**
- New `retention_exempt` boolean on `ChatSession` (default `false`) + Alembic migration `da41c7ca5933`.
- `get_chat_sessions_older_than` — the single query the EE retention/TTL task uses to pick sessions to hard-delete — now excludes `retention_exempt` sessions, so a kept chat is never returned and never deleted.
- Flag plumbed through `update_chat_session`, the `PATCH /chat/chat-session/{id}` endpoint (`ChatSessionUpdateRequest.retention_exempt`), and surfaced on `ChatSessionDetails` (list) + `ChatSessionDetailResponse` (single) so the frontend can read/toggle it. Setting the flag is available to any authenticated owner; it is simply inert without the EE TTL job.

**Frontend**
- `Keep Chat` / `Exempt from Auto-Deletion` `LineItemButton` added to the in-chat dots menu in `AppChrome.tsx`, shown only when `useTierAtLeast(Tier.ENTERPRISE)` **and** `settings.maximum_chat_retention_days` is a finite value. Toggling calls the PATCH endpoint and revalidates the session list; the item shows a selected state while active.
- New `SvgArchive` icon (Opal, 16×16 stroke style) to match the design.
- `retention_exempt` added to the `ChatSession` / `BackendChatSession` types and all construction sites.

## Testing
- **Added** integration test `test_chat_retention_respects_keep_chat`: an old, inactive session marked `retention_exempt` survives TTL cleanup while an equally-old non-exempt session is deleted.
- **Verified live** against the dev DB that `get_chat_sessions_older_than` excludes exempt sessions and includes non-exempt ones.
- Migration applied cleanly (`alembic upgrade head`); backend `ruff`/`ty` and frontend `tsgo` type check + `oxlint` pass for all changed files.
- Not yet manually driven in the browser end-to-end (requires an EE license + an org retention policy configured).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-chat “Keep Chat” option that exempts selected chats from the org’s retention policy so they are never auto-deleted by the TTL job. Enterprise-only and shown only when a finite retention policy is configured.

- **New Features**
  - Backend: `retention_exempt` boolean on `ChatSession` (default false) with migration; TTL selection query excludes exempt sessions.
  - API: `PATCH /chat/chat-session/{id}` accepts `retention_exempt`; flag returned in session list/detail responses.
  - Frontend: “Keep Chat” in the in-chat … menu with `SvgArchive`; gated to Enterprise tier and finite `settings.maximum_chat_retention_days`; toggle updates and refreshes.
  - Tests: Integration test confirms exempt sessions survive TTL cleanup while equally old non-exempt sessions are deleted.

<sup>Written for commit ac0ca765b2713d5c42ece0f35dfc591b6847338e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

