### PR TITLE
fix: scope Drive domain shares to a domain group instead of instance-public

### DIFF
--- a/backend/ee/onyx/access/access.py
+++ b/backend/ee/onyx/access/access.py
@@ -11,11 +11,8 @@ from onyx.access.access import (
 from onyx.access.access import _get_acl_for_user as get_acl_for_user_without_groups
 from onyx.access.access import collect_user_file_access
 from onyx.access.models import DocumentAccess
-from onyx.access.utils import build_domain_group_id
-from onyx.access.utils import build_ext_group_name_for_onyx
 from onyx.access.utils import prefix_external_group
 from onyx.access.utils import prefix_user_group
-from onyx.configs.constants import DocumentSource
 from onyx.db.document import get_document_sources
 from onyx.db.document import get_documents_by_ids
 from onyx.db.models import User
@@ -210,18 +207,7 @@ def _get_acl_for_user(user: User, db_session: Session) -> set[str]:
     user_acl = set(prefixed_user_groups + prefixed_external_groups)
     user_acl.update(get_acl_for_user_without_groups(user, db_session))
 
-    # Drive "everyone at <domain>" shares are stored as derived domain groups
-    # (domain:<domain>); membership is the user's own email domain, so no
-    # directory lookup or membership rows are involved.
-    if not is_anonymous and user.email and "@" in user.email:
-        email_domain = user.email.rsplit("@", 1)[-1].strip().lower()
-        if email_domain:
-            user_acl.add(
-                prefix_external_group(
-                    build_ext_group_name_for_onyx(
-                        build_domain_group_id(email_domain), DocumentSource.GOOGLE_DRIVE
-                    )
-                )
-            )
-
+    # Drive "everyone at <domain>" shares resolve through the synced domain group
+    # in prefixed_external_groups above (real Workspace membership), not from the
+    # user's email string.
     return user_acl

--- a/backend/ee/onyx/access/access.py
+++ b/backend/ee/onyx/access/access.py
@@ -207,7 +207,4 @@ def _get_acl_for_user(user: User, db_session: Session) -> set[str]:
     user_acl = set(prefixed_user_groups + prefixed_external_groups)
     user_acl.update(get_acl_for_user_without_groups(user, db_session))
 
-    # Drive "everyone at <domain>" shares resolve through the synced domain group
-    # in prefixed_external_groups above (real Workspace membership), not from the
-    # user's email string.
     return user_acl

--- a/backend/ee/onyx/access/access.py
+++ b/backend/ee/onyx/access/access.py
@@ -11,8 +11,11 @@ from onyx.access.access import (
 from onyx.access.access import _get_acl_for_user as get_acl_for_user_without_groups
 from onyx.access.access import collect_user_file_access
 from onyx.access.models import DocumentAccess
+from onyx.access.utils import build_domain_group_id
+from onyx.access.utils import build_ext_group_name_for_onyx
 from onyx.access.utils import prefix_external_group
 from onyx.access.utils import prefix_user_group
+from onyx.configs.constants import DocumentSource
 from onyx.db.document import get_document_sources
 from onyx.db.document import get_documents_by_ids
 from onyx.db.models import User
@@ -206,5 +209,19 @@ def _get_acl_for_user(user: User, db_session: Session) -> set[str]:
 
     user_acl = set(prefixed_user_groups + prefixed_external_groups)
     user_acl.update(get_acl_for_user_without_groups(user, db_session))
+
+    # Drive "everyone at <domain>" shares are stored as derived domain groups
+    # (domain:<domain>); membership is the user's own email domain, so no
+    # directory lookup or membership rows are involved.
+    if not is_anonymous and user.email and "@" in user.email:
+        email_domain = user.email.rsplit("@", 1)[-1].strip().lower()
+        if email_domain:
+            user_acl.add(
+                prefix_external_group(
+                    build_ext_group_name_for_onyx(
+                        build_domain_group_id(email_domain), DocumentSource.GOOGLE_DRIVE
+                    )
+                )
+            )
 
     return user_acl

--- a/backend/ee/onyx/external_permissions/google_drive/doc_sync.py
+++ b/backend/ee/onyx/external_permissions/google_drive/doc_sync.py
@@ -28,6 +28,34 @@ from onyx.utils.logger import setup_logger
 logger = setup_logger()
 
 
+def _domain_group_for_permission(
+    permission: GoogleDrivePermission,
+    own_domain: str | None,
+    entity_desc: str,
+) -> str | None:
+    """Map an "everyone at <domain>" permission to its derived domain group, or
+    None when the share grants searchable access to no one. Link-only shares
+    (allow_file_discovery=False) grant nothing: Google exposes them only to
+    domain users who already hold the link, not to domain-wide search. The
+    matching user-side token is derived from the user's own email domain in ee
+    _get_acl_for_user."""
+    if not permission.domain:
+        logger.warning(
+            "Domain permission without a domain for %s\n %s", entity_desc, permission
+        )
+        return None
+    if permission.domain != own_domain:
+        # Cross-workspace share (e.g. shared to a partner company's whole domain).
+        logger.debug(
+            "Domain permission for %s scoped to external domain %s",
+            entity_desc,
+            permission.domain,
+        )
+    if permission.allow_file_discovery is False:
+        return None
+    return build_domain_group_id(permission.domain)
+
+
 def _get_slim_doc_generator(
     cc_pair: ConnectorCredentialPair,
     google_drive_connector: GoogleDriveConnector,
@@ -190,29 +218,11 @@ def get_external_access_for_raw_gdrive_file(
                     permission,
                 )
         elif permission.type == PermissionType.DOMAIN:
-            # "Everyone at <domain>" grants a derived domain group scoped to that
-            # domain's users, never instance-public. The matching user-side token
-            # is derived from the user's own email domain in ee _get_acl_for_user.
-            # Link-only shares (allowFileDiscovery=False) grant nothing: Google
-            # exposes them only to domain users who already hold the link, not
-            # to domain-wide search.
-            if permission.domain:
-                if permission.allow_file_discovery is not False:
-                    domain_groups.add(build_domain_group_id(permission.domain))
-                if permission.domain != company_domain:
-                    # Cross-workspace domain share (e.g. a doc shared to a
-                    # partner company's whole domain).
-                    logger.debug(
-                        "Domain permission for %s scoped to external domain %s",
-                        doc_id,
-                        permission.domain,
-                    )
-            else:
-                logger.warning(
-                    "Permission is type `domain` but no domain is provided for document %s\n %s",
-                    doc_id,
-                    permission,
-                )
+            domain_group = _domain_group_for_permission(
+                permission, company_domain, f"document {doc_id}"
+            )
+            if domain_group:
+                domain_groups.add(domain_group)
         elif permission.type == PermissionType.ANYONE:
             public = True
 
@@ -305,25 +315,11 @@ def get_external_access_for_folder(
                     "Group permission without email for folder %s", folder_id
                 )
         elif permission.type == PermissionType.DOMAIN:
-            # "Everyone at <domain>" grants a derived domain group scoped to that
-            # domain's users, never instance-public. The matching user-side token
-            # is derived from the user's own email domain in ee _get_acl_for_user.
-            # Link-only shares (allowFileDiscovery=False) grant nothing: Google
-            # exposes them only to domain users who already hold the link, not
-            # to domain-wide search.
-            if permission.domain:
-                if permission.allow_file_discovery is not False:
-                    domain_groups.add(build_domain_group_id(permission.domain))
-                if permission.domain != google_domain:
-                    logger.debug(
-                        "Domain permission scoped to external domain %s for folder %s",
-                        permission.domain,
-                        folder_id,
-                    )
-            else:
-                logger.warning(
-                    "Domain permission without domain for folder %s", folder_id
-                )
+            domain_group = _domain_group_for_permission(
+                permission, google_domain, f"folder {folder_id}"
+            )
+            if domain_group:
+                domain_groups.add(domain_group)
         elif permission.type == PermissionType.ANYONE:
             # Only public if discoverable (allowFileDiscovery is not False)
             # If allowFileDiscovery is False, it's "link only" access

--- a/backend/ee/onyx/external_permissions/google_drive/doc_sync.py
+++ b/backend/ee/onyx/external_permissions/google_drive/doc_sync.py
@@ -37,8 +37,8 @@ def _domain_group_for_permission(
     None when the share grants searchable access to no one. Link-only shares
     (allow_file_discovery=False) grant nothing: Google exposes them only to
     domain users who already hold the link, not to domain-wide search. The
-    matching user-side token is derived from the user's own email domain in ee
-    _get_acl_for_user."""
+    matching user-side token is derived from the user's own email domain at
+    query time."""
     if not permission.domain:
         logger.warning(
             "Domain permission without a domain for %s\n %s", entity_desc, permission

--- a/backend/ee/onyx/external_permissions/google_drive/doc_sync.py
+++ b/backend/ee/onyx/external_permissions/google_drive/doc_sync.py
@@ -193,8 +193,12 @@ def get_external_access_for_raw_gdrive_file(
             # "Everyone at <domain>" grants a derived domain group scoped to that
             # domain's users, never instance-public. The matching user-side token
             # is derived from the user's own email domain in ee _get_acl_for_user.
+            # Link-only shares (allowFileDiscovery=False) grant nothing: Google
+            # exposes them only to domain users who already hold the link, not
+            # to domain-wide search.
             if permission.domain:
-                domain_groups.add(build_domain_group_id(permission.domain))
+                if permission.allow_file_discovery is not False:
+                    domain_groups.add(build_domain_group_id(permission.domain))
                 if permission.domain != company_domain:
                     # Cross-workspace domain share (e.g. a doc shared to a
                     # partner company's whole domain).
@@ -304,8 +308,12 @@ def get_external_access_for_folder(
             # "Everyone at <domain>" grants a derived domain group scoped to that
             # domain's users, never instance-public. The matching user-side token
             # is derived from the user's own email domain in ee _get_acl_for_user.
+            # Link-only shares (allowFileDiscovery=False) grant nothing: Google
+            # exposes them only to domain users who already hold the link, not
+            # to domain-wide search.
             if permission.domain:
-                domain_groups.add(build_domain_group_id(permission.domain))
+                if permission.allow_file_discovery is not False:
+                    domain_groups.add(build_domain_group_id(permission.domain))
                 if permission.domain != google_domain:
                     logger.debug(
                         "Domain permission scoped to external domain %s for folder %s",

--- a/backend/ee/onyx/external_permissions/google_drive/doc_sync.py
+++ b/backend/ee/onyx/external_permissions/google_drive/doc_sync.py
@@ -33,12 +33,12 @@ def _domain_group_for_permission(
     own_domain: str | None,
     entity_desc: str,
 ) -> str | None:
-    """Map an "everyone at <domain>" permission to its derived domain group, or
-    None when the share grants searchable access to no one. Link-only shares
+    """Map an "everyone at <domain>" permission to its domain group, or None when
+    the share grants searchable access to no one. Link-only shares
     (allow_file_discovery=False) grant nothing: Google exposes them only to
-    domain users who already hold the link, not to domain-wide search. The
-    matching user-side token is derived from the user's own email domain at
-    query time."""
+    domain users who already hold the link, not to domain-wide search. The Drive
+    group sync populates the domain group with that domain's real Workspace
+    members."""
     if not permission.domain:
         logger.warning(
             "Domain permission without a domain for %s\n %s", entity_desc, permission

--- a/backend/ee/onyx/external_permissions/google_drive/doc_sync.py
+++ b/backend/ee/onyx/external_permissions/google_drive/doc_sync.py
@@ -13,6 +13,7 @@ from onyx.access.models import DocExternalAccess
 from onyx.access.models import ElementExternalAccess
 from onyx.access.models import ExternalAccess
 from onyx.access.models import NodeExternalAccess
+from onyx.access.utils import build_domain_group_id
 from onyx.access.utils import build_ext_group_name_for_onyx
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.google_drive.connector import GoogleDriveConnector
@@ -148,6 +149,7 @@ def get_external_access_for_raw_gdrive_file(
     folder_ids_to_inherit_permissions_from: set[str] = set()
     user_emails: set[str] = set()
     group_emails: set[str] = set()
+    domain_groups: set[str] = set()
     public = False
 
     for permission in permissions_list:
@@ -187,12 +189,24 @@ def get_external_access_for_raw_gdrive_file(
                     doc_id,
                     permission,
                 )
-        elif permission.type == PermissionType.DOMAIN and company_domain:
-            if permission.domain == company_domain:
-                public = True
+        elif permission.type == PermissionType.DOMAIN:
+            # "Everyone at <domain>" grants a derived domain group scoped to that
+            # domain's users, never instance-public. The matching user-side token
+            # is derived from the user's own email domain in ee _get_acl_for_user.
+            if permission.domain:
+                domain_groups.add(build_domain_group_id(permission.domain))
+                if permission.domain != company_domain:
+                    # Cross-workspace domain share (e.g. a doc shared to a
+                    # partner company's whole domain).
+                    logger.debug(
+                        "Domain permission for %s scoped to external domain %s",
+                        doc_id,
+                        permission.domain,
+                    )
             else:
                 logger.warning(
-                    "Permission is type domain but does not match company domain:\n %s",
+                    "Permission is type `domain` but no domain is provided for document %s\n %s",
+                    doc_id,
                     permission,
                 )
         elif permission.type == PermissionType.ANYONE:
@@ -200,6 +214,7 @@ def get_external_access_for_raw_gdrive_file(
 
     group_ids = (
         group_emails
+        | domain_groups
         | folder_ids_to_inherit_permissions_from
         | ({drive_id} if drive_id is not None else set())
     )
@@ -268,6 +283,7 @@ def get_external_access_for_folder(
 
     user_emails: set[str] = set()
     group_emails: set[str] = set()
+    domain_groups: set[str] = set()
     is_public = False
 
     for permission in permissions_list:
@@ -285,18 +301,20 @@ def get_external_access_for_folder(
                     "Group permission without email for folder %s", folder_id
                 )
         elif permission.type == PermissionType.DOMAIN:
-            # Domain permission - check if it matches company domain
-            if permission.domain == google_domain:
-                # Only public if discoverable (allowFileDiscovery is not False)
-                # If allowFileDiscovery is False, it's "link only" access
-                is_public = permission.allow_file_discovery is not False
+            # "Everyone at <domain>" grants a derived domain group scoped to that
+            # domain's users, never instance-public. The matching user-side token
+            # is derived from the user's own email domain in ee _get_acl_for_user.
+            if permission.domain:
+                domain_groups.add(build_domain_group_id(permission.domain))
+                if permission.domain != google_domain:
+                    logger.debug(
+                        "Domain permission scoped to external domain %s for folder %s",
+                        permission.domain,
+                        folder_id,
+                    )
             else:
-                logger.debug(
-                    "Domain permission for %s does not match "
-                    "company domain %s for folder %s",
-                    permission.domain,
-                    google_domain,
-                    folder_id,
+                logger.warning(
+                    "Domain permission without domain for folder %s", folder_id
                 )
         elif permission.type == PermissionType.ANYONE:
             # Only public if discoverable (allowFileDiscovery is not False)
@@ -304,11 +322,11 @@ def get_external_access_for_folder(
             is_public = permission.allow_file_discovery is not False
 
     # Prefix group IDs with source type if requested (for indexing path)
-    group_ids: set[str] = group_emails
+    group_ids: set[str] = group_emails | domain_groups
     if add_prefix:
         group_ids = {
             build_ext_group_name_for_onyx(group_id, DocumentSource.GOOGLE_DRIVE)
-            for group_id in group_emails
+            for group_id in group_ids
         }
 
     return ExternalAccess(

--- a/backend/ee/onyx/external_permissions/google_drive/doc_sync.py
+++ b/backend/ee/onyx/external_permissions/google_drive/doc_sync.py
@@ -44,6 +44,8 @@ def _domain_group_for_permission(
             "Domain permission without a domain for %s\n %s", entity_desc, permission
         )
         return None
+    if permission.allow_file_discovery is False:
+        return None
     if permission.domain != own_domain:
         # Cross-workspace share (e.g. shared to a partner company's whole domain).
         logger.debug(
@@ -51,8 +53,6 @@ def _domain_group_for_permission(
             entity_desc,
             permission.domain,
         )
-    if permission.allow_file_discovery is False:
-        return None
     return build_domain_group_id(permission.domain)
 
 

--- a/backend/ee/onyx/external_permissions/google_drive/group_sync.py
+++ b/backend/ee/onyx/external_permissions/google_drive/group_sync.py
@@ -12,6 +12,7 @@ from ee.onyx.external_permissions.google_drive.folder_retrieval import (
 )
 from ee.onyx.external_permissions.google_drive.models import GoogleDrivePermission
 from ee.onyx.external_permissions.google_drive.models import PermissionType
+from onyx.access.utils import build_domain_group_id
 from onyx.connectors.google_drive.connector import GoogleDriveConnector
 from onyx.connectors.google_utils.google_utils import execute_paginated_retrieval
 from onyx.connectors.google_utils.resources import AdminService
@@ -279,6 +280,26 @@ def _drive_member_map_to_onyx_groups(
         )
 
 
+def _get_all_domain_users(
+    admin_service: AdminService,
+    google_domain: str,
+) -> list[str]:
+    """Every user Google lists in the Workspace domain. This is the real
+    membership behind an "everyone at <domain>" Drive share, so a user is only in
+    the domain group if Google actually places them in the Workspace, not because
+    their email string ends in the domain."""
+    user_emails: set[str] = set()
+    for user in execute_paginated_retrieval(
+        admin_service.users().list,  # ty: ignore[unresolved-attribute]
+        list_key="users",
+        domain=google_domain,
+        fields="users(primaryEmail),nextPageToken",
+    ):
+        if email := user.get("primaryEmail"):
+            user_emails.add(email)
+    return list(user_emails)
+
+
 def _get_all_google_groups(
     admin_service: AdminService,
     google_domain: str,
@@ -463,3 +484,15 @@ def gdrive_group_sync(
     )
     for folder in folder_info:
         yield _drive_folder_to_onyx_group(folder, group_email_to_member_emails_map)
+
+    # "Everyone at <domain>" Drive shares resolve to this group. Only this
+    # connector's own domain is enumerable here; a share to a partner domain is
+    # populated by that domain's own connector sync.
+    domain_users = _get_all_domain_users(
+        admin_service, google_drive_connector.google_domain
+    )
+    if domain_users:
+        yield ExternalUserGroup(
+            id=build_domain_group_id(google_drive_connector.google_domain),
+            user_emails=domain_users,
+        )

--- a/backend/onyx/access/utils.py
+++ b/backend/onyx/access/utils.py
@@ -25,3 +25,10 @@ def build_ext_group_name_for_onyx(ext_group_name: str, source: DocumentSource) -
     NOTE: the name is lowercased to handle case sensitivity for group names
     """
     return f"{source.value}_{ext_group_name}".lower()
+
+
+def build_domain_group_id(domain: str) -> str:
+    """Derived pseudo-group for "everyone at <domain>" shares. It has no
+    membership rows: the doc side stores this id and the user side derives the
+    matching token from the user's own email domain."""
+    return f"domain:{domain.lower()}"

--- a/backend/onyx/access/utils.py
+++ b/backend/onyx/access/utils.py
@@ -28,7 +28,7 @@ def build_ext_group_name_for_onyx(ext_group_name: str, source: DocumentSource) -
 
 
 def build_domain_group_id(domain: str) -> str:
-    """Derived pseudo-group for "everyone at <domain>" shares. It has no
-    membership rows: the doc side stores this id and the user side derives the
-    matching token from the user's own email domain."""
+    """Group id for "everyone at <domain>" Drive shares. The Drive group sync
+    populates it with the real Workspace roster for the domain, so membership is
+    Google's own rather than inferred from a user's email string."""
     return f"domain:{domain.lower()}"

--- a/backend/tests/unit/ee/onyx/external_permissions/google_drive/test_gdrive_domain_permission_scoping.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/google_drive/test_gdrive_domain_permission_scoping.py
@@ -1,7 +1,7 @@
-"""Drive "everyone at <domain>" shares must map to a derived domain group
+"""Drive "everyone at <domain>" shares must map to a domain group
 (domain:<domain>), never to instance-public, on both the file and folder
-permission paths, and the user-side ACL must carry the matching token derived
-from the user's own email domain."""
+permission paths. The user-side token comes from the synced domain group's real
+Workspace membership, not from the user's email string."""
 
 from types import SimpleNamespace
 from typing import Any
@@ -165,7 +165,35 @@ def test_folder_anyone_link_only_stays_non_public() -> None:
     assert access.is_public is False
 
 
-def test_user_acl_carries_own_domain_token() -> None:
+def test_user_acl_carries_synced_domain_group() -> None:
+    from ee.onyx.access.access import _get_acl_for_user
+
+    user = cast(
+        User, SimpleNamespace(id="u1", email="Alice@CompanyA.com", is_anonymous=False)
+    )
+    domain_group = build_ext_group_name_for_onyx(
+        f"domain:{COMPANY_DOMAIN}", DocumentSource.GOOGLE_DRIVE
+    )
+    with (
+        patch("ee.onyx.access.access.fetch_user_groups_for_user", return_value=[]),
+        patch(
+            "ee.onyx.access.access.fetch_external_groups_for_user",
+            return_value=[SimpleNamespace(external_user_group_id=domain_group)],
+        ),
+        patch(
+            "ee.onyx.access.access.get_acl_for_user_without_groups",
+            return_value=set(),
+        ),
+    ):
+        acl = _get_acl_for_user(user, db_session=cast(Session, None))
+
+    assert prefix_external_group(domain_group) in acl
+
+
+def test_user_acl_has_no_domain_token_without_synced_membership() -> None:
+    # A user's email domain alone must not grant the domain group. Membership
+    # comes only from the synced group, so a user Google never placed in the
+    # Workspace gets nothing even if their email string matches.
     from ee.onyx.access.access import _get_acl_for_user
 
     user = cast(
@@ -181,12 +209,7 @@ def test_user_acl_carries_own_domain_token() -> None:
     ):
         acl = _get_acl_for_user(user, db_session=cast(Session, None))
 
-    expected = prefix_external_group(
-        build_ext_group_name_for_onyx(
-            f"domain:{COMPANY_DOMAIN}", DocumentSource.GOOGLE_DRIVE
-        )
-    )
-    assert expected in acl
+    assert not any(entry.startswith("external_group:") for entry in acl)
 
 
 def test_anonymous_user_gets_no_domain_token() -> None:
@@ -200,3 +223,22 @@ def test_anonymous_user_gets_no_domain_token() -> None:
         acl = _get_acl_for_user(user, db_session=cast(Session, None))
 
     assert not any(entry.startswith("external_group:") for entry in acl)
+
+
+def test_group_sync_domain_group_uses_real_roster() -> None:
+    from ee.onyx.external_permissions.google_drive import group_sync
+
+    roster = [
+        {"primaryEmail": "alice@companya.com"},
+        {"primaryEmail": "bob@companya.com"},
+        {},  # rows Google returns without a primaryEmail are skipped
+    ]
+    admin_service = cast(
+        Any, SimpleNamespace(users=lambda: SimpleNamespace(list=object()))
+    )
+    with patch.object(
+        group_sync, "execute_paginated_retrieval", return_value=iter(roster)
+    ):
+        members = group_sync._get_all_domain_users(admin_service, COMPANY_DOMAIN)
+
+    assert set(members) == {"alice@companya.com", "bob@companya.com"}

--- a/backend/tests/unit/ee/onyx/external_permissions/google_drive/test_gdrive_domain_permission_scoping.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/google_drive/test_gdrive_domain_permission_scoping.py
@@ -72,6 +72,13 @@ def test_domain_is_lowercased() -> None:
     assert f"domain:{COMPANY_DOMAIN}" in access.external_user_group_ids
 
 
+def test_link_only_domain_share_grants_nothing() -> None:
+    perm = {**_domain_permission(COMPANY_DOMAIN), "allowFileDiscovery": False}
+    access = _file_access([perm])
+    assert access.is_public is False
+    assert not access.external_user_group_ids
+
+
 def test_domain_permission_without_domain_grants_nothing() -> None:
     access = _file_access([{"id": "p1", "type": "domain"}])
     assert access.is_public is False
@@ -137,12 +144,12 @@ def test_folder_domain_share_is_domain_group_not_public() -> None:
     assert f"domain:{COMPANY_DOMAIN}" in access.external_user_group_ids
 
 
-def test_folder_link_only_domain_share_still_grants_domain_group() -> None:
+def test_folder_link_only_domain_share_grants_nothing() -> None:
     access = _folder_access(
         [_folder_domain_permission(COMPANY_DOMAIN, allow_file_discovery=False)]
     )
     assert access.is_public is False
-    assert f"domain:{COMPANY_DOMAIN}" in access.external_user_group_ids
+    assert not access.external_user_group_ids
 
 
 def test_folder_anyone_link_only_stays_non_public() -> None:

--- a/backend/tests/unit/ee/onyx/external_permissions/google_drive/test_gdrive_domain_permission_scoping.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/google_drive/test_gdrive_domain_permission_scoping.py
@@ -1,0 +1,195 @@
+"""Drive "everyone at <domain>" shares must map to a derived domain group
+(domain:<domain>), never to instance-public, on both the file and folder
+permission paths, and the user-side ACL must carry the matching token derived
+from the user's own email domain."""
+
+from types import SimpleNamespace
+from typing import Any
+from typing import cast
+from unittest.mock import patch
+
+from sqlalchemy.orm import Session
+
+from ee.onyx.external_permissions.google_drive.doc_sync import (
+    get_external_access_for_folder,
+)
+from ee.onyx.external_permissions.google_drive.doc_sync import (
+    get_external_access_for_raw_gdrive_file,
+)
+from ee.onyx.external_permissions.google_drive.models import GoogleDrivePermission
+from ee.onyx.external_permissions.google_drive.models import PermissionType
+from onyx.access.models import ExternalAccess
+from onyx.access.utils import build_ext_group_name_for_onyx
+from onyx.access.utils import prefix_external_group
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.google_utils.resources import GoogleDriveService
+from onyx.db.models import User
+
+COMPANY_DOMAIN = "companya.com"
+OTHER_DOMAIN = "companyb.com"
+
+# Never used: the file path takes inline permissions and the folder path's
+# permission fetch is patched.
+_DRIVE_SERVICE = cast(GoogleDriveService, SimpleNamespace())
+
+
+def _raw_file(permissions: list[dict[str, Any]]) -> dict[str, Any]:
+    return {"id": "doc-1", "permissions": permissions}
+
+
+def _domain_permission(domain: str, perm_id: str = "perm-domain") -> dict[str, Any]:
+    return {"id": perm_id, "type": "domain", "domain": domain}
+
+
+def _file_access(
+    permissions: list[dict[str, Any]], add_prefix: bool = False
+) -> ExternalAccess:
+    return get_external_access_for_raw_gdrive_file(
+        file=_raw_file(permissions),
+        company_domain=COMPANY_DOMAIN,
+        retriever_drive_service=None,
+        admin_drive_service=_DRIVE_SERVICE,
+        fallback_user_email="admin@companya.com",
+        add_prefix=add_prefix,
+    )
+
+
+def test_own_domain_share_is_domain_group_not_public() -> None:
+    access = _file_access([_domain_permission(COMPANY_DOMAIN)])
+    assert access.is_public is False
+    assert f"domain:{COMPANY_DOMAIN}" in access.external_user_group_ids
+
+
+def test_cross_company_domain_share_scopes_to_that_domain() -> None:
+    access = _file_access([_domain_permission(OTHER_DOMAIN)])
+    assert access.is_public is False
+    assert f"domain:{OTHER_DOMAIN}" in access.external_user_group_ids
+    assert f"domain:{COMPANY_DOMAIN}" not in access.external_user_group_ids
+
+
+def test_domain_is_lowercased() -> None:
+    access = _file_access([_domain_permission("CompanyA.COM")])
+    assert f"domain:{COMPANY_DOMAIN}" in access.external_user_group_ids
+
+
+def test_domain_permission_without_domain_grants_nothing() -> None:
+    access = _file_access([{"id": "p1", "type": "domain"}])
+    assert access.is_public is False
+    assert not access.external_user_group_ids
+
+
+def test_anyone_share_stays_public() -> None:
+    access = _file_access([{"id": "p1", "type": "anyone"}])
+    assert access.is_public is True
+
+
+def test_user_and_group_shares_unchanged() -> None:
+    access = _file_access(
+        [
+            {"id": "p1", "type": "user", "emailAddress": "bob@companyb.com"},
+            {"id": "p2", "type": "group", "emailAddress": "eng@companya.com"},
+        ]
+    )
+    assert access.is_public is False
+    assert access.external_user_emails == {"bob@companyb.com"}
+    assert "eng@companya.com" in access.external_user_group_ids
+
+
+def test_indexing_path_prefixes_domain_group() -> None:
+    access = _file_access([_domain_permission(COMPANY_DOMAIN)], add_prefix=True)
+    expected = build_ext_group_name_for_onyx(
+        f"domain:{COMPANY_DOMAIN}", DocumentSource.GOOGLE_DRIVE
+    )
+    assert expected in access.external_user_group_ids
+
+
+def _folder_access(
+    permissions: list[GoogleDrivePermission], add_prefix: bool = False
+) -> ExternalAccess:
+    with patch(
+        "ee.onyx.external_permissions.google_drive.doc_sync.get_permissions_by_ids",
+        return_value=permissions,
+    ):
+        return get_external_access_for_folder(
+            folder={"id": "folder-1", "permissionIds": ["p1"]},
+            google_domain=COMPANY_DOMAIN,
+            drive_service=_DRIVE_SERVICE,
+            add_prefix=add_prefix,
+        )
+
+
+def _folder_domain_permission(
+    domain: str, allow_file_discovery: bool | None = True
+) -> GoogleDrivePermission:
+    return GoogleDrivePermission(
+        id="p1",
+        email_address=None,
+        type=PermissionType.DOMAIN,
+        domain=domain,
+        permission_details=None,
+        allow_file_discovery=allow_file_discovery,
+    )
+
+
+def test_folder_domain_share_is_domain_group_not_public() -> None:
+    access = _folder_access([_folder_domain_permission(COMPANY_DOMAIN)])
+    assert access.is_public is False
+    assert f"domain:{COMPANY_DOMAIN}" in access.external_user_group_ids
+
+
+def test_folder_link_only_domain_share_still_grants_domain_group() -> None:
+    access = _folder_access(
+        [_folder_domain_permission(COMPANY_DOMAIN, allow_file_discovery=False)]
+    )
+    assert access.is_public is False
+    assert f"domain:{COMPANY_DOMAIN}" in access.external_user_group_ids
+
+
+def test_folder_anyone_link_only_stays_non_public() -> None:
+    anyone = GoogleDrivePermission(
+        id="p1",
+        email_address=None,
+        type=PermissionType.ANYONE,
+        domain=None,
+        permission_details=None,
+        allow_file_discovery=False,
+    )
+    access = _folder_access([anyone])
+    assert access.is_public is False
+
+
+def test_user_acl_carries_own_domain_token() -> None:
+    from ee.onyx.access.access import _get_acl_for_user
+
+    user = cast(
+        User, SimpleNamespace(id="u1", email="Alice@CompanyA.com", is_anonymous=False)
+    )
+    with (
+        patch("ee.onyx.access.access.fetch_user_groups_for_user", return_value=[]),
+        patch("ee.onyx.access.access.fetch_external_groups_for_user", return_value=[]),
+        patch(
+            "ee.onyx.access.access.get_acl_for_user_without_groups",
+            return_value=set(),
+        ),
+    ):
+        acl = _get_acl_for_user(user, db_session=cast(Session, None))
+
+    expected = prefix_external_group(
+        build_ext_group_name_for_onyx(
+            f"domain:{COMPANY_DOMAIN}", DocumentSource.GOOGLE_DRIVE
+        )
+    )
+    assert expected in acl
+
+
+def test_anonymous_user_gets_no_domain_token() -> None:
+    from ee.onyx.access.access import _get_acl_for_user
+
+    user = cast(User, SimpleNamespace(id="u2", email="anon@x.com", is_anonymous=True))
+    with patch(
+        "ee.onyx.access.access.get_acl_for_user_without_groups",
+        return_value={"PUBLIC"},
+    ):
+        acl = _get_acl_for_user(user, db_session=cast(Session, None))
+
+    assert not any(entry.startswith("external_group:") for entry in acl)


### PR DESCRIPTION
## Description

Bug: a Drive doc shared to "everyone at \<domain\>" is stored as `is_public=True`, so every user on the instance sees it. On an instance serving more than one company, domain-internal docs leak across companies. A domain permission for any other domain granted nothing at all.

Fix:
- Map every Drive `domain` permission to a `domain:<domain>` group (`build_domain_group_id`), on both the file and folder paths. Domain shares are never instance-public.
- The Drive group sync populates that group with the domain's real Workspace roster (`admin.directory.users.list`). Membership is Google's own, not inferred from the user's email string, so a user gets the group only if Google actually places them in the Workspace. This is what makes it correct when two orgs share an email domain but live in different Workspaces.
- Cross-domain shares (a doc shared to a partner company's whole domain) grant that domain's group, populated by that domain's own connector sync (Change C connects both Workspaces).

Notes:
- "Anyone with the link" is unchanged (still public).
- The domain group is as fresh as the last group sync, not live, and it needs a service-account connector with directory access.
- Already-indexed docs keep their old permissions until a re-sync runs. After deploy, run a group sync then a permission re-sync.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
