### PR TITLE
feat: add sso_provider table and per-type config store (OIDC + SAML)

### DIFF
--- a/backend/alembic/versions/1fc2904131a3_add_sso_provider_table_and_seed_from_env.py
+++ b/backend/alembic/versions/1fc2904131a3_add_sso_provider_table_and_seed_from_env.py
@@ -80,7 +80,7 @@ def _seed_from_env(table: sa.Table) -> None:
     # the login `name` matches the oauth_name existing linked accounts carry so
     # linkage survives the routing cutover.
     if AUTH_TYPE == AuthType.GOOGLE_OAUTH:
-        provider_type, name = "GOOGLE", "google"
+        provider_type, name = "GOOGLE_OAUTH", "google"
         display_name, config_url = "Continue with Google", None
     elif AUTH_TYPE == AuthType.OIDC:
         if not OPENID_CONFIG_URL:

--- a/backend/alembic/versions/1fc2904131a3_add_sso_provider_table_and_seed_from_env.py
+++ b/backend/alembic/versions/1fc2904131a3_add_sso_provider_table_and_seed_from_env.py
@@ -1,7 +1,7 @@
 """add sso_provider table and seed from env
 
 Revision ID: 1fc2904131a3
-Revises: 2e0b2b146de1
+Revises: 20f09b642ed0
 Create Date: 2026-07-06 21:34:08.516250
 
 """
@@ -18,7 +18,7 @@ from onyx.utils.encryption import encrypt_string_to_bytes
 
 # revision identifiers, used by Alembic.
 revision = "1fc2904131a3"
-down_revision = "2e0b2b146de1"
+down_revision = "20f09b642ed0"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/1fc2904131a3_add_sso_provider_table_and_seed_from_env.py
+++ b/backend/alembic/versions/1fc2904131a3_add_sso_provider_table_and_seed_from_env.py
@@ -31,8 +31,8 @@ def _sso_provider_table(metadata: sa.MetaData) -> sa.Table:
         sa.Column("name", sa.String, nullable=False, unique=True),
         sa.Column("display_name", sa.String, nullable=False),
         sa.Column("provider_type", sa.String, nullable=False),
-        # Protocol-specific config, encrypted JSON (matches the EncryptedJson
-        # ORM column). Shape differs by provider_type; validated in the app.
+        # Protocol-specific config as encrypted JSON. Shape differs by
+        # provider_type and is validated in the app.
         sa.Column("config", sa.LargeBinary, nullable=False),
         sa.Column(
             "allowed_email_domains",
@@ -97,8 +97,7 @@ def _seed_from_env(table: sa.Table) -> None:
     if bind.execute(sa.select(table.c.id).limit(1)).first():
         return
 
-    # Config shape matches the per-type models in onyx.db.sso_provider, encrypted
-    # exactly as the EncryptedJson column would store it (json then encrypt).
+    # Store the config the way the ORM does: JSON-encode, then encrypt.
     config: dict[str, str] = {
         "client_id": OAUTH_CLIENT_ID,
         "client_secret": OAUTH_CLIENT_SECRET,

--- a/backend/alembic/versions/1fc2904131a3_add_sso_provider_table_and_seed_from_env.py
+++ b/backend/alembic/versions/1fc2904131a3_add_sso_provider_table_and_seed_from_env.py
@@ -8,12 +8,9 @@ Create Date: 2026-07-06 21:34:08.516250
 
 from __future__ import annotations
 
-import os
-
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
-from dotenv import load_dotenv, find_dotenv
 
 from onyx.utils.encryption import encrypt_string_to_bytes
 
@@ -58,58 +55,55 @@ def _sso_provider_table(metadata: sa.MetaData) -> sa.Table:
 
 
 def _seed_from_env(table: sa.Table) -> None:
-    """One-time import of legacy single-provider env config. The DB is the
-    source of truth afterwards; env vars are never read at request time.
+    """One-time import of legacy single-provider config. The DB is the source
+    of truth afterwards; env vars are never read at request time.
 
-    Skipped in multi-tenant (cloud auth does not use per-instance provider
-    rows) and when the table already has any row.
+    Reads the already-resolved app_config constants (not raw os.environ) so
+    the legacy GOOGLE_OAUTH_* fallbacks and the VALID_EMAIL_DOMAINS parsing
+    stay in one place. Skipped in multi-tenant (cloud auth does not use
+    per-instance provider rows) and when the table already has any row.
     """
-    load_dotenv(find_dotenv())
+    from onyx.configs.app_configs import AUTH_TYPE
+    from onyx.configs.app_configs import OAUTH_CLIENT_ID
+    from onyx.configs.app_configs import OAUTH_CLIENT_SECRET
+    from onyx.configs.app_configs import OPENID_CONFIG_URL
+    from onyx.configs.app_configs import VALID_EMAIL_DOMAINS
+    from onyx.configs.constants import AuthType
+    from shared_configs.configs import MULTI_TENANT
 
-    if os.environ.get("MULTI_TENANT", "").lower() == "true":
+    if MULTI_TENANT:
         return
 
-    auth_type = os.environ.get("AUTH_TYPE", "").lower()
-    client_id = os.environ.get("OAUTH_CLIENT_ID")
-    client_secret = os.environ.get("OAUTH_CLIENT_SECRET")
-    openid_config_url = os.environ.get("OPENID_CONFIG_URL")
-
-    # Seed names match the oauth_name that existing linked login accounts
-    # carry ("google" / "openid"), so account linkage survives the cutover
-    # to provider-row routing.
-    if auth_type == "google_oauth":
-        provider_type, name, display_name = "google", "google", "Continue with Google"
-        config_url = None
-    elif auth_type == "oidc":
-        if not openid_config_url:
+    # provider_type is the enum member NAME (Enum(native_enum=False) storage);
+    # the login `name` matches the oauth_name existing linked accounts carry so
+    # linkage survives the routing cutover.
+    if AUTH_TYPE == AuthType.GOOGLE_OAUTH:
+        provider_type, name = "GOOGLE", "google"
+        display_name, config_url = "Continue with Google", None
+    elif AUTH_TYPE == AuthType.OIDC:
+        if not OPENID_CONFIG_URL:
             return
-        provider_type, name, display_name = "oidc", "openid", "Single Sign-On"
-        config_url = openid_config_url
+        provider_type, name = "OIDC", "openid"
+        display_name, config_url = "Single Sign-On", OPENID_CONFIG_URL
     else:
         return
 
-    if not client_id or not client_secret:
+    if not OAUTH_CLIENT_ID or not OAUTH_CLIENT_SECRET:
         return
 
     bind = op.get_bind()
     if bind.execute(sa.select(table.c.id).limit(1)).first():
         return
 
-    allowed_email_domains = [
-        domain.strip().lower()
-        for domain in os.environ.get("VALID_EMAIL_DOMAINS", "").split(",")
-        if domain.strip()
-    ]
-
     bind.execute(
         table.insert().values(
             name=name,
             display_name=display_name,
             provider_type=provider_type,
-            client_id=client_id,
-            client_secret=encrypt_string_to_bytes(client_secret),
+            client_id=OAUTH_CLIENT_ID,
+            client_secret=encrypt_string_to_bytes(OAUTH_CLIENT_SECRET),
             openid_config_url=config_url,
-            allowed_email_domains=allowed_email_domains,
+            allowed_email_domains=[d.lower() for d in VALID_EMAIL_DOMAINS],
             enabled=True,
         )
     )

--- a/backend/alembic/versions/1fc2904131a3_add_sso_provider_table_and_seed_from_env.py
+++ b/backend/alembic/versions/1fc2904131a3_add_sso_provider_table_and_seed_from_env.py
@@ -8,6 +8,8 @@ Create Date: 2026-07-06 21:34:08.516250
 
 from __future__ import annotations
 
+import json
+
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
@@ -29,9 +31,9 @@ def _sso_provider_table(metadata: sa.MetaData) -> sa.Table:
         sa.Column("name", sa.String, nullable=False, unique=True),
         sa.Column("display_name", sa.String, nullable=False),
         sa.Column("provider_type", sa.String, nullable=False),
-        sa.Column("client_id", sa.String, nullable=False),
-        sa.Column("client_secret", sa.LargeBinary, nullable=False),
-        sa.Column("openid_config_url", sa.String, nullable=True),
+        # Protocol-specific config, encrypted JSON (matches the EncryptedJson
+        # ORM column). Shape differs by provider_type; validated in the app.
+        sa.Column("config", sa.LargeBinary, nullable=False),
         sa.Column(
             "allowed_email_domains",
             postgresql.ARRAY(sa.String),
@@ -95,14 +97,21 @@ def _seed_from_env(table: sa.Table) -> None:
     if bind.execute(sa.select(table.c.id).limit(1)).first():
         return
 
+    # Config shape matches the per-type models in onyx.db.sso_provider, encrypted
+    # exactly as the EncryptedJson column would store it (json then encrypt).
+    config: dict[str, str] = {
+        "client_id": OAUTH_CLIENT_ID,
+        "client_secret": OAUTH_CLIENT_SECRET,
+    }
+    if config_url is not None:
+        config["openid_config_url"] = config_url
+
     bind.execute(
         table.insert().values(
             name=name,
             display_name=display_name,
             provider_type=provider_type,
-            client_id=OAUTH_CLIENT_ID,
-            client_secret=encrypt_string_to_bytes(OAUTH_CLIENT_SECRET),
-            openid_config_url=config_url,
+            config=encrypt_string_to_bytes(json.dumps(config)),
             allowed_email_domains=[d.lower() for d in VALID_EMAIL_DOMAINS],
             enabled=True,
         )

--- a/backend/alembic/versions/1fc2904131a3_add_sso_provider_table_and_seed_from_env.py
+++ b/backend/alembic/versions/1fc2904131a3_add_sso_provider_table_and_seed_from_env.py
@@ -1,0 +1,126 @@
+"""add sso_provider table and seed from env
+
+Revision ID: 1fc2904131a3
+Revises: 2e0b2b146de1
+Create Date: 2026-07-06 21:34:08.516250
+
+"""
+
+from __future__ import annotations
+
+import os
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+from dotenv import load_dotenv, find_dotenv
+
+from onyx.utils.encryption import encrypt_string_to_bytes
+
+# revision identifiers, used by Alembic.
+revision = "1fc2904131a3"
+down_revision = "2e0b2b146de1"
+branch_labels = None
+depends_on = None
+
+
+def _sso_provider_table(metadata: sa.MetaData) -> sa.Table:
+    return sa.Table(
+        "sso_provider",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("name", sa.String, nullable=False, unique=True),
+        sa.Column("display_name", sa.String, nullable=False),
+        sa.Column("provider_type", sa.String, nullable=False),
+        sa.Column("client_id", sa.String, nullable=False),
+        sa.Column("client_secret", sa.LargeBinary, nullable=False),
+        sa.Column("openid_config_url", sa.String, nullable=True),
+        sa.Column(
+            "allowed_email_domains",
+            postgresql.ARRAY(sa.String),
+            nullable=False,
+            server_default=sa.text("'{}'"),
+        ),
+        sa.Column("enabled", sa.Boolean, nullable=False, server_default=sa.true()),
+        sa.Column(
+            "time_created",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "time_updated",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+
+
+def _seed_from_env(table: sa.Table) -> None:
+    """One-time import of legacy single-provider env config. The DB is the
+    source of truth afterwards; env vars are never read at request time.
+
+    Skipped in multi-tenant (cloud auth does not use per-instance provider
+    rows) and when the table already has any row.
+    """
+    load_dotenv(find_dotenv())
+
+    if os.environ.get("MULTI_TENANT", "").lower() == "true":
+        return
+
+    auth_type = os.environ.get("AUTH_TYPE", "").lower()
+    client_id = os.environ.get("OAUTH_CLIENT_ID")
+    client_secret = os.environ.get("OAUTH_CLIENT_SECRET")
+    openid_config_url = os.environ.get("OPENID_CONFIG_URL")
+
+    # Seed names match the oauth_name that existing linked login accounts
+    # carry ("google" / "openid"), so account linkage survives the cutover
+    # to provider-row routing.
+    if auth_type == "google_oauth":
+        provider_type, name, display_name = "google", "google", "Continue with Google"
+        config_url = None
+    elif auth_type == "oidc":
+        if not openid_config_url:
+            return
+        provider_type, name, display_name = "oidc", "openid", "Single Sign-On"
+        config_url = openid_config_url
+    else:
+        return
+
+    if not client_id or not client_secret:
+        return
+
+    bind = op.get_bind()
+    if bind.execute(sa.select(table.c.id).limit(1)).first():
+        return
+
+    allowed_email_domains = [
+        domain.strip().lower()
+        for domain in os.environ.get("VALID_EMAIL_DOMAINS", "").split(",")
+        if domain.strip()
+    ]
+
+    bind.execute(
+        table.insert().values(
+            name=name,
+            display_name=display_name,
+            provider_type=provider_type,
+            client_id=client_id,
+            client_secret=encrypt_string_to_bytes(client_secret),
+            openid_config_url=config_url,
+            allowed_email_domains=allowed_email_domains,
+            enabled=True,
+        )
+    )
+
+
+def upgrade() -> None:
+    metadata = sa.MetaData()
+    table = _sso_provider_table(metadata)
+    table.create(op.get_bind())
+    _seed_from_env(table)
+
+
+def downgrade() -> None:
+    op.drop_table("sso_provider")

--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -637,5 +637,7 @@ class PersonaSharingStatus(str, PyEnum):
 
 
 class SSOProviderType(str, PyEnum):
-    GOOGLE = "google"
-    OIDC = "oidc"
+    # name == value: Enum(native_enum=False) columns persist the member name,
+    # so the two must match to round-trip (repo-wide convention).
+    GOOGLE = "GOOGLE"
+    OIDC = "OIDC"

--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -634,3 +634,8 @@ class PersonaSharingStatus(str, PyEnum):
     PRIVATE = "PRIVATE"
     SHARED = "SHARED"
     PUBLIC = "PUBLIC"
+
+
+class SSOProviderType(str, PyEnum):
+    GOOGLE = "google"
+    OIDC = "oidc"

--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -641,3 +641,4 @@ class SSOProviderType(str, PyEnum):
     # so the two must match to round-trip (repo-wide convention).
     GOOGLE = "GOOGLE"
     OIDC = "OIDC"
+    SAML = "SAML"

--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -639,6 +639,6 @@ class PersonaSharingStatus(str, PyEnum):
 class SSOProviderType(str, PyEnum):
     # name == value: Enum(native_enum=False) columns persist the member name,
     # so the two must match to round-trip (repo-wide convention).
-    GOOGLE = "GOOGLE"
+    GOOGLE_OAUTH = "GOOGLE_OAUTH"
     OIDC = "OIDC"
     SAML = "SAML"

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -99,6 +99,7 @@ from onyx.db.enums import ScheduledTaskTriggerSource
 from onyx.db.enums import SessionOrigin
 from onyx.db.enums import SharingScope
 from onyx.db.enums import SkillSharePermission
+from onyx.db.enums import SSOProviderType
 from onyx.db.enums import SwitchoverType
 from onyx.db.enums import SyncStatus
 from onyx.db.enums import SyncType
@@ -6561,4 +6562,41 @@ class ExternalAppPolicy(Base):
             "action_id",
             name="uq_external_app_policy_app_action",
         ),
+    )
+
+
+class SSOProvider(Base):
+    """A configured SSO identity provider. Providers are rows, not startup
+    wiring: login routes resolve the row at request time, so adding or
+    editing one requires no restart."""
+
+    __tablename__ = "sso_provider"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    # URL path segment for the login routes and the oauth_name stored on
+    # linked login accounts. Renaming a provider orphans those links.
+    name: Mapped[str] = mapped_column(String, unique=True, nullable=False)
+    display_name: Mapped[str] = mapped_column(String, nullable=False)
+    provider_type: Mapped[SSOProviderType] = mapped_column(
+        Enum(SSOProviderType, native_enum=False), nullable=False
+    )
+    client_id: Mapped[str] = mapped_column(String, nullable=False)
+    client_secret: Mapped[SensitiveValue[str] | None] = mapped_column(
+        EncryptedString(), nullable=False
+    )
+    # OIDC discovery document URL; None for GOOGLE providers
+    openid_config_url: Mapped[str | None] = mapped_column(String, nullable=True)
+    # Email domains admitted through this provider's login, lowercased
+    allowed_email_domains: Mapped[list[str]] = mapped_column(
+        postgresql.ARRAY(String), nullable=False, default=list
+    )
+    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    time_created: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    time_updated: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
     )

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -6568,10 +6568,9 @@ class ExternalAppPolicy(Base):
 class SSOProvider(Base):
     """A configured SSO identity provider. Providers are rows, not startup
     wiring: login routes resolve the row at request time, so adding or editing
-    one requires no restart. Fields common to every auth method are columns;
-    everything protocol-specific lives in the encrypted `config` blob, validated
-    per provider_type in onyx.db.sso_provider. So a new method (OIDC, SAML, ...)
-    is a new config shape, not a set of new columns."""
+    one requires no restart. Fields common to every auth method are columns. The
+    protocol-specific settings live in the encrypted `config` blob, validated
+    per provider_type on write."""
 
     __tablename__ = "sso_provider"
 
@@ -6584,7 +6583,7 @@ class SSOProvider(Base):
         Enum(SSOProviderType, native_enum=False), nullable=False
     )
     # Protocol-specific settings: OAuth client creds + discovery URL for
-    # GOOGLE/OIDC, or IdP metadata for SAML. Encrypted at rest; shape validated
+    # GOOGLE/OIDC, or IdP metadata for SAML. Encrypted at rest, validated
     # against provider_type on write.
     config: Mapped[SensitiveValue[dict[str, Any]] | None] = mapped_column(
         EncryptedJson(), nullable=False

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -6567,8 +6567,11 @@ class ExternalAppPolicy(Base):
 
 class SSOProvider(Base):
     """A configured SSO identity provider. Providers are rows, not startup
-    wiring: login routes resolve the row at request time, so adding or
-    editing one requires no restart."""
+    wiring: login routes resolve the row at request time, so adding or editing
+    one requires no restart. Fields common to every auth method are columns;
+    everything protocol-specific lives in the encrypted `config` blob, validated
+    per provider_type in onyx.db.sso_provider. So a new method (OIDC, SAML, ...)
+    is a new config shape, not a set of new columns."""
 
     __tablename__ = "sso_provider"
 
@@ -6580,12 +6583,12 @@ class SSOProvider(Base):
     provider_type: Mapped[SSOProviderType] = mapped_column(
         Enum(SSOProviderType, native_enum=False), nullable=False
     )
-    client_id: Mapped[str] = mapped_column(String, nullable=False)
-    client_secret: Mapped[SensitiveValue[str] | None] = mapped_column(
-        EncryptedString(), nullable=False
+    # Protocol-specific settings: OAuth client creds + discovery URL for
+    # GOOGLE/OIDC, or IdP metadata for SAML. Encrypted at rest; shape validated
+    # against provider_type on write.
+    config: Mapped[SensitiveValue[dict[str, Any]] | None] = mapped_column(
+        EncryptedJson(), nullable=False
     )
-    # OIDC discovery document URL; None for GOOGLE providers
-    openid_config_url: Mapped[str | None] = mapped_column(String, nullable=True)
     # Email domains admitted through this provider's login, lowercased
     allowed_email_domains: Mapped[list[str]] = mapped_column(
         postgresql.ARRAY(String), nullable=False, default=list

--- a/backend/onyx/db/sso_provider.py
+++ b/backend/onyx/db/sso_provider.py
@@ -33,9 +33,9 @@ class OIDCProviderConfig(_ProviderConfig):
 
 
 class SAMLProviderConfig(_ProviderConfig):
-    """Stub for the not-yet-wired SAML login flow. Fields mirror what the
-    OneLogin toolkit needs (see onyx/server/saml.py) so the store, migration,
-    and admin path are proven before the flow itself lands."""
+    """SAML provider config: the IdP metadata a SAML login needs. No login flow
+    consumes it yet, so a SAML row validates and stores but cannot drive a
+    login."""
 
     idp_entity_id: str
     idp_sso_url: str
@@ -44,8 +44,7 @@ class SAMLProviderConfig(_ProviderConfig):
     email_attribute: str | None = None
 
 
-# provider_type selects the config shape. A new auth method is a new model plus
-# an entry here, never a schema migration.
+# provider_type selects the config shape. A new auth method adds a model here.
 _CONFIG_MODEL_BY_TYPE: dict[SSOProviderType, type[_ProviderConfig]] = {
     SSOProviderType.GOOGLE: GoogleProviderConfig,
     SSOProviderType.OIDC: OIDCProviderConfig,

--- a/backend/onyx/db/sso_provider.py
+++ b/backend/onyx/db/sso_provider.py
@@ -31,10 +31,16 @@ def fetch_sso_providers(
     return list(db_session.scalars(stmt).all())
 
 
-def fetch_sso_provider_by_name(db_session: Session, name: str) -> SSOProvider | None:
-    return db_session.scalars(
-        select(SSOProvider).where(SSOProvider.name == name)
-    ).first()
+def fetch_sso_provider_by_name(
+    db_session: Session, name: str, enabled_only: bool = False
+) -> SSOProvider | None:
+    """The login route must pass enabled_only=True so a disabled provider can
+    never resolve into an authorization flow. The admin API leaves it False to
+    read a disabled row for re-enabling."""
+    stmt = select(SSOProvider).where(SSOProvider.name == name)
+    if enabled_only:
+        stmt = stmt.where(SSOProvider.enabled.is_(True))
+    return db_session.scalars(stmt).first()
 
 
 def create_sso_provider(
@@ -50,6 +56,8 @@ def create_sso_provider(
     validate_sso_provider_name(name)
     if provider_type == SSOProviderType.OIDC and not openid_config_url:
         raise ValueError("OIDC providers require an openid_config_url")
+    if provider_type != SSOProviderType.OIDC and openid_config_url:
+        raise ValueError("openid_config_url only applies to OIDC providers")
 
     provider = SSOProvider(
         name=name,

--- a/backend/onyx/db/sso_provider.py
+++ b/backend/onyx/db/sso_provider.py
@@ -46,7 +46,7 @@ class SAMLProviderConfig(_ProviderConfig):
 
 # provider_type selects the config shape. A new auth method adds a model here.
 _CONFIG_MODEL_BY_TYPE: dict[SSOProviderType, type[_ProviderConfig]] = {
-    SSOProviderType.GOOGLE: GoogleProviderConfig,
+    SSOProviderType.GOOGLE_OAUTH: GoogleProviderConfig,
     SSOProviderType.OIDC: OIDCProviderConfig,
     SSOProviderType.SAML: SAMLProviderConfig,
 }

--- a/backend/onyx/db/sso_provider.py
+++ b/backend/onyx/db/sso_provider.py
@@ -1,0 +1,111 @@
+import re
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from onyx.db.enums import SSOProviderType
+from onyx.db.models import SSOProvider
+
+# The name becomes the login URL path segment and the oauth_name stored on
+# linked login accounts, so it must be a stable, URL-safe slug.
+_PROVIDER_NAME_PATTERN = re.compile(r"^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$")
+
+
+def validate_sso_provider_name(name: str) -> None:
+    if not _PROVIDER_NAME_PATTERN.fullmatch(name):
+        raise ValueError(
+            "Provider name must be a lowercase slug (a-z, 0-9, inner hyphens)"
+        )
+
+
+def _normalize_domains(domains: list[str]) -> list[str]:
+    return sorted({domain.strip().lower() for domain in domains if domain.strip()})
+
+
+def fetch_sso_providers(
+    db_session: Session, enabled_only: bool = False
+) -> list[SSOProvider]:
+    stmt = select(SSOProvider).order_by(SSOProvider.id)
+    if enabled_only:
+        stmt = stmt.where(SSOProvider.enabled.is_(True))
+    return list(db_session.scalars(stmt).all())
+
+
+def fetch_sso_provider_by_name(db_session: Session, name: str) -> SSOProvider | None:
+    return db_session.scalars(
+        select(SSOProvider).where(SSOProvider.name == name)
+    ).first()
+
+
+def create_sso_provider(
+    db_session: Session,
+    name: str,
+    display_name: str,
+    provider_type: SSOProviderType,
+    client_id: str,
+    client_secret: str,
+    allowed_email_domains: list[str],
+    openid_config_url: str | None = None,
+) -> SSOProvider:
+    validate_sso_provider_name(name)
+    if provider_type == SSOProviderType.OIDC and not openid_config_url:
+        raise ValueError("OIDC providers require an openid_config_url")
+
+    provider = SSOProvider(
+        name=name,
+        display_name=display_name,
+        provider_type=provider_type,
+        client_id=client_id,
+        client_secret=client_secret,
+        openid_config_url=openid_config_url,
+        allowed_email_domains=_normalize_domains(allowed_email_domains),
+    )
+    db_session.add(provider)
+    db_session.commit()
+    return provider
+
+
+def update_sso_provider(
+    db_session: Session,
+    provider_id: int,
+    display_name: str | None = None,
+    client_id: str | None = None,
+    client_secret: str | None = None,
+    allowed_email_domains: list[str] | None = None,
+    openid_config_url: str | None = None,
+) -> SSOProvider:
+    """Partial update. The provider name is immutable because linked login
+    accounts and the login URL reference it. A None field is left unchanged,
+    so a secret is only rewritten when a new one is supplied."""
+    provider = db_session.get(SSOProvider, provider_id)
+    if provider is None:
+        raise ValueError(f"SSO provider {provider_id} does not exist")
+
+    if display_name is not None:
+        provider.display_name = display_name
+    if client_id is not None:
+        provider.client_id = client_id
+    if client_secret is not None:
+        provider.client_secret = client_secret  # ty: ignore[invalid-assignment]
+    if allowed_email_domains is not None:
+        provider.allowed_email_domains = _normalize_domains(allowed_email_domains)
+    if openid_config_url is not None:
+        if provider.provider_type != SSOProviderType.OIDC:
+            raise ValueError("openid_config_url only applies to OIDC providers")
+        provider.openid_config_url = openid_config_url
+
+    db_session.commit()
+    return provider
+
+
+def set_sso_provider_enabled(
+    db_session: Session, provider_id: int, enabled: bool
+) -> SSOProvider:
+    """Providers are disabled, never hard-deleted, so linked login accounts
+    survive a re-enable."""
+    provider = db_session.get(SSOProvider, provider_id)
+    if provider is None:
+        raise ValueError(f"SSO provider {provider_id} does not exist")
+    provider.enabled = enabled
+    db_session.commit()
+    return provider

--- a/backend/onyx/db/sso_provider.py
+++ b/backend/onyx/db/sso_provider.py
@@ -1,5 +1,9 @@
 import re
+from typing import Any
 
+from pydantic import BaseModel
+from pydantic import ConfigDict
+from pydantic import ValidationError
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
@@ -9,6 +13,56 @@ from onyx.db.models import SSOProvider
 # The name becomes the login URL path segment and the oauth_name stored on
 # linked login accounts, so it must be a stable, URL-safe slug.
 _PROVIDER_NAME_PATTERN = re.compile(r"^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$")
+
+
+class _ProviderConfig(BaseModel):
+    # Reject unknown keys so a config built for a different provider type (or a
+    # typo) fails loudly on write instead of being stored and mis-read later.
+    model_config = ConfigDict(extra="forbid")
+
+
+class GoogleProviderConfig(_ProviderConfig):
+    client_id: str
+    client_secret: str
+
+
+class OIDCProviderConfig(_ProviderConfig):
+    client_id: str
+    client_secret: str
+    openid_config_url: str
+
+
+class SAMLProviderConfig(_ProviderConfig):
+    """Stub for the not-yet-wired SAML login flow. Fields mirror what the
+    OneLogin toolkit needs (see onyx/server/saml.py) so the store, migration,
+    and admin path are proven before the flow itself lands."""
+
+    idp_entity_id: str
+    idp_sso_url: str
+    idp_x509_cert: str
+    sp_entity_id: str
+    email_attribute: str | None = None
+
+
+# provider_type selects the config shape. A new auth method is a new model plus
+# an entry here, never a schema migration.
+_CONFIG_MODEL_BY_TYPE: dict[SSOProviderType, type[_ProviderConfig]] = {
+    SSOProviderType.GOOGLE: GoogleProviderConfig,
+    SSOProviderType.OIDC: OIDCProviderConfig,
+    SSOProviderType.SAML: SAMLProviderConfig,
+}
+
+
+def validate_sso_config(
+    provider_type: SSOProviderType, config: dict[str, Any]
+) -> dict[str, Any]:
+    """Validate a raw config against its provider type and return the normalized
+    dict for storage. Raises ValueError on a missing or unknown field so callers
+    see one exception type regardless of the provider."""
+    try:
+        return _CONFIG_MODEL_BY_TYPE[provider_type].model_validate(config).model_dump()
+    except ValidationError as e:
+        raise ValueError(f"invalid {provider_type.value} provider config: {e}") from e
 
 
 def validate_sso_provider_name(name: str) -> None:
@@ -48,24 +102,15 @@ def create_sso_provider(
     name: str,
     display_name: str,
     provider_type: SSOProviderType,
-    client_id: str,
-    client_secret: str,
+    config: dict[str, Any],
     allowed_email_domains: list[str],
-    openid_config_url: str | None = None,
 ) -> SSOProvider:
     validate_sso_provider_name(name)
-    if provider_type == SSOProviderType.OIDC and not openid_config_url:
-        raise ValueError("OIDC providers require an openid_config_url")
-    if provider_type != SSOProviderType.OIDC and openid_config_url:
-        raise ValueError("openid_config_url only applies to OIDC providers")
-
     provider = SSOProvider(
         name=name,
         display_name=display_name,
         provider_type=provider_type,
-        client_id=client_id,
-        client_secret=client_secret,
-        openid_config_url=openid_config_url,
+        config=validate_sso_config(provider_type, config),
         allowed_email_domains=_normalize_domains(allowed_email_domains),
     )
     db_session.add(provider)
@@ -77,30 +122,25 @@ def update_sso_provider(
     db_session: Session,
     provider_id: int,
     display_name: str | None = None,
-    client_id: str | None = None,
-    client_secret: str | None = None,
+    config: dict[str, Any] | None = None,
     allowed_email_domains: list[str] | None = None,
-    openid_config_url: str | None = None,
 ) -> SSOProvider:
-    """Partial update. The provider name is immutable because linked login
-    accounts and the login URL reference it. A None field is left unchanged,
-    so a secret is only rewritten when a new one is supplied."""
+    """Partial update. Name and provider_type are immutable: linked login
+    accounts and the login URL reference the name, and the type fixes the config
+    shape. A None field is left unchanged, so the config (and its secrets) is
+    only rewritten when a new one is supplied."""
     provider = db_session.get(SSOProvider, provider_id)
     if provider is None:
         raise ValueError(f"SSO provider {provider_id} does not exist")
 
     if display_name is not None:
         provider.display_name = display_name
-    if client_id is not None:
-        provider.client_id = client_id
-    if client_secret is not None:
-        provider.client_secret = client_secret  # ty: ignore[invalid-assignment]
+    if config is not None:
+        provider.config = validate_sso_config(  # ty: ignore[invalid-assignment]
+            provider.provider_type, config
+        )
     if allowed_email_domains is not None:
         provider.allowed_email_domains = _normalize_domains(allowed_email_domains)
-    if openid_config_url is not None:
-        if provider.provider_type != SSOProviderType.OIDC:
-            raise ValueError("openid_config_url only applies to OIDC providers")
-        provider.openid_config_url = openid_config_url
 
     db_session.commit()
     return provider

--- a/backend/tests/external_dependency_unit/db/test_sso_provider_store.py
+++ b/backend/tests/external_dependency_unit/db/test_sso_provider_store.py
@@ -45,7 +45,7 @@ def _create(db_session: Session, name: str, **overrides: object) -> SSOProvider:
     kwargs: dict = dict(
         name=name,
         display_name="Company A",
-        provider_type=SSOProviderType.GOOGLE,
+        provider_type=SSOProviderType.GOOGLE_OAUTH,
         config=dict(_GOOGLE_CONFIG),
         allowed_email_domains=["CompanyA.com ", "companya.com"],
     )
@@ -73,7 +73,7 @@ def test_invalid_name_rejected(db_session: Session) -> None:
             db_session,
             name="Not A Slug!",
             display_name="X",
-            provider_type=SSOProviderType.GOOGLE,
+            provider_type=SSOProviderType.GOOGLE_OAUTH,
             config=dict(_GOOGLE_CONFIG),
             allowed_email_domains=[],
         )
@@ -99,7 +99,7 @@ def test_google_rejects_unknown_config_key(
         _create(
             db_session,
             provider_name,
-            provider_type=SSOProviderType.GOOGLE,
+            provider_type=SSOProviderType.GOOGLE_OAUTH,
             config=dict(_OIDC_CONFIG),  # openid_config_url not allowed for GOOGLE
         )
 

--- a/backend/tests/external_dependency_unit/db/test_sso_provider_store.py
+++ b/backend/tests/external_dependency_unit/db/test_sso_provider_store.py
@@ -82,6 +82,43 @@ def test_oidc_requires_config_url(db_session: Session, provider_name: str) -> No
         )
 
 
+def test_google_rejects_config_url(db_session: Session, provider_name: str) -> None:
+    with pytest.raises(ValueError):
+        _create(
+            db_session,
+            provider_name,
+            provider_type=SSOProviderType.GOOGLE,
+            openid_config_url="https://idp.example.com/.well-known/openid-configuration",
+        )
+
+
+def test_provider_type_roundtrips_through_db(
+    db_session: Session, provider_name: str
+) -> None:
+    created = _create(
+        db_session,
+        provider_name,
+        provider_type=SSOProviderType.OIDC,
+        openid_config_url="https://idp.example.com/.well-known/openid-configuration",
+    )
+    db_session.expire(created)
+    fetched = fetch_sso_provider_by_name(db_session, provider_name)
+    assert fetched is not None
+    assert fetched.provider_type is SSOProviderType.OIDC
+
+
+def test_disabled_provider_hidden_from_enabled_only_by_name(
+    db_session: Session, provider_name: str
+) -> None:
+    created = _create(db_session, provider_name)
+    set_sso_provider_enabled(db_session, created.id, enabled=False)
+
+    assert fetch_sso_provider_by_name(db_session, provider_name) is not None
+    assert (
+        fetch_sso_provider_by_name(db_session, provider_name, enabled_only=True) is None
+    )
+
+
 def test_partial_update_preserves_secret(
     db_session: Session, provider_name: str
 ) -> None:

--- a/backend/tests/external_dependency_unit/db/test_sso_provider_store.py
+++ b/backend/tests/external_dependency_unit/db/test_sso_provider_store.py
@@ -1,0 +1,106 @@
+"""The sso_provider store must round-trip encrypted secrets, enforce the
+slug name contract, preserve secrets on partial update, and keep
+disable-not-delete semantics."""
+
+from collections.abc import Generator
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import delete
+from sqlalchemy.orm import Session
+
+from onyx.db.enums import SSOProviderType
+from onyx.db.models import SSOProvider
+from onyx.db.sso_provider import create_sso_provider
+from onyx.db.sso_provider import fetch_sso_provider_by_name
+from onyx.db.sso_provider import fetch_sso_providers
+from onyx.db.sso_provider import set_sso_provider_enabled
+from onyx.db.sso_provider import update_sso_provider
+from onyx.db.sso_provider import validate_sso_provider_name
+
+_NAME_PREFIX = "testsso"
+
+
+@pytest.fixture()
+def provider_name(db_session: Session) -> Generator[str, None, None]:
+    name = f"{_NAME_PREFIX}-{uuid4().hex[:8]}"
+    yield name
+    db_session.execute(delete(SSOProvider).where(SSOProvider.name.like(f"{name}%")))
+    db_session.commit()
+
+
+def _create(db_session: Session, name: str, **overrides: object) -> SSOProvider:
+    kwargs: dict = dict(
+        name=name,
+        display_name="Company A",
+        provider_type=SSOProviderType.GOOGLE,
+        client_id="client-id",
+        client_secret="super-secret",
+        allowed_email_domains=["CompanyA.com ", "companya.com"],
+    )
+    kwargs.update(overrides)
+    return create_sso_provider(db_session, **kwargs)
+
+
+def test_create_and_fetch_roundtrip(db_session: Session, provider_name: str) -> None:
+    created = _create(db_session, provider_name)
+
+    fetched = fetch_sso_provider_by_name(db_session, provider_name)
+    assert fetched is not None
+    assert fetched.id == created.id
+    # domains are deduped and lowercased
+    assert fetched.allowed_email_domains == ["companya.com"]
+    # secret decrypts to the original and masks by default
+    assert fetched.client_secret is not None
+    assert fetched.client_secret.get_value(apply_mask=False) == "super-secret"
+    assert fetched.client_secret.get_value(apply_mask=True) != "super-secret"
+
+
+def test_invalid_name_rejected(db_session: Session) -> None:
+    with pytest.raises(ValueError):
+        create_sso_provider(
+            db_session,
+            name="Not A Slug!",
+            display_name="X",
+            provider_type=SSOProviderType.GOOGLE,
+            client_id="cid",
+            client_secret="s",
+            allowed_email_domains=[],
+        )
+    for bad in ("-leading", "trailing-", "UPPER", "with space"):
+        with pytest.raises(ValueError):
+            validate_sso_provider_name(bad)
+
+
+def test_oidc_requires_config_url(db_session: Session, provider_name: str) -> None:
+    with pytest.raises(ValueError):
+        _create(
+            db_session,
+            provider_name,
+            provider_type=SSOProviderType.OIDC,
+            openid_config_url=None,
+        )
+
+
+def test_partial_update_preserves_secret(
+    db_session: Session, provider_name: str
+) -> None:
+    created = _create(db_session, provider_name)
+
+    updated = update_sso_provider(
+        db_session, created.id, display_name="Renamed", client_secret=None
+    )
+    assert updated.display_name == "Renamed"
+    assert updated.client_secret is not None
+    assert updated.client_secret.get_value(apply_mask=False) == "super-secret"
+
+
+def test_disable_keeps_row_and_filters(db_session: Session, provider_name: str) -> None:
+    created = _create(db_session, provider_name)
+
+    set_sso_provider_enabled(db_session, created.id, enabled=False)
+
+    all_names = {p.name for p in fetch_sso_providers(db_session)}
+    enabled_names = {p.name for p in fetch_sso_providers(db_session, enabled_only=True)}
+    assert provider_name in all_names
+    assert provider_name not in enabled_names

--- a/backend/tests/external_dependency_unit/db/test_sso_provider_store.py
+++ b/backend/tests/external_dependency_unit/db/test_sso_provider_store.py
@@ -1,6 +1,6 @@
-"""The sso_provider store must round-trip encrypted secrets, enforce the
-slug name contract, preserve secrets on partial update, and keep
-disable-not-delete semantics."""
+"""The sso_provider store must round-trip the encrypted per-type config,
+enforce the slug name contract, validate config against provider_type, preserve
+config on partial update, and keep disable-not-delete semantics."""
 
 from collections.abc import Generator
 from uuid import uuid4
@@ -19,6 +19,18 @@ from onyx.db.sso_provider import update_sso_provider
 from onyx.db.sso_provider import validate_sso_provider_name
 
 _NAME_PREFIX = "testsso"
+_GOOGLE_CONFIG = {"client_id": "client-id", "client_secret": "super-secret"}
+_OIDC_CONFIG = {
+    "client_id": "client-id",
+    "client_secret": "super-secret",
+    "openid_config_url": "https://idp.example.com/.well-known/openid-configuration",
+}
+_SAML_CONFIG = {
+    "idp_entity_id": "https://idp.example.com/entity",
+    "idp_sso_url": "https://idp.example.com/sso",
+    "idp_x509_cert": "MIIC-fake-cert",
+    "sp_entity_id": "https://onyx.example.com/saml",
+}
 
 
 @pytest.fixture()
@@ -34,8 +46,7 @@ def _create(db_session: Session, name: str, **overrides: object) -> SSOProvider:
         name=name,
         display_name="Company A",
         provider_type=SSOProviderType.GOOGLE,
-        client_id="client-id",
-        client_secret="super-secret",
+        config=dict(_GOOGLE_CONFIG),
         allowed_email_domains=["CompanyA.com ", "companya.com"],
     )
     kwargs.update(overrides)
@@ -50,10 +61,10 @@ def test_create_and_fetch_roundtrip(db_session: Session, provider_name: str) -> 
     assert fetched.id == created.id
     # domains are deduped and lowercased
     assert fetched.allowed_email_domains == ["companya.com"]
-    # secret decrypts to the original and masks by default
-    assert fetched.client_secret is not None
-    assert fetched.client_secret.get_value(apply_mask=False) == "super-secret"
-    assert fetched.client_secret.get_value(apply_mask=True) != "super-secret"
+    # config decrypts to the original and masks the secret by default
+    assert fetched.config is not None
+    assert fetched.config.get_value(apply_mask=False) == _GOOGLE_CONFIG
+    assert fetched.config.get_value(apply_mask=True)["client_secret"] != "super-secret"
 
 
 def test_invalid_name_rejected(db_session: Session) -> None:
@@ -63,8 +74,7 @@ def test_invalid_name_rejected(db_session: Session) -> None:
             name="Not A Slug!",
             display_name="X",
             provider_type=SSOProviderType.GOOGLE,
-            client_id="cid",
-            client_secret="s",
+            config=dict(_GOOGLE_CONFIG),
             allowed_email_domains=[],
         )
     for bad in ("-leading", "trailing-", "UPPER", "with space"):
@@ -78,17 +88,51 @@ def test_oidc_requires_config_url(db_session: Session, provider_name: str) -> No
             db_session,
             provider_name,
             provider_type=SSOProviderType.OIDC,
-            openid_config_url=None,
+            config=dict(_GOOGLE_CONFIG),  # missing openid_config_url
         )
 
 
-def test_google_rejects_config_url(db_session: Session, provider_name: str) -> None:
+def test_google_rejects_unknown_config_key(
+    db_session: Session, provider_name: str
+) -> None:
     with pytest.raises(ValueError):
         _create(
             db_session,
             provider_name,
             provider_type=SSOProviderType.GOOGLE,
-            openid_config_url="https://idp.example.com/.well-known/openid-configuration",
+            config=dict(_OIDC_CONFIG),  # openid_config_url not allowed for GOOGLE
+        )
+
+
+def test_saml_config_validates_and_roundtrips(
+    db_session: Session, provider_name: str
+) -> None:
+    created = _create(
+        db_session,
+        provider_name,
+        provider_type=SSOProviderType.SAML,
+        config=dict(_SAML_CONFIG),
+    )
+    db_session.expire(created)
+
+    fetched = fetch_sso_provider_by_name(db_session, provider_name)
+    assert fetched is not None
+    assert fetched.provider_type is SSOProviderType.SAML
+    assert fetched.config is not None
+    stored = fetched.config.get_value(apply_mask=False)
+    assert stored["idp_entity_id"] == _SAML_CONFIG["idp_entity_id"]
+    # optional field defaults to None and is persisted
+    assert stored["email_attribute"] is None
+
+
+def test_saml_missing_field_rejected(db_session: Session, provider_name: str) -> None:
+    incomplete = {k: v for k, v in _SAML_CONFIG.items() if k != "idp_x509_cert"}
+    with pytest.raises(ValueError):
+        _create(
+            db_session,
+            provider_name,
+            provider_type=SSOProviderType.SAML,
+            config=incomplete,
         )
 
 
@@ -99,7 +143,7 @@ def test_provider_type_roundtrips_through_db(
         db_session,
         provider_name,
         provider_type=SSOProviderType.OIDC,
-        openid_config_url="https://idp.example.com/.well-known/openid-configuration",
+        config=dict(_OIDC_CONFIG),
     )
     db_session.expire(created)
     fetched = fetch_sso_provider_by_name(db_session, provider_name)
@@ -119,17 +163,15 @@ def test_disabled_provider_hidden_from_enabled_only_by_name(
     )
 
 
-def test_partial_update_preserves_secret(
+def test_partial_update_preserves_config(
     db_session: Session, provider_name: str
 ) -> None:
     created = _create(db_session, provider_name)
 
-    updated = update_sso_provider(
-        db_session, created.id, display_name="Renamed", client_secret=None
-    )
+    updated = update_sso_provider(db_session, created.id, display_name="Renamed")
     assert updated.display_name == "Renamed"
-    assert updated.client_secret is not None
-    assert updated.client_secret.get_value(apply_mask=False) == "super-secret"
+    assert updated.config is not None
+    assert updated.config.get_value(apply_mask=False) == _GOOGLE_CONFIG
 
 
 def test_disable_keeps_row_and_filters(db_session: Session, provider_name: str) -> None:


### PR DESCRIPTION
## Description

First slice of multi-IdP SSO. Ships dark: nothing reads the table yet.

- `sso_provider` table: fields common to every auth method are columns (name, label, `provider_type`, enabled, allowed email domains). Everything protocol-specific lives in one encrypted JSON `config` blob (`EncryptedJson`), validated per type. A new auth method is a new config shape, not a schema migration.
- Provider types: `GOOGLE`, `OIDC`, `SAML`. Each has a Pydantic config model (client id/secret plus discovery URL for Google/OIDC, IdP metadata for SAML). `extra="forbid"` rejects a config built for the wrong type. SAML's config is stubbed here, its login flow lands in a follow-up (A-PR6).
- `onyx/db/sso_provider.py`: fetch/create/update/enable store with per-type config validation. Provider `name` is an immutable URL-safe slug because it becomes the login path segment and the `oauth_name` on linked accounts. Config is only rewritten when supplied. Providers are disabled, never deleted.
- Migration creates the table and does a one-time seed from legacy single-provider env (`AUTH_TYPE` google_oauth/oidc) into the config blob, skipped on multi-tenant and when any row exists. Env is never read at request time.

Login routes, domain gates, and the admin API build on this in follow-ups.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
