### PR TITLE
fix(llm): Claude Sonnet 5 uses adaptive thinking and rejects sampling params

### DIFF
--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -84,6 +84,8 @@ _VERTEX_ANTHROPIC_MODELS_REJECTING_OUTPUT_CONFIG = (
 _ANTHROPIC_ADAPTIVE_THINKING_MODELS = (
     "claude-opus-4-7",
     "claude-opus-4-8",
+    "claude-sonnet-5",
+    "claude-5-sonnet",
     "claude-fable-5",
     "claude-5-fable",
     "claude-mythos-5",
@@ -105,6 +107,8 @@ _ANTHROPIC_NO_SAMPLING_PARAMS_MODELS = (
     "claude-opus-4.8",
     "claude-4-8-opus",
     "claude-4.8-opus",
+    "claude-sonnet-5",
+    "claude-5-sonnet",
     "claude-fable-5",
     "claude-5-fable",
     "claude-mythos-5",

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -437,6 +437,8 @@ ANTHROPIC_MODELS_OMITTING_SAMPLING_PARAMS = [
     "claude-opus-4.8",
     "claude-4-8-opus",
     "claude-4.8-opus",
+    "claude-sonnet-5",
+    "claude-5-sonnet",
     "claude-fable-5",
     "claude-fable-5@20260101",
     "claude-5-fable",
@@ -473,6 +475,8 @@ def test_omits_temperature_for_no_sampling_params_models(model_name: str) -> Non
     [
         "claude-opus-4-7",
         "claude-opus-4-8",
+        "claude-sonnet-5",
+        "claude-5-sonnet",
         "claude-fable-5",
         "claude-5-fable",
         "claude-mythos-5",


### PR DESCRIPTION
## Description

Claude Sonnet 5 follows the same API contract as the other Claude 4.7+/5-family models, but isn't in either allowlist yet, so requests fail with 400s:

- With reasoning enabled, the provider rejects the legacy thinking config: `"thinking.type.enabled" is not supported for this model. Use "thinking.type.adaptive" and "output_config.effort"`.
- Any sampling parameter is rejected: ``temperature` is deprecated for this model`.

Both behaviors verified against Bedrock's converse API (`global.anthropic.claude-sonnet-5`).

Fix: add `claude-sonnet-5` / `claude-5-sonnet` to `_ANTHROPIC_ADAPTIVE_THINKING_MODELS` and `_ANTHROPIC_NO_SAMPLING_PARAMS_MODELS`, plus cases in both parametrized test suites (77 pass).

## How Has This Been Tested?

- `pytest tests/unit/onyx/llm/test_multi_llm.py` — 77 passed (6 new Sonnet 5 cases)
- Live Bedrock converse calls confirming both error modes without the fix

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 400 errors when calling Claude Sonnet 5 by treating it like other Claude 4.7+/5 models. We now use adaptive thinking and omit sampling params for this model.

- **Bug Fixes**
  - Added `claude-sonnet-5` and `claude-5-sonnet` to `_ANTHROPIC_ADAPTIVE_THINKING_MODELS` and `_ANTHROPIC_NO_SAMPLING_PARAMS_MODELS`.
  - Extended parametrized tests to cover Sonnet 5 behavior.

<sup>Written for commit 404c9d28ec0c97f586846ee2d6b2639d57033ddb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

