### PR TITLE
fix(llm): omit sampling params and use adaptive thinking for claude-sonnet-5

### DIFF
--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -88,6 +88,8 @@ _ANTHROPIC_ADAPTIVE_THINKING_MODELS = (
     "claude-5-fable",
     "claude-mythos-5",
     "claude-5-mythos",
+    "claude-sonnet-5",
+    "claude-5-sonnet",
 )
 
 # Anthropic models that reject any non-default sampling parameter (temperature,
@@ -109,6 +111,8 @@ _ANTHROPIC_NO_SAMPLING_PARAMS_MODELS = (
     "claude-5-fable",
     "claude-mythos-5",
     "claude-5-mythos",
+    "claude-sonnet-5",
+    "claude-5-sonnet",
 )
 
 

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -442,6 +442,9 @@ ANTHROPIC_MODELS_OMITTING_SAMPLING_PARAMS = [
     "claude-5-fable",
     "claude-mythos-5",
     "claude-5-mythos",
+    "claude-sonnet-5",
+    "claude-sonnet-5@20260203",
+    "claude-5-sonnet",
 ]
 
 
@@ -477,6 +480,8 @@ def test_omits_temperature_for_no_sampling_params_models(model_name: str) -> Non
         "claude-5-fable",
         "claude-mythos-5",
         "claude-5-mythos",
+        "claude-sonnet-5",
+        "claude-5-sonnet",
     ],
 )
 @pytest.mark.parametrize(
@@ -524,6 +529,38 @@ def test_keeps_temperature_for_other_models(default_multi_llm: LitellmLLM) -> No
 
         kwargs = mock_completion.call_args.kwargs
         assert kwargs["temperature"] == 0.0
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "claude-sonnet-4-5",
+        "claude-sonnet-4-6",
+        "claude-3-5-sonnet-20241022",
+    ],
+)
+def test_keeps_temperature_for_older_sonnet_models(model_name: str) -> None:
+    # The no-sampling-params match is substring-based; make sure sonnet-5
+    # entries don't catch older sonnets, which still accept temperature.
+    llm = LitellmLLM(
+        api_key="test_key",
+        timeout=30,
+        model_provider=LlmProviderNames.LITELLM_PROXY,
+        model_name=model_name,
+        max_input_tokens=get_max_input_tokens(
+            model_provider=LlmProviderNames.LITELLM_PROXY,
+            model_name=model_name,
+        ),
+    )
+
+    with patch("litellm.completion") as mock_completion:
+        mock_completion.return_value = []
+
+        messages: LanguageModelInput = [UserMessage(content="Hi")]
+        list(llm.stream(messages))
+
+        kwargs = mock_completion.call_args.kwargs
+        assert "temperature" in kwargs
 
 
 @pytest.mark.parametrize("model_name", VERTEX_OPUS_MODELS_REJECTING_OUTPUT_CONFIG)


### PR DESCRIPTION
## Description

A customer configuring `claude-sonnet-5` (via an OpenAI-compatible proxy routing to Vertex) hit a 400 on every chat request:

```
litellm.BadRequestError: OpenAIException - `temperature` is deprecated for this model.
```

Claude Sonnet 5 has the same API surface as Opus 4.7/4.8 and Fable 5: it rejects non-default sampling parameters (`temperature`/`top_p`/`top_k`) with a 400, and it only supports the adaptive thinking API (`thinking.type=adaptive` + `output_config.effort`) — the legacy `budget_tokens` path also 400s.

This adds `claude-sonnet-5` / `claude-5-sonnet` to `_ANTHROPIC_NO_SAMPLING_PARAMS_MODELS` and `_ANTHROPIC_ADAPTIVE_THINKING_MODELS`, mirroring the earlier Opus 4.7/4.8 and Fable 5 fixes. Matching is substring-based to cover proxy/Vertex naming variants; older Sonnets (4.5/4.6, 3.5) are unaffected and still receive `temperature`.

## How Has This Been Tested?

- Extended the existing parametrized unit tests in `backend/tests/unit/onyx/llm/test_multi_llm.py` to cover the sonnet-5 variants (sampling params omitted, adaptive thinking used).
- Added a negative test asserting older Sonnet models still receive `temperature` (guards the substring match).
- Full `test_multi_llm.py` file passes (81 tests).

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop sending sampling params and enable adaptive thinking for `claude-sonnet-5` to prevent 400s (“temperature is deprecated”) on Anthropic/Vertex and OpenAI-compatible proxy routes. Older Sonnet models are unchanged.

- **Bug Fixes**
  - Added `claude-sonnet-5` and `claude-5-sonnet` to `_ANTHROPIC_NO_SAMPLING_PARAMS_MODELS` and `_ANTHROPIC_ADAPTIVE_THINKING_MODELS`.
  - Substring matching covers proxy/Vertex variants (e.g., `claude-sonnet-5@20260203`).
  - Guarded so Sonnet 4.x/3.5 models still receive `temperature`.

- **Tests**
  - Extended parameterized tests to assert no sampling params and adaptive thinking for Sonnet 5.
  - Added a negative test to ensure older Sonnets keep `temperature`.

<sup>Written for commit 25352d1ec626fc6c34b7eddb1565c89f4db14180. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

