### PR TITLE
feat(indexing): add GA gemini-embedding-2 to cloud embedding options

### DIFF
--- a/backend/onyx/configs/embedding_configs.py
+++ b/backend/onyx/configs/embedding_configs.py
@@ -82,6 +82,11 @@ _BASE_EMBEDDING_MODELS = [
         index_name="danswer_chunk_gemini_embedding_2_preview",
     ),
     _BaseEmbeddingModel(
+        name="google/gemini-embedding-2",
+        dim=3072,
+        index_name="danswer_chunk_gemini_embedding_2",
+    ),
+    _BaseEmbeddingModel(
         name="voyage/voyage-large-2-instruct",
         dim=1024,
         index_name="danswer_chunk_voyage_large_2_instruct",

--- a/backend/tests/unit/onyx/configs/test_google_embedding_configs.py
+++ b/backend/tests/unit/onyx/configs/test_google_embedding_configs.py
@@ -1,11 +1,17 @@
+import pytest
+
 from onyx.configs.embedding_configs import SUPPORTED_EMBEDDING_MODELS
 
 
-def test_supported_embedding_models_include_gemini_embedding_2_preview() -> None:
+@pytest.mark.parametrize(
+    "model_name",
+    ["google/gemini-embedding-2", "google/gemini-embedding-2-preview"],
+)
+def test_supported_embedding_models_include_gemini_embedding_2(
+    model_name: str,
+) -> None:
     gemini_embedding_2_models = [
-        model
-        for model in SUPPORTED_EMBEDDING_MODELS
-        if model.name == "google/gemini-embedding-2-preview"
+        model for model in SUPPORTED_EMBEDDING_MODELS if model.name == model_name
     ]
 
     # One FLOAT-precision entry and one BFLOAT16-precision entry per registered model.

--- a/backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py
+++ b/backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py
@@ -127,6 +127,10 @@ async def test_vertex_embed_keeps_task_type_for_existing_models(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
+    "model_name",
+    ["gemini-embedding-2", "gemini-embedding-2-preview"],
+)
+@pytest.mark.parametrize(
     ("embedding_type", "expected_text"),
     [
         ("RETRIEVAL_QUERY", "task: search result | query: hello world"),
@@ -134,6 +138,7 @@ async def test_vertex_embed_keeps_task_type_for_existing_models(
     ],
 )
 async def test_vertex_embed_uses_instruction_prefix_for_gemini_embedding_2(
+    model_name: str,
     embedding_type: str,
     expected_text: str,
     sample_embeddings: list[list[float]],
@@ -159,7 +164,7 @@ async def test_vertex_embed_uses_instruction_prefix_for_gemini_embedding_2(
             try:
                 result = await embedding._embed_vertex(
                     ["hello world"],
-                    "gemini-embedding-2-preview",
+                    model_name,
                     embedding_type,
                     None,
                 )

--- a/web/src/lib/indexing/index.ts
+++ b/web/src/lib/indexing/index.ts
@@ -111,13 +111,22 @@ export const CLOUD_BASED_PROVIDERS: EmbeddingProvider[] = [
         description: "Smaller, lighter-weight embedding model from Google.",
       },
       {
+        modelName: "gemini-embedding-2",
+        modelDim: 3072,
+        normalize: false,
+        queryPrefix: "",
+        passagePrefix: "",
+        description:
+          "Google's latest multimodal embedding model (GA). Highest-quality retrieval with a 3072-dim output.",
+      },
+      {
         modelName: "gemini-embedding-2-preview",
         modelDim: 3072,
         normalize: false,
         queryPrefix: "",
         passagePrefix: "",
         description:
-          "Google's multimodal embedding model. Higher-quality retrieval with a 3072-dim output.",
+          "Preview version of Gemini Embedding 2. Superseded by gemini-embedding-2 for new setups.",
       },
     ],
   },


### PR DESCRIPTION
## Description

Google shipped the GA version of Gemini Embedding 2 (`gemini-embedding-2`), but the admin Search Settings UI only lists the older `gemini-embedding-2-preview` under the Google cloud provider. This adds the GA model:

- `web/src/lib/indexing/index.ts`: add `gemini-embedding-2` (3072-dim) to the Google cloud provider list; mark the preview entry's description as superseded (kept for existing deployments).
- `backend/onyx/configs/embedding_configs.py`: register `google/gemini-embedding-2` so multi-tenant Vespa provisioning creates its index.

No embedding-path changes are needed: `_is_gemini_embedding_2_model()` matches on the `gemini-embedding-2` prefix, so the GA model already gets the correct no-`task_type` + instruction-format handling, and the query/document templates match Google's documented GA format ([docs](https://ai.google.dev/gemini-api/docs/embeddings)).

Note: this exposes the model for text embedding. Multimodal (image/audio/video) inputs to the embedding model are not wired into the indexing pipeline; images continue to be handled via vision-LLM analysis.

## How Has This Been Tested?

- Extended `test_google_embedding_configs.py` and the Vertex instruction-prefix tests in `test_search_nlp_models.py` to cover the GA model name; all 23 tests pass.
- Pre-commit (ty, ruff, oxlint, TypeScript type check) passes.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Google’s GA `gemini-embedding-2` (3072-dim) to cloud embedding options and backend so new deployments can use the latest model; keep the preview model for existing setups.

- **New Features**
  - UI: Added `gemini-embedding-2` to the Google provider; marked `gemini-embedding-2-preview` as superseded.
  - Backend: Registered `google/gemini-embedding-2` (3072-dim) with its Vespa index; updated tests to cover the GA model.

- **Migration**
  - No config changes needed; existing Gemini v2 handling applies (no `task_type`, instruction prefix supported).
  - Text embeddings only; multimodal inputs are not wired into indexing.

<sup>Written for commit 094da2b73e74f08b208045b98ebbb0d97cf76e8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12736?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

